### PR TITLE
fix: run-evidence parks as action_required on release-please branches, stopping every release cut at ship evidence

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -195,15 +195,21 @@ jobs:
       # the Release PR its checks. Cancellation is the one case that still skips, because a
       # cancelled run's dispatches would race the run that replaces it.
       #
-      # The `for entry in …` list below is workflow file → the required check-run name that
-      # file produces, and it is the drift surface: the required set lives in the repo's
+      # The `for entry in …` list below is workflow file → the check-run name that file
+      # produces, and it is the drift surface: the required set lives in the repo's
       # `main protection` ruleset, not here, so a check added there but not here would never run
       # on the Release PR. Two things make that loud rather than silent — the trigger
       # assertion (a mapped file that lost its `workflow_dispatch:` reds this run), and the
       # dispatch-on-failure stance (an unreadable check-run probe dispatches rather than skips).
       # `ci.yml` carries TWO required checks — `ci-required` and `validate skill frontmatter`
       # — from the same run, so probing the first covers both; one dispatch, one entry.
-      - name: Kick the standing Release PR's required checks at its current head
+      #
+      # `run-evidence.yml` is in the map though it gates nothing (#6759). It is the evidence
+      # producer `ship` reads at step 5, and a parked producer publishes no artifact, so `ship`
+      # refuses the release cut while every dashboard reads green — the same stale-green this
+      # step exists to end, arriving one gate later. A parked run reports no check run at all,
+      # which is exactly what makes the probe below dispatch rather than skip.
+      - name: Kick the standing Release PR's checks and evidence producer at its current head
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -233,12 +239,12 @@ jobs:
           # A literal list and not a here-doc: a here-doc's terminator has to sit at column 0,
           # which no indented step body can give it, and a `printf | while` puts the loop in
           # a subshell where the `exit 1`s below would abort nothing.
-          for entry in "ci.yml=ci-required" "leak-guard.yml=scan changed files for leaks"; do
+          for entry in "ci.yml=ci-required" "leak-guard.yml=scan changed files for leaks" "run-evidence.yml=produce run-evidence bundle"; do
             file="${entry%%=*}"
             check="${entry#*=}"
 
             if ! grep -qE '^[[:space:]]*workflow_dispatch:' ".github/workflows/$file"; then
-              echo "::error::.github/workflows/$file carries no workflow_dispatch trigger, so the required check '$check' can never run on the Release PR."
+              echo "::error::.github/workflows/$file carries no workflow_dispatch trigger, so '$check' can never run on the Release PR."
               exit 1
             fi
 

--- a/.github/workflows/run-evidence.yml
+++ b/.github/workflows/run-evidence.yml
@@ -9,9 +9,10 @@
 # Load-bearing invariant (ADR 0054 §1 / 0056 fetch contract): the manifest's `commit`
 # MUST equal the head SHA the gate keys on. On `pull_request`, `github.sha` is the
 # synthetic merge commit, NOT the head — so the adapter is stamped with the head via the
-# job-level HEAD_SHA (`pull_request.head.sha`, or `merge_group.head_sha` on the merge
-# queue's batch ref — ADR 0132). Getting this wrong silently unbinds the evidence from the
-# commit the gate keys on.
+# job-level HEAD_SHA (`pull_request.head.sha`, `merge_group.head_sha` on the merge queue's
+# batch ref — ADR 0132 — and `github.sha` on `workflow_dispatch`, where it is the dispatched
+# ref's own head). Getting this wrong silently unbinds the evidence from the commit the gate
+# keys on.
 #
 # crabbox output contract (verified locally against v0.31.0, spike #235): `crabbox run
 # --timing-json` prints its machine-readable run-summary JSON as the LAST line of its
@@ -32,6 +33,15 @@ on:
   # every queued merge hangs (ADR 0132). On `merge_group` the head is the batch head
   # (`merge_group.head_sha`), the exact commit that merges — resolved into HEAD_SHA below.
   merge_group:
