### PR TITLE
fix: A repair round's second build-deviations marker makes the disclosure unreadable through wire read

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -107,6 +107,16 @@ not a disclosure — and the Absent/Malformed split for comments: an ordinary co
 while a marker line whose promised section is missing or drifted is `Malformed`, so a tail reviewer
 cannot mistake a broken disclosure for a child with nothing to say.
 
+**One marker per issue, and the producer is what enforces it.** A child that takes a repair round
+discloses again, and a second comment is not a second disclosure — the `deviations` reader counts
+the conforming `## Deviations` headings and refuses two as undecidable, so a stacked marker leaves
+the tail review reading `malformed` where a human reads two comments fine, and UNKNOWN blocks a PASS
+(#6691). The reader keeps that refusal: `wire read` judges bytes on stdin and cannot see which
+comment is newer, so a "newest wins" rule there would have it guess at a genuinely ambiguous body.
+The rule is therefore held at the write seam — `fabrika build deviations <issue>` edits the standing
+marker in place and retracts any superseded one, and it is the only sanctioned way this marker is
+posted. A raw `gh issue comment` appends, which is the shape that produced the bug.
+
 ### `verdict-marker`
 
 This is the first line of a gate's verdict comment on a PR, and the artifact the merge decision

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -270,10 +270,26 @@ to arrive a whole review round later, and could not say what was wrong (#5566).
 **An epic child opens no PR, and its disclosure surface moves with that** (#5903). When your spawn
 brief carries the epic rules — you build on a branch cut from the assembly branch, and steps 5's
 push and PR are not yours — the same `## Deviations` section lands as a `build-deviations` marker
-comment on the child issue instead: the line `build-deviations: #<n>` over the section, composed
-through `fabrika wire emit --format build-deviations` and posted with `gh issue comment`. The
-epic-tail review reads every landed child's comment from there, so a child with nothing to disclose
-still posts the checked `None.` — an absent comment reads as "never considered it", not as
+comment on the child issue instead. One verb posts it, and it takes the section on stdin exactly as
+you would have written it into a PR body:
+
+```bash
+fabrika build deviations <n> --token <claim-token> <<'EOF'
+## Deviations
+
+None.
+EOF
+```
+
+The verb composes the `build-deviations: #<n>` line from the number you gave it, validates the
+section through the wire format before writing anything, and reads the landed comment back from live
+issue state. **Never post this marker with a raw `gh issue comment`** — that appends, so a repair
+round leaves two markers, and the reader refuses two conforming headings as undecidable, which is an
+UNKNOWN the tail review cannot pass (#6691). Re-run the verb on every round: it edits the standing
+marker in place.
+
+The epic-tail review reads every landed child's comment from there, so a child with nothing to
+disclose still posts the checked `None.` — an absent comment reads as "never considered it", not as
 "nothing to disclose". A child that lands its commit and posts that comment ends on `BUILT-NO-PR`,
 below — not on a `SHIPPED-PR` naming a PR nobody opened.
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -2245,6 +2245,7 @@ comment reads back, so a write that then fails can never destroy the standing di
 | `build deviations: the disclosure landed on comment <id>, but <k> superseded marker(s) could not be retracted (<ids>) — #<n> still carries more than one, so \`fabrika wire read --format build-deviations\` reads it as malformed; delete them and re-run.` | 8 | refusal |
 | `build deviations: posted (comment <id>) but the read-back does not yield this disclosure (<why>) — it needs a human eye.` | 9 | refusal |
 | `build deviations: #<n> is a pull request — a PR discloses in its body, and this marker is the epic child's surface (ADR 0285). Use \`fabrika build pr\` or \`fabrika build pr-body\`.` | 10 | refusal |
+| `build deviations: cannot read #<n>: <reason> — nothing was written.` | 11 | refusal |
 | `build deviations: cannot read #<n>'s comments: <reason> — nothing was written; a partial list would stack a second marker.` | 11 | refusal |
 | `build deviations: cannot read the authenticated user: <reason> — nothing was written.` | 11 | refusal |
 | `build deviations: #<n> is held by <winning token>, not by <caller token>.` | 15 | refusal |

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -8,6 +8,8 @@
 
 **Amended 2026-08-13** — `build commit` ([#5484](https://github.com/kamp-us/phoenix/issues/5484)): the group had no commit verb, so the message-carrying path at every call site was improvised and nothing asserted the message on the resulting commit. A lane's improvised `git commit -F <leaf>` read back a two-day-old message from another lane and committed it, silently, with every command exiting 0. The verb prescribes the carrying path, tests the numbers the message names against this lane's claim, and reads the message back off the created commit — plus one code (`24`) in the shared exit matrix.
 
+**Amended 2026-08-21** — `build deviations` ([#6691](https://github.com/kamp-us/phoenix/issues/6691)): the epic child's disclosure had no verb, so the skill hand-rolled `wire emit` into `gh issue comment`, which appends. A repair round left the child carrying two markers, and `wire read --format build-deviations` refuses two conforming headings as undecidable — so a repaired child stranded its epic's whole tail review. The verb owns the write seam and holds one marker per issue: the standing marker is edited in place, every superseded one is retracted, and the landed comment is read back. No new code — it allocates from the shared matrix.
+
 The verbs land in `packages/fabrika-cli/` under the `build` subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped `adr`, `report`, `triage` and `wire`
 groups. The [CLI interface convention](../../docs/cli-interface-convention.md) governs every verb;
@@ -77,6 +79,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build pr` | open the PR from a stdin body, refusing the known defect shapes, with read-back | mechanical guards over an authored body; *authoring* stays in the skill |
 | `build pr-body` | replace an open PR's body from a stdin body, under `build pr`'s guards, with read-back | the same mechanical guards as `build pr`, over a `PATCH` that moves no ref; *authoring* stays in the skill |
 | `build note` | post a progress/handoff comment, head-stamped, leak-guarded, with read-back | as `report note`, plus the head stamp |
+| `build deviations` | post an epic child's `## Deviations` disclosure as the ONE `build-deviations` marker on its issue, edited in place on every later round | a claim-gated upsert with a read-back, over a section validated by the wire format; *authoring* the disclosure stays in the skill |
 | `build verdicts` | the paginated, per-gate verdict fold: current-head on a PR, range-bound on an epic child | fetch-all + fold via the wire module; *acting on rows* stays in the skill |
 | `build clear` | record the founder's clearance of one extra repair round on a PR | a conjunctive ACL/authorization protocol with read-back; *whether to grant* is the founder's, never the verb's |
 
@@ -108,8 +111,9 @@ Every verb obeys these; stated once.
   construction: no verb caches content across invocations; every invocation re-fetches and
   re-gates, so a gate change is in force on the next read.
 - **Isolation preconditions are guarded identically wherever they apply.** `branch`, `commit`,
-  `check`, `push`, `pr` and `pr-body` run the same tree assertions `tree` runs, with the same codes (`note` runs only
-  the posting guards — a stop-report must remain postable from a refused tree) — a sibling that
+  `check`, `push`, `pr` and `pr-body` run the same tree assertions `tree` runs, with the same codes (`note` and
+  `deviations` run only the posting guards — a stop-report must remain postable from a refused tree, and so
+  must the disclosure a repair round owes) — a sibling that
   took the same ground unguarded would be the split this table exists to prevent.
   Their refusal messages are `tree`'s rows with the verb-name prefix substituted; **every error
   message contract-wide is prefixed with the invoked verb's name**, stated once here.
@@ -2165,6 +2169,119 @@ EOF
 
 ---
 
+## `build deviations`
+
+**Invocation**
+
+```
+fabrika build deviations 6566 --token <token> [--repo <owner/name>] <<'EOF'
+## Deviations
+
+None.
+EOF
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<issue>` | positional integer | yes | — | the epic child the disclosure is for, and the issue the marker sits on. A pull request is `10`: a PR discloses in its body, which is `build pr` / `build pr-body` |
+| `--repo` | string | no | the `origin` remote's `owner/name` | the repository written to |
+| `--token` | string | yes | — | the token `build claim` handed this lane — which lane is asking (#6037). Not a claim token, or one carrying another session id, is `1` |
+| stdin | text | yes | — | the `## Deviations` section, read through the `deviations` wire format before anything is written |
+
+**Output** — machine.
+`{"answer": "posted", "issue": 6566, "commentId": 900, "upsert": "created", "retracted": 0, "url": "https://github.com/o/r/issues/6566#issuecomment-900"}`.
+`upsert` is `"created"` when the child carried no standing marker and `"edited"` when one was
+PATCHed in place; `retracted` counts the superseded markers deleted behind it.
+
+**One marker per issue is this verb's invariant** (#6691, [ADR 0285](../../../../.decisions/0285-epic-machine-ends-in-review.md)).
+An epic child opens no PR, so its disclosure is a `build-deviations` marker comment; the tail review
+reads every child's through `fabrika wire read --format build-deviations`, and that reader refuses
+two conforming `## Deviations` headings as undecidable. The rule is held **at this write seam and
+not in the reader** — the reader judges bytes on stdin and cannot see which comment is newer, so a
+"newest wins" rule there would have it guess at a genuinely ambiguous body. So the verb edits the
+standing marker rather than appending, and retracts every superseded marker of this account's that
+the format reads as *this* issue's disclosure — the second half is what makes the invariant hold on
+a child a pre-fix lane already stacked.
+
+Guards, in order: stdin non-empty (`3`), bare-`@` body (`6`), the section readable through the
+`deviations` format (`4`), target is an open issue and not a PR (`7`/`10`), caller token parses
+(`1`), claim held (`15`/`11`), leak predicates over the composed comment (`5`), the authenticated
+user and the comment list both readable (`11`), write (`8`), read-back (`9`), retraction (`8`).
+
+The marker line is composed from the positional and never taken from stdin, so a disclosure cannot
+name an issue other than the one it sits on. Read-back is a re-fetch of the landed comment asserted
+twice — through `build-deviations.read`, the contract a tail reviewer runs, and byte-for-byte
+against the composed bytes through `normalizeForReadback`. Retraction runs **after** the live
+comment reads back, so a write that then fails can never destroy the standing disclosure.
+
+**Exit status** (beyond the universal four)
+
+| Code | Trigger |
+|---|---|
+| `3` | stdin held nothing |
+| `4` | the `## Deviations` section does not read `Found` through the `deviations` wire format — absent, empty, a drifted heading, or an entry short a field |
+| `5` | the composed comment carries a machine-local path |
+| `6` | the disclosure is a bare `@` path reference |
+| `7` | the issue is proven absent or closed |
+| `8` | the write failed, or the disclosure landed and a superseded marker could not be retracted — UNKNOWN either way |
+| `9` | the comment landed but the read-back does not yield this disclosure |
+| `10` | the number is a pull request, which discloses in its body |
+| `11` | a precondition read failed — the issue, the authenticated user, or the comment list |
+| `15` | proven: this lane does not hold the claim on the issue |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `build deviations: stdin held nothing — an absent disclosure reads as "never considered it"; send the "## Deviations" section, or "None." under its heading.` | 3 | refusal |
+| `build deviations: the disclosure carries no "## Deviations" heading — <the wire format's reason>.` | 4 | refusal |
+| `build deviations: the disclosure is malformed — <reason> (<evidence>).` | 4 | refusal |
+| `build deviations: the body carries a machine-local path: <first hit> — redact before posting.` | 5 | refusal |
+| `build deviations: the disclosure is a bare @ path reference — write the section, not a pointer to it.` | 6 | refusal |
+| `build deviations: #<n> is proven absent or closed — nothing to disclose on.` | 7 | refusal |
+| `build deviations: the write failed: <reason> — UNKNOWN whether the disclosure landed; re-read #<n> before retrying.` | 8 | refusal |
+| `build deviations: the disclosure landed on comment <id>, but <k> superseded marker(s) could not be retracted (<ids>) — #<n> still carries more than one, so \`fabrika wire read --format build-deviations\` reads it as malformed; delete them and re-run.` | 8 | refusal |
+| `build deviations: posted (comment <id>) but the read-back does not yield this disclosure (<why>) — it needs a human eye.` | 9 | refusal |
+| `build deviations: #<n> is a pull request — a PR discloses in its body, and this marker is the epic child's surface (ADR 0285). Use \`fabrika build pr\` or \`fabrika build pr-body\`.` | 10 | refusal |
+| `build deviations: cannot read #<n>'s comments: <reason> — nothing was written; a partial list would stack a second marker.` | 11 | refusal |
+| `build deviations: cannot read the authenticated user: <reason> — nothing was written.` | 11 | refusal |
+| `build deviations: #<n> is held by <winning token>, not by <caller token>.` | 15 | refusal |
+
+**Scope** — one issue's marker, written by one claim-holding lane. It runs the posting guards only,
+never the tree assertions: a child's disclosure is composed from the branch's work but the comment
+is not a git write, and gating it on the tree would strand a disclosure a repair round owes. It
+never touches a PR body, never posts a second comment, and deletes nothing but a superseded marker
+of this account's that reads as this same issue's disclosure.
+
+**Example**
+
+```
+$ fabrika build deviations 6566 --token <token> <<'EOF'
+## Deviations
+
+- **Scope narrowing** — **Said:** #6566 names the ledger row and its header. **Did:** wrote the
+  row only. **Why:** the header is another child's file. **Disposition:** stated here.
+EOF
+{"answer":"posted","issue":6566,"commentId":900,"upsert":"edited","retracted":1,"url":"https://github.com/o/r/issues/6566#issuecomment-900"}
+```
+
+**Grounding**
+
+- #6691 — a repair round's second marker made the disclosure unreadable through `wire read`, and
+  stranded the tail review of epic #5843 on children #6566 and #6567.
+- [ADR 0285](../../../../.decisions/0285-epic-machine-ends-in-review.md) — an epic child opens no
+  PR, which is why the disclosure surface is a comment at all.
+- [ADR 0228](../../../../.decisions/0228-scripts-relay-never-derive.md) — the skill's hand-rolled
+  `gh issue comment` is the glue a verb is supposed to own.
+- `packages/fabrika-cli/src/review/post-verb.ts` — the upsert spine this verb mirrors: viewer,
+  list, edit-or-create, read back. It keys on the head because a verdict is head-bound; a
+  disclosure carries no head, so this verb keys on the issue.
+- #3173 — a write call's own echo is not evidence; the read-back is a re-fetch.
+
+---
+
 ## `build verdicts`
 
 **Invocation**
@@ -2429,5 +2546,5 @@ script, another skill's prose, or the authoring session. The three hand-checks t
 lineage demands: every reachable outcome above was walked against its verb's failure modes; every
 example value is derivable from its verb's stated rules (the nonce from the claim token, the
 verdict line from the protocol); and sibling verbs guard shared preconditions identically
-(`branch`/`commit`/`check`/`push` run `tree`'s assertions; `pr`/`pr-body`/`note` run the same posting guards on
+(`branch`/`commit`/`check`/`push` run `tree`'s assertions; `pr`/`pr-body`/`note`/`deviations` run the same posting guards on
 the same codes, and `commit` runs the same authored-text guards on `3`/`5`/`6`).

--- a/packages/fabrika-cli/src/build/authored.ts
+++ b/packages/fabrika-cli/src/build/authored.ts
@@ -1,5 +1,6 @@
 /**
- * The guard over **authored** text — the bytes the caller just wrote — for `build pr` and `build note`.
+ * The guard over **authored** text — the bytes the caller just wrote — for `build pr`, `build note`
+ * and `build deviations`.
  *
  * Four outcomes, and the first two must never collapse: an **unread** pipe is UNKNOWN and seats on
  * `1`, a **read-but-empty** one is a proven `3`. Swallowing the first into the second makes an unread

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -27,6 +27,7 @@ import {runAdopt, runClaim, runConfirm, runRelease} from "./claim-verb.ts";
 import {type DocumentRead, runClear} from "./clear-verb.ts";
 import {OFF_VOCABULARY} from "./codes.ts";
 import {runCommit} from "./commit-verb.ts";
+import {runDeviations} from "./deviations-verb.ts";
 import {runEligible} from "./eligible-verb.ts";
 import {runIssue} from "./issue-verb.ts";
 import {runNote} from "./note-verb.ts";
@@ -503,6 +504,33 @@ const note = leafCommand(
 	),
 );
 
+const deviations = leafCommand(
+	"deviations",
+	{
+		issue: Argument.integer("issue").pipe(
+			Argument.withDescription("the epic child the disclosure is for, and sits on"),
+		),
+		token: tokenFlag,
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({issue, token, repo}) {
+		yield* emit(
+			yield* runDeviations({
+				issue,
+				token,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Post an epic child's deviation disclosure as its one marker."),
+	Command.withDescription(
+		'Post the "## Deviations" section on STDIN as the epic child\'s build-deviations marker comment — the disclosure surface a child has instead of a PR body (ADR 0285). ONE marker per issue: the standing marker is edited in place and every superseded one of this account\'s is retracted, so `fabrika wire read --format build-deviations` never meets two conforming headings. The marker line is composed from the positional, so a disclosure cannot name an issue other than the one it sits on. The section is validated through the wire format before anything is written, and the landed comment is read back from live issue state. Prints {"answer":"posted","issue":n,"commentId":n,"upsert":"created"|"edited","retracted":n,"url":"…"}. Exits 1 (--token is not a claim token of this session), 3 (stdin held nothing), 4 (the "## Deviations" section is missing or malformed), 5 (machine-local path), 6 (bare @ reference), 7 (the issue is proven absent or closed), 8 (the write failed, or a superseded marker could not be retracted — UNKNOWN), 9 (posted but does not read back), 10 (the number is a pull request, which discloses in its body), 11 (a precondition read failed), 15 (this LANE does not hold the claim). Example: fabrika build deviations 6566 --token build:s-9f2e:c1a4d6f8-… < deviations.md',
+	),
+);
+
 const verdicts = leafCommand(
 	"verdicts",
 	{
@@ -655,6 +683,7 @@ export const buildCommand = Command.make("build").pipe(
 		pr,
 		prBody,
 		note,
+		deviations,
 		verdicts,
 		clear,
 	]),

--- a/packages/fabrika-cli/src/build/deviations-verb.ts
+++ b/packages/fabrika-cli/src/build/deviations-verb.ts
@@ -1,0 +1,257 @@
+/**
+ * `build deviations` — post an epic child's disclosure as the ONE `build-deviations` marker on its
+ * issue, replaced in place on every later round.
+ *
+ * An epic child opens no PR (ADR 0285), so its `## Deviations` section lands as a marker comment on
+ * the child issue instead of a PR body. The skill used to compose that comment with `wire emit` and
+ * post it with a raw `gh issue comment`, which appends — so a repair round left the issue carrying
+ * two markers, and `wire read --format build-deviations` refuses two conforming headings as
+ * undecidable. The tail review is told to read every child's disclosure through that verb, so one
+ * repaired child stranded a whole epic's tail (#6691).
+ *
+ * **One marker per issue is this verb's invariant, and it is enforced in both directions.** The
+ * standing marker is PATCHed in place rather than appended, and any older marker of this issue's own
+ * — this account's, read through the format — is retracted after the new bytes read back. Retraction
+ * is what makes the invariant hold on an issue a pre-fix lane already stacked; leaving the stale one
+ * would keep the reader at `malformed` for exactly the reason the fix exists. A retraction that
+ * fails is UNKNOWN and never a success: two markers still read as no disclosure at all.
+ *
+ * The marker line is composed here from the positional, never taken from stdin, so a disclosure
+ * cannot name an issue other than the one it sits on.
+ */
+import {Effect} from "effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import type {Attempt} from "../io/git.ts";
+import {
+	type CommentRecord,
+	createComment,
+	deleteComment,
+	getComment,
+	listComments,
+} from "../io/issues.ts";
+import {patchComment, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import * as buildDeviations from "../wire/build-deviations.ts";
+import * as deviations from "../wire/deviations.ts";
+import {leakRefusal, readAuthored} from "./authored.ts";
+import {requireCallerToken, requireClaim, requireSession} from "./claim.ts";
+import {
+	BAD_SECTIONS,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {isPullRequest} from "./github.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const VERB = "build deviations";
+
+const SURFACE = {
+	verb: VERB,
+	emptyMessage: `${VERB}: stdin held nothing — an absent disclosure reads as "never considered it"; send the "## ${deviations.HEADING_TEXT}" section, or "${deviations.NONE_TEXT}" under its heading.`,
+	bareAtMessage: `${VERB}: the disclosure is a bare @ path reference — write the section, not a pointer to it.`,
+};
+
+export interface DeviationsOptions {
+	/** The epic child the disclosure is for — the issue the comment sits on. */
+	readonly issue: number;
+	/** The token `build claim` handed this lane — the identity it posts under (#6037). */
+	readonly token: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+/**
+ * This account's standing markers for `issue`, oldest first.
+ *
+ * Read through the format rather than by prefix match, so a comment that merely quotes the marker
+ * line is not mistaken for one, and a marker disclosing for another issue is never edited from here.
+ */
+const standingMarkers = (
+	comments: ReadonlyArray<CommentRecord>,
+	me: string,
+	issue: number,
+): ReadonlyArray<CommentRecord> =>
+	comments.filter((comment) => {
+		if (comment.author !== me) return false;
+		const read = buildDeviations.read(comment.body);
+		return read._tag === "Found" && read.value.issue === issue;
+	});
+
+/**
+ * Why the re-fetched comment does not show what was posted, or `null` when it does.
+ *
+ * Both assertions are needed. The **format** read is the contract a tail reviewer will run, so a
+ * comment that landed unreadable must refuse here rather than a review round later. The **bytes**
+ * comparison is the broader net: a marker that parses proves nothing about the section under it,
+ * and the section is the disclosure.
+ */
+const readbackMismatch = (
+	back: Attempt<string>,
+	composed: string,
+	issue: number,
+): string | null => {
+	if (back._tag === "Failure") return back.reason;
+	const normalized = normalizeForReadback(back.value);
+	const parsed = buildDeviations.read(normalized);
+	if (parsed._tag === "Absent") return parsed.reason;
+	if (parsed._tag === "Malformed") return parsed.reason;
+	if (parsed.value.issue !== issue) {
+		return `the marker discloses for #${parsed.value.issue}, expected #${issue}`;
+	}
+	return normalized === normalizeForReadback(composed)
+		? null
+		: "the comment's bytes are not the ones that were sent";
+};
+
+export const runDeviations = (
+	options: DeviationsOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient
+> =>
+	Effect.gen(function* () {
+		const {issue} = options;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const section = deviations.read(authored.text);
+		if (section._tag === "Absent") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the disclosure carries no "${"#".repeat(deviations.HEADING_LEVEL)} ${deviations.HEADING_TEXT}" heading — ${section.reason}.`,
+			);
+		}
+		if (section._tag === "Malformed") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the disclosure is malformed — ${section.reason} (${section.evidence}).`,
+			);
+		}
+
+		const sessionRead = requireSession(VERB, options.env);
+		if (sessionRead._tag === "Refused") return sessionRead.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const kind = yield* isPullRequest(options.env, repo, issue);
+		if (kind._tag === "Absent") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${issue} is proven absent or closed — nothing to disclose on.`,
+			);
+		}
+		if (kind._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue}: ${kind.reason} — nothing was written.`,
+			);
+		}
+		if (kind.value) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: #${issue} is a pull request — a PR discloses in its body, and this marker is the epic child's surface (ADR 0285). Use \`fabrika build pr\` or \`fabrika build pr-body\`.`,
+			);
+		}
+
+		const asking = requireCallerToken(VERB, sessionRead.id, options.token);
+		if (asking._tag === "Refused") return asking.outcome;
+
+		const held = yield* requireClaim(VERB, repo, issue, asking.caller);
+		if (held._tag === "Refused") return held.outcome;
+
+		const composed = buildDeviations.emit({issue, disclosure: section.value});
+		const leaked = leakRefusal(VERB, composed);
+		if (leaked !== null) return leaked;
+
+		const me = yield* viewerLogin;
+		if (me._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the authenticated user: ${me.reason} — nothing was written.`,
+				held.notes,
+			);
+		}
+		const comments = yield* listComments(repo, issue);
+		if (comments._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue}'s comments: ${comments.reason} — nothing was written; a partial list would stack a second marker.`,
+				held.notes,
+			);
+		}
+		const standing = standingMarkers(comments.value, me.value, issue);
+		// The NEWEST standing marker is the one in force, and the list arrives oldest-first — editing
+		// the first match would revise a superseded disclosure and leave the live one untouched.
+		const current = standing.at(-1);
+
+		let landed: {readonly id: number; readonly url: string} | null = null;
+		let failure: string | null = null;
+		if (current === undefined) {
+			const created = yield* createComment(repo, issue, composed);
+			if (created._tag === "Failure") failure = created.reason;
+			else landed = {id: created.value.id, url: created.value.url};
+		} else {
+			const edited = yield* patchComment(repo, current.id, composed);
+			if (edited._tag === "Failure") failure = edited.reason;
+			else landed = {id: current.id, url: edited.value};
+		}
+		if (landed === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the write failed: ${failure ?? "unknown"} — UNKNOWN whether the disclosure landed; re-read #${issue} before retrying.`,
+				held.notes,
+			);
+		}
+		const upsert = current === undefined ? "created" : "edited";
+
+		// The write call's own echo is not evidence (#3173): re-fetch, and assert both halves — the
+		// bytes that were sent, and that the format still reads them as this issue's disclosure.
+		const back = yield* getComment(repo, landed.id);
+		const mismatch = readbackMismatch(back, composed, issue);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: posted (comment ${landed.id}) but the read-back does not yield this disclosure (${mismatch}) — it needs a human eye.`,
+				held.notes,
+			);
+		}
+
+		// Retract every older marker only once the live one is proven — a retraction taken first would
+		// destroy the standing disclosure on a write that then failed.
+		const stale = standing.filter((comment) => comment.id !== landed.id);
+		const leftover: number[] = [];
+		for (const comment of stale) {
+			const removed = yield* deleteComment(repo, comment.id);
+			if (removed._tag === "Failure") leftover.push(comment.id);
+		}
+		if (leftover.length > 0) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the disclosure landed on comment ${landed.id}, but ${leftover.length} superseded marker(s) could not be retracted (${leftover.join(", ")}) — #${issue} still carries more than one, so \`fabrika wire read --format build-deviations\` reads it as malformed; delete them and re-run.`,
+				held.notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "posted",
+				issue,
+				commentId: landed.id,
+				upsert,
+				retracted: stale.length,
+				url: landed.url,
+			}),
+			held.notes,
+		);
+	});

--- a/packages/fabrika-cli/src/build/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/deviations-verb.unit.test.ts
@@ -1,0 +1,304 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import * as buildDeviations from "../wire/build-deviations.ts";
+import {
+	BAD_SECTIONS,
+	CLAIM_NOT_MINE,
+	EMPTY_STDIN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runDeviations} from "./deviations-verb.ts";
+import {
+	comments,
+	GATEWAY,
+	GH_TOKEN_ENV,
+	LANE_TOKEN,
+	LANE_UUID,
+	marker,
+	NOT_FOUND,
+	served,
+} from "./fixtures.test-support.ts";
+
+const ISSUE = 6566;
+
+const IS_ISSUE = new RegExp(`^GET https://api\\.github\\.com/repos/o/r/issues/${ISSUE}$`);
+const COMMENTS = new RegExp(`GET .*/repos/o/r/issues/${ISSUE}/comments`);
+const PERM = /GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+const USER = /GET .*\/api\.github\.com\/user$/;
+const POST = new RegExp(`POST .*/repos/o/r/issues/${ISSUE}/comments`);
+const PATCH = /PATCH .*\/repos\/o\/r\/issues\/comments\/(\d+)$/;
+const DELETE_ONE = /DELETE .*\/repos\/o\/r\/issues\/comments\/(\d+)$/;
+const getComment = (id: number) => new RegExp(`GET .*/repos/o/r/issues/comments/${id}$`);
+
+const WRITE = served({permission: "write"});
+const ME = served({login: "agent"});
+const CLAIM = {id: 1, body: marker("s-9f2e", LANE_UUID)};
+
+const NONE = "## Deviations\n\nNone.\n";
+const FULL = [
+	"## Deviations",
+	"",
+	"- **Scope narrowing** — **Said:** #6566 names the ledger row. **Did:** wrote the row only.",
+	"  **Why:** the header is another child's. **Disposition:** stated here.",
+	"",
+].join("\n");
+
+/** What the format composes for this issue — the bytes the verb must land, byte for byte. */
+const composed = (section: string): string => {
+	const read = buildDeviations.read(`${buildDeviations.KEY_PREFIX} #${ISSUE}\n\n${section}`);
+	if (read._tag !== "Found") throw new Error(`fixture section is not readable: ${read._tag}`);
+	return buildDeviations.emit(read.value);
+};
+
+const options = {
+	issue: ISSUE,
+	token: LANE_TOKEN,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e", ...GH_TOKEN_ENV} as Record<
+		string,
+		string | undefined
+	>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: NONE}),
+};
+
+const seamsFor = (script: ReadonlyArray<Scripted>) => fakeSeams(script);
+
+/**
+ * The comment bytes the one write matching `pattern` carried.
+ *
+ * `bodies` is aligned with `requests`, and a run's last request is the read-back GET — which carries
+ * no body — so the posted bytes are only reachable through the request line that sent them. What
+ * that slot holds is the REST envelope, and the disclosure is its `body` field.
+ */
+const writtenBody = (seams: ReturnType<typeof seamsFor>, pattern: RegExp): string => {
+	const at = seams.requests.findIndex((line) => pattern.test(line));
+	if (at === -1) return "";
+	const envelope: unknown = JSON.parse(seams.bodies[at] ?? "{}");
+	return typeof envelope === "object" &&
+		envelope !== null &&
+		"body" in envelope &&
+		typeof envelope.body === "string"
+		? envelope.body
+		: "";
+};
+
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(
+		Effect.provide(runDeviations({...options, ...overrides}), seamsFor(script).layer),
+	);
+
+/** The script for an issue whose comments are `rows` — claim marker included. */
+const board = (...rows: ReadonlyArray<{readonly id: number; readonly body: string}>) =>
+	[
+		[IS_ISSUE, served({number: ISSUE})],
+		[COMMENTS, comments(CLAIM, ...rows)],
+		[PERM, WRITE],
+		[USER, ME],
+	] as ReadonlyArray<Scripted>;
+
+describe("runDeviations", () => {
+	it("creates the marker when the child carries none", async () => {
+		const seams = seamsFor([
+			...board(),
+			[POST, served({id: 900, html_url: "https://github.com/o/r/issues/6566#c900"}, 201)],
+			[getComment(900), served({body: composed(NONE)})],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runDeviations(options), seams.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "posted",
+			issue: ISSUE,
+			commentId: 900,
+			upsert: "created",
+			retracted: 0,
+			url: "https://github.com/o/r/issues/6566#c900",
+		});
+		expect(writtenBody(seams, POST)).toBe(composed(NONE));
+	});
+
+	/**
+	 * The whole bug (#6691): the repair round's disclosure must REPLACE the first, because
+	 * `wire read --format build-deviations` refuses two conforming headings as undecidable — so a
+	 * second comment strands the epic's tail review on an UNKNOWN.
+	 */
+	it("edits the standing marker on a second disclosure, and posts no second comment", async () => {
+		const first = seamsFor([
+			...board(),
+			[POST, served({id: 900, html_url: "https://github.com/o/r/issues/6566#c900"}, 201)],
+			[getComment(900), served({body: composed(NONE)})],
+		]);
+		const opened = await Effect.runPromise(Effect.provide(runDeviations(options), first.layer));
+		expect(opened.code).toBe(0);
+		const landed = writtenBody(first, POST);
+
+		// The second round reads the board the first round left, not a hand-written stand-in.
+		const second = seamsFor([
+			...board({id: 900, body: landed}),
+			[PATCH, served({id: 900, html_url: "https://github.com/o/r/issues/6566#c900"})],
+			[getComment(900), served({body: composed(FULL)})],
+			[POST, served({message: "a second comment must never be created"}, 500)],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDeviations({...options, stdin: Effect.succeed({_tag: "Text", text: FULL})}),
+				second.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			commentId: 900,
+			upsert: "edited",
+			retracted: 0,
+		});
+		expect(second.requests.some((line) => POST.test(line))).toBe(false);
+		// The second emit's bytes are what the verb read back — the criterion's other half.
+		expect(writtenBody(second, PATCH)).toBe(composed(FULL));
+	});
+
+	it("retracts a stacked marker a pre-fix lane left, so one comment survives", async () => {
+		const seams = seamsFor([
+			...board({id: 900, body: composed(NONE)}, {id: 901, body: composed(NONE)}),
+			[PATCH, served({id: 901, html_url: "https://github.com/o/r/issues/6566#c901"})],
+			[getComment(901), served({body: composed(FULL)})],
+			[DELETE_ONE, served({}, 204)],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDeviations({...options, stdin: Effect.succeed({_tag: "Text", text: FULL})}),
+				seams.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		// The NEWEST standing marker is the one edited; the older is deleted.
+		expect(JSON.parse(out.stdout)).toMatchObject({commentId: 901, retracted: 1});
+		expect(seams.requests.some((line) => /DELETE .*\/issues\/comments\/900$/.test(line))).toBe(
+			true,
+		);
+	});
+
+	it("is UNKNOWN when a superseded marker survives its retraction", async () => {
+		const out = await run(
+			[
+				...board({id: 900, body: composed(NONE)}, {id: 901, body: composed(NONE)}),
+				[PATCH, served({id: 901, html_url: "https://github.com/o/r/issues/6566#c901"})],
+				[getComment(901), served({body: composed(FULL)})],
+				[DELETE_ONE, GATEWAY],
+			],
+			{stdin: Effect.succeed({_tag: "Text", text: FULL})},
+		);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("900");
+	});
+
+	it("never edits another issue's marker, nor a comment this account did not write", async () => {
+		const seams = seamsFor([
+			...board(
+				{id: 800, body: `${buildDeviations.KEY_PREFIX} #6567\n\n${NONE}`},
+				{id: 801, body: "quoting build-deviations: #6566 in prose"},
+			),
+			[POST, served({id: 900, html_url: "https://github.com/o/r/issues/6566#c900"}, 201)],
+			[getComment(900), served({body: composed(NONE)})],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runDeviations(options), seams.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({upsert: "created", retracted: 0});
+	});
+
+	it("composes the marker line from the positional, not from stdin", async () => {
+		const seams = seamsFor([
+			...board(),
+			[POST, served({id: 900, html_url: "https://github.com/o/r/issues/6566#c900"}, 201)],
+			[getComment(900), served({body: composed(NONE)})],
+		]);
+		await Effect.runPromise(
+			Effect.provide(
+				runDeviations({
+					...options,
+					stdin: Effect.succeed({
+						_tag: "Text",
+						text: `${buildDeviations.KEY_PREFIX} #1234\n\n${NONE}`,
+					}),
+				}),
+				seams.layer,
+			),
+		);
+		const posted = writtenBody(seams, POST);
+		expect(posted.startsWith(`${buildDeviations.KEY_PREFIX} #${ISSUE}`)).toBe(true);
+		expect(posted).not.toContain("#1234");
+	});
+
+	it("refuses a section that is absent, before anything is written", async () => {
+		const seams = seamsFor(board());
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDeviations({...options, stdin: Effect.succeed({_tag: "Text", text: "no heading here"})}),
+				seams.layer,
+			),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(seams.requests).toHaveLength(0);
+	});
+
+	it("refuses an entry missing a field, naming the field", async () => {
+		const out = await run(board(), {
+			stdin: Effect.succeed({_tag: "Text", text: "## Deviations\n\n- **Said:** only this.\n"}),
+		});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.join("\n")).toContain("**Did:**");
+	});
+
+	it("refuses empty stdin rather than reading it as nothing to disclose", async () => {
+		const out = await run(board(), {stdin: Effect.succeed({_tag: "Text", text: "  \n"})});
+		expect(out.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a pull request — a PR discloses in its body", async () => {
+		const out = await run([
+			[IS_ISSUE, served({number: ISSUE, pull_request: {url: "…"}})],
+			[COMMENTS, comments(CLAIM)],
+			[PERM, WRITE],
+		]);
+		expect(out.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses an issue proven absent", async () => {
+		const out = await run([[IS_ISSUE, NOT_FOUND]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("is UNKNOWN when the comment list cannot be read, and writes nothing", async () => {
+		const seams = seamsFor([
+			[IS_ISSUE, served({number: ISSUE})],
+			[COMMENTS, comments(CLAIM)],
+			[PERM, WRITE],
+			[USER, GATEWAY],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runDeviations(options), seams.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(seams.requests.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses when this lane does not hold the claim", async () => {
+		const out = await run([
+			[IS_ISSUE, served({number: ISSUE})],
+			[COMMENTS, comments({id: 1, body: marker("other", LANE_UUID)})],
+			[PERM, WRITE],
+		]);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+	});
+
+	it("refuses when the landed comment does not read back as this disclosure", async () => {
+		const out = await run([
+			...board(),
+			[POST, served({id: 900, html_url: "https://github.com/o/r/issues/6566#c900"}, 201)],
+			[getComment(900), served({body: "the marker never landed"})],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+});

--- a/packages/fabrika-cli/src/build/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/deviations-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeSeams, type Scripted} from "../fakes.test-support.ts";
+import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import * as buildDeviations from "../wire/build-deviations.ts";
 import {
@@ -272,7 +272,7 @@ describe("runDeviations", () => {
 		expect(out.code).toBe(ZERO_SCOPE);
 	});
 
-	it("is UNKNOWN when the comment list cannot be read, and writes nothing", async () => {
+	it("is UNKNOWN when the authenticated user cannot be read, and writes nothing", async () => {
 		const seams = seamsFor([
 			[IS_ISSUE, served({number: ISSUE})],
 			[COMMENTS, comments(CLAIM)],
@@ -282,6 +282,22 @@ describe("runDeviations", () => {
 		const out = await Effect.runPromise(Effect.provide(runDeviations(options), seams.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(seams.requests.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when the comment list cannot be read, and writes nothing", async () => {
+		// The claim resolver reads the same endpoint first, so only the SECOND read can be the one
+		// that fails — `once` spends the served row, and the verb's own read falls through to the 502.
+		const seams = seamsFor([
+			[IS_ISSUE, served({number: ISSUE})],
+			[once(COMMENTS), comments(CLAIM)],
+			[COMMENTS, GATEWAY],
+			[PERM, WRITE],
+			[USER, ME],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runDeviations(options), seams.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("a partial list would stack a second marker");
+		expect(seams.requests.some((line) => POST.test(line) || PATCH.test(line))).toBe(false);
 	});
 
 	it("refuses when this lane does not hold the claim", async () => {

--- a/packages/fabrika-cli/src/wire/build-deviations.ts
+++ b/packages/fabrika-cli/src/wire/build-deviations.ts
@@ -18,6 +18,14 @@
  * the entry grammar, because two readers of the four-field bullet is the disagreement that format
  * exists to remove (#5566).
  *
+ * **One marker per issue.** A repair round re-discloses, and a second comment is not a second
+ * disclosure: `./deviations.ts` refuses two conforming headings as undecidable, so a stacked marker
+ * makes the disclosure unreadable through the very verb the tail review is told to read it with
+ * (#6691). Nothing here can enforce that — this module judges one artifact's bytes and cannot see a
+ * comment timeline — so the rule is held at the write seam by `build deviations`
+ * (`../build/deviations-verb.ts`), which edits the standing marker in place. That verb is the only
+ * sanctioned producer; a hand-rolled `gh issue comment` appends.
+ *
  * The discrimination that carries the weight is **Absent vs Malformed**: bytes with no
  * `build-deviations:` first line are `Absent` — an ordinary comment, not a defective disclosure —
  * while a marker line over a missing or drifted section is `Malformed`, because the marker promised

--- a/packages/fabrika-cli/src/wire/lane-brief.ts
+++ b/packages/fabrika-cli/src/wire/lane-brief.ts
@@ -235,9 +235,12 @@ A child re-entering \`build\` after a \`FAIL\` is a repair, not a second build: 
 the fresh claim naming that FAIL, and the route it points at takes over the branch the prior lane
 built on rather than cutting another (#6386).
 A child's build discloses its deviations — the section a PR body would carry — as a
-\`build-deviations\` marker comment on the child issue, composed through
-\`node <fabrika> wire emit --format build-deviations\`; the epic-tail review
-reads them from there (#5903).
+\`build-deviations\` marker comment on the child issue, posted through
+\`node <fabrika> build deviations <child> --token <claim-token>\` with the
+\`## Deviations\` section on stdin; the epic-tail review reads them from there (#5903).
+That verb is the only sanctioned way this marker is posted: it edits the standing
+marker in place, so a repair round re-discloses without stacking a second comment the
+reader would refuse as undecidable (#6691).
 A child's review judges the \`range\` above and records its verdict on the child issue in the
 \`range-verdict-marker\` format, composed through
 \`node <fabrika> wire emit --format range-verdict-marker\`.`;

--- a/packages/fabrika-cli/src/wire/lane-brief.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/lane-brief.unit.test.ts
@@ -107,7 +107,7 @@ describe("the lane-brief carries no repo's own path in its rules", () => {
 
 	it("points the shell at the `fabrika:` field rather than at a literal", () => {
 		expect(RULES).toContain("node <fabrika> <group> <verb>");
-		expect(EPIC_RULES).toContain("node <fabrika> wire emit --format build-deviations");
+		expect(EPIC_RULES).toContain("node <fabrika> build deviations <child>");
 		expect(EPIC_RULES).toContain("node <fabrika> wire emit --format range-verdict-marker");
 		expect(EPIC_TAIL_RULES).toContain("node <fabrika> wire read --format build-deviations");
 	});


### PR DESCRIPTION
A repair round on an epic child posted a **second** `build-deviations` comment instead of replacing
the first. The reader counts conforming `## Deviations` headings and refuses two as undecidable, so
the disclosure a tail reviewer is told to read through the verb could not be read through the verb at
all — and UNKNOWN blocks a PASS. One repaired child could strand its whole epic's tail review.

The fix holds the one-marker rule at the **write** seam, where the comment timeline is visible. The
reader is untouched: `wire read` judges bytes on stdin and cannot see which comment is newer, so a
"newest wins" rule there would have it guess at a genuinely ambiguous body.

`fabrika build deviations <issue> --token <t>` is the new producer. It takes the `## Deviations`
section on stdin exactly as you would write it into a PR body, and:

- validates the section through the `deviations` wire format before anything is written;
- composes the `build-deviations: #<n>` line from the positional, so a disclosure cannot name an
  issue other than the one it sits on;
- edits the standing marker in place, and retracts any superseded one of this account's — so an
  issue a pre-fix lane already stacked heals on the next round;
- reads the landed comment back from live issue state, through the format and byte for byte.

A retraction that fails is `8` (UNKNOWN), never a success: two markers still read as no disclosure.

`build`'s epic-child step and the epic lane brief both call the verb now instead of piping
`wire emit` into `gh issue comment`. The rule is stated under `build-deviations` in
`claude-plugins/fabrika/docs/wire-formats.md` and in the format module's own docblock.

Round 2 (criteria 8 and 9): `claude-plugins/fabrika/skills/build/contract.md` now carries the verb —
a ledger amendment, the `Verb inventory` row, and the per-verb block with its exit table transcribed
from the verb's own refusals. Two test changes go with it: the `listComments` failure arm is covered
(exit 11, no write attempted, the "a partial list would stack a second marker" message asserted), and
the case that claimed to cover it is renamed to what it actually scripts — a failing `GET /user`.
The claim resolver reads the same comments endpoint first, so the new case uses the existing `once`
helper to spend the served row and let the verb's own read fall through to the 502.

Fixes #6691

## Deviations

- **Out-of-scope change** — **Said:** #6691 names `claude-plugins/fabrika/skills/build/SKILL.md` as
  the step to repoint. **Did:** also repointed `EPIC_RULES` in
  `packages/fabrika-cli/src/wire/lane-brief.ts`, and updated the one assertion in
  `lane-brief.unit.test.ts` that pinned the old literal. **Why:** that brief is what a child build
  shell provably reads, so leaving it naming the raw `gh issue comment` would keep producing the
  stacked marker the SKILL.md edit exists to stop. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the acceptance criteria ask only that the standing marker be
  replaced in place. **Did:** the verb also deletes superseded markers it finds. **Why:** an issue a
  pre-fix lane already stacked has two markers, and editing only the newest leaves the reader at
  `malformed` for exactly the reason the fix exists; deletion is scoped to comments this account
  wrote that the format reads as this issue's own disclosure. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** no criterion names `packages/fabrika-cli/src/build/authored.ts`.
  **Did:** widened its docblock, which enumerated `build pr` and `build note` as the verbs it guards,
  to name `build deviations` too. **Why:** this PR is what made that list wrong — the new verb calls
  `readAuthored` and `leakRefusal`. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** round 1's `review-code` PASS carried three craft notes.
  **Did:** addressed the third (the misnamed test) because criterion 9 names it, and left the other
  two — the `at(-1)` inline note that says "newest" where the list is creation-ordered, and the
  `landed`/`failure` mutable pair. **Why:** both were graded non-blocking and neither became a
  criterion, so fixing them here would widen a repair round past its findings.
  **Disposition:** stated here; the verdict comment on this PR carries the detail.
