### PR TITLE
fix: Acceptance-criteria reader still serves the first block: ADR 0326's rules are unimplemented

### DIFF
--- a/packages/fabrika-cli/src/triage/repair-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/repair-criteria.unit.test.ts
@@ -85,6 +85,18 @@ describe("planRepair — the mechanical repair", () => {
 		expect(result.reason).toContain("undecidable");
 	});
 
+	it("refuses a conforming block followed by a level-drifted one — the wedge ADR 0326 leaves standing", () => {
+		// Rule 4 makes the reader `Malformed` here, and this module's own multi-heading refusal still
+		// fires, so the body has no automated repair route. Pinned as the stated outcome: widening
+		// repair to reach it would be a second selection rule (ADR 0326's binding constraints).
+		const result = plan(
+			enveloped(`### Acceptance criteria\n\n${ITEMS}\n\n## Acceptance criteria\n\n- [ ] again`),
+		);
+		expect(result._tag).toBe("Refused");
+		if (result._tag !== "Refused") return;
+		expect(result.reason).toContain("undecidable");
+	});
+
 	it("refuses a drifted heading whose section holds no checkbox item — pre-verified, never written", () => {
 		const result = plan(enveloped("## Acceptance criteria\n\nProse, no checkboxes."));
 		expect(result._tag).toBe("Refused");

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.ts
@@ -315,6 +315,11 @@ const malformed = (reason: string, evidence: string): WireMalformed => ({
  * {@link read} is this answer with the spans dropped, so there is one scanner and one wrapping rule
  * for both — a second one would be a second definition of "criterion".
  *
+ * Which block is served when a body carries more than one is ADR 0326's rules 3–5: the **last**
+ * conforming block is the contract, because amend-never-rewrite appends a re-scope below the
+ * original; a candidate that misses the spelling *below* the served block is `Malformed` rather than
+ * dropped, and one above it stays dropped. The selection lives here and nowhere else (ADR 0241).
+ *
  * `Found` is unreachable with zero criteria — the only `return` that produces it is guarded by the
  * emptiness check below and the type would reject it regardless.
  */
@@ -333,16 +338,19 @@ export const readSpans = (body: string): AcceptanceCriteriaSpans => {
 	if (conforming.length === 0 && first !== undefined) {
 		return malformed(driftReason(first), quote(first));
 	}
-	if (conforming.length > 1) {
-		return malformed(
-			`the body carries ${conforming.length} acceptance-criteria headings — which one is the contract is undecidable`,
-			conforming.map(quote).join(" | "),
-		);
-	}
-
-	const heading = conforming[0];
+	const heading = conforming[conforming.length - 1];
 	if (heading === undefined) {
 		return malformed("the acceptance-criteria heading could not be resolved", "");
+	}
+
+	const nearMissBelow = candidates.find(
+		(candidate) => candidate.line > heading.line && !conforms(candidate),
+	);
+	if (nearMissBelow !== undefined) {
+		return malformed(
+			`a heading below the acceptance-criteria block reaches for it and misses — heading text "${nearMissBelow.text}" at line ${nearMissBelow.line}; an amendment re-posts its whole revised list under "${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}"`,
+			quote(nearMissBelow),
+		);
 	}
 
 	const criteria: CriterionSpan[] = [];

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
@@ -267,13 +267,12 @@ describe("read — Malformed: the drifts a naive reader answers `empty` for", ()
 		expect(result._tag).toBe("Malformed");
 	});
 
-	it("two conforming headings are Malformed — which one is the contract is undecidable", () => {
-		const result = read(
-			body("### Acceptance criteria", "- [ ] one", "", "### Acceptance criteria", "- [ ] two"),
-		);
-		expect(result._tag).toBe("Malformed");
-		if (result._tag !== "Malformed") return;
-		expect(result.reason).toContain("2");
+	it("two conforming headings serve the LAST — an amendment supersedes what it sits below", () => {
+		expect(
+			found(
+				body("### Acceptance criteria", "- [ ] one", "", "### Acceptance criteria", "- [ ] two"),
+			),
+		).toEqual([criterion("two", false)]);
 	});
 
 	it("no drift answer is ever Found, so no caller can read a drift as a zero-criteria contract", () => {
@@ -285,6 +284,81 @@ describe("read — Malformed: the drifts a naive reader answers `empty` for", ()
 			body("### Acceptance criteria", "just prose"),
 		];
 		for (const drift of drifts) expect(read(drift)._tag).toBe("Malformed");
+	});
+});
+
+/**
+ * One case per rule, in the ADR's own order. The pair that carries the design is rules 4 and 5: the
+ * same near-miss heading refuses below the served block and is dropped above it, because only the
+ * one below can be an amendment nobody is grading.
+ */
+describe("read — block selection in an amended body (ADR 0326)", () => {
+	it("rule 1: no candidate heading at all is Absent", () => {
+		expect(read(body("### What to build", "Stand up the group."))._tag).toBe("Absent");
+	});
+
+	it("rule 2: candidates with none conforming is Malformed, naming the first candidate's drift", () => {
+		const result = read(
+			body(
+				"## Acceptance criteria",
+				"- [ ] one",
+				"",
+				"### Revised acceptance criteria",
+				"- [ ] two",
+			),
+		);
+		expect(result._tag).toBe("Malformed");
+		if (result._tag !== "Malformed") return;
+		expect(result.reason).toContain("heading level 2");
+		expect(result.evidence).toContain("## Acceptance criteria");
+	});
+
+	it("rule 3: two conforming blocks serve the last, whole and alone", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the superseded one",
+					"",
+					"## Re-scope after #6690",
+					"",
+					"### Acceptance criteria",
+					"- [ ] the revised one",
+					"- [x] and its second row",
+				),
+			),
+		).toEqual([criterion("the revised one", false), criterion("and its second row", true)]);
+	});
+
+	it("rule 4: a near-miss below the served block is Malformed, naming its text and line", () => {
+		const result = read(
+			body(
+				"### Acceptance criteria",
+				"- [ ] one",
+				"",
+				"### Revised acceptance criteria",
+				"- [ ] two",
+			),
+		);
+		expect(result._tag).toBe("Malformed");
+		if (result._tag !== "Malformed") return;
+		expect(result.reason).toContain("Revised acceptance criteria");
+		expect(result.reason).toContain("line 4");
+		expect(result.evidence).toBe('line 4: "### Revised acceptance criteria"');
+	});
+
+	it("rule 5: a near-miss above the served block is dropped, and the read is Found", () => {
+		expect(
+			found(
+				body(
+					"### Revised acceptance criteria",
+					"- [ ] one",
+					"",
+					"### Acceptance criteria",
+					"- [ ] two",
+				),
+			),
+		).toEqual([criterion("two", false)]);
 	});
 });
 


