### PR TITLE
chore: Porting an io adapter off gh reds ~1200 verb unit tests that script gh api

### DIFF
--- a/packages/fabrika-cli/src/adr/mint-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/mint-verb.unit.test.ts
@@ -5,7 +5,15 @@
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type FakeFs, fakeFs, fakeShell, okOut, tree} from "../fakes.test-support.ts";
+import {
+	errOut,
+	type FakeFs,
+	fakeFs,
+	fakeSeams,
+	okOut,
+	type Scripted,
+	tree,
+} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {
 	ALREADY_EXISTS,
@@ -20,17 +28,25 @@ import {runMint} from "./mint-verb.ts";
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 const PATH = ".decisions/0240-only-landed-adrs-may-be-cited.md";
 
-const shell = (overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = []) =>
-	fakeShell([
+const PULLS = /GET .*\/pulls\?state=open/;
+
+/** A pull request's file list, as the endpoint answers it. */
+const files = (...entries: ReadonlyArray<readonly [string, string]>) => ({
+	status: 200,
+	body: JSON.stringify(entries.map(([status, filename]) => ({status, filename}))),
+});
+
+const seams = (overrides: ReadonlyArray<Scripted> = []) =>
+	fakeSeams([
 		...overrides,
 		[/^git remote$/, okOut("origin\n")],
 		[/^git remote get-url origin$/, okOut("git@github.com:kamp-us/phoenix.git\n")],
 		[/^git fetch/, okOut("")],
 		[/^git rev-parse/, okOut(`${SHA}\n`)],
 		[/^git ls-tree/, okOut(tree("0234-a.md", "0235-b.md", "0236-c.md"))],
-		[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("11\n12\n")],
-		[/pulls\/11\/files/, okOut("added\t.decisions/0237-x.md\nmodified\tREADME.md\n")],
-		[/pulls\/12\/files/, okOut("added\t.decisions/0239-y.md\n")],
+		[PULLS, {status: 200, body: JSON.stringify([{number: 11}, {number: 12}])}],
+		[/pulls\/11\/files/, files(["added", ".decisions/0237-x.md"], ["modified", "README.md"])],
+		[/pulls\/12\/files/, files(["added", ".decisions/0239-y.md"])],
 	]);
 
 const options = {
@@ -46,12 +62,12 @@ const options = {
 };
 
 const run = (
-	overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = [],
+	overrides: ReadonlyArray<Scripted> = [],
 	opts: Partial<typeof options> = {},
 	fs: FakeFs = fakeFs({}),
 ) =>
 	Effect.runPromise(
-		Effect.provide(runMint({...options, ...opts}), Layer.merge(shell(overrides).layer, fs.layer)),
+		Effect.provide(runMint({...options, ...opts}), Layer.merge(seams(overrides).layer, fs.layer)),
 	);
 
 describe("runMint", () => {
@@ -79,25 +95,33 @@ describe("runMint", () => {
 
 	it("allocates over the in-flight set, not the merged maximum", async () => {
 		const fs = fakeFs({});
-		await run([[/pulls\/12\/files/, okOut("added\t.decisions/0299-z.md\n")]], {}, fs);
+		await run([[/pulls\/12\/files/, files(["added", ".decisions/0299-z.md"])]], {}, fs);
 		expect([...fs.written.keys()]).toEqual([".decisions/0300-only-landed-adrs-may-be-cited.md"]);
 	});
 
-	it.each([
+	const unreadable: ReadonlyArray<readonly [string, Scripted, number]> = [
 		[
 			"the origin remote is unreadable",
-			[/^git remote get-url origin$/, ORIGIN_REPO_UNRESOLVABLE] as const,
+			[/^git remote get-url origin$/, errOut("boom")],
+			ORIGIN_REPO_UNRESOLVABLE,
 		],
-		["the base ref cannot be fetched", [/^git fetch/, BASE_UNFETCHABLE] as const],
-		["the record directory is unreadable", [/^git ls-tree/, DIR_UNREADABLE] as const],
+		["the base ref cannot be fetched", [/^git fetch/, errOut("boom")], BASE_UNFETCHABLE],
+		["the record directory is unreadable", [/^git ls-tree/, errOut("boom")], DIR_UNREADABLE],
 		[
 			"the open pull requests cannot be enumerated",
-			[/^gh api --paginate repos\/[^ ]+\/pulls\?/, IN_FLIGHT_UNKNOWN] as const,
+			[PULLS, {status: 502, body: "{}"}],
+			IN_FLIGHT_UNKNOWN,
 		],
-		["a pull request's files cannot be read", [/pulls\/11\/files/, IN_FLIGHT_UNKNOWN] as const],
-	])("writes nothing when %s", async (_name, [pattern, code]) => {
+		[
+			"a pull request's files cannot be read",
+			[/pulls\/11\/files/, {status: 502, body: "{}"}],
+			IN_FLIGHT_UNKNOWN,
+		],
+	];
+
+	it.each(unreadable)("writes nothing when %s", async (_name, row, code) => {
 		const fs = fakeFs({});
-		const out = await run([[pattern, errOut("boom")]], {}, fs);
+		const out = await run([row], {}, fs);
 		expect(out.code).toBe(code);
 		expect(out.stdout).toBe("");
 		expect(fs.written.size).toBe(0);
@@ -122,7 +146,7 @@ describe("runMint", () => {
 
 	it("refuses a slug that is not kebab-case before it spends a read", async () => {
 		const fs = fakeFs({});
-		const sh = shell();
+		const sh = seams();
 		const out = await Effect.runPromise(
 			Effect.provide(runMint({...options, slug: "Not Kebab"}), Layer.merge(sh.layer, fs.layer)),
 		);
@@ -132,6 +156,6 @@ describe("runMint", () => {
 		);
 		expect(fs.written.size).toBe(0);
 		// A usage error costs no fetch and no pull-request enumeration.
-		expect(sh.calls).toEqual([]);
+		expect(sh.log).toEqual([]);
 	});
 });

--- a/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, tree} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, okOut, type Scripted, tree} from "../fakes.test-support.ts";
 import {
 	BASE_UNFETCHABLE,
 	DIR_UNREADABLE,
@@ -12,25 +12,38 @@ import {runNext} from "./next-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 
-const base = (overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = []) =>
-	fakeShell([
+const base = (overrides: ReadonlyArray<Scripted> = []) =>
+	fakeSeams([
 		...overrides,
 		[/^git remote$/, okOut("origin\n")],
 		[/^git remote get-url origin$/, okOut("git@github.com:kamp-us/phoenix.git\n")],
 		[/^git fetch/, okOut("")],
 		[/^git rev-parse/, okOut(`${SHA}\n`)],
 		[/^git ls-tree/, okOut(tree("0234-a.md", "0235-b.md", "0236-c.md"))],
-		[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("11\n12\n")],
-		[/pulls\/11\/files/, okOut("added\t.decisions/0237-x.md\nmodified\tREADME.md\n")],
-		[/pulls\/12\/files/, okOut("added\t.decisions/0239-y.md\n")],
+		[
+			/GET .*\/pulls\?state=open/,
+			{status: 200, body: JSON.stringify([{number: 11}, {number: 12}])},
+		],
+		[
+			/pulls\/11\/files/,
+			{
+				status: 200,
+				body: JSON.stringify([
+					{status: "added", filename: ".decisions/0237-x.md"},
+					{status: "modified", filename: "README.md"},
+				]),
+			},
+		],
+		[
+			/pulls\/12\/files/,
+			{status: 200, body: JSON.stringify([{status: "added", filename: ".decisions/0239-y.md"}])},
+		],
 	]);
 
 const options = {dir: ".decisions", base: "origin/main", repo: null, json: false};
 
-const run = (
-	overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = [],
-	opts: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runNext({...options, ...opts}), base(overrides).layer));
+const run = (overrides: ReadonlyArray<Scripted> = [], opts: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runNext({...options, ...opts}), base(overrides).layer));
 
 describe("runNext", () => {
 	it("answers max(union) + 1 on stdout with the scope line on stderr", async () => {
@@ -60,7 +73,7 @@ describe("runNext", () => {
 
 	it("refuses when the open pull requests cannot be enumerated — never 'nothing reserved'", async () => {
 		const out = await run([
-			[/^gh api --paginate repos\/[^ ]+\/pulls\?/, errOut("gh: Not Found (HTTP 404)")],
+			[/GET .*\/pulls\?state=open/, {status: 404, body: '{"message":"Not Found"}'}],
 		]);
 		expect(out.code).toBe(IN_FLIGHT_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -68,20 +81,22 @@ describe("runNext", () => {
 	});
 
 	it("refuses when ONE pull request's file list cannot be read — incomplete is UNKNOWN", async () => {
-		const out = await run([[/pulls\/12\/files/, errOut("HTTP 502")]]);
+		const out = await run([[/pulls\/12\/files/, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(IN_FLIGHT_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("PR #12");
 		expect(out.stderr.at(-1)).toContain("INCOMPLETE");
 	});
 
-	it("refuses when gh exits 0 with output that is not a list of numbers", async () => {
-		const out = await run([[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("null\n")]]);
+	it("refuses when GitHub answers 200 with a body that is not a list of pull requests", async () => {
+		const out = await run([[/GET .*\/pulls\?state=open/, {status: 200, body: "null"}]]);
 		expect(out.code).toBe(IN_FLIGHT_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses when a pull request's file list comes back in an unexpected shape", async () => {
-		const out = await run([[/pulls\/11\/files/, okOut("just-a-filename.md\n")]]);
+		const out = await run([
+			[/pulls\/11\/files/, {status: 200, body: JSON.stringify([{filename: "just-a-filename.md"}])}],
+		]);
 		expect(out.code).toBe(IN_FLIGHT_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
@@ -92,7 +107,7 @@ describe("runNext", () => {
 	it("answers 0001 on a readable-but-empty --dir, with no open PR claiming an id", async () => {
 		const out = await run([
 			[/^git ls-tree/, okOut("")],
-			[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("")],
+			[/GET .*\/pulls\?state=open/, {status: 200, body: "[]"}],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("0001\n");

--- a/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, record, tree} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, okOut, record, type Scripted, tree} from "../fakes.test-support.ts";
 import {
 	BASE_UNFETCHABLE,
 	DIR_UNREADABLE,
@@ -15,8 +15,10 @@ const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 const AMEND_LIST =
 	"amended-in-part by [0025](0025-split-livedo-connection-topic.md), [0028](0028-effect-durable-object-model.md)";
 
-const base = (overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = []) =>
-	fakeShell([
+const PULLS = /GET .*\/pulls\?state=open/;
+
+const base = (overrides: ReadonlyArray<Scripted> = []) =>
+	fakeSeams([
 		...overrides,
 		[/^git remote$/, okOut("origin\n")],
 		[/^git remote get-url origin$/, okOut("https://github.com/kamp-us/phoenix.git\n")],
@@ -29,16 +31,22 @@ const base = (overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut
 		[/show .*0023-live-views-sse-livedo\.md$/, okOut(record("0023", AMEND_LIST))],
 		[/show .*0126-ambient\.md$/, okOut(record("0126", "accepted"))],
 		[/show .*0164-guard\.md$/, okOut(record("0164", "proposed"))],
-		[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("4711\n")],
-		[/pulls\/4711\/files/, okOut("added\t.decisions/0239-campaign-milestones.md\n")],
+		[PULLS, {status: 200, body: JSON.stringify([{number: 4711}])}],
+		[
+			/pulls\/4711\/files/,
+			{
+				status: 200,
+				body: JSON.stringify([
+					{status: "added", filename: ".decisions/0239-campaign-milestones.md"},
+				]),
+			},
+		],
 	]);
 
 const options = {ids: ["0164"], dir: ".decisions", base: "origin/main", repo: null, json: false};
 
-const run = (
-	overrides: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = [],
-	opts: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runResolve({...options, ...opts}), base(overrides).layer));
+const run = (overrides: ReadonlyArray<Scripted> = [], opts: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runResolve({...options, ...opts}), base(overrides).layer));
 
 describe("runResolve", () => {
 	it("splits presence from authority: a proposed record is landed, not live", async () => {
@@ -102,7 +110,7 @@ describe("runResolve", () => {
 	});
 
 	it("refuses when the open pull requests cannot be enumerated — absent is indistinguishable from in-flight", async () => {
-		const out = await run([[/^gh api --paginate repos\/[^ ]+\/pulls\?/, errOut("HTTP 404")]]);
+		const out = await run([[PULLS, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(IN_FLIGHT_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("indistinguishable from");
@@ -113,7 +121,7 @@ describe("runResolve", () => {
 	it("answers absent against a readable-but-empty --dir", async () => {
 		const out = await run([
 			[/^git ls-tree/, okOut("")],
-			[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("")],
+			[PULLS, {status: 200, body: "[]"}],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("absent\t-\t-\n");

--- a/packages/fabrika-cli/src/build/blockedness.unit.test.ts
+++ b/packages/fabrika-cli/src/build/blockedness.unit.test.ts
@@ -1,22 +1,20 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {gateOf, readBlockedness} from "./blockedness.ts";
-import {issue} from "./fixtures.test-support.ts";
+import {GATEWAY, issuePayload, NOT_FOUND, served} from "./fixtures.test-support.ts";
 
-const EDGES =
-	/^gh api --paginate repos\/o\/r\/issues\/4312\/dependencies\/blocked_by\?per_page=100$/;
-const BLOCKER = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
+const EDGES = /GET .*\/repos\/o\/r\/issues\/4312\/dependencies\/blocked_by/;
+const BLOCKER = (n: number) => new RegExp(`GET .*/repos/o/r/issues/${n}$`);
 
-const NOT_FOUND = errOut("gh: Not Found (HTTP 404)");
-const GATEWAY = errOut("gh: Bad gateway (HTTP 502)");
+/** What `existenceOf` and the paged read both name a served 502. */
+const UNREADABLE = "GitHub answered HTTP 502";
 
-const edges = (...numbers: ReadonlyArray<number>): ExecResult =>
-	okOut(JSON.stringify(numbers.map((number) => ({number, state: "open"}))));
+const edges = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served(numbers.map((number) => ({number, state: "open"})));
 
-const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
-	Effect.runPromise(Effect.provide(readBlockedness("o/r", 4312), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>) =>
+	Effect.runPromise(Effect.provide(readBlockedness("o/r", 4312), fakeSeams(script).layer));
 
 describe("readBlockedness", () => {
 	it("proves not-blocked over an empty edge list, and says how many it scanned", async () => {
@@ -26,8 +24,8 @@ describe("readBlockedness", () => {
 	it("counts an open blocker, and leaves a closed one out", async () => {
 		const out = await run([
 			[EDGES, edges(210, 211)],
-			[BLOCKER(210), issue({number: 210, state: "closed"})],
-			[BLOCKER(211), issue({number: 211, state: "open"})],
+			[BLOCKER(210), served(issuePayload({number: 210, state: "closed"}))],
+			[BLOCKER(211), served(issuePayload({number: 211, state: "open"}))],
 		]);
 		expect(out).toEqual({_tag: "Read", scanned: 2, open: [211], unread: []});
 	});
@@ -44,21 +42,18 @@ describe("readBlockedness", () => {
 		const out = await run([
 			[EDGES, edges(210, 211)],
 			[BLOCKER(210), GATEWAY],
-			[BLOCKER(211), issue({number: 211, state: "open"})],
+			[BLOCKER(211), served(issuePayload({number: 211, state: "open"}))],
 		]);
 		expect(out).toEqual({
 			_tag: "Read",
 			scanned: 2,
 			open: [211],
-			unread: [{number: 210, reason: "gh: Bad gateway (HTTP 502)"}],
+			unread: [{number: 210, reason: UNREADABLE}],
 		});
 	});
 
 	it("is Unknown when the edge list could not be read — never an empty list", async () => {
-		expect(await run([[EDGES, GATEWAY]])).toEqual({
-			_tag: "Unknown",
-			reason: "gh: Bad gateway (HTTP 502)",
-		});
+		expect(await run([[EDGES, GATEWAY]])).toEqual({_tag: "Unknown", reason: UNREADABLE});
 	});
 
 	it("is Unknown on a 404, which the caller has already ruled out by proving the issue open", async () => {
@@ -88,7 +83,7 @@ describe("gateOf", () => {
 			_tag: "Read",
 			scanned: 2,
 			open: [211],
-			unread: [{number: 210, reason: "gh: Bad gateway (HTTP 502)"}],
+			unread: [{number: 210, reason: UNREADABLE}],
 		});
 		expect(out).toEqual({_tag: "Blocked", scanned: 2, open: [211]});
 	});
@@ -99,20 +94,20 @@ describe("gateOf", () => {
 			scanned: 2,
 			open: [],
 			unread: [
-				{number: 210, reason: "gh: Bad gateway (HTTP 502)"},
-				{number: 211, reason: "gh: Bad gateway (HTTP 502)"},
+				{number: 210, reason: UNREADABLE},
+				{number: 211, reason: UNREADABLE},
 			],
 		});
 		expect(out).toEqual({
 			_tag: "Unknown",
-			reason: "blocker #210: gh: Bad gateway (HTTP 502); blocker #211: gh: Bad gateway (HTTP 502)",
+			reason: `blocker #210: ${UNREADABLE}; blocker #211: ${UNREADABLE}`,
 		});
 	});
 
 	it("carries an unreadable edge list straight through as Unknown", () => {
-		expect(gateOf({_tag: "Unknown", reason: "gh: Bad gateway (HTTP 502)"})).toEqual({
+		expect(gateOf({_tag: "Unknown", reason: UNREADABLE})).toEqual({
 			_tag: "Unknown",
-			reason: "gh: Bad gateway (HTTP 502)",
+			reason: UNREADABLE,
 		});
 	});
 });

--- a/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
@@ -18,9 +18,9 @@ import {
 } from "./fixtures.test-support.ts";
 
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
 const REMOTES = /^git remote$/;
 const FETCH = /^git fetch --quiet origin main$/;
 const RESOLVE = /^git rev-parse --verify --quiet FETCH_HEAD/;
@@ -28,6 +28,9 @@ const VERIFY_BRANCH = /^git rev-parse --verify --quiet refs\/heads\//;
 const SWITCH_NEW = /^git switch -c /;
 
 const MINE = comments({id: 1, body: marker("s-9f2e", LANE_UUID)});
+
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
 
 const options = {
 	number: 4312 as number | null,
@@ -47,7 +50,7 @@ const CLAIMED: ReadonlyArray<Scripted> = [
 	[REV_PARSE, GIT_DIRS],
 	[ISSUE, issue()],
 	[COMMENTS, MINE],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
 const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
@@ -123,7 +126,7 @@ describe("runBranch — create mode", () => {
 			[REV_PARSE, GIT_DIRS],
 			[ISSUE, issue()],
 			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runBranch(options), shell.layer));
 		expect(out.code).toBe(CLAIM_NOT_MINE);
@@ -149,8 +152,8 @@ describe("runBranch — create mode", () => {
 });
 
 describe("runBranch — resume mode", () => {
-	const RESUME_ISSUE = /^gh api repos\/o\/r\/issues\/4310$/;
-	const RESUME_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
+	const RESUME_ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4310$/;
+	const RESUME_COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4310\/comments/;
 	const PULL_HEAD = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4310$/;
 	const resumeOptions = {number: null, slug: null, resume: 4310};
 
@@ -159,7 +162,7 @@ describe("runBranch — resume mode", () => {
 			[REV_PARSE, GIT_DIRS],
 			[RESUME_ISSUE, issue({number: 4310})],
 			[RESUME_COMMENTS, MINE],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 			[PULL_HEAD, served(pullPayload({number: 4310, head: {ref: "umut/fix-focus", sha: HEAD}}))],
 			[REMOTES, okOut("origin\n")],
 			[/^git fetch --quiet origin umut\/fix-focus$/, okOut("")],
@@ -184,7 +187,7 @@ describe("runBranch — resume mode", () => {
 				[REV_PARSE, GIT_DIRS],
 				[RESUME_ISSUE, issue({number: 4310})],
 				[RESUME_COMMENTS, MINE],
-				[PERM, okOut("write\n")],
+				[PERM, WRITE],
 				[
 					PULL_HEAD,
 					served(

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -38,9 +38,9 @@ const ROOT = "/repo/trees/lane-a";
 
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
 const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
 const REPO_META = /^GET https:\/\/api\.github\.com\/repos\/o\/r$/;
 const MERGE_BASE = /^git merge-base HEAD origin\/main$/;
 const DIFF = /^git diff --name-only /;
@@ -97,7 +97,7 @@ const LANE_OK: ReadonlyArray<Scripted> = [
 	[BRANCH, okOut(`${LANE}\n`)],
 	[ISSUE, issue()],
 	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, served({permission: "write"})],
 	[REPO_META, served({default_branch: "main"})],
 	[MERGE_BASE, okOut(`${HEAD}\n`)],
 	untracked(""),

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {ROADMAP_FILE} from "../triage/roadmap.ts";
 import {FAILED} from "../verb.ts";
 import {runAdopt, runClaim, runConfirm, runRelease} from "./claim-verb.ts";
@@ -27,12 +26,14 @@ import {
 	campaignsTable,
 	candidatePage,
 	comments,
+	GATEWAY,
 	GH_TOKEN_ENV,
 	issue,
 	LANE_TOKEN,
 	LANE_UUID,
 	marker,
 	NO_BLOCKERS,
+	NOT_FOUND,
 	SIBLING_TOKEN,
 	SIBLING_UUID,
 	served,
@@ -40,20 +41,27 @@ import {
 } from "./fixtures.test-support.ts";
 import {runPick} from "./pick-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/4312\/comments/;
-const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/9001$/;
-const DELETE = /^gh api --method DELETE repos\/o\/r\/issues\/comments\//;
-const perm = (login: string) => new RegExp(`^gh api repos/o/r/collaborators/${login}/permission`);
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const POST = /^POST \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const GET_COMMENT = /^GET \S+\/repos\/o\/r\/issues\/comments\/9001$/;
+const DELETE = /^DELETE \S+\/repos\/o\/r\/issues\/comments\//;
+const perm = (login: string) => new RegExp(`^GET \\S+/repos/o/r/collaborators/${login}/permission`);
+
+/** The two permissions the ACL answers with: one authorizes a marker, the other does not. */
+const WRITES = served({permission: "write"});
+const READS = served({permission: "read"});
+/** What GitHub answers a successful delete with — a status and no body at all. */
+const NO_CONTENT: HttpReply = {status: 204, body: ""};
+const TIMEOUT: HttpReply = {status: 504, body: '{"message":"Gateway timeout"}'};
 
 const MINE = marker("s-9f2e", LANE_UUID);
 const THEIRS = marker("s-77aa", "9d8c7b6a-5f4e-3d2c-1b0a-998877665544");
 /** A marker of the same SESSION under another nonce — a sibling lane's, which release must NOT sweep. */
 const SIBLING_MARKER = marker("s-9f2e", SIBLING_UUID);
 
-const POSTED = okOut(JSON.stringify({id: 9001, html_url: "https://github.com/o/r/issues/4312#c"}));
-const ECHO = okOut(JSON.stringify({body: MINE}));
+const POSTED = served({id: 9001, html_url: "https://github.com/o/r/issues/4312#c"}, 201);
+const ECHO = served({body: MINE});
 
 const labelled = (...names: ReadonlyArray<string>) => names.map((name) => ({name}));
 
@@ -75,7 +83,7 @@ const unclaimed = () => [once(COMMENTS), comments()] as const;
  * every read after it. The protocol reads the thread several times in one run, and a static entry
  * cannot tell a pre-post read from the checkpoint that follows it.
  */
-const thread = (...states: ReadonlyArray<ExecResult>) =>
+const thread = (...states: ReadonlyArray<HttpReply>) =>
 	states.map((state, i) =>
 		i === states.length - 1 ? ([COMMENTS, state] as const) : ([once(COMMENTS), state] as const),
 	);
@@ -84,7 +92,7 @@ const thread = (...states: ReadonlyArray<ExecResult>) =>
 const NO_CAMPAIGNS = fakeFs({files: {}});
 
 /**
- * `fakeShell` with every `blocked_by` edge list answering empty.
+ * Both seams with every `blocked_by` edge list answering empty.
  *
  * The claim seam reads the graph on the path to every marker (ADR 0301), so a script about any other
  * axis would otherwise hit an unscripted read and refuse on `11`. A test about blockedness scripts
@@ -131,7 +139,7 @@ describe("runClaim", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
@@ -155,14 +163,11 @@ describe("runClaim", () => {
 		const siblingMarker = marker("s-9f2e", SIBLING_UUID);
 		const shell = unblocked([
 			[ISSUE, CLAIMABLE],
-			[POST, okOut(JSON.stringify({id: 9002, html_url: "https://github.com/o/r/issues/4312#c"}))],
-			[
-				/^gh api repos\/o\/r\/issues\/comments\/9002$/,
-				okOut(JSON.stringify({body: siblingMarker})),
-			],
+			[POST, served({id: 9002, html_url: "https://github.com/o/r/issues/4312#c"}, 201)],
+			[/^GET \S+\/repos\/o\/r\/issues\/comments\/9002$/, served({body: siblingMarker})],
 			[COMMENTS, comments({id: 9001, body: MINE}, {id: 9002, body: siblingMarker})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -172,11 +177,11 @@ describe("runClaim", () => {
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.some((line) => line.includes(`lost to ${LANE_TOKEN}`))).toBe(true);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9002",
+		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/comments/9002",
 		]);
 		expect(
-			shell.calls.some((line) => /DELETE repos\/o\/r\/issues\/comments\/9001/.test(line)),
+			shell.requests.some((line) => /DELETE \S+\/repos\/o\/r\/issues\/comments\/9001/.test(line)),
 		).toBe(false);
 	});
 
@@ -187,13 +192,13 @@ describe("runClaim", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		await Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
-		const posted = shell.calls.findIndex((line) => POST.test(line));
-		const swept = shell.calls.findLastIndex((line) => COMMENTS.test(line));
+		const posted = shell.requests.findIndex((line) => POST.test(line));
+		const swept = shell.requests.findLastIndex((line) => COMMENTS.test(line));
 		expect(posted).toBeGreaterThanOrEqual(0);
 		expect(swept).toBeGreaterThan(posted);
 	});
@@ -211,8 +216,8 @@ describe("runClaim", () => {
 					{id: 9001, body: MINE, createdAt: "2026-08-09T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -222,7 +227,7 @@ describe("runClaim", () => {
 		expect(out.stderr.at(-1)).toContain("lost to build:s-77aa:");
 		expect(out.stderr.some((line) => line.includes("retracted this run's own marker"))).toBe(true);
 		expect(
-			shell.calls.some((line) => /DELETE repos\/o\/r\/issues\/comments\/9001/.test(line)),
+			shell.requests.some((line) => /DELETE \S+\/repos\/o\/r\/issues\/comments\/9001/.test(line)),
 		).toBe(true);
 	});
 
@@ -239,8 +244,8 @@ describe("runClaim", () => {
 					{id: 9001, body: MINE, createdAt: "2026-08-09T00:00:00Z"},
 				),
 			],
-			[perm("drive-by"), okOut("read\n")],
-			[perm("agent"), okOut("write\n")],
+			[perm("drive-by"), READS],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stderr.some((line) => line.includes("who holds no write permission"))).toBe(true);
@@ -251,7 +256,7 @@ describe("runClaim", () => {
 			[ISSUE, CLAIMABLE],
 			unclaimed(),
 			unclaimed(),
-			[POST, errOut("gh: Gateway timeout (HTTP 504)")],
+			[POST, TIMEOUT],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		// `confirm` and `release` both require --token, so the minted token has to reach the operator
@@ -269,7 +274,7 @@ describe("runClaim", () => {
 			unclaimed(),
 			unclaimed(),
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: "something else"}))],
+			[GET_COMMENT, served({body: "something else"})],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 	});
@@ -281,7 +286,7 @@ describe("runClaim", () => {
 			unclaimed(),
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
-			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			[COMMENTS, GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain('ownership is UNKNOWN, never "unclaimed"');
@@ -294,16 +299,16 @@ describe("runClaim", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain("page boundary");
+		expect(out.stderr.at(-1)).toContain("GitHub answered 200 but its body is not a list");
 		expect(out.stderr.some((line) => line.includes("is not authorized"))).toBe(false);
-		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => DELETE.test(line))).toBe(false);
 	});
 
 	it("refuses an unreadable PERMISSION on 11 — a transient read never demotes an author", async () => {
@@ -313,7 +318,7 @@ describe("runClaim", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), errOut("gh: Bad gateway (HTTP 502)")],
+			[perm("agent"), GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
@@ -324,7 +329,7 @@ describe("runClaim", () => {
 	});
 
 	it("refuses a proven-absent issue on 7", async () => {
-		const out = await run(runClaim, [[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run(runClaim, [[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 });
@@ -332,25 +337,21 @@ describe("runClaim", () => {
 /**
  * The fence, at the seam where it has teeth.
  *
- * Every refusal below asserts on **`shell.calls`** as well as the exit code: "refuses" and "refuses
+ * Every refusal below asserts on **`shell.requests`** as well as the exit code: "refuses" and "refuses
  * before writing anything" are different claims, and only the call log can tell them apart. A claim
  * that posted and then refused would leave a marker on the issue with nothing to retract it.
  */
 describe("runClaim — the admission test runs before any marker is written", () => {
 	const IN_SCOPE = fakeFs({files: {[ROADMAP_FILE]: campaignsTable(44)}});
 
-	const claimWith = (
-		target: ExecResult,
-		fs = IN_SCOPE,
-		overrides: Partial<typeof options> = {},
-	) => {
+	const claimWith = (target: HttpReply, fs = IN_SCOPE, overrides: Partial<typeof options> = {}) => {
 		const shell = unblocked([
 			[ISSUE, target],
 			unclaimed(),
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		return Effect.runPromise(
 			Effect.provide(runClaim({...options, ...overrides}), Layer.merge(shell.layer, fs.layer)),
@@ -370,7 +371,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN);
 		expect(out.code).toBe(OUT_OF_SCOPE);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.some((line) => line.includes("out of scope"))).toBe(true);
 		expect(out.stderr.at(-1)).toContain("nothing was written");
 	});
@@ -397,7 +398,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 	it("refuses a non-agent audience on 21 — a sibling axis, never folded into 20", async () => {
 		const {out, shell} = await claimWith(HUMAN_AUDIENCE);
 		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.some((line) => line.includes("ready-for:human"))).toBe(true);
 	});
 
@@ -423,7 +424,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		const {out, shell} = await claimWith(NO_CONTRACT);
 		expect(out.code).toBe(NO_ACCEPTANCE_CRITERIA);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.join("\n")).toContain("no acceptance criteria");
 		expect(out.stderr.join("\n")).toContain("triage enrich");
 		expect(out.stderr.at(-1)).toContain("nothing was written");
@@ -435,7 +436,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			overrideLane: "build",
 		});
 		expect(out.code).toBe(NO_ACCEPTANCE_CRITERIA);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.at(-1)).not.toContain("--override");
 	});
 
@@ -457,7 +458,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			fakeFs({files: {[ROADMAP_FILE]: null}, unprobeable: [ROADMAP_FILE]}),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.at(-1)).toContain("scope is UNKNOWN, never admitted; nothing was written");
 	});
 
@@ -467,7 +468,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			fakeFs({files: {[ROADMAP_FILE]: campaignsTable(44).replace("| active |", "| activ |")}}),
 		);
 		expect(out.code).toBe(BAD_SECTIONS);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("claims a refused issue under --override, recording the lane and reason on the marker and in the answer", async () => {
@@ -483,11 +484,12 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			token: `build:s-9f2e:${LANE_UUID}`,
 			override: {lane: "build-ui", reason: "hotfix for the release blocker"},
 		});
+		const posted = shell.bodies.filter(
+			(_, index) => POST.test(shell.requests[index] ?? "") === true,
+		);
 		expect(
-			shell.calls.some(
-				(line) =>
-					POST.test(line) &&
-					line.includes("build-claim-override: build-ui · hotfix for the release blocker"),
+			posted.some((body) =>
+				body.includes("build-claim-override: build-ui · hotfix for the release blocker"),
 			),
 		).toBe(true);
 	});
@@ -499,7 +501,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			{override: "I know what I am doing", overrideLane: "build-ui"},
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("refuses an empty --override reason on 1 — an override is recorded or it is not one", async () => {
@@ -508,7 +510,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			overrideLane: "build-ui",
 		});
 		expect(out.code).toBe(FAILED);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("refuses an --override that names no lane on 1 — the escape hatch says who took it (#5175)", async () => {
@@ -517,7 +519,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		});
 		expect(out.code).toBe(FAILED);
 		expect(out.stderr.some((line) => line.includes("--override-lane"))).toBe(true);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("refuses a blank --override-lane on 1 — whitespace names no lane", async () => {
@@ -526,13 +528,13 @@ describe("runClaim — the admission test runs before any marker is written", ()
 			overrideLane: "   ",
 		});
 		expect(out.code).toBe(FAILED);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("refuses an --override-lane with no --override on 1 — a lane names no override alone", async () => {
 		const {out, shell} = await claimWith(CLAIMABLE, IN_SCOPE, {overrideLane: "build-ui"});
 		expect(out.code).toBe(FAILED);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("names the declaration it judged against on a win, so an inert-fence claim reads as one", async () => {
@@ -567,15 +569,15 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		// The same issue, handed straight to `claim` by number: the pool was bypassed, the fence is not.
 		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN);
 		expect(out.code).toBe(OUT_OF_SCOPE);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("leaves confirm and release outside the fence — a mid-lane pause strands no lane", async () => {
 		const script: ReadonlyArray<Scripted> = [
 			[ISSUE, OUT_OF_CAMPAIGN],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		];
 		const confirmed = await run(runConfirm, script, {}, IN_SCOPE);
 		expect(confirmed.code).toBe(0);
@@ -591,7 +593,7 @@ describe("runClaim — the admission test runs before any marker is written", ()
  */
 describe("runClaim — a PR number is judged by the issue it serves", () => {
 	const IN_SCOPE = fakeFs({files: {[ROADMAP_FILE]: campaignsTable(44)}});
-	const SERVED = /^gh api repos\/o\/r\/issues\/5553$/;
+	const SERVED = /^GET \S+\/repos\/o\/r\/issues\/5553$/;
 
 	const pull = (body: string) =>
 		issue({
@@ -602,26 +604,24 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			pull_request: {url: "https://api.github.com/repos/o/r/pulls/4312"},
 		});
 
-	const served = (
+	const servedTicket = (
 		milestone: number | null,
 		labels = labelled("status:triaged", "ready-for:agent"),
 	) =>
-		okOut(
-			JSON.stringify({
-				number: 5553,
-				title: "The ticket the lane serves",
-				body: CRITERIA_BODY,
-				state: "open",
-				labels,
-				html_url: "https://github.com/o/r/issues/5553",
-				milestone: milestone === null ? null : {number: milestone},
-				state_reason: null,
-			}),
-		);
+		served({
+			number: 5553,
+			title: "The ticket the lane serves",
+			body: CRITERIA_BODY,
+			state: "open",
+			labels,
+			html_url: "https://github.com/o/r/issues/5553",
+			milestone: milestone === null ? null : {number: milestone},
+			state_reason: null,
+		});
 
 	const claimPull = (
 		body: string,
-		servedRecord: ExecResult,
+		servedRecord: HttpReply,
 		overrides: Partial<typeof options> = {},
 	) => {
 		const shell = unblocked([
@@ -631,7 +631,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		return Effect.runPromise(
 			Effect.provide(
@@ -642,28 +642,28 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 	};
 
 	it("admits a PR whose served issue is in scope, with no override", async () => {
-		const {out} = await claimPull("Fixes #5553\n", served(44));
+		const {out} = await claimPull("Fixes #5553\n", servedTicket(44));
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).answer).toBe("won");
 		expect(out.stderr.some((line) => line.includes("PR #4312 serves #5553 (fixes)"))).toBe(true);
 	});
 
 	it("reads Part of #<n> too — the partial-PR shape build --partial emits", async () => {
-		const {out} = await claimPull("Part of #5553\n", served(44));
+		const {out} = await claimPull("Part of #5553\n", servedTicket(44));
 		expect(out.code).toBe(0);
 		expect(out.stderr.some((line) => line.includes("serves #5553 (part-of)"))).toBe(true);
 	});
 
 	it("still refuses at 20 when the served issue is genuinely out of scope, and posts NOTHING", async () => {
-		const {out, shell} = await claimPull("Fixes #5553\n", served(39));
+		const {out, shell} = await claimPull("Fixes #5553\n", servedTicket(39));
 		expect(out.code).toBe(OUT_OF_SCOPE);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.some((line) => line.includes("out of scope"))).toBe(true);
 		expect(out.stderr.some((line) => line.includes("this issue's home is 39"))).toBe(true);
 	});
 
 	it("keeps that refusal overridable", async () => {
-		const {out} = await claimPull("Fixes #5553\n", served(39), {
+		const {out} = await claimPull("Fixes #5553\n", servedTicket(39), {
 			override: "repairing a landed FAIL",
 			overrideLane: "build",
 		});
@@ -673,11 +673,11 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 
 	it("refuses a PR naming no issue at 20, saying which case fired — and stays overridable", async () => {
 		const body = "A conversation-authored ADR.\n\n## Deviations\nNone.\n";
-		const {out, shell} = await claimPull(body, served(44));
+		const {out, shell} = await claimPull(body, servedTicket(44));
 		expect(out.code).toBe(OUT_OF_SCOPE);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.some((line) => line.includes("no served issue"))).toBe(true);
-		const overridden = await claimPull(body, served(44), {
+		const overridden = await claimPull(body, servedTicket(44), {
 			override: "no ticket — the ADR was authored in conversation",
 			overrideLane: "build",
 		});
@@ -685,15 +685,15 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 	});
 
 	it("refuses at 20 when the named issue is proven absent — never on the PR's own empty home", async () => {
-		const {out} = await claimPull("Fixes #5553\n", errOut("gh: Not Found (HTTP 404)"));
+		const {out} = await claimPull("Fixes #5553\n", NOT_FOUND);
 		expect(out.code).toBe(OUT_OF_SCOPE);
 		expect(out.stderr.some((line) => line.includes("proven absent"))).toBe(true);
 	});
 
 	it("refuses at 11 when the served issue cannot be read — UNKNOWN, never admitted", async () => {
-		const {out, shell} = await claimPull("Fixes #5553\n", errOut("gh: Bad gateway (HTTP 502)"));
+		const {out, shell} = await claimPull("Fixes #5553\n", GATEWAY);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	/**
@@ -703,17 +703,17 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 	 * marker or a broken one would refuse the very repair it was written to route to (#6386).
 	 */
 	it("never runs the prior-build gate on a PR target — repair has already answered its question", async () => {
-		const {out, shell} = await claimPull("Fixes #5553\n", served(44));
+		const {out, shell} = await claimPull("Fixes #5553\n", servedTicket(44));
 		expect(out.code).toBe(0);
 		expect(out.stderr.join("\n")).not.toContain("standing range verdict");
 		// Two comment reads on the admitting path: the existing-claim scan, and the marker read-back.
-		expect(shell.calls.filter((line) => COMMENTS.test(line))).toHaveLength(2);
+		expect(shell.requests.filter((line) => COMMENTS.test(line))).toHaveLength(2);
 	});
 
 	it("judges the audience on the served issue too, so a repair lane is not refused at 21", async () => {
 		const {out} = await claimPull(
 			"Fixes #5553\n",
-			served(44, labelled("status:triaged", "ready-for:agent")),
+			servedTicket(44, labelled("status:triaged", "ready-for:agent")),
 		);
 		expect(out.code).toBe(0);
 		expect(out.stderr.some((line) => line.includes("this issue carries ready-for:agent"))).toBe(
@@ -731,7 +731,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, IN_SCOPE.layer)),
@@ -747,7 +747,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -763,7 +763,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 	 * so the one that reads whichever record the resolution returned.
 	 */
 	describe("with no campaign active", () => {
-		const claimInert = (body: string, servedRecord: ExecResult | null) => {
+		const claimInert = (body: string, servedRecord: HttpReply | null) => {
 			const shell = unblocked([
 				[ISSUE, pull(body)],
 				...(servedRecord === null ? [] : ([[SERVED, servedRecord]] as ReadonlyArray<Scripted>)),
@@ -771,7 +771,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			]);
 			return Effect.runPromise(
 				Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -779,7 +779,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		};
 
 		it("resolves a served issue anyway, so the audience axis reads it and the claim is won", async () => {
-			const {out} = await claimInert("Fixes #5553\n", served(null));
+			const {out} = await claimInert("Fixes #5553\n", servedTicket(null));
 			expect(out.code).toBe(0);
 			expect(out.stderr.some((line) => line.includes("PR #4312 serves #5553 (fixes)"))).toBe(true);
 			expect(out.stderr.some((line) => line.includes("scope fence inert"))).toBe(true);
@@ -788,14 +788,14 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		it("leaves an unserved PR on its own record, audience and all — the pre-#5562 answer", async () => {
 			const {out, shell} = await claimInert("No reference at all.\n", null);
 			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 			expect(out.stderr.some((line) => line.includes("serves #"))).toBe(false);
 		});
 
 		it("still refuses at 11 when the served issue cannot be read — an inert fence does not soften UNKNOWN", async () => {
-			const {out, shell} = await claimInert("Fixes #5553\n", errOut("gh: Bad gateway (HTTP 502)"));
+			const {out, shell} = await claimInert("Fixes #5553\n", GATEWAY);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		});
 	});
 
@@ -809,7 +809,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		const DECISION = labelled("status:triaged", "type:decision", "ready-for:human");
 
 		it("admits the repair claim with no override, and writes the marker", async () => {
-			const {out, shell} = await claimPull("Fixes #5553\n", served(44, DECISION));
+			const {out, shell} = await claimPull("Fixes #5553\n", servedTicket(44, DECISION));
 			expect(out.code).toBe(0);
 			expect(JSON.parse(out.stdout)).toEqual({
 				answer: "won",
@@ -817,7 +817,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				purpose: "build",
 				token: `build:s-9f2e:${LANE_UUID}`,
 			});
-			expect(shell.calls.some((line) => POST.test(line))).toBe(true);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(true);
 			expect(
 				out.stderr.some((line) =>
 					line.includes(
@@ -828,7 +828,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		});
 
 		it("records no override on the answer — the ruling made this the ordinary path", async () => {
-			const {out} = await claimPull("Fixes #5553\n", served(44, DECISION));
+			const {out} = await claimPull("Fixes #5553\n", servedTicket(44, DECISION));
 			expect(JSON.parse(out.stdout).override).toBeUndefined();
 		});
 
@@ -842,13 +842,13 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			]);
 			const out = await Effect.runPromise(
 				Effect.provide(runClaim(options), Layer.merge(shell.layer, IN_SCOPE.layer)),
 			);
 			expect(out.code).toBe(TYPE_NOT_BUILDABLE);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 			expect(out.stderr.some((line) => line.includes("type not buildable"))).toBe(true);
 		});
 
@@ -859,7 +859,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			]);
 			const out = await Effect.runPromise(
 				Effect.provide(
@@ -873,7 +873,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			// The DECISION fixture is `ready-for:human`, which triage re-stamps when it routes a ruled
 			// decision to an agent. Until it does, the claim stops here (ADR 0300's binding constraint).
 			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		});
 
 		it("takes the ruled decision once triage has stamped it for an agent", async () => {
@@ -889,7 +889,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			]);
 			const cites = "https://github.com/o/r/issues/4312#issuecomment-5335398768";
 			const out = await Effect.runPromise(
@@ -907,7 +907,7 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			]);
 			const out = await Effect.runPromise(
 				Effect.provide(
@@ -919,22 +919,22 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 				),
 			);
 			expect(out.code).toBe(1);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		});
 
 		it("keeps the fence for every other type an open PR serves", async () => {
 			const {out, shell} = await claimPull(
 				"Fixes #5553\n",
-				served(44, labelled("status:triaged", "type:bug", "ready-for:human")),
+				servedTicket(44, labelled("status:triaged", "type:bug", "ready-for:human")),
 			);
 			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		});
 
 		it("keeps the scope fence armed — an out-of-scope decision PR is still 20", async () => {
-			const {out, shell} = await claimPull("Fixes #5553\n", served(39, DECISION));
+			const {out, shell} = await claimPull("Fixes #5553\n", servedTicket(39, DECISION));
 			expect(out.code).toBe(OUT_OF_SCOPE);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		});
 	});
 });
@@ -949,14 +949,14 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 describe("runClaim — the purpose axis", () => {
 	const IN_SCOPE = fakeFs({files: {[ROADMAP_FILE]: campaignsTable(44)}});
 
-	const claimWith = (target: ExecResult, overrides: Partial<typeof options> = {}) => {
+	const claimWith = (target: HttpReply, overrides: Partial<typeof options> = {}) => {
 		const shell = unblocked([
 			[ISSUE, target],
 			unclaimed(),
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		return Effect.runPromise(
 			Effect.provide(
@@ -981,14 +981,14 @@ describe("runClaim — the purpose axis", () => {
 	it("keeps the fence with no purpose passed — 30, and no marker written", async () => {
 		const {out, shell} = await claimWith(UNLABELLED_EPIC);
 		expect(out.code).toBe(TYPE_NOT_BUILDABLE);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.some((line) => line.includes("type not buildable"))).toBe(true);
 	});
 
 	it("keeps the fence under an explicit --purpose build — the default is not the only path", async () => {
 		const {out, shell} = await claimWith(UNLABELLED_EPIC, {purpose: "build"});
 		expect(out.code).toBe(TYPE_NOT_BUILDABLE);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("still seats 21 under build on a type the type axis admits", async () => {
@@ -996,7 +996,7 @@ describe("runClaim — the purpose axis", () => {
 			issue({milestone: {number: 44}, labels: labelled("type:bug", "p1", "status:triaged")}),
 		);
 		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	for (const purpose of ["plan", "gate"] as const) {
@@ -1019,7 +1019,7 @@ describe("runClaim — the purpose axis", () => {
 		it(`still refuses an out-of-scope epic on 20 under --purpose ${purpose} — scope is untouched`, async () => {
 			const {out, shell} = await claimWith(OUT_OF_CAMPAIGN_EPIC, {purpose});
 			expect(out.code).toBe(OUT_OF_SCOPE);
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		});
 	}
 
@@ -1027,7 +1027,7 @@ describe("runClaim — the purpose axis", () => {
 		const {out, shell} = await claimWith(UNLABELLED_EPIC, {purpose: "planning"});
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.some((line) => line.includes("plan | gate | build"))).toBe(true);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 });
 
@@ -1036,7 +1036,7 @@ describe("runConfirm", () => {
 		const out = await run(runConfirm, [
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({answer: "mine", number: 4312, token: LANE_TOKEN});
@@ -1048,7 +1048,7 @@ describe("runConfirm", () => {
 			[
 				[ISSUE, CLAIMABLE],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			],
 			{token: SIBLING_TOKEN},
 		);
@@ -1062,7 +1062,7 @@ describe("runConfirm", () => {
 		const out = await run(runConfirm, [
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 8000, body: THEIRS})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.at(-1)).toBe(
@@ -1075,7 +1075,7 @@ describe("runConfirm", () => {
 	it("refuses proven-unclaimed on 15 too, with the no-claim message", async () => {
 		const out = await run(runConfirm, [
 			[ISSUE, CLAIMABLE],
-			[COMMENTS, okOut("[]")],
+			[COMMENTS, served([])],
 		]);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.at(-1)).toBe(
@@ -1087,10 +1087,10 @@ describe("runConfirm", () => {
 		const out = await run(runConfirm, [
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain("page boundary");
+		expect(out.stderr.at(-1)).toContain("GitHub answered 200 but its body is not a list");
 	});
 });
 
@@ -1099,16 +1099,16 @@ describe("runRelease", () => {
 		const shell = unblocked([
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312});
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
+		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/comments/9001",
 		]);
 	});
 
@@ -1116,7 +1116,7 @@ describe("runRelease", () => {
 		const shell = unblocked([
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 8000, body: THEIRS})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -1125,29 +1125,29 @@ describe("runRelease", () => {
 		expect(out.stderr.at(-1)).toBe(
 			"build release: this lane holds no claim on #4312 — refusing to release another lane's.",
 		);
-		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => DELETE.test(line))).toBe(false);
 	});
 
 	it("refuses a truncated read on 11 and deletes nothing", async () => {
 		const shell = unblocked([
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => DELETE.test(line))).toBe(false);
 	});
 
 	it("refuses a failed retraction on 8 — whether the claim is still held is UNKNOWN", async () => {
 		const out = await run(runRelease, [
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[once(DELETE), errOut("gh: Gateway timeout (HTTP 504)")],
+			[perm("agent"), WRITES],
+			[once(DELETE), TIMEOUT],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain(`run "fabrika build confirm 4312 --token ${LANE_TOKEN}"`);
@@ -1171,7 +1171,7 @@ describe("the claim protocol", () => {
 		...thread(comments(), comments({id: 9001, body: MINE})),
 		[POST, POSTED] as const,
 		[GET_COMMENT, ECHO] as const,
-		[perm("agent"), okOut("write\n")] as const,
+		[perm("agent"), WRITES] as const,
 	];
 
 	const on = (
@@ -1184,7 +1184,7 @@ describe("the claim protocol", () => {
 		const shell = unblocked(held());
 		const first = await on(shell, runClaim);
 		const second = await on(shell, runClaim);
-		expect(shell.calls.filter((line) => POST.test(line))).toHaveLength(1);
+		expect(shell.requests.filter((line) => POST.test(line))).toHaveLength(1);
 		expect(second.code).toBe(0);
 		expect(JSON.parse(second.stdout)).toEqual(JSON.parse(first.stdout));
 		expect(second.stderr.at(-1)).toContain("already held by this lane");
@@ -1203,13 +1203,10 @@ describe("the claim protocol", () => {
 				comments({id: 9001, body: MINE}),
 				comments({id: 9001, body: MINE}, {id: 9002, body: SIBLING_MARKER}),
 			),
-			[POST, okOut(JSON.stringify({id: 9002, html_url: "https://github.com/o/r/issues/4312#c"}))],
-			[
-				/^gh api repos\/o\/r\/issues\/comments\/9002$/,
-				okOut(JSON.stringify({body: SIBLING_MARKER})),
-			],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[POST, served({id: 9002, html_url: "https://github.com/o/r/issues/4312#c"}, 201)],
+			[/^GET \S+\/repos\/o\/r\/issues\/comments\/9002$/, served({body: SIBLING_MARKER})],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -1219,8 +1216,8 @@ describe("the claim protocol", () => {
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.some((line) => line.includes(`lost to ${LANE_TOKEN}`))).toBe(true);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9002",
+		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/comments/9002",
 		]);
 	});
 
@@ -1247,19 +1244,19 @@ describe("the claim protocol", () => {
 			...thread(dirty, dirty, dirty, comments({id: 9003, body: SIBLING_MARKER})),
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const claimed = await on(shell, runClaim);
 		expect(claimed.code).toBe(0);
 		expect(JSON.parse(claimed.stdout).token).toBe(LANE_TOKEN);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 
 		const released = await on(shell, runRelease);
 		expect(released.code).toBe(0);
-		expect(shell.calls.filter((line) => DELETE.test(line)).sort()).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
-			"gh api --method DELETE repos/o/r/issues/comments/9002",
+		expect(shell.requests.filter((line) => DELETE.test(line)).sort()).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/comments/9001",
+			"DELETE https://api.github.com/repos/o/r/issues/comments/9002",
 		]);
 
 		const confirmed = await on(shell, runConfirm);
@@ -1302,7 +1299,7 @@ describe("runAdopt / succession", () => {
 		const shell = unblocked([
 			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: ADOPT}))],
+			[GET_COMMENT, served({body: ADOPT})],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runAdopt(adoptOptions), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -1314,7 +1311,7 @@ describe("runAdopt / succession", () => {
 			session: DEAD,
 			token: `build:s-9f2e:${LANE_UUID}`,
 		});
-		expect(shell.calls.filter((line) => POST.test(line))).toHaveLength(1);
+		expect(shell.requests.filter((line) => POST.test(line))).toHaveLength(1);
 	});
 
 	it("refuses an adopt naming this very session, and writes nothing", async () => {
@@ -1327,7 +1324,7 @@ describe("runAdopt / succession", () => {
 		);
 		expect(out.code).toBe(FAILED);
 		expect(out.stderr.at(-1)).toContain("already covers");
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("refuses an empty reason before anything is read", async () => {
@@ -1347,7 +1344,7 @@ describe("runAdopt / succession", () => {
 			);
 			expect(out.code).toBe(FAILED);
 			expect(out.stderr.at(-1)).toContain("no reader can read back");
-			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		}
 	});
 
@@ -1361,7 +1358,7 @@ describe("runAdopt / succession", () => {
 		);
 		expect(out.code).toBe(FAILED);
 		expect(out.stderr.at(-1)).toContain("one line");
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	// A tokenless `claim` over an adopted number is the shape a real successor produces: `adopt` ran
@@ -1385,8 +1382,8 @@ describe("runAdopt / succession", () => {
 					{id: 9001, body: MINE, createdAt: "2026-08-11T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -1396,8 +1393,8 @@ describe("runAdopt / succession", () => {
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.some((line) => line.includes("lost to build:s-77aa:"))).toBe(true);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
+		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/comments/9001",
 		]);
 	});
 
@@ -1411,7 +1408,7 @@ describe("runAdopt / succession", () => {
 					{id: 8100, body: ADOPT, createdAt: "2026-08-10T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -1419,14 +1416,14 @@ describe("runAdopt / succession", () => {
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		// The token named is the ADOPT's — the one `release` accepts — never the dead session's winner.
 		expect(out.stderr.some((line) => line.includes(`--token ${LANE_TOKEN}`))).toBe(true);
-		expect(shell.calls.some((line) => POST.test(line) || DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line) || DELETE.test(line))).toBe(false);
 	});
 
 	it("release still refuses the dead session's claim while no adopt marker names it", async () => {
 		const shell = unblocked([
 			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 8000, body: THEIRS})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -1435,7 +1432,7 @@ describe("runAdopt / succession", () => {
 		expect(out.stderr.some((line) => line.includes("fabrika build adopt 4312 --session"))).toBe(
 			true,
 		);
-		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => DELETE.test(line))).toBe(false);
 	});
 
 	it("release retracts BOTH markers once an authorized adopt names the dead session", async () => {
@@ -1448,17 +1445,17 @@ describe("runAdopt / succession", () => {
 					{id: 8100, body: ADOPT, createdAt: "2026-08-10T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312, adopted: DEAD});
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/8000",
-			"gh api --method DELETE repos/o/r/issues/comments/8100",
+		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/comments/8000",
+			"DELETE https://api.github.com/repos/o/r/issues/comments/8100",
 		]);
 	});
 
@@ -1475,7 +1472,7 @@ describe("runAdopt / succession", () => {
 					{id: 8100, body: ADOPT, createdAt: "2026-08-10T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runConfirm(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -1494,15 +1491,15 @@ describe("runAdopt / succession", () => {
 					{id: 8100, body: ADOPT, author: "drive-by", createdAt: "2026-08-10T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
-			[perm("drive-by"), okOut("read\n")],
+			[perm("agent"), WRITES],
+			[perm("drive-by"), READS],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.some((line) => line.includes("counted, never a succession"))).toBe(true);
-		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => DELETE.test(line))).toBe(false);
 	});
 
 	// The adopt names ONE lane by its whole token, so succession confers exactly what an ordinary win
@@ -1521,7 +1518,7 @@ describe("runAdopt / succession", () => {
 					{id: 8100, body: ADOPT, createdAt: "2026-08-10T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -1530,7 +1527,7 @@ describe("runAdopt / succession", () => {
 			),
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
-		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => DELETE.test(line))).toBe(false);
 	});
 });
 
@@ -1540,8 +1537,8 @@ describe("runAdopt / succession", () => {
  * so this is where the refusal has teeth.
  */
 describe("runClaim — the blockedness gate", () => {
-	const EDGES = /^gh api --paginate repos\/o\/r\/issues\/4312\/dependencies\/blocked_by/;
-	const blocker = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
+	const EDGES = /^GET \S+\/repos\/o\/r\/issues\/4312\/dependencies\/blocked_by/;
+	const blocker = (n: number) => new RegExp(`^GET \\S+/repos/o/r/issues/${n}$`);
 
 	const claimAgainst = (graph: ReadonlyArray<Scripted>) => {
 		const shell = fakeSeams([
@@ -1551,7 +1548,7 @@ describe("runClaim — the blockedness gate", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		return Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
@@ -1565,7 +1562,7 @@ describe("runClaim — the blockedness gate", () => {
 		]);
 		expect(out.code).toBe(BLOCKED);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.at(-1)).toContain("blocked by 1 open blocked_by edge: #210");
 		expect(out.stderr.at(-1)).toContain("nothing was written");
 	});
@@ -1592,17 +1589,17 @@ describe("runClaim — the blockedness gate", () => {
 	});
 
 	it('refuses an unreadable edge list on 11 — UNKNOWN is never "not blocked"', async () => {
-		const {out, shell} = await claimAgainst([[EDGES, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const {out, shell} = await claimAgainst([[EDGES, GATEWAY]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 		expect(out.stderr.at(-1)).toContain("cannot read the blocked_by edges of #4312");
 	});
 
 	it("refuses on 11 when a blocker's own state could not be read and nothing is proven open", async () => {
 		const {out} = await claimAgainst([
 			[EDGES, blockedBy(210)],
-			[blocker(210), errOut("gh: Bad gateway (HTTP 502)")],
+			[blocker(210), GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("blocker #210");
@@ -1629,7 +1626,7 @@ describe("runClaim — the blockedness gate", () => {
 			),
 		);
 		expect(out.code).toBe(OUT_OF_SCOPE);
-		expect(shell.calls.some((line) => EDGES.test(line))).toBe(false);
+		expect(shell.requests.some((line) => EDGES.test(line))).toBe(false);
 	});
 });
 
@@ -1668,7 +1665,7 @@ describe("runClaim — the prior-build gate on an epic child", () => {
 		await Effect.runPromise(
 			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("admits the claim under --resume, so the refusal points at a route that exists", async () => {
@@ -1681,7 +1678,7 @@ describe("runClaim — the prior-build gate on an epic child", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			],
 			{resume: true},
 		);
@@ -1712,17 +1709,13 @@ describe("runClaim — the prior-build gate on an epic child", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(0);
 	});
 
 	it("refuses on 11 when the comments cannot be read — never 'no prior build'", async () => {
-		const out = await run(runClaim, [
-			[ISSUE, CLAIMABLE],
-			unclaimed(),
-			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
-		]);
+		const out = await run(runClaim, [[ISSUE, CLAIMABLE], unclaimed(), [COMMENTS, GATEWAY]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "no"');
 	});
@@ -1770,7 +1763,7 @@ describe("runClaim — the prior-build gate on an epic child", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITES],
 		]);
 		expect(out.code).toBe(0);
 	});
@@ -1784,7 +1777,7 @@ describe("runClaim — the prior-build gate on an epic child", () => {
 				[POST, POSTED],
 				[GET_COMMENT, ECHO],
 				[COMMENTS, comments({id: 9001, body: MINE})],
-				[perm("agent"), okOut("write\n")],
+				[perm("agent"), WRITES],
 			],
 			{purpose: "plan"},
 		);

--- a/packages/fabrika-cli/src/build/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim.unit.test.ts
@@ -1,8 +1,7 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {describe, expect, it} from "vitest";
-import {fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {
 	anySessionCaller,
@@ -21,21 +20,24 @@ import {
 	SIBLING_NONCE,
 	SIBLING_TOKEN,
 	SIBLING_UUID,
+	served,
 } from "./fixtures.test-support.ts";
 
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+
+const WRITE = served({permission: "write"});
 
 const run = <A>(
 	effect: Effect.Effect<A, never, ChildProcessSpawner.ChildProcessSpawner>,
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-) => Effect.runPromise(Effect.provide(effect, fakeShell(script).layer));
+	script: ReadonlyArray<Scripted>,
+) => Effect.runPromise(Effect.provide(effect, fakeSeams(script).layer));
 
 /**
  * Two lanes, one session id, one number — the shape the session-only rule could not see (#6037). The
  * earlier marker is lane A's; lane B reads the same thread and must be told it lost.
  */
-const BOTH_LANES: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const BOTH_LANES: ReadonlyArray<Scripted> = [
 	[
 		COMMENTS,
 		comments(
@@ -43,7 +45,7 @@ const BOTH_LANES: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 			{id: 9002, body: marker("s-9f2e", SIBLING_UUID)},
 		),
 	],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
 describe("resolveOwnership", () => {
@@ -71,7 +73,7 @@ describe("resolveOwnership", () => {
 			resolveOwnership("o/r", 4312, laneCaller("s-9f2e", NONCE, LANE_TOKEN)),
 			[
 				[COMMENTS, comments({id: 9001, body: marker("s-77aa", LANE_UUID)})],
-				[PERM, okOut("write\n")],
+				[PERM, WRITE],
 			],
 		);
 		expect(ownership._tag === "Foreign" && ownership.sameSession).toBe(false);
@@ -82,7 +84,7 @@ describe("resolveOwnership", () => {
 			resolveOwnership("o/r", 4312, laneCaller("s-9f2e", NONCE, LANE_TOKEN)),
 			[
 				[COMMENTS, comments({id: 9001, body: marker("s-9f2e", LANE_UUID)})],
-				[PERM, okOut("write\n")],
+				[PERM, WRITE],
 			],
 		);
 		expect(ownership._tag).toBe("Mine");

--- a/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
@@ -1,22 +1,24 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {coderTemplateText} from "../lane/fixtures.test-support.ts";
 import {compileText} from "../lane/machine.ts";
 import {CAP_ROUND, RETRY_BUDGET} from "../retry-budget.ts";
 import {type DocumentRead, runClear} from "./clear-verb.ts";
 import {AUTHORIZATION_VOID, GRANT_UNAUTHORIZED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {comments, HEAD, PRIOR_HEADS, pull} from "./fixtures.test-support.ts";
+import {comments, HEAD, PRIOR_HEADS, pull, served} from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
-const VIEWER = /^gh api user --jq \.login$/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4310$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4310\/comments/;
+const VIEWER = /^GET https:\/\/api\.github\.com\/user$/;
 const CONFIG = /^GET \S+\/repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
 const TEAM = /orgs\/kamp-us\/teams\/control-plane\/members/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/usirin\/permission/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/4310\/comments/;
-const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
+const PERMISSION = /^GET \S+\/repos\/o\/r\/collaborators\/usirin\/permission/;
+const POST = /^POST \S+\/repos\/o\/r\/issues\/4310\/comments/;
+const GET_COMMENT = /^GET \S+\/repos\/o\/r\/issues\/comments\/\d+$/;
+
+const viewer = (login: string): HttpReply => served({login});
+const permission = (level: string): HttpReply => served({permission: level});
 
 const WORKFLOW = ".fabrika/lanes/4312/workflow.json";
 const NOW = new Date("2026-08-18T07:16:03Z");
@@ -34,7 +36,7 @@ const CONFIGURED: HttpReply = {
 	status: 200,
 	body: '{\n\t// the founder accounts\n\t"capClearAuthors": ["@usirin"]\n}\n',
 };
-const POSTED = (id: number): ExecResult => okOut(JSON.stringify({id, html_url: "https://x/y#c"}));
+const POSTED = (id: number): HttpReply => served({id, html_url: "https://x/y#c"}, 201);
 
 const document = (text: string): Effect.Effect<DocumentRead> =>
 	Effect.succeed(text === "" ? {_tag: "Failed", reason: "no such file"} : {_tag: "Text", text});
@@ -51,38 +53,44 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	files: Record<string, string | null> = {},
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [[CONFIG, CONFIGURED]],
+	config: ReadonlyArray<Scripted> = [[CONFIG, CONFIGURED]],
 ) => {
-	const shell = fakeShell(script);
+	const seams = fakeSeams([...script, ...config]);
 	const fs = fakeFs({files});
 	return Effect.runPromise(
-		Effect.provide(
-			runClear({...options, ...overrides}),
-			Layer.mergeAll(shell.layer, fs.layer, fakeHttp(http).layer),
-		),
-	).then((outcome) => ({outcome, inputs: shell.inputs, calls: shell.calls, written: fs.written}));
+		Effect.provide(runClear({...options, ...overrides}), Layer.merge(seams.layer, fs.layer)),
+	).then((outcome) => ({
+		outcome,
+		requests: seams.requests,
+		bodies: seams.bodies,
+		written: fs.written,
+	}));
 };
 
-const GRANTABLE: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+/** The bodies of the requests that wrote, in order — what the two posted comments carried. */
+const postedBodies = (
+	requests: ReadonlyArray<string>,
+	bodies: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+	bodies.filter((_, index) => requests[index]?.startsWith("POST") === true);
+
+const GRANTABLE: ReadonlyArray<Scripted> = [
 	[PULL, pull({number: 4310, base: {ref: "main"}})],
 	[COMMENTS, THREE_ROUNDS],
-	[VIEWER, okOut("usirin\n")],
-	[PERMISSION, okOut("admin\n")],
+	[VIEWER, viewer("usirin")],
+	[PERMISSION, permission("admin")],
 ];
 
 describe("runClear", () => {
 	it("posts the authorization first and the marker second, then answers `cleared`", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests, bodies} = await run(
 			[
 				...GRANTABLE,
 				[POST, POSTED(900)],
-				[
-					GET_COMMENT,
-					okOut(JSON.stringify({body: "cap-cleared: round 3 · 2026-08-18T07:16:03Z\n"})),
-				],
+				[GET_COMMENT, served({body: "cap-cleared: round 3 · 2026-08-18T07:16:03Z\n"})],
 			],
 			{},
 			{[WORKFLOW]: coderTemplateText()},
@@ -91,7 +99,7 @@ describe("runClear", () => {
 		const parsed = JSON.parse(outcome.stdout);
 		expect(parsed).toMatchObject({round: CAP_ROUND, by: "usirin", resolvesTo: "cleared"});
 		expect(parsed.cap).toBe(CAP_ROUND + 1);
-		const posted = calls.filter((line) => line.includes("--method POST"));
+		const posted = postedBodies(requests, bodies);
 		expect(posted[0]).toContain("Founder ruling 2026-08-18");
 		expect(posted[1]).toContain("cap-cleared: round 3");
 	});
@@ -101,10 +109,7 @@ describe("runClear", () => {
 			[
 				...GRANTABLE,
 				[POST, POSTED(900)],
-				[
-					GET_COMMENT,
-					okOut(JSON.stringify({body: "cap-cleared: round 3 · 2026-08-18T07:16:03Z\n"})),
-				],
+				[GET_COMMENT, served({body: "cap-cleared: round 3 · 2026-08-18T07:16:03Z\n"})],
 			],
 			{},
 			{[WORKFLOW]: coderTemplateText()},
@@ -115,13 +120,13 @@ describe("runClear", () => {
 	});
 
 	it("refuses an account outside the configured set, writing nothing", async () => {
-		const {outcome, calls} = await run([
+		const {outcome, requests} = await run([
 			[PULL, pull({number: 4310, base: {ref: "main"}})],
 			[COMMENTS, THREE_ROUNDS],
-			[VIEWER, okOut("someone-else\n")],
+			[VIEWER, viewer("someone-else")],
 		]);
 		expect(outcome.code).toBe(GRANT_UNAUTHORIZED);
-		expect(calls.some((line) => /--method POST/.test(line))).toBe(false);
+		expect(requests.some((request) => request.startsWith("POST"))).toBe(false);
 	});
 
 	it("refuses when the repo configures nobody — an absent config grants nobody (#5959)", async () => {
@@ -129,7 +134,7 @@ describe("runClear", () => {
 			[
 				[PULL, pull({number: 4310, base: {ref: "main"}})],
 				[COMMENTS, THREE_ROUNDS],
-				[VIEWER, okOut("usirin\n")],
+				[VIEWER, viewer("usirin")],
 			],
 			{},
 			{},
@@ -143,7 +148,7 @@ describe("runClear", () => {
 			[
 				[PULL, pull({number: 4310, base: {ref: "main"}})],
 				[COMMENTS, THREE_ROUNDS],
-				[VIEWER, okOut("usirin\n")],
+				[VIEWER, viewer("usirin")],
 			],
 			{},
 			{},
@@ -156,11 +161,11 @@ describe("runClear", () => {
 	});
 
 	it("refuses a bare stamp — an authorization with no date is void (#4938)", async () => {
-		const {outcome, calls} = await run(GRANTABLE, {
+		const {outcome, requests} = await run(GRANTABLE, {
 			authorization: document("one more round, go ahead"),
 		});
 		expect(outcome.code).toBe(AUTHORIZATION_VOID);
-		expect(calls).toEqual([]);
+		expect(requests).toEqual([]);
 	});
 
 	it("refuses an empty authorization before reading anything", async () => {
@@ -182,7 +187,7 @@ describe("runClear", () => {
 					createdAt: "2026-08-18T01:00:00Z",
 				}),
 			],
-			[VIEWER, okOut("usirin\n")],
+			[VIEWER, viewer("usirin")],
 		]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 	});
@@ -205,13 +210,10 @@ describe("runClear", () => {
 						{id: 6, body: `review-code: FAIL @ ${HEAD} — four`, createdAt: "2026-08-18T04:00:00Z"},
 					),
 				],
-				[VIEWER, okOut("usirin\n")],
-				[PERMISSION, okOut("admin\n")],
+				[VIEWER, viewer("usirin")],
+				[PERMISSION, permission("admin")],
 				[POST, POSTED(901)],
-				[
-					GET_COMMENT,
-					okOut(JSON.stringify({body: "cap-cleared: round 4 · 2026-08-18T07:16:03Z\n"})),
-				],
+				[GET_COMMENT, served({body: "cap-cleared: round 4 · 2026-08-18T07:16:03Z\n"})],
 			],
 			{},
 			{[WORKFLOW]: coderTemplateText()},
@@ -224,23 +226,23 @@ describe("runClear", () => {
 
 	/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0294). */
 	it("refuses a configured account that resolves below write at the ACL", async () => {
-		const {outcome, calls} = await run([
+		const {outcome, requests} = await run([
 			[PULL, pull({number: 4310, base: {ref: "main"}})],
 			[COMMENTS, THREE_ROUNDS],
-			[VIEWER, okOut("usirin\n")],
-			[PERMISSION, okOut("read\n")],
+			[VIEWER, viewer("usirin")],
+			[PERMISSION, permission("read")],
 		]);
 		expect(outcome.code).toBe(GRANT_UNAUTHORIZED);
 		expect(outcome.stderr.at(-1)).toContain("below write");
-		expect(calls.some((line) => /--method POST/.test(line))).toBe(false);
+		expect(requests.some((request) => request.startsWith("POST"))).toBe(false);
 	});
 
 	it("holds an unreadable permission UNKNOWN rather than granting on the config alone", async () => {
 		const {outcome} = await run([
 			[PULL, pull({number: 4310, base: {ref: "main"}})],
 			[COMMENTS, THREE_ROUNDS],
-			[VIEWER, okOut("usirin\n")],
-			[PERMISSION, {ok: false, stdout: "", reason: "HTTP 502"}],
+			[VIEWER, viewer("usirin")],
+			[PERMISSION, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});
@@ -250,7 +252,7 @@ describe("runClear", () => {
 	 * now makes the budget test say "not spent". The re-run must reconcile the lane, not refuse on 7.
 	 */
 	it("reconciles the lane on a re-run for a round already granted, posting nothing", async () => {
-		const {outcome, calls, written} = await run(
+		const {outcome, requests, written} = await run(
 			[
 				[PULL, pull({number: 4310, base: {ref: "main"}})],
 				[
@@ -266,8 +268,8 @@ describe("runClear", () => {
 						},
 					),
 				],
-				[VIEWER, okOut("usirin\n")],
-				[PERMISSION, okOut("admin\n")],
+				[VIEWER, viewer("usirin")],
+				[PERMISSION, permission("admin")],
 			],
 			{},
 			{[WORKFLOW]: coderTemplateText()},
@@ -279,7 +281,7 @@ describe("runClear", () => {
 			authorization: 4,
 			resolvesTo: "reconciled",
 		});
-		expect(calls.some((line) => /--method POST/.test(line))).toBe(false);
+		expect(requests.some((request) => request.startsWith("POST"))).toBe(false);
 		const compiled = compileText(written.get(WORKFLOW) ?? "");
 		if (compiled._tag !== "Compiled") throw new Error("the lane document did not recompile");
 		expect(compiled.lane.tasks.issue?.initial.maxRetries).toBe(RETRY_BUDGET + 1);

--- a/packages/fabrika-cli/src/build/commit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/commit-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeFs, fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {scanBody} from "../report/leaks.ts";
 import type {VerbOutcome} from "../verb.ts";
@@ -28,14 +27,18 @@ import {
 	NONCE,
 	OLD_HEAD,
 	pull,
+	served,
 } from "./fixtures.test-support.ts";
 import {laneScratchDir} from "./scratch-verb.ts";
 
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
+
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
 const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
 const HEAD_SHA = /^git rev-parse HEAD$/;
 const STAGED = /^git diff --cached --name-only -z$/;
 const COMMIT = /^git commit /;
@@ -51,12 +54,12 @@ const MESSAGE = "fix(build): read the commit message back off the commit (#4312)
 /** The message the #5484 incident's commit really carried — another lane's, two days stale. */
 const BORROWED = "fix(report): state the guarantee the eval set actually delivers (#4789)\n";
 
-const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const LANE_OK: ReadonlyArray<Scripted> = [
 	[REV_PARSE, GIT_DIRS],
 	[BRANCH, okOut(`${LANE}\n`)],
 	[ISSUE, issue()],
 	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
 /**
@@ -65,7 +68,7 @@ const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
  * Built fresh per call: `once` carries its own spent flag, so a shared array would answer the
  * second test's before-read with the first test's after-read.
  */
-const ready = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const ready = (): ReadonlyArray<Scripted> => [
 	...LANE_OK,
 	[STAGED, okOut("packages/fabrika-cli/src/build/commit-verb.ts\0")],
 	[once(HEAD_SHA), okOut(`${OLD_HEAD}\n`)],
@@ -83,7 +86,14 @@ const options = {
 	tmpRoot: TMP_ROOT,
 };
 
-const shellFor = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => fakeShell(script);
+/**
+ * Both seams off one script, keeping the spawner's `inputs` reachable.
+ *
+ * `fakeSeams` hands back everything else this file needs but not what a child was piped, and the
+ * message travelling on `git commit -F -`'s own stdin is exactly what one of these tests is about
+ * (#5484) — so the two fakes are built side by side here rather than through it.
+ */
+const shellFor = (script: ReadonlyArray<Scripted>) => fakeSeams(script);
 
 const runWith = (
 	shell: ReturnType<typeof shellFor>,
@@ -98,7 +108,7 @@ const runWith = (
 	);
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	files: Record<string, string | null> = {},
 ): Promise<VerbOutcome> => runWith(shellFor(script), overrides, files);
@@ -195,13 +205,13 @@ describe("runCommit — the message names only what this lane holds", () => {
 		const shell = shellFor([
 			[REV_PARSE, GIT_DIRS],
 			[BRANCH, okOut(`${resume}\n`)],
-			[/^gh api repos\/o\/r\/issues\/4318$/, issue({number: 4318})],
+			[/^GET \S+\/repos\/o\/r\/issues\/4318$/, issue({number: 4318})],
 			[
-				/^gh api --paginate repos\/o\/r\/issues\/4318\/comments/,
+				/^GET \S+\/repos\/o\/r\/issues\/4318\/comments/,
 				comments({id: 1, body: marker(SESSION, LANE_UUID)}),
 			],
-			[PERM, okOut("write\n")],
-			[/^gh api repos\/o\/r\/pulls\/4318$/, pull()],
+			[PERM, WRITE],
+			[/^GET \S+\/repos\/o\/r\/pulls\/4318$/, pull()],
 			[STAGED, okOut("a.ts\0")],
 			[once(HEAD_SHA), okOut(`${OLD_HEAD}\n`)],
 			[HEAD_SHA, okOut(`${HEAD}\n`)],
@@ -303,7 +313,7 @@ describe("runCommit — preconditions", () => {
 			[BRANCH, okOut(`${LANE}\n`)],
 			[ISSUE, issue()],
 			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 			[COMMIT, okOut("")],
 		]);
 		const out = await runWith(shell);

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -1,29 +1,19 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, type HttpReply, okOut, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {BLOCKED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {runEligible} from "./eligible-verb.ts";
-import {
-	GH_TOKEN_ENV,
-	NOT_FOUND as HTTP_404,
-	GATEWAY as HTTP_502,
-	issue,
-	served,
-} from "./fixtures.test-support.ts";
+import {GATEWAY, GH_TOKEN_ENV, issue, NOT_FOUND, served} from "./fixtures.test-support.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
 const PARENT = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4312\/parent$/;
-const EDGES =
-	/^gh api --paginate repos\/o\/r\/issues\/4312\/dependencies\/blocked_by\?per_page=100$/;
-const BLOCKER = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
-
-const NOT_FOUND = errOut("gh: Not Found (HTTP 404)");
-const GATEWAY = errOut("gh: Bad gateway (HTTP 502)");
+const EDGES = /^GET \S+\/repos\/o\/r\/issues\/4312\/dependencies\/blocked_by\?/;
+const BLOCKER = (n: number) => new RegExp(`^GET \\S+/repos/o/r/issues/${n}$`);
 
 /** The `blocked_by` payload, shaped like the endpoint's rows rather than like the parser. */
-const edges = (...numbers: ReadonlyArray<number>): ExecResult =>
-	okOut(JSON.stringify(numbers.map((number) => ({number, state: "open"}))));
+const edges = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served(numbers.map((number) => ({number, state: "open"})));
 
 const options = {
 	number: 4312,
@@ -34,11 +24,11 @@ const options = {
 const run = (script: ReadonlyArray<Scripted>) =>
 	Effect.runPromise(Effect.provide(runEligible(options), fakeSeams(script).layer));
 
-/** The same run, with the command lines it spawned — how "no git read happened" is asserted. */
+/** The same run, with what it spawned and what it requested — how "X was never read" is asserted. */
 const runWatched = async (script: ReadonlyArray<Scripted>) => {
 	const seams = fakeSeams(script);
 	const out = await Effect.runPromise(Effect.provide(runEligible(options), seams.layer));
-	return {out, calls: seams.calls};
+	return {out, calls: seams.calls, requests: seams.requests};
 };
 
 const ASSEMBLY = /^git rev-parse --verify --quiet epic\/4300\^\{commit\}$/;
@@ -64,7 +54,7 @@ describe("runEligible", () => {
 	it("answers eligible for a standalone issue with no edges, with parent null", async () => {
 		const out = await run([
 			[ISSUE, issue()],
-			[PARENT, HTTP_404],
+			[PARENT, NOT_FOUND],
 			[EDGES, edges()],
 		]);
 		expect(out.code).toBe(0);
@@ -90,7 +80,7 @@ describe("runEligible", () => {
 	 * for this child and answer `eligible`.
 	 */
 	it("holds back a child blocked by a native edge no prose row names", async () => {
-		const {out, calls} = await runWatched([
+		const {out, requests} = await runWatched([
 			[ISSUE, issue()],
 			[PARENT, served({number: 4300})],
 			[EDGES, edges(210)],
@@ -102,13 +92,13 @@ describe("runEligible", () => {
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe("build eligible: blocked by 1 open blocked_by edge: #210.");
 		// The parent ledger body is never fetched — the prose block is not an input any more.
-		expect(calls.some((line) => line === "gh api repos/o/r/issues/4300")).toBe(false);
+		expect(requests.some((request) => request.endsWith("/issues/4300"))).toBe(false);
 	});
 
 	it("gates a STANDALONE issue on its own edges — no parent ledger to derive from", async () => {
 		const out = await run([
 			[ISSUE, issue()],
-			[PARENT, HTTP_404],
+			[PARENT, NOT_FOUND],
 			[EDGES, edges(210)],
 			[BLOCKER(210), issue({number: 210, state: "open"})],
 		]);
@@ -119,7 +109,7 @@ describe("runEligible", () => {
 	it("names EVERY open edge, not only the first", async () => {
 		const out = await run([
 			[ISSUE, issue()],
-			[PARENT, HTTP_404],
+			[PARENT, NOT_FOUND],
 			[EDGES, edges(210, 211)],
 			[BLOCKER(210), issue({number: 210, state: "open"})],
 			[BLOCKER(211), issue({number: 211, state: "open"})],
@@ -133,7 +123,7 @@ describe("runEligible", () => {
 	it("counts a blocker the token cannot see as open, never as discharged", async () => {
 		const out = await run([
 			[ISSUE, issue()],
-			[PARENT, HTTP_404],
+			[PARENT, NOT_FOUND],
 			[EDGES, edges(210)],
 			[BLOCKER(210), NOT_FOUND],
 		]);
@@ -158,19 +148,19 @@ describe("runEligible", () => {
 		it("the issue itself", async () => {
 			const out = await run([
 				[ISSUE, GATEWAY],
-				[PARENT, HTTP_404],
+				[PARENT, NOT_FOUND],
 			]);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
 			expect(out.stdout).toBe("");
 			expect(out.stderr.at(-1)).toBe(
-				'build eligible: cannot read #4312: gh: Bad gateway (HTTP 502) — eligibility is UNKNOWN, never "eligible".',
+				'build eligible: cannot read #4312: GitHub answered HTTP 502 — eligibility is UNKNOWN, never "eligible".',
 			);
 		});
 
 		it("the parent lookup — never 'standalone'", async () => {
 			const out = await run([
 				[ISSUE, issue()],
-				[PARENT, HTTP_502],
+				[PARENT, GATEWAY],
 			]);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
 			expect(out.stderr.at(-1)).toContain('eligibility is UNKNOWN, never "eligible"');
@@ -179,7 +169,7 @@ describe("runEligible", () => {
 		it("the edge list — never 'no edges, so not blocked'", async () => {
 			const out = await run([
 				[ISSUE, issue()],
-				[PARENT, HTTP_404],
+				[PARENT, NOT_FOUND],
 				[EDGES, GATEWAY],
 			]);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -190,7 +180,7 @@ describe("runEligible", () => {
 		it("a 404 on the edge list of an issue already proven open", async () => {
 			const out = await run([
 				[ISSUE, issue()],
-				[PARENT, HTTP_404],
+				[PARENT, NOT_FOUND],
 				[EDGES, NOT_FOUND],
 			]);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -200,7 +190,7 @@ describe("runEligible", () => {
 		it("a blocker's state, with nothing else proven open", async () => {
 			const out = await run([
 				[ISSUE, issue()],
-				[PARENT, HTTP_404],
+				[PARENT, NOT_FOUND],
 				[EDGES, edges(210)],
 				[BLOCKER(210), GATEWAY],
 			]);
@@ -245,7 +235,7 @@ describe("runEligible", () => {
 		it("reads no branch for a standalone issue, which has no assembly branch", async () => {
 			const {out, calls} = await runWatched([
 				[ISSUE, issue()],
-				[PARENT, HTTP_404],
+				[PARENT, NOT_FOUND],
 				[EDGES, edges(210)],
 				[BLOCKER(210), issue({number: 210, state: "open"})],
 			]);
@@ -288,7 +278,7 @@ describe("runEligible", () => {
 				[EDGES, edges(210)],
 				[BLOCKER(210), issue({number: 210, state: "open"})],
 				[ASSEMBLY, okOut(`${TIP}\n`)],
-				[TRUNK, HTTP_502],
+				[TRUNK, GATEWAY],
 			]);
 			expect(out.code).toBe(BLOCKED);
 			expect(out.stderr.some((line) => line.includes("cannot name o/r's default branch"))).toBe(
@@ -330,7 +320,7 @@ describe("runEligible", () => {
 	it("an unread blocker never masks a proven-open one, and is reported beside it", async () => {
 		const out = await run([
 			[ISSUE, issue()],
-			[PARENT, HTTP_404],
+			[PARENT, NOT_FOUND],
 			[EDGES, edges(210, 211)],
 			[BLOCKER(210), GATEWAY],
 			[BLOCKER(211), issue({number: 211, state: "open"})],

--- a/packages/fabrika-cli/src/build/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/build/fixtures.test-support.ts
@@ -1,12 +1,11 @@
 /**
- * The canned `gh` and `git` responses the `build` verb tests script their spawner with.
+ * The canned GitHub and `git` answers the `build` verb tests script their seams with.
  *
  * They are shaped like the real payloads rather than like the parsers, so a parser that starts reading
  * a different field still has to find it here — a fixture trimmed to exactly what the code reads today
  * stops being able to catch tomorrow's misread.
  */
 import {type HttpReply, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
 
 /**
  * The credential a ported test hands its verb.
@@ -59,8 +58,8 @@ export const issuePayload = (overrides: Record<string, unknown> = {}): Record<st
 	...overrides,
 });
 
-export const issue = (overrides: Record<string, unknown> = {}): ExecResult =>
-	okOut(JSON.stringify(issuePayload(overrides)));
+export const issue = (overrides: Record<string, unknown> = {}): HttpReply =>
+	served(issuePayload(overrides));
 
 export const pullPayload = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
 	number: 4318,
@@ -73,51 +72,53 @@ export const pullPayload = (overrides: Record<string, unknown> = {}): Record<str
 	...overrides,
 });
 
-export const pull = (overrides: Record<string, unknown> = {}): ExecResult =>
-	okOut(JSON.stringify(pullPayload(overrides)));
+export const pull = (overrides: Record<string, unknown> = {}): HttpReply =>
+	served(pullPayload(overrides));
+
+export interface CommentFixture {
+	readonly id: number;
+	readonly body: string;
+	readonly author?: string;
+	readonly createdAt?: string;
+}
+
+const commentPayload = (rows: ReadonlyArray<CommentFixture>): ReadonlyArray<unknown> =>
+	rows.map((row) => ({
+		id: row.id,
+		body: row.body,
+		user: {login: row.author ?? "agent"},
+		created_at: row.createdAt ?? "2026-08-09T00:00:00Z",
+	}));
 
 /** One paged `issues/<n>/comments` response. */
-export const comments = (
-	...rows: ReadonlyArray<{id: number; body: string; author?: string; createdAt?: string}>
-): ExecResult =>
-	okOut(
-		JSON.stringify(
-			rows.map((row) => ({
-				id: row.id,
-				body: row.body,
-				user: {login: row.author ?? "agent"},
-				created_at: row.createdAt ?? "2026-08-09T00:00:00Z",
-			})),
-		),
-	);
+export const comments = (...rows: ReadonlyArray<CommentFixture>): HttpReply =>
+	served(commentPayload(rows));
 
 /**
- * The same response, cut off before its last comment closes — what a killed `gh --paginate` leaves
- * on stdout, and the read a claim must never resolve ownership from.
+ * The same response, cut off before its last comment closes — a 200 whose bytes are not the list
+ * they claim to be, and the read a claim must never resolve ownership from.
  */
-export const truncatedComments = (
-	...rows: ReadonlyArray<{id: number; body: string; author?: string; createdAt?: string}>
-): ExecResult => {
-	const whole = comments(...rows).stdout;
-	return okOut(whole.slice(0, whole.lastIndexOf("}")));
+export const truncatedComments = (...rows: ReadonlyArray<CommentFixture>): HttpReply => {
+	const whole = JSON.stringify(commentPayload(rows));
+	return {status: 200, body: whole.slice(0, whole.lastIndexOf("}"))};
 };
 
 /**
  * Every `blocked_by` edge list answering empty — the unblocked board, for a test about some other
  * axis.
  *
- * {@link fakeShell} resolves by first match, so this belongs LAST in a script: a test that scripts a
+ * The fakes resolve by first match, so this belongs LAST in a script: a test that scripts a
  * specific issue's edges wins over it. Without it every claim and every pool candidate reads an
- * unscripted command, and the blockedness gate correctly seats that as UNKNOWN.
+ * unscripted request, and the blockedness gate correctly seats that as UNKNOWN.
  */
-export const NO_BLOCKERS: readonly [RegExp, ExecResult] = [
-	/^gh api --paginate repos\/[^ ]+\/issues\/\d+\/dependencies\/blocked_by/,
-	okOut("[]"),
+export const NO_BLOCKERS: readonly [RegExp, HttpReply] = [
+	/GET .*\/issues\/\d+\/dependencies\/blocked_by/,
+	served([]),
 ];
 
 /** The same edge list, naming one blocker — pair it with that blocker's own `issues/<n>` read. */
-export const blockedBy = (...blockers: ReadonlyArray<number>): ExecResult =>
-	okOut(JSON.stringify(blockers.map((number) => ({number, state: "open"}))));
+export const blockedBy = (...blockers: ReadonlyArray<number>): HttpReply =>
+	served(blockers.map((number) => ({number, state: "open"})));
 
 /**
  * A body carrying the conforming block — what a triaged, agent-ready issue looks like.

--- a/packages/fabrika-cli/src/build/issue-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/issue-verb.unit.test.ts
@@ -1,12 +1,11 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {issue} from "./fixtures.test-support.ts";
+import {GATEWAY, issue, NOT_FOUND} from "./fixtures.test-support.ts";
 import {runIssue} from "./issue-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
 
 const options = {
 	number: 4312,
@@ -14,8 +13,8 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
-	Effect.runPromise(Effect.provide(runIssue(options), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>) =>
+	Effect.runPromise(Effect.provide(runIssue(options), fakeSeams(script).layer));
 
 describe("runIssue", () => {
 	it("carries the body and the criteria rows through", async () => {
@@ -58,7 +57,7 @@ describe("runIssue", () => {
 	});
 
 	it("refuses a proven-absent issue on 7", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("build issue: issue #4312 is proven absent or closed.");
 	});
@@ -69,7 +68,7 @@ describe("runIssue", () => {
 	});
 
 	it("refuses an unreadable issue on 11 — its content is UNKNOWN", async () => {
-		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[ISSUE, GATEWAY]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("its content is UNKNOWN");

--- a/packages/fabrika-cli/src/build/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/note-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BARE_AT_PATH,
@@ -24,12 +24,15 @@ import {
 } from "./fixtures.test-support.ts";
 import {headStamp, runNote} from "./note-verb.ts";
 
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
+
 const IS_PULL = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4310$/;
-const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/4310\/comments/;
-const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/512346$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4310$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4310\/comments/;
+const PERM = /GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+const POST = /POST .*\/repos\/o\/r\/issues\/4310\/comments/;
+const GET_COMMENT = /GET .*\/repos\/o\/r\/issues\/comments\/512346$/;
 
 const TEXT = "Round 2 findings addressed: focus restore moved out of the render path.";
 const STAMPED = `${TEXT}\n\n${headStamp(HEAD)}`;
@@ -38,10 +41,10 @@ const CLAIMED: ReadonlyArray<Scripted> = [
 	[IS_PULL, served({number: 4310, pull_request: {url: "…"}})],
 	[PULL, pull({number: 4310})],
 	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
-const POSTED = okOut(JSON.stringify({id: 512346, html_url: "https://github.com/o/r/pull/4310#c"}));
+const POSTED = served({id: 512346, html_url: "https://github.com/o/r/pull/4310#c"}, 201);
 
 const options = {
 	number: 4310,
@@ -59,12 +62,8 @@ const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options>
 
 describe("runNote", () => {
 	it("stamps a note on a PR with that PR's head SHA (#4808)", async () => {
-		const shell = fakeSeams([
-			...CLAIMED,
-			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: STAMPED}))],
-		]);
-		const out = await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		const seams = fakeSeams([...CLAIMED, [POST, POSTED], [GET_COMMENT, served({body: STAMPED})]]);
+		const out = await Effect.runPromise(Effect.provide(runNote(options), seams.layer));
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
 			answer: "posted",
@@ -72,16 +71,16 @@ describe("runNote", () => {
 			commentId: 512346,
 			head: HEAD,
 		});
-		expect(shell.calls.some((line) => line.includes(`— at ${HEAD}`))).toBe(true);
+		expect(seams.bodies.some((body) => body.includes(`— at ${HEAD}`))).toBe(true);
 	});
 
 	it("does not stamp a note on a plain issue, and reports head null", async () => {
 		const out = await run([
 			[IS_PULL, served({number: 4310})],
 			[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: TEXT}))],
+			[GET_COMMENT, served({body: TEXT})],
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).head).toBeNull();
@@ -92,13 +91,9 @@ describe("runNote", () => {
 	 * `build tree` just refused, so this verb never runs the tree assertions.
 	 */
 	it("never runs the tree assertions — a refused tree does not silence the report", async () => {
-		const shell = fakeSeams([
-			...CLAIMED,
-			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: STAMPED}))],
-		]);
-		await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
-		expect(shell.calls.some((line) => /git rev-parse|git status/.test(line))).toBe(false);
+		const seams = fakeSeams([...CLAIMED, [POST, POSTED], [GET_COMMENT, served({body: STAMPED})]]);
+		await Effect.runPromise(Effect.provide(runNote(options), seams.layer));
+		expect(seams.calls.some((line) => /git rev-parse|git status/.test(line))).toBe(false);
 	});
 
 	it("refuses empty stdin on 3", async () => {
@@ -114,18 +109,18 @@ describe("runNote", () => {
 	});
 
 	it("refuses a machine-local path on 5, and posts nothing", async () => {
-		const shell = fakeSeams(CLAIMED);
+		const seams = fakeSeams(CLAIMED);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runNote({
 					...options,
 					stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "see /Users/someone/log.txt"}),
 				}),
-				shell.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(LEAKED_PATH);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 
 	it("refuses a proven-absent target on 7", async () => {
@@ -137,19 +132,19 @@ describe("runNote", () => {
 	});
 
 	it("refuses a foreign claim on 15, and posts nothing", async () => {
-		const shell = fakeSeams([
+		const seams = fakeSeams([
 			[IS_PULL, served({number: 4310, pull_request: {url: "…"}})],
 			[PULL, pull({number: 4310})],
 			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runNote(options), seams.layer));
 		expect(out.code).toBe(CLAIM_NOT_MINE);
-		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 
 	it("refuses a failed write on 8 — UNKNOWN whether it landed", async () => {
-		const out = await run([...CLAIMED, [POST, errOut("gh: Gateway timeout (HTTP 504)")]]);
+		const out = await run([...CLAIMED, [POST, {status: 504, body: "{}"}]]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 	});
 
@@ -157,7 +152,7 @@ describe("runNote", () => {
 		const out = await run([
 			...CLAIMED,
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: "something else"}))],
+			[GET_COMMENT, served({body: "something else"})],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 	});

--- a/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeSeams, linkNext, type Scripted} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, linkNext, type Scripted} from "../fakes.test-support.ts";
 import {ROADMAP_FILE} from "../triage/roadmap.ts";
 import {FAILED} from "../verb.ts";
 import {BAD_SECTIONS, PRECONDITION_UNKNOWN} from "./codes.ts";
@@ -408,8 +408,8 @@ describe("runPick", () => {
  */
 describe("runPick — the blocked_by graph", () => {
 	const edges = (n: number) =>
-		new RegExp(`^gh api --paginate repos/o/r/issues/${n}/dependencies/blocked_by`);
-	const blocker = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
+		new RegExp(`^GET \\S+/repos/o/r/issues/${n}/dependencies/blocked_by`);
+	const blocker = (n: number) => new RegExp(`^GET \\S+/repos/o/r/issues/${n}$`);
 
 	it("excludes a candidate with an open blocker, with `blocked` as its named reason", async () => {
 		const out = await run([
@@ -442,7 +442,7 @@ describe("runPick — the blocked_by graph", () => {
 			[bucket("p0"), candidatePage({number: 500, labels: [...TRIAGED, "p0"]})],
 			[bucket("p1"), EMPTY],
 			[bucket("p2"), EMPTY],
-			[edges(500), errOut("gh: Bad gateway (HTTP 502)")],
+			[edges(500), GATEWAY],
 		]);
 		expect(out.code).toBe(0);
 		expect(pool(out)).toEqual([]);
@@ -467,6 +467,6 @@ describe("runPick — the blocked_by graph", () => {
 			Effect.provide(runPick(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(0);
-		expect(shell.calls.some((line) => /dependencies\/blocked_by/.test(line))).toBe(false);
+		expect(shell.requests.some((line) => /dependencies\/blocked_by/.test(line))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
@@ -33,13 +33,16 @@ import {runPr, runPrBody} from "./pr-verb.ts";
 
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
 const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
 const OPEN_PULLS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\?state=open&head=/;
 const REPO_META = /^GET https:\/\/api\.github\.com\/repos\/o\/r$/;
 const CREATE = /^POST https:\/\/api\.github\.com\/repos\/o\/r\/pulls$/;
-const READ_BACK = /^gh api repos\/o\/r\/pulls\/4318$/;
+const READ_BACK = /^GET \S+\/repos\/o\/r\/pulls\/4318$/;
+
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
 
 const LANE = `build/4312-editor-focus-loss-${NONCE}`;
 const BODY = "Fixes #4312\n\nEditor focus now survives a save.\n\n## Deviations\nNone.\n";
@@ -49,7 +52,7 @@ const LANE_OK: ReadonlyArray<Scripted> = [
 	[REV_PARSE, GIT_DIRS],
 	[BRANCH, okOut(`${LANE}\n`)],
 	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
 const options = {
@@ -157,7 +160,8 @@ describe("runPr — the write path", () => {
 			[READ_BACK, pull({body: BODY})],
 		]);
 		await Effect.runPromise(Effect.provide(runPr(options), shell.layer));
-		expect(shell.calls.some((line) => line.includes("body=@"))).toBe(false);
+		const create = shell.requests.findIndex((line) => CREATE.test(line));
+		expect(JSON.parse(shell.bodies[create] ?? "null")).toMatchObject({body: BODY});
 	});
 
 	it("answers `existing` on exit 0 when this head already has an open PR — no duplicate", async () => {
@@ -214,8 +218,15 @@ describe("runPr — the write path", () => {
 const PULL_HEAD = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4318$/;
 const PATCH_BODY = /^PATCH https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4318$/;
 
+/**
+ * The head read, scripted to answer once.
+ *
+ * The head probe and the read-back hit the same endpoint, so a row that matched forever would
+ * answer the read-back with the payload the probe was scripted with — and every read-back test
+ * would compare the body against itself.
+ */
 const head = (overrides: {ref?: string; state?: string; merged?: boolean} = {}): Scripted => [
-	PULL_HEAD,
+	once(PULL_HEAD),
 	served(
 		pullPayload({
 			number: 4318,
@@ -233,7 +244,7 @@ const LANE_ONLY: ReadonlyArray<Scripted> = [
 	[REV_PARSE, GIT_DIRS],
 	[BRANCH, okOut(`${LANE}\n`)],
 	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
 const bodyOptions = {
@@ -408,10 +419,10 @@ describe("runPrBody — the guarded body-only repair (#5618)", () => {
 			[REV_PARSE, GIT_DIRS],
 			[BRANCH, okOut(`${other}\n`)],
 			[
-				/^gh api --paginate repos\/o\/r\/issues\/9999\/comments/,
+				/^GET \S+\/repos\/o\/r\/issues\/9999\/comments/,
 				comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
 			],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 			head(),
 		]);
 		expect(out.code).toBe(WRONG_LANE);
@@ -423,7 +434,7 @@ describe("runPrBody — the guarded body-only repair (#5618)", () => {
 			[REV_PARSE, GIT_DIRS],
 			[BRANCH, okOut(`${LANE}\n`)],
 			[COMMENTS, comments()],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 			head(),
 			[PATCH_BODY, PATCHED],
 		]);

--- a/packages/fabrika-cli/src/build/push-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/push-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	CLAIM_NOT_MINE,
 	HEAD_DROPS_REMOTE,
@@ -20,14 +19,18 @@ import {
 	marker,
 	NONCE,
 	OLD_HEAD,
+	served,
 } from "./fixtures.test-support.ts";
 import {runPush} from "./push-verb.ts";
 
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
+
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
 const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
 const HEAD_SHA = /^git rev-parse HEAD$/;
 const UPSTREAM = /^git rev-parse --abbrev-ref --symbolic-full-name /;
 const LS_REMOTE = /^git ls-remote origin /;
@@ -39,12 +42,12 @@ const LOG = /^git log /;
 
 const LANE = `build/4312-editor-focus-loss-${NONCE}`;
 
-const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const LANE_OK: ReadonlyArray<Scripted> = [
 	[REV_PARSE, GIT_DIRS],
 	[BRANCH, okOut(`${LANE}\n`)],
 	[ISSUE, issue()],
 	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 	[HEAD_SHA, okOut(`${HEAD}\n`)],
 	[UPSTREAM, errOut("fatal: no upstream")],
 	// The remote head is in this object database, so the containment test has both commits.
@@ -61,11 +64,8 @@ const options = {
 	>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runPush({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runPush({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runPush", () => {
 	it("puts the WHOLE report on stdout, with the verdict line last", async () => {
@@ -83,15 +83,15 @@ describe("runPush", () => {
 	});
 
 	it("proves MOVED by reading the remote ref back, not by git push's own report (#4136)", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...LANE_OK,
 			[/^git remote$/, okOut("origin\n")],
 			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
 			[ANCESTOR, okOut("")],
 			[PUSH, errOut("everything up-to-date")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
-		expect(shell.calls.filter((line) => LS_REMOTE.test(line)).length).toBeGreaterThanOrEqual(2);
+		const out = await Effect.runPromise(Effect.provide(runPush(options), seams.layer));
+		expect(seams.calls.filter((line) => LS_REMOTE.test(line)).length).toBeGreaterThanOrEqual(2);
 		expect(out.code).toBe(0);
 	});
 
@@ -127,22 +127,22 @@ describe("runPush", () => {
 	});
 
 	it("refuses a non-fast-forward without --force-with-lease on 19, and pushes nothing", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...LANE_OK,
 			[/^git remote$/, okOut("origin\n")],
 			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
 			[ANCESTOR, errOut("")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runPush(options), seams.layer));
 		expect(out.code).toBe(UNSAFE_PUSH);
 		expect(out.stderr.at(-1)).toBe(
 			"build push: non-fast-forward — pass --force-with-lease only for this lane's own repair resubmission.",
 		);
-		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+		expect(seams.calls.some((line) => PUSH.test(line))).toBe(false);
 	});
 
 	it("passes --force-with-lease through, and never a bare --force or --no-verify", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...LANE_OK,
 			[/^git remote$/, okOut("origin\n")],
 			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
@@ -150,24 +150,24 @@ describe("runPush", () => {
 			[PUSH, okOut("")],
 		]);
 		await Effect.runPromise(
-			Effect.provide(runPush({...options, forceWithLease: true}), shell.layer),
+			Effect.provide(runPush({...options, forceWithLease: true}), seams.layer),
 		);
-		const pushed = shell.calls.find((line) => PUSH.test(line)) ?? "";
+		const pushed = seams.calls.find((line) => PUSH.test(line)) ?? "";
 		expect(pushed).toContain("--force-with-lease");
 		expect(pushed).not.toMatch(/--force(?!-with-lease)/);
 		expect(pushed).not.toContain("--no-verify");
 	});
 
 	it("pushes to the TRACKED UPSTREAM when there is one — resume mode's local name differs", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV_PARSE, GIT_DIRS],
 			[BRANCH, okOut(`build/pr-4310-${NONCE}\n`)],
-			[/^gh api repos\/o\/r\/issues\/4310$/, issue({number: 4310})],
+			[/^GET \S+\/repos\/o\/r\/issues\/4310$/, issue({number: 4310})],
 			[
-				/^gh api --paginate repos\/o\/r\/issues\/4310\/comments/,
+				/^GET \S+\/repos\/o\/r\/issues\/4310\/comments/,
 				comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
 			],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 			[HEAD_SHA, okOut(`${HEAD}\n`)],
 			[UPSTREAM, okOut("origin/umut/fix-focus\n")],
 			[PRESENT, okOut(`${HEAD}\n`)],
@@ -176,15 +176,15 @@ describe("runPush", () => {
 			[ANCESTOR, okOut("")],
 			[PUSH, okOut("")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runPush(options), seams.layer));
 		expect(out.code).toBe(0);
-		expect(shell.calls).toContain("git push origin HEAD:refs/heads/umut/fix-focus");
+		expect(seams.calls).toContain("git push origin HEAD:refs/heads/umut/fix-focus");
 	});
 
 	// The repair path mandates --force-with-lease, and the lease is blind to THIS lane dropping the
 	// remote's own commits — so these four are the containment contract (#5222).
 	it("refuses on 23 when the force-path head does not contain the remote head, and pushes nothing", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...LANE_OK,
 			[/^git remote$/, okOut("origin\n")],
 			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
@@ -193,11 +193,11 @@ describe("runPush", () => {
 			[PUSH, okOut("")],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runPush({...options, forceWithLease: true}), shell.layer),
+			Effect.provide(runPush({...options, forceWithLease: true}), seams.layer),
 		);
 		expect(out.code).toBe(HEAD_DROPS_REMOTE);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+		expect(seams.calls.some((line) => PUSH.test(line))).toBe(false);
 		const said = out.stderr.at(-1) ?? "";
 		expect(said).toContain(`does not contain origin/${LANE} (${OLD_HEAD})`);
 		expect(said).toContain("a1b2c3d restore the 20 workflow triggers");
@@ -205,7 +205,7 @@ describe("runPush", () => {
 	});
 
 	it("publishes the dropping head only when --drop-remote-commits says so, and says it did", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...LANE_OK,
 			[/^git remote$/, okOut("origin\n")],
 			[once(LS_REMOTE), okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
@@ -216,7 +216,7 @@ describe("runPush", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runPush({...options, forceWithLease: true, dropRemoteCommits: true}),
-				shell.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(0);
@@ -225,7 +225,7 @@ describe("runPush", () => {
 	});
 
 	it("refuses on 11 when the remote head is unreadable locally — UNKNOWN, never 'not contained'", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...LANE_OK.filter(([pattern]) => pattern !== PRESENT),
 			[/^git remote$/, okOut("origin\n")],
 			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
@@ -233,12 +233,12 @@ describe("runPush", () => {
 			[FETCH, errOut("fatal: could not read from remote repository")],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runPush({...options, forceWithLease: true}), shell.layer),
+			Effect.provide(runPush({...options, forceWithLease: true}), seams.layer),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
-		expect(shell.calls.some((line) => FETCH.test(line))).toBe(true);
+		expect(seams.calls.some((line) => PUSH.test(line))).toBe(false);
+		expect(seams.calls.some((line) => FETCH.test(line))).toBe(true);
 		expect(out.stderr.at(-1)).toContain("cannot prove containment");
 	});
 
@@ -267,15 +267,15 @@ describe("runPush", () => {
 	});
 
 	it("refuses a foreign claim on 15, and pushes nothing", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV_PARSE, GIT_DIRS],
 			[BRANCH, okOut(`${LANE}\n`)],
 			[ISSUE, issue()],
 			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runPush(options), seams.layer));
 		expect(out.code).toBe(CLAIM_NOT_MINE);
-		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+		expect(seams.calls.some((line) => PUSH.test(line))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/build/scratch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scratch-verb.unit.test.ts
@@ -1,20 +1,30 @@
 import {Effect, FileSystem, Layer, PlatformError} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {CLAIM_NOT_MINE, OFF_VOCABULARY} from "./codes.ts";
-import {comments, issue, LANE_TOKEN, LANE_UUID, marker, NONCE} from "./fixtures.test-support.ts";
+import {
+	comments,
+	issue,
+	LANE_TOKEN,
+	LANE_UUID,
+	marker,
+	NONCE,
+	served,
+} from "./fixtures.test-support.ts";
 import {runScratch} from "./scratch-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
 
-const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+
+const CLAIMED: ReadonlyArray<Scripted> = [
 	[ISSUE, issue()],
 	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, WRITE],
 ];
 
 const options = {
@@ -29,14 +39,11 @@ const options = {
 	tmpRoot: "/scratch-root",
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runScratch({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeFs({}).layer),
+			Layer.merge(fakeSeams(script).layer, fakeFs({}).layer),
 		),
 	);
 
@@ -68,7 +75,7 @@ describe("runScratch", () => {
 		const out = await run([
 			[ISSUE, issue()],
 			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, WRITE],
 		]);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stdout).toBe("");
@@ -87,7 +94,7 @@ describe("runScratch", () => {
 				),
 		});
 		const out = await Effect.runPromise(
-			Effect.provide(runScratch(options), Layer.merge(fakeShell(CLAIMED).layer, unmakeable)),
+			Effect.provide(runScratch(options), Layer.merge(fakeSeams(CLAIMED).layer, unmakeable)),
 		);
 		expect(out.code).toBe(FAILED);
 		expect(out.stdout).toBe("");

--- a/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
@@ -1,18 +1,29 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {CLAIM_NOT_MINE, DIRTY_TREE, PRECONDITION_UNKNOWN, WRONG_LANE} from "./codes.ts";
-import {comments, GIT_DIRS, issue, LANE_UUID, marker, NONCE} from "./fixtures.test-support.ts";
+import {
+	comments,
+	GATEWAY,
+	GIT_DIRS,
+	issue,
+	LANE_UUID,
+	marker,
+	NONCE,
+	served,
+} from "./fixtures.test-support.ts";
 import {runTree} from "./tree-verb.ts";
+
+/** The write permission the marker's author holds — what authorizes a claim (ADR 0055). */
+const WRITE = served({permission: "write"});
 
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
 const STATUS = /^git status --porcelain$/;
 const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
 
 const LANE_BRANCH = okOut(`build/4312-editor-focus-loss-${NONCE}\n`);
 const MINE = comments({id: 1, body: marker("s-9f2e", LANE_UUID)});
@@ -27,11 +38,8 @@ const options = {
 	>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runTree({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runTree({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runTree", () => {
 	it("prints the tree root when the git dir and the common dir differ", async () => {
@@ -48,18 +56,18 @@ describe("runTree", () => {
 	});
 
 	it("refuses a dirty tree at a --require-clean open on 13, and never cleans it", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV_PARSE, GIT_DIRS],
 			[STATUS, okOut(" M apps/web/src/App.tsx\n?? scratch.md\n")],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runTree({...options, requireClean: true}), shell.layer),
+			Effect.provide(runTree({...options, requireClean: true}), seams.layer),
 		);
 		expect(out.code).toBe(DIRTY_TREE);
 		expect(out.stderr.at(-1)).toBe(
 			"build tree: 2 uncommitted change(s) at open — refusing; an unauthored hunk is not yours to keep or clean.",
 		);
-		expect(shell.calls.some((line) => /git (checkout|clean|restore|stash)/.test(line))).toBe(false);
+		expect(seams.calls.some((line) => /git (checkout|clean|restore|stash)/.test(line))).toBe(false);
 	});
 
 	it("passes --require-clean over a clean tree", async () => {
@@ -76,7 +84,7 @@ describe("runTree", () => {
 				[REV_PARSE, GIT_DIRS],
 				[ISSUE, issue()],
 				[COMMENTS, MINE],
-				[PERM, okOut("write\n")],
+				[PERM, WRITE],
 				[BRANCH, LANE_BRANCH],
 			],
 			{issue: 4312},
@@ -91,7 +99,7 @@ describe("runTree", () => {
 				[REV_PARSE, GIT_DIRS],
 				[ISSUE, issue()],
 				[COMMENTS, MINE],
-				[PERM, okOut("write\n")],
+				[PERM, WRITE],
 				[BRANCH, okOut("build/4312-editor-focus-loss-deadbeef\n")],
 			],
 			{issue: 4312},
@@ -106,7 +114,7 @@ describe("runTree", () => {
 				[REV_PARSE, GIT_DIRS],
 				[ISSUE, issue()],
 				[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
-				[PERM, okOut("write\n")],
+				[PERM, WRITE],
 				[BRANCH, LANE_BRANCH],
 			],
 			{issue: 4312},
@@ -122,7 +130,7 @@ describe("runTree", () => {
 			[
 				[REV_PARSE, GIT_DIRS],
 				[ISSUE, issue()],
-				[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+				[COMMENTS, GATEWAY],
 				[BRANCH, LANE_BRANCH],
 			],
 			{issue: 4312},

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
 	comments,
@@ -8,6 +8,7 @@ import {
 	GH_TOKEN_ENV,
 	HEAD,
 	issue,
+	NOT_FOUND,
 	OLD_HEAD,
 	PRIOR_HEADS,
 	pull,
@@ -15,10 +16,10 @@ import {
 } from "./fixtures.test-support.ts";
 import {runChildVerdicts, runVerdicts} from "./verdicts-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4310$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4310\/comments/;
 const REVIEWS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4310\/reviews/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
 
 const FAIL_NOW = `review-code: FAIL @ ${HEAD} — the debounce fix races the unmount`;
 const failAt = (sha: string) => `review-code: FAIL @ ${sha} — the debounce fix races the unmount`;
@@ -73,7 +74,7 @@ describe("runVerdicts", () => {
 	it("reports a native review as its OWN row kind, never coerced into a marker (#4555)", async () => {
 		const out = await run([
 			[PULL, PR],
-			[COMMENTS, okOut("[]")],
+			[COMMENTS, served([])],
 			[REVIEWS, served([{id: 98001, state: "CHANGES_REQUESTED", body: "the debounce races"}])],
 			[ISSUE, issue()],
 		]);
@@ -155,7 +156,7 @@ describe("runVerdicts", () => {
 	it("lists only the criteria appended AFTER round 2, by their provenance tag", async () => {
 		const out = await run([
 			[PULL, PR],
-			[COMMENTS, okOut("[]")],
+			[COMMENTS, served([])],
 			[REVIEWS, NO_REVIEWS],
 			[
 				ISSUE,
@@ -192,7 +193,7 @@ describe("runVerdicts", () => {
 	});
 
 	it("refuses a proven-absent PR on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("build verdicts: PR #4310 is proven absent or closed.");
 	});
@@ -200,7 +201,7 @@ describe("runVerdicts", () => {
 	it("refuses an unreadable comment page on 11 — never a shorter list", async () => {
 		const out = await run([
 			[PULL, PR],
-			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			[COMMENTS, GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -210,33 +211,30 @@ describe("runVerdicts", () => {
 	it("refuses an unreadable review page on 11 too", async () => {
 		const out = await run([
 			[PULL, PR],
-			[COMMENTS, okOut("[]")],
+			[COMMENTS, served([])],
 			[REVIEWS, GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
-	// One assertion per seam, because the two list reads no longer sit on the same one: the comments
-	// still page through `gh --paginate`, the reviews page over the client (ADR 0315).
 	it("paginates both list reads", async () => {
 		const seams = fakeSeams([
 			[PULL, PR],
-			[COMMENTS, okOut("[]")],
+			[COMMENTS, served([])],
 			[REVIEWS, NO_REVIEWS],
 			[ISSUE, issue()],
 		]);
 		await Effect.runPromise(Effect.provide(runVerdicts(options), seams.layer));
-		expect(seams.calls.filter((line) => line.includes("--paginate")).length).toBeGreaterThanOrEqual(
-			1,
-		);
-		expect(seams.requests.filter((line) => line.includes("per_page=100")).length).toBe(1);
+		expect(seams.requests.filter((line) => line.includes("per_page=100")).length).toBe(2);
 	});
 	describe("the founder's cleared rounds", () => {
-		const CONFIG =
-			/^gh api -H Accept: application\/vnd\.github\.raw repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
-		const CONFIGURED = okOut('{"capClearAuthors": ["@usirin"]}');
-		const PERMISSION = /^gh api repos\/o\/r\/collaborators\/usirin\/permission/;
-		const WRITES = okOut("admin\n");
+		const CONFIG = /^GET \S+\/repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
+		const CONFIGURED: HttpReply = {
+			status: 200,
+			body: JSON.stringify({capClearAuthors: ["@usirin"]}),
+		};
+		const PERMISSION = /^GET \S+\/repos\/o\/r\/collaborators\/usirin\/permission/;
+		const WRITES = served({permission: "admin"});
 		const AUTHORIZATION = 'Founder ruling 2026-08-18: "one more round."';
 		// Three graded heads, so three rounds — a round is a head, not a span of clock (#6137).
 		const CAPPED = [
@@ -354,7 +352,7 @@ describe("runVerdicts", () => {
 				[PULL, PR_ON_MAIN],
 				[COMMENTS, comments(...CAPPED, ...GRANT)],
 				[CONFIG, CONFIGURED],
-				[PERMISSION, okOut("read\n")],
+				[PERMISSION, served({permission: "read"})],
 				[REVIEWS, NO_REVIEWS],
 				[ISSUE, issue()],
 			]);
@@ -369,7 +367,7 @@ describe("runVerdicts", () => {
 				[PULL, PR_ON_MAIN],
 				[COMMENTS, comments(...CAPPED, ...GRANT)],
 				[CONFIG, CONFIGURED],
-				[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+				[PERMISSION, GATEWAY],
 				[REVIEWS, NO_REVIEWS],
 				[ISSUE, issue()],
 			]);
@@ -403,7 +401,7 @@ describe("runVerdicts", () => {
 			const out = await run([
 				[PULL, PR_ON_MAIN],
 				[COMMENTS, comments(...CAPPED, ...GRANT)],
-				[CONFIG, errOut("gh: Bad gateway (HTTP 502)")],
+				[CONFIG, GATEWAY],
 				[REVIEWS, NO_REVIEWS],
 				[ISSUE, issue()],
 			]);
@@ -421,7 +419,7 @@ describe("runChildVerdicts", () => {
 	const BASE = "9f2c1ab4d5e6f708192a3b4c5d6e7f8091a2b3c4";
 	const TIP = "03135b917283a4b5c6d7e8f90a1b2c3d4e5f6071";
 	const NEXT_TIP = "5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f";
-	const CHILD_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+	const CHILD_COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
 	const range = (polarity: string, tip = TIP) =>
 		`review-code: ${polarity} range:${BASE}..${tip} content:2f1a9c4e0b7d — the child's range`;
 
@@ -489,7 +487,7 @@ describe("runChildVerdicts", () => {
 	it("refuses an unreadable comment page on 11 — never 'none'", async () => {
 		const out = await runChild([
 			[ISSUE, issue()],
-			[CHILD_COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			[CHILD_COMMENTS, GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -489,6 +489,14 @@ export const fakeSeams = (
 	readonly calls: ReadonlyArray<string>;
 	readonly requests: ReadonlyArray<string>;
 	readonly bodies: ReadonlyArray<string>;
+	/**
+	 * What each request carried as headers, aligned with `requests`.
+	 *
+	 * The only place an `Accept` claim can be read: two reads of one URL that differ solely by
+	 * `Accept` — the pull metadata read and the diff read — are one line in `requests`, so a fence
+	 * pinning which of them ran can be stated nowhere else (#5117, #5122).
+	 */
+	readonly headers: ReadonlyArray<Readonly<Record<string, string>>>;
 	/** Both seams' traffic in one order — the only place a "X happened before Y" claim can be read. */
 	readonly log: ReadonlyArray<string>;
 } => {
@@ -509,6 +517,7 @@ export const fakeSeams = (
 		calls: shell.calls,
 		requests: http.calls,
 		bodies: http.bodies,
+		headers: http.headers,
 		log,
 	};
 };

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -487,6 +487,8 @@ export const fakeSeams = (
 ): {
 	readonly layer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient>;
 	readonly calls: ReadonlyArray<string>;
+	/** What each spawn was handed on stdin, aligned with `calls` — a `git commit -F -` claim (#5484). */
+	readonly inputs: ReadonlyArray<string>;
 	readonly requests: ReadonlyArray<string>;
 	readonly bodies: ReadonlyArray<string>;
 	/**
@@ -515,6 +517,7 @@ export const fakeSeams = (
 	return {
 		layer: Layer.merge(shell.layer, http.layer),
 		calls: shell.calls,
+		inputs: shell.inputs,
 		requests: http.calls,
 		bodies: http.bodies,
 		headers: http.headers,

--- a/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {runBase} from "./base-verb.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
@@ -19,7 +19,10 @@ import {
 	treeOf,
 } from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+
+/** A fixture's canned JSON, served as the 200 the REST read now parses. */
+const served = (result: ExecResult) => ({status: 200, body: result.stdout});
 
 const options = {
 	pr: 4321 as number | null,
@@ -30,25 +33,22 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runBase({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runBase({...options, ...overrides}), fakeSeams(script).layer));
 
 const SKILL_BYTES = "---\nname: governance\n---\n\n# governance\n";
 const CONTRACT_BYTES = "# contract\n";
 
 const upTo = (
 	tree: ReadonlyArray<string> = [`${SKILL_ROOT}SKILL.md`, `${SKILL_ROOT}contract.md`],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[once(PULL), pull()],
+): ReadonlyArray<Scripted> => [
+	[once(PULL), served(pull())],
 	...binding(),
-	[PULL, pull()],
+	[PULL, served(pull())],
 	[TREE_AT(MERGE_BASE), treeOf(...tree)],
 ];
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	...upTo(),
 	[SHOW_AT(MERGE_BASE, `${SKILL_ROOT}SKILL.md`), okOut(SKILL_BYTES)],
 	[SHOW_AT(MERGE_BASE, `${SKILL_ROOT}contract.md`), okOut(CONTRACT_BYTES)],
@@ -120,7 +120,11 @@ describe("runBase", () => {
 
 	it("refuses on 12 when the head moved while the base was being resolved", async () => {
 		const moved = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
-		const out = await run([[once(PULL), pull()], ...binding(), [PULL, pull({head: moved})]]);
+		const out = await run([
+			[once(PULL), served(pull())],
+			...binding(),
+			[PULL, served(pull({head: moved}))],
+		]);
 		expect(out.code).toBe(STALE_HEAD);
 		expect(out.stderr.at(-1)).toBe(
 			`governance base: #4321's head moved to ${moved} while resolving — re-run.`,
@@ -131,7 +135,7 @@ describe("runBase", () => {
 	// rather than `bindHead`'s — the entry precedes `binding()` because the first match wins.
 	it("refuses an unresolvable merge base on 11", async () => {
 		const out = await run([
-			[once(PULL), pull()],
+			[once(PULL), served(pull())],
 			[/^git merge-base /, errOut("fatal: no merge base")],
 			...binding(),
 		]);
@@ -142,12 +146,14 @@ describe("runBase", () => {
 	});
 
 	it("refuses an absent PR on 7 and a non-PR number on 1", async () => {
-		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]])).code).toBe(
+			ZERO_SCOPE,
+		);
 		expect((await run(happy, {pr: 0})).code).toBe(1);
 	});
 
 	it("reads the head it bound, so nothing is ever checked out", async () => {
-		const fake = fakeShell(happy);
+		const fake = fakeSeams(happy);
 		await Effect.runPromise(Effect.provide(runBase(options), fake.layer));
 		expect(fake.calls.some((call) => call.startsWith("git checkout"))).toBe(false);
 		expect(fake.calls).toContain(`git ls-tree -r --name-only -z ${MERGE_BASE}`);
@@ -159,12 +165,12 @@ const ranged = {pr: null, base: RANGE_BASE, tip: RANGE_TIP};
 
 const overRange = (
 	tree: ReadonlyArray<string> = [`${SKILL_ROOT}SKILL.md`, `${SKILL_ROOT}contract.md`],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+): ReadonlyArray<Scripted> => [
 	[MERGE_BASE_OF(), okOut(`${RANGE_MERGE_BASE}\n`)],
 	[TREE_AT(RANGE_MERGE_BASE), treeOf(...tree)],
 ];
 
-const happyRange: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happyRange: ReadonlyArray<Scripted> = [
 	...overRange(),
 	[SHOW_AT(RANGE_MERGE_BASE, `${SKILL_ROOT}SKILL.md`), okOut(SKILL_BYTES)],
 	[SHOW_AT(RANGE_MERGE_BASE, `${SKILL_ROOT}contract.md`), okOut(CONTRACT_BYTES)],
@@ -250,9 +256,9 @@ describe("runBase over a range", () => {
 	});
 
 	it("resolves no PR on a range — the epic child has none to resolve", async () => {
-		const fake = fakeShell(happyRange);
+		const fake = fakeSeams(happyRange);
 		await Effect.runPromise(Effect.provide(runBase({...options, ...ranged}), fake.layer));
-		expect(fake.calls.some((call) => call.startsWith("gh "))).toBe(false);
+		expect(fake.requests).toEqual([]);
 		expect(fake.calls.some((call) => call.startsWith("git checkout"))).toBe(false);
 		expect(fake.calls).toContain(`git ls-tree -r --name-only -z ${RANGE_MERGE_BASE}`);
 	});

--- a/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, once} from "../fakes.test-support.ts";
+import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	accepted,
 	ENV,
@@ -10,43 +10,31 @@ import {
 	runsAtHead,
 	workflowRun,
 } from "../heal-ci/fixtures.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
 import {HEAD} from "./fixtures.test-support.ts";
 import {assertFloorAt, floorLine, floorToken} from "./floor-assert.ts";
 
-const RUNS = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
+/** The paged envelope read at the head — `&per_page=100&page=1` follows, so no `$` anchor. */
+const RUNS = /^GET .*\/repos\/o\/r\/actions\/runs\?head_sha=/;
 
 const FLOOR = 31_863_008_185;
 
-const assert = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) =>
-	Effect.runPromise(
-		Effect.provide(
-			assertFloorAt("o/r", HEAD, ENV),
-			Layer.merge(fakeShell(script).layer, fakeHttp(served).layer),
-		),
-	);
+const assert = (script: ReadonlyArray<Scripted>) =>
+	Effect.runPromise(Effect.provide(assertFloorAt("o/r", HEAD, ENV), fakeSeams(script).layer));
 
-const withCalls = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) => {
-	const shell = fakeShell(script);
-	const http = fakeHttp(served);
-	return Effect.runPromise(
-		Effect.provide(assertFloorAt("o/r", HEAD, ENV), Layer.merge(shell.layer, http.layer)),
-	).then((assertion) => ({assertion, shell, http}));
+const withCalls = (script: ReadonlyArray<Scripted>) => {
+	const seams = fakeSeams(script);
+	return Effect.runPromise(Effect.provide(assertFloorAt("o/r", HEAD, ENV), seams.layer)).then(
+		(assertion) => ({assertion, seams}),
+	);
 };
 
-/** The run list at the head, still a `gh` read — it lives in `ship/github.ts`, not this port. */
+/** The `{total_count, workflow_runs}` envelope the run list at a head is read out of. */
 const listed = (
 	...rows: ReadonlyArray<{id: number; name?: string; status?: string; conclusion?: string | null}>
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [[RUNS, runsAtHead(rows.length, rows)]];
+): ReadonlyArray<Scripted> => [[RUNS, {status: 200, body: runsAtHead(rows.length, rows).stdout}]];
 
 /** A red floor run at the head, re-fired into a second attempt. */
-const red = (): ReadonlyArray<readonly [RegExp, HttpReply]> => [
+const red = (): ReadonlyArray<Scripted> => [
 	[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 	[RERUN, accepted],
 	[RUN, workflowRun({id: FLOOR, attempt: 2})],
@@ -54,63 +42,63 @@ const red = (): ReadonlyArray<readonly [RegExp, HttpReply]> => [
 
 describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 	it("re-fires the red floor run at this head and proves the new attempt", async () => {
-		const {assertion, shell, http} = await withCalls(
-			listed({id: 1, name: "ci"}, {id: FLOOR, name: "governance-floor"}),
-			red(),
-		);
+		const {assertion, seams} = await withCalls([
+			...red(),
+			...listed({id: 1, name: "ci"}, {id: FLOOR, name: "governance-floor"}),
+		]);
 		expect(assertion).toEqual({_tag: "Refired", run: FLOOR, attempt: 2});
-		expect(http.calls.some((call) => RERUN.test(call))).toBe(true);
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(true);
 		// The re-fire re-runs `ship floor` in CI. Nothing here writes a check-run or a status, so the
 		// green a PR ends up with is one the gate's own job derived (#5585).
-		expect([...shell.calls, ...http.calls].some((call) => call.includes("check-runs"))).toBe(false);
+		expect(seams.log.some((call) => call.includes("check-runs"))).toBe(false);
 	});
 
 	it("picks the NEWEST floor run at the head, not the first one listed", async () => {
-		const {http} = await withCalls(
-			listed({id: 700, name: "governance-floor"}, {id: 900, name: "governance-floor"}),
-			[
-				[once(RUN), workflowRun({id: 900, attempt: 1})],
-				[RERUN, accepted],
-				[RUN, workflowRun({id: 900, attempt: 2})],
-			],
-		);
-		expect(http.calls.some((call) => call.endsWith("/actions/runs/900"))).toBe(true);
-		expect(http.calls.some((call) => call.endsWith("/actions/runs/700"))).toBe(false);
+		const {seams} = await withCalls([
+			[once(RUN), workflowRun({id: 900, attempt: 1})],
+			[RERUN, accepted],
+			[RUN, workflowRun({id: 900, attempt: 2})],
+			...listed({id: 700, name: "governance-floor"}, {id: 900, name: "governance-floor"}),
+		]);
+		expect(seams.requests.some((call) => call.endsWith("/actions/runs/900"))).toBe(true);
+		expect(seams.requests.some((call) => call.endsWith("/actions/runs/700"))).toBe(false);
 	});
 
 	it("leaves an in-flight run alone — it cannot be re-fired, and saying so is the answer", async () => {
-		const {assertion, http} = await withCalls(
+		const {assertion, seams} = await withCalls(
 			listed({id: FLOOR, name: "governance-floor", status: "in_progress"}),
 		);
 		expect(assertion).toEqual({_tag: "InFlight", run: FLOOR});
-		expect(http.calls.some((call) => RERUN.test(call))).toBe(false);
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(false);
 	});
 
 	it("re-fires nothing when the run at this head already reads green", async () => {
-		const {assertion, http} = await withCalls(
+		const {assertion, seams} = await withCalls(
 			listed({id: FLOOR, name: "governance-floor", conclusion: "success"}),
 		);
 		expect(assertion).toEqual({_tag: "Green", run: FLOOR});
-		expect(http.calls.some((call) => RERUN.test(call))).toBe(false);
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(false);
 	});
 
 	// GitHub bumps `run_attempt` a beat after it accepts the dispatch, and calling that beat UNKNOWN
 	// sent three agents to `heal-ci` over re-fires that had taken and went green untouched (#5982).
 	it("reads a same-id run that is running again as a re-fire to wait on, not UNKNOWN", async () => {
-		const {assertion, http} = await withCalls(listed({id: FLOOR, name: "governance-floor"}), [
+		const {assertion, seams} = await withCalls([
 			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, accepted],
 			[RUN, workflowRun({id: FLOOR, attempt: 1, status: "in_progress", conclusion: null})],
+			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion).toEqual({_tag: "Restarting", run: FLOOR, status: "in_progress"});
-		expect(http.calls.some((call) => RERUN.test(call))).toBe(true);
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(true);
 	});
 
 	it("reads a queued same-id run the same way — the counter has simply not caught up", async () => {
-		const assertion = await assert(listed({id: FLOOR, name: "governance-floor"}), [
+		const assertion = await assert([
 			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, accepted],
 			[RUN, workflowRun({id: FLOOR, attempt: 1, status: "queued", conclusion: null})],
+			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion).toEqual({_tag: "Restarting", run: FLOOR, status: "queued"});
 	});
@@ -122,15 +110,18 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 
 describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
 	it("refuses to read NoRun out of a truncated run list", async () => {
-		const assertion = await assert([[RUNS, runsAtHead(9, [{id: 1, name: "ci"}])]]);
+		const assertion = await assert([
+			[RUNS, {status: 200, body: runsAtHead(9, [{id: 1, name: "ci"}]).stdout}],
+		]);
 		expect(assertion._tag).toBe("Unknown");
 		expect(assertion._tag === "Unknown" && assertion.reason).toContain("of 9 declared runs");
 	});
 
 	it("reports a failed re-fire request as UNKNOWN", async () => {
-		const assertion = await assert(listed({id: FLOOR, name: "governance-floor"}), [
+		const assertion = await assert([
 			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, httpError(403, "Forbidden")],
+			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion._tag).toBe("Unknown");
 		expect(assertion._tag === "Unknown" && assertion.reason).toContain("403");
@@ -139,16 +130,17 @@ describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
 	// The dispatch's 2xx is an acknowledgement, not an attempt: a re-fire reported on the strength of
 	// the response would tell the caller a red is clearing itself when nothing re-ran.
 	it("refuses to call it re-fired when the run stayed completed at the same attempt", async () => {
-		const assertion = await assert(listed({id: FLOOR, name: "governance-floor"}), [
+		const assertion = await assert([
 			[RUN, workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, accepted],
+			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion._tag).toBe("Unknown");
 		expect(assertion._tag === "Unknown" && assertion.reason).toContain("stayed at attempt 1");
 	});
 
 	it("reports an unreadable run list as UNKNOWN", async () => {
-		const assertion = await assert([[RUNS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const assertion = await assert([[RUNS, {status: 502, body: "{}"}]]);
 		expect(assertion._tag).toBe("Unknown");
 	});
 });

--- a/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {DIFF_AT} from "../review/fixtures.test-support.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
@@ -17,8 +17,11 @@ import {
 } from "./fixtures.test-support.ts";
 import {runGuards} from "./guards-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
 const SKILL = "claude-plugins/fabrika/skills/review/SKILL.md";
+
+/** A fixture's canned JSON, served as the 200 the REST read now parses. */
+const served = (result: ExecResult) => ({status: 200, body: result.stdout});
 
 const options = {
 	pr: 4321,
@@ -28,11 +31,8 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runGuards({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runGuards({...options, ...overrides}), fakeSeams(script).layer));
 
 const diffOf = (path: string, ...body: ReadonlyArray<string>): string =>
 	[
@@ -55,8 +55,8 @@ const scripted = (
 	bytes: string,
 	path = SKILL,
 	before = bytes,
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull({changedFiles: 1})],
+): ReadonlyArray<Scripted> => [
+	[PULL, served(pull({changedFiles: 1}))],
 	...binding(),
 	[DIFF_AT(), okOut(diff)],
 	[STATUS_AT(), statuses(["M", path])],
@@ -110,8 +110,8 @@ describe("runGuards", () => {
 
 	it("caps the guard-file evidence at five and counts the rest, on both channels (ADR 0308)", async () => {
 		const paths = Array.from({length: 7}, (_, i) => `.github/workflows/g${i}.yml`);
-		const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-			[PULL, pull({changedFiles: paths.length})],
+		const script: ReadonlyArray<Scripted> = [
+			[PULL, served(pull({changedFiles: paths.length}))],
 			...binding(),
 			[DIFF_AT(), okOut(paths.map((path) => diffOf(path, "-  run: a", "+  run: b")).join("\n"))],
 			[STATUS_AT(), statuses(...paths.map((path) => ["M", path] as const))],
@@ -120,7 +120,7 @@ describe("runGuards", () => {
 					[
 						[SHOW_AT(HEAD, path), okOut("jobs: {}\n")],
 						[SHOW_AT(BASE, path), okOut("jobs: {}\n")],
-					] as ReadonlyArray<readonly [RegExp, ExecResult]>,
+					] as ReadonlyArray<Scripted>,
 			),
 		];
 
@@ -167,7 +167,7 @@ describe("runGuards", () => {
 	it("compares the anchor block at the merge base, not at a main that edited it since", async () => {
 		const anchored = (text: string): string => `<!-- anchor: G --> ${text}\n`;
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[DIFF_AT(), okOut(diffOf(SKILL, "-prose", "+other prose"))],
 			[STATUS_AT(), statuses(["M", SKILL])],
@@ -253,7 +253,7 @@ describe("runGuards", () => {
 
 	it("refuses an unreadable BASE read on 11 — UNKNOWN, never `nothing moved`", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[DIFF_AT(), okOut(diffOf(SKILL, "-a", "+b"))],
 			[STATUS_AT(), statuses(["M", SKILL])],
@@ -269,7 +269,7 @@ describe("runGuards", () => {
 
 	it("does NOT read an added file at the base — it has no base side to compare", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[DIFF_AT(), okOut(diffOf(SKILL, "+<!-- anchor: G --> a claim"))],
 			[STATUS_AT(), statuses(["A", SKILL])],
@@ -283,7 +283,7 @@ describe("runGuards", () => {
 
 	it("reports a deleted file's anchors as removed — the walk still covers what has no head bytes", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[DIFF_AT(), okOut(diffOf(SKILL, "-<!-- anchor: G --> a claim"))],
 			[STATUS_AT(), statuses(["D", SKILL])],
@@ -292,14 +292,16 @@ describe("runGuards", () => {
 	});
 
 	it("refuses an absent, closed, or empty PR on 7", async () => {
-		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
-		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(ZERO_SCOPE);
-		expect((await run([[PULL, pull({changedFiles: 0})]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]])).code).toBe(
+			ZERO_SCOPE,
+		);
+		expect((await run([[PULL, served(pull({state: "closed"}))]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, served(pull({changedFiles: 0}))]])).code).toBe(ZERO_SCOPE);
 	});
 
 	it("refuses an unreadable diff on 11 — UNKNOWN, never `nothing moved`", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[DIFF_AT(), errOut("fatal: bad revision")],
 		]);
@@ -309,7 +311,7 @@ describe("runGuards", () => {
 
 	it("refuses a partial diff on 13 rather than scanning it", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 4})],
+			[PULL, served(pull({changedFiles: 4}))],
 			...binding(),
 			[DIFF_AT(), okOut(diffOf(SKILL, "-a", "+b"))],
 		]);

--- a/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
@@ -1,14 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {
-	errOut,
-	fakeHttp,
-	fakeShell,
-	type HttpReply,
-	okOut,
-	once,
-	unconfigured,
-} from "../fakes.test-support.ts";
+import {fakeSeams, okOut, once, type Scripted, unconfigured} from "../fakes.test-support.ts";
 import {accepted, RERUN, RUN, runsAtHead, workflowRun} from "../heal-ci/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
@@ -28,17 +20,20 @@ import {
 import {binding, comments, HEAD, OLD_HEAD, paths, pull} from "./fixtures.test-support.ts";
 import {runPost} from "./post-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const VIEWER = /^gh api user --jq \.login$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/77/;
-const READ_BACK = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
-const RUNS = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const VIEWER = /^GET .*\/user$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /^POST .*\/repos\/o\/r\/issues\/4321\/comments$/;
+const PATCH = /^PATCH .*\/repos\/o\/r\/issues\/comments\/77$/;
+const READ_BACK = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+const RUNS = /^GET .*\/repos\/o\/r\/actions\/runs\?head_sha=/;
 const FLOOR = 31_863_008_185;
 
 const BODY = "The sweep found no contradiction; no anchored invariant is in reach.\n";
 const URL = "https://github.com/o/r/pull/4321#issuecomment-5154902211";
+
+/** A fixture's canned JSON, served as the 200 the REST read now parses. */
+const served = (result: ExecResult) => ({status: 200, body: result.stdout});
 
 const options = {
 	pr: 4321,
@@ -57,38 +52,35 @@ const options = {
 	stdin: Effect.succeed({_tag: "Text", text: BODY} as StdinRead),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) =>
-	Effect.runPromise(
-		Effect.provide(
-			runPost({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, unconfigured, fakeHttp(served).layer),
-		),
-	);
+const layerFor = (script: ReadonlyArray<Scripted>) => {
+	const seams = fakeSeams(script);
+	return {seams, layer: Layer.mergeAll(seams.layer, unconfigured)};
+};
+
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runPost({...options, ...overrides}), layerFor(script).layer));
 
 const composed = (body = BODY, sha = HEAD): string =>
 	`governance: PASS @ ${sha} content:${CONTENT} — no contradiction, no weakening\n\n${body}`;
 
 const created = (id = 91): ExecResult => okOut(JSON.stringify({id, html_url: URL}));
 
-const governing = (
-	...extra: ReadonlyArray<readonly [RegExp, ExecResult]>
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull()],
+const governing = (...extra: ReadonlyArray<Scripted>): ReadonlyArray<Scripted> => [
+	[PULL, served(pull())],
 	...binding(),
 	[PATHS_AT(), paths(".decisions/0240-x.md", "src/cart.ts")],
-	[VIEWER, okOut("kampus-bot\n")],
-	[COMMENTS, comments()],
+	[VIEWER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+	[COMMENTS, served(comments())],
 	...extra,
 ];
 
 describe("runPost", () => {
 	it("composes the marker, upserts one comment, reads it back, and prints the line", async () => {
 		const out = await run(
-			governing([CREATE, created()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+			governing(
+				[CREATE, {status: 201, body: created().stdout}],
+				[READ_BACK, {status: 200, body: JSON.stringify({body: composed()})}],
+			),
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`posted\tgovernance\tPASS\t${HEAD}\t${CONTENT}\tcreated\t${URL}\n`);
@@ -98,13 +90,13 @@ describe("runPost", () => {
 	// dimension, so only a re-post at the SAME head takes the edit path at all.
 	it("edits the namespace's own comment rather than stacking a second one", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths(".decisions/0240-x.md", "src/cart.ts")],
-			[VIEWER, okOut("kampus-bot\n")],
-			[COMMENTS, comments({id: 77, body: composed("older\n")})],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
-			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
+			[VIEWER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments({id: 77, body: composed("older\n")}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
+			[READ_BACK, {status: 200, body: JSON.stringify({body: composed()})}],
 		]);
 		expect(out.stdout).toContain("\tedited\t");
 	});
@@ -113,29 +105,30 @@ describe("runPost", () => {
 	// it forward, so a re-gate after a repair PATCHed the prior head's verdict away and the record of
 	// what was true over that tree became unrecoverable (#5585).
 	it("leaves a prior head's verdict intact and appends at the new head", async () => {
-		const shell = fakeShell([
-			[PULL, pull()],
+		const {seams, layer} = layerFor([
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths(".decisions/0240-x.md", "src/cart.ts")],
-			[VIEWER, okOut("kampus-bot\n")],
-			[COMMENTS, comments({id: 77, body: composed("the round before the repair\n", OLD_HEAD)})],
-			[CREATE, created()],
-			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
+			[VIEWER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[
+				COMMENTS,
+				served(comments({id: 77, body: composed("the round before the repair\n", OLD_HEAD)})),
+			],
+			[CREATE, {status: 201, body: created().stdout}],
+			[READ_BACK, {status: 200, body: JSON.stringify({body: composed()})}],
 		]);
-		const out = await Effect.runPromise(
-			Effect.provide(
-				runPost(options),
-				Layer.mergeAll(shell.layer, unconfigured, fakeHttp([]).layer),
-			),
-		);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), layer));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tcreated\t");
-		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(seams.requests.some((call) => PATCH.test(call))).toBe(false);
 	});
 
 	it("emits the record with --json, naming the fixed namespace", async () => {
 		const out = await run(
-			governing([CREATE, created()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+			governing(
+				[CREATE, {status: 201, body: created().stdout}],
+				[READ_BACK, {status: 200, body: JSON.stringify({body: composed()})}],
+			),
 			{json: true},
 		);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -147,22 +140,17 @@ describe("runPost", () => {
 	});
 
 	it("refuses on 14 when the diff derives NO governance root, and writes nothing", async () => {
-		const fake = fakeShell([
-			[PULL, pull()],
+		const {seams, layer} = layerFor([
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
 		]);
-		const out = await Effect.runPromise(
-			Effect.provide(
-				runPost(options),
-				Layer.mergeAll(fake.layer, unconfigured, fakeHttp([]).layer),
-			),
-		);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), layer));
 		expect(out.code).toBe(NOT_HARNESS_TOUCHING);
 		expect(out.code).not.toBe(OFF_VOCABULARY);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("a verdict in it would attest a scope nobody derived");
-		expect(fake.calls.some((call) => call.includes("--method POST"))).toBe(false);
+		expect(seams.requests.filter((call) => call.startsWith("POST"))).toEqual([]);
 	});
 
 	it("refuses a stale --sha on 12 before it writes anything", async () => {
@@ -203,12 +191,14 @@ describe("runPost", () => {
 	});
 
 	it("refuses an absent or closed PR on 7", async () => {
-		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
-		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]])).code).toBe(
+			ZERO_SCOPE,
+		);
+		expect((await run([[PULL, served(pull({state: "closed"}))]])).code).toBe(ZERO_SCOPE);
 	});
 
 	it("seats a failed write on 8, never on 1 — the outcome is UNKNOWN", async () => {
-		const out = await run(governing([CREATE, errOut("gh: Gateway timeout (HTTP 504)")]));
+		const out = await run(governing([CREATE, {status: 504, body: "{}"}]));
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.code).not.toBe(1);
 		expect(out.stderr.at(-1)).toContain("UNKNOWN whether the verdict landed");
@@ -216,29 +206,30 @@ describe("runPost", () => {
 
 	it("seats a read-back that does not carry the marker on 9", async () => {
 		const out = await run(
-			governing([CREATE, created()], [READ_BACK, okOut(JSON.stringify({body: "thanks!\n"}))]),
+			governing(
+				[CREATE, {status: 201, body: created().stdout}],
+				[READ_BACK, {status: 200, body: JSON.stringify({body: "thanks!\n"})}],
+			),
 		);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("inspect comment 91");
 	});
 
 	it("seats an unreadable precondition on 11 — nothing was posted", async () => {
-		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[PULL, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was posted");
 	});
 
 	it("re-reads the comment from live state — the write call's own echo is not evidence", async () => {
-		const fake = fakeShell(
-			governing([once(CREATE), created()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
-		);
-		await Effect.runPromise(
-			Effect.provide(
-				runPost(options),
-				Layer.mergeAll(fake.layer, unconfigured, fakeHttp([]).layer),
+		const {seams, layer} = layerFor(
+			governing(
+				[once(CREATE), {status: 201, body: created().stdout}],
+				[READ_BACK, {status: 200, body: JSON.stringify({body: composed()})}],
 			),
 		);
-		expect(fake.calls).toContain("gh api repos/o/r/issues/comments/91");
+		await Effect.runPromise(Effect.provide(runPost(options), layer));
+		expect(seams.requests).toContain("GET https://api.github.com/repos/o/r/issues/comments/91");
 	});
 });
 
@@ -246,68 +237,60 @@ describe("runPost", () => {
 // a head that has no verdict yet and nothing re-fires it. The gate that just wrote the verdict is the
 // actor with no ordering problem — founder ruling, 2026-08-16 (#5585).
 describe("runPost asserts the governance floor at the head it posted to", () => {
-	const landed = (
-		...extra: ReadonlyArray<readonly [RegExp, ExecResult]>
-	): ReadonlyArray<readonly [RegExp, ExecResult]> =>
+	const landed = (...extra: ReadonlyArray<Scripted>): ReadonlyArray<Scripted> =>
 		governing(
-			[CREATE, created()],
-			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
+			[CREATE, {status: 201, body: created().stdout}],
+			[READ_BACK, {status: 200, body: JSON.stringify({body: composed()})}],
 			...extra,
 		);
 
-	/** The run list is still a `gh` read; the run reads and the re-fire went to HTTP (ADR 0315). */
-	const floorListed: readonly [RegExp, ExecResult] = [
+	/** The `{total_count, workflow_runs}` envelope at the head the verdict landed on. */
+	const floorListed: Scripted = [
 		RUNS,
-		runsAtHead(1, [{id: FLOOR, name: "governance-floor"}]),
+		{status: 200, body: runsAtHead(1, [{id: FLOOR, name: "governance-floor"}]).stdout},
 	];
 
-	const floorRed = (): ReadonlyArray<readonly [RegExp, HttpReply]> => [
+	const floorRed = (): ReadonlyArray<Scripted> => [
 		[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 		[RERUN, accepted],
 		[RUN, workflowRun({id: FLOOR, attempt: 2})],
 	];
 
 	it("re-fires the red floor run and names the new attempt on stderr", async () => {
-		const shell = fakeShell(landed(floorListed));
-		const http = fakeHttp(floorRed());
-		const out = await Effect.runPromise(
-			Effect.provide(runPost(options), Layer.mergeAll(shell.layer, unconfigured, http.layer)),
-		);
+		const {seams, layer} = layerFor([...floorRed(), ...landed(floorListed)]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), layer));
 		expect(out.code).toBe(0);
-		expect(http.calls.some((call) => RERUN.test(call))).toBe(true);
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(true);
 		expect(out.stderr.at(-1)).toContain(`re-fired governance-floor run ${FLOOR} at attempt 2`);
 	});
 
 	it("carries the floor's outcome in the --json record", async () => {
-		const out = await run(landed(floorListed), {json: true}, floorRed());
+		const out = await run([...floorRed(), ...landed(floorListed)], {json: true});
 		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "posted", floor: "refired"});
 	});
 
 	// The verdict is landed and read back before the floor is touched, so a floor that could not be
 	// asserted is a red check to clear, never an unwritten verdict to retry.
 	it("still answers 0 when the floor cannot be asserted, and says the check may need a re-fire", async () => {
-		const out = await run(landed([RUNS, errOut("gh: Bad gateway (HTTP 502)")]));
+		const out = await run(landed([RUNS, {status: 502, body: "{}"}]));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tcreated\t");
 		expect(out.stderr.at(-1)).toContain("may still need a re-fire");
 	});
 
-	// The two seams record their own calls, so the order is proven by what a failed read-back
-	// leaves undone rather than by two indices in one list: a verdict that did not read back
-	// re-fires nothing at all.
+	// The order is proven by what a failed read-back leaves undone rather than by two indices in one
+	// list: a verdict that did not read back re-fires nothing at all.
 	it("asserts the floor only after the verdict has been read back", async () => {
-		const shell = fakeShell(
-			governing(
-				[CREATE, created()],
-				[READ_BACK, errOut("gh: Bad gateway (HTTP 502)")],
+		const {seams, layer} = layerFor([
+			...floorRed(),
+			...governing(
+				[CREATE, {status: 201, body: created().stdout}],
+				[READ_BACK, {status: 502, body: "{}"}],
 				floorListed,
 			),
-		);
-		const http = fakeHttp(floorRed());
-		await Effect.runPromise(
-			Effect.provide(runPost(options), Layer.mergeAll(shell.layer, unconfigured, http.layer)),
-		);
-		expect(shell.calls.some((call) => READ_BACK.test(call))).toBe(true);
-		expect(http.calls.some((call) => RERUN.test(call))).toBe(false);
+		]);
+		await Effect.runPromise(Effect.provide(runPost(options), layer));
+		expect(seams.requests.some((call) => READ_BACK.test(call))).toBe(true);
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/governance/readout-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/readout-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {emit, parseFields} from "../wire/governance-digest.ts";
@@ -18,15 +18,24 @@ import {
 import {comments} from "./fixtures.test-support.ts";
 import {ARTIFACT_ENV, runReadout} from "./readout-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4952$/;
-const TITLED = /^gh api --paginate repos\/o\/r\/issues\?state=open/;
-const VIEWER = /^gh api user --jq \.login$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4952\/comments/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4952\/comments/;
-const READ_BACK = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/4952$/;
+const TITLED = /^GET .*\/repos\/o\/r\/issues\?state=open/;
+const VIEWER = /^GET .*\/user$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4952\/comments/;
+const CREATE = /^POST .*\/repos\/o\/r\/issues\/4952\/comments$/;
+const READ_BACK = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
 
 const URL = "https://github.com/o/r/issues/4952#issuecomment-5229900001";
 const ROWS = "row\t0240\ttension\tsits against ADR 0058\nrow\t0238\troutine\tno tension found\n";
+
+/** A fixture's canned JSON, served as the 200 the REST read now parses. */
+const served = (result: ExecResult) => ({status: 200, body: result.stdout});
+
+/** The open-issue list, as the bare JSON array the title lookup filters. */
+const titled = (...rows: ReadonlyArray<{number: number; title: string}>) => ({
+	status: 200,
+	body: JSON.stringify(rows),
+});
 
 const composed = (rows = ROWS): string => {
 	const parsed = parseFields(rows);
@@ -55,55 +64,52 @@ const options = {
 	stdin: Effect.succeed({_tag: "Text", text: ROWS} as StdinRead),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(runReadout({...options, ...overrides}), fakeShell(script).layer),
+		Effect.provide(runReadout({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
-const happy = (
-	...extra: ReadonlyArray<readonly [RegExp, ExecResult]>
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[ISSUE, issue()],
-	[VIEWER, okOut("kampus-bot\n")],
-	[COMMENTS, comments()],
+const happy = (...extra: ReadonlyArray<Scripted>): ReadonlyArray<Scripted> => [
+	[ISSUE, served(issue())],
+	[VIEWER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+	[COMMENTS, served(comments())],
 	...extra,
 ];
 
-const landed = (id = 55): ExecResult => okOut(JSON.stringify({id, html_url: URL}));
+const landed = (id = 55) => ({
+	status: 201,
+	body: JSON.stringify({id, html_url: URL}),
+});
+
+const readBack = (body: string) => ({status: 200, body: JSON.stringify({body})});
 
 describe("runReadout", () => {
 	it("upserts the block and prints the issue, row count and outcome", async () => {
-		const out = await run(
-			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
-		);
+		const out = await run(happy([CREATE, landed()], [READ_BACK, readBack(composed())]));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`readout\t4952\t2\tcreated\t${URL}\n`);
 	});
 
 	it("emits the record with --json", async () => {
-		const out = await run(
-			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
-			{json: true},
-		);
+		const out = await run(happy([CREATE, landed()], [READ_BACK, readBack(composed())]), {
+			json: true,
+		});
 		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "readout", issue: 4952, rows: 2});
 	});
 
 	it("resolves the artifact from the environment when no number is passed", async () => {
-		const out = await run(
-			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
-			{issue: null, env: {CLAUDE_PIPELINE_REPO: "o/r", [ARTIFACT_ENV]: "4952"}},
-		);
+		const out = await run(happy([CREATE, landed()], [READ_BACK, readBack(composed())]), {
+			issue: null,
+			env: {CLAUDE_PIPELINE_REPO: "o/r", [ARTIFACT_ENV]: "4952"},
+		});
 		expect(out.code).toBe(0);
 	});
 
 	it("resolves it from the single open issue with the exact title when the env is unset", async () => {
 		const out = await run(
 			[
-				[TITLED, okOut("4952\tGovernance readout\n")],
-				...happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+				[TITLED, titled({number: 4952, title: "Governance readout"})],
+				...happy([CREATE, landed()], [READ_BACK, readBack(composed())]),
 			],
 			{issue: null},
 		);
@@ -111,7 +117,7 @@ describe("runReadout", () => {
 	});
 
 	it("refuses to GUESS when neither lookup resolves one — 7, naming both", async () => {
-		const out = await run([[TITLED, okOut("")]], {issue: null});
+		const out = await run([[TITLED, titled()]], {issue: null});
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("refusing to guess where the digest lands");
 		expect(out.stderr.at(-1)).toContain(ARTIFACT_ENV);
@@ -119,27 +125,36 @@ describe("runReadout", () => {
 
 	it("refuses when two issues carry the title, rather than picking one", async () => {
 		const out = await run(
-			[[TITLED, okOut("4952\tGovernance readout\n5001\tGovernance readout\n")]],
-			{
-				issue: null,
-			},
+			[
+				[
+					TITLED,
+					titled(
+						{number: 4952, title: "Governance readout"},
+						{
+							number: 5001,
+							title: "Governance readout",
+						},
+					),
+				],
+			],
+			{issue: null},
 		);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 
 	it("refuses an off-vocabulary kind and a non-four-digit id on 10, before touching GitHub", async () => {
-		const fake = fakeShell([]);
+		const seams = fakeSeams([]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runReadout({
 					...options,
 					stdin: Effect.succeed({_tag: "Text", text: "row\t0240\turgent\tnote\n"}),
 				}),
-				fake.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(OFF_VOCABULARY);
-		expect(fake.calls).toEqual([]);
+		expect(seams.requests).toEqual([]);
 		expect(
 			(await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: "row\t240\troutine\tn\n"})}))
 				.code,
@@ -163,21 +178,23 @@ describe("runReadout", () => {
 	});
 
 	it("refuses an absent or closed artifact on 7", async () => {
-		expect((await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
-		expect((await run([[ISSUE, issue("closed")]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[ISSUE, {status: 404, body: '{"message":"Not Found"}'}]])).code).toBe(
+			ZERO_SCOPE,
+		);
+		expect((await run([[ISSUE, served(issue("closed"))]])).code).toBe(ZERO_SCOPE);
 	});
 
 	it("separates an unreadable artifact from an absent one — 11, never 7", async () => {
-		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[ISSUE, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was written");
 	});
 
 	it("refuses a partial comment sweep on 13 — the upsert target would be unknown", async () => {
 		const out = await run([
-			[ISSUE, issue("open", 9)],
-			[VIEWER, okOut("kampus-bot\n")],
-			[COMMENTS, comments()],
+			[ISSUE, served(issue("open", 9))],
+			[VIEWER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stderr.at(-1)).toBe(
@@ -186,10 +203,8 @@ describe("runReadout", () => {
 	});
 
 	it("seats a failed write on 8 and a read-back that lost the rows on 9", async () => {
-		expect((await run(happy([CREATE, errOut("gh: Gateway timeout")]))).code).toBe(WRITE_UNKNOWN);
-		const stale = await run(
-			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: "thanks\n"}))]),
-		);
+		expect((await run(happy([CREATE, {status: 504, body: "{}"}]))).code).toBe(WRITE_UNKNOWN);
+		const stale = await run(happy([CREATE, landed()], [READ_BACK, readBack("thanks\n")]));
 		expect(stale.code).toBe(READBACK_MISMATCH);
 	});
 
@@ -197,18 +212,14 @@ describe("runReadout", () => {
 		const reversed = composed(
 			"row\t0238\troutine\tno tension found\nrow\t0240\ttension\tsits against ADR 0058\n",
 		);
-		const out = await run(
-			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: reversed}))]),
-		);
+		const out = await run(happy([CREATE, landed()], [READ_BACK, readBack(reversed)]));
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("row 1 read back as");
 	});
 
 	it("re-reads from live state — the write call's own echo is not evidence", async () => {
-		const fake = fakeShell(
-			happy([once(CREATE), landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
-		);
-		await Effect.runPromise(Effect.provide(runReadout(options), fake.layer));
-		expect(fake.calls).toContain("gh api repos/o/r/issues/comments/55");
+		const seams = fakeSeams(happy([once(CREATE), landed()], [READ_BACK, readBack(composed())]));
+		await Effect.runPromise(Effect.provide(runReadout(options), seams.layer));
+		expect(seams.requests).toContain("GET https://api.github.com/repos/o/r/issues/comments/55");
 	});
 });

--- a/packages/fabrika-cli/src/governance/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/scope-verb.unit.test.ts
@@ -1,6 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut, unconfigured} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeFs,
+	fakeSeams,
+	okOut,
+	type Scripted,
+	unconfigured,
+} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -32,7 +39,10 @@ import {
 } from "./fixtures.test-support.ts";
 import {NOT_CP_NOTICE, runScope} from "./scope-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+
+/** A fixture's canned JSON, served as the 200 the REST read now parses. */
+const served = (result: ExecResult) => ({status: 200, body: result.stdout});
 
 const options = {
 	pr: 4321 as number | null,
@@ -45,21 +55,16 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runScope({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, unconfigured),
+			Layer.merge(fakeSeams(script).layer, unconfigured),
 		),
 	);
 
-const happy = (
-	...rows: ReadonlyArray<readonly [string, string]>
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull({changedFiles: rows.length})],
+const happy = (...rows: ReadonlyArray<readonly [string, string]>): ReadonlyArray<Scripted> => [
+	[PULL, served(pull({changedFiles: rows.length}))],
 	...binding(),
 	[STATUS_AT(), statuses(...rows)],
 	[TREE_AT(), treeOf(...FULL_TREE)],
@@ -80,7 +85,7 @@ describe("runScope over a foreign repo's declared roots (#6296)", () => {
 			Effect.provide(
 				runScope({...options}),
 				Layer.merge(
-					fakeShell(happy(["M", "src/cart.ts"])).layer,
+					fakeSeams(happy(["M", "src/cart.ts"])).layer,
 					declaring({governedRoots: ["src/", ".fabrika.jsonc"]}).layer,
 				),
 			),
@@ -96,7 +101,7 @@ describe("runScope over a foreign repo's declared roots (#6296)", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runScope({...options}),
-				Layer.merge(fakeShell(GOVERNING).layer, declaring({governedRoots: 7}).layer),
+				Layer.merge(fakeSeams(GOVERNING).layer, declaring({governedRoots: 7}).layer),
 			),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -157,7 +162,7 @@ describe("runScope", () => {
 
 	it("says on stderr, on every run, that this is not the §CP answer", async () => {
 		expect((await run(GOVERNING)).stderr).toContain(NOT_CP_NOTICE);
-		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).stderr).toContain(
+		expect((await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]])).stderr).toContain(
 			NOT_CP_NOTICE,
 		);
 	});
@@ -174,7 +179,7 @@ describe("runScope", () => {
 
 	it("names a root that is absent in this repository rather than counting it silently", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[STATUS_AT(), statuses(["M", ".decisions/0240-x.md"])],
 			[TREE_AT(), treeOf(".decisions/0240-x.md", "src/cart.ts")],
@@ -185,20 +190,20 @@ describe("runScope", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses a closed PR, and a zero-file PR, on 7 — never `not-required`", async () => {
-		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(ZERO_SCOPE);
-		const empty = await run([[PULL, pull({changedFiles: 0})]]);
+		expect((await run([[PULL, served(pull({state: "closed"}))]])).code).toBe(ZERO_SCOPE);
+		const empty = await run([[PULL, served(pull({changedFiles: 0}))]]);
 		expect(empty.code).toBe(ZERO_SCOPE);
 		expect(empty.stderr.at(-2)).toContain("refusing to derive over an empty diff");
 	});
 
 	it("separates an UNREADABLE PR from an absent one — 11, never 7", async () => {
-		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[PULL, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.code).not.toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-2)).toContain('is UNKNOWN, never "not-required"');
@@ -206,7 +211,7 @@ describe("runScope", () => {
 
 	it("phrases the binding failure in this verb's own noun", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -217,7 +222,7 @@ describe("runScope", () => {
 
 	it("refuses a short changed-file read on 13, distinct from 11 and 7", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 9})],
+			[PULL, served(pull({changedFiles: 9}))],
 			...binding(),
 			[STATUS_AT(), statuses(["M", "src/cart.ts"])],
 		]);
@@ -242,9 +247,7 @@ describe("runScope", () => {
 
 const ranged = {pr: null, base: RANGE_BASE, tip: RANGE_TIP};
 
-const overRange = (
-	...rows: ReadonlyArray<StatusRow>
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const overRange = (...rows: ReadonlyArray<StatusRow>): ReadonlyArray<Scripted> => [
 	[MERGE_BASE_OF(), okOut(`${RANGE_MERGE_BASE}\n`)],
 	[STATUS_AT(RANGE_BASE, RANGE_TIP), statuses(...rows)],
 	// `--name-only` gives a rename its destination alone, which is a record's last field either way.
@@ -406,11 +409,11 @@ describe("runScope over a range", () => {
 	});
 
 	it("reads only the object database — no PR is resolved and nothing is checked out", async () => {
-		const fake = fakeShell(overRange(["M", "src/cart.ts"]));
+		const fake = fakeSeams(overRange(["M", "src/cart.ts"]));
 		await Effect.runPromise(
 			Effect.provide(runScope({...options, ...ranged}), Layer.merge(fake.layer, unconfigured)),
 		);
-		expect(fake.calls.some((call) => call.startsWith("gh "))).toBe(false);
+		expect(fake.requests).toEqual([]);
 		expect(fake.calls.some((call) => call.startsWith("git checkout"))).toBe(false);
 		expect(fake.calls).toContain(`git merge-base ${RANGE_BASE} ${RANGE_TIP}`);
 	});

--- a/packages/fabrika-cli/src/governance/sweep-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/sweep-verb.unit.test.ts
@@ -1,12 +1,15 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut, record} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, okOut, record, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {binding, HEAD, pull, SHOW_AT, STATUS_AT, statuses} from "./fixtures.test-support.ts";
 import {runSweep} from "./sweep-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+
+/** A fixture's canned JSON, served as the 200 the REST read now parses. */
+const served = (result: ExecResult) => ({status: 200, body: result.stdout});
 const DIR = ".decisions";
 const SUBJECT_PATH = ".decisions/0240-only-landed-adrs-may-be-cited.md";
 
@@ -38,14 +41,14 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	fs = fakeFs({dirs: {[DIR]: names}, files: corpusFiles()}),
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runSweep({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fs.layer),
+			Layer.merge(fakeSeams(script).layer, fs.layer),
 		),
 	);
 
@@ -118,8 +121,8 @@ describe("runSweep in --landed mode", () => {
 });
 
 describe("runSweep in --record mode", () => {
-	const scripted: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 1})],
+	const scripted: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 1}))],
 		...binding(),
 		[STATUS_AT(), statuses(["A", SUBJECT_PATH])],
 		[
@@ -136,7 +139,11 @@ describe("runSweep in --record mode", () => {
 
 	it("refuses when the bound commit carries no such record on 11", async () => {
 		const out = await run(
-			[[PULL, pull({changedFiles: 1})], ...binding(), [STATUS_AT(), statuses(["M", "src/a.ts"])]],
+			[
+				[PULL, served(pull({changedFiles: 1}))],
+				...binding(),
+				[STATUS_AT(), statuses(["M", "src/a.ts"])],
+			],
 			{pr: 4321, record: "0240"},
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -145,7 +152,11 @@ describe("runSweep in --record mode", () => {
 
 	it("refuses a short changed-file read on 13", async () => {
 		const out = await run(
-			[[PULL, pull({changedFiles: 9})], ...binding(), [STATUS_AT(), statuses(["A", SUBJECT_PATH])]],
+			[
+				[PULL, served(pull({changedFiles: 9}))],
+				...binding(),
+				[STATUS_AT(), statuses(["A", SUBJECT_PATH])],
+			],
 			{pr: 4321, record: "0240"},
 		);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
@@ -153,7 +164,10 @@ describe("runSweep in --record mode", () => {
 	});
 
 	it("refuses an absent PR on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]], {pr: 4321, record: "0240"});
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]], {
+			pr: 4321,
+			record: "0240",
+		});
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 });

--- a/packages/fabrika-cli/src/graduate/emit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/emit-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import * as graduateEmitted from "../wire/graduate-emitted.ts";
 import {markerTime} from "../wire/grill-marker.ts";
 import {
@@ -27,13 +26,19 @@ import {
 import {renderFooter, withFooter} from "./spec.ts";
 import {digestOfDecisions} from "./trail.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
 const PERMISSION = /collaborators\/.*\/permission/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels\?/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues /;
-const CREATED_ISSUE = /^gh api repos\/o\/r\/issues\/9520$/;
-const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/9412\/comments/;
+const LABELS = /^GET .*\/repos\/o\/r\/labels\?/;
+const CREATE = /^POST .*\/repos\/o\/r\/issues$/;
+const CREATED_ISSUE = /^GET .*\/repos\/o\/r\/issues\/9520$/;
+const COMMENT = /^POST .*\/repos\/o\/r\/issues\/9412\/comments$/;
+
+/** A served 200 — every read below asks for JSON and gets a whole single page. */
+const served = (body: string): HttpReply => ({status: 200, body});
+
+/** A served 201 — what a create answers. */
+const created = (body: string): HttpReply => ({status: 201, body});
 
 const NOW = new Date("2026-08-09T18:36:48.000Z");
 const AT = markerTime("2026-08-09T18:36:48Z");
@@ -48,11 +53,11 @@ const LANDED = withFooter(
 const TITLE = "Cap moderation weight per topic";
 
 const emit = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	spec: DocumentRead = {_tag: "Text", text: SPEC},
 	title = TITLE,
 ) => {
-	const shell = fakeShell(script);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
 		Effect.provide(
 			runEmit({
@@ -64,27 +69,37 @@ const emit = (
 				env: {CLAUDE_PIPELINE_REPO: REPO},
 				now: () => NOW,
 			}),
-			shell.layer,
+			seams.layer,
 		),
-	).then((outcome) => ({outcome, shell}));
+	).then((outcome) => ({outcome, seams}));
 };
 
-const healthy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
-	[COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
-	[PERMISSION, okOut("write")],
-	[LABELS, okOut(`${INTAKE_LABEL}\ntype:feature\np1`)],
-	[CREATE, okOut(JSON.stringify({number: 9520, html_url: "https://example.test/issues/9520"}))],
+/** The JSON body of the first request matching `pattern`; `""` when none was issued. */
+const bodyOf = (seams: ReturnType<typeof fakeSeams>, pattern: RegExp): string =>
+	seams.bodies[seams.requests.findIndex((line) => pattern.test(line))] ?? "";
+
+const labelSet = (...names: ReadonlyArray<string>): HttpReply =>
+	served(JSON.stringify(names.map((name) => ({name}))));
+
+const healthy = (): ReadonlyArray<Scripted> => [
+	[ISSUE, served(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+	[COMMENTS, served(commentsPayload([...CLEARED_SESSION]))],
+	[PERMISSION, served(JSON.stringify({permission: "write"}))],
+	[LABELS, labelSet(INTAKE_LABEL, "type:feature", "p1")],
+	[CREATE, created(JSON.stringify({number: 9520, html_url: "https://example.test/issues/9520"}))],
 	[
 		CREATED_ISSUE,
-		okOut(issueJson({number: 9520, title: TITLE, body: LANDED, labels: [INTAKE_LABEL]})),
+		served(issueJson({number: 9520, title: TITLE, body: LANDED, labels: [INTAKE_LABEL]})),
 	],
-	[COMMENT, okOut(JSON.stringify({id: 5234567892, html_url: "https://example.test/c/5234567892"}))],
+	[
+		COMMENT,
+		created(JSON.stringify({id: 5234567892, html_url: "https://example.test/c/5234567892"})),
+	],
 ];
 
 describe("the whole transaction", () => {
 	it("files one issue at status:needs-triage, reads it back, then posts the marker", async () => {
-		const {outcome, shell} = await emit(healthy());
+		const {outcome, seams} = await emit(healthy());
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toEqual({
 			source: SESSION,
@@ -94,23 +109,20 @@ describe("the whole transaction", () => {
 			labels: [INTAKE_LABEL],
 			marker: 5234567892,
 		});
-		const created = shell.calls.findIndex((line) => CREATE.test(line));
-		const marker = shell.calls.findIndex((line) => COMMENT.test(line));
-		expect(created).toBeGreaterThanOrEqual(0);
-		expect(marker).toBeGreaterThan(created);
+		const filed = seams.requests.findIndex((line) => CREATE.test(line));
+		const marker = seams.requests.findIndex((line) => COMMENT.test(line));
+		expect(filed).toBeGreaterThanOrEqual(0);
+		expect(marker).toBeGreaterThan(filed);
 	});
 
 	it("applies exactly one label and no classification of its own", async () => {
-		const {shell} = await emit(healthy());
-		const create = shell.calls.find((line) => CREATE.test(line)) ?? "";
-		expect(create).toContain(`labels[]=${INTAKE_LABEL}`);
-		expect(create).not.toContain("type:");
-		expect(create).not.toContain("p1");
+		const {seams} = await emit(healthy());
+		expect(JSON.parse(bodyOf(seams, CREATE)).labels).toEqual([INTAKE_LABEL]);
 	});
 
 	it("posts a marker binding the spec digest and every covered ref", async () => {
-		const {shell} = await emit(healthy());
-		const posted = shell.calls.find((line) => COMMENT.test(line)) ?? "";
+		const {seams} = await emit(healthy());
+		const posted = JSON.parse(bodyOf(seams, COMMENT)).body as string;
 		expect(posted).toContain(`graduate-emitted: #${SESSION} → #9520 @ ${SPEC_DIGEST}`);
 		expect(posted).toContain("covers R1.1;R1.2");
 		expect(graduateEmitted.read(posted.slice(posted.indexOf("graduate-emitted:")))._tag).toBe(
@@ -119,8 +131,8 @@ describe("the whole transaction", () => {
 	});
 
 	it("appends the footer BEFORE the leak scan, so its own bytes are scanned too", async () => {
-		const {shell} = await emit(healthy());
-		const create = shell.calls.find((line) => CREATE.test(line)) ?? "";
+		const {seams} = await emit(healthy());
+		const create = bodyOf(seams, CREATE);
 		expect(create).toContain(`spec ${SPEC_DIGEST}`);
 		expect(create).toContain("Filed by an agent");
 	});
@@ -161,7 +173,7 @@ describe("the digest is re-derived, never trusted from --spec", () => {
 				...healthy().filter(([pattern]) => pattern !== CREATED_ISSUE),
 				[
 					CREATED_ISSUE,
-					okOut(issueJson({number: 9520, title: TITLE, body: landed, labels: [INTAKE_LABEL]})),
+					served(issueJson({number: 9520, title: TITLE, body: landed, labels: [INTAKE_LABEL]})),
 				],
 			],
 			{_tag: "Text", text: specFor(subset)},
@@ -180,13 +192,15 @@ describe("the digest is re-derived, never trusted from --spec", () => {
 			at: AT,
 		});
 		const {outcome} = await emit([
-			[ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
-			[once(COMMENTS), okOut(commentsPayload([...CLEARED_SESSION]))],
+			[ISSUE, served(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+			[once(COMMENTS), served(commentsPayload([...CLEARED_SESSION]))],
 			[
 				COMMENTS,
-				okOut(commentsPayload([...CLEARED_SESSION, {id: 7, author: "acme-founder", body: marker}])),
+				served(
+					commentsPayload([...CLEARED_SESSION, {id: 7, author: "acme-founder", body: marker}]),
+				),
 			],
-			[PERMISSION, okOut("write")],
+			[PERMISSION, served(JSON.stringify({permission: "write"}))],
 		]);
 		expect(outcome.code).toBe(ALREADY_GRADUATED);
 		expect(outcome.stderr.join("\n")).toContain("#9520");
@@ -196,9 +210,9 @@ describe("the digest is re-derived, never trusted from --spec", () => {
 
 describe("the refusals that write nothing", () => {
 	it("refuses a spec missing a section", async () => {
-		const {outcome, shell} = await emit(healthy(), {_tag: "Text", text: "## Problem\nx\n"});
+		const {outcome, seams} = await emit(healthy(), {_tag: "Text", text: "## Problem\nx\n"});
 		expect(outcome.code).toBe(BAD_SECTIONS);
-		expect(shell.calls).toEqual([]);
+		expect(seams.log).toEqual([]);
 	});
 
 	it("refuses a hand-edited decisions line rather than skipping it", async () => {
@@ -213,7 +227,7 @@ describe("the refusals that write nothing", () => {
 	it("refuses a repo with no status:needs-triage label", async () => {
 		const {outcome} = await emit([
 			...healthy().filter(([pattern]) => pattern !== LABELS),
-			[LABELS, okOut("type:feature\np1")],
+			[LABELS, labelSet("type:feature", "p1")],
 		]);
 		expect(outcome.code).toBe(NO_TARGET);
 		expect(outcome.stderr.join("\n")).toContain("no triage run can find");
@@ -230,7 +244,7 @@ describe("a write whose outcome is unproven", () => {
 	it("seats a failed create on 8, naming the repo to check", async () => {
 		const {outcome} = await emit([
 			...healthy().filter(([pattern]) => pattern !== CREATE),
-			[CREATE, errOut("gh: Bad gateway (HTTP 502)")],
+			[CREATE, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stdout).toBe("");
@@ -239,22 +253,22 @@ describe("a write whose outcome is unproven", () => {
 	it("seats a failed marker write on 8, naming the ORPHANED spec a re-run would duplicate", async () => {
 		const {outcome} = await emit([
 			...healthy().filter(([pattern]) => pattern !== COMMENT),
-			[COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+			[COMMENT, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("the spec EXISTS but #9412 does not record it");
 	});
 
 	it("seats a read-back that does not match on 9, before any marker is written", async () => {
-		const {outcome, shell} = await emit([
+		const {outcome, seams} = await emit([
 			...healthy().filter(([pattern]) => pattern !== CREATED_ISSUE),
 			[
 				CREATED_ISSUE,
-				okOut(issueJson({number: 9520, title: TITLE, body: LANDED, labels: [INTAKE_LABEL, "p1"]})),
+				served(issueJson({number: 9520, title: TITLE, body: LANDED, labels: [INTAKE_LABEL, "p1"]})),
 			],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
-		expect(shell.calls.some((line) => COMMENT.test(line))).toBe(false);
+		expect(seams.requests.some((line) => COMMENT.test(line))).toBe(false);
 	});
 });
 

--- a/packages/fabrika-cli/src/graduate/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/read-verb.unit.test.ts
@@ -1,15 +1,17 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import * as graduateEmitted from "../wire/graduate-emitted.ts";
 import {markerTime} from "../wire/grill-marker.ts";
 import {NO_TARGET, PRECONDITION_UNKNOWN, SOURCE_UNRECOGNIZED} from "./codes.ts";
 import {commentsPayload, issueJson, REPO, SESSION} from "./fixtures.test-support.ts";
 import {runRead} from "./read-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
+
+/** A served 200 — every read below asks for JSON and gets a whole single page. */
+const served = (body: string): HttpReply => ({status: 200, body});
 
 const AT = markerTime("2026-08-09T18:36:48Z");
 if (AT === null) throw new Error("the fixture stamp did not build");
@@ -27,19 +29,19 @@ const marker = (digest: string, emitted: number, covers: [string, ...string[]]):
 		at: AT,
 	});
 
-const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+const run = (script: ReadonlyArray<Scripted>) =>
 	Effect.runPromise(
 		Effect.provide(
 			runRead({source: SESSION, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}}),
-			fakeShell(script).layer,
+			fakeSeams(script).layer,
 		),
 	);
 
-const source = [ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))] as const;
+const source = [ISSUE, served(issueJson({number: SESSION, labels: ["grilling:session"]}))] as const;
 
 describe("the read is total and three-valued", () => {
 	it("reads a source with no comments as ungraduated — zero comments is a FACT", async () => {
-		const out = await run([source, [COMMENTS, okOut("[]")]]);
+		const out = await run([source, [COMMENTS, served("[]")]]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
 			source: SESSION,
@@ -55,7 +57,7 @@ describe("the read is total and three-valued", () => {
 			source,
 			[
 				COMMENTS,
-				okOut(
+				served(
 					commentsPayload([
 						{id: 5, author: "acme-founder", body: marker("a1b2c3d4e5f6", 9520, ["R1.1", "R1.2"])},
 						{id: 6, author: "acme-founder", body: marker("0123456789ab", 9530, ["#9301 R1.4"])},
@@ -89,7 +91,7 @@ describe("the read is total and three-valued", () => {
 			source,
 			[
 				COMMENTS,
-				okOut(
+				served(
 					commentsPayload([
 						{
 							id: 9,
@@ -111,7 +113,7 @@ describe("the read is total and three-valued", () => {
 			source,
 			[
 				COMMENTS,
-				okOut(commentsPayload([{id: 3, author: "acme-founder", body: "picking this up"}])),
+				served(commentsPayload([{id: 3, author: "acme-founder", body: "picking this up"}])),
 			],
 		]);
 		expect(JSON.parse(out.stdout).disregarded).toEqual([]);
@@ -120,13 +122,13 @@ describe("the read is total and three-valued", () => {
 
 describe("its only three refusals", () => {
 	it("refuses a source that does not exist", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(NO_TARGET);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses a source carrying neither label, in this verb's own words", async () => {
-		const out = await run([[ISSUE, okOut(issueJson({number: SESSION, labels: []}))]]);
+		const out = await run([[ISSUE, served(issueJson({number: SESSION, labels: []}))]]);
 		expect(out.code).toBe(SOURCE_UNRECOGNIZED);
 		expect(out.stderr.join("\n")).toContain(
 			`graduate read: #${SESSION} carries neither grilling:session nor wayfinding:map.`,
@@ -134,7 +136,7 @@ describe("its only three refusals", () => {
 	});
 
 	it('refuses a comment read that could not complete — never "no"', async () => {
-		const out = await run([source, [COMMENTS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([source, [COMMENTS, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain('UNKNOWN, never "no"');

--- a/packages/fabrika-cli/src/graduate/trail-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/trail-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {BAD_SECTIONS, NO_TARGET, PRECONDITION_UNKNOWN, SOURCE_UNRECOGNIZED} from "./codes.ts";
 import {
 	CLEARED_DECISIONS,
@@ -17,33 +16,36 @@ import {
 import {digestOfDecisions} from "./trail.ts";
 import {runTrail} from "./trail-verb.ts";
 
-const SESSION_ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const SESSION_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
+const SESSION_ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const SESSION_COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
 const PERMISSION = /collaborators\/.*\/permission/;
-const MAP_ISSUE = /^gh api repos\/o\/r\/issues\/9140$/;
+const MAP_ISSUE = /^GET .*\/repos\/o\/r\/issues\/9140$/;
 const CHILDREN = /issues\/9140\/sub_issues/;
-const TICKET_ISSUE = /issues\/9142$/;
+const TICKET_ISSUE = /^GET .*\/issues\/9142$/;
 const TICKET_COMMENTS = /issues\/9142\/comments/;
 const BLOCKED_BY = /issues\/9142\/dependencies\/blocked_by/;
 const BLOCKING = /issues\/9142\/dependencies\/blocking/;
 
-const run = (source: number, script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+/** A served 200 — every read below asks for JSON and gets a whole single page. */
+const served = (body: string): HttpReply => ({status: 200, body});
+
+const run = (source: number, script: ReadonlyArray<Scripted>) =>
 	Effect.runPromise(
 		Effect.provide(
 			runTrail({source, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}}),
-			fakeShell(script).layer,
+			fakeSeams(script).layer,
 		),
 	);
 
 const session = (labels: ReadonlyArray<string> = ["grilling:session"]) =>
-	[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels}))] as const;
+	[SESSION_ISSUE, served(issueJson({number: SESSION, labels}))] as const;
 
 describe("a grilling source resolves through the grill reader", () => {
 	it("answers `ready` at exit 0 with both provenance words and the trail digest", async () => {
 		const out = await run(SESSION, [
 			session(),
-			[SESSION_COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
-			[PERMISSION, okOut("write")],
+			[SESSION_COMMENTS, served(commentsPayload([...CLEARED_SESSION]))],
+			[PERMISSION, served(JSON.stringify({permission: "write"}))],
 		]);
 		expect(out.code).toBe(0);
 		const answer = JSON.parse(out.stdout);
@@ -61,8 +63,8 @@ describe("a grilling source resolves through the grill reader", () => {
 	it("answers `blocked` at exit 0, carrying the resolver's own state word", async () => {
 		const out = await run(SESSION, [
 			session(),
-			[SESSION_COMMENTS, okOut(commentsPayload([ROUND]))],
-			[PERMISSION, okOut("write")],
+			[SESSION_COMMENTS, served(commentsPayload([ROUND]))],
+			[PERMISSION, served(JSON.stringify({permission: "write"}))],
 		]);
 		expect(out.code).toBe(0);
 		const answer = JSON.parse(out.stdout);
@@ -74,7 +76,7 @@ describe("a grilling source resolves through the grill reader", () => {
 	});
 
 	it("answers `empty` at exit 0 on a session with nothing on it — zero decisions is a fact", async () => {
-		const out = await run(SESSION, [session(), [SESSION_COMMENTS, okOut("[]")]]);
+		const out = await run(SESSION, [session(), [SESSION_COMMENTS, served("[]")]]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({readiness: "empty", decisions: [], counts: {}});
 	});
@@ -86,8 +88,8 @@ describe("the digest is neutral to every write this group makes", () => {
 			(
 				await run(SESSION, [
 					session(),
-					[SESSION_COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
-					[PERMISSION, okOut("write")],
+					[SESSION_COMMENTS, served(commentsPayload([...CLEARED_SESSION]))],
+					[PERMISSION, served(JSON.stringify({permission: "write"}))],
 				])
 			).stdout,
 		);
@@ -97,7 +99,7 @@ describe("the digest is neutral to every write this group makes", () => {
 					session(),
 					[
 						SESSION_COMMENTS,
-						okOut(
+						served(
 							commentsPayload([
 								...CLEARED_SESSION,
 								{
@@ -108,7 +110,7 @@ describe("the digest is neutral to every write this group makes", () => {
 							]),
 						),
 					],
-					[PERMISSION, okOut("write")],
+					[PERMISSION, served(JSON.stringify({permission: "write"}))],
 				])
 			).stdout,
 		);
@@ -119,18 +121,18 @@ describe("the digest is neutral to every write this group makes", () => {
 
 describe("a map source resolves through the map module, not through `map read`'s stdout", () => {
 	const mapHealthy = [
-		[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
-		[CHILDREN, okOut('[{"number":9142}]')],
-		[TICKET_ISSUE, okOut(issueJson({number: 9142, body: "which table carries it?"}))],
+		[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+		[CHILDREN, served('[{"number":9142}]')],
+		[TICKET_ISSUE, served(issueJson({number: 9142, body: "which table carries it?"}))],
 		[
 			TICKET_COMMENTS,
-			okOut(
+			served(
 				'[{"id":1,"body":"map-ticket: #9140 · research · 7f3a9c21","user":{"login":"acme-founder"},"created_at":"2026-08-10T00:00:00Z","updated_at":"2026-08-10T00:00:00Z"}]',
 			),
 		],
-		[BLOCKED_BY, okOut("[]")],
-		[BLOCKING, okOut("[]")],
-		[PERMISSION, okOut("write")],
+		[BLOCKED_BY, served("[]")],
+		[BLOCKING, served("[]")],
+		[PERMISSION, served(JSON.stringify({permission: "write"}))],
 	] as const;
 
 	it("takes its decisions from the body's `## Decisions` section, with the citations as refs", async () => {
@@ -173,7 +175,7 @@ describe("a map source resolves through the map module, not through `map read`'s
 		const out = await run(MAP, [
 			[
 				MAP_ISSUE,
-				okOut(issueJson({number: MAP, body: "## Fog\nnothing", labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: "## Fog\nnothing", labels: ["wayfinding:map"]})),
 			],
 		]);
 		expect(out.code).toBe(BAD_SECTIONS);
@@ -195,7 +197,9 @@ describe("the dispatch refuses rather than guesses", () => {
 	});
 
 	it("refuses a source that does not exist", async () => {
-		const out = await run(SESSION, [[SESSION_ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run(SESSION, [
+			[SESSION_ISSUE, {status: 404, body: '{"message":"Not Found"}'}],
+		]);
 		expect(out.code).toBe(NO_TARGET);
 		expect(out.stdout).toBe("");
 	});
@@ -203,10 +207,7 @@ describe("the dispatch refuses rather than guesses", () => {
 
 describe("a read that could not complete is UNKNOWN, never an empty trail", () => {
 	it("seats a failed comment read on 11 with nothing on stdout", async () => {
-		const out = await run(SESSION, [
-			session(),
-			[SESSION_COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
-		]);
+		const out = await run(SESSION, [session(), [SESSION_COMMENTS, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("never empty and never ready");
@@ -215,8 +216,8 @@ describe("a read that could not complete is UNKNOWN, never an empty trail", () =
 	it("seats a failed ACL read on 11, saying a ruling's authority is never granted by it", async () => {
 		const out = await run(SESSION, [
 			session(),
-			[SESSION_COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+			[SESSION_COMMENTS, served(commentsPayload([...CLEARED_SESSION]))],
+			[PERMISSION, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.join("\n")).toContain("UNKNOWN, never granted");

--- a/packages/fabrika-cli/src/grill/answer-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/grill/answer-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {type DocumentRead, runAnswer} from "./answer-verb.ts";
 import {
 	BAD_SECTIONS,
@@ -24,11 +23,16 @@ import {
 	supersedeComment,
 } from "./fixtures.test-support.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/[a-z-]+\/permission/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/9412\/comments -f/;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
+const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/[a-z-]+\/permission$/;
+const POST = /^POST .*\/repos\/o\/r\/issues\/9412\/comments$/;
+const READBACK = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+
+const served = (body: string, status = 200): HttpReply => ({status, body});
+const granted = (permission: string): HttpReply => served(JSON.stringify({permission}));
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 const FINDING = "The vote table carries no weight column; the schema is in the vote feature.\n";
 const BOUND = roundDigestOf(1);
@@ -44,38 +48,36 @@ const options = {
 	now: () => new Date("2026-08-09T18:36:48.000Z"),
 };
 
-const posted = okOut(
+const posted = served(
 	JSON.stringify({id: 5234567891, html_url: "https://example.test/issues/9412#c"}),
+	201,
 );
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runAnswer({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runAnswer({...options, ...overrides}), fakeSeams(script).layer));
 
 /** Run once to learn the body the verb composes, then replay with a read-back that echoes it. */
 const runEchoing = async (
 	comments: string,
 	overrides: Partial<typeof options> = {},
 ): Promise<{code: number; stdout: string; stderr: ReadonlyArray<string>; body: string}> => {
-	const probe = fakeShell([
-		[ISSUE, okOut(sessionPayload(9412))],
-		[COMMENTS, okOut(comments)],
-		[PERMISSION, okOut("write")],
+	const probe = fakeSeams([
+		[ISSUE, served(sessionPayload(9412))],
+		[COMMENTS, served(comments)],
+		[PERMISSION, granted("write")],
 		[POST, posted],
-		[READBACK, okOut(JSON.stringify({body: "not what was sent"}))],
+		[READBACK, served(JSON.stringify({body: "not what was sent"}))],
 	]);
 	await Effect.runPromise(Effect.provide(runAnswer({...options, ...overrides}), probe.layer));
-	const call = probe.calls.find((line) => POST.test(line)) ?? "";
-	const body = call.slice(call.indexOf("-f body=") + "-f body=".length);
+	const at = probe.requests.findIndex((request) => POST.test(request));
+	const body = at === -1 ? "" : String(JSON.parse(probe.bodies[at] ?? "{}").body ?? "");
 	const out = await run(
 		[
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, okOut(comments)],
-			[PERMISSION, okOut("write")],
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, served(comments)],
+			[PERMISSION, granted("write")],
 			[POST, posted],
-			[READBACK, okOut(JSON.stringify({body}))],
+			[READBACK, served(JSON.stringify({body}))],
 		],
 		overrides,
 	);
@@ -103,8 +105,8 @@ describe("runAnswer refuses on the kind guard, and it is the guard that fires", 
 	it("refuses a decision question, pointing at grill rule", async () => {
 		const out = await run(
 			[
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, okOut(ROUND_ONE)],
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, served(ROUND_ONE)],
 			],
 			{question: "R1.2"},
 		);
@@ -124,9 +126,9 @@ describe("runAnswer refuses on the kind guard, and it is the guard that fires", 
 		]);
 		const out = await run(
 			[
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, okOut(comments)],
-				[PERMISSION, okOut("write")],
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, served(comments)],
+				[PERMISSION, granted("write")],
 			],
 			{question: "R1.2"},
 		);
@@ -135,14 +137,14 @@ describe("runAnswer refuses on the kind guard, and it is the guard that fires", 
 });
 
 describe("runAnswer seats each refusal on its own code, with nothing on stdout", () => {
-	const base: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[ISSUE, okOut(sessionPayload(9412))],
-		[COMMENTS, okOut(ROUND_ONE)],
-		[PERMISSION, okOut("write")],
+	const base: ReadonlyArray<Scripted> = [
+		[ISSUE, served(sessionPayload(9412))],
+		[COMMENTS, served(ROUND_ONE)],
+		[PERMISSION, granted("write")],
 	];
 
 	const cases: ReadonlyArray<
-		readonly [string, number, ReadonlyArray<readonly [RegExp, ExecResult]>, Partial<typeof options>]
+		readonly [string, number, ReadonlyArray<Scripted>, Partial<typeof options>]
 	> = [
 		[
 			"an empty finding",
@@ -162,13 +164,13 @@ describe("runAnswer seats each refusal on its own code, with nothing on stdout",
 			base,
 			{finding: Effect.succeed<DocumentRead>({_tag: "Text", text: "@/Users/someone/finding.md"})},
 		],
-		["an absent session", NO_TARGET, [[ISSUE, errOut("gh: Not Found (HTTP 404)")]], {}],
+		["an absent session", NO_TARGET, [[ISSUE, NOT_FOUND]], {}],
 		[
 			"a comment read that could not complete",
 			PRECONDITION_UNKNOWN,
 			[
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, GATEWAY],
 			],
 			{},
 		],
@@ -178,9 +180,9 @@ describe("runAnswer seats each refusal on its own code, with nothing on stdout",
 			"a write that failed",
 			WRITE_UNKNOWN,
 			[
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, okOut(ROUND_ONE)],
-				[POST, errOut("gh: Bad gateway (HTTP 502)")],
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, served(ROUND_ONE)],
+				[POST, GATEWAY],
 			],
 			{},
 		],
@@ -188,10 +190,10 @@ describe("runAnswer seats each refusal on its own code, with nothing on stdout",
 			"a read-back that differs",
 			READBACK_MISMATCH,
 			[
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, okOut(ROUND_ONE)],
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, served(ROUND_ONE)],
 				[POST, posted],
-				[READBACK, okOut(JSON.stringify({body: "something else"}))],
+				[READBACK, served(JSON.stringify({body: "something else"}))],
 			],
 			{},
 		],
@@ -199,10 +201,10 @@ describe("runAnswer seats each refusal on its own code, with nothing on stdout",
 			"a round whose block is missing the field the digest covers",
 			DIGEST_UNBINDABLE,
 			[
-				[ISSUE, okOut(sessionPayload(9412))],
+				[ISSUE, served(sessionPayload(9412))],
 				[
 					COMMENTS,
-					okOut(
+					served(
 						commentsPayload([
 							{
 								id: 1,
@@ -229,9 +231,9 @@ describe("runAnswer seats each refusal on its own code, with nothing on stdout",
 
 	it("writes nothing on any refusal", async () => {
 		for (const [, , script, overrides] of cases) {
-			const shell = fakeShell(script);
-			await Effect.runPromise(Effect.provide(runAnswer({...options, ...overrides}), shell.layer));
-			const posts = shell.calls.filter((call) => POST.test(call));
+			const seams = fakeSeams(script);
+			await Effect.runPromise(Effect.provide(runAnswer({...options, ...overrides}), seams.layer));
+			const posts = seams.requests.filter((request) => POST.test(request));
 			// The write-failure and read-back cases attempt exactly one write by construction.
 			expect(posts.length).toBeLessThanOrEqual(1);
 		}

--- a/packages/fabrika-cli/src/grill/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/grill/fixtures.test-support.ts
@@ -89,7 +89,7 @@ export interface FakeComment {
 	readonly body: string;
 }
 
-/** The `gh api --paginate .../comments` payload for a comment list. */
+/** The paged `.../issues/<n>/comments` payload for a comment list. */
 export const commentsPayload = (comments: ReadonlyArray<FakeComment>): string =>
 	JSON.stringify(
 		comments.map((comment) => ({
@@ -101,7 +101,7 @@ export const commentsPayload = (comments: ReadonlyArray<FakeComment>): string =>
 		})),
 	);
 
-/** The `gh api repos/<repo>/issues/<n>` payload for a labelled session issue. */
+/** The `repos/<repo>/issues/<n>` payload for a labelled session issue. */
 export const sessionPayload = (
 	session: number,
 	options: {

--- a/packages/fabrika-cli/src/grill/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/grill/open-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {cameFromSection} from "../wire/came-from.ts";
 import {
 	BARE_AT_PATH,
@@ -16,11 +15,15 @@ import {
 import {sessionPayload} from "./fixtures.test-support.ts";
 import {type OpenSubject, openSubject, runOpen} from "./open-verb.ts";
 
-const LABELS = /^gh api --paginate repos\/o\/r\/labels\?/;
-const SEARCH = /^gh api --paginate repos\/o\/r\/issues\?state=open&labels=/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/\d+$/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues -f title=/;
-const LABEL_WRITE = /^gh api --method POST repos\/o\/r\/issues\/\d+\/labels/;
+const LABELS = /^GET .*\/repos\/o\/r\/labels\?/;
+const SEARCH = /^GET .*\/repos\/o\/r\/issues\?state=open&labels=/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/\d+$/;
+const CREATE = /^POST .*\/repos\/o\/r\/issues$/;
+const LABEL_WRITE = /^POST .*\/repos\/o\/r\/issues\/\d+\/labels$/;
+
+const served = (body: string, status = 200): HttpReply => ({status, body});
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 const TOPIC = "sozluk moderation model";
 
@@ -38,14 +41,27 @@ const subjectOf = (topic: string | null, ticket: number | null): OpenSubject => 
 
 const onTopic = {...options, subject: subjectOf(TOPIC, null)};
 
-const created = okOut(JSON.stringify({number: 9412, html_url: "https://example.test/issues/9412"}));
+const created = served(
+	JSON.stringify({number: 9412, html_url: "https://example.test/issues/9412"}),
+	201,
+);
 
-/** One row of the search's `{number, title, body} | @json` output — the bytes the verb parses. */
-const row = (number: number, title: string, body = ""): string =>
-	JSON.stringify({number, title, body});
+/** One entry of the label-scoped issue list — the payload the verb parses. */
+const row = (number: number, title: string, body = ""): Record<string, unknown> => ({
+	number,
+	title,
+	body,
+});
+
+/** The list read's served page. */
+const listing = (...rows: ReadonlyArray<Record<string, unknown>>): HttpReply =>
+	served(JSON.stringify(rows));
+
+const labelled = (...names: ReadonlyArray<string>): HttpReply =>
+	served(JSON.stringify(names.map((name) => ({name}))));
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: {readonly topic?: string | null; readonly ticket?: number | null} = {},
 ) =>
 	Effect.runPromise(
@@ -57,19 +73,19 @@ const run = (
 					overrides.ticket ?? null,
 				),
 			}),
-			fakeShell(script).layer,
+			fakeSeams(script).layer,
 		),
 	);
 
-const withLabel: readonly [RegExp, ExecResult] = [LABELS, okOut("grilling:session\nbug")];
+const withLabel: Scripted = [LABELS, labelled("grilling:session", "bug")];
 
 describe("runOpen mints a session when none matches", () => {
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	const script: ReadonlyArray<Scripted> = [
 		withLabel,
-		[SEARCH, okOut("")],
+		[SEARCH, listing()],
 		[CREATE, created],
-		[ISSUE, okOut(sessionPayload(9412, {labels: []}))],
-		[LABEL_WRITE, okOut("{}")],
+		[ISSUE, served(sessionPayload(9412, {labels: []}))],
+		[LABEL_WRITE, served("{}")],
 	];
 
 	it("answers with created:true and the minted number", async () => {
@@ -85,23 +101,23 @@ describe("runOpen mints a session when none matches", () => {
 	});
 
 	it("applies the label as part of the create, never as a caller's follow-up", async () => {
-		const shell = fakeShell(script);
-		await Effect.runPromise(Effect.provide(runOpen(onTopic), shell.layer));
-		expect(shell.calls.some((call) => LABEL_WRITE.test(call))).toBe(true);
+		const seams = fakeSeams(script);
+		await Effect.runPromise(Effect.provide(runOpen(onTopic), seams.layer));
+		expect(seams.requests.some((request) => LABEL_WRITE.test(request))).toBe(true);
 	});
 });
 
 describe("runOpen resumes an existing session", () => {
 	it("answers created:false without writing anything", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			withLabel,
-			[SEARCH, okOut(row(9412, TOPIC))],
-			[ISSUE, okOut(sessionPayload(9412))],
+			[SEARCH, listing(row(9412, TOPIC))],
+			[ISSUE, served(sessionPayload(9412))],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runOpen(onTopic), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runOpen(onTopic), seams.layer));
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({session: 9412, created: false});
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(seams.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it.each([
@@ -111,8 +127,8 @@ describe("runOpen resumes an existing session", () => {
 	])("matches a title differing only in %s", async (_case, title) => {
 		const out = await run([
 			withLabel,
-			[SEARCH, okOut(row(9412, title))],
-			[ISSUE, okOut(sessionPayload(9412))],
+			[SEARCH, listing(row(9412, title))],
+			[ISSUE, served(sessionPayload(9412))],
 		]);
 		expect(JSON.parse(out.stdout)).toMatchObject({session: 9412, created: false});
 	});
@@ -120,10 +136,10 @@ describe("runOpen resumes an existing session", () => {
 	it("does not match a title a human reads as related but that is not equal", async () => {
 		const out = await run([
 			withLabel,
-			[SEARCH, okOut(row(9412, "sozluk moderation"))],
+			[SEARCH, listing(row(9412, "sozluk moderation"))],
 			[CREATE, created],
-			[ISSUE, okOut(sessionPayload(9412, {labels: []}))],
-			[LABEL_WRITE, okOut("{}")],
+			[ISSUE, served(sessionPayload(9412, {labels: []}))],
+			[LABEL_WRITE, served("{}")],
 		]);
 		expect(JSON.parse(out.stdout)).toMatchObject({created: true});
 	});
@@ -134,7 +150,7 @@ describe("runOpen seats each refusal on its own code, with nothing on stdout", (
 		readonly [
 			string,
 			number,
-			ReadonlyArray<readonly [RegExp, ExecResult]>,
+			ReadonlyArray<Scripted>,
 			{readonly topic?: string | null; readonly ticket?: number | null},
 		]
 	> = [
@@ -145,29 +161,19 @@ describe("runOpen seats each refusal on its own code, with nothing on stdout", (
 			{topic: "why /Users/someone/notes.md is stale"},
 		],
 		["a bare @ path topic", BARE_AT_PATH, [withLabel], {topic: "@/Users/someone/notes.md"}],
-		["the session label not existing", NO_TARGET, [[LABELS, okOut("bug\nchore")]], {}],
-		[
-			"a label read that failed",
-			PRECONDITION_UNKNOWN,
-			[[LABELS, errOut("gh: Bad gateway (HTTP 502)")]],
-			{},
-		],
-		[
-			"a search that could not complete",
-			PRECONDITION_UNKNOWN,
-			[withLabel, [SEARCH, errOut("gh: Bad gateway (HTTP 502)")]],
-			{},
-		],
+		["the session label not existing", NO_TARGET, [[LABELS, labelled("bug", "chore")]], {}],
+		["a label read that failed", PRECONDITION_UNKNOWN, [[LABELS, GATEWAY]], {}],
+		["a search that could not complete", PRECONDITION_UNKNOWN, [withLabel, [SEARCH, GATEWAY]], {}],
 		[
 			"more than one matching session",
 			SESSION_AMBIGUOUS,
-			[withLabel, [SEARCH, okOut(`${row(9412, TOPIC)}\n${row(9431, TOPIC)}`)]],
+			[withLabel, [SEARCH, listing(row(9412, TOPIC), row(9431, TOPIC))]],
 			{},
 		],
 		[
 			"a create that failed",
 			WRITE_UNKNOWN,
-			[withLabel, [SEARCH, okOut("")], [CREATE, errOut("gh: Bad gateway (HTTP 502)")]],
+			[withLabel, [SEARCH, listing()], [CREATE, GATEWAY]],
 			{},
 		],
 		[
@@ -175,9 +181,9 @@ describe("runOpen seats each refusal on its own code, with nothing on stdout", (
 			READBACK_MISMATCH,
 			[
 				withLabel,
-				[SEARCH, okOut("")],
+				[SEARCH, listing()],
 				[CREATE, created],
-				[ISSUE, okOut(sessionPayload(9412, {labels: [], title: "something else entirely"}))],
+				[ISSUE, served(sessionPayload(9412, {labels: [], title: "something else entirely"}))],
 			],
 			{},
 		],
@@ -186,10 +192,10 @@ describe("runOpen seats each refusal on its own code, with nothing on stdout", (
 			WRITE_UNKNOWN,
 			[
 				withLabel,
-				[SEARCH, okOut("")],
+				[SEARCH, listing()],
 				[CREATE, created],
-				[ISSUE, okOut(sessionPayload(9412, {labels: []}))],
-				[LABEL_WRITE, errOut("gh: Bad gateway (HTTP 502)")],
+				[ISSUE, served(sessionPayload(9412, {labels: []}))],
+				[LABEL_WRITE, GATEWAY],
 			],
 			{},
 		],
@@ -205,19 +211,19 @@ describe("runOpen seats each refusal on its own code, with nothing on stdout", (
 	it("names the orphaned issue when the label write is the half that failed", async () => {
 		const out = await run([
 			withLabel,
-			[SEARCH, okOut("")],
+			[SEARCH, listing()],
 			[CREATE, created],
-			[ISSUE, okOut(sessionPayload(9412, {labels: []}))],
-			[LABEL_WRITE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, served(sessionPayload(9412, {labels: []}))],
+			[LABEL_WRITE, GATEWAY],
 		]);
 		expect(out.stderr.join("\n")).toContain("#9412");
 		expect(out.stderr.join("\n")).toContain("unlabelled and unfindable");
 	});
 
 	it("mints nothing when the search could not complete", async () => {
-		const shell = fakeShell([withLabel, [once(SEARCH), errOut("gh: Bad gateway (HTTP 502)")]]);
-		await Effect.runPromise(Effect.provide(runOpen(onTopic), shell.layer));
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		const seams = fakeSeams([withLabel, [once(SEARCH), GATEWAY]]);
+		await Effect.runPromise(Effect.provide(runOpen(onTopic), seams.layer));
+		expect(seams.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("keeps every refusal on a code of its own", () => {
@@ -229,30 +235,30 @@ describe("runOpen seats each refusal on its own code, with nothing on stdout", (
 describe("runOpen binds a session to a wayfinding frontier ticket", () => {
 	const TICKET = 5652;
 	const TITLE = "does the extension seam belong to the plugin or the repo?";
-	const TICKET_READ = /^gh api repos\/o\/r\/issues\/5652$/;
-	const SESSION_READ = /^gh api repos\/o\/r\/issues\/9412$/;
-	const ticketRead: readonly [RegExp, ExecResult] = [
+	const TICKET_READ = /^GET .*\/repos\/o\/r\/issues\/5652$/;
+	const SESSION_READ = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+	const ticketRead: Scripted = [
 		TICKET_READ,
-		okOut(sessionPayload(TICKET, {labels: ["wayfinding:map"], title: TITLE})),
+		served(sessionPayload(TICKET, {labels: ["wayfinding:map"], title: TITLE})),
 	];
-	const bound = (number: number, title = TITLE): string =>
+	const bound = (number: number, title = TITLE): Record<string, unknown> =>
 		row(number, title, `A grilling session.\n\n${cameFromSection(TICKET)}`);
-	const onTicket = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => fakeShell(script);
-	const forTicket = (shell: ReturnType<typeof fakeShell>, topic: string | null = null) =>
+	const onTicket = (script: ReadonlyArray<Scripted>) => fakeSeams(script);
+	const forTicket = (seams: ReturnType<typeof fakeSeams>, topic: string | null = null) =>
 		Effect.runPromise(
-			Effect.provide(runOpen({...options, subject: subjectOf(topic, TICKET)}), shell.layer),
+			Effect.provide(runOpen({...options, subject: subjectOf(topic, TICKET)}), seams.layer),
 		);
 
 	it("takes the title from the ticket and records the ticket on the body", async () => {
-		const shell = onTicket([
+		const seams = onTicket([
 			withLabel,
 			ticketRead,
-			[SEARCH, okOut("")],
+			[SEARCH, listing()],
 			[CREATE, created],
-			[SESSION_READ, okOut(sessionPayload(9412, {labels: [], title: TITLE}))],
-			[LABEL_WRITE, okOut("{}")],
+			[SESSION_READ, served(sessionPayload(9412, {labels: [], title: TITLE}))],
+			[LABEL_WRITE, served("{}")],
 		]);
-		const out = await forTicket(shell);
+		const out = await forTicket(seams);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
 			session: 9412,
@@ -260,21 +266,22 @@ describe("runOpen binds a session to a wayfinding frontier ticket", () => {
 			ticket: TICKET,
 			created: true,
 		});
-		const create = shell.calls.find((call) => CREATE.test(call)) ?? "";
-		expect(create).toContain(`title=${TITLE}`);
-		expect(create).toContain(cameFromSection(TICKET));
+		const at = seams.requests.findIndex((request) => CREATE.test(request));
+		const create = JSON.parse(seams.bodies[at] ?? "{}") as Record<string, string>;
+		expect(create.title).toBe(TITLE);
+		expect(create.body).toContain(cameFromSection(TICKET));
 	});
 
 	it("resumes the bound session on a second run, minting nothing", async () => {
-		const shell = onTicket([
+		const seams = onTicket([
 			withLabel,
 			ticketRead,
-			[SEARCH, okOut(bound(9412))],
-			[SESSION_READ, okOut(sessionPayload(9412, {title: TITLE}))],
+			[SEARCH, listing(bound(9412))],
+			[SESSION_READ, served(sessionPayload(9412, {title: TITLE}))],
 		]);
-		const out = await forTicket(shell);
+		const out = await forTicket(seams);
 		expect(JSON.parse(out.stdout)).toMatchObject({session: 9412, ticket: TICKET, created: false});
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(seams.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("resumes on the ticket even after both titles were edited apart", async () => {
@@ -283,8 +290,8 @@ describe("runOpen binds a session to a wayfinding frontier ticket", () => {
 			onTicket([
 				withLabel,
 				ticketRead,
-				[SEARCH, okOut(bound(9412, renamed))],
-				[SESSION_READ, okOut(sessionPayload(9412, {title: renamed}))],
+				[SEARCH, listing(bound(9412, renamed))],
+				[SESSION_READ, served(sessionPayload(9412, {title: renamed}))],
 			]),
 			"a topic nobody would match on",
 		);
@@ -296,10 +303,10 @@ describe("runOpen binds a session to a wayfinding frontier ticket", () => {
 			onTicket([
 				withLabel,
 				ticketRead,
-				[SEARCH, okOut(row(9400, TITLE))],
+				[SEARCH, listing(row(9400, TITLE))],
 				[CREATE, created],
-				[SESSION_READ, okOut(sessionPayload(9412, {labels: [], title: TITLE}))],
-				[LABEL_WRITE, okOut("{}")],
+				[SESSION_READ, served(sessionPayload(9412, {labels: [], title: TITLE}))],
+				[LABEL_WRITE, served("{}")],
 			]),
 		);
 		expect(JSON.parse(out.stdout)).toMatchObject({session: 9412, created: true});
@@ -307,32 +314,32 @@ describe("runOpen binds a session to a wayfinding frontier ticket", () => {
 
 	it("refuses on 16 when two open sessions carry the same ticket", async () => {
 		const out = await forTicket(
-			onTicket([withLabel, ticketRead, [SEARCH, okOut(`${bound(9412)}\n${bound(9431)}`)]]),
+			onTicket([withLabel, ticketRead, [SEARCH, listing(bound(9412), bound(9431))]]),
 		);
 		expect(out.code).toBe(SESSION_AMBIGUOUS);
 		expect(out.stderr.join("\n")).toContain(`ticket #${TICKET}`);
 	});
 
 	it.each([
-		[NO_TARGET, "does not exist", "gh: Not Found (HTTP 404)"],
-		[PRECONDITION_UNKNOWN, "could not be read", "gh: Bad gateway (HTTP 502)"],
-	])("refuses on %i when the ticket %s, minting nothing", async (code, _case, reason) => {
-		const shell = onTicket([withLabel, [TICKET_READ, errOut(reason)]]);
-		const out = await forTicket(shell);
+		[NO_TARGET, "does not exist", NOT_FOUND],
+		[PRECONDITION_UNKNOWN, "could not be read", GATEWAY],
+	])("refuses on %i when the ticket %s, minting nothing", async (code, _case, reply) => {
+		const seams = onTicket([withLabel, [TICKET_READ, reply]]);
+		const out = await forTicket(seams);
 		expect(out.code).toBe(code);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(seams.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("refuses on 19 rather than minting a second session past a body it could not parse", async () => {
 		const drifted = row(9400, TITLE, `A grilling session.\n\n### Came from\n\n#${TICKET}\n`);
-		const shell = onTicket([withLabel, ticketRead, [SEARCH, okOut(drifted)]]);
-		const out = await forTicket(shell);
+		const seams = onTicket([withLabel, ticketRead, [SEARCH, listing(drifted)]]);
+		const out = await forTicket(seams);
 		expect(out.code).toBe(BINDING_MALFORMED);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("#9400");
 		expect(out.stderr.join("\n")).toContain("does not parse");
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(seams.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("reads a session bound to a different ticket as no match, not as a drift", async () => {
@@ -341,10 +348,10 @@ describe("runOpen binds a session to a wayfinding frontier ticket", () => {
 			onTicket([
 				withLabel,
 				ticketRead,
-				[SEARCH, okOut(other)],
+				[SEARCH, listing(other)],
 				[CREATE, created],
-				[SESSION_READ, okOut(sessionPayload(9412, {labels: [], title: TITLE}))],
-				[LABEL_WRITE, okOut("{}")],
+				[SESSION_READ, served(sessionPayload(9412, {labels: [], title: TITLE}))],
+				[LABEL_WRITE, served("{}")],
 			]),
 		);
 		expect(JSON.parse(out.stdout)).toMatchObject({session: 9412, created: true});

--- a/packages/fabrika-cli/src/grill/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/grill/read-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply} from "../fakes.test-support.ts";
 import {cameFromSection} from "../wire/came-from.ts";
 import {NO_TARGET, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {
@@ -17,9 +16,14 @@ import {
 } from "./fixtures.test-support.ts";
 import {runRead} from "./read-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/([a-z-]+)\/permission/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
+const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/[a-z-]+\/permission$/;
+
+const served = (body: string): HttpReply => ({status: 200, body});
+const granted = (permission: string): HttpReply => served(JSON.stringify({permission}));
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 const BOUND = roundDigestOf(1);
 const ROUND = {id: 1, author: "acme-founder", body: roundComment(1)} satisfies FakeComment;
@@ -42,14 +46,14 @@ interface ReadAnswer {
 
 const readSession = async (
 	comments: ReadonlyArray<FakeComment>,
-	permission: ExecResult = okOut("write"),
+	permission: HttpReply = granted("write"),
 ): Promise<{code: number; answer: ReadAnswer}> => {
 	const out = await Effect.runPromise(
 		Effect.provide(
 			runRead(options),
-			fakeShell([
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, okOut(commentsPayload(comments))],
+			fakeSeams([
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, served(commentsPayload(comments))],
 				[PERMISSION, permission],
 			]).layer,
 		),
@@ -62,9 +66,9 @@ describe("the answer names the ticket the session is bound to", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRead(options),
-				fakeShell([
-					[ISSUE, okOut(sessionPayload(9412, {body}))],
-					[COMMENTS, okOut(commentsPayload([]))],
+				fakeSeams([
+					[ISSUE, served(sessionPayload(9412, {body}))],
+					[COMMENTS, served(commentsPayload([]))],
 				]).layer,
 			),
 		);
@@ -83,9 +87,9 @@ describe("the answer names the ticket the session is bound to", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRead(options),
-				fakeShell([
-					[ISSUE, okOut(sessionPayload(9412, {body: "### Came from\n\n#5652\n"}))],
-					[COMMENTS, okOut(commentsPayload([]))],
+				fakeSeams([
+					[ISSUE, served(sessionPayload(9412, {body: "### Came from\n\n#5652\n"}))],
+					[COMMENTS, served(commentsPayload([]))],
 				]).layer,
 			),
 		);
@@ -182,7 +186,7 @@ describe("a ruling resolves only when all four clauses hold", () => {
 				{id: 2, author: "stranger", body: AUTHORIZATION},
 				{id: 3, author: "stranger", body: rulingComment("R1.2", BOUND)},
 			],
-			okOut("read"),
+			granted("read"),
 		);
 		expect(answer.questions[1]).toMatchObject({state: "open"});
 		expect(answer.disregarded[0]).toMatchObject({comment: 3, reason: "unauthorized"});
@@ -270,10 +274,7 @@ describe("supersession comes from the marker and from nothing else", () => {
 describe("the only refusals are an absent session and a read that could not complete", () => {
 	it("refuses an absent session as proven", async () => {
 		const out = await Effect.runPromise(
-			Effect.provide(
-				runRead(options),
-				fakeShell([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]).layer,
-			),
+			Effect.provide(runRead(options), fakeSeams([[ISSUE, NOT_FOUND]]).layer),
 		);
 		expect(out.code).toBe(NO_TARGET);
 		expect(out.stdout).toBe("");
@@ -283,9 +284,9 @@ describe("the only refusals are an absent session and a read that could not comp
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRead(options),
-				fakeShell([
-					[ISSUE, okOut(sessionPayload(9412))],
-					[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+				fakeSeams([
+					[ISSUE, served(sessionPayload(9412))],
+					[COMMENTS, GATEWAY],
 				]).layer,
 			),
 		);
@@ -298,18 +299,18 @@ describe("the only refusals are an absent session and a read that could not comp
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRead(options),
-				fakeShell([
-					[ISSUE, okOut(sessionPayload(9412))],
+				fakeSeams([
+					[ISSUE, served(sessionPayload(9412))],
 					[
 						COMMENTS,
-						okOut(
+						served(
 							commentsPayload([
 								ROUND,
 								{id: 3, author: "acme-founder", body: rulingComment("R1.2", BOUND)},
 							]),
 						),
 					],
-					[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+					[PERMISSION, GATEWAY],
 				]).layer,
 			),
 		);

--- a/packages/fabrika-cli/src/grill/round-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/grill/round-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BAD_SECTIONS,
@@ -26,11 +25,20 @@ import {
 } from "./fixtures.test-support.ts";
 import {runRound} from "./round-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/([a-z-]+)\/permission/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/9412\/comments -f/;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
+const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/[a-z-]+\/permission$/;
+const POST = /^POST .*\/repos\/o\/r\/issues\/9412\/comments$/;
+const READBACK = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+
+const served = (body: string, status = 200): HttpReply => ({status, body});
+const granted = (permission: string): HttpReply => served(JSON.stringify({permission}));
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
+
+/** The bodies a write carried, in order — where a "what was posted" claim is read now. */
+const postedBodies = (seams: ReturnType<typeof fakeSeams>): ReadonlyArray<string> =>
+	seams.bodies.filter((_, at) => POST.test(seams.requests[at] ?? ""));
 
 const options = {
 	session: 9412,
@@ -42,26 +50,23 @@ const options = {
 };
 
 const postedAs = (id: number) =>
-	okOut(JSON.stringify({id, html_url: `https://example.test/issues/9412#issuecomment-${id}`}));
+	served(
+		JSON.stringify({id, html_url: `https://example.test/issues/9412#issuecomment-${id}`}),
+		201,
+	);
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runRound({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runRound({...options, ...overrides}), fakeSeams(script).layer));
 
 /**
  * A script whose read-back echoes the body the verb composed. The composed round is derived from the
  * same fixture builder the verb uses, so an echo is a real read-back rather than a rubber stamp.
  */
-const happy = (
-	comments: string = commentsPayload([]),
-	round = 1,
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[ISSUE, okOut(sessionPayload(9412))],
-	[COMMENTS, okOut(comments)],
+const happy = (comments: string = commentsPayload([]), round = 1): ReadonlyArray<Scripted> => [
+	[ISSUE, served(sessionPayload(9412))],
+	[COMMENTS, served(comments)],
 	[POST, postedAs(5234567890)],
-	[READBACK, okOut(JSON.stringify({body: roundComment(round)}))],
+	[READBACK, served(JSON.stringify({body: roundComment(round)}))],
 ];
 
 describe("runRound derives the round number and stamps the ids", () => {
@@ -101,16 +106,16 @@ describe("runRound validates the grammar before it writes", () => {
 		["a heading that is not a question block", "### Background\nprose\n"],
 		["a kind outside the set", "### 1 · musing\nWhat if?\n\n**Recommended:** x\n"],
 	])("refuses %s on BAD_SECTIONS with nothing posted", async (_case, text) => {
-		const shell = fakeShell(happy());
+		const seams = fakeSeams(happy());
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRound({...options, stdin: Effect.succeed<StdinRead>({_tag: "Text", text})}),
-				shell.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(BAD_SECTIONS);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((call) => POST.test(call))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 
 	it("refuses an empty stdin on its own code", async () => {
@@ -129,47 +134,47 @@ describe("runRound validates the grammar before it writes", () => {
 		["a bare @ path body", "@/Users/someone/round.md", BARE_AT_PATH],
 	])("refuses %s before any write", async (_case, text, code) => {
 		const stdin = Effect.succeed<StdinRead>({_tag: "Text", text});
-		const shell = fakeShell(happy());
-		const out = await Effect.runPromise(Effect.provide(runRound({...options, stdin}), shell.layer));
+		const seams = fakeSeams(happy());
+		const out = await Effect.runPromise(Effect.provide(runRound({...options, stdin}), seams.layer));
 		expect(out.code).toBe(code);
-		expect(shell.calls.some((call) => POST.test(call))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 });
 
 describe("runRound seats each read and write failure on its own code", () => {
 	it("refuses an absent session as proven, never as unreadable", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(NO_TARGET);
 	});
 
 	it("refuses an issue that is not a grilling session", async () => {
-		const out = await run([[ISSUE, okOut(sessionPayload(9412, {labels: ["bug"]}))]]);
+		const out = await run([[ISSUE, served(sessionPayload(9412, {labels: ["bug"]}))]]);
 		expect(out.code).toBe(NO_TARGET);
 	});
 
 	it("refuses a comment read that could not complete — the next round number is UNKNOWN", async () => {
-		const shell = fakeShell([
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		const seams = fakeSeams([
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, GATEWAY],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runRound(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runRound(options), seams.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((call) => POST.test(call))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 
 	it("refuses a truncated comment page rather than answering short", async () => {
 		const out = await run([
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, okOut(`${commentsPayload([])}[{"id":`)],
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, served(`${commentsPayload([])}[{"id":`)],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("refuses a comment write that failed as UNKNOWN, never as 1", async () => {
 		const out = await run([
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, okOut(commentsPayload([]))],
-			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, served(commentsPayload([]))],
+			[POST, GATEWAY],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -177,10 +182,10 @@ describe("runRound seats each read and write failure on its own code", () => {
 
 	it("refuses a read-back that differs from what was sent", async () => {
 		const out = await run([
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, okOut(commentsPayload([]))],
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, served(commentsPayload([]))],
 			[POST, postedAs(5234567890)],
-			[READBACK, okOut(JSON.stringify({body: "something else"}))],
+			[READBACK, served(JSON.stringify({body: "something else"}))],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 	});
@@ -190,16 +195,16 @@ describe("runRound --supersedes retires a question", () => {
 	const bound = roundDigestOf(1);
 	const withRoundOne = commentsPayload([{id: 1, author: "acme-founder", body: roundComment(1)}]);
 
-	const supersedeScript = (comments: string): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-		[ISSUE, okOut(sessionPayload(9412))],
-		[COMMENTS, okOut(comments)],
-		[PERMISSION, okOut("write")],
+	const supersedeScript = (comments: string): ReadonlyArray<Scripted> => [
+		[ISSUE, served(sessionPayload(9412))],
+		[COMMENTS, served(comments)],
+		[PERMISSION, granted("write")],
 		[once(POST), postedAs(5234567890)],
-		[once(READBACK), okOut(JSON.stringify({body: roundComment(2)}))],
+		[once(READBACK), served(JSON.stringify({body: roundComment(2)}))],
 		[POST, postedAs(5234567891)],
 		[
 			READBACK,
-			okOut(
+			served(
 				JSON.stringify({
 					body: supersedeComment([{question: "R1.2", digest: bound, round: 2}]),
 				}),
@@ -208,9 +213,9 @@ describe("runRound --supersedes retires a question", () => {
 	];
 
 	it("writes the round first and the marker second, naming both ids", async () => {
-		const shell = fakeShell(supersedeScript(withRoundOne));
+		const seams = fakeSeams(supersedeScript(withRoundOne));
 		const out = await Effect.runPromise(
-			Effect.provide(runRound({...options, supersedes: ["R1.2"]}), shell.layer),
+			Effect.provide(runRound({...options, supersedes: ["R1.2"]}), seams.layer),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -219,17 +224,17 @@ describe("runRound --supersedes retires a question", () => {
 			comment: 5234567890,
 			supersedeComment: 5234567891,
 		});
-		const posts = shell.calls.filter((call) => POST.test(call));
+		const posts = postedBodies(seams);
 		expect(posts[0]).toContain("grill-round: 2");
 		expect(posts[1]).toContain("grill-superseded: R1.2");
 	});
 
 	it("binds the RETIRED question's round digest, not the retiring round's", async () => {
-		const shell = fakeShell(supersedeScript(withRoundOne));
+		const seams = fakeSeams(supersedeScript(withRoundOne));
 		await Effect.runPromise(
-			Effect.provide(runRound({...options, supersedes: ["R1.2"]}), shell.layer),
+			Effect.provide(runRound({...options, supersedes: ["R1.2"]}), seams.layer),
 		);
-		const marker = shell.calls.filter((call) => POST.test(call))[1] ?? "";
+		const marker = postedBodies(seams)[1] ?? "";
 		expect(marker).toContain(roundDigestOf(1));
 		expect(marker).not.toContain(roundDigestOf(2));
 	});
@@ -268,21 +273,21 @@ describe("runRound --supersedes retires a question", () => {
 				body: supersedeComment([{question: "R1.1", digest: bound, round: 2}]),
 			},
 		]);
-		const shell = fakeShell([
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, okOut(comments)],
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+		const seams = fakeSeams([
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, served(comments)],
+			[PERMISSION, GATEWAY],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runRound({...options, supersedes: ["R1.2"]}), shell.layer),
+			Effect.provide(runRound({...options, supersedes: ["R1.2"]}), seams.layer),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((call) => POST.test(call))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 
 	it("costs no ACL read at all when nothing is being retired", async () => {
-		const shell = fakeShell(happy(withRoundOne, 2));
-		await Effect.runPromise(Effect.provide(runRound(options), shell.layer));
-		expect(shell.calls.some((call) => PERMISSION.test(call))).toBe(false);
+		const seams = fakeSeams(happy(withRoundOne, 2));
+		await Effect.runPromise(Effect.provide(runRound(options), seams.layer));
+		expect(seams.requests.some((request) => PERMISSION.test(request))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/grill/rule-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/grill/rule-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {DocumentRead} from "./answer-verb.ts";
 import {
 	AUTHORIZATION_ABSENT,
@@ -28,12 +27,17 @@ import {
 } from "./fixtures.test-support.ts";
 import {runRule} from "./rule-verb.ts";
 
-const VIEWER = /^gh api user --jq \.login$/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/[a-z-]+\/permission/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/9412\/comments -f/;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const VIEWER = /^GET .*\/user$/;
+const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/[a-z-]+\/permission$/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9412\/comments\?/;
+const POST = /^POST .*\/repos\/o\/r\/issues\/9412\/comments$/;
+const READBACK = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+
+const served = (body: string, status = 200): HttpReply => ({status, body});
+const granted = (permission: string): HttpReply => served(JSON.stringify({permission}));
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 const BOUND = roundDigestOf(1);
 const ROUND_ONE = commentsPayload([{id: 1, author: "acme-founder", body: roundComment(1)}]);
@@ -49,27 +53,24 @@ const options = {
 };
 
 const postedAs = (id: number) =>
-	okOut(JSON.stringify({id, html_url: `https://example.test/#${id}`}));
+	served(JSON.stringify({id, html_url: `https://example.test/#${id}`}), 201);
 
-const identity: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[VIEWER, okOut("acme-founder")],
-	[PERMISSION, okOut("write")],
+const identity: ReadonlyArray<Scripted> = [
+	[VIEWER, served(JSON.stringify({login: "acme-founder"}))],
+	[PERMISSION, granted("write")],
 ];
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	...identity,
-	[ISSUE, okOut(sessionPayload(9412))],
-	[COMMENTS, okOut(ROUND_ONE)],
+	[ISSUE, served(sessionPayload(9412))],
+	[COMMENTS, served(ROUND_ONE)],
 	[once(POST), postedAs(5234567893)],
 	[POST, postedAs(5234567892)],
-	[READBACK, okOut(JSON.stringify({body: rulingComment("R1.2", BOUND)}))],
+	[READBACK, served(JSON.stringify({body: rulingComment("R1.2", BOUND)}))],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runRule({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runRule({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runRule records a bound ruling", () => {
 	it("answers with both comment ids and resolvesTo ruled", async () => {
@@ -86,9 +87,9 @@ describe("runRule records a bound ruling", () => {
 	});
 
 	it("writes the authorization FIRST and the marker second", async () => {
-		const shell = fakeShell(happy);
-		await Effect.runPromise(Effect.provide(runRule(options), shell.layer));
-		const posts = shell.calls.filter((call) => POST.test(call));
+		const seams = fakeSeams(happy);
+		await Effect.runPromise(Effect.provide(runRule(options), seams.layer));
+		const posts = seams.bodies.filter((_, at) => POST.test(seams.requests[at] ?? ""));
 		expect(posts).toHaveLength(2);
 		expect(posts[0]).toContain("weight is earned per account");
 		expect(posts[0]).not.toContain("grill-ruled:");
@@ -98,10 +99,10 @@ describe("runRule records a bound ruling", () => {
 	it("names the orphaned authorization when the marker write is the half that failed", async () => {
 		const out = await run([
 			...identity,
-			[ISSUE, okOut(sessionPayload(9412))],
-			[COMMENTS, okOut(ROUND_ONE)],
+			[ISSUE, served(sessionPayload(9412))],
+			[COMMENTS, served(ROUND_ONE)],
 			[once(POST), postedAs(5234567893)],
-			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			[POST, GATEWAY],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -115,56 +116,56 @@ describe("runRule refuses without a quoted, dated authorization", () => {
 		["an empty authorization", "   \n"],
 		["an authorization carrying no ISO-8601 date", 'he said "do it that way"\n'],
 	])("refuses %s on AUTHORIZATION_ABSENT with nothing written", async (_case, text) => {
-		const shell = fakeShell(happy);
+		const seams = fakeSeams(happy);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRule({...options, authorization: Effect.succeed<DocumentRead>({_tag: "Text", text})}),
-				shell.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(AUTHORIZATION_ABSENT);
-		expect(shell.calls.some((call) => POST.test(call))).toBe(false);
+		expect(seams.requests.some((request) => POST.test(request))).toBe(false);
 	});
 });
 
 describe("runRule never grants authority from a failed lookup", () => {
 	it("refuses a permission read that could not complete as UNKNOWN", async () => {
 		const out = await run([
-			[VIEWER, okOut("acme-founder")],
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+			[VIEWER, served(JSON.stringify({login: "acme-founder"}))],
+			[PERMISSION, GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("refuses a token below write on its own code, distinct from UNKNOWN", async () => {
 		const out = await run([
-			[VIEWER, okOut("acme-founder")],
-			[PERMISSION, okOut("read")],
+			[VIEWER, served(JSON.stringify({login: "acme-founder"}))],
+			[PERMISSION, granted("read")],
 		]);
 		expect(out.code).toBe(TOKEN_UNAUTHORIZED);
 	});
 
 	it("refuses a token that is no collaborator at all", async () => {
 		const out = await run([
-			[VIEWER, okOut("acme-founder")],
-			[PERMISSION, errOut("gh: Not Found (HTTP 404)")],
+			[VIEWER, served(JSON.stringify({login: "acme-founder"}))],
+			[PERMISSION, NOT_FOUND],
 		]);
 		expect(out.code).toBe(TOKEN_UNAUTHORIZED);
 	});
 
 	it("resolves the ACL before it reads the session, so nothing is read on an unauthorized token", async () => {
-		const shell = fakeShell([
-			[VIEWER, okOut("acme-founder")],
-			[PERMISSION, okOut("read")],
+		const seams = fakeSeams([
+			[VIEWER, served(JSON.stringify({login: "acme-founder"}))],
+			[PERMISSION, granted("read")],
 		]);
-		await Effect.runPromise(Effect.provide(runRule(options), shell.layer));
-		expect(shell.calls.some((call) => ISSUE.test(call))).toBe(false);
+		await Effect.runPromise(Effect.provide(runRule(options), seams.layer));
+		expect(seams.requests.some((request) => ISSUE.test(request))).toBe(false);
 	});
 });
 
 describe("runRule seats every other refusal on its own code", () => {
 	const cases: ReadonlyArray<
-		readonly [string, number, ReadonlyArray<readonly [RegExp, ExecResult]>, Partial<typeof options>]
+		readonly [string, number, ReadonlyArray<Scripted>, Partial<typeof options>]
 	> = [
 		[
 			"an authorization carrying a machine-local path",
@@ -188,12 +189,7 @@ describe("runRule seats every other refusal on its own code", () => {
 				}),
 			},
 		],
-		[
-			"an absent session",
-			NO_TARGET,
-			[...identity, [ISSUE, errOut("gh: Not Found (HTTP 404)")]],
-			{},
-		],
+		["an absent session", NO_TARGET, [...identity, [ISSUE, NOT_FOUND]], {}],
 		["an id that names no question", QUESTION_UNKNOWN, happy, {question: "R9.9"}],
 		["a fact question", KIND_MISMATCH, happy, {question: "R1.1"}],
 		[
@@ -201,10 +197,10 @@ describe("runRule seats every other refusal on its own code", () => {
 			QUESTION_RETIRED,
 			[
 				...identity,
-				[ISSUE, okOut(sessionPayload(9412))],
+				[ISSUE, served(sessionPayload(9412))],
 				[
 					COMMENTS,
-					okOut(
+					served(
 						commentsPayload([
 							{id: 1, author: "acme-founder", body: roundComment(1)},
 							{
@@ -223,10 +219,10 @@ describe("runRule seats every other refusal on its own code", () => {
 			DIGEST_UNBINDABLE,
 			[
 				...identity,
-				[ISSUE, okOut(sessionPayload(9412))],
+				[ISSUE, served(sessionPayload(9412))],
 				[
 					COMMENTS,
-					okOut(
+					served(
 						commentsPayload([
 							{
 								id: 1,
@@ -247,11 +243,11 @@ describe("runRule seats every other refusal on its own code", () => {
 			READBACK_MISMATCH,
 			[
 				...identity,
-				[ISSUE, okOut(sessionPayload(9412))],
-				[COMMENTS, okOut(ROUND_ONE)],
+				[ISSUE, served(sessionPayload(9412))],
+				[COMMENTS, served(ROUND_ONE)],
 				[once(POST), postedAs(5234567893)],
 				[POST, postedAs(5234567892)],
-				[READBACK, okOut(JSON.stringify({body: "something else"}))],
+				[READBACK, served(JSON.stringify({body: "something else"}))],
 			],
 			{},
 		],

--- a/packages/fabrika-cli/src/grill/session.unit.test.ts
+++ b/packages/fabrika-cli/src/grill/session.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {CommentRecord} from "../io/issues.ts";
 import {
 	answerComment,
@@ -30,8 +30,12 @@ const comment = (id: number, author: string, body: string): CommentRecord => ({
 });
 
 const BOUND = roundDigestOf(1);
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/([a-z-]+)\/permission/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
+const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/[a-z-]+\/permission$/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9412$/;
+
+const served = (payload: unknown): HttpReply => ({status: 200, body: JSON.stringify(payload)});
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 describe("normalizeTopic", () => {
 	it.each([
@@ -48,24 +52,24 @@ describe("normalizeTopic", () => {
 });
 
 describe("resolveSession splits absent from unreadable", () => {
-	const resolve = (script: Parameters<typeof fakeShell>[0]) =>
-		Effect.runPromise(Effect.provide(resolveSession("o/r", 9412), fakeShell(script).layer));
+	const resolve = (script: ReadonlyArray<Scripted>) =>
+		Effect.runPromise(Effect.provide(resolveSession("o/r", 9412), fakeSeams(script).layer));
 
 	it("resolves a labelled issue", async () => {
-		expect(await resolve([[ISSUE, okOut(sessionPayload(9412))]])).toMatchObject({_tag: "Session"});
+		expect(await resolve([[ISSUE, {status: 200, body: sessionPayload(9412)}]])).toMatchObject({
+			_tag: "Session",
+		});
 	});
 
 	it("treats an issue without the session label as absent, not as a session", async () => {
-		expect(await resolve([[ISSUE, okOut(sessionPayload(9412, {labels: ["bug"]}))]])).toEqual({
-			_tag: "Absent",
-		});
+		expect(
+			await resolve([[ISSUE, {status: 200, body: sessionPayload(9412, {labels: ["bug"]})}]]),
+		).toEqual({_tag: "Absent"});
 	});
 
 	it("keeps a 404 and a 502 apart", async () => {
-		expect(await resolve([[ISSUE, errOut("gh: Not Found (HTTP 404)")]])).toEqual({_tag: "Absent"});
-		expect(await resolve([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]])).toMatchObject({
-			_tag: "Unknown",
-		});
+		expect(await resolve([[ISSUE, NOT_FOUND]])).toEqual({_tag: "Absent"});
+		expect(await resolve([[ISSUE, GATEWAY]])).toMatchObject({_tag: "Unknown"});
 	});
 
 	it("names the label the whole group keys on", () => {
@@ -105,9 +109,11 @@ describe("scanning rounds", () => {
 });
 
 describe("scanMarkers resolves authority before it counts anything", () => {
-	const scan = (comments: ReadonlyArray<CommentRecord>, permission = okOut("write")) =>
+	const granted = (permission: string): HttpReply => served({permission});
+
+	const scan = (comments: ReadonlyArray<CommentRecord>, permission = granted("write")) =>
 		Effect.runPromise(
-			Effect.provide(scanMarkers("o/r", comments), fakeShell([[PERMISSION, permission]]).layer),
+			Effect.provide(scanMarkers("o/r", comments), fakeSeams([[PERMISSION, permission]]).layer),
 		);
 
 	it("counts a marker whose author resolves write+", async () => {
@@ -121,7 +127,7 @@ describe("scanMarkers resolves authority before it counts anything", () => {
 	it("disregards a marker whose author is below write, and says so", async () => {
 		const result = await scan(
 			[comment(3, "stranger", rulingComment("R1.2", BOUND))],
-			okOut("read"),
+			granted("read"),
 		);
 		if (result._tag !== "Scanned") throw new Error("expected a scan");
 		expect(result.scan.rulings).toEqual([]);
@@ -129,31 +135,28 @@ describe("scanMarkers resolves authority before it counts anything", () => {
 	});
 
 	it("returns UNKNOWN, naming the marker, when a permission read fails", async () => {
-		const result = await scan(
-			[comment(3, "acme-founder", rulingComment("R1.2", BOUND))],
-			errOut("gh: Bad gateway (HTTP 502)"),
-		);
+		const result = await scan([comment(3, "acme-founder", rulingComment("R1.2", BOUND))], GATEWAY);
 		expect(result).toMatchObject({_tag: "Unknown", login: "acme-founder", subject: "R1.2"});
 	});
 
 	it("resolves each distinct author once", async () => {
-		const shell = fakeShell([[PERMISSION, okOut("write")]]);
+		const seams = fakeSeams([[PERMISSION, granted("write")]]);
 		await Effect.runPromise(
 			Effect.provide(
 				scanMarkers("o/r", [
 					comment(3, "acme-founder", rulingComment("R1.2", BOUND)),
 					comment(4, "acme-founder", answerComment("R1.1", BOUND)),
 				]),
-				shell.layer,
+				seams.layer,
 			),
 		);
-		expect(shell.calls.filter((call) => PERMISSION.test(call))).toHaveLength(1);
+		expect(seams.requests.filter((request) => PERMISSION.test(request))).toHaveLength(1);
 	});
 
 	it("gates the supersede marker at the ACL too — clear is what a downstream skill keys on", async () => {
 		const result = await scan(
 			[comment(4, "stranger", supersedeComment([{question: "R1.2", digest: BOUND, round: 2}]))],
-			okOut("read"),
+			granted("read"),
 		);
 		if (result._tag !== "Scanned") throw new Error("expected a scan");
 		expect(retirements(result.scan).size).toBe(0);

--- a/packages/fabrika-cli/src/guard/homing-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/homing-verb.unit.test.ts
@@ -1,21 +1,20 @@
 /**
- * `guard homing-guard check` over a scripted `gh` — the two scopes, and every read failure that has
- * to land as UNKNOWN rather than as a clean or a red.
+ * `guard homing-guard check` over a scripted GitHub — the two scopes, and every read failure that
+ * has to land as UNKNOWN rather than as a clean or a red.
  *
- * The scoping reads are asserted by the command lines the verb spawns: the sweep must narrow at the
+ * The scoping reads are asserted by the requests the verb issues: the sweep must narrow at the
  * endpoint, and the label-set read must happen only on the fork that needs it (#4272).
  */
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, VIOLATION, ZERO_SCOPE} from "./codes.ts";
 import {runHomingGuard} from "./homing-verb.ts";
 
-const BACKLOG = /^gh api --paginate repos\/o\/r\/issues\?state=open&labels=status%3Atriaged/;
-const ONE = /^gh api repos\/o\/r\/issues\/9$/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
+const BACKLOG = /^GET .*\/repos\/o\/r\/issues\?state=open&labels=status%3Atriaged/;
+const ONE = /^GET .*\/repos\/o\/r\/issues\/9$/;
+const LABELS = /^GET .*\/repos\/o\/r\/labels/;
 
 const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
 
@@ -37,18 +36,23 @@ const body = (shape: IssueShape) => ({
 	...(shape.pull === true ? {pull_request: {url: "https://example.test/pulls/9"}} : {}),
 });
 
-const board = (...shapes: ReadonlyArray<IssueShape>): ExecResult =>
-	okOut(JSON.stringify(shapes.map(body)));
+const board = (...shapes: ReadonlyArray<IssueShape>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(shapes.map(body)),
+});
 
-const one = (shape: IssueShape): ExecResult => okOut(JSON.stringify(body(shape)));
+const one = (shape: IssueShape): HttpReply => ({status: 200, body: JSON.stringify(body(shape))});
 
-const labels = (...names: ReadonlyArray<string>): ExecResult => okOut(names.join("\n"));
+const labels = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	options: {issue?: number; repo?: string | null; env?: Record<string, string | undefined>} = {},
 ) => {
-	const shell = fakeShell(script);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
 		Effect.provide(
 			runHomingGuard({
@@ -56,14 +60,14 @@ const run = (
 				repo: options.repo ?? null,
 				env: options.env ?? ENV,
 			}),
-			shell.layer,
+			seams.layer,
 		),
-	).then((outcome) => ({outcome, calls: shell.calls}));
+	).then((outcome) => ({outcome, calls: seams.calls, requests: seams.requests}));
 };
 
 describe("runHomingGuard — the backlog sweep", () => {
 	it("passes and reports what it scanned when every triaged issue is homed or exempt", async () => {
-		const {outcome, calls} = await run([
+		const {outcome, requests} = await run([
 			[
 				BACKLOG,
 				board(
@@ -75,13 +79,13 @@ describe("runHomingGuard — the backlog sweep", () => {
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toContain("scanned 2 triaged issue(s)");
 		expect(outcome.stdout).toContain("1 milestone-homed");
-		expect(calls).toHaveLength(1);
+		expect(requests).toHaveLength(1);
 	});
 
 	it("narrows at the endpoint rather than paging the whole open board", async () => {
-		const {calls} = await run([[BACKLOG, board({number: 1, milestone: 17})]]);
-		expect(calls[0]).toContain("labels=status%3Atriaged");
-		expect(calls[0]).toContain("state=open");
+		const {requests} = await run([[BACKLOG, board({number: 1, milestone: 17})]]);
+		expect(requests[0]).toContain("labels=status%3Atriaged");
+		expect(requests[0]).toContain("state=open");
 	});
 
 	it("reds 12 on an un-homed issue and prints the three home-or-exempt-or-kill outcomes", async () => {
@@ -106,19 +110,19 @@ describe("runHomingGuard — the backlog sweep", () => {
 	});
 
 	it("reds 7 on an empty sweep — a vacuous pass would hide every floater (ADR 0092)", async () => {
-		const {outcome} = await run([[BACKLOG, okOut("[]")]]);
+		const {outcome} = await run([[BACKLOG, {status: 200, body: "[]"}]]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.join("\n")).toContain("ZERO status:triaged issues");
 	});
 
 	it("reds 11 when the board cannot be read — never clean, never a violation", async () => {
-		const {outcome} = await run([[BACKLOG, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const {outcome} = await run([[BACKLOG, {status: 502, body: "{}"}]]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("UNKNOWN");
 	});
 
 	it("emits a ::error annotation for every refusal under Actions", async () => {
-		const {outcome} = await run([[BACKLOG, okOut("[]")]], {
+		const {outcome} = await run([[BACKLOG, {status: 200, body: "[]"}]], {
 			env: {...ENV, GITHUB_ACTIONS: "true"},
 		});
 		expect(outcome.stderr.some((line) => line.startsWith("::error"))).toBe(true);
@@ -127,10 +131,10 @@ describe("runHomingGuard — the backlog sweep", () => {
 
 describe("runHomingGuard — the --issue seam", () => {
 	it("scans just that issue and reds it when it left triage un-homed", async () => {
-		const {outcome, calls} = await run([[ONE, one({number: 9})]], {issue: 9});
+		const {outcome, requests} = await run([[ONE, one({number: 9})]], {issue: 9});
 		expect(outcome.code).toBe(VIOLATION);
 		expect(outcome.stderr.join("\n")).toContain("#9 issue 9");
-		expect(calls).toEqual(["gh api repos/o/r/issues/9"]);
+		expect(requests).toEqual(["GET https://api.github.com/repos/o/r/issues/9"]);
 	});
 
 	it("passes a triaged, milestone-homed issue", async () => {
@@ -167,7 +171,7 @@ describe("runHomingGuard — the --issue seam", () => {
 		const {outcome} = await run(
 			[
 				[ONE, one({number: 9, labels: ["type:chore"]})],
-				[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+				[LABELS, {status: 502, body: "{}"}],
 			],
 			{issue: 9},
 		);
@@ -175,12 +179,14 @@ describe("runHomingGuard — the --issue seam", () => {
 	});
 
 	it("skips the label read entirely when the issue carries the label", async () => {
-		const {calls} = await run([[ONE, one({number: 9, milestone: 17})]], {issue: 9});
-		expect(calls.some((line) => LABELS.test(line))).toBe(false);
+		const {requests} = await run([[ONE, one({number: 9, milestone: 17})]], {issue: 9});
+		expect(requests.some((line) => LABELS.test(line))).toBe(false);
 	});
 
 	it("reds 11 on an issue that does not exist", async () => {
-		const {outcome} = await run([[ONE, errOut("gh: Not Found (HTTP 404)")]], {issue: 9});
+		const {outcome} = await run([[ONE, {status: 404, body: '{"message":"Not Found"}'}]], {
+			issue: 9,
+		});
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("does not exist");
 	});
@@ -192,9 +198,9 @@ describe("runHomingGuard — the --issue seam", () => {
 	});
 
 	it("refuses a non-positive issue number as usage, before any read", async () => {
-		const {outcome, calls} = await run([], {issue: 0});
+		const {outcome, requests} = await run([], {issue: 0});
 		expect(outcome.code).toBe(FAILED);
-		expect(calls).toEqual([]);
+		expect(requests).toEqual([]);
 	});
 });
 
@@ -206,9 +212,10 @@ describe("runHomingGuard — the repo", () => {
 	});
 
 	it("honours an explicit --repo over the environment", async () => {
-		const {calls} = await run([[/^gh api --paginate repos\/other\/x\/issues/, okOut("[]")]], {
-			repo: "other/x",
-		});
-		expect(calls[0]).toContain("repos/other/x/issues");
+		const {requests} = await run(
+			[[/^GET .*\/repos\/other\/x\/issues/, {status: 200, body: "[]"}]],
+			{repo: "other/x"},
+		);
+		expect(requests[0]).toContain("repos/other/x/issues");
 	});
 });

--- a/packages/fabrika-cli/src/guard/pitch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/pitch-verb.unit.test.ts
@@ -1,24 +1,38 @@
 /**
- * `guard pitch-guard check` over a scripted `gh` — the two scopes, the three-read hydration, and
+ * `guard pitch-guard check` over a scripted GitHub — the two scopes, the three-read hydration, and
  * every read failure that has to land as UNKNOWN rather than as a clean or a red.
  *
- * The read ORDER is asserted by the command lines the verb spawns: the sweep narrows at the
- * endpoint, each shortlisted issue is re-read singly for the parent link the list omits, and the ACL
- * is resolved per comment author, fail-closed (ADR 0055).
+ * The read ORDER is asserted by the requests the verb issues: the sweep narrows at the endpoint,
+ * each shortlisted issue is re-read singly for the parent link the list omits, and the ACL is
+ * resolved per comment author, fail-closed (ADR 0055).
  */
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, VIOLATION, ZERO_SCOPE} from "./codes.ts";
 import {runPitchGuard} from "./pitch-verb.ts";
 
-const SWEEP = /^gh api --paginate repos\/o\/r\/issues\?state=open&labels=status%3Atriaged/;
-const ONE = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
-const COMMENTS = (n: number) => new RegExp(`^gh api --paginate repos/o/r/issues/${n}/comments`);
-const PERM = (login: string) => new RegExp(`^gh api repos/o/r/collaborators/${login}/permission`);
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
+const SWEEP = /^GET .*\/repos\/o\/r\/issues\?state=open&labels=status%3Atriaged/;
+const ONE = (n: number) => new RegExp(`^GET .*/repos/o/r/issues/${n}$`);
+const COMMENTS = (n: number) => new RegExp(`^GET .*/repos/o/r/issues/${n}/comments`);
+const PERM = (login: string) => new RegExp(`^GET .*/repos/o/r/collaborators/${login}/permission`);
+const LABELS = /^GET .*\/repos\/o\/r\/labels/;
+
+/** One collaborator's repository permission, in the record the ACL read parses. */
+const permission = (level: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({permission: level}),
+});
+
+/** The repository's defined labels, as the bare JSON array the universe read walks. */
+const labelSet = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+const EMPTY: HttpReply = {status: 200, body: "[]"};
+const BAD_GATEWAY: HttpReply = {status: 502, body: "{}"};
 
 const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
 
@@ -52,23 +66,28 @@ const payload = (shape: IssueShape) => ({
 	...(shape.pull === true ? {pull_request: {url: "https://example.test/pulls/9"}} : {}),
 });
 
-const sweep = (...shapes: ReadonlyArray<IssueShape>): ExecResult =>
-	okOut(JSON.stringify(shapes.map(payload)));
+const sweep = (...shapes: ReadonlyArray<IssueShape>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(shapes.map(payload)),
+});
 
-const one = (shape: IssueShape): ExecResult => okOut(JSON.stringify(payload(shape)));
+const one = (shape: IssueShape): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(payload(shape)),
+});
 
-const comments = (...bodies: ReadonlyArray<{author: string; body: string}>): ExecResult =>
-	okOut(
-		JSON.stringify(
-			bodies.map((entry, index) => ({
-				id: index + 1,
-				user: {login: entry.author},
-				created_at: "2026-08-18T00:00:00Z",
-				updated_at: "2026-08-18T00:00:00Z",
-				body: entry.body,
-			})),
-		),
-	);
+const comments = (...bodies: ReadonlyArray<{author: string; body: string}>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(
+		bodies.map((entry, index) => ({
+			id: index + 1,
+			user: {login: entry.author},
+			created_at: "2026-08-18T00:00:00Z",
+			updated_at: "2026-08-18T00:00:00Z",
+			body: entry.body,
+		})),
+	),
+});
 
 const APPROVED = {
 	author: "founder",
@@ -76,10 +95,10 @@ const APPROVED = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	options: {issue?: number; repo?: string | null; env?: Record<string, string | undefined>} = {},
 ) => {
-	const shell = fakeShell(script);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
 		Effect.provide(
 			runPitchGuard({
@@ -87,9 +106,9 @@ const run = (
 				repo: options.repo ?? null,
 				env: options.env ?? ENV,
 			}),
-			shell.layer,
+			seams.layer,
 		),
-	).then((outcome) => ({outcome, calls: shell.calls}));
+	).then((outcome) => ({outcome, requests: seams.requests}));
 };
 
 describe("runPitchGuard — the backlog sweep", () => {
@@ -98,30 +117,30 @@ describe("runPitchGuard — the backlog sweep", () => {
 			[SWEEP, sweep({number: 11})],
 			[ONE(11), one({number: 11})],
 			[COMMENTS(11), comments(APPROVED)],
-			[PERM("founder"), okOut("admin\n")],
+			[PERM("founder"), permission("admin")],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toContain("scanned 1 lane-entering issue(s)");
 	});
 
 	it("narrows at the endpoint, then re-reads each shortlisted issue for its parent link", async () => {
-		const {calls} = await run([
+		const {requests} = await run([
 			[SWEEP, sweep({number: 11}, {number: 12, labels: ["status:triaged", "type:chore"]})],
 			[ONE(11), one({number: 11})],
 			[COMMENTS(11), comments(APPROVED)],
-			[PERM("founder"), okOut("write\n")],
+			[PERM("founder"), permission("write")],
 		]);
-		expect(calls[0]).toContain("labels=status%3Atriaged");
+		expect(requests[0]).toContain("labels=status%3Atriaged");
 		// The chore is filtered before the single read — a non-bet costs no extra call.
-		expect(calls).not.toContain("gh api repos/o/r/issues/12");
-		expect(calls).toContain("gh api repos/o/r/issues/11");
+		expect(requests).not.toContain("GET https://api.github.com/repos/o/r/issues/12");
+		expect(requests).toContain("GET https://api.github.com/repos/o/r/issues/11");
 	});
 
 	it("holds a sub-issue out of scope — it inherits its epic's pitch", async () => {
 		const {outcome} = await run([
 			[SWEEP, sweep({number: 11})],
 			[ONE(11), one({number: 11, parent: true, body: "no pitch here"})],
-			[COMMENTS(11), okOut("[]")],
+			[COMMENTS(11), EMPTY],
 		]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 	});
@@ -130,7 +149,7 @@ describe("runPitchGuard — the backlog sweep", () => {
 		const {outcome} = await run([
 			[SWEEP, sweep({number: 11})],
 			[ONE(11), one({number: 11, body: "no pitch here"})],
-			[COMMENTS(11), okOut("[]")],
+			[COMMENTS(11), EMPTY],
 		]);
 		expect(outcome.code).toBe(VIOLATION);
 		expect(outcome.stdout).toBe("");
@@ -145,7 +164,7 @@ describe("runPitchGuard — the backlog sweep", () => {
 			[SWEEP, sweep({number: 11})],
 			[ONE(11), one({number: 11})],
 			[COMMENTS(11), comments({author: "drive-by", body: "pitch-approved: appetite 2 cycles"})],
-			[PERM("drive-by"), okOut("read\n")],
+			[PERM("drive-by"), permission("read")],
 		]);
 		expect(outcome.code).toBe(VIOLATION);
 		expect(outcome.stderr.join("\n")).toContain("not from a write+ collaborator");
@@ -156,20 +175,20 @@ describe("runPitchGuard — the backlog sweep", () => {
 			[SWEEP, sweep({number: 11})],
 			[ONE(11), one({number: 11})],
 			[COMMENTS(11), comments(APPROVED)],
-			[PERM("founder"), errOut("gh: Bad gateway (HTTP 502)")],
+			[PERM("founder"), BAD_GATEWAY],
 		]);
 		expect(outcome.code).toBe(VIOLATION);
 		expect(outcome.stderr.join("\n")).toContain("not from a write+ collaborator");
 	});
 
 	it("reds 7 on an empty sweep — a vacuous pass would hide every unpitched bet (ADR 0092)", async () => {
-		const {outcome} = await run([[SWEEP, okOut("[]")]]);
+		const {outcome} = await run([[SWEEP, EMPTY]]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.join("\n")).toContain("ZERO lane-entering issues");
 	});
 
 	it("reds 11 when the board cannot be read — never clean, never a violation", async () => {
-		const {outcome} = await run([[SWEEP, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const {outcome} = await run([[SWEEP, BAD_GATEWAY]]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("UNKNOWN");
 	});
@@ -178,14 +197,14 @@ describe("runPitchGuard — the backlog sweep", () => {
 		const {outcome} = await run([
 			[SWEEP, sweep({number: 11})],
 			[ONE(11), one({number: 11})],
-			[COMMENTS(11), errOut("gh: Bad gateway (HTTP 502)")],
+			[COMMENTS(11), BAD_GATEWAY],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("went unread");
 	});
 
 	it("emits a ::error annotation for every refusal under Actions", async () => {
-		const {outcome} = await run([[SWEEP, okOut("[]")]], {
+		const {outcome} = await run([[SWEEP, EMPTY]], {
 			env: {...ENV, GITHUB_ACTIONS: "true"},
 		});
 		expect(outcome.stderr.some((line) => line.startsWith("::error"))).toBe(true);
@@ -194,38 +213,36 @@ describe("runPitchGuard — the backlog sweep", () => {
 
 describe("runPitchGuard — the --issue seam", () => {
 	it("scans just that issue and reds it when it became pickable unpitched", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests} = await run(
 			[
 				[ONE(9), one({number: 9, body: "no pitch"})],
-				[COMMENTS(9), okOut("[]")],
+				[COMMENTS(9), EMPTY],
 			],
 			{issue: 9},
 		);
 		expect(outcome.code).toBe(VIOLATION);
 		expect(outcome.stderr.join("\n")).toContain("#9 issue 9");
-		expect(calls).not.toContain(
-			"gh api --paginate repos/o/r/issues?state=open&labels=status%3Atriaged&per_page=100",
-		);
+		expect(requests.some((request) => SWEEP.test(request))).toBe(false);
 	});
 
 	it("passes an out-of-scope issue where the scoping labels exist, reading the label set once", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests} = await run(
 			[
 				[ONE(9), one({number: 9, labels: ["status:triaged", "type:chore"]})],
-				[LABELS, okOut("status:triaged\ntype:epic\ntype:feature\n")],
+				[LABELS, labelSet("status:triaged", "type:epic", "type:feature")],
 			],
 			{issue: 9},
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toContain("not lane-entering work");
-		expect(calls.some((call) => call.includes("/labels"))).toBe(true);
+		expect(requests.some((request) => request.includes("/labels"))).toBe(true);
 	});
 
 	it("reds 11 on an out-of-scope issue in a repo missing the scoping labels (#4272)", async () => {
 		const {outcome} = await run(
 			[
 				[ONE(9), one({number: 9, labels: ["status:triaged", "type:chore"]})],
-				[LABELS, okOut("bug\n")],
+				[LABELS, labelSet("bug")],
 			],
 			{issue: 9},
 		);
@@ -234,15 +251,15 @@ describe("runPitchGuard — the --issue seam", () => {
 	});
 
 	it("does not read the label set when the issue IS lane-entering — no ambiguity to resolve", async () => {
-		const {calls} = await run(
+		const {requests} = await run(
 			[
 				[ONE(9), one({number: 9})],
 				[COMMENTS(9), comments(APPROVED)],
-				[PERM("founder"), okOut("maintain\n")],
+				[PERM("founder"), permission("maintain")],
 			],
 			{issue: 9},
 		);
-		expect(calls.some((call) => call.includes("/labels"))).toBe(false);
+		expect(requests.some((request) => request.includes("/labels"))).toBe(false);
 	});
 
 	it("refuses a pull request — a pitch binds at intake and never at merge (#3909)", async () => {
@@ -252,15 +269,17 @@ describe("runPitchGuard — the --issue seam", () => {
 	});
 
 	it("refuses an issue that does not exist rather than passing over an empty scan", async () => {
-		const {outcome} = await run([[ONE(9), errOut("gh: Not Found (HTTP 404)")]], {issue: 9});
+		const {outcome} = await run([[ONE(9), {status: 404, body: '{"message":"Not Found"}'}]], {
+			issue: 9,
+		});
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("does not exist");
 	});
 
 	it("refuses a non-issue-number argument before it reads anything", async () => {
-		const {outcome, calls} = await run([], {issue: 0});
+		const {outcome, requests} = await run([], {issue: 0});
 		expect(outcome.code).toBe(FAILED);
-		expect(calls).toEqual([]);
+		expect(requests).toEqual([]);
 	});
 });
 

--- a/packages/fabrika-cli/src/guard/roadmap-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/roadmap-verb.unit.test.ts
@@ -1,25 +1,33 @@
 /**
- * `guard roadmap-guard check` over a scripted filesystem and a scripted `gh` — the exit taxonomy the
- * port exists for. The v1 original exited `1` for drift, for an unreadable ROADMAP.md and
- * for a `gh` that could not answer; each case below pins one of those onto its own code.
+ * `guard roadmap-guard check` over a scripted filesystem and a scripted GitHub — the exit taxonomy
+ * the port exists for. The v1 original exited `1` for drift, for an unreadable ROADMAP.md and for a
+ * read that could not answer; each case below pins one of those onto its own code.
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {
+	type FakeFsOptions,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import {PRECONDITION_UNKNOWN, VIOLATION, ZERO_SCOPE} from "./codes.ts";
 import {runRoadmapGuard} from "./roadmap-verb.ts";
 
 const ROOT = "/repo";
 const ROADMAP = `${ROOT}/ROADMAP.md`;
-const MILESTONES = /^gh api --paginate repos\/o\/r\/milestones\?state=all/;
+const MILESTONES = /^GET .*\/repos\/o\/r\/milestones\?state=all/;
 
 const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
 
-/** The projection `gh api --jq` prints: `<number>\t<state>\t<title>` rows. */
+/** The milestone list, as the bare JSON array the read validates its shape against. */
 const milestones = (
 	...rows: ReadonlyArray<readonly [number, "open" | "closed", string]>
-): ExecResult => okOut(rows.map(([n, state, title]) => `${n}\t${state}\t${title}`).join("\n"));
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(rows.map(([number, state, title]) => ({number, state, title}))),
+});
 
 const roadmap = (body: string): FakeFsOptions => ({files: {[ROADMAP]: body}});
 
@@ -47,13 +55,13 @@ const PROJECTION = milestones(
 
 const run = (
 	fs: FakeFsOptions,
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	env: Record<string, string | undefined> = ENV,
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runRoadmapGuard({root: ROOT, repo: null, cwd: ROOT, env}),
-			Layer.merge(fakeFs(fs).layer, fakeShell(script).layer),
+			Layer.merge(fakeFs(fs).layer, fakeSeams(script).layer),
 		),
 	);
 
@@ -133,7 +141,7 @@ describe("runRoadmapGuard", () => {
 	});
 
 	it("fails closed when the repo has no milestones at all", async () => {
-		const out = await run(roadmap(IN_SYNC), [[MILESTONES, okOut("")]]);
+		const out = await run(roadmap(IN_SYNC), [[MILESTONES, {status: 200, body: "[]"}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.join("\n")).toContain("0 milestone(s)");
 	});
@@ -154,15 +162,20 @@ describe("runRoadmapGuard", () => {
 	});
 
 	it("seats a failed milestone read on PRECONDITION_UNKNOWN, never on ZERO_SCOPE", async () => {
-		const out = await run(roadmap(IN_SYNC), [[MILESTONES, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run(roadmap(IN_SYNC), [[MILESTONES, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.join("\n")).toContain("Bad gateway");
+		expect(out.stderr.join("\n")).toContain("HTTP 502");
 	});
 
 	// A shape that is not the projection asked for is a failed read, never an empty one — an empty
-	// one would read as ZERO_SCOPE and blame the roadmap for `gh` printing something else.
+	// one would read as ZERO_SCOPE and blame the roadmap for GitHub answering something else.
 	it("seats a malformed projection on PRECONDITION_UNKNOWN", async () => {
-		const out = await run(roadmap(IN_SYNC), [[MILESTONES, okOut("17\tajar\tFour Pillars")]]);
+		const out = await run(roadmap(IN_SYNC), [
+			[
+				MILESTONES,
+				{status: 200, body: JSON.stringify([{number: 17, state: "ajar", title: "Four Pillars"}])},
+			],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.join("\n")).toContain('state is "ajar"');
 	});
@@ -208,7 +221,7 @@ describe("runRoadmapGuard", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRoadmapGuard({root: null, repo: null, cwd: "/nowhere", env: ENV}),
-				Layer.merge(fakeFs({files: {}}).layer, fakeShell([[MILESTONES, PROJECTION]]).layer),
+				Layer.merge(fakeFs({files: {}}).layer, fakeSeams([[MILESTONES, PROJECTION]]).layer),
 			),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);

--- a/packages/fabrika-cli/src/guard/unresolved-threads-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/unresolved-threads-verb.unit.test.ts
@@ -1,34 +1,34 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {comments, ENV, pull, threadPage} from "../ship/fixtures.test-support.ts";
 import {PRECONDITION_UNKNOWN, VIOLATION, ZERO_SCOPE} from "./codes.ts";
 import {runUnresolvedThreadsGuard} from "./unresolved-threads-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
 const GRAPHQL = /^POST https:\/\/api\.github\.com\/graphql$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
-const ACL = /^gh api repos\/o\/r\/collaborators\/[^ ]+\/permission/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4321\/comments/;
+const ACL = /^GET .*\/repos\/o\/r\/collaborators\/[^ /]+\/permission/;
 
-const write = okOut("write\n");
-const readOnly = okOut("read\n");
+/** A fixture's canned JSON, served as the 200 the read now parses. */
+const served = (page: ExecResult): HttpReply => ({status: 200, body: page.stdout});
+
+/** One collaborator's repository permission, in the record the ACL read parses. */
+const permission = (level: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({permission: level}),
+});
+
+const write = permission("write");
+const readOnly = permission("read");
+const BAD_GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 const options = {pr: 4321, repo: null, env: ENV};
 
-/** The one sanctioned GraphQL read, served: `threadPage`'s payload as the endpoint answers it. */
-const served = (page: ExecResult): HttpReply => ({status: 200, body: page.stdout});
-
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(
-			runUnresolvedThreadsGuard({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(http).layer),
-		),
+		Effect.provide(runUnresolvedThreadsGuard({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 const SITE = ".github/workflows/commands-guard.yml:35";
@@ -59,95 +59,78 @@ const PASS_ACCOUNTED = `review-code: PASS @ 4da28749abc0000000000000000000000000
 
 describe("runUnresolvedThreadsGuard", () => {
 	it("REDS the #3329 shape: a live thread the authorized PASS never names", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: PASS_NO_ACCOUNTING, author: "reviewer"})],
-				[ACL, write],
-			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+		const out = await run([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: PASS_NO_ACCOUNTING, author: "reviewer"}))],
+			[ACL, write],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(VIOLATION);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain(SITE);
 	});
 
 	it("passes when the authorized verdict names the site — polarity-blind", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: PASS_ACCOUNTED, author: "reviewer"})],
-				[ACL, write],
-			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+		const out = await run([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: PASS_ACCOUNTED, author: "reviewer"}))],
+			[ACL, write],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("all accounted-for");
 	});
 
 	it("passes on zero review threads without reading the ACL at all", async () => {
-		const shell = fakeShell([
-			[PULL, pull()],
-			[COMMENTS, comments()],
+		const seams = fakeSeams([
+			[PULL, served(pull())],
+			[COMMENTS, served(comments())],
+			[GRAPHQL, served(threadPage(0, []))],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(
-				runUnresolvedThreadsGuard(options),
-				Layer.merge(shell.layer, fakeHttp([[GRAPHQL, served(threadPage(0, []))]]).layer),
-			),
+			Effect.provide(runUnresolvedThreadsGuard(options), seams.layer),
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("no review threads");
-		expect(shell.calls.some((line) => ACL.test(line))).toBe(false);
+		expect(seams.requests.some((line) => ACL.test(line))).toBe(false);
 	});
 
 	it("passes when the only thread is resolved", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
-			],
-			{},
-			[[GRAPHQL, codeqlPage(true)]],
-		);
+		const out = await run([
+			[PULL, served(pull())],
+			[COMMENTS, served(comments())],
+			[GRAPHQL, codeqlPage(true)],
+		]);
 		expect(out.code).toBe(0);
 	});
 
 	it("REDS when the verdict's author holds no write+ permission — a forged marker accounts for nothing", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: PASS_ACCOUNTED, author: "drive-by"})],
-				[ACL, readOnly],
-			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+		const out = await run([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: PASS_ACCOUNTED, author: "drive-by"}))],
+			[ACL, readOnly],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(VIOLATION);
 		expect(out.stderr.join("\n")).toContain("no authorized review-code verdict");
 	});
 
 	it("REDS when the ACL itself is unreadable — the marker is dropped, never trusted", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: PASS_ACCOUNTED, author: "reviewer"})],
-				[ACL, errOut("gh: Bad gateway (HTTP 502)")],
-			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+		const out = await run([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: PASS_ACCOUNTED, author: "reviewer"}))],
+			[ACL, BAD_GATEWAY],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(VIOLATION);
 	});
 
 	it("takes the newest write stamp, so a re-written FAIL outranks an older accounting PASS", async () => {
-		const out = await run(
+		const out = await run([
+			[PULL, served(pull({comments: 2}))],
 			[
-				[PULL, pull({comments: 2})],
-				[
-					COMMENTS,
+				COMMENTS,
+				served(
 					comments(
 						{id: 1, body: PASS_ACCOUNTED, author: "reviewer", updatedAt: "2026-08-08T00:00:00Z"},
 						{
@@ -157,78 +140,74 @@ describe("runUnresolvedThreadsGuard", () => {
 							updatedAt: "2026-08-09T00:00:00Z",
 						},
 					),
-				],
-				[ACL, write],
+				),
 			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+			[ACL, write],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(VIOLATION);
 	});
 
 	it("ignores another gate's verdict — a review-doc PASS accounts for nothing", async () => {
-		const out = await run(
+		const out = await run([
+			[PULL, served(pull({comments: 1}))],
 			[
-				[PULL, pull({comments: 1})],
-				[
-					COMMENTS,
+				COMMENTS,
+				served(
 					comments({
 						id: 1,
 						body: `review-doc: PASS @ 4da28749abc0000000000000000000000000000 — ${SITE} is fine`,
 						author: "reviewer",
 					}),
-				],
-				[ACL, write],
+				),
 			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+			[ACL, write],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(VIOLATION);
 	});
 
 	it("is UNKNOWN, never clean, when the thread read fails", async () => {
-		const out = await run([[PULL, pull()]], {}, [
-			[GRAPHQL, {status: 502, body: '{"message":"Bad gateway"}'}],
+		const out = await run([
+			[PULL, served(pull())],
+			[GRAPHQL, BAD_GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("is UNKNOWN when the thread page arrives short of what it declared", async () => {
-		const out = await run([[PULL, pull()]], {}, [[GRAPHQL, served(threadPage(4, []))]]);
+		const out = await run([
+			[PULL, served(pull())],
+			[GRAPHQL, served(threadPage(4, []))],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.join("\n")).toContain("received 0 of 4");
 	});
 
 	it("is UNKNOWN when the comment read fails — the verdict may be in what never arrived", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
-			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+		const out = await run([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, BAD_GATEWAY],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("is UNKNOWN when the comment sweep is short of the platform's own count", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 5})],
-				[COMMENTS, comments({id: 1, body: PASS_ACCOUNTED, author: "reviewer"})],
-				[ACL, write],
-			],
-			{},
-			[[GRAPHQL, codeqlPage()]],
-		);
+		const out = await run([
+			[PULL, served(pull({comments: 5}))],
+			[COMMENTS, served(comments({id: 1, body: PASS_ACCOUNTED, author: "reviewer"}))],
+			[ACL, write],
+			[GRAPHQL, codeqlPage()],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("is UNKNOWN when the PR read fails, and ZERO SCOPE when the PR is proven absent", async () => {
-		const unreadable = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const unreadable = await run([[PULL, BAD_GATEWAY]]);
 		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);
-		const missing = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const missing = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(missing.code).toBe(ZERO_SCOPE);
 	});
 
@@ -240,12 +219,12 @@ describe("runUnresolvedThreadsGuard", () => {
 	it("emits an ::error annotation at the thread's line under Actions", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: PASS_NO_ACCOUNTING, author: "reviewer"})],
+				[PULL, served(pull({comments: 1}))],
+				[COMMENTS, served(comments({id: 1, body: PASS_NO_ACCOUNTING, author: "reviewer"}))],
 				[ACL, write],
+				[GRAPHQL, codeqlPage()],
 			],
 			{env: {...ENV, GITHUB_ACTIONS: "true"}},
-			[[GRAPHQL, codeqlPage()]],
 		);
 		expect(out.stderr.some((line) => line.startsWith("::error file="))).toBe(true);
 		expect(out.stderr.join("\n")).toContain(

--- a/packages/fabrika-cli/src/handoff/capture-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/handoff/capture-verb.unit.test.ts
@@ -1,10 +1,17 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {runCapture} from "./capture-verb.ts";
 import {NO_TARGET, PRECONDITION_UNKNOWN} from "./codes.ts";
-import {BASE, GROUND, groundScript, ISSUE, REPO} from "./fixtures.test-support.ts";
+import {
+	BASE,
+	GROUND,
+	groundScript,
+	ISSUE,
+	ISSUE_READ,
+	REPO,
+	REPO_READ,
+} from "./fixtures.test-support.ts";
 
 const options = {
 	issue: ISSUE,
@@ -14,10 +21,8 @@ const options = {
 	now: () => new Date("2026-08-09T18:36:48.000Z"),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runCapture({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runCapture({...options, ...over}), fakeSeams(script).layer));
 
 describe("runCapture", () => {
 	it("exits 0 with the whole ground state on stdout", async () => {
@@ -28,14 +33,14 @@ describe("runCapture", () => {
 	});
 
 	it("reports no pull request as the FACT null, not as an absence", async () => {
-		const out = await run([[/pulls\?state=all/, okOut("[]")], ...groundScript()]);
+		const out = await run([[/pulls\?state=all/, {status: 200, body: "[]"}], ...groundScript()]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).board.pull).toBeNull();
 	});
 
 	it("exits 7 on an issue that does not exist", async () => {
 		const out = await run([
-			[new RegExp(`api repos/${REPO}/issues/${ISSUE}$`), errOut("gh: Not Found (HTTP 404)")],
+			[ISSUE_READ, {status: 404, body: '{"message":"Not Found"}'}],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(NO_TARGET);
@@ -53,19 +58,13 @@ describe("runCapture", () => {
 	});
 
 	it("exits 11 when the check-run rollup could not be read — reporting none would claim a read that failed", async () => {
-		const out = await run([
-			[/check-runs/, errOut("gh: Bad gateway (HTTP 502)")],
-			...groundScript(),
-		]);
+		const out = await run([[/check-runs/, {status: 502, body: "{}"}], ...groundScript()]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("exits 11 when the default branch could not be read, rather than guessing one", async () => {
-		const out = await run([
-			[new RegExp(`api repos/${REPO} --jq`), errOut("gh: Bad gateway (HTTP 502)")],
-			...groundScript(),
-		]);
+		const out = await run([[REPO_READ, {status: 502, body: "{}"}], ...groundScript()]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});

--- a/packages/fabrika-cli/src/handoff/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/handoff/claim-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {instant, packNonce} from "../wire/handoff-pack.ts";
 import {runClaim} from "./claim-verb.ts";
 import {
@@ -23,9 +22,9 @@ import {
 } from "./fixtures.test-support.ts";
 import {composeClaimMarker} from "./markers.ts";
 
-const POST = new RegExp(`--method POST repos/${REPO}/issues/${ISSUE}/comments`);
-const GET_COMMENT = /issues\/comments\/\d+/;
-const LIST = new RegExp(`issues/${ISSUE}/comments`);
+const POST = new RegExp(`POST .*/repos/${REPO}/issues/${ISSUE}/comments`);
+const GET_COMMENT = /GET .*\/issues\/comments\/\d+/;
+const LIST = new RegExp(`GET .*/issues/${ISSUE}/comments`);
 const PACK_COMMENT = 9234567891;
 
 const claim = (nonce: string, packComment = PACK_COMMENT): string => {
@@ -43,13 +42,11 @@ const options = {
 	now: () => new Date("2026-08-09T19:02:11.000Z"),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runClaim({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runClaim({...options, ...over}), fakeSeams(script).layer));
 
 const sealed = (comments: ReadonlyArray<{readonly id: number; readonly body: string}>) =>
-	[[LIST, okOut(commentsJson(comments))], ...groundScript()] as const;
+	[[LIST, {status: 200, body: commentsJson(comments)}], ...groundScript()] as const;
 
 describe("runClaim", () => {
 	it("exits 1 on a claim key two runs would collide on", async () => {
@@ -68,8 +65,8 @@ describe("runClaim", () => {
 	it("exits 0 and holds the pack when it is free", async () => {
 		const body = claim(NONCE);
 		const out = await run([
-			[POST, okOut('{"id":9234599999,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			[POST, {status: 201, body: '{"id":9234599999,"html_url":"u"}'}],
+			[GET_COMMENT, {status: 200, body: JSON.stringify({body})}],
 			...sealed([{id: PACK_COMMENT, body: packBody()}]),
 		]);
 		expect(out.code).toBe(0);
@@ -84,16 +81,16 @@ describe("runClaim", () => {
 	});
 
 	it("exits 0 with `resumed` and posts no second comment when this nonce already holds it", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...sealed([
 				{id: PACK_COMMENT, body: packBody()},
 				{id: 9234599999, body: claim(NONCE)},
 			]),
 		]);
-		const out = await Effect.runPromise(Effect.provide(runClaim(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runClaim(options), seams.layer));
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).claim).toBe("resumed");
-		expect(shell.calls.some((line) => /--method POST/.test(line))).toBe(false);
+		expect(seams.requests.filter((line) => line.startsWith("POST"))).toEqual([]);
 	});
 
 	it("exits 15 when another nonce holds the pack", async () => {
@@ -117,14 +114,14 @@ describe("runClaim", () => {
 	});
 
 	it("exits 11 when the comment walk failed — whether a pack is claimed is UNKNOWN, never free", async () => {
-		const out = await run([[LIST, errOut("gh: Bad gateway (HTTP 502)")], ...groundScript()]);
+		const out = await run([[LIST, {status: 502, body: "{}"}], ...groundScript()]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("exits 8 when the claim write failed — whether the claim holds is UNKNOWN", async () => {
 		const out = await run([
-			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			[POST, {status: 502, body: "{}"}],
 			...sealed([{id: PACK_COMMENT, body: packBody()}]),
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
@@ -133,8 +130,8 @@ describe("runClaim", () => {
 
 	it("exits 9 when the posted claim does not read back — the stamp is verified, never assumed", async () => {
 		const out = await run([
-			[POST, okOut('{"id":9234599999,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			[POST, {status: 201, body: '{"id":9234599999,"html_url":"u"}'}],
+			[GET_COMMENT, {status: 200, body: JSON.stringify({body: "something else entirely"})}],
 			...sealed([{id: PACK_COMMENT, body: packBody()}]),
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);

--- a/packages/fabrika-cli/src/handoff/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/handoff/fixtures.test-support.ts
@@ -7,6 +7,7 @@
  * the digest re-check makes that disagreement invisible until a read refuses.
  */
 
+import type {Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {emit, instant, packNonce, groundDigest as toGroundDigest} from "../wire/handoff-pack.ts";
 import {digestOf, type GroundState, renderGround} from "./ground.ts";
@@ -151,16 +152,22 @@ export const checkRunsJson = (conclusion: string): string =>
 
 const okOut = (stdout: string): ExecResult => ({ok: true, stdout, reason: ""});
 
+/** `GET https://api.github.com/repos/o/r`, and nothing under it — the default-branch read. */
+export const REPO_READ = new RegExp(`GET .*/repos/${REPO}$`);
+
+/** `GET https://api.github.com/repos/o/r/issues/5021`, and not its comments. */
+export const ISSUE_READ = new RegExp(`GET .*/repos/${REPO}/issues/${ISSUE}$`);
+
 /**
  * The whole happy-path script: the git reads rows 3-13 rest on, the board reads rows 14-19 rest on,
  * the default-branch read, and the issue itself.
  *
- * Ordered most-specific first, because `fakeShell` resolves a call by the **first** pattern that
- * matches its command line.
+ * Ordered most-specific first, because both fakes resolve a call by the **first** pattern that
+ * matches — the spawned command line for a git row, `METHOD <url>` for a board row.
  */
 export const groundScript = (
 	over: {readonly branch?: string; readonly conclusion?: string} = {},
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+): ReadonlyArray<Scripted> => [
 	[/rev-parse --abbrev-ref --symbolic-full-name/, okOut(`origin/${over.branch ?? BRANCH}`)],
 	[/rev-parse --abbrev-ref HEAD$/, okOut(over.branch ?? BRANCH)],
 	[/rev-parse --verify --quiet main\^/, okOut(BASE_HEAD)],
@@ -169,9 +176,9 @@ export const groundScript = (
 	[/rev-list --left-right --count/, okOut("0\t0")],
 	[/status --porcelain/, okOut("")],
 	[/rev-parse --is-inside-work-tree/, okOut("true")],
-	[/check-runs/, okOut(checkRunsJson(over.conclusion ?? "failure"))],
-	[/pulls\?state=all/, okOut(pullsJson())],
-	[new RegExp(`api repos/${REPO} --jq`), okOut(BASE)],
-	[/collaborators\/.*\/permission/, okOut("write")],
-	[new RegExp(`api repos/${REPO}/issues/${ISSUE}$`), okOut(issueJson())],
+	[/check-runs/, {status: 200, body: checkRunsJson(over.conclusion ?? "failure")}],
+	[/pulls\?state=all/, {status: 200, body: pullsJson()}],
+	[REPO_READ, {status: 200, body: JSON.stringify({default_branch: BASE})}],
+	[/collaborators\/.*\/permission/, {status: 200, body: JSON.stringify({permission: "write"})}],
+	[ISSUE_READ, {status: 200, body: issueJson()}],
 ];

--- a/packages/fabrika-cli/src/handoff/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/handoff/fixtures.test-support.ts
@@ -1,5 +1,5 @@
 /**
- * The one ground state, pack document and `gh api` / `git` script every `handoff` verb test is
+ * The one ground state, pack document and GitHub / `git` script every `handoff` verb test is
  * driven from.
  *
  * Shared so the four verb suites assert against one canonical pack rather than each inventing its

--- a/packages/fabrika-cli/src/handoff/ground.unit.test.ts
+++ b/packages/fabrika-cli/src/handoff/ground.unit.test.ts
@@ -1,8 +1,7 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import {GROUND, groundScript} from "./fixtures.test-support.ts";
 import {
 	COMPARED_FIELDS,
@@ -49,8 +48,8 @@ const WORKED = {
 
 const run = <A>(
 	effect: Effect.Effect<A, never, ChildProcessSpawner.ChildProcessSpawner>,
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-): Promise<A> => Effect.runPromise(Effect.provide(effect, fakeShell(script).layer));
+	script: ReadonlyArray<Scripted>,
+): Promise<A> => Effect.runPromise(Effect.provide(effect, fakeSeams(script).layer));
 
 describe("the digest pre-image", () => {
 	it("is the nineteen fields, in order, as the contract prints them", () => {
@@ -194,11 +193,11 @@ describe("the derivations", () => {
 	it("reports checks as none only over a rollup it read, never over one it could not", async () => {
 		expect(
 			await run(deriveChecks("o/r", "abc"), [
-				[/check-runs/, okOut('{"total_count":0,"check_runs":[]}')],
+				[/check-runs/, {status: 200, body: '{"total_count":0,"check_runs":[]}'}],
 			]),
 		).toMatchObject({value: "none"});
 		expect(
-			await run(deriveChecks("o/r", "abc"), [[/check-runs/, errOut("gh: Bad gateway (HTTP 502)")]]),
+			await run(deriveChecks("o/r", "abc"), [[/check-runs/, {status: 502, body: "{}"}]]),
 		).toMatchObject({_tag: "Failure"});
 	});
 

--- a/packages/fabrika-cli/src/handoff/packs.unit.test.ts
+++ b/packages/fabrika-cli/src/handoff/packs.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {instant, packNonce} from "../wire/handoff-pack.ts";
 import {
 	commentsJson,
@@ -15,8 +14,11 @@ import {
 import {composeClaimMarker} from "./markers.ts";
 import {resolvePack} from "./packs.ts";
 
-const COMMENTS = new RegExp(`issues/${ISSUE}/comments`);
-const PERMISSION = /collaborators\/.*\/permission/;
+const COMMENTS = new RegExp(`GET .*/issues/${ISSUE}/comments`);
+const PERMISSION = /GET .*\/collaborators\/.*\/permission/;
+
+const served = (body: string) => ({status: 200, body});
+const writes = served('{"permission":"write"}');
 
 const claim = (nonce: string, packComment: number): string => {
 	const key = packNonce(nonce);
@@ -25,24 +27,24 @@ const claim = (nonce: string, packComment: number): string => {
 	return composeClaimMarker({nonce: key, packComment, claimedAt: at});
 };
 
-const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
-	Effect.runPromise(Effect.provide(resolvePack(REPO, ISSUE), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>) =>
+	Effect.runPromise(Effect.provide(resolvePack(REPO, ISSUE), fakeSeams(script).layer));
 
 describe("resolvePack", () => {
 	it("answers None over an issue whose comments carry no pack — zero packs is a fact", async () => {
-		const out = await run([[COMMENTS, okOut(commentsJson([{id: 1, body: "picking this up"}]))]]);
+		const out = await run([[COMMENTS, served(commentsJson([{id: 1, body: "picking this up"}]))]]);
 		expect(out).toMatchObject({_tag: "None", comments: 1, disregarded: []});
 	});
 
 	it("answers Unknown when the comment walk could not complete — never None", async () => {
-		const out = await run([[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[COMMENTS, {status: 502, body: "{}"}]]);
 		expect(out).toMatchObject({_tag: "Unknown"});
 	});
 
 	it("honours the latest authorized pack", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[COMMENTS, okOut(commentsJson([{id: 1, body: packBody()}]))],
+			[PERMISSION, writes],
+			[COMMENTS, served(commentsJson([{id: 1, body: packBody()}]))],
 		]);
 		expect(out).toMatchObject({_tag: "Sealed", heldBy: null});
 		if (out._tag !== "Sealed") return;
@@ -52,10 +54,10 @@ describe("resolvePack", () => {
 
 	it("refuses a malformed latest pack rather than reporting no pack over a pack that exists", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
+			[PERMISSION, writes],
 			[
 				COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: packBody()},
 						{id: 2, body: packBody().replace("## Next act", "## Next steps")},
@@ -68,8 +70,8 @@ describe("resolvePack", () => {
 
 	it("refuses a pack whose digest disagrees with the fields it labels", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[COMMENTS, okOut(commentsJson([{id: 1, body: packBody({digest: "aaaaaaaaaaaa"})}]))],
+			[PERMISSION, writes],
+			[COMMENTS, served(commentsJson([{id: 1, body: packBody({digest: "aaaaaaaaaaaa"})}]))],
 		]);
 		expect(out).toMatchObject({_tag: "Malformed", comment: 1});
 		if (out._tag !== "Malformed") return;
@@ -78,11 +80,11 @@ describe("resolvePack", () => {
 
 	it("disregards a pack from an author below write and keeps looking at older ones", async () => {
 		const out = await run([
-			[/collaborators\/stranger\/permission/, okOut("read")],
-			[PERMISSION, okOut("write")],
+			[/GET .*\/collaborators\/stranger\/permission/, served('{"permission":"read"}')],
+			[PERMISSION, writes],
 			[
 				COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: packBody()},
 						{id: 2, body: packBody({unsure: "nothing"}), author: "stranger"},
@@ -98,18 +100,18 @@ describe("resolvePack", () => {
 
 	it("answers Unknown when a permission read failed — a failed lookup is never a grant", async () => {
 		const out = await run([
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
-			[COMMENTS, okOut(commentsJson([{id: 1, body: packBody()}]))],
+			[PERMISSION, {status: 502, body: "{}"}],
+			[COMMENTS, served(commentsJson([{id: 1, body: packBody()}]))],
 		]);
 		expect(out).toMatchObject({_tag: "Unknown"});
 	});
 
 	it("reports the holder of a claim on the honoured pack", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
+			[PERMISSION, writes],
 			[
 				COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: packBody()},
 						{id: 2, body: claim(NONCE, 1)},
@@ -122,10 +124,10 @@ describe("resolvePack", () => {
 
 	it("surfaces a claim on a superseded pack rather than leaving the field empty", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
+			[PERMISSION, writes],
 			[
 				COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: packBody()},
 						{id: 2, body: claim(OTHER_NONCE, 1)},

--- a/packages/fabrika-cli/src/handoff/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/handoff/read-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import {instant, packNonce} from "../wire/handoff-pack.ts";
 import {NO_TARGET, PACK_MALFORMED, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {
@@ -9,6 +8,7 @@ import {
 	GROUND,
 	groundScript,
 	ISSUE,
+	ISSUE_READ,
 	NONCE,
 	packBody,
 	REPO,
@@ -16,7 +16,7 @@ import {
 import {composeClaimMarker} from "./markers.ts";
 import {runRead} from "./read-verb.ts";
 
-const LIST = new RegExp(`issues/${ISSUE}/comments`);
+const LIST = new RegExp(`GET .*/issues/${ISSUE}/comments`);
 
 const claim = (packComment: number): string => {
 	const nonce = packNonce(NONCE);
@@ -27,15 +27,13 @@ const claim = (packComment: number): string => {
 
 const options = {issue: ISSUE, base: null, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}};
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runRead({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runRead({...options, ...over}), fakeSeams(script).layer));
 
 describe("runRead", () => {
 	it("exits 0 with `none` over an issue nobody handed off — the ordinary case", async () => {
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 1, body: "picking this up"}]))],
+			[LIST, {status: 200, body: commentsJson([{id: 1, body: "picking this up"}])}],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(0);
@@ -57,7 +55,7 @@ describe("runRead", () => {
 
 	it("reports drift none when the live ground still matches the packed one", async () => {
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 9234567891, body: packBody()}]))],
+			[LIST, {status: 200, body: commentsJson([{id: 9234567891, body: packBody()}])}],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(0);
@@ -72,7 +70,7 @@ describe("runRead", () => {
 
 	it("re-derives against the PACKED branch, not the successor's HEAD", async () => {
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 1, body: packBody()}]))],
+			[LIST, {status: 200, body: commentsJson([{id: 1, body: packBody()}])}],
 			// A successor sitting on `main`: were the derivation taken from HEAD, ten rows would move.
 			[/rev-parse --abbrev-ref HEAD$/, okOut("main")],
 			...groundScript(),
@@ -83,7 +81,7 @@ describe("runRead", () => {
 	it("reports the moved field, and only that one", async () => {
 		const moved = "7ab3419e0c25d8f6041a2b3c4d5e6f7089abcdef";
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 1, body: packBody()}]))],
+			[LIST, {status: 200, body: commentsJson([{id: 1, body: packBody()}])}],
 			[/rev-parse --verify --quiet main\^/, okOut(GROUND.git.base.head)],
 			[/rev-parse --verify --quiet/, okOut(moved)],
 			...groundScript(),
@@ -97,12 +95,13 @@ describe("runRead", () => {
 		const out = await run([
 			[
 				LIST,
-				okOut(
-					commentsJson([
+				{
+					status: 200,
+					body: commentsJson([
 						{id: 1, body: packBody()},
 						{id: 2, body: claim(1)},
 					]),
-				),
+				},
 			],
 			...groundScript(),
 		]);
@@ -119,7 +118,7 @@ describe("runRead", () => {
 
 	it("reports rows 3-10 as moved with a null live value when the packed branch is gone", async () => {
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 1, body: packBody()}]))],
+			[LIST, {status: 200, body: commentsJson([{id: 1, body: packBody()}])}],
 			[/rev-parse --verify --quiet/, errOut("")],
 			...groundScript(),
 		]);
@@ -131,7 +130,13 @@ describe("runRead", () => {
 
 	it("exits 14 on a malformed latest pack — never `none` over a pack that exists", async () => {
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 77, body: packBody().replace("## Unsure", "## Doubts")}]))],
+			[
+				LIST,
+				{
+					status: 200,
+					body: commentsJson([{id: 77, body: packBody().replace("## Unsure", "## Doubts")}]),
+				},
+			],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(PACK_MALFORMED);
@@ -140,15 +145,15 @@ describe("runRead", () => {
 	});
 
 	it("exits 11 when the comment walk failed — whether a pack exists is UNKNOWN, never none", async () => {
-		const out = await run([[LIST, errOut("gh: Bad gateway (HTTP 502)")], ...groundScript()]);
+		const out = await run([[LIST, {status: 502, body: "{}"}], ...groundScript()]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("exits 11 when the live re-derivation failed — the drift is not reported as unchanged", async () => {
 		const out = await run([
-			[LIST, okOut(commentsJson([{id: 1, body: packBody()}]))],
-			[/pulls\?state=all/, errOut("gh: Bad gateway (HTTP 502)")],
+			[LIST, {status: 200, body: commentsJson([{id: 1, body: packBody()}])}],
+			[/pulls\?state=all/, {status: 502, body: "{}"}],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -157,7 +162,7 @@ describe("runRead", () => {
 
 	it("exits 7 on an issue that does not exist", async () => {
 		const out = await run([
-			[new RegExp(`api repos/${REPO}/issues/${ISSUE}$`), errOut("gh: Not Found (HTTP 404)")],
+			[ISSUE_READ, {status: 404, body: '{"message":"Not Found"}'}],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(NO_TARGET);

--- a/packages/fabrika-cli/src/handoff/take-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/handoff/take-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BAD_SECTIONS,
@@ -20,6 +19,7 @@ import {
 	GROUND,
 	groundScript,
 	ISSUE,
+	ISSUE_READ,
 	NONCE,
 	packBody,
 	REPO,
@@ -27,9 +27,9 @@ import {
 import {digestOf} from "./ground.ts";
 import {runTake} from "./take-verb.ts";
 
-const POST = new RegExp(`--method POST repos/${REPO}/issues/${ISSUE}/comments`);
-const GET_COMMENT = /issues\/comments\/\d+/;
-const LIST = new RegExp(`issues/${ISSUE}/comments`);
+const POST = new RegExp(`POST .*/repos/${REPO}/issues/${ISSUE}/comments`);
+const GET_COMMENT = /GET .*\/issues\/comments\/\d+/;
+const LIST = new RegExp(`GET .*/issues/${ISSUE}/comments`);
 
 const text = (value: string): Effect.Effect<StdinRead> =>
 	Effect.succeed({_tag: "Text", text: value});
@@ -45,19 +45,17 @@ const options = {
 	now: () => new Date("2026-08-09T18:36:48.000Z"),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runTake({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runTake({...options, ...over}), fakeSeams(script).layer));
 
 /** The happy-path script: post, read back the pack this run composes, and one prior-pack-free walk. */
 const sealScript = (
 	readback = packBody(),
 	comments = commentsJson([]),
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[POST, okOut('{"id":9234567891,"html_url":"u"}')],
-	[GET_COMMENT, okOut(JSON.stringify({body: readback}))],
-	[LIST, okOut(comments)],
+): ReadonlyArray<Scripted> => [
+	[POST, {status: 201, body: '{"id":9234567891,"html_url":"u"}'}],
+	[GET_COMMENT, {status: 200, body: JSON.stringify({body: readback})}],
+	[LIST, {status: 200, body: comments}],
 	...groundScript(),
 ];
 
@@ -115,7 +113,7 @@ describe("runTake", () => {
 
 	it("exits 7 on an issue that does not exist", async () => {
 		const out = await run([
-			[new RegExp(`api repos/${REPO}/issues/${ISSUE}$`), errOut("gh: Not Found (HTTP 404)")],
+			[ISSUE_READ, {status: 404, body: '{"message":"Not Found"}'}],
 			...groundScript(),
 		]);
 		expect(out.code).toBe(NO_TARGET);
@@ -183,14 +181,14 @@ describe("runTake", () => {
 	});
 
 	it("exits 8 when the write failed — whether the pack landed is UNKNOWN", async () => {
-		const out = await run([[POST, errOut("gh: Bad gateway (HTTP 502)")], ...sealScript()]);
+		const out = await run([[POST, {status: 502, body: "{}"}], ...sealScript()]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("exits 9 when the posted pack does not read back", async () => {
 		const out = await run([
-			[GET_COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			[GET_COMMENT, {status: 200, body: JSON.stringify({body: "something else entirely"})}],
 			...sealScript(),
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
@@ -218,7 +216,7 @@ describe("runTake", () => {
 	});
 
 	it("exits 11 when the comment walk failed — supersedes is never guessed", async () => {
-		const out = await run([[LIST, errOut("gh: Bad gateway (HTTP 502)")], ...sealScript()]);
+		const out = await run([[LIST, {status: 502, body: "{}"}], ...sealScript()]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});

--- a/packages/fabrika-cli/src/heal-ci/diagnose-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/diagnose-verb.unit.test.ts
@@ -1,50 +1,65 @@
 import {Effect, type FileSystem, Layer, type Path} from "effect";
 import {describe, expect, it} from "vitest";
 import {
-	errOut,
 	fakeFs,
-	fakeHttp,
-	fakeShell,
+	fakeSeams,
 	type HttpReply,
-	okOut,
+	linkNext,
+	type Scripted,
 	unconfigured,
 } from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {runDiagnose} from "./diagnose-verb.ts";
 import {
-	behind,
-	CHECK_RUNS,
-	COMMENTS,
 	COMMIT_DATE,
-	COMMIT_EXISTS,
-	COMPARE,
 	checkRuns,
 	comments,
-	commitDate,
 	ENV,
-	FILES,
 	files,
 	HEAD,
 	httpError,
-	PERMISSION,
 	PROTECTION,
-	PULL,
-	permission,
 	protection,
 	pull,
-	REVIEWS,
 	RULES,
-	RUN_COUNT,
-	reviews,
 	rules,
 	runsTotal,
-	TIMELINE,
-	timeline,
-	unexhaustedPage,
-	WORKFLOWS,
 	workflows,
 } from "./fixtures.test-support.ts";
+
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET .*\/repos\/o\/r\/pulls\/4321\/files\?/;
+const CHECK_RUNS = /^GET .*\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
+const WORKFLOWS = /^GET .*\/repos\/o\/r\/actions\/workflows\?/;
+const RUN_COUNT = /^GET .*\/repos\/o\/r\/actions\/runs\?head_sha=[0-9a-f]+&per_page=1$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4321\/comments\?/;
+const TIMELINE = /^GET .*\/repos\/o\/r\/issues\/4321\/timeline\?/;
+const REVIEWS = /^GET .*\/repos\/o\/r\/pulls\/4321\/reviews\?/;
+const COMPARE = /^GET .*\/repos\/o\/r\/compare\/main\.\.\.[0-9a-f]+$/;
+const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/\S+\/permission$/;
+
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+/** An empty bare-array page — no `Link`, so the walk is proven exhausted. */
+const emptyPage: HttpReply = {status: 200, body: "[]"};
+
+/**
+ * The commit payload, carrying both fields read off it: `commitExists` wants `sha` and
+ * `commitPushedAt` wants the committer date, and the two calls hit the one endpoint.
+ */
+const commit = (at: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({sha: HEAD, commit: {committer: {date: at}}}),
+});
+
+const behind = (by: number): HttpReply => ({status: 200, body: JSON.stringify({behind_by: by})});
+
+const permission = (level: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({permission: level}),
+});
 
 const NOW = Date.parse("2026-08-08T01:00:00Z");
 const PUSHED = "2026-08-08T00:25:00Z";
@@ -62,60 +77,46 @@ const options = {
 	now: NOW,
 };
 
-/** The three reads this verb makes over the HTTP client; cases override the row they are about. */
-const served = (
-	overrides: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-): ReadonlyArray<readonly [RegExp, HttpReply]> => [
+const green = (name = "ci-required") => ({name, status: "completed", conclusion: "success"});
+
+/** The whole happy read set, in the order the verb walks it. Cases override the row they are about. */
+const script = (overrides: ReadonlyArray<Scripted> = []): ReadonlyArray<Scripted> => [
 	...overrides,
-	[COMMIT_DATE, commitDate(PUSHED)],
+	[PULL, reply(pull({updatedAt: PUSHED}))],
+	[FILES, reply(files("apps/web/worker/a.ts", "apps/web/worker/b.ts"))],
+	[CHECK_RUNS, reply(checkRuns(1, [green()]))],
+	[WORKFLOWS, reply(workflows("active"))],
+	[RUN_COUNT, reply(runsTotal(3))],
+	[COMMENTS, reply(comments())],
+	[TIMELINE, emptyPage],
+	[REVIEWS, emptyPage],
+	[COMPARE, behind(0)],
+	[COMMIT_DATE, commit(PUSHED)],
+	[PERMISSION, permission("write")],
 	[RULES, rules("ci-required")],
 	[PROTECTION, protection()],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = served(),
-) =>
+const run = (rows: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runDiagnose({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, unconfigured, fakeHttp(http).layer),
+			Layer.mergeAll(fakeSeams(rows).layer, unconfigured),
 		),
 	);
 
 /** The same run against a repo that declared something — the config arm `unconfigured` cannot reach. */
 const runWith = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	rows: ReadonlyArray<Scripted>,
 	config: Layer.Layer<FileSystem.FileSystem | Path.Path>,
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runDiagnose({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, config, fakeHttp(served()).layer),
+			Layer.mergeAll(fakeSeams(rows).layer, config),
 		),
 	);
-
-const green = (name = "ci-required") => ({name, status: "completed", conclusion: "success"});
-
-/** The whole happy read set, in the order the verb walks it. Cases override the row they are about. */
-const script = (
-	overrides: ReadonlyArray<readonly [RegExp, ExecResult]> = [],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	...overrides,
-	[PULL, pull({updatedAt: PUSHED})],
-	[FILES, files("apps/web/worker/a.ts", "apps/web/worker/b.ts")],
-	[CHECK_RUNS, checkRuns(1, [green()])],
-	[WORKFLOWS, workflows("active")],
-	[RUN_COUNT, runsTotal(3)],
-	[COMMENTS, comments()],
-	[TIMELINE, timeline()],
-	[REVIEWS, reviews()],
-	[COMPARE, behind(0)],
-	[COMMIT_EXISTS, okOut(HEAD)],
-	[PERMISSION, permission("write")],
-];
 
 describe("runDiagnose answers", () => {
 	it("prints the class, the head, the age and every evidence line, always", async () => {
@@ -140,7 +141,7 @@ describe("runDiagnose answers", () => {
 			script([
 				[
 					CHECK_RUNS,
-					checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "failure"}]),
+					reply(checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "failure"}])),
 				],
 			]),
 		);
@@ -153,11 +154,10 @@ describe("runDiagnose answers", () => {
 			script([
 				[
 					CHECK_RUNS,
-					checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "failure"}]),
+					reply(checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "failure"}])),
 				],
+				[RULES, rules("ci-required", "code-scanning/codeql")],
 			]),
-			{},
-			served([[RULES, rules("ci-required", "code-scanning/codeql")]]),
 		);
 		expect(out.stdout.split("\n")[0]).toBe(`stall\tcheck-surface\t${HEAD}\t35`);
 	});
@@ -167,18 +167,17 @@ describe("runDiagnose answers", () => {
 			script([
 				[
 					CHECK_RUNS,
-					checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "failure"}]),
+					reply(checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "failure"}])),
 				],
+				[RULES, httpError(403, "Must have admin rights")],
 			]),
-			{},
-			served([[RULES, httpError(403, "Must have admin rights")]]),
 		);
 		expect(out.stdout.split("\n")[0]).toBe(`stall\tred\t${HEAD}\t35`);
 		expect(out.stderr.join("\n")).toContain("UNPROBEABLE");
 	});
 
 	it("declares arm 6's unimplemented half on stderr rather than letting the class read whole", async () => {
-		const out = await run(script([[PULL, pull({assignees: ["usirin"]})]]));
+		const out = await run(script([[PULL, reply(pull({assignees: ["usirin"]}))]]));
 		expect(out.code).toBe(0);
 		expect(out.stderr.join("\n")).toContain("UNIMPLEMENTED");
 		expect(out.stderr.join("\n")).toContain("derived from reviews alone");
@@ -186,21 +185,21 @@ describe("runDiagnose answers", () => {
 
 	it("reads an assignee whose activity is inside the dwell as attended, not as a strand", async () => {
 		const out = await run(
-			script([[PULL, pull({assignees: ["usirin"], updatedAt: "2026-08-08T00:55:00Z"})]]),
+			script([[PULL, reply(pull({assignees: ["usirin"], updatedAt: "2026-08-08T00:55:00Z"}))]]),
 		);
 		expect(out.stdout.split("\n")[0]).toBe(`stall\tattended\t${HEAD}\t5`);
 	});
 
 	it("reads an assignee gone quiet past the dwell as claim-stale, naming why", async () => {
 		const out = await run(
-			script([[PULL, pull({assignees: ["usirin"], updatedAt: "2026-08-07T20:00:00Z"})]]),
+			script([[PULL, reply(pull({assignees: ["usirin"], updatedAt: "2026-08-07T20:00:00Z"}))]]),
 		);
 		expect(out.stdout.split("\n")[0]).toContain("claim-stale");
 		expect(out.stderr.join("\n")).toContain("claim-stale fired on inactivity");
 	});
 
 	it("reads a draft as not-open — an answer, not a refusal", async () => {
-		const out = await run(script([[PULL, pull({draft: true, updatedAt: PUSHED})]]));
+		const out = await run(script([[PULL, reply(pull({draft: true, updatedAt: PUSHED}))]]));
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toContain("not-open");
 	});
@@ -208,16 +207,16 @@ describe("runDiagnose answers", () => {
 	it("keeps the two zero-signal CI tokens apart", async () => {
 		const noRuns = await run(
 			script([
-				[CHECK_RUNS, checkRuns(0, [])],
-				[RUN_COUNT, runsTotal(0)],
+				[CHECK_RUNS, reply(checkRuns(0, []))],
+				[RUN_COUNT, reply(runsTotal(0))],
 			]),
 		);
 		expect(noRuns.stdout).toContain("ci\tno-runs\t0");
 		const noCi = await runWith(
 			script([
-				[CHECK_RUNS, checkRuns(0, [])],
-				[WORKFLOWS, workflows()],
-				[RUN_COUNT, runsTotal(0)],
+				[CHECK_RUNS, reply(checkRuns(0, []))],
+				[WORKFLOWS, reply(workflows())],
+				[RUN_COUNT, reply(runsTotal(0))],
 			]),
 			fakeFs({files: {"/repo/.fabrika.jsonc": '{"ci": {"noProducer": "degrade"}}'}}).layer,
 		);
@@ -230,9 +229,9 @@ describe("runDiagnose answers", () => {
 	it("refuses zero workflows rather than reading `none` off a repo that declared nothing", async () => {
 		const out = await run(
 			script([
-				[CHECK_RUNS, checkRuns(0, [])],
-				[WORKFLOWS, workflows()],
-				[RUN_COUNT, runsTotal(0)],
+				[CHECK_RUNS, reply(checkRuns(0, []))],
+				[WORKFLOWS, reply(workflows())],
+				[RUN_COUNT, reply(runsTotal(0))],
 			]),
 		);
 		expect(out.code).toBe(ZERO_SCOPE);
@@ -243,9 +242,9 @@ describe("runDiagnose answers", () => {
 	it("refuses zero workflows as UNKNOWN when the config itself could not be decoded", async () => {
 		const out = await runWith(
 			script([
-				[CHECK_RUNS, checkRuns(0, [])],
-				[WORKFLOWS, workflows()],
-				[RUN_COUNT, runsTotal(0)],
+				[CHECK_RUNS, reply(checkRuns(0, []))],
+				[WORKFLOWS, reply(workflows())],
+				[RUN_COUNT, reply(runsTotal(0))],
 			]),
 			fakeFs({files: {"/repo/.fabrika.jsonc": '{"ci": {"noProducer": "maybe"}}'}}).layer,
 		);
@@ -257,7 +256,7 @@ describe("runDiagnose answers", () => {
 
 describe("runDiagnose refuses rather than guessing a class", () => {
 	it("refuses an unreadable check-run read on 11 — never `attended`", async () => {
-		const out = await run(script([[CHECK_RUNS, errOut("gh: Bad gateway (HTTP 502)")]]));
+		const out = await run(script([[CHECK_RUNS, httpError(502, "Bad gateway")]]));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "attended"');
@@ -266,8 +265,8 @@ describe("runDiagnose refuses rather than guessing a class", () => {
 	it("refuses a short comment enumeration on 13", async () => {
 		const out = await run(
 			script([
-				[PULL, pull({comments: 9, updatedAt: PUSHED})],
-				[COMMENTS, comments()],
+				[PULL, reply(pull({comments: 9, updatedAt: PUSHED}))],
+				[COMMENTS, reply(comments())],
 			]),
 		);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
@@ -275,19 +274,21 @@ describe("runDiagnose refuses rather than guessing a class", () => {
 	});
 
 	it("refuses an unexhausted timeline read on 13 — a queue entry could sit on an unread page", async () => {
-		const out = await run(script([[TIMELINE, unexhaustedPage()]]));
+		const out = await run(
+			script([[TIMELINE, {...emptyPage, headers: linkNext("https://api.github.com/next")}]]),
+		);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stderr.at(-1)).toContain("never reached a terminal page");
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run(script([[PULL, errOut("gh: Not Found (HTTP 404)")]]));
+		const out = await run(script([[PULL, httpError(404, "Not Found")]]));
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("heal-ci diagnose: PR #4321 not found in o/r.");
 	});
 
 	it("refuses a --sha this PR never had on 7", async () => {
-		const out = await run(script([[COMMIT_EXISTS, errOut("gh: Not Found (HTTP 404)")]]), {
+		const out = await run(script([[COMMIT_DATE, httpError(404, "Not Found")]]), {
 			sha: "deadbee",
 		});
 		expect(out.code).toBe(ZERO_SCOPE);
@@ -303,9 +304,12 @@ describe("runDiagnose refuses rather than guessing a class", () => {
 	it("refuses an unreadable ACL on 11 rather than dropping the verdict it gates", async () => {
 		const out = await run(
 			script([
-				[PULL, pull({comments: 1, updatedAt: PUSHED})],
-				[COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — the ACs are met.`})],
-				[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+				[PULL, reply(pull({comments: 1, updatedAt: PUSHED}))],
+				[
+					COMMENTS,
+					reply(comments({id: 1, body: `review-code: PASS @ ${HEAD} — the ACs are met.`})),
+				],
+				[PERMISSION, httpError(502, "Bad gateway")],
 			]),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);

--- a/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
@@ -16,28 +16,12 @@ export {
 	comments,
 	ENV,
 	HEAD,
-	httpPage,
 	OTHER_HEAD,
 	pull,
-	reviews,
 	runsTotal,
-	timeline,
-	unexhaustedPage,
 	workflows,
 } from "../ship/fixtures.test-support.ts";
 
-export const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-export const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-export const COMMIT_EXISTS = /^gh api repos\/o\/r\/commits\/[0-9a-f]+ --jq \.sha$/;
-export const CHECK_RUNS = /^gh api --paginate repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
-export const WORKFLOWS = /^gh api --paginate repos\/o\/r\/actions\/workflows/;
-export const RUN_COUNT = /^gh api repos\/o\/r\/actions\/runs\?head_sha=[0-9a-f]+&per_page=1$/;
-export const RUNS_AT_HEAD = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
-export const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
-export const TIMELINE = /^gh api -i repos\/o\/r\/issues\/4321\/timeline/;
-export const REVIEWS = /^gh api -i repos\/o\/r\/pulls\/4321\/reviews/;
-export const COMPARE = /^gh api repos\/o\/r\/compare\/main\.\.\.[0-9a-f]+ --jq \.behind_by$/;
-export const PERMISSION = /^gh api repos\/o\/r\/collaborators\/\S+\/permission/;
 /**
  * The nine reads this group makes over the HTTP client, matched on `METHOD url` (ADR 0315).
  *
@@ -56,18 +40,9 @@ export const RATE_LIMIT = new RegExp(`^GET ${API}\\/rate_limit$`);
 export const RULES = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/rules\\/branches\\/main\\?`);
 export const PROTECTION = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/branches\\/main\\/protection$`);
 export const COMMIT_DATE = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/commits\\/[0-9a-f]+$`);
-export const CREATE_COMMENT = /^gh api --method POST repos\/o\/r\/issues\/\d+\/comments/;
-export const READ_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
-
-/** A `--paginate` bare-array page — the shape `pagedJson` walks. */
-export const jsonArray = (value: unknown): ExecResult => okOut(JSON.stringify(value));
 
 export const files = (...names: ReadonlyArray<string>): ExecResult =>
 	okOut(JSON.stringify(names.map((filename) => ({filename}))));
-
-export const behind = (by: number): ExecResult => okOut(String(by));
-
-export const permission = (level: string): ExecResult => okOut(level);
 
 /** A terminal page: 200 with no `rel="next"`, which is what the exhaustion proof reads. */
 const served = (body: unknown, status = 200): HttpReply => ({

--- a/packages/fabrika-cli/src/heal-ci/logs-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/logs-verb.unit.test.ts
@@ -1,10 +1,9 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, LOGS_EXPIRED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
-	CHECK_RUNS,
 	checkRuns,
 	ENV,
 	HEAD,
@@ -12,12 +11,17 @@ import {
 	JOB_LOG,
 	JOBS,
 	jobs,
-	PULL,
 	pull,
-	RUNS_AT_HEAD,
 	runsAtHead,
 } from "./fixtures.test-support.ts";
 import {runLogs, tailBytes} from "./logs-verb.ts";
+
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const CHECK_RUNS = /^GET .*\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
+const RUNS_AT_HEAD = /^GET .*\/repos\/o\/r\/actions\/runs\?head_sha=/;
+
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
 
 const options = {
 	pr: 4321,
@@ -29,17 +33,8 @@ const options = {
 	env: ENV,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(
-		Effect.provide(
-			runLogs({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(served).layer),
-		),
-	);
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runLogs({...options, ...overrides}), fakeSeams(script).layer));
 
 /** A served log body: the bytes GitHub's signed URL answers with, not JSON. */
 const logText = (text: string): HttpReply => ({status: 200, body: text});
@@ -59,23 +54,22 @@ describe("tailBytes", () => {
 
 describe("runLogs reads every failing gating context, not the first", () => {
 	it("frames one block per failing context with its job, bytes and truncation", async () => {
-		const out = await run(
+		const out = await run([
+			[PULL, reply(pull())],
 			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(3, [failed("unit tests"), failed("typecheck"), passed("lint")])],
-				[RUNS_AT_HEAD, runsAtHead(1, [{id: 77}])],
+				CHECK_RUNS,
+				reply(checkRuns(3, [failed("unit tests"), failed("typecheck"), passed("lint")])),
 			],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
 			[
-				[
-					JOBS,
-					jobs(2, [
-						{id: 441, name: "unit tests"},
-						{id: 442, name: "typecheck"},
-					]),
-				],
-				[JOB_LOG, logText("AssertionError: expected 3 to be 2")],
+				JOBS,
+				jobs(2, [
+					{id: 441, name: "unit tests"},
+					{id: 442, name: "typecheck"},
+				]),
 			],
-		);
+			[JOB_LOG, logText("AssertionError: expected 3 to be 2")],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe(`logs\t2\t${HEAD}`);
 		expect(out.stdout).toContain("==== context unit tests job 441 bytes 34 truncated false ====");
@@ -84,9 +78,9 @@ describe("runLogs reads every failing gating context, not the first", () => {
 
 	it("answers `logs 0` when nothing gating is failing — a proven answer, not a refusal", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CHECK_RUNS, checkRuns(1, [passed("ci-required")])],
-			[RUNS_AT_HEAD, runsAtHead(0, [])],
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [passed("ci-required")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(0, []))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`logs\t0\t${HEAD}\n`);
@@ -94,25 +88,21 @@ describe("runLogs reads every failing gating context, not the first", () => {
 
 	it("excludes an informational context before anything is fetched (ADR 0061)", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CHECK_RUNS, checkRuns(1, [failed("deploy (web)")])],
-			[RUNS_AT_HEAD, runsAtHead(0, [])],
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [failed("deploy (web)")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(0, []))],
 		]);
 		expect(out.stdout).toBe(`logs\t0\t${HEAD}\n`);
 	});
 
 	it("emits a context with no workflow job behind it rather than failing the whole read", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(2, [failed("external scan"), failed("unit tests")])],
-				[RUNS_AT_HEAD, runsAtHead(1, [{id: 77}])],
-			],
-			[
-				[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
-				[JOB_LOG, logText("AssertionError")],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(2, [failed("external scan"), failed("unit tests")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
+			[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
+			[JOB_LOG, logText("AssertionError")],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe(`logs\t2\t${HEAD}`);
 		expect(out.stdout).toContain("==== context external scan job - bytes 0 truncated false ====");
@@ -122,11 +112,9 @@ describe("runLogs reads every failing gating context, not the first", () => {
 	it("declares truncation rather than letting a bounded log read as complete", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [failed("unit tests")])],
-				[RUNS_AT_HEAD, runsAtHead(1, [{id: 77}])],
-			],
-			[
+				[PULL, reply(pull())],
+				[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
+				[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
 				[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
 				[JOB_LOG, logText("0123456789")],
 			],
@@ -139,65 +127,54 @@ describe("runLogs reads every failing gating context, not the first", () => {
 
 describe("runLogs refuses rather than answering `no failed steps`", () => {
 	it("refuses expired logs on 15 — a fact about the run, not a failed read", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [failed("unit tests")])],
-				[RUNS_AT_HEAD, runsAtHead(1, [{id: 77}])],
-			],
-			[
-				[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
-				[JOB_LOG, httpError(410, "Gone")],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
+			[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
+			[JOB_LOG, httpError(410, "Gone")],
+		]);
 		expect(out.code).toBe(LOGS_EXPIRED);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses a purged log on 15 when the platform answers 404 rather than 410", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [failed("unit tests")])],
-				[RUNS_AT_HEAD, runsAtHead(1, [{id: 77}])],
-			],
-			[
-				[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
-				[JOB_LOG, httpError(404, "Not Found")],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
+			[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
+			[JOB_LOG, httpError(404, "Not Found")],
+		]);
 		expect(out.code).toBe(LOGS_EXPIRED);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses an unreadable check-run read on 11", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CHECK_RUNS, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, reply(pull())],
+			[CHECK_RUNS, httpError(502, "Bad gateway")],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "no failed steps"');
 	});
 
 	it("refuses a short job enumeration on 13", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [failed("unit tests")])],
-				[RUNS_AT_HEAD, runsAtHead(1, [{id: 77}])],
-			],
-			[[JOBS, jobs(9, [{id: 441, name: "unit tests"}])]],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
+			[JOBS, jobs(9, [{id: 441, name: "unit tests"}])],
+		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
 	it("refuses a --context naming no failing gating context on 7, listing the ones there are", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [failed("unit tests")])],
+				[PULL, reply(pull())],
+				[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
 			],
-			[],
 			{context: "typecheck"},
 		);
 		expect(out.code).toBe(ZERO_SCOPE);

--- a/packages/fabrika-cli/src/heal-ci/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/note-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
@@ -11,36 +11,32 @@ import {
 	WRITE_UNKNOWN,
 	ZERO_SCOPE,
 } from "./codes.ts";
-import {
-	CREATE_COMMENT,
-	commentBody,
-	createdComment,
-	ENV,
-	PULL,
-	pull,
-	READ_COMMENT,
-} from "./fixtures.test-support.ts";
+import {commentBody, createdComment, ENV, pull} from "./fixtures.test-support.ts";
 import {runNote} from "./note-verb.ts";
 
 const BODY = "heal-ci: ROUTED — PR #4321 → ship\n\nGate satisfied, CI green, nobody holding it.\n";
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	read: StdinRead = {_tag: "Text", text: BODY},
-) =>
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const CREATE_COMMENT = /^POST .*\/repos\/o\/r\/issues\/\d+\/comments$/;
+const READ_COMMENT = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+const run = (script: ReadonlyArray<Scripted>, read: StdinRead = {_tag: "Text", text: BODY}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runNote({pr: 4321, repo: null, json: false, env: ENV, stdin: Effect.succeed(read)}),
-			fakeShell(script).layer,
+			fakeSeams(script).layer,
 		),
 	);
 
 describe("runNote leaves the durable record", () => {
 	it("posts a NEW comment and prints its url", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CREATE_COMMENT, createdComment(5155001122)],
-			[READ_COMMENT, commentBody(BODY)],
+			[PULL, reply(pull())],
+			[CREATE_COMMENT, reply(createdComment(5155001122), 201)],
+			[READ_COMMENT, reply(commentBody(BODY))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("noted\thttps://example.test/pull/4321#issuecomment-5155001122\n");
@@ -48,9 +44,9 @@ describe("runNote leaves the durable record", () => {
 
 	it("posts on a closed PR — a strand that resolved still deserves the record", async () => {
 		const out = await run([
-			[PULL, pull({state: "closed"})],
-			[CREATE_COMMENT, createdComment(1)],
-			[READ_COMMENT, commentBody(BODY)],
+			[PULL, reply(pull({state: "closed"}))],
+			[CREATE_COMMENT, reply(createdComment(1), 201)],
+			[READ_COMMENT, reply(commentBody(BODY))],
 		]);
 		expect(out.code).toBe(0);
 	});
@@ -58,13 +54,13 @@ describe("runNote leaves the durable record", () => {
 
 describe("runNote refuses before it writes", () => {
 	it("refuses empty stdin on 3 — a silent classification leaves the strand invisible", async () => {
-		const out = await run([[PULL, pull()]], {_tag: "Text", text: "  \n"});
+		const out = await run([[PULL, reply(pull())]], {_tag: "Text", text: "  \n"});
 		expect(out.code).toBe(EMPTY_STDIN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses a body carrying a machine-local path on 5", async () => {
-		const out = await run([[PULL, pull()]], {
+		const out = await run([[PULL, reply(pull())]], {
 			_tag: "Text",
 			text: "see ~/code/github.com/kamp-us/phoenix/x.ts\n",
 		});
@@ -72,19 +68,19 @@ describe("runNote refuses before it writes", () => {
 	});
 
 	it("refuses a bare @ path reference on 6 — not redactable", async () => {
-		const out = await run([[PULL, pull()]], {_tag: "Text", text: "@/tmp/note.md"});
+		const out = await run([[PULL, reply(pull())]], {_tag: "Text", text: "@/tmp/note.md"});
 		expect(out.code).toBe(BARE_AT_PATH);
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 
 	it("reports a failed create as UNKNOWN on 8, never as a landed note", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CREATE_COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, reply(pull())],
+			[CREATE_COMMENT, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("UNKNOWN whether the note landed");
@@ -92,9 +88,9 @@ describe("runNote refuses before it writes", () => {
 
 	it("reports a mismatched read-back on 9", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CREATE_COMMENT, createdComment(7)],
-			[READ_COMMENT, commentBody("something else")],
+			[PULL, reply(pull())],
+			[CREATE_COMMENT, reply(createdComment(7), 201)],
+			[READ_COMMENT, reply(commentBody("something else"))],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 	});

--- a/packages/fabrika-cli/src/heal-ci/rerun-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/rerun-verb.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, once} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -14,8 +14,6 @@ import {
 } from "./codes.ts";
 import {
 	accepted,
-	COMMENTS,
-	CREATE_COMMENT,
 	commentBody,
 	comments,
 	createdComment,
@@ -23,15 +21,21 @@ import {
 	HEAD,
 	httpError,
 	OTHER_HEAD,
-	PULL,
 	pull,
-	READ_COMMENT,
 	RERUN,
 	RUN,
 	workflowRun,
 } from "./fixtures.test-support.ts";
 import {renderMarker} from "./marker.ts";
 import {runRerun} from "./rerun-verb.ts";
+
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4321\/comments\?/;
+const CREATE_COMMENT = /^POST .*\/repos\/o\/r\/issues\/\d+\/comments$/;
+const READ_COMMENT = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
 
 const RUN_ID = 9182736450;
 const MARKER = renderMarker({head: HEAD, run: RUN_ID, signature: "preview-warmup"});
@@ -46,27 +50,15 @@ const options = {
 	env: ENV,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(
-		Effect.provide(
-			runRerun({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(served).layer),
-		),
-	);
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runRerun({...options, ...overrides}), fakeSeams(script).layer));
 
 /** The whole happy path: failed run at attempt 1, no marker, a new attempt, a matching read-back. */
-const happyShell = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull()],
-	[COMMENTS, comments()],
-	[CREATE_COMMENT, createdComment(5155001122)],
-	[READ_COMMENT, commentBody(MARKER)],
-];
-
-const happyHttp = (): ReadonlyArray<readonly [RegExp, HttpReply]> => [
+const happy = (): ReadonlyArray<Scripted> => [
+	[PULL, reply(pull())],
+	[COMMENTS, reply(comments())],
+	[CREATE_COMMENT, reply(createdComment(5155001122), 201)],
+	[READ_COMMENT, reply(commentBody(MARKER))],
 	[once(RUN), workflowRun({attempt: 1})],
 	[RERUN, accepted],
 	[RUN, workflowRun({attempt: 2})],
@@ -74,7 +66,7 @@ const happyHttp = (): ReadonlyArray<readonly [RegExp, HttpReply]> => [
 
 describe("runRerun spends the one rerun and records it", () => {
 	it("prints the attempt READ BACK, never the one the caller held", async () => {
-		const out = await run(happyShell(), happyHttp());
+		const out = await run(happy());
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
 			`rerun\t2\t${RUN_ID}\thttps://example.test/pull/4321#issuecomment-5155001122\n`,
@@ -84,123 +76,115 @@ describe("runRerun spends the one rerun and records it", () => {
 
 describe("the guard lives in the verb, and trusts nothing it was told", () => {
 	it("refuses a head that moved past --sha on 12", async () => {
-		const out = await run([[PULL, pull({head: OTHER_HEAD})]]);
+		const out = await run([[PULL, reply(pull({head: OTHER_HEAD}))]]);
 		expect(out.code).toBe(STALE_HEAD);
 		expect(out.stderr.at(-1)).toContain("refusing to rerun against a tree nobody classified");
 	});
 
 	it("refuses a run that did not fail on 14 — nothing was mutated", async () => {
-		const out = await run([[PULL, pull()]], [[RUN, workflowRun({conclusion: "success"})]]);
+		const out = await run([
+			[PULL, reply(pull())],
+			[RUN, workflowRun({conclusion: "success"})],
+		]);
 		expect(out.code).toBe(PROVEN_NOT_IN_STATE);
 		expect(out.stderr.at(-1)).toContain("refusing to rerun a run that did not fail");
 	});
 
 	it("refuses a head already rerun by run_attempt on 14", async () => {
-		const out = await run([[PULL, pull()]], [[RUN, workflowRun({attempt: 2})]]);
+		const out = await run([
+			[PULL, reply(pull())],
+			[RUN, workflowRun({attempt: 2})],
+		]);
 		expect(out.code).toBe(PROVEN_NOT_IN_STATE);
 		expect(out.stderr.at(-1)).toContain("a second rerun is escalation, not retry");
 	});
 
 	it("refuses a head already rerun by a bound marker on 14 — the other independent signal", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 91, body: MARKER})],
-			],
-			[[RUN, workflowRun({attempt: 1})]],
-		);
+		const out = await run([
+			[PULL, reply(pull({comments: 1}))],
+			[COMMENTS, reply(comments({id: 91, body: MARKER}))],
+			[RUN, workflowRun({attempt: 1})],
+		]);
 		expect(out.code).toBe(PROVEN_NOT_IN_STATE);
 		expect(out.stderr.at(-1)).toContain("marker 91");
 	});
 
 	it("refuses a closed PR on 14", async () => {
-		const out = await run([[PULL, pull({state: "closed"})]]);
+		const out = await run([[PULL, reply(pull({state: "closed"}))]]);
 		expect(out.code).toBe(PROVEN_NOT_IN_STATE);
 	});
 
 	it("refuses a truncated marker read on 13 — an unexhausted read licenses no rerun", async () => {
-		const out = await run(
-			[
-				[PULL, pull({comments: 40})],
-				[COMMENTS, comments()],
-			],
-			[[RUN, workflowRun({attempt: 1})]],
-		);
+		const out = await run([
+			[PULL, reply(pull({comments: 40}))],
+			[COMMENTS, reply(comments())],
+			[RUN, workflowRun({attempt: 1})],
+		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
 	it("refuses an off-vocabulary --signature on 10 before any read", async () => {
-		const out = await run([], [], {signature: "flaky"});
+		const out = await run([], {signature: "flaky"});
 		expect(out.code).toBe(OFF_VOCABULARY);
 	});
 
 	it("refuses a run proven absent on 7", async () => {
-		const out = await run([[PULL, pull()]], [[RUN, httpError(404, "Not Found")]]);
+		const out = await run([
+			[PULL, reply(pull())],
+			[RUN, httpError(404, "Not Found")],
+		]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 });
 
 describe("the marker is written only once a new attempt is confirmed", () => {
 	it("refuses a 2xx that materialised no new attempt on 8, writing NO marker", async () => {
-		const shell = fakeShell([
-			[PULL, pull()],
-			[COMMENTS, comments()],
+		const seams = fakeSeams([
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments())],
+			[RUN, workflowRun({attempt: 1})],
+			[RERUN, accepted],
 		]);
-		const out = await Effect.runPromise(
-			Effect.provide(
-				runRerun(options),
-				Layer.merge(
-					shell.layer,
-					fakeHttp([
-						[RUN, workflowRun({attempt: 1})],
-						[RERUN, accepted],
-					]).layer,
-				),
-			),
-		);
+		const out = await Effect.runPromise(Effect.provide(runRerun(options), seams.layer));
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("no marker written");
-		expect(shell.calls.some((call) => call.includes("issues/4321/comments -f"))).toBe(false);
+		expect(seams.requests.filter((request) => CREATE_COMMENT.test(request))).toEqual([]);
 	});
 
 	it("refuses a failed rerun request on 8 with nothing written", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
-			],
-			[
-				[RUN, workflowRun({attempt: 1})],
-				[RERUN, httpError(502, "Bad gateway")],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments())],
+			[RUN, workflowRun({attempt: 1})],
+			[RERUN, httpError(502, "Bad gateway")],
+		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("no new attempt, no marker written");
 	});
 
 	it("reports a landed rerun whose marker could not be written on 16, not on 8", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
-				[CREATE_COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
-			],
-			happyHttp(),
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments())],
+			[CREATE_COMMENT, httpError(502, "Bad gateway")],
+			[once(RUN), workflowRun({attempt: 1})],
+			[RERUN, accepted],
+			[RUN, workflowRun({attempt: 2})],
+		]);
 		expect(out.code).toBe(RERUN_UNRECORDED);
 		expect(out.stderr.at(-1)).toContain("rerun and UNRECORDED");
 	});
 
 	it("reports a marker whose read-back does not match on 9", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
-				[CREATE_COMMENT, createdComment(77)],
-				[READ_COMMENT, commentBody("something else entirely")],
-			],
-			happyHttp(),
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments())],
+			[CREATE_COMMENT, reply(createdComment(77), 201)],
+			[READ_COMMENT, reply(commentBody("something else entirely"))],
+			[once(RUN), workflowRun({attempt: 1})],
+			[RERUN, accepted],
+			[RUN, workflowRun({attempt: 2})],
+		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("the rerun is real, the record is not");
 	});

--- a/packages/fabrika-cli/src/heal-ci/surface-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/surface-verb.unit.test.ts
@@ -1,16 +1,14 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, type HttpReply, linkNext} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, linkNext, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {
-	CHECK_RUNS,
 	checkRuns,
 	ENV,
 	HEAD,
 	httpError,
 	PROTECTION,
-	PULL,
 	protection,
 	pull,
 	RULES,
@@ -18,34 +16,29 @@ import {
 } from "./fixtures.test-support.ts";
 import {runSurface} from "./surface-verb.ts";
 
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const CHECK_RUNS = /^GET .*\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
+
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
 const options = {pr: 4321, sha: "", repo: null, json: false, env: ENV};
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(
-			runSurface({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(served).layer),
-		),
+		Effect.provide(runSurface({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 const completed = (name: string) => ({name, status: "completed", conclusion: "success"});
 
 describe("runSurface compares the two sides and judges neither", () => {
 	it("names an armed context nothing produces as the gap it is", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(2, [completed("ci-required"), completed("unit tests")])],
-			],
-			[
-				[RULES, rules("ci-required", "code-scanning/codeql")],
-				[PROTECTION, protection()],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(2, [completed("ci-required"), completed("unit tests")]))],
+			[RULES, rules("ci-required", "code-scanning/codeql")],
+			[PROTECTION, protection()],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
 			[
@@ -60,30 +53,22 @@ describe("runSurface compares the two sides and judges neither", () => {
 	});
 
 	it("answers covered when every declared context has a producing run", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [completed("ci-required")])],
-			],
-			[
-				[RULES, rules("ci-required")],
-				[PROTECTION, protection()],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [completed("ci-required")]))],
+			[RULES, rules("ci-required")],
+			[PROTECTION, protection()],
+		]);
 		expect(out.stdout.split("\n")[0]).toBe(`surface\tcovered\t${HEAD}`);
 	});
 
 	it("answers no-requirements only on a SUCCESSFUL rules read plus the protection 404", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [completed("unit tests")])],
-			],
-			[
-				[RULES, rules()],
-				[PROTECTION, httpError(404, "Branch not protected")],
-			],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [completed("unit tests")]))],
+			[RULES, rules()],
+			[PROTECTION, httpError(404, "Branch not protected")],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
 			[
@@ -96,13 +81,11 @@ describe("runSurface compares the two sides and judges neither", () => {
 	});
 
 	it("answers unprobeable — never no-requirements — when the token cannot see the surface", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [completed("unit tests")])],
-			],
-			[[RULES, httpError(403, "Resource not accessible by integration")]],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [completed("unit tests")]))],
+			[RULES, httpError(403, "Resource not accessible by integration")],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
 			[
@@ -118,13 +101,11 @@ describe("runSurface compares the two sides and judges neither", () => {
 
 describe("runSurface refuses rather than answering over unknown scope", () => {
 	it("refuses a transport failure on the rules read on 11", async () => {
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [completed("ci-required")])],
-			],
-			[[RULES, httpError(502, "Bad gateway")]],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [completed("ci-required")]))],
+			[RULES, httpError(502, "Bad gateway")],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "no-requirements"');
@@ -133,20 +114,18 @@ describe("runSurface refuses rather than answering over unknown scope", () => {
 	it("refuses an unexhausted rules enumeration on 13", async () => {
 		// Every page declares a `next`, so the walk hits PAGE_CAP with the link still outstanding —
 		// which is the only shape that proves non-exhaustion rather than merely failing to disprove it.
-		const out = await run(
-			[
-				[PULL, pull()],
-				[CHECK_RUNS, checkRuns(1, [completed("ci-required")])],
-			],
-			[[RULES, {...rules(), headers: linkNext("https://api.github.com/next")}]],
-		);
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [completed("ci-required")]))],
+			[RULES, {...rules(), headers: linkNext("https://api.github.com/next")}],
+		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
 	it("refuses a short check-run enumeration on 13", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[CHECK_RUNS, checkRuns(9, [completed("ci-required")])],
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(9, [completed("ci-required")]))],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");

--- a/packages/fabrika-cli/src/heal-ci/sweep-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/sweep-verb.unit.test.ts
@@ -1,20 +1,16 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {
-	errOut,
-	fakeHttp,
-	fakeShell,
+	fakeSeams,
 	type HttpReply,
 	linkNext,
+	type Scripted,
 	unconfigured,
 } from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {
-	behind,
-	CHECK_RUNS,
 	COMMIT_DATE,
-	COMPARE,
 	checkRuns,
 	comments,
 	commitDate,
@@ -29,16 +25,31 @@ import {
 	pull,
 	RATE_LIMIT,
 	RULES,
-	RUN_COUNT,
 	rateLimit,
-	reviews,
 	rules,
 	runsTotal,
-	timeline,
-	WORKFLOWS,
 	workflows,
 } from "./fixtures.test-support.ts";
 import {runSweep} from "./sweep-verb.ts";
+
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/\d+$/;
+const FILES = /^GET .*\/repos\/o\/r\/pulls\/\d+\/files\?/;
+const CHECK_RUNS = /^GET .*\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
+const WORKFLOWS = /^GET .*\/repos\/o\/r\/actions\/workflows\?/;
+const RUN_COUNT = /^GET .*\/repos\/o\/r\/actions\/runs\?head_sha=[0-9a-f]+&per_page=1$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/\d+\/comments\?/;
+const TIMELINE = /^GET .*\/repos\/o\/r\/issues\/\d+\/timeline\?/;
+const REVIEWS = /^GET .*\/repos\/o\/r\/pulls\/\d+\/reviews\?/;
+const COMPARE = /^GET .*\/repos\/o\/r\/compare\/main\.\.\.[0-9a-f]+$/;
+
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+/** An empty bare-array page — no `Link`, so the walk is proven exhausted. */
+const emptyPage: HttpReply = {status: 200, body: "[]"};
+
+/** `compare` answers a record; `behind_by` is the field, not the `--jq` era's bare number. */
+const behind = (by: number): HttpReply => ({status: 200, body: JSON.stringify({behind_by: by})});
 
 const NOW = Date.parse("2026-08-08T01:00:00Z");
 const PUSHED = "2026-08-08T00:00:00Z";
@@ -57,40 +68,30 @@ const options = {
 	now: NOW,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runSweep({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, unconfigured, fakeHttp(served).layer),
+			Layer.mergeAll(fakeSeams(script).layer, unconfigured),
 		),
 	);
 
-/** One classifiable PR's `gh` reads, reachable by any number: they are not keyed on it. */
-const classifiable = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[/^gh api repos\/o\/r\/pulls\/\d+$/, pull({updatedAt: PUSHED})],
-	[
-		/^gh api --paginate repos\/o\/r\/pulls\/\d+\/files/,
-		files("apps/web/worker/a.ts", "apps/web/worker/b.ts"),
-	],
-	[CHECK_RUNS, checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "success"}])],
-	[WORKFLOWS, workflows("active")],
-	[RUN_COUNT, runsTotal(3)],
-	[/^gh api --paginate repos\/o\/r\/issues\/\d+\/comments/, comments()],
-	[/^gh api -i repos\/o\/r\/issues\/\d+\/timeline/, timeline()],
-	[/^gh api -i repos\/o\/r\/pulls\/\d+\/reviews/, reviews()],
-	[COMPARE, behind(0)],
-];
-
-/** The same PR's reads over the HTTP client, beneath whichever board read the case scripts. */
-const classifiableHttp = (
-	board: readonly [RegExp, HttpReply],
-): ReadonlyArray<readonly [RegExp, HttpReply]> => [
+/** One classifiable PR's reads, reachable by any number: they are not keyed on it. */
+const classifiable = (board: Scripted): ReadonlyArray<Scripted> => [
 	board,
 	[RATE_LIMIT, rateLimit(4000)],
+	[PULL, reply(pull({updatedAt: PUSHED}))],
+	[FILES, reply(files("apps/web/worker/a.ts", "apps/web/worker/b.ts"))],
+	[
+		CHECK_RUNS,
+		reply(checkRuns(1, [{name: "ci-required", status: "completed", conclusion: "success"}])),
+	],
+	[WORKFLOWS, reply(workflows("active"))],
+	[RUN_COUNT, reply(runsTotal(3))],
+	[COMMENTS, reply(comments())],
+	[TIMELINE, emptyPage],
+	[REVIEWS, emptyPage],
+	[COMPARE, behind(0)],
 	[COMMIT_DATE, commitDate(PUSHED)],
 	[RULES, rules("ci-required")],
 	[PROTECTION, protection()],
@@ -99,11 +100,7 @@ const classifiableHttp = (
 describe("runSweep reports the whole board or none of it", () => {
 	it("prints both counts and one row per stalled PR, oldest strand first", async () => {
 		const out = await run(
-			classifiable(),
-			classifiableHttp([
-				OPEN_PULLS,
-				openPulls({number: 4321, head: HEAD}, {number: 4322, head: HEAD}),
-			]),
+			classifiable([OPEN_PULLS, openPulls({number: 4321, head: HEAD}, {number: 4322, head: HEAD})]),
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
@@ -114,50 +111,44 @@ describe("runSweep reports the whole board or none of it", () => {
 	});
 
 	it("answers a quiet board rather than refusing it", async () => {
-		const out = await run([], [[OPEN_PULLS, openPulls()]]);
+		const out = await run([[OPEN_PULLS, openPulls()]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("swept\t0\t0\n");
 	});
 
 	it("omits a PR inside the grace window", async () => {
-		const out = await run(
-			classifiable(),
-			classifiableHttp([OPEN_PULLS, openPulls({number: 4321, head: HEAD})]),
-			{minAgeMinutes: 600},
-		);
+		const out = await run(classifiable([OPEN_PULLS, openPulls({number: 4321, head: HEAD})]), {
+			minAgeMinutes: 600,
+		});
 		expect(out.stdout).toBe("swept\t1\t0\n");
 	});
 
 	it("writes nothing at all", async () => {
-		const shell = fakeShell(classifiable());
-		const http = fakeHttp(classifiableHttp([OPEN_PULLS, openPulls({number: 4321, head: HEAD})]));
+		const seams = fakeSeams(classifiable([OPEN_PULLS, openPulls({number: 4321, head: HEAD})]));
 		await Effect.runPromise(
-			Effect.provide(runSweep(options), Layer.mergeAll(shell.layer, unconfigured, http.layer)),
+			Effect.provide(runSweep(options), Layer.mergeAll(seams.layer, unconfigured)),
 		);
-		expect(shell.calls.some((call) => call.includes("--method POST"))).toBe(false);
-		expect(http.calls.every((call) => call.startsWith("GET "))).toBe(true);
+		expect(seams.requests.every((request) => request.startsWith("GET "))).toBe(true);
 	});
 });
 
 describe("runSweep refuses a board it could not read whole", () => {
 	it("refuses an unexhausted open-PR read on 13", async () => {
-		const out = await run(
-			[],
-			[[OPEN_PULLS, {...openPulls(), headers: linkNext("https://api.github.com/next")}]],
-		);
+		const out = await run([
+			[OPEN_PULLS, {...openPulls(), headers: linkNext("https://api.github.com/next")}],
+		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses an unreadable list on 11 — never `none stranded`", async () => {
-		const out = await run([], [[OPEN_PULLS, httpError(502, "Bad gateway")]]);
+		const out = await run([[OPEN_PULLS, httpError(502, "Bad gateway")]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "none stranded"');
 	});
 
 	it("refuses a board larger than --limit rather than answering over a subset", async () => {
 		const out = await run(
-			[],
 			[[OPEN_PULLS, openPulls({number: 4321, head: HEAD}, {number: 4322, head: HEAD})]],
 			{limit: 1},
 		);
@@ -166,38 +157,31 @@ describe("runSweep refuses a board it could not read whole", () => {
 	});
 
 	it("refuses a sweep with a hole in it rather than dropping the PR", async () => {
-		const out = await run(
-			[[/^gh api repos\/o\/r\/pulls\/\d+$/, errOut("gh: Bad gateway (HTTP 502)")]],
-			[
-				[OPEN_PULLS, openPulls({number: 4321, head: HEAD})],
-				[RATE_LIMIT, rateLimit(4000)],
-			],
-		);
+		const out = await run([
+			[OPEN_PULLS, openPulls({number: 4321, head: HEAD})],
+			[RATE_LIMIT, rateLimit(4000)],
+			[PULL, httpError(502, "Bad gateway")],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("refusing a sweep with a hole in it");
 	});
 
 	it("refuses a partial board on an exhausted rate limit, emitting nothing", async () => {
-		const out = await run(
-			[],
-			[
-				[OPEN_PULLS, openPulls({number: 4321, head: HEAD})],
-				[RATE_LIMIT, rateLimit(2)],
-			],
-		);
+		const out = await run([
+			[OPEN_PULLS, openPulls({number: 4321, head: HEAD})],
+			[RATE_LIMIT, rateLimit(2)],
+		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("refusing a partial board");
 	});
 
 	it("counts a PR that vanished between the list read and its classification as scanned", async () => {
-		const out = await run(
-			[[/^gh api repos\/o\/r\/pulls\/\d+$/, errOut("gh: Not Found (HTTP 404)")]],
-			[
-				[OPEN_PULLS, openPulls({number: 4321, head: HEAD})],
-				[RATE_LIMIT, rateLimit(4000)],
-			],
-		);
+		const out = await run([
+			[OPEN_PULLS, openPulls({number: 4321, head: HEAD})],
+			[RATE_LIMIT, rateLimit(4000)],
+			[PULL, httpError(404, "Not Found")],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("swept\t1\t0\n");
 		expect(out.stderr.join("\n")).toContain("counted as scanned, not stalled");

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -3,7 +3,14 @@ import {resolve} from "node:path";
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import type {EntrypointRead} from "../delegate/entrypoint.ts";
-import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {EPIC_RULES, EPIC_TAIL_RULES, RULES, read as readBrief} from "../wire/lane-brief.ts";
 import {runBrief} from "./brief-verb.ts";
@@ -26,38 +33,41 @@ const ISSUE_URL = "https://github.com/o/r/issues/5751";
 const PR_URL = "https://github.com/o/r/pull/5790";
 const TITLE = "the operator hand-writes every spawn prompt";
 
-const ISSUE_READ = /^gh api repos\/o\/r\/issues\/5751$/;
-const CHILD_READ = /^gh api repos\/o\/r\/issues\/5729$/;
-const PR_CLOSERS = /^gh api graphql -f query=query\(/;
+const ISSUE_READ = /^GET .*\/repos\/o\/r\/issues\/5751$/;
+const CHILD_READ = /^GET .*\/repos\/o\/r\/issues\/5729$/;
+const PR_CLOSERS = /^POST .*\/graphql$/;
 
-const issuePayload = (number: number, url: string): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number,
-			title: TITLE,
-			body: "## What is wrong\n\nNothing prints it, nothing records it.",
-			state: "open",
-			labels: [{name: "type:feature"}],
-			html_url: url,
-		}),
-	);
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const SERVER_ERROR: HttpReply = {status: 503, body: '{"message":"Server Error"}'};
+
+const issuePayload = (number: number, url: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number,
+		title: TITLE,
+		body: "## What is wrong\n\nNothing prints it, nothing records it.",
+		state: "open",
+		labels: [{name: "type:feature"}],
+		html_url: url,
+	}),
+});
 
 /** One page of the closing-issue link edge — every node OPEN, since the verb filters on that. */
-const closingPulls = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
-	okOut(
-		JSON.stringify({
-			data: {
-				repository: {
-					issue: {
-						closedByPullRequestsReferences: {
-							pageInfo: {hasNextPage: false, endCursor: null},
-							nodes: rows.map(([number, url]) => ({number, url, state: "OPEN"})),
-						},
+const closingPulls = (...rows: ReadonlyArray<readonly [number, string]>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		data: {
+			repository: {
+				issue: {
+					closedByPullRequestsReferences: {
+						pageInfo: {hasNextPage: false, endCursor: null},
+						nodes: rows.map(([number, url]) => ({number, url, state: "OPEN"})),
 					},
 				},
 			},
-		}),
-	);
+		},
+	}),
+});
 
 /** A single-issue lane at `lane`, with one log line per operator event already recorded. */
 const lane = (id: string, events: ReadonlyArray<string>) =>
@@ -82,8 +92,8 @@ const lane = (id: string, events: ReadonlyArray<string>) =>
 const EPIC = 5800;
 const EPIC_URL = "https://github.com/o/r/issues/5800";
 const CHILD_URL = "https://github.com/o/r/issues/5828";
-const EPIC_ISSUE_READ = /^gh api repos\/o\/r\/issues\/5800$/;
-const EPIC_CHILD_READ = /^gh api repos\/o\/r\/issues\/5828$/;
+const EPIC_ISSUE_READ = /^GET .*\/repos\/o\/r\/issues\/5800$/;
+const EPIC_CHILD_READ = /^GET .*\/repos\/o\/r\/issues\/5828$/;
 
 /** The child's range as this tree holds it: the epic branch's commit, and the build branch's tip. */
 const EPIC_BASE = "58ad239e2f8b41c0d7a6935ee1c204ab5d3f9017";
@@ -104,7 +114,7 @@ const logOf = (...rows: ReadonlyArray<readonly [string, string]>): ExecResult =>
 const locating = (
 	branches: ReadonlyArray<string> = [CHILD_BRANCH, "main", "epic/5800"],
 	commits: ReadonlyArray<readonly [string, string]> = [[CHILD_TIP, CHILD_MESSAGE]],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+): ReadonlyArray<Scripted> => [
 	[REV("epic/5800"), okOut(`${EPIC_BASE}\n`)],
 	[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
 	[BRANCHES, okOut(`${branches.join("\n")}\n`)],
@@ -160,13 +170,13 @@ const options = {
 
 const run = (
 	fs: ReturnType<typeof fakeFs>,
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runBrief({...options, ...overrides}),
-			Layer.merge(fs.layer, fakeShell(script).layer),
+			Layer.merge(fs.layer, fakeSeams(script).layer),
 		),
 	);
 
@@ -399,17 +409,13 @@ describe("lane brief", () => {
 	});
 
 	it("refuses when the issue is proven absent", async () => {
-		const out = await run(lane("5751", ["WIP"]), [
-			[ISSUE_READ, errOut("gh: Not Found (HTTP 404)")],
-		]);
+		const out = await run(lane("5751", ["WIP"]), [[ISSUE_READ, NOT_FOUND]]);
 
 		expect(out.code).toBe(ISSUE_UNRESOLVED);
 	});
 
 	it("refuses when the issue could not be read — UNKNOWN, never a brief", async () => {
-		const out = await run(lane("5751", ["WIP"]), [
-			[ISSUE_READ, errOut("gh: Server Error (HTTP 503)")],
-		]);
+		const out = await run(lane("5751", ["WIP"]), [[ISSUE_READ, SERVER_ERROR]]);
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stdout).toBe("");
@@ -440,21 +446,21 @@ describe("lane brief", () => {
 describe("lane brief on an epic lane", () => {
 	const runEpic = async (
 		fs: ReturnType<typeof fakeFs>,
-		script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+		script: ReadonlyArray<Scripted>,
 		overrides: Partial<typeof options>,
 	) => {
-		const shell = fakeShell(script);
+		const seams = fakeSeams(script);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runBrief({...options, lane: String(EPIC), ...overrides}),
-				Layer.merge(fs.layer, shell.layer),
+				Layer.merge(fs.layer, seams.layer),
 			),
 		);
-		return {out, calls: shell.calls};
+		return {out, calls: seams.calls, requests: seams.requests};
 	};
 
 	it("briefs a child's build on the epic branch, resolving no PR at all", async () => {
-		const {out, calls} = await runEpic(
+		const {out, calls, requests} = await runEpic(
 			epicLane([["issue_5828", "WIP"]]),
 			[
 				[EPIC_CHILD_READ, issuePayload(5828, CHILD_URL)],
@@ -477,14 +483,12 @@ describe("lane brief on an epic lane", () => {
 		});
 		expect(out.stdout).toContain(EPIC_RULES);
 		expect(out.stdout).not.toContain("range:");
-		expect(calls.some((call) => PR_CLOSERS.test(call))).toBe(false);
+		expect(requests.some((request) => PR_CLOSERS.test(request))).toBe(false);
 		// No child branch exists yet at `build`, so the tree is never read for one.
 		expect(calls.some((call) => call.startsWith("git "))).toBe(false);
 	});
 
-	const reviewing = (
-		script: ReadonlyArray<readonly [RegExp, ExecResult]> = locating(),
-	): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	const reviewing = (script: ReadonlyArray<Scripted> = locating()): ReadonlyArray<Scripted> => [
 		[EPIC_CHILD_READ, issuePayload(5828, CHILD_URL)],
 		[EPIC_ISSUE_READ, issuePayload(EPIC, EPIC_URL)],
 		...script,
@@ -497,7 +501,7 @@ describe("lane brief on an epic lane", () => {
 		]);
 
 	it("briefs a child's review with the range this tree resolved and the range-verdict contract", async () => {
-		const {out, calls} = await runEpic(atReview(), reviewing(), {task: "issue_5828"});
+		const {out, requests} = await runEpic(atReview(), reviewing(), {task: "issue_5828"});
 
 		expect(out.code).toBe(0);
 		expect(readBrief(out.stdout)).toMatchObject({
@@ -514,7 +518,7 @@ describe("lane brief on an epic lane", () => {
 		});
 		expect(out.stdout).toContain(`range: ${EPIC_BASE}..${CHILD_TIP}`);
 		expect(out.stdout).toContain("range-verdict-marker");
-		expect(calls.some((call) => PR_CLOSERS.test(call))).toBe(false);
+		expect(requests.some((request) => PR_CLOSERS.test(request))).toBe(false);
 	});
 
 	it("never prints a literal HEAD — the spawned reviewer would re-resolve it in its own worktree", async () => {
@@ -628,7 +632,7 @@ describe("lane brief on an epic lane", () => {
 			epicLane([["issue_5828", "WIP"]]),
 			[
 				[EPIC_CHILD_READ, issuePayload(5828, CHILD_URL)],
-				[EPIC_ISSUE_READ, errOut("gh: Server Error (HTTP 503)")],
+				[EPIC_ISSUE_READ, SERVER_ERROR],
 			],
 			{task: "issue_5828"},
 		);

--- a/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
@@ -8,20 +8,33 @@ import {
 	LANE_UUID,
 	NO_BLOCKERS,
 	SIBLING_UUID,
+	served,
 	truncatedComments,
 } from "../build/fixtures.test-support.ts";
-import {fakeFs, fakeShell, okOut, unconfigured} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	type Scripted,
+	unconfigured,
+} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {runLaneClaim, runLaneRelease} from "./claim-verb.ts";
 import {APPEND_UNKNOWN, CLAIM_NOT_MINE, LANE_UNREADABLE, MARKER_READBACK} from "./codes.ts";
 import {parseKey} from "./key.ts";
 
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/5492\/comments/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/5492\/comments/;
-const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/9001$/;
-const DELETE = /^gh api --method DELETE repos\/o\/r\/issues\/comments\//;
-const perm = (login: string) => new RegExp(`^gh api repos/o/r/collaborators/${login}/permission`);
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/5492\/comments\?/;
+const POST = /^POST .*\/repos\/o\/r\/issues\/5492\/comments$/;
+const GET_COMMENT = /^GET .*\/repos\/o\/r\/issues\/comments\/9001$/;
+const DELETE = /^DELETE .*\/repos\/o\/r\/issues\/comments\//;
+const perm = (login: string) => new RegExp(`^GET .*/repos/o/r/collaborators/${login}/permission$`);
+
+/** The request line a retraction shows up as — what a "which markers were deleted" claim reads. */
+const deleted = (id: number) => `DELETE https://api.github.com/repos/o/r/issues/comments/${id}`;
+
+const WRITE_PERMISSION: HttpReply = served({permission: "write"});
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
+const DELETED: HttpReply = {status: 204, body: ""};
 
 const OTHER_UUID = "9d8c7b6a-5f4e-3d2c-1b0a-998877665544";
 
@@ -36,8 +49,8 @@ const SIBLING = laneMarker("s-9f2e", SIBLING_UUID);
 const MY_TOKEN = `lane:s-9f2e:${LANE_UUID}`;
 const SIBLING_TOKEN = `lane:s-9f2e:${SIBLING_UUID}`;
 
-const POSTED = okOut(JSON.stringify({id: 9001, html_url: "https://github.com/o/r/issues/5492#c"}));
-const ECHO = okOut(JSON.stringify({body: MINE}));
+const POSTED = served({id: 9001, html_url: "https://github.com/o/r/issues/5492#c"}, 201);
+const ECHO = served({body: MINE});
 
 const key = (raw: string) => {
 	const parsed = parseKey(raw);
@@ -59,25 +72,19 @@ const options = {
 	at: "2026-08-17T00:00:00Z",
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runLaneClaim({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, unconfigured),
+			Layer.merge(fakeSeams(script).layer, unconfigured),
 		),
 	);
 
-const release = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const release = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runLaneRelease({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, unconfigured),
+			Layer.merge(fakeSeams(script).layer, unconfigured),
 		),
 	);
 
@@ -87,7 +94,7 @@ describe("runLaneClaim", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, buildComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
@@ -99,21 +106,21 @@ describe("runLaneClaim", () => {
 	});
 
 	it("re-reads AFTER posting — the checkpoint is what resolves a staggered race", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, buildComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
-		await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
-		const posted = shell.calls.findIndex((line) => POST.test(line));
-		const swept = shell.calls.findIndex((line) => COMMENTS.test(line));
+		await Effect.runPromise(Effect.provide(runLaneClaim(options), seams.layer));
+		const posted = seams.requests.findIndex((line) => POST.test(line));
+		const swept = seams.requests.findIndex((line) => COMMENTS.test(line));
 		expect(posted).toBeGreaterThanOrEqual(0);
 		expect(swept).toBeGreaterThan(posted);
 	});
 
 	it("exits 31 on a proven loss — never 0 — and retracts only its OWN marker", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[
@@ -123,15 +130,15 @@ describe("runLaneClaim", () => {
 					{id: 9001, body: MINE, createdAt: "2026-08-17T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), seams.layer));
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain(`lane:s-77aa:${OTHER_UUID}`);
-		const deletes = shell.calls.filter((line) => DELETE.test(line));
-		expect(deletes).toEqual(["gh api --method DELETE repos/o/r/issues/comments/9001"]);
+		const deletes = seams.requests.filter((line) => DELETE.test(line));
+		expect(deletes).toEqual([deleted(9001)]);
 	});
 
 	/**
@@ -140,7 +147,7 @@ describe("runLaneClaim", () => {
 	 * neighbour's claim as its own (#6060).
 	 */
 	it("loses to a sibling driver of its own session, and says which one", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[
@@ -150,15 +157,13 @@ describe("runLaneClaim", () => {
 					{id: 9001, body: MINE, createdAt: "2026-08-17T00:00:00Z"},
 				),
 			],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), seams.layer));
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.join("\n")).toContain(SIBLING_TOKEN);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
-		]);
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([deleted(9001)]);
 	});
 
 	/**
@@ -167,33 +172,31 @@ describe("runLaneClaim", () => {
 	 * resolve, on a namespace with no TTL to expire it (#6000).
 	 */
 	it("exits 11 on an unreadable marker set — UNKNOWN, never unclaimed — retracting its own", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), seams.layer));
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
-		]);
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([deleted(9001)]);
 	});
 
 	it("exits 1 with no session id, and writes nothing", async () => {
-		const shell = fakeShell([]);
+		const seams = fakeSeams([]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneClaim({...options, env: {CLAUDE_PIPELINE_REPO: "o/r"}}), shell.layer),
+			Effect.provide(runLaneClaim({...options, env: {CLAUDE_PIPELINE_REPO: "o/r"}}), seams.layer),
 		);
 		expect(out.code).toBe(FAILED);
-		expect(shell.calls).toEqual([]);
+		expect(seams.requests).toEqual([]);
 	});
 
 	it("exits 8 when the marker write fails — UNKNOWN, never a held lane", async () => {
-		const out = await run([[POST, {ok: false, stdout: "", reason: "502"}]]);
+		const out = await run([[POST, GATEWAY]]);
 		expect(out.code).toBe(APPEND_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
@@ -201,51 +204,51 @@ describe("runLaneClaim", () => {
 	it("exits 9 when the marker lands and does not read back", async () => {
 		const out = await run([
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: THEIRS}))],
+			[GET_COMMENT, served({body: THEIRS})],
 		]);
 		expect(out.code).toBe(MARKER_READBACK);
 		expect(out.stderr.join("\n")).toContain("9001");
 	});
 
 	it("answers unclaimable on a chore lane, writing nothing", async () => {
-		const shell = fakeShell([]);
+		const seams = fakeSeams([]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runLaneClaim({...options, key: key("chore:park-sweep"), lane: "chore:park-sweep"}),
-				shell.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).answer).toBe("unclaimable");
-		expect(shell.calls).toEqual([]);
+		expect(seams.requests).toEqual([]);
 	});
 });
 
 describe("runLaneRelease", () => {
 	it("retracts this driver's own marker", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, buildComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({answer: "released", lane: "5492", number: 5492});
-		expect(shell.calls).toContain("gh api --method DELETE repos/o/r/issues/comments/9001");
+		expect(seams.requests).toContain(deleted(9001));
 	});
 
 	it("exits 31 rather than retracting another driver's marker", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, buildComments({id: 8000, body: THEIRS})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([]);
 	});
 
 	/**
@@ -254,47 +257,47 @@ describe("runLaneRelease", () => {
 	 * (#6060). The refusal names the holding token so a reader can find the comment.
 	 */
 	it("refuses a sibling driver of its OWN session, naming the holding token", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, buildComments({id: 8000, body: SIBLING})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.join("\n")).toContain(SIBLING_TOKEN);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([]);
 	});
 
 	it("exits 1 with no --token on a board lane, and reads nothing", async () => {
-		const shell = fakeShell([]);
-		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), shell.layer));
+		const seams = fakeSeams([]);
+		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), seams.layer));
 		expect(out.code).toBe(FAILED);
-		expect(shell.calls).toEqual([]);
+		expect(seams.requests).toEqual([]);
 	});
 
 	/** A read that failed is UNKNOWN, and an UNKNOWN holding never authorizes a delete. */
 	it("exits 11 on an unreadable marker read, retracting nothing", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([]);
 	});
 
 	it("exits 8 when the delete fails — whether the lane is still held is UNKNOWN", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, buildComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, {ok: false, stdout: "", reason: "502"}],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, GATEWAY],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(APPEND_UNKNOWN);
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
@@ -318,12 +321,12 @@ describe("one driver, one marker", () => {
 		buildComments(...bodies.map(([id, body]) => ({id, body})));
 
 	it("posts no second marker on a re-claim, and answers with the owning token", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, held([9001, MINE])],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneClaim({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneClaim({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
@@ -332,42 +335,40 @@ describe("one driver, one marker", () => {
 			number: 5492,
 			token: MY_TOKEN,
 		});
-		expect(shell.calls.filter((line) => POST.test(line))).toEqual([]);
+		expect(seams.requests.filter((line) => POST.test(line))).toEqual([]);
 	});
 
 	/** Claim, re-claim, release once: no marker of this driver survives for a later claim to lose to. */
 	it("leaves nothing behind after one release", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, held([9001, MINE])],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
 		await Effect.runPromise(
-			Effect.provide(runLaneClaim({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneClaim({...options, token: MY_TOKEN}), seams.layer),
 		);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(0);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
-		]);
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([deleted(9001)]);
 	});
 
 	/** A thread that already carries duplicates — written before the guard — is swept, not crashed on. */
 	it("sweeps every marker carrying this driver's token, and only those", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, held([9001, MINE], [9002, MINE], [9003, THEIRS])],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), seams.layer),
 		);
 		expect(out.code).toBe(0);
-		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/comments/9001",
-			"gh api --method DELETE repos/o/r/issues/comments/9002",
+		expect(seams.requests.filter((line) => DELETE.test(line))).toEqual([
+			deleted(9001),
+			deleted(9002),
 		]);
 	});
 
@@ -377,16 +378,16 @@ describe("one driver, one marker", () => {
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, buildComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
+			[perm("agent"), WRITE_PERMISSION],
 		]);
 		const token = JSON.parse(claimed.stdout).token as string;
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[COMMENTS, buildComments({id: 9001, body: MINE})],
-			[perm("agent"), okOut("write\n")],
-			[DELETE, okOut("")],
+			[perm("agent"), WRITE_PERMISSION],
+			[DELETE, DELETED],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runLaneRelease({...options, token}), shell.layer),
+			Effect.provide(runLaneRelease({...options, token}), seams.layer),
 		);
 		expect(out.code).toBe(0);
 	});
@@ -399,7 +400,7 @@ describe("a driver's claim and the builder it spawns", () => {
 	 * two namespaces on one thread rather than one race with two entrants (#5761).
 	 */
 	it("lets the spawned builder claim the same issue and win", async () => {
-		const BUILD_ISSUE = /^gh api repos\/o\/r\/issues\/5492$/;
+		const BUILD_ISSUE = /^GET .*\/repos\/o\/r\/issues\/5492$/;
 		const BUILD_COMMENTS = COMMENTS;
 		const claimable = buildIssue({
 			number: 5492,
@@ -427,13 +428,10 @@ describe("a driver's claim and the builder it spawns", () => {
 					cites: null,
 					resume: false,
 				}),
-				fakeShell([
+				fakeSeams([
 					[BUILD_ISSUE, claimable],
-					[POST, okOut(JSON.stringify({id: 9002, html_url: "https://github.com/o/r#c"}))],
-					[
-						/^gh api repos\/o\/r\/issues\/comments\/9002$/,
-						okOut(JSON.stringify({body: buildMarker})),
-					],
+					[POST, served({id: 9002, html_url: "https://github.com/o/r#c"}, 201)],
+					[/^GET .*\/repos\/o\/r\/issues\/comments\/9002$/, served({body: buildMarker})],
 					[
 						BUILD_COMMENTS,
 						buildComments(
@@ -442,7 +440,7 @@ describe("a driver's claim and the builder it spawns", () => {
 							{id: 9002, body: buildMarker, createdAt: "2026-08-17T00:10:00Z"},
 						),
 					],
-					[perm("agent"), okOut("write\n")],
+					[perm("agent"), WRITE_PERMISSION],
 					NO_BLOCKERS,
 				]).layer,
 			).pipe(Effect.provide(fakeFs({files: {}}).layer)),

--- a/packages/fabrika-cli/src/lane/emit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit-verb.unit.test.ts
@@ -1,10 +1,9 @@
 /** `lane emit` — the board reads, the emit refusal seats, and the write that lands the machine. */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {issue} from "../build/fixtures.test-support.ts";
-import {errOut, fakeFs, fakeHttp, fakeShell, type HttpReply} from "../fakes.test-support.ts";
+import {issuePayload, NOT_FOUND, served} from "../build/fixtures.test-support.ts";
+import {fakeFs, fakeHttp, fakeShell, type HttpReply} from "../fakes.test-support.ts";
 import {readGoldenFixture} from "../golden-fixture.ts";
-import type {ExecResult} from "../io/exec.ts";
 import {
 	LANE_ABSENT,
 	LANE_EXISTS,
@@ -15,12 +14,15 @@ import {
 } from "./codes.ts";
 import {runEmit} from "./emit-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4300$/;
+const ISSUE = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 const SUBS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/sub_issues\?/;
 
 const body = (): string => readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.body.txt");
 const golden = (): string =>
 	readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.workflow.golden.txt");
+
+const epic = (overrides: Record<string, unknown> = {}): HttpReply =>
+	served(issuePayload({number: 4300, body: body(), ...overrides}));
 
 const children: HttpReply = {
 	status: 200,
@@ -41,21 +43,20 @@ const OPTIONS = {
 	>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-	fs = fakeFs({files: {}}),
-) =>
+const run = (script: ReadonlyArray<readonly [RegExp, HttpReply]> = [], fs = fakeFs({files: {}})) =>
 	Effect.runPromise(
 		Effect.provide(
 			runEmit(OPTIONS),
-			Layer.mergeAll(fs.layer, fakeShell(script).layer, fakeHttp(served).layer),
+			Layer.mergeAll(fs.layer, fakeShell([]).layer, fakeHttp(script).layer),
 		),
 	).then((out) => ({out, fs}));
 
 describe("lane emit", () => {
 	it("writes the golden machine bytes to the epic's lane dir", async () => {
-		const {out, fs} = await run([[ISSUE, issue({number: 4300, body: body()})]], [[SUBS, children]]);
+		const {out, fs} = await run([
+			[ISSUE, epic()],
+			[SUBS, children],
+		]);
 
 		expect(out.code).toBe(0);
 		expect(fs.written.get(".fabrika/lanes/4300/workflow.json")).toBe(golden());
@@ -69,8 +70,10 @@ describe("lane emit", () => {
 
 	it("refuses an existing lane dir with the open verb's code and writes nothing", async () => {
 		const {out, fs} = await run(
-			[[ISSUE, issue({number: 4300, body: body()})]],
-			[[SUBS, children]],
+			[
+				[ISSUE, epic()],
+				[SUBS, children],
+			],
 			fakeFs({files: {}, directories: [".fabrika/lanes/4300"]}),
 		);
 
@@ -79,30 +82,25 @@ describe("lane emit", () => {
 	});
 
 	it("refuses a proven-absent epic on the no-target seat", async () => {
-		const {out} = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const {out} = await run([[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(LANE_ABSENT);
 	});
 
 	it("refuses an unreadable child list as UNKNOWN — never an epic with no children", async () => {
-		const {out, fs} = await run(
-			[[ISSUE, issue({number: 4300, body: body()})]],
-			[[SUBS, {status: 503, body: '{"message":"unreachable"}'}]],
-		);
+		const {out, fs} = await run([
+			[ISSUE, epic()],
+			[SUBS, {status: 503, body: '{"message":"unreachable"}'}],
+		]);
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(fs.written.size).toBe(0);
 	});
 
 	it("refuses a child entry with no readable state as UNKNOWN — never a queued default", async () => {
-		const {out, fs} = await run(
-			[[ISSUE, issue({number: 4300, body: body()})]],
-			[
-				[
-					SUBS,
-					{status: 200, body: JSON.stringify([{number: 4301}, {number: 4302}, {number: 4303}])},
-				],
-			],
-		);
+		const {out, fs} = await run([
+			[ISSUE, epic()],
+			[SUBS, {status: 200, body: JSON.stringify([{number: 4301}, {number: 4302}, {number: 4303}])}],
+		]);
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain("#4301");
@@ -110,20 +108,20 @@ describe("lane emit", () => {
 	});
 
 	it("refuses an epic with no topology block, naming the absence", async () => {
-		const {out} = await run(
-			[[ISSUE, issue({number: 4300, body: "## Plan\n\nno topology\n"})]],
-			[[SUBS, children]],
-		);
+		const {out} = await run([
+			[ISSUE, epic({body: "## Plan\n\nno topology\n"})],
+			[SUBS, children],
+		]);
 
 		expect(out.code).toBe(TOPOLOGY_ABSENT);
 		expect(out.stderr.join("\n")).toContain("Dependencies");
 	});
 
 	it("refuses a topology referencing a non-child, naming the ref", async () => {
-		const {out} = await run(
-			[[ISSUE, issue({number: 4300, body: "## Dependencies\n\n- phase 1: #9999\n"})]],
-			[[SUBS, children]],
-		);
+		const {out} = await run([
+			[ISSUE, epic({body: "## Dependencies\n\n- phase 1: #9999\n"})],
+			[SUBS, children],
+		]);
 
 		expect(out.code).toBe(TOPOLOGY_FOREIGN);
 		expect(out.stderr.join("\n")).toContain("#9999");
@@ -132,7 +130,10 @@ describe("lane emit", () => {
 	it("refuses a cycle, naming the path", async () => {
 		const cyclic =
 			"## Dependencies\n\n- phase 1: #4301, #4302\n- #4301 requires: #4302\n- #4302 requires: #4301\n";
-		const {out} = await run([[ISSUE, issue({number: 4300, body: cyclic})]], [[SUBS, children]]);
+		const {out} = await run([
+			[ISSUE, epic({body: cyclic})],
+			[SUBS, children],
+		]);
 
 		expect(out.code).toBe(TOPOLOGY_CYCLE);
 		expect(out.stderr.join("\n")).toContain("#4301");

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -1,6 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeHttp, fakeShell, okOut} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import {readGoldenFixture} from "../golden-fixture.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {contentDigest, parseRaw} from "../review/content-binding.ts";
@@ -20,34 +27,42 @@ const LOG = `${ROOT}/5747/events.jsonl`;
 const HEAD = "03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1";
 const OLD = "8f1c2ad4e5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0";
 
-const CLOSERS = /^gh api graphql -f query=query\(/;
-const SEARCH = /^gh api --paginate search\/issues/;
-const PULL = /^gh api repos\/o\/r\/pulls\/4318$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4318\/files/;
-const PR_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4318\/comments/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/5747$/;
-const ISSUE_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/5747\/comments/;
+const CLOSERS = /^POST .*\/graphql$/;
+const SEARCH = /^GET .*\/search\/issues\?/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4318$/;
+const FILES = /^GET .*\/repos\/o\/r\/pulls\/4318\/files\?/;
+const PR_COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4318\/comments\?/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/5747$/;
+const ISSUE_COMMENTS = /^GET .*\/repos\/o\/r\/issues\/5747\/comments\?/;
+
+const served = (payload: unknown): HttpReply => ({status: 200, body: JSON.stringify(payload)});
+const GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
+
+/** The `{total_count, items}` envelope the search index answers with. */
+const nominated = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served({
+		total_count: numbers.length,
+		items: numbers.map((number) => ({number, title: `pull ${number}`})),
+	});
 
 /** One page of the closing-issue link edge, every node OPEN — the verb filters on that itself. */
-const closingPulls = (...numbers: ReadonlyArray<number>): ExecResult =>
-	okOut(
-		JSON.stringify({
-			data: {
-				repository: {
-					issue: {
-						closedByPullRequestsReferences: {
-							pageInfo: {hasNextPage: false, endCursor: null},
-							nodes: numbers.map((number) => ({
-								number,
-								url: `https://github.com/o/r/pull/${number}`,
-								state: "OPEN",
-							})),
-						},
+const closingPulls = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served({
+		data: {
+			repository: {
+				issue: {
+					closedByPullRequestsReferences: {
+						pageInfo: {hasNextPage: false, endCursor: null},
+						nodes: numbers.map((number) => ({
+							number,
+							url: `https://github.com/o/r/pull/${number}`,
+							state: "OPEN",
+						})),
 					},
 				},
 			},
-		}),
-	);
+		},
+	});
 
 const logLine = (event: string, at: string): string =>
 	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at})}\n`;
@@ -64,54 +79,43 @@ const laneAt = (state: "build" | "review") =>
 		},
 	});
 
-const pull = (overrides: Record<string, unknown> = {}): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4318,
-			state: "open",
-			head: {sha: HEAD},
-			base: {ref: "main"},
-			body: "Fixes #5747\n\n## Deviations\nNone.\n",
-			changed_files: 1,
-			comments: 1,
-			merged: false,
-			...overrides,
-		}),
-	);
+const pull = (overrides: Record<string, unknown> = {}): HttpReply =>
+	served({
+		number: 4318,
+		state: "open",
+		head: {sha: HEAD},
+		base: {ref: "main"},
+		body: "Fixes #5747\n\n## Deviations\nNone.\n",
+		changed_files: 1,
+		comments: 1,
+		merged: false,
+		...overrides,
+	});
 
 const comments = (
 	...rows: ReadonlyArray<{id: number; body: string; createdAt?: string}>
-): ExecResult =>
-	okOut(
-		JSON.stringify(
-			rows.map((row) => ({
-				id: row.id,
-				body: row.body,
-				user: {login: "agent"},
-				created_at: row.createdAt ?? "2026-08-16T03:00:00Z",
-				updated_at: row.createdAt ?? "2026-08-16T03:00:00Z",
-			})),
-		),
+): HttpReply =>
+	served(
+		rows.map((row) => ({
+			id: row.id,
+			body: row.body,
+			user: {login: "agent"},
+			created_at: row.createdAt ?? "2026-08-16T03:00:00Z",
+			updated_at: row.createdAt ?? "2026-08-16T03:00:00Z",
+		})),
 	);
 
-const issue = (labels: ReadonlyArray<string>): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 5747,
-			title: "a lane task",
-			body: "",
-			state: "open",
-			labels: labels.map((name) => ({name})),
-			html_url: "https://github.com/o/r/issues/5747",
-		}),
-	);
+const issue = (labels: ReadonlyArray<string>): HttpReply =>
+	served({
+		number: 5747,
+		title: "a lane task",
+		body: "",
+		state: "open",
+		labels: labels.map((name) => ({name})),
+		html_url: "https://github.com/o/r/issues/5747",
+	});
 
-const run = (
-	fs: ReturnType<typeof fakeFs>,
-	shell: ReturnType<typeof fakeShell>,
-	event: string,
-	http: ReturnType<typeof fakeHttp> = fakeHttp([]),
-) =>
+const run = (fs: ReturnType<typeof fakeFs>, seams: ReturnType<typeof fakeSeams>, event: string) =>
 	Effect.runPromise(
 		Effect.provide(
 			runProve({
@@ -123,19 +127,19 @@ const run = (
 				cwd: "/repo",
 				env: {CLAUDE_PIPELINE_REPO: "o/r"},
 			}),
-			Layer.mergeAll(fs.layer, shell.layer, http.layer),
+			Layer.mergeAll(fs.layer, seams.layer),
 		),
 	);
 
 describe("lane prove — the two events that carry a claim", () => {
 	it("proves a build DONE against the one open PR whose body links the issue", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -147,15 +151,15 @@ describe("lane prove — the two events that carry a claim", () => {
 	});
 
 	it("proves a review PASS when every derived namespace passes at the live head", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
-			[FILES, okOut(JSON.stringify([{filename: "packages/fabrika-cli/src/lane/prove.ts"}]))],
+			[FILES, served([{filename: "packages/fabrika-cli/src/lane/prove.ts"}])],
 			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS");
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -167,14 +171,14 @@ describe("lane prove — the two events that carry a claim", () => {
 
 describe("lane prove — the refusals, each on its own remedy", () => {
 	it("refuses a build DONE with no open PR and no no-PR outcome, naming what it looked for", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("")],
+			[SEARCH, nominated()],
 			[ISSUE, issue(["type:feature"])],
 			[ISSUE_COMMENTS, comments()],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(PROOF_ABSENT);
 		expect(out.stdout).toBe("");
@@ -183,129 +187,126 @@ describe("lane prove — the refusals, each on its own remedy", () => {
 	});
 
 	it("refuses a build DONE when several open PRs link the issue", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n4319\n")],
+			[SEARCH, nominated(4318, 4319)],
 			[PULL, pull()],
-			[/^gh api repos\/o\/r\/pulls\/4319$/, pull({number: 4319})],
+			[/^GET .*\/repos\/o\/r\/pulls\/4319$/, pull({number: 4319})],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(PROOF_AMBIGUOUS);
 		expect(out.stderr.join("\n")).toContain("#4318, #4319");
 	});
 
 	it("refuses a PASS while a derived namespace has no current-head verdict", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
-			[
-				FILES,
-				okOut(JSON.stringify([{filename: "claude-plugins/fabrika/skills/operate/SKILL.md"}])),
-			],
+			[FILES, served([{filename: "claude-plugins/fabrika/skills/operate/SKILL.md"}])],
 			[PR_COMMENTS, comments({id: 1, body: `review-skill: PASS @ ${HEAD} — reads clean`})],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS");
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("governance (absent)");
 	});
 
 	it("refuses a PASS whose namespace verdict is at a head the PR has moved past", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
-			[FILES, okOut(JSON.stringify([{filename: "packages/fabrika-cli/src/lane/prove.ts"}]))],
+			[FILES, served([{filename: "packages/fabrika-cli/src/lane/prove.ts"}])],
 			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${OLD} — merge-ready`})],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS");
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-code (stale)");
 	});
 
 	it("refuses a PASS the board contradicts with a current-head FAIL", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
-			[FILES, okOut(JSON.stringify([{filename: "packages/fabrika-cli/src/lane/prove.ts"}]))],
+			[FILES, served([{filename: "packages/fabrika-cli/src/lane/prove.ts"}])],
 			[PR_COMMENTS, comments({id: 1, body: `review-code: FAIL @ ${HEAD} — the fold drops a row`})],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS");
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_CONTRADICTED);
 		expect(out.stderr.join("\n")).toContain("FAIL");
 	});
 
 	it("leaves the proof UNKNOWN when a board read fails — never proven, never absent", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, errOut("HTTP 502")],
+			[SEARCH, GATEWAY],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
 	});
 
 	it("leaves the proof UNKNOWN when the closing-issue edge fails, before any search", async () => {
-		const shell = fakeShell([[CLOSERS, errOut("HTTP 502")]]);
+		const seams = fakeSeams([[CLOSERS, GATEWAY]]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain("closing #5747");
-		expect(shell.calls.some((line) => SEARCH.test(line))).toBe(false);
+		expect(seams.requests.some((line) => SEARCH.test(line))).toBe(false);
 	});
 });
 
 describe("lane prove — the union of the two nomination reads", () => {
 	it("proves a DONE off the closing edge while the search index still lags the fresh PR", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls(4318)],
-			[SEARCH, okOut("")],
+			[SEARCH, nominated()],
 			[PULL, pull()],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({evidence: {kind: "open-pull", pr: 4318}});
 	});
 
 	it("proves a DONE off the search nomination for a Part of PR the closing edge cannot see", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull({body: "Part of #5747\n\n## Deviations\nNone.\n"})],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({evidence: {kind: "open-pull", pr: 4318}});
 	});
 
 	it("counts a PR both reads nominate once, so agreement is not ambiguity", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls(4318)],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({evidence: {kind: "open-pull", pr: 4318}});
-		expect(shell.calls.filter((line) => PULL.test(line))).toHaveLength(1);
+		expect(seams.requests.filter((line) => PULL.test(line))).toHaveLength(1);
 	});
 });
 
@@ -314,21 +315,19 @@ describe("lane prove — the §CP advisory carrier (ADR 0111/0226)", () => {
 	const CONFIG = /^GET \S+\/repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
 	const advisory = (rows = ""): string =>
 		`review-code: advisory — merge stays human-gated\n${rows}\nReviewed-head: @ ${HEAD}\n`;
-	const codeFile = okOut(JSON.stringify([{filename: "packages/fabrika-cli/src/lane/prove.ts"}]));
+	const codeFile = served([{filename: "packages/fabrika-cli/src/lane/prove.ts"}]);
 
 	it("proves a review PASS carried by an advisory when the diff classifies control-plane", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: advisory()})],
-		]);
-		const http = fakeHttp([
 			[CODEOWNERS, {status: 200, body: "/packages/fabrika-cli/ @kamp-us/control-plane\n"}],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -339,18 +338,16 @@ describe("lane prove — the §CP advisory carrier (ADR 0111/0226)", () => {
 	});
 
 	it("still rows a marker-less comment absent when the diff is not control-plane", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: advisory()})],
-		]);
-		const http = fakeHttp([
 			[CODEOWNERS, {status: 200, body: "/claude-plugins/ @kamp-us/control-plane\n"}],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-code (absent)");
@@ -358,18 +355,16 @@ describe("lane prove — the §CP advisory carrier (ADR 0111/0226)", () => {
 	});
 
 	it("reads a [FAIL] row inside an advisory as fail, never as a pass", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: advisory("\n- [FAIL] the guard is bypassed\n")})],
-		]);
-		const http = fakeHttp([
 			[CODEOWNERS, {status: 200, body: "/packages/fabrika-cli/ @kamp-us/control-plane\n"}],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_CONTRADICTED);
 		expect(out.stderr.join("\n")).toContain("invalid emission (ADR 0226)");
@@ -377,90 +372,85 @@ describe("lane prove — the §CP advisory carrier (ADR 0111/0226)", () => {
 
 	it("refuses an advisory bound to a head the PR has moved past as in-flight, not proven", async () => {
 		const stale = `review-code: advisory — merge stays human-gated\n\nReviewed-head: @ ${OLD}\n`;
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: stale})],
-		]);
-		const http = fakeHttp([
 			[CODEOWNERS, {status: 200, body: "/packages/fabrika-cli/ @kamp-us/control-plane\n"}],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-code (stale)");
 	});
 
 	it("leaves the proof UNKNOWN when the boundary itself cannot be read", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: advisory()})],
+			[CODEOWNERS, {status: 502, body: '{"message":"Bad Gateway"}'}],
 		]);
-		const http = fakeHttp([[CODEOWNERS, {status: 502, body: '{"message":"Bad Gateway"}'}]]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain(".github/CODEOWNERS");
 	});
 
 	it("still refuses a failed boundary read when the repo's config says ship (ADR 0220 §4)", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: advisory()})],
-		]);
-		const http = fakeHttp([
 			[CODEOWNERS, {status: 502, body: '{"message":"Bad Gateway"}'}],
 			[CONFIG, {status: 200, body: '{"unreadableCodeowners": "ship"}'}],
 		]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 	});
 
 	it("never reads the boundary while no comment reaches for the advisory carrier", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 			[FILES, codeFile],
 			[PR_COMMENTS, comments({id: 1, body: "looks good to me"})],
 		]);
-		const http = fakeHttp([]);
 
-		const out = await run(laneAt("review"), shell, "PASS", http);
+		const out = await run(laneAt("review"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
-		expect(http.calls.some((line) => CODEOWNERS.test(line))).toBe(false);
+		expect(seams.requests.some((line) => CODEOWNERS.test(line))).toBe(false);
 	});
 });
 
 describe("lane prove — what it does not claim, and what it never writes", () => {
 	it("answers not-required for an event no board read can falsify, reading nothing", async () => {
-		const shell = fakeShell([]);
+		const seams = fakeSeams([]);
 		const fs = laneAt("build");
 
-		const out = await run(fs, shell, "BLOCKED");
+		const out = await run(fs, seams, "BLOCKED");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({proof: "not-required", state: "build"});
-		expect(shell.calls).toEqual([]);
+		expect(seams.log).toEqual([]);
 	});
 
 	it("proves a no-PR builder outcome from the investigation label and its diagnosis", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("")],
+			[SEARCH, nominated()],
 			[ISSUE, issue(["type:investigation"])],
 			[
 				ISSUE_COMMENTS,
@@ -468,7 +458,7 @@ describe("lane prove — what it does not claim, and what it never writes", () =
 			],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -478,27 +468,27 @@ describe("lane prove — what it does not claim, and what it never writes", () =
 	});
 
 	it("refuses a no-PR DONE whose only comment predates the build", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("")],
+			[SEARCH, nominated()],
 			[ISSUE, issue(["type:investigation"])],
 			[ISSUE_COMMENTS, comments({id: 900, body: "triaged", createdAt: "2026-08-16T00:30:00Z"})],
 		]);
 
-		const out = await run(laneAt("build"), shell, "DONE");
+		const out = await run(laneAt("build"), seams, "DONE");
 
 		expect(out.code).toBe(PROOF_ABSENT);
 	});
 
 	it("writes nothing on any path — the ledger append stays lane transition's (single-issue)", async () => {
 		const fs = laneAt("build");
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
-			[SEARCH, okOut("4318\n")],
+			[SEARCH, nominated(4318)],
 			[PULL, pull()],
 		]);
 
-		await run(fs, shell, "DONE");
+		await run(fs, seams, "DONE");
 
 		expect(fs.written.size).toBe(0);
 	});
@@ -552,7 +542,7 @@ const epicLaneAt = (state: "build" | "review" | "tail") =>
 
 const runEpic = (
 	fs: ReturnType<typeof fakeFs>,
-	shell: ReturnType<typeof fakeShell>,
+	seams: ReturnType<typeof fakeSeams>,
 	event: string,
 	task: string,
 ) =>
@@ -567,7 +557,7 @@ const runEpic = (
 				cwd: "/repo",
 				env: {CLAUDE_PIPELINE_REPO: "o/r"},
 			}),
-			Layer.mergeAll(fs.layer, shell.layer),
+			Layer.mergeAll(fs.layer, seams.layer),
 		),
 	);
 
@@ -581,7 +571,7 @@ const LOG_RANGE = /^git log --format=/;
 const MERGE_BASE = /^git merge-base /;
 const ANCESTRY = /^git rev-list --parents --ancestry-path /;
 const RAW = /^git diff .* --raw --abbrev=40 -z /;
-const CHILD_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4301\/comments/;
+const CHILD_COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4301\/comments\?/;
 
 /** `git log`'s framing for one commit: `<sha>\x1f<message>\x1e`. */
 const logOf = (...rows: ReadonlyArray<readonly [string, string]>): ExecResult =>
@@ -606,7 +596,7 @@ const GOVERNED_DIGEST = digestOf(GOVERNED_RAW);
 const locating = (
 	branches: ReadonlyArray<string> = [CHILD_BRANCH, "main", "epic/4300"],
 	commits: ReadonlyArray<readonly [string, string]> = [[CHILD_TIP, CHILD_MESSAGE]],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+): ReadonlyArray<Scripted> => [
 	[REV("epic/4300"), okOut(`${EPIC_BASE}\n`)],
 	[BRANCHES, okOut(`${branches.join("\n")}\n`)],
 	[REV(CHILD_BRANCH), okOut(`${CHILD_TIP}\n`)],
@@ -637,9 +627,9 @@ const rangeMarker = (
 
 describe("lane prove — an epic child's DONE stands on commits, never on a PR", () => {
 	it("proves a child DONE from the commits its branch adds over the epic branch", async () => {
-		const shell = fakeShell([...locating()]);
+		const seams = fakeSeams([...locating()]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -655,11 +645,11 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 				naming: 1,
 			},
 		});
-		expect(shell.calls.filter((line) => line.startsWith("gh "))).toEqual([]);
+		expect(seams.requests).toEqual([]);
 	});
 
 	it("reports the range's size and its naming commits as the two numbers they are", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...locating(
 				[CHILD_BRANCH, "main", "epic/4300"],
 				[
@@ -669,7 +659,7 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			),
 		]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence).toMatchObject({commits: 2, naming: 1});
@@ -679,7 +669,7 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 	it("proves a child DONE after its commits have landed on the epic branch", async () => {
 		// The merge base of a contained tip IS that tip, so the range only survives integration if the
 		// verb recovers the epic branch as it stood before the merge that took the child in (#5984).
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
 			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
 			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
@@ -689,7 +679,7 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
 		]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence).toMatchObject({
@@ -700,7 +690,7 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 	});
 
 	it("measures a not-yet-integrated child over its fork point, not over the moved epic tip", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
 			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
 			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
@@ -708,18 +698,18 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
 		]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence).toMatchObject({range: {base: FORK, tip: CHILD_TIP}});
-		expect(shell.calls.some((line) => line.includes(`${FORK}..${CHILD_TIP}`))).toBe(true);
-		expect(shell.calls.some((line) => ANCESTRY.test(line))).toBe(false);
+		expect(seams.calls.some((line) => line.includes(`${FORK}..${CHILD_TIP}`))).toBe(true);
+		expect(seams.calls.some((line) => ANCESTRY.test(line))).toBe(false);
 	});
 
 	it("refuses a child DONE whose branch was cut and never built on", async () => {
-		const shell = fakeShell([...locating([CHILD_BRANCH], [])]);
+		const seams = fakeSeams([...locating([CHILD_BRANCH], [])]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(PROOF_ABSENT);
 		expect(out.stdout).toBe("");
@@ -729,7 +719,7 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 	it("still refuses a never-built branch whose tip a sibling's merge names as first parent", async () => {
 		// The tip is an epic commit, so it is contained and a later merge names it — as its FIRST
 		// parent. Reading the second there would hand back a sibling's fork point and prove nothing.
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
 			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
 			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
@@ -738,28 +728,28 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			[LOG_RANGE, logOf()],
 		]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(PROOF_ABSENT);
 		expect(out.stderr.join("\n")).toContain("cut and not built on");
-		expect(shell.calls.some((line) => line.startsWith(`git merge-base ${sha("5b1b1a9c")}`))).toBe(
+		expect(seams.calls.some((line) => line.startsWith(`git merge-base ${sha("5b1b1a9c")}`))).toBe(
 			false,
 		);
 	});
 
 	it("refuses a child DONE when the branch carries only another child's commits", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			...locating([CHILD_BRANCH], [[CHILD_TIP, "feat(lane): another child (#4302)"]]),
 		]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(PROOF_ABSENT);
 		expect(out.stderr.join("\n")).toContain("names #4301");
 	});
 
 	it("refuses a child DONE when two lane branches both carry its commits", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV("epic/4300"), okOut(`${EPIC_BASE}\n`)],
 			[BRANCHES, okOut(`${CHILD_BRANCH}\nbuild/4301-second-try-deadbeef\n`)],
 			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
@@ -767,24 +757,24 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
 		]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(PROOF_AMBIGUOUS);
 		expect(out.stderr.join("\n")).toContain("build/4301-second-try-deadbeef");
 	});
 
 	it("leaves a child DONE UNKNOWN when the epic branch is not in this tree", async () => {
-		const shell = fakeShell([[REV("epic/4300"), errOut("unknown revision")]]);
+		const seams = fakeSeams([[REV("epic/4300"), errOut("unknown revision")]]);
 
-		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+		const out = await runEpic(epicLaneAt("build"), seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
-		expect(shell.calls.some((line) => BRANCHES.test(line))).toBe(false);
+		expect(seams.calls.some((line) => BRANCHES.test(line))).toBe(false);
 	});
 
 	it("answers not-required for the DONE that lands a reviewed range, reading nothing", async () => {
-		const shell = fakeShell([]);
+		const seams = fakeSeams([]);
 		const fs = fakeFs({
 			files: {
 				[EPIC_WORKFLOW]: epicWorkflowText(),
@@ -795,35 +785,33 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			},
 		});
 
-		const out = await runEpic(fs, shell, "DONE", "issue_4301");
+		const out = await runEpic(fs, seams, "DONE", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({proof: "not-required", state: "integrate"});
-		expect(shell.calls).toEqual([]);
+		expect(seams.log).toEqual([]);
 	});
 });
 
 describe("lane prove — an epic child's PASS stands on a range verdict that still binds", () => {
 	const proving = (...comments: ReadonlyArray<{id: number; body: string}>) =>
-		fakeShell([...locating(), [RAW, okOut(CHILD_RAW)], [CHILD_COMMENTS, comments_(comments)]]);
+		fakeSeams([...locating(), [RAW, okOut(CHILD_RAW)], [CHILD_COMMENTS, comments_(comments)]]);
 
-	const comments_ = (rows: ReadonlyArray<{id: number; body: string}>): ExecResult =>
-		okOut(
-			JSON.stringify(
-				rows.map((row) => ({
-					id: row.id,
-					body: row.body,
-					user: {login: "agent"},
-					created_at: "2026-08-16T03:00:00Z",
-					updated_at: "2026-08-16T03:00:00Z",
-				})),
-			),
+	const comments_ = (rows: ReadonlyArray<{id: number; body: string}>): HttpReply =>
+		served(
+			rows.map((row) => ({
+				id: row.id,
+				body: row.body,
+				user: {login: "agent"},
+				created_at: "2026-08-16T03:00:00Z",
+				updated_at: "2026-08-16T03:00:00Z",
+			})),
 		);
 
 	it("proves a child PASS whose verdict binds the content this range carries now", async () => {
-		const shell = proving({id: 1, body: rangeMarker("PASS", CHILD_DIGEST)});
+		const seams = proving({id: 1, body: rangeMarker("PASS", CHILD_DIGEST)});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -837,7 +825,7 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 	it("digests the range the reviewer measured once the child has been integrated", async () => {
 		// The binding is content and only content (ADR 0276), so an integrated child's PASS reads
 		// `Current` only while prove diffs the same two endpoints the marker was posted over (#5984).
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
 			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
 			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
@@ -849,41 +837,41 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 			[CHILD_COMMENTS, comments_([{id: 1, body: rangeMarker("PASS", CHILD_DIGEST)}])],
 		]);
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence).toMatchObject({
 			range: {base: FORK, tip: CHILD_TIP},
 			content: CHILD_DIGEST,
 		});
-		expect(shell.calls.some((line) => RAW.test(line) && line.includes(FORK))).toBe(true);
+		expect(seams.calls.some((line) => RAW.test(line) && line.includes(FORK))).toBe(true);
 	});
 
 	it("refuses a child PASS with no verdict at all on the child issue", async () => {
-		const shell = proving({id: 1, body: "looks good to me"});
+		const seams = proving({id: 1, body: "looks good to me"});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-code (absent)");
 	});
 
 	it("refuses a child PASS whose verdict binds a digest the range has moved past", async () => {
-		const shell = proving({id: 1, body: rangeMarker("PASS", "2f1a9c4e0b7d")});
+		const seams = proving({id: 1, body: rangeMarker("PASS", "2f1a9c4e0b7d")});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-code (stale)");
 	});
 
 	it("refuses a child PASS whose verdict was written over another range's content", async () => {
-		const shell = proving({
+		const seams = proving({
 			id: 1,
 			body: rangeMarker("PASS", OTHER_DIGEST, "aaaaaaa", "bbbbbbb"),
 		});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-code (stale)");
@@ -891,30 +879,30 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 	});
 
 	it("refuses a child PASS the child issue contradicts with a range FAIL", async () => {
-		const shell = proving({id: 1, body: rangeMarker("FAIL", CHILD_DIGEST)});
+		const seams = proving({id: 1, body: rangeMarker("FAIL", CHILD_DIGEST)});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(PROOF_CONTRADICTED);
 		expect(out.stderr.join("\n")).toContain("FAIL");
 	});
 
 	it("names a PR-scoped marker posted on the child issue instead of reading it as no verdict", async () => {
-		const shell = proving({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`});
+		const seams = proving({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("is not a range one");
 	});
 
 	const governedBy = (...comments: ReadonlyArray<{id: number; body: string}>) =>
-		fakeShell([...locating(), [RAW, okOut(GOVERNED_RAW)], [CHILD_COMMENTS, comments_(comments)]]);
+		fakeSeams([...locating(), [RAW, okOut(GOVERNED_RAW)], [CHILD_COMMENTS, comments_(comments)]]);
 
 	it("refuses a child PASS whose range touches a governance root and carries no governance verdict", async () => {
-		const shell = governedBy({id: 1, body: rangeMarker("PASS", GOVERNED_DIGEST)});
+		const seams = governedBy({id: 1, body: rangeMarker("PASS", GOVERNED_DIGEST)});
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("derives review-code, governance");
@@ -923,7 +911,7 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 	});
 
 	it("proves that same governed child PASS once the governance range verdict is on the issue", async () => {
-		const shell = governedBy(
+		const seams = governedBy(
 			{id: 1, body: rangeMarker("PASS", GOVERNED_DIGEST)},
 			{
 				id: 2,
@@ -937,7 +925,7 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 			},
 		);
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(0);
 		expect(
@@ -946,9 +934,9 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 	});
 
 	it("leaves a child PASS UNKNOWN when the range's own content cannot be read", async () => {
-		const shell = fakeShell([...locating(), [RAW, errOut("fatal: bad object")]]);
+		const seams = fakeSeams([...locating(), [RAW, errOut("fatal: bad object")]]);
 
-		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+		const out = await runEpic(epicLaneAt("review"), seams, "PASS", "issue_4301");
 
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
@@ -957,35 +945,15 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 
 describe("lane prove — the epic tail keeps the PR arms", () => {
 	it("proves the tail PASS off the one PR's current-head verdicts, reading no range", async () => {
-		const shell = fakeShell([
-			[/^gh api graphql -f query=query\(/, closingPulls()],
-			[/^gh api --paginate search\/issues/, okOut("4318\n")],
-			[
-				/^gh api repos\/o\/r\/pulls\/4318$/,
-				okOut(
-					JSON.stringify({
-						number: 4318,
-						state: "open",
-						head: {sha: HEAD},
-						base: {ref: "main"},
-						body: "Fixes #4300\n\n## Deviations\nNone.\n",
-						changed_files: 1,
-						comments: 1,
-						merged: false,
-					}),
-				),
-			],
-			[
-				/^gh api --paginate repos\/o\/r\/pulls\/4318\/files/,
-				okOut(JSON.stringify([{filename: "packages/fabrika-cli/src/lane/prove.ts"}])),
-			],
-			[
-				/^gh api --paginate repos\/o\/r\/issues\/4318\/comments/,
-				comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`}),
-			],
+		const seams = fakeSeams([
+			[CLOSERS, closingPulls()],
+			[SEARCH, nominated(4318)],
+			[PULL, pull({body: "Fixes #4300\n\n## Deviations\nNone.\n"})],
+			[FILES, served([{filename: "packages/fabrika-cli/src/lane/prove.ts"}])],
+			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
 		]);
 
-		const out = await runEpic(epicLaneAt("tail"), shell, "PASS", "epic_4300");
+		const out = await runEpic(epicLaneAt("tail"), seams, "PASS", "epic_4300");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -993,6 +961,6 @@ describe("lane prove — the epic tail keeps the PR arms", () => {
 			issue: 4300,
 			evidence: {kind: "head-verdicts", pr: 4318, head: HEAD},
 		});
-		expect(shell.calls.some((line) => BRANCHES.test(line))).toBe(false);
+		expect(seams.calls.some((line) => BRANCHES.test(line))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
@@ -1,8 +1,8 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {GIT_DIRS, served} from "../build/fixtures.test-support.ts";
+import {GATEWAY, GIT_DIRS, served} from "../build/fixtures.test-support.ts";
 import {CONFIG_PATH} from "../config/document.ts";
-import {errOut, fakeFs, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {runChild} from "./child-verb.ts";
 import {
@@ -34,9 +34,10 @@ import {manifestPath, parseManifest, renderRunRecord, runJsonPath} from "./run.t
 const CREATE = /^POST https:\/\/api\.github\.com\/repos\/o\/r\/issues$/;
 const LINK = /^POST https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/sub_issues$/;
 const READBACK = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4301$/;
-const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
-const MILESTONES = /^gh api --paginate repos\/o\/r\/milestones/;
+const SUBS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/sub_issues\?/;
+const LABELS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/labels\?/;
+const MILESTONES = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/milestones\?/;
+const EPIC_READ = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 
 const MINTED_LABELS = ["type:feature", "p1", "status:planned", "ready-for:agent"];
 
@@ -56,7 +57,7 @@ const RUN_JSON = (cycleDoc: "present" | "absent" | "unknown" = "present") =>
 const CREATED = served({number: 4301, id: 90210});
 
 const HAPPY: ReadonlyArray<Scripted> = [
-	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+	[EPIC_READ, epic()],
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	...CLAIMED,
 	[LABELS, labelSet(...DEFAULT_LABELS)],
@@ -64,7 +65,7 @@ const HAPPY: ReadonlyArray<Scripted> = [
 	[CREATE, CREATED],
 	[LINK, served({})],
 	[READBACK, childIssue({number: 4301, labels: MINTED_LABELS, milestone: HOME})],
-	[SUBS, okOut(JSON.stringify([{number: 4301, id: 90210, state: "open", state_reason: null}]))],
+	[SUBS, served([{number: 4301, id: 90210, state: "open", state_reason: null}])],
 ];
 
 const options = {
@@ -99,7 +100,7 @@ const run = (
 	).then((outcome) => ({
 		outcome,
 		written: fs.written,
-		calls: shell.calls,
+		calls: shell.log,
 		requests: shell.requests,
 		bodies: shell.bodies,
 	}));
@@ -219,7 +220,7 @@ describe("runChild", () => {
 		expect(JSON.parse(minted.outcome.stdout).observed.milestone).toBe(null);
 		expect(sent(minted, CREATE).labels).toContain(LANE);
 		expect(sent(minted, CREATE)).not.toHaveProperty("milestone");
-		expect(minted.calls.some((line) => MILESTONES.test(line))).toBe(false);
+		expect(minted.requests.some((line) => MILESTONES.test(line))).toBe(false);
 	});
 
 	it("refuses a retired priority", async () => {
@@ -230,12 +231,12 @@ describe("runChild", () => {
 
 	/** #4285: `POST .../labels` CREATES an unknown label rather than rejecting it. */
 	it("refuses a label absent from the repo taxonomy rather than minting it", async () => {
-		const {outcome, calls} = await run({labels: ["not-a-label"]});
+		const {outcome, requests} = await run({labels: ["not-a-label"]});
 		expect(outcome.code).toBe(OFF_VOCABULARY);
 		expect(outcome.stderr.at(-1)).toBe(
 			'ledger child: label "not-a-label" is absent from o/r\'s taxonomy — refusing to create it (#4285).',
 		);
-		expect(calls.some((line) => CREATE.test(line))).toBe(false);
+		expect(requests.some((line) => CREATE.test(line))).toBe(false);
 	});
 
 	it("refuses a milestone that is not open in the repo", async () => {
@@ -336,18 +337,18 @@ describe("runChild", () => {
 	});
 
 	it("refuses when a precondition read fails, and creates nothing", async () => {
-		const {outcome, calls} = await run({}, [
+		const {outcome, requests} = await run({}, [
 			...HAPPY.filter(([pattern]) => pattern !== LABELS),
-			[LABELS, errOut("gh: Bad Gateway (HTTP 502)")],
+			[LABELS, GATEWAY],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
-		expect(calls.some((line) => CREATE.test(line))).toBe(false);
+		expect(requests.some((line) => CREATE.test(line))).toBe(false);
 	});
 
 	it("seats a create that could not be proven on 8", async () => {
 		const {outcome} = await run({}, [
 			...HAPPY.filter(([pattern]) => pattern !== CREATE),
-			[CREATE, errOut("gh: Bad Gateway (HTTP 502)")],
+			[CREATE, GATEWAY],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 	});
@@ -360,7 +361,7 @@ describe("runChild", () => {
 	it("records the child before it links, so a 23 leaves a findable number", async () => {
 		const {outcome, written} = await run({}, [
 			...HAPPY.filter(([pattern]) => pattern !== LINK),
-			[LINK, errOut("gh: Unprocessable (HTTP 422)")],
+			[LINK, {status: 422, body: '{"message":"Unprocessable"}'}],
 		]);
 		expect(outcome.code).toBe(LINK_UNPROVEN);
 		expect(outcome.stderr.at(-1)).toContain("recorded in the run manifest as linked:false");
@@ -372,7 +373,7 @@ describe("runChild", () => {
 	it("seats an unprovable link on 23 even when the write itself returned", async () => {
 		const {outcome} = await run({}, [
 			...HAPPY.filter(([pattern]) => pattern !== SUBS),
-			[SUBS, okOut("[]")],
+			[SUBS, served([])],
 		]);
 		expect(outcome.code).toBe(LINK_UNPROVEN);
 	});
@@ -380,7 +381,7 @@ describe("runChild", () => {
 	it("seats a create it cannot re-read on 8", async () => {
 		const {outcome} = await run({}, [
 			...HAPPY.filter(([pattern]) => pattern !== READBACK),
-			[READBACK, errOut("gh: Bad Gateway (HTTP 502)")],
+			[READBACK, GATEWAY],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 	});

--- a/packages/fabrika-cli/src/ledger/draft-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/draft-verb.unit.test.ts
@@ -1,8 +1,7 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {GIT_DIRS} from "../build/fixtures.test-support.ts";
-import {errOut, fakeFs, fakeShell} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeFs, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BAD_SECTIONS,
@@ -21,8 +20,10 @@ import {planPath, renderRunRecord, runJsonPath} from "./run.ts";
 const EPIC_BODY = "An epic brief about the moderation queue.\n";
 const DIGEST = bodyDigest(EPIC_BODY);
 
-const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+const EPIC_READ = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
+
+const GROUND: ReadonlyArray<Scripted> = [
+	[EPIC_READ, epic()],
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	...CLAIMED,
 ];
@@ -42,11 +43,11 @@ const run = (
 	stdin: Effect.Effect<StdinRead>,
 	options: {
 		digest?: string;
-		script?: ReadonlyArray<readonly [RegExp, ExecResult]>;
+		script?: ReadonlyArray<Scripted>;
 		files?: Readonly<Record<string, string | null>>;
 	} = {},
 ) => {
-	const shell = fakeShell(options.script ?? GROUND);
+	const shell = fakeSeams(options.script ?? GROUND);
 	const fs = fakeFs({files: options.files ?? {[runJsonPath(DIR)]: RUN_JSON}});
 	return Effect.runPromise(
 		Effect.provide(
@@ -146,7 +147,7 @@ describe("runDraft", () => {
 	it("refuses an unreadable tree root on 11 — the run directory is UNKNOWN", async () => {
 		const {outcome} = await run(text(planBlock()), {
 			script: [
-				[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+				[EPIC_READ, epic()],
 				[/^git rev-parse --path-format=absolute/, errOut("fatal: not a git repository")],
 				...CLAIMED,
 			],
@@ -160,7 +161,7 @@ describe("runDraft", () => {
 	it("refuses an issue that is not a type:epic", async () => {
 		const {outcome} = await run(text(planBlock()), {
 			script: [
-				[/^gh api repos\/o\/r\/issues\/4300$/, epic({labels: [{name: "type:chore"}]})],
+				[EPIC_READ, epic({labels: [{name: "type:chore"}]})],
 				[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 				...CLAIMED,
 			],

--- a/packages/fabrika-cli/src/ledger/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/ledger/fixtures.test-support.ts
@@ -1,5 +1,5 @@
 /**
- * The canned `gh` and `git` responses the `ledger` verb tests script their spawner with.
+ * The canned GitHub and `git` responses the `ledger` verb tests script their seams with.
  *
  * Shaped like the real payloads rather than like the parsers, so a parser that starts reading a
  * different field still has to find it here — a fixture trimmed to exactly what the code reads today
@@ -16,8 +16,7 @@ import {
 	NONCE,
 	served,
 } from "../build/fixtures.test-support.ts";
-import {type HttpReply, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import type {HttpReply} from "../fakes.test-support.ts";
 import {PLAN_SECTIONS} from "./plan-block.ts";
 import {runDir, runKey} from "./run.ts";
 
@@ -36,20 +35,18 @@ export const env = {
 	...GH_TOKEN_ENV,
 } as Record<string, string | undefined>;
 
-export const epic = (overrides: Record<string, unknown> = {}): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: EPIC,
-			title: "The moderation queue epic",
-			body: "An epic brief about the moderation queue.\n",
-			state: "open",
-			labels: [{name: "type:epic"}, {name: "status:triaged"}],
-			html_url: "https://github.com/o/r/issues/4300",
-			milestone: null,
-			state_reason: null,
-			...overrides,
-		}),
-	);
+export const epic = (overrides: Record<string, unknown> = {}): HttpReply =>
+	served({
+		number: EPIC,
+		title: "The moderation queue epic",
+		body: "An epic brief about the moderation queue.\n",
+		state: "open",
+		labels: [{name: "type:epic"}, {name: "status:triaged"}],
+		html_url: "https://github.com/o/r/issues/4300",
+		milestone: null,
+		state_reason: null,
+		...overrides,
+	});
 
 export interface SubIssueFixture {
 	readonly number: number;
@@ -129,8 +126,8 @@ export const childBody = (
 		"",
 	].join("\n");
 
-export const labelSet = (...names: ReadonlyArray<string>): ExecResult =>
-	okOut(`${names.join("\n")}\n`);
+export const labelSet = (...names: ReadonlyArray<string>): HttpReply =>
+	served(names.map((name) => ({name})));
 
 export const DEFAULT_LABELS: ReadonlyArray<string> = [
 	"type:feature",
@@ -144,24 +141,30 @@ export const DEFAULT_LABELS: ReadonlyArray<string> = [
 	"ready-for:human",
 ];
 
-export const milestones = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
-	okOut(rows.map(([number, title]) => `${number}\t${title}`).join("\n"));
+export const milestones = (...rows: ReadonlyArray<readonly [number, string]>): HttpReply =>
+	served(rows.map(([number, title]) => ({number, title})));
 
-/** `<number>\t<title>` rows — the shape the `search/issues` dedup source is still read in. */
-export const issueRows = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
-	okOut(rows.map(([number, title]) => `${number}\t${title}`).join("\n"));
+/** One page of the `search/issues` envelope — the dedup index's own shape, count and all. */
+export const issueRows = (...rows: ReadonlyArray<readonly [number, string]>): HttpReply =>
+	served({
+		total_count: rows.length,
+		items: rows.map(([number, title]) => ({number, title})),
+	});
 
 /** The same rows as one served page of `issues?state=open` — the backlog dedup source. */
 export const backlogPage = (...rows: ReadonlyArray<readonly [number, string]>): HttpReply =>
 	served(rows.map(([number, title]) => ({number, title})));
 
 /** The claim on the epic, held by the lane `TOKEN` names — the one the run key is derived from. */
-export const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+export const CLAIMED: ReadonlyArray<readonly [RegExp, HttpReply]> = [
 	[
-		new RegExp(`^gh api --paginate repos/${REPO}/issues/${EPIC}/comments`),
+		new RegExp(`^GET .*/repos/${REPO}/issues/${EPIC}/comments\\?`),
 		comments({id: 1, body: marker(SESSION, LANE_UUID)}),
 	],
-	[new RegExp(`^gh api repos/${REPO}/collaborators/agent/permission`), okOut("write\n")],
+	[
+		new RegExp(`^GET .*/repos/${REPO}/collaborators/agent/permission`),
+		served({permission: "write"}),
+	],
 ];
 
 /** The `--token` the fixture lane passes: the claim `CLAIMED` posts, read back as an identity. */

--- a/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
@@ -26,12 +26,13 @@ import {manifestPath, parseManifest, parseRunRecord, runJsonPath} from "./run.ts
 
 const SHA = "03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1";
 
-const EPIC_READ = /^gh api repos\/o\/r\/issues\/4300$/;
+const EPIC_READ = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 const TREE = /^git rev-parse --path-format=absolute/;
 const SUBS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/sub_issues/;
-const CYCLE = /^gh api repos\/o\/r\/contents\/product-development-cycle\.md$/;
+const CYCLE =
+	/^GET https:\/\/api\.github\.com\/repos\/o\/r\/contents\/product-development-cycle\.md$/;
 const BACKLOG = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\?state=open/;
-const SEARCH = /^gh api --paginate search\/issues/;
+const SEARCH = /^GET https:\/\/api\.github\.com\/search\/issues\?/;
 const REV_LIST = /^git rev-list --count/;
 
 const GROUND: ReadonlyArray<Scripted> = [
@@ -47,7 +48,7 @@ const CLEAN: ReadonlyArray<Scripted> = [
 	...CLAIMED,
 	...GROUND,
 	[SUBS, subIssues()],
-	[CYCLE, okOut("{}")],
+	[CYCLE, {status: 200, body: "{}"}],
 	[BACKLOG, backlogPage([4180, "queue view for reports"])],
 	[SEARCH, issueRows()],
 ];
@@ -199,17 +200,14 @@ describe("runOpen", () => {
 
 	it("refuses a proven-absent epic on 7", async () => {
 		const {outcome} = await run([
-			[EPIC_READ, errOut("gh: Not Found (HTTP 404)")],
+			[EPIC_READ, {status: 404, body: '{"message":"Not Found"}'}],
 			...CLEAN.slice(1),
 		]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 	});
 
 	it("refuses an unreadable epic on 11 — absence is decided by status, never by text", async () => {
-		const {outcome} = await run([
-			[EPIC_READ, errOut("gh: Bad Gateway (HTTP 502)")],
-			...CLEAN.slice(1),
-		]);
+		const {outcome} = await run([[EPIC_READ, GATEWAY], ...CLEAN.slice(1)]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
@@ -227,7 +225,7 @@ describe("runOpen", () => {
 			[EPIC_READ, epic()],
 			[TREE, GIT_DIRS],
 			[
-				/^gh api --paginate repos\/o\/r\/issues\/4300\/comments/,
+				/^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/comments\?/,
 				comments({id: 1, body: "nothing here"}),
 			],
 			...CLEAN.slice(4),

--- a/packages/fabrika-cli/src/ledger/supersede-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/supersede-verb.unit.test.ts
@@ -1,16 +1,7 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {GATEWAY, GIT_DIRS, served} from "../build/fixtures.test-support.ts";
-import {
-	errOut,
-	fakeFs,
-	fakeSeams,
-	type HttpReply,
-	okOut,
-	once,
-	type Scripted,
-} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	BARE_AT_PATH,
 	LEAKED_PATH,
@@ -33,7 +24,8 @@ import {runSupersede} from "./supersede-verb.ts";
 
 const SUBS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/sub_issues/;
 const CHILD = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4288$/;
-const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4288\/comments/;
+const EPIC_READ = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
+const COMMENT = /^POST https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4288\/comments$/;
 const UNLINK = /^DELETE https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300\/sub_issue$/;
 const CLOSE = /^PATCH https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4288$/;
 
@@ -63,21 +55,19 @@ const files = (...records: ReadonlyArray<ChildRecord>) => ({
 	[manifestPath(DIR)]: renderManifest(records),
 });
 
-const COMMENTED = okOut(
-	JSON.stringify({id: 5230661234, html_url: "https://github.com/o/r/issues/4288#c"}),
-);
+const COMMENTED = served({id: 5230661234, html_url: "https://github.com/o/r/issues/4288#c"}, 201);
 
 /** The three legs and the reads around them; `once` lets each read differ before and after. */
 const happy = (
 	overrides: {
-		comment?: ExecResult;
+		comment?: HttpReply;
 		unlink?: HttpReply;
 		close?: HttpReply;
 		after?: HttpReply;
 		afterSubs?: HttpReply;
 	} = {},
 ): ReadonlyArray<Scripted> => [
-	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+	[EPIC_READ, epic()],
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	...CLAIMED,
 	[once(SUBS), subIssues({number: 4288, id: 42880})],
@@ -139,8 +129,6 @@ describe("runSupersede", () => {
 	 * Closing before unlinking leaves a closed issue still counted as a sub-issue, which the gate reads
 	 * as a child in scope that can never carry a live assignee (#5026).
 	 */
-	// The three legs no longer share a seam — the journal is a `gh` comment, the unlink and close are
-	// requests — so the order is read off the combined log rather than off either one.
 	it("unlinks before it closes, and journals before either", async () => {
 		const {log} = await run();
 		const order = log.filter((line) => COMMENT.test(line) || UNLINK.test(line) || CLOSE.test(line));
@@ -158,18 +146,18 @@ describe("runSupersede", () => {
 	});
 
 	it("refuses a child this run minted — a re-plan does not retire its own work", async () => {
-		const {outcome, calls} = await run(happy(), files(record(4288, true)));
+		const {outcome, requests} = await run(happy(), files(record(4288, true)));
 		expect(outcome.code).toBe(OFF_VOCABULARY);
 		expect(outcome.stderr.at(-1)).toBe(
 			"ledger supersede: #4288 was minted by this run — refusing to supersede a child of the current plan.",
 		);
-		expect(calls.some((line) => COMMENT.test(line))).toBe(false);
+		expect(requests.some((line) => COMMENT.test(line))).toBe(false);
 	});
 
 	it("refuses a child that is not this epic's sub-issue", async () => {
 		const {outcome} = await run(
 			[
-				[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+				[EPIC_READ, epic()],
 				[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 				...CLAIMED,
 				[SUBS, subIssues({number: 4301, id: 43010})],
@@ -182,7 +170,7 @@ describe("runSupersede", () => {
 
 	it("refuses a child that is already closed", async () => {
 		const {outcome} = await run([
-			[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+			[EPIC_READ, epic()],
 			[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 			...CLAIMED,
 			[SUBS, subIssues({number: 4288, id: 42880})],
@@ -192,12 +180,12 @@ describe("runSupersede", () => {
 	});
 
 	it("refuses a reason carrying a machine-local path, masked", async () => {
-		const {outcome, calls} = await run(happy(), files(record(4288, false)), {
+		const {outcome, log} = await run(happy(), files(record(4288, false)), {
 			reason: "see /Users/someone/notes.md",
 		});
 		expect(outcome.code).toBe(LEAKED_PATH);
 		expect(outcome.stderr.join("\n")).toContain("/Users/<redacted>");
-		expect(calls).toEqual([]);
+		expect(log).toEqual([]);
 	});
 
 	it("refuses a reason that is a bare @ path reference", async () => {
@@ -233,10 +221,10 @@ describe("runSupersede", () => {
 
 	it("refuses when the sub-issue list could not be read", async () => {
 		const {outcome} = await run([
-			[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+			[EPIC_READ, epic()],
 			[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 			...CLAIMED,
-			[SUBS, errOut("gh: Bad Gateway (HTTP 502)")],
+			[SUBS, GATEWAY],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});

--- a/packages/fabrika-cli/src/ledger/topology-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/topology-verb.unit.test.ts
@@ -1,8 +1,7 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {GIT_DIRS} from "../build/fixtures.test-support.ts";
-import {fakeFs, fakeShell} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BAD_SECTIONS,
@@ -24,8 +23,8 @@ import {
 } from "./run.ts";
 import {runTopology} from "./topology-verb.ts";
 
-const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+const GROUND: ReadonlyArray<Scripted> = [
+	[/^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/, epic()],
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	...CLAIMED,
 ];
@@ -60,7 +59,7 @@ const run = (
 	stdinText: string,
 	fsFiles: Readonly<Record<string, string | null>> = files(record(4301), record(4303)),
 ) => {
-	const shell = fakeShell(GROUND);
+	const shell = fakeSeams(GROUND);
 	const fs = fakeFs({files: fsFiles});
 	const stdin: Effect.Effect<StdinRead> = Effect.succeed({_tag: "Text", text: stdinText});
 	return Effect.runPromise(

--- a/packages/fabrika-cli/src/ledger/write-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/write-verb.unit.test.ts
@@ -1,8 +1,7 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {GIT_DIRS} from "../build/fixtures.test-support.ts";
-import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	EPIC_MOVED,
 	NOT_STAGED,
@@ -17,8 +16,9 @@ import {CLAIMED, DIR, env, epic, TOKEN} from "./fixtures.test-support.ts";
 import {planPath, renderRunRecord, runJsonPath, topologyPath} from "./run.ts";
 import {runWrite} from "./write-verb.ts";
 
-const EPIC_READ = /^gh api repos\/o\/r\/issues\/4300$/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4300/;
+const EPIC_READ = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
+const PATCH = /^PATCH https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
+const PATCHED: HttpReply = {status: 200, body: "{}"};
 
 const BODY = "An epic brief about the moderation queue.\n";
 const DIGEST = bodyDigest(BODY);
@@ -46,28 +46,28 @@ const STAGED = {
  * the pre-write one. Built per call, because a spent `once` pattern would leak across tests.
  */
 const happy = (
-	options: {before?: string; after?: string; patch?: ExecResult} = {},
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	options: {before?: string; after?: string; patch?: HttpReply} = {},
+): ReadonlyArray<Scripted> => [
 	[once(EPIC_READ), epic({body: options.before ?? BODY})],
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	...CLAIMED,
-	[PATCH, options.patch ?? okOut("{}")],
+	[PATCH, options.patch ?? PATCHED],
 	[EPIC_READ, epic({body: options.after ?? SPLICED})],
 ];
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]> = happy(),
+	script: ReadonlyArray<Scripted> = happy(),
 	files: Readonly<Record<string, string | null>> = STAGED,
 	digest: string = DIGEST,
 ) => {
-	const shell = fakeShell(script);
+	const shell = fakeSeams(script);
 	const fs = fakeFs({files});
 	return Effect.runPromise(
 		Effect.provide(
 			runWrite({number: 4300, bodyDigest: digest, token: TOKEN, repo: null, cwd: "/repo", env}),
 			Layer.mergeAll(shell.layer, fs.layer),
 		),
-	).then((outcome) => ({outcome, calls: shell.calls}));
+	).then((outcome) => ({outcome, calls: shell.log}));
 };
 
 describe("runWrite", () => {
@@ -140,7 +140,7 @@ describe("runWrite", () => {
 				[once(EPIC_READ), epic({body})],
 				[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 				...CLAIMED,
-				[PATCH, okOut("{}")],
+				[PATCH, PATCHED],
 				[EPIC_READ, epic({body})],
 			],
 			{...STAGED, [runJsonPath(DIR)]: runJson("fresh")},
@@ -150,7 +150,7 @@ describe("runWrite", () => {
 	});
 
 	it("seats an unconfirmable PATCH on 8", async () => {
-		const {outcome} = await run(happy({patch: errOut("gh: Bad Gateway (HTTP 502)")}));
+		const {outcome} = await run(happy({patch: {status: 502, body: '{"message":"Bad Gateway"}'}}));
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stdout).toBe("");
 	});
@@ -161,7 +161,7 @@ describe("runWrite", () => {
 			[once(EPIC_READ), epic()],
 			[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 			...CLAIMED,
-			[PATCH, okOut("{}")],
+			[PATCH, PATCHED],
 			[EPIC_READ, epic({body: `${SPLICED}\nsomeone else wrote this\n`})],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);

--- a/packages/fabrika-cli/src/map/descope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/descope-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import {renderOutOfScope, spliceSection} from "./body.ts";
 import {ALREADY_DESCOPED, BAD_SECTIONS, DIGEST_STALE, TICKET_UNKNOWN} from "./codes.ts";
 import {runDescope} from "./descope-verb.ts";
@@ -22,12 +21,14 @@ import {composeTicketMarker} from "./markers.ts";
 const PERMISSION = /collaborators\/.*\/permission/;
 const CHILDREN = /issues\/9140\/sub_issues/;
 const TICKET_COMMENTS = /issues\/9142\/comments/;
-const POST_TICKET = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const POST_TICKET = /POST .*\/issues\/9142\/comments/;
 const EDGES = /issues\/9142\/dependencies\//;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
-const PATCH_MAP = /--method PATCH repos\/o\/r\/issues\/9140/;
-const PATCH_TICKET = /--method PATCH repos\/o\/r\/issues\/9142/;
+const PATCH_MAP = /PATCH .*\/issues\/9140/;
+const PATCH_TICKET = /PATCH .*\/issues\/9142/;
+
+const served = (body: string) => ({status: 200, body}) as const;
 
 const REASON = "reason.md";
 const DIRECTION = "a per-topic weight multiplier";
@@ -45,14 +46,14 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	over: Partial<typeof options> = {},
 	files: Readonly<Record<string, string | null>> = {[REASON]: `${WHY}\n`},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runDescope({...options, ...over}),
-			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+			Layer.merge(fakeSeams(script).layer, fakeFs({files}).layer),
 		),
 	);
 
@@ -62,8 +63,10 @@ const appended = spliceSection(
 	renderOutOfScope({direction: DIRECTION, reason: WHY, recordedAt: "2026-08-10"}),
 );
 
-const mapOk = (body = MAP_BODY) =>
-	[MAP_ISSUE, okOut(issueJson({number: MAP, body, labels: ["wayfinding:map"]}))] as const;
+const mapOk = (body = MAP_BODY): Scripted => [
+	MAP_ISSUE,
+	served(issueJson({number: MAP, body, labels: ["wayfinding:map"]})),
+];
 
 describe("runDescope", () => {
 	it("exits 4 on an empty reason — an entry with none is one the next session re-proposes", async () => {
@@ -90,18 +93,18 @@ describe("runDescope", () => {
 	it("exits 13 when --ticket is not a frontier ticket of this map", async () => {
 		const out = await run(
 			[
-				[PERMISSION, okOut("write")],
-				[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+				[PERMISSION, served('{"permission":"write"}')],
+				[CHILDREN, served(`[{"number":${TICKET}}]`)],
 				[
 					TICKET_COMMENTS,
-					okOut(
+					served(
 						commentsJson([
 							{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
 						]),
 					),
 				],
-				[EDGES, okOut("[]")],
-				[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+				[EDGES, served("[]")],
+				[TICKET_ISSUE, served(issueJson({number: TICKET}))],
 				mapOk(),
 			],
 			{ticket: 9999},
@@ -112,12 +115,12 @@ describe("runDescope", () => {
 
 	it("exits 0 and reports the section's new size, which only ever grows", async () => {
 		const out = await run([
-			[PATCH_MAP, okOut("{}")],
+			[PATCH_MAP, served("{}")],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: appended, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: appended, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({map: MAP, direction: DIRECTION, entries: 1});
@@ -137,13 +140,13 @@ describe("runDescope", () => {
 				}),
 			].join("\n"),
 		);
-		const shell = fakeShell([
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_MAP, served("{}")],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY_WITH_REJECTION, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY_WITH_REJECTION, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: twoEntries, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: twoEntries, labels: ["wayfinding:map"]}))],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -153,49 +156,49 @@ describe("runDescope", () => {
 					direction: "importing the old forum's reputation score",
 				}),
 				Layer.merge(
-					shell.layer,
+					seams.layer,
 					fakeFs({files: {[REASON]: "the old score counted post volume\n"}}).layer,
 				),
 			),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).entries).toBe(2);
-		const patch = shell.calls.find((line) => line.includes("PATCH")) ?? "";
+		const patch = seams.bodies[seams.requests.findIndex((line) => line.startsWith("PATCH"))] ?? "";
 		expect(patch).toContain("a per-topic weight multiplier");
 	});
 
 	it("retires the named ticket off the frontier and closes it", async () => {
 		const retired = spliceSection(parsed(appended), "Frontier", "");
-		const shell = fakeShell([
-			[POST_TICKET, okOut('{"id":3,"html_url":"u"}')],
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+		const seams = fakeSeams([
+			[POST_TICKET, {status: 201, body: '{"id":3,"html_url":"u"}'}],
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
 			[
 				TICKET_COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
 					]),
 				),
 			],
-			[EDGES, okOut("[]")],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[EDGES, served("[]")],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: retired, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: retired, labels: ["wayfinding:map"]}))],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runDescope({...options, ticket: TICKET}),
-				Layer.merge(shell.layer, fakeFs({files: {[REASON]: `${WHY}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[REASON]: `${WHY}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
-		expect(shell.calls.some((line) => line.includes("map-retired:"))).toBe(true);
-		expect(shell.calls.some((line) => line.includes("state_reason=completed"))).toBe(true);
+		expect(seams.bodies.some((body) => body.includes("map-retired:"))).toBe(true);
+		expect(seams.bodies.some((body) => body.includes('"state_reason":"completed"'))).toBe(true);
 	});
 });

--- a/packages/fabrika-cli/src/map/finding-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/finding-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {
 	BAD_SECTIONS,
 	KIND_MISMATCH,
@@ -22,7 +21,7 @@ import {
 } from "./fixtures.test-support.ts";
 import {composeFindingMarker, composeLaneMarker, composeTicketMarker} from "./markers.ts";
 
-const POST = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const POST = /POST .*\/issues\/9142\/comments/;
 const GET_COMMENT = /issues\/comments\/\d+/;
 const PERMISSION = /collaborators\/.*\/permission/;
 const CHILDREN = /issues\/9140\/sub_issues/;
@@ -30,6 +29,8 @@ const TICKET_COMMENTS = /issues\/9142\/comments/;
 const EDGES = /issues\/9142\/dependencies\//;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
+
+const served = (body: string) => ({status: 200, body}) as const;
 
 const FINDING_PATH = "finding.md";
 
@@ -44,34 +45,33 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	over: Partial<typeof options> = {},
 	files: Readonly<Record<string, string | null>> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runFinding({...options, ...over}),
-			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+			Layer.merge(fakeSeams(script).layer, fakeFs({files}).layer),
 		),
 	);
 
-const held = (nonce = NONCE) =>
+const held = (nonce = NONCE): ReadonlyArray<Scripted> => [
+	[PERMISSION, served('{"permission":"write"}')],
+	[CHILDREN, served(`[{"number":${TICKET}}]`)],
 	[
-		[PERMISSION, okOut("write")],
-		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-		[
-			TICKET_COMMENTS,
-			okOut(
-				commentsJson([
-					{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
-					{id: 2, body: composeLaneMarker({map: MAP, ticket: TICKET, nonce})},
-				]),
-			),
-		],
-		[EDGES, okOut("[]")],
-		[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table?"}))],
-		[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
-	] as const;
+		TICKET_COMMENTS,
+		served(
+			commentsJson([
+				{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
+				{id: 2, body: composeLaneMarker({map: MAP, ticket: TICKET, nonce})},
+			]),
+		),
+	],
+	[EDGES, served("[]")],
+	[TICKET_ISSUE, served(issueJson({number: TICKET, body: "which table?"}))],
+	[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+];
 
 describe("runFinding — the outcome vocabulary", () => {
 	it("exits 1 on an off-vocabulary outcome, naming the three", async () => {
@@ -120,8 +120,8 @@ describe("runFinding — the lane", () => {
 	it("exits 0, records the outcome and releases the lane", async () => {
 		const body = `${composeFindingMarker({map: MAP, ticket: TICKET, outcome: "no-evidence", nonce: NONCE})}\n`;
 		const out = await run([
-			[POST, okOut('{"id":77,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			[POST, {status: 201, body: '{"id":77,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body}))],
 			...held(),
 		]);
 		expect(out.code).toBe(0);
@@ -143,19 +143,19 @@ describe("runFinding — the lane", () => {
 
 	it("exits 15 when no lane is held at all — the state is named rather than guessed", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
 			[
 				TICKET_COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
 					]),
 				),
 			],
-			[EDGES, okOut("[]")],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			[EDGES, served("[]")],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(LANE_NOT_MINE);
 		expect(out.stderr.join("\n")).toContain("the ticket reads open");
@@ -163,19 +163,19 @@ describe("runFinding — the lane", () => {
 
 	it("exits 20 on a decision ticket — a decision has no lane", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
 			[
 				TICKET_COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: composeTicketMarker({map: MAP, kind: "decision", nonce: NONCE})},
 					]),
 				),
 			],
-			[EDGES, okOut("[]")],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			[EDGES, served("[]")],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(KIND_MISMATCH);
 		expect(out.stdout).toBe("");
@@ -183,24 +183,24 @@ describe("runFinding — the lane", () => {
 
 	it("never touches the map body — lane traffic goes to the ticket", async () => {
 		const body = `${composeFindingMarker({map: MAP, ticket: TICKET, outcome: "no-evidence", nonce: NONCE})}\n`;
-		const shell = fakeShell([
-			[POST, okOut('{"id":77,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body}))],
+		const seams = fakeSeams([
+			[POST, {status: 201, body: '{"id":77,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body}))],
 			...held(),
 		]);
 		await Effect.runPromise(
-			Effect.provide(runFinding(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+			Effect.provide(runFinding(options), Layer.merge(seams.layer, fakeFs({}).layer)),
 		);
-		expect(shell.calls.some((line) => line.includes("--method PATCH"))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("PATCH"))).toBe(false);
 	});
 
 	it("exits 8 when the comment write fails, and 9 when it does not read back", async () => {
-		const failed = await run([[POST, errOut("gh: Bad gateway (HTTP 502)")], ...held()]);
+		const failed = await run([[POST, {status: 502, body: "{}"}], ...held()]);
 		expect(failed.code).toBe(WRITE_UNKNOWN);
 		expect(failed.stdout).toBe("");
 		const drifted = await run([
-			[POST, okOut('{"id":77,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body: "not the marker"}))],
+			[POST, {status: 201, body: '{"id":77,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body: "not the marker"}))],
 			...held(),
 		]);
 		expect(drifted.code).toBe(READBACK_MISMATCH);

--- a/packages/fabrika-cli/src/map/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/map/fixtures.test-support.ts
@@ -1,5 +1,5 @@
 /**
- * The map bodies and `gh api` responses every `map` verb test is driven from.
+ * The map bodies and GitHub responses every `map` verb test is driven from.
  *
  * Shared so the eight verb suites assert against one canonical map rather than each inventing its
  * own: a fixture per suite is how two tests come to disagree about what a well-formed body is, and

--- a/packages/fabrika-cli/src/map/fork-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/fork-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import {renderFrontierRow, spliceSection} from "./body.ts";
 import {DIGEST_STALE, KIND_MISMATCH, TICKET_UNKNOWN} from "./codes.ts";
 import {
@@ -18,7 +17,7 @@ import {
 import {runFork, SESSION_LABEL} from "./fork-verb.ts";
 import {composeForkMarker, composeTicketMarker} from "./markers.ts";
 
-const POST = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const POST = /POST .*\/issues\/9142\/comments/;
 const GET_COMMENT = /issues\/comments\/\d+/;
 const PERMISSION = /collaborators\/.*\/permission/;
 const CHILDREN = /issues\/9140\/sub_issues/;
@@ -27,7 +26,9 @@ const EDGES = /issues\/9142\/dependencies\//;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
 const SESSION_ISSUE = /issues\/9301$/;
-const PATCH = /--method PATCH repos\/o\/r\/issues\/9140/;
+const PATCH = /PATCH .*\/issues\/9140/;
+
+const served = (body: string) => ({status: 200, body}) as const;
 
 const options = {
 	map: MAP,
@@ -39,30 +40,27 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: REPO},
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runFork({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runFork({...options, ...over}), fakeSeams(script).layer));
 
-const frontier = (kind: "research" | "prototype" | "decision") =>
+const frontier = (kind: "research" | "prototype" | "decision"): ReadonlyArray<Scripted> => [
+	[PERMISSION, served('{"permission":"write"}')],
+	[CHILDREN, served(`[{"number":${TICKET}}]`)],
 	[
-		[PERMISSION, okOut("write")],
-		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-		[
-			TICKET_COMMENTS,
-			okOut(commentsJson([{id: 1, body: composeTicketMarker({map: MAP, kind, nonce: NONCE})}])),
-		],
-		[EDGES, okOut("[]")],
-		[
-			TICKET_ISSUE,
-			okOut(issueJson({number: TICKET, body: "does an invited çaylak start at 0 karma?"})),
-		],
-	] as const;
+		TICKET_COMMENTS,
+		served(commentsJson([{id: 1, body: composeTicketMarker({map: MAP, kind, nonce: NONCE})}])),
+	],
+	[EDGES, served("[]")],
+	[
+		TICKET_ISSUE,
+		served(issueJson({number: TICKET, body: "does an invited çaylak start at 0 karma?"})),
+	],
+];
 
-const mapOk = [
+const mapOk: Scripted = [
 	MAP_ISSUE,
-	okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
-] as const;
+	served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+];
 
 const forked = spliceSection(
 	parsed(MAP_BODY),
@@ -100,7 +98,7 @@ describe("runFork", () => {
 
 	it("exits 13 when --session is not a grilling session", async () => {
 		const out = await run([
-			[SESSION_ISSUE, okOut(issueJson({number: 9301}))],
+			[SESSION_ISSUE, served(issueJson({number: 9301}))],
 			...frontier("decision"),
 			mapOk,
 		]);
@@ -112,20 +110,20 @@ describe("runFork", () => {
 	it("exits 0, marks the ticket and renders the route onto the row", async () => {
 		const marker = composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301});
 		const out = await run([
-			[POST, okOut('{"id":9,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body: marker}))],
-			[SESSION_ISSUE, okOut(issueJson({number: 9301, labels: [SESSION_LABEL]}))],
-			[PATCH, okOut("{}")],
+			[POST, {status: 201, body: '{"id":9,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body: marker}))],
+			[SESSION_ISSUE, served(issueJson({number: 9301, labels: [SESSION_LABEL]}))],
+			[PATCH, served("{}")],
 			...frontier("decision"),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: forked, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: forked, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
@@ -138,25 +136,25 @@ describe("runFork", () => {
 
 	it("records where the decision is being made and never the decision itself", async () => {
 		const marker = composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301});
-		const shell = fakeShell([
-			[POST, okOut('{"id":9,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body: marker}))],
-			[SESSION_ISSUE, okOut(issueJson({number: 9301, labels: [SESSION_LABEL]}))],
-			[PATCH, okOut("{}")],
+		const seams = fakeSeams([
+			[POST, {status: 201, body: '{"id":9,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body: marker}))],
+			[SESSION_ISSUE, served(issueJson({number: 9301, labels: [SESSION_LABEL]}))],
+			[PATCH, served("{}")],
 			...frontier("decision"),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: forked, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: forked, labels: ["wayfinding:map"]}))],
 		]);
-		await Effect.runPromise(Effect.provide(runFork(options), shell.layer));
-		const patch = shell.calls.find((line) => line.includes("--method PATCH")) ?? "";
-		expect(patch).not.toContain("## Decisions\n-");
+		await Effect.runPromise(Effect.provide(runFork(options), seams.layer));
+		const patch = seams.bodies[seams.requests.findIndex((line) => line.startsWith("PATCH"))] ?? "";
+		expect(patch).not.toContain("## Decisions\\n-");
 		expect(patch).toContain("forked to #9301");
 	});
 });

--- a/packages/fabrika-cli/src/map/lane-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/lane-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {
 	KIND_MISMATCH,
 	LANE_NOT_MINE,
@@ -23,7 +22,7 @@ import {
 import {runLane} from "./lane-verb.ts";
 import {composeLaneMarker, composeRetiredMarker, composeTicketMarker} from "./markers.ts";
 
-const POST = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const POST = /POST .*\/issues\/9142\/comments/;
 const GET_COMMENT = /issues\/comments\/\d+/;
 const PERMISSION = /collaborators\/.*\/permission/;
 const CHILDREN = /issues\/9140\/sub_issues/;
@@ -31,6 +30,8 @@ const TICKET_COMMENTS = /issues\/9142\/comments/;
 const EDGES = /issues\/9142\/dependencies\//;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
+
+const served = (body: string) => ({status: 200, body}) as const;
 
 const ticketMarker = (kind: "research" | "decision" | "prototype" = "research") =>
 	composeTicketMarker({map: MAP, kind, nonce: NONCE});
@@ -43,23 +44,20 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: REPO},
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runLane({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runLane({...options, ...over}), fakeSeams(script).layer));
 
 const frontier = (
 	comments: ReadonlyArray<{readonly id: number; readonly body: string}>,
 	ticketState = "open",
-) =>
-	[
-		[PERMISSION, okOut("write")],
-		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-		[TICKET_COMMENTS, okOut(commentsJson(comments))],
-		[EDGES, okOut("[]")],
-		[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table?", state: ticketState}))],
-		[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
-	] as const;
+): ReadonlyArray<Scripted> => [
+	[PERMISSION, served('{"permission":"write"}')],
+	[CHILDREN, served(`[{"number":${TICKET}}]`)],
+	[TICKET_COMMENTS, served(commentsJson(comments))],
+	[EDGES, served("[]")],
+	[TICKET_ISSUE, served(issueJson({number: TICKET, body: "which table?", state: ticketState}))],
+	[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+];
 
 describe("runLane", () => {
 	it("exits 1 on a lane key two runs would collide on, before any read", async () => {
@@ -72,8 +70,8 @@ describe("runLane", () => {
 	it("exits 0 and holds the lane when it is free", async () => {
 		const body = composeLaneMarker({map: MAP, ticket: TICKET, nonce: NONCE});
 		const out = await run([
-			[POST, okOut('{"id":7,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			[POST, {status: 201, body: '{"id":7,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body}))],
 			...frontier([{id: 1, body: ticketMarker()}]),
 		]);
 		expect(out.code).toBe(0);
@@ -139,10 +137,10 @@ describe("runLane", () => {
 
 	it("exits 11 when the comment read fails — whether a lane is held is UNKNOWN, never free", async () => {
 		const out = await run([
-			[TICKET_COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			[TICKET_COMMENTS, {status: 502, body: "{}"}],
 			...frontier([{id: 1, body: ticketMarker()}]).slice(3),
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -150,7 +148,7 @@ describe("runLane", () => {
 
 	it("exits 8 when the claim write fails — whether the lane is held is UNKNOWN", async () => {
 		const out = await run([
-			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			[POST, {status: 502, body: "{}"}],
 			...frontier([{id: 1, body: ticketMarker()}]),
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
@@ -159,8 +157,8 @@ describe("runLane", () => {
 
 	it("exits 9 when the posted marker does not read back — the stamp is verified, never assumed", async () => {
 		const out = await run([
-			[POST, okOut('{"id":7,"html_url":"u"}')],
-			[GET_COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			[POST, {status: 201, body: '{"id":7,"html_url":"u"}'}],
+			[GET_COMMENT, served(JSON.stringify({body: "something else entirely"}))],
 			...frontier([{id: 1, body: ticketMarker()}]),
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);

--- a/packages/fabrika-cli/src/map/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/open-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	ALREADY_DESCOPED,
@@ -21,15 +20,25 @@ import {runOpen} from "./open-verb.ts";
 const LABELS = /repos\/o\/r\/labels/;
 const OPEN_MAPS = /issues\?state=open&labels=/;
 const SEARCH = /search\/issues/;
-const CREATE = /--method POST repos\/o\/r\/issues -f/;
-const ADD_LABEL = /--method POST repos\/o\/r\/issues\/9140\/labels/;
+const CREATE = /POST .*\/repos\/o\/r\/issues$/;
+const ADD_LABEL = /POST .*\/issues\/9140\/labels/;
 const NEW_MAP = /issues\/9140$/;
 const EXISTING_MAP = /issues\/9200$/;
+
+const served = (body: string) => ({status: 200, body}) as const;
+
+/** The label list as `repos/<repo>/labels` really answers it: one object per label. */
+const labelList = (...names: ReadonlyArray<string>) =>
+	JSON.stringify(names.map((name) => ({name})));
+
+/** An `is:issue` search envelope — `search/issues` declares its count beside its items. */
+const searchHits = (...rows: ReadonlyArray<{readonly number: number; readonly title: string}>) =>
+	JSON.stringify({total_count: rows.length, items: rows});
 
 const QUESTIONS = "does a suspended account keep its weight?\nwhat clock does weight decay on?\n";
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	stdin: StdinRead = {_tag: "Text", text: QUESTIONS},
 	destination = "how moderation weight is earned",
 ) =>
@@ -41,13 +50,13 @@ const run = (
 				env: {CLAUDE_PIPELINE_REPO: REPO},
 				stdin: Effect.succeed(stdin),
 			}),
-			fakeShell(script).layer,
+			fakeSeams(script).layer,
 		),
 	);
 
-const labelsOk = [LABELS, okOut("wayfinding:map\nstatus:needs-triage")] as const;
-const noMaps = [OPEN_MAPS, okOut("")] as const;
-const noHits = [SEARCH, okOut("")] as const;
+const labelsOk: Scripted = [LABELS, served(labelList("wayfinding:map", "status:needs-triage"))];
+const noMaps: Scripted = [OPEN_MAPS, served("[]")];
+const noHits: Scripted = [SEARCH, served(searchHits())];
 const minted = issueJson({number: 9140, body: "", labels: ["wayfinding:map"]});
 
 describe("runOpen — the checks before it mints", () => {
@@ -78,13 +87,13 @@ describe("runOpen — the checks before it mints", () => {
 	});
 
 	it("exits 7 when the wayfinding:map label does not exist", async () => {
-		const out = await run([[LABELS, okOut("status:needs-triage")]]);
+		const out = await run([[LABELS, served(labelList("status:needs-triage"))]]);
 		expect(out.code).toBe(NO_TARGET);
 		expect(out.stderr.join("\n")).toContain("no later run could find");
 	});
 
 	it("exits 11 when the map search fails — nothing was written and charting is UNKNOWN", async () => {
-		const out = await run([labelsOk, [OPEN_MAPS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([labelsOk, [OPEN_MAPS, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
@@ -93,10 +102,10 @@ describe("runOpen — the checks before it mints", () => {
 		const out = await run(
 			[
 				labelsOk,
-				[OPEN_MAPS, okOut("9200\twayfinding: something else")],
+				[OPEN_MAPS, served(JSON.stringify([{number: 9200, title: "wayfinding: something else"}]))],
 				[
 					EXISTING_MAP,
-					okOut(
+					served(
 						issueJson({number: 9200, body: MAP_BODY_WITH_REJECTION, labels: ["wayfinding:map"]}),
 					),
 				],
@@ -109,14 +118,22 @@ describe("runOpen — the checks before it mints", () => {
 	});
 
 	it("exits 16 when two open maps match, refusing to guess which", async () => {
-		const body = okOut(issueJson({number: 9200, body: MAP_BODY, labels: ["wayfinding:map"]}));
+		const body = served(issueJson({number: 9200, body: MAP_BODY, labels: ["wayfinding:map"]}));
 		const out = await run([
 			labelsOk,
-			[OPEN_MAPS, okOut("9200\twayfinding: a\n9201\twayfinding: b")],
+			[
+				OPEN_MAPS,
+				served(
+					JSON.stringify([
+						{number: 9200, title: "wayfinding: a"},
+						{number: 9201, title: "wayfinding: b"},
+					]),
+				),
+			],
 			[/issues\/9200$/, body],
 			[
 				/issues\/9201$/,
-				okOut(issueJson({number: 9201, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: 9201, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
 		]);
 		expect(out.code).toBe(MAP_AMBIGUOUS);
@@ -130,9 +147,12 @@ describe("runOpen — minting and resuming", () => {
 			labelsOk,
 			noMaps,
 			noHits,
-			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
-			[ADD_LABEL, okOut("{}")],
-			[NEW_MAP, okOut(minted)],
+			[
+				CREATE,
+				{status: 201, body: '{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}'},
+			],
+			[ADD_LABEL, served("{}")],
+			[NEW_MAP, served(minted)],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stdout).toBe("");
@@ -158,9 +178,12 @@ describe("runOpen — minting and resuming", () => {
 			labelsOk,
 			noMaps,
 			noHits,
-			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
-			[ADD_LABEL, okOut("{}")],
-			[NEW_MAP, okOut(issueJson({number: 9140, body: composed, labels: ["wayfinding:map"]}))],
+			[
+				CREATE,
+				{status: 201, body: '{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}'},
+			],
+			[ADD_LABEL, served("{}")],
+			[NEW_MAP, served(issueJson({number: 9140, body: composed, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(0);
 		const answer = JSON.parse(out.stdout);
@@ -174,8 +197,11 @@ describe("runOpen — minting and resuming", () => {
 			labelsOk,
 			noMaps,
 			noHits,
-			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
-			[ADD_LABEL, errOut("gh: Bad gateway (HTTP 502)")],
+			[
+				CREATE,
+				{status: 201, body: '{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}'},
+			],
+			[ADD_LABEL, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -183,10 +209,15 @@ describe("runOpen — minting and resuming", () => {
 	});
 
 	it("resumes an already-charted destination without touching its body", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			labelsOk,
-			[OPEN_MAPS, okOut("9200\twayfinding: how moderation weight is earned")],
-			[EXISTING_MAP, okOut(issueJson({number: 9200, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			[
+				OPEN_MAPS,
+				served(
+					JSON.stringify([{number: 9200, title: "wayfinding: how moderation weight is earned"}]),
+				),
+			],
+			[EXISTING_MAP, served(issueJson({number: 9200, body: MAP_BODY, labels: ["wayfinding:map"]}))],
 			noHits,
 		]);
 		const out = await Effect.runPromise(
@@ -197,12 +228,12 @@ describe("runOpen — minting and resuming", () => {
 					env: {CLAUDE_PIPELINE_REPO: REPO},
 					stdin: Effect.succeed({_tag: "Text", text: QUESTIONS} as StdinRead),
 				}),
-				shell.layer,
+				seams.layer,
 			),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({map: 9200, created: false, questions: 2});
-		expect(shell.calls.some((line) => line.includes("--method PATCH"))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("PATCH"))).toBe(false);
 	});
 
 	it("reports ranked candidates as evidence and charts every question anyway", async () => {
@@ -224,11 +255,22 @@ describe("runOpen — minting and resuming", () => {
 		const out = await run([
 			labelsOk,
 			noMaps,
-			[once(SEARCH), okOut("9098\tA suspended account keeps its moderation weight")],
-			[SEARCH, okOut("")],
-			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
-			[ADD_LABEL, okOut("{}")],
-			[NEW_MAP, okOut(issueJson({number: 9140, body: composed, labels: ["wayfinding:map"]}))],
+			[
+				once(SEARCH),
+				served(
+					searchHits({
+						number: 9098,
+						title: "A suspended account keeps its moderation weight",
+					}),
+				),
+			],
+			[SEARCH, served(searchHits())],
+			[
+				CREATE,
+				{status: 201, body: '{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}'},
+			],
+			[ADD_LABEL, served("{}")],
+			[NEW_MAP, served(issueJson({number: 9140, body: composed, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(0);
 		const answer = JSON.parse(out.stdout);

--- a/packages/fabrika-cli/src/map/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/read-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {BAD_SECTIONS, NO_TARGET, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {
 	commentsJson,
@@ -24,28 +23,30 @@ const BLOCKING = /issues\/9142\/dependencies\/blocking/;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
 
-const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+const served = (body: string) => ({status: 200, body}) as const;
+
+const run = (script: ReadonlyArray<Scripted>) =>
 	Effect.runPromise(
 		Effect.provide(
 			runRead({map: MAP, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}}),
-			fakeShell(script).layer,
+			fakeSeams(script).layer,
 		),
 	);
 
-const mapOk = [
+const mapOk: Scripted = [
 	MAP_ISSUE,
-	okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
-] as const;
+	served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+];
 const marker = composeTicketMarker({map: MAP, kind: "research", nonce: NONCE});
-const healthy = [
-	[PERMISSION, okOut("write")],
-	[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-	[TICKET_COMMENTS, okOut(commentsJson([{id: 1, body: marker}]))],
-	[BLOCKED_BY, okOut("[]")],
-	[BLOCKING, okOut("[]")],
-	[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table carries it?"}))],
+const healthy: ReadonlyArray<Scripted> = [
+	[PERMISSION, served('{"permission":"write"}')],
+	[CHILDREN, served(`[{"number":${TICKET}}]`)],
+	[TICKET_COMMENTS, served(commentsJson([{id: 1, body: marker}]))],
+	[BLOCKED_BY, served("[]")],
+	[BLOCKING, served("[]")],
+	[TICKET_ISSUE, served(issueJson({number: TICKET, body: "which table carries it?"}))],
 	mapOk,
-] as const;
+];
 
 describe("runRead", () => {
 	it("exits 0 with the frontier token, the digest and one ticket row", async () => {
@@ -69,32 +70,29 @@ describe("runRead", () => {
 	});
 
 	it("exits 0 with `empty` on a proven-empty child set — zero children is a FACT", async () => {
-		const out = await run([[CHILDREN, okOut("[]")], mapOk]);
+		const out = await run([[CHILDREN, served("[]")], mapOk]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).frontier).toBe("empty");
 	});
 
 	it("exits 11 with nothing on stdout when the child read fails — never an empty frontier", async () => {
-		const out = await run([[CHILDREN, errOut("gh: Bad gateway (HTTP 502)")], mapOk]);
+		const out = await run([[CHILDREN, {status: 502, body: "{}"}], mapOk]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("the frontier is UNKNOWN, never empty");
 	});
 
 	it("exits 11 when a permission read fails — never a demotion that frees another run's lane", async () => {
-		const out = await run([
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
-			...healthy.slice(1),
-		]);
+		const out = await run([[PERMISSION, {status: 502, body: "{}"}], ...healthy.slice(1)]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("exits 7 on an issue that is not a map, and on one that does not exist", async () => {
-		const unlabelled = await run([[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY}))]]);
+		const unlabelled = await run([[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY}))]]);
 		expect(unlabelled.code).toBe(NO_TARGET);
 		expect(unlabelled.stdout).toBe("");
-		const missing = await run([[MAP_ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const missing = await run([[MAP_ISSUE, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(missing.code).toBe(NO_TARGET);
 		expect(missing.stderr.join("\n")).toContain("is not a wayfinding map");
 	});
@@ -103,7 +101,7 @@ describe("runRead", () => {
 		const out = await run([
 			[
 				MAP_ISSUE,
-				okOut(issueJson({number: MAP, body: "## Frontier\n", labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: "## Frontier\n", labels: ["wayfinding:map"]})),
 			],
 		]);
 		expect(out.code).toBe(BAD_SECTIONS);
@@ -112,13 +110,13 @@ describe("runRead", () => {
 
 	it("disregards a malformed marker at exit 0 rather than suppressing the whole frontier", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
 			[
 				TICKET_COMMENTS,
-				okOut(commentsJson([{id: 1, body: "map-ticket: #9140 · investigation · 7f3a9c21"}])),
+				served(commentsJson([{id: 1, body: "map-ticket: #9140 · investigation · 7f3a9c21"}])),
 			],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
 			mapOk,
 		]);
 		expect(out.code).toBe(0);
@@ -135,17 +133,17 @@ describe("runRead", () => {
 
 	it("disregards a marker naming another map, so a stranger's issue is visible not counted", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
 			[
 				TICKET_COMMENTS,
-				okOut(
+				served(
 					commentsJson([
 						{id: 1, body: composeTicketMarker({map: 9999, kind: "research", nonce: NONCE})},
 					]),
 				),
 			],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
 			mapOk,
 		]);
 		expect(JSON.parse(out.stdout).disregarded[0]).toMatchObject({reason: "foreign-map"});
@@ -153,10 +151,10 @@ describe("runRead", () => {
 
 	it("disregards a marker from an author with no write permission", async () => {
 		const out = await run([
-			[PERMISSION, okOut("read")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-			[TICKET_COMMENTS, okOut(commentsJson([{id: 1, body: marker, author: "stranger"}]))],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[PERMISSION, served('{"permission":"read"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
+			[TICKET_COMMENTS, served(commentsJson([{id: 1, body: marker, author: "stranger"}]))],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
 			mapOk,
 		]);
 		expect(JSON.parse(out.stdout).disregarded[0]).toMatchObject({reason: "unauthorized"});
@@ -164,10 +162,10 @@ describe("runRead", () => {
 
 	it("counts an unmarked child as nothing at all — it is not a frontier ticket", async () => {
 		const out = await run([
-			[PERMISSION, okOut("write")],
-			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-			[TICKET_COMMENTS, okOut(commentsJson([]))],
-			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[PERMISSION, served('{"permission":"write"}')],
+			[CHILDREN, served(`[{"number":${TICKET}}]`)],
+			[TICKET_COMMENTS, served(commentsJson([]))],
+			[TICKET_ISSUE, served(issueJson({number: TICKET}))],
 			mapOk,
 		]);
 		const answer = JSON.parse(out.stdout);

--- a/packages/fabrika-cli/src/map/record-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	AUTHORIZATION,
 	answerComment,
@@ -8,7 +8,6 @@ import {
 	roundDigestOf,
 	rulingComment,
 } from "../grill/fixtures.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
 import {type DecisionEntry, renderDecision, renderOutOfScope, spliceSection} from "./body.ts";
 import {
 	BAD_SECTIONS,
@@ -45,8 +44,25 @@ const TICKET_COMMENTS = /issues\/9142\/comments/;
 const EDGES = /issues\/9142\/dependencies\//;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
-const PATCH_MAP = /--method PATCH repos\/o\/r\/issues\/9140/;
-const PATCH_TICKET = /--method PATCH repos\/o\/r\/issues\/9142/;
+const PATCH_MAP = /PATCH .*\/issues\/9140/;
+const PATCH_TICKET = /PATCH .*\/issues\/9142/;
+
+const served = (body: string) => ({status: 200, body}) as const;
+
+type Seams = ReturnType<typeof fakeSeams>;
+
+/** The JSON bodies of every `PATCH …/issues/9140` the run issued, in order. */
+const mapPatches = (seams: Seams): ReadonlyArray<string> =>
+	seams.requests
+		.map((line, index) => ({line, body: seams.bodies[index] ?? ""}))
+		.filter(({line}) => line.startsWith("PATCH") && line.includes("/issues/9140"))
+		.map(({body}) => body);
+
+const mapPatchAt = (seams: Seams): number =>
+	seams.requests.findIndex((line) => line.startsWith("PATCH") && line.includes("/issues/9140"));
+
+const closeAt = (seams: Seams): number =>
+	seams.bodies.findIndex((body) => body.includes('"state_reason":"completed"'));
 
 const FINDING = "finding.md";
 const ANSWER = "the weight column lives on the account row";
@@ -64,14 +80,14 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	over: Partial<typeof options> = {},
 	files: Readonly<Record<string, string | null>> = {[FINDING]: `${ANSWER}\n`},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runRecord({...options, ...over}),
-			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+			Layer.merge(fakeSeams(script).layer, fakeFs({files}).layer),
 		),
 	);
 
@@ -80,14 +96,13 @@ const ticketComments = (
 	kind: "research" | "decision" | "prototype" = "research",
 ) => commentsJson([{id: 1, body: composeTicketMarker({map: MAP, kind, nonce: NONCE})}, ...extra]);
 
-const frontier = (comments: string) =>
-	[
-		[PERMISSION, okOut("write")],
-		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
-		[TICKET_COMMENTS, okOut(comments)],
-		[EDGES, okOut("[]")],
-		[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table carries it?"}))],
-	] as const;
+const frontier = (comments: string): ReadonlyArray<Scripted> => [
+	[PERMISSION, served('{"permission":"write"}')],
+	[CHILDREN, served(`[{"number":${TICKET}}]`)],
+	[TICKET_COMMENTS, served(comments)],
+	[EDGES, served("[]")],
+	[TICKET_ISSUE, served(issueJson({number: TICKET, body: "which table carries it?"}))],
+];
 
 const laneClosed = (outcome: "answered" | "no-evidence" | "unreachable") =>
 	ticketComments([
@@ -120,7 +135,7 @@ describe("runRecord", () => {
 	it("exits 21 when the lane returned unreachable — there is no answer to record", async () => {
 		const out = await run([
 			...frontier(laneClosed("unreachable")),
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(OUTCOME_UNRECORDABLE);
 		expect(out.stdout).toBe("");
@@ -140,27 +155,27 @@ describe("runRecord", () => {
 					"decision",
 				),
 			),
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(TICKET_UNKNOWN);
 		expect(out.stderr.join("\n")).toContain("never by restating it");
 	});
 
 	it("exits 0 on a research finding, moving the row and closing the ticket in that order", async () => {
-		const shell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...frontier(laneClosed("answered")),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRecord(options),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
@@ -170,30 +185,28 @@ describe("runRecord", () => {
 			recorded: `— from #${TICKET}`,
 			closed: true,
 		});
-		const bodyAt = shell.calls.findIndex((line) => line.includes("PATCH repos/o/r/issues/9140"));
-		const closeAt = shell.calls.findIndex((line) => line.includes("state_reason=completed"));
 		// The close is second so the surviving half of a partial application is the re-runnable one.
-		expect(closeAt).toBeGreaterThan(bodyAt);
+		expect(closeAt(seams)).toBeGreaterThan(mapPatchAt(seams));
 	});
 
 	it("moves the answer and the row in ONE body PATCH, so the two cannot separate", async () => {
-		const shell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...frontier(laneClosed("answered")),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
 		]);
 		await Effect.runPromise(
 			Effect.provide(
 				runRecord(options),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
-		const patches = shell.calls.filter((line) => line.includes("PATCH repos/o/r/issues/9140"));
+		const patches = mapPatches(seams);
 		expect(patches).toHaveLength(1);
 		expect(patches[0]).toContain(`— from #${TICKET}`);
 		expect(patches[0]).not.toContain(`- #${TICKET} · research`);
@@ -201,14 +214,14 @@ describe("runRecord", () => {
 
 	it("exits 8 naming the ticket when the close does not land — the visible half is the survivor", async () => {
 		const out = await run([
-			[PATCH_TICKET, errOut("gh: Bad gateway (HTTP 502)")],
-			[PATCH_MAP, okOut("{}")],
+			[PATCH_TICKET, {status: 502, body: "{}"}],
+			[PATCH_MAP, served("{}")],
 			...frontier(laneClosed("answered")),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -236,48 +249,47 @@ const FOLDED = MULTI_PARAGRAPH.replace(/\s*\n\s*/g, " ");
 describe("a multi-paragraph finding", () => {
 	it("is folded to one line, so the body it writes still parses", async () => {
 		const folded = composed({text: FOLDED, authority: {_tag: "Finding", ticket: TICKET}});
-		const shell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...frontier(laneClosed("answered")),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: folded, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: folded, labels: ["wayfinding:map"]}))],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRecord(options),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
 		const landed = parsed(folded);
 		expect(landed.decisions).toHaveLength(1);
 		expect(landed.decisions[0]?.text).toBe(FOLDED);
-		const patch = shell.calls.find((line) => line.includes("PATCH repos/o/r/issues/9140")) ?? "";
-		expect(patch).toContain(FOLDED);
+		expect(mapPatches(seams)[0] ?? "").toContain(FOLDED);
 	});
 });
 
 describe("map record and map descope fold free text the same way", () => {
 	it("both land one line — a sibling that stopped folding fails here", async () => {
 		const folded = composed({text: FOLDED, authority: {_tag: "Finding", ticket: TICKET}});
-		const recordShell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const recordSeams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...frontier(laneClosed("answered")),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: folded, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: folded, labels: ["wayfinding:map"]}))],
 		]);
 		const fromRecord = await Effect.runPromise(
 			Effect.provide(
 				runRecord(options),
-				Layer.merge(recordShell.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
+				Layer.merge(recordSeams.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
 			),
 		);
 
@@ -291,13 +303,13 @@ describe("map record and map descope fold free text the same way", () => {
 				recordedAt: "2026-08-10",
 			}),
 		);
-		const descopeShell = fakeShell([
-			[PATCH_MAP, okOut("{}")],
+		const descopeSeams = fakeSeams([
+			[PATCH_MAP, served("{}")],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: descoped, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: descoped, labels: ["wayfinding:map"]}))],
 		]);
 		const fromDescope = await Effect.runPromise(
 			Effect.provide(
@@ -311,13 +323,13 @@ describe("map record and map descope fold free text the same way", () => {
 					env: {CLAUDE_PIPELINE_REPO: REPO},
 					now: () => new Date("2026-08-10T00:00:00Z"),
 				}),
-				Layer.merge(descopeShell.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
+				Layer.merge(descopeSeams.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
 			),
 		);
 
 		expect([fromRecord.code, fromDescope.code]).toEqual([0, 0]);
-		for (const shell of [recordShell, descopeShell]) {
-			const patch = shell.calls.find((line) => line.includes("PATCH repos/o/r/issues/9140")) ?? "";
+		for (const seams of [recordSeams, descopeSeams]) {
+			const patch = mapPatches(seams)[0] ?? "";
 			expect(patch).toContain(FOLDED.replace(/\.$/, ""));
 			expect(patch).not.toContain("1. the audit log already joins on account id\\n");
 		}
@@ -326,18 +338,17 @@ describe("map record and map descope fold free text the same way", () => {
 
 describe("the lockstep is one act: an interrupted run resumes", () => {
 	/** The map after the body half landed: the answer recorded, the ticket never closed. */
-	const halfDone = () =>
-		[
-			...frontier(laneClosed("answered")),
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
-		] as const;
+	const halfDone = (): ReadonlyArray<Scripted> => [
+		...frontier(laneClosed("answered")),
+		[MAP_ISSUE, served(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+	];
 
 	it("closes the ticket and writes no second entry when the answer is already on the map", async () => {
-		const shell = fakeShell([[PATCH_TICKET, okOut("{}")], ...halfDone()]);
+		const seams = fakeSeams([[PATCH_TICKET, served("{}")], ...halfDone()]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRecord({...options, digest: digestFor(recorded)}),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
@@ -348,12 +359,12 @@ describe("the lockstep is one act: an interrupted run resumes", () => {
 			closed: true,
 			resumed: true,
 		});
-		expect(shell.calls.some((line) => line.includes("PATCH repos/o/r/issues/9140"))).toBe(false);
-		expect(shell.calls.some((line) => line.includes("state_reason=completed"))).toBe(true);
+		expect(mapPatches(seams)).toEqual([]);
+		expect(seams.bodies.some((body) => body.includes('"state_reason":"completed"'))).toBe(true);
 	});
 
 	it("exits 8 when the resumed close still does not land — never 0 with the ticket open", async () => {
-		const out = await run([[PATCH_TICKET, errOut("gh: Bad gateway (HTTP 502)")], ...halfDone()], {
+		const out = await run([[PATCH_TICKET, {status: 502, body: "{}"}], ...halfDone()], {
 			digest: digestFor(recorded),
 		});
 		expect(out.code).toBe(WRITE_UNKNOWN);
@@ -371,7 +382,7 @@ const BOUND = roundDigestOf(1);
 const QUESTION = "R1.2";
 
 /** The frontier of a map whose one ticket is a decision forked to session #9301. */
-const forkedDecision = () =>
+const forkedDecision = (): ReadonlyArray<Scripted> =>
 	frontier(
 		ticketComments(
 			[
@@ -384,14 +395,17 @@ const forkedDecision = () =>
 		),
 	);
 
-const mapAt = (body: string) =>
-	[MAP_ISSUE, okOut(issueJson({number: MAP, body, labels: ["wayfinding:map"]}))] as const;
+const mapAt = (body: string): Scripted => [
+	MAP_ISSUE,
+	served(issueJson({number: MAP, body, labels: ["wayfinding:map"]})),
+];
 
-const session = (comments: ReadonlyArray<{readonly id: number; readonly body: string}>) =>
-	[
-		[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
-		[SESSION_COMMENTS, okOut(commentsJson(comments))],
-	] as const;
+const session = (
+	comments: ReadonlyArray<{readonly id: number; readonly body: string}>,
+): ReadonlyArray<Scripted> => [
+	[SESSION_ISSUE, served(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+	[SESSION_COMMENTS, served(commentsJson(comments))],
+];
 
 /** Round 1 posted, then R1.2 ruled with its adjacent dated authorization. */
 const RULED = [
@@ -407,21 +421,21 @@ const ruledRecord = composed({
 
 describe("a forked decision ticket's ruling is read through the grill reader", () => {
 	it("exits 0 recording the ruling when the cited question reads ruled", async () => {
-		const shell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...forkedDecision(),
 			...session(RULED),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
 			mapAt(ruledRecord),
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRecord({...options, ruledOn: SESSION, questionId: QUESTION}),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
@@ -431,9 +445,7 @@ describe("a forked decision ticket's ruling is read through the grill reader", (
 			recorded: `— ruled on #${SESSION} ${QUESTION}`,
 			closed: true,
 		});
-		const bodyAt = shell.calls.findIndex((line) => line.includes("PATCH repos/o/r/issues/9140"));
-		const closeAt = shell.calls.findIndex((line) => line.includes("state_reason=completed"));
-		expect(closeAt).toBeGreaterThan(bodyAt);
+		expect(closeAt(seams)).toBeGreaterThan(mapPatchAt(seams));
 	});
 
 	it("exits 11 when the reader cannot complete its read — never assumed ruled", async () => {
@@ -441,8 +453,8 @@ describe("a forked decision ticket's ruling is read through the grill reader", (
 			[
 				...forkedDecision(),
 				mapAt(MAP_BODY),
-				[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
-				[SESSION_COMMENTS, errOut("gh: API rate limit exceeded")],
+				[SESSION_ISSUE, served(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+				[SESSION_COMMENTS, {status: 403, body: '{"message":"API rate limit exceeded"}'}],
 			],
 			{ruledOn: SESSION, questionId: QUESTION},
 		);
@@ -453,7 +465,11 @@ describe("a forked decision ticket's ruling is read through the grill reader", (
 
 	it("exits 7 when the cited session does not exist — an absent session is not an unread one", async () => {
 		const out = await run(
-			[...forkedDecision(), mapAt(MAP_BODY), [SESSION_ISSUE, errOut("gh: Not Found (HTTP 404)")]],
+			[
+				...forkedDecision(),
+				mapAt(MAP_BODY),
+				[SESSION_ISSUE, {status: 404, body: '{"message":"Not Found"}'}],
+			],
 			{ruledOn: SESSION, questionId: QUESTION},
 		);
 		expect(out.code).toBe(NO_TARGET);
@@ -505,14 +521,14 @@ describe("two decision tickets forked to one grilling session", () => {
 			{text: ANSWER, authority: {_tag: "Ruled", session: SESSION, questionId: QUESTION}},
 			siblingRecorded,
 		);
-		const shell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...forkedDecision(),
 			...session(RULED),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: siblingRecorded, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: siblingRecorded, labels: ["wayfinding:map"]})),
 			],
 			mapAt(landed),
 		]);
@@ -524,7 +540,7 @@ describe("two decision tickets forked to one grilling session", () => {
 					ruledOn: SESSION,
 					questionId: QUESTION,
 				}),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
@@ -533,8 +549,7 @@ describe("two decision tickets forked to one grilling session", () => {
 			closed: true,
 			resumed: false,
 		});
-		const patch = shell.calls.find((line) => line.includes("PATCH repos/o/r/issues/9140")) ?? "";
-		expect(patch).toContain(`${ANSWER} — ruled on #${SESSION} ${QUESTION}`);
+		expect(mapPatches(seams)[0] ?? "").toContain(`${ANSWER} — ruled on #${SESSION} ${QUESTION}`);
 		expect(parsed(landed).decisions).toHaveLength(2);
 	});
 
@@ -543,7 +558,7 @@ describe("two decision tickets forked to one grilling session", () => {
 			{text: ANSWER, authority: {_tag: "Ruled", session: SESSION, questionId: QUESTION}},
 			siblingRecorded,
 		);
-		const shell = fakeShell([[PATCH_TICKET, okOut("{}")], ...forkedDecision(), mapAt(mine)]);
+		const seams = fakeSeams([[PATCH_TICKET, served("{}")], ...forkedDecision(), mapAt(mine)]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRecord({
@@ -552,35 +567,35 @@ describe("two decision tickets forked to one grilling session", () => {
 					ruledOn: SESSION,
 					questionId: QUESTION,
 				}),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({resumed: true, closed: true});
-		expect(shell.calls.some((line) => line.includes("PATCH repos/o/r/issues/9140"))).toBe(false);
+		expect(mapPatches(seams)).toEqual([]);
 	});
 });
 
 describe("a citation on a ticket carrying no fork marker", () => {
 	/** An ordinary research ticket's frontier — no fork marker on it. */
-	const unforked = () => frontier(ticketComments());
+	const unforked = (): ReadonlyArray<Scripted> => frontier(ticketComments());
 
 	it("exits 0 recording the ruling when the cited question reads ruled", async () => {
-		const shell = fakeShell([
-			[PATCH_TICKET, okOut("{}")],
-			[PATCH_MAP, okOut("{}")],
+		const seams = fakeSeams([
+			[PATCH_TICKET, served("{}")],
+			[PATCH_MAP, served("{}")],
 			...unforked(),
 			...session(RULED),
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
 			mapAt(ruledRecord),
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runRecord({...options, ruledOn: SESSION, questionId: QUESTION}),
-				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+				Layer.merge(seams.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
 			),
 		);
 		expect(out.code).toBe(0);
@@ -588,7 +603,7 @@ describe("a citation on a ticket carrying no fork marker", () => {
 			recorded: `— ruled on #${SESSION} ${QUESTION}`,
 			closed: true,
 		});
-		expect(shell.calls.some((line) => line.includes("issues/9301/comments"))).toBe(true);
+		expect(seams.requests.some((line) => line.includes("issues/9301/comments"))).toBe(true);
 	});
 
 	it("exits 13 naming the state it read instead of recording the citation verbatim", async () => {
@@ -613,8 +628,8 @@ describe("a citation on a ticket carrying no fork marker", () => {
 			[
 				...unforked(),
 				mapAt(MAP_BODY),
-				[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
-				[SESSION_COMMENTS, errOut("gh: API rate limit exceeded")],
+				[SESSION_ISSUE, served(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+				[SESSION_COMMENTS, {status: 403, body: '{"message":"API rate limit exceeded"}'}],
 			],
 			{ruledOn: SESSION, questionId: QUESTION},
 		);
@@ -625,7 +640,11 @@ describe("a citation on a ticket carrying no fork marker", () => {
 
 	it("exits 7 when the cited session does not exist", async () => {
 		const out = await run(
-			[...unforked(), mapAt(MAP_BODY), [SESSION_ISSUE, errOut("gh: Not Found (HTTP 404)")]],
+			[
+				...unforked(),
+				mapAt(MAP_BODY),
+				[SESSION_ISSUE, {status: 404, body: '{"message":"Not Found"}'}],
+			],
 			{ruledOn: SESSION, questionId: QUESTION},
 		);
 		expect(out.code).toBe(NO_TARGET);

--- a/packages/fabrika-cli/src/map/ticket-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/ticket-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import {parseBody, renderFrontierRow, spliceSection} from "./body.ts";
 import {
 	ALREADY_DESCOPED,
@@ -26,17 +25,18 @@ import {composeTicketMarker} from "./markers.ts";
 import {runTicket} from "./ticket-verb.ts";
 
 const PERMISSION = /collaborators\/.*\/permission/;
-const CHILDREN = /issues\/9140\/sub_issues/;
+const CHILDREN = /GET .*\/issues\/9140\/sub_issues/;
 const TICKET_COMMENTS = /issues\/9142\/comments/;
 const EDGES = /issues\/9142\/dependencies\//;
 const TICKET_ISSUE = /issues\/9142$/;
 const MAP_ISSUE = /issues\/9140$/;
-const INTERNAL_ID = /issues\/\d+ --jq \.id/;
-const CREATE = /--method POST repos\/o\/r\/issues -f/;
-const POST_COMMENT = /--method POST repos\/o\/r\/issues\/9145\/comments/;
-const NEW_ID = /issues\/9145 --jq \.id/;
-const LINK = /sub_issues -F/;
-const PATCH = /--method PATCH repos\/o\/r\/issues\/9140/;
+const CREATE = /POST .*\/repos\/o\/r\/issues$/;
+const POST_COMMENT = /POST .*\/issues\/9145\/comments/;
+const NEW_ISSUE = /issues\/9145$/;
+const LINK = /POST .*\/issues\/9140\/sub_issues/;
+const PATCH = /PATCH .*\/issues\/9140/;
+
+const served = (body: string) => ({status: 200, body}) as const;
 
 const QUESTION = "does better-auth mint a single-use token without a new table?";
 
@@ -52,28 +52,28 @@ const options = {
 	nonce: () => NONCE,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	over: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(runTicket({...options, ...over}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, over: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runTicket({...options, ...over}), fakeSeams(script).layer));
 
-const mapOk = (body = MAP_BODY) =>
-	[MAP_ISSUE, okOut(issueJson({number: MAP, body, labels: ["wayfinding:map"]}))] as const;
+const mapOk = (body = MAP_BODY): Scripted => [
+	MAP_ISSUE,
+	served(issueJson({number: MAP, body, labels: ["wayfinding:map"]})),
+];
 
-const frontier = [
-	[PERMISSION, okOut("write")],
-	[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+const frontier: ReadonlyArray<Scripted> = [
+	[PERMISSION, served('{"permission":"write"}')],
+	[CHILDREN, served(`[{"number":${TICKET}}]`)],
 	[
 		TICKET_COMMENTS,
-		okOut(
+		served(
 			commentsJson([
 				{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
 			]),
 		),
 	],
-	[EDGES, okOut("[]")],
-	[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table carries it?"}))],
-] as const;
+	[EDGES, served("[]")],
+	[TICKET_ISSUE, served(issueJson({number: TICKET, body: "which table carries it?"}))],
+];
 
 /** The body a successful file leaves: the fixture's row plus the new ticket's. */
 const spliced = spliceSection(
@@ -121,31 +121,29 @@ describe("runTicket — the preconditions, all before anything is written", () =
 		expect(out.stderr.join("\n")).toContain("no run can drain");
 	});
 
+	// The frontier's issue payload carries no `id`, so the edge target's internal id is unresolvable
+	// off the very read that answers everything else about it.
 	it("exits 14 when an edge target's internal id cannot be resolved, before the create", async () => {
-		const shell = fakeShell([
-			[INTERNAL_ID, errOut("gh: Bad gateway (HTTP 502)")],
-			...frontier,
-			mapOk(),
-		]);
+		const seams = fakeSeams([...frontier, mapOk()]);
 		const out = await Effect.runPromise(
-			Effect.provide(runTicket({...options, blockedBy: [TICKET]}), shell.layer),
+			Effect.provide(runTicket({...options, blockedBy: [TICKET]}), seams.layer),
 		);
 		expect(out.code).toBe(EDGE_UNRESOLVABLE);
 		expect(out.stderr.join("\n")).toContain("nothing was written");
-		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("POST"))).toBe(false);
 	});
 });
 
 describe("runTicket — the write order", () => {
-	const created = [
+	const created: Scripted = [
 		CREATE,
-		okOut('{"number":9145,"html_url":"https://github.com/o/r/issues/9145"}'),
-	] as const;
+		{status: 201, body: '{"number":9145,"html_url":"https://github.com/o/r/issues/9145"}'},
+	];
 
 	it("exits 8 naming the number when the marker does not land — the issue is inert, not half-present", async () => {
 		const out = await run([
 			created,
-			[POST_COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+			[POST_COMMENT, {status: 502, body: "{}"}],
 			...frontier,
 			mapOk(),
 		]);
@@ -157,9 +155,9 @@ describe("runTicket — the write order", () => {
 	it("exits 8 naming the number when the sub-issue link does not land", async () => {
 		const out = await run([
 			created,
-			[POST_COMMENT, okOut('{"id":1,"html_url":"u"}')],
-			[NEW_ID, okOut("55")],
-			[LINK, errOut("gh: Bad gateway (HTTP 502)")],
+			[POST_COMMENT, {status: 201, body: '{"id":1,"html_url":"u"}'}],
+			[NEW_ISSUE, served('{"id":55}')],
+			[LINK, {status: 502, body: "{}"}],
 			...frontier,
 			mapOk(),
 		]);
@@ -168,31 +166,33 @@ describe("runTicket — the write order", () => {
 	});
 
 	it("exits 0 with the ticket, its edges and the map's NEW digest", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			created,
-			[POST_COMMENT, okOut('{"id":1,"html_url":"u"}')],
-			[NEW_ID, okOut("55")],
-			[LINK, okOut("{}")],
-			[PATCH, okOut("{}")],
+			[POST_COMMENT, {status: 201, body: '{"id":1,"html_url":"u"}'}],
+			[NEW_ISSUE, served('{"id":55}')],
+			[LINK, served("{}")],
+			[PATCH, served("{}")],
 			...frontier,
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
 			[
 				once(MAP_ISSUE),
-				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+				served(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
 			],
-			[MAP_ISSUE, okOut(issueJson({number: MAP, body: spliced, labels: ["wayfinding:map"]}))],
+			[MAP_ISSUE, served(issueJson({number: MAP, body: spliced, labels: ["wayfinding:map"]}))],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runTicket(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runTicket(options), seams.layer));
 		expect(out.code).toBe(0);
 		const answer = JSON.parse(out.stdout);
 		expect(answer).toMatchObject({map: MAP, ticket: 9145, kind: "research"});
 		expect(answer.digest).not.toBe(options.digest);
 		// The body write is last, so it spends the shortest time between the guard and the write.
-		const patchAt = shell.calls.findIndex((line) => line.includes("--method PATCH"));
-		const linkAt = shell.calls.findIndex((line) => line.includes("sub_issues -F"));
+		const patchAt = seams.requests.findIndex((line) => line.startsWith("PATCH"));
+		const linkAt = seams.requests.findIndex(
+			(line) => line.startsWith("POST") && line.includes("/sub_issues"),
+		);
 		expect(patchAt).toBeGreaterThan(linkAt);
 	});
 

--- a/packages/fabrika-cli/src/plan/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/check-verb.unit.test.ts
@@ -1,6 +1,5 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut} from "../fakes.test-support.ts";
 import {runCheck} from "./check-verb.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
@@ -19,11 +18,11 @@ import {
 	subIssues,
 } from "./fixtures.test-support.ts";
 
-const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const EPIC = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 const SUBS = SUB_ISSUES;
 const CHILD_1 = CHILD(4301);
 const CHILD_2 = CHILD(4302);
-const REF_9999 = /^gh api repos\/o\/r\/issues\/9999$/;
+const REF_9999 = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/9999$/;
 const CYCLE = CYCLE_DOC;
 
 const options = {number: 4300, repo: null, env: ENV, cwd: CWD};
@@ -112,7 +111,7 @@ describe("runCheck", () => {
 			[EPIC, referencing],
 			[SUBS, subIssues(4301)],
 			[CHILD_1, child({number: 4301})],
-			[REF_9999, errOut("gh: Not Found (HTTP 404)")],
+			[REF_9999, {status: 404, body: '{"message":"Not Found"}'}],
 			[CYCLE, cycleDoc],
 		]);
 		expect(JSON.parse(dangling.stdout).defects).toContainEqual({
@@ -125,7 +124,7 @@ describe("runCheck", () => {
 			[EPIC, referencing],
 			[SUBS, subIssues(4301)],
 			[CHILD_1, child({number: 4301})],
-			[REF_9999, errOut("gh: Bad gateway (HTTP 502)")],
+			[REF_9999, {status: 502, body: '{"message":"Bad gateway"}'}],
 			[CYCLE, cycleDoc],
 		]);
 		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);

--- a/packages/fabrika-cli/src/plan/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/plan/fixtures.test-support.ts
@@ -1,5 +1,5 @@
 /**
- * The canned `gh` responses the `plan` verb tests script their spawner with.
+ * The canned GitHub responses the `plan` verb tests script their seams with.
  *
  * Shaped like the real payloads rather than like the parsers, so a parser that starts reading a
  * different field still has to find it here — a fixture trimmed to exactly what the code reads today
@@ -14,7 +14,7 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {CONFIG_PATH} from "../config/document.ts";
 import type {FakeHttp, FakeShell, HttpReply} from "../fakes.test-support.ts";
-import {fakeFs, fakeHttp, fakeShell, okOut} from "../fakes.test-support.ts";
+import {fakeFs, fakeHttp, fakeShell} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 
 export const EPIC = 4300;
@@ -36,20 +36,20 @@ export const epicBody = (overrides: {dependencies?: string; stories?: string} = 
 		"",
 	].join("\n");
 
-export const epic = (overrides: Record<string, unknown> = {}): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: EPIC,
-			title: "The plan gate",
-			body: epicBody(),
-			state: "open",
-			labels: [{name: "type:epic"}],
-			html_url: "https://github.com/o/r/issues/4300",
-			milestone: null,
-			state_reason: null,
-			...overrides,
-		}),
-	);
+export const epic = (overrides: Record<string, unknown> = {}): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: EPIC,
+		title: "The plan gate",
+		body: epicBody(),
+		state: "open",
+		labels: [{name: "type:epic"}],
+		html_url: "https://github.com/o/r/issues/4300",
+		milestone: null,
+		state_reason: null,
+		...overrides,
+	}),
+});
 
 export const subIssues = (...numbers: ReadonlyArray<number>): HttpReply => ({
 	status: 200,
@@ -99,8 +99,10 @@ export const child = (options: {
 	}),
 });
 
-export const labelSet = (...names: ReadonlyArray<string>): ExecResult =>
-	okOut(`${names.join("\n")}\n`);
+export const labelSet = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
 
 /** The directory a plan verb under test is standing in. Its config is the one the load reads. */
 export const CWD = "/repo";

--- a/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
@@ -1,8 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {comments, LANE_UUID, marker, LANE_TOKEN as TOKEN} from "../build/fixtures.test-support.ts";
-import {errOut, type HttpReply, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {type HttpReply, once} from "../fakes.test-support.ts";
 import {runCheck} from "./check-verb.ts";
 import {
 	CLAIM_NOT_MINE,
@@ -31,19 +30,23 @@ import {
 } from "./fixtures.test-support.ts";
 import {childrenEvidence, runFlip} from "./flip-verb.ts";
 
-const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const EPIC = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 const SUBS = SUB_ISSUES;
 const CHILD = CHILD_AT(4301);
 const CYCLE = CYCLE_DOC;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4300\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
-const ADD = /^gh api --method POST repos\/o\/r\/issues\/4301\/labels/;
-const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4301\/labels/;
-const ADD_EPIC = /^gh api --method POST repos\/o\/r\/issues\/4300\/labels/;
-const REMOVE_EPIC = /^gh api --method DELETE repos\/o\/r\/issues\/4300\/labels/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4300\/comments\?/;
+const PERM = /^GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+const LABELS = /^GET .*\/repos\/o\/r\/labels\?/;
+const ADD = /^POST .*\/repos\/o\/r\/issues\/4301\/labels$/;
+const REMOVE = /^DELETE .*\/repos\/o\/r\/issues\/4301\/labels\//;
+const ADD_EPIC = /^POST .*\/repos\/o\/r\/issues\/4300\/labels$/;
+const REMOVE_EPIC = /^DELETE .*\/repos\/o\/r\/issues\/4300\/labels\//;
+/** Any label write at all — what an assertion that nothing was written reads. */
+const LABEL_WRITE = /^(POST|DELETE) .*\/labels/;
+const SERVED_LABELS: HttpReply = {status: 200, body: "[]"};
+const BAD_GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
-const oneChildEpic = (labels: ReadonlyArray<string>): ExecResult =>
+const oneChildEpic = (labels: ReadonlyArray<string>): HttpReply =>
 	epic({
 		body: epicBody({dependencies: "- phase 1: #4301"}),
 		labels: labels.map((name) => ({name})),
@@ -61,7 +64,7 @@ const env = {
 
 const CLAIMED: ReadonlyArray<Scripted> = [
 	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, {status: 200, body: '{"permission":"write"}'}],
 ];
 
 const PLANNED = child({number: 4301, labels: ["type:feature", "p1", "status:planned"]});
@@ -71,7 +74,7 @@ const TRIAGED = child({number: 4301, labels: ["type:feature", "p1", "status:tria
 const ledger = (
 	first: HttpReply,
 	reread: HttpReply,
-	epics: {first?: ExecResult; reread?: ExecResult} = {},
+	epics: {first?: HttpReply; reread?: HttpReply} = {},
 ): ReadonlyArray<Scripted> => [
 	[once(EPIC), epics.first ?? ONE_CHILD_EPIC],
 	[SUBS, subIssues(4301)],
@@ -102,7 +105,7 @@ const run = (digest: string, script: ReadonlyArray<Scripted>) => {
 			runFlip({number: 4300, digest, token: TOKEN, repo: null, env, cwd: CWD}),
 			seams.layer,
 		),
-	).then((outcome) => ({outcome, calls: seams.shell.calls, reads: seams.http.calls}));
+	).then((outcome) => ({outcome, calls: seams.http.calls}));
 };
 
 describe("runFlip", () => {
@@ -112,10 +115,10 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, TRIAGED),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent", "type:feature")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, okOut("[]")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, SERVED_LABELS],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({
@@ -142,16 +145,16 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, TRIAGED),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, okOut("[]")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, SERVED_LABELS],
 		];
-		const {calls, reads} = await run(digest, script);
+		const {calls} = await run(digest, script);
 		const childWrite = calls.findIndex((line) => REMOVE.test(line));
 		const epicAdd = calls.findIndex((line) => ADD_EPIC.test(line));
 		const epicRemove = calls.findIndex((line) => REMOVE_EPIC.test(line));
-		expect(reads.filter((line) => CHILD.test(line)).length).toBe(2);
+		expect(calls.filter((line) => CHILD.test(line)).length).toBe(2);
 		expect(epicAdd).toBeGreaterThan(childWrite);
 		expect(epicRemove).toBeGreaterThan(epicAdd);
 
@@ -161,10 +164,10 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, {status: 502, body: '{"message":"Bad gateway"}'}),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, okOut("[]")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, SERVED_LABELS],
 		]);
 		expect(unread.calls.some((line) => ADD_EPIC.test(line))).toBe(false);
 	});
@@ -175,10 +178,10 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, TRIAGED, {reread: ONE_CHILD_EPIC}),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, errOut("gh: Bad gateway (HTTP 502)")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, BAD_GATEWAY],
 		]);
 		expect(outcome.code).toBe(PARTIAL_FLIP);
 		expect(outcome.stdout).toBe("");
@@ -191,12 +194,12 @@ describe("runFlip", () => {
 		const digest = await digestOf(CLEAN_READ);
 		const {outcome} = await run(digest, [
 			...CLAIMED,
-			...ledger(PLANNED, TRIAGED, {reread: errOut("gh: Bad gateway (HTTP 502)")}),
+			...ledger(PLANNED, TRIAGED, {reread: BAD_GATEWAY}),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, okOut("[]")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, SERVED_LABELS],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("could not re-read the epic #4300");
@@ -217,7 +220,7 @@ describe("runFlip", () => {
 		]);
 		expect(outcome.code).toBe(LABEL_ABSENT);
 		expect(outcome.stderr.at(-1)).toContain('label "ready-for:agent" is absent');
-		expect(calls.some((line) => /--method POST .*labels/.test(line))).toBe(false);
+		expect(calls.some((line) => /^POST .*\/labels/.test(line))).toBe(false);
 	});
 
 	/**
@@ -231,10 +234,10 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, TRIAGED),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, okOut("[]")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, SERVED_LABELS],
 		]);
 		const add = calls.findIndex((line) => ADD.test(line));
 		const remove = calls.findIndex((line) => REMOVE.test(line));
@@ -265,7 +268,7 @@ describe("runFlip", () => {
 		]);
 		expect(outcome.code).toBe(FLOOR_DEFECTIVE);
 		expect(outcome.stdout).toBe("");
-		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
+		expect(calls.some((line) => LABEL_WRITE.test(line))).toBe(false);
 	});
 
 	/** The TOCTOU answer: the gap between deciding and writing is closed by re-deciding. */
@@ -277,7 +280,7 @@ describe("runFlip", () => {
 		]);
 		expect(outcome.code).toBe(PLAN_MOVED);
 		expect(outcome.stderr.at(-1)).toContain("the plan moved since the check");
-		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
+		expect(calls.some((line) => LABEL_WRITE.test(line))).toBe(false);
 	});
 
 	/**
@@ -293,7 +296,7 @@ describe("runFlip", () => {
 		]);
 		expect(outcome.code).toBe(LABEL_ABSENT);
 		expect(outcome.stderr.at(-1)).toContain('label "status:triaged" is absent');
-		expect(calls.some((line) => /--method POST .*labels/.test(line))).toBe(false);
+		expect(calls.some((line) => /^POST .*\/labels/.test(line))).toBe(false);
 	});
 
 	it("skips the vocabulary check when there is nothing to flip", async () => {
@@ -316,7 +319,7 @@ describe("runFlip", () => {
 			audience: {result: "already", observed: ["ready-for:agent", "type:epic"]},
 		});
 		expect(calls.some((line) => LABELS.test(line))).toBe(false);
-		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
+		expect(calls.some((line) => LABEL_WRITE.test(line))).toBe(false);
 	});
 
 	/** #5680's shape: an epic planned and gated before #5832, re-gated to earn its audience label. */
@@ -332,8 +335,8 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(already, already),
 			[LABELS, labelSet("ready-for:agent")],
-			[ADD_EPIC, okOut("[]")],
-			[REMOVE_EPIC, okOut("[]")],
+			[ADD_EPIC, SERVED_LABELS],
+			[REMOVE_EPIC, SERVED_LABELS],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({
@@ -359,8 +362,8 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, stuck),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, BAD_GATEWAY],
 		]);
 		expect(outcome.code).toBe(PARTIAL_FLIP);
 		expect(outcome.stdout).toBe("");
@@ -374,8 +377,8 @@ describe("runFlip", () => {
 			...CLAIMED,
 			...ledger(PLANNED, {status: 502, body: '{"message":"Bad gateway"}'}),
 			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
-			[ADD, okOut("[]")],
-			[REMOVE, okOut("[]")],
+			[ADD, SERVED_LABELS],
+			[REMOVE, SERVED_LABELS],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("the outcome is UNKNOWN");
@@ -385,10 +388,10 @@ describe("runFlip", () => {
 		const {outcome, calls} = await run("4d90e1bb27ac", [
 			[EPIC, ONE_CHILD_EPIC],
 			[COMMENTS, comments({id: 1, body: marker("another-session", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, {status: 200, body: '{"permission":"write"}'}],
 		]);
 		expect(outcome.code).toBe(CLAIM_NOT_MINE);
-		expect(calls.some((line) => /--method/.test(line))).toBe(false);
+		expect(calls.some((line) => !line.startsWith("GET "))).toBe(false);
 	});
 
 	it("refuses 10 on a --digest that is not 12 lowercase hex, before any read", async () => {

--- a/packages/fabrika-cli/src/plan/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/read-verb.unit.test.ts
@@ -1,6 +1,5 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut} from "../fakes.test-support.ts";
 import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
 	CHILD,
@@ -20,7 +19,7 @@ import {
 } from "./fixtures.test-support.ts";
 import {runRead} from "./read-verb.ts";
 
-const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const EPIC = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 const SUBS = SUB_ISSUES;
 const CHILD_1 = CHILD(4301);
 const CHILD_2 = CHILD(4302);
@@ -93,9 +92,9 @@ describe("runRead", () => {
 	});
 
 	it("refuses a proven-absent epic on 7 and an unreadable one on 11", async () => {
-		const absent = await run([[EPIC, errOut("gh: Not Found (HTTP 404)")]]);
+		const absent = await run([[EPIC, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(absent.code).toBe(ZERO_SCOPE);
-		const unknown = await run([[EPIC, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const unknown = await run([[EPIC, {status: 502, body: '{"message":"Bad gateway"}'}]]);
 		expect(unknown.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
@@ -173,7 +172,7 @@ describe("runRead", () => {
 	});
 
 	it("reads the child fetches at bounded fan-out, one request per child", async () => {
-		const seams = planSeams([...CLEAN, [/^gh api --paginate repos\/o\/r\/labels/, labelSet()]]);
+		const seams = planSeams([...CLEAN, [/^GET .*\/repos\/o\/r\/labels\?/, labelSet()]]);
 		await Effect.runPromise(Effect.provide(runRead(options), seams.layer));
 		expect(seams.http.calls.filter((line) => /issues\/430[12]$/.test(line))).toHaveLength(2);
 	});

--- a/packages/fabrika-cli/src/plan/verdict-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/verdict-verb.unit.test.ts
@@ -1,7 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {comments, LANE_UUID, marker, LANE_TOKEN as TOKEN} from "../build/fixtures.test-support.ts";
-import {type HttpReply, okOut} from "../fakes.test-support.ts";
+import type {HttpReply} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {read as readMarker} from "../wire/verdict-marker.ts";
 import {runCheck} from "./check-verb.ts";
@@ -30,14 +30,14 @@ import {
 } from "./fixtures.test-support.ts";
 import {runVerdict} from "./verdict-verb.ts";
 
-const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const EPIC = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
 const SUBS = SUB_ISSUES;
 const CHILD = CHILD_AT(4301);
 const CYCLE = CYCLE_DOC;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4300\/comments/;
-const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/4300\/comments/;
-const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/512346$/;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4300\/comments\?/;
+const PERM = /^GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+const POST = /^POST .*\/repos\/o\/r\/issues\/4300\/comments$/;
+const GET_COMMENT = /^GET .*\/repos\/o\/r\/issues\/comments\/512346$/;
 
 const ONE_CHILD_EPIC = epic({body: epicBody({dependencies: "- phase 1: #4301"})});
 const CLEAN_CHILD = child({number: 4301});
@@ -51,7 +51,7 @@ const env = {
 
 const CLAIMED: ReadonlyArray<Scripted> = [
 	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
-	[PERM, okOut("write\n")],
+	[PERM, {status: 200, body: '{"permission":"write"}'}],
 ];
 
 const ledger = (childPayload: HttpReply): ReadonlyArray<Scripted> => [
@@ -61,9 +61,10 @@ const ledger = (childPayload: HttpReply): ReadonlyArray<Scripted> => [
 	[CYCLE, cycleDoc],
 ];
 
-const POSTED = okOut(
-	JSON.stringify({id: 512346, html_url: "https://github.com/o/r/issues/4300#c"}),
-);
+const POSTED: HttpReply = {
+	status: 201,
+	body: JSON.stringify({id: 512346, html_url: "https://github.com/o/r/issues/4300#c"}),
+};
 
 const digestOf = async (childPayload: HttpReply): Promise<string> => {
 	const out = await Effect.runPromise(
@@ -99,25 +100,29 @@ const run = (
 			}),
 			seams.layer,
 		),
-	).then((outcome) => ({outcome, calls: seams.shell.calls}));
+	).then((outcome) => ({outcome, calls: seams.http.calls, bodies: seams.http.bodies}));
 };
 
-/** The bytes the verb handed `gh` — the `-f body=` operand is last on the POST line. */
-const postedBody = (calls: ReadonlyArray<string>): string => {
-	const line = calls.find((candidate) => POST.test(candidate)) ?? "";
-	return /-f body=([\s\S]*)$/.exec(line)?.[1] ?? "";
+/** The bytes the verb posted — the marker travels as the request body's `body` field now. */
+const postedBody = (run: {calls: ReadonlyArray<string>; bodies: ReadonlyArray<string>}): string => {
+	const at = run.calls.findIndex((line) => POST.test(line));
+	if (at < 0) return "";
+	const sent: unknown = JSON.parse(run.bodies[at] ?? "{}");
+	return typeof sent === "object" && sent !== null && "body" in sent
+		? String((sent as {body: unknown}).body)
+		: "";
 };
 
 describe("runVerdict", () => {
 	it("posts a PASS bound to the digest and reads it back", async () => {
 		const digest = await digestOf(CLEAN_CHILD);
 		const first = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]]);
-		const body = postedBody(first.calls);
+		const body = postedBody(first);
 		const {outcome} = await run(digest, [
 			...CLAIMED,
 			...ledger(CLEAN_CHILD),
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			[GET_COMMENT, {status: 200, body: JSON.stringify({body})}],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toEqual({
@@ -138,8 +143,8 @@ describe("runVerdict", () => {
 	 */
 	it("emits a marker the shared format reads back", async () => {
 		const digest = await digestOf(CLEAN_CHILD);
-		const {calls} = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]]);
-		const marked = readMarker(postedBody(calls));
+		const posted = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]]);
+		const marked = readMarker(postedBody(posted));
 		expect(marked._tag).toBe("Found");
 		if (marked._tag !== "Found") return;
 		expect(marked.value).toMatchObject({
@@ -152,8 +157,8 @@ describe("runVerdict", () => {
 
 	it("derives FAIL from the floor and posts it — a defective floor is the deliverable", async () => {
 		const digest = await digestOf(DEFECTIVE_CHILD);
-		const {calls} = await run(digest, [...CLAIMED, ...ledger(DEFECTIVE_CHILD), [POST, POSTED]]);
-		const body = postedBody(calls);
+		const posted = await run(digest, [...CLAIMED, ...ledger(DEFECTIVE_CHILD), [POST, POSTED]]);
+		const body = postedBody(posted);
 		expect(
 			body.startsWith(`check-epic-plan: FAIL @ ${digest} — 1 children scanned, floor 1 defect(s)`),
 		).toBe(true);
@@ -187,10 +192,10 @@ describe("runVerdict", () => {
 
 	it("records caveats verbatim under their kinds and counts them", async () => {
 		const digest = await digestOf(CLEAN_CHILD);
-		const {calls} = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
+		const posted = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
 			caveats: 'caveat: ac-not-checkable #4301 — "works well" states no observable outcome',
 		});
-		const body = postedBody(calls);
+		const body = postedBody(posted);
 		expect(body).toContain("### ac-not-checkable");
 		expect(body).toContain('- #4301 — "works well" states no observable outcome');
 	});
@@ -250,7 +255,7 @@ describe("runVerdict", () => {
 			...CLAIMED,
 			...ledger(CLEAN_CHILD),
 			[POST, POSTED],
-			[GET_COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			[GET_COMMENT, {status: 200, body: JSON.stringify({body: "something else entirely"})}],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stdout).toBe("");
@@ -260,7 +265,7 @@ describe("runVerdict", () => {
 		const {outcome, calls} = await run("4d90e1bb27ac", [
 			[EPIC, ONE_CHILD_EPIC],
 			[COMMENTS, comments({id: 1, body: marker("another-session", LANE_UUID)})],
-			[PERM, okOut("write\n")],
+			[PERM, {status: 200, body: '{"permission":"write"}'}],
 		]);
 		expect(outcome.code).toBe(CLAIM_NOT_MINE);
 		expect(calls.some((line) => POST.test(line))).toBe(false);
@@ -303,8 +308,8 @@ describe("runVerdict", () => {
 			Effect.provide(runCheck({number: 4300, repo: null, env, cwd: CWD}), planSeams(script).layer),
 		);
 		const digest = JSON.parse(out.stdout).digest as string;
-		const {calls} = await run(digest, [...CLAIMED, ...script, [POST, POSTED]]);
-		expect(postedBody(calls)).toContain("1 class(es) skipped");
-		expect(postedBody(calls)).toContain("## Skipped classes");
+		const posted = await run(digest, [...CLAIMED, ...script, [POST, POSTED]]);
+		expect(postedBody(posted)).toContain("1 class(es) skipped");
+		expect(postedBody(posted)).toContain("## Skipped classes");
 	});
 });

--- a/packages/fabrika-cli/src/recipe/rerun-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/rerun-verb.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, once} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {comments, ENV, HEAD, OTHER_HEAD, pull} from "../ship/fixtures.test-support.ts";
 import {
@@ -17,9 +17,9 @@ import {
 import {governanceMarker, httpError, oneRun, runsAtHead} from "./fixtures.test-support.ts";
 import {runRerun} from "./rerun-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
 const API = "https:\\/\\/api\\.github\\.com";
+const PULL = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/pulls\\/4321$`);
+const COMMENTS = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/issues\\/4321\\/comments\\?`);
 const RUNS = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/actions\\/runs\\?head_sha=`);
 const RERUN = new RegExp(`^POST ${API}\\/repos\\/o\\/r\\/actions\\/runs\\/77\\/rerun$`);
 const ONE_RUN = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/actions\\/runs\\/77$`);
@@ -27,41 +27,28 @@ const ONE_RUN = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/actions\\/runs\\/77$`)
 /** The rerun endpoint answers 201 with no body. */
 const ACCEPTED: HttpReply = {status: 201, body: ""};
 
-const seams = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) => {
-	const shell = fakeShell(script);
-	const http = fakeHttp(served);
-	return {shell, http, layer: Layer.merge(shell.layer, http.layer)};
-};
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) =>
+const run = (script: ReadonlyArray<Scripted>) =>
 	Effect.runPromise(
-		Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), seams(script, served).layer),
+		Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), fakeSeams(script).layer),
 	);
 
-const PASSING = comments({id: 1, body: governanceMarker("PASS", HEAD)});
+const PASSING = reply(comments({id: 1, body: governanceMarker("PASS", HEAD)}));
 
 describe("recipe rerun — the gate is read before anything moves", () => {
 	it("reruns the failed run and proves it by the run's own new attempt", async () => {
-		const {http, layer} = seams(
-			[
-				[PULL, pull()],
-				[COMMENTS, PASSING],
-			],
-			[
-				[RUNS, runsAtHead({id: 77, name: "ci"}, {id: 78, conclusion: "success"})],
-				[RERUN, ACCEPTED],
-				[ONE_RUN, oneRun({id: 77, attempt: 2, status: "queued", conclusion: null})],
-			],
-		);
+		const seams = fakeSeams([
+			[PULL, reply(pull())],
+			[COMMENTS, PASSING],
+			[RUNS, runsAtHead({id: 77, name: "ci"}, {id: 78, conclusion: "success"})],
+			[RERUN, ACCEPTED],
+			[ONE_RUN, oneRun({id: 77, attempt: 2, status: "queued", conclusion: null})],
+		]);
 
 		const out = await Effect.runPromise(
-			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), layer),
+			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), seams.layer),
 		);
 
 		expect(out.code).toBe(0);
@@ -72,27 +59,27 @@ describe("recipe rerun — the gate is read before anything moves", () => {
 			rerun: [{id: 77, name: "ci", attempt: 2}],
 		});
 		// The read-back is a real second call, not the POST's own status re-read as evidence.
-		expect(http.calls.filter((line) => ONE_RUN.test(line))).toHaveLength(1);
+		expect(seams.requests.filter((line) => ONE_RUN.test(line))).toHaveLength(1);
 	});
 
 	it("is VERDICT_ABSENT with nothing posted when the PR carries no governance verdict", async () => {
-		const {http, layer} = seams([
-			[PULL, pull()],
-			[COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — ok`})],
+		const seams = fakeSeams([
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments({id: 1, body: `review-code: PASS @ ${HEAD} — ok`}))],
 		]);
 
 		const out = await Effect.runPromise(
-			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), layer),
+			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), seams.layer),
 		);
 
 		expect(out.code).toBe(VERDICT_ABSENT);
-		expect(http.calls.some((line) => line.startsWith("POST "))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("POST "))).toBe(false);
 	});
 
 	it("is VERDICT_STALE when the verdict is bound to another head — never folded into absent", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[COMMENTS, comments({id: 1, body: governanceMarker("PASS", OTHER_HEAD)})],
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments({id: 1, body: governanceMarker("PASS", OTHER_HEAD)}))],
 		]);
 
 		expect(out.code).toBe(VERDICT_STALE);
@@ -100,27 +87,29 @@ describe("recipe rerun — the gate is read before anything moves", () => {
 	});
 
 	it("is VERDICT_FAIL on a FAIL at head, and reruns nothing", async () => {
-		const {http, layer} = seams([
-			[PULL, pull()],
-			[COMMENTS, comments({id: 1, body: governanceMarker("FAIL", HEAD)})],
+		const seams = fakeSeams([
+			[PULL, reply(pull())],
+			[COMMENTS, reply(comments({id: 1, body: governanceMarker("FAIL", HEAD)}))],
 		]);
 
 		const out = await Effect.runPromise(
-			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), layer),
+			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), seams.layer),
 		);
 
 		expect(out.code).toBe(VERDICT_FAIL);
-		expect(http.calls.some((line) => line.startsWith("POST "))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("POST "))).toBe(false);
 	});
 
 	it("takes the latest verdict by write stamp, so a FAIL upserted into an older comment wins", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, reply(pull())],
 			[
 				COMMENTS,
-				comments(
-					{id: 1, body: governanceMarker("FAIL", HEAD), updatedAt: "2026-08-16T02:00:00Z"},
-					{id: 2, body: governanceMarker("PASS", HEAD), updatedAt: "2026-08-16T01:00:00Z"},
+				reply(
+					comments(
+						{id: 1, body: governanceMarker("FAIL", HEAD), updatedAt: "2026-08-16T02:00:00Z"},
+						{id: 2, body: governanceMarker("PASS", HEAD), updatedAt: "2026-08-16T01:00:00Z"},
+					),
 				),
 			],
 		]);
@@ -129,13 +118,13 @@ describe("recipe rerun — the gate is read before anything moves", () => {
 	});
 
 	it("is TARGET_ABSENT on a closed PR", async () => {
-		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(TARGET_ABSENT);
+		expect((await run([[PULL, reply(pull({state: "closed"}))]])).code).toBe(TARGET_ABSENT);
 	});
 
 	it('is UNKNOWN when the comments cannot be read — never "no verdict"', async () => {
 		const out = await run([
-			[PULL, pull()],
-			[COMMENTS, errOut("api down")],
+			[PULL, reply(pull())],
+			[COMMENTS, httpError(503, "api down")],
 		]);
 
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -144,19 +133,19 @@ describe("recipe rerun — the gate is read before anything moves", () => {
 });
 
 describe("recipe rerun — nothing to do, and writes that do not prove themselves", () => {
-	const gated: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
+	const gated: ReadonlyArray<Scripted> = [
+		[PULL, reply(pull())],
 		[COMMENTS, PASSING],
 	];
 
 	it("is NOTHING_TO_RERUN when no run at the head concluded in failure", async () => {
-		const out = await run(gated, [[RUNS, runsAtHead({id: 78, conclusion: "success"})]]);
+		const out = await run([...gated, [RUNS, runsAtHead({id: 78, conclusion: "success"})]]);
 
 		expect(out.code).toBe(NOTHING_TO_RERUN);
 	});
 
 	it('is UNKNOWN when the run list cannot be read — never "nothing to rerun"', async () => {
-		const out = await run(gated, [[RUNS, httpError(503, "api down")]]);
+		const out = await run([...gated, [RUNS, httpError(503, "api down")]]);
 
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.code).not.toBe(NOTHING_TO_RERUN);
@@ -167,7 +156,8 @@ describe("recipe rerun — nothing to do, and writes that do not prove themselve
 	// re-derived against the platform's own count.
 	it("is UNKNOWN when fewer runs arrived than the endpoint declared", async () => {
 		const short = runsAtHead({id: 77});
-		const out = await run(gated, [
+		const out = await run([
+			...gated,
 			[RUNS, {...short, body: JSON.stringify({...JSON.parse(short.body), total_count: 4})}],
 		]);
 
@@ -175,7 +165,8 @@ describe("recipe rerun — nothing to do, and writes that do not prove themselve
 	});
 
 	it("is WRITE_UNKNOWN when the rerun request itself does not land", async () => {
-		const out = await run(gated, [
+		const out = await run([
+			...gated,
 			[RUNS, runsAtHead({id: 77})],
 			[RERUN, httpError(422, "Unprocessable")],
 		]);
@@ -184,7 +175,8 @@ describe("recipe rerun — nothing to do, and writes that do not prove themselve
 	});
 
 	it("is RERUN_UNKNOWN when the request landed and the run cannot be re-read", async () => {
-		const out = await run(gated, [
+		const out = await run([
+			...gated,
 			[RUNS, runsAtHead({id: 77})],
 			[RERUN, ACCEPTED],
 			[ONE_RUN, httpError(503, "api down")],
@@ -195,7 +187,8 @@ describe("recipe rerun — nothing to do, and writes that do not prove themselve
 	});
 
 	it("is READBACK_MISMATCH when the re-read shows the same attempt on a completed run", async () => {
-		const out = await run(gated, [
+		const out = await run([
+			...gated,
 			[once(RUNS), runsAtHead({id: 77, attempt: 3})],
 			[RERUN, ACCEPTED],
 			[ONE_RUN, oneRun({id: 77, attempt: 3, status: "completed"})],
@@ -206,7 +199,8 @@ describe("recipe rerun — nothing to do, and writes that do not prove themselve
 	});
 
 	it("accepts a run still on its old attempt once it has left `completed`", async () => {
-		const out = await run(gated, [
+		const out = await run([
+			...gated,
 			[RUNS, runsAtHead({id: 77, attempt: 3})],
 			[RERUN, ACCEPTED],
 			[ONE_RUN, oneRun({id: 77, attempt: 3, status: "in_progress", conclusion: null})],

--- a/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeHttp, fakeShell, type HttpReply} from "../fakes.test-support.ts";
+import {errOut, fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {CODEOWNERS, ENV, files, HEAD, pull} from "../ship/fixtures.test-support.ts";
 import {
@@ -15,6 +15,7 @@ import {
 import {
 	branchList,
 	closingPulls,
+	httpError,
 	LANE,
 	LANE_BRANCH,
 	LANES_ROOT,
@@ -29,9 +30,9 @@ import {
 } from "./fixtures.test-support.ts";
 import {runUnpark} from "./unpark-verb.ts";
 
-const CLOSERS = /^gh api graphql/;
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const CLOSERS = /^POST .*\/graphql$/;
+const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET .*\/repos\/o\/r\/pulls\/4321\/files\?/;
 const OWNERS = /contents\/\.github\/CODEOWNERS/;
 const COMPARE = /\/repos\/o\/r\/compare\//;
 const ROSTER = /orgs\/kamp-us\/teams\/control-plane\/members/;
@@ -39,8 +40,11 @@ const REVIEWS = /\/repos\/o\/r\/pulls\/4321\/reviews/;
 const BRANCHES = /^git for-each-ref/;
 const TREES = /^git worktree list/;
 
+/** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
+const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
 /** The §CP path set, so the boundary classifies `control-plane` and the discharge table runs. */
-const CP_FILES = files(".github/workflows/ci.yml", "README.md");
+const CP_FILES = reply(files(".github/workflows/ci.yml", "README.md"));
 
 const members = (...logins: ReadonlyArray<string>): HttpReply => ({
 	status: 200,
@@ -62,15 +66,15 @@ const reviewPage = (
 	),
 });
 
-/** The shell half of a discharged §CP park: the closing PR, its shape, its changed files. */
-const DISCHARGED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[CLOSERS, closingPulls(4321)],
-	[PULL, pull({author: "usirin"})],
+/** A discharged §CP park's target half: the closing PR, its shape, its changed files. */
+const DISCHARGED: ReadonlyArray<Scripted> = [
+	[CLOSERS, reply(closingPulls(4321))],
+	[PULL, reply(pull({author: "usirin"}))],
 	[FILES, CP_FILES],
 ];
 
-/** The HTTP half: the boundary, no base drift, the roster, an approving owner at the live head. */
-const DISCHARGED_HTTP: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+/** The clearance half: the boundary, no base drift, the roster, an approving owner at the live head. */
+const DISCHARGED_HTTP: ReadonlyArray<Scripted> = [
 	[OWNERS, {status: 200, body: CODEOWNERS}],
 	[COMPARE, {status: 200, body: '{"behind_by":0}'}],
 	[ROSTER, members("usirin", "notusirin")],
@@ -82,14 +86,14 @@ const lane = (log: string, extra: Parameters<typeof fakeFs>[0] = {}) =>
 
 const run = (
 	fs: ReturnType<typeof fakeFs>,
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = DISCHARGED_HTTP,
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted> = DISCHARGED_HTTP,
 	task: string | null = null,
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runUnpark({root: LANES_ROOT, lane: LANE, task, repo: null, env: ENV}),
-			Layer.mergeAll(fs.layer, fakeShell(script).layer, fakeHttp(http).layer),
+			Layer.merge(fs.layer, fakeSeams([...script, ...http]).layer),
 		),
 	);
 
@@ -201,9 +205,9 @@ describe("recipe unpark — the refusals write nothing", () => {
 		const out = await run(
 			fs,
 			[
-				[CLOSERS, closingPulls(4321)],
-				[PULL, pull()],
-				[FILES, files("apps/web/src/App.tsx", "README.md")],
+				[CLOSERS, reply(closingPulls(4321))],
+				[PULL, reply(pull())],
+				[FILES, reply(files("apps/web/src/App.tsx", "README.md"))],
 			],
 			[
 				[OWNERS, {status: 200, body: CODEOWNERS}],
@@ -218,7 +222,7 @@ describe("recipe unpark — the refusals write nothing", () => {
 	it("is PARK_NOVEL when several open PRs declare they close the issue", async () => {
 		const fs = lane(PARKED_AT_CP);
 
-		const out = await run(fs, [[CLOSERS, closingPulls(4321, 4322)]]);
+		const out = await run(fs, [[CLOSERS, reply(closingPulls(4321, 4322))]]);
 
 		expect(out.code).toBe(PARK_NOVEL);
 		expect(out.stderr.join("\n")).toMatch(/#4321, #4322/);
@@ -231,8 +235,8 @@ describe("recipe unpark — the refusals write nothing", () => {
 		const out = await run(
 			fs,
 			[
-				[CLOSERS, closingPulls(4321)],
-				[PULL, pull({author: "usirin"})],
+				[CLOSERS, reply(closingPulls(4321))],
+				[PULL, reply(pull({author: "usirin"}))],
 				[FILES, CP_FILES],
 			],
 			[
@@ -260,7 +264,7 @@ describe("recipe unpark — the refusals write nothing", () => {
 	it("is TARGET_ABSENT when no open PR declares it closes the issue the park hangs on", async () => {
 		const fs = lane(PARKED_AT_CP);
 
-		const out = await run(fs, [[CLOSERS, closingPulls()]]);
+		const out = await run(fs, [[CLOSERS, reply(closingPulls())]]);
 
 		expect(out.code).toBe(TARGET_ABSENT);
 		expect(fs.written.size).toBe(0);
@@ -269,7 +273,7 @@ describe("recipe unpark — the refusals write nothing", () => {
 	it("is UNKNOWN when the closing-PR read fails — never a cleared park", async () => {
 		const fs = lane(PARKED_AT_CP);
 
-		const out = await run(fs, [[CLOSERS, errOut("api down")]]);
+		const out = await run(fs, [[CLOSERS, httpError(503, "api down")]]);
 
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(fs.written.size).toBe(0);
@@ -296,7 +300,7 @@ describe("recipe unpark — the refusals write nothing", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runUnpark({root, lane: "nightly", task: null, repo: null, env: ENV}),
-				Layer.mergeAll(fs.layer, fakeShell(DISCHARGED).layer, fakeHttp(DISCHARGED_HTTP).layer),
+				Layer.merge(fs.layer, fakeSeams([...DISCHARGED, ...DISCHARGED_HTTP]).layer),
 			),
 		);
 

--- a/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
@@ -1,12 +1,32 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {NO_TARGET, QUEUE_UNREADABLE, SEARCH_UNREADABLE} from "./codes.ts";
 import {runDedup} from "./dedup-verb.ts";
 
 const LABELS = /repos\/o\/r\/labels/;
 const QUEUE = /repos\/o\/r\/issues\?state=open/;
 const SEARCH = /search\/issues/;
+
+/** A label-set page: the endpoint answers `[{name}]`, not one name per line. */
+const labelSet = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+const issueRows = (...rows: ReadonlyArray<readonly [number, string]>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(rows.map(([number, title]) => ({number, title}))),
+});
+
+/** The search index answers a `{total_count, items}` envelope. */
+const searchHits = (...rows: ReadonlyArray<readonly [number, string]>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		total_count: rows.length,
+		items: rows.map(([number, title]) => ({number, title})),
+	}),
+});
 
 const options = {
 	query: "retry helper swallows the abort reason",
@@ -18,20 +38,17 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runDedup({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runDedup({...options, ...overrides}), fakeSeams(script).layer));
 
-const labelsOk = [LABELS, okOut("status:needs-triage\ntype:bug\np0")] as const;
+const labelsOk = [LABELS, labelSet("status:needs-triage", "type:bug", "p0")] as const;
 
 describe("runDedup", () => {
 	it("exits 0 with a ranked candidates list", async () => {
 		const out = await run([
 			labelsOk,
-			[QUEUE, okOut("4312\tAbort reason lost when the retry helper re-wraps the request")],
-			[SEARCH, okOut("4088\thttp worker retries do not propagate cancellation")],
+			[QUEUE, issueRows([4312, "Abort reason lost when the retry helper re-wraps the request"])],
+			[SEARCH, searchHits([4088, "http worker retries do not propagate cancellation"])],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe("candidates");
@@ -42,7 +59,7 @@ describe("runDedup", () => {
 	it("--exclude drops the issue being deduped from both sources, so it cannot flag itself", async () => {
 		const title = "Abort reason lost when the retry helper re-wraps the request";
 		const out = await run(
-			[labelsOk, [QUEUE, okOut(`4312\t${title}`)], [SEARCH, okOut(`4312\t${title}`)]],
+			[labelsOk, [QUEUE, issueRows([4312, title])], [SEARCH, searchHits([4312, title])]],
 			{exclude: 4312},
 		);
 		expect(out.code).toBe(0);
@@ -51,12 +68,12 @@ describe("runDedup", () => {
 	});
 
 	it("says nothing about exclusion on the scope line when --exclude was not given", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, okOut("")]]);
+		const out = await run([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]]);
 		expect(out.stderr.join("\n")).not.toContain("excluded from both sources");
 	});
 
 	it("exits 0 on a PROVEN none, printing the token rather than empty stdout", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, okOut("")]]);
+		const out = await run([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("none\n");
 		expect(out.stderr.join("\n")).toContain("both sources were read");
@@ -70,20 +87,20 @@ describe("runDedup", () => {
 	});
 
 	it("REFUSES a --label that does not exist rather than printing `none` over zero scope (#4752)", async () => {
-		const out = await run([[LABELS, okOut("type:bug\np0")]]);
+		const out = await run([[LABELS, labelSet("type:bug", "p0")]]);
 		expect(out.code).toBe(NO_TARGET);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain('never "none"');
 	});
 
 	it("never reads either source once the label is proven absent", async () => {
-		const shell = fakeShell([[LABELS, okOut("type:bug")]]);
-		await Effect.runPromise(Effect.provide(runDedup(options), shell.layer));
-		expect(shell.calls.some((c) => QUEUE.test(c) || SEARCH.test(c))).toBe(false);
+		const seams = fakeSeams([[LABELS, labelSet("type:bug")]]);
+		await Effect.runPromise(Effect.provide(runDedup(options), seams.layer));
+		expect(seams.requests.some((c) => QUEUE.test(c) || SEARCH.test(c))).toBe(false);
 	});
 
 	it("refuses an UNREADABLE label set as UNKNOWN — never as `the label is missing`", async () => {
-		const out = await run([[LABELS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[LABELS, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(QUEUE_UNREADABLE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("UNKNOWN");
@@ -92,8 +109,8 @@ describe("runDedup", () => {
 	it("refuses an unreadable queue — UNKNOWN, never `none`", async () => {
 		const out = await run([
 			labelsOk,
-			[QUEUE, errOut("gh: Not Found (HTTP 404)")],
-			[SEARCH, okOut("")],
+			[QUEUE, {status: 404, body: '{"message":"Not Found"}'}],
+			[SEARCH, searchHits()],
 		]);
 		expect(out.code).toBe(QUEUE_UNREADABLE);
 		expect(out.stdout).toBe("");
@@ -101,7 +118,11 @@ describe("runDedup", () => {
 	});
 
 	it("refuses an unreadable search index on its own code", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, errOut("rate limited")]]);
+		const out = await run([
+			labelsOk,
+			[QUEUE, issueRows()],
+			[SEARCH, {status: 429, body: '{"message":"rate limited"}'}],
+		]);
 		expect(out.code).toBe(SEARCH_UNREADABLE);
 		expect(out.stdout).toBe("");
 	});
@@ -109,23 +130,27 @@ describe("runDedup", () => {
 	it("reports the QUEUE's code when both fail, and names both failures", async () => {
 		const out = await run([
 			labelsOk,
-			[QUEUE, errOut("queue down")],
-			[SEARCH, errOut("search down")],
+			[QUEUE, {status: 503, body: "{}"}],
+			[SEARCH, {status: 429, body: "{}"}],
 		]);
 		expect(out.code).toBe(QUEUE_UNREADABLE);
-		expect(out.stderr.at(-1)).toContain("queue down");
-		expect(out.stderr.at(-1)).toContain("search down");
+		expect(out.stderr.at(-1)).toContain("HTTP 503");
+		expect(out.stderr.at(-1)).toContain("HTTP 429");
 	});
 
-	it("refuses a `gh` that exited 0 with output that is not issue rows", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("not a row")], [SEARCH, okOut("")]]);
+	it("refuses a 200 whose body is not a list of issues", async () => {
+		const out = await run([
+			labelsOk,
+			[QUEUE, {status: 200, body: JSON.stringify([{title: "no number"}])}],
+			[SEARCH, searchHits()],
+		]);
 		expect(out.code).toBe(QUEUE_UNREADABLE);
 		expect(out.stdout).toBe("");
 	});
 
 	it("puts the --json payload on STDOUT, with both source counts", async () => {
 		const out = await run(
-			[labelsOk, [QUEUE, okOut("4312\tretry helper abort reason")], [SEARCH, okOut("")]],
+			[labelsOk, [QUEUE, issueRows([4312, "retry helper abort reason"])], [SEARCH, searchHits()]],
 			{json: true},
 		);
 		const payload = JSON.parse(out.stdout);
@@ -137,10 +162,10 @@ describe("runDedup", () => {
 	});
 
 	it("says on stderr when the cap truncated the list", async () => {
-		const rows = Array.from({length: 4}, (_, i) => `${i + 1}\tretry helper abort reason`).join(
-			"\n",
-		);
-		const out = await run([labelsOk, [QUEUE, okOut(rows)], [SEARCH, okOut("")]], {limit: 2});
+		const rows = Array.from({length: 4}, (_, i) => [i + 1, "retry helper abort reason"] as const);
+		const out = await run([labelsOk, [QUEUE, issueRows(...rows)], [SEARCH, searchHits()]], {
+			limit: 2,
+		});
 		expect(out.stdout.split("\n").filter((l) => l !== "")).toHaveLength(3);
 		expect(out.stderr[0]).toContain("TRUNCATED");
 	});

--- a/packages/fabrika-cli/src/report/file-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/file-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {errOut, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BAD_SECTIONS,
@@ -17,8 +16,8 @@ import {
 import {composeBody, REQUIRED_SECTIONS, renderFooter} from "./compose.ts";
 import {runFile} from "./file-verb.ts";
 
-const READBACK = /^gh api repos\/o\/r\/issues\/\d+$/;
-const CREATE = /--method POST repos\/o\/r\/issues -f/;
+const READBACK = /^GET .*\/repos\/o\/r\/issues\/\d+$/;
+const CREATE = /^POST .*\/repos\/o\/r\/issues$/;
 const LABELS = /repos\/o\/r\/labels/;
 const BRANCH = /git rev-parse/;
 
@@ -34,19 +33,25 @@ const composed = composeBody(
 	renderFooter({session: null, model: null, branch: null, timestamp: "2026-08-01T14:22:07Z"}),
 );
 
-const created = okOut(JSON.stringify({number: 4732, html_url: "https://example.test/issues/4732"}));
+const created: HttpReply = {
+	status: 201,
+	body: JSON.stringify({number: 4732, html_url: "https://example.test/issues/4732"}),
+};
 
-const landed = (body: string, labels: ReadonlyArray<string> = ["status:needs-triage"]) =>
-	okOut(
-		JSON.stringify({
-			number: 4732,
-			title: "t",
-			body,
-			state: "open",
-			labels: labels.map((name) => ({name})),
-			html_url: "https://example.test/issues/4732",
-		}),
-	);
+const landed = (
+	body: string,
+	labels: ReadonlyArray<string> = ["status:needs-triage"],
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4732,
+		title: "t",
+		body,
+		state: "open",
+		labels: labels.map((name) => ({name})),
+		html_url: "https://example.test/issues/4732",
+	}),
+});
 
 const options = {
 	title: "Retry helper in the http worker swallows the abort reason",
@@ -59,21 +64,23 @@ const options = {
 	now: () => NOW,
 };
 
-const labelsOk = [LABELS, okOut("status:needs-triage\ntype:bug\np0")] as const;
+const labelSet = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+const labelsOk = [LABELS, labelSet("status:needs-triage", "type:bug", "p0")] as const;
 const branchDetached = [BRANCH, errOut("detached")] as const;
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	[READBACK, landed(composed)],
 	[CREATE, created],
 	labelsOk,
 	branchDetached,
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runFile({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runFile({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runFile", () => {
 	it("files, reads back, and prints a bare tab-separated number and url", async () => {
@@ -95,9 +102,9 @@ describe("runFile", () => {
 	});
 
 	it("appends the footer itself, with the never-dropped marker", async () => {
-		const shell = fakeShell(happy);
-		await Effect.runPromise(Effect.provide(runFile(options), shell.layer));
-		const create = shell.calls.find((c) => CREATE.test(c)) ?? "";
+		const seams = fakeSeams(happy);
+		await Effect.runPromise(Effect.provide(runFile(options), seams.layer));
+		const create = seams.bodies[seams.requests.findIndex((c) => CREATE.test(c))] ?? "";
 		expect(create).toContain("Filed by an agent");
 		expect(create).toContain("2026-08-01T14:22:07Z");
 	});
@@ -178,16 +185,16 @@ describe("runFile", () => {
 	});
 
 	it("refuses an UNREADABLE label set as UNKNOWN, and files nothing", async () => {
-		const shell = fakeShell([
+		const seams = fakeSeams([
 			[READBACK, landed(composed)],
 			[CREATE, created],
-			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, {status: 502, body: "{}"}],
 			branchDetached,
 		]);
-		const out = await Effect.runPromise(Effect.provide(runFile(options), shell.layer));
+		const out = await Effect.runPromise(Effect.provide(runFile(options), seams.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(seams.requests.some((c) => CREATE.test(c))).toBe(false);
 	});
 
 	it("refuses a --label that classifies", async () => {
@@ -205,7 +212,7 @@ describe("runFile", () => {
 	it("reports a failed create as UNKNOWN, with the re-run-dedup recovery", async () => {
 		const out = await run([
 			[READBACK, landed(composed)],
-			[CREATE, errOut("gh: Service unavailable (HTTP 503)")],
+			[CREATE, {status: 503, body: "{}"}],
 			labelsOk,
 			branchDetached,
 		]);

--- a/packages/fabrika-cli/src/report/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/note-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	BARE_AT_PATH,
@@ -14,40 +13,36 @@ import {
 } from "./codes.ts";
 import {runNote} from "./note-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const POST = /repos\/o\/r\/issues\/4312\/comments -f/;
-const COMMENT = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const ISSUE = /^GET .*\/repos\/o\/r\/issues\/4312$/;
+const POST = /^POST .*\/repos\/o\/r\/issues\/4312\/comments$/;
+const COMMENT = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
 
 const NOTE = "Also reproduces on the streaming path, not just the buffered one.";
 
-const issueOpen = okOut(
-	JSON.stringify({
+const issue = (state: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
 		number: 4312,
 		title: "t",
 		body: "b",
-		state: "open",
+		state,
 		labels: [],
 		html_url: "https://example.test/issues/4312",
 	}),
-);
+});
 
-const issueClosed = okOut(
-	JSON.stringify({
-		number: 4312,
-		title: "t",
-		body: "b",
-		state: "closed",
-		labels: [],
-		html_url: "https://example.test/issues/4312",
-	}),
-);
+const issueOpen = issue("open");
+const issueClosed = issue("closed");
 
-const posted = okOut(
-	JSON.stringify({
+const comment = (body: string): HttpReply => ({status: 200, body: JSON.stringify({body})});
+
+const posted: HttpReply = {
+	status: 201,
+	body: JSON.stringify({
 		id: 5154891644,
 		html_url: "https://example.test/issues/4312#issuecomment-5154891644",
 	}),
-);
+};
 
 const options = {
 	issue: 4312,
@@ -58,17 +53,14 @@ const options = {
 	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: NOTE}),
 };
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[COMMENT, okOut(JSON.stringify({body: NOTE}))],
+const happy: ReadonlyArray<Scripted> = [
+	[COMMENT, comment(NOTE)],
 	[ISSUE, issueOpen],
 	[POST, posted],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runNote", () => {
 	it("posts, reads back, and prints a bare tab-separated id and url", async () => {
@@ -91,7 +83,7 @@ describe("runNote", () => {
 	it("validates nothing about the note's structure — a note is free prose", async () => {
 		const out = await run(
 			[
-				[COMMENT, okOut(JSON.stringify({body: "one line, no headings"}))],
+				[COMMENT, comment("one line, no headings")],
 				[ISSUE, issueOpen],
 				[POST, posted],
 			],
@@ -101,16 +93,16 @@ describe("runNote", () => {
 	});
 
 	it("appends no footer — the note lands byte-for-byte as sent", async () => {
-		const shell = fakeShell(happy);
-		await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
-		const post = shell.calls.find((c) => POST.test(c)) ?? "";
-		expect(post).toContain(`body=${NOTE}`);
+		const seams = fakeSeams(happy);
+		await Effect.runPromise(Effect.provide(runNote(options), seams.layer));
+		const post = seams.bodies[seams.requests.findIndex((c) => POST.test(c))] ?? "";
+		expect(post).toBe(JSON.stringify({body: NOTE}));
 		expect(post).not.toContain("Filed by an agent");
 	});
 
 	it("posts on a CLOSED issue but says so — never a surprise about where it landed", async () => {
 		const out = await run([
-			[COMMENT, okOut(JSON.stringify({body: NOTE}))],
+			[COMMENT, comment(NOTE)],
 			[ISSUE, issueClosed],
 			[POST, posted],
 		]);
@@ -157,7 +149,7 @@ describe("runNote", () => {
 		const masked = "reproduced from /Users/<redacted>";
 		const out = await run(
 			[
-				[COMMENT, okOut(JSON.stringify({body: masked}))],
+				[COMMENT, comment(masked)],
 				[ISSUE, issueOpen],
 				[POST, posted],
 			],
@@ -174,22 +166,22 @@ describe("runNote", () => {
 	});
 
 	it("refuses an issue that does not exist", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(NO_TARGET);
 		expect(out.stderr.at(-1)).toBe("report note: o/r has no issue #4312.");
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and posts nothing", async () => {
-		const shell = fakeShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
-		const out = await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		const seams = fakeSeams([[ISSUE, {status: 502, body: "{}"}]]);
+		const out = await Effect.runPromise(Effect.provide(runNote(options), seams.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((c) => POST.test(c))).toBe(false);
+		expect(seams.requests.some((c) => POST.test(c))).toBe(false);
 	});
 
 	it("reports a failed post as UNKNOWN, with the re-read recovery", async () => {
 		const out = await run([
 			[ISSUE, issueOpen],
-			[POST, errOut("gh: timeout")],
+			[POST, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -198,7 +190,7 @@ describe("runNote", () => {
 
 	it("refuses when the landed comment is not what was sent (#3173)", async () => {
 		const out = await run([
-			[COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			[COMMENT, comment("something else entirely")],
 			[ISSUE, issueOpen],
 			[POST, posted],
 		]);
@@ -208,7 +200,7 @@ describe("runNote", () => {
 
 	it("refuses when the read-back itself fails — a post that is not verified is not finished", async () => {
 		const out = await run([
-			[COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+			[COMMENT, {status: 502, body: "{}"}],
 			[ISSUE, issueOpen],
 			[POST, posted],
 		]);

--- a/packages/fabrika-cli/src/review-ui/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/note-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	EMPTY_STDIN,
@@ -16,25 +15,25 @@ import {runNote} from "./note-verb.ts";
 const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
 const URL = "https://example.test/pull/4321#issuecomment-512399";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321\b/;
+const CREATE = /POST .*\/repos\/o\/r\/issues\/4321\/comments/;
+const READBACK = /GET .*\/repos\/o\/r\/issues\/comments\/\d+/;
 
 const NOTE =
 	"review-ui cannot see this PR: no preview-deploy comment exists, so there is nothing to judge\nwithout running the PR's code.\n";
 
-const pull = (state = "open"): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4321,
-			state,
-			head: {sha: HEAD},
-			base: {ref: "main"},
-			body: "",
-			changed_files: 1,
-			comments: 0,
-		}),
-	);
+const pull = (state = "open"): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4321,
+		state,
+		head: {sha: HEAD},
+		base: {ref: "main"},
+		body: "",
+		changed_files: 1,
+		comments: 0,
+	}),
+});
 
 const options = {
 	pr: 4321,
@@ -43,19 +42,16 @@ const options = {
 	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: NOTE}),
 };
 
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const happy = (): ReadonlyArray<Scripted> => [
 	[PULL, pull()],
-	[CREATE, okOut(JSON.stringify({id: 512399, html_url: URL}))],
-	[READBACK, okOut(JSON.stringify({body: NOTE}))],
+	[CREATE, {status: 201, body: JSON.stringify({id: 512399, html_url: URL})}],
+	[READBACK, {status: 200, body: JSON.stringify({body: NOTE})}],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
-	const shell = fakeShell(script);
-	return Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), shell.layer)).then(
-		(outcome) => ({outcome, calls: shell.calls}),
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const seams = fakeSeams(script);
+	return Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), seams.layer)).then(
+		(outcome) => ({outcome, requests: seams.requests}),
 	);
 };
 
@@ -73,11 +69,11 @@ describe("runNote", () => {
 
 	it("refuses a marker-shaped body on 10 — a verdict goes through review-ui post", async () => {
 		const marker = `review-ui: PASS @ ${HEAD} — sneaking a verdict through\n`;
-		const {outcome, calls} = await run(happy(), {
+		const {outcome, requests} = await run(happy(), {
 			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: marker}),
 		});
 		expect(outcome.code).toBe(OFF_VOCABULARY);
-		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("refuses a body reaching for a marker and missing it, too", async () => {
@@ -121,7 +117,7 @@ describe("runNote", () => {
 	it("refuses on 8 when the post failed — UNKNOWN whether it landed", async () => {
 		const {outcome} = await run([
 			[PULL, pull()],
-			[CREATE, {ok: false, stdout: "", reason: "gh: 502"}],
+			[CREATE, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 	});
@@ -129,8 +125,8 @@ describe("runNote", () => {
 	it("refuses on 9 when the comment does not read back as sent", async () => {
 		const {outcome} = await run([
 			[PULL, pull()],
-			[CREATE, okOut(JSON.stringify({id: 512399, html_url: URL}))],
-			[READBACK, okOut(JSON.stringify({body: "something else"}))],
+			[CREATE, {status: 201, body: JSON.stringify({id: 512399, html_url: URL})}],
+			[READBACK, {status: 200, body: JSON.stringify({body: "something else"})}],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 	});

--- a/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, FileSystem, Layer, Path, PlatformError} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	EMPTY_STDIN,
@@ -86,40 +85,40 @@ const world = (overrides: FsShape = {}): Layer.Layer<FileSystem.FileSystem | Pat
 		bytes: {[CAPTURE_PATH]: BYTES, ...overrides.bytes},
 	});
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const USER = /^gh api user --jq \.login$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/\d+ /;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321\b/;
+const USER = /GET .*api\.github\.com\/user$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /POST .*\/repos\/o\/r\/issues\/4321\/comments/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/comments\/\d+/;
+const READBACK = /GET .*\/repos\/o\/r\/issues\/comments\/\d+/;
 
-const pull = (state = "open", head = HEAD): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4321,
-			state,
-			head: {sha: head},
-			base: {ref: "main"},
-			body: "",
-			changed_files: 1,
-			comments: 0,
-		}),
-	);
+const pull = (state = "open", head = HEAD): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4321,
+		state,
+		head: {sha: head},
+		base: {ref: "main"},
+		body: "",
+		changed_files: 1,
+		comments: 0,
+	}),
+});
 
 const comments = (
 	...rows: ReadonlyArray<{id: number; body: string; author?: string; updatedAt?: string}>
-): ExecResult =>
-	okOut(
-		JSON.stringify(
-			rows.map((row) => ({
-				id: row.id,
-				user: {login: row.author ?? "kampus-bot"},
-				created_at: "2026-08-08T00:00:00Z",
-				updated_at: row.updatedAt ?? "2026-08-08T00:00:00Z",
-				body: row.body,
-			})),
-		),
-	);
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(
+		rows.map((row) => ({
+			id: row.id,
+			user: {login: row.author ?? "kampus-bot"},
+			created_at: "2026-08-08T00:00:00Z",
+			updated_at: row.updatedAt ?? "2026-08-08T00:00:00Z",
+			body: row.body,
+		})),
+	),
+});
 
 const hostingLeg: UploadLeg = () => Effect.succeed({_tag: "Hosted", url: HOSTED});
 const failingLeg: UploadLeg = () => Effect.succeed({_tag: "Failed", reason: "HTTP 500"});
@@ -142,38 +141,32 @@ const options = {
 };
 
 /** The comment as the verb will have posted it, echoed back by the read-back read. */
-const posted = (body: string): ExecResult => okOut(JSON.stringify({body}));
+const posted = (body: string): HttpReply => ({status: 200, body: JSON.stringify({body})});
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	layer: Layer.Layer<FileSystem.FileSystem | Path.Path> = world(),
 ) => {
-	const shell = fakeShell(script);
-	// The upload leg is injected, so nothing here reaches the network; the client is provided only
-	// because the seam `githubAttachmentUploadLeg` runs on is part of `runPost`'s requirements now.
-	const http = fakeHttp([]);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
-		Effect.provide(
-			runPost({...options, ...overrides}),
-			Layer.mergeAll(shell.layer, http.layer, layer),
-		),
-	).then((outcome) => ({outcome, calls: shell.calls}));
+		Effect.provide(runPost({...options, ...overrides}), Layer.merge(seams.layer, layer)),
+	).then((outcome) => ({outcome, requests: seams.requests, bodies: seams.bodies}));
 };
 
 const COMPOSED = `review-ui: FAIL @ ${HEAD} — changes-requested\n\n${BODY.trimEnd()}\n\n## Evidence\n\n### /pano\n\n![/pano](${HOSTED})`;
 
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const happy = (): ReadonlyArray<Scripted> => [
 	[PULL, pull()],
-	[USER, okOut("kampus-bot")],
+	[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 	[COMMENTS, comments()],
-	[CREATE, okOut(JSON.stringify({id: 5154902211, html_url: URL}))],
+	[CREATE, {status: 201, body: JSON.stringify({id: 5154902211, html_url: URL})}],
 	[READBACK, posted(COMPOSED)],
 ];
 
 describe("runPost", () => {
 	it("posts one marker-first comment with the verified evidence gallery under it", async () => {
-		const {outcome, calls} = await run(happy());
+		const {outcome, requests, bodies} = await run(happy());
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toEqual({
 			answer: "posted",
@@ -185,8 +178,8 @@ describe("runPost", () => {
 			surfaces: 1,
 			commentUrl: URL,
 		});
-		const write = calls.find((call) => CREATE.test(call)) ?? "";
-		const body = write.slice(write.indexOf("body=") + "body=".length);
+		const write = bodies[requests.findIndex((request) => CREATE.test(request))] ?? "";
+		const body = String(JSON.parse(write).body);
 		expect(body.split("\n")[0]).toBe(`review-ui: FAIL @ ${HEAD} — changes-requested`);
 		expect(body).toContain(`![/pano](${HOSTED})`);
 		// The gallery embeds the hosted URL, never the local path the reviewer judged.
@@ -212,9 +205,9 @@ describe("runPost", () => {
 	});
 
 	it("refuses on 12 when the live head moved past --sha, and posts nothing", async () => {
-		const {outcome, calls} = await run([[PULL, pull("open", OLD_HEAD)], ...happy().slice(1)]);
+		const {outcome, requests} = await run([[PULL, pull("open", OLD_HEAD)], ...happy().slice(1)]);
 		expect(outcome.code).toBe(STALE_TREE);
-		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("refuses on 12 when the evidence set was rendered at another head", async () => {
@@ -257,25 +250,25 @@ describe("runPost", () => {
 	});
 
 	it("posts NOTHING when an evidence upload fails — 17 is this verb's reason to exist", async () => {
-		const {outcome, calls} = await run(happy(), {upload: failingLeg});
+		const {outcome, requests} = await run(happy(), {upload: failingLeg});
 		expect(outcome.code).toBe(UPLOAD_FAILED);
-		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(requests.some((request) => CREATE.test(request))).toBe(false);
 		expect(outcome.stderr.at(-1)).toMatch(/broken evidence channel/);
 	});
 
 	it("still refuses when the AUTHENTICATED probe reads 404 — #6520 does not soften #3925", async () => {
 		const notResolving: UploadLeg = () =>
 			Effect.succeed({_tag: "Failed", reason: classifyProbe(404) ?? ""});
-		const {outcome, calls} = await run(happy(), {upload: notResolving});
+		const {outcome, requests} = await run(happy(), {upload: notResolving});
 		expect(outcome.code).toBe(UPLOAD_FAILED);
-		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(requests.some((request) => CREATE.test(request))).toBe(false);
 		expect(outcome.stderr.join("\n")).toMatch(/probed back HTTP 404/);
 	});
 
 	it("edits this namespace's own comment instead of stacking a second marker", async () => {
-		const {outcome, calls} = await run([
+		const {outcome, requests} = await run([
 			[PULL, pull()],
-			[USER, okOut("kampus-bot")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
 				comments({
@@ -284,18 +277,18 @@ describe("runPost", () => {
 					author: "kampus-bot",
 				}),
 			],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, posted(COMPOSED)],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).upsert).toBe("edited");
-		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("edits the NEWEST of two markers at one SHA, not whichever came back first (#4881)", async () => {
-		const {outcome, calls} = await run([
+		const {outcome, requests} = await run([
 			[PULL, pull()],
-			[USER, okOut("kampus-bot")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
 				comments(
@@ -311,19 +304,19 @@ describe("runPost", () => {
 					},
 				),
 			],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, posted(COMPOSED)],
 		]);
 		expect(outcome.code).toBe(0);
-		expect(calls.find((call) => PATCH.test(call))).toContain("issues/comments/42");
+		expect(requests.find((request) => PATCH.test(request))).toContain("issues/comments/42");
 	});
 
 	it("refuses on 8 when the write itself failed — UNKNOWN, never 1", async () => {
 		const {outcome} = await run([
 			[PULL, pull()],
-			[USER, okOut("kampus-bot")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[COMMENTS, comments()],
-			[CREATE, {ok: false, stdout: "", reason: "gh: 502"}],
+			[CREATE, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 	});
@@ -331,9 +324,9 @@ describe("runPost", () => {
 	it("refuses on 9 when the read-back does not yield this marker", async () => {
 		const {outcome} = await run([
 			[PULL, pull()],
-			[USER, okOut("kampus-bot")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[COMMENTS, comments()],
-			[CREATE, okOut(JSON.stringify({id: 1, html_url: URL}))],
+			[CREATE, {status: 201, body: JSON.stringify({id: 1, html_url: URL})}],
 			[once(READBACK), posted("someone else's comment entirely")],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {
 	INVALID_CAPTURE,
 	NO_PREVIEW,
@@ -18,34 +17,34 @@ import {type RenderLeg, runRender, type SurfaceRender} from "./render-verb.ts";
 const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
 const PREVIEW = "https://pr-4321-web.example.test";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321\b/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4321\/comments/;
 
-const pull = (state = "open", head = HEAD): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4321,
-			state,
-			head: {sha: head},
-			base: {ref: "main"},
-			body: "",
-			changed_files: 2,
-			comments: 1,
-		}),
-	);
+const pull = (state = "open", head = HEAD): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4321,
+		state,
+		head: {sha: head},
+		base: {ref: "main"},
+		body: "",
+		changed_files: 2,
+		comments: 1,
+	}),
+});
 
-const announcement = (sha: string = HEAD.slice(0, 7)): ExecResult =>
-	okOut(
-		JSON.stringify([
-			{
-				id: 7,
-				user: {login: "kampus-bot"},
-				created_at: "2026-08-09T00:00:00Z",
-				updated_at: "2026-08-09T00:00:00Z",
-				body: `<!-- preview-deploy:web -->\n- **web** — Stage \`pr-4321\` → ${PREVIEW} <sub>(${sha})</sub>`,
-			},
-		]),
-	);
+const announcement = (sha: string = HEAD.slice(0, 7)): HttpReply => ({
+	status: 200,
+	body: JSON.stringify([
+		{
+			id: 7,
+			user: {login: "kampus-bot"},
+			created_at: "2026-08-09T00:00:00Z",
+			updated_at: "2026-08-09T00:00:00Z",
+			body: `<!-- preview-deploy:web -->\n- **web** — Stage \`pr-4321\` → ${PREVIEW} <sub>(${sha})</sub>`,
+		},
+	]),
+});
 
 const rendered = (surface: string, outDir: string): SurfaceRender => ({
 	_tag: "Rendered",
@@ -76,20 +75,17 @@ const options = {
 	render: legOf({}),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
 	const fs = fakeFs({});
 	return Effect.runPromise(
 		Effect.provide(
 			runRender({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fs.layer),
+			Layer.merge(fakeSeams(script).layer, fs.layer),
 		),
 	).then((outcome) => ({outcome, written: fs.written}));
 };
 
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const happy = (): ReadonlyArray<Scripted> => [
 	[PULL, pull()],
 	[COMMENTS, announcement()],
 ];
@@ -159,11 +155,12 @@ describe("runRender", () => {
 	});
 
 	it("proves CANT-SEE (16) only when no comment carries the preview anchor", async () => {
-		const none = okOut(
-			JSON.stringify([
+		const none: HttpReply = {
+			status: 200,
+			body: JSON.stringify([
 				{id: 1, user: {login: "x"}, created_at: "", updated_at: "", body: "looks fine"},
 			]),
-		);
+		};
 		const {outcome} = await run([
 			[PULL, pull()],
 			[COMMENTS, none],
@@ -172,8 +169,9 @@ describe("runRender", () => {
 	});
 
 	it("calls a malformed announcement UNKNOWN (11), never absent", async () => {
-		const malformed = okOut(
-			JSON.stringify([
+		const malformed: HttpReply = {
+			status: 200,
+			body: JSON.stringify([
 				{
 					id: 1,
 					user: {login: "x"},
@@ -182,7 +180,7 @@ describe("runRender", () => {
 					body: "<!-- preview-deploy:web -->\n- **web** — the deploy failed",
 				},
 			]),
-		);
+		};
 		const {outcome} = await run([
 			[PULL, pull()],
 			[COMMENTS, malformed],

--- a/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {runAppendCriterion} from "./append-criterion-verb.ts";
@@ -17,11 +17,25 @@ import {
 } from "./codes.ts";
 import {issue} from "./fixtures.test-support.ts";
 
-const USER = /^gh api user --jq \.login$/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/kampus-bot\/permission --jq \.permission$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4287 -f body=/;
-const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4287\/comments /;
+const USER = /GET .*api\.github\.com\/user$/;
+const PERMISSION = /GET .*\/repos\/o\/r\/collaborators\/kampus-bot\/permission$/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4287$/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/4287$/;
+const COMMENT = /POST .*\/repos\/o\/r\/issues\/4287\/comments/;
+
+const NOT_FOUND = '{"message":"Not Found"}';
+
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+/** The body the PATCH carried, as text — the successor to reading it off a `-f body=` argv. */
+const patched = (seams: {
+	readonly requests: ReadonlyArray<string>;
+	readonly bodies: ReadonlyArray<string>;
+}): string => {
+	const index = seams.requests.findIndex((request) => PATCH.test(request));
+	return index === -1 ? "" : String(JSON.parse(seams.bodies[index] ?? "{}").body ?? "");
+};
 
 const TEXT = "a regression test covers qty > 1";
 const ROW = `- [ ] ${TEXT} <!-- ac:review pr:#4321 round:1 -->`;
@@ -45,20 +59,17 @@ const options = {
 	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: TEXT}),
 };
 
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[USER, okOut("kampus-bot")],
-	[PERMISSION, okOut("write")],
-	[once(ISSUE), issue()],
-	[ISSUE, issue(APPENDED)],
-	[PATCH, okOut("{}")],
+const happy = (): ReadonlyArray<Scripted> => [
+	[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+	[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+	[once(ISSUE), served(issue())],
+	[ISSUE, served(issue(APPENDED))],
+	[PATCH, {status: 200, body: "{}"}],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(runAppendCriterion({...options, ...overrides}), fakeShell(script).layer),
+		Effect.provide(runAppendCriterion({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 describe("runAppendCriterion", () => {
@@ -69,17 +80,17 @@ describe("runAppendCriterion", () => {
 	});
 
 	it("writes exactly one row, tagged with its provenance", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
-		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		const write = patched(shell);
 		expect(write).toContain(ROW);
 	});
 
 	// Fence 1 — the ACL, fail-closed.
 	it("refuses a token below write on 14, and writes nothing", async () => {
-		const shell = fakeShell([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("read")],
+		const shell = fakeSeams([
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "read"})}],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
 		expect(out.code).toBe(ACL_DENIED);
@@ -87,34 +98,34 @@ describe("runAppendCriterion", () => {
 		expect(out.stderr.at(-1)).toBe(
 			"review append-criterion: token resolves below write on o/r, or the ACL could not be read — refusing the append (ADR 0055, fail-closed).",
 		);
-		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => PATCH.test(request))).toBe(false);
 	});
 
 	it("refuses a FAILED ACL lookup on 14 too — authority never comes from a failed read", async () => {
 		const lookupFailed = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 502, body: "{}"}],
 		]);
 		expect(lookupFailed.code).toBe(ACL_DENIED);
 
-		const noIdentity = await run([[USER, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const noIdentity = await run([[USER, {status: 502, body: "{}"}]]);
 		expect(noIdentity.code).toBe(ACL_DENIED);
 	});
 
 	it("admits admin and maintain, which resolve above write", async () => {
 		for (const permission of ["admin", "maintain", "write"]) {
 			const out = await run([
-				[USER, okOut("kampus-bot")],
-				[PERMISSION, okOut(permission)],
-				[once(ISSUE), issue()],
-				[ISSUE, issue(APPENDED)],
-				[PATCH, okOut("{}")],
+				[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+				[PERMISSION, {status: 200, body: JSON.stringify({permission})}],
+				[once(ISSUE), served(issue())],
+				[ISSUE, served(issue(APPENDED))],
+				[PATCH, {status: 200, body: "{}"}],
 			]);
 			expect(out.code).toBe(0);
 		}
 		const triage = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("triage")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "triage"})}],
 		]);
 		expect(triage.code).toBe(ACL_DENIED);
 	});
@@ -129,21 +140,23 @@ describe("runAppendCriterion", () => {
 
 - [ ] a checkbox that is not a criterion
 `;
-		const shell = fakeShell([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[once(ISSUE), issue(withLaterList)],
+		const shell = fakeSeams([
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue(withLaterList))],
 			[
 				ISSUE,
-				issue(
-					withLaterList.replace("- [ ] the only criterion", `- [ ] the only criterion\n${ROW}`),
+				served(
+					issue(
+						withLaterList.replace("- [ ] the only criterion", `- [ ] the only criterion\n${ROW}`),
+					),
 				),
 			],
-			[PATCH, okOut("{}")],
+			[PATCH, {status: 200, body: "{}"}],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
 		expect(out.code).toBe(0);
-		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		const write = patched(shell);
 		expect(write.indexOf(ROW)).toBeLessThan(write.indexOf("## Notes"));
 	});
 
@@ -159,17 +172,17 @@ describe("runAppendCriterion", () => {
   the runtime actually applies rather than the one the ADR proposed, so a reader comparing the two
   can tell which is in force.
 `;
-		const shell = fakeShell([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[once(ISSUE), issue(wrapped)],
-			[ISSUE, issue(`${wrapped.trimEnd()}\n${ROW}\n`)],
-			[PATCH, okOut("{}")],
+		const shell = fakeSeams([
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue(wrapped))],
+			[ISSUE, served(issue(`${wrapped.trimEnd()}\n${ROW}\n`))],
+			[PATCH, {status: 200, body: "{}"}],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("appended\t4287\t3\n");
-		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		const write = patched(shell);
 		expect(write).toContain(`can tell which is in force.\n${ROW}`);
 	});
 
@@ -184,13 +197,13 @@ describe("runAppendCriterion", () => {
 	it("keeps 15 distinct from every other refusal this verb can reach", async () => {
 		const reachable = await Promise.all([
 			run([
-				[USER, okOut("kampus-bot")],
-				[PERMISSION, okOut("read")],
+				[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+				[PERMISSION, {status: 200, body: JSON.stringify({permission: "read"})}],
 			]),
 			run([
-				[USER, okOut("kampus-bot")],
-				[PERMISSION, okOut("write")],
-				[ISSUE, errOut("gh: Not Found (HTTP 404)")],
+				[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+				[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+				[ISSUE, {status: 404, body: NOT_FOUND}],
 			]),
 			run(happy(), {stdin: Effect.succeed({_tag: "Text", text: ""})}),
 		]);
@@ -199,28 +212,28 @@ describe("runAppendCriterion", () => {
 
 	// Fence 3 — frozen at round 3.
 	it("escalates instead of appending at the freeze, and appends NOTHING", async () => {
-		const shell = fakeShell([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[ISSUE, issue()],
-			[COMMENT, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		const shell = fakeSeams([
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[ISSUE, served(issue())],
+			[COMMENT, {status: 201, body: JSON.stringify({id: 1, html_url: "https://example.test/c/1"})}],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(runAppendCriterion({...options, round: 3}), shell.layer),
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("escalated-frozen\t4287\t3\n");
-		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
-		expect(shell.calls.some((call) => COMMENT.test(call))).toBe(true);
+		expect(shell.requests.some((request) => PATCH.test(request))).toBe(false);
+		expect(shell.requests.some((request) => COMMENT.test(request))).toBe(true);
 	});
 
 	it("reports a failed escalation comment as 8, naming which write it was", async () => {
 		const out = await run(
 			[
-				[USER, okOut("kampus-bot")],
-				[PERMISSION, okOut("write")],
-				[ISSUE, issue()],
-				[COMMENT, errOut("gh: timeout")],
+				[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+				[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+				[ISSUE, served(issue())],
+				[COMMENT, {status: 502, body: "{}"}],
 			],
 			{round: 3},
 		);
@@ -232,16 +245,16 @@ describe("runAppendCriterion", () => {
 	// The target's own preconditions.
 	it("refuses an absent issue on 7 and a CLOSED one on 7 — a row there enters no cycle", async () => {
 		const absent = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[ISSUE, errOut("gh: Not Found (HTTP 404)")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[ISSUE, {status: 404, body: NOT_FOUND}],
 		]);
 		expect(absent.code).toBe(ZERO_SCOPE);
 
 		const closed = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[ISSUE, issue(undefined, "closed")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[ISSUE, served(issue(undefined, "closed"))],
 		]);
 		expect(closed.code).toBe(ZERO_SCOPE);
 		expect(closed.stderr.at(-1)).toContain("file the finding instead");
@@ -249,9 +262,9 @@ describe("runAppendCriterion", () => {
 
 	it("refuses an issue with no conforming block on 7, naming absent vs malformed", async () => {
 		const out = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[ISSUE, issue("nothing to append under")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[ISSUE, served(issue("nothing to append under"))],
 		]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("(absent:");
@@ -260,9 +273,9 @@ describe("runAppendCriterion", () => {
 
 	it("refuses an unreadable issue on 11 — nothing was written", async () => {
 		const out = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[ISSUE, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was written");
@@ -270,10 +283,10 @@ describe("runAppendCriterion", () => {
 
 	it("reports a failed PATCH as 8 — UNKNOWN whether the row landed", async () => {
 		const out = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[ISSUE, issue()],
-			[PATCH, errOut("gh: timeout")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[ISSUE, served(issue())],
+			[PATCH, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -282,11 +295,11 @@ describe("runAppendCriterion", () => {
 
 	it("refuses on 9 when the read-back does not show the prior rows plus this one", async () => {
 		const out = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[once(ISSUE), issue()],
-			[ISSUE, issue()],
-			[PATCH, okOut("{}")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue())],
+			[ISSUE, served(issue())],
+			[PATCH, {status: 200, body: "{}"}],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stdout).toBe("");
@@ -301,11 +314,11 @@ describe("runAppendCriterion", () => {
 ${ROW}
 `;
 		const out = await run([
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[once(ISSUE), issue()],
-			[ISSUE, issue(mutated)],
-			[PATCH, okOut("{}")],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue())],
+			[ISSUE, served(issue(mutated))],
+			[PATCH, {status: 200, body: "{}"}],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 	});
@@ -327,14 +340,14 @@ ${ROW}
 	});
 
 	it("writes nothing at all on a stdin refusal — not even the ACL lookup", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		await Effect.runPromise(
 			Effect.provide(
 				runAppendCriterion({...options, stdin: Effect.succeed({_tag: "Text", text: ""})}),
 				shell.layer,
 			),
 		);
-		expect(shell.calls).toEqual([]);
+		expect(shell.log).toEqual([]);
 	});
 
 	it("emits the record with --json, naming the ACL it resolved", async () => {

--- a/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
@@ -1,26 +1,32 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {workflows} from "../ship/fixtures.test-support.ts";
 import {runCi} from "./ci-verb.ts";
 import {INCOMPLETE_SCAN, NO_GATE_COVERAGE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {checkRuns, HEAD, inventory, OLD_HEAD, pull, runsAtHead} from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const COMMIT = (sha: string) => new RegExp(`^gh api repos/o/r/commits/${sha} --jq \\.sha$`);
-const RUNS = /^gh api --paginate repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
-// The two Actions reads went over to HTTP with `ship/github.ts`; everything else here still shells.
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321$/;
+const COMMIT = (sha: string) => new RegExp(`GET .*/repos/o/r/commits/${sha}$`);
+const RUNS = /GET .*\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
 const WORKFLOWS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/actions\/workflows\?/;
 const AT_HEAD = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/actions\/runs\?head_sha=/;
 const CONFIG = "/repo/.fabrika.jsonc";
 
-/** A canned payload, served as the body of the 200 the ported read now issues. */
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
 const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
 
 const BAD_GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
+const NOT_FOUND = '{"message":"Not Found"}';
 
-const GREEN = checkRuns(3, [
+/** The check-run envelope at a commit, as the platform serves it. */
+const runs = (
+	declared: number,
+	list: ReadonlyArray<{name: string; status: string; conclusion: string | null}>,
+): HttpReply => served(checkRuns(declared, list));
+
+const GREEN = runs(3, [
 	{name: "lint / format / typecheck", status: "completed", conclusion: "success"},
 	{name: "unit tests", status: "completed", conclusion: "success"},
 	{name: "leak-guard", status: "completed", conclusion: "success"},
@@ -31,7 +37,7 @@ const GUARD_YML = ".github/workflows/leak-guard.yml";
 const CODEQL = "dynamic/github-code-scanning/codeql";
 
 /** The repo's own gates ran here — the coverage reads every non-red rollup now owes. */
-const GATED: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+const GATED: ReadonlyArray<Scripted> = [
 	[WORKFLOWS, served(inventory(CI_YML, GUARD_YML, CODEQL))],
 	[AT_HEAD, served(runsAtHead(CI_YML, GUARD_YML))],
 ];
@@ -46,15 +52,15 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted> = [],
 	overrides: Partial<typeof options> = {},
 	files: Readonly<Record<string, string | null>> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runCi({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, fakeHttp(http).layer, fakeFs({files}).layer),
+			Layer.merge(fakeSeams([...script, ...http]).layer, fakeFs({files}).layer),
 		),
 	);
 
@@ -62,7 +68,7 @@ describe("runCi", () => {
 	it("prints the rollup, the count of lines that follow, and one line per run", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			GATED,
@@ -82,10 +88,10 @@ describe("runCi", () => {
 
 	it("names a red check by name, not as a rollup boolean", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[
 				RUNS,
-				checkRuns(2, [
+				runs(2, [
 					{name: "unit tests", status: "completed", conclusion: "failure"},
 					{name: "leak-guard", status: "completed", conclusion: "success"},
 				]),
@@ -98,8 +104,8 @@ describe("runCi", () => {
 	it("enumerates at --sha and notices when the live head has moved past it", async () => {
 		const out = await run(
 			[
-				[PULL, pull({head: HEAD})],
-				[COMMIT(OLD_HEAD), okOut(OLD_HEAD)],
+				[PULL, served(pull({head: HEAD}))],
+				[COMMIT(OLD_HEAD), {status: 200, body: JSON.stringify({sha: OLD_HEAD})}],
 				[RUNS, GREEN],
 			],
 			GATED,
@@ -113,8 +119,8 @@ describe("runCi", () => {
 	it("refuses a --sha proven absent on 7", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[COMMIT(OLD_HEAD), errOut("gh: Not Found (HTTP 404)")],
+				[PULL, served(pull())],
+				[COMMIT(OLD_HEAD), {status: 404, body: NOT_FOUND}],
 			],
 			[],
 			{sha: OLD_HEAD},
@@ -126,8 +132,8 @@ describe("runCi", () => {
 	it("refuses zero declared check runs on 7 — a vacuous green is the ADR 0092 fail-open", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[RUNS, checkRuns(0, [])],
+				[PULL, served(pull())],
+				[RUNS, runs(0, [])],
 			],
 			[[WORKFLOWS, served(workflows("active", "active"))]],
 		);
@@ -138,8 +144,8 @@ describe("runCi", () => {
 
 	it("refuses a short enumeration on 13 — never read as `no red checks`", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[RUNS, checkRuns(9, [{name: "unit tests", status: "completed", conclusion: "success"}])],
+			[PULL, served(pull())],
+			[RUNS, runs(9, [{name: "unit tests", status: "completed", conclusion: "success"}])],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
@@ -150,8 +156,8 @@ describe("runCi", () => {
 
 	it("refuses an unreadable enumeration on 11 — CI state is UNKNOWN, never green", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[RUNS, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, served(pull())],
+			[RUNS, BAD_GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -161,7 +167,7 @@ describe("runCi", () => {
 	it("reports what it scanned against what was declared", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			GATED,
@@ -172,7 +178,7 @@ describe("runCi", () => {
 
 describe("the gate-coverage read", () => {
 	/** The live incident: a conflicted head where only CodeQL's default setup reported (#6522). */
-	const CODEQL_ONLY = checkRuns(4, [
+	const CODEQL_ONLY = runs(4, [
 		{name: "CodeQL", status: "completed", conclusion: "success"},
 		{name: "Analyze (actions)", status: "completed", conclusion: "success"},
 		{name: "Analyze (javascript-typescript)", status: "completed", conclusion: "success"},
@@ -182,7 +188,7 @@ describe("the gate-coverage read", () => {
 	it("refuses an all-passed CodeQL-only head on 16 — never green over ungated bytes", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, CODEQL_ONLY],
 			],
 			[
@@ -200,8 +206,8 @@ describe("the gate-coverage read", () => {
 	it("refuses a pending rollup with no gate coverage too — the reviewer would wait forever", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[RUNS, checkRuns(1, [{name: "CodeQL", status: "in_progress", conclusion: null}])],
+				[PULL, served(pull())],
+				[RUNS, runs(1, [{name: "CodeQL", status: "in_progress", conclusion: null}])],
 			],
 			[
 				[WORKFLOWS, served(inventory(CI_YML, CODEQL))],
@@ -214,7 +220,7 @@ describe("the gate-coverage read", () => {
 	it("names the coverage it judged when the repo's own gates did run", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			GATED,
@@ -228,7 +234,7 @@ describe("the gate-coverage read", () => {
 	it("carries the coverage on the --json object", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			GATED,
@@ -241,8 +247,8 @@ describe("the gate-coverage read", () => {
 		// No WORKFLOWS or AT_HEAD entry in the script: a call would fail the fake, which is the
 		// assertion. A red check names itself; refusing it as ungated would bury that.
 		const out = await run([
-			[PULL, pull()],
-			[RUNS, checkRuns(1, [{name: "unit tests", status: "completed", conclusion: "failure"}])],
+			[PULL, served(pull())],
+			[RUNS, runs(1, [{name: "unit tests", status: "completed", conclusion: "failure"}])],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tred\n");
@@ -251,7 +257,7 @@ describe("the gate-coverage read", () => {
 	it("judges no coverage when the repo authors no workflow of its own", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			[
@@ -270,7 +276,7 @@ describe("the gate-coverage read", () => {
 	it("refuses an unreadable inventory on 11 — which gates exist is UNKNOWN, never green", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			[[WORKFLOWS, BAD_GATEWAY]],
@@ -283,7 +289,7 @@ describe("the gate-coverage read", () => {
 	it("refuses an unreadable run list on 11 — which gates ran is UNKNOWN, never green", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			[
@@ -298,9 +304,9 @@ describe("the gate-coverage read", () => {
 });
 
 describe("the no-producer split", () => {
-	const empty: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
-		[RUNS, checkRuns(0, [])],
+	const empty: ReadonlyArray<Scripted> = [
+		[PULL, served(pull())],
+		[RUNS, runs(0, [])],
 	];
 
 	it("never asks the producer question while checks are reporting", async () => {
@@ -309,7 +315,7 @@ describe("the no-producer split", () => {
 		// malformed refuses on 11 the moment anything asks it, and nothing here does.
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[RUNS, GREEN],
 			],
 			GATED,

--- a/packages/fabrika-cli/src/review/criteria-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/criteria-verb.unit.test.ts
@@ -1,12 +1,15 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {runCriteria} from "./criteria-verb.ts";
 import {issue} from "./fixtures.test-support.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4287\b/;
+
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
 
 const options = {
 	issue: 4287,
@@ -15,17 +18,14 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(runCriteria({...options, ...overrides}), fakeShell(script).layer),
+		Effect.provide(runCriteria({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 describe("runCriteria", () => {
 	it("prints the count and one line per criterion, in the wire format's own grammar", async () => {
-		const out = await run([[ISSUE, issue()]]);
+		const out = await run([[ISSUE, served(issue())]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
 			[
@@ -38,45 +38,45 @@ describe("runCriteria", () => {
 	});
 
 	it("emits the record with --json", async () => {
-		const out = await run([[ISSUE, issue()]], {json: true});
+		const out = await run([[ISSUE, served(issue())]], {json: true});
 		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "criteria", issue: 4287, count: 2});
 	});
 
 	it("reads a CLOSED issue's contract anyway, with a notice — a re-review is legitimate", async () => {
-		const out = await run([[ISSUE, issue(undefined, "closed")]]);
+		const out = await run([[ISSUE, served(issue(undefined, "closed"))]]);
 		expect(out.code).toBe(0);
 		expect(out.stderr[0]).toContain("#4287 is closed");
 	});
 
 	it("refuses an issue proven absent on 7", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("review criteria: issue #4287 not found in o/r.");
 	});
 
 	it("refuses an ABSENT block on 7, naming the wire reason", async () => {
-		const out = await run([[ISSUE, issue("no contract here")]]);
+		const out = await run([[ISSUE, served(issue("no contract here"))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("carries no acceptance-criteria block — absent:");
 		expect(out.stderr.at(-1)).toContain("Grade nothing; the contract is missing.");
 	});
 
 	it("reds a DRIFTED heading as malformed — never as `there were none`", async () => {
-		const out = await run([[ISSUE, issue("## Acceptance Criteria\n\n- [ ] a thing\n")]]);
+		const out = await run([[ISSUE, served(issue("## Acceptance Criteria\n\n- [ ] a thing\n"))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("is malformed:");
 		expect(out.stderr.at(-1)).toContain('not "there were none"');
 	});
 
 	it("gives absent and malformed the same code and never the same message", async () => {
-		const absent = await run([[ISSUE, issue("nothing")]]);
-		const malformed = await run([[ISSUE, issue("## Acceptance Criteria\n\n- [ ] x\n")]]);
+		const absent = await run([[ISSUE, served(issue("nothing"))]]);
+		const malformed = await run([[ISSUE, served(issue("## Acceptance Criteria\n\n- [ ] x\n"))]]);
 		expect(absent.code).toBe(malformed.code);
 		expect(absent.stderr.at(-1)).not.toBe(malformed.stderr.at(-1));
 	});
 
 	it("refuses an unreadable issue on 11 — whether a block exists is UNKNOWN", async () => {
-		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[ISSUE, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("whether a block exists is UNKNOWN");

--- a/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, type HttpReply, okOut, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -22,9 +22,35 @@ import {
 	pull,
 } from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-/** The unbound endpoint this verb no longer reads — scripted so a regression has bytes to serve. */
-const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321$/;
+const NOT_FOUND = '{"message":"Not Found"}';
+
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+/**
+ * How many times the run asked GitHub for `pulls/4321`.
+ *
+ * The unbound diff read this verb must never make is that same URL under a diff `Accept`, so the
+ * two are one line at the HTTP seam and only the count tells them apart: one read is the metadata
+ * read every run makes, two is the PR-number diff read coming back (#5122).
+ */
+const pullReads = (requests: ReadonlyArray<string>): number =>
+	requests.filter((request) => PULL.test(request)).length;
+
+/**
+ * How many requests carried a diff `Accept` — the unbound read's only distinguishing mark.
+ *
+ * The diff read and the metadata read are the same URL, so `requests` alone cannot tell them apart;
+ * the `Accept` header is the one place the difference is stated, and this holds the fence's original
+ * claim rather than inferring it from a count.
+ */
+const diffAcceptReads = (fake: {
+	readonly requests: ReadonlyArray<string>;
+	readonly headers: ReadonlyArray<Readonly<Record<string, string>>>;
+}): number =>
+	fake.requests.filter((_, i) => (fake.headers[i]?.accept ?? "").includes("vnd.github.diff"))
+		.length;
 
 const SUPPRESSING_DIFF = `diff --git a/src/cart.ts b/src/cart.ts
 --- a/src/cart.ts
@@ -48,40 +74,33 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const shell = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
-	const fake = fakeShell(script);
+const shell = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const fake = fakeSeams(script);
 	return {
 		fake,
 		out: Effect.runPromise(Effect.provide(runDeviations({...options, ...overrides}), fake.layer)),
 	};
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => shell(script, overrides).out;
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	shell(script, overrides).out;
 
 /**
- * The green path: the bound range serves `diff`, the same range's `--name-only` read serves
- * `inRange` (the completeness denominator), and the PR-number endpoint serves `endpoint`.
+ * The green path: the bound range serves `diff`, and the same range's `--name-only` read serves
+ * `inRange` — the completeness denominator.
  */
 const scripted = (
 	diff: string,
-	endpoint: string,
 	shape: Parameters<typeof pull>[0] = {},
 	inRange: ReadonlyArray<string> = ["src/cart.ts", "README.md"],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull(shape)],
+): ReadonlyArray<Scripted> => [
+	[PULL, served(pull(shape))],
 	...binding(),
 	[DIFF_AT(), okOut(diff)],
 	[PATHS_AT(), paths(...inRange)],
-	[RAW, okOut(endpoint)],
 ];
 
-const happy = (shape: Parameters<typeof pull>[0] = {}) => scripted(DIFF, DIFF, shape);
+const happy = (shape: Parameters<typeof pull>[0] = {}) => scripted(DIFF, shape);
 
 /** A rename git pairs into ONE `diff --git` entry — the shape GitHub may count as two files. */
 const RENAME_DIFF = `diff --git a/src/old.ts b/src/new.ts
@@ -103,7 +122,7 @@ describe("runDeviations", () => {
 	});
 
 	it("makes a falsified `None.` visible in one read — the claim beside the hits", async () => {
-		const out = await run(scripted(SUPPRESSING_DIFF, SUPPRESSING_DIFF));
+		const out = await run(scripted(SUPPRESSING_DIFF));
 		expect(out.stdout).toBe(
 			[
 				"deviations\tnone-declared",
@@ -131,7 +150,7 @@ describe("runDeviations", () => {
 	});
 
 	it("refuses a diff short of the range's own file list on 13 — a partial scan must not print beside a claim", async () => {
-		const out = await run(scripted(DIFF, DIFF, {}, ["src/cart.ts", "README.md", "src/dropped.ts"]));
+		const out = await run(scripted(DIFF, {}, ["src/cart.ts", "README.md", "src/dropped.ts"]));
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
@@ -141,7 +160,7 @@ describe("runDeviations", () => {
 
 	it("refuses on 11 when the range's file list cannot be read, rather than scanning against nothing", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[DIFF_AT(), okOut(DIFF)],
 			[PATHS_AT(), errOut("fatal: bad revision")],
@@ -153,17 +172,17 @@ describe("runDeviations", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: NOT_FOUND}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("review deviations: PR #4321 not found in o/r.");
 	});
 
 	it("refuses an unreadable body or diff on 11, and never answers `none`", async () => {
 		for (const script of [
-			[[PULL, errOut("gh: Bad gateway (HTTP 502)")]] as const,
-			[[PULL, pull()], ...binding(), [DIFF_AT(), errOut("fatal: bad revision")]] as const,
+			[[PULL, {status: 502, body: "{}"}]] as const,
+			[[PULL, served(pull())], ...binding(), [DIFF_AT(), errOut("fatal: bad revision")]] as const,
 		]) {
-			const out = await run(script as ReadonlyArray<readonly [RegExp, ExecResult]>);
+			const out = await run(script as ReadonlyArray<Scripted>);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
 			expect(out.stdout).toBe("");
 			expect(out.stderr.at(-1)).toContain('the disclosure state is UNKNOWN, never "none"');
@@ -179,7 +198,7 @@ describe("runDeviations", () => {
  * pairs into one entry and the platform declares two.
  */
 describe("runDeviations proves its scan complete against git's own count", () => {
-	const renamed = () => scripted(RENAME_DIFF, RENAME_DIFF, {changedFiles: 2}, ["src/new.ts"]);
+	const renamed = () => scripted(RENAME_DIFF, {changedFiles: 2}, ["src/new.ts"]);
 
 	it("scans a rename git paired into one entry, though GitHub declares it as two files", async () => {
 		const out = await run(renamed());
@@ -209,25 +228,27 @@ describe("runDeviations proves its scan complete against git's own count", () =>
  * A `deviation-disclosure` verdict claims "nothing undisclosed that this gate could see", so the hit
  * list is not one input among many — read at a head nobody scoped it is under- or over-reported
  * beside the disclosure it is printed next to, and the caller reads a checked-clean answer at exit 0.
- * Every case below scripts the PR-number endpoint with a *different* head's bytes, so a read that
- * reverts to it fails on a **wrong answer**, not on a crash.
+ * A read that reverted to the PR-number endpoint would answer with whatever head the platform is
+ * serving right now — a **wrong answer**, not a crash — so every case below counts that URL's reads
+ * through {@link pullReads} and holds it at the one metadata read.
  */
 describe("runDeviations binds its Tier-M scan to a commit", () => {
 	it("scans the bound commit's bytes, never the PR-number endpoint's", async () => {
-		const {fake, out} = shell(scripted(SUPPRESSING_DIFF, DIFF));
+		const {fake, out} = shell(scripted(SUPPRESSING_DIFF));
 		const result = await out;
 		expect(result.code).toBe(0);
 		expect(result.stdout).toContain("tier-m\tsuppression\tsrc/cart.ts:11\t@ts-expect-error");
 		expect(fake.calls).toContain(
 			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ ${BASE}...${HEAD}`,
 		);
-		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+		expect(pullReads(fake.requests)).toBe(1);
+		expect(diffAcceptReads(fake)).toBe(0);
 	});
 
 	// The fail-OPEN direction, and the reason this is priced above its fail-closed sibling: the
 	// unbound read answers `none-declared` with an empty hit list beside a `None.` body, at exit 0.
 	it("does not print a clean scan beside a `None.` when the endpoint's head is the clean one", async () => {
-		const out = await run(scripted(SUPPRESSING_DIFF, DIFF));
+		const out = await run(scripted(SUPPRESSING_DIFF));
 		expect(out.stdout).not.toBe("deviations\tnone-declared\n");
 	});
 
@@ -235,11 +256,12 @@ describe("runDeviations binds its Tier-M scan to a commit", () => {
 	// live head and every staleness check passes — while the PR-number endpoint still serves the
 	// intermediate head's bytes. Only reading at the commit tells the two trees apart.
 	it("scans the recorded commit after a REWIND back onto it, not what the endpoint serves", async () => {
-		const {fake, out} = shell(scripted(SUPPRESSING_DIFF, DIFF), {sha: HEAD});
+		const {fake, out} = shell(scripted(SUPPRESSING_DIFF), {sha: HEAD});
 		const result = await out;
 		expect(result.code).toBe(0);
 		expect(result.stdout).toContain("tier-m\tremoved-assertion");
-		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+		expect(pullReads(fake.requests)).toBe(1);
+		expect(diffAcceptReads(fake)).toBe(0);
 	});
 
 	it("reports the commit it bound to, ahead of what it scanned", async () => {
@@ -269,9 +291,8 @@ describe("runDeviations binds its Tier-M scan to a commit", () => {
 
 	it("refuses on 11 when the commit cannot be bound, rather than scanning an unbound diff", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
-			[RAW, okOut(SUPPRESSING_DIFF)],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");

--- a/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, type HttpReply, okOut, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -21,18 +21,35 @@ import {
 	pull,
 } from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-/** The unbound endpoint this verb no longer reads — scripted so a regression has bytes to serve. */
-const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321$/;
+const NOT_FOUND = '{"message":"Not Found"}';
 
-/** What that endpoint would hand back mid-flight: a *different* head's diff, one file wide. */
-const MOVED_DIFF = `diff --git a/src/other.ts b/src/other.ts
---- a/src/other.ts
-+++ b/src/other.ts
-@@ -1,1 +1,2 @@
- const x = 1;
-+const y = 2;
-`;
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+/**
+ * How many times the run asked GitHub for `pulls/4321`.
+ *
+ * The unbound diff read this verb must never make is that same URL under a diff `Accept`, so the
+ * two are one line at the HTTP seam and only the count tells them apart: one read is the metadata
+ * read every run makes, two is the PR-number diff read coming back (#5117).
+ */
+const pullReads = (requests: ReadonlyArray<string>): number =>
+	requests.filter((request) => PULL.test(request)).length;
+
+/**
+ * How many requests carried a diff `Accept` — the unbound read's only distinguishing mark.
+ *
+ * The diff read and the metadata read are the same URL, so `requests` alone cannot tell them apart;
+ * the `Accept` header is the one place the difference is stated, and this holds the fence's original
+ * claim rather than inferring it from a count.
+ */
+const diffAcceptReads = (fake: {
+	readonly requests: ReadonlyArray<string>;
+	readonly headers: ReadonlyArray<Readonly<Record<string, string>>>;
+}): number =>
+	fake.requests.filter((_, i) => (fake.headers[i]?.accept ?? "").includes("vnd.github.diff"))
+		.length;
 
 const options = {
 	pr: 4321,
@@ -41,21 +58,16 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const shell = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
-	const fake = fakeShell(script);
+const shell = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const fake = fakeSeams(script);
 	return {
 		fake,
 		out: Effect.runPromise(Effect.provide(runDiff({...options, ...overrides}), fake.layer)),
 	};
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => shell(script, overrides).out;
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	shell(script, overrides).out;
 
 /**
  * The whole green path: the PR read, the four binding reads, the diff at the bound commit, and the
@@ -65,12 +77,11 @@ const green = (
 	diff: string = DIFF,
 	shape: Parameters<typeof pull>[0] = {},
 	inRange: ReadonlyArray<string> = ["src/cart.ts", "README.md"],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull(shape)],
+): ReadonlyArray<Scripted> => [
+	[PULL, served(pull(shape))],
 	...binding(),
 	[DIFF_AT(), okOut(diff)],
 	[PATHS_AT(), paths(...inRange)],
-	[RAW, okOut(MOVED_DIFF)],
 ];
 
 /** A rename git pairs into ONE `diff --git` entry — the shape GitHub may count as two files. */
@@ -114,7 +125,7 @@ describe("runDiff", () => {
 
 	it("refuses on 11 when the range's file list cannot be read, rather than proving completeness against nothing", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[DIFF_AT(), okOut(DIFF)],
 			[PATHS_AT(), errOut("fatal: bad revision")],
@@ -125,7 +136,7 @@ describe("runDiff", () => {
 	});
 
 	it("makes the same zero-file refusal `review scope` does, so neither serves a review over nothing", async () => {
-		const out = await run([[PULL, pull({changedFiles: 0})]]);
+		const out = await run([[PULL, served(pull({changedFiles: 0}))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain(
 			"refusing to serve an empty diff as a reviewable one (ADR 0092).",
@@ -133,9 +144,9 @@ describe("runDiff", () => {
 	});
 
 	it("refuses an absent PR on 7 and an unreadable diff on 11", async () => {
-		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, {status: 404, body: NOT_FOUND}]])).code).toBe(ZERO_SCOPE);
 		const unreadable = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[DIFF_AT(), errOut("fatal: bad object")],
 		]);
@@ -178,20 +189,20 @@ describe("runDiff proves completeness against git's own count", () => {
 /**
  * The provenance fence (#5117).
  *
- * Each case here fails if the read reverts to the PR-number endpoint: that endpoint is scripted in
- * every green fixture and serves a *different* head's bytes, so an unbound read does not error — it
- * answers, plausibly and wrongly. That is the whole hazard, so it is the whole assertion.
+ * Each case here fails if the read reverts to the PR-number endpoint: that read does not error, it
+ * answers with whatever head the platform is serving right now — plausibly and wrongly. That is the
+ * whole hazard, so it is the whole assertion, counted through {@link pullReads}.
  */
 describe("runDiff binds its bytes to a commit", () => {
 	it("reads the object database and never the PR-number diff endpoint", async () => {
 		const {fake, out} = shell(green());
 		const result = await out;
 		expect(result.stdout).toBe(DIFF);
-		expect(result.stdout).not.toContain("src/other.ts");
 		expect(fake.calls).toContain(
 			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ 0f1e2d3c4b5a69788796a5b4c3d2e1f009182736...${HEAD}`,
 		);
-		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+		expect(pullReads(fake.requests)).toBe(1);
+		expect(diffAcceptReads(fake)).toBe(0);
 	});
 
 	it("serves the scoped commit's bytes through a rewind, which the post-time re-resolve passes clean", async () => {
@@ -201,7 +212,8 @@ describe("runDiff binds its bytes to a commit", () => {
 		const result = await out;
 		expect(result.code).toBe(0);
 		expect(result.stdout).toBe(DIFF);
-		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+		expect(pullReads(fake.requests)).toBe(1);
+		expect(diffAcceptReads(fake)).toBe(0);
 	});
 
 	it("refuses on 12 when --sha is not the PR's head, instead of reading whatever is live", async () => {
@@ -223,7 +235,7 @@ describe("runDiff binds its bytes to a commit", () => {
 
 	it("refuses on 11 when no remote in this checkout serves the target repo", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -236,7 +248,7 @@ describe("runDiff binds its bytes to a commit", () => {
 		// The override goes FIRST: `fakeShell` answers with the first matching row, so a row placed
 		// after the green binding would never be reached.
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[/^git fetch --quiet origin pull\/4321\/head$/, errOut("couldn't find remote ref")],
 			...binding(),
 		]);
@@ -248,7 +260,7 @@ describe("runDiff binds its bytes to a commit", () => {
 		// A local ref or tag spelled as hex resolves elsewhere — a name that verifies and still names
 		// the wrong tree, which is why the resolved object name is compared against the one asked for.
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[
 				new RegExp(`^git rev-parse --verify --quiet ${HEAD}\\^\\{commit\\}$`),
 				okOut(`${OLD_HEAD}\n`),
@@ -261,7 +273,7 @@ describe("runDiff binds its bytes to a commit", () => {
 
 	it("refuses on 11 when the base end of the range will not resolve", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[/^git fetch --quiet origin main$/, errOut("couldn't find remote ref main")],
 			...binding(),
 		]);

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -21,12 +21,11 @@ import {Effect, type FileSystem, Layer, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {
-	errOut,
-	fakeHttp,
-	fakeShell,
+	fakeSeams,
 	type HttpReply,
 	okOut,
 	once,
+	type Scripted,
 	unconfigured,
 } from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
@@ -56,17 +55,16 @@ import {
 	runsAtHead,
 } from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
-const RUNS = /^gh api --paginate repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
-const USER = /^gh api user --jq \.login$/;
-const PERMISSION = /^gh api repos\/o\/r\/collaborators\/kampus-bot\/permission --jq \.permission$/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4287 -f body=/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /GET .*\/repos\/o\/r\/pulls\/4321\/files\?/;
+const RUNS = /GET .*\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /POST .*\/repos\/o\/r\/issues\/4321\/comments/;
+const READBACK = /GET .*\/repos\/o\/r\/issues\/comments\/\d+/;
+const USER = /GET .*api\.github\.com\/user$/;
+const PERMISSION = /GET .*\/repos\/o\/r\/collaborators\/kampus-bot\/permission$/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4287$/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/4287$/;
 
 const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
 
@@ -80,20 +78,17 @@ const withShell = <A>(
 		never,
 		ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 	>,
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted> = [],
 ): Promise<A> =>
 	Effect.runPromise(
-		Effect.provide(
-			effect,
-			Layer.mergeAll(fakeShell(script).layer, fakeHttp(http).layer, unconfigured),
-		),
+		Effect.provide(effect, Layer.merge(fakeSeams([...script, ...http]).layer, unconfigured)),
 	);
 
-/** A canned payload, served as the body of the 200 the ported `ship/github.ts` read now issues. */
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
 const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
 
-/** The two Actions reads that moved to HTTP; every other read in this file still shells out. */
+/** The two Actions reads, addressed by their full URLs — the query is what tells them apart. */
 const WORKFLOWS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/actions\/workflows\?/;
 const AT_HEAD = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/actions\/runs\?head_sha=/;
 
@@ -126,11 +121,11 @@ describe("the CI rollup's fail-closed buckets", () => {
 	// Scripted so the mutant reaches the exact wrong answer this case pins. The real verb short-
 	// circuits on `red` and never issues these two reads; only the mutant, having dropped the
 	// cancelled run, gets far enough to ask which gates ran.
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
-		[RUNS, CANCELLED],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull())],
+		[RUNS, served(CANCELLED)],
 	];
-	const http: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+	const http: ReadonlyArray<Scripted> = [
 		[WORKFLOWS, served(inventory(CI_YML))],
 		[AT_HEAD, served(runsAtHead(CI_YML))],
 	];
@@ -165,11 +160,11 @@ describe("the CI rollup's gate-coverage refusal", () => {
 	const CI_YML = ".github/workflows/ci.yml";
 	const CODEQL = "dynamic/github-code-scanning/codeql";
 	/** The #6522 head: a complete, all-passed enumeration that no gate of this repo produced. */
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
-		[RUNS, checkRuns(1, [{name: "CodeQL", status: "completed", conclusion: "success"}])],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull())],
+		[RUNS, served(checkRuns(1, [{name: "CodeQL", status: "completed", conclusion: "success"}]))],
 	];
-	const http: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+	const http: ReadonlyArray<Scripted> = [
 		[WORKFLOWS, served(inventory(CI_YML, CODEQL))],
 		[AT_HEAD, served(runsAtHead(CODEQL))],
 	];
@@ -203,9 +198,9 @@ describe("the CI rollup's gate-coverage refusal", () => {
 
 describe("the three-outcome binding", () => {
 	const STALE = `review-code: PASS @ ${OLD_HEAD} — merge-ready`;
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({comments: 1})],
-		[COMMENTS, comments({id: 1, body: STALE})],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({comments: 1}))],
+		[COMMENTS, served(comments({id: 1, body: STALE}))],
 	];
 
 	it("prints a stale PASS as stale", async () => {
@@ -237,8 +232,8 @@ describe("the three-outcome binding", () => {
 describe("the diff completeness proof", () => {
 	// The range carries seven files; the served diff carries two. Both counts are git's, over the
 	// same range — anything but a refusal judges 2/7 (#5139).
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 7})],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 7}))],
 		...binding(),
 		[DIFF_AT(), okOut(DIFF)],
 		[PATHS_AT(), paths("src/cart.ts", "README.md", "c.ts", "d.ts", "e.ts", "f.ts", "g.ts")],
@@ -278,12 +273,11 @@ describe("the commit binding on the read verbs", () => {
 +const y = 2;
 `;
 
-	const diffScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 1})],
+	const diffScript: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 1}))],
 		...binding(),
 		[DIFF_AT(), okOut(DIFF)],
 		[PATHS_AT(), paths("src/cart.ts")],
-		[RAW, okOut(MOVED_DIFF)],
 	];
 
 	it("serves the bound commit's bytes", async () => {
@@ -304,11 +298,11 @@ describe("the commit binding on the read verbs", () => {
 		expect(out.stdout).not.toBe(DIFF);
 	});
 
-	const scopeScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 1})],
+	const scopeScript: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 1}))],
 		...binding(),
 		[PATHS_AT(), paths("src/cart.ts")],
-		[FILES, files("docs/moved.md")],
+		[FILES, served(files("docs/moved.md"))],
 	];
 
 	it("partitions the bound commit's file list", async () => {
@@ -350,12 +344,11 @@ diff --git a/README.md b/README.md
 +a line
 `;
 
-	const deviationsScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
+	const deviationsScript: ReadonlyArray<Scripted> = [
+		[PULL, served(pull())],
 		...binding(),
 		[DIFF_AT(), okOut(SUPPRESSING_DIFF)],
 		[PATHS_AT(), paths("src/cart.ts", "README.md")],
-		[RAW, okOut(DIFF)],
 	];
 
 	it("scans the bound commit's bytes for Tier-M tokens", async () => {
@@ -396,30 +389,31 @@ diff --git a/README.md b/README.md
 		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "the table\n"}),
 		now: NOW,
 	};
-	const postScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 1})],
+	const postScript: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 1}))],
 		...binding(),
 		[PATHS_AT(), paths("src/cart.ts")],
-		[FILES, files("skills/deploy/SKILL.md")],
-		[USER, okOut("kampus-bot")],
-		[COMMENTS, comments()],
-		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		[FILES, served(files("skills/deploy/SKILL.md"))],
+		[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+		[COMMENTS, served(comments())],
+		[CREATE, {status: 201, body: JSON.stringify({id: 1, html_url: "https://example.test/c/1"})}],
 		[
 			READBACK,
-			okOut(
-				JSON.stringify({
+			{
+				status: 200,
+				body: JSON.stringify({
 					body: `review-skill: PASS @ ${HEAD} content:${CONTENT} — guide matches shipped behavior\n\nthe table\n\n${STAMP}`,
 				}),
-			),
+			},
 		],
 	];
 
 	it("refuses a namespace the bound commit's file list does not derive", async () => {
 		const {runPost} = await import("./post-verb.ts");
-		const shell = fakeShell(postScript);
+		const shell = fakeSeams(postScript);
 		const out = await Effect.runPromise(Effect.provide(runPost(postOptions), shell.layer));
 		expect(out.code).toBe(10);
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("MUTANT: reading the PR-number file list POSTS a namespace this run never derived", async () => {
@@ -428,11 +422,11 @@ diff --git a/README.md b/README.md
 				Effect.succeed({_tag: "Ok" as const, value: ["skills/deploy/SKILL.md"]}),
 		}));
 		const {runPost} = await import("./post-verb.ts");
-		const shell = fakeShell(postScript);
+		const shell = fakeSeams(postScript);
 		const out = await Effect.runPromise(Effect.provide(runPost(postOptions), shell.layer));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("posted\treview-skill\tPASS");
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(true);
+		expect(shell.requests.some((request) => CREATE.test(request))).toBe(true);
 	});
 });
 
@@ -453,30 +447,31 @@ describe("the leak predicate over the assembled verdict", () => {
 		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: LEAKY}),
 		now: NOW,
 	};
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull())],
 		...binding(),
 		[PATHS_AT(), paths("src/cart.ts", "README.md")],
-		[FILES, files("skills/deploy/SKILL.md")],
-		[USER, okOut("kampus-bot")],
-		[COMMENTS, comments()],
-		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		[FILES, served(files("skills/deploy/SKILL.md"))],
+		[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+		[COMMENTS, served(comments())],
+		[CREATE, {status: 201, body: JSON.stringify({id: 1, html_url: "https://example.test/c/1"})}],
 		[
 			READBACK,
-			okOut(
-				JSON.stringify({
+			{
+				status: 200,
+				body: JSON.stringify({
 					body: `review-doc: PASS @ ${HEAD} content:${CONTENT} — guide matches shipped behavior\n\n${LEAKY}\n\n${STAMP}`,
 				}),
-			),
+			},
 		],
 	];
 
 	it("refuses a machine-local path in the verdict body on 5, posting nothing", async () => {
 		const {runPost} = await import("./post-verb.ts");
-		const shell = fakeShell(script);
+		const shell = fakeSeams(script);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(LEAKED_PATH);
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("MUTANT: a predicate that finds nothing posts the machine-local path to the PR (#3173)", async () => {
@@ -484,10 +479,10 @@ describe("the leak predicate over the assembled verdict", () => {
 			scanBody: (body: string) => ({leaks: [], redacted: body}),
 		}));
 		const {runPost} = await import("./post-verb.ts");
-		const shell = fakeShell(script);
+		const shell = fakeSeams(script);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(0);
-		expect(shell.calls.some((call) => call.includes("/Users/someone/scratch/case.md"))).toBe(true);
+		expect(shell.bodies.some((body) => body.includes("/Users/someone/scratch/case.md"))).toBe(true);
 	});
 });
 
@@ -509,21 +504,22 @@ describe("normalizeForReadback's trailing-newline step", () => {
 		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "the table\n"}),
 		now: NOW,
 	};
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull()],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull())],
 		...binding(),
 		[PATHS_AT(), paths("src/cart.ts", "README.md")],
-		[FILES, files("skills/deploy/SKILL.md")],
-		[USER, okOut("kampus-bot")],
-		[COMMENTS, comments()],
-		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		[FILES, served(files("skills/deploy/SKILL.md"))],
+		[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+		[COMMENTS, served(comments())],
+		[CREATE, {status: 201, body: JSON.stringify({id: 1, html_url: "https://example.test/c/1"})}],
 		[
 			READBACK,
-			okOut(
-				JSON.stringify({
+			{
+				status: 200,
+				body: JSON.stringify({
 					body: `review-doc: PASS @ ${HEAD} content:${CONTENT} — guide matches shipped behavior   \n\nthe table\n\n${STAMP}\n\n\n`,
 				}),
-			),
+			},
 		],
 	];
 
@@ -563,11 +559,11 @@ describe("the append-only fence", () => {
 
 nothing yet.
 `;
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[USER, okOut("kampus-bot")],
-		[PERMISSION, okOut("write")],
-		[ISSUE, issue(WITH_LATER_SECTION)],
-		[PATCH, okOut("{}")],
+	const script: ReadonlyArray<Scripted> = [
+		[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+		[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+		[ISSUE, served(issue(WITH_LATER_SECTION))],
+		[PATCH, {status: 200, body: "{}"}],
 	];
 
 	it("MUTANT: a composition that appends PAST the block reds on 15, before any PATCH", async () => {
@@ -578,14 +574,14 @@ nothing yet.
 			}),
 		}));
 		const {runAppendCriterion} = await import("./append-criterion-verb.ts");
-		const shell = fakeShell(script);
+		const shell = fakeSeams(script);
 		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
 		expect(out.code).toBe(APPEND_ONLY);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
 			"review append-criterion: the composed body does not re-read as the 1 prior row(s) plus this one — it re-reads as 1 row(s); refusing (append-only fence).",
 		);
-		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => PATCH.test(request))).toBe(false);
 	});
 
 	it("MUTANT: a growth check that always passes lets an unchanged read-back exit 0", async () => {
@@ -593,12 +589,12 @@ nothing yet.
 			grewByOne: () => true,
 		}));
 		const {runAppendCriterion} = await import("./append-criterion-verb.ts");
-		const unchanged: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[once(ISSUE), issue()],
-			[ISSUE, issue()],
-			[PATCH, okOut("{}")],
+		const unchanged: ReadonlyArray<Scripted> = [
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue())],
+			[ISSUE, served(issue())],
+			[PATCH, {status: 200, body: "{}"}],
 		];
 		const out = await withShell(runAppendCriterion(options), unchanged);
 		expect(out.code).toBe(0);
@@ -606,12 +602,12 @@ nothing yet.
 
 	it("without the mutant, that same unchanged read-back reds on 9", async () => {
 		const {runAppendCriterion} = await import("./append-criterion-verb.ts");
-		const unchanged: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-			[USER, okOut("kampus-bot")],
-			[PERMISSION, okOut("write")],
-			[once(ISSUE), issue()],
-			[ISSUE, issue()],
-			[PATCH, okOut("{}")],
+		const unchanged: ReadonlyArray<Scripted> = [
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue())],
+			[ISSUE, served(issue())],
+			[PATCH, {status: 200, body: "{}"}],
 		];
 		const out = await withShell(runAppendCriterion(options), unchanged);
 		expect(out.code).toBe(READBACK_MISMATCH);
@@ -621,8 +617,8 @@ nothing yet.
 describe("the empty-read refusal on the changed-file list", () => {
 	// git reports no paths while GitHub declares nine: the emptiness refuses, the disagreement does
 	// not (#5154).
-	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 9})],
+	const script: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 9}))],
 		...binding(),
 		[PATHS_AT(), paths()],
 	];
@@ -658,7 +654,7 @@ describe("the empty-read refusal on the changed-file list", () => {
 		const {runScope} = await import("./scope-verb.ts");
 		const out = await withShell(
 			runScope({pr: 4321, sha: null, repo: null, json: false, cwd: "/repo", env: ENV}),
-			[[PULL, errOut("gh: Bad gateway (HTTP 502)")]],
+			[[PULL, {status: 502, body: "{}"}]],
 		);
 		expect(out.code).not.toBe(0);
 	});

--- a/packages/fabrika-cli/src/review/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/post-verb.unit.test.ts
@@ -1,6 +1,13 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	once,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
@@ -28,24 +35,41 @@ import {
 } from "./fixtures.test-support.ts";
 import {runPost} from "./post-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321$/;
 /**
  * The unbound endpoint this verb no longer reads, scripted with a **skill-only** list — so a read
  * that drifts back to it derives `review-skill` where the bound commit derives code and doc, and
  * every case below fails on a wrong answer rather than on a missing script.
  */
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-const USER = /^gh api user --jq \.login$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/\d+ /;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const FILES = /GET .*\/repos\/o\/r\/pulls\/4321\/files\?/;
+const USER = /GET .*api\.github\.com\/user$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /POST .*\/repos\/o\/r\/issues\/4321\/comments/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/comments\/\d+/;
+const READBACK = /GET .*\/repos\/o\/r\/issues\/comments\/\d+/;
+
+const NOT_FOUND = '{"message":"Not Found"}';
+
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
+
+/** The body one write carried, as text — the successor to reading it off a `-f body=` argv. */
+const written = (
+	seams: {
+		readonly requests: ReadonlyArray<string>;
+		readonly bodies: ReadonlyArray<string>;
+	},
+	pattern: RegExp,
+): string => {
+	const index = seams.requests.findIndex((request) => pattern.test(request));
+	return index === -1 ? "" : String(JSON.parse(seams.bodies[index] ?? "{}").body ?? "");
+};
 
 const BODY = "| criterion | verdict |\n|---|---|\n| the first thing | PASS |\n";
 const URL = "https://example.test/pull/4321#issuecomment-5154902211";
 const MARKER = `review-doc: PASS @ ${HEAD} content:${CONTENT} — guide matches shipped behavior`;
 
-const created = okOut(JSON.stringify({id: 5154902211, html_url: URL}));
+const created: HttpReply = {status: 201, body: JSON.stringify({id: 5154902211, html_url: URL})};
 
 /** The instant every run below writes its verdict at, so the stamp the verb emits is predictable. */
 const NOW = Date.parse("2026-08-09T06:30:00.412Z");
@@ -55,8 +79,10 @@ const STAMP = "Verdict-written: 2026-08-09T06:30:00Z";
  * A read-back of `body` as the verb will have posted it — stamped, since the stamp is part of the
  * bytes the verb sends and therefore part of what its whole-comment comparison expects back.
  */
-const commentBody = (body: string): ExecResult =>
-	okOut(JSON.stringify({body: `${body.replace(/\s+$/, "")}\n\n${STAMP}`}));
+const commentBody = (body: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({body: `${body.replace(/\s+$/, "")}\n\n${STAMP}`}),
+});
 
 const options = {
 	pr: 4321,
@@ -74,22 +100,19 @@ const options = {
 	now: Effect.succeed(NOW),
 };
 
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull()],
+const happy = (): ReadonlyArray<Scripted> => [
+	[PULL, served(pull())],
 	...binding(),
 	[PATHS_AT(), paths("src/cart.ts", "README.md")],
-	[FILES, files("skills/deploy/SKILL.md")],
-	[USER, okOut("kampus-bot")],
-	[COMMENTS, comments()],
+	[FILES, served(files("skills/deploy/SKILL.md"))],
+	[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+	[COMMENTS, served(comments())],
 	[CREATE, created],
 	[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runPost({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runPost({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runPost", () => {
 	it("posts the verdict and says whether it created or edited", async () => {
@@ -99,10 +122,9 @@ describe("runPost", () => {
 	});
 
 	it("puts the marker on the comment's LITERAL first line, never stacked on line 2", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
-		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
-		const body = write.slice(write.indexOf("body=") + "body=".length);
+		const body = written(shell, CREATE);
 		expect(body.split("\n")[0]).toBe(MARKER);
 		expect(body.split("\n").filter((line) => line.startsWith("review-doc:"))).toHaveLength(1);
 	});
@@ -110,27 +132,29 @@ describe("runPost", () => {
 	// The prior comment is bound to HEAD, not OLD_HEAD, and that is load-bearing: the upsert key
 	// carries a head dimension, so only a re-post at the SAME head takes the edit path at all.
 	it("edits this namespace's existing comment instead of stacking a second one", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
-				comments({
-					id: 42,
-					body: `review-doc: PASS @ ${HEAD} — earlier round at this head`,
-					author: "kampus-bot",
-				}),
+				served(
+					comments({
+						id: 42,
+						body: `review-doc: PASS @ ${HEAD} — earlier round at this head`,
+						author: "kampus-bot",
+					}),
+				),
 			],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tedited\t");
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	// The head dimension of the upsert key. It shipped in v1 under #4007 and this tree did not carry
@@ -138,19 +162,21 @@ describe("runPost", () => {
 	// what was true over that tree became unrecoverable (#5585). Both carriers are pinned, because
 	// each binds its head on different bytes and a fix to one says nothing about the other.
 	it("leaves a prior head's marker verdict intact and appends at the new head", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
-				comments({
-					id: 42,
-					body: `review-doc: PASS @ ${OLD_HEAD} — the round before the repair`,
-					author: "kampus-bot",
-				}),
+				served(
+					comments({
+						id: 42,
+						body: `review-doc: PASS @ ${OLD_HEAD} — the round before the repair`,
+						author: "kampus-bot",
+					}),
+				),
 			],
 			[CREATE, created],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
@@ -158,19 +184,19 @@ describe("runPost", () => {
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tcreated\t");
-		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => PATCH.test(request))).toBe(false);
 	});
 
 	it("leaves a prior head's advisory intact and appends at the new head", async () => {
 		const advisoryFor = (sha: string): string =>
 			`review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${sha}\n\n${BODY}`;
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: advisoryFor(OLD_HEAD), author: "kampus-bot"})],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments({id: 42, body: advisoryFor(OLD_HEAD), author: "kampus-bot"}))],
 			[CREATE, created],
 			[READBACK, commentBody(advisoryFor(HEAD))],
 		]);
@@ -182,32 +208,32 @@ describe("runPost", () => {
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tcreated\t");
-		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => PATCH.test(request))).toBe(false);
 	});
 
 	it("stamps the write-recency line on the comment it creates", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
-		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
+		const write = written(shell, CREATE);
 		expect(write).toContain(STAMP);
 	});
 
 	it("stamps the write-recency line on the comment it edits, too", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
-				comments({id: 42, body: `review-doc: FAIL @ ${HEAD} — earlier round at this head`}),
+				served(comments({id: 42, body: `review-doc: FAIL @ ${HEAD} — earlier round at this head`})),
 			],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
 		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
-		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		const write = written(shell, PATCH);
 		expect(write).toContain(STAMP);
 	});
 
@@ -215,78 +241,82 @@ describe("runPost", () => {
 	// that already holds two of this author's comments it edited the one the resolver is least likely
 	// to be reading, and reported success.
 	it("edits the NEWEST comment in the namespace when two of this author's already exist", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 2})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 2}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
-				comments(
-					{
-						id: 42,
-						createdAt: "2026-08-09T03:46:59Z",
-						body: `review-doc: FAIL @ ${HEAD} — the older duplicate`,
-					},
-					{
-						id: 77,
-						createdAt: "2026-08-09T04:05:28Z",
-						body: `review-doc: FAIL @ ${HEAD} — the newer duplicate`,
-					},
+				served(
+					comments(
+						{
+							id: 42,
+							createdAt: "2026-08-09T03:46:59Z",
+							body: `review-doc: FAIL @ ${HEAD} — the older duplicate`,
+						},
+						{
+							id: 77,
+							createdAt: "2026-08-09T04:05:28Z",
+							body: `review-doc: FAIL @ ${HEAD} — the newer duplicate`,
+						},
+					),
 				),
 			],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tedited\t");
-		expect(shell.calls.find((call) => PATCH.test(call))).toContain("/issues/comments/77 ");
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(shell.requests.find((request) => PATCH.test(request))).toContain("/issues/comments/77");
+		expect(shell.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	// The case slot-creation time gets backwards, and the reason the stamp is the key: comment 42's
 	// slot is the older one, but its verdict was REWRITTEN into that slot after 77 was created. A PATCH
 	// leaves `created_at` where it was, so only the stamp can say 42 now carries the later verdict.
 	it("ranks by the write-recency stamp, not by when the comment slot was opened", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 2})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 2}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
-				comments(
-					{
-						id: 42,
-						createdAt: "2026-08-09T03:46:59Z",
-						body: `review-doc: FAIL @ ${HEAD} — re-posted in place\n\nVerdict-written: 2026-08-09T05:10:00Z`,
-					},
-					{
-						id: 77,
-						createdAt: "2026-08-09T04:05:28Z",
-						body: `review-doc: FAIL @ ${HEAD} — the newer slot, older verdict`,
-					},
+				served(
+					comments(
+						{
+							id: 42,
+							createdAt: "2026-08-09T03:46:59Z",
+							body: `review-doc: FAIL @ ${HEAD} — re-posted in place\n\nVerdict-written: 2026-08-09T05:10:00Z`,
+						},
+						{
+							id: 77,
+							createdAt: "2026-08-09T04:05:28Z",
+							body: `review-doc: FAIL @ ${HEAD} — the newer slot, older verdict`,
+						},
+					),
 				),
 			],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(0);
-		expect(shell.calls.find((call) => PATCH.test(call))).toContain("/issues/comments/42 ");
+		expect(shell.requests.find((request) => PATCH.test(request))).toContain("/issues/comments/42");
 	});
 
 	it("does not edit another author's comment in the same namespace", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
+		const shell = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: MARKER, author: "someone-else"})],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments({id: 42, body: MARKER, author: "someone-else"}))],
 			[CREATE, created],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
@@ -316,7 +346,7 @@ describe("runPost", () => {
 	});
 
 	it("refuses a moved-past head on 12 and writes nothing — re-review, never re-bind", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		const out = await Effect.runPromise(
 			Effect.provide(runPost({...options, sha: OLD_HEAD}), shell.layer),
 		);
@@ -325,7 +355,9 @@ describe("runPost", () => {
 		expect(out.stderr.at(-1)).toBe(
 			`review post: the live head is ${HEAD}, not ${OLD_HEAD} — the tree you judged is gone; re-review at ${HEAD} (ADR 0058).`,
 		);
-		expect(shell.calls.some((call) => CREATE.test(call) || PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request) || PATCH.test(request))).toBe(
+			false,
+		);
 	});
 
 	it("refuses an empty verdict body on 3 — an empty verdict reads as UNGATED", async () => {
@@ -363,8 +395,8 @@ describe("runPost", () => {
 	});
 
 	it("refuses an absent PR on 7 and a closed one on 7 with its own reason", async () => {
-		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
-		const closed = await run([[PULL, pull({state: "closed"})]]);
+		expect((await run([[PULL, {status: 404, body: NOT_FOUND}]])).code).toBe(ZERO_SCOPE);
+		const closed = await run([[PULL, served(pull({state: "closed"}))]]);
 		expect(closed.code).toBe(ZERO_SCOPE);
 		expect(closed.stderr.at(-1)).toBe(
 			"review post: PR #4321 is closed — a verdict on a closed PR gates nothing.",
@@ -372,26 +404,26 @@ describe("runPost", () => {
 	});
 
 	it("refuses a failed precondition read on 11, with nothing posted", async () => {
-		const shell = fakeShell([
-			[PULL, pull()],
+		const shell = fakeSeams([
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), errOut("fatal: bad revision")],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was posted");
-		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	it("reports a failed write as 8 — UNKNOWN whether the verdict landed", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments()],
-			[CREATE, errOut("gh: timeout")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
+			[CREATE, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -401,12 +433,12 @@ describe("runPost", () => {
 
 	it("refuses on 9 when the read-back does not yield this marker (#3173)", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments()],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
 			[CREATE, created],
 			[READBACK, commentBody("something else entirely")],
 		]);
@@ -417,12 +449,12 @@ describe("runPost", () => {
 
 	it("reads back from LIVE state — a garbled SHA on the PR reds even though the write returned ok", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments()],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
 			[CREATE, created],
 			[READBACK, commentBody(`review-doc: PASS @ ${OLD_HEAD} — guide matches shipped behavior`)],
 		]);
@@ -432,13 +464,13 @@ describe("runPost", () => {
 
 	it("composes the advisory carrier with a SHA-less first line and a Reviewed-head body line", async () => {
 		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n\n${BODY}`;
-		const shell = fakeShell([
-			[PULL, pull()],
+		const shell = fakeSeams([
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments()],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
 			[CREATE, created],
 			[READBACK, commentBody(advisory)],
 		]);
@@ -449,7 +481,7 @@ describe("runPost", () => {
 			),
 		);
 		expect(out.code).toBe(0);
-		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
+		const write = written(shell, CREATE);
 		expect(write).toContain("review-doc: advisory");
 		expect(write).toContain(`Reviewed-head: @ ${HEAD}`);
 		expect(write).not.toContain(`advisory — ... @ ${HEAD}`);
@@ -464,13 +496,13 @@ describe("runPost", () => {
 			clause: "blocking-set PR (manual merge)",
 		};
 
-		const fresh = fakeShell([
-			[PULL, pull()],
+		const fresh = fakeSeams([
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments()],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
 			[CREATE, created],
 			[READBACK, commentBody(advisoryFor(HEAD))],
 		]);
@@ -478,53 +510,55 @@ describe("runPost", () => {
 		expect(first.code).toBe(0);
 		expect(first.stdout).toContain("\tcreated\t");
 
-		const again = fakeShell([
-			[PULL, pull({comments: 1})],
+		const again = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: advisoryFor(HEAD), author: "kampus-bot"})],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments({id: 42, body: advisoryFor(HEAD), author: "kampus-bot"}))],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, commentBody(advisoryFor(HEAD))],
 		]);
 		const repost = await Effect.runPromise(Effect.provide(runPost(advisoryOptions), again.layer));
 		expect(repost.code).toBe(0);
 		expect(repost.stdout).toContain("\tedited\t");
-		expect(again.calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(again.requests.some((request) => CREATE.test(request))).toBe(false);
 	});
 
 	// Both prior comments below sit at HEAD, so the only thing that can send either post down the
 	// create path is the carrier mismatch — at OLD_HEAD the head dimension would carry the test.
 	it("never crosses the carriers: a marker post skips an advisory comment, and the reverse", async () => {
 		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n\n${BODY}`;
-		const overAdvisory = fakeShell([
-			[PULL, pull({comments: 1})],
+		const overAdvisory = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: advisory, author: "kampus-bot"})],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments({id: 42, body: advisory, author: "kampus-bot"}))],
 			[CREATE, created],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
 		const marker = await Effect.runPromise(Effect.provide(runPost(options), overAdvisory.layer));
 		expect(marker.stdout).toContain("\tcreated\t");
-		expect(overAdvisory.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(overAdvisory.requests.some((request) => PATCH.test(request))).toBe(false);
 
-		const overMarker = fakeShell([
-			[PULL, pull({comments: 1})],
+		const overMarker = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
 			[
 				COMMENTS,
-				comments({
-					id: 42,
-					body: `review-doc: PASS @ ${HEAD} — a marker at this same head`,
-					author: "kampus-bot",
-				}),
+				served(
+					comments({
+						id: 42,
+						body: `review-doc: PASS @ ${HEAD} — a marker at this same head`,
+						author: "kampus-bot",
+					}),
+				),
 			],
 			[CREATE, created],
 			[
@@ -541,7 +575,7 @@ describe("runPost", () => {
 			),
 		);
 		expect(advisoryPost.stdout).toContain("\tcreated\t");
-		expect(overMarker.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(overMarker.requests.some((request) => PATCH.test(request))).toBe(false);
 	});
 
 	it("emits the record with --json", async () => {
@@ -557,26 +591,26 @@ describe("runPost", () => {
 	});
 
 	it("refuses a blank clause and a non-SHA --sha on 10, before any read", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		const blank = await Effect.runPromise(
 			Effect.provide(runPost({...options, clause: "  "}), shell.layer),
 		);
 		expect(blank.code).toBe(OFF_VOCABULARY);
 		expect((await run(happy(), {sha: "nothex"})).code).toBe(OFF_VOCABULARY);
-		expect(shell.calls).toEqual([]);
+		expect(shell.log).toEqual([]);
 	});
 
 	it("uses `once` to prove the read-back is a SECOND fetch, not the write's echo", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
-			[FILES, files("skills/deploy/SKILL.md")],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments()],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[COMMENTS, served(comments())],
 			[CREATE, created],
 			[once(READBACK), commentBody(`${MARKER}\n\n${BODY}`)],
-			[READBACK, errOut("never reached")],
+			[READBACK, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(0);
 	});
@@ -592,19 +626,19 @@ describe("runPost", () => {
  */
 describe("runPost recomputes its namespace set at the bound commit", () => {
 	it("derives the set from the bound commit, never from the PR-number endpoint", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(0);
 		expect(shell.calls).toContain(
 			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ --name-only -z ${BASE}...${HEAD}`,
 		);
-		expect(shell.calls.some((call) => call.includes("pulls/4321/files"))).toBe(false);
+		expect(shell.requests.some((request) => request.includes("pulls/4321/files"))).toBe(false);
 	});
 
 	// The fail-OPEN direction: `review-skill` is derived only by the endpoint's list, so an unbound
 	// recompute POSTS it — a verdict filling a namespace this run never judged, at exit 0.
 	it("refuses a namespace only the unbound endpoint derives, and writes nothing", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		const out = await Effect.runPromise(
 			Effect.provide(runPost({...options, namespace: "review-skill"}), shell.layer),
 		);
@@ -613,7 +647,9 @@ describe("runPost recomputes its namespace set at the bound commit", () => {
 		expect(out.stderr.at(-1)).toBe(
 			"review post: --namespace review-skill is not derived by #4321's diff (present: review-code, review-doc) — a gate never emits a namespace it did not judge.",
 		);
-		expect(shell.calls.some((call) => CREATE.test(call) || PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request) || PATCH.test(request))).toBe(
+			false,
+		);
 	});
 
 	// The hole `12` cannot close, and the reason binding had to be added underneath it rather than
@@ -621,13 +657,13 @@ describe("runPost recomputes its namespace set at the bound commit", () => {
 	// the live head prefix-matches `--sha` and step 1 passes clean — while the PR-number endpoint
 	// still answers with the intermediate head's file list.
 	it("derives the REWOUND commit's set even though the live head matches --sha", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		const out = await Effect.runPromise(
 			Effect.provide(runPost({...options, namespace: "review-doc"}), shell.layer),
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain(`\t${HEAD}\t`);
-		expect(shell.calls.some((call) => call.includes("pulls/4321/files"))).toBe(false);
+		expect(shell.requests.some((request) => request.includes("pulls/4321/files"))).toBe(false);
 	});
 
 	it("names the commit the set was derived at on stderr", async () => {
@@ -638,20 +674,22 @@ describe("runPost recomputes its namespace set at the bound commit", () => {
 	});
 
 	it("refuses on 11 when the commit cannot be bound, rather than deriving an unbound set", async () => {
-		const shell = fakeShell([
-			[PULL, pull()],
+		const shell = fakeSeams([
+			[PULL, served(pull())],
 			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
-			[FILES, files("skills/deploy/SKILL.md")],
+			[FILES, served(files("skills/deploy/SKILL.md"))],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(shell.calls.some((call) => CREATE.test(call) || PATCH.test(call))).toBe(false);
+		expect(shell.requests.some((request) => CREATE.test(request) || PATCH.test(request))).toBe(
+			false,
+		);
 	});
 
 	// The `12` seat is `review post`'s own, ahead of the binding — the binding is added underneath it.
 	it("keeps the 12 refusal on a forward-moved head, before any commit is bound", async () => {
-		const shell = fakeShell(happy());
+		const shell = fakeSeams(happy());
 		const out = await Effect.runPromise(
 			Effect.provide(runPost({...options, sha: OLD_HEAD}), shell.layer),
 		);

--- a/packages/fabrika-cli/src/review/range-post.unit.test.ts
+++ b/packages/fabrika-cli/src/review/range-post.unit.test.ts
@@ -6,25 +6,30 @@
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, okOut, unconfigured} from "../fakes.test-support.ts";
+import {
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	type Scripted,
+	unconfigured,
+} from "../fakes.test-support.ts";
 import {NOT_HARNESS_TOUCHING} from "../governance/codes.ts";
 import {
 	type PostOptions as GovernancePostOptions,
 	runPost as runGovernancePost,
 } from "../governance/post-verb.ts";
-import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {read as readRangeMarker} from "../wire/range-verdict-marker.ts";
 import {OFF_VOCABULARY, ZERO_SCOPE} from "./codes.ts";
 import {BASE, CONTENT, comments, HEAD, RAW, RAW_AT} from "./fixtures.test-support.ts";
 import {type PostOptions as ReviewPostOptions, runPost as runReviewPost} from "./post-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/5830$/;
-const USER = /^gh api user --jq \.login$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/5830\/comments/;
-const CREATE = /^gh api --method POST repos\/o\/r\/issues\/5830\/comments /;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/\d+ /;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/5830$/;
+const USER = /GET .*api\.github\.com\/user$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/5830\/comments/;
+const CREATE = /POST .*\/repos\/o\/r\/issues\/5830\/comments/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/comments\/\d+/;
+const READBACK = /GET .*\/repos\/o\/r\/issues\/comments\/\d+/;
 
 const BODY = "| criterion | verdict |\n|---|---|\n| the first thing | PASS |\n";
 const URL = "https://example.test/issues/5830#issuecomment-6100000001";
@@ -36,22 +41,34 @@ const GOV_RAW = `:100644 100644 ${"a".repeat(40)} ${"b".repeat(40)} M\0claude-pl
 const GOV_CONTENT = "bb15e4131548";
 const GOV_MARKER = `governance: PASS range:${RANGE} content:${GOV_CONTENT} — no contradiction, no weakening`;
 
-const issue = (shape: {state?: string; pull?: boolean} = {}): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 5830,
-			title: "epic child",
-			body: "",
-			state: shape.state ?? "open",
-			labels: [],
-			html_url: "https://example.test/issues/5830",
-			user: {login: "usirin"},
-			...(shape.pull ? {pull_request: {url: "https://example.test/pulls/5830"}} : {}),
-		}),
-	);
+const issue = (shape: {state?: string; pull?: boolean} = {}): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 5830,
+		title: "epic child",
+		body: "",
+		state: shape.state ?? "open",
+		labels: [],
+		html_url: "https://example.test/issues/5830",
+		user: {login: "usirin"},
+		...(shape.pull ? {pull_request: {url: "https://example.test/pulls/5830"}} : {}),
+	}),
+});
 
-const created = okOut(JSON.stringify({id: 6100000001, html_url: URL}));
-const commentBody = (body: string): ExecResult => okOut(JSON.stringify({body}));
+const created: HttpReply = {status: 201, body: JSON.stringify({id: 6100000001, html_url: URL})};
+const commentBody = (body: string): HttpReply => ({status: 200, body: JSON.stringify({body})});
+
+/** The body one write carried, as text — the successor to reading it off a `-f body=` argv. */
+const written = (
+	seams: {
+		readonly requests: ReadonlyArray<string>;
+		readonly bodies: ReadonlyArray<string>;
+	},
+	pattern: RegExp,
+): string => {
+	const index = seams.requests.findIndex((request) => pattern.test(request));
+	return index === -1 ? "" : String(JSON.parse(seams.bodies[index] ?? "{}").body ?? "");
+};
 
 const reviewOptions: ReviewPostOptions = {
 	pr: 5830,
@@ -83,43 +100,43 @@ const governanceOptions: GovernancePostOptions = {
 	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
 };
 
-const reviewHappy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const reviewHappy = (): ReadonlyArray<Scripted> => [
 	[ISSUE, issue()],
 	[RAW_AT(BASE, HEAD), okOut(RAW)],
-	[USER, okOut("kampus-bot")],
-	[COMMENTS, comments()],
+	[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+	[COMMENTS, {status: 200, body: comments().stdout}],
 	[CREATE, created],
 	[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 ];
 
-const governanceHappy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const governanceHappy = (): ReadonlyArray<Scripted> => [
 	[ISSUE, issue()],
 	[RAW_AT(BASE, HEAD), okOut(GOV_RAW)],
-	[USER, okOut("kampus-bot")],
-	[COMMENTS, comments()],
+	[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+	[COMMENTS, {status: 200, body: comments().stdout}],
 	[CREATE, created],
 	[READBACK, commentBody(`${GOV_MARKER}\n\n${BODY}`)],
 ];
 
 const runReview = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof reviewOptions> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runReviewPost({...reviewOptions, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, unconfigured, fakeHttp([]).layer),
+			Layer.merge(fakeSeams(script).layer, unconfigured),
 		),
 	);
 
 const runGovernance = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof governanceOptions> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runGovernancePost({...governanceOptions, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, unconfigured, fakeHttp([]).layer),
+			Layer.merge(fakeSeams(script).layer, unconfigured),
 		),
 	);
 
@@ -131,12 +148,11 @@ describe("review post --base/--tip", () => {
 	});
 
 	it("composes the exact marker the epic-child prove arm reads back", async () => {
-		const shell = fakeShell(reviewHappy());
+		const shell = fakeSeams(reviewHappy());
 		await Effect.runPromise(
 			Effect.provide(runReviewPost(reviewOptions), Layer.merge(shell.layer, unconfigured)),
 		);
-		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
-		const body = write.slice(write.indexOf("body=") + "body=".length);
+		const body = written(shell, CREATE);
 		expect(body.split("\n")[0]).toBe(MARKER);
 		const parsed = readRangeMarker(body);
 		expect(parsed._tag).toBe("Found");
@@ -152,9 +168,12 @@ describe("review post --base/--tip", () => {
 		const out = await runReview([
 			[ISSUE, issue()],
 			[RAW_AT(BASE, HEAD), okOut(RAW)],
-			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: `${MARKER}\n\nan earlier table\n`})],
-			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[
+				COMMENTS,
+				{status: 200, body: comments({id: 42, body: `${MARKER}\n\nan earlier table\n`}).stdout},
+			],
+			[PATCH, {status: 200, body: JSON.stringify({html_url: URL})}],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
 		expect(out.code).toBe(0);
@@ -219,15 +238,11 @@ describe("governance post --base/--tip", () => {
 	});
 
 	it("composes the governance marker through the range wire format", async () => {
-		const shell = fakeShell(governanceHappy());
+		const shell = fakeSeams(governanceHappy());
 		await Effect.runPromise(
-			Effect.provide(
-				runGovernancePost(governanceOptions),
-				Layer.mergeAll(shell.layer, unconfigured, fakeHttp([]).layer),
-			),
+			Effect.provide(runGovernancePost(governanceOptions), Layer.merge(shell.layer, unconfigured)),
 		);
-		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
-		const body = write.slice(write.indexOf("body=") + "body=".length);
+		const body = written(shell, CREATE);
 		const parsed = readRangeMarker(body);
 		expect(parsed._tag).toBe("Found");
 		if (parsed._tag === "Found") {

--- a/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
@@ -1,6 +1,14 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut, unconfigured} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	type Scripted,
+	unconfigured,
+} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -22,9 +30,13 @@ import {
 } from "./fixtures.test-support.ts";
 import {runScope} from "./scope-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321$/;
 /** The unbound endpoint this verb no longer reads — scripted so a regression has a list to serve. */
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const FILES = /GET .*\/repos\/o\/r\/pulls\/4321\/files\?/;
+const NOT_FOUND = '{"message":"Not Found"}';
+
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
 
 const options = {
 	pr: 4321,
@@ -35,11 +47,8 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const shell = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
-	const fake = fakeShell(script);
+const shell = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const fake = fakeSeams(script);
 	return {
 		fake,
 		out: Effect.runPromise(
@@ -48,23 +57,19 @@ const shell = (
 	};
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => shell(script, overrides).out;
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	shell(script, overrides).out;
 
 /**
  * The green path. The PR-number files endpoint is scripted too, and deliberately answers a
  * *different* file set — so a read that drifts back to it derives `review-doc` where the bound
  * commit derives both classes, instead of failing loudly.
  */
-const happy = (
-	shape: Parameters<typeof pull>[0] = {},
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull(shape)],
+const happy = (shape: Parameters<typeof pull>[0] = {}): ReadonlyArray<Scripted> => [
+	[PULL, served(pull(shape))],
 	...binding(),
 	[PATHS_AT(), paths("src/cart.ts", "README.md")],
-	[FILES, files("docs/moved.md", "docs/also.md")],
+	[FILES, served(files("docs/moved.md", "docs/also.md"))],
 ];
 
 describe("runScope", () => {
@@ -93,7 +98,7 @@ describe("runScope", () => {
 			},
 		});
 		const out = await Effect.runPromise(
-			Effect.provide(runScope({...options}), Layer.merge(fakeShell(happy()).layer, declared.layer)),
+			Effect.provide(runScope({...options}), Layer.merge(fakeSeams(happy()).layer, declared.layer)),
 		);
 		expect(out.stdout).toContain("governance\trequired");
 		expect(out.stderr).toContain(
@@ -104,7 +109,7 @@ describe("runScope", () => {
 	it("refuses rather than deriving when the config cannot be decoded", async () => {
 		const broken = fakeFs({files: {"/repo/.fabrika.jsonc": '{"governedRoots": []}'}});
 		const out = await Effect.runPromise(
-			Effect.provide(runScope({...options}), Layer.merge(fakeShell(happy()).layer, broken.layer)),
+			Effect.provide(runScope({...options}), Layer.merge(fakeSeams(happy()).layer, broken.layer)),
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -130,10 +135,10 @@ describe("runScope", () => {
 	 */
 	it("prints `governance required` on a `.decisions/`-only diff, where `harness` is false", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths(".decisions/0280-review-shell-carries-the-spawn-tool.md")],
-			[FILES, files("docs/moved.md")],
+			[FILES, served(files("docs/moved.md"))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("harness\tfalse");
@@ -142,10 +147,10 @@ describe("runScope", () => {
 
 	it("keeps the two answers apart on a harness diff — both roots, both tokens", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			...binding(),
 			[PATHS_AT(), paths(".github/workflows/ci.yml")],
-			[FILES, files("docs/moved.md")],
+			[FILES, served(files("docs/moved.md"))],
 		]);
 		expect(out.stdout).toContain("harness\ttrue");
 		expect(out.stdout).toContain("governance\trequired");
@@ -195,26 +200,26 @@ describe("runScope refusals and diagnostics", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: NOT_FOUND}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe("review scope: PR #4321 not found in o/r.");
 	});
 
 	it("refuses a closed PR on 7 — nothing to review", async () => {
-		const out = await run([[PULL, pull({state: "closed"})]]);
+		const out = await run([[PULL, served(pull({state: "closed"}))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("review scope: PR #4321 is closed — nothing to review.");
 	});
 
 	it("refuses a zero-file PR on 7 rather than classifying an empty review (#4060)", async () => {
-		const out = await run([[PULL, pull({changedFiles: 0})]]);
+		const out = await run([[PULL, served(pull({changedFiles: 0}))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("has zero changed files");
 	});
 
 	it("separates an UNREADABLE PR from an absent one — 11, never 7", async () => {
-		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[PULL, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.code).not.toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("the scope is UNKNOWN");
@@ -222,7 +227,7 @@ describe("runScope refusals and diagnostics", () => {
 
 	it("refuses an unreadable file list on 11 — the partition would be over unknown scope", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[PATHS_AT(), errOut("fatal: bad revision")],
 			...binding(),
 		]);
@@ -232,7 +237,11 @@ describe("runScope refusals and diagnostics", () => {
 	});
 
 	it("refuses an empty file list on 13, distinct from 11 and 7", async () => {
-		const out = await run([[PULL, pull({changedFiles: 9})], ...binding(), [PATHS_AT(), paths()]]);
+		const out = await run([
+			[PULL, served(pull({changedFiles: 9}))],
+			...binding(),
+			[PATHS_AT(), paths()],
+		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.code).not.toBe(PRECONDITION_UNKNOWN);
 		expect(out.code).not.toBe(ZERO_SCOPE);
@@ -247,7 +256,7 @@ describe("runScope refusals and diagnostics", () => {
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runScope({...options, env: {}}),
-				Layer.merge(fakeShell([]).layer, unconfigured),
+				Layer.merge(fakeSeams([]).layer, unconfigured),
 			),
 		);
 		expect(out.code).toBe(1);
@@ -263,8 +272,8 @@ describe("runScope refusals and diagnostics", () => {
  */
 describe("runScope never refuses on GitHub's declared count", () => {
 	/** git pairs the rename into one `--name-only` path; GitHub counts the delete and the add. */
-	const renamed: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-		[PULL, pull({changedFiles: 2})],
+	const renamed: ReadonlyArray<Scripted> = [
+		[PULL, served(pull({changedFiles: 2}))],
 		...binding(),
 		[PATHS_AT(), paths("src/new.ts")],
 	];
@@ -290,7 +299,7 @@ describe("runScope never refuses on GitHub's declared count", () => {
 
 	it("scopes a list LONGER than GitHub declares, which the old inequality also let through", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
+			[PULL, served(pull({changedFiles: 1}))],
 			...binding(),
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
 		]);
@@ -315,7 +324,7 @@ describe("runScope binds its file list to the commit it prints", () => {
 		expect(fake.calls).toContain(
 			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ --name-only -z ${BASE}...${HEAD}`,
 		);
-		expect(fake.calls.some((c) => c.includes("pulls/4321/files"))).toBe(false);
+		expect(fake.requests.some((r) => r.includes("pulls/4321/files"))).toBe(false);
 	});
 
 	it("prints the head it actually read the files out of", async () => {
@@ -341,7 +350,7 @@ describe("runScope binds its file list to the commit it prints", () => {
 
 	it("refuses on 11 when the commit cannot be bound, rather than partitioning an unbound list", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);

--- a/packages/fabrika-cli/src/review/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/verdicts-verb.unit.test.ts
@@ -1,13 +1,16 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {comments, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
 import {runVerdicts} from "./verdicts-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const PULL = /GET .*\/repos\/o\/r\/pulls\/4321\b/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4321\/comments/;
+
+/** A canned payload as the platform serves it — the fixtures speak `ExecResult`, the seam HTTP. */
+const served = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
 
 const CURRENT = `review-doc: PASS @ ${HEAD} — guide matches shipped behavior`;
 const STALE = `review-code: PASS @ ${OLD_HEAD} — merge-ready`;
@@ -20,19 +23,16 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(runVerdicts({...options, ...overrides}), fakeShell(script).layer),
+		Effect.provide(runVerdicts({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 describe("runVerdicts", () => {
 	it("prints the three bindings as THREE distinct tokens, newest first", async () => {
 		const out = await run([
-			[PULL, pull({comments: 2})],
-			[COMMENTS, comments({id: 5154891644, body: STALE}, {id: 5154902211, body: CURRENT})],
+			[PULL, served(pull({comments: 2}))],
+			[COMMENTS, served(comments({id: 5154891644, body: STALE}, {id: 5154902211, body: CURRENT}))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
@@ -47,8 +47,8 @@ describe("runVerdicts", () => {
 
 	it("never lets a stale PASS print as a current one", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: STALE})],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: STALE}))],
 		]);
 		expect(out.stdout).toContain("\tstale\t");
 		expect(out.stdout).not.toContain("\tcurrent\t");
@@ -56,8 +56,8 @@ describe("runVerdicts", () => {
 
 	it("prints unbindable on EVERY row when the live head could not be resolved", async () => {
 		const out = await run([
-			[PULL, errOut("gh: Bad gateway (HTTP 502)")],
-			[COMMENTS, comments({id: 1, body: CURRENT}, {id: 2, body: STALE})],
+			[PULL, {status: 502, body: "{}"}],
+			[COMMENTS, served(comments({id: 1, body: CURRENT}, {id: 2, body: STALE}))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe("verdicts\t-\t2");
@@ -69,8 +69,8 @@ describe("runVerdicts", () => {
 
 	it("counts 0 as a proven answer — the PR carries no verdict", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: "just a normal comment"})],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: "just a normal comment"}))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`verdicts\t${HEAD}\t0\n`);
@@ -78,8 +78,8 @@ describe("runVerdicts", () => {
 
 	it("surfaces a drifted marker as a malformed ROW, never drops it from the sweep", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 77, body: "review-code: PASS — merge-ready"})],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 77, body: "review-code: PASS — merge-ready"}))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("malformed\t-\t-\t-\t77");
@@ -88,22 +88,22 @@ describe("runVerdicts", () => {
 
 	it("reads an advisory carrier as ADVISORY, bound by its Reviewed-head line", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 9, body: ADVISORY})],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 9, body: ADVISORY}))],
 		]);
 		expect(out.stdout).toBe(`verdicts\t${HEAD}\t1\nreview-skill\tADVISORY\t${HEAD}\tcurrent\t9\n`);
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("review verdicts: PR #4321 not found in o/r.");
 	});
 
 	it("refuses an unreadable comment list on 11 — never zero", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, served(pull())],
+			[COMMENTS, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -112,8 +112,8 @@ describe("runVerdicts", () => {
 
 	it("refuses a provably short sweep on 13 rather than narrowing", async () => {
 		const out = await run([
-			[PULL, pull({comments: 12})],
-			[COMMENTS, comments({id: 1, body: CURRENT})],
+			[PULL, served(pull({comments: 12}))],
+			[COMMENTS, served(comments({id: 1, body: CURRENT}))],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
@@ -125,8 +125,8 @@ describe("runVerdicts", () => {
 	it("emits the record with --json, keeping malformed rows in their own array", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 2})],
-				[COMMENTS, comments({id: 1, body: CURRENT}, {id: 2, body: "review-code: nope"})],
+				[PULL, served(pull({comments: 2}))],
+				[COMMENTS, served(comments({id: 1, body: CURRENT}, {id: 2, body: "review-code: nope"}))],
 			],
 			{json: true},
 		);

--- a/packages/fabrika-cli/src/ship/checks-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/checks-verb.unit.test.ts
@@ -1,13 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {rollupFor, runChecks} from "./checks-verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {checkRuns, ENV, HEAD, pull, runsTotal, workflows} from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const COMMIT = /^gh api repos\/o\/r\/commits\/[0-9a-f]+ --jq \.sha$/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const COMMIT = /^GET \S+\/repos\/o\/r\/commits\/[0-9a-f]+$/;
 const RUNS = /\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
 const WORKFLOWS = /\/repos\/o\/r\/actions\/workflows/;
 const RUN_COUNT = /\/repos\/o\/r\/actions\/runs\?head_sha=/;
@@ -36,22 +36,22 @@ const options = {
 const CONFIG = "/repo/.fabrika.jsonc";
 
 const run = (
-	shell: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	shell: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	files: Readonly<Record<string, string | null>> = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runChecks({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(shell).layer, fakeHttp(http).layer, fakeFs({files}).layer),
+			Layer.merge(fakeSeams([...shell, ...http]).layer, fakeFs({files}).layer),
 		),
 	);
 
-/** The PR and the commit probe, which both still shell out to `gh`. */
-const found: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[PULL, pull()],
-	[COMMIT, okOut(HEAD)],
+/** The PR and the commit probe — a present PR at a commit the repository holds. */
+const found: ReadonlyArray<Scripted> = [
+	[PULL, served(pull())],
+	[COMMIT, {status: 200, body: JSON.stringify({sha: HEAD})}],
 ];
 
 const noRun = (name: string, status: string, conclusion: string | null = null) => ({
@@ -251,8 +251,8 @@ describe("runChecks", () => {
 	it("refuses a --sha proven absent on 7", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[COMMIT, errOut("gh: Not Found (HTTP 404)")],
+				[PULL, served(pull())],
+				[COMMIT, {status: 404, body: '{"message":"Not Found"}'}],
 			],
 			[],
 		);
@@ -262,7 +262,7 @@ describe("runChecks", () => {
 });
 
 describe("the no-producer split", () => {
-	const noWorkflows: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+	const noWorkflows: ReadonlyArray<Scripted> = [
 		[RUNS, served(checkRuns(0, []))],
 		[WORKFLOWS, served(workflows())],
 		[RUN_COUNT, served(runsTotal(0))],

--- a/packages/fabrika-cli/src/ship/cp-approval-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/cp-approval-verb.unit.test.ts
@@ -1,14 +1,14 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, type HttpReply, linkNext} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, linkNext, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {latestPerAuthor, runCpApproval} from "./cp-approval-verb.ts";
 import {CODEOWNERS, comments, ENV, files, HEAD, OTHER_HEAD, pull} from "./fixtures.test-support.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4321\/comments\?/;
 
 const OWNERS = /contents\/\.github\/CODEOWNERS/;
 const CONFIG = /contents\/\.fabrika\.jsonc/;
@@ -54,20 +54,20 @@ const reviewPage = (
 
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
 
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
 const run = (
-	shell: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	shell: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
-		Effect.provide(
-			runCpApproval({...options, ...overrides}),
-			Layer.merge(fakeShell(shell).layer, fakeHttp(http).layer),
-		),
+		Effect.provide(runCpApproval({...options, ...overrides}), fakeSeams([...shell, ...http]).layer),
 	);
 
 /** The §CP path set, so the boundary classifies `control-plane` and the table actually runs. */
-const CP_FILES = files(".github/workflows/ci.yml", "README.md");
+const CP_FILES = served(files(".github/workflows/ci.yml", "README.md"));
 
 const OWNED: HttpReply = {status: 200, body: CODEOWNERS};
 
@@ -87,8 +87,8 @@ describe("runCpApproval", () => {
 	it("answers n/a on a proven-ordinary PR, computed from the same cp derivation `ship scope` prints", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[FILES, files("apps/web/src/App.tsx", "README.md")],
+				[PULL, served(pull())],
+				[FILES, served(files("apps/web/src/App.tsx", "README.md"))],
 			],
 			[
 				[OWNERS, OWNED],
@@ -102,7 +102,7 @@ describe("runCpApproval", () => {
 	it("discharges on a non-author member's APPROVED review bound to --sha", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin"})],
+				[PULL, served(pull({author: "usirin"}))],
 				[FILES, CP_FILES],
 			],
 			[
@@ -118,7 +118,7 @@ describe("runCpApproval", () => {
 	it("refuses an unexhausted review read on 13 — an approval could sit on an unread page", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin"})],
+				[PULL, served(pull({author: "usirin"}))],
 				[FILES, CP_FILES],
 			],
 			[
@@ -138,7 +138,7 @@ describe("runCpApproval", () => {
 	it("does NOT discharge on an approval bound to a superseded head (#3769)", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin"})],
+				[PULL, served(pull({author: "usirin"}))],
 				[FILES, CP_FILES],
 			],
 			[
@@ -154,7 +154,7 @@ describe("runCpApproval", () => {
 	it("never counts the author's own approval", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin"})],
+				[PULL, served(pull({author: "usirin"}))],
 				[FILES, CP_FILES],
 			],
 			[
@@ -170,11 +170,13 @@ describe("runCpApproval", () => {
 	it("takes the sole-owner-authored arm through the head-bound self-approval marker", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin", comments: 1})],
+				[PULL, served(pull({author: "usirin", comments: 1}))],
 				[FILES, CP_FILES],
 				[
 					COMMENTS,
-					comments({id: 1, author: "usirin", body: `control-plane-self-approval @ ${HEAD}`}),
+					served(
+						comments({id: 1, author: "usirin", body: `control-plane-self-approval @ ${HEAD}`}),
+					),
 				],
 			],
 			[
@@ -189,8 +191,8 @@ describe("runCpApproval", () => {
 	it("stops on zero-owners when CODEOWNERS names no resolvable owner at all", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[FILES, files("a/b.ts", "README.md")],
+				[PULL, served(pull())],
+				[FILES, served(files("a/b.ts", "README.md"))],
 			],
 			[
 				[OWNERS, {status: 200, body: "/a/ owner@example.test\n"}],
@@ -203,8 +205,8 @@ describe("runCpApproval", () => {
 	it("discharges on an individual @login owner's approval, with no roster read at all (#6299)", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin"})],
-				[FILES, files("a/b.ts", "README.md")],
+				[PULL, served(pull({author: "usirin"}))],
+				[FILES, served(files("a/b.ts", "README.md"))],
 			],
 			[
 				[OWNERS, {status: 200, body: "/a/ @cansirin\n"}],
@@ -218,15 +220,17 @@ describe("runCpApproval", () => {
 	it("takes the self-approval path when the sole individual owner authored the PR", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin", comments: 1})],
-				[FILES, files("a/b.ts", "README.md")],
+				[PULL, served(pull({author: "usirin", comments: 1}))],
+				[FILES, served(files("a/b.ts", "README.md"))],
 				[
 					COMMENTS,
-					comments({
-						id: 1,
-						author: "usirin",
-						body: `control-plane-self-approval @ ${HEAD}`,
-					}),
+					served(
+						comments({
+							id: 1,
+							author: "usirin",
+							body: `control-plane-self-approval @ ${HEAD}`,
+						}),
+					),
 				],
 			],
 			[
@@ -240,7 +244,7 @@ describe("runCpApproval", () => {
 	it("unions an individual owner with a team roster — GitHub's any-listed-owner semantics", async () => {
 		const out = await run(
 			[
-				[PULL, pull({author: "usirin"})],
+				[PULL, served(pull({author: "usirin"}))],
 				[FILES, CP_FILES],
 			],
 			[
@@ -256,7 +260,7 @@ describe("runCpApproval", () => {
 	it("never answers n/a on a proven-absent CODEOWNERS — an empty boundary is the `unknown` hold", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[FILES, CP_FILES],
 			],
 			[
@@ -271,7 +275,7 @@ describe("runCpApproval", () => {
 	it("refuses a failed boundary read on 11 whatever the repo's config says (ADR 0220 §4)", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[FILES, CP_FILES],
 			],
 			[
@@ -287,7 +291,7 @@ describe("runCpApproval", () => {
 	it("refuses an UNREADABLE roster on 11 — never `stop`, never `awaiting approval` (#4223)", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
+				[PULL, served(pull())],
 				[FILES, CP_FILES],
 			],
 			[
@@ -304,8 +308,8 @@ describe("runCpApproval", () => {
 	it("notices base drift so the approval is not spent on a head that must move (#4477)", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[FILES, files("apps/web/src/App.tsx", "README.md")],
+				[PULL, served(pull())],
+				[FILES, served(files("apps/web/src/App.tsx", "README.md"))],
 			],
 			[
 				[OWNERS, OWNED],
@@ -320,8 +324,8 @@ describe("runCpApproval", () => {
 	it("refuses a truncated file sweep on 13", async () => {
 		const out = await run(
 			[
-				[PULL, pull({changedFiles: 9})],
-				[FILES, files("README.md")],
+				[PULL, served(pull({changedFiles: 9}))],
+				[FILES, served(files("README.md"))],
 			],
 			[],
 		);
@@ -329,13 +333,13 @@ describe("runCpApproval", () => {
 	});
 
 	it("refuses a closed PR on 7 — nothing to discharge", async () => {
-		const out = await run([[PULL, pull({state: "closed"})]], []);
+		const out = await run([[PULL, served(pull({state: "closed"}))]], []);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("ship cp-approval: PR #4321 is closed — nothing to discharge.");
 	});
 
 	it("refuses a malformed --sha rather than treating it as a pattern (#4223)", async () => {
-		const out = await run([[PULL, pull()]], [], {sha: ""});
+		const out = await run([[PULL, served(pull())]], [], {sha: ""});
 		expect(out.code).toBe(1);
 		expect(out.stderr.at(-1)).toContain("never a pattern that matches every head");
 	});

--- a/packages/fabrika-cli/src/ship/disarm-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/disarm-verb.unit.test.ts
@@ -1,17 +1,22 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, WRITE_UNKNOWN} from "./codes.ts";
 import {runDisarm} from "./disarm-verb.ts";
 import {ENV, pull} from "./fixtures.test-support.ts";
 import {ADDED, REMOVED} from "./queue.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
 
 const TIMELINE = /\/repos\/o\/r\/issues\/4321\/timeline/;
 const RULES = /\/repos\/o\/r\/rules\/branches\/main/;
 const GRAPHQL = /\/graphql$/;
+
+/** The PR read, served — the same canned payload the spawner era scripted. */
+const pullServed = (shape: Parameters<typeof pull>[0] = {}): HttpReply => ({
+	status: 200,
+	body: pull(shape).stdout,
+});
 
 /** A terminal page of the PR's timeline — no `Link` header, which is the completeness proof. */
 const timeline = (...rows: ReadonlyArray<{event: string; at: string}>): HttpReply => ({
@@ -37,22 +42,15 @@ const disarmed: HttpReply = {
 
 const options = {pr: 4321, site: "preflight", repo: null, json: false, env: ENV};
 
-const layers = (
-	shell: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
-) => {
-	const spawner = fakeShell(shell);
-	const client = fakeHttp(http);
-	return {spawner, client, layer: Layer.merge(spawner.layer, client.layer)};
-};
+const layers = (script: ReadonlyArray<Scripted>) => fakeSeams(script);
 
 const run = (
-	shell: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted> = [],
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
-		Effect.provide(runDisarm({...options, ...overrides}), layers(shell, http).layer),
+		Effect.provide(runDisarm({...options, ...overrides}), layers([...script, ...http]).layer),
 	);
 
 const noQueue: HttpReply = {status: 200, body: JSON.stringify([])};
@@ -60,47 +58,41 @@ const _withQueue: HttpReply = {status: 200, body: JSON.stringify([{type: "merge_
 
 describe("runDisarm", () => {
 	it("keeps a never-armed intent and says so", async () => {
-		const out = await run([[PULL, pull()]], [[TIMELINE, timeline()]]);
+		const out = await run([[PULL, pullServed()]], [[TIMELINE, timeline()]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("disarm\tkept\tpreflight\tnot-armed\n");
 	});
 
 	it("clears an armed intent and PROVES it from the re-read", async () => {
-		const scripted = layers(
-			[
-				[once(PULL), pull({autoMerge: true})],
-				[PULL, pull({autoMerge: false})],
-			],
-			[
-				[TIMELINE, timeline()],
-				[GRAPHQL, disarmed],
-			],
-		);
+		const scripted = layers([
+			[once(PULL), pullServed({autoMerge: true})],
+			[PULL, pullServed({autoMerge: false})],
+			[TIMELINE, timeline()],
+			[GRAPHQL, disarmed],
+		]);
 		const out = await Effect.runPromise(Effect.provide(runDisarm(options), scripted.layer));
 		expect(out.stdout).toBe("disarm\tdisarmed\tpreflight\tcleared\n");
-		expect(
-			scripted.client.bodies.some((body) => body.includes("disablePullRequestAutoMerge")),
-		).toBe(true);
+		expect(scripted.bodies.some((body) => body.includes("disablePullRequestAutoMerge"))).toBe(true);
 		// The queue owns the merge method, so the mutation must not name one — `mergeMethod` is the
 		// GraphQL spelling of the `--squash`-alongside-`--auto` trap that no-ops the enqueue silently.
-		expect(scripted.client.bodies.some((body) => body.includes("mergeMethod"))).toBe(false);
+		expect(scripted.bodies.some((body) => body.includes("mergeMethod"))).toBe(false);
 	});
 
 	it("never disturbs a live queue entry", async () => {
-		const scripted = layers(
-			[[PULL, pull({autoMerge: true})]],
-			[[TIMELINE, timeline({event: ADDED, at: "2026-08-08T10:00:00Z"})]],
-		);
+		const scripted = layers([
+			[PULL, pullServed({autoMerge: true})],
+			[TIMELINE, timeline({event: ADDED, at: "2026-08-08T10:00:00Z"})],
+		]);
 		const out = await Effect.runPromise(Effect.provide(runDisarm(options), scripted.layer));
 		expect(out.stdout).toBe("disarm\tkept\tpreflight\tlive-queued\n");
-		expect(
-			scripted.client.bodies.some((body) => body.includes("disablePullRequestAutoMerge")),
-		).toBe(false);
+		expect(scripted.bodies.some((body) => body.includes("disablePullRequestAutoMerge"))).toBe(
+			false,
+		);
 	});
 
 	it("keeps the intent off a queue-less base at post-enqueue — there `--auto` IS the mechanism", async () => {
 		const out = await run(
-			[[PULL, pull({autoMerge: true})]],
+			[[PULL, pullServed({autoMerge: true})]],
 			[
 				[TIMELINE, timeline({event: REMOVED, at: "2026-08-08T10:00:00Z"})],
 				[RULES, noQueue],
@@ -113,8 +105,8 @@ describe("runDisarm", () => {
 	it("reads an UNREADABLE regime as queue-governed, so a failed read cannot grant the keep", async () => {
 		const out = await run(
 			[
-				[once(PULL), pull({autoMerge: true})],
-				[PULL, pull({autoMerge: false})],
+				[once(PULL), pullServed({autoMerge: true})],
+				[PULL, pullServed({autoMerge: false})],
 			],
 			[
 				[TIMELINE, timeline()],
@@ -127,14 +119,16 @@ describe("runDisarm", () => {
 	});
 
 	it("answers `kept merged` for a merged PR rather than refusing — there is no 7 seat here", async () => {
-		const out = await run([[PULL, pull({merged: true, state: "closed"})]], [], {site: "ejected"});
+		const out = await run([[PULL, pullServed({merged: true, state: "closed"})]], [], {
+			site: "ejected",
+		});
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("disarm\tkept\tejected\tmerged\n");
 	});
 
 	it("refuses on 8 when the re-read cannot confirm the intent is clear", async () => {
 		const out = await run(
-			[[PULL, pull({autoMerge: true})]],
+			[[PULL, pullServed({autoMerge: true})]],
 			[
 				[TIMELINE, timeline()],
 				// The node-id read lands; the mutation behind it is what fails.
@@ -147,16 +141,16 @@ describe("runDisarm", () => {
 	});
 
 	it("refuses an unreadable merge state on 11 before any write is attempted", async () => {
-		const scripted = layers([[PULL, errOut("gh: Bad gateway (HTTP 502)")]], []);
+		const scripted = layers([[PULL, {status: 502, body: '{"message":"Bad gateway"}'}]]);
 		const out = await Effect.runPromise(Effect.provide(runDisarm(options), scripted.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(
-			scripted.client.bodies.some((body) => body.includes("disablePullRequestAutoMerge")),
-		).toBe(false);
+		expect(scripted.bodies.some((body) => body.includes("disablePullRequestAutoMerge"))).toBe(
+			false,
+		);
 	});
 
 	it("refuses an off-vocabulary --site on 10", async () => {
-		const out = await run([[PULL, pull()]], [], {site: "later"});
+		const out = await run([[PULL, pullServed()]], [], {site: "later"});
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.at(-1)).toBe(
 			"ship disarm: --site later is not a lifecycle site (preflight, refuse, post-enqueue, ejected).",

--- a/packages/fabrika-cli/src/ship/enqueue-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/enqueue-verb.unit.test.ts
@@ -1,14 +1,16 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, type HttpReply, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {PRECONDITION_UNKNOWN, STALE_HEAD, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {runEnqueue} from "./enqueue-verb.ts";
 import {ENV, HEAD, OTHER_HEAD, type PullShape, pull} from "./fixtures.test-support.ts";
 import {ADDED} from "./queue.ts";
 
-/** The live-head read is `../io/pulls.ts`'s, which still shells out to `gh`. */
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/**
+ * The live-head read and the mergeability read hit the same endpoint, so the first answer is
+ * scripted `once` and every later one falls through to {@link MERGEABILITY}.
+ */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
 
 /** The mergeability read is `./github.ts`'s, and hits the same endpoint over HTTP. */
 const MERGEABILITY = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
@@ -20,6 +22,9 @@ const mergeability = (shape: PullShape = {}): HttpReply => ({
 	status: 200,
 	body: pull(shape).stdout,
 });
+
+/** The verb's first read of the pull request — the live head it refuses drift on. */
+const livePull = (shape: PullShape = {}): Scripted => [once(PULL), mergeability(shape)];
 
 /** One body carrying both keys: each reader looks up only the key it needs. */
 const ARMED: HttpReply = {
@@ -43,45 +48,29 @@ const timeline = (...rows: ReadonlyArray<{event: string; at: string}>): HttpRepl
 
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
 
-const both = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
-	overrides: Partial<typeof options> = {},
-) => {
-	const shell = fakeShell(rows);
-	const client = fakeHttp(http);
+const both = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const seams = fakeSeams(script);
 	return {
-		shell,
-		client,
-		outcome: Effect.runPromise(
-			Effect.provide(
-				runEnqueue({...options, ...overrides}),
-				Layer.merge(shell.layer, client.layer),
-			),
-		),
+		seams,
+		outcome: Effect.runPromise(Effect.provide(runEnqueue({...options, ...overrides}), seams.layer)),
 	};
 };
 
-const run = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
-	overrides: Partial<typeof options> = {},
-) => both(rows, http, overrides).outcome;
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	both(script, overrides).outcome;
 
 describe("runEnqueue", () => {
 	it("arms with NO merge-method flag and reports the visible entry", async () => {
-		const scripted = both(
-			[[PULL, pull()]],
-			[
-				[MERGEABILITY, mergeability()],
-				[GRAPHQL, ARMED],
-				[TIMELINE, timeline({event: ADDED, at: "2026-08-08T10:00:00Z"})],
-			],
-		);
+		const scripted = both([
+			livePull(),
+			[MERGEABILITY, mergeability()],
+			[GRAPHQL, ARMED],
+			[TIMELINE, timeline({event: ADDED, at: "2026-08-08T10:00:00Z"})],
+		]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`enqueued\t${HEAD}\tqueued\n`);
-		const armed = scripted.client.bodies.filter((body) =>
+		const armed = scripted.seams.bodies.filter((body) =>
 			body.includes("enablePullRequestAutoMerge"),
 		);
 		expect(armed).toHaveLength(1);
@@ -89,41 +78,37 @@ describe("runEnqueue", () => {
 	});
 
 	it("reports `settling` when the entry has not surfaced — the normal race, not a failure", async () => {
-		const out = await run(
-			[[PULL, pull()]],
-			[
-				[MERGEABILITY, mergeability()],
-				[GRAPHQL, ARMED],
-				[TIMELINE, timeline()],
-			],
-		);
+		const out = await run([
+			livePull(),
+			[MERGEABILITY, mergeability()],
+			[GRAPHQL, ARMED],
+			[TIMELINE, timeline()],
+		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`enqueued\t${HEAD}\tsettling\n`);
 	});
 
 	it("refuses a moved head on 12 — arming a tree nobody verified", async () => {
-		const scripted = both([[PULL, pull({head: OTHER_HEAD})]], []);
+		const scripted = both([livePull({head: OTHER_HEAD})]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(STALE_HEAD);
 		expect(out.stdout).toBe("");
-		expect(scripted.client.calls.some((line) => /graphql/.test(line))).toBe(false);
+		expect(scripted.seams.requests.some((line) => /graphql/.test(line))).toBe(false);
 	});
 
 	it("refuses an already-merged PR on 7 — an idempotent success is `ship scope`'s answer", async () => {
-		const out = await run([[PULL, pull({merged: true, state: "closed"})]], []);
+		const out = await run([livePull({merged: true, state: "closed"})]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("ship enqueue: PR #4321 is merged — nothing to enqueue.");
 	});
 
 	it("refuses on 8 when the arm fails, quoting the error so the jam is discriminable", async () => {
-		const out = await run(
-			[[PULL, pull()]],
-			[
-				[MERGEABILITY, mergeability()],
-				[once(GRAPHQL), ARMED],
-				[GRAPHQL, refused("Pull request is in unstable status")],
-			],
-		);
+		const out = await run([
+			livePull(),
+			[MERGEABILITY, mergeability()],
+			[once(GRAPHQL), ARMED],
+			[GRAPHQL, refused("Pull request is in unstable status")],
+		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain(
 			'the arm failed: "the GraphQL endpoint refused: Pull request is in unstable status"',
@@ -135,52 +120,48 @@ describe("runEnqueue", () => {
 	// intent, so nothing but this precondition stands between `dirty` and a parked intent reported as
 	// a healthy enqueue.
 	it("refuses on 11 when mergeability stays indefinite — an unknown read is never green", async () => {
-		const scripted = both(
-			[[PULL, pull()]],
-			[[MERGEABILITY, mergeability({mergeable: null, mergeableState: "unknown"})]],
-		);
+		const scripted = both([
+			livePull(),
+			[MERGEABILITY, mergeability({mergeable: null, mergeableState: "unknown"})],
+		]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
 			"ship enqueue: #4321's mergeable_state is still indefinite after 3 polls — mergeability is UNKNOWN, never green; nothing was armed.",
 		);
-		expect(scripted.client.calls.some((line) => /graphql/.test(line))).toBe(false);
+		expect(scripted.seams.requests.some((line) => /graphql/.test(line))).toBe(false);
 	}, 20_000);
 
 	it("arms on a definite mergeable_state, whatever that state says", async () => {
-		const scripted = both(
-			[[PULL, pull()]],
-			[
-				[MERGEABILITY, mergeability({mergeable: false, mergeableState: "dirty"})],
-				[GRAPHQL, ARMED],
-				[TIMELINE, timeline()],
-			],
-		);
+		const scripted = both([
+			livePull(),
+			[MERGEABILITY, mergeability({mergeable: false, mergeableState: "dirty"})],
+			[GRAPHQL, ARMED],
+			[TIMELINE, timeline()],
+		]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(0);
-		expect(scripted.client.bodies.some((body) => body.includes("enablePullRequestAutoMerge"))).toBe(
+		expect(scripted.seams.bodies.some((body) => body.includes("enablePullRequestAutoMerge"))).toBe(
 			true,
 		);
 	});
 
 	it("refuses on 11 when the mergeability read itself fails — nothing was armed", async () => {
-		const scripted = both([[PULL, pull()]], [[MERGEABILITY, badGateway]]);
+		const scripted = both([livePull(), [MERGEABILITY, badGateway]]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("cannot read #4321's mergeability");
-		expect(scripted.client.calls.some((line) => /graphql/.test(line))).toBe(false);
+		expect(scripted.seams.requests.some((line) => /graphql/.test(line))).toBe(false);
 	});
 
 	it("refuses on 8 when the confirming read-back fails", async () => {
-		const out = await run(
-			[[PULL, pull()]],
-			[
-				[MERGEABILITY, mergeability()],
-				[GRAPHQL, ARMED],
-				[TIMELINE, badGateway],
-			],
-		);
+		const out = await run([
+			livePull(),
+			[MERGEABILITY, mergeability()],
+			[GRAPHQL, ARMED],
+			[TIMELINE, badGateway],
+		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("the confirming read-back failed");
 	});

--- a/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
@@ -1,17 +1,16 @@
 import {mkdtempSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, okOut, type Scripted} from "../fakes.test-support.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {readManifest, runEvidence} from "./evidence-verb.ts";
 import {ENV, HEAD, OTHER_HEAD, pull} from "./fixtures.test-support.ts";
 
-/** The live-head reads and the scratch/unzip legs still shell out. */
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const COMMIT = /^gh api repos\/o\/r\/commits\/[0-9a-f]+ --jq \.sha$/;
+/** The scratch and unzip legs stay spawns; the two GitHub reads are served. */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const COMMIT = /^GET \S+\/repos\/o\/r\/commits\/[0-9a-f]+$/;
 const MKTEMP = /^mktemp -d$/;
 const UNZIP = /^sh -c unzip -p /;
 
@@ -79,37 +78,34 @@ const producerManifest = (commit: string): string =>
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
-		Effect.provide(
-			runEvidence({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(http).layer),
-		),
+		Effect.provide(runEvidence({...options, ...overrides}), fakeSeams([...script, ...http]).layer),
 	);
 
-const shellUpToArtifact = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull()],
-	[COMMIT, okOut(HEAD)],
+const readsUpToArtifact = (): ReadonlyArray<Scripted> => [
+	[PULL, {status: 200, body: pull().stdout}],
+	[COMMIT, {status: 200, body: JSON.stringify({sha: HEAD})}],
 	[MKTEMP, okOut(scratch())],
 ];
 
-const HTTP_UP_TO_ARTIFACT: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+const HTTP_UP_TO_ARTIFACT: ReadonlyArray<Scripted> = [
 	[WORKFLOW, {status: 200, body: JSON.stringify({path: ".github/workflows/run-evidence.yml"})}],
 	[RUNS, runsAt({id: 9182736450, name: "run-evidence", status: "completed"})],
 	[ARTIFACTS, artifactsFor({id: 2211334455, name: "run-evidence"})],
 	[ZIP, zipBody()],
 ];
 
-/** The shell rows for a run that never reaches the download. */
-const SHELL_HEAD: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[PULL, pull()],
-	[COMMIT, okOut(HEAD)],
+/** The rows for a run that never reaches the download. */
+const HEAD_READS: ReadonlyArray<Scripted> = [
+	[PULL, {status: 200, body: pull().stdout}],
+	[COMMIT, {status: 200, body: JSON.stringify({sha: HEAD})}],
 ];
 
-const WORKFLOW_PRESENT: readonly [RegExp, HttpReply] = [
+const WORKFLOW_PRESENT: Scripted = [
 	WORKFLOW,
 	{status: 200, body: JSON.stringify({path: ".github/workflows/run-evidence.yml"})},
 ];
@@ -134,7 +130,7 @@ describe("runEvidence", () => {
 	it("reports present with the lookup evidence and the manifest checks as a status tally", async () => {
 		const out = await run(
 			[
-				...shellUpToArtifact(),
+				...readsUpToArtifact(),
 				[
 					UNZIP,
 					okOut(
@@ -163,7 +159,7 @@ describe("runEvidence", () => {
 	it("tallies the manifest's checks by status instead of printing a row per check", async () => {
 		const out = await run(
 			[
-				...shellUpToArtifact(),
+				...readsUpToArtifact(),
 				[
 					UNZIP,
 					okOut(
@@ -187,7 +183,7 @@ describe("runEvidence", () => {
 	it("mirrors the same collapsed tally into the --json payload", async () => {
 		const out = await run(
 			[
-				...shellUpToArtifact(),
+				...readsUpToArtifact(),
 				[
 					UNZIP,
 					okOut(
@@ -208,7 +204,7 @@ describe("runEvidence", () => {
 	// never writes, so every real bundle read `failed` and no PR could ship on green evidence.
 	it("reports present for a manifest in the producer's own published shape", async () => {
 		const out = await run(
-			[...shellUpToArtifact(), [UNZIP, okOut(producerManifest(HEAD))]],
+			[...readsUpToArtifact(), [UNZIP, okOut(producerManifest(HEAD))]],
 			HTTP_UP_TO_ARTIFACT,
 		);
 		expect(out.code).toBe(0);
@@ -217,7 +213,7 @@ describe("runEvidence", () => {
 
 	it("reports failed for a check carrying GitHub's `success` — an unknown word is not passing", async () => {
 		const out = await run(
-			[...shellUpToArtifact(), [UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "success"}]))]],
+			[...readsUpToArtifact(), [UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "success"}]))]],
 			HTTP_UP_TO_ARTIFACT,
 		);
 		expect(out.code).toBe(0);
@@ -225,7 +221,7 @@ describe("runEvidence", () => {
 	});
 
 	it("reports pending for an in-flight producer run — pending is NOT absent (#3913)", async () => {
-		const out = await run(SHELL_HEAD, [
+		const out = await run(HEAD_READS, [
 			WORKFLOW_PRESENT,
 			[RUNS, runsAt({id: 9182736999, name: "run-evidence", status: "in_progress"})],
 		]);
@@ -239,7 +235,7 @@ describe("runEvidence", () => {
 	});
 
 	it("reports absent on the foreign-repo degradation, proven by a SUCCESSFUL inventory read", async () => {
-		const out = await run(SHELL_HEAD, [[WORKFLOW, {status: 404, body: '{"message":"Not Found"}'}]]);
+		const out = await run(HEAD_READS, [[WORKFLOW, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe(`evidence\tabsent\t${HEAD}`);
 	});
@@ -247,7 +243,7 @@ describe("runEvidence", () => {
 	// Clause 6: "completed, zero artifacts" is two facts in one shape. The 120s window against the
 	// local clock is what separates a listing lag from a producer that published nothing.
 	it("reports pending for a JUST-completed run with zero artifacts — listing lag, not a CI gap", async () => {
-		const out = await run(SHELL_HEAD, [
+		const out = await run(HEAD_READS, [
 			WORKFLOW_PRESENT,
 			[RUNS, runsAt({id: 9182736450, name: "run-evidence", status: "completed"})],
 			[ARTIFACTS, artifactsFor()],
@@ -258,7 +254,7 @@ describe("runEvidence", () => {
 	});
 
 	it("reports absent once that run is older than the window — the producer published nothing", async () => {
-		const out = await run(SHELL_HEAD, [
+		const out = await run(HEAD_READS, [
 			WORKFLOW_PRESENT,
 			[
 				RUNS,
@@ -277,7 +273,7 @@ describe("runEvidence", () => {
 	});
 
 	it("reports absent when the run never reports a completion time at all", async () => {
-		const out = await run(SHELL_HEAD, [
+		const out = await run(HEAD_READS, [
 			WORKFLOW_PRESENT,
 			[
 				RUNS,
@@ -291,7 +287,7 @@ describe("runEvidence", () => {
 	// Clause 5: `failed` is the most DEFINITE answer this verb has; `unknown` means the opposite.
 	it("reports failed for a bundle that binds this head and attests a failing run", async () => {
 		const out = await run(
-			[...shellUpToArtifact(), [UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "fail"}]))]],
+			[...readsUpToArtifact(), [UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "fail"}]))]],
 			HTTP_UP_TO_ARTIFACT,
 		);
 		expect(out.code).toBe(0);
@@ -303,7 +299,7 @@ describe("runEvidence", () => {
 
 	it("reports unknown when the bundle attests another tree", async () => {
 		const out = await run(
-			[...shellUpToArtifact(), [UNZIP, okOut(manifest(OTHER_HEAD, []))]],
+			[...readsUpToArtifact(), [UNZIP, okOut(manifest(OTHER_HEAD, []))]],
 			HTTP_UP_TO_ARTIFACT,
 		);
 		expect(out.stdout.split("\n")[0]).toBe(`evidence\tunknown\t${HEAD}`);
@@ -311,7 +307,7 @@ describe("runEvidence", () => {
 	});
 
 	it("refuses a body that is not a zip on 11 — a 503 saved as .zip is not a bundle (#3716)", async () => {
-		const out = await run(shellUpToArtifact(), [
+		const out = await run(readsUpToArtifact(), [
 			...HTTP_UP_TO_ARTIFACT.filter(([pattern]) => pattern !== ZIP),
 			[ZIP, {status: 200, body: "<html>service unavailable</html>"}],
 		]);
@@ -322,7 +318,7 @@ describe("runEvidence", () => {
 	});
 
 	it("refuses an unreadable run list on 11, never `absent`", async () => {
-		const out = await run(SHELL_HEAD, [
+		const out = await run(HEAD_READS, [
 			WORKFLOW_PRESENT,
 			[RUNS, {status: 503, body: '{"message":"Service unavailable"}'}],
 		]);
@@ -332,8 +328,8 @@ describe("runEvidence", () => {
 	it("refuses a --sha proven absent on 7", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[COMMIT, errOut("gh: Not Found (HTTP 404)")],
+				[PULL, {status: 200, body: pull().stdout}],
+				[COMMIT, {status: 404, body: '{"message":"Not Found"}'}],
 			],
 			[],
 		);

--- a/packages/fabrika-cli/src/ship/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/ship/fixtures.test-support.ts
@@ -112,46 +112,6 @@ export const comments = (
 		),
 	);
 
-/**
- * A `gh api -i` response: status line, headers, blank line, body.
- *
- * The bare-array reads prove completeness by **exhausted pagination**, so their fixtures have to
- * carry the header that proof reads. Omitting the `Link` header is a terminal page (the platform
- * sends none when there is only one); `next` present is a page still outstanding.
- */
-export const httpPage = (body: string, options: {next?: boolean} = {}): ExecResult =>
-	okOut(
-		[
-			"HTTP/2.0 200 OK",
-			"content-type: application/json",
-			...(options.next === true
-				? ['link: <https://api.github.com/next?page=2>; rel="next", <https://x>; rel="last"']
-				: []),
-			"",
-			body,
-		].join("\r\n"),
-	);
-
-export const reviews = (
-	...rows: ReadonlyArray<{login: string; state: string; commit: string; at?: string}>
-): ExecResult =>
-	httpPage(
-		JSON.stringify(
-			rows.map((row) => ({
-				user: {login: row.login},
-				state: row.state,
-				commit_id: row.commit,
-				submitted_at: row.at ?? "2026-08-08T00:00:00Z",
-			})),
-		),
-	);
-
-export const timeline = (...rows: ReadonlyArray<{event: string; at: string}>): ExecResult =>
-	httpPage(JSON.stringify(rows.map((row) => ({event: row.event, created_at: row.at}))));
-
-/** The same page, but declaring a `next` — the read that can never prove it is complete. */
-export const unexhaustedPage = (): ExecResult => httpPage("[]", {next: true});
-
 export const threadPage = (
 	declared: number,
 	nodes: ReadonlyArray<{

--- a/packages/fabrika-cli/src/ship/floor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/floor-verb.unit.test.ts
@@ -7,14 +7,7 @@
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {
-	errOut,
-	fakeHttp,
-	fakeShell,
-	type HttpReply,
-	okOut,
-	unconfigured,
-} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted, unconfigured} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	GOVERNANCE_FLOOR_UNMET,
@@ -25,31 +18,37 @@ import {
 import {comments, ENV, files, HEAD, OTHER_HEAD, pull} from "./fixtures.test-support.ts";
 import {runFloor} from "./floor-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4321\/comments\?/;
 const REVIEWS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4321\/reviews/;
+const ACL = /^GET \S+\/repos\/o\/r\/collaborators\/[^/]+\/permission$/;
 
 /** No native review on the PR — the floor is a marker question, so every test reads the same page. */
 const NO_REVIEWS: readonly [RegExp, HttpReply] = [REVIEWS, {status: 200, body: "[]"}];
-const ACL = /^gh api repos\/o\/r\/collaborators\/[^ ]+\/permission/;
+
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+/** The permission endpoint's own shape — a `{permission}` record, not a bare word. */
+const permissionServed = (permission: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({permission}),
+});
 
 /** A fabrika-tree diff — `claude-plugins/` is one of the shipped governance roots. */
 const FABRIKA_TREE = [
 	FILES,
-	files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts"),
+	served(files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts")),
 ] as const;
 
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, cwd: "/repo", env: ENV};
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(
 			runFloor({...options, ...overrides}),
-			Layer.mergeAll(fakeShell([...script]).layer, fakeHttp([NO_REVIEWS]).layer, unconfigured),
+			Layer.merge(fakeSeams([...script, NO_REVIEWS]).layer, unconfigured),
 		),
 	);
 
@@ -59,10 +58,10 @@ const marker = (namespace: string, polarity: string, sha: string): string =>
 /** A governance-root PR carrying exactly one comment, with the ACL answer the test wants. */
 const withVerdict = (body: string, permission = "write") =>
 	[
-		[PULL, pull({comments: 1})],
+		[PULL, served(pull({comments: 1}))],
 		FABRIKA_TREE,
-		[COMMENTS, comments({id: 1, body})],
-		[ACL, okOut(permission)],
+		[COMMENTS, served(comments({id: 1, body}))],
+		[ACL, permissionServed(permission)],
 	] as const;
 
 describe("runFloor", () => {
@@ -74,8 +73,8 @@ describe("runFloor", () => {
 
 	it("answers n/a — not satisfied — when the diff touches no governance root", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, files("apps/web/src/a.ts", "apps/web/src/b.ts")],
+			[PULL, served(pull())],
+			[FILES, served(files("apps/web/src/a.ts", "apps/web/src/b.ts"))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`floor\tn/a\t${HEAD}\nns\tgovernance\t-\n`);
@@ -83,7 +82,11 @@ describe("runFloor", () => {
 	});
 
 	it("reds when the verdict is ABSENT — the #5293/#5333 shape", async () => {
-		const out = await run([[PULL, pull({comments: 0})], FABRIKA_TREE, [COMMENTS, comments()]]);
+		const out = await run([
+			[PULL, served(pull({comments: 0}))],
+			FABRIKA_TREE,
+			[COMMENTS, served(comments())],
+		]);
 		expect(out.code).toBe(GOVERNANCE_FLOOR_UNMET);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("is absent");
@@ -115,10 +118,10 @@ describe("runFloor", () => {
 
 	it("fails closed when the ACL cannot be read — UNKNOWN is never a discharge", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
+			[PULL, served(pull({comments: 1}))],
 			FABRIKA_TREE,
-			[COMMENTS, comments({id: 1, body: marker("governance", "PASS", HEAD)})],
-			[ACL, errOut("HTTP 403")],
+			[COMMENTS, served(comments({id: 1, body: marker("governance", "PASS", HEAD)}))],
+			[ACL, {status: 403, body: '{"message":"Forbidden"}'}],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -126,8 +129,8 @@ describe("runFloor", () => {
 
 	it("fails closed when the changed-file list cannot be read", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, errOut("HTTP 502")],
+			[PULL, served(pull())],
+			[FILES, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.join("\n")).toContain('never "n/a"');
@@ -135,16 +138,16 @@ describe("runFloor", () => {
 
 	it("refuses a short file list — a governance root could sit in the part nobody read", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 9})],
-			[FILES, files("apps/web/src/a.ts")],
+			[PULL, served(pull({changedFiles: 9}))],
+			[FILES, served(files("apps/web/src/a.ts"))],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
 	it("refuses a zero-file diff rather than answering n/a (ADR 0092)", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 0})],
-			[FILES, files()],
+			[PULL, served(pull({changedFiles: 0}))],
+			[FILES, served(files())],
 		]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});

--- a/packages/fabrika-cli/src/ship/gate-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/gate-verb.unit.test.ts
@@ -2,11 +2,11 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {
 	errOut,
-	fakeHttp,
-	fakeShell,
+	fakeSeams,
 	type HttpReply,
 	linkNext,
 	okOut,
+	type Scripted,
 	unconfigured,
 } from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
@@ -15,11 +15,11 @@ import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from 
 import {comments, ENV, files, HEAD, OTHER_HEAD, pull} from "./fixtures.test-support.ts";
 import {inForce, requiredWithFloor, runGate} from "./gate-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4321\/comments\?/;
 const REVIEWS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4321\/reviews/;
-const ACL = /^gh api repos\/o\/r\/collaborators\/[^ ]+\/permission/;
+const ACL = /^GET \S+\/repos\/o\/r\/collaborators\/[^/]+\/permission$/;
 
 /**
  * A served page of the reviews read — a bare array whose completeness proof is the ABSENCE of a
@@ -41,15 +41,29 @@ const reviewPage = (
 	headers: options.next === true ? linkNext("https://api.github.com/next?page=2") : undefined,
 });
 
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+/** The comment sweep's page, served. */
+const commentsServed = (
+	...rows: ReadonlyArray<{id: number; body: string; author?: string; updatedAt?: string}>
+): HttpReply => served(comments(...rows));
+
+/** The permission endpoint's own shape — a `{permission}` record, not a bare word. */
+const permission = (level: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({permission: level}),
+});
+
 /** No reviews at all — the answer every test that is not about the native fold reads. */
 const NO_REVIEWS = [REVIEWS, reviewPage()] as const;
 
 /** The default two-file diff, under no governance root — the floor stays off unless a test asks. */
-const ORDINARY = [FILES, files("apps/web/src/a.ts", "apps/web/src/b.ts")] as const;
+const ORDINARY = [FILES, served(files("apps/web/src/a.ts", "apps/web/src/b.ts"))] as const;
 /** A fabrika-tree diff: `claude-plugins/` is one of the shipped governance roots. */
 const FABRIKA_TREE = [
 	FILES,
-	files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts"),
+	served(files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts")),
 ] as const;
 
 const options = {
@@ -69,18 +83,14 @@ const options = {
  * other test reads an ordinary diff with no native review on it.
  */
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	http: ReadonlyArray<Scripted> = [],
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runGate({...options, ...overrides}),
-			Layer.mergeAll(
-				fakeShell([...script, ORDINARY]).layer,
-				fakeHttp([...http, NO_REVIEWS]).layer,
-				unconfigured,
-			),
+			Layer.merge(fakeSeams([...script, ...http, ORDINARY, NO_REVIEWS]).layer, unconfigured),
 		),
 	);
 
@@ -122,15 +132,15 @@ describe("runGate", () => {
 	it("prints one ns line per required namespace and satisfies only when all pass", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 2})],
+				[PULL, served(pull({comments: 2}))],
 				[
 					COMMENTS,
-					comments(
+					commentsServed(
 						{id: 1, body: marker("review-code", "PASS", HEAD)},
 						{id: 2, body: marker("review-doc", "PASS", HEAD)},
 					),
 				],
-				[ACL, okOut("write")],
+				[ACL, permission("write")],
 			],
 			{require: ["review-code", "review-doc"]},
 		);
@@ -148,15 +158,15 @@ describe("runGate", () => {
 	it("does not collapse repeated --require: a live FAIL in the second namespace blocks (#4520)", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 2})],
+				[PULL, served(pull({comments: 2}))],
 				[
 					COMMENTS,
-					comments(
+					commentsServed(
 						{id: 1, body: marker("review-code", "PASS", HEAD)},
 						{id: 2, body: marker("review-doc", "FAIL", HEAD)},
 					),
 				],
-				[ACL, okOut("write")],
+				[ACL, permission("write")],
 			],
 			{require: ["review-code", "review-doc"]},
 		);
@@ -166,8 +176,8 @@ describe("runGate", () => {
 
 	it("blocks on `absent` — a PR with no live-head verdict at all (#3944)", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[COMMENTS, comments()],
+			[PULL, served(pull())],
+			[COMMENTS, served(comments())],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
@@ -177,27 +187,27 @@ describe("runGate", () => {
 
 	it("blocks on `stale` and keeps it a distinct token from absent", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: marker("review-code", "PASS", OTHER_HEAD)})],
-			[ACL, okOut("write")],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: marker("review-code", "PASS", OTHER_HEAD)}))],
+			[ACL, permission("write")],
 		]);
 		expect(out.stdout).toContain("ns\treview-code\tstale\tmarker");
 	});
 
 	it("drops an unauthorized author's marker rather than counting it (ADR 0055)", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: marker("review-code", "PASS", HEAD)})],
-			[ACL, okOut("read")],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: marker("review-code", "PASS", HEAD)}))],
+			[ACL, permission("read")],
 		]);
 		expect(out.stdout).toContain("ns\treview-code\tabsent\t-");
 	});
 
 	it("refuses on 11 when the ACL lookup itself fails — never `absent`", async () => {
 		const out = await run([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: marker("review-code", "PASS", HEAD)})],
-			[ACL, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: marker("review-code", "PASS", HEAD)}))],
+			[ACL, {status: 502, body: '{"message":"Bad gateway"}'}],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -206,8 +216,8 @@ describe("runGate", () => {
 	it("folds a decisive native review at this head into the code namespace", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
+				[PULL, served(pull())],
+				[COMMENTS, served(comments())],
 			],
 			{},
 			[[REVIEWS, reviewPage([{login: "cansirin", state: "APPROVED", commit: HEAD}])]],
@@ -218,15 +228,15 @@ describe("runGate", () => {
 	it("treats a §CP advisory carrying a [FAIL] row as fail and says so (ADR 0226)", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 1})],
+				[PULL, served(pull({comments: 1}))],
 				[
 					COMMENTS,
-					comments({
+					commentsServed({
 						id: 1,
 						body: `review-code: advisory — a clause\n\nReviewed-head: @ ${HEAD}\n\n- [FAIL] a criterion`,
 					}),
 				],
-				[ACL, okOut("write")],
+				[ACL, permission("write")],
 			],
 			{cp: true},
 		);
@@ -235,7 +245,7 @@ describe("runGate", () => {
 	});
 
 	it("refuses an off-vocabulary --require on 10", async () => {
-		const out = await run([[PULL, pull()]], {require: ["review-vibes"]});
+		const out = await run([[PULL, served(pull())]], {require: ["review-vibes"]});
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.at(-1)).toContain("is not a gateable namespace");
 	});
@@ -243,8 +253,8 @@ describe("runGate", () => {
 	it("admits --require governance and gates on it like any other namespace (#5199)", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
+				[PULL, served(pull())],
+				[COMMENTS, served(comments())],
 			],
 			{require: ["governance"]},
 		);
@@ -260,9 +270,9 @@ describe("runGate", () => {
 	it("satisfies the namespace from a posted governance PASS marker (#5199 surface change 2)", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: marker("governance", "PASS", HEAD)})],
-				[ACL, okOut("write")],
+				[PULL, served(pull({comments: 1}))],
+				[COMMENTS, served(comments({id: 1, body: marker("governance", "PASS", HEAD)}))],
+				[ACL, permission("write")],
 			],
 			{require: ["governance"]},
 		);
@@ -274,9 +284,9 @@ describe("runGate", () => {
 	it("blocks on a posted governance FAIL rather than passing it — the widening carries both polarities", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 1})],
-				[COMMENTS, comments({id: 1, body: marker("governance", "FAIL", HEAD)})],
-				[ACL, okOut("write")],
+				[PULL, served(pull({comments: 1}))],
+				[COMMENTS, served(comments({id: 1, body: marker("governance", "FAIL", HEAD)}))],
+				[ACL, permission("write")],
 			],
 			{require: ["governance"]},
 		);
@@ -287,8 +297,8 @@ describe("runGate", () => {
 
 	it("refuses a truncated comment sweep on 13", async () => {
 		const out = await run([
-			[PULL, pull({comments: 9})],
-			[COMMENTS, comments({id: 1, body: "hi"})],
+			[PULL, served(pull({comments: 9}))],
+			[COMMENTS, served(comments({id: 1, body: "hi"}))],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
@@ -297,8 +307,8 @@ describe("runGate", () => {
 	it("refuses an unexhausted review read on 13 — pagination is the reviews' only proof", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[COMMENTS, comments()],
+				[PULL, served(pull())],
+				[COMMENTS, served(comments())],
 			],
 			{},
 			[[REVIEWS, reviewPage([], {next: true})]],
@@ -310,14 +320,14 @@ describe("runGate", () => {
 	});
 
 	it("refuses a closed PR on 7", async () => {
-		const out = await run([[PULL, pull({state: "closed"})]]);
+		const out = await run([[PULL, served(pull({state: "closed"}))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 
 	it("refuses a truncated changed-file read on 13 — the floor may not rest on it", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 9})],
-			[FILES, files("claude-plugins/fabrika/skills/ship/SKILL.md")],
+			[PULL, served(pull({changedFiles: 9}))],
+			[FILES, served(files("claude-plugins/fabrika/skills/ship/SKILL.md"))],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
@@ -325,8 +335,8 @@ describe("runGate", () => {
 
 	it("refuses a zero-file diff on 7 — a conjunction over an empty diff proves nothing", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 0})],
-			[FILES, files()],
+			[PULL, served(pull({changedFiles: 0}))],
+			[FILES, served(files())],
 		]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
@@ -338,10 +348,10 @@ describe("runGate — the governance floor (#5036)", () => {
 	it("requires governance on a fabrika-tree diff the caller never asked to gate on it", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 1})],
+				[PULL, served(pull({comments: 1}))],
 				FABRIKA_TREE,
-				[COMMENTS, comments({id: 1, body: marker("review-skill", "PASS", HEAD)})],
-				[ACL, okOut("write")],
+				[COMMENTS, served(comments({id: 1, body: marker("review-skill", "PASS", HEAD)}))],
+				[ACL, permission("write")],
 			],
 			{require: ["review-skill"]},
 		);
@@ -362,16 +372,16 @@ describe("runGate — the governance floor (#5036)", () => {
 	it("satisfies the floored namespace from a posted governance PASS", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 2})],
+				[PULL, served(pull({comments: 2}))],
 				FABRIKA_TREE,
 				[
 					COMMENTS,
-					comments(
+					commentsServed(
 						{id: 1, body: marker("review-skill", "PASS", HEAD)},
 						{id: 2, body: marker("governance", "PASS", HEAD)},
 					),
 				],
-				[ACL, okOut("write")],
+				[ACL, permission("write")],
 			],
 			{require: ["review-skill"]},
 		);
@@ -386,7 +396,7 @@ describe("runGate — the governance floor (#5036)", () => {
 	});
 
 	it("counts the floored namespace in --json `required`, so coverage cannot narrow silently", async () => {
-		const out = await run([[PULL, pull()], FABRIKA_TREE, [COMMENTS, comments()]], {
+		const out = await run([[PULL, served(pull())], FABRIKA_TREE, [COMMENTS, served(comments())]], {
 			require: ["review-skill"],
 			json: true,
 		});
@@ -396,10 +406,10 @@ describe("runGate — the governance floor (#5036)", () => {
 	it("leaves a diff under no governance root gated exactly as before", async () => {
 		const out = await run(
 			[
-				[PULL, pull({comments: 1})],
+				[PULL, served(pull({comments: 1}))],
 				ORDINARY,
-				[COMMENTS, comments({id: 1, body: marker("review-code", "PASS", HEAD)})],
-				[ACL, okOut("write")],
+				[COMMENTS, served(comments({id: 1, body: marker("review-code", "PASS", HEAD)}))],
+				[ACL, permission("write")],
 			],
 			{require: ["review-code"]},
 		);
@@ -459,7 +469,7 @@ describe("runGate — staleness is the content question", () => {
 	const DIGEST = "65ebe421b3c0";
 	const RAW = `:100644 100644 ${"a".repeat(40)} ${"b".repeat(40)} M\0apps/web/src/a.ts\0`;
 
-	const bound = (raw: ExecResult): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	const bound = (raw: ExecResult): ReadonlyArray<Scripted> => [
 		[
 			/^git remote -v$/,
 			okOut("origin\tgit@github.com:o/r.git (fetch)\norigin\tgit@github.com:o/r.git (push)\n"),
@@ -476,13 +486,10 @@ describe("runGate — staleness is the content question", () => {
 	const bindingMarker = (sha: string, content: string | null): string =>
 		`review-code: PASS @ ${sha}${content === null ? "" : ` content:${content}`} — the clause`;
 
-	const atMovedHead = (
-		content: string | null,
-		raw: ExecResult,
-	): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-		[PULL, pull({comments: 1})],
-		[COMMENTS, comments({id: 1, body: bindingMarker(OTHER_HEAD, content)})],
-		[ACL, okOut("write")],
+	const atMovedHead = (content: string | null, raw: ExecResult): ReadonlyArray<Scripted> => [
+		[PULL, served(pull({comments: 1}))],
+		[COMMENTS, served(comments({id: 1, body: bindingMarker(OTHER_HEAD, content)}))],
+		[ACL, permission("write")],
 		...bound(raw),
 	];
 
@@ -500,20 +507,18 @@ describe("runGate — staleness is the content question", () => {
 	});
 
 	it("blocks a moved-head verdict carrying NO content field, and reads no git for it", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: bindingMarker(OTHER_HEAD, null)})],
-			[ACL, okOut("write")],
+		const seams = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: bindingMarker(OTHER_HEAD, null)}))],
+			[ACL, permission("write")],
 			ORDINARY,
+			NO_REVIEWS,
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(
-				runGate(options),
-				Layer.mergeAll(shell.layer, fakeHttp([NO_REVIEWS]).layer, unconfigured),
-			),
+			Effect.provide(runGate(options), Layer.merge(seams.layer, unconfigured)),
 		);
 		expect(out.stdout).toContain("ns\treview-code\tstale\tmarker");
-		expect(shell.calls.some((call) => call.startsWith("git "))).toBe(false);
+		expect(seams.calls.some((call) => call.startsWith("git "))).toBe(false);
 	});
 
 	it("blocks — not passes — when this head's digest cannot be read at all", async () => {
@@ -524,19 +529,17 @@ describe("runGate — staleness is the content question", () => {
 	});
 
 	it("reads no git at all when every verdict is already at this head — the common path", async () => {
-		const shell = fakeShell([
-			[PULL, pull({comments: 1})],
-			[COMMENTS, comments({id: 1, body: bindingMarker(HEAD, DIGEST)})],
-			[ACL, okOut("write")],
+		const seams = fakeSeams([
+			[PULL, served(pull({comments: 1}))],
+			[COMMENTS, served(comments({id: 1, body: bindingMarker(HEAD, DIGEST)}))],
+			[ACL, permission("write")],
 			ORDINARY,
+			NO_REVIEWS,
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(
-				runGate(options),
-				Layer.mergeAll(shell.layer, fakeHttp([NO_REVIEWS]).layer, unconfigured),
-			),
+			Effect.provide(runGate(options), Layer.merge(seams.layer, unconfigured)),
 		);
 		expect(out.stdout).toContain("ns\treview-code\tpass\tmarker");
-		expect(shell.calls.some((call) => call.startsWith("git "))).toBe(false);
+		expect(seams.calls.some((call) => call.startsWith("git "))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/ship/landing.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/landing.unit.test.ts
@@ -1,21 +1,25 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
+import {fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {branchRules, ENV, repositoryServed} from "./fixtures.test-support.ts";
 import {landingOf, preferredMethod, readLanding} from "./landing.ts";
 
-const RULES = /^gh api repos\/o\/r\/rules\/branches\/main$/;
+const RULES = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/rules\/branches\/main$/;
 const REPO = /^GET https:\/\/api\.github\.com\/repos\/o\/r$/;
 
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
 const read = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	script: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	spawns: ReadonlyArray<readonly [RegExp, ExecResult]> = [],
+	unstartable: ReadonlyArray<RegExp> = [],
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			readLanding("o/r", "main", ENV),
-			Layer.merge(fakeShell(script).layer, fakeHttp(served).layer),
+			Layer.merge(fakeShell(spawns, undefined, unstartable).layer, fakeHttp(script).layer),
 		),
 	);
 
@@ -52,43 +56,45 @@ describe("landingOf", () => {
 
 describe("readLanding", () => {
 	it("answers `queue` off the branch's rules, without reading the repository at all", async () => {
-		const shell = fakeShell([[RULES, branchRules("merge_queue", "pull_request")]]);
-		const http = fakeHttp([]);
+		const http = fakeHttp([[RULES, served(branchRules("merge_queue", "pull_request"))]]);
 		const out = await Effect.runPromise(
-			Effect.provide(readLanding("o/r", "main", ENV), Layer.merge(shell.layer, http.layer)),
+			Effect.provide(readLanding("o/r", "main", ENV), Layer.merge(fakeShell([]).layer, http.layer)),
 		);
 		expect(out).toEqual({_tag: "Ok", value: {path: "queue", method: null}});
-		expect(http.calls).toEqual([]);
+		expect(http.calls.filter((call) => REPO.test(call))).toEqual([]);
 	});
 
 	it("answers `direct` with the preferred method when no queue governs the branch", async () => {
-		const out = await read([[RULES, branchRules("pull_request")]], [[REPO, repositoryServed()]]);
+		const out = await read([
+			[RULES, served(branchRules("pull_request"))],
+			[REPO, repositoryServed()],
+		]);
 		expect(out).toEqual({_tag: "Ok", value: {path: "direct", method: "squash"}});
 	});
 
 	it("answers `none` when the repository permits no merge method", async () => {
-		const out = await read(
-			[[RULES, okOut("[]")]],
-			[[REPO, repositoryServed({squash: false, merge: false, rebase: false})]],
-		);
+		const out = await read([
+			[RULES, served(okOut("[]"))],
+			[REPO, repositoryServed({squash: false, merge: false, rebase: false})],
+		]);
 		expect(out).toEqual({_tag: "Ok", value: {path: "none", method: null}});
 	});
 
 	it("fails rather than assuming a regime when the rules read fails", async () => {
-		const out = await read([[RULES, errOut("HTTP 503")]]);
+		const out = await read([[RULES, {status: 503, body: '{"message":"unavailable"}'}]]);
 		expect(out._tag).toBe("Failure");
 	});
 
 	it("fails rather than assuming a method when the repository read fails", async () => {
-		const out = await read(
-			[[RULES, okOut("[]")]],
-			[[REPO, {status: 503, body: '{"message":"unavailable"}'}]],
-		);
+		const out = await read([
+			[RULES, served(okOut("[]"))],
+			[REPO, {status: 503, body: '{"message":"unavailable"}'}],
+		]);
 		expect(out._tag).toBe("Failure");
 	});
 
 	it("fails on a rule payload that is not a list — a shape mismatch is never `no queue`", async () => {
-		const out = await read([[RULES, okOut('{"message":"Not Found"}')]]);
+		const out = await read([[RULES, served(okOut('{"message":"Not Found"}'))]]);
 		expect(out._tag).toBe("Failure");
 	});
 
@@ -97,8 +103,8 @@ describe("readLanding", () => {
 			Effect.provide(
 				readLanding("o/r", "main", {CLAUDE_PIPELINE_REPO: "o/r"}),
 				Layer.merge(
-					fakeShell([[RULES, okOut("[]")]], undefined, [/^gh auth token$/]).layer,
-					fakeHttp([]).layer,
+					fakeShell([], undefined, [/^gh auth token$/]).layer,
+					fakeHttp([[RULES, served(okOut("[]"))]]).layer,
 				),
 			),
 		);

--- a/packages/fabrika-cli/src/ship/merge-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/merge-verb.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	NO_LANDING_METHOD,
@@ -18,39 +18,48 @@ import {
 	MERGE_COMMIT,
 	mergeProofServed,
 	OTHER_HEAD,
+	type PullShape,
 	pull,
 	repositoryServed,
 } from "./fixtures.test-support.ts";
 import {runMerge} from "./merge-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const RULES = /^gh api repos\/o\/r\/rules\/branches\/main$/;
+/**
+ * Three legs read the pull request and they all read the same endpoint: the live head, then
+ * mergeability, then the landing proof. `once` is what keeps their answers distinguishable.
+ */
+const PULL = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4321$/;
+const RULES = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/rules\/branches\/main$/;
 const REPO = /^GET https:\/\/api\.github\.com\/repos\/o\/r$/;
-const PROOF = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4321$/;
 const MERGE = /^PUT https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4321\/merge$/;
-const UNQUEUED: readonly [RegExp, ExecResult] = [RULES, branchRules("pull_request")];
-const MERGED: readonly [RegExp, HttpReply] = [MERGE, {status: 200, body: "{}"}];
+
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+const UNQUEUED: Scripted = [RULES, served(branchRules("pull_request"))];
+const MERGED: Scripted = [MERGE, {status: 200, body: "{}"}];
+
+/** The verb's first read of the pull request — the live head it refuses drift on. */
+const livePull = (shape: PullShape = {}): Scripted => [once(PULL), served(pull(shape))];
+
+/** The mergeability poll, which reads the same endpoint one request later. */
+const mergeabilityRead = (shape: PullShape = {}): Scripted => [once(PULL), served(pull(shape))];
 
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
 
-const land = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-	overrides: Partial<typeof options> = {},
-) => {
-	const shell = fakeShell(script);
-	const http = fakeHttp(served);
-	return Effect.runPromise(
-		Effect.provide(runMerge({...options, ...overrides}), Layer.merge(shell.layer, http.layer)),
-	).then((outcome) => ({outcome, calls: http.calls, bodies: http.bodies}));
+const land = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const seams = fakeSeams(script);
+	return Effect.runPromise(Effect.provide(runMerge({...options, ...overrides}), seams.layer)).then(
+		(outcome) => ({outcome, calls: seams.requests, bodies: seams.bodies}),
+	);
 };
 
 /** Every read the happy path makes, in the order the verb makes them. */
-const HAPPY_SHELL: ReadonlyArray<readonly [RegExp, ExecResult]> = [[PULL, pull()], UNQUEUED];
-const HAPPY_HTTP: ReadonlyArray<readonly [RegExp, HttpReply]> = [
+const happyReads = (): ReadonlyArray<Scripted> => [
+	livePull(),
+	mergeabilityRead(),
+	UNQUEUED,
 	[REPO, repositoryServed()],
-	MERGED,
-	[PROOF, mergeProofServed()],
 ];
 
 const withoutWrite = (calls: ReadonlyArray<string>): boolean =>
@@ -58,7 +67,11 @@ const withoutWrite = (calls: ReadonlyArray<string>): boolean =>
 
 describe("runMerge", () => {
 	it("lands on an unqueued base with the repo's preferred method and proves the commit", async () => {
-		const {outcome, calls, bodies} = await land(HAPPY_SHELL, HAPPY_HTTP);
+		const {outcome, calls, bodies} = await land([
+			...happyReads(),
+			MERGED,
+			[PULL, mergeProofServed()],
+		]);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe(`merged\t${MERGE_COMMIT}\tsquash\n`);
 		const at = calls.findIndex((line) => line.startsWith("PUT "));
@@ -67,25 +80,27 @@ describe("runMerge", () => {
 	});
 
 	it("hands the platform the FULL live head, not the caller's abbreviation", async () => {
-		const {calls, bodies} = await land(HAPPY_SHELL, HAPPY_HTTP, {sha: HEAD.slice(0, 8)});
+		const {calls, bodies} = await land([...happyReads(), MERGED, [PULL, mergeProofServed()]], {
+			sha: HEAD.slice(0, 8),
+		});
 		const at = calls.findIndex((line) => line.startsWith("PUT "));
 		expect(JSON.parse(bodies[at] as string).sha).toBe(HEAD);
 	});
 
 	it("falls to the merge commit when the repository has squash disabled", async () => {
-		const {outcome} = await land(HAPPY_SHELL, [
+		const {outcome} = await land([
+			livePull(),
+			mergeabilityRead(),
+			UNQUEUED,
 			[REPO, repositoryServed({squash: false})],
 			MERGED,
-			[PROOF, mergeProofServed()],
+			[PULL, mergeProofServed()],
 		]);
 		expect(outcome.stdout).toBe(`merged\t${MERGE_COMMIT}\tmerge\n`);
 	});
 
 	it("refuses on 16 when a merge queue governs the base, and points at `ship enqueue`", async () => {
-		const {outcome, calls} = await land([
-			[PULL, pull()],
-			[RULES, branchRules("merge_queue")],
-		]);
+		const {outcome, calls} = await land([livePull(), [RULES, served(branchRules("merge_queue"))]]);
 		expect(outcome.code).toBe(PROVEN_NOT_IN_STATE);
 		expect(outcome.stderr.at(-1)).toBe(
 			"ship merge: a merge queue governs main — the queue owns the method and the landing; run `fabrika ship enqueue` instead.",
@@ -94,13 +109,11 @@ describe("runMerge", () => {
 	});
 
 	it("refuses on 19 when the repository permits no merge method — never guessing one", async () => {
-		const {outcome, calls} = await land(
-			[
-				[PULL, pull()],
-				[RULES, okOut("[]")],
-			],
-			[[REPO, repositoryServed({squash: false, merge: false, rebase: false})]],
-		);
+		const {outcome, calls} = await land([
+			livePull(),
+			[RULES, {status: 200, body: "[]"}],
+			[REPO, repositoryServed({squash: false, merge: false, rebase: false})],
+		]);
 		expect(outcome.code).toBe(NO_LANDING_METHOD);
 		expect(outcome.stderr.at(-1)).toContain("permits no merge method");
 		expect(withoutWrite(calls)).toBe(true);
@@ -108,8 +121,8 @@ describe("runMerge", () => {
 
 	it("refuses on 11 when the landing path cannot be read — never landing on an unread regime", async () => {
 		const {outcome, calls} = await land([
-			[PULL, pull()],
-			[RULES, errOut("HTTP 503")],
+			livePull(),
+			[RULES, {status: 503, body: '{"message":"unavailable"}'}],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("cannot read main's landing path");
@@ -117,10 +130,12 @@ describe("runMerge", () => {
 	});
 
 	it("refuses on 11 when mergeability stays indefinite — an unknown read is never green", async () => {
-		const {outcome, calls} = await land(
-			[[PULL, pull({mergeable: null, mergeableState: "unknown"})], UNQUEUED],
-			[[REPO, repositoryServed()]],
-		);
+		const {outcome, calls} = await land([
+			livePull(),
+			UNQUEUED,
+			[REPO, repositoryServed()],
+			[PULL, served(pull({mergeable: null, mergeableState: "unknown"}))],
+		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toBe(
 			"ship merge: #4321's mergeable_state is still indefinite after 3 polls — mergeability is UNKNOWN, never green; nothing was merged.",
@@ -129,10 +144,12 @@ describe("runMerge", () => {
 	}, 20_000);
 
 	it("refuses on 16 on a definite `dirty` — the endpoint would reject it indistinguishably", async () => {
-		const {outcome, calls} = await land(
-			[[PULL, pull({mergeable: false, mergeableState: "dirty"})], UNQUEUED],
-			[[REPO, repositoryServed()]],
-		);
+		const {outcome, calls} = await land([
+			livePull(),
+			UNQUEUED,
+			[REPO, repositoryServed()],
+			[PULL, served(pull({mergeable: false, mergeableState: "dirty"}))],
+		]);
 		expect(outcome.code).toBe(PROVEN_NOT_IN_STATE);
 		expect(outcome.stderr.at(-1)).toBe(
 			"ship merge: #4321 is not mergeable (mergeable_state: dirty) — a definite read; nothing was merged.",
@@ -141,21 +158,21 @@ describe("runMerge", () => {
 	});
 
 	it("refuses on 12 when the live head moved past --sha", async () => {
-		const {outcome, calls} = await land([[PULL, pull({head: OTHER_HEAD})]]);
+		const {outcome, calls} = await land([livePull({head: OTHER_HEAD})]);
 		expect(outcome.code).toBe(STALE_HEAD);
 		expect(outcome.stderr.at(-1)).toContain("refusing to merge a tree nobody verified");
 		expect(withoutWrite(calls)).toBe(true);
 	});
 
 	it("refuses an already-merged PR on 7 — an idempotent success is `ship scope`'s answer", async () => {
-		const {outcome} = await land([[PULL, pull({merged: true, state: "closed"})]]);
+		const {outcome} = await land([livePull({merged: true, state: "closed"})]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.at(-1)).toBe("ship merge: PR #4321 is merged — nothing to merge.");
 	});
 
 	it("refuses on 8 when the merge call fails, quoting the status", async () => {
-		const {outcome} = await land(HAPPY_SHELL, [
-			[REPO, repositoryServed()],
+		const {outcome} = await land([
+			...happyReads(),
 			[MERGE, {status: 405, body: '{"message":"Pull Request is not mergeable"}'}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
@@ -163,47 +180,45 @@ describe("runMerge", () => {
 	});
 
 	it("refuses on 8 when the confirming read-back fails — the landing is UNKNOWN", async () => {
-		const {outcome} = await land(HAPPY_SHELL, [
-			[REPO, repositoryServed()],
+		const {outcome} = await land([
+			...happyReads(),
 			MERGED,
-			[PROOF, {status: 503, body: '{"message":"unavailable"}'}],
+			[PULL, {status: 503, body: '{"message":"unavailable"}'}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("the confirming read-back failed");
 	});
 
 	it("refuses on 9 when the read-back names no merge commit — a claim is not evidence", async () => {
-		const {outcome} = await land(HAPPY_SHELL, [
-			[REPO, repositoryServed()],
-			MERGED,
-			[PROOF, mergeProofServed({commit: ""})],
-		]);
+		const {outcome} = await land([...happyReads(), MERGED, [PULL, mergeProofServed({commit: ""})]]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stderr.at(-1)).toContain("the landing is not proven");
 	});
 
 	it("refuses on 9 when the read-back shows the PR is still not merged", async () => {
-		const {outcome} = await land(HAPPY_SHELL, [
-			[REPO, repositoryServed()],
+		const {outcome} = await land([
+			...happyReads(),
 			MERGED,
-			[PROOF, mergeProofServed({merged: false})],
+			[PULL, mergeProofServed({merged: false})],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stderr.at(-1)).toContain("merged: false");
 	});
 
 	it("refuses on 8 when the read-back names no merge state at all — never reading it unmerged", async () => {
-		const {outcome} = await land(HAPPY_SHELL, [
-			[REPO, repositoryServed()],
+		const {outcome} = await land([
+			...happyReads(),
 			MERGED,
-			[PROOF, {status: 200, body: '{"number":4321}'}],
+			[PULL, {status: 200, body: '{"number":4321}'}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("the confirming read-back failed");
 	});
 
 	it("emits the landing object under --json", async () => {
-		const {outcome} = await land(HAPPY_SHELL, HAPPY_HTTP, {json: true});
+		const {outcome} = await land([...happyReads(), MERGED, [PULL, mergeProofServed()]], {
+			json: true,
+		});
 		expect(JSON.parse(outcome.stdout)).toEqual({
 			outcome: "merged",
 			sha: HEAD,

--- a/packages/fabrika-cli/src/ship/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/note-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
@@ -14,15 +14,21 @@ import {
 import {ENV, pull} from "./fixtures.test-support.ts";
 import {runNote} from "./note-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const POST = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments/;
-const READBACK = /^gh api repos\/o\/r\/issues\/comments\/5155001122$/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const POST = /^POST \S+\/repos\/o\/r\/issues\/4321\/comments$/;
+const READBACK = /^GET \S+\/repos\/o\/r\/issues\/comments\/5155001122$/;
 
 const BODY = "ship: refused — head CI red at 9fe12ab0. Merge intent disarmed at site refuse.";
 const URL = "https://github.com/o/r/pull/4321#issuecomment-5155001122";
 
-const created = okOut(JSON.stringify({id: 5155001122, html_url: URL}));
-const landed = (body: string): ExecResult => okOut(JSON.stringify({body}));
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+const created: HttpReply = {
+	status: 201,
+	body: JSON.stringify({id: 5155001122, html_url: URL}),
+};
+const landed = (body: string): HttpReply => ({status: 200, body: JSON.stringify({body})});
 
 const options = {
 	pr: 4321,
@@ -32,16 +38,13 @@ const options = {
 	stdin: Effect.succeed({_tag: "Text", text: BODY} as StdinRead),
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), fakeSeams(script).layer));
 
 describe("runNote", () => {
 	it("posts the note and proves it from a read-back", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[POST, created],
 			[READBACK, landed(BODY)],
 		]);
@@ -51,7 +54,7 @@ describe("runNote", () => {
 
 	it("posts on a merged PR — a refusal at any lifecycle stage still deserves a record", async () => {
 		const out = await run([
-			[PULL, pull({merged: true, state: "closed"})],
+			[PULL, served(pull({merged: true, state: "closed"}))],
 			[POST, created],
 			[READBACK, landed(BODY)],
 		]);
@@ -59,7 +62,7 @@ describe("runNote", () => {
 	});
 
 	it("refuses an empty body on 3 — a silent stop is the #1928 defect", async () => {
-		const out = await run([[PULL, pull()]], {
+		const out = await run([[PULL, served(pull())]], {
 			stdin: Effect.succeed({_tag: "Text", text: "\n\n"} as StdinRead),
 		});
 		expect(out.code).toBe(EMPTY_STDIN);
@@ -67,7 +70,7 @@ describe("runNote", () => {
 	});
 
 	it("refuses a machine-local path on 5, naming the line and class", async () => {
-		const out = await run([[PULL, pull()]], {
+		const out = await run([[PULL, served(pull())]], {
 			stdin: Effect.succeed({_tag: "Text", text: "logs at /tmp/run/out.txt"} as StdinRead),
 		});
 		expect(out.code).toBe(LEAKED_PATH);
@@ -75,7 +78,7 @@ describe("runNote", () => {
 	});
 
 	it("refuses a bare @ reference on 6", async () => {
-		const out = await run([[PULL, pull()]], {
+		const out = await run([[PULL, served(pull())]], {
 			stdin: Effect.succeed({_tag: "Text", text: "@notes/stop.md"} as StdinRead),
 		});
 		expect(out.code).toBe(BARE_AT_PATH);
@@ -83,15 +86,15 @@ describe("runNote", () => {
 
 	it("refuses on 8 when the create fails — UNKNOWN whether it landed", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, served(pull())],
+			[POST, {status: 502, body: "{}"}],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 	});
 
 	it("refuses on 9 when the landed body is not what was sent", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[POST, created],
 			[READBACK, landed("something else entirely")],
 		]);
@@ -103,7 +106,7 @@ describe("runNote", () => {
 
 	it("accepts a read-back that differs only by trailing newlines", async () => {
 		const out = await run([
-			[PULL, pull()],
+			[PULL, served(pull())],
 			[POST, created],
 			[READBACK, landed(`${BODY}\n\n`)],
 		]);
@@ -111,7 +114,7 @@ describe("runNote", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 });

--- a/packages/fabrika-cli/src/ship/nudge-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/nudge-verb.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, type HttpReply, linkNext, once} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, linkNext, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -12,8 +12,8 @@ import {
 import {checkRuns, ENV, HEAD, OTHER_HEAD, pull, workflows} from "./fixtures.test-support.ts";
 import {runNudge} from "./nudge-verb.ts";
 
-/** The live-head read is `../io/pulls.ts`'s, which still shells out to `gh`. */
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/** The live-head read is `../io/pulls.ts`'s, served over HTTP like every other leg. */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
 
 const RUNS = /^GET \S+\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
 const STATUS = /^GET \S+\/repos\/o\/r\/commits\/[0-9a-f]+\/status$/;
@@ -48,25 +48,16 @@ const unexhaustedPage = (): HttpReply => ({
 
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
 
-const both = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
-) => {
-	const shell = fakeShell(rows);
-	const client = fakeHttp(http);
+const both = (rows: ReadonlyArray<Scripted>, http: ReadonlyArray<Scripted>) => {
+	const seams = fakeSeams([...rows, ...http]);
 	return {
-		shell,
-		client,
-		outcome: Effect.runPromise(
-			Effect.provide(runNudge(options), Layer.merge(shell.layer, client.layer)),
-		),
+		seams,
+		outcome: Effect.runPromise(Effect.provide(runNudge(options), seams.layer)),
 	};
 };
 
-const run = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
-) => both(rows, http).outcome;
+const run = (rows: ReadonlyArray<Scripted>, http: ReadonlyArray<Scripted>) =>
+	both(rows, http).outcome;
 
 const preconditionsMet: ReadonlyArray<readonly [RegExp, HttpReply]> = [
 	[RUNS, served(checkRuns(0, []))],
@@ -80,9 +71,9 @@ describe("runNudge", () => {
 	it("closes, verifies, reopens and verifies — both legs read back", async () => {
 		const out = await run(
 			[
-				[once(PULL), pull()],
-				[once(PULL), pull({state: "closed"})],
-				[PULL, pull()],
+				[once(PULL), served(pull())],
+				[once(PULL), served(pull({state: "closed"}))],
+				[PULL, served(pull())],
 			],
 			[...preconditionsMet, [PATCH_PULL, {status: 200, body: "{}"}]],
 		);
@@ -91,18 +82,18 @@ describe("runNudge", () => {
 	});
 
 	it("refuses on 16 when runs already exist at the head — it re-derives, it does not trust (#4816)", async () => {
-		const scripted = both([[PULL, pull()]], [[RUNS, served(checkRuns(14, []))]]);
+		const scripted = both([[PULL, served(pull())]], [[RUNS, served(checkRuns(14, []))]]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(PROVEN_NOT_IN_STATE);
 		expect(out.stderr.at(-1)).toBe(
 			`ship nudge: #4321 is not in the dropped-trigger state (14 check runs exist at ${HEAD}) — refusing to touch it (#4816).`,
 		);
-		expect(scripted.client.calls.some((line) => line.startsWith("PATCH"))).toBe(false);
+		expect(scripted.seams.requests.some((line) => line.startsWith("PATCH"))).toBe(false);
 	});
 
 	it("refuses on 16 when a commit status exists even though check runs do not", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[RUNS, served(checkRuns(0, []))],
 				[STATUS, statusTotal(3)],
@@ -114,7 +105,7 @@ describe("runNudge", () => {
 
 	it("refuses on 16 when the repository declares no workflows at all", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[RUNS, served(checkRuns(0, []))],
 				[STATUS, statusTotal(0)],
@@ -127,7 +118,7 @@ describe("runNudge", () => {
 
 	it("refuses a second nudge on the same head on 16 — escalation, not retry", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[RUNS, served(checkRuns(0, []))],
 				[STATUS, statusTotal(0)],
@@ -141,22 +132,22 @@ describe("runNudge", () => {
 	});
 
 	it("refuses a moved head on 12 — the state diagnosed is another tree's", async () => {
-		const out = await run([[PULL, pull({head: OTHER_HEAD})]], []);
+		const out = await run([[PULL, served(pull({head: OTHER_HEAD}))]], []);
 		expect(out.code).toBe(STALE_HEAD);
 	});
 
 	it("refuses an unreadable precondition on 11 without touching the PR", async () => {
-		const scripted = both([[PULL, pull()]], [[RUNS, badGateway]]);
+		const scripted = both([[PULL, served(pull())]], [[RUNS, badGateway]]);
 		const out = await scripted.outcome;
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(scripted.client.calls.some((line) => line.startsWith("PATCH"))).toBe(false);
+		expect(scripted.seams.requests.some((line) => line.startsWith("PATCH"))).toBe(false);
 	});
 
 	it("returns 17 — the loudest code — when the close landed and the reopen is unconfirmed", async () => {
 		const out = await run(
 			[
-				[once(PULL), pull()],
-				[PULL, pull({state: "closed"})],
+				[once(PULL), served(pull())],
+				[PULL, served(pull({state: "closed"}))],
 			],
 			[
 				...preconditionsMet,
@@ -170,7 +161,7 @@ describe("runNudge", () => {
 
 	it("refuses an unexhausted timeline on 13 — an undercounted history licenses a second nudge", async () => {
 		const scripted = both(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				...preconditionsMet.filter(([pattern]) => pattern !== TIMELINE),
 				[TIMELINE, unexhaustedPage()],
@@ -181,6 +172,6 @@ describe("runNudge", () => {
 		expect(out.stderr.at(-1)).toBe(
 			"ship nudge: the timeline read never reached a terminal page — pagination is unexhausted; refusing to count reopens over a truncated history.",
 		);
-		expect(scripted.client.calls.some((line) => line.startsWith("PATCH"))).toBe(false);
+		expect(scripted.seams.requests.some((line) => line.startsWith("PATCH"))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/ship/reconcile-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/reconcile-verb.unit.test.ts
@@ -1,14 +1,13 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, linkNext} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, linkNext, type Scripted} from "../fakes.test-support.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {ENV, pull} from "./fixtures.test-support.ts";
 import {ADDED, MERGED, REMOVED} from "./queue.ts";
 import {runReconcile} from "./reconcile-verb.ts";
 
-/** The pull read is `../io/pulls.ts`'s, which still shells out to `gh`. */
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/** The pull read is `../io/pulls.ts`'s, and it is served over HTTP. */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
 
 const RULES = /^GET \S+\/repos\/o\/r\/rules\/branches\/main$/;
 const SUBJECTS = /^GET \S+\/repos\/o\/r\/commits\?sha=main/;
@@ -18,16 +17,21 @@ const TIMELINE = /^GET \S+\/repos\/o\/r\/issues\/4321\/timeline\?/;
 const options = {pr: 4321, polls: 1, cadenceSeconds: 0, repo: null, json: false, env: ENV};
 
 const run = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	rows: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
-		Effect.provide(
-			runReconcile({...options, ...overrides}),
-			Layer.merge(fakeShell(rows).layer, fakeHttp(http).layer),
-		),
+		Effect.provide(runReconcile({...options, ...overrides}), fakeSeams([...rows, ...http]).layer),
 	);
+
+/** The PR read, served — the same canned payload the spawner era scripted. */
+const pullServed = (shape: Parameters<typeof pull>[0] = {}): HttpReply => ({
+	status: 200,
+	body: pull(shape).stdout,
+});
+
+const PR = pullServed();
 
 const withQueue: HttpReply = {status: 200, body: JSON.stringify([{type: "merge_queue"}])};
 const offQueue: HttpReply = {status: 200, body: "[]"};
@@ -49,14 +53,17 @@ const unexhaustedPage = (): HttpReply => ({
 
 describe("runReconcile", () => {
 	it("classifies landed off merged:true", async () => {
-		const out = await run([[PULL, pull({merged: true, state: "closed"})]], [[RULES, withQueue]]);
+		const out = await run(
+			[[PULL, pullServed({merged: true, state: "closed"})]],
+			[[RULES, withQueue]],
+		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("reconcile\tlanded\t1\t0\n");
 	});
 
 	it("classifies landed off a base-branch squash whose subject ENDS with the number", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, subjects("fix(x): a thing (#3924) (#4321)")],
@@ -67,7 +74,7 @@ describe("runReconcile", () => {
 
 	it("does NOT credit a landing whose subject merely mentions the number", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, subjects("fix(x): a thing (#4321) (#4999)")],
@@ -79,7 +86,7 @@ describe("runReconcile", () => {
 
 	it("reports `ejected` as a proven answer at exit 0, never an error (#4557)", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, noSubjects],
@@ -98,7 +105,7 @@ describe("runReconcile", () => {
 
 	it("does not call a merge-paired removal an ejection (#4155)", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, noSubjects],
@@ -116,7 +123,7 @@ describe("runReconcile", () => {
 
 	it("reports `parked` when the arm never entered a queue on a queue-governed base", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, noSubjects],
@@ -128,7 +135,7 @@ describe("runReconcile", () => {
 
 	it("reports `unresolved` off a queue, where a long dwell is ordinary", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, offQueue],
 				[SUBJECTS, noSubjects],
@@ -140,7 +147,7 @@ describe("runReconcile", () => {
 
 	it("refuses on 11 when every poll failed to read — UNKNOWN, not `unresolved`", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, noSubjects],
@@ -154,7 +161,7 @@ describe("runReconcile", () => {
 
 	it("refuses an unexhausted timeline on 13 — a truncated history classifies nothing", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[RULES, withQueue],
 				[SUBJECTS, noSubjects],
@@ -169,7 +176,7 @@ describe("runReconcile", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]], []);
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]], []);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 });

--- a/packages/fabrika-cli/src/ship/release-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/release-verb.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply, okOut} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	INCOMPLETE_SCAN,
@@ -13,14 +13,30 @@ import {FLAG_REGISTRY} from "./dark-ship.ts";
 import {ENV, files, issue, pull} from "./fixtures.test-support.ts";
 import {runRelease} from "./release-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
-const DIFF = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
-const LABEL = /^gh api --method POST repos\/o\/r\/issues\/4287\/labels/;
-const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
-/** The registry is read at the base ref over HTTP; every other read here still shells out. */
+/**
+ * The pull record and the unified diff are the same URL under different `Accept` headers, so the
+ * record is scripted `once` and the diff answers every later read of that endpoint.
+ */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const DIFF = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
+const LABELS = /^GET \S+\/repos\/o\/r\/labels\?/;
+const LABEL = /^POST \S+\/repos\/o\/r\/issues\/4287\/labels$/;
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4287$/;
+/** The registry is read at the base ref through the raw media type. */
 const REGISTRY = /contents\/apps\/web\/worker\/features\/flagship\/resources\.ts/;
+
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+/** The verb's first read of the pull request — the record, before the diff of the same URL. */
+const pullRecord = (shape: Parameters<typeof pull>[0] = {}): Scripted => [
+	once(PULL),
+	served(pull(shape)),
+];
+
+/** The diff, served as bytes under the diff media type. */
+const diff = (text: string): Scripted => [DIFF, {status: 200, body: text}];
 
 const REGISTRY_TEXT = `export const flags = [
 	FlagshipFlag("sozluk-vote-widget", {defaultVariation: "off"}),
@@ -34,7 +50,13 @@ const REGISTRY_ABSENT: HttpReply = {status: 404, body: '{"message":"Not Found"}'
 
 const REGISTRY_UNREADABLE: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
-const TAXONOMY = okOut("status:awaiting-release\nstatus:triaged\ntype:bug\n");
+/** The repository's label vocabulary, as the labels endpoint answers it. */
+const taxonomy = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+const TAXONOMY = taxonomy("status:awaiting-release", "status:triaged", "type:bug");
 
 const PLAIN_DIFF = `diff --git a/apps/web/src/App.tsx b/apps/web/src/App.tsx
 +const a = 1;
@@ -47,37 +69,28 @@ const DECLARING_DIFF = `diff --git a/${FLAG_REGISTRY} b/${FLAG_REGISTRY}
 const options = {pr: 4321, repo: null, json: false, env: ENV};
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted> = [],
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
-		Effect.provide(
-			runRelease({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(http).layer),
-		),
+		Effect.provide(runRelease({...options, ...overrides}), fakeSeams([...script, ...http]).layer),
 	);
 
-const runObserved = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
-) => {
-	const shell = fakeShell(script);
-	return Effect.runPromise(
-		Effect.provide(runRelease(options), Layer.merge(shell.layer, fakeHttp(http).layer)),
-	).then((out) => ({out, calls: shell.calls}));
+const runObserved = (script: ReadonlyArray<Scripted>, http: ReadonlyArray<Scripted> = []) => {
+	const seams = fakeSeams([...script, ...http]);
+	return Effect.runPromise(Effect.provide(runRelease(options), seams.layer)).then((out) => ({
+		out,
+		calls: seams.requests,
+	}));
 };
 
-const twoFiles = files("apps/web/src/App.tsx", "README.md");
+const twoFiles = served(files("apps/web/src/App.tsx", "README.md"));
 
 describe("runRelease", () => {
 	it("answers n/a when no signal fires", async () => {
 		const out = await run(
-			[
-				[PULL, pull()],
-				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
-			],
+			[pullRecord(), [FILES, twoFiles], diff(PLAIN_DIFF)],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
 		expect(out.code).toBe(0);
@@ -87,12 +100,12 @@ describe("runRelease", () => {
 	it("queues the linked issue and PROVES the label from a re-read", async () => {
 		const out = await run(
 			[
-				[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+				pullRecord({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"}),
 				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
+				diff(PLAIN_DIFF),
 				[LABELS, TAXONOMY],
-				[LABEL, okOut("[]")],
-				[ISSUE, issue(["status:awaiting-release"])],
+				[LABEL, {status: 200, body: "[]"}],
+				[ISSUE, served(issue(["status:awaiting-release"]))],
 			],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
@@ -101,11 +114,7 @@ describe("runRelease", () => {
 
 	it("answers no-issue — never n/a — when a signal fires with nothing to label", async () => {
 		const out = await run(
-			[
-				[PULL, pull({body: "no closing keyword here"})],
-				[FILES, twoFiles],
-				[DIFF, okOut(DECLARING_DIFF)],
-			],
+			[pullRecord({body: "no closing keyword here"}), [FILES, twoFiles], diff(DECLARING_DIFF)],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
 		expect(out.code).toBe(0);
@@ -115,9 +124,9 @@ describe("runRelease", () => {
 	it("never reads an inherited Containment stamp — the #1257 phantom release", async () => {
 		const out = await run(
 			[
-				[PULL, pull({body: "Fixes #4287\n\n**Containment:** flag (default-off)\n"})],
+				pullRecord({body: "Fixes #4287\n\n**Containment:** flag (default-off)\n"}),
 				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
+				diff(PLAIN_DIFF),
 			],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
@@ -126,11 +135,7 @@ describe("runRelease", () => {
 
 	it("treats an ABSENT registry as a repo without a flag substrate, not as UNKNOWN", async () => {
 		const out = await run(
-			[
-				[PULL, pull()],
-				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
-			],
+			[pullRecord(), [FILES, twoFiles], diff(PLAIN_DIFF)],
 			[[REGISTRY, REGISTRY_ABSENT]],
 		);
 		expect(out.code).toBe(0);
@@ -139,11 +144,7 @@ describe("runRelease", () => {
 
 	it("refuses an UNREADABLE registry on 11 — dark-ship-ness is UNKNOWN, never n/a", async () => {
 		const out = await run(
-			[
-				[PULL, pull()],
-				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
-			],
+			[pullRecord(), [FILES, twoFiles], diff(PLAIN_DIFF)],
 			[[REGISTRY, REGISTRY_UNREADABLE]],
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -151,21 +152,18 @@ describe("runRelease", () => {
 	});
 
 	it("refuses a truncated diff on 13 rather than scanning it for flag signals", async () => {
-		const out = await run([
-			[PULL, pull({changedFiles: 9})],
-			[FILES, files("README.md")],
-		]);
+		const out = await run([pullRecord({changedFiles: 9}), [FILES, served(files("README.md"))]]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
 	it("refuses on 8 when the label write fails — escalate, never `queued`", async () => {
 		const out = await run(
 			[
-				[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+				pullRecord({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"}),
 				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
+				diff(PLAIN_DIFF),
 				[LABELS, TAXONOMY],
-				[LABEL, errOut("gh: Bad gateway (HTTP 502)")],
+				[LABEL, {status: 502, body: '{"message":"Bad gateway"}'}],
 			],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
@@ -176,12 +174,12 @@ describe("runRelease", () => {
 	it("refuses on 9 when the write landed and the read-back does not show the label", async () => {
 		const out = await run(
 			[
-				[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+				pullRecord({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"}),
 				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
+				diff(PLAIN_DIFF),
 				[LABELS, TAXONOMY],
-				[LABEL, okOut("[]")],
-				[ISSUE, issue([])],
+				[LABEL, {status: 200, body: "[]"}],
+				[ISSUE, served(issue([]))],
 			],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
@@ -191,10 +189,10 @@ describe("runRelease", () => {
 	it("refuses on 23 when status:awaiting-release is absent — never minting it (#4285)", async () => {
 		const {out, calls} = await runObserved(
 			[
-				[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+				pullRecord({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"}),
 				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
-				[LABELS, okOut("status:triaged\ntype:bug\n")],
+				diff(PLAIN_DIFF),
+				[LABELS, taxonomy("status:triaged", "type:bug")],
 			],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
@@ -208,10 +206,10 @@ describe("runRelease", () => {
 	it("refuses an unreadable taxonomy on 11 — an unreachable GitHub is not an absent label", async () => {
 		const {out, calls} = await runObserved(
 			[
-				[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+				pullRecord({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"}),
 				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
-				[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+				diff(PLAIN_DIFF),
+				[LABELS, {status: 502, body: '{"message":"Bad gateway"}'}],
 			],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
@@ -222,22 +220,14 @@ describe("runRelease", () => {
 
 	it("reads no taxonomy on the paths that post nothing — n/a and no-issue", async () => {
 		const nonWriting = await runObserved(
-			[
-				[PULL, pull()],
-				[FILES, twoFiles],
-				[DIFF, okOut(PLAIN_DIFF)],
-			],
+			[pullRecord(), [FILES, twoFiles], diff(PLAIN_DIFF)],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
 		expect(nonWriting.out.code).toBe(0);
 		expect(nonWriting.calls.some((line) => LABELS.test(line))).toBe(false);
 
 		const noIssue = await runObserved(
-			[
-				[PULL, pull({body: "no closing keyword here"})],
-				[FILES, twoFiles],
-				[DIFF, okOut(DECLARING_DIFF)],
-			],
+			[pullRecord({body: "no closing keyword here"}), [FILES, twoFiles], diff(DECLARING_DIFF)],
 			[[REGISTRY, REGISTRY_SERVED]],
 		);
 		expect(noIssue.out.code).toBe(0);

--- a/packages/fabrika-cli/src/ship/resolve-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/resolve-verb.unit.test.ts
@@ -1,6 +1,6 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeHttp, fakeShell, type HttpReply, once} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
@@ -15,8 +15,8 @@ import {
 import {ENV, pull, threadPage} from "./fixtures.test-support.ts";
 import {runResolve} from "./resolve-verb.ts";
 
-/** The pull read is `../io/pulls.ts`'s, which still shells out to `gh`. */
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/** The pull read is `../io/pulls.ts`'s, served over HTTP. */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
 
 /**
  * Every thread leg is a POST to the one GraphQL endpoint, so the request line cannot tell them
@@ -77,34 +77,27 @@ const options = {
 };
 
 const both = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	rows: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 ) => {
-	const shell = fakeShell(rows);
-	const client = fakeHttp(http);
+	const seams = fakeSeams([...rows, ...http]);
 	return {
-		shell,
-		client,
-		outcome: Effect.runPromise(
-			Effect.provide(
-				runResolve({...options, ...overrides}),
-				Layer.merge(shell.layer, client.layer),
-			),
-		),
+		seams,
+		outcome: Effect.runPromise(Effect.provide(runResolve({...options, ...overrides}), seams.layer)),
 	};
 };
 
 const run = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]>,
+	rows: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 ) => both(rows, http, overrides).outcome;
 
 describe("runResolve", () => {
 	it("replies, resolves and proves both from a re-read", async () => {
 		const scripted = both(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[graphql(), openBotThread],
 				[graphql(), replied],
@@ -115,13 +108,13 @@ describe("runResolve", () => {
 		const out = await scripted.outcome;
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(`resolved\tPRRT_kwDOLxx1\t${URL}\n`);
-		expect(scripted.client.bodies[1]).toContain("addPullRequestReviewThreadReply");
-		expect(scripted.client.bodies[2]).toContain("resolveReviewThread");
+		expect(scripted.seams.bodies[2]).toContain("addPullRequestReviewThreadReply");
+		expect(scripted.seams.bodies[3]).toContain("resolveReviewThread");
 	});
 
 	it("refuses a thread with any non-Bot author on 16 — a human objection is theirs", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[
 					graphql(),
@@ -142,7 +135,7 @@ describe("runResolve", () => {
 
 	it("refuses an already-resolved thread on 16", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[
 					graphql(),
@@ -159,12 +152,12 @@ describe("runResolve", () => {
 	});
 
 	it("refuses a thread absent from the PR on 7", async () => {
-		const out = await run([[PULL, pull()]], [[graphql(), served(threadPage(0, []))]]);
+		const out = await run([[PULL, served(pull())]], [[graphql(), served(threadPage(0, []))]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 
 	it("refuses an empty rationale on 3 — a silent resolve is unauditable", async () => {
-		const out = await run([[PULL, pull()]], [], {
+		const out = await run([[PULL, served(pull())]], [], {
 			stdin: Effect.succeed({_tag: "Text", text: "   "} as StdinRead),
 		});
 		expect(out.code).toBe(EMPTY_STDIN);
@@ -172,7 +165,7 @@ describe("runResolve", () => {
 	});
 
 	it("refuses a machine-local path in the rationale on 5", async () => {
-		const out = await run([[PULL, pull()]], [], {
+		const out = await run([[PULL, served(pull())]], [], {
 			stdin: Effect.succeed({_tag: "Text", text: "see /Users/someone/notes.md"} as StdinRead),
 		});
 		expect(out.code).toBe(LEAKED_PATH);
@@ -180,7 +173,7 @@ describe("runResolve", () => {
 	});
 
 	it("refuses a bare @ reference on 6 — the bytes never arrived", async () => {
-		const out = await run([[PULL, pull()]], [], {
+		const out = await run([[PULL, served(pull())]], [], {
 			stdin: Effect.succeed({_tag: "Text", text: "@notes/rationale.md"} as StdinRead),
 		});
 		expect(out.code).toBe(BARE_AT_PATH);
@@ -188,7 +181,7 @@ describe("runResolve", () => {
 
 	it("refuses on 8 when the reply itself fails — UNKNOWN what landed", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[graphql(), openBotThread],
 				[graphql(), badGateway],
@@ -200,7 +193,7 @@ describe("runResolve", () => {
 
 	it("refuses on 9 when the write landed and the read-back does not show it resolved", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, served(pull())]],
 			[
 				[graphql(), openBotThread],
 				[graphql(), replied],

--- a/packages/fabrika-cli/src/ship/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/scope-verb.unit.test.ts
@@ -1,13 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {
-	errOut,
-	fakeHttp,
-	fakeShell,
-	type HttpReply,
-	okOut,
-	unconfigured,
-} from "../fakes.test-support.ts";
+import {fakeSeams, type HttpReply, type Scripted, unconfigured} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
@@ -21,33 +14,42 @@ import {
 } from "./fixtures.test-support.ts";
 import {runScope} from "./scope-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
 const OWNERS = /contents\/\.github\/CODEOWNERS/;
-const RULES = /^gh api repos\/o\/r\/rules\/branches\/main$/;
+const RULES = /^GET \S+\/repos\/o\/r\/rules\/branches\/main/;
 const REPO = /^GET https:\/\/api\.github\.com\/repos\/o\/r$/;
 const CONFIG = /contents\/\.fabrika\.jsonc/;
+
+/** A canned `ExecResult` fixture as the body of a 200 — the same payload, off the served seam. */
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+/** A file served through the raw media type, which hands back bytes rather than JSON. */
+const raw = (body: string): HttpReply => ({status: 200, body});
+
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const BAD_GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
 
 const options = {pr: 4321, repo: null, json: false, cwd: "/repo", env: ENV};
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
-	served: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	extra: ReadonlyArray<Scripted> = [],
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runScope({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(script).layer, unconfigured, fakeHttp(served).layer),
+			Layer.merge(fakeSeams([...script, ...extra]).layer, unconfigured),
 		),
 	);
 
 describe("runScope", () => {
 	it("renders a partial split as `part-of:<n>` — the marker resolves at this seam as it does at review's", async () => {
 		const out = await run([
-			[PULL, pull({body: "does things\n\nPart of #4000\n"})],
-			[FILES, files("apps/web/worker/cart.ts", "README.md")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull({body: "does things\n\nPart of #4000\n"}))],
+			[FILES, served(files("apps/web/worker/cart.ts", "README.md"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.stdout.split("\n")[0]).toBe(`scoped\t${HEAD}\topen\tpart-of:4000`);
 	});
@@ -55,10 +57,10 @@ describe("runScope", () => {
 	it("prints one derivation: state, issue ref, classes, the namespaces they require, cp, landing and count", async () => {
 		const out = await run(
 			[
-				[PULL, pull()],
-				[FILES, files("apps/web/src/App.tsx", "README.md")],
-				[OWNERS, okOut(CODEOWNERS)],
-				[RULES, branchRules("pull_request")],
+				[PULL, served(pull())],
+				[FILES, served(files("apps/web/src/App.tsx", "README.md"))],
+				[OWNERS, raw(CODEOWNERS)],
+				[RULES, served(branchRules("pull_request"))],
 			],
 			{},
 			[[REPO, repositoryServed()]],
@@ -83,10 +85,10 @@ describe("runScope", () => {
 
 	it("names the queue path when a queue governs the base — the shipper's route, read once", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, files("README.md", "DEVELOPMENT.md")],
-			[OWNERS, okOut(CODEOWNERS)],
-			[RULES, branchRules("merge_queue")],
+			[PULL, served(pull())],
+			[FILES, served(files("README.md", "DEVELOPMENT.md"))],
+			[OWNERS, raw(CODEOWNERS)],
+			[RULES, served(branchRules("merge_queue"))],
 		]);
 		expect(out.stdout).toContain(`landing\tqueue\t-\n`);
 	});
@@ -97,10 +99,10 @@ describe("runScope", () => {
 	 */
 	it("prints `unknown` and still answers when the landing path cannot be read", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, files("README.md", "DEVELOPMENT.md")],
-			[OWNERS, okOut(CODEOWNERS)],
-			[RULES, errOut("HTTP 503")],
+			[PULL, served(pull())],
+			[FILES, served(files("README.md", "DEVELOPMENT.md"))],
+			[OWNERS, raw(CODEOWNERS)],
+			[RULES, {status: 503, body: '{"message":"unavailable"}'}],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain(`landing\tunknown\t-\n`);
@@ -109,18 +111,18 @@ describe("runScope", () => {
 
 	it("derives review-ui from a rendered surface but not from its own test file", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, files("apps/web/src/App.tsx", "apps/web/src/App.test.tsx")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull())],
+			[FILES, served(files("apps/web/src/App.tsx", "apps/web/src/App.test.tsx"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.stdout).toContain("class\tui\t1");
 	});
 
 	it("prints governance beside the class namespaces when the diff touches a governance root", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, files(".decisions/0244-corpus-review.md", "README.md")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull())],
+			[FILES, served(files(".decisions/0244-corpus-review.md", "README.md"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.stdout).toContain("namespace\tgovernance");
 		// One class here, so the whole namespace block is exactly these two lines, in this order.
@@ -129,18 +131,18 @@ describe("runScope", () => {
 
 	it("prints no governance line for a diff under no governance root", async () => {
 		const out = await run([
-			[PULL, pull()],
-			[FILES, files("apps/web/src/App.tsx", "README.md")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull())],
+			[FILES, served(files("apps/web/src/App.tsx", "README.md"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.stdout).not.toContain("governance");
 	});
 
 	it("reports a merged PR as an ANSWER, not a refusal", async () => {
 		const out = await run([
-			[PULL, pull({merged: true, state: "closed", changedFiles: 1})],
-			[FILES, files("README.md")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull({merged: true, state: "closed", changedFiles: 1}))],
+			[FILES, served(files("README.md"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toContain("\tmerged\t");
@@ -148,27 +150,27 @@ describe("runScope", () => {
 
 	it("reports a draft PR as an answer too", async () => {
 		const out = await run([
-			[PULL, pull({draft: true, changedFiles: 1})],
-			[FILES, files("README.md")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull({draft: true, changedFiles: 1}))],
+			[FILES, served(files("README.md"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.stdout.split("\n")[0]).toContain("\tdraft\t");
 	});
 
 	it("classifies a control-plane path off CODEOWNERS itself", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
-			[FILES, files(".github/workflows/ci.yml")],
-			[OWNERS, okOut(CODEOWNERS)],
+			[PULL, served(pull({changedFiles: 1}))],
+			[FILES, served(files(".github/workflows/ci.yml"))],
+			[OWNERS, raw(CODEOWNERS)],
 		]);
 		expect(out.stdout).toContain("cp\tcontrol-plane");
 	});
 
 	it("holds on unknown when the boundary is proven absent — never match-everything", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
-			[FILES, files("README.md")],
-			[OWNERS, errOut("gh: Not Found (HTTP 404)")],
+			[PULL, served(pull({changedFiles: 1}))],
+			[FILES, served(files("README.md"))],
+			[OWNERS, NOT_FOUND],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("cp\tunknown");
@@ -176,9 +178,9 @@ describe("runScope", () => {
 
 	it("still holds on unknown for a boundary that reads fine and bounds nothing", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
-			[FILES, files("README.md")],
-			[OWNERS, okOut("/a/ owner@example.test\n")],
+			[PULL, served(pull({changedFiles: 1}))],
+			[FILES, served(files("README.md"))],
+			[OWNERS, raw("/a/ owner@example.test\n")],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("cp\tunknown");
@@ -186,9 +188,9 @@ describe("runScope", () => {
 
 	it("refuses an UNREADABLE boundary on 11 — a failed read is not `unknown`", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
-			[FILES, files("README.md")],
-			[OWNERS, errOut("gh: Bad gateway (HTTP 502)")],
+			[PULL, served(pull({changedFiles: 1}))],
+			[FILES, served(files("README.md"))],
+			[OWNERS, BAD_GATEWAY],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -197,10 +199,10 @@ describe("runScope", () => {
 
 	it("refuses a failed read whatever the repo's config says — never `not-control-plane`", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 1})],
-			[FILES, files("README.md")],
-			[OWNERS, errOut("gh: Bad gateway (HTTP 502)")],
-			[CONFIG, okOut('{"unreadableCodeowners": "ship"}')],
+			[PULL, served(pull({changedFiles: 1}))],
+			[FILES, served(files("README.md"))],
+			[OWNERS, BAD_GATEWAY],
+			[CONFIG, raw('{"unreadableCodeowners": "ship"}')],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -208,8 +210,8 @@ describe("runScope", () => {
 
 	it("refuses zero changed files on 7", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 0})],
-			[FILES, files()],
+			[PULL, served(pull({changedFiles: 0}))],
+			[FILES, served(files())],
 		]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe(
@@ -219,8 +221,8 @@ describe("runScope", () => {
 
 	it("refuses a truncated file list on 13 rather than partitioning it", async () => {
 		const out = await run([
-			[PULL, pull({changedFiles: 9})],
-			[FILES, files("README.md")],
+			[PULL, served(pull({changedFiles: 9}))],
+			[FILES, served(files("README.md"))],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
@@ -230,7 +232,7 @@ describe("runScope", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("ship scope: PR #4321 not found in o/r.");
 	});

--- a/packages/fabrika-cli/src/ship/threads-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/threads-verb.unit.test.ts
@@ -1,14 +1,16 @@
-import {Effect, Layer} from "effect";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeHttp, fakeShell, type HttpReply} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {ENV, pull, threadPage} from "./fixtures.test-support.ts";
 import {runThreads} from "./threads-verb.ts";
 
-const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-/** The thread enumeration is the GraphQL carve, and it is HTTP now — the PR read still shells. */
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+/** The thread enumeration is the GraphQL carve. */
 const GRAPHQL = /^POST https:\/\/api\.github\.com\/graphql$/;
+
+/** The PR read, served — the same canned payload the spawner era scripted. */
+const PR: HttpReply = {status: 200, body: pull().stdout};
 
 /** One served thread page, as the endpoint answers it. */
 const threads = (declared: number, nodes: Parameters<typeof threadPage>[1]): HttpReply => ({
@@ -19,15 +21,12 @@ const threads = (declared: number, nodes: Parameters<typeof threadPage>[1]): Htt
 const options = {pr: 4321, repo: null, json: false, env: ENV};
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	http: ReadonlyArray<readonly [RegExp, HttpReply]> = [],
+	script: ReadonlyArray<Scripted>,
+	http: ReadonlyArray<Scripted> = [],
 	overrides: Partial<typeof options> = {},
 ) =>
 	Effect.runPromise(
-		Effect.provide(
-			runThreads({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeHttp(http).layer),
-		),
+		Effect.provide(runThreads({...options, ...overrides}), fakeSeams([...script, ...http]).layer),
 	);
 
 const bot = {login: "github-advanced-security", typename: "Bot"};
@@ -35,14 +34,14 @@ const human = {login: "cansirin", typename: "User"};
 
 describe("runThreads", () => {
 	it("prints a proven zero rather than an empty answer", async () => {
-		const out = await run([[PULL, pull()]], [[GRAPHQL, threads(0, [])]]);
+		const out = await run([[PULL, PR]], [[GRAPHQL, threads(0, [])]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("threads\t0\n");
 	});
 
 	it("classes a thread bot only when EVERY author is a Bot", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[
 					GRAPHQL,
@@ -68,7 +67,7 @@ describe("runThreads", () => {
 
 	it("classes a bot thread HUMAN once a human replies — v1's first-comment-only hole", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[
 					GRAPHQL,
@@ -91,7 +90,7 @@ describe("runThreads", () => {
 
 	it("classes an unrecognised author type as human by construction, never by enumeration", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[
 					GRAPHQL,
@@ -104,7 +103,7 @@ describe("runThreads", () => {
 
 	it("omits resolved threads from the count without dropping them from the scan", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[
 				[
 					GRAPHQL,
@@ -121,7 +120,7 @@ describe("runThreads", () => {
 
 	it("refuses a short thread enumeration on 13", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[[GRAPHQL, threads(9, [{id: "T1", comments: [{...bot, body: "x"}]}])]],
 		);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
@@ -130,7 +129,7 @@ describe("runThreads", () => {
 
 	it("refuses a short COMMENT enumeration on 13 — the second pagination layer", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[[GRAPHQL, threads(1, [{id: "T1", declaredComments: 4, comments: [{...bot, body: "x"}]}])]],
 		);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
@@ -139,7 +138,7 @@ describe("runThreads", () => {
 
 	it("refuses an unreadable payload on 11 — UNKNOWN, never zero", async () => {
 		const out = await run(
-			[[PULL, pull()]],
+			[[PULL, PR]],
 			[[GRAPHQL, {status: 502, body: '{"message":"Bad gateway"}'}]],
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -148,7 +147,7 @@ describe("runThreads", () => {
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
-		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[PULL, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 });

--- a/packages/fabrika-cli/src/spike/capture-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/capture-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {type FakeFsOptions, fakeFs, fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {captureComment, captureMarker, forfeitMarker, WORKSPACE_MASK} from "./bodies.ts";
 import {runCapture} from "./capture-verb.ts";
@@ -69,33 +68,39 @@ const options = {
 	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: DECISION}),
 };
 
-const identity: ReadonlyArray<readonly [RegExp, ExecResult]> = [
-	[VIEWER, okOut("agent")],
-	[PERMISSION, okOut("write")],
+const identity: ReadonlyArray<Scripted> = [
+	[VIEWER, {status: 200, body: '{"login":"agent"}'}],
+	[PERMISSION, {status: 200, body: '{"permission":"write"}'}],
 ];
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	...identity,
-	[ISSUE, okOut(issuePayload())],
-	[COMMENTS, okOut(commentsPayload([]))],
-	[POST, okOut(JSON.stringify({id: 512347, html_url: "https://example.test/#c"}))],
-	[READBACK, okOut(JSON.stringify({body: BODY}))],
-	[CLOSE, okOut("{}")],
+	[ISSUE, {status: 200, body: issuePayload()}],
+	[COMMENTS, {status: 200, body: commentsPayload([])}],
+	[POST, {status: 201, body: JSON.stringify({id: 512347, html_url: "https://example.test/#c"})}],
+	[READBACK, {status: 200, body: JSON.stringify({body: BODY})}],
+	[CLOSE, {status: 200, body: "{}"}],
 ];
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	fs: FakeFsOptions = resident,
 ) => {
-	const shell = fakeShell(script);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
 		Effect.provide(
 			runCapture({...options, ...overrides}),
-			Layer.merge(fakeFs(fs).layer, shell.layer),
+			Layer.merge(fakeFs(fs).layer, seams.layer),
 		),
-	).then((outcome) => ({outcome, calls: shell.calls}));
+	).then((outcome) => ({outcome, requests: seams.requests, bodies: seams.bodies}));
 };
+
+/** What the one POST carried, or `""` when none was issued. */
+const postedBody = (run: {
+	readonly requests: ReadonlyArray<string>;
+	readonly bodies: ReadonlyArray<string>;
+}): string => run.bodies[run.requests.findIndex((line) => POST.test(line))] ?? "";
 
 describe("runCapture records a decision the log grounds", () => {
 	it("posts, reads back, closes and answers", async () => {
@@ -113,8 +118,7 @@ describe("runCapture records a decision the log grounds", () => {
 	});
 
 	it("transcribes the run table beside the decision", async () => {
-		const {calls} = await run(happy);
-		const posted = calls.find((line) => POST.test(line)) ?? "";
+		const posted = postedBody(await run(happy));
 		expect(posted).toContain("## Runs");
 		expect(posted).toContain("printf");
 	});
@@ -129,14 +133,17 @@ describe("runCapture records a decision the log grounds", () => {
 			records,
 			workspace: LEAKY_WORKSPACE,
 		});
-		const {outcome, calls} = await run(
+		const posting = await run(
 			[
 				...identity,
-				[ISSUE, okOut(issuePayload())],
-				[COMMENTS, okOut(commentsPayload([]))],
-				[POST, okOut(JSON.stringify({id: 512349, html_url: "https://example.test/#c"}))],
-				[READBACK, okOut(JSON.stringify({body}))],
-				[CLOSE, okOut("{}")],
+				[ISSUE, {status: 200, body: issuePayload()}],
+				[COMMENTS, {status: 200, body: commentsPayload([])}],
+				[
+					POST,
+					{status: 201, body: JSON.stringify({id: 512349, html_url: "https://example.test/#c"})},
+				],
+				[READBACK, {status: 200, body: JSON.stringify({body})}],
+				[CLOSE, {status: 200, body: "{}"}],
 			],
 			{tmpRoot: LEAKY_TMP_ROOT},
 			{
@@ -144,8 +151,8 @@ describe("runCapture records a decision the log grounds", () => {
 				files: {[LEAKY_MANIFEST]: manifestText(), [LEAKY_EVIDENCE]: log},
 			},
 		);
-		expect(outcome.code).toBe(0);
-		const posted = calls.find((line) => POST.test(line)) ?? "";
+		expect(posting.outcome.code).toBe(0);
+		const posted = postedBody(posting);
 		expect(posted).toContain(`${WORKSPACE_MASK}/probe.sh`);
 		expect(posted).not.toContain(LEAKY_WORKSPACE);
 	});
@@ -153,7 +160,7 @@ describe("runCapture records a decision the log grounds", () => {
 
 describe("runCapture reds on zero scope — the precondition it most exists for", () => {
 	it("refuses a log with zero recorded runs on 14, naming both ways forward", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests} = await run(
 			happy,
 			{},
 			{...resident, files: {[MANIFEST]: manifestText()}},
@@ -162,7 +169,7 @@ describe("runCapture reds on zero scope — the precondition it most exists for"
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.join("\n")).toContain("spike run");
 		expect(outcome.stderr.join("\n")).toContain("--forfeit");
-		expect(calls.filter((line) => POST.test(line))).toHaveLength(0);
+		expect(requests.filter((line) => POST.test(line))).toHaveLength(0);
 	});
 });
 
@@ -185,13 +192,16 @@ describe("runCapture refuses on the authored text before it reads anything", () 
 
 describe("runCapture splits a proven absence from a failed read", () => {
 	it("seats a 404 on 7", async () => {
-		const {outcome} = await run([...identity, [ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const {outcome} = await run([
+			...identity,
+			[ISSUE, {status: 404, body: '{"message":"Not Found"}'}],
+		]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.join("\n")).toContain("proven absent");
 	});
 
 	it("seats any other read failure on 11", async () => {
-		const {outcome} = await run([...identity, [ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const {outcome} = await run([...identity, [ISSUE, {status: 502, body: "{}"}]]);
 		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("never granted");
 	});
@@ -213,22 +223,22 @@ describe("runCapture splits a proven absence from a failed read", () => {
 
 describe("the ACL gate precedes every write, on every path (ADR 0055)", () => {
 	it("refuses an author below write on 19", async () => {
-		const {outcome, calls} = await run([
-			[VIEWER, okOut("agent")],
-			[PERMISSION, okOut("read")],
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
+		const {outcome, requests} = await run([
+			[VIEWER, {status: 200, body: '{"login":"agent"}'}],
+			[PERMISSION, {status: 200, body: '{"permission":"read"}'}],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
 		]);
 		expect(outcome.code).toBe(AUTHOR_UNAUTHORIZED);
-		expect(calls.filter((line) => POST.test(line) || CLOSE.test(line))).toHaveLength(0);
+		expect(requests.filter((line) => POST.test(line) || CLOSE.test(line))).toHaveLength(0);
 	});
 
 	it("seats a permission read that failed on 11 — UNKNOWN, never a grant", async () => {
 		const {outcome} = await run([
-			[VIEWER, okOut("agent")],
-			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
+			[VIEWER, {status: 200, body: '{"login":"agent"}'}],
+			[PERMISSION, {status: 502, body: "{}"}],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
 		]);
 		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
 	});
@@ -238,37 +248,46 @@ describe("runCapture's re-entry turns on the newest marker for this nonce", () =
 	const marked = (digest: string, state = "open") =>
 		[
 			...identity,
-			[ISSUE, okOut(issuePayload({state}))],
-			[COMMENTS, okOut(commentsPayload([{id: 500, body: `${captureMarker(NONCE, digest)}\n`}]))],
-			[POST, okOut(JSON.stringify({id: 512348, html_url: "https://example.test/#c"}))],
-			[READBACK, okOut(JSON.stringify({body: BODY}))],
-			[CLOSE, okOut("{}")],
-		] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+			[ISSUE, {status: 200, body: issuePayload({state})}],
+			[
+				COMMENTS,
+				{
+					status: 200,
+					body: commentsPayload([{id: 500, body: `${captureMarker(NONCE, digest)}\n`}]),
+				},
+			],
+			[
+				POST,
+				{status: 201, body: JSON.stringify({id: 512348, html_url: "https://example.test/#c"})},
+			],
+			[READBACK, {status: 200, body: JSON.stringify({body: BODY})}],
+			[CLOSE, {status: 200, body: "{}"}],
+		] as ReadonlyArray<Scripted>;
 
 	it("posts nothing when the marker already covers this log, and says the stdin was discarded", async () => {
-		const {outcome, calls} = await run(marked(ONE_RUN_DIGEST));
+		const {outcome, requests} = await run(marked(ONE_RUN_DIGEST));
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({commentId: 500, discardedStdin: true});
-		expect(calls.filter((line) => POST.test(line))).toHaveLength(0);
+		expect(requests.filter((line) => POST.test(line))).toHaveLength(0);
 	});
 
 	it("ensures the close even on that branch, so a re-run after a failed close is safe", async () => {
-		const {calls} = await run(marked(ONE_RUN_DIGEST));
-		expect(calls.filter((line) => CLOSE.test(line))).toHaveLength(1);
+		const {requests} = await run(marked(ONE_RUN_DIGEST));
+		expect(requests.filter((line) => CLOSE.test(line))).toHaveLength(1);
 	});
 
 	it("supersedes a marker whose digest differs, and closes either way", async () => {
-		const {outcome, calls} = await run(marked("a".repeat(64), "closed"));
+		const {outcome, requests} = await run(marked("a".repeat(64), "closed"));
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({commentId: 512348, discardedStdin: false});
-		expect(calls.filter((line) => POST.test(line))).toHaveLength(1);
+		expect(requests.filter((line) => POST.test(line))).toHaveLength(1);
 	});
 
 	it("refuses a closed spike carrying no marker for this nonce on 7", async () => {
 		const {outcome} = await run([
 			...identity,
-			[ISSUE, okOut(issuePayload({state: "closed"}))],
-			[COMMENTS, okOut(commentsPayload([{id: 500, body: forfeitMarker(NONCE, 1)}]))],
+			[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+			[COMMENTS, {status: 200, body: commentsPayload([{id: 500, body: forfeitMarker(NONCE, 1)}])}],
 		]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.join("\n")).toContain("nothing to supersede");
@@ -279,9 +298,9 @@ describe("runCapture proves the comment landed", () => {
 	it("seats an unproven post on 8", async () => {
 		const {outcome} = await run([
 			...identity,
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
-			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
+			[POST, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("may or may not have landed");
@@ -290,10 +309,13 @@ describe("runCapture proves the comment landed", () => {
 	it("seats a read-back that differs on 9", async () => {
 		const {outcome} = await run([
 			...identity,
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
-			[POST, okOut(JSON.stringify({id: 512347, html_url: "https://example.test/#c"}))],
-			[READBACK, okOut(JSON.stringify({body: "somebody edited it"}))],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
+			[
+				POST,
+				{status: 201, body: JSON.stringify({id: 512347, html_url: "https://example.test/#c"})},
+			],
+			[READBACK, {status: 200, body: JSON.stringify({body: "somebody edited it"})}],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 	});
@@ -301,11 +323,14 @@ describe("runCapture proves the comment landed", () => {
 	it("seats a failed close on 8 while saying the decision DID land", async () => {
 		const {outcome} = await run([
 			...identity,
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
-			[once(POST), okOut(JSON.stringify({id: 512347, html_url: "https://example.test/#c"}))],
-			[READBACK, okOut(JSON.stringify({body: BODY}))],
-			[CLOSE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
+			[
+				once(POST),
+				{status: 201, body: JSON.stringify({id: 512347, html_url: "https://example.test/#c"})},
+			],
+			[READBACK, {status: 200, body: JSON.stringify({body: BODY})}],
+			[CLOSE, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("IS on the record");

--- a/packages/fabrika-cli/src/spike/dispose-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/dispose-verb.unit.test.ts
@@ -1,7 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {
+	errOut,
+	type FakeFsOptions,
+	fakeFs,
+	fakeSeams,
+	okOut,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import {captureMarker, forfeitNote} from "./bodies.ts";
 import {
 	CAPTURE_STALE,
@@ -59,24 +65,24 @@ const options = {
 
 const CAPTURED = commentsPayload([{id: 500, body: `${captureMarker(NONCE, ONE_RUN_DIGEST)}\n`}]);
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	[STATUS, okOut("")],
-	[ISSUE, okOut(issuePayload({state: "closed"}))],
-	[COMMENTS, okOut(CAPTURED)],
+	[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+	[COMMENTS, {status: 200, body: CAPTURED}],
 ];
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	fs: FakeFsOptions = resident,
 ) => {
-	const shell = fakeShell(script);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
 		Effect.provide(
 			runDispose({...options, ...overrides}),
-			Layer.merge(fakeFs(fs).layer, shell.layer),
+			Layer.merge(fakeFs(fs).layer, seams.layer),
 		),
-	).then((outcome) => ({outcome, calls: shell.calls}));
+	).then((outcome) => ({outcome, requests: seams.requests, bodies: seams.bodies}));
 };
 
 describe("runDispose removes a captured spike's workspace and proves it is gone", () => {
@@ -108,16 +114,16 @@ describe("runDispose removes a captured spike's workspace and proves it is gone"
 describe("the tree comparison runs first, so a 17 never destroys the leak it found", () => {
 	const dirty = [
 		[STATUS, okOut("?? apps/web/src/probe.ts\n!! node_modules/\n")],
-		[ISSUE, okOut(issuePayload({state: "closed"}))],
-		[COMMENTS, okOut(CAPTURED)],
-	] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+		[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+		[COMMENTS, {status: 200, body: CAPTURED}],
+	] as ReadonlyArray<Scripted>;
 
 	it("refuses on 17 with the workspace intact and nothing posted", async () => {
-		const {outcome, calls} = await run(dirty, {forfeit: true});
+		const {outcome, requests} = await run(dirty, {forfeit: true});
 		expect(outcome.code).toBe(TREE_MOVED);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.join("\n")).toContain("NOT removed");
-		expect(calls.filter((line) => POST.test(line))).toHaveLength(0);
+		expect(requests.filter((line) => POST.test(line))).toHaveLength(0);
 	});
 
 	it("enumerates every differing line, not only the first", async () => {
@@ -129,8 +135,8 @@ describe("the tree comparison runs first, so a 17 never destroys the leak it fou
 	it("counts an ignored path — the check has no hole where prototypes write", async () => {
 		const {outcome} = await run([
 			[STATUS, okOut("!! dist/\n")],
-			[ISSUE, okOut(issuePayload({state: "closed"}))],
-			[COMMENTS, okOut(CAPTURED)],
+			[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+			[COMMENTS, {status: 200, body: CAPTURED}],
 		]);
 		expect(outcome.code).toBe(TREE_MOVED);
 	});
@@ -145,8 +151,8 @@ describe("runDispose refuses to destroy what a decision would rest on", () => {
 	it("seats an uncaptured spike on 15, naming both ways forward", async () => {
 		const {outcome} = await run([
 			[STATUS, okOut("")],
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
 		]);
 		expect(outcome.code).toBe(NOT_CAPTURED);
 		expect(outcome.stderr.join("\n")).toContain("--forfeit");
@@ -155,20 +161,32 @@ describe("runDispose refuses to destroy what a decision would rest on", () => {
 	it("seats a capture that no longer covers the log on 21, forfeit or not", async () => {
 		const stale = [
 			[STATUS, okOut("")],
-			[ISSUE, okOut(issuePayload({state: "closed"}))],
-			[COMMENTS, okOut(commentsPayload([{id: 500, body: captureMarker(NONCE, "a".repeat(64))}]))],
-		] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+			[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+			[
+				COMMENTS,
+				{
+					status: 200,
+					body: commentsPayload([{id: 500, body: captureMarker(NONCE, "a".repeat(64))}]),
+				},
+			],
+		] as ReadonlyArray<Scripted>;
 		expect((await run(stale)).outcome.code).toBe(CAPTURE_STALE);
 		const forfeited = await run(stale, {forfeit: true});
 		expect(forfeited.outcome.code).toBe(CAPTURE_STALE);
-		expect(forfeited.calls.filter((line) => POST.test(line))).toHaveLength(0);
+		expect(forfeited.requests.filter((line) => POST.test(line))).toHaveLength(0);
 	});
 
 	it("names the human escalation a 19 on capture would force", async () => {
 		const {outcome} = await run([
 			[STATUS, okOut("")],
-			[ISSUE, okOut(issuePayload({state: "closed"}))],
-			[COMMENTS, okOut(commentsPayload([{id: 500, body: captureMarker(NONCE, "a".repeat(64))}]))],
+			[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+			[
+				COMMENTS,
+				{
+					status: 200,
+					body: commentsPayload([{id: 500, body: captureMarker(NONCE, "a".repeat(64))}]),
+				},
+			],
 		]);
 		expect(outcome.stderr.join("\n")).toContain("someone holding write");
 	});
@@ -185,34 +203,34 @@ describe("runDispose refuses to destroy what a decision would rest on", () => {
 });
 
 describe("--forfeit abandons the spike on the record before disposing", () => {
-	const forfeitScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	const forfeitScript: ReadonlyArray<Scripted> = [
 		[STATUS, okOut("")],
-		[ISSUE, okOut(issuePayload())],
-		[COMMENTS, okOut(commentsPayload([]))],
-		[POST, okOut(JSON.stringify({id: 700, html_url: "https://example.test/#c"}))],
-		[READBACK, okOut(JSON.stringify({body: NOTE}))],
-		[CLOSE, okOut("{}")],
+		[ISSUE, {status: 200, body: issuePayload()}],
+		[COMMENTS, {status: 200, body: commentsPayload([])}],
+		[POST, {status: 201, body: JSON.stringify({id: 700, html_url: "https://example.test/#c"})}],
+		[READBACK, {status: 200, body: JSON.stringify({body: NOTE})}],
+		[CLOSE, {status: 200, body: "{}"}],
 	];
 
 	it("posts the note, closes, disposes and says so", async () => {
-		const {outcome, calls} = await run(forfeitScript, {forfeit: true});
+		const {outcome, requests} = await run(forfeitScript, {forfeit: true});
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).forfeited).toBe(true);
-		expect(calls.filter((line) => CLOSE.test(line))).toHaveLength(1);
+		expect(requests.filter((line) => CLOSE.test(line))).toHaveLength(1);
 	});
 
 	it("reads the question from the manifest — dispose takes no --question", async () => {
-		const {calls} = await run(forfeitScript, {forfeit: true});
-		expect(calls.find((line) => POST.test(line))).toContain(QUESTION);
+		const {requests, bodies} = await run(forfeitScript, {forfeit: true});
+		expect(bodies[requests.findIndex((line) => POST.test(line))]).toContain(QUESTION);
 	});
 
 	it("seats an unproven post on 8 with nothing removed", async () => {
 		const {outcome} = await run(
 			[
 				[STATUS, okOut("")],
-				[ISSUE, okOut(issuePayload())],
-				[COMMENTS, okOut(commentsPayload([]))],
-				[POST, errOut("gh: Bad gateway (HTTP 502)")],
+				[ISSUE, {status: 200, body: issuePayload()}],
+				[COMMENTS, {status: 200, body: commentsPayload([])}],
+				[POST, {status: 502, body: "{}"}],
 			],
 			{forfeit: true},
 		);
@@ -223,7 +241,7 @@ describe("--forfeit abandons the spike on the record before disposing", () => {
 
 describe("a provisional manifest skips the issue half entirely", () => {
 	it("disposes an orphaned workspace with no GitHub read at all", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests} = await run(
 			[[STATUS, okOut("")]],
 			{},
 			{
@@ -233,6 +251,6 @@ describe("a provisional manifest skips the issue half entirely", () => {
 		);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({spike: null, runs: 0, forfeited: false});
-		expect(calls.filter((line) => line.startsWith("gh "))).toHaveLength(0);
+		expect(requests).toHaveLength(0);
 	});
 });

--- a/packages/fabrika-cli/src/spike/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/spike/fixtures.test-support.ts
@@ -111,16 +111,33 @@ export const commentsPayload = (
 		})),
 	);
 
+/** Every label name a `listLabels` read parses out of, as GitHub serves them. */
+export const labelsPayload = (...names: ReadonlyArray<string>): string =>
+	JSON.stringify(names.map((name) => ({name})));
+
+/** The `{number, title}` rows an open-issues-by-label read parses. */
+export const issueRowsPayload = (
+	rows: ReadonlyArray<{readonly number: number; readonly title: string}>,
+): string => JSON.stringify(rows);
+
 /** The command lines the fake spawner is scripted on. */
 export const ROOT = /^git rev-parse --show-toplevel$/;
 export const STATUS = /^git -C \/repo status --porcelain=v1/;
-export const LABELS = /^gh api --paginate repos\/o\/r\/labels\?/;
-export const ISSUE = /^gh api repos\/o\/r\/issues\/9310$/;
-export const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9310\/comments\?/;
-export const CREATE = /^gh api --method POST repos\/o\/r\/issues -f/;
-export const POST = /^gh api --method POST repos\/o\/r\/issues\/9310\/comments -f/;
-export const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
-export const CLOSE = /^gh api --method PATCH repos\/o\/r\/issues\/9310 -f state=closed/;
-export const VIEWER = /^gh api user --jq \.login$/;
-export const PERMISSION = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
-export const OPEN_SPIKES = /^gh api --paginate repos\/o\/r\/issues\?state=open&labels=/;
+
+/**
+ * The requests the fake transport is scripted on, as `METHOD <url>`.
+ *
+ * A paged read appends `&per_page=100&page=N`, so those patterns anchor on the query's stable head
+ * rather than on `$`. The method carries what the `gh`-era `--method POST` argv did, which is what
+ * keeps {@link CREATE} apart from a read of the same path.
+ */
+export const LABELS = /^GET .*\/repos\/o\/r\/labels\?/;
+export const ISSUE = /^GET .*\/repos\/o\/r\/issues\/9310$/;
+export const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/9310\/comments\?/;
+export const CREATE = /^POST .*\/repos\/o\/r\/issues$/;
+export const POST = /^POST .*\/repos\/o\/r\/issues\/9310\/comments$/;
+export const READBACK = /^GET .*\/repos\/o\/r\/issues\/comments\/\d+$/;
+export const CLOSE = /^PATCH .*\/repos\/o\/r\/issues\/9310$/;
+export const VIEWER = /^GET .*\/user$/;
+export const PERMISSION = /^GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+export const OPEN_SPIKES = /^GET .*\/repos\/o\/r\/issues\?state=open&labels=/;

--- a/packages/fabrika-cli/src/spike/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/open-verb.unit.test.ts
@@ -1,7 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {
+	errOut,
+	type FakeFsOptions,
+	fakeFs,
+	fakeSeams,
+	okOut,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import {issueBody, spikeTitle} from "./bodies.ts";
 import {
 	MALFORMED_RECORD,
@@ -21,7 +27,9 @@ import {
 	ENV,
 	ISSUE,
 	issuePayload,
+	issueRowsPayload,
 	LABELS,
+	labelsPayload,
 	MANIFEST,
 	manifestText,
 	NONCE,
@@ -51,24 +59,32 @@ const options = {
 	mintNonce: () => NONCE,
 };
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	[ROOT, okOut(`${TREE_ROOT}\n`)],
-	[LABELS, okOut("prototyping:spike\ntype:bug\n")],
+	[LABELS, {status: 200, body: labelsPayload("prototyping:spike", "type:bug")}],
 	[STATUS, okOut("")],
-	[CREATE, okOut(JSON.stringify({number: SPIKE, html_url: "https://example.test/#9310"}))],
-	[ISSUE, okOut(issuePayload({title: TITLE, body: BODY}))],
+	[
+		CREATE,
+		{status: 201, body: JSON.stringify({number: SPIKE, html_url: "https://example.test/#9310"})},
+	],
+	[ISSUE, {status: 200, body: issuePayload({title: TITLE, body: BODY})}],
 ];
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	fs: FakeFsOptions = {},
 ) => {
 	const disk = fakeFs(fs);
-	const shell = fakeShell(script);
+	const seams = fakeSeams(script);
 	return Effect.runPromise(
-		Effect.provide(runOpen({...options, ...overrides}), Layer.merge(disk.layer, shell.layer)),
-	).then((outcome) => ({outcome, written: disk.written, calls: shell.calls}));
+		Effect.provide(runOpen({...options, ...overrides}), Layer.merge(disk.layer, seams.layer)),
+	).then((outcome) => ({
+		outcome,
+		written: disk.written,
+		requests: seams.requests,
+		bodies: seams.bodies,
+	}));
 };
 
 describe("runOpen mints a spike, its workspace and their binding", () => {
@@ -85,14 +101,16 @@ describe("runOpen mints a spike, its workspace and their binding", () => {
 	});
 
 	it("creates the workspace BEFORE the issue, so a half-run leaves a collectable orphan", async () => {
-		const {written, calls} = await run(happy);
+		const {written, requests} = await run(happy);
 		expect([...written.keys()]).toContain(MANIFEST);
-		expect(calls.filter((line) => CREATE.test(line))).toHaveLength(1);
+		expect(requests.filter((line) => CREATE.test(line))).toHaveLength(1);
 	});
 
-	it("sends the label in the create call itself, so there is no unlabelled window", async () => {
-		const {calls} = await run(happy);
-		expect(calls.find((line) => CREATE.test(line))).toContain("labels[]=prototyping:spike");
+	it("sends the label in the create request itself, so there is no unlabelled window", async () => {
+		const {requests, bodies} = await run(happy);
+		expect(bodies[requests.findIndex((line) => CREATE.test(line))]).toContain(
+			'"labels":["prototyping:spike"]',
+		);
 	});
 
 	it("completes the manifest with the spike number", async () => {
@@ -127,7 +145,7 @@ describe("runOpen refuses before it writes anything", () => {
 	it("refuses a proven-absent label on 7 and names the bootstrap", async () => {
 		const {outcome, written} = await run([
 			[ROOT, okOut(`${TREE_ROOT}\n`)],
-			[LABELS, okOut("type:bug\n")],
+			[LABELS, {status: 200, body: labelsPayload("type:bug")}],
 		]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.join("\n")).toContain("front-door");
@@ -137,7 +155,7 @@ describe("runOpen refuses before it writes anything", () => {
 	it("refuses an unreadable label set on 11 — never as a proven absence", async () => {
 		const {outcome} = await run([
 			[ROOT, okOut(`${TREE_ROOT}\n`)],
-			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
 		expect(outcome.stderr.join("\n")).not.toContain("front-door");
@@ -146,7 +164,7 @@ describe("runOpen refuses before it writes anything", () => {
 	it("refuses an unreadable tree on 11 — an unreadable tree is never clean", async () => {
 		const {outcome, written} = await run([
 			[ROOT, okOut(`${TREE_ROOT}\n`)],
-			[LABELS, okOut("prototyping:spike\n")],
+			[LABELS, {status: 200, body: labelsPayload("prototyping:spike")}],
 			[STATUS, errOut("fatal: not a git repository")],
 		]);
 		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
@@ -164,10 +182,10 @@ describe("runOpen re-enters an existing workspace rather than minting a second i
 	const resident: FakeFsOptions = {directories: [WORKSPACE], files: {[MANIFEST]: manifestText()}};
 
 	it("answers the existing manifest and creates nothing", async () => {
-		const {outcome, calls} = await run(happy, {nonce: NONCE}, resident);
+		const {outcome, requests} = await run(happy, {nonce: NONCE}, resident);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).spike).toBe(SPIKE);
-		expect(calls.filter((line) => CREATE.test(line))).toHaveLength(0);
+		expect(requests.filter((line) => CREATE.test(line))).toHaveLength(0);
 	});
 
 	it("refuses a workspace holding a different question on 18", async () => {
@@ -201,8 +219,8 @@ describe("runOpen re-enters an existing workspace rather than minting a second i
 		const {outcome, written} = await run(
 			[
 				[ROOT, okOut(`${TREE_ROOT}\n`)],
-				[OPEN_SPIKES, okOut(`${SPIKE}\t${TITLE}\n`)],
-				[ISSUE, okOut(issuePayload({title: TITLE, body: BODY}))],
+				[OPEN_SPIKES, {status: 200, body: issueRowsPayload([{number: SPIKE, title: TITLE}])}],
+				[ISSUE, {status: 200, body: issuePayload({title: TITLE, body: BODY})}],
 			],
 			{nonce: NONCE},
 			{directories: [WORKSPACE], files: {[MANIFEST]: manifestText({spike: null})}},
@@ -219,7 +237,7 @@ describe("runOpen re-enters an existing workspace rather than minting a second i
 		const {outcome, written} = await run(
 			[
 				[ROOT, okOut(`${TREE_ROOT}\n`)],
-				[OPEN_SPIKES, errOut("gh: Bad gateway (HTTP 502)")],
+				[OPEN_SPIKES, {status: 502, body: "{}"}],
 			],
 			{nonce: NONCE},
 			{directories: [WORKSPACE], files: {[MANIFEST]: manifestText({spike: null})}},
@@ -233,9 +251,9 @@ describe("runOpen proves the issue landed as sent", () => {
 	it("seats an unproven create on 8", async () => {
 		const {outcome} = await run([
 			[ROOT, okOut(`${TREE_ROOT}\n`)],
-			[LABELS, okOut("prototyping:spike\n")],
+			[LABELS, {status: 200, body: labelsPayload("prototyping:spike")}],
 			[STATUS, okOut("")],
-			[CREATE, errOut("gh: Bad gateway (HTTP 502)")],
+			[CREATE, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("may or may not have landed");
@@ -244,7 +262,7 @@ describe("runOpen proves the issue landed as sent", () => {
 	it("seats a body that does not read back as sent on 9", async () => {
 		const {outcome} = await run([
 			...happy.filter(([pattern]) => pattern !== ISSUE),
-			[ISSUE, okOut(issuePayload({title: TITLE, body: "somebody edited it"}))],
+			[ISSUE, {status: 200, body: issuePayload({title: TITLE, body: "somebody edited it"})}],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stderr.join("\n")).toContain("body");
@@ -253,7 +271,7 @@ describe("runOpen proves the issue landed as sent", () => {
 	it("seats a label that did not land on 9", async () => {
 		const {outcome} = await run([
 			...happy.filter(([pattern]) => pattern !== ISSUE),
-			[ISSUE, okOut(issuePayload({title: TITLE, body: BODY, labels: []}))],
+			[ISSUE, {status: 200, body: issuePayload({title: TITLE, body: BODY, labels: []})}],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stderr.join("\n")).toContain("labels");
@@ -263,8 +281,8 @@ describe("runOpen proves the issue landed as sent", () => {
 		const {outcome} = await run(
 			[
 				[ROOT, okOut(`${TREE_ROOT}\n`)],
-				[OPEN_SPIKES, okOut(`${SPIKE}\t${TITLE}\n`)],
-				[ISSUE, okOut(issuePayload({title: TITLE, body: BODY}))],
+				[OPEN_SPIKES, {status: 200, body: issueRowsPayload([{number: SPIKE, title: TITLE}])}],
+				[ISSUE, {status: 200, body: issuePayload({title: TITLE, body: BODY})}],
 			],
 			{nonce: NONCE},
 			{

--- a/packages/fabrika-cli/src/spike/status-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/status-verb.unit.test.ts
@@ -1,7 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {
+	errOut,
+	type FakeFsOptions,
+	fakeFs,
+	fakeSeams,
+	okOut,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import {captureMarker} from "./bodies.ts";
 import {MALFORMED_RECORD, OFF_VOCABULARY, READ_OR_EXEC_UNKNOWN} from "./codes.ts";
 import {
@@ -31,21 +37,21 @@ const resident: FakeFsOptions = {
 
 const options = {nonce: NONCE, repo: null as string | null, env: ENV, tmpRoot: TMP_ROOT};
 
-const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const happy: ReadonlyArray<Scripted> = [
 	[STATUS, okOut("")],
-	[ISSUE, okOut(issuePayload())],
-	[COMMENTS, okOut(commentsPayload([]))],
+	[ISSUE, {status: 200, body: issuePayload()}],
+	[COMMENTS, {status: 200, body: commentsPayload([])}],
 ];
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	overrides: Partial<typeof options> = {},
 	fs: FakeFsOptions = resident,
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runStatus({...options, ...overrides}),
-			Layer.merge(fakeFs(fs).layer, fakeShell(script).layer),
+			Layer.merge(fakeFs(fs).layer, fakeSeams(script).layer),
 		),
 	);
 
@@ -102,8 +108,11 @@ describe("runStatus reports per-field state inside exit 0", () => {
 	it("reports a captured spike", async () => {
 		const outcome = await run([
 			[STATUS, okOut("")],
-			[ISSUE, okOut(issuePayload({state: "closed"}))],
-			[COMMENTS, okOut(commentsPayload([{id: 1, body: captureMarker(NONCE, ONE_RUN_DIGEST)}]))],
+			[ISSUE, {status: 200, body: issuePayload({state: "closed"})}],
+			[
+				COMMENTS,
+				{status: 200, body: commentsPayload([{id: 1, body: captureMarker(NONCE, ONE_RUN_DIGEST)}])},
+			],
 		]);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({spikeState: "closed", captured: true});
 	});
@@ -111,8 +120,8 @@ describe("runStatus reports per-field state inside exit 0", () => {
 	it("reports treeMatched as information, never as a verdict", async () => {
 		const outcome = await run([
 			[STATUS, okOut("?? probe.ts\n")],
-			[ISSUE, okOut(issuePayload())],
-			[COMMENTS, okOut(commentsPayload([]))],
+			[ISSUE, {status: 200, body: issuePayload()}],
+			[COMMENTS, {status: 200, body: commentsPayload([])}],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).treeMatched).toBe(false);
@@ -151,7 +160,7 @@ describe("the near-totality is bounded by ADR 0092", () => {
 	it("refuses an unreadable spike state on 11 rather than reporting a default", async () => {
 		const outcome = await run([
 			[STATUS, okOut("")],
-			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
 		expect(outcome.stdout).toBe("");
@@ -172,7 +181,7 @@ describe("a proven-absent spike is reported, never fused with an unreadable one"
 	it("names it on stderr and leaves the state null at exit 0", async () => {
 		const outcome = await run([
 			[STATUS, okOut("")],
-			[ISSUE, errOut("gh: Not Found (HTTP 404)")],
+			[ISSUE, {status: 404, body: '{"message":"Not Found"}'}],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).spikeState).toBeNull();

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -9,8 +9,7 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {audienceLabel, type BoardVocabulary, statusList, typeLabel} from "../config/board.ts";
 import {SURFACE_REGISTRY} from "../config/keys/surface-dispositions.ts";
-import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, fakeShell, type HttpReply} from "../fakes.test-support.ts";
 import {ok} from "../io/git.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {AWAITING_RELEASE, DEFAULT_STATUS_NAMES, PLANNED, STATUSES} from "../labels.ts";
@@ -741,27 +740,30 @@ describe("the roadmap-focus row count", () => {
  * write — the branch is proven only when the outcome no longer depends on it.
  */
 describe("the readout-artifact read-back reads the created issue by number", () => {
-	const LIST = /^gh api --paginate repos\/o\/r\/issues\?state=open/;
-	const CREATE = /^gh api --method POST repos\/o\/r\/issues /;
-	const READBACK = /^gh api repos\/o\/r\/issues\/3$/;
-	const CREATED = okOut(JSON.stringify({number: 3, html_url: "https://github.com/o/r/issues/3"}));
+	const LIST = /GET .*\/repos\/o\/r\/issues\?state=open/;
+	const CREATE = /POST .*\/repos\/o\/r\/issues$/;
+	const READBACK = /GET .*\/repos\/o\/r\/issues\/3$/;
+	const CREATED: HttpReply = {
+		status: 201,
+		body: JSON.stringify({number: 3, html_url: "https://github.com/o/r/issues/3"}),
+	};
 
-	const artifact = (overrides: Readonly<Record<string, unknown>> = {}) =>
-		okOut(
-			JSON.stringify({
-				number: 3,
-				title: ARTIFACT_TITLE,
-				body: "",
-				state: "open",
-				labels: [],
-				html_url: "https://github.com/o/r/issues/3",
-				...overrides,
-			}),
-		);
+	const artifact = (overrides: Readonly<Record<string, unknown>> = {}): HttpReply => ({
+		status: 200,
+		body: JSON.stringify({
+			number: 3,
+			title: ARTIFACT_TITLE,
+			body: "",
+			state: "open",
+			labels: [],
+			html_url: "https://github.com/o/r/issues/3",
+			...overrides,
+		}),
+	});
 
-	const run = (readback: ExecResult) => {
-		const shell = fakeShell([
-			[LIST, okOut("")],
+	const run = (readback: HttpReply) => {
+		const seams = fakeSeams([
+			[LIST, {status: 200, body: "[]"}],
 			[CREATE, CREATED],
 			[READBACK, readback],
 		]);
@@ -777,9 +779,9 @@ describe("the readout-artifact read-back reads the created issue by number", () 
 					repo: ok("o/r"),
 					stdin: Effect.succeed({_tag: "NoStdin"} as StdinRead),
 				}),
-				Layer.mergeAll(shell.layer, fs.layer),
+				Layer.mergeAll(seams.layer, fs.layer),
 			),
-		).then((outcome) => ({outcome, calls: shell.calls}));
+		).then((outcome) => ({outcome, calls: seams.requests}));
 	};
 
 	it("reports created off the issue's own resource, never a second list read", async () => {
@@ -796,12 +798,12 @@ describe("the readout-artifact read-back reads the created issue by number", () 
 	});
 
 	it("spends READBACK_MISMATCH only on a proven 404", async () => {
-		const {outcome} = await run(errOut("gh: Not Found (HTTP 404)"));
+		const {outcome} = await run({status: 404, body: '{"message":"Not Found"}'});
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 	});
 
 	it("reads an unreadable re-read as WRITE_UNKNOWN, never as a mismatch", async () => {
-		const {outcome} = await run(errOut("gh: Bad Gateway (HTTP 502)"));
+		const {outcome} = await run({status: 502, body: "{}"});
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 	});
 

--- a/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {runApply} from "./apply-verb.ts";
 import {
 	COMMENTS,
@@ -23,12 +22,23 @@ import {
 	ZERO_SCOPE,
 } from "./codes.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
-const MILESTONES = /^gh api --paginate repos\/o\/r\/milestones/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4312 -F milestone=/;
-const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4312\/labels\//;
-const ADD = /^gh api --method POST repos\/o\/r\/issues\/4312\/labels /;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+const MILESTONES = /GET .*\/repos\/o\/r\/milestones\?/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/4312$/;
+const REMOVE = /DELETE .*\/repos\/o\/r\/issues\/4312\/labels\//;
+const ADD = /POST .*\/repos\/o\/r\/issues\/4312\/labels$/;
+
+const ACCEPTED: HttpReply = {status: 200, body: "{}"};
+const LABELLED: HttpReply = {status: 200, body: "[]"};
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const WRITE_FAILED: HttpReply = {status: 500, body: "{}"};
+
+const labelSet = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
 
 /** A body carrying the conforming block — what `--ready-for agent` requires (#6025). */
 const CRITERIA_BODY = "## Summary\n\ns\n\n### Acceptance criteria\n\n- [ ] the one criterion\n";
@@ -39,35 +49,39 @@ const issue = (
 	labels: ReadonlyArray<string>,
 	milestone: number | null,
 	body = CRITERIA_BODY,
-): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4312,
-			title: "t",
-			body,
-			state: "open",
-			labels: labels.map((name) => ({name})),
-			html_url: "https://example.test/issues/4312",
-			milestone: milestone === null ? null : {number: milestone},
-		}),
-	);
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4312,
+		title: "t",
+		body,
+		state: "open",
+		labels: labels.map((name) => ({name})),
+		html_url: "https://example.test/issues/4312",
+		milestone: milestone === null ? null : {number: milestone},
+	}),
+});
 
-const VOCABULARY = okOut(
-	[
-		"type:bug",
-		"type:chore",
-		"p1",
-		"p2",
-		"status:needs-triage",
-		"status:triaged",
-		"ready-for:agent",
-		"ready-for:human",
-		"wayfinder:backlog",
-		"axis:pipeline-hardening",
-	].join("\n"),
+const VOCABULARY = labelSet(
+	"type:bug",
+	"type:chore",
+	"p1",
+	"p2",
+	"status:needs-triage",
+	"status:triaged",
+	"ready-for:agent",
+	"ready-for:human",
+	"wayfinder:backlog",
+	"axis:pipeline-hardening",
 );
 
-const OPEN_MILESTONES = okOut("47\tfabrika campaign\n44\twayfinder");
+const OPEN_MILESTONES: HttpReply = {
+	status: 200,
+	body: JSON.stringify([
+		{number: 47, title: "fabrika campaign"},
+		{number: 44, title: "wayfinder"},
+	]),
+};
 
 const options = {
 	issue: 4312,
@@ -83,20 +97,17 @@ const options = {
 };
 
 /** Observed: needs-triage on `p1` and unhomed. Read back: the whole triaged shape. */
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const happy = (): ReadonlyArray<Scripted> => [
 	[once(ISSUE), issue(["status:needs-triage", "p1"], null)],
 	[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
 	[LABELS, VOCABULARY],
 	[MILESTONES, OPEN_MILESTONES],
-	[PATCH, okOut("{}")],
-	[REMOVE, okOut("[]")],
-	[ADD, okOut("[]")],
+	[PATCH, ACCEPTED],
+	[REMOVE, LABELLED],
+	[ADD, LABELLED],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(runApply({...options, ...overrides}), triageContext(guardedShell(script))),
 	);
@@ -121,7 +132,7 @@ describe("runApply under a refused config", () => {
 		await Effect.runPromise(
 			Effect.provide(runApply(options), triageContext(shell, VIOLATING_CONFIG)),
 		);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	it("still runs on a config that declares nothing about the facets", async () => {
@@ -151,7 +162,7 @@ describe("runApply under a refused config", () => {
 		);
 		expect(out.code).toBe(CONFIG_REFUSED);
 		expect(out.stderr.join(" ")).toContain(expected);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 });
 
@@ -185,20 +196,26 @@ describe("runApply", () => {
 	it("homes BEFORE it labels, so the homing guard never sees a triaged un-homed issue", async () => {
 		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runApply(options), triageContext(shell)));
-		const writes = shell.calls.filter((c) => PATCH.test(c) || REMOVE.test(c) || ADD.test(c));
-		expect(writes[0]).toBe("gh api --method PATCH repos/o/r/issues/4312 -F milestone=47");
-		expect(writes.at(-1)).toContain("--method POST");
+		const writes = shell.requests
+			.map((line, at) => ({line, body: shell.bodies[at] ?? ""}))
+			.filter(({line}) => PATCH.test(line) || REMOVE.test(line) || ADD.test(line));
+		expect(writes[0]?.line).toBe("PATCH https://api.github.com/repos/o/r/issues/4312");
+		expect(writes[0]?.body).toBe('{"milestone":47}');
+		expect(writes.at(-1)?.line).toContain("POST");
 	});
 
 	it("removes the superseded priority and never the applied one (#4285)", async () => {
 		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runApply(options), triageContext(shell)));
-		const removes = shell.calls.filter((c) => REMOVE.test(c));
+		const removes = shell.requests.filter((c) => REMOVE.test(c));
 		expect(removes).toEqual([
-			"gh api --method DELETE repos/o/r/issues/4312/labels/status%3Aneeds-triage",
-			"gh api --method DELETE repos/o/r/issues/4312/labels/p1",
+			"DELETE https://api.github.com/repos/o/r/issues/4312/labels/status%3Aneeds-triage",
+			"DELETE https://api.github.com/repos/o/r/issues/4312/labels/p1",
 		]);
-		expect(shell.calls.find((c) => ADD.test(c))).toContain("labels[]=p2");
+		const added: unknown = JSON.parse(
+			shell.bodies[shell.requests.findIndex((c) => ADD.test(c))] ?? "{}",
+		);
+		expect((added as {readonly labels: ReadonlyArray<string>}).labels).toContain("p2");
 	});
 
 	it("leaves a label no facet owns entirely alone", async () => {
@@ -207,12 +224,12 @@ describe("runApply", () => {
 			[ISSUE, issue(["area:pipeline", "type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
 			[LABELS, VOCABULARY],
 			[MILESTONES, OPEN_MILESTONES],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runApply(options), triageContext(shell)));
 		expect(out.code).toBe(0);
-		expect(shell.calls.some((c) => c.includes("area%3Apipeline"))).toBe(false);
+		expect(shell.requests.some((c) => c.includes("area%3Apipeline"))).toBe(false);
 	});
 
 	it("clears the milestone under --lane, because a lane-exempt issue is not homed (ADR 0208)", async () => {
@@ -223,9 +240,9 @@ describe("runApply", () => {
 				issue(["type:bug", "p2", "status:triaged", "ready-for:agent", "wayfinder:backlog"], null),
 			],
 			[LABELS, VOCABULARY],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -235,8 +252,8 @@ describe("runApply", () => {
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("triaged\t4312\tbug\tp2\tagent\twayfinder:backlog\n");
-		expect(shell.calls).toContain("gh api --method PATCH repos/o/r/issues/4312 -F milestone=null");
-		expect(shell.calls.some((c) => MILESTONES.test(c))).toBe(false);
+		expect(shell.bodies[shell.requests.findIndex((c) => PATCH.test(c))]).toBe('{"milestone":null}');
+		expect(shell.requests.some((c) => MILESTONES.test(c))).toBe(false);
 	});
 
 	it("refuses both --home and --lane", async () => {
@@ -268,7 +285,7 @@ describe("runApply", () => {
 		);
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stdout).toBe("");
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	/**
@@ -287,7 +304,7 @@ describe("runApply", () => {
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("this repo declares no standing lane");
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	it("refuses a milestone that is not open, on the same code", async () => {
@@ -300,16 +317,16 @@ describe("runApply", () => {
 		const shell = guardedShell([
 			[once(ISSUE), issue(["status:needs-triage"], null)],
 			[ISSUE, issue([], null)],
-			[LABELS, okOut(["type:bug", "p2", "status:triaged"].join("\n"))],
+			[LABELS, labelSet("type:bug", "p2", "status:triaged")],
 			[MILESTONES, OPEN_MILESTONES],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runApply(options), triageContext(shell)));
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("label ready-for:agent does not exist");
-		expect(shell.calls.some((c) => ADD.test(c) || PATCH.test(c))).toBe(false);
+		expect(shell.requests.some((c) => ADD.test(c) || PATCH.test(c))).toBe(false);
 	});
 
 	it("checks only the labels THIS run writes, not the whole vocabulary", async () => {
@@ -317,33 +334,33 @@ describe("runApply", () => {
 		const out = await run([
 			[once(ISSUE), issue(["status:needs-triage", "p1"], null)],
 			[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
-			[LABELS, okOut(["type:bug", "p1", "p2", "status:triaged", "ready-for:agent"].join("\n"))],
+			[LABELS, labelSet("type:bug", "p1", "p2", "status:triaged", "ready-for:agent")],
 			[MILESTONES, OPEN_MILESTONES],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(0);
 	});
 
 	it("refuses an issue proven absent on 7", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("triage apply: issue #4312 not found in o/r.");
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
-		const shell = guardedShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const shell = guardedShell([[ISSUE, UNREADABLE]]);
 		const out = await Effect.runPromise(Effect.provide(runApply(options), triageContext(shell)));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was written");
-		expect(shell.calls.some((c) => PATCH.test(c) || ADD.test(c))).toBe(false);
+		expect(shell.requests.some((c) => PATCH.test(c) || ADD.test(c))).toBe(false);
 	});
 
 	it("refuses an unreadable label set as UNKNOWN, never as an empty vocabulary", async () => {
 		const out = await run([
 			[ISSUE, issue(["status:needs-triage"], null)],
-			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, UNREADABLE],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("cannot read the label set");
@@ -353,7 +370,7 @@ describe("runApply", () => {
 		const out = await run([
 			[ISSUE, issue(["status:needs-triage"], null)],
 			[LABELS, VOCABULARY],
-			[MILESTONES, errOut("gh: Bad gateway (HTTP 502)")],
+			[MILESTONES, UNREADABLE],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("cannot read the milestone set");
@@ -365,9 +382,9 @@ describe("runApply", () => {
 			[ISSUE, issue([], null)],
 			[LABELS, VOCABULARY],
 			[MILESTONES, OPEN_MILESTONES],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, errOut("gh: timeout")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, WRITE_FAILED],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -381,9 +398,9 @@ describe("runApply", () => {
 			[ISSUE, issue(["type:bug", "p2", "ready-for:agent"], 47)],
 			[LABELS, VOCABULARY],
 			[MILESTONES, OPEN_MILESTONES],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stdout).toBe("");
@@ -397,9 +414,9 @@ describe("runApply", () => {
 			[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:agent"], null)],
 			[LABELS, VOCABULARY],
 			[MILESTONES, OPEN_MILESTONES],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("milestone=none");
@@ -408,12 +425,12 @@ describe("runApply", () => {
 	it("refuses when the read-back itself fails — a write that is not verified is not finished", async () => {
 		const out = await run([
 			[once(ISSUE), issue(["status:needs-triage"], null)],
-			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, UNREADABLE],
 			[LABELS, VOCABULARY],
 			[MILESTONES, OPEN_MILESTONES],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("read-back shows nothing");
@@ -429,9 +446,9 @@ describe("runApply", () => {
 				[ISSUE, issue(["status:needs-triage"], null, body)],
 				[LABELS, VOCABULARY],
 				[MILESTONES, OPEN_MILESTONES],
-				[PATCH, okOut("{}")],
-				[REMOVE, okOut("[]")],
-				[ADD, okOut("[]")],
+				[PATCH, ACCEPTED],
+				[REMOVE, LABELLED],
+				[ADD, LABELLED],
 			]);
 
 		it("refuses an absent block, points at enrich, and writes NO label", async () => {
@@ -441,7 +458,9 @@ describe("runApply", () => {
 			expect(out.stdout).toBe("");
 			expect(out.stderr.at(-1)).toContain("carries no acceptance-criteria block");
 			expect(out.stderr.at(-1)).toContain("triage enrich");
-			expect(shell.calls.some((c) => ADD.test(c) || REMOVE.test(c) || PATCH.test(c))).toBe(false);
+			expect(shell.requests.some((c) => ADD.test(c) || REMOVE.test(c) || PATCH.test(c))).toBe(
+				false,
+			);
 		});
 
 		it("refuses a malformed block on the same code, naming the drift and repair-criteria", async () => {
@@ -451,7 +470,7 @@ describe("runApply", () => {
 			expect(out.stderr.at(-1)).toContain("is malformed");
 			expect(out.stderr.at(-1)).toContain("heading level 2, expected 3");
 			expect(out.stderr.at(-1)).toContain("triage repair-criteria 4312");
-			expect(shell.calls.some((c) => ADD.test(c))).toBe(false);
+			expect(shell.requests.some((c) => ADD.test(c))).toBe(false);
 		});
 
 		/** An epic's criteria arrive per child from the plan ledger, never in its own body. */
@@ -460,11 +479,11 @@ describe("runApply", () => {
 				[
 					[once(ISSUE), issue(["status:needs-triage"], null, NO_CRITERIA_BODY)],
 					[ISSUE, issue(["type:epic", "p2", "status:triaged", "ready-for:agent"], 47)],
-					[LABELS, okOut(["type:epic", "p2", "status:triaged", "ready-for:agent"].join("\n"))],
+					[LABELS, labelSet("type:epic", "p2", "status:triaged", "ready-for:agent")],
 					[MILESTONES, OPEN_MILESTONES],
-					[PATCH, okOut("{}")],
-					[REMOVE, okOut("[]")],
-					[ADD, okOut("[]")],
+					[PATCH, ACCEPTED],
+					[REMOVE, LABELLED],
+					[ADD, LABELLED],
 				],
 				{type: "epic"},
 			);
@@ -479,9 +498,9 @@ describe("runApply", () => {
 					[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:human"], 47)],
 					[LABELS, VOCABULARY],
 					[MILESTONES, OPEN_MILESTONES],
-					[PATCH, okOut("{}")],
-					[REMOVE, okOut("[]")],
-					[ADD, okOut("[]")],
+					[PATCH, ACCEPTED],
+					[REMOVE, LABELLED],
+					[ADD, LABELLED],
 				],
 				{readyFor: "human"},
 			);
@@ -507,8 +526,9 @@ describe("runApply — the target guard", () => {
 		string,
 		string | undefined
 	>;
-	const closed = okOut(
-		JSON.stringify({
+	const closed: HttpReply = {
+		status: 200,
+		body: JSON.stringify({
 			number: 4312,
 			title: "t",
 			body: CRITERIA_BODY,
@@ -517,14 +537,14 @@ describe("runApply — the target guard", () => {
 			html_url: "https://example.test/issues/4312",
 			milestone: null,
 		}),
-	);
+	};
 
-	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const guard = async (script: ReadonlyArray<Scripted>) => {
 		const shell = guardedShell(script);
 		const out = await Effect.runPromise(
 			Effect.provide(runApply({...options, env: mine}), triageContext(shell)),
 		);
-		return {out, wrote: shell.calls.some((line) => ADD.test(line) || PATCH.test(line))};
+		return {out, wrote: shell.requests.some((line) => ADD.test(line) || PATCH.test(line))};
 	};
 
 	it("refuses a closed issue on 7 and writes nothing", async () => {

--- a/packages/fabrika-cli/src/triage/board-vocabulary.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/board-vocabulary.unit.test.ts
@@ -7,21 +7,31 @@
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {ok} from "../io/git.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {runBootstrap} from "../status/bootstrap-verb.ts";
 import {runApply} from "./apply-verb.ts";
-import {CWD, guardedShell, triageContext} from "./claim-fixtures.test-support.ts";
+import {
+	CWD,
+	type GuardedSeams,
+	guardedShell,
+	triageContext,
+} from "./claim-fixtures.test-support.ts";
 import {OFF_VOCABULARY} from "./codes.ts";
 import {runPark} from "./park-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
-const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4312\/labels\//;
-const ADD = /^gh api --method POST repos\/o\/r\/issues\/4312\/labels /;
-const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4312\/comments /;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+const REMOVE = /DELETE .*\/repos\/o\/r\/issues\/4312\/labels\//;
+const ADD = /POST .*\/repos\/o\/r\/issues\/4312\/labels$/;
+const COMMENT = /POST .*\/repos\/o\/r\/issues\/4312\/comments$/;
+
+/** What one matching request carried as its JSON body — where the labels now travel. */
+const bodyFor = (seams: GuardedSeams, pattern: RegExp): string => {
+	const at = seams.requests.findIndex((line) => pattern.test(line));
+	return at < 0 ? "" : (seams.bodies[at] ?? "");
+};
 
 /** The whole board a hypothetical adopting repo declares: its own types, priorities and lanes. */
 const FOREIGN = JSON.stringify({
@@ -36,34 +46,37 @@ const FOREIGN = JSON.stringify({
 
 const BODY = "## Summary\n\ns\n\n### Acceptance criteria\n\n- [ ] the one criterion\n";
 
-const issue = (labels: ReadonlyArray<string>): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4312,
-			title: "t",
-			body: BODY,
-			state: "open",
-			labels: labels.map((name) => ({name})),
-			html_url: "https://example.test/issues/4312",
-			milestone: null,
-		}),
-	);
+const issue = (labels: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4312,
+		title: "t",
+		body: BODY,
+		state: "open",
+		labels: labels.map((name) => ({name})),
+		html_url: "https://example.test/issues/4312",
+		milestone: null,
+	}),
+});
 
 /** Every label the foreign board can produce, as the repo's own label set reads back. */
-const FOREIGN_LABELS = okOut(
-	[
-		"type:task",
-		"type:defect",
-		"sev1",
-		"sev2",
-		"state:new",
-		"state:ready",
-		"state:blocked",
-		"ready-for:agent",
-		"ready-for:human",
-		"team:infra",
-	].join("\n"),
-);
+const FOREIGN_LABELS: HttpReply = {
+	status: 200,
+	body: JSON.stringify(
+		[
+			"type:task",
+			"type:defect",
+			"sev1",
+			"sev2",
+			"state:new",
+			"state:ready",
+			"state:blocked",
+			"ready-for:agent",
+			"ready-for:human",
+			"team:infra",
+		].map((name) => ({name})),
+	),
+};
 
 const applyOptions = {
 	issue: 4312,
@@ -80,12 +93,12 @@ const applyOptions = {
 
 describe("triage apply under a declared board vocabulary", () => {
 	/** Observed: new, on `sev1`. Read back: the whole triaged shape in the repo's own vocabulary. */
-	const script = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	const script = (): ReadonlyArray<Scripted> => [
 		[once(ISSUE), issue(["state:new", "sev1"])],
 		[ISSUE, issue(["type:task", "sev2", "state:ready", "ready-for:agent", "team:infra"])],
 		[LABELS, FOREIGN_LABELS],
-		[REMOVE, okOut("[]")],
-		[ADD, okOut("[]")],
+		[REMOVE, {status: 200, body: "[]"}],
+		[ADD, {status: 200, body: "[]"}],
 	];
 
 	it("writes the repo's own type, priority, status and lane", async () => {
@@ -94,7 +107,7 @@ describe("triage apply under a declared board vocabulary", () => {
 			Effect.provide(runApply(applyOptions), triageContext(shell, FOREIGN)),
 		);
 		expect(out.code).toBe(0);
-		const added = shell.calls.find((line) => ADD.test(line)) ?? "";
+		const added = bodyFor(shell, ADD);
 		for (const label of ["type:task", "sev2", "state:ready", "team:infra"]) {
 			expect(added).toContain(label);
 		}
@@ -108,7 +121,7 @@ describe("triage apply under a declared board vocabulary", () => {
 		);
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.join(" ")).toContain("task, defect");
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	/** The lanes are an open set now, so this decode is the only thing standing between a typo'd
@@ -123,7 +136,7 @@ describe("triage apply under a declared board vocabulary", () => {
 		);
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.join(" ")).toContain("team:infra");
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	it("accepts a lane the declaring repo named", async () => {
@@ -140,9 +153,9 @@ describe("triage park under a declared board vocabulary", () => {
 			[once(ISSUE), issue(["type:task", "sev1", "state:ready"])],
 			[ISSUE, issue(["state:blocked"])],
 			[LABELS, FOREIGN_LABELS],
-			[COMMENT, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[COMMENT, {status: 201, body: JSON.stringify({id: 1, html_url: "https://example.test/c/1"})}],
+			[REMOVE, {status: 200, body: "[]"}],
+			[ADD, {status: 200, body: "[]"}],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -158,18 +171,18 @@ describe("triage park under a declared board vocabulary", () => {
 			),
 		);
 		expect(out.code).toBe(0);
-		expect(shell.calls.some((line) => line.includes("state:blocked"))).toBe(true);
+		expect(shell.bodies.some((body) => body.includes("state:blocked"))).toBe(true);
 	});
 });
 
 describe("status bootstrap under a declared board vocabulary", () => {
-	const LIST = /^gh api --paginate repos\/o\/r\/labels/;
-	const CREATE = /^gh api --method POST repos\/o\/r\/labels /;
+	const LIST = /GET .*\/repos\/o\/r\/labels\?/;
+	const CREATE = /POST .*\/repos\/o\/r\/labels$/;
 
 	const run = (config: string | null) => {
 		const shell = guardedShell([
-			[LIST, okOut("")],
-			[CREATE, okOut("{}")],
+			[LIST, {status: 200, body: "[]"}],
+			[CREATE, {status: 201, body: "{}"}],
 		]);
 		const files = config === null ? {} : {[`${CWD}/.fabrika.jsonc`]: config};
 		return Effect.runPromise(
@@ -185,12 +198,14 @@ describe("status bootstrap under a declared board vocabulary", () => {
 				}),
 				Layer.merge(shell.layer, fakeFs({files}).layer),
 			),
-		).then(() => ({calls: shell.calls}));
+		).then(() => shell);
 	};
 
+	const created = (seams: GuardedSeams): string =>
+		seams.bodies.filter((_, at) => CREATE.test(seams.requests[at] ?? "")).join(" ");
+
 	it("creates the resolved taxonomy, never the shipped one", async () => {
-		const {calls} = await run(FOREIGN);
-		const wrote = calls.filter((line) => CREATE.test(line)).join(" ");
+		const wrote = created(await run(FOREIGN));
 		for (const label of ["state:new", "state:ready", "state:blocked", "sev1", "type:task"]) {
 			expect(wrote).toContain(label);
 		}
@@ -199,8 +214,7 @@ describe("status bootstrap under a declared board vocabulary", () => {
 	});
 
 	it("creates phoenix's taxonomy for a repo that declared nothing", async () => {
-		const {calls} = await run(null);
-		const wrote = calls.filter((line) => CREATE.test(line)).join(" ");
+		const wrote = created(await run(null));
 		expect(wrote).toContain("status:needs-triage");
 		expect(wrote).toContain("type:bug");
 	});
@@ -210,8 +224,8 @@ describe("status bootstrap under a declared board vocabulary", () => {
 	// mechanism, arriving from the other direction).
 	it("writes nothing when the config could not be read", async () => {
 		const shell = guardedShell([
-			[LIST, okOut("")],
-			[CREATE, okOut("{}")],
+			[LIST, {status: 200, body: "[]"}],
+			[CREATE, {status: 201, body: "{}"}],
 		]);
 		const out = await Effect.runPromise(
 			Effect.provide(
@@ -228,6 +242,6 @@ describe("status bootstrap under a declared board vocabulary", () => {
 			),
 		);
 		expect(out.code).toBe(11);
-		expect(shell.calls.some((line) => CREATE.test(line))).toBe(false);
+		expect(shell.requests.some((line) => CREATE.test(line))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/triage/claim-fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/triage/claim-fixtures.test-support.ts
@@ -9,14 +9,14 @@
  * {@link EXPIRED} cannot come back.
  */
 import {type FileSystem, Layer, type Path} from "effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {CONFIG_PATH} from "../config/document.ts";
-import {type FakeShell, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {markerBody} from "./claim.ts";
 
-/** `listComments`' command line, whichever issue it names. */
-export const COMMENTS = /^gh api --paginate repos\/[^ ]+\/comments\?per_page=100$/;
+/** `listComments`' request line, whichever issue it names. */
+export const COMMENTS = /GET .*\/issues\/\d+\/comments\?/;
 
 /** A `created_at` no TTL can have passed. */
 export const LIVE = "2999-01-01T00:00:00Z";
@@ -36,30 +36,33 @@ export const claimPage = (
 		readonly createdAt: string;
 		readonly lane?: string;
 	}>
-): ExecResult =>
-	okOut(
-		JSON.stringify(
-			held.map((row, index) => ({
-				id: 900 + index,
-				user: {login: "agent"},
-				created_at: row.createdAt,
-				updated_at: row.createdAt,
-				body: markerBody({session: row.session, nonce: row.lane ?? `fixture${index}`}),
-			})),
-		),
-	);
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(
+		held.map((row, index) => ({
+			id: 900 + index,
+			user: {login: "agent"},
+			created_at: row.createdAt,
+			updated_at: row.createdAt,
+			body: markerBody({session: row.session, nonce: row.lane ?? `fixture${index}`}),
+		})),
+	),
+});
 
 /** The default every existing test gets: the issue carries no claim marker at all. */
-export const UNCLAIMED: readonly [RegExp, ExecResult] = [COMMENTS, okOut("[]")];
+export const UNCLAIMED: Scripted = [COMMENTS, {status: 200, body: "[]"}];
+
+/** Both seams off one script, with the unclaimed comments page appended as the last resort. */
+export type GuardedSeams = ReturnType<typeof fakeSeams>;
 
 /**
- * A spawner scripted on `script`, with the unclaimed comments page appended as the last resort.
+ * Both seams scripted on `script`, with the unclaimed comments page appended as the last resort.
  *
- * Appended rather than prepended so a test that scripts its own comments page still wins:
- * {@link fakeShell} resolves each call by the first pattern that matches.
+ * Appended rather than prepended so a test that scripts its own comments page still wins: the fakes
+ * resolve each call by the first pattern that matches.
  */
-export const guardedShell = (script: ReadonlyArray<readonly [RegExp, ExecResult]>): FakeShell =>
-	fakeShell([...script, UNCLAIMED]);
+export const guardedShell = (script: ReadonlyArray<Scripted>): GuardedSeams =>
+	fakeSeams([...script, UNCLAIMED]);
 
 /** The directory a triage verb under test is standing in. Its config is the one the load reads. */
 export const CWD = "/repo";
@@ -79,9 +82,16 @@ export type ConfigFixture = string | {readonly unreadable: true};
  * defaults case every existing test runs in.
  */
 export const triageContext = (
-	shell: FakeShell,
+	shell: {
+		readonly layer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient>;
+	},
 	config?: ConfigFixture,
-): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path> => {
+): Layer.Layer<
+	| ChildProcessSpawner.ChildProcessSpawner
+	| HttpClient.HttpClient
+	| FileSystem.FileSystem
+	| Path.Path
+> => {
 	const path = `${CWD}/${CONFIG_PATH}`;
 	const files = config === undefined ? {} : {[path]: typeof config === "string" ? config : ""};
 	const unreadable = config === undefined || typeof config === "string" ? [] : [path];

--- a/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {composeClaimToken, markerBody} from "./claim.ts";
 import {runClaim} from "./claim-verb.ts";
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
@@ -17,10 +16,24 @@ const SIBLING_UUID = "bbbbbbbb-1111-4222-8333-444444444444";
 const SIBLING_NONCE = "bbbbbbbb";
 const THEIR_NONCE = "cccccccc";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const LIST = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
-const POST = /--method POST repos\/o\/r\/issues\/4312\/comments/;
-const DELETE = /--method DELETE repos\/o\/r\/issues\/comments\//;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const LIST = /GET .*\/repos\/o\/r\/issues\/4312\/comments\?/;
+const POST = /POST .*\/repos\/o\/r\/issues\/4312\/comments$/;
+const DELETE = /DELETE .*\/repos\/o\/r\/issues\/comments\//;
+
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const DELETED: HttpReply = {status: 204, body: ""};
+
+/** What the first request matching `pattern` carried as its JSON body. */
+const bodyOf = (
+	requests: ReadonlyArray<string>,
+	bodies: ReadonlyArray<string>,
+	pattern: RegExp,
+): string => {
+	const at = requests.findIndex((line) => pattern.test(line));
+	return at < 0 ? "" : (bodies[at] ?? "");
+};
 
 /**
  * A pattern that matches at most once, so the two identical comment-list reads of one run can be
@@ -40,17 +53,17 @@ const once = (pattern: RegExp): RegExp => {
 	return re;
 };
 
-const issue = (state: string) =>
-	okOut(
-		JSON.stringify({
-			number: 4312,
-			title: "t",
-			body: "b",
-			state,
-			labels: [],
-			html_url: "https://example.test/issues/4312",
-		}),
-	);
+const issue = (state: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4312,
+		title: "t",
+		body: "b",
+		state,
+		labels: [],
+		html_url: "https://example.test/issues/4312",
+	}),
+});
 
 const comment = (id: number, body: string, createdAt: string) => ({
 	id,
@@ -59,11 +72,15 @@ const comment = (id: number, body: string, createdAt: string) => ({
 	body,
 });
 
-const comments = (...entries: ReadonlyArray<ReturnType<typeof comment>>) =>
-	okOut(JSON.stringify(entries));
+const comments = (...entries: ReadonlyArray<Record<string, unknown>>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(entries),
+});
 
-const posted = (id: number) =>
-	okOut(JSON.stringify({id, html_url: `https://example.test/issues/4312#issuecomment-${id}`}));
+const posted = (id: number): HttpReply => ({
+	status: 201,
+	body: JSON.stringify({id, html_url: `https://example.test/issues/4312#issuecomment-${id}`}),
+});
 
 const NOW = new Date("2026-08-02T10:00:00Z");
 const MY_MARKER = comment(
@@ -95,18 +112,15 @@ const options = {
 	now: () => NOW,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
-	const shell = fakeShell(script);
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const shell = fakeSeams(script);
 	return Effect.runPromise(Effect.provide(runClaim({...options, ...overrides}), shell.layer)).then(
-		(outcome) => ({outcome, calls: shell.calls}),
+		(outcome) => ({outcome, requests: shell.requests, bodies: shell.bodies}),
 	);
 };
 
 /** before: nobody. post lands. after: only mine. */
-const winning = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const winning = (): ReadonlyArray<Scripted> => [
 	[ISSUE, issue("open")],
 	[POST, posted(5001)],
 	[once(LIST), comments()],
@@ -114,7 +128,7 @@ const winning = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 ];
 
 /** before: theirs is already there. post lands. after: both. */
-const losing = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const losing = (): ReadonlyArray<Scripted> => [
 	[ISSUE, issue("open")],
 	[POST, posted(5001)],
 	[once(LIST), comments(THEIR_MARKER)],
@@ -123,11 +137,11 @@ const losing = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 
 describe("runClaim — winning", () => {
 	it("posts the exact marker literal and prints the state word `won`", async () => {
-		const {outcome, calls} = await run(winning());
+		const {outcome, requests, bodies} = await run(winning());
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
-		expect(calls.find((c) => POST.test(c))).toContain(
-			`body=${markerBody({session: MINE, nonce: MY_NONCE})}`,
+		expect(bodyOf(requests, bodies, POST)).toContain(
+			`"body":${JSON.stringify(markerBody({session: MINE, nonce: MY_NONCE}))}`,
 		);
 	});
 
@@ -168,7 +182,7 @@ describe("runClaim — winning", () => {
 	});
 
 	it("re-resolves rather than posting a second marker when this LANE already holds one", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests} = await run(
 			[
 				[ISSUE, issue("open")],
 				[LIST, comments(MY_MARKER)],
@@ -176,20 +190,20 @@ describe("runClaim — winning", () => {
 			{token: MY_TOKEN},
 		);
 		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
-		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
-		expect(calls.filter((c) => LIST.test(c))).toHaveLength(1);
+		expect(requests.filter((c) => POST.test(c))).toHaveLength(0);
+		expect(requests.filter((c) => LIST.test(c))).toHaveLength(1);
 	});
 });
 
 describe("runClaim — two lanes of one session", () => {
 	// The defect: both siblings share CLAUDE_CODE_SESSION_ID, so a session-only marker read each
 	// sibling's claim back as its own and both wrote the issue (#6132).
-	const race = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	const race = (): ReadonlyArray<Scripted> => [
 		[ISSUE, issue("open")],
 		[POST, posted(5001)],
 		[once(LIST), comments(SIBLING_MARKER)],
 		[LIST, comments(SIBLING_MARKER, MY_MARKER)],
-		[DELETE, okOut("")],
+		[DELETE, DELETED],
 	];
 
 	it("loses to a sibling lane of its own session instead of adopting its marker", async () => {
@@ -202,15 +216,15 @@ describe("runClaim — two lanes of one session", () => {
 	});
 
 	it("retracts its OWN marker on that loss, never the sibling's", async () => {
-		const {calls} = await run(race());
-		const deletes = calls.filter((c) => DELETE.test(c));
+		const {requests} = await run(race());
+		const deletes = requests.filter((c) => DELETE.test(c));
 		expect(deletes).toHaveLength(1);
 		expect(deletes[0]).toContain("issues/comments/5001");
 	});
 
 	it("posts its own marker rather than reading the sibling's as a re-entry", async () => {
-		const {calls} = await run(race());
-		expect(calls.filter((c) => POST.test(c))).toHaveLength(1);
+		const {requests} = await run(race());
+		expect(requests.filter((c) => POST.test(c))).toHaveLength(1);
 	});
 
 	it("wins when its own marker is the earliest — the sibling is later, not equal", async () => {
@@ -227,21 +241,21 @@ describe("runClaim — two lanes of one session", () => {
 
 describe("runClaim — --token", () => {
 	it("refuses at 1 on a token that is not a triage claim token", async () => {
-		const {outcome, calls} = await run([], {token: "build:whoever:0123456789ab"});
+		const {outcome, requests} = await run([], {token: "build:whoever:0123456789ab"});
 		expect(outcome.code).toBe(1);
 		expect(outcome.stderr.join("\n")).toContain("which lane is asking is not stated");
-		expect(calls).toHaveLength(0);
+		expect(requests).toHaveLength(0);
 	});
 
 	it("refuses at 1 on another session's token — a lane names itself, never another", async () => {
-		const {outcome, calls} = await run([], {token: composeClaimToken(THEIRS, SIBLING_UUID)});
+		const {outcome, requests} = await run([], {token: composeClaimToken(THEIRS, SIBLING_UUID)});
 		expect(outcome.code).toBe(1);
 		expect(outcome.stderr.join("\n")).toContain(`carries session ${THEIRS}`);
-		expect(calls).toHaveLength(0);
+		expect(requests).toHaveLength(0);
 	});
 
 	it("re-posts under the named lane when its marker aged out, and answers with that same token", async () => {
-		const {outcome, calls} = await run(
+		const {outcome, requests, bodies} = await run(
 			[
 				[ISSUE, issue("open")],
 				[POST, posted(5001)],
@@ -251,15 +265,15 @@ describe("runClaim — --token", () => {
 			{token: MY_TOKEN},
 		);
 		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
-		expect(calls.find((c) => POST.test(c))).toContain(
-			`body=${markerBody({session: MINE, nonce: MY_NONCE})}`,
+		expect(bodyOf(requests, bodies, POST)).toContain(
+			`"body":${JSON.stringify(markerBody({session: MINE, nonce: MY_NONCE}))}`,
 		);
 	});
 });
 
 describe("runClaim — losing", () => {
 	it("prints `lost\\t<holder>` at exit 0 and names the holder in full", async () => {
-		const {outcome} = await run([...losing(), [DELETE, okOut("")]]);
+		const {outcome} = await run([...losing(), [DELETE, DELETED]]);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe(`lost\t${THEIRS}\n`);
 		expect(outcome.stderr.join("\n")).toContain(
@@ -268,14 +282,14 @@ describe("runClaim — losing", () => {
 	});
 
 	it("deletes its OWN marker and only that one", async () => {
-		const {calls} = await run([...losing(), [DELETE, okOut("")]]);
-		const deletes = calls.filter((c) => DELETE.test(c));
+		const {requests} = await run([...losing(), [DELETE, DELETED]]);
+		const deletes = requests.filter((c) => DELETE.test(c));
 		expect(deletes).toHaveLength(1);
 		expect(deletes[0]).toContain("issues/comments/5001");
 	});
 
 	it("refuses at 9 when the conceded marker cannot be deleted — a live stale claim is not an aside", async () => {
-		const {outcome} = await run([...losing(), [DELETE, errOut("gh: Forbidden (HTTP 403)")]]);
+		const {outcome} = await run([...losing(), [DELETE, {status: 403, body: "{}"}]]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.join("\n")).toContain(
@@ -290,19 +304,19 @@ describe("runClaim — `won` requires positive proof", () => {
 			[ISSUE, issue("open")],
 			[POST, posted(5001)],
 			[once(LIST), comments()],
-			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
+			[LIST, UNREADABLE],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.join("\n")).toContain('no claim was resolved; never "won"');
 	});
 
-	it("refuses at 11 when the comment payload is not a list, even though gh exited 0", async () => {
+	it("refuses at 11 when the comment payload is not a list, even though GitHub answered 200", async () => {
 		const {outcome} = await run([
 			[ISSUE, issue("open")],
 			[POST, posted(5001)],
 			[once(LIST), comments()],
-			[LIST, okOut(JSON.stringify({message: "Not Found"}))],
+			[LIST, {status: 200, body: '{"message":"Not Found"}'}],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stdout).toBe("");
@@ -313,7 +327,7 @@ describe("runClaim — `won` requires positive proof", () => {
 			[ISSUE, issue("open")],
 			[POST, posted(5001)],
 			[once(LIST), comments()],
-			[LIST, okOut(JSON.stringify([{note: "no id here"}]))],
+			[LIST, {status: 200, body: '[{"note":"no id here"}]'}],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});
@@ -352,7 +366,7 @@ describe("runClaim — `won` requires positive proof", () => {
 			[POST, posted(5001)],
 			[once(LIST), comments(malformed)],
 			[LIST, comments(malformed, MY_MARKER)],
-			[DELETE, okOut("")],
+			[DELETE, DELETED],
 		]);
 		expect(outcome.stdout).toBe("lost\t\n");
 	});
@@ -360,14 +374,14 @@ describe("runClaim — `won` requires positive proof", () => {
 
 describe("runClaim — preconditions", () => {
 	it("refuses at 1 with an unset session id, and touches the network for nothing", async () => {
-		const {outcome, calls} = await run([], {
+		const {outcome, requests} = await run([], {
 			env: {CLAUDE_PIPELINE_REPO: "o/r"},
 		});
 		expect(outcome.code).toBe(1);
 		expect(outcome.stderr.join("\n")).toContain(
 			"CLAUDE_CODE_SESSION_ID is unset — refusing to post an unattributable claim.",
 		);
-		expect(calls).toHaveLength(0);
+		expect(requests).toHaveLength(0);
 	});
 
 	it("refuses at 1 on a session id that would not read back as itself", async () => {
@@ -379,36 +393,36 @@ describe("runClaim — preconditions", () => {
 	});
 
 	it("refuses at 7 on a proven-absent issue", async () => {
-		const {outcome} = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const {outcome} = await run([[ISSUE, NOT_FOUND]]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.join("\n")).toContain("issue #4312 not found in o/r.");
 	});
 
 	it("refuses at 7 on a closed issue — nothing to triage", async () => {
-		const {outcome, calls} = await run([[ISSUE, issue("closed")]]);
+		const {outcome, requests} = await run([[ISSUE, issue("closed")]]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
-		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
+		expect(requests.filter((c) => POST.test(c))).toHaveLength(0);
 	});
 
 	it("refuses at 11 on an unreadable issue — a 502 is not a fact about anything", async () => {
-		const {outcome} = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const {outcome} = await run([[ISSUE, UNREADABLE]]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("posts nothing when the FIRST comment read fails", async () => {
-		const {outcome, calls} = await run([
+		const {outcome, requests} = await run([
 			[ISSUE, issue("open")],
-			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
+			[LIST, UNREADABLE],
 		]);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
-		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
+		expect(requests.filter((c) => POST.test(c))).toHaveLength(0);
 	});
 
 	it("refuses at 8 when the marker POST itself fails — UNKNOWN whether it landed", async () => {
 		const {outcome} = await run([
 			[ISSUE, issue("open")],
 			[LIST, comments()],
-			[POST, errOut("gh: Service unavailable (HTTP 503)")],
+			[POST, {status: 503, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.join("\n")).toContain("re-run before mutating #4312.");
@@ -419,7 +433,7 @@ describe("runClaim — preconditions", () => {
 			[ISSUE, issue("open")],
 			[POST, posted(5001)],
 			[once(LIST), comments()],
-			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
+			[LIST, UNREADABLE],
 		]);
 		expect(outcome.stderr.join("\n")).toContain("this lane's marker 5001 is live on #4312");
 	});

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -1,9 +1,15 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
-import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
+import {
+	COMMENTS,
+	claimPage,
+	EXPIRED,
+	type GuardedSeams,
+	guardedShell,
+	LIVE,
+} from "./claim-fixtures.test-support.ts";
 import {
 	BARE_AT_PATH,
 	CLAIMED_ELSEWHERE,
@@ -18,26 +24,31 @@ import {
 import {MARKER_RE, renderMarker, SUMMARY_LINE} from "./enrich.ts";
 import {runEnrich} from "./enrich-verb.ts";
 
-const READ = /^gh api repos\/o\/r\/issues\/4312$/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4312 -f body=/;
+const READ = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/4312$/;
+
+const ACCEPTED: HttpReply = {status: 200, body: "{}"};
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const WRITE_FAILED: HttpReply = {status: 500, body: "{}"};
 
 const ORIGINAL = "## Summary\n\nThe editor loses focus after a save.";
 const REWRITE = "## What to build\n\nKeep focus on the editor across a save.";
 const PITCH =
 	"**Problem:** yazars lose their place\n**Arc:** fabrika campaign\n**Appetite:** 2 cycles\n**Rabbit-holes:** none\n**No-gos:** no rewrite";
 
-const issue = (body: string): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4312,
-			title: "t",
-			body,
-			state: "open",
-			labels: [],
-			html_url: "https://example.test/issues/4312",
-			milestone: null,
-		}),
-	);
+const issue = (body: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4312,
+		title: "t",
+		body,
+		state: "open",
+		labels: [],
+		html_url: "https://example.test/issues/4312",
+		milestone: null,
+	}),
+});
 
 const options = {
 	issue: 4312,
@@ -49,9 +60,12 @@ const options = {
 };
 
 /** The body the PATCH carried, or `null` when the verb wrote nothing. */
-const written = (calls: ReadonlyArray<string>): string | null => {
-	const call = calls.find((line) => PATCH.test(line));
-	return call === undefined ? null : call.slice(call.indexOf(" -f body=") + " -f body=".length);
+const written = (seams: GuardedSeams): string | null => {
+	const at = seams.requests.findIndex((line) => PATCH.test(line));
+	if (at < 0) return null;
+	const sent: unknown = JSON.parse(seams.bodies[at] ?? "{}");
+	const body = (sent as {readonly body?: unknown}).body;
+	return typeof body === "string" ? body : null;
 };
 
 /**
@@ -63,29 +77,26 @@ const written = (calls: ReadonlyArray<string>): string | null => {
 const run = async (before: string, overrides: Partial<typeof options> = {}) => {
 	const shell = guardedShell([
 		[once(READ), issue(before)],
-		[PATCH, okOut("{}")],
+		[PATCH, ACCEPTED],
 	]);
 	// Two passes: the first to learn what the verb writes, the second to feed it back as the read-back.
 	const probe = await Effect.runPromise(
 		Effect.provide(runEnrich({...options, ...overrides}), shell.layer),
 	);
-	const patched = written(shell.calls);
-	if (patched === null) return {outcome: probe, body: null, calls: shell.calls};
+	const patched = written(shell);
+	if (patched === null) return {outcome: probe, body: null, requests: shell.requests};
 	const echoing = guardedShell([
 		[once(READ), issue(before)],
-		[PATCH, okOut("{}")],
+		[PATCH, ACCEPTED],
 		[READ, issue(patched)],
 	]);
 	const outcome = await Effect.runPromise(
 		Effect.provide(runEnrich({...options, ...overrides}), echoing.layer),
 	);
-	return {outcome, body: patched, calls: echoing.calls};
+	return {outcome, body: patched, requests: echoing.requests};
 };
 
-const runScripted = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const runScripted = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(runEnrich({...options, ...overrides}), guardedShell(script).layer),
 	);
@@ -287,7 +298,7 @@ describe("runEnrich — the composed body's criteria block must be one the wire 
 		);
 		expect(outcome.code).toBe(MALFORMED_CRITERIA);
 		expect(outcome.stderr.at(-1)).toContain("heading level 2, expected 3");
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("accepts a conforming level-3 block", async () => {
@@ -331,7 +342,7 @@ describe("runEnrich — the composed body's criteria block must be one the wire 
 			),
 		);
 		expect(outcome.code).toBe(MALFORMED_CRITERIA);
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 });
 
@@ -353,7 +364,7 @@ describe("runEnrich — refusals", () => {
 			),
 		);
 		expect(outcome.code).toBe(EMPTY_STDIN);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	it("refuses a bare @ reference on 6", async () => {
@@ -379,21 +390,21 @@ describe("runEnrich — refusals", () => {
 		);
 		expect(outcome.code).toBe(LEAKED_PATH);
 		expect(outcome.stderr.at(-1)).toContain("rewrite it repo-relative");
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("refuses an issue proven absent on 7", async () => {
-		const outcome = await runScripted([[READ, errOut("gh: Not Found (HTTP 404)")]]);
+		const outcome = await runScripted([[READ, NOT_FOUND]]);
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.at(-1)).toBe("triage enrich: issue #4312 not found in o/r.");
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
-		const shell = guardedShell([[READ, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const shell = guardedShell([[READ, UNREADABLE]]);
 		const outcome = await Effect.runPromise(Effect.provide(runEnrich(options), shell.layer));
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("an original that was never read");
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("refuses an EMPTY body rather than preserving nothing as though it were the record", async () => {
@@ -401,13 +412,13 @@ describe("runEnrich — refusals", () => {
 		const outcome = await Effect.runPromise(Effect.provide(runEnrich(options), shell.layer));
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.at(-1)).toContain("there is no original to preserve");
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("reports a failed PATCH as UNKNOWN on 8, never as a failure to write", async () => {
 		const outcome = await runScripted([
 			[READ, issue(ORIGINAL)],
-			[PATCH, errOut("gh: timeout")],
+			[PATCH, WRITE_FAILED],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stdout).toBe("");
@@ -417,7 +428,7 @@ describe("runEnrich — refusals", () => {
 	it("refuses on 9 when the read-back does not match what was written", async () => {
 		const outcome = await runScripted([
 			[once(READ), issue(ORIGINAL)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue("something else entirely")],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
@@ -428,8 +439,8 @@ describe("runEnrich — refusals", () => {
 	it("refuses on 9 when the read-back itself fails", async () => {
 		const outcome = await runScripted([
 			[once(READ), issue(ORIGINAL)],
-			[PATCH, okOut("{}")],
-			[READ, errOut("gh: Bad gateway (HTTP 502)")],
+			[PATCH, ACCEPTED],
+			[READ, UNREADABLE],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 		expect(outcome.stderr.at(-1)).toContain("could not be read back");
@@ -439,7 +450,7 @@ describe("runEnrich — refusals", () => {
 		const composed = `${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
 		const outcome = await runScripted([
 			[once(READ), issue(ORIGINAL)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue(`${composed.replace(/\n/g, "\r\n")}\r\n\r\n`)],
 		]);
 		expect(outcome.code).toBe(0);
@@ -452,7 +463,7 @@ describe("runEnrich — refusals", () => {
 			Effect.provide(runEnrich({...options, env: {}}), shell.layer),
 		);
 		expect(outcome.code).toBe(1);
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 });
 
@@ -464,8 +475,9 @@ describe("runEnrich — the target guard", () => {
 		string,
 		string | undefined
 	>;
-	const closed = okOut(
-		JSON.stringify({
+	const closed: HttpReply = {
+		status: 200,
+		body: JSON.stringify({
 			number: 4312,
 			title: "t",
 			body: ORIGINAL,
@@ -474,14 +486,14 @@ describe("runEnrich — the target guard", () => {
 			html_url: "https://example.test/issues/4312",
 			milestone: null,
 		}),
-	);
+	};
 
-	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const guard = async (script: ReadonlyArray<Scripted>) => {
 		const shell = guardedShell(script);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runEnrich({...options, env: mine}), shell.layer),
 		);
-		return {outcome, patched: shell.calls.some((line) => PATCH.test(line))};
+		return {outcome, patched: shell.requests.some((line) => PATCH.test(line))};
 	};
 
 	it("refuses a closed issue on 7 and writes nothing", async () => {
@@ -494,7 +506,7 @@ describe("runEnrich — the target guard", () => {
 		const {outcome, patched} = await guard([
 			[READ, issue(ORIGINAL)],
 			[COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 		]);
 		expect(outcome.code).toBe(CLAIMED_ELSEWHERE);
 		expect(patched).toBe(false);
@@ -504,7 +516,7 @@ describe("runEnrich — the target guard", () => {
 		const {patched} = await guard([
 			[once(READ), issue(ORIGINAL)],
 			[COMMENTS, claimPage({session: MINE, createdAt: LIVE})],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue(ORIGINAL)],
 		]);
 		expect(patched).toBe(true);
@@ -513,7 +525,7 @@ describe("runEnrich — the target guard", () => {
 	it("writes over an issue nobody has claimed", async () => {
 		const {patched} = await guard([
 			[once(READ), issue(ORIGINAL)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue(ORIGINAL)],
 		]);
 		expect(patched).toBe(true);
@@ -523,7 +535,7 @@ describe("runEnrich — the target guard", () => {
 		const {patched} = await guard([
 			[once(READ), issue(ORIGINAL)],
 			[COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue(ORIGINAL)],
 		]);
 		expect(patched).toBe(true);

--- a/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
@@ -1,19 +1,30 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {ANSWER, FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {RUNNING_MARKER, runHomes} from "./homes-verb.ts";
 import {offeredLanes} from "./standing-lanes.ts";
 
-const MILESTONES = /repos\/o\/r\/milestones/;
-const LABELS = /repos\/o\/r\/labels/;
+const MILESTONES = /GET .*\/repos\/o\/r\/milestones\?/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+
+const labels = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+const milestones = (
+	...rows: ReadonlyArray<{readonly number: number; readonly title: string}>
+): HttpReply => ({status: 200, body: JSON.stringify(rows)});
 
 /** The shipped default lane set — what a repo declaring no `boardVocabulary` resolves to. */
 const PHOENIX_LANES = ["wayfinder:backlog", "axis:pipeline-hardening"];
 
 /** A board carrying both lane labels, so the presence filter offers both — phoenix's own state. */
-const bothLabels = [LABELS, okOut(["type:bug", ...PHOENIX_LANES].join("\n"))] as const;
+const bothLabels = [LABELS, labels("type:bug", ...PHOENIX_LANES)] as const;
 
 const ROADMAP = `## Arcs
 
@@ -37,7 +48,7 @@ const options = {
 };
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	script: ReadonlyArray<Scripted>,
 	files: Record<string, string | null> = {"ROADMAP.md": ROADMAP},
 	overrides: Partial<typeof options> = {},
 	fs: {
@@ -50,13 +61,13 @@ const run = (
 			runHomes({...options, ...overrides}),
 			// The label read is appended, never prepended: a case that scripts `LABELS` itself is
 			// asserting on the presence filter, and its entry has to win the first-match lookup.
-			Layer.merge(fakeShell([...script, bothLabels]).layer, fakeFs({files, ...fs}).layer),
+			Layer.merge(fakeSeams([...script, bothLabels]).layer, fakeFs({files, ...fs}).layer),
 		),
 	);
 
 const twoMilestones = [
 	MILESTONES,
-	okOut("24\tSözlük — search and discovery\n44\tfabrika"),
+	milestones({number: 24, title: "Sözlük — search and discovery"}, {number: 44, title: "fabrika"}),
 ] as const;
 
 describe("runHomes", () => {
@@ -83,7 +94,7 @@ describe("runHomes", () => {
 
 	it("reports an open milestone no roadmap row pins as null rather than hiding it", async () => {
 		const out = await run(
-			[[MILESTONES, okOut("99\toff-roadmap")]],
+			[[MILESTONES, milestones({number: 99, title: "off-roadmap"})]],
 			{"ROADMAP.md": ROADMAP},
 			{
 				json: true,
@@ -100,20 +111,20 @@ describe("runHomes", () => {
 	});
 
 	it("REFUSES zero open milestones — `no home exists` routes to an irreversible close", async () => {
-		const out = await run([[MILESTONES, okOut("")]]);
+		const out = await run([[MILESTONES, milestones()]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("0 open milestones");
 	});
 
 	it("still names the standing lanes on stderr when it refuses over zero milestones", async () => {
-		const out = await run([[MILESTONES, okOut("")]]);
+		const out = await run([[MILESTONES, milestones()]]);
 		expect(out.stderr.join("\n")).toContain("wayfinder:backlog");
 		expect(out.stderr.join("\n")).toContain("axis:pipeline-hardening");
 	});
 
 	it("refuses an unreadable milestone list as UNKNOWN — never as `no homes`", async () => {
-		const out = await run([[MILESTONES, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[MILESTONES, UNREADABLE]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("never empty");
@@ -170,7 +181,7 @@ describe("runHomes", () => {
 	});
 
 	it("still refuses zero open milestones when the roadmap is absent — the two guards are independent", async () => {
-		const out = await run([[MILESTONES, okOut("")]], {});
+		const out = await run([[MILESTONES, milestones()]], {});
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.join("\n")).toContain("0 open milestones");
 	});
@@ -189,15 +200,15 @@ describe("runHomes", () => {
 	});
 
 	it("pages the milestone read and asks only for open ones", async () => {
-		const shell = fakeShell([twoMilestones, bothLabels]);
+		const shell = fakeSeams([twoMilestones, bothLabels]);
 		await Effect.runPromise(
 			Effect.provide(
 				runHomes(options),
 				Layer.merge(shell.layer, fakeFs({files: {"ROADMAP.md": ROADMAP}}).layer),
 			),
 		);
-		const call = shell.calls.find((line) => line.includes("/milestones")) ?? "";
-		expect(call).toContain("--paginate");
+		const call = shell.requests.find((line) => line.includes("/milestones")) ?? "";
+		expect(call).toContain("per_page=100");
 		expect(call).toContain("state=open");
 	});
 
@@ -281,7 +292,7 @@ describe("runHomes and the running-campaign marker", () => {
 
 describe("runHomes and the standing lanes the host repo carries", () => {
 	it("offers a declared lane only when the board carries its label — the bare-repo arm", async () => {
-		const out = await run([twoMilestones, [LABELS, okOut("bug\nenhancement")]]);
+		const out = await run([twoMilestones, [LABELS, labels("bug", "enhancement")]]);
 		expect(out.code).toBe(ANSWER);
 		expect(out.stdout.trimEnd().split("\n")).toEqual([
 			"homes",
@@ -299,27 +310,27 @@ describe("runHomes and the standing lanes the host repo carries", () => {
 	});
 
 	it("drops only the missing lane when the board carries one of the two", async () => {
-		const out = await run([twoMilestones, [LABELS, okOut("wayfinder:backlog")]]);
+		const out = await run([twoMilestones, [LABELS, labels("wayfinder:backlog")]]);
 		expect(out.stdout).toContain("lane\twayfinder:backlog");
 		expect(out.stdout).not.toContain("axis:pipeline-hardening");
 	});
 
 	it("names the dropped labels on stderr, so the config/board gap is readable at the point it bites", async () => {
-		const out = await run([twoMilestones, [LABELS, okOut("bug")]]);
+		const out = await run([twoMilestones, [LABELS, labels("bug")]]);
 		expect(out.stderr.join("\n")).toContain(
 			"standing lanes: 0 of 2 declared carry a label in o/r — not offered: wayfinder:backlog, axis:pipeline-hardening.",
 		);
 	});
 
 	it("carries the offered lanes, not the declared set, into the --json payload", async () => {
-		const out = await run([twoMilestones, [LABELS, okOut("wayfinder:backlog")]], {}, {json: true});
+		const out = await run([twoMilestones, [LABELS, labels("wayfinder:backlog")]], {}, {json: true});
 		expect(JSON.parse(out.stdout).lanes).toEqual(
 			offeredLanes(PHOENIX_LANES, new Set(["wayfinder:backlog"])),
 		);
 	});
 
 	it("refuses an unreadable label list as UNKNOWN — never as `this repo declares no lanes`", async () => {
-		const out = await run([twoMilestones, [LABELS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([twoMilestones, [LABELS, UNREADABLE]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("which standing lanes this board accepts is UNKNOWN");
@@ -331,14 +342,14 @@ describe("runHomes and the standing lanes the host repo carries", () => {
 	 * `command.ts` passes what it read straight through (#6440).
 	 */
 	it("reads no labels at all when the repo declares no lanes — there is nothing to filter", async () => {
-		const shell = fakeShell([twoMilestones]);
+		const shell = fakeSeams([twoMilestones]);
 		await Effect.runPromise(
 			Effect.provide(
 				runHomes({...options, standingLanes: []}),
 				Layer.merge(shell.layer, fakeFs({files: {"ROADMAP.md": ROADMAP}}).layer),
 			),
 		);
-		expect(shell.calls.some((line) => line.includes("/labels"))).toBe(false);
+		expect(shell.requests.some((line) => line.includes("/labels"))).toBe(false);
 	});
 
 	it("says the repo declares none rather than printing a bare 0-of-0 count", async () => {

--- a/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import type {HttpReply, Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {
@@ -18,20 +17,41 @@ import {
 } from "./codes.ts";
 import {KILL_LABEL, runKill} from "./kill-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
-const DUPLICATE = /^gh api repos\/o\/r\/issues\/4290$/;
-const LABELS = /labels\?per_page=100/;
-const REASON_COMMENT = /repos\/o\/r\/issues\/4312\/comments -f/;
-const FOLD_COMMENT = /repos\/o\/r\/issues\/4290\/comments -f/;
-const APPLY_LABEL = /repos\/o\/r\/issues\/4312\/labels/;
-const CLOSE = /--method PATCH repos\/o\/r\/issues\/4312 -f state=closed/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const DUPLICATE = /GET .*\/repos\/o\/r\/issues\/4290$/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+const REASON_COMMENT = /POST .*\/repos\/o\/r\/issues\/4312\/comments$/;
+const FOLD_COMMENT = /POST .*\/repos\/o\/r\/issues\/4290\/comments$/;
+const APPLY_LABEL = /POST .*\/repos\/o\/r\/issues\/4312\/labels$/;
+const CLOSE = /PATCH .*\/repos\/o\/r\/issues\/4312$/;
+
+const ACCEPTED: HttpReply = {status: 200, body: "{}"};
+const LABELLED: HttpReply = {status: 200, body: "[]"};
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const WRITE_FAILED: HttpReply = {status: 500, body: "{}"};
+
+const labels = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+/** What the first request matching `pattern` carried as its JSON body. */
+const bodyOf = (
+	requests: ReadonlyArray<string>,
+	bodies: ReadonlyArray<string>,
+	pattern: RegExp,
+): string => {
+	const at = requests.findIndex((line) => pattern.test(line));
+	return at < 0 ? "" : (bodies[at] ?? "");
+};
 
 /**
  * A pattern that matches once and then never again.
  *
- * A kill makes the *same* `gh api repos/o/r/issues/<n>` call twice — the precondition read and the
- * read-back — and `fakeShell` resolves a line against the first pattern that matches, so scripting
- * the two to different answers needs a pattern that retires itself. It is a real `RegExp` subclass
+ * A kill reads the *same* `GET .../issues/<n>` endpoint twice — the precondition read and the
+ * read-back — and the fake resolves a line against the first pattern that matches, so scripting the
+ * two to different answers needs a pattern that retires itself. It is a real `RegExp` subclass
  * rather than a cast object because the package forbids type assertions.
  */
 class FirstCallOnly extends RegExp {
@@ -47,34 +67,35 @@ const firstCallOnly = (re: RegExp): RegExp => new FirstCallOnly(re.source, re.fl
 
 const FOOTER = "---\n<sub>Filed by an agent · 2026-01-01T00:00:00Z</sub>";
 
-const issue = (over: Record<string, unknown> = {}) =>
-	okOut(
-		JSON.stringify({
-			number: 4312,
-			title: "t",
-			body: `## Summary\n\nsomething\n\n${FOOTER}`,
-			state: "open",
-			labels: [],
-			html_url: "https://example.test/issues/4312",
-			...over,
-		}),
-	);
+const issue = (over: Record<string, unknown> = {}): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4312,
+		title: "t",
+		body: `## Summary\n\nsomething\n\n${FOOTER}`,
+		state: "open",
+		labels: [],
+		html_url: "https://example.test/issues/4312",
+		...over,
+	}),
+});
 
-const duplicate = (over: Record<string, unknown> = {}) =>
-	okOut(
-		JSON.stringify({
-			number: 4290,
-			title: "survivor",
-			body: "the surviving issue",
-			state: "open",
-			labels: [],
-			html_url: "https://example.test/issues/4290",
-			...over,
-		}),
-	);
+const duplicate = (over: Record<string, unknown> = {}): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4290,
+		title: "survivor",
+		body: "the surviving issue",
+		state: "open",
+		labels: [],
+		html_url: "https://example.test/issues/4290",
+		...over,
+	}),
+});
 
-const killed = okOut(
-	JSON.stringify({
+const killed: HttpReply = {
+	status: 200,
+	body: JSON.stringify({
 		number: 4312,
 		title: "t",
 		body: `## Summary\n\nsomething\n\n${FOOTER}`,
@@ -83,13 +104,14 @@ const killed = okOut(
 		labels: [{name: KILL_LABEL}],
 		html_url: "https://example.test/issues/4312",
 	}),
-);
+};
 
-const comment = okOut(
-	JSON.stringify({id: 99, html_url: "https://example.test/issues/4312#issuecomment-99"}),
-);
+const comment: HttpReply = {
+	status: 201,
+	body: JSON.stringify({id: 99, html_url: "https://example.test/issues/4312#issuecomment-99"}),
+};
 
-const labelSet = okOut([KILL_LABEL, "status:needs-triage", "p1"].join("\n"));
+const labelSet = labels(KILL_LABEL, "status:needs-triage", "p1");
 
 const REASON = "Superseded by the merged contract; nothing here moves forward.";
 
@@ -110,36 +132,33 @@ const OPERATOR_ENV = {
 } as Record<string, string | undefined>;
 
 /** The whole sequence green: precondition read, label set, three writes, a not-planned read-back. */
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const happy = (): ReadonlyArray<Scripted> => [
 	[firstCallOnly(ISSUE), issue()],
 	[ISSUE, killed],
 	[LABELS, labelSet],
 	[REASON_COMMENT, comment],
-	[APPLY_LABEL, okOut("[]")],
-	[CLOSE, okOut("{}")],
+	[APPLY_LABEL, LABELLED],
+	[CLOSE, ACCEPTED],
 ];
 
-const runWith = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) => {
+const runWith = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
 	const shell = guardedShell(script);
 	return Effect.runPromise(Effect.provide(runKill({...options, ...overrides}), shell.layer)).then(
-		(out) => ({out, calls: shell.calls}),
+		(out) => ({out, requests: shell.requests, bodies: shell.bodies}),
 	);
 };
 
 describe("runKill", () => {
 	it("closes not-planned and prints the outcome line", async () => {
-		const {out, calls} = await runWith(happy());
+		const {out, requests} = await runWith(happy());
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("killed\t4312\tnone\n");
-		expect(calls.filter((c) => CLOSE.test(c))).toHaveLength(1);
+		expect(requests.filter((c) => CLOSE.test(c))).toHaveLength(1);
 	});
 
 	it("writes in the order that keeps a failure recoverable: reason, label, close", async () => {
-		const {calls} = await runWith(happy());
-		const at = (re: RegExp) => calls.findIndex((c) => re.test(c));
+		const {requests} = await runWith(happy());
+		const at = (re: RegExp) => requests.findIndex((c) => re.test(c));
 		expect(at(REASON_COMMENT)).toBeLessThan(at(APPLY_LABEL));
 		expect(at(APPLY_LABEL)).toBeLessThan(at(CLOSE));
 	});
@@ -163,18 +182,18 @@ describe("runKill", () => {
 	// --- the provenance guard ------------------------------------------------------------------
 
 	it("refuses a human-filed issue on 12 and writes nothing", async () => {
-		const {out, calls} = await runWith([
+		const {out, requests} = await runWith([
 			[firstCallOnly(ISSUE), issue({body: "I typed this myself."})],
 			...happy().slice(1),
 		]);
 		expect(out.code).toBe(HUMAN_FILED);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("Park it with questions instead.");
-		expect(calls.some((c) => CLOSE.test(c) || REASON_COMMENT.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c) || REASON_COMMENT.test(c))).toBe(false);
 	});
 
 	it("refuses a body that merely QUOTES the footer — an unanchored match would close it", async () => {
-		const {out, calls} = await runWith([
+		const {out, requests} = await runWith([
 			[
 				firstCallOnly(ISSUE),
 				issue({body: 'The footer text "Filed by an agent" renders wrong on mobile.'}),
@@ -182,7 +201,7 @@ describe("runKill", () => {
 			...happy().slice(1),
 		]);
 		expect(out.code).toBe(HUMAN_FILED);
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	it("refuses an empty body as human, and says the answer was defaulted", async () => {
@@ -200,7 +219,7 @@ describe("runKill", () => {
 	});
 
 	it("kills a FOOTERLESS filing authored by a configured operator account (#4619)", async () => {
-		const {out, calls} = await runWith(
+		const {out, requests} = await runWith(
 			[
 				[
 					firstCallOnly(ISSUE),
@@ -212,11 +231,11 @@ describe("runKill", () => {
 			{env: OPERATOR_ENV},
 		);
 		expect(out.code).toBe(0);
-		expect(calls.filter((c) => CLOSE.test(c))).toHaveLength(1);
+		expect(requests.filter((c) => CLOSE.test(c))).toHaveLength(1);
 	});
 
 	it("still refuses a footerless filing by any OTHER author, operator set configured", async () => {
-		const {out, calls} = await runWith(
+		const {out, requests} = await runWith(
 			[
 				[firstCallOnly(ISSUE), issue({body: "no footer at all", user: {login: "cansirin"}})],
 				...happy().slice(1),
@@ -224,7 +243,7 @@ describe("runKill", () => {
 			{env: OPERATOR_ENV},
 		);
 		expect(out.code).toBe(HUMAN_FILED);
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	it("drops the empty-body fail-closed notice when the operator author decided the answer", async () => {
@@ -241,19 +260,19 @@ describe("runKill", () => {
 	});
 
 	it("refuses an UNREADABLE body on 11, never as a human verdict", async () => {
-		const {out, calls} = await runWith([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const {out, requests} = await runWith([[ISSUE, UNREADABLE]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("a body that was never read");
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	// --- the confirmation guard ----------------------------------------------------------------
 
 	it("refuses an agent-filed issue without --confirm on 13, and writes nothing", async () => {
-		const {out, calls} = await runWith(happy(), {confirm: false});
+		const {out, requests} = await runWith(happy(), {confirm: false});
 		expect(out.code).toBe(UNCONFIRMED);
 		expect(out.stderr.at(-1)).toContain("ADR 0159");
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	it("checks provenance BEFORE confirmation — a human-filed issue refuses on 12 either way", async () => {
@@ -267,7 +286,7 @@ describe("runKill", () => {
 	// --- preconditions -------------------------------------------------------------------------
 
 	it("refuses an absent issue on 7", async () => {
-		const {out} = await runWith([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const {out} = await runWith([[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("triage kill: issue #4312 not found in o/r.");
 	});
@@ -282,29 +301,29 @@ describe("runKill", () => {
 	});
 
 	it("refuses when closed-by-triage is absent from the repo — the kill would be unauditable", async () => {
-		const {out, calls} = await runWith([
+		const {out, requests} = await runWith([
 			[firstCallOnly(ISSUE), issue()],
 			[ISSUE, killed],
-			[LABELS, okOut("p1\nstatus:needs-triage")],
+			[LABELS, labels("p1", "status:needs-triage")],
 			...happy().slice(3),
 		]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("invisible to the audit");
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	it("refuses an unreadable label set on 11, not on 7", async () => {
 		const {out} = await runWith([
 			[firstCallOnly(ISSUE), issue()],
 			[ISSUE, killed],
-			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, UNREADABLE],
 			...happy().slice(3),
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("refuses a closed --duplicate-of on 7 — nobody would read the fold", async () => {
-		const {out, calls} = await runWith(
+		const {out, requests} = await runWith(
 			[
 				[firstCallOnly(ISSUE), issue()],
 				[ISSUE, killed],
@@ -314,7 +333,7 @@ describe("runKill", () => {
 			{duplicateOf: 4290},
 		);
 		expect(out.code).toBe(ZERO_SCOPE);
-		expect(calls.some((c) => FOLD_COMMENT.test(c))).toBe(false);
+		expect(requests.some((c) => FOLD_COMMENT.test(c))).toBe(false);
 	});
 
 	it("refuses an absent --duplicate-of on 7", async () => {
@@ -322,7 +341,7 @@ describe("runKill", () => {
 			[
 				[firstCallOnly(ISSUE), issue()],
 				[ISSUE, killed],
-				[DUPLICATE, errOut("gh: Not Found (HTTP 404)")],
+				[DUPLICATE, NOT_FOUND],
 				...happy().slice(2),
 			],
 			{duplicateOf: 4290},
@@ -335,7 +354,7 @@ describe("runKill", () => {
 			[
 				[firstCallOnly(ISSUE), issue()],
 				[ISSUE, killed],
-				[DUPLICATE, errOut("gh: Bad gateway (HTTP 502)")],
+				[DUPLICATE, UNREADABLE],
 				...happy().slice(2),
 			],
 			{duplicateOf: 4290},
@@ -390,7 +409,7 @@ describe("runKill", () => {
 	});
 
 	it("refuses a machine-local path in the authored reason on 5, listing every hit", async () => {
-		const {out, calls} = await runWith(happy(), {
+		const {out, requests} = await runWith(happy(), {
 			stdin: Effect.succeed({
 				_tag: "Text",
 				text: "see /Users/someone/notes/why.md\nand /Users/someone/notes/how.md",
@@ -404,13 +423,13 @@ describe("runKill", () => {
 			"  line 1, absolute home root",
 			"  line 2, absolute home root",
 		]);
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	// --- the duplicate fold --------------------------------------------------------------------
 
 	it("folds the redacted body into the survivor and names it on stdout", async () => {
-		const {out, calls} = await runWith(
+		const {out, requests, bodies} = await runWith(
 			[
 				[firstCallOnly(ISSUE), issue({body: `repro at /Users/someone/x.md\n\n${FOOTER}`})],
 				[ISSUE, killed],
@@ -418,21 +437,21 @@ describe("runKill", () => {
 				[LABELS, labelSet],
 				[FOLD_COMMENT, comment],
 				[REASON_COMMENT, comment],
-				[APPLY_LABEL, okOut("[]")],
-				[CLOSE, okOut("{}")],
+				[APPLY_LABEL, LABELLED],
+				[CLOSE, ACCEPTED],
 			],
 			{duplicateOf: 4290},
 		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("killed\t4312\t4290\n");
-		const fold = calls.find((c) => FOLD_COMMENT.test(c)) ?? "";
+		const fold = bodyOf(requests, bodies, FOLD_COMMENT);
 		expect(fold).toContain("/Users/<redacted>");
 		expect(fold).not.toContain("/Users/someone/x.md");
 		expect(out.stderr.join("\n")).toContain("redacted 1 machine-local path(s)");
 	});
 
 	it("folds before it comments, and comments before it closes", async () => {
-		const {calls} = await runWith(
+		const {requests} = await runWith(
 			[
 				[firstCallOnly(ISSUE), issue()],
 				[ISSUE, killed],
@@ -440,12 +459,12 @@ describe("runKill", () => {
 				[LABELS, labelSet],
 				[FOLD_COMMENT, comment],
 				[REASON_COMMENT, comment],
-				[APPLY_LABEL, okOut("[]")],
-				[CLOSE, okOut("{}")],
+				[APPLY_LABEL, LABELLED],
+				[CLOSE, ACCEPTED],
 			],
 			{duplicateOf: 4290},
 		);
-		const at = (re: RegExp) => calls.findIndex((c) => re.test(c));
+		const at = (re: RegExp) => requests.findIndex((c) => re.test(c));
 		expect(at(FOLD_COMMENT)).toBeLessThan(at(REASON_COMMENT));
 		expect(at(REASON_COMMENT)).toBeLessThan(at(CLOSE));
 	});
@@ -453,20 +472,20 @@ describe("runKill", () => {
 	// --- the four gated writes -----------------------------------------------------------------
 
 	it("stops at a failed fold: nothing else is attempted and nothing was lost", async () => {
-		const {out, calls} = await runWith(
+		const {out, requests} = await runWith(
 			[
 				[firstCallOnly(ISSUE), issue()],
 				[ISSUE, killed],
 				[DUPLICATE, duplicate()],
 				[LABELS, labelSet],
-				[FOLD_COMMENT, errOut("gh: timeout")],
+				[FOLD_COMMENT, WRITE_FAILED],
 				...happy().slice(3),
 			],
 			{duplicateOf: 4290},
 		);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was lost. Re-run.");
-		expect(calls.some((c) => REASON_COMMENT.test(c) || CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => REASON_COMMENT.test(c) || CLOSE.test(c))).toBe(false);
 	});
 
 	it("names the landed fold when the reason comment fails — a blind re-run would double-post", async () => {
@@ -477,9 +496,9 @@ describe("runKill", () => {
 				[DUPLICATE, duplicate()],
 				[LABELS, labelSet],
 				[FOLD_COMMENT, comment],
-				[REASON_COMMENT, errOut("gh: timeout")],
-				[APPLY_LABEL, okOut("[]")],
-				[CLOSE, okOut("{}")],
+				[REASON_COMMENT, WRITE_FAILED],
+				[APPLY_LABEL, LABELLED],
+				[CLOSE, ACCEPTED],
 			],
 			{duplicateOf: 4290},
 		);
@@ -488,31 +507,31 @@ describe("runKill", () => {
 	});
 
 	it("stops at a failed reason comment: the issue stays open and unlabelled", async () => {
-		const {out, calls} = await runWith([
+		const {out, requests} = await runWith([
 			[firstCallOnly(ISSUE), issue()],
 			[ISSUE, killed],
 			[LABELS, labelSet],
-			[REASON_COMMENT, errOut("gh: timeout")],
-			[APPLY_LABEL, okOut("[]")],
-			[CLOSE, okOut("{}")],
+			[REASON_COMMENT, WRITE_FAILED],
+			[APPLY_LABEL, LABELLED],
+			[CLOSE, ACCEPTED],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("is NOT closed");
-		expect(calls.some((c) => APPLY_LABEL.test(c) || CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => APPLY_LABEL.test(c) || CLOSE.test(c))).toBe(false);
 	});
 
 	it("stops at a failed label: the issue stays OPEN rather than closed and unauditable", async () => {
-		const {out, calls} = await runWith([
+		const {out, requests} = await runWith([
 			[firstCallOnly(ISSUE), issue()],
 			[ISSUE, killed],
 			[LABELS, labelSet],
 			[REASON_COMMENT, comment],
-			[APPLY_LABEL, errOut("gh: timeout")],
-			[CLOSE, okOut("{}")],
+			[APPLY_LABEL, WRITE_FAILED],
+			[CLOSE, ACCEPTED],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("still OPEN and invisible to the kill audit");
-		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+		expect(requests.some((c) => CLOSE.test(c))).toBe(false);
 	});
 
 	it("reports a failed close as UNKNOWN with the by-hand recovery", async () => {
@@ -521,8 +540,8 @@ describe("runKill", () => {
 			[ISSUE, killed],
 			[LABELS, labelSet],
 			[REASON_COMMENT, comment],
-			[APPLY_LABEL, okOut("[]")],
-			[CLOSE, errOut("gh: timeout")],
+			[APPLY_LABEL, LABELLED],
+			[CLOSE, WRITE_FAILED],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("state_reason=not_planned");
@@ -535,18 +554,19 @@ describe("runKill", () => {
 			[firstCallOnly(ISSUE), issue()],
 			[
 				ISSUE,
-				okOut(
-					JSON.stringify({
-						...JSON.parse(issue().stdout),
+				{
+					status: 200,
+					body: JSON.stringify({
+						...JSON.parse(issue().body),
 						state: "closed",
 						state_reason: "completed",
 					}),
-				),
+				},
 			],
 			[LABELS, labelSet],
 			[REASON_COMMENT, comment],
-			[APPLY_LABEL, okOut("[]")],
-			[CLOSE, okOut("{}")],
+			[APPLY_LABEL, LABELLED],
+			[CLOSE, ACCEPTED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("reads as done rather than killed");
@@ -555,11 +575,11 @@ describe("runKill", () => {
 	it("refuses when the read-back itself fails — the writes landed but the close is unproven", async () => {
 		const {out} = await runWith([
 			[firstCallOnly(ISSUE), issue()],
-			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, UNREADABLE],
 			[LABELS, labelSet],
 			[REASON_COMMENT, comment],
-			[APPLY_LABEL, okOut("[]")],
-			[CLOSE, okOut("{}")],
+			[APPLY_LABEL, LABELLED],
+			[CLOSE, ACCEPTED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("the close is unverified");
@@ -583,9 +603,9 @@ describe("runKill — the target guard", () => {
 		CLAUDE_CODE_SESSION_ID: MINE,
 	} as Record<string, string | undefined>;
 
-	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
-		const {out, calls} = await runWith(script, {env: mine});
-		return {out, wrote: calls.some((line) => CLOSE.test(line) || REASON_COMMENT.test(line))};
+	const guard = async (script: ReadonlyArray<Scripted>) => {
+		const {out, requests} = await runWith(script, {env: mine});
+		return {out, wrote: requests.some((line) => CLOSE.test(line) || REASON_COMMENT.test(line))};
 	};
 
 	it("refuses a closed issue on 7 and writes nothing", async () => {

--- a/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {
 	COMMENTS,
@@ -25,38 +24,54 @@ import {
 } from "./codes.ts";
 import {runPark} from "./park-verb.ts";
 
-const ISSUE = /^gh api repos\/o\/r\/issues\/4290$/;
-const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
-const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4290\/comments /;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4290 -F milestone=/;
-const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4290\/labels\//;
-const ADD = /^gh api --method POST repos\/o\/r\/issues\/4290\/labels /;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4290$/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+const COMMENT = /POST .*\/repos\/o\/r\/issues\/4290\/comments$/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/4290$/;
+const REMOVE = /DELETE .*\/repos\/o\/r\/issues\/4290\/labels\//;
+const ADD = /POST .*\/repos\/o\/r\/issues\/4290\/labels$/;
+
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const WRITE_FAILED: HttpReply = {status: 500, body: "{}"};
+const ACCEPTED: HttpReply = {status: 200, body: "{}"};
+const LABELLED: HttpReply = {status: 200, body: "[]"};
+
+const labelSet = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
 
 const QUESTIONS = "Which of the two sozluk surfaces does this cover?";
 
-const issue = (labels: ReadonlyArray<string>, milestone: number | null): ExecResult =>
-	okOut(
-		JSON.stringify({
-			number: 4290,
-			title: "t",
-			body: "b",
-			state: "open",
-			labels: labels.map((name) => ({name})),
-			html_url: "https://example.test/issues/4290",
-			milestone: milestone === null ? null : {number: milestone},
-		}),
-	);
+const issue = (labels: ReadonlyArray<string>, milestone: number | null): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4290,
+		title: "t",
+		body: "b",
+		state: "open",
+		labels: labels.map((name) => ({name})),
+		html_url: "https://example.test/issues/4290",
+		milestone: milestone === null ? null : {number: milestone},
+	}),
+});
 
-const VOCABULARY = okOut(
-	["type:bug", "p1", "status:needs-triage", "status:needs-info", "ready-for:agent"].join("\n"),
+const VOCABULARY = labelSet(
+	"type:bug",
+	"p1",
+	"status:needs-triage",
+	"status:needs-info",
+	"ready-for:agent",
 );
 
-const POSTED = okOut(
-	JSON.stringify({
+const POSTED: HttpReply = {
+	status: 201,
+	body: JSON.stringify({
 		id: 5170421888,
 		html_url: "https://example.test/issues/4290#issuecomment-5170421888",
 	}),
-);
+};
 
 const options = {
 	issue: 4290,
@@ -68,20 +83,17 @@ const options = {
 };
 
 /** Observed: a fully priced issue. Read back: nothing but the parked status. */
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+const happy = (): ReadonlyArray<Scripted> => [
 	[once(ISSUE), issue(["type:bug", "p1", "status:triaged", "ready-for:agent"], 47)],
 	[ISSUE, issue(["status:needs-info"], null)],
 	[LABELS, VOCABULARY],
 	[COMMENT, POSTED],
-	[PATCH, okOut("{}")],
-	[REMOVE, okOut("[]")],
-	[ADD, okOut("[]")],
+	[PATCH, ACCEPTED],
+	[REMOVE, LABELLED],
+	[ADD, LABELLED],
 ];
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
 		Effect.provide(runPark({...options, ...overrides}), triageContext(guardedShell(script))),
 	);
@@ -108,7 +120,7 @@ describe("runPark under a refused config", () => {
 		await Effect.runPromise(
 			Effect.provide(runPark(options), triageContext(shell, VIOLATING_CONFIG)),
 		);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	/** The same three non-decoding arms `apply` refuses — one guard, so one set of cases. */
@@ -123,7 +135,7 @@ describe("runPark under a refused config", () => {
 		);
 		expect(out.code).toBe(CONFIG_REFUSED);
 		expect(out.stderr.join(" ")).toContain(expected);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 });
 
@@ -154,24 +166,29 @@ describe("runPark", () => {
 	it("posts the questions BEFORE it touches a label", async () => {
 		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runPark(options), triageContext(shell)));
-		const writes = shell.calls.filter(
-			(c) => COMMENT.test(c) || PATCH.test(c) || REMOVE.test(c) || ADD.test(c),
-		);
-		expect(writes[0]).toContain("/comments");
-		expect(writes[0]).toContain(`body=${QUESTIONS}`);
+		const writes = shell.requests
+			.map((line, at) => ({line, body: shell.bodies[at] ?? ""}))
+			.filter(
+				({line}) => COMMENT.test(line) || PATCH.test(line) || REMOVE.test(line) || ADD.test(line),
+			);
+		expect(writes[0]?.line).toContain("/comments");
+		expect(writes[0]?.body).toContain(`"body":${JSON.stringify(QUESTIONS)}`);
 	});
 
 	it("clears every priced facet, milestone included", async () => {
 		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runPark(options), triageContext(shell)));
-		expect(shell.calls).toContain("gh api --method PATCH repos/o/r/issues/4290 -F milestone=null");
-		expect(shell.calls.filter((c) => REMOVE.test(c))).toEqual([
-			"gh api --method DELETE repos/o/r/issues/4290/labels/type%3Abug",
-			"gh api --method DELETE repos/o/r/issues/4290/labels/p1",
-			"gh api --method DELETE repos/o/r/issues/4290/labels/status%3Atriaged",
-			"gh api --method DELETE repos/o/r/issues/4290/labels/ready-for%3Aagent",
+		const patchedAt = shell.requests.findIndex((c) => PATCH.test(c));
+		expect(patchedAt).toBeGreaterThanOrEqual(0);
+		expect(shell.bodies[patchedAt]).toBe('{"milestone":null}');
+		expect(shell.requests.filter((c) => REMOVE.test(c))).toEqual([
+			"DELETE https://api.github.com/repos/o/r/issues/4290/labels/type%3Abug",
+			"DELETE https://api.github.com/repos/o/r/issues/4290/labels/p1",
+			"DELETE https://api.github.com/repos/o/r/issues/4290/labels/status%3Atriaged",
+			"DELETE https://api.github.com/repos/o/r/issues/4290/labels/ready-for%3Aagent",
 		]);
-		expect(shell.calls.find((c) => ADD.test(c))).toContain("labels[]=status:needs-info");
+		const addedAt = shell.requests.findIndex((c) => ADD.test(c));
+		expect(shell.bodies[addedAt]).toContain('"labels":["status:needs-info"]');
 	});
 
 	it("leaves a label no facet owns alone across a park", async () => {
@@ -180,12 +197,12 @@ describe("runPark", () => {
 			[ISSUE, issue(["area:pipeline", "status:needs-info"], null)],
 			[LABELS, VOCABULARY],
 			[COMMENT, POSTED],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPark(options), triageContext(shell)));
 		expect(out.code).toBe(0);
-		expect(shell.calls.some((c) => c.includes("area%3Apipeline"))).toBe(false);
+		expect(shell.requests.some((c) => c.includes("area%3Apipeline"))).toBe(false);
 	});
 
 	it("refuses a FAILED stdin read on 1, never on the empty code", async () => {
@@ -272,38 +289,38 @@ describe("runPark", () => {
 				triageContext(shell),
 			),
 		);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	it("refuses an issue proven absent on 7", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, NOT_FOUND]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe("triage park: issue #4290 not found in o/r.");
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and posts nothing", async () => {
-		const shell = guardedShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const shell = guardedShell([[ISSUE, UNREADABLE]]);
 		const out = await Effect.runPromise(Effect.provide(runPark(options), triageContext(shell)));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(shell.calls.some((c) => COMMENT.test(c))).toBe(false);
+		expect(shell.requests.some((c) => COMMENT.test(c))).toBe(false);
 	});
 
 	it("refuses to write status:needs-info when the repo does not define it (#4285)", async () => {
 		const shell = guardedShell([
 			[ISSUE, issue(["status:needs-triage"], null)],
-			[LABELS, okOut(["type:bug", "status:needs-triage"].join("\n"))],
+			[LABELS, labelSet("type:bug", "status:needs-triage")],
 			[COMMENT, POSTED],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPark(options), triageContext(shell)));
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toContain("label status:needs-info does not exist");
-		expect(shell.calls.some((c) => COMMENT.test(c))).toBe(false);
+		expect(shell.requests.some((c) => COMMENT.test(c))).toBe(false);
 	});
 
 	it("refuses an unreadable label set as UNKNOWN, never as an empty vocabulary", async () => {
 		const out = await run([
 			[ISSUE, issue(["status:needs-triage"], null)],
-			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, UNREADABLE],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("cannot read the label set");
@@ -313,13 +330,13 @@ describe("runPark", () => {
 		const shell = guardedShell([
 			[ISSUE, issue(["status:needs-triage"], null)],
 			[LABELS, VOCABULARY],
-			[COMMENT, errOut("gh: timeout")],
+			[COMMENT, WRITE_FAILED],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPark(options), triageContext(shell)));
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("nothing was labelled");
-		expect(shell.calls.some((c) => REMOVE.test(c) || ADD.test(c))).toBe(false);
+		expect(shell.requests.some((c) => REMOVE.test(c) || ADD.test(c))).toBe(false);
 	});
 
 	it("distinguishes a failed label swap — the questions landed, the labels may be partial", async () => {
@@ -328,8 +345,8 @@ describe("runPark", () => {
 			[ISSUE, issue([], null)],
 			[LABELS, VOCABULARY],
 			[COMMENT, POSTED],
-			[REMOVE, errOut("gh: timeout")],
-			[ADD, okOut("[]")],
+			[REMOVE, WRITE_FAILED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("the questions landed but the label swap failed");
@@ -341,8 +358,8 @@ describe("runPark", () => {
 			[ISSUE, issue(["status:needs-info", "p1"], null)],
 			[LABELS, VOCABULARY],
 			[COMMENT, POSTED],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stdout).toBe("");
@@ -355,8 +372,8 @@ describe("runPark", () => {
 			[ISSUE, issue(["status:needs-info", "status:triaged"], null)],
 			[LABELS, VOCABULARY],
 			[COMMENT, POSTED],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 	});
@@ -367,9 +384,9 @@ describe("runPark", () => {
 			[ISSUE, issue(["status:needs-info"], 47)],
 			[LABELS, VOCABULARY],
 			[COMMENT, POSTED],
-			[PATCH, okOut("{}")],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[PATCH, ACCEPTED],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("milestone=47");
@@ -378,11 +395,11 @@ describe("runPark", () => {
 	it("refuses when the read-back itself fails", async () => {
 		const out = await run([
 			[once(ISSUE), issue(["status:triaged"], null)],
-			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, UNREADABLE],
 			[LABELS, VOCABULARY],
 			[COMMENT, POSTED],
-			[REMOVE, okOut("[]")],
-			[ADD, okOut("[]")],
+			[REMOVE, LABELLED],
+			[ADD, LABELLED],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
 		expect(out.stderr.at(-1)).toContain("read-back shows nothing");
@@ -410,8 +427,9 @@ describe("runPark — the target guard", () => {
 		string,
 		string | undefined
 	>;
-	const closed = okOut(
-		JSON.stringify({
+	const closed: HttpReply = {
+		status: 200,
+		body: JSON.stringify({
 			number: 4290,
 			title: "t",
 			body: "b",
@@ -420,14 +438,14 @@ describe("runPark — the target guard", () => {
 			html_url: "https://example.test/issues/4290",
 			milestone: null,
 		}),
-	);
+	};
 
-	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const guard = async (script: ReadonlyArray<Scripted>) => {
 		const shell = guardedShell(script);
 		const out = await Effect.runPromise(
 			Effect.provide(runPark({...options, env: mine}), triageContext(shell)),
 		);
-		return {out, wrote: shell.calls.some((line) => COMMENT.test(line) || ADD.test(line))};
+		return {out, wrote: shell.requests.some((line) => COMMENT.test(line) || ADD.test(line))};
 	};
 
 	it("refuses a closed issue on 7 and writes nothing", async () => {

--- a/packages/fabrika-cli/src/triage/provenance-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/provenance-verb.unit.test.ts
@@ -1,11 +1,11 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, type Scripted} from "../fakes.test-support.ts";
 import {ANSWER, FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {runProvenance} from "./provenance-verb.ts";
 
-const ISSUE = /repos\/o\/r\/issues\/4312/;
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
 
 const options = {
 	issue: 4312,
@@ -31,57 +31,56 @@ const issueJson = (body: string, author = "someone-else") =>
 		user: {login: author},
 	});
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const served = (body: string) => ({status: 200, body});
+
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(runProvenance({...options, ...overrides}), fakeShell(script).layer),
+		Effect.provide(runProvenance({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 const AGENT_BODY = "What I observed.\n\n---\n<sub>Filed by an agent · 2026-08-03T05:47:38Z</sub>\n";
 
 describe("runProvenance", () => {
 	it("answers `agent` on the footer, on stdout, exit 0", async () => {
-		const out = await run([[ISSUE, okOut(issueJson(AGENT_BODY))]]);
+		const out = await run([[ISSUE, served(issueJson(AGENT_BODY))]]);
 		expect(out.code).toBe(ANSWER);
 		expect(out.stdout).toBe("agent\n");
 	});
 
 	it("answers `human` for a hand-typed body", async () => {
-		const out = await run([[ISSUE, okOut(issueJson("I hit a bug in the retry helper.\n"))]]);
+		const out = await run([[ISSUE, served(issueJson("I hit a bug in the retry helper.\n"))]]);
 		expect(out.code).toBe(ANSWER);
 		expect(out.stdout).toBe("human\n");
 	});
 
 	it("answers `human` for a PRESENT-but-empty body — a measurement, fail-closed", async () => {
-		const out = await run([[ISSUE, okOut(issueJson("   \n"))]]);
+		const out = await run([[ISSUE, served(issueJson("   \n"))]]);
 		expect(out.code).toBe(ANSWER);
 		expect(out.stdout).toBe("human\n");
 		expect(out.stderr.join("\n")).toContain("empty body");
 	});
 
 	it("REFUSES an unreadable issue as UNKNOWN — never `human`, which a kill acts on", async () => {
-		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[ISSUE, {status: 502, body: "{}"}]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("UNKNOWN");
 	});
 
 	it("refuses a PROVEN-absent issue on the zero-scope code, apart from the unknown one", async () => {
-		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		const out = await run([[ISSUE, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 	});
 
 	it("puts the --json payload on stdout with the marker and the reason", async () => {
-		const out = await run([[ISSUE, okOut(issueJson(AGENT_BODY))]], {json: true});
+		const out = await run([[ISSUE, served(issueJson(AGENT_BODY))]], {json: true});
 		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "agent", marker: true});
 		expect(out.stderr.join("")).not.toContain('"outcome"');
 	});
 
 	it("answers `agent` for a FOOTERLESS filing by a configured operator account (#4619)", async () => {
-		const out = await run([[ISSUE, okOut(issueJson("no footer here\n", "operator-account"))]], {
+		const out = await run([[ISSUE, served(issueJson("no footer here\n", "operator-account"))]], {
 			env: OPERATOR_ENV,
 		});
 		expect(out.code).toBe(ANSWER);
@@ -90,7 +89,7 @@ describe("runProvenance", () => {
 	});
 
 	it("still answers `human` for a footerless filing by any other author", async () => {
-		const out = await run([[ISSUE, okOut(issueJson("no footer here\n", "cansirin"))]], {
+		const out = await run([[ISSUE, served(issueJson("no footer here\n", "cansirin"))]], {
 			env: OPERATOR_ENV,
 		});
 		expect(out.code).toBe(ANSWER);
@@ -98,7 +97,7 @@ describe("runProvenance", () => {
 	});
 
 	it("marks the operator answer in --json, keeping the footer fact separate from it", async () => {
-		const out = await run([[ISSUE, okOut(issueJson("no footer here\n", "operator-account"))]], {
+		const out = await run([[ISSUE, served(issueJson("no footer here\n", "operator-account"))]], {
 			env: OPERATOR_ENV,
 			json: true,
 		});
@@ -110,7 +109,7 @@ describe("runProvenance", () => {
 	});
 
 	it("answers `agent` for an EMPTY body from an operator — the ruling, not the fail-closed default", async () => {
-		const out = await run([[ISSUE, okOut(issueJson("   \n", "operator-account"))]], {
+		const out = await run([[ISSUE, served(issueJson("   \n", "operator-account"))]], {
 			env: OPERATOR_ENV,
 		});
 		expect(out.code).toBe(ANSWER);

--- a/packages/fabrika-cli/src/triage/queue-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/queue-verb.unit.test.ts
@@ -1,12 +1,12 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
 import {ANSWER, FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {ageDays, runQueue, toRows} from "./queue-verb.ts";
 
-const LABELS = /repos\/o\/r\/labels/;
-const QUEUE = /repos\/o\/r\/issues\?state=open/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+const QUEUE = /GET .*\/repos\/o\/r\/issues\?state=open/;
 
 const NOW = new Date("2026-08-03T00:00:00Z");
 
@@ -19,15 +19,28 @@ const options = {
 	now: () => NOW,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
-	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runQueue({...options, ...overrides}), fakeShell(script).layer));
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runQueue({...options, ...overrides}), fakeSeams(script).layer));
 
-const labelsOk = [LABELS, okOut("status:needs-triage\ntype:bug\np0")] as const;
+const labels = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
 
-const row = (n: number, createdAt: string, title: string) => `${n}\t${createdAt}\t${title}`;
+const labelsOk = [LABELS, labels("status:needs-triage", "type:bug", "p0")] as const;
+
+const row = (n: number, createdAt: string, title: string) => ({
+	number: n,
+	created_at: createdAt,
+	title,
+});
+
+const queued = (...rows: ReadonlyArray<unknown>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(rows),
+});
+
+const BAD_GATEWAY: HttpReply = {status: 502, body: "{}"};
 
 describe("ageDays", () => {
 	it("floors to whole days", () => {
@@ -74,14 +87,14 @@ describe("runQueue", () => {
 	it("prints `queued` then one `<number>\\t<age-days>\\t<title>` line per issue", async () => {
 		const out = await run([
 			labelsOk,
-			[QUEUE, okOut(row(4312, "2026-08-01T00:00:00Z", "Abort reason lost"))],
+			[QUEUE, queued(row(4312, "2026-08-01T00:00:00Z", "Abort reason lost"))],
 		]);
 		expect(out.code).toBe(ANSWER);
 		expect(out.stdout).toBe("queued\n4312\t2\tAbort reason lost\n");
 	});
 
 	it("prints the STATE WORD `empty` — never empty stdout, which a sweep cannot read", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("")]]);
+		const out = await run([labelsOk, [QUEUE, queued()]]);
 		expect(out.code).toBe(ANSWER);
 		expect(out.stdout).toBe("empty\n");
 	});
@@ -89,69 +102,62 @@ describe("runQueue", () => {
 	it("reports the scanned count on stderr", async () => {
 		const out = await run([
 			labelsOk,
-			[
-				QUEUE,
-				okOut(
-					[row(1, "2026-08-01T00:00:00Z", "a"), row(2, "2026-08-01T00:00:00Z", "b")].join("\n"),
-				),
-			],
+			[QUEUE, queued(row(1, "2026-08-01T00:00:00Z", "a"), row(2, "2026-08-01T00:00:00Z", "b"))],
 		]);
 		expect(out.stderr.join("\n")).toContain("scanned 2 open status:needs-triage issues in o/r");
 	});
 
 	it("says on stderr when --limit truncated the list", async () => {
-		const rows = Array.from({length: 4}, (_, i) => row(i + 1, "2026-08-01T00:00:00Z", "t")).join(
-			"\n",
-		);
-		const out = await run([labelsOk, [QUEUE, okOut(rows)]], {limit: 2});
+		const rows = Array.from({length: 4}, (_, i) => row(i + 1, "2026-08-01T00:00:00Z", "t"));
+		const out = await run([labelsOk, [QUEUE, queued(...rows)]], {limit: 2});
 		expect(out.stdout.trimEnd().split("\n")).toHaveLength(3);
 		expect(out.stderr.join("\n")).toContain("TRUNCATED");
 	});
 
 	it("REFUSES a --label that does not exist rather than reporting the queue drained", async () => {
-		const out = await run([[LABELS, okOut("type:bug\np0")]]);
+		const out = await run([[LABELS, labels("type:bug", "p0")]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 	});
 
 	it("never reads the queue once the label is proven absent", async () => {
-		const shell = fakeShell([[LABELS, okOut("type:bug")]]);
-		await Effect.runPromise(Effect.provide(runQueue(options), shell.layer));
-		expect(shell.calls.some((c) => QUEUE.test(c))).toBe(false);
+		const seams = fakeSeams([[LABELS, labels("type:bug")]]);
+		await Effect.runPromise(Effect.provide(runQueue(options), seams.layer));
+		expect(seams.requests.some((c) => QUEUE.test(c))).toBe(false);
 	});
 
 	it("refuses an UNREADABLE label set as UNKNOWN — never as `the label is missing`", async () => {
-		const out = await run([[LABELS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([[LABELS, BAD_GATEWAY]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("refuses an unreadable queue as UNKNOWN — never `empty`, which terminates a sweep", async () => {
-		const out = await run([labelsOk, [QUEUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([labelsOk, [QUEUE, BAD_GATEWAY]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain('never "empty"');
 	});
 
 	it("prints NO scanned count beside a failed read — a count is a measurement", async () => {
-		const out = await run([labelsOk, [QUEUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await run([labelsOk, [QUEUE, BAD_GATEWAY]]);
 		expect(out.stderr.join("\n")).not.toContain("scanned");
 	});
 
-	it("refuses a `gh` that exited 0 with bytes that are not queue rows", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("not a row")]]);
+	it("refuses a GitHub 200 carrying bytes that are not queue rows", async () => {
+		const out = await run([labelsOk, [QUEUE, queued("not a row")]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 	});
 
 	it("pages the queue read — an unpaginated read truncates at GitHub's default page", async () => {
-		const shell = fakeShell([labelsOk, [QUEUE, okOut("")]]);
-		await Effect.runPromise(Effect.provide(runQueue(options), shell.layer));
-		expect(shell.calls.find((c) => QUEUE.test(c))).toContain("--paginate");
+		const seams = fakeSeams([labelsOk, [QUEUE, queued()]]);
+		await Effect.runPromise(Effect.provide(runQueue(options), seams.layer));
+		expect(seams.requests.find((c) => QUEUE.test(c))).toContain("per_page=100");
 	});
 
 	it("puts the --json payload on stdout, carrying the outcome word and the scanned count", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut(row(4312, "2026-08-01T00:00:00Z", "t"))]], {
+		const out = await run([labelsOk, [QUEUE, queued(row(4312, "2026-08-01T00:00:00Z", "t"))]], {
 			json: true,
 		});
 		expect(JSON.parse(out.stdout)).toEqual({
@@ -163,7 +169,7 @@ describe("runQueue", () => {
 	});
 
 	it("carries the `empty` outcome word into the --json payload too", async () => {
-		const out = await run([labelsOk, [QUEUE, okOut("")]], {json: true});
+		const out = await run([labelsOk, [QUEUE, queued()]], {json: true});
 		expect(JSON.parse(out.stdout).outcome).toBe("empty");
 	});
 

--- a/packages/fabrika-cli/src/triage/repair-criteria-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/repair-criteria-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
@@ -11,11 +10,24 @@ import {
 } from "./codes.ts";
 import {runRepairCriteria} from "./repair-criteria-verb.ts";
 
-const READ = /^gh api repos\/o\/r\/issues\/5726$/;
-const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/5726 -f body=/;
-const LIST = /^gh api --paginate repos\/o\/r\/issues\?state=open&per_page=100$/;
-const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/5726\/comments -f body=/;
-const COMMENTED = okOut('{"id":1,"html_url":"https://example.test/c/1"}');
+const READ = /GET .*\/repos\/o\/r\/issues\/5726$/;
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/5726$/;
+const LIST = /GET .*\/repos\/o\/r\/issues\?state=open/;
+const COMMENT = /POST .*\/repos\/o\/r\/issues\/5726\/comments$/;
+const COMMENTED: HttpReply = {status: 201, body: '{"id":1,"html_url":"https://example.test/c/1"}'};
+
+const ACCEPTED: HttpReply = {status: 200, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const WRITE_FAILED: HttpReply = {status: 500, body: "{}"};
+
+const served = (value: unknown): HttpReply => ({status: 200, body: JSON.stringify(value)});
+
+/** What one matching request carried as its JSON body — where the text now travels. */
+const bodyFor = (seams: ReturnType<typeof fakeSeams>, pattern: RegExp): string => {
+	const at = seams.requests.findIndex((line) => pattern.test(line));
+	return at < 0 ? "" : (seams.bodies[at] ?? "");
+};
 
 const ITEMS = "- [ ] one criterion\n- [x] a checked one";
 const DRIFTED = `Intro.\n\n## Acceptance criteria\n\n${ITEMS}`;
@@ -32,8 +44,8 @@ const record = (number: number, body: string, extra: Record<string, unknown> = {
 	...extra,
 });
 
-const issue = (body: string, extra: Record<string, unknown> = {}): ExecResult =>
-	okOut(JSON.stringify(record(5726, body, extra)));
+const issue = (body: string, extra: Record<string, unknown> = {}): HttpReply =>
+	served(record(5726, body, extra));
 
 const options = {
 	issue: 5726 as number | null,
@@ -44,19 +56,16 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
-const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
-	overrides: Partial<typeof options> = {},
-) =>
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
 	Effect.runPromise(
-		Effect.provide(runRepairCriteria({...options, ...overrides}), fakeShell(script).layer),
+		Effect.provide(runRepairCriteria({...options, ...overrides}), fakeSeams(script).layer),
 	);
 
 describe("runRepairCriteria — one issue", () => {
 	it("repairs a level-2 drift: PATCH, read-back, then the repaired line", async () => {
-		const shell = fakeShell([
+		const shell = fakeSeams([
 			[once(READ), issue(DRIFTED)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue(REPAIRED)],
 			[COMMENT, COMMENTED],
 		]);
@@ -65,17 +74,17 @@ describe("runRepairCriteria — one issue", () => {
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe("repaired\t5726\n");
-		const patched = shell.calls.find((line) => PATCH.test(line));
+		const patched = bodyFor(shell, PATCH);
 		expect(patched).toContain("### Acceptance criteria");
-		expect(patched).not.toContain("\n## Acceptance criteria");
-		expect(shell.calls.find((line) => COMMENT.test(line))).toContain("level 2 → 3");
+		expect(patched).not.toContain("\\n## Acceptance criteria");
+		expect(bodyFor(shell, COMMENT)).toContain("level 2 → 3");
 	});
 
 	it("converts plain bullets under a conforming heading and PATCHes the checkboxes (#6001)", async () => {
 		const bullets = "### Acceptance criteria\n\n- one criterion\n- a second";
-		const shell = fakeShell([
+		const shell = fakeSeams([
 			[once(READ), issue(bullets)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue("### Acceptance criteria\n\n- [ ] one criterion\n- [ ] a second")],
 			[COMMENT, COMMENTED],
 		]);
@@ -84,38 +93,38 @@ describe("runRepairCriteria — one issue", () => {
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe("repaired\t5726\n");
-		expect(shell.calls.find((line) => PATCH.test(line))).toContain("- [ ] one criterion");
+		expect(bodyFor(shell, PATCH)).toContain("- [ ] one criterion");
 	});
 
 	it("answers conforming on a level-3 body and writes nothing", async () => {
-		const shell = fakeShell([[READ, issue(REPAIRED)]]);
+		const shell = fakeSeams([[READ, issue(REPAIRED)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria(options), shell.layer),
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe("conforming\t5726\n");
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("answers no-block on a body with no heading at all, and writes nothing", async () => {
-		const shell = fakeShell([[READ, issue("## Summary\n\nJust prose.")]]);
+		const shell = fakeSeams([[READ, issue("## Summary\n\nJust prose.")]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria(options), shell.layer),
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe("no-block\t5726\n");
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("refuses drifted text on 14, naming what it read, and writes nothing", async () => {
-		const shell = fakeShell([[READ, issue(`## Acceptance criterias\n\n${ITEMS}`)]]);
+		const shell = fakeSeams([[READ, issue(`## Acceptance criterias\n\n${ITEMS}`)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria(options), shell.layer),
 		);
 		expect(outcome.code).toBe(UNREPAIRABLE);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.at(-1)).toContain('heading text "Acceptance criterias"');
-		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line))).toBe(false);
 	});
 
 	it("emits the record on stdout with --json", async () => {
@@ -124,10 +133,8 @@ describe("runRepairCriteria — one issue", () => {
 	});
 
 	it("refuses an absent issue on 7, an unreadable one on 11", async () => {
-		expect((await run([[READ, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
-		expect((await run([[READ, errOut("gh: Bad gateway (HTTP 502)")]])).code).toBe(
-			PRECONDITION_UNKNOWN,
-		);
+		expect((await run([[READ, NOT_FOUND]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[READ, UNREADABLE]])).code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("refuses a pull request and a closed issue on 7 — neither carries a gradeable contract", async () => {
@@ -141,13 +148,13 @@ describe("runRepairCriteria — one issue", () => {
 	it("reports a failed PATCH as UNKNOWN on 8, and a read-back mismatch on 9", async () => {
 		const failed = await run([
 			[READ, issue(DRIFTED)],
-			[PATCH, errOut("gh: timeout")],
+			[PATCH, WRITE_FAILED],
 		]);
 		expect(failed.code).toBe(WRITE_UNKNOWN);
 		expect(failed.stderr.at(-1)).toContain("UNKNOWN whether the body changed");
 		const mismatched = await run([
 			[once(READ), issue(DRIFTED)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue("something else entirely")],
 		]);
 		expect(mismatched.code).toBe(READBACK_MISMATCH);
@@ -156,23 +163,23 @@ describe("runRepairCriteria — one issue", () => {
 	it("reports a failed disclosure comment on 8 — an in-place edit with no record of it", async () => {
 		const outcome = await run([
 			[once(READ), issue(DRIFTED)],
-			[PATCH, okOut("{}")],
+			[PATCH, ACCEPTED],
 			[READ, issue(REPAIRED)],
-			[COMMENT, errOut("gh: timeout")],
+			[COMMENT, WRITE_FAILED],
 		]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("nothing recording it");
 	});
 
 	it("answers would-repair under --dry-run: the plan on stdout, no PATCH and no comment", async () => {
-		const shell = fakeShell([[READ, issue(DRIFTED)]]);
+		const shell = fakeSeams([[READ, issue(DRIFTED)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria({...options, dryRun: true}), shell.layer),
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe("would-repair\t5726\n");
 		expect(outcome.stderr.at(-1)).toContain("level 2 → 3");
-		expect(shell.calls.some((line) => PATCH.test(line) || COMMENT.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH.test(line) || COMMENT.test(line))).toBe(false);
 	});
 
 	it("refuses usage that names neither or both targets, before reading anything", async () => {
@@ -182,25 +189,23 @@ describe("runRepairCriteria — one issue", () => {
 });
 
 describe("runRepairCriteria — the sweep", () => {
-	const board = okOut(
-		JSON.stringify([
-			record(3, "## Summary\n\nno block here"),
-			record(2, REPAIRED),
-			record(1, DRIFTED.replace("Intro.", "First.")),
-			record(4, `## Acceptance criterias\n\n${ITEMS}`),
-			record(9, DRIFTED, {pull_request: {url: "x"}}),
-		]),
-	);
-	const PATCH_1 = /^gh api --method PATCH repos\/o\/r\/issues\/1 -f body=/;
-	const READ_1 = /^gh api repos\/o\/r\/issues\/1$/;
-	const COMMENT_1 = /^gh api --method POST repos\/o\/r\/issues\/1\/comments -f body=/;
+	const board = served([
+		record(3, "## Summary\n\nno block here"),
+		record(2, REPAIRED),
+		record(1, DRIFTED.replace("Intro.", "First.")),
+		record(4, `## Acceptance criterias\n\n${ITEMS}`),
+		record(9, DRIFTED, {pull_request: {url: "x"}}),
+	]);
+	const PATCH_1 = /PATCH .*\/repos\/o\/r\/issues\/1$/;
+	const READ_1 = /GET .*\/repos\/o\/r\/issues\/1$/;
+	const COMMENT_1 = /POST .*\/repos\/o\/r\/issues\/1\/comments$/;
 
 	it("repairs every drifted open issue and prints one outcome line per issue, ascending", async () => {
-		const shell = fakeShell([
+		const shell = fakeSeams([
 			[LIST, board],
-			[once(READ_1), okOut(JSON.stringify(record(1, DRIFTED.replace("Intro.", "First."))))],
-			[PATCH_1, okOut("{}")],
-			[READ_1, okOut(JSON.stringify(record(1, REPAIRED.replace("Intro.", "First."))))],
+			[once(READ_1), served(record(1, DRIFTED.replace("Intro.", "First.")))],
+			[PATCH_1, ACCEPTED],
+			[READ_1, served(record(1, REPAIRED.replace("Intro.", "First.")))],
 			[COMMENT_1, COMMENTED],
 		]);
 		const outcome = await Effect.runPromise(
@@ -222,8 +227,8 @@ describe("runRepairCriteria — the sweep", () => {
 		const outcome = await run(
 			[
 				[LIST, board],
-				[once(READ_1), okOut(JSON.stringify(record(1, DRIFTED.replace("Intro.", "First."))))],
-				[PATCH_1, errOut("gh: timeout")],
+				[once(READ_1), served(record(1, DRIFTED.replace("Intro.", "First.")))],
+				[PATCH_1, WRITE_FAILED],
 			],
 			{issue: null, sweep: true},
 		);
@@ -232,15 +237,15 @@ describe("runRepairCriteria — the sweep", () => {
 	});
 
 	it("answers moved and writes nothing when the body changed after the board snapshot", async () => {
-		const shell = fakeShell([
+		const shell = fakeSeams([
 			[LIST, board],
-			[READ_1, okOut(JSON.stringify(record(1, "somebody rewrote this body mid-sweep")))],
+			[READ_1, served(record(1, "somebody rewrote this body mid-sweep"))],
 		]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria({...options, issue: null, sweep: true}), shell.layer),
 		);
 		expect(outcome.code).toBe(0);
-		expect(shell.calls.some((line) => PATCH_1.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH_1.test(line))).toBe(false);
 		const [summary, ...lines] = outcome.stdout.trimEnd().split("\n");
 		expect(summary).toBe("swept\t0\t1\t1\t1\t1\t0");
 		expect(lines[0]).toBe(
@@ -249,7 +254,7 @@ describe("runRepairCriteria — the sweep", () => {
 	});
 
 	it("--dry-run prints the exact set it would touch and issues no re-read, PATCH or comment", async () => {
-		const shell = fakeShell([[LIST, board]]);
+		const shell = fakeSeams([[LIST, board]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runRepairCriteria({...options, issue: null, sweep: true, dryRun: true}),
@@ -261,39 +266,41 @@ describe("runRepairCriteria — the sweep", () => {
 		expect(summary).toBe("swept\t0\t1\t1\t1\t0\t1");
 		expect(lines[0]).toBe("would-repair\t1\tline 3: level 2 → 3");
 		expect(
-			shell.calls.some((line) => PATCH_1.test(line) || READ_1.test(line) || COMMENT_1.test(line)),
+			shell.requests.some(
+				(line) => PATCH_1.test(line) || READ_1.test(line) || COMMENT_1.test(line),
+			),
 		).toBe(false);
 	});
 
 	it("answers moved when the issue left the open board between the snapshot and its write", async () => {
-		const shell = fakeShell([
+		const shell = fakeSeams([
 			[LIST, board],
-			[READ_1, errOut("gh: Not Found (HTTP 404)")],
+			[READ_1, NOT_FOUND],
 		]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria({...options, issue: null, sweep: true}), shell.layer),
 		);
 		expect(outcome.code).toBe(0);
-		expect(shell.calls.some((line) => PATCH_1.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH_1.test(line))).toBe(false);
 		expect(outcome.stdout).toContain("moved\t1\tthe issue left the open board mid-sweep");
 	});
 
 	it("halts on 11 when an issue cannot be re-read before its write — never writes the stale plan", async () => {
-		const shell = fakeShell([
+		const shell = fakeSeams([
 			[LIST, board],
-			[READ_1, errOut("gh: Bad gateway (HTTP 502)")],
+			[READ_1, UNREADABLE],
 		]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runRepairCriteria({...options, issue: null, sweep: true}), shell.layer),
 		);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stdout).toBe("");
-		expect(shell.calls.some((line) => PATCH_1.test(line))).toBe(false);
+		expect(shell.requests.some((line) => PATCH_1.test(line))).toBe(false);
 		expect(outcome.stderr.at(-1)).toContain("cannot re-read #1 before writing it");
 	});
 
 	it("refuses an unreadable board on 11 — a sweep over unknown scope proves nothing", async () => {
-		const outcome = await run([[LIST, errOut("gh: Bad gateway (HTTP 502)")]], {
+		const outcome = await run([[LIST, UNREADABLE]], {
 			issue: null,
 			sweep: true,
 		});

--- a/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
@@ -1,7 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {type HttpReply, okOut, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {renderFooter} from "../report/compose.ts";
 import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
@@ -18,13 +17,52 @@ import {composeChildBody} from "./split.ts";
 import {runSplit} from "./split-verb.ts";
 
 const BRANCH = /^git rev-parse/;
-const PARENT = /^gh api repos\/o\/r\/issues\/4312$/;
-const LABELS = /repos\/o\/r\/labels/;
-const QUEUE = /repos\/o\/r\/issues\?state=open/;
-const TIMELINE = /repos\/o\/r\/issues\/4312\/timeline/;
-const CREATE = /--method POST repos\/o\/r\/issues -f/;
-const CROSSLINK = /--method POST repos\/o\/r\/issues\/4312\/comments/;
-const issueRead = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
+const PARENT = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const LABELS = /GET .*\/repos\/o\/r\/labels\?/;
+const QUEUE = /GET .*\/repos\/o\/r\/issues\?state=open/;
+const TIMELINE = /GET .*\/repos\/o\/r\/issues\/4312\/timeline\?/;
+const CREATE = /POST .*\/repos\/o\/r\/issues$/;
+const CROSSLINK = /POST .*\/repos\/o\/r\/issues\/4312\/comments$/;
+const issueRead = (n: number) => new RegExp(`GET .*/repos/o/r/issues/${n}$`);
+
+const UNREADABLE: HttpReply = {status: 502, body: "{}"};
+const NOT_FOUND: HttpReply = {status: 404, body: '{"message":"Not Found"}'};
+const WRITE_FAILED: HttpReply = {status: 500, body: "{}"};
+
+const labels = (...names: ReadonlyArray<string>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(names.map((name) => ({name}))),
+});
+
+/** Open issues carrying the queue label, as the list endpoint answers them. */
+const queue = (
+	...rows: ReadonlyArray<{readonly number: number; readonly title: string}>
+): HttpReply => ({status: 200, body: JSON.stringify(rows)});
+
+/** `cross-referenced` timeline entries — the only event shape the adapter reads. */
+const timeline = (
+	...refs: ReadonlyArray<{readonly number: number; readonly pull?: boolean}>
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(
+		refs.map((ref) => ({
+			event: "cross-referenced",
+			source: {
+				issue: {number: ref.number, ...(ref.pull === true ? {pull_request: {url: "x"}} : {})},
+			},
+		})),
+	),
+});
+
+/** What the first request matching `pattern` carried as its JSON body. */
+const bodyOf = (
+	requests: ReadonlyArray<string>,
+	bodies: ReadonlyArray<string>,
+	pattern: RegExp,
+): string => {
+	const at = requests.findIndex((line) => pattern.test(line));
+	return at < 0 ? "" : (bodies[at] ?? "");
+};
 
 const TITLE = "Editor loses focus after save";
 const BODY = "The editor drops focus once the save round-trips.";
@@ -40,22 +78,28 @@ const COMPOSED = composeChildBody(
 	}),
 );
 
-const issue = (over: Record<string, unknown>) =>
-	okOut(
-		JSON.stringify({
-			number: 4321,
-			title: TITLE,
-			body: COMPOSED,
-			state: "open",
-			labels: [{name: "status:needs-triage"}],
-			html_url: "https://example.test/issues/4321",
-			...over,
-		}),
-	);
+const issue = (over: Record<string, unknown>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4321,
+		title: TITLE,
+		body: COMPOSED,
+		state: "open",
+		labels: [{name: "status:needs-triage"}],
+		html_url: "https://example.test/issues/4321",
+		...over,
+	}),
+});
 
 const parentIssue = issue({number: 4312, title: "Two unrelated bugs", body: "a\nb"});
-const created = okOut(JSON.stringify({number: 4321, html_url: "https://example.test/issues/4321"}));
-const posted = okOut(JSON.stringify({id: 7, html_url: "https://example.test/c/7"}));
+const created: HttpReply = {
+	status: 201,
+	body: JSON.stringify({number: 4321, html_url: "https://example.test/issues/4321"}),
+};
+const posted: HttpReply = {
+	status: 201,
+	body: JSON.stringify({id: 7, html_url: "https://example.test/c/7"}),
+};
 
 const options = {
 	parent: 4312,
@@ -68,28 +112,31 @@ const options = {
 };
 
 /** The base script: parent present, label present, nothing already split, create + cross-link fine. */
-const base: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const base: ReadonlyArray<Scripted> = [
 	[BRANCH, okOut("umut/x\n")],
 	[PARENT, parentIssue],
-	[LABELS, okOut("status:needs-triage\ntype:bug")],
-	[QUEUE, okOut("")],
-	[TIMELINE, okOut("")],
+	[LABELS, labels("status:needs-triage", "type:bug")],
+	[QUEUE, queue()],
+	[TIMELINE, timeline()],
 	[CREATE, created],
 	[CROSSLINK, posted],
 	[issueRead(4321), issue({})],
 ];
 
-const script = (
-	...overrides: ReadonlyArray<readonly [RegExp, ExecResult]>
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [...overrides, ...base];
+const script = (...overrides: ReadonlyArray<Scripted>): ReadonlyArray<Scripted> => [
+	...overrides,
+	...base,
+];
 
-const run = (
-	steps: ReadonlyArray<readonly [RegExp, ExecResult]> = base,
-	over: Partial<typeof options> = {},
-) => {
+const run = (steps: ReadonlyArray<Scripted> = base, over: Partial<typeof options> = {}) => {
 	const shell = guardedShell(steps);
 	return Effect.runPromise(Effect.provide(runSplit({...options, ...over}), shell.layer)).then(
-		(outcome) => ({outcome, calls: shell.calls}),
+		(outcome) => ({
+			outcome,
+			calls: shell.calls,
+			requests: shell.requests,
+			bodies: shell.bodies,
+		}),
 	);
 };
 
@@ -101,16 +148,16 @@ describe("runSplit — the created path", () => {
 	});
 
 	it("creates the child carrying the back-reference and the queue label", async () => {
-		const {calls} = await run();
-		const create = calls.find((c) => CREATE.test(c)) ?? "";
+		const {requests, bodies} = await run();
+		const create = bodyOf(requests, bodies, CREATE);
 		expect(create).toContain("split from #4312");
 		expect(create).toContain("Filed by an agent");
-		expect(create).toContain("labels[]=status:needs-triage");
+		expect(create).toContain('"labels":["status:needs-triage"]');
 	});
 
 	it("cross-links the parent as part of the same operation", async () => {
-		const {calls} = await run();
-		expect(calls.some((c) => CROSSLINK.test(c) && c.includes("split into #4321"))).toBe(true);
+		const {requests, bodies} = await run();
+		expect(bodyOf(requests, bodies, CROSSLINK)).toContain("split into #4321");
 	});
 
 	it("reports the object with --json", async () => {
@@ -132,7 +179,7 @@ describe("runSplit — the created path", () => {
 	});
 
 	it("still exits 0 when the cross-link fails — the child demonstrably exists", async () => {
-		const {outcome} = await run(script([CROSSLINK, errOut("gh: timeout")]), {json: true});
+		const {outcome} = await run(script([CROSSLINK, WRITE_FAILED]), {json: true});
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).crossLinked).toBe(false);
 		expect(outcome.stderr.join("\n")).toContain("add the comment by hand");
@@ -144,18 +191,18 @@ describe("runSplit — the create-once key", () => {
 	const foreign = issue({number: 4400, body: "unrelated\n\nsplit from #9999\n"});
 
 	it("reuses a child matching BOTH halves of the key, and writes nothing", async () => {
-		const {outcome, calls} = await run(
-			script([QUEUE, okOut(`4321\t${TITLE}\n`)], [issueRead(4321), issue({})]),
+		const {outcome, requests} = await run(
+			script([QUEUE, queue({number: 4321, title: TITLE})], [issueRead(4321), issue({})]),
 		);
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe("reused\t4321\thttps://example.test/issues/4321\n");
-		expect(calls.some((c) => CREATE.test(c))).toBe(false);
-		expect(calls.some((c) => CROSSLINK.test(c))).toBe(false);
+		expect(requests.some((c) => CREATE.test(c))).toBe(false);
+		expect(requests.some((c) => CROSSLINK.test(c))).toBe(false);
 	});
 
 	it("names the key it matched on, and never claims a cross-link it did not make", async () => {
 		const {outcome} = await run(
-			script([QUEUE, okOut(`4321\t${TITLE}\n`)], [issueRead(4321), issue({})]),
+			script([QUEUE, queue({number: 4321, title: TITLE})], [issueRead(4321), issue({})]),
 			{json: true},
 		);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({
@@ -167,7 +214,7 @@ describe("runSplit — the create-once key", () => {
 
 	it("does NOT reuse on the title alone — a same-titled child of another parent is not this child", async () => {
 		const {outcome} = await run(
-			script([QUEUE, okOut(`4400\t${TITLE}\n`)], [issueRead(4400), foreign]),
+			script([QUEUE, queue({number: 4400, title: TITLE})], [issueRead(4400), foreign]),
 		);
 		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
 	});
@@ -177,94 +224,90 @@ describe("runSplit — the create-once key", () => {
 	// reuse. Through the queue the title narrowing would reject it before the key ran at all.
 	it("does NOT reuse on the back-reference alone — a sibling split is not this child", async () => {
 		const {outcome} = await run(
-			script([TIMELINE, okOut("4400\tfalse\n")], [issueRead(4400), sibling]),
+			script([TIMELINE, timeline({number: 4400})], [issueRead(4400), sibling]),
 		);
 		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
 	});
 
 	it("reaches a child already triaged out of the queue, through the timeline", async () => {
 		const {outcome} = await run(
-			script([TIMELINE, okOut("4321\tfalse\n")], [issueRead(4321), issue({})]),
+			script([TIMELINE, timeline({number: 4321})], [issueRead(4321), issue({})]),
 		);
 		expect(outcome.stdout).toBe("reused\t4321\thttps://example.test/issues/4321\n");
 	});
 
 	it("ignores pull requests in the timeline", async () => {
-		const {outcome, calls} = await run(script([TIMELINE, okOut("9001\ttrue\n")]));
+		const {outcome, requests} = await run(script([TIMELINE, timeline({number: 9001, pull: true})]));
 		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
-		expect(calls.some((c) => issueRead(9001).test(c))).toBe(false);
+		expect(requests.some((c) => issueRead(9001).test(c))).toBe(false);
 	});
 
 	it("narrows on the title before fetching, so an unrelated queue row costs no read", async () => {
-		const {calls} = await run(script([QUEUE, okOut("4400\tSomething else entirely\n")]));
-		expect(calls.some((c) => issueRead(4400).test(c))).toBe(false);
+		const {requests} = await run(
+			script([QUEUE, queue({number: 4400, title: "Something else entirely"})]),
+		);
+		expect(requests.some((c) => issueRead(4400).test(c))).toBe(false);
 	});
 });
 
 describe("runSplit — a read that cannot see is never an answer", () => {
 	it("exits 11 on an UNKNOWN candidate body, and creates nothing", async () => {
-		const {outcome, calls} = await run(
-			script(
-				[QUEUE, okOut(`4400\t${TITLE}\n`)],
-				[issueRead(4400), errOut("gh: Bad gateway (HTTP 502)")],
-			),
+		const {outcome, requests} = await run(
+			script([QUEUE, queue({number: 4400, title: TITLE})], [issueRead(4400), UNREADABLE]),
 		);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.at(-1)).toContain("refusing to create a possible twin");
-		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(requests.some((c) => CREATE.test(c))).toBe(false);
 	});
 
 	// The same refusal on the second loop. The timeline read carries no titles, so it fetches every
 	// cross-reference — an UNKNOWN one there is just as likely to BE the child as an UNKNOWN queue row.
 	it("exits 11 on an UNKNOWN timeline candidate too, not only a queue one", async () => {
-		const {outcome, calls} = await run(
-			script(
-				[TIMELINE, okOut("4400\tfalse\n")],
-				[issueRead(4400), errOut("gh: Bad gateway (HTTP 502)")],
-			),
+		const {outcome, requests} = await run(
+			script([TIMELINE, timeline({number: 4400})], [issueRead(4400), UNREADABLE]),
 		);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stdout).toBe("");
-		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(requests.some((c) => CREATE.test(c))).toBe(false);
 	});
 
 	it("exits 11 on an unreadable queue, never on a silent create", async () => {
-		const {outcome, calls} = await run(script([QUEUE, errOut("gh: Bad gateway (HTTP 502)")]));
+		const {outcome, requests} = await run(script([QUEUE, UNREADABLE]));
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
-		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(requests.some((c) => CREATE.test(c))).toBe(false);
 	});
 
 	it("exits 11 on an unreadable timeline", async () => {
-		const {outcome, calls} = await run(script([TIMELINE, errOut("gh: Bad gateway (HTTP 502)")]));
+		const {outcome, requests} = await run(script([TIMELINE, UNREADABLE]));
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
-		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(requests.some((c) => CREATE.test(c))).toBe(false);
 	});
 
 	it("exits 11 on an unreadable parent, and 7 on one proven absent", async () => {
-		const unreadable = await run(script([PARENT, errOut("gh: Bad gateway (HTTP 502)")]));
+		const unreadable = await run(script([PARENT, UNREADABLE]));
 		expect(unreadable.outcome.code).toBe(PRECONDITION_UNKNOWN);
-		const absent = await run(script([PARENT, errOut("gh: Not Found (HTTP 404)")]));
+		const absent = await run(script([PARENT, NOT_FOUND]));
 		expect(absent.outcome.code).toBe(ZERO_SCOPE);
 		expect(absent.outcome.stderr.at(-1)).toBe("triage split: parent #4312 not found in o/r.");
 	});
 
 	it("exits 11 on an unreadable label set", async () => {
-		const {outcome} = await run(script([LABELS, errOut("gh: Bad gateway (HTTP 502)")]));
+		const {outcome} = await run(script([LABELS, UNREADABLE]));
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
 	it("exits 7 when the queue label does not exist — a 200 over [] is not a proven negative", async () => {
-		const {outcome, calls} = await run(script([LABELS, okOut("type:bug\np0")]));
+		const {outcome, requests} = await run(script([LABELS, labels("type:bug", "p0")]));
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.at(-1)).toContain("(ADR 0092)");
-		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(requests.some((c) => CREATE.test(c))).toBe(false);
 	});
 });
 
 describe("runSplit — the write and its read-back", () => {
 	it("exits 8 with the re-run recovery when the create fails", async () => {
-		const {outcome} = await run(script([CREATE, errOut("gh: timeout")]));
+		const {outcome} = await run(script([CREATE, WRITE_FAILED]));
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.at(-1)).toContain("which will reuse it if it did");
@@ -279,7 +322,7 @@ describe("runSplit — the write and its read-back", () => {
 	});
 
 	it("exits 9 when the read-back itself fails", async () => {
-		const {outcome} = await run(script([issueRead(4321), errOut("gh: Bad gateway (HTTP 502)")]));
+		const {outcome} = await run(script([issueRead(4321), UNREADABLE]));
 		expect(outcome.code).toBe(READBACK_MISMATCH);
 	});
 
@@ -293,28 +336,29 @@ describe("runSplit — the write and its read-back", () => {
 
 describe("runSplit — the authored-text guard", () => {
 	it("refuses an empty body before any network read", async () => {
-		const {outcome, calls} = await run(base, {
+		const {outcome, requests} = await run(base, {
 			stdin: Effect.succeed({_tag: "Text", text: ""} satisfies StdinRead),
 		});
 		expect(outcome.code).toBe(EMPTY_STDIN);
-		expect(calls.some((c) => c.startsWith("gh"))).toBe(false);
+		expect(requests).toEqual([]);
 	});
 
 	it("scans the COMPOSED body, so nothing the verb appends can escape the predicate", async () => {
-		const {outcome, calls} = await run(base, {
+		const {outcome, requests} = await run(base, {
 			stdin: Effect.succeed({
 				_tag: "Text",
 				text: "reproduced from /Users/someone/scratch/case.md",
 			} satisfies StdinRead),
 		});
 		expect(outcome.code).toBe(LEAKED_PATH);
-		expect(calls.some((c) => c.startsWith("gh"))).toBe(false);
+		expect(requests).toEqual([]);
 	});
 
 	it("refuses a non-issue-number parent without touching the network", async () => {
-		const {outcome, calls} = await run(base, {parent: 0});
+		const {outcome, calls, requests} = await run(base, {parent: 0});
 		expect(outcome.code).toBe(1);
 		expect(calls).toEqual([]);
+		expect(requests).toEqual([]);
 	});
 });
 
@@ -329,9 +373,9 @@ describe("runSplit — the parent guard", () => {
 
 	// The composed child body carries the session in its footer, so a run under a session id cannot
 	// match COMPOSED's read-back. What the guard decides is whether the create was reached at all.
-	const guard = async (steps: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
-		const {outcome, calls} = await run(steps, {env: mine});
-		return {outcome, created: calls.some((line) => CREATE.test(line))};
+	const guard = async (steps: ReadonlyArray<Scripted>) => {
+		const {outcome, requests} = await run(steps, {env: mine});
+		return {outcome, created: requests.some((line) => CREATE.test(line))};
 	};
 
 	it("refuses a closed parent on 7 and creates nothing", async () => {

--- a/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, type okOut} from "../fakes.test-support.ts";
+import type {Scripted} from "../fakes.test-support.ts";
 import type {IssueRecord} from "../io/issues.ts";
 import {DEFAULT_TTL_MINUTES} from "./claim.ts";
 import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
@@ -32,7 +32,7 @@ const said = (outcome: {readonly stderr: ReadonlyArray<string>} | null): string 
 	(outcome?.stderr ?? []).join("\n");
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	script: ReadonlyArray<Scripted>,
 	over: {readonly state?: "open" | "closed"; readonly session?: string} = {},
 ) =>
 	Effect.runPromise(
@@ -112,7 +112,7 @@ describe("guardTarget", () => {
 			),
 		);
 		expect(outcome?.code).toBe(ZERO_SCOPE);
-		expect(shell.calls).toEqual([]);
+		expect(shell.requests).toEqual([]);
 	});
 
 	it("names the target by the caller's noun", async () => {
@@ -153,7 +153,7 @@ describe("guardTarget", () => {
 	});
 
 	it("refuses on 11 when the comment read fails — never a pass", async () => {
-		const outcome = await run([[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")]], {session: MINE});
+		const outcome = await run([[COMMENTS, {status: 502, body: "{}"}]], {session: MINE});
 		expect(outcome?.code).toBe(PRECONDITION_UNKNOWN);
 	});
 

--- a/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
@@ -10,8 +10,7 @@ import {
 	NONCE,
 	pull,
 } from "../build/fixtures.test-support.ts";
-import {fakeHttp, fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import {isBareAtReference} from "../report/leaks.ts";
 import {
 	BAD_SECTIONS,
@@ -62,24 +61,31 @@ const files = (): Record<string, Uint8Array | string> => ({
 
 const POSTED_ID = 512347;
 
-const script = (
-	overrides: ReadonlyArray<readonly [RegExp, ExecResult]> = [],
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+// One `pulls/4318` row answers both reads over that resource: the PR record and the head branch the
+// lane fence compares against.
+const script = (overrides: ReadonlyArray<Scripted> = []): ReadonlyArray<Scripted> => [
 	...overrides,
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	[/^git rev-parse --abbrev-ref HEAD$/, okOut(`${LANE}\n`)],
-	[/^gh api repos\/o\/r\/issues\/4312$/, issue()],
+	[/GET .*\/repos\/o\/r\/issues\/4312$/, issue()],
 	[
-		/^gh api --paginate repos\/o\/r\/issues\/4312\/comments/,
+		/GET .*\/repos\/o\/r\/issues\/4312\/comments/,
 		comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
 	],
-	[/^gh api repos\/o\/r\/collaborators\/agent\/permission/, okOut("write\n")],
-	[/^gh api repos\/o\/r\/pulls\/4318$/, pull({head: {sha: HEAD, ref: LANE}})],
 	[
-		/^gh api --method POST repos\/o\/r\/issues\/4318\/comments/,
-		okOut(
-			JSON.stringify({id: POSTED_ID, html_url: "https://github.com/o/r/pull/4318#issuecomment-1"}),
-		),
+		/GET .*\/repos\/o\/r\/collaborators\/agent\/permission/,
+		{status: 200, body: '{"permission":"write"}'},
+	],
+	[/GET .*\/repos\/o\/r\/pulls\/4318$/, pull({head: {sha: HEAD, ref: LANE}})],
+	[
+		/POST .*\/repos\/o\/r\/issues\/4318\/comments/,
+		{
+			status: 201,
+			body: JSON.stringify({
+				id: POSTED_ID,
+				html_url: "https://github.com/o/r/pull/4318#issuecomment-1",
+			}),
+		},
 	],
 ];
 
@@ -92,11 +98,6 @@ const uploads: Pick<EvidenceOptions, "storeUpload" | "attachmentUpload"> = {
 			url: `https://github.com/user-attachments/assets/${target.role}${target.surface}`,
 		}),
 };
-
-/** The head-branch read moved onto the fetch client (ADR 0315); the rest of the verb is still `gh`. */
-const HTTP = fakeHttp([
-	[/pulls\/4318/, {status: 200, body: JSON.stringify({head: {ref: LANE}})}],
-]).layer;
 
 const options: EvidenceOptions = {
 	pr: 4318,
@@ -114,10 +115,13 @@ const options: EvidenceOptions = {
 
 /** The read-back the happy path needs: the posted body, echoed. */
 const withReadback = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	rows: ReadonlyArray<Scripted>,
 	body: () => string,
-): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[/^gh api repos\/o\/r\/issues\/comments\/512347$/, okOut(JSON.stringify({body: body()}))],
+): ReadonlyArray<Scripted> => [
+	[
+		/GET .*\/repos\/o\/r\/issues\/comments\/512347$/,
+		{status: 200, body: JSON.stringify({body: body()})},
+	],
 	...rows,
 ];
 
@@ -133,15 +137,14 @@ const EXPECTED_BODY = composeEvidence(
 );
 
 const run = (
-	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	rows: ReadonlyArray<Scripted>,
 	fs: FakeBytesFsOptions,
 	overrides: Partial<EvidenceOptions> = {},
-	http = HTTP,
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runEvidence({...options, ...overrides}),
-			Layer.mergeAll(fakeShell(rows).layer, fakeBytesFs(fs).layer, http),
+			Layer.mergeAll(fakeSeams(rows).layer, fakeBytesFs(fs).layer),
 		),
 	);
 
@@ -197,7 +200,7 @@ describe("runEvidence", () => {
 	});
 
 	it("refuses on 17 with NOTHING posted when one upload fails", async () => {
-		const calls = fakeShell(withReadback(script(), () => EXPECTED_BODY));
+		const seams = fakeSeams(withReadback(script(), () => EXPECTED_BODY));
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEvidence({
@@ -209,12 +212,12 @@ describe("runEvidence", () => {
 								: {_tag: "Ok", url: "https://github.com/user-attachments/assets/x"},
 						),
 				}),
-				Layer.mergeAll(calls.layer, fakeBytesFs({files: files()}).layer, HTTP),
+				Layer.mergeAll(seams.layer, fakeBytesFs({files: files()}).layer),
 			),
 		);
 		expect(outcome.code).toBe(UPLOAD_FAILED);
 		expect(outcome.stdout).toBe("");
-		expect(calls.calls.some((line) => line.includes("--method POST"))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("POST"))).toBe(false);
 	});
 
 	it("refuses an after-surface with no baseline on 4", async () => {
@@ -242,7 +245,7 @@ describe("runEvidence", () => {
 		const outcome = await run(
 			script([
 				[
-					/^gh api repos\/o\/r\/pulls\/4318$/,
+					/GET .*\/repos\/o\/r\/pulls\/4318$/,
 					pull({state: "closed", head: {sha: HEAD, ref: LANE}}),
 				],
 			]),
@@ -253,15 +256,13 @@ describe("runEvidence", () => {
 
 	it("refuses another lane's PR on 18 — an evidence comment there is a cross-lane write", async () => {
 		const outcome = await run(
-			script(),
-			{files: files()},
-			{},
-			fakeHttp([
+			script([
 				[
-					/pulls\/4318/,
-					{status: 200, body: JSON.stringify({head: {ref: "build/9999-other-aaaaaaaa"}})},
+					/GET .*\/repos\/o\/r\/pulls\/4318$/,
+					pull({head: {sha: HEAD, ref: "build/9999-other-aaaaaaaa"}}),
 				],
-			]).layer,
+			]),
+			{files: files()},
 		);
 		expect(outcome.code).toBe(LANE_NOT_MINE);
 	});
@@ -270,7 +271,7 @@ describe("runEvidence", () => {
 		const outcome = await run(
 			script([
 				[
-					/^gh api --paginate repos\/o\/r\/issues\/4312\/comments/,
+					/GET .*\/repos\/o\/r\/issues\/4312\/comments/,
 					comments({id: 1, body: marker("other-session", LANE_UUID)}),
 				],
 			]),
@@ -281,12 +282,7 @@ describe("runEvidence", () => {
 
 	it("refuses on 8 when the post itself fails — it may or may not have landed", async () => {
 		const outcome = await run(
-			script([
-				[
-					/^gh api --method POST repos\/o\/r\/issues\/4318\/comments/,
-					{ok: false, stdout: "", reason: "HTTP 502"},
-				],
-			]),
+			script([[/POST .*\/repos\/o\/r\/issues\/4318\/comments/, {status: 502, body: "{}"}]]),
 			{files: files()},
 		);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
@@ -314,7 +310,7 @@ describe("runEvidence", () => {
 		const tampered = files();
 		tampered[`${SCRATCH}/after/pano.png`] = encodePng(2, 2, solid(2, 2, [255, 0, 0, 255]));
 		const uploaded: string[] = [];
-		const shell = fakeShell(script());
+		const seams = fakeSeams(script());
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEvidence({
@@ -327,16 +323,16 @@ describe("runEvidence", () => {
 						});
 					},
 				}),
-				Layer.mergeAll(shell.layer, fakeBytesFs({files: tampered}).layer, HTTP),
+				Layer.mergeAll(seams.layer, fakeBytesFs({files: tampered}).layer),
 			),
 		);
 		expect(outcome.code).toBe(CAPTURE_INVALID);
 		expect(uploaded).toEqual([]);
-		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("POST"))).toBe(false);
 	});
 
 	it("refuses a machine-local path in the composed comment on 5, and posts nothing", async () => {
-		const shell = fakeShell(script());
+		const seams = fakeSeams(script());
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEvidence({
@@ -347,12 +343,12 @@ describe("runEvidence", () => {
 							url: `/Users/someone/captures/${target.fileName}`,
 						}),
 				}),
-				Layer.mergeAll(shell.layer, fakeBytesFs({files: files()}).layer, HTTP),
+				Layer.mergeAll(seams.layer, fakeBytesFs({files: files()}).layer),
 			),
 		);
 		expect(outcome.code).toBe(LEAKED_PATH);
 		expect(outcome.stdout).toBe("");
-		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+		expect(seams.requests.some((line) => line.startsWith("POST"))).toBe(false);
 	});
 
 	// Seat 6 is the #3086 backstop, and `runEvidence` cannot reach it: `composeEvidence` always leads

--- a/packages/fabrika-cli/src/ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/render-verb.unit.test.ts
@@ -8,8 +8,7 @@ import {
 	marker,
 	NONCE,
 } from "../build/fixtures.test-support.ts";
-import {fakeShell, okOut} from "../fakes.test-support.ts";
-import type {ExecResult} from "../io/exec.ts";
+import {fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
 import {
 	BAD_SECTIONS,
@@ -29,15 +28,18 @@ const HARNESS = `${ROOT}/design-harness.json`;
 const LANE = `build/4312-editor-focus-loss-${NONCE}`;
 const SET_DIR = `/tmp/fabrika-build/s-9f2e/4312-${NONCE}/after`;
 
-const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+const LANE_OK: ReadonlyArray<Scripted> = [
 	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
 	[/^git rev-parse --abbrev-ref HEAD$/, okOut(`${LANE}\n`)],
-	[/^gh api repos\/o\/r\/issues\/4312$/, issue()],
+	[/GET .*\/repos\/o\/r\/issues\/4312$/, issue()],
 	[
-		/^gh api --paginate repos\/o\/r\/issues\/4312\/comments/,
+		/GET .*\/repos\/o\/r\/issues\/4312\/comments/,
 		comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
 	],
-	[/^gh api repos\/o\/r\/collaborators\/agent\/permission/, okOut("write\n")],
+	[
+		/GET .*\/repos\/o\/r\/collaborators\/agent\/permission/,
+		{status: 200, body: '{"permission":"write"}'},
+	],
 ];
 
 const PNG = encodePng(4, 4, solid(4, 4, [0, 0, 0, 255]));
@@ -64,7 +66,7 @@ const browsing =
 		Effect.succeed(outcome(request.url));
 
 const run = (
-	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	script: ReadonlyArray<Scripted>,
 	fs: FakeBytesFsOptions,
 	overrides: Partial<typeof options> & {browse?: BrowseLeg} = {},
 ) =>
@@ -75,7 +77,7 @@ const run = (
 				browse: browsing(() => ({_tag: "Captured"})),
 				...overrides,
 			}),
-			Layer.merge(fakeShell(script).layer, fakeBytesFs(fs).layer),
+			Layer.merge(fakeSeams(script).layer, fakeBytesFs(fs).layer),
 		),
 	);
 
@@ -109,7 +111,7 @@ describe("runRender", () => {
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runRender({...options, browse: browsing(() => ({_tag: "Captured"}))}),
-				Layer.merge(fakeShell(LANE_OK).layer, fs.layer),
+				Layer.merge(fakeSeams(LANE_OK).layer, fs.layer),
 			),
 		);
 		expect(outcome.code).toBe(0);
@@ -202,9 +204,9 @@ describe("runRender", () => {
 	});
 
 	it("refuses a foreign lane on 18", async () => {
-		const foreign = LANE_OK.map((row) =>
+		const foreign: ReadonlyArray<Scripted> = LANE_OK.map((row) =>
 			row[0].source.includes("comments")
-				? ([row[0], comments({id: 1, body: marker("other-session", LANE_UUID)})] as const)
+				? [row[0], comments({id: 1, body: marker("other-session", LANE_UUID)})]
 				: row,
 		);
 		const outcome = await run(foreign, captured);
@@ -213,10 +215,8 @@ describe("runRender", () => {
 	});
 
 	it("refuses on 11 when the claim state cannot be read", async () => {
-		const unreadable = LANE_OK.map((row) =>
-			row[0].source.includes("comments")
-				? ([row[0], {ok: false, stdout: "", reason: "HTTP 502"}] as const)
-				: row,
+		const unreadable: ReadonlyArray<Scripted> = LANE_OK.map((row) =>
+			row[0].source.includes("comments") ? [row[0], {status: 502, body: "{}"}] : row,
 		);
 		const outcome = await run(unreadable, captured);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);


### PR DESCRIPTION
Re-seams every `packages/fabrika-cli/` unit test that scripted a GitHub read or write as a `gh api`
subprocess onto the HTTP fake, in one pass, now that epic #6629's phase-2 adapters read over
`src/io/gh-api.ts`.

The baseline on `epic/6629` at 73de0a1a6 was **1606 failed of 7242 across 126 red files**. This branch
is **7242 passed of 7242 across 429 files** — the same total, so nothing was deleted rather than
re-seamed. `pnpm typecheck` and `pnpm lint` are green.

## What changed

126 test files move from `fakeShell`'s `gh api` script to `fakeHttp` / `fakeSeams`. Rows scripting
`git` are untouched and stay on the spawn seam — `fakeSeams` carries both in one ordered script, so a
row that moved seams changed its reply, not its place.

The substantive part is not the seam, it is the payloads. The `gh` era scripted `gh api --jq` output —
tab-separated rows, bare numbers, one id per line — and the ported adapters parse real GitHub JSON.
Every body was read off the parser that consumes it rather than guessed: bare-array reads became JSON
arrays whose terminal page carries no `Link` header, envelope reads became `{total_count, items}` /
`{total_count, workflow_runs}`, `--jq .permission` became `{"permission":"write"}`, writes carry a JSON
body instead of `-f key=value` argv, GraphQL became `POST /graphql`, and a `204` delete carries no body.

Assertions that pinned a command line — `toContain("--paginate")`, `--method POST`, `-f body=` —
became the equivalent claim on the recorded request, its JSON body, or its headers. No behavioural
assertion was weakened or dropped.

Two additions to `fakes.test-support.ts`, both to keep a claim a chunk had otherwise lowered:
`fakeSeams` now passes through the `headers` and `inputs` its two underlying fakes already collected.
Headers are what the `Accept: vnd.github.diff` provenance fences (#5117, #5122) need — the diff read and
the metadata read are the same URL, so `Accept` is the only place the difference is stated. `inputs` is
what `commit-verb`'s `git commit -F -` claim (#5484) needs, and exposing it deleted a verbatim
re-implementation of `fakeSeams` that had been inlined in that test to reach it.

Also drops fixture exports that nothing can reach any more: fourteen `gh api` command regexes and three
`ExecResult` helpers in the heal-ci fixtures, and the `gh api -i` status-line page builders in the ship
fixtures. Nothing scripts a subprocess for GitHub now, so they answered nobody — and a live `gh api`
string in a fixture is what #6651's no-`gh` guard is going to trip on.

## What a reviewer should look at first

`packages/fabrika-cli/src/map/ticket-verb.unit.test.ts` — the one case whose seam genuinely collapsed,
disclosed below. Then the two `fakes.test-support.ts` additions, since they are the only shared-surface
change. The rest is mechanical and the suite is the proof.

Fixes #6700

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #6700 scopes the pass to re-seaming unit tests.
  **Did:** also deleted dead exports from `packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts`
  (fourteen `gh api` regexes, plus `jsonArray`, `behind`, `permission`) and from
  `packages/fabrika-cli/src/ship/fixtures.test-support.ts` (`httpPage`, `reviews`, `timeline`,
  `unexhaustedPage`), and reworded four fixture doc comments that still named `gh api`.
  **Why:** every consumer had already stopped importing them, so they were unreachable text, and they
  are exactly the live `gh api` strings phase-3's no-`gh` guard scans for. **Disposition:** stated here;
  typecheck and the full suite green after the removal.

- **Out-of-scope change** — **Said:** the pass re-seams tests and touches nothing shared.
  **Did:** added `headers` and `inputs` pass-throughs to `fakeSeams` in
  `packages/fabrika-cli/src/fakes.test-support.ts`. **Why:** without `headers` the
  `Accept: vnd.github.diff` fences in `review/diff-verb` and `review/deviations-verb` could only infer
  their claim from a read count, which is weaker than what they asserted before (#5117, #5122); without
  `inputs`, `build/commit-verb` had inlined a copy of `fakeSeams` to reach the spawn stdin its
  `git commit -F -` claim reads (#5484). Both fields were already collected by the underlying fakes and
  merely not passed through. **Disposition:** stated here.

- **Known defect left unfixed** — **Said:** the driver asked whether `heal-ci/surface.ts`'s
  `readDeclared` should be moved onto `authed`/`onTransport` in this pass. **Did:** left it, and left the
  whole of `packages/fabrika-cli/src/heal-ci/github.ts` with it — every export there still publishes
  `HttpClient.HttpClient` and takes an `env`, against the #6704 ruling's adapter shape. **Why:** this
  issue's sixth acceptance criterion forbids modifying a non-test source file, and it is a whole-module
  change plus two verb call sites, not a one-liner; nothing is broken today, since the verbs provide what
  it asks for and typecheck is green. **Disposition:** filed as #6720, which names #6651 as the likely
  home.

- **Known defect left unfixed** — **Said:** re-seam the tests without changing what they pin.
  **Did:** `packages/fabrika-cli/src/map/ticket-verb.unit.test.ts`'s "exits 14 when an edge target's
  internal id cannot be resolved" no longer fails the internal-id read while the frontier read of the
  same issue succeeds. **Why:** under `gh` those were two distinguishable commands; over HTTP both are
  the identical `GET /repos/o/r/issues/<n>`, so they cannot be scripted apart at all. The subject is
  kept by making the id unresolvable the other way the adapter allows — the served payload carries no
  `id` — and the exit code, "nothing was written" and "no POST happened" all still assert.
  **Disposition:** stated here, with a comment at the test saying why; the underlying double-fetch is
  filed as #6724.

- **Declined guidance** — **Said:** several chunks proposed hoisting the per-file HTTP pattern and
  `reply` helper duplication into the shared fixture modules. **Did:** left the duplication; only the
  provably dead exports were removed. **Why:** the hoist rewrites payload builders that eight files
  across two directories consume, for no change in what any test pins, and it collides with #6651, which
  already owns fixture consolidation. **Disposition:** stated here.
