### PR TITLE
feat: publish @kampus/fabrika-opencode so external opencode users can install fabrika

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,6 +119,9 @@ jobs:
           if [[ "$TAG" =~ ^fabrika-cli-v([0-9].*)$ ]]; then
             PKG_DIR="packages/fabrika-cli"
             TAG_VERSION="${BASH_REMATCH[1]}"
+          elif [[ "$TAG" =~ ^fabrika-opencode-v([0-9].*)$ ]]; then
+            PKG_DIR="packages/fabrika-opencode"
+            TAG_VERSION="${BASH_REMATCH[1]}"
           else
             echo "::error::release tag '$TAG' matches no published package's <name>-v<version> grammar — refusing to publish"
             exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -153,10 +153,11 @@ jobs:
       # repo-wide `releases_created` would dispatch a publish for a package that did not
       # release.
       - name: Dispatch the npm publish for each tag this push released
-        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' }}
+        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-opencode--release_created'] == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FABRIKA_CLI_TAG: ${{ steps.release.outputs['packages/fabrika-cli--tag_name'] }}
+          FABRIKA_OPENCODE_TAG: ${{ steps.release.outputs['packages/fabrika-opencode--tag_name'] }}
         run: |
           # `-e` spelled out because the runner sets it for us: a `run:` block with no
           # `shell:` key executes under `bash --noprofile --norc -eo pipefail`, and every
@@ -167,9 +168,10 @@ jobs:
 
           # An `x && y` list whose test FAILS is a failing statement under the `-e` above, so
           # each tag is appended from inside an `if` — the accumulate-then-check shape stays
-          # because the set is one package today and more the day another root is configured.
+          # so every configured package's tag rides the same loop.
           tags=()
           if [ -n "${FABRIKA_CLI_TAG:-}" ]; then tags+=("$FABRIKA_CLI_TAG"); fi
+          if [ -n "${FABRIKA_OPENCODE_TAG:-}" ]; then tags+=("$FABRIKA_OPENCODE_TAG"); fi
 
           if [ "${#tags[@]}" -eq 0 ]; then
             echo "::error::a per-path release_created output was true but no tag_name is set — refusing to leave a release unpublished with nothing said about it"
@@ -255,10 +257,11 @@ jobs:
       # The one gate in this file, keyed on the PER-PATH outputs. `releases_created`
       # appears nowhere.
       - name: Summarize which packages this push released
-        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' }}
+        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-opencode--release_created'] == 'true' }}
         env:
           PATHS_RELEASED: ${{ steps.release.outputs.paths_released }}
           FABRIKA_CLI_TAG: ${{ steps.release.outputs['packages/fabrika-cli--tag_name'] }}
+          FABRIKA_OPENCODE_TAG: ${{ steps.release.outputs['packages/fabrika-opencode--tag_name'] }}
         run: |
           set -uo pipefail
 
@@ -280,7 +283,7 @@ jobs:
             # shellcheck disable=SC2016
             printf -- '- `%s`\n' "${released[@]}"
             echo
-            echo "Tags: \`${FABRIKA_CLI_TAG:-none}\`"
+            echo "Tags: \`${FABRIKA_CLI_TAG:-none}\` \`${FABRIKA_OPENCODE_TAG:-none}\`"
             echo
             echo "Publishing is \`publish.yml\`, dispatched by this run at each tag above (ADR 0292)."
             echo "A human-cut release reaches the same workflow on the \`release: published\` event instead."

--- a/.patterns/release-path.md
+++ b/.patterns/release-path.md
@@ -116,8 +116,8 @@ which makes it worse rather than better, because it looks trustworthy while gati
 pipeline-cli action on a fabrika-cli release.
 
 `release-please.yml`'s only condition keys on the per-path
-`<path>--release_created` outputs (`packages/pipeline-cli--release_created`,
-`packages/fabrika-cli--release_created`) and reports from the `paths_released` JSON array.
+`<path>--release_created` outputs (`packages/fabrika-cli--release_created`,
+`packages/fabrika-opencode--release_created`) and reports from the `paths_released` JSON array.
 `releases_created` appears nowhere in the file, deliberately. A later "simplification" back
 to the single output is the regression ADR 0239 §5 Hazard A names.
 
