### PR TITLE
chore: Already-emitted epic lane machines cannot reach ship:queued, and lane migrate skips them

### DIFF
--- a/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
+++ b/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
@@ -121,3 +121,41 @@ escalation path out of the wait.
 An epic run's tail gets the same cell for the same reason: the tail is where an epic meets the merge
 queue. A child region has no `ship` and reaches no queue, so it needs none (ADR
 [0285](0285-epic-machine-ends-in-review.md)).
+
+## Amendment — 2026-08-20: an epic lane already on disk drains on the machine it was emitted with
+
+Founder ruling,
+[2026-08-20](https://github.com/kamp-us/phoenix/issues/6683#issuecomment-5361645200), on
+[#6683](https://github.com/kamp-us/phoenix/issues/6683). This amendment transcribes it.
+
+The migration above covers a *booted* lane, whose machine is a copy of a committed template. An epic
+lane's machine is **generated** by `lane emit` from the epic body's topology, so there is no template
+to bring it up to and `lane migrate` reports it `generated` and writes nothing. Five epic lanes were
+on disk when the `WIP` remap landed, each with a tail `ship` state holding cells for `DONE` /
+`BLOCKED` / `FAIL` and none for `WIP`.
+
+**They are not migrated. They drain on the machine they were emitted with**, and no regenerate path
+is built.
+
+**The route out when one is hit.** An old-shape epic tail whose shipper reports its ordinary `QUEUED`
+now maps to `WIP` and refuses with `NoCellError` against that `ship` state. The refusal leaves the
+log byte-identical, so nothing is lost — the driver records the lane's terminal by hand from the
+board's truth with `lane transition`: on a merged PR, `UNBLOCKED` first if the lane is sitting in a
+park, back to the state it came from, then `DONE` from `ship`. That is the same fold lane 6462 took
+and the one the park route above already names. If the epic still has phases to run, the lane is
+re-emitted — which means retiring its directory by hand and running `lane emit` fresh, since
+`placeMachine` refuses over a lane that already exists and that refusal is untouched here.
+
+**Two other answers were considered and rejected**, so the next reader does not re-open them:
+
+1. **Teach `lane migrate` to regenerate a `generated` lane** — re-run `emitMachine` and judge the
+   candidate by the replay test the verb already applies to a template graft. Rejected: `emitMachine`
+   needs the epic's board state, which `lane migrate` reads nothing of today. That is a new read and
+   a new failure mode inside a verb whose whole guarantee is that it writes only where the swap is
+   provably inert.
+2. **Give `lane emit` a `--regenerate`** that overwrites an existing epic lane behind the same
+   proving fold. Rejected: the refusal over an existing lane is there so a lane is never re-booted
+   over, and carving an exception into it costs more than the five lanes are worth.
+
+`lane migrate`'s `generated` verdict therefore stays a skip, and its reason points a reader here
+rather than stating only that the machine was generated.

--- a/packages/fabrika-cli/src/lane/migrate-verb.ts
+++ b/packages/fabrika-cli/src/lane/migrate-verb.ts
@@ -102,7 +102,12 @@ const migrateLane = (
 		if (graft === undefined) {
 			const foreign = grafts.find((candidate) => candidate._tag === "Foreign");
 			const id = foreign === undefined ? name : foreign.id;
-			return {key, root, verdict: "generated", reason: `machine "${id}" was generated`};
+			return {
+				key,
+				root,
+				verdict: "generated",
+				reason: `machine "${id}" was generated, not booted — it drains on the machine it was emitted with and is never migrated (ADR 0313, amendment 2026-08-20)`,
+			};
 		}
 		if (sameMachine(onDisk.success, graft.text)) return {key, root, verdict: "current"};
 


### PR DESCRIPTION
Transcribes the founder's ruling on #6683: an epic lane whose machine was already generated by `lane emit` drains on that machine, and no regenerate path is built.

Ruling comment: https://github.com/kamp-us/phoenix/issues/6683#issuecomment-5361645200

Two files:

- `.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md` gains a dated amendment below the existing body. It records the choice, the driver's route out when an old-shape epic tail refuses with `NoCellError` at ship (record the terminal by hand with `lane transition` from the board's truth, re-emit if phases remain), and why options 1 (teach `lane migrate` to regenerate) and 2 (`lane emit --regenerate`) were rejected.
- `packages/fabrika-cli/src/lane/migrate-verb.ts` still writes nothing on the `generated` verdict; its reason string now points a reader at the ruling instead of stating only that the machine was generated.

No verb gains a regenerate path: `lane emit` grows no flag and `lane migrate` reads no board state.

Fixes #6683

## Deviations

None.
