### PR TITLE
fix: An epic plan's stated dependency never becomes a blocked_by edge, so a gated child passes both build gates

### DIFF
--- a/claude-plugins/fabrika/guide/how-fabrika-works.md
+++ b/claude-plugins/fabrika/guide/how-fabrika-works.md
@@ -68,7 +68,7 @@ structural, and it enforces itself through state rather than advice — a child 
 labelled in a way that makes it unpickable, so "an unverified child got built" is not a thing that
 can happen rather than a thing discouraged.
 
-The human checkpoint sits between them, and it is not redundant with the gate. The gate is thirteen
+The human checkpoint sits between them, and it is not redundant with the gate. The gate is fourteen
 structural defect classes; not one of them reads product intent. So an agent could write the user
 stories, satisfy every structural rule, and produce a clean plan for the wrong product. The founder
 approves the plan before the gate runs, and every epic is grilled while it is being planned rather

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -100,7 +100,7 @@ fabrika plan check $epic_number
 ```
 
 This is the **whole pass/fail decision** over the closed hard-defect enum
-(`fabrika wire doc-section --heading "The floor — thirteen defect types" < <skill-base>/contract.md`).
+(`fabrika wire doc-section --heading "The floor — fourteen defect types" < <skill-base>/contract.md`).
 Do not read the ledger and form your own verdict beside it: two
 answers to one question is how a gate contradicts itself. Both arms exit `0` — read `answer`
 (`clean` or `defective`), and carry `digest` forward to every verb that writes.
@@ -110,7 +110,10 @@ that could **not be derived** — the floor still answered, but over less than t
 your terminal says so.
 
 `defective` ends the run at `PLAN-REFUSED`: post the verdict (step 4), flip nothing, stop. **The
-defective path is terminal here.** Re-planning is `plan-epic`'s lane; hand back to it.
+defective path is terminal here.** Re-planning is `plan-epic`'s lane; hand back to it. Say so when
+every defect is `UNENFORCED_DEP`, because that one is the cheap case: the plan is right and only the
+`blocked_by` graph is behind it, which `plan-epic` clears with `fabrika ledger edges` and no
+re-plan.
 
 ## 3 — Flip, and report what you observed
 

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -85,8 +85,10 @@ as the sibling contracts do):
   `build`'s picker question, open on [#4920](https://github.com/kamp-us/phoenix/issues/4920). This
   gate makes children *eligible*; it computes no second answer to *pickable*. This is also why
   `build`'s `16 BLOCKED` seat is unreachable here — blocked-ness reaches this gate only as the
-  dependency-shaped defects `DEP_CYCLE` / `DANGLING_DEP` / `ORPHAN_CHILD`, never as a per-child
-  readiness verdict.
+  dependency-shaped defects `DEP_CYCLE` / `DANGLING_DEP` / `UNENFORCED_DEP` / `ORPHAN_CHILD`, never
+  as a per-child readiness verdict. `UNENFORCED_DEP` reads the `blocked_by` graph and still is not
+  that verdict: it asks whether the graph *carries* the edge the plan states, never whether the
+  blocker behind it is closed.
 - **An epic-body writer.** This gate never edits an issue body. The planner owns splicing, with its
   round-trip scars ([#4879](https://github.com/kamp-us/phoenix/issues/4879)).
 - **A gate-was-never-run detector.** [#4104](https://github.com/kamp-us/phoenix/issues/4104) is
@@ -98,7 +100,7 @@ as the sibling contracts do):
 | Verb | Purpose | Split test |
 |---|---|---|
 | `plan read` | fetch the epic and its children, parse the ledger, print it as one object | fetch + registered parses — no judgment; *what the plan is worth* stays in the skill |
-| `plan check` | the deterministic floor: the thirteen hard defect types over the scanned child set | a total function from the ledger to a sorted defect list; the whole pass/fail decision, checkable by construction |
+| `plan check` | the deterministic floor: the fourteen hard defect types over the scanned child set | a total function from the ledger to a sorted defect list; the whole pass/fail decision, checkable by construction |
 | `plan flip` | flip every `status:planned` child to `status:triaged` and the epic itself to `ready-for:agent`, re-gating first, reporting the **observed** result for each | a guarded batch write with a read-back — no judgment; *what a partial flip means* stays in the skill |
 | `plan verdict` | post the gate's verdict comment, bound to the scope digest, and read it back | marker composition + a guarded write; the caveats are the skill's judgment, taken as input |
 | `plan approve` | post the approval marker on the epic, bound to a scope digest the verb derives itself, and read it back | an ACL-checked guarded write with a read-back — no judgment; **no `--digest` flag exists**, because an approval whose scope its caller supplies attests whatever the caller pleased |
@@ -166,7 +168,7 @@ and the same `4`. Leading keyword only, from the set the repo's `containmentVoca
 plus the reserved `none` (phoenix declares `flag` · `exempt`). Anything unrecognised reads as unset,
 which `MISSING_CONTAINMENT` treats identically to `none`; only a declared value satisfies it.
 
-## The floor — thirteen defect types
+## The floor — fourteen defect types
 
 `plan check` derives a sorted `Defect[]` over this closed enum. The order below is the emission
 order and the primary sort key; the secondary key is the lowest ref the defect names. Each defect
@@ -178,23 +180,25 @@ prose — the templates are the third column.
 | 1 | `MISSING_DEPS_SECTION` | the epic body's `## Dependencies` read is `Absent` | `no ## Dependencies section` |
 | 2 | `DEP_CYCLE` | the topology's edges contain a cycle, walked transitively; reported as the sorted member set, deduped | `cycle: #<a> → #<b> → #<a>` |
 | 3 | `DANGLING_DEP` | a referenced ref is neither the epic, nor a child, nor an issue **proven present** by a 404-discriminating probe | `#<n> is referenced but is not a child and is proven absent` |
