### PR TITLE
fix(fabrika): fence the resumed dead lane across an adopt succession

### DIFF
--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -416,14 +416,39 @@ export const resolveOwnership = (
 		}
 		const parsed = parseToken(winner.token, grammar.prefix);
 		const sameSession = parsed !== null && parsed.session === caller.session;
+		const unauthorizedAdopts: AdoptMarker[] = [];
 		if (namesCaller(winner.token)) {
+			// ADOPT-FENCE (#7010): the winning marker names this lane, but an authorized adopt marker
+			// handing that session's claim to a DIFFERENT lane means succession already happened —
+			// the resumed "dead" lane reads Foreign, never Mine, so one succession can never answer
+			// Mine to two lanes.
+			for (const adopt of adoptMarkersIn(listed.value, grammar)) {
+				if (parsed === null || adopt.adopted !== parsed.session) continue;
+				if (namesCaller(adopt.token)) continue;
+				const permission = yield* authorizationOf(adopt.author);
+				if (permission._tag === "Unknown") {
+					return {
+						ownership: {_tag: "Unknown", reason: permission.reason},
+						unauthorized,
+						unauthorizedAdopts,
+					};
+				}
+				if (permission._tag === "Unauthorized") {
+					unauthorizedAdopts.push(adopt);
+					continue;
+				}
+				return {
+					ownership: {_tag: "Foreign" as const, marker: winner, sameSession},
+					unauthorized,
+					unauthorizedAdopts,
+				};
+			}
 			return {
 				ownership: {_tag: "Mine" as const, marker: winner, adopt: null},
 				unauthorized,
-				unauthorizedAdopts: [],
+				unauthorizedAdopts,
 			};
 		}
-		const unauthorizedAdopts: AdoptMarker[] = [];
 		for (const adopt of adoptMarkersIn(listed.value, grammar)) {
 			if (parsed === null || adopt.adopted !== parsed.session) continue;
 			if (!namesCaller(adopt.token)) continue;
@@ -558,7 +583,13 @@ export type Held =
 			readonly ownership: Ownership;
 			readonly notes: ReadonlyArray<string>;
 	  }
