### PR TITLE
docs(roadmap): flip Diátaxis README passes campaign to active

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ flowchart TD
 		camp_ge_it_product_push["Geçit product push"]:::active
 		camp_lane_integrity["Lane integrity"]:::active
 		camp_epic_lanes["Epic lanes"]:::paused
-		camp_di_taxis_readme_passes["Diátaxis README passes"]:::paused
+		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -110,7 +110,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Geçit product push | #24 | active |
 | Lane integrity | #48 | active |
 | Epic lanes | #49 | paused |
-| Diátaxis README passes | #50 | paused |
+| Diátaxis README passes | #50 | active |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Founder ruling (session, 2026-08-23): mark the Diátaxis README passes campaign active and execute it. Cited marker: https://github.com/kamp-us/phoenix/issues/6713#issuecomment-5384608516

- `## Campaigns` row #50: paused → active (written by `fabrika campaign state`, read back)
- mermaid node `camp_di_taxis_readme_passes` restyled :::active in the same edit
- execution already in flight: lane 6490 carries the #7013–#7022 cure batch; README-truth passes (#4079–#4100, #6869) open next against the now-dispatching milestone