### PR TITLE
fix: unit + client tests goes red on an unhandled ReferenceError: document is not defined from Dialog.test.tsx

### DIFF
--- a/.patterns/zag-machine-interaction-tests.md
+++ b/.patterns/zag-machine-interaction-tests.md
@@ -83,6 +83,23 @@ synchronous read → flush → read:
 
 Treat any Manti primitive the same way, whether or not it is listed here.
 
+## The mirror image — Zag also schedules work *after* the unmount
+
+The same deferral runs past the end of a test, and there it is the tier's problem rather than
+yours. Two Zag paths outlive the unmount that should have ended them, because nothing cancels
+them: `@zag-js/dialog`'s `checkRenderedElements` action discards the cancel handle `raf()` hands
+back, and `@zag-js/focus-trap`'s `deactivate()` restores focus on a `setTimeout(fn, 0)`. Both
+resolve their root through `@zag-js/core` `createScope`, whose `props.getRootNode?.() ?? document`
+is a bare global read — so once Vitest tears the jsdom environment down at the end of a file, that
+read throws `ReferenceError: document is not defined` rather than yielding `undefined`, and Vitest
+collects it as an unhandled error that reds a fully-green run.
+
+`apps/web/tests/client/setup.ts` drains those queues in an `afterAll` — two animation frames
+(`raf.mjs`'s `nextTick` double-nests) plus one macrotask — so the work runs inside the
+environment's life. **You inherit this; do not re-solve it per test.** What it means for you: a
+`client`-tier test may leave Zag work pending without reding the run, but a test that deletes or
+stubs `document` itself still has to restore it before its own teardown.
+
 ## Related
 
 - [property-based-a11y.md](./property-based-a11y.md) — the other `ui/` test surface; it

--- a/apps/web/tests/client/setup.ts
+++ b/apps/web/tests/client/setup.ts
@@ -3,7 +3,7 @@
 // imports, so unmount-after-each is wired here instead, keeping each `*.test.tsx`
 // isolated.
 import {cleanup} from "@testing-library/react";
-import {afterEach} from "vitest";
+import {afterAll, afterEach} from "vitest";
 
 // Manti's Zag/Floating UI layers use these two browser APIs, which jsdom does not
 // provide. These are behaviourally inert shims with the right interface, enough to
@@ -30,3 +30,18 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 }
 
 afterEach(cleanup);
+
+// Zag schedules DOM work past the unmount that should have ended it, and nothing cancels it:
+// `dialog.machine.mjs` `checkRenderedElements` discards the cancel handle `raf()` returns, and
+// focus-trap's `deactivate()` restores focus on a `setTimeout(fn, 0)`. Either can still be pending
+// when Vitest tears the jsdom environment down at the end of a file, and both resolve their root
+// through `@zag-js/core` `createScope`, whose `props.getRootNode?.() ?? document` is a BARE global
+// read — with the global gone that throws `ReferenceError` instead of yielding `undefined`, and
+// Vitest collects it as an unhandled error that reds a fully-green run (#6166). Draining the queues
+// here runs that work inside the environment's life. Two frames, because `raf.mjs` `nextTick`
+// double-nests; then a macrotask for the focus-trap timer.
+afterAll(async () => {
+	await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+	await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+});


### PR DESCRIPTION
The required `unit + client tests` job was going red on a fully-passing client suite, blocking merge on PRs whose diff could not touch the failing file (#6158, #6930). Vitest collected an unhandled `ReferenceError: document is not defined` blamed on `Dialog.test.tsx`.

## The mechanism, reproduced

Two Zag paths outlive the unmount that should have ended them, and nothing cancels either:

- `@zag-js/dialog` `dialog.machine.mjs` `checkRenderedElements` discards the cancel handle `raf()` returns.
- `@zag-js/focus-trap` `deactivate()` restores focus on a `setTimeout(fn, 0)`.

Both resolve their root through `@zag-js/core` `createScope`, whose `props.getRootNode?.() ?? document` is a bare global read. We pass no `getRootNode`, so the fallback is always live. Once Vitest tears the jsdom environment down at the end of a file, a bare reference to the removed global throws `ReferenceError` instead of yielding `undefined` — and Vitest collects it as an unhandled error that flips the run's exit code.

Reproduced locally by deleting the `document` global immediately after an unmount in `Dialog.test.tsx`. That gave a real stack, which named `checkRenderedElements`' `raf` rather than the focus-trap timer the issue's amendment traced:

```
ReferenceError: document is not defined
 ❯ getRootNode  @zag-js/core/dist/scope.mjs:4:54
 ❯ Module.getTitleEl  @zag-js/dialog/dist/dialog.dom.mjs:19:31
 ❯ @zag-js/dialog/dist/dialog.machine.mjs:199:26   (checkRenderedElements)
 ❯ @zag-js/dom-query/dist/raf.mjs:21:29
 ❯ runAnimationFrameCallbacks  jsdom/lib/jsdom/browser/Window.js:662:13
```

So there are two pending sources, not one — a `raf` and a `setTimeout`. Adding the flush and re-running the same probe turned it green; removing it turned it red again.

## The fix

`apps/web/tests/client/setup.ts` gains an `afterAll` that drains both queues — two animation frames (`raf.mjs`'s `nextTick` double-nests) plus one macrotask — so the deferred work runs while the environment is still alive. `afterAll` rather than `afterEach`: the environment is torn down per file, so once per file is the whole exposure, and the client tier's wall clock is unchanged (8.8s vs 9.5s before, inside run-to-run noise).

`onUnhandledError` is untouched, so every other unhandled error in the `client` tier still fails the run, and no `dangerouslyIgnoreUnhandledErrors` is introduced.

`.patterns/zag-machine-interaction-tests.md` gains a section for the post-unmount half of the same deferral it already documents.

Verified: `pnpm --filter './apps/**' test:client` — 61 files, 319 tests, all passing, no unhandled-error section.

Fixes #6166

## Deviations

- **Out-of-scope change** — **Said:** #6166 names the test failure only. **Did:** also extended `.patterns/zag-machine-interaction-tests.md` with a post-unmount section. **Why:** CLAUDE.md requires a pattern doc for a load-bearing shape you rely on, and that doc already owns Zag's deferral in the client tier. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** fix the teardown race. **Did:** left the upstream cause in place — `checkRenderedElements` leaking its `raf` handle and `createScope`'s bare `document` read are both Zag bugs. **Why:** neither is ours to patch, and the flush neutralizes both from our side. **Disposition:** stated here; no upstream issue filed.
