### PR TITLE
feat: A builder killed by an account session limit leaves its lane reading build with nothing recorded

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -198,6 +198,7 @@ Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build
 | `build pick` | the ranked candidate pool, with every excluded issue under the axis that refused it |
 | `build eligible` | whether one issue's dependency gate is open |
 | `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, re-prove it, retract it, or take a dead session's |
+| `build claimants` | who holds an issue's claim, read by a caller holding none — no token, no write, no clearance |
 | `build issue` | the claimed issue's body and its criteria — `found` / `absent` / `malformed`, all on exit 0 |
 | `build branch` / `scratch` | the lane's branch off a fresh base, and its scratch directory |
 | `build commit` / `push` | the commit whose message is proven this lane's, and the push whose ref is proven moved |
@@ -576,7 +577,7 @@ snapshot. Lane state is local and never committed.
 | `lane open` / `emit` | boot a lane from a committed template, or generate an epic's machine from its board topology |
 | `lane brief` | the spawn prompt for one task's current leaf state |
 | `lane assembly` / `push` | an epic run's assembly worktree, and its published branch |
-| `lane stale` | which lanes have gone quiet with something owed on them |
+| `lane stale` | which lanes have gone quiet with something owed on them — offline, or `--claims` to pair each non-terminal lane with the claim standing on its issue |
 | `lane claim` / `release` | who is driving this lane |
 
 **Exit codes.** `4` the lane read in full and is not the shape · `7` the lane is absent · `8` the

--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -105,20 +105,34 @@ export const composeMarker = (
 		? `${grammar.keyword}: ${token} · ${at}`
 		: `${grammar.keyword}: ${token} · ${at}\n${grammar.keyword}-override: ${override.lane} · ${override.reason}`;
 
-/** The token a comment body claims in `grammar`, or `null` when it carries no marker of that kind. */
-export const readMarkerToken = (
+/**
+ * The marker a comment body carries in `grammar`, or `null` when it carries none of that kind.
+ *
+ * The session comes back beside the token because it is read out of the same parse the token's
+ * well-formedness already turns on — deriving it again at a call site is a second parse that can
+ * disagree, and the one it would disagree about is which session a stranded claim names.
+ */
+const readMarker = (
 	body: string,
-	grammar: ClaimGrammar = BUILD_CLAIM,
-): string | null => {
+	grammar: ClaimGrammar,
+): {readonly token: string; readonly session: string} | null => {
 	const m = grammar.marker.exec(body);
-	return m?.[1] === undefined || parseToken(m[1], grammar.prefix) === null ? null : m[1];
+	if (m?.[1] === undefined) return null;
+	const parsed = parseToken(m[1], grammar.prefix);
+	return parsed === null ? null : {token: m[1], session: parsed.session};
 };
+
+/** The token a comment body claims in `grammar`, or `null` when it carries no marker of that kind. */
+export const readMarkerToken = (body: string, grammar: ClaimGrammar = BUILD_CLAIM): string | null =>
+	readMarker(body, grammar)?.token ?? null;
 
 export interface ClaimMarker {
 	readonly commentId: number;
 	readonly author: string;
 	readonly createdAt: string;
 	readonly token: string;
+	/** The session the token names — what `build adopt --session` takes when that session is gone. */
+	readonly session: string;
 }
 
 /**
@@ -198,13 +212,13 @@ export const markersIn = (
 ): ReadonlyArray<ClaimMarker> => {
 	const markers: ClaimMarker[] = [];
 	for (const comment of comments) {
-		const token = readMarkerToken(comment.body, grammar);
-		if (token !== null) {
+		const read = readMarker(comment.body, grammar);
+		if (read !== null) {
 			markers.push({
 				commentId: comment.id,
 				author: comment.author,
 				createdAt: comment.createdAt,
-				token,
+				...read,
 			});
 		}
 	}
@@ -437,6 +451,83 @@ export const resolveOwnership = (
 			ownership: {_tag: "Foreign" as const, marker: winner, sameSession},
 			unauthorized,
 			unauthorizedAdopts,
+		};
+	});
+
+/** One claim marker on a thread, with the authority question already answered for it. */
+export interface Claimant extends ClaimMarker {
+	/** Whether the author's repository permission authorizes the marker (ADR 0055). */
+	readonly authorized: boolean;
+}
+
+/** One succession marker, with the same authority question answered. */
+export interface Adopter extends AdoptMarker {
+	readonly authorized: boolean;
+}
+
+/**
+ * Who holds a number, asked by nobody in particular.
+ *
+ * `Unknown` is the whole reason this is a sum rather than a list: a comment page or an ACL read that
+ * failed leaves the question unanswered, and "no claim" is the one answer it must never collapse to.
+ */
+export type Claimants =
+	| {readonly _tag: "Unknown"; readonly reason: string}
+	| {
+			readonly _tag: "Read";
+			/** Every marker on the thread, oldest first — the unauthorized ones included. */
+			readonly claimants: ReadonlyArray<Claimant>;
+			readonly adopts: ReadonlyArray<Adopter>;
+			/** The earliest authorized marker: the one every ownership question resolves against. */
+			readonly holder: Claimant | null;
+	  };
+
+/**
+ * Every claim on `number`, read against no asking lane at all.
+ *
+ * {@link resolveOwnership} answers "is this mine", which is the only question the protocol needed
+ * while every asker held a claim. A driver arriving after a session limit killed its builders holds
+ * none, and had no way to ask which issues those dead lanes left claimed (#6771) — `confirm` requires
+ * a token of the caller's own session, and `claim` would answer only by racing a marker of its own.
+ *
+ * Unlike `resolveOwnership`, which stops at the first authorized marker because the winner is all it
+ * needs, every marker's author is resolved: an unauthorized marker sitting beside the winner is
+ * exactly what explains a thread a driver cannot make sense of, and hiding it would leave the
+ * stranded set half-named. The ACL reader is memoized, so a thread of one author still costs one read.
+ *
+ * It reads and returns. Nothing here clears a claim, and nothing infers one from absence: the two
+ * clearances are `build release` and `build adopt` (ADR 0295).
+ */
+export const readClaimants = (
+	repo: string,
+	number: number,
+	grammar: ClaimGrammar = BUILD_CLAIM,
+): Effect.Effect<Claimants, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const listed = yield* listComments(repo, number);
+		if (listed._tag === "Failure") return {_tag: "Unknown" as const, reason: listed.reason};
+		const authorizationOf = permissionReader(repo);
+		const claimants: Claimant[] = [];
+		for (const marker of markersIn(listed.value, grammar)) {
+			const permission = yield* authorizationOf(marker.author);
+			if (permission._tag === "Unknown") {
+				return {_tag: "Unknown" as const, reason: permission.reason};
+			}
+			claimants.push({...marker, authorized: permission._tag === "Authorized"});
+		}
+		const adopts: Adopter[] = [];
+		for (const adopt of adoptMarkersIn(listed.value, grammar)) {
+			const permission = yield* authorizationOf(adopt.author);
+			if (permission._tag === "Unknown") {
+				return {_tag: "Unknown" as const, reason: permission.reason};
+			}
+			adopts.push({...adopt, authorized: permission._tag === "Authorized"});
+		}
+		return {
+			_tag: "Read" as const,
+			claimants,
+			adopts,
+			holder: claimants.find((claimant) => claimant.authorized) ?? null,
 		};
 	});
 

--- a/packages/fabrika-cli/src/build/claimants-verb.ts
+++ b/packages/fabrika-cli/src/build/claimants-verb.ts
@@ -1,0 +1,150 @@
+/**
+ * `build claimants` — who holds the claim on this number, asked by a caller holding none.
+ *
+ * The protocol's three ownership verbs all ask about the asking lane: `confirm` re-proves this
+ * lane's claim and takes a token that must belong to this session, so a driver arriving after a
+ * session limit killed its builders cannot use it to inspect the numbers those dead lanes left
+ * claimed — and `claim` would answer only by racing a marker of its own, which is a write (#6771).
+ * This asks the board and reports, and it is the whole of what it does.
+ *
+ * **It clears nothing.** ADR 0295 bans a TTL, a lease, a steal and eviction inferred from absence: a
+ * stranded claim passes to a successor through a written `build adopt` and leaves through
+ * `build release`. So this verb's answer is a list a driver acts on, never an act.
+ *
+ * A closed issue is reported rather than refused, unlike the rest of the group's `openIssue` fold:
+ * the question here is answerable on a closed thread, and a claim marker outliving the issue it was
+ * taken on is precisely the strandedness this verb is for. Absent is still `7` — there is no thread
+ * to read — and unreadable is still `11`.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, resolveRepo} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {type Adopter, type Claimant, type Claimants, readClaimants} from "./claim.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const CLAIMANTS = "build claimants";
+
+export interface ClaimantsOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** How the answer names one marker: the token, and the session a successor would adopt. */
+const claimantJson = (claimant: Claimant) => ({
+	commentId: claimant.commentId,
+	author: claimant.author,
+	createdAt: claimant.createdAt,
+	token: claimant.token,
+	session: claimant.session,
+	authorized: claimant.authorized,
+});
+
+const adoptJson = (adopt: Adopter) => ({
+	commentId: adopt.commentId,
+	author: adopt.author,
+	createdAt: adopt.createdAt,
+	adopted: adopt.adopted,
+	token: adopt.token,
+	reason: adopt.reason,
+	authorized: adopt.authorized,
+});
+
+export const runClaimants = (
+	options: ClaimantsOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const resolved = yield* resolveTargetRepo(CLAIMANTS, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {repo} = resolved;
+		const {number} = options;
+
+		const found = yield* getIssue(repo, number);
+		if (found._tag === "Absent") {
+			return refuse(
+				ZERO_SCOPE,
+				`${CLAIMANTS}: issue #${number} is proven absent — there is no thread to read a claim off.`,
+			);
+		}
+		if (found._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${CLAIMANTS}: cannot read #${number}: ${found.reason} — who holds it is UNKNOWN, never "unclaimed".`,
+			);
+		}
+
+		const read = yield* readClaimants(repo, number);
+		if (read._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${CLAIMANTS}: cannot read the claim markers on #${number}: ${read.reason} — who holds it is UNKNOWN, never "unclaimed".`,
+			);
+		}
+
+		const holder = read.holder;
+		const payload = {
+			answer: holder === null ? "unclaimed" : "held",
+			number,
+			holder: holder === null ? null : claimantJson(holder),
+			claimants: read.claimants.map(claimantJson),
+			adopts: read.adopts.map(adoptJson),
+		};
+		const notes = [
+			...(found.value.state === "open" ? [] : [`${CLAIMANTS}: #${number} is closed.`]),
+			...read.claimants
+				.filter((claimant) => !claimant.authorized)
+				.map(
+					(claimant) =>
+						`${CLAIMANTS}: comment ${claimant.commentId} carries a claim marker from "${claimant.author}", who holds no write permission — counted, never a winner.`,
+				),
+		];
+		if (holder === null) {
+			return answer(JSON.stringify(payload), [
+				...notes,
+				`${CLAIMANTS}: no authorized claim marker stands on #${number}.`,
+			]);
+		}
+		const succeeded = read.adopts.some(
+			(adopt) => adopt.authorized && adopt.adopted === holder.session,
+		);
+		return answer(JSON.stringify(payload), [
+			...notes,
+			`${CLAIMANTS}: #${number} is held by ${holder.token} (session ${holder.session}, comment ${holder.commentId}, posted ${holder.createdAt}).`,
+			succeeded
+				? `${CLAIMANTS}: session ${holder.session} has already been adopted — the lane that adopt names releases it.`
+				: `${CLAIMANTS}: if that session is gone, the succession is a written one: fabrika build adopt ${number} --session ${holder.session} --reason "<why>", then release under the token adopt prints. Nothing clears a claim on its own (ADR 0295).`,
+		]);
+	});
+
+/**
+ * The same read, shaped for a sweep: a repo resolved once, then one answer per number.
+ *
+ * `lane stale --claims` pairs a lane with its issue's claim state, and it holds a token for none of
+ * them — so it reaches the board through this rather than through the protocol's own verbs. The
+ * repo is resolved on the first call and reused: a sweep of forty lanes otherwise pays forty
+ * resolutions for one answer that cannot change mid-run.
+ */
+export const claimReader = (
+	repo: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): ((
+	number: number,
+) => Effect.Effect<Claimants, never, ChildProcessSpawner.ChildProcessSpawner>) => {
+	let resolved: string | null = null;
+	return (number) =>
+		Effect.gen(function* () {
+			if (resolved === null) {
+				const attempt = yield* resolveRepo(repo, env);
+				if (attempt._tag === "Failure") {
+					return {
+						_tag: "Unknown" as const,
+						reason: "no target repo resolves — set CLAUDE_PIPELINE_REPO, or pass --repo owner/name",
+					};
+				}
+				resolved = attempt.value;
+			}
+			return yield* readClaimants(resolved, number);
+		});
+};

