### PR TITLE
fix: Profile contributions feed's sandboxed field is not owner-scoped

### DIFF
--- a/apps/web/src/components/profile/ContributionRow.tsx
+++ b/apps/web/src/components/profile/ContributionRow.tsx
@@ -7,7 +7,7 @@ import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import {Badge} from "../ui/Badge";
-import {ReviewBadge} from "../ui/ReviewBadge";
+import {SandboxMarker} from "../ui/SandboxMarker";
 import "./ContributionRow.css";
 
 export const ContributionView = view<Contribution>()({
@@ -15,9 +15,8 @@ export const ContributionView = view<Contribution>()({
 	id: true,
 	score: true,
 	createdAt: true,
-	// A bare boolean carrying no reviewer identity (one-way glass), and sent only to
-	// the author/moderator — a non-owner never receives a sandboxed row at all.
 	sandboxed: true,
+	sandboxedInPlace: true,
 	bodyExcerpt: true,
 	termSlug: true,
 	termTitle: true,
@@ -29,12 +28,26 @@ export const ContributionView = view<Contribution>()({
 
 export interface ContributionRowProps {
 	node: ViewRef<"Contribution">;
+	/**
+	 * The viewer authored these rows. The feed is author-scoped, so ownership is a
+	 * property of the profile being read, not of the individual row — which is why it
+	 * cannot be derived here and has to be passed down.
+	 */
+	isOwn?: boolean;
 	sandboxBadge?: boolean;
 }
 
-export function ContributionRow({node, sandboxBadge = false}: ContributionRowProps) {
+export function ContributionRow({node, isOwn = false, sandboxBadge = false}: ContributionRowProps) {
 	const c = useView(ContributionView, node);
-	const badge = sandboxBadge && c.sandboxed ? <ReviewBadge /> : null;
+	// `sandboxBadge` is the caller's çaylak-status gate on the OWNER badge (#1316); a
+	// surface that withholds it passes `undefined` and lands on `none` for the owner.
+	const badge = (
+		<SandboxMarker
+			isOwn={isOwn}
+			sandboxed={sandboxBadge ? c.sandboxed : undefined}
+			sandboxedInPlace={c.sandboxedInPlace}
+		/>
+	);
 
 	if (c.kind === "definition") {
 		return (

--- a/apps/web/src/components/profile/ProfileContributionSignal.tsx
+++ b/apps/web/src/components/profile/ProfileContributionSignal.tsx
@@ -128,7 +128,7 @@ function SignalList({profile, username}: {profile: ViewRef<"Profile">; username:
 		<>
 			<ul className="kp-user-profile__list kp-signal__list">
 				{items.map(({cursor, node}) => (
-					<ContributionRow key={cursor} node={node} />
+					<ContributionRow key={cursor} node={node} isOwn />
 				))}
 			</ul>
 			{loadNext ? (

--- a/apps/web/src/components/ui/sandbox-marker-surfaces.unit.test.ts
+++ b/apps/web/src/components/ui/sandbox-marker-surfaces.unit.test.ts
@@ -1,7 +1,7 @@
 /**
  * The çaylak marker's surface coverage (#6427, epic #4306): every place the #6425 wire field
  * is delivered renders it, and renders it through `SandboxMarker` rather than a hand-rolled
- * ternary — a fifth surface that selects the field but forgets the badge is the drift this
+ * ternary — a new surface that selects the field but forgets the badge is the drift this
  * pins. A source scan, like `badge-variant-contract`: it holds even for the surfaces whose
  * live render needs a fate transport to mount.
  */
@@ -11,12 +11,16 @@ import {describe, expect, it} from "vitest";
 
 const sourceRoot = join(import.meta.dirname, "../..");
 
-/** The four surfaces the issue names: the pano feed row, post detail, comment node, sözlük entry. */
+/**
+ * The pano feed row, post detail, comment node, sözlük entry — plus the profile
+ * contribution row, the fifth surface #6464 brought onto the split.
+ */
 const surfaces = [
 	"components/pano/PanoPostCard.tsx",
 	"components/pano/PanoPostHeader.tsx",
 	"components/pano/CommentTreeNode.tsx",
 	"components/sozluk/DefinitionCard.tsx",
+	"components/profile/ContributionRow.tsx",
 ];
 
 const read = (path: string) => readFileSync(join(sourceRoot, path), "utf8");

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -91,8 +91,8 @@ function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 	const data = useView(UserProfileView, profile);
 	const {userId} = useView(UserProfileHeaderView, profile);
 	const {me} = useMe();
-	// The badge is own-profile only; a non-owner never receives a sandboxed row anyway.
-	const sandboxBadge = shouldShowCaylakStatus(me?.tier, me?.id === userId);
+	const isOwn = me?.id === userId;
+	const sandboxBadge = shouldShowCaylakStatus(me?.tier, isOwn);
 	const [items, loadNext] = useListView(ContributionsConnectionView, data.contributions);
 
 	return (
@@ -106,7 +106,7 @@ function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 			) : (
 				<ul className="kp-user-profile__list">
 					{items.map(({cursor, node}) => (
-						<ContributionRow key={cursor} node={node} sandboxBadge={sandboxBadge} />
+						<ContributionRow key={cursor} node={node} isOwn={isOwn} sandboxBadge={sandboxBadge} />
 					))}
 				</ul>
 			)}

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -20,8 +20,10 @@ import {moderatorTuple, type PlatformRole} from "../kunye/moderate.ts";
 import type {StoredTier} from "../kunye/standing.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {
+	ownSandboxed,
 	resolveSandboxViewer,
 	sandboxBacklogWhere,
+	sandboxedInPlace,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
 import {postVisibleWhere} from "../pano/PostVisibility.ts";
@@ -89,13 +91,33 @@ export interface SetDisplayNameResult {
 	image: string | null;
 }
 
-// `sandboxed` = `sandboxed_at IS NOT NULL` (#1316). It carries NO reviewer identity,
-// and the feed only ever surfaces a sandboxed row to its author + a moderator.
 interface ContributionBase {
 	id: string;
 	createdAt: Date;
 	score: number;
+	/**
+	 * Owner-scoped in-review flag (#1316/#2200): `true` only when this row is still
+	 * sandboxed AND the viewer is its author, so it never leaks review state to anyone
+	 * else. The client renders it as `ReviewBadge` ("incelemede") — the author's own
+	 * signal about their own row.
+	 */
 	sandboxed: boolean;
+	/**
+	 * The reader-facing çaylak marker (#6425): `true` iff this row is still sandboxed AND
+	 * the viewer is the opted-in in-place reader of #6423, derived from the resolved
+	 * `SandboxViewer` this read already carries.
+	 *
+	 * The twin of `sandboxed` above, and never a substitute for it — this one marks
+	 * SOMEBODY ELSE's hazırlık-stage work for a reader who asked to see çaylak work in
+	 * place, so the two are true for disjoint audiences on the same row and cannot
+	 * collapse into one field. Structurally `false` for every viewer while
+	 * `PHOENIX_CAYLAK_VISIBILITY` is off.
+	 *
+	 * A çaylak→yazar promotion sweep does not re-announce this connection (#6462): the
+	 * profile feed is read through `useListView`, not `useLiveListView`, so no subscriber
+	 * holds it open and the next read re-derives both fields.
+	 */
+	sandboxedInPlace: boolean;
 }
 
 // The single source of variant→fields for the contribution union: every other shape
@@ -849,6 +871,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 								createdAt: schema.definitionRecord.createdAt,
 								score: schema.definitionRecord.score,
 								sandboxedAt: schema.definitionRecord.sandboxedAt,
+								authorId: schema.definitionRecord.authorId,
 								bodyExcerpt: schema.definitionRecord.bodyExcerpt,
 								termSlug: schema.definitionRecord.termSlug,
 								termTitle: schema.definitionRecord.termTitle,
@@ -867,6 +890,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 								createdAt: schema.postRecord.createdAt,
 								score: schema.postRecord.score,
 								sandboxedAt: schema.postRecord.sandboxedAt,
+								authorId: schema.postRecord.authorId,
 								title: schema.postRecord.title,
 								bodyExcerpt: schema.postRecord.bodyExcerpt,
 							})
@@ -883,6 +907,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 								createdAt: schema.commentRecord.createdAt,
 								score: schema.commentRecord.score,
 								sandboxedAt: schema.commentRecord.sandboxedAt,
+								authorId: schema.commentRecord.authorId,
 								bodyExcerpt: schema.commentRecord.bodyExcerpt,
 								postId: schema.commentRecord.postId,
 								postTitle: schema.commentRecord.postTitle,
@@ -913,7 +938,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 							id: d.id,
 							createdAt: d.createdAt ?? new Date(0),
 							score: d.score,
-							sandboxed: d.sandboxedAt != null,
+							sandboxed: ownSandboxed(d, viewer.viewerId),
+							sandboxedInPlace: sandboxedInPlace(d, viewer),
 							bodyExcerpt: d.bodyExcerpt,
 							termSlug: d.termSlug,
 							termTitle: d.termTitle,
@@ -923,7 +949,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 							id: p.id,
 							createdAt: p.createdAt ?? new Date(0),
 							score: p.score,
-							sandboxed: p.sandboxedAt != null,
+							sandboxed: ownSandboxed(p, viewer.viewerId),
+							sandboxedInPlace: sandboxedInPlace(p, viewer),
 							title: p.title,
 							slug: p.slug,
 							bodyExcerpt: p.bodyExcerpt,
@@ -933,7 +960,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 							id: c.id,
 							createdAt: c.createdAt ?? new Date(0),
 							score: c.score,
-							sandboxed: c.sandboxedAt != null,
+							sandboxed: ownSandboxed(c, viewer.viewerId),
+							sandboxedInPlace: sandboxedInPlace(c, viewer),
 							bodyExcerpt: c.bodyExcerpt,
 							postId: c.postId,
 							postTitle: c.postTitle,

--- a/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
@@ -177,44 +177,103 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 	);
 });
 
-// The per-item review-state flag (#1316) the status block badges "incelemede" off, derived
-// in the feed map as `sandboxed: sandboxed_at != null`.
-describe("Pasaport.listContributions — the per-item sandboxed flag (#1316)", () => {
-	const sandboxedDef = {
-		id: "d-sandboxed",
-		createdAt: new Date("2026-01-02T00:00:00Z"),
-		score: 0,
-		sandboxedAt: new Date("2026-01-03T00:00:00Z"),
-		bodyExcerpt: "in review",
-		termSlug: "s",
-		termTitle: "T",
-	};
-	const liveDef = {
-		id: "d-live",
-		createdAt: new Date("2026-01-01T00:00:00Z"),
-		score: 0,
-		sandboxedAt: null,
-		bodyExcerpt: "live",
-		termSlug: "s",
-		termTitle: "T",
-	};
+const sandboxedDef = {
+	id: "d-sandboxed",
+	createdAt: new Date("2026-01-02T00:00:00Z"),
+	score: 0,
+	sandboxedAt: new Date("2026-01-03T00:00:00Z"),
+	authorId: AUTHOR,
+	bodyExcerpt: "in review",
+	termSlug: "s",
+	termTitle: "T",
+};
+const liveDef = {
+	id: "d-live",
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	score: 0,
+	sandboxedAt: null,
+	authorId: AUTHOR,
+	bodyExcerpt: "live",
+	termSlug: "s",
+	termTitle: "T",
+};
 
+// Order: def/post/comment feed SELECTs, then the three COUNT(*) totals.
+const readFeedAs = (sandboxViewer: SandboxViewer) =>
+	Effect.gen(function* () {
+		const {access} = scriptedAccess([[sandboxedDef, liveDef], [], [], 2, 0, 0]);
+		const connection = yield* Effect.gen(function* () {
+			const pasaport = yield* Pasaport;
+			return yield* pasaport.listContributions({authorId: AUTHOR, first: 10, sandboxViewer});
+		}).pipe(Effect.provide(pasaportOver(access)));
+		return new Map(connection.rows.map((r) => [r.node.id, r.node]));
+	});
+
+// The per-item review-state flag (#1316) the status block badges "incelemede" off, now
+// owner-scoped through `ownSandboxed`.
+describe("Pasaport.listContributions — the per-item sandboxed flag (#1316)", () => {
 	it.effect("flags a sandboxed item `sandboxed: true` and a live item `sandboxed: false`", () =>
 		Effect.gen(function* () {
-			// Order: def/post/comment feed SELECTs, then the three COUNT(*) totals.
-			const {access} = scriptedAccess([[sandboxedDef, liveDef], [], [], 2, 0, 0]);
-			const connection = yield* Effect.gen(function* () {
-				const pasaport = yield* Pasaport;
-				return yield* pasaport.listContributions({
-					authorId: AUTHOR,
-					first: 10,
-					sandboxViewer: viewers.author,
-				});
-			}).pipe(Effect.provide(pasaportOver(access)));
-
-			const byId = new Map(connection.rows.map((r) => [r.node.id, r.node]));
+			const byId = yield* readFeedAs(viewers.author);
 			assert.strictEqual(byId.get("d-sandboxed")?.sandboxed, true, "sandboxed item flagged true");
 			assert.strictEqual(byId.get("d-live")?.sandboxed, false, "live item flagged false");
 		}),
 	);
+});
+
+/**
+ * The two-field split (#6464) this feed was missing: `sandboxed` is the AUTHOR's own
+ * "incelemede" signal, `sandboxedInPlace` is the #6423 in-place reader's marker about
+ * somebody ELSE's row. Both derive from the resolved `SandboxViewer` the read carries, so
+ * the fifth çaylak surface can no longer hand a reader the author-facing badge.
+ */
+describe("Pasaport.listContributions — the owner/reader split (#6464)", () => {
+	const inPlaceReader = {
+		viewerId: OTHER,
+		canSeeSandboxed: false,
+		seesSandboxedInPlace: true,
+	} satisfies SandboxViewer;
+
+	it.effect("the author reads their own row as `sandboxed`, never as the reader marker", () =>
+		Effect.gen(function* () {
+			const row = (yield* readFeedAs(viewers.author)).get("d-sandboxed");
+			assert.strictEqual(row?.sandboxed, true);
+			assert.strictEqual(row?.sandboxedInPlace, false, "the owner is not a reader of their own");
+		}),
+	);
+
+	it.effect("the opted-in in-place reader gets the marker and NO owner flag", () =>
+		Effect.gen(function* () {
+			const row = (yield* readFeedAs(inPlaceReader)).get("d-sandboxed");
+			assert.strictEqual(row?.sandboxed, false, "review state never leaves the author");
+			assert.strictEqual(row?.sandboxedInPlace, true);
+		}),
+	);
+
+	it.effect("a live row carries neither field for the in-place reader", () =>
+		Effect.gen(function* () {
+			const row = (yield* readFeedAs(inPlaceReader)).get("d-live");
+			assert.strictEqual(row?.sandboxed, false);
+			assert.strictEqual(row?.sandboxedInPlace, false, "nothing to mark on promoted work");
+		}),
+	);
+
+	// Every non-author viewer reachable with `PHOENIX_CAYLAK_VISIBILITY` down: the flag is
+	// what resolves `seesSandboxedInPlace`, so with it off there is no third viewer class and
+	// `sandboxedInPlace` is structurally false — matching `SandboxVisibility.unit.test.ts`.
+	const flagDownNonAuthors = {
+		"a plain signed-in non-author": viewers.otherMember,
+		"an anonymous viewer": viewers.anonymous,
+		"a moderator": viewers.moderator,
+	} satisfies Record<string, SandboxViewer>;
+
+	for (const [label, viewer] of Object.entries(flagDownNonAuthors)) {
+		it.effect(`${label} reads both fields false with the flag off`, () =>
+			Effect.gen(function* () {
+				const row = (yield* readFeedAs(viewer)).get("d-sandboxed");
+				assert.strictEqual(row?.sandboxed, false, "owner flag is author-only");
+				assert.strictEqual(row?.sandboxedInPlace, false, "marker is flag-gated");
+			}),
+		);
+	}
 });

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -139,7 +139,7 @@ export function toContributionRow(node: ContributionNode): ContributionRow {
 	const variantColumns = Object.fromEntries(
 		CONTRIBUTION_VARIANT_FIELD_NAMES.map((name) => [name, null]),
 	);
-	const {kind, id, score, createdAt, sandboxed, ...variantFields} = node;
+	const {kind, id, score, createdAt, sandboxed, sandboxedInPlace, ...variantFields} = node;
 	return {
 		...variantColumns,
 		kind,
@@ -147,6 +147,7 @@ export function toContributionRow(node: ContributionNode): ContributionRow {
 		score,
 		createdAt,
 		sandboxed,
+		sandboxedInPlace,
 		...variantFields,
 	} as ContributionRow;
 }

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -34,8 +34,10 @@ export class ContributionView extends FateDataView<ContributionViewRow>()("Contr
 	id: true,
 	score: true,
 	createdAt: true,
-	// Carries no reviewer identity (one-way-glass, #1316).
+	// The two-field çaylak split (#6464): `sandboxed` is owner-scoped, `sandboxedInPlace`
+	// is the reader-facing marker. Both are derived per viewer, never row-intrinsic.
 	sandboxed: true,
+	sandboxedInPlace: true,
 	bodyExcerpt: true,
 	termSlug: true,
 	termTitle: true,


### PR DESCRIPTION
The profile contributions feed stamped `sandboxed` as a bare "is this row in review" bit with no viewer in it, while the three sibling çaylak surfaces stamp the owner-scoped `ownSandboxed`. Once #6423's in-place reader arm goes live, a non-author reading a çaylak's profile gets `sandboxed: true` on somebody else's rows and sees the author-facing "incelemede" badge about them. This lands the two-field split the founder ruled: `sandboxed` narrowed to `ownSandboxed`, plus a reader-facing `sandboxedInPlace`.

**Server.** The three feed selects now project `author_id` beside `sandboxed_at`, so each merge stamps both fields off the row itself against the `SandboxViewer` `keysetWhere` already resolved — no synthetic record assembled from `input.authorId`, and no hand-rolled `sandboxedAt != null` left on this surface. `ContributionBase`, `toContributionRow` and `ContributionView` carry the new field; the old docblock claiming the feed only reaches the author and a moderator is replaced by the sibling surfaces' twin-field wording.

**Client.** `ContributionRow` selects `sandboxedInPlace` and renders through `<SandboxMarker>`, so the "at most one badge, owner's wins" rule in `sandbox-marker.ts` decides instead of a local ternary. Ownership is a property of the profile being read rather than of a row, so it arrives as a new `isOwn` prop: `UserProfilePage` passes `me?.id === userId`, and the owner-only `ProfileContributionSignal` passes it constant. The existing `sandboxBadge` çaylak-status gate still gates the owner badge and is threaded in as the marker's `sandboxed` input.

**Tests.** `contributions-sandbox.unit.test.ts` proves the split per viewer on a sandboxed row: the author reads `true` / `false`, the opted-in in-place reader reads `false` / `true`, and a plain signed-in non-author, an anonymous viewer and a moderator all read both `false` — which is also the flag-down case, since `sandboxedInPlace` rides `seesSandboxedInPlace` alone and that resolves `false` with `PHOENIX_CAYLAK_VISIBILITY` off. The surface scan lists the contribution row as a fifth surface and passes all three of its checks.

### The promotion sweep question

Answering criterion 10 explicitly: **no sweep invalidation is needed here**, and that is a decision rather than an omission.

The #6462 rule binds a connection some subscriber holds open over `/fate/live`. `Profile.contributions` is not one. Both readers of this feed use the non-live hooks — `useListView` / `useView` in `UserProfilePage.tsx` and `ProfileContributionSignal.tsx`, never `useLiveListView` / `useLiveView` — and `apps/web/worker/features/pasaport/live.ts` carries exactly one target, `User.update`, with no `Profile.contributions` topic to publish to. So no subscriber can be sitting on a stale `sandboxedInPlace` after a promotion sweep; the next read of the feed re-derives both fields against the reader's own viewer. The same reasoning is recorded at the field's declaration in `Pasaport.ts`, so it survives outside this description.

Fixes #6464

## Deviations

- **Out-of-scope change** — **Said:** #6464's criterion 6 names only `ContributionRow.tsx`. **Did:** also added an `isOwn` prop and passed it from both call sites (`UserProfilePage.tsx`, `ProfileContributionSignal.tsx`). **Why:** `SandboxMarker`'s owner-wins rule needs ownership, and the contribution wire row carries no `authorId` — the feed is author-scoped, so ownership is knowable only at the caller. Passing it beats widening the wire shape with a field nothing else reads. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** add new stamp assertions beside the existing `.toSQL()` test. **Did:** also gave the two existing definition fixtures an `authorId` and lifted the existing flag test's body into a shared `readFeedAs` helper. **Why:** the merges now read `authorId` off the row, so a fixture without one cannot stamp; the helper is reused by seven cases rather than copied. The existing assertion is unchanged. **Disposition:** stated here.
