### PR TITLE
fix: A base-drift ship stop routes to review, which re-verdicts the same head and spends the budget

### DIFF
--- a/.decisions/0317-ui-lane-carries-its-own-shells.md
+++ b/.decisions/0317-ui-lane-carries-its-own-shells.md
@@ -100,6 +100,16 @@ This is not an invention: the epic tail task already has that shape — the gold
 routes both `review.FAIL` and `ship.FAIL` back to `review`. The single-issue template was the
 outlier.
 
+**Reverted for the single-issue template by [#6826](https://github.com/kamp-us/phoenix/issues/6826);
+the epic tail keeps this shape.** The premise above — that a `ship` FAIL is "a green PR refused for a
+missing verdict" — no longer holds: the shipper's three routing terminals (#6002) send that refusal
+to `ROUTED-REVIEW`, which maps to `BLOCKED`, not `FAIL`. What still reaches `ISSUE.FAIL` at `ship` is
+`ROUTED-REPAIR` and `EJECTED`, and both name repair, which is `build`'s. Sending them to `review` had
+the reviewer re-verdict a byte-identical head and hand it straight back, spending a retry per lap;
+two laps froze three lanes on 2026-08-20. The epic tail is not the same case and is unchanged: its
+region has no `build` state at all, so `review` is the only retry arm it can have
+([`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts)).
+
 ## Consequences
 
 - A UI-class lane reaches `shipped` with no human hand-firing a round, and no driver authoring a

--- a/.decisions/0317-ui-lane-carries-its-own-shells.md
+++ b/.decisions/0317-ui-lane-carries-its-own-shells.md
@@ -1,7 +1,7 @@
 ---
 id: 0317
 title: A UI-class lane carries its own build and review shells, and the lane state carries the class
-status: accepted
+status: amended-in-part by [0327](0327-ship-fail-routes-to-build.md)
 date: 2026-08-20
 tags: [fabrika, lane, pipeline, review, state-machine]
 ---
@@ -87,7 +87,7 @@ ends a rendered-visual subject on the *routed elsewhere* terminal, a handoff to 
 nothing in the loop was there to receive. Folding the rubrics together does not remove that terminal;
 it hides it inside one shell that now owns a modality it cannot judge.
 
-### Why `ISSUE.FAIL` at `ship` routes back to `review`
+### Why `ISSUE.FAIL` at `ship` routes back to `review` — holds for the epic tail only, per ADR [0327](0327-ship-fail-routes-to-build.md)
 
 The single-issue coder template
 ([`packages/fabrika-cli/src/lane/templates/coder.workflow.json`](../packages/fabrika-cli/src/lane/templates/coder.workflow.json))
@@ -99,16 +99,6 @@ This is not an invention: the epic tail task already has that shape — the gold
 [`packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt`](../packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt)
 routes both `review.FAIL` and `ship.FAIL` back to `review`. The single-issue template was the
 outlier.
-
-**Reverted for the single-issue template by [#6826](https://github.com/kamp-us/phoenix/issues/6826);
-the epic tail keeps this shape.** The premise above — that a `ship` FAIL is "a green PR refused for a
-missing verdict" — no longer holds: the shipper's three routing terminals (#6002) send that refusal
-to `ROUTED-REVIEW`, which maps to `BLOCKED`, not `FAIL`. What still reaches `ISSUE.FAIL` at `ship` is
-`ROUTED-REPAIR` and `EJECTED`, and both name repair, which is `build`'s. Sending them to `review` had
-the reviewer re-verdict a byte-identical head and hand it straight back, spending a retry per lap;
-two laps froze three lanes on 2026-08-20. The epic tail is not the same case and is unchanged: its
-region has no `build` state at all, so `review` is the only retry arm it can have
-([`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts)).
 
 ## Consequences
 

--- a/.decisions/0327-ship-fail-routes-to-build.md
+++ b/.decisions/0327-ship-fail-routes-to-build.md
@@ -1,0 +1,88 @@
+---
+id: 0327
+title: A `ship` FAIL routes to `build` in the single-issue lane, and a base-drift stop parks
+status: accepted
+date: 2026-08-21
+tags: [fabrika, lane, pipeline, ship, state-machine]
+---
+
+# 0327 — A `ship` FAIL routes to `build` in the single-issue lane, and a base-drift stop parks
+
+**What this decides:** in the single-issue lane machine, a shipper FAIL sends the lane back to
+`build`, not `review`; and a shipper stopping because the head is behind its base parks with a named
+cause instead of failing at all.
+
+## Context
+
+ADR [0317](0317-ui-lane-carries-its-own-shells.md) §"Why `ISSUE.FAIL` at `ship` routes back to
+`review`" moved the single-issue coder template's retry arm from `build` to `review`. Its premise
+was that a `ship` FAIL means "a green PR refused for a missing verdict", where `build` has nothing
+to repair.
+
+That premise stopped holding. The shipper's routing terminals (#6002) send a missing-verdict refusal
+to `ROUTED-REVIEW`, and in
+[`packages/fabrika-cli/src/lane/report.ts`](../packages/fabrika-cli/src/lane/report.ts)'s
+`SHELL_VOCABULARIES` that token maps to `BLOCKED`, not `FAIL`. Exactly two shipper tokens still map
+to `FAIL`: `ROUTED-REPAIR` and `EJECTED`. Both name a repair, and `build` is the only state owning a
+verb that can move a branch.
+
+So the arm 0317 wrote now sends every shipper FAIL to a stage that cannot act on it. The reviewer
+re-verdicts a byte-identical head, exits PASS, and hands the lane straight back to `ship`, which
+stops on the same thing. Each lap spends a repair retry. On 2026-08-20 PT that froze three lanes —
+6759 (#6801), 6374 (#6894) and 6226 (#6916) — none of which had a defect in it. Lane 6226 was one
+commit behind, so the trigger is any drift at all, and a control-plane-gated PR cannot avoid drift:
+the human approval it waits on outlasts main standing still.
+
+The same template already answered this question the other way one state along. `ship:queued`'s
+`ISSUE.FAIL` targets `build`, written that way by ADR
+[0313](0313-a-queue-dwell-is-a-wait-not-a-park.md), which "routes an ejection back into `build`".
+`review`'s FAIL arm targets `build` too. `ship` was the outlier.
+
+The second half is the drift stop itself, which should never have reached a FAIL arm.
+`ship cp-approval` emits `stop` / `awaiting-approval` on a head behind its base; the drift is a
+diagnostic line, not a second outcome
+([`packages/fabrika-cli/src/ship/cp-approval-verb.ts`](../packages/fabrika-cli/src/ship/cp-approval-verb.ts)).
+Three shippers read `claude-plugins/fabrika/skills/ship/SKILL.md` §2's rebase-first sentence over its
+terminal sentence and reported `ROUTED-REPAIR`. ADR 0313 drew the line that reading crosses:
+`retries` is "the lane failed and is spending a chance to fix itself", `waits` is "a lane that did
+nothing wrong". Drift is the second kind.
+
+This amends 0317 §"Why `ISSUE.FAIL` at `ship` routes back to `review`" in part. The rest of 0317
+stands, including the UI shells, the `build:ui` / `review:ui` states, and that section's own claim
+about the **epic tail**, which is a different case and unchanged.
+
+## Decision
+
+**In the single-issue coder template, `ship`'s `ISSUE.FAIL` retry arm targets `build`; and a
+`ship cp-approval` stop carrying a base-drift notice is reported as `AWAITING-CP-APPROVAL` with
+`--cause head-behind-base`, never as `ROUTED-REPAIR`.**
+
+- [`packages/fabrika-cli/src/lane/templates/coder.workflow.json`](../packages/fabrika-cli/src/lane/templates/coder.workflow.json)'s
+  `ship` state routes `ISSUE.FAIL` to `build`. The `retriesRemaining` guard, the `incrementRetries`
+  action and the `frozen` fallthrough are unchanged, so a spent budget still freezes.
+- The epic tail keeps `review`. [`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts)
+  builds a tail region with no `build` state at all — its repair round happens outside the machine
+  and the next verdict is another review — so `review` is the only retry arm that region can have.
+  Retargeting it would break that design, not fix it.
+- `PARK_CAUSES` in `report.ts` carries `head-behind-base`. It owes no `KNOWN_PARKS` row: clearing it
+  needs a verb that merges the base into the head and `build` ships none, so `classifyPark` answers
+  `Novel` **naming the cause** and routes to a human. A cause row alone is legal wherever no remedy
+  verb exists; the pairing rule binds the other direction.
+- `ship`'s SKILL §2 states which of its two sentences wins: the terminal is `AWAITING-CP-APPROVAL`,
+  which maps to `BLOCKED`, and a park spends neither budget.
+
+## Consequences
+
+- A shipper FAIL now reaches the one stage that can act on it, and a lane can no longer burn its
+  retry budget on laps that move nothing.
+- A drift stop costs no budget at all, so a cp-gated PR waiting on a human no longer freezes for
+  waiting. Unfreezing one cost a founder `build clear` plus a human `UNBLOCKED` (ADR
+  [0312](0312-event-anchored-retry-budget.md), exit 36).
+- A `head-behind-base` park still spends a person until somebody writes the remedy verb and its
+  `KNOWN_PARKS` row. That is the trade taken here: naming the cause is what makes the park readable
+  enough for that row to be writable later.
+- `ISSUE.BLOCKED` targets are untouched — [#6503](https://github.com/kamp-us/phoenix/issues/6503)
+  still owns the three-meanings collapse onto `human:cp-approval`, and
+  [#6380](https://github.com/kamp-us/phoenix/issues/6380) still owns the exit back out of that park.
+- 0317's body is not rewritten. Its status line carries `amended-in-part by 0327` and its section
+  heading names the scope it still holds for, per the repo's ADR-immutability convention.

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -81,15 +81,15 @@ so the approval is never spent on a head that must move.
 The notice says what has to happen before the approval is solicited; it is not a second outcome, and
 the verb's own emitted outcome stays `stop` on the `behind > 0` branch. So a base-drift diagnostic on
 a `stop` is never reported as `ROUTED-REPAIR` — that token folds `ISSUE.FAIL` and charges a repair
-retry to a lane with no defect in it, which froze three lanes on 2026-08-20 (#6826). Name the cause
-when you record it, so the park is one a sweep can read:
+retry to a lane with no defect in it, which froze three lanes on 2026-08-20 (ADR 0327). Name the
+cause when you record it, so the park is one a sweep can read:
 
 ```bash
 node <fabrika> lane report <lane> --root <root> --task <task> --token AWAITING-CP-APPROVAL --cause head-behind-base --pr <pr-url>
 ```
 
-Pass `--cause head-behind-base` only when the notice fired; a `stop` with no drift carries no cause,
-which is the park `recipe unpark` already clears by re-reading the approval. <!-- anchor: NO-REBASE-AFTER-APPROVAL -->
+Pass it when the head is still behind at the moment you record. A `stop` with no drift carries no
+cause, which is the park `recipe unpark` already clears by re-reading the approval. <!-- anchor: NO-REBASE-AFTER-APPROVAL -->
 Once a control-plane approval exists, **never rebase or force-push the head**: a moved head means
 re-approval, patch-identical or not. **That is the human approval only.** A fabrika `review-*` or
 `governance` marker binds the content it judged as well as the head, so a branch update leaving the

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -75,7 +75,21 @@ fabrika ship cp-approval $pr_number --sha 03135b91
 `discharge` → continue, and pass `--cp` to step 3's gate. `stop` → disarm, post
 `awaiting control-plane approval` via `note`, and end — soliciting the approval is a human's;
 before it is solicited, a base-drift notice from the verb routes rebase → re-gate → re-bank first,
-so the approval is never spent on a head that must move. <!-- anchor: NO-REBASE-AFTER-APPROVAL -->
+so the approval is never spent on a head that must move.
+
+**On a `stop`, the terminal is `AWAITING-CP-APPROVAL` and a base-drift notice never changes that.**
+The notice says what has to happen before the approval is solicited; it is not a second outcome, and
+the verb's own emitted outcome stays `stop` on the `behind > 0` branch. So a base-drift diagnostic on
+a `stop` is never reported as `ROUTED-REPAIR` — that token folds `ISSUE.FAIL` and charges a repair
+retry to a lane with no defect in it, which froze three lanes on 2026-08-20 (#6826). Name the cause
+when you record it, so the park is one a sweep can read:
+
+```bash
+node <fabrika> lane report <lane> --root <root> --task <task> --token AWAITING-CP-APPROVAL --cause head-behind-base --pr <pr-url>
+```
+
+Pass `--cause head-behind-base` only when the notice fired; a `stop` with no drift carries no cause,
+which is the park `recipe unpark` already clears by re-reading the approval. <!-- anchor: NO-REBASE-AFTER-APPROVAL -->
 Once a control-plane approval exists, **never rebase or force-push the head**: a moved head means
 re-approval, patch-identical or not. **That is the human approval only.** A fabrika `review-*` or
 `governance` marker binds the content it judged as well as the head, so a branch update leaving the

--- a/packages/fabrika-cli/src/lane/__fixtures__/coder.cells.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/coder.cells.golden.txt
@@ -78,9 +78,9 @@ ship	BLOCKED	-	0/2	-> human:cp-approval	0/2
 ship	BLOCKED	-	2/2	-> human:cp-approval	2/2
 ship	BLOCKED	ui	0/2	-> human:cp-approval	0/2
 ship	BLOCKED	ui	2/2	-> human:cp-approval	2/2
-ship	FAIL	-	0/2	-> review	1/2
+ship	FAIL	-	0/2	-> build	1/2
 ship	FAIL	-	2/2	-> frozen	2/2
-ship	FAIL	ui	0/2	-> review	1/2
+ship	FAIL	ui	0/2	-> build	1/2
 ship	FAIL	ui	2/2	-> frozen	2/2
 ship	CLEARED	-	0/2	-> ship	0/2
 ship	CLEARED	-	2/2	-> ship	2/2

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -8,7 +8,7 @@ import {
 	stateNode,
 	twoPhaseWorkflow,
 } from "./fixtures.test-support.ts";
-import {applyEvent, foldLog, type LogEntry} from "./fold.ts";
+import {applyEvent, foldLog, type LogEntry, standingCauses} from "./fold.ts";
 import {
 	CLEARED_EVENT,
 	type CompiledLane,
@@ -18,6 +18,7 @@ import {
 	type TaskState,
 	topology,
 } from "./machine.ts";
+import {causeForEvent, eventForToken} from "./report.ts";
 
 const compiled = (workflow: unknown) => {
 	const result = compile(workflow);
@@ -57,6 +58,37 @@ const leaves = (
 		log.push(applied.entry);
 		return defined(statesOf()[task]).type;
 	});
+};
+
+/** Drive the same events as {@link leaves}, but answer with the task's folded state and budgets. */
+const budgets = (lane: CompiledLane, task: string, events: ReadonlyArray<string>): TaskState =>
+	driven(lane, task, events).state;
+
+/**
+ * Drive one task's events and answer with both its folded state and the cause standing over it.
+ *
+ * The cause rides the final entry because it is a field `lane report` writes onto the parking event
+ * rather than machine state (#6480) — the fold derives it back from there.
+ */
+const driven = (
+	lane: CompiledLane,
+	task: string,
+	events: ReadonlyArray<string>,
+	cause: string | null = null,
+): {readonly state: TaskState; readonly cause: string | undefined} => {
+	const log: LogEntry[] = [];
+	const statesOf = () => {
+		const fold = foldLog(lane, log);
+		if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
+		return fold.states;
+	};
+	for (const [index, event] of events.entries()) {
+		const applied = applyEvent(lane, statesOf(), task, event, "2026-08-20T00:00:00.000Z");
+		if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
+		const last = index === events.length - 1 && cause !== null;
+		log.push(last ? {...applied.entry, cause} : applied.entry);
+	}
+	return {state: defined(statesOf()[task]), cause: standingCauses(log)[task]};
 };
 
 /**
@@ -210,15 +242,28 @@ describe("the compiler — structural recognition", () => {
 		expect(summary.trigger).toBeUndefined();
 	});
 
-	it("re-reviews on a FAIL at ship, and freezes once the retries are spent (#5807)", () => {
+	it("repairs on a FAIL at ship, and freezes once the retries are spent (#5807, #6826)", () => {
 		const lane = compiled(coderWorkflow());
-		// A ship-stage failure is not a construction defect: the PR is green and there is nothing at
-		// `build` to repair, so the retry buys a re-review rather than a builder round (#6688).
-		const roundTrip = ["FAIL", "PASS"];
+		// Everything that still reaches ISSUE.FAIL at `ship` names repair — `ROUTED-REPAIR` and
+		// `EJECTED` — because the shipper's other refusals map to BLOCKED. `review` owns no verb that
+		// moves a branch, so routing there re-verdicted an unchanged head and spent a retry per lap
+		// (#6826, reverting ADR 0317's arm for this template only).
+		const roundTrip = ["FAIL", "DONE", "PASS"];
 
 		expect(
 			leaves(lane, "issue", ["WIP", "DONE", "PASS", ...roundTrip, ...roundTrip, "FAIL"]),
-		).toEqual(["build", "review", "ship", "review", "ship", "review", "ship", "frozen"]);
+		).toEqual([
+			"build",
+			"review",
+			"ship",
+			"build",
+			"review",
+			"ship",
+			"build",
+			"review",
+			"ship",
+			"frozen",
+		]);
 	});
 
 	it("routes a UI-class lane through build:ui and review:ui, and back to build:ui on a FAIL", () => {
@@ -392,22 +437,6 @@ describe("`ship:queued` — a proven-clean enqueue is a wait, not a park (ADR 03
 	const toShip = ["WIP", "DONE", "PASS"] as const;
 	const reached = ["build", "review", "ship"] as const;
 
-	/** Drive the same events as {@link leaves}, but answer with the task's folded budgets. */
-	const budgets = (lane: CompiledLane, task: string, events: ReadonlyArray<string>) => {
-		const log: LogEntry[] = [];
-		const statesOf = () => {
-			const fold = foldLog(lane, log);
-			if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
-			return fold.states;
-		};
-		for (const event of events) {
-			const applied = applyEvent(lane, statesOf(), task, event, "2026-08-20T00:00:00.000Z");
-			if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
-			log.push(applied.entry);
-		}
-		return defined(statesOf()[task]);
-	};
-
 	it("takes a still-queued shipper out of `ship` into the wait cell", () => {
 		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, "WIP"])).toEqual([
 			...reached,
@@ -491,5 +520,64 @@ describe("`ship:queued` — a proven-clean enqueue is a wait, not a park (ADR 03
 		expect(() =>
 			leaves(compiled(coderWorkflow()), "issue", [...toShip, "BLOCKED", "DONE"]),
 		).toThrow(/DONE/);
+	});
+});
+
+describe("`ship` FAIL routes to repair, and a base-drift stop spends nothing (#6826)", () => {
+	const toShip = ["WIP", "DONE", "PASS"] as const;
+	const reached = ["build", "review", "ship"] as const;
+
+	it("lands a FAIL folded from `ship` on `build`, with the retry spent", () => {
+		const lane = compiled(coderWorkflow());
+
+		expect(leaves(lane, "issue", [...toShip, "FAIL"])).toEqual([...reached, "build"]);
+		expect(budgets(lane, "issue", [...toShip, "FAIL"])).toMatchObject({
+			type: "build",
+			retries: 1,
+			waits: 0,
+		});
+	});
+
+	it("freezes at `ship` once the repair budget is spent, leaving the frozen arm as it was", () => {
+		const lane = compiled(coderWorkflow());
+		const spent = [...toShip, "FAIL", "DONE", "PASS", "FAIL", "DONE", "PASS", "FAIL"];
+
+		expect(defined(leaves(lane, "issue", spent).at(-1))).toBe("frozen");
+		expect(budgets(lane, "issue", spent)).toMatchObject({type: "frozen", retries: 2});
+	});
+
+	it("maps the drift stop's terminal to BLOCKED and takes its cause", () => {
+		const resolved = eventForToken("AWAITING-CP-APPROVAL");
+		if (resolved._tag !== "Mapped") throw new Error(resolved.reason);
+
+		expect(resolved.event).toBe("BLOCKED");
+		expect(causeForEvent("head-behind-base", resolved.event)).toEqual({
+			_tag: "Caused",
+			cause: "head-behind-base",
+		});
+	});
+
+	// The whole reported harm: three lanes froze at 2/2 over drift alone, with no defect in the work
+	// and every namespace PASS at the head the reviewer re-read.
+	it("spends neither budget when that terminal folds from `ship`", () => {
+		const lane = compiled(coderWorkflow());
+		const before = budgets(lane, "issue", [...toShip]);
+		const parked = driven(lane, "issue", [...toShip, "BLOCKED"], "head-behind-base");
+
+		expect(parked.cause).toBe("head-behind-base");
+		expect(parked.state).toMatchObject({
+			type: "human:cp-approval",
+			retries: before.retries,
+			waits: before.waits,
+		});
+	});
+
+	// No `KNOWN_PARKS` row exists for this cause and none is owed yet: clearing it needs a verb that
+	// merges the base into the head, and `build` ships none. Novel-naming-the-cause is the answer.
+	it("reads as a novel park that names its cause, never as the causeless §CP row", () => {
+		const classified = classifyPark("human:cp-approval", "head-behind-base");
+
+		expect(classified._tag).toBe("Novel");
+		if (classified._tag === "Novel") expect(classified.reason).toContain("head-behind-base");
 	});
 });

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -142,8 +142,12 @@ export const eventForToken = (raw: string): TokenResolution => {
  *
  * It is a closed set for the same reason the terminal tokens are: a free-text cause is prose a
  * recipe would have to interpret, and interpreting a report is the failure class this module
- * deletes. Each entry's value is what the cause means, in the clause a refusal can quote — a new
- * cause is a row here plus a `KNOWN_PARKS` row that says how to prove it gone, never one alone.
+ * deletes. Each entry's value is what the cause means, in the clause a refusal can quote.
+ *
+ * A cause pairs with a `KNOWN_PARKS` row wherever a remedy verb exists to clear it. Where none does,
+ * the cause still earns its row alone: `classifyPark` then answers `Novel` **naming this cause**
+ * instead of the bare "recorded the event and not why", which is the difference between a gap
+ * somebody can write a row for and a structural dead end (`recipe/parks.ts`).
  */
 export const PARK_CAUSES = {
 	/**
@@ -152,6 +156,17 @@ export const PARK_CAUSES = {
 	 * another tree. The whole remedy is removing that worktree, which is why it owes no decision.
 	 */
 	"worktree-holds-branch": "a working tree still holds the lane branch this build must stand on",
+	/**
+	 * The #6826 shape: `ship cp-approval` stops on a head behind its base, and the head must move
+	 * before an approval is solicited (#4477). The park spends neither budget, which is the whole
+	 * point — drift is a lane that did nothing wrong (ADR 0313), and reporting it as `ROUTED-REPAIR`
+	 * charged a repair retry for a trip through a stage that owns no verb that can move a branch.
+	 *
+	 * It carries no `KNOWN_PARKS` row on purpose: clearing it needs a verb that merges the base into
+	 * the head, and `build` ships none, so the sweep routes it to a human by naming this cause.
+	 */
+	"head-behind-base":
+		"the PR's head is behind its base and must move before an approval is solicited",
 } as const;
 
 export type ParkCause = keyof typeof PARK_CAUSES;

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -157,10 +157,10 @@ export const PARK_CAUSES = {
 	 */
 	"worktree-holds-branch": "a working tree still holds the lane branch this build must stand on",
 	/**
-	 * The #6826 shape: `ship cp-approval` stops on a head behind its base, and the head must move
-	 * before an approval is solicited (#4477). The park spends neither budget, which is the whole
-	 * point — drift is a lane that did nothing wrong (ADR 0313), and reporting it as `ROUTED-REPAIR`
-	 * charged a repair retry for a trip through a stage that owns no verb that can move a branch.
+	 * See ADR 0327. `ship cp-approval` stops on a head behind its base, and the head must move before
+	 * an approval is solicited (#4477). The park spends neither budget, and reporting it as
+	 * `ROUTED-REPAIR` charged a repair retry for a trip through a stage that owns no verb that can
+	 * move a branch.
 	 *
 	 * It carries no `KNOWN_PARKS` row on purpose: clearing it needs a verb that merges the base into
 	 * the head, and `build` ships none, so the sweep routes it to a human by naming this cause.

--- a/packages/fabrika-cli/src/lane/templates/coder.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/coder.workflow.json
@@ -73,7 +73,7 @@
 									"ISSUE.BLOCKED": "human:cp-approval",
 									"ISSUE.FAIL": [
 										{
-											"target": "review",
+											"target": "build",
 											"guard": "retriesRemaining",
 											"actions": "incrementRetries"
 										},


### PR DESCRIPTION
A `ship` stop over base drift used to spend a repair retry on a trip through a stage that owns no
verb which can move a branch. Three lanes froze at 2/2 on 2026-08-20 with nothing wrong in the work.
Two independent halves, both here:

**The routing.** `coder.workflow.json`'s `issue` region routes `ship`'s `ISSUE.FAIL` retry arm to
`build` instead of `review`; the `frozen` fallthrough is untouched, and so is every `ISSUE.BLOCKED`
target and every `ship:queued` arm (#6503 still owns the BLOCKED collapse). Everything that still
reaches that arm names repair — `ROUTED-REPAIR` and `EJECTED` — because the shipper's other refusals
map to `BLOCKED`, so `build` is the stage that can act on it.

**The park.** `PARK_CAUSES` gains `head-behind-base`, and the ship skill's §2 now says which of its
two sentences wins on a `stop` carrying a base-drift notice: the terminal is `AWAITING-CP-APPROVAL`,
which maps to `BLOCKED`, and a drift diagnostic never becomes `ROUTED-REPAIR`. The `lane report`
snippet for that stop passes `--cause head-behind-base`. That park spends neither budget, which is
the whole reported harm.

**The record.** Both halves reverse part of ADR 0317, so they are recorded as ADR
[0327](.decisions/0327-ship-fail-routes-to-build.md) rather than by rewriting 0317. 0317's body is
back to what it said; `fabrika adr amend-in-part 0317 --by 0327` wrote its `status:` line, and its
section heading now names the scope it still holds for (the epic tail), so no heading in that file
states the opposite of what the template does. `report.ts` and the ship skill cite 0327.

`packages/fabrika-cli/src/lane/emit.ts` is unchanged. The epic tail's `review` retry arm is correct
there for a reason this template does not share: the tail region has no `build` state at all — the
epic's repair round happens outside the machine, so the next thing that region can record is another
verdict. Retargeting it would break that design.

Tests: `machine.unit.test.ts` pins the `ship` FAIL landing on `build` with `retries` incremented and
freezing once the budget is spent, and pins the drift park leaving `retries` and `waits` both
unchanged while standing as a `Novel` park that names its cause. The `coder.cells.golden.txt` cell
table moved with the arm. `pnpm typecheck`, `pnpm lint:worktree` and the full fabrika-cli suite
(7701 tests, including `retry-budget.unit.test.ts`) are green in this tree.

## Deviations

- **Governing-ADR departure** — **Said:** ADR 0317 §"Why `ISSUE.FAIL` at `ship` routes back to
  `review`" decided this arm targets `review`, and #6826 does not mention that ADR. **Did:** reverted
  the arm for the single-issue template and minted ADR 0327 to carry the reversal. **Why:** 0317's
  premise was that a `ship` FAIL is "a green PR refused for a missing verdict", and the shipper's
  three routing terminals (#6002) send that refusal to `ROUTED-REVIEW` → `BLOCKED`, not `FAIL` — so
  the case the ADR reasoned about no longer reaches this arm. **Disposition:** recorded in ADR 0327;
  0317 carries only the `amended-in-part` status line the verb wrote.
- **Out-of-scope change** — **Said:** criterion 9 asks for a decision record and a status line on
  0317. **Did:** also scoped 0317's section heading, which is a body edit of an accepted ADR.
  **Why:** the heading is a claim, and after this change it is false for the template it names; the
  criterion asks that no heading in the file state the opposite of what the template does.
  **Disposition:** stated here — the edit adds a scope clause and a pointer to 0327 and changes no
  argument in the section.
- **Out-of-scope change** — **Said:** criterion 6 asks only for a `PARK_CAUSES` row. **Did:** also
  rewrote that block's closing sentence, which read "a new cause is a row here plus a `KNOWN_PARKS`
  row …, never one alone". **Why:** the issue puts the `KNOWN_PARKS` row out of scope (no verb merges
  a base into a head), so the new row would have landed contradicting the doc directly above it.
  **Disposition:** stated here; the rewritten sentence names the no-remedy case and what
  `classifyPark` answers for it.
- **Pre-existing test or fixture changed** — **Said:** nothing about the existing ship-FAIL test.
  **Did:** rewrote `machine.unit.test.ts`'s "re-reviews on a FAIL at ship" to drive the new route,
  and updated four rows of `coder.cells.golden.txt`. **Why:** both pinned the arm this issue moves;
  a routing change that left them passing would mean the arm never moved. **Disposition:** stated
  here — no assertion was weakened, the round-trip just runs through `build` now.

Fixes #6826
