### PR TITLE
fix: ship checks reads a concurrency-cancelled run as a hard red at an unmoved head

### DIFF
--- a/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
@@ -124,6 +124,8 @@ export const runsAtHead = (
 			workflow_runs: rows.map((row) => ({
 				id: row.id,
 				name: row.name ?? "ci",
+				workflow_id: 1,
+				check_suite_id: row.id,
 				status: row.status ?? "completed",
 				conclusion: row.conclusion === undefined ? "failure" : row.conclusion,
 				completed_at: "2026-08-08T00:00:00Z",

--- a/packages/fabrika-cli/src/review/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/review/fixtures.test-support.ts
@@ -136,6 +136,8 @@ export const runsAtHead = (...paths: ReadonlyArray<string>): ExecResult =>
 				id: index + 1,
 				name: path,
 				path,
+				workflow_id: index + 1,
+				check_suite_id: index + 1,
 				status: "completed",
 				conclusion: "success",
 				completed_at: "2026-08-08T00:00:00Z",

--- a/packages/fabrika-cli/src/ship/checks-verb.ts
+++ b/packages/fabrika-cli/src/ship/checks-verb.ts
@@ -21,12 +21,13 @@ import {isFailing, isInformational, isStalled, rollupOf, statusOf} from "../revi
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
-	countWorkflowRuns,
 	latestPerContext,
+	listRunsAtHead,
 	listShipCheckRuns,
 	listWorkflows,
 	type ShipCheckRun,
 } from "./github.ts";
+import {isSuperseded, supersededSuites} from "./supersession.ts";
 import {
 	badNumber,
 	inspectedSha,
@@ -64,16 +65,25 @@ export interface ChecksOptions {
  * The gating axis rides inside the key because status
  * alone would leave the rollup underivable from the payload: a `red` head and a head whose only
  * `failure` is an ADR 0061 informational run would tally identically, and the carve-out is exactly
- * what separates them.
+ * what separates them. A superseded cancel says so in the key for the same reason — it pends where a
+ * plain `cancelled` reds.
  */
-const checkClassOf = (run: ShipCheckRun): string =>
-	`${statusOf(run)}/${isInformational(run.name) ? "informational" : "gating"}`;
+const checkClassOf = (run: ShipCheckRun, superseded: ReadonlySet<number>): string => {
+	const status = isSuperseded(run, superseded) ? `${statusOf(run)}-superseded` : statusOf(run);
+	return `${status}/${isInformational(run.name) ? "informational" : "gating"}`;
+};
 
 export interface Sample {
 	readonly runs: ReadonlyArray<ShipCheckRun>;
 	readonly workflows: number;
 	readonly runCount: number;
+	/** The suites a newer run of their own workflow replaced at this head — see `./supersession.ts`. */
+	readonly superseded: ReadonlySet<number>;
 }
+
+/** The gating check runs a superseded suite cancelled — read as still in flight, never as failed. */
+const supersededGating = (sample: Sample): ReadonlyArray<ShipCheckRun> =>
+	sample.runs.filter((run) => !isInformational(run.name) && isSuperseded(run, sample.superseded));
 
 /**
  * The whole answer over one sample.
@@ -88,7 +98,11 @@ export const rollupFor = (sample: Sample, wedged: ReadonlyArray<string>): Checks
 		if (sample.workflows === 0) return "no-producer";
 		return sample.runCount === 0 ? "no-runs" : "pending";
 	}
-	return rollupOf(sample.runs.filter((run) => !isInformational(run.name)));
+	const gating = sample.runs.filter((run) => !isInformational(run.name));
+	const rollup = rollupOf(gating.filter((run) => !isSuperseded(run, sample.superseded)));
+	// A superseded cancel is exactly as unfinished as a running check, so it pends a green and loses
+	// to a red — the substitution `rollupOf` would make if the row were still in flight.
+	return rollup === "green" && supersededGating(sample).length > 0 ? "pending" : rollup;
 };
 
 export const runChecks = (
@@ -158,18 +172,21 @@ export const runChecks = (
 					diagnostics,
 				);
 			}
-			const runCount = yield* countWorkflowRuns(repo, bound);
-			if (runCount._tag === "Failure") {
+			// Enumerated rather than counted: `total_count` is still the `no-runs` discriminator, and
+			// the rows beside it are the only place supersession can be read from (#6834).
+			const atHead = yield* listRunsAtHead(repo, bound);
+			if (atHead._tag === "Failure") {
 				return refuse(
 					PRECONDITION_UNKNOWN,
-					unreadable("the workflow runs", runCount.reason),
+					unreadable("the workflow runs", atHead.reason),
 					diagnostics,
 				);
 			}
 			return {
 				runs: latestPerContext(runs),
 				workflows: workflows.value,
-				runCount: runCount.value,
+				runCount: atHead.value.declared,
+				superseded: supersededSuites(atHead.value.runs),
 			} satisfies Sample;
 		});
 
@@ -180,7 +197,13 @@ export const runChecks = (
 			settle: Settle | null,
 		): VerbOutcome => {
 			const failing = read.runs
-				.filter((run) => !isInformational(run.name) && isFailing(run))
+				.filter(
+					(run) =>
+						!isInformational(run.name) && isFailing(run) && !isSuperseded(run, read.superseded),
+				)
+				.map((run) => run.name)
+				.sort();
+			const replaced = supersededGating(read)
 				.map((run) => run.name)
 				.sort();
 			const scope = [
@@ -196,11 +219,16 @@ export const runChecks = (
 					: [
 							`${VERB}: stranded past the dwell: ${wedged.join(", ")} — the cancel-and-rerun lever is an operator's (#3999).`,
 						]),
+				...(replaced.length === 0
+					? []
+					: [
+							`${VERB}: cancelled by a newer run of the same workflow at this head: ${replaced.join(", ")} — waiting on that run, not routing.`,
+						]),
 				...(failing.length === 0
 					? []
 					: [`${VERB}: failing gating checks: ${failing.join(", ")} — route these to heal-ci.`]),
 			];
-			const checks = reasonHistogram(read.runs, checkClassOf);
+			const checks = reasonHistogram(read.runs, (run) => checkClassOf(run, read.superseded));
 			if (json) {
 				return answer(
 					JSON.stringify({

--- a/packages/fabrika-cli/src/ship/checks-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/checks-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {rollupFor, runChecks} from "./checks-verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
@@ -60,21 +60,99 @@ const noRun = (name: string, status: string, conclusion: string | null = null) =
 	conclusion,
 });
 
+const empty = {runs: [], superseded: new Set<number>()};
+
+/**
+ * One sample's check rows, with the suites a newer run replaced.
+ *
+ * A row's `checkSuiteId` is the join `supersededSuites` computes over, so a test states the two
+ * halves — the row's suite and the superseded set — rather than a "this is superseded" flag the
+ * verb has no way to receive.
+ */
+const sampleOf = (
+	rows: ReadonlyArray<{name: string; conclusion: string; suite?: number}>,
+	superseded: ReadonlyArray<number> = [],
+) => ({
+	runs: rows.map((row, index) => ({
+		name: row.name,
+		status: "completed",
+		conclusion: row.conclusion,
+		startedAt: "2026-08-08T00:00:00Z",
+		id: index + 1,
+		checkSuiteId: row.suite ?? 1,
+	})),
+	workflows: 1,
+	runCount: 2,
+	superseded: new Set(superseded),
+});
+
 describe("rollupFor", () => {
 	it("names any wedged check as the whole answer", () => {
-		expect(rollupFor({runs: [], workflows: 3, runCount: 0}, ["ci-required"])).toBe("wedged");
+		expect(rollupFor({...empty, workflows: 3, runCount: 0}, ["ci-required"])).toBe("wedged");
 	});
 
 	it("is no-runs only with positive evidence: workflows exist and none fired at this head", () => {
-		expect(rollupFor({runs: [], workflows: 12, runCount: 0}, [])).toBe("no-runs");
+		expect(rollupFor({...empty, workflows: 12, runCount: 0}, [])).toBe("no-runs");
 	});
 
 	it("is no-producer on zero workflows, never collapsed into pending (#6298)", () => {
-		expect(rollupFor({runs: [], workflows: 0, runCount: 0}, [])).toBe("no-producer");
+		expect(rollupFor({...empty, workflows: 0, runCount: 0}, [])).toBe("no-producer");
 	});
 
 	it("keeps no-producer apart from pending — the second waits on a run, the first never will", () => {
-		expect(rollupFor({runs: [], workflows: 1, runCount: 3}, [])).toBe("pending");
+		expect(rollupFor({...empty, workflows: 1, runCount: 3}, [])).toBe("pending");
+	});
+});
+
+// #6834: the repo cancels its own runs at an unmoved head, so `cancelled` there means "replaced",
+// not "failed" — and the dependent aggregator is the row that lands in it.
+describe("rollupFor over a concurrency-cancelled run", () => {
+	it("pends a superseded cancelled aggregator rather than reding it", () => {
+		expect(
+			rollupFor(sampleOf([{name: "ci-required", conclusion: "cancelled", suite: 91}], [91]), []),
+		).toBe("pending");
+	});
+
+	it("reds a cancelled run no newer run of its workflow replaced", () => {
+		expect(
+			rollupFor(sampleOf([{name: "ci-required", conclusion: "cancelled", suite: 91}]), []),
+		).toBe("red");
+	});
+
+	it("reds when the newer run has already concluded failure at the same head", () => {
+		const sample = sampleOf(
+			[
+				{name: "ci-required", conclusion: "cancelled", suite: 91},
+				{name: "unit tests", conclusion: "failure", suite: 92},
+			],
+			[91],
+		);
+		expect(rollupFor(sample, [])).toBe("red");
+	});
+
+	it("never reclassifies a conclusion other than cancelled, however superseded its suite", () => {
+		for (const conclusion of [
+			"failure",
+			"timed_out",
+			"action_required",
+			"startup_failure",
+			"stale",
+		]) {
+			expect(rollupFor(sampleOf([{name: "ci-required", conclusion, suite: 91}], [91]), [])).toBe(
+				"red",
+			);
+		}
+	});
+
+	it("leaves an informational run carved out on both sides of the rule (ADR 0061)", () => {
+		const sample = sampleOf(
+			[
+				{name: "deploy (web)", conclusion: "cancelled", suite: 91},
+				{name: "ci-required", conclusion: "success", suite: 92},
+			],
+			[91],
+		);
+		expect(rollupFor(sample, [])).toBe("green");
 	});
 });
 
@@ -258,6 +336,87 @@ describe("runChecks", () => {
 		);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe(`ship checks: no commit ${HEAD} on PR #4321.`);
+	});
+});
+
+/**
+ * The incident head of #6834, end to end: a close/reopen re-fired the suite without moving the head,
+ * so the older run was concurrency-cancelled and the newer run had not published its own
+ * `ci-required` yet. The verb read the cancelled aggregator and settled red on the first sample.
+ */
+describe("the concurrency-cancelled head", () => {
+	const cancelledAggregator = served(
+		checkRuns(1, [{...noRun("ci-required", "completed", "cancelled"), check_suite_id: 91}]),
+	);
+
+	/** The older run cancelled, the newer run of the same workflow still going, at one head. */
+	const supersededRuns = served(
+		runsTotal(2, [
+			{id: 11, workflowId: 7, checkSuiteId: 91, conclusion: "cancelled"},
+			{id: 12, workflowId: 7, checkSuiteId: 92, status: "in_progress", conclusion: null},
+		]),
+	);
+
+	it("reads pending, names the replaced context, and routes nothing to heal-ci", async () => {
+		const out = await run(found, [
+			[RUNS, cancelledAggregator],
+			[WORKFLOWS, served(workflows("active"))],
+			[RUN_COUNT, supersededRuns],
+		]);
+		expect(out.stdout.split("\n")[0]).toBe(`checks\t${HEAD}\tpending`);
+		expect(out.stdout).toContain("check\tcancelled-superseded/gating\t1");
+		expect(out.stderr).toContain(
+			"ship checks: cancelled by a newer run of the same workflow at this head: ci-required — waiting on that run, not routing.",
+		);
+		expect(out.stderr.join("\n")).not.toContain("failing gating checks");
+	});
+
+	it("reds the same head when no newer run of that workflow exists", async () => {
+		const out = await run(found, [
+			[RUNS, cancelledAggregator],
+			[WORKFLOWS, served(workflows("active"))],
+			[
+				RUN_COUNT,
+				served(runsTotal(1, [{id: 11, workflowId: 7, checkSuiteId: 91, conclusion: "cancelled"}])),
+			],
+		]);
+		expect(out.stdout.split("\n")[0]).toBe(`checks\t${HEAD}\tred`);
+		expect(out.stderr).toContain(
+			"ship checks: failing gating checks: ci-required — route these to heal-ci.",
+		);
+	});
+
+	it("--wait stays in the loop and settles on the newer run's verdict, not the cancel", async () => {
+		const out = await run(
+			found,
+			[
+				[once(RUNS), cancelledAggregator],
+				[
+					RUNS,
+					served(
+						checkRuns(1, [
+							{...noRun("ci-required", "completed", "success"), id: 5, check_suite_id: 92},
+						]),
+					),
+				],
+				[WORKFLOWS, served(workflows("active"))],
+				[once(RUN_COUNT), supersededRuns],
+				[
+					RUN_COUNT,
+					served(
+						runsTotal(2, [
+							{id: 11, workflowId: 7, checkSuiteId: 91, conclusion: "cancelled"},
+							{id: 12, workflowId: 7, checkSuiteId: 92, conclusion: "success"},
+						]),
+					),
+				],
+			],
+			{wait: true, cadenceSeconds: 0},
+		);
+		expect(out.stdout.split("\n").slice(0, 2)).toEqual([
+			"settle\tsettled",
+			`checks\t${HEAD}\tgreen`,
+		]);
 	});
 });
 

--- a/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
@@ -35,6 +35,8 @@ const runsAt = (
 		total_count: rows.length,
 		workflow_runs: rows.map(({completedAt, ...row}) => ({
 			...row,
+			workflow_id: row.id,
+			check_suite_id: row.id,
 			conclusion: "success",
 			completed_at: completedAt === undefined ? new Date().toISOString() : completedAt,
 		})),

--- a/packages/fabrika-cli/src/ship/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/ship/fixtures.test-support.ts
@@ -68,6 +68,8 @@ export const checkRuns = (
 		conclusion?: string | null;
 		started_at?: string | null;
 		id?: number;
+		/** The suite that published it — what {@link runsTotal}'s rows are joined to. */
+		check_suite_id?: number;
 	}>,
 ): ExecResult =>
 	okOut(
@@ -79,6 +81,7 @@ export const checkRuns = (
 				status: run.status,
 				conclusion: run.conclusion ?? null,
 				started_at: run.started_at ?? "2026-08-08T00:00:00Z",
+				check_suite: {id: run.check_suite_id ?? 1},
 			})),
 		}),
 	);
@@ -95,7 +98,37 @@ export const workflows = (...states: ReadonlyArray<string>): ExecResult =>
 		}),
 	);
 
-export const runsTotal = (total: number): ExecResult => okOut(JSON.stringify({total_count: total}));
+/**
+ * The Actions run list at one head: the declared total, and the rows a caller cares to enumerate.
+ *
+ * The total and the rows are separate arguments because they answer separate questions — the
+ * `no-runs` discriminator reads only the first, supersession only the second.
+ */
+export const runsTotal = (
+	total: number,
+	rows: ReadonlyArray<{
+		id: number;
+		workflowId?: number;
+		checkSuiteId?: number | null;
+		status?: string;
+		conclusion?: string | null;
+	}> = [],
+): ExecResult =>
+	okOut(
+		JSON.stringify({
+			total_count: total,
+			workflow_runs: rows.map((row) => ({
+				id: row.id,
+				name: "ci",
+				path: ".github/workflows/ci.yml",
+				workflow_id: row.workflowId ?? 1,
+				check_suite_id: row.checkSuiteId === undefined ? row.id : row.checkSuiteId,
+				status: row.status ?? "completed",
+				conclusion: row.conclusion === undefined ? "success" : row.conclusion,
+				completed_at: "2026-08-08T00:00:00Z",
+			})),
+		}),
+	);
 
 export const comments = (
 	...rows: ReadonlyArray<{id: number; body: string; author?: string; updatedAt?: string}>

--- a/packages/fabrika-cli/src/ship/github.ts
+++ b/packages/fabrika-cli/src/ship/github.ts
@@ -198,6 +198,8 @@ export interface ShipCheckRun {
 	/** `null` while the run has never started — half of the queued-but-wedged discriminator. */
 	readonly startedAt: string | null;
 	readonly id: number;
+	/** The suite that produced it — the join onto {@link WorkflowRun.checkSuiteId} (`./supersession.ts`). */
+	readonly checkSuiteId: number;
 }
 
 export interface CheckRunSet {
@@ -227,12 +229,19 @@ export const listShipCheckRuns = (repo: string, sha: string): Shell<Attempt<Chec
 					) {
 						return fail("GitHub answered 200 but one entry is not a check run");
 					}
+					// `check_suite` is `{id} | null` in the platform's own schema, so a row can arrive
+					// without the join key — and a check run nothing can be joined to a workflow run is
+					// unreadable rather than lenient (`./supersession.ts`).
+					if (!isRecord(value.check_suite) || typeof value.check_suite.id !== "number") {
+						return fail("GitHub answered 200 but one check run names no check suite");
+					}
 					runs.push({
 						name: value.name,
 						status: value.status,
 						conclusion: typeof value.conclusion === "string" ? value.conclusion : null,
 						startedAt: typeof value.started_at === "string" ? value.started_at : null,
 						id: typeof value.id === "number" ? value.id : 0,
+						checkSuiteId: value.check_suite.id,
 					});
 				}
 				return ok({declared: enveloped.value.declared, runs});
@@ -346,6 +355,15 @@ export interface WorkflowRun {
 	readonly completedAt: string | null;
 	/** The workflow this run came from, as {@link listWorkflowPaths} addresses it. */
 	readonly path: string;
+	/** The workflow's own id — what makes two runs at one head runs of the *same* workflow. */
+	readonly workflowId: number;
+	/**
+	 * The suite this run published its check runs under, joining onto {@link ShipCheckRun.checkSuiteId}.
+	 *
+	 * `null` because the platform's schema declares the field optional: a run that names no suite
+	 * simply joins to nothing, which leaves every check run at its own conclusion.
+	 */
+	readonly checkSuiteId: number | null;
 }
 
 /** The runs at exactly this head — `head_sha` match only, never a name or a date heuristic. */
@@ -360,7 +378,11 @@ export const listRunsAtHead = (
 				if (enveloped._tag === "Failure") return enveloped;
 				const runs: WorkflowRun[] = [];
 				for (const value of enveloped.value.entries) {
-					if (!isRecord(value) || typeof value.id !== "number") {
+					if (
+						!isRecord(value) ||
+						typeof value.id !== "number" ||
+						typeof value.workflow_id !== "number"
+					) {
 						return fail("GitHub answered 200 but one entry is not a workflow run");
 					}
 					runs.push({
@@ -370,6 +392,8 @@ export const listRunsAtHead = (
 						conclusion: typeof value.conclusion === "string" ? value.conclusion : null,
 						completedAt: typeof value.completed_at === "string" ? value.completed_at : null,
 						path: str(value.path),
+						workflowId: value.workflow_id,
+						checkSuiteId: typeof value.check_suite_id === "number" ? value.check_suite_id : null,
 					});
 				}
 				return ok({declared: enveloped.value.declared, runs});

--- a/packages/fabrika-cli/src/ship/github.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/github.unit.test.ts
@@ -12,6 +12,7 @@ import {
 	fetchManifest,
 	listReviews,
 	listReviewThreads,
+	listRunsAtHead,
 	listShipCheckRuns,
 	listTeamMembers,
 	listWorkflowPaths,
@@ -98,18 +99,67 @@ describe("the envelope proof", () => {
 			[
 				/check-runs\?per_page=100&page=1$/,
 				json(
-					{total_count: 3, check_runs: [{name: "ci", status: "completed", id: 1}]},
+					{
+						total_count: 3,
+						check_runs: [{name: "ci", status: "completed", id: 1, check_suite: {id: 91}}],
+					},
 					linkNext("https://api.github.com/x?page=2"),
 				),
 			],
 			[
 				/&page=2$/,
-				json({total_count: 3, check_runs: [{name: "lint", status: "completed", id: 2}]}),
+				json({
+					total_count: 3,
+					check_runs: [{name: "lint", status: "completed", id: 2, check_suite: {id: 91}}],
+				}),
 			],
 		]);
 		const read = value(await run(listShipCheckRuns("o/r", "abc"), http));
 		expect(read.declared).toBe(3);
 		expect(read.runs).toHaveLength(2);
+		expect(read.runs.map((entry) => entry.checkSuiteId)).toEqual([91, 91]);
+	});
+
+	// The join key onto the workflow run is what tells a concurrency-cancel from a failure (#6834),
+	// and the platform's own schema types `check_suite` as nullable — so the row can really arrive
+	// without it, and an unjoinable row is UNKNOWN rather than a run with no supersession.
+	it("refuses a check run that names no check suite rather than dropping the join key", async () => {
+		const http = fakeHttp([
+			[
+				/check-runs/,
+				json({total_count: 1, check_runs: [{name: "ci", status: "completed", id: 1}]}),
+			],
+		]);
+		const read = await run(listShipCheckRuns("o/r", "abc"), http);
+		expect(reason(read)).toContain("names no check suite");
+	});
+
+	it("carries each run's workflow and suite ids — the two halves of the supersession join", async () => {
+		const http = fakeHttp([
+			[
+				/actions\/runs\?head_sha=/,
+				json({
+					total_count: 2,
+					workflow_runs: [
+						{id: 11, workflow_id: 7, check_suite_id: 91, status: "completed"},
+						{id: 12, workflow_id: 7, status: "in_progress"},
+					],
+				}),
+			],
+		]);
+		const read = value(await run(listRunsAtHead("o/r", "abc"), http));
+		expect(read.runs.map((entry) => [entry.workflowId, entry.checkSuiteId])).toEqual([
+			[7, 91],
+			[7, null],
+		]);
+	});
+
+	it("refuses a workflow run naming no workflow — two runs of nothing are not the same workflow", async () => {
+		const http = fakeHttp([
+			[/actions\/runs\?head_sha=/, json({total_count: 1, workflow_runs: [{id: 11}]})],
+		]);
+		const read = await run(listRunsAtHead("o/r", "abc"), http);
+		expect(reason(read)).toContain("not a workflow run");
 	});
 
 	it("refuses an envelope that declares no total_count rather than inventing one", async () => {

--- a/packages/fabrika-cli/src/ship/supersession.ts
+++ b/packages/fabrika-cli/src/ship/supersession.ts
@@ -1,0 +1,42 @@
+/**
+ * Which check contexts at a head belong to a workflow run something newer already replaced.
+ *
+ * A repo whose CI declares `concurrency: {group, cancel-in-progress}` cancels its own older run
+ * whenever the suite re-fires **without the head moving** — a close/reopen, a base refresh, a rapid
+ * second push. The older run's contexts conclude `cancelled` at the same `head_sha` the newer run is
+ * still proving, and the dependent aggregator job (`ci-required`) makes it worse: the newer run has
+ * not created its own aggregator context yet, so latest-per-context resolves to the cancelled one.
+ * `ship checks` then read a healthy head as a hard red and routed a green PR to `heal-ci` (#6834).
+ *
+ * **Only `cancelled` is reclassified, and only into `pending`.** The rollup's fail-closed default
+ * (`../review/rollup.ts`) is load-bearing everywhere else: a cancel proved nothing, and "proved
+ * nothing" must never read green. What supersession adds is the one case where something else is
+ * proving it right now — so the answer is "wait", not "pass". A `failure` stays red at every level
+ * of supersession, and a cancel with no newer run of its workflow at that head stays red too.
+ */
+import type {ShipCheckRun, WorkflowRun} from "./github.ts";
+
+/**
+ * The suites whose workflow run a later run of the same workflow replaced at this head.
+ *
+ * Read off run ids rather than timestamps: two runs started in the same second are ordered by id and
+ * by nothing else the list carries.
+ */
+export const supersededSuites = (runs: ReadonlyArray<WorkflowRun>): ReadonlySet<number> => {
+	const newest = new Map<number, number>();
+	for (const run of runs) {
+		const held = newest.get(run.workflowId);
+		if (held === undefined || run.id > held) newest.set(run.workflowId, run.id);
+	}
+	const superseded = new Set<number>();
+	for (const run of runs) {
+		if (run.checkSuiteId !== null && (newest.get(run.workflowId) ?? run.id) > run.id) {
+			superseded.add(run.checkSuiteId);
+		}
+	}
+	return superseded;
+};
+
+/** A cancelled check run published by a superseded suite — in flight elsewhere, not failed here. */
+export const isSuperseded = (run: ShipCheckRun, suites: ReadonlySet<number>): boolean =>
+	run.conclusion === "cancelled" && suites.has(run.checkSuiteId);

--- a/packages/fabrika-cli/src/ship/supersession.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/supersession.unit.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from "vitest";
+import type {ShipCheckRun, WorkflowRun} from "./github.ts";
+import {isSuperseded, supersededSuites} from "./supersession.ts";
+
+const workflowRun = (shape: {
+	id: number;
+	workflowId: number;
+	suite?: number | null;
+	conclusion?: string | null;
+}): WorkflowRun => ({
+	id: shape.id,
+	name: "CI",
+	status: shape.conclusion == null ? "in_progress" : "completed",
+	conclusion: shape.conclusion ?? null,
+	completedAt: null,
+	path: ".github/workflows/ci.yml",
+	workflowId: shape.workflowId,
+	checkSuiteId: shape.suite === undefined ? shape.id : shape.suite,
+});
+
+const checkRun = (conclusion: string, checkSuiteId: number): ShipCheckRun => ({
+	name: "ci-required",
+	status: "completed",
+	conclusion,
+	startedAt: "2026-08-08T00:00:00Z",
+	id: 1,
+	checkSuiteId,
+});
+
+describe("supersededSuites", () => {
+	it("names the suite of every run a later run of the same workflow replaced", () => {
+		const suites = supersededSuites([
+			workflowRun({id: 11, workflowId: 7, conclusion: "cancelled"}),
+			workflowRun({id: 12, workflowId: 7}),
+		]);
+		expect([...suites]).toEqual([11]);
+	});
+
+	it("leaves the newest run of a workflow alone, however many preceded it", () => {
+		const suites = supersededSuites([
+			workflowRun({id: 11, workflowId: 7, conclusion: "cancelled"}),
+			workflowRun({id: 12, workflowId: 7, conclusion: "cancelled"}),
+			workflowRun({id: 13, workflowId: 7}),
+		]);
+		expect([...suites].sort()).toEqual([11, 12]);
+	});
+
+	it("never crosses workflows — a newer run of a different workflow supersedes nothing", () => {
+		const suites = supersededSuites([
+			workflowRun({id: 11, workflowId: 7, conclusion: "cancelled"}),
+			workflowRun({id: 12, workflowId: 8}),
+		]);
+		expect([...suites]).toEqual([]);
+	});
+
+	it("skips a run naming no suite — there is nothing to join a check context to", () => {
+		const suites = supersededSuites([
+			workflowRun({id: 11, workflowId: 7, suite: null, conclusion: "cancelled"}),
+			workflowRun({id: 12, workflowId: 7}),
+		]);
+		expect([...suites]).toEqual([]);
+	});
+});
+
+describe("isSuperseded", () => {
+	it("holds only for a cancelled run published by a superseded suite", () => {
+		const suites = new Set([91]);
+		expect(isSuperseded(checkRun("cancelled", 91), suites)).toBe(true);
+		expect(isSuperseded(checkRun("cancelled", 92), suites)).toBe(false);
+		expect(isSuperseded(checkRun("failure", 91), suites)).toBe(false);
+	});
+});


### PR DESCRIPTION
`ship checks` read a concurrency-cancelled workflow run as a hard red, so a shipper at a healthy head
routed a green PR to `heal-ci` (hit twice on 2026-08-20 PT). When the repo's own `concurrency` group
cancels an older run because the suite re-fired at an unmoved head, the cancelled run's `ci-required`
is the only aggregator context at that head until the newer run publishes its own — and `cancelled`
buckets red, so `--wait` settled on the first sample instead of waiting.

The fix joins the two reads the verb already makes. `ShipCheckRun` now carries `check_suite.id`, the
head's workflow runs are enumerated rather than counted (`listRunsAtHead` gives both the rows and the
`total_count` the `no-runs`/`no-producer` discriminators need), and a new `ship/supersession.ts` owns
the one rule: a `cancelled` check run whose suite belongs to a workflow run that a later run of the
same `workflow_id` replaced at this head reads **pending**, so the existing wait horizon absorbs it.
Nothing else moves — `failure`, `timed_out`, `startup_failure`, an unrecognised conclusion, and a
cancel with no newer run all stay red, and the informational carve-out (ADR 0061) is untouched.

No shell-side change: a shipper gets the right answer from `ship checks --wait` on this head shape
without overriding its own verb, which is what ADR 0228 requires.

Grounding: both join keys are read against GitHub's published OpenAPI schema
(`@octokit/openapi-types`) rather than assumed. `check-run.check_suite` is `{id: number} | null`, so
a row really can arrive without the key and the enumeration refuses it; `workflow-run.check_suite_id`
is **optional** in that same schema, so `WorkflowRun.checkSuiteId` is nullable and a run naming no
suite simply joins to nothing.

## Deviations

- **Out-of-scope change** — **Said:** #6834 asks only that a superseded cancel classify as pending.
  **Did:** also changed the `checks` histogram key, so a superseded row tallies as
  `cancelled-superseded/gating` instead of `cancelled/gating`. **Why:** that key's own docblock says
  it exists so the rollup stays derivable from the payload, and after the reclassification a
  `cancelled/gating` count beside a `pending` rollup would no longer be. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the notes channel. **Did:** added one stderr line
  naming the superseded contexts, and excluded them from the existing "failing gating checks — route
  these to heal-ci" line. **Why:** leaving them on the routing line would tell an operator to route a
  head the verb just decided to wait on. **Disposition:** stated here.
- **Scope narrowing** — **Said:** enumerate the head's runs with "at minimum run id, `workflow_id`,
  `check_suite_id`, `status`, `conclusion`". **Did:** `workflow_id` is required (a missing one refuses
  the enumeration) but `check_suite_id` is `number | null`. **Why:** GitHub's schema declares
  `check_suite_id` optional on a workflow run; refusing on it would red reads that are fine, and a run
  with no suite id joins to nothing, which leaves every check at its own conclusion — the fail-closed
  direction. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** touch `checks-verb.unit.test.ts` and the rollup
  module's tests. **Did:** also added `workflow_id`/`check_suite_id` to three shared workflow-run
  fixtures (`heal-ci`, `review`, `ship/evidence-verb.unit.test.ts`) and `check_suite` to the `ship`
  check-run fixture, plus one payload in `ship/github.unit.test.ts`. **Why:** the parse is now strict
  on those keys, so a fixture without them is not a payload GitHub could send. No assertion was
  weakened; the full 7586-test suite passes. **Disposition:** stated here.

Fixes #6834
