### PR TITLE
fix: Successful yazar promote leaves divan roster and backlog stale

### DIFF
--- a/apps/web/src/components/divan/CaylakDetail.promote-refresh.test.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.promote-refresh.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Regression pin for #7036: a settled `user.promote` from the divan reviewer actions
+ * must re-pull BOTH review roots (`divan.roster` + the open author's `divan.backlog`)
+ * network-only, so the promoted çaylak and their pending items leave the screen
+ * without a reload. Denials and transport errors must not touch either read.
+ *
+ * The fate hooks are stubbed at react-fate's boundary (the CaylakVisibilityToggle
+ * idiom): the REAL request builders from `./divanReads` flow through the component,
+ * so what the mount reads is asserted to be byte-identical to what the refresh
+ * re-pulls — the property that makes the refresh land on the rendered lists.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {CaylakDetail} from "./CaylakDetail";
+
+const h = vi.hoisted(() => {
+	const state = {
+		// Overridable per test: the fake `mutations.user.promote` result/throw.
+		promote: (() => ({
+			result: {promoted: true, vouchRecorded: false},
+			error: null,
+		})) as () => unknown,
+	};
+	const mountedRequests: Array<Record<string, unknown>> = [];
+	const clientRequests: Array<{request: unknown; options: unknown}> = [];
+	return {state, mountedRequests, clientRequests};
+});
+
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {
+		...actual,
+		useRequest: (request: Record<string, unknown>) => {
+			h.mountedRequests.push(request);
+			return Object.fromEntries(Object.keys(request).map((root) => [root, Symbol("connection")]));
+		},
+		useListView: () => [
+			[
+				{
+					cursor: "definition:d-1",
+					node: {id: "definition:d-1", kind: "definition", preview: "bir tanım"},
+				},
+			],
+			null,
+		],
+		useView: (_view: unknown, ref: unknown) =>
+			ref && typeof ref === "object" && "__typename" in (ref as object)
+				? // CaylakIdentityById's Profile ref.
+					{
+						userId: "u-1",
+						displayName: "Çaylak Kişi",
+						username: "caylak",
+						image: null,
+						totalKarma: 7,
+						definitionCount: 1,
+						postCount: 0,
+						commentCount: 0,
+					}
+				: ref,
+		useFateClient: () =>
+			({
+				mutations: {
+					user: {promote: () => h.state.promote()},
+					divan: {
+						vote: () => Promise.resolve({result: null, error: null}),
+						vouch: () => Promise.resolve({result: null, error: null}),
+					},
+					report: {submit: () => Promise.resolve({result: null, error: null})},
+				},
+				request: (request: unknown, options?: unknown) => {
+					h.clientRequests.push({request, options});
+					return Promise.resolve({});
+				},
+				ref: (_type: string, id: string) => ({__typename: "Profile", id}),
+			}) as never,
+	};
+});
+
+const clickPromote = () => fireEvent.click(screen.getByTestId("promote-button"));
+
+beforeEach(() => {
+	h.mountedRequests.length = 0;
+	h.clientRequests.length = 0;
+	h.state.promote = () => ({result: {promoted: true, vouchRecorded: false}, error: null});
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+function renderDetail() {
+	return render(<CaylakDetail authorId="u-1" viewerTier={undefined} viewerIsModerator={true} />);
+}
+
+describe("CaylakDetail promote refresh (#7036)", () => {
+	it("mounts exactly the shared builder's backlog shape", () => {
+		renderDetail();
+		expect(h.mountedRequests).toEqual([
+			{"divan.backlog": {list: expect.anything(), args: {authorId: "u-1", first: 50}}},
+		]);
+	});
+
+	it("a successful promote fires ONE network-only refresh naming both roots", async () => {
+		renderDetail();
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promote-status").textContent).toContain("yazar oldu"),
+		);
+		expect(h.clientRequests).toEqual([
+			{
+				request: {
+					"divan.roster": {list: expect.anything(), args: {first: 50}},
+					"divan.backlog": {list: expect.anything(), args: {authorId: "u-1", first: 50}},
+				},
+				options: {mode: "network-only"},
+			},
+		]);
+	});
+
+	it("an already-yazar answer ALSO refreshes — the double press repairs the stale screen", async () => {
+		h.state.promote = () => ({result: {promoted: false, vouchRecorded: false}, error: null});
+		renderDetail();
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promote-status").textContent).toContain("zaten yazar"),
+		);
+		expect(h.clientRequests).toHaveLength(1);
+		expect(h.clientRequests[0]?.options).toEqual({mode: "network-only"});
+	});
+
+	it("an UNAUTHORIZED denial changes nothing: no refresh, backlog still rendered", async () => {
+		h.state.promote = () => ({result: null, error: {code: "UNAUTHORIZED", message: "x"}});
+		renderDetail();
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promote-status").textContent).toContain("yetkin yok"),
+		);
+		expect(h.clientRequests).toHaveLength(0);
+		expect(screen.getByTestId("divan-item-definition:d-1")).toBeTruthy();
+	});
+
+	it("a thrown transport error likewise leaves both reads untouched", async () => {
+		h.state.promote = () => {
+			throw new Error("boundary-class refusal");
+		};
+		renderDetail();
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promote-status").textContent).toContain("işlem başarısız oldu"),
+		);
+		expect(h.clientRequests).toHaveLength(0);
+		expect(screen.getByTestId("divan-item-definition:d-1")).toBeTruthy();
+	});
+});

