### PR TITLE
feat: Build @kampus/fabrika-pi: the npm bundle ADR 0332 ruled on

### DIFF
--- a/packages/fabrika-pi/README.md
+++ b/packages/fabrika-pi/README.md
@@ -1,0 +1,40 @@
+# @kampus/fabrika-pi
+
+Every [fabrika](../../claude-plugins/fabrika/) skill plus all eight agent shells, bundled as one
+npm package a [pi](https://github.com/badlogic/pi-mono) project can consume with one command
+([ADR 0332](../../.decisions/0332-fabrika-pi-ships-as-npm-package.md)).
+
+## Install
+
+```bash
+pi install npm:@kampus/fabrika-pi
+```
+
+Pi reads the installed package's manifest keys (`pi.skills`, `pi.subagents.agents`) and discovers
+the bundled resources with no further wiring.
+
+**Agent shells require the [pi-subagents](https://github.com/nicobailon/pi-subagents) extension**
+(`pi install npm:pi-subagents`) — that is the convention that reads `pi.subagents.agents`. **All
+skills work without it**: skills are standard SKILL.md trees, which pi loads natively.
+
+## Single-source rule
+
+Nothing in this package is hand-maintained. Authored content lives only at:
+
+- [`claude-plugins/fabrika/skills/`](../../claude-plugins/fabrika/skills/) — ~25 SKILL.md trees,
+- [`.pi/agents/`](../../.pi/agents/) — the 8 agent shells (builder, mixed-builder, operator,
+  reviewer, shipper, triager, ui-builder, ui-reviewer).
+
+`scripts/sync-bundle.mjs` copies both into `dist/` at build/pack time (`prepack` runs it; so does
+`pnpm --filter @kampus/fabrika-pi sync`). The script refuses to bundle zero skills or zero agent
+shells, and rebuilds `dist/` from scratch on every run — never edit anything under `dist/`, and
+never commit a bundled copy: both are lost or wrong on the next sync.
+
+The package carries **zero dependencies** by design: pi's installer resolves npm dependencies but
+does not speak pnpm's `catalog:` protocol (#6970 prototype), so there is nothing to resolve.
+
+## Publishing
+
+Versioned by release-please and published through the documented release path
+([`.patterns/release-path.md`](../../.patterns/release-path.md)) — publishing stays human-gated;
+no CI publishes this package without that flip.

--- a/packages/fabrika-pi/package.json
+++ b/packages/fabrika-pi/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@kampus/fabrika-pi",
+	"version": "0.1.0",
+	"description": "@kampus/fabrika-pi — every fabrika skill and agent shell, bundled for pi projects (ADR 0332)",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kamp-us/phoenix.git",
+		"directory": "packages/fabrika-pi"
+	},
+	"type": "module",
+	"files": [
+		"dist",
+		"scripts",
+		"README.md"
+	],
+	"scripts": {
+		"sync": "node scripts/sync-bundle.mjs",
+		"prepack": "node scripts/sync-bundle.mjs",
+		"test": "node --test 'scripts/*.unit.test.mjs'"
+	},
+	"pi": {
+		"skills": [
+			"./dist/skills"
+		],
+		"subagents": {
+			"agents": [
+				"./dist/agents"
+			]
+		}
+	},
+	"engines": {
+		"node": ">=22.12"
+	}
+}

