### PR TITLE
feat: welcome moment: hoş geldin çaylak surface with once-per-account arrival wiring

### DIFF
--- a/.patterns/flag-dark-page-gate.md
+++ b/.patterns/flag-dark-page-gate.md
@@ -91,5 +91,10 @@ regardless of membership.
 ## Pages carrying the gate today
 
 `BildirimlerPage`, `CaylakVisibilityPage`, `MecmuaDraftsPage`, `MecmuaEditorPage`,
-`MecmuaFeedPage`, `MecmuaIndexPage`, `MecmuaPostPage`, `MutesPage` — all under
+`MecmuaFeedPage`, `MecmuaIndexPage`, `MecmuaPostPage`, `MutesPage`, `WelcomePage` — all under
 `apps/web/src/pages/`.
+
+`WelcomePage` is the one whose gate also decides a **suppression**: past `sign-in` it asks whether
+this account has already been welcomed and, if so, redirects to the carried `returnTo` instead of
+rendering. That fifth rung is why its states are lifted into the pure `welcomeGate`
+([`welcomeGating.ts`](../apps/web/src/pages/welcomeGating.ts)), per the two-condition rule above.

--- a/.patterns/flag-dark-page-gate.md
+++ b/.patterns/flag-dark-page-gate.md
@@ -88,6 +88,12 @@ regardless of membership.
   page, so both read `value` alone and let the default hold through loading. Use `<FlagGate>` for
   the declarative version.
 
+An **irreversible** action off a non-member flag is neither of those, and it must honour `loading`
+even though it is not a page gate. The post-auth redirect in
+[`App.tsx`](../apps/web/src/App.tsx) reads `PHOENIX_WELCOME` to choose between the old destination
+and the `/hosgeldin` detour: acting on the not-yet-loaded `false` navigates and unmounts `/auth`, so
+the flag's real value arrives with nothing left to steer. Hold the navigation while `loading`.
+
 ## Pages carrying the gate today
 
 `BildirimlerPage`, `CaylakVisibilityPage`, `MecmuaDraftsPage`, `MecmuaEditorPage`,
@@ -98,3 +104,10 @@ regardless of membership.
 this account has already been welcomed and, if so, redirects to the carried `returnTo` instead of
 rendering. That fifth rung is why its states are lifted into the pure `welcomeGate`
 ([`welcomeGating.ts`](../apps/web/src/pages/welcomeGating.ts)), per the two-condition rule above.
+
+The suppression's input is read **once per account id**, not once per mount. The marker is keyed by
+user, and on a reload the session is still pending for the first renders — so a mount-frozen read
+answers for a `null` id and then survives the real account's arrival, re-showing a welcome that was
+already suppressed. Latching on the id keeps both halves: the answer is stable across the mid-visit
+write that would otherwise bounce the reader off their own arrival, and it still waits for an
+account to answer about.

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -60,6 +60,7 @@ import {
 	userAdminFlag,
 	userBanFlag,
 	userRoleAssignFlag,
+	welcomeFlag,
 } from "./worker/features/flagship/resources.ts";
 import {provisionEmailSending} from "./worker/features/pasaport/email-resources.ts";
 import PhoenixLive, {Phoenix} from "./worker/index.ts";
@@ -145,6 +146,10 @@ export default Alchemy.Stack(
 		// rollup-record list and the client section gate behind, so the cohort DISPLAY can be
 		// enabled independently of the always-on capture until a human release.
 		yield* funnelCohortFlag(flagship.appId);
+		// The welcome-arrival dark-ship flag, default-off (#7043, epic #4304) — the single
+		// seam the post-auth redirect intercept in App.tsx and the /hosgeldin welcome surface
+		// gate behind, so the new-user arrival ships dark until a human release.
+		yield* welcomeFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -10,6 +10,7 @@ import {act, render, screen, within} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {MemoryRouter} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {installFakeStorage} from "../tests/client/fakeStorage";
 import {App} from "./App";
 import {WELCOME_SEEN_SCHEMA, welcomeSeenKey} from "./components/onboarding/welcomeSeen";
 import {WELCOME_PATH} from "./pages/welcomeGating";
@@ -117,13 +118,17 @@ vi.mock("./pages/useProfileStats", () => ({useProfileStats: () => ({status: "idl
 vi.mock("./components/divan/useDivanAccess", () => ({useDivanAccess: () => false}));
 vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: () => 0}));
 
-// `loading: false` on every read models the shell-key members' synchronous `__BOOT__` resolution
-// (ADR 0179): a member carries its final value on the first render, with no post-boot flip.
+// `loading: false` models the shell-key members' synchronous `__BOOT__` resolution (ADR 0179): a
+// member carries its final value on the first render, with no post-boot flip. `PHOENIX_WELCOME` is
+// not a member, so it alone gets a settable `loading` axis.
 // `signedIn` drives the mocked `readBootUser` below; default false = `__BOOT__` absent.
 const flags = vi.hoisted(() => ({
 	mecmua: false,
 	mecmuaFeed: false,
 	welcome: false,
+	// `PHOENIX_WELCOME` is NOT a boot member, so unlike its neighbours above it really does
+	// start loading and resolve later — the axis the redirect race lives on.
+	welcomeLoading: false,
 	signedIn: false,
 }));
 vi.mock("./flags/useFlag", async () => {
@@ -138,7 +143,7 @@ vi.mock("./flags/useFlag", async () => {
 						: key === PHOENIX_WELCOME
 							? flags.welcome
 							: false,
-			loading: false,
+			loading: key === PHOENIX_WELCOME ? flags.welcomeLoading : false,
 		}),
 	};
 });
@@ -688,11 +693,13 @@ describe("post-auth welcome intercept (#7043)", () => {
 		fateMounts.length = 0;
 		sessionState = {data: null, isPending: true};
 		flags.welcome = false;
-		localStorage.clear();
+		flags.welcomeLoading = false;
+		installFakeStorage();
 	});
 	afterEach(() => {
 		flags.welcome = false;
-		localStorage.clear();
+		flags.welcomeLoading = false;
+		vi.unstubAllGlobals();
 		vi.clearAllMocks();
 	});
 
@@ -751,6 +758,33 @@ describe("post-auth welcome intercept (#7043)", () => {
 		});
 		expect(screen.queryByTestId("welcome-stub")).toBeNull();
 		expect(screen.getByTestId("eager-pano-feed")).toBeTruthy();
+	});
+
+	// REGRESSION (criterion 2, the async boundary): `PHOENIX_WELCOME` resolves after boot, so the
+	// session can settle first. Consuming `value` alone read the not-yet-loaded `false`, navigated
+	// to the old returnTo and unmounted /auth — the new account never reached /hosgeldin with the
+	// flag ON. The redirect must hold until the flag lands.
+	it("flag on but still loading when the session resolves: the redirect waits, then detours", () => {
+		flags.welcome = true;
+		flags.welcomeLoading = true;
+		renderApp(AUTH_ROUTE);
+
+		// The session wins the race. Nothing may navigate yet — neither destination is knowable.
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.queryByTestId("welcome-stub")).toBeNull();
+		expect(screen.queryByTestId("eager-pano-feed")).toBeNull();
+
+		// The flag lands second. `session.data` is the SAME reference, so only the resolved flag
+		// can re-fire the effect — which is exactly the dependency that was missing.
+		act(() => {
+			flags.welcomeLoading = false;
+			setSession({...SIGNED_IN});
+		});
+		expect(screen.getByTestId("welcome-stub").textContent).toBe(
+			`${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano")}`,
+		);
 	});
 
 	// The marker is per account, so one welcomed account on a shared browser never silently

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -11,6 +11,8 @@ import type {ReactNode} from "react";
 import {MemoryRouter} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {App} from "./App";
+import {WELCOME_SEEN_SCHEMA, welcomeSeenKey} from "./components/onboarding/welcomeSeen";
+import {WELCOME_PATH} from "./pages/welcomeGating";
 
 const {PUBLIC_CLIENT} = vi.hoisted(() => ({PUBLIC_CLIENT: {__tier: "public"} as never}));
 
