### PR TITLE
fix: fabrika-cli verbs silently truncate a large answer written to a pipe

### DIFF
--- a/claude-plugins/fabrika/docs/interface-convention.md
+++ b/claude-plugins/fabrika/docs/interface-convention.md
@@ -106,6 +106,13 @@ exit taxonomy, and the verdict-vs-invocation separation proven in v1 at
 
 - **`0` means "I produced the answer on stdout". Any non-zero means "I could not produce one"** —
   UNKNOWN, never the permissive reading. A caller reads the status before the bytes.
+- **The whole answer reaches the caller, or the verb has not answered.** A write to stdout is
+  asynchronous when stdout is a pipe — and `x=$(fabrika …)` is a pipe — so `process.exit` on the line
+  after the write discards whatever is still queued, silently and on exit `0`. Every group adapter
+  emits through the one shared helper,
+  [`emit.ts`](../../../packages/fabrika-cli/src/emit.ts), which exits from the write callback
+  instead; a group that hand-rolls its own truncates its long answers again
+  ([#6226](https://github.com/kamp-us/phoenix/issues/6226)).
 - **A verdict a verb proved must never share an exit code with a failure to invoke.** `1` is what
   the Effect CLI returns for a usage error and what a failed module load returns; `127` is the
   shell's missing-binary code. A proven verdict seated on either is unreadable as proof, because

--- a/packages/fabrika-cli/src/adr/command.ts
+++ b/packages/fabrika-cli/src/adr/command.ts
@@ -9,6 +9,7 @@
 import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {corpusOverride, decisionsDirOr} from "../config/paths.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {CORPUS_DECLINED, DIR_UNREADABLE} from "./codes.ts";
@@ -19,20 +20,6 @@ import {runRelate} from "./relate-verb.ts";
 import {runResolve} from "./resolve-verb.ts";
 import {DEFAULT_LIMIT} from "./sweep.ts";
 import {runSweep} from "./sweep-verb.ts";
-
-/**
- * Write the outcome and exit on its code.
- *
- * stdout carries the answer and nothing else; the scope line and every refusal go to stderr. The
- * exit is explicit even for 0 so the code a verb computed is the code the process returns, never
- * whatever the runtime would have inferred.
- */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const dirFlag = Flag.string("dir").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -16,11 +16,12 @@ import {randomUUID} from "node:crypto";
 import {tmpdir} from "node:os";
 import {Effect, type FileSystem, Option, Result} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readFile} from "../io/fs.ts";
 import {readStdin} from "../io/stdin.ts";
 import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
-import {refuse, type VerbOutcome} from "../verb.ts";
+import {refuse} from "../verb.ts";
 import {runBranch} from "./branch-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runAdopt, runClaim, runConfirm, runRelease} from "./claim-verb.ts";
@@ -48,14 +49,6 @@ import {
 import {runScratch} from "./scratch-verb.ts";
 import {runTree} from "./tree-verb.ts";
 import {runChildVerdicts, runVerdicts} from "./verdicts-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/campaign/command.ts
+++ b/packages/fabrika-cli/src/campaign/command.ts
@@ -11,18 +11,11 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runList} from "./list-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runState} from "./state-verb.ts";
-
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const fileFlag = Flag.string("file").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/ci/command.ts
+++ b/packages/fabrika-cli/src/ci/command.ts
@@ -17,21 +17,13 @@
 
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {passThroughStdin, runAnnotate} from "./annotate-verb.ts";
 import {runChangelog} from "./changelog-verb.ts";
 import {runCiEvidence} from "./evidence-verb.ts";
 import {runPrBody} from "./pr-body-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/config/command.ts
+++ b/packages/fabrika-cli/src/config/command.ts
@@ -11,20 +11,12 @@
 import {Effect, type FileSystem, type Path, Result} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {discoverRepoRoot} from "../delegate/root.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {exists, readFile, writeFile} from "../io/fs.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {CONFIG_SCHEMA_FILE} from "./json-schema.ts";
 import {KEY_GROUPS} from "./registry.ts";
 import {runSchema, type SchemaRead, type SchemaRoot, type SchemaSave} from "./schema-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const jsonFlag = Flag.boolean("json").pipe(
 	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),

--- a/packages/fabrika-cli/src/decision/command.ts
+++ b/packages/fabrika-cli/src/decision/command.ts
@@ -12,18 +12,10 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runRule} from "./rule-verb.ts";
 import {runRuling} from "./ruling-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/emit.cli.test.ts
