### PR TITLE
fix: A repair round on an epic child wedges its lane at lane prove exit 25

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -538,7 +538,7 @@ event and never skipped as an optimisation. Its refusals each name a different n
 | `22` | the artifact is provably absent — no open PR links the task's issue and no legal no-PR outcome is proven either (the issue is not a `type:investigation`, or it is one but no diagnosis was posted since the task entered `build`); on an epic child, no branch in this tree carries commits naming it | the report is unproven — record `BLOCKED`, never the `DONE` |
 | `23` | a derived namespace has no verdict that still binds — no current-head one on a PR, or, on an epic child, none whose content digest matches what the range carries now | record **nothing**; re-read this pass |
 | `24` | a still-binding `FAIL` under a claimed `PASS` | record the event the artifact supports (`FAIL`) |
-| `25` | several candidates — open PRs linking the issue, or lane branches carrying an epic child's commits | park — step 4, naming the ambiguity |
+| `25` | several candidates — open PRs linking the issue, or lane branches carrying an epic child's commits that no one of them contains, so a repair round's superseding branch is not one of these (#6049) | park — step 4, naming the ambiguity |
 | `11` | a lane, board or tree read failed | the proof is UNKNOWN — end `STOPPED` naming the code |
 
 A builder's `SUCCESS-NO-PR` is a proven `DONE`, not an unproven one: the verb takes the no-PR arm

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -160,6 +160,13 @@ export interface BranchFact {
 	readonly tip: string;
 	/** Every message the range adds, whole. Empty where the branch adds nothing. */
 	readonly messages: ReadonlyArray<string>;
+	/**
+	 * The other candidates' tips this branch's history already contains, as object names.
+	 *
+	 * Ancestry arrives as data so {@link traceRange} stays pure — the read itself is git's, taken
+	 * once per pair by `locateRange` (`./range.ts`).
+	 */
+	readonly contains: ReadonlyArray<string>;
 }
 
 /**
@@ -211,6 +218,13 @@ export type RangeTrace =
  * Several branches carrying this child's commits is its own answer for the same reason
  * {@link tracePulls} keeps `Many`: which one the lane owns is not derivable here, and picking the
  * first records a `DONE` against a range nobody reviewed.
+ *
+ * The one exception is supersession, and it is derived rather than guessed: a repair round is a new
+ * claim, so it is a new nonce, so it is a new branch name (`../build/lane.ts`), and the machine
+ * budgets for repair rounds — every one of them used to wedge the lane at the ambiguous arm (#6049).
+ * When exactly one candidate's history contains every other candidate's tip, that candidate is the
+ * later round of the same work and it is the range. A genuine fork — no candidate containing all the
+ * others, or two of them containing each other — stays `Many`.
  */
 export const traceRange = (
 	issue: number,
@@ -220,19 +234,22 @@ export const traceRange = (
 	const carrying = facts.filter((fact) =>
 		fact.messages.some((message) => issueRefsIn(message).includes(issue)),
 	);
-	const [first] = carrying;
-	if (first !== undefined) {
-		return carrying.length === 1
-			? {
-					_tag: "One",
-					branch: first.branch,
-					base: first.base,
-					tip: first.tip,
-					commits: first.messages.length,
-					naming: first.messages.filter((message) => issueRefsIn(message).includes(issue)).length,
-				}
-			: {_tag: "Many", branches: carrying.map((fact) => fact.branch)};
+	const superseding = carrying.filter((fact, at) =>
+		carrying.every((other, other_at) => other_at === at || fact.contains.includes(other.tip)),
+	);
+	const one =
+		carrying.length === 1 ? carrying[0] : superseding.length === 1 ? superseding[0] : undefined;
+	if (one !== undefined) {
+		return {
+			_tag: "One",
+			branch: one.branch,
+			base: one.base,
+			tip: one.tip,
+			commits: one.messages.length,
+			naming: one.messages.filter((message) => issueRefsIn(message).includes(issue)).length,
+		};
 	}
+	if (carrying.length > 0) return {_tag: "Many", branches: carrying.map((fact) => fact.branch)};
 	const names = facts.map((fact) => fact.branch).join(", ");
 	if (facts.length === 0) {
 		return {

--- a/packages/fabrika-cli/src/lane/prove.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove.unit.test.ts
@@ -168,6 +168,7 @@ describe("traceRange", () => {
 		base: "664eb9d",
 		tip: "03135b9",
 		messages: [commit(5829)],
+		contains: [],
 	};
 
 	it("traces the one branch whose commits name the child, and counts them", () => {
@@ -210,14 +211,76 @@ describe("traceRange", () => {
 		expect(foreign._tag === "None" && foreign.why).toContain("names #5829");
 	});
 
-	it("keeps several carrying branches as their own answer rather than picking one", () => {
+	it("keeps a genuine fork as its own answer rather than picking one", () => {
 		const traced = traceRange(5829, "epic/5800", [
 			carrying,
-			{...carrying, branch: "build/5829-second-try-deadbeef"},
+			{...carrying, branch: "build/5829-second-try-deadbeef", tip: "9b51636"},
 		]);
 		expect(traced).toEqual({
 			_tag: "Many",
 			branches: [carrying.branch, "build/5829-second-try-deadbeef"],
+		});
+	});
+
+	it("resolves a repair round's superseding branch to the range it strictly contains", () => {
+		const repaired = {
+			...carrying,
+			branch: "build/5829-second-try-deadbeef",
+			tip: "a1068c0",
+			messages: [commit(5829), commit(5829)],
+			contains: [carrying.tip],
+		};
+		expect(traceRange(5829, "epic/5800", [carrying, repaired])).toEqual({
+			_tag: "One",
+			branch: repaired.branch,
+			base: "664eb9d",
+			tip: "a1068c0",
+			commits: 2,
+			naming: 2,
+		});
+	});
+
+	it("walks a three-round chain to the newest tip rather than an intermediate one", () => {
+		const second = {
+			...carrying,
+			branch: "build/5829-second-try-deadbeef",
+			tip: "a1068c0",
+			contains: [carrying.tip],
+		};
+		const third = {
+			...carrying,
+			branch: "build/5829-third-try-c0ffee00",
+			tip: "7d21ab4",
+			contains: [carrying.tip, second.tip],
+		};
+		const traced = traceRange(5829, "epic/5800", [carrying, second, third]);
+		expect(traced._tag === "One" && traced.branch).toBe(third.branch);
+		expect(traced._tag === "One" && traced.tip).toBe("7d21ab4");
+	});
+
+	it("stays ambiguous when two candidates each contain the other", () => {
+		const twin = {...carrying, branch: "build/5829-twin-deadbeef", contains: [carrying.tip]};
+		const traced = traceRange(5829, "epic/5800", [{...carrying, contains: [twin.tip]}, twin]);
+		expect(traced._tag).toBe("Many");
+	});
+
+	it("stays ambiguous when a third branch forks off a superseded round", () => {
+		const second = {
+			...carrying,
+			branch: "build/5829-second-try-deadbeef",
+			tip: "a1068c0",
+			contains: [carrying.tip],
+		};
+		const forked = {
+			...carrying,
+			branch: "build/5829-forked-c0ffee00",
+			tip: "7d21ab4",
+			contains: [carrying.tip],
+		};
+		const traced = traceRange(5829, "epic/5800", [carrying, second, forked]);
+		expect(traced).toEqual({
+			_tag: "Many",
+			branches: [carrying.branch, second.branch, forked.branch],
 		});
 	});
 });

--- a/packages/fabrika-cli/src/lane/range.ts
+++ b/packages/fabrika-cli/src/lane/range.ts
@@ -101,7 +101,7 @@ export const locateRange = (
 			};
 		}
 		const candidates = childLaneBranches(issue, branches.value);
-		const facts: BranchFact[] = [];
+		const scanned: Array<Omit<BranchFact, "contains">> = [];
 		for (const branch of candidates) {
 			const tip = yield* resolveCommit(branch);
 			if (tip._tag === "Failure") {
@@ -123,7 +123,7 @@ export const locateRange = (
 					reason: walked.reason,
 				};
 			}
-			facts.push({
+			scanned.push({
 				branch,
 				base: forked.value,
 				tip: tip.value,
@@ -131,10 +131,41 @@ export const locateRange = (
 			});
 		}
 
+		const facts: BranchFact[] = [];
+		for (const fact of scanned) {
+			const contains: string[] = [];
+			for (const other of scanned) {
+				if (other.branch === fact.branch) continue;
+				const shared = yield* mergeBase(other.tip, fact.tip);
+				// A read that failed says nothing about containment, and reading it as "not contained"
+				// would turn an unreadable object database into a proven fork.
+				if (shared._tag === "Failure") {
+					return {
+						_tag: "Unreadable" as const,
+						what: `whether "${fact.branch}" already carries "${other.branch}"`,
+						reason: shared.reason,
+					};
+				}
+				if (shared.value === other.tip) contains.push(other.tip);
+			}
+			facts.push({...fact, contains});
+		}
+
 		const notes = [
 			`${verb}: #${issue} is a child of epic #${epic} and opens no PR of its own — looked in this tree for a lane branch of #${issue} over ${baseRef}; ${branches.value.length} local branch(es) read, ${candidates.length} candidate(s).`,
 		];
 		const trace = traceRange(issue, baseRef, facts);
+		if (trace._tag === "One" && candidates.length > 1) {
+			const won = facts.find((fact) => fact.branch === trace.branch);
+			const superseded = facts
+				.filter((fact) => fact.branch !== trace.branch && won?.contains.includes(fact.tip) === true)
+				.map((fact) => fact.branch);
+			if (superseded.length > 0) {
+				notes.push(
+					`${verb}: ${trace.branch} already carries ${superseded.join(", ")}, so it is the later round of one lane rather than a fork.`,
+				);
+			}
+		}
 		if (trace._tag === "None") return {_tag: "Absent" as const, why: trace.why, notes};
 		if (trace._tag === "Many") {
 			return {


### PR DESCRIPTION
An epic child opens no PR, so `lane prove` derives its commit range by scanning this tree's local
branches for commits naming the child. A repair round is a new claim, so a new nonce, so a new
branch name — two branches then carry the child's commits and the scan refused as ambiguous (exit
25), parking the lane for a human even though the newer branch strictly contained the older one.
The retry budget is 2, so the machine expects repair rounds and every one of them hit this.

`traceRange` now resolves supersession: when several candidates carry the issue and exactly one of
them contains every other candidate's tip, that one is the range. A genuine fork — no candidate
containing all the others, or two containing each other — still answers `Many` and still refuses at
exit 25 with the existing message.

Ancestry arrives as data on `BranchFact.contains`, so `traceRange` stays pure and spawn-free. The
read itself is `locateRange`'s, one `git merge-base` per candidate pair against this tree's object
database; a failed read returns the existing `Unreadable` seat rather than "not contained", so an
unreadable object database can never be mistaken for a proven fork. `build/lane.ts`'s per-claim
nonce is untouched.

Unit tests cover the superseding branch, a three-round chain resolving to the newest tip, a genuine
fork, two candidates each containing the other, a third branch forked off a superseded round, and
the single-candidate case unchanged.

The last acceptance criterion asks for a re-run against epic #5817's parked `issue_6007`. Its two
branches named in the report are gone from this clone, but the epic re-ran and left two others for
the same child in the same shape (`build/6007-regrounded-guide-arm-c4788d14` and
`build/6007-regrounded-guide-arm-289c28b0`, the second containing the first). `locateRange` on
`(5817, 6007)` in this tree answered `Ambiguous` before this change and now answers:

```
build/6007-regrounded-guide-arm-289c28b0 already carries
build/6007-regrounded-guide-arm-c4788d14, so it is the later round of one lane rather than a fork.
```

`operate`'s exit-25 park row is amended to say what the code now refuses on.

Fixes #6049

## Deviations

- **Out-of-scope change** — **Said:** #6049 names `prove.ts`, `prove-verb.ts`'s `locateRange`, and
  tests. **Did:** also amended the exit-25 row in
  `claude-plugins/fabrika/skills/operate/SKILL.md`. **Why:** that row told an operator exit 25 fires
  on "several lane branches carrying an epic child's commits", which this change makes untrue for
  the repair-round case. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the issue's triage note suggests
  `git merge-base --is-ancestor <other> <candidate>`. **Did:** used the existing `mergeBase` helper
  and compared its answer to the other tip. **Why:** `--is-ancestor` reports "not an ancestor" as
  exit 1, and this repo's `execCapture` fuses a non-zero exit with a spawn fault into one
  `ok: false` — so `--is-ancestor` would have turned every genuine fork into UNKNOWN and broken the
  fourth acceptance criterion, unless a tri-state spawn helper were added. `merge-base` answers the
  same question with the three outcomes already kept apart. **Disposition:** stated here.
