### PR TITLE
feat: Pull yazars into the divan with a pending-count badge, staged before bildirim fan-out

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import {useMe} from "./auth/useMe";
 import {useBildirimUnread} from "./components/bildirim/useBildirimUnread";
 import {DivanSubnavLayout} from "./components/divan/DivanSubnavLayout";
 import {useDivanAccess} from "./components/divan/useDivanAccess";
+import {useDivanPendingCount} from "./components/divan/useDivanPendingCount";
 import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
 import {Topbar} from "./components/layout/Topbar";
@@ -69,6 +70,7 @@ type TopbarChips = {
 	userProps: {user: {name: string; username: string | null}} | undefined;
 	karma: number | undefined;
 	divanTo: string | undefined;
+	divanCount: number | undefined;
 	bildirim: {to: string; unread: number} | undefined;
 };
 
@@ -170,6 +172,7 @@ function Layout() {
 								...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
 							]}
 							divanTo={chips?.divanTo}
+							divanPending={chips?.divanCount}
 							// Boot props carry the first paint, before `LayoutContent` publishes any chips.
 							// A signed-out publish leaves `userProps` undefined, so they land again there —
 							// inert, because `reserveSignedInSlots` is false and gates the whole account side.
@@ -241,6 +244,10 @@ function LayoutContent() {
 	// çaylak/non-mod skips the guaranteed-`UNAUTHORIZED` probe; the ambiguous case
 	// still probes.
 	const showDivan = useDivanAccess(me);
+	// The divan glyph's pending-review badge (#6760). Same gate as the entry itself —
+	// `showDivan` is the probe's answer — so the gated count read fires only for a subject
+	// the wire would let read `divan.roster`, and stays unissued for everyone else.
+	const divanCount = useDivanPendingCount(showDivan);
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
@@ -276,9 +283,20 @@ function LayoutContent() {
 				: undefined,
 			karma: selfKarma,
 			divanTo: showDivan ? "/divan" : undefined,
+			divanCount: showDivan ? divanCount : undefined,
 			bildirim: bildirimOn && isSignedIn ? {to: "/bildirimler", unread: bildirimUnread} : undefined,
 		}),
