### PR TITLE
chore: Topbar account pill is not gated on reserveSignedInSlots — only the placeholder is

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -264,6 +264,40 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
 	});
 
+	// #6660: the same divergence, read as the coupling itself. `LayoutContent` publishes no
+	// `userProps` for a signed-out session, so the spread falls through to the boot props and the
+	// topbar is handed a `user` — the account side stays empty only because the CTA's own
+	// condition gates it. Drop that gate and this render carries a phantom pill beside `giriş yap`.
+	it("__BOOT__ present, settled signed-out, no userProps published: the CTA and the account side never share a render", () => {
+		flags.signedIn = true;
+		const {container} = renderApp(FATE_FREE_ROUTE);
+
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+
+		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
+		expect(container.querySelector(".kp-topbar__user")).toBeNull();
+	});
+
+	// The other direction of the same gate: with no `__BOOT__` the claim comes from the settled
+	// session alone, so widening it to cover the pill must not cost a signed-in visitor their menu.
+	it("__BOOT__ absent but the session settles signed-in: the account pill renders and no CTA does", () => {
+		const {container} = renderApp(FATE_FREE_ROUTE);
+		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
+
+		act(() => {
+			setSession({
+				data: {user: {id: "user-42", name: "Elif", email: "elif@kamp.us"}},
+				isPending: false,
+			});
+		});
+
+		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
+		expect(container.querySelector(".kp-topbar__user")).not.toBeNull();
+		expect(screen.getByText("Elif")).toBeTruthy();
+	});
+
 	it("__BOOT__ absent (readBootUser null): the shell is exactly as today — giriş-yap, no account cluster (AC-3)", () => {
 		renderApp();
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -6,7 +6,7 @@
  * the REAL `FateProvider` gate through a mount-recording `FateClient` spy; see the two
  * `// REGRESSION:` notes on the assertions.
  */
-import {act, render, screen} from "@testing-library/react";
+import {act, render, screen, within} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {MemoryRouter} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
@@ -278,6 +278,11 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
 		expect(container.querySelector(".kp-topbar__user")).toBeNull();
+		// The gate that empties the account side also decides where the theme control lives: with
+		// no user menu to carry it, the utility-zone picker must render (#2612).
+		expect(
+			within(screen.getByTestId("topbar-zone-utility")).getByTestId("topbar-theme-picker"),
+		).toBeTruthy();
 	});
 
 	// The other direction of the same gate: with no `__BOOT__` the claim comes from the settled

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,7 +66,7 @@ import {UserProfilePage} from "./pages/UserProfilePage";
 import {useProfileStats} from "./pages/useProfileStats";
 
 type TopbarChips = {
-	userProps: {user?: {name: string; username: string | null}};
+	userProps: {user: {name: string; username: string | null}} | undefined;
 	karma: number | undefined;
 	divanTo: string | undefined;
 	bildirim: {to: string; unread: number} | undefined;
@@ -127,15 +127,17 @@ function Layout() {
 	// `__BOOT__` this is null and the session-gated `isSignedIn` governs.
 	const bootUser = readBootUser();
 	const bootSignedIn = bootUser != null;
-	// Reserve the account slot only while the edge said signed-in AND we haven't settled to a
-	// definitively signed-out session — so an absent `__BOOT__` never reserves (today's render)
-	// and a boot/session divergence collapses cleanly rather than stranding a phantom slot.
-	const reserveSignedInSlots = bootSignedIn && (session.isPending || isSignedIn);
-	// Both halves of the account side hang off that one condition, so they can never collapse in
-	// opposite directions: the CTA is suppressed exactly while the slot is filled or reserved.
-	// Keying it off `__BOOT__` alone left a boot/session divergence showing neither the pill nor
-	// the CTA, a shell with no way to sign in (#6577).
-	const showSignInCta = !isSignedIn && !reserveSignedInSlots;
+	// The account side is claimed by a settled signed-in session, or on trust while the edge said
+	// signed-in and the session has yet to answer. A boot/session divergence therefore releases it
+	// on the settle rather than stranding a phantom slot, and an absent `__BOOT__` claims nothing
+	// before the session settles (today's render).
+	const reserveSignedInSlots = isSignedIn || (bootSignedIn && session.isPending);
+	// Both halves of the account side read this one value — `Topbar` gates the pill and its
+	// placeholder on the prop, the CTA is its literal negation — so they can never collapse in
+	// opposite directions. Keying the CTA off `__BOOT__` alone left a divergence showing neither,
+	// a shell with no way to sign in (#6577); leaving the pill on a truthy `user` prop left the
+	// other direction, a phantom pill beside the CTA, held off only by a distant `{}` (#6660).
+	const showSignInCta = !reserveSignedInSlots;
 	const bootUserProps = bootUser
 		? {
 				user: {
@@ -168,6 +170,9 @@ function Layout() {
 								...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
 							]}
 							divanTo={chips?.divanTo}
+							// Boot props carry the first paint, before `LayoutContent` publishes any chips.
+							// A signed-out publish leaves `userProps` undefined, so they land again there —
+							// inert, because `reserveSignedInSlots` is false and gates the whole account side.
 							{...(chips?.userProps ?? bootUserProps)}
 							karma={chips?.karma}
 							{...(chips?.bildirim ? {bildirim: chips.bildirim} : {})}
@@ -268,7 +273,7 @@ function LayoutContent() {
 							username,
 						},
 					}
-				: {},
+				: undefined,
 			karma: selfKarma,
 			divanTo: showDivan ? "/divan" : undefined,
 			bildirim: bildirimOn && isSignedIn ? {to: "/bildirimler", unread: bildirimUnread} : undefined,

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -13,7 +13,13 @@ const NAV = [
 function renderTopbar() {
 	return render(
 		<MemoryRouter>
-			<Topbar nav={NAV} divanTo="/divan" karma={42} user={{name: "Elif", username: "elif"}} />
+			<Topbar
+				nav={NAV}
+				divanTo="/divan"
+				karma={42}
+				reserveSignedInSlots
+				user={{name: "Elif", username: "elif"}}
+			/>
 		</MemoryRouter>,
 	);
 }
@@ -49,7 +55,13 @@ describe("Topbar nav-IA zone grammar (#2611)", () => {
 		// destination zone ties the CSS-source guard to a real DOM occupant.
 		render(
 			<MemoryRouter initialEntries={["/pano"]}>
-				<Topbar nav={NAV} divanTo="/divan" karma={42} user={{name: "Elif", username: "elif"}} />
+				<Topbar
+					nav={NAV}
+					divanTo="/divan"
+					karma={42}
+					reserveSignedInSlots
+					user={{name: "Elif", username: "elif"}}
+				/>
 			</MemoryRouter>,
 		);
 		const activePano = screen.getByRole("link", {name: "pano"});
@@ -172,6 +184,7 @@ describe("Topbar status/signal zone (#2613)", () => {
 					nav={NAV}
 					divanTo="/divan"
 					karma={42}
+					reserveSignedInSlots
 					user={{name: "Elif", username: "elif"}}
 					{...props}
 				/>
@@ -226,6 +239,7 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 					nav={NAV}
 					themeChoice="auto"
 					onThemeChange={() => {}}
+					reserveSignedInSlots
 					user={{name: "Elif", username: "elif"}}
 				/>
 			</MemoryRouter>,
@@ -247,6 +261,7 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 					nav={NAV}
 					themeChoice="dark"
 					onThemeChange={onThemeChange}
+					reserveSignedInSlots
 					user={{name: "Elif", username: "elif"}}
 				/>
 			</MemoryRouter>,
@@ -298,6 +313,7 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 					nav={NAV}
 					themeChoice="light"
 					onThemeChange={() => {}}
+					reserveSignedInSlots
 					user={{name: "Elif", username: "elif"}}
 				/>
 			</MemoryRouter>,
@@ -367,6 +383,19 @@ describe("Topbar reserved signed-in account slot (#2933)", () => {
 
 	it("reserve off, no user: no placeholder — today's signed-out render (AC-3 no-op)", () => {
 		const {container} = renderReserved({reserveSignedInSlots: false});
+		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
+		expect(container.querySelector(".kp-topbar__user")).toBeNull();
+	});
+
+	// #6660: the flag gates the pill too, not just the placeholder. A caller showing its sign-in
+	// CTA off this flag's negation can hand a stale `user` through — an edge-resolved identity the
+	// settled session denies — and must still get an empty account side, never a pill beside a CTA.
+	it("reserve off, user supplied: no pill either — the flag gates the whole account side", () => {
+		const {container} = renderReserved({
+			reserveSignedInSlots: false,
+			user: {name: "Elif", username: "elif"},
+		});
+		expect(screen.queryByText("Elif")).toBeNull();
 		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
 		expect(container.querySelector(".kp-topbar__user")).toBeNull();
 	});

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -399,4 +399,28 @@ describe("Topbar reserved signed-in account slot (#2933)", () => {
 		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
 		expect(container.querySelector(".kp-topbar__user")).toBeNull();
 	});
+
+	// #2612 says exactly one theme control renders in every state, and the account gate is what
+	// decides which one. These two cases are the states where the gate and a bare `user` disagree.
+	it("reserve off, user supplied: the utility picker still renders — no menu means no menu picker", () => {
+		renderReserved({
+			reserveSignedInSlots: false,
+			user: {name: "Elif", username: "elif"},
+			themeChoice: "light",
+			onThemeChange: () => {},
+		});
+		const utility = screen.getByTestId("topbar-zone-utility");
+		expect(within(utility).getByTestId("topbar-theme-picker")).toBeTruthy();
+	});
+
+	it("reserve on, no user: the utility picker renders beside the placeholder", () => {
+		renderReserved({
+			reserveSignedInSlots: true,
+			themeChoice: "light",
+			onThemeChange: () => {},
+		});
+		const utility = screen.getByTestId("topbar-zone-utility");
+		expect(within(utility).getByTestId("topbar-theme-picker")).toBeTruthy();
+		expect(screen.getByTestId("topbar-user-placeholder")).toBeTruthy();
+	});
 });

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -45,6 +45,8 @@ export function Topbar({
 	themeChoice?: ThemeChoice;
 	onThemeChange?: (choice: ThemeChoice) => void;
 	onLogout?: () => void;
+	// The account side is claimed — gates the pill as well as its placeholder, so a caller that
+	// also renders a sign-in CTA must derive that CTA from this flag's negation (#6660).
 	reserveSignedInSlots?: boolean;
 }) {
 	// ⌘K (mac) / Ctrl+K (other) focuses search, backing the <Kbd>⌘K</Kbd> hint below.
@@ -146,20 +148,23 @@ export function Topbar({
 			onLogout={onLogout}
 		/>
 	) : null;
-	// The placeholder holds the account slot's geometry until fate publishes the real user, so
-	// the menu fills in place with no shift. See ADR 0179 §1 and ADR 0185.
-	const accountSlot =
-		userMenu ??
-		(reserveSignedInSlots ? (
-			<span
-				className="kp-topbar__user kp-topbar__user--placeholder"
-				data-testid="topbar-user-placeholder"
-				aria-hidden="true"
-			>
-				<span className="kp-avatar" />
-				<span className="kp-topbar__name-placeholder" />
-			</span>
-		) : null);
+	// `reserveSignedInSlots` gates the whole account side, pill included. The caller derives its
+	// sign-in CTA from the negation of this same flag, so gating only the placeholder left the
+	// pill riding a truthy `user` prop that a signed-out caller could still supply — pill and CTA
+	// on screen together (#6660). Inside the gate the placeholder holds the slot's geometry until
+	// the real user arrives, so the menu fills in place with no shift. See ADR 0179 §1, ADR 0185.
+	const accountSlot = reserveSignedInSlots
+		? (userMenu ?? (
+				<span
+					className="kp-topbar__user kp-topbar__user--placeholder"
+					data-testid="topbar-user-placeholder"
+					aria-hidden="true"
+				>
+					<span className="kp-avatar" />
+					<span className="kp-topbar__name-placeholder" />
+				</span>
+			))
+		: null;
 
 	// Every element sits in its one lawful zone (see ADR 0176). The primary-action zone is
 	// empty on purpose — #2600 moved `+ gönderi` to the pano Subnav CTA; do not refill it.

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -139,15 +139,16 @@ export function Topbar({
 		bildirim && showUnreadBadge(bildirim.unread) ? (
 			<BildirimPopover to={bildirim.to} unread={bildirim.unread} />
 		) : null;
-	const userMenu = user ? (
-		<UserMenu
-			user={user}
-			bildirim={bildirim}
-			themeChoice={themeChoice}
-			onThemeChange={onThemeChange}
-			onLogout={onLogout}
-		/>
-	) : null;
+	const userMenu =
+		reserveSignedInSlots && user ? (
+			<UserMenu
+				user={user}
+				bildirim={bildirim}
+				themeChoice={themeChoice}
+				onThemeChange={onThemeChange}
+				onLogout={onLogout}
+			/>
+		) : null;
 	// `reserveSignedInSlots` gates the whole account side, pill included. The caller derives its
 	// sign-in CTA from the negation of this same flag, so gating only the placeholder left the
 	// pill riding a truthy `user` prop that a signed-out caller could still supply — pill and CTA
@@ -186,9 +187,11 @@ export function Topbar({
 			<span className="kp-topbar__spacer" />
 			<div className="kp-topbar__zone kp-topbar__zone--utility" data-testid="topbar-zone-utility">
 				{searchForm}
-				{/* Signed-out visitors reach the theme picker here; signed-in ones in the user
-				    menu (above), so exactly one theme control renders either way (#2612). */}
-				{!user ? themePicker : null}
+				{/* The picker rides the user menu when one renders, and sits here when none does, so
+				    exactly one theme control renders in every state (#2612). It reads `userMenu`
+				    itself, not `user` — `user` alone can be truthy with the account side gated shut,
+				    and gating this on it left that state with no theme control at all (#6660). */}
+				{userMenu ? null : themePicker}
 			</div>
 			<div
 				className="kp-topbar__zone kp-topbar__zone--status-signal"


### PR DESCRIPTION
The topbar's account pill and the `giriş yap` CTA were supposed to be two halves of one condition. Only the placeholder was: the pill rendered on a truthy `user` prop, and it stayed hidden on a boot/session divergence only because `LayoutContent` happened to publish `userProps: {}` — not nullish, so the `??` never fell through to the boot props. Spell that `undefined` as a tidy-up and a signed-out visitor gets a phantom pill for someone else's name beside the sign-in button.

Three changes make the coupling structural:

- `Topbar` gates the **whole** account side on `reserveSignedInSlots` — pill as well as placeholder. The prop now means "the account side is claimed", and its doc line states the caller contract: a caller that also renders a sign-in CTA must derive that CTA from this flag's negation.
- `App` derives the claim as `isSignedIn || (bootSignedIn && session.isPending)` and the CTA as its literal negation, so the two can no longer collapse in opposite directions. The CTA's behaviour is unchanged in every state — the old expression `!isSignedIn && !reserve` is equal to `!reserve` under the new definition.
- `LayoutContent` now publishes no `userProps` at all for a signed-out session instead of `{}`, which removes the empty-object convention the invariant used to lean on. The boot props land again in that state and are inert, because the gate is false there.

`bootUserProps` is not dead: it still carries the first paint, before `LayoutContent` publishes any chips — the "no giriş-yap flash" test pins that.

### Round 2: the theme control follows the same gate

Round 1's `review-code` FAIL caught a real regression. The utility-zone theme picker was still gated on `!user`, so in the exact state this PR creates — gate closed over a truthy boot `user` — neither the menu picker nor the utility picker rendered and the visitor had no theme control at all. `userMenu` now carries the gate itself (`reserveSignedInSlots && user`) and the utility picker renders whenever no menu does, so one value decides where the single theme control lives in every state. `user` alone no longer drives any branch.

Tests: two cases in `App.test.tsx` (the divergence with no `userProps` published, which now also asserts the utility picker; and the reverse direction, `__BOOT__` absent + a settled signed-in session still rendering the pill) and three in `Topbar.test.tsx` (reserve off with a `user` supplied renders no pill, and still renders the utility picker; reserve on with no user renders the picker beside the placeholder). Full client suite green: 319 tests.

Fixes #6660

## Deviations

- **Declined guidance** — **Said:** the round-1 review suggested gating the utility picker on `!reserveSignedInSlots` (or on `accountSlot == null`). **Did:** gated it on `userMenu` instead — the picker renders whenever no user menu does. **Why:** both suggested spellings drop the picker in the reserve-on-but-no-user frame (the geometry placeholder), which is a state that renders the picker today and would become a second hole of the same kind. `userMenu` is itself gated on the claim now, so the criterion's requirement — read the claim, not `!user` — is met without that cost. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** #6660 names only `App.test.tsx` for new coverage. **Did:** added `reserveSignedInSlots` to six `Topbar.test.tsx` render fixtures that pass a `user`. **Why:** the prop now gates the pill, so a fixture rendering a signed-in topbar has to say the account side is claimed; without it those tests render an empty account slot. No assertion was changed or relaxed. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** ADR 0185 says the absent-`__BOOT__` surfaces "render exactly as they do today", and #6660 asks only for the pill/CTA coupling. **Did:** on that path a signed-in session now shows the geometry placeholder for the one frame between the session settling and `LayoutContent` publishing chips; previously that frame had an empty account slot. **Why:** the claim has to widen to cover a settled signed-in session with no `__BOOT__`, or the pill gate would erase that visitor's menu entirely; one frame of skeleton is the geometry hold ADR 0179 §1 asks for rather than a regression. **Disposition:** stated here, flagged for the governance read rather than silently widening the ADR's clause.