### PR DESCRIPTION
ADR 0326 landed as documentation only; the reader it rules still implemented the pre-0326 selection. This makes the reader match the ADR.

`readSpans` in `packages/fabrika-cli/src/wire/acceptance-criteria.ts` now:

- serves the **last** conforming `### Acceptance criteria` block when two or more conform, and the `conforming.length > 1` "undecidable" `Malformed` branch is gone (rule 3);
- answers `Malformed` when a candidate heading that reaches for the block but misses the spelling sits **below** the served block, naming that heading's text and its 1-based line, with `quote(heading)` as evidence (rule 4);
- still drops a near-miss **above** the served block in silence (rule 5).

Rules 1 and 2 are untouched, and their existing tests pass unedited. The answer type is unchanged — `Found` / `Absent` / `Malformed`, no new tag and no new field — and no consumer grew a selection branch of its own: the change is confined to `readSpans`, and `read` / `readToLines` inherit it (ADR 0241).

`packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts` gains one case per rule 1–5, and the old `"two conforming headings are Malformed"` case is rewritten to assert last-wins rather than deleted.

`packages/fabrika-cli/src/triage/repair-criteria.ts` is unchanged. A body carrying `### Acceptance criteria` followed by a level-drifted `## Acceptance criteria` is now `Malformed` under rule 4 **and** still refused by `repair-criteria`'s own multi-heading "undecidable" check, so it has no automated repair route. ADR 0326's binding constraints keep repair's scope fixed, so that wedge is pinned as a test in `repair-criteria.unit.test.ts` rather than repaired here.

## Blast radius, re-measured on this branch

Re-ran ADR 0326's measurement against the live open board today, applying the new selection to every open issue body: **287 open issues, 177 carrying a candidate heading, 0 carrying two conforming blocks, 0 carrying a near-miss below the served block.** No open issue's grade changes. (The ADR's own count was 284/177/0/0 yesterday; the delta is three issues filed since.)

`pnpm typecheck` and the full `packages/fabrika-cli` unit suite are green — 451 files, 7668 tests.

Fixes #6898

## Deviations

None.
