### PR TITLE
fix: review ci reads green when a PR head raised no workflow runs at all

### DIFF
--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -637,7 +637,7 @@ though the `12` stale-refusal seat belongs to `review post`, the write seam.
 | `7` | the PR or the `--sha` is proven absent — no commit to enumerate; **or zero check runs are declared at the commit** — a vacuous green is the ADR 0092 fail-open and is refused; **or the repo has zero workflows** under the shipped `ci.noProducer: "refuse"` |
 | `11` | the check-run read, the workflow-inventory read, the runs-at-head read, or `.fabrika.jsonc`'s `ci` key failed — CI state is UNKNOWN, never `green` |
 | `13` | entries received < declared `total_count` — the enumeration is provably incomplete and is never read as "no red checks" |
-| `16` | the rollup is not `red` and **no workflow this repo authors produced a run at the head** — the enumeration is complete and no gate inspected the bytes |
+| `16` | the rollup is not `red` and **no workflow this repo authors produced a run at the head** — the enumeration is complete, no gate inspected the bytes, and the CI state is UNKNOWN, never `green` |
 
 **Errors**
 
@@ -652,7 +652,7 @@ though the `12` stale-refusal seat belongs to `review post`, the write seam.
 | `review ci: cannot read \`ci\` from the repo config (<reason>) — whether <repo> produces CI is UNKNOWN, never green.` | 11 | refusal |
 | `review ci: <repo> declares \`ci.noProducer: degrade\` and has zero workflows — no producer, so there is nothing to roll up.` | 0 | notice |
 | `review ci: received <k> of <m> declared check runs at <sha> — refusing the partial enumeration (#3999).` | 13 | refusal |
-| `review ci: none of the <g> workflow(s) <repo> authors produced a run at <sha> — the <n> check run(s) here came from elsewhere, so no gate inspected these bytes (#6522).` | 16 | refusal |
+| `review ci: none of the <g> workflow(s) <repo> authors produced a run at <sha> — the <n> check run(s) here came from elsewhere, so no gate inspected these bytes: the CI state is UNKNOWN, never green (#6522).` | 16 | refusal |
 | `review ci: cannot enumerate the workflow inventory of <repo>: <reason> — which gates exist is UNKNOWN, never green.` | 11 | refusal |
 | `review ci: cannot enumerate the workflow runs at <sha>: <reason> — which gates ran is UNKNOWN, never green.` | 11 | refusal |
 | `review ci: <c> of <g> workflow(s) <repo> authors produced a run at <sha>.` | 0 | notice |

--- a/packages/fabrika-cli/src/review/ci-verb.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.ts
@@ -180,7 +180,7 @@ export const runCi = (
 			if (coverage._tag === "Uncovered") {
 				return refuse(
 					NO_GATE_COVERAGE,
-					`${VERB}: none of the ${coverage.declared} workflow(s) ${repo} authors produced a run at ${sha} — the ${runs.length} check run(s) here came from elsewhere, so no gate inspected these bytes (#6522).`,
+					`${VERB}: none of the ${coverage.declared} workflow(s) ${repo} authors produced a run at ${sha} — the ${runs.length} check run(s) here came from elsewhere, so no gate inspected these bytes: the CI state is UNKNOWN, never green (#6522).`,
 					diagnostics,
 				);
 			}

--- a/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
@@ -199,7 +199,25 @@ describe("the gate-coverage read", () => {
 		expect(out.code).toBe(NO_GATE_COVERAGE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
-			`review ci: none of the 2 workflow(s) o/r authors produced a run at ${HEAD} — the 4 check run(s) here came from elsewhere, so no gate inspected these bytes (#6522).`,
+			`review ci: none of the 2 workflow(s) o/r authors produced a run at ${HEAD} — the 4 check run(s) here came from elsewhere, so no gate inspected these bytes: the CI state is UNKNOWN, never green (#6522).`,
+		);
+	});
+
+	it("answers when one authored run sits among the platform's — one gate is coverage", async () => {
+		const out = await run(
+			[
+				[PULL, served(pull())],
+				[RUNS, CODEQL_ONLY],
+			],
+			[
+				[WORKFLOWS, served(inventory(CI_YML, GUARD_YML, CODEQL))],
+				[AT_HEAD, served(runsAtHead(CI_YML, CODEQL))],
+			],
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain(`ci\t${HEAD}\tgreen`);
+		expect(out.stderr).toContain(
+			`review ci: 1 of 2 workflow(s) o/r authors produced a run at ${HEAD}.`,
 		);
 	});
 


### PR DESCRIPTION
Part of #6086.

Most of #6086 already landed under #6522, which built the gate-coverage read this issue asked for:
`review ci` now refuses on exit `16` when the check runs at a head trace to no workflow the repo
authors, using the Actions-API `path` signal (`.github/workflows/…` vs a `dynamic/…` synthesized
run) rather than a list of expected workflow names.

Two gaps in #6086's criteria were still open, and this PR closes them:

- The `16` refusal message did not carry the verb's own anchor phrase. It now ends
  `… so no gate inspected these bytes: the CI state is UNKNOWN, never green (#6522).`, matching the
  wording of the `PRECONDITION_UNKNOWN` arms beside it, so a reviewer reading only stderr sees the
  refusal is an unread state and not a soft pass. The contract's exit and error tables move with it.
- The unit tests covered the all-CodeQL refusal and the all-authored green and red paths, but not
  the mixed case #6086 names — one authored-workflow run among the platform's. Added: it answers
  `green` and reports `1 of 2 workflow(s)`.

Criteria 1, 3 and 5 were already satisfied by the landed code and are unchanged here; criterion 6
is declined below, which is why this is `Part of` rather than `Fixes`.

## Deviations

- **Declined guidance** — **Said:** #6086's last criterion is "the verb makes at most one additional
  GitHub read per invocation". **Did:** left the two reads the gate-coverage path makes — the live
  workflow inventory and the workflow runs at the head. **Why:** coverage is the *intersection* of
  the two, and the inventory read is what makes it fail-closed. Dropping it and judging coverage
  from the runs alone would count a run whose workflow the repo no longer carries as a gate that
  inspected these bytes — a loosening of the exact fail-open #6086 exists to close
  (`gate-coverage.unit.test.ts` pins that case). Reordering so the inventory is read only when no
  authored run is present buys nothing either: that is the refusal path, where the second read is
  load-bearing. **Disposition:** stated here; if the read budget is meant to bind harder than the
  intersection, that is a call for the reviewer, and the criterion should be struck or rewritten
  rather than met by weakening the gate.
- **Scope narrowing** — **Said:** criterion 1 asks the verb to refuse "instead of answering
  `green`/`red`" over an ungated head. **Did:** left #6522's behaviour, which asks the coverage
  question only when the rollup is not `red`. **Why:** a `red` rollup is already the answer a caller
  must act on, and refusing it as ungated would bury a named failing check behind an UNKNOWN.
  `green` and `pending` are the two words that read as "nothing to do here", and both are refused.
  **Disposition:** stated here; landed before this lane, unchanged by it.
