### PR TITLE
fix: operate's stranded-lane sweep still runs bare lane stale, so no driver reads the new claim pairing

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -8,6 +8,8 @@
 
 **Amended 2026-08-13** — `build commit` ([#5484](https://github.com/kamp-us/phoenix/issues/5484)): the group had no commit verb, so the message-carrying path at every call site was improvised and nothing asserted the message on the resulting commit. A lane's improvised `git commit -F <leaf>` read back a two-day-old message from another lane and committed it, silently, with every command exiting 0. The verb prescribes the carrying path, tests the numbers the message names against this lane's claim, and reads the message back off the created commit — plus one code (`24`) in the shared exit matrix.
 
+**Amended 2026-08-20** — `build claimants` ([#6837](https://github.com/kamp-us/phoenix/pull/6837), [#6771](https://github.com/kamp-us/phoenix/issues/6771)): every ownership verb in the claim family asks about the *asking* lane, so a driver arriving after a session limit killed its builders could read which lanes stopped but not which numbers those dead lanes left claimed — `confirm` refuses a token of any other session and `claim` would only answer by writing a marker of its own. The verb reads one issue's claim state holding no token, writing nothing and clearing nothing, and `lane stale --claims` runs the same read across a sweep. Its block sits under the existing claim-family heading rather than standing alone, and it adds no code to the shared exit matrix.
+
 The verbs land in `packages/fabrika-cli/` under the `build` subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped `adr`, `report`, `triage` and `wire`
 groups. The [CLI interface convention](../../docs/cli-interface-convention.md) governs every verb;
@@ -68,6 +70,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build confirm` | re-prove this LANE still holds the claim before a mutation | a lookup with a defined answer |
 | `build release` | retract this LANE's own claim | a guarded single write |
 | `build adopt` | record that a dead session's claim passes to the lane this marker names, which may then release it or carry on | a marker write with a read-back; *whether the session is really gone* is the driver's judgment |
+| `build claimants` | who holds the claim on one issue, asked by a caller holding no token | the same ownership fold `confirm` runs, reported instead of tested against a caller; *what to do about a stranded claim* stays with the driver |
 | `build issue` | the claimed issue's body + parsed acceptance criteria, through the content gate | fetch + parse via the wire module; *judging* the criteria stays in the skill |
 | `build branch` | cut (or resume) the lane's nonce branch off a freshly fetched base | fetch, derive, create — the nonce is a function of the claim token |
 | `build scratch` | the per-lane scratch path, allocated fail-closed | deterministic path derivation keyed session + issue + claim nonce |
@@ -1093,6 +1096,130 @@ $ echo $?
 - v1 scars designed out: `step3-direct-claim.sh` exit-0-on-lost; `claim/command.ts:57` fused
   refusals; `claim/github.ts:229-231` where a transient permission-read failure silently demoted
   an authorized author (here that read failing is `11`, never a silent demotion).
+
+### `build claimants`
+
+**The one ownership read that does not ask about the caller.** Every verb above resolves ownership
+against the lane that is asking: `confirm` takes a `--token` that must carry this session's id, and
+`claim` answers only by writing a marker of its own. So a driver arriving after a session limit
+killed its builders could list the lanes that stopped and not the numbers those dead lanes left
+claimed — it opened each issue by hand
+([#6771](https://github.com/kamp-us/phoenix/issues/6771)). `claimants` runs the same fold and
+**reports** it: no `--token`, no session needed, nothing written.
+
+**It clears nothing, and that is a designed limit rather than an unfinished one.** ADR 0295 bans a
+TTL, a lease, a steal and eviction inferred from absence, so a stranded claim still leaves through
+`build adopt` then `build release`. The answer is a list a driver acts on, never an act.
+
+**A closed issue is answered, not refused.** The rest of the group folds through `openIssue`, where
+absent and closed share `7` because neither leaves a live issue to act on. Here the question is
+answerable on a closed thread, and a marker outliving the issue it was taken on is exactly the
+strandedness this reads for — so closed is reported on stderr and answered on exit `0`. Absent is
+still `7`: there is no thread. Unreadable is still `11`.
+
+**Invocation**
+
+```
+fabrika build claimants 6669 [--repo <owner/name>]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<number>` | positional integer | yes | — | the issue this lane serves |
+| `--repo` | string | no | `$CLAUDE_PIPELINE_REPO`, else `$GITHUB_REPOSITORY`, else the `origin` remote | the target owner/name |
+
+**Output** — machine, one JSON object:
+
+```
+{"answer": "held" | "unclaimed", "number": 6669,
+ "holder": {"commentId": 512345, "author": "…", "createdAt": "…", "token": "…", "session": "…",
+            "authorized": true} | null,
+ "claimants": [<the same shape, one per claim marker on the thread>],
+ "adopts": [{"commentId": …, "author": "…", "createdAt": "…", "adopted": "<dead session>",
+             "token": "…", "reason": "…", "authorized": …}]}
+```
+
+`holder` is the **earliest authorized** marker — the same winner every ownership question in this
+group resolves against, never a second derivation — and `null` exactly when `answer` is
+`"unclaimed"`. `claimants` lists every marker beside it, authorized or not, so an unauthorized one is
+visible as counted-and-not-a-winner rather than dropped (ADR 0055). `adopts` lists the succession
+markers on the thread, which is how a reader tells a claim already passed to a successor from one
+still stranded. Empty `claimants` and `adopts` arrays are an answer, not an absence: they mean the
+thread was read in full and carries no marker of that kind. An unreadable thread never lands here —
+it is `11`.
+
+**Exit status** (beyond the universal four)
+
+| Code | Trigger |
+|---|---|
+| `7` | the issue is **proven absent** — there is no thread to read a claim off. Closed is not this: a closed issue is answered on `0` |
+| `11` | the issue, its comments, or an author's permission could not be read — who holds it is UNKNOWN, never "unclaimed" |
+
+No other code is reachable. There is nothing to lose (`15` needs a caller identity, and this verb
+holds none), nothing to write (`8`, `9`), and no fence to refuse against (`20`, `21`, `30`, `31`,
+`32`, `16`) — the admission test governs what may *start*, and this starts nothing.
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `build claimants: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.` | 1 | usage error |
+| `build claimants: issue #<n> is proven absent — there is no thread to read a claim off.` | 7 | refusal |
+| `build claimants: cannot read #<n>: <reason> — who holds it is UNKNOWN, never "unclaimed".` | 11 | refusal |
+| `build claimants: cannot read the claim markers on #<n>: <reason> — who holds it is UNKNOWN, never "unclaimed".` | 11 | refusal |
+| `build claimants: #<n> is closed.` — beside the answer on exit 0, never instead of it | 0 | note |
+| `build claimants: comment <id> carries a claim marker from "<author>", who holds no write permission — counted, never a winner.` — one line per unauthorized marker | 0 | note |
+| `build claimants: no authorized claim marker stands on #<n>.` — beside `{"answer":"unclaimed", …}` | 0 | note |
+| `build claimants: #<n> is held by <token> (session <session>, comment <id>, posted <ISO>).` | 0 | note |
+| `build claimants: if that session is gone, the succession is a written one: fabrika build adopt <n> --session <session> --reason "<why>", then release under the token adopt prints. Nothing clears a claim on its own (ADR 0295).` | 0 | note |
+| `build claimants: session <session> has already been adopted — the lane that adopt names releases it.` — this line replaces the one above when an authorized adopt marker names the holder's session | 0 | note |
+
+**Scope** — one issue's comment markers, paginated in full, and nothing else. It reads no campaign
+declaration, no `blocked_by` edge and no label: the admission test governs starting work and this
+verb starts none. Zero markers is a proven answer (`"unclaimed"` on exit `0`), never a refusal —
+which is the one place this verb's shape differs from `confirm`, where proven-unclaimed is `15`
+because the caller was about to mutate.
+
+**Examples**
+
+A thread carrying exactly one claim marker, comment `512345` by a `write` account:
+
+```
+$ fabrika build claimants 6669
+{"answer":"held","number":6669,"holder":{"commentId":512345,"author":"usirin","createdAt":"2026-08-19T22:14:03Z","token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","session":"s-9f2e","authorized":true},"claimants":[{"commentId":512345,"author":"usirin","createdAt":"2026-08-19T22:14:03Z","token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","session":"s-9f2e","authorized":true}],"adopts":[]}
+```
+
+A thread carrying no claim marker at all:
+
+```
+$ fabrika build claimants 6670
+{"answer":"unclaimed","number":6670,"holder":null,"claimants":[],"adopts":[]}
+$ echo $?
+0
+```
+
+A number with no issue behind it:
+
+```
+$ fabrika build claimants 999999
+build claimants: issue #999999 is proven absent — there is no thread to read a claim off.
+$ echo $?
+7
+```
+
+**Grounding**
+
+- #6771 — the driver could list the lanes that stopped and not the issues those lanes left claimed;
+  this verb and `lane stale --claims` are the two halves of that read, landed in
+  [#6837](https://github.com/kamp-us/phoenix/pull/6837).
+- ADR 0295 — succession is written on the board; no TTL, no lease, no steal, no eviction from
+  absence. A read verb that cleared anything would be that eviction by another name.
+- ADR 0055 — authorization from repository permissions; an unauthorized marker is counted and named,
+  never a winner.
+- #6060 — the holder is the earliest authorized marker, one fold shared with `confirm`, so this
+  cannot answer a different winner than the protocol enforces.
 
 ---
 

--- a/claude-plugins/fabrika/skills/front-door/SKILL.md
+++ b/claude-plugins/fabrika/skills/front-door/SKILL.md
@@ -53,7 +53,7 @@ question.
 the session can re-run one instead of trusting the render. Each field has one command behind it —
 `fabrika status menu`, `fabrika status settings`, `fabrika status readout`, `fabrika lane stale` for
 the lanes field (the stale-lane sweep over this machine's `.fabrika/` roots — it reports, it never
-resumes), and for the board:
+resumes; `fabrika lane stale --claims` is that field's deeper read, below), and for the board:
 
 ```bash
 fabrika status board
@@ -61,6 +61,13 @@ fabrika status board
 
 The readout carries only two headline counts, so the other buckets are **not seen** rather than zero
 until you run this. Report them that way.
+
+**The lanes field's deeper read is `fabrika lane stale --claims`.** It additionally pairs each
+non-terminal lane with the claim standing on its issue, which is the other half a dead session
+strands: the lane record cannot see markers. It costs a board read per paired lane where the bare
+form makes no network call at all, so reach for it when you suspect a session died rather than on
+every pass. It reports there too, retracting nothing — and an `unknown` claims row means the board
+could not be read, never that the number is unclaimed.
 
 <!-- anchor: NO-READOUT-IS-ITSELF-A-STATE --> **If no readout appeared above**, the verb group is not
 built in this install — the group is greenfield and its implementation is tracked separately. Say so

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -740,6 +740,34 @@ Every `stale` row is a lane something is owed on that has not moved in the thres
 re-spawn. It reports and never resumes: a driver or a human decides, and the resume is the
 re-spawn above ([#5897](https://github.com/kamp-us/phoenix/issues/5897)).
 
+**That bare form is the routine sweep, and it stays bare because it costs nothing.** The whole scan
+runs off disk and makes no network call, so a driver can run it on every pass without paying for the
+board. Reach past it in one case: you suspect a session died — an outage, a crash, an account limit
+that killed a batch of shells at once. Then the lane half is only half the answer, because a dead
+builder's claim marker outlives it and the ledger cannot see markers at all
+([#6771](https://github.com/kamp-us/phoenix/issues/6771)):
+
+```bash
+node <fabrika> lane stale --claims
+```
+
+`--claims` reads the board and pairs each **non-terminal** lane with the claim standing on its issue,
+which is the network call the bare form avoids — one per paired lane, so this is the deliberate sweep,
+not the default one. Each paired row carries `claims` as `held` (with the token, the session, the
+author and the comment id), `unclaimed`, or `unknown` with a reason. **Read `unknown` as unknown**: a
+board read that failed says nothing about who holds the number, and reporting it as `unclaimed` is
+the one misreading that turns a stranded claim into an invisible one. Chore lanes drive no issue and
+are not paired. To ask the same question about a single number without a token, `node <fabrika> build
+claimants <n>` gives the same answer for one issue.
+
+**A `held` row is not cleared by having been swept.** Nothing in this sweep retracts anything —
+`--claims` reports, exactly as the bare form does. A claim a dead session left leaves the way ADR
+[0295](../../../../.decisions/0295-board-attested-claim-succession.md) prescribes and no other way:
+`build adopt` naming that session, then `build release` under the token the adopt printed. The
+mechanics, the guards and the exact invocations are in the adopt-then-release passage of step 3
+above ("A claim stranded by a gone session is releasable, once you say so on the board") — the
+`session` field on the `held` row is the `--session` argument that passage asks for.
+
 ## Terminal vocabulary
 
 Every run ends as exactly one of — each naming what was recorded and what the fold reads after:


### PR DESCRIPTION
Both halves of PR #6837 landed without a caller: no skill in `claude-plugins/` mentioned `lane stale --claims` or `build claimants`, so the recovery read a driver needs after a session limit kills its builders was still done by hand. This wires the callers. Docs only — nothing under `packages/fabrika-cli/src/` changes and no flag default moves.

**`operate/SKILL.md`** — the stranded-lane sweep block keeps `lane stale --older-than 60` as the routine sweep and now says why it stays bare (the whole scan runs off disk, no network call). `--claims` is added as the conditional reach: a suspected dead session, not every pass. A `held` row routes to `build adopt` then `build release` per ADR 0295, pointing at the adopt-then-release passage already in step 3 rather than restating its mechanics — the `session` field on the row is that passage's `--session` argument. The text states that nothing here clears a claim, and that an `unknown` claims row is unknown, never `unclaimed`.

**`front-door/SKILL.md`** — the lanes field's drill-in names `--claims` as its deeper read, with the same cost framing and the same `unknown` warning. The existing "it reports, it never resumes" statement is untouched.

**`build/contract.md`** — a `build claimants` inventory row, a full per-verb spec under the existing `## build claim, build confirm, build release, build adopt` heading (it is a claim-family read, not a nineteenth standalone section), and a dated header amendment citing #6837 and #6771, in the shape of the 2026-08-13 `build commit` one. The spec records what makes the verb different from `confirm`: no `--token`, no session, writes nothing, clears nothing, and answers rather than refuses on a closed issue.

Every behavioural claim in the added text was checked against `lane stale --help`, `build claimants --help`, and `packages/fabrika-cli/src/build/claimants-verb.ts` in this tree.

Fixes #6840

## Deviations

- **Out-of-scope change** — **Said:** the issue names the lanes field's drill-in *line* in `front-door/SKILL.md`. **Did:** the deeper read is a short paragraph after the `fabrika status board` block, with a one-clause pointer left on the drill-in line itself. **Why:** the field's parenthetical is mid-sentence, and five lines inside it swallowed the sentence's tail; the paragraph placement also keeps "until you run this" adjacent to the block it refers to. **Disposition:** stated here.
