### PR TITLE
feat: Issue-body amendments via gh api -f body=@file post the path string, not the file

### DIFF
--- a/claude-plugins/fabrika/skills/report/SKILL.md
+++ b/claude-plugins/fabrika/skills/report/SKILL.md
@@ -93,7 +93,7 @@ the file's contents, which is how a machine-local path reaches a public artifact
 reads success — the rule and its reasoning are one section
 (`fabrika wire doc-section --heading "The body is a value, never a path" < <skill-base>/contract.md`).
 Which exit carries which refusal is
-`--heading "The shared exit taxonomy for the two writing verbs"`, and what counts as a leak is
+`--heading "The shared exit taxonomy for the writing verbs"`, and what counts as a leak is
 `--heading "The body-surface leak predicate"`.
 
 Use `--redact` when a machine-local path is genuinely part of the evidence — reporting a leak
@@ -116,6 +116,13 @@ EOF
 Done when the verb exits 0 and prints the comment id and URL. It runs the same guards as `file` over
 a comment body, and its section says which
 (`fabrika wire doc-section --heading "report note" < <skill-base>/contract.md`).
+
+**When the correction belongs in the body rather than under it, amend — never rewrite.** GitHub
+keeps no issue-body history, so a hand-rolled `gh api -X PATCH -f body=@file` that posts the path
+instead of the file destroys the body it was correcting (#6708, #6736). `fabrika report amend
+--issue <n>` appends your section under a separator and a dated heading it composes, leaves the
+prior body verbatim, and proves both halves on the read-back
+(`fabrika wire doc-section --heading "report amend" < <skill-base>/contract.md`).
 
 ## 5 — Report and return
 

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -62,7 +62,7 @@ corpus-wide work filed separately, and these live here until it does.)
   `report file`, so it is a precondition rather than a verb; minting it would be a wrapper whose
   only behaviour is relaying an upstream answer, which ADR 0238 bans.
 - **A standalone redactor verb.** Same test: a transform with one caller is that caller's
-  precondition. It is the `--redact` flag on the two writing verbs.
+  precondition. It is the `--redact` flag on the three writing verbs.
 
 **The residual this accepts.** Because there is no preview verb, a refusal costs the caller the
 whole heredoc again — and re-sending under refusal pressure is exactly the condition that produced
@@ -127,7 +127,7 @@ is how one observation becomes two issues.
 
 ### The body is a value, never a path
 
-The two writing verbs take the body **on stdin only**. There is deliberately **no `--body` flag, no
+The three writing verbs take the body **on stdin only**. There is deliberately **no `--body` flag, no
 `--body-file`, and no temp file**: a flag that accepts a path turns the body into a string the verb
 could post verbatim, which is precisely how the incidents below happened. A shell redirect
 (`< some-file`) is fine and expected — the *shell* reads the file, so what reaches the verb is

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -47,6 +47,7 @@ description stays.
 | `report dedup` | rank the open issues that may already cover an observation | two REST reads, tokenize, score, sort — deciding whether a candidate *is* your observation stays in the skill |
 | `report file` | compose, guard and create the intake issue, then read back what landed | the template, the footer, the leak predicate, the classification refusal, the label and the read-back are all mechanical; what goes in the sections is judgment |
 | `report note` | add a note to an existing issue over the same guarded path | as above, minus composition — the guard and the read-back are the deterministic part |
+| `report amend` | append a dated amendment to an existing issue's **body** over that path | the separator, the dated heading, the guard and the two-halved read-back are mechanical; what the amendment says is judgment |
 
 **Considered and deliberately not derived.** Each is a real proposal someone could make again, so it
 is recorded rather than left to be re-litigated. (The conventions' §7 puts rejections in a plugin-root
@@ -92,24 +93,25 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
 - **GitHub access follows [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql)**
   — REST, paginated, reads and writes alike. The reason lives there, not here.
 
-### The shared exit taxonomy for the two writing verbs
+### The shared exit taxonomy for the writing verbs
 
-`report file` and `report note` allocate codes from **one table**, so a code means the same thing
-whichever produced it. A verb that cannot reach a code leaves it unused rather than compacting the
-range — a gap is cheaper than a collision.
+`report file`, `report note` and `report amend` allocate codes from **one table**, so a code means
+the same thing whichever produced it. A verb that cannot reach a code leaves it unused rather than
+compacting the range — a gap is cheaper than a collision.
 
-| Code | Meaning | `file` | `note` |
-|---|---|:--:|:--:|
-| `0` | the write landed, read back clean, and its answer is on stdout | ✓ | ✓ |
-| `1` | usage error, unresolvable repo, or a failed stdin read | ✓ | ✓ |
-| `3` | stdin was read and held nothing | ✓ | ✓ |
-| `4` | a required section is missing, out of order, or empty | ✓ | — |
-| `5` | the body carries a machine-local path and `--redact` was not given | ✓ | ✓ |
-| `6` | the body is a bare `@` path reference — **not** redactable | ✓ | ✓ |
-| `7` | the write target does not exist (`--label` in the repo / `--issue`) | ✓ | ✓ |
-| `8` | the write itself failed — the outcome is **UNKNOWN** | ✓ | ✓ |
-| `9` | the write landed but the read-back does not match | ✓ | ✓ |
-| `10` | the title or `--label` carries a type or priority classification | ✓ | — |
+| Code | Meaning | `file` | `note` | `amend` |
+|---|---|:--:|:--:|:--:|
+| `0` | the write landed, read back clean, and its answer is on stdout | ✓ | ✓ | ✓ |
+| `1` | usage error, unresolvable repo, or a failed stdin read | ✓ | ✓ | ✓ |
+| `3` | stdin was read and held nothing | ✓ | ✓ | ✓ |
+| `4` | a required section is missing, out of order, or empty | ✓ | — | — |
+| `5` | the body carries a machine-local path and `--redact` was not given | ✓ | ✓ | ✓ |
+| `6` | the body is a bare `@` path reference — **not** redactable | ✓ | ✓ | ✓ |
+| `7` | the write target does not exist (`--label` in the repo / `--issue`) | ✓ | ✓ | ✓ |
+| `8` | the write itself failed — the outcome is **UNKNOWN** | ✓ | ✓ | ✓ |
+| `9` | the write landed but the read-back does not match | ✓ | ✓ | ✓ |
+| `10` | the title or `--label` carries a type or priority classification | ✓ | — | — |
+| `11` | a precondition read failed, so nothing was written | ✓ | ✓ | ✓ |
 
 **`5` and `6` are separate because their fixes are opposite.** The obvious caller loop on a
 path refusal is *re-run with `--redact`*; on a body that **is** a path, `--redact` is a no-op and
@@ -626,7 +628,7 @@ bind here.
 keys `id`, `url`, `issue`, `redactions` and `bodyBytes`.
 
 **Exit status** — allocated from the shared table above. This verb can return `0`, `1`, `3`, `5`,
-`6`, `7`, `8` and `9`; `7` is *`--issue` names no issue in `--repo`*. Codes `4` and `10` are
+`6`, `7`, `8`, `9` and `11`; `7` is *`--issue` names no issue in `--repo`*. Codes `4` and `10` are
 structurally unreachable here and are left unused rather than reassigned.
 
 **Errors**
@@ -695,3 +697,130 @@ $ echo $?
 - v1's `tracker create-comment` prints `tracker: commented on #<n> (ref <id>).` — prose on a machine
   channel, the same scar as its create sibling, and the reason this line is tab-separated with a
   bare id.
+
+---
+
+## `report amend`
+
+Appends a section to an existing issue's **body**, under a separator and a dated heading this verb
+composes. **It exists because there was no public verb for that operation, and the hand-rolled call
+that filled the gap posts a path.** `gh api -X PATCH -f body=@file` takes its value as a raw string,
+so the literal `@/path/to/file` becomes the whole body and the write returns success — #6708 and
+#6736 on 2026-08-21, both self-caught inside a minute. The plumbing was already in the package; what
+was missing was a reachable seat for it, since `triage enrich` is stage-scoped and cannot serve an
+append to an already-triaged issue.
+
+**Invocation**
+
+```
+fabrika report amend --issue 4312 [--redact] [--repo <owner/name>] [--json]
+```
+
+The amendment arrives on **stdin** as markdown.
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--issue` | integer | yes | — | the issue number whose body the amendment is appended to |
+| `--redact` | boolean | no | `false` | mask each machine-local path in the amendment down to its class marker and append the masked section, instead of refusing |
+| `--repo` | string | no | resolved (see Shared conventions) | the repository the issue lives in |
+| `--json` | boolean | no | `false` | emit the full amend record instead of the line grammar |
+| stdin | markdown | yes | — | the amendment section, without its heading |
+
+### The envelope, pinned
+
+The verb composes the separator and the heading, so no caller invents its own and two amendments on
+one issue read as one document. Given a prior body `P` and a section `S` amended on `2026-08-21`,
+the posted body is **exactly**:
+
+```
+<P, with trailing whitespace trimmed>
+
+---
+
+## Amendment — 2026-08-21
+
+<S, trimmed>
+```
+
+with a single trailing newline. `P` is otherwise **verbatim** — no reflow, no re-heading, and no
+redaction of text this verb did not author. On a prior body that is empty or blank the separator is
+omitted and the amendment stands alone: a rule over nothing renders as a stray horizontal line.
+
+The date is **UTC**, so two machines amending the same issue on the same day agree on the heading.
+Two amendments on one day therefore produce two identical headings; that is accepted rather than
+disambiguated, because the `## Amendment — <date>` form is the one
+[`build`'s prose rubric](../build/references/prose.md) already pins, and the reader of an issue body
+reads it top to bottom rather than by heading lookup.
+
+**It never replaces a body.** GitHub keeps no issue-body history, so a replaced body is a lost one —
+which is what both incidents actually destroyed. There is no flag that makes this verb overwrite.
+
+**Output** — one **tab-separated** line: `<issue>`, `<url>`. With `--json`, one object with keys
+`issue`, `url`, `redactions`, `appendedBytes` and `bodyBytes`.
+
+**Exit status** — allocated from the shared table above. This verb can return `0`, `1`, `3`, `5`,
+`6`, `7`, `8`, `9` and `11`. Codes `4` and `10` are structurally unreachable here and are left
+unused rather than reassigned.
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `report amend: stdin was read and held 0 bytes — refusing to append an empty amendment.` | 3 | refusal |
+| `report amend: could not read stdin: <reason> — the amendment is UNKNOWN, never empty.` | 1 | refusal |
+| `report amend: the amendment carries <n> machine-local path(s) — refusing to append them to a public issue.` (then one indented `line <n>, <class>` per hit) | 5 | refusal |
+| `report amend: the amendment is a bare "@" path reference — the composed section never arrived. Send it on stdin; --redact does not apply.` | 6 | refusal |
+| `report amend: <repo> has no issue #<n>.` | 7 | refusal |
+| `report amend: cannot read #<n> in <repo>: <reason> — whether the issue exists is UNKNOWN, so nothing was written.` | 11 | refusal |
+| `report amend: could not write the body of #<n>: <reason> — the amendment is UNKNOWN. Re-read the issue before retrying; the append may have landed.` | 8 | refusal |
+| `report amend: wrote the body of #<n> but the read-back is wrong: <what differs>. The issue exists and needs fixing by hand.` | 9 | refusal |
+
+A **closed** issue is not a refusal — a correction on a closed issue is often exactly the point — but
+the verb says so on stderr (`report amend: #<n> is closed.`).
+
+**Scope** — the leak scan reads the **appended section only**, never the prior body. Scanning the
+prior body would make an append a rewrite of text this verb did not author, and `--redact` would
+then silently edit someone else's words. Zero scope is unreachable: an empty stdin is exit 3 before
+the scan runs. The scope line on stderr names the bytes read and the size of the prior body.
+
+**The read-back proves both halves.** After the PATCH the verb re-reads the issue body and asserts
+the appended section is present **and** the prior body survived, on the same normalized comparison
+`report file` uses. The write's own echo is not evidence — that is #3173's lesson — and a landed
+body missing the prior text is a replacement wearing an append's shape, with no history to recover
+it from.
+
+**Examples**
+
+```
+$ fabrika report amend --issue 4312 <<'EOF'
+The fanout classifier landed in #6629; this issue's `Pointers` section predates it.
+EOF
+4312	https://github.com/kamp-us/phoenix/issues/4312
+```
+
+```
+$ fabrika report amend --issue 4312 --json < correction.md
+{"issue":4312,"url":"https://github.com/kamp-us/phoenix/issues/4312","redactions":[],"appendedBytes":112,"bodyBytes":1904}
+```
+
+```
+$ printf '' | fabrika report amend --issue 4312
+report amend: stdin was read and held 0 bytes — refusing to append an empty amendment.
+$ echo $?
+3
+```
+
+**Grounding**
+
+- **#6708 and #6736** are the two live hits: `-f` posts its value as a raw string, so `body=@file`
+  ships the literal path. Both bodies were briefly destroyed and both were repaired fix-forward.
+- **`restWrite`** ([`packages/fabrika-cli/src/io/gh-api.ts`](../../../../packages/fabrika-cli/src/io/gh-api.ts))
+  sends the body as JSON on the wire, so no `-f`/`-F` argv shape exists inside the CLI at all. This
+  verb is how a caller reaches that path instead of rebuilding the argv one.
+- **#4683** filed the same hazard and was killed because its deliverable hung off retired
+  `pipeline-cli` surfaces. That kill carved out old-pipeline work fabrika lacks the capability for,
+  which is this.
+- **#3086** is the earlier PR-description instance of the same byte pattern, now covered by
+  `build pr-body`. Exit 6 is the shape both share.

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -137,7 +137,7 @@ more than one group: **repo-wide the same number does not mean the same thing.**
 *the format's block is provably not in the artifact*, where `report`'s and this group's is *stdin was
 read and held nothing*.
 
-Where this group's codes overlap **`report`'s two writing verbs** (`3`, `5`, `6`, `7`, `8`, `9`,
+Where this group's codes overlap **`report`'s writing verbs** (`3`, `5`, `6`, `7`, `8`, `9`,
 `10`, `11`) they match them **deliberately**, code for code, so a caller driving `report` and `triage`
 in one sweep reads one meaning. This spec calls `report dedup` (the `--exclude` extension below), and
 that verb reads from the same `report` table: `7` when `--label` is absent, `27`/`28` when the queue

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -773,13 +773,14 @@ File one follow-up observation into the intake queue. Contract:
 | `report dedup` | ranks the open issues that may already cover an observation — `candidates` / `none` / `indeterminate`, all three at exit 0 |
 | `report file` | composes the intake issue from the six sections on stdin, guards it, creates it, and reads back what landed |
 | `report note` | adds a note to an existing issue over the same guarded path, and reads the comment back |
+| `report amend` | appends a dated amendment to an existing issue's **body** over that path, leaving the prior body verbatim above it, and reads the body back |
 
 **Exit codes.** The shared table this group defines, plus `27` the intake queue could not be read ·
 `28` the search index could not be read.
 
-Four behaviours are worth knowing:
+Five behaviours are worth knowing:
 
-- **The body is a value, never a path.** The two writing verbs take it on **stdin only** — no
+- **The body is a value, never a path.** The three writing verbs take it on **stdin only** — no
   `--body`, no `--body-file`. A flag that accepts a path turns the body into a string the verb
   could post verbatim. A shell redirect is fine: the *shell* reads the file.
 - **An empty stdin is a refusal, not an empty body.** A read that failed exits `1` (the body is
@@ -789,6 +790,9 @@ Four behaviours are worth knowing:
   negative over a scope of zero. Both reading and writing verbs check the label first and exit `7`.
 - **The write is not finished until it is read back.** A create call's own response is the server
   echoing the request; exit `9` is the landed artifact failing to match what was composed.
+- **A body is amended, never replaced.** GitHub keeps no issue-body history, so `report amend`
+  appends under a separator and a dated heading it composes itself, and its read-back proves both
+  halves — the amendment landed *and* the prior body survived.
 
 Intake applies **no type and no priority**, defended mechanically: exit `10` refuses a `--label` or
 a title prefix that resolves to the target repo's own type/priority vocabulary.

--- a/packages/fabrika-cli/src/report/amend-verb.ts
+++ b/packages/fabrika-cli/src/report/amend-verb.ts
@@ -1,0 +1,169 @@
+/**
+ * `report amend` — append a dated section to an existing issue's body over the guarded path.
+ *
+ * **This verb exists because there was no public one, and the hand-rolled call that filled the gap
+ * posts a path.** `gh api -X PATCH -f body=@file` takes its value as a raw string, so the literal
+ * `@/path/to/file` lands as the whole body and the write returns success — #6708 and #6736 on
+ * 2026-08-21. The plumbing was already here; what was missing was a reachable seat for it, since
+ * `triage enrich` is stage-scoped and cannot serve an append to an already-triaged issue.
+ *
+ * The scan reads the appended section only. Redacting the prior body would make an append a rewrite
+ * of text this verb never authored, which is the one thing it must never do.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, patchIssueBody, resolveRepo} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {compose} from "./amend.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {normalizeForReadback} from "./compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "./leaks.ts";
+
+export interface AmendOptions {
+	readonly issue: number;
+	readonly redact: boolean;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+	readonly now: () => Date;
+}
+
+const bytes = (text: string): number => new TextEncoder().encode(text).length;
+
+export const runAmend = (
+	options: AmendOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, json} = options;
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `report amend: --issue ${issue} is not an issue number.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"report amend: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`report amend: could not read stdin: ${read.reason} — the amendment is UNKNOWN, never empty.`,
+			);
+		}
+		const sent = read._tag === "NoStdin" ? "" : read.text;
+		const bytesIn = bytes(sent);
+		if (sent.trim() === "") {
+			return refuse(
+				EMPTY_STDIN,
+				bytesIn === 0
+					? "report amend: stdin was read and held 0 bytes — refusing to append an empty amendment."
+					: `report amend: stdin was read and held ${bytesIn} bytes of whitespace — refusing to append an empty amendment.`,
+			);
+		}
+
+		if (isBareAtReference(sent)) {
+			return refuse(
+				BARE_AT_PATH,
+				'report amend: the amendment is a bare "@" path reference — the composed section never arrived. Send it on stdin; --redact does not apply.',
+			);
+		}
+
+		const scan = scanBody(sent);
+		if (scan.leaks.length > 0 && !options.redact) {
+			return refuse(
+				LEAKED_PATH,
+				`report amend: the amendment carries ${scan.leaks.length} machine-local path(s) — refusing to append them to a public issue.`,
+				renderLeaks(scan.leaks),
+			);
+		}
+		const section = options.redact ? scan.redacted : sent;
+		const redactions = options.redact
+			? scan.leaks.map((leak) => ({line: leak.line, class: leak.class}))
+			: [];
+		const redactionNotes = redactions.map(
+			(r) => `report amend: redacted a machine-local path — line ${r.line}, ${r.class}`,
+		);
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(NO_TARGET, `report amend: ${repo} has no issue #${issue}.`);
+		}
+		if (target._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`report amend: cannot read #${issue} in ${repo}: ${target.reason} — whether the issue exists is UNKNOWN, so nothing was written.`,
+			);
+		}
+
+		const prior = target.value.body;
+		const amendment = compose(prior, section, options.now());
+
+		const scope = `report amend: ${repo}#${issue}, ${bytesIn} byte(s) read, appended to ${bytes(prior)} byte(s) of prior body.`;
+		const closed = target.value.state === "closed" ? [`report amend: #${issue} is closed.`] : [];
+		const diagnostics = [scope, ...closed, ...redactionNotes];
+
+		const written = yield* patchIssueBody(repo, issue, amendment.body);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`report amend: could not write the body of #${issue}: ${written.reason} — the amendment is UNKNOWN. Re-read the issue before retrying; the append may have landed.`,
+				diagnostics,
+			);
+		}
+
+		const back = yield* getIssue(repo, issue);
+		if (back._tag !== "Present") {
+			return refuse(
+				READBACK_MISMATCH,
+				`report amend: body written but it could not be read back (${
+					back._tag === "Absent" ? "the issue is now absent" : back.reason
+				}) — inspect #${issue} before continuing.`,
+				diagnostics,
+			);
+		}
+		const landed = normalizeForReadback(back.value.body);
+		// Both halves are the append's whole claim, so both are proven: a landed body missing the prior
+		// text is a replacement wearing an append's shape, and GitHub keeps no history to recover it.
+		const wrong = !landed.includes(normalizeForReadback(amendment.appended))
+			? "the appended amendment is not in the landed body"
+			: !landed.includes(normalizeForReadback(prior))
+				? "the prior body did not survive the write"
+				: null;
+		if (wrong !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`report amend: wrote the body of #${issue} but the read-back is wrong: ${wrong}. The issue exists and needs fixing by hand.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						issue,
+						url: target.value.url,
+						redactions,
+						appendedBytes: bytes(amendment.appended),
+						bodyBytes: bytes(amendment.body),
+					}),
+					diagnostics,
+				)
+			: answer(`${issue}\t${target.value.url}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/report/amend-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/amend-verb.unit.test.ts
@@ -1,0 +1,237 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {compose} from "./amend.ts";
+import {runAmend} from "./amend-verb.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+
+const READ = /^GET .*\/repos\/o\/r\/issues\/4312$/;
+const PATCH = /^PATCH .*\/repos\/o\/r\/issues\/4312$/;
+
+const PRIOR = "## Summary\n\nThe editor loses focus after a save.";
+const SECTION = "Reproduces on the streaming path too, not just the buffered one.";
+const NOW = new Date("2026-08-21T03:31:36Z");
+const URL = "https://example.test/issues/4312";
+
+const issue = (body: string, state = "open"): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		number: 4312,
+		title: "t",
+		body,
+		state,
+		labels: [],
+		html_url: URL,
+		milestone: null,
+	}),
+});
+
+const ACCEPTED: HttpReply = {status: 200, body: "{}"};
+
+const options = {
+	issue: 4312,
+	redact: false,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: SECTION}),
+	now: () => NOW,
+};
+
+const runScripted = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runAmend({...options, ...overrides}), fakeSeams(script).layer));
+
+/** The body the PATCH carried, or `null` when the verb wrote nothing. */
+const written = (seams: {
+	readonly requests: ReadonlyArray<string>;
+	readonly bodies: ReadonlyArray<string>;
+}): string | null => {
+	const at = seams.requests.findIndex((line) => PATCH.test(line));
+	if (at < 0) return null;
+	const sent: unknown = JSON.parse(seams.bodies[at] ?? "{}");
+	const body = (sent as {readonly body?: unknown}).body;
+	return typeof body === "string" ? body : null;
+};
+
+/**
+ * Run against a prior body, echoing whatever the verb PATCHes back on the read-back.
+ *
+ * A live round-trip returns what was written, so a fake answering a fixed body would make every
+ * read-back assertion a claim about the fixture instead of about the verb.
+ */
+const run = async (prior: string, overrides: Partial<typeof options> = {}) => {
+	const probe = fakeSeams([
+		[once(READ), issue(prior)],
+		[PATCH, ACCEPTED],
+	]);
+	const first = await Effect.runPromise(
+		Effect.provide(runAmend({...options, ...overrides}), probe.layer),
+	);
+	const patched = written(probe);
+	if (patched === null) return {outcome: first, body: null};
+	const echoing = fakeSeams([
+		[once(READ), issue(prior)],
+		[PATCH, ACCEPTED],
+		[READ, issue(patched)],
+	]);
+	const outcome = await Effect.runPromise(
+		Effect.provide(runAmend({...options, ...overrides}), echoing.layer),
+	);
+	return {outcome, body: patched};
+};
+
+describe("runAmend", () => {
+	it("appends without touching the prior body, and prints a tab-separated issue and url", async () => {
+		const {outcome, body} = await run(PRIOR);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`4312\t${URL}\n`);
+		expect(body).toBe(compose(PRIOR, SECTION, NOW).body);
+		expect(body?.startsWith(PRIOR)).toBe(true);
+	});
+
+	it("emits the equivalent object on STDOUT with --json", async () => {
+		const {outcome} = await run(PRIOR, {json: true});
+		expect(JSON.parse(outcome.stdout)).toMatchObject({issue: 4312, url: URL, redactions: []});
+	});
+
+	it("amends an empty body with the amendment alone", async () => {
+		const {outcome, body} = await run("");
+		expect(outcome.code).toBe(0);
+		expect(body).toBe(
+			"## Amendment — 2026-08-21\n\nReproduces on the streaming path too, not just the buffered one.\n",
+		);
+	});
+
+	it("amends a CLOSED issue but says so — never a surprise about where it landed", async () => {
+		const script: ReadonlyArray<Scripted> = [
+			[once(READ), issue(PRIOR, "closed")],
+			[PATCH, ACCEPTED],
+			[READ, issue(compose(PRIOR, SECTION, NOW).body, "closed")],
+		];
+		const outcome = await runScripted(script);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stderr.join("\n")).toContain("#4312 is closed.");
+	});
+
+	it("refuses a FAILED stdin read as UNKNOWN, never as an empty amendment", async () => {
+		const outcome = await runScripted([[READ, issue(PRIOR)]], {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
+		});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses an empty-but-READ stdin on its own, different code, and writes nothing", async () => {
+		const seams = fakeSeams([[READ, issue(PRIOR)]]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runAmend({...options, stdin: Effect.succeed({_tag: "Text", text: ""})}),
+				seams.layer,
+			),
+		);
+		expect(outcome.code).toBe(EMPTY_STDIN);
+		expect(seams.requests.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("refuses a bare @ path on its own code even under --redact, and writes nothing", async () => {
+		const seams = fakeSeams([[READ, issue(PRIOR)]]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runAmend({
+					...options,
+					redact: true,
+					stdin: Effect.succeed({_tag: "Text", text: "@/tmp/correction.md"}),
+				}),
+				seams.layer,
+			),
+		);
+		expect(outcome.code).toBe(BARE_AT_PATH);
+		expect(seams.requests.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("refuses a machine-local path in the appended section", async () => {
+		const outcome = await runScripted([[READ, issue(PRIOR)]], {
+			stdin: Effect.succeed({_tag: "Text", text: "reproduced from /Users/someone/case.md"}),
+		});
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(outcome.stderr[0]).toBe("  line 1, absolute home root");
+	});
+
+	it("appends the masked section under --redact", async () => {
+		const {outcome, body} = await run(PRIOR, {
+			redact: true,
+			stdin: Effect.succeed({_tag: "Text", text: "reproduced from /Users/someone/case.md"}),
+		});
+		expect(outcome.code).toBe(0);
+		expect(body).toContain("reproduced from /Users/<redacted>");
+		expect(outcome.stderr.join("\n")).toContain("redacted a machine-local path");
+	});
+
+	it("scans the appended section only — a path in the prior body is preserved, not rewritten", async () => {
+		const leaky = `${PRIOR}\n\nfirst seen at /Users/someone/case.md`;
+		const {outcome, body} = await run(leaky);
+		expect(outcome.code).toBe(0);
+		expect(body).toContain("/Users/someone/case.md");
+	});
+
+	it("refuses an issue that does not exist", async () => {
+		const outcome = await runScripted([[READ, {status: 404, body: '{"message":"Not Found"}'}]]);
+		expect(outcome.code).toBe(NO_TARGET);
+		expect(outcome.stderr.at(-1)).toBe("report amend: o/r has no issue #4312.");
+	});
+
+	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
+		const seams = fakeSeams([[READ, {status: 502, body: "{}"}]]);
+		const outcome = await Effect.runPromise(Effect.provide(runAmend(options), seams.layer));
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(seams.requests.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("reports a failed PATCH as UNKNOWN, with the re-read recovery", async () => {
+		const outcome = await runScripted([
+			[READ, issue(PRIOR)],
+			[PATCH, {status: 500, body: "{}"}],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("may have landed");
+	});
+
+	it("refuses when the appended section is absent from the landed body", async () => {
+		const outcome = await runScripted([
+			[once(READ), issue(PRIOR)],
+			[PATCH, ACCEPTED],
+			[READ, issue(PRIOR)],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain("appended amendment is not in the landed body");
+	});
+
+	it("refuses when the prior body did not survive — a replacement wearing an append's shape", async () => {
+		const outcome = await runScripted([
+			[once(READ), issue(PRIOR)],
+			[PATCH, ACCEPTED],
+			[READ, issue(`something else entirely\n\n${compose(PRIOR, SECTION, NOW).appended}`)],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain("prior body did not survive");
+	});
+
+	it("refuses when the read-back itself fails — the write's own echo is not evidence", async () => {
+		const outcome = await runScripted([
+			[once(READ), issue(PRIOR)],
+			[PATCH, ACCEPTED],
+			[READ, {status: 502, body: "{}"}],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+});

--- a/packages/fabrika-cli/src/report/amend.ts
+++ b/packages/fabrika-cli/src/report/amend.ts
@@ -10,13 +10,16 @@
 /** The rule that separates the prior body from the amendment. */
 export const SEPARATOR = "---";
 
-/** The dated heading each amendment opens with, on the `## Amendment` form `.patterns` prose pins. */
+/**
+ * The dated heading each amendment opens with, on the `## Amendment` form pinned by
+ * `claude-plugins/fabrika/skills/build/references/prose.md`.
+ */
 export const heading = (on: Date): string => `## Amendment — ${on.toISOString().slice(0, 10)}`;
 
 export interface Amendment {
 	/** The whole body to PATCH: the prior body, the envelope, then the section. */
 	readonly body: string;
-	/** The envelope plus the section — what the read-back must find, and what the leak scan read. */
+	/** The envelope plus the section — what the read-back must find. */
 	readonly appended: string;
 }
 

--- a/packages/fabrika-cli/src/report/amend.ts
+++ b/packages/fabrika-cli/src/report/amend.ts
@@ -1,0 +1,33 @@
+/**
+ * The amendment envelope — the bytes `report amend` puts between a filed body and its addendum.
+ *
+ * GitHub keeps no issue-body history, so a body that is replaced is a body that is gone. Every
+ * write here is therefore an append: the prior body survives verbatim above the separator, and the
+ * verb composes the separator and the dated heading itself so no caller invents its own envelope
+ * and two amendments on one issue read as two different documents.
+ */
+
+/** The rule that separates the prior body from the amendment. */
+export const SEPARATOR = "---";
+
+/** The dated heading each amendment opens with, on the `## Amendment` form `.patterns` prose pins. */
+export const heading = (on: Date): string => `## Amendment — ${on.toISOString().slice(0, 10)}`;
+
+export interface Amendment {
+	/** The whole body to PATCH: the prior body, the envelope, then the section. */
+	readonly body: string;
+	/** The envelope plus the section — what the read-back must find, and what the leak scan read. */
+	readonly appended: string;
+}
+
+/**
+ * Append `section` to `prior` under a dated amendment heading.
+ *
+ * A body that is empty or blank gets the amendment alone: a separator ruling off nothing renders as
+ * a stray horizontal rule, and there is no prior text for it to separate.
+ */
+export const compose = (prior: string, section: string, on: Date): Amendment => {
+	const above = prior.replace(/\s+$/, "");
+	const appended = `${above === "" ? "" : `${SEPARATOR}\n\n`}${heading(on)}\n\n${section.trim()}\n`;
+	return {body: above === "" ? appended : `${above}\n\n${appended}`, appended};
+};

--- a/packages/fabrika-cli/src/report/amend.unit.test.ts
+++ b/packages/fabrika-cli/src/report/amend.unit.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from "vitest";
+import {compose, heading, SEPARATOR} from "./amend.ts";
+
+const ON = new Date("2026-08-21T03:31:36Z");
+
+describe("compose", () => {
+	it("keeps the prior body verbatim above the envelope", () => {
+		const prior = "## Summary\n\nThe editor loses focus after a save.";
+		expect(compose(prior, "Reproduces on the streaming path too.", ON).body).toBe(
+			`${prior}\n\n---\n\n## Amendment — 2026-08-21\n\nReproduces on the streaming path too.\n`,
+		);
+	});
+
+	it("composes the separator and the dated heading itself", () => {
+		const {appended} = compose("prior", "note", ON);
+		expect(appended).toBe(`${SEPARATOR}\n\n${heading(ON)}\n\nnote\n`);
+	});
+
+	it("dates the heading in UTC, never the running machine's zone", () => {
+		expect(heading(new Date("2026-08-21T23:59:59Z"))).toBe("## Amendment — 2026-08-21");
+	});
+
+	it("omits the separator on a blank prior body — a rule over nothing rules off nothing", () => {
+		expect(compose("   \n\n", "note", ON).body).toBe("## Amendment — 2026-08-21\n\nnote\n");
+	});
+
+	it("normalises the seam so a prior body's trailing newlines cannot stack blank lines", () => {
+		expect(compose("prior\n\n\n", "note", ON).body).toBe(compose("prior", "note", ON).body);
+	});
+
+	it("appends rather than nests — a second amendment leaves the first one standing", () => {
+		const once = compose("prior", "first", ON).body;
+		const twice = compose(once, "second", ON).body;
+		expect(twice.startsWith(once.trimEnd())).toBe(true);
+		expect(twice.split("## Amendment").length - 1).toBe(2);
+	});
+});

--- a/packages/fabrika-cli/src/report/codes.ts
+++ b/packages/fabrika-cli/src/report/codes.ts
@@ -37,10 +37,10 @@ export const CLASSIFIED = 10;
 /**
  * A precondition read failed, so nothing was written and no outcome is proven.
  *
- * Not in the contract's table, and allocated here rather than folded into an existing code
- * (#4752's class): the label-set read is what makes {@link NO_TARGET} and {@link CLASSIFIED}
- * *proven*, so a failed read of it can be neither. It is not `8` — nothing was attempted — and not
- * `1`, which would fuse an unreachable GitHub with a bad flag.
+ * Allocated its own code rather than folded into an existing one (#4752's class): the label-set
+ * read is what makes {@link NO_TARGET} and {@link CLASSIFIED} *proven*, so a failed read of it can
+ * be neither. It is not `8` — nothing was attempted — and not `1`, which would fuse an unreachable
+ * GitHub with a bad flag.
  */
 export const PRECONDITION_UNKNOWN = 11;
 /**

--- a/packages/fabrika-cli/src/report/codes.ts
+++ b/packages/fabrika-cli/src/report/codes.ts
@@ -1,6 +1,6 @@
 /**
- * The one exit table `report file` and `report note` allocate from, so a code means the same thing
- * whichever verb produced it. A verb that cannot reach a code leaves it unused rather than
+ * The one exit table `report file`, `report note` and `report amend` allocate from, so a code means
+ * the same thing whichever verb produced it. A verb that cannot reach a code leaves it unused rather than
  * compacting the range — a gap is cheaper than a collision.
  *
  * `0`, `1` and `127` are the interface convention's reserved codes (see `../verb.ts`); everything

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -1,5 +1,5 @@
 /**
- * The `report` verb group — `fabrika report <dedup|file|note>`.
+ * The `report` verb group — `fabrika report <dedup|file|note|amend>`.
  *
  * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
  * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives
@@ -16,6 +16,7 @@ import {Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import type {VerbOutcome} from "../verb.ts";
+import {runAmend} from "./amend-verb.ts";
 import {DEFAULT_LIMIT} from "./dedup.ts";
 import {runDedup} from "./dedup-verb.ts";
 import {runFile} from "./file-verb.ts";
@@ -157,8 +158,38 @@ const note = leafCommand(
 	),
 );
 
+const amend = leafCommand(
+	"amend",
+	{
+		issue: Flag.integer("issue").pipe(
+			Flag.withDescription("the issue number whose body the amendment is appended to"),
+		),
+		redact: redactFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, redact, repo, json}) {
+		yield* emit(
+			yield* runAmend({
+				issue,
+				redact,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Append a dated amendment from stdin to an existing issue's body."),
+	Command.withDescription(
+		"Append the section on STDIN to an existing issue's body under a separator and a dated `## Amendment` heading this verb composes, leaving the prior body verbatim above it, then read the body back. Never replaces a body — GitHub keeps no issue-body history. Prints `<issue>\\t<url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue), 8 (write failed — UNKNOWN), 9 (read-back mismatch), 11 (issue unreadable). Example: fabrika report amend --issue 4312 < correction.md",
+	),
+);
+
 export const reportCommand = Command.make("report").pipe(
-	Command.withSubcommands([dedup, fileCmd, note]),
+	Command.withSubcommands([dedup, fileCmd, note, amend]),
 	Command.withShortDescription("File one follow-up observation into the intake queue."),
 	Command.withDescription(
 		"File one follow-up observation into the intake queue: check for a duplicate, then compose and post it over a guarded path that refuses a leak, an empty body, or a hand-applied classification",

--- a/packages/fabrika-cli/src/report/leaks.ts
+++ b/packages/fabrika-cli/src/report/leaks.ts
@@ -1,5 +1,5 @@
 /**
- * The body-surface leak predicate, shared by `report file` and `report note`.
+ * The body-surface leak predicate, shared by `report file`, `report note` and `report amend`.
  *
  * A machine-local path in a body posted to a public issue is a leak, and no merge gate covers it —
  * the repo's committed-file leak gate decides whether a *file in a diff* carries one, and a runtime

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -8,7 +8,7 @@
  * code on `PreToolUse` (`../hook/harness-exit.ts`, #5423).
  *
  * **The alignment with `report` is deliberate, code-for-code, and re-exported rather than
- * re-typed.** Where this table overlaps `report`'s two writing verbs — `3`, `5`, `6`, `7`, `8`, `9`,
+ * re-typed.** Where this table overlaps `report`'s writing verbs — `3`, `5`, `6`, `7`, `8`, `9`,
  * `10`, `11` — the values are *imported* from `../report/codes.ts`, so a caller driving `report` and
  * `triage` in one sweep reads one meaning and a drift between the two is unrepresentable rather than
  * merely detectable (`../review/codes.ts` set the precedent; `../exit-code-alignment.ts` owns the


### PR DESCRIPTION
`report amend` appends a section to an existing issue's **body**, from stdin, over the same guarded
path `report file` and `report note` already use. It never replaces a body.

The gap it fills: fabrika shipped no public verb for amending an issue body, so agents hand-rolled
`gh api -X PATCH -f body=@file` — and `-f` takes its value as a raw string, so the literal
`@/path/to/file` becomes the whole body while the write returns success. `patchIssueBody` already
existed but was reachable only through `triage enrich`, which is stage-scoped and cannot serve an
append to an already-triaged issue.

**What it does**

- Composes the envelope itself: the prior body verbatim, then `---`, then `## Amendment — <UTC date>`,
  then the section. No caller invents its own separator or heading, and the contract pins the bytes.
- Scans the **appended section only**. Scanning the prior body would make an append a rewrite of text
  the verb did not author, and `--redact` would then silently edit someone else's words.
- Proves both halves on the read-back: the amendment landed **and** the prior body survived. A landed
  body missing the prior text is a replacement wearing an append's shape, and GitHub keeps no
  issue-body history to recover it from.
- Allocates no new exit codes — it seats on the `report` group's existing table.

**Where to look first:** [`packages/fabrika-cli/src/report/amend.ts`](packages/fabrika-cli/src/report/amend.ts)
is the whole envelope (30 lines, pure); the two-halved read-back is the `wrong` ternary near the end of
`amend-verb.ts`. The contract section is readable by
`fabrika wire doc-section --heading "report amend" < claude-plugins/fabrika/skills/report/contract.md`.

Grounded in source, not intuition: `restWrite` in `packages/fabrika-cli/src/io/gh-api.ts` sends the
body as JSON on the wire, which is why no `-f`/`-F` argv shape exists inside the CLI and why this
verb is the fix rather than a guard over the flag.

Fixes #6804

## Deviations

- **Out-of-scope change** — **Said:** #6804 names the new verb, its contract section and its tests.
  **Did:** also added a row for exit `11` to the contract's shared exit taxonomy table and added `11`
  to `report note`'s stated exit list. **Why:** `report file` and `report note` both already return
  `PRECONDITION_UNKNOWN` (`file-verb.ts:177`, `note-verb.ts:105`) and the table omitted it; I was
  rewriting that table to add an `amend` column, so leaving the gap would have been me re-publishing
  a table I had just verified is wrong. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** add the verb's contract section. **Did:** also renamed the
  heading `### The shared exit taxonomy for the two writing verbs` to `… for the writing verbs`, and
  updated the `doc-section` pointer in `report/SKILL.md` that names it. **Why:** there are three
  writing verbs now, and the heading is a `wire doc-section` lookup key, so a stale name is a broken
  pointer rather than a wording preference. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the verb composes the dated heading. **Did:** two
  amendments on one issue on one UTC day produce two identical `## Amendment — <date>` headings.
  **Why:** the date-only form is what `build`'s prose rubric already pins, and an issue body is read
  top to bottom rather than by heading lookup. Disambiguating it would be me changing a pinned
  convention from a build lane. **Disposition:** stated in the contract section and here.
- **Out-of-scope change** — **Said:** criterion 11 names two stale sentences in
  `report/contract.md`. **Did:** also changed `triage/contract.md` and
  `packages/fabrika-cli/src/triage/codes.ts`, which both say "`report`'s two writing verbs" when
  naming the exit codes they deliberately share, to "`report`'s writing verbs". **Why:** adding a
  third writing verb is what made those two sentences false, so this diff created the staleness. I
  dropped the count rather than raising it, since both sentences are about which codes align, not
  about how many verbs exist. `ship/authored.ts` says "the two writing verbs" too and was left
  alone: it means `ship note` and `ship resolve`, and is still true. **Disposition:** stated here.