+++ b/packages/fabrika-cli/src/emit.cli.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The half of `emit` only a real subprocess can prove: an answer bigger than the pipe buffer arrives
+ * whole.
+ *
+ * Nothing in-process can catch this. The defect was `process.exit` running before the OS pipe had
+ * drained, so it needs a real process, a real pipe, and an answer past the buffer — under those
+ * three the pre-fix build returned 65,536 of 3,795,600 bytes on exit 0 (#6226). An assertion on the
+ * *shape* of stdout passes against that bug; the assertions here are byte-exact.
+ *
+ * `wire emit` is the producer because its answer scales with stdin, it touches no network, and its
+ * composition is a pure function this file can call directly for the expected bytes.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
+import {emitFromFields} from "./wire/build-deviations.ts";
+import {ZERO_SCOPE} from "./wire/codes.ts";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+/** Comfortably past a 64 KiB pipe buffer — the pre-fix build stopped at one bufferful. */
+const ENTRIES = 20_000;
+
+const fields = [
+	"issue: 6226",
+	...Array.from(
+		{length: ENTRIES},
+		(_unused, at) => `-\tsaid ${at}\tdid ${at}\twhy ${at}\tstated here ${at}`,
+	),
+].join("\n");
+
+/**
+ * `FABRIKA_SKIP_INFER` pins the invocation to *this* copy: the delegation would otherwise resolve
+ * whichever install the enclosing repo root pins, which is not the tree under test.
+ */
+const fabrika = (
+	args: ReadonlyArray<string>,
+	input: string,
+): {readonly code: number; readonly stdout: string} => {
+	try {
+		return {
+			code: 0,
+			stdout: execFileSync(process.execPath, [BIN, ...args], {
+				encoding: "utf8",
+				env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+				input,
+				// execFileSync's own default is 1 MiB, and the answer under test is larger.
+				maxBuffer: 64 * 1024 * 1024,
+				stdio: ["pipe", "pipe", "pipe"],
+			}),
+		};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? ""};
+	}
+};
+
+describe("a verb's answer survives a pipe", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("delivers a multi-megabyte answer byte-complete", () => {
+		const composed = emitFromFields(fields);
+		expect(composed._tag).toBe("Composed");
+		const bytes = composed._tag === "Composed" ? composed.bytes : "";
+		const expected = bytes.endsWith("\n") ? bytes : `${bytes}\n`;
+		expect(expected.length).toBeGreaterThan(1024 * 1024);
+
+		const run = fabrika(["wire", "emit", "--format", "build-deviations"], fields);
+
+		expect(run.code).toBe(0);
+		expect(run.stdout.length).toBe(expected.length);
+		expect(run.stdout).toBe(expected);
+	});
+
+	it("still returns the verb's own exit code", () => {
+		const run = fabrika(["wire", "emit", "--format", "no-such-format"], fields);
+		expect(run.code).toBe(ZERO_SCOPE);
+		expect(run.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/emit.ts
+++ b/packages/fabrika-cli/src/emit.ts
@@ -1,0 +1,38 @@
+/**
+ * Write a verb's outcome to the process streams and exit on its code — stdout is the answer,
+ * everything else is stderr.
+ *
+ * **The exit hangs off the write callbacks, not off the write call returning.** When stdout is a
+ * pipe — including the `x=$(fabrika …)` a caller writes without thinking of it as one — the write is
+ * asynchronous, and `process.exit` tears the process down without draining what is still queued. So
+ * exiting on the line after the write discarded every byte past the pipe buffer, silently and on
+ * exit 0, exactly when the answer was long enough for a reader to need all of it (#6226).
+ *
+ * The exit is explicit on every code, 0 included, so the code a verb computed is the code the
+ * process returns rather than whatever the runtime would have inferred. `process.exitCode` is set
+ * ahead of the writes so a stream that never reports a flush still lands on that same code.
+ */
+import {Effect} from "effect";
+import type {VerbOutcome} from "./verb.ts";
+
+export const emit = (outcome: VerbOutcome): Effect.Effect<never> =>
+	Effect.callback<never>(() => {
+		process.exitCode = outcome.code;
+
+		// The exit holds a count of its own alongside each stream's, so a callback that fires
+		// synchronously cannot exit before the second write has been issued.
+		let pending = 1;
+		const settle = (): void => {
+			pending -= 1;
+			if (pending === 0) process.exit(outcome.code);
+		};
+		const write = (stream: NodeJS.WriteStream, chunk: string): void => {
+			if (chunk === "") return;
+			pending += 1;
+			stream.write(chunk, settle);
+		};
+
+		write(process.stderr, outcome.stderr.map((line) => `${line}\n`).join(""));
+		write(process.stdout, outcome.stdout);
+		settle();
+	});

--- a/packages/fabrika-cli/src/emit.ts
+++ b/packages/fabrika-cli/src/emit.ts
@@ -15,8 +15,11 @@
 import {Effect} from "effect";
 import type {VerbOutcome} from "./verb.ts";
 
-export const emit = (outcome: VerbOutcome): Effect.Effect<never> =>
-	Effect.callback<never>(() => {
+// Declared `void` rather than the `never` this actually is: an `Effect<never>` yielded without
+// `return` is what effect's `missingReturnYieldStar` rule reds on, and every adapter's tail is a
+// bare `yield* emit(...)`. Nothing resumes past the exit either way.
+export const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.callback<void>(() => {
 		process.exitCode = outcome.code;
 
 		// The exit holds a count of its own alongside each stream's, so a callback that fires

--- a/packages/fabrika-cli/src/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/emit.unit.test.ts
@@ -3,7 +3,7 @@
  * answers again, silently and on exit 0 (#6226). Reds instead.
  *
  * It reads source text rather than behaviour on purpose — the defect is invisible in-process, so
- * only a spawn can observe it (`./emit.cli.test.ts` does, once), and spawning all 29 groups to prove
+ * only a spawn can observe it (`./emit.cli.test.ts` does, once), and spawning every group to prove
  * a shared helper is still shared is not a budget this package has.
  */
 import {readdirSync, readFileSync} from "node:fs";

--- a/packages/fabrika-cli/src/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/emit.unit.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The coverage guard: a group that writes its own `emit` opts out of the drain and truncates its
+ * answers again, silently and on exit 0 (#6226). Reds instead.
+ *
+ * It reads source text rather than behaviour on purpose — the defect is invisible in-process, so
+ * only a spawn can observe it (`./emit.cli.test.ts` does, once), and spawning all 29 groups to prove
+ * a shared helper is still shared is not a budget this package has.
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+const SRC = fileURLToPath(new URL(".", import.meta.url));
+
+const groupCommands = readdirSync(SRC, {withFileTypes: true})
+	.filter((entry) => entry.isDirectory())
+	.map((entry) => [`${entry.name}/command.ts`, `${SRC}${entry.name}/command.ts`] as const)
+	.filter(([, path]) => {
+		try {
+			readFileSync(path, "utf8");
+			return true;
+		} catch {
+			return false;
+		}
+	});
+
+describe("every verb group emits through the shared, drain-safe helper", () => {
+	it("finds group adapters at all — fail closed on zero scope (ADR 0092)", () => {
+		expect(groupCommands.length).toBeGreaterThan(0);
+	});
+
+	it.each(groupCommands)("`%s` imports it rather than declaring one", (_label, path) => {
+		expect(readFileSync(path, "utf8")).toContain('from "../emit.ts"');
+	});
+
+	it.each(groupCommands)("`%s` never exits on an undrained write", (_label, path) => {
+		expect(readFileSync(path, "utf8")).not.toContain("process.exit(outcome.code)");
+	});
+});

--- a/packages/fabrika-cli/src/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/emit.unit.test.ts
@@ -24,6 +24,12 @@ const groupCommands = readdirSync(SRC, {withFileTypes: true})
 		}
 	});
 
+/** The name the adapter bound the shared helper to — several import it `as emitOutcome`. */
+const localName = (source: string): string | undefined => {
+	const match = /\bemit(?:\s+as\s+(\w+))?\s*(?:,[^}]*)?\}\s*from\s*"\.\.\/emit\.ts"/.exec(source);
+	return match === null ? undefined : (match[1] ?? "emit");
+};
+
 describe("every verb group emits through the shared, drain-safe helper", () => {
 	it("finds group adapters at all — fail closed on zero scope (ADR 0092)", () => {
 		expect(groupCommands.length).toBeGreaterThan(0);
@@ -33,7 +39,16 @@ describe("every verb group emits through the shared, drain-safe helper", () => {
 		expect(readFileSync(path, "utf8")).toContain('from "../emit.ts"');
 	});
 
-	it.each(groupCommands)("`%s` never exits on an undrained write", (_label, path) => {
-		expect(readFileSync(path, "utf8")).not.toContain("process.exit(outcome.code)");
+	it.each(groupCommands)("`%s` calls it, not merely imports it", (_label, path) => {
+		const source = readFileSync(path, "utf8");
+		const bound = localName(source);
+		expect(bound).toBeDefined();
+		expect(source).toMatch(new RegExp(`yield\\*\\s*${bound}\\(`));
+	});
+
+	// Any exit from an adapter is a hand-rolled emit however it is spelled: the answer is on stdout
+	// by then, and only the shared helper's write callbacks know it drained.
+	it.each(groupCommands)("`%s` never exits the process itself", (_label, path) => {
+		expect(readFileSync(path, "utf8")).not.toMatch(/process\.exit\(/);
 	});
 });

--- a/packages/fabrika-cli/src/glossary/command.ts
+++ b/packages/fabrika-cli/src/glossary/command.ts
@@ -18,23 +18,15 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runAdd} from "./add-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runDrift} from "./drift-verb.ts";
 import {runInit} from "./init-verb.ts";
 import {runLookup} from "./lookup-verb.ts";
 import {runSections} from "./sections-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const dirFlag = Flag.string("dir").pipe(
 	Flag.withDefault(".glossary"),

--- a/packages/fabrika-cli/src/governance/command.ts
+++ b/packages/fabrika-cli/src/governance/command.ts
@@ -18,6 +18,7 @@
 import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {corpusOverride, decisionsDirOr} from "../config/paths.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
@@ -29,14 +30,6 @@ import {runPost} from "./post-verb.ts";
 import {runReadout} from "./readout-verb.ts";
 import {runScope} from "./scope-verb.ts";
 import {runSweep} from "./sweep-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/graduate/command.ts
+++ b/packages/fabrika-cli/src/graduate/command.ts
@@ -15,23 +15,15 @@
 
 import {Effect, type FileSystem, Option, Result} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit as emitOutcome} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readFile} from "../io/fs.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import type {DocumentRead} from "./compose-verb.ts";
 import {runCompose} from "./compose-verb.ts";
 import {runEmit} from "./emit-verb.ts";
 import {runRead} from "./read-verb.ts";
 import {runTrail} from "./trail-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emitOutcome = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 /**
  * Read a document the verb was pointed at, as a value.

--- a/packages/fabrika-cli/src/grill/command.ts
+++ b/packages/fabrika-cli/src/grill/command.ts
@@ -15,23 +15,16 @@
 
 import {Effect, type FileSystem, Option, Result} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readFile} from "../io/fs.ts";
 import {readStdin} from "../io/stdin.ts";
-import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {FAILED, refuse} from "../verb.ts";
 import {type DocumentRead, runAnswer} from "./answer-verb.ts";
 import {openSubject, runOpen} from "./open-verb.ts";
 import {runRead} from "./read-verb.ts";
 import {runRound} from "./round-verb.ts";
 import {runRule} from "./rule-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 /**
  * Read a document the verb was pointed at, as a value.

--- a/packages/fabrika-cli/src/guard/command.ts
+++ b/packages/fabrika-cli/src/guard/command.ts
@@ -14,8 +14,8 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runCatalogGuard} from "./catalog-verb.ts";
 import {runChangeDetectGuard} from "./change-detect-verb.ts";
 import {runCodeownersCpGuard} from "./codeowners-cp-verb.ts";
@@ -36,14 +36,6 @@ import {runRoadmapGuard} from "./roadmap-verb.ts";
 import {runSettingsEnvGuard} from "./settings-env-verb.ts";
 import {runSkillLint} from "./skill-lint-verb.ts";
 import {runUnresolvedThreadsGuard} from "./unresolved-threads-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/handoff/command.ts
+++ b/packages/fabrika-cli/src/handoff/command.ts
@@ -17,21 +17,13 @@
 
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runCapture} from "./capture-verb.ts";
 import {runClaim} from "./claim-verb.ts";
 import {runRead} from "./read-verb.ts";
 import {runTake} from "./take-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/heal-ci/command.ts
+++ b/packages/fabrika-cli/src/heal-ci/command.ts
@@ -16,9 +16,9 @@
  */
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runClassify} from "./classify-verb.ts";
 import {runDiagnose} from "./diagnose-verb.ts";
 import {runLogs} from "./logs-verb.ts";
@@ -27,14 +27,6 @@ import {runRerun} from "./rerun-verb.ts";
 import {SIGNATURE_IDS} from "./signatures.ts";
 import {runSurface} from "./surface-verb.ts";
 import {runSweep} from "./sweep-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/hook/command.ts
+++ b/packages/fabrika-cli/src/hook/command.ts
@@ -10,19 +10,11 @@
  */
 import {Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {emit as emitOutcome} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runCodes} from "./codes-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emitOutcome = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const jsonFlag = Flag.boolean("json").pipe(
 	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -12,6 +12,7 @@ import {Effect, type FileSystem, Option, Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {claimReader} from "../build/claimants-verb.ts";
 import {resolveEntrypoint} from "../delegate/entrypoint.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {SHIP_CLASS_NAMES} from "../review/classes.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
@@ -37,14 +38,6 @@ import {runStatus} from "./status-verb.ts";
 import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
 import {runTransition} from "./transition-verb.ts";
 import {DEFAULT_VIEW_PORT, listeningAt, runView} from "./view-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const laneArgument = Argument.string("lane").pipe(
 	Argument.withDescription(

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -17,9 +17,9 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runChild} from "./child-verb.ts";
 import {runDraft} from "./draft-verb.ts";
 import {runEdges} from "./edges-verb.ts";
@@ -27,14 +27,6 @@ import {runOpen} from "./open-verb.ts";
 import {runSupersede} from "./supersede-verb.ts";
 import {runTopology} from "./topology-verb.ts";
 import {runWrite} from "./write-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/map/command.ts
+++ b/packages/fabrika-cli/src/map/command.ts
@@ -23,9 +23,9 @@
 import {randomBytes} from "node:crypto";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {KINDS} from "./body.ts";
 import {runDescope} from "./descope-verb.ts";
 import {runFinding} from "./finding-verb.ts";
@@ -36,14 +36,6 @@ import {runOpen} from "./open-verb.ts";
 import {runRead} from "./read-verb.ts";
 import {runRecord} from "./record-verb.ts";
 import {runTicket} from "./ticket-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/pattern/command.ts
+++ b/packages/fabrika-cli/src/pattern/command.ts
@@ -13,21 +13,13 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runAnchor} from "./anchor-verb.ts";
 import {runCorpus} from "./corpus-verb.ts";
 import {runDrift} from "./drift-verb.ts";
 import {runNew} from "./new-verb.ts";
 import {runRegister} from "./register-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const dirFlag = Flag.string("dir").pipe(
 	Flag.withDefault(".patterns"),

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -15,23 +15,15 @@
 
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runApproval} from "./approval-verb.ts";
 import {runApprove} from "./approve-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runFlip} from "./flip-verb.ts";
 import {runRead} from "./read-verb.ts";
 import {runVerdict} from "./verdict-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/recipe/command.ts
+++ b/packages/fabrika-cli/src/recipe/command.ts
@@ -8,20 +8,12 @@
  */
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runRerun} from "./rerun-verb.ts";
 import {runRoute} from "./route-verb.ts";
 import {runUnpark} from "./unpark-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -13,22 +13,14 @@
  */
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runAmend} from "./amend-verb.ts";
 import {DEFAULT_LIMIT} from "./dedup.ts";
 import {runDedup} from "./dedup-verb.ts";
 import {runFile} from "./file-verb.ts";
 import {runNote} from "./note-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const DEFAULT_LABEL = "status:needs-triage";
 

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -16,9 +16,10 @@ import {tmpdir} from "node:os";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {designHarnessOr} from "../config/paths.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import {refuse, type VerbOutcome} from "../verb.ts";
+import {refuse} from "../verb.ts";
 import {PRECONDITION_UNKNOWN} from "./codes.ts";
 import {runNote} from "./note-verb.ts";
 import {runPost} from "./post-verb.ts";
