### PR TITLE
fix: A gh-api write failure refuses with a bare HTTP status, dropping GitHub's own error message

### DIFF
--- a/packages/fabrika-cli/src/build/blockedness.unit.test.ts
+++ b/packages/fabrika-cli/src/build/blockedness.unit.test.ts
@@ -7,8 +7,8 @@ import {GATEWAY, issuePayload, NOT_FOUND, served} from "./fixtures.test-support.
 const EDGES = /GET .*\/repos\/o\/r\/issues\/4312\/dependencies\/blocked_by/;
 const BLOCKER = (n: number) => new RegExp(`GET .*/repos/o/r/issues/${n}$`);
 
-/** What `existenceOf` and the paged read both name a served 502. */
-const UNREADABLE = "GitHub answered HTTP 502";
+/** What `existenceOf` and the paged read both name a served 502 — `GATEWAY`'s own `message` included. */
+const UNREADABLE = "GitHub answered HTTP 502: Bad gateway";
 
 const edges = (...numbers: ReadonlyArray<number>): HttpReply =>
 	served(numbers.map((number) => ({number, state: "open"})));

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -153,7 +153,7 @@ describe("runEligible", () => {
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
 			expect(out.stdout).toBe("");
 			expect(out.stderr.at(-1)).toBe(
-				'build eligible: cannot read #4312: GitHub answered HTTP 502 — eligibility is UNKNOWN, never "eligible".',
+				'build eligible: cannot read #4312: GitHub answered HTTP 502: Bad gateway — eligibility is UNKNOWN, never "eligible".',
 			);
 		});
 

--- a/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
@@ -244,7 +244,7 @@ describe("runPick", () => {
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
-			"build pick: cannot read the p0 bucket: GitHub answered HTTP 502 — the pool is UNKNOWN, never partial.",
+			"build pick: cannot read the p0 bucket: GitHub answered HTTP 502: Bad gateway — the pool is UNKNOWN, never partial.",
 		);
 	});
 

--- a/packages/fabrika-cli/src/io/gh-api.ts
+++ b/packages/fabrika-cli/src/io/gh-api.ts
@@ -304,8 +304,36 @@ export const restWrite = (
 	body?: Readonly<Record<string, unknown>>,
 ): Api<Rest> => restCall(token, {method, path, body});
 
