### PR TITLE
chore: An orphaned agent worktree pins a build branch and deadlocks every repair round

### DIFF
--- a/.decisions/0321-dead-spawn-worktree-ownership.md
+++ b/.decisions/0321-dead-spawn-worktree-ownership.md
@@ -1,7 +1,7 @@
 ---
 id: 0321
 title: The driver retires a dead spawn's worktree, salvaging its dirty work onto the branch first
-status: accepted
+status: amended-in-part by [0323](0323-board-licensed-worktree-retirement.md)
 date: 2026-08-21
 tags: [fabrika, pipeline-hardening, worktree, isolation]
 ---

--- a/.decisions/0323-board-licensed-worktree-retirement.md
+++ b/.decisions/0323-board-licensed-worktree-retirement.md
@@ -1,0 +1,157 @@
+---
+id: 0323
+title: A verb retires an orphaned build worktree on a board-attested license, and a lane frees its own branch at its terminal
+status: accepted
+date: 2026-08-21
+tags: [fabrika, pipeline-hardening, worktree, isolation]
+---
+
+# 0323 — A verb retires an orphaned build worktree on a board-attested license, and a lane frees its own branch at its terminal
+
+**What this decides:** `fabrika build retire <n>` takes back the checkout a registered worktree is
+holding on `#n`'s lane branch, licensed by a written positive board state and never by a tree looking
+idle. The two licenses are the ticket reaching a terminal state, and an ADR
+[0295](0295-board-attested-claim-succession.md) adopt marker naming the session whose claim carries
+that branch's lane nonce. **Dirtiness is not a refusal condition**, and it costs nobody their only
+copy: ADR [0321](0321-dead-spawn-worktree-ownership.md)'s salvage runs first. As a complement,
+`build release` detaches its own tree's HEAD when that tree is standing on the released lane's
+branch, so a lane that ends normally never forms the pin at all.
+
+## Context
+
+A build lane's worktree outlives the session that registered it. While it stays registered it holds
+that lane's branch checked out, and `build branch --resume-lane` refuses on exit `11` rather than
+re-key the branch out from under a live checkout — a refusal that is correct, because `git branch -m`
+does not refuse there, it renames and silently retargets that worktree's `HEAD`
+(`packages/fabrika-cli/src/build/git.ts`, measured against git 2.40.1 on #6386).
+
+No actor inside the loop could clear the residue, so every such round ended as a human park on a
+cleanup carrying no judgment. Both phase-1 children of epic #5843 (#6566, #6567) parked on it in a
+single drive, and #6684, #6687 and #6651 then showed it is not only a killed session's leak: those
+builders reported `BUILT-NO-PR` and released their claims, and still left the tree holding the
+branch. The park's routing half already existed — `recipe/parks.ts` carries the `blocked` +
+`worktree-holds-branch` row — but its clearance only *read* whether a tree still held the branch, so
+`recipe unpark` sat at exit `13` until a human ran `git worktree remove`.
+
+The founder ruled on
+[#6610](https://github.com/kamp-us/phoenix/issues/6610#issuecomment-5360396072): option 2 (a verb
+retires), with option 1 (a lane releases its own at its terminal) as a cheap complement, and the
+release proof is the worktree's ticket state rather than dirtiness — because agents routinely leave a
+worktree dirty *after* its ticket merged, so "dirty" is a false negative for "work in progress" and
+reading it keeps the deadlock in the case that most needs clearing.
+
+## Decision
+
+### 1. Two licenses, both written positive board states
+
+`build retire <n>` releases a worktree holding `#n`'s lane branch when either holds:
+
+- **`ticket-terminal`** — the number is terminal on the board: a closed issue, or a **merged** pull
+  request. A PR closed unmerged is not terminal, because it can be reopened onto the same head.
+- **`session-adopted`** — an authorized ADR 0295 `build-adopt` marker on `#n` names the session that
+  took the claim whose token carries this branch's lane nonce. That is the only link from a branch
+  name back to a session, and it is read through `readClaimants`, so the ACL answers authority
+  (ADR [0055](0055-acl-sourced-review-authz.md)) exactly as it does for a claim.
+
+No new attestation format is minted. The adopt marker already proves succession, and the ticket's
+state is the board's own.
+
+### 2. Dirtiness is not an input, and ADR 0321's salvage is why that is safe
+
+The predicate takes no dirtiness argument at all, which makes reading one unrepresentable rather than
+merely unused. What keeps that from destroying a dying spawn's only copy is that ADR 0321's order
+runs first on every released tree: commit whatever the tree holds uncommitted onto its own branch,
+**then** `git worktree remove` — **without `--force`**, which 0321 bans on every path for every tree.
+A removal that still refuses is reported as an incident to file, never overridden. The recurring
+instance is a *locked* tree, which refuses however clean it is; the agent harness locks the trees it
+registers, so that refusal is named in full and left to a human
+([#6881](https://github.com/kamp-us/phoenix/issues/6881)).
+
+The two rulings are therefore one act, not a conflict: #6610 says a dirty tree is still retired, and
+0321 says its work is preserved first. A detached-HEAD tree, whose salvage arm 0321 leaves undefined
+(#6868), never reaches this verb at all: it holds no branch name, so it is no lane's pin and appears
+in no subject list.
+
+### 3. Releasing a git registration is outside ADR 0215 §5
+
+**It does not fall inside §5's ban on eviction by inference, because it evicts no claim.** §5
+enumerates how a *claim* ends and bans inferring that ending from absence. A worktree registration is
+not a claim: it confers no ownership of a number, no verb resolves ownership against it, and removing
+one changes nothing about who holds `#n`. ADR 0321 already states the converse — no eviction of a
+claim follows from a removed tree — and this record states the direction it left open: no eviction of
+a *tree* is an eviction of a claim either.
+
+So no widening of §5 is taken and none is needed, and the adversarial read 0295 earned is not owed
+here. What §5's *posture* does bind, and what this decision keeps, is the evidentiary rule: both
+licenses are written positive statements on the board. A tree that merely looks idle, a session that
+has not been heard from, an old registration — none of those license anything. That is the whole
+reason the predicate reads the ticket and the adopt marker rather than the tree.
+
+### 4. The verb belongs to the `build` group
+
+`build retire`, beside `adopt` and `release`. It reads that group's claim markers, that group's lane
+branch grammar, and clears that group's residue; a `lane` verb would have to import all three to ask
+a question about a build lane.
+
+### 5. The falsifiable question, answered by running it
+
+**A worktree-isolated caller can invoke this verb, and the verb's own git reaches the other tree.**
+Measured on #6610 from inside `.claude/worktrees/agent-a91911776626b3a79`, against git 2.40.1:
+
+- A **typed** `git -C <another worktree> …` is refused by the harness before it runs.
+- A typed `git worktree remove <another worktree>` is **not** refused — it runs, and git's own
+  answer comes back (dirty refused; `--force` overrode; a locked tree needed `-f -f`; the branch
+  survived every removal).
+- A **node child process** running `git -C <another worktree> status` succeeds.
+
+The harness rule reads the typed command, so it binds a shell and not a verb's child process. That
+retires the premise ADR 0321 rested its actor choice on, and 0321 named this exact case: "if the
+harness changes and a worktree-isolated agent can reach another tree, the ownership can move …
+without disturbing the salvage-then-remove rule, which is the part the ruling was actually about."
+**This record therefore amends ADR 0321's first binding constraint in part** — the obligation is a
+verb's, invocable from any shell, primary or isolated — and leaves the rest of 0321 untouched:
+salvage before remove, no `--force` on any path, no claim eviction inferred from a removed tree.
+
+### 6. The complement, and the routing
+
+- `build release` detaches its own tree's HEAD when that tree stands on the released lane's branch.
+  The commit is unchanged and uncommitted work carries over, so a lane may do it at any terminal —
+  `BUILT-NO-PR` included — without deciding anything about what is still in the tree. A failed
+  detach is reported and never fatal: the claim is already retracted by then.
+- The `blocked` + `worktree-holds-branch` recipe row now names its remedy, and `recipe unpark` runs
+  it before re-reading. A park whose only cause is a stale registration clears without a human.
+
+**Banned.**
+
+- Reading dirtiness, staleness, mtime, or any property of the tree itself as a license.
+- Removing the tree the run is standing in.
+- Reporting a removal that was not read back off a second `git worktree list`.
+- `git worktree remove --force`, on any path, for any tree (ADR 0321, unchanged).
+
+## Consequences
+
+- The `build` group grows one verb and one exit code, `33` (`WORKTREE_HELD`): a tree holds the branch
+  and the board licenses no release. It is proven, never `11`.
+- `build release`'s answer gains a `freed` field, so a caller can tell a lane that let go of its
+  branch from one that never held it.
+- A locked worktree still needs a human, because 0321's `--force` ban outranks the convenience.
+  [#6881](https://github.com/kamp-us/phoenix/issues/6881) carries that gap to the founder rather than
+  this ADR resolving it by widening a constraint a day-old ruling wrote.
+- ADR 0321's actor constraint is amended in part, on 0321's own stated terms; its status line records
+  it, per the accepted-ADR immutability rule.
+
+## Alternatives considered
+
+- **Refuse on a dirty tree.** The founder's ruling rejects it by name: dirty is a false negative for
+  work in progress, and refusing keeps the deadlock exactly where it hurts.
+- **A TTL, an mtime, or "the session has not been heard from".** Banned by ADR 0215 §5's posture and
+  by 0295's restatement of it. Every one of them is an inference from absence.
+- **A new attestation format for "this session is gone".** The adopt marker already is one, and a
+  second would give the same fact two spellings that can disagree.
+- **Leave the obligation with the primary-checkout driver (ADR 0321 as written).** Its premise was one
+  live observation, and the observation does not hold for a verb. Keeping it would price every
+  stale registration at a human hop the tooling can now take.
+
+## Records
+
+no vocabulary impact

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -451,14 +451,18 @@ this order:
   ruling rejected a lease, a TTL and steal outright, and eviction by inference from
   absence stays banned (ADR
   [0215](../../../../.decisions/0215-claim-identity-continuity-proof.md) §5).
-- **Retire the worktree it left.** Salvage first: if the tree is dirty, commit its contents to the
-  dead spawn's branch as a WIP commit, because that uncommitted work is the only copy of what the
-  spawn was doing. Then `git worktree remove` **without `--force`** — a remove that still refuses is
-  an incident to file through [`report`](../report/SKILL.md), never a force. A tree left standing
-  holds the lane branch checked out, which refuses the next repair round's `build branch
-  --resume-lane` on exit `11`. This one is the **primary checkout's**, not a worktree-isolated
-  spawn's (ADR
-  [0321](../../../../.decisions/0321-dead-spawn-worktree-ownership.md)).
+- **Retire the worktree it left**, with `fabrika build retire <n>`. A tree left standing holds the
+  lane branch checked out, which refuses the next repair round's `build branch --resume-lane` on
+  exit `11`. The verb does ADR
+  [0321](../../../../.decisions/0321-dead-spawn-worktree-ownership.md)'s two steps in its order —
+  salvage the tree's uncommitted work onto its own branch, then `git worktree remove` **without
+  `--force`**, and a remove that still refuses is an incident to file through
+  [`report`](../report/SKILL.md), never a force — and it removes nothing the board does not license:
+  the ticket is terminal, or an adopt marker names the holding lane's session as gone (ADR
+  [0323](../../../../.decisions/0323-board-licensed-worktree-retirement.md)). **Run it from wherever
+  you are.** The harness rule that refuses a *typed* cross-worktree `git` reads the command you
+  type, so it does not bind the verb's own child process — which is why this obligation is no longer
+  the primary checkout's alone.
 
 **A claim stranded by a gone session is releasable, once you say so on the board.** `build release`
 refuses it on `15` — proven-foreign — until an adopt marker names that session as dead and this one

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -86,7 +86,8 @@ import {
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
-import {composeToken, nonceOf, parseToken} from "./lane.ts";
+import {currentBranch, detachHead} from "./git.ts";
+import {composeToken, laneNumber, nonceOf, parseLaneBranch, parseToken} from "./lane.ts";
 import {failing, readRangeVerdicts} from "./range-verdicts.ts";
 import {
 	admissionOf,
@@ -733,17 +734,83 @@ export const runRelease = (
 				);
 			}
 		}
+		const freed = yield* freeLaneBranch(number, lane.nonce);
 		const adopt = ownership.adopt;
-		if (adopt === null) return answer(JSON.stringify({answer: "released", number}), notes);
+		if (adopt === null) {
+			return answer(JSON.stringify({answer: "released", number, freed: freed.branch}), [
+				...notes,
+				...freed.notes,
+			]);
+		}
 		// The adopt outlives nothing: it exists to authorize this release, so it goes with the claim.
 		const cleared = yield* deleteComment(repo, adopt.commentId);
 		return cleared._tag === "Failure"
 			? refuse(
 					WRITE_UNKNOWN,
 					`${RELEASE}: the claim was retracted and its adopt marker (comment ${adopt.commentId}) was not: ${cleared.reason} — delete it by hand, or a later claim on #${number} reads a succession that no longer applies.`,
-					notes,
+					[...notes, ...freed.notes],
 				)
-			: answer(JSON.stringify({answer: "released", number, adopted: adopt.adopted}), notes);
+			: answer(
+					JSON.stringify({
+						answer: "released",
+						number,
+						adopted: adopt.adopted,
+						freed: freed.branch,
+					}),
+					[...notes, ...freed.notes],
+				);
+	});
+
+/**
+ * Detach this tree's HEAD when it is standing on the branch of the lane just released — the cheap
+ * complement half of the #6610 ruling (ADR 0323).
+ *
+ * A lane that ends normally leaks no pin this way, so `build retire` is left for the trees a killed
+ * session leaves behind rather than being the ordinary route. Detaching is enough and is all that is
+ * done: the commit is unchanged, an uncommitted edit carries over, and the branch keeps existing —
+ * what goes is only the checkout that made `branch --resume-lane` refuse.
+ *
+ * **Never fatal.** The claim comments are already retracted by the time this runs, so refusing here
+ * would report a failure over work that had finished.
+ */
+const freeLaneBranch = (
+	number: number,
+	nonce: string,
+): Effect.Effect<
+	{readonly branch: string | null; readonly notes: ReadonlyArray<string>},
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const held = yield* currentBranch;
+		if (held._tag === "Failure") {
+			return {
+				branch: null,
+				notes: [
+					`${RELEASE}: the claim was retracted; this tree's branch could not be read (${held.reason}), so nothing was detached.`,
+				],
+			};
+		}
+		const name = held.value;
+		if (name === null) return {branch: null, notes: []};
+		const lane = parseLaneBranch(name);
+		if (lane === null || laneNumber(lane) !== number || lane.nonce !== nonce) {
+			return {branch: null, notes: []};
+		}
+		const detached = yield* detachHead;
+		return detached._tag === "Failure"
+			? {
+					branch: null,
+					notes: [
+						`${RELEASE}: the claim was retracted and this tree still holds ${name}: ${detached.reason} — a later repair round on #${number} will need "fabrika build retire ${number}".`,
+					],
+				}
+			: {
+					branch: name,
+					notes: [
+						`${RELEASE}: detached this tree's HEAD, freeing ${name} — a later repair lane can resume it (ADR 0323).`,
+					],
+				};
 	});
 
 const ADOPT = "build adopt";

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -1,6 +1,14 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	once,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import {ROADMAP_FILE} from "../triage/roadmap.ts";
 import {FAILED} from "../verb.ts";
 import {runAdopt, runClaim, runConfirm, runRelease} from "./claim-verb.ts";