@@ -26,14 +27,6 @@ import {captureRenderLeg} from "./render-leg.ts";
 import {runRender} from "./render-verb.ts";
 import {runRoute} from "./route-verb.ts";
 import {githubAttachmentUploadLeg} from "./upload-leg.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -11,10 +11,10 @@
  */
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import {CAP_ROUND} from "../retry-budget.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runAppendCriterion} from "./append-criterion-verb.ts";
 import {runCi} from "./ci-verb.ts";
 import {runCriteria} from "./criteria-verb.ts";
@@ -23,14 +23,6 @@ import {runDiff} from "./diff-verb.ts";
 import {runPost} from "./post-verb.ts";
 import {runScope} from "./scope-verb.ts";
 import {runVerdicts} from "./verdicts-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 /**
  * The two flags every verb in this group shares, declared once here.

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -11,9 +11,9 @@
  */
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runChecks} from "./checks-verb.ts";
 import {runCpApproval} from "./cp-approval-verb.ts";
 import {runDisarm} from "./disarm-verb.ts";
@@ -30,14 +30,6 @@ import {runRelease} from "./release-verb.ts";
 import {runResolve} from "./resolve-verb.ts";
 import {runScope} from "./scope-verb.ts";
 import {runThreads} from "./threads-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/spend/command.ts