--- a/packages/fabrika-pi/scripts/sync-bundle.mjs
+++ b/packages/fabrika-pi/scripts/sync-bundle.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Release-time bundle for @kampus/fabrika-pi (ADR 0332).
+ *
+ * Copies the single authored sources into `dist/` so the published package carries real copies and
+ * the manifest keys (`pi.skills`, `pi.subagents.agents`) point at bundled paths:
+ *
+ *   claude-plugins/fabrika/skills/<skill>/…  →  dist/skills/<skill>/…
+ *   .pi/agents/<shell>.md                    →  dist/agents/<shell>.md
+ *
+ * The single-source rule (#6985): nothing here is hand-maintained — authored content lives only in
+ * `claude-plugins/fabrika/skills/` and `.pi/agents/`, and this script is the only thing that
+ * produces the bundled copies. Editing anything under `dist/` by hand is lost on the next sync.
+ *
+ * Fail-closed, mirroring #6967's sync: a source tree that yields zero skills or zero agents is a
+ * moved or emptied source, and bundling nothing would publish a package whose manifest points at
+ * nothing — so the script refuses instead. The sync is total: `dist/` is removed and rebuilt on
+ * every run, so running twice is idempotent and stale copies of deleted sources never survive.
+ */
+import {cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync} from "node:fs";
+import {join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const REPO_ROOT = resolve(PACKAGE_ROOT, "../..");
+
+/** The authored sources, resolved off this script's own location — never off cwd. */
+export const SOURCES = {
+	skills: join(REPO_ROOT, "claude-plugins", "fabrika", "skills"),
+	agents: join(REPO_ROOT, ".pi", "agents"),
+};
+
+/** Where the bundled copies land — the paths the manifest keys point at. */
+export const DEST = join(PACKAGE_ROOT, "dist");
+
+/**
+ * Sync the bundle. Returns what shipped so the caller (and the summary line) can prove it was
+ * something; throws when a source is empty, because an empty bundle must not ship.
+ *
+ * @param {{skills?: string, agents?: string, dest?: string}} [paths] overrides for tests.
+ * @returns {{skills: string[], agents: string[]}} bundled names, sorted.
+ */
+export function syncBundle(paths = {}) {
+	const skillsSource = paths.skills ?? SOURCES.skills;
+	const agentsSource = paths.agents ?? SOURCES.agents;
+	const dest = paths.dest ?? DEST;
+
+	if (!existsSync(skillsSource)) {
+		throw new Error(`sync-bundle: skills source is missing: ${skillsSource}`);
+	}
+	if (!existsSync(agentsSource)) {
+		throw new Error(`sync-bundle: agents source is missing: ${agentsSource}`);
+	}
+
+	// A skill is a directory carrying its own SKILL.md — the same rule pi uses to discover one,
+	// so a stray non-skill directory under the authored tree is skipped rather than shipped.
+	const skills = readdirSync(skillsSource)
+		.filter((name) => {
+			const entry = join(skillsSource, name);
+			return statSync(entry).isDirectory() && existsSync(join(entry, "SKILL.md"));
+		})
+		.sort();
+	const agents = readdirSync(agentsSource)
+		.filter((name) => name.endsWith(".md"))
+		.sort();
+
+	if (skills.length === 0) {
+		throw new Error(
+			`sync-bundle: refusing to bundle zero skills — no SKILL.md directory found under ${skillsSource}`,
+		);
+	}
+	if (agents.length === 0) {
+		throw new Error(
+			`sync-bundle: refusing to bundle zero agent shells — no .md file found under ${agentsSource}`,
+		);
+	}
+
+	rmSync(dest, {recursive: true, force: true});
+	for (const skill of skills) {
+		cpSync(join(skillsSource, skill), join(dest, "skills", skill), {recursive: true});
+	}
+	mkdirSync(join(dest, "agents"), {recursive: true});
+	for (const agent of agents) {
+		cpSync(join(agentsSource, agent), join(dest, "agents", agent));
+	}
+
+	return {skills, agents};
+}
+
+/** Print one line naming everything that shipped, so a green run says what it bundled. */
+function report({skills, agents}) {
+	console.log(
+		`sync-bundle: bundled ${skills.length} skill${skills.length === 1 ? "" : "s"} (${skills.join(", ")}) ` +
+			`and ${agents.length} agent shell${agents.length === 1 ? "" : "s"} (${agents.join(", ")}) → ${DEST}`,
+	);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	report(syncBundle());
+}

--- a/packages/fabrika-pi/scripts/sync-bundle.unit.test.mjs
+++ b/packages/fabrika-pi/scripts/sync-bundle.unit.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the release-time bundle sync (`node --test scripts/`), kept dependency-free so the
+ * package stays installable in isolation (#6985 — no `catalog:` strings may appear in its manifest).
+ *
+ * Every case runs against a throwaway fixture tree, never against the authored sources: the
+ * fail-closed refusals must be provable without touching a source tree that is always full.
+ */
+import assert from "node:assert/strict";
+import {mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {join} from "node:path";
+import {test} from "node:test";
+import {syncBundle} from "./sync-bundle.mjs";
+
+/** One temp dir holding both fixture sources and the destination. */
+function fixture({skills = 2, agents = 3} = {}) {
+	const root = mkdtempSync(join(process.cwd(), "sync-bundle-fixture-"));
+	const paths = {
+		skills: join(root, "authored-skills"),
+		agents: join(root, "authored-agents"),
+		dest: join(root, "dist"),
+	};
+	for (let i = 0; i < skills; i++) {
+		const skill = join(paths.skills, `skill-${i}`);
+		mkdirSync(skill, {recursive: true});
+		writeFileSync(join(skill, "SKILL.md"), `# skill ${i}\n`);
+	}
+	for (let i = 0; i < agents; i++) {
+		mkdirSync(paths.agents, {recursive: true});
+		writeFileSync(join(paths.agents, `shell-${i}.md`), `---\nname: shell-${i}\n---\nbody\n`);
+	}
+	// Both source directories must exist even when empty, so the zero-count refusals — not the
+	// missing-source refusals — are what these fixtures prove.
+	mkdirSync(paths.skills, {recursive: true});
+	mkdirSync(paths.agents, {recursive: true});
+	// A directory with no SKILL.md under the skills tree is not a skill — it must not ship.
+	if (skills > 0) {
+		mkdirSync(join(paths.skills, "not-a-skill"), {recursive: true});
+		writeFileSync(join(paths.skills, "not-a-skill", "README.md"), "stray\n");
+	}
+	return {root, paths};
+}
+
+test("bundles every SKILL.md directory and every agent shell", () => {
+	const fx = fixture();
+	try {
+		const shipped = syncBundle(fx.paths);
+		assert.deepEqual(shipped.skills, ["skill-0", "skill-1"]);
+		assert.deepEqual(shipped.agents, ["shell-0.md", "shell-1.md", "shell-2.md"]);
+		const bundledSkills = readdirSync(join(fx.paths.dest, "skills")).sort();
+		assert.deepEqual(
+			bundledSkills,
+			["skill-0", "skill-1"],
+			"non-skill directories must not bundle",
+		);
+		assert.equal(
+			readFileSync(join(fx.paths.dest, "skills", "skill-1", "SKILL.md"), "utf8"),
+			"# skill 1\n",
+		);
+		assert.equal(
+			readFileSync(join(fx.paths.dest, "agents", "shell-0.md"), "utf8"),
+			"---\nname: shell-0\n---\nbody\n",
+		);
+	} finally {
+		rmSync(fx.root, {recursive: true, force: true});
+	}
+});
+
+test("running twice is idempotent — same files, no stale copies", () => {
+	const fx = fixture();
+	try {
+		const first = syncBundle(fx.paths);
+		const snapshot = () => readdirSync(fx.paths.dest, {recursive: true}).sort().join("\n");
+		const before = snapshot();
+		const second = syncBundle(fx.paths);
+		assert.deepEqual(second, first);
+		assert.equal(snapshot(), before);
+		// A source deleted between runs must not survive as a stale copy.
+		rmSync(join(fx.paths.agents, "shell-2.md"));
+		syncBundle(fx.paths);
+		assert.deepEqual(readdirSync(join(fx.paths.dest, "agents")).sort(), [
+			"shell-0.md",
+			"shell-1.md",
+		]);
+	} finally {
+		rmSync(fx.root, {recursive: true, force: true});
+	}
+});
+
+test("refuses to bundle zero skills — fail-closed like #6967's sync", () => {
+	const fx = fixture({skills: 0, agents: 1});
+	try {
+		assert.throws(() => syncBundle(fx.paths), /refusing to bundle zero skills/);
+	} finally {
+		rmSync(fx.root, {recursive: true, force: true});
+	}
+});
+
+test("refuses to bundle zero agent shells", () => {
+	const fx = fixture({skills: 1, agents: 0});
+	try {
+		assert.throws(() => syncBundle(fx.paths), /refusing to bundle zero agent shells/);
+	} finally {
+		rmSync(fx.root, {recursive: true, force: true});
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,6 +728,8 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/fabrika-pi: {}
+
   packages/fate-effect:
     dependencies:
       '@nkzw/fate':


### PR DESCRIPTION
Fixes #6985

## What

`@kampus/fabrika-pi` — the npm package ADR 0332 ruled on: every fabrika skill plus all eight agent shells, bundled for pi projects, installed with one command:

```bash
pi install npm:@kampus/fabrika-pi
```

Pi discovers the bundled resources from the package manifest's `pi.skills` and `pi.subagents.agents` keys with no further wiring. Agent shells additionally require the [pi-subagents](https://github.com/nicobailon/pi-subagents) extension (the convention that reads `pi.subagents.agents`); **all skills work without it**.

## Shape

- `packages/fabrika-pi/` — a real workspace member (registered in `pnpm-lock.yaml` as a dependency-less importer) whose manifest carries **zero `catalog:` strings**: pi's installer does not speak pnpm's catalog protocol (#6970 prototype), so there is nothing to resolve.
- `scripts/sync-bundle.mjs` — the single-source-rule bundler: copies `claude-plugins/fabrika/skills/` (26 SKILL.md trees) → `dist/skills/` and `.pi/agents/` (8 shells) → `dist/agents/`. Fail-closed: refuses zero skills or zero agents. Total-rebuild on every run, so running twice is idempotent and stale copies never survive. Wired as both an explicit `sync` script and `prepack`, so any pack/publish re-bundles from the authored sources.
- Nothing bundled is committed — `dist/` is gitignored; the tarball is produced at pack time from the one authored source.
- README per repo convention: what it is, the install line, the skills-vs-shells requirement statement, the do-not-edit-`dist/` rule, and the human-gated release posture.

## Acceptance evidence

- **Workspace member + guards:** `readme-guard check` → all 17 `packages/*` members carry a README; `catalog-guard check` → clean across 21 manifests.
- **Manifest:** declares `@kampus/fabrika-pi`, `pi.skills: ["./dist/skills"]`, `pi.subagents.agents: ["./dist/agents"]`; `grep catalog:` over the manifest finds nothing.
- **Idempotent regeneration:** 4 unit tests (`node --test`, zero deps) cover bundle content, non-skill-directory exclusion, double-run idempotence + stale-copy removal, and both zero-source refusals.
- **`npm pack --dry-run`:** 68 files — manifest, README, sync script, all 26 skill trees under `dist/skills/`, all 8 shells under `dist/agents/`.
- **External headless probe:** packed the real tarball, unpacked it, `pi install <dir> -l` into a throwaway `/tmp` project, then `pi -p "list every skill available"` — all 25 model-visible fabrika skills listed by name, total skill count exactly baseline + 26. The 26th, `front-door`, carries authored `disable-model-invocation: true` and is excluded from the system prompt by design (verified in pi's own loader source), so no probe can ever see it — its presence in the tarball is file-verified.

## Deviations

- **Standalone bundling, release machinery untouched** — **Said:** #6985 says to coordinate with PR #6967's unmerged opencode bundling machinery where cheap, standalone acceptable if cleaner, disclosed either way. **Did:** built standalone and did not touch `publish.yml`, `release-please.yml`, or `release-please-config.json`, which #6967 modifies; adding a `fabrika-pi` resolve arm here would guarantee merge conflicts with that open PR for wiring this issue's acceptance criteria do not require. **Why:** the criteria gate on the package, not the CI publish path, and #6967's review is still moving. **Disposition:** stated here; whoever merges second rebases their resolve-arm addition on top.
