### PR TITLE
fix: report amend accepts a pull-request number, so it PATCHes a PR body

### DIFF
--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -773,6 +773,7 @@ unused rather than reassigned.
 | `report amend: the amendment carries <n> machine-local path(s) — refusing to append them to a public issue.` (then one indented `line <n>, <class>` per hit) | 5 | refusal |
 | `report amend: the amendment is a bare "@" path reference — the composed section never arrived. Send it on stdin; --redact does not apply.` | 6 | refusal |
 | `report amend: <repo> has no issue #<n>.` | 7 | refusal |
+| `report amend: #<n> in <repo> is a pull request, not an issue — a PR body is written by \`build pr-body\`.` | 7 | refusal |
 | `report amend: cannot read #<n> in <repo>: <reason> — whether the issue exists is UNKNOWN, so nothing was written.` | 11 | refusal |
 | `report amend: could not write the body of #<n>: <reason> — the amendment is UNKNOWN. Re-read the issue before retrying; the append may have landed.` | 8 | refusal |
 | `report amend: wrote the body of #<n> but the read-back is wrong: <what differs>. The issue exists and needs fixing by hand.` | 9 | refusal |

--- a/packages/fabrika-cli/src/report/amend-verb.ts
+++ b/packages/fabrika-cli/src/report/amend-verb.ts
@@ -112,6 +112,13 @@ export const runAmend = (
 			);
 		}
 
+		if (target.value.isPullRequest) {
+			return refuse(
+				NO_TARGET,
+				`report amend: #${issue} in ${repo} is a pull request, not an issue — a PR body is written by \`build pr-body\`.`,
+			);
+		}
+
 		const prior = target.value.body;
 		const amendment = compose(prior, section, options.now());
 

--- a/packages/fabrika-cli/src/report/amend-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/amend-verb.unit.test.ts
@@ -35,6 +35,15 @@ const issue = (body: string, state = "open"): HttpReply => ({
 	}),
 });
 
+/** What `repos/o/r/issues/4312` answers when 4312 is a pull request: the issue shape plus that key. */
+const pullRequest = (body: string): HttpReply => ({
+	status: 200,
+	body: JSON.stringify({
+		...(JSON.parse(issue(body).body) as Record<string, unknown>),
+		pull_request: {html_url: "https://example.test/pull/4312"},
+	}),
+});
+
 const ACCEPTED: HttpReply = {status: 200, body: "{}"};
 
 const options = {
@@ -187,6 +196,16 @@ describe("runAmend", () => {
 		const outcome = await runScripted([[READ, {status: 404, body: '{"message":"Not Found"}'}]]);
 		expect(outcome.code).toBe(NO_TARGET);
 		expect(outcome.stderr.at(-1)).toBe("report amend: o/r has no issue #4312.");
+	});
+
+	it("refuses a number that is a pull request, and writes nothing", async () => {
+		const seams = fakeSeams([[READ, pullRequest(PRIOR)]]);
+		const outcome = await Effect.runPromise(Effect.provide(runAmend(options), seams.layer));
+		expect(outcome.code).toBe(NO_TARGET);
+		expect(outcome.stderr.at(-1)).toBe(
+			"report amend: #4312 in o/r is a pull request, not an issue — a PR body is written by `build pr-body`.",
+		);
+		expect(written(seams)).toBe(null);
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {


### PR DESCRIPTION
Fixes #6903

`report amend` read its target with `getIssue` and never asked whether the number was an issue or a
pull request. `repos/<owner>/<name>/issues/<n>` answers for both, so `report amend --issue <pr>`
composed its dated `## Amendment` section and PATCHed it onto a PR body — a parsed surface that
`review deviations` and `build deviations` read, and that `build pr-body` is the sanctioned writer for.

This adds the check the nine sibling verbs already carry, on `IssueRecord.isPullRequest`
(`packages/fabrika-cli/src/io/issues.ts`, set from `isRecord(value.pull_request)`). It sits after the
`getIssue` read and before `compose`, so no PATCH is issued, and it reuses `NO_TARGET` (`7`) — the code
the contract already seats for a target that is not an issue — rather than minting one.

A unit test drives the verb against a target fixture carrying a `pull_request` key and asserts both the
exit code and that `written()` returns `null`. The `report amend` exit table in the skill contract carries
the new row.

`report note` has the same missing check and is deliberately untouched: commenting on a PR is often
legitimate, so whether it wants the guard is a separate question the issue ruled out of scope.

## Deviations

None.
