### PR TITLE
fix(lane): serialize ledger appends behind a write lock (#5994)

### DIFF
--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -86,6 +86,11 @@ export interface FakeFsOptions {
 	readonly unremovable?: ReadonlyArray<string>;
 	/** Paths a removal is scripted to NOT actually remove, so the re-probe has something to catch. */
 	readonly survivesRemoval?: ReadonlyArray<string>;
+	/**
+	 * Directory paths whose creation fails `AlreadyExists` even when nothing is there — modeling a
+	 * lock another writer holds, so the losing side of an append race is testable on demand (#5994).
+	 */
+	readonly mkdirExisting?: ReadonlyArray<string>;
 }
 
 export interface FakeFs {
@@ -131,6 +136,16 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 			},
 			makeDirectory: (path: string) => {
 				if (options.unwritable?.includes(path) === true) return notFound("makeDirectory", path);
+				if (options.mkdirExisting?.includes(path) === true) {
+					return Effect.fail(
+						PlatformError.systemError({
+							_tag: "AlreadyExists",
+							module: "FileSystem",
+							method: "makeDirectory",
+							pathOrDescriptor: path,
+						}),
+					);
+				}
 				directories.add(path);
 				return Effect.void;
 			},

--- a/packages/fabrika-cli/src/lane/append-lock.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.ts
@@ -1,0 +1,138 @@
+/**
+ * The lane ledger's write lock — the serialization #5994 owes concurrent shells.
+ *
+ * Until shells recorded their own terminals (#5736/#5980), a lane had exactly one writer and the
+ * check-then-act window between `loadLane` and `appendText` never opened. An epic run's parallel
+ * phase has several shells alive at once, so the window is live now: two writers can both validate
+ * against the same fold and both append, and the loser records an event the machine would have
+ * refused against the state that actually existed when its bytes landed. The corruption is silent
+ * and permanent — the fold is the lane's only state.
+ *
+ * The primitive is an atomic `mkdir` on a sidecar directory (`events.lock` beside `events.jsonl`):
+ * directory creation either lands whole or fails `AlreadyExists`, so exactly one writer holds it.
+ * Every verb that appends to a lane log takes the lock around its **entire** load → fold → validate
+ * → append section, so validation always runs against the bytes that are about to receive the
+ * write. A writer that finds the lock held waits within its budget; on budget exhaustion it refuses
+ * {@link CONCURRENT_WRITE} — a distinct seat from an ordinary machine refusal, because the remedy
+ * differs: retry this same event, versus pick a different one.
+ *
+ * **A crashed holder must not brick the lane.** A process killed between acquire and release would
+ * otherwise leave the sidecar forever, so a lock whose directory mtime is older than
+ * {@link STALE_LOCK_MS} is stolen on sight. Anything newer is presumed alive; waiting is the honest
+ * answer.
+ */
+import {Effect, type FileSystem, Option, type Path, Result} from "effect";
+import {CONCURRENT_WRITE} from "./codes.ts";
+
+/** The sidecar directory a holding writer creates inside the lane directory. */
+export const LOCK_DIR_NAME = "events.lock";
+
+/** How long a writer waits for a held lock before refusing rather than writing blind. */
+const DEFAULT_LOCK_BUDGET_MS = 5_000;
+
+/**
+ * The budget is an operations surface, not just a constant: a caller that would rather refuse fast
+ * (a test, an interactive shell) sets `FABRIKA_LANE_LOCK_BUDGET_MS` and every verb honors it.
+ */
+const lockBudgetMs = (): number => {
+	const raw = process.env["FABRIKA_LANE_LOCK_BUDGET_MS"];
+	const parsed = raw === undefined ? Number.NaN : Number(raw);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LOCK_BUDGET_MS;
+};
+
+/** A held lock older than this is presumed crashed, not slow, and is stolen. */
+const STALE_LOCK_MS = 60_000;
+
+/** Poll cadence while waiting for a held lock. */
+const POLL_MS = 50;
+
+export interface LockRefusal {
+	readonly _tag: "Locked";
+	readonly lockDir: string;
+	readonly reason: string;
+}
+
+const acquireOnce = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<boolean, never> =>
+	Effect.gen(function* () {
+		const made = yield* Effect.result(fs.makeDirectory(lockDir, {recursive: false}));
+		if (Result.isSuccess(made)) return true;
+		// Any failure to create is treated as "held" — the atomic-mkdir race lands here too,
+		// and a non-existence failure mode is not one mkdir has.
+		return false;
+	});
+
+const stealIfStale = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<boolean, never> =>
+	Effect.gen(function* () {
+		const probed = yield* Effect.result(fs.stat(lockDir));
+		if (Result.isFailure(probed)) return false;
+		const mtime = probed.success.mtime;
+		if (Option.isNone(mtime)) return false;
+		return Date.now() - mtime.value.getTime() > STALE_LOCK_MS;
+	});
+
+const removeLock = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<void, never> =>
+	Effect.ignore(fs.remove(lockDir, {recursive: true}));
+
+/**
+ * Wait for and hold the lane's write lock. `true` means this writer holds it — release is the
+ * caller's duty, best-effort via {@link releaseLock}. `false` means the budget ran out with the
+ * lock still held elsewhere; nothing was written anywhere.
+ */
+export const acquireLedgerLock = (
+	fs: FileSystem.FileSystem,
+	lockDir: string,
+	budgetMs: number = lockBudgetMs(),
+): Effect.Effect<boolean, never> =>
+	Effect.gen(function* () {
+		const deadline = Date.now() + budgetMs;
+		while (true) {
+			if (yield* acquireOnce(fs, lockDir)) return true;
+			if ((yield* stealIfStale(fs, lockDir)) && (yield* acquireOnce(fs, lockDir))) return true;
+			if (Date.now() >= deadline) return false;
+			yield* Effect.sleep(`${POLL_MS} millis`);
+		}
+	});
+
+/** Best-effort release: a failed removal leaves the lock to be stolen as stale, never retried here. */
+export const releaseLedgerLock = (
+	fs: FileSystem.FileSystem,
+	lockDir: string,
+): Effect.Effect<void, never> => removeLock(fs, lockDir);
+
+/**
+ * Run one verb body inside the lane's write lock. The inner effect sees the bytes as they are when
+ * the lock is already held, so its validation cannot race another writer's append. On lock-budget
+ * exhaustion the caller's `onLocked` builds the refusal — {@link CONCURRENT_WRITE}'s seat, never
+ * an ordinary machine-refusal code, so a caller can tell "retry me" from "this event is invalid".
+ * Release runs on every exit, refusal included.
+ */
+export const withLedgerLock = <A, R>(
+	deps: {
+		readonly fs: FileSystem.FileSystem;
+		readonly path: Path.Path;
+		/** The lane directory the log lives in — the lock sits beside the log, inside it. */
+		readonly dir: string;
+		/** The invoking verb's label, quoted in the lock-timeout refusal. */
+		readonly verb: string;
+	},
+	inner: Effect.Effect<A, never, R>,
+	onLocked: (lockDir: string, reason: string) => A,
+): Effect.Effect<A, never, R> =>
+	Effect.gen(function* () {
+		const lockDir = deps.path.join(deps.dir, LOCK_DIR_NAME);
+		const held = yield* acquireLedgerLock(deps.fs, lockDir);
+		if (!held) {
+			return onLocked(
+				lockDir,
+				`another writer holds ${lockDir} — concurrent writers are serialized, so retry this exact event once the holder clears`,
+			);
+		}
+		return yield* Effect.onExit(inner, () => removeLock(deps.fs, lockDir));
+	});
+
+/** The refusal message fragment every appending verb shares on lock-budget exhaustion. */
+export const lockedRefusal = (verb: string, lockDir: string): string =>
+	`${verb}: refused (log unappended): another writer holds ${lockDir} — concurrent ledger writes are serialized (${CONCURRENT_WRITE}); retry this exact event once the holder clears.`;
+
+// Re-exported so callers need no second import site for the refusal seat.
+export {CONCURRENT_WRITE};

--- a/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The append lock's own contract at unit tier (#5994): a writer that finds the lock held refuses
+ * {@link CONCURRENT_WRITE} — distinguishable from an ordinary machine refusal — with the log left
+ * byte-identical, while the uncontended path behaves exactly as it did before the lock existed.
+ *
+ * Contention here is scripted (`mkdirExisting`), not raced: the point is the *deterministic* half
+ * of the guarantee. The probabilistic half — that two live processes actually collide often enough
+ * for the guard to matter — lives in [`append-race.cli.test.ts`](append-race.cli.test.ts), which
+ * races real processes against one ledger.
+ */
+import {Effect} from "effect";
+import {afterEach, describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {CONCURRENT_WRITE, EVENT_REFUSED} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runTransition} from "./transition-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const WORKFLOW = `${ROOT}/42/workflow.json`;
+const LOG = `${ROOT}/42/events.jsonl`;
+const LOCK = `${ROOT}/42/events.lock`;
+
+const freshLane = (extra: Parameters<typeof fakeFs>[0] = {}) =>
+	fakeFs({
+		files: {[WORKFLOW]: coderTemplateText()},
+		...extra,
+	});
+
+const run = (fs: ReturnType<typeof fakeFs>) =>
+	Effect.runPromise(
+		Effect.provide(
+			runTransition({root: ROOT, lane: "42", event: "WIP", task: null, cause: null, classes: []}),
+			fs.layer,
+		),
+	);
+
+const SHORT_LOCK_MS = "120";
+
+describe("lane append lock (#5994)", {timeout: 10_000}, () => {
+	afterEach(() => {
+		delete process.env["FABRIKA_LANE_LOCK_BUDGET_MS"];
+	});
+	it("a writer that finds the lock held refuses CONCURRENT_WRITE and leaves the log untouched", async () => {
+		process.env["FABRIKA_LANE_LOCK_BUDGET_MS"] = SHORT_LOCK_MS;
+		const fs = freshLane({mkdirExisting: [LOCK]});
+
+		const out = await run(fs);
+		expect(out.code).toBe(CONCURRENT_WRITE);
+		expect(out.stderr.join(" ")).toContain("another writer holds");
+		expect(out.stderr.join(" ")).toContain(LOCK);
+		// Byte-identical: no events.jsonl was ever created by the losing writer.
+		expect(fs.written.get(LOG)).toBeUndefined();
+	});
+
+	it("the refusal is distinguishable from an ordinary machine refusal on the same event", async () => {
+		process.env["FABRIKA_LANE_LOCK_BUDGET_MS"] = SHORT_LOCK_MS;
+		const heldLock = freshLane({mkdirExisting: [LOCK]});
+		const machineRefusal = freshLane({
+			files: {
+				[WORKFLOW]: coderTemplateText(),
+				[LOG]: `${JSON.stringify({task: "issue", event: "ISSUE.WIP", at: "2026-08-16T00:00:00.000Z"})}\n`,
+			},
+		});
+
+		const lockedOut = await run(heldLock);
+		const refused = await run(machineRefusal);
+		// Same event, two different seats: "retry me" versus "this event is invalid".
+		expect(lockedOut.code).toBe(CONCURRENT_WRITE);
+		expect(refused.code).toBe(EVENT_REFUSED);
+		expect(lockedOut.code).not.toBe(refused.code);
+		// And the wording itself carries the distinction, not just the number.
+		expect(lockedOut.stderr.join(" ")).toContain("retry this exact event");
+	});
+
+	it("the uncontended path appends exactly as before the lock existed", async () => {
+		const fs = freshLane();
+
+		const out = await run(fs);
+		expect(out.code).toBe(0);
+		const appended = fs.written.get(LOG);
+		expect(appended).toBeDefined();
+		expect(JSON.parse(appended?.trim() ?? "")).toMatchObject({task: "issue", event: "ISSUE.WIP"});
+	});
+});

--- a/packages/fabrika-cli/src/lane/append-race.cli.test.ts
+++ b/packages/fabrika-cli/src/lane/append-race.cli.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Two real processes racing one lane ledger — the probabilistic half of #5994's evidence.
+ *
+ * The deterministic half (a scripted held lock refuses CONCURRENT_WRITE with the log untouched)
+ * lives in [`append-lock.unit.test.ts`](append-lock.unit.test.ts). What that tier cannot prove is
+ * that two live processes launched against the same ledger actually interleave badly enough for
+ * the guard to matter, and that when they do, the outcome stays coherent: every appended line
+ * parses, every exit is one of the three legal seats (won / machine-refused / lock-refused), and a
+ * machine-refused event never reaches the log.
+ *
+ * The children run this checkout's own `src/bin.ts` under node's type stripping — no build step on
+ * the gate path. Collision frequency depends on real scheduling, so the invariants are asserted
+ * across repeated pairs rather than trusting one lucky race.
+ */
+import {execFile} from "node:child_process";
+import {existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {promisify} from "node:util";
+import {beforeAll, describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+const exec = promisify(execFile);
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const spawnTransition = async (root: string): Promise<Run> => {
+	try {
+		const {stdout} = await exec(
+			process.execPath,
+			[
+				"--experimental-strip-types",
+				BIN,
+				"lane",
+				"transition",
+				"42",
+				"WIP",
+				"--root",
+				join(root, ".fabrika", "lanes"),
+			],
+			{cwd: root, env: process.env},
+		);
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {code?: number; stdout?: string; stderr?: string};
+		return {code: failure.code ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("two concurrent lane writers stay coherent (#5994)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	const root = join(mkdtempSync(join(tmpdir(), "lane-race-")), "checkout");
+	const lanesRoot = join(root, ".fabrika", "lanes");
+	const logPath = join(lanesRoot, "42", "events.jsonl");
+
+	beforeAll(() => {
+		// The ground guard needs a repo marker; `.fabrika` itself is one (#6212).
+		mkdirSync(join(root, ".fabrika"), {recursive: true});
+		mkdirSync(join(lanesRoot, "42"), {recursive: true});
+		writeFileSync(join(lanesRoot, "42", "workflow.json"), coderTemplateText());
+	});
+
+	it("a raced pair leaves the ledger parseable and never records a refused event twice", async () => {
+		for (let pair = 0; pair < 6; pair++) {
+			const before = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+
+			const [a, b] = await Promise.all([spawnTransition(root), spawnTransition(root)]);
+			const runs = [
+				{...a, name: "A"},
+				{...b, name: "B"},
+			];
+
+			for (const r of runs) {
+				// 0 won · 12 the machine refused it against the true state · 40 the lock said wait longer.
+				expect([0, 12, 40]).toContain(r.code);
+				if (r.code === 0) expect(() => JSON.parse(r.stdout)).not.toThrow();
+			}
+			// A fresh lane accepts WIP exactly once: both writers cannot both win it.
+			expect([a.code, b.code].filter((c) => c === 0).length).toBeLessThanOrEqual(1);
+
+			// No torn or half-written lines: every recorded line parses, and nothing was lost.
+			const after = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+			for (const line of after.split("\n").filter(Boolean)) {
+				expect(() => JSON.parse(line)).not.toThrow();
+			}
+			// The losing writer's refusal left the log byte-identical to before its attempt.
+			if ([a.code, b.code].every((c) => c !== 0)) {
+				expect(after).toBe(before);
+			}
+		}
+
+		const lines = readFileSync(logPath, "utf8").split("\n").filter(Boolean);
+		expect(lines.length).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/packages/fabrika-cli/src/lane/clearance.ts
+++ b/packages/fabrika-cli/src/lane/clearance.ts
@@ -17,8 +17,9 @@
  * operator re-runs the verb and the budget is the same as if it had landed the first time.
  */
 
-import {Effect, type FileSystem, type Path, Result} from "effect";
+import {Effect, FileSystem, Path, Result} from "effect";
 import {appendText} from "../io/fs.ts";
+import {lockedRefusal, withLedgerLock} from "./append-lock.ts";
 import {applyClearance, resolveTask} from "./fold.ts";
 import {type LaneRef, loadLane} from "./store.ts";
 
@@ -34,35 +35,49 @@ export const recordClearedRound = (
 	ref: LaneRef,
 	task: string | null,
 	round: number,
-): Effect.Effect<Recorded, never, FileSystem.FileSystem | Path.Path> =>
-	Effect.gen(function* () {
-		const loaded = yield* loadLane(ref);
-		if (loaded._tag === "Absent") return {_tag: "NoLane" as const, dir: loaded.dir};
-		if (loaded._tag === "Unreadable") {
-			return {_tag: "Unusable" as const, path: loaded.path, reason: loaded.reason};
-		}
-		if (loaded._tag === "Malformed") {
-			return {_tag: "Unusable" as const, path: loaded.path, reason: loaded.defects.join("; ")};
-		}
+): Effect.Effect<Recorded, never, FileSystem.FileSystem | Path.Path> => {
+	const VERB = "lane clearance";
+	return Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* withLedgerLock(
+			{fs, path, dir: path.join(ref.root, ref.lane), verb: VERB},
+			Effect.gen(function* () {
+				const loaded = yield* loadLane(ref);
+				if (loaded._tag === "Absent") return {_tag: "NoLane" as const, dir: loaded.dir};
+				if (loaded._tag === "Unreadable") {
+					return {_tag: "Unusable" as const, path: loaded.path, reason: loaded.reason};
+				}
+				if (loaded._tag === "Malformed") {
+					return {_tag: "Unusable" as const, path: loaded.path, reason: loaded.defects.join("; ")};
+				}
 
-		const resolved = resolveTask(loaded.lane, task);
-		if (resolved._tag === "Unresolved") {
-			return {_tag: "Unusable" as const, path: loaded.logPath, reason: resolved.reason};
-		}
+				const resolved = resolveTask(loaded.lane, task);
+				if (resolved._tag === "Unresolved") {
+					return {_tag: "Unusable" as const, path: loaded.logPath, reason: resolved.reason};
+				}
 
-		const at = yield* Effect.sync(() => new Date().toISOString());
-		const applied = applyClearance(loaded.lane, loaded.entries, resolved.taskId, round, at);
-		if (applied._tag === "Refused") {
-			return {_tag: "Unusable" as const, path: loaded.logPath, reason: applied.reason};
-		}
-		if (applied._tag === "AlreadyHeld") {
-			return {_tag: "AlreadyHeld" as const, task: resolved.taskId, path: loaded.logPath};
-		}
+				const at = yield* Effect.sync(() => new Date().toISOString());
+				const applied = applyClearance(loaded.lane, loaded.entries, resolved.taskId, round, at);
+				if (applied._tag === "Refused") {
+					return {_tag: "Unusable" as const, path: loaded.logPath, reason: applied.reason};
+				}
+				if (applied._tag === "AlreadyHeld") {
+					return {_tag: "AlreadyHeld" as const, task: resolved.taskId, path: loaded.logPath};
+				}
 
-		const wrote = yield* Effect.result(
-			appendText(loaded.logPath, `${JSON.stringify(applied.entry)}\n`),
+				const wrote = yield* Effect.result(
+					appendText(loaded.logPath, `${JSON.stringify(applied.entry)}\n`),
+				);
+				return Result.isFailure(wrote)
+					? ({_tag: "Unusable", path: loaded.logPath, reason: wrote.failure.reason} as const)
+					: ({_tag: "Recorded", task: resolved.taskId, path: loaded.logPath} as const);
+			}),
+			(lockDir) => ({
+				_tag: "Unusable" as const,
+				path: lockDir,
+				reason: lockedRefusal(VERB, lockDir),
+			}),
 		);
-		return Result.isFailure(wrote)
-			? ({_tag: "Unusable", path: loaded.logPath, reason: wrote.failure.reason} as const)
-			: ({_tag: "Recorded", task: resolved.taskId, path: loaded.logPath} as const);
 	});
+};

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -282,3 +282,13 @@ export const CLASS_UNRECOGNISED = 38;
  * "not a repo at all" never may.
  */
 export const NOT_A_REPO = 39;
+
+/**
+ * Another writer held the lane's write lock for this writer's whole wait budget, so nothing was
+ * validated or appended (#5994). Its own seat rather than {@link EVENT_REFUSED}'s because the
+ * remedies are opposite: an ordinary refusal says this event is invalid against the state that
+ * exists and a different event is wanted, while this one says the event may be exactly right and
+ * the caller should retry it once the holder clears. The stderr detail names the lock directory;
+ * the code is what lets a shell tell "retry me" from "rethink me" without parsing prose.
+ */
+export const CONCURRENT_WRITE = 40;

--- a/packages/fabrika-cli/src/lane/report-verb.ts
+++ b/packages/fabrika-cli/src/lane/report-verb.ts
@@ -17,13 +17,15 @@
  * remedies are `lane prove`'s, unchanged. The prover is a parameter so this verb's unit tier stays
  * offline; the CLI always hands it `runProve`, which is the only prover a shell ever invokes.
  */
-import {Effect, type FileSystem, type Path, Result} from "effect";
+import {Effect, FileSystem, Path, Result} from "effect";
 import {appendText} from "../io/fs.ts";
 import {ANSWER, answer, refuse, type VerbOutcome} from "../verb.ts";
+import {lockedRefusal, withLedgerLock} from "./append-lock.ts";
 import {
 	APPEND_UNKNOWN,
 	CAUSE_UNRECOGNISED,
 	CLASS_UNRECOGNISED,
+	CONCURRENT_WRITE,
 	EVENT_REFUSED,
 	TASK_UNKNOWN,
 	TOKEN_UNRECOGNISED,
@@ -62,6 +64,8 @@ export const runReport = <R>(
 	prove: (options: ProveOptions) => Effect.Effect<VerbOutcome, never, R>,
 ): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path | R> =>
 	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
 		const resolved = eventForToken(options.token);
 		if (resolved._tag === "Unrecognised") {
 			return refuse(TOKEN_UNRECOGNISED, `${VERB}: refused (log unappended): ${resolved.reason}`);
@@ -96,6 +100,9 @@ export const runReport = <R>(
 			return refuse(EVENT_REFUSED, `${VERB}: refused (log unappended): ${applied.reason}`);
 		}
 
+		// The proof runs BEFORE the lock: it is read-only over the artifacts, never over the lane's
+		// bytes, so holding writers up behind a slow board read buys nothing (#5994). What the lock
+		// covers is the authoritative second pass below, where a fresh fold decides and appends.
 		const proved = yield* prove({
 			root: options.root,
 			lane: options.lane,
@@ -116,37 +123,69 @@ export const runReport = <R>(
 			);
 		}
 
-		const entry: LogEntry = {
-			...applied.entry,
-			...(options.pr === null ? {} : {pr: options.pr}),
-			...(options.comment === null ? {} : {comment: options.comment}),
-			...(caused._tag === "Caused" ? {cause: caused.cause} : {}),
-		};
-		const wrote = yield* Effect.result(appendText(loaded.logPath, `${JSON.stringify(entry)}\n`));
-		if (Result.isFailure(wrote)) {
-			return refuse(
-				APPEND_UNKNOWN,
-				`${VERB}: the append to ${loaded.logPath} did not land: ${wrote.failure.reason} — the event is NOT recorded.`,
-			);
-		}
-		return answer(
-			JSON.stringify(
-				{
-					token: resolved.token,
-					previous: applied.previous.stateValue,
-					event: entry.event,
-					current: applied.current.stateValue,
-					taskAffected: task.taskId,
+		// Authoritative pass, inside the write lock: a fresh load → fold → validate → append against
+		// the bytes as they exist under the lock, so a shell recording its terminal cannot validate
+		// against a state another writer is about to move under it (#5994). The pre-lock pass above
+		// only gated whether proving was worth its board read; this pass decides.
+		return yield* withLedgerLock(
+			{fs, path, dir: path.join(options.root, options.lane), verb: VERB},
+			Effect.gen(function* () {
+				const fresh = yield* loadLane(options);
+				if (fresh._tag !== "Loaded") return loadRefusal(VERB, fresh);
+				const freshTask = resolveTask(fresh.lane, options.task);
+				if (freshTask._tag === "Unresolved") {
+					return refuse(TASK_UNKNOWN, `${VERB}: ${freshTask.reason}`);
+				}
+				const freshFold = foldLog(fresh.lane, fresh.entries);
+				if (freshFold._tag !== "Folded") return replayRefusal(VERB, fresh.logPath, freshFold);
+
+				const now = yield* Effect.sync(() => new Date().toISOString());
+				const reapplied = applyEvent(
+					fresh.lane,
+					freshFold.states,
+					freshTask.taskId,
+					resolved.event,
+					now,
+					classed.classes,
+				);
+				if (reapplied._tag === "Refused") {
+					return refuse(EVENT_REFUSED, `${VERB}: refused (log unappended): ${reapplied.reason}`);
+				}
+
+				const entry: LogEntry = {
+					...reapplied.entry,
 					...(options.pr === null ? {} : {pr: options.pr}),
 					...(options.comment === null ? {} : {comment: options.comment}),
 					...(caused._tag === "Caused" ? {cause: caused.cause} : {}),
-				},
-				null,
-				2,
-			),
-			[
-				...proved.stderr,
-				`${VERB}: appended ${entry.event} (token ${resolved.token}) to ${loaded.logPath}, proven first.`,
-			],
+				};
+				const wrote = yield* Effect.result(appendText(fresh.logPath, `${JSON.stringify(entry)}\n`));
+				if (Result.isFailure(wrote)) {
+					return refuse(
+						APPEND_UNKNOWN,
+						`${VERB}: the append to ${fresh.logPath} did not land: ${wrote.failure.reason} — the event is NOT recorded.`,
+					);
+				}
+				return answer(
+					JSON.stringify(
+						{
+							token: resolved.token,
+							previous: reapplied.previous.stateValue,
+							event: entry.event,
+							current: reapplied.current.stateValue,
+							taskAffected: freshTask.taskId,
+							...(options.pr === null ? {} : {pr: options.pr}),
+							...(options.comment === null ? {} : {comment: options.comment}),
+							...(caused._tag === "Caused" ? {cause: caused.cause} : {}),
+						},
+						null,
+						2,
+					),
+					[
+						...proved.stderr,
+						`${VERB}: appended ${entry.event} (token ${resolved.token}) to ${fresh.logPath}, proven first.`,
+					],
+				);
+			}),
+			(lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
 		);
 	});

--- a/packages/fabrika-cli/src/lane/transition-verb.ts
+++ b/packages/fabrika-cli/src/lane/transition-verb.ts
@@ -5,14 +5,21 @@
  * machine accepts. An invalid event — no cell in the current state, outside the six, wrong phase,
  * finished workflow — never reaches the append, so the refusal leaves `events.jsonl` untouched
  * (#5671, run 8). An append that fails is {@link APPEND_UNKNOWN}, never reported as recorded.
+ *
+ * The whole load → fold → validate → append section runs inside the lane's write lock
+ * ([`append-lock.ts`](append-lock.ts)), so a shell recording its own terminal cannot validate
+ * against bytes another writer is about to move under it (#5994). Lock-budget exhaustion refuses
+ * {@link CONCURRENT_WRITE} — retry this same event — never an ordinary machine-refusal code.
  */
-import {Effect, type FileSystem, type Path, Result} from "effect";
+import {Effect, FileSystem, Path, Result} from "effect";
 import {appendText} from "../io/fs.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {lockedRefusal, withLedgerLock} from "./append-lock.ts";
 import {
 	APPEND_UNKNOWN,
 	CAUSE_UNRECOGNISED,
 	CLASS_UNRECOGNISED,
+	CONCURRENT_WRITE,
 	EVENT_REFUSED,
 	RESUME_UNBUDGETED,
 	TASK_UNKNOWN,
@@ -53,62 +60,82 @@ export const runTransition = (
 	options: TransitionOptions,
 ): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
-		const loaded = yield* loadLane(options);
-		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
-		const task = resolveTask(loaded.lane, options.task);
-		if (task._tag === "Unresolved") {
-			return refuse(TASK_UNKNOWN, `${VERB}: ${task.reason}`);
-		}
-		const fold = foldLog(loaded.lane, loaded.entries);
-		if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* withLedgerLock(
+			{fs, path, dir: path.join(options.root, options.lane), verb: VERB},
+			Effect.gen(function* () {
+				const loaded = yield* loadLane(options);
+				if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+				const task = resolveTask(loaded.lane, options.task);
+				if (task._tag === "Unresolved") {
+					return refuse(TASK_UNKNOWN, `${VERB}: ${task.reason}`);
+				}
+				const fold = foldLog(loaded.lane, loaded.entries);
+				if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
 
-		const event = options.event.toUpperCase();
-		// An event outside the six is applyEvent's refusal below, and its message is the better one;
-		// seating the cause as Uncaused here just keeps this read total until that refusal lands.
-		const caused: CauseResolution = isOperatorEvent(event)
-			? causeForEvent(options.cause, event)
-			: {_tag: "Uncaused"};
-		if (caused._tag === "Rejected") {
-			return refuse(CAUSE_UNRECOGNISED, `${VERB}: refused (log unappended): ${caused.reason}.`);
-		}
-		const classed = classesForEvent(options.classes);
-		if (classed._tag === "Rejected") {
-			return refuse(CLASS_UNRECOGNISED, `${VERB}: refused (log unappended): ${classed.reason}.`);
-		}
+				const event = options.event.toUpperCase();
+				// An event outside the six is applyEvent's refusal below, and its message is the better one;
+				// seating the cause as Uncaused here just keeps this read total until that refusal lands.
+				const caused: CauseResolution = isOperatorEvent(event)
+					? causeForEvent(options.cause, event)
+					: {_tag: "Uncaused"};
+				if (caused._tag === "Rejected") {
+					return refuse(CAUSE_UNRECOGNISED, `${VERB}: refused (log unappended): ${caused.reason}.`);
+				}
+				const classed = classesForEvent(options.classes);
+				if (classed._tag === "Rejected") {
+					return refuse(
+						CLASS_UNRECOGNISED,
+						`${VERB}: refused (log unappended): ${classed.reason}.`,
+					);
+				}
 
-		const at = yield* Effect.sync(() => new Date().toISOString());
-		const applied = applyEvent(loaded.lane, fold.states, task.taskId, event, at, classed.classes);
-		if (applied._tag === "Refused") {
-			return refuse(
-				applied.kind === "unbudgeted-resume" ? RESUME_UNBUDGETED : EVENT_REFUSED,
-				`${VERB}: refused (log unappended): ${applied.reason}`,
-			);
-		}
+				const at = yield* Effect.sync(() => new Date().toISOString());
+				const applied = applyEvent(
+					loaded.lane,
+					fold.states,
+					task.taskId,
+					event,
+					at,
+					classed.classes,
+				);
+				if (applied._tag === "Refused") {
+					return refuse(
+						applied.kind === "unbudgeted-resume" ? RESUME_UNBUDGETED : EVENT_REFUSED,
+						`${VERB}: refused (log unappended): ${applied.reason}`,
+					);
+				}
 
-		const entry: LogEntry = {
-			...applied.entry,
-			...(caused._tag === "Caused" ? {cause: caused.cause} : {}),
-		};
-		const wrote = yield* Effect.result(appendText(loaded.logPath, `${JSON.stringify(entry)}\n`));
-		if (Result.isFailure(wrote)) {
-			return refuse(
-				APPEND_UNKNOWN,
-				`${VERB}: the append to ${loaded.logPath} did not land: ${wrote.failure.reason} — the event is NOT recorded.`,
-			);
-		}
-		return answer(
-			JSON.stringify(
-				{
-					previous: applied.previous.stateValue,
-					event: entry.event,
-					current: applied.current.stateValue,
-					taskAffected: task.taskId,
-					...(classed.classes === null ? {} : {classes: classed.classes}),
+				const entry: LogEntry = {
+					...applied.entry,
 					...(caused._tag === "Caused" ? {cause: caused.cause} : {}),
-				},
-				null,
-				2,
-			),
-			[`${VERB}: appended ${entry.event} to ${loaded.logPath}.`],
+				};
+				const wrote = yield* Effect.result(
+					appendText(loaded.logPath, `${JSON.stringify(entry)}\n`),
+				);
+				if (Result.isFailure(wrote)) {
+					return refuse(
+						APPEND_UNKNOWN,
+						`${VERB}: the append to ${loaded.logPath} did not land: ${wrote.failure.reason} — the event is NOT recorded.`,
+					);
+				}
+				return answer(
+					JSON.stringify(
+						{
+							previous: applied.previous.stateValue,
+							event: entry.event,
+							current: applied.current.stateValue,
+							taskAffected: task.taskId,
+							...(classed.classes === null ? {} : {classes: classed.classes}),
+							...(caused._tag === "Caused" ? {cause: caused.cause} : {}),
+						},
+						null,
+						2,
+					),
+					[`${VERB}: appended ${entry.event} to ${loaded.logPath}.`],
+				);
+			}),
+			(lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
 		);
 	});


### PR DESCRIPTION
## Problem

`lane transition`/`report`/`clearance` are check-then-act over `events.jsonl` with nothing serializing them. Two shells can both load the same log, both validate against that same fold, and both append — the loser records an event the machine would have refused against the state that actually existed when its bytes landed. With shells recording their own terminals (#5980, merged), every epic run's parallel phase has several live writers and the window is open.

The corruption is silent and permanent: the fold is the lane's only state.

## Fix

A lock directory (`events.lock`) beside the log, created by atomic `mkdir`. The entire **load → fold → validate → append** section of all three appending verbs runs inside it:

- validation always sees the bytes about to receive the write
- budget exhaustion (default 5s, `FABRIKA_LANE_LOCK_BUDGET_MS` overrides) refuses **CONCURRENT_WRITE (40)** — "retry this exact event", distinguishable from an ordinary machine refusal on stdout/exit
- a crashed holder's stale lock (mtime > 60s) is stolen, so a killed process cannot brick the lane
- `lane report` proves *before* it locks — the proof is read-only over artifacts, so a slow board read never holds writers up

## Tests

- unit: contended lock refuses 40 with byte-identical log; distinguishable from EVENT_REFUSED by code *and* wording; uncontended path unchanged
- cli race: six pairs of real processes racing one ledger via node type-stripping; asserts exit codes ∈ {0,12,40}, ≤1 winner per fresh lane, every line parses, refused attempts leave the log byte-identical

Closes #5994