+++ b/packages/fabrika-cli/src/spend/command.ts
@@ -8,19 +8,11 @@
  */
 import {Effect} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {DEFAULT_SPEND_LEDGER_PATH} from "./ledger.ts";
 import {runRead} from "./read-verb.ts";
 import {runRollup} from "./rollup-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const read = leafCommand(
 	"read",

--- a/packages/fabrika-cli/src/spike/command.ts
+++ b/packages/fabrika-cli/src/spike/command.ts
@@ -20,24 +20,16 @@ import {randomBytes} from "node:crypto";
 import {tmpdir} from "node:os";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {execRecord} from "../io/exec.ts";
 import {readStdin} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runCapture} from "./capture-verb.ts";
 import {runDispose} from "./dispose-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runRun} from "./run-verb.ts";
 import {runStatus} from "./status-verb.ts";
 import {KINDS} from "./workspace.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -17,6 +17,7 @@ import {CONFIG_PATH, type ConfigSource} from "../config/document.ts";
 import {readConfigSource} from "../config/source.ts";
 import {repoConfigSource} from "../config/working-root.ts";
 import {discoverRepoRoot} from "../delegate/root.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import type {Attempt} from "../io/git.ts";
 import {resolveRepo} from "../io/issues.ts";
@@ -24,7 +25,6 @@ import {readStdin} from "../io/stdin.ts";
 import {DEFAULT_STALE_MINUTES} from "../lane/stale.ts";
 import {runStale} from "../lane/stale-verb.ts";
 import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT} from "../lane/store.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {readBoard, runBoard} from "./board-verb.ts";
 import {knownIds, runBootstrap} from "./bootstrap-verb.ts";
 import {instant, readNow} from "./fields.ts";
