### PR TITLE
fix: Twenty non-2xx arms outside gh-api.ts still refuse with a bare HTTP status

### DIFF
--- a/packages/fabrika-cli/src/heal-ci/github.ts
+++ b/packages/fabrika-cli/src/heal-ci/github.ts
@@ -25,6 +25,7 @@ import {
 	type PagedAttempt,
 	pagedEnvelope,
 	pagedWithLinkProof,
+	refusalText,
 	restRead,
 } from "../io/gh-api.ts";
 import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
@@ -114,7 +115,7 @@ export const fetchJobLog = (repo: string, job: number): Shell<LogRead> =>
 		}
 		return outcome.status === 410 || outcome.status === 404
 			? {_tag: "Expired" as const}
-			: {_tag: "Failed" as const, reason: `GitHub answered HTTP ${outcome.status}`};
+			: {_tag: "Failed" as const, reason: refusalText(outcome)};
 	});
 
 export interface RunRecord {
@@ -162,7 +163,7 @@ export const rerunFailedJobs = (repo: string, run: number): Shell<Attempt<void>>
 				if (outcome._tag === "Unreachable") return fail(outcome.reason);
 				return outcome.status >= 200 && outcome.status < 300
 					? ok<void>(undefined)
-					: fail(`GitHub answered HTTP ${outcome.status}`);
+					: fail(refusalText(outcome));
 			},
 		),
 	);
@@ -292,7 +293,7 @@ export const readRateLimit = (): Shell<Attempt<RateLimit>> =>
 		Effect.map(restRead(token, "GET", "rate_limit"), (outcome) => {
 			if (outcome._tag === "Unreachable") return fail(outcome.reason);
 			if (outcome.status < 200 || outcome.status >= 300) {
-				return fail(`GitHub answered HTTP ${outcome.status}`);
+				return fail(refusalText(outcome));
 			}
 			const parsed = outcome.body;
 			const core =
@@ -313,7 +314,7 @@ export const commitPushedAt = (repo: string, sha: string): Shell<Attempt<string>
 		Effect.map(restRead(token, "GET", `repos/${repo}/commits/${sha}`), (outcome) => {
 			if (outcome._tag === "Unreachable") return fail(outcome.reason);
 			if (outcome.status < 200 || outcome.status >= 300) {
-				return fail(`GitHub answered HTTP ${outcome.status}`);
+				return fail(refusalText(outcome));
 			}
 			const commit = isRecord(outcome.body) ? outcome.body.commit : null;
 			const committer = isRecord(commit) ? commit.committer : null;

--- a/packages/fabrika-cli/src/heal-ci/logs-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/heal-ci/logs-verb.unit.test.ts
@@ -150,6 +150,31 @@ describe("runLogs refuses rather than answering `no failed steps`", () => {
 		expect(out.stdout).toBe("");
 	});
 
+	it("names GitHub's own message when the job-log read is refused on 11", async () => {
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
+			[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
+			[JOB_LOG, httpError(500, "Server Error")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("GitHub answered HTTP 500: Server Error");
+	});
+
+	it("falls back to the bare status when the refused job-log body carries no message", async () => {
+		const out = await run([
+			[PULL, reply(pull())],
+			[CHECK_RUNS, reply(checkRuns(1, [failed("unit tests")]))],
+			[RUNS_AT_HEAD, reply(runsAtHead(1, [{id: 77}]))],
+			[JOBS, jobs(1, [{id: 441, name: "unit tests"}])],
+			[JOB_LOG, {status: 500, body: "{}"}],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("GitHub answered HTTP 500");
+		expect(out.stderr.at(-1)).not.toContain("HTTP 500:");
+	});
+
 	it("refuses an unreadable check-run read on 11", async () => {
 		const out = await run([
 			[PULL, reply(pull())],

--- a/packages/fabrika-cli/src/io/edges.ts
+++ b/packages/fabrika-cli/src/io/edges.ts
@@ -24,7 +24,14 @@
  * marking it wrong — the fail-open direction.
  */
 import {Effect} from "effect";
-import {authed, authedExistence, existenceOf, pagedExistence, restCall} from "./gh-api.ts";
+import {
+	authed,
+	authedExistence,
+	existenceOf,
+	pagedExistence,
+	refusalText,
+	restCall,
+} from "./gh-api.ts";
 import {type Attempt, fail, ok, type Shell} from "./git.ts";
 import {type Existence, present, unknown} from "./issues.ts";
 import {isRecord} from "./json.ts";
@@ -90,7 +97,7 @@ const edgeWrite = (path: string, body: Readonly<Record<string, number>>): Shell<
 				if (outcome._tag === "Unreachable") return fail(outcome.reason);
 				return outcome.status >= 200 && outcome.status < 300
 					? ok(undefined)
-					: fail(`GitHub answered HTTP ${outcome.status}`);
+					: fail(refusalText(outcome));
 			}),
 		),
 	);

--- a/packages/fabrika-cli/src/io/pulls.ts
+++ b/packages/fabrika-cli/src/io/pulls.ts
@@ -23,6 +23,7 @@ import {
 	pagedEnvelope,
 	pagedWithLinkProof,
 	type Rest,
+	refusalText,
 	restCall,
 } from "./gh-api.ts";
 import {type Attempt, fail, ok, type Shell} from "./git.ts";
@@ -132,7 +133,7 @@ export const getPullDiff = (repo: string, pr: number): Shell<Attempt<string>> =>
 				if (outcome._tag === "Unreachable") return fail(outcome.reason);
 				return outcome.status >= 200 && outcome.status < 300
 					? ok(outcome.text)
-					: fail(`GitHub answered HTTP ${outcome.status}`);
+					: fail(refusalText(outcome));
 			}),
 		),
 	);
@@ -203,7 +204,7 @@ export const viewerLogin: Shell<Attempt<string>> = authed((token) =>
 		Effect.map((outcome) => {
 			if (outcome._tag === "Unreachable") return fail(outcome.reason);
 			if (outcome.status < 200 || outcome.status >= 300) {
-				return fail(`GitHub answered HTTP ${outcome.status}`);
+				return fail(refusalText(outcome));
 			}
 			const login =
 				isRecord(outcome.body) && typeof outcome.body.login === "string"
@@ -250,7 +251,7 @@ export const patchComment = (repo: string, id: number, body: string): Shell<Atte
 			Effect.map((outcome) => {
 				if (outcome._tag === "Unreachable") return fail(outcome.reason);
 				if (outcome.status < 200 || outcome.status >= 300) {
-					return fail(`GitHub answered HTTP ${outcome.status}`);
+					return fail(refusalText(outcome));
 				}
 				return isRecord(outcome.body) && typeof outcome.body.html_url === "string"
 					? ok(outcome.body.html_url)
@@ -347,7 +348,7 @@ export const openPullsClosing = (
 					});
 					if (outcome._tag === "Unreachable") return fail(outcome.reason);
 					if (outcome.status < 200 || outcome.status >= 300) {
-						return fail(`GitHub answered HTTP ${outcome.status}`);
+						return fail(refusalText(outcome));
 					}
 					const parsed: unknown = outcome.body;
 					if (isRecord(parsed) && Array.isArray(parsed.errors) && parsed.errors.length > 0) {

--- a/packages/fabrika-cli/src/io/pulls.unit.test.ts
+++ b/packages/fabrika-cli/src/io/pulls.unit.test.ts
@@ -244,12 +244,20 @@ describe("getPullDiff", () => {
 		expect(http.headers[0]?.accept).toBe("application/vnd.github.diff");
 	});
 
-	it("refuses a diff GitHub did not serve", async () => {
+	it("refuses a diff GitHub did not serve, naming GitHub's own message", async () => {
 		const {layer} = wired([[/pulls/, served(404, {message: "Not Found"})]]);
 		const result = await Effect.runPromise(
 			Effect.provide(getPullDiff("kamp-us/phoenix", 1), layer),
 		);
-		expect(result._tag).toBe("Failure");
+		expect(result).toEqual({_tag: "Failure", reason: "GitHub answered HTTP 404: Not Found"});
+	});
+
+	it("falls back to the bare status when the refusal body carries no message", async () => {
+		const {layer} = wired([[/pulls/, served(404, {})]]);
+		const result = await Effect.runPromise(
+			Effect.provide(getPullDiff("kamp-us/phoenix", 1), layer),
+		);
+		expect(result).toEqual({_tag: "Failure", reason: "GitHub answered HTTP 404"});
 	});
 });
 

--- a/packages/fabrika-cli/src/recipe/github.ts
+++ b/packages/fabrika-cli/src/recipe/github.ts
@@ -16,7 +16,7 @@
 import {Effect} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {pagedEnvelope, resolveToken, restRead} from "../io/gh-api.ts";
+import {pagedEnvelope, refusalText, resolveToken, restRead} from "../io/gh-api.ts";
 import {type Attempt, fail, ok} from "../io/git.ts";
 import {isRecord} from "../io/json.ts";
 
@@ -105,7 +105,7 @@ export const getRun = (repo: string, id: number, env: Env): Authed<Attempt<Workf
 		const outcome = yield* restRead(token.value, "GET", `repos/${repo}/actions/runs/${id}`);
 		if (outcome._tag === "Unreachable") return fail(outcome.reason);
 		if (outcome.status < 200 || outcome.status >= 300) {
-			return fail(`GitHub answered HTTP ${outcome.status}`);
+			return fail(refusalText(outcome));
 		}
 		const run = toRun(outcome.body);
 		return run === null ? fail(SHAPE) : ok(run);
@@ -120,7 +120,7 @@ export const rerunRun = (repo: string, id: number, env: Env): Authed<Attempt<voi
 		if (outcome._tag === "Unreachable") return fail(outcome.reason);
 		return outcome.status >= 200 && outcome.status < 300
 			? ok<void>(undefined)
-			: fail(`GitHub answered HTTP ${outcome.status}`);
+			: fail(refusalText(outcome));
 	});
 
 /** Whether a re-read proves the rerun landed: a new attempt, or a run that is no longer completed. */

--- a/packages/fabrika-cli/src/ship/github.ts
+++ b/packages/fabrika-cli/src/ship/github.ts
@@ -35,6 +35,7 @@ import {
 	onTransport,
 	PAGE_CAP,
 	type Rest,
+	refusalText,
 	restBytes,
 	restCall,
 	restRead,
@@ -102,7 +103,7 @@ const pagedForExistence = (token: string, path: string): Api<Existence<ReadonlyA
 			}
 			if (outcome.status === 404) return absent<ReadonlyArray<unknown>>();
 			if (outcome.status < 200 || outcome.status >= 300) {
-				return unknown<ReadonlyArray<unknown>>(`GitHub answered HTTP ${outcome.status}`);
+				return unknown<ReadonlyArray<unknown>>(refusalText(outcome));
 			}
 			if (!Array.isArray(outcome.body)) {
 				return unknown<ReadonlyArray<unknown>>("GitHub answered 200 but its body is not a list");
@@ -129,7 +130,7 @@ export const defaultBranch = (repo: string): Shell<Attempt<string>> =>
 		Effect.map(restRead(token, "GET", `repos/${repo}`), (outcome) => {
 			if (outcome._tag === "Unreachable") return fail(outcome.reason);
 			if (outcome.status < 200 || outcome.status >= 300) {
-				return fail(`GitHub answered HTTP ${outcome.status}`);
+				return fail(refusalText(outcome));
 			}
 			const name = isRecord(outcome.body) ? outcome.body.default_branch : undefined;
 			return typeof name === "string" && name.trim() !== ""
@@ -180,7 +181,7 @@ export const readFileAtRef = (repo: string, path: string, ref: string): Shell<Ex
 				if (outcome._tag === "Unreachable") return unknown<string>(outcome.reason);
 				if (outcome.status === 404) return absent<string>();
 				if (outcome.status < 200 || outcome.status >= 300) {
-					return unknown<string>(`GitHub answered HTTP ${outcome.status}`);
+					return unknown<string>(refusalText(outcome));
 				}
 				// The raw media type is what makes `text` the answer here: a file's bytes are not
 				// JSON, so `body` parses to `null` for every file that is not itself a JSON document.
@@ -323,7 +324,7 @@ export const countCommitStatuses = (repo: string, sha: string): Shell<Attempt<nu
 const bodyOf = (outcome: Rest): Attempt<unknown> => {
 	if (outcome._tag === "Unreachable") return fail(outcome.reason);
 	if (outcome.status < 200 || outcome.status >= 300) {
-		return fail(`GitHub answered HTTP ${outcome.status}`);
+		return fail(refusalText(outcome));
 	}
 	return ok(outcome.body);
 };
@@ -694,7 +695,7 @@ export const setPullState = (repo: string, pr: number, state: string): Shell<Att
 			if (outcome._tag === "Unreachable") return fail(outcome.reason);
 			return outcome.status >= 200 && outcome.status < 300
 				? ok(undefined)
-				: fail(`GitHub answered HTTP ${outcome.status}`);
+				: fail(refusalText(outcome));
 		}),
 	);
 

--- a/packages/fabrika-cli/src/ship/landing.ts
+++ b/packages/fabrika-cli/src/ship/landing.ts
@@ -18,7 +18,7 @@
 import {Effect} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {resolveToken, restRead, restWrite} from "../io/gh-api.ts";
+import {refusalText, resolveToken, restRead, restWrite} from "../io/gh-api.ts";
 import {type Attempt, fail, ok} from "../io/git.ts";
 import {isRecord} from "../io/json.ts";
 import {isQueueGoverned} from "./github.ts";
@@ -62,7 +62,7 @@ export const readAllowedMethods = (repo: string, env: Env): Authed<Attempt<Allow
 		const outcome = yield* restRead(token.value, "GET", `repos/${repo}`);
 		if (outcome._tag === "Unreachable") return fail(outcome.reason);
 		if (outcome.status < 200 || outcome.status >= 300) {
-			return fail(`GitHub answered HTTP ${outcome.status}`);
+			return fail(refusalText(outcome));
 		}
 		const parsed = outcome.body;
 		if (!isRecord(parsed)) return fail("GitHub answered 200 but its body is not a repository");
@@ -122,7 +122,7 @@ export const readMergeProof = (repo: string, pr: number, env: Env): Authed<Attem
 		const outcome = yield* restRead(token.value, "GET", `repos/${repo}/pulls/${pr}`);
 		if (outcome._tag === "Unreachable") return fail(outcome.reason);
 		if (outcome.status < 200 || outcome.status >= 300) {
-			return fail(`GitHub answered HTTP ${outcome.status}`);
+			return fail(refusalText(outcome));
 		}
 		const parsed = outcome.body;
 		if (!isRecord(parsed) || typeof parsed.merged !== "boolean") {
@@ -156,5 +156,5 @@ export const mergePull = (
 		if (outcome._tag === "Unreachable") return fail(outcome.reason);
 		return outcome.status >= 200 && outcome.status < 300
 			? ok(undefined)
-			: fail(`GitHub answered HTTP ${outcome.status}`);
+			: fail(refusalText(outcome));
 	});

--- a/packages/fabrika-cli/src/ship/merge-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/merge-verb.unit.test.ts
@@ -170,11 +170,19 @@ describe("runMerge", () => {
 		expect(outcome.stderr.at(-1)).toBe("ship merge: PR #4321 is merged — nothing to merge.");
 	});
 
-	it("refuses on 8 when the merge call fails, quoting the status", async () => {
+	it("refuses on 8 when the merge call fails, quoting the status and GitHub's own message", async () => {
 		const {outcome} = await land([
 			...happyReads(),
 			[MERGE, {status: 405, body: '{"message":"Pull Request is not mergeable"}'}],
 		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain(
+			'the merge failed: "GitHub answered HTTP 405: Pull Request is not mergeable"',
+		);
+	});
+
+	it("falls back to the bare status when the failing merge body carries no message", async () => {
+		const {outcome} = await land([...happyReads(), [MERGE, {status: 405, body: "{}"}]]);
 		expect(outcome.code).toBe(WRITE_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain('the merge failed: "GitHub answered HTTP 405"');
 	});


### PR DESCRIPTION
Nineteen non-2xx arms in `packages/fabrika-cli` outside `io/gh-api.ts` and `io/issues.ts` built `GitHub answered HTTP <status>` inline and dropped GitHub's own `message`, which was already parsed and sitting on the `Rest` value at each of those lines. PR #6836 landed the shared `refusalText` and routed those two modules through it; this is the sweep of the rest.

Each of the nineteen sites now imports `refusalText` and calls it in place of the template literal. Every one already sat after an `outcome._tag === "Unreachable"` guard, so `outcome` was already narrowed to the `Response` arm the helper takes — no control flow moved, no refusal condition changed, no exit code changed.

The visible win: `ship merge` refusing a 405 whose body is `{"message":"Pull Request is not mergeable"}` now says so instead of printing a bare number an operator cannot act on.

Left alone, deliberately:

- `ship/github.ts` `restBytes` download arm — its value is `Served<Uint8Array>`, which carries no parsed `body`, so `refusalText` does not typecheck against it.
- `ship/github.ts` GraphQL arm — a different string (`the GraphQL endpoint answered HTTP <status>`) whose `errors[]` handling directly below it is the real refusal.

Tests:

- `ship/merge-verb.unit.test.ts` — the 405 fixture now asserts `GitHub answered HTTP 405: Pull Request is not mergeable`, and a sibling case pins the bare-status fallback when the body carries no message.
- `heal-ci/logs-verb.unit.test.ts` — a refused job-log read end to end through the verb: a 500 carrying `Server Error` names it, a 500 with an empty body falls back to the bare status.
- `io/pulls.unit.test.ts` — the `getPullDiff` 404 refusal now asserts the full enriched reason, plus a no-message fallback case.

The whole `fabrika-cli` suite passes (7528 tests), and `pnpm typecheck` + `pnpm lint:worktree` are green in this tree.

Fixes #6838

## Deviations

- **Scope narrowing** — **Said:** criterion 2 names `ship/github.ts:439` and `:609` as the two non-test lines left carrying the literal. **Did:** they now read at lines 440 and 610. **Why:** adding the `refusalText` import to that file shifted every line below it by one; the two arms themselves are byte-identical to their prior state. **Disposition:** stated here; the criterion's substance (those two arms untouched) holds.