--- a/packages/fabrika-cli/src/build/claimants-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claimants-verb.unit.test.ts
@@ -1,0 +1,146 @@
+/** `build claimants` — who holds a number, answered to a caller holding no claim and no token. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
+import {runClaimants} from "./claimants-verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	adoptMarker,
+	comments,
+	GATEWAY,
+	GH_TOKEN_ENV,
+	issue,
+	LANE_TOKEN,
+	LANE_UUID,
+	marker,
+	NOT_FOUND,
+	SIBLING_UUID,
+	served,
+} from "./fixtures.test-support.ts";
+
+const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = (login: string) => new RegExp(`GET .*/repos/o/r/collaborators/${login}/permission`);
+
+const WRITE = served({permission: "write"});
+const READ_ONLY = served({permission: "read"});
+
+/** No CLAUDE_CODE_SESSION_ID anywhere: the verb answers without an identity of its own. */
+const ENV = {...GH_TOKEN_ENV, CLAUDE_PIPELINE_REPO: "o/r"};
+
+const run = (script: ReadonlyArray<Scripted>) =>
+	Effect.runPromise(
+		Effect.provide(runClaimants({number: 4312, repo: null, env: ENV}), fakeSeams(script).layer),
+	);
+
+describe("build claimants", () => {
+	it("names the holder, its session and the adopt route, holding no token itself", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 9001, body: marker("s-dead", LANE_UUID)})],
+			[PERM("agent"), WRITE],
+		]);
+
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer).toMatchObject({
+			answer: "held",
+			number: 4312,
+			holder: {
+				commentId: 9001,
+				token: `build:s-dead:${LANE_UUID}`,
+				session: "s-dead",
+				authorized: true,
+			},
+		});
+		expect(out.stderr.join("\n")).toContain("fabrika build adopt 4312 --session s-dead");
+	});
+
+	it("lists every marker, not only the winner, and counts an unauthorized one as never a winner", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[
+				COMMENTS,
+				comments(
+					{id: 9001, body: marker("s-drive-by", SIBLING_UUID), author: "outsider"},
+					{id: 9002, body: marker("s-9f2e", LANE_UUID), author: "agent"},
+				),
+			],
+			[PERM("outsider"), READ_ONLY],
+			[PERM("agent"), WRITE],
+		]);
+
+		const answer = JSON.parse(out.stdout);
+		expect(answer.claimants.map((row: {commentId: number}) => row.commentId)).toEqual([9001, 9002]);
+		expect(answer.holder.token).toBe(LANE_TOKEN);
+		expect(out.stderr.join("\n")).toContain("counted, never a winner");
+	});
+
+	it("says a succession is already recorded rather than pointing at a second adopt", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[
+				COMMENTS,
+				comments(
+					{id: 9001, body: marker("s-dead", LANE_UUID)},
+					{id: 9002, body: adoptMarker("s-dead", "s-live", SIBLING_UUID)},
+				),
+			],
+			[PERM("agent"), WRITE],
+		]);
+
+		expect(JSON.parse(out.stdout).adopts).toHaveLength(1);
+		expect(out.stderr.join("\n")).toContain("has already been adopted");
+	});
+
+	it("answers unclaimed on a thread carrying no authorized marker", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 9001, body: "ordinary discussion"})],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "unclaimed", holder: null});
+	});
+
+	it("answers a CLOSED issue rather than refusing it — a marker outliving its issue is the point", async () => {
+		const out = await run([
+			[ISSUE, issue({state: "closed"})],
+			[COMMENTS, comments({id: 9001, body: marker("s-dead", LANE_UUID)})],
+			[PERM("agent"), WRITE],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("held");
+		expect(out.stderr.join("\n")).toContain("#4312 is closed");
+	});
+
+	it("refuses an absent issue on 7 — there is no thread to read", async () => {
+		const out = await run([[ISSUE, NOT_FOUND]]);
+
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("is UNKNOWN, never unclaimed, when the comments cannot be read", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[COMMENTS, GATEWAY],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain('UNKNOWN, never "unclaimed"');
+	});
+
+	it("is UNKNOWN, never a demotion, when an author's permission cannot be read", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 9001, body: marker("s-dead", LANE_UUID)})],
+			[PERM("agent"), GATEWAY],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -24,6 +24,7 @@ import {refuse, type VerbOutcome} from "../verb.ts";
 import {runBranch} from "./branch-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runAdopt, runClaim, runConfirm, runRelease} from "./claim-verb.ts";
+import {runClaimants} from "./claimants-verb.ts";
 import {type DocumentRead, runClear} from "./clear-verb.ts";
 import {OFF_VOCABULARY} from "./codes.ts";
 import {runCommit} from "./commit-verb.ts";
@@ -221,6 +222,19 @@ const confirm = leafCommand(
 	Command.withShortDescription("Re-prove this session still holds the claim."),
 	Command.withDescription(
 		'Re-prove THIS LANE still holds the claim, before a mutation. --token is the lane asking: one session runs many lanes, so ownership turns on the whole token and a same-session marker under another nonce is a proven loss (#6037). Prints {"answer":"mine","number":n,"token":"…"}. Exits 1 (CLAUDE_CODE_SESSION_ID unset, or --token is not a claim token of this session), 7 (issue proven absent or closed), 11 (the marker set could not be read — UNKNOWN, never "unclaimed"), 15 (proven: held by another lane, or no claim exists — the detail is on stderr, naming both tokens). Example: fabrika build confirm 4312 --token build:s-9f2e:c1a4d6f8-…',
+	),
+);
+
+const claimants = leafCommand(
+	"claimants",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runClaimants({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Which sessions hold live claims on one issue."),
+	Command.withDescription(
+		'Read who holds the claim on an issue, holding none yourself. It takes no --token and needs no session: confirm re-proves THIS lane\'s claim and refuses a token of any other session, so a driver arriving after a session limit killed its builders could not ask which numbers those dead lanes left claimed (#6771). It writes nothing, and it clears nothing — a stranded claim leaves through "fabrika build adopt" then "fabrika build release", never through a TTL, a lease or an inference from absence (ADR 0295). Prints {"answer":"held"|"unclaimed","number":n,"holder":{"commentId","author","createdAt","token","session","authorized"}|null,"claimants":[…],"adopts":[…]}: the holder is the EARLIEST AUTHORIZED marker, the same one every ownership question resolves against, and every other marker is listed beside it — an unauthorized one is counted and named on stderr, never a winner (ADR 0055). A closed issue is answered rather than refused, because a marker outliving its issue is exactly the strandedness this reads for; its state is named on stderr. Exits 7 (the issue is proven absent — there is no thread to read), 11 (the issue, its comments or an author\'s permission could not be read — UNKNOWN, never "unclaimed"). Example: fabrika build claimants 6669',
 	),
 );
 
@@ -644,6 +658,7 @@ export const buildCommand = Command.make("build").pipe(
 		eligible,
 		claim,
 		confirm,
+		claimants,
 		release,
 		adopt,
 		issue,

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -10,6 +10,7 @@ import {randomUUID} from "node:crypto";
 import {fileURLToPath} from "node:url";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {claimReader} from "../build/claimants-verb.ts";
 import {resolveEntrypoint} from "../delegate/entrypoint.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {SHIP_CLASS_NAMES} from "../review/classes.ts";
@@ -504,8 +505,19 @@ const stale = leafCommand(
 				`minutes of silence before a lane something is owed on is stale (default: ${DEFAULT_STALE_MINUTES})`,
 			),
 		),
+		claims: Flag.boolean("claims").pipe(
+			Flag.withDescription(
+				"additionally read the board and pair each non-terminal lane with the claim standing on its issue — the one thing here that makes a network call (default: false)",
+			),
+		),
+		repo: Flag.string("repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the owner/name the --claims pairing reads (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote); read only with --claims",
+			),
+		),
 	},
-	Effect.fn(function* ({root, olderThan}) {
+	Effect.fn(function* ({root, olderThan, claims, repo}) {
 		yield* emit(
 			yield* runStale({
 				roots: Option.match(root, {
@@ -514,13 +526,14 @@ const stale = leafCommand(
 				}),
 				olderThanMinutes: Option.getOrElse(olderThan, () => DEFAULT_STALE_MINUTES),
 				now: new Date().toISOString(),
+				claims: claims ? claimReader(Option.getOrNull(repo), process.env) : null,
 			}),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Which lanes have gone quiet with something owed on them."),
 	Command.withDescription(
-		`Sweep every lane on disk and answer which ones nothing is driving. A lane's ledger records state, not liveness, so a shell that dies leaves the lane reading active forever (#5897); the age here comes off the \`at\` every event line already carries — nothing new is stored. stdout is {now, olderThanMinutes, scanned, summary, lanes}, oldest silence first, each lane carrying its folded stateValue, its last event's timestamp, its age in minutes and one verdict: "stale" (non-terminal, unparked and silent past the threshold), "moving", "parked" (blocked or a human:* hold — a park is meant to sit), "terminal", "unstarted" (a lane with no events at all, so no age to judge) or "unreadable" (the lane is there and its record is not readable — it is reported, never dropped). Both default roots are swept unless --root names one; an absent root holds no lanes and is not a fault, and zero lanes is an empty answer at exit 0. Stale lanes exit 0 too — this reports, it never resumes. Exits 1 (--older-than is not a non-negative number of minutes), 11 (a root is there and could not be listed — the lane set is UNKNOWN, never a short list). Examples: fabrika lane stale · fabrika lane stale --older-than 30`,
+		`Sweep every lane on disk and answer which ones nothing is driving. A lane's ledger records state, not liveness, so a shell that dies leaves the lane reading active forever (#5897); the age here comes off the \`at\` every event line already carries — nothing new is stored. stdout is {now, olderThanMinutes, scanned, summary, lanes}, oldest silence first, each lane carrying its folded stateValue, its last event's timestamp, its age in minutes and one verdict: "stale" (non-terminal, unparked and silent past the threshold), "moving", "parked" (blocked or a human:* hold — a park is meant to sit), "terminal", "unstarted" (a lane with no events at all, so no age to judge) or "unreadable" (the lane is there and its record is not readable — it is reported, never dropped). Both default roots are swept unless --root names one; an absent root holds no lanes and is not a fault, and zero lanes is an empty answer at exit 0. Stale lanes exit 0 too — this reports, it never resumes. Without --claims the whole sweep runs off disk and makes no network call. --claims additionally reads the board and pairs each NON-TERMINAL lane with the claim standing on its issue, which is the other half a session limit strands: the dead builder's claim marker outlives it, and the lane log cannot see that (#6771). Each paired row then carries claims: {"state":"held",token,session,author,commentId} | {"state":"unclaimed"} | {"state":"unknown",reason} — a board read that failed is unknown, never "unclaimed" — and the answer carries a top-level claims summary, null when the board was never asked. Chore lanes drive no issue and are not paired. Nothing here clears a claim: a stranded one leaves through "fabrika build adopt" then "fabrika build release" (ADR 0295), and "fabrika build claimants <n>" reads one issue the same way. Exits 1 (--older-than is not a non-negative number of minutes), 11 (a root is there and could not be listed — the lane set is UNKNOWN, never a short list). Examples: fabrika lane stale · fabrika lane stale --older-than 30 · fabrika lane stale --claims`,
 	),
 );
 