+  # The standing Release PR's branch is pushed by release-please with `secrets.GITHUB_TOKEN`, and
+  # GitHub parks every run raised on it at `action_required` until a human approves by hand — so
+  # this producer publishes nothing and `ship evidence` reads `absent` on every release cut
+  # (#6759). A `workflow_dispatch` run is never parked, so release-please.yml re-dispatches this
+  # workflow at the branch head, the same #5718 shape `leak-guard.yml` already carries. On a
+  # dispatch both event heads above are empty and `github.sha` IS the dispatched ref's head — a
+  # real commit, not the synthetic merge ref it is on `pull_request` — which is what HEAD_SHA
+  # resolves to below.
+  workflow_dispatch:
 
 # One producer run per head ref; cancel superseded pushes so the latest head SHA wins.
 concurrency:
@@ -48,11 +58,28 @@ jobs:
     permissions:
       contents: read
     # HEAD_SHA is the commit the bundle binds to — the PR head on `pull_request`, the
-    # batch head on `merge_group` (`pull_request.head.sha` is empty on merge_group). Both
-    # are the exact ref that merges, the binding key the gate consumers assert (ADR 0132).
+    # batch head on `merge_group` (`pull_request.head.sha` is empty on merge_group), the
+    # dispatched ref's head on `workflow_dispatch` (both event heads are empty there). Each is
+    # the exact ref that merges, the binding key the gate consumers assert (ADR 0132).
+    #
+    # The dispatch arm leads and tests `event_name` rather than trailing the `||` chain: falling
+    # through to `github.sha` would bind a `pull_request` run to the synthetic merge ref the
+    # moment `pull_request.head.sha` came back empty, publishing a bundle at a commit no gate
+    # keys on — worse than publishing none.
     env:
-      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
     steps:
+      # An empty HEAD_SHA would check out the default branch and stamp the bundle off a commit
+      # this run never resolved, so it is refused before the checkout rather than after.
+      - name: Assert the binding head resolved
+        run: |
+          set -uo pipefail
+          if [ -z "${HEAD_SHA:-}" ]; then
+            echo "::error::HEAD_SHA is empty on a '${{ github.event_name }}' event — refusing to build a bundle bound to no commit."
+            exit 1
+          fi
+          echo "binding run-evidence to $HEAD_SHA"
+
       # Check out the head (not the merge ref) so the in-repo `git rev-parse HEAD`
       # and the explicit head-sha stamp agree, and crabbox syncs the head tree.
       - uses: actions/checkout@v4.2.2

--- a/packages/fabrika-cli/src/ship/evidence-verb.ts
+++ b/packages/fabrika-cli/src/ship/evidence-verb.ts
@@ -26,6 +26,7 @@ import {
 	listRunArtifacts,
 	listRunsAtHead,
 	makeScratchDirectory,
+	type WorkflowRun,
 	workflowExists,
 } from "./github.ts";
 import {
@@ -74,6 +75,29 @@ export const withinFreshnessWindow = (completedAt: string | null, nowMs: number)
 	const finished = Date.parse(completedAt);
 	if (Number.isNaN(finished)) return false;
 	return nowMs - finished <= FRESH_COMPLETION_SECONDS * 1000;
+};
+
+/**
+ * GitHub's conclusion for a run it created but will not start without a human approval. A run
+ * parked this way reports `status: "completed"`, so it is not `pending`, and it publishes nothing.
+ */
+const PARKED_CONCLUSION = "action_required";
+
+/**
+ * Pick the producer run when a head carries several.
+ *
+ * A Release PR's head carries two after #6759: the `pull_request` run GitHub parks on the bot's
+ * branch, and the dispatched one that actually runs. A first match decides that on GitHub's
+ * undocumented return order for `runs?head_sha=`, and losing the tie reads `absent` at a head whose
+ * bundle exists — the exact symptom #6759 kills. So a parked run never wins over one that is not
+ * parked. It is still returned when it is all there is, so the `lookup` line names the run behind
+ * the `absent` rather than nothing.
+ */
+export const selectProducerRun = (runs: ReadonlyArray<WorkflowRun>): WorkflowRun | undefined => {
+	const candidates = runs.filter((candidate) => candidate.name.includes(ARTIFACT_NAME));
+	return (
+		candidates.find((candidate) => candidate.conclusion !== PARKED_CONCLUSION) ?? candidates[0]
+	);
 };
 
 export interface ManifestCheck {
@@ -204,8 +228,13 @@ export const runEvidence = (
 				diagnostics,
 			);
 		}
