### PR TITLE
fix: lane prove accepts a `Part of #N` PR but lane brief refuses it, so the lane deadlocks at review

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -298,8 +298,9 @@ Open it yourself; no shell owns this branch. Its body carries two
 things, neither of them a summary you compose:
 
 - **one closing reference per child that has landed so far**, plus one on the epic issue itself.
-  The epic's is what makes the PR findable at all — `lane brief` resolves the tail's PR through
-  GitHub's closing-issue edge on the epic, and without it every tail dispatch refuses with exit
+  The epic's is what makes the PR findable at all — `lane brief` resolves the tail's PR through the
+  same nominator `lane prove` uses (GitHub's closing-issue edge unioned with a body search), and a
+  body naming the epic on neither refuses every tail dispatch with exit
   `20`. The children's are what make all of them close at the single merge, which is how ADR
   [0131](../../../../.decisions/0131-epic-autoclose-on-all-children-closed.md)'s auto-close reads
   under this shape: it fires on the GitHub edge after the merge, never mid-lane;
@@ -323,8 +324,8 @@ node strategy classifies on the subject alone: an untyped one is unroutable and 
 is hidden, either way dropping every package change the epic carried from the notes (#6754; incident
 #5771 is the same rule for builder PRs, derived in
 [`pr-title.ts`](../../../../packages/fabrika-cli/src/build/pr-title.ts)). `feat` is the shown type an
-epic earns by construction. `lane brief` still resolves the tail's PR through the closing-issue edge,
-not the title:
+epic earns by construction. `lane brief` still resolves the tail's PR through the body's links, not
+the title:
 
 ```bash
 gh pr create --draft --head epic/$lane_key \

--- a/packages/fabrika-cli/src/governance/head.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/head.unit.test.ts
@@ -10,6 +10,7 @@ const PULL_RECORD = {
 	state: "open",
 	headSha: HEAD,
 	body: "",
+	htmlUrl: "https://github.com/o/r/pull/4321",
 	changedFiles: 2,
 	comments: 0,
 	draft: false,

--- a/packages/fabrika-cli/src/io/pulls.ts
+++ b/packages/fabrika-cli/src/io/pulls.ts
@@ -35,6 +35,8 @@ export interface PullRecord {
 	readonly state: string;
 	readonly headSha: string;
 	readonly body: string;
+	/** The PR's own page — the link a `lane brief` hands a shell, empty when the board published none. */
+	readonly htmlUrl: string;
 	/** What the platform says the PR changes — the denominator every completeness proof divides by. */
 	readonly changedFiles: number;
 	/** Issue comments on the PR, as the platform counts them. The verdict sweep's denominator. */
@@ -66,6 +68,7 @@ const toPullRecord = (value: unknown): PullRecord | null => {
 		state,
 		headSha,
 		body: typeof body === "string" ? body : "",
+		htmlUrl: typeof value.html_url === "string" ? value.html_url : "",
 		changedFiles,
 		comments: typeof comments === "number" ? comments : 0,
 		draft: value.draft === true,

--- a/packages/fabrika-cli/src/lane/brief-verb.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.ts
@@ -24,7 +24,6 @@ import {Effect, type FileSystem, Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import type {EntrypointRead} from "../delegate/entrypoint.ts";
 import {getIssue, resolveRepo} from "../io/issues.ts";
-import {openPullsClosing} from "../io/pulls.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	type ArtifactUrl,
@@ -52,7 +51,8 @@ import {
 	TASK_UNKNOWN,
 } from "./codes.ts";
 import {foldLog, resolveTask} from "./fold.ts";
-import {epicOf, issueOf} from "./prove.ts";
+import {nominateOpenPulls, nominationScope} from "./nominate.ts";
+import {epicOf, issueOf, tracePulls} from "./prove.ts";
 import {locateRange, type RangeLocation} from "./range.ts";
 import {loadRefusal, replayRefusal} from "./refusals.ts";
 import {type LaneRef, loadLane} from "./store.ts";
@@ -291,31 +291,35 @@ export const runBrief = (
 			]);
 		}
 
-		const pulls = yield* openPullsClosing(repo.value, issue);
-		if (pulls._tag === "Failure") {
+		const nominated = yield* nominateOpenPulls(repo.value, issue);
+		if (nominated._tag === "Unreadable") {
 			return refuse(
 				LANE_UNREADABLE,
-				`${VERB}: cannot read the open PRs declaring they close #${issue}: ${pulls.reason} — UNKNOWN.`,
+				`${VERB}: cannot read ${nominated.what}: ${nominated.reason} — UNKNOWN.`,
 				notes,
 			);
 		}
