### PR TITLE
fix: Lane verbs answer no-lane from a wrong cwd, and exit 7 is the boot signal

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -95,7 +95,10 @@ node <fabrika> lane status $lane_key
 ```
 
 Exit `0` is resume — the lane exists and its fold is the state; go to step 2. Exit `7` (no lane)
-is boot:
+is boot, and it is the **only** exit that is: exit `39` says this cwd is not a repo at all, so the
+root the verb resolved is not the one your lane lives under, and booting on it writes a second
+ledger over a live lane ([#6212](https://github.com/kamp-us/phoenix/issues/6212)). On `39`, move to
+the repo root and re-read — never boot.
 
 ```bash
 node <fabrika> lane emit $lane_key

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -274,7 +274,7 @@ export const PATTERN_SEATS: SharedSeats = {
  * did not land (`APPEND_UNKNOWN`), and the read that failed before any of that could be proven
  * (`LANE_UNREADABLE`). `lane claim` adds the fifth: it posts a marker and reads it back, so alone in
  * this group it can establish *the write landed and the read-back contradicts it* (`MARKER_READBACK`,
- * #5761). The private band runs `12`-`34`, skipping `27` and `28` because the base already speaks for
+ * #5761). The private band runs `12`-`39`, skipping `27` and `28` because the base already speaks for
  * both.
  */
 export const LANE_SEATS: SharedSeats = {

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -270,3 +270,15 @@ export const MIGRATION_UNSAFE = 37;
  * class, and the event must not land until it is.
  */
 export const CLASS_UNRECOGNISED = 38;
+
+/**
+ * The directory a relative lanes root would resolve against holds neither `.fabrika` nor `.git` —
+ * the verb is not standing in a repo, so the root it would read or write is somewhere nobody meant.
+ *
+ * Its own seat rather than {@link LANE_ABSENT}'s, and that is the whole point: a drifted cwd used to
+ * prove the lane *absent*, which `operate` reads as the boot signal, so a driver whose shell reset
+ * into a scratchpad would boot a second ledger over a live lane — duplicate spawns on one issue, the
+ * collision the claim machinery exists to prevent (#6212). "No lane in this repo" may mean boot;
+ * "not a repo at all" never may.
+ */
+export const NOT_A_REPO = 39;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -8,7 +8,7 @@
  */
 import {randomUUID} from "node:crypto";
 import {fileURLToPath} from "node:url";
-import {Effect, Option} from "effect";
+import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {claimReader} from "../build/claimants-verb.ts";
 import {resolveEntrypoint} from "../delegate/entrypoint.ts";
@@ -20,6 +20,7 @@ import {runBrief} from "./brief-verb.ts";
 import {runLaneClaim, runLaneRelease} from "./claim-verb.ts";
 import {CLASS_UNRECOGNISED} from "./codes.ts";
 import {runEmit} from "./emit-verb.ts";
+import {onGround} from "./ground.ts";
 import {runHistory} from "./history-verb.ts";
 import {type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
 import {runMigrate} from "./migrate-verb.ts";
@@ -60,29 +61,45 @@ const rootFlag = Flag.string("root").pipe(
 
 /**
  * Resolve the `lane` argument to a key and its directory, or refuse it — the one step every keyed
- * verb shares, so a malformed key is caught before any verb reads or writes anything.
+ * verb shares, so a malformed key is caught before any verb reads or writes anything, and the ground
+ * under the resolved root is proven before either.
  */
 const onKey = <R>(
+	verb: string,
 	raw: string,
 	root: Option.Option<string>,
 	run: (key: LaneKey, ref: LaneRef) => Effect.Effect<VerbOutcome, never, R>,
+): Effect.Effect<VerbOutcome, never, R | FileSystem.FileSystem | Path.Path> => {
+	const parsed = parseKey(raw);
+	if (parsed._tag === "Malformed") return Effect.succeed(keyRefusal(parsed));
+	const ref = laneRef(parsed.key, Option.getOrNull(root));
+	return onGround(verb, [ref.root], process.cwd(), () => run(parsed.key, ref));
+};
+
+/**
+ * Resolve the `lane` argument for a verb whose ground is the **board**, not the disk — `claim` and
+ * `release`, which race a marker on the issue a lane drives and read no lanes root at all. They take
+ * the key alone rather than a ref, so neither can reach a root the cwd would decide, and neither owes
+ * the repo probe {@link onGround} makes.
+ */
+const onBoardKey = <R>(
+	raw: string,
+	run: (key: LaneKey) => Effect.Effect<VerbOutcome, never, R>,
 ): Effect.Effect<VerbOutcome, never, R> => {
 	const parsed = parseKey(raw);
-	return parsed._tag === "Malformed"
-		? Effect.succeed(keyRefusal(parsed))
-		: run(parsed.key, laneRef(parsed.key, Option.getOrNull(root)));
+	return parsed._tag === "Malformed" ? Effect.succeed(keyRefusal(parsed)) : run(parsed.key);
 };
 
 const status = leafCommand(
 	"status",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* onKey(lane, root, (_key, ref) => runStatus(ref)));
+		yield* emit(yield* onKey("status", lane, root, (_key, ref) => runStatus(ref)));
 	}),
 ).pipe(
 	Command.withShortDescription("One lane's derived state, folded fresh from its event log."),
 	Command.withDescription(
-		"One lane's derived state, folded fresh from the whole events.jsonl every invocation — no resident process, no snapshot. stdout is the operator's status JSON: compound `stateValue` (active phase → per-task leaf state, future phases \"waiting\", or a bare terminal), `status` active/done, and per-task `{retries, maxRetries, …}` context with the tripped tasks in `errors`. Exits 4 (workflow.json or events.jsonl read in full and not the shape — every defect on stderr), 7 (no lane there — copy a workflow template to open it), 11 (the lane could not be read — its state is UNKNOWN, never fresh), 21 (the key is not a lane key). Examples: fabrika lane status 5673 · fabrika lane status chore:park-sweep",
+		'One lane\'s derived state, folded fresh from the whole events.jsonl every invocation — no resident process, no snapshot. stdout is the operator\'s status JSON: compound `stateValue` (active phase → per-task leaf state, future phases "waiting", or a bare terminal), `status` active/done, and per-task `{retries, maxRetries, …}` context with the tripped tasks in `errors`. Exits 4 (workflow.json or events.jsonl read in full and not the shape — every defect on stderr), 7 (no lane there — copy a workflow template to open it), 11 (the lane could not be read — its state is UNKNOWN, never fresh), 21 (the key is not a lane key), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT "no lane here", so never a boot). Examples: fabrika lane status 5673 · fabrika lane status chore:park-sweep',
 	),
 );
 
@@ -134,7 +151,7 @@ const transition = leafCommand(
 	},
 	Effect.fn(function* ({lane, event, root, task, cause, classes}) {
 		yield* emit(
-			yield* onKey(lane, root, (_key, ref) =>
+			yield* onKey("transition", lane, root, (_key, ref) =>
 				runTransition({
 					...ref,
 					event,
@@ -148,7 +165,7 @@ const transition = leafCommand(
 ).pipe(
 	Command.withShortDescription("Record one operator event, refusing an invalid one unappended."),
 	Command.withDescription(
-		"Record one operator event on the lane's append-only log — after the machine accepts it, never before. stdout is `{previous, event, current, taskAffected}` with the two stateValues around the fold. An invalid event — no cell in the task's current state (tea's NoCellError, surfaced verbatim), outside the operator's six, a task outside the active phase, a finished workflow — is refused loudly and the log is left byte-identical. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (the lane could not be read), 12 (the event is refused, log unappended), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 21 (the key is not a lane key), 35 (--cause is outside the closed park-cause set or rides on an event that is not BLOCKED), 38 (--class is outside the closed lane-class set), 36 (an UNBLOCKED out of an error final would restore the state and not the repair budget — record the founder's cleared round with `build clear` first; the two land in either order). A cleared round is NOT recorded here: it is a `<TASK>.CLEARED` event `build clear` appends, it targets no state, and the operator's six are unchanged (ADR 0312). An optional --cause lands on a BLOCKED's event line and is what `recipe unpark` keys its recipe table on; a BLOCKED with no cause is the bare park it always was, and routes to a human. A repeatable --class lands the lane classes standing at the event on the same line, and is the fact the machine's `class:<name>` arms route on — `--class ui` on a WIP sends the lane to `build:ui`, and it stands until another event names a different set. Example: fabrika lane transition 5673 DONE",
+		"Record one operator event on the lane's append-only log — after the machine accepts it, never before. stdout is `{previous, event, current, taskAffected}` with the two stateValues around the fold. An invalid event — no cell in the task's current state (tea's NoCellError, surfaced verbatim), outside the operator's six, a task outside the active phase, a finished workflow — is refused loudly and the log is left byte-identical. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (the lane could not be read), 12 (the event is refused, log unappended), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 21 (the key is not a lane key), 35 (--cause is outside the closed park-cause set or rides on an event that is not BLOCKED), 38 (--class is outside the closed lane-class set), 36 (an UNBLOCKED out of an error final would restore the state and not the repair budget — record the founder's cleared round with `build clear` first; the two land in either order), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). A cleared round is NOT recorded here: it is a `<TASK>.CLEARED` event `build clear` appends, it targets no state, and the operator's six are unchanged (ADR 0312). An optional --cause lands on a BLOCKED's event line and is what `recipe unpark` keys its recipe table on; a BLOCKED with no cause is the bare park it always was, and routes to a human. A repeatable --class lands the lane classes standing at the event on the same line, and is the fact the machine's `class:<name>` arms route on — `--class ui` on a WIP sends the lane to `build:ui`, and it stands until another event names a different set. Example: fabrika lane transition 5673 DONE",
 	),
 );
 
@@ -185,7 +202,7 @@ const report = leafCommand(
 	},
 	Effect.fn(function* ({lane, token, root, task, pr, comment, cause, classes, repo}) {
 		yield* emit(
-			yield* onKey(lane, root, (_key, ref) =>
+			yield* onKey("report", lane, root, (_key, ref) =>
 				runReport(
 					{
 						...ref,
@@ -207,7 +224,7 @@ const report = leafCommand(
 ).pipe(
 	Command.withShortDescription("Record a shell's terminal token, mapped to one operator event."),
 	Command.withDescription(
-		"Record a spawned shell's terminal token on the lane's append-only log: the token→event map in code (report.ts) picks one of the operator's six, the mapped event is then proven exactly as `lane prove` proves it — a token is a self-report, so a DONE and a PASS reach the log only with their artifact behind them, every other event answering not-required without a board read — and only then does the append ride transition's exact path, validated against the folded state first, refused unappended otherwise. Optional --pr/--comment refs land on the event line itself, so the event names its evidence (visible via lane history), a repeatable --class lands the lane classes standing at the event (what the machine's `class:<name>` arms route on), and an optional --cause names why a BLOCKED parked, from a closed set in code — the key `recipe unpark` seats the park against, without which every BLOCKED is novel and costs a human UNBLOCKED. stdout is `{token, previous, event, current, taskAffected}` plus the refs. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (a lane, board or tree read failed — whether the event is proven is UNKNOWN), 12 (the mapped event is refused, log unappended), 13 (the task is not in the machine, names no issue, or --task omitted on a multi-task lane), 21 (the key is not a lane key), 22/23/24/25 (`lane prove`'s own refusals — artifact provably absent, a namespace with no still-binding verdict, a FAIL under a claimed PASS, several candidates — log unappended, remedies unchanged), 32 (the token is no shell's terminal token — refused, never interpreted), 35 (--cause is outside the closed park-cause set or rides on an event that is not BLOCKED), 38 (--class is outside the closed lane-class set). Example: fabrika lane report 5736 --token SHIPPED-PR --pr https://github.com/kamp-us/phoenix/pull/5760",
+		"Record a spawned shell's terminal token on the lane's append-only log: the token→event map in code (report.ts) picks one of the operator's six, the mapped event is then proven exactly as `lane prove` proves it — a token is a self-report, so a DONE and a PASS reach the log only with their artifact behind them, every other event answering not-required without a board read — and only then does the append ride transition's exact path, validated against the folded state first, refused unappended otherwise. Optional --pr/--comment refs land on the event line itself, so the event names its evidence (visible via lane history), a repeatable --class lands the lane classes standing at the event (what the machine's `class:<name>` arms route on), and an optional --cause names why a BLOCKED parked, from a closed set in code — the key `recipe unpark` seats the park against, without which every BLOCKED is novel and costs a human UNBLOCKED. stdout is `{token, previous, event, current, taskAffected}` plus the refs. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (a lane, board or tree read failed — whether the event is proven is UNKNOWN), 12 (the mapped event is refused, log unappended), 13 (the task is not in the machine, names no issue, or --task omitted on a multi-task lane), 21 (the key is not a lane key), 22/23/24/25 (`lane prove`'s own refusals — artifact provably absent, a namespace with no still-binding verdict, a FAIL under a claimed PASS, several candidates — log unappended, remedies unchanged), 32 (the token is no shell's terminal token — refused, never interpreted), 35 (--cause is outside the closed park-cause set or rides on an event that is not BLOCKED), 38 (--class is outside the closed lane-class set), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Example: fabrika lane report 5736 --token SHIPPED-PR --pr https://github.com/kamp-us/phoenix/pull/5760",
 	),
 );
 
@@ -238,7 +255,7 @@ const prove = leafCommand(
 			return;
 		}
 		yield* emit(
-			yield* onKey(lane, root, (_key, ref) =>
+			yield* onKey("prove", lane, root, (_key, ref) =>
 				runProve({
 					...ref,
 					event,
@@ -254,7 +271,7 @@ const prove = leafCommand(
 ).pipe(
 	Command.withShortDescription("Prove a lane event against the board before recording it."),
 	Command.withDescription(
-		"Read the artifact a lane event claims — artifacts over self-reports, the rule the retired epic conductor held against a conducted branch. Two events carry a claim, and which artifact answers them is the task's shape. On a single-issue lane and on an epic run's tail: a DONE out of `build` claims an open PR whose body links the task's issue (or, for an investigation, the diagnosis comment a no-PR builder posted since the task entered build), and a PASS out of `review` claims a current-head verdict in every namespace that PR's diff derives, governance included — minus, and only minus, a routed namespace this very event's arm hands to a later cell of this lane's own machine (`--class ui` into `review:ui`; ADR 0320), which then proves the whole set. On an epic run's child, which opens no PR at all (ADR 0285): a DONE out of `build` claims the commits its lane branch adds over `epic/<n>` in THIS tree, and a PASS out of `review` claims a range-scoped verdict on the child issue still bound to the content that range carries now (ADR 0276). Every other event answers `not-required` at exit 0. Writes nothing — the append stays `lane transition`'s. The refusals are artifact-independent, so the range arms take no new seat. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (a lane, board or tree read failed — the proof is UNKNOWN, never proven; an epic branch this tree does not carry is UNKNOWN too), 13 (the task is not in the machine, or names no issue), 21 (the key is not a lane key), 22 (the artifact is provably not there), 23 (a required namespace has no current or still-binding verdict — re-read, record nothing), 24 (a FAIL under a claimed PASS), 25 (several open PRs link the issue, or several lane branches carry the child's commits). Exits 38 too (--class is outside the closed lane-class set). Example: fabrika lane prove 5673 DONE",
+		"Read the artifact a lane event claims — artifacts over self-reports, the rule the retired epic conductor held against a conducted branch. Two events carry a claim, and which artifact answers them is the task's shape. On a single-issue lane and on an epic run's tail: a DONE out of `build` claims an open PR whose body links the task's issue (or, for an investigation, the diagnosis comment a no-PR builder posted since the task entered build), and a PASS out of `review` claims a current-head verdict in every namespace that PR's diff derives, governance included — minus, and only minus, a routed namespace this very event's arm hands to a later cell of this lane's own machine (`--class ui` into `review:ui`; ADR 0320), which then proves the whole set. On an epic run's child, which opens no PR at all (ADR 0285): a DONE out of `build` claims the commits its lane branch adds over `epic/<n>` in THIS tree, and a PASS out of `review` claims a range-scoped verdict on the child issue still bound to the content that range carries now (ADR 0276). Every other event answers `not-required` at exit 0. Writes nothing — the append stays `lane transition`'s. The refusals are artifact-independent, so the range arms take no new seat. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (a lane, board or tree read failed — the proof is UNKNOWN, never proven; an epic branch this tree does not carry is UNKNOWN too), 13 (the task is not in the machine, or names no issue), 21 (the key is not a lane key), 22 (the artifact is provably not there), 23 (a required namespace has no current or still-binding verdict — re-read, record nothing), 24 (a FAIL under a claimed PASS), 25 (several open PRs link the issue, or several lane branches carry the child's commits). Exits 38 too (--class is outside the closed lane-class set), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Example: fabrika lane prove 5673 DONE",
 	),
 );
 
@@ -262,12 +279,12 @@ const history = leafCommand(
 	"history",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* onKey(lane, root, (_key, ref) => runHistory(ref)));
+		yield* emit(yield* onKey("history", lane, root, (_key, ref) => runHistory(ref)));
 	}),
 ).pipe(
 	Command.withShortDescription("The lane's append-only event log, verbatim."),
 	Command.withDescription(
-		"The lane's append-only event log, verbatim — one `{task, event, at}` per recorded event, in append order, carrying the optional `pr`/`comment` refs where the event was recorded with one as its evidence, the `round` a `CLEARED` clears, and the `classes` a class-carrying event named; the log IS the history, and `from`/`to` are reconstructible by folding, never stored. A lane with no events yet answers `[]`. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane could not be read), 21 (the key is not a lane key). Example: fabrika lane history 5673",
+		'The lane\'s append-only event log, verbatim — one `{task, event, at}` per recorded event, in append order, carrying the optional `pr`/`comment` refs where the event was recorded with one as its evidence, the `round` a `CLEARED` clears, and the `classes` a class-carrying event named; the log IS the history, and `from`/`to` are reconstructible by folding, never stored. A lane with no events yet answers `[]`. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane could not be read), 21 (the key is not a lane key), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT "no lane here", so never a boot). Example: fabrika lane history 5673',
 	),
 );
 
@@ -275,12 +292,12 @@ const print = leafCommand(
 	"print",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* onKey(lane, root, (_key, ref) => runPrint(ref)));
+		yield* emit(yield* onKey("print", lane, root, (_key, ref) => runPrint(ref)));
 	}),
 ).pipe(
 	Command.withShortDescription("The lane's compiled machine topology, as data."),
 	Command.withDescription(
-		"The lane's compiled machine topology — phases in order, the two workflow terminals, and per task its initial state, retry budget, and each state's legal events (everything absent refuses at transition time). Exits 4 (workflow.json read in full and not the shape), 7 (no lane there), 11 (the lane could not be read), 21 (the key is not a lane key). Example: fabrika lane print 5673",
+		"The lane's compiled machine topology — phases in order, the two workflow terminals, and per task its initial state, retry budget, and each state's legal events (everything absent refuses at transition time). Exits 4 (workflow.json read in full and not the shape), 7 (no lane there), 11 (the lane could not be read), 21 (the key is not a lane key), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Example: fabrika lane print 5673",
 	),
 );
 
@@ -292,7 +309,7 @@ const open = leafCommand(
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
 		yield* emit(
-			yield* onKey(lane, root, (key, ref) =>
+			yield* onKey("open", lane, root, (key, ref) =>
 				runOpen({...ref, templatePath: templatePath(key._tag)}),
 			),
 		);
@@ -300,7 +317,7 @@ const open = leafCommand(
 ).pipe(
 	Command.withShortDescription("Boot a lane from the committed template its key selects."),
 	Command.withDescription(
-		"Boot one lane: create `<root>/<key>/` and place a byte-identical copy of the committed template the key selects as its workflow.json — the coder template for an issue number, the chore template for a `chore:<name>` key. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template or the lane dir's existence could not be read — UNKNOWN, never a boot), 14 (the lane already exists), 21 (the key is not a lane key). Examples: fabrika lane open 5673 · fabrika lane open chore:park-sweep",
+		'Boot one lane: create `<root>/<key>/` and place a byte-identical copy of the committed template the key selects as its workflow.json — the coder template for an issue number, the chore template for a `chore:<name>` key. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template or the lane dir\'s existence could not be read — UNKNOWN, never a boot), 14 (the lane already exists), 21 (the key is not a lane key), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT "no lane here", so never a boot). Examples: fabrika lane open 5673 · fabrika lane open chore:park-sweep',
 	),
 );
 
@@ -319,19 +336,22 @@ const emitLane = leafCommand(
 		),
 	},
 	Effect.fn(function* ({epic, root, repo}) {
+		const resolved = Option.getOrNull(root) ?? DEFAULT_LANES_ROOT;
 		yield* emit(
-			yield* runEmit({
-				epic,
-				root: Option.getOrNull(root) ?? DEFAULT_LANES_ROOT,
-				repo: Option.getOrNull(repo),
-				env: process.env,
-			}),
+			yield* onGround("emit", [resolved], process.cwd(), () =>
+				runEmit({
+					epic,
+					root: resolved,
+					repo: Option.getOrNull(repo),
+					env: process.env,
+				}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Generate an epic's lane machine from its board topology."),
 	Command.withDescription(
-		"Generate a lane machine from the epic's board state: read the epic body's `## Dependencies` topology (the shape `ledger topology` stages) and emit `<root>/<epic>/workflow.json` — one region per child in the coder template's exact shape, phase-sequenced, parallel within a phase. A closed child boots its region in a final state (`completed` → `shipped`, any other close → `frozen`), so a partly-built epic's machine can still terminate. Deterministic: the same epic body bytes and the same child links (number, state and close reason per child) emit the same machine bytes. Exits 4 (the topology was read in full and does not parse — the defective line, duplicate placement or unplaced requires subject is named), 7 (the epic is proven absent or closed), 8 (the write did not land), 11 (the epic, its child list or the lane dir could not be read — UNKNOWN), 14 (the lane already exists — remove it to regenerate), 15 (no `## Dependencies` topology — plan the epic first), 16 (the topology references a non-child, named), 17 (the topology holds a cycle, path named). Example: fabrika lane emit 5680",
+		"Generate a lane machine from the epic's board state: read the epic body's `## Dependencies` topology (the shape `ledger topology` stages) and emit `<root>/<epic>/workflow.json` — one region per child in the coder template's exact shape, phase-sequenced, parallel within a phase. A closed child boots its region in a final state (`completed` → `shipped`, any other close → `frozen`), so a partly-built epic's machine can still terminate. Deterministic: the same epic body bytes and the same child links (number, state and close reason per child) emit the same machine bytes. Exits 4 (the topology was read in full and does not parse — the defective line, duplicate placement or unplaced requires subject is named), 7 (the epic is proven absent or closed), 8 (the write did not land), 11 (the epic, its child list or the lane dir could not be read — UNKNOWN), 14 (the lane already exists — remove it to regenerate), 15 (no `## Dependencies` topology — plan the epic first), 16 (the topology references a non-child, named), 17 (the topology holds a cycle, path named), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Example: fabrika lane emit 5680",
 	),
 );
 
@@ -347,19 +367,17 @@ const assembly = leafCommand(
 		root: rootFlag,
 	},
 	Effect.fn(function* ({epic, remove, root}) {
+		const resolved = Option.getOrNull(root) ?? DEFAULT_LANES_ROOT;
 		yield* emit(
-			yield* runAssembly({
-				epic,
-				remove,
-				root: Option.getOrNull(root) ?? DEFAULT_LANES_ROOT,
-				lane: String(epic),
-			}),
+			yield* onGround("assembly", [resolved], process.cwd(), () =>
+				runAssembly({epic, remove, root: resolved, lane: String(epic)}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Place, resume or remove an epic run's assembly worktree."),
 	Command.withDescription(
-		"Place the working tree an epic run assembles in — `epic/<n>` checked out at `.claude/worktrees/epic-<n>`, both derived from the epic number and never taken from the caller — and print its absolute path on stdout. The invoking checkout is NEVER switched: `operate`'s boot used to `git switch --create` the assembly branch in whatever tree ran it, which parked a human's working tree on `epic/<n>` for the whole run and left a second concurrent epic no tree to integrate in (#6163). Idempotent in both directions: a worktree already holding the branch is resumed and its path answered with nothing written, and a branch that outlived its worktree — the state `--remove` at a terminal leaves behind — is checked out again as it stands, never re-cut off a fresh base. A worktree whose directory is gone but whose record git still carries (`prunable`) is that same state: the registration is cleared and the branch placed again, never answered as a live path. `--remove` is the lane's terminal step and never forces — a dirty assembly tree is unlanded work, so git's refusal is the answer. Every mode reads the outcome back off `git worktree list` before answering. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there — emit the run's machine first), 8 (the placement or removal ran and did not read back — UNKNOWN), 11 (the working trees or origin could not be read — nothing was placed or removed), 33 (`epic/<n>` is checked out in the main working tree — switch that tree off it first). Examples: fabrika lane assembly 5680 · fabrika lane assembly 5680 --remove",
+		"Place the working tree an epic run assembles in — `epic/<n>` checked out at `.claude/worktrees/epic-<n>`, both derived from the epic number and never taken from the caller — and print its absolute path on stdout. The invoking checkout is NEVER switched: `operate`'s boot used to `git switch --create` the assembly branch in whatever tree ran it, which parked a human's working tree on `epic/<n>` for the whole run and left a second concurrent epic no tree to integrate in (#6163). Idempotent in both directions: a worktree already holding the branch is resumed and its path answered with nothing written, and a branch that outlived its worktree — the state `--remove` at a terminal leaves behind — is checked out again as it stands, never re-cut off a fresh base. A worktree whose directory is gone but whose record git still carries (`prunable`) is that same state: the registration is cleared and the branch placed again, never answered as a live path. `--remove` is the lane's terminal step and never forces — a dirty assembly tree is unlanded work, so git's refusal is the answer. Every mode reads the outcome back off `git worktree list` before answering. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there — emit the run's machine first), 8 (the placement or removal ran and did not read back — UNKNOWN), 11 (the working trees or origin could not be read — nothing was placed or removed), 33 (`epic/<n>` is checked out in the main working tree — switch that tree off it first), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Examples: fabrika lane assembly 5680 · fabrika lane assembly 5680 --remove",
 	),
 );
 
@@ -372,18 +390,17 @@ const pushLane = leafCommand(
 		root: rootFlag,
 	},
 	Effect.fn(function* ({epic, root}) {
+		const resolved = Option.getOrNull(root) ?? DEFAULT_LANES_ROOT;
 		yield* emit(
-			yield* runPush({
-				epic,
-				root: Option.getOrNull(root) ?? DEFAULT_LANES_ROOT,
-				lane: String(epic),
-			}),
+			yield* onGround("push", [resolved], process.cwd(), () =>
+				runPush({epic, root: resolved, lane: String(epic)}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Publish an epic run's assembly branch, confirming the ref moved."),
 	Command.withDescription(
-		"Publish the assembly branch of one epic run — `epic/<n>`, derived from the epic number and never taken from the caller — and INDEPENDENTLY confirm the remote ref moved by reading it back with git ls-remote. The sanctioned push for the one branch no spawned shell owns (ADR 0285), where `build push` refuses because the branch carries no build claim's nonce and a bare `git push` cannot report whether the ref landed (#4213). The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. No force flag exists: the assembly branch only ever grows, one merge per landed child, so a non-fast-forward push is always a mistake. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there — emit the run's machine first), 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane, HEAD, the remote ref or containment could not be read — nothing was pushed), 26 (the tree is not on the assembly branch, or HEAD is detached), 29 (the push would drop commits the remote holds — fetch and merge, never rewrite), 30 (proven: the remote ref did not move). Example: fabrika lane push 5680",
+		"Publish the assembly branch of one epic run — `epic/<n>`, derived from the epic number and never taken from the caller — and INDEPENDENTLY confirm the remote ref moved by reading it back with git ls-remote. The sanctioned push for the one branch no spawned shell owns (ADR 0285), where `build push` refuses because the branch carries no build claim's nonce and a bare `git push` cannot report whether the ref landed (#4213). The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. No force flag exists: the assembly branch only ever grows, one merge per landed child, so a non-fast-forward push is always a mistake. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there — emit the run's machine first), 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane, HEAD, the remote ref or containment could not be read — nothing was pushed), 26 (the tree is not on the assembly branch, or HEAD is detached), 29 (the push would drop commits the remote holds — fetch and merge, never rewrite), 30 (proven: the remote ref did not move), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Example: fabrika lane push 5680",
 	),
 );
 
@@ -406,7 +423,7 @@ const brief = leafCommand(
 	Effect.fn(function* ({lane, root, task, repo}) {
 		const entrypoint = yield* resolveEntrypoint();
 		yield* emit(
-			yield* onKey(lane, root, (_key, ref) =>
+			yield* onKey("brief", lane, root, (_key, ref) =>
 				runBrief({
 					...ref,
 					task: Option.getOrNull(task),
@@ -420,7 +437,7 @@ const brief = leafCommand(
 ).pipe(
 	Command.withShortDescription("The spawn prompt for one task's current leaf state."),
 	Command.withDescription(
-		"Print the spawn prompt for one task's current leaf state, folded fresh from the ledger — so a driver pastes a brief rather than composing one. stdout is the `lane-brief` wire format: which lane, task, state and shell, this driver's lanes root resolved absolute (the shell passes it back to `lane report` as --root; a relative one would resolve against the shell's own worktree), the fabrika entrypoint resolved for this repo (repo-relative in a checkout of fabrika's own repo so each worktree runs its own copy, absolute for an installed one no worktree has a node_modules for), the resolved issue and PR URLs (URLs only — the spawned shell re-reads its own ground), and the format's byte-fixed rules. Hand the bytes to the spawn verbatim — a line appended under them is text the format's own reader calls malformed. On an epic lane a child's state resolves no PR at all and briefs the epic issue, the epic branch and the range to judge, while the tail task briefs the run's single PR under the same refusals (ADR 0285). Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane, the issue, its PRs, this fabrika's own entrypoint or — on a child `review` state — this tree's branches could not be read, UNKNOWN), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 18 (the leaf state routes to no shell — `queued`, `blocked`, `human:*`, a final), 19 (neither the task nor the lane names an issue, or that issue is proven absent), 20 (zero open PRs where the state needs one, or several where one is required), 21 (the key is not a lane key), 22 and 25 (a child `review` state's range, on the seats `lane prove` already spends on the same two facts — no local branch in this tree carries the child's commits, or several do). Example: fabrika lane brief 5680 --task issue_5729",
+		"Print the spawn prompt for one task's current leaf state, folded fresh from the ledger — so a driver pastes a brief rather than composing one. stdout is the `lane-brief` wire format: which lane, task, state and shell, this driver's lanes root resolved absolute (the shell passes it back to `lane report` as --root; a relative one would resolve against the shell's own worktree), the fabrika entrypoint resolved for this repo (repo-relative in a checkout of fabrika's own repo so each worktree runs its own copy, absolute for an installed one no worktree has a node_modules for), the resolved issue and PR URLs (URLs only — the spawned shell re-reads its own ground), and the format's byte-fixed rules. Hand the bytes to the spawn verbatim — a line appended under them is text the format's own reader calls malformed. On an epic lane a child's state resolves no PR at all and briefs the epic issue, the epic branch and the range to judge, while the tail task briefs the run's single PR under the same refusals (ADR 0285). Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane, the issue, its PRs, this fabrika's own entrypoint or — on a child `review` state — this tree's branches could not be read, UNKNOWN), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 18 (the leaf state routes to no shell — `queued`, `blocked`, `human:*`, a final), 19 (neither the task nor the lane names an issue, or that issue is proven absent), 20 (zero open PRs where the state needs one, or several where one is required), 21 (the key is not a lane key), 22 and 25 (a child `review` state's range, on the seats `lane prove` already spends on the same two facts — no local branch in this tree carries the child's commits, or several do), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Example: fabrika lane brief 5680 --task issue_5729",
 	),
 );
 
@@ -443,7 +460,7 @@ const claim = leafCommand(
 	},
 	Effect.fn(function* ({lane, token, repo}) {
 		yield* emit(
-			yield* onKey(lane, Option.none(), (key) =>
+			yield* onBoardKey(lane, (key) =>
 				runLaneClaim({
 					key,
 					lane,
@@ -477,7 +494,7 @@ const release = leafCommand(
 	},
 	Effect.fn(function* ({lane, token, repo}) {
 		yield* emit(
-			yield* onKey(lane, Option.none(), (key) =>
+			yield* onBoardKey(lane, (key) =>
 				runLaneRelease({
 					key,
 					lane,
@@ -518,22 +535,25 @@ const stale = leafCommand(
 		),
 	},
 	Effect.fn(function* ({root, olderThan, claims, repo}) {
+		const roots = Option.match(root, {
+			onNone: () => [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT],
+			onSome: (only) => [only],
+		});
 		yield* emit(
-			yield* runStale({
-				roots: Option.match(root, {
-					onNone: () => [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT],
-					onSome: (only) => [only],
+			yield* onGround("stale", roots, process.cwd(), () =>
+				runStale({
+					roots,
+					olderThanMinutes: Option.getOrElse(olderThan, () => DEFAULT_STALE_MINUTES),
+					now: new Date().toISOString(),
+					claims: claims ? claimReader(Option.getOrNull(repo), process.env) : null,
 				}),
-				olderThanMinutes: Option.getOrElse(olderThan, () => DEFAULT_STALE_MINUTES),
-				now: new Date().toISOString(),
-				claims: claims ? claimReader(Option.getOrNull(repo), process.env) : null,
-			}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Which lanes have gone quiet with something owed on them."),
 	Command.withDescription(
-		`Sweep every lane on disk and answer which ones nothing is driving. A lane's ledger records state, not liveness, so a shell that dies leaves the lane reading active forever (#5897); the age here comes off the \`at\` every event line already carries — nothing new is stored. stdout is {now, olderThanMinutes, scanned, summary, lanes}, oldest silence first, each lane carrying its folded stateValue, its last event's timestamp, its age in minutes and one verdict: "stale" (non-terminal, unparked and silent past the threshold), "moving", "parked" (blocked or a human:* hold — a park is meant to sit), "terminal", "unstarted" (a lane with no events at all, so no age to judge) or "unreadable" (the lane is there and its record is not readable — it is reported, never dropped). Both default roots are swept unless --root names one; an absent root holds no lanes and is not a fault, and zero lanes is an empty answer at exit 0. Stale lanes exit 0 too — this reports, it never resumes. Without --claims the whole sweep runs off disk and makes no network call. --claims additionally reads the board and pairs each NON-TERMINAL lane with the claim standing on its issue, which is the other half a session limit strands: the dead builder's claim marker outlives it, and the lane log cannot see that (#6771). Each paired row then carries claims: {"state":"held",token,session,author,commentId} | {"state":"unclaimed"} | {"state":"unknown",reason} — a board read that failed is unknown, never "unclaimed" — and the answer carries a top-level claims summary, null when the board was never asked. Chore lanes drive no issue and are not paired. Nothing here clears a claim: a stranded one leaves through "fabrika build adopt" then "fabrika build release" (ADR 0295), and "fabrika build claimants <n>" reads one issue the same way. Exits 1 (--older-than is not a non-negative number of minutes), 11 (a root is there and could not be listed — the lane set is UNKNOWN, never a short list). Examples: fabrika lane stale · fabrika lane stale --older-than 30 · fabrika lane stale --claims`,
+		`Sweep every lane on disk and answer which ones nothing is driving. A lane's ledger records state, not liveness, so a shell that dies leaves the lane reading active forever (#5897); the age here comes off the \`at\` every event line already carries — nothing new is stored. stdout is {now, olderThanMinutes, scanned, summary, lanes}, oldest silence first, each lane carrying its folded stateValue, its last event's timestamp, its age in minutes and one verdict: "stale" (non-terminal, unparked and silent past the threshold), "moving", "parked" (blocked or a human:* hold — a park is meant to sit), "terminal", "unstarted" (a lane with no events at all, so no age to judge) or "unreadable" (the lane is there and its record is not readable — it is reported, never dropped). Both default roots are swept unless --root names one; an absent root holds no lanes and is not a fault, and zero lanes is an empty answer at exit 0. Stale lanes exit 0 too — this reports, it never resumes. Without --claims the whole sweep runs off disk and makes no network call. --claims additionally reads the board and pairs each NON-TERMINAL lane with the claim standing on its issue, which is the other half a session limit strands: the dead builder's claim marker outlives it, and the lane log cannot see that (#6771). Each paired row then carries claims: {"state":"held",token,session,author,commentId} | {"state":"unclaimed"} | {"state":"unknown",reason} — a board read that failed is unknown, never "unclaimed" — and the answer carries a top-level claims summary, null when the board was never asked. Chore lanes drive no issue and are not paired. Nothing here clears a claim: a stranded one leaves through "fabrika build adopt" then "fabrika build release" (ADR 0295), and "fabrika build claimants <n>" reads one issue the same way. Exits 1 (--older-than is not a non-negative number of minutes), 11 (a root is there and could not be listed — the lane set is UNKNOWN, never a short list), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT "no lane here", so never a boot). Examples: fabrika lane stale · fabrika lane stale --older-than 30 · fabrika lane stale --claims`,
 	),
 );
 
@@ -546,27 +566,30 @@ const migrate = leafCommand(
 		),
 	},
 	Effect.fn(function* ({root, check}) {
+		const roots = Option.match(root, {
+			onNone: () => [
+				{root: DEFAULT_LANES_ROOT, templatePaths: [templatePath("Issue")]},
+				{root: DEFAULT_CHORES_ROOT, templatePaths: [templatePath("Chore")]},
+			],
+			// A relocated root holds whatever was opened into it, so both templates are
+			// candidates and the lane's own machine id picks — never the root's position.
+			onSome: (only) => [
+				{root: only, templatePaths: [templatePath("Issue"), templatePath("Chore")]},
+			],
+		});
 		yield* emit(
-			yield* runMigrate({
-				roots: Option.match(root, {
-					onNone: () => [
-						{root: DEFAULT_LANES_ROOT, templatePaths: [templatePath("Issue")]},
-						{root: DEFAULT_CHORES_ROOT, templatePaths: [templatePath("Chore")]},
-					],
-					// A relocated root holds whatever was opened into it, so both templates are
-					// candidates and the lane's own machine id picks — never the root's position.
-					onSome: (only) => [
-						{root: only, templatePaths: [templatePath("Issue"), templatePath("Chore")]},
-					],
-				}),
-				check,
-			}),
+			yield* onGround(
+				"migrate",
+				roots.map((swept) => swept.root),
+				process.cwd(),
+				() => runMigrate({roots, check}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Bring every booted lane's machine up to the committed template."),
 	Command.withDescription(
-		'Bring each booted lane\'s workflow.json up to the committed template its root selects, but only where the swap provably moves nothing. `lane open` places a byte-identical copy at boot and refuses to overwrite one afterwards, so a template edit reaches lanes booted after it and no lane already on disk — safe until a token→event map in code changes with it, at which point every booted lane is asked for a cell its frozen machine does not have (ADR 0313). Two things are kept: the lane\'s own `machine.context`, which is per-lane DATA (the task\'s maxRetries, and whatever else a lane declares) and would be erased by a verbatim copy, and any lane whose machine was GENERATED rather than booted — an emitted epic document has no committed template to be brought up to, and is reported, never touched. State is the event log replayed from scratch with no snapshot, so the swap is safe exactly when the existing events.jsonl folds to the same per-task leaf state through both machines; anything else is a rewritten history, not a migration. Each lane carries one verdict: "current" (already the machine this verb would write, read past formatting), "migrated" (judged safe and written), "stale" (judged safe, --check withheld the write), "generated" (not booted from this template), "unsafe" (the log will not replay through one of the two machines, or it folds to a different state — named, never written) or "unreadable". stdout is {check, scanned, summary, lanes}. Both default roots are swept unless --root names one, which is read as a relocated root whose lanes may have booted from either committed template — the lane\'s own machine id picks, never the root\'s position; an absent root holds no lanes and is not a fault. Exits 11 (a template could not be read, or a root is there and could not be listed — the lane set is UNKNOWN, never empty), 37 (at least one lane cannot take the template without moving; those lanes are named on stderr and none of them was written, and so are the ones that were). Examples: fabrika lane migrate --check · fabrika lane migrate',
+		'Bring each booted lane\'s workflow.json up to the committed template its root selects, but only where the swap provably moves nothing. `lane open` places a byte-identical copy at boot and refuses to overwrite one afterwards, so a template edit reaches lanes booted after it and no lane already on disk — safe until a token→event map in code changes with it, at which point every booted lane is asked for a cell its frozen machine does not have (ADR 0313). Two things are kept: the lane\'s own `machine.context`, which is per-lane DATA (the task\'s maxRetries, and whatever else a lane declares) and would be erased by a verbatim copy, and any lane whose machine was GENERATED rather than booted — an emitted epic document has no committed template to be brought up to, and is reported, never touched. State is the event log replayed from scratch with no snapshot, so the swap is safe exactly when the existing events.jsonl folds to the same per-task leaf state through both machines; anything else is a rewritten history, not a migration. Each lane carries one verdict: "current" (already the machine this verb would write, read past formatting), "migrated" (judged safe and written), "stale" (judged safe, --check withheld the write), "generated" (not booted from this template), "unsafe" (the log will not replay through one of the two machines, or it folds to a different state — named, never written) or "unreadable". stdout is {check, scanned, summary, lanes}. Both default roots are swept unless --root names one, which is read as a relocated root whose lanes may have booted from either committed template — the lane\'s own machine id picks, never the root\'s position; an absent root holds no lanes and is not a fault. Exits 11 (a template could not be read, or a root is there and could not be listed — the lane set is UNKNOWN, never empty), 37 (at least one lane cannot take the template without moving; those lanes are named on stderr and none of them was written, and so are the ones that were), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT "no lane here", so never a boot). Examples: fabrika lane migrate --check · fabrika lane migrate',
 	),
 );
 
@@ -581,12 +604,12 @@ const view = leafCommand(
 	},
 	Effect.fn(function* ({root, port}) {
 		const chosen = Option.getOrElse(port, () => DEFAULT_VIEW_PORT);
+		const resolved = Option.getOrElse(root, () => DEFAULT_LANES_ROOT);
 		yield* Effect.logInfo(listeningAt(chosen));
 		yield* emit(
-			yield* runView({
-				root: Option.getOrElse(root, () => DEFAULT_LANES_ROOT),
-				port: chosen,
-			}),
+			yield* onGround("view", [resolved], process.cwd(), () =>
+				runView({root: resolved, port: chosen}),
+			),
 		);
 	}),
 ).pipe(
@@ -594,7 +617,7 @@ const view = leafCommand(
 		"Every lane on disk, on one screen, the ones needing a person first.",
 	),
 	Command.withDescription(
-		"Serve every lane under the root as one page and keep it current while lanes move. `lane status` answers one lane and `lane stale` answers liveness across the fleet; neither answers the question a driver opens a terminal to ask, which is which of these needs ME — a driver reading twelve stateValue blocks to find the one task a human has to unblock is doing by hand what the fold already knows (#6131). Lanes are ordered by attention: waiting on a human, then tripped, then gone quiet, then moving, then finished. Opening one shows its phases, each task's leaf, what it is waiting on, its retry budget and its region drawn with the edges the log walked. The page can send the operator's six events, and every one goes through `lane transition` — validated against the folded state and appended only if the machine accepts it, so a refusal is that verb's own words and `events.jsonl` has exactly one writer, as it did before this verb existed. It serves on localhost and reads the disk it was started on: nothing is uploaded and no lane leaves the machine. Runs until interrupted. Exits 11 (the root is there and could not be listed — the lane set is UNKNOWN, never a short list). Examples: fabrika lane view · fabrika lane view --port 6000",
+		"Serve every lane under the root as one page and keep it current while lanes move. `lane status` answers one lane and `lane stale` answers liveness across the fleet; neither answers the question a driver opens a terminal to ask, which is which of these needs ME — a driver reading twelve stateValue blocks to find the one task a human has to unblock is doing by hand what the fold already knows (#6131). Lanes are ordered by attention: waiting on a human, then tripped, then gone quiet, then moving, then finished. Opening one shows its phases, each task's leaf, what it is waiting on, its retry budget and its region drawn with the edges the log walked. The page can send the operator's six events, and every one goes through `lane transition` — validated against the folded state and appended only if the machine accepts it, so a refusal is that verb's own words and `events.jsonl` has exactly one writer, as it did before this verb existed. It serves on localhost and reads the disk it was started on: nothing is uploaded and no lane leaves the machine. Runs until interrupted. Exits 11 (the root is there and could not be listed — the lane set is UNKNOWN, never a short list), 39 (the cwd is not a repo — neither .fabrika nor .git is there, so a relative lanes root resolves somewhere nobody meant; NOT \"no lane here\", so never a boot). Examples: fabrika lane view · fabrika lane view --port 6000",
 	),
 );
 

--- a/packages/fabrika-cli/src/lane/ground.ts
+++ b/packages/fabrika-cli/src/lane/ground.ts
@@ -1,0 +1,85 @@
+/**
+ * Whether the directory a relative lanes root resolves against is a repo at all — the fact, its
+ * refusal, and the guard every rooted `lane` verb runs through.
+ *
+ * A lanes root is a path (`.fabrika/lanes`, `.fabrika/chores`), so a relative one is joined onto
+ * whatever cwd the process happens to hold. When that cwd drifts off the repo — a session scratchpad,
+ * a subdirectory — the root resolves somewhere nobody meant, and the load path proves the lane
+ * *absent*: the same `7` a repo with no such lane answers, which `operate` reads as "boot a fresh
+ * ledger". A drifted-cwd boot then writes a second ledger over a live lane (#6212). "Not a repo" is a
+ * different fact from "no lane here", and only the second may mean boot.
+ *
+ * An **absolute** root resolves against nothing, so no drift is expressible and no probe is owed —
+ * `lane brief` hands a shell its driver's root absolute for exactly that reason.
+ */
+import {Effect, type FileSystem, Path, Result} from "effect";
+import {exists} from "../io/fs.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {LANE_UNREADABLE, NOT_A_REPO} from "./codes.ts";
+
+/** What marks a directory as a repo checkout: fabrika's own state, or git's (a file in a worktree). */
+export const REPO_MARKERS = [".fabrika", ".git"] as const;
+
+export type Ground =
+	| {readonly _tag: "Grounded"}
+	| {readonly _tag: "NotARepo"; readonly cwd: string; readonly roots: ReadonlyArray<string>}
+	| {readonly _tag: "Unprobeable"; readonly path: string; readonly reason: string};
+
+/**
+ * Prove the ground under every root a verb is about to resolve. A probe that could not be performed
+ * is UNKNOWN, never a repo: an unproven ground may not license a boot any more than a drifted one.
+ */
+export const proveGround = (
+	roots: ReadonlyArray<string>,
+	cwd: string,
+): Effect.Effect<Ground, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const relative = roots.filter((root) => !path.isAbsolute(root));
+		if (relative.length === 0) return {_tag: "Grounded"} as const;
+
+		for (const marker of REPO_MARKERS) {
+			const at = path.join(cwd, marker);
+			const probe = yield* Effect.result(exists(at));
+			if (Result.isFailure(probe)) {
+				return {_tag: "Unprobeable", path: at, reason: probe.failure.reason} as const;
+			}
+			if (probe.success) return {_tag: "Grounded"} as const;
+		}
+		return {_tag: "NotARepo", cwd, roots: relative} as const;
+	});
+
+/**
+ * Seat a ground that is not a repo, saying which fact it is: the cwd is wrong, NOT that this repo
+ * holds no such lane. A caller reading `7` boots; a caller reading this one moves.
+ */
+export const groundRefusal = (
+	verb: string,
+	ground: Exclude<Ground, {_tag: "Grounded"}>,
+): VerbOutcome =>
+	ground._tag === "Unprobeable"
+		? refuse(
+				LANE_UNREADABLE,
+				`${verb}: cannot establish whether ${ground.path} is there: ${ground.reason} — whether this is a repo is UNKNOWN, never a lane's absence.`,
+			)
+		: refuse(
+				NOT_A_REPO,
+				`${verb}: ${ground.cwd} is not a repo — it holds neither ${REPO_MARKERS.join(" nor ")}, so ${ground.roots.join(", ")} resolves somewhere nobody meant. This is NOT "no lane here": run from the repo root, or pass --root as an absolute path.`,
+			);
+
+/**
+ * Run a rooted verb on ground it proved. The group-level guard ahead of every read and every boot,
+ * so no verb re-checks and none can forget: a root reaches a verb only through here.
+ */
+export const onGround = <R>(
+	verb: string,
+	roots: ReadonlyArray<string>,
+	cwd: string,
+	run: () => Effect.Effect<VerbOutcome, never, R>,
+): Effect.Effect<VerbOutcome, never, R | FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const ground = yield* proveGround(roots, cwd);
+		return ground._tag === "Grounded"
+			? yield* run()
+			: groundRefusal(`fabrika lane ${verb}`, ground);
+	});

--- a/packages/fabrika-cli/src/lane/ground.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/ground.unit.test.ts
@@ -1,0 +1,70 @@
+/** The ground guard: a drifted cwd refuses on its own code, a repo with no such lane still boots. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {LANE_ABSENT, LANE_UNREADABLE, NOT_A_REPO} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {onGround} from "./ground.ts";
+import {runStatus} from "./status-verb.ts";
+import {DEFAULT_LANES_ROOT} from "./store.ts";
+
+const REPO = "/work/phoenix";
+const DRIFTED = "/work/phoenix/scratchpad";
+const REF = {root: DEFAULT_LANES_ROOT, lane: "42"};
+
+/** `lane status` behind the guard, exactly as the adapter composes it. */
+const status = (fs: ReturnType<typeof fakeFs>, cwd: string) =>
+	Effect.runPromise(
+		Effect.provide(
+			onGround("status", [REF.root], cwd, () => runStatus(REF)),
+			fs.layer,
+		),
+	);
+
+describe("the ground under a lane verb's root", () => {
+	it("proves a lane absent as before when the cwd IS a repo — a genuine boot is unaffected", async () => {
+		const out = await status(fakeFs({files: {}, directories: [`${REPO}/.git`]}), REPO);
+
+		expect(out.code).toBe(LANE_ABSENT);
+		expect(out.stderr.join("\n")).toContain("copy a workflow template");
+	});
+
+	it("refuses a cwd holding neither marker on its own code, never the lane's absence", async () => {
+		const out = await status(fakeFs({files: {}}), DRIFTED);
+
+		expect(out.code).toBe(NOT_A_REPO);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain(`${DRIFTED} is not a repo`);
+		expect(out.stderr.join("\n")).toContain('NOT "no lane here"');
+	});
+
+	it("takes `.fabrika` alone as a repo — a checkout with lanes and no git dir of its own", async () => {
+		const fs = fakeFs({
+			files: {[`${DEFAULT_LANES_ROOT}/42/workflow.json`]: coderTemplateText()},
+			directories: [`${REPO}/.fabrika`],
+		});
+		const out = await status(fs, REPO);
+
+		expect(out.code).toBe(0);
+	});
+
+	it("owes no probe on an absolute root — nothing resolves against the cwd to drift", async () => {
+		const fs = fakeFs({files: {}});
+		const out = await Effect.runPromise(
+			Effect.provide(
+				onGround("status", ["/elsewhere/.fabrika/lanes"], DRIFTED, () => runStatus(REF)),
+				fs.layer,
+			),
+		);
+
+		expect(out.code).toBe(LANE_ABSENT);
+	});
+
+	it("keeps an unprobeable marker UNKNOWN rather than reading it as a repo or as drift", async () => {
+		const fs = fakeFs({files: {}, unprobeable: [`${REPO}/.fabrika`]});
+		const out = await status(fs, REPO);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stderr.join("\n")).toContain("UNKNOWN");
+	});
+});


### PR DESCRIPTION
Fixes #6212

`lane` verbs resolve `.fabrika/lanes` as a path relative to the cwd, and the load path could not tell
"this repo has no such lane" from "you are not standing in a repo at all" — both came back `Absent`
and exited `7`. `operate` reads `7` as the boot signal, so a driver whose shell drifted into a
scratchpad would boot a fresh ledger over a live lane. It happened twice on 2026-08-18 and only a
human noticing stopped the duplicate.

Now the group proves its ground first. A new `lane/ground.ts` owns the fact end to end: `proveGround`
answers whether the directory a **relative** root resolves against holds `.fabrika` or `.git`,
`groundRefusal` seats it, and `onGround` is the guard every rooted verb runs through — `status`,
`transition`, `report`, `prove`, `history`, `print`, `open`, `brief` via the shared `onKey` adapter,
and `emit`, `assembly`, `push`, `stale`, `migrate`, `view` at their own root resolution. A cwd
holding neither marker exits the new `NOT_A_REPO = 39` with stderr naming the cwd, the root it would
have resolved, and that this is not "no lane here". An absolute root owes no probe at all — nothing
resolves against the cwd, which is why `lane brief` hands a shell its driver's root absolute. A probe
that fails is `11`, never a repo.

`claim` and `release` read no lanes root — they race a marker on the board — so they move to a new
`onBoardKey` that takes the key alone and can no longer reach a root the cwd would decide.

The `Absent` path is untouched when the cwd is a repo: `lane status <n>` on a missing lane still
exits `7` with the "copy a workflow template" remedy. Verified live in this tree both ways (exit `7`
from the repo root, exit `39` from a scratchpad), plus five unit tests in
`lane/ground.unit.test.ts` covering both branches, the `.fabrika`-only marker, the absolute-root
exemption and the unprobeable case.

Grounded in source: `lane/store.ts`'s four load outcomes, `lane/codes.ts`'s `12`+ band and
`exit-code-alignment.ts`'s private-code check (39 clears the base's whole table), and `Result`/`Path`
usage matched to the store's existing idiom.

## Deviations

- **Out-of-scope change** — **Said:** #6212's criteria name the lane verb group's exit code and its
  test. **Did:** also added a sentence to `operate`'s step 1 and exit `39` to the affected verbs'
  `--help` exit lists. **Why:** the skill line "exit `7` is boot" is the second half of the hazard
  the issue describes, and the interface convention says a verb's `--help` lists the codes it can
  exit on. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `claim`/`release`. **Did:** moved them off
  `onKey` onto a new `onBoardKey`. **Why:** they passed `Option.none()` for a root they never read,
  and leaving them on `onKey` would have made the repo probe fire on two verbs whose ground is the
  board — a real regression for a `--repo`-driven run outside a checkout. **Disposition:** stated
  here.