@@ -205,11 +205,13 @@ corrupted by it — no version is consumed, because nothing was published.
 
 ## Current state
 
-Both published packages have an npm Trusted Publisher registration naming this repo and this
-workflow file — but only one of them has ever been *exercised* by it, and those are two
-different facts.
+Two package roots are configured today (`fabrika-cli`, `fabrika-opencode`).
+`pipeline-cli` was deleted from the repo with its release machinery (#6326) — its npm
+artifacts remain, so its history below stays recorded. Registrations that exist name this
+repo and this workflow file, but only some have ever been *exercised* by it, and those are
+two different facts.
 
-- **`pipeline-cli` — proven by exercise.** Its registration has carried two green `publish.yml`
+- **`pipeline-cli` — proven by exercise (retired).** Its registration has carried two green `publish.yml`
   release runs, and the published artifact carries the publish attestations
   (`npm view @kampus/pipeline-cli --json` → a `dist.attestations` key) that only an OIDC publish
   stamps.
@@ -219,16 +221,23 @@ different facts.
   for the package. `fabrika-cli@0.1.0` reached the registry through the bootstrap `pnpm publish`
   of step 4 above, not through this path (its artifact carries no attestations). Its **first**
   release run is the first use of that registration, and that run is the proof.
+- **`fabrika-opencode` — wired, not yet bootstrapped (#6965).** The resolve arm, the
+  release-please root and manifest entry all exist; steps 4–5 do not. A human must run the
+  bootstrap `pnpm publish` of `0.1.0` from a checkout at the merge that introduced it, then
+  register the Trusted Publisher on npmjs.com. Until both happen, a Release PR merge for the
+  package creates a tag whose publish run 403s after install/build pass — the fail-closed
+  shape above, recovering cleanly once the registration exists.
 
 That record is the authority, because nothing here can re-derive it: npm exposes no
 trusted-publisher field over the CLI or the registry API, so registration state is a web-UI
 fact and npmjs.com (Settings → Publishing) is the only place to check it. Never restate it as
 tool-verified.
 
-So expect no outcome in either direction for that first run. If it 403s, the path failed closed:
+So expect no outcome in either direction for a first run. If it 403s, the path failed closed:
 nothing was published, **no version number is burned**, and re-running the release after fixing
 the registration recovers cleanly.
 
 Because `release-please-config.json` sets `separate-pull-requests: false`, one Release PR can
-carry both packages and its merge can create both tags — two publish runs, one over a
-registration proven by exercise and one over a registration being used for the first time.
+carry several packages and its merge can create their tags together — one publish run per tag,
+some over registrations proven by exercise and some over registrations being used for the
+first time.

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-	"packages/fabrika-cli": "0.5.0"
+	"packages/fabrika-cli": "0.5.0",
+	"packages/fabrika-opencode": "0.1.0"
 }

--- a/packages/fabrika-opencode/README.md
+++ b/packages/fabrika-opencode/README.md
@@ -1,0 +1,55 @@
+# @kampus/fabrika-opencode
+
+The opencode plugin for [fabrika](../../claude-plugins/fabrika/) — fabrika's eight agent
+shells and 26 skills, installed into any repo with one config line (issue #6965).
+
+## Install
+
+Add the package to your repo's `opencode.json`:
+
+```json
+{
+	"$schema": "https://opencode.ai/config.json",
+	"plugin": ["@kampus/fabrika-opencode"]
+}
+```
+
+opencode installs it from npm at startup. Verify with:
+
+```bash
+opencode agent list   # the eight fabrika shells appear as subagents
+opencode debug skill  # the bundled skills are listed
+```
+
+## What registers
+
+The plugin's `config()` hook runs at startup and:
+
+- registers each bundled agent shell as a subagent — the shell markdown under `dist/agents/`
+  becomes the agent's prompt;
+- appends the bundled skills dir (`dist/skills/`) to `skills.paths`, leaving paths you
+  already configured in place.
+
+Agent shells that share a name with one of your own agents resolve to the plugin's
+definition; rename yours if you need both.
+
+## Fallback: clone-and-point
+
+Without npm, a clone of [phoenix](https://github.com/kamp-us/phoenix) works too:
+
+```json
+{
+	"$schema": "https://opencode.ai/config.json",
+	"skills": { "paths": ["/path/to/phoenix/claude-plugins/fabrika/skills"] }
+}
+```
+
+Skills load from the clone; agents have no remote mechanism in opencode, so copy the
+mirrors into your repo's `.opencode/agent/`. The tradeoff is staleness: the plugin updates
+with every release cut, a clone only when you pull.
+
+## How the bundle stays fresh
+
+`dist/agents/` and `dist/skills/` are copied from phoenix's authored dirs at build time
+(`scripts/sync-bundle.mjs`) on every publish, so a released tarball always carries the
+skills dir exactly as it was authored at the tag.

--- a/packages/fabrika-opencode/package.json
+++ b/packages/fabrika-opencode/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "@kampus/fabrika-opencode",
+	"version": "0.1.0",
+	"description": "@kampus/fabrika-opencode — the opencode plugin that installs fabrika's eight agent shells and bundled skills with one config line (issue #6965)",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kamp-us/phoenix.git",
+		"directory": "packages/fabrika-opencode"
+	},
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json && node ./scripts/sync-bundle.mjs",
+		"prepublishOnly": "pnpm run build",
+		"typecheck": "tsc -p tsconfig.json",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"yaml": "catalog:"
+	},
+	"devDependencies": {
+		"@opencode-ai/plugin": "catalog:",
+		"@opencode-ai/sdk": "catalog:",
+		"@types/node": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/fabrika-opencode/scripts/sync-bundle.mjs
+++ b/packages/fabrika-opencode/scripts/sync-bundle.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * The release-time bundle copy: the authored agent-shell mirrors and skills dir become
+ * `dist/agents/` and `dist/skills/`, which `dist/index.js` reads by path off
+ * `import.meta.url` (issue #6965). tsc emits nothing for either source, so without this
+ * step the published tarball registers zero agents and zero skills.
+ *
+ * Sources are the repo's authored dirs — `.opencode/agent/` (the opencode mirror shells)
+ * and `claude-plugins/fabrika/skills/` (the single authored skills dir) — read at build
+ * time so a release can never ship a stale hand-bundled copy. The copy is total: every
+ * file under a skill dir ships, because a SKILL.md may reference a sibling asset by
+ * relative path and an exception list is where that reference silently breaks. Both
+ * counts are printed so the release log records what shipped; every failure exits
+ * non-zero.
+ */
+import {copyFileSync, existsSync, mkdirSync, readdirSync} from "node:fs";
+import {join, relative, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const REPO_ROOT = resolve(PACKAGE_ROOT, "../..");
+const DIST = join(PACKAGE_ROOT, "dist");
+
+const AGENT_SOURCE = join(REPO_ROOT, ".opencode", "agent");
+const SKILLS_SOURCE = join(REPO_ROOT, "claude-plugins", "fabrika", "skills");
+const AGENTS_TARGET = join(DIST, "agents");
+const SKILLS_TARGET = join(DIST, "skills");
+
+const walkFiles = (dir) =>
+	readdirSync(dir, {recursive: true, withFileTypes: true})
+		.filter((entry) => entry.isFile())
+		.map((entry) => join(entry.parentPath, entry.name));
+
+for (const dir of [AGENT_SOURCE, SKILLS_SOURCE]) {
+	if (!existsSync(dir)) {
+		console.error(
+			`sync-bundle: authored dir ${dir} does not exist — refusing to bundle an empty package`,
+		);
+		process.exit(1);
+	}
+}
+
+mkdirSync(AGENTS_TARGET, {recursive: true});
+const shells = walkFiles(AGENT_SOURCE)
+	.filter((file) => file.endsWith(".md"))
+	.sort();
+if (shells.length === 0) {
+	console.error(
+		`sync-bundle: ${AGENT_SOURCE} carries no .md shell — refusing to bundle zero agents`,
+	);
+	process.exit(1);
+}
+for (const shell of shells) {
+	const target = join(AGENTS_TARGET, relative(AGENT_SOURCE, shell));
+	mkdirSync(resolve(target, ".."), {recursive: true});
+	copyFileSync(shell, target);
+}
+
+mkdirSync(SKILLS_TARGET, {recursive: true});
+const skills = readdirSync(SKILLS_SOURCE, {withFileTypes: true})
+	.filter((entry) => entry.isDirectory() && existsSync(join(SKILLS_SOURCE, entry.name, "SKILL.md")))
+	.map((entry) => entry.name)
+	.sort();
+if (skills.length === 0) {
+	console.error(
+		`sync-bundle: ${SKILLS_SOURCE} carries no SKILL.md dirs — refusing to bundle zero skills`,
+	);
+	process.exit(1);
+}
+let skillFiles = 0;
+for (const skill of skills) {
+	for (const file of walkFiles(join(SKILLS_SOURCE, skill))) {
+		const target = join(SKILLS_TARGET, relative(SKILLS_SOURCE, file));
+		mkdirSync(resolve(target, ".."), {recursive: true});
+		copyFileSync(file, target);
+		skillFiles += 1;
+	}
+}
+
+console.log(
+	`sync-bundle: bundled ${shells.length} agent shell(s) from .opencode/agent and ${skillFiles} file(s) across ${skills.length} skill(s) from claude-plugins/fabrika/skills`,
+);

--- a/packages/fabrika-opencode/src/agents.ts
+++ b/packages/fabrika-opencode/src/agents.ts
@@ -1,0 +1,94 @@
+import {parse} from "yaml";
+
+export type AgentDefinition = {
+	name: string;
+	description?: string;
+	mode?: "subagent" | "primary" | "all";
+	permission?: PermissionRuleset;
+	prompt: string;
+};
+
+const ACTIONS = ["ask", "allow", "deny"] as const;
+export type PermissionAction = (typeof ACTIONS)[number];
+
+// opencode's v1 agent permission ruleset: top-level tool keys mapping to an action or
+// (bash-style) a pattern map of actions.
+export type PermissionRuleset = {
+	[tool: string]: PermissionAction | {[pattern: string]: PermissionAction};
+};
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const MODES = ["subagent", "primary", "all"] as const;
+
+export const parseAgentMarkdown = (source: string): AgentDefinition => {
+	const match = FRONTMATTER.exec(source);
+	if (!match) {
+		throw new Error("agent shell markdown carries no --- frontmatter block");
+	}
+
+	const frontmatter = match[1];
+	if (frontmatter === undefined) {
+		throw new Error("agent shell markdown carries an empty --- frontmatter block");
+	}
+
+	const prompt = source.slice(match[0].length).trim();
+	if (prompt.length === 0) {
+		throw new Error("agent shell markdown carries an empty prompt body");
+	}
+
+	const data: unknown = parse(frontmatter);
+	if (typeof data !== "object" || data === null || Array.isArray(data)) {
+		throw new Error("agent shell frontmatter is not a mapping");
+	}
+	const fields = data as Record<string, unknown>;
+	if (typeof fields.name !== "string" || fields.name.length === 0) {
+		throw new Error("agent shell frontmatter carries no name");
+	}
+	const mode = MODES.find((candidate) => candidate === fields.mode);
+	if (fields.mode !== undefined && mode === undefined) {
+		throw new Error(
+			`agent shell ${fields.name} declares mode ${JSON.stringify(fields.mode)}, not a mode literal`,
+		);
+	}
+
+	const shell: AgentDefinition = {name: fields.name, prompt};
+	if (typeof fields.description === "string") shell.description = fields.description;
+	if (mode !== undefined) shell.mode = mode;
+	if (fields.permission !== undefined)
+		shell.permission = parsePermissionRuleset(fields.permission, fields.name);
+	return shell;
+};
+
+// Authored shells ship only shapes this returns — anything else throws so a bad mirror
+// dies at build time and test, never silently at install.
+export const parsePermissionRuleset = (value: unknown, shell: string): PermissionRuleset => {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`agent shell ${shell} declares permission that is not a mapping`);
+	}
+	const out: PermissionRuleset = {};
+	for (const [tool, rule] of Object.entries(value)) {
+		const action = ACTIONS.find((candidate) => candidate === rule);
+		if (action !== undefined) {
+			out[tool] = action;
+			continue;
+		}
+		if (typeof rule === "object" && rule !== null && !Array.isArray(rule)) {
+			const patterns: {[pattern: string]: PermissionAction} = {};
+			for (const [pattern, inner] of Object.entries(rule)) {
+				const innerAction = ACTIONS.find((candidate) => candidate === inner);
+				if (innerAction === undefined) {
+					throw new Error(
+						`agent shell ${shell} declares permission ${tool}[${pattern}] = ${JSON.stringify(inner)}, not an action literal`,
+					);
+				}
+				patterns[pattern] = innerAction;
+			}
+			out[tool] = patterns;
+			continue;
+		}
+		throw new Error(
+			`agent shell ${shell} declares permission ${tool} that is neither an action nor a pattern map`,
+		);
+	}
+	return out;
+};

--- a/packages/fabrika-opencode/src/agents.unit.test.ts
+++ b/packages/fabrika-opencode/src/agents.unit.test.ts
@@ -1,0 +1,69 @@
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+import {parseAgentMarkdown} from "./agents.ts";
+
+const AGENT_SHELLS_DIR = join(import.meta.dirname, "../../../.opencode/agent");
+
+describe("parseAgentMarkdown", () => {
+	it("maps frontmatter fields and the body prompt", () => {
+		const shell = parseAgentMarkdown(
+			[
+				"---",
+				"name: builder",
+				"description: The construction stage.",
+				"mode: subagent",
+				"---",
+				"",
+				"Body line one.",
+				"Body line two.",
+			].join("\n"),
+		);
+		expect(shell.name).toBe("builder");
+		expect(shell.description).toBe("The construction stage.");
+		expect(shell.mode).toBe("subagent");
+		expect(shell.prompt).toBe("Body line one.\nBody line two.");
+	});
+
+	it("defaults a missing mode to undefined so the entry defaults to subagent", () => {
+		const shell = parseAgentMarkdown(["---", "name: x", "---", "prompt"].join("\n"));
+		expect(shell.mode).toBeUndefined();
+	});
+
+	it("carries a nested permission block through untouched", () => {
+		const shell = parseAgentMarkdown(
+			["---", "name: operator", "permission:", "  edit: deny", "---", "body"].join("\n"),
+		);
+		expect(shell.permission).toEqual({edit: "deny"});
+	});
+
+	it("refuses markdown without frontmatter, without a body, or without a name", () => {
+		expect(() => parseAgentMarkdown("no fence here")).toThrow(/frontmatter/);
+		expect(() => parseAgentMarkdown("---\nname: x\n---")).toThrow(/empty prompt/);
+		expect(() => parseAgentMarkdown("---\ndescription: y\n---\nbody")).toThrow(/no name/);
+	});
+
+	it("refuses a mode outside the literal set", () => {
+		expect(() => parseAgentMarkdown("---\nname: x\nmode: chief\n---\nbody")).toThrow(
+			/not a mode literal/,
+		);
+	});
+});
+
+describe("authored agent shell mirrors", () => {
+	const mirrors = readdirSync(AGENT_SHELLS_DIR)
+		.filter((entry) => entry.endsWith(".md"))
+		.sort();
+
+	it("the authored mirror dir is non-empty", () => {
+		expect(mirrors.length).toBeGreaterThan(0);
+	});
+
+	it.each(mirrors)("%s parses into a named subagent shell", (file) => {
+		const shell = parseAgentMarkdown(readFileSync(join(AGENT_SHELLS_DIR, file), "utf8"));
+		expect(shell.name).toBe(file.replace(/\.md$/, ""));
+		expect(shell.mode ?? "subagent").toBe("subagent");
+		expect(shell.description).toBeTruthy();
+		expect(shell.prompt.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/fabrika-opencode/src/index.ts
+++ b/packages/fabrika-opencode/src/index.ts
@@ -1,0 +1,43 @@
+import {readdirSync, readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import type {Config, Plugin} from "@opencode-ai/plugin";
+import {parseAgentMarkdown} from "./agents.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const agentsDir = resolve(here, "./agents");
+const skillsDir = resolve(here, "./skills");
+
+// The runtime config schema carries `skills.paths` (opencode core v1 config; this repo's
+// own opencode.json sets it), but @opencode-ai/sdk@1.18.21's generated Config type does
+// not declare it yet — so the one key this plugin appends goes through this narrow view.
+type SkillsConfigView = {paths?: string[]};
+
+type AgentEntry = NonNullable<NonNullable<Config["agent"]>[string]>;
+
+export const FabrikaOpenCodePlugin: Plugin = async () => {
+	return {
+		config: async (cfg) => {
+			cfg.agent = cfg.agent ?? {};
+			for (const entry of readdirSync(agentsDir).sort()) {
+				if (!entry.endsWith(".md")) continue;
+				const shell = parseAgentMarkdown(readFileSync(join(agentsDir, entry), "utf8"));
+				const def: AgentEntry = {mode: shell.mode ?? "subagent", prompt: shell.prompt};
+				if (shell.description !== undefined) def.description = shell.description;
+				if (shell.permission !== undefined) {
+					def.permission = shell.permission as NonNullable<AgentEntry["permission"]>;
+				}
+				cfg.agent[shell.name] = def;
+			}
+
+			const skills = (cfg as Config & {skills?: SkillsConfigView}).skills ?? {};
+			skills.paths = [...(skills.paths ?? [])];
+			if (!skills.paths.includes(skillsDir)) {
+				skills.paths.push(skillsDir);
+			}
+			(cfg as Config & {skills?: SkillsConfigView}).skills = skills;
+		},
+	};
+};
+
+export default FabrikaOpenCodePlugin;

--- a/packages/fabrika-opencode/tsconfig.build.json
+++ b/packages/fabrika-opencode/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": false,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts", "vitest.config.ts"]
+}

--- a/packages/fabrika-opencode/tsconfig.json
+++ b/packages/fabrika-opencode/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/fabrika-opencode/vitest.config.ts
+++ b/packages/fabrika-opencode/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.unit.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,12 @@ catalogs:
     '@nkzw/fate':
       specifier: 1.3.1
       version: 1.3.1
+    '@opencode-ai/plugin':
+      specifier: 1.18.21
+      version: 1.18.21
+    '@opencode-ai/sdk':
+      specifier: 1.18.21
+      version: 1.18.21
     '@playwright/test':
       specifier: ^1.62.1
       version: 1.62.1
@@ -728,6 +734,28 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/fabrika-opencode:
+    dependencies:
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
+    devDependencies:
+      '@opencode-ai/plugin':
+        specifier: 'catalog:'
+        version: 1.18.21
+      '@opencode-ai/sdk':
+        specifier: 'catalog:'
+        version: 1.18.21
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/fabrika-pi: {}
 
   packages/fate-effect:
@@ -956,6 +984,10 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
@@ -2048,6 +2080,23 @@ packages:
   '@octokit/webhooks@14.2.0':
     resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
     engines: {node: '>= 20'}
+
+  '@opencode-ai/plugin@1.18.21':
+    resolution: {integrity: sha512-wQXMbSvg3pG75F8fYAiJxYuyr6Cl9Hd74lSCY2yznZnejpwa+ksd2kMphmgSo+/UgLhb2AId9KAI6dsRhprzTg==}
+    peerDependencies:
+      '@opentui/core': '>=0.4.5'
+      '@opentui/keymap': '>=0.4.5'
+      '@opentui/solid': '>=0.4.5'
+    peerDependenciesMeta:
+      '@opentui/core':
+        optional: true
+      '@opentui/keymap':
+        optional: true
+      '@opentui/solid':
+        optional: true
+
+  '@opencode-ai/sdk@1.18.21':
+    resolution: {integrity: sha512-k6iHQ5C8wOPglk+LgFyYnst168cGMQYumgpbVoeXJ+iC1AtvwD5zmjuF8CxMze/y9G1K2bOeO6p9yRvA7eHZLA==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -3275,6 +3324,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
@@ -3472,6 +3525,9 @@ packages:
         optional: true
       zod:
         optional: true
+
+  effect@4.0.0-beta.83:
+    resolution: {integrity: sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==}
 
   effect@4.0.0-beta.92:
     resolution: {integrity: sha512-et6Fy8X9cxhzV/w4U372lB7YCP/B9a8FYVxlx9UMzSgnmwWKxpldnaHz7mHpZHh+OU+ENhU9DO/rTAakmT0sEA==}
@@ -3676,6 +3732,9 @@ packages:
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -3700,6 +3759,9 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
@@ -3976,6 +4038,10 @@ packages:
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4263,6 +4329,14 @@ packages:
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -4340,10 +4414,6 @@ packages:
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -4538,6 +4608,11 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -4591,10 +4666,17 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
 
   '@alcalzone/ansi-tokenize@0.2.5':
     dependencies:
@@ -5658,6 +5740,17 @@ snapshots:
       '@octokit/openapi-webhooks-types': 12.1.0
       '@octokit/request-error': 7.1.0
       '@octokit/webhooks-methods': 6.0.0
+
+  '@opencode-ai/plugin@1.18.21':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@opencode-ai/sdk': 1.18.21
+      effect: 4.0.0-beta.83
+      zod: 4.1.8
+
+  '@opencode-ai/sdk@1.18.21':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -7003,6 +7096,12 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -7054,6 +7153,19 @@ snapshots:
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
+
+  effect@4.0.0-beta.83:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.8.0
+      find-my-way-ts: 0.1.6
+      ini: 7.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 2.0.1
+      multipasta: 0.2.7
+      toml: 4.1.1
+      uuid: 14.0.0
+      yaml: 2.9.0
 
   effect@4.0.0-beta.92(patch_hash=ed3008c54709e9cf624df2b898d592f905c570fc0a673eeaadf06ce377caac89):
     dependencies:
@@ -7188,10 +7300,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -7334,6 +7442,8 @@ snapshots:
 
   isarray@1.0.0: {}
 
+  isexe@2.0.0: {}
+
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
@@ -7370,6 +7480,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  json-schema@0.4.0: {}
 
   json-with-bigint@3.5.8: {}
 
@@ -7606,6 +7718,8 @@ snapshots:
   patch-console@2.0.0: {}
 
   path-expression-matcher@1.5.0: {}
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -7929,6 +8043,12 @@ snapshots:
 
   setimmediate@1.0.5: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -7990,11 +8110,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -8122,11 +8237,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
@@ -8155,6 +8270,10 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -8192,5 +8311,7 @@ snapshots:
   yaml@2.9.0: {}
 
   yoga-layout@3.2.1: {}
+
+  zod@4.1.8: {}
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ catalog:
   '@manti-ui/react': 0.9.0
   '@manti-ui/styles': 0.9.0
   '@nkzw/fate': 1.3.1
+  '@opencode-ai/plugin': 1.18.21
+  '@opencode-ai/sdk': 1.18.21
   '@playwright/test': ^1.62.1
   '@sentry/cloudflare': 10.62.0
   '@sentry/effect': 10.62.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
 	"packages": {
 		"packages/fabrika-cli": {
 			"component": "fabrika-cli"
+		},
+		"packages/fabrika-opencode": {
+			"component": "fabrika-opencode"
 		}
 	}
 }


### PR DESCRIPTION
Closes #6965

## What

`@kampus/fabrika-opencode` — an npm plugin that gives an external opencode user fabrika with one config line:

```json
{ "plugin": ["@kampus/fabrika-opencode"] }
```

The plugin's `config()` hook registers the eight agent shells as subagents and appends a release-time bundle of `claude-plugins/fabrika/skills/` to `skills.paths`. Route 1 from the issue; routes 2–3 stay rejected for the reasons recorded there.

## The spike ran first (acceptance gate 1)

**Confirmed, not refuted.** The `config` hook is in opencode's published `Hooks` type (`config?: (input: Config) => Promise<void>`) even though [the plugin docs](https://opencode.ai/docs/plugins/) never mention it. Verified on a real install (opencode 1.18.21):

1. **Local-file form** — a throwaway plugin mutated `cfg.agent["spike-agent"]`; `opencode agent list` resolved it as a subagent.
2. **npm form** — packed tarball referenced via `"plugin": ["file:…tgz"]`, installed by opencode into its per-user package cache through the real arborist flow; the registered agent and bundled skill both resolved from inside the installed package.
3. **Upstream corroboration** — anomalyco/opencode carries its own regression test for exactly this chain (`packages/opencode/test/agent/plugin-agent-regression.test.ts`: plugin → config hook → `Agent.list`), and the config-side agent schema (`packages/core/src/v1/config/agent.ts`) pins the entry shape this plugin writes (`description` / `mode` / `prompt` / `permission`).

## Acceptance evidence (foreign repo, real install)

A temp repo with only the one-line spec above, against the actual packed tarball:

- **All eight shells resolve as subagents** — builder, mixed-builder, operator, reviewer, shipper, triager, ui-builder, ui-reviewer — stable across cold-cache and warm-cache runs.
- **26/26 skills load from inside the installed package** (`opencode debug skill` locations under `…/@kampus/fabrika-opencode/dist/skills/`), matching the authored dir at pack time.
- **Shell content survives**: prompts carry through, and operator's `permission: edit deny` lands in the resolved permission ruleset.

## Shape

- `packages/fabrika-opencode/` — zero-runtime-dep entry plus the `yaml` catalog dep for authored frontmatter; parser validates name/mode/permission fail-closed so a bad mirror dies at build/test, not at install.
- `scripts/sync-bundle.mjs` — the release-time copy (`.opencode/agent/*.md` → `dist/agents/`, skills → `dist/skills/`); refuses to bundle zero agents or zero skills and prints what shipped.
- Release wiring per [.patterns/release-path.md § Adding a third published package](https://github.com/kamp-us/phoenix/blob/main/.patterns/release-path.md): the `fabrika-opencode-v*` resolve arm in `publish.yml` (widening `publish-isolation-guard`'s scope — verified green at 2 published packages), the release-please root + manifest at `0.1.0`, and per-path dispatch outputs in `release-please.yml`.
- README is the install doc: one-line npm path, verify commands, clone-and-point documented as the fallback with its staleness tradeoff.
- `release-path.md`'s Current state updated for the third root and pipeline-cli's #6326 deletion.

## HUMAN steps after merge (release-path procedure steps 4–5)

1. Bootstrap-publish `0.1.0` by hand: `pnpm publish` from `packages/fabrika-opencode/` at the merged tree.
2. Register the Trusted Publisher on npmjs.com (repo + workflow file `publish.yml`, environment field empty). Until then a tag's publish run 403s after install/build — fail-closed, no version burned.

## Test plan

- [x] `pnpm --filter @kampus/fabrika-opencode build && test && typecheck`
- [x] `biome check`, `actionlint`
- [x] `publish-isolation-guard check`, `catalog-guard check`, `readme-guard check`
- [x] Real-install verification above

## Deviations

- **Out-of-scope change** — **Said:** #6965 asks for an npm distribution path for fabrika under opencode. **Did:** the opening commit also stripped ~95 lines of load-bearing rationale from `pnpm-workspace.yaml` — the better-auth/better-call/tea/fast-xml-parser exact-pin coupling notes (#108, #5673, #2291, the PR #535 rule), the drizzle RQB v1/v2 incompatibility warning, and the entire ADR 0038 patchedDependencies policy block with per-patch retire conditions. **Why:** nothing in the strip traced to this issue's goal and nothing disclosed or rehomed it; review-code failed the round on exactly this absent disclosure (rehoming tracked separately as #6969). **Disposition:** reverted in full — commit 9bb0076 restores every deleted block verbatim, so the PR's only remaining `pnpm-workspace.yaml` change is the two catalog entries the new package needs (`@opencode-ai/plugin` / `@opencode-ai/sdk` at 1.18.21).