@@ -46,14 +46,6 @@ import {badIssueRefusal, issueNumberOf, readReadout, runReadout} from "./readout
 import {type RosterSources, readRoster} from "./roster.ts";
 import {runSettings, settingRows} from "./settings-verb.ts";
 import {readWiringSource, repoWiringSource, runWiring, wiringOf} from "./wiring-verb.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -20,9 +20,10 @@ import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {CONFIG_PATH} from "../config/document.ts";
 import {readRoadmapFile} from "../config/paths.ts";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
-import {refuse, type VerbOutcome} from "../verb.ts";
+import {refuse} from "../verb.ts";
 import {runApply} from "./apply-verb.ts";
 import {runClaim} from "./claim-verb.ts";
 import {PRECONDITION_UNKNOWN} from "./codes.ts";
@@ -39,14 +40,6 @@ import {ROADMAP_FILE} from "./roadmap.ts";
 import {runScratch} from "./scratch-verb.ts";
 import {runSplit} from "./split-verb.ts";
 import {readStandingLanes} from "./standing-lanes.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 /**
  * The two flags every verb in this group shares, declared once here.

--- a/packages/fabrika-cli/src/ui/command.ts
+++ b/packages/fabrika-cli/src/ui/command.ts
@@ -12,8 +12,8 @@
 import {tmpdir} from "node:os";
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {playwrightBrowse} from "./browser.ts";
 import {runEvidence} from "./evidence-verb.ts";
 import {runGolden} from "./golden-verb.ts";