-		const [only, ...rest] = pulls.value;
-		if (rest.length > 0) {
+		const traced = tracePulls(issue, nominated.pulls);
+		if (traced._tag === "Many") {
 			return refuse(
 				PR_AMBIGUOUS,
-				`${VERB}: ${pulls.value.length} open PRs declare they close #${issue} — exactly one is the lane's, and which is not this verb's to guess.`,
-				[...notes, `${VERB}: candidates: ${pulls.value.map((p) => `#${p.number}`).join(", ")}.`],
+				`${VERB}: ${traced.prs.length} open PRs link #${issue} — exactly one is the lane's, and which is not this verb's to guess.`,
+				[...notes, `${VERB}: candidates: ${traced.prs.map((pr) => `#${pr}`).join(", ")}.`],
 			);
 		}
-		if (only === undefined && !isBuildState(state)) {
+		if (traced._tag === "None" && !isBuildState(state)) {
 			return refuse(
 				PR_AMBIGUOUS,
-				`${VERB}: no open PR declares it closes #${issue}, and a "${state}" shell has nothing to read without one.`,
+				`${VERB}: ${traced.why} across ${nominationScope(issue)}, and a "${state}" shell has nothing to read without one.`,
 				notes,
 			);
 		}
-		const prUrl = only === undefined ? null : artifactUrl(only.url);
-		if (only !== undefined && prUrl === null) {
+		const only =
+			traced._tag === "One"
+				? (nominated.pulls.find((pull) => pull.number === traced.pr) ?? null)
+				: null;
+		const prUrl = only === null ? null : artifactUrl(only.htmlUrl);
+		if (only !== null && prUrl === null) {
 			return refuse(
 				LANE_UNREADABLE,
 				`${VERB}: the board published no URL for PR #${only.number} — the ground is UNKNOWN.`,

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -69,6 +69,46 @@ const closingPulls = (...rows: ReadonlyArray<readonly [number, string]>): HttpRe
 	}),
 });
 
+/** The search index's nomination envelope — candidate numbers, never a proof (`searchOpenPulls`). */
+const nominated = (...numbers: ReadonlyArray<number>): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({total_count: numbers.length, items: numbers.map((number) => ({number}))}),
+});
+
+/** Nothing nominated by the body half, so the union answers off the closing edge alone. */
+const NO_NOMINATIONS: Scripted = [/^GET .*\/search\/issues\?/, nominated()];
+
+const pullPayload = (number: number, url: string, body: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number,
+		state: "open",
+		head: {sha: "6ba0a4e2ff5e4f6b9e2b0e4b1f7cf50b7b6a3d21"},
+		base: {ref: "main"},
+		body,
+		changed_files: 1,
+		comments: 0,
+		html_url: url,
+	}),
+});
+
+/**
+ * The nominator's reads for one issue: the closing edge, plus each candidate's own record — the
+ * body is what `tracePulls` matches on, so a candidate the edge names still has to link the issue.
+ */
+const linked = (
+	issue: number,
+	...rows: ReadonlyArray<readonly [number, string]>
+): ReadonlyArray<Scripted> => [
+	[PR_CLOSERS, closingPulls(...rows)],
+	...rows.map(
+		([number, url]): Scripted => [
+			new RegExp(`^GET .*/repos/o/r/pulls/${number}$`),
+			pullPayload(number, url, `Fixes #${issue}\n`),
+		],
+	),
+];
+
 /**
  * A single-issue lane at `lane`, with one log line per operator event already recorded. `classes`
  * rides the first event, which is where a UI-class lane's own routing is decided.
@@ -184,7 +224,8 @@ const run = (
 	Effect.runPromise(
 		Effect.provide(
 			runBrief({...options, ...overrides}),
-			Layer.merge(fs.layer, fakeSeams(script).layer),
+			// The body half is tailed, so a test scripting its own wins the seam's first-match lookup.
+			Layer.merge(fs.layer, fakeSeams([...script, NO_NOMINATIONS]).layer),
 		),
 	);
 
@@ -207,7 +248,7 @@ describe("lane brief", () => {
 	it("briefs the reviewer on a `review` state, carrying the one open PR that traces to the issue", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_CLOSERS, closingPulls([5790, PR_URL])],
+			...linked(5751, [5790, PR_URL]),
 		]);
 
 		expect(out.code).toBe(0);
@@ -238,7 +279,7 @@ describe("lane brief", () => {
 	it("briefs the ui-reviewer shell on a `review:ui` state, over the same one PR", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE", "PASS"], ["ui"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_CLOSERS, closingPulls([5790, PR_URL])],
+			...linked(5751, [5790, PR_URL]),
 		]);
 
 		expect(out.code).toBe(0);
@@ -251,7 +292,7 @@ describe("lane brief", () => {
 	it("prints a single-issue brief byte for byte — the format's bytes, nothing per dispatch", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_CLOSERS, closingPulls([5790, PR_URL])],
+			...linked(5751, [5790, PR_URL]),
 		]);
 
 		expect(out.stdout).toBe(
@@ -298,7 +339,7 @@ describe("lane brief", () => {
 	it("briefs the shipper on a `ship` state", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE", "PASS"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_CLOSERS, closingPulls([5790, PR_URL])],
+			...linked(5751, [5790, PR_URL]),
 		]);
 
 		expect(out.code).toBe(0);
@@ -311,7 +352,7 @@ describe("lane brief", () => {
 	it("carries URLs only — no title, no body, no verdict text", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_CLOSERS, closingPulls([5790, PR_URL])],
+			...linked(5751, [5790, PR_URL]),
 		]);
 
 		expect(out.stdout).not.toContain(TITLE);
@@ -455,10 +496,41 @@ describe("lane brief", () => {
 		expect(out.stdout).toBe("");
 	});
 
+	it("resolves a `Part of #5751` PR the closing edge cannot see — the lane-5981 shape (#6179)", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_CLOSERS, closingPulls()],
+			[/^GET .*\/search\/issues\?/, nominated(5790)],
+			[/^GET .*\/repos\/o\/r\/pulls\/5790$/, pullPayload(5790, PR_URL, "Part of #5751.\n")],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(readBrief(out.stdout)).toMatchObject({
+			_tag: "Found",
+			value: {state: "review", shell: "reviewer", ground: {_tag: "Pull", pr: PR_URL}},
+		});
+	});
+
+	it("refuses two PRs the body search alone nominated, both linking the issue", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_CLOSERS, closingPulls()],
+			[/^GET .*\/search\/issues\?/, nominated(5790, 5791)],
+			[/^GET .*\/repos\/o\/r\/pulls\/5790$/, pullPayload(5790, PR_URL, "Part of #5751.\n")],
+			[
+				/^GET .*\/repos\/o\/r\/pulls\/5791$/,
+				pullPayload(5791, "https://github.com/o/r/pull/5791", "Part of #5751.\n"),
+			],
+		]);
+
+		expect(out.code).toBe(PR_AMBIGUOUS);
+		expect(out.stderr.join("\n")).toContain("#5790, #5791");
+	});
+
 	it("refuses several open PRs, naming every candidate", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_CLOSERS, closingPulls([5790, PR_URL], [5791, "https://github.com/o/r/pull/5791"])],
+			...linked(5751, [5790, PR_URL], [5791, "https://github.com/o/r/pull/5791"]),
 		]);
 
 		expect(out.code).toBe(PR_AMBIGUOUS);
@@ -466,7 +538,7 @@ describe("lane brief", () => {
 		expect(out.stderr.join("\n")).toContain("#5791");
 	});
 
-	it("refuses zero open PRs where the state needs one", async () => {
+	it("refuses zero open PRs where the state needs one, naming the whole union it searched", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE", "PASS"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
 			[PR_CLOSERS, closingPulls()],
@@ -474,6 +546,7 @@ describe("lane brief", () => {
 
 		expect(out.code).toBe(PR_AMBIGUOUS);
 		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("the closing-issue edge and the open PRs whose body");
 	});
 });
 
@@ -483,7 +556,7 @@ describe("lane brief on an epic lane", () => {
 		script: ReadonlyArray<Scripted>,
 		overrides: Partial<typeof options>,
 	) => {
-		const seams = fakeSeams(script);
+		const seams = fakeSeams([...script, NO_NOMINATIONS]);
 		const out = await Effect.runPromise(
 			Effect.provide(
 				runBrief({...options, lane: String(EPIC), ...overrides}),
@@ -602,10 +675,7 @@ describe("lane brief on an epic lane", () => {
 				["issue_5828", "DONE"],
 				["issue_5828", "PASS"],
 			]),
-			[
-				[EPIC_ISSUE_READ, issuePayload(EPIC, EPIC_URL)],
-				[PR_CLOSERS, closingPulls([5890, PR_URL])],
-			],
+			[[EPIC_ISSUE_READ, issuePayload(EPIC, EPIC_URL)], ...linked(EPIC, [5890, PR_URL])],
 			{task: "epic_5800"},
 		);
 
@@ -652,7 +722,7 @@ describe("lane brief on an epic lane", () => {
 			]),
 			[
 				[EPIC_ISSUE_READ, issuePayload(EPIC, EPIC_URL)],
-				[PR_CLOSERS, closingPulls([5890, PR_URL], [5891, "https://github.com/o/r/pull/5891"])],
+				...linked(EPIC, [5890, PR_URL], [5891, "https://github.com/o/r/pull/5891"]),
 			],
 			{task: "epic_5800"},
 		);

--- a/packages/fabrika-cli/src/lane/nominate.ts
+++ b/packages/fabrika-cli/src/lane/nominate.ts
@@ -1,0 +1,78 @@
+/**
+ * The one place a lane verb asks "which open PR is this issue's".
+ *
+ * Two nomination reads, unioned, because neither alone answers the question. The closing-issue edge
+ * (`openPullsClosing`) is authoritative and lag-free but blind to `Part of #N`, the shape
+ * `build --partial` emits and the shape a builder writes when it honestly declines to close its
+ * issue; the search index sees any body but lags a fresh PR. Reading the edge first means a lagging
+ * index can only fail to add a candidate, never hide the closing one.
+ *
+ * Both reads only nominate; the body's links decide, through `issueRefsOf` and the set membership
+ * `tracePulls` applies (#6797). A candidate that has closed since it was nominated, or that only
+ * mentions the number in prose, drops out here rather than counting — so unioning in the looser read
+ * widens candidates without widening what counts.
+ *
+ * **Why it is shared rather than copied.** `lane prove` unioned both reads while `lane brief` read
+ * the edge alone, so a `Part of #N` PR proved a `DONE`, folded the lane to `review`, and then had no
+ * reviewer dispatchable against it — a park no event could clear, because the divergence was a
+ * property of the artifact and restoring the state restored the wall (#6179). Two verbs answering
+ * one question have to answer it from one nominator.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getPullRequest, openPullsClosing, searchOpenPulls} from "../io/pulls.ts";
+import {issueRefsOf} from "../review/classes.ts";
+import type {PullFact} from "./prove.ts";
+
+/** One nominated PR, read off the board: the trace's facts plus the link a brief hands on. */
+export interface NominatedPull extends PullFact {
+	readonly htmlUrl: string;
+}
+
+export type Nomination =
+	| {readonly _tag: "Nominated"; readonly pulls: ReadonlyArray<NominatedPull>}
+	/** A read that did not answer — never an empty candidate set, which is a different fact. */
+	| {readonly _tag: "Unreadable"; readonly what: string; readonly reason: string};
+
+/** What the union searched, for a refusal that has to name its own scope rather than half of it. */
+export const nominationScope = (issue: number): string =>
+	`the closing-issue edge and the open PRs whose body names #${issue}`;
+
+export const nominateOpenPulls = (
+	repo: string,
+	issue: number,
+): Effect.Effect<Nomination, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const closing = yield* openPullsClosing(repo, issue);
+		if (closing._tag === "Failure") {
+			return {
+				_tag: "Unreadable" as const,
+				what: `the open pull requests closing #${issue}`,
+				reason: closing.reason,
+			};
+		}
+		const found = yield* searchOpenPulls(repo, [`${issue}`, "in:body"]);
+		if (found._tag === "Failure") {
+			return {
+				_tag: "Unreadable" as const,
+				what: `the open pull requests mentioning #${issue}`,
+				reason: found.reason,
+			};
+		}
+		const candidates = new Set([...closing.value.map((pull) => pull.number), ...found.value]);
+		const pulls: NominatedPull[] = [];
+		for (const candidate of candidates) {
+			const pull = yield* getPullRequest(repo, candidate);
+			if (pull._tag === "Unknown") {
+				return {_tag: "Unreadable" as const, what: `PR #${candidate}`, reason: pull.reason};
+			}
+			if (pull._tag === "Absent") continue;
+			pulls.push({
+				number: pull.value.number,
+				open: pull.value.state === "open",
+				linkedIssues: issueRefsOf(pull.value.body).numbers,
+				htmlUrl: pull.value.htmlUrl,
+			});
+		}
+		return {_tag: "Nominated" as const, pulls};
+	});

