### PR TITLE
fix: comment.react broadcasts the owner-scoped sandboxed flag unstripped (latent; every sibling path strips or gates)

### DIFF
--- a/apps/web/worker/features/pano/comment-sandboxed-wire.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-sandboxed-wire.unit.test.ts
@@ -7,7 +7,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {ownSandboxed} from "../lifecycle/SandboxVisibility.ts";
 import {commentViewFields} from "./comment-fields.ts";
-import {toComment} from "./shapers.ts";
+import {broadcastComment, toComment} from "./shapers.ts";
 
 const AUTHOR = "user-author";
 const OTHER = "user-other";
@@ -64,5 +64,26 @@ describe("the Comment wire shape carries sandboxed", () => {
 	// a published-looking node, never an accidental `incelemede` on live content.
 	it("toComment defaults an unstamped row to false", () => {
 		assert.strictEqual(toComment(commentFields()).sandboxed, false);
+	});
+});
+
+// #4313: `comment.react` broadcasts a node re-resolved against the REACTOR, so an author
+// reacting to their own sandboxed comment would hand their review state to every other
+// subscriber of the viewer-blind `Comment` topic.
+describe("broadcastComment blanks every viewer-scoped review field at once", () => {
+	const ownView = toComment({...commentFields({sandboxed: true}), sandboxedInPlace: true});
+
+	it("an author's own view goes out as neither sandboxed nor sandboxedInPlace", () => {
+		const published = broadcastComment(ownView);
+		assert.strictEqual(published.sandboxed, false);
+		assert.strictEqual(published.sandboxedInPlace, false);
+	});
+
+	it("leaves the rest of the node alone", () => {
+		assert.deepStrictEqual(broadcastComment(ownView), {
+			...ownView,
+			sandboxed: false,
+			sandboxedInPlace: false,
+		});
 	});
 });

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -36,7 +36,7 @@ import {PanoFeedCache} from "./feed-cache.ts";
 import {CommentId, PostId} from "./ids.ts";
 import {panoLive} from "./live.ts";
 import {Pano} from "./Pano.ts";
-import {toComment, toPost, toPostFromPage} from "./shapers.ts";
+import {broadcastComment, toComment, toPost, toPostFromPage} from "./shapers.ts";
 import type {Comment, Post} from "./views.ts";
 import {CommentView, PostView} from "./views.ts";
 
@@ -618,8 +618,15 @@ export const mutations = {
 				emoji: input.emoji,
 				sandboxViewer,
 			});
+			// `r.comment` is re-resolved against the REACTOR, so an author reacting to their own
+			// sandboxed comment would otherwise fan their review state out to the viewer-blind
+			// `Comment` topic. `changed: ["reactions"]` trims both flags off the frame since #6585;
+			// this is the belt to that brace, the same one `comment.edit` keeps (#4313).
 			const comment = toComment(r.comment);
-			yield* live.comment.update(comment.id, {changed: ["reactions"], data: comment});
+			yield* live.comment.update(comment.id, {
+				changed: ["reactions"],
+				data: broadcastComment(comment),
+			});
 			return comment;
 		}),
 	),

--- a/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
@@ -76,11 +76,30 @@ const commentRowWith = (reactions: ReactionAggregate): CommentRow => ({
 	reactions,
 });
 
