### PR TITLE
feat: backlog-release felt moment: the terfi sweep tells the promoted çaylak what went public

### DIFF
--- a/apps/web/src/components/bildirim/bildirim.test.ts
+++ b/apps/web/src/components/bildirim/bildirim.test.ts
@@ -82,6 +82,16 @@ describe("bildirimCopy — Turkish product voice per kind (#1695)", () => {
 		expect(bildirimCopy("terfi", 1)).toBe("tebrikler, artık bir yazarsın!");
 	});
 
+	it("backlog-release carries the swept count — R1.1 on #7049 ruled the count in (#7061)", () => {
+		expect(bildirimCopy("backlog-release", 3)).toBe("3 yazınız artık herkese açık");
+		expect(bildirimCopy("backlog-release", 1)).toBe("1 yazınız artık herkese açık");
+	});
+
+	it('a zero-entry sweep renders the zero arm — never "0 yazınız…"', () => {
+		expect(bildirimCopy("backlog-release", 0)).toBe("bundan sonra yazılarınız herkese açık");
+		expect(bildirimCopy("backlog-release", 0)).not.toMatch(/^0/);
+	});
+
 	it("reply renders Turkish copy — the raw `reply` identifier no longer surfaces (#2016)", () => {
 		expect(bildirimCopy("reply", 1)).toBe("gönderine yanıt geldi");
 		expect(bildirimCopy("reply", 3)).toBe("gönderine 3 yanıt geldi");

--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -29,6 +29,14 @@ export function rowUnread(
 	return readAt == null && !markedThisSession && !allMarkedThisSession;
 }
 
+// R1.1 on #7049 ruled the count into the backlog-release copy, with a distinct zero arm
+// for a sweep that published nothing. Both arms are required fields, so shipping the kind
+// with either arm missing is a compile error — "0 yazınız…" stays unrepresentable.
+const BACKLOG_RELEASE_COPY: {zero: string; some: (count: number) => string} = {
+	zero: "bundan sonra yazılarınız herkese açık",
+	some: (count) => `${count} yazınız artık herkese açık`,
+};
+
 // `satisfies Record<NotificationKind, …>` keeps the map exhaustive over the shared kind
 // union (#2016): a new emitter kind without its copy is a compile error, not a raw wire
 // identifier rendered to a reader.
@@ -42,6 +50,8 @@ const KIND_COPY = {
 	"report-filed": (count) =>
 		count > 1 ? `${count} yeni içerik bildirildi` : "yeni bir içerik bildirildi",
 	"caylak-pending": () => "yeni bir çaylak divanda incelenmeyi bekliyor",
+	"backlog-release": (count) =>
+		count > 0 ? BACKLOG_RELEASE_COPY.some(count) : BACKLOG_RELEASE_COPY.zero,
 } satisfies Record<NotificationKind, (count: number) => string>;
 
 /** An unknown kind — a future emitter's, read by an older client — degrades to the raw kind. */

--- a/apps/web/worker/features/bildirim/kind.ts
+++ b/apps/web/worker/features/bildirim/kind.ts
@@ -16,6 +16,7 @@ export const NOTIFICATION_KINDS = [
 	"vote",
 	"report-filed",
 	"caylak-pending",
+	"backlog-release",
 ] as const;
 
 export type NotificationKind = (typeof NOTIFICATION_KINDS)[number];

--- a/apps/web/worker/features/bildirim/rite-emitters.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.ts
@@ -18,6 +18,7 @@ import {Notification} from "./Notification.ts";
 export const DIVAN_VOTE_KIND: NotificationKind = "divan-vote";
 export const KEFIL_KIND: NotificationKind = "kefil";
 export const PROMOTION_KIND: NotificationKind = "terfi";
+export const BACKLOG_RELEASE_KIND: NotificationKind = "backlog-release";
 
 // Self-suppression: `null` when the recipient IS the actor.
 export const riteRecipient = (recipientId: string, actorId: string): string | null =>
@@ -82,3 +83,20 @@ export const notifyPromotion = (input: {userId: string}) =>
 			actorId: null,
 		});
 	}).pipe(swallow(PROMOTION_KIND));
+
+// The terfi sweep's what-went-public moment (#7061): a system emit like the promotion,
+// so no self-suppression and `actorId` null. `count` carries the swept-entry count and 0
+// rides too — the client's zero arm (R1.1 on #7049) needs a row to render.
+export const notifyBacklogRelease = (input: {userId: string; releasedCount: number}) =>
+	Effect.gen(function* () {
+		if (!(yield* bildirimOn)) return;
+		const bildirim = yield* Notification;
+		yield* bildirim.record({
+			recipientId: input.userId,
+			kind: BACKLOG_RELEASE_KIND,
+			targetKind: "user",
+			targetId: input.userId,
+			actorId: null,
+			count: input.releasedCount,
+		});
+	}).pipe(swallow(BACKLOG_RELEASE_KIND));

