### PR TITLE
fix(io): getCommentRecord refuses an unreadable author instead of seating a blank one

### DIFF
--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -493,10 +493,16 @@ export const getCommentRecord = (repo: string, id: number): Shell<Attempt<Commen
 				if (!isRecord(body) || typeof body.body !== "string" || typeof body.id !== "number") {
 					return fail("GitHub answered 200 but its body is not a comment");
 				}
+				// An unreadable author is a failed read, never a blank one: a blank login would
+				// downstream as AUTHOR_UNDECLARED (16) — a proven negative about a person GitHub
+				// never named. Callers seat this arm on their read-failure exit instead (#6983).
 				const user = body.user;
+				if (!isRecord(user) || typeof user.login !== "string") {
+					return fail("GitHub answered 200 but the comment carries no readable author login");
+				}
 				return ok({
 					id: body.id,
-					author: isRecord(user) && typeof user.login === "string" ? user.login : "",
+					author: user.login,
 					createdAt: typeof body.created_at === "string" ? body.created_at : "",
 					updatedAt: typeof body.updated_at === "string" ? body.updated_at : "",
 					body: body.body,

--- a/packages/fabrika-cli/src/io/issues.unit.test.ts
+++ b/packages/fabrika-cli/src/io/issues.unit.test.ts
@@ -17,6 +17,7 @@ import {
 	createComment,
 	createIssue,
 	deleteComment,
+	getCommentRecord,
 	getIssue,
 	issueTimeline,
 	listComments,
@@ -561,6 +562,48 @@ describe("the writes send the fields the API needs, in the form it accepts", () 
 		expect(http.calls[0]).toBe(
 			"DELETE https://api.github.com/repos/kamp-us/phoenix/issues/comments/5170139674",
 		);
+	});
+
+	it("getCommentRecord reads the whole record off a well-formed comment", async () => {
+		const http = scripted([
+			[
+				/comments\/7/,
+				{
+					status: 200,
+					body: {
+						id: 7,
+						user: {login: "usirin"},
+						body: "ruling text",
+						created_at: "2026-08-23T00:00:00Z",
+						updated_at: "2026-08-23T01:00:00Z",
+					},
+				},
+			],
+		]);
+		const result = await against(getCommentRecord("kamp-us/phoenix", 7), http);
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: {
+				id: 7,
+				author: "usirin",
+				createdAt: "2026-08-23T00:00:00Z",
+				updatedAt: "2026-08-23T01:00:00Z",
+				body: "ruling text",
+			},
+		});
+	});
+
+	it("getCommentRecord refuses a 200 whose author login is unreadable — a blank author would downstream as a proven AUTHOR_UNDECLARED (#6983)", async () => {
+		for (const user of [undefined, {}, {login: 9}]) {
+			const http = scripted([
+				[/comments\/8/, {status: 200, body: {id: 8, user, body: "mystery bytes"}}],
+			]);
+			const result = await against(getCommentRecord("kamp-us/phoenix", 8), http);
+			expect(result._tag).toBe("Failure");
+			if (result._tag === "Failure") {
+				expect(result.reason).toContain("no readable author login");
+			}
+		}
 	});
 
 	it("patchIssueBody and deleteComment surface the failure rather than swallowing it", async () => {


### PR DESCRIPTION
Closes #6983.

## What changed
- `getCommentRecord` (`packages/fabrika-cli/src/io/issues.ts`) now **fails** when a 200 body carries no readable string `user.login`, instead of returning `author: ""`.
- Through the campaign authority guard, that Failure routes through the existing `unreadable()` helper → seat 13 (AUTHORITY_UNKNOWN), naming the unreadable-author read — never the proven-negative AUTHOR_UNDECLARED (16) message about the campaignAuthors set.
- `createdAt`/`updatedAt` fallbacks left as-is per the issue's scope note (no current caller reads them).

## Tests
- Happy-path record read asserted field for field.
- New case drives the missing-`user.login` arm across all three unreadable shapes (`undefined` user, non-record user, non-string `login`) and asserts a failure naming the arm.
- Full package suite green: 458 files / 7863 tests. `tsc --noEmit` clean.


## Deviations

None.