### PR TITLE
feat: The governance-verdict-at-head check reads FAILURE while a lane is simply not reviewed yet

### DIFF
--- a/.decisions/0318-the-governance-floor-reports-through-a-check-run.md
+++ b/.decisions/0318-the-governance-floor-reports-through-a-check-run.md
@@ -43,7 +43,11 @@ The verb publishes a check-run; the job relays what it did.
 | `absent` | left `in_progress` — **pending** | exit 0 |
 | `stale`, `fail` | `completed` / `failure` | exit 0 |
 | UNKNOWN (`ship floor` 7 / 11 / 13) | `completed` / `failure` | exit 0 |
-| the check-run could not be written | — | non-zero |
+| the check-run could not be written, or the head's check-runs could not be read | — | non-zero |
+
+The executable spec for those rows — the stdout shapes, the exit codes and their messages — is
+`ship/contract.md`'s **The check-run mode** heading. This table is what the decision is, not a second
+home for the mechanics.
 
 Three things this does not change, each load-bearing:
 
@@ -51,18 +55,26 @@ Three things this does not change, each load-bearing:
   governance verdict is absent. Only the human-facing report moved.
 - **Every other caller of `ship floor` keeps its exit semantics.** The check-run lives behind
   `--publish-check`; without the flag the verb is byte-for-byte what it was, and no exit code was
-  repurposed. The mode's own two refusals (`8` write failed, `9` echo mismatch) are the `ship`
-  group's existing meanings.
+  repurposed. The mode's own refusals (`8` write failed, `9` echo mismatch, `11` the head's
+  check-runs could not be read) are the `ship` group's existing meanings.
 - **UNKNOWN concludes `failure`, never pending.** A floor nobody could read is not a floor still
   being read (ADR [0092](0092-gates-fail-closed-on-zero-scope.md)).
 
 ## Why pending, and not neutral
 
-GitHub treats a `neutral` required check as **passing**. `neutral` would therefore un-bind the floor
-at the moment it is most needed — the window in which no verdict exists. A check-run that has not
-concluded is not a passing one: branch protection holds the PR, the merge queue will not take it, and
-`ship checks` rolls a pending gating run up as `pending` rather than `green`. Pending is the only
-non-red state that reads as waiting to a human without telling the platform the gate is satisfied.
+GitHub treats a `neutral` required check as **passing**: "Required status checks must have a
+`successful`, `skipped`, or `neutral` status before collaborators can make changes to a protected
+branch" ([About protected branches → Require status checks before
+merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)).
+`neutral` would therefore un-bind the floor at the moment it is most needed — the window in which no
+verdict exists.
+
+A check-run that has not concluded is on neither list, so it is not a passing one. What that buys
+today and what it buys after the ruleset flip are different things, and the difference is the next
+section: `ship checks` already rolls a pending gating run up as `pending` rather than `green`, which
+is what withholds the merge now; once the check is **required**, branch protection and the merge
+queue withhold it too. Pending is the only non-red state that reads as waiting to a human without
+telling the platform the gate is satisfied.
 
 ## What it costs
 

--- a/.decisions/0318-the-governance-floor-reports-through-a-check-run.md
+++ b/.decisions/0318-the-governance-floor-reports-through-a-check-run.md
@@ -1,0 +1,86 @@
+---
+id: 0318
+title: The governance floor reports through a check-run, pending while nobody has judged the head
+status: accepted
+date: 2026-08-20
+tags: [fabrika, ship, governance, ci, pipeline]
+---
+
+# 0318 — The governance floor reports through a check-run, pending while nobody has judged the head
+
+**What this decides:** `fabrika ship floor --publish-check` writes the floor's answer to a check-run
+named `governance floor at head` instead of seating it on the job's exit code. `absent` — no
+governance verdict posted at this head yet — leaves that check-run `in_progress`; `stale`, `fail` and
+UNKNOWN conclude `failure`; `satisfied` and `n/a` conclude `success`. The job then exits 0 whenever
+the verb published an answer. Founder ruling on
+[#6161](https://github.com/kamp-us/phoenix/issues/6161), 2026-08-20:
+[the comment](https://github.com/kamp-us/phoenix/issues/6161#issuecomment-5364681459).
+
+## Context
+
+A GitHub Actions job's conclusion is `success`, `failure`, `cancelled` or `skipped`. Nothing else is
+representable. So while the floor was seated on `ship floor`'s exit code (ADR
+[0228](0228-scripts-relay-never-derive.md)'s relay shape, landed for #5408), one red carried two
+facts that route opposite ways:
+
+- **not yet** — the PR touches a governance root and nobody has posted a verdict at this head. Every
+  governance-root PR passes through this state, by construction: `governance-floor.yml` fires on
+  `pull_request`, so it always runs before the verdict a human or an agent has to read the diff to
+  write (#5585).
+- **wrong** — a verdict exists and it is FAIL, or it is bound to another head.
+
+On 2026-08-18 five of the six red open PRs (#6159, #6158, #6140, #6122, #6031) were red on only this
+check while healthy mid-pipeline. A red that usually means "not yet" is a red people stop reading,
+and the reds that mean something go with it.
+
+## Decision
+
+The verb publishes a check-run; the job relays what it did.
+
+| Floor at the head | Check-run | Job |
+|---|---|---|
+| `satisfied`, `n/a` | `completed` / `success` | exit 0 |
+| `absent` | left `in_progress` — **pending** | exit 0 |
+| `stale`, `fail` | `completed` / `failure` | exit 0 |
+| UNKNOWN (`ship floor` 7 / 11 / 13) | `completed` / `failure` | exit 0 |
+| the check-run could not be written | — | non-zero |
+
+Three things this does not change, each load-bearing:
+
+- **`ship gate` is untouched and stays the single merge authority.** It still refuses while a
+  governance verdict is absent. Only the human-facing report moved.
+- **Every other caller of `ship floor` keeps its exit semantics.** The check-run lives behind
+  `--publish-check`; without the flag the verb is byte-for-byte what it was, and no exit code was
+  repurposed. The mode's own two refusals (`8` write failed, `9` echo mismatch) are the `ship`
+  group's existing meanings.
+- **UNKNOWN concludes `failure`, never pending.** A floor nobody could read is not a floor still
+  being read (ADR [0092](0092-gates-fail-closed-on-zero-scope.md)).
+
+## Why pending, and not neutral
+
+GitHub treats a `neutral` required check as **passing**. `neutral` would therefore un-bind the floor
+at the moment it is most needed — the window in which no verdict exists. A check-run that has not
+concluded is not a passing one: branch protection holds the PR, the merge queue will not take it, and
+`ship checks` rolls a pending gating run up as `pending` rather than `green`. Pending is the only
+non-red state that reads as waiting to a human without telling the platform the gate is satisfied.
+
+## What it costs
+
+`governance post` re-fires the floor run at the head it just posted to, and that re-fire is what
+turns a pending check-run green — no new workflow trigger. Two consequences follow from the job now
+succeeding whenever it published:
+
+- The re-fire decision moved off the job's conclusion onto the check-run's state. A green job beside a
+  pending check-run is the ordinary "no verdict yet" shape, and the old rule would have read it as
+  nothing to clear.
+- It requests a **whole-run** re-run rather than `rerun-failed-jobs`, which GitHub refuses on a run
+  with no failed job.
+
+The floor's own state is written by the verb rather than derived by the job, so the job needs
+`checks: write`. It reads nothing new.
+
+## Status of the ruleset
+
+Making `governance floor at head` a **required** status check on `main` is a repository-ruleset
+change, which is the founder's. Until that flip the check is visible but not required, exactly as the
+job's context was before this — no weaker, and recorded here rather than glossed.

--- a/.github/workflows/governance-floor.yml
+++ b/.github/workflows/governance-floor.yml
@@ -9,10 +9,17 @@ name: governance-floor
 # (#5293, #5333) merged with no governance verdict after the floor was live. A control that never
 # withholds a merge is worse than none, because it looks present.
 #
-# `fabrika ship floor` is the decision; this job only relays its exit code (ADR 0228). Nothing here
-# decides which paths are governance-bearing, which verdict is in force, or whether an author may
-# author one — the verb reads the PR's changed files and resolves the verdict through `ship gate`
-# itself, which stays the single merge authority.
+# `fabrika ship floor` is the decision; this job only relays it (ADR 0228). Nothing here decides
+# which paths are governance-bearing, which verdict is in force, or whether an author may author one
+# — the verb reads the PR's changed files and resolves the verdict through `ship gate` itself, which
+# stays the single merge authority.
+#
+# Since #6161 the verb publishes that decision as a check-run rather than seating it on this job's
+# conclusion. A job conclusion is success/failure/cancelled/skipped and nothing else, so "no verdict
+# posted at this head yet" — the state every governance-root PR passes through — showed the same red
+# as a verdict that is FAIL or bound to another head, and a red meaning "not yet" is a red people
+# stop reading. A check-run can stay `in_progress`, so that one state reads as waiting. The verb
+# writes it; this job still decides nothing (ADR 0318).
 #
 # It runs on EVERY pull request with no `paths:` filter on purpose. A YAML path filter is a second
 # copy of `GOVERNANCE_ROOTS` that nothing reds when it drifts (#4604); the verb's own read of the
@@ -22,11 +29,12 @@ on:
   pull_request:
 
 # Least-privilege: the job checks out the repo and reads the PR's metadata, changed files, comments,
-# reviews and the comment authors' repository permission (the ADR 0055 write+ gate). It posts no
-# check-run, status or comment and fails by exit code alone.
+# reviews and the comment authors' repository permission (the ADR 0055 write+ gate), and writes the
+# one check-run the verb publishes its answer on. It posts no status and no comment.
 permissions:
   contents: read
   pull-requests: read
+  checks: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,15 +64,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Exit 0 = the floor does not bind (`n/a`) or is discharged (`satisfied`). Every non-zero reds,
-      # and they are different facts: 18 means the diff touches a governance root and its verdict is
-      # absent, stale or fail — a human owes this PR a verdict. 7 / 11 / 13 mean the floor could not
-      # be resolved at all, which is UNKNOWN and never a pass (ADR 0092).
-      - name: Decide whether the governance floor is discharged at this head
+      # Exit 0 = the verb published its answer as the `governance floor at head` check-run, whatever
+      # that answer was — the floor's own polarity is that check-run's, not this job's. A non-zero
+      # here is the one fact this job still carries: the answer could not be published at all, which
+      # is UNKNOWN and never a pass (ADR 0092), so the job reds and a human reads why on stderr.
+      - name: Publish whether the governance floor is discharged at this head
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLAUDE_PIPELINE_REPO: ${{ github.repository }}
         run: |
           node packages/fabrika-cli/src/bin.ts ship floor \
             ${{ github.event.pull_request.number }} \
-            --sha ${{ github.event.pull_request.head.sha }}
+            --sha ${{ github.event.pull_request.head.sha }} \
+            --publish-check

--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -211,8 +211,11 @@ one. Re-review, never re-bind.
 
 **`post` also re-fires the floor check at that head.** The `governance-floor` job runs on
 `pull_request`, so it judged the PR before your verdict existed and nothing else re-fires it. The verb
-re-runs that job, which re-derives `ship floor` against your verdict — it never writes a check-run, so
-the green is the job's own. Its last stderr line says which of `refired` / `restarting` / `green` /
+re-runs that job, which re-derives `ship floor` against your verdict — it never writes a check-run
+itself, so the green is the job's own. What it re-fires on is the `governance floor at head`
+check-run's state rather than the job's conclusion: since #6161 the job succeeds whenever it
+*published* an answer, and a pending check-run beside a green job is exactly the "no verdict yet"
+state your post just cleared. Its last stderr line says which of `refired` / `restarting` / `green` /
 `in-flight` / `no-run` / `unknown` happened.
 
 **Done when** `post` prints `posted`, its read-back conformed, and you have read the floor line — an
@@ -297,7 +300,7 @@ skill cannot touch one.** It holds a shell and a repo-scoped token, and performs
 writes of its own: the namespaced verdict comment, the readout artifact, and one re-run request for
 the `governance-floor` run at the head its verdict binds — which is why the token also needs
 `actions: write`. **That third write asserts nothing:** it writes no check-run and no status, so the
-floor's green stays a green that job derived itself against live comment state, and a token without
+floor's green stays a green that job derived — and published — itself against live comment state, and a token without
 `actions: write` costs a red check, never a false one. (Routing a finding to `/report` fires that
 skill, whose write is that skill's capability and not one claimed here.) Every run ends as exactly
 one of:

--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -300,8 +300,8 @@ skill cannot touch one.** It holds a shell and a repo-scoped token, and performs
 writes of its own: the namespaced verdict comment, the readout artifact, and one re-run request for
 the `governance-floor` run at the head its verdict binds — which is why the token also needs
 `actions: write`. **That third write asserts nothing:** it writes no check-run and no status, so the
-floor's green stays a green that job derived — and published — itself against live comment state, and a token without
-`actions: write` costs a red check, never a false one. (Routing a finding to `/report` fires that
+floor's green stays a green that job derived — and published — itself against live comment state, and
+a token without `actions: write` costs a red check, never a false one. (Routing a finding to `/report` fires that
 skill, whose write is that skill's capability and not one claimed here.) Every run ends as exactly
 one of:
 

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -275,9 +275,12 @@ readers. So the requirement is a property of the diff, not of what a session rem
 `ship gate` seats `blocked` at exit 0 and no workflow invoked it, so the floor bound on nothing but
 prose in the `ship` skill and two fabrika-tree PRs merged with no governance verdict after it
 shipped. `fabrika ship floor` reads the same conjunction for this one namespace and refuses on `18`
-when the verdict is absent, stale or fail; `.github/workflows/governance-floor.yml` relays that exit
-code. The mechanism choice and why the alternatives were rejected are recorded once, in
-[the `ship` contract](../ship/contract.md#the-mechanism-choice).
+when the verdict is absent, stale or fail; `.github/workflows/governance-floor.yml` runs it with
+`--publish-check`, which publishes that answer as the `governance floor at head` check-run — pending
+while no verdict exists, red once one exists and is wrong (#6161, ADR 0318). The mechanism choice and
+why the alternatives were rejected are recorded once, in
+[the `ship` contract](../ship/contract.md#the-mechanism-choice); the conclusion map is
+[its check-run section](../ship/contract.md#publish-check).
 
 **The founder ruled this instead of a §CP row** ([veto on
 #5036](https://github.com/kamp-us/phoenix/issues/5036#issuecomment-5234614633), 2026-08-10):
@@ -958,17 +961,22 @@ namespace is a constant, so it cannot be aimed anywhere else even by a confused 
    variable instead of live state re-ships #3173's false PASS.
 7. **Assert the floor at this head.** `governance-floor.yml` triggers on `pull_request` alone, so it
    ran before this verdict could exist, judged a head with no verdict on it, and no comment write can
-   re-fire a `pull_request`-triggered job — every governance-root PR reds at least once and stays red
-   until something re-runs the job (#5585). The verb reads the runs at the bound head, and when the
-   newest `governance-floor` run there is completed-and-red it requests a re-run of that run's failed
-   jobs, then re-reads the run and requires the re-fire to be **proven from run state** — either
+   re-fire a `pull_request`-triggered job — every governance-root PR carries an unsatisfied floor at
+   least once and carries it until something re-runs the job (#5585). The verb reads the runs at the
+   bound head, and when the newest `governance-floor` run there is completed it asks the
+   `governance floor at head` check-run whether the floor still needs clearing — pending or red, both
+   do; the job's own conclusion decides only where no such check-run exists, because since #6161 the
+   job succeeds whenever it *published* an answer (ADR 0318). Where it does, it requests a re-run of
+   the whole run — `rerun-failed-jobs` is refused on a run with no failed job, which is now the
+   ordinary shape — then re-reads the run and requires the re-fire to be **proven from run state** —
+   either
    `run_attempt` increased, or that same run id is no longer `completed`, which only this dispatch
    could have caused. The counter lags the dispatch by a beat, and calling that beat unproven is what
    sent three agents chasing a `heal-ci` pass over re-fires that had taken (#5982). **The re-run is a
    re-derivation, never a claim**: nothing here writes a check-run or a status, so the green a PR ends
    with is one `ship floor` reached itself against live comment state. **This step is the one place
    the verb needs `actions: write`** on its token; no earlier step asks for it. Without it the
-   `rerun-failed-jobs` request 403s, the floor reads `unknown`, and the fix degrades to
+   re-run request 403s, the floor reads `unknown`, and the fix degrades to
    #5585's own symptom — a red check a human clears — never to a false green.
 
 **The floor assertion never changes the exit code.** By step 7 the verdict is landed and read back, so

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -133,7 +133,8 @@ you read `ns governance` as anything but `pass`, that check is not green either,
 not concluded as a discharged floor. Why the floor is a caller verb rather than a new exit code, why
 it refuses on WRONG and not only on MISSING, and the conclusion map are its sections
 (`fabrika wire doc-section --heading "ship floor" < <skill-base>/contract.md`, then
-`--heading "It refuses on WRONG, not only on MISSING"`, then `--heading "The check-run mode: pending while nobody has judged this head (#6161)"`).
+`--heading "It refuses on WRONG, not only on MISSING"`, then
+`--heading "The check-run mode: pending while nobody has judged this head (#6161)"`).
 
 ## 4 — CI at the head, and only at the head
 

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -124,14 +124,16 @@ content-digest binding and the whole `blocked` taxonomy are the verb's section
 (`fabrika wire doc-section --heading "ship gate" < <skill-base>/contract.md`).
 
 **Your reading of `blocked` is not the only thing enforcing the governance floor.**
-`.github/workflows/governance-floor.yml` runs `fabrika ship floor` on every PR and reds when a
-governance-root diff has no head-bound governance PASS — absent, stale, FAIL and a verdict from an
-author without write+ all red. This step and that job resolve the same verdict through the same
-`ship gate`, so they cannot disagree: if you read `ns governance` as anything but `pass`, the check
-is red too, and routing to the `governance` skill is what clears both. Why the floor is a caller verb
-rather than a new exit code, and why it refuses on WRONG and not only on MISSING, are its sections
+`.github/workflows/governance-floor.yml` runs `fabrika ship floor --publish-check` on every PR and
+publishes the answer as the `governance floor at head` check-run: pending while no verdict has been
+posted at the head, red once one exists and is stale, FAIL, or from an author without write+. This
+step and that job resolve the same verdict through the same `ship gate`, so they cannot disagree: if
+you read `ns governance` as anything but `pass`, that check is not green either, and routing to the
+`governance` skill is what clears both. **Pending is not green** — do not read a check-run that has
+not concluded as a discharged floor. Why the floor is a caller verb rather than a new exit code, why
+it refuses on WRONG and not only on MISSING, and the conclusion map are its sections
 (`fabrika wire doc-section --heading "ship floor" < <skill-base>/contract.md`, then
-`--heading "It refuses on WRONG, not only on MISSING"`).
+`--heading "It refuses on WRONG, not only on MISSING"`, then `--heading "The check-run mode: pending while nobody has judged this head (#6161)"`).
 
 ## 4 — CI at the head, and only at the head
 

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -729,7 +729,7 @@ ns	governance	absent	-
 **Invocation**
 
 ```
-fabrika ship floor 4321 --sha 03135b91 [--repo <owner/name>] [--json]
+fabrika ship floor 4321 --sha 03135b91 [--publish-check] [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -738,6 +738,7 @@ fabrika ship floor 4321 --sha 03135b91 [--repo <owner/name>] [--json]
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number |
 | `--sha` | string | yes | — | the head the answer binds to (7–40 lowercase hex) |
+| `--publish-check` | boolean | no | `false` | publish the answer as a check-run on the head instead of seating it on this verb's exit code |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -749,6 +750,46 @@ fabrika ship floor 4321 --sha 03135b91 [--repo <owner/name>] [--json]
 none of this repo's governed roots, so the floor does not bind — and the verb says so on stderr, in
 those words, because "the check was green" is exactly the reading that would make this gate
 decorative for the diffs it does not cover.
+
+<a id="publish-check"></a>
+### The check-run mode: pending while nobody has judged this head (#6161)
+
+An Actions job concludes success, failure, cancelled or skipped and nothing else. While the floor was
+seated on this verb's exit code, the ordinary mid-lane state — *no verdict posted at this head yet* —
+showed the same red as a verdict that is FAIL or bound to another head. On 2026-08-18 five of six red
+open PRs were red on exactly that, all healthy, and a red meaning "not yet" is a red people stop
+reading. A check-run has the state a job conclusion does not: it can stay `in_progress`.
+
+So `--publish-check` writes the answer to a check-run named **`governance floor at head`** — a stable
+name, distinct from the job's — and this map is the whole of it:
+
+| Floor | Check-run | Why |
+|---|---|---|
+| `satisfied`, `n/a` | `completed` / `success` | nothing is owed |
+| `absent` | left `in_progress` (**pending**) | nobody has judged this head yet; not wrong, not done |
+| `stale`, `fail` | `completed` / `failure` | a verdict was formed and it is not a head-bound PASS |
+| UNKNOWN (`7` / `11` / `13`) | `completed` / `failure` | UNKNOWN never passes and is not "still going" (ADR 0092) |
+
+**The process then exits 0 whenever the check-run landed, whatever it said.** The floor's polarity is
+the check-run's; a non-zero in this mode says only that the answer could not be published, which is
+the one fact the job still carries. It seats `8` (the write failed) and `9` (GitHub echoed a state
+this run did not decide), both this group's existing meanings — no exit code is repurposed, and every
+other caller of `ship floor` is untouched.
+
+**A pending check-run does not weaken the block.** `ship gate` is unchanged and still refuses while a
+governance verdict is absent, `ship checks` rolls a pending gating run up as `pending` rather than
+`green`, and a required check that is pending is not a passing one. What changed is what a human
+reads, not what a merge is allowed to do.
+
+**One row per head.** A check-run this head already carries is rewritten in place rather than stacked
+on, so the PR shows one row. The exception is the backwards transition — a completed check-run being
+re-opened as pending — which the platform will not model, because an update cannot clear a conclusion
+it has recorded; that one posts a fresh check-run instead.
+
+**What re-fires it.** Nothing new: `governance post` re-fires the floor run at the head it posted to,
+and that re-run re-derives the floor and rewrites the check-run green. Since the job now succeeds
+whenever it *published* an answer, that re-fire keys on the check-run's state rather than the job's
+conclusion, and requests a whole-run re-run rather than a failed-jobs one.
 
 <a id="the-mechanism-choice"></a>
 ### Why a caller verb, and not a new exit code on `ship gate` (#5408)
@@ -796,6 +837,8 @@ it is *present and wrong* (#5416, #4887). All four of these red on `18`, and eac
 | `11` | the PR, its changed-file list, or the conjunction underneath could not be read — the floor is UNKNOWN, never `n/a` |
 | `13` | the changed-file enumeration is provably short — a governance root could sit in the part nobody read |
 | `18` | the diff touches a governance root and its `governance` verdict at this head is `absent`, `stale` or `fail` |
+| `8` | **`--publish-check` only** — the check-run could not be written, so the floor is resolved and nothing published it |
+| `9` | **`--publish-check` only** — the check-run landed and GitHub echoed a state this run did not decide |
 
 **Errors**
 
@@ -816,10 +859,11 @@ the comment authors' ACL). Both scanned counts reach stderr, this verb's first.
 
 **Where it is enforced.** `.github/workflows/governance-floor.yml`, job `floor`, on every
 `pull_request` with no `paths:` filter — the verb's own read of the changed files is the path
-decision, so there is no YAML copy of the root list to drift. The job relays the exit code and does
-nothing else. Making that context **required** is a repository-ruleset change and therefore a
-human's; until it is required the check is red-but-not-blocking, which is a weaker state than the
-ruling asks for and is recorded here rather than glossed.
+decision, so there is no YAML copy of the root list to drift. The job runs `--publish-check` and
+relays what the verb did, deciding nothing. Making the `governance floor at head` context
+**required** is a repository-ruleset change and therefore a human's; until it is, the check is
+visible-but-not-blocking at the ruleset, which is a weaker state than the ruling asks for and is
+recorded here rather than glossed.
 
 **Examples**
 

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -742,9 +742,29 @@ fabrika ship floor 4321 --sha 03135b91 [--publish-check] [--repo <owner/name>] [
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
-**Output** — machine channel. Two lines: `floor\t<satisfied|n/a>\t<sha>` then
-`ns\tgovernance\t<pass|->`. With `--json`, an object with keys `outcome`, `sha`, `namespace`,
-`state` and `scanned`.
+**Output** — machine channel, and the two modes print different shapes.
+
+Without `--publish-check`, two lines:
+
+```
+floor	<satisfied|n/a>	<sha>
+ns	governance	<pass|->
+```
+
+With `--json`, an object with keys `outcome`, `sha`, `namespace`, `state` and `scanned`.
+
+With `--publish-check`, three lines — the check-run the verb wrote comes first, and the floor and
+namespace words are the raw ones the resolution carried rather than the exit-code mode's two:
+
+```
+check	<in_progress|completed>	<success|failure|->	<check-run id>
+floor	<n/a|satisfied|blocked|unresolved>	<sha>
+ns	governance	<pass|absent|stale|fail|->
+```
+
+With `--json` in that mode, an object with keys `outcome`, `sha`, `namespace`, `state` and
+`checkRun` (`{id, name, status, conclusion}`) — **no `scanned` key**, because what this mode answers
+is what it published.
 
 **`n/a` is an answer about the diff, never a discharged verdict.** It means the changed files touch
 none of this repo's governed roots, so the floor does not bind — and the verb says so on stderr, in
@@ -772,9 +792,10 @@ name, distinct from the job's — and this map is the whole of it:
 
 **The process then exits 0 whenever the check-run landed, whatever it said.** The floor's polarity is
 the check-run's; a non-zero in this mode says only that the answer could not be published, which is
-the one fact the job still carries. It seats `8` (the write failed) and `9` (GitHub echoed a state
-this run did not decide), both this group's existing meanings — no exit code is repurposed, and every
-other caller of `ship floor` is untouched.
+the one fact the job still carries. It seats `8` (the write failed), `9` (GitHub echoed a state this
+run did not decide) and `11` (the head's check-runs could not be enumerated, so nothing was written),
+all three this group's existing meanings — no exit code is repurposed, and every other caller of
+`ship floor` is untouched.
 
 **A pending check-run does not weaken the block.** `ship gate` is unchanged and still refuses while a
 governance verdict is absent, `ship checks` rolls a pending gating run up as `pending` rather than
@@ -784,7 +805,9 @@ reads, not what a merge is allowed to do.
 **One row per head.** A check-run this head already carries is rewritten in place rather than stacked
 on, so the PR shows one row. The exception is the backwards transition — a completed check-run being
 re-opened as pending — which the platform will not model, because an update cannot clear a conclusion
-it has recorded; that one posts a fresh check-run instead.
+it has recorded; that one posts a fresh check-run instead. A head whose check-runs cannot be read is
+neither case: the verb refuses on `11` and publishes nothing, because "unreadable" read as "no row
+here" is how one head ends up with two.
 
 **What re-fires it.** Nothing new: `governance post` re-fires the floor run at the head it posted to,
 and that re-run re-derives the floor and rewrites the check-run green. Since the job now succeeds
@@ -834,7 +857,7 @@ it is *present and wrong* (#5416, #4887). All four of these red on `18`, and eac
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed, or has zero changed files — whether it touches a governance root is unanswerable (ADR 0092) |
-| `11` | the PR, its changed-file list, or the conjunction underneath could not be read — the floor is UNKNOWN, never `n/a` |
+| `11` | the PR, its changed-file list, or the conjunction underneath could not be read — the floor is UNKNOWN, never `n/a`. Under `--publish-check`, also: the check-runs at the head could not be enumerated, so whether this head already carries the floor's row is unknown and nothing is published |
 | `13` | the changed-file enumeration is provably short — a governance root could sit in the part nobody read |
 | `18` | the diff touches a governance root and its `governance` verdict at this head is `absent`, `stale` or `fail` |
 | `8` | **`--publish-check` only** — the check-run could not be written, so the floor is resolved and nothing published it |
@@ -852,6 +875,11 @@ it is *present and wrong* (#5416, #4887). All four of these red on `18`, and eac
 | `ship floor: received <k> of <m> changed files — a governance root could sit in the part nobody read.` | 13 | refusal |
 | `ship floor: #<n> touches a governance root and its governance verdict at <sha> is <state> — <remedy> (#5408).` | 18 | refusal |
 | `ship floor: #<n>'s diff touches no governance root, so the floor does not bind — this is an answer about the diff, not a discharged verdict.` | 0 | notice |
+| `ship floor --publish-check: cannot enumerate the check runs at <sha>: <reason> — nothing was published, so the floor stays UNKNOWN rather than posting a duplicate row.` | 11 | refusal |
+| `ship floor --publish-check: the check-run could not be written: <reason> — the floor is resolved and nothing published it.` | 8 | refusal |
+| `ship floor --publish-check: wrote <status>/<conclusion> to check-run <id> and GitHub echoed <status>/<conclusion> — what the PR shows is not what this run decided.` | 9 | refusal |
+| `ship floor --publish-check: posted check-run <id> — the job's own exit code no longer carries the floor (#6161).` | 0 | notice |
+| `ship floor --publish-check: rewrote check-run <id> — the job's own exit code no longer carries the floor (#6161).` | 0 | notice |
 
 **Scope** — one PR's changed-file list, count-checked against the declared total, plus whatever
 `ship gate` scans for the one required namespace (its own file list, the comments, the reviews and
@@ -886,6 +914,21 @@ ship gate: scanned 0 reviews; pagination exhausted.
 ship floor: #5481 touches a governance root and its governance verdict at c9deb6047acc69da85b033a46b1fe05d2e0f5b91 is absent — no authorized governance verdict at this head — run the `governance` skill and emit one with `fabrika governance post` (#5408).
 $ echo $?
 18
+```
+
+The same absent floor under `--publish-check` — the answer moves to the check-run and the process
+exits 0 on having published it:
+
+```
+$ fabrika ship floor 5481 --sha c9deb6047acc69da85b033a46b1fe05d2e0f5b91 --publish-check
+ship floor: scanned 1 changed file; 1 declared.
+ship floor: #5481 touches a governance root and its governance verdict at c9deb6047acc69da85b033a46b1fe05d2e0f5b91 is absent — no authorized governance verdict at this head — run the `governance` skill and emit one with `fabrika governance post` (#5408).
+ship floor --publish-check: posted check-run 48812301 — the job's own exit code no longer carries the floor (#6161).
+check	in_progress	-	48812301
+floor	blocked	c9deb6047acc69da85b033a46b1fe05d2e0f5b91
+ns	governance	absent
+$ echo $?
+0
 ```
 
 **Grounding**

--- a/packages/fabrika-cli/src/governance/floor-assert.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.ts
@@ -14,7 +14,9 @@
  *
  * **Asserting is re-deriving, never claiming.** Nothing here writes a check-run or a status: it
  * re-fires the floor job, which re-runs `ship floor` against live comment state and reaches its own
- * verdict. A fabricated green is the one outcome this module must never be able to produce.
+ * verdict. A fabricated green is the one outcome this module must never be able to produce. Since
+ * #6161 the job publishes that verdict as a check-run and succeeds whenever it published one, so
+ * what a re-fire is owed to is the check-run's state and no longer the job's conclusion.
  *
  * The run IO is imported from the two homes that already serve it — `../ship/github.ts` for the runs
  * at a head, `../heal-ci/github.ts` for one run and the rerun request. A third copy of either is how
@@ -23,14 +25,55 @@
 import {Effect} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {getWorkflowRun, rerunFailedJobs} from "../heal-ci/github.ts";
-import {listRunsAtHead} from "../ship/github.ts";
+import {getWorkflowRun, rerunRun} from "../heal-ci/github.ts";
+import {type Attempt, ok} from "../io/git.ts";
+import {CHECK_RUN_NAME} from "../ship/floor-check.ts";
+import {
+	latestPerContext,
+	listRunsAtHead,
+	listShipCheckRuns,
+	type ShipCheckRun,
+} from "../ship/github.ts";
 
 /** The floor workflow's `name:`, which is what a run at a head carries. */
 export const FLOOR_WORKFLOW_NAME = "governance-floor";
 
 /** The conclusions that leave the check red. Anything else at `completed` is not a red to clear. */
 const RED_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+
+/**
+ * The `governance floor at head` check-run this head carries, latest-per-context, or `null` when the
+ * head carries none.
+ *
+ * `null` is not a failure: a run predating `--publish-check`, or one that could not publish, leaves
+ * the head with no check-run at all, and the job's own conclusion is the only signal there.
+ */
+const floorCheckRun = (
+	repo: string,
+	sha: string,
+): Effect.Effect<
+	Attempt<ShipCheckRun | null>,
+	never,
+	HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.map(listShipCheckRuns(repo, sha), (listed) =>
+		listed._tag === "Failure"
+			? listed
+			: ok(latestPerContext(listed.value.runs).find((run) => run.name === CHECK_RUN_NAME) ?? null),
+	);
+
+/**
+ * Whether the floor's state at this head is one a re-fire could move.
+ *
+ * The job's conclusion is no longer the floor's answer: since #6161 the job succeeds whenever it
+ * *published* one, and the answer itself is the check-run's — which is pending exactly when the
+ * verdict has not landed, the state this whole module exists to clear. So the check-run decides when
+ * there is one, and the job's conclusion decides when there is not.
+ */
+export const needsRefire = (jobConclusion: string | null, check: ShipCheckRun | null): boolean =>
+	check === null
+		? RED_CONCLUSIONS.has(jobConclusion ?? "")
+		: check.status !== "completed" || check.conclusion !== "success";
 
 export type FloorAssertion =
 	/** No floor run at this head: the workflow is not installed here, or it has not fired yet. */
@@ -83,7 +126,10 @@ export const assertFloorAt = (
 		// workflow — and the check the PR shows is the last one.
 		const latest = floors.reduce((held, run) => (run.id > held.id ? run : held));
 		if (latest.status !== "completed") return {_tag: "InFlight", run: latest.id};
-		if (!RED_CONCLUSIONS.has(latest.conclusion ?? "")) return {_tag: "Green", run: latest.id};
+
+		const standing = yield* floorCheckRun(repo, sha);
+		if (standing._tag === "Failure") return unknown(standing.reason);
+		if (!needsRefire(latest.conclusion, standing.value)) return {_tag: "Green", run: latest.id};
 
 		const before = yield* getWorkflowRun(repo, latest.id);
 		if (before._tag !== "Present") {
@@ -93,7 +139,7 @@ export const assertFloorAt = (
 					: `run ${latest.id}: ${before.reason}`,
 			);
 		}
-		const requested = yield* rerunFailedJobs(repo, latest.id);
+		const requested = yield* rerunRun(repo, latest.id);
 		if (requested._tag === "Failure") return unknown(requested.reason);
 		const after = yield* getWorkflowRun(repo, latest.id);
 		if (after._tag !== "Present") {

--- a/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
@@ -48,6 +48,16 @@ const noFloorCheck: ReadonlyArray<Scripted> = [
 	],
 ];
 
+/**
+ * Whether one recorded request WROTE a check-run — the fence this module must never trip.
+ *
+ * Every method that is not a GET counts. `ship floor --publish-check` creates with POST and rewrites
+ * with PATCH, so a POST-shaped fence would let a PATCH-shaped fabricated conclusion straight through
+ * (#6161).
+ */
+const writesCheckRun = (call: string): boolean =>
+	call.includes("check-runs") && !call.startsWith("GET ");
+
 const FLOOR = 31_863_008_185;
 
 const assert = (script: ReadonlyArray<Scripted>) =>
@@ -83,10 +93,10 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 		expect(seams.requests.some((call) => RERUN.test(call))).toBe(true);
 		// The re-fire re-runs `ship floor` in CI. Nothing here WRITES a check-run — the read above is
 		// how this module learns the floor's state, and the green a PR ends up with is one the job
-		// derived for itself (#5585).
-		expect(
-			seams.requests.some((call) => call.startsWith("POST") && call.includes("check-runs")),
-		).toBe(false);
+		// derived for itself (#5585). The fence is every method that is not a GET, not `POST` alone:
+		// `ship floor --publish-check` rewrites a held row with `PATCH /check-runs/{id}`, so a
+		// method-specific fence would let the PATCH-shaped fabrication through (#6161).
+		expect(seams.requests.some(writesCheckRun)).toBe(false);
 	});
 
 	it("picks the NEWEST floor run at the head, not the first one listed", async () => {
@@ -265,5 +275,16 @@ describe("needsRefire reads the check-run, and the job only where there is none"
 		expect(needsRefire("success", null)).toBe(false);
 		expect(needsRefire("failure", null)).toBe(true);
 		expect(needsRefire(null, null)).toBe(false);
+	});
+});
+
+describe("the check-run fence these cases assert on", () => {
+	it("catches every write method and lets the read through", () => {
+		expect(writesCheckRun("POST https://api.github.com/repos/o/r/check-runs")).toBe(true);
+		expect(writesCheckRun("PATCH https://api.github.com/repos/o/r/check-runs/55")).toBe(true);
+		expect(writesCheckRun("DELETE https://api.github.com/repos/o/r/check-runs/55")).toBe(true);
+		expect(
+			writesCheckRun("GET https://api.github.com/repos/o/r/commits/abc/check-runs?per_page=100"),
+		).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
@@ -3,17 +3,50 @@ import {describe, expect, it} from "vitest";
 import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import {
 	accepted,
+	checkRuns,
+	HEAD_CHECK_RUNS,
 	httpError,
-	RERUN,
+	RERUN_ALL as RERUN,
 	RUN,
 	runsAtHead,
 	workflowRun,
 } from "../heal-ci/fixtures.test-support.ts";
+import {CHECK_RUN_NAME} from "../ship/floor-check.ts";
 import {HEAD} from "./fixtures.test-support.ts";
-import {assertFloorAt, floorLine, floorToken} from "./floor-assert.ts";
+import {assertFloorAt, floorLine, floorToken, needsRefire} from "./floor-assert.ts";
 
 /** The paged envelope read at the head — `&per_page=100&page=1` follows, so no `$` anchor. */
 const RUNS = /^GET .*\/repos\/o\/r\/actions\/runs\?head_sha=/;
+
+/** The floor's own check-run at the head, in whichever state the case is about. */
+const floorCheck = (
+	over: {status?: string; conclusion?: string | null} = {},
+): ReadonlyArray<Scripted> => [
+	[
+		HEAD_CHECK_RUNS,
+		{
+			status: 200,
+			body: checkRuns(1, [
+				{
+					name: CHECK_RUN_NAME,
+					status: over.status ?? "completed",
+					conclusion: over.conclusion === undefined ? "failure" : over.conclusion,
+				},
+			]).stdout,
+		},
+	],
+];
+
+/** A head carrying no check-run of the floor's name at all — a run that predates `--publish-check`. */
+const noFloorCheck: ReadonlyArray<Scripted> = [
+	[
+		HEAD_CHECK_RUNS,
+		{
+			status: 200,
+			body: checkRuns(1, [{name: "ci", status: "completed", conclusion: "success"}]).stdout,
+		},
+	],
+];
 
 const FLOOR = 31_863_008_185;
 
@@ -43,13 +76,17 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 	it("re-fires the red floor run at this head and proves the new attempt", async () => {
 		const {assertion, seams} = await withCalls([
 			...red(),
+			...floorCheck(),
 			...listed({id: 1, name: "ci"}, {id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion).toEqual({_tag: "Refired", run: FLOOR, attempt: 2});
 		expect(seams.requests.some((call) => RERUN.test(call))).toBe(true);
-		// The re-fire re-runs `ship floor` in CI. Nothing here writes a check-run or a status, so the
-		// green a PR ends up with is one the gate's own job derived (#5585).
-		expect(seams.log.some((call) => call.includes("check-runs"))).toBe(false);
+		// The re-fire re-runs `ship floor` in CI. Nothing here WRITES a check-run — the read above is
+		// how this module learns the floor's state, and the green a PR ends up with is one the job
+		// derived for itself (#5585).
+		expect(
+			seams.requests.some((call) => call.startsWith("POST") && call.includes("check-runs")),
+		).toBe(false);
 	});
 
 	it("picks the NEWEST floor run at the head, not the first one listed", async () => {
@@ -57,6 +94,7 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 			[once(RUN), workflowRun({id: 900, attempt: 1})],
 			[RERUN, accepted],
 			[RUN, workflowRun({id: 900, attempt: 2})],
+			...floorCheck(),
 			...listed({id: 700, name: "governance-floor"}, {id: 900, name: "governance-floor"}),
 		]);
 		expect(seams.requests.some((call) => call.endsWith("/actions/runs/900"))).toBe(true);
@@ -71,10 +109,33 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 		expect(seams.requests.some((call) => RERUN.test(call))).toBe(false);
 	});
 
-	it("re-fires nothing when the run at this head already reads green", async () => {
-		const {assertion, seams} = await withCalls(
-			listed({id: FLOOR, name: "governance-floor", conclusion: "success"}),
-		);
+	it("re-fires nothing when the check-run at this head already reads green", async () => {
+		const {assertion, seams} = await withCalls([
+			...floorCheck({conclusion: "success"}),
+			...listed({id: FLOOR, name: "governance-floor", conclusion: "success"}),
+		]);
+		expect(assertion).toEqual({_tag: "Green", run: FLOOR});
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(false);
+	});
+
+	// The job now succeeds whenever it PUBLISHED an answer, so its green says nothing about the floor
+	// (#6161). A pending check-run beside a green job is the ordinary "no verdict yet" state, and it is
+	// exactly the state this module exists to clear.
+	it("re-fires a green job whose check-run is still pending", async () => {
+		const {assertion, seams} = await withCalls([
+			...red(),
+			...floorCheck({status: "in_progress", conclusion: null}),
+			...listed({id: FLOOR, name: "governance-floor", conclusion: "success"}),
+		]);
+		expect(assertion).toEqual({_tag: "Refired", run: FLOOR, attempt: 2});
+		expect(seams.requests.some((call) => RERUN.test(call))).toBe(true);
+	});
+
+	it("falls back to the job's conclusion when the head carries no floor check-run", async () => {
+		const {assertion, seams} = await withCalls([
+			...noFloorCheck,
+			...listed({id: FLOOR, name: "governance-floor", conclusion: "success"}),
+		]);
 		expect(assertion).toEqual({_tag: "Green", run: FLOOR});
 		expect(seams.requests.some((call) => RERUN.test(call))).toBe(false);
 	});
@@ -86,6 +147,7 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, accepted],
 			[RUN, workflowRun({id: FLOOR, attempt: 1, status: "in_progress", conclusion: null})],
+			...floorCheck(),
 			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion).toEqual({_tag: "Restarting", run: FLOOR, status: "in_progress"});
@@ -97,6 +159,7 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, accepted],
 			[RUN, workflowRun({id: FLOOR, attempt: 1, status: "queued", conclusion: null})],
+			...floorCheck(),
 			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion).toEqual({_tag: "Restarting", run: FLOOR, status: "queued"});
@@ -120,6 +183,7 @@ describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
 		const assertion = await assert([
 			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, httpError(403, "Forbidden")],
+			...floorCheck(),
 			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion._tag).toBe("Unknown");
@@ -132,6 +196,7 @@ describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
 		const assertion = await assert([
 			[RUN, workflowRun({id: FLOOR, attempt: 1})],
 			[RERUN, accepted],
+			...floorCheck(),
 			...listed({id: FLOOR, name: "governance-floor"}),
 		]);
 		expect(assertion._tag).toBe("Unknown");
@@ -140,6 +205,14 @@ describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
 
 	it("reports an unreadable run list as UNKNOWN", async () => {
 		const assertion = await assert([[RUNS, {status: 502, body: "{}"}]]);
+		expect(assertion._tag).toBe("Unknown");
+	});
+
+	it("reports an unreadable check-run list as UNKNOWN rather than as a green", async () => {
+		const assertion = await assert([
+			[HEAD_CHECK_RUNS, {status: 502, body: "{}"}],
+			...listed({id: FLOOR, name: "governance-floor", conclusion: "success"}),
+		]);
 		expect(assertion._tag).toBe("Unknown");
 	});
 });
@@ -165,5 +238,32 @@ describe("floorLine says what the caller must do next", () => {
 		expect(line).toContain("wait and re-read");
 		expect(line).toContain("nothing to escalate");
 		expect(floorToken({_tag: "Restarting", run: FLOOR, status: "in_progress"})).toBe("restarting");
+	});
+});
+
+describe("needsRefire reads the check-run, and the job only where there is none", () => {
+	const check = (status: string, conclusion: string | null) => ({
+		name: CHECK_RUN_NAME,
+		status,
+		conclusion,
+		startedAt: null,
+		id: 1,
+		checkSuiteId: 1,
+	});
+
+	it("holds a pending check-run to be re-fireable however the job concluded", () => {
+		expect(needsRefire("success", check("in_progress", null))).toBe(true);
+		expect(needsRefire("failure", check("in_progress", null))).toBe(true);
+	});
+
+	it("clears only on a completed, successful check-run", () => {
+		expect(needsRefire("success", check("completed", "success"))).toBe(false);
+		expect(needsRefire("success", check("completed", "failure"))).toBe(true);
+	});
+
+	it("reads the job's conclusion when the head carries no check-run", () => {
+		expect(needsRefire("success", null)).toBe(false);
+		expect(needsRefire("failure", null)).toBe(true);
+		expect(needsRefire(null, null)).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
@@ -1,10 +1,19 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeSeams, okOut, once, type Scripted, unconfigured} from "../fakes.test-support.ts";
-import {accepted, RERUN, RUN, runsAtHead, workflowRun} from "../heal-ci/fixtures.test-support.ts";
+import {
+	accepted,
+	checkRuns,
+	HEAD_CHECK_RUNS,
+	RERUN_ALL as RERUN,
+	RUN,
+	runsAtHead,
+	workflowRun,
+} from "../heal-ci/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {CONTENT, PATHS_AT} from "../review/fixtures.test-support.ts";
+import {CHECK_RUN_NAME} from "../ship/floor-check.ts";
 import {
 	BARE_AT_PATH,
 	EMPTY_STDIN,
@@ -250,10 +259,20 @@ describe("runPost asserts the governance floor at the head it posted to", () => 
 		{status: 200, body: runsAtHead(1, [{id: FLOOR, name: "governance-floor"}]).stdout},
 	];
 
+	/** The floor's check-run at the head, still pending — the state a re-fire is owed to (#6161). */
+	const floorPending: Scripted = [
+		HEAD_CHECK_RUNS,
+		{
+			status: 200,
+			body: checkRuns(1, [{name: CHECK_RUN_NAME, status: "in_progress", conclusion: null}]).stdout,
+		},
+	];
+
 	const floorRed = (): ReadonlyArray<Scripted> => [
 		[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
 		[RERUN, accepted],
 		[RUN, workflowRun({id: FLOOR, attempt: 2})],
+		floorPending,
 	];
 
 	it("re-fires the red floor run and names the new attempt on stderr", async () => {

--- a/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
@@ -35,6 +35,13 @@ export const RUN = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/actions\\/runs\\/\\
 export const RERUN = new RegExp(
 	`^POST ${API}\\/repos\\/o\\/r\\/actions\\/runs\\/\\d+\\/rerun-failed-jobs$`,
 );
+/** The whole-run re-fire, which `RERUN` cannot also match — its own pattern ends on `/rerun`. */
+export const RERUN_ALL = new RegExp(
+	`^POST ${API}\\/repos\\/o\\/r\\/actions\\/runs\\/\\d+\\/rerun$`,
+);
+export const HEAD_CHECK_RUNS = new RegExp(
+	`^GET ${API}\\/repos\\/o\\/r\\/commits\\/[0-9a-f]+\\/check-runs\\?`,
+);
 export const OPEN_PULLS = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/pulls\\?state=open`);
 export const RATE_LIMIT = new RegExp(`^GET ${API}\\/rate_limit$`);
 export const RULES = new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/rules\\/branches\\/main\\?`);

--- a/packages/fabrika-cli/src/heal-ci/github.ts
+++ b/packages/fabrika-cli/src/heal-ci/github.ts
@@ -147,6 +147,16 @@ export const getWorkflowRun = (repo: string, run: number): Shell<Existence<RunRe
 		),
 	);
 
+const rerunRequest = (path: string): Shell<Attempt<void>> =>
+	authed((token) =>
+		Effect.map(restRead(token, "POST", path), (outcome) => {
+			if (outcome._tag === "Unreachable") return fail(outcome.reason);
+			return outcome.status >= 200 && outcome.status < 300
+				? ok<void>(undefined)
+				: fail(refusalText(outcome));
+		}),
+	);
+
 /**
  * Request a re-run of a run's **failed jobs only**.
  *
@@ -156,17 +166,19 @@ export const getWorkflowRun = (repo: string, run: number): Shell<Existence<RunRe
  * future rerun of a run that never re-ran.
  */
 export const rerunFailedJobs = (repo: string, run: number): Shell<Attempt<void>> =>
-	authed((token) =>
-		Effect.map(
-			restRead(token, "POST", `repos/${repo}/actions/runs/${run}/rerun-failed-jobs`),
-			(outcome) => {
-				if (outcome._tag === "Unreachable") return fail(outcome.reason);
-				return outcome.status >= 200 && outcome.status < 300
-					? ok<void>(undefined)
-					: fail(refusalText(outcome));
-			},
-		),
-	);
+	rerunRequest(`repos/${repo}/actions/runs/${run}/rerun-failed-jobs`);
+
+/**
+ * Request a re-run of **every** job in a run, whatever it concluded.
+ *
+ * {@link rerunFailedJobs} is refused on a run with no failed job, which is the ordinary state of a
+ * governance-floor run since the floor moved off the job's exit code onto a check-run: the job
+ * succeeds — it published an answer — while the check-run it published stays pending (#6161). The
+ * same 2xx-is-not-an-attempt discipline holds; the caller still proves the new attempt from run
+ * state.
+ */
+export const rerunRun = (repo: string, run: number): Shell<Attempt<void>> =>
+	rerunRequest(`repos/${repo}/actions/runs/${run}/rerun`);
 
 /**
  * A read's answer beside the status GitHub served — which is what a permission denial is told apart

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -19,6 +19,7 @@ import {runCpApproval} from "./cp-approval-verb.ts";
 import {runDisarm} from "./disarm-verb.ts";
 import {runEnqueue} from "./enqueue-verb.ts";
 import {runEvidence} from "./evidence-verb.ts";
+import {runFloorCheck} from "./floor-check.ts";
 import {runFloor} from "./floor-verb.ts";
 import {runGate} from "./gate-verb.ts";
 import {runMerge} from "./merge-verb.ts";
@@ -139,23 +140,32 @@ const gate = leafCommand(
 
 const floor = leafCommand(
 	"floor",
-	{pr: prArg, sha: shaFlag, repo: repoFlag, json: jsonFlag},
-	Effect.fn(function* ({pr, sha, repo, json}) {
-		yield* emit(
-			yield* runFloor({
-				pr,
-				sha,
-				repo: Option.getOrNull(repo),
-				json,
-				cwd: process.cwd(),
-				env: process.env,
-			}),
-		);
+	{
+		pr: prArg,
+		sha: shaFlag,
+		publishCheck: Flag.boolean("publish-check").pipe(
+			Flag.withDescription(
+				"publish the answer as a check-run on the head instead of seating it on this verb's exit code; the process then exits 0 whenever the check-run landed",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({pr, sha, publishCheck, repo, json}) {
+		const options = {
+			pr,
+			sha,
+			repo: Option.getOrNull(repo),
+			json,
+			cwd: process.cwd(),
+			env: process.env,
+		};
+		yield* emit(yield* publishCheck ? runFloorCheck(options) : runFloor(options));
 	}),
 ).pipe(
 	Command.withShortDescription("Whether a governance-root diff carries its governance verdict."),
 	Command.withDescription(
-		"Decide whether the governance floor binds on this PR at one head, and seat the answer on an exit code a CI job can red on. Prints `floor\\t<satisfied|n/a>\\t<sha>` then `ns\\tgovernance\\t<pass|->`; `n/a` is a proven answer about the diff — it touches no governance root — and never a discharged verdict. The verdict itself is `ship gate`'s, asked for the one `governance` namespace, so this is not a second conjunction and it decides nothing about enqueue. Exits 7 (PR proven absent or closed, or zero changed files), 11 (the PR, its file list or the conjunction could not be read — the floor is UNKNOWN, never n/a), 13 (the changed-file enumeration is provably short — a governance root could sit in the part nobody read), 18 (the diff touches a governance root and its governance verdict is absent, stale or fail — the one refusal that means a human owes this PR a verdict, #5408). Example: fabrika ship floor 4321 --sha 03135b91",
+		"Decide whether the governance floor binds on this PR at one head, and seat the answer on an exit code a CI job can red on. Prints `floor\\t<satisfied|n/a>\\t<sha>` then `ns\\tgovernance\\t<pass|->`; `n/a` is a proven answer about the diff — it touches no governance root — and never a discharged verdict. The verdict itself is `ship gate`'s, asked for the one `governance` namespace, so this is not a second conjunction and it decides nothing about enqueue. Exits 7 (PR proven absent or closed, or zero changed files), 11 (the PR, its file list or the conjunction could not be read — the floor is UNKNOWN, never n/a), 13 (the changed-file enumeration is provably short — a governance root could sit in the part nobody read), 18 (the diff touches a governance root and its governance verdict is absent, stale or fail — the one refusal that means a human owes this PR a verdict, #5408). With --publish-check the same answer is seated on a check-run named `governance floor at head` instead (`checks: write` required): `satisfied`/`n/a` conclude success, `absent` leaves the check-run in_progress so \"no verdict yet\" reads as waiting rather than as a failure, `stale`/`fail` conclude failure, and UNKNOWN concludes failure too (ADR 0092). In that mode the process exits 0 whenever the check-run landed — a non-zero means the verb could not publish, never that the floor is unmet — and it seats 8 (the check-run could not be written) and 9 (GitHub echoed a state this run did not decide). Every other caller's exit semantics are unchanged (#6161). Example: fabrika ship floor 4321 --sha 03135b91",
 	),
 );
 

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -19,8 +19,7 @@ import {runCpApproval} from "./cp-approval-verb.ts";
 import {runDisarm} from "./disarm-verb.ts";
 import {runEnqueue} from "./enqueue-verb.ts";
 import {runEvidence} from "./evidence-verb.ts";
-import {runFloorCheck} from "./floor-check.ts";
-import {runFloor} from "./floor-verb.ts";
+import {floorRunner} from "./floor-check.ts";
 import {runGate} from "./gate-verb.ts";
 import {runMerge} from "./merge-verb.ts";
 import {runNote} from "./note-verb.ts";
@@ -160,7 +159,7 @@ const floor = leafCommand(
 			cwd: process.cwd(),
 			env: process.env,
 		};
-		yield* emit(yield* publishCheck ? runFloorCheck(options) : runFloor(options));
+		yield* emit(yield* floorRunner(publishCheck)(options));
 	}),
 ).pipe(
 	Command.withShortDescription("Whether a governance-root diff carries its governance verdict."),

--- a/packages/fabrika-cli/src/ship/floor-check.ts
+++ b/packages/fabrika-cli/src/ship/floor-check.ts
@@ -1,0 +1,223 @@
+/**
+ * `ship floor --publish-check` — the same floor, seated on a check-run instead of an exit code.
+ *
+ * A GitHub Actions job's conclusion is success/failure/cancelled/skipped and nothing else, so while
+ * the floor was seated on the job's exit code, "no verdict posted at this head yet" — the ordinary
+ * mid-lane state every governance-root PR passes through — showed a human the same red as a verdict
+ * that is FAIL or bound to another head. Five of six red open PRs were red on exactly that on
+ * 2026-08-18, and a red that means "not yet" trains people to stop reading reds (#6161).
+ *
+ * A check-run has the state a job conclusion does not: it can stay `in_progress`. So the absent
+ * verdict leaves the check pending, which reads as "waiting" to a human and still withholds a merge
+ * — a pending required check is not a passing one, and `ship checks` rolls it up as `pending` rather
+ * than green. The founder ruled the mechanism on
+ * [2026-08-20](https://github.com/kamp-us/phoenix/issues/6161#issuecomment-5364681459); ADR 0318
+ * carries the why.
+ *
+ * **The verb writes the check-run; the job only relays what it did** (ADR 0228). Nothing in
+ * `governance-floor.yml` decides a conclusion, and nothing here re-derives the floor: the answer is
+ * `./floor-verb.ts`'s `resolveFloor`, which is the same derivation the exit-code mode seats.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {
+	type FloorOptions,
+	type FloorResolution,
+	floorRefusalLine,
+	NAMESPACE,
+	resolveFloor,
+} from "./floor-verb.ts";
+import {
+	type CheckRunDraft,
+	createCheckRun,
+	latestPerContext,
+	listShipCheckRuns,
+	updateCheckRun,
+} from "./github.ts";
+import {inspectedSha, NULL_TOKEN, resolveTargetRepo} from "./target.ts";
+
+const VERB = "ship floor --publish-check";
+
+/**
+ * The check-run's name, which is what a branch-protection rule names as a required status check.
+ *
+ * Deliberately not the job's name: two rows in one PR's check list called the same thing would be
+ * unreadable, and a ruleset naming the job would go on binding the exit code this mode exists to
+ * stop binding.
+ */
+export const CHECK_RUN_NAME = "governance floor at head";
+
+/** The floor word the payload carries — what was decided, beside how the check-run seats it. */
+export type FloorWord = "n/a" | "satisfied" | "blocked" | "unresolved";
+
+/**
+ * What to write, in the two shapes the platform distinguishes.
+ *
+ * `Pending` is the whole point of this mode and carries no conclusion, because a conclusion is what
+ * completes a check-run.
+ */
+export type CheckPlan =
+	| {
+			readonly _tag: "Pending";
+			readonly floor: FloorWord;
+			readonly title: string;
+			readonly summary: string;
+	  }
+	| {
+			readonly _tag: "Concluded";
+			readonly conclusion: "success" | "failure";
+			readonly floor: FloorWord;
+			readonly title: string;
+			readonly summary: string;
+	  };
+
+/**
+ * The conclusion map, whole, in one pure function — the acceptance criteria of #6161 read as a
+ * table, so a reader checks it against them without tracing control flow.
+ *
+ * `absent` is the one row that stays pending. Every other blocking state has a verdict behind it,
+ * and a verdict that is FAIL or bound to another head is a thing that went wrong rather than a thing
+ * that has not happened. UNKNOWN concludes `failure` and never pending: a floor nobody could read is
+ * not a floor still being read, and ADR 0092 gives it the same polarity as a refusal.
+ */
+export const planFor = (pr: number, resolution: FloorResolution): CheckPlan => {
+	if (resolution._tag === "Unbound") {
+		return {
+			_tag: "Concluded",
+			conclusion: "success",
+			floor: "n/a",
+			title: "The floor does not bind",
+			summary: `#${pr}'s diff touches no governance root, so no ${NAMESPACE} verdict is owed. This is an answer about the diff, not a discharged verdict.`,
+		};
+	}
+	if (resolution._tag === "Unresolved") {
+		const reason = resolution.outcome.stderr.at(-1) ?? "the floor could not be resolved";
+		return {
+			_tag: "Concluded",
+			conclusion: "failure",
+			floor: "unresolved",
+			title: "The floor could not be resolved",
+			summary: `${reason}\n\nUNKNOWN never passes (ADR 0092), so this concludes failure rather than waiting.`,
+		};
+	}
+	if (resolution.state === "pass") {
+		return {
+			_tag: "Concluded",
+			conclusion: "success",
+			floor: "satisfied",
+			title: "The floor is discharged at this head",
+			summary: `#${pr} carries an authorized ${NAMESPACE} PASS bound to ${resolution.sha}.`,
+		};
+	}
+	if (resolution.state === "absent") {
+		return {
+			_tag: "Pending",
+			floor: "blocked",
+			title: "Waiting for a governance verdict at this head",
+			summary: `${floorRefusalLine(pr, resolution.state, resolution.sha)}\n\nNothing is wrong yet — this check stays pending until the verdict lands, and \`fabrika governance post\` re-fires the job that turns it green.`,
+		};
+	}
+	return {
+		_tag: "Concluded",
+		conclusion: "failure",
+		floor: "blocked",
+		title: `The governance verdict at this head is ${resolution.state}`,
+		summary: floorRefusalLine(pr, resolution.state, resolution.sha),
+	};
+};
+
+const draftFor = (plan: CheckPlan, headSha: string): CheckRunDraft =>
+	plan._tag === "Pending"
+		? {_tag: "Pending", name: CHECK_RUN_NAME, headSha, title: plan.title, summary: plan.summary}
+		: {
+				_tag: "Concluded",
+				name: CHECK_RUN_NAME,
+				headSha,
+				conclusion: plan.conclusion,
+				title: plan.title,
+				summary: plan.summary,
+			};
+
+const stateOf = (resolution: FloorResolution): string =>
+	resolution._tag === "Bound" ? resolution.state : NULL_TOKEN;
+
+export const runFloorCheck = (
+	options: FloorOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		// The head and the repository are resolved before the floor is, because they are what a
+		// check-run is addressed to: without either there is nowhere to post the answer, so those two
+		// refusals are the only ones that reach the caller as a non-zero exit.
+		const bound = inspectedSha(VERB, options.sha);
+		if (typeof bound !== "string") return bound;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const resolution = yield* resolveFloor({...options, repo});
+		const plan = planFor(options.pr, resolution);
+		const relayed =
+			resolution._tag === "Unresolved" ? resolution.outcome.stderr : [...resolution.stderr];
+
+		// A check-run this head already carries is rewritten rather than duplicated, so the PR shows
+		// one row per head instead of a column of superseded ones. The exception is the backwards
+		// transition — a completed check-run being re-opened as pending — which the platform does not
+		// model: a `conclusion` already set is not cleared by an update, so that one posts a fresh run.
+		const listed = yield* listShipCheckRuns(repo, bound);
+		const held =
+			listed._tag === "Ok"
+				? (latestPerContext(listed.value.runs).find((run) => run.name === CHECK_RUN_NAME) ?? null)
+				: null;
+		const rewritable = held !== null && !(held.status === "completed" && plan._tag === "Pending");
+
+		const draft = draftFor(plan, bound);
+		const written = yield* rewritable && held !== null
+			? updateCheckRun(repo, held.id, draft)
+			: createCheckRun(repo, draft);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the check-run could not be written: ${written.reason} — the floor is resolved and nothing published it.`,
+				relayed,
+			);
+		}
+
+		const expectedStatus = plan._tag === "Pending" ? "in_progress" : "completed";
+		const expectedConclusion = plan._tag === "Pending" ? null : plan.conclusion;
+		if (
+			written.value.name !== CHECK_RUN_NAME ||
+			written.value.status !== expectedStatus ||
+			written.value.conclusion !== expectedConclusion
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${expectedStatus}/${expectedConclusion ?? NULL_TOKEN} to check-run ${written.value.id} and GitHub echoed ${written.value.status}/${written.value.conclusion ?? NULL_TOKEN} — what the PR shows is not what this run decided.`,
+				relayed,
+			);
+		}
+
+		const posted = `${VERB}: ${rewritable ? "rewrote" : "posted"} check-run ${written.value.id} — the job's own exit code no longer carries the floor (#6161).`;
+		return answer(
+			options.json
+				? JSON.stringify({
+						outcome: plan.floor,
+						sha: bound,
+						namespace: NAMESPACE,
+						state: resolution._tag === "Bound" ? resolution.state : null,
+						checkRun: {
+							id: written.value.id,
+							name: written.value.name,
+							status: written.value.status,
+							conclusion: written.value.conclusion,
+						},
+					})
+				: `check\t${written.value.status}\t${written.value.conclusion ?? NULL_TOKEN}\t${written.value.id}\nfloor\t${plan.floor}\t${bound}\nns\t${NAMESPACE}\t${stateOf(resolution)}`,
+			[...relayed, posted],
+		);
+	});

--- a/packages/fabrika-cli/src/ship/floor-check.ts
+++ b/packages/fabrika-cli/src/ship/floor-check.ts
@@ -21,13 +21,14 @@
 import {Effect, type FileSystem, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
-import {READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
 import {
 	type FloorOptions,
 	type FloorResolution,
 	floorRefusalLine,
 	NAMESPACE,
 	resolveFloor,
+	runFloor,
 } from "./floor-verb.ts";
 import {
 	type CheckRunDraft,
@@ -152,14 +153,17 @@ export const runFloorCheck = (
 > =>
 	Effect.gen(function* () {
 		// The head and the repository are resolved before the floor is, because they are what a
-		// check-run is addressed to: without either there is nowhere to post the answer, so those two
-		// refusals are the only ones that reach the caller as a non-zero exit.
+		// check-run is addressed to: without either there is nowhere to post the answer. Every non-zero
+		// exit this mode has is a seat like that one — the answer was derived and something on the way
+		// to publishing it was UNKNOWN. What the floor itself decided never reddens the job.
 		const bound = inspectedSha(VERB, options.sha);
 		if (typeof bound !== "string") return bound;
 		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
 		if (resolved._tag === "Refused") return resolved.outcome;
 		const repo = resolved.repo;
 
+		// `resolveFloor` resolves the repository again, and that second call is a pass-through rather
+		// than a second probe: it is handed the name this one already proved.
 		const resolution = yield* resolveFloor({...options, repo});
 		const plan = planFor(options.pr, resolution);
 		const relayed =
@@ -170,10 +174,19 @@ export const runFloorCheck = (
 		// transition — a completed check-run being re-opened as pending — which the platform does not
 		// model: a `conclusion` already set is not cleared by an update, so that one posts a fresh run.
 		const listed = yield* listShipCheckRuns(repo, bound);
+		if (listed._tag === "Failure") {
+			// An unreadable list is not a head carrying no row: collapsing the two would post a second
+			// check-run and quietly break the one-row-per-head invariant above. Every sibling reader of
+			// this seam refuses here too (`ship checks`, `heal-ci surface`, `governance post`), so the
+			// group holds one disposition for one read (#6161).
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot enumerate the check runs at ${bound}: ${listed.reason} — nothing was published, so the floor stays UNKNOWN rather than posting a duplicate row.`,
+				relayed,
+			);
+		}
 		const held =
-			listed._tag === "Ok"
-				? (latestPerContext(listed.value.runs).find((run) => run.name === CHECK_RUN_NAME) ?? null)
-				: null;
+			latestPerContext(listed.value.runs).find((run) => run.name === CHECK_RUN_NAME) ?? null;
 		const rewritable = held !== null && !(held.status === "completed" && plan._tag === "Pending");
 
 		const draft = draftFor(plan, bound);
@@ -221,3 +234,13 @@ export const runFloorCheck = (
 			[...relayed, posted],
 		);
 	});
+
+/**
+ * Which of the two modes `--publish-check` selects, as a value rather than a branch inside the
+ * command handler — the handler is the one surface no test in this package reaches, so a flag wired
+ * to the wrong arm would ship green (#6161).
+ */
+export const floorRunner = (
+	publishCheck: boolean,
+): ((options: FloorOptions) => ReturnType<typeof runFloor>) =>
+	publishCheck ? runFloorCheck : runFloor;

--- a/packages/fabrika-cli/src/ship/floor-check.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/floor-check.unit.test.ts
@@ -1,0 +1,269 @@
+/**
+ * The check-run mode's whole point is that ONE of the blocking states reads as waiting: `absent`
+ * means nobody has judged this head yet, and showing that as the same red a FAIL shows is what
+ * taught people to stop reading reds (#6161). So the battery below pins the conclusion map row by
+ * row, and pins the two things the polarity change must not cost — a `stale`/`fail` verdict still
+ * concludes failure, and an UNKNOWN still concludes failure rather than waiting (ADR 0092).
+ */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeSeams, type HttpReply, type Scripted, unconfigured} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {checkRuns, comments, ENV, files, HEAD, OTHER_HEAD, pull} from "./fixtures.test-support.ts";
+import {CHECK_RUN_NAME, planFor, runFloorCheck} from "./floor-check.ts";
+
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4321\/comments\?/;
+const REVIEWS = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/4321\/reviews/;
+const ACL = /^GET \S+\/repos\/o\/r\/collaborators\/[^/]+\/permission$/;
+const HEAD_CHECKS = /^GET \S+\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
+const CREATE = /^POST \S+\/repos\/o\/r\/check-runs$/;
+const UPDATE = /^PATCH \S+\/repos\/o\/r\/check-runs\/\d+$/;
+
+const NO_REVIEWS: Scripted = [REVIEWS, {status: 200, body: "[]"}];
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+const permissionServed = (permission: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({permission}),
+});
+
+/** A fabrika-tree diff — `claude-plugins/` is one of the shipped governance roots. */
+const FABRIKA_TREE: Scripted = [
+	FILES,
+	served(files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts")),
+];
+
+/** What GitHub echoes for a check-run this run just wrote. */
+const echoed = (status: string, conclusion: string | null, id = 77): HttpReply => ({
+	status: 201,
+	body: JSON.stringify({id, name: CHECK_RUN_NAME, status, conclusion}),
+});
+
+/** The head carrying no check-run of the floor's name — the first run at a fresh head. */
+const NO_HELD_CHECK: Scripted = [
+	HEAD_CHECKS,
+	{
+		status: 200,
+		body: checkRuns(1, [{name: "ci", status: "completed", conclusion: "success"}]).stdout,
+	},
+];
+
+const options = {pr: 4321, sha: HEAD, repo: null, json: false, cwd: "/repo", env: ENV};
+
+const seamsFor = (script: ReadonlyArray<Scripted>) => fakeSeams([...script, NO_REVIEWS]);
+
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const seams = seamsFor(script);
+	return Effect.runPromise(
+		Effect.provide(
+			runFloorCheck({...options, ...overrides}),
+			Layer.merge(seams.layer, unconfigured),
+		),
+	).then((outcome) => ({outcome, seams}));
+};
+
+const marker = (namespace: string, polarity: string, sha: string): string =>
+	`${namespace}: ${polarity} @ ${sha} — the clause`;
+
+/** A governance-root PR carrying exactly one comment, with the ACL answer the case wants. */
+const withVerdict = (body: string, permission = "write"): ReadonlyArray<Scripted> => [
+	[PULL, served(pull({comments: 1}))],
+	FABRIKA_TREE,
+	[COMMENTS, served(comments({id: 1, body}))],
+	[ACL, permissionServed(permission)],
+];
+
+/** What the one write in a run carried — the claim "it posted PENDING" can be read nowhere else. */
+const written = (seams: {
+	readonly requests: ReadonlyArray<string>;
+	readonly bodies: ReadonlyArray<string>;
+}) => {
+	const at = seams.requests.findIndex((call) => CREATE.test(call) || UPDATE.test(call));
+	return at === -1 ? null : JSON.parse(seams.bodies[at] ?? "{}");
+};
+
+describe("planFor is the conclusion map, whole", () => {
+	const sha = HEAD;
+	const bound = (state: string) => ({_tag: "Bound" as const, state, sha, scanned: 2, stderr: []});
+
+	it("concludes success on the two states that owe nothing", () => {
+		expect(planFor(1, {_tag: "Unbound", sha, scanned: 2, stderr: []})).toMatchObject({
+			_tag: "Concluded",
+			conclusion: "success",
+			floor: "n/a",
+		});
+		expect(planFor(1, bound("pass"))).toMatchObject({_tag: "Concluded", conclusion: "success"});
+	});
+
+	it("leaves the check PENDING on absent — the one state that is not yet, rather than wrong", () => {
+		expect(planFor(1, bound("absent"))).toMatchObject({_tag: "Pending", floor: "blocked"});
+	});
+
+	it("concludes failure on a verdict that is stale or FAIL", () => {
+		expect(planFor(1, bound("stale"))).toMatchObject({_tag: "Concluded", conclusion: "failure"});
+		expect(planFor(1, bound("fail"))).toMatchObject({_tag: "Concluded", conclusion: "failure"});
+	});
+
+	// A state word this map has never seen concludes failure for the same reason the rollup reds an
+	// unrecognised conclusion: a permissive default is guaranteed wrong exactly where nobody looked.
+	it("concludes failure on a state it has never seen", () => {
+		expect(planFor(1, bound("something-new"))).toMatchObject({
+			_tag: "Concluded",
+			conclusion: "failure",
+		});
+	});
+
+	it("concludes failure on UNKNOWN rather than waiting (ADR 0092)", () => {
+		const plan = planFor(1, {
+			_tag: "Unresolved",
+			outcome: {code: 11, stdout: "", stderr: ["ship floor: cannot read the changed-file list"]},
+		});
+		expect(plan).toMatchObject({_tag: "Concluded", conclusion: "failure", floor: "unresolved"});
+		expect(plan.summary).toContain("cannot read the changed-file list");
+	});
+});
+
+describe("runFloorCheck publishes the answer and exits 0 on having published it", () => {
+	it("leaves the check pending when no verdict has been posted at this head", async () => {
+		const {outcome, seams} = await run([
+			[PULL, served(pull({comments: 0}))],
+			FABRIKA_TREE,
+			[COMMENTS, served(comments())],
+			NO_HELD_CHECK,
+			[CREATE, echoed("in_progress", null)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(written(seams)).toMatchObject({
+			name: CHECK_RUN_NAME,
+			head_sha: HEAD,
+			status: "in_progress",
+		});
+		expect(written(seams).conclusion).toBeUndefined();
+		expect(outcome.stdout).toContain("floor\tblocked");
+	});
+
+	it("concludes success on a head-bound PASS from an authorized author", async () => {
+		const {outcome, seams} = await run([
+			...withVerdict(marker("governance", "PASS", HEAD)),
+			NO_HELD_CHECK,
+			[CREATE, echoed("completed", "success")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(written(seams)).toMatchObject({status: "completed", conclusion: "success"});
+		expect(outcome.stdout).toContain("floor\tsatisfied");
+	});
+
+	it("concludes failure on a verdict bound to another head", async () => {
+		const {outcome, seams} = await run([
+			...withVerdict(marker("governance", "PASS", OTHER_HEAD)),
+			NO_HELD_CHECK,
+			[CREATE, echoed("completed", "failure")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(written(seams)).toMatchObject({status: "completed", conclusion: "failure"});
+		expect(outcome.stdout).toContain("ns\tgovernance\tstale");
+	});
+
+	it("concludes success and says n/a when the diff touches no governance root", async () => {
+		const {outcome, seams} = await run([
+			[PULL, served(pull())],
+			[FILES, served(files("apps/web/src/a.ts", "apps/web/src/b.ts"))],
+			NO_HELD_CHECK,
+			[CREATE, echoed("completed", "success")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(written(seams)).toMatchObject({conclusion: "success"});
+		expect(outcome.stdout).toContain("floor\tn/a");
+	});
+
+	// The job relays this exit code, so an UNKNOWN that published its own red must not ALSO red the
+	// job: the red belongs on the check-run, and the job's non-zero is reserved for a failed publish.
+	it("publishes a red for an UNKNOWN floor and still exits 0", async () => {
+		const {outcome, seams} = await run([
+			[PULL, served(pull())],
+			[FILES, {status: 502, body: "{}"}],
+			NO_HELD_CHECK,
+			[CREATE, echoed("completed", "failure")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(written(seams)).toMatchObject({conclusion: "failure"});
+		expect(outcome.stdout).toContain("floor\tunresolved");
+	});
+
+	it("rewrites the check-run this head already carries instead of stacking a second", async () => {
+		const {outcome, seams} = await run([
+			...withVerdict(marker("governance", "PASS", HEAD)),
+			[
+				HEAD_CHECKS,
+				{
+					status: 200,
+					body: checkRuns(1, [
+						{name: CHECK_RUN_NAME, status: "in_progress", conclusion: null, id: 55},
+					]).stdout,
+				},
+			],
+			[UPDATE, echoed("completed", "success", 55)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(seams.requests.some((call) => UPDATE.test(call))).toBe(true);
+		expect(seams.requests.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	// An update cannot clear a conclusion the platform has already recorded, so re-opening a completed
+	// check-run as pending would silently leave the PR showing the old conclusion.
+	it("posts a fresh check-run rather than re-opening a completed one as pending", async () => {
+		const {outcome, seams} = await run([
+			[PULL, served(pull({comments: 0}))],
+			FABRIKA_TREE,
+			[COMMENTS, served(comments())],
+			[
+				HEAD_CHECKS,
+				{
+					status: 200,
+					body: checkRuns(1, [
+						{name: CHECK_RUN_NAME, status: "completed", conclusion: "failure", id: 55},
+					]).stdout,
+				},
+			],
+			[CREATE, echoed("in_progress", null)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(seams.requests.some((call) => CREATE.test(call))).toBe(true);
+		expect(seams.requests.some((call) => UPDATE.test(call))).toBe(false);
+	});
+});
+
+describe("a floor nobody published is the one thing this mode reds the job on", () => {
+	it("refuses when the check-run could not be written", async () => {
+		const {outcome} = await run([
+			...withVerdict(marker("governance", "PASS", HEAD)),
+			NO_HELD_CHECK,
+			[CREATE, {status: 403, body: '{"message":"Forbidden"}'}],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("nothing published it");
+	});
+
+	// The echo is the read-back: a check-run the PR shows in a state this run did not decide is not a
+	// published answer, and reporting it as one would put a green on a floor nobody discharged.
+	it("refuses when GitHub echoes a state this run did not decide", async () => {
+		const {outcome} = await run([
+			[PULL, served(pull({comments: 0}))],
+			FABRIKA_TREE,
+			[COMMENTS, served(comments())],
+			NO_HELD_CHECK,
+			[CREATE, echoed("completed", "success")],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses a malformed --sha before writing anything at all", async () => {
+		const {outcome, seams} = await run([], {sha: "not-a-sha"});
+		expect(outcome.code).not.toBe(0);
+		expect(seams.requests.some((call) => CREATE.test(call))).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/ship/floor-check.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/floor-check.unit.test.ts
@@ -9,9 +9,10 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeSeams, type HttpReply, type Scripted, unconfigured} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
 import {checkRuns, comments, ENV, files, HEAD, OTHER_HEAD, pull} from "./fixtures.test-support.ts";
-import {CHECK_RUN_NAME, planFor, runFloorCheck} from "./floor-check.ts";
+import {CHECK_RUN_NAME, floorRunner, planFor, runFloorCheck} from "./floor-check.ts";
+import {runFloor} from "./floor-verb.ts";
 
 const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
 const FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
@@ -265,5 +266,26 @@ describe("a floor nobody published is the one thing this mode reds the job on", 
 		const {outcome, seams} = await run([], {sha: "not-a-sha"});
 		expect(outcome.code).not.toBe(0);
 		expect(seams.requests.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	// A list nobody could read is not a head carrying no row. Reading the two as one would post a
+	// second check-run beside a row that may already be there, breaking one-row-per-head with no
+	// signal anywhere — so the read refuses like every other reader of this seam does.
+	it("refuses when the check-runs at the head could not be enumerated", async () => {
+		const {outcome, seams} = await run([
+			...withVerdict(marker("governance", "PASS", HEAD)),
+			[HEAD_CHECKS, {status: 502, body: "{}"}],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("cannot enumerate the check runs");
+		expect(seams.requests.some((call) => CREATE.test(call) || UPDATE.test(call))).toBe(false);
+	});
+});
+
+describe("--publish-check selects the mode", () => {
+	it("routes the flag to the check-run mode and its absence to the exit-code one", () => {
+		expect(floorRunner(true)).toBe(runFloorCheck);
+		expect(floorRunner(false)).toBe(runFloor);
 	});
 });

--- a/packages/fabrika-cli/src/ship/floor-verb.ts
+++ b/packages/fabrika-cli/src/ship/floor-verb.ts
@@ -17,6 +17,12 @@
  * {@link GOVERNANCE_FLOOR_UNMET}; a verdict from an author without write+ resolves `absent` through
  * the ADR 0055 ACL gate and lands there too. Only a head-bound PASS from an authorized author is
  * satisfied.
+ *
+ * **What the floor is, and how it is seated, are two things.** {@link resolveFloor} answers the
+ * first and nothing else; {@link runFloor} seats that answer on this verb's exit table, and
+ * `./floor-check.ts` seats the same answer on a check-run. Splitting them is what lets the
+ * check-run mode distinguish "not judged yet" from "judged wrong" without a second derivation of
+ * the floor to disagree with this one (#6161).
  */
 import {Effect, type FileSystem, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -43,7 +49,8 @@ import {
 
 const VERB = "ship floor";
 
-const NAMESPACE = "governance";
+/** The one namespace the floor asks `ship gate` about. */
+export const NAMESPACE = "governance";
 
 export interface FloorOptions {
 	readonly pr: number;
@@ -82,29 +89,60 @@ const governanceState = (stdout: string): string | null => {
 	return null;
 };
 
-export const runFloor = (
+/**
+ * What the floor is at one head, before any interface decides how to seat it.
+ *
+ * `Bound` carries the namespace state verbatim rather than a pass/blocked boolean: `absent` and
+ * `fail` are one refusal on the exit table and two different conclusions on a check-run, and a type
+ * that had already collapsed them could not tell them apart again.
+ */
+export type FloorResolution =
+	/** The diff touches no governance root, so the floor does not bind — never a discharged verdict. */
+	| {
+			readonly _tag: "Unbound";
+			readonly sha: string;
+			readonly scanned: number;
+			readonly stderr: ReadonlyArray<string>;
+	  }
+	/** The floor binds, and `ship gate` resolved `governance` to this state at this head. */
+	| {
+			readonly _tag: "Bound";
+			readonly state: string;
+			readonly sha: string;
+			readonly scanned: number;
+			readonly stderr: ReadonlyArray<string>;
+	  }
+	/** Nothing was proven. The refusal carries its own code and its own reason — UNKNOWN, never n/a. */
+	| {readonly _tag: "Unresolved"; readonly outcome: VerbOutcome};
+
+const unresolved = (outcome: VerbOutcome): FloorResolution => ({_tag: "Unresolved", outcome});
+
+/** The floor itself, answered once, for every interface that seats it. */
+export const resolveFloor = (
 	options: FloorOptions,
 ): Effect.Effect<
-	VerbOutcome,
+	FloorResolution,
 	never,
 	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
-		const {pr, json} = options;
+		const {pr} = options;
 		const bad = badNumber(VERB, "a pull-request number", pr);
-		if (bad !== null) return bad;
+		if (bad !== null) return unresolved(bad);
 		const bound = inspectedSha(VERB, options.sha);
-		if (typeof bound !== "string") return bound;
+		if (typeof bound !== "string") return unresolved(bound);
 
 		const governed = yield* governedRootsOr(
 			VERB,
 			options.cwd,
 			'whether the floor binds is UNKNOWN, never "n/a".',
 		);
-		if (governed._tag === "Refused") return refuse(PRECONDITION_UNKNOWN, governed.message);
+		if (governed._tag === "Refused") {
+			return unresolved(refuse(PRECONDITION_UNKNOWN, governed.message));
+		}
 
 		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
-		if (resolved._tag === "Refused") return resolved.outcome;
+		if (resolved._tag === "Refused") return unresolved(resolved.outcome);
 		const repo = resolved.repo;
 
 		const target = yield* resolvePull(VERB, repo, pr, {
@@ -112,48 +150,48 @@ export const runFloor = (
 			unknownMessage: (reason) =>
 				`${VERB}: cannot read PR #${pr} in ${repo}: ${reason} — whether the floor binds is UNKNOWN, never "n/a".`,
 		});
-		if (target._tag === "Refused") return target.outcome;
+		if (target._tag === "Refused") return unresolved(target.outcome);
 		const pull = target.pull;
 
 		const listed = yield* listPullFiles(repo, pr);
 		if (listed._tag === "Failure") {
-			return refuse(
-				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot read the changed-file list for #${pr}: ${listed.reason} — whether the floor binds is UNKNOWN, never "n/a".`,
+			return unresolved(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read the changed-file list for #${pr}: ${listed.reason} — whether the floor binds is UNKNOWN, never "n/a".`,
+				),
 			);
 		}
 		const scanned = [
 			scannedLine(VERB, listed.value.length, "changed file", `${pull.changedFiles} declared`),
 		];
 		if (listed.value.length < pull.changedFiles) {
-			return refuse(
-				INCOMPLETE_SCAN,
-				`${VERB}: received ${listed.value.length} of ${pull.changedFiles} changed files — a governance root could sit in the part nobody read.`,
-				scanned,
+			return unresolved(
+				refuse(
+					INCOMPLETE_SCAN,
+					`${VERB}: received ${listed.value.length} of ${pull.changedFiles} changed files — a governance root could sit in the part nobody read.`,
+					scanned,
+				),
 			);
 		}
 		if (listed.value.length === 0) {
-			return refuse(
-				ZERO_SCOPE,
-				`${VERB}: PR #${pr} has zero changed files — whether it touches a governance root is unanswerable (ADR 0092).`,
-				scanned,
+			return unresolved(
+				refuse(
+					ZERO_SCOPE,
+					`${VERB}: PR #${pr} has zero changed files — whether it touches a governance root is unanswerable (ADR 0092).`,
+					scanned,
+				),
 			);
 		}
 
 		if (!touchesGovernanceRoot(listed.value, governed.roots)) {
 			const clear = `${VERB}: #${pr}'s diff touches no governance root, so the floor does not bind — this is an answer about the diff, not a discharged verdict.`;
-			return answer(
-				json
-					? JSON.stringify({
-							outcome: "n/a",
-							sha: bound,
-							namespace: NAMESPACE,
-							state: null,
-							scanned: listed.value.length,
-						})
-					: `floor\tn/a\t${bound}\nns\t${NAMESPACE}\t${NULL_TOKEN}`,
-				[...scanned, clear],
-			);
+			return {
+				_tag: "Unbound",
+				sha: bound,
+				scanned: listed.value.length,
+				stderr: [...scanned, clear],
+			};
 		}
 
 		// The floor's whole resolution — marker read, ADR 0055 ACL, head-binding, in-force ordering —
@@ -172,34 +210,66 @@ export const runFloor = (
 		});
 		const relayed = [...scanned, ...gated.stderr];
 		if (gated.code !== 0) {
-			return {...gated, stderr: relayed};
+			return unresolved({...gated, stderr: relayed});
 		}
 
 		const state = governanceState(gated.stdout);
 		if (state === null) {
-			return refuse(
-				PRECONDITION_UNKNOWN,
-				`${VERB}: \`ship gate\` answered without a resolvable ${NAMESPACE} row — the floor is UNKNOWN, never discharged.`,
-				relayed,
+			return unresolved(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: \`ship gate\` answered without a resolvable ${NAMESPACE} row — the floor is UNKNOWN, never discharged.`,
+					relayed,
+				),
 			);
 		}
-		if (state !== "pass") {
+		return {_tag: "Bound", state, sha: bound, scanned: listed.value.length, stderr: relayed};
+	});
+
+/** Why a blocking state blocks, in the words the person reading the check needs. */
+export const floorRefusalLine = (pr: number, state: string, sha: string): string =>
+	`${VERB}: #${pr} touches a governance root and its ${NAMESPACE} verdict at ${sha} is ${state} — ${REMEDY[state] ?? "the floor is not discharged"} (#5408).`;
+
+export const runFloor = (
+	options: FloorOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.map(resolveFloor(options), (resolution) => {
+		if (resolution._tag === "Unresolved") return resolution.outcome;
+		if (resolution._tag === "Unbound") {
+			return answer(
+				options.json
+					? JSON.stringify({
+							outcome: "n/a",
+							sha: resolution.sha,
+							namespace: NAMESPACE,
+							state: null,
+							scanned: resolution.scanned,
+						})
+					: `floor\tn/a\t${resolution.sha}\nns\t${NAMESPACE}\t${NULL_TOKEN}`,
+				resolution.stderr,
+			);
+		}
+		if (resolution.state !== "pass") {
 			return refuse(
 				GOVERNANCE_FLOOR_UNMET,
-				`${VERB}: #${pr} touches a governance root and its ${NAMESPACE} verdict at ${bound} is ${state} — ${REMEDY[state] ?? "the floor is not discharged"} (#5408).`,
-				relayed,
+				floorRefusalLine(options.pr, resolution.state, resolution.sha),
+				resolution.stderr,
 			);
 		}
 		return answer(
-			json
+			options.json
 				? JSON.stringify({
 						outcome: "satisfied",
-						sha: bound,
+						sha: resolution.sha,
 						namespace: NAMESPACE,
-						state,
-						scanned: listed.value.length,
+						state: resolution.state,
+						scanned: resolution.scanned,
 					})
-				: `floor\tsatisfied\t${bound}\nns\t${NAMESPACE}\t${state}`,
-			relayed,
+				: `floor\tsatisfied\t${resolution.sha}\nns\t${NAMESPACE}\t${resolution.state}`,
+			resolution.stderr,
 		);
 	});

--- a/packages/fabrika-cli/src/ship/github.ts
+++ b/packages/fabrika-cli/src/ship/github.ts
@@ -26,6 +26,7 @@ import {execCapture} from "../io/exec.ts";
 import {
 	type Api,
 	ambientToken,
+	attemptOf,
 	authed,
 	authedExistence,
 	pagedEnvelope as envelopeOverHttp,
@@ -248,6 +249,92 @@ export const listShipCheckRuns = (repo: string, sha: string): Shell<Attempt<Chec
 			},
 		),
 	);
+
+/**
+ * What one check-run write says. The two statuses are separate because the platform's are: a
+ * `conclusion` is legal only once `status` reaches `completed`, and sending one alongside
+ * `in_progress` completes the run — which is exactly the pending state `ship floor --publish-check`
+ * needs to hold open ([Checks API](https://docs.github.com/en/rest/checks/runs#create-a-check-run)).
+ */
+export type CheckRunDraft =
+	| {
+			readonly _tag: "Pending";
+			readonly name: string;
+			readonly headSha: string;
+			readonly title: string;
+			readonly summary: string;
+	  }
+	| {
+			readonly _tag: "Concluded";
+			readonly name: string;
+			readonly headSha: string;
+			readonly conclusion: "success" | "failure";
+			readonly title: string;
+			readonly summary: string;
+	  };
+
+/** What the platform echoed back for a check-run this process just wrote. */
+export interface WrittenCheckRun {
+	readonly id: number;
+	readonly name: string;
+	readonly status: string;
+	readonly conclusion: string | null;
+}
+
+const checkRunBody = (draft: CheckRunDraft): Record<string, unknown> => ({
+	name: draft.name,
+	head_sha: draft.headSha,
+	status: draft._tag === "Pending" ? "in_progress" : "completed",
+	...(draft._tag === "Pending" ? {} : {conclusion: draft.conclusion}),
+	output: {title: draft.title, summary: draft.summary},
+});
+
+const toWrittenCheckRun = (body: unknown): Attempt<WrittenCheckRun> => {
+	if (
+		!isRecord(body) ||
+		typeof body.id !== "number" ||
+		typeof body.name !== "string" ||
+		typeof body.status !== "string"
+	) {
+		return fail("GitHub answered 2xx but its output is not a check run");
+	}
+	return ok({
+		id: body.id,
+		name: body.name,
+		status: body.status,
+		conclusion: typeof body.conclusion === "string" ? body.conclusion : null,
+	});
+};
+
+/** Create a check-run at a head. */
+export const createCheckRun = (
+	repo: string,
+	draft: CheckRunDraft,
+): Shell<Attempt<WrittenCheckRun>> =>
+	authed((token) =>
+		Effect.map(
+			restCall(token, {
+				method: "POST",
+				path: `repos/${repo}/check-runs`,
+				body: checkRunBody(draft),
+			}),
+			(outcome) => attemptOf(outcome, toWrittenCheckRun),
+		),
+	);
+
+/** Rewrite one check-run in place — `head_sha` is not among the fields an update may move. */
+export const updateCheckRun = (
+	repo: string,
+	id: number,
+	draft: CheckRunDraft,
+): Shell<Attempt<WrittenCheckRun>> =>
+	authed((token) => {
+		const {head_sha: _pinned, ...mutable} = checkRunBody(draft);
+		return Effect.map(
+			restCall(token, {method: "PATCH", path: `repos/${repo}/check-runs/${id}`, body: mutable}),
+			(outcome) => attemptOf(outcome, toWrittenCheckRun),
+		);
+	});
 
 /** Latest-per-context: the highest run id wins, computed over the joined pages. */
 export const latestPerContext = (

--- a/packages/fabrika-cli/src/ship/github.ts
+++ b/packages/fabrika-cli/src/ship/github.ts
@@ -313,11 +313,7 @@ export const createCheckRun = (
 ): Shell<Attempt<WrittenCheckRun>> =>
 	authed((token) =>
 		Effect.map(
-			restCall(token, {
-				method: "POST",
-				path: `repos/${repo}/check-runs`,
-				body: checkRunBody(draft),
-			}),
+			restWrite(token, "POST", `repos/${repo}/check-runs`, checkRunBody(draft)),
 			(outcome) => attemptOf(outcome, toWrittenCheckRun),
 		),
 	);
@@ -331,7 +327,7 @@ export const updateCheckRun = (
 	authed((token) => {
 		const {head_sha: _pinned, ...mutable} = checkRunBody(draft);
 		return Effect.map(
-			restCall(token, {method: "PATCH", path: `repos/${repo}/check-runs/${id}`, body: mutable}),
+			restWrite(token, "PATCH", `repos/${repo}/check-runs/${id}`, mutable),
 			(outcome) => attemptOf(outcome, toWrittenCheckRun),
 		);
 	});


### PR DESCRIPTION
The governance floor's CI check reported FAILURE for "no governance verdict posted at this head yet"
— the state every governance-root PR passes through, because the job fires on `pull_request` and so
always runs before the verdict exists. Same red as a verdict that is FAIL or bound to another head.
On 2026-08-18 five of six red open PRs were red on only this, all healthy.

`fabrika ship floor --publish-check` now writes the answer to a check-run named
`governance floor at head` instead of seating it on the job's exit code:

| Floor | Check-run |
|---|---|
| `satisfied`, `n/a` | success |
| `absent` | left `in_progress` — pending |
| `stale`, `fail` | failure |
| UNKNOWN (7 / 11 / 13) | failure |

The job then exits 0 whenever the verb published an answer; a non-zero says only that it could not
publish. `ship gate` is untouched and still refuses while a verdict is absent, `ship checks` rolls a
pending gating run up as `pending` rather than `green`, and every caller of `ship floor` without the
flag keeps its exit semantics — no code repurposed. ADR
[0318](.decisions/0318-the-governance-floor-reports-through-a-check-run.md) records the why; the
founder's mechanism ruling is
[comment 5364681459](https://github.com/kamp-us/phoenix/issues/6161#issuecomment-5364681459).

**Where to look first.** `governance post` re-fires the floor run at the head it posted to, and that
re-fire is what turns a pending check-run green. Since the job now succeeds whenever it published,
`floor-assert.ts` had to move its re-fire decision off the job's conclusion onto the check-run's
state, and onto a whole-run re-run — `rerun-failed-jobs` is refused on a run with no failed job,
which is now the ordinary shape. That coupling is the part most worth a second read.

The final acceptance criterion — proving on this PR that a pending check-run holds it out of the
merge queue before the ruleset flip — is evidence this PR produces about itself once CI runs; it is
posted as a comment here at each head.

**Round 2 repairs.** The "this module never writes a check-run" fence in
`floor-assert.unit.test.ts` now catches every method that is not a GET, so the PATCH this change set
adds cannot slip past it, and the fence is itself tested. An unreadable check-run list at the head
refuses on `11` instead of collapsing into "this head carries no row", which is the disposition every
other reader of that seam already holds. The `ship floor` contract's **Output** row and **Errors**
table now cover `--publish-check`'s three stdout lines, its `--json` keys and its three refusals, and
ADR 0318's `neutral` claim is cited to GitHub's own docs with the branch-protection sentence
qualified to the state before the ruleset flip.

Fixes #6161

## Deviations

- **Out-of-scope change** — **Said:** #6161's criteria name `ship floor`, the workflow and
  `governance post`'s re-fire. **Did:** also changed `packages/fabrika-cli/src/heal-ci/github.ts`,
  adding `rerunRun` beside `rerunFailedJobs`. **Why:** the re-fire criterion cannot hold without it —
  GitHub refuses `rerun-failed-jobs` on a run with no failed job, which is what a published-answer job
  now is. `rerunFailedJobs` itself is unchanged and `heal-ci` still uses it. **Disposition:** stated
  here.
- **Out-of-scope change** — **Said:** the criteria name no ADR and no skill docs. **Did:** added
  `.decisions/0318-…` and updated the `ship` and `governance` skills' SKILL/contract passages.
  **Why:** the docs described the old mechanism ("reds when a governance-root diff has no PASS",
  "requests a re-run of that run's failed jobs") and would have been wrong on merge; the why of a
  governed control's reporting change belongs in `.decisions/`. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** the criteria say nothing about
  `floor-assert.unit.test.ts`'s existing assertions. **Did:** rewrote its "nothing here writes a
  check-run" assertion twice — round 1 moved it from `seams.log` to `seams.requests` with a `POST`
  filter, round 2 replaced that filter with "every method that is not a GET" and extracted it as a
  named predicate with its own case. **Why:** the module now legitimately GETs `/check-runs`, so an
  unfiltered assertion would red on a read; a `POST`-only filter then let the `PATCH` this same change
  set adds through the fence the guard exists to be. Criterion 8 names the widened form.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** no criterion asks for a seam for the `--publish-check` branch.
  **Did:** moved the flag's two-arm branch out of `ship/command.ts` into `floorRunner` in
  `floor-check.ts`, and tested it. **Why:** the command handler is the one surface no test in this
  package reaches, so a flag wired to the wrong arm would have shipped green — a review finding this
  round. **Disposition:** stated here.
