### PR TITLE
chore: gh-api's restRead cannot send a request body, and every phase-2 port needs one

### DIFF
--- a/packages/fabrika-cli/src/io/gh-api.ts
+++ b/packages/fabrika-cli/src/io/gh-api.ts
@@ -28,6 +28,7 @@ import {Effect, Option} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import {execRecord} from "./exec.ts";
 import {type Attempt, type Failure, fail, type Ok, ok, type Shell} from "./git.ts";
 import {absent, type Existence, present, unknown} from "./issues.ts";
@@ -164,27 +165,53 @@ const headersFor = (token: string, accept: string = JSON_ACCEPT): Record<string,
 	"user-agent": "fabrika-cli",
 });
 
-const send = (request: HttpClientRequest.HttpClientRequest): Api<Rest> =>
+/** One response read into whatever shape its media type has, or the reason none arrived. */
+export type Served<A> =
+	| {
+			readonly _tag: "Response";
+			readonly status: number;
+			readonly headers: Readonly<Record<string, string>>;
+			readonly value: A;
+	  }
+	| {readonly _tag: "Unreachable"; readonly reason: string};
+
+const served = <A>(
+	request: HttpClientRequest.HttpClientRequest,
+	read: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<A, unknown>,
+): Api<Served<A>> =>
 	HttpClient.execute(request).pipe(
 		Effect.flatMap((response) =>
-			response.text.pipe(
-				Effect.map(
-					(text): Rest => ({
-						_tag: "Response",
-						status: response.status,
-						headers: response.headers,
-						body: parseJson(text),
-						text,
-					}),
-				),
+			Effect.map(
+				read(response),
+				(value): Served<A> => ({
+					_tag: "Response",
+					status: response.status,
+					headers: response.headers,
+					value,
+				}),
 			),
 		),
 		Effect.catch((error: unknown) =>
-			Effect.succeed<Rest>({
+			Effect.succeed<Served<A>>({
 				_tag: "Unreachable",
 				reason: `the GitHub API could not be reached: ${String(error)}`,
 			}),
 		),
+	);
+
+const send = (request: HttpClientRequest.HttpClientRequest): Api<Rest> =>
+	Effect.map(
+		served(request, (response) => response.text),
+		(outcome): Rest =>
+			outcome._tag === "Unreachable"
+				? outcome
+				: {
+						_tag: "Response",
+						status: outcome.status,
+						headers: outcome.headers,
+						body: parseJson(outcome.value),
+						text: outcome.value,
+					},
 	);
 
 /** What a call is, beyond its path: the method, an optional JSON body, an optional `Accept`. */
@@ -222,6 +249,22 @@ export const restRead = (token: string, method: "GET" | "POST", path: string): A
 	restCall(token, {method, path});
 
 /**
+ * A read whose answer is bytes — the run-evidence artifact zip, and nothing else today.
+ *
+ * It is separate from {@link restCall} rather than a flag on it because {@link Rest} carries a
+ * parsed body and a decoded `text`, and a zip decoded as UTF-8 is corrupt rather than merely
+ * unparsed. The caller still reads `status` before the bytes: a 503 body saved as `.zip` is not a
+ * bundle.
+ */
+export const restBytes = (token: string, path: string, accept?: string): Api<Served<Uint8Array>> =>
+	served(
+		HttpClientRequest.get(endpoint(path)).pipe(
+			HttpClientRequest.setHeaders(headersFor(token, accept)),
+		),
+		(response) => Effect.map(response.arrayBuffer, (buffer) => new Uint8Array(buffer)),
+	);
+
+/**
  * Run `use` under the ambient credential and the ambient transport, or hand back the refusal that
  * says there is no credential.
  *
@@ -246,7 +289,8 @@ export const authedExistence = <A>(
 	});
 
 /**
- * One REST call carrying a JSON body — the write half of {@link restRead}.
+ * One REST call carrying a JSON body — the write half of {@link restRead}. The body is optional
+ * because a `DELETE` has none, and {@link RestCall} omits an absent one rather than sending `null`.
  *
  * The body travels as JSON on the wire, which is what retires the `gh`-era `-f key=value` argv
  * shape and the `-f body=@file` scar with it: `@` made `gh` read the value as a *path*, so a
@@ -257,7 +301,7 @@ export const restWrite = (
 	token: string,
 	method: "POST" | "PATCH" | "PUT" | "DELETE",
 	path: string,
-	body: Readonly<Record<string, unknown>>,
+	body?: Readonly<Record<string, unknown>>,
 ): Api<Rest> => restCall(token, {method, path, body});
 
 const refusalText = (outcome: Rest & {_tag: "Response"}): string =>
@@ -440,6 +484,9 @@ export const pagedEnvelope = (
 			entries.push(...body[key]);
 			if (!declaresNextPage(outcome.headers)) return ok({declared, entries, exhausted: true});
 		}
+		// Unreachable at runtime — page one refuses without a numeric `total_count`, so a loop that
+		// ran at all set `declared`. Kept as a type-narrowing device: TypeScript does not narrow
+		// across the loop, and dropping the branch reds `EnvelopeRead.declared: number`.
 		return declared === null
 			? statusless("GitHub answered 200 and printed no envelope at all")
 			: ok({declared, entries, exhausted: false});

--- a/packages/fabrika-cli/src/io/gh-api.unit.test.ts
+++ b/packages/fabrika-cli/src/io/gh-api.unit.test.ts
@@ -13,8 +13,10 @@ import {
 	pagedWithLinkProof,
 	type Rest,
 	resolveToken,
+	restBytes,
 	restCall,
 	restRead,
+	restWrite,
 } from "./gh-api.ts";
 import {fail, ok} from "./git.ts";
 
@@ -330,6 +332,60 @@ describe("restCall — the write leg", () => {
 		expect(http.headers[0]?.accept).toBe("application/vnd.github.v3.diff");
 		expect(result._tag === "Response" && result.body).toBeNull();
 		expect(result._tag === "Response" && result.text).toContain("diff --git");
+	});
+});
+
+describe("the credential reaches the transport", () => {
+	// `headersFor` is the only place the token is attached, and it is attached nowhere a response
+	// assertion can see. Without these, dropping the `setHeaders` pipe leaves the suite green.
+	it("attaches `authorization` on a read", async () => {
+		const http = fakeHttp([[/repos\/o\/r$/, served(200, {default_branch: "main"})]]);
+		await Effect.runPromise(Effect.provide(restRead(TOKEN, "GET", "repos/o/r"), http.layer));
+		expect(http.headers[0]?.authorization).toBe(`token ${TOKEN}`);
+	});
+
+	it("attaches `authorization` on a write", async () => {
+		const http = fakeHttp([[/issues\/9$/, served(200, {number: 9})]]);
+		await Effect.runPromise(
+			Effect.provide(restWrite(TOKEN, "PATCH", "repos/o/r/issues/9", {body: "x"}), http.layer),
+		);
+		expect(http.headers[0]?.authorization).toBe(`token ${TOKEN}`);
+	});
+
+	it("attaches `authorization` on the bytes leg", async () => {
+		const http = fakeHttp([[/artifacts\/5\/zip$/, {status: 200, body: "PK", headers: {}}]]);
+		await Effect.runPromise(
+			Effect.provide(restBytes(TOKEN, "repos/o/r/actions/artifacts/5/zip"), http.layer),
+		);
+		expect(http.headers[0]?.authorization).toBe(`token ${TOKEN}`);
+	});
+
+	it("attaches `authorization` on the GraphQL leg", async () => {
+		const http = fakeHttp([[/graphql$/, served(200, {data: {}})]]);
+		await Effect.runPromise(Effect.provide(graphqlRead(TOKEN, "query{x}", {}), http.layer));
+		expect(http.headers[0]?.authorization).toBe(`token ${TOKEN}`);
+	});
+});
+
+describe("restBytes — the raw-bytes read", () => {
+	it("hands back the bytes undecoded, beside the status", async () => {
+		const http = fakeHttp([[/artifacts\/5\/zip$/, {status: 200, body: "PK", headers: {}}]]);
+		const result = await Effect.runPromise(
+			Effect.provide(restBytes(TOKEN, "repos/o/r/actions/artifacts/5/zip"), http.layer),
+		);
+		expect(http.calls).toEqual(["GET https://api.github.com/repos/o/r/actions/artifacts/5/zip"]);
+		expect(result._tag).toBe("Response");
+		expect(result._tag === "Response" && Array.from(result.value.slice(0, 2))).toEqual([
+			0x50, 0x4b,
+		]);
+	});
+
+	it("answers Unreachable rather than a status when GitHub was never reached", async () => {
+		const http = fakeHttp([], undefined, [/artifacts\/5\/zip$/]);
+		const result = await Effect.runPromise(
+			Effect.provide(restBytes(TOKEN, "repos/o/r/actions/artifacts/5/zip"), http.layer),
+		);
+		expect(result._tag).toBe("Unreachable");
 	});
 });
 

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -19,7 +19,6 @@
 import {Effect} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
-import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import {execCapture} from "./exec.ts";
 import {
 	type Api,
@@ -30,9 +29,10 @@ import {
 	type Rest,
 	resolveToken,
 	restRead,
+	restWrite,
 } from "./gh-api.ts";
 import {type Attempt, fail, ok, originRepo, type Shell} from "./git.ts";
-import {isRecord, parseJson} from "./json.ts";
+import {isRecord} from "./json.ts";
 
 /** A three-way probe: proven present, proven absent, or unreadable — never two of those fused. */
 export type Existence<A> =
@@ -123,50 +123,6 @@ const servedBody = (outcome: Rest): Attempt<unknown> => {
 
 /** A write whose only evidence is its status — the body it echoes is not proof of anything. */
 const accepted = (outcome: Rest): Attempt<void> => then(servedBody(outcome), () => ok(undefined));
-
-const API_ROOT = "https://api.github.com";
-
-// `restRead` sends no request body, and every write below needs one. Duplicated here rather than
-// added to `gh-api.ts` because this epic partitions its children by file and a sibling's branch
-// would collide; #6693 tracks folding the copies back into the client.
-const restWrite = (
-	token: string,
-	method: "POST" | "PATCH" | "DELETE",
-	path: string,
-	body?: Readonly<Record<string, unknown>>,
-): Api<Rest> => {
-	const base = HttpClientRequest.make(method)(`${API_ROOT}/${path.replace(/^\//, "")}`).pipe(
-		HttpClientRequest.setHeaders({
-			authorization: `token ${token}`,
-			accept: "application/vnd.github+json",
-			"x-github-api-version": "2022-11-28",
-			"user-agent": "fabrika-cli",
-		}),
-	);
-	return HttpClient.execute(
-		body === undefined ? base : HttpClientRequest.bodyJsonUnsafe(base, body),
-	).pipe(
-		Effect.flatMap((response) =>
-			response.text.pipe(
-				Effect.map(
-					(text): Rest => ({
-						_tag: "Response",
-						status: response.status,
-						headers: response.headers,
-						body: parseJson(text),
-						text,
-					}),
-				),
-			),
-		),
-		Effect.catch((error: unknown) =>
-			Effect.succeed<Rest>({
-				_tag: "Unreachable",
-				reason: `the GitHub API could not be reached: ${String(error)}`,
-			}),
-		),
-	);
-};
 
 // A function, not a top-level constant: `gh-api.ts` imports this module back, so at the moment
 // this one is evaluated `PAGE_CAP` is still in its exporter's temporal dead zone.

--- a/packages/fabrika-cli/src/ship/github.ts
+++ b/packages/fabrika-cli/src/ship/github.ts
@@ -22,9 +22,6 @@
 
 import {writeFile} from "node:fs/promises";
 import {Effect} from "effect";
-import * as HttpClient from "effect/unstable/http/HttpClient";
-import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import {execCapture} from "../io/exec.ts";
 import {
 	type Api,
@@ -38,56 +35,16 @@ import {
 	onTransport,
 	PAGE_CAP,
 	type Rest,
+	restBytes,
+	restCall,
 	restRead,
+	restWrite,
 } from "../io/gh-api.ts";
 import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
 import {absent, type Existence, present, unknown} from "../io/issues.ts";
 import {isRecord} from "../io/json.ts";
 
 const str = (value: unknown): string => (typeof value === "string" ? value : "");
-
-const API_ROOT = "https://api.github.com";
-
-const headersFor = (token: string, accept: string): Record<string, string> => ({
-	authorization: `token ${token}`,
-	accept,
-	"x-github-api-version": "2022-11-28",
-	"user-agent": "fabrika-cli",
-});
-
-const endpoint = (path: string): string => `${API_ROOT}/${path.replace(/^\//, "")}`;
-
-/** One served response, or the reason none arrived. */
-type Delivered<A> =
-	| {readonly _tag: "Delivered"; readonly status: number; readonly value: A}
-	| {readonly _tag: "Unreachable"; readonly reason: string};
-
-/**
- * The three legs `../io/gh-api.ts` does not carry: a raw media type, a PATCH body, and raw bytes.
- *
- * They live here rather than in the client because five sibling ports are cutting from the same
- * base and no child owns that file — #6693 tracks hoisting them, which is where they belong once
- * the parallel ports have landed.
- */
-const deliver = <A>(
-	request: HttpClientRequest.HttpClientRequest,
-	read: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<A, unknown>,
-): Api<Delivered<A>> =>
-	HttpClient.execute(request).pipe(
-		Effect.flatMap((response) =>
-			Effect.map(read(response), (value) => ({
-				_tag: "Delivered" as const,
-				status: response.status,
-				value,
-			})),
-		),
-		Effect.catch((error: unknown) =>
-			Effect.succeed({
-				_tag: "Unreachable" as const,
-				reason: `the GitHub API could not be reached: ${String(error)}`,
-			}),
-		),
-	);
 
 export interface ReviewRecord {
 	readonly login: string;
@@ -165,7 +122,7 @@ const pagedForExistence = (token: string, path: string): Api<Existence<ReadonlyA
  *
  * A second reading of `build/github.ts`'s `defaultBranch` only because that one publishes `env` and
  * `HttpClient` up into its callers; `../ship/roster.ts` is reached from a hundred `Shell<…>` sites
- * that thread neither. #6693 folds the two once one convention wins.
+ * that thread neither. #6814 folds the two once one convention wins.
  */
 export const defaultBranch = (repo: string): Shell<Attempt<string>> =>
 	authed((token) =>
@@ -214,19 +171,20 @@ export const listTeamMembers = (
 export const readFileAtRef = (repo: string, path: string, ref: string): Shell<Existence<string>> =>
 	authedExistence((token) =>
 		Effect.map(
-			deliver(
-				HttpClientRequest.get(endpoint(`repos/${repo}/contents/${path}?ref=${ref}`)).pipe(
-					HttpClientRequest.setHeaders(headersFor(token, "application/vnd.github.raw")),
-				),
-				(response) => response.text,
-			),
+			restCall(token, {
+				method: "GET",
+				path: `repos/${repo}/contents/${path}?ref=${ref}`,
+				accept: "application/vnd.github.raw",
+			}),
 			(outcome): Existence<string> => {
 				if (outcome._tag === "Unreachable") return unknown<string>(outcome.reason);
 				if (outcome.status === 404) return absent<string>();
 				if (outcome.status < 200 || outcome.status >= 300) {
 					return unknown<string>(`GitHub answered HTTP ${outcome.status}`);
 				}
-				return present(outcome.value);
+				// The raw media type is what makes `text` the answer here: a file's bytes are not
+				// JSON, so `body` parses to `null` for every file that is not itself a JSON document.
+				return present(outcome.text);
 			},
 		),
 	);
@@ -474,12 +432,7 @@ export const fetchManifest = (
 		const token = yield* ambientToken;
 		if (token._tag === "Failure") return token;
 		const download = yield* onTransport(
-			deliver(
-				HttpClientRequest.get(endpoint(`repos/${repo}/actions/artifacts/${artifactId}/zip`)).pipe(
-					HttpClientRequest.setHeaders(headersFor(token.value, "application/vnd.github+json")),
-				),
-				(response) => Effect.map(response.arrayBuffer, (buffer) => new Uint8Array(buffer)),
-			),
+			restBytes(token.value, `repos/${repo}/actions/artifacts/${artifactId}/zip`),
 		);
 		if (download._tag === "Unreachable") return fail(download.reason);
 		if (download.status < 200 || download.status >= 300) {
@@ -737,21 +690,12 @@ export const disableAutoMerge = (repo: string, pr: number): Shell<Attempt<void>>
 /** Close or reopen a pull request. Each leg is read back by the caller; neither is trusted here. */
 export const setPullState = (repo: string, pr: number, state: string): Shell<Attempt<void>> =>
 	authed((token) =>
-		Effect.map(
-			deliver(
-				HttpClientRequest.patch(endpoint(`repos/${repo}/pulls/${pr}`)).pipe(
-					HttpClientRequest.setHeaders(headersFor(token, "application/vnd.github+json")),
-					HttpClientRequest.bodyJsonUnsafe({state}),
-				),
-				(response) => response.text,
-			),
-			(outcome) => {
-				if (outcome._tag === "Unreachable") return fail(outcome.reason);
-				return outcome.status >= 200 && outcome.status < 300
-					? ok(undefined)
-					: fail(`GitHub answered HTTP ${outcome.status}`);
-			},
-		),
+		Effect.map(restWrite(token, "PATCH", `repos/${repo}/pulls/${pr}`, {state}), (outcome) => {
+			if (outcome._tag === "Unreachable") return fail(outcome.reason);
+			return outcome.status >= 200 && outcome.status < 300
+				? ok(undefined)
+				: fail(`GitHub answered HTTP ${outcome.status}`);
+		}),
 	);
 
 export interface ThreadComment {


### PR DESCRIPTION
Folds `packages/fabrika-cli`'s two duplicate GitHub transports back into the one client, and closes
the credential test gap that let either of them drop its `authorization` header with the suite green.

## What changed

**`io/gh-api.ts` grows a raw-bytes read.** `restBytes` is the one leg the shared client genuinely
lacked: `Rest` carries a parsed body and a decoded `text`, and a zip decoded as UTF-8 is corrupt
rather than merely unparsed. `send` and `restBytes` now share one `served` helper, so the
execute/catch shape exists once instead of three times. `restWrite`'s body becomes optional — a
`DELETE` carries none, and `RestCall` already omits an absent body rather than sending `null`.

**`io/issues.ts`'s local `restWrite` is gone**, and its inline
`authorization`/`accept`/`x-github-api-version`/`user-agent` literal with it. All twelve call sites
now run on the shared `restWrite` unchanged.

**`ship/github.ts`'s `deliver`, `headersFor`, `endpoint` and `API_ROOT` are gone.** `readFileAtRef`
goes through `restCall` with the raw `Accept`, `setPullState` through `restWrite`, `fetchManifest`
through `restBytes`. The undici redirect note on `fetchManifest` is untouched — that behaviour is
the runtime's and did not move.

**Two tests the criteria name.** Four cases assert `authorization` reaches the transport on the
read, write, bytes and GraphQL legs; deleting the header line off `headersFor` fails exactly those
four and nothing else (verified by running it). `restBytes` gets its own pair — bytes handed back
undecoded, and a transport fault answering `Unreachable` rather than a status.

**`pagedEnvelope`'s tail keeps its branch** with the note the criterion asked for: unreachable at
runtime, load-bearing as a type-narrowing device, because dropping it reds
`EnvelopeRead.declared: number`.

Green in-tree: `pnpm typecheck --force`, `pnpm lint:worktree`, and all 7485 tests across 441 files
in `packages/fabrika-cli`.

## Deviations

- **Out-of-scope change** — **Said:** the acceptance criteria name three duplicate transports and
  nothing else. **Did:** also retargeted the `#6693` pointer in `ship/github.ts`'s `defaultBranch`
  docblock to #6814. **Why:** that comment says "#6693 folds the two once one convention wins", but
  the two `defaultBranch` readings are a different duplication — split by credential-resolution
  convention, not by transport — and this ticket's re-scoped criteria never covered it. Left as
  written, the pointer would send its reader to a closed issue that never did the thing it promises.
  **Disposition:** the fold itself is not done here; it needs a package-wide ruling on env-threaded
  vs ambient credential resolution first. Filed as https://github.com/kamp-us/phoenix/issues/6814
  and the comment now points there.

- **Scope narrowing** — **Said:** the original criteria list asked for a body-capable four-method
  REST leg, a `fakeHttp` header recorder, and a write-leg method/body test. **Did:** none of those.
  **Why:** the issue's own `## Re-scope after #6690` amendment struck them — all three landed on
  `main` in https://github.com/kamp-us/phoenix/pull/6690, verified in-tree at
  `io/gh-api.ts:190-261`, `fakes.test-support.ts:398-399` and `io/gh-api.unit.test.ts:286-332`.
  **Disposition:** built to the amendment's six revised criteria; the original list is stale and the
  amendment says so.

- **Scope narrowing** — **Said:** the original criteria list ends with "cut from and merged into
  `epic/6629`". **Did:** cut from `main`. **Why:** the same amendment supersedes it — epic #6629
  landed via #6690, so the code is on the default branch and `epic/6629` is spent.
  **Disposition:** stated here; the amendment's last criterion asks for green on `main`, which is
  what ran.

Fixes #6693
