### PR TITLE
docs(roadmap): claim milestones #48–#50 as paused campaign rows

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,9 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | fabrika fast follows | #46 | done |
 | fabrika everywhere | #47 | active |
 | Geçit product push | #24 | active |
+| Lane integrity | #48 | paused |
+| Epic lanes | #49 | paused |
+| Diátaxis README passes | #50 | paused |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,9 @@ flowchart TD
 		camp_fabrika_fast_follows["fabrika fast follows"]:::done
 		camp_fabrika_everywhere["fabrika everywhere"]:::active
 		camp_ge_it_product_push["Geçit product push"]:::active
+		camp_lane_integrity["Lane integrity"]:::paused
+		camp_epic_lanes["Epic lanes"]:::paused
+		camp_di_taxis_readme_passes["Diátaxis README passes"]:::paused
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external


### PR DESCRIPTION
Reconciles the ROADMAP ↔ milestone drift the roadmap-guard reds on (exit 12, three I3 violations): open milestones #48 (Lane integrity), #49 (Epic lanes) and #50 (Diátaxis README passes) — created by the founder 2026-08-21 03:39Z — were claimed by no arc or campaign row. Adds the three campaign rows in `paused` per the table's own grammar (a newly added row is paused; flipping to `active` is the separate dispatch grant, ADR 0304). Fixes #6824; unblocks the red check on PR #6817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations
None.
