### PR TITLE
docs(decisions): amend ADR 0317 — a skill and its shell never share a spelling

### DIFF
--- a/.decisions/0317-ui-lane-carries-its-own-shells.md
+++ b/.decisions/0317-ui-lane-carries-its-own-shells.md
@@ -113,9 +113,12 @@ outlier.
 - The routing table grows but stays one table; a state that routes to no shell is still a refusal.
 - `prove` tightens **last**. Tightened before the shells and routing exist, it converts today's park
   into a stall, which is worse than the deadlock it replaces.
-- Two lane-state nouns become load-bearing: `build:ui` and `review:ui` are where a lane sits;
-  `build-ui` and `review-ui` are the skills, and `ui-builder` and `ui-reviewer` the shells that
-  load them.
+- Two lane-state nouns become load-bearing: `build:ui` and `review:ui` are where a lane sits. Four
+  more nouns ride beside them, and the skill and the shell that loads it never share a spelling:
+  `build-ui` and `review-ui` are the skills; `ui-builder` and `ui-reviewer` are the shells that load
+  them. ADR [0281](0281-agent-names-are-nouns.md) is why they differ — an agent whose `name:` is the
+  bare spelling of its skill is banned there, so deriving a shell name from a skill name yields one
+  nobody can spawn.
 
 ## Records
 

--- a/.decisions/0317-ui-lane-carries-its-own-shells.md
+++ b/.decisions/0317-ui-lane-carries-its-own-shells.md
@@ -115,7 +115,9 @@ outlier.
   into a stall, which is worse than the deadlock it replaces.
 - Two lane-state nouns become load-bearing: `build:ui` and `review:ui` are where a lane sits;
   `build-ui` and `review-ui` are the skills, and `ui-builder` and `ui-reviewer` the shells that
-  load them.
+  load them. **Amended 2026-08-21 ([#6721](https://github.com/kamp-us/phoenix/issues/6721)):** a
+  skill and the shell that preloads it never share a spelling — see the amendment below, and ADR
+  [0281](0281-agent-names-are-nouns.md).
 
 ## Records
 

--- a/.decisions/0317-ui-lane-carries-its-own-shells.md
+++ b/.decisions/0317-ui-lane-carries-its-own-shells.md
@@ -113,14 +113,28 @@ outlier.
 - The routing table grows but stays one table; a state that routes to no shell is still a refusal.
 - `prove` tightens **last**. Tightened before the shells and routing exist, it converts today's park
   into a stall, which is worse than the deadlock it replaces.
-- Two lane-state nouns become load-bearing: `build:ui` and `review:ui` are where a lane sits. Four
-  more nouns ride beside them, and the skill and the shell that loads it never share a spelling:
-  `build-ui` and `review-ui` are the skills; `ui-builder` and `ui-reviewer` are the shells that load
-  them. ADR [0281](0281-agent-names-are-nouns.md) is why they differ — an agent whose `name:` is the
-  bare spelling of its skill is banned there, so deriving a shell name from a skill name yields one
-  nobody can spawn.
+- Two lane-state nouns become load-bearing: `build:ui` and `review:ui` are where a lane sits;
+  `build-ui` and `review-ui` are the skills, and `ui-builder` and `ui-reviewer` the shells that
+  load them.
 
 ## Records
 
 - Ruling: https://github.com/kamp-us/phoenix/issues/6505#issuecomment-5360947091
 - Epic: https://github.com/kamp-us/phoenix/issues/6505
+
+## Amendment (2026-08-21, [#6721](https://github.com/kamp-us/phoenix/issues/6721)) — a skill and the shell that loads it never share a spelling
+
+The last `## Consequences` bullet names four nouns in one clause: `build-ui` and `review-ui` are the
+skills, `ui-builder` and `ui-reviewer` the shells that load them. It states the pairing and stops, so
+a reader who wants a shell name and only skims the clause can derive it from the skill name and get a
+pair nobody can spawn. One build already did, on [#6688](https://github.com/kamp-us/phoenix/issues/6688),
+and wrote `"build:ui": "build-ui"` into the lane routing table; it took a `review-code` FAIL.
+
+**The rule.** A skill and the shell that preloads it never share a spelling. ADR
+[0281](0281-agent-names-are-nouns.md) is why: an agent definition whose `name:` is the bare spelling
+of the skill it preloads is banned there, so a shell name derived from a skill name names nothing.
+Read a shell name off `claude-plugins/fabrika/agents/`, never off the skill it loads.
+
+The decision itself is unchanged — the direction, the lane-state nouns `build:ui` and `review:ui`,
+and the `lane prove` consequences all stand as written above. This amendment adds the reason the four
+nouns differ, which the bullet assumed and never said.


### PR DESCRIPTION
ADR 0317's consequences list names the four UI-lane nouns — `build-ui` / `review-ui` the skills, `ui-builder` / `ui-reviewer` the shells — but never says why the two differ. A reader deriving a shell name from a skill name had nothing telling them not to, and one build already did exactly that on #6688 and shipped an unspawnable name into the lane routing table.

This lands that rule as an appended, dated amendment on 0317: a skill and the shell that preloads it never share a spelling, with ADR 0281's ban as the reason. The Consequences bullet that names the four nouns keeps its sentence byte-for-byte and gains a dated pointer to the amendment, so a reader who only skims the bullet still lands on the rule. The diff is +20 / −1, append-only in substance.

Fixes #6721

## Deviations

- **Scope narrowing** — **Said:** #6721 names three stale clauses in the ADR (lines 12, 44, 113) that call the shells `build-ui` and `review-ui`. **Did:** touched none of them. **Why:** the issue was filed against `origin/epic/6505`; that epic has since merged (b54a3815f), and on `main` lines 12 and 44 already read `ui-builder` / `ui-reviewer`. A fresh grep turns up no other shell reference using the old spelling — every remaining `build-ui` / `review-ui` names the skill or the verdict namespace, which is the correct noun there. **Disposition:** criteria 1, 2, 4 and 5 were already satisfied by the merged epic; only criterion 3 needed work.

- **Governing-ADR departure** — **Said:** criterion 3 asks that the line-113 clause itself state the split and point at ADR 0281. **Did:** the rule's reasoning lives in an appended `## Amendment (2026-08-21, #6721)` section, and the clause carries a dated one-sentence pointer to it plus the ADR 0281 link. The clause's original sentence is unchanged. **Why:** a landed ADR body is not rewritten in place (`adr` SKILL.md §4), which is what took the `governance` FAIL at `cecdb45a`; appending a pointer onto a surviving sentence is a different act, and this file already carries that shape in commit 2357066c6 (#6807), where a Consequences bullet gained a `**Narrowed by ADR 0320**` clause the same way. **Disposition:** criterion 3 is met in both substance and location; the departure is only that the reasoning sits below rather than inline.