--- a/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
@@ -13,8 +13,10 @@ import {Mute} from "../mute/Mute.ts";
 import {makeNotificationStub} from "./Notification.testing.ts";
 import type {NotificationAggregateInput, NotificationRecordInput} from "./Notification.ts";
 import {
+	BACKLOG_RELEASE_KIND,
 	DIVAN_VOTE_KIND,
 	KEFIL_KIND,
+	notifyBacklogRelease,
 	notifyDivanVote,
 	notifyKefil,
 	notifyPromotion,
@@ -233,6 +235,73 @@ describe("notifyPromotion — the çaylak→yazar ceremony emit", () => {
 	it.effect("a DYING notification write is swallowed — the promotion caller still succeeds", () =>
 		Effect.gen(function* () {
 			const exit = yield* notifyPromotion({userId: "u-promoted"}).pipe(
+				Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+				Effect.exit,
+			);
+			assert.strictEqual(exit._tag, "Success");
+		}),
+	);
+});
+
+describe("notifyBacklogRelease — the terfi sweep's what-went-public emit (#7061)", () => {
+	it.effect("records ONE notification carrying the swept-entry count (no actor identity)", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyBacklogRelease({userId: "u-promoted", releasedCount: 3}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							record: (input) => {
+								calls.push(input);
+								return Effect.succeed({id: "n1"});
+							},
+						}),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-promoted",
+				kind: BACKLOG_RELEASE_KIND,
+				targetKind: "user",
+				targetId: "u-promoted",
+				actorId: null,
+				count: 3,
+			});
+		}),
+	);
+
+	it.effect("a zero-entry sweep still emits, carrying count 0 for the client's zero arm", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyBacklogRelease({userId: "u-promoted", releasedCount: 0}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							record: (input) => {
+								calls.push(input);
+								return Effect.succeed({id: "n1"});
+							},
+						}),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 1);
+			assert.strictEqual(calls[0]?.count, 0);
+		}),
+	);
+
+	it.effect("with the bildirim flag OFF the write never happens (dark by default)", () =>
+		notifyBacklogRelease({userId: "u-promoted", releasedCount: 3}).pipe(
+			Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(false))),
+		),
+	);
+
+	it.effect("a DYING notification write is swallowed — the promotion caller still succeeds", () =>
+		Effect.gen(function* () {
+			const exit = yield* notifyBacklogRelease({userId: "u-promoted", releasedCount: 3}).pipe(
 				Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
 				Effect.exit,
 			);

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -12,7 +12,7 @@ import {
 	PHOENIX_USER_ROLE_ASSIGN,
 } from "../../../src/flags/keys.ts";
 import {UserId} from "../../lib/ids.ts";
-import {notifyKefil, notifyPromotion} from "../bildirim/rite-emitters.ts";
+import {notifyBacklogRelease, notifyKefil, notifyPromotion} from "../bildirim/rite-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
@@ -35,6 +35,7 @@ import {CandidateId} from "./ids.ts";
 import {pasaportLive} from "./live.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {publishPromotion} from "./promote-live.ts";
+import {sweptEntryCount} from "./sandbox-sweep.ts";
 import {
 	toAccountDeletionReceipt,
 	toBanState,
@@ -393,11 +394,12 @@ const promoteGated = Effect.fn("user.promoteGated")(function* (input: typeof Pro
 	yield* Moderate;
 	const pasaport = yield* Pasaport;
 	const {promoted, sweep} = yield* pasaport.promoteToYazar({userId: input.userId});
-	// Both keyed on `promoted`, so an already-yazar no-op notifies and publishes nothing.
-	// Both are infallible (failures swallowed inside the emitter/publisher), so neither
+	// All keyed on `promoted`, so an already-yazar no-op notifies and publishes nothing.
+	// All are infallible (failures swallowed inside the emitter/publisher), so none
 	// can fail the committed flip.
 	if (promoted) {
 		yield* notifyPromotion({userId: input.userId});
+		yield* notifyBacklogRelease({userId: input.userId, releasedCount: sweptEntryCount(sweep)});
 		yield* publishPromotion(input.userId, sweep);
 	}
 	return toPromotionReceipt({userId: input.userId, promoted, vouchRecorded: false});

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -26,7 +26,7 @@ import {Mute} from "../mute/Mute.ts";
 import {mutations} from "./mutations.ts";
 import {makePasaportStub} from "./Pasaport.testing.ts";
 import {noopLive, relationStoreNoModerators} from "./promote-live.testing.ts";
-import {NO_SANDBOX_SWEEP} from "./sandbox-sweep.ts";
+import {NO_SANDBOX_SWEEP, type SandboxSweep} from "./sandbox-sweep.ts";
 
 // A landed flip re-resolves the promoted `User` for the #1886 live-publish, so a
 // `promoted: true` stub must answer `getUsersByIds`.
@@ -419,7 +419,7 @@ describe("user.vouch — kefil bildirimi (#1695)", () => {
 	);
 });
 
-describe("user.promote — terfi bildirimi (#1696)", () => {
+describe("user.promote — terfi + backlog-release bildirimleri (#1696, #7061)", () => {
 	const promotionRecording = () => {
 		const emits: NotificationRecordInput[] = [];
 		const layer = makeNotificationStub({
@@ -431,13 +431,24 @@ describe("user.promote — terfi bildirimi (#1696)", () => {
 		return {layer, emits};
 	};
 
+	// 2 posts + 1 comment swept public ⇒ the backlog-release count is 3.
+	const sweptBacklog: SandboxSweep = {
+		feed: true,
+		commentThreads: ["p-parent"],
+		definitionTerms: [],
+		postIds: ["p1", "p2"],
+		commentIds: ["c1"],
+		definitionIds: [],
+	};
+
 	const promoteLayers = (
 		notification: ReturnType<typeof makeNotificationStub>,
 		promoted: boolean,
+		sweep: SandboxSweep = NO_SANDBOX_SWEEP,
 	) =>
 		Layer.mergeAll(
 			makePasaportStub({
-				promoteToYazar: () => Effect.succeed({promoted, sweep: NO_SANDBOX_SWEEP}),
+				promoteToYazar: () => Effect.succeed({promoted, sweep}),
 				...promotedUsersByIds("u-target"),
 			}),
 			relationStoreOf(["u-mod"]),
@@ -447,19 +458,40 @@ describe("user.promote — terfi bildirimi (#1696)", () => {
 			noopLive,
 		);
 
-	it.effect("a landed mod promotion emits ONE terfi notification for the promoted member", () => {
+	it.effect(
+		"a landed mod promotion emits ONE terfi and ONE backlog-release carrying the swept count",
+		() => {
+			const {layer, emits} = promotionRecording();
+			return Effect.gen(function* () {
+				yield* promote("u-target");
+				assert.deepStrictEqual(emits, [
+					{
+						recipientId: "u-target",
+						kind: "terfi",
+						targetKind: "user",
+						targetId: "u-target",
+						actorId: null,
+					},
+					{
+						recipientId: "u-target",
+						kind: "backlog-release",
+						targetKind: "user",
+						targetId: "u-target",
+						actorId: null,
+						count: 3,
+					},
+				]);
+			}).pipe(Effect.provide(promoteLayers(layer, true, sweptBacklog)));
+		},
+	);
+
+	it.effect("a zero-entry promotion's backlog-release carries count 0 (the zero arm's row)", () => {
 		const {layer, emits} = promotionRecording();
 		return Effect.gen(function* () {
 			yield* promote("u-target");
-			assert.deepStrictEqual(emits, [
-				{
-					recipientId: "u-target",
-					kind: "terfi",
-					targetKind: "user",
-					targetId: "u-target",
-					actorId: null,
-				},
-			]);
+			const backlogEmits = emits.filter((e) => e.kind === "backlog-release");
+			assert.strictEqual(backlogEmits.length, 1);
+			assert.strictEqual(backlogEmits[0]?.count, 0);
 		}).pipe(Effect.provide(promoteLayers(layer, true)));
 	});
 

--- a/apps/web/worker/features/pasaport/sandbox-sweep.ts
+++ b/apps/web/worker/features/pasaport/sandbox-sweep.ts
@@ -37,6 +37,10 @@ export const NO_SANDBOX_SWEEP: SandboxSweep = {
 	definitionIds: [],
 };
 
+/** How many sandboxed entries the sweep made public — the backlog-release moment's count (#7061). */
+export const sweptEntryCount = (sweep: SandboxSweep): number =>
+	sweep.postIds.length + sweep.commentIds.length + sweep.definitionIds.length;
+
 /**
  * Lives beside the shape so a field added above cannot leave the publisher's early
  * return reading half of it.

--- a/apps/web/worker/features/pasaport/tandem.ts
+++ b/apps/web/worker/features/pasaport/tandem.ts
@@ -8,12 +8,13 @@
  * "the yazar never holds a promote capability" true (`.glossary/TERMS.md`).
  */
 import {Effect} from "effect";
-import {notifyPromotion} from "../bildirim/rite-emitters.ts";
+import {notifyBacklogRelease, notifyPromotion} from "../bildirim/rite-emitters.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {VOUCH_PROMOTION_KARMA_BAR} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {publishPromotion} from "./promote-live.ts";
+import {sweptEntryCount} from "./sandbox-sweep.ts";
 
 /** `promoted` is `true` only when THIS call's flip fired, never for an already-yazar. */
 export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (candidateId: string) {
@@ -26,10 +27,11 @@ export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (cand
 
 	const pasaport = yield* Pasaport;
 	const {promoted, sweep} = yield* pasaport.promoteToYazar({userId: candidateId});
-	// Both keyed on `promoted`, so an idempotent re-fire notifies and publishes nothing.
-	// Both are infallible, so neither can fail this committed tier flip.
+	// All keyed on `promoted`, so an idempotent re-fire notifies and publishes nothing.
+	// All are infallible, so none can fail this committed tier flip.
 	if (promoted) {
 		yield* notifyPromotion({userId: candidateId});
+		yield* notifyBacklogRelease({userId: candidateId, releasedCount: sweptEntryCount(sweep)});
 		yield* publishPromotion(candidateId, sweep);
 	}
 	return {promoted};

--- a/apps/web/worker/features/pasaport/tandem.unit.test.ts
+++ b/apps/web/worker/features/pasaport/tandem.unit.test.ts
@@ -9,7 +9,7 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
 import type {NotificationRecordInput} from "../bildirim/Notification.ts";
-import {PROMOTION_KIND} from "../bildirim/rite-emitters.ts";
+import {BACKLOG_RELEASE_KIND, PROMOTION_KIND} from "../bildirim/rite-emitters.ts";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
@@ -155,9 +155,10 @@ describe("resolveTandem — order-independent promotion", () => {
 	);
 });
 
-// The emit is keyed on `promoted`: a landed flip emits ONE `terfi` bildirimi, an
-// idempotent no-op flip emits nothing (#1696).
-describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
+// The emits are keyed on `promoted`: a landed flip emits ONE `terfi` bildirimi and ONE
+// `backlog-release` carrying the swept-entry count (#7061); an idempotent no-op flip
+// emits nothing (#1696).
+describe("resolveTandem — promotion ceremony bildirimleri (#1696, #7061)", () => {
 	const promotionRecording = () => {
 		const emits: NotificationRecordInput[] = [];
 		const layer = makeNotificationStub({
@@ -169,7 +170,7 @@ describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
 		return {layer, emits};
 	};
 
-	it.effect("a landed flip emits one terfi notification for the promoted çaylak", () => {
+	it.effect("a landed flip emits terfi + backlog-release (count 0 — empty backlog)", () => {
 		const {layer, emits} = promotionRecording();
 		return Effect.gen(function* () {
 			yield* resolveTandem("u-caylak");
@@ -180,6 +181,14 @@ describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
 					targetKind: "user",
 					targetId: "u-caylak",
 					actorId: null,
+				},
+				{
+					recipientId: "u-caylak",
+					kind: BACKLOG_RELEASE_KIND,
+					targetKind: "user",
+					targetId: "u-caylak",
+					actorId: null,
+					count: 0,
 				},
 			]);
 		}).pipe(


### PR DESCRIPTION
Adds the `backlog-release` felt moment (R1.1 on #7049): when a çaylak is promoted to yazar, the promotion sweep now tells them what went public.

- `backlog-release` appended to `NOTIFICATION_KINDS`; the client `KIND_COPY` arm sources both copies from a typed two-field object (`zero` + `some`), so the map compiles only with both arms present and "0 yazınız…" is unrepresentable.
- Non-zero copy is the ruled string ("3 yazınız artık herkese açık", per https://github.com/kamp-us/phoenix/issues/7049#issuecomment-5388192975); a zero-entry sweep renders "bundan sonra yazılarınız herkese açık".
- `notifyBacklogRelease` emits once per promoted user from both promotion sites (mod-direct `user.promote` and the vouch tandem), keyed on `promoted` after the atomic tier-flip batch commits, carrying `sweptEntryCount(sweep)` — a new domain helper on `SandboxSweep` beside `isEmptySweep`. A zero-entry promotion still emits, with count 0, so the zero arm has a row to render.
- Gated on `bildirimOn` like every sibling emitter; failures swallowed at the seam, so a dying write can never fail the committed flip. Ships dark.

TDD: copy arms, emitter, and both call sites covered red-first in `bildirim.test.ts`, `rite-emitters.unit.test.ts`, `promotion-mutation.unit.test.ts`, `tandem.unit.test.ts`.

Fixes #7061

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #7061 names the new kind, copy, and emitter. **Did:** widened the exact-emit `deepStrictEqual` assertions in `promotion-mutation.unit.test.ts` and `tandem.unit.test.ts` to expect the new backlog-release emit beside terfi. **Why:** those tests assert the full ordered emit list, so the deliberately added emit fails them as written. **Disposition:** stated here.
