### PR TITLE
feat: Build the campaign verb group specified by claude-plugins/fabrika/skills/campaign/contract.md

### DIFF
--- a/.fabrika.schema.json
+++ b/.fabrika.schema.json
@@ -81,6 +81,14 @@
 			},
 			"additionalProperties": false
 		},
+		"campaignAuthors": {
+			"type": "array",
+			"description": "Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `fabrika campaign state`), narrowing the repository's collaborator ACL — an entry here still needs `write` or above on the repo (ADR 0294). Each entry is a GitHub `@user` or `@org/team`, `@`-prefixed. Empty (or absent) means nobody may declare.",
+			"items": {
+				"type": "string",
+				"pattern": "^@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)$|^@([^/\\s]+)\\/([^/\\s]+)$"
+			}
+		},
 		"capClearAuthors": {
 			"type": "array",
 			"description": "Who may clear one extra repair round on a PR (`fabrika build clear`). Each entry is a GitHub `@user` or `@org/team`, `@`-prefixed. Empty (or absent) means nobody may grant.",

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -342,61 +342,129 @@ const isHeader = (cells: ReadonlyArray<string>): boolean =>
 	cells[1]?.toLowerCase() === "milestone" &&
 	cells[2]?.toLowerCase() === "state";
 
+/** One `## Campaigns` data line as found, before any cell is judged. */
+export interface CampaignLine {
+	/** Its index in `text.split("\n")` — what a writer rewrites in place. */
+	readonly index: number;
+	readonly cells: ReadonlyArray<string>;
+}
+
+/** Where the `## Campaigns` table sits in a roadmap file. `null` is "this file has none". */
+export interface CampaignScan {
+	readonly heading: number | null;
+	readonly header: number | null;
+	readonly separator: number | null;
+	readonly rows: ReadonlyArray<CampaignLine>;
+}
+
 /**
- * Read `ROADMAP.md`'s `## Campaigns` table into the set of milestones its `active` rows permit.
+ * Locate the `## Campaigns` table: the heading, the header, the separator, and every data line.
  *
- * The header row is recognised by its column names and the separator by its dashes, so what is left is
- * a data row **whatever it contains** — which is what makes a mistyped state cell malformed rather than
- * invisible. Skipping unrecognised rows instead would answer "nothing is active" for a broken table,
- * the well-formed-and-always-wrong shape this fence exists to avoid.
+ * The header row is recognised by its column names and the separator by its dashes, so what is left
+ * is a data row **whatever it contains** — which is what makes a mistyped state cell malformed
+ * rather than invisible. Skipping unrecognised rows instead would answer "nothing is active" for a
+ * broken table, the well-formed-and-always-wrong shape this fence exists to avoid.
  *
- * One unreadable row makes the **whole** table malformed rather than degrading to the rows that did
- * parse (ADR 0298's rule, carried onto the surface that replaced it): a partial read reported as the
- * permission is a fence quietly wider or narrower than what was written.
+ * Split out from {@link parseCampaigns} so `campaign open` and `campaign state` can edit the table
+ * without a second copy of these regexes (`claude-plugins/fabrika/skills/campaign/contract.md`).
  */
-export const readCampaigns = (text: string): Dispatch => {
+export const scanCampaigns = (text: string): CampaignScan => {
 	const lines = text.split("\n");
 	const start = lines.findIndex((line) => HEADING.test(line.trim()));
-	if (start === -1) return {_tag: "None"};
+	if (start === -1) return {heading: null, header: null, separator: null, rows: []};
 
-	const rows: ReadonlyArray<string>[] = [];
+	let header: number | null = null;
+	let separator: number | null = null;
+	const rows: CampaignLine[] = [];
 	for (let i = start + 1; i < lines.length; i++) {
 		const line = lines[i] ?? "";
 		if (ANY_HEADING.test(line.trim())) break;
 		const cells = cellsOf(line);
-		if (cells === null || isSeparator(cells) || isHeader(cells)) continue;
-		rows.push(cells);
+		if (cells === null) continue;
+		if (isSeparator(cells)) {
+			separator ??= i;
+			continue;
+		}
+		if (isHeader(cells)) {
+			header ??= i;
+			continue;
+		}
+		rows.push({index: i, cells});
 	}
+	return {heading: start, header, separator, rows};
+};
 
-	const active: ActiveCampaign[] = [];
-	for (const [index, row] of rows.entries()) {
+/** One readable `## Campaigns` row. */
+export interface CampaignRow {
+	readonly milestone: number;
+	readonly state: CampaignState;
+	readonly name: string;
+}
+
+/**
+ * Every declared campaign, or the reason the table cannot be read at all.
+ *
+ * One unreadable row makes the **whole** table malformed rather than degrading to the rows that did
+ * parse (ADR 0298's rule, carried onto the surface that replaced it): a partial read reported as the
+ * permission is a fence quietly wider or narrower than what was written.
+ *
+ * An absent heading and a table with no rows are both `Rows` with an empty array — a fact about the
+ * file, never a failed read. Which of those a caller calls `none` is the caller's question.
+ */
+export type CampaignTable =
+	| {readonly _tag: "Rows"; readonly rows: ReadonlyArray<CampaignRow>}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/**
+ * Judge every scanned row. Its `rows` are positionally aligned with {@link scanCampaigns}'s, because
+ * a table with one unreadable row returns `Malformed` instead of a short list — which is what lets a
+ * writer take a row's line index from the scan and its values from here.
+ */
+export const parseCampaigns = (text: string): CampaignTable => {
+	const rows: CampaignRow[] = [];
+	for (const [index, {cells}] of scanCampaigns(text).rows.entries()) {
 		const where = `## Campaigns row ${index + 1}`;
-		if (row.length !== 3) {
+		if (cells.length !== 3) {
 			return {
 				_tag: "Malformed",
-				reason: `${where} has ${row.length} cells, not the 3 the grammar declares (Campaign | Milestone | State)`,
+				reason: `${where} has ${cells.length} cells, not the 3 the grammar declares (Campaign | Milestone | State)`,
 			};
 		}
-		const name = row[0] ?? "";
+		const name = cells[0] ?? "";
 		if (name === "") {
 			return {_tag: "Malformed", reason: `${where}'s campaign cell is empty`};
 		}
-		const milestone = MILESTONE_CELL.exec(row[1] ?? "");
+		const milestone = MILESTONE_CELL.exec(cells[1] ?? "");
 		if (milestone?.[1] === undefined) {
-			return {_tag: "Malformed", reason: `${where}'s milestone cell "${row[1]}" is not #<int>`};
+			return {_tag: "Malformed", reason: `${where}'s milestone cell "${cells[1]}" is not #<int>`};
 		}
-		const state = (row[2] ?? "").toLowerCase();
-		if (!CAMPAIGN_STATES.some((legal) => legal === state)) {
+		const state = (cells[2] ?? "").toLowerCase();
+		const legal = CAMPAIGN_STATES.find((candidate) => candidate === state);
+		if (legal === undefined) {
 			return {
 				_tag: "Malformed",
-				reason: `${where}'s state cell "${row[2]}" is none of ${CAMPAIGN_STATES.join(" / ")}`,
+				reason: `${where}'s state cell "${cells[2]}" is none of ${CAMPAIGN_STATES.join(" / ")}`,
 			};
 		}
-		if (state === "active") {
-			active.push({milestone: Number.parseInt(milestone[1], 10), name});
-		}
+		rows.push({milestone: Number.parseInt(milestone[1], 10), state: legal, name});
 	}
-	const [first, ...rest] = active;
+	return {_tag: "Rows", rows};
+};
+
+/**
+ * What the fence reads: `ROADMAP.md`'s `## Campaigns` table narrowed to the milestones its `active`
+ * rows permit.
+ *
+ * A narrowing over {@link parseCampaigns} and nothing more — the two cannot disagree about what a
+ * row says, which is the whole reason `campaign list` and the writers bind to the parse below rather
+ * than to a parser of their own.
+ */
+export const readCampaigns = (text: string): Dispatch => {
+	const table = parseCampaigns(text);
+	if (table._tag === "Malformed") return table;
+	const [first, ...rest] = table.rows
+		.filter((row) => row.state === "active")
+		.map(({milestone, name}): ActiveCampaign => ({milestone, name}));
 	return first === undefined ? {_tag: "None"} : {_tag: "Active", campaigns: [first, ...rest]};
 };
 

--- a/packages/fabrika-cli/src/campaign/authority.ts
+++ b/packages/fabrika-cli/src/campaign/authority.ts
@@ -1,0 +1,92 @@
+/**
+ * Who may write the `## Campaigns` table — **two conjunctive clauses, neither substituting for the
+ * other** (ADR 0294).
+ *
+ * 1. The configured set: the cited comment's author is in `.fabrika.jsonc`'s `campaignAuthors`,
+ *    case-insensitively for a `@user` entry and by REST membership for a `@org/team` one.
+ * 2. The live ACL: that same login's repository permission, read at the moment of the act, is one of
+ *    `admin` / `maintain` / `write`.
+ *
+ * **Clause 2 is load-bearing here specifically.** These verbs run against a working tree before any
+ * pull request exists, so there is no base ref to resolve `campaignAuthors` at and the file is the
+ * one the same actor is editing — the "a checked-in identity list is instructions, not enforcement"
+ * hole ADR 0055 supersedes 0051 to close. A login appended to the key on a branch, by somebody with
+ * no collaboration on the repo, must not satisfy the check.
+ */
+
+import {Effect} from "effect";
+import {clearsWriteFloor} from "../build/clearances.ts";
+import type {GrantAuthor} from "../config/keys/cap-clear-authors.ts";
+import type {Shell} from "../io/git.ts";
+import {permissionFor} from "../io/pulls.ts";
+import {teamHolds} from "./github.ts";
+
+/** A read failed, so authority is UNKNOWN and nothing is written — the caller's `13`. */
+export interface AuthorityUnknown {
+	readonly _tag: "Unknown";
+	readonly reason: string;
+}
+
+export type Declared = {readonly _tag: "Yes"} | {readonly _tag: "No"} | AuthorityUnknown;
+
+export type Acl =
+	/** Clause 2 holds. `level` is what the ACL answered, for the notice line. */
+	| {readonly _tag: "Cleared"; readonly level: string}
+	/**
+	 * Below the floor — the caller's `21`. `level` is `null` for `permissionFor`'s **proven** 404,
+	 * which is a different true thing from a level below the floor and prints as `no collaboration`.
+	 */
+	| {readonly _tag: "BelowFloor"; readonly level: string | null}
+	| AuthorityUnknown;
+
+/**
+ * Clause 1, with every team resolved through one membership read each.
+ *
+ * Exported apart from {@link aclOf} because the two do not run back to back: the contract's
+ * most-informative-first precedence puts a named-set miss (`16`) above a malformed marker (`15`) and
+ * the ACL refusal (`21`) below both, so the marker checks sit between them.
+ */
+export const declaredBy = (authors: ReadonlyArray<GrantAuthor>, login: string): Shell<Declared> =>
+	Effect.gen(function* () {
+		const teams: Array<{readonly org: string; readonly team: string}> = [];
+		for (const author of authors) {
+			if (author._tag === "User") {
+				if (author.login.toLowerCase() === login.toLowerCase()) return {_tag: "Yes" as const};
+				continue;
+			}
+			teams.push({org: author.org, team: author.team});
+		}
+		for (const {org, team} of teams) {
+			const read = yield* teamHolds(org, team, login);
+			if (read._tag === "Unknown") {
+				return {
+					_tag: "Unknown" as const,
+					reason: `cannot resolve membership of ${login} in @${org}/${team}: ${read.reason}`,
+				};
+			}
+			if (read._tag === "NoTeam") {
+				return {
+					_tag: "Unknown" as const,
+					reason: `campaignAuthors names @${org}/${team}, which ${org} does not have — fix the key`,
+				};
+			}
+			if (read._tag === "Member") return {_tag: "Yes" as const};
+		}
+		return {_tag: "No" as const};
+	});
+
+/** Clause 2 — the live read, at the moment of the act. */
+export const aclOf = (repo: string, login: string): Shell<Acl> =>
+	Effect.gen(function* () {
+		const permission = yield* permissionFor(repo, login);
+		if (permission._tag === "Unknown") {
+			return {
+				_tag: "Unknown" as const,
+				reason: `cannot resolve @${login}'s permission on ${repo}: ${permission.reason}`,
+			};
+		}
+		if (permission._tag === "Absent") return {_tag: "BelowFloor" as const, level: null};
+		return clearsWriteFloor(permission.value)
+			? {_tag: "Cleared" as const, level: permission.value}
+			: {_tag: "BelowFloor" as const, level: permission.value};
+	});

--- a/packages/fabrika-cli/src/campaign/authority.ts
+++ b/packages/fabrika-cli/src/campaign/authority.ts
@@ -67,7 +67,9 @@ export const declaredBy = (authors: ReadonlyArray<GrantAuthor>, login: string): 
 			if (read._tag === "NoTeam") {
 				return {
 					_tag: "Unknown" as const,
-					reason: `campaignAuthors names @${org}/${team}, which ${org} does not have — fix the key`,
+					// The trailing `;` is the joiner this reason hands its caller: it has already spent
+					// the sentence's one em dash, so the UNKNOWN disclosure joins onto it.
+					reason: `campaignAuthors names @${org}/${team}, which ${org} does not have — fix the key;`,
 				};
 			}
 			if (read._tag === "Member") return {_tag: "Yes" as const};

--- a/packages/fabrika-cli/src/campaign/citation.ts
+++ b/packages/fabrika-cli/src/campaign/citation.ts
@@ -1,0 +1,30 @@
+/**
+ * The `--cites` URL, read for its shape and the repository it names.
+ *
+ * The two answers are seated apart on purpose: a value that is not a comment URL at all is a **usage
+ * error** the caller mistyped, and a well-formed URL naming another repository is a proven refusal
+ * (`15`) — a ruling recorded elsewhere rules nothing here.
+ */
+
+/** Both spellings GitHub gives one comment, since a ruling can live on an issue or on a PR. */
+const COMMENT_URL =
+	/^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/\d+#issuecomment-(\d+)$/;
+
+export const CITATION_GRAMMAR =
+	".../issues/<n>#issuecomment-<id> or .../pull/<n>#issuecomment-<id>";
+
+export interface Citation {
+	/** The URL as written, for every message that quotes it back. */
+	readonly url: string;
+	/** `owner/name` as the URL spells it — compared to `--repo` by the trace, never assumed equal. */
+	readonly repo: string;
+	readonly commentId: number;
+}
+
+/** `null` when the value is not a comment URL at all — the caller's exit `1`. */
+export const readCitation = (value: string): Citation | null => {
+	const url = value.trim();
+	const match = COMMENT_URL.exec(url);
+	if (match?.[1] === undefined || match[2] === undefined || match[3] === undefined) return null;
+	return {url, repo: `${match[1]}/${match[2]}`, commentId: Number.parseInt(match[3], 10)};
+};

--- a/packages/fabrika-cli/src/campaign/codes.ts
+++ b/packages/fabrika-cli/src/campaign/codes.ts
@@ -1,0 +1,59 @@
+/**
+ * The one exit table all three `campaign` verbs allocate from
+ * (`claude-plugins/fabrika/skills/campaign/contract.md`).
+ *
+ * Four seats are the base's and are **imported, never restated as numerals**, so a drift is
+ * unrepresentable. `3`, `4`, `5`, `6` and `10` are left unallocated — no verb here reads stdin,
+ * composes a body, or classifies anything — and this group's private band is `12`-`22`.
+ *
+ * {@link WRITE_UNKNOWN} and {@link PRECONDITION_UNKNOWN} are two different facts and the split is
+ * the point: `11` is *nothing was attempted*, `8` is *a write was attempted and `ROADMAP.md` may be
+ * half-written*, and {@link READBACK_MISMATCH} is the third — the file is written, readable, and
+ * does not say what the verb wrote.
+ */
+
+import {
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Proven: the selector names no row on the table. `campaign state` only. */
+export const NO_TARGET = REPORT_NO_TARGET;
+/** The write to the roadmap file failed, so the file may be half-written — UNKNOWN. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed and the read-back does not match it. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** The roadmap file could not be read, so nothing was attempted — UNKNOWN. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Proven: a data row under `## Campaigns` will not parse — the whole table is unreadable. */
+export const TABLE_UNREADABLE = 12;
+/**
+ * The cited comment, a team membership or the author's permission could not be read, so authority is
+ * UNKNOWN and nothing was written.
+ *
+ * Also the seat for a `campaignAuthors` that will not decode: the contract's `22` is the
+ * *roadmapFile* seat, and a set nobody could read is authority nobody could resolve — not an empty
+ * set, which is `17` and a different, proven fact.
+ */
+export const AUTHORITY_UNKNOWN = 13;
+/** Proven: the cited comment's first line carries no `campaign-approve:` marker. */
+export const NO_MARKER = 14;
+/** Proven: the marker is malformed, names another milestone or state, or is in another repository. */
+export const MARKER_UNBOUND = 15;
+/** Proven: the cited comment's author is not in `campaignAuthors`. */
+export const AUTHOR_UNDECLARED = 16;
+/** Proven: `campaignAuthors` is empty or absent — nobody may declare in this repo. */
+export const NOBODY_DECLARED = 17;
+/** Proven: the selector names more than one row. `campaign state` only. */
+export const AMBIGUOUS_SELECTOR = 18;
+/** Proven: the table already holds a row for this campaign or this milestone. `campaign open` only. */
+export const DUPLICATE_ROW = 19;
+/** Proven: the row already holds the state `--to` names — nothing written. `campaign state` only. */
+export const ALREADY_IN_STATE = 20;
+/** Proven: the cited comment's author is below the `write` floor on this repository (ADR 0055). */
+export const BELOW_WRITE_FLOOR = 21;
+/** `.fabrika.jsonc` could not be read, or its `roadmapFile` will not decode — UNKNOWN. */
+export const CONFIG_UNREADABLE = 22;

--- a/packages/fabrika-cli/src/campaign/codes.ts
+++ b/packages/fabrika-cli/src/campaign/codes.ts
@@ -25,7 +25,13 @@ export const NO_TARGET = REPORT_NO_TARGET;
 export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
 /** The write landed and the read-back does not match it. */
 export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
-/** The roadmap file could not be read, so nothing was attempted — UNKNOWN. */
+/**
+ * The roadmap file could not be read, so nothing was attempted — UNKNOWN.
+ *
+ * Also the seat for a located row that reads as three cells but does not edit as three: the
+ * contract's trigger names the file read, and the half of the `8`/`11` split that carries the
+ * operator's next move is *whether a write was attempted*, which on that arm it was not.
+ */
 export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
 
 /** Proven: a data row under `## Campaigns` will not parse — the whole table is unreadable. */

--- a/packages/fabrika-cli/src/campaign/command.ts
+++ b/packages/fabrika-cli/src/campaign/command.ts
@@ -1,0 +1,158 @@
+/**
+ * The `campaign` verb group — `fabrika campaign <list|open|state>`, the `campaign` skill's half of
+ * the roadmap surface.
+ *
+ * The adapter and nothing else: it declares the flags, hands the verb the ambient cwd and env, and
+ * emits the outcome. Every decision lives in the `*-verb.ts` modules beside it.
+ *
+ * `--state` and `--to` are declared as strings and checked in the verbs, so a refusal can name the
+ * whole closed vocabulary in this group's own words rather than emit the parser's generic message.
+ */
+
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runList} from "./list-verb.ts";
+import {runOpen} from "./open-verb.ts";
+import {runState} from "./state-verb.ts";
+
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const fileFlag = Flag.string("file").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the roadmap file (default: `roadmapFile` in .fabrika.jsonc, itself defaulting to ROADMAP.md)",
+	),
+);
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repository the cited comment must belong to (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const citesFlag = Flag.string("cites").pipe(
+	Flag.withDescription(
+		"the comment URL whose first line carries the campaign-approve: marker authorizing this write",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("print one JSON object instead of the row line grammar"),
+);
+
+const list = leafCommand(
+	"list",
+	{
+		state: Flag.string("state").pipe(
+			Flag.optional,
+			Flag.withDescription("print only the rows holding this state: active, paused or done"),
+		),
+		file: fileFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({state, file, json}) {
+		yield* emit(
+			yield* runList({
+				state: Option.getOrNull(state),
+				file: Option.getOrNull(file),
+				json,
+				cwd: process.cwd(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Print the ## Campaigns rows, optionally narrowed to one state."),
+	Command.withDescription(
+		'Print the ## Campaigns rows as #<milestone>\\t<state>\\t<name>, in table order. An absent table, an empty one and a --state that matches nothing all print the single line "none" at exit 0 — nothing declared means the dispatch fence is off, not closed. Under --json: {"rows":[{"milestone":47,"state":"active","name":"…"}],"file":"ROADMAP.md"}. Exits 1 (a --state outside the three values), 11 (the roadmap file could not be read), 12 (a data row will not parse — the whole table is unreadable), 22 (.fabrika.jsonc could not be read, or its roadmapFile will not decode). Example: fabrika campaign list --state active',
+	),
+);
+
+const open = leafCommand(
+	"open",
+	{
+		name: Argument.string("name").pipe(
+			Argument.withDescription(
+				"the founder-voice campaign name, written verbatim into the row's first cell",
+			),
+		),
+		milestone: Flag.integer("milestone").pipe(
+			Flag.withDescription("the GitHub milestone number this campaign pins"),
+		),
+		cites: citesFlag,
+		file: fileFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({name, milestone, cites, file, repo, json}) {
+		yield* emit(
+			yield* runOpen({
+				name,
+				milestone,
+				cites,
+				file: Option.getOrNull(file),
+				repo: Option.getOrNull(repo),
+				json,
+				cwd: process.cwd(),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Append a new paused campaign row, past the approval trace."),
+	Command.withDescription(
+		'Append a new campaign row pinning a milestone, past the campaign-approve: trace, and read it back. The row is always written paused and there is no flag to change that: naming a campaign and granting it dispatch are two acts (ADR 0304), and the second is `campaign state`. Prints the row read back, or under --json {"row":{"milestone":52,"state":"paused","name":"…"},"file":"ROADMAP.md"}. Exits 1 (usage), 8 (the write failed — the table may be half-written), 9 (the read-back holds no row for --milestone), 11 (the roadmap could not be read), 12 (the table is unreadable), 13 (the comment, a team membership, the author\'s permission or the repository could not be resolved — authority is UNKNOWN), 14 (no marker on the comment\'s first line), 15 (the marker is malformed, misbound, or in another repository), 16 (the author is not in campaignAuthors), 17 (campaignAuthors is empty — nobody may declare), 19 (a row already holds this name or pins this milestone), 21 (the author holds below write on the repo), 22 (config). Example: fabrika campaign open "Mecmua reading layout" --milestone 52 --cites https://github.com/kamp-us/phoenix/issues/6289#issuecomment-5337663028',
+	),
+);
+
+const state = leafCommand(
+	"state",
+	{
+		selector: Argument.string("selector").pipe(
+			Argument.withDescription(
+				"#<milestone>, or a campaign name matched exactly against the row's first cell",
+			),
+		),
+		to: Flag.string("to").pipe(
+			Flag.withDescription("the state to write into the row's third cell: active, paused or done"),
+		),
+		cites: citesFlag,
+		file: fileFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({selector, to, cites, file, repo, json}) {
+		yield* emit(
+			yield* runState({
+				selector,
+				to,
+				cites,
+				file: Option.getOrNull(file),
+				repo: Option.getOrNull(repo),
+				json,
+				cwd: process.cwd(),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Rewrite one campaign row's State cell, past the approval trace."),
+	Command.withDescription(
+		'Rewrite one campaign row\'s State cell, past the campaign-approve: trace, and read it back. Only the state token moves — the cell is never re-padded, so every other line stays byte-identical. Selection is exact: two matches refuse rather than pick. Prints the row read back, or under --json {"row":{…},"from":"paused","file":"ROADMAP.md"}. Exits 1 (usage), 7 (the selector matches no row), 8 (the write failed — the row may be half-written), 9 (the read-back does not hold --to), 11 (the roadmap could not be read), 12 (the table is unreadable), 13 (authority is UNKNOWN), 14 (no marker), 15 (the marker is malformed, misbound, or in another repository), 16 (the author is not in campaignAuthors), 17 (campaignAuthors is empty), 18 (the selector matches more than one row), 20 (the row already holds --to — nothing written), 21 (the author holds below write), 22 (config). Example: fabrika campaign state \'#42\' --to active --cites https://github.com/kamp-us/phoenix/issues/6289#issuecomment-5337663028',
+	),
+);
+
+export const campaignCommand = Command.make("campaign").pipe(
+	Command.withSubcommands([list, open, state]),
+	Command.withShortDescription("Read and write the ## Campaigns table that gates dispatch."),
+	Command.withDescription(
+		"Read the ## Campaigns table, declare a new campaign paused, and flip one campaign's lifecycle state — each write past a cited founder approval, because that State cell is the permission to open lanes against a milestone (ADR 0304)",
+	),
+);

--- a/packages/fabrika-cli/src/campaign/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/campaign/fixtures.test-support.ts
@@ -1,0 +1,106 @@
+/**
+ * The one repo all three `campaign` verb tests drive against: a two-row `ROADMAP.md`, a
+ * `.fabrika.jsonc` naming one author, and one cited comment carrying the marker.
+ *
+ * Each helper takes what the case under test varies and holds everything else fixed, so a test reads
+ * as the one fact it pins.
+ */
+
+import {Layer} from "effect";
+import {
+	type FakeFsOptions,
+	fakeFs,
+	fakeSeams,
+	type HttpReply,
+	type Scripted,
+} from "../fakes.test-support.ts";
+
+export const REPO = "o/r";
+export const AUTHOR = "usirin";
+export const COMMENT = 900001;
+export const CITES = `https://github.com/${REPO}/issues/6289#issuecomment-${COMMENT}`;
+export const ROOT = "/repo";
+export const FILE = "ROADMAP.md";
+export const ROADMAP_PATH = `${ROOT}/${FILE}`;
+export const CONFIG_FILE = `${ROOT}/.fabrika.jsonc`;
+
+export const env = {CLAUDE_PIPELINE_REPO: REPO, GITHUB_TOKEN: "ghp_scripted"} as Record<
+	string,
+	string | undefined
+>;
+
+/** The two-row table every example in the contract runs against. */
+export const TWO_ROWS = `# Roadmap
+
+## Campaigns
+
+| Campaign | Milestone | State |
+|----------|-----------|-------|
+| Taste-Skill Library | #42 | paused |
+| fabrika everywhere | #47 | active |
+
+## Dependency graph
+
+nothing here.
+`;
+
+export const config = (...authors: ReadonlyArray<string>): string =>
+	JSON.stringify({campaignAuthors: authors}, null, 2);
+
+const API = "https:\\/\\/api\\.github\\.com";
+export const GET_COMMENT = new RegExp(
+	`^GET ${API}\\/repos\\/${REPO}\\/issues\\/comments\\/${COMMENT}$`,
+);
+export const PERMISSION = new RegExp(
+	`^GET ${API}\\/repos\\/${REPO}\\/collaborators\\/${AUTHOR}\\/permission$`,
+);
+export const MEMBERSHIP = new RegExp(
+	`^GET ${API}\\/orgs\\/kamp-us\\/teams\\/founders\\/memberships\\/${AUTHOR}$`,
+);
+export const TEAM = new RegExp(`^GET ${API}\\/orgs\\/kamp-us\\/teams\\/founders$`);
+
+const served = (body: unknown): HttpReply => ({status: 200, body: JSON.stringify(body)});
+
+/** The cited comment, with whatever first line the case wants. */
+export const comment = (body: string, author: string = AUTHOR): HttpReply =>
+	served({
+		id: COMMENT,
+		user: {login: author},
+		created_at: "2026-08-20T04:11:09Z",
+		updated_at: "2026-08-20T04:11:09Z",
+		body,
+	});
+
+export const marker = (milestone: number, state: string): string =>
+	`campaign-approve: #${milestone} ${state} · 2026-08-20T04:11:09Z`;
+
+export const permission = (level: string): HttpReply => served({permission: level});
+
+/** The scripted board an authorized write runs against. */
+export const approving = (milestone: number, state: string): ReadonlyArray<Scripted> => [
+	[GET_COMMENT, comment(marker(milestone, state))],
+	[PERMISSION, permission("write")],
+];
+
+export interface Seams {
+	readonly layer: Layer.Layer<never>;
+	readonly written: Map<string, string>;
+	readonly requests: ReadonlyArray<string>;
+}
+
+/** Both IO seams over one scripted board and one in-memory tree. */
+export const seams = (script: ReadonlyArray<Scripted>, fs: FakeFsOptions) => {
+	const tree = fakeFs(fs);
+	const board = fakeSeams(script);
+	return {
+		layer: Layer.merge(tree.layer, board.layer),
+		written: tree.written,
+		requests: board.requests,
+	};
+};
+
+/** The default tree: the two-row roadmap and a config naming `@usirin`. */
+export const tree = (
+	roadmap: string = TWO_ROWS,
+	fabrika: string = config(`@${AUTHOR}`),
+): FakeFsOptions => ({files: {[ROADMAP_PATH]: roadmap, [CONFIG_FILE]: fabrika}});

--- a/packages/fabrika-cli/src/campaign/github.ts
+++ b/packages/fabrika-cli/src/campaign/github.ts
@@ -1,0 +1,64 @@
+/**
+ * The one GitHub read local to this group: whether a login is a member of a `@org/team` entry in
+ * `campaignAuthors`.
+ *
+ * REST, never GraphQL, per skill conventions §11. The collaborator-permission read is
+ * `../io/pulls.ts`'s `permissionFor` and is not re-implemented.
+ *
+ * **A `404` on the membership and a `404` on the team are two answers, and the split is the point.**
+ * The first is a proven "not a member"; the second is a typo in `campaignAuthors`, and reading it as
+ * "not a member" would send the caller off to find a different approver instead of to the key. So a
+ * missing membership probes the team before it answers.
+ */
+
+import {Effect} from "effect";
+import {authedExistence, existenceOf, restRead} from "../io/gh-api.ts";
+import {fail, ok, type Shell} from "../io/git.ts";
+import type {Existence} from "../io/issues.ts";
+import {isRecord} from "../io/json.ts";
+
+const probeTeam = (org: string, team: string): Shell<Existence<string>> =>
+	authedExistence((token) =>
+		Effect.map(restRead(token, "GET", `orgs/${org}/teams/${team}`), (outcome) =>
+			existenceOf(outcome, (body) =>
+				isRecord(body) && typeof body.slug === "string"
+					? ok(body.slug)
+					: fail("GitHub answered 200 but named no team"),
+			),
+		),
+	);
+
+const probeMembership = (org: string, team: string, login: string): Shell<Existence<string>> =>
+	authedExistence((token) =>
+		Effect.map(
+			restRead(token, "GET", `orgs/${org}/teams/${team}/memberships/${login}`),
+			(outcome) =>
+				existenceOf(outcome, (body) =>
+					isRecord(body) && typeof body.state === "string"
+						? ok(body.state)
+						: fail("GitHub answered 200 but named no membership state"),
+				),
+		),
+	);
+
+/** Four answers, because "the org has no such team" routes to the config key and the others do not. */
+export type TeamRead =
+	| {readonly _tag: "Member"}
+	| {readonly _tag: "NotMember"}
+	| {readonly _tag: "NoTeam"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/** Whether `login` is an active member of `@org/team`. */
+export const teamHolds = (org: string, team: string, login: string): Shell<TeamRead> =>
+	Effect.gen(function* () {
+		const membership = yield* probeMembership(org, team, login);
+		if (membership._tag === "Unknown") return {_tag: "Unknown" as const, reason: membership.reason};
+		if (membership._tag === "Present") {
+			return membership.value === "active"
+				? ({_tag: "Member"} as const)
+				: ({_tag: "NotMember"} as const);
+		}
+		const exists = yield* probeTeam(org, team);
+		if (exists._tag === "Unknown") return {_tag: "Unknown" as const, reason: exists.reason};
+		return exists._tag === "Absent" ? ({_tag: "NoTeam"} as const) : ({_tag: "NotMember"} as const);
+	});

--- a/packages/fabrika-cli/src/campaign/guards.ts
+++ b/packages/fabrika-cli/src/campaign/guards.ts
@@ -1,0 +1,252 @@
+/**
+ * What all three `campaign` verbs do before they diverge: find the roadmap file, read it, parse it —
+ * and, for the two writers, run the approval trace end to end.
+ *
+ * The trace's order is the contract's most-informative-first precedence made executable:
+ * `17` (nobody declared) outranks everything, then the repository binding, then a named-set miss
+ * (`16`), then the marker itself (`14`/`15`), then the live ACL (`21`). A caller with a bad selector
+ * never reaches any of it — the duplicate and no-op checks run first, so nobody is told their
+ * citation is fine on a write that was never going to land.
+ */
+
+import {Effect, type FileSystem, Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type CampaignRow, type CampaignState, parseCampaigns} from "../build/scope-admission.ts";
+import {CONFIG_PATH} from "../config/document.ts";
+import {campaignAuthorsKey} from "../config/keys/campaign-authors.ts";
+import {grantAuthorText} from "../config/keys/cap-clear-authors.ts";
+import {readRoadmapFile} from "../config/paths.ts";
+import {readKey} from "../config/read-key.ts";
+import {discoverRepoRoot} from "../delegate/root.ts";
+import {readFile} from "../io/fs.ts";
+import {getCommentRecord} from "../io/issues.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {aclOf, declaredBy} from "./authority.ts";
+import {
+	AUTHOR_UNDECLARED,
+	AUTHORITY_UNKNOWN,
+	BELOW_WRITE_FLOOR,
+	CONFIG_UNREADABLE,
+	MARKER_UNBOUND,
+	NO_MARKER,
+	NOBODY_DECLARED,
+	PRECONDITION_UNKNOWN,
+	TABLE_UNREADABLE,
+} from "./codes.ts";
+import {bindingMiss, readMarker} from "./marker.ts";
+
+/** What a verb that only touches the working tree needs — `campaign list` never reaches the board. */
+export type FileEffect<A> = Effect.Effect<A, never, FileSystem.FileSystem | Path.Path>;
+
+/** {@link FileEffect} plus the spawner the credential resolution shells out for. */
+export type CampaignEffect<A> = Effect.Effect<
+	A,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+>;
+
+/** The roadmap file to open, and the spelling every message names it by. */
+export interface Located {
+	readonly path: string;
+	readonly display: string;
+}
+
+export type LocateRead =
+	| {readonly _tag: "File"; readonly located: Located}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/**
+ * Where the roadmap is: `--file` as typed, else the repo's declared `roadmapFile` under its root.
+ *
+ * `roadmapFile` is a plain path key with no declined form, so a config that will not decode is `22`
+ * and no file is opened — never a silent fall back to `ROADMAP.md`, which would validate one file
+ * while the fence read another.
+ */
+export const locateRoadmap = (
+	verb: string,
+	cwd: string,
+	explicit: string | null,
+): FileEffect<LocateRead> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		if (explicit !== null) {
+			return {
+				_tag: "File" as const,
+				located: {path: path.resolve(cwd, explicit), display: explicit},
+			};
+		}
+		const declared = yield* readRoadmapFile(cwd);
+		if (declared._tag === "Refused") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					CONFIG_UNREADABLE,
+					`${verb}: cannot resolve roadmapFile from ${CONFIG_PATH}: ${declared.reason.replace(/\.$/, "")} — UNKNOWN, no roadmap file was opened.`,
+				),
+			};
+		}
+		const root = yield* discoverRepoRoot(cwd).pipe(
+			Effect.catchTag("fabrika-cli/ReadFailed", () => Effect.succeed(undefined)),
+		);
+		if (root === undefined) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read ${declared.value}: no repo root at or above ${cwd} — UNKNOWN, nothing was attempted.`,
+				),
+			};
+		}
+		return {
+			_tag: "File" as const,
+			located: {path: path.join(root, declared.value), display: declared.value},
+		};
+	});
+
+/** What every refusal past a write-verb read states it did not do. */
+const NOTHING = "NOTHING was written.";
+
+export type TableRead =
+	| {
+			readonly _tag: "Text";
+			readonly text: string;
+			readonly rows: ReadonlyArray<CampaignRow>;
+	  }
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/**
+ * The roadmap's bytes, with the table proven parseable — `11` unread, `12` unreadable.
+ *
+ * `didNot` is what this verb did not do, and every refusal past a read states it: a refusal that
+ * leaves the caller guessing whether a row landed is the one that makes them write a second.
+ */
+export const readRoadmap = (
+	verb: string,
+	located: Located,
+	didNot: "nothing was parsed" | "nothing was written",
+): FileEffect<TableRead> =>
+	readFile(located.path).pipe(
+		Effect.map((text): TableRead => {
+			const parsed = parseCampaigns(text);
+			const tail = didNot === "nothing was written" ? ` ${NOTHING}` : "";
+			return parsed._tag === "Malformed"
+				? {
+						_tag: "Refused",
+						outcome: refuse(
+							TABLE_UNREADABLE,
+							`${verb}: ${located.display}: ${parsed.reason} — the whole ## Campaigns table is unreadable (ADR 0304).${tail}`,
+						),
+					}
+				: {_tag: "Text", text, rows: parsed.rows};
+		}),
+		Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+			Effect.succeed<TableRead>({
+				_tag: "Refused",
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read ${located.display}: ${failure.reason} — UNKNOWN, ${didNot}.`,
+				),
+			}),
+		),
+	);
+
+export interface TraceRequest {
+	readonly verb: string;
+	readonly cwd: string;
+	readonly repo: string;
+	/** The citation as typed, already proven to be a comment URL. */
+	readonly url: string;
+	readonly urlRepo: string;
+	readonly commentId: number;
+	/** The milestone of the row being written. */
+	readonly milestone: number;
+	/** The state the write produces — `paused` for `open`, `--to` for `state`. */
+	readonly state: CampaignState;
+	/** What an empty `campaignAuthors` says nobody may do: `declare` for `open`, `flip` for `state`. */
+	readonly act: "declare" | "flip";
+}
+
+export type Trace =
+	| {
+			readonly _tag: "Approved";
+			readonly login: string;
+			readonly level: string;
+			/** `campaignAuthors` as the file spells it, for the notice line. */
+			readonly declared: string;
+	  }
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+export const runTrace = (request: TraceRequest): CampaignEffect<Trace> =>
+	Effect.gen(function* () {
+		const {verb, url} = request;
+		const no = (code: number, reason: string): Trace => ({
+			_tag: "Refused",
+			outcome: refuse(code, `${verb}: ${reason} — ${NOTHING}`),
+		});
+		// The UNKNOWN family reads "— authority is UNKNOWN, NOTHING was written." on one dash: a
+		// second em dash before the disclosure would split one sentence into two claims.
+		const unreadable = (reason: string): Trace => ({
+			_tag: "Refused",
+			outcome: refuse(AUTHORITY_UNKNOWN, `${verb}: ${reason} — authority is UNKNOWN, ${NOTHING}`),
+		});
+
+		const key = yield* readKey(request.cwd, campaignAuthorsKey);
+		if (key._tag === "Refused") {
+			return unreadable(
+				`cannot read campaignAuthors from ${CONFIG_PATH}: ${key.reason.replace(/\.$/, "")}`,
+			);
+		}
+		if (key.value.length === 0) {
+			return {
+				_tag: "Refused",
+				outcome: refuse(
+					NOBODY_DECLARED,
+					`${verb}: campaignAuthors is empty in ${CONFIG_PATH} — nobody may ${request.act} a campaign in this repo. ${NOTHING}`,
+				),
+			};
+		}
+		const declared = key.value.map(grantAuthorText).join(", ");
+
+		if (request.urlRepo !== request.repo) {
+			return no(MARKER_UNBOUND, `${url} is a comment in ${request.urlRepo}, not ${request.repo}`);
+		}
+
+		const comment = yield* getCommentRecord(request.repo, request.commentId);
+		if (comment._tag === "Failure") {
+			return unreadable(`cannot fetch ${url}: ${comment.reason}`);
+		}
+		const login = comment.value.author;
+
+		const inSet = yield* declaredBy(key.value, login);
+		if (inSet._tag === "Unknown") {
+			return unreadable(inSet.reason);
+		}
+		if (inSet._tag === "No") {
+			return no(
+				AUTHOR_UNDECLARED,
+				`${url} was authored by @${login}, who is not in campaignAuthors (${declared})`,
+			);
+		}
+
+		const marker = readMarker(comment.value.body);
+		if (marker._tag === "Absent") {
+			return no(NO_MARKER, `${url} has no campaign-approve: marker on its first line`);
+		}
+		if (marker._tag === "Malformed") {
+			return no(MARKER_UNBOUND, `${url} marker is malformed: ${marker.reason}`);
+		}
+		const miss = bindingMiss(marker.marker, request.milestone, request.state);
+		if (miss !== null) return no(MARKER_UNBOUND, `${url} ${miss}`);
+
+		const acl = yield* aclOf(request.repo, login);
+		if (acl._tag === "Unknown") {
+			return unreadable(acl.reason);
+		}
+		if (acl._tag === "BelowFloor") {
+			return no(
+				BELOW_WRITE_FLOOR,
+				`${url} was authored by @${login}, who resolves to ${acl.level ?? "no collaboration"} on ${request.repo}, below write — authority is the ACL's, never ${CONFIG_PATH}'s alone (ADR 0055)`,
+			);
+		}
+		return {_tag: "Approved", login, level: acl.level, declared};
+	});

--- a/packages/fabrika-cli/src/campaign/guards.ts
+++ b/packages/fabrika-cli/src/campaign/guards.ts
@@ -184,10 +184,15 @@ export const runTrace = (request: TraceRequest): CampaignEffect<Trace> =>
 			outcome: refuse(code, `${verb}: ${reason} — ${NOTHING}`),
 		});
 		// The UNKNOWN family reads "— authority is UNKNOWN, NOTHING was written." on one dash: a
-		// second em dash before the disclosure would split one sentence into two claims.
+		// second em dash before the disclosure would split one sentence into two claims. A reason
+		// that already spent its dash carries its own terminator (the team-typo arm ends "— fix the
+		// key;"), and this joins onto it rather than adding a second dash.
 		const unreadable = (reason: string): Trace => ({
 			_tag: "Refused",
-			outcome: refuse(AUTHORITY_UNKNOWN, `${verb}: ${reason} — authority is UNKNOWN, ${NOTHING}`),
+			outcome: refuse(
+				AUTHORITY_UNKNOWN,
+				`${verb}: ${reason}${reason.endsWith(";") ? "" : " —"} authority is UNKNOWN, ${NOTHING}`,
+			),
 		});
 
 		const key = yield* readKey(request.cwd, campaignAuthorsKey);
@@ -243,10 +248,15 @@ export const runTrace = (request: TraceRequest): CampaignEffect<Trace> =>
 			return unreadable(acl.reason);
 		}
 		if (acl._tag === "BelowFloor") {
-			return no(
-				BELOW_WRITE_FLOOR,
-				`${url} was authored by @${login}, who resolves to ${acl.level ?? "no collaboration"} on ${request.repo}, below write — authority is the ACL's, never ${CONFIG_PATH}'s alone (ADR 0055)`,
-			);
+			// Composed past `no()`: this line spends its em dash on the ADR clause, so the disclosure
+			// starts a second sentence instead of hanging off a second dash.
+			return {
+				_tag: "Refused",
+				outcome: refuse(
+					BELOW_WRITE_FLOOR,
+					`${verb}: ${url} was authored by @${login}, who resolves to ${acl.level ?? "no collaboration"} on ${request.repo}, below write — authority is the ACL's, never ${CONFIG_PATH}'s alone (ADR 0055). ${NOTHING}`,
+				),
+			};
 		}
 		return {_tag: "Approved", login, level: acl.level, declared};
 	});

--- a/packages/fabrika-cli/src/campaign/list-verb.ts
+++ b/packages/fabrika-cli/src/campaign/list-verb.ts
@@ -1,0 +1,55 @@
+/**
+ * `campaign list` — the `## Campaigns` rows, parsed, optionally narrowed to one state.
+ *
+ * **Zero rows is a fact at exit `0`, not ADR 0092's red.** An absent table and an empty one are one
+ * well-formed default: nothing declared means the dispatch fence is off, not closed (founder ruling
+ * on #5011, carried onto this surface by ADR 0304). A judging verb would refuse here; this one
+ * supplies an input, and its empty answer is true.
+ *
+ * **`none` means no row survived, never "nothing is active".** A table whose every row is `paused`
+ * prints those rows — someone opened each one and the file says so. The dispatch question is
+ * `--state active`, and only there does such a table answer `none`.
+ */
+
+import {Effect} from "effect";
+import {CAMPAIGN_STATES} from "../build/scope-admission.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {type FileEffect, locateRoadmap, readRoadmap} from "./guards.ts";
+import {rowLine} from "./table.ts";
+
+export interface ListOptions {
+	readonly state: string | null;
+	readonly file: string | null;
+	readonly json: boolean;
+	readonly cwd: string;
+}
+
+const VERB = "campaign list";
+
+export const runList = (options: ListOptions): FileEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const narrowing = options.state;
+		if (narrowing !== null && !CAMPAIGN_STATES.some((legal) => legal === narrowing)) {
+			return refuse(
+				FAILED,
+				`${VERB}: --state "${narrowing}" is not one of ${CAMPAIGN_STATES.join(", ")}.`,
+			);
+		}
+
+		const located = yield* locateRoadmap(VERB, options.cwd, options.file);
+		if (located._tag === "Refused") return located.outcome;
+		const {display} = located.located;
+
+		const read = yield* readRoadmap(VERB, located.located, "nothing was parsed");
+		if (read._tag === "Refused") return read.outcome;
+
+		const all = read.rows;
+		const rows = narrowing === null ? all : all.filter((row) => row.state === narrowing);
+		const active = all.filter((row) => row.state === "active").length;
+
+		const scope = `${VERB}: read ${display} — ${all.length} campaign row(s), ${active} active; printed ${rows.length}.`;
+		if (options.json) {
+			return answer(`${JSON.stringify({rows, file: display})}\n`, [scope]);
+		}
+		return answer(rows.length === 0 ? "none\n" : `${rows.map(rowLine).join("\n")}\n`, [scope]);
+	});

--- a/packages/fabrika-cli/src/campaign/list-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/list-verb.unit.test.ts
@@ -1,0 +1,101 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
+import {FILE, ROADMAP_PATH, ROOT, TWO_ROWS, tree} from "./fixtures.test-support.ts";
+import {runList} from "./list-verb.ts";
+
+const run = (
+	fs: FakeFsOptions,
+	options: {state?: string; json?: boolean; file?: string | null} = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runList({
+				state: options.state ?? null,
+				file: options.file === undefined ? FILE : options.file,
+				json: options.json ?? false,
+				cwd: ROOT,
+			}),
+			fakeFs(fs).layer,
+		),
+	);
+
+describe("campaign list", () => {
+	it("prints every row in table order", async () => {
+		const outcome = await run(tree());
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(
+			"#42\tpaused\tTaste-Skill Library\n#47\tactive\tfabrika everywhere\n",
+		);
+	});
+
+	it("counts the whole table on the scope line even under --state", async () => {
+		const outcome = await run(tree(), {state: "active"});
+		expect(outcome.stdout).toBe("#47\tactive\tfabrika everywhere\n");
+		expect(outcome.stderr[0]).toContain("2 campaign row(s), 1 active; printed 1.");
+	});
+
+	it("answers none at exit 0 when a --state matches nothing", async () => {
+		const outcome = await run(tree(), {state: "done"});
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("none\n");
+	});
+
+	it("answers none at exit 0 for an absent table — nothing declared is a fact, not a red", async () => {
+		const outcome = await run(tree("# Roadmap\n\nnothing yet.\n"));
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("none\n");
+	});
+
+	it("prints an all-paused table's rows rather than calling it none", async () => {
+		const outcome = await run(tree(TWO_ROWS.replace("| active |", "| paused |")));
+		expect(outcome.stdout.split("\n").filter((line) => line !== "")).toHaveLength(2);
+	});
+
+	it("emits the documented object under --json, with rows [] for the none case", async () => {
+		expect(JSON.parse((await run(tree(), {json: true})).stdout)).toEqual({
+			rows: [
+				{milestone: 42, state: "paused", name: "Taste-Skill Library"},
+				{milestone: 47, state: "active", name: "fabrika everywhere"},
+			],
+			file: FILE,
+		});
+		expect(JSON.parse((await run(tree(), {json: true, state: "done"})).stdout)).toEqual({
+			rows: [],
+			file: FILE,
+		});
+	});
+
+	it("refuses a --state outside the three values as a usage error", async () => {
+		const outcome = await run(tree(), {state: "archived"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign list: --state "archived" is not one of active, paused, done.',
+		);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses an unreadable roadmap on 11 with nothing parsed", async () => {
+		const outcome = await run({files: {[ROADMAP_PATH]: TWO_ROWS}, unreadable: [ROADMAP_PATH]});
+		expect(outcome.code).toBe(11);
+		expect(outcome.stderr.at(-1)).toContain("UNKNOWN, nothing was parsed.");
+	});
+
+	it("refuses one unreadable row as the whole table on 12", async () => {
+		const outcome = await run(tree(TWO_ROWS.replace("| #42 |", "| (was #42) |")));
+		expect(outcome.code).toBe(12);
+		expect(outcome.stderr.at(-1)).toContain(
+			"the whole ## Campaigns table is unreadable (ADR 0304).",
+		);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses on 22 when roadmapFile will not decode, opening no file at all", async () => {
+		const outcome = await run(
+			{files: {[ROADMAP_PATH]: TWO_ROWS, [`${ROOT}/.fabrika.jsonc`]: '{"roadmapFile": 7}'}},
+			{file: null},
+		);
+		expect(outcome.code).toBe(22);
+		expect(outcome.stderr.at(-1)).toContain("no roadmap file was opened.");
+	});
+});

--- a/packages/fabrika-cli/src/campaign/marker.ts
+++ b/packages/fabrika-cli/src/campaign/marker.ts
@@ -1,0 +1,114 @@
+/**
+ * The `campaign-approve:` marker — the only thing `--cites` proves about a comment's text.
+ *
+ *     campaign-approve: #47 active · 2026-08-20T04:11:09Z
+ *
+ * Anchored to the comment's **first line**, split off rather than matched whole. v1 required the
+ * whole body to *be* the marker, so a founder who wrote their approval and then explained it read as
+ * malformed (#3831); splitting closes the inverse at the same time, since a marker quoted mid-body
+ * inside somebody else's comment is a quotation, never a grant.
+ *
+ * **The timestamp is compared to nothing** — no staleness window, no ordering, no binding against
+ * the comment's own `created_at`. It is evidence a human reader dates the ruling by, and its only
+ * mechanical job is to make the marker a deliberate line rather than a phrase typed in passing.
+ * Stated because a validated input with no stated effect is where one implementer adds a freshness
+ * rule and another does not (ADR 0247).
+ */
+
+import type {CampaignState} from "../build/scope-admission.ts";
+
+const MARKER =
+	/^\s*\*{0,2}\s*campaign-approve:\s*#(?<milestone>\d+)\s+(?<state>active|paused|done)\s*·\s*(?<ts>\S+?)\s*\*{0,2}\s*$/i;
+
+const ISO_UTC = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?Z$/;
+
+/**
+ * Whether `ts` is both regex-shaped and a real instant.
+ *
+ * `Date.parse` alone does not answer this: the ECMAScript Date Time String Format admits any `DD` in
+ * `01`-`31`, and `MakeDay` then rolls the overflow forward — so `2026-02-30T00:00:00Z` parses to a
+ * finite number naming March 2 (ECMA-262 §21.4.1.12 / §21.4.3.2). Reading the fields back off the
+ * parsed instant is what catches the roll.
+ */
+const isInstant = (ts: string): boolean => {
+	const shaped = ISO_UTC.exec(ts);
+	if (shaped === null) return false;
+	const at = Date.parse(ts);
+	if (!Number.isFinite(at)) return false;
+	const parsed = new Date(at);
+	const fields = [
+		parsed.getUTCFullYear(),
+		parsed.getUTCMonth() + 1,
+		parsed.getUTCDate(),
+		parsed.getUTCHours(),
+		parsed.getUTCMinutes(),
+		parsed.getUTCSeconds(),
+	];
+	return fields.every((field, index) => field === Number(shaped[index + 1]));
+};
+
+/** The canonical spelling, quoted in the refusals that ask for one. */
+export const MARKER_GRAMMAR = "campaign-approve: #<milestone> <state> · <ISO-8601 UTC timestamp>";
+
+export interface Marker {
+	readonly milestone: number;
+	readonly state: CampaignState;
+	readonly at: string;
+}
+
+export type MarkerRead =
+	/** The first line reaches for no marker at all — the caller's `14`. */
+	| {readonly _tag: "Absent"}
+	/** A marker was reached for and does not hold up — the caller's `15`. */
+	| {readonly _tag: "Malformed"; readonly reason: string}
+	| {readonly _tag: "Marker"; readonly marker: Marker};
+
+const REACHES = /^\s*\*{0,2}\s*campaign-approve:/i;
+
+/**
+ * Read the marker off a comment body's first line.
+ *
+ * `Absent` and `Malformed` are two answers because their remedies are opposite: a comment that never
+ * reached for a marker needs one written, and a comment that reached and missed needs the line it
+ * already has fixed.
+ */
+export const readMarker = (body: string): MarkerRead => {
+	const first = body.split(/\r?\n/)[0] ?? "";
+	const match = MARKER.exec(first);
+	if (match?.groups === undefined) {
+		return REACHES.test(first)
+			? {_tag: "Malformed", reason: `"${first.trim()}" is not \`${MARKER_GRAMMAR}\``}
+			: {_tag: "Absent"};
+	}
+	const {milestone, state, ts} = match.groups;
+	if (ts === undefined || !isInstant(ts)) {
+		return {
+			_tag: "Malformed",
+			reason: `"${ts ?? ""}" is not an ISO-8601 UTC timestamp — the grammar is YYYY-MM-DDTHH:MM:SSZ`,
+		};
+	}
+	return {
+		_tag: "Marker",
+		marker: {
+			milestone: Number.parseInt(milestone ?? "", 10),
+			state: (state ?? "").toLowerCase() as CampaignState,
+			at: ts,
+		},
+	};
+};
+
+/**
+ * Whether the marker authorizes **this** write: the row's milestone, and the state the write
+ * produces.
+ *
+ * An approval of one campaign never authorizes another, and an approval to pause never authorizes a
+ * start. Returns the refusal reason, or `null` when the marker binds.
+ */
+export const bindingMiss = (
+	marker: Marker,
+	milestone: number,
+	state: CampaignState,
+): string | null =>
+	marker.milestone === milestone && marker.state === state
+		? null
+		: `approves #${marker.milestone} ${marker.state}, not #${milestone} ${state}`;

--- a/packages/fabrika-cli/src/campaign/marker.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/marker.unit.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, it} from "vitest";
+import {bindingMiss, readMarker} from "./marker.ts";
+
+const AT = "2026-08-20T04:11:09Z";
+
+describe("readMarker", () => {
+	it("reads the marker off a comment whose first line carries it", () => {
+		const read = readMarker(`campaign-approve: #47 active · ${AT}`);
+		expect(read).toEqual({_tag: "Marker", marker: {milestone: 47, state: "active", at: AT}});
+	});
+
+	it("tolerates emphasis at both ends and a capitalised keyword", () => {
+		const read = readMarker(`**Campaign-Approve: #47 paused · ${AT}**`);
+		expect(read._tag).toBe("Marker");
+	});
+
+	it("reads only the first line, so an approval carrying its rationale still parses (#3831)", () => {
+		const read = readMarker(`campaign-approve: #47 done · ${AT}\n\nBecause the arc is finished.`);
+		expect(read).toEqual({_tag: "Marker", marker: {milestone: 47, state: "done", at: AT}});
+	});
+
+	it("reads a marker quoted below somebody else's opening line as no marker at all", () => {
+		expect(readMarker(`I agree with this:\n\ncampaign-approve: #47 active · ${AT}`)).toEqual({
+			_tag: "Absent",
+		});
+	});
+
+	it("splits on CRLF too, so a comment written on Windows is not one long first line", () => {
+		expect(readMarker(`campaign-approve: #47 active · ${AT}\r\nrationale`)._tag).toBe("Marker");
+	});
+
+	it("calls a comment that never reached for a marker absent, not malformed", () => {
+		expect(readMarker("Ship it.")).toEqual({_tag: "Absent"});
+	});
+
+	it("calls a line that reached for the marker and missed malformed", () => {
+		const read = readMarker("campaign-approve: #47 activ · nope");
+		expect(read._tag).toBe("Malformed");
+	});
+
+	it("refuses a state outside the three", () => {
+		expect(readMarker(`campaign-approve: #47 archived · ${AT}`)._tag).toBe("Malformed");
+	});
+
+	it("refuses a timestamp that is regex-shaped and calendar-invalid", () => {
+		const read = readMarker("campaign-approve: #47 active · 2026-02-30T00:00:00Z");
+		expect(read._tag).toBe("Malformed");
+	});
+
+	it("refuses a timestamp carrying an offset instead of Z", () => {
+		expect(readMarker("campaign-approve: #47 active · 2026-08-20T04:11:09+00:00")._tag).toBe(
+			"Malformed",
+		);
+	});
+
+	it("accepts fractional seconds, which the grammar allows", () => {
+		expect(readMarker("campaign-approve: #47 active · 2026-08-20T04:11:09.500Z")._tag).toBe(
+			"Marker",
+		);
+	});
+
+	it("refuses a hyphen separator — the separator is the middle dot", () => {
+		expect(readMarker(`campaign-approve: #47 active - ${AT}`)._tag).toBe("Malformed");
+	});
+});
+
+describe("bindingMiss", () => {
+	const marker = {milestone: 47, state: "active"} as const;
+
+	it("binds when both the milestone and the state match the write", () => {
+		expect(bindingMiss({...marker, at: AT}, 47, "active")).toBeNull();
+	});
+
+	it("refuses an approval of another campaign", () => {
+		expect(bindingMiss({...marker, at: AT}, 52, "active")).toBe(
+			"approves #47 active, not #52 active",
+		);
+	});
+
+	it("refuses an approval to pause as authority for a start", () => {
+		expect(bindingMiss({milestone: 47, state: "paused", at: AT}, 47, "active")).toBe(
+			"approves #47 paused, not #47 active",
+		);
+	});
+});

--- a/packages/fabrika-cli/src/campaign/open-verb.ts
+++ b/packages/fabrika-cli/src/campaign/open-verb.ts
@@ -37,9 +37,16 @@ const NOTHING = "NOTHING was written.";
 
 export const runOpen = (options: OpenOptions): CampaignEffect<VerbOutcome> =>
 	Effect.gen(function* () {
-		const {name, milestone} = options;
+		const {milestone} = options;
+		// Trimmed once, here, so the name the duplicate check compares is the name the row is written
+		// with and the name it reads back as — cells arrive trimmed from the parse, so an untrimmed
+		// one clears the check and appends a second row nothing can select afterwards.
+		const name = options.name.trim();
 		if (!Number.isInteger(milestone) || milestone <= 0) {
 			return refuse(FAILED, `${VERB}: --milestone must be a positive integer, got "${milestone}".`);
+		}
+		if (name === "") {
+			return refuse(FAILED, `${VERB}: --name is required.`);
 		}
 		if (!nameFitsCell(name)) {
 			return refuse(

--- a/packages/fabrika-cli/src/campaign/open-verb.ts
+++ b/packages/fabrika-cli/src/campaign/open-verb.ts
@@ -1,0 +1,131 @@
+/**
+ * `campaign open` — append a new `paused` row pinning a milestone, past the approval trace.
+ *
+ * **The state is always `paused` and there is no flag to change it.** A row that could be written
+ * `active` would grant dispatch in the same stroke that names the campaign, which is exactly what
+ * ADR 0304 separated into two acts. Flipping it is `campaign state`'s, and it demands its own
+ * citation.
+ *
+ * Nothing here checks that the milestone exists, is open, or is in sync with the board:
+ * `guard roadmap-guard check` owns I1-I5, and a second answer to a merge-gating question is worse
+ * than no answer at all (ADR 0238).
+ */
+
+import {Effect} from "effect";
+import type {CampaignRow} from "../build/scope-admission.ts";
+import {writeFile} from "../io/fs.ts";
+import {resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {CITATION_GRAMMAR, readCitation} from "./citation.ts";
+import {AUTHORITY_UNKNOWN, DUPLICATE_ROW, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {type CampaignEffect, locateRoadmap, readRoadmap, runTrace} from "./guards.ts";
+import {appendRow, nameFitsCell, rowLine} from "./table.ts";
+
+export interface OpenOptions {
+	readonly name: string;
+	readonly milestone: number;
+	readonly cites: string;
+	readonly file: string | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly cwd: string;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "campaign open";
+const NOTHING = "NOTHING was written.";
+
+export const runOpen = (options: OpenOptions): CampaignEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const {name, milestone} = options;
+		if (!Number.isInteger(milestone) || milestone <= 0) {
+			return refuse(FAILED, `${VERB}: --milestone must be a positive integer, got "${milestone}".`);
+		}
+		if (!nameFitsCell(name)) {
+			return refuse(
+				FAILED,
+				`${VERB}: ${name} holds "|" or a newline — a campaign name must fit one table cell.`,
+			);
+		}
+
+		const resolved = yield* resolveRepo(options.repo, options.env);
+		if (resolved._tag === "Failure") {
+			return refuse(
+				AUTHORITY_UNKNOWN,
+				`${VERB}: no --repo, no CLAUDE_PIPELINE_REPO, no GITHUB_REPOSITORY and no readable origin remote — the citation cannot be bound to a repository. ${NOTHING}`,
+			);
+		}
+		const repo = resolved.value;
+
+		const citation = readCitation(options.cites);
+		if (citation === null) {
+			return refuse(
+				FAILED,
+				`${VERB}: --cites "${options.cites}" is not a comment URL in ${repo} — expected ${CITATION_GRAMMAR}.`,
+			);
+		}
+
+		const located = yield* locateRoadmap(VERB, options.cwd, options.file);
+		if (located._tag === "Refused") return located.outcome;
+		const {display, path} = located.located;
+
+		const read = yield* readRoadmap(VERB, located.located, "nothing was written");
+		if (read._tag === "Refused") return read.outcome;
+
+		const byName = read.rows.find((row) => row.name === name);
+		if (byName !== undefined) {
+			return refuse(
+				DUPLICATE_ROW,
+				`${VERB}: ${display} already holds "${name}" at #${byName.milestone} — ${NOTHING}`,
+			);
+		}
+		const byPin = read.rows.find((row) => row.milestone === milestone);
+		if (byPin !== undefined) {
+			return refuse(
+				DUPLICATE_ROW,
+				`${VERB}: ${display} already pins #${milestone} to "${byPin.name}" — ${NOTHING}`,
+			);
+		}
+
+		const trace = yield* runTrace({
+			verb: VERB,
+			cwd: options.cwd,
+			repo,
+			url: citation.url,
+			urlRepo: citation.repo,
+			commentId: citation.commentId,
+			milestone,
+			state: "paused",
+			act: "declare",
+		});
+		if (trace._tag === "Refused") return trace.outcome;
+
+		const written = yield* writeFile(path, appendRow(read.text, name, milestone)).pipe(
+			Effect.as<VerbOutcome | null>(null),
+			Effect.catchTag("fabrika-cli/WriteFailed", (failure) =>
+				Effect.succeed<VerbOutcome | null>(
+					refuse(
+						WRITE_UNKNOWN,
+						`${VERB}: cannot write ${display}: ${failure.reason} — UNKNOWN, the table may be half-written; re-read it.`,
+					),
+				),
+			),
+		);
+		if (written !== null) return written;
+
+		const back = yield* readRoadmap(VERB, located.located, "nothing was written");
+		if (back._tag === "Refused") return back.outcome;
+		const landed = back.rows.find((row) => row.milestone === milestone);
+		if (landed === undefined) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${display} but the read-back holds no row for #${milestone} — the write landed and the file does not say so; re-read it before retrying.`,
+			);
+		}
+
+		const notice = `${VERB}: cited ${citation.url} by @${trace.login} (campaignAuthors: ${trace.declared}; ${trace.level} on ${repo}); appended "${name}" #${milestone} paused to ${display} — dispatches nothing until it is flipped to active.`;
+		return answer(rendered(landed, display, options.json), [notice]);
+	});
+
+const rendered = (row: CampaignRow, file: string, json: boolean): string =>
+	json ? `${JSON.stringify({row, file})}\n` : `${rowLine(row)}\n`;

--- a/packages/fabrika-cli/src/campaign/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/open-verb.unit.test.ts
@@ -102,6 +102,13 @@ describe("campaign open — usage refusals", () => {
 		expect(outcome.stderr.at(-1)).toContain("must fit one table cell");
 	});
 
+	it("refuses a name that is only whitespace, which would append a cell nothing can read", async () => {
+		const {outcome, written} = await run(APPROVED, tree(), {name: "   "});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toBe("campaign open: --name is required.");
+		expect(written.size).toBe(0);
+	});
+
 	it("refuses a --cites that is not a comment URL", async () => {
 		const {outcome} = await run(APPROVED, tree(), {cites: "https://github.com/o/r/issues/6289"});
 		expect(outcome.code).toBe(1);
@@ -124,6 +131,14 @@ describe("campaign open — the duplicate check runs before the trace", () => {
 			'campaign open: ROADMAP.md already holds "fabrika everywhere" at #47 — NOTHING was written.',
 		);
 		expect(requests).toEqual([]);
+	});
+
+	it("refuses a padded spelling of a name already on the table, which reads back the same", async () => {
+		const {outcome} = await run(APPROVED, tree(), {name: "  fabrika everywhere  "});
+		expect(outcome.code).toBe(19);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign open: ROADMAP.md already holds "fabrika everywhere" at #47 — NOTHING was written.',
+		);
 	});
 
 	it("refuses a milestone already pinned on 19", async () => {
@@ -186,7 +201,9 @@ describe("campaign open — the approval trace", () => {
 			[PERMISSION, permission("read")],
 		]);
 		expect(outcome.code).toBe(21);
-		expect(outcome.stderr.at(-1)).toContain("who resolves to read on o/r, below write");
+		expect(outcome.stderr.at(-1)).toBe(
+			`campaign open: ${CITES} was authored by @usirin, who resolves to read on o/r, below write — authority is the ACL's, never .fabrika.jsonc's alone (ADR 0055). NOTHING was written.`,
+		);
 		expect(written.size).toBe(0);
 	});
 
@@ -214,7 +231,9 @@ describe("campaign open — the approval trace", () => {
 			tree(TWO_ROWS, config("@kamp-us/founders")),
 		);
 		expect(outcome.code).toBe(13);
-		expect(outcome.stderr.at(-1)).toContain("which kamp-us does not have — fix the key");
+		expect(outcome.stderr.at(-1)).toBe(
+			"campaign open: campaignAuthors names @kamp-us/founders, which kamp-us does not have — fix the key; authority is UNKNOWN, NOTHING was written.",
+		);
 	});
 
 	it("reads a 404 membership on a real team as a proven miss, which is 16", async () => {

--- a/packages/fabrika-cli/src/campaign/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/open-verb.unit.test.ts
@@ -1,0 +1,251 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {parseCampaigns} from "../build/scope-admission.ts";
+import type {FakeFsOptions, Scripted} from "../fakes.test-support.ts";
+import {
+	approving,
+	CITES,
+	comment,
+	config,
+	env,
+	FILE,
+	GET_COMMENT,
+	MEMBERSHIP,
+	marker,
+	PERMISSION,
+	permission,
+	ROADMAP_PATH,
+	ROOT,
+	seams,
+	TEAM,
+	TWO_ROWS,
+	tree,
+} from "./fixtures.test-support.ts";
+import {runOpen} from "./open-verb.ts";
+
+const NEW = "Mecmua reading layout";
+
+const run = (
+	script: ReadonlyArray<Scripted>,
+	fs: FakeFsOptions = tree(),
+	options: {name?: string; milestone?: number; cites?: string; json?: boolean} = {},
+) => {
+	const io = seams(script, fs);
+	return Effect.runPromise(
+		Effect.provide(
+			runOpen({
+				name: options.name ?? NEW,
+				milestone: options.milestone ?? 52,
+				cites: options.cites ?? CITES,
+				file: FILE,
+				repo: null,
+				json: options.json ?? false,
+				cwd: ROOT,
+				env,
+			}),
+			io.layer,
+		),
+	).then((outcome) => ({outcome, written: io.written, requests: io.requests}));
+};
+
+const APPROVED = approving(52, "paused");
+
+describe("campaign open — the answer", () => {
+	it("appends a paused row and prints it back", async () => {
+		const {outcome, written} = await run(APPROVED);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`#52\tpaused\t${NEW}\n`);
+		const landed = parseCampaigns(written.get(ROADMAP_PATH) ?? "");
+		expect(landed._tag === "Rows" ? landed.rows.at(-1) : null).toEqual({
+			milestone: 52,
+			state: "paused",
+			name: NEW,
+		});
+	});
+
+	it("names the citation, the declared set and the ACL level on the scope line", async () => {
+		const {outcome} = await run(APPROVED);
+		expect(outcome.stderr.at(-1)).toBe(
+			`campaign open: cited ${CITES} by @usirin (campaignAuthors: @usirin; write on o/r); appended "${NEW}" #52 paused to ROADMAP.md — dispatches nothing until it is flipped to active.`,
+		);
+	});
+
+	it("emits the documented object under --json", async () => {
+		const {outcome} = await run(APPROVED, tree(), {json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			row: {milestone: 52, state: "paused", name: NEW},
+			file: FILE,
+		});
+	});
+
+	it("admits an author reached through a team entry", async () => {
+		const {outcome} = await run(
+			[...APPROVED, [MEMBERSHIP, {status: 200, body: '{"state":"active"}'}]],
+			tree(TWO_ROWS, config("@kamp-us/founders")),
+		);
+		expect(outcome.code).toBe(0);
+	});
+});
+
+describe("campaign open — usage refusals", () => {
+	it("refuses a --milestone that is not a positive integer", async () => {
+		const {outcome} = await run(APPROVED, tree(), {milestone: 0});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign open: --milestone must be a positive integer, got "0".',
+		);
+	});
+
+	it("refuses a name that cannot fit one table cell", async () => {
+		const {outcome} = await run(APPROVED, tree(), {name: "a | b"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toContain("must fit one table cell");
+	});
+
+	it("refuses a --cites that is not a comment URL", async () => {
+		const {outcome} = await run(APPROVED, tree(), {cites: "https://github.com/o/r/issues/6289"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toContain("is not a comment URL in o/r");
+	});
+
+	it("accepts a pull-request comment URL, which is the same artifact", async () => {
+		const {outcome} = await run(APPROVED, tree(), {
+			cites: CITES.replace("/issues/", "/pull/"),
+		});
+		expect(outcome.code).toBe(0);
+	});
+});
+
+describe("campaign open — the duplicate check runs before the trace", () => {
+	it("refuses a name already on the table on 19, reading no comment at all", async () => {
+		const {outcome, requests} = await run(APPROVED, tree(), {name: "fabrika everywhere"});
+		expect(outcome.code).toBe(19);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign open: ROADMAP.md already holds "fabrika everywhere" at #47 — NOTHING was written.',
+		);
+		expect(requests).toEqual([]);
+	});
+
+	it("refuses a milestone already pinned on 19", async () => {
+		const {outcome} = await run(APPROVED, tree(), {milestone: 47});
+		expect(outcome.code).toBe(19);
+		expect(outcome.stderr.at(-1)).toContain('already pins #47 to "fabrika everywhere"');
+	});
+});
+
+describe("campaign open — the approval trace", () => {
+	it("refuses an empty campaignAuthors on 17 before reading anything", async () => {
+		const {outcome, requests} = await run(APPROVED, tree(TWO_ROWS, config()));
+		expect(outcome.code).toBe(17);
+		expect(outcome.stderr.at(-1)).toContain("nobody may declare a campaign in this repo");
+		expect(requests).toEqual([]);
+	});
+
+	it("refuses a citation in another repository on 15", async () => {
+		const {outcome} = await run(APPROVED, tree(), {
+			cites: CITES.replace("github.com/o/r", "github.com/o/other"),
+		});
+		expect(outcome.code).toBe(15);
+		expect(outcome.stderr.at(-1)).toContain("is a comment in o/other, not o/r");
+	});
+
+	it("refuses an unreachable comment on 13, writing nothing", async () => {
+		const {outcome, written} = await run([[GET_COMMENT, {status: 500, body: "{}"}]]);
+		expect(outcome.code).toBe(13);
+		expect(outcome.stderr.at(-1)).toContain("authority is UNKNOWN, NOTHING was written.");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses an author outside campaignAuthors on 16, ahead of any marker check", async () => {
+		const {outcome} = await run([[GET_COMMENT, comment("no marker here", "stranger")]]);
+		expect(outcome.code).toBe(16);
+		expect(outcome.stderr.at(-1)).toContain("who is not in campaignAuthors (@usirin)");
+	});
+
+	it("refuses a comment with no marker on its first line on 14", async () => {
+		const {outcome} = await run([[GET_COMMENT, comment("Looks good to me.")]]);
+		expect(outcome.code).toBe(14);
+		expect(outcome.stderr.at(-1)).toContain("has no campaign-approve: marker on its first line");
+	});
+
+	it("refuses a marker that names another milestone on 15", async () => {
+		const {outcome} = await run([[GET_COMMENT, comment(marker(47, "paused"))]]);
+		expect(outcome.code).toBe(15);
+		expect(outcome.stderr.at(-1)).toContain("approves #47 paused, not #52 paused");
+	});
+
+	it("refuses a marker approving a start as authority for a declaration on 15", async () => {
+		const {outcome} = await run([[GET_COMMENT, comment(marker(52, "active"))]]);
+		expect(outcome.code).toBe(15);
+		expect(outcome.stderr.at(-1)).toContain("approves #52 active, not #52 paused");
+	});
+
+	it("refuses a declared author below the write floor on 21 (ADR 0055)", async () => {
+		const {outcome, written} = await run([
+			[GET_COMMENT, comment(marker(52, "paused"))],
+			[PERMISSION, permission("read")],
+		]);
+		expect(outcome.code).toBe(21);
+		expect(outcome.stderr.at(-1)).toContain("who resolves to read on o/r, below write");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a declared author with no collaboration on 21, naming that instead of a level", async () => {
+		const {outcome} = await run([
+			[GET_COMMENT, comment(marker(52, "paused"))],
+			[PERMISSION, {status: 404, body: "{}"}],
+		]);
+		expect(outcome.code).toBe(21);
+		expect(outcome.stderr.at(-1)).toContain("resolves to no collaboration on o/r");
+	});
+
+	it("refuses an unreadable permission on 13 rather than reading it as below the floor", async () => {
+		const {outcome} = await run([
+			[GET_COMMENT, comment(marker(52, "paused"))],
+			[PERMISSION, {status: 500, body: "{}"}],
+		]);
+		expect(outcome.code).toBe(13);
+		expect(outcome.stderr.at(-1)).toContain("cannot resolve @usirin's permission on o/r");
+	});
+
+	it("refuses a campaignAuthors team the org does not have on 13, pointing at the key", async () => {
+		const {outcome} = await run(
+			[...APPROVED, [MEMBERSHIP, {status: 404, body: "{}"}], [TEAM, {status: 404, body: "{}"}]],
+			tree(TWO_ROWS, config("@kamp-us/founders")),
+		);
+		expect(outcome.code).toBe(13);
+		expect(outcome.stderr.at(-1)).toContain("which kamp-us does not have — fix the key");
+	});
+
+	it("reads a 404 membership on a real team as a proven miss, which is 16", async () => {
+		const {outcome} = await run(
+			[
+				...APPROVED,
+				[MEMBERSHIP, {status: 404, body: "{}"}],
+				[TEAM, {status: 200, body: '{"slug":"founders"}'}],
+			],
+			tree(TWO_ROWS, config("@kamp-us/founders")),
+		);
+		expect(outcome.code).toBe(16);
+	});
+});
+
+describe("campaign open — the write and its read-back", () => {
+	it("refuses a failed write on 8, saying the table may be half-written", async () => {
+		const {outcome} = await run(APPROVED, {
+			...tree(),
+			unwritable: [ROADMAP_PATH],
+		});
+		expect(outcome.code).toBe(8);
+		expect(outcome.stderr.at(-1)).toContain("the table may be half-written; re-read it.");
+	});
+
+	it("refuses an unreadable roadmap on 11, saying nothing was written", async () => {
+		const {outcome} = await run(APPROVED, {
+			files: {[ROADMAP_PATH]: TWO_ROWS, [`${ROOT}/.fabrika.jsonc`]: config("@usirin")},
+			unreadable: [ROADMAP_PATH],
+		});
+		expect(outcome.code).toBe(11);
+		expect(outcome.stderr.at(-1)).toContain("UNKNOWN, nothing was written.");
+	});
+});

--- a/packages/fabrika-cli/src/campaign/state-verb.ts
+++ b/packages/fabrika-cli/src/campaign/state-verb.ts
@@ -23,6 +23,7 @@ import {
 	AMBIGUOUS_SELECTOR,
 	AUTHORITY_UNKNOWN,
 	NO_TARGET,
+	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
@@ -119,9 +120,11 @@ export const runState = (options: StateOptions): CampaignEffect<VerbOutcome> =>
 
 		const next = rewriteState(read.text, target.line, to);
 		if (next === null) {
+			// Nothing has been written at this point, so this cannot be an `8`: seating an untouched
+			// file as a possibly half-written one sends the operator to repair bytes nobody moved.
 			return refuse(
-				WRITE_UNKNOWN,
-				`${VERB}: cannot write ${display}: row ${target.line + 1} does not carry three cells between four pipes — UNKNOWN, the row may be half-written; re-read it.`,
+				PRECONDITION_UNKNOWN,
+				`${VERB}: row ${target.line + 1} of ${display} reads as three cells but does not edit as three — UNKNOWN, nothing was attempted; re-read the row. ${NOTHING}`,
 			);
 		}
 		const written = yield* writeFile(path, next).pipe(

--- a/packages/fabrika-cli/src/campaign/state-verb.ts
+++ b/packages/fabrika-cli/src/campaign/state-verb.ts
@@ -1,0 +1,158 @@
+/**
+ * `campaign state` — rewrite one row's `State` cell, past the approval trace.
+ *
+ * Selection is exact, never fuzzy, and **two rows matching is `18` rather than a first-wins pick**: a
+ * lifecycle flip aimed at the wrong campaign grants dispatch on a milestone nobody named.
+ *
+ * **`20` is a refusal and not a quiet `0`.** A flip to `active` is the grant of dispatch permission,
+ * so a caller who reads "done" over a cell nobody moved cannot tell a grant they made from a grant
+ * somebody else made first.
+ *
+ * Whether the milestone should be closed alongside a flip to `done` is `roadmap-guard`'s I5 and is
+ * not repeated here (ADR 0238).
+ */
+
+import {Effect} from "effect";
+import {CAMPAIGN_STATES, type CampaignState} from "../build/scope-admission.ts";
+import {writeFile} from "../io/fs.ts";
+import {resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {CITATION_GRAMMAR, readCitation} from "./citation.ts";
+import {
+	ALREADY_IN_STATE,
+	AMBIGUOUS_SELECTOR,
+	AUTHORITY_UNKNOWN,
+	NO_TARGET,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {type CampaignEffect, locateRoadmap, readRoadmap, runTrace} from "./guards.ts";
+import {placedRows, rewriteState, rowLine, selects} from "./table.ts";
+
+export interface StateOptions {
+	readonly selector: string;
+	readonly to: string;
+	readonly cites: string;
+	readonly file: string | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly cwd: string;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "campaign state";
+const NOTHING = "NOTHING was written.";
+
+export const runState = (options: StateOptions): CampaignEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const to = CAMPAIGN_STATES.find((legal) => legal === options.to);
+		if (to === undefined) {
+			return refuse(
+				FAILED,
+				`${VERB}: --to "${options.to}" is not one of ${CAMPAIGN_STATES.join(", ")}.`,
+			);
+		}
+
+		const resolved = yield* resolveRepo(options.repo, options.env);
+		if (resolved._tag === "Failure") {
+			return refuse(
+				AUTHORITY_UNKNOWN,
+				`${VERB}: no --repo, no CLAUDE_PIPELINE_REPO, no GITHUB_REPOSITORY and no readable origin remote — the citation cannot be bound to a repository. ${NOTHING}`,
+			);
+		}
+		const repo = resolved.value;
+
+		const citation = readCitation(options.cites);
+		if (citation === null) {
+			return refuse(
+				FAILED,
+				`${VERB}: --cites "${options.cites}" is not a comment URL in ${repo} — expected ${CITATION_GRAMMAR}.`,
+			);
+		}
+
+		const located = yield* locateRoadmap(VERB, options.cwd, options.file);
+		if (located._tag === "Refused") return located.outcome;
+		const {display, path} = located.located;
+
+		const read = yield* readRoadmap(VERB, located.located, "nothing was written");
+		if (read._tag === "Refused") return read.outcome;
+
+		const placed = placedRows(read.text);
+		// `readRoadmap` already refused the `Malformed` arm, so this only narrows the union.
+		const matched = (placed._tag === "Rows" ? placed.rows : []).filter((row) =>
+			selects(row, options.selector),
+		);
+		const target = matched[0];
+		if (target === undefined) {
+			return refuse(
+				NO_TARGET,
+				`${VERB}: ${display} has no campaign row matching "${options.selector}" — ${NOTHING}`,
+			);
+		}
+		if (matched.length > 1) {
+			const names = matched.map((row) => `"${row.row.name}"`).join(", ");
+			return refuse(
+				AMBIGUOUS_SELECTOR,
+				`${VERB}: "${options.selector}" matches ${matched.length} rows (${names}) — ${NOTHING}`,
+			);
+		}
+		const from: CampaignState = target.row.state;
+		if (from === to) {
+			return refuse(
+				ALREADY_IN_STATE,
+				`${VERB}: "${target.row.name}" #${target.row.milestone} already holds ${to} — ${NOTHING}`,
+			);
+		}
+
+		const trace = yield* runTrace({
+			verb: VERB,
+			cwd: options.cwd,
+			repo,
+			url: citation.url,
+			urlRepo: citation.repo,
+			commentId: citation.commentId,
+			milestone: target.row.milestone,
+			state: to,
+			act: "flip",
+		});
+		if (trace._tag === "Refused") return trace.outcome;
+
+		const next = rewriteState(read.text, target.line, to);
+		if (next === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: cannot write ${display}: row ${target.line + 1} does not carry three cells between four pipes — UNKNOWN, the row may be half-written; re-read it.`,
+			);
+		}
+		const written = yield* writeFile(path, next).pipe(
+			Effect.as<VerbOutcome | null>(null),
+			Effect.catchTag("fabrika-cli/WriteFailed", (failure) =>
+				Effect.succeed<VerbOutcome | null>(
+					refuse(
+						WRITE_UNKNOWN,
+						`${VERB}: cannot write ${display}: ${failure.reason} — UNKNOWN, the row may be half-written; re-read it.`,
+					),
+				),
+			),
+		);
+		if (written !== null) return written;
+
+		const back = yield* readRoadmap(VERB, located.located, "nothing was written");
+		if (back._tag === "Refused") return back.outcome;
+		const landed = back.rows.find((row) => row.milestone === target.row.milestone);
+		if (landed === undefined || landed.state !== to) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${display} but the read-back holds ${landed?.state ?? "no row"} for #${target.row.milestone}, not ${to} — the write landed and the file does not say so; re-read it before retrying.`,
+			);
+		}
+
+		const grant = to === "active" ? ` — lanes may now open against #${landed.milestone}.` : "";
+		const notice = `${VERB}: cited ${citation.url} by @${trace.login} (campaignAuthors: ${trace.declared}; ${trace.level} on ${repo}); "${landed.name}" #${landed.milestone} ${from} → ${to} in ${display}.${grant}`;
+		return answer(
+			options.json
+				? `${JSON.stringify({row: landed, from, file: display})}\n`
+				: `${rowLine(landed)}\n`,
+			[notice],
+		);
+	});

--- a/packages/fabrika-cli/src/campaign/state-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/state-verb.unit.test.ts
@@ -167,4 +167,12 @@ describe("campaign state — the write and its read-back", () => {
 		expect(outcome.code).toBe(12);
 		expect(outcome.stderr.at(-1)).toContain("(ADR 0304). NOTHING was written.");
 	});
+
+	it("flips a row carrying no trailing pipe, which the parse reads and campaign list prints", async () => {
+		const open = TWO_ROWS.replace("| #42 | paused |", "| #42 | paused");
+		const {outcome, written} = await run(APPROVED, tree(open));
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("#42\tactive\tTaste-Skill Library\n");
+		expect(written.get(ROADMAP_PATH)).toContain("| Taste-Skill Library | #42 | active\n");
+	});
 });

--- a/packages/fabrika-cli/src/campaign/state-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/state-verb.unit.test.ts
@@ -1,0 +1,170 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import type {FakeFsOptions, Scripted} from "../fakes.test-support.ts";
+import {
+	approving,
+	CITES,
+	comment,
+	config,
+	env,
+	FILE,
+	GET_COMMENT,
+	marker,
+	PERMISSION,
+	permission,
+	ROADMAP_PATH,
+	ROOT,
+	seams,
+	TWO_ROWS,
+	tree,
+} from "./fixtures.test-support.ts";
+import {runState} from "./state-verb.ts";
+
+const run = (
+	script: ReadonlyArray<Scripted>,
+	fs: FakeFsOptions = tree(),
+	options: {selector?: string; to?: string; json?: boolean} = {},
+) => {
+	const io = seams(script, fs);
+	return Effect.runPromise(
+		Effect.provide(
+			runState({
+				selector: options.selector ?? "#42",
+				to: options.to ?? "active",
+				cites: CITES,
+				file: FILE,
+				repo: null,
+				json: options.json ?? false,
+				cwd: ROOT,
+				env,
+			}),
+			io.layer,
+		),
+	).then((outcome) => ({outcome, written: io.written, requests: io.requests}));
+};
+
+const APPROVED = approving(42, "active");
+
+describe("campaign state — the answer", () => {
+	it("rewrites the selected row's cell and prints it back", async () => {
+		const {outcome, written} = await run(APPROVED);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("#42\tactive\tTaste-Skill Library\n");
+		expect(written.get(ROADMAP_PATH)).toContain("| Taste-Skill Library | #42 | active |");
+	});
+
+	it("leaves every other line byte-identical", async () => {
+		const {written} = await run(APPROVED);
+		const before = TWO_ROWS.split("\n");
+		const after = (written.get(ROADMAP_PATH) ?? "").split("\n");
+		expect(after.filter((line, at) => line !== before[at])).toHaveLength(1);
+	});
+
+	it("says lanes may now open when the flip is to active", async () => {
+		const {outcome} = await run(APPROVED);
+		expect(outcome.stderr.at(-1)).toBe(
+			`campaign state: cited ${CITES} by @usirin (campaignAuthors: @usirin; write on o/r); "Taste-Skill Library" #42 paused → active in ROADMAP.md. — lanes may now open against #42.`,
+		);
+	});
+
+	it("omits that clause on a flip that grants nothing", async () => {
+		const {outcome} = await run(approving(42, "done"), tree(), {to: "done"});
+		expect(outcome.stderr.at(-1)).toContain("paused → done in ROADMAP.md.");
+		expect(outcome.stderr.at(-1)).not.toContain("lanes may now open");
+	});
+
+	it("emits the documented object under --json, carrying the state it came from", async () => {
+		const {outcome} = await run(APPROVED, tree(), {json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			row: {milestone: 42, state: "active", name: "Taste-Skill Library"},
+			from: "paused",
+			file: FILE,
+		});
+	});
+
+	it("selects by exact name as readily as by pin", async () => {
+		const {outcome} = await run(APPROVED, tree(), {selector: "Taste-Skill Library"});
+		expect(outcome.code).toBe(0);
+	});
+});
+
+describe("campaign state — the selector", () => {
+	it("refuses a selector matching no row on 7, reading no comment", async () => {
+		const {outcome, requests} = await run(APPROVED, tree(), {selector: "#999"});
+		expect(outcome.code).toBe(7);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign state: ROADMAP.md has no campaign row matching "#999" — NOTHING was written.',
+		);
+		expect(requests).toEqual([]);
+	});
+
+	it("refuses a selector matching two rows on 18 rather than picking the first", async () => {
+		const twins = TWO_ROWS.replace("| fabrika everywhere |", "| Taste-Skill Library |");
+		const {outcome, written} = await run(approving(42, "active"), tree(twins), {
+			selector: "Taste-Skill Library",
+		});
+		expect(outcome.code).toBe(18);
+		expect(outcome.stderr.at(-1)).toContain("matches 2 rows");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a no-op flip on 20 rather than answering 0 over a cell nobody moved", async () => {
+		const {outcome, written} = await run(APPROVED, tree(), {selector: "#47"});
+		expect(outcome.code).toBe(20);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign state: "fabrika everywhere" #47 already holds active — NOTHING was written.',
+		);
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a --to outside the three values as a usage error", async () => {
+		const {outcome} = await run(APPROVED, tree(), {to: "archived"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toBe(
+			'campaign state: --to "archived" is not one of active, paused, done.',
+		);
+	});
+});
+
+describe("campaign state — the approval trace binds to the selected row", () => {
+	it("refuses a marker approving another campaign on 15", async () => {
+		const {outcome} = await run([[GET_COMMENT, comment(marker(47, "active"))]]);
+		expect(outcome.code).toBe(15);
+		expect(outcome.stderr.at(-1)).toContain("approves #47 active, not #42 active");
+	});
+
+	it("refuses a marker approving another state on 15", async () => {
+		const {outcome} = await run([[GET_COMMENT, comment(marker(42, "done"))]]);
+		expect(outcome.code).toBe(15);
+		expect(outcome.stderr.at(-1)).toContain("approves #42 done, not #42 active");
+	});
+
+	it("refuses an empty campaignAuthors on 17, in this verb's own words", async () => {
+		const {outcome} = await run(APPROVED, tree(TWO_ROWS, config()));
+		expect(outcome.code).toBe(17);
+		expect(outcome.stderr.at(-1)).toContain("nobody may flip a campaign in this repo");
+	});
+
+	it("refuses a declared author below the write floor on 21, writing nothing", async () => {
+		const {outcome, written} = await run([
+			[GET_COMMENT, comment(marker(42, "active"))],
+			[PERMISSION, permission("triage")],
+		]);
+		expect(outcome.code).toBe(21);
+		expect(written.size).toBe(0);
+	});
+});
+
+describe("campaign state — the write and its read-back", () => {
+	it("refuses a failed write on 8, saying the row may be half-written", async () => {
+		const {outcome} = await run(APPROVED, {...tree(), unwritable: [ROADMAP_PATH]});
+		expect(outcome.code).toBe(8);
+		expect(outcome.stderr.at(-1)).toContain("the row may be half-written; re-read it.");
+	});
+
+	it("refuses an unreadable table on 12, saying nothing was written", async () => {
+		const {outcome} = await run(APPROVED, tree(TWO_ROWS.replace("| paused |", "| snoozed |")));
+		expect(outcome.code).toBe(12);
+		expect(outcome.stderr.at(-1)).toContain("(ADR 0304). NOTHING was written.");
+	});
+});

--- a/packages/fabrika-cli/src/campaign/table.ts
+++ b/packages/fabrika-cli/src/campaign/table.ts
@@ -1,0 +1,119 @@
+/**
+ * The `## Campaigns` writers, added **beside** the fence's parse rather than as a fourth parser.
+ *
+ * Every cell this module reads comes from `../build/scope-admission.ts` — `scanCampaigns` for where
+ * a row sits, `parseCampaigns` for what it says — so a row a verb here writes and the dispatch fence
+ * calls `Malformed` is unconstructible. Binding to `../guard/roadmap.ts` instead would buy exactly
+ * that divergence: its pin regex is unanchored and its milestone cell is resolved away, so it admits
+ * rows the fence refuses.
+ */
+
+import {
+	type CampaignRow,
+	type CampaignState,
+	parseCampaigns,
+	scanCampaigns,
+} from "../build/scope-admission.ts";
+
+/** The one shape every verb prints a row in. */
+export const rowLine = (row: CampaignRow): string => `#${row.milestone}\t${row.state}\t${row.name}`;
+
+/** The bytes a fresh table is scaffolded with — nothing else, because the prose is founder-voice. */
+const HEADER_LINES = ["| Campaign | Milestone | State |", "|----------|-----------|-------|"];
+
+const dataLine = (name: string, milestone: number, state: CampaignState): string =>
+	`| ${name} | #${milestone} | ${state} |`;
+
+/** A `<name>` that cannot be written into a table cell at all. */
+export const nameFitsCell = (name: string): boolean => !name.includes("|") && !/[\r\n]/.test(name);
+
+/**
+ * Append a `paused` row for `name` at `milestone`, returning the whole file's new text.
+ *
+ * Three insertion points, one per state the file can be in, because leaving them to the implementer
+ * is how one implementation scaffolds the heading and another refuses.
+ */
+export const appendRow = (text: string, name: string, milestone: number): string => {
+	const lines = text.split("\n");
+	const scan = scanCampaigns(text);
+	const row = dataLine(name, milestone, "paused");
+
+	const last = scan.rows.at(-1);
+	if (last !== undefined) {
+		lines.splice(last.index + 1, 0, row);
+		return lines.join("\n");
+	}
+	if (scan.separator !== null) {
+		lines.splice(scan.separator + 1, 0, row);
+		return lines.join("\n");
+	}
+	if (scan.heading !== null) {
+		lines.splice(scan.heading + 1, 0, "", ...HEADER_LINES, row);
+		return lines.join("\n");
+	}
+	// A file with no heading grows one as its last `## ` section, which is where a reader of a
+	// roadmap looks for a table nobody has written yet.
+	const trailing = text.endsWith("\n") ? "" : "\n";
+	return `${text}${trailing}\n## Campaigns\n\n${[...HEADER_LINES, row].join("\n")}\n`;
+};
+
+/**
+ * Swap one row's state token in place, returning the whole file's new text.
+ *
+ * Only the token moves: the cell's leading and trailing whitespace is preserved exactly as found and
+ * the cell is **never re-padded to a column width**, so `paused` → `done` shortens the line and every
+ * other line of the file is byte-identical afterwards. Re-padding would be a second, silent edit the
+ * caller did not ask for.
+ *
+ * `null` when the line does not carry three cells between four pipes — which `parseCampaigns` has
+ * already refused by the time any caller gets here, so it is a floor rather than a branch.
+ */
+export const rewriteState = (text: string, line: number, to: CampaignState): string | null => {
+	const lines = text.split("\n");
+	const raw = lines[line];
+	if (raw === undefined) return null;
+	const pipes = [...raw].flatMap((char, index) => (char === "|" ? [index] : []));
+	const open = pipes[2];
+	const close = pipes[3];
+	if (pipes.length !== 4 || open === undefined || close === undefined) return null;
+	const cell = raw.slice(open + 1, close);
+	const spans = /^(\s*)(\S+)(\s*)$/.exec(cell);
+	if (spans === null) return null;
+	lines[line] = `${raw.slice(0, open + 1)}${spans[1]}${to}${spans[3]}${raw.slice(close)}`;
+	return lines.join("\n");
+};
+
+/** A row, and the line it sits on — what a writer needs and `parseCampaigns` alone cannot give. */
+export interface PlacedRow {
+	readonly row: CampaignRow;
+	readonly line: number;
+}
+
+export type PlacedTable =
+	| {readonly _tag: "Rows"; readonly rows: ReadonlyArray<PlacedRow>}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/**
+ * Every readable row with its line index, by zipping the scan against the parse.
+ *
+ * Positional alignment is safe because `parseCampaigns` refuses the **whole** table on the first
+ * unreadable row rather than returning a short list, so a `Rows` answer holds one entry per scanned
+ * line, in order.
+ */
+export const placedRows = (text: string): PlacedTable => {
+	const parsed = parseCampaigns(text);
+	if (parsed._tag === "Malformed") return parsed;
+	const scanned = scanCampaigns(text).rows;
+	return {
+		_tag: "Rows",
+		rows: parsed.rows.map((row, index) => ({row, line: scanned[index]?.index ?? -1})),
+	};
+};
+
+/** How `campaign state`'s positional argument names a row: by pin, or by exact name. */
+export const selects = (placed: PlacedRow, selector: string): boolean => {
+	const pin = /^#(\d+)$/.exec(selector.trim());
+	return pin?.[1] === undefined
+		? placed.row.name === selector.trim()
+		: placed.row.milestone === Number.parseInt(pin[1], 10);
+};

--- a/packages/fabrika-cli/src/campaign/table.ts
+++ b/packages/fabrika-cli/src/campaign/table.ts
@@ -65,8 +65,13 @@ export const appendRow = (text: string, name: string, milestone: number): string
  * other line of the file is byte-identical afterwards. Re-padding would be a second, silent edit the
  * caller did not ask for.
  *
- * `null` when the line does not carry three cells between four pipes — which `parseCampaigns` has
- * already refused by the time any caller gets here, so it is a floor rather than a branch.
+ * The trailing pipe is optional, exactly as it is for `cellsOf` in the fence's parse: `| a | #1 |
+ * paused` is a readable row there, so it is a writable one here. A writer stricter than the parse
+ * would refuse to flip a row `campaign list` prints, which is the disagreement this module exists to
+ * make unconstructible.
+ *
+ * `null` is the residual: the located line does not carry the three cells the parse read off it.
+ * Nothing is written on that arm, so a caller must seat it where *nothing was attempted* is true.
  */
 export const rewriteState = (text: string, line: number, to: CampaignState): string | null => {
 	const lines = text.split("\n");
@@ -74,8 +79,8 @@ export const rewriteState = (text: string, line: number, to: CampaignState): str
 	if (raw === undefined) return null;
 	const pipes = [...raw].flatMap((char, index) => (char === "|" ? [index] : []));
 	const open = pipes[2];
-	const close = pipes[3];
-	if (pipes.length !== 4 || open === undefined || close === undefined) return null;
+	if (open === undefined || pipes.length > 4) return null;
+	const close = pipes[3] ?? raw.length;
 	const cell = raw.slice(open + 1, close);
 	const spans = /^(\s*)(\S+)(\s*)$/.exec(cell);
 	if (spans === null) return null;

--- a/packages/fabrika-cli/src/campaign/table.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/table.unit.test.ts
@@ -92,6 +92,30 @@ describe("rewriteState", () => {
 		const at = scanCampaigns(padded).rows[0]?.index ?? -1;
 		expect(rewriteState(padded, at, "done") ?? "").toContain("| #42 |  done  |");
 	});
+
+	it("flips a row whose trailing pipe is absent, which the parse reads and so must the writer", () => {
+		const open = TWO_ROWS.replace("| #42 | paused |", "| #42 | paused");
+		const at = scanCampaigns(open).rows[0]?.index ?? -1;
+		const next = rewriteState(open, at, "active") ?? "";
+		expect(rowsOf(next)[0]).toEqual({milestone: 42, state: "active", name: "Taste-Skill Library"});
+		const before = open.split("\n");
+		expect(next.split("\n").filter((row, index) => row !== before[index])).toEqual([
+			"| Taste-Skill Library | #42 | active",
+		]);
+	});
+
+	it("keeps the padding of a trailing-pipe-less cell, trailing spaces and all", () => {
+		const open = TWO_ROWS.replace("| #42 | paused |", "| #42 |  paused  ");
+		const at = scanCampaigns(open).rows[0]?.index ?? -1;
+		expect(rewriteState(open, at, "done") ?? "").toContain("| #42 |  done  \n");
+	});
+
+	it("returns null on a line carrying more cells than the grammar declares", () => {
+		const lines = TWO_ROWS.split("\n");
+		const at = scanCampaigns(TWO_ROWS).rows[0]?.index ?? -1;
+		lines[at] = "| Taste-Skill Library | #42 | paused | extra |";
+		expect(rewriteState(lines.join("\n"), at, "active")).toBeNull();
+	});
 });
 
 describe("selects", () => {

--- a/packages/fabrika-cli/src/campaign/table.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/table.unit.test.ts
@@ -1,0 +1,131 @@
+import {describe, expect, it} from "vitest";
+import {parseCampaigns, readCampaigns, scanCampaigns} from "../build/scope-admission.ts";
+import {TWO_ROWS} from "./fixtures.test-support.ts";
+import {appendRow, nameFitsCell, placedRows, rewriteState, rowLine, selects} from "./table.ts";
+
+const rowsOf = (text: string) => {
+	const parsed = parseCampaigns(text);
+	if (parsed._tag === "Malformed") throw new Error(parsed.reason);
+	return parsed.rows;
+};
+
+describe("parseCampaigns — the extraction the fence narrows", () => {
+	it("returns every row whatever its state, where readCampaigns keeps only the active ones", () => {
+		expect(rowsOf(TWO_ROWS)).toEqual([
+			{milestone: 42, state: "paused", name: "Taste-Skill Library"},
+			{milestone: 47, state: "active", name: "fabrika everywhere"},
+		]);
+		expect(readCampaigns(TWO_ROWS)).toEqual({
+			_tag: "Active",
+			campaigns: [{milestone: 47, name: "fabrika everywhere"}],
+		});
+	});
+
+	it("calls an all-paused table rows, where the fence calls the same table None", () => {
+		const paused = TWO_ROWS.replace("| active |", "| paused |");
+		expect(rowsOf(paused)).toHaveLength(2);
+		expect(readCampaigns(paused)).toEqual({_tag: "None"});
+	});
+
+	it("reads an absent heading and an empty table as the same well-formed default", () => {
+		expect(parseCampaigns("# Roadmap\n")).toEqual({_tag: "Rows", rows: []});
+		expect(
+			parseCampaigns("## Campaigns\n\n| Campaign | Milestone | State |\n|---|---|---|\n"),
+		).toEqual({_tag: "Rows", rows: []});
+	});
+
+	it("makes the WHOLE table unreadable on one bad row, never a partial read", () => {
+		const broken = TWO_ROWS.replace("| #42 |", "| (was #42) |");
+		expect(parseCampaigns(broken)._tag).toBe("Malformed");
+		expect(readCampaigns(broken)._tag).toBe("Malformed");
+	});
+
+	it("stops at the next ## heading, so a table below it is another section", () => {
+		expect(scanCampaigns(TWO_ROWS).rows).toHaveLength(2);
+	});
+});
+
+describe("appendRow", () => {
+	it("appends after the current last row and touches nothing else", () => {
+		const next = appendRow(TWO_ROWS, "Mecmua reading layout", 52);
+		expect(rowsOf(next).at(-1)).toEqual({
+			milestone: 52,
+			state: "paused",
+			name: "Mecmua reading layout",
+		});
+		expect(next.split("\n").slice(0, 8)).toEqual(TWO_ROWS.split("\n").slice(0, 8));
+	});
+
+	it("writes the row immediately after the separator when the table has no rows", () => {
+		const empty = "## Campaigns\n\n| Campaign | Milestone | State |\n|---|---|---|\n\n## Next\n";
+		const next = appendRow(empty, "First", 1);
+		expect(next.split("\n")[4]).toBe("| First | #1 | paused |");
+	});
+
+	it("scaffolds the header under an existing heading that carries no table", () => {
+		const next = appendRow("# Roadmap\n\n## Campaigns\n\nprose.\n", "First", 1);
+		expect(rowsOf(next)).toEqual([{milestone: 1, state: "paused", name: "First"}]);
+		expect(next).toContain("| Campaign | Milestone | State |");
+	});
+
+	it("writes the heading as the last section when the file has none", () => {
+		const next = appendRow("# Roadmap\n\n## Arcs\n\nprose.\n", "First", 1);
+		expect(next.endsWith("| First | #1 | paused |\n")).toBe(true);
+		expect(rowsOf(next)).toEqual([{milestone: 1, state: "paused", name: "First"}]);
+	});
+});
+
+describe("rewriteState", () => {
+	const line = scanCampaigns(TWO_ROWS).rows[0]?.index ?? -1;
+
+	it("swaps the token and leaves every other line byte-identical", () => {
+		const next = rewriteState(TWO_ROWS, line, "active") ?? "";
+		const before = TWO_ROWS.split("\n");
+		const after = next.split("\n");
+		expect(after.filter((row, at) => row !== before[at])).toEqual([
+			"| Taste-Skill Library | #42 | active |",
+		]);
+	});
+
+	it("preserves the cell's padding exactly rather than re-padding to a column width", () => {
+		const padded = TWO_ROWS.replace("| #42 | paused |", "| #42 |  paused  |");
+		const at = scanCampaigns(padded).rows[0]?.index ?? -1;
+		expect(rewriteState(padded, at, "done") ?? "").toContain("| #42 |  done  |");
+	});
+});
+
+describe("selects", () => {
+	const placed = placedRows(TWO_ROWS);
+	const rows = placed._tag === "Rows" ? placed.rows : [];
+
+	it("matches a #<n> selector against the pin", () => {
+		expect(rows.filter((row) => selects(row, "#42")).map((row) => row.row.name)).toEqual([
+			"Taste-Skill Library",
+		]);
+	});
+
+	it("matches anything else against the first cell character for character", () => {
+		expect(rows.filter((row) => selects(row, "fabrika everywhere"))).toHaveLength(1);
+		expect(rows.filter((row) => selects(row, "fabrika"))).toHaveLength(0);
+	});
+
+	it("carries each row's line index, so a writer edits the row it selected", () => {
+		expect(rows.map((row) => row.line)).toEqual(
+			scanCampaigns(TWO_ROWS).rows.map((row) => row.index),
+		);
+	});
+});
+
+describe("rowLine and nameFitsCell", () => {
+	it("prints a row as #<milestone>\\t<state>\\t<name>", () => {
+		expect(rowLine({milestone: 47, state: "active", name: "fabrika everywhere"})).toBe(
+			"#47\tactive\tfabrika everywhere",
+		);
+	});
+
+	it("refuses a name carrying a pipe or a newline", () => {
+		expect(nameFitsCell("fine")).toBe(true);
+		expect(nameFitsCell("a | b")).toBe(false);
+		expect(nameFitsCell("a\nb")).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/config/keys/campaign-authors.ts
+++ b/packages/fabrika-cli/src/config/keys/campaign-authors.ts
@@ -1,0 +1,33 @@
+/**
+ * `campaignAuthors` — who may declare a campaign or flip its lifecycle state.
+ *
+ * A **narrowing predicate over the live ACL, never authority on its own** (ADR 0294): an entry here
+ * still has to hold `write` or above on the repository at the moment of the act. Its shipped default
+ * is the empty set — nobody may declare — which is the one default this key can have, because the
+ * privilege behind it is the dispatch permission itself (ADR 0304), and a set that filled itself in
+ * on an absent file would hand that permission to whoever the fallback named.
+ */
+
+import type {KeyGroup} from "../key-group.ts";
+import {
+	AUTHOR_TEAM,
+	AUTHOR_USER,
+	decodeGrantAuthors,
+	type GrantAuthor,
+	grantAuthorText,
+} from "./cap-clear-authors.ts";
+
+export const CAMPAIGN_AUTHORS = "campaignAuthors";
+
+export const campaignAuthorsKey: KeyGroup<ReadonlyArray<GrantAuthor>> = {
+	key: CAMPAIGN_AUTHORS,
+	shippedDefault: [],
+	decode: (raw) => decodeGrantAuthors(CAMPAIGN_AUTHORS, raw),
+	render: (authors) => authors.map(grantAuthorText),
+	jsonSchema: {
+		type: "array",
+		description:
+			"Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `fabrika campaign state`), narrowing the repository's collaborator ACL — an entry here still needs `write` or above on the repo (ADR 0294). Each entry is a GitHub `@user` or `@org/team`, `@`-prefixed. Empty (or absent) means nobody may declare.",
+		items: {type: "string", pattern: `${AUTHOR_USER.source}|${AUTHOR_TEAM.source}`},
+	},
+};

--- a/packages/fabrika-cli/src/config/keys/cap-clear-authors.ts
+++ b/packages/fabrika-cli/src/config/keys/cap-clear-authors.ts
@@ -16,36 +16,50 @@ export type GrantAuthor =
 	| {readonly _tag: "User"; readonly login: string}
 	| {readonly _tag: "Team"; readonly org: string; readonly team: string};
 
-const USER = /^@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)$/;
-const TEAM = /^@([^/\s]+)\/([^/\s]+)$/;
+export const AUTHOR_USER = /^@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)$/;
+export const AUTHOR_TEAM = /^@([^/\s]+)\/([^/\s]+)$/;
 
-const decode = (raw: unknown): Decoded<ReadonlyArray<GrantAuthor>> => {
+/** One written entry as a {@link GrantAuthor}, or `null` when it is neither spelling. */
+export const grantAuthorEntry = (entry: string): GrantAuthor | null => {
+	const value = entry.trim();
+	const team = AUTHOR_TEAM.exec(value);
+	if (team?.[1] !== undefined && team[2] !== undefined) {
+		return {_tag: "Team", org: team[1], team: team[2]};
+	}
+	const user = AUTHOR_USER.exec(value);
+	return user?.[1] === undefined ? null : {_tag: "User", login: user[1]};
+};
+
+/**
+ * The author-set decoder, parameterized by the key raising the refusal.
+ *
+ * Shared because `campaignAuthors` decodes the identical grammar (ADR 0294 binds the second key to
+ * the first's shape *and* its authority clause), and a hand-copied second regex pair is free to
+ * drift from the one every refusal message quotes.
+ */
+export const decodeGrantAuthors = (
+	key: string,
+	raw: unknown,
+): Decoded<ReadonlyArray<GrantAuthor>> => {
 	if (!Array.isArray(raw)) {
-		return {_tag: "Malformed", reason: `\`${CAP_CLEAR_AUTHORS}\` is not an array`};
+		return {_tag: "Malformed", reason: `\`${key}\` is not an array`};
 	}
 	const authors: GrantAuthor[] = [];
 	for (const entry of raw) {
 		if (typeof entry !== "string") {
 			return {
 				_tag: "Malformed",
-				reason: `\`${CAP_CLEAR_AUTHORS}\` holds a non-string entry — expected "@user" or "@org/team"`,
+				reason: `\`${key}\` holds a non-string entry — expected "@user" or "@org/team"`,
 			};
 		}
-		const value = entry.trim();
-		const team = TEAM.exec(value);
-		if (team?.[1] !== undefined && team[2] !== undefined) {
-			authors.push({_tag: "Team", org: team[1], team: team[2]});
-			continue;
+		const author = grantAuthorEntry(entry);
+		if (author === null) {
+			return {
+				_tag: "Malformed",
+				reason: `"${entry}" is not a \`${key}\` entry — expected "@user" or "@org/team"`,
+			};
 		}
-		const user = USER.exec(value);
-		if (user?.[1] !== undefined) {
-			authors.push({_tag: "User", login: user[1]});
-			continue;
-		}
-		return {
-			_tag: "Malformed",
-			reason: `"${entry}" is not a \`${CAP_CLEAR_AUTHORS}\` entry — expected "@user" or "@org/team"`,
-		};
+		authors.push(author);
 	}
 	return {_tag: "Value", value: authors};
 };
@@ -57,7 +71,7 @@ export const grantAuthorText = (author: GrantAuthor): string =>
 export const capClearAuthorsKey: KeyGroup<ReadonlyArray<GrantAuthor>> = {
 	key: CAP_CLEAR_AUTHORS,
 	shippedDefault: [],
-	decode,
+	decode: (raw) => decodeGrantAuthors(CAP_CLEAR_AUTHORS, raw),
 	render: (authors) => authors.map(grantAuthorText),
 	jsonSchema: {
 		type: "array",
@@ -65,6 +79,6 @@ export const capClearAuthorsKey: KeyGroup<ReadonlyArray<GrantAuthor>> = {
 			"Who may clear one extra repair round on a PR (`fabrika build clear`). Each entry is a GitHub `@user` or `@org/team`, `@`-prefixed. Empty (or absent) means nobody may grant.",
 		// Composed from the two regexes `decode` runs, never restated: a hand-copied alternation is
 		// free to drift from the decoder it claims to describe.
-		items: {type: "string", pattern: `${USER.source}|${TEAM.source}`},
+		items: {type: "string", pattern: `${AUTHOR_USER.source}|${AUTHOR_TEAM.source}`},
 	},
 };

--- a/packages/fabrika-cli/src/config/registry.ts
+++ b/packages/fabrika-cli/src/config/registry.ts
@@ -8,6 +8,7 @@
 
 import {type Registration, register} from "./key-group.ts";
 import {boardVocabularyKey} from "./keys/board-vocabulary.ts";
+import {campaignAuthorsKey} from "./keys/campaign-authors.ts";
 import {capClearAuthorsKey} from "./keys/cap-clear-authors.ts";
 import {ciKey} from "./keys/ci.ts";
 import {codeValidatorsKey} from "./keys/code-validators.ts";
@@ -22,6 +23,7 @@ import {workflowValidatorsKey} from "./keys/workflow-validators.ts";
 
 export const KEY_GROUPS: ReadonlyArray<Registration> = [
 	register(boardVocabularyKey),
+	register(campaignAuthorsKey),
 	register(capClearAuthorsKey),
 	register(ciKey),
 	register(codeValidatorsKey),

--- a/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
@@ -49,7 +49,7 @@ describe("reconcile", () => {
 	it("agrees when the committed file matches the assembled schema", () => {
 		const {outcome} = run({write: false, read: {_tag: "Text", text: committed}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\tagrees\t15");
+		expect(outcome.stdout).toContain("schema\tagrees\t16");
 	});
 
 	it("agrees whatever the committed file's whitespace, comparing content not bytes", () => {
@@ -87,7 +87,7 @@ describe("write", () => {
 	it("renders the file from the registry and reports written", () => {
 		const {outcome, saves} = run({write: true, read: {_tag: "Absent"}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\twritten\t15");
+		expect(outcome.stdout).toContain("schema\twritten\t16");
 		expect(saves).toHaveLength(1);
 		expect(saves[0]).toBe(committed);
 	});

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -349,10 +349,27 @@ export const DECISION_SEATS: SharedSeats = {
 	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
 };
 
+/**
+ * `campaign`'s seats: four, under the base's own names.
+ *
+ * The group writes one file and reads two, so it claims the write-shaped pair and the
+ * unreadable-precondition seat, plus `7` as `NO_TARGET` in the base's own reading — `campaign state`
+ * addresses exactly one row and its selector matching nothing is a target proven absent, not a scope
+ * proven empty. Nothing here reads stdin, composes a body or classifies a label, so `3`, `4`, `5`,
+ * `6` and `10` stay unclaimed rather than seating a second meaning.
+ */
+export const CAMPAIGN_SEATS: SharedSeats = {
+	NO_TARGET: "NO_TARGET",
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
+};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
 	build: BUILD_SEATS,
+	campaign: CAMPAIGN_SEATS,
 	decision: DECISION_SEATS,
 	governance: GOVERNANCE_SEATS,
 	hook: HOOK_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -5,6 +5,7 @@ import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import * as adr from "./adr/codes.ts";
 import * as build from "./build/codes.ts";
+import * as campaign from "./campaign/codes.ts";
 import * as ci from "./ci/codes.ts";
 import * as config from "./config/codes.ts";
 import * as decision from "./decision/codes.ts";
@@ -58,6 +59,7 @@ const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
 const TABLES: Readonly<Record<string, CodeTable>> = {
 	adr,
 	build,
+	campaign,
 	ci,
 	config,
 	decision,

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -479,6 +479,32 @@ export const getComment = (repo: string, id: number): Shell<Attempt<string>> =>
 		),
 	);
 
+/**
+ * One comment as a whole record — its author beside its body.
+ *
+ * Separate from {@link getComment}, which serves the read-back after a write and needs only the
+ * bytes. A citation is read for **who** wrote it as much as for what it says, and folding the author
+ * into the body-only read would leave every caller of that one carrying a field it never asked for.
+ */
+export const getCommentRecord = (repo: string, id: number): Shell<Attempt<CommentRecord>> =>
+	withToken((token) =>
+		Effect.map(restRead(token, "GET", `repos/${repo}/issues/comments/${id}`), (outcome) =>
+			then(servedBody(outcome), (body) => {
+				if (!isRecord(body) || typeof body.body !== "string" || typeof body.id !== "number") {
+					return fail("GitHub answered 200 but its body is not a comment");
+				}
+				const user = body.user;
+				return ok({
+					id: body.id,
+					author: isRecord(user) && typeof user.login === "string" ? user.login : "",
+					createdAt: typeof body.created_at === "string" ? body.created_at : "",
+					updatedAt: typeof body.updated_at === "string" ? body.updated_at : "",
+					body: body.body,
+				});
+			}),
+		),
+	);
+
 // ---------------------------------------------------------------------------------------------
 // The `triage` group's reads and writes, appended as one block so later verb slices extend the
 // file here without colliding with the `report` half above.

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -17,6 +17,7 @@ import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
 import {adrCommand} from "./adr/command.ts";
 import {buildCommand} from "./build/command.ts";
+import {campaignCommand} from "./campaign/command.ts";
 import {ciCommand} from "./ci/command.ts";
 import {configCommand} from "./config/command.ts";
 import {decisionCommand} from "./decision/command.ts";
@@ -52,6 +53,7 @@ export type VerbGroup = Command.Command<any, any, object, unknown, NodeServices.
 export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	adrCommand,
 	buildCommand,
+	campaignCommand,
 	ciCommand,
 	configCommand,
 	decisionCommand,


### PR DESCRIPTION
Builds the `campaign` verb group the `campaign` skill has been calling since PR #6788 landed the spec. Every fence in that skill routed to a command that answered "no such group", so opening a campaign or flipping one to `active` was still a hand edit to `ROADMAP.md` — an unguarded edit to the cell that grants dispatch permission (ADR 0304).

Five pieces, all in `packages/fabrika-cli/`:

- **The parse is extracted, not copied.** `build/scope-admission.ts` now exports `scanCampaigns` (where the table sits), `parseCampaigns` (every row, whatever its state) and re-expresses `readCampaigns` as a narrowing over the second. Its `Dispatch` signature and `Active`-is-non-empty invariant are untouched and no fence call site changed. `guard/roadmap.ts` is not touched either — the three verbs bind to the fence's own reader, so a row this group writes and the fence calls `Malformed` is unconstructible.
- **`campaignAuthors`**, a new `config/keys/` entry with shipped default `[]`. Its decoder is `capClearAuthors`'s, now shared rather than copied, so one regex pair serves both keys.
- **`campaign/codes.ts`**, importing `7`/`8`/`9`/`11` from `report/codes.ts` and allocating `12`-`22` privately; registered in `exit-code-alignment.ts` as `CAMPAIGN_SEATS`.
- **The `campaign-approve:` marker parser** — first line only, emphasis-tolerant, `·`-separated, bound to the milestone being written and the state the write produces.
- **The three verbs** — `list`, `open`, `state` — with authority as two conjunctive clauses: membership in `campaignAuthors`, then a live `permissionFor` read at the `write` floor (ADR 0294/0055).

`fabrika campaign list` run against this repo's real `ROADMAP.md` prints all 24 rows and reports 3 active. 81 new unit tests cover the marker, the parse extraction, the writers, both authority clauses and each verb's refusal seats.

Reviewers: start at `packages/fabrika-cli/src/campaign/guards.ts`'s `runTrace` — it is where the contract's most-informative-first refusal precedence (`17` over `16` over `15` over `14`, with `21` last) becomes an execution order.

Fixes #6787

## Deviations

- **Governing-ADR departure** — **Said:** the contract's exit table seats `22` as "`.fabrika.jsonc` could not be read, or its `roadmapFile` will not decode", and gives no seat at all for a `campaignAuthors` that will not decode. **Did:** seated a malformed `campaignAuthors` on `13` (authority is UNKNOWN), documented at the constant in `campaign/codes.ts`. **Why:** `22`'s wording is scoped to `roadmapFile`, and a whole-file read failure already reaches `22` through the `roadmapFile` reader that runs first; what is left is a readable config whose author set will not decode, which is authority nobody could resolve — not an empty set, which is `17` and a different, proven fact. **Disposition:** stated here and in the code; the contract has the gap, and this fills it with the seat whose meaning already covers it.
- **Pre-existing test or fixture changed** — **Said:** nothing about `config/schema-verb.unit.test.ts`. **Did:** moved its two hardcoded key counts from `15` to `16`, and regenerated the committed `.fabrika.schema.json`. **Why:** both are mechanical consequences of registering a sixteenth config key; the assertions are counts, not behaviour. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #6787 names `campaignAuthors` as a new key on `cap-clear-authors.ts`'s shape. **Did:** also refactored `cap-clear-authors.ts` itself, exporting its two regexes and a shared `decodeGrantAuthors(key, raw)` that its own decoder now calls. **Why:** "sharing its decoder shape" read as a copy or a share, and a hand-copied second regex pair is free to drift from the one every refusal message quotes. No behaviour of `capClearAuthors` changes; its tests pass unedited. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `io/issues.ts`. **Did:** added `getCommentRecord`, a comment read carrying the author beside the body. **Why:** the existing `getComment` returns only the body, and a citation is read for who wrote it as much as for what it says; widening `getComment` would have handed a field to its hundred-odd existing callers. **Disposition:** stated here.

- **Governing-ADR departure** — **Said:** the contract seats `11` as "the roadmap file could not be read, so nothing was attempted". **Did:** also seated `campaign state`'s residual `rewriteState` null there — a located row that reads as three cells but does not edit as three. **Why:** round 1 caught that arm on `8`, which claims the file may be half-written when no write was attempted; the half of the `8`/`11` split that carries the operator's next move is *whether a write happened*, and on that arm it did not. `12` was the alternative and is worse: the table did parse. **Disposition:** stated here and at the constant in `campaign/codes.ts`.
- **Out-of-scope change** — **Said:** the contract's usage table names `|` and a newline as the `<name>` a cell cannot hold. **Did:** `campaign open` also refuses a whitespace-only `<name>`, on the contract's own `campaign open: --<flag> is required.` line. **Why:** trimming the name (round 1, nit 3) makes an all-whitespace one write an empty first cell, which is a row `parseCampaigns` refuses — so the verb would corrupt the table and then report it on a read-back seat. No new refusal line is invented; it lands on the one the contract already writes for a missing flag. **Disposition:** stated here.
