### PR TITLE
feat: Fanned triage subagents share one scratchpad, so generic filenames collide

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -37,6 +37,18 @@ another session, so proceeding on a `lost` no longer overwrites the winner's wor
 The same re-read refuses a closed target on `7`. Neither refusal is overridable, and a comment read
 that fails is `11` — never a pass.
 
+**Every working file you write goes where this prints, and nowhere else:**
+
+```bash
+fabrika triage scratch $issue_number --slug authored --token <claim-token>
+```
+
+The token's nonce is what keys that directory to your lane. A fan-out shares one session
+scratchpad, so a file named by convention — `authored.md` — is overwritten by a sibling lane
+silently, and the body you then post is another issue's
+([#6630](https://github.com/kamp-us/phoenix/issues/6630)). The path it prints is machine-local and
+must never reach a posted artifact; the writing verbs red on it (`5`).
+
 ## 2 — Read the issue, then read the code it is about
 
 Never classify from the title. Read the body, then read enough of the repo to say what this is about

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -29,6 +29,7 @@ makes the implementer guess ([#4734](https://github.com/kamp-us/phoenix/issues/4
 |---|---|---|
 | `triage queue` | the claimable `status:needs-triage` queue, with the count it scanned | paginating a label query and separating a proven-empty queue from a failed read is mechanical; which issue to take is judgment |
 | `triage claim` | take one lane's claim on one issue, proven by read-back | a marker write plus an earliest-claim tiebreak is a protocol, not a decision |
+| `triage scratch` | the per-lane directory this lane's working files go under | keying a namespace on the claim nonce is mechanical; what the file holds is judgment |
 | `triage provenance` | was this issue reported by an agent or hand-typed by a human | a structural marker test over a fetched body, plus a membership test over the configured operator set — an empty body fails closed to `human`, an unreadable one refuses rather than guessing; what to *do* about a human filing stays in the skill |
 | `triage homes` | the assignable homes — open milestones joined to their ROADMAP rows, plus the standing lanes this repo declares AND carries the labels for, with every `active` campaign's milestone marked `running` | the join, the open-milestone filter and reading the campaigns table are mechanical; picking which home fits, and whether an exception applies, is judgment |
 | `triage split` | create one split child, once, keyed on the parent back-reference | idempotency keyed on a durable reference is mechanical; deciding a report *is* a bundle is judgment |
@@ -130,7 +131,7 @@ Stated once rather than repeated per block.
 
 ### The shared exit taxonomy
 
-**All nine verbs allocate from one internal table**, so a code means one thing across *this group*.
+**Every verb in this group allocates from one internal table**, so a code means one thing across *this group*.
 That is a property of this group and not of `fabrika`, and the difference matters to anyone driving
 more than one group: **repo-wide the same number does not mean the same thing.** `wire`'s `3` is
 *the format's block is provably not in the artifact*, where `report`'s and this group's is *stdin was
@@ -143,27 +144,28 @@ that verb reads from the same `report` table: `7` when `--label` is absent, `27`
 or the search index could not be read
 ([#5296](https://github.com/kamp-us/phoenix/issues/5296)).
 
-| Code | Meaning | queue | claim | prov | homes | split | enrich | apply | park | kill |
-|---|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| `0` | the answer is on stdout | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `1` | usage error, unresolvable repo, or the verb failed to run | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `126` | no implementation could be resolved | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `3` | stdin was read and held nothing | — | — | — | — | ✓ | ✓ | — | ✓ | ✓ |
-| `4` | *(deliberate gap — see below)* | — | — | — | — | — | — | — | — | — |
-| `5` | the **authored** text carries a machine-local path | — | — | — | — | ✓ | ✓ | — | ✓ | ✓ |
-| `6` | the **authored** text is a bare `@` path reference — **not** redactable | — | — | — | — | ✓ | ✓ | — | ✓ | ✓ |
-| `7` | zero scope: a read that succeeded over nothing, an absent label vocabulary, or a target issue **proven absent (404)** or closed — a fail-closed refusal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `8` | the write itself failed — the outcome is **UNKNOWN** | — | ✓ | — | — | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `9` | the write landed but the read-back does not match | — | ✓ | — | — | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `10` | the supplied classification value is not permitted here — off the closed vocabulary, or a non-open milestone | — | — | — | — | — | — | ✓ | — | — |
-| `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `12` | refused: the issue is human-filed | — | — | — | — | — | — | — | — | ✓ |
-| `13` | refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159) | — | — | — | — | — | — | — | — | ✓ |
-| `15` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — |
-| `16` | refused: `--ready-for agent` over a live body whose acceptance-criteria block the wire reader does not answer `Found` on — every type but `epic` | — | — | — | — | — | — | ✓ | — | — |
-| `17` | refused: a live claim marker on the target names a session other than this one | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `18` | refused: no value of `.fabrika.jsonc` may be used — a key's load-time check refused it, it could not be read, or it did not decode | — | — | — | — | — | — | ✓ | ✓ | — |
-| `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Code | Meaning | queue | claim | prov | homes | split | enrich | apply | park | kill | scratch |
+|---|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| `0` | the answer is on stdout | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `1` | usage error, unresolvable repo, or the verb failed to run | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `126` | no implementation could be resolved | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `3` | stdin was read and held nothing | — | — | — | — | ✓ | ✓ | — | ✓ | ✓ | — |
+| `4` | *(deliberate gap — see below)* | — | — | — | — | — | — | — | — | — | — |
+| `5` | the **authored** text carries a machine-local path | — | — | — | — | ✓ | ✓ | — | ✓ | ✓ | — |
+| `6` | the **authored** text is a bare `@` path reference — **not** redactable | — | — | — | — | ✓ | ✓ | — | ✓ | ✓ | — |
+| `7` | zero scope: a read that succeeded over nothing, an absent label vocabulary, or a target issue **proven absent (404)** or closed — a fail-closed refusal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `8` | the write itself failed — the outcome is **UNKNOWN** | — | ✓ | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `9` | the write landed but the read-back does not match | — | ✓ | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `10` | the supplied value is not permitted here — off the closed vocabulary, a non-open milestone, or a slug that is not a kebab-case leaf | — | — | — | — | — | — | ✓ | — | — | ✓ |
+| `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `12` | refused: the issue is human-filed | — | — | — | — | — | — | — | — | ✓ | — |
+| `13` | refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159) | — | — | — | — | — | — | — | — | ✓ | — |
+| `15` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — | — |
+| `16` | refused: `--ready-for agent` over a live body whose acceptance-criteria block the wire reader does not answer `Found` on — every type but `epic` | — | — | — | — | — | — | ✓ | — | — | — |
+| `17` | refused: a live claim marker on the target names a session other than this one | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `18` | refused: no value of `.fabrika.jsonc` may be used — a key's load-time check refused it, it could not be read, or it did not decode | — | — | — | — | — | — | ✓ | ✓ | — | — |
+| `19` | refused: the asking lane holds no live claim on the target | — | — | — | — | — | — | — | — | — | ✓ |
+| `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every verb in
 this group can return `0`, `1`, `126` and `127` with the meanings above, and each of the four is stated
@@ -539,6 +541,113 @@ $ fabrika triage claim 4312 --json
 - #4780 — audience moved to `ready-for:`, so a claim no longer has to be released to keep an issue
   pickable. The TTL replaces v1's mandatory release, whose script swallowed every error
   (`2>/dev/null || true`) and could silently leave an issue unpickable forever.
+
+---
+
+## `triage scratch`
+
+**Invocation**
+
+```
+fabrika triage scratch 4312 --slug authored --token <claim-token> [--repo <owner/name>]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| *(positional)* | integer | yes | — | the issue this lane holds the claim on |
+| `--slug` | string | yes | — | the file's leaf name: kebab-case, ≤5 words, no path separators |
+| `--token` | string | yes | — | the token `triage claim` handed THIS lane — what keys the namespace |
+| `--repo` | string | no | resolved | the repository |
+
+**Output** — machine channel. One absolute path:
+`<temp root>/fabrika-triage/<session-id>/<issue>-<claim-nonce>/<slug>`. The directory is created if
+absent, so the path is writable the moment it is printed; the leaf itself is not created. There is no
+`--json`: the answer is one path, and an object around it would carry nothing the path does not.
+
+**The claim nonce is in the key, and that is the whole verb.** A fan-out of triagers runs under one
+`$CLAUDE_CODE_SESSION_ID`, so a namespace keyed on the session alone hands every lane the same
+directory — and a working file under a fixed name like `authored.md` then overwrites a sibling's
+silently. That happened on 2026-08-20 across #6597/#6189/#6146 and was caught only because the
+clobbered content happened to be a different issue's body
+([#6630](https://github.com/kamp-us/phoenix/issues/6630)); the failure it points at is one issue's
+authored body posted onto another. Keying on the lane makes the collision unconstructible rather than
+detectable, exactly as `build scratch` already does for build lanes
+([#6037](https://github.com/kamp-us/phoenix/issues/6037)). The nonce is read off the token the
+**caller** holds, never off the winning marker — that string is the same for two lanes of one
+session, which is how keying on it re-opens the hole it closed.
+
+**Holding the claim is a precondition here, unlike everywhere else in this group.** The five mutating
+verbs pass when nobody holds a claim, because an unclaimed issue is the ordinary first-triage case.
+A scratch path *is* the lane, so a caller that cannot prove one has nothing to be allocated a
+directory under: no live marker of this lane, or a marker that lost the race to a sibling, is exit
+`19` and no path on stdout.
+
+**The printed path is machine-local and must never reach a posted artifact.** `enrich`, `split`,
+`park` and `kill` red on it (`5`) — the temp roots it lives under are three of the leak predicate's
+structural shapes.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `10` | `--slug` carries a path separator, or is not a kebab-case leaf |
+| `11` | the issue's comment list could not be read, or its markers could not be ordered — the claim is UNKNOWN |
+| `19` | proven: this lane holds no live claim on the issue |
+
+`1` additionally covers the two identity refusals and the allocation failure, as the errors table
+below states. `7`, `8` and `9` are unreachable: this verb writes nothing to GitHub and reads no issue
+record, so it has no write to fail and no read-back to mismatch.
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `triage scratch: --slug "<s>" must be a kebab-case leaf, no path separators.` | 10 | refusal |
+| `triage scratch: CLAUDE_CODE_SESSION_ID is unset — refusing to key a scratch namespace on an unattributable session.` | 1 | refusal |
+| `triage scratch: CLAUDE_CODE_SESSION_ID is not a single token — a marker stamped with it would not read back as this session.` | 1 | refusal |
+| `triage scratch: CLAUDE_CODE_SESSION_ID is not one path segment — it cannot name a directory of its own.` | 1 | refusal |
+| `triage scratch: --token "<t>" is not a claim token (triage:<session-id>:<uuid>) — which lane is asking is not stated.` | 1 | refusal |
+| `triage scratch: --token "<t>" carries session <s>, but this run is session <mine> — a lane names itself, never another.` | 1 | refusal |
+| `triage scratch: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN, so no path was allocated.` | 11 | refusal |
+| `triage scratch: cannot resolve the claim on #<n> in <repo>: <reason> — no path was allocated.` | 11 | refusal |
+| `triage scratch: this lane holds no live claim on #<n> — run \`fabrika triage claim <n>\` and act only on \`won\`.` | 19 | refusal |
+| `triage scratch: #<n> is held by the lane on nonce <nonce>, not by this one — back off.` | 19 | refusal |
+| `triage scratch: cannot create <dir>: <reason>` | 1 | refusal |
+
+**Scope** — the issue's comments, paginated, filtered to the marker prefix, with the scanned count on
+stderr like every other read in this group.
+
+**Examples**
+
+```
+$ fabrika triage scratch 4312 --slug authored --token triage:b2e1-…:5f1c9a20-…
+triage scratch: scanned 3 comments in kamp-us/phoenix.
+/var/folders/xy/T/fabrika-triage/b2e1-…/4312-5f1c9a20/authored
+```
+
+A sibling lane of the same session, on the same issue and the same slug, is handed a different
+directory — which is the property the verb exists for:
+
+```
+$ fabrika triage scratch 4312 --slug authored --token triage:b2e1-…:7c3d0e91-…
+/var/folders/xy/T/fabrika-triage/b2e1-…/4312-7c3d0e91/authored
+```
+
+```
+$ fabrika triage scratch 4312 --slug authored --token triage:b2e1-…:5f1c9a20-…
+triage scratch: this lane holds no live claim on #4312 — run `fabrika triage claim 4312` and act only on `won`.
+$ echo $?
+19
+```
+
+**Grounding**
+
+- `packages/fabrika-cli/src/build/scratch-verb.ts` — the same allocator for build lanes, whose
+  docblock records the five clobbers session-only keying cost (#4516, #4544, #4875, #4692, #6037).
+- The `build` skill makes its path the only sanctioned one ("Scratch files go only where this
+  prints"); this verb is what lets the triage skill say the same thing.
 
 ---
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1062,12 +1062,14 @@ Take one intake-queue issue from arrival to triaged. Contract:
 | `triage park` | an issue demoted to needs-info with the questions on stdin |
 | `triage kill` | an agent-filed issue closed not-planned, with a reason |
 | `triage repair-criteria` | an acceptance-criteria block's shape repaired mechanically |
+| `triage scratch` | the per-lane directory a triager's working files go under |
 
 **Exit codes.** The shared table, plus `12` the issue is human-filed · `13` agent-filed and
 close-eligible, but the kill is unconfirmed (ADR 0159) · `14` the criteria block is drifted in a
 way no mechanical repair covers · `15` the composed body's authored region carries a `Malformed`
 criteria block · `16` `--ready-for agent` over a body whose criteria block does not read `Found` ·
-`17` a live claim marker names another session. `4` is a deliberate gap.
+`17` a live claim marker names another session · `18` no value of `.fabrika.jsonc` may be used ·
+`19` the asking lane holds no live claim on the target. `4` is a deliberate gap.
 
 Two repairs are worth spelling out, because they are what `repair-criteria` will and will not do.
 It rewrites a level-drifted `## Acceptance criteria` heading to the conforming `###`, and, when the

--- a/packages/fabrika-cli/src/triage/claim-verb.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.ts
@@ -29,19 +29,16 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {createComment, deleteComment, getIssue, listComments, resolveRepo} from "../io/issues.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
-	claimNonceOf,
-	composeClaimToken,
+	type AskedLane,
 	DEFAULT_TTL_MINUTES,
 	expiryOf,
-	isStampableSession,
-	type LaneCaller,
-	laneCaller,
 	markerBody,
 	markersOf,
+	mintCaller,
 	myMarker,
-	parseClaimToken,
+	requireCallerToken,
+	requireSession,
 	resolveClaim,
-	TOKEN_PREFIX,
 } from "./claim.ts";
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {scannedLine} from "./scope.ts";
@@ -61,82 +58,19 @@ export interface ClaimOptions {
 const VERB = "triage claim";
 
 /**
- * The session id, or a refusal.
- *
- * The unset case is seated on `1` because the merged contract's errors table puts it there. That
- * sits against the group's own rule that a proven refusal never shares a code with a failure to
- * invoke — the tension is real and disclosed rather than renumbered here, and it is defensible: an
- * unstamped environment is a precondition of *invoking* the verb, not a verdict it reached.
- */
-const sessionFrom = (
-	env: Readonly<Record<string, string | undefined>>,
-): {readonly session: string} | {readonly refusal: VerbOutcome} => {
-	const raw = env.CLAUDE_CODE_SESSION_ID ?? "";
-	if (raw.trim() === "") {
-		return {
-			refusal: refuse(
-				FAILED,
-				`${VERB}: CLAUDE_CODE_SESSION_ID is unset — refusing to post an unattributable claim.`,
-			),
-		};
-	}
-	const session = raw.trim();
-	if (!isStampableSession(session)) {
-		return {
-			refusal: refuse(
-				FAILED,
-				`${VERB}: CLAUDE_CODE_SESSION_ID is not a single token — a marker stamped with it would not read back as this session.`,
-			),
-		};
-	}
-	return {session};
-};
-
-/**
  * The lane that is asking — the one it was handed a token for, or a fresh one minted here.
  *
- * A token from another session is refused rather than trusted: the env says which session is
- * running, the flag says which lane of it, and a pair that disagrees is a token threaded through
- * from somewhere else.
+ * Both arms and the session read behind them live in `claim.ts`, so `triage scratch` asks the same
+ * question in the same words rather than in a second copy of them.
  */
 const callerFrom = (
 	session: string,
 	token: string | null,
 	uuid: string,
-): {readonly caller: LaneCaller; readonly token: string} | {readonly refusal: VerbOutcome} => {
-	if (token === null) {
-		const minted = composeClaimToken(session, uuid);
-		const nonce = claimNonceOf(minted);
-		if (nonce === null) {
-			return {
-				refusal: refuse(
-					FAILED,
-					`${VERB}: could not mint a lane token for session ${session} — nothing was written.`,
-				),
-			};
-		}
-		return {caller: laneCaller(session, nonce, minted), token: minted};
-	}
-	const trimmed = token.trim();
-	const parsed = parseClaimToken(trimmed);
-	const nonce = claimNonceOf(trimmed);
-	if (parsed === null || nonce === null) {
-		return {
-			refusal: refuse(
-				FAILED,
-				`${VERB}: --token "${trimmed}" is not a claim token (${TOKEN_PREFIX}:<session-id>:<uuid>) — which lane is asking is not stated.`,
-			),
-		};
-	}
-	if (parsed.session !== session) {
-		return {
-			refusal: refuse(
-				FAILED,
-				`${VERB}: --token "${trimmed}" carries session ${parsed.session}, but this run is session ${session} — a lane names itself, never another.`,
-			),
-		};
-	}
-	return {caller: laneCaller(session, nonce, trimmed), token: trimmed};
+): AskedLane | {readonly refusal: VerbOutcome} => {
+	const asked =
+		token === null ? mintCaller(VERB, session, uuid) : requireCallerToken(VERB, session, token);
+	return "refusal" in asked ? asked : asked.value;
 };
 
 export const runClaim = (
@@ -149,9 +83,9 @@ export const runClaim = (
 			return refuse(FAILED, `${VERB}: ${issue} is not an issue number.`);
 		}
 
-		const stamped = sessionFrom(options.env);
+		const stamped = requireSession(VERB, options.env, "refusing to post an unattributable claim");
 		if ("refusal" in stamped) return stamped.refusal;
-		const {session} = stamped;
+		const session = stamped.value;
 
 		const asking = callerFrom(session, options.token, options.uuid);
 		if ("refusal" in asking) return asking.refusal;

--- a/packages/fabrika-cli/src/triage/claim.ts
+++ b/packages/fabrika-cli/src/triage/claim.ts
@@ -19,8 +19,9 @@
  * branches testable without a network: the verb supplies markers, a clock and a caller, and
  * this module decides.
  */
-import type {Caller} from "../build/claim.ts";
+import {type Caller, type LaneCaller, laneCaller} from "../build/claim.ts";
 import {composeToken, nonceOf, parseToken} from "../build/lane.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
 
 export {anySessionCaller, type Caller, type LaneCaller, laneCaller} from "../build/claim.ts";
 
@@ -43,6 +44,85 @@ export const claimNonceOf = (token: string): string | null => nonceOf(token, TOK
 export const parseClaimToken = (
 	token: string,
 ): {readonly session: string; readonly uuid: string} | null => parseToken(token, TOKEN_PREFIX);
+
+/** Either half of the "who is asking" read: the answer, or the refusal that ends the verb. */
+export type Asked<A> =
+	| {readonly _tag: "Asked"; readonly value: A}
+	| {readonly refusal: VerbOutcome};
+
+const usage = (verb: string, message: string): {readonly refusal: VerbOutcome} => ({
+	refusal: refuse(FAILED, `${verb}: ${message}`),
+});
+
+/**
+ * The session this run is stamped with, or the refusal that ends the verb.
+ *
+ * Seated on `1` because the merged contract's errors table puts it there — an unstamped environment
+ * is a precondition of *invoking* a verb, not a verdict one reached. `refusing` is what this verb
+ * would otherwise have done with the id, because the contract pins each caller's line verbatim.
+ */
+export const requireSession = (
+	verb: string,
+	env: Readonly<Record<string, string | undefined>>,
+	refusing: string,
+): Asked<string> => {
+	const raw = (env.CLAUDE_CODE_SESSION_ID ?? "").trim();
+	if (raw === "") {
+		return usage(verb, `CLAUDE_CODE_SESSION_ID is unset — ${refusing}.`);
+	}
+	if (!isStampableSession(raw)) {
+		return usage(
+			verb,
+			"CLAUDE_CODE_SESSION_ID is not a single token — a marker stamped with it would not read back as this session.",
+		);
+	}
+	return {_tag: "Asked", value: raw};
+};
+
+/** One resolved lane and the token that names it — non-null by construction, unlike `Caller.token`. */
+export interface AskedLane {
+	readonly caller: LaneCaller;
+	readonly token: string;
+}
+
+/**
+ * The lane a `--token` names, or the refusal that ends the verb.
+ *
+ * A token from another session is refused rather than trusted: the env says which session is
+ * running, the flag says which lane of it, and a pair that disagrees is a token threaded through
+ * from somewhere else.
+ */
+export const requireCallerToken = (
+	verb: string,
+	session: string,
+	token: string,
+): Asked<AskedLane> => {
+	const trimmed = token.trim();
+	const parsed = parseClaimToken(trimmed);
+	const nonce = claimNonceOf(trimmed);
+	if (parsed === null || nonce === null) {
+		return usage(
+			verb,
+			`--token "${trimmed}" is not a claim token (${TOKEN_PREFIX}:<session-id>:<uuid>) — which lane is asking is not stated.`,
+		);
+	}
+	if (parsed.session !== session) {
+		return usage(
+			verb,
+			`--token "${trimmed}" carries session ${parsed.session}, but this run is session ${session} — a lane names itself, never another.`,
+		);
+	}
+	return {_tag: "Asked", value: {caller: laneCaller(session, nonce, trimmed), token: trimmed}};
+};
+
+/** A fresh lane of `session`, minted from `uuid` — `triage claim`'s no-`--token` path. */
+export const mintCaller = (verb: string, session: string, uuid: string): Asked<AskedLane> => {
+	const minted = composeClaimToken(session, uuid);
+	const nonce = claimNonceOf(minted);
+	return nonce === null
+		? usage(verb, `could not mint a lane token for session ${session} — nothing was written.`)
+		: {_tag: "Asked", value: {caller: laneCaller(session, nonce, minted), token: minted}};
+};
 
 /** The exact one-line body a claim marker carries, up to the session id. */
 export const MARKER_PREFIX = "<!-- fabrika-triage-claim session=";

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -1,5 +1,5 @@
 /**
- * The one exit table all nine `triage` verbs allocate from, so a code means one thing across this
+ * The one exit table every `triage` verb allocates from, so a code means one thing across this
  * group whichever verb produced it.
  *
  * `0`, `1`, `126` and `127` are reserved by the interface convention (see `../verb.ts` and the
@@ -71,12 +71,14 @@ export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
 /** The write landed but the read-back does not match. The artifact exists and needs a human. */
 export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
 /**
- * The supplied classification value is not permitted in this position — off a closed enum, or a
- * `--home` naming a milestone that is not open.
+ * The supplied value is not permitted in this position — off a closed enum, a `--home` naming a
+ * milestone that is not open, or a `--slug` that is not a kebab-case leaf.
  *
  * The superset that keeps `report`'s reading true: there `10` is a title or `--label` carrying a
  * type or priority. A closed milestone is an off-vocabulary home, so it belongs with the enum
- * refusals rather than with the shape errors.
+ * refusals rather than with the shape errors; a slug joins them because its whole fix is the same
+ * one — re-run with another value — which is exactly what `1` cannot tell a caller (`build scratch`
+ * seats it here for the same reason).
  */
 export const OFF_VOCABULARY = REPORT_CLASSIFIED;
 /** A precondition read failed — nothing was written and no outcome is proven. `report`'s `11`. */
@@ -164,6 +166,19 @@ export const CLAIMED_ELSEWHERE = 17;
  * that retried this code would loop forever.
  */
 export const CONFIG_REFUSED = 18;
+/**
+ * Refused: the asking lane holds no live claim on the target, so it has no nonce to key on.
+ *
+ * `triage scratch`'s, and only a namespace allocator needs it. The five mutating verbs pass when
+ * nobody holds a claim — an unclaimed issue is the ordinary first-triage case — but a scratch path
+ * IS the lane, so a caller that cannot prove one has nothing to be allocated a directory under.
+ *
+ * Its own seat rather than {@link CLAIMED_ELSEWHERE}'s: that code means a live marker names *another
+ * session*, deliberately excluding "I hold none". This one covers both ways a lane fails to hold the
+ * claim — no marker of its own, and a marker of its own that lost the race to a sibling lane — and
+ * the message says which, because the caller's move differs: claim first, versus back off.
+ */
+export const CLAIM_NOT_HELD = 19;
 
 /** The verb never ran (unresolved binary). The shell's, not this process's — no constant owns it. */
 const NEVER_RAN = 127;
@@ -194,7 +209,11 @@ export const TRIAGE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
 	},
 	{code: WRITE_UNKNOWN, meaning: "the write itself failed — the outcome is UNKNOWN"},
 	{code: READBACK_MISMATCH, meaning: "the write landed but the read-back does not match"},
-	{code: OFF_VOCABULARY, meaning: "the supplied classification value is not permitted here"},
+	{
+		code: OFF_VOCABULARY,
+		meaning:
+			"the supplied value is not permitted here — off a closed vocabulary, a non-open milestone, or a slug that is not a kebab-case leaf",
+	},
 	{
 		code: PRECONDITION_UNKNOWN,
 		meaning: "a precondition read failed — nothing was written and the outcome is UNKNOWN",
@@ -227,6 +246,10 @@ export const TRIAGE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
 		code: CONFIG_REFUSED,
 		meaning:
 			"refused: no value of .fabrika.jsonc may be used — a key's load-time check refused it, it could not be read, or it did not decode",
+	},
+	{
+		code: CLAIM_NOT_HELD,
+		meaning: "refused: the asking lane holds no live claim on the target",
 	},
 	{code: NO_IMPLEMENTATION, meaning: "no implementation could be resolved"},
 	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},

--- a/packages/fabrika-cli/src/triage/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/codes.unit.test.ts
@@ -4,6 +4,7 @@ import * as report from "../report/codes.ts";
 import * as codes from "./codes.ts";
 import {
 	BARE_AT_PATH,
+	CLAIM_NOT_HELD,
 	CLAIMED_ELSEWHERE,
 	CRITERIA_REQUIRED,
 	DELIBERATE_GAP,
@@ -83,6 +84,16 @@ describe("the codes this group adds", () => {
 	 * the base's occupied seats off its exports instead, which is the only form that covers a code
 	 * nobody has written yet (#4924).
 	 */
+	/**
+	 * `17` is *a live marker names another session* and deliberately passes a caller holding none;
+	 * `19` is *this lane holds none*, which only the scratch allocator may refuse on. Fusing them
+	 * would either make an unclaimed issue unmutable or hand a claimless lane a namespace.
+	 */
+	it("seats the claim-not-held refusal clear of the claimed-elsewhere one", () => {
+		expect(CLAIM_NOT_HELD).toBe(19);
+		expect(CLAIM_NOT_HELD).not.toBe(CLAIMED_ELSEWHERE);
+	});
+
 	it("clears every seat `report` occupies, read from its exports and not a list", () => {
 		expect(checkAlignment(report, codes, SHARED_SEATS).collisions).toEqual([]);
 	});
@@ -97,7 +108,9 @@ describe("TRIAGE_EXIT_TABLE", () => {
 	});
 
 	it("carries every allocated code exactly once", () => {
-		expect(codes).toEqual([0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 126, 127]);
+		expect(codes).toEqual([
+			0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 126, 127,
+		]);
 	});
 
 	it("gives every code a non-empty meaning", () => {
@@ -114,5 +127,6 @@ describe("TRIAGE_EXIT_TABLE", () => {
 		expect(meaningOf(MALFORMED_CRITERIA)).toContain("acceptance-criteria");
 		expect(meaningOf(CRITERIA_REQUIRED)).toContain("--ready-for agent");
 		expect(meaningOf(CLAIMED_ELSEWHERE)).toContain("another session");
+		expect(meaningOf(CLAIM_NOT_HELD)).toContain("holds no live claim");
 	});
 });

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -15,6 +15,7 @@
  * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
  */
 import {randomUUID} from "node:crypto";
+import {tmpdir} from "node:os";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {CONFIG_PATH} from "../config/document.ts";
@@ -35,6 +36,7 @@ import {runProvenance} from "./provenance-verb.ts";
 import {DEFAULT_QUEUE_LABEL, DEFAULT_QUEUE_LIMIT, runQueue} from "./queue-verb.ts";
 import {runRepairCriteria} from "./repair-criteria-verb.ts";
 import {ROADMAP_FILE} from "./roadmap.ts";
+import {runScratch} from "./scratch-verb.ts";
 import {runSplit} from "./split-verb.ts";
 import {readStandingLanes} from "./standing-lanes.ts";
 
@@ -453,6 +455,40 @@ const repairCriteria = leafCommand(
 	),
 );
 
+const scratch = leafCommand(
+	"scratch",
+	{
+		issue: Argument.integer("issue").pipe(
+			Argument.withDescription("the issue this lane holds the claim on"),
+		),
+		slug: Flag.string("slug").pipe(
+			Flag.withDescription("the file's leaf name: kebab-case, no path separators"),
+		),
+		token: Flag.string("token").pipe(
+			Flag.withDescription("the claim token `triage claim` handed this lane — its identity"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({issue, slug, token, repo}) {
+		yield* emit(
+			yield* runScratch({
+				issue,
+				slug,
+				token,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("The per-lane scratch path a triager's working files go under."),
+	Command.withDescription(
+		"The per-lane scratch path, allocated fail-closed: <temp root>/fabrika-triage/<session-id>/<issue>-<claim-nonce>/<slug>, one absolute path on stdout, the directory created if absent. --token's nonce is what keys the namespace per LANE rather than per session, so two triagers of one fan-out cannot clobber each other's fixed-name files. The printed path is machine-local and must never reach a posted artifact. Exits 1 (the directory could not be created, CLAUDE_CODE_SESSION_ID is unset or is not one path segment, --token is not a claim token of this session, or the repo does not resolve), 10 (--slug carries a path separator or is not kebab-case), 11 (the claim state could not be read — UNKNOWN), 19 (proven: this lane holds no live claim on the issue). Example: fabrika triage scratch 4312 --slug authored --token triage:s-9f2e:c1a4d6f8-…",
+	),
+);
+
 export const triageCommand = Command.make("triage").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
@@ -468,6 +504,7 @@ export const triageCommand = Command.make("triage").pipe(
 		homes,
 		enrich,
 		repairCriteria,
+		scratch,
 	]),
 	Command.withShortDescription("Take one intake-queue issue from arrival to triaged."),
 	Command.withDescription(

--- a/packages/fabrika-cli/src/triage/scratch-verb.ts
+++ b/packages/fabrika-cli/src/triage/scratch-verb.ts
@@ -1,0 +1,147 @@
+/**
+ * `triage scratch` — the per-lane scratch path a triager writes its working files under.
+ *
+ * `<temp root>/fabrika-triage/<session-id>/<issue>-<claim-nonce>/<slug>`. A fan-out of triagers runs
+ * under one session id, so a namespace keyed on the session alone hands every lane the same
+ * directory and a fixed name like `authored.md` clobbers a sibling's file silently — which happened
+ * on 2026-08-20 across #6597/#6189/#6146, and was caught only because the overwritten content
+ * happened to be a different issue's body (#6630). The claim nonce in the key makes that
+ * unconstructible rather than detectable, exactly as `build scratch` does for build lanes (#6037).
+ *
+ * The printed path is machine-local and must never reach a posted artifact — the leak predicate the
+ * writing verbs share reds on the temp roots it lives under.
+ */
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {isKebabSlug} from "../build/lane.ts";
+import {listComments, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	DEFAULT_TTL_MINUTES,
+	markersOf,
+	requireCallerToken,
+	requireSession,
+	resolveClaim,
+} from "./claim.ts";
+import {CLAIM_NOT_HELD, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {scannedLine} from "./scope.ts";
+
+const VERB = "triage scratch";
+
+/** A session id fit to be one directory segment — a `/` in it would nest the namespace elsewhere. */
+const isPathSegment = (value: string): boolean => /^[A-Za-z0-9._-]+$/.test(value);
+
+/** This lane's namespace, exported so a caller derives the path rather than restating the formula. */
+export const laneScratchDir = (
+	tmpRoot: string,
+	session: string,
+	issue: number,
+	nonce: string,
+): string => `${tmpRoot.replace(/\/+$/, "")}/fabrika-triage/${session}/${issue}-${nonce}`;
+
+export interface ScratchOptions {
+	readonly issue: number;
+	readonly slug: string;
+	/** The token `triage claim` handed this lane — what keys the namespace per lane, not per session. */
+	readonly token: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The OS temp root, read by the adapter — the one machine fact this verb does not derive. */
+	readonly tmpRoot: string;
+	readonly now: () => Date;
+}
+
+export const runScratch = (
+	options: ScratchOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const {issue, slug} = options;
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `${VERB}: ${issue} is not an issue number.`);
+		}
+		if (slug.includes("/") || slug.includes("\\") || !isKebabSlug(slug)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --slug "${slug}" must be a kebab-case leaf, no path separators.`,
+			);
+		}
+
+		const stamped = requireSession(
+			VERB,
+			options.env,
+			"refusing to key a scratch namespace on an unattributable session",
+		);
+		if ("refusal" in stamped) return stamped.refusal;
+		const session = stamped.value;
+		if (!isPathSegment(session)) {
+			return refuse(
+				FAILED,
+				`${VERB}: CLAUDE_CODE_SESSION_ID is not one path segment — it cannot name a directory of its own.`,
+			);
+		}
+
+		const asking = requireCallerToken(VERB, session, options.token);
+		if ("refusal" in asking) return asking.refusal;
+		const {caller} = asking.value;
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const comments = yield* listComments(repo, issue);
+		if (comments._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue}'s comments in ${repo}: ${comments.reason} — the claim on it is UNKNOWN, so no path was allocated.`,
+			);
+		}
+		const scope = scannedLine(VERB, repo, comments.value.length, "comment");
+
+		const resolution = resolveClaim({
+			markers: markersOf(comments.value),
+			caller,
+			now: options.now().getTime(),
+			ttlMinutes: DEFAULT_TTL_MINUTES,
+		});
+		if (resolution._tag === "Unresolvable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve the claim on #${issue} in ${repo}: ${resolution.reason} — no path was allocated.`,
+				[scope],
+			);
+		}
+		if (resolution._tag === "MineAbsent") {
+			return refuse(
+				CLAIM_NOT_HELD,
+				`${VERB}: this lane holds no live claim on #${issue} — run \`fabrika triage claim ${issue}\` and act only on \`won\`.`,
+				[scope],
+			);
+		}
+		if (resolution._tag === "Lost") {
+			return refuse(
+				CLAIM_NOT_HELD,
+				`${VERB}: #${issue} is held by the lane on nonce ${resolution.holder.lane ?? "(unstated)"}, not by this one — back off.`,
+				[scope],
+			);
+		}
+
+		const dir = laneScratchDir(options.tmpRoot, session, issue, caller.nonce);
+		const fs = yield* FileSystem.FileSystem;
+		const failure: string | null = yield* fs.makeDirectory(dir, {recursive: true}).pipe(
+			Effect.as(null),
+			Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)),
+		);
+		return failure === null
+			? answer(`${dir}/${slug}`, [scope])
+			: refuse(FAILED, `${VERB}: cannot create ${dir}: ${failure}`, [scope]);
+	});

--- a/packages/fabrika-cli/src/triage/scratch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/scratch-verb.unit.test.ts
@@ -1,0 +1,179 @@
+import {Effect, FileSystem, Layer, PlatformError} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs, fakeSeams, type Scripted} from "../fakes.test-support.ts";
+import {FAILED} from "../verb.ts";
+import {composeClaimToken} from "./claim.ts";
+import {COMMENTS, claimPage, EXPIRED, LIVE} from "./claim-fixtures.test-support.ts";
+import {CLAIM_NOT_HELD, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {runScratch} from "./scratch-verb.ts";
+
+const SESSION = "s-9f2e";
+/** Two lanes of ONE session — the fan-out shape #6630 is about. */
+const UUID_A = "c1a4d6f8-0000-4000-8000-000000000001";
+const UUID_B = "b7e30912-0000-4000-8000-000000000002";
+const TOKEN_A = composeClaimToken(SESSION, UUID_A);
+const TOKEN_B = composeClaimToken(SESSION, UUID_B);
+const NONCE_A = "c1a4d6f8";
+const NONCE_B = "b7e30912";
+
+const options = {
+	issue: 4312,
+	slug: "authored",
+	token: TOKEN_A,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: SESSION} as Record<
+		string,
+		string | undefined
+	>,
+	tmpRoot: "/scratch-root",
+	now: () => new Date("2026-08-20T18:00:00Z"),
+};
+
+const held = (lane: string): ReadonlyArray<Scripted> => [
+	[COMMENTS, claimPage({session: SESSION, createdAt: LIVE, lane})],
+];
+
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(
+		Effect.provide(
+			runScratch({...options, ...overrides}),
+			Layer.merge(fakeSeams(script).layer, fakeFs({}).layer),
+		),
+	);
+
+describe("runScratch", () => {
+	it("keys the directory on session, issue and the CALLER token's lane nonce", async () => {
+		const out = await run(held(NONCE_A));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`/scratch-root/fabrika-triage/${SESSION}/4312-${NONCE_A}/authored\n`);
+	});
+
+	/**
+	 * The whole point of the verb: a fan-out runs under one session id, so two lanes asking for the
+	 * same slug on the same issue must not be handed the same file (#6630).
+	 */
+	it("hands two lanes of one session two directories on one issue", async () => {
+		const first = await run(held(NONCE_A));
+		const second = await run(
+			[[COMMENTS, claimPage({session: SESSION, createdAt: LIVE, lane: NONCE_B})]],
+			{token: TOKEN_B},
+		);
+		expect(first.code).toBe(0);
+		expect(second.code).toBe(0);
+		expect(second.stdout).not.toBe(first.stdout);
+		expect(second.stdout).toContain(`4312-${NONCE_B}/`);
+	});
+
+	it("refuses a slug carrying a path separator on 10, with no path on stdout", async () => {
+		const out = await run([], {slug: "notes/inner"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			'triage scratch: --slug "notes/inner" must be a kebab-case leaf, no path separators.',
+		);
+	});
+
+	it("refuses a non-kebab slug on 10", async () => {
+		const out = await run([], {slug: "Authored"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a token carrying another session on 1 — a lane names itself, never another", async () => {
+		const out = await run(held(NONCE_A), {token: composeClaimToken("s-77aa", UUID_A)});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("carries session s-77aa, but this run is session s-9f2e");
+	});
+
+	it("refuses a token that is not a triage claim token on 1", async () => {
+		const out = await run(held(NONCE_A), {token: `build:${SESSION}:${UUID_A}`});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("is not a claim token");
+	});
+
+	it("refuses an unstamped session on 1", async () => {
+		const out = await run(held(NONCE_A), {
+			env: {CLAUDE_PIPELINE_REPO: "o/r"},
+		});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("CLAUDE_CODE_SESSION_ID is unset");
+	});
+
+	it("refuses a session id that is not one path segment on 1", async () => {
+		const out = await run(held(NONCE_A), {
+			env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s/../root"},
+			token: composeClaimToken("s/../root", UUID_A),
+		});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("is not one path segment");
+	});
+
+	it("refuses on 19 when no marker of this lane is live — no lane, no namespace", async () => {
+		const out = await run([[COMMENTS, {status: 200, body: "[]"}]]);
+		expect(out.code).toBe(CLAIM_NOT_HELD);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("holds no live claim on #4312");
+	});
+
+	it("refuses on 19 when this lane's own marker has aged out", async () => {
+		const out = await run([
+			[COMMENTS, claimPage({session: SESSION, createdAt: EXPIRED, lane: NONCE_A})],
+		]);
+		expect(out.code).toBe(CLAIM_NOT_HELD);
+		expect(out.stdout).toBe("");
+	});
+
+	/** A sibling lane got there first: this lane holds a marker, and it is not the earliest. */
+	it("refuses on 19 when a sibling lane of the same session won the race", async () => {
+		const out = await run([
+			[
+				COMMENTS,
+				claimPage(
+					{session: SESSION, createdAt: "2026-08-20T17:00:00Z", lane: NONCE_B},
+					{session: SESSION, createdAt: "2026-08-20T17:30:00Z", lane: NONCE_A},
+				),
+			],
+		]);
+		expect(out.code).toBe(CLAIM_NOT_HELD);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain(`held by the lane on nonce ${NONCE_B}`);
+	});
+
+	it("refuses an unreadable comment list on 11 — UNKNOWN, never an allocated path", async () => {
+		const out = await run([[COMMENTS, {status: 502, body: "{}"}]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unorderable marker set on 11", async () => {
+		const out = await run([
+			[COMMENTS, claimPage({session: SESSION, createdAt: "not-a-date", lane: NONCE_A})],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unmakeable directory on 1 — never a path it could not allocate", async () => {
+		const unmakeable = FileSystem.layerNoop({
+			makeDirectory: (path: string) =>
+				Effect.fail(
+					PlatformError.systemError({
+						_tag: "PermissionDenied",
+						module: "FileSystem",
+						method: "makeDirectory",
+						pathOrDescriptor: path,
+					}),
+				),
+		});
+		const out = await Effect.runPromise(
+			Effect.provide(runScratch(options), Layer.merge(fakeSeams(held(NONCE_A)).layer, unmakeable)),
+		);
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("triage scratch: cannot create ");
+	});
+});


### PR DESCRIPTION
A fan-out of triage subagents runs under one session id, so every lane's scratchpad root is that one
directory. A triager writing `authored.md` overwrites a sibling lane's file of the same name,
silently — that happened on 2026-08-20 across #6597/#6189/#6146, and was caught only because the
clobbered content happened to be a different issue's body. The failure it points at is one issue's
authored body posted onto another.

`build` already solved this for build lanes by keying the namespace on the claim nonce. This gives
`triage` the same allocator:

- `fabrika triage scratch <issue> --slug <kebab> --token <claim-token>` prints
  `<temp root>/fabrika-triage/<session>/<issue>-<claim-nonce>/<slug>`, directory created, nothing on
  stdout on any refusal. The nonce comes off the **caller's** token, never the winning marker's —
  that string is the same for two lanes of one session, which is how keying on it re-opens the hole.
- Holding the claim is a precondition here, unlike the five mutating verbs (which pass when nobody
  holds one, because an unclaimed issue is the ordinary first-triage case). A scratch path *is* the
  lane, so no live marker of this lane — or a marker that lost to a sibling — is the new exit `19`.
  It gets its own seat rather than `17`'s, whose documented reading explicitly excludes "I hold
  none".
- `10` widens from "classification value" to "value not permitted here", covering the slug shape.
  Additive: every existing reading still holds, and it matches `build scratch` seat for seat.
- `triage claim`'s private `sessionFrom`/`callerFrom` moved into `claim.ts` as `requireSession` /
  `requireCallerToken` / `mintCaller` so `scratch` asks "which lane is asking" in the same words
  rather than a second copy of them. `claim`'s messages are unchanged — the contract pins them
  verbatim, so the one that varies is passed in.
- The skill now names the verb as the only place a working file goes, and the contract carries a
  `triage scratch` section (readable by `fabrika wire doc-section`) plus a `scratch` column across
  the exit matrix.

Reviewer's first look: the claim precondition in `scratch-verb.ts` — `MineAbsent` and `Lost` both
refuse, and the message distinguishes them because the caller's move differs (claim first vs back
off).

Verified in-tree: `build check --surface code` and `--surface prose` both green, 7611 tests pass, and
a live run against #6630 with an unheld token exits 19 with no path on stdout.

Fixes #6630

## Deviations

- **Out-of-scope change** — **Said:** #6630 names the allocator, one skill line, and the contract
  section. **Did:** also refactored `triage claim`'s session/caller reads out of `claim-verb.ts` into
  `claim.ts`. **Why:** `scratch` needs the same two refusals, and a second copy of the token grammar
  is exactly the drift this group's docs warn about. **Disposition:** stated here; `claim`'s wire
  messages and exit codes are byte-identical, and its own test file passes unchanged.
- **Out-of-scope change** — **Said:** nothing about exit code `10`. **Did:** widened its documented
  meaning to cover a bad `--slug`, in `codes.ts`, the contract matrix and the README. **Why:** the
  slug refusal needs a seat, and `1` would fuse "re-run with another slug" with "the binary is
  broken". **Disposition:** stated here; the widening is additive, so no existing reading of `10`
  changed.
- **Out-of-scope change** — **Said:** nothing about the session id's shape. **Did:** added a
  path-segment guard on `CLAUDE_CODE_SESSION_ID` (exit `1`). **Why:** the session id is a directory
  segment in this key, and the token grammar admits `/` in it, so without the guard a crafted id
  nests the namespace somewhere else. **Disposition:** stated here, documented in the contract's
  errors table, covered by a test.
- **Out-of-scope change** — **Said:** nothing about the README. **Did:** added the verb's row and
  the `18`/`19` codes to `packages/fabrika-cli/README.md`. **Why:** the README's triage table
  enumerates every verb; a new one absent from it is a stale doc on the day it lands. **Disposition:**
  stated here.
