### PR TITLE
fix: The five mutating triage verbs still guard on the session id alone, so a sibling lane can overwrite the winner

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -31,11 +31,15 @@ claim, and never re-run without it — a tokenless re-run is a new lane racing y
 proves, and which refusal each exit code carries, is the verb's own section
 (`fabrika wire doc-section --heading "triage claim" < <skill-base>/contract.md`).
 
-**That rule has teeth now.** Every verb below that writes — `enrich`, `apply`, `park`, `kill`,
-`split` — re-reads the claim before its first write and refuses on `17` when a live marker names
-another session, so proceeding on a `lost` no longer overwrites the winner's work; it just fails.
-The same re-read refuses a closed target on `7`. Neither refusal is overridable, and a comment read
-that fails is `11` — never a pass.
+**That rule has teeth now, and the token is what gives it them.** Every verb below that writes —
+`enrich`, `apply`, `park`, `kill`, `split` — re-reads the claim before its first write and refuses
+on `17` when a live marker names another claimant, so proceeding on a `lost` no longer overwrites the
+winner's work; it just fails. **Pass `--token <claim-token>` to every one of those five.** Without it
+the verb can only tell that *some* lane of your session holds the claim, which is exactly the sibling
+it cannot tell you from — so it falls back to a fail-closed reading and refuses the moment two lanes
+of your session hold live markers. With it, a sibling's claim is refused and your own passes. The
+same re-read refuses a closed target on `7`. Neither refusal is overridable, and a comment read that
+fails is `11` — never a pass.
 
 **Every working file you write goes where this prints, and nowhere else:**
 
@@ -128,7 +132,7 @@ Done when you have taken one of the three routes and the reason is written down.
 Two problems agents could work at different times are a bundle; two facets of one change are not.
 
 ```bash
-fabrika triage split $issue_number --title "Editor loses focus after save" <<'EOF'
+fabrika triage split $issue_number --title "Editor loses focus after save" --token <claim-token> <<'EOF'
 …
 EOF
 ```
@@ -159,7 +163,7 @@ fabrika triage homes
 ```
 
 ```bash
-fabrika triage enrich $issue_number <<'EOF'
+fabrika triage enrich $issue_number --token <claim-token> <<'EOF'
 …
 EOF
 ```
@@ -188,7 +192,7 @@ merit: `p0` for ship-work and fires, `p1` for what you would genuinely pull next
 default** and most of a healthy backlog. A roadmap row confers no band either way.
 
 ```bash
-fabrika triage apply $issue_number --type bug --priority p2 --ready-for agent --home 47
+fabrika triage apply $issue_number --type bug --priority p2 --ready-for agent --home 47 --token <claim-token>
 ```
 
 A standing lane takes `--lane wayfinder:backlog` (or `axis:pipeline-hardening`) **instead of**
@@ -246,7 +250,7 @@ verb refuses to infer, is its section
   (`fabrika wire doc-section --heading "triage park" < <skill-base>/contract.md`).
 
 ```bash
-fabrika triage park $issue_number <<'EOF'
+fabrika triage park $issue_number --token <claim-token> <<'EOF'
 …
 EOF
 ```
@@ -260,7 +264,7 @@ EOF
   (`fabrika wire doc-section --heading "triage kill" < <skill-base>/contract.md`).
 
 ```bash
-fabrika triage kill $issue_number --confirm --duplicate-of 4290 <<'EOF'
+fabrika triage kill $issue_number --confirm --duplicate-of 4290 --token <claim-token> <<'EOF'
 …
 EOF
 ```

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -162,7 +162,7 @@ or the search index could not be read
 | `13` | refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159) | — | — | — | — | — | — | — | — | ✓ | — |
 | `15` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — | — |
 | `16` | refused: `--ready-for agent` over a live body whose acceptance-criteria block the wire reader does not answer `Found` on — every type but `epic` | — | — | — | — | — | — | ✓ | — | — | — |
-| `17` | refused: a live claim marker on the target names a session other than this one | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `17` | refused: a live claim marker on the target names a claimant other than the asking lane — another session, or another lane of this one | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | — |
 | `18` | refused: no value of `.fabrika.jsonc` may be used — a key's load-time check refused it, it could not be read, or it did not decode | — | — | — | — | — | — | ✓ | ✓ | — | — |
 | `19` | refused: the asking lane holds no live claim on the target | — | — | — | — | — | — | — | — | — | ✓ |
 | `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -435,12 +435,19 @@ winner is this session; every unresolvable state answers `lost`, never `won`.
 
 **The claim binds, and every mutating verb is what makes it bind.** `split`, `enrich`, `apply`,
 `park` and `kill` each re-read the markers on their target immediately before their first write, and
