### PR TITLE
feat: build and build-ui exclude each other's lane with no rule for a shell loading both

### DIFF
--- a/claude-plugins/fabrika/agents/mixed-builder.md
+++ b/claude-plugins/fabrika/agents/mixed-builder.md
@@ -1,0 +1,13 @@
+---
+name: mixed-builder
+description: The mixed builder — spawn target for the fabrika `build` and `build-ui` skills together, the construction stage for a ticket whose deliverable spans both text and a rendered surface. Use it when a driver needs a subagent that lands one mixed-deliverable ticket as a single PR, or repairs such a PR against its gates' current-head verdicts. It carries no behaviour of its own; everything it does comes from the preloaded skills.
+skills: ["fabrika:build", "fabrika:build-ui"]
+tools: ["Bash", "Read", "Write", "Edit", "Grep", "Glob", "Skill", "Agent"]
+---
+
+An agent shell: the **mixed builder** is a spawn target that exists so a driver can address the
+fabrika `build` and `build-ui` skills together, with both already in context. The shell names the
+actor and never the skills it loads, so the `mixed-builder` shell runs `build` and `build-ui`. Every
+step, rubric and terminal token is the skills'. Read them there, and read each skill's composition
+clause for how the two apply to one diff (ADR
+[0319](../../../.decisions/0319-skill-composition-via-shell-skills-list.md)).

--- a/claude-plugins/fabrika/skills/build-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/build-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-ui
-description: "Execute one triaged issue whose deliverable is a rendered visual surface, and land it as a PR — or, given a PR number, enter repair mode. Trigger on \"build the UI for #N\", \"implement the page/component/screen\", \"make the visual change in #N\", \"repair the design FAIL on PR #N\", and whenever backlog work's deliverable is something a user will see rendered. Text construction — code-as-text, prose, plans — is `build`'s lane; judging a rendered surface is `review-ui`'s."
+description: "Execute one triaged issue whose deliverable is a rendered visual surface, and land it as a PR — or, given a PR number, enter repair mode. Trigger on \"build the UI for #N\", \"implement the page/component/screen\", \"make the visual change in #N\", \"repair the design FAIL on PR #N\", and whenever backlog work's deliverable is something a user will see rendered. Text construction — code-as-text, prose, plans — is `build`'s lane, unless a shell preloads both, and then the diff's class picks the law per file; judging a rendered surface is `review-ui`'s."
 arguments: [issue_or_pr_number]
 argument-hint: "[issue-number|pr-number] — an issue number builds, a PR number repairs; omit to pick from the pool"
 context: fork
