### PR TITLE
fix: report amend emits two exit-9 messages but its contract table documents only one

### DIFF
--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -790,7 +790,11 @@ the scan runs. The scope line on stderr names the bytes read and the size of the
 the appended section is present **and** the prior body survived, on the same normalized comparison
 `report file` uses. The write's own echo is not evidence — that is #3173's lesson — and a landed
 body missing the prior text is a replacement wearing an append's shape, with no history to recover
-it from.
+it from. A read-back that could not be **performed** — the issue answers 404 after the write, or the
+re-read fails — is reported through that same one message, as `the read-back itself failed:
+<reason>` or `the issue is not readable after the write` in the `<what differs>` clause, exactly as
+`report note` and `report file` report theirs. The exit stays `9`: the body was mutated and nobody
+has proven what is in it.
 
 **Examples**
 

--- a/packages/fabrika-cli/src/report/amend-verb.ts
+++ b/packages/fabrika-cli/src/report/amend-verb.ts
@@ -13,7 +13,13 @@
 
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {getIssue, patchIssueBody, resolveRepo} from "../io/issues.ts";
+import {
+	type Existence,
+	getIssue,
+	type IssueRecord,
+	patchIssueBody,
+	resolveRepo,
+} from "../io/issues.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {compose} from "./amend.ts";
@@ -40,6 +46,31 @@ export interface AmendOptions {
 }
 
 const bytes = (text: string): number => new TextEncoder().encode(text).length;
+
+/**
+ * What the read-back found wrong after the PATCH, or `null` when the amendment landed.
+ *
+ * A read-back that could not be performed folds into the same clause as one that came back wrong, so
+ * the verb has a single `READBACK_MISMATCH` message — the shape `report note` and `report file` use.
+ */
+const readbackMismatch = (
+	landed: Existence<IssueRecord>,
+	prior: string,
+	appended: string,
+): string | null => {
+	if (landed._tag === "Absent") return "the issue is not readable after the write";
+	if (landed._tag === "Unknown") return `the read-back itself failed: ${landed.reason}`;
+	const body = normalizeForReadback(landed.value.body);
+	// Both halves are the append's whole claim, so both are proven: a landed body missing the prior
+	// text is a replacement wearing an append's shape, and GitHub keeps no history to recover it.
+	if (!body.includes(normalizeForReadback(appended))) {
+		return "the appended amendment is not in the landed body";
+	}
+	if (!body.includes(normalizeForReadback(prior))) {
+		return "the prior body did not survive the write";
+	}
+	return null;
+};
 
 export const runAmend = (
 	options: AmendOptions,
@@ -135,24 +166,7 @@ export const runAmend = (
 			);
 		}
 
-		const back = yield* getIssue(repo, issue);
-		if (back._tag !== "Present") {
-			return refuse(
-				READBACK_MISMATCH,
-				`report amend: body written but it could not be read back (${
-					back._tag === "Absent" ? "the issue is now absent" : back.reason
-				}) — inspect #${issue} before continuing.`,
-				diagnostics,
-			);
-		}
-		const landed = normalizeForReadback(back.value.body);
-		// Both halves are the append's whole claim, so both are proven: a landed body missing the prior
-		// text is a replacement wearing an append's shape, and GitHub keeps no history to recover it.
-		const wrong = !landed.includes(normalizeForReadback(amendment.appended))
-			? "the appended amendment is not in the landed body"
-			: !landed.includes(normalizeForReadback(prior))
-				? "the prior body did not survive the write"
-				: null;
+		const wrong = readbackMismatch(yield* getIssue(repo, issue), prior, amendment.appended);
 		if (wrong !== null) {
 			return refuse(
 				READBACK_MISMATCH,

--- a/packages/fabrika-cli/src/report/amend-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/amend-verb.unit.test.ts
@@ -252,5 +252,19 @@ describe("runAmend", () => {
 			[READ, {status: 502, body: "{}"}],
 		]);
 		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain("the read-back is wrong:");
+		expect(outcome.stderr.at(-1)).toContain("the read-back itself failed");
+	});
+
+	it("refuses when the issue is gone after the write, through the one message", async () => {
+		const outcome = await runScripted([
+			[once(READ), issue(PRIOR)],
+			[PATCH, ACCEPTED],
+			[READ, {status: 404, body: "{}"}],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain(
+			"report amend: wrote the body of #4312 but the read-back is wrong: the issue is not readable after the write. The issue exists and needs fixing by hand.",
+		);
 	});
 });


### PR DESCRIPTION
`report amend` could exit `9` from two places with two different messages: one when the read-back
call itself came back non-`Present` after the PATCH, one when the landed body was wrong. The Errors
table in `report`'s contract documented only the second — the missing one being the branch a reader
most needs, since the issue body has already been mutated.

Folded to one message, matching what `report note` and `report file` already do. A private
`readbackMismatch` helper (same name and shape as `file-verb.ts`'s) turns every failure into a
`<what differs>` clause of the single `wrote the body of #<n> but the read-back is wrong: …`
refusal: `the read-back itself failed: <reason>` for `Unknown`, `the issue is not readable after the
write` for `Absent`, and the two existing body clauses unchanged. Exit stays `9` everywhere.

Tests: the existing read-back-failure test now pins the message shape, and a new test covers the
404-after-write branch. The contract's exit-`9` row is unchanged; the prose under it now says an
unperformable read-back reports through that same message.

Fixes #6904

## Deviations

None.
