### PR TITLE
fix: campaign state --to refusal text names the positional as a flag

### DIFF
--- a/claude-plugins/fabrika/skills/campaign/contract.md
+++ b/claude-plugins/fabrika/skills/campaign/contract.md
@@ -495,7 +495,7 @@ answer: a run that wrote nothing exits non-zero. Under `--json`:
 | `campaign open: --milestone must be a positive integer, got "<value>".` | 1 | usage error |
 | `campaign open: <name> holds "\|" or a newline — a campaign name must fit one table cell.` | 1 | usage error |
 | `campaign open: --cites "<value>" is not a comment URL in <repo> — expected .../issues/<n>#issuecomment-<id> or .../pull/<n>#issuecomment-<id>.` | 1 | usage error |
-| `campaign open: --<flag> is required.` | 1 | usage error |
+| `campaign open: <name> is required.` — positional spelling; `<name>` is declared positional, so no `--` prefix ever appears | 1 | usage error |
 | `campaign open: cannot read <file>: <reason> — UNKNOWN, nothing was written.` | 11 | refusal |
 | `campaign open: cannot write <file>: <reason> — UNKNOWN, the table may be half-written; re-read it.` | 8 | refusal |
 | `campaign open: <file>: <reason> — the whole ## Campaigns table is unreadable (ADR 0304). NOTHING was written.` | 12 | refusal |

--- a/packages/fabrika-cli/src/campaign/open-verb.ts
+++ b/packages/fabrika-cli/src/campaign/open-verb.ts
@@ -46,7 +46,7 @@ export const runOpen = (options: OpenOptions): CampaignEffect<VerbOutcome> =>
 			return refuse(FAILED, `${VERB}: --milestone must be a positive integer, got "${milestone}".`);
 		}
 		if (name === "") {
-			return refuse(FAILED, `${VERB}: --name is required.`);
+			return refuse(FAILED, `${VERB}: <name> is required.`);
 		}
 		if (!nameFitsCell(name)) {
 			return refuse(

--- a/packages/fabrika-cli/src/campaign/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/campaign/open-verb.unit.test.ts
@@ -105,7 +105,7 @@ describe("campaign open — usage refusals", () => {
 	it("refuses a name that is only whitespace, which would append a cell nothing can read", async () => {
 		const {outcome, written} = await run(APPROVED, tree(), {name: "   "});
 		expect(outcome.code).toBe(1);
-		expect(outcome.stderr.at(-1)).toBe("campaign open: --name is required.");
+		expect(outcome.stderr.at(-1)).toBe("campaign open: <name> is required.");
 		expect(written.size).toBe(0);
 	});
 


### PR DESCRIPTION
## Summary

`campaign open`'s missing-name refusal spelled the positional `<name>` argument in flag form (`--name is required.`), so an agent following the remedy literally retried with a flag the verb does not declare and failed twice. Reworded to the positional spelling; behavior unchanged (exit 1, nothing written).

## What changes

- `open-verb.ts`: refusal reworded to `` `campaign open: <name> is required.` `` — `<name>` is declared `Argument.string("name")`, no `--name` flag exists on any verb in the group.
- `contract.md`: the open verb's error-table row `--<flag> is required.` replaced with the explicit positional-spelling row (no other refusal in the group emits the flag template, so the graded lines stay truthful).
- Unit test expectation updated to the new stderr line.

## Evidence

- `npx vitest run src/campaign/` → 5 files, 87 tests pass.
- Live: `fabrika campaign open "   " ...` → stderr `campaign open: <name> is required.`, exit 1.
- `git grep -n '"--' packages/fabrika-cli/src/campaign/` → zero matches.

Fixes #6984

## Deviations

- **Pre-existing test or fixture changed** — **Said:** the existing exact-output unit assertion expected `campaign open: --name is required.`. **Did:** changed it to expect the corrected positional refusal `campaign open: <name> is required.`. **Why:** the acceptance criteria require the test to assert the corrected public stderr wording rather than the undeclared `--name` flag spelling. **Disposition:** disclosed here.
