### PR TITLE
chore: Closed issues leave parked lane ledgers the viewer sorts as waiting on a human

### DIFF
--- a/.decisions/0322-closed-issue-lanes-demote-at-read-time.md
+++ b/.decisions/0322-closed-issue-lanes-demote-at-read-time.md
@@ -46,6 +46,12 @@ mechanism was barred.
 did.** Board state is a fact about the issue, read at the moment someone looks, never an event
 appended to `events.jsonl`.
 
+The principle already holds at the other end of a lane's life. `initialFor` in
+[`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts) boots an epic
+child whose issue closed *without* landing into `frozen` rather than `landed`, because — in its own
+words — "marking it `landed` would fabricate a landing". That is this rule at boot time; this record
+extends it to read time.
+
 - **The vocabulary stays closed.** `OPERATOR_EVENTS` keeps its six members and ADR 0297's binding
   constraint stands unamended. This record supersedes nothing.
 - **The fold learns nothing.** `events.jsonl` stays the fold's only input, so a closed-issue lane
@@ -73,10 +79,13 @@ itself is a demlik change, tracked on that repo.
 
 Phoenix owes the input: per-lane board state passed alongside the existing four. The reader exists —
 `getIssue(repo, issue)` in [`packages/fabrika-cli/src/io/issues.ts`](../packages/fabrika-cli/src/io/issues.ts)
-returns an `IssueRecord` carrying `state` — so this is wiring, not a new client. It is also the first
-board read in the lane group: nothing under `packages/fabrika-cli/src/lane/` reads issue state today.
-That makes an unreachable board a real case, and the honest reading of one is that a lane's bucket is
-UNKNOWN — it stays where its fold puts it rather than being demoted on a failed read.
+returns an `IssueRecord` carrying `state` — so this is wiring, not a new client, and the lane group
+already calls it: `lane brief` and `lane prove` both read an issue record today.
+
+A board read can fail, so an unreachable board is a real case, and the honest reading of one is that
+a lane's bucket is UNKNOWN — it stays where its fold puts it rather than being demoted on a failed
+read. Demoting on a failed read would hide a genuine park behind a network error, which is the exact
+failure this record exists to fix, pointed the other way.
 
 ## Consequences
 

--- a/.decisions/0322-closed-issue-lanes-demote-at-read-time.md
+++ b/.decisions/0322-closed-issue-lanes-demote-at-read-time.md
@@ -1,0 +1,94 @@
+---
+id: 0322
+title: A lane whose issue closed elsewhere is demoted at read time, not reconciled on disk
+status: accepted
+date: 2026-08-21
+tags: [fabrika, lane, pipeline, viewer, state-machine]
+---
+
+# 0322 — A lane whose issue closed elsewhere is demoted at read time, not reconciled on disk
+
+**What this decides:** nothing new is written to a lane whose issue was closed outside the lane's own
+flow. `lane view` cross-checks the board when it renders and buckets such a lane into a "finished
+elsewhere" band, away from the needs-a-person band. No seventh operator event, no new terminal cell,
+no reconciliation verb.
+
+Founder ruling,
+[2026-08-20](https://github.com/kamp-us/phoenix/issues/6603#issuecomment-5361711214) — shape 3 of the
+three put to him on [#6603](https://github.com/kamp-us/phoenix/issues/6603), verbatim "3". It
+restates his direction earlier that day
+([2026-08-20](https://github.com/kamp-us/phoenix/issues/6603#issuecomment-5359348420)): reconcile
+rather than delete, keep `events.jsonl` on disk, make the rows reflect reality. This ADR transcribes
+that ruling; the choice is the founder's, not this record's.
+
+## The problem
+
+The lane viewer sorts by what needs a person first. On 2026-08-20, nine of the first ten rows reading
+"issue is waiting on a human" were for issues already closed on the board, most of them shipped days
+before. The one genuine park, 5648, sat at position ten.
+
+A reconciliation pass under the reconcile-don't-delete direction cleared 5937 with legal events and
+found six lanes — 5845, 5851, 5877, 5866, 6282, 6452 — that no legal event sequence can move. Each
+sits in `blocked` for an issue closed without a branch or a PR. The only exit from `blocked` is
+`UNBLOCKED` to `queued`, whose only exits are `WIP` and `BLOCKED`; every remaining route to a
+terminal cell runs through a build `DONE` plus a review `PASS`/`FAIL` naming a PR that never existed,
+which `lane prove` refuses.
+
+The mechanism that pass proposed — a seventh operator event — collides with ADR
+[0297](0297-frozen-is-a-park-not-an-end.md)'s binding constraint that "the six-event vocabulary is
+unchanged and closed", itself the founder's own closure on
+[#5570](https://github.com/kamp-us/phoenix/issues/5570). So the goal was ruled and the only named
+mechanism was barred.
+
+## The decision
+
+**The ledger records what the lane itself did, and being closed elsewhere is not something the lane
+did.** Board state is a fact about the issue, read at the moment someone looks, never an event
+appended to `events.jsonl`.
+
+- **The vocabulary stays closed.** `OPERATOR_EVENTS` keeps its six members and ADR 0297's binding
+  constraint stands unamended. This record supersedes nothing.
+- **The fold learns nothing.** `events.jsonl` stays the fold's only input, so a closed-issue lane
+  keeps folding to exactly the cell its own events earn — `blocked` for the six above. The board read
+  is the viewer's, not the machine's, and it happens after the fold rather than inside it.
+- **No terminal cell is minted.** There is no `abandoned`, and `frozen` is not repurposed. The
+  question "what is the terminal cell called" has no answer under this shape, which is the point:
+  the lane's state is unchanged and only its presentation moves.
+- **`lane view` renders it as finished elsewhere.** A lane whose issue is CLOSED is bucketed into a
+  "finished elsewhere" band and ranks below every row that needs a person. Its ledger is intact and
+  still readable; it just stops competing with real parks for the top of the screen.
+- **Reconciliation is a derivation on read, not a verb someone runs.** Nothing is written, so there
+  is nothing to run and nothing to schedule. Closing the issue is the whole act; the next render
+  tells the truth.
+
+**The six named lanes are covered by this and need no further action.** 5845, 5851, 5877, 5866, 6282
+and 6452 stay in `blocked` with their logs byte-identical, and drop out of the needs-a-person band
+the first time the bucket ships. 5648 stays where it is — it is open, and it is the one true park.
+
+## Where the work lands
+
+The derivation and the sort are `@demlik/tea/chart/lane/server`'s. `lane view` supplies only the
+facts fabrika knows — the root, the event origins, the transition callback, the port — so the bucket
+itself is a demlik change, tracked on that repo.
+
+Phoenix owes the input: per-lane board state passed alongside the existing four. The reader exists —
+`getIssue(repo, issue)` in [`packages/fabrika-cli/src/io/issues.ts`](../packages/fabrika-cli/src/io/issues.ts)
+returns an `IssueRecord` carrying `state` — so this is wiring, not a new client. It is also the first
+board read in the lane group: nothing under `packages/fabrika-cli/src/lane/` reads issue state today.
+That makes an unreachable board a real case, and the honest reading of one is that a lane's bucket is
+UNKNOWN — it stays where its fold puts it rather than being demoted on a failed read.
+
+## Consequences
+
+A `blocked` row no longer means a person is owed. Anything reading the viewer's ordering as "these
+all need me" has to read the band as well, and anything reading `events.jsonl` alone still sees six
+lanes parked forever — correctly, because that is what the lanes did.
+
+The cost the founder accepted is that the ledger and the board can disagree on disk. The reply is
+that they were never the same claim: the ledger is the lane's own history, and a lane does not get to
+record work it never performed just to look tidy.
+
+## Records
+
+No vocabulary impact. "Finished elsewhere" is a band in the viewer's presentation, not a lane state,
+and the lane states are unchanged.


### PR DESCRIPTION
Transcribes the founder's ruling on #6603 (https://github.com/kamp-us/phoenix/issues/6603#issuecomment-5361711214, verbatim "3") as ADR 0322.

A lane whose issue was closed outside the lane's own flow is demoted where it is rendered, not reconciled on disk: `lane view` cross-checks the board at read time and buckets the row into a "finished elsewhere" band, below everything that needs a person. The six-event operator vocabulary stays closed, so ADR 0297's binding constraint stands unamended and this record supersedes nothing. No seventh event, no new terminal cell, no reconciliation verb, nothing written.

The ADR also names where the work lands: the bucket and the sort are `@demlik/tea/chart/lane/server`'s, and phoenix owes only the per-lane board state that feeds it — `getIssue` already returns `state`, and `lane brief` and `lane prove` already call it, so it is wiring. It records that an unreachable board leaves a lane's bucket UNKNOWN rather than demoting it, because demoting on a failed read would hide a real park behind a network error.

The six stuck lanes (5845, 5851, 5877, 5866, 6282, 6452) are covered and need no further action; 5648 stays parked because it is the one genuinely open row.

Fixes #6603

## Deviations

None.