+interface UpdateCall {
+	readonly type: string;
+	readonly data: unknown;
+}
+
+// Records at the `LivePublisher` SERVICE boundary, not in `livePublisherFor`'s `publish`
+// callback: `updateFrame` trims `data` down to `["id", "reactions"]` before the frame
+// leaves, so a frame-level assertion passes with the owner-scoped flags still in the
+// payload the mutation handed over (#4313).
+const recordingLive = (calls: UpdateCall[]): Layer.Layer<LivePublisher> =>
+	Layer.succeed(LivePublisher)({
+		...livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
+		update: (type, _id, options) => {
+			calls.push({type, data: options?.data});
+			return Effect.void;
+		},
+	});
+
 const react = (
 	pano: Layer.Layer<Pano>,
 	on: boolean,
 	input: {id: string; emoji: string | null},
 	user: typeof CAYLAK | undefined = CAYLAK,
+	live: Layer.Layer<LivePublisher> = liveStub,
 ) =>
 	resolveWire(mutations["comment.react"], {
 		input,
@@ -90,7 +109,7 @@ const react = (
 			Layer.mergeAll(
 				pano,
 				flagsStub(on),
-				liveStub,
+				live,
 				// Both branches now re-resolve the comment through the real sandbox viewer
 				// (#6424 for the inert one, #6586 for the write's own re-read), so both axes
 				// it probes have to be on the context. `flagsStub` answers every key with
@@ -281,6 +300,50 @@ describe("comment.react — (4) reactions are ungated (a çaylak reacts, no tier
 				(comment as {reactions?: {myReaction?: string}}).reactions?.myReaction,
 				"❤️",
 			);
+		}),
+	);
+});
+
+describe("comment.react — (5) the broadcast payload is viewer-blind", () => {
+	// The reactor IS the author here: `reactToComment` re-resolves the row against the
+	// reactor, so this is the one case where both review-state flags come back `true`.
+	const ownSandboxedRow: CommentRow = {
+		...commentRowWith({counts: [{emoji: "👍", count: 1}], myReaction: "👍"}),
+		authorId: CAYLAK.id,
+		sandboxed: true,
+		sandboxedInPlace: true,
+	};
+
+	it.effect("an author reacting to their own sandboxed comment broadcasts neither flag", () =>
+		Effect.gen(function* () {
+			const calls: UpdateCall[] = [];
+			const comment = yield* react(
+				panoProxy({
+					reactToComment: () => Effect.succeed({comment: ownSandboxedRow, changed: true}),
+				}),
+				true,
+				{id: "comment_1", emoji: "👍"},
+				CAYLAK,
+				recordingLive(calls),
+			);
+
+			assert.strictEqual(calls.length, 1, "the fanned publish still fires");
+			const published = calls[0]?.data as Record<string, unknown>;
+			assert.strictEqual(calls[0]?.type, "Comment");
+			assert.strictEqual(published.sandboxed, false);
+			// Absent rather than `false`: `panoLive`'s `viewerBlindUpdate` deletes the in-place
+			// marker outright (#6462) between the shaper and this boundary. `broadcastComment`'s
+			// literal `false` is asserted on the shaper itself in `comment-sandboxed-wire`.
+			assert.notStrictEqual(published.sandboxedInPlace, true);
+			// The field the mutation actually changed survives the strip.
+			assert.deepStrictEqual(published.reactions, {
+				counts: [{emoji: "👍", count: 1}],
+				myReaction: "👍",
+			});
+
+			// The reactor's own result keeps what they are entitled to see.
+			assert.strictEqual((comment as {sandboxed?: boolean}).sandboxed, true);
+			assert.strictEqual((comment as {sandboxedInPlace?: boolean}).sandboxedInPlace, true);
 		}),
 	);
 });

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -106,3 +106,20 @@ export const toComment = (r: CommentFields): Comment => ({
 	sandboxedInPlace: r.sandboxedInPlace ?? false,
 	reactions: r.reactions ?? EMPTY_REACTION_AGGREGATE,
 });
+
+/**
+ * The viewer-blind form of a `Comment` node — what a broadcast to the viewer-blind
+ * `Comment` topic may carry. Both review-state fields are stamped from whoever resolved
+ * the row (`sandboxed` #4282, `sandboxedInPlace` #6423), so a payload re-resolved against
+ * the mutator hands their own review state to every other subscriber.
+ *
+ * One shaper owns the whole list so a third such field cannot be stripped at one broadcast
+ * site and missed at another (#4313). It is the innermost of three layers over the same
+ * leak — `viewerBlindUpdate` drops the in-place marker at `panoLive`, and the publisher's
+ * `changed` trim drops both since #6585 — and the only one a call site states for itself.
+ */
+export const broadcastComment = (comment: Comment): Comment => ({
+	...comment,
+	sandboxed: false,
+	sandboxedInPlace: false,
+});


### PR DESCRIPTION
`comment.react` re-resolves the comment against the **reactor**, so an author reacting to
their own still-sandboxed comment handed their own review state (`sandboxed`,
`sandboxedInPlace`) to the viewer-blind `Comment` topic. It was the one `Comment` broadcast
site relying on the publisher's `changed` trim alone; every sibling states the strip itself.

## What changed

- New `broadcastComment` shaper in `apps/web/worker/features/pano/shapers.ts` — the
  viewer-blind form of a `Comment` node, blanking both review-state fields at once.
  `comment.react`'s broadcast payload goes through it. The mutation's **return** value is
  untouched, so an author still sees their own `incelemede` badge.
- Two tests. The mutation-level one records the invariant at the `LivePublisher` service
  boundary — the payload the mutation hands over, before `updateFrame` trims it to
  `["id", "reactions"]` — and checks the reactor's returned node keeps its own values. The
  shaper-level one pins `broadcastComment`'s literal output. Reverting the one-line fix
  fails the mutation test.

Why a shaper and not `shapeComment`: `shapeComment` drops `reactions`, which is the field
this broadcast exists to fan, and it has no `sandboxedInPlace` parameter — so routing
through it would break the payload and still miss half the defect. A named shaper owns the
whole viewer-scoped field list in one place, so a third such field cannot be stripped at
one broadcast site and missed at another.

`comment.react` stays `fanned: true`; the publish is unchanged and `fanout-guard` is green.
No other broadcast site is touched.

Fixes #4313

## Deviations

- **Scope narrowing** — **Said:** criterion 6 asks the broadcast payload to carry
  `sandboxedInPlace: false`, and criterion 7 asks the test to assert both fields as `false`
  on the payload handed to `WorkerLivePublisher`. **Did:** `broadcastComment` sets it
  `false`, but at that boundary the key is **absent**, so the mutation test asserts
  `sandboxedInPlace` is never `true` there and the literal `false` is asserted on the shaper
  itself. **Why:** `panoLive`'s `viewerBlindUpdate` (#6462, landed after the issue's
  amendment) deletes the in-place marker outright between the shaper and the publisher, so
  an `=== false` assertion at that boundary is unsatisfiable. **Disposition:** stated here;
  the criterion's substance — the reactor's marker never reaches the topic — is covered at
  both boundaries.