--- a/packages/fabrika-cli/src/lane/stale-verb.ts
+++ b/packages/fabrika-cli/src/lane/stale-verb.ts
@@ -10,8 +10,15 @@
  * one broken lane would hide every other lane's silence, which is the failure this verb exists to
  * end. The sweep itself refuses only when a root it was asked to scan is there and cannot be listed —
  * that leaves the lane set UNKNOWN, and an UNKNOWN lane set is never a short list.
+ *
+ * The sweep is **offline unless a caller asks for more**. A session limit strands a lane's state and
+ * the claim marker its dead builder left on the issue, and only the first is on disk (#6771) — so
+ * `claims` pairs the second onto each non-terminal row. It is a reader the caller passes rather than
+ * a flag this module reads, which is what keeps the default provable: with no reader there is no
+ * seam to reach the board through.
  */
 import {Effect, type FileSystem, type Path, Result} from "effect";
+import type {Claimants} from "../build/claim.ts";
 import {exists, readDir} from "../io/fs.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {LANE_UNREADABLE} from "./codes.ts";
@@ -22,13 +29,37 @@ import {DEFAULT_CHORES_ROOT, loadLane} from "./store.ts";
 
 const VERB = "fabrika lane stale";
 
-export interface StaleOptions {
+/** The board read that pairs one issue with its claim state — the sweep's only network seam. */
+export type ClaimReader<R> = (number: number) => Effect.Effect<Claimants, never, R>;
+
+export interface StaleOptions<R = never> {
 	/** The lane roots to sweep, in order. An absent root is an empty one, not a fault. */
 	readonly roots: ReadonlyArray<string>;
 	readonly olderThanMinutes: number;
 	/** The instant the ages are measured against, ISO — the adapter's clock, so the verb stays pure. */
 	readonly now: string;
+	/** The claim reader, or `null` for the offline sweep every caller gets by default. */
+	readonly claims: ClaimReader<R> | null;
 }
+
+/**
+ * What the board says about the issue a lane drives.
+ *
+ * `unknown` is a seat rather than an absent field for the reason every read in this protocol keeps
+ * it: a comment page that did not load says nothing about whether a claim stands, and calling it
+ * `unclaimed` would tell a driver an issue is free to pick up when it may not be.
+ */
+type LaneClaim =
+	| {
+			readonly state: "held";
+			readonly token: string;
+			/** The session to name in `build adopt --session` when that session is gone. */
+			readonly session: string;
+			readonly author: string;
+			readonly commentId: number;
+	  }
+	| {readonly state: "unclaimed"}
+	| {readonly state: "unknown"; readonly reason: string};
 
 interface LaneRow extends Judgement {
 	/** The key this lane is addressed by — what a caller passes to any other `lane` verb. */
@@ -38,6 +69,8 @@ interface LaneRow extends Judgement {
 	readonly status: LaneStatus["status"] | null;
 	/** Why the lane could not be judged; absent on every readable lane. */
 	readonly reason?: string;
+	/** The claim on this lane's issue; absent unless a reader was passed and this row was paired. */
+	readonly claims?: LaneClaim;
 }
 
 interface ScannedRoot {
@@ -131,9 +164,43 @@ const byAge = (left: LaneRow, right: LaneRow): number => {
 	return left.key.localeCompare(right.key);
 };
 
-export const runStale = (
-	options: StaleOptions,
-): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+/**
+ * The issue a lane key names, or `null` when it names none.
+ *
+ * A chore lane is keyed `chore:<name>` and drives no issue, so there is no thread to pair it with —
+ * and a claim is a fact about an issue, never about a lane directory.
+ */
+const issueOf = (key: string): number | null =>
+	/^[0-9]+$/.test(key) ? Number.parseInt(key, 10) : null;
+
+/** The row plus what the board says about its issue — a terminal lane and a chore lane are skipped. */
+const pair = <R>(row: LaneRow, read: ClaimReader<R>): Effect.Effect<LaneRow, never, R> =>
+	Effect.gen(function* () {
+		const issue = issueOf(row.key);
+		if (issue === null || row.verdict === "terminal") return row;
+		const claimants = yield* read(issue);
+		if (claimants._tag === "Unknown") {
+			return {...row, claims: {state: "unknown" as const, reason: claimants.reason}};
+		}
+		const holder = claimants.holder;
+		return {
+			...row,
+			claims:
+				holder === null
+					? {state: "unclaimed" as const}
+					: {
+							state: "held" as const,
+							token: holder.token,
+							session: holder.session,
+							author: holder.author,
+							commentId: holder.commentId,
+						},
+		};
+	});
+
+export const runStale = <R = never>(
+	options: StaleOptions<R>,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path | R> =>
 	Effect.gen(function* () {
 		if (!Number.isFinite(options.olderThanMinutes) || options.olderThanMinutes < 0) {
 			return refuse(FAILED, `${VERB}: --older-than must be a non-negative number of minutes.`);
@@ -177,8 +244,17 @@ export const runStale = (
 		const summary = Object.fromEntries(
 			VERDICTS.map((verdict) => [verdict, lanes.filter((row) => row.verdict === verdict).length]),
 		);
-		const sorted = [...lanes].sort(byAge);
+		const reader = options.claims;
+		const paired: LaneRow[] =
+			reader === null
+				? lanes
+				: yield* Effect.forEach(lanes, (row) => pair(row, reader), {concurrency: 1});
+		const sorted = [...paired].sort(byAge);
 		const stale = sorted.filter((row) => row.verdict === "stale");
+		const held = sorted.flatMap((row) =>
+			row.claims?.state === "held" ? [`${row.key} (${row.claims.token})`] : [],
+		);
+		const unknown = sorted.flatMap((row) => (row.claims?.state === "unknown" ? [row.key] : []));
 		return answer(
 			JSON.stringify(
 				{
@@ -186,6 +262,16 @@ export const runStale = (
 					olderThanMinutes: options.olderThanMinutes,
 					scanned,
 					summary,
+					// `null` says the board was never asked, which "nothing is held" would silently claim.
+					claims:
+						reader === null
+							? null
+							: {
+									paired: sorted.filter((row) => row.claims !== undefined).length,
+									held: held.length,
+									unclaimed: sorted.filter((row) => row.claims?.state === "unclaimed").length,
+									unknown: unknown.length,
+								},
 					lanes: sorted,
 				},
 				null,
@@ -196,6 +282,22 @@ export const runStale = (
 				stale.length === 0
 					? `${VERB}: no lane has been silent for ${options.olderThanMinutes} minute(s) with something owed on it.`
 					: `${VERB}: ${stale.length} stale: ${stale.map((row) => `${row.key} (${String(row.ageMinutes)}m)`).join(", ")}.`,
+				...(reader === null
+					? []
+					: [
+							held.length === 0
+								? `${VERB}: no non-terminal lane's issue carries a live claim.`
+								: `${VERB}: ${held.length} lane(s) whose issue is still claimed: ${held.join(
+										", ",
+									)} — a claim clears through "fabrika build adopt" then "fabrika build release", never on its own (ADR 0295).`,
+						]),
+				...(unknown.length === 0
+					? []
+					: [
+							`${VERB}: ${unknown.length} lane(s) whose claim state could not be read: ${unknown.join(
+								", ",
+							)} — UNKNOWN, never "unclaimed".`,
+						]),
 			],
 		);
 	});

--- a/packages/fabrika-cli/src/lane/stale-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/stale-verb.unit.test.ts
@@ -1,6 +1,7 @@
 /** `lane stale` — the sweep across lanes, its per-lane rows, and the one thing it refuses. */
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
+import type {Claimants} from "../build/claim.ts";
 import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
 import {LANE_UNREADABLE} from "./codes.ts";
 import {coderTemplateText} from "./fixtures.test-support.ts";
@@ -40,6 +41,13 @@ const tree = (lanes: ReadonlyArray<LaneFixture>, extra: FakeFsOptions = {}) => {
 	});
 };
 
+/**
+ * The default sweep, run with the filesystem as its ONLY provided service.
+ *
+ * That is the offline claim, stated where a test can red it: the claim reader is the verb's one
+ * network seam, `null` removes it, and a run that reached the board here would want a service this
+ * environment does not carry.
+ */
 const sweep = (
 	fs: ReturnType<typeof fakeFs>,
 	options: {roots?: ReadonlyArray<string>; olderThanMinutes?: number; now?: string} = {},
@@ -50,10 +58,47 @@ const sweep = (
 				roots: options.roots ?? [DEFAULT_LANES_ROOT],
 				olderThanMinutes: options.olderThanMinutes ?? 60,
 				now: options.now ?? NOW,
+				claims: null,
 			}),
 			fs.layer,
 		),
 	);
+
+/** The same sweep with a scripted board reader, and the log of every number it was asked about. */
+const sweepWithClaims = (
+	fs: ReturnType<typeof fakeFs>,
+	claimants: (number: number) => Claimants,
+	options: {roots?: ReadonlyArray<string>} = {},
+) => {
+	const asked: Array<number> = [];
+	return Effect.runPromise(
+		Effect.provide(
+			runStale({
+				roots: options.roots ?? [DEFAULT_LANES_ROOT],
+				olderThanMinutes: 60,
+				now: NOW,
+				claims: (number) =>
+					Effect.sync(() => {
+						asked.push(number);
+						return claimants(number);
+					}),
+			}),
+			fs.layer,
+		),
+	).then((out) => ({out, asked}));
+};
+
+const HOLDER = {
+	commentId: 9001,
+	author: "agent",
+	createdAt: minutesAgo(80),
+	token: "build:s-dead:c1a4d6f8-1111-2222-3333-444455556666",
+	session: "s-dead",
+	authorized: true,
+} as const;
+
+const held: Claimants = {_tag: "Read", claimants: [HOLDER], adopts: [], holder: HOLDER};
+const unclaimed: Claimants = {_tag: "Read", claimants: [], adopts: [], holder: null};
 
 describe("lane stale", () => {
 	it("reports a driven lane silent past the threshold as stale, with its state and age", async () => {
@@ -219,5 +264,76 @@ describe("lane stale", () => {
 
 		expect(out.code).toBe(1);
 		expect(out.stdout).toBe("");
+	});
+
+	describe("--claims", () => {
+		it("reads no board at all by default — no row carries a claim, and the summary says unasked", async () => {
+			const out = await sweep(tree([{lane: "6669", log: line("WIP", minutesAgo(90))}]));
+			const answer = JSON.parse(out.stdout);
+
+			expect(answer.claims).toBeNull();
+			expect(answer.lanes[0]).not.toHaveProperty("claims");
+		});
+
+		it("pairs a stale lane with the claim its dead builder left on the issue", async () => {
+			const {out, asked} = await sweepWithClaims(
+				tree([{lane: "6669", log: line("WIP", minutesAgo(90))}]),
+				() => held,
+			);
+			const answer = JSON.parse(out.stdout);
+
+			expect(asked).toEqual([6669]);
+			expect(answer.lanes[0].claims).toEqual({
+				state: "held",
+				token: HOLDER.token,
+				session: "s-dead",
+				author: "agent",
+				commentId: 9001,
+			});
+			expect(answer.claims).toEqual({paired: 1, held: 1, unclaimed: 0, unknown: 0});
+			expect(out.stderr.join("\n")).toContain(`6669 (${HOLDER.token})`);
+		});
+
+		it("answers unknown on a board read that failed, never unclaimed", async () => {
+			const {out} = await sweepWithClaims(
+				tree([{lane: "6670", log: line("WIP", minutesAgo(90))}]),
+				() => ({_tag: "Unknown", reason: "GitHub answered 502"}),
+			);
+			const answer = JSON.parse(out.stdout);
+
+			expect(answer.lanes[0].claims).toEqual({
+				state: "unknown",
+				reason: "GitHub answered 502",
+			});
+			expect(answer.claims).toMatchObject({unknown: 1, unclaimed: 0});
+			expect(out.stderr.join("\n")).toContain('UNKNOWN, never "unclaimed"');
+		});
+
+		it("asks about neither a terminal lane nor a chore lane — one drives no work, the other no issue", async () => {
+			const done =
+				line("WIP", minutesAgo(300)) +
+				line("DONE", minutesAgo(290)) +
+				line("PASS", minutesAgo(280)) +
+				line("DONE", minutesAgo(270));
+			const {out, asked} = await sweepWithClaims(
+				tree([
+					{lane: "6671", log: done},
+					{lane: "6672", log: line("WIP", minutesAgo(90))},
+					{root: DEFAULT_CHORES_ROOT, lane: "sweep", log: line("WIP", minutesAgo(90))},
+				]),
+				() => unclaimed,
+				{roots: [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT]},
+			);
+			const answer = JSON.parse(out.stdout);
+			const rows = Object.fromEntries(
+				answer.lanes.map((row: {key: string; claims?: unknown}) => [row.key, row.claims]),
+			);
+
+			expect(asked).toEqual([6672]);
+			expect(rows["6671"]).toBeUndefined();
+			expect(rows["chore:sweep"]).toBeUndefined();
+			expect(rows["6672"]).toEqual({state: "unclaimed"});
+			expect(answer.claims).toEqual({paired: 1, held: 0, unclaimed: 1, unknown: 0});
+		});
 	});
 });

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -350,6 +350,8 @@ const open = leafCommand(
 							roots,
 							olderThanMinutes: DEFAULT_STALE_MINUTES,
 							now: new Date().toISOString(),
+							// The front door renders on a cold start and must not wait on the board for it.
+							claims: null,
 						}),
 						roots,
 						asOf,

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -977,7 +977,7 @@ describe("the lanes field renders `lane stale`'s sweep, never a second staleness
 	const sweep = (fs: ReturnType<typeof fakeFs>) =>
 		Effect.runPromise(
 			Effect.provide(
-				runStale({roots: ROOTS, olderThanMinutes: DEFAULT_STALE_MINUTES, now: NOW}),
+				runStale({roots: ROOTS, olderThanMinutes: DEFAULT_STALE_MINUTES, now: NOW, claims: null}),
 				fs.layer,
 			),
 		);


### PR DESCRIPTION
Fixes #6771

A driver that arrives after a session limit killed its builders can list the lanes that stopped, but not the issues those dead lanes left claimed — so it opens each one by hand. `lane stale` already answers the first half off disk. This adds the second half.

**`fabrika build claimants <n>`** reads who holds an issue's claim, holding none itself. `build confirm` cannot answer this: it re-proves *this lane's* claim and refuses a token from any other session, and `build claim` would answer only by racing a marker of its own, which is a write. The new verb takes no `--token` and needs no session. It prints the holder (the earliest authorized marker — the same one every ownership question resolves against), every other marker beside it, and any adopt markers. An unauthorized marker is counted and named on stderr, never a winner (ADR 0055). A comment page or an ACL read that failed is exit 11, never "unclaimed". A closed issue is answered rather than refused, since a marker outliving its issue is exactly the strandedness this reads for; absent is still exit 7.

**`fabrika lane stale --claims`** pairs each non-terminal lane with that read, so one command names the stranded set after a limit window. Chore lanes drive no issue and terminal lanes owe nothing, so neither is paired. Each paired row carries `claims: held | unclaimed | unknown`, and the top-level `claims` summary is `null` when the board was never asked — which is the fact "nothing is held" would otherwise silently claim.

**The default stays offline.** The reader is a value the caller passes, not a flag the sweep reads, so with no reader there is no seam to reach the board through: `fabrika lane stale` and `status open`'s lanes field run exactly as before, and the unit tests provide the filesystem as their only service.

**Nothing clears a claim.** ADR 0295 bans a TTL, a lease, a steal and eviction inferred from absence; `build release` and `build adopt` stay the only clearances, and both new surfaces point at them rather than acting.

The marker grammar is not re-derived: `readClaimants` lives in `build/claim.ts` beside `resolveOwnership` and reads through the same `markersIn` / `adoptMarkersIn`. `ClaimMarker` now carries the session out of the parse the token's well-formedness already turns on, rather than letting a call site parse it a second time.

Verified live on this repo: `build claimants 6771` names this lane's own claim, and `lane stale --claims` over the real lanes root swept 168 lanes, paired the 25 non-terminal ones, and found the one held issue.

## Deviations

- **Out-of-scope change** — **Said:** #6771 asks for a read-only claim answer and an opt-in sweep pairing. **Did:** also added `session` to `ClaimMarker`, which every existing marker reader now carries. **Why:** the answer must name the session for `build adopt --session`, and deriving it at the new call site is the second parse the acceptance criteria's "not re-derived" rule exists to prevent. **Disposition:** stated here; no existing behaviour reads the new field.
- **Out-of-scope change** — **Said:** nothing about `status open`. **Did:** passed `claims: null` at its `runStale` call site. **Why:** the reader became a required option, and the front door must stay an offline cold-start read. **Disposition:** stated here.