-| 4 | `ORPHAN_CHILD` | the deps section parsed, and a linked child appears in no phase line and no `requires:` line | `#<n> appears in no phase or requires line` |
-| 5 | `MISSING_STORIES_SECTION` | the epic body declares zero user stories | `the epic declares no user stories` |
-| 6 | `UNCOVERED_STORY` | a story the epic declares that no child claims | `story <k> is claimed by no child` |
-| 7 | `ZERO_AC` | a child's acceptance-criteria read is not `Found`, or is `Found` with zero criteria | `acceptance criteria read as <absent\|malformed\|empty>` |
-| 8 | `MISSING_STORY` | the epic declares stories and the child's `**Stories:**` line is absent or non-conforming | `no **Stories:** line` / `**Stories:** value does not conform: "<value>"` |
-| 9 | `MISSING_LABEL` | a child lacks a `type:` label, a `status:` label, or one of `p0` / `p1` / `p2` | `missing a <type:\|status:\|priority> label` |
-| 10 | `MISSING_CONTAINMENT` | `cycleDoc` is `present`, the child carries a type the repo's `containmentVocabulary` asks, and its containment is off that vocabulary's values | `<asked type> with containment <keyword\|unset>` |
-| 11 | `NEEDS_TRIAGE_LABEL` | a child still carries `status:needs-triage` | `still carries status:needs-triage` |
-| 12 | `UNVERIFIABLE_ASSIGNEE` | the child payload's `assignees` key was **not observed** — an unread field is UNKNOWN, never "unassigned is fine" | `the assignees field was not observed` |
-| 13 | `HELD_CHILD_UNASSIGNED` | a child carries `ready-for:human` and its observed assignee list is empty | `ready-for:human with an empty assignee slot` |
+| 4 | `UNENFORCED_DEP` | the topology requires an edge (a `requires:` row, else the phase boundary) that the dependent's native `blocked_by` list does not carry; a prerequisite proven absent is `DANGLING_DEP`'s instead | `#<n> waits on #<m> in prose with no blocked_by edge` |
+| 5 | `ORPHAN_CHILD` | the deps section parsed, and a linked child appears in no phase line and no `requires:` line | `#<n> appears in no phase or requires line` |
+| 6 | `MISSING_STORIES_SECTION` | the epic body declares zero user stories | `the epic declares no user stories` |
+| 7 | `UNCOVERED_STORY` | a story the epic declares that no child claims | `story <k> is claimed by no child` |
+| 8 | `ZERO_AC` | a child's acceptance-criteria read is not `Found`, or is `Found` with zero criteria | `acceptance criteria read as <absent\|malformed\|empty>` |
+| 9 | `MISSING_STORY` | the epic declares stories and the child's `**Stories:**` line is absent or non-conforming | `no **Stories:** line` / `**Stories:** value does not conform: "<value>"` |
+| 10 | `MISSING_LABEL` | a child lacks a `type:` label, a `status:` label, or one of `p0` / `p1` / `p2` | `missing a <type:\|status:\|priority> label` |
+| 11 | `MISSING_CONTAINMENT` | `cycleDoc` is `present`, the child carries a type the repo's `containmentVocabulary` asks, and its containment is off that vocabulary's values | `<asked type> with containment <keyword\|unset>` |
+| 12 | `NEEDS_TRIAGE_LABEL` | a child still carries `status:needs-triage` | `still carries status:needs-triage` |
+| 13 | `UNVERIFIABLE_ASSIGNEE` | the child payload's `assignees` key was **not observed** — an unread field is UNKNOWN, never "unassigned is fine" | `the assignees field was not observed` |
+| 14 | `HELD_CHILD_UNASSIGNED` | a child carries `ready-for:human` and its observed assignee list is empty | `ready-for:human with an empty assignee slot` |
 
 **Grounded, and corrected against source.** [Brief #4948](https://github.com/kamp-us/phoenix/issues/4948)
-names ten types; the live enum carries **fourteen names**, because the brief's list was copied from
+names ten types; the live enum carries **fifteen names**, because the brief's list was copied from
 v1's `review-plan/SKILL.md` prose, which is stale (that file's own validator calls it "the closed
-7-type enum"). The four the brief omits are `ZERO_SCOPE`, `MISSING_CONTAINMENT`,
-`UNVERIFIABLE_ASSIGNEE` and `HELD_CHILD_UNASSIGNED`. One of those four — `ZERO_SCOPE` — is seated
-here as exit `7` rather than a defect, so **fourteen names, thirteen defects**. Derive the enum
+7-type enum"). The five the brief omits are `ZERO_SCOPE`, `UNENFORCED_DEP`,
+`MISSING_CONTAINMENT`, `UNVERIFIABLE_ASSIGNEE` and `HELD_CHILD_UNASSIGNED`. One of those five —
+`ZERO_SCOPE` — is seated here as exit `7` rather than a defect, so **fifteen names, fourteen
+defects**. Derive the enum
 from this table, never from a skill's prose.
 
 **Why `ZERO_SCOPE` is exit `7` and not defect zero.** v1 made a childless epic defect #1 and
@@ -212,7 +216,7 @@ child blocks the flip for every sibling. Back-fill versus grandfather is **unrul
 ([#5026](https://github.com/kamp-us/phoenix/issues/5026)); this contract takes the refusing arm
 because the permissive arm would flip a held child into the build pool, which is the exact outcome
 the barrier exists to prevent ([#4637-C](https://github.com/kamp-us/phoenix/issues/4637)). The seam
-a ruling lands at is this table's row 13.
+a ruling lands at is this table's row 14.
 
 **When a class cannot be derived, it is named, never dropped.** `MISSING_CONTAINMENT` rests on a
 probe for the **declared** cycle doc (`cycleDoc`, whose shipped value here is
@@ -933,7 +937,7 @@ The three hand-checks, which the presence tests above cannot perform:
    deliberate non-seat is `3`: `plan verdict`'s stdin is optional, so an empty stdin is a fact.
 2. **Every example value is derivable.** The digest from §The scope digest's serialization (and the
    four examples use four different literals, because they are taken over four different scopes);
-   the defect `type` and `detail` values from the thirteen-row table's third column; `result` and
+   the defect `type` and `detail` values from the fourteen-row table's third column; `result` and
    `terminal` from their closed sets; the marker line from `emit`'s template plus the fixed clause
    grammar; `containment`, `stories` and the edge orientation from §The ledger grammar. `comment`
    is server-assigned and named as such.

--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -317,7 +317,31 @@ region could not be resolved — a duplicated anchor, or a mode that disagrees w
 end without a written body, and **your children still exist and are linked**; say so, because a
 successor that re-mints them doubles the ledger.
 
-## 8 — Hand to the gate
+## 8 — Put the topology on the graph
+
+The block you just wrote is a **picture** of the dependencies. The thing every build gate reads is
+GitHub's native `blocked_by` graph (ADR
+[0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md)), so a plan that stops at the
+picture leaves both gates blind — epic #6595 said in three places that #6598 waited on an unruled
+decision, and `build claim` admitted it anyway on `scanned 0 blocked_by edges` ([#6616](https://github.com/kamp-us/phoenix/issues/6616)):
+
+```bash
+fabrika ledger edges $epic_number --token <claim-token>
+```
+
+It reads the epic's own block, writes every edge it requires, and proves each one by re-reading the
+graph. Done when it answers `reconciled` with `verified: true`. It is idempotent and reconciles
+rather than replaces, so re-running it writes nothing and an edge no ledger authored is left alone.
+
+`9` means an edge was POSTed and does not read back, and `8` means the graph could not be re-read
+after a POST — both leave the graph UNKNOWN and need a human eye; say the epic body **is** written,
+so nobody re-plans it. `24` means a prerequisite the block names is proven absent: the topology is
+wrong, not the graph.
+
+**Do not skip this because the gate would catch it.** The gate reds `UNENFORCED_DEP` on exactly what
+this leaves undone, and a floor you hand over defective is a re-plan round nobody needed.
+
+## 9 — Hand to the gate
 
 Release the claim, then hand off — clearing the floor and flipping children is
 `check-epic-plan`'s, and doing it yourself is the two-answers defect:
@@ -344,12 +368,16 @@ holds for the `grill` verbs step 4 calls: they allocate from their own table
 ([`packages/fabrika-cli/src/grill/codes.ts`](../../../../packages/fabrika-cli/src/grill/codes.ts)),
 and every row below that seats one says so.
 
-- `PLANNED` — **success.** Plan and topology written and byte-verified, children minted and linked.
-  A ledger exists; it is not gated and no child is pickable.
+- `PLANNED` — **success.** Plan and topology written and byte-verified, children minted and linked,
+  and every edge the topology requires proven on the `blocked_by` graph. A ledger exists; it is not
+  gated and no child is pickable.
 - `RE-PLANNED` — **success.** As above, naming the children superseded this run.
-- `TOPOLOGY-REFUSED` — `24`: the declared topology is proven invalid. **A back-off, and a cheap
-  one** — nothing reached the epic body and the repair is re-declaring, not re-minting. Name the
-  children that exist.
+- `TOPOLOGY-REFUSED` — `24`, and **its disposition turns on which verb seated it.** From `ledger
+  topology` nothing reached the epic body and the repair is re-declaring, not re-minting: a back-off,
+  and a cheap one. From `ledger edges` at step 8 the body **is** written and a prerequisite it names
+  is proven absent, so the repair is a re-plan of that row, not a re-mint — say which, because a
+  successor that reads the cheap case re-declares a topology that is already published. Either way,
+  name the children that exist.
 - `BODY-UNRESOLVABLE` — `22` from `ledger open` or `ledger write`: the plan region is proven
   ambiguous or mode-mismatched. **A back-off that needs a human** to disambiguate the body; nothing
   was written to it.
@@ -371,7 +399,9 @@ and every row below that seats one says so.
 - `WRITE-UNPROVEN` — `8` or `9` from any writing `ledger` verb, and from `grill open`, `grill round`
   or `grill answer`, which allocate those two seats for the same fact: a write landed, or may have,
   and could not be proven. **Neither a success nor a clean back-off — it is UNKNOWN and needs a
-  human.** Report the code, the verb, and any number known. Do not repeat the write.
+  human.** Report the code, the verb, and any number known. Do not repeat the write. From `ledger
+  edges` this says the graph is UNKNOWN while the epic body is written: say so, or a successor
+  re-plans an epic that only needs its edges reconciled.
 - `EPIC-UNPLANNABLE` — a proven verdict **about the epic itself**: `7` or `10` from a `ledger`
   verb, `7` from `build claim` at step 1, or a `7` from `grill open --ticket $epic_number` **whose
   message names the epic** — the same fact reached by a third verb. That verb seats `7` for the

--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -122,7 +122,7 @@ as the sibling contracts do):
   homed or standing-lane exempt) and computes no second answer, because a planner that told an
   author "homed" while the guard reds is worse than one that stays quiet.
 - **The structural floor.** `fabrika plan check` is the whole pass/fail decision over the
-  thirteen hard defects, and it is [`check-epic-plan`](../check-epic-plan/contract.md)'s. This
+  fourteen hard defects, and it is [`check-epic-plan`](../check-epic-plan/contract.md)'s. This
   group derives no second verdict; `ledger draft`, `ledger child` and `ledger topology` each
   validate *the document they are composing* so a defect is caught at authoring time, which is a
   different question from grading a finished ledger.
@@ -147,6 +147,7 @@ as the sibling contracts do):
 | `ledger child` | mint one child with every birth attribute in one create, link it, re-read it, record it | a guarded write with a read-back; *what the child should contain* is the skill's, taken as input |
 | `ledger topology` | validate the declared edges against the recorded children and render the block | a total function from edges to a verdict — cycles, dangling refs and orphans are decidable; *which slices may run in parallel* is the skill's |
 | `ledger write` | splice the staged plan and topology into the epic body, byte-verified | anchor resolution + a guarded PATCH with a round-trip diff — no judgment |
+| `ledger edges` | write the epic's written `## Dependencies` block into the native `blocked_by` graph, reconciling rather than replacing | a total derivation from the block to the pairs it owes, plus a guarded write with a read-back — no judgment; *what the topology should be* was decided at `ledger topology` |
 | `ledger supersede` | retire a child the re-plan no longer contains | an ordered three-leg write with a read-back; *which child to retire* is the skill's |
 
 **Considered and not derived: a `ledger validate` verb** that pre-runs the gate's floor. It would
@@ -276,10 +277,13 @@ rests on.** Walked against every write this contract makes:
 | `ledger child` — link as sub-issue | no — `sub_issues` is a separate relation; the body is untouched |
 | `ledger topology` — render into the run directory | no — nothing reaches GitHub |
 | `ledger supersede` — comment, unlink, close the child | no — a different issue |
-| `ledger write` — PATCH the epic body | **yes, and it is the last write of the run** |
+| `ledger write` — PATCH the epic body | **yes, and it is the only write that does** |
+| `ledger edges` — POST each missing `blocked_by` edge | no — a native relation on the children; the body is untouched, which is why it may run after `write` |
 
 So the digest taken at `open` still binds through minting, topology and supersede, and is consumed
-by the single body write. **It is void afterwards**: a second `ledger write` in one run is not a
+by the single body write. `ledger edges` runs after that write and takes no digest at all, because
+it writes no body text and its own guard is the graph read-back. **The digest is void afterwards**:
+a second `ledger write` in one run is not a
 supported operation, and a caller that re-uses a spent digest gets `21` rather than a silent
 double-splice. Unlike the sibling gate's scope digest this one is deliberately *not* neutral to
 its own guarded write — the write is terminal, so neutrality would buy nothing and would require
@@ -356,9 +360,10 @@ Every `ledger` verb obeys these; stated once.
   per [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql),
   paginated in full — v1's idempotency read used `per_page=100` with no `--paginate`, so in any
   repo past a hundred open issues its duplicate check was mostly blind and failed by re-minting.
-- **Bounded fan-out, where there is any.** Only `ledger open` fans out — it reads every existing
-  child of the epic — and it does so at concurrency **8**, never `"unbounded"`; a rate-limit
-  response must not abort the whole read, which is how v1's sixty-child epic failed. **No other verb fans out over a
+- **Bounded fan-out, where there is any.** Two verbs fan out and both do so at concurrency **8**,
+  never `"unbounded"`; a rate-limit response must not abort the whole read, which is how v1's
+  sixty-child epic failed. `ledger open` reads every existing child of the epic, and `ledger edges`
+  reads one `blocked_by` list per dependent the topology names. **No other verb fans out over a
   set**, so no other verb needs the rule: `child` mints one child, `supersede` retires one child
   (touching the epic only to unlink it), and `topology` writes nothing at all — it reads the epic
   once for the shared preconditions and derives everything else from the manifest. There is deliberately no
@@ -368,8 +373,9 @@ Every `ledger` verb obeys these; stated once.
 - **Preconditions.** Every verb runs `resolveTargetRepo`, refuses a non-`type:epic` target on
   `10`, resolves the run directory (`11` when the tree root cannot be read), and runs
   the imported `requireClaim` on the **epic** number (`15`). Every verb's `7` means **zero scope**;
-  for five of the six that is the epic proven absent (404) or closed, and `ledger topology` adds one
-  documented arm — an empty run manifest — stated in its own table with its reason.
+  for five of the seven that is the epic proven absent (404) or closed, and two add one documented
+  arm each — an empty run manifest for `ledger topology`, an epic declaring no topology for `ledger
+  edges` — stated in their own tables with their reasons.
   **`13` is not this group's.** `--require-clean` belongs to `fabrika build tree`, called once at
   the skill's step 1; no `ledger` verb declares that flag, so none can seat the code. It is carried
   in the matrix below only as a reserved seat with `build`'s meaning.
@@ -1092,6 +1098,111 @@ $ echo $?
 
 ---
 
+## `ledger edges`
+
+**Invocation**
+
+```
+fabrika ledger edges <epic> --token <claim-token> [--repo owner/name]
+```
+
+**Answer**
+
+```json
+{"answer": "reconciled", "epic": 4300, "required": 3, "already": 1, "written": 2, "verified": true}
+```
+
+**Why it exists.** The `## Dependencies` block is a **picture** of the dependency graph, never the
+graph. ADR [0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md) makes GitHub's
+native `blocked_by` edges the one carrier of blockedness, and `build eligible` / `build claim` read
+only those. So a plan that stops at the picture admits a child it has itself declared blocked: epic
+#6595 stated in three places that #6598 waited on the open, unruled decision #6597, and `build claim`
+took it on `scanned 0 blocked_by edges`
+([#6616](https://github.com/kamp-us/phoenix/issues/6616)). This verb is the bridge.
+
+Order of operations:
+
+1. **Read the epic's own body**, not this run's staged `topology.md`. The board is what the gates
+   read, so the board is what the graph is compared against — and reading the body is what lets this
+   verb reconcile an epic some earlier run planned, which is the whole repair path for an epic
+   already published with prose-only dependencies. An unparseable block is `4`; a body with no block,
+   or one whose block parses to nothing, is `7`.
+2. **Derive the required pairs** through `requiredEdges` in
+   [`build/dependencies.ts`](../../../../packages/fabrika-cli/src/build/dependencies.ts) — one
+   statement of the rule, shared with the gate's `UNENFORCED_DEP`. A `requires:` row is the precise
+   gate where one is present; otherwise the phase boundary is, and the subject waits on every earlier
+   phase. A ledger-local `C<int>` names no issue, so no edge over it is required.
+3. **Read one `blocked_by` list per dependent**, bounded at concurrency 8. An unread list is `11`
+   and **nothing is written** — an edge nobody could see is never an edge that is there.
+4. **Resolve each missing prerequisite's internal `id`** and POST the edge on that id, never on the
+   issue number ([`io/edges.ts`](../../../../packages/fabrika-cli/src/io/edges.ts)'s
+   `EDGE-BODY-TAKES-AN-INTERNAL-ID`). A prerequisite proven absent is `24`: the topology is wrong,
+   and no edge can point at it.
+5. **Re-read every dependent's list and prove each required pair**. A POST's own response is not
+   evidence: a refused write and a write whose response was lost look identical at the client, and
+   only the graph tells them apart. An unread re-read is `8`; a pair that does not read back is `9`.
+
+**Reconcile, never replace.** Only missing edges are written. An edge the block does not name is
+left alone, because a `blocked_by` list may carry edges no ledger authored — a human's, another
+epic's — and deleting one would unblock work on the strength of a document that was never the
+carrier. The verb is therefore idempotent: a second run over a reconciled epic writes nothing and
+answers `written: 0`.
+
+**Exit status** (beyond the universal four)
+
+| Code | Trigger |
+|---|---|
+| `4` | the `## Dependencies` block is unparseable |
+| `7` | the epic is proven absent or closed, or it declares no topology — zero scope |
+| `8` | edges were POSTed and the graph could not be re-read — UNKNOWN |
+| `9` | the graph does not read back carrying every required edge |
+| `10` | the issue is not a `type:epic` |
+| `11` | a read failed before any write — **nothing was written** |
+| `15` | this lane does not hold the epic's claim |
+| `24` | a prerequisite the block names is proven absent, so no edge can point at it |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `ledger edges: #<n>'s ## Dependencies block is unparseable at line <k>: <text>` | 4 | refusal |
+| `ledger edges: #<n> declares no topology — refusing to answer over zero scope (ADR 0092).` | 7 | refusal |
+| `ledger edges: <k> edge(s) were POSTed and cannot be confirmed — cannot read <what>: <reason>.` | 8 | refusal |
+| `ledger edges: <k> edge(s) do not read back on the graph — it needs a human eye.` | 9 | refusal |
+| `ledger edges: #<n> is not a type:epic — refusing to write edges for it.` | 10 | refusal |
+| `ledger edges: cannot read <what>: <reason> — nothing was written.` | 11 | refusal |
+| `ledger edges: this lane does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger edges: #<n> is named as a prerequisite and is proven absent — no edge can point at it.` | 24 | refusal |
+
+**Scope** — one epic body read, one `blocked_by` read per dependent, one POST per missing edge, and
+one confirming read per dependent. The scanned line names the required-edge count, so an answer over
+a surprising scope is auditable without re-running.
+
+**Examples**
+
+```
+$ fabrika ledger edges 4300 --token <claim-token>
+ledger edges: scanned 3 required edges.
+{"answer":"reconciled","epic":4300,"required":3,"already":1,"written":2,"verified":true}
+```
+
+```
+$ fabrika ledger edges 4300 --token <claim-token>
+ledger edges: #4300 declares no topology — refusing to answer over zero scope (ADR 0092).
+$ echo $?
+7
+```
+
+**Grounding**
+
+- [#6616](https://github.com/kamp-us/phoenix/issues/6616) — the defect this verb answers, with the
+  epic #6595 / #6597 / #6598 reproduction.
+- ADR 0301 — the `blocked_by` graph is the carrier; the prose block is at most a picture of it.
+- [`map ticket`](../../../../packages/fabrika-cli/src/map/ticket-verb.ts) — the shipped precedent for
+  writing an edge on a resolved internal id, whose shape this verb follows rather than re-deriving.
+
+---
+
 ## `ledger supersede`
 
 **Invocation**
@@ -1224,9 +1335,9 @@ The three hand-checks the presence tests cannot perform:
    set reaches `ledger topology` and `ledger supersede` through `<dir>/children.jsonl`, and the
    staged documents reach `ledger write` through the run directory — so a compaction between
    minting and splicing loses nothing, which is the v1 failure this shape exists to remove.
-4. **Sibling verbs guard shared preconditions identically.** All six run `resolveTargetRepo`, the
+4. **Sibling verbs guard shared preconditions identically.** All seven run `resolveTargetRepo`, the
    `type:epic` check (`10`), `assertGround` (`11`), the imported `requireClaim` (`15`) and the
-   same `7` trigger, with `topology`'s one documented widening of `7` (an empty run manifest)
-   stated in its own table. `open` states the other divergence — it alone proves freshness (`20`) —
+   same `7` trigger, with two documented widenings of `7` — `topology`'s empty run manifest and
+   `edges`' epic that declares no topology — stated in their own tables. `open` states the other divergence — it alone proves freshness (`20`) —
    with its reason: the ground is established once and inherited. `13` is seated by no verb here;
    `--require-clean` is `build tree`'s flag at the skill's step 1.

--- a/packages/fabrika-cli/src/build/dependencies.ts
+++ b/packages/fabrika-cli/src/build/dependencies.ts
@@ -10,6 +10,11 @@
  * ledger renderer, and the epic machine emitter. A reader that wants to know whether work may start
  * asks the graph.
  *
+ * **{@link requiredEdges} does not weaken that.** It reads the block to say which edges the graph
+ * *owes*, so `ledger edges` can write them and the plan gate can red when the two disagree — the
+ * picture is still never consulted at a build gate, and the picture is still never the thing a
+ * builder waits on.
+ *
  * The section holds only blank lines and list lines of two forms:
  *
  * ```
@@ -156,4 +161,43 @@ export const predecessorsOf = (
 	return phases
 		.filter((edge) => edge.phase < own.phase)
 		.flatMap((edge) => edge.members.map((ref) => ({kind: "phase" as const, ref})));
+};
+
+/** One `blocked_by` edge the block requires on the board: `dependent` waits on `prerequisite`. */
+export interface RequiredEdge {
+	readonly dependent: number;
+	readonly prerequisite: number;
+}
+
+/**
+ * Every `blocked_by` edge this block requires, deduped and ascending by `[dependent, prerequisite]`.
+ *
+ * The rendering is not the carrier, so a plan that only *says* `#N requires: #M` leaves the graph
+ * empty and both build gates blind — which is how a child gated behind an unruled decision was
+ * admitted for construction (#6616). This is the bridge: `ledger edges` writes what it names, and the
+ * plan gate reds on a pair the board does not carry.
+ *
+ * The rule is {@link predecessorsOf}'s and is not restated — every subject the block names is asked
+ * for its predecessors. Only `#<int>` refs become pairs: a ledger-local `C<int>` names no issue, so
+ * no edge over it is writable and none is required. A self-pair is dropped as unwritable; `DEP_CYCLE`
+ * is what reports it.
+ */
+export const requiredEdges = (edges: ReadonlyArray<Edge>): ReadonlyArray<RequiredEdge> => {
+	const subjects = edges.flatMap((edge) =>
+		edge._tag === "Phase" ? [...edge.members] : [edge.subject],
+	);
+	const pairs = new Map<string, RequiredEdge>();
+	for (const subject of subjects) {
+		if (subject._tag !== "Issue") continue;
+		for (const {ref} of predecessorsOf(edges, subject)) {
+			if (ref._tag !== "Issue" || ref.number === subject.number) continue;
+			pairs.set(`${subject.number}>${ref.number}`, {
+				dependent: subject.number,
+				prerequisite: ref.number,
+			});
+		}
+	}
+	return [...pairs.values()].sort((a, b) =>
+		a.dependent === b.dependent ? a.prerequisite - b.prerequisite : a.dependent - b.dependent,
+	);
 };

--- a/packages/fabrika-cli/src/build/dependencies.unit.test.ts
+++ b/packages/fabrika-cli/src/build/dependencies.unit.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {predecessorsOf, readTopology} from "./dependencies.ts";
+import {predecessorsOf, readTopology, requiredEdges} from "./dependencies.ts";
 
 const ledger = (body: string) => `# Epic\n\n## Dependencies\n\n${body}\n\n## Notes\n\nunrelated\n`;
 
@@ -101,5 +101,48 @@ describe("predecessorsOf", () => {
 
 	it("gives an issue the topology never names no predecessors", () => {
 		expect(predecessorsOf(edges("- phase 1: #210"), {_tag: "Issue", number: 999})).toEqual([]);
+	});
+});
+
+describe("requiredEdges", () => {
+	const of = (body: string) => {
+		const read = readTopology(ledger(body));
+		return requiredEdges(read._tag === "Parsed" ? read.edges : []);
+	};
+
+	/** Epic #6595's shape: the row exists, the graph does not, and both build gates read the graph. */
+	it("names the pair a `requires:` row states", () => {
+		expect(of("- phase 1: #6597\n- phase 2: #6598\n- #6598 requires: #6597")).toEqual([
+			{dependent: 6598, prerequisite: 6597},
+		]);
+	});
+
+	it("names every earlier-phase pair when no requires: row narrows it", () => {
+		expect(of("- phase 1: #210, #211\n- phase 2: #212")).toEqual([
+			{dependent: 212, prerequisite: 210},
+			{dependent: 212, prerequisite: 211},
+		]);
+	});
+
+	it("reaches back through every earlier phase, not just the one below", () => {
+		expect(of("- phase 1: #210\n- phase 2: #211\n- phase 3: #212")).toEqual([
+			{dependent: 211, prerequisite: 210},
+			{dependent: 212, prerequisite: 210},
+			{dependent: 212, prerequisite: 211},
+		]);
+	});
+
+	it("requires nothing of a single phase — a sibling does not gate a sibling", () => {
+		expect(of("- phase 1: #210, #211")).toEqual([]);
+	});
+
+	it("skips a ledger-local ref: `C1` names no issue, so no edge over it is writable", () => {
+		expect(of("- phase 1: C1\n- phase 2: #212\n- #212 requires: C1")).toEqual([]);
+	});
+
+	it("dedupes a pair two rows both state", () => {
+		expect(
+			of("- phase 1: #210\n- phase 2: #212\n- #212 requires: #210\n- #212 requires: #210"),
+		).toEqual([{dependent: 212, prerequisite: 210}]);
 	});
 });

--- a/packages/fabrika-cli/src/ledger/codes.ts
+++ b/packages/fabrika-cli/src/ledger/codes.ts
@@ -1,5 +1,5 @@
 /**
- * The one exit table the six `ledger` verbs allocate from.
+ * The one exit table the seven `ledger` verbs allocate from.
  *
  * Three tiers, and the tier decides how a constant gets here rather than what it means:
  *

--- a/packages/fabrika-cli/src/ledger/command.cli.test.ts
+++ b/packages/fabrika-cli/src/ledger/command.cli.test.ts
@@ -1,5 +1,5 @@
 /**
- * The end-to-end half: `fabrika ledger` resolves, and so does every one of its six verbs.
+ * The end-to-end half: `fabrika ledger` resolves, and so does every one of its seven verbs.
  *
  * The reported defect was a group that answered `Unknown subcommand "ledger"` — a fact only a real
  * process can settle, because the unit tests exercise the verbs directly and would pass against a
@@ -47,6 +47,7 @@ describe("`fabrika ledger` is a registered group", {timeout: SUBPROCESS_TEST_TIM
 		["child"],
 		["topology"],
 		["write"],
+		["edges"],
 		["supersede"],
 	])("`ledger %s --help` exits 0 with its flags on stdout", (verb) => {
 		const run = fabrika("ledger", verb, "--help");

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -22,6 +22,7 @@ import {readStdin} from "../io/stdin.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runChild} from "./child-verb.ts";
 import {runDraft} from "./draft-verb.ts";
+import {runEdges} from "./edges-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runSupersede} from "./supersede-verb.ts";
 import {runTopology} from "./topology-verb.ts";
@@ -260,6 +261,27 @@ const supersede = leafCommand(
 	),
 );
 
+const edges = leafCommand(
+	"edges",
+	{number: epicArg, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, token, repo}) {
+		yield* emit(
+			yield* runEdges({
+				number,
+				token,
+				repo: Option.getOrNull(repo),
+				cwd: process.cwd(),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Write the epic's declared dependencies into the blocked_by graph."),
+	Command.withDescription(
+		'Read the epic\'s own ## Dependencies block and write every edge it requires into GitHub\'s native blocked_by graph, then prove each one by re-reading the graph. ADR 0301 makes that graph the ONE carrier of blockedness and both build gates read only it, so a dependency living in prose alone admits a child the plan already declared blocked (#6616). Reconcile, never replace: an edge already present is "already", an edge no ledger authored is left alone. It reads the epic body, not this run\'s staged topology, so an epic planned by an earlier run reconciles the same way — and it is idempotent, so a re-run over a reconciled epic writes nothing. Prints {"answer":"reconciled","epic":n,"required":k,"already":k,"written":k,"verified":true}. Exits 4 (the ## Dependencies block is unparseable), 7 (the epic is proven absent or closed, or declares no topology — zero scope), 8 (edges were POSTed and the graph could not be re-read — UNKNOWN), 9 (the graph does not read back carrying every required edge), 10 (not a type:epic), 11 (a read failed — nothing was written), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, #6060), 24 (a prerequisite the block names is proven absent, so no edge can point at it). Example: fabrika ledger edges 4300 --token build:s-9f2e:c1a4d6f8-…',
+	),
+);
+
 export const ledgerCommand = Command.make("ledger").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
@@ -268,6 +290,7 @@ export const ledgerCommand = Command.make("ledger").pipe(
 		child,
 		topology,
 		write,
+		edges,
 		supersede,
 	]),
 	Command.withShortDescription("Author an epic's plan and its children."),

--- a/packages/fabrika-cli/src/ledger/edges-verb.ts
+++ b/packages/fabrika-cli/src/ledger/edges-verb.ts
@@ -1,0 +1,200 @@
+/**
+ * `ledger edges` — write the epic's `## Dependencies` block into GitHub's native `blocked_by` graph.
+ *
+ * ADR [0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md) makes that graph the one
+ * carrier of blockedness, and both build gates read only it. A plan whose dependencies live in prose
+ * alone therefore admits a child it has already declared blocked — epic #6595 let a child gated behind
+ * an open, unruled decision through `build claim` on `scanned 0 blocked_by edges` (#6616). This verb
+ * closes that gap by writing the edges the block owes.
+ *
+ * **It reads the epic's own body, never this run's staged topology**, so it reconciles an epic planned
+ * by an earlier run exactly as it reconciles one written a moment ago. The board is what the gates
+ * read, so the board is what this compares against.
+ *
+ * **Reconcile, never replace.** Only missing edges are POSTed; an edge already there is `already` and
+ * an edge nobody's plan names is left alone. A `blocked_by` list may carry edges no ledger authored —
+ * a human's, another epic's — and deleting one because this block does not name it would silently
+ * unblock work on the strength of a document that was never the carrier.
+ */
+
+import {Effect} from "effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type RequiredEdge, readTopology, requiredEdges} from "../build/dependencies.ts";
+import {scannedLine} from "../build/target.ts";
+import {addBlockedBy, blockedBy, internalId} from "../io/edges.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TOPOLOGY_INVALID,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+
+const VERB = "ledger edges";
+
+/** Bounded like every other fan in this package — v1 spawned one call per child, unbounded. */
+const FAN_OUT = 8;
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to write edges for it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was written.`,
+};
+
+/** Each dependent's `blocked_by` list, or the refusal the unread one owes. */
+type Graph =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Graph"; readonly edges: ReadonlyMap<number, ReadonlySet<number>>};
+
+const readGraph = (
+	repo: string,
+	dependents: ReadonlyArray<number>,
+	/** The refusal an unread list owes — it differs before the writes (nothing written) and after. */
+	whenUnread: (what: string, reason: string) => VerbOutcome,
+): Effect.Effect<Graph, never, ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient> =>
+	Effect.gen(function* () {
+		const read = yield* Effect.forEach(
+			dependents,
+			(number) => blockedBy(repo, number).pipe(Effect.map((found) => [number, found] as const)),
+			{concurrency: FAN_OUT},
+		);
+		const edges = new Map<number, ReadonlySet<number>>();
+		for (const [number, found] of read) {
+			if (found._tag !== "Present") {
+				return {
+					_tag: "Refused" as const,
+					outcome: whenUnread(
+						`#${number}'s blocked_by list`,
+						found._tag === "Absent"
+							? "it answered 404 for an issue the topology names"
+							: found.reason,
+					),
+				};
+			}
+			edges.set(number, new Set(found.value));
+		}
+		return {_tag: "Graph" as const, edges};
+	});
+
+const missingFrom = (
+	graph: ReadonlyMap<number, ReadonlySet<number>>,
+	required: ReadonlyArray<RequiredEdge>,
+): ReadonlyArray<RequiredEdge> =>
+	required.filter((edge) => graph.get(edge.dependent)?.has(edge.prerequisite) !== true);
+
+export const runEdges = (
+	options: OpenOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient
+> =>
+	Effect.gen(function* () {
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {repo, epic, notes} = ground;
+
+		const topology = readTopology(epic.body);
+		if (topology._tag === "Unparseable") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: #${epic.number}'s ## Dependencies block is unparseable at line ${topology.line}: ${topology.text}`,
+				notes,
+			);
+		}
+		if (topology._tag === "Absent" || topology.edges.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${epic.number} declares no topology — refusing to answer over zero scope (ADR 0092).`,
+				notes,
+			);
+		}
+
+		const required = requiredEdges(topology.edges);
+		const dependents = [...new Set(required.map((edge) => edge.dependent))].sort((a, b) => a - b);
+		const scanned = scannedLine(VERB, required.length, "required edge");
+
+		const before = yield* readGraph(repo, dependents, (what, reason) =>
+			refuse(PRECONDITION_UNKNOWN, MESSAGES.unreadable(what, reason), notes),
+		);
+		if (before._tag === "Refused") return before.outcome;
+		const missing = missingFrom(before.edges, required);
+
+		const prerequisites = [...new Set(missing.map((edge) => edge.prerequisite))].sort(
+			(a, b) => a - b,
+		);
+		const resolved = yield* Effect.forEach(
+			prerequisites,
+			(number) => internalId(repo, number).pipe(Effect.map((found) => [number, found] as const)),
+			{concurrency: FAN_OUT},
+		);
+		const ids = new Map<number, number>();
+		for (const [number, found] of resolved) {
+			if (found._tag === "Absent") {
+				return refuse(
+					TOPOLOGY_INVALID,
+					`${VERB}: #${number} is named as a prerequisite and is proven absent — no edge can point at it.`,
+					[...notes, scanned],
+				);
+			}
+			if (found._tag === "Unknown") {
+				return refuse(PRECONDITION_UNKNOWN, MESSAGES.unreadable(`#${number}`, found.reason), [
+					...notes,
+					scanned,
+				]);
+			}
+			ids.set(number, found.value);
+		}
+
+		const failures: string[] = [];
+		for (const edge of missing) {
+			const written = yield* addBlockedBy(
+				repo,
+				edge.dependent,
+				ids.get(edge.prerequisite) as number,
+			);
+			if (written._tag === "Failure") {
+				failures.push(`#${edge.dependent} → #${edge.prerequisite}: ${written.reason}`);
+			}
+		}
+
+		// Every POST is proven by this re-read, failures included: a refused write and a write whose
+		// response was lost look identical at the client, and only the graph can tell them apart.
+		const after = yield* readGraph(repo, dependents, (what, reason) =>
+			refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: ${missing.length} edge(s) were POSTed and cannot be confirmed — cannot read ${what}: ${reason}.`,
+				[...notes, scanned],
+			),
+		);
+		if (after._tag === "Refused") return after.outcome;
+		const stillMissing = missingFrom(after.edges, required);
+		if (stillMissing.length > 0) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: ${stillMissing.length} edge(s) do not read back on the graph — it needs a human eye.`,
+				[
+					...notes,
+					scanned,
+					...stillMissing.map((edge) => `${VERB}: #${edge.dependent} → #${edge.prerequisite}.`),
+					...failures.map((line) => `${VERB}: ${line}.`),
+				],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "reconciled",
+				epic: epic.number,
+				required: required.length,
+				already: required.length - missing.length,
+				written: missing.length,
+				verified: true,
+			}),
+			[...notes, scanned],
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/edges-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/edges-verb.unit.test.ts
@@ -1,0 +1,142 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {GIT_DIRS, served} from "../build/fixtures.test-support.ts";
+import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
+import {
+	BAD_SECTIONS,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TOPOLOGY_INVALID,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runEdges} from "./edges-verb.ts";
+import {CLAIMED, env, epic, TOKEN} from "./fixtures.test-support.ts";
+
+const EPIC_READ = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
+const GRAPH = (issue: number) =>
+	new RegExp(`^GET https://api\\.github\\.com/repos/o/r/issues/${issue}/dependencies/blocked_by`);
+const WRITE = (issue: number) =>
+	new RegExp(`^POST https://api\\.github\\.com/repos/o/r/issues/${issue}/dependencies/blocked_by$`);
+const ISSUE = (number: number) =>
+	new RegExp(`^GET https://api\\.github\\.com/repos/o/r/issues/${number}$`);
+
+/** Epic #6595's shape: #4302 sits in phase 2 behind #4301, and the graph carries nothing. */
+const GATED = epic({
+	body: "## Dependencies\n\n- phase 1: #4301\n- phase 2: #4302\n- #4302 requires: #4301\n",
+});
+
+const blockers = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served(numbers.map((number) => ({number, state: "open", title: `blocker ${number}`})));
+
+const run = (script: ReadonlyArray<Scripted>) => {
+	const shell = fakeSeams(script);
+	const fs = fakeFs({files: {}});
+	return Effect.runPromise(
+		Effect.provide(
+			runEdges({number: 4300, token: TOKEN, repo: null, cwd: "/repo", env}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, requests: shell.requests, bodies: shell.bodies}));
+};
+
+const ground = (body: HttpReply = GATED): ReadonlyArray<Scripted> => [
+	[EPIC_READ, body],
+	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
+	...CLAIMED,
+];
+
+describe("runEdges", () => {
+	it("writes the missing edge on the prerequisite's internal id and proves it", async () => {
+		const {outcome, bodies, requests} = await run([
+			...ground(),
+			[once(GRAPH(4302)), blockers()],
+			[ISSUE(4301), served({number: 4301, id: 43010})],
+			[WRITE(4302), served({}, 201)],
+			[GRAPH(4302), blockers(4301)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "reconciled",
+			epic: 4300,
+			required: 1,
+			already: 0,
+			written: 1,
+			verified: true,
+		});
+		const at = requests.findIndex((line) => WRITE(4302).test(line));
+		expect(JSON.parse(bodies[at] ?? "null")).toEqual({issue_id: 43010});
+	});
+
+	it("is idempotent — an edge already on the graph is `already` and is not re-POSTed", async () => {
+		const {outcome, requests} = await run([...ground(), [GRAPH(4302), blockers(4301)]]);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({required: 1, already: 1, written: 0});
+		expect(requests.some((line) => WRITE(4302).test(line))).toBe(false);
+	});
+
+	/**
+	 * A `blocked_by` list may carry edges no ledger authored. Deleting one because this block does not
+	 * name it would unblock work on the strength of a document that was never the carrier (ADR 0301).
+	 */
+	it("leaves an edge the block does not name alone", async () => {
+		const {outcome, requests} = await run([...ground(), [GRAPH(4302), blockers(4301, 9999)]]);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({written: 0});
+		expect(requests.some((line) => /DELETE/.test(line))).toBe(false);
+	});
+
+	it("refuses 11 on an unread graph, before anything is written", async () => {
+		const {outcome, requests} = await run([
+			...ground(),
+			[GRAPH(4302), {status: 502, body: '{"message":"Bad gateway"}'}],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("nothing was written");
+		expect(requests.some((line) => WRITE(4302).test(line))).toBe(false);
+	});
+
+	/** A refused POST and a POST whose response was lost look identical here; only the graph tells. */
+	it("refuses 9 when a written edge does not read back", async () => {
+		const {outcome} = await run([
+			...ground(),
+			[ISSUE(4301), served({number: 4301, id: 43010})],
+			[WRITE(4302), served({}, 201)],
+			[GRAPH(4302), blockers()],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr).toContain("ledger edges: #4302 → #4301.");
+	});
+
+	it("refuses 8 when the re-read cannot confirm the POSTs", async () => {
+		const {outcome} = await run([
+			...ground(),
+			[once(GRAPH(4302)), blockers()],
+			[ISSUE(4301), served({number: 4301, id: 43010})],
+			[WRITE(4302), served({}, 201)],
+			[GRAPH(4302), {status: 502, body: '{"message":"Bad gateway"}'}],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("cannot be confirmed");
+	});
+
+	it("refuses 24 on a prerequisite proven absent — no edge can point at it", async () => {
+		const {outcome} = await run([
+			...ground(),
+			[GRAPH(4302), blockers()],
+			[ISSUE(4301), {status: 404, body: '{"message":"Not Found"}'}],
+		]);
+		expect(outcome.code).toBe(TOPOLOGY_INVALID);
+		expect(outcome.stderr.at(-1)).toContain("is proven absent");
+	});
+
+	it("refuses zero scope rather than answering over an epic that declares no topology", async () => {
+		const {outcome} = await run(ground(epic({body: "An epic with no plan yet.\n"})));
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unparseable block on 4 — 'no parseable edges' is never 'no edges'", async () => {
+		const {outcome} = await run(
+			ground(epic({body: "## Dependencies\n\n- phase 1: #4301\n- these two are related\n"})),
+		);
+		expect(outcome.code).toBe(BAD_SECTIONS);
+	});
+});

--- a/packages/fabrika-cli/src/ledger/preconditions.ts
+++ b/packages/fabrika-cli/src/ledger/preconditions.ts
@@ -1,5 +1,5 @@
 /**
- * The four preconditions every `ledger` verb runs before it answers, in one place so six copies cannot
+ * The four preconditions every `ledger` verb runs before it answers, in one place so seven copies cannot
  * drift apart: resolve the repo, refuse a target that is not a `type:epic`, read the tree root the run
  * directory hangs off, and prove this session holds the epic's claim.
  *

--- a/packages/fabrika-cli/src/plan/check-verb.ts
+++ b/packages/fabrika-cli/src/plan/check-verb.ts
@@ -121,7 +121,13 @@ export const runCheck = (
 		]);
 		if (approval._tag === "Refused") return approval.outcome;
 
-		const derived = yield* deriveFloorFor(MESSAGES, repo, ledger, vocabulary.vocabulary);
+		const derived = yield* deriveFloorFor(
+			MESSAGES,
+			repo,
+			ledger,
+			vocabulary.vocabulary,
+			read.required,
+		);
 		if (derived._tag === "Refused") return derived.outcome;
 		const floor = derived.floor;
 

--- a/packages/fabrika-cli/src/plan/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/check-verb.unit.test.ts
@@ -7,6 +7,8 @@ import {OFF_VOCABULARY, PLAN_UNAPPROVED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from 
 import {
 	APPROVER,
 	approvalRow,
+	BLOCKED_BY,
+	blockers,
 	CHILD,
 	CWD,
 	CYCLE_DOC,
@@ -153,6 +155,50 @@ describe("runCheck", () => {
 		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);
 		expect(unreadable.stdout).toBe("");
 		expect(unreadable.stderr.at(-1)).toContain("the floor is UNKNOWN, not clean");
+	});
+
+	/**
+	 * Epic #6595's shape, end to end: the ledger says #4302 requires #4301 and the graph carries
+	 * nothing. Before this defect the floor answered `clean` here, `plan flip` made #4302 pickable, and
+	 * `build claim` admitted it on `scanned 0 blocked_by edges` (#6616).
+	 */
+	it("reds UNENFORCED_DEP when the graph does not carry a stated dependency", async () => {
+		const gated = epic({
+			body: epicBody({dependencies: "- phase 1: #4301\n- phase 2: #4302\n- #4302 requires: #4301"}),
+		});
+		const script: ReadonlyArray<Scripted> = [
+			[EPIC, gated],
+			[SUBS, subIssues(4301, 4302)],
+			[CHILD_1, child({number: 4301})],
+			[CHILD_2, child({number: 4302, body: childBody({stories: "2"})})],
+			[CYCLE, cycleDoc],
+		];
+
+		const blind = await run([...script, [BLOCKED_BY(4302), blockers()]]);
+		expect(blind.code).toBe(0);
+		expect(JSON.parse(blind.stdout)).toMatchObject({answer: "defective"});
+		expect(JSON.parse(blind.stdout).defects).toContainEqual({
+			type: "UNENFORCED_DEP",
+			refs: [4301, 4302],
+			detail: "#4302 waits on #4301 in prose with no blocked_by edge",
+		});
+
+		const written = await run([...script, [BLOCKED_BY(4302), blockers(4301)]]);
+		expect(JSON.parse(written.stdout)).toMatchObject({answer: "clean"});
+	});
+
+	it("refuses 11 on an unread blocked_by list — an unseen edge is never a present one", async () => {
+		const out = await run([
+			[EPIC, epic({body: epicBody({dependencies: "- phase 1: #4301\n- #4301 requires: #4302"})})],
+			[SUBS, subIssues(4301, 4302)],
+			[CHILD_1, child({number: 4301})],
+			[CHILD_2, child({number: 4302, body: childBody({stories: "2"})})],
+			[CYCLE, cycleDoc],
+			[BLOCKED_BY(4301), {status: 502, body: '{"message":"Bad gateway"}'}],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("the floor is UNKNOWN, not clean");
 	});
 
 	it("refuses zero scope on 7 rather than answering `clean` over nothing", async () => {

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -80,9 +80,9 @@ const check = leafCommand(
 		);
 	}),
 ).pipe(
-	Command.withShortDescription("The deterministic floor over the thirteen hard defect types."),
+	Command.withShortDescription("The deterministic floor over the fourteen hard defect types."),
 	Command.withDescription(
-		'The deterministic floor over the thirteen hard defect types — the whole pass/fail decision. BOTH arms exit 0 and the discriminator is the "answer" state word (clean | defective); a defective floor is this verb\'s answer, never its refusal, and the guard against acting on one lives at `plan flip`\'s own re-gate. "skipped" names a class that could not be derived (today only MISSING_CONTAINMENT, and only when the cycle-doc probe failed) — it never makes the floor clean by omission. Exits 4 (the ledger grammar refused), 7 (zero scope), 10 (the issue is not a type:epic), 11 (a read the floor depends on failed, the control-plane roster included — UNKNOWN, never "not approved"), 25 (the plan is not approved as it now stands: no standing marker, or one binding a digest the plan has moved off — refused BEFORE the floor is derived, so an unapproved AND defective plan refuses on this, ADR 0289). Example: fabrika plan check 4300',
+		'The deterministic floor over the fourteen hard defect types — the whole pass/fail decision. BOTH arms exit 0 and the discriminator is the "answer" state word (clean | defective); a defective floor is this verb\'s answer, never its refusal, and the guard against acting on one lives at `plan flip`\'s own re-gate. "skipped" names a class that could not be derived (today only MISSING_CONTAINMENT, and only when the cycle-doc probe failed) — it never makes the floor clean by omission. Exits 4 (the ledger grammar refused), 7 (zero scope), 10 (the issue is not a type:epic), 11 (a read the floor depends on failed — a child, a referenced issue, a dependent\'s blocked_by list, or the control-plane roster — UNKNOWN, never "not approved" and never "no edge"), 25 (the plan is not approved as it now stands: no standing marker, or one binding a digest the plan has moved off — refused BEFORE the floor is derived, so an unapproved AND defective plan refuses on this, ADR 0289). Example: fabrika plan check 4300',
 	),
 );
 

--- a/packages/fabrika-cli/src/plan/defects.ts
+++ b/packages/fabrika-cli/src/plan/defects.ts
@@ -1,8 +1,14 @@
 /**
- * The floor: a total function from the ledger to a sorted defect list over a closed thirteen-type
+ * The floor: a total function from the ledger to a sorted defect list over a closed fourteen-type
  * enum. `plan check` is this function plus a fetch; nothing above it can change the answer.
  *
- * **Fourteen names, thirteen defects.** `ZERO_SCOPE` is the fourteenth and is seated as exit `7`
+ * **`UNENFORCED_DEP` is the one defect about the *board* rather than the document.** ADR 0301 makes
+ * the native `blocked_by` graph the only carrier of blockedness, so a plan whose dependency lives in
+ * `## Dependencies` alone is a plan whose gates are blind — epic #6595 admitted a child gated behind
+ * an open, unruled decision (#6616). This defect is what makes "floor clean" mean the graph agrees
+ * with the prose; `ledger edges` is the write that clears it.
+ *
+ * **Fifteen names, fourteen defects.** `ZERO_SCOPE` is the fifteenth and is seated as exit `7`
  * rather than as defect zero: v1 made a childless epic defect #1 and early-returned, so the ledger
  * was never validated and the verdict reported exactly one thing wrong about a plan it had not read.
  * A refused scope is not a defect list of length one (ADR 0092).
@@ -15,6 +21,7 @@
  * The priority set is exactly `{p0, p1, p2}` — `p3` was ruled *retired*, not widened (#4101, #2413).
  */
 
+import type {RequiredEdge} from "../build/dependencies.ts";
 import {type ContainmentVocabulary, containmentGap} from "../config/keys/containment-vocabulary.ts";
 import type {LedgerScope} from "./digest.ts";
 import type {ChildLedger} from "./model.ts";
@@ -24,6 +31,7 @@ export const DEFECT_TYPES = [
 	"MISSING_DEPS_SECTION",
 	"DEP_CYCLE",
 	"DANGLING_DEP",
+	"UNENFORCED_DEP",
 	"ORPHAN_CHILD",
 	"MISSING_STORIES_SECTION",
 	"UNCOVERED_STORY",
@@ -169,10 +177,33 @@ const missingLabelKinds = (labels: ReadonlyArray<string>): ReadonlyArray<string>
 	return missing;
 };
 
+/**
+ * The required pairs `UNENFORCED_DEP` is derived over: everything except a pair whose prerequisite the
+ * probe proved absent, which is `DANGLING_DEP`'s and which no edge could point at anyway.
+ *
+ * Exported because the verb reads a `blocked_by` list per dependent and must read exactly this set —
+ * two spellings of the filter would let the floor report a pair the verb never read, which reads as a
+ * defect and is really an unread.
+ */
+export const edgesToEnforce = (
+	required: ReadonlyArray<RequiredEdge>,
+	provenAbsent: ReadonlySet<number>,
+): ReadonlyArray<RequiredEdge> => required.filter((edge) => !provenAbsent.has(edge.prerequisite));
+
 export interface FloorInput {
 	readonly ledger: LedgerScope;
 	/** The refs {@link refsToProbe} named that a 404-discriminating probe proved **absent**. */
 	readonly provenAbsent: ReadonlySet<number>;
+	/** Every `blocked_by` edge the topology requires, off the one derivation in `build/dependencies.ts`. */
+	readonly required: ReadonlyArray<RequiredEdge>;
+	/**
+	 * Each dependent's observed `blocked_by` set, read off the board.
+	 *
+	 * Total over the dependents `required` names — the verb refuses on an unread list rather than
+	 * calling this, so a dependent absent from the map is read here as carrying no edges, which is the
+	 * fail-closed direction (ADR 0092).
+	 */
+	readonly observed: ReadonlyMap<number, ReadonlySet<number>>;
 	/**
 	 * The resolved containment vocabulary — config, not ledger, which is why it is an input here
 	 * rather than a field of the ledger the scope digest is taken over.
@@ -180,7 +211,13 @@ export interface FloorInput {
 	readonly vocabulary: ContainmentVocabulary;
 }
 
-export const deriveFloor = ({ledger, provenAbsent, vocabulary}: FloorInput): Floor => {
+export const deriveFloor = ({
+	ledger,
+	provenAbsent,
+	required,
+	observed,
+	vocabulary,
+}: FloorInput): Floor => {
 	const defects: Defect[] = [];
 
 	if (ledger.dependenciesAbsent) {
@@ -206,6 +243,15 @@ export const deriveFloor = ({ledger, provenAbsent, vocabulary}: FloorInput): Flo
 			type: "DANGLING_DEP",
 			refs: [ref],
 			detail: `#${ref} is referenced but is not a child and is proven absent`,
+		});
+	}
+
+	for (const {dependent, prerequisite} of edgesToEnforce(required, provenAbsent)) {
+		if (observed.get(dependent)?.has(prerequisite) === true) continue;
+		defects.push({
+			type: "UNENFORCED_DEP",
+			refs: [dependent, prerequisite].sort((a, b) => a - b),
+			detail: `#${dependent} waits on #${prerequisite} in prose with no blocked_by edge`,
 		});
 	}
 

--- a/packages/fabrika-cli/src/plan/defects.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/defects.unit.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import type {RequiredEdge} from "../build/dependencies.ts";
 import {SHIPPED_CONTAINMENT_VOCABULARY} from "../config/keys/containment-vocabulary.ts";
 import {DEFECT_TYPES, type DefectType, deriveFloor, refsToProbe} from "./defects.ts";
 import type {LedgerScope} from "./digest.ts";
@@ -27,15 +28,35 @@ const scope = (overrides: Partial<LedgerScope> = {}): LedgerScope => ({
 	...overrides,
 });
 
-const floorOf = (overrides: Partial<LedgerScope> = {}, absent: ReadonlyArray<number> = []) =>
+/** The board half of the floor's inputs: what the topology owes, and what the graph carries. */
+interface Graph {
+	readonly required?: ReadonlyArray<RequiredEdge>;
+	readonly observed?: Readonly<Record<number, ReadonlyArray<number>>>;
+}
+
+const floorOf = (
+	overrides: Partial<LedgerScope> = {},
+	absent: ReadonlyArray<number> = [],
+	graph: Graph = {},
+) =>
 	deriveFloor({
 		ledger: scope(overrides),
 		provenAbsent: new Set(absent),
+		required: graph.required ?? [],
+		observed: new Map(
+			Object.entries(graph.observed ?? {}).map(([number, blockers]) => [
+				Number.parseInt(number, 10),
+				new Set(blockers),
+			]),
+		),
 		vocabulary: SHIPPED_CONTAINMENT_VOCABULARY,
 	});
 
-const types = (overrides: Partial<LedgerScope> = {}, absent: ReadonlyArray<number> = []) =>
-	floorOf(overrides, absent).defects.map((defect) => defect.type);
+const types = (
+	overrides: Partial<LedgerScope> = {},
+	absent: ReadonlyArray<number> = [],
+	graph: Graph = {},
+) => floorOf(overrides, absent, graph).defects.map((defect) => defect.type);
 
 describe("a clean plan", () => {
 	it("derives no defects and skips no class", () => {
@@ -43,7 +64,7 @@ describe("a clean plan", () => {
 	});
 });
 
-describe("each of the thirteen types fires on its own condition", () => {
+describe("each of the fourteen types fires on its own condition", () => {
 	it("MISSING_DEPS_SECTION", () => {
 		expect(types({dependenciesAbsent: true})).toContain("MISSING_DEPS_SECTION");
 	});
@@ -76,6 +97,41 @@ describe("each of the thirteen types fires on its own condition", () => {
 		};
 		expect(types(referenced, [9999])).toContain("DANGLING_DEP");
 		expect(types(referenced, [])).not.toContain("DANGLING_DEP");
+	});
+
+	/**
+	 * The pre-fix state, in one assertion: epic #6595's shape — a phase-2 child requiring an open
+	 * phase-1 decision — with the dependency in prose and nothing on the graph. Before `UNENFORCED_DEP`
+	 * this floor read `clean`, `plan flip` made the child pickable, and `build claim` admitted it on
+	 * `scanned 0 blocked_by edges` (#6616).
+	 */
+	it("UNENFORCED_DEP when the prose names an edge the graph does not carry", () => {
+		const gated = {
+			children: [child({number: 6597}), child({number: 6598})],
+			topology: {
+				phases: [
+					{phase: 1, members: ["#6597"]},
+					{phase: 2, members: ["#6598"]},
+				],
+				edges: [["#6598", "#6597"] as const],
+			},
+		};
+		const required: ReadonlyArray<RequiredEdge> = [{dependent: 6598, prerequisite: 6597}];
+
+		const blind = floorOf(gated, [], {required});
+		const defect = blind.defects.find((row) => row.type === "UNENFORCED_DEP");
+		expect(defect?.refs).toEqual([6597, 6598]);
+		expect(defect?.detail).toBe("#6598 waits on #6597 in prose with no blocked_by edge");
+
+		expect(types(gated, [], {required, observed: {6598: [6597]}})).not.toContain("UNENFORCED_DEP");
+	});
+
+	it("UNENFORCED_DEP yields to DANGLING_DEP when the prerequisite is proven absent", () => {
+		const dangling = {
+			topology: {phases: [{phase: 1, members: ["#4301", "#9999"]}], edges: []},
+		};
+		const required: ReadonlyArray<RequiredEdge> = [{dependent: 4301, prerequisite: 9999}];
+		expect(types(dangling, [9999], {required})).not.toContain("UNENFORCED_DEP");
 	});
 
 	it("ORPHAN_CHILD", () => {

--- a/packages/fabrika-cli/src/plan/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/plan/fixtures.test-support.ts
@@ -134,6 +134,16 @@ export const SUB_ISSUES = new RegExp(
 );
 export const CHILD = (number: number): RegExp =>
 	new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/issues\\/${number}$`);
+/** The native `blocked_by` list `UNENFORCED_DEP` is derived over. */
+export const BLOCKED_BY = (number: number): RegExp =>
+	new RegExp(`^GET ${API}\\/repos\\/o\\/r\\/issues\\/${number}\\/dependencies\\/blocked_by`);
+/** The list payload that endpoint answers — full issue rows, of which the reader takes `number`. */
+export const blockers = (...numbers: ReadonlyArray<number>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(
+		numbers.map((number) => ({number, state: "open", title: `blocker ${number}`})),
+	),
+});
 /**
  * The cycle-doc probe. Bound to the doc's own path, not to `contents/`: the roster reads
  * `.github/CODEOWNERS` through the same endpoint, and a prefix pattern here answers that read too.

--- a/packages/fabrika-cli/src/plan/flip-verb.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.ts
@@ -193,7 +193,13 @@ export const runFlip = (
 		const approval = yield* requireApproval(MESSAGES, repo, ledger.epic, ledger.digest, notes);
 		if (approval._tag === "Refused") return approval.outcome;
 
-		const derived = yield* deriveFloorFor(MESSAGES, repo, ledger, vocabulary.vocabulary);
+		const derived = yield* deriveFloorFor(
+			MESSAGES,
+			repo,
+			ledger,
+			vocabulary.vocabulary,
+			read.required,
+		);
 		if (derived._tag === "Refused") return derived.outcome;
 		if (derived.floor.defects.length > 0) {
 			return refuse(

--- a/packages/fabrika-cli/src/plan/load.ts
+++ b/packages/fabrika-cli/src/plan/load.ts
@@ -13,7 +13,14 @@
 import {Effect, type FileSystem, type Path} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {type PhaseLine, type RequiresLine, readTopology, renderRef} from "../build/dependencies.ts";
+import {
+	type PhaseLine,
+	type RequiredEdge,
+	type RequiresLine,
+	readTopology,
+	renderRef,
+	requiredEdges,
+} from "../build/dependencies.ts";
 import {openIssue} from "../build/target.ts";
 import {CONFIG_PATH} from "../config/document.ts";
 import {
@@ -24,12 +31,13 @@ import {
 } from "../config/keys/containment-vocabulary.ts";
 import {resolve} from "../config/load.ts";
 import {loadRepoConfig} from "../config/working-root.ts";
+import {blockedBy} from "../io/edges.ts";
 import {getIssue, type IssueRecord} from "../io/issues.ts";
 import {EPIC_TYPE_LABEL} from "../triage/facets.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {read as readAcceptanceCriteria} from "../wire/acceptance-criteria.ts";
 import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {deriveFloor, type Floor, refsToProbe} from "./defects.ts";
+import {deriveFloor, edgesToEnforce, type Floor, refsToProbe} from "./defects.ts";
 import {type LedgerScope, scopeDigest} from "./digest.ts";
 import {getChild, listSubIssues, probeCycleDoc} from "./github.ts";
 import {
@@ -118,7 +126,16 @@ export const requireEpic = (
 
 export type LedgerRead =
 	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
-	| {readonly _tag: "Ledger"; readonly ledger: Ledger};
+	| {
+			readonly _tag: "Ledger";
+			readonly ledger: Ledger;
+			/**
+			 * The edges the topology requires on the board, carried beside the ledger rather than on it:
+			 * the digest is taken over the ledger, and this is a function of the topology already in it,
+			 * so folding it in would invalidate every standing approval to say nothing new (ADR 0289).
+			 */
+			readonly required: ReadonlyArray<RequiredEdge>;
+	  };
 
 const criteriaOf = (body: string): {token: CriteriaToken; count: number} => {
 	const read = readAcceptanceCriteria(body);
@@ -263,7 +280,11 @@ export const loadLedger = (
 			topology: {phases, edges},
 			dependenciesAbsent: topology._tag === "Absent",
 		};
-		return {_tag: "Ledger" as const, ledger: {...scope, digest: scopeDigest(scope)}};
+		return {
+			_tag: "Ledger" as const,
+			ledger: {...scope, digest: scopeDigest(scope)},
+			required: requiredEdges(parsed),
+		};
 	});
 
 /**
@@ -283,17 +304,19 @@ export type FloorRead =
 	| {readonly _tag: "Floor"; readonly floor: Floor};
 
 /**
- * The floor over a loaded ledger, including the one read it needs: the 404-discriminating probe
- * behind `DANGLING_DEP`.
+ * The floor over a loaded ledger, including the two reads it needs: the 404-discriminating probe
+ * behind `DANGLING_DEP`, and each dependent's `blocked_by` list behind `UNENFORCED_DEP`.
  *
  * An `Unknown` probe refuses on `11` rather than resolving either way — "I could not tell whether
- * this ref exists" is not "it does", and it is certainly not "it does not".
+ * this ref exists" is not "it does", and it is certainly not "it does not". An unread `blocked_by`
+ * list refuses the same way: an edge nobody could see is never an edge that is there.
  */
 export const deriveFloorFor = (
 	messages: PlanMessages,
 	repo: string,
 	ledger: LedgerScope,
 	vocabulary: ContainmentVocabulary,
+	required: ReadonlyArray<RequiredEdge>,
 ): Effect.Effect<
 	FloorRead,
 	never,
@@ -318,5 +341,36 @@ export const deriveFloorFor = (
 			}
 			if (found._tag === "Absent") provenAbsent.add(ref);
 		}
-		return {_tag: "Floor" as const, floor: deriveFloor({ledger, provenAbsent, vocabulary})};
+
+		const dependents = [
+			...new Set(edgesToEnforce(required, provenAbsent).map((edge) => edge.dependent)),
+		].sort((a, b) => a - b);
+		const graph = yield* Effect.forEach(
+			dependents,
+			(number) => blockedBy(repo, number).pipe(Effect.map((found) => [number, found] as const)),
+			{concurrency: FAN_OUT},
+		);
+		const observed = new Map<number, ReadonlySet<number>>();
+		for (const [number, found] of graph) {
+			if (found._tag !== "Present") {
+				return {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						PRECONDITION_UNKNOWN,
+						messages.unreadable(
+							`#${number}'s blocked_by list`,
+							found._tag === "Absent"
+								? "it answered 404 for an issue the topology names"
+								: found.reason,
+						),
+					),
+				};
+			}
+			observed.set(number, new Set(found.value));
+		}
+
+		return {
+			_tag: "Floor" as const,
+			floor: deriveFloor({ledger, provenAbsent, required, observed, vocabulary}),
+		};
 	});

--- a/packages/fabrika-cli/src/plan/verdict-verb.ts
+++ b/packages/fabrika-cli/src/plan/verdict-verb.ts
@@ -199,7 +199,13 @@ export const runVerdict = (
 		const approval = yield* requireApproval(MESSAGES, repo, ledger.epic, ledger.digest, notes);
 		if (approval._tag === "Refused") return approval.outcome;
 
-		const derived = yield* deriveFloorFor(MESSAGES, repo, ledger, vocabulary.vocabulary);
+		const derived = yield* deriveFloorFor(
+			MESSAGES,
+			repo,
+			ledger,
+			vocabulary.vocabulary,
+			read.required,
+		);
 		if (derived._tag === "Refused") return derived.outcome;
 		const floor = derived.floor;
 


### PR DESCRIPTION
Fixes #6616

An epic's plan wrote its dependencies as prose and nothing else. ADR 0301 makes GitHub's native
`blocked_by` graph the one carrier of blockedness and both build gates read only that graph, so a
`#N requires: #M` row that lived only in `## Dependencies` left them blind — epic #6595 said in three
places that #6598 waited on the open, unruled decision #6597, and `build claim` took it anyway on
`scanned 0 blocked_by edges`.

Two halves, one derivation shared between them:

- **`requiredEdges`** in `build/dependencies.ts` says which pairs the block owes. It is stated once,
  on top of the existing `predecessorsOf` rule: an explicit `requires:` row is the precise gate where
  there is one, otherwise the phase boundary is.
- **`fabrika ledger edges <epic> --token …`** writes them. It reads the epic's own body (not the run's
  staged topology), POSTs each missing edge on the prerequisite's internal id, and proves every pair
  by re-reading the graph. It reconciles rather than replaces — an edge no ledger authored is left
  alone — so it is idempotent and also repairs an epic some earlier run already published. `plan-epic`
  runs it as its new step 8.
- **`UNENFORCED_DEP`**, the fourteenth floor defect, reds `plan check` when a pair the topology
  requires is not on the dependent's `blocked_by` list. An unread list refuses `11` rather than
  reading as "no edge". A prerequisite proven absent stays `DANGLING_DEP`'s, so one unfixable pair is
  never named twice.

Worth a reviewer's eye first: the shared `edgesToEnforce` filter, which exists so the verb reads
exactly the set the floor grades — two spellings of it would let the floor report a pair nobody read.

## Deviations

- **Out-of-scope change** — **Said:** the criteria name a `#N requires: #M` row. **Did:** the derived
  edge set also covers phase-implied dependencies, so a phase-2 child with no `requires:` row gets
  edges to every earlier-phase member. **Why:** `build/dependencies.ts` already declares a phase
  boundary to be real blockedness ("an issue in phase *k* is blocked while any ref in a phase below
  *k* is open"), so covering only `requires:` rows would have left the identical blind spot for every
  phase-only plan. **Disposition:** stated here; the rule is `predecessorsOf`'s, not a new one.
- **Scope narrowing** — **Said:** criterion 3 asks for the refusal reproduced against the epic
  #6595 / #6597 / #6598 shape. **Did:** reproduced it as tests over that shape — the floor case in
  `check-verb.unit.test.ts` and the derivation in `dependencies.unit.test.ts` — not against the live
  board. **Why:** a build lane holds no claim on #6595 and writing edges onto live epics from here
  would mutate three issues this PR does not own. **Disposition:** stated here; #6595 still needs
  `ledger edges` run against it, filed separately.
- **Known defect left unfixed** — **Said:** nothing about already-planned epics. **Did:** every epic
  planned before this lands reds `UNENFORCED_DEP` at the gate until `ledger edges` runs on it.
  **Why:** the fail-closed direction is the point — a floor that passed such an epic is the bug.
  **Disposition:** stated here; the remedy is one idempotent verb, and `check-epic-plan` now says so
  on the defective path.
