### PR TITLE
chore: biome-plugins/no-context-tag.grit still calls Effect v4 the effect-smol line

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
 		// A held `/fate/live` SSE stream that's still open when its client
 		// disconnects has its response-body Effect fiber interrupted; the
 		// interrupt-only `Cause` squashes to a generic
-		// `Error("All fibers interrupted without error")` (effect-smol
+		// `Error("All fibers interrupted without error")` (Effect-TS/effect
 		// `Cause.squash`), which the workerd isolate logs as an uncaught
 		// exception and Vitest's main-process StateManager then collects as an
 		// unhandled error — flipping a fully-green run's exit code to non-zero

--- a/apps/web/worker/features/fate-live/cold-start-retry.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.ts
@@ -5,7 +5,7 @@
  * `.patterns/alchemy-durable-objects.md`. The GET SSE-open `.fetch` path is a second
  * channel: alchemy wraps it in an uncaught `Effect.promise`, so the same cold-DO
  * rejection arrives as a DEFECT and must be lifted before the shared retry sees it
- * (#1048). Schedule shape grounds in effect-smol `LLMS.md` §"Working with Schedules".
+ * (#1048). Schedule shape grounds in Effect-TS/effect `LLMS.md` §"Working with Schedules".
  */
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -90,7 +90,7 @@ export type SandboxViewerResolution = typeof resolveSandboxViewer;
  * tier read + one opt-in read between them instead of three each (#6457). Shape and its
  * three load-bearing properties: `.patterns/fate-effect-worker-wiring.md`.
  *
- * The default MUST stay stateless — `Context.Reference` caches it on the key (effect-smol
+ * The default MUST stay stateless — `Context.Reference` caches it on the key (Effect-TS/effect
  * `Context.ts`), so state here would be an isolate-level cache handing one viewer's tier
  * to another request.
  */
@@ -148,7 +148,7 @@ export const moderatorSandboxViewer: Effect.Effect<SandboxViewer, never, Moderat
 export type PublishDecision = Brand.Branded<{readonly broadcast: boolean}, "PublishDecision">;
 
 // Kept PRIVATE: it is the only way to mint a `PublishDecision`, and `Brand.nominal`
-// applies no runtime check (effect-smol `Brand.ts`) — it returns its input.
+// applies no runtime check (Effect-TS/effect `Brand.ts`) — it returns its input.
 const makePublishDecision = Brand.nominal<PublishDecision>();
 const branded = (broadcast: boolean): PublishDecision => makePublishDecision({broadcast});
 

--- a/apps/web/worker/lib/ids.ts
+++ b/apps/web/worker/lib/ids.ts
@@ -4,11 +4,11 @@
  * `Schema.brand` makes them distinct types while staying plain strings at runtime: the brand
  * is type-only, so wire and D1 bytes are byte-identical.
  *
- * Idiom grounded in effect-smol `SCHEMA.md` §Branding.
+ * Idiom grounded in Effect-TS/effect `SCHEMA.md` §Branding.
  */
 import * as Schema from "effect/Schema";
 
-// Type-only: adds no runtime check or transform (effect-smol `SCHEMA.md` §Branding).
+// Type-only: adds no runtime check or transform (Effect-TS/effect `SCHEMA.md` §Branding).
 export const brandedId = <const B extends string>(brand: B) =>
 	Schema.String.pipe(Schema.brand(brand));
 

--- a/biome-plugins/no-context-tag.grit
+++ b/biome-plugins/no-context-tag.grit
@@ -2,11 +2,11 @@
 // `Effect.Service(...)` — require Effect-v4 `Context.Service`.
 //
 // Rationale (single site; .patterns/effect-context-service.md): phoenix is on Effect v4
-// (the effect-smol line). The v3 service idioms — `Context.Tag`, `Context.GenericTag`,
-// and the `Effect.Service` helper — are wrong here; the single v4 idiom is
-// `class S extends Context.Service<S, Shape>()("id") {}`. This rule is a pure regression
-// gate: the repo scan for #2736 found ZERO existing violations (the codebase is already
-// all-v4), so it exists only to stop a v3 form from re-entering.
+// (`effect@4.0.0-beta.*`, developed on `Effect-TS/effect` main). The v3 service idioms —
+// `Context.Tag`, `Context.GenericTag`, and the `Effect.Service` helper — are wrong here;
+// the single v4 idiom is `class S extends Context.Service<S, Shape>()("id") {}`. This rule
+// is a pure regression gate: the repo scan for #2736 found ZERO existing violations (the
+// codebase is already all-v4), so it exists only to stop a v3 form from re-entering.
 //
 // Matched on the member-access callee (`Context.Tag` etc.) rather than a call snippet,
 // because the forms differ in arity/type-args (`Context.Tag("id")<S, Shape>()`,


### PR DESCRIPTION
Comment citations that pointed at the retired Effect v4 prototype repo now name `Effect-TS/effect`, where Effect v4 actually lives.

- `biome-plugins/no-context-tag.grit` — the rationale comment now reads "phoenix is on Effect v4 (`effect@4.0.0-beta.*`, developed on `Effect-TS/effect` main)", matching the wording `.patterns/effect-context-service.md` carries at line 8. The comment cites that doc as its single site, so the two now say the fact one way.
- `apps/web/vitest.config.ts` — the `Cause.squash` source citation.
- `apps/web/worker/lib/ids.ts`, `apps/web/worker/features/fate-live/cold-start-retry.ts`, `apps/web/worker/features/kunye/sandbox.ts` — four more source citations in the same directory tree.

Comment-only. No code, no config, no `.decisions/` file changed.

## Grounding

Every cited file was checked against `Effect-TS/effect` main before the rename: `LLMS.md` §"Working with Schedules" (line 267), `packages/effect/SCHEMA.md` §Branding (line 2678), `packages/effect/src/Context.ts`, `packages/effect/src/Brand.ts`, and `Cause.squash` at `packages/effect/src/Cause.ts:736`. Each citation still resolves; only the repo name moved.

## What a reviewer should look at first

`biome-plugins/no-context-tag.grit` is outside every declared code validator, so `build check` names it `unvalidated`. Proven separately: `biome check` with the repo config over a probe file containing `Context.Tag("S")` still reports the plugin diagnostic on the member-access callee, unchanged. The three `register_diagnostic` message strings carry no repo reference at all, so they are untouched.

## Deviations

- **Out-of-scope change** — **Said:** #6781's prose names two files, `biome-plugins/no-context-tag.grit` and `apps/web/vitest.config.ts`, and its triage note states "exactly these two remain". **Did:** also re-pointed four citations across `apps/web/worker/lib/ids.ts`, `apps/web/worker/features/fate-live/cold-start-retry.ts` and `apps/web/worker/features/kunye/sandbox.ts`. **Why:** acceptance criterion 3 demands `git grep -n "effect-smol" -- biome-plugins/ apps/` return zero hits on the branch head, and those four hits sit inside that grep's scope. The prose enumeration undercounted; the mechanical criterion is the binding one, and meeting it required all six. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** #6781 scopes `.patterns/` out, as the earlier doc sweep's territory. **Did:** left two surviving `effect-smol` citations in `.patterns/fate-effect-worker-wiring.md` (lines 165 and 169) untouched. **Why:** the issue rules `.patterns/` out of scope explicitly, and criterion 3's grep does not reach it, so fixing it here would widen the diff past the contract. **Disposition:** filed as https://github.com/kamp-us/phoenix/issues/6873.

## Rejects the temptation to widen further

`.decisions/` still carries its roughly twenty historical `effect-smol` references verbatim. Criterion 4 is met by leaving them: an ADR records what was true when the decision was made.

Fixes #6781