@@ -22,14 +22,6 @@ import {runLaw} from "./law-verb.ts";
 import {runManifest} from "./manifest-verb.ts";
 import {runRender} from "./render-verb.ts";
 import {spawnHarness} from "./server.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const repoFlag = Flag.string("repo").pipe(
 	Flag.optional,

--- a/packages/fabrika-cli/src/wire/command.ts
+++ b/packages/fabrika-cli/src/wire/command.ts
@@ -15,10 +15,10 @@
 import {fileURLToPath} from "node:url";
 import {Effect, type FileSystem, Option, type Path, Result} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {emit as emitOutcome} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {readFile, writeFile} from "../io/fs.ts";
 import {readStdin, type StdinRead} from "../io/stdin.ts";
-import type {VerbOutcome} from "../verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runCodes} from "./codes-verb.ts";
 import {runDocSection} from "./doc-section-verb.ts";
@@ -28,14 +28,6 @@ import {DOC_PATH} from "./index-doc.ts";
 import {type DocRead, type DocSave, runIndex} from "./index-verb.ts";
 import {runRead} from "./read-verb.ts";
 import {registeredFormats, registeredKeys} from "./registry.ts";
-
-/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
-const emitOutcome = (outcome: VerbOutcome): Effect.Effect<void> =>
-	Effect.sync(() => {
-		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
-		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
-		process.exit(outcome.code);
-	});
 
 const jsonFlag = Flag.boolean("json").pipe(
 	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),


