### PR TITLE
fix: Shell skills omit --task from their lane report call, so no shell can record its terminal on an epic lane

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -357,14 +357,19 @@ to a `BLOCKED` event, which is already the routing a denial wants, so no sixth t
 bypass read the same in the transcript, which is the whole reason the denial is worth reporting.
 
 **Record the terminal yourself, then print it.** When your spawn brief named a lane, your terminal
-step is the verb — pass back the `lane` and `root` its `## Task` section carries, and the token→event
-map is the verb's code; the event lands on the lane's own ledger with the PR as its evidence (#5736).
-`<fabrika>` is that same section's `fabrika:` entrypoint, the one path this repo's verbs actually run
-from (#6012):
+step is the verb — pass back the `lane`, `root` and `task` its `## Task` section carries, and the
+token→event map is the verb's code; the event lands on the lane's own ledger with the PR as its
+evidence (#5736). `<fabrika>` is that same section's `fabrika:` entrypoint, the one path this repo's
+verbs actually run from (#6012):
 
 ```bash
-node <fabrika> lane report <lane> --root <root> --token SHIPPED-PR --pr <pr-url>
+node <fabrika> lane report <lane> --root <root> --task <task> --token SHIPPED-PR --pr <pr-url>
 ```
+
+`--task` names which task of the lane your terminal addresses, and it is not optional wherever a
+lane has more than one — every epic run. The verb resolves a missing one only on a single-task lane
+and otherwise refuses at exit `13` before it appends anything, so a report that omits it records
+nothing (#6084).
 
 `--pr` whenever the terminal names one; `--comment` for the diagnosis comment behind a
 `SUCCESS-NO-PR`; a `BUILT-NO-PR` carries neither, because its evidence is the commits themselves.
@@ -375,7 +380,7 @@ else, because only a park has a cause to be gone. The one token that names a sto
 `build branch --resume-lane` refuses at exit `11` — another worktree still holds the lane branch:
 
 ```bash
-node <fabrika> lane report <lane> --root <root> --token STOPPED --cause worktree-holds-branch
+node <fabrika> lane report <lane> --root <root> --task <task> --token STOPPED --cause worktree-holds-branch
 ```
 
 That cause is the whole difference between a park `recipe unpark` clears itself and one that spends

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -415,8 +415,10 @@ or an event recorded this pass.
 ## 3 — Verify the record landed, and record what no shell can
 
 **A shell records its own terminal.** Every spawned shell ends by invoking
-`lane report <lane> --root <root> --token <TOKEN>` against the lane and root its brief named, and
-the token→event map is code
+`lane report <lane> --root <root> --task <task> --token <TOKEN>` against the lane, root and task its
+brief named — the same `--task` you pass on your own `lane transition`, because the shell's report
+resolves a task exactly as yours does and refuses at exit `13` on a multi-task lane without one
+(#6084). The token→event map is code
 ([`packages/fabrika-cli/src/lane/report.ts`](../../../../packages/fabrika-cli/src/lane/report.ts)),
 never a table you execute — an unrecognised token is that verb's refusal (exit `32`), not a reading
 of yours. **That verb proves before it appends**: it runs `lane prove`'s read on the mapped event

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -269,20 +269,25 @@ governance held no binding verdict, the machine had no state that could fire it,
 filled only because an unrelated second driver happened to run governance on the same lane.
 
 **Record the terminal yourself, then print it.** When your spawn brief named a lane, your terminal
-step is the verb — pass back the `lane` and `root` its `## Task` section carries, one token per
-terminal above (`PASS`, `FAIL`, `UNKNOWN`, `STALE`, `UNBINDABLE`, `ROUTED`), mapped to a lane event
-in its code, with the PR as the event's evidence (#5736). `<fabrika>` is that same section's
+step is the verb — pass back the `lane`, `root` and `task` its `## Task` section carries, one token
+per terminal above (`PASS`, `FAIL`, `UNKNOWN`, `STALE`, `UNBINDABLE`, `ROUTED`), mapped to a lane
+event in its code, with the PR as the event's evidence (#5736). `<fabrika>` is that same section's
 `fabrika:` entrypoint, the one path this repo's verbs actually run from (#6012):
 
 ```bash
-node <fabrika> lane report <lane> --root <root> --token PASS --pr <pr-url>
+node <fabrika> lane report <lane> --root <root> --task <task> --token PASS --pr <pr-url>
 ```
+
+`--task` names which task of the lane your verdict addresses, and it is not optional wherever a lane
+has more than one — every epic run. The verb resolves a missing one only on a single-task lane and
+otherwise refuses at exit `13` before it appends anything, so a report that omits it records nothing
+(#6084).
 
 **Add `--class ui` to that line only when §1 printed a `routed\treview-ui` row**, and never
 otherwise:
 
 ```bash
-node <fabrika> lane report <lane> --root <root> --token PASS --pr <pr-url> --class ui
+node <fabrika> lane report <lane> --root <root> --task <task> --token PASS --pr <pr-url> --class ui
 ```
 
 `--class` is repeatable and carries §1's `routed` rows and nothing else — relay what printed, never

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -264,8 +264,8 @@ A note that routes another lane opens with the fixed first line
 branded reference, no steering prose; the receiver re-fetches from the PR itself.
 
 **Record the terminal yourself, then print it.** When your spawn brief named a lane, your terminal
-step is the verb — pass back the `lane` and `root` its `## Task` section carries, one token per
-terminal above (`ALREADY-MERGED`, `QUEUED`, `LANDED`, `REFUSED`, `AWAITING-CP-APPROVAL`,
+step is the verb — pass back the `lane`, `root` and `task` its `## Task` section carries, one token
+per terminal above (`ALREADY-MERGED`, `QUEUED`, `LANDED`, `REFUSED`, `AWAITING-CP-APPROVAL`,
 `ROUTED-REPAIR`, `ROUTED-HEAL-CI`, `ROUTED-REVIEW`, `UNRESOLVED`, `EJECTED`, `UNKNOWN`), mapped to a
 lane event in its code, with the PR as the event's evidence (#5736). The routing token names the arm
 your note's first line already names — report the one you took, never a bare `ROUTED`, which is the
@@ -273,8 +273,13 @@ reviewer's token and means something else. `<fabrika>` is that same section's `f
 the one path this repo's verbs actually run from (#6012):
 
 ```bash
-node <fabrika> lane report <lane> --root <root> --token LANDED --pr <pr-url>
+node <fabrika> lane report <lane> --root <root> --task <task> --token LANDED --pr <pr-url>
 ```
+
+`--task` names which task of the lane your terminal addresses, and it is not optional wherever a
+lane has more than one — every epic run. The verb resolves a missing one only on a single-task lane
+and otherwise refuses at exit `13` before it appends anything, so a report that omits it records
+nothing (#6084).
 
 The reason behind a `refused` stays in your note and report — the verb takes the bare token. It
 refuses a token outside this vocabulary (exit `32`) rather than interpreting it. It proves an event


### PR DESCRIPTION
Every fabrika shell skill told its spawn to record its terminal with
`lane report <lane> --root <root> --token <TOKEN>`. None of them mentioned `--task`. On a lane with
more than one task — every epic run — `resolveTask` (`packages/fabrika-cli/src/lane/fold.ts:310`)
returns `Unresolved`, and `runReport` refuses with `TASK_UNKNOWN` (exit `13`) before the fold and
before the append. So a shell following its skill literally could never record its own terminal on
an epic lane. Most visible on the builder's `BUILT-NO-PR`, which only exists on an epic lane.

The value was already in the shell's hands: `lane brief` prints `task: <name>` in the `## Task`
section it hands every spawn (`packages/fabrika-cli/src/wire/lane-brief.ts:320`). This teaches the
four docs to pass it.

- `build`, `review`, `ship`: the terminal-record sentence now says `lane`, `root` **and** `task`,
  every snippet carries `--task <task>`, and each file gains one paragraph saying why it is not
  optional and what exit `13` means.
- `operate`: its description of what every spawned shell runs shows `--task` too, so the driver and
  the shells describe the same command.

No CLI change — `fold.ts` and `report-verb.ts` are untouched, per the ticket's scope note.

Fixes #6084

## Deviations

None.
