### PR TITLE
fix: review and ship disagree on which review namespaces a diff requires

### DIFF
--- a/.decisions/0317-ui-lane-carries-its-own-shells.md
+++ b/.decisions/0317-ui-lane-carries-its-own-shells.md
@@ -105,7 +105,11 @@ outlier.
 - A UI-class lane reaches `shipped` with no human hand-firing a round, and no driver authoring a
   verdict.
 - `lane prove` and `ship gate` derive from the same partition, so a lane cannot leave `review` on a
-  set the merge gate will refuse.
+  set the merge gate will refuse. **Narrowed by ADR [0320](0320-the-review-bar-splits-across-two-cells-and-the-machine-decides.md)**
+  to the review *phase*: a `PASS` the machine takes into `review:ui` leaves the `review` cell on the
+  set minus the routed namespace, which that cell then proves whole. Written as stated here, this
+  line made the arm into `review:ui` unwalkable — the `PASS` that takes it was required to hold a
+  verdict only the cell it entered could produce.
 - The routing table grows but stays one table; a state that routes to no shell is still a refusal.
 - `prove` tightens **last**. Tightened before the shells and routing exist, it converts today's park
   into a stall, which is worse than the deadlock it replaces.

--- a/.decisions/0320-the-review-bar-splits-across-two-cells-and-the-machine-decides.md
+++ b/.decisions/0320-the-review-bar-splits-across-two-cells-and-the-machine-decides.md
@@ -1,0 +1,88 @@
+---
+id: 0320
+title: The review bar splits across the two review cells, and the lane's own machine decides where
+status: accepted
+date: 2026-08-21
+tags: [fabrika, lane, pipeline, review, state-machine]
+---
+
+# 0320 — The review bar splits across the two review cells, and the lane's own machine decides where
+
+**What this decides:** `lane prove` proves a `PASS` out of the plain `review` cell against the
+derived namespace set **minus** the routed namespaces, and only when this lane's own machine takes
+that very event into `review:ui`. Every other `review` `PASS` still stands on the whole set. This
+narrows ADR [0317](0317-ui-lane-carries-its-own-shells.md)'s consequence "a lane cannot leave
+`review` on a set the merge gate will refuse" from the cell to the phase.
+
+## Context
+
+0317 wired the `ui-builder` / `ui-reviewer` shells and the `build:ui` / `review:ui` states, and made
+`lane prove` require `review-ui` whenever the `ui` class is raised. That last half closed a circle.
+
+The coder template's only arm into `review:ui` is the `PASS` out of `review`, guarded on `class:ui`
+([`packages/fabrika-cli/src/lane/templates/coder.workflow.json`](../packages/fabrika-cli/src/lane/templates/coder.workflow.json)).
+So requiring `review-ui` **of that event** required a verdict from the cell the lane had not entered
+yet — the only cell that could produce one. Every rendered-surface lane refused at exit `23` and
+needed a driver to hand-spawn the ui reviewer, which is exactly the act 0317 removed
+([#6793](https://github.com/kamp-us/phoenix/issues/6793)).
+
+0317 foresaw the ordering ("`prove` tightens **last**") but not this shape: the tightening is not too
+early, it is asked of the wrong event.
+
+## Decision
+
+The bar splits across the two cells. Out of `review` a routed namespace is the next cell's; out of
+`review:ui` the whole derived set stands. `ship gate` re-derives all of it at the merge regardless,
+so the merge bar is untouched — 0317's rejected direction 2 stays rejected, and nothing here waives
+a namespace at the gate.
+
+### The deferral is derived from the machine, never from a constant
+
+The subtraction is legal exactly when this event routes into the cell that owes the work. `lane prove`
+asks the compiled cell itself (`nextLeaf` in
+[`packages/fabrika-cli/src/lane/fold.ts`](../packages/fabrika-cli/src/lane/fold.ts)), with the same
+classes the append will carry, and defers only on `review:ui`.
+
+Hardcoding the subtraction to the `review` cell was the first shape, and it was wrong in two ways
+that a reader will re-propose because the code is shorter:
+
+- **A machine with no such arm.** A `chore` workflow has no `review:ui` state
+  ([`templates/chore.workflow.json`](../packages/fabrika-cli/src/lane/templates/chore.workflow.json)),
+  so a lane on it defers to a cell that does not exist and walks to `ship`.
+- **A class nobody relayed.** The arm is guarded on `class:ui`, seeded by a reviewer's
+  `lane report … --class ui`. Omit the flag on a rendered diff and the guard does not hold: the lane
+  takes the `ship` arm, and a constant subtraction would still have dropped the namespace.
+
+In both cases the lane lands on `ship gate`'s refusal — the wasted ship dispatch and park
+[#6664](https://github.com/kamp-us/phoenix/issues/6664) set out to remove, reintroduced on the paths
+nobody was looking at. `lane prove` exists because a report can lie; making its proof depend on a
+class value supplied by that same report, with nothing checking the class routes anywhere, is the
+one thing it may not do. Reading the arm off the machine is what makes the flag's absence visible:
+no arm, no deferral, and the old floor stands unchanged.
+
+### Why not tighten `ship gate` instead, or drop the class guard
+
+Tightening the merge gate answers a different question — it already requires the full set. Dropping
+the `class:ui` guard so every lane walks through `review:ui` would send text-only PRs to a gate whose
+`render` refuses a zero-`--surface` run, turning a clean lane into a park. The class guard is 0317's
+own routing decision and stays.
+
+## Consequences
+
+- A rendered-surface lane walks `review` → `review:ui` → `ship` with no hand-spawned round.
+- A `review` `PASS` that routes anywhere else proves the whole derived set, so the pre-0317 floor is
+  intact on every machine shape and on a missing class flag.
+- `lane prove` takes the lane classes as an input (`--class`, the same closed set `lane report`
+  validates), and `lane report` hands it the classes it is about to append.
+- 0317's consequence line now reads at phase granularity: a lane cannot leave the **review phase** on
+  a set the merge gate will refuse. Leaving the `review` **cell** on a short set is legal, and only
+  toward the cell that fills it.
+- The deferred namespace is named on stderr either way — as owed by the cell being entered, or as
+  required here with the class flag as the remedy — so a refusal never leaves an operator guessing
+  which of the two it hit.
+
+## Records
+
+- Issue: https://github.com/kamp-us/phoenix/issues/6664
+- Operator-side report of the same deadlock: https://github.com/kamp-us/phoenix/issues/6793
+- Narrows: ADR [0317](0317-ui-lane-carries-its-own-shells.md)

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -483,6 +483,13 @@ very event — and every rendered-surface lane deadlocked at exit `23` until a d
 ui reviewer (#6793). Nothing reaches `ship` on less, and `ship gate` re-derives the full set at the
 merge regardless.
 
+**That split is the routing, so it never outlives it.** `prove` asks this lane's own machine which
+arm the event takes, with the classes the append will carry, and defers only into `review:ui` — so a
+lane whose machine has no such arm, and a rendered `PASS` whose class flag was never relayed, both
+owe the whole set at `review` and refuse there exactly as before
+(ADR [0320](../../../../.decisions/0320-the-review-bar-splits-across-two-cells-and-the-machine-decides.md)).
+The remedy the refusal names is the class relay, and it is the reviewer's to make.
+
 `lane prove` reads the two events a report can lie about — a `DONE` out of `build` and a `PASS` out
 of `review` — and answers `not-required` at exit `0` for every other one, so it is run on every
 event and never skipped as an optimisation. Its refusals each name a different next move:

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -471,8 +471,17 @@ no head to scope and no `ui` label to read, so the class you relay is the one th
 carries — `lane status` prints the task's `classes` when any stand, seeded from the lane document
 the plan wrote and carried forward by every event since. No `classes` key means unclassed: record
 the bare `WIP`. Once
-a head exists, `ship scope` / `review scope` name the classes it raises, and those are what you
-relay from then on. A spelling outside the closed set is refused at exit `38`, never routed.
+a head exists, `ship scope` / `review scope` name the classes it raises — one derivation, printed by
+both, so they cannot disagree (#6664) — and those are what you relay from then on. A spelling
+outside the closed set is refused at exit `38`, never routed.
+
+**The two review cells prove different halves, and that is what makes the ui arm walkable.** `lane
+prove` takes the `PASS` out of `review` against the namespaces that cell owes, leaving the routed
+`review-ui` to the cell the `PASS` routes into; the `PASS` out of `review:ui` stands on the whole
+derived set. Requiring all of it at `review` was a closed circle — the arm into `review:ui` is that
+very event — and every rendered-surface lane deadlocked at exit `23` until a driver hand-spawned the
+ui reviewer (#6793). Nothing reaches `ship` on less, and `ship gate` re-derives the full set at the
+merge regardless.
 
 `lane prove` reads the two events a report can lie about — a `DONE` out of `build` and a `PASS` out
 of `review` — and answers `not-required` at exit `0` for every other one, so it is run on every

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -31,13 +31,32 @@ Never invent one nobody named.
 fabrika review scope $pr_number
 ```
 
-<!-- anchor: NAMESPACE-SET-IS-THE-EMISSION-CHECKLIST --> The printed class set derives your
-namespaces (`review-code` / `review-doc` / `review-skill`) and is **both floor and ceiling**: a
-mixed diff gets a verdict in each class present, because one filled namespace fail-closes an
-otherwise passing PR, and a namespace outside the set is one you did not judge and must not emit.
+<!-- anchor: NAMESPACE-SET-IS-THE-EMISSION-CHECKLIST --> The printed `namespace` rows are **what this
+PR requires**, and they are the merge gate's own set — `ship scope` derives them from the same map,
+so the two verbs cannot disagree about what the PR owes. Your emission checklist is that set **minus
+every `routed` row**, and it is **both floor and ceiling**: a mixed diff gets a verdict in each class
+you own, because one filled namespace fail-closes an otherwise passing PR, and a namespace outside
+your checklist is one you did not judge and must not emit.
+
+<!-- anchor: A-ROUTED-ROW-IS-THE-HANDOFF-TRIGGER --> **A `routed` row is a namespace this PR requires
+that this gate cannot reach, and it is the handoff's trigger.** Today the one row is
+`routed\treview-ui`, raised whenever the diff changes a rendered `apps/web/src/**` surface: pixels
+are `review-ui`'s modality, its verbs are the only ones that may post that namespace, and it keeps
+its own refusals (a zero-`--surface` `render`, an evidence-required `post`). So do not judge it and
+do not emit it — and equally, do not read its absence from your verdicts as a gap in yours.
+
+**What a `routed` row costs you is one flag, not a different ending.** Carry the class it names on
+your terminal — `lane report … --class ui` — and the lane's machine takes its guarded arm from
+`review` into `review:ui`, which dispatches the rendered gate with nobody hand-spawning it. Relay
+the class the row printed; never derive one from your own reading of the diff. While no row existed,
+a reviewer read `class code` as the whole bar, PASSed bare, and the merge gate refused on a
+`review-ui` namespace nobody had been told to route — a wasted ship dispatch and a park per PR
+(#6664).
+
 `scope` also prints the head SHA, the issue reference (`fixes:<n>` / `part-of:<n>` / `-`), `self`,
 `harness`, and `governance\t<required|not-required>` — §6's trigger, and a different question from
-`harness`. Done when the set is read.
+`harness`. Governance is never a `routed` row: it is derived-required at every round and fired
+inside this run (§6). Done when the set is read.
 
 The printed head is the commit the file list was **read out of**, not a label beside it: `scope`
 fetches the PR head and reads the changed files from the object database, checking nothing out. It
@@ -224,6 +243,20 @@ Stale/Unbindable — re-review required** · **routed elsewhere** (`review-ui` /
 only). Precedence: **an unseen input blocks PASS, never FAIL** — FAIL on what you did
 see, naming the unread piece UNKNOWN; no namespace PASSes on an unseen input.
 
+**`routed elsewhere` has a mechanical trigger, and it is §1's `routed` rows against your emission
+checklist.** You end `ROUTED` when the routed rows are the *whole* required set — every namespace
+this PR derives is one you may not emit, so there is no round here to run. That is the only shape
+`ROUTED` fits, because `lane report` maps it to a park: a lane routed while you still owed a verdict
+would sit on a human instead of walking to `review:ui`.
+
+**On a mixed diff — the ordinary rendered-surface PR — you own namespaces, so your terminal is the
+ordinary `PASS`/`FAIL` and the route rides §1's class flag.** Every non-`.md` file also classes
+`code`, a rendered `.tsx` included, so a PR whose whole required set is routed is rare by
+construction; do not reach for `ROUTED` because a `routed` row is printed. Whether the diff renders
+anything at all is `review-ui`'s judgment, taken through `review-ui route`, never yours.
+`check-epic-plan` is the other route and has no row: its trigger is being handed a plan ledger
+rather than a PR.
+
 **Governance is not one of the routes, and never was a legal way to end.** `routed elsewhere` carries
 the two modality handoffs and nothing else — `review-ui` for a rendered visual, `check-epic-plan` for
 a plan ledger — each a subject this skill cannot judge at all. Governance it can and must reach: §6
@@ -241,16 +274,21 @@ in its code, with the PR as the event's evidence (#5736). `<fabrika>` is that sa
 `fabrika:` entrypoint, the one path this repo's verbs actually run from (#6012):
 
 ```bash
-node <fabrika> lane report <lane> --root <root> --token PASS --pr <pr-url>
+node <fabrika> lane report <lane> --root <root> --token PASS --pr <pr-url> --class ui
 ```
+
+`--class` is repeatable and carries §1's `routed` rows — `--class ui` on the row this skill routes.
+Omit it where no row printed; a spelling outside the closed set is refused at exit `38`.
 
 One guard is yours before a `FAIL`: record it **only when every derived namespace holds a verdict
 that still binds at the head** — a `FAIL` beside an in-flight namespace is an incomplete read the
 lane must not act on yet, so print the terminal without recording and leave the record to the
 operator's re-read. The verb refuses a token outside this vocabulary (exit `32`) rather than
-interpreting it, and it **proves a `PASS` before it records it** — every namespace the PR's diff
-derives must hold a verdict still binding at the head, read off the PR itself (exit `23` where one
-does not). A refusal is the PR disagreeing with your terminal: print the token, name the exit code,
+interpreting it, and it **proves a `PASS` before it records it** — read off the PR itself, exit `23`
+where a namespace holds no verdict still binding at the head. What it proves is what *this* cell
+owes: out of `review` a routed namespace is left to the `review:ui` cell your class flag routes
+into, and out of `review:ui` the whole derived set must stand — the merge gate re-derives all of it
+either way. A refusal is the PR disagreeing with your terminal: print the token, name the exit code,
 change nothing. Then print the terminal either way; a run whose caller named no lane prints it only
 and records nothing.
 

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -250,9 +250,10 @@ this PR derives is one you may not emit, so there is no round here to run. That 
 would sit on a human instead of walking to `review:ui`.
 
 **On a mixed diff — the ordinary rendered-surface PR — you own namespaces, so your terminal is the
-ordinary `PASS`/`FAIL` and the route rides §1's class flag.** Every non-`.md` file also classes
-`code`, a rendered `.tsx` included, so a PR whose whole required set is routed is rare by
-construction; do not reach for `ROUTED` because a `routed` row is printed. Whether the diff renders
+ordinary `PASS`/`FAIL` and the route rides §1's class flag.** On this repo that is every rendered PR:
+`ui` is an overlay rather than a bucket, so a rendered `.tsx` classes `code` **as well** and you
+always own `review-code` beside the routed row. A whole-set route is therefore unreachable here
+today, not merely rare — do not reach for `ROUTED` because a `routed` row is printed. Whether the diff renders
 anything at all is `review-ui`'s judgment, taken through `review-ui route`, never yours.
 `check-epic-plan` is the other route and has no row: its trigger is being handed a plan ledger
 rather than a PR.
@@ -274,11 +275,20 @@ in its code, with the PR as the event's evidence (#5736). `<fabrika>` is that sa
 `fabrika:` entrypoint, the one path this repo's verbs actually run from (#6012):
 
 ```bash
+node <fabrika> lane report <lane> --root <root> --token PASS --pr <pr-url>
+```
+
+**Add `--class ui` to that line only when §1 printed a `routed\treview-ui` row**, and never
+otherwise:
+
+```bash
 node <fabrika> lane report <lane> --root <root> --token PASS --pr <pr-url> --class ui
 ```
 
-`--class` is repeatable and carries §1's `routed` rows — `--class ui` on the row this skill routes.
-Omit it where no row printed; a spelling outside the closed set is refused at exit `38`.
+`--class` is repeatable and carries §1's `routed` rows and nothing else — relay what printed, never
+what you inferred. A spelling outside the closed set is refused at exit `38`, but the *right*
+spelling on a PR that raised no such row is not refused: it routes the lane into a rendered round its
+diff cannot fill.
 
 One guard is yours before a `FAIL`: record it **only when every derived namespace holds a verdict
 that still binds at the head** — a `FAIL` beside an in-flight namespace is an incomplete read the
@@ -286,9 +296,11 @@ lane must not act on yet, so print the terminal without recording and leave the 
 operator's re-read. The verb refuses a token outside this vocabulary (exit `32`) rather than
 interpreting it, and it **proves a `PASS` before it records it** — read off the PR itself, exit `23`
 where a namespace holds no verdict still binding at the head. What it proves is what *this* cell
-owes: out of `review` a routed namespace is left to the `review:ui` cell your class flag routes
-into, and out of `review:ui` the whole derived set must stand — the merge gate re-derives all of it
-either way. A refusal is the PR disagreeing with your terminal: print the token, name the exit code,
+owes, and your class flag is what decides that: a routed namespace is left to the `review:ui` cell
+only when the flag routes this very `PASS` into it, and out of `review:ui` the whole derived set must
+stand. Omit the flag on a rendered PR and the routed namespace is owed **here** — exit `23` naming
+it, with the flag as the remedy (ADR [0320](../../../../.decisions/0320-the-review-bar-splits-across-two-cells-and-the-machine-decides.md)).
+The merge gate re-derives all of it either way. A refusal is the PR disagreeing with your terminal: print the token, name the exit code,
 change nothing. Then print the terminal either way; a run whose caller named no lane prints it only
 and records nothing.
 

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -22,7 +22,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 
 | Verb | Purpose | Split test |
 |---|---|---|
-| `review scope` | the PR's head SHA, linked issue, artifact-class partition of its changed files, the `self` / `harness` flags, and whether the diff requires the `governance` namespace | partitioning paths against a fixed class map and failing closed on an empty file list is mechanical; what to do with each class is judgment |
+| `review scope` | the PR's head SHA, linked issue, artifact-class partition of its changed files, the namespace set that partition requires and which of those are routed to another gate, the `self` / `harness` flags, and whether the diff requires the `governance` namespace | partitioning paths against a fixed class map, deriving the merge gate's own required set from it, and failing closed on an empty file list is mechanical; what to do with each class is judgment |
 | `review diff` | the PR's diff bytes, with truncation refused rather than silently passed through | fetching and proving completeness is mechanical; reading the diff is the whole judgment layer |
 | `review criteria` | the linked issue's acceptance-criteria block, read through the registered `acceptance-criteria` wire format | fetch + registered parse + checkbox states are mechanical; grading a criterion is judgment |
 | `review ci` | the live CI check-run rollup at a head, fail-closed on incomplete enumeration | classifying check runs and proving the enumeration complete is mechanical (#4552, #3999); weighing a red check is judgment |
@@ -239,19 +239,34 @@ fabrika review scope 4321 [--sha <head>] [--repo <owner/name>] [--json]
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
-**Output** — machine channel. First line: `scoped\t<head-sha>\t<fixes:n|part-of:n|->`, where the
-head is the commit the file list was actually read out of and the third field is the issue
-reference — the same token `ship scope` prints. Then one line per
-present class — `class\t<name>\t<file-count>` where `<name>` is one of `code`, `doc`, `skill` —
-then two flag lines `self\t<true|false>` and `harness\t<true|false>`, then
-`governance\t<required|not-required>`.
+**Output** — machine channel, in this line order. First line:
+`scoped\t<head-sha>\t<fixes:n|part-of:n|->`, where the head is the commit the file list was actually
+read out of and the third field is the issue reference — the same token `ship scope` prints. Then one
+line per present class — `class\t<name>\t<file-count>` where `<name>` is one of `code`, `doc`,
+`skill`, `ui`. Then one `namespace\t<ns>` line per namespace the diff requires, then one
+`routed\t<ns>` line per required namespace this gate may not emit — a subset of the `namespace` rows,
+re-printed rather than removed. Then two flag lines `self\t<true|false>` and
+`harness\t<true|false>`, then `governance\t<required|not-required>`.
 
 With `--json`, an object with keys `outcome`, `head` (full 40-hex), `issue` (an object
 `{kind, number}` where `kind` is `fixes` / `part-of` / `none` and `number` is an integer, or `null`
 on `none`), `classes` (array of `{name, files}`), `self` (boolean), `harness` (boolean), `governance`
 (the string `required` or `not-required`), `scanned`
-(changed files seen), and `namespaces` (array — the derived namespace per present class, e.g.
-`["review-code","review-doc"]`).
+(changed files seen), `namespaces` (array — the required set, e.g. `["review-code","review-doc"]`),
+and `routed` (array — the subset of `namespaces` routed to another gate).
+
+**The required set is `ship scope`'s own.** Both verbs call one pair of functions over one file list
+(`partitionWithUi` + `shipNamespacesOf` in
+[`packages/fabrika-cli/src/review/classes.ts`](../../../../packages/fabrika-cli/src/review/classes.ts)),
+so they cannot report different sets for the same diff. That is why `ui` is a class here at all: the
+reviewer's set was short one namespace and the merge gate refused, once per rendered-surface PR
+(#6664). `self` and `harness` still come off the three-class partition.
+
+**`routed` is what the wider set costs, and it costs nothing else.** Today the one routed namespace
+is `review-ui`: `review` derives it, prints it, and still may not emit it — `review post`'s fence is
+the three text classes, unchanged. `governance` is never routed; it is derived-required and fired
+inside the review run (ADR 0293). What a reviewer does with a `routed` row is `SKILL.md` §1's, not
+this verb's.
 
 **The class map is a fixed path partition, stated here so two runs cannot disagree:**
 
@@ -260,8 +275,9 @@ on `none`), `classes` (array of `{name, files}`), `self` (boolean), `harness` (b
 | `skill` | `claude-plugins/**` (SKILL.md, rubric/reference files, contract specs), `.claude/**` agent and skill definitions, `skills/**`, and any file named `SKILL.md` wherever it sits — the last two rows are what keep the map honest on a repo that homes its skills elsewhere (found live by an eval run: a toy repo's `skills/deploy-notes/SKILL.md` partitioned to `doc` under the first two rows alone) |
 | `doc` | `*.md` outside `claude-plugins/**` — `.decisions/`, `.patterns/`, `.glossary/`, `reports/`, `README`/`DEVELOPMENT`, docs directories |
 | `code` | everything else — source, tests, config, workflows, manifests |
+| `ui` | a rendered `apps/web/src/**` surface — an **overlay**, not a fourth bucket: such a file is `code` as well, and is counted in both rows. It is the only class a file can hold beside another, which is why the row counts can exceed `scanned` |
 
-Every changed file maps to exactly one class, `code` the residual — a file the map cannot place
+Every changed file maps to exactly one class of the first three, `code` the residual — a file the map cannot place
 is `code`, never dropped, because an unclassified file silently excluded from every rubric is a
 review that never saw it. `self` is true when any changed path is under
 `claude-plugins/fabrika/skills/review/`. `harness` is true when any changed path is under
@@ -330,16 +346,25 @@ $ fabrika review scope 4321
 scoped	03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c	fixes:4287
 class	code	3
 class	doc	1
+namespace	review-code
+namespace	review-doc
 self	false
 harness	false
 governance	not-required
 ```
+
+A rendered surface raises `ui` beside `code`, and its namespace comes back on a `routed` row:
 
 ```
 $ fabrika review scope 4322
 scoped	6f7b834bcf1cf16fc465389d8f45cc21bd23a3fe	part-of:5434
 class	code	5
 class	doc	1
+class	ui	2
+namespace	review-code
+namespace	review-doc
+namespace	review-ui
+routed	review-ui
 self	false
 harness	false
 governance	not-required
@@ -349,6 +374,8 @@ governance	not-required
 $ fabrika review scope 4323
 scoped	6a562f751a5d4d0e2efa277286f793b7ece3a008	fixes:5599
 class	doc	1
+namespace	review-doc
+namespace	governance
 self	false
 harness	false
 governance	required
@@ -356,7 +383,7 @@ governance	required
 
 ```
 $ fabrika review scope 4321 --json
-{"outcome":"scoped","head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","issue":{"kind":"fixes","number":4287},"classes":[{"name":"code","files":3},{"name":"doc","files":1}],"self":false,"harness":false,"governance":"not-required","scanned":4,"namespaces":["review-code","review-doc"]}
+{"outcome":"scoped","head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","issue":{"kind":"fixes","number":4287},"classes":[{"name":"code","files":3},{"name":"doc","files":1}],"self":false,"harness":false,"governance":"not-required","scanned":4,"namespaces":["review-code","review-doc"],"routed":[]}
 ```
 
 **Grounding**
@@ -364,7 +391,9 @@ $ fabrika review scope 4321 --json
 - #4060 — v1's `class-probe` read 0 files and silently classified `has-code` exit 0; the zero-file
   case here is a `7` refusal.
 - #3170 — one namespace filled on a mixed diff; `namespaces` is printed as a set precisely so the
-  emission checklist is machine-derived, not remembered.
+  emission checklist is machine-derived, not remembered. It is that set minus the `routed` rows.
+- #6664 — the two verbs derived different required sets from one map, so the reviewer PASSed one
+  namespace short and the merge gate refused. `namespace` and `routed` are that fix's output.
 - v1's `classify-skills-only.sh` prints nothing on its code-PR branch and falls off the end (the
   S10 else-less classifier) — every outcome here is a token.
 - ADR 0052 — `self` is the input the skill's BASE-revision fence keys on.

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -13,10 +13,11 @@ import {Argument, Command, Flag} from "effect/unstable/cli";
 import {resolveEntrypoint} from "../delegate/entrypoint.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {SHIP_CLASS_NAMES} from "../review/classes.ts";
-import type {VerbOutcome} from "../verb.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
 import {runAssembly} from "./assembly-verb.ts";
 import {runBrief} from "./brief-verb.ts";
 import {runLaneClaim, runLaneRelease} from "./claim-verb.ts";
+import {CLASS_UNRECOGNISED} from "./codes.ts";
 import {runEmit} from "./emit-verb.ts";
 import {runHistory} from "./history-verb.ts";
 import {type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
@@ -26,7 +27,7 @@ import {runPrint} from "./print-verb.ts";
 import {runProve} from "./prove-verb.ts";
 import {runPush} from "./push-verb.ts";
 import {keyRefusal} from "./refusals.ts";
-import {PARK_CAUSE_TOKENS} from "./report.ts";
+import {classesForEvent, PARK_CAUSE_TOKENS} from "./report.ts";
 import {runReport} from "./report-verb.ts";
 import {DEFAULT_STALE_MINUTES} from "./stale.ts";
 import {runStale} from "./stale-verb.ts";
@@ -221,6 +222,7 @@ const prove = leafCommand(
 			Flag.optional,
 			Flag.withDescription("the task the event addresses; omittable on a single-task lane"),
 		),
+		classes: classFlag,
 		repo: Flag.string("repo").pipe(
 			Flag.optional,
 			Flag.withDescription(
@@ -228,13 +230,19 @@ const prove = leafCommand(
 			),
 		),
 	},
-	Effect.fn(function* ({lane, event, root, task, repo}) {
+	Effect.fn(function* ({lane, event, root, task, classes, repo}) {
+		const classed = classesForEvent(classes);
+		if (classed._tag === "Rejected") {
+			yield* emit(refuse(CLASS_UNRECOGNISED, `fabrika lane prove: ${classed.reason}.`));
+			return;
+		}
 		yield* emit(
 			yield* onKey(lane, root, (_key, ref) =>
 				runProve({
 					...ref,
 					event,
 					task: Option.getOrNull(task),
+					classes: classed.classes,
 					repo: Option.getOrNull(repo),
 					cwd: process.cwd(),
 					env: process.env,
@@ -245,7 +253,7 @@ const prove = leafCommand(
 ).pipe(
 	Command.withShortDescription("Prove a lane event against the board before recording it."),
 	Command.withDescription(
-		"Read the artifact a lane event claims — artifacts over self-reports, the rule the retired epic conductor held against a conducted branch. Two events carry a claim, and which artifact answers them is the task's shape. On a single-issue lane and on an epic run's tail: a DONE out of `build` claims an open PR whose body links the task's issue (or, for an investigation, the diagnosis comment a no-PR builder posted since the task entered build), and a PASS out of `review` claims a current-head verdict in every namespace that PR's diff derives, governance included. On an epic run's child, which opens no PR at all (ADR 0285): a DONE out of `build` claims the commits its lane branch adds over `epic/<n>` in THIS tree, and a PASS out of `review` claims a range-scoped verdict on the child issue still bound to the content that range carries now (ADR 0276). Every other event answers `not-required` at exit 0. Writes nothing — the append stays `lane transition`'s. The refusals are artifact-independent, so the range arms take no new seat. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (a lane, board or tree read failed — the proof is UNKNOWN, never proven; an epic branch this tree does not carry is UNKNOWN too), 13 (the task is not in the machine, or names no issue), 21 (the key is not a lane key), 22 (the artifact is provably not there), 23 (a required namespace has no current or still-binding verdict — re-read, record nothing), 24 (a FAIL under a claimed PASS), 25 (several open PRs link the issue, or several lane branches carry the child's commits). Example: fabrika lane prove 5673 DONE",
+		"Read the artifact a lane event claims — artifacts over self-reports, the rule the retired epic conductor held against a conducted branch. Two events carry a claim, and which artifact answers them is the task's shape. On a single-issue lane and on an epic run's tail: a DONE out of `build` claims an open PR whose body links the task's issue (or, for an investigation, the diagnosis comment a no-PR builder posted since the task entered build), and a PASS out of `review` claims a current-head verdict in every namespace that PR's diff derives, governance included — minus, and only minus, a routed namespace this very event's arm hands to a later cell of this lane's own machine (`--class ui` into `review:ui`; ADR 0320), which then proves the whole set. On an epic run's child, which opens no PR at all (ADR 0285): a DONE out of `build` claims the commits its lane branch adds over `epic/<n>` in THIS tree, and a PASS out of `review` claims a range-scoped verdict on the child issue still bound to the content that range carries now (ADR 0276). Every other event answers `not-required` at exit 0. Writes nothing — the append stays `lane transition`'s. The refusals are artifact-independent, so the range arms take no new seat. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (a lane, board or tree read failed — the proof is UNKNOWN, never proven; an epic branch this tree does not carry is UNKNOWN too), 13 (the task is not in the machine, or names no issue), 21 (the key is not a lane key), 22 (the artifact is provably not there), 23 (a required namespace has no current or still-binding verdict — re-read, record nothing), 24 (a FAIL under a claimed PASS), 25 (several open PRs link the issue, or several lane branches carry the child's commits). Exits 38 too (--class is outside the closed lane-class set). Example: fabrika lane prove 5673 DONE",
 	),
 );
 

--- a/packages/fabrika-cli/src/lane/fold.ts
+++ b/packages/fabrika-cli/src/lane/fold.ts
@@ -267,6 +267,41 @@ export const deriveStatus = (
 	return {stateValue, status: "active", context};
 };
 
+/**
+ * The leaf this task would land in if this event were recorded now, asked of the compiled cell
+ * itself — `null` where the machine holds no cell for it.
+ *
+ * `lane prove` needs the answer to know which cell owes what, and reading it off the machine rather
+ * than off a state-name list is what keeps the routing and the proof one fact: a `PASS` out of
+ * `review` that lands in `review:ui` is a `PASS` whose rendered namespace the cell it routes into
+ * owes, while the same `PASS` on a machine with no such arm — a chore workflow, or a rendered head
+ * whose reviewer relayed no class — lands in `ship` and owes the whole set here (#6664).
+ *
+ * It answers the machine's question only. Whether the event is *appendable* stays
+ * {@link applyEvent}'s, which asks several more.
+ */
+export const nextLeaf = (
+	lane: CompiledLane,
+	states: Readonly<Record<string, TaskState>>,
+	taskId: string,
+	event: string,
+	classes: ReadonlyArray<string> | null,
+): string | null => {
+	const task = lane.tasks[taskId];
+	const from = states[taskId];
+	if (task === undefined || from === undefined || !isOperatorEvent(event)) return null;
+	try {
+		const [next] = applyCell<TaskState, LaneMsg, never>(task.machine, from, {
+			type: event,
+			...(classes === null ? {} : {classes}),
+		});
+		return next.type;
+	} catch (error) {
+		if (error instanceof NoCellError) return null;
+		throw error;
+	}
+};
+
 export type TaskResolution =
 	| {readonly _tag: "Task"; readonly taskId: string}
 	| {readonly _tag: "Unresolved"; readonly reason: string};

--- a/packages/fabrika-cli/src/lane/fold.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/fold.unit.test.ts
@@ -12,6 +12,7 @@ import {
 	deriveStatus,
 	foldLog,
 	type LogEntry,
+	nextLeaf,
 	parseLog,
 	resolveTask,
 	standingCauses,
@@ -642,6 +643,38 @@ describe("the fold is deterministic and total over its inputs", () => {
 		expect(resolveTask(lane(coderWorkflow()), null)).toEqual({_tag: "Task", taskId: "issue"});
 		expect(resolveTask(lane(twoPhaseWorkflow()), null)).toMatchObject({_tag: "Unresolved"});
 		expect(resolveTask(lane(coderWorkflow()), "nope")).toMatchObject({_tag: "Unresolved"});
+	});
+});
+
+describe("nextLeaf — the arm an event would take, asked before it is recorded (#6664)", () => {
+	const atReview = () => {
+		const compiled = lane(coderWorkflow());
+		return {
+			compiled,
+			states: statesOf(
+				compiled,
+				drive(compiled, [
+					["issue", "WIP"],
+					["issue", "DONE"],
+				]),
+			),
+		};
+	};
+
+	it("routes a review PASS into `review:ui` only when the ui class rides on it", () => {
+		const {compiled, states} = atReview();
+
+		expect(nextLeaf(compiled, states, "issue", "PASS", ["ui"])).toBe("review:ui");
+		expect(nextLeaf(compiled, states, "issue", "PASS", null)).toBe("ship");
+		expect(nextLeaf(compiled, states, "issue", "PASS", ["code"])).toBe("ship");
+	});
+
+	it("answers null where the machine holds no cell for the event, rather than guessing one", () => {
+		const {compiled, states} = atReview();
+
+		expect(nextLeaf(compiled, states, "issue", "UNBLOCKED", null)).toBeNull();
+		expect(nextLeaf(compiled, states, "issue", "NOPE", null)).toBeNull();
+		expect(nextLeaf(compiled, states, "task_z", "PASS", null)).toBeNull();
 	});
 });
 

--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -240,6 +240,7 @@ export const runProve = (
 			event,
 			diagnostics,
 			governed.roots,
+			claim.defers,
 		);
 	});
 
@@ -365,11 +366,17 @@ const proveNoPull = (
 	});
 
 /**
- * Every namespace this PR's diff derives, judged at its live head.
+ * Every namespace this PR's diff derives that the state being left owes, judged at its live head.
  *
  * The derivation is `ship scope`'s own pair — the `ui`-bearing partition and the namespace map that
  * appends the `governance` floor — so the bar this proves against is the same object the merge gate
  * enforces rather than a second reading of it.
+ *
+ * `defers` is the one subtraction, and it is a routing fact rather than a relaxation: the machine
+ * enters `review:ui` on the `PASS` out of `review`, so demanding `review-ui` of that very event
+ * demanded a verdict from a cell the lane had not reached (#6664/#6793). Each review cell proves
+ * what it owes and `review:ui` proves the whole set, so nothing reaches `ship` on less — and
+ * `ship gate` re-derives the full set at the merge either way.
  *
  * On a control-plane PR the reviewer's PASS arrives through the §CP advisory carrier by design —
  * no first-line marker, the head in the body (ADR 0111/0226) — so a marker-only read would row it
@@ -393,6 +400,7 @@ const proveVerdicts = (
 	event: string,
 	diagnostics: ReadonlyArray<string>,
 	roots: ReadonlyArray<string>,
+	defers: ReadonlyArray<string>,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
 		const pull = yield* getPullRequest(repo, pr);
@@ -406,7 +414,9 @@ const proveVerdicts = (
 		if (files._tag === "Failure") {
 			return unreadable(`the changed files of #${pr}`, files.reason);
 		}
-		const required = shipNamespacesOf(partitionWithUi(files.value, roots));
+		const derived = shipNamespacesOf(partitionWithUi(files.value, roots));
+		const deferred = derived.filter((namespace) => defers.includes(namespace));
+		const required = derived.filter((namespace) => !defers.includes(namespace));
 
 		const commented = yield* listComments(repo, pr);
 		if (commented._tag === "Failure") {
@@ -476,7 +486,13 @@ const proveVerdicts = (
 			}
 		}
 
-		const notes = [...diagnostics];
+		const notes = [
+			...diagnostics,
+			...deferred.map(
+				(namespace) =>
+					`${VERB}: ${namespace} on #${pr} is owed by a later cell of this lane, not by this one — the event being proven is the arm that routes into that cell, so requiring it here is the deadlock #6664 closed.`,
+			),
+		];
 		if (advisories.length > 0) {
 			const boundary = yield* readBoundary(repo, pull.value.baseRef);
 			if (boundary._tag === "Unreadable") {

--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -26,7 +26,12 @@ import {governedRootsOr} from "../config/paths.ts";
 import {getIssue, listComments} from "../io/issues.ts";
 import {getPullRequest, listPullFiles, openPullsClosing, searchOpenPulls} from "../io/pulls.ts";
 import {readAdvisory} from "../review/advisory.ts";
-import {issueRefOf, partitionWithUi, shipNamespacesOf} from "../review/classes.ts";
+import {
+	issueRefOf,
+	partitionWithUi,
+	ROUTED_NAMESPACES,
+	shipNamespacesOf,
+} from "../review/classes.ts";
 import {bindRange, contentDigestAt, rangeContentAt} from "../review/content-binding.ts";
 import {bindHead} from "../review/head.ts";
 import {CODEOWNERS_PATH, readBoundary} from "../ship/boundary.ts";
@@ -44,7 +49,7 @@ import {
 	PROOF_IN_FLIGHT,
 	TASK_UNKNOWN,
 } from "./codes.ts";
-import {foldLog, resolveTask} from "./fold.ts";
+import {foldLog, nextLeaf, resolveTask} from "./fold.ts";
 import {
 	claimOf,
 	epicOf,
@@ -80,6 +85,13 @@ export interface ProveOptions extends LaneRef {
 	readonly event: string;
 	/** The task the event addresses; `null` resolves only on a single-task lane. */
 	readonly task: string | null;
+	/**
+	 * The lane classes the caller is about to record, exactly as `lane report` validated them —
+	 * `null` leaves the classes already standing alone, the fold's own rule (ADR 0317). They are an
+	 * input here because they pick the arm the event takes, and the arm picks which cell owes the
+	 * routed namespace (#6664).
+	 */
+	readonly classes: ReadonlyArray<string> | null;
 	readonly repo: string | null;
 	/** Where to look for `.fabrika.jsonc` — the checkout this run stands in, not the ledger root. */
 	readonly cwd: string;
@@ -122,7 +134,8 @@ export const runProve = (
 		const leaf = fold.states[taskId]?.type ?? "";
 		const event = options.event.toUpperCase();
 		const role = roleOf(taskId, epicOf(Object.keys(loaded.lane.tasks)));
-		const claim = claimOf(event, leaf, role);
+		const routing = nextLeaf(loaded.lane, fold.states, taskId, event, options.classes);
+		const claim = claimOf(event, leaf, role, routing);
 		if (claim._tag === "None") {
 			return answer(
 				JSON.stringify({proof: "not-required", event, task: taskId, state: leaf}, null, 2),
@@ -372,10 +385,11 @@ const proveNoPull = (
  * appends the `governance` floor — so the bar this proves against is the same object the merge gate
  * enforces rather than a second reading of it.
  *
- * `defers` is the one subtraction, and it is a routing fact rather than a relaxation: the machine
- * enters `review:ui` on the `PASS` out of `review`, so demanding `review-ui` of that very event
- * demanded a verdict from a cell the lane had not reached (#6664/#6793). Each review cell proves
- * what it owes and `review:ui` proves the whole set, so nothing reaches `ship` on less — and
+ * `defers` is the one subtraction, and it is a routing fact rather than a relaxation: it is non-empty
+ * only where this lane's own machine takes the deferred namespace's event into the cell that owes it,
+ * so a subtraction can never outlive the round it hands the work to (ADR 0320). Demanding `review-ui`
+ * of the very `PASS` that enters `review:ui` demanded a verdict from a cell the lane had not reached
+ * (#6664/#6793); demanding it of a `PASS` that walks to `ship` is the floor, and it still stands.
  * `ship gate` re-derives the full set at the merge either way.
  *
  * On a control-plane PR the reviewer's PASS arrives through the §CP advisory carrier by design —
@@ -486,11 +500,18 @@ const proveVerdicts = (
 			}
 		}
 
+		const unrouted = derived.filter(
+			(namespace) => ROUTED_NAMESPACES.includes(namespace) && !defers.includes(namespace),
+		);
 		const notes = [
 			...diagnostics,
 			...deferred.map(
 				(namespace) =>
-					`${VERB}: ${namespace} on #${pr} is owed by a later cell of this lane, not by this one — the event being proven is the arm that routes into that cell, so requiring it here is the deadlock #6664 closed.`,
+					`${VERB}: ${namespace} on #${pr} is owed by the cell this event routes into, not by this one — the event being proven is that arm, so requiring it here is the deadlock #6664 closed.`,
+			),
+			...unrouted.map(
+				(namespace) =>
+					`${VERB}: #${pr} derives ${namespace} and this event routes into no cell that could fill it, so it is required here — relay the class \`review scope\` printed (\`lane report … --class ui\`) if this lane's machine carries the rendered round (ADR 0320).`,
 			),
 		];
 		if (advisories.length > 0) {

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -64,18 +64,25 @@ const closingPulls = (...numbers: ReadonlyArray<number>): HttpReply =>
 		},
 	});
 
-const logLine = (event: string, at: string): string =>
-	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at})}\n`;
+const logLine = (event: string, at: string, classes?: ReadonlyArray<string>): string =>
+	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at, ...(classes === undefined ? {} : {classes})})}\n`;
 
-/** The lane in `build` (one WIP), or in `review` (WIP then DONE). */
-const laneAt = (state: "build" | "review") =>
+/**
+ * The lane in `build` (one WIP), in `review` (WIP then DONE), or in `review:ui` — which is the same
+ * path with `ui` standing from the `WIP`, so the `PASS` out of `review` took the class-guarded arm.
+ */
+const laneAt = (state: "build" | "review" | "review:ui") =>
 	fakeFs({
 		files: {
 			[WORKFLOW]: coderTemplateText(),
 			[LOG]:
 				state === "build"
 					? logLine("WIP", "2026-08-16T01:00:00Z")
-					: logLine("WIP", "2026-08-16T01:00:00Z") + logLine("DONE", "2026-08-16T02:00:00Z"),
+					: state === "review"
+						? logLine("WIP", "2026-08-16T01:00:00Z") + logLine("DONE", "2026-08-16T02:00:00Z")
+						: logLine("WIP", "2026-08-16T01:00:00Z", ["ui"]) +
+							logLine("DONE", "2026-08-16T02:00:00Z") +
+							logLine("PASS", "2026-08-16T03:00:00Z"),
 		},
 	});
 
@@ -172,7 +179,12 @@ describe("lane prove — the two events that carry a claim", () => {
 describe("lane prove — the ui class, derived exactly as `ship scope` derives it", () => {
 	const UI_FILE = served([{filename: "apps/web/src/routes/pano.tsx"}]);
 
-	it("holds a lane whose head raises the ui class and carries no review-ui verdict", async () => {
+	/**
+	 * The deadlock #6664/#6793 closed. This `PASS` **is** the arm into `review:ui`, so requiring
+	 * `review-ui` of it required a verdict from the cell it had not entered — every rendered-surface
+	 * lane needed a hand-spawned ui reviewer to get out. The next case is the floor that replaces it.
+	 */
+	it("lets a ui lane's PASS out of `review` through, so the machine can reach `review:ui`", async () => {
 		const seams = fakeSeams([
 			[CLOSERS, closingPulls()],
 			[SEARCH, nominated(4318)],
@@ -182,6 +194,24 @@ describe("lane prove — the ui class, derived exactly as `ship scope` derives i
 		]);
 
 		const out = await run(laneAt("review"), seams, "PASS");
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).evidence.namespaces).toEqual([
+			{namespace: "review-code", state: "pass", commentId: 1},
+		]);
+		expect(out.stderr.join("\n")).toContain("review-ui on #4318 is owed by a later cell");
+	});
+
+	it("holds the PASS out of `review:ui` while the lane carries no review-ui verdict", async () => {
+		const seams = fakeSeams([
+			[CLOSERS, closingPulls()],
+			[SEARCH, nominated(4318)],
+			[PULL, pull()],
+			[FILES, UI_FILE],
+			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
+		]);
+
+		const out = await run(laneAt("review:ui"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-ui (absent)");
@@ -202,7 +232,7 @@ describe("lane prove — the ui class, derived exactly as `ship scope` derives i
 			],
 		]);
 
-		const out = await run(laneAt("review"), seams, "PASS");
+		const out = await run(laneAt("review:ui"), seams, "PASS");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence.namespaces).toEqual([
@@ -246,7 +276,7 @@ describe("lane prove — the ui class, derived exactly as `ship scope` derives i
 			],
 		]);
 
-		const out = await run(laneAt("review"), seams, "PASS");
+		const out = await run(laneAt("review:ui"), seams, "PASS");
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence.namespaces).toEqual([
@@ -274,7 +304,7 @@ describe("lane prove — the ui class, derived exactly as `ship scope` derives i
 			],
 		]);
 
-		const out = await run(laneAt("review"), seams, "PASS");
+		const out = await run(laneAt("review:ui"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_IN_FLIGHT);
 		expect(out.stderr.join("\n")).toContain("review-ui (stale)");
@@ -304,7 +334,7 @@ describe("lane prove — the ui class, derived exactly as `ship scope` derives i
 			],
 		]);
 
-		const out = await run(laneAt("review"), seams, "PASS");
+		const out = await run(laneAt("review:ui"), seams, "PASS");
 
 		expect(out.code).toBe(PROOF_CONTRADICTED);
 		expect(out.stderr.join("\n")).toContain("review-ui");

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -18,7 +18,7 @@ import {
 	PROOF_CONTRADICTED,
 	PROOF_IN_FLIGHT,
 } from "./codes.ts";
-import {coderTemplateText} from "./fixtures.test-support.ts";
+import {coderTemplateText, coderWorkflow} from "./fixtures.test-support.ts";
 import {runProve} from "./prove-verb.ts";
 
 const ROOT = ".fabrika/lanes";
@@ -86,6 +86,33 @@ const laneAt = (state: "build" | "review" | "review:ui") =>
 		},
 	});
 
+/**
+ * The same lane in `review`, on a machine whose `review` `PASS` targets `ship` outright — no
+ * `class:ui` arm, and no `review:ui` state to reach. Built by collapsing the coder template's
+ * guarded array rather than hand-writing a document, so it stays the shipped machine minus exactly
+ * the one arm under test.
+ */
+const laneWithNoUiArm = () => {
+	const document = coderWorkflow() as {
+		machine: {
+			states: Record<
+				string,
+				{states: Record<string, {states: Record<string, {on: Record<string, unknown>}>}>}
+			>;
+		};
+	};
+	const states = document.machine.states.pipeline?.states.issue?.states;
+	if (states?.review === undefined) throw new Error("the coder template holds no review state");
+	states.review.on["ISSUE.PASS"] = "ship";
+	delete states["review:ui"];
+	return fakeFs({
+		files: {
+			[WORKFLOW]: JSON.stringify(document),
+			[LOG]: logLine("WIP", "2026-08-16T01:00:00Z") + logLine("DONE", "2026-08-16T02:00:00Z"),
+		},
+	});
+};
+
 const pull = (overrides: Record<string, unknown> = {}): HttpReply =>
 	served({
 		number: 4318,
@@ -122,7 +149,12 @@ const issue = (labels: ReadonlyArray<string>): HttpReply =>
 		html_url: "https://github.com/o/r/issues/5747",
 	});
 
-const run = (fs: ReturnType<typeof fakeFs>, seams: ReturnType<typeof fakeSeams>, event: string) =>
+const run = (
+	fs: ReturnType<typeof fakeFs>,
+	seams: ReturnType<typeof fakeSeams>,
+	event: string,
+	classes: ReadonlyArray<string> | null = null,
+) =>
 	Effect.runPromise(
 		Effect.provide(
 			runProve({
@@ -130,6 +162,7 @@ const run = (fs: ReturnType<typeof fakeFs>, seams: ReturnType<typeof fakeSeams>,
 				lane: "5747",
 				event,
 				task: null,
+				classes,
 				repo: null,
 				cwd: "/repo",
 				env: {CLAUDE_PIPELINE_REPO: "o/r"},
@@ -193,13 +226,57 @@ describe("lane prove — the ui class, derived exactly as `ship scope` derives i
 			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
 		]);
 
-		const out = await run(laneAt("review"), seams, "PASS");
+		const out = await run(laneAt("review"), seams, "PASS", ["ui"]);
 
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).evidence.namespaces).toEqual([
 			{namespace: "review-code", state: "pass", commentId: 1},
 		]);
-		expect(out.stderr.join("\n")).toContain("review-ui on #4318 is owed by a later cell");
+		expect(out.stderr.join("\n")).toContain(
+			"review-ui on #4318 is owed by the cell this event routes into",
+		);
+	});
+
+	/**
+	 * The floor the deferral must not lift (ADR 0320). Same rendered head, same cell — but no class
+	 * relayed, so the machine's `class:ui` arm does not hold and this `PASS` walks to `ship`. There
+	 * is no later cell to defer to, so `review-ui` is owed here and the lane is held.
+	 */
+	it("holds the same PASS when no class is relayed, because the ui arm is not the one it takes", async () => {
+		const seams = fakeSeams([
+			[CLOSERS, closingPulls()],
+			[SEARCH, nominated(4318)],
+			[PULL, pull()],
+			[FILES, UI_FILE],
+			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
+		]);
+
+		const out = await run(laneAt("review"), seams, "PASS");
+
+		expect(out.code).toBe(PROOF_IN_FLIGHT);
+		expect(out.stderr.join("\n")).toContain("review-ui (absent)");
+		expect(out.stderr.join("\n")).toContain("routes into no cell that could fill it");
+	});
+
+	/**
+	 * The other half of the same floor, and the one a class flag cannot talk its way past: a machine
+	 * whose `review` cell has no arm into `review:ui` at all — every workflow shape but the coder
+	 * template, the shipped `chore` one included. The class stands and the deferral still does not.
+	 */
+	it("holds a ui-class PASS on a machine whose review cell has no arm into review:ui", async () => {
+		const seams = fakeSeams([
+			[CLOSERS, closingPulls()],
+			[SEARCH, nominated(4318)],
+			[PULL, pull()],
+			[FILES, UI_FILE],
+			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
+		]);
+
+		const out = await run(laneWithNoUiArm(), seams, "PASS", ["ui"]);
+
+		expect(out.code).toBe(PROOF_IN_FLIGHT);
+		expect(out.stderr.join("\n")).toContain("review-ui (absent)");
+		expect(out.stderr.join("\n")).toContain("routes into no cell that could fill it");
 	});
 
 	it("holds the PASS out of `review:ui` while the lane carries no review-ui verdict", async () => {
@@ -725,6 +802,7 @@ const runEpic = (
 				lane: "4300",
 				event,
 				task,
+				classes: null,
 				repo: null,
 				cwd: "/repo",
 				env: {CLAUDE_PIPELINE_REPO: "o/r"},

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -47,8 +47,9 @@ export const REVIEW_STATE = "review";
  * taken on the `PASS` out of {@link REVIEW_STATE}, so proving that `PASS` against `review-ui` asked
  * a lane to hold a verdict only the cell it had not reached yet could produce — every rendered-surface
  * lane deadlocked at exit 23 and needed a hand-spawned reviewer to get out (#6664, #6793). Each cell
- * now proves what it owes: `review` the namespaces it can reach, `review:ui` all of them. Nothing
- * reaches `ship` on less, and `ship gate` re-derives the full set regardless.
+ * now proves what it owes: `review` the namespaces it can reach **when this arm is the one it is
+ * taking**, `review:ui` all of them. A lane that is not taking it holds the whole set at `review`,
+ * so the deferral can never outlive the routing that earns it (ADR 0320).
  */
 export const REVIEW_UI_STATE = "review:ui";
 
@@ -90,8 +91,9 @@ export type Claim =
 	| {readonly _tag: "OpenPull"}
 	/**
 	 * `defers` is the slice of the required set this cell hands to a later one, subtracted before the
-	 * proof is taken. Empty everywhere but the plain `review` cell, which defers what only
-	 * {@link REVIEW_UI_STATE} can fill.
+	 * proof is taken. Non-empty only on a `review` `PASS` this lane's own machine routes into
+	 * {@link REVIEW_UI_STATE} — the cell that then owes it. Empty everywhere else, including on a
+	 * `review` `PASS` that walks to `ship`.
 	 */
 	| {readonly _tag: "HeadVerdicts"; readonly defers: ReadonlyArray<string>}
 	| {readonly _tag: "RangeCommits"; readonly epic: number}
@@ -101,18 +103,30 @@ export type Claim =
 /**
  * What this event, recorded out of this leaf state in this role, asserts about the world.
  *
- * A child's `PASS` defers nothing: its regions carry no `review:ui` cell, so there is no later cell
- * to defer to and its range-scoped set stands whole.
+ * `next` is the leaf this event would land in, read off the caller's own machine — the one input
+ * that decides whether the plain `review` cell may defer. It defers exactly when the event routes
+ * into {@link REVIEW_UI_STATE}, so the subtraction and the routing are one fact rather than two:
+ * a machine with no such arm (a `chore` workflow), or a `PASS` whose class flag never raised `ui`
+ * and so walks straight to `ship`, defers nothing and stands on the whole derived set. A child's
+ * `PASS` defers nothing either, and for the same reason read structurally: its regions carry no
+ * `review:ui` cell at all.
  */
-export const claimOf = (event: string, leaf: string, role: LaneRole): Claim => {
+export const claimOf = (
+	event: string,
+	leaf: string,
+	role: LaneRole,
+	next: string | null = null,
+): Claim => {
 	const child = role._tag === "Child";
 	if (event === "DONE" && leaf === BUILD_STATE) {
 		return child ? {_tag: "RangeCommits", epic: role.epic} : {_tag: "OpenPull"};
 	}
 	if (event === "PASS" && leaf === REVIEW_STATE) {
-		return child
-			? {_tag: "RangeVerdict", epic: role.epic}
-			: {_tag: "HeadVerdicts", defers: ROUTED_NAMESPACES};
+		if (child) return {_tag: "RangeVerdict", epic: role.epic};
+		return {
+			_tag: "HeadVerdicts",
+			defers: next === REVIEW_UI_STATE ? ROUTED_NAMESPACES : [],
+		};
 	}
 	if (event === "PASS" && leaf === REVIEW_UI_STATE && !child) {
 		return {_tag: "HeadVerdicts", defers: []};

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -9,7 +9,9 @@
  * one verdict out — so the whole table is testable without a network and without a checkout.
  *
  * **Two events carry a claim; the other four carry none.** `DONE` out of a `build` state asserts the
- * work exists, `PASS` out of a `review` state asserts every derived namespace judged it. A
+ * work exists, `PASS` out of a review state asserts the namespaces that state owes judged it —
+ * every derived one out of `review:ui`, every one the plain `review` cell can itself reach out of
+ * `review` (see {@link REVIEW_UI_STATE} for why the two differ). A
  * `BLOCKED`, a `WIP`, an `UNBLOCKED`, a `FAIL`, a `DONE` out of `ship` or a `DONE` out of a child's
  * `integrate` asserts nothing a read could falsify — those answer {@link Claim} `None`, so a caller
  * may prove *every* event and still only pay for the two that can lie.
@@ -26,6 +28,7 @@
 
 import {issueRefsIn} from "../build/commit-message.ts";
 import type {ParentedCommit} from "../io/git.ts";
+import {ROUTED_NAMESPACES} from "../review/classes.ts";
 
 /** The branch grammar's own reader, re-exported so this module's callers take one derivation. */
 export {childLaneBranches} from "../build/lane.ts";
@@ -35,6 +38,19 @@ export const BUILD_STATE = "build";
 
 /** The leaf state a reviewer runs in — a `PASS` out of it claims a verdict that still binds. */
 export const REVIEW_STATE = "review";
+
+/**
+ * The leaf state the rendered-visual gate runs in — the second review cell, and the one whose `PASS`
+ * stands on the **whole** required set.
+ *
+ * Splitting the two cells is what makes the machine's `review → review:ui` arm walkable. That arm is
+ * taken on the `PASS` out of {@link REVIEW_STATE}, so proving that `PASS` against `review-ui` asked
+ * a lane to hold a verdict only the cell it had not reached yet could produce — every rendered-surface
+ * lane deadlocked at exit 23 and needed a hand-spawned reviewer to get out (#6664, #6793). Each cell
+ * now proves what it owes: `review` the namespaces it can reach, `review:ui` all of them. Nothing
+ * reaches `ship` on less, and `ship gate` re-derives the full set regardless.
+ */
+export const REVIEW_UI_STATE = "review:ui";
 
 /** The label a no-PR builder outcome is only legal under (`build`'s `SUCCESS-NO-PR`). */
 export const INVESTIGATION_LABEL = "type:investigation";
@@ -72,23 +88,38 @@ export const roleOf = (taskId: string, epic: number | null): LaneRole => {
 
 export type Claim =
 	| {readonly _tag: "OpenPull"}
-	| {readonly _tag: "HeadVerdicts"}
+	/**
+	 * `defers` is the slice of the required set this cell hands to a later one, subtracted before the
+	 * proof is taken. Empty everywhere but the plain `review` cell, which defers what only
+	 * {@link REVIEW_UI_STATE} can fill.
+	 */
+	| {readonly _tag: "HeadVerdicts"; readonly defers: ReadonlyArray<string>}
 	| {readonly _tag: "RangeCommits"; readonly epic: number}
 	| {readonly _tag: "RangeVerdict"; readonly epic: number}
 	| {readonly _tag: "None"; readonly why: string};
 
-/** What this event, recorded out of this leaf state in this role, asserts about the world. */
+/**
+ * What this event, recorded out of this leaf state in this role, asserts about the world.
+ *
+ * A child's `PASS` defers nothing: its regions carry no `review:ui` cell, so there is no later cell
+ * to defer to and its range-scoped set stands whole.
+ */
 export const claimOf = (event: string, leaf: string, role: LaneRole): Claim => {
 	const child = role._tag === "Child";
 	if (event === "DONE" && leaf === BUILD_STATE) {
 		return child ? {_tag: "RangeCommits", epic: role.epic} : {_tag: "OpenPull"};
 	}
 	if (event === "PASS" && leaf === REVIEW_STATE) {
-		return child ? {_tag: "RangeVerdict", epic: role.epic} : {_tag: "HeadVerdicts"};
+		return child
+			? {_tag: "RangeVerdict", epic: role.epic}
+			: {_tag: "HeadVerdicts", defers: ROUTED_NAMESPACES};
+	}
+	if (event === "PASS" && leaf === REVIEW_UI_STATE && !child) {
+		return {_tag: "HeadVerdicts", defers: []};
 	}
 	return {
 		_tag: "None",
-		why: `${event} out of "${leaf}" asserts no artifact — only DONE out of "${BUILD_STATE}" and PASS out of "${REVIEW_STATE}" do`,
+		why: `${event} out of "${leaf}" asserts no artifact — only DONE out of "${BUILD_STATE}" and PASS out of "${REVIEW_STATE}" / "${REVIEW_UI_STATE}" do`,
 	};
 };
 

--- a/packages/fabrika-cli/src/lane/prove.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove.unit.test.ts
@@ -34,7 +34,7 @@ describe("epicOf and roleOf", () => {
 describe("claimOf", () => {
 	it("claims a pull request for a DONE out of build, verdicts for a PASS out of review", () => {
 		expect(claimOf("DONE", "build", SINGLE)).toEqual({_tag: "OpenPull"});
-		expect(claimOf("PASS", "review", SINGLE)).toEqual({
+		expect(claimOf("PASS", "review", SINGLE, "review:ui")).toEqual({
 			_tag: "HeadVerdicts",
 			defers: ["review-ui"],
 		});
@@ -46,13 +46,30 @@ describe("claimOf", () => {
 	 * arm asked the lane for a verdict from the cell it had not entered (#6664/#6793).
 	 */
 	it("defers the routed namespace out of `review` and nothing out of `review:ui`", () => {
-		expect(claimOf("PASS", "review:ui", SINGLE)).toEqual({_tag: "HeadVerdicts", defers: []});
-		expect(claimOf("PASS", "review:ui", TAIL)).toEqual({_tag: "HeadVerdicts", defers: []});
+		expect(claimOf("PASS", "review:ui", SINGLE, "ship")).toEqual({
+			_tag: "HeadVerdicts",
+			defers: [],
+		});
+		expect(claimOf("PASS", "review:ui", TAIL, "ship")).toEqual({
+			_tag: "HeadVerdicts",
+			defers: [],
+		});
+	});
+
+	/**
+	 * The deferral is the routing, so a `review` `PASS` the machine sends anywhere else defers
+	 * nothing — the chore-shaped machine with no such arm, and the rendered head whose class was
+	 * never relayed, both land here (ADR 0320). Without this the subtraction outlived the round it
+	 * hands the work to, and `ship gate` was left as the only thing still asking.
+	 */
+	it("defers nothing out of `review` when the event does not route into `review:ui`", () => {
+		expect(claimOf("PASS", "review", SINGLE, "ship")).toEqual({_tag: "HeadVerdicts", defers: []});
+		expect(claimOf("PASS", "review", TAIL, null)).toEqual({_tag: "HeadVerdicts", defers: []});
 	});
 
 	it("claims the same two artifacts for an epic tail — the tail is the one PR (ADR 0285)", () => {
 		expect(claimOf("DONE", "build", TAIL)).toEqual({_tag: "OpenPull"});
-		expect(claimOf("PASS", "review", TAIL)).toEqual({
+		expect(claimOf("PASS", "review", TAIL, "review:ui")).toEqual({
 			_tag: "HeadVerdicts",
 			defers: ["review-ui"],
 		});

--- a/packages/fabrika-cli/src/lane/prove.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove.unit.test.ts
@@ -34,17 +34,38 @@ describe("epicOf and roleOf", () => {
 describe("claimOf", () => {
 	it("claims a pull request for a DONE out of build, verdicts for a PASS out of review", () => {
 		expect(claimOf("DONE", "build", SINGLE)).toEqual({_tag: "OpenPull"});
-		expect(claimOf("PASS", "review", SINGLE)).toEqual({_tag: "HeadVerdicts"});
+		expect(claimOf("PASS", "review", SINGLE)).toEqual({
+			_tag: "HeadVerdicts",
+			defers: ["review-ui"],
+		});
+	});
+
+	/**
+	 * The two review cells prove different halves, and only that split makes the machine's
+	 * `review --PASS--> review:ui` arm walkable: proving `review-ui` of the event that *takes* the
+	 * arm asked the lane for a verdict from the cell it had not entered (#6664/#6793).
+	 */
+	it("defers the routed namespace out of `review` and nothing out of `review:ui`", () => {
+		expect(claimOf("PASS", "review:ui", SINGLE)).toEqual({_tag: "HeadVerdicts", defers: []});
+		expect(claimOf("PASS", "review:ui", TAIL)).toEqual({_tag: "HeadVerdicts", defers: []});
 	});
 
 	it("claims the same two artifacts for an epic tail — the tail is the one PR (ADR 0285)", () => {
 		expect(claimOf("DONE", "build", TAIL)).toEqual({_tag: "OpenPull"});
-		expect(claimOf("PASS", "review", TAIL)).toEqual({_tag: "HeadVerdicts"});
+		expect(claimOf("PASS", "review", TAIL)).toEqual({
+			_tag: "HeadVerdicts",
+			defers: ["review-ui"],
+		});
 	});
 
 	it("claims a range for a child, which never opens a PR to claim", () => {
 		expect(claimOf("DONE", "build", CHILD)).toEqual({_tag: "RangeCommits", epic: 5800});
 		expect(claimOf("PASS", "review", CHILD)).toEqual({_tag: "RangeVerdict", epic: 5800});
+	});
+
+	/** A child's regions carry no `review:ui` cell, so its range-scoped set has nowhere to defer to. */
+	it("claims nothing for a child out of `review:ui`, a cell its regions do not have", () => {
+		expect(claimOf("PASS", "review:ui", CHILD)._tag).toBe("None");
 	});
 
 	it("claims nothing for the events no read can falsify, in either shape", () => {

--- a/packages/fabrika-cli/src/lane/report-verb.ts
+++ b/packages/fabrika-cli/src/lane/report-verb.ts
@@ -100,6 +100,9 @@ export const runReport = <R>(
 			lane: options.lane,
 			event: resolved.event,
 			task: task.taskId,
+			// The same classes the append carries, so the proof asks about the arm this event actually
+			// takes rather than the one the lane stood on before it (#6664).
+			classes: classed.classes,
 			repo: options.repo,
 			cwd: options.cwd,
 			env: options.env,

--- a/packages/fabrika-cli/src/lane/report-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report-verb.unit.test.ts
@@ -207,11 +207,26 @@ describe("lane report — the append is proof-gated", () => {
 				lane: "42",
 				event: "DONE",
 				task: "issue",
+				classes: null,
 				repo: "kamp-us/phoenix",
 				cwd: "/repo",
 				env: {},
 			},
 		]);
+	});
+
+	/**
+	 * The classes go to the prover as well as to the log, because they pick the arm the event takes
+	 * and the arm picks which cell owes the routed namespace (#6664). A prover asked without them
+	 * would answer about a different transition than the one being appended.
+	 */
+	it("hands the prover the same classes the append carries", async () => {
+		const fs = laneAt(LOG_AT.review);
+		const prover = fakeProver();
+
+		const out = await run(fs, "PASS", {prover, classes: ["ui"]});
+		expect(out.code).toBe(0);
+		expect(prover.asked[0]).toMatchObject({event: "PASS", classes: ["ui"]});
 	});
 
 	it("refuses on the prover's own code with the log byte-identical", async () => {

--- a/packages/fabrika-cli/src/review/classes.ts
+++ b/packages/fabrika-cli/src/review/classes.ts
@@ -83,17 +83,26 @@ export const partition = (files: ReadonlyArray<string>): Partition => {
 	};
 };
 
+/**
+ * The namespaces `review post` may emit — narrower than what a PR *requires*, and deliberately so.
+ * The required set is {@link shipNamespacesOf}'s; this is the image the emit fence checks against.
+ */
 export const namespacesOf = (result: Partition): ReadonlyArray<string> =>
 	result.classes.map((entry) => namespaceOf(entry.name));
 
 /**
- * The `ui` class, which `ship scope` derives **in addition to** the three above.
+ * The `ui` class, which extends the three above.
  *
  * It lives here rather than in a second copy under `ship/` so the two groups partition one map: v1
  * printed the class set from one derivation and hand-copied it into another, and the copy dropped a
- * class on a live PR (#4730). `review scope` does not print it — its rubric has no `ui` row — but
- * the rows and their order are shared, which is the property that keeps ship and review from
- * disagreeing about what a file is.
+ * class on a live PR (#4730). Both `review scope` and `ship scope` print these rows, in this order.
+ *
+ * `review scope` printing `ui` is not `review` growing a rendered rubric. It still emits no
+ * `review-ui` verdict — {@link namespacesOf} over {@link CLASS_NAMES} is the narrower image
+ * `review post` fences on, and that fence is untouched. What the two verbs must agree on is what a
+ * file is *and* what the merge gate will require: while only the ship side derived `ui`, a reviewer
+ * read its own short set as the whole bar, PASSed, and the gate then refused on a namespace nobody
+ * had been told to route (#6664).
  */
 export const SHIP_CLASS_NAMES = [...CLASS_NAMES, "ui"] as const;
 export type ShipClassName = (typeof SHIP_CLASS_NAMES)[number];
@@ -160,6 +169,24 @@ export const shipNamespacesOf = (result: ShipPartition): ReadonlyArray<string> =
 	const classes = result.classes.map((entry) => `review-${entry.name}`);
 	return result.governance ? [...classes, "governance"] : classes;
 };
+
+/**
+ * The namespaces a derived set carries that the text-review gate hands to another modality instead
+ * of emitting.
+ *
+ * `review-ui` is the whole list, and `governance` is deliberately not on it: a `governance:
+ * required` round fires inside the review run and no terminal ends that run with the namespace
+ * un-fired (ADR 0293). Routing is the *other* shape — a subject `review` cannot judge at all, whose
+ * verdict only the `review-ui` group's own verbs may post.
+ *
+ * It reads a namespace list rather than a partition so both sides of one lane ask it the same
+ * question: `review scope` prints the row a reviewer routes on, and `lane prove` subtracts it from
+ * what a `PASS` out of the plain `review` cell has to stand on (#6664).
+ */
+export const ROUTED_NAMESPACES: ReadonlyArray<string> = ["review-ui"];
+
+export const routedNamespacesOf = (namespaces: ReadonlyArray<string>): ReadonlyArray<string> =>
+	namespaces.filter((name) => ROUTED_NAMESPACES.includes(name));
 
 /**
  * The closed namespace vocabulary `ship gate --require` admits.

--- a/packages/fabrika-cli/src/review/scope-agreement.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-agreement.unit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * `review scope` and `ship scope` over one file list, compared row for row.
+ *
+ * The two verbs live in different groups, read the changed files off different seams (git for
+ * review, the pulls API for ship) and print different surrounding fields, so nothing but a test that
+ * runs *both* catches them drifting. While only the ship side derived `ui`, a reviewer on a rendered
+ * diff was told `review-code` was the whole bar, PASSed, and `ship gate` then refused a `review-ui`
+ * namespace nobody had routed — one wasted ship dispatch and a park per PR (#6664).
+ */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeSeams, type HttpReply, type Scripted, unconfigured} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	branchRules,
+	CODEOWNERS,
+	ENV,
+	repositoryServed,
+	files as shipFiles,
+	pull as shipPull,
+} from "../ship/fixtures.test-support.ts";
+import {runScope as runShipScope} from "../ship/scope-verb.ts";
+import {binding, PATHS_AT, paths, pull as reviewPull} from "./fixtures.test-support.ts";
+import {runScope as runReviewScope} from "./scope-verb.ts";
+
+/** One mixed diff: a worker source file, a doc, and a rendered surface beside its own test. */
+const CHANGED = [
+	"apps/web/worker/cart.ts",
+	"README.md",
+	"apps/web/src/components/layout/Topbar.tsx",
+	"apps/web/src/components/layout/Topbar.test.tsx",
+] as const;
+
+const served = (result: ExecResult): HttpReply => ({status: 200, body: result.stdout});
+
+const PULL = /^GET \S+\/repos\/o\/r\/pulls\/4321$/;
+const SHIP_FILES = /^GET \S+\/repos\/o\/r\/pulls\/4321\/files\?/;
+const OWNERS = /contents\/\.github\/CODEOWNERS/;
+const RULES = /^GET \S+\/repos\/o\/r\/rules\/branches\/main/;
+const REPO = /^GET https:\/\/api\.github\.com\/repos\/o\/r$/;
+
+const namespaceRows = (stdout: string): ReadonlyArray<string> =>
+	stdout
+		.split("\n")
+		.filter((line) => line.startsWith("namespace\t"))
+		.map((line) => line.slice("namespace\t".length));
+
+const reviewScope = (...changed: ReadonlyArray<string>) =>
+	Effect.runPromise(
+		Effect.provide(
+			runReviewScope({
+				pr: 4321,
+				sha: null,
+				repo: null,
+				json: false,
+				cwd: "/repo",
+				env: {CLAUDE_PIPELINE_REPO: "o/r"},
+			}),
+			Layer.merge(
+				fakeSeams([
+					[PULL, served(reviewPull({changedFiles: changed.length}))],
+					...binding(),
+					[PATHS_AT(), paths(...changed)],
+				]).layer,
+				unconfigured,
+			),
+		),
+	);
+
+const shipScope = (...changed: ReadonlyArray<string>) =>
+	Effect.runPromise(
+		Effect.provide(
+			runShipScope({pr: 4321, repo: null, json: false, cwd: "/repo", env: ENV}),
+			Layer.merge(
+				fakeSeams([
+					[PULL, served(shipPull({changedFiles: changed.length}))],
+					[SHIP_FILES, served(shipFiles(...changed))],
+					[OWNERS, {status: 200, body: CODEOWNERS}],
+					[RULES, served(branchRules("pull_request"))],
+					[REPO, repositoryServed()],
+				] as ReadonlyArray<Scripted>).layer,
+				unconfigured,
+			),
+		),
+	);
+
+describe("review scope and ship scope over one file list", () => {
+	it("derive the same required-namespace set from a mixed code + ui diff", async () => {
+		const review = await reviewScope(...CHANGED);
+		const ship = await shipScope(...CHANGED);
+
+		expect(review.code).toBe(0);
+		expect(ship.code).toBe(0);
+		expect(namespaceRows(review.stdout)).toEqual(["review-code", "review-doc", "review-ui"]);
+		expect(namespaceRows(review.stdout)).toEqual(namespaceRows(ship.stdout));
+	});
+
+	it("names `review-ui` routed on the review side — derived there, emitted only by `review-ui`", async () => {
+		const review = await reviewScope(...CHANGED);
+
+		expect(review.stdout).toContain("class\tui\t1");
+		expect(review.stdout).toContain("routed\treview-ui");
+	});
+
+	it("routes nothing when the diff raises no ui class", async () => {
+		const review = await reviewScope("apps/web/worker/cart.ts");
+
+		expect(review.stdout).not.toContain("routed\t");
+		expect(namespaceRows(review.stdout)).toEqual(["review-code"]);
+	});
+});

--- a/packages/fabrika-cli/src/review/scope-verb.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.ts
@@ -1,6 +1,18 @@
 /**
  * `review scope` — the head SHA, the linked issue, the artifact-class partition of the PR's changed
- * files, the `self` / `harness` flags, and the `governance` requirement.
+ * files, the namespaces they require, the `self` / `harness` flags, and the `governance`
+ * requirement.
+ *
+ * **The class rows and the namespace rows are `ship scope`'s own derivation, printed here too** —
+ * `partitionWithUi` + `shipNamespacesOf`, the same objects the merge gate enforces. The two verbs
+ * cannot answer differently about one file list, because there is one answer. While this side
+ * partitioned without `ui`, a reviewer on a rendered diff derived `review-code` alone, PASSed, and
+ * `ship gate` refused the `review-ui` namespace nobody had routed (#6664).
+ *
+ * The wider set does **not** widen what this gate emits. `review post`'s fence is `namespacesOf` over
+ * the three text classes and is untouched, and every derived namespace this skill cannot emit is
+ * re-printed on its own `routed` row — the reviewer's trigger to hand the round to `review-ui` under
+ * that skill's `routed elsewhere` terminal.
  *
  * The `governance` line reads {@link touchesGovernanceRoot} over this repo's own `governedRoots` —
  * the same derivation `governance scope` prints, over the same declared list, imported rather than
@@ -27,9 +39,11 @@ import {diffRangePaths} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	issueRefOf,
-	namespacesOf,
 	partition,
+	partitionWithUi,
 	renderIssueRef,
+	routedNamespacesOf,
+	shipNamespacesOf,
 	touchesGovernanceRoot,
 } from "./classes.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
@@ -115,7 +129,10 @@ export const runScope = (
 			);
 		}
 
-		const result = partition(files);
+		const flags = partition(files);
+		const result = partitionWithUi(files, roots.roots);
+		const namespaces = shipNamespacesOf(result);
+		const routed = routedNamespacesOf(namespaces);
 		const governance = touchesGovernanceRoot(files, roots.roots) ? "required" : "not-required";
 		const issue = issueRefOf(pull.body);
 		if (json) {
@@ -125,11 +142,12 @@ export const runScope = (
 					head: head.sha,
 					issue,
 					classes: result.classes,
-					self: result.self,
-					harness: result.harness,
+					self: flags.self,
+					harness: flags.harness,
 					governance,
 					scanned: result.scanned,
-					namespaces: namespacesOf(result),
+					namespaces,
+					routed,
 				}),
 				diagnostics,
 			);
@@ -138,8 +156,10 @@ export const runScope = (
 			[
 				`scoped\t${head.sha}\t${renderIssueRef(issue, NULL_TOKEN)}`,
 				...result.classes.map((entry) => `class\t${entry.name}\t${entry.files}`),
-				`self\t${result.self}`,
-				`harness\t${result.harness}`,
+				...namespaces.map((namespace) => `namespace\t${namespace}`),
+				...routed.map((namespace) => `routed\t${namespace}`),
+				`self\t${flags.self}`,
+				`harness\t${flags.harness}`,
 				`governance\t${governance}`,
 			].join("\n"),
 			diagnostics,

--- a/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
@@ -73,7 +73,7 @@ const happy = (shape: Parameters<typeof pull>[0] = {}): ReadonlyArray<Scripted> 
 ];
 
 describe("runScope", () => {
-	it("prints the head, the linked issue, the present classes, the flags and the governance token", async () => {
+	it("prints the head, the linked issue, the present classes, the namespaces, the flags and the governance token", async () => {
 		const out = await run(happy());
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
@@ -81,6 +81,8 @@ describe("runScope", () => {
 				`scoped\t${HEAD}\tfixes:4287`,
 				"class\tcode\t1",
 				"class\tdoc\t1",
+				"namespace\treview-code",
+				"namespace\treview-doc",
 				"self\tfalse",
 				"harness\tfalse",
 				"governance\tnot-required",


### PR DESCRIPTION
`review scope` and `ship scope` partitioned the same diff over one shared map but asked it two different questions, and only the ship side knew about `ui`. On any PR touching a rendered surface the reviewer derived a set short one namespace, PASSed, and the merge gate refused — one wasted ship dispatch and a park, every time.

Three changes close it.

**`review scope` derives what the gate derives.** It now calls `partitionWithUi` + `shipNamespacesOf` — literally `ship scope`'s pair — and prints the `class` and `namespace` rows off them. The two verbs cannot answer differently about one file list because there is one answer. `self` / `harness` still come off the plain partition; the `governance` line is unchanged.

The wider set does not widen what `review` emits. `review post`'s fence is still `namespacesOf` over the three text classes, untouched, and every derived namespace this gate cannot emit is re-printed on its own `routed` row. `review`'s SKILL.md states the trigger that row is, and `contract.md`'s `review scope` section now documents the grammar the verb actually prints — the line order, the `ui` class, the `routed` row and the `--json` key.

**`lane prove` proves each review cell against what that cell owes.** The machine enters `review:ui` on the `PASS` out of `review`, so requiring `review-ui` of that very event required a verdict from the cell the lane had not reached — a closed circle that deadlocked every rendered-surface lane at exit `23` until a driver hand-spawned the ui reviewer (#6793).

**The deferral is derived from the machine, not hardcoded to the cell.** `lane prove` asks this lane's own compiled cell which arm the event takes, with the classes the append will carry (`nextLeaf` in `src/lane/fold.ts`), and defers only into `review:ui`. So the two paths a constant would have dropped the namespace on stay fail-closed exactly as before: a machine with no such arm — the shipped `chore` template is one — and a rendered head whose reviewer never relayed `--class ui`, which makes the `class:ui` guard false and sends the `PASS` to `ship`. Both refuse at `review` with the class relay named as the remedy. `ship gate` re-derives the full set at the merge either way.

That splits ADR 0317's "a lane cannot leave `review` on a set the merge gate will refuse" from the cell to the phase, so it is recorded: ADR 0320, with a pointer appended to 0317's consequence line so a reader of 0317 alone is not misled.

Reviewers: `src/lane/prove.ts`'s `claimOf` is the one place the bar moves, and it moves only where the machine routes. `src/lane/prove-verb.unit.test.ts` covers all four cases — the `PASS` out of `review` deferring on a relayed `ui` class, the same `PASS` held when no class is relayed, a ui-class `PASS` held on a machine with no `review:ui` arm, and the `PASS` out of `review:ui` held at `PROOF_IN_FLIGHT` while `review-ui` is empty.

Fixes #6664

## Deviations

- **Out-of-scope change** — **Said:** #6664 names the two scope verbs and `review`'s SKILL.md.
  **Did:** also split the review claim in `lane/prove.ts` + `lane/prove-verb.ts`, added `nextLeaf` to
  `lane/fold.ts`, gave `lane prove` a `--class` flag, and added paragraphs to `operate`'s SKILL.md.
  **Why:** acceptance criterion 1 requires the `review-ui` round to be dispatched with no human
  hand-dispatch, and the scope fix alone does not reach it — the machine's only arm into `review:ui`
  is a `PASS` that `lane prove` refused at exit `23` until `review-ui` was already bound. This is the
  same defect #6793 filed from the operator's side. **Disposition:** stated here; #6793 should be
  read against this PR before it is worked.
- **Governing-ADR departure** — **Said:** ADR 0317's consequence is that a lane cannot leave `review`
  on a set the merge gate will refuse. **Did:** a `PASS` the machine routes into `review:ui` leaves
  the `review` cell on the set minus `review-ui`. **Why:** written at cell granularity that line makes
  the arm into `review:ui` unwalkable — the event that takes it is the event that was required to hold
  the verdict only that cell can produce. **Disposition:** recorded as ADR 0320, with a pointer
  appended under 0317's own consequence line rather than a rewrite of it.
- **Pre-existing test or fixture changed** — **Said:** nothing about the existing ui-class proof
  cases. **Did:** retargeted four cases in `src/lane/prove-verb.unit.test.ts` from the `review` cell
  to a new `review:ui` lane fixture, flipped the fifth to assert the `PASS` now goes through with the
  class relayed, and added the `classes` field to two `ProveOptions` fixtures and one prover
  assertion in `src/lane/report-verb.unit.test.ts`. **Why:** those cases encoded the deadlock as the
  expected behaviour, so they are the assertions this issue changes. **Disposition:** stated here;
  the floor they guarded is re-asserted one cell later against `review:ui`, and on both unrouted
  paths at `review` itself.
- **Known defect left unfixed** — **Said:** make `review`'s `routed elsewhere (review-ui)` terminal
  reachable. **Did:** stated its trigger, but the terminal stays unreachable on this repo.
  **Why:** `ui` is an overlay rather than a bucket — a rendered `.tsx` classes `code` as well, so the
  routed rows can never be the whole required set. Routing the round as a terminal would also be
  wrong on a mixed diff: `lane report` maps `ROUTED` to a park, the opposite of the dispatch this
  issue asks for. **Disposition:** stated here and in the skill text, which now says
  unreachable-today rather than rare.
