### PR TITLE
chore: The §CP boundary's last copy loses its fence the day packages/pipeline-cli is deleted

### DIFF
--- a/.decisions/0100-control-plane-covers-enforcement-guard-packages.md
+++ b/.decisions/0100-control-plane-covers-enforcement-guard-packages.md
@@ -1,7 +1,7 @@
 ---
 id: 0100
 title: The control-plane / §CP boundary covers the enforcement-guard packages (`packages/*-guard/**` + `packages/ci-required/**`) — a guard is a self-weakening surface wherever it lives, so it is BLOCKING (human merge), not auto-merged on a `review-code` PASS
-status: amended-in-part by [0218](0218-pipeline-cli-cp-enforcement-core.md)
+status: amended-in-part by [0218](0218-pipeline-cli-cp-enforcement-core.md), [0330](0330-codeowners-is-the-cp-boundary.md)
 date: 2026-06-20
 tags: [pipeline, ship-it, control-plane, security, guards]
 ---

--- a/.decisions/0299-cp-fence-covers-fabrika-ci-core.md
+++ b/.decisions/0299-cp-fence-covers-fabrika-ci-core.md
@@ -1,7 +1,7 @@
 ---
 id: 0299
 title: §CP covers packages/fabrika-cli/src/ci/, the ci-required verdict core, and nothing wider
-status: accepted
+status: amended-in-part by [0330](0330-codeowners-is-the-cp-boundary.md)
 date: 2026-08-18
 tags: [fabrika, pipeline, control-plane, codeowners, ci, guards]
 ---