-		[sessionUser, me?.name, username, selfKarma, showDivan, bildirimOn, isSignedIn, bildirimUnread],
+		[
+			sessionUser,
+			me?.name,
+			username,
+			selfKarma,
+			showDivan,
+			divanCount,
+			bildirimOn,
+			isSignedIn,
+			bildirimUnread,
+		],
 	);
 
 	useEffect(() => {

--- a/apps/web/src/components/divan/useDivanPendingCount.ts
+++ b/apps/web/src/components/divan/useDivanPendingCount.ts
@@ -1,0 +1,20 @@
+/**
+ * `useDivanPendingCount` — the topbar divan glyph's pending-review count (#6760).
+ *
+ * A one-shot imperative read (`useImperativeView`) because it mounts in the `Layout`
+ * shell above any `<Screen>` Suspense boundary. Deliberately NOT a live subscription
+ * (#6760): the badge is a pull-the-yazar nudge, not a queue meter, so it re-reads on
+ * navigation like the rest of the chips. Enabled only once `useDivanAccess` granted,
+ * so the gated wire read fires only for subjects with divan standing; any denial (or
+ * an unset count) fails closed to `undefined` — no number, no badge.
+ */
+import {view} from "react-fate";
+import type {DivanPending} from "../../../worker/features/fate/views";
+import {useImperativeView} from "../../fate/useImperativeView";
+
+const DivanPendingView = view<DivanPending>()({id: true, count: true});
+
+export function useDivanPendingCount(enabled: boolean): number | undefined {
+	const {state} = useImperativeView("divan.pendingCount", DivanPendingView, {enabled});
+	return state.status === "ok" ? state.data?.count : undefined;
+}

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -65,6 +65,11 @@
 .kp-topbar__signal-link .kp-icon {
 	color: inherit;
 }
+/* The divan glyph's pending-count badge (#6760) — the bildirim bell's count idiom, so it
+   rides the link's inline-flex box and only needs its type token pinned here. */
+.kp-topbar__signal-link .kp-topbar__count {
+	font: var(--t-meta);
+}
 .kp-topbar__nav a:hover,
 .kp-topbar__signal-link:hover {
 	color: var(--text-primary);

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -229,6 +229,30 @@ describe("Topbar status/signal zone (#2613)", () => {
 		expect(divan.querySelector("svg")).not.toBeNull();
 		expect(screen.getByRole("link", {name: "divan"})).toBe(divan);
 	});
+
+	// #6760: the pending-count badge rides the existing glyph with the bildirim bell's exact
+	// grammar — the same two helpers, so zero hides and >99 caps at 99+.
+	it("the divan glyph renders a nonzero pending count as a badge", () => {
+		renderStatus({divanPending: 3});
+		const divan = screen.getByTestId("topbar-divan-link");
+		expect(divan.textContent).toContain("3");
+		expect(screen.getByRole("link", {name: "divan"})).toBe(divan);
+	});
+
+	it("a zero pending count hides the badge", () => {
+		renderStatus({divanPending: 0});
+		expect(screen.getByTestId("topbar-divan-link").textContent).not.toContain("0");
+	});
+
+	it("an unset pending count renders no badge", () => {
+		renderStatus({divanPending: undefined});
+		expect(screen.getByTestId("topbar-divan-link").textContent).toBe("");
+	});
+
+	it("a pending count over 99 renders the 99+ overflow cap", () => {
+		renderStatus({divanPending: 150});
+		expect(screen.getByTestId("topbar-divan-link").textContent).toContain("99+");
+	});
 });
 
 describe("Topbar tema toggle → theme picker (#2612)", () => {

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -5,10 +5,11 @@ import {Link, NavLink} from "react-router";
 import {isSearchShortcut} from "../../lib/searchShortcut";
 import type {ThemeChoice} from "../../lib/theme";
 import {BildirimPopover} from "../bildirim/BildirimPopover";
-import {showUnreadBadge} from "../bildirim/bildirim";
+import {formatUnreadBadge, showUnreadBadge} from "../bildirim/bildirim";
 import {Icon} from "../Icon";
 import {Karma} from "../karma/Karma";
 import {Kbd} from "../ui/atoms";
+import {Badge} from "../ui/Badge";
 import {Input} from "../ui/Form";
 import {ThemeChoicePicker} from "./ThemeChoicePicker";
 import {UserMenu} from "./UserMenu";
@@ -21,6 +22,7 @@ export function Topbar({
 	brandTo = "/",
 	nav = [],
 	divanTo,
+	divanPending,
 	user,
 	karma,
 	bildirim,
@@ -36,6 +38,8 @@ export function Topbar({
 	brandTo?: string;
 	nav?: NavItem[];
 	divanTo?: string;
+	/** The divan glyph's pending-review count (#6760); `undefined`/0 renders no badge. */
+	divanPending?: number;
 	user?: {name: string; src?: string; username?: string | null};
 	karma?: number;
 	bildirim?: {to: string; unread: number};
@@ -90,6 +94,14 @@ export function Topbar({
 			title="divan"
 		>
 			<Icon icon={Gavel} size={16} />
+			{/* The bildirim bell's exact badge grammar (#6760): the same Badge + the same two
+		    helpers, so zero hides and >99 caps at 99+. aria-hidden — the glyph's accessible
+		    name stays "divan", the count is a visual pull, not a value to announce. */}
+			{divanPending !== undefined && showUnreadBadge(divanPending) ? (
+				<Badge variant="secondary" size="sm" className="kp-topbar__count" aria-hidden="true">
+					{formatUnreadBadge(divanPending)}
+				</Badge>
+			) : null}
 		</NavLink>
 	) : null;
 	const searchForm = (

--- a/apps/web/src/fate/useImperativeView.test.tsx
+++ b/apps/web/src/fate/useImperativeView.test.tsx
@@ -37,6 +37,19 @@ describe("useImperativeView — the hook over its React interface", () => {
 		expect(request).not.toHaveBeenCalled();
 	});
 
+	it("stays idle with NO FateClient provider while disabled (#6760)", async () => {
+		// The shell mounts enabled-off imperative hooks fate-free (first paint #2160),
+		// so a missing provider must not throw until the read actually enables.
+		const {result} = renderHook(() => useImperativeView("test", TestView, {enabled: false}));
+		await waitFor(() => expect(result.current.state.status).toBe("idle"));
+	});
+
+	it("still throws when enabled with no FateClient provider", () => {
+		expect(() => renderHook(() => useImperativeView("test", TestView, {enabled: true}))).toThrow(
+			/FateClient/,
+		);
+	});
+
 	it("drives the mount read to an ok state carrying the cast-surfaced data", async () => {
 		const request = vi.fn().mockResolvedValue({test: "ref-1"});
 		const readView = vi.fn().mockResolvedValue({data: DATA, coverage: []});

--- a/apps/web/src/fate/useImperativeView.ts
+++ b/apps/web/src/fate/useImperativeView.ts
@@ -58,6 +58,21 @@ export interface UseImperativeViewOptions {
 }
 
 /**
+ * A disabled read needs no client, so a missing provider is only fatal when enabled
+ * (#6760): the shell mounts enabled-off imperative hooks above any FateProvider, and
+ * demanding a context there would break every fate-free first-paint render. The hook
+ * call itself stays unconditional — the catch demotes the throw, not the read.
+ */
+function useFateClientWhenEnabled(enabled: boolean): ImperativeViewClient | null {
+	try {
+		return useFateClient();
+	} catch (err) {
+		if (enabled) throw err;
+		return null;
+	}
+}
+
+/**
  * A `null` ref (root resolved to nothing) is a successful `ok` with `data: null`, NOT
  * an error — the caller decides what a null result means (#448).
  */
@@ -66,11 +81,11 @@ export function useImperativeView<V extends View<any, any>>(
 	view: V,
 	{args, enabled, deps = []}: UseImperativeViewOptions,
 ): {readonly state: ImperativeViewState<V>; readonly refetch: () => Promise<void>} {
-	const fate = useFateClient();
+	const fate = useFateClientWhenEnabled(enabled);
 	const [state, setState] = useState<ImperativeViewState<V>>({status: "idle"});
 
 	const refetch = useCallback(async () => {
-		if (!enabled) {
+		if (!enabled || fate == null) {
 			setState({status: "idle"});
 			return;
 		}

--- a/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
@@ -80,12 +80,14 @@ const divanPending = (count: number): Layer.Layer<Divan> =>
 		roster: () => Effect.die(new Error("Divan.roster not exercised")),
 		backlogOf: () => Effect.die(new Error("Divan.backlogOf not exercised")),
 		pendingCountOf: () => Effect.succeed(count),
+		pendingTotal: () => Effect.die(new Error("Divan.pendingTotal not exercised")),
 	});
 
 const divanDies: Layer.Layer<Divan> = Layer.succeed(Divan, {
 	roster: () => Effect.die(new Error("Divan.roster not exercised")),
 	backlogOf: () => Effect.die(new Error("Divan.backlogOf not exercised")),
 	pendingCountOf: () => Effect.die(new Error("Divan.pendingCountOf must not be read")),
+	pendingTotal: () => Effect.die(new Error("Divan.pendingTotal must not be read")),
 });
 
 describe("modRecipients — moderator resolution + actor self-suppression, pure", () => {

--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -33,6 +33,12 @@ export class Divan extends Context.Service<
 		// plain-string author id — branding this param would fail typecheck in that
 		// out-of-feature site, which epic #2700's report slice (#2721) does not touch.
 		readonly pendingCountOf: (authorId: string) => Effect.Effect<number>;
+		/**
+		 * The whole-roster pending total (#6760) — the topbar badge's read. Unlike
+		 * {@link pendingCountOf} it needs no identity join, so it skips the profile read
+		 * entirely: the badge is a number, not a roster.
+		 */
+		readonly pendingTotal: () => Effect.Effect<number>;
 	}
 >()("divan/Divan") {}
 
@@ -108,6 +114,7 @@ export const DivanLive = Layer.effect(Divan)(
 					[...items].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
 				),
 			pendingCountOf: (authorId) => Effect.map(collect({authorId}), (items) => items.length),
+			pendingTotal: () => Effect.map(collect(), (items) => items.length),
 		};
 	}),
 );

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -223,6 +223,29 @@ describe("Divan.roster — person-grouped, removed & live excluded", () => {
 	});
 });
 
+describe("Divan.pendingTotal — the whole-roster count the badge reads (#6760)", () => {
+	// DEFS+POSTS+COMMENTS hold four live sandboxed rows (d1, d3, p1, c1); the removed and
+	// never-sandboxed ones must not count.
+	it("counts every pending item across authors; removed and live rows excluded", () => {
+		assert.strictEqual(
+			Effect.runSync(Effect.flatMap(Divan, (d) => d.pendingTotal()).pipe(Effect.provide(layer))),
+			4,
+		);
+	});
+
+	it("an empty backlog reads 0", () => {
+		const emptyLayer = DivanLive.pipe(
+			Layer.provideMerge(Layer.mergeAll(sozlukStub([]), panoStub([], []), pasaportStub([]))),
+		);
+		assert.strictEqual(
+			Effect.runSync(
+				Effect.flatMap(Divan, (d) => d.pendingTotal()).pipe(Effect.provide(emptyLayer)),
+			),
+			0,
+		);
+	});
+});
+
 describe("Divan preview — a short excerpt, never the full node", () => {
 	const longBody = "söz ".repeat(200).trim(); // ~799 chars, well past the 280 excerpt cap
 	const longLayer = DivanLive.pipe(

--- a/apps/web/worker/features/divan/fate-module.ts
+++ b/apps/web/worker/features/divan/fate-module.ts
@@ -3,18 +3,27 @@ import {list} from "@nkzw/fate/server";
 import type {FateModule, FateRootsRecord} from "../fate/module.ts";
 import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
-import {divanBacklogItemSource, divanCaylakSource, divanVoteReceiptSource} from "./sources.ts";
-import {divanBacklogItemDataView, divanCaylakDataView} from "./views.ts";
+import {queries} from "./queries.ts";
+import {
+	divanBacklogItemSource,
+	divanCaylakSource,
+	divanPendingSource,
+	divanVoteReceiptSource,
+} from "./sources.ts";
+import {divanBacklogItemDataView, divanCaylakDataView, divanPendingDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
 	// The `divan.*` resolvers own the order: roster by pending desc, backlog newest-first.
 	"divan.roster": list(divanCaylakDataView),
 	"divan.backlog": list(divanBacklogItemDataView),
+	// A synthetic singleton, in the `bildirim.unreadCount` shape (#6760).
+	"divan.pendingCount": divanPendingDataView,
 };
 
 export const fateModule = {
 	lists,
 	mutations,
-	sources: [divanCaylakSource, divanBacklogItemSource, divanVoteReceiptSource],
+	queries,
+	sources: [divanCaylakSource, divanBacklogItemSource, divanVoteReceiptSource, divanPendingSource],
 	roots,
 } satisfies FateModule;

--- a/apps/web/worker/features/divan/queries.ts
+++ b/apps/web/worker/features/divan/queries.ts
@@ -1,0 +1,35 @@
+/**
+ * `divan.pendingCount` — the topbar badge's read (#6760): a synthetic singleton
+ * carrying how many sandbox-backlog items await divan review. It sits behind the SAME
+ * disjunctive {@link requireDivanAccess} gate `divan.roster`/`divan.backlog` enforce,
+ * so a çaylak or visitor is denied at the wire exactly as they are there — the badge
+ * never widens who can read the divan, it only gives its existing audience a reason to
+ * open it. No flag, no `/fate/live` topic: a plain one-shot query.
+ */
+import {Fate} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Denied} from "../kunye/errors.ts";
+import {Divan} from "./Divan.ts";
+import {requireDivanAccess, ViewDivan} from "./gate.ts";
+
+/** The `bildirim.unreadCount` singleton idiom (`UNREAD_SINGLETON_ID`). */
+export const PENDING_SINGLETON_ID = "pending";
+
+// The handler stamps `__typename` itself: an inline-resolved entity has no source that
+// would stamp it (the same call `lists.ts` makes for its two views).
+const pendingGated = Effect.fn("divan.pendingGated")(function* () {
+	yield* ViewDivan;
+	const divan = yield* Divan;
+	const count = yield* divan.pendingTotal();
+	return {__typename: "DivanPending" as const, id: PENDING_SINGLETON_ID, count};
+});
+
+export const queries = {
+	"divan.pendingCount": Fate.query(
+		{type: "DivanPending", error: Schema.Union([Denied])},
+		Effect.fn("divan.pendingCount")(function* () {
+			return yield* requireDivanAccess(pendingGated());
+		}),
+	),
+};

--- a/apps/web/worker/features/divan/queries.unit.test.ts
+++ b/apps/web/worker/features/divan/queries.unit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `divan.pendingCount` — the topbar badge's read (#6760), driven through the REAL
+ * `requireDivanAccess` gate the way `gate.unit.test.ts` proves it: a yazar and a mod are
+ * both served (the badge must not be a `tier === "yazar"` check), while a çaylak and an
+ * unauthenticated actor draw the same invisible `Denied` `divan.roster` gives them. The
+ * count itself comes off a stubbed {@link Divan}, so what is asserted is the gate + shape,
+ * not the backlog predicate (that is `Divan.unit.test.ts`'s).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	human,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {Effect, Exit, Layer} from "effect";
+import type {Denied} from "../kunye/errors.ts";
+import {Kunye} from "../kunye/Kunye.ts";
+import type {Tier} from "../kunye/standing.ts";
+import {Divan} from "./Divan.ts";
+import {queries} from "./queries.ts";
+
+const pendingCountQuery = queries["divan.pendingCount"];
+
+const divanStub = (count: number): Layer.Layer<Divan> =>
+	// biome-ignore lint/plugin: a service double — only the whole-roster total is on this path.
+	Layer.succeed(Divan, {
+		pendingTotal: () => Effect.succeed(count),
+	} as unknown as typeof Divan.Service);
+
+const resolveAs = (
+	actor: Actor,
+	opts: {
+		readonly tier?: Tier;
+		readonly mods?: ReadonlyArray<string>;
+		readonly count?: number;
+	} = {},
+): Exit.Exit<
+	{readonly __typename: "DivanPending"; readonly id: string; readonly count: number},
+	Denied
+> =>
+	Effect.runSyncExit(
+		pendingCountQuery.resolve({select: []}).pipe(
+			Effect.provide(divanStub(opts.count ?? 0)),
+			Effect.provideService(CurrentActor, {actor}),
+			Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+			Effect.provideService(Kunye, {
+				tierOf: () => Effect.succeed(opts.tier ?? ("visitor" as const)),
+				karmaOf: (_id: string) => Effect.die(new Error("divan gate must not read karma")),
+				rootOf: (id: string) => Effect.succeed(id),
+			}),
+			Effect.provideService(RelationStore, {
+				has: (tuple) =>
+					Effect.succeed(
+						tuple.relation === "moderates" &&
+							tuple.object.type === "platform" &&
+							(opts.mods ?? []).includes(tuple.subject),
+					),
+				hasSubjects: ({subjects, relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform"
+								? subjects.filter((s) => (opts.mods ?? []).includes(s))
+								: [],
+						),
+					),
+				subjectsOf: ({relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform" ? (opts.mods ?? []) : [],
+						),
+					),
+			}),
+		),
+	);
+
+describe("divan.pendingCount — the divan gate, not a tier equality (#6760)", () => {
+	it("a yazar reads the pending singleton with the service's count", () => {
+		const exit = resolveAs(human("u"), {tier: "yazar", count: 7});
+		assert.isTrue(Exit.isSuccess(exit));
+		if (!Exit.isSuccess(exit)) return;
+		assert.deepStrictEqual(exit.value, {
+			__typename: "DivanPending",
+			id: "pending",
+			count: 7,
+		});
+	});
+
+	it("a platform moderator who is only a çaylak is served too — the disjunctive arm", () => {
+		const exit = resolveAs(human("u"), {tier: "çaylak", mods: ["u"], count: 2});
+		assert.isTrue(Exit.isSuccess(exit));
+		if (!Exit.isSuccess(exit)) return;
+		assert.strictEqual(exit.value.count, 2);
+	});
+
+	it("a çaylak with no moderation is denied at the wire, exactly as divan.roster denies", () => {
+		assert.isTrue(Exit.isFailure(resolveAs(human("u"), {tier: "çaylak"})));
+	});
+
+	it("an unauthenticated actor is denied", () => {
+		assert.isTrue(Exit.isFailure(resolveAs(unauthenticated)));
+	});
+});

--- a/apps/web/worker/features/divan/sources.ts
+++ b/apps/web/worker/features/divan/sources.ts
@@ -1,12 +1,18 @@
 /**
- * Divan fate sources — both views are delivered INLINE by their `divan.*` list
- * resolver and never read by id (a private moderation/proving-ground surface), so
+ * Divan fate sources — every view here is delivered INLINE by its `divan.*` resolver
+ * and never read by id (a private moderation/proving-ground surface), so
  * each is a capability-less `Fate.syntheticSource` (view-reachable, no fetch path).
  * Mirrors `report`'s `OpenReport` source. See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
-import {DivanBacklogItemView, DivanCaylakView, DivanVoteReceiptView} from "./views.ts";
+import {
+	DivanBacklogItemView,
+	DivanCaylakView,
+	DivanPendingView,
+	DivanVoteReceiptView,
+} from "./views.ts";
 
 export const divanCaylakSource = Fate.syntheticSource(DivanCaylakView);
 export const divanBacklogItemSource = Fate.syntheticSource(DivanBacklogItemView);
 export const divanVoteReceiptSource = Fate.syntheticSource(DivanVoteReceiptView);
+export const divanPendingSource = Fate.syntheticSource(DivanPendingView);

--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -67,6 +67,26 @@ export const divanBacklogItemDataView = DivanBacklogItemView.view;
 export type DivanBacklogItem = WorkerEntity<typeof DivanBacklogItemView>;
 
 /**
+ * The topbar badge's synthetic singleton (#6760): one row carrying how many
+ * sandbox-backlog items await divan review. Delivered inline by the
+ * `divan.pendingCount` query (no by-id read), so like the other two private views its
+ * source is capability-less.
+ */
+export type DivanPendingViewRow = ViewRow<{
+	id: string;
+	count: number;
+}>;
+
+export class DivanPendingView extends FateDataView<DivanPendingViewRow>()("DivanPending")({
+	id: true,
+	count: true,
+} as const satisfies {[K in keyof DivanPendingViewRow]: true}) {}
+
+export const divanPendingDataView = DivanPendingView.view;
+
+export type DivanPending = WorkerEntity<typeof DivanPendingView>;
+
+/**
  * The receipt a `divan.vote` returns, delivered inline by the mutation (no by-id read), so
  * its source is a capability-less `Fate.syntheticSource` like the other two. `id` is the
  * `<kind>:<itemId>` composite — the same identity as {@link DivanBacklogItemView}.

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -14,7 +14,12 @@ import type {
 	NotificationView,
 } from "../bildirim/views.ts";
 import type {CaylakVisibilityPreferenceView} from "../caylak-visibility/views.ts";
-import type {DivanBacklogItemView, DivanCaylakView, DivanVoteReceiptView} from "../divan/views.ts";
+import type {
+	DivanBacklogItemView,
+	DivanCaylakView,
+	DivanPendingView,
+	DivanVoteReceiptView,
+} from "../divan/views.ts";
 import type {FunnelSummaryView} from "../funnel/views.ts";
 import type {MecmuaPostView, MecmuaSubscriptionReceiptView} from "../mecmua/views.ts";
 import type {MutedMemberView, MuteReceiptView} from "../mute/views.ts";
@@ -59,10 +64,16 @@ export {
 } from "../bildirim/views.ts";
 export type {CaylakVisibilityPreference} from "../caylak-visibility/views.ts";
 export {caylakVisibilityPreferenceDataView} from "../caylak-visibility/views.ts";
-export type {DivanBacklogItem, DivanCaylak, DivanVoteReceipt} from "../divan/views.ts";
+export type {
+	DivanBacklogItem,
+	DivanCaylak,
+	DivanPending,
+	DivanVoteReceipt,
+} from "../divan/views.ts";
 export {
 	divanBacklogItemDataView,
 	divanCaylakDataView,
+	divanPendingDataView,
 	divanVoteReceiptDataView,
 } from "../divan/views.ts";
 export type {FunnelSummary} from "../funnel/views.ts";
@@ -163,6 +174,7 @@ type _FateViewsFieldMapResolved = [
 	>,
 	AssertResolved<typeof DivanCaylakView, AssertFieldMapResolved<typeof DivanCaylakView>>,
 	AssertResolved<typeof DivanBacklogItemView, AssertFieldMapResolved<typeof DivanBacklogItemView>>,
+	AssertResolved<typeof DivanPendingView, AssertFieldMapResolved<typeof DivanPendingView>>,
 	AssertResolved<typeof DivanVoteReceiptView, AssertFieldMapResolved<typeof DivanVoteReceiptView>>,
 	AssertResolved<typeof FunnelSummaryView, AssertFieldMapResolved<typeof FunnelSummaryView>>,
 	AssertResolved<typeof MecmuaPostView, AssertFieldMapResolved<typeof MecmuaPostView>>,

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -62,6 +62,7 @@ const divanStub = Layer.succeed(Divan, {
 	roster: () => Effect.die("Divan.roster not exercised in definition-mutation"),
 	backlogOf: () => Effect.die("Divan.backlogOf not exercised in definition-mutation"),
 	pendingCountOf: () => Effect.die("Divan.pendingCountOf not exercised in definition-mutation"),
+	pendingTotal: () => Effect.die("Divan.pendingTotal not exercised in definition-mutation"),
 });
 const relationStoreStub = Layer.succeed(RelationStore, {
 	has: () => Effect.die("RelationStore.has not exercised in definition-mutation"),


### PR DESCRIPTION
## Problem

Nothing pulls a yazar into `/divan`, so review attention reaches a week-1 çaylak only by accident. The topbar's divan entry was a bare, unbadged glyph with no count anywhere in its prop type (#6760).

## What changed

**Worker — a new gated count read over `/fate`:**

- `Divan.pendingTotal()` — the whole-roster pending item count off the same `collect()` read model the roster uses; unlike `pendingCountOf` it needs no profile-identity join, since the badge is a number, not a roster.
- `divan.pendingCount` query (`worker/features/divan/queries.ts`) returning a synthetic `DivanPending` singleton (the `bildirim.unreadCount` idiom), wrapped in the SAME disjunctive `requireDivanAccess` gate `divan.roster`/`divan.backlog` enforce — so a çaylak or visitor is denied at the wire exactly as they are there. No flag, no `/fate/live` topic.

**Client — the badge on the existing glyph:**

- `useDivanPendingCount(enabled)` — a one-shot imperative read (`useImperativeView`, no live subscription), enabled only once `useDivanAccess` has granted, so the gated read fires only for subjects with divan standing.
- `Topbar` gains an optional `divanPending` prop alongside `divanTo`; the component never fetches. When nonzero it renders `Badge variant="secondary" size="sm"` inside the Gavel link via the existing `showUnreadBadge` / `formatUnreadBadge` helpers — zero hides, >99 caps at `99+`, exactly the bildirim bell's grammar.
- The gate-derived visibility carries through: signed-out users and çaylaks get neither glyph nor badge (`divanTo` undefined ⇒ nothing mounts), and the badge audience is yazar **or** platform moderator — derived from the gate, never a `tier === "yazar"` equality.

Grounding for the gate shape: `worker/features/divan/gate.ts` discharges `DivanStanding` (min `yazar`) OR `Moderate.over(platform)`; the triage note on #6760 that the original's `tier === "yazar"` claim was wrong is honored here.

## Tests

- `queries.unit.test.ts` drives the real resolver through the real gate: yazar served, çaylak-tier platform mod served (the disjunctive arm), çaylak and unauthenticated denied.
- `Divan.unit.test.ts` covers `pendingTotal` (cross-author total, removed/live rows excluded, empty backlog reads 0).
- `Topbar.test.tsx` covers the badge's show / hide-at-zero / unset / `99+` overflow rendering.

Fixes #6760

## Deviations

- **Out-of-scope change** — **Said:** #6760 says the badge "does not touch `apps/web/worker/features/bildirim/`". **Did:** two mechanical lines in `worker/features/bildirim/mod-emitters.unit.test.ts`. **Why:** that file's `Divan` service doubles must satisfy the service type, which this change extends with `pendingTotal` — without the stub method those pre-existing tests stop compiling. No bildirim runtime code, emitter, or flag is touched. **Disposition:** stated here; the alternative (making `pendingTotal` optional on the service) would have weakened the contract for every real consumer instead.
