### PR TITLE
fix: git stash is one stack for every worktree, so parallel lanes pop each other's work

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -75,19 +75,21 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   one; address git at your worktree explicitly.** This is the cwd-reset bullet's most
   damaging instance. A worktree agent *armed* by `@kampus/worktree-guard` has its
   non-mutating bare commands prepended with `cd "$WORKTREE_ROOT" && …`; a bare
-  **working-state-mutating** op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) that
+  **working-state-mutating** op (`checkout`/`switch`/`reset`/`rebase`/`merge`) that
   is not scoped to the worktree is now **refused outright** by the `pre-bash` guard (the
   enforced guard route below), because cd-pinning it would only relocate the mutation into
-  the worktree rather than surface the mistake. The class this closes: a bare
+  the worktree rather than surface the mistake. (`stash` is **not** on that list because
+  scoping does not save it — see the stash hazard below, where the rule is *never*, not
+  *scope it*.) The class this closes: a bare
   `git checkout <pr-head-sha>`, run after a between-calls cwd reset, executes in the
-  **primary** tree — detaching the shared `main`, or (for a bare `stash pop` / `merge`)
+  **primary** tree — detaching the shared `main`, or (for a bare `merge`)
   corrupting its working tree — which then stalls a sibling puller's `git merge --ff-only
   origin/main` with the symptom (puller stuck, merged work not propagating) far from the cause.
   The rule, mandatory for **every** worktree/review/ship agent:
   - **Capture `WT="$(git rev-parse --show-toplevel)"` once at spawn** (right after the
     opening worktree preflight passes) and run **ALL** git ops as `git -C "$WT" …`, so a
     cwd reset can never silently relocate the command into the primary tree.
-  - **Never run a bare `git checkout` / `git switch`** (nor `rebase` / `reset` / `stash` /
+  - **Never run a bare `git checkout` / `git switch`** (nor `rebase` / `reset` /
     `merge`) against a shared checkout. To bring a **PR head** in for review, fetch and check out
     *inside the worktree* by ref, not by a bare SHA:
     ```bash
@@ -107,7 +109,12 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   `$WORKTREE_ROOT`) and its legitimate `git checkout main` (ff-pull/reattach) are **never**
   intercepted. The safe form it points agents to — `git -C "$WT" <op> …`, or `git -C "$WT" fetch
   origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD` for a PR head — is recognized as