@@ -33,7 +41,9 @@ import {
 	LANE_UUID,
 	marker,
 	NO_BLOCKERS,
+	NONCE,
 	NOT_FOUND,
+	SIBLING_NONCE,
 	SIBLING_TOKEN,
 	SIBLING_UUID,
 	served,
@@ -47,6 +57,8 @@ const POST = /^POST \S+\/repos\/o\/r\/issues\/4312\/comments/;
 const GET_COMMENT = /^GET \S+\/repos\/o\/r\/issues\/comments\/9001$/;
 const DELETE = /^DELETE \S+\/repos\/o\/r\/issues\/comments\//;
 const perm = (login: string) => new RegExp(`^GET \\S+/repos/o/r/collaborators/${login}/permission`);
+const SHOW_CURRENT = /^git branch --show-current$/;
+const DETACH = /^git switch --detach$/;
 
 /** The two permissions the ACL answers with: one authorizes a marker, the other does not. */
 const WRITES = served({permission: "write"});
@@ -1106,10 +1118,63 @@ describe("runRelease", () => {
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(0);
-		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312});
+		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312, freed: null});
 		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
 			"DELETE https://api.github.com/repos/o/r/issues/comments/9001",
 		]);
+	});
+
+	// The complement half of the #6610 ruling (ADR 0323): a lane that ends normally frees the branch
+	// on its way out, so the pin `build branch --resume-lane` refuses on never forms in the first
+	// place. Detaching is the whole act — the branch survives, and so does anything uncommitted.
+	it("detaches this tree's HEAD when the tree is standing on the released lane's own branch", async () => {
+		const shell = unblocked([
+			[ISSUE, CLAIMABLE],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
+			[SHOW_CURRENT, okOut(`build/4312-editor-focus-loss-${NONCE}\n`)],
+			[DETACH, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).freed).toBe(`build/4312-editor-focus-loss-${NONCE}`);
+		expect(shell.calls).toContain("git switch --detach");
+	});
+
+	it("detaches nothing when this tree stands on another lane's branch", async () => {
+		const shell = unblocked([
+			[ISSUE, CLAIMABLE],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
+			[SHOW_CURRENT, okOut(`build/4312-editor-focus-loss-${SIBLING_NONCE}\n`)],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).freed).toBeNull();
+		expect(shell.calls.some((line) => DETACH.test(line))).toBe(false);
+	});
+
+	it("reports a failed detach and stays exit 0 — the claim is already retracted by then", async () => {
+		const shell = unblocked([
+			[ISSUE, CLAIMABLE],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), WRITES],
+			[DELETE, NO_CONTENT],
+			[SHOW_CURRENT, okOut(`build/4312-editor-focus-loss-${NONCE}\n`)],
+			[DETACH, errOut("index.lock exists")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).freed).toBeNull();
+		expect(out.stderr.join("\n")).toMatch(/fabrika build retire 4312/);
 	});
 
 	it("refuses to release another lane's claim on 15, and deletes nothing", async () => {
@@ -1452,7 +1517,12 @@ describe("runAdopt / succession", () => {
 			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
 		);
 		expect(out.code).toBe(0);
-		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312, adopted: DEAD});
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "released",
+			number: 4312,
+			adopted: DEAD,
+			freed: null,
+		});
 		expect(shell.requests.filter((line) => DELETE.test(line))).toEqual([
 			"DELETE https://api.github.com/repos/o/r/issues/comments/8000",
 			"DELETE https://api.github.com/repos/o/r/issues/comments/8100",

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -187,3 +187,13 @@ export const PRIOR_BUILD_MISMATCH = 31;
  * never reaches this axis.
  */
 export const NO_ACCEPTANCE_CRITERIA = 32;
+/**
+ * Proven: a working tree still holds this number's lane branch, and the board licenses no release.
+ *
+ * A *proven* refusal about the board — the ticket is not terminal and no authorized adopt marker
+ * says the holding lane's session is gone (ADR 0323) — so it never borrows
+ * {@link PRECONDITION_UNKNOWN}, which is for a read that failed. Its own seat rather than
+ * {@link WRONG_LANE}'s: `14` says *you* are standing in the wrong tree, and this says another tree
+ * is standing where you need to be, with the board declining to move it.
+ */
+export const WORKTREE_HELD = 33;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -35,6 +35,7 @@ import {runNote} from "./note-verb.ts";
 import {runPick} from "./pick-verb.ts";
 import {runPr, runPrBody} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
+import {runRetire} from "./retire-verb.ts";
 import {
 	ADMISSION_EXIT_CODES,
 	CITATION_GRAMMAR,
@@ -248,7 +249,20 @@ const release = leafCommand(
 ).pipe(
 	Command.withShortDescription("Retract this session's own claim marker."),
 	Command.withDescription(
-		'Retract this LANE\'s OWN claim marker, and only its own — --token says which lane that is. Prints {"answer":"released","number":n}. Exits 1 (CLAUDE_CODE_SESSION_ID unset, or --token is not a claim token of this session), 7 (issue proven absent or closed), 8 (the retraction failed — UNKNOWN), 11 (the marker set could not be read), 15 (this lane holds no claim — refusing to release another lane\'s). Example: fabrika build release 4312 --token build:s-9f2e:c1a4d6f8-…',
+		'Retract this LANE\'s OWN claim marker, and only its own — --token says which lane that is. It then frees this tree\'s checkout when the tree is standing on the released lane\'s own branch: HEAD is detached at the commit it already holds, so the branch stays and the pin that refuses a later "build branch --resume-lane" never forms (ADR 0323). The branch is reported as "freed"; a tree on any other branch, and a detach that fails, are both reported and neither is fatal — the claim is already retracted by then. Prints {"answer":"released","number":n,"freed":"<branch>"|null}. Exits 1 (CLAUDE_CODE_SESSION_ID unset, or --token is not a claim token of this session), 7 (issue proven absent or closed), 8 (the retraction failed — UNKNOWN), 11 (the marker set could not be read), 15 (this lane holds no claim — refusing to release another lane\'s). Example: fabrika build release 4312 --token build:s-9f2e:c1a4d6f8-…',
+	),
+);
+
+const retire = leafCommand(
+	"retire",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runRetire({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Take back the checkout an orphaned build worktree is holding."),
+	Command.withDescription(
+		'Retire the working trees of this clone that hold #<n>\'s lane branch, so a repair lane refused at "build branch --resume-lane" can stand where it needs to (ADR 0323). Two licenses, both written positive board states and never an inference from a tree that looks idle: the ticket is TERMINAL (a closed issue, a merged PR), or an authorized ADR 0295 build-adopt marker on #<n> names the session whose claim carries that branch\'s lane nonce. DIRTINESS IS NOT A REFUSAL — an agent routinely leaves a worktree dirty after its ticket merged — and it costs nobody their only copy either: ADR 0321\'s salvage runs first, committing whatever the tree holds uncommitted onto its own branch, and only then is the tree removed WITHOUT --force, which that ADR bans on every path. A removal that still refuses (a locked tree does, however clean) is reported as an incident to file, never overridden. The removal takes the tree, never the branch. It first prunes registrations whose directory is already gone, never removes the tree the run is standing in, and reads every removal back off a second worktree list. A worktree-isolated caller may run it — the harness rule that refuses a typed cross-worktree git does not bind a verb\'s own child process. Prints {"answer":"retired"|"held"|"none","number":n,"retired":[…],"held":[…]}. Exits 7 (#<n> proven absent), 8 (the salvage or the removal failed — UNKNOWN), 9 (git reported a removal and the registration survives), 11 (a precondition read failed), 33 (a tree still holds the branch and the board licenses no release). Example: fabrika build retire 6567',
 	),
 );
 
@@ -689,6 +703,7 @@ export const buildCommand = Command.make("build").pipe(
 		claimants,
 		release,
 		adopt,
+		retire,
 		issue,
 		branch,
 		scratch,

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -122,6 +122,78 @@ export const worktreeCheckouts: Shell<Attempt<ReadonlyArray<WorktreeCheckout>>> 
 	},
 );
 
+/**
+ * Drop the registrations whose working directory is gone — git's own definition of a stale record.
+ *
+ * It asks nothing of the board and needs nothing from it: a pruned record has no directory, so there
+ * is no tree holding work and no session whose fate anyone has to attest to. That keeps it outside
+ * ADR 0295's licensing question rather than an exception to it.
+ */
+export const pruneWorktrees: Shell<Attempt<void>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["worktree", "prune"]);
+	return r.ok ? ok<void>(undefined) : fail(r.reason);
+});
+
+/** How many paths another worktree has uncommitted — `0` is a clean tree, salvage-free. */
+export const worktreeDirtyPaths = (path: string): Shell<Attempt<number>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["-C", path, "status", "--porcelain"]);
+		if (!r.ok) return fail(r.reason);
+		return ok(r.stdout.split("\n").filter((line) => line.trim() !== "").length);
+	});
+
+/**
+ * Commit everything another worktree holds onto the branch it is standing on — ADR 0321's salvage.
+ *
+ * The uncommitted work in a dead spawn's tree is the only copy of what it was doing, so it is
+ * preserved before the tree goes rather than weighed: that is what lets a retirement ignore
+ * dirtiness (ADR 0323) without the removal being the thing that destroys the record.
+ *
+ * `--no-verify` because the hooks are this repo's contribution gate and a salvage is not a
+ * contribution — a formatter rewriting a dying spawn's half-written file, or a guard refusing it,
+ * loses exactly the bytes being rescued.
+ */
+export const salvageWorktree = (path: string, message: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const staged = yield* execCapture("git", ["-C", path, "add", "--all"]);
+		if (!staged.ok) return fail(staged.reason);
+		const committed = yield* execCaptureInput(
+			"git",
+			["-C", path, "commit", "--no-verify", "--cleanup=verbatim", "-F", "-"],
+			message,
+		);
+		return committed.ok ? ok<void>(undefined) : fail(committed.reason);
+	});
+
+/**
+ * Remove one worktree and its registration — **never with `--force`**, which ADR 0321 bans on every
+ * path for every tree.
+ *
+ * A remove that refuses after the salvage means something in that tree is unaccounted for, and the
+ * caller reports that rather than overriding it. The recurring instance measured against git 2.40.1
+ * is a *locked* tree, which answers `cannot remove a locked working tree` however clean it is; the
+ * agent harness locks the trees it registers, so that refusal is the one a caller must name in full.
+ *
+ * **The branch survives** — removal frees the checkout, it does not delete the ref. That is the
+ * whole point: the repair lane refused at `branch --resume-lane` needs exactly that branch.
+ */
+export const removeWorktree = (path: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["worktree", "remove", path]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/**
+ * Detach this tree's HEAD at the commit it already holds, freeing the branch name it was holding.
+ *
+ * The content is untouched — same commit, and an uncommitted edit carries over — so a lane may do
+ * this at its terminal without deciding anything about work still in the tree.
+ */
+export const detachHead: Shell<Attempt<void>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["switch", "--detach"]);
+	return r.ok ? ok<void>(undefined) : fail(r.reason);
+});
+
 /** The branch this tree holds, or `null` when its HEAD is detached. */
 export const currentBranch: Shell<Attempt<string | null>> = Effect.gen(function* () {
 	const r = yield* execCapture("git", ["branch", "--show-current"]);

--- a/packages/fabrika-cli/src/build/retire-verb.ts
+++ b/packages/fabrika-cli/src/build/retire-verb.ts
@@ -1,0 +1,324 @@
+/**
+ * `build retire` — take back the checkout an orphaned build worktree is holding, when the board
+ * licenses it.
+ *
+ * The residue this clears is #6610: a session dies mid-round, its worktree stays registered holding
+ * the lane branch, and `build branch --resume-lane` then refuses on `11` rather than rename the
+ * branch out from under a live checkout. Nothing inside the loop could clear it, so every such round
+ * ended as a human park on a cleanup carrying no judgment.
+ *
+ * The order is the contract:
+ *
+ *   1. `git worktree prune` drops registrations whose directory is already gone.
+ *   2. The worktrees holding this number's lane branches are read (`./git.ts`), and the tree this
+ *      process is standing in is excluded — a checkout cannot be pulled out from under its own run.
+ *   3. The board is read once: the ticket's state, and the ACL-checked claim and adopt markers.
+ *   4. {@link classify} seats each subject. **Nothing is removed on a `Hold`**, and a read that
+ *      failed refuses on `11` rather than resolve to either verdict.
+ *   5. Each released tree is **salvaged then removed**, in ADR 0321's order and under its ban on
+ *      `--force`: uncommitted work goes onto the tree's own branch first, so ignoring dirtiness
+ *      costs nobody their only copy, and a removal that still refuses is reported for a human.
+ *   6. Every removal is read back off a second `worktree list` — a removal this verb reports is one
+ *      it proved, never one `git` exited 0 on.
+ *
+ * It removes the tree and leaves the branch: the repair lane the pin refused needs exactly that ref.
+ *
+ * **A worktree-isolated caller may run this**, which is what moved ADR 0321's obligation off the
+ * primary-checkout driver: the harness rule that refused a cross-worktree `git` reads the typed
+ * command, so it binds a shell and not a verb's own child process (measured on #6610).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue} from "../io/issues.ts";
+import {getPullRequest} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {readClaimants} from "./claim.ts";
+import {
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WORKTREE_HELD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	pruneWorktrees,
+	removeWorktree,
+	salvageWorktree,
+	worktreeCheckouts,
+	worktreeDirtyPaths,
+} from "./git.ts";
+import {type BoardState, classify, type Subject, sessionsByNonce, subjectsFor} from "./retire.ts";
+import {badNumber, resolveTargetRepo, scannedLine} from "./target.ts";
+import {readTree} from "./tree.ts";
+
+const VERB = "fabrika build retire";
+
+export interface RetireOptions {
+	/** The number whose lane branches are held — the child issue, or the PR a repair lane resumed. */
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+type Deps = ChildProcessSpawner.ChildProcessSpawner;
+
+type Board =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Board"; readonly board: BoardState};
+
+export const runRetire = (options: RetireOptions): Effect.Effect<VerbOutcome, never, Deps> =>
+	Effect.gen(function* () {
+		const {number} = options;
+		const bad = badNumber(VERB, "an issue or pull request number", number);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {repo} = resolved;
+
+		const pruned = yield* pruneWorktrees;
+		if (pruned._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot prune this clone's worktree registrations: ${pruned.reason} — which trees hold #${number}'s lane branch is UNKNOWN.`,
+			);
+		}
+
+		const held = yield* subjects(number);
+		if (held._tag === "Refused") return held.outcome;
+		const scope = scannedLine(VERB, held.scanned, "working tree", `#${number}`);
+		if (held.subjects.length === 0) {
+			return answer(JSON.stringify({answer: "none", number, retired: [], held: []}), [
+				scope,
+				`${VERB}: no working tree of this clone holds a lane branch for #${number}.`,
+			]);
+		}
+
+		const read = yield* board(repo, number);
+		if (read._tag === "Refused") return read.outcome;
+
+		const self = yield* readTree;
+		if (self._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read this run's own tree root: ${self.reason} — which tree is this one is UNKNOWN, and a run that cannot recognise itself must remove nothing.`,
+				[scope],
+			);
+		}
+		const selfPaths = new Set([self.value.root]);
+		const verdicts = held.subjects.map((subject) => ({
+			subject,
+			verdict: classify(subject, read.board, selfPaths),
+		}));
+
+		const retired: Array<{
+			path: string;
+			branch: string;
+			license: string;
+			salvaged: boolean;
+		}> = [];
+		for (const {subject, verdict} of verdicts) {
+			if (verdict._tag !== "Release") continue;
+			const salvaged = yield* salvage(subject);
+			if (salvaged._tag === "Refused") return salvaged.outcome;
+			const removed = yield* removeWorktree(subject.path);
+			if (removed._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: git refused to remove ${subject.path}: ${removed.reason} — ADR 0321 bans --force on every path, so this is an incident to file (/report), not an override. ${retired.length} tree(s) were retired before it.`,
+					[scope],
+				);
+			}
+			retired.push({
+				path: subject.path,
+				branch: subject.branch,
+				license: verdict.license,
+				salvaged: salvaged.salvaged,
+			});
+		}
+
+		if (retired.length > 0) {
+			const after = yield* worktreeCheckouts;
+			if (after._tag === "Failure") {
+				return refuse(
+					READBACK_MISMATCH,
+					`${VERB}: ${retired.length} tree(s) were removed and the registrations could not be read back: ${after.reason} — the retirement is NOT proven.`,
+					[scope],
+				);
+			}
+			const survivor = retired.find((row) =>
+				after.value.some((checkout) => checkout.path === row.path),
+			);
+			if (survivor !== undefined) {
+				return refuse(
+					READBACK_MISMATCH,
+					`${VERB}: git reported ${survivor.path} removed and it is still registered — the retirement is NOT proven, and this clone needs a human.`,
+					[scope],
+				);
+			}
+		}
+
+		const holding = verdicts.flatMap(({subject, verdict}) =>
+			verdict._tag === "Release" ? [] : [{subject, verdict}],
+		);
+		const notes = [
+			scope,
+			...retired.map(
+				(row) =>
+					`${VERB}: retired ${row.path} — it held ${row.branch} (${row.license})${row.salvaged ? `; its uncommitted work was salvaged onto ${row.branch} first` : ""}.`,
+			),
+			...holding.map(
+				({subject, verdict}) =>
+					`${VERB}: ${subject.path} still holds ${subject.branch} — ${verdict._tag === "Self" ? "it is the tree this run is standing in, which no run may remove from inside" : verdict.because}.`,
+			),
+		];
+		const payload = {
+			answer: retired.length > 0 ? "retired" : "held",
+			number,
+			retired,
+			held: holding.map(({subject, verdict}) => ({
+				path: subject.path,
+				branch: subject.branch,
+				reason: verdict._tag === "Self" ? "self" : verdict.because,
+			})),
+		};
+		return holding.length > 0 && retired.length === 0
+			? refuse(
+					WORKTREE_HELD,
+					`${VERB}: the board licenses no release of #${number}'s lane branch — nothing was removed.`,
+					notes,
+				)
+			: answer(JSON.stringify(payload), notes);
+	});
+
+type Salvaged =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Salvaged"; readonly salvaged: boolean};
+
+/**
+ * ADR 0321's first step: whatever the tree holds uncommitted goes onto its own branch before the
+ * tree goes.
+ *
+ * This is what makes dirtiness a non-question rather than a tolerated risk (ADR 0323): the ruling
+ * that a dirty tree is still retired and the rule that a removal must not destroy a dying spawn's
+ * only copy are the same act, in this order. A read that fails salvages nothing and removes nothing.
+ */
+const salvage = (subject: Subject): Effect.Effect<Salvaged, never, Deps> =>
+	Effect.gen(function* () {
+		const dirty = yield* worktreeDirtyPaths(subject.path);
+		if (dirty._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read whether ${subject.path} holds uncommitted work: ${dirty.reason} — nothing was salvaged and nothing was removed.`,
+				),
+			};
+		}
+		if (dirty.value === 0) return {_tag: "Salvaged" as const, salvaged: false};
+		const committed = yield* salvageWorktree(
+			subject.path,
+			`wip: salvage ${dirty.value} uncommitted path(s) from a retired worktree (${subject.branch})\n`,
+		);
+		return committed._tag === "Failure"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						WRITE_UNKNOWN,
+						`${VERB}: cannot salvage ${dirty.value} uncommitted path(s) in ${subject.path}: ${committed.reason} — the tree is left standing, because removing it would destroy the only copy (ADR 0321).`,
+					),
+				}
+			: {_tag: "Salvaged" as const, salvaged: true};
+	});
+
+type Held =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {
+			readonly _tag: "Held";
+			readonly subjects: ReadonlyArray<Subject>;
+			readonly scanned: number;
+	  };
+
+const subjects = (number: number): Effect.Effect<Held, never, Deps> =>
+	Effect.gen(function* () {
+		const checkouts = yield* worktreeCheckouts;
+		if (checkouts._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read which working tree holds what: ${checkouts.reason} — whether one holds #${number}'s lane branch is UNKNOWN.`,
+				),
+			};
+		}
+		return {
+			_tag: "Held" as const,
+			subjects: subjectsFor(number, checkouts.value),
+			scanned: checkouts.value.length,
+		};
+	});
+
+/**
+ * The board's two answers about `number`, in one read each.
+ *
+ * A pull request's terminal state is `merged`, never `closed`: a PR closed unmerged can be reopened
+ * onto the same head, so treating it as terminal would retire a tree whose work is still live. An
+ * issue's is `closed` — the state its own children's builds end in.
+ */
+const board = (repo: string, number: number): Effect.Effect<Board, never, Deps> =>
+	Effect.gen(function* () {
+		const no = (code: number, reason: string): Board => ({
+			_tag: "Refused",
+			outcome: refuse(code, reason),
+		});
+
+		const found = yield* getIssue(repo, number);
+		if (found._tag === "Absent") {
+			return no(
+				ZERO_SCOPE,
+				`${VERB}: #${number} is proven absent — there is no board state to license a release with.`,
+			);
+		}
+		if (found._tag === "Unknown") {
+			return no(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${number}: ${found.reason} — whether its ticket is terminal is UNKNOWN, never "terminal".`,
+			);
+		}
+
+		let terminal = found.value.state === "closed";
+		let describe = terminal ? "is closed" : "is open";
+		if (found.value.isPullRequest) {
+			const pull = yield* getPullRequest(repo, number);
+			if (pull._tag !== "Present") {
+				return no(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: #${number} is a pull request and could not be read as one${pull._tag === "Unknown" ? `: ${pull.reason}` : ""} — whether it merged is UNKNOWN.`,
+				);
+			}
+			terminal = pull.value.merged;
+			describe = terminal
+				? "is merged"
+				: `is a pull request that has not merged (${pull.value.state})`;
+		}
+
+		const claimants = yield* readClaimants(repo, number);
+		if (claimants._tag === "Unknown") {
+			return no(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the claim markers on #${number}: ${claimants.reason} — whether a holding session was adopted is UNKNOWN, never "not adopted".`,
+			);
+		}
+
+		return {
+			_tag: "Board",
+			board: {
+				terminal,
+				describe,
+				adoptedSessions: claimants.adopts
+					.filter((adopt) => adopt.authorized)
+					.map((adopt) => adopt.adopted),
+				sessionByNonce: sessionsByNonce(claimants.claimants),
+			},
+		};
+	});