@@ -43,6 +45,24 @@ vi.mock("react-fate", async (importOriginal) => {
 vi.mock("./pages/PanoFeed", () => ({
 	PanoFeed: ({host}: {host?: string}) => <div data-testid="eager-pano-feed">{host ?? "all"}</div>,
 }));
+
+// Stubbed inert for the same reason as PanoFeed: the intercept tests assert WHERE the post-auth
+// redirect landed, and the surface's own contract is proven in `WelcomePage.test.tsx`. The stub
+// echoes the live location, which is what carries the original `returnTo` through the detour.
+vi.mock("./pages/WelcomePage", async () => {
+	const {useLocation} = await import("react-router");
+	return {
+		WelcomePage: () => {
+			const location = useLocation();
+			return <div data-testid="welcome-stub">{`${location.pathname}${location.search}`}</div>;
+		},
+	};
+});
+
+// `AuthPage` calls `useFateClient()` at render, and the spied `FateClient` above provides no real
+// context — so the one route the intercept starts from needs an inert stand-in to be reachable
+// here at all. Its own behaviour is not under test in this file.
+vi.mock("./pages/AuthPage", () => ({AuthPage: () => <div data-testid="auth-stub" />}));
 
 vi.mock("./fate/publicClient", () => ({getPublicFateClient: () => PUBLIC_CLIENT}));
 
@@ -103,14 +123,21 @@ vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: ()
 const flags = vi.hoisted(() => ({
 	mecmua: false,
 	mecmuaFeed: false,
+	welcome: false,
 	signedIn: false,
 }));
 vi.mock("./flags/useFlag", async () => {
-	const {MECMUA_PUBLIC_READ, MECMUA_FEED} = await import("./flags/keys");
+	const {MECMUA_PUBLIC_READ, MECMUA_FEED, PHOENIX_WELCOME} = await import("./flags/keys");
 	return {
 		useFlag: (key: string) => ({
 			value:
-				key === MECMUA_PUBLIC_READ ? flags.mecmua : key === MECMUA_FEED ? flags.mecmuaFeed : false,
+				key === MECMUA_PUBLIC_READ
+					? flags.mecmua
+					: key === MECMUA_FEED
+						? flags.mecmuaFeed
+						: key === PHOENIX_WELCOME
+							? flags.welcome
+							: false,
 			loading: false,
 		}),
 	};
@@ -647,5 +674,94 @@ describe("Authed feed snapshot wiring (#2321)", () => {
 		});
 		expect(snapshotSpies.hydrateAuthedClient).not.toHaveBeenCalled();
 		expect(snapshotSpies.installAuthedSnapshotPersistence).not.toHaveBeenCalled();
+	});
+});
+
+// The post-auth welcome intercept (#7043, epic #4304). These pin the WIRING at the redirect
+// itself — the pure decision is `postAuthDestination` (`welcomeGating.unit.test.ts`) and the
+// surface is `WelcomePage.test.tsx`; what only shows up here is whether the effect consults the
+// marker and carries the original `returnTo` through the detour.
+describe("post-auth welcome intercept (#7043)", () => {
+	const AUTH_ROUTE = `/auth?returnTo=${encodeURIComponent("/pano")}`;
+
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.welcome = false;
+		localStorage.clear();
+	});
+	afterEach(() => {
+		flags.welcome = false;
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	// REGRESSION (criterion 1): with the flag at its default the redirect is exactly today's —
+	// the marker is never even read, so a stale marker cannot change where a signup lands.
+	it("flag off: the post-auth redirect lands on the returnTo, never the welcome surface", () => {
+		renderApp(AUTH_ROUTE);
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.queryByTestId("welcome-stub")).toBeNull();
+		expect(screen.getByTestId("eager-pano-feed")).toBeTruthy();
+	});
+
+	it("flag off with a marker already set: still today's redirect", () => {
+		localStorage.setItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, "u1"), "1");
+		renderApp(AUTH_ROUTE);
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.queryByTestId("welcome-stub")).toBeNull();
+		expect(screen.getByTestId("eager-pano-feed")).toBeTruthy();
+	});
+
+	// Criterion 2: the brand-new account's first post-signup navigation detours, and the target it
+	// was headed for rides along so "devam et" can hand it back.
+	it("flag on, never welcomed: the first post-auth navigation lands on the welcome surface", () => {
+		flags.welcome = true;
+		renderApp(AUTH_ROUTE);
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.getByTestId("welcome-stub").textContent).toBe(
+			`${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano")}`,
+		);
+	});
+
+	it("flag on, no returnTo: the detour carries the cold fallback /", () => {
+		flags.welcome = true;
+		renderApp("/auth");
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.getByTestId("welcome-stub").textContent).toBe(
+			`${WELCOME_PATH}?returnTo=${encodeURIComponent("/")}`,
+		);
+	});
+
+	// Criterion 4, at the intercept: the marker suppresses the detour on every later arrival.
+	it("flag on, already welcomed: the intercept is suppressed and the redirect is today's", () => {
+		flags.welcome = true;
+		localStorage.setItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, "u1"), "1");
+		renderApp(AUTH_ROUTE);
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.queryByTestId("welcome-stub")).toBeNull();
+		expect(screen.getByTestId("eager-pano-feed")).toBeTruthy();
+	});
+
+	// The marker is per account, so one welcomed account on a shared browser never silently
+	// swallows another's welcome.
+	it("flag on, a DIFFERENT account's marker set: this account is still welcomed", () => {
+		flags.welcome = true;
+		localStorage.setItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, "someone-else"), "1");
+		renderApp(AUTH_ROUTE);
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.getByTestId("welcome-stub")).toBeTruthy();
 	});
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -255,7 +255,7 @@ function LayoutContent() {
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
 	// The welcome arrival's seam (#7043): one flag releases both this intercept and the
 	// /hosgeldin surface.
-	const {value: welcomeOn} = useFlag(PHOENIX_WELCOME, false);
+	const {value: welcomeOn, loading: welcomeLoading} = useFlag(PHOENIX_WELCOME, false);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
 	// resolving. `signUp.email` establishes the session before the separate
 	// `setUsername` lands; without this hold the redirect unmounts AuthPage and
@@ -267,6 +267,11 @@ function LayoutContent() {
 		if (!session.data) return;
 		if (location.pathname !== "/auth") return;
 		if (usernamePending) return;
+		// `PHOENIX_WELCOME` is not a boot member (ADR 0179), so it starts `{value:false,
+		// loading:true}` and resolves async. Without this hold a session that settles first
+		// navigates on the not-yet-loaded `false`, unmounting /auth before the enabled value
+		// lands — and a brand-new account never reaches /hosgeldin with the flag ON.
+		if (welcomeLoading) return;
 		const params = new URLSearchParams(location.search);
 		const target = safeReturnTo(params.get("returnTo"));
 		// The welcome intercept (#7043, epic #4304): flag on + never welcomed ⇒ the first
@@ -275,7 +280,15 @@ function LayoutContent() {
 		const welcomeSeen = welcomeOn ? hasSeenWelcome(welcomeStorage(), session.data.user.id) : false;
 		const destination = postAuthDestination(welcomeOn, welcomeSeen, target);
 		navigate(destination.to, {replace: true});
-	}, [session.data, location.pathname, location.search, navigate, usernamePending, welcomeOn]);
+	}, [
+		session.data,
+		location.pathname,
+		location.search,
+		navigate,
+		usernamePending,
+		welcomeOn,
+		welcomeLoading,
+	]);
 
 	const sessionUser = session.data?.user;
 	const username = me?.username ?? null;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import {Topbar} from "./components/layout/Topbar";
 import {MecmuaSubnavLayout} from "./components/mecmua/MecmuaSubnavLayout";
 import {EmailDeliveryNoticeMount} from "./components/membrane/EmailDeliveryNoticeMount";
 import {actorLabel} from "./components/moderation/actor-identity";
+import {hasSeenWelcome, welcomeStorage} from "./components/onboarding/welcomeSeen";
 import {PanoSubnavLayout} from "./components/pano/PanoSubnavLayout";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
 import {SozlukCreateDialogProvider} from "./components/sozluk/SozlukCreateDialogState";
@@ -33,7 +34,7 @@ import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {teardownAuthedSnapshot} from "./fate/snapshot";
 import {readBootUser} from "./flags/boot";
 import {EdgeShellBootMarker} from "./flags/EdgeShellBoot";
-import {MECMUA_PUBLIC_READ, PHOENIX_BILDIRIM} from "./flags/keys";
+import {MECMUA_PUBLIC_READ, PHOENIX_BILDIRIM, PHOENIX_WELCOME} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {AtolyeExhibitPage} from "./lab/atolye/AtolyeExhibitPage";
 import {AtolyeIndexPage} from "./lab/atolye/AtolyeIndexPage";
@@ -65,6 +66,8 @@ import {useUsernameResolutionPending} from "./pages/signupUsernameGate";
 import {UsernameBootstrap} from "./pages/UsernameBootstrap";
 import {UserProfilePage} from "./pages/UserProfilePage";
 import {useProfileStats} from "./pages/useProfileStats";
