### PR TITLE
fix: Epic tail merge subjects are untyped, so release-please drops their changes from release notes

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -303,13 +303,20 @@ things, neither of them a summary you compose:
 
 Open the draft with the command below as written. `--base` is omitted on purpose — `gh pr create`
 defaults it to the repository's default branch, the same branch the assembly cut from. The title
-is deliberately the lane key, not the epic's prose title: nothing downstream reads a PR title
-(`lane brief` resolves the tail's PR through the closing-issue edge), and a literal title is what
-keeps this fence expansion-free:
+is deliberately the lane key rather than the epic's prose title, because a literal title keeps this
+fence expansion-free — but it leads with `feat(epic):`, and that prefix is not decoration.
+**release-please reads this title.** The repo squash-merges with
+`squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so the title becomes the subject on `main`, and the
+node strategy classifies on the subject alone: an untyped one is unroutable and a `chore`/`docs` one
+is hidden, either way dropping every package change the epic carried from the notes (#6754; incident
+#5771 is the same rule for builder PRs, derived in
+[`pr-title.ts`](../../../../packages/fabrika-cli/src/build/pr-title.ts)). `feat` is the shown type an
+epic earns by construction. `lane brief` still resolves the tail's PR through the closing-issue edge,
+not the title:
 
 ```bash
 gh pr create --draft --head epic/$lane_key \
-  --title "epic #$lane_key: one-PR run" --body-file -
+  --title "feat(epic): #$lane_key one-PR run" --body-file -
 ```
 
 Every later integration pushes the same branch and **appends that child's closing reference** to the

--- a/packages/fabrika-cli/src/build/pr-title.ts
+++ b/packages/fabrika-cli/src/build/pr-title.ts
@@ -14,10 +14,21 @@
  * here: this is the one place an issue title becomes a commit subject.
  */
 
-/** `type:<label>` → conventional-commit type. Anything unlisted falls back to `chore`. */
+/**
+ * `type:<label>` → conventional-commit type. Anything unlisted falls back to `chore`.
+ *
+ * Only a type the release strategy *shows* keeps the change visible: the node strategy takes the
+ * conventionalcommits preset's default sections, where `feat`, `fix`, `perf` and `revert` render and
+ * `chore`/`docs`/`style`/`refactor`/`test`/`build`/`ci` carry `hidden: true`
+ * (`conventional-changelog-conventionalcommits/writer-opts.js`, `config.types`). So `type:epic` maps
+ * to `feat` rather than falling through: an epic spans children and carries feature work by
+ * construction, and a minor bump on an all-fixes epic is cheaper than a whole epic vanishing from
+ * the notes (#6754).
+ */
 const PREFIX_BY_LABEL: ReadonlyMap<string, string> = new Map([
 	["type:bug", "fix"],
 	["type:feature", "feat"],
+	["type:epic", "feat"],
 ]);
 
 /**

--- a/packages/fabrika-cli/src/build/pr-title.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-title.unit.test.ts
@@ -19,6 +19,23 @@ describe("conventionalTitleOf", () => {
 		);
 	});
 
+	// #6754: the epic tail squashes to a subject on `main`, and a type the node strategy hides drops
+	// the whole epic's changes from the release notes. These are the hidden types in the
+	// conventionalcommits preset's default `config.types`.
+	const HIDDEN_TYPES = ["chore", "docs", "style", "refactor", "test", "build", "ci"];
+
+	it("derives a type release-please shows from type:epic, never a hidden one", () => {
+		const title = conventionalTitleOf("Retire the v1 pipeline plugin", [
+			"type:epic",
+			"status:triaged",
+			"ready-for:agent",
+		]);
+		expect(title).toBe("feat: Retire the v1 pipeline plugin");
+		for (const hidden of HIDDEN_TYPES) {
+			expect(title.startsWith(`${hidden}:`)).toBe(false);
+		}
+	});
+
 	it("falls back to chore for every other type label", () => {
 		expect(conventionalTitleOf("Sweep the stale worktrees", ["type:chore"])).toBe(
 			"chore: Sweep the stale worktrees",


### PR DESCRIPTION
An epic's tail PR title was hand-authored as `epic #<n>: one-PR run` — no conventional-commit prefix. The repo squash-merges with `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so that title becomes the subject on `main`, and release-please classifies on the subject alone. Commit `6a1aa8a21` (epic #6147's tail) is the proof: its whole `packages/fabrika-cli` contents dropped out of the 0.5.0 notes.

Three changes:

- `claude-plugins/fabrika/skills/operate/SKILL.md` now opens the tail draft with `--title "feat(epic): #$lane_key one-PR run"`, and the prose above it no longer claims nothing downstream reads a PR title. It names release-please as the reader, the squash setting as the mechanism, and keeps the true half of the old claim (`lane brief` resolves the tail's PR through the closing-issue edge, not the title).
- `PREFIX_BY_LABEL` in `packages/fabrika-cli/src/build/pr-title.ts` maps the epic label to `feat` instead of letting it fall through to the `chore` default, which release-please would parse and then hide.
- A unit test pins that mapping and fails on any of the seven hidden prefixes.

Why `feat` and not `chore(epic):`: the node release strategy takes the conventionalcommits preset's default `config.types`, where `feat`/`fix`/`perf`/`revert` render and `docs`/`style`/`chore`/`refactor`/`test`/`build`/`ci` carry `hidden: true`. Verified in the preset source (`conventional-changelog-conventionalcommits@6.1.0/writer-opts.js`, lines 178-191) rather than assumed — that is also why the three `docs(fabrika-cli)` commits are already missing from the notes. An epic spans children and carries feature work by construction, so a minor bump on an all-fixes epic is the cheap direction of error against a whole epic vanishing.

`conventionalTitleOf`'s existing behaviour is untouched: an already-prefixed title still passes through, and the `details` tag stripping (#5946) is unchanged. All 7529 fabrika-cli tests pass.

Fixes #6754

## Deviations

None.