--- a/packages/fabrika-cli/src/lane/nominate.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/nominate.unit.test.ts
@@ -1,0 +1,219 @@
+/**
+ * The shared candidate nominator, and the deadlock it was extracted to end (#6179): `lane prove`
+ * proving a `DONE` off a `Part of #N` PR that `lane brief` then refused to see.
+ */
+import {resolve} from "node:path";
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import type {EntrypointRead} from "../delegate/entrypoint.ts";
+import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
+import {RULES} from "../wire/lane-brief.ts";
+import {runBrief} from "./brief-verb.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {nominateOpenPulls} from "./nominate.ts";
+import {tracePulls} from "./prove.ts";
+import {runProve} from "./prove-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const ISSUE = 5751;
+const PR = 5790;
+const PR_URL = `https://github.com/o/r/pull/${PR}`;
+const ISSUE_URL = `https://github.com/o/r/issues/${ISSUE}`;
+const ENTRY = "/checkout/node_modules/@kampus/fabrika-cli/dist/bin.js";
+
+const CLOSERS = /^POST .*\/graphql$/;
+const SEARCH = /^GET .*\/search\/issues\?/;
+const PULL = new RegExp(`^GET .*/repos/o/r/pulls/${PR}$`);
+const ISSUE_READ = new RegExp(`^GET .*/repos/o/r/issues/${ISSUE}$`);
+
+const served = (payload: unknown): HttpReply => ({status: 200, body: JSON.stringify(payload)});
+
+const closingEdge = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served({
+		data: {
+			repository: {
+				issue: {
+					closedByPullRequestsReferences: {
+						pageInfo: {hasNextPage: false, endCursor: null},
+						nodes: numbers.map((number) => ({
+							number,
+							url: `https://github.com/o/r/pull/${number}`,
+							state: "OPEN",
+						})),
+					},
+				},
+			},
+		},
+	});
+
+const nominatedBy = (...numbers: ReadonlyArray<number>): HttpReply =>
+	served({total_count: numbers.length, items: numbers.map((number) => ({number}))});
+
+/** The lane-5981 / lane-6610 shape: an open PR that links the issue without closing it. */
+const partOfPull = served({
+	number: PR,
+	state: "open",
+	head: {sha: "6ba0a4e2ff5e4f6b9e2b0e4b1f7cf50b7b6a3d21"},
+	base: {ref: "main"},
+	body: `Part of #${ISSUE}.\n\n## Deviations\nNone.\n`,
+	changed_files: 1,
+	comments: 0,
+	html_url: PR_URL,
+});
+
+const issuePayload = served({
+	number: ISSUE,
+	title: "the two verbs disagree about which PR links the lane",
+	body: "## What is wrong\n\nThe lane deadlocks at review.",
+	state: "open",
+	labels: [{name: "type:bug"}],
+	html_url: ISSUE_URL,
+});
+
+/** One board, three ways of nominating the same PR — the fixture the two verbs have to agree over. */
+const shapes: ReadonlyArray<readonly [string, ReadonlyArray<Scripted>]> = [
+	[
+		"closing-edge-only",
+		[
+			[CLOSERS, closingEdge(PR)],
+			[SEARCH, nominatedBy()],
+			[PULL, partOfPull],
+		],
+	],
+	[
+		"body-search-only",
+		[
+			[CLOSERS, closingEdge()],
+			[SEARCH, nominatedBy(PR)],
+			[PULL, partOfPull],
+		],
+	],
+	[
+		"both",
+		[
+			[CLOSERS, closingEdge(PR)],
+			[SEARCH, nominatedBy(PR)],
+			[PULL, partOfPull],
+		],
+	],
+];
+
+const laneAt = (...events: ReadonlyArray<string>) =>
+	fakeFs({
+		files: {
+			[`${ROOT}/${ISSUE}/workflow.json`]: coderTemplateText(),
+			[`${ROOT}/${ISSUE}/events.jsonl`]: events
+				.map(
+					(event, index) =>
+						`${JSON.stringify({
+							task: "issue",
+							event: `ISSUE.${event}`,
+							at: `2026-08-21T0${index}:00:00Z`,
+						})}\n`,
+				)
+				.join(""),
+		},
+	});
+
+describe("the shared candidate nominator", () => {
+	for (const [shape, script] of shapes) {
+		it(`nominates the same one candidate from a ${shape} board`, async () => {
+			const nomination = await Effect.runPromise(
+				Effect.provide(nominateOpenPulls("o/r", ISSUE), fakeSeams(script).layer),
+			);
+
+			expect(nomination).toMatchObject({_tag: "Nominated"});
+			if (nomination._tag !== "Nominated") throw new Error("unreachable");
+			expect(nomination.pulls.map((pull) => pull.number)).toEqual([PR]);
+			expect(tracePulls(ISSUE, nomination.pulls)).toEqual({_tag: "One", pr: PR});
+			expect(nomination.pulls[0]?.htmlUrl).toBe(PR_URL);
+		});
+	}
+
+	it("is UNKNOWN rather than an empty set when the body search cannot be read", async () => {
+		const nomination = await Effect.runPromise(
+			Effect.provide(
+				nominateOpenPulls("o/r", ISSUE),
+				fakeSeams([
+					[CLOSERS, closingEdge()],
+					[SEARCH, {status: 502, body: '{"message":"Bad gateway"}'}],
+				]).layer,
+			),
+		);
+
+		expect(nomination._tag).toBe("Unreadable");
+	});
+});
+
+describe("the `Part of #N` sequence that used to deadlock (#6179)", () => {
+	/** The one board both verbs read, with the PR linking the issue through its body alone. */
+	const board: ReadonlyArray<Scripted> = [
+		[CLOSERS, closingEdge()],
+		[SEARCH, nominatedBy(PR)],
+		[PULL, partOfPull],
+		[ISSUE_READ, issuePayload],
+	];
+
+	it("proves the DONE, then briefs the reviewer on the same PR — no exit-20 refusal in between", async () => {
+		const proven = await Effect.runPromise(
+			Effect.provide(
+				runProve({
+					root: ROOT,
+					lane: String(ISSUE),
+					event: "DONE",
+					task: null,
+					classes: null,
+					repo: null,
+					cwd: "/repo",
+					env: {CLAUDE_PIPELINE_REPO: "o/r"},
+				}),
+				Layer.merge(laneAt("WIP").layer, fakeSeams(board).layer),
+			),
+		);
+
+		expect(proven.code).toBe(0);
+		expect(JSON.parse(proven.stdout)).toMatchObject({
+			proof: "proven",
+			evidence: {kind: "open-pull", pr: PR},
+		});
+
+		const briefed = await Effect.runPromise(
+			Effect.provide(
+				runBrief({
+					root: ROOT,
+					lane: String(ISSUE),
+					task: null,
+					repo: null,
+					env: {CLAUDE_PIPELINE_REPO: "o/r"},
+					entrypoint: {_tag: "Entrypoint", entrypoint: ENTRY} as EntrypointRead,
+				}),
+				Layer.merge(laneAt("WIP", "DONE").layer, fakeSeams(board).layer),
+			),
+		);
+
+		expect(briefed.code).toBe(0);
+		expect(briefed.stdout).toBe(
+			`## Task\nlane: ${ISSUE}\nroot: ${resolve(ROOT)}\nfabrika: ${ENTRY}\ntask: issue\nstate: review\nshell: reviewer\n## Ground\nissue: ${ISSUE_URL}\npr: ${PR_URL}\n## Rules\n${RULES}\n`,
+		);
+	});
+
+	it("carries the same lane on to its shipper — a non-closing PR is the partial flow, not a defect", async () => {
+		const briefed = await Effect.runPromise(
+			Effect.provide(
+				runBrief({
+					root: ROOT,
+					lane: String(ISSUE),
+					task: null,
+					repo: null,
+					env: {CLAUDE_PIPELINE_REPO: "o/r"},
+					entrypoint: {_tag: "Entrypoint", entrypoint: ENTRY} as EntrypointRead,
+				}),
+				Layer.merge(laneAt("WIP", "DONE", "PASS").layer, fakeSeams(board).layer),
+			),
+		);
+
+		expect(briefed.code).toBe(0);
+		expect(briefed.stdout).toContain("shell: shipper");
+		expect(briefed.stdout).toContain(`pr: ${PR_URL}`);
+	});
+});