@@ -56,6 +56,19 @@ rendered surface is `review-ui`'s. **When in doubt, the work is not yours.** Gat
 `fabrika build eligible $issue_or_pr_number`, then claim with `fabrika build claim
 $issue_or_pr_number`. Keep the token it prints — it is `<claim-token>` below, this LANE's name, and
 every later verb takes it as `--token` (#6037). Re-confirm before every later mutation.
+
+**Composition — what holds when `build` is loaded beside this skill.** A shell's `skills:` list is
+its capability set, so a shell preloading both carries both construction laws and a mixed-deliverable
+ticket routes to it whole (ADR
+[0319](../../../../.decisions/0319-skill-composition-via-shell-skills-list.md)). Under that co-load
+the claim-only rule and the doubt clause above stop refusing a ticket that also carries text: claim
+it and build all of it, because the text half is `build`'s law to apply, not a reason to decline.
+**The diff's class picks the law per file** — a ui-class file builds under this skill, a text file
+under `build`'s — and **`fabrika ui manifest` (step 2) stays mandatory before any ui-class file is
+touched**, co-load or not. Co-load lifts nothing else: a ticket with no rendered surface at all is
+still not this skill's, doubt still resolves toward refusal with `build` absent, and either way you
+never invoke another stage skill mid-run to cover a law you lack — a ticket whose class the seed got
+wrong stops here and the lane re-spawns the right shell.
 
 ## 2 — Read the law before you generate anything
 

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build
-description: "Execute one triaged, agent-ready issue end to end and land it as a PR — or, given a PR number, enter repair mode on that PR's branch. Trigger on \"work the next issue\", \"pick up an issue\", \"implement issue #N\", \"build #N\", \"repair PR #N\", \"fix the FAIL on #N\", and whenever triaged backlog work needs turning into a pull request. Rendered-visual construction is `build-ui`'s lane, not this skill's."
+description: "Execute one triaged, agent-ready issue end to end and land it as a PR — or, given a PR number, enter repair mode on that PR's branch. Trigger on \"work the next issue\", \"pick up an issue\", \"implement issue #N\", \"build #N\", \"repair PR #N\", \"fix the FAIL on #N\", and whenever triaged backlog work needs turning into a pull request. Rendered-visual construction is `build-ui`'s lane, not this skill's — unless a shell preloads both, and then the diff's class picks the law per file."
 arguments: [issue_or_pr_number]
 argument-hint: "[issue-number|pr-number] — an issue number builds, a PR number repairs; omit to pick from the pool"
 context: fork
@@ -58,7 +58,9 @@ whether any campaign is active at all — an inert fence is a fact to report, no
 explain.
 Two refusals before claiming: a `type:decision`'s deliverable is a recorded choice
 (`/adr`'s, not yours), and a rendered-visual deliverable is outside this skill's modality
-(`build-ui`'s) — **do not claim either**. The decision refusal has one arm, and a citation is the only
+(`build-ui`'s) — **do not claim either**. Each refusal has exactly one arm. The rendered-visual one
+opens only when `build-ui` is loaded beside you, which is the composition clause below; with that
+skill absent it is unconditional. The decision refusal's arm is a citation, and that is the only
 thing that opens it: when the issue carries a founder ruling comment that already made the choice,
 the deciding is done and the writing is all that is left, so claim it and transcribe — turn that
 ruling into the ADR or amendment it names, nothing more. **The citation goes inside the artifact you
@@ -77,6 +79,19 @@ triage, when it first reads a decision that already carries a ruling comment —
 already parked. On `ready-for:human` the claim is exit `21` and step 2's rule holds unchanged: end
 the run naming the code, and name that verb as the way back in — a control-plane human runs it, never
 you, and never an override on your own authority, however good the citation.
+
+**Composition — what holds when `build-ui` is loaded beside this skill.** A shell's `skills:` list is
+its capability set, so a shell preloading both carries both construction laws and a mixed-deliverable
+ticket routes to it whole (ADR
+[0319](../../../../.decisions/0319-skill-composition-via-shell-skills-list.md)). Under that co-load
+the rendered-visual refusal above does not fire: claim the ticket and build all of it. **The diff's
+class picks the law per file** — a text file builds under this skill, a ui-class file under
+`build-ui`'s — and **`fabrika ui manifest` stays mandatory before any ui-class file is touched**.
+Co-load is the only thing that lifts the refusal, and it lifts that one alone: with `build-ui` absent
+the refusal reads exactly as it does above, and either way you never invoke another stage skill
+mid-run to cover a law you lack — a ticket whose class the seed got wrong stops here and the lane
+re-spawns the right shell.
+
 This skill is not a router: on its own text surfaces
 it executes the whole loop itself. In pick mode neither the argument nor your caller gave you a
 number, so the one `pick` returned stands in its place everywhere below. Then gate your choice:


### PR DESCRIPTION
ADR 0319 rules that a mixed-deliverable ticket routes whole to one shell preloading both `build` and `build-ui`, but forbids wiring that co-load until each skill states what holds under it. Neither did, and both claim gates refused a mixed ticket at once — so the ADR's path was unbuildable. This lands the two clauses and the shell.

- `build` §1: the rendered-visual refusal now names its one arm (co-load), and a composition clause states the rule — the diff's class picks the law per file, `fabrika ui manifest` stays mandatory before any ui-class file is touched. Unconditional again with `build-ui` absent.
- `build-ui` §1: the mirrored clause, carving the claim-only rule and the "when in doubt" clause so they stop refusing a ticket that also carries text. A ticket with no rendered surface is still not that skill's.
- Both `description:` frontmatter lines carry the same carve-out, since that is what the harness surfaces at selection time.
- New `claude-plugins/fabrika/agents/mixed-builder.md` preloads both skills, same tool list and body shape as `builder.md` / `ui-builder.md`.

No skill invokes another skill mid-run: both clauses route a mis-seeded ticket back to the lane instead, per ADR 0319's second binding constraint. ADR 0319 merged to `main` before this branch was cut.

Reviewer: read the two clauses side by side — they must not disagree about which law owns a file, and neither may lift a refusal the ADR left standing.

Fixes #6820

## Deviations

None.
