### PR TITLE
chore: Six sandbox-visibility comments still say "author + a moderator" after the third viewer class landed

### DIFF
--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -64,8 +64,9 @@ export const lists = {
 	posts: Fate.list(
 		{args: PostsArgs, type: PostView},
 		Effect.fn("posts")(function* ({args}) {
-			// Resolved once (identity + moderator probe): the feed hides çaylak-sandboxed
-			// posts from anyone but their author + a mod (#1205).
+			// The feed admits a çaylak-sandboxed post to its author, a moderator, or the
+			// opted-in in-place reader of #6423 — the rule is `sandboxVisibleWhere` in
+			// lifecycle/SandboxVisibility.ts (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
 			// Gated behind the default-off `member-mute` flag — empty set means unchanged

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -34,7 +34,9 @@ export const queries = {
 		{args: PostArgs, type: PostView},
 		Effect.fn("post")(function* ({args, select}) {
 			const pano = yield* Pano;
-			// A sandboxed post is hidden from anyone but its author + a moderator (#1205).
+			// A çaylak-sandboxed post is visible to its author, a moderator, or the opted-in
+			// in-place reader of #6423 — the rule is `sandboxVisibleWhere` in
+			// lifecycle/SandboxVisibility.ts (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
 			// Mute read-mask (#3113): default-off `member-mute` ⇒ empty set ⇒ unchanged.

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -218,8 +218,9 @@ export class Pasaport extends Context.Service<
 			value: string;
 		}) => Effect.Effect<SetDisplayNameResult, DisplayNameEmpty | UserNotFound>;
 
-		// `viewer` applies the #1205 sandbox filter to the headline counts (#1312):
-		// only the author + a moderator see sandboxed content counted. Omitted ⇒
+		// `viewer` applies the #1205 sandbox filter to the headline counts (#1312): they
+		// follow whichever viewer `sandboxVisibleWhere` was handed, the opted-in in-place
+		// reader of #6423 included — see lifecycle/SandboxVisibility.ts. Omitted ⇒
 		// anonymous (public-only), the fail-safe default.
 		readonly lookupProfile: (
 			username: string,

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -62,7 +62,8 @@ export const queries = {
 			const pasaport = yield* Pasaport;
 			// The SAME viewer must thread into both the headline counts and the
 			// contribution feed, or the header disagrees with the feed for that viewer
-			// (#1309/#1312). Only the author and a moderator see sandboxed content.
+			// (#1309/#1312). Sandboxed content shows to its author, a moderator, or the
+			// opted-in in-place reader of #6423 — see lifecycle/SandboxVisibility.ts.
 			const sandboxViewer = yield* currentSandboxViewer;
 			const row = yield* pasaport.lookupProfile(args.username, {sandboxViewer});
 			if (!row) return null;


### PR DESCRIPTION
Fixes #6465

Four comments in pano and pasaport still stated the old two-way çaylak sandbox rule ("author + a moderator") as fact, sitting directly on reads that resolve three viewer classes. Each one now names the three — the author, a moderator, and the opted-in in-place reader of #6423 — and defers to `lifecycle/SandboxVisibility.ts` for the rule itself rather than restating the mechanics.

Grounded in source, not the issue's summary: `sandboxArm` checks `viewer.seesSandboxedInPlace` before the author arm and widens author-blind when it holds, and `lifecycleVisibilityRule.Sandboxed` is `AuthorOrModeratorOrInPlaceViewer`, interpreted in `ruleVisibleTo` as moderator OR in-place viewer OR author.

`apps/web/worker/features/search/lists.ts` carries the same phrasing and is untouched: `searchPosts` narrows its viewer through `withoutInPlaceVisibility`, so the two-way rule really is the whole rule there. After this change the issue's grep returns that one hit and nothing else.

The diff is comments only — no expression, signature, import or predicate moved, and no test file is edited.

## Deviations

- **Out-of-scope change** — **Said:** #6465 scopes each site to its stale audience sentence. **Did:** in `pano/lists.ts` I also dropped the comment's lead clause "Resolved once (identity + moderator probe)". **Why:** that clause was stale on a second axis — the resolve is now memoized per `POST /fate` request through `SandboxViewerMemo` (#6457), whose docblock states it, and the clause's parenthetical listed only two of the three inputs `currentSandboxViewer` reads. Keeping it would have shipped a fresh half-truth beside the sentence I was there to correct. **Disposition:** stated here; the surviving comment is the audience note the criteria ask for.
- **Known defect left unfixed** — **Said:** criterion 8 asks that the existing sandbox / çaylak-visibility / lifecycle tests pass unamended. **Did:** ran the unit tier only (23 files, 237 tests, all green, none amended); the integration tier aborts locally with `Unauthorized` from `@distilled.cloud/cloudflare` before any test runs. **Why:** the integration project needs Cloudflare credentials this worktree has no access to. **Disposition:** left to CI, which owns that tier; the diff changes no executable text, so no test can change verdict on it.
