### PR TITLE
chore: Wire @kampus/fabrika-pi into release-please and the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,6 +119,9 @@ jobs:
           if [[ "$TAG" =~ ^fabrika-cli-v([0-9].*)$ ]]; then
             PKG_DIR="packages/fabrika-cli"
             TAG_VERSION="${BASH_REMATCH[1]}"
+          elif [[ "$TAG" =~ ^fabrika-pi-v([0-9].*)$ ]]; then
+            PKG_DIR="packages/fabrika-pi"
+            TAG_VERSION="${BASH_REMATCH[1]}"
           else
             echo "::error::release tag '$TAG' matches no published package's <name>-v<version> grammar — refusing to publish"
             exit 1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
 	"packages": {
 		"packages/fabrika-cli": {
 			"component": "fabrika-cli"
+		},
+		"packages/fabrika-pi": {
+			"component": "fabrika-pi"
 		}
 	}
 }


### PR DESCRIPTION
Wire `@kampus/fabrika-pi` into the release machinery so the package ADR 0332 ruled on can actually be published.

## What changed

- **`release-please-config.json`** — registered `packages/fabrika-pi` with component `fabrika-pi` beside `fabrika-cli`, so release-please derives versions and grooms Release PRs for it.
- **`.github/workflows/publish.yml`** — added an anchored `^fabrika-pi-v([0-9].*)$` arm to the resolve step's tag-match, exactly parallel to the `fabrika-cli-v*` arm. That file stays the single source of truth for the published set: `publish-isolation-guard` machine-reads its regex anchors, and after this change the guard's scope widens automatically — it now reports 2 published packages (`@kampus/fabrika-cli`, `@kampus/fabrika-pi`) and passes.

## Verification

- `guard publish-isolation-guard check` exits 0 post-change.
- The resolver semantics were exercised directly: `fabrika-pi-v0.1.0` resolves to `packages/fabrika-pi`; a disagreeing version (`fabrika-pi-v9.9.9`) fails with the same version-mismatch error as the cli arm; an unknown prefix still refuses.
- `build check --surface workflows` (actionlint) and `--surface code` (typecheck, lint) both green in this tree, cache bypassed.

Fixes #6993

## Deviations

None.