-	| {readonly _tag: "Held"; readonly marker: ClaimMarker; readonly notes: ReadonlyArray<string>};
+	| {
+			readonly _tag: "Held";
+			readonly marker: ClaimMarker;
+			/** Non-null when this lane holds through succession — what the run key keys on (#7010). */
+			readonly adopt: AdoptMarker | null;
+			readonly notes: ReadonlyArray<string>;
+	  };
 
 /**
  * The precondition every mutating verb runs: this lane holds `number`'s claim, proven now.
@@ -615,5 +646,5 @@ export const requireClaim = (
 				),
 			};
 		}
-		return {_tag: "Held" as const, marker: ownership.marker, notes};
+		return {_tag: "Held" as const, marker: ownership.marker, adopt: ownership.adopt, notes};
 	});

--- a/packages/fabrika-cli/src/build/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim.unit.test.ts
@@ -12,7 +12,14 @@ import {
 } from "./claim.ts";
 import {CLAIM_NOT_MINE} from "./codes.ts";
 import {
+	adoptMarker,
 	comments,
+	GONE_NONCE,
+	GONE_TOKEN,
+	GONE_UUID,
+	HEIR_NONCE,
+	HEIR_TOKEN,
+	HEIR_UUID,
 	LANE_TOKEN,
 	LANE_UUID,
 	marker,
@@ -99,6 +106,60 @@ describe("resolveOwnership", () => {
 	});
 });
 
+describe("resolveOwnership — the adopt fence (#7010)", () => {
+	/** A claim by the gone session, then an authorized succession handing it to the heir. */
+	const SUCCEEDED: ReadonlyArray<Scripted> = [
+		[
+			COMMENTS,
+			comments(
+				{id: 9101, body: marker("s-gone", GONE_UUID)},
+				{id: 9102, body: adoptMarker("s-gone", "s-heir", HEIR_UUID)},
+			),
+		],
+		[PERM, WRITE],
+	];
+
+	it("reads Foreign for the resumed dead lane — never Mine across one succession", async () => {
+		const {ownership} = await run(
+			resolveOwnership("o/r", 4312, laneCaller("s-gone", GONE_NONCE, GONE_TOKEN)),
+			SUCCEEDED,
+		);
+		expect(ownership._tag).toBe("Foreign");
+	});
+
+	it("still reads Mine for the heir the adopt names, carrying the adopt", async () => {
+		const {ownership} = await run(
+			resolveOwnership("o/r", 4312, laneCaller("s-heir", HEIR_NONCE, HEIR_TOKEN)),
+			SUCCEEDED,
+		);
+		expect(ownership._tag).toBe("Mine");
+		expect(ownership._tag === "Mine" && ownership.adopt?.token).toBe(HEIR_TOKEN);
+	});
+
+	it("does not fence on an unauthorized adoption — the succession never legally happened", async () => {
+		const {ownership, unauthorizedAdopts} = await run(
+			resolveOwnership("o/r", 4312, laneCaller("s-gone", GONE_NONCE, GONE_TOKEN)),
+			[
+				[
+					COMMENTS,
+					comments(
+						{id: 9101, body: marker("s-gone", GONE_UUID)},
+						{
+							id: 9102,
+							body: adoptMarker("s-gone", "s-heir", HEIR_UUID),
+							author: "ghost",
+						},
+					),
+				],
+				[PERM, WRITE],
+				[/GET .*\/repos\/o\/r\/collaborators\/ghost\/permission/, served({permission: "read"})],
+			],
+		);
+		expect(ownership._tag).toBe("Mine");
+		expect(unauthorizedAdopts.length).toBe(1);
+	});
+});
+
 describe("requireClaim", () => {
 	it("refuses the sibling lane on 15, naming the winner and the asking lane", async () => {
 		const held = await run(
@@ -119,6 +180,43 @@ describe("requireClaim", () => {
 			BOTH_LANES,
 		);
 		expect(held._tag).toBe("Held");
+	});
+
+	it("carries the succession on Held, so a run keys on the adopt token (#7010)", async () => {
+		const held = await run(
+			requireClaim("build note", "o/r", 4312, laneCaller("s-heir", HEIR_NONCE, HEIR_TOKEN)),
+			[
+				[
+					COMMENTS,
+					comments(
+						{id: 9101, body: marker("s-gone", GONE_UUID)},
+						{id: 9102, body: adoptMarker("s-gone", "s-heir", HEIR_UUID)},
+					),
+				],
+				[PERM, WRITE],
+			],
+		);
+		expect(held._tag).toBe("Held");
+		expect(held._tag === "Held" && held.adopt?.token).toBe(HEIR_TOKEN);
+	});
+
+	it("refuses the resumed dead lane on 15 across a succession (#7010)", async () => {
+		const held = await run(
+			requireClaim("build note", "o/r", 4312, laneCaller("s-gone", GONE_NONCE, GONE_TOKEN)),
+			[
+				[
+					COMMENTS,
+					comments(
+						{id: 9101, body: marker("s-gone", GONE_UUID)},
+						{id: 9102, body: adoptMarker("s-gone", "s-heir", HEIR_UUID)},
+					),
+				],
+				[PERM, WRITE],
+			],
+		);
+		expect(held._tag).toBe("Refused");
+		if (held._tag !== "Refused") return;
+		expect(held.outcome.code).toBe(CLAIM_NOT_MINE);
 	});
 });
 

--- a/packages/fabrika-cli/src/build/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/build/fixtures.test-support.ts
@@ -196,3 +196,13 @@ export const LANE_TOKEN = `build:s-9f2e:${LANE_UUID}`;
 export const SIBLING_UUID = "7bab0955-616f-4a6a-af6e-71c34b7c68c7";
 export const SIBLING_NONCE = "7bab0955";
 export const SIBLING_TOKEN = `build:s-9f2e:${SIBLING_UUID}`;
+
+/** The presumed-dead session whose claim a successor adopted — the resume-fence shape (#7010). */
+export const GONE_UUID = "9f3c7a21-5d44-4e08-b1c2-77aa0f3e91d0";
+export const GONE_NONCE = "9f3c7a21";
+export const GONE_TOKEN = `build:s-gone:${GONE_UUID}`;
+
+/** The session that adopted the gone lane's claim (ADR 0295). */
+export const HEIR_UUID = "b2ee7f04-8a19-4d57-93ba-1c5d92e6f7a8";
+export const HEIR_NONCE = "b2ee7f04";
+export const HEIR_TOKEN = `build:s-heir:${HEIR_UUID}`;

--- a/packages/fabrika-cli/src/ledger/preconditions.ts
+++ b/packages/fabrika-cli/src/ledger/preconditions.ts
@@ -19,14 +19,13 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {requireCallerToken, requireClaim, requireSession} from "../build/claim.ts";
-import {nonceOf} from "../build/lane.ts";
 import {badNumber, openIssue, resolveTargetRepo} from "../build/target.ts";
 import {assertGround} from "../build/tree.ts";
 import type {IssueRecord} from "../io/issues.ts";
 import {EPIC_TYPE_LABEL} from "../triage/facets.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {CLAIM_NOT_MINE, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
-import {runDir, runKey} from "./run.ts";
+import {runDir, runKey, runKeyNonce} from "./run.ts";
 
 /** The per-verb halves of the shared refusals — the same facts, each verb's own wording. */
 export interface LedgerMessages {
@@ -109,7 +108,10 @@ export const openGround = (
 			);
 		}
 
-		const nonce = nonceOf(held.marker.token);
+		// A succession keys the run on the ADOPT token's nonce (#7010): inheriting the dead lane's
+		// nonce is how both sides of one succession wrote one manifest. The adopt token is the
+		// successor's own and stable across its re-opens — a resume stays a resume.
+		const nonce = runKeyNonce(held.marker.token, held.adopt?.token ?? null);
 		if (nonce === null) {
 			return refused(
 				refuse(

--- a/packages/fabrika-cli/src/ledger/run.ts
+++ b/packages/fabrika-cli/src/ledger/run.ts
@@ -15,6 +15,7 @@
  * an unreadable manifest and an empty one take opposite branches, and only one of them is a fact.
  */
 
+import {nonceOf} from "../build/lane.ts";
 import {isRecord, parseJson} from "../io/json.ts";
 
 /** The directory the run tree lives under, inside the epic's tree. */
@@ -30,6 +31,16 @@ export const EXCLUDE_ENTRY = `${RUN_ROOT}/`;
 
 /** The run key: `<epic>-<claim-nonce>`. */
 export const runKey = (epic: number, nonce: string): string => `${epic}-${nonce}`;
+
+/**
+ * The nonce a ledger run keys on: through a succession, the ADOPT token's — never the dead lane's.
+ *
+ * Inheriting the dead marker's nonce is how both sides of one succession wrote one manifest (#7010).
+ * The adopt token is the successor's own, stable across its re-opens, so keying on it keeps a resume
+ * a resume while giving the two sides of a succession separate manifests.
+ */
+export const runKeyNonce = (markerToken: string, adoptToken: string | null): string | null =>
+	nonceOf(adoptToken ?? markerToken) ?? nonceOf(markerToken);
 
 /** The run’s directory inside the epic tree. */
 export const runDir = (treeRoot: string, key: string): string =>

--- a/packages/fabrika-cli/src/ledger/run.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/run.unit.test.ts
@@ -8,6 +8,7 @@ import {
 	renderRunRecord,
 	runDir,
 	runKey,
+	runKeyNonce,
 } from "./run.ts";
 
 const CHILD: ChildRecord = {
@@ -32,6 +33,21 @@ describe("the run key", () => {
 
 	it("excludes its own root from the tree", () => {
 		expect(EXCLUDE_ENTRY).toBe(".fabrika-plan/");
+	});
+
+	it("keys a succession on the adopt token's nonce, never the dead lane's (#7010)", () => {
+		expect(runKeyNonce("build:s-gone:9f3c7a21-5d44", "build:s-heir:b2ee7f04-8a19")).toBe(
+			"b2ee7f04",
+		);
+	});
+
+	it("keys an ordinary claim on the winning marker's own token", () => {
+		expect(runKeyNonce("build:s-9f2e:c1a4d6f8-3b7e", null)).toBe("c1a4d6f8");
+	});
+
+	it("falls back to the marker when the adopt token is unparseable, and nulls when neither reads", () => {
+		expect(runKeyNonce("build:s-9f2e:c1a4d6f8-3b7e", "not-a-token")).toBe("c1a4d6f8");
+		expect(runKeyNonce("garbage", "also-garbage")).toBeNull();
 	});
 });
 


### PR DESCRIPTION
Closes #7010

## What broke
`build adopt` hands a dead session's claim to a successor, but nothing fenced the *adopted* session from resuming: `resolveOwnership` answered **Mine to both sides** — the winner marker names the original session's token, so the resumed lane re-owned the claim its own successor had adopted. Live incident on epic #5979: two planning lanes minted eight children into one shared manifest, every overlapping write exiting 0.

## The fix (both acceptance mechanisms)
1. **The fence** — `resolveOwnership`: on the ordinary-Mine path, an authorized adopt marker handing that session's claim to a *different* lane fences the asking lane to `Foreign`. The resumed original now refuses on 15 at `confirm`/`release`/`requireClaim`. Unauthorized adopts are counted, never fencing (ADR 0055).
2. **Run-key succession** — ledger preconditions key the run on the **adopt token's** nonce (`runKeyNonce`) instead of inheriting the dead marker's: the successor gets its own stable manifest; the original can't reach the ledger at all.

## Tests
- adopt fence: resumed original → Foreign; heir → Mine carrying the adopt; unauthorized adoption fences nobody
- requireClaim: carries adopt on Held; refuses resumed original on 15
- runKeyNonce: succession keys on adopt nonce; ordinary unchanged; unparseable fallbacks

Full suite: 458 files / 7864 tests green.