### PR TITLE
docs(fate-effect): pin the Diátaxis-lite README shape in .patterns + apply it to fate-effect

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -300,6 +300,17 @@ is addressed by a key, and the key decides where its ledger lives:
 above ("The composition shell / recipe", ADR 0182) — one flat element-prop per zone. They share
 nothing but the word; name which one you mean when the context does not fix it.
 
+### Diátaxis-lite README shape
+
+The canonical section order every `packages/*/README.md` follows — explanation (*what it is* /
+*why it exists*, citing the forcing ADR) → how-to (runnable recipes) → reference (dry,
+look-it-up, last or linked out) → a short testing tail — with two hard rules: no tutorial at
+package scale (a walkthrough moves to its own linked surface), and scope/non-goals live in the
+explanation half. A small package may satisfy it in three short sections; the order is canonical,
+the length is not. The [`diataxis`](../claude-plugins/fabrika/skills/diataxis/SKILL.md) skill is
+the single-mode classifier over any page. Pinned by
+[package-readme-shape.md](../.patterns/package-readme-shape.md).
+
 ### The three senses of "phoenix"
 
 "phoenix" carries **three distinct meanings**, each with a graduation name —

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -166,6 +166,12 @@ The infra layer beneath the domain and fate layers. phoenix runs on [alchemy-eff
 - **One service per feature folder.** Reads + writes coexist.
 - **Testing strategy:** **two tiers** ([ADR 0082](../.decisions/0082-two-test-tiers-unit-integration.md)). `unit` — pure logic and Effect control flow with **no database**, substituting the `Drizzle` seam directly (`*.unit.test.ts`, offline in the `unit` Vitest project under `@effect/vitest`); `integration` — real behavior against **real remote D1** and the deployed worker (black-box HTTP, [alchemy-test-harness.md](./alchemy-test-harness.md)). `node:sqlite` / `makeSqliteTestDb` is **banned** as a backing. Litmus: *could this be wrong even if the DB behaved perfectly?* yes → `unit`, only-wrong-if-real-D1-differs → `integration`. See [effect-testing.md](./effect-testing.md).
 
+## Index — docs & meta patterns
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [package-readme-shape.md](./package-readme-shape.md) | The canonical `packages/*/README.md` section order (explanation → how-to → reference → testing), the no-tutorial-at-package-scale rule, the small-package minimum; the [`diataxis`](../claude-plugins/fabrika/skills/diataxis/SKILL.md) skill is the single-mode classifier | Writing or restructuring a package README |
+
 ## When to add a new pattern doc here
 
 Add a doc when:

--- a/.patterns/package-readme-shape.md
+++ b/.patterns/package-readme-shape.md
@@ -1,32 +1,44 @@
 # package-readme-shape — the canonical `packages/*/README.md` section order
 
-> Forged against real READMEs (`cf-credentials`, `composer`, `depo`, `fate-effect`) rather than declared in the abstract. The `diataxis` skill is the classifier that checks a page holds one mode; this doc states the shape it classifies against.
+Use the [`diataxis` skill](../claude-plugins/fabrika/skills/diataxis/SKILL.md) to classify the README
+before applying this shape. A README has one dominant mode; entries for other reader needs link to
+their own pages instead of embedding a second mode.
 
-Every `packages/*/README.md` follows one section order, scaled to README size:
+## Canonical order
 
 ```text
 # <package name>
-## What it is          ← explanation
-## Why it exists       ← explanation (the ADR that forced the package)
-## How to use it       ← how-to (runnable commands, import-and-call)
-## Reference           ← reference last or linked out (exports, flags, config keys)
-## Testing             ← a short testing tail
+## What it is          ← explanation, or a link to the explanation home
+## Why it exists       ← explanation, or links to the governing ADRs
+## How to use it       ← how-to recipes
+## Reference           ← reference content or a link to the reference page
+## Testing             ← short task-oriented validation commands
 ```
 
-## The rules that make it checkable
+The navigation order is explanation → how-to → reference → testing even when the README's dominant
+mode moves some entries to linked pages.
 
-1. **Explanation first.** A reader decides whether to care before they decide how to act. *What it is* names the thing in one paragraph; *why it exists* cites the decision that forced it (an ADR number, an incident) instead of re-arguing the why.
-2. **No tutorial at package scale.** A step-by-step walkthrough ("build your first X", numbered lessons followed start to finish) never blends into the README — it moves to its own linked surface next to the package. A README is mid-task material; a tutorial is study material. The two modes on one page serve neither reader ([diataxis](../../claude-plugins/fabrika/skills/diataxis/SKILL.md)).
-3. **Scope and non-goals live in the explanation half.** What the package deliberately does not cover is a *why-it-exists* concern, stated once up front — not scattered through reference sections as apologies.
-4. **How-to is recipes, not lessons.** Each how-to entry targets one real result (run this command, call this export), assumes competence, and links out for the concepts behind it.
-5. **Reference is dry and complete.** Exports, flags, config keys, module maps — look-it-up tables matching the code's structure, at the tail or on a linked page. No persuasion, no narration.
-6. **Small-package minimum.** A small package may satisfy the whole shape in three short sections (*What it is* carrying the why, *How to use it*, *Testing*) — the order is canonical, the length is not.
+## Rules
 
-## The mode contract
+1. **Explanation first.** State what the package is and point to the decision that forced it. Do not
+   re-argue an ADR in the README.
+2. **No tutorial at package scale.** Move every start-to-finish lesson to a linked tutorial next to
+   the package.
+3. **Scope and non-goals live in the explanation half.** State them once on the explanation surface.
+4. **How-to is recipes, not lessons.** Each recipe targets one result and assumes competence.
+5. **Reference is dry and complete.** Keep exports, flags, configuration keys, and module maps on a
+   reference surface at the tail or on a linked page.
+6. **Small-package minimum.** A small package may use three short entries: what/why, how to use it,
+   and testing.
+7. **One dominant mode.** A page that answers more than one reader need must split; section labels do
+   not make a mixed page single-mode.
 
-One README serves one dominant mode at a time per section, and the sections appear in explanation → how-to → reference order. When a draft reads like it wanders, run the `diataxis` classification over it: a single dominant mode with no unresolved type-mixing flag is the pass condition. Rewriting a flagged page is `build`'s job, not the classifier's.
+## Classification contract
+
+Record one dominant mode with no unresolved type-mixing flag. The `diataxis` skill classifies; a
+`build` repair splits any mixed page it reports.
 
 ## See also
 
-- [index.md](./index.md) — the pattern library front door
-- [diataxis skill](../../claude-plugins/fabrika/skills/diataxis/SKILL.md) — the single-mode classifier
+- [Pattern library index](./index.md)
+- [`diataxis` classifier](../claude-plugins/fabrika/skills/diataxis/SKILL.md)

--- a/.patterns/package-readme-shape.md
+++ b/.patterns/package-readme-shape.md
@@ -1,46 +1,32 @@
-# Diátaxis-lite README shape
+# package-readme-shape — the canonical `packages/*/README.md` section order
 
-The canonical section order every `packages/*/README.md` follows, scaled to package size.
-Grounded in the shape the repo converged on: [`packages/cf-credentials/README.md`](../packages/cf-credentials/README.md),
-[`packages/composer/README.md`](../packages/composer/README.md), [`packages/depo/README.md`](../packages/depo/README.md).
-The `diataxis` skill is the classifier that checks a page holds one dominant mode; this doc is
-the README-sized projection of that law.
+> Forged against real READMEs (`cf-credentials`, `composer`, `depo`, `fate-effect`) rather than declared in the abstract. The `diataxis` skill is the classifier that checks a page holds one mode; this doc states the shape it classifies against.
 
-## The canonical section order
+Every `packages/*/README.md` follows one section order, scaled to README size:
 
-1. **`# @kampus/<name>`** — one-line identity: what the package is in a sentence.
-2. **`## What it is`** — explanation. The surfaces a consumer touches, named file-by-file or
-   export-by-export. This is the *reference-adjacent* half: concrete, checkable against source.
-3. **`## Why it exists`** — explanation. The forcing constraint or decision that minted the
-   package, citing the ADR (and the "promote at the 2nd usage" trigger where it applies).
-   Scope and non-goals live here — in the explanation half, never buried in a how-to step.
-4. **`## How to use it`** — how-to. The runnable commands and the import-and-call snippet a
-   consumer needs. No narrative arc; if it needs steps 1-through-6 with prose between, that is
-   a tutorial and belongs on its own linked surface.
-5. **Reference tail** — tables of rules/invariants, module maps, config keys, flags. Last
-   section(s), or linked out to a dedicated page when they outgrow the README.
-6. **`## Testing`** — short tail: how to run this package's tests, anything surprising about
-   them.
-
-A small package may satisfy the shape in three short sections (`What it is`, `How to use it`,
-`Testing`) — the minimum is that explanation leads and reference trails.
+```text
+# <package name>
+## What it is          ← explanation
+## Why it exists       ← explanation (the ADR that forced the package)
+## How to use it       ← how-to (runnable commands, import-and-call)
+## Reference           ← reference last or linked out (exports, flags, config keys)
+## Testing             ← a short testing tail
+```
 
 ## The rules that make it checkable
 
-- **No tutorial at package scale.** A numbered walkthrough with narrative between steps moves
-  to its own linked surface (e.g. `WALKTHROUGH.md` beside the README), referenced from
-  *How to use it* — never blended into the README body.
-- **Scope and non-goals live in the explanation half** (*What it is* / *Why it exists*). A
-  reader deciding "is this for me?" should not have to parse a how-to to find the boundary.
-- **Every behavioural claim must verify against source at the PR's head.** Commands run,
-  exports exist, behaviours hold. The additive truth rule: each public surface introduced
-  since the README's last truth pass is either described or explicitly named as out of scope.
-- **One dominant mode per section.** Explanation sections explain; how-to sections instruct;
-  reference sections enumerate. The `diataxis` skill flags type-mixing.
+1. **Explanation first.** A reader decides whether to care before they decide how to act. *What it is* names the thing in one paragraph; *why it exists* cites the decision that forced it (an ADR number, an incident) instead of re-arguing the why.
+2. **No tutorial at package scale.** A step-by-step walkthrough ("build your first X", numbered lessons followed start to finish) never blends into the README — it moves to its own linked surface next to the package. A README is mid-task material; a tutorial is study material. The two modes on one page serve neither reader ([diataxis](../../claude-plugins/fabrika/skills/diataxis/SKILL.md)).
+3. **Scope and non-goals live in the explanation half.** What the package deliberately does not cover is a *why-it-exists* concern, stated once up front — not scattered through reference sections as apologies.
+4. **How-to is recipes, not lessons.** Each how-to entry targets one real result (run this command, call this export), assumes competence, and links out for the concepts behind it.
+5. **Reference is dry and complete.** Exports, flags, config keys, module maps — look-it-up tables matching the code's structure, at the tail or on a linked page. No persuasion, no narration.
+6. **Small-package minimum.** A small package may satisfy the whole shape in three short sections (*What it is* carrying the why, *How to use it*, *Testing*) — the order is canonical, the length is not.
 
-## Applying it to an existing README
+## The mode contract
 
-Re-ground before restructuring: diff the README's claims against `src/**` at head (the
-drift window = commits touching the package after the README's last touch), then reorder into
-the canonical order, moving any walkthrough to its own surface and demoting stale claims.
-Worked example: [`packages/fate-effect/README.md`](../packages/fate-effect/README.md).
+One README serves one dominant mode at a time per section, and the sections appear in explanation → how-to → reference order. When a draft reads like it wanders, run the `diataxis` classification over it: a single dominant mode with no unresolved type-mixing flag is the pass condition. Rewriting a flagged page is `build`'s job, not the classifier's.
+
+## See also
+
+- [index.md](./index.md) — the pattern library front door
+- [diataxis skill](../../claude-plugins/fabrika/skills/diataxis/SKILL.md) — the single-mode classifier

--- a/packages/fate-effect/README.md
+++ b/packages/fate-effect/README.md
@@ -1,68 +1,55 @@
 # @kampus/fate-effect
 
-Effect-native [fate](https://github.com/nkzw-tech/fate) integration — fate's structure with
-Effect's semantics. Phoenix's domain↔protocol seam: feature code keeps fate's record shapes
-(`queries` / `lists` / `mutations` / `sources` / views), and every record entry pairs a
-**pure-data definition** (Effect Schema inputs, the success view, a declared error union) with an
-**`Effect.fn` handler**.
+Use `@kampus/fate-effect` to author fate queries, lists, mutations, sources, and views with Effect.
+This page is the task guide. Read [reference.md](./reference.md) for lookup material,
+[walkthrough.md](./walkthrough.md) for a start-to-finish lesson, and
+[ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md) plus
+[ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md) for the design and
+history.
 
-```
-defining things                 composing                serving
-───────────────                 ─────────                ───────
-FateWireCode (errors)  ┐
-FateDataView (views)      │
-Fate.source (loaders)     ├──►  FateServer.config  ──►  FateInterpreter.handleRequest
-Fate.query / list /       │     FateServer.layer         (one Effect, request fiber)
-Fate.mutation (resolvers) ┘            │
-                                       └────────────►    FateExecutor.toCodegenServer
-                                                          (build-time client codegen)
-```
+The package owns the server and authoring substrate. The host owns HTTP routing, abort wiring, and
+database services; client code consumes the generated fate API.
 
-## Why it exists
+## Author entries
 
-The types carry the contracts, so the failure modes a hand-rolled data layer grows silently are
-*compile* errors here:
+Define errors with `FateWireCode`, views with `FateDataView`, sources with `Fate.source`, and
+operations with `Fate.query`, `Fate.list`, or `Fate.mutation`. Use the focused recipes for each task:
 
-- an unloadable source doesn't type (`SourceLoaderContract`),
-- an undeclared wire error doesn't compile (`E extends DefinitionErrors<D>`),
-- a forgotten domain layer doesn't compile (`FateServer.layer`'s `R`).
+- [data views](../../.patterns/fate-effect-data-views.md)
+- [sources](../../.patterns/fate-effect-sources.md)
+- [operations](../../.patterns/fate-effect-operations.md)
+- [wire errors](../../.patterns/fate-effect-wire-errors.md)
 
-Requests are served by a native Effect interpreter on the request fiber — no Effect→Promise hop
-per request, sources batched per request (N+1 is structurally impossible), one error codec for
-the whole wire surface. The interpreter is verified **byte-equal** to fate's own server by a
-differential oracle in this package's test suite. The why and history:
-[ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md) (v1 architecture),
-[ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md) (native interpreter
-cutover).
+For a guided build of one feature, use [walkthrough.md](./walkthrough.md).
 
-**What this package is not:** not a general Effect HTTP framework (the host owns routing and
-abort wiring); no client lives here — the SPA consumes generated types through
-[react-fate](https://github.com/kamp-us/phoenix/blob/main/package.json). Authoring guidance lives
-in the pattern docs, not here ([see below](#going-deeper)).
+## Guard view field maps against symbol slips
 
-## How to use it
-
-**Author entries** — errors carry a `FateWireCode`, views are `FateDataView` classes, sources are
-`Fate.source(...)` loaders, operations are `Fate.query`/`list`/`mutation` definitions + handlers.
-The recipes live in the pattern docs:
-[data views](../../.patterns/fate-effect-data-views.md) ·
-[sources](../../.patterns/fate-effect-sources.md) ·
-[operations](../../.patterns/fate-effect-operations.md) ·
-[wire errors](../../.patterns/fate-effect-wire-errors.md).
-A start-to-finish guided build of one feature is at [walkthrough.md](./walkthrough.md).
-
-**Guard view field maps against symbol slips.** A view whose kernel `view` recovery slipped
-(renamed export, moved field map) fails loudly at the definition site when you assert it:
+Apply the type-only `AssertFieldMapResolved` guard where all shipping views are assembled. The
+second generic must extend the first; a slipped field-map symbol therefore produces a named compile
+error at this definition site.
 
 ```ts
-import {AssertFieldMapResolved} from "@kampus/fate-effect";
-export const NoteView = AssertFieldMapResolved(NoteViewBase);
+import type {AssertFieldMapResolved} from "@kampus/fate-effect";
+
+type AssertResolved<Resolved, Guarded extends Resolved> = Guarded;
+type NoteViewFieldMapResolved = AssertResolved<
+	typeof NoteView,
+	AssertFieldMapResolved<typeof NoteView>
+>;
 ```
 
-**Compose one config, one layer** — the package's only composition construct:
+The shipping example is the worker's
+[view assembly](../../apps/web/worker/features/fate/views.ts). The guard is a type alias, not a
+runtime function.
+
+## Compose one config and layer
+
+Build the one config shared by serving and code generation, then discharge domain services in its
+layer:
 
 ```ts
 import {FateServer} from "@kampus/fate-effect";
+import * as Layer from "effect/Layer";
 
 export const fateConfig = FateServer.config({
 	queries: panoQueries,
@@ -70,110 +57,63 @@ export const fateConfig = FateServer.config({
 	mutations: panoMutations,
 	sources: panoSources,
 });
+
 export const FateLive = FateServer.layer(fateConfig).pipe(Layer.provide(Pano));
 ```
 
-Init-time validation runs against the same config the codegen imports, so a bad config also fails
-the build ([server pattern](../../.patterns/fate-effect-server.md)).
+Use the [server pattern](../../.patterns/fate-effect-server.md) when adding sources or request
+services.
 
-**Serve per request** — one Effect on your request fiber; the interpreter owns no runtime and the
-context deliberately carries no abort signal (the caller wires both):
+## Serve a request
+
+Call the interpreter on the host's request fiber and provide fresh request values:
 
 ```ts
 import {FateInterpreter, type FateRequestContext} from "@kampus/fate-effect";
 
 const context: FateRequestContext = {
 	currentUser: {user: session?.user},
-	livePublisher, // the worker builds this from its live topics + waitUntil
+	livePublisher,
 };
 const response = yield* FateInterpreter.handleRequest(request, context);
 ```
 
-See the worker's [route](../../apps/web/worker/features/fate/route.ts) for the
-abort→interruption pattern.
+Wire abort to interruption in the host. The worker
+[route](../../apps/web/worker/features/fate/route.ts) is the shipping example.
 
-**Generate client types at build time** — the same config with inert handlers, importable at
-build time:
+## Generate client types
+
+Export an inert server from the same config so the fate Vite plugin can import it at build time:
 
 ```ts
-// schema.ts — the fate Vite plugin imports this via runnerImport
 import {FateExecutor} from "@kampus/fate-effect";
 import {fateConfig} from "./config.ts";
 
 export const fateServer = FateExecutor.toCodegenServer(fateConfig);
 ```
 
-`InferFateAPI<typeof fateServer>` produces the same client types as the live server.
+Use `InferFateAPI<typeof fateServer>` for the client API type. See the
+[compiler/codegen pattern](../../.patterns/fate-effect-compiler.md) for the complete setup.
 
-## Reference
+## Publish live changes
 
-**Live publish surface** — `LivePublisher` publishes three ways to a row and four to a
-connection:
+Use `LivePublisher` for row or connection updates. Choose `invalidate` when a field is
+viewer-derived; each subscriber must re-read its own value rather than receive the mutator's value.
+The complete method table is in [reference.md](./reference.md#live-publish-surface), and
+[ADR 0314](../../.decisions/0314-entity-invalidate-frame-upstream.md) governs entity invalidation.
 
-| Call | Tells subscribers |
-| --- | --- |
-| `live.update(type, id, {changed, data})` | here are these fields' new values |
-| `live.delete(type, id)` | this row is gone |
-| `live.invalidate(type, id)` | read this row again — no data attached |
-| `live.topic(procedure, args).{appendNode,prependNode,deleteEdge,invalidate}(…)` | this connection's membership moved, or re-load it whole |
+## Check a change
 
-`invalidate` is the only honest repair for a **viewer-derived** field — one whose value depends on
-who is reading. Its true new value differs per subscriber, so a broadcast payload would overwrite
-every reader with the mutator's answer; attaching no data forces each subscriber to re-read on its
-own viewer ([ADR 0314](../../.decisions/0314-entity-invalidate-frame-upstream.md)).
+```bash
+pnpm --filter @kampus/fate-effect test
+pnpm --filter @kampus/fate-effect typecheck
+```
 
-**Invariants, in one list**
+The suite checks the differential oracle, codegen types, protocol drift, wire-code enumeration, and
+Effect-to-Promise conversion boundaries.
 
-| Invariant | Enforced by |
-| --- | --- |
-| A source with no loader doesn't exist | type-level (`SourceLoaderContract`) |
-| Loaders can't fail typefully; infra dies | the service-boundary die rule + `E = never` on handler slots |
-| Undeclared wire errors don't compile | `E extends DefinitionErrors<D>` bound |
-| Invalid input never reaches a handler | Schema decode in the entry's `resolve` |
-| A missing domain layer doesn't compile | `FateServer.layer`'s `R` |
-| Wire codes can't silently drift | per-feature enumeration pin tests |
-| A failed live publish can't fail a mutation | `LivePublisher` methods are `Effect<void>` |
-| One Effect→Promise conversion in the package — the oracle baseline's runner in `Executor.ts`; the serving path converts at the platform edge, outside the package | an enumeration test source-greps `src/` for `run*` |
-| v2 serves exactly what fate would | the differential oracle (byte-equal corpus, per-plane suites) |
+## Related task guides
 
-**Module map**
-
-| Module | What it is |
-| --- | --- |
-| `WireError.ts` | `FateWireCode` annotation + `encodeWireError` (the one error codec) |
-| `DataView.ts` | `FateDataView` class factory, `Entity<>`, `FateDataView.list`, the `AssertFieldMapResolved` slip guard |
-| `Source.ts` | `Fate.source` — per-entity loaders, span-named handlers; `syntheticSource` for non-table views |
-| `Operation.ts` | `Fate.query` / `Fate.list` / `Fate.mutation` + `InputValidationError` |
-| `Fate.ts` | the `Fate` authoring namespace (the constructors + `Entity` + `FateWireCode`; every member is also flat-exported) |
-| `Server.ts` | `FateServer` tag, `config`, `layer`; config validation (shared with codegen, so a bad config also fails the build) |
-| `CurrentUser.ts`, `LivePublisher.ts` | the per-request pair (tags; values come from the host) |
-| `RequestContext.ts` | `FateRequestContext` — the per-request contract (the pair as values; deliberately no `signal`) |
-| `Provision.ts` | `provideRequestPair` — the one per-request provision pipeline (request values innermost, captured build-time services beneath) |
-| `Protocol.ts` | the wire protocol as Effect Schema, drift-pinned against fate's types |
-| `Interpreter.ts`, `Walk.ts`, `Connection.ts` | the native serving path: dispatch, selection walk with `RequestResolver` batching, pagination |
-| `Executor.ts` | the frozen v1 compile step — the differential oracle's baseline only since the cutover (and the package's one `runPromise` conversion) |
-| `Codegen.ts` | `toCodegenServer` — the build-time codegen surface (inert handlers; what `schema.ts` exports) |
-| `Compiled.ts` | the compiled-definition internals `Executor.ts` and `Codegen.ts` share (so the two lifecycles never import each other) |
-
-## Testing
-
-`pnpm --filter @kampus/fate-effect test` runs the suite: the differential oracle pinning the
-interpreter byte-equal to fate's server (per-plane suites over a fixed corpus), type-level pins
-for the codegen surface, enumeration tests that source-grep `src/` for wire-code and
-conversion-drift drift. Typecheck: `pnpm --filter @kampus/fate-effect typecheck`.
-
-## Going deeper
-
-- Pattern docs (how to write feature code):
-  [data views](../../.patterns/fate-effect-data-views.md) ·
-  [sources](../../.patterns/fate-effect-sources.md) ·
-  [operations](../../.patterns/fate-effect-operations.md) ·
-  [wire errors](../../.patterns/fate-effect-wire-errors.md) ·
-  [server](../../.patterns/fate-effect-server.md) ·
-  [interpreter](../../.patterns/fate-effect-interpreter.md) ·
-  [compiler/codegen](../../.patterns/fate-effect-compiler.md) ·
-  [worker wiring](../../.patterns/fate-effect-worker-wiring.md) ·
-  [per-feature assembly](../../.patterns/per-feature-fate-aggregators.md)
-- Guided lesson: [walkthrough.md](./walkthrough.md) — one feature, end to end
-- Decisions (the why): [ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md),
-  [ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md)
+- [interpreter](../../.patterns/fate-effect-interpreter.md)
+- [worker wiring](../../.patterns/fate-effect-worker-wiring.md)
+- [per-feature assembly](../../.patterns/per-feature-fate-aggregators.md)

--- a/packages/fate-effect/README.md
+++ b/packages/fate-effect/README.md
@@ -45,21 +45,31 @@ runtime function.
 ## Compose one config and layer
 
 Build the one config shared by serving and code generation, then discharge domain services in its
-layer:
+layer. Pass the per-request service keys as `FateServer.layer`'s second argument: it is a type-level
+witness (ADR 0107 §7) that lifts those services out of the layer's build-time requirements, so their
+values arrive per request through `FateRequestContext.requestServices` instead. Wrap the mutations
+only on the serving path — code generation reads the plain config:
 
 ```ts
 import {FateServer} from "@kampus/fate-effect";
 import * as Layer from "effect/Layer";
+import {CurrentActor} from "@kampus/authz";
 import {fateConfig} from "./config.ts";
 import {makeFateLayer} from "./layers.ts";
+import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {PanoFeedCache} from "../pano/feed-cache.ts";
+import {throttleMutations} from "../throttle/throttle-mutations.ts";
 
-export const PhoenixFateLive = FateServer.layer(fateConfig).pipe(
-	Layer.provideMerge(makeFateLayer),
-);
+export const PhoenixFateLive = FateServer.layer(
+	{...fateConfig, mutations: throttleMutations(fateConfig.mutations)},
+	[CurrentActor, RequestFlagOverrides, PanoFeedCache],
+).pipe(Layer.provideMerge(makeFateLayer));
 ```
 
-Use the [server pattern](../../.patterns/fate-effect-server.md) when adding sources or request
-services.
+Omit the second argument only when the config needs no request services; with it omitted, anything
+the operations require stays a build-time requirement of the layer. The shipping composition is the
+worker's [fate layers](../../apps/web/worker/features/fate/layers.ts). Use the
+[server pattern](../../.patterns/fate-effect-server.md) when adding sources or request services.
 
 ## Serve a request
 

--- a/packages/fate-effect/README.md
+++ b/packages/fate-effect/README.md
@@ -50,15 +50,12 @@ layer:
 ```ts
 import {FateServer} from "@kampus/fate-effect";
 import * as Layer from "effect/Layer";
+import {fateConfig} from "./config.ts";
+import {makeFateLayer} from "./layers.ts";
 
-export const fateConfig = FateServer.config({
-	queries: panoQueries,
-	lists: panoLists,
-	mutations: panoMutations,
-	sources: panoSources,
-});
-
-export const FateLive = FateServer.layer(fateConfig).pipe(Layer.provide(Pano));
+export const PhoenixFateLive = FateServer.layer(fateConfig).pipe(
+	Layer.provideMerge(makeFateLayer),
+);
 ```
 
 Use the [server pattern](../../.patterns/fate-effect-server.md) when adding sources or request

--- a/packages/fate-effect/README.md
+++ b/packages/fate-effect/README.md
@@ -1,7 +1,10 @@
 # @kampus/fate-effect
 
 Effect-native [fate](https://github.com/nkzw-tech/fate) integration — fate's structure with
-Effect's semantics.
+Effect's semantics. Phoenix's domain↔protocol seam: feature code keeps fate's record shapes
+(`queries` / `lists` / `mutations` / `sources` / views), and every record entry pairs a
+**pure-data definition** (Effect Schema inputs, the success view, a declared error union) with an
+**`Effect.fn` handler**.
 
 ```
 defining things                 composing                serving
@@ -15,108 +18,111 @@ Fate.mutation (resolvers) ┘            │
                                                           (build-time client codegen)
 ```
 
-## What it is
-
-Feature code keeps fate's record shapes (`queries` / `lists` / `mutations` / `sources` / views),
-but every record entry pairs a **pure-data definition** (Effect Schema inputs, the success view,
-a declared error union) with an **`Effect.fn` handler**. The types carry the contracts: an
-unloadable source, an undeclared wire error, or a forgotten domain layer is a *compile* error,
-not a runtime surprise.
-
-Requests are served by a native Effect interpreter on the request fiber — no Effect→Promise hop
-per request, sources batched per request (N+1 is structurally impossible), and one error codec
-for the whole wire surface. The interpreter is verified **byte-equal** to fate's own server by a
-differential oracle in this package's test suite.
-
-The authoring surfaces, one line each (full detail in the module map below):
-
-- **`FateWireCode`** (`WireError.ts`) — annotate a domain error and it becomes a wire error;
-  `encodeWireError` is the one codec, there is no registry.
-- **`FateDataView`** (`DataView.ts`) — the view class factory; its static `view` *is* the kernel
-  data view. A field-map symbol slip loud-fails at construction instead of degrading to `never`
-  far away.
-- **`Fate.source`** (`Source.ts`) — per-entity loaders; handlers are plain generators wrapped in
-  `Effect.fn`, batched per request.
-- **`Fate.query` / `Fate.list` / `Fate.mutation`** (`Operation.ts`) — record entries keyed by
-  wire name; inputs are decoded before your handler runs, declared errors are compile-checked.
-- **`FateServer`** (`Server.ts`) — one config, one layer; config validation names every offender
-  at layer build *and* at codegen, so a bad config fails `pnpm build`.
-- **`CurrentUser` / `LivePublisher`** — the per-request pair; fresh values provided onto each
-  handler from the request context.
-
 ## Why it exists
 
-fate is the data layer phoenix's frontend already speaks (its protocol, its live wire), but its
-semantics are Promise-shaped. This package keeps fate's structure so the client story stays
-byte-compatible, and swaps the semantics to Effect so every contract a feature team cares about
-— declared errors, required domain services, input decoding — moves from runtime surprise to
-compile error. The v1 architecture decision is [ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md);
-the native-interpreter cutover (v2 serves exactly what fate would, verified by the differential
-oracle) is [ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md).
+The types carry the contracts, so the failure modes a hand-rolled data layer grows silently are
+*compile* errors here:
 
-Scope boundary: this package owns the server/authoring substrate only — no HTTP routing (the
-worker's route calls `FateInterpreter.handleRequest` inside its own handler), no database
-clients (loaders receive your domain services), and no client bundle (codegen emits what the
-fate Vite plugin consumes).
+- an unloadable source doesn't type (`SourceLoaderContract`),
+- an undeclared wire error doesn't compile (`E extends DefinitionErrors<D>`),
+- a forgotten domain layer doesn't compile (`FateServer.layer`'s `R`).
+
+Requests are served by a native Effect interpreter on the request fiber — no Effect→Promise hop
+per request, sources batched per request (N+1 is structurally impossible), one error codec for
+the whole wire surface. The interpreter is verified **byte-equal** to fate's own server by a
+differential oracle in this package's test suite. The why and history:
+[ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md) (v1 architecture),
+[ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md) (native interpreter
+cutover).
+
+**What this package is not:** not a general Effect HTTP framework (the host owns routing and
+abort wiring); no client lives here — the SPA consumes generated types through
+[react-fate](https://github.com/kamp-us/phoenix/blob/main/package.json). Authoring guidance lives
+in the pattern docs, not here ([see below](#going-deeper)).
 
 ## How to use it
 
-Depend on it via `workspace:*` and author four record kinds, then compose:
+**Author entries** — errors carry a `FateWireCode`, views are `FateDataView` classes, sources are
+`Fate.source(...)` loaders, operations are `Fate.query`/`list`/`mutation` definitions + handlers.
+The recipes live in the pattern docs:
+[data views](../../.patterns/fate-effect-data-views.md) ·
+[sources](../../.patterns/fate-effect-sources.md) ·
+[operations](../../.patterns/fate-effect-operations.md) ·
+[wire errors](../../.patterns/fate-effect-wire-errors.md).
+A start-to-finish guided build of one feature is at [walkthrough.md](./walkthrough.md).
+
+**Guard view field maps against symbol slips.** A view whose kernel `view` recovery slipped
+(renamed export, moved field map) fails loudly at the definition site when you assert it:
 
 ```ts
-import {Fate} from "@kampus/fate-effect";
-
-export const noteSource = Fate.source(NoteView, {id: "id"}, {
-	byIds: function* (ids) {
-		const notes = yield* Notes;
-		return yield* notes.getByIds(ids);
-	},
-});
-
-export const mutations = {
-	"note.add": Fate.mutation(
-		{input: AddNoteInput, type: NoteView, error: Schema.Union([Unauthorized, NoteNotFound])},
-		Effect.fn("note.add")(function* ({input}) {
-			/* ... */
-		}),
-	),
-};
-
-export const fateConfig = FateServer.config({queries, lists, mutations, sources: [noteSource]});
+import {AssertFieldMapResolved} from "@kampus/fate-effect";
+export const NoteView = AssertFieldMapResolved(NoteViewBase);
 ```
 
-Serve it as one Effect on your request fiber — per request:
+**Compose one config, one layer** — the package's only composition construct:
 
 ```ts
+import {FateServer} from "@kampus/fate-effect";
+
+export const fateConfig = FateServer.config({
+	queries: panoQueries,
+	lists: panoLists,
+	mutations: panoMutations,
+	sources: panoSources,
+});
+export const FateLive = FateServer.layer(fateConfig).pipe(Layer.provide(Pano));
+```
+
+Init-time validation runs against the same config the codegen imports, so a bad config also fails
+the build ([server pattern](../../.patterns/fate-effect-server.md)).
+
+**Serve per request** — one Effect on your request fiber; the interpreter owns no runtime and the
+context deliberately carries no abort signal (the caller wires both):
+
+```ts
+import {FateInterpreter, type FateRequestContext} from "@kampus/fate-effect";
+
 const context: FateRequestContext = {
 	currentUser: {user: session?.user},
-	livePublisher,
+	livePublisher, // the worker builds this from its live topics + waitUntil
 };
 const response = yield* FateInterpreter.handleRequest(request, context);
 ```
 
-Build-time client codegen needs the same config with inert handlers:
+See the worker's [route](../../apps/web/worker/features/fate/route.ts) for the
+abort→interruption pattern.
+
+**Generate client types at build time** — the same config with inert handlers, importable at
+build time:
 
 ```ts
+// schema.ts — the fate Vite plugin imports this via runnerImport
 import {FateExecutor} from "@kampus/fate-effect";
 import {fateConfig} from "./config.ts";
 
 export const fateServer = FateExecutor.toCodegenServer(fateConfig);
 ```
 
-The full narrative walkthrough — building a `Note` entity end to end with real code — lives in
-[WALKTHROUGH.md](./WALKTHROUGH.md). Per-topic pattern docs:
-[data views](../../.patterns/fate-effect-data-views.md) ·
-[sources](../../.patterns/fate-effect-sources.md) ·
-[operations](../../.patterns/fate-effect-operations.md) ·
-[wire errors](../../.patterns/fate-effect-wire-errors.md) ·
-[server](../../.patterns/fate-effect-server.md) ·
-[interpreter](../../.patterns/fate-effect-interpreter.md) ·
-[compiler/codegen](../../.patterns/fate-effect-compiler.md) ·
-[worker wiring](../../.patterns/fate-effect-worker-wiring.md) ·
-[per-feature assembly](../../.patterns/per-feature-fate-aggregators.md)
+`InferFateAPI<typeof fateServer>` produces the same client types as the live server.
 
-## The rules, in one list
+## Reference
+
+**Live publish surface** — `LivePublisher` publishes three ways to a row and four to a
+connection:
+
+| Call | Tells subscribers |
+| --- | --- |
+| `live.update(type, id, {changed, data})` | here are these fields' new values |
+| `live.delete(type, id)` | this row is gone |
+| `live.invalidate(type, id)` | read this row again — no data attached |
+| `live.topic(procedure, args).{appendNode,prependNode,deleteEdge,invalidate}(…)` | this connection's membership moved, or re-load it whole |
+
+`invalidate` is the only honest repair for a **viewer-derived** field — one whose value depends on
+who is reading. Its true new value differs per subscriber, so a broadcast payload would overwrite
+every reader with the mutator's answer; attaching no data forces each subscriber to re-read on its
+own viewer ([ADR 0314](../../.decisions/0314-entity-invalidate-frame-upstream.md)).
+
+**Invariants, in one list**
 
 | Invariant | Enforced by |
 | --- | --- |
@@ -126,21 +132,20 @@ The full narrative walkthrough — building a `Note` entity end to end with real
 | Invalid input never reaches a handler | Schema decode in the entry's `resolve` |
 | A missing domain layer doesn't compile | `FateServer.layer`'s `R` |
 | Wire codes can't silently drift | per-feature enumeration pin tests |
-| A field-map symbol slip loud-fails at view construction | `AssertFieldMapResolved` in `DataView.ts` (the #2805 class of silent `never`s) |
 | A failed live publish can't fail a mutation | `LivePublisher` methods are `Effect<void>` |
 | One Effect→Promise conversion in the package — the oracle baseline's runner in `Executor.ts`; the serving path converts at the platform edge, outside the package | an enumeration test source-greps `src/` for `run*` |
 | v2 serves exactly what fate would | the differential oracle (byte-equal corpus, per-plane suites) |
 
-## Module map
+**Module map**
 
 | Module | What it is |
 | --- | --- |
 | `WireError.ts` | `FateWireCode` annotation + `encodeWireError` (the one error codec) |
-| `DataView.ts` | `FateDataView` class factory, `Entity<>`, `FateDataView.list`; the `AssertFieldMapResolved` loud-fail guard |
-| `Source.ts` | `Fate.source` — per-entity loaders, span-named handlers |
+| `DataView.ts` | `FateDataView` class factory, `Entity<>`, `FateDataView.list`, the `AssertFieldMapResolved` slip guard |
+| `Source.ts` | `Fate.source` — per-entity loaders, span-named handlers; `syntheticSource` for non-table views |
 | `Operation.ts` | `Fate.query` / `Fate.list` / `Fate.mutation` + `InputValidationError` |
 | `Fate.ts` | the `Fate` authoring namespace (the constructors + `Entity` + `FateWireCode`; every member is also flat-exported) |
-| `Server.ts` | `FateServer` tag, `config`, `layer`; config validation (shared with codegen, so a bad config also fails the build); the per-request provision seam ([ADR 0107](../../.decisions/0107-capability-authz-framework.md) §7) |
+| `Server.ts` | `FateServer` tag, `config`, `layer`; config validation (shared with codegen, so a bad config also fails the build) |
 | `CurrentUser.ts`, `LivePublisher.ts` | the per-request pair (tags; values come from the host) |
 | `RequestContext.ts` | `FateRequestContext` — the per-request contract (the pair as values; deliberately no `signal`) |
 | `Provision.ts` | `provideRequestPair` — the one per-request provision pipeline (request values innermost, captured build-time services beneath) |
@@ -150,17 +155,25 @@ The full narrative walkthrough — building a `Note` entity end to end with real
 | `Codegen.ts` | `toCodegenServer` — the build-time codegen surface (inert handlers; what `schema.ts` exports) |
 | `Compiled.ts` | the compiled-definition internals `Executor.ts` and `Codegen.ts` share (so the two lifecycles never import each other) |
 
-Decisions (the why): [ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md) (v1
-architecture), [ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md)
-(native interpreter cutover).
-
 ## Testing
 
-```bash
-pnpm --filter @kampus/fate-effect test        # vitest run
-pnpm --filter @kampus/fate-effect typecheck   # tsc -p tsconfig.json
-```
+`pnpm --filter @kampus/fate-effect test` runs the suite: the differential oracle pinning the
+interpreter byte-equal to fate's server (per-plane suites over a fixed corpus), type-level pins
+for the codegen surface, enumeration tests that source-grep `src/` for wire-code and
+conversion-drift drift. Typecheck: `pnpm --filter @kampus/fate-effect typecheck`.
 
-The suite carries the differential oracle (the interpreter must serve byte-equal to fate's own
-server across the corpus), type-level pin tests (client types identical between live server and
-codegen server), and the enumeration tests behind the rules table above.
+## Going deeper
+
+- Pattern docs (how to write feature code):
+  [data views](../../.patterns/fate-effect-data-views.md) ·
+  [sources](../../.patterns/fate-effect-sources.md) ·
+  [operations](../../.patterns/fate-effect-operations.md) ·
+  [wire errors](../../.patterns/fate-effect-wire-errors.md) ·
+  [server](../../.patterns/fate-effect-server.md) ·
+  [interpreter](../../.patterns/fate-effect-interpreter.md) ·
+  [compiler/codegen](../../.patterns/fate-effect-compiler.md) ·
+  [worker wiring](../../.patterns/fate-effect-worker-wiring.md) ·
+  [per-feature assembly](../../.patterns/per-feature-fate-aggregators.md)
+- Guided lesson: [walkthrough.md](./walkthrough.md) — one feature, end to end
+- Decisions (the why): [ADR 0042](../../.decisions/0042-fate-effect-v1-architecture.md),
+  [ADR 0043](../../.decisions/0043-fate-effect-v2-native-interpreter-cutover.md)

--- a/packages/fate-effect/reference.md
+++ b/packages/fate-effect/reference.md
@@ -1,0 +1,68 @@
+# @kampus/fate-effect reference
+
+Lookup tables for the package's public authoring, serving, and code-generation surface.
+
+## Public surface groups
+
+| Surface | Public exports |
+| --- | --- |
+| Errors | `FateWireCode`, `encodeWireError`, `wireCodeOf`, `wireCodeOfClass`, `failureOf`, `INTERNAL_WIRE_CODE`, `Unauthorized` |
+| Views and entities | `FateDataView`, `Entity<>`, `WorkerEntity<>`, `AssertFieldMapResolved<>`, `FieldMapResolved<>`, `FieldMapRecoveryFailed<>`, `DataViewOf<>`, `FateDataViewClass`, `KernelDataView`, `ListFieldOf<>` |
+| Sources | `Fate.source`, `source`, `syntheticSource`, `FateSource`, `SourceLoaderContract`, source handler and service helper types |
+| Operations | `Fate.query`, `Fate.list`, `Fate.mutation`, flat `query`, `list`, `mutation`, `InputValidationError`, definition and handler helper types |
+| Composition | `FateServer.config`, `FateServer.layer`, `FateServerConfig`, `FateServerRequirements`, `RegisteredRequestServices<>`, `RequestServiceId<>` |
+| Serving | `FateInterpreter`, `FateRequestContext`, `CurrentUser`, `LivePublisher` |
+| Code generation | `FateExecutor.toCodegenServer`, `FateCodegenServer` and API helper types |
+| Protocol | schemas and encoded/decoded operation and result types from `Protocol.ts` |
+
+`WorkerEntity<View, DateKeys, Override>` applies worker-side date and relation corrections to an
+`Entity`. `RegisteredRequestServices<Keys>` extracts the service identifiers registered with
+`FateServer.layer`; `RequestServiceId<Key>` extracts one identifier. These three are type-only
+exports.
+
+The barrel at [`src/index.ts`](./src/index.ts) is the exhaustive export list.
+
+## Live publish surface
+
+| Call | Subscriber result |
+| --- | --- |
+| `live.update(type, id, {changed, data})` | Apply the supplied field values. |
+| `live.delete(type, id)` | Remove the row. |
+| `live.invalidate(type, id)` | Re-read the row without applying shared data. |
+| `live.topic(procedure, args).appendNode(…)` | Append a connection node. |
+| `live.topic(procedure, args).prependNode(…)` | Prepend a connection node. |
+| `live.topic(procedure, args).deleteEdge(…)` | Remove a connection edge. |
+| `live.topic(procedure, args).invalidate()` | Re-read the connection. |
+
+## Invariants
+
+| Invariant | Enforced by |
+| --- | --- |
+| A source has a loader | `SourceLoaderContract` |
+| Source infrastructure failures do not enter the typed error channel | `E = never` on handler slots |
+| Wire errors are declared | `E extends DefinitionErrors<D>` |
+| Inputs are decoded before handlers run | the operation's `resolve` path |
+| Domain requirements remain in the layer input | `FateServer.layer`'s `R` channel |
+| Wire codes remain enumerated | per-feature enumeration tests |
+| Live publication cannot fail a mutation | `LivePublisher` methods return `Effect<void>` |
+| The production serving path does not convert Effect to Promise | the source enumeration test |
+| The native interpreter matches fate | the byte-equal differential oracle |
+
+## Module map
+
+| Module | Contents |
+| --- | --- |
+| `WireError.ts` | wire annotation, encoder, and error lookup helpers |
+| `DataView.ts` | view factory; entity, `WorkerEntity`, list-field, and field-map guard types |
+| `Source.ts` | source constructors and loader contracts; `syntheticSource` |
+| `Operation.ts` | query, list, and mutation definitions and handlers |
+| `Fate.ts` | authoring namespace over the flat exports |
+| `Server.ts` | configuration, layer construction, request-service types including `RegisteredRequestServices` and `RequestServiceId` |
+| `CurrentUser.ts`, `LivePublisher.ts` | request-scoped services |
+| `RequestContext.ts` | request value contract |
+| `Provision.ts` | request-value provision pipeline |
+| `Protocol.ts` | wire schemas and protocol types |
+| `Interpreter.ts`, `Walk.ts`, `Connection.ts` | native request dispatch, selection, batching, and pagination |
+| `Executor.ts` | frozen v1 oracle baseline |
+| `Codegen.ts` | inert build-time server |
+| `Compiled.ts` | compiled internals shared by executor and codegen |

--- a/packages/fate-effect/walkthrough.md
+++ b/packages/fate-effect/walkthrough.md
@@ -1,9 +1,7 @@
 # @kampus/fate-effect — worked walkthrough
 
-A guided build of one small feature — a `Note` entity with a read, a write, and a live update — against the real API, end to end. Every piece is production API; the in-repo worked example is sozluk ([views](../../apps/web/worker/features/sozluk/views.ts), [sources](../../apps/web/worker/features/sozluk/sources.ts), [queries](../../apps/web/worker/features/sozluk/queries.ts), [mutations](../../apps/web/worker/features/sozluk/mutations.ts), [errors](../../apps/web/worker/features/sozluk/errors.ts)). Start from the [README](./README.md) for the shape of the package; this page is the start-to-finish lesson.
-
-The walkthrough builds one small feature — a `Note` entity with a read, a write, and a live
-update. Every piece below is the real API; the in-repo worked example is sozluk
+Build one small feature — a `Note` entity with a read, a write, and a live update — against the
+real API, end to end. The in-repo worked example is sozluk
 ([views](../../apps/web/worker/features/sozluk/views.ts),
 [sources](../../apps/web/worker/features/sozluk/sources.ts),
 [queries](../../apps/web/worker/features/sozluk/queries.ts),
@@ -136,20 +134,9 @@ full contract is the pattern doc's: [operations](../../.patterns/fate-effect-ope
 `CurrentUser` and `LivePublisher` are ordinary services from the handler's point of view; the
 serving layer provides fresh per-request values.
 
-`LivePublisher` publishes three ways to a row and four to a connection:
-
-| Call | Tells subscribers |
-| --- | --- |
-| `live.update(type, id, {changed, data})` | here are these fields' new values |
-| `live.delete(type, id)` | this row is gone |
-| `live.invalidate(type, id)` | read this row again — no data attached |
-| `live.topic(procedure, args).{appendNode,prependNode,deleteEdge,invalidate}(…)` | this connection's membership moved, or re-load it whole |
-
-`invalidate` is the only honest repair for a **viewer-derived** field — one whose value depends on
-who is reading, like a viewer's own vote or a moderation marker. Its true new value differs per
-subscriber, so a broadcast payload would overwrite every reader with the mutator's answer;
-attaching no data is what forces each subscriber to re-read on its own viewer
-([ADR 0314](../../.decisions/0314-entity-invalidate-frame-upstream.md)).
+The mutation publishes one connection change with `appendNode`. Use the
+[live-publish reference](./reference.md#live-publish-surface) when your feature needs another row or
+connection operation.
 
 Queries are the same minus `input`: `Fate.query({args: ArgsSchema, type: NoteView}, handler)`,
 where the handler bag is `{args, select}` — `select` is the client's field selection, useful for

--- a/packages/fate-effect/walkthrough.md
+++ b/packages/fate-effect/walkthrough.md
@@ -1,15 +1,6 @@
-# @kampus/fate-effect walkthrough
+# @kampus/fate-effect — worked walkthrough
 
-The full numbered walkthrough — building one small feature (a `Note` entity with a read, a
-write, and a live update) end to end. Every piece is the real API; the in-repo worked example
-is sozluk ([views](../../apps/web/worker/features/sozluk/views.ts),
-[sources](../../apps/web/worker/features/sozluk/sources.ts),
-[queries](../../apps/web/worker/features/sozluk/queries.ts),
-[mutations](../../apps/web/worker/features/sozluk/mutations.ts),
-[errors](../../apps/web/worker/features/sozluk/errors.ts)). The README carries the shape and
-the reference; this page carries the narrative.
-
-## Getting started
+A guided build of one small feature — a `Note` entity with a read, a write, and a live update — against the real API, end to end. Every piece is production API; the in-repo worked example is sozluk ([views](../../apps/web/worker/features/sozluk/views.ts), [sources](../../apps/web/worker/features/sozluk/sources.ts), [queries](../../apps/web/worker/features/sozluk/queries.ts), [mutations](../../apps/web/worker/features/sozluk/mutations.ts), [errors](../../apps/web/worker/features/sozluk/errors.ts)). Start from the [README](./README.md) for the shape of the package; this page is the start-to-finish lesson.
 
 The walkthrough builds one small feature — a `Note` entity with a read, a write, and a live
 update. Every piece below is the real API; the in-repo worked example is sozluk


### PR DESCRIPTION
## What

Pins the package README shape as a repository pattern, then applies it to `@kampus/fate-effect` without mixing reader needs on one page.

- `.patterns/package-readme-shape.md` defines the explanation → how-to → reference → testing navigation order, the no-package-tutorial rule, the explanation-half scope rule, the small-package minimum, and the single-mode classification contract.
- `packages/fate-effect/README.md` is now a task-oriented how-to with verified compose, serve, codegen, field-map guard, live-publish, and validation recipes.
- `packages/fate-effect/reference.md` owns dry lookup material, including the live-publish table, invariants, module map, and additive public type exports.
- `packages/fate-effect/walkthrough.md` remains the linked start-to-finish tutorial without duplicated introductions or reference tables.
- `.patterns/index.md` and `.glossary/LANGUAGE.md` link and name the new pattern.

Closes #4079.

## Validation

- `node packages/fabrika-cli/src/bin.ts build check --surface prose`
- `pnpm --filter @kampus/fate-effect typecheck`
- `pnpm --filter @kampus/fate-effect test` (16 files, 158 tests)

## Deviations

- **Pre-existing test or fixture changed** — **Said:** the first truth pass verified every documented export recipe. **Did:** the repair replaced the invalid runtime call to the type-only `AssertFieldMapResolved` with the compile-time constraint used by the shipping view assembly. **Why:** review proved the original import/call could not compile. **Disposition:** corrected in the README and identified explicitly as a type alias.
- **Out-of-scope change** — **Said:** the first truth pass covered the public exports added in the source window. **Did:** the repair added the omitted `WorkerEntity`, `RegisteredRequestServices`, and `RequestServiceId` type exports to the new reference surface. **Why:** review found that the README module map neither described nor excluded them. **Disposition:** corrected in `reference.md`.
- **Scope narrowing** — **Said:** one README could classify as explanation-dominant while embedding how-to and reference sections. **Did:** the repair made the README how-to-only and moved lookup tables to `reference.md`; the walkthrough remains tutorial-only. **Why:** the Diátaxis pass reported mixed reader needs despite the section labels. **Disposition:** each page now has one dominant mode.
- **Out-of-scope change** — **Said:** documentation validation was green. **Did:** the repair corrected both `.patterns/package-readme-shape.md` classifier links from `../../claude-plugins/...` to `../claude-plugins/...`. **Why:** review's complete CI-at-head read found the dead internal links. **Disposition:** the prose check now resolves every changed Markdown link.

- **Out-of-scope change** — **Said:** the round-3 repair verified every documented composition recipe against its source. **Did:** round 4 rewrote the `PhoenixFateLive` recipe to carry `FateServer.layer`'s second argument, `[CurrentActor, RequestFlagOverrides, PanoFeedCache]`, and the serving-only `throttleMutations` wrapper. **Why:** review proved the recipe named the shipping identifiers while documenting a different composition — without the request-service witness those services stay build-time layer requirements. **Disposition:** the recipe now matches `apps/web/worker/features/fate/layers.ts:180-188` and links it.