--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -8,7 +8,6 @@
 import {useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {
-	DivanBacklogItem,
 	DivanVoteReceipt,
 	PromotionReceipt,
 	ReportReceipt,
@@ -27,22 +26,17 @@ import {
 	parseBacklogItemId,
 	promoteOutcome,
 	promoteOutcomeMessage,
+	promoteRefreshWarranted,
 	promoteVisible,
 	vouchVisible,
 } from "./divanGating";
+import {
+	BacklogConnectionView,
+	BacklogItemView,
+	divanBacklogRequest,
+	refreshDivanReview,
+} from "./divanReads";
 import {VouchSheet} from "./VouchSheet";
-
-const BACKLOG_PAGE_SIZE = 50;
-
-const BacklogItemView = view<DivanBacklogItem>()({
-	id: true,
-	kind: true,
-	authorId: true,
-	createdAt: true,
-	preview: true,
-});
-
-const BacklogConnectionView = {items: {node: BacklogItemView}} as const;
 
 const VoteReceiptView = view<DivanVoteReceipt>()({
 	id: true,
@@ -72,9 +66,7 @@ export function CaylakDetail({
 	readonly viewerTier: Tier | undefined;
 	readonly viewerIsModerator: boolean;
 }) {
-	const result = useRequest({
-		"divan.backlog": {list: BacklogConnectionView, args: {authorId, first: BACKLOG_PAGE_SIZE}},
-	});
+	const result = useRequest(divanBacklogRequest(authorId));
 	const [items] = useListView(BacklogConnectionView, result["divan.backlog"]);
 
 	return (
@@ -139,6 +131,11 @@ function ReviewerActions({
 				!!error && !denied,
 			);
 			setMessage(promoteOutcomeMessage(outcome));
+			// Fire-and-forget: the promote DID succeed, so a failed refresh must not
+			// overwrite its message — the lists just stay as they were.
+			if (promoteRefreshWarranted(outcome)) {
+				void refreshDivanReview(fate, authorId).catch(() => undefined);
+			}
 		} catch (caught) {
 			const code = codeOf(caught);
 			const denied = code === "UNAUTHORIZED" || code === "FORBIDDEN";

--- a/apps/web/src/components/divan/DivanRoster.tsx
+++ b/apps/web/src/components/divan/DivanRoster.tsx
@@ -5,26 +5,10 @@
  * per-row by-id `Profile` read and no per-row Suspense boundary (ADR 0021's no-waterfalls
  * contract); a since-deleted profile degrades to the bare "çaylak" label.
  */
-import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
-import type {DivanCaylak} from "../../../worker/features/fate/views";
+import {useListView, useRequest, useView, type ViewRef} from "react-fate";
 import {Button} from "../ui/Button";
 import {CaylakIdentity} from "./CaylakIdentity";
-
-const ROSTER_PAGE_SIZE = 50;
-
-const RosterRowView = view<DivanCaylak>()({
-	id: true,
-	authorId: true,
-	username: true,
-	displayName: true,
-	totalKarma: true,
-	definitionCount: true,
-	postCount: true,
-	commentCount: true,
-	totalCount: true,
-});
-
-const RosterConnectionView = {items: {node: RosterRowView}} as const;
+import {divanRosterRequest, RosterConnectionView, RosterRowView} from "./divanReads";
 
 export function DivanRoster({
 	selectedId,
@@ -33,9 +17,7 @@ export function DivanRoster({
 	readonly selectedId: string | null;
 	readonly onSelect: (authorId: string) => void;
 }) {
-	const result = useRequest({
-		"divan.roster": {list: RosterConnectionView, args: {first: ROSTER_PAGE_SIZE}},
-	});
+	const result = useRequest(divanRosterRequest());
 	const [items] = useListView(RosterConnectionView, result["divan.roster"]);
 
 	if (items.length === 0) {

--- a/apps/web/src/components/divan/divanGating.ts
+++ b/apps/web/src/components/divan/divanGating.ts
@@ -95,6 +95,16 @@ export function promoteOutcomeMessage(outcome: PromoteOutcome): string {
 	}
 }
 
+/**
+ * Which promote outcomes warrant re-pulling the review reads (#7036). A flip leaves
+ * roster/backlog stale; an "already yazar" answer means the screen was ALREADY stale
+ * when pressed (the double-press case), so it refreshes too. A denial or transport
+ * error says nothing about the lists — their rendering stays untouched.
+ */
+export function promoteRefreshWarranted(outcome: PromoteOutcome): boolean {
+	return outcome === "promoted" || outcome === "alreadyYazar";
+}
+
 export type VouchOutcome = "promoted" | "recorded" | "limit" | "denied" | "error";
 
 export function vouchOutcome(

--- a/apps/web/src/components/divan/divanReads.test.ts
+++ b/apps/web/src/components/divan/divanReads.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, it, vi} from "vitest";
+import {promoteRefreshWarranted} from "./divanGating";
+import {divanBacklogRequest, divanRosterRequest, refreshDivanReview} from "./divanReads";
+
+describe("divan request builders — the one shape both the mounted read and the refresh use (#7036)", () => {
+	it("the roster request names the gated divan.roster root with its page size", () => {
+		expect(divanRosterRequest()).toEqual({
+			"divan.roster": {list: expect.anything(), args: {first: 50}},
+		});
+	});
+
+	it("the backlog request scopes to the open author", () => {
+		expect(divanBacklogRequest("u-1")).toEqual({
+			"divan.backlog": {list: expect.anything(), args: {authorId: "u-1", first: 50}},
+		});
+	});
+
+	it("both builders are stable across calls, so a re-driven request hits the same keys", () => {
+		expect(divanRosterRequest()).toEqual(divanRosterRequest());
+		expect(divanBacklogRequest("u-1")).toEqual(divanBacklogRequest("u-1"));
+	});
+});
+
+describe("refreshDivanReview — one network-only re-pull of both review roots (#7036)", () => {
+	it("issues ONE network-only request carrying both roots", () => {
+		const client = {request: vi.fn(async () => ({}))};
+		void refreshDivanReview(client as never, "u-1");
+		expect(client.request).toHaveBeenCalledTimes(1);
+		expect(client.request).toHaveBeenCalledWith(
+			{
+				"divan.roster": {list: expect.anything(), args: {first: 50}},
+				"divan.backlog": {list: expect.anything(), args: {authorId: "u-1", first: 50}},
+			},
+			{mode: "network-only"},
+		);
+	});
+
+	it("returns the client's promise so the caller can swallow a failed refresh", async () => {
+		const marker = Symbol("done");
+		const client = {request: vi.fn(async () => marker)};
+		await expect(refreshDivanReview(client as never, "u-1")).resolves.toBe(marker);
+	});
+});
+
+describe("promoteRefreshWarranted — which outcomes re-pull the reads (#7036)", () => {
+	it("a flip refreshes", () => {
+		expect(promoteRefreshWarranted("promoted")).toBe(true);
+	});
+	it("an already-yazar answer means the screen was already stale, so it refreshes too", () => {
+		expect(promoteRefreshWarranted("alreadyYazar")).toBe(true);
+	});
+	it("denied and errored attempts leave the rendering untouched", () => {
+		expect(promoteRefreshWarranted("denied")).toBe(false);
+		expect(promoteRefreshWarranted("error")).toBe(false);
+	});
+});

--- a/apps/web/src/components/divan/divanReads.ts
+++ b/apps/web/src/components/divan/divanReads.ts
@@ -1,0 +1,60 @@
+/**
+ * The two divan review reads in ONE place (#7036). Both are plain one-shot reads of
+ * gated private roots — the divan deliberately has no `/fate/live` topic — so nothing
+ * reconciles them after a mutation; the promote handler re-pulls them itself. The
+ * mounted reads and that refresh share these builders, so the re-driven request can
+ * only land on exactly the cache keys the rendered roster/backlog hold.
+ */
+import {type useFateClient, view} from "react-fate";
+import type {DivanBacklogItem, DivanCaylak} from "../../../worker/features/fate/views";
+
+export const BACKLOG_PAGE_SIZE = 50;
+export const ROSTER_PAGE_SIZE = 50;
+
+export const BacklogItemView = view<DivanBacklogItem>()({
+	id: true,
+	kind: true,
+	authorId: true,
+	createdAt: true,
+	preview: true,
+});
+
+export const BacklogConnectionView = {items: {node: BacklogItemView}} as const;
+
+export const RosterRowView = view<DivanCaylak>()({
+	id: true,
+	authorId: true,
+	username: true,
+	displayName: true,
+	totalKarma: true,
+	definitionCount: true,
+	postCount: true,
+	commentCount: true,
+	totalCount: true,
+});
+
+export const RosterConnectionView = {items: {node: RosterRowView}} as const;
+
+export const divanRosterRequest = () => ({
+	"divan.roster": {list: RosterConnectionView, args: {first: ROSTER_PAGE_SIZE}},
+});
+
+export const divanBacklogRequest = (authorId: string) => ({
+	"divan.backlog": {list: BacklogConnectionView, args: {authorId, first: BACKLOG_PAGE_SIZE}},
+});
+
+/**
+ * Re-pull both review roots over ONE network-only request, so a committed promote is
+ * reflected without a reload: the promoted çaylak leaves the roster and their pending
+ * items leave the backlog (fate derives each root list's key from root name + args +
+ * view, and a fresh fetch replaces that list state in place).
+ */
+export function refreshDivanReview(
+	client: ReturnType<typeof useFateClient>,
+	authorId: string,
+): Promise<unknown> {
+	return client.request(
+		{...divanRosterRequest(), ...divanBacklogRequest(authorId)},
+		{mode: "network-only"},
+	);
+}

--- a/apps/web/src/components/profile/PromotionActions.refresh.test.tsx
+++ b/apps/web/src/components/profile/PromotionActions.refresh.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Regression pin for #7036's profile leg: the profile-page promote handler mirrors the
+ * divan one — a settled tier answer (flip OR already-yazar) invokes the page-supplied
+ * post-success refresh; a denial or thrown transport error must not.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {PromotionActions} from "./PromotionActions";
+
+const h = vi.hoisted(() => {
+	const state = {
+		promote: (() => ({
+			result: {promoted: true, vouchRecorded: false},
+			error: null,
+		})) as () => unknown,
+	};
+	return {state};
+});
+
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {
+		...actual,
+		useFateClient: () =>
+			({
+				mutations: {
+					user: {promote: () => h.state.promote()},
+				},
+			}) as never,
+	};
+});
+
+const clickPromote = () => fireEvent.click(screen.getByTestId("promote-button"));
+
+afterEach(() => {
+	h.state.promote = () => ({result: {promoted: true, vouchRecorded: false}, error: null});
+});
+
+describe("PromotionActions post-success refresh (#7036)", () => {
+	it("a flip triggers the page refresh exactly once", async () => {
+		const onSuccessRefresh = vi.fn();
+		render(<PromotionActions userId="u-1" onSuccessRefresh={onSuccessRefresh} />);
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promotion-status").textContent).toContain("yazar oldu"),
+		);
+		expect(onSuccessRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("an already-yazar answer triggers it too — the stale page re-pulls", async () => {
+		h.state.promote = () => ({result: {promoted: false, vouchRecorded: false}, error: null});
+		const onSuccessRefresh = vi.fn();
+		render(<PromotionActions userId="u-1" onSuccessRefresh={onSuccessRefresh} />);
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promotion-status").textContent).toContain("zaten yazar"),
+		);
+		expect(onSuccessRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("an UNAUTHORIZED denial does not trigger any refresh", async () => {
+		h.state.promote = () => ({result: null, error: {code: "UNAUTHORIZED", message: "x"}});
+		const onSuccessRefresh = vi.fn();
+		render(<PromotionActions userId="u-1" onSuccessRefresh={onSuccessRefresh} />);
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promotion-status").textContent).toContain("yetkin yok"),
+		);
+		expect(onSuccessRefresh).not.toHaveBeenCalled();
+	});
+
+	it("a thrown transport error does not trigger any refresh", async () => {
+		h.state.promote = () => {
+			throw new Error("boundary-class refusal");
+		};
+		const onSuccessRefresh = vi.fn();
+		render(<PromotionActions userId="u-1" onSuccessRefresh={onSuccessRefresh} />);
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promotion-status").textContent).toContain("işlem başarısız oldu"),
+		);
+		expect(onSuccessRefresh).not.toHaveBeenCalled();
+	});
+
+	it("renders fine with no refresh supplied (prop is optional)", async () => {
+		render(<PromotionActions userId="u-1" />);
+		clickPromote();
+		await waitFor(() =>
+			expect(screen.getByTestId("promotion-status").textContent).toContain("yazar oldu"),
+		);
+	});
+});

--- a/apps/web/src/components/profile/PromotionActions.tsx
+++ b/apps/web/src/components/profile/PromotionActions.tsx
@@ -11,7 +11,7 @@ import {useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {PromotionReceipt} from "../../../worker/features/fate/views";
 import {codeOf} from "../../fate/wire";
-import {promoteVisible} from "../divan/divanGating";
+import {promoteRefreshWarranted, promoteVisible} from "../divan/divanGating";
 import {Alert} from "../ui/Alert";
 import {Button} from "../ui/Button";
 
@@ -58,7 +58,14 @@ export function promotionOutcomeMessage(outcome: PromotionOutcome): string {
 	}
 }
 
-export function PromotionActions({userId}: {userId: string}) {
+export function PromotionActions({
+	userId,
+	onSuccessRefresh,
+}: {
+	userId: string;
+	/** Invoked when the answer is evidence about the user's tier — the page re-pulls its own read. */
+	onSuccessRefresh?: () => void;
+}) {
 	const fate = useFateClient();
 	const [busy, setBusy] = useState(false);
 	const [message, setMessage] = useState("");
@@ -71,7 +78,9 @@ export function PromotionActions({userId}: {userId: string}) {
 				input: {userId},
 				view: PromotionReceiptView,
 			});
-			setMessage(promotionOutcomeMessage(promoteOutcome(result, error)));
+			const outcome = promoteOutcome(result, error);
+			setMessage(promotionOutcomeMessage(outcome));
+			if (promoteRefreshWarranted(outcome)) onSuccessRefresh?.();
 		} catch (caught) {
 			setMessage(promotionOutcomeMessage(errorOutcome(caught)));
 		} finally {

--- a/apps/web/src/components/profile/profileReads.ts
+++ b/apps/web/src/components/profile/profileReads.ts
@@ -1,0 +1,23 @@
+/**
+ * The profile page's own read in ONE place (#7036) — the `profile` query root, its
+ * page size, and the connection view the contributions list renders through. The
+ * mounted read and the post-promote refetch share these, so the re-driven request can
+ * only land on exactly the cache keys the rendered page holds.
+ */
+import {view} from "react-fate";
+import type {Profile} from "../../../worker/features/fate/views";
+import {ContributionView} from "./ContributionRow";
+import {UserProfileHeaderView} from "./UserProfileHeader";
+
+export const PROFILE_PAGE_SIZE = 20;
+
+export const ContributionsConnectionView = {items: {node: ContributionView}} as const;
+
+export const UserProfileView = view<Profile>()({
+	...UserProfileHeaderView,
+	contributions: ContributionsConnectionView,
+});
+
+export const profileRequest = (username: string) => ({
+	profile: {view: UserProfileView, args: {username, contributions: {first: PROFILE_PAGE_SIZE}}},
+});

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -2,32 +2,28 @@
  * Public user profile page. The nested `contributions` connection switches on a `kind`
  * discriminant (ADR 0018); see `.patterns/fate-connections.md` for the masking rules.
  */
-import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {useCallback} from "react";
+import {useFateClient, useListView, useRequest, useView, type ViewRef} from "react-fate";
 import {useParams} from "react-router";
-import type {Profile} from "../../worker/features/fate/views";
 import {useMe} from "../auth/useMe";
 import {shouldShowCaylakStatus} from "../components/profile/CaylakStatusBlock";
-import {ContributionRow, ContributionView} from "../components/profile/ContributionRow";
+import {ContributionRow} from "../components/profile/ContributionRow";
 import {PromotionActions, shouldShowPromotionActions} from "../components/profile/PromotionActions";
 import {
 	CONTRIBUTIONS_EMPTY,
 	CONTRIBUTIONS_HEADING,
 } from "../components/profile/profileContributions";
+import {
+	ContributionsConnectionView,
+	profileRequest,
+	UserProfileView,
+} from "../components/profile/profileReads";
 import {UserProfileHeader, UserProfileHeaderView} from "../components/profile/UserProfileHeader";
 import {EmptyState} from "../components/ui/EmptyState";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
 import {NotFoundPage} from "./NotFoundPage";
 import "./UserProfilePage.css";
-
-const PAGE_SIZE = 20;
-
-const ContributionsConnectionView = {items: {node: ContributionView}} as const;
-
-const UserProfileView = view<Profile>()({
-	...UserProfileHeaderView,
-	contributions: ContributionsConnectionView,
-});
 
 export function UserProfilePage() {
 	const {username} = useParams<{username: string}>();
@@ -54,9 +50,14 @@ export function UserProfilePage() {
 }
 
 function UserProfileContent({username}: {username: string}) {
-	const {profile} = useRequest({
-		profile: {view: UserProfileView, args: {username, contributions: {first: PAGE_SIZE}}},
-	});
+	const fate = useFateClient();
+	const {profile} = useRequest(profileRequest(username));
+	// The same network-only re-pull the divan promote handler drives (#7036): a settled
+	// tier answer re-pulls this page's read so the rendered status can't stay stale.
+	const refetchProfile = useCallback(
+		() => fate.request(profileRequest(username), {mode: "network-only"}),
+		[fate, username],
+	);
 
 	if (!profile) {
 		return (
@@ -71,20 +72,29 @@ function UserProfileContent({username}: {username: string}) {
 		<div className="kp-user-profile" data-testid="user-profile-page">
 			<div className="kp-user-profile__inner">
 				<UserProfileHeader profile={profile} fallbackHandle={username} />
-				<ProfilePromotion profile={profile} />
+				<ProfilePromotion
+					profile={profile}
+					onSuccessRefresh={() => void refetchProfile().catch(() => undefined)}
+				/>
 				<ContributionsList profile={profile} />
 			</div>
 		</div>
 	);
 }
 
-function ProfilePromotion({profile}: {profile: ViewRef<"Profile">}) {
+function ProfilePromotion({
+	profile,
+	onSuccessRefresh,
+}: {
+	profile: ViewRef<"Profile">;
+	onSuccessRefresh?: () => void;
+}) {
 	const {userId} = useView(UserProfileHeaderView, profile);
 	const {me} = useMe();
 	// Mirror the divan's promote gate: mod-only + never own-profile (#1841). Absent
 	// me (loading / signed-out) reads as non-moderator ⇒ hidden.
 	if (!shouldShowPromotionActions(me?.isModerator ?? false, me?.id === userId)) return null;
-	return <PromotionActions userId={userId} />;
+	return <PromotionActions userId={userId} onSuccessRefresh={onSuccessRefresh} />;
 }
 
 function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {


### PR DESCRIPTION
A committed `user.promote` never reached the reviewer's screen. The divan roster/backlog (`DivanRoster`, `CaylakDetail`) and the profile page (`UserProfilePage`) render plain one-shot fate reads — the divan deliberately has no `/fate/live` topic — and neither promote handler touched read state, so the promoted çaylak stayed on screen until a reload and a second press reported "kullanıcı zaten yazar." against stale state (#7036).

## What changed

- **`divanReads.ts` (new)** — the two review reads get one home: the view selections, page sizes, request builders (`divanRosterRequest`, `divanBacklogRequest`), and `refreshDivanReview`, which re-pulls BOTH roots over one `network-only` request. `CaylakDetail` and `DivanRoster` mount their reads through the same builders, so the refresh can only land on exactly the cache keys the rendered lists hold (fate derives each root list's key deterministically from root name + args + view and replaces that list state in place).
- **`ReviewerActions.onPromote`** — after a settled outcome it fires the refresh fire-and-forget; a failed refresh must not overwrite the promote message, so its rejection is swallowed and the lists simply stay as they were.
- **`profileReads.ts` (new) + `UserProfilePage`** — the same treatment for the profile leg: the page's `profile` root read is built through one shared builder, and the page hands `PromotionActions` a network-only refetch (the established `refetchPost` idiom). The wiring is a callback prop because `PromotionActions` only knows the target's `userId`, while the page read is keyed by `username`.
- **`promoteRefreshWarranted`** (`divanGating.ts`, shared by both handlers) — which outcomes re-pull: `promoted` AND `alreadyYazar`. Denials (`UNAUTHORIZED`/`FORBIDDEN`) and transport errors say nothing about the lists and change nothing on screen.

## Tests

- `divanReads.test.ts` — builder shapes and stability, the single combined network-only refresh call, the outcome-gating table.
- `CaylakDetail.promote-refresh.test.tsx` — mounts the real detail surface over stubbed fate hooks: the mounted read is pinned equal to the builder's shape; success and already-yazar each fire exactly one network-only refresh naming both roots; denial and thrown transport error fire none and leave the backlog rendered.
- `PromotionActions.refresh.test.tsx` — the profile call site mirrors those cases against the supplied refetch callback.
- Existing `divanGating` / `PromotionActions` suites pass unchanged; `build check --surface code` (typecheck + lint, cache-bypassed) is green in this tree.

Fixes #7036

## Deviations

- **Refresh on the already-yazar answer** — **Said:** #7036 asks for a post-success refresh after a successful `user.promote`. **Did:** both handlers also re-pull when the server answers `promoted: false` ("kullanıcı zaten yazar."). **Why:** criterion 2 forbids a second press reporting that message while a stale entry is still rendered — the answer itself is evidence the screen was already stale, and the refresh is what repairs it. **Disposition:** stated here.