--- a/packages/fabrika-cli/src/build/retire-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/retire-verb.unit.test.ts
@@ -1,0 +1,362 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
+import {
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WORKTREE_HELD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	adoptMarker,
+	comments,
+	GH_TOKEN_ENV,
+	issue,
+	LANE_UUID,
+	marker,
+	NONCE,
+	NOT_FOUND,
+	pull,
+	served,
+} from "./fixtures.test-support.ts";
+import {runRetire} from "./retire-verb.ts";
+
+const PRUNE = /^git worktree prune$/;
+const TREES = /^git worktree list --porcelain$/;
+const REMOVE = /^git worktree remove /;
+const STATUS = /^git -C \S+ status --porcelain$/;
+const ADD = /^git -C \S+ add --all$/;
+const SALVAGE = /^git -C \S+ commit --no-verify/;
+const SELF = /^git rev-parse --path-format=absolute/;
+
+/**
+ * A clean tree needs no salvage — the common case, appended LAST so a test scripting a dirty one
+ * wins over it (the fakes resolve by first match).
+ */
+const CLEAN: ReadonlyArray<Scripted> = [[STATUS, okOut("")]];
+const ISSUE = /^GET \S+\/repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
+const WRITE = served({permission: "write"});
+
+const BRANCH = `build/4312-editor-focus-loss-${NONCE}`;
+const ORPHAN = "/trees/agent-a9bd";
+const HERE = "/trees/agent-self";
+
+const options = {
+	number: 4312,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", ...GH_TOKEN_ENV} as Record<string, string | undefined>,
+};
+
+/** `git worktree list --porcelain`, as blocks of `worktree`/`HEAD`/`branch` lines. */
+const trees = (...held: ReadonlyArray<{path: string; branch: string}>) =>
+	okOut(
+		held
+			.map((tree) => `worktree ${tree.path}\nHEAD 0000000\nbranch refs/heads/${tree.branch}\n`)
+			.join("\n"),
+	);
+
+/** What `git rev-parse` names for THIS run's checkout — the tree no retirement may remove. */
+const here = okOut([`${HERE}/.git`, HERE].join("\n"));
+
+const run = (script: ReadonlyArray<Scripted>) => {
+	const shell = fakeSeams([...script, ...CLEAN]);
+	return Effect.runPromise(Effect.provide(runRetire(options), shell.layer)).then((out) => ({
+		out,
+		calls: shell.calls,
+	}));
+};
+
+/** The board with one authorized claim marker on #4312 and no adopt — the ordinary live lane. */
+const CLAIMED: ReadonlyArray<Scripted> = [
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, WRITE],
+];
+
+describe("runRetire — the terminal-ticket license", () => {
+	it("retires the tree holding the branch of a closed issue and reads the removal back", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[REMOVE, okOut("")],
+			[TREES, trees()],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "retired",
+			number: 4312,
+			retired: [{path: ORPHAN, branch: BRANCH, license: "ticket-terminal", salvaged: false}],
+			held: [],
+		});
+		expect(calls).toContain(`git worktree remove ${ORPHAN}`);
+	});
+
+	it("removes WITHOUT --force on any path — ADR 0321 bans it for every tree", async () => {
+		const {calls} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[REMOVE, okOut("")],
+			[TREES, trees()],
+		]);
+
+		expect(calls.filter((line) => REMOVE.test(line))).toEqual([`git worktree remove ${ORPHAN}`]);
+		expect(calls.some((line) => line.includes("--force"))).toBe(false);
+	});
+
+	it("holds a pull request's tree until the PR MERGED — a closed-unmerged PR can reopen", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: `build/pr-4312-${NONCE}`})],
+			[ISSUE, issue({state: "closed", pull_request: {url: "…"}})],
+			[/^GET \S+\/repos\/o\/r\/pulls\/4312$/, pull({state: "closed", merged: false})],
+			...CLAIMED,
+			[SELF, here],
+		]);
+
+		expect(out.code).toBe(WORKTREE_HELD);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+
+	it("retires a merged pull request's tree", async () => {
+		const {out} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: `build/pr-4312-${NONCE}`})],
+			[ISSUE, issue({state: "closed", pull_request: {url: "…"}})],
+			[/^GET \S+\/repos\/o\/r\/pulls\/4312$/, pull({state: "closed", merged: true})],
+			...CLAIMED,
+			[SELF, here],
+			[REMOVE, okOut("")],
+			[TREES, trees()],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).retired).toHaveLength(1);
+	});
+});
+
+describe("runRetire — the adopted-session license", () => {
+	it("retires the tree when an authorized adopt on the number names the holding lane's session", async () => {
+		const {out} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue()],
+			[
+				COMMENTS,
+				comments(
+					{id: 1, body: marker("s-9f2e", LANE_UUID)},
+					{id: 2, body: adoptMarker("s-9f2e", "s-next", LANE_UUID)},
+				),
+			],
+			[PERM, WRITE],
+			[SELF, here],
+			[REMOVE, okOut("")],
+			[TREES, trees()],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).retired).toMatchObject([{license: "session-adopted"}]);
+	});
+
+	it("counts no adopt from an account below write — content is not authority (ADR 0055)", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue()],
+			[
+				COMMENTS,
+				comments(
+					{id: 1, body: marker("s-9f2e", LANE_UUID)},
+					{id: 2, body: adoptMarker("s-9f2e", "s-next", LANE_UUID), author: "drive-by"},
+				),
+			],
+			[PERM, WRITE],
+			[/collaborators\/drive-by\/permission/, served({permission: "read"})],
+			[SELF, here],
+		]);
+
+		expect(out.code).toBe(WORKTREE_HELD);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+});
+
+describe("runRetire — what it refuses to touch", () => {
+	it("never removes the tree this run is standing in, however terminal the ticket", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: HERE, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+		]);
+
+		expect(out.code).toBe(WORKTREE_HELD);
+		expect(out.stderr.join("\n")).toMatch(/the tree this run is standing in/);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+
+	it("answers none — never a refusal — when no tree holds the number's lane branch", async () => {
+		const {out} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/repo", branch: "main"})],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "none", retired: [], held: []});
+	});
+
+	it("is ZERO_SCOPE on a number the board proves absent — there is nothing to license a release", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, NOT_FOUND],
+		]);
+
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when the claim markers cannot be read — never 'not adopted'", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue()],
+			[COMMENTS, {status: 502, body: '{"message":"Bad gateway"}'}],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toMatch(/never "not adopted"/);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when this run cannot recognise its own tree — it must remove nothing then", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, errOut("not a git repository")],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+});
+
+describe("runRetire — ADR 0321's salvage runs before the tree goes", () => {
+	it("commits a dirty tree's work onto its own branch, then removes it", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[STATUS, okOut(" M worker/app.ts\n?? notes.md\n")],
+			[ADD, okOut("")],
+			[SALVAGE, okOut("")],
+			[REMOVE, okOut("")],
+			[TREES, trees()],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).retired).toMatchObject([{salvaged: true}]);
+		expect(calls.findIndex((line) => SALVAGE.test(line))).toBeLessThan(
+			calls.findIndex((line) => REMOVE.test(line)),
+		);
+	});
+
+	it("commits nothing in a clean tree", async () => {
+		const {calls} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[REMOVE, okOut("")],
+			[TREES, trees()],
+		]);
+
+		expect(calls.some((line) => SALVAGE.test(line))).toBe(false);
+	});
+
+	it("leaves the tree standing when the salvage fails — removing it would destroy the only copy", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[STATUS, okOut(" M worker/app.ts\n")],
+			[ADD, okOut("")],
+			[SALVAGE, errOut("cannot commit on a detached HEAD with no changes staged")],
+		]);
+
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when the tree's own status cannot be read — it salvages and removes nothing", async () => {
+		const {out, calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[STATUS, errOut("not a git repository")],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+});
+
+describe("runRetire — the removal is proven, never reported", () => {
+	it("reports a refused removal as an incident rather than overriding it with --force", async () => {
+		const {out} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[REMOVE, errOut("cannot remove a locked working tree")],
+		]);
+
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toMatch(/ADR 0321 bans --force/);
+	});
+
+	it("is READBACK_MISMATCH when git exits 0 and the registration survives", async () => {
+		const {out} = await run([
+			[PRUNE, okOut("")],
+			[once(TREES), trees({path: ORPHAN, branch: BRANCH})],
+			[ISSUE, issue({state: "closed"})],
+			...CLAIMED,
+			[SELF, here],
+			[REMOVE, okOut("")],
+			[TREES, trees({path: ORPHAN, branch: BRANCH})],
+		]);
+
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.join("\n")).toMatch(/still registered/);
+	});
+
+	it("prunes the registrations whose directory is gone before it reads which trees hold what", async () => {
+		const {calls} = await run([
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/repo", branch: "main"})],
+		]);
+
+		expect(calls.findIndex((line) => PRUNE.test(line))).toBeLessThan(
+			calls.findIndex((line) => TREES.test(line)),
+		);
+	});
+});

--- a/packages/fabrika-cli/src/build/retire.ts
+++ b/packages/fabrika-cli/src/build/retire.ts
@@ -1,0 +1,119 @@
+/**
+ * The release predicate `build retire` turns on: may this worktree's checkout be taken from it?
+ *
+ * Pure, and separated from the verb because the whole ruling on #6610 lives here — the two licenses
+ * are board-attested positive statements, and neither is an inference from a tree that looks idle
+ * (ADR 0323, which is why ADR [0215](../../../../.decisions/0215-claim-identity-continuity-proof.md)
+ * §5's ban on eviction-by-inference is satisfied rather than widened).
+ *
+ * **Dirty is not an input.** The founder's ruling rejects it explicitly: agents routinely leave a
+ * worktree dirty long after its ticket merged, so dirtiness is a false negative for "work in
+ * progress" and reading it would keep the deadlock in the case that most needs clearing.
+ */
+
+import {type LaneBranch, laneNumber, nonceOf, parseLaneBranch} from "./lane.ts";
+
+/** One worktree of this clone that holds a build lane branch. */
+export interface Subject {
+	readonly path: string;
+	readonly branch: string;
+	readonly lane: LaneBranch;
+}
+
+/** The subjects among `checkouts` whose branch is a lane branch claimed under `number`. */
+export const subjectsFor = (
+	number: number,
+	checkouts: ReadonlyArray<{readonly path: string; readonly branch: string}>,
+): ReadonlyArray<Subject> =>
+	checkouts.flatMap((checkout) => {
+		const lane = parseLaneBranch(checkout.branch);
+		return lane === null || laneNumber(lane) !== number
+			? []
+			: [{path: checkout.path, branch: checkout.branch, lane}];
+	});
+
+/**
+ * What the board says about the number a lane branch carries.
+ *
+ * `terminal` is the *ticket* reaching its end — a closed issue, a merged pull request — and it is
+ * read off the board rather than derived from anything local. `adoptedSessions` are the sessions an
+ * **authorized** ADR 0295 adopt marker on this number declares gone; `sessionByNonce` maps each
+ * authorized claim marker's lane nonce to the session that took it, which is the only link from a
+ * branch name back to a session.
+ */
+export interface BoardState {
+	readonly terminal: boolean;
+	/** What the board state is, in one clause a refusal or an answer can quote. */
+	readonly describe: string;
+	readonly adoptedSessions: ReadonlyArray<string>;
+	readonly sessionByNonce: Readonly<Record<string, string>>;
+}
+
+/** Why a worktree may be retired. Two constructors, because there are exactly two licenses. */
+export type License = "ticket-terminal" | "session-adopted";
+
+export type Verdict =
+	| {readonly _tag: "Release"; readonly license: License; readonly because: string}
+	| {readonly _tag: "Hold"; readonly because: string}
+	/** This is the tree the verb is running in — git refuses to remove it, and so does this. */
+	| {readonly _tag: "Self"};
+
+/**
+ * Seat one subject against the board.
+ *
+ * The self arm comes first because it is not a licensing question at all: a process cannot pull the
+ * checkout out from under itself, and a verdict that said it could would be a refusal git makes
+ * anyway, one step later and with a worse message.
+ */
+export const classify = (
+	subject: Subject,
+	board: BoardState,
+	selfPaths: ReadonlySet<string>,
+): Verdict => {
+	if (selfPaths.has(subject.path)) return {_tag: "Self"};
+	if (board.terminal) {
+		return {
+			_tag: "Release",
+			license: "ticket-terminal",
+			because: `#${laneNumber(subject.lane)} ${board.describe}`,
+		};
+	}
+	const session = board.sessionByNonce[subject.lane.nonce];
+	if (session !== undefined && board.adoptedSessions.includes(session)) {
+		return {
+			_tag: "Release",
+			license: "session-adopted",
+			because: `session ${session} holds this lane's claim and an authorized build-adopt marker on #${laneNumber(subject.lane)} declares it gone`,
+		};
+	}
+	return {
+		_tag: "Hold",
+		because:
+			session === undefined
+				? `#${laneNumber(subject.lane)} ${board.describe}, and no authorized claim marker on it carries this branch's lane nonce — nothing on the board says its session is gone`
+				: `#${laneNumber(subject.lane)} ${board.describe}, and no authorized build-adopt marker on it names session ${session}`,
+	};
+};
+
+/**
+ * The lane nonce an authorized claim marker's token confers, paired with the session that took it.
+ *
+ * Later markers do not overwrite earlier ones: the earliest authorized marker is the holder every
+ * other ownership question resolves against (`./claim.ts`), and a retirement must key on the same
+ * one rather than on whoever posted last.
+ */
+export const sessionsByNonce = (
+	markers: ReadonlyArray<{
+		readonly token: string;
+		readonly session: string;
+		readonly authorized: boolean;
+	}>,
+): Readonly<Record<string, string>> => {
+	const byNonce: Record<string, string> = {};
+	for (const marker of markers) {
+		if (!marker.authorized) continue;
+		const nonce = nonceOf(marker.token);
+		if (nonce !== null && byNonce[nonce] === undefined) byNonce[nonce] = marker.session;
+	}
+	return byNonce;
+};

