### PR TITLE
docs(roadmap): declare Lane integrity, Epic lanes and Diátaxis README passes, and start Lane integrity

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -10,6 +10,12 @@
 	// three founder accounts. One grant buys exactly one round.
 	"capClearAuthors": ["@usirin", "@notusirin", "@cansirin"],
 
+	// Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `campaign
+	// state`). It narrows the repo's collaborator ACL and never replaces it: an entry here still
+	// needs `write` or above on the repo (ADR 0294). Founder-declared 2026-08-20 on #6811 — the
+	// shipped default is empty, which refuses every declaration, so phoenix names the founder.
+	"campaignAuthors": ["@usirin"],
+
 	// Docs whose subject IS path hygiene: they must spell the forbidden path shapes out, so
 	// `fabrika build check --surface prose` skips its leak scan on them. Repo-relative path
 	// suffixes, matched by suffix the way `fabrika guard leak-guard scan` matches its own

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ flowchart TD
 		camp_fabrika_fast_follows["fabrika fast follows"]:::done
 		camp_fabrika_everywhere["fabrika everywhere"]:::active
 		camp_ge_it_product_push["Geçit product push"]:::active
-		camp_lane_integrity["Lane integrity"]:::paused
+		camp_lane_integrity["Lane integrity"]:::active
 		camp_epic_lanes["Epic lanes"]:::paused
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::paused
 	end
@@ -108,7 +108,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | fabrika fast follows | #46 | done |
 | fabrika everywhere | #47 | active |
 | Geçit product push | #24 | active |
-| Lane integrity | #48 | paused |
+| Lane integrity | #48 | active |
 | Epic lanes | #49 | paused |
 | Diátaxis README passes | #50 | paused |
 


### PR DESCRIPTION
Three campaigns declared on the founder's ruling of 2026-08-20 PT, given in session.

| Campaign | Milestone | State | Tracking issue |
|----------|-----------|-------|----------------|
| Lane integrity | #48 | active | #6811 |
| Epic lanes | #49 | paused | #6812 |
| Diátaxis README passes | #50 | paused | #6813 |

## Two commits, because declaring and starting are two writes

ADR [0304](https://github.com/kamp-us/phoenix/blob/main/.decisions/0304-campaign-active-is-the-dispatch-permission.md) makes the `State` cell the dispatch permission, and a new row is born `paused` — flipping it to `active` is a separate act with its own ruling and its own citation. The branch keeps that shape:

- `c6bce6b7e` — all three rows appended `paused`, mermaid nodes classed `paused`.
- `0bfbb18d8` — Lane integrity's cell and node flipped to `active`, nothing else touched.

## Marker comments cited

- Lane integrity, `paused`: https://github.com/kamp-us/phoenix/issues/6811#issuecomment-5364909216
- Lane integrity, `active`: https://github.com/kamp-us/phoenix/issues/6811#issuecomment-5364909728
- Epic lanes, `paused`: https://github.com/kamp-us/phoenix/issues/6812#issuecomment-5364910226
- Diátaxis README passes, `paused`: https://github.com/kamp-us/phoenix/issues/6813#issuecomment-5364910746
- `campaignAuthors` declared: https://github.com/kamp-us/phoenix/issues/6811#issuecomment-5365022171

## Two things worth a reviewer's eye

**Hand-written, not verb-written.** The `fabrika campaign` verbs are not implemented yet (#6787), so both edits follow the campaign skill's rules by hand: rows in the pinned `Campaign | Milestone | State` shape, mermaid ids computed per the skill's rule and checked against the ids already in the block (`camp_lane_integrity`, `camp_epic_lanes`, `camp_di_taxis_readme_passes` — the last matching the existing `camp_di_taxis_docs_pipeline_crew_mcp` precedent), class equal to state. `## Dependencies` is untouched.

**`campaignAuthors` is declared for the first time.** The key shipped absent, which means nobody may declare, so this PR adds `"campaignAuthors": ["@usirin"]`. It narrows the repo's collaborator ACL and never replaces it (ADR 0294) — an entry there still needs `write` or above, read live. The generated `.fabrika.schema.json` has no such key yet and is never hand-edited, so an editor will red the line until #6787 lands and regenerates the schema.

`fabrika guard roadmap-guard check` passes at both commits: green at HEAD with 4 arc rows + 24 campaign rows against 46 milestones, 3 campaigns active (I1–I5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations

- **Declined guidance** — **Said:** the campaign skill's §3 writes a `## Campaigns` row through `fabrika campaign open` and flips its state through `fabrika campaign state`. **Did:** wrote both edits to `ROADMAP.md` by hand, in two commits, following the skill's row grammar and mermaid-id rule literally. **Why:** those verbs do not exist yet — #6787 is the issue that implements them — so the verb route was unavailable while the founder's ruling was already given. **Disposition:** stated here; the hand edit is checked against the skill's own rules and `roadmap-guard` is green at head.
- **Out-of-scope change** — **Said:** the ruling names three campaign rows on `ROADMAP.md`. **Did:** also declared `campaignAuthors` as `["@usirin"]` in `.fabrika.jsonc`, six lines with a four-line comment. **Why:** the key ships absent, and absent refuses every declaration, so the rows are unwritable by any future verb run until it is declared — the campaign skill names declaring it as the remedy. **Disposition:** stated here; the key is unregistered in `packages/fabrika-cli/src/config/registry.ts`, so nothing reads it until #6787 registers it, and it cannot un-govern the file it sits in.
- **Known defect left unfixed** — **Said:** `.fabrika.schema.json` is generated from the config registry and carries `"additionalProperties": false`. **Did:** left it unregenerated, so `.fabrika.jsonc` is out of schema on the new key. **Why:** the schema is never hand-edited, and it regenerates when #6787 registers `campaignAuthors`; no CI gate validates the jsonc against it, and `fabrika config schema` reconciles the committed schema against the registry, neither of which moved. **Disposition:** stated here, editor-only, bounded to #6787.
- **Governing-ADR departure** — **Said:** the code rubric wants a falsifiable in-file claim grounded in a source a reader can follow. **Did:** the `.fabrika.jsonc` comment cites the issue (`#6811`), not the exact comment, for the founder declaration. **Why:** the declaration anchor was posted after this head was pushed, and moving the head would unbind the review verdicts already written at `0bfbb18d8`. **Disposition:** the anchor now exists and the pointer resolves — https://github.com/kamp-us/phoenix/issues/6811#issuecomment-5365022171, a `campaign-authors-declare` marker from the founder naming this key and this PR. A reader following `#6811` lands on the ruling; the comment URL is cited here for the merge record.