### PR DESCRIPTION
Every fabrika verb group wrote its answer to stdout and then called `process.exit` on the next line.
When stdout is a pipe — and `x=$(fabrika …)` is a pipe — that write is asynchronous, so everything
still queued was discarded, silently, on exit 0. Measured on this branch before the fix: a
3,795,600-byte answer came back as 65,536 bytes, three runs in a row, exit 0 every time. The same
answer redirected to a file was complete.

The duplicated copies of `emit` are now one shared helper,
`packages/fabrika-cli/src/emit.ts`, which exits from the `process.stdout.write` callback instead of
from the line after it. `process.exitCode` is set ahead of the writes, so a stream that never
reports a flush still lands on the verb's own code rather than on 0. It lives beside `verb.ts`
rather than in it because `bin.ts` statically imports `verb.ts` and depends on that module importing
nothing.

Two tests. `emit.cli.test.ts` spawns the real bin twice: one ~1.9 MB answer through a real pipe,
asserted byte-exact against the pure composition function, and one refusal asserting the exit code
survives. Reverting `emit.ts` to the old body reds it at 65,536 of 1,875,600 bytes, so it catches
the bug it was written for. `emit.unit.test.ts` is the coverage guard — it scans every
`src/*/command.ts` for the shared import and for the old exit-before-drain line, fail-closed on zero
scope, so a group that hand-rolls its own emit reds without needing one spawn per group.

Reviewer's first stop: `packages/fabrika-cli/src/emit.ts`. The rest of the diff is the mechanical
removal of the duplicated helper.

Fixes #6226

## Deviations

- **Out-of-scope change** — **Said:** #6226's criteria name the `packages/fabrika-cli/src/*/command.ts`
  copies and nothing else. **Did:** also added one bullet to
  `claude-plugins/fabrika/docs/interface-convention.md` §3 stating that the whole answer must
  reach the caller and that adapters emit through the shared helper. **Why:** CLAUDE.md requires a
  load-bearing pattern to be documented, and §3 already owns "the exit status is the answer" — a
  helper nobody is told to use is a helper the next group skips. **Disposition:** stated here.
- **Scope widening** — **Said:** the registered criterion reads "all 26
  `packages/fabrika-cli/src/*/command.ts` copies". **Did:** converted 30. **Why:** the issue counted
  26 when it was written; more groups (including the `ci` port from #6099) landed on main since, and
  this diff touches all 30 `src/*/command.ts` adapters that exist at this head. **Disposition:**
  stated here; the number in the criterion is stale, the intent — every adapter — is met in full.

## Amendment 2026-08-28

The `## Deviations` section above was repaired in place to clear the
`review-code: FAIL @ 4bd3fc62` blocker. What it said before, and why it was wrong:

- It claimed the criteria name **29** adapters in one entry and quoted the criterion as **26** in the
  next — self-contradictory, and neither number matched the **30** adapters the diff actually changes.
- It cited the docs file as `cli-interface-convention.md`; the file in the diff is
  `claude-plugins/fabrika/docs/interface-convention.md`.

No code changed; the head SHA is unchanged at `4bd3fc62df85f99a5dce7e6cd22649a118219798`.
