### PR TITLE
fix: lane prove reads a PR body's linked issue as a scalar first match, so no epic tail can prove its own PASS

### DIFF
--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -27,7 +27,7 @@ import {getIssue, listComments} from "../io/issues.ts";
 import {getPullRequest, listPullFiles, openPullsClosing, searchOpenPulls} from "../io/pulls.ts";
 import {readAdvisory} from "../review/advisory.ts";
 import {
-	issueRefOf,
+	issueRefsOf,
 	partitionWithUi,
 	ROUTED_NAMESPACES,
 	shipNamespacesOf,
@@ -199,7 +199,7 @@ export const runProve = (
 		const traced = yield* traceOpenPull(repo, issue);
 		if (traced._tag === "Refused") return traced.outcome;
 		const diagnostics = [
-			`${VERB}: looked for an open PR in ${repo} whose body links #${issue} (Fixes/Part of); ${traced.scanned} candidate(s) read.`,
+			`${VERB}: looked for an open PR in ${repo} whose body links #${issue} (any closing keyword, or Part of, anywhere in the body); ${traced.scanned} candidate(s) read.`,
 		];
 
 		if (claim._tag === "OpenPull") {
@@ -228,7 +228,15 @@ export const runProve = (
 					diagnostics,
 				);
 			}
-			return yield* proveNoPull(repo, issue, taskId, event, loaded.entries, diagnostics);
+			return yield* proveNoPull(
+				repo,
+				issue,
+				taskId,
+				event,
+				loaded.entries,
+				diagnostics,
+				traced.trace.why,
+			);
 		}
 
 		if (traced.trace._tag !== "One") {
@@ -240,7 +248,7 @@ export const runProve = (
 						}
 					: {
 							_tag: "Absent",
-							what: `no open PR links #${issue}, so there is nothing a verdict could have been written on`,
+							what: `${traced.trace.why}, so there is nothing a verdict could have been written on`,
 						},
 				diagnostics,
 			);
@@ -271,12 +279,19 @@ interface Traced {
  * `build --partial` emits; the search index sees any body but lags a fresh PR — and this verb runs
  * at the worst moment for that lag, right after a builder reports `SHIPPED-PR`. Reading the edge
  * first means a lagging index can only fail to add a candidate, never hide the closing one, so a
- * lane that shipped is not recorded `BLOCKED` on exit `22`. `lane brief` asks the same question
- * through the same edge, so the two lane verbs agree on the closing-link half.
+ * lane that shipped is not recorded `BLOCKED` on exit `22`.
  *
- * Both reads only nominate; the body's link decides. A candidate that has closed since it was
+ * Both reads only nominate; the body's links decide. A candidate that has closed since it was
  * nominated, or that only mentions the number in prose, drops out here rather than counting as
  * proof — so unioning in the looser read widens candidates without widening what counts.
+ *
+ * **What `lane brief` and this verb still differ on.** Both start from the same edge, and since
+ * #6797 the body read is plural, so a tail closing N+1 issues traces to each of them here exactly as
+ * it does on the edge. The residue is that `brief` answers off the edge alone while this verb
+ * re-derives the link from body text, so a PR linked through the sidebar's Development panel rather
+ * than a keyword in its body (GitHub's "Manually linking a pull request to an issue using the pull
+ * request sidebar") is on the edge and is not a proof here. That is deliberate — a proof
+ * this verb records has to be readable in the artifact it names — not an agreement claim.
  */
 const traceOpenPull = (
 	repo: string,
@@ -315,7 +330,7 @@ const traceOpenPull = (
 			facts.push({
 				number: pull.value.number,
 				open: pull.value.state === "open",
-				linkedIssue: issueRefOf(pull.value.body).number,
+				linkedIssues: issueRefsOf(pull.value.body).numbers,
 			});
 		}
 		return {_tag: "Traced" as const, trace: tracePulls(issue, facts), scanned: facts.length};
@@ -333,13 +348,14 @@ const proveNoPull = (
 	event: string,
 	entries: ReadonlyArray<{readonly task: string; readonly at: string}>,
 	diagnostics: ReadonlyArray<string>,
+	unlinked: string,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
 		const found = yield* getIssue(repo, issue);
 		if (found._tag === "Unknown") return unreadable(`issue #${issue}`, found.reason);
 		if (found._tag === "Absent") {
 			return seat(
-				{_tag: "Absent", what: `no open PR links #${issue}, and #${issue} itself is not there`},
+				{_tag: "Absent", what: `${unlinked}, and #${issue} itself is not there`},
 				diagnostics,
 			);
 		}
@@ -357,7 +373,7 @@ const proveNoPull = (
 			return seat(
 				{
 					_tag: "Absent",
-					what: `no open PR links #${issue}, and ${diagnosis.why} — the ${event} rests on the spawn's word alone`,
+					what: `${unlinked}, and ${diagnosis.why} — the ${event} rests on the spawn's word alone`,
 				},
 				looked,
 			);

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -252,26 +252,44 @@ export const traceRange = (
 export interface PullFact {
 	readonly number: number;
 	readonly open: boolean;
-	/** The issue the body links, through the closing keyword or `Part of` — never the search term. */
-	readonly linkedIssue: number | null;
+	/**
+	 * **Every** issue the body links, through the closing keywords or `Part of` — never the search
+	 * term. Plural because an epic tail links one issue per landed child plus the epic itself, and a
+	 * scalar field there can only ever report one of them (#6797).
+	 */
+	readonly linkedIssues: ReadonlyArray<number>;
 }
 
 export type PullTrace =
 	| {readonly _tag: "One"; readonly pr: number}
-	| {readonly _tag: "None"}
+	| {readonly _tag: "None"; readonly why: string}
 	| {readonly _tag: "Many"; readonly prs: ReadonlyArray<number>};
 
 /**
  * The open PR tracing to this issue.
  *
- * The search index only nominates; the trace is the body's own link, so a PR that merely mentions
+ * The search index only nominates; the trace is the body's own links, so a PR that merely mentions
  * the number in prose is not a proof of it. Several is its own answer — which one the lane owns is
  * not derivable here, and picking the first is how a lane records a DONE against another lane's PR.
+ *
+ * `None` carries its own reason for the same purpose `traceRange`'s does: "nothing was nominated"
+ * and "candidates were read and every one linked elsewhere" have different remedies, and a refusal
+ * saying the first of a board that shows the second is false of the board (#6797).
  */
 export const tracePulls = (issue: number, facts: ReadonlyArray<PullFact>): PullTrace => {
-	const matched = facts.filter((fact) => fact.open && fact.linkedIssue === issue);
+	const open = facts.filter((fact) => fact.open);
+	const matched = open.filter((fact) => fact.linkedIssues.includes(issue));
 	const first = matched[0];
-	if (first === undefined) return {_tag: "None"};
+	if (first === undefined) {
+		if (facts.length === 0) return {_tag: "None", why: `no open PR links #${issue}`};
+		const read = facts.map((fact) => `#${fact.number}`).join(", ");
+		return open.length === 0
+			? {
+					_tag: "None",
+					why: `read ${read} — every candidate has closed since it was nominated`,
+				}
+			: {_tag: "None", why: `read ${read} — no candidate's body links #${issue}`};
+	}
 	return matched.length === 1
 		? {_tag: "One", pr: first.number}
 		: {_tag: "Many", prs: matched.map((fact) => fact.number)};

--- a/packages/fabrika-cli/src/lane/prove.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove.unit.test.ts
@@ -223,22 +223,45 @@ describe("traceRange", () => {
 });
 
 describe("tracePulls", () => {
-	const linking = {number: 4318, open: true, linkedIssue: 4312};
+	const linking = {number: 4318, open: true, linkedIssues: [4312]};
 
 	it("traces the one open PR whose body links the issue", () => {
 		expect(tracePulls(4312, [linking])).toEqual({_tag: "One", pr: 4318});
 	});
 
+	/**
+	 * The #6797 shape: an epic tail body carries one closing reference per landed child plus the
+	 * epic's own, and the epic's sits last. A scalar `linkedIssue` field reported the first child and
+	 * left the tail unproven against the epic it closes.
+	 */
+	it("proves the epic tail against the epic whose reference is last among N+1", () => {
+		const tail = {number: 6690, open: true, linkedIssues: [6642, 6643, 6648, 6629]};
+		expect(tracePulls(6629, [tail])).toEqual({_tag: "One", pr: 6690});
+		expect(tracePulls(6642, [tail])).toEqual({_tag: "One", pr: 6690});
+	});
+
 	it("does not count a PR that only mentions the number, or one that has closed", () => {
-		expect(tracePulls(4312, [{number: 4400, open: true, linkedIssue: null}])).toEqual({
+		expect(tracePulls(4312, [{number: 4400, open: true, linkedIssues: []}])).toMatchObject({
 			_tag: "None",
 		});
-		expect(tracePulls(4312, [{...linking, open: false}])).toEqual({_tag: "None"});
+		expect(tracePulls(4312, [{...linking, open: false}])).toMatchObject({_tag: "None"});
 	});
 
 	it("keeps several linking PRs as their own answer rather than picking the first", () => {
-		const trace = tracePulls(4312, [linking, {number: 4319, open: true, linkedIssue: 4312}]);
+		const trace = tracePulls(4312, [linking, {number: 4319, open: true, linkedIssues: [4312]}]);
 		expect(trace).toEqual({_tag: "Many", prs: [4318, 4319]});
+	});
+
+	it("tells a candidate that was read and discarded from one that was never nominated", () => {
+		const nothing = tracePulls(4312, []);
+		const read = tracePulls(4312, [{number: 4400, open: true, linkedIssues: [4000]}]);
+		const closed = tracePulls(4312, [{...linking, open: false}]);
+		expect(nothing).toEqual({_tag: "None", why: "no open PR links #4312"});
+		expect(read).toEqual({_tag: "None", why: "read #4400 — no candidate's body links #4312"});
+		expect(closed).toEqual({
+			_tag: "None",
+			why: "read #4318 — every candidate has closed since it was nominated",
+		});
 	});
 });
 

--- a/packages/fabrika-cli/src/review/classes.ts
+++ b/packages/fabrika-cli/src/review/classes.ts
@@ -215,6 +215,24 @@ export const linkedIssueOf = (body: string): number | null => {
 };
 
 /**
+ * **Every** issue the body's closing keywords link, in body order, deduplicated.
+ *
+ * A sibling rather than a widening of {@link linkedIssueOf}, whose scalar first match is load
+ * bearing where a PR closes one issue and the caller wants that one (`ship release`, `heal-ci`).
+ * An epic tail body carries one closing reference per landed child plus one on the epic itself, at
+ * an arbitrary position among them, so a scalar reader there reports whichever child happens to be
+ * first and answers "unlinked" of the epic — which is false of the board, since GitHub links all of
+ * them (#6797). Callers asking "does this body link #N" ask this one and test membership.
+ */
+export const linkedIssuesOf = (body: string): ReadonlyArray<number> => {
+	const all = new RegExp(CLOSING_KEYWORD.source, "gi");
+	const numbers = [...body.matchAll(all)].flatMap((match) =>
+		match[1] === undefined ? [] : [Number.parseInt(match[1], 10)],
+	);
+	return [...new Set(numbers)];
+};
+
+/**
  * The **whole** reference a PR body can carry to its issue: a closing keyword, else the explicit
  * non-closing `Part of #N`, else nothing.
  *
@@ -240,6 +258,29 @@ export const issueRefOf = (body: string): IssueRef => {
 	return part?.[1] === undefined
 		? {kind: "none", number: null}
 		: {kind: "part-of", number: Number.parseInt(part[1], 10)};
+};
+
+export interface IssueRefs {
+	readonly kind: "fixes" | "part-of" | "none";
+	readonly numbers: ReadonlyArray<number>;
+}
+
+/**
+ * The plural sibling of {@link issueRefOf}: every issue of the winning kind, not the first.
+ *
+ * Same precedence — closing beats `Part of`, and a body carrying both is a `fixes` body — so a
+ * caller trading the scalar for this one changes only how many references it can see.
+ */
+export const issueRefsOf = (body: string): IssueRefs => {
+	const closing = linkedIssuesOf(body);
+	if (closing.length > 0) return {kind: "fixes", numbers: closing};
+	const all = new RegExp(PART_OF.source, "gi");
+	const parts = [...body.matchAll(all)].flatMap((match) =>
+		match[1] === undefined ? [] : [Number.parseInt(match[1], 10)],
+	);
+	return parts.length === 0
+		? {kind: "none", numbers: []}
+		: {kind: "part-of", numbers: [...new Set(parts)]};
 };
 
 /** `fixes:<n>` / `part-of:<n>`, or the calling group's null token. */

--- a/packages/fabrika-cli/src/review/classes.unit.test.ts
+++ b/packages/fabrika-cli/src/review/classes.unit.test.ts
@@ -3,7 +3,9 @@ import {
 	classOf,
 	SHIPPED_GOVERNED_ROOTS as GOVERNANCE_ROOTS,
 	issueRefOf,
+	issueRefsOf,
 	linkedIssueOf,
+	linkedIssuesOf,
 	namespacesOf,
 	partition,
 	partitionWithUi,
@@ -171,6 +173,50 @@ describe("linkedIssueOf", () => {
 		expect(linkedIssueOf("relates to #4287")).toBeNull();
 		expect(linkedIssueOf("Part of #4287")).toBeNull();
 		expect(linkedIssueOf("")).toBeNull();
+	});
+});
+
+describe("linkedIssuesOf", () => {
+	/** The #6797 shape: the epic's own reference is last among N+1, and a scalar reader lost it. */
+	it("reports every closing reference an epic tail body carries, epic included", () => {
+		const tail = "Closes #6642. Closes #6643. Closes #6648. Closes #6629.";
+		expect(linkedIssuesOf(tail)).toEqual([6642, 6643, 6648, 6629]);
+		expect(linkedIssuesOf(tail)).toContain(6629);
+	});
+
+	it("agrees with the scalar reader on a single-reference body", () => {
+		for (const body of ["does things\n\nFixes #4287\n", "Resolved #7", "relates to #4287", ""]) {
+			expect(linkedIssuesOf(body)[0] ?? null).toBe(linkedIssueOf(body));
+		}
+		expect(linkedIssuesOf("does things\n\nFixes #4287\n")).toEqual([4287]);
+		expect(linkedIssuesOf("Part of #4287")).toEqual([]);
+	});
+
+	it("names a repeated reference once", () => {
+		expect(linkedIssuesOf("Closes #12\nFixes #12")).toEqual([12]);
+	});
+});
+
+describe("issueRefsOf", () => {
+	it("keeps the scalar reader's precedence, and reports the whole set of the winning kind", () => {
+		expect(issueRefsOf("Closes #6642. Closes #6629.\n\nPart of #6000")).toEqual({
+			kind: "fixes",
+			numbers: [6642, 6629],
+		});
+		expect(issueRefsOf("does things\n\nPart of #5434\nPart of #5437\n")).toEqual({
+			kind: "part-of",
+			numbers: [5434, 5437],
+		});
+		expect(issueRefsOf("see #4000")).toEqual({kind: "none", numbers: []});
+	});
+
+	it("answers the scalar reader's kind and first number on every single-reference body", () => {
+		for (const body of ["Fixes #4287", "Part of #4000", "part of: #12", "see #4000", ""]) {
+			const ref = issueRefOf(body);
+			const refs = issueRefsOf(body);
+			expect(refs.kind).toBe(ref.kind);
+			expect(refs.numbers[0] ?? null).toBe(ref.number);
+		}
 	});
 });
 


### PR DESCRIPTION
`fabrika lane prove` read a candidate PR's linked issue as a single number — the first closing
keyword in the body. An epic tail body carries one closing reference per landed child plus one on the
epic itself, in whatever order the children landed, so the epic's own reference usually loses. The
verb then answered exit 22 "no open PR links #N", which is false of the board: GitHub links every one
of those references, and the tail is right there.

The fix is a plural reader beside the scalar one, not a change to it. `linkedIssueOf`'s first-match
contract is load bearing in `ship release` and `heal-ci`, where the question really is "the one issue
this PR closes", so those keep reading it and are untouched. New in
`packages/fabrika-cli/src/review/classes.ts`:

- `linkedIssuesOf(body)` — every closing reference, in body order, deduplicated.
- `issueRefsOf(body)` — the plural sibling of `issueRefOf`, same precedence (closing beats `Part of`),
  reporting the whole set of whichever kind wins.

`PullFact` in `packages/fabrika-cli/src/lane/prove.ts` now carries `linkedIssues`, and `tracePulls`
matches on membership. `Many` and `None` are unchanged answers, and `None` now carries its own reason
so the refusal can say which of two different situations it is: nothing was nominated at all, or
candidates were read and none of their bodies linked the issue. That second wording is what the old
message got wrong.

The `traceOpenPull` docblock used to claim `lane brief` and `lane prove` "agree on the closing-link
half". That is now closer to true but still not exactly true, so it says what still differs: `brief`
answers off GitHub's closing-issue edge, this verb re-derives from body text, so a PR linked through
the sidebar's Development panel is on the edge and is not a proof here — deliberately, since a proof
this verb records has to be readable in the artifact it names.

Reviewer's first look: `tracePulls` in `packages/fabrika-cli/src/lane/prove.ts` — the membership test
plus the three `None` reasons.

Fixes #6797

## Deviations

- **Out-of-scope change** — **Said:** #6797 asks for the plural set of *closing* references.
  **Did:** `issueRefsOf` makes the `Part of` half plural too. **Why:** `PullFact` fed off
  `issueRefOf`, which falls back to `Part of` for the `build --partial` shape; a closing-only plural
  reader would have dropped that fallback and stopped tracing partial-split PRs. The `Part of` half
  had the identical first-match-wins bug. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** add tests, do not rewrite them. **Did:** the
  existing `tracePulls` fixtures moved from `linkedIssue: 4312` to `linkedIssues: [4312]`, and two
  `toEqual({_tag: "None"})` assertions became `toMatchObject`. **Why:** the field was renamed and
  `None` gained a `why`; the exact reasons are asserted in a new test instead. **Disposition:**
  stated here.