--- a/.decisions/0330-codeowners-is-the-cp-boundary.md
+++ b/.decisions/0330-codeowners-is-the-cp-boundary.md
@@ -1,0 +1,120 @@
+---
+id: 0330
+title: .github/CODEOWNERS is the only source of §CP truth, never a path regex in source
+status: accepted
+date: 2026-08-21
+tags: [control-plane, codeowners, guards, fabrika, security]
+---
+
+# 0330 — `.github/CODEOWNERS` is the only source of §CP truth, never a path regex in source
+
+**What this decides:** whether a path needs a human code-owner's approval is answered by reading
+`.github/CODEOWNERS`, and by nothing else. The `CONTROL_PLANE_RE` regex stops being a source of
+truth and is deleted rather than fenced.
+
+## Context
+
+Founder ruling, 2026-08-20, on
+[this comment](https://github.com/kamp-us/phoenix/issues/6248#issuecomment-5362559734). The driver
+offered two shapes for [#6248](https://github.com/kamp-us/phoenix/issues/6248) — move the regex into
+the already-fenced `packages/fabrika-cli/src/ci/`, or extend the regex to cover its own file — and
+the founder ruled neither.
+
+#6248 reports a real gap, open at head. `packages/fabrika-cli/src/guard/control-plane-re.ts` holds
+the only copy of `CONTROL_PLANE_RE`. It used to be kept honest by a pin test against a second copy in
+`packages/pipeline-cli/`, but that package was deleted by PR #6326 and the pin was written to go with
+it (recorded in [0218](0218-pipeline-cli-cp-enforcement-core.md)'s 2026-08-19 amendment). The
+surviving file matches no CODEOWNERS row, `.github/CODEOWNERS` carries no `*` catch-all, and the
+`main` ruleset pairs `required_approving_review_count: 0` with `require_code_owner_review: true`. So
+the file that says which paths need a human merge needs none itself: a PR narrowing the boundary
+there merges at zero approvals with nothing red.
+
+The regex is also the last holdout of a model that was already ruled. On 2026-08-08 the founder ruled
+CODEOWNERS the single source of §CP truth, recorded in
+[`claude-plugins/fabrika/docs/control-plane-classification.md`](../claude-plugins/fabrika/docs/control-plane-classification.md),
+which states in as many words that there is no second source and no content regex. Every fabrika verb
+that classifies §CP already implements it. `guard codeowners-cp check` is the one surface that does
+not — it expands the regex into paths and checks each has a covering CODEOWNERS row, which only makes
+sense while two sources exist.
+
+## Decision
+
+**A path is control-plane iff the last matching `.github/CODEOWNERS` row for it, read at the
+repository's default branch, names a control-plane owner. No path regex is a source of truth in
+source.**
+
+**The derivation rule.** Last match wins, and an owner-less row unsets ownership — GitHub's own
+documented rule. That is the reading already implemented by `ownersOf`, `controlPlaneOwnersOf` and
+`classify` in [`packages/fabrika-cli/src/ship/codeowners.ts`](../packages/fabrika-cli/src/ship/codeowners.ts),
+wrapped for the roster by `controlPlaneRoster` in
+[`packages/fabrika-cli/src/ship/roster.ts`](../packages/fabrika-cli/src/ship/roster.ts). Those two
+modules are the boundary's readers; a third reading of "who is on the control plane" would drift from
+the one the merge gate enforces, and drift there is an approval nobody with authority gave.
+
+**Where the control-plane owners come from: the CODEOWNERS rows themselves.** `controlPlaneOwnersOf`
+parses them off the file — an `@org/team` or an individual `@login`, both counting the same — so a
+repo with a different team, or with no org at all, is answered rather than mis-answered. Naming the
+team a second time in configuration would be the second source this ADR bans, so `.fabrika.jsonc`
+declares no control-plane team and must not gain one. It carries adjacent, distinct ACLs
+(`capClearAuthors`, `campaignAuthors`) and a dead `unreadableCodeowners` key nothing reads; none of
+them bounds §CP.
+
+**The source of truth guards itself.** `.github/CODEOWNERS` is covered by the
+`/.github/ @kamp-us/control-plane` row inside `.github/CODEOWNERS`, so every edit to the boundary is
+itself a §CP change reviewed by the people accountable for it. That is the property the regex copy
+never had, and it is why the fix is deleting the copy rather than fencing it.
+
+**Disposition of `packages/fabrika-cli/src/guard/control-plane-re.ts`: deleted, not fenced.** These
+consumers are re-based onto the CODEOWNERS-derived boundary or retire with it:
+
+- `packages/fabrika-cli/src/guard/codeowners-cp-verb.ts` — imports the const
+- `packages/fabrika-cli/src/guard/codeowners-cp.ts` — the pure rule that expands it into paths
+- `packages/fabrika-cli/src/guard/codeowners-cp-verb.unit.test.ts` and
+  `packages/fabrika-cli/src/guard/codeowners-cp.unit.test.ts`
+- the `.github/workflows/codeowners-cp.yml` job that runs the verb
+
+**This weakens no fail-closed behaviour, and the two arms below are not droppable.** An unreadable or
+absent `.github/CODEOWNERS` stays the refusal it is today — the `Unknown` arm of `controlPlaneRoster`,
+never a collapse to `not-control-plane`, which [0220](0220-cp-surface-declared-at-standup.md) §4 names
+this repo's recurring fail-open defect. A boundary resolving to zero owned paths stays a red, the
+zero-scope refusal in `codeowners-cp-verb.ts` per
+[0092](0092-gates-fail-closed-on-zero-scope.md). Removing a regex removes a second *source*, not a
+guard.
+
+**Interim rule, in force from this record until the migration lands.** No PR may edit
+`packages/fabrika-cli/src/guard/control-plane-re.ts` without control-plane review. Reviewers treat
+that path as §CP by this ruling even though no CODEOWNERS row matches it. This is a human convention
+with no mechanical backing, which is the whole reason the migration is tracked rather than deferred.
+
+**Binding constraints.**
+
+- No second source of §CP truth in source — no path regex, no path list, no config key naming the
+  team. A surface that needs the boundary reads it through `ship/codeowners.ts`.
+- A surface that becomes governance-bearing gains its `.github/CODEOWNERS` row in the change that
+  creates it. Path-set completeness is the whole protection, and it is an obligation the
+  `@kamp-us/control-plane` team owns, not a property that holds by itself.
+- Neither fail-closed arm above may be relaxed by the migration.
+
+## Consequences
+
+The code half is [#6942](https://github.com/kamp-us/phoenix/issues/6942): delete the const, re-base or
+retire `guard codeowners-cp` and its workflow job. It is tracked, not assumed. Until it lands the
+interim rule is the only thing holding that file, so the gap #6248 reports stays open in the
+mechanical sense.
+
+`guard codeowners-cp` loses its subject rather than its rigour. It exists to catch drift between two
+sources; with one source there is nothing to compare. What, if anything, replaces the green check is
+#6942's to answer.
+
+This supersedes the **regex framing** of [0299](0299-cp-fence-covers-fabrika-ci-core.md) and
+[0100](0100-control-plane-covers-enforcement-guard-packages.md), and nothing else in either. Both rest
+on §CP being a regex that CODEOWNERS mirrors, and their lockstep clauses have no referent once the
+regex is gone. What each of them actually ruled about *coverage* stands unchanged and stands as
+CODEOWNERS rows: `packages/fabrika-cli/src/ci/` is control-plane and no wider slice of that package
+is (0299), and the enforcement-guard packages are control-plane wherever they live (0100). Both are
+amended in part rather than superseded outright for that reason.
+
+## Records
+
+No vocabulary impact. §CP, control plane, boundary and roster are all defined already; this record
+changes where the boundary is read from, not what any of them means.

--- a/.decisions/0330-codeowners-is-the-cp-boundary.md
+++ b/.decisions/0330-codeowners-is-the-cp-boundary.md
@@ -109,10 +109,28 @@ sources; with one source there is nothing to compare. What, if anything, replace
 This supersedes the **regex framing** of [0299](0299-cp-fence-covers-fabrika-ci-core.md) and
 [0100](0100-control-plane-covers-enforcement-guard-packages.md), and nothing else in either. Both rest
 on §CP being a regex that CODEOWNERS mirrors, and their lockstep clauses have no referent once the
-regex is gone. What each of them actually ruled about *coverage* stands unchanged and stands as
-CODEOWNERS rows: `packages/fabrika-cli/src/ci/` is control-plane and no wider slice of that package
-is (0299), and the enforcement-guard packages are control-plane wherever they live (0100). Both are
-amended in part rather than superseded outright for that reason.
+regex is gone. What each of them actually ruled about *coverage* stands unchanged, and both are
+amended in part rather than superseded outright for that reason. Only one of the two is held by a
+row today:
+
+- **0299 — held.** `packages/fabrika-cli/src/ci/` is control-plane and no wider slice of that
+  package is, and `/packages/fabrika-cli/src/ci/ @kamp-us/control-plane` is a standing CODEOWNERS
+  row.
+- **0100 — an open gap, not a standing row.** The enforcement-guard packages are control-plane
+  wherever they live, and at this record's date no row covers them: `.github/CODEOWNERS` has no `*`
+  catch-all and matches neither `packages/migrations-guard/**` nor
+  `packages/fabrika-cli/src/guard/**`, where every surviving guard verb now lives. The regex holds
+  it no better — its `^packages/[^/]*-guard/` branch went when the standalone guards folded
+  ([0103](0103-consolidate-pipeline-cli-package.md), #1003) and was never re-added. So
+  0100's rule is enforced by neither source, and this record — which makes CODEOWNERS the *only*
+  source — is what makes the gap the whole exposure. It is tracked as
+  [#6947](https://github.com/kamp-us/phoenix/issues/6947), and until the covering rows land it sits
+  beside the `control-plane-re.ts` interim rule above: a rule the corpus states and nothing
+  mechanically holds.
+
+Naming that gap rather than certifying it closed is this record's own binding constraint applied to
+itself. Under "path-set completeness is the whole protection", a gap asserted shut is worse than a
+gap left named.
 
 ## Records
 


### PR DESCRIPTION
Records the founder's 2026-08-20 ruling on #6248 as ADR 0330: `.github/CODEOWNERS` is the only source
of §CP truth, and the `CONTROL_PLANE_RE` const is deleted rather than fenced.

The ruling comment is https://github.com/kamp-us/phoenix/issues/6248#issuecomment-5362559734, cited
inside the ADR body. Three files change and all three are markdown:

- `.decisions/0330-codeowners-is-the-cp-boundary.md` — the new record
- `.decisions/0299-*.md` and `.decisions/0100-*.md` — `status:` pointers, written by
  `fabrika adr amend-in-part`. Amended in part, not superseded: only their regex framing dies, and
  what each ruled about coverage stands as `.github/CODEOWNERS` rows.

The code half is filed as #6942 — delete the const, re-base or retire `guard codeowners-cp` and its
workflow job. Criterion 9 allows either that or landing it here; a decision claim's deliverable is
the recorded choice, so it is tracked separately.

**Reviewer, start here:** the third acceptance criterion asks the ADR to name `.fabrika.jsonc` as
where the §CP team is declared. It is not, and the ADR says the opposite. See Deviations.

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 3 asks the ADR to name `.fabrika.jsonc` as
  where the §CP team is declared, echoing the ruling's "`.fabrika.jsonc` names the team". **Did:**
  the ADR states that the owners are parsed off the `.github/CODEOWNERS` rows themselves by
  `controlPlaneOwnersOf`, that `.fabrika.jsonc` declares no §CP team, and that it must not gain one
  because a second declaration would be the second source the ruling bans. **Why:** the premise is
  false at head. `.fabrika.jsonc` has no §CP key — it carries `capClearAuthors`, `campaignAuthors`
  and a dead `unreadableCodeowners` key its own comment says nothing reads. The docblock of
  `packages/fabrika-cli/src/ship/codeowners.ts` states "the owners are parsed, never hardcoded", and
  `controlPlaneOwnersOf` reads them from the rows. The founder's verbatim words were "codeowners
  and/or .fabrika.jsonc", which `.github/CODEOWNERS` alone satisfies. Writing the criterion as given
  would have put a false claim in the corpus and invited someone to add the banned second source.
  **Disposition:** stated here, and the ADR carries the corrected reading. This is why the PR says
  `Part of #6248` rather than closing it: whether the substance discharges criterion 3 is the
  reader's call, not mine.

Part of #6248