-		const run = listed.value.runs.find((candidate) => candidate.name.includes(ARTIFACT_NAME));
+		const run = selectProducerRun(listed.value.runs);
 		if (run === undefined) return emit("absent", null, null, null, []);
+		if (run.conclusion === PARKED_CONCLUSION) {
+			diagnostics.push(
+				`${VERB}: every ${ARTIFACT_NAME} run at ${bound} is parked at ${PARKED_CONCLUSION} — GitHub created run ${run.id} but never started it, so nothing was published.`,
+			);
+		}
 		if (run.status !== "completed") return emit("pending", run.id, null, run.status, []);
 
 		const artifacts = yield* listRunArtifacts(repo, run.id);

--- a/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
@@ -28,20 +28,35 @@ const ZIP = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/actions\/artifacts\/\
 const scratch = (): string => mkdtempSync(join(tmpdir(), "fabrika-test-"));
 
 const runsAt = (
-	...rows: ReadonlyArray<{id: number; name: string; status: string; completedAt?: string | null}>
+	...rows: ReadonlyArray<{
+		id: number;
+		name: string;
+		status: string;
+		conclusion?: string;
+		completedAt?: string | null;
+	}>
 ): HttpReply => ({
 	status: 200,
 	body: JSON.stringify({
 		total_count: rows.length,
-		workflow_runs: rows.map(({completedAt, ...row}) => ({
+		workflow_runs: rows.map(({completedAt, conclusion, ...row}) => ({
 			...row,
 			workflow_id: row.id,
 			check_suite_id: row.id,
-			conclusion: "success",
+			conclusion: conclusion ?? "success",
 			completed_at: completedAt === undefined ? new Date().toISOString() : completedAt,
 		})),
 	}),
 });
+
+/** The shape GitHub reports for a run parked on a bot-authored branch: completed, never started. */
+const PARKED_RUN = {
+	id: 9182730001,
+	name: "run-evidence",
+	status: "completed",
+	conclusion: "action_required",
+	completedAt: "2026-08-08T00:00:00Z",
+} as const;
 
 const artifactsFor = (
 	...rows: ReadonlyArray<{id: number; name: string; expired?: boolean}>
@@ -154,6 +169,34 @@ describe("runEvidence", () => {
 				"",
 			].join("\n"),
 		);
+	});
+
+	// #6759: a Release PR's head carries both the parked `pull_request` run and the dispatched one,
+	// and GitHub's return order for `runs?head_sha=` is undocumented. Taking the first match would
+	// read `absent` at a head whose bundle exists.
+	it("picks the run that ran over a parked one, whatever order GitHub lists them in", async () => {
+		const out = await run(
+			[...readsUpToArtifact(), [UNZIP, okOut(producerManifest(HEAD))]],
+			[
+				WORKFLOW_PRESENT,
+				[RUNS, runsAt(PARKED_RUN, {id: 9182736450, name: "run-evidence", status: "completed"})],
+				[ARTIFACTS, artifactsFor({id: 2211334455, name: "run-evidence"})],
+				[ZIP, zipBody()],
+			],
+		);
+		expect(out.stdout).toContain(`evidence\tpresent\t${HEAD}`);
+		expect(out.stdout).toContain("lookup\trun:9182736450\tartifact:2211334455");
+	});
+
+	it("names the parking when a parked run is the only one at the head", async () => {
+		const out = await run(HEAD_READS, [
+			WORKFLOW_PRESENT,
+			[RUNS, runsAt(PARKED_RUN)],
+			[ARTIFACTS, artifactsFor()],
+		]);
+		expect(out.stdout.split("\n")[0]).toBe(`evidence\tabsent\t${HEAD}`);
+		expect(out.stdout).toContain(`lookup\trun:${PARKED_RUN.id}`);
+		expect(out.stderr.some((line) => line.includes("parked at action_required"))).toBe(true);
 	});
 
 	// ADR 0308: `checks` is an evidence-array, so the manifest's rows collapse to a status tally. The


### PR DESCRIPTION
Fixes #6759

GitHub parks every workflow run raised on `release-please--branches--main` at
`action_required`, because release-please pushes that branch with `secrets.GITHUB_TOKEN`. The
run-evidence producer therefore publishes no artifact, `ship`'s step 5 reads the bundle `absent`,
and the release cannot merge until a human approves the parked run by hand. Nothing before step 5
shows it: run-evidence is not a required check, so `ship checks` reads green the whole time.

This takes the ticket's route 1 — make run-evidence run on the release branch — and extends the
existing kick mechanism rather than exempting release diffs from the ADR 0054 evidence rule.

**`.github/workflows/run-evidence.yml`** gains a `workflow_dispatch:` trigger, and `HEAD_SHA` now
resolves the dispatched ref's own head:

```
HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
```

The dispatch arm leads and tests `event_name` instead of trailing the `||` chain on purpose. A
trailing `|| github.sha` would bind a `pull_request` run to the synthetic merge ref the moment
`pull_request.head.sha` came back empty, publishing a bundle at a commit no gate keys on — worse
than publishing none. On `workflow_dispatch` at a branch ref, `github.sha` is that branch's head
commit, not a merge ref. A new first step refuses an empty `HEAD_SHA` before the checkout, since an
empty `ref:` silently falls back to the default branch. The existing `STAMPED != HEAD_SHA`
assertion is untouched.

**`.github/workflows/release-please.yml`** adds `run-evidence.yml=produce run-evidence bundle` to
the kick step's map. Two facts checked against the Actions API rather than assumed:

- The check-run name is `produce run-evidence bundle` — read off head
  `d2662a0c3da4faece89b36e42ccc7495ced36a3a`, where the run concluded `success`.
- A parked run reports **no** check run at all. At the currently-parked release head
  `b687a0d959e98048a6c06b067e45ef707b47ef1c` the check-run list carries `ci-required`,
  `scan changed files for leaks` and the rest, and nothing named for run-evidence. So the kick
  step's existing "already reported at this head" probe correctly dispatches on a parked head and
  correctly suppresses a duplicate once a run has reported.

No PR class loses its evidence obligation; route 2 is not taken.

While reading the consumer I filed #6800 — `ship evidence` takes the first run-evidence run at a
head with no tie-break, so once a parked run and a dispatched run share a head the answer rests on
GitHub's return order. Newest-first is what makes it work today; that ordering is an observation,
not a documented contract.

## Deviations

- **Out-of-scope change** — **Said:** #6759 AC3 names only the map entry in the kick step.
  **Did:** also renamed that step from "…required checks at its current head" to "…checks and
  evidence producer at its current head", loosened its comment block, and dropped the word
  "required" from the missing-trigger error message. **Why:** run-evidence is deliberately not a
  required check, so leaving the step and its error saying "required" would have made the map's own
  documentation false at the line the map lives on. **Disposition:** stated here; nothing machine-reads
  the step name (grepped, the only occurrence is the workflow itself).
- **Scope narrowing** — **Said:** AC5 asks that a dispatched run publish a bundle whose
  `manifest.json` `commit` equals the Release PR head, so `fabrika ship evidence` reads `present`.
  **Did:** built it by construction and verified every input to it against the Actions API, but did
  not observe an actual dispatched run. **Why:** `gh workflow run` requires the `workflow_dispatch:`
  trigger to exist on the default branch, so no dispatch of this workflow is possible until this PR
  merges. **Disposition:** stated here — the first release cut after merge is where it is observable,
  and #6800 is the one known way that observation could still read `absent`.