-const refusalText = (outcome: Rest & {_tag: "Response"}): string =>
-	`GitHub answered HTTP ${outcome.status}`;
+/**
+ * How many characters of GitHub's own `message` a refusal carries.
+ *
+ * A refusal reason is interpolated into operator-facing text and quoted into GitHub comments, so an
+ * unbounded append is a flooding surface as well as noise. 200 holds every real API message
+ * ("Validation Failed", "Reference already exists", the secret-scanning block) whole.
+ */
+const MESSAGE_CAP = 200;
+
+/**
+ * The refusal a non-2xx is, naming GitHub's own `message` when it sent one.
+ *
+ * Every non-2xx arm in this module and in `./issues.ts` builds its reason here, because the string
+ * used to be constructed at five call sites and enriching one of them would have left the other
+ * four naming a bare number (#6708). The status leads: a caller telling a permission denial apart
+ * from a validation failure reads the number, and the message is the clause that separates a
+ * fixable input from an unfixable one.
+ *
+ * The append is best-effort by construction — a body that is `null`, is not a record, or carries no
+ * string `message` falls back to the bare status rather than becoming a second failure.
+ */
+export const refusalText = (outcome: Rest & {_tag: "Response"}): string => {
+	const status = `GitHub answered HTTP ${outcome.status}`;
+	if (!isRecord(outcome.body) || typeof outcome.body.message !== "string") return status;
+	const message = outcome.body.message.replace(/\s+/g, " ").trim();
+	if (message === "") return status;
+	const bounded =
+		message.length <= MESSAGE_CAP ? message : `${message.slice(0, MESSAGE_CAP)}…truncated`;
+	return `${status}: ${bounded}`;
+};
 
 /**
  * The three-arm {@link Existence} construction, off the status the response carried.
@@ -319,9 +347,7 @@ export const existenceOf = <A>(
 ): Existence<A> => {
 	if (outcome._tag === "Unreachable") return unknown<A>(outcome.reason);
 	if (outcome.status === 404) return absent<A>();
-	if (outcome.status < 200 || outcome.status >= 300) {
-		return unknown<A>(`GitHub answered HTTP ${outcome.status}`);
-	}
+	if (outcome.status < 200 || outcome.status >= 300) return unknown<A>(refusalText(outcome));
 	const value = read(outcome.body);
 	return value._tag === "Failure" ? unknown<A>(value.reason) : present<A>(value.value);
 };
@@ -388,7 +414,7 @@ const statusless = (reason: string): Failure & {readonly status: null} => ({
 });
 
 const refusalFor = (outcome: Rest & {_tag: "Response"}): Failure & {readonly status: number} => ({
-	...fail(`GitHub answered HTTP ${outcome.status}`),
+	...fail(refusalText(outcome)),
 	status: outcome.status,
 });
 

--- a/packages/fabrika-cli/src/io/gh-api.unit.test.ts
+++ b/packages/fabrika-cli/src/io/gh-api.unit.test.ts
@@ -12,6 +12,7 @@ import {
 	pagedExistence,
 	pagedWithLinkProof,
 	type Rest,
+	refusalText,
 	resolveToken,
 	restBytes,
 	restCall,
@@ -102,6 +103,47 @@ describe("restRead", () => {
 	});
 });
 
+describe("refusalText — the status, and GitHub's own message when it sent one", () => {
+	const responded = (status: number, body: unknown): Rest & {_tag: "Response"} => ({
+		_tag: "Response",
+		status,
+		headers: {},
+		body,
+		text: JSON.stringify(body),
+	});
+
+	it("names the message a 422 carried beside the status", () => {
+		expect(
+			refusalText(
+				responded(422, {
+					message: "Validation Failed",
+					errors: [{field: "milestone", code: "invalid"}],
+				}),
+			),
+		).toBe("GitHub answered HTTP 422: Validation Failed");
+	});
+
+	it("falls back to the bare status when no string message is there to read", () => {
+		expect(refusalText(responded(502, null))).toBe("GitHub answered HTTP 502");
+		expect(refusalText(responded(502, ["not", "a", "record"]))).toBe("GitHub answered HTTP 502");
+		expect(refusalText(responded(502, {}))).toBe("GitHub answered HTTP 502");
+		expect(refusalText(responded(502, {message: 404}))).toBe("GitHub answered HTTP 502");
+		expect(refusalText(responded(502, {message: "   "}))).toBe("GitHub answered HTTP 502");
+	});
+
+	it("bounds what it appends, so a hostile body cannot flood a quoted refusal", () => {
+		const reason = refusalText(responded(500, {message: "x".repeat(5000)}));
+		expect(reason.length).toBeLessThan(300);
+		expect(reason).toContain("truncated");
+	});
+
+	it("flattens the message onto one line", () => {
+		expect(refusalText(responded(403, {message: "blocked\nby\tpolicy"}))).toBe(
+			"GitHub answered HTTP 403: blocked by policy",
+		);
+	});
+});
+
 describe("existenceOf — three arms, never two", () => {
 	const response = (status: number, body: unknown): Rest => ({
 		_tag: "Response",
@@ -123,6 +165,14 @@ describe("existenceOf — three arms, never two", () => {
 		const result = existenceOf(response(502, null), readName);
 		expect(result._tag).toBe("Unknown");
 		expect(result._tag === "Unknown" && result.reason).toContain("502");
+	});
+
+	it("routes its Unknown arm through refusalText rather than building the status inline", () => {
+		const result = existenceOf(response(422, {message: "Validation Failed"}), readName);
+		expect(result).toEqual({
+			_tag: "Unknown",
+			reason: "GitHub answered HTTP 422: Validation Failed",
+		});
 	});
 
 	it("constructs Unknown when the transport never reached GitHub", () => {

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -27,6 +27,7 @@ import {
 	pagedEnvelope,
 	pagedWithLinkProof,
 	type Rest,
+	refusalText,
 	resolveToken,
 	restRead,
 	restWrite,
@@ -109,15 +110,10 @@ const withToken = <A>(read: (token: string) => Api<Attempt<A>>): Shell<Attempt<A
 		return token._tag === "Failure" ? token : yield* onTransport(read(token.value));
 	});
 
-const refusalFor = (outcome: Rest & {_tag: "Response"}): string => {
-	const named = isRecord(outcome.body) && typeof outcome.body.message === "string";
-	return `GitHub answered HTTP ${outcome.status}${named ? `: ${String(outcome.body.message)}` : ""}`;
-};
-
 /** A served 2xx body, or the refusal a non-2xx or an unreached endpoint is. */
 const servedBody = (outcome: Rest): Attempt<unknown> => {
 	if (outcome._tag === "Unreachable") return fail(outcome.reason);
-	if (outcome.status < 200 || outcome.status >= 300) return fail(refusalFor(outcome));
+	if (outcome.status < 200 || outcome.status >= 300) return fail(refusalText(outcome));
 	return ok(outcome.body);
 };
 


### PR DESCRIPTION
`refusalFor`/`refusalText` in `packages/fabrika-cli/src/io/gh-api.ts` collapsed every non-2xx to `GitHub answered HTTP <status>`, throwing away the `message` GitHub had already parsed onto the `Rest` value. An operator reading `WRITE_UNKNOWN: GitHub answered HTTP 422` could only find out what was wrong by reconstructing the call by hand.

One `refusalText` now builds that string for all five call sites (`attemptOf`, `existenceOf`, `pagedExistence`, `pagedWithLinkProof`, `pagedEnvelope`), appending GitHub's own `message` when the parsed body is a record carrying a string there. A body that is `null`, is not a record, or carries no string `message` still refuses with the bare status — the enrichment never turns an unparseable body into a failure. The append is whitespace-flattened and capped at 200 characters, because a refusal reason gets quoted into GitHub comments.

`existenceOf` no longer builds the literal inline, and `issues.ts`'s private near-copy is deleted in favour of the shared one, so the string is constructed in one place instead of three.

Fixes #6708

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #6708 asks for new tests on the enrichment. **Did:** also updated four existing expectations in `blockedness.unit.test.ts`, `eligible-verb.unit.test.ts` and `pick-verb.unit.test.ts`. **Why:** they assert refusal strings built from the shared `GATEWAY` fixture, whose body is `{"message":"Bad gateway"}`, so the enrichment lands in them by design. **Disposition:** expectations updated to the enriched string; no assertion weakened or removed.
- **Declined guidance** — **Said:** the issue's non-binding shape suggests optionally folding in `errors[]`. **Did:** appended `message` only. **Why:** the acceptance criteria require `message`, and `errors[]` is the field the `gh` era already dropped at `firstLine(stderr)`, so leaving it out is parity rather than regression. **Disposition:** stated here; a follow-up can add it as a net improvement.