--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -24,14 +24,9 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {resolveTargetRepo} from "../build/target.ts";
 import {governedRootsOr} from "../config/paths.ts";
 import {getIssue, listComments} from "../io/issues.ts";
-import {getPullRequest, listPullFiles, openPullsClosing, searchOpenPulls} from "../io/pulls.ts";
+import {getPullRequest, listPullFiles} from "../io/pulls.ts";
 import {readAdvisory} from "../review/advisory.ts";
-import {
-	issueRefsOf,
-	partitionWithUi,
-	ROUTED_NAMESPACES,
-	shipNamespacesOf,
-} from "../review/classes.ts";
+import {partitionWithUi, ROUTED_NAMESPACES, shipNamespacesOf} from "../review/classes.ts";
 import {bindRange, contentDigestAt, rangeContentAt} from "../review/content-binding.ts";
 import {bindHead} from "../review/head.ts";
 import {CODEOWNERS_PATH, readBoundary} from "../ship/boundary.ts";
@@ -50,6 +45,7 @@ import {
 	TASK_UNKNOWN,
 } from "./codes.ts";
 import {foldLog, nextLeaf, resolveTask} from "./fold.ts";
+import {nominateOpenPulls} from "./nominate.ts";
 import {
 	claimOf,
 	epicOf,
@@ -59,7 +55,6 @@ import {
 	judgeVerdicts,
 	type NamespaceRow,
 	type Proof,
-	type PullFact,
 	roleOf,
 	traceDiagnosis,
 	tracePulls,
@@ -272,26 +267,14 @@ interface Traced {
 }
 
 /**
- * The open PRs linking this issue, each read as its own record.
+ * The open PRs linking this issue, nominated by `./nominate.ts` — the union `lane brief` and
+ * `recipe unpark` resolve their PR through too, so the three verbs cannot disagree about which PR a
+ * lane owns (#6179). What that union is, and why the edge is read before the index, lives there.
  *
- * Two nomination reads, unioned, because neither alone answers the question. The closing-issue edge
- * (`openPullsClosing`) is authoritative and lag-free but blind to `Part of #N`, the shape
- * `build --partial` emits; the search index sees any body but lags a fresh PR — and this verb runs
- * at the worst moment for that lag, right after a builder reports `SHIPPED-PR`. Reading the edge
- * first means a lagging index can only fail to add a candidate, never hide the closing one, so a
- * lane that shipped is not recorded `BLOCKED` on exit `22`.
- *
- * Both reads only nominate; the body's links decide. A candidate that has closed since it was
- * nominated, or that only mentions the number in prose, drops out here rather than counting as
- * proof — so unioning in the looser read widens candidates without widening what counts.
- *
- * **What `lane brief` and this verb still differ on.** Both start from the same edge, and since
- * #6797 the body read is plural, so a tail closing N+1 issues traces to each of them here exactly as
- * it does on the edge. The residue is that `brief` answers off the edge alone while this verb
- * re-derives the link from body text, so a PR linked through the sidebar's Development panel rather
- * than a keyword in its body (GitHub's "Manually linking a pull request to an issue using the pull
- * request sidebar") is on the edge and is not a proof here. That is deliberate — a proof
- * this verb records has to be readable in the artifact it names — not an agreement claim.
+ * The one thing this verb adds is the ruling on the sidebar link: a PR linked through GitHub's
+ * Development panel rather than a keyword in its body is on the edge and is still not a proof here,
+ * because a proof this verb records has to be readable in the artifact it names. The nominator
+ * offers it as a candidate; `tracePulls` drops it on the body read.
  */
 const traceOpenPull = (
 	repo: string,
@@ -302,37 +285,14 @@ const traceOpenPull = (
 	ChildProcessSpawner.ChildProcessSpawner
 > =>
 	Effect.gen(function* () {
-		const closing = yield* openPullsClosing(repo, issue);
-		if (closing._tag === "Failure") {
+		const nominated = yield* nominateOpenPulls(repo, issue);
+		if (nominated._tag === "Unreadable") {
 			return {
 				_tag: "Refused" as const,
-				outcome: unreadable(`the open pull requests closing #${issue}`, closing.reason),
+				outcome: unreadable(nominated.what, nominated.reason),
 			};
 		}
-		const found = yield* searchOpenPulls(repo, [`${issue}`, "in:body"]);
-		if (found._tag === "Failure") {
-			return {
-				_tag: "Refused" as const,
-				outcome: unreadable(`the open pull requests mentioning #${issue}`, found.reason),
-			};
-		}
-		const candidates = new Set([...closing.value.map((pull) => pull.number), ...found.value]);
-		const facts: PullFact[] = [];
-		for (const candidate of candidates) {
-			const pull = yield* getPullRequest(repo, candidate);
-			if (pull._tag === "Unknown") {
-				return {
-					_tag: "Refused" as const,
-					outcome: unreadable(`PR #${candidate}`, pull.reason),
-				};
-			}
-			if (pull._tag === "Absent") continue;
-			facts.push({
-				number: pull.value.number,
-				open: pull.value.state === "open",
-				linkedIssues: issueRefsOf(pull.value.body).numbers,
-			});
-		}
+		const facts = nominated.pulls;
 		return {_tag: "Traced" as const, trace: tracePulls(issue, facts), scanned: facts.length};
 	});
 

--- a/packages/fabrika-cli/src/recipe/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/recipe/fixtures.test-support.ts
@@ -93,6 +93,10 @@ export const closingPulls = (...numbers: ReadonlyArray<number>): ExecResult =>
 		}),
 	);
 
+/** The search index's nomination envelope — candidate numbers, never a proof (`searchOpenPulls`). */
+export const nominatedPulls = (...numbers: ReadonlyArray<number>): ExecResult =>
+	okOut(JSON.stringify({total_count: numbers.length, items: numbers.map((number) => ({number}))}));
+
 export interface RunShape {
 	readonly id: number;
 	readonly name?: string;

--- a/packages/fabrika-cli/src/recipe/unpark-verb.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.ts
@@ -25,7 +25,8 @@ import {childLaneBranches} from "../build/lane.ts";
 import {runRetire} from "../build/retire-verb.ts";
 import {localBranches} from "../io/git.ts";
 import {isRecord, parseJson} from "../io/json.ts";
-import {openPullsClosing} from "../io/pulls.ts";
+import {nominateOpenPulls, nominationScope} from "../lane/nominate.ts";
+import {tracePulls} from "../lane/prove.ts";
 import {runStatus} from "../lane/status-verb.ts";
 import {runTransition} from "../lane/transition-verb.ts";
 import {runCpApproval} from "../ship/cp-approval-verb.ts";
@@ -183,49 +184,53 @@ const clearCpApproval = (
 		if (resolved._tag === "Refused") return no(resolved.outcome);
 		const repo = resolved.repo;
 
-		const pulls = yield* openPullsClosing(repo, issue);
-		if (pulls._tag === "Failure") {
+		// The lane's PR through the shared nominator (`../lane/nominate.ts`): a §CP park sits on the same
+		// PR `lane brief` dispatched a shipper against, and a `Part of #N` PR that this verb could not
+		// see is a park no recipe could ever clear (#6179).
+		const nominated = yield* nominateOpenPulls(repo, issue);
+		if (nominated._tag === "Unreadable") {
 			return no(
 				refuse(
 					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot read the open PRs declaring they close #${issue}: ${pulls.reason} — the park's cause is UNKNOWN, never cleared.`,
+					`${VERB}: cannot read ${nominated.what}: ${nominated.reason} — the park's cause is UNKNOWN, never cleared.`,
 				),
 			);
 		}
-		const [only, ...rest] = pulls.value;
-		if (only === undefined) {
+		const traced = tracePulls(issue, nominated.pulls);
+		if (traced._tag === "None") {
 			return no(
 				refuse(
 					TARGET_ABSENT,
-					`${VERB}: no open PR declares it closes #${issue}, and "${recipe.park}" waits on ${recipe.waitingOn} — there is no subject to read.`,
+					`${VERB}: ${traced.why} across ${nominationScope(issue)}, and "${recipe.park}" waits on ${recipe.waitingOn} — there is no subject to read.`,
 				),
 			);
 		}
-		if (rest.length > 0) {
+		if (traced._tag === "Many") {
 			return no(
 				refuse(
 					PARK_NOVEL,
-					`${VERB}: ${pulls.value.length} open PRs declare they close #${issue} (${pulls.value
-						.map((p) => `#${p.number}`)
+					`${VERB}: ${traced.prs.length} open PRs link #${issue} (${traced.prs
+						.map((candidate) => `#${candidate}`)
 						.join(
 							", ",
 						)}) — which one the park hangs on is not this verb's to guess; route this to a human.`,
 				),
 			);
 		}
+		const pr = traced.pr;
 
 		const target = yield* openPull(
 			VERB,
 			repo,
-			only.number,
+			pr,
 			(reason) =>
-				`${VERB}: cannot read PR #${only.number}: ${reason} — the park's cause is UNKNOWN, never cleared.`,
+				`${VERB}: cannot read PR #${pr}: ${reason} — the park's cause is UNKNOWN, never cleared.`,
 		);
 		if (target._tag === "Refused") return no(target.outcome);
 		const head = target.pull.headSha;
 
 		const discharge = yield* runCpApproval({
-			pr: only.number,
+			pr,
 			sha: head,
 			repo,
 			json: true,
@@ -249,7 +254,7 @@ const clearCpApproval = (
 				),
 			);
 		}
-		const scope = scannedLine(VERB, 1, "pull request", `#${only.number} at ${head}`);
+		const scope = scannedLine(VERB, 1, "pull request", `#${pr} at ${head}`);
 		switch (answered.outcome) {
 			case "discharge":
 				return {
@@ -260,7 +265,7 @@ const clearCpApproval = (
 				return no(
 					refuse(
 						PARK_HOLDS,
-						`${VERB}: "${recipe.park}" still waits on ${recipe.waitingOn} — PR #${only.number} is not discharged at ${head}; nothing was written.`,
+						`${VERB}: "${recipe.park}" still waits on ${recipe.waitingOn} — PR #${pr} is not discharged at ${head}; nothing was written.`,
 						[scope],
 					),
 				);
@@ -268,7 +273,7 @@ const clearCpApproval = (
 				return no(
 					refuse(
 						PARK_NOVEL,
-						`${VERB}: PR #${only.number} is not control-plane, so "${recipe.park}" is parked over something this recipe does not cover — refusing with the ledger untouched; route this to a human.`,
+						`${VERB}: PR #${pr} is not control-plane, so "${recipe.park}" is parked over something this recipe does not cover — refusing with the ledger untouched; route this to a human.`,
 						[scope],
 					),
 				);

--- a/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
@@ -29,6 +29,7 @@ import {
 	LANES_ROOT,
 	LOG,
 	laneTemplate,
+	nominatedPulls,
 	PARKED_AT_CP,
 	PARKED_BLOCKED,
 	PARKED_ON_WORKTREE,
@@ -39,7 +40,9 @@ import {
 import {runUnpark} from "./unpark-verb.ts";
 
 const CLOSERS = /^POST .*\/graphql$/;
+const SEARCH = /^GET .*\/search\/issues\?/;
 const PULL = /^GET .*\/repos\/o\/r\/pulls\/4321$/;
+const SECOND_PULL = /^GET .*\/repos\/o\/r\/pulls\/4322$/;
 const FILES = /^GET .*\/repos\/o\/r\/pulls\/4321\/files\?/;
 const OWNERS = /contents\/\.github\/CODEOWNERS/;
 const COMPARE = /\/repos\/o\/r\/compare\//;
@@ -110,6 +113,24 @@ const DISCHARGED_HTTP: ReadonlyArray<Scripted> = [
 const lane = (log: string, extra: Parameters<typeof fakeFs>[0] = {}) =>
 	fakeFs({files: {[WORKFLOW]: laneTemplate(), [LOG]: log}, ...extra});
 
+/** A second candidate the search index alone nominates, its body linking the same lane issue. */
+const otherPull = (number: number): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number,
+		state: "open",
+		head: {sha: HEAD},
+		base: {ref: "main"},
+		body: `Part of #${LANE}\n`,
+		changed_files: 1,
+		comments: 0,
+		user: {login: "usirin"},
+		html_url: `https://github.com/o/r/pull/${number}`,
+	}),
+});
+
+const NO_NOMINATIONS: Scripted = [SEARCH, reply(nominatedPulls())];
+
 const run = (
 	fs: ReturnType<typeof fakeFs>,
 	script: ReadonlyArray<Scripted>,
@@ -119,7 +140,9 @@ const run = (
 	Effect.runPromise(
 		Effect.provide(
 			runUnpark({root: LANES_ROOT, lane: LANE, task, repo: null, env: ENV}),
-			Layer.merge(fs.layer, fakeSeams([...script, ...http]).layer),
+			// The nominator's body-search half is tailed, so a test scripting its own wins the lookup.
+			// Empty by default: the union then answers off the closing edge, as these tests always did.
+			Layer.merge(fs.layer, fakeSeams([...script, ...http, NO_NOMINATIONS]).layer),
 		),
 	);
 
@@ -138,6 +161,20 @@ describe("recipe unpark — the known recipe clears", () => {
 			current: "ship",
 		});
 		expect(fs.written.get(LOG)).toMatch(/ISSUE\.UNBLOCKED/);
+	});
+
+	it("clears a §CP park whose PR only says `Part of #N` — the shared nominator's body half (#6179)", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, [
+			[CLOSERS, reply(closingPulls())],
+			[SEARCH, reply(nominatedPulls(4321))],
+			[PULL, reply(pull({author: "usirin", body: `Part of #${LANE}\n`}))],
+			[FILES, CP_FILES],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({park: "human:cp-approval", current: "ship"});
 	});
 
 	it("names the discharge mechanism it relayed rather than restating the §CP rule", async () => {
@@ -282,10 +319,15 @@ describe("recipe unpark — the refusals write nothing", () => {
 		expect(fs.written.size).toBe(0);
 	});
 
-	it("is PARK_NOVEL when several open PRs declare they close the issue", async () => {
+	it("is PARK_NOVEL when several open PRs link the issue", async () => {
 		const fs = lane(PARKED_AT_CP);
 
-		const out = await run(fs, [[CLOSERS, reply(closingPulls(4321, 4322))]]);
+		const out = await run(fs, [
+			[CLOSERS, reply(closingPulls(4321))],
+			[SEARCH, reply(nominatedPulls(4322))],
+			[PULL, reply(pull({author: "usirin"}))],
+			[SECOND_PULL, otherPull(4322)],
+		]);
 
 		expect(out.code).toBe(PARK_NOVEL);
 		expect(out.stderr.join("\n")).toMatch(/#4321, #4322/);
@@ -324,7 +366,7 @@ describe("recipe unpark — the refusals write nothing", () => {
 		expect(fs.written.size).toBe(0);
 	});
 
-	it("is TARGET_ABSENT when no open PR declares it closes the issue the park hangs on", async () => {
+	it("is TARGET_ABSENT when no open PR links the issue the park hangs on", async () => {
 		const fs = lane(PARKED_AT_CP);
 
 		const out = await run(fs, [[CLOSERS, reply(closingPulls())]]);

--- a/packages/fabrika-cli/src/review/head.unit.test.ts
+++ b/packages/fabrika-cli/src/review/head.unit.test.ts
@@ -21,6 +21,7 @@ const PULL: PullRecord = {
 	state: "open",
 	headSha: HEAD,
 	body: "",
+	htmlUrl: "https://github.com/o/r/pull/4321",
 	changedFiles: 2,
 	comments: 0,
 	draft: false,


### PR DESCRIPTION
Fixes #6179

`lane prove` and `lane brief` disagreed about which open PR links a lane's issue. `prove` unioned
GitHub's closing-issue edge with a body search, so a PR whose body opens `Part of #N` proved a
`DONE` and the lane folded to `review`; `brief` read the edge alone and refused that same PR on the
next pass with exit 20, so no reviewer could be dispatched and no event moved the lane. Lane 5981
(PR #6177) and lane 6610 (PR #6883) both parked on it.

Per the ruling on the issue, `brief` widens to `prove`'s union rather than `prove` tightening.

- New `packages/fabrika-cli/src/lane/nominate.ts` — `nominateOpenPulls`, the closing edge unioned
  with `searchOpenPulls(repo, [<issue>, "in:body"])`, each candidate re-read off the board and
  returned as facts `tracePulls` matches by set membership (#6874's plural `issueRefsOf`).
- `prove-verb`, `brief-verb` and `recipe/unpark-verb` all resolve the lane's PR through it. The
  third caller consumes it rather than documenting divergence: a §CP park on a `Part of` PR is a
  park no recipe could ever clear.
- Exit 20 is unchanged in kind — zero candidates still refuses, two or more still refuses — but the
  zero-candidate text now names the whole union it searched instead of the closing edge alone.
- `PullRecord` gains `htmlUrl`, since the brief's PR link used to come off the edge's own node.
- `traceOpenPull`'s docblock no longer asserts the old divergence; the two lines in `operate`'s
  SKILL.md that said `lane brief` resolves the tail's PR through the closing edge are corrected.

Tests: a new `nominate.unit.test.ts` covers the nominator over closing-edge-only, body-search-only
and both boards, and replays the deadlocked sequence end to end — `prove` records the `DONE` off a
`Part of #N` PR, the lane folds to `review`, `brief` prints the reviewer brief, and the same lane
goes on to brief its shipper. `brief-verb` gains the `Part of` resolution, a two-body-candidate
refusal, and an assertion that the zero-candidate text names the union.

## Deviations

- **Out-of-scope change** — **Said:** #6179 names `lane prove`, `lane brief` and `recipe unpark`.
  **Did:** also added `htmlUrl` to `PullRecord` in `src/io/pulls.ts`, and a field to two unrelated
  test fixtures that construct a `PullRecord` literal. **Why:** the brief's PR URL used to come
  from the closing edge's GraphQL node, which the shared nominator no longer reads per candidate;
  the REST record is where the URL has to come from now. **Disposition:** stated here.