-  worktree-scoped and **allowed**. The prose-only rule alone did not hold (the detach recurred
+  worktree-scoped and **allowed** — **for the HEAD-moving ops named above, and for those only.**
+  Scoping is a real remedy when the damage is "the command landed in the wrong tree", which is every
+  op on that list. It is **not** a remedy for `stash`, whose damage is that the stack itself is
+  shared: `git -C "$WT" stash push` is textbook worktree-scoped and still writes the shared stack.
+  Do not read this paragraph as licensing a scoped `stash` (it did, and that is how #6701's incident
+  happened). The prose-only rule alone did not hold (the detach recurred
   after it shipped), which is why the mechanical guard route was taken (#1571).
 
   **Keeping the primary current, by hand.** `pipeline-cli main-sync` retired with that package and
@@ -128,6 +135,40 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   PULLER/orchestrator ROE therefore stands on prose alone: drive sync ONLY through the
   fetch-inspect-`ff-only` seam — never a bare `checkout -B main` / `branch -f main` / `reset` /
   `update-ref refs/heads/main` on the primary checkout.**
+
+- **`git stash` is repository-global — a lane worktree NEVER runs it, in any form.** `refs/stash`
+  lives in the **common** git dir, not the per-worktree one, so every worktree of a clone pushes to
+  and pops from **one** stack. Prove it from any linked tree:
+
+  ```bash
+  git rev-parse --git-dir --git-common-dir        # differ in a linked worktree
+  git rev-parse --git-path refs/stash             # resolves under the COMMON dir either way
+  ```
+
+  This is the one hazard on this page that **scoping does not fix**. `git -C "$WT" stash push` is
+  correctly scoped to your worktree and still writes the shared stack, so the bullet above's remedy —
+  address git at your worktree explicitly — is no defence here. Between your `push` and your `pop` a
+  sibling lane's entry becomes `stash@{0}`, and your `pop` restores **their** files into **your** tree
+  and drops their stash commit. Neither command warns; the pop reports success. Lanes #6643 and #6646
+  did exactly this to each other on 2026-08-20, both children of one epic
+  ([#6701](https://github.com/kamp-us/phoenix/issues/6701)) — and epic runs fan several lanes on
+  purpose, so the collision window is routine, not rare.
+
+  **What to do instead.** To get a clean tree for a baseline run, commit to your lane branch and
+  `git -C "$WT" reset` back to it afterwards, or read the baseline from a second checkout. Both keep
+  your work on a ref only your lane names.
+
+  **Recovery, if a pop already ate someone's work.** A dropped stash commit stays reachable through
+  the reflog for its expiry window, and files can be lifted out of it without touching the shared
+  stack:
+
+  ```bash
+  git -C "$WT" reflog stash                       # names the dropped commits
+  git -C "$WT" restore --source=<stash-sha> --worktree -- <paths>
+  ```
+
+  `git restore --source=<sha>` reads one commit and writes the named paths — no push, no pop, no drop,
+  so it cannot damage a sibling lane the way the recovery attempt itself otherwise might.
 
 - **Run root `pnpm` scripts as `pnpm -w <script>` (or from the worktree root),
   never from a subdir.** A root-level script (`pnpm lint`, `pnpm typecheck`, …) run

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -82,8 +82,8 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   where a review-doc agent's `git stash pop` + `reset --hard` silently discarded the owner's
   uncommitted work — but the guard refused only the **unscoped** form and allowed
   `git -C "$WT" stash`, and that allowance is the hole #6701 fell through. So read the stash
-  hazard below rather than this bullet: there the rule is *never*, not *scope it*.
-  The class this closes: a bare
+  hazard below rather than this bullet: there the rule is *never*, not *scope it*. The class this
+  closes: a bare
   `git checkout <pr-head-sha>`, run after a between-calls cwd reset, executes in the
   **primary** tree — detaching the shared `main`, or (for a bare `stash pop` / `merge`)
   corrupting its working tree — which then stalls a sibling puller's `git merge --ff-only
@@ -118,9 +118,8 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   and scoping is a real remedy. For `stash` the damage is that the stack itself is shared:
   `git -C "$WT" stash push` is textbook worktree-scoped and still writes the shared stack, so the
   guard waved through the exact command that caused #6701. Do not read this paragraph as licensing a
-  scoped `stash`; that rule is *never*, in any form.
-  The prose-only rule alone did not hold (the detach recurred
-  after it shipped), which is why the mechanical guard route was taken (#1571).
+  scoped `stash`; that rule is *never*, in any form. The prose-only rule alone did not hold (the
+  detach recurred after it shipped), which is why the mechanical guard route was taken (#1571).
 
   **Keeping the primary current, by hand.** `pipeline-cli main-sync` retired with that package and
   has no fabrika successor, so the driving session drives sync itself:
@@ -155,22 +154,33 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   address git at your worktree explicitly — is no defence here. Between your `push` and your `pop` a
   sibling lane's entry becomes `stash@{0}`, and your `pop` restores **their** files into **your** tree
   and drops their stash commit. Neither command warns; the pop reports success. Lanes #6643 and #6646
-  did exactly this to each other on 2026-08-20, both children of one epic
-  ([#6701](https://github.com/kamp-us/phoenix/issues/6701)) — and epic runs fan several lanes on
-  purpose, so the collision window is routine, not rare.
+  did exactly this to each other on 2026-08-20, both children of epic
+  [#6629](https://github.com/kamp-us/phoenix/issues/6629); the incident is reported in full on
+  [#6701](https://github.com/kamp-us/phoenix/issues/6701). Epic runs fan several lanes on purpose, so
+  the collision window is routine, not rare.
 
   **What to do instead.** To get a clean tree for a baseline run, commit to your lane branch and
   `git -C "$WT" reset` back to it afterwards, or read the baseline from a second checkout. Both keep
   your work on a ref only your lane names.
 
-  **Recovery, if a pop already ate someone's work.** A dropped stash commit stays reachable through
-  the reflog for its expiry window, and files can be lifted out of it without touching the shared
-  stack:
+  **Recovery, if a pop already ate someone's work.** The commit survives the drop for its expiry
+  window, so the files can be lifted out of it — but **`git reflog stash` will not name it.** A clean
+  `pop` deletes the entry from the stash reflog as it drops, and if that was the last entry the
+  command is a hard error (`fatal: ambiguous argument 'stash'`); with siblings left on the stack it
+  succeeds and simply omits the SHA you need. Verified live on git 2.40.1, and it is `git-stash(1)`'s
+  own position under *"Recovering stash entries that were cleared/dropped erroneously"*: dropped
+  entries "cannot be recovered through the normal safety mechanisms". Use the incantation that manual
+  prescribes instead:
 
   ```bash
-  git -C "$WT" reflog stash                       # names the dropped commits
+  git -C "$WT" fsck --unreachable | grep commit    # lists the dropped stash commits (repo-wide)
+  git -C "$WT" show --stat <stash-sha>             # identify which one is the lost work
   git -C "$WT" restore --source=<stash-sha> --worktree -- <paths>
   ```
+
+  The reflog is worth a look only while the entry is still **on** the stack — a `pop` that stopped on
+  a conflict leaves it there, and so does a plain `push` you have not popped yet. Once it drops,
+  `fsck` is the only route.
 
   `git restore --source=<sha>` reads one commit and writes the named paths — no push, no pop, no drop,
   so it cannot damage a sibling lane the way the recovery attempt itself otherwise might.

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -73,16 +73,19 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
 
 - **A bare `git checkout`/`switch` can detach the *shared primary* HEAD — never run
   one; address git at your worktree explicitly.** This is the cwd-reset bullet's most
-  damaging instance. A worktree agent *armed* by `@kampus/worktree-guard` has its
+  damaging instance. A worktree agent *armed* by `@kampus/worktree-guard` had its
   non-mutating bare commands prepended with `cd "$WORKTREE_ROOT" && …`; a bare
-  **working-state-mutating** op (`checkout`/`switch`/`reset`/`rebase`/`merge`) that
-  is not scoped to the worktree is now **refused outright** by the `pre-bash` guard (the
-  enforced guard route below), because cd-pinning it would only relocate the mutation into
-  the worktree rather than surface the mistake. (`stash` is **not** on that list because
-  scoping does not save it — see the stash hazard below, where the rule is *never*, not
-  *scope it*.) The class this closes: a bare
+  **working-state-mutating** op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) that
+  was not scoped to the worktree was **refused outright** by the `pre-bash` guard (the
+  retired guard route below), because cd-pinning it would only relocate the mutation into
+  the worktree rather than surface the mistake. `stash` **was** on that list — added for #2030,
+  where a review-doc agent's `git stash pop` + `reset --hard` silently discarded the owner's
+  uncommitted work — but the guard refused only the **unscoped** form and allowed
+  `git -C "$WT" stash`, and that allowance is the hole #6701 fell through. So read the stash
+  hazard below rather than this bullet: there the rule is *never*, not *scope it*.
+  The class this closes: a bare
   `git checkout <pr-head-sha>`, run after a between-calls cwd reset, executes in the
-  **primary** tree — detaching the shared `main`, or (for a bare `merge`)
+  **primary** tree — detaching the shared `main`, or (for a bare `stash pop` / `merge`)
   corrupting its working tree — which then stalls a sibling puller's `git merge --ff-only
   origin/main` with the symptom (puller stuck, merged work not propagating) far from the cause.
   The rule, mandatory for **every** worktree/review/ship agent:
@@ -109,12 +112,14 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   `$WORKTREE_ROOT`) and its legitimate `git checkout main` (ff-pull/reattach) are **never**
   intercepted. The safe form it points agents to — `git -C "$WT" <op> …`, or `git -C "$WT" fetch
   origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD` for a PR head — is recognized as
-  worktree-scoped and **allowed** — **for the HEAD-moving ops named above, and for those only.**
-  Scoping is a real remedy when the damage is "the command landed in the wrong tree", which is every
-  op on that list. It is **not** a remedy for `stash`, whose damage is that the stack itself is
-  shared: `git -C "$WT" stash push` is textbook worktree-scoped and still writes the shared stack.
-  Do not read this paragraph as licensing a scoped `stash` (it did, and that is how #6701's incident
-  happened). The prose-only rule alone did not hold (the detach recurred
+  worktree-scoped and **allowed** — and the guard allowed the scoped form for *every* op in that
+  set, `stash` included. **That allowance is right for `checkout`/`switch`/`reset`/`rebase`/`merge`
+  and wrong for `stash`.** For the other five the damage is "the command landed in the wrong tree",
+  and scoping is a real remedy. For `stash` the damage is that the stack itself is shared:
+  `git -C "$WT" stash push` is textbook worktree-scoped and still writes the shared stack, so the
+  guard waved through the exact command that caused #6701. Do not read this paragraph as licensing a
+  scoped `stash`; that rule is *never*, in any form.
+  The prose-only rule alone did not hold (the detach recurred
   after it shipped), which is why the mechanical guard route was taken (#1571).
 
   **Keeping the primary current, by hand.** `pipeline-cli main-sync` retired with that package and

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -188,7 +188,18 @@ fabrika build branch $issue_or_pr_number --slug editor-focus-loss --token <claim
 Construct. Match the surrounding artifact's idiom; for code: domain logic in domain objects,
 invalid states unrepresentable. Re-run `fabrika build tree --issue $issue_or_pr_number` before every
 git mutation — the cwd resets between shell calls, so the tree you proved is not the tree you are
-standing in until you prove it again. Scratch files go only where this prints:
+standing in until you prove it again.
+
+**A lane never runs `git stash` — not scoped, not any form.** `refs/stash` lives in the common git
+dir, so every worktree of this clone shares one stack: between your push and your pop a sibling
+lane's entry becomes `stash@{0}`, and your pop restores their files into your tree and drops their
+commit, reporting success either way. `git -C "$WT" stash push` is correctly scoped and still writes
+the shared stack, so scoping is no defence. To get a clean tree for a baseline run, commit to your
+lane branch and `reset` back to it, or read the baseline from a second checkout. The hazard and its
+`git reflog stash` recovery path are in
+[`.patterns/worktree-agent-constraints.md`](../../../../.patterns/worktree-agent-constraints.md).
+
+Scratch files go only where this prints:
 
 ```bash
 fabrika build scratch $issue_or_pr_number --slug notes --token <claim-token>

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -196,7 +196,7 @@ lane's entry becomes `stash@{0}`, and your pop restores their files into your tr
 commit, reporting success either way. `git -C "$WT" stash push` is correctly scoped and still writes
 the shared stack, so scoping is no defence. To get a clean tree for a baseline run, commit to your
 lane branch and `reset` back to it, or read the baseline from a second checkout. The hazard and its
-`git reflog stash` recovery path are in
+recovery path are in
 [`.patterns/worktree-agent-constraints.md`](../../../../.patterns/worktree-agent-constraints.md).
 
 Scratch files go only where this prints:


### PR DESCRIPTION
`refs/stash` lives in the common git dir, not the per-worktree one, so every worktree of a clone
shares one stack. Lanes #6643 and #6646 popped each other's work on 2026-08-20 with no warning from
either command.

The pattern doc already named `stash`, but only for a bare command landing in the primary tree, and
its remedy — scope it with `git -C "$WT" …` — is false for stash: the scoped form writes the shared
stack too. So the doc was licensing the exact command that destroyed the work.

- `.patterns/worktree-agent-constraints.md` gets `stash` as its own hazard: the stack is
  repository-global, no form is safe, with the two `git rev-parse` reads that prove it, the
  commit-and-reset alternative, and a `git fsck --unreachable` + `git restore --source=<sha>`
  recovery path. `stash` comes out of the bare-op lists, and the "recognized as worktree-scoped and
  allowed" sentence keeps its wording but gains an explicit carve-out naming `stash` as the one op
  scoping does not save.
- `claude-plugins/fabrika/skills/build/SKILL.md` §4 carries the rule directly: a lane never runs
  `git stash`, plus the baseline alternative and a pointer to the pattern doc.

Verified in this tree rather than taken from the report: `git rev-parse --git-path refs/stash` and
`--git-path objects` both resolve under the common dir from inside a linked worktree. Verified in a
scratch repo on git 2.40.1: after a clean `git stash pop`, `git reflog stash` no longer names the
dropped commit — it is a hard error when the stack empties — and `git fsck --unreachable` does. That
is `git-stash(1)`'s own prescription under "Recovering stash entries that were cleared/dropped
erroneously", so the runbook now uses it and says the reflog helps only while the entry is still on
the stack.

No guard code — a `--git-common-dir != --git-dir` refusal is the ticket's named out-of-scope
follow-up.

Fixes #6701

## Deviations

None.