-refuse on `17` when a live one names another session — the check reuses this verb's own reader and
-resolver, so there is one marker grammar. Those five read the **session** axis only: they are handed
-no claim token, so a sibling lane of one session still passes that check, exactly as it did before
-the lane nonce existed. Holding **no** marker still passes: an unclaimed issue is
+refuse on `17` when a live one names another claimant — the check reuses this verb's own reader and
+resolver, so there is one marker grammar. Those five decide foreignness on the **session+lane pair**,
+the same identity `claim` resolves on: each takes the optional `--token` this verb handed the lane,
+and a same-session marker under a different nonce is somebody else's
+([#6303](https://github.com/kamp-us/phoenix/issues/6303)). A call that passes no `--token` cannot say
+which lane it is, so it is priced fail-closed on exactly that: it passes while its session's live
+markers all name one lane, and refuses on `17` once two lanes of its session hold live markers.
+Holding **no** marker still passes: an unclaimed issue is
 the ordinary first-triage case, and demanding one would refuse every existing caller. The same
-re-read refuses a closed target on `7`, and a comment read that fails is `11`. Before, the protocol
+re-read refuses a closed target on `7`, and a comment read that fails is `11`. A `--token` that will
+not parse as `triage:<session-id>:<uuid>`, or that carries a session other than the one running, is a
+usage error on `1` on all five — the same two lines `claim` itself prints, verbatim, since it is the
+same reader; a lane names itself, never another. Before, the protocol
 was advisory at exactly the point it needed to bite: on 2026-08-15 a session that had read `lost`
 ran `enrich` anyway and replaced the winner's authored body
 ([#5644](https://github.com/kamp-us/phoenix/issues/5644), on
@@ -1000,7 +1007,7 @@ $ fabrika triage homes --json
 **Invocation**
 
 ```
-fabrika triage split 4312 --title "Editor loses focus after save" [--repo <owner/name>] [--json]
+fabrika triage split 4312 --title "Editor loses focus after save" [--token <claim-token>] [--repo <owner/name>] [--json]
 ```
 
 The child body arrives on **stdin only**. There is no `--body` and no `--body-file`: a flag that
@@ -1014,6 +1021,7 @@ path reaches a public issue while the poster reads success. A shell redirect is 
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the parent issue this unit is split from |
 | `--title` | string | yes | — | the child's single-unit title; also half the create-once key |
+| `--token` | string | no | none | the claim token `triage claim` handed this lane; without it the guard reads the session alone and refuses once two lanes of it hold live markers |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -1091,7 +1099,7 @@ a silent lost split, in the one direction v1's own module says it refuses.
 | `8` | the create failed — UNKNOWN whether a child landed |
 | `9` | the child was created but the read-back does not match |
 | `11` | a precondition read failed — the parent, its comments, the claim on it, the queue, the timeline, or a candidate's body |
-| `17` | a live claim marker on the parent names another session |
+| `17` | a live claim marker on the parent names another session — or, when `--token` named this lane, another lane of this one; a tokenless call is refused once two lanes of its session hold live markers |
 
 **Errors**
 
@@ -1103,6 +1111,8 @@ a silent lost split, in the one direction v1's own module says it refuses.
 | `triage split: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
 | `triage split: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
 | `triage split: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage split: #<n> is claimed by lane <l> of this session, not by this lane (<nonce>) — refusing to mutate a sibling lane's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage split: #<n> carries live claim markers from more than one lane of this session and this call names none, so which lane is asking is UNKNOWN — pass the `--token` `fabrika triage claim <n>` handed this lane.` | 17 | refusal |
 | `triage split: label status:needs-triage does not exist in <repo> — refusing to create a child over a queue that would scan nothing (ADR 0092).` | 7 | refusal |
 | `triage split: the child body carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
 | `triage split: the child body is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
@@ -1210,7 +1220,7 @@ $ fabrika triage split 4312 --title "Editor loses focus after save" --json < chi
 **Invocation**
 
 ```
-fabrika triage enrich 4312 [--epic] [--repo <owner/name>] [--json]
+fabrika triage enrich 4312 [--epic] [--token <claim-token>] [--repo <owner/name>] [--json]
 ```
 
 The rewrite — or, with `--epic`, the pitch — arrives on **stdin only**, for the reason given under
@@ -1222,6 +1232,7 @@ The rewrite — or, with `--epic`, the pitch — arrives on **stdin only**, for 
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the issue to enrich |
 | `--epic` | boolean | no | `false` | wrap the original in place under a fixed header and head the pitch above it, instead of writing a rewrite over it; stdin carries the pitch, not a rewrite |
+| `--token` | string | no | none | the claim token `triage claim` handed this lane; without it the guard reads the session alone and refuses once two lanes of it hold live markers |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 | stdin | markdown | yes | — | the rewritten body that goes above the preserved original — with `--epic`, the pitch's five field lines instead: `**Problem:**`, `**Arc:**`, `**Appetite:** <N> cycles`, `**Rabbit-holes:**`, `**No-gos:**`, one per line |
@@ -1510,7 +1521,7 @@ criteria block; a verb that demanded one would be a different verb.
 | `8` | the `PATCH` failed — UNKNOWN whether the body changed |
 | `9` | the body was written but the read-back does not match |
 | `11` | the issue body could not be read, so there is no original to preserve — or its comments, or the claim on them, could not be read |
-| `17` | a live claim marker on the issue names another session |
+| `17` | a live claim marker on the issue names another session — or, when `--token` named this lane, another lane of this one; a tokenless call is refused once two lanes of its session hold live markers |
 | `15` | the composed body's **authored region** carries an acceptance-criteria block the wire reader classifies `Malformed` |
 
 **Errors**
@@ -1523,6 +1534,8 @@ criteria block; a verb that demanded one would be a different verb.
 | `triage enrich: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
 | `triage enrich: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
 | `triage enrich: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage enrich: #<n> is claimed by lane <l> of this session, not by this lane (<nonce>) — refusing to mutate a sibling lane's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage enrich: #<n> carries live claim markers from more than one lane of this session and this call names none, so which lane is asking is UNKNOWN — pass the `--token` `fabrika triage claim <n>` handed this lane.` | 17 | refusal |
 | `triage enrich: #<n> has an empty body — there is no original to preserve, and an empty one must never be preserved as though it were the record.` | 7 | refusal |
 | `triage enrich: cannot read #<n> in <repo>: <reason> — refusing to write an envelope over an original that was never read.` | 11 | refusal |
 | `triage enrich: the text you sent on stdin carries a machine-local path at line <k> (<class>) — rewrite it repo-relative. The preserved original is redacted automatically; this refusal is about the text you wrote.` | 5 | refusal |
@@ -1594,6 +1607,7 @@ $ fabrika triage enrich 4312 --json < enriched.md
 ```
 fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47
 fabrika triage apply 4312 --type chore --priority p2 --ready-for agent --lane axis:pipeline-hardening
+fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47 --token <claim-token>
 ```
 
 **Inputs**
@@ -1606,6 +1620,7 @@ fabrika triage apply 4312 --type chore --priority p2 --ready-for agent --lane ax
 | `--ready-for` | enum | yes | — | who picks it up: `human` or `agent` |
 | `--home` | integer | one of | — | the **number** of an open milestone to home the issue in |
 | `--lane` | enum | one of | — | a standing lane, taking its values from the `lane` rows `triage homes` prints |
+| `--token` | string | no | none | the claim token `triage claim` handed this lane; without it the guard reads the session alone and refuses once two lanes of it hold live markers |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -1722,7 +1737,7 @@ for drift, not because they are currently absent.)
 | `9` | the writes landed but the read-back does not show the required end state |
 | `10` | an off-vocabulary enum value, or `--home` names a milestone that is not open |
 | `11` | the issue, its comments, the claim on it, the repository's label set, or its milestone set could not be read |
-| `17` | a live claim marker on the issue names another session |
+| `17` | a live claim marker on the issue names another session — or, when `--token` named this lane, another lane of this one; a tokenless call is refused once two lanes of its session hold live markers |
 | `16` | `--ready-for agent` over a live body the wire reader does not answer `Found` on — every type but `epic`; nothing was written |
 | `18` | `.fabrika.jsonc` yielded no usable value — a key's load-time check refused it (the containment invariant is one such check), the file could not be read, or a key did not decode; refused at load, before the issue is even read |
 
@@ -1745,6 +1760,8 @@ stamp.
 | `triage apply: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
 | `triage apply: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
 | `triage apply: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage apply: #<n> is claimed by lane <l> of this session, not by this lane (<nonce>) — refusing to mutate a sibling lane's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage apply: #<n> carries live claim markers from more than one lane of this session and this call names none, so which lane is asking is UNKNOWN — pass the `--token` `fabrika triage claim <n>` handed this lane.` | 17 | refusal |
 | `triage apply: .fabrika.jsonc is refused — <reason>. Nothing was written; fix the config, because every label this verb would reconcile is judged against it.` | 18 | refusal |
 | `triage apply: cannot read <what> in <repo>: <reason> — nothing was written; the transition is UNKNOWN.` | 11 | refusal |
 | `triage apply: write failed after <k> of <m> changes: <reason> — #<n> may be partially labelled; re-run this verb, which is idempotent.` | 8 | refusal |
@@ -1829,7 +1846,7 @@ $ fabrika triage apply 4290 --type chore --priority p2 --ready-for agent --lane 
 **Invocation**
 
 ```
-fabrika triage park 4312 [--repo <owner/name>] [--json]
+fabrika triage park 4312 [--token <claim-token>] [--repo <owner/name>] [--json]
 ```
 
 The questions arrive on **stdin**.
@@ -1839,6 +1856,7 @@ The questions arrive on **stdin**.
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the issue to park |
+| `--token` | string | no | none | the claim token `triage claim` handed this lane; without it the guard reads the session alone and refuses once two lanes of it hold live markers |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 | stdin | markdown | yes | — | the questions that would unblock the issue |
@@ -1889,7 +1907,7 @@ it.
 | `8` | the comment or the label swap failed — UNKNOWN which landed |
 | `9` | the writes landed but the read-back does not match |
 | `11` | the issue, its comments, the claim on it, or the repository's label set could not be read |
-| `17` | a live claim marker on the issue names another session |
+| `17` | a live claim marker on the issue names another session — or, when `--token` named this lane, another lane of this one; a tokenless call is refused once two lanes of its session hold live markers |
 | `18` | `.fabrika.jsonc` yielded no usable value — a key's load-time check refused it (the containment invariant is one such check), the file could not be read, or a key did not decode; refused at load, before the comment is posted |
 
 **Errors**
@@ -1902,6 +1920,8 @@ it.
 | `triage park: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
 | `triage park: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
 | `triage park: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage park: #<n> is claimed by lane <l> of this session, not by this lane (<nonce>) — refusing to mutate a sibling lane's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage park: #<n> carries live claim markers from more than one lane of this session and this call names none, so which lane is asking is UNKNOWN — pass the `--token` `fabrika triage claim <n>` handed this lane.` | 17 | refusal |
 | `triage park: .fabrika.jsonc is refused — <reason>. Nothing was written; fix the config, because every label this verb would reconcile is judged against it.` | 18 | refusal |
 | `triage park: the questions text carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
 | `triage park: the questions text is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
@@ -1947,7 +1967,7 @@ $ fabrika triage park 4290 --json < questions.md
 **Invocation**
 
 ```
-fabrika triage kill 4312 --confirm [--duplicate-of <n>] [--repo <owner/name>] [--json]
+fabrika triage kill 4312 --confirm [--duplicate-of <n>] [--token <claim-token>] [--repo <owner/name>] [--json]
 ```
 
 The reason arrives on **stdin**.
@@ -1959,6 +1979,7 @@ The reason arrives on **stdin**.
 | *(positional)* | integer | yes | — | the issue to close not-planned |
 | `--confirm` | boolean | no | `false` | assert that the confirmation step ADR 0159 requires has been performed — salvage was attempted and this filing is genuinely unsalvageable or moves nothing forward. Its absence is a **refusal on `13`**, not a usage error |
 | `--duplicate-of` | integer | no | absent | the surviving issue; this issue's content is folded into it before closing |
+| `--token` | string | no | none | the claim token `triage claim` handed this lane; without it the guard reads the session alone and refuses once two lanes of it hold live markers |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 | stdin | markdown | yes | — | the reason this issue is being closed not-planned |
@@ -2010,7 +2031,7 @@ location, with the leak matcher literally named for comments.
 | `8` | one of the four writes failed — the message names what did and did not land |
 | `9` | the writes landed but the read-back does not show a not-planned close |
 | `11` | the issue body, its comments, the claim on it, the duplicate, or the label set could not be read — no kill was attempted |
-| `17` | a live claim marker on the issue names another session |
+| `17` | a live claim marker on the issue names another session — or, when `--token` named this lane, another lane of this one; a tokenless call is refused once two lanes of its session hold live markers |
 | `12` | refused: the issue is human-filed — no agent footer and no operator author |
 | `13` | refused: agent-filed and close-eligible, but `--confirm` was absent (ADR 0159) |
 
@@ -2029,6 +2050,8 @@ location, with the leak matcher literally named for comments.
 | `triage kill: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
 | `triage kill: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
 | `triage kill: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage kill: #<n> is claimed by lane <l> of this session, not by this lane (<nonce>) — refusing to mutate a sibling lane's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
+| `triage kill: #<n> carries live claim markers from more than one lane of this session and this call names none, so which lane is asking is UNKNOWN — pass the `--token` `fabrika triage claim <n>` handed this lane.` | 17 | refusal |
 | `triage kill: #<n> is human-filed — refusing to close it. Park it with questions instead.` | 12 | refusal |
 | `triage kill: #<n> is agent-filed and close-eligible, but ADR 0159 makes the confirmation the guard — pass --confirm once salvage has genuinely been attempted.` | 13 | refusal |
 | `triage kill: the fold comment on #<m> failed: <reason> — #<n> is NOT closed, carries no reason and no label; nothing was lost. Re-run.` | 8 | refusal |

--- a/packages/fabrika-cli/src/triage/apply-verb.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.ts
@@ -44,6 +44,8 @@ export interface ApplyOptions {
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The claim token `triage claim` handed this lane — which lane of the session is asking. */
+	readonly token: string | null;
 	/** Where the run stands. The repo root above it is where `.fabrika.jsonc` is read. */
 	readonly cwd: string;
 }
@@ -175,6 +177,7 @@ export const runApply = (
 			issue,
 			target: target.value,
 			env: options.env,
+			token: options.token,
 		});
 		if (guarded !== null) return guarded;
 

--- a/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
@@ -90,6 +90,7 @@ const options = {
 	readyFor: "agent",
 	home: 47 as number | null,
 	lane: null as string | null,
+	token: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,

--- a/packages/fabrika-cli/src/triage/board-vocabulary.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/board-vocabulary.unit.test.ts
@@ -85,6 +85,7 @@ const applyOptions = {
 	readyFor: "agent",
 	home: null as number | null,
 	lane: "team:infra" as string | null,
+	token: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
@@ -161,6 +162,7 @@ describe("triage park under a declared board vocabulary", () => {
 			Effect.provide(
 				runPark({
 					issue: 4312,
+					token: null as string | null,
 					repo: null,
 					json: false,
 					env: {CLAUDE_PIPELINE_REPO: "o/r"},

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -66,6 +66,20 @@ export const jsonFlag = Flag.boolean("json").pipe(
 	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
 );
 
+/**
+ * The identity every mutating verb re-proves its claim against (#6303).
+ *
+ * Optional, because the guard has a fail-closed reading for a call that names no lane: it passes an
+ * uncontested session and refuses one whose markers name two lanes. Making it required would refuse
+ * every existing call site over a race most of them are not in.
+ */
+export const laneTokenFlag = Flag.string("token").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the claim token `triage claim` handed this lane — what tells two triagers of ONE session apart",
+	),
+);
+
 const codes = leafCommand(
 	"codes",
 	{json: jsonFlag},
@@ -99,15 +113,17 @@ const kill = leafCommand(
 				"the surviving issue; this issue's body is folded into it, leak-redacted, before the close",
 			),
 		),
+		token: laneTokenFlag,
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({issue, confirm, duplicateOf, repo, json}) {
+	Effect.fn(function* ({issue, confirm, duplicateOf, token, repo, json}) {
 		yield* emit(
 			yield* runKill({
 				issue,
 				confirm,
 				duplicateOf: Option.getOrNull(duplicateOf),
+				token: Option.getOrNull(token),
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -118,7 +134,7 @@ const kill = leafCommand(
 ).pipe(
 	Command.withShortDescription("Close an agent-filed issue not-planned, with a reason."),
 	Command.withDescription(
-		"Close an agent-filed issue not-planned over four gated writes — the optional redacted duplicate fold, the reason from STDIN, the closed-by-triage label, then the close — and read back that it says not_planned. Prints `killed\\t<number>\\t<foldedInto|none>`. Exits 3 (empty stdin), 5 (machine-local path in the reason), 6 (bare @ reference), 7 (issue absent or closed, duplicate absent or closed, or no closed-by-triage label), 8 (a write failed — UNKNOWN), 9 (read-back is not a not-planned close), 11 (a precondition read failed, including the claim on the issue), 12 (human-filed — no agent footer and no operator author, see $FABRIKA_OPERATOR_ACCOUNTS), 13 (unconfirmed), 17 (a live claim marker on the issue names another session). Example: fabrika triage kill 4312 --confirm --duplicate-of 4290 < reason.md",
+		"Close an agent-filed issue not-planned over four gated writes — the optional redacted duplicate fold, the reason from STDIN, the closed-by-triage label, then the close — and read back that it says not_planned. Prints `killed\\t<number>\\t<foldedInto|none>`. Exits 3 (empty stdin), 5 (machine-local path in the reason), 6 (bare @ reference), 7 (issue absent or closed, duplicate absent or closed, or no closed-by-triage label), 8 (a write failed — UNKNOWN), 9 (read-back is not a not-planned close), 11 (a precondition read failed, including the claim on the issue), 12 (human-filed — no agent footer and no operator author, see $FABRIKA_OPERATOR_ACCOUNTS), 13 (unconfirmed), 17 (a live claim marker on the issue names another session, or — with --token — another lane of this one). Example: fabrika triage kill 4312 --confirm --duplicate-of 4290 < reason.md",
 	),
 );
 
@@ -137,14 +153,16 @@ const split = leafCommand(
 		title: Flag.string("title").pipe(
 			Flag.withDescription("the child's single-unit title; also half the create-once key"),
 		),
+		token: laneTokenFlag,
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({parent, title, repo, json}) {
+	Effect.fn(function* ({parent, title, token, repo, json}) {
 		yield* emit(
 			yield* runSplit({
 				parent,
 				title,
+				token: Option.getOrNull(token),
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -156,7 +174,7 @@ const split = leafCommand(
 ).pipe(
 	Command.withShortDescription("Create one child of a bundled report, exactly once."),
 	Command.withDescription(
-		'Create one child of a bundled report from the body on STDIN, exactly once, and cross-link the parent. Prints `<created|reused>\\t<number>\\t<url>`; both outcomes exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (parent absent or closed, or the queue label does not exist), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed, including the claim on the parent — never a silent create), 17 (a live claim marker on the parent names another session). Example: fabrika triage split 4312 --title "Editor loses focus after save" < child.md',
+		'Create one child of a bundled report from the body on STDIN, exactly once, and cross-link the parent. Prints `<created|reused>\\t<number>\\t<url>`; both outcomes exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (parent absent or closed, or the queue label does not exist), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed, including the claim on the parent — never a silent create), 17 (a live claim marker on the parent names another session, or — with --token — another lane of this one). Example: fabrika triage split 4312 --title "Editor loses focus after save" < child.md',
 	),
 );
 
@@ -197,10 +215,11 @@ const apply = leafCommand(
 				`a standing lane instead of a milestone; this repo's own set, defaulting to ${STANDING_LANES.join(" or ")}`,
 			),
 		),
+		token: laneTokenFlag,
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({issue, type, priority, readyFor, home, lane, repo, json}) {
+	Effect.fn(function* ({issue, type, priority, readyFor, home, lane, token, repo, json}) {
 		yield* emit(
 			yield* runApply({
 				issue,
@@ -209,6 +228,7 @@ const apply = leafCommand(
 				readyFor,
 				home: Option.getOrNull(home),
 				lane: Option.getOrNull(lane),
+				token: Option.getOrNull(token),
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -219,17 +239,18 @@ const apply = leafCommand(
 ).pipe(
 	Command.withShortDescription("Stamp the whole triaged transition as one reconcile."),
 	Command.withDescription(
-		"Stamp the whole triaged transition — type, priority, audience, status and home — as ONE owned-facet reconcile, then read the end state back positively. Exactly one of --home / --lane. Prints `triaged\\t<n>\\t<type>\\t<priority>\\t<ready-for>\\t<home>`. Exits 7 (no such issue, it is closed, or a label this run would write does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (off-vocabulary value, or a non-open milestone), 11 (a precondition read failed, including the claim on the issue), 16 (--ready-for agent over a body with no readable acceptance-criteria block — every type but epic), 17 (a live claim marker on the issue names another session), 18 (.fabrika.jsonc yielded no usable value — refused by a key's load-time check, unreadable, or undecodable). Example: fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47",
+		"Stamp the whole triaged transition — type, priority, audience, status and home — as ONE owned-facet reconcile, then read the end state back positively. Exactly one of --home / --lane. Prints `triaged\\t<n>\\t<type>\\t<priority>\\t<ready-for>\\t<home>`. Exits 7 (no such issue, it is closed, or a label this run would write does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (off-vocabulary value, or a non-open milestone), 11 (a precondition read failed, including the claim on the issue), 16 (--ready-for agent over a body with no readable acceptance-criteria block — every type but epic), 17 (a live claim marker on the issue names another session, or — with --token — another lane of this one), 18 (.fabrika.jsonc yielded no usable value — refused by a key's load-time check, unreadable, or undecodable). Example: fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47",
 	),
 );
 
 const park = leafCommand(
 	"park",
-	{issue: issueArg, repo: repoFlag, json: jsonFlag},
-	Effect.fn(function* ({issue, repo, json}) {
+	{issue: issueArg, token: laneTokenFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({issue, token, repo, json}) {
 		yield* emit(
 			yield* runPark({
 				issue,
+				token: Option.getOrNull(token),
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -241,7 +262,7 @@ const park = leafCommand(
 ).pipe(
 	Command.withShortDescription("Demote an issue to needs-info with the questions on stdin."),
 	Command.withDescription(
-		"Demote an issue to status:needs-info with the questions on STDIN, clearing every priced facet — type, priority, audience, lane and milestone. The comment is posted BEFORE the labels move. Prints `parked\\t<n>\\t<comment-url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue, it is closed, or status:needs-info does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed, including the claim on the issue), 17 (a live claim marker on the issue names another session), 18 (.fabrika.jsonc yielded no usable value — refused by a key's load-time check, unreadable, or undecodable). Example: fabrika triage park 4290 < questions.md",
+		"Demote an issue to status:needs-info with the questions on STDIN, clearing every priced facet — type, priority, audience, lane and milestone. The comment is posted BEFORE the labels move. Prints `parked\\t<n>\\t<comment-url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue, it is closed, or status:needs-info does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed, including the claim on the issue), 17 (a live claim marker on the issue names another session, or — with --token — another lane of this one), 18 (.fabrika.jsonc yielded no usable value — refused by a key's load-time check, unreadable, or undecodable). Example: fabrika triage park 4290 < questions.md",
 	),
 );
 
@@ -394,14 +415,16 @@ const enrich = leafCommand(
 				"wrap the original under a fixed header and head a pitch above it; stdin carries the pitch's five field lines, not a rewrite",
 			),
 		),
+		token: laneTokenFlag,
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({issue, epic, repo, json}) {
+	Effect.fn(function* ({issue, epic, token, repo, json}) {
 		yield* emit(
 			yield* runEnrich({
 				issue,
 				epic,
+				token: Option.getOrNull(token),
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -412,7 +435,7 @@ const enrich = leafCommand(
 ).pipe(
 	Command.withShortDescription("Replace an issue body with the rewrite on stdin."),
 	Command.withDescription(
-		"Replace an issue body with the rewrite on STDIN above the preserved, leak-redacted original — or with --epic, a pitch above the original under a fixed header. A prior enrichment is recognised by the marker this verb writes, bound to this issue number, so a re-run in EITHER mode replaces the authored region instead of nesting a second envelope. Prints `enriched\\t<number>\\t<redactions>`. Exits 3 (empty stdin), 5 (machine-local path in the authored text), 6 (bare @ reference), 7 (issue absent or closed, or its body is empty — no original to preserve), 8 (the PATCH failed — UNKNOWN), 9 (read-back mismatch), 11 (the issue, or the claim on it, could not be read), 17 (a live claim marker on the issue names another session). Example: fabrika triage enrich 4312 < enriched.md",
+		"Replace an issue body with the rewrite on STDIN above the preserved, leak-redacted original — or with --epic, a pitch above the original under a fixed header. A prior enrichment is recognised by the marker this verb writes, bound to this issue number, so a re-run in EITHER mode replaces the authored region instead of nesting a second envelope. Prints `enriched\\t<number>\\t<redactions>`. Exits 3 (empty stdin), 5 (machine-local path in the authored text), 6 (bare @ reference), 7 (issue absent or closed, or its body is empty — no original to preserve), 8 (the PATCH failed — UNKNOWN), 9 (read-back mismatch), 11 (the issue, or the claim on it, could not be read), 17 (a live claim marker on the issue names another session, or — with --token — another lane of this one). Example: fabrika triage enrich 4312 < enriched.md",
 	),
 );
 

--- a/packages/fabrika-cli/src/triage/enrich-verb.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.ts
@@ -39,6 +39,8 @@ export interface EnrichOptions {
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The claim token `triage claim` handed this lane — which lane of the session is asking. */
+	readonly token: string | null;
 	readonly stdin: Effect.Effect<StdinRead>;
 }
 
@@ -91,6 +93,7 @@ export const runEnrich = (
 			issue,
 			target: target.value,
 			env: options.env,
+			token: options.token,
 		});
 		if (guarded !== null) return guarded;
 

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -53,6 +53,7 @@ const issue = (body: string): HttpReply => ({
 const options = {
 	issue: 4312,
 	epic: false,
+	token: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,

--- a/packages/fabrika-cli/src/triage/kill-verb.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.ts
@@ -61,6 +61,8 @@ export interface KillOptions {
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The claim token `triage claim` handed this lane — which lane of the session is asking. */
+	readonly token: string | null;
 	readonly stdin: Effect.Effect<StdinRead>;
 }
 
@@ -118,6 +120,7 @@ export const runKill = (
 			issue,
 			target: target.value,
 			env: options.env,
+			token: options.token,
 		});
 		if (guarded !== null) return guarded;
 

--- a/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
@@ -119,6 +119,7 @@ const options = {
 	issue: 4312,
 	confirm: true,
 	duplicateOf: null as number | null,
+	token: null as string | null,
 	repo: null as string | null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,

--- a/packages/fabrika-cli/src/triage/park-verb.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.ts
@@ -36,6 +36,8 @@ export interface ParkOptions {
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The claim token `triage claim` handed this lane — which lane of the session is asking. */
+	readonly token: string | null;
 	readonly stdin: Effect.Effect<StdinRead>;
 	/** Where the run stands. The repo root above it is where `.fabrika.jsonc` is read. */
 	readonly cwd: string;
@@ -95,6 +97,7 @@ export const runPark = (
 			issue,
 			target: target.value,
 			env: options.env,
+			token: options.token,
 		});
 		if (guarded !== null) return guarded;
 

--- a/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
@@ -75,6 +75,7 @@ const POSTED: HttpReply = {
 
 const options = {
 	issue: 4290,
+	token: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,

--- a/packages/fabrika-cli/src/triage/split-verb.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.ts
@@ -62,6 +62,8 @@ export interface SplitOptions {
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The claim token `triage claim` handed this lane — which lane of the session is asking. */
+	readonly token: string | null;
 	/** The fd-0 read, injected so the failed-read and TTY paths are testable without a descriptor. */
 	readonly stdin: Effect.Effect<StdinRead>;
 	/** The footer's timestamp, injected so a child body is byte-reproducible in a test. */
@@ -179,6 +181,7 @@ export const runSplit = Effect.fn(function* (options: SplitOptions) {
 		target: parentIssue.value,
 		noun: "parent",
 		env: options.env,
+		token: options.token,
 		now: options.now,
 	});
 	if (guarded !== null) return guarded;

--- a/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
@@ -104,6 +104,7 @@ const posted: HttpReply = {
 const options = {
 	parent: 4312,
 	title: TITLE,
+	token: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,

--- a/packages/fabrika-cli/src/triage/target-guard.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.ts
@@ -1,6 +1,6 @@
 /**
  * The two preconditions every mutating `triage` verb re-reads on its target: it is still open, and
- * no live claim marker on it names another session.
+ * no live claim marker on it names a claimant other than the asking lane.
  *
  * `triage claim` resolved the race correctly and nothing after it read the answer back, so the
  * protocol held only as long as prose discipline did. On 2026-08-15 it did not: a session that had
@@ -13,39 +13,51 @@
  * every existing caller. The consequence is that this guard narrows the window rather than closing
  * it — two unclaimed sessions still race — which is `triage claim`'s job, not this one's.
  *
- * **The session is the whole identity here, and the lane nonce #6132 added is not read.** These five
- * verbs are handed no claim token, so a sibling lane of one session reads its sibling's marker as
- * its own and passes — the same window that stayed open before, no wider. Closing it means threading
- * the token through every mutating verb, which is its own change.
+ * **Foreignness is the session+lane pair, never the session alone (#6303).** A `--token` names which
+ * lane of the session is asking, and a same-session marker under a different nonce is somebody
+ * else's — the identity `triage claim` already resolves on (#6132) and the `build` namespace resolves
+ * ownership against (#6037), now read on this side of the claim too.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {type IssueRecord, listComments} from "../io/issues.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {
+	type Asked,
+	anySessionCaller,
+	type Caller,
 	DEFAULT_TTL_MINUTES,
 	isStampableSession,
 	liveMarkers,
 	type Marker,
 	markersOf,
+	namesCaller,
+	requireCallerToken,
+	requireSession,
 } from "./claim.ts";
 import {CLAIMED_ELSEWHERE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 
 /**
- * The live markers naming a session other than `session`, or the reason the set is unreadable.
+ * The live markers that do not name `caller`, or the reason the set is unreadable.
  *
  * A session id this module cannot attribute a marker to — unset, or not one stampable token — makes
  * **every** live marker foreign. The alternative fails open exactly where it matters: an empty id
  * matches no marker, so a set full of live competitors would resolve to "nobody else holds it".
+ *
+ * A tokenless caller (`AnySession`) cannot prove *which* lane of its session it is, so it is priced
+ * fail-closed on exactly that ambiguity: it passes its session's markers while they all name one
+ * lane, and once two lanes of its session hold live markers every one of them is foreign, because
+ * the caller has no way to say which is its own. That keeps the uncontested call sites working and
+ * refuses precisely the sibling race #6303 is about.
  */
 export const foreignMarkers = ({
 	markers,
-	session,
+	caller,
 	now,
 	ttlMinutes,
 }: {
 	readonly markers: ReadonlyArray<Marker>;
-	readonly session: string;
+	readonly caller: Caller;
 	readonly now: number;
 	readonly ttlMinutes: number;
 }):
@@ -56,10 +68,19 @@ export const foreignMarkers = ({
 	  } => {
 	const scanned = liveMarkers({markers, now, ttlMinutes});
 	if (scanned._tag === "Unresolvable") return scanned;
-	const mine = isStampableSession(session) ? session : null;
+	if (!isStampableSession(caller.session)) {
+		return {_tag: "Foreign", foreign: scanned.live};
+	}
+	if (caller._tag === "Lane") {
+		return {_tag: "Foreign", foreign: scanned.live.filter((m) => !namesCaller(m, caller))};
+	}
+	const lanes = new Set(
+		scanned.live.filter((m) => m.session === caller.session).map((m) => m.lane),
+	);
+	const contested = lanes.size > 1;
 	return {
 		_tag: "Foreign",
-		foreign: scanned.live.filter((m) => mine === null || m.session !== mine),
+		foreign: scanned.live.filter((m) => contested || m.session !== caller.session),
 	};
 };
 
@@ -73,8 +94,53 @@ export interface GuardOptions {
 	/** What the target is to this verb — `split` guards a parent, not the issue it creates. */
 	readonly noun?: string;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/**
+	 * The token `triage claim` handed this lane, when the caller passed one — what tells two lanes of
+	 * one session apart. Absent, the guard falls back to the session-wide identity and its
+	 * fail-closed reading of a contested session.
+	 */
+	readonly token?: string | null;
 	readonly now?: () => Date;
 }
+
+/** Which claimant is asking: the lane `--token` names, or the whole session when it named none. */
+const askCaller = (
+	verb: string,
+	env: Readonly<Record<string, string | undefined>>,
+	token: string | null | undefined,
+): Asked<Caller> => {
+	const trimmed = (token ?? "").trim();
+	if (trimmed === "") {
+		return {_tag: "Asked", value: anySessionCaller((env.CLAUDE_CODE_SESSION_ID ?? "").trim())};
+	}
+	const session = requireSession(
+		verb,
+		env,
+		"the lane --token names cannot be checked against the session running it",
+	);
+	if (!("_tag" in session)) return session;
+	const lane = requireCallerToken(verb, session.value, trimmed);
+	return "_tag" in lane ? {_tag: "Asked", value: lane.value.caller} : lane;
+};
+
+/**
+ * How the refusal names the claimant that beat this caller.
+ *
+ * A sibling lane of one session and a wholly foreign session are the same refusal and different
+ * facts, and "claimed by session <mine>" over the first would read as this caller's own claim
+ * locking it out.
+ */
+const heldElsewhere = (issue: number, holder: Marker, caller: Caller): string => {
+	const run = `Run \`fabrika triage claim ${issue}\` and act only on \`won\`.`;
+	if (holder.session !== caller.session) {
+		const named = holder.session === "" ? "(unreadable)" : holder.session;
+		return `#${issue} is claimed by session ${named} — refusing to mutate another session's issue. ${run}`;
+	}
+	if (caller._tag === "Lane") {
+		return `#${issue} is claimed by lane ${holder.lane ?? "(pre-#6132, session-only)"} of this session, not by this lane (${caller.nonce}) — refusing to mutate a sibling lane's issue. ${run}`;
+	}
+	return `#${issue} carries live claim markers from more than one lane of this session and this call names none, so which lane is asking is UNKNOWN — pass the \`--token\` \`fabrika triage claim ${issue}\` handed this lane.`;
+};
 
 /**
  * The refusal this target earns, or `null` when it is open and uncontested.
@@ -93,6 +159,9 @@ export const guardTarget = (
 			return refuse(ZERO_SCOPE, `${verb}: ${noun} #${issue} is already closed.`);
 		}
 
+		const asked = askCaller(verb, options.env, options.token);
+		if (!("_tag" in asked)) return asked.refusal;
+
 		const comments = yield* listComments(repo, issue);
 		if (comments._tag === "Failure") {
 			return refuse(
@@ -101,9 +170,10 @@ export const guardTarget = (
 			);
 		}
 
+		const caller = asked.value;
 		const scanned = foreignMarkers({
 			markers: markersOf(comments.value),
-			session: options.env.CLAUDE_CODE_SESSION_ID ?? "",
+			caller,
 			now: (options.now ?? (() => new Date()))().getTime(),
 			ttlMinutes: DEFAULT_TTL_MINUTES,
 		});
@@ -116,10 +186,7 @@ export const guardTarget = (
 
 		const holder = scanned.foreign[0];
 		if (holder !== undefined) {
-			return refuse(
-				CLAIMED_ELSEWHERE,
-				`${verb}: #${issue} is claimed by session ${holder.session === "" ? "(unreadable)" : holder.session} — refusing to mutate another session's issue. Run \`fabrika triage claim ${issue}\` and act only on \`won\`.`,
-			);
+			return refuse(CLAIMED_ELSEWHERE, `${verb}: ${heldElsewhere(issue, holder, caller)}`);
 		}
 		return null;
 	});

--- a/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
@@ -2,15 +2,17 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import type {Scripted} from "../fakes.test-support.ts";
 import type {IssueRecord} from "../io/issues.ts";
-import {DEFAULT_TTL_MINUTES} from "./claim.ts";
+import {anySessionCaller, DEFAULT_TTL_MINUTES, laneCaller} from "./claim.ts";
 import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {CLAIMED_ELSEWHERE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {foreignMarkers, guardTarget} from "./target-guard.ts";
 
 const MINE = "session-mine";
 const THEIRS = "session-theirs";
-/** This guard reads the session axis only, so which lane a marker names never changes its answer. */
 const LANE = "aaaaaaaa";
+const SIBLING = "bbbbbbbb";
+/** A token whose nonce is {@link LANE}: the first eight hex digits of the uuid half. */
+const TOKEN = `triage:${MINE}:aaaaaaaa-1111-2222-3333-444444444444`;
 
 const target = (over: Partial<IssueRecord> = {}): IssueRecord => ({
 	number: 4312,
@@ -33,7 +35,11 @@ const said = (outcome: {readonly stderr: ReadonlyArray<string>} | null): string 
 
 const run = (
 	script: ReadonlyArray<Scripted>,
-	over: {readonly state?: "open" | "closed"; readonly session?: string} = {},
+	over: {
+		readonly state?: "open" | "closed";
+		readonly session?: string;
+		readonly token?: string;
+	} = {},
 ) =>
 	Effect.runPromise(
 		Effect.provide(
@@ -42,6 +48,7 @@ const run = (
 				repo: "o/r",
 				issue: 4312,
 				target: target(over.state === undefined ? {} : {state: over.state}),
+				token: over.token ?? null,
 				env:
 					over.session === undefined
 						? {CLAUDE_PIPELINE_REPO: "o/r"}
@@ -60,34 +67,67 @@ describe("foreignMarkers", () => {
 			readonly lane: string | null;
 			readonly createdAt: string;
 		}>,
-		session: string,
-	) => foreignMarkers({markers, session, now, ttlMinutes: DEFAULT_TTL_MINUTES});
+		caller: Parameters<typeof foreignMarkers>[0]["caller"],
+	) => foreignMarkers({markers, caller, now, ttlMinutes: DEFAULT_TTL_MINUTES});
+
+	const lane = laneCaller(MINE, LANE, TOKEN);
+	const tokenless = anySessionCaller(MINE);
 
 	it("counts a live marker of another session foreign", () => {
-		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: LIVE}], MINE);
+		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: LIVE}], lane);
 		expect(scanned._tag).toBe("Foreign");
 		expect(scanned._tag === "Foreign" && scanned.foreign.map((m) => m.session)).toEqual([THEIRS]);
 	});
 
-	it("counts this session's own live marker as not foreign", () => {
-		const scanned = scan([{id: 1, session: MINE, lane: LANE, createdAt: LIVE}], MINE);
+	it("counts this lane's own live marker as not foreign", () => {
+		const scanned = scan([{id: 1, session: MINE, lane: LANE, createdAt: LIVE}], lane);
 		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
 	});
 
-	it("ages an expired foreign marker out", () => {
-		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: EXPIRED}], MINE);
+	it("counts a sibling lane's live marker of this same session foreign", () => {
+		const scanned = scan([{id: 1, session: MINE, lane: SIBLING, createdAt: LIVE}], lane);
+		expect(scanned._tag === "Foreign" && scanned.foreign.map((m) => m.lane)).toEqual([SIBLING]);
+	});
+
+	// A claimant that named a session and nothing else is one no live lane can prove is its own.
+	it("counts a pre-#6132 session-only marker foreign to a lane caller", () => {
+		const scanned = scan([{id: 1, session: MINE, lane: null, createdAt: LIVE}], lane);
+		expect(scanned._tag === "Foreign" && scanned.foreign).toHaveLength(1);
+	});
+
+	it("ages an expired sibling marker out", () => {
+		const scanned = scan([{id: 1, session: MINE, lane: SIBLING, createdAt: EXPIRED}], lane);
 		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
+	});
+
+	it("passes a tokenless caller over one lane of its own session", () => {
+		const scanned = scan([{id: 1, session: MINE, lane: LANE, createdAt: LIVE}], tokenless);
+		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
+	});
+
+	it("counts every marker foreign to a tokenless caller once two lanes of its session are live", () => {
+		const scanned = scan(
+			[
+				{id: 1, session: MINE, lane: LANE, createdAt: LIVE},
+				{id: 2, session: MINE, lane: SIBLING, createdAt: LIVE},
+			],
+			tokenless,
+		);
+		expect(scanned._tag === "Foreign" && scanned.foreign).toHaveLength(2);
 	});
 
 	// An empty id matches no marker, so a session-blind filter would answer "nobody else holds it"
 	// over a set full of live competitors — the one direction this may not fail.
 	it("counts every live marker foreign when this session cannot be attributed", () => {
-		const scanned = scan([{id: 1, session: MINE, lane: LANE, createdAt: LIVE}], "");
+		const scanned = scan(
+			[{id: 1, session: MINE, lane: LANE, createdAt: LIVE}],
+			anySessionCaller(""),
+		);
 		expect(scanned._tag === "Foreign" && scanned.foreign).toHaveLength(1);
 	});
 
 	it("refuses to resolve a marker whose ordering key will not parse", () => {
-		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: "whenever"}], MINE);
+		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: "whenever"}], lane);
 		expect(scanned._tag).toBe("Unresolvable");
 	});
 });
@@ -140,10 +180,56 @@ describe("guardTarget", () => {
 		expect(said(outcome)).toContain(THEIRS);
 	});
 
-	it("passes when the live claim is this session's own", async () => {
+	it("passes when the live claim is this lane's own", async () => {
 		expect(
-			await run([[COMMENTS, claimPage({session: MINE, createdAt: LIVE})]], {session: MINE}),
+			await run([[COMMENTS, claimPage({session: MINE, createdAt: LIVE, lane: LANE})]], {
+				session: MINE,
+				token: TOKEN,
+			}),
 		).toBeNull();
+	});
+
+	it("refuses a sibling lane of this session on 17, before any write", async () => {
+		const outcome = await run(
+			[[COMMENTS, claimPage({session: MINE, createdAt: LIVE, lane: SIBLING})]],
+			{
+				session: MINE,
+				token: TOKEN,
+			},
+		);
+		expect(outcome?.code).toBe(CLAIMED_ELSEWHERE);
+		expect(said(outcome)).toContain(`claimed by lane ${SIBLING} of this session`);
+	});
+
+	it("refuses a tokenless call on 17 once two lanes of its session hold live markers", async () => {
+		const outcome = await run(
+			[
+				[
+					COMMENTS,
+					claimPage(
+						{session: MINE, createdAt: LIVE, lane: LANE},
+						{session: MINE, createdAt: LIVE, lane: SIBLING},
+					),
+				],
+			],
+			{session: MINE},
+		);
+		expect(outcome?.code).toBe(CLAIMED_ELSEWHERE);
+		expect(said(outcome)).toContain("this call names none");
+	});
+
+	it("passes a tokenless call over one lane of its session — the uncontested call sites", async () => {
+		expect(
+			await run([[COMMENTS, claimPage({session: MINE, createdAt: LIVE, lane: LANE})]], {
+				session: MINE,
+			}),
+		).toBeNull();
+	});
+
+	it("refuses on 1 when --token names a session other than the one running", async () => {
+		const outcome = await run([], {session: MINE, token: `triage:${THEIRS}:aaaaaaaa-1-2-3-4`});
+		expect(outcome?.code).toBe(1);
+		expect(said(outcome)).toContain("a lane names itself, never another");
 	});
 
 	it("passes an expired foreign claim — the TTL still ages markers out", async () => {


### PR DESCRIPTION
Fixes #6303

`foreignMarkers` in `triage/target-guard.ts` filtered live claim markers with
`m.session !== mine`, so the five mutating verbs (`apply`/`enrich`/`split`/`park`/`kill`) could only
tell *some* lane of the running session from another session — never one sibling of a fan-out from
another. A lane that read `lost` still passed the guard and replaced the winner's authored body.
#6132 made the marker carry `lane=<nonce>`; this reads that half.

What changed:

- `foreignMarkers` now takes a `Caller` (the identity `triage claim` and the `build` namespace both
  resolve on) instead of a bare session string, and answers through `namesCaller` — a same-session
  marker under a different nonce is foreign.
- The five verbs each take an optional `--token`; `guardTarget` resolves it through `claim.ts`'s own
  `requireSession`/`requireCallerToken`, so a token from another session is a usage error on `1`
  rather than a trusted identity.
- A tokenless call is priced fail-closed on exactly the ambiguity it cannot resolve: it passes while
  its session's live markers all name one lane, and refuses on `17` once two lanes of its session
  hold live markers. That keeps every existing tokenless call site working when nothing races it.
- The `17` refusal now names what actually beat you — a foreign session, a sibling lane, or "this
  call names no lane" — because "claimed by session <your own id>" reads as nonsense on the sibling
  case.

Contract and `SKILL.md` updated: the `--token` flag rows, the invocation lines, the reworded `17`
rows, and the two new refusal messages per verb. The skill now tells a triager to pass its token to
all five.

Where to look first: `foreignMarkers`' three branches in
`packages/fabrika-cli/src/triage/target-guard.ts`, and whether "two distinct lane values live" is
the right reading of "a competing live sibling marker" from the issue's triage note. A marker with
no `lane=` at all counts as one distinct claimant, per `laneOf`'s existing contract.

## Deviations

None.