+import {WelcomePage} from "./pages/WelcomePage";
+import {postAuthDestination, WELCOME_PATH} from "./pages/welcomeGating";
 
 type TopbarChips = {
 	userProps: {user: {name: string; username: string | null}} | undefined;
@@ -250,6 +253,9 @@ function LayoutContent() {
 	const divanCount = useDivanPendingCount(showDivan);
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
+	// The welcome arrival's seam (#7043): one flag releases both this intercept and the
+	// /hosgeldin surface.
+	const {value: welcomeOn} = useFlag(PHOENIX_WELCOME, false);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
 	// resolving. `signUp.email` establishes the session before the separate
 	// `setUsername` lands; without this hold the redirect unmounts AuthPage and
@@ -263,8 +269,13 @@ function LayoutContent() {
 		if (usernamePending) return;
 		const params = new URLSearchParams(location.search);
 		const target = safeReturnTo(params.get("returnTo"));
-		navigate(target, {replace: true});
-	}, [session.data, location.pathname, location.search, navigate, usernamePending]);
+		// The welcome intercept (#7043, epic #4304): flag on + never welcomed ⇒ the first
+		// post-auth navigation detours through /hosgeldin carrying the original target as
+		// its returnTo. Flag off ⇒ byte-for-byte today's redirect (see `postAuthDestination`).
+		const welcomeSeen = welcomeOn ? hasSeenWelcome(welcomeStorage(), session.data.user.id) : false;
+		const destination = postAuthDestination(welcomeOn, welcomeSeen, target);
+		navigate(destination.to, {replace: true});
+	}, [session.data, location.pathname, location.search, navigate, usernamePending, welcomeOn]);
 
 	const sessionUser = session.data?.user;
 	const username = me?.username ?? null;
@@ -409,6 +420,9 @@ export function App() {
 						</Route>
 						<Route path="/search" element={<SearchPage />} />
 						<Route path="/auth" element={<AuthPage />} />
+						{/* The welcome moment (#7043) — dark behind phoenix-welcome; the page owns
+						    its own visibility per `.patterns/flag-dark-page-gate.md`. */}
+						<Route path={WELCOME_PATH} element={<WelcomePage />} />
 						<Route path="/funnel" element={<FunnelPage />} />
 						<Route path="/bildirimler" element={<BildirimlerPage />} />
 						{/* /lab/composer — throwaway tiptap spike (#2465), reachable by URL only,

--- a/apps/web/src/components/onboarding/welcomeSeen.ts
+++ b/apps/web/src/components/onboarding/welcomeSeen.ts
@@ -1,0 +1,57 @@
+/**
+ * The shown-once welcome marker (#7043, epic #4304).
+ *
+ * One persisted per-account fact — "this account has already been welcomed" — that both
+ * the post-auth intercept in `App.tsx` and `WelcomePage` itself read. Keyed by user id so
+ * accounts on one browser never suppress each other, and surviving reloads *and* repeat
+ * logins, which is what "once per account" (#4266) means here.
+ *
+ * Client-side by design: the welcome surface and its intercept are client seams, and no
+ * worker write path belongs to this slice. A browser that refuses storage degrades to
+ * "never seen" — the welcome may show again, but nothing breaks.
+ *
+ * DOM-free (storage is injected) so the suppression contract is unit-testable without a
+ * document, mirroring `fate/snapshot.ts`.
+ */
+
+/** Bumped to force every persisted marker stale. */
+export const WELCOME_SEEN_SCHEMA = "v1";
+
+const WELCOME_SEEN_VALUE = "1";
+
+export interface WelcomeStorage {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+}
+
+export function welcomeSeenKey(schema: string, userId: string): string {
+	return `welcome-seen:${schema}:user:${userId}`;
+}
+
+export function hasSeenWelcome(storage: WelcomeStorage | null, userId: string | null): boolean {
+	if (!storage || !userId) return false;
+	return storage.getItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, userId)) === WELCOME_SEEN_VALUE;
+}
+
+/** Idempotent; a failed write stays silent — losing the marker only re-shows the welcome. */
+export function markWelcomeSeen(storage: WelcomeStorage | null, userId: string | null): void {
+	if (!storage || !userId) return;
+	try {
+		storage.setItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, userId), WELCOME_SEEN_VALUE);
+	} catch {
+		// Private mode / quota: degrade to "not marked", never break the arrival.
+	}
+}
+
+/**
+ * `null` when unavailable — Safari private mode throws on `window.localStorage` access,
+ * and SSR/boot has no window at all (same defensive shape as `fate/snapshot.ts`).
+ */
+export function welcomeStorage(): WelcomeStorage | null {
+	if (typeof window === "undefined") return null;
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+}

--- a/apps/web/src/components/onboarding/welcomeSeen.unit.test.ts
+++ b/apps/web/src/components/onboarding/welcomeSeen.unit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The shown-once marker's contract (#7043), pinned without a DOM — storage is injected.
+ * The user-id keying is the load-bearing half: accounts on one browser must never
+ * suppress each other's welcome.
+ */
+import {describe, expect, it} from "vitest";
+import {hasSeenWelcome, markWelcomeSeen, WELCOME_SEEN_SCHEMA, welcomeSeenKey} from "./welcomeSeen";
+
+interface MemoryStorage {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+}
+
+function storageOver(store: Map<string, string>): MemoryStorage {
+	return {
+		getItem: (k) => store.get(k) ?? null,
+		setItem: (k, v) => void store.set(k, v),
+	};
+}
+
+function memoryStorage(): MemoryStorage & {readonly store: Map<string, string>} {
+	const store = new Map<string, string>();
+	return {...storageOver(store), store};
+}
+
+describe("welcomeSeen — the per-account shown-once marker", () => {
+	it("starts unseen for an account with no marker", () => {
+		expect(hasSeenWelcome(memoryStorage(), "u-1")).toBe(false);
+	});
+
+	it("marks seen and reads back seen", () => {
+		const storage = memoryStorage();
+		markWelcomeSeen(storage, "u-1");
+		expect(hasSeenWelcome(storage, "u-1")).toBe(true);
+	});
+
+	it("is idempotent — marking twice changes nothing", () => {
+		const storage = memoryStorage();
+		markWelcomeSeen(storage, "u-1");
+		markWelcomeSeen(storage, "u-1");
+		expect(hasSeenWelcome(storage, "u-1")).toBe(true);
+	});
+
+	it("keys by account, so a second account on the same browser is still unseen", () => {
+		const storage = memoryStorage();
+		markWelcomeSeen(storage, "u-1");
+		expect(hasSeenWelcome(storage, "u-2")).toBe(false);
+	});
+
+	it("survives a fresh handle over the same backing store — a reload re-reads the marker", () => {
+		const before = memoryStorage();
+		markWelcomeSeen(before, "u-1");
+		// A reload builds a brand-new wrapper over the browser's persisted store.
+		expect(hasSeenWelcome(storageOver(before.store), "u-1")).toBe(true);
+	});
+
+	it("repeat login is the same read — no session state involved", () => {
+		const storage = memoryStorage();
+		markWelcomeSeen(storage, "u-1");
+		expect(hasSeenWelcome(storage, "u-1")).toBe(true);
+	});
+
+	it("a foreign value at the key never reads as seen", () => {
+		const storage = memoryStorage();
+		storage.setItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, "u-1"), "yes");
+		expect(hasSeenWelcome(storage, "u-1")).toBe(false);
+	});
+
+	it("no storage or no account degrades to unseen — and writing is a no-op", () => {
+		expect(hasSeenWelcome(null, "u-1")).toBe(false);
+		expect(hasSeenWelcome(memoryStorage(), null)).toBe(false);
+		expect(() => markWelcomeSeen(null, "u-1")).not.toThrow();
+		expect(() => markWelcomeSeen(memoryStorage(), null)).not.toThrow();
+	});
+
+	it("a refusing storage degrades to unseen instead of throwing through the arrival", () => {
+		const refusing: MemoryStorage = {
+			getItem: () => null,
+			setItem: () => {
+				throw new Error("quota");
+			},
+		};
+		expect(() => markWelcomeSeen(refusing, "u-1")).not.toThrow();
+	});
+});

--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -67,7 +67,10 @@ type Standing = Pick<AuthorshipStanding, "karma" | "bar" | "vouchExists" | "inRe
 
 // A failed read resolves to `null` on purpose — the safe/off path, so an error
 // degrades to "no block" rather than throwing the whole header.
