### PR TITLE
fix: The decision-ruling verb has no skill route, so nothing tells anyone to run it

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -70,11 +70,13 @@ record (ADR [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-b
 decision settled yourself: "this looks settled" is not a citation, a converged thread is not a
 citation, and a gap the ruling left open goes back to the founder rather than getting filled here.
 **The arm opens this refusal and nothing else** — the audience fence at step 2 is a separate gate the
-citation does not lift, so the issue still has to carry `ready-for:agent`, which triage stamps on a
-ruled decision issue — its [`--ready-for` routing](../triage/SKILL.md) owns that call, not this
-skill. On `ready-for:human` the claim is exit `21` and
-step 2's rule holds unchanged: end the run naming the code and say the issue needs re-stamping by
-triage — never override on your own authority, however good the citation.
+citation does not lift, so the issue still has to carry `ready-for:agent`. Two things stamp it:
+triage, when it first reads a decision that already carries a ruling comment — its
+[`--ready-for` routing](../triage/SKILL.md) owns that call, not this skill — and
+`fabrika decision rule <n> --cites <url>`, which a control-plane human runs on a decision that is
+already parked. On `ready-for:human` the claim is exit `21` and step 2's rule holds unchanged: end
+the run naming the code, and name that verb as the way back in — a control-plane human runs it, never
+you, and never an override on your own authority, however good the citation.
 This skill is not a router: on its own text surfaces
 it executes the whole loop itself. In pick mode neither the argument nor your caller gave you a
 number, so the one `pick` returned stands in its place everywhere below. Then gate your choice:
@@ -113,7 +115,9 @@ overridable, and the remedy is on the refusal line.** An epic goes to `--purpose
 `--cites <ruling-comment-url>` — the comment URL is checked against this repository and this issue,
 and the verb can prove no more than that, so citing a comment that does not rule anything is a lie
 the tool cannot catch and you must not tell. Passing `--cites` on a decision whose audience is still
-`ready-for:human` lands on `21`, because the citation opens the type axis and nothing else.
+`ready-for:human` lands on `21`, because the citation opens the type axis and nothing else — the
+route back in is `fabrika decision rule <n> --cites <url>`, run by a control-plane human, as step 1
+says.
 
 Exit `32` (no acceptance criteria) is the fourth refusal, and it is the one you are most likely to
 meet: the verb reads the issue's body itself, so a body with no readable `### Acceptance criteria`

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -211,8 +211,9 @@ not apply, so a type refusal is not on the overridable set at all. What the verb
 pointer's shape and its target; whether that comment rules anything is the reader's judgement and is
 stated as such. `type:epic` has no arm — its deliverable is a ledger no citation turns into a pull
 request, and the remedy is `--purpose plan` or `--purpose gate`. The arm opens the type axis and
-nothing else: the issue still has to carry `ready-for:agent`, which triage stamps, so a
-`ready-for:human` decision with a perfect citation is still `21`.
+nothing else: the issue still has to carry `ready-for:agent`, which triage stamps at intake and
+`fabrika decision rule <n> --cites <url>` stamps afterwards, so a `ready-for:human` decision with a
+perfect citation is still `21` until one of them has run.
 
 **The inputs, and where each is read.**
 

--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -199,7 +199,9 @@ the issue carries a founder ruling comment that made the call: the deliverable i
 `build`'s citation arm reads; without it the arm is unreachable and the ruling costs another human
 round-trip. No such comment, and the default above stands: `human`. You cite the comment rather than
 judging the question settled yourself, and a ruling that left a gap open is still a judgment, so it
-stays `human`.
+stays `human`. An issue already parked on `human` needs no triage re-run to come back:
+`fabrika decision rule <n> --cites <url>` is how a control-plane human records the ruling and flips
+the audience, and its contract is that verb's `--help`, not this page.
 
 **`--ready-for agent` requires a criteria block on every type but `epic`.** The verb reads the live
 body through the same wire reader every grader downstream reads, and refuses on `16` — writing no


### PR DESCRIPTION
`fabrika decision rule <n> --cites <url>` ships in `packages/fabrika-cli/src/decision/`, but no skill named it, so a builder hitting the exit `21` audience refusal was sent to a triage re-stamp that is not the route, and triage §7 said nothing about how an already-parked decision comes back.

Three prose edits, no CLI change:

- `skills/build/SKILL.md` — the §1 audience paragraph now names both stamps (triage at intake, `decision rule` afterwards) and points the `21` refusal at the verb, which a human on the verb's own roster runs, never the lane. The `--cites`-on-`ready-for:human` clause in §2 points back at it.
- `skills/build/contract.md` — the same one-clause correction where the contract said "which triage stamps".
- `skills/triage/SKILL.md` §7 — one clause on the decision paragraph: an issue already parked on `human` needs no triage re-run, and the verb's contract is its own `--help`, not that page.

The verb name and flag spelling were read off `packages/fabrika-cli/src/decision/command.ts` on this tree, not off the issue text. No operator runbook step added — the issue scopes that out.

Fixes #6676

## Deviations

- **Out-of-scope change** — **Said:** #6676's criteria name `skills/build/SKILL.md` and `skills/triage/SKILL.md`. **Did:** also corrected one clause in `skills/build/contract.md`. **Why:** the issue's Scope line covers "their contracts if the route is stated there", and that contract stated the stale route ("which triage stamps"). **Disposition:** stated here.
