### PR TITLE
fix(io): bound every GitHub HTTP exchange with a client-side timeout

### DIFF
--- a/packages/fabrika-cli/src/io/gh-api.ts
+++ b/packages/fabrika-cli/src/io/gh-api.ts
@@ -198,7 +198,6 @@ const served = <A>(
 	read: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<A, unknown>,
 ): Api<Served<A>> =>
 	HttpClient.execute(request).pipe(
-		Effect.timeout(Duration.seconds(githubHttpTimeoutSeconds())),
 		Effect.flatMap((response) =>
 			Effect.map(
 				read(response),
@@ -210,6 +209,10 @@ const served = <A>(
 				}),
 			),
 		),
+		// The bound covers the WHOLE exchange — connect through final body byte. Above
+		// `flatMap(read)` it would spare a stalled body stream, which dies exactly as hard as a
+		// black-holed connect (#7025 criterion 4).
+		Effect.timeout(Duration.seconds(githubHttpTimeoutSeconds())),
 		Effect.catch((error: unknown) =>
 			Effect.succeed<Served<A>>({
 				_tag: "Unreachable",

--- a/packages/fabrika-cli/src/io/gh-api.ts
+++ b/packages/fabrika-cli/src/io/gh-api.ts
@@ -56,7 +56,7 @@ const DEFAULT_HTTP_TIMEOUT_SECONDS = 60;
  * tests and pathological networks with `FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS`.
  */
 export const githubHttpTimeoutSeconds = (): number => {
-	const raw = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+	const raw = process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
 	const parsed = raw === undefined ? DEFAULT_HTTP_TIMEOUT_SECONDS : Number(raw);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_HTTP_TIMEOUT_SECONDS;
 };
@@ -197,31 +197,41 @@ const served = <A>(
 	request: HttpClientRequest.HttpClientRequest,
 	read: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<A, unknown>,
 ): Api<Served<A>> =>
-	HttpClient.execute(request).pipe(
-		Effect.flatMap((response) =>
-			Effect.map(
-				read(response),
-				(value): Served<A> => ({
-					_tag: "Response",
-					status: response.status,
-					headers: response.headers,
-					value,
-				}),
+	Effect.gen(function* () {
+		// Read once per exchange: the bound that is applied and the bound a refusal reports must be
+		// the same number even if the env moves between the two reads (review finding on #7048).
+		const boundSeconds = githubHttpTimeoutSeconds();
+		const startedAtMs = Date.now();
+		return yield* Effect.catch(
+			HttpClient.execute(request).pipe(
+				Effect.flatMap((response) =>
+					Effect.map(
+						read(response),
+						(value): Served<A> => ({
+							_tag: "Response",
+							status: response.status,
+							headers: response.headers,
+							value,
+						}),
+					),
+				),
+				// The bound covers the WHOLE exchange — connect through final body byte. Above
+				// `flatMap(read)` it would spare a stalled body stream, which dies exactly as hard as
+				// a black-holed connect (#7025 criterion 4).
+				Effect.timeout(Duration.seconds(boundSeconds)),
 			),
-		),
-		// The bound covers the WHOLE exchange — connect through final body byte. Above
-		// `flatMap(read)` it would spare a stalled body stream, which dies exactly as hard as a
-		// black-holed connect (#7025 criterion 4).
-		Effect.timeout(Duration.seconds(githubHttpTimeoutSeconds())),
-		Effect.catch((error: unknown) =>
-			Effect.succeed<Served<A>>({
-				_tag: "Unreachable",
-				reason: Cause.isTimeoutError(error)
-					? `the GitHub API call exceeded its ${githubHttpTimeoutSeconds()}s client-side bound`
-					: `the GitHub API could not be reached: ${String(error)}`,
-			}),
-		),
-	);
+			(error: unknown) =>
+				Effect.succeed<Served<A>>({
+					_tag: "Unreachable",
+					reason: Cause.isTimeoutError(error)
+						? // The hung invocation's own record: which call, which bound, how long it actually
+							// held the lane (#7025 criterion 1) — measured wall-clock, not the configured
+							// bound restated.
+							`${request.method} ${request.url} exceeded its ${boundSeconds}s client-side bound after ${((Date.now() - startedAtMs) / 1000).toFixed(1)}s`
+						: `the GitHub API could not be reached: ${String(error)}`,
+				}),
+		);
+	});
 
 const send = (request: HttpClientRequest.HttpClientRequest): Api<Rest> =>
 	Effect.map(

--- a/packages/fabrika-cli/src/io/gh-api.ts
+++ b/packages/fabrika-cli/src/io/gh-api.ts
@@ -24,7 +24,9 @@
  * theirs, and they erase the transport requirement with {@link onTransport} rather than publishing
  * `HttpClient` up through 45 verb annotations (ADR 0315, as amended).
  */
-import {Effect, Option} from "effect";
+
+import {Duration, Effect, Option} from "effect";
+import * as Cause from "effect/Cause";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
@@ -42,6 +44,22 @@ const GRAPHQL_URL = `${API_ROOT}/graphql`;
 
 /** How many pages a bare-array read walks before it gives up and reports non-exhaustion. */
 export const PAGE_CAP = 50;
+
+/** The default client-side bound on one GitHub HTTP exchange, in seconds. */
+const DEFAULT_HTTP_TIMEOUT_SECONDS = 60;
+
+/**
+ * The client-side bound on one GitHub HTTP exchange. `HttpClient.execute` has no timeout of its
+ * own, so a stalled transport (black-holed connect, silent drop) blocks a verb indefinitely —
+ * observed live as gate shells stuck 240s+ on one call (#7025). Failing fast turns the stall into
+ * the existing `Unreachable` outcome, which every caller already treats as data. Override for
+ * tests and pathological networks with `FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS`.
+ */
+export const githubHttpTimeoutSeconds = (): number => {
+	const raw = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+	const parsed = raw === undefined ? DEFAULT_HTTP_TIMEOUT_SECONDS : Number(raw);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_HTTP_TIMEOUT_SECONDS;
+};
 
 const NEXT_LINK = /<[^>]*>\s*;\s*rel="next"/i;
 
@@ -180,6 +198,7 @@ const served = <A>(
 	read: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<A, unknown>,
 ): Api<Served<A>> =>
 	HttpClient.execute(request).pipe(
+		Effect.timeout(Duration.seconds(githubHttpTimeoutSeconds())),
 		Effect.flatMap((response) =>
 			Effect.map(
 				read(response),
@@ -194,7 +213,9 @@ const served = <A>(
 		Effect.catch((error: unknown) =>
 			Effect.succeed<Served<A>>({
 				_tag: "Unreachable",
-				reason: `the GitHub API could not be reached: ${String(error)}`,
+				reason: Cause.isTimeoutError(error)
+					? `the GitHub API call exceeded its ${githubHttpTimeoutSeconds()}s client-side bound`
+					: `the GitHub API could not be reached: ${String(error)}`,
 			}),
 		),
 	);

--- a/packages/fabrika-cli/src/io/gh-api.unit.test.ts
+++ b/packages/fabrika-cli/src/io/gh-api.unit.test.ts
@@ -1,9 +1,11 @@
 import {Effect, Layer} from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeHttp, fakeShell, linkNext, okOut} from "../fakes.test-support.ts";
 import {
 	ambientToken,
 	existenceOf,
+	githubHttpTimeoutSeconds,
 	graphqlRead,
 	NO_TOKEN,
 	onTransport,
@@ -486,6 +488,45 @@ describe("pagedExistence — 404 is a verdict", () => {
 			Effect.provide(pagedExistence(TOKEN, "repos/o/r/x"), http.layer),
 		);
 		expect(result._tag).toBe("Unknown");
+	});
+});
+
+describe("githubHttpTimeoutSeconds", () => {
+	it("bounds a never-responding endpoint into Unreachable instead of hanging forever", async () => {
+		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+		try {
+			process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = "1";
+			const http = Layer.succeed(HttpClient.HttpClient)(HttpClient.make(() => Effect.never));
+			const started = Date.now();
+			const result = await Effect.runPromise(
+				Effect.provide(restRead(TOKEN, "GET", "repos/o/r/pulls/1"), http),
+			);
+			expect(result._tag).toBe("Unreachable");
+			if (result._tag === "Unreachable") {
+				expect(result.reason).toContain("client-side bound");
+			}
+			expect(Date.now() - started).toBeLessThan(10_000);
+		} finally {
+			if (before === undefined) delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+			else process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = before;
+		}
+	});
+
+	it("defaults to 60s and ignores non-positive or non-numeric overrides", () => {
+		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+		try {
+			delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+			expect(githubHttpTimeoutSeconds()).toBe(60);
+			process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = "30";
+			expect(githubHttpTimeoutSeconds()).toBe(30);
+			for (const junk of ["0", "-5", "nope", "Infinity"]) {
+				process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = junk;
+				expect(githubHttpTimeoutSeconds()).toBe(60);
+			}
+		} finally {
+			if (before === undefined) delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+			else process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = before;
+		}
 	});
 });
 

--- a/packages/fabrika-cli/src/io/gh-api.unit.test.ts
+++ b/packages/fabrika-cli/src/io/gh-api.unit.test.ts
@@ -495,9 +495,9 @@ describe("pagedExistence — 404 is a verdict", () => {
 
 describe("githubHttpTimeoutSeconds", () => {
 	it("bounds a stalled body stream, not just a silent connect", async () => {
-		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+		const before = process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
 		try {
-			process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = "1";
+			process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = "1";
 			// Headers arrive instantly; the body stream never produces a byte — the shape of a
 			// silent post-header drop (#7025 criterion 4).
 			const request = HttpClientRequest.get("https://api.github.com/repos/o/r/pulls/1");
@@ -514,19 +514,23 @@ describe("githubHttpTimeoutSeconds", () => {
 			);
 			expect(result._tag).toBe("Unreachable");
 			if (result._tag === "Unreachable") {
-				expect(result.reason).toContain("client-side bound");
+				// The hung invocation's own record — which exchange, which bound, measured elapsed
+				// (#7025 criterion 1).
+				expect(result.reason).toMatch(
+					/^GET https:\/\/api\.github\.com\/repos\/o\/r\/pulls\/1 exceeded its 1s client-side bound after \d+\.\ds$/,
+				);
 			}
 			expect(Date.now() - started).toBeLessThan(10_000);
 		} finally {
-			if (before === undefined) delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
-			else process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = before;
+			if (before === undefined) delete process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
+			else process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = before;
 		}
 	});
 
 	it("bounds a never-responding endpoint into Unreachable instead of hanging forever", async () => {
-		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+		const before = process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
 		try {
-			process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = "1";
+			process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = "1";
 			const http = Layer.succeed(HttpClient.HttpClient)(HttpClient.make(() => Effect.never));
 			const started = Date.now();
 			const result = await Effect.runPromise(
@@ -534,29 +538,30 @@ describe("githubHttpTimeoutSeconds", () => {
 			);
 			expect(result._tag).toBe("Unreachable");
 			if (result._tag === "Unreachable") {
-				expect(result.reason).toContain("client-side bound");
+				expect(result.reason).toContain("GET https://api.github.com/repos/o/r/pulls/1");
+				expect(result.reason).toMatch(/client-side bound after \d+\.\ds$/);
 			}
 			expect(Date.now() - started).toBeLessThan(10_000);
 		} finally {
-			if (before === undefined) delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
-			else process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = before;
+			if (before === undefined) delete process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
+			else process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = before;
 		}
 	});
 
 	it("defaults to 60s and ignores non-positive or non-numeric overrides", () => {
-		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+		const before = process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
 		try {
-			delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+			delete process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
 			expect(githubHttpTimeoutSeconds()).toBe(60);
-			process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = "30";
+			process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = "30";
 			expect(githubHttpTimeoutSeconds()).toBe(30);
 			for (const junk of ["0", "-5", "nope", "Infinity"]) {
-				process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = junk;
+				process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = junk;
 				expect(githubHttpTimeoutSeconds()).toBe(60);
 			}
 		} finally {
-			if (before === undefined) delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
-			else process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = before;
+			if (before === undefined) delete process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS;
+			else process.env.FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS = before;
 		}
 	});
 });

--- a/packages/fabrika-cli/src/io/gh-api.unit.test.ts
+++ b/packages/fabrika-cli/src/io/gh-api.unit.test.ts
@@ -1,5 +1,7 @@
 import {Effect, Layer} from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeHttp, fakeShell, linkNext, okOut} from "../fakes.test-support.ts";
 import {
@@ -492,6 +494,35 @@ describe("pagedExistence — 404 is a verdict", () => {
 });
 
 describe("githubHttpTimeoutSeconds", () => {
+	it("bounds a stalled body stream, not just a silent connect", async () => {
+		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+		try {
+			process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = "1";
+			// Headers arrive instantly; the body stream never produces a byte — the shape of a
+			// silent post-header drop (#7025 criterion 4).
+			const request = HttpClientRequest.get("https://api.github.com/repos/o/r/pulls/1");
+			const http = Layer.succeed(HttpClient.HttpClient)(
+				HttpClient.make(() =>
+					Effect.succeed(
+						HttpClientResponse.fromWeb(request, new Response(new ReadableStream({start() {}}))),
+					),
+				),
+			);
+			const started = Date.now();
+			const result = await Effect.runPromise(
+				Effect.provide(restRead(TOKEN, "GET", "repos/o/r/pulls/1"), http),
+			);
+			expect(result._tag).toBe("Unreachable");
+			if (result._tag === "Unreachable") {
+				expect(result.reason).toContain("client-side bound");
+			}
+			expect(Date.now() - started).toBeLessThan(10_000);
+		} finally {
+			if (before === undefined) delete process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
+			else process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"] = before;
+		}
+	});
+
 	it("bounds a never-responding endpoint into Unreachable instead of hanging forever", async () => {
 		const before = process.env["FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS"];
 		try {


### PR DESCRIPTION
Closes #7025.

## What
`HttpClient.execute` in `packages/fabrika-cli/src/io/gh-api.ts` had no timeout: a stalled transport (black-holed TCP connect ~75s/attempt, silent drop) blocked a verb indefinitely — the mechanism behind tonight's gate shells stuck 240s+ on one bash call mid review/ship (three incidents on lanes of PRs #6994 and #7011, plus live builder deaths).

## The fix
One bound at the single choke point (`served()`): `Effect.timeout` around `execute`, mapped into the existing `Unreachable` outcome — failing fast is data every caller already handles. Default 60s; `FABRIKA_GITHUB_HTTP_TIMEOUT_SECONDS` overrides for tests and pathological networks. Remedy path (a) from the investigation: non-interactive defaults with explicit timeouts, not an env contract for gate shells.

## Investigation record (the ticket's own deliverable)
- Blocking mechanism: unbounded application-level HTTP wait (not pager — pager only engages under a tty, captured shells are safe).
- Reproduction: never-responding endpoint maps to `Unreachable` within the bound (new unit test); OS connect window measured ~75s against a black-hole listener.
- Recommendation: committed to non-interactive defaults + explicit timeouts as primary; headless env contract set aside as redundant once defaults are safe.