### PR TITLE
chore: Each read call site re-resolves currentSandboxViewer, so the çaylak opt-in costs two D1 reads per site

### DIFF
--- a/.patterns/fate-effect-worker-wiring.md
+++ b/.patterns/fate-effect-worker-wiring.md
@@ -111,6 +111,7 @@ request fiber:
 const ctx: FateRequestContext = {
 	currentUser: {user: session?.user},          // CurrentUserInfo is a structural subset — direct assignment
 	livePublisher: livePublisherFor({publish: publishToTopic, waitUntil}),
+	requestServices,                             // `requestServicesFor(...)` — the ADR 0107 §7 seam
 	// no `signal` field — abort is wired at this edge, below
 };
 const res = yield* FateInterpreter.handleRequest(raw, ctx).pipe(interruptOnAbort(raw.signal));
@@ -128,11 +129,50 @@ const res = yield* FateInterpreter.handleRequest(raw, ctx).pipe(interruptOnAbort
   `abort` listener — effect-smol's own platform idiom (`HttpEffect.toWebHandlerWith`).
 - **One ctx object per request**: the interpreter provides the pair as VALUES off this object
   to every operation. Never copy/rebuild it per resolver.
+- **A value the whole request shares goes on `requestServices`, never in a `FiberRef`.** Every
+  operation in a `/fate` envelope runs on its own child fiber at unbounded concurrency, so a
+  child's `FiberRef` set is invisible to its siblings. `requestServicesFor(...)` builds that
+  context in one place and a test pins its membership (`request-services.unit.test.ts`).
 - The publish surface rides one topic capability: the worker-init `LiveTopics.publish` with the
   route's `LiveLimits` applied + the request's `waitUntil`. `livePublisherFor` (the per-request
   `LivePublisher` service value) builds frames + topic keys directly — the one
   frame-building code path; the static `liveBusConfig` fate holds is a throwing stub
   for the build-time `"subscribe" in live` check only.
+
+### Memoizing a per-request read across resolvers
+
+When one derived value costs a database read and many resolvers ask for it — the sandbox viewer
+(`kunye/sandbox.ts`) is the case that forced this — memoize it for the request rather than
+threading it through every call site:
+
+```ts
+export const SandboxViewerMemo = Context.Reference<SandboxViewerResolution>(
+	"kunye/SandboxViewerMemo",
+	{defaultValue: () => resolveSandboxViewer},        // the unmemoized read
+);
+export const makeSandboxViewerMemo = Effect.cached(resolveSandboxViewer);  // one per request
+export const currentSandboxViewer = Effect.gen(function* () {
+	return yield* yield* SandboxViewerMemo;
+});
+```
+
+Three properties are load-bearing:
+
+- **`Context.Reference`, not `Context.Service`.** The default keeps `R` at every call site
+  exactly as it was, so tests and the long-lived `/fate/live` connection go on resolving fresh
+  instead of holding a viewer across SSE frames.
+- **The default must be stateless.** `Context.Reference` caches its default value on the key
+  (effect-smol `Context.ts`), so a stateful one is an isolate-level cache serving one request's
+  answer to another.
+- **`Effect.cached` is the single-flight part.** It guards one latch, so K sibling fibers
+  arriving together produce one read and K-1 awaits; a plain check-then-compute lets all K miss
+  (effect-smol `internal/effect.ts`, `cachedInvalidateWithTTL`). It is lazy — building the memo
+  reads nothing.
+
+Only memoize what is stable for the request. Batch operations already run with no ordering
+between a mutation and a query, so a value a same-envelope mutation can change was never
+read-your-writes to begin with; one that becomes stale for a *different* reason is not a
+candidate.
 
 ## `schema.ts` (build time — the codegen export)
 

--- a/apps/web/worker/features/fate/request-services.unit.test.ts
+++ b/apps/web/worker/features/fate/request-services.unit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * What the `/fate` route puts on `requestServices` (ADR 0107 §7).
+ *
+ * The sandbox-viewer memo (#6457) is the reason this file exists: it is a
+ * `Context.Reference`, so a route that stopped installing it would still typecheck and
+ * still serve — every read would just go back to paying its own D1 round trips. Nothing
+ * but a test can tell those two apart.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentActor, unauthenticated} from "@kampus/authz";
+import {Context, Effect} from "effect";
+import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {SandboxViewerMemo} from "../kunye/sandbox.ts";
+import {PanoFeedCache} from "../pano/feed-cache.ts";
+import {requestServicesFor} from "./route.ts";
+
+const memoStub = Effect.succeed({
+	viewerId: null,
+	canSeeSandboxed: false,
+	seesSandboxedInPlace: false,
+});
+
+const services = () =>
+	requestServicesFor({
+		actor: Context.make(CurrentActor, {actor: unauthenticated}),
+		flagOverrides: {cookieHeader: null, overridesAllowed: false},
+		feedCache: {purge: () => Effect.void},
+		sandboxViewer: memoStub,
+	});
+
+describe("the /fate route's per-request context", () => {
+	it("installs the request's sandbox-viewer memo, not the per-read default", () => {
+		assert.strictEqual(Context.get(services(), SandboxViewerMemo), memoStub);
+		assert.notStrictEqual(
+			Context.get(Context.empty(), SandboxViewerMemo),
+			memoStub,
+			"the default is the unmemoized resolution — the assertion above would be vacuous otherwise",
+		);
+	});
+
+	it("still carries the per-request services registered in layers.ts", () => {
+		const context = services();
+		assert.deepStrictEqual(Context.get(context, CurrentActor).actor, unauthenticated);
+		assert.isFalse(Context.get(context, RequestFlagOverrides).overridesAllowed);
+		assert.isFunction(Context.get(context, PanoFeedCache).purge);
+	});
+});

--- a/apps/web/worker/features/fate/route.ts
+++ b/apps/web/worker/features/fate/route.ts
@@ -7,6 +7,7 @@
  * bridge runs the request fiber without abort wiring, so a disconnected client would
  * not interrupt the resolver fibers unless the edge wires it.
  */
+import type {CurrentActor} from "@kampus/authz";
 import {FateInterpreter, type FateRequestContext} from "@kampus/fate-effect";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {Context} from "effect";
@@ -24,8 +25,39 @@ import {
 } from "../flagship/FlagsContext.ts";
 import {overridesAuthorized} from "../flagship/override-authz.ts";
 import {currentActorContext} from "../kunye/CurrentActorLive.ts";
+import {
+	makeSandboxViewerMemo,
+	SandboxViewerMemo,
+	type SandboxViewerResolution,
+} from "../kunye/sandbox.ts";
 import {PanoFeedCache, panoFeedCacheFor} from "../pano/feed-cache.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
+
+/**
+ * ONE context object for the whole request — never copied or rebuilt per resolver. It
+ * fulfills the per-request services registered in `layers.ts` (ADR 0107 §7).
+ *
+ * Exported so its membership is pinned by a test rather than by reading this file:
+ * {@link SandboxViewerMemo} is a `Context.Reference`, so dropping it from here would not
+ * break a type or a run — every read would just quietly go back to resolving per call
+ * site (#6457).
+ */
+export const requestServicesFor = (parts: {
+	readonly actor: Context.Context<CurrentActor>;
+	readonly flagOverrides: typeof RequestFlagOverrides.Service;
+	readonly feedCache: typeof PanoFeedCache.Service;
+	readonly sandboxViewer: SandboxViewerResolution;
+}): Context.Context<CurrentActor | PanoFeedCache | RequestFlagOverrides> =>
+	Context.merge(
+		parts.actor,
+		Context.merge(
+			Context.make(RequestFlagOverrides, parts.flagOverrides),
+			Context.merge(
+				Context.make(PanoFeedCache, parts.feedCache),
+				Context.make(SandboxViewerMemo, parts.sandboxViewer),
+			),
+		),
+	);
 
 export const handleFate = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
@@ -59,19 +91,17 @@ export const handleFate = Effect.gen(function* () {
 		Effect.provide(currentActorContext(session?.user)),
 	);
 
-	// ONE context object for the whole request — never copy or rebuild it per resolver.
-	// No `signal` field: interruption is wired at this edge (below). This fulfills the
-	// per-request services registered in `layers.ts` (ADR 0107 §7).
-	const requestServices = Context.merge(
-		currentActorContext(session?.user),
-		Context.merge(
-			Context.make(RequestFlagOverrides, {
-				cookieHeader: raw.headers.get("cookie"),
-				overridesAllowed,
-			}),
-			Context.make(PanoFeedCache, feedCache),
-		),
-	);
+	// The sandbox viewer costs up to three reads and is asked for at 26 resolver sites, so
+	// it resolves once per request instead of once per site (#6457). Lazy: nothing is read
+	// until the first site asks, and a request touching none reads nothing.
+	const sandboxViewer = yield* makeSandboxViewerMemo;
+
+	const requestServices = requestServicesFor({
+		actor: currentActorContext(session?.user),
+		flagOverrides: {cookieHeader: raw.headers.get("cookie"), overridesAllowed},
+		feedCache,
+		sandboxViewer,
+	});
 	const ctx: FateRequestContext = {
 		currentUser: {user: session?.user},
 		livePublisher: livePublisherFor({publish: publishToTopic, waitUntil}),

--- a/apps/web/worker/features/kunye/sandbox-viewer-memo.unit.test.ts
+++ b/apps/web/worker/features/kunye/sandbox-viewer-memo.unit.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The per-request sandbox-viewer memo (#6457). Every assertion here is a call count, not
+ * a value: the viewer a memoized read returns is the one the unmemoized read already
+ * returned (`sandbox-viewer.unit.test.ts` pins that), so only the number of D1 round
+ * trips can tell the memo apart from what it replaced.
+ *
+ * The stubs are `yieldNow`-punctuated, so the concurrent case genuinely has two fibers
+ * in the resolution at once — with synchronous stubs the first would run to completion
+ * before the second started, and a broken memo would pass.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {AgentAuthority, CurrentActor, human, RelationStore} from "@kampus/authz";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Context, Effect, Layer} from "effect";
+import {CaylakVisibility} from "../caylak-visibility/CaylakVisibility.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {Kunye} from "./Kunye.ts";
+import {currentSandboxViewer, makeSandboxViewerMemo, SandboxViewerMemo} from "./sandbox.ts";
+
+const VIEWER = {id: "yzr", email: "kaan@kamp.us", name: "kaan", image: null};
+
+interface Counts {
+	moderatorProbe: number;
+	tierOf: number;
+	preference: number;
+}
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "sandbox-viewer-memo-test",
+	id: "sandbox-viewer-memo-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+/** Every service the resolution reads, each counting its own invocations. */
+const countingLayer = (counts: Counts, options: {readonly flagOn: boolean}) =>
+	Layer.mergeAll(
+		Layer.succeed(CurrentUser, {user: VIEWER}),
+		Layer.succeed(CurrentActor, {actor: human(VIEWER.id)}),
+		Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)}),
+		Layer.succeed(RelationStore, {
+			has: () =>
+				Effect.gen(function* () {
+					counts.moderatorProbe += 1;
+					yield* Effect.yieldNow;
+					return false;
+				}),
+			hasSubjects: () => Effect.die("RelationStore.hasSubjects not exercised"),
+			subjectsOf: () => Effect.die("RelationStore.subjectsOf not exercised"),
+		}),
+		Layer.succeed(Flags, {
+			getBoolean: () => Effect.succeed(options.flagOn),
+			getString: () => Effect.die("getString not exercised"),
+			getNumber: () => Effect.die("getNumber not exercised"),
+			getObject: () => Effect.die("getObject not exercised"),
+		} as typeof Flags.Service),
+		Layer.succeed(RequestFlagOverrides, {cookieHeader: null, overridesAllowed: false}),
+		Layer.succeed(Kunye, {
+			tierOf: () =>
+				Effect.gen(function* () {
+					counts.tierOf += 1;
+					yield* Effect.yieldNow;
+					return "yazar" as const;
+				}),
+			karmaOf: () => Effect.die("Kunye.karmaOf not exercised"),
+			rootOf: () => Effect.die("Kunye.rootOf not exercised"),
+		}),
+		Layer.succeed(CaylakVisibility, {
+			read: () =>
+				Effect.gen(function* () {
+					counts.preference += 1;
+					yield* Effect.yieldNow;
+					return {optedIn: true, setAt: new Date("2026-08-19T00:00:00.000Z")};
+				}),
+			set: () => Effect.die("CaylakVisibility.set not exercised"),
+		}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+type StubbedServices = Layer.Success<ReturnType<typeof countingLayer>>;
+
+/**
+ * One request: build the memo the way `fate/route.ts` does, install it on a context the
+ * way `requestServices` does, and run `body` under it.
+ */
+const underOneRequest = <A>(
+	counts: Counts,
+	body: Effect.Effect<A, never, StubbedServices>,
+	options: {readonly flagOn: boolean} = {flagOn: true},
+): Effect.Effect<A> =>
+	Effect.gen(function* () {
+		const memo = yield* makeSandboxViewerMemo;
+		return yield* body.pipe(Effect.provideContext(Context.make(SandboxViewerMemo, memo)));
+	}).pipe(Effect.provide(countingLayer(counts, options)));
+
+const freshCounts = (): Counts => ({moderatorProbe: 0, tierOf: 0, preference: 0});
+
+describe("the per-request sandbox-viewer memo (#6457)", () => {
+	it.effect("two call sites in one request resolve the viewer once", () => {
+		const counts = freshCounts();
+		return Effect.gen(function* () {
+			const [first, second] = yield* underOneRequest(
+				counts,
+				Effect.gen(function* () {
+					const a = yield* currentSandboxViewer;
+					const b = yield* currentSandboxViewer;
+					return [a, b] as const;
+				}),
+			);
+			assert.deepStrictEqual(counts, {moderatorProbe: 1, tierOf: 1, preference: 1});
+			assert.deepStrictEqual(first, {
+				viewerId: VIEWER.id,
+				canSeeSandboxed: false,
+				seesSandboxedInPlace: true,
+			} satisfies SandboxViewer);
+			assert.deepStrictEqual(second, first);
+		});
+	});
+
+	it.effect("concurrent call sites collapse to one resolution — the memo is single-flight", () => {
+		const counts = freshCounts();
+		return Effect.gen(function* () {
+			const viewers = yield* underOneRequest(
+				counts,
+				Effect.all([currentSandboxViewer, currentSandboxViewer, currentSandboxViewer], {
+					concurrency: "unbounded",
+				}),
+			);
+			assert.deepStrictEqual(counts, {moderatorProbe: 1, tierOf: 1, preference: 1});
+			assert.deepStrictEqual(viewers[1], viewers[0]);
+			assert.deepStrictEqual(viewers[2], viewers[0]);
+		});
+	});
+
+	it.effect(
+		"building the memo reads nothing — a request touching no call site pays nothing",
+		() => {
+			const counts = freshCounts();
+			return Effect.gen(function* () {
+				yield* underOneRequest(counts, Effect.void);
+				assert.deepStrictEqual(counts, {moderatorProbe: 0, tierOf: 0, preference: 0});
+			});
+		},
+	);
+
+	it.effect("the memo does not defeat the flag short-circuit", () => {
+		const counts = freshCounts();
+		return Effect.gen(function* () {
+			const viewer = yield* underOneRequest(counts, currentSandboxViewer, {flagOn: false});
+			assert.isFalse(viewer.seesSandboxedInPlace);
+			assert.deepStrictEqual(counts, {moderatorProbe: 1, tierOf: 0, preference: 0});
+		});
+	});
+
+	// The default is what a caller outside `POST /fate` gets — a unit test, or the
+	// long-lived `/fate/live` connection, where memoizing a viewer across frames would
+	// serve a stale one. It must resolve fresh, which is exactly this count.
+	it.effect("with no memo installed, every call site resolves for itself", () => {
+		const counts = freshCounts();
+		return Effect.gen(function* () {
+			yield* currentSandboxViewer;
+			yield* currentSandboxViewer;
+			assert.deepStrictEqual(counts, {moderatorProbe: 2, tierOf: 2, preference: 2});
+		}).pipe(Effect.provide(countingLayer(counts, {flagOn: true})));
+	});
+});

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -9,8 +9,8 @@
  *     yazar ⇒ live).
  *   - {@link currentSandboxViewer} — the read-time viewer: the signed-in id, a
  *     non-throwing moderator probe of `Moderate.over(platform)`, and the flag-gated
- *     in-place opt-in (#6423), resolved once per read and handed to the
- *     `SandboxVisibility` predicates.
+ *     in-place opt-in (#6423), handed to the `SandboxVisibility` predicates. Resolved
+ *     once per `POST /fate` request through {@link SandboxViewerMemo} (#6457).
  *   - {@link moderatorSandboxViewer} — the same viewer for an already-`Moderate`-gated
  *     read, taken off the discharged grant instead of re-probing for it (#6472).
  *   - {@link PublishDecision} / {@link decidePublish} / {@link alwaysLive} — the
@@ -26,7 +26,7 @@
  */
 
 import {CurrentUser} from "@kampus/fate-effect";
-import {Brand, Effect} from "effect";
+import {Brand, Context, Effect} from "effect";
 import {CaylakVisibility} from "../caylak-visibility/CaylakVisibility.ts";
 import {caylakVisibilityOn} from "../caylak-visibility/gate.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
@@ -70,7 +70,7 @@ const inPlaceVisibility = Effect.fn("kunye.inPlaceVisibility")(function* (viewer
  * `Denied` otherwise; we collapse that to a boolean so a non-moderator reads as
  * `canSeeSandboxed: false` rather than erroring the read.
  */
-export const currentSandboxViewer = Effect.gen(function* () {
+const resolveSandboxViewer = Effect.gen(function* () {
 	const {user} = yield* CurrentUser;
 	const viewerId = user?.id ?? null;
 	// A non-throwing probe of the moderation gate: `requireModeration` discharges
@@ -81,6 +81,31 @@ export const currentSandboxViewer = Effect.gen(function* () {
 	);
 	const seesSandboxedInPlace = yield* inPlaceVisibility(viewerId);
 	return {viewerId, canSeeSandboxed, seesSandboxedInPlace} satisfies SandboxViewer;
+});
+
+export type SandboxViewerResolution = typeof resolveSandboxViewer;
+
+/**
+ * Where a request installs its one resolution, so the 26 call sites cost one probe + one
+ * tier read + one opt-in read between them instead of three each (#6457). Shape and its
+ * three load-bearing properties: `.patterns/fate-effect-worker-wiring.md`.
+ *
+ * The default MUST stay stateless — `Context.Reference` caches it on the key (effect-smol
+ * `Context.ts`), so state here would be an isolate-level cache handing one viewer's tier
+ * to another request.
+ */
+export const SandboxViewerMemo = Context.Reference<SandboxViewerResolution>(
+	"kunye/SandboxViewerMemo",
+	{defaultValue: () => resolveSandboxViewer},
+);
+
+/** One request's memo, for the `/fate` route edge to put on `requestServices`. */
+export const makeSandboxViewerMemo: Effect.Effect<SandboxViewerResolution> =
+	Effect.cached(resolveSandboxViewer);
+
+/** @see {@link resolveSandboxViewer} — this reads it through the request's {@link SandboxViewerMemo}. */
+export const currentSandboxViewer: SandboxViewerResolution = Effect.gen(function* () {
+	return yield* yield* SandboxViewerMemo;
 });
 
 /**


### PR DESCRIPTION
Fixes #6457

`currentSandboxViewer` resolved independently at each of its 26 call sites. For a signed-in
viewer with `phoenix-caylak-visibility` on, each resolution costs a `RelationStore.has`
(the moderator probe), a `Kunye.tierOf` (a D1 read) and a `CaylakVisibility.read` — so one
`POST /fate` batch touching several sites paid all three several times over.

It now resolves once per request. The route builds the memo and puts it on
`requestServices`; the call sites are byte-for-byte unchanged.

Three things about the shape, all pinned by tests:

- **`Context.Reference`, not `Context.Service`.** Its default is the unmemoized read, so `R`
  at all 26 sites is exactly what it was — no existing test needed editing, and a caller
  outside `POST /fate` (a unit test, the long-lived `/fate/live` connection) keeps resolving
  fresh instead of holding one viewer across SSE frames. The default is a stateless
  module-level effect, because `Context.Reference` caches its default on the key.
- **Single-flight.** `Effect.cached` guards one latch, so the K sibling fibers a batch runs at
  unbounded concurrency produce one resolution and K-1 awaits. `sandbox-viewer-memo.unit.test.ts`
  proves it with `yieldNow`-punctuated counting stubs under `Effect.all(…, {concurrency:
  "unbounded"})`; swapping `Effect.cached` for `Effect.succeed` fails it.
- **Lazy.** Building the memo reads nothing, so a request touching no call site pays nothing.

Behavior is unchanged. Within-request staleness was already unguaranteed — batch operations
run concurrently with no ordering between a mutation and a query in the same envelope — so a
same-batch `caylakVisibility.optIn` could already be observed either way.

Reviewer's first stop: `SandboxViewerMemo` in `apps/web/worker/features/kunye/sandbox.ts`,
then the memo's install site in `apps/web/worker/features/fate/route.ts`.

## Deviations

- **Out-of-scope change** — **Said:** #6457 asks for the memo and its unit tests. **Did:**
  also extracted `requestServicesFor` out of `handleFate` and added
  `apps/web/worker/features/fate/request-services.unit.test.ts`. **Why:** a `Context.Reference`
  degrades silently — a route that stopped installing the memo would still typecheck and
  still serve, just paying per call site again. Nothing but a test can tell those apart, and
  `handleFate` has no test today. **Disposition:** kept; the extraction is a rename, the
  context's membership is identical.
- **Out-of-scope change** — **Said:** nothing about docs. **Did:** extended
  `.patterns/fate-effect-worker-wiring.md` with the per-request memo shape, and fixed its
  `ctx` snippet, which predated the `requestServices` field. **Why:** CLAUDE.md requires a
  load-bearing pattern to be documented rather than left to the next reader to rediscover.
  **Disposition:** stated here.
