### PR TITLE
chore: wayfinding says map blocked_by edges are never pipeline eligibility, but build eligible now reads them

### DIFF
--- a/claude-plugins/fabrika/skills/wayfinding/SKILL.md
+++ b/claude-plugins/fabrika/skills/wayfinding/SKILL.md
@@ -152,8 +152,11 @@ something to build is the failure mode: re-frame it as the question underneath, 
 already settled — record it as a decision instead. Build work is not fog and does not belong on a
 map at all.
 
-**The edges are map topology, not board state** — never pipeline eligibility, because a frontier
-ticket is not pickable.
+**The edges are map topology and real blockedness both.** A native `blocked_by` edge gates pipeline
+eligibility whoever wrote it, so a destination stays unpickable until its frontier tickets close —
+`build claim`, `build pick` and `build eligible` all read this graph. That gating is intended, not a
+side effect: ADR [0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md), ruled for
+map edges at [#6271](https://github.com/kamp-us/phoenix/issues/6271#issuecomment-5362260727).
 
 **Done when** every open question you named is a ticket, and `map read` shows the frontier you
 intended.

--- a/claude-plugins/fabrika/skills/wayfinding/contract.md
+++ b/claude-plugins/fabrika/skills/wayfinding/contract.md
@@ -199,6 +199,13 @@ in the body. Four endpoints, all REST (skill conventions
 Writes: `POST repos/<repo>/issues/<n>/dependencies/blocked_by` and
 `POST repos/<repo>/issues/<map>/sub_issues`.
 
+**The edges this group writes are read as blockedness by the build seams.**
+[`src/build/blockedness.ts`](../../../../packages/fabrika-cli/src/build/blockedness.ts) is the one
+reader, and `build claim`, `build pick` and `build eligible` all gate on it — so a destination
+carrying an open frontier ticket is answered blocked until that ticket closes. No edge is carved out
+by who wrote it: ADR [0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md), ruled
+for map edges at [#6271](https://github.com/kamp-us/phoenix/issues/6271#issuecomment-5362260727).
+
 <!-- anchor: EDGE-BODY-TAKES-AN-INTERNAL-ID --> **Both POST bodies take the target's internal `id`,
 not its issue number**, and the sub-issue key is the singular `sub_issue_id`. Passing a number
 silently addresses a different issue. This is the trap v1 already recorded once for `sub_issue_id`;
@@ -545,10 +552,9 @@ frontier with nothing to retire it.
 
 **A ticket is `blocked` when its `blockedBy` holds an unresolved ticket**, which is a derived
 property reported in `counts` rather than a `state` — a ticket can be both `open` and blocked, and
-collapsing them would lose which. This is derived, never stored: whether a standalone issue may
-carry stored blockedness is open at [#4840](https://github.com/kamp-us/phoenix/issues/4840), and
-this verb takes no position on it. The native edges here are map topology, and the derivation stays
-in the reader.
+collapsing them would lose which. This is `map read`'s own derivation — computed per read, never
+stored — and it is unchanged by the edges also gating build eligibility (see *The edge reads*
+above).
 
 **`frontier` is a closed set of four, and all four exit `0`:**
 

--- a/packages/fabrika-cli/src/map/frontier.ts
+++ b/packages/fabrika-cli/src/map/frontier.ts
@@ -430,8 +430,7 @@ export const counts = (tickets: ReadonlyArray<Ticket>): Readonly<Record<string, 
 	for (const ticket of tickets) {
 		tally[ticket.state] = (tally[ticket.state] ?? 0) + 1;
 		// Derived, never stored: a ticket can be both `open` and blocked, and collapsing the two would
-		// lose which. Whether a standalone issue may carry stored blockedness is open at #4840; this
-		// read takes no position on it.
+		// lose which.
 		if (ticket.blockedBy.some((number) => unresolved.has(number))) {
 			tally.blocked = (tally.blocked ?? 0) + 1;
 		}


### PR DESCRIPTION
Ruling **A** on #6271 said a native `blocked_by` edge gates pipeline eligibility no matter who wrote it — map edges included — so ADR 0301 stays carve-out-free and the remaining work is the doc fix. This is that transcription; no ADR is added or changed.

The ruling comment: https://github.com/kamp-us/phoenix/issues/6271#issuecomment-5362260727

- `wayfinding/SKILL.md` line 155 said the edges are "never pipeline eligibility". It now says they are map topology **and** real blockedness, that a destination stays unpickable until its frontier tickets close, and names the three verbs that read the graph.
- `wayfinding/contract.md` "The edge reads" gains a paragraph naming `src/build/blockedness.ts` as the one reader behind `build claim`, `build pick` and `build eligible`.
- `contract.md`'s `map read` blocked-tally paragraph drops the "open at #4840" question (that issue closed on 2026-08-18) and the "these edges are map topology only" claim. Its own point — blocked is derived per read, never stored — is kept.
- `map/frontier.ts` drops the same #4840 citation from the tally comment, keeping the derived-never-stored note.

Each reworded passage points at ADR 0301 or the ruling comment instead of restating the rationale.

Fixes #6271

## Deviations

None.
