### PR TITLE
chore: opencode harness exports no session id so every identity verb refuses

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -78,6 +78,12 @@ is not a lane-claim token of this session), `8` (the marker write is UNKNOWN), `
 does not read back) and `11` (the marker set could not be read) all end `STOPPED` naming the code —
 an unproven claim is never driven through.
 
+**Harness note — opencode exports no session id.** Verified against upstream `sst/opencode` at
+`v1.18.21`: the bash tool spawns shells with inherited environment only, and the shipped binary
+carries no `OPENCODE_SESSION_ID`. So under opencode the chain comes up empty on its own — export
+`FABRIKA_SESSION_ID` (any stable value you control) before your first attribution-bearing verb, or
+every verb refuses with the three-variable unset message above.
+
 **Keep the `token` a `won` prints — it is this driver's name, and `lane release` takes it as
 `--token`.** One session routinely spawns several operators, so a release handed only the session id
 cannot tell a sibling driver's marker from yours, and used to delete it: an unrecoverable retraction

--- a/packages/fabrika-cli/src/io/session-id.ts
+++ b/packages/fabrika-cli/src/io/session-id.ts
@@ -13,7 +13,15 @@
  * single-path-segment check (`triage scratch`, `build scratch`).
  */
 
-/** The consulted variables, in precedence order — the unset refusal names all three. */
+/**
+ * The consulted variables, in precedence order — the unset refusal names all three.
+ *
+ * opencode exposes no session id a driver shell could read (verified against upstream `sst/opencode`
+ * at v1.18.21: the bash tool spawns with inherited environment only, and no `OPENCODE_SESSION_ID`
+ * exists anywhere in the shipped binary), so an opencode driver must export `FABRIKA_SESSION_ID` by
+ * hand before any attribution-bearing verb — otherwise every verb refuses with
+ * {@link sessionIdUnset}.
+ */
 export const SESSION_ID_VARS = [
 	"FABRIKA_SESSION_ID",
 	"CLAUDE_CODE_SESSION_ID",


### PR DESCRIPTION
Document that opencode drivers must export `FABRIKA_SESSION_ID` before any attribution-bearing verb.

opencode exposes no session id a driver shell can read (verified against upstream `sst/opencode` at v1.18.21: the bash tool spawns shells with inherited environment only, and the shipped binary carries no `OPENCODE_SESSION_ID`). So under opencode the `FABRIKA_SESSION_ID` → `CLAUDE_CODE_SESSION_ID` → `PI_SUBAGENT_PARENT_SESSION` chain comes up empty on its own, and every fabrika verb correctly refuses to mint an identity. The fix is documentation, not a fourth `SESSION_ID_VARS` entry:

- The operate skill's step-1 claim preflight gains a harness note: export `FABRIKA_SESSION_ID` first, or every verb refuses with the three-variable unset message.
- The doc comment on `SESSION_ID_VARS` in `packages/fabrika-cli/src/io/session-id.ts` records the upstream verification and names the unset refusal message drivers will see.

No behavior change: `sessionIdFrom`, `SESSION_ID_VARS` values and the refusal message are untouched; existing tests pass unchanged.

Fixes #6979

## Deviations

None.