-function useAuthorshipStanding(enabled: boolean): Standing | null {
+//
+// Exported for `WelcomePage` (#7043): the welcome surface reads the SAME view selection
+// through this one hook rather than growing a second `myAuthorshipStanding` read.
+export function useAuthorshipStanding(enabled: boolean): Standing | null {
 	const {state} = useImperativeView("myAuthorshipStanding", StandingView, {enabled});
 	return state.status === "ok" ? state.data : null;
 }

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -137,6 +137,13 @@ export const PHOENIX_CAYLAK_VISIBILITY = "phoenix-caylak-visibility";
  */
 export const PHOENIX_FUNNEL_COHORT = "phoenix-funnel-cohort";
 
+/**
+ * The single seam for the welcome arrival (#7043, epic #4304) — the post-auth redirect
+ * intercept AND the `/hosgeldin` welcome surface reuse this one key, so one flip releases
+ * the whole slice. Default-off, ADR 0083.
+ */
+export const PHOENIX_WELCOME = "phoenix-welcome";
+
 /** A declared flag paired with its default variation — the row the flags console lists (#2742). */
 export interface FlagDeclaration {
 	readonly key: string;
@@ -164,4 +171,5 @@ export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
 	{key: MEMBER_MUTE, defaultValue: false},
 	{key: PHOENIX_CAYLAK_VISIBILITY, defaultValue: false},
 	{key: PHOENIX_FUNNEL_COHORT, defaultValue: false},
+	{key: PHOENIX_WELCOME, defaultValue: false},
 ];

--- a/apps/web/src/lib/density.test.tsx
+++ b/apps/web/src/lib/density.test.tsx
@@ -1,26 +1,8 @@
 import {act, render} from "@testing-library/react";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {installFakeStorage} from "../../tests/client/fakeStorage";
 import {DensityProvider, useDensity} from "./density";
 import {DENSITY_STORAGE_KEY} from "./densityStorage";
-
-// jsdom in the `client` tier ships no localStorage (Node's is experimental/off), so the
-// provider has nothing to read/write against without a fake installed per test.
-function installFakeStorage(initial?: Record<string, string>): Storage {
-	const map = new Map<string, string>(Object.entries(initial ?? {}));
-	const storage: Storage = {
-		get length() {
-			return map.size;
-		},
-		clear: () => map.clear(),
-		getItem: (k) => map.get(k) ?? null,
-		key: (i) => [...map.keys()][i] ?? null,
-		removeItem: (k) => void map.delete(k),
-		setItem: (k, v) => void map.set(k, v),
-	};
-	vi.stubGlobal("localStorage", storage);
-	Object.defineProperty(window, "localStorage", {value: storage, configurable: true});
-	return storage;
-}
 
 function Probe() {
 	const {setChoice} = useDensity();

--- a/apps/web/src/pages/WelcomePage.css
+++ b/apps/web/src/pages/WelcomePage.css
@@ -1,0 +1,100 @@
+/* The /hosgeldin welcome moment (#7043, epic #4304) — one screen, explicitly not a
+   tour (#4266). Role tokens only — no color literal. */
+
+.kp-welcome {
+	padding: var(--s-4) 0;
+}
+
+.kp-welcome__inner {
+	max-width: calc(var(--s-8) * 16);
+	margin: 0 auto;
+	padding: 0 var(--s-4);
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-4);
+}
+
+.kp-welcome__masthead {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-welcome__title {
+	font: var(--t-h-page);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-welcome__lede {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.kp-welcome__section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-welcome__heading {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-welcome__line {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+/* The unvouched çaylak's standing (#4261, via CaylakStatusBlock's settled copy):
+   words instead of a bar, because no karma number promotes an unvouched account. */
+.kp-welcome__vouch-needed {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-welcome__vouch-message {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-welcome__vouch-hint {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.kp-welcome__facts {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	margin: 0;
+}
+
+.kp-welcome__fact {
+	display: flex;
+	gap: var(--s-2);
+}
+
+.kp-welcome__term {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	min-width: 6ch;
+	margin: 0;
+}
+
+.kp-welcome__value {
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-welcome__continue {
+	align-self: flex-start;
+}

--- a/apps/web/src/pages/WelcomePage.test.tsx
+++ b/apps/web/src/pages/WelcomePage.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * `/hosgeldin` route contract (#7043, epic #4304). The rows that lose silently if the
+ * gate order is "simplified": the dark route 404s, the resolving flag shows a neutral
+ * placeholder instead of flashing that 404, arrival writes the shown-once marker so a
+ * reload or repeat login bounces straight to the `returnTo`, an unvouched çaylak gets
+ * the settled vouch-needed copy and NO promotion bar (#4261), and the whole moment is
+ * one screen with one exit.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {MemoryRouter, Route, Routes, useLocation} from "react-router";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {WELCOME_SEEN_SCHEMA, welcomeSeenKey} from "../components/onboarding/welcomeSeen";
+import {WelcomePage} from "./WelcomePage";
+import {WELCOME_PATH} from "./welcomeGating";
+
+const flag = {value: false, loading: false};
+let signedIn = true;
+let sessionPending = false;
+let tier: string | null = "çaylak";
+// The `myAuthorshipStanding` read, pinned per test through the mocked imperative view.
+let standingState: {status: string; data: unknown} = {
+	status: "ok",
+	data: {id: "s-1", karma: 3, bar: 15, vouchExists: false, inReviewCount: 0},
+};
+
+vi.mock("../auth/client", () => ({
+	useSession: () => ({
+		data: signedIn ? {user: {id: "u-1"}} : null,
+		isPending: sessionPending,
+	}),
+}));
+vi.mock("../auth/useMe", () => ({
+	useMe: () => ({
+		me: tier ? {id: "u-1", tier} : null,
+		status: "ok",
+		loading: false,
+		refetch: vi.fn(),
+	}),
+}));
+vi.mock("../flags/useFlag", () => ({useFlag: () => flag}));
+vi.mock("../fate/useImperativeView", () => ({
+	useImperativeView: () => ({state: standingState, refetch: vi.fn()}),
+}));
+
+function LocationProbe({label}: {label: string}) {
+	const location = useLocation();
+	return <div data-testid={label}>{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderRoute(initialEntry = `${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano")}`) {
+	return render(
+		<MemoryRouter initialEntries={[initialEntry]}>
+			<Routes>
+				<Route path={WELCOME_PATH} element={<WelcomePage />} />
+				<Route path="/pano" element={<LocationProbe label="pano-probe" />} />
+				<Route path="/auth" element={<LocationProbe label="auth-probe" />} />
+				<Route path="/" element={<LocationProbe label="home-probe" />} />
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	flag.value = false;
+	flag.loading = false;
+	signedIn = true;
+	sessionPending = false;
+	tier = "çaylak";
+	standingState = {
+		status: "ok",
+		data: {id: "s-1", karma: 3, bar: 15, vouchExists: false, inReviewCount: 0},
+	};
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe("WelcomePage — the flag-dark gate (.patterns/flag-dark-page-gate.md)", () => {
+	it("self-404s with phoenix-welcome off (criterion 1)", () => {
+		renderRoute();
+		expect(screen.getByTestId("not-found-page")).toBeTruthy();
+		expect(screen.queryByTestId("welcome-page")).toBeNull();
+	});
+
+	it("shows a neutral placeholder while the flag resolves — no 404 flash", () => {
+		flag.loading = true;
+		renderRoute();
+		expect(screen.getByTestId("welcome-loading")).toBeTruthy();
+		expect(screen.queryByTestId("not-found-page")).toBeNull();
+	});
+
+	it("redirects a signed-out visitor to auth carrying a returnTo back", () => {
+		flag.value = true;
+		signedIn = false;
+		tier = null;
+		renderRoute();
+		expect(screen.getByTestId("auth-probe").textContent).toBe(
+			`/auth?returnTo=${encodeURIComponent("/pano")}`,
+		);
+	});
+});
+
+describe("WelcomePage — one screen answering #4266's three questions", () => {
+	it("renders what-this-is, where-you-stand and the rite ahead — with exactly one exit", () => {
+		flag.value = true;
+		renderRoute();
+		expect(screen.getByTestId("welcome-page").tagName).toBe("MAIN");
+		expect(screen.getByTestId("welcome-standing")).toBeTruthy();
+		expect(screen.getByTestId("welcome-rite")).toBeTruthy();
+		// One screen, no second step: a single control leaves the surface.
+		expect(screen.getAllByTestId("welcome-continue")).toHaveLength(1);
+		expect(document.querySelectorAll("button")).toHaveLength(1);
+	});
+
+	it("greets a çaylak in the founder's ruled words — 'hoş geldin, çaylak' (#4266)", () => {
+		flag.value = true;
+		renderRoute();
+		expect(screen.getByTestId("welcome-title").textContent).toBe("hoş geldin, çaylak");
+	});
+});
+
+describe("WelcomePage — honest framing for the unvouched çaylak (#4261, criterion 5)", () => {
+	it("shows vouch-needed copy and kefil yok — never a promotion bar", () => {
+		flag.value = true;
+		renderRoute();
+		const vouchNeeded = screen.getByTestId("welcome-vouch-needed");
+		expect(vouchNeeded.textContent).toContain("bir yazar sana kefil olmalı");
+		expect(vouchNeeded.textContent).toContain("ya da bir moderatör seni doğrudan yükseltebilir");
+		expect(screen.getByTestId("welcome-vouch").textContent).toBe("yok");
+		expect(screen.queryByTestId("welcome-karma")).toBeNull();
+	});
+
+	it("a vouched çaylak gets the honest reduced bar and kefil var", () => {
+		flag.value = true;
+		standingState = {
+			status: "ok",
+			data: {id: "s-1", karma: 7, bar: 15, vouchExists: true, inReviewCount: 0},
+		};
+		renderRoute();
+		expect(screen.queryByTestId("welcome-vouch-needed")).toBeNull();
+		expect(screen.getByTestId("welcome-karma")).toBeTruthy();
+		expect(screen.getByTestId("welcome-vouch").textContent).toBe("var");
+	});
+
+	it("never addresses a yazar as a çaylak", () => {
+		flag.value = true;
+		tier = "yazar";
+		renderRoute();
+		expect(screen.getByTestId("welcome-yazar-note")).toBeTruthy();
+		expect(screen.queryByTestId("welcome-vouch-needed")).toBeNull();
+		// The greeting drops the tier word rather than calling a yazar a çaylak.
+		expect(screen.getByTestId("welcome-title").textContent).toBe("hoş geldin");
+	});
+});
+
+describe("WelcomePage — shown-once persistence (criterion 4)", () => {
+	it("arrival writes the per-account marker", () => {
+		flag.value = true;
+		renderRoute();
+		expect(localStorage.getItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, "u-1"))).toBe("1");
+	});
+
+	it("a reload lands past the surface — straight to the original returnTo", () => {
+		flag.value = true;
+		const first = renderRoute();
+		first.unmount();
+		// The reload re-mounts the page fresh over the persisted marker.
+		renderRoute();
+		expect(screen.queryByTestId("welcome-page")).toBeNull();
+		expect(screen.getByTestId("pano-probe").textContent).toBe("/pano");
+	});
+
+	it("repeat login suppresses too — the marker outlives any session object", () => {
+		flag.value = true;
+		const first = renderRoute();
+		first.unmount();
+		// A later login hands the component a brand-new session object; same account id.
+		renderRoute();
+		expect(screen.getByTestId("pano-probe")).toBeTruthy();
+	});
+
+	it("another account on the same browser is not suppressed by u-1's marker", () => {
+		flag.value = true;
+		localStorage.setItem(welcomeSeenKey(WELCOME_SEEN_SCHEMA, "u-other"), "1");
+		renderRoute();
+		expect(screen.getByTestId("welcome-page")).toBeTruthy();
+	});
+});
+
+describe("WelcomePage — continuing returns to context (criterion 2)", () => {
+	it("devam et navigates to the carried returnTo", () => {
+		flag.value = true;
+		renderRoute();
+		fireEvent.click(screen.getByTestId("welcome-continue"));
+		expect(screen.getByTestId("pano-probe").textContent).toBe("/pano");
+	});
+
+	it("without a returnTo param the cold fallback is /", () => {
+		flag.value = true;
+		renderRoute(WELCOME_PATH);
+		fireEvent.click(screen.getByTestId("welcome-continue"));
+		expect(screen.getByTestId("home-probe").textContent).toBe("/");
+	});
+});

--- a/apps/web/src/pages/WelcomePage.test.tsx
+++ b/apps/web/src/pages/WelcomePage.test.tsx
@@ -9,6 +9,7 @@
 import {fireEvent, render, screen} from "@testing-library/react";
 import {MemoryRouter, Route, Routes, useLocation} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {installFakeStorage} from "../../tests/client/fakeStorage";
 import {WELCOME_SEEN_SCHEMA, welcomeSeenKey} from "../components/onboarding/welcomeSeen";
 import {WelcomePage} from "./WelcomePage";
 import {WELCOME_PATH} from "./welcomeGating";
@@ -47,8 +48,10 @@ function LocationProbe({label}: {label: string}) {
 	return <div data-testid={label}>{`${location.pathname}${location.search}`}</div>;
 }
 
-function renderRoute(initialEntry = `${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano")}`) {
-	return render(
+const DEFAULT_ENTRY = `${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano")}`;
+
+function routeTree(initialEntry: string) {
+	return (
 		<MemoryRouter initialEntries={[initialEntry]}>
 			<Routes>
 				<Route path={WELCOME_PATH} element={<WelcomePage />} />
@@ -56,12 +59,19 @@ function renderRoute(initialEntry = `${WELCOME_PATH}?returnTo=${encodeURICompone
 				<Route path="/auth" element={<LocationProbe label="auth-probe" />} />
 				<Route path="/" element={<LocationProbe label="home-probe" />} />
 			</Routes>
-		</MemoryRouter>,
+		</MemoryRouter>
 	);
 }
 
+function renderRoute(initialEntry = DEFAULT_ENTRY) {
+	const view = render(routeTree(initialEntry));
+	// Re-render the SAME mounted tree, the way a resolving session re-renders a live page —
+	// distinct from `renderRoute()` again, which is a fresh mount (a reload).
+	return {...view, settle: () => view.rerender(routeTree(initialEntry))};
+}
+
 beforeEach(() => {
-	localStorage.clear();
+	installFakeStorage();
 	flag.value = false;
 	flag.loading = false;
 	signedIn = true;
@@ -74,7 +84,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	localStorage.clear();
+	vi.unstubAllGlobals();
 });
 
 describe("WelcomePage — the flag-dark gate (.patterns/flag-dark-page-gate.md)", () => {
@@ -179,6 +189,26 @@ describe("WelcomePage — shown-once persistence (criterion 4)", () => {
 		// A later login hands the component a brand-new session object; same account id.
 		renderRoute();
 		expect(screen.getByTestId("pano-probe")).toBeTruthy();
+	});
+
+	// REGRESSION: a real reload paints with `session.isPending` true, so the account id is
+	// not knowable yet. Freezing the marker read at mount latched `false` for the null id and
+	// re-showed the welcome once the session landed — the suppression this criterion buys.
+	it("a reload whose session is still pending still suppresses once the account lands", () => {
+		flag.value = true;
+		installFakeStorage({[welcomeSeenKey(WELCOME_SEEN_SCHEMA, "u-1")]: "1"});
+		sessionPending = true;
+		signedIn = false;
+		const {settle} = renderRoute();
+		expect(screen.getByTestId("welcome-loading")).toBeTruthy();
+
+		// The session resolves into the SAME mounted component, as it does on a real reload.
+		sessionPending = false;
+		signedIn = true;
+		settle();
+
+		expect(screen.queryByTestId("welcome-page")).toBeNull();
+		expect(screen.getByTestId("pano-probe").textContent).toBe("/pano");
 	});
 
 	it("another account on the same browser is not suppressed by u-1's marker", () => {

--- a/apps/web/src/pages/WelcomePage.tsx
+++ b/apps/web/src/pages/WelcomePage.tsx
@@ -47,10 +47,16 @@ export function WelcomePage() {
 	const returnTo = welcomeReturnTo(location.search);
 	const userId = session.data?.user.id ?? null;
 
-	// The seen-decision freezes at mount. The effect below writes the marker mid-visit;
-	// re-reading it on every render would flip this very visit to `return` and bounce
-	// the reader before the screen ever painted.
-	const [seenAtArrival] = useState(() => hasSeenWelcome(welcomeStorage(), userId));
+	// The seen-decision latches per account, NOT at mount: on a reload `session.isPending`
+	// holds `userId` at null for the first renders, and a mount-frozen `false` would then
+	// survive the real session's arrival and re-show a welcome that was already suppressed.
+	// It must still latch once the id is known, because the effect below writes the marker
+	// mid-visit and a live re-read would bounce this very visit before it painted.
+	const [seenLatch, setSeenLatch] = useState<{userId: string; seen: boolean} | null>(null);
+	if (userId !== null && seenLatch?.userId !== userId) {
+		setSeenLatch({userId, seen: hasSeenWelcome(welcomeStorage(), userId)});
+	}
+	const seenAtArrival = seenLatch?.userId === userId && seenLatch.seen;
 
 	const gate = welcomeGate({
 		flagOn,

--- a/apps/web/src/pages/WelcomePage.tsx
+++ b/apps/web/src/pages/WelcomePage.tsx
@@ -1,0 +1,173 @@
+/**
+ * `WelcomePage` — `/hosgeldin`, the welcome moment (#7043, epic #4304): ONE screen
+ * answering what kamp.us is, where the reader stands and what the yazarlık rite ahead
+ * looks like — explicitly not a tour, no second step (#4266's ruling). Reached through
+ * the post-auth intercept in `App.tsx`; ships dark behind `phoenix-welcome`
+ * (`.patterns/flag-dark-page-gate.md`).
+ *
+ * Honest framing is inherited, never re-derived (#4261): an unvouched çaylak gets
+ * `CaylakStatusBlock`'s settled vouch-needed copy and NO karma bar, off the same
+ * aggregate-only `myAuthorshipStanding` read. The exit nudge is sibling slice #7044's
+ * seam — this surface ends at "devam et".
+ *
+ * Shown-once semantics: arrival itself writes the per-account marker
+ * (`welcomeSeen.ts`), so a reload or repeat login lands in the gate's `return` state and
+ * bounces straight to the original `returnTo`.
+ */
+import {useEffect, useState} from "react";
+import {Navigate, useLocation, useNavigate} from "react-router";
+import {useSession} from "../auth/client";
+import {useMe} from "../auth/useMe";
+import {Karma} from "../components/karma/Karma";
+import {
+	hasSeenWelcome,
+	markWelcomeSeen,
+	welcomeStorage,
+} from "../components/onboarding/welcomeSeen";
+import {
+	caylakPromotionPath,
+	useAuthorshipStanding,
+	vouchExistsLabel,
+} from "../components/profile/CaylakStatusBlock";
+import {Button} from "../components/ui/Button";
+import {PHOENIX_WELCOME} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {authRedirectPath} from "../lib/returnTo";
+import {NotFoundPage} from "./NotFoundPage";
+import {welcomeAddressing, welcomeGate, welcomeReturnTo} from "./welcomeGating";
+import "./WelcomePage.css";
+
+export function WelcomePage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(PHOENIX_WELCOME, false);
+	const session = useSession();
+	const navigate = useNavigate();
+	const location = useLocation();
+	const {me} = useMe();
+
+	const returnTo = welcomeReturnTo(location.search);
+	const userId = session.data?.user.id ?? null;
+
+	// The seen-decision freezes at mount. The effect below writes the marker mid-visit;
+	// re-reading it on every render would flip this very visit to `return` and bounce
+	// the reader before the screen ever painted.
+	const [seenAtArrival] = useState(() => hasSeenWelcome(welcomeStorage(), userId));
+
+	const gate = welcomeGate({
+		flagOn,
+		flagLoading,
+		sessionPending: session.isPending,
+		signedIn: !!session.data?.user,
+		welcomeSeen: seenAtArrival,
+	});
+
+	// Arrival is the showing: once-per-account (#4266) means the marker lands when the
+	// surface mounts, not only when "devam et" is clicked.
+	useEffect(() => {
+		if (gate !== "ready") return;
+		markWelcomeSeen(welcomeStorage(), userId);
+	}, [gate, userId]);
+
+	const addressing = welcomeAddressing(me?.tier);
+	const standing = useAuthorshipStanding(gate === "ready");
+
+	if (gate === "loading") {
+		return (
+			<div className="kp-welcome">
+				<div className="kp-welcome__inner">
+					<p className="kp-welcome__lede" data-testid="welcome-loading">
+						yükleniyor…
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (gate === "not-found") return <NotFoundPage />;
+
+	if (gate === "sign-in") {
+		return <Navigate to={authRedirectPath(returnTo)} replace />;
+	}
+
+	if (gate === "return") return <Navigate to={returnTo} replace />;
+
+	const promotionPath = standing ? caylakPromotionPath(standing.vouchExists) : null;
+
+	return (
+		<main className="kp-welcome" data-testid="welcome-page">
+			<div className="kp-welcome__inner">
+				<header className="kp-welcome__masthead">
+					{/* "hoş geldin, çaylak" is the founder's ruled copy for this moment (#4266); the
+					    tier is named only to a reader who actually holds it (#4261). */}
+					<h1 className="kp-welcome__title" data-testid="welcome-title">
+						{addressing === "çaylak" ? "hoş geldin, çaylak" : "hoş geldin"}
+					</h1>
+					<p className="kp-welcome__lede">
+						kamp.us, geliştiricilerin kendi kendine bir şey öğrettiği yavaş bir köşe. panoda
+						bağlantı ve yazı paylaşılıyor; sözlükte terimler kendi cümlelerimizle yazılıyor. reklam
+						yok, takipçi yarışı yok — söz hakkı kazanılır.
+					</p>
+				</header>
+
+				<section className="kp-welcome__section" data-testid="welcome-standing">
+					<h2 className="kp-welcome__heading">neredesin</h2>
+					{addressing === "çaylak" ? (
+						<>
+							<p className="kp-welcome__line">hesabın yeni açıldı; henüz bir çaylaksın.</p>
+							{promotionPath?.kind === "vouch-needed" ? (
+								<div className="kp-welcome__vouch-needed" data-testid="welcome-vouch-needed">
+									<p className="kp-welcome__vouch-message">{promotionPath.message}</p>
+									<p className="kp-welcome__vouch-hint">{promotionPath.hint}</p>
+								</div>
+							) : null}
+							{promotionPath?.kind === "karma-bar" && standing ? (
+								<Karma
+									value={standing.karma}
+									target={standing.bar}
+									label="karma"
+									testId="welcome-karma"
+								/>
+							) : null}
+							{standing ? (
+								<dl className="kp-welcome__facts">
+									<div className="kp-welcome__fact">
+										<dt className="kp-welcome__term">kefil</dt>
+										<dd className="kp-welcome__value" data-testid="welcome-vouch">
+											{vouchExistsLabel(standing.vouchExists)}
+										</dd>
+									</div>
+								</dl>
+							) : null}
+						</>
+					) : addressing === "yazar" ? (
+						<p className="kp-welcome__line" data-testid="welcome-yazar-note">
+							zaten bir yazarsın; yazdıkların doğrudan yayına girer.
+						</p>
+					) : (
+						<p className="kp-welcome__line">durumun yükleniyor.</p>
+					)}
+				</section>
+
+				{addressing !== "yazar" ? (
+					<section className="kp-welcome__section" data-testid="welcome-rite">
+						<h2 className="kp-welcome__heading">önündeki yol</h2>
+						<p className="kp-welcome__line">
+							ilk katkını yaz — mevcut bir başlığa girdi ekleyerek başlayabilirsin. katkı verdikçe
+							bir yazar sana kefil olur; kefillik ve inceleme tamamlandığında yazar olursun ve
+							yazdıkların doğrudan yayına girer.
+						</p>
+					</section>
+				) : null}
+
+				<Button
+					type="button"
+					variant="primary"
+					className="kp-welcome__continue"
+					data-testid="welcome-continue"
+					onClick={() => navigate(returnTo, {replace: true})}
+				>
+					devam et
+				</Button>
+			</div>
+		</main>
+	);
+}

--- a/apps/web/src/pages/welcomeGating.ts
+++ b/apps/web/src/pages/welcomeGating.ts
@@ -1,0 +1,74 @@
+/**
+ * The welcome arrival's two pure decisions (#7043, epic #4304), extracted DOM-free —
+ * the `landingGating` / `caylakVisibilityGating` idiom.
+ *
+ * `postAuthDestination` is what the post-auth redirect effect in `App.tsx` consults. The
+ * flag-off branch is byte-for-byte today's behavior: the same target string out that went
+ * in (already through `safeReturnTo`), so with the flag at its default the redirect is
+ * unchanged no matter how the marker reads.
+ */
+import type {Tier} from "../../worker/features/kunye/standing";
+import {safeReturnTo} from "../lib/returnTo";
+
+export const WELCOME_PATH = "/hosgeldin";
+
+export type PostAuthDestination =
+	| {readonly kind: "context"; readonly to: string}
+	| {readonly kind: "welcome"; readonly to: string};
+
+export function postAuthDestination(
+	welcomeOn: boolean,
+	welcomeSeen: boolean,
+	target: string,
+): PostAuthDestination {
+	if (!welcomeOn || welcomeSeen) return {kind: "context", to: target};
+	return {kind: "welcome", to: `${WELCOME_PATH}?returnTo=${encodeURIComponent(target)}`};
+}
+
+/** The `returnTo` the arrival must hand back to — read off the welcome URL, guarded. */
+export function welcomeReturnTo(search: string): string {
+	return safeReturnTo(new URLSearchParams(search).get("returnTo"));
+}
+
+export type WelcomeGate =
+	/** The flag or the session is still resolving — a neutral placeholder. */
+	| "loading"
+	/** The flag is off: the route does not exist. */
+	| "not-found"
+	/** Signed out: send them to auth carrying a `returnTo`. */
+	| "sign-in"
+	/** Already welcomed: suppress the surface, straight to the `returnTo`. */
+	| "return"
+	/** A signed-in account that has never been welcomed. */
+	| "ready";
+
+export interface WelcomeGateInput {
+	readonly flagOn: boolean;
+	readonly flagLoading: boolean;
+	readonly sessionPending: boolean;
+	readonly signedIn: boolean;
+	readonly welcomeSeen: boolean;
+}
+
+/**
+ * The order is load-bearing (`flag-dark-page-gate.md`): `loading` outranks everything so a
+ * resolving flag never flashes the 404; a dark route leaks nothing to anyone; and the
+ * seen-check comes after sign-in because an anonymous visitor has no account to have been
+ * welcomed under.
+ */
+export function welcomeGate(input: WelcomeGateInput): WelcomeGate {
+	if (input.flagLoading || input.sessionPending) return "loading";
+	if (!input.flagOn) return "not-found";
+	if (!input.signedIn) return "sign-in";
+	if (input.welcomeSeen) return "return";
+	return "ready";
+}
+
+/**
+ * How the screen may address the reader. Only the two real tiers get standing claims;
+ * anything else stays neutral, because addressing an unknown-tier reader as a çaylak
+ * would be a lie (#4261).
+ */
+export function welcomeAddressing(tier: Tier | null | undefined): Tier | "unknown" {
+	return tier === "çaylak" || tier === "yazar" ? tier : "unknown";
+}

--- a/apps/web/src/pages/welcomeGating.unit.test.ts
+++ b/apps/web/src/pages/welcomeGating.unit.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The welcome arrival's decision contract (#7043, epic #4304), pinned without a DOM.
+ * The load-bearing rows are the flag-off identity (criterion 1: the redirect is
+ * byte-for-byte today's) and the gate order (`flag-dark-page-gate.md`).
+ */
+import {describe, expect, it} from "vitest";
+import {
+	postAuthDestination,
+	WELCOME_PATH,
+	welcomeAddressing,
+	welcomeGate,
+	welcomeReturnTo,
+} from "./welcomeGating";
+
+const READY_GATE = {
+	flagOn: true,
+	flagLoading: false,
+	sessionPending: false,
+	signedIn: true,
+	welcomeSeen: false,
+};
+
+describe("postAuthDestination — the App.tsx intercept's decision", () => {
+	it("flag off is byte-for-byte today's redirect, whatever the marker reads", () => {
+		expect(postAuthDestination(false, false, "/pano")).toEqual({kind: "context", to: "/pano"});
+		expect(postAuthDestination(false, true, "/pano")).toEqual({kind: "context", to: "/pano"});
+		// The cold fallback target rides through untouched too.
+		expect(postAuthDestination(false, false, "/")).toEqual({kind: "context", to: "/"});
+	});
+
+	it("flag on + never welcomed detours through the welcome surface carrying the target", () => {
+		expect(postAuthDestination(true, false, "/pano")).toEqual({
+			kind: "welcome",
+			to: `${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano")}`,
+		});
+	});
+
+	it("the carried returnTo survives query strings and slashes via one encodeURIComponent", () => {
+		const {to} = postAuthDestination(true, false, "/pano/yeni?sort=saved");
+		expect(to).toBe(`${WELCOME_PATH}?returnTo=${encodeURIComponent("/pano/yeni?sort=saved")}`);
+	});
+
+	it("flag on + already welcomed goes straight to the context, as before", () => {
+		expect(postAuthDestination(true, true, "/sozluk")).toEqual({kind: "context", to: "/sozluk"});
+	});
+});
+
+describe("welcomeReturnTo — what the arrival hands back to", () => {
+	it("passes a same-origin path through", () => {
+		expect(welcomeReturnTo(`?returnTo=${encodeURIComponent("/pano")}`)).toBe("/pano");
+	});
+
+	it("falls back to / when the param is missing or off-site (safeReturnTo)", () => {
+		expect(welcomeReturnTo("")).toBe("/");
+		expect(welcomeReturnTo("?returnTo=https%3A%2F%2Fevil.example")).toBe("/");
+		expect(welcomeReturnTo(`?returnTo=${encodeURIComponent("//evil.example")}`)).toBe("/");
+	});
+});
+
+describe("welcomeGate — the page's render decision", () => {
+	it("loading outranks everything while the flag or session resolves", () => {
+		expect(welcomeGate({...READY_GATE, flagLoading: true})).toBe("loading");
+		expect(welcomeGate({...READY_GATE, sessionPending: true})).toBe("loading");
+	});
+
+	it("a dark route 404s before any session question is asked", () => {
+		expect(welcomeGate({...READY_GATE, flagOn: false, signedIn: false})).toBe("not-found");
+	});
+
+	it("a signed-out visitor is sent to auth, not 404'd", () => {
+		expect(welcomeGate({...READY_GATE, signedIn: false})).toBe("sign-in");
+	});
+
+	it("an already-welcomed account is suppressed in favor of the returnTo", () => {
+		expect(welcomeGate({...READY_GATE, welcomeSeen: true})).toBe("return");
+		expect(welcomeGate(READY_GATE)).toBe("ready");
+	});
+});
+
+describe("welcomeAddressing — who the screen may address by tier", () => {
+	it("names the two real tiers and stays neutral otherwise", () => {
+		expect(welcomeAddressing("çaylak")).toBe("çaylak");
+		expect(welcomeAddressing("yazar")).toBe("yazar");
+		expect(welcomeAddressing(null)).toBe("unknown");
+		expect(welcomeAddressing(undefined)).toBe("unknown");
+		expect(welcomeAddressing("visitor")).toBe("unknown");
+	});
+});

--- a/apps/web/tests/client/fakeStorage.ts
+++ b/apps/web/tests/client/fakeStorage.ts
@@ -1,0 +1,26 @@
+/**
+ * An in-memory `Storage` for the `client` vitest tier, which ships no `localStorage` of its
+ * own — bare `localStorage.x` there is `undefined` and every access throws (#7043).
+ *
+ * Installed on BOTH the bare global and `window`: production readers split across the two
+ * (`welcomeSeen.ts` goes through `window.localStorage`, test setup calls bare `localStorage`),
+ * and stubbing one leaves the other undefined.
+ */
+import {vi} from "vitest";
+
+export function installFakeStorage(initial?: Record<string, string>): Storage {
+	const map = new Map<string, string>(Object.entries(initial ?? {}));
+	const storage: Storage = {
+		get length() {
+			return map.size;
+		},
+		clear: () => map.clear(),
+		getItem: (k) => map.get(k) ?? null,
+		key: (i) => [...map.keys()][i] ?? null,
+		removeItem: (k) => void map.delete(k),
+		setItem: (k, v) => void map.set(k, v),
+	};
+	vi.stubGlobal("localStorage", storage);
+	Object.defineProperty(window, "localStorage", {value: storage, configurable: true});
+	return storage;
+}

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -23,6 +23,7 @@ import {
 	PHOENIX_USER_ADMIN,
 	PHOENIX_USER_BAN,
 	PHOENIX_USER_ROLE_ASSIGN,
+	PHOENIX_WELCOME,
 	PROFILE_CANVAS,
 } from "../../../src/flags/keys.ts";
 
@@ -307,3 +308,28 @@ export const FUNNEL_COHORT_FLAG = {
 /** A plain boolean kill-switch, no targeting rules — see `caylakVisibilityFlag`. */
 export const funnelCohortFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_funnel_cohort", {appId, ...FUNNEL_COHORT_FLAG});
+
+/**
+ * The welcome-arrival dark-ship flag config (#7043, epic #4304). The SINGLE seam the whole
+ * slice gates behind: the post-auth redirect intercept in `App.tsx` and the `/hosgeldin`
+ * welcome surface. Default-OFF so the arrival ships dark — with it off the post-signup
+ * redirect behaves byte-for-byte as before; flipping it on is the human release act
+ * (ADR 0083).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           onboarding (the new-user arrival surface)
+ *   - originating:     #7043 (epic: new-user onboarding, #4304)
+ *   - removal trigger: once the welcome moment is on at 100% and stable for one release,
+ *                      retire the flag and inline the intercept.
+ */
+export const WELCOME_FLAG = {
+	key: PHOENIX_WELCOME,
+	description:
+		"welcome arrival — post-auth intercept + /hosgeldin surface dark-ship (#7043, epic #4304). owner: onboarding. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/** A plain boolean kill-switch, no targeting rules — see `caylakVisibilityFlag`. */
+export const welcomeFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_welcome", {appId, ...WELCOME_FLAG});

--- a/apps/web/worker/features/flagship/welcome.invariant.test.ts
+++ b/apps/web/worker/features/flagship/welcome.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the welcome-arrival flag (#7043, epic
+ * #4304). Inspected off the exported `WELCOME_FLAG` record (the same object the factory
+ * spreads into `FlagshipFlag`), so no alchemy resource is constructed — mirrors
+ * `caylak-visibility.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_WELCOME} from "../../../src/flags/keys.ts";
+import {WELCOME_FLAG, welcomeFlag} from "./resources.ts";
+
+describe("welcome — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(WELCOME_FLAG.defaultVariation, "off");
+		assert.strictEqual(WELCOME_FLAG.variations.off, false);
+		assert.strictEqual(WELCOME_FLAG.variations.on, true);
+		assert.strictEqual(WELCOME_FLAG.key, "phoenix-welcome");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(WELCOME_FLAG.key, PHOENIX_WELCOME);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof welcomeFlag, "function");
+	});
+});


### PR DESCRIPTION
Phase 1 of epic #4304: the arrival a brand-new account walks through, and the one screen it lands on.

Today a signup ends emptier than it started — `/auth` bootstraps a username, redirects to `returnTo`, and the landing page strips its rite copy for signed-in readers. This adds the welcome moment the founder ruled on #4266 (one lightweight surface, explicitly not a tour) and the wiring that routes a never-welcomed account through it once, then hands them back to wherever they were headed.

**What it does**

- `phoenix-welcome`, default-off, is the whole slice's release seam — one human flip releases both the intercept and the route (ADR 0083).
- The Layout's post-auth effect now asks `postAuthDestination` where to go. Flag on plus a never-welcomed account detours through `/hosgeldin` carrying the original target; everything else is today's redirect unchanged. The marker is read only when the flag is on, so a stale marker cannot move a default-off signup.
- `/hosgeldin` is one screen: what kamp.us is, where the reader stands, what the yazarlık rite ahead looks like, and a single "devam et" back to context (cold fallback `/`). No second step, no checklist.
- Standing comes from `CaylakStatusBlock`'s existing hook rather than a second `myAuthorshipStanding` read, so the settled vouch-needed copy and the no-bar-while-unvouched rule are inherited, not re-derived (#4261). The greeting names the tier only to a reader who holds it — a yazar is never called a çaylak.
- Shown-once is one per-account marker in `localStorage`, keyed by user id, read by both the intercept and the page. A refusing store degrades to "never seen".

The exit nudge is sibling slice #7044's, deliberately absent here.

**Where to look first:** the intercept at `apps/web/src/App.tsx` and the flag-off rows in `apps/web/src/App.test.tsx` — criterion 1 is the one a reviewer should be hardest on, since a regression there is invisible until it reaches a real signup.

`LAW-SOURCE: manifest-prose` — this repo ships no typed prohibition registry beside `design-system-manifest.md`, so the manifest's prose prohibitions were the law read before generating the surface.

## Deviations

- **Guard or gate bypassed** — **Said:** the rendered-visual half owes render→look→fix evidence attached to this PR. **Did:** attached one capture, of the flag-off `bulunamadı` state; the welcome composition itself is unjudged. **Why:** `fabrika review-ui render` works on this PR — it resolves the preview-deploy comment and captured `/hosgeldin` at 1280x800 with zero page errors — but it cannot reach the composition, twice over. `phoenix-welcome` is default-off and resolves server-side through `POST /api/flags/evaluate` (`apps/web/src/flags/useFlag.ts`); it is not a boot member (`SHELL_FLAG_KEYS` is `[MECMUA_PUBLIC_READ, MECMUA_FEED]`) and there is no client-side override — no query param, no storage seam — so the capture lands on the shell's not-found page. And even flag-on, `welcomeGate` returns `sign-in` for an anonymous visitor (`welcomeGating.ts`), which the capture machinery has no authenticated-session path to satisfy. Both halves would have to be fixed for these pixels to be judgeable, so this is unrenderable at any head, not at this one. The unjudged states are the welcome composition's spacing rhythm, hierarchy, dark mode, karma bar in situ, and the vouch-needed block. **Disposition:** stated here, under the interim rider of the founder's ruling on #6541 (https://github.com/kamp-us/phoenix/issues/6541#issuecomment-5363127455, 2026-08-20 PT), which makes the mitigation disclosure-only until `review-ui render` grows a flag override and a seeded session — a verdict must name the states that did not render. ADR 0336 records that ruling and is landing on PR #7219; it is not in the corpus at this head. The implementation is tracked at #7218.
- **Out-of-scope change** — **Said:** #7043 names the welcome files and the `App.tsx` redirect effect. **Did:** also exported `useAuthorshipStanding` from `apps/web/src/components/profile/CaylakStatusBlock.tsx`. **Why:** the epic's named rabbit hole is "growing a second standing source"; reusing the one hook is what keeps the `STANDING_FIELDS` selection single-sourced. No behaviour of `CaylakStatusBlock` changes. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** same. **Did:** also extended `.patterns/flag-dark-page-gate.md` with `WelcomePage` and its extra suppression rung. **Why:** CLAUDE.md requires a pattern doc be extended when a load-bearing pattern is relied on, and that doc's page list reads as complete, so omitting the new page would make it quietly wrong. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about `App.test.tsx`'s existing fixtures. **Did:** added inert `vi.mock` stubs for `AuthPage` and `WelcomePage`, and widened the `useFlag` mock with the new key. **Why:** the intercept starts on `/auth`, and `AuthPage` calls `useFateClient()` under this file's spied `FateClient`, which provides no context — the route is unreachable here without a stand-in. No existing assertion changed; all 33 prior rows still pass. **Disposition:** stated here.
- **Scope narrowing** — **Said:** nothing. **Did:** cut the lane branch fresh as `build/7043-welcome-arrival-cd5e1ace` rather than resuming `build/7043-welcome-arrival-20e9e4f7`. **Why:** two stale branches were cut for #7043 by earlier lanes, which makes `build branch --resume-lane` underivable; both were empty and unpushed, and the operator's brief said to leave the sibling in place. The reaped lane's uncommitted work was carried over whole — nothing was dropped. **Disposition:** stated here.

- **Out-of-scope change** — **Said:** #7043 names the welcome files and the `App.tsx` redirect effect. **Did:** also replaced the local `installFakeStorage` helper in `apps/web/src/lib/density.test.tsx` with an import of the new shared `apps/web/tests/client/fakeStorage.ts`. **Why:** the client vitest tier ships no `localStorage`, and this repair needed the same fake in two more files; leaving a third hand-copy of it beside a freshly-extracted shared one is the duplication a reviewer would rightly flag. The extracted helper is byte-identical in behaviour and density's 3 rows still pass. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing further about `App.test.tsx`. **Did:** gave its `useFlag` mock a per-key `loading` axis (`flags.welcomeLoading`) instead of a hardcoded `loading: false`, and swapped its `localStorage.clear()` lifecycle for `installFakeStorage()` / `vi.unstubAllGlobals()`. **Why:** the flag-loading race cannot be expressed at all while every mocked flag resolves synchronously — `PHOENIX_WELCOME` is not a boot member and really does load late. Only `PHOENIX_WELCOME` gets the axis; every other key still reads `loading: false`, so no existing row's inputs moved and all prior rows still pass. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** same. **Did:** added a second paragraph to `.patterns/flag-dark-page-gate.md`'s "When this is not the gate you want" section, about an irreversible navigation off a non-member flag having to honour `loading`. **Why:** that section previously said a flag outside a page gate may read `value` alone, which is the exact reading that produced this PR's redirect race — leaving it would document the bug as the pattern. **Disposition:** stated here.

Fixes #7043