--- a/packages/fabrika-cli/src/build/retire.unit.test.ts
+++ b/packages/fabrika-cli/src/build/retire.unit.test.ts
@@ -1,0 +1,140 @@
+import {describe, expect, it} from "vitest";
+import {LANE_TOKEN, NONCE, SIBLING_NONCE, SIBLING_TOKEN} from "./fixtures.test-support.ts";
+import {type BoardState, classify, sessionsByNonce, subjectsFor} from "./retire.ts";
+
+const BRANCH = `build/4312-editor-focus-loss-${NONCE}`;
+const PATH = "/trees/agent-a9bd";
+
+const subject = (branch = BRANCH, path = PATH) => {
+	const [only] = subjectsFor(4312, [{path, branch}]);
+	if (only === undefined) throw new Error(`${branch} is not a lane branch for #4312`);
+	return only;
+};
+
+const board = (overrides: Partial<BoardState> = {}): BoardState => ({
+	terminal: false,
+	describe: "is open",
+	adoptedSessions: [],
+	sessionByNonce: {},
+	...overrides,
+});
+
+const NOBODY = new Set<string>();
+
+describe("subjectsFor", () => {
+	it("keeps the worktrees holding a lane branch of the number, in either lane mode", () => {
+		const held = subjectsFor(4312, [
+			{path: "/a", branch: BRANCH},
+			{path: "/b", branch: `build/pr-4312-${SIBLING_NONCE}`},
+		]);
+
+		expect(held.map((s) => s.path)).toEqual(["/a", "/b"]);
+	});
+
+	it("keeps no worktree on another number's lane branch, or on no lane branch at all", () => {
+		const held = subjectsFor(4312, [
+			{path: "/a", branch: `build/4313-other-work-${NONCE}`},
+			{path: "/b", branch: "main"},
+			{path: "/c", branch: "worktree-agent-a9bd"},
+		]);
+
+		expect(held).toEqual([]);
+	});
+});
+
+describe("classify — the terminal-ticket license", () => {
+	it("releases a worktree whose ticket is terminal", () => {
+		const verdict = classify(subject(), board({terminal: true, describe: "is closed"}), NOBODY);
+
+		expect(verdict).toMatchObject({_tag: "Release", license: "ticket-terminal"});
+	});
+
+	it("releases a terminal ticket's worktree WITHOUT reading dirtiness — dirty is not a refusal", () => {
+		// The founder's ruling on #6610: an agent routinely leaves a worktree dirty after its ticket
+		// merged, so dirtiness is a false negative for "work in progress". The predicate takes no
+		// dirtiness input at all, which is what makes that unrepresentable rather than merely unused.
+		expect(Object.keys(board())).not.toContain("dirty");
+		expect(
+			classify(subject(), board({terminal: true, describe: "is merged"}), NOBODY),
+		).toMatchObject({_tag: "Release", license: "ticket-terminal"});
+	});
+
+	it("holds a worktree whose ticket is not terminal, and says what the board reads", () => {
+		const verdict = classify(subject(), board(), NOBODY);
+
+		expect(verdict._tag).toBe("Hold");
+		expect(verdict._tag === "Hold" && verdict.because).toMatch(/#4312 is open/);
+	});
+});
+
+describe("classify — the adopted-session license", () => {
+	it("releases when an authorized adopt names the session whose claim carries this branch's nonce", () => {
+		const verdict = classify(
+			subject(),
+			board({adoptedSessions: ["s-9f2e"], sessionByNonce: {[NONCE]: "s-9f2e"}}),
+			NOBODY,
+		);
+
+		expect(verdict).toMatchObject({_tag: "Release", license: "session-adopted"});
+	});
+
+	it("holds when the adopt names a different session than this branch's lane took", () => {
+		const verdict = classify(
+			subject(),
+			board({adoptedSessions: ["s-other"], sessionByNonce: {[NONCE]: "s-9f2e"}}),
+			NOBODY,
+		);
+
+		expect(verdict._tag).toBe("Hold");
+		expect(verdict._tag === "Hold" && verdict.because).toMatch(/names session s-9f2e/);
+	});
+
+	it("holds when no claim marker on the board carries this branch's nonce — absence licenses nothing", () => {
+		const verdict = classify(
+			subject(),
+			board({adoptedSessions: ["s-9f2e"], sessionByNonce: {[SIBLING_NONCE]: "s-9f2e"}}),
+			NOBODY,
+		);
+
+		expect(verdict._tag).toBe("Hold");
+		expect(verdict._tag === "Hold" && verdict.because).toMatch(/no authorized claim marker/);
+	});
+});
+
+describe("classify — the tree this run is standing in", () => {
+	it("is Self even when the board would license it, so no run removes itself", () => {
+		const verdict = classify(
+			subject(),
+			board({terminal: true, describe: "is closed"}),
+			new Set([PATH]),
+		);
+
+		expect(verdict).toEqual({_tag: "Self"});
+	});
+});
+
+describe("sessionsByNonce", () => {
+	it("maps an authorized marker's lane nonce to the session that took it", () => {
+		const map = sessionsByNonce([
+			{token: LANE_TOKEN, session: "s-9f2e", authorized: true},
+			{token: SIBLING_TOKEN, session: "s-9f2e", authorized: true},
+		]);
+
+		expect(map).toEqual({[NONCE]: "s-9f2e", [SIBLING_NONCE]: "s-9f2e"});
+	});
+
+	it("counts no unauthorized marker — content is not authority (ADR 0055)", () => {
+		expect(sessionsByNonce([{token: LANE_TOKEN, session: "s-9f2e", authorized: false}])).toEqual(
+			{},
+		);
+	});
+
+	it("keeps the EARLIEST authorized marker's session on a nonce, as every other reader does", () => {
+		const map = sessionsByNonce([
+			{token: LANE_TOKEN, session: "s-first", authorized: true},
+			{token: LANE_TOKEN, session: "s-later", authorized: true},
+		]);
+
+		expect(map).toEqual({[NONCE]: "s-first"});
+	});
+});

--- a/packages/fabrika-cli/src/recipe/parks.ts
+++ b/packages/fabrika-cli/src/recipe/parks.ts
@@ -34,6 +34,16 @@ export interface ParkRecipe {
 	readonly cause: string | null;
 	/** The read whose answer decides whether the park's cause is gone. */
 	readonly clearance: Clearance;
+	/**
+	 * The verb the clearance runs to remove the park's cause before re-reading, or `null` for a
+	 * clearance that only waits on somebody else.
+	 *
+	 * A row naming one is a row that clears itself: `branch-free` sat at exit 13 forever without one,
+	 * because reading whether a tree still holds the branch cannot make it stop (#6610). A row naming
+	 * `null` is deliberate, not unfinished — `cp-approval` waits on a human's judgment, and a recipe
+	 * that "removed" that cause would be granting the approval.
+	 */
+	readonly remedy: string | null;
 	/** What the park is waiting on, in one clause a refusal can quote. */
 	readonly waitingOn: string;
 }
@@ -46,19 +56,24 @@ export interface ParkRecipe {
  * second reading of it here would be the drift #2435 closed. `blocked` + `worktree-holds-branch` is
  * the #6395 shape, and its clearance is the inverse of the very read that refuses the build:
  * `build branch --resume-lane` refuses while a working tree holds the child's lane branch, so the
- * park is clear exactly when no working tree holds it.
+ * park is clear exactly when no working tree holds it — and since #6610 the clearance first runs
+ * `build retire`, which takes that checkout back when the board licenses it (ADR 0323). Without the
+ * remedy the row read the pin and could never remove it, so every lane parked on this cause sat at
+ * exit 13 until a human ran `git worktree remove` by hand.
  */
 export const KNOWN_PARKS: ReadonlyArray<ParkRecipe> = [
 	{
 		park: "human:cp-approval",
 		cause: null,
 		clearance: "cp-approval",
+		remedy: null,
 		waitingOn: "a control-plane approval at the PR's current head",
 	},
 	{
 		park: "blocked",
 		cause: "worktree-holds-branch",
 		clearance: "branch-free",
+		remedy: "fabrika build retire",
 		waitingOn: "the working tree holding this build's lane branch to be removed",
 	},
 ];

--- a/packages/fabrika-cli/src/recipe/relay.ts
+++ b/packages/fabrika-cli/src/recipe/relay.ts
@@ -11,6 +11,10 @@
  * type-level fact rather than a number two files agree about by luck.
  */
 import {
+	READBACK_MISMATCH as BUILD_READBACK_MISMATCH,
+	WRITE_UNKNOWN as BUILD_WRITE_UNKNOWN,
+} from "../build/codes.ts";
+import {
 	LANE_ABSENT,
 	APPEND_UNKNOWN as LANE_APPEND_UNKNOWN,
 	EVENT_REFUSED as LANE_EVENT_REFUSED,
@@ -23,6 +27,7 @@ import {refuse, type VerbOutcome} from "../verb.ts";
 import {
 	MALFORMED_RECORD,
 	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
 	TARGET_ABSENT,
 	TASK_UNRESOLVED,
 	UNPARK_REFUSED,
@@ -52,6 +57,27 @@ export const laneExit = (code: number): number => {
 			return UNPARK_REFUSED;
 		case LANE_TASK_UNKNOWN:
 			return TASK_UNRESOLVED;
+		default:
+			return PRECONDITION_UNKNOWN;
+	}
+};
+
+/**
+ * This group's seat for a `build` verb's refusal — today, `build retire`'s.
+ *
+ * Only the two write-side facts carry across, and they carry because both tables import the same
+ * base constant for them: a removal whose outcome is unproven and a removal contradicted by its
+ * read-back mean here exactly what they mean there. Everything else is
+ * {@link PRECONDITION_UNKNOWN}, including `build`'s own proven refusals: `7` says a *number* is
+ * absent, which is not this group's "no lane at this ref", and re-seating it as one would report a
+ * missing issue as a missing lane.
+ */
+export const buildExit = (code: number): number => {
+	switch (code) {
+		case BUILD_WRITE_UNKNOWN:
+			return WRITE_UNKNOWN;
+		case BUILD_READBACK_MISMATCH:
+			return READBACK_MISMATCH;
 		default:
 			return PRECONDITION_UNKNOWN;
 	}

--- a/packages/fabrika-cli/src/recipe/unpark-verb.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.ts
@@ -19,8 +19,10 @@
  */
 import {Effect, type FileSystem, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
+import {WORKTREE_HELD} from "../build/codes.ts";
 import {worktreeCheckouts} from "../build/git.ts";
 import {childLaneBranches} from "../build/lane.ts";
+import {runRetire} from "../build/retire-verb.ts";
 import {localBranches} from "../io/git.ts";
 import {isRecord, parseJson} from "../io/json.ts";
 import {openPullsClosing} from "../io/pulls.ts";
@@ -38,7 +40,7 @@ import {
 	TASK_UNRESOLVED,
 } from "./codes.ts";
 import {classifyPark, type ParkRecipe} from "./parks.ts";
-import {laneExit, relayRefusal} from "./relay.ts";
+import {buildExit, laneExit, relayRefusal} from "./relay.ts";
 import {clearProof, issueOf, leafOf} from "./status-read.ts";
 import {openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 
@@ -334,8 +336,30 @@ const clearBranchFree = (
 				),
 			);
 		}
-		const held = checkouts.value.filter((checkout) => candidates.includes(checkout.branch));
+		let held = checkouts.value.filter((checkout) => candidates.includes(checkout.branch));
 		const scope = scannedLine(VERB, checkouts.value.length, "working tree", candidates.join(", "));
+		let retired = 0;
+		if (held.length > 0 && recipe.remedy !== null) {
+			const retire = yield* runRetire({number: issue, repo: options.repo, env: options.env});
+			// `33` is the retirement proving the board licenses none, which is this recipe's own hold
+			// rather than a fault — the re-read below reports it in the recipe's words.
+			if (retire.code !== 0 && retire.code !== WORKTREE_HELD) {
+				return no(relayRefusal(VERB, `${recipe.remedy} ${issue}`, retire, buildExit(retire.code)));
+			}
+			const after = yield* worktreeCheckouts;
+			if (after._tag === "Failure") {
+				return no(
+					refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot re-read which working tree holds ${candidates.join(", ")} after the retirement: ${after.reason} — the park's cause is UNKNOWN, never cleared.`,
+						[scope],
+					),
+				);
+			}
+			retired = held.length;
+			held = after.value.filter((checkout) => candidates.includes(checkout.branch));
+			retired -= held.length;
+		}
 		if (held.length > 0) {
 			return no(
 				refuse(
@@ -343,10 +367,18 @@ const clearBranchFree = (
 					`${VERB}: "${recipe.park}" still waits on ${recipe.waitingOn} — ${held
 						.map((checkout) => `${checkout.branch} is checked out in ${checkout.path}`)
 						.join("; ")}; nothing was written.`,
-					[scope],
+					retired === 0
+						? [scope]
+						: [scope, `${VERB}: ${retired} working tree(s) were retired, and these still hold.`],
 				),
 			);
 		}
 
-		return {_tag: "Cleared", mechanism: `branch-free:${candidates.join(",")}`};
+		return {
+			_tag: "Cleared",
+			mechanism:
+				retired === 0
+					? `branch-free:${candidates.join(",")}`
+					: `branch-free:${candidates.join(",")} (retired ${retired} working tree(s))`,
+		};
 	});

--- a/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
@@ -1,6 +1,14 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
+import {
+	errOut,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	okOut,
+	once,
+	type Scripted,
+} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {CODEOWNERS, ENV, files, HEAD, pull} from "../ship/fixtures.test-support.ts";
 import {
@@ -39,6 +47,24 @@ const ROSTER = /orgs\/kamp-us\/teams\/control-plane\/members/;
 const REVIEWS = /\/repos\/o\/r\/pulls\/4321\/reviews/;
 const BRANCHES = /^git for-each-ref/;
 const TREES = /^git worktree list/;
+const PRUNE = /^git worktree prune$/;
+const REMOVE = /^git worktree remove /;
+const STATUS = /^git -C \S+ status --porcelain$/;
+const SELF = /^git rev-parse --path-format=absolute/;
+const LANE_ISSUE = new RegExp(`^GET \\S+/repos/o/r/issues/${LANE}$`);
+const LANE_COMMENTS = new RegExp(`^GET \\S+/repos/o/r/issues/${LANE}/comments`);
+
+/** What `build retire` reads the park's number as — an open issue, so only a closed one licenses. */
+const openIssue = {
+	number: Number(LANE),
+	title: "the lane's issue",
+	body: "",
+	state: "open",
+	labels: [],
+	html_url: `https://github.com/o/r/issues/${LANE}`,
+	milestone: null,
+	state_reason: null,
+};
 
 /** The shared payload fixtures speak `gh`'s `ExecResult`; the seam now serves the same bytes. */
 const reply = (result: ExecResult, status = 200): HttpReply => ({status, body: result.stdout});
@@ -140,17 +166,54 @@ describe("recipe unpark — a BLOCKED park clears on its cause (#6480)", () => {
 		expect(fs.written.get(LOG)).toMatch(/ISSUE\.UNBLOCKED/);
 	});
 
-	it("is PARK_HOLDS while a working tree still holds the branch, naming that tree", async () => {
+	it("is PARK_HOLDS while a working tree holds the branch and the board licenses no retirement", async () => {
 		const fs = lane(PARKED_ON_WORKTREE);
 
-		const out = await run(fs, [
-			[BRANCHES, branchList(LANE_BRANCH)],
-			[TREES, worktreeList({path: "/trees/agent-a9bd", branch: LANE_BRANCH})],
-		]);
+		const out = await run(
+			fs,
+			[
+				[BRANCHES, branchList(LANE_BRANCH)],
+				[TREES, worktreeList({path: "/trees/agent-a9bd", branch: LANE_BRANCH})],
+				[PRUNE, okOut("")],
+				[SELF, okOut(["/repo/.git", "/repo"].join("\n"))],
+			],
+			[
+				[LANE_ISSUE, {status: 200, body: JSON.stringify(openIssue)}],
+				[LANE_COMMENTS, {status: 200, body: "[]"}],
+			],
+		);
 
 		expect(out.code).toBe(PARK_HOLDS);
 		expect(out.stderr.join("\n")).toMatch(/\/trees\/agent-a9bd/);
 		expect(fs.written.size).toBe(0);
+	});
+
+	// The routing half of #6610: the row names `fabrika build retire`, so a park whose only cause is a
+	// stale registration clears without a human running `git worktree remove` by hand.
+	it("clears the park by retiring the holding tree when the board licenses it", async () => {
+		const fs = lane(PARKED_ON_WORKTREE);
+
+		const out = await run(
+			fs,
+			[
+				[BRANCHES, branchList(LANE_BRANCH)],
+				[once(TREES), worktreeList({path: "/trees/agent-a9bd", branch: LANE_BRANCH})],
+				[PRUNE, okOut("")],
+				[once(TREES), worktreeList({path: "/trees/agent-a9bd", branch: LANE_BRANCH})],
+				[SELF, okOut(["/repo/.git", "/repo"].join("\n"))],
+				[STATUS, okOut("")],
+				[REMOVE, okOut("")],
+				[TREES, worktreeList()],
+			],
+			[
+				[LANE_ISSUE, {status: 200, body: JSON.stringify({...openIssue, state: "closed"})}],
+				[LANE_COMMENTS, {status: 200, body: "[]"}],
+			],
+		);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).mechanism).toMatch(/retired 1 working tree/);
+		expect(fs.written.get(LOG)).toMatch(/ISSUE\.UNBLOCKED/);
 	});
 
 	it("is TARGET_ABSENT in a clone that never cut the branch — never a clear on an absent read", async () => {


### PR DESCRIPTION
Fixes #6610.

Retires the worktree that pins a build lane's branch, so a repair round stops parking on a cleanup nobody could do.

A registered worktree holding `#n`'s lane branch refuses the next `build branch --resume-lane` on exit `11` — correctly, since `git branch -m` would rename the branch out from under that checkout instead of failing. Nothing inside the loop could clear it, so the park routed to a human every time.

**`fabrika build retire <n>`** takes the checkout back on one of two written board states, and never on a tree that looks idle:

- `ticket-terminal` — the number is closed, or its PR merged (a PR closed unmerged is not terminal; it can reopen).
- `session-adopted` — an authorized ADR 0295 adopt marker on `#n` names the session whose claim carries that branch's lane nonce.

Dirtiness is not an input to the predicate at all. It costs nobody their only copy either: ADR 0321's salvage runs first, committing the tree's uncommitted work onto its own branch, and only then is the tree removed **without `--force`**, which 0321 bans. A removal that still refuses is reported as an incident, never overridden.

Two smaller halves: `build release` now detaches its own tree's HEAD when standing on the released lane's branch, so a normally-ending lane never forms the pin; and the `blocked` + `worktree-holds-branch` recipe row names its remedy, so `recipe unpark` runs the retirement before re-reading rather than sitting at exit 13.

**Run live from this isolated worktree**, against git 2.40.1: a dirty tree on a closed issue's lane branch was salvaged (`wip: salvage 1 uncommitted path(s) …`), removed, and the branch survived; the same tree locked refused on exit 8 naming the ban. That run also answers the issue's falsifiable question — a typed `git -C <other tree>` is refused by the harness, a verb's own child process running the same command is not.

ADR 0323 records the ruling, and amends ADR 0321's actor constraint in part on 0321's own stated terms.

## Deviations

- **Governing-ADR departure** — **Said:** the #6610 ruling says release a licensed worktree "dirty or not", and criterion 5 asks that a parked lane clear through `recipe unpark` without a human running `git worktree remove` by hand. **Did:** removals pass no `--force`, so a *locked* worktree is reported rather than retired, and the harness locks most trees it registers — which leaves the locked majority still needing a human. **Why:** ADR 0321 landed a day after that ruling and bans `git worktree remove --force` on every path for every tree; a builder does not narrow a day-old constraint to make its own criterion pass. **Disposition:** stated here, and the keyword stays `Fixes` — the locked-tree half is outside #6610's seven acceptance criteria, all of which this PR meets, so closing the issue is correct. The gap is filed as https://github.com/kamp-us/phoenix/issues/6881 for a founder ruling on whether `git worktree unlock` before a plain remove is inside the ban, and it is named in ADR 0323's Consequences.
- **Out-of-scope change** — **Said:** #6610 names the verb, the complement, the parks row and the ADR. **Did:** also rewrote `operate` SKILL.md's fourth residue obligation and flipped ADR 0321's status line. **Why:** the skill told a driver to do this cleanup by hand as the primary checkout's job, which the verb and ADR 0323 now contradict; leaving it would ship a doc that argues with the code it describes. **Disposition:** stated here.
