### PR TITLE
fix: Requiring the floor check froze the merge queue — the workflow never runs on merge_group

### DIFF
--- a/.github/workflows/governance-floor.yml
+++ b/.github/workflows/governance-floor.yml
@@ -27,6 +27,12 @@ name: governance-floor
 # this job passes on.
 on:
   pull_request:
+  # `governance floor at head` is bound for the ruleset's required set, and the merge queue awaits a
+  # required context on the batched `merge_group` ref — which only a `merge_group:` trigger reaches.
+  # Without this arm the flip froze every merge in the repo for ~40 minutes on 2026-08-21 (#6968),
+  # the same failure ADR 0132 records for `ci-required`. The batch is served by the `batch` job
+  # below, never by `floor`: a batch ref has no `github.event.pull_request` to resolve a floor over.
+  merge_group:
 
 # Least-privilege: the job checks out the repo and reads the PR's metadata, changed files, comments,
 # reviews and the comment authors' repository permission (the ADR 0055 write+ gate), and writes the
@@ -43,6 +49,7 @@ concurrency:
 jobs:
   floor:
     name: a governance-root diff carries a governance verdict at its head
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       # `fetch-depth: 0`, not the action's default 1. Under ADR 0276 `ship floor` resolves a
@@ -77,3 +84,40 @@ jobs:
             ${{ github.event.pull_request.number }} \
             --sha ${{ github.event.pull_request.head.sha }} \
             --publish-check
+
+  # The queue's half of the same context. `floor` above cannot serve it: on a `merge_group` event
+  # `github.event.pull_request` is empty, so it would ask the verb about PR #0 at an empty head.
+  #
+  # This job publishes the row and derives nothing, because a batch ref carries nothing to derive
+  # from — no PR number, no comments, no reviews. The floor is still held where it was: each PR in
+  # the batch was gated at its own head by the `floor` job, and `ship gate` refuses a governance-root
+  # PR whose verdict is absent, stale or FAIL before `ship enqueue` is reached. `floor-batch` is a
+  # verb, not a bash decision, so the required context's NAME lives once in `CHECK_RUN_NAME` — a job
+  # named after it here would be a second copy that nothing reds when it drifts (ADR 0228, #6968).
+  #
+  # The default shallow checkout is enough: nothing here reads git history.
+  batch:
+    name: the batch ref carries the floor's context by construction
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Same relay contract as the PR job: exit 0 means the check-run landed, and a non-zero means it
+      # could not be published — UNKNOWN, so the job reds and the queue holds rather than merging.
+      - name: Publish the floor's required context on the batch ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_PIPELINE_REPO: ${{ github.repository }}
+        run: |
+          node packages/fabrika-cli/src/bin.ts ship floor-batch \
+            --sha ${{ github.event.merge_group.head_sha }}

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -43,6 +43,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `ship cp-approval` | the ADR 0175 cardinality discharge: `discharge` / `stop` / `n/a` from head-bound signals only | the roster-cardinality case split and head-binding are a transcription of a ruled table; nothing in it is judgment (#2435 is what judgment did) |
 | `ship gate` | the verdict conjunction: every required namespace's in-force, current-head verdict, §CP advisory resolution and native-review fold included | in-force resolution (write-stamp ordering, staleness, authorization) is mechanical; what to do with `blocked` is judgment |
 | `ship floor` | whether the governance floor binds on this diff and is discharged at this head — `n/a` / `satisfied` / a refusal CI reds on | asking `ship gate` for the one `governance` namespace and seating the answer on an exit code is mechanical; nothing about the verdict itself is decided here |
+| `ship floor-batch` | the same required context on a merge queue's batched `merge_group` head, concluded success — the batch ref has no pull request to resolve a floor over | publishing a named row is mechanical; the verb decides nothing, and what the floor means was settled at each PR's own head |
 | `ship checks` | the head CI rollup — green/red/pending with the running/wedged split and the zero-checkset facts; `--wait` adds the bounded settle poll | latest-per-context dedupe, status vocabulary, and a budgeted poll are mechanical; the wedge remedy is a human's |
 | `ship evidence` | the SHA-bound run-evidence bundle read as five states: present / pending / failed / absent / unknown | the lookup chain and the positive-evidence rules for each state are mechanical; none of it is judgment |
 | `ship threads` | every unresolved review thread, fully paginated, with per-thread class facts | pagination, count proof, and author-type classification are mechanical; nit-vs-substantive is THE retained judgment and never enters this verb |
@@ -888,10 +889,11 @@ the comment authors' ACL). Both scanned counts reach stderr, this verb's first.
 **Where it is enforced.** `.github/workflows/governance-floor.yml`, job `floor`, on every
 `pull_request` with no `paths:` filter — the verb's own read of the changed files is the path
 decision, so there is no YAML copy of the root list to drift. The job runs `--publish-check` and
-relays what the verb did, deciding nothing. Making the `governance floor at head` context
-**required** is a repository-ruleset change and therefore a human's; until it is, the check is
-visible-but-not-blocking at the ruleset, which is a weaker state than the ruling asks for and is
-recorded here rather than glossed.
+relays what the verb did, deciding nothing. The queue's half of the same context is the `batch` job,
+which runs [`ship floor-batch`](#ship-floor-batch) on `merge_group`. Making the `governance floor at
+head` context **required** is a repository-ruleset change and therefore a human's; until it is, the
+check is visible-but-not-blocking at the ruleset, which is a weaker state than the ruling asks for
+and is recorded here rather than glossed.
 
 **Examples**
 
@@ -943,6 +945,122 @@ $ echo $?
   rather than re-derived, which is what makes an unauthorized or stale PASS red here.
 - ADR 0092 — an unreadable answer reds. `11` and `13` are not softer than `18`; they are a different
   fact, and neither is a pass.
+
+---
+
+<a id="ship-floor-batch"></a>
+
+## `ship floor-batch`
+
+**Invocation**
+
+```
+fabrika ship floor-batch --sha 03135b91 [--repo <owner/name>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--sha` | string | yes | — | the batch head — `github.event.merge_group.head_sha`, the commit that actually merges |
+| `--repo` | string | no | resolved | the repository |
+| `--json` | boolean | no | `false` | emit the result object |
+
+There is no PR argument, and its absence is the point: a `merge_group` ref is not a pull request.
+
+**Output** — three lines, the same grammar the check-run mode prints:
+
+```
+check	completed	success	<check-run id>
+floor	batch	<sha>
+ns	governance	-
+```
+
+`batch` is the one floor word no diff produces. With `--json`, an object with keys `outcome`, `sha`,
+`namespace`, `state` (always `null`) and `checkRun` (`{id, name, status, conclusion}`).
+
+### Why the batch ref gets a pass, and what still holds the floor
+
+A required status check is demanded on the queue's batched `merge_group` ref, and a workflow only
+runs there if it carries a `merge_group:` trigger (ADR [0132](../../../../.decisions/0132-merge-queue-for-base-freshness.md), §CI-under-batch). `governance-floor.yml` had `pull_request:` alone, so when `governance floor at
+head` was added to the ruleset's required set on 2026-08-21 the batch could never carry the context
+and every queued merge in the repository hung toward the check timeout — a ~40-minute freeze, ended
+by reverting the flip (#6968). It is the identical failure ADR 0132 records for `ci-required`.
+
+**This verb resolves no floor, because a batch ref carries nothing to resolve one from.** It has no
+number, no changed-file list against the base a verdict was written over, no comments and no reviews.
+`ship floor` reads all four, so on a batch it has no input at all — the pass here is the absence of a
+question, not a question waved through.
+
+**The floor is held where it always was, at the PR ref, by two independent things:**
+
+- each PR in a batch was floor-gated at its own head by `ship floor --publish-check`, the `floor` job;
+- `ship gate` — the single merge authority — refuses a governance-root PR whose `governance` verdict
+  is `absent`, `stale` or `fail`, and the `ship` skill runs it before `ship enqueue` is reached.
+
+**Why a verb and not a job named after the context.** A branch protection matches a required check by
+name. Naming a `merge_group`-only job `governance floor at head` would satisfy the queue with no CLI
+change — and would put a second copy of `CHECK_RUN_NAME` in YAML that nothing reds when it drifts
+(the #4604 failure class, and ADR 0228's rule that a workflow step relays and never decides). It
+would also stack a second check of that name on every PR ref, since a job skipped by its `if:` still
+reports; a required context resolved from two producers is exactly the ambiguity this floor cannot
+afford. So the name stays in one place and the workflow relays a verb.
+
+**One row per head** and the read-back are `ship floor --publish-check`'s, shared rather than copied
+— `publishFloorCheck` in `ship/floor-check.ts` is the single implementation.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `1` | usage: `--sha` is not 7–40 lowercase hex, or no target repository resolves |
+| `8` | the check-run could not be written |
+| `9` | the check-run landed and GitHub echoed a state this run did not decide |
+| `11` | the check-runs at the head could not be enumerated, so nothing was published rather than a duplicate row |
+
+There is no `18` here and no state that reds on the floor's own polarity: this verb has no polarity
+to report. A non-zero means the context could not be published, which leaves the queue's required
+check missing — it holds rather than merges, which is the fail-closed direction.
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `ship floor-batch: --sha "<raw>" is not 7-40 lowercase hex — an empty or malformed SHA is a usage error, never a pattern that matches every head.` | 1 | refusal |
+| `ship floor-batch: cannot enumerate the check runs at <sha>: <reason> — nothing was published, so the floor stays UNKNOWN rather than posting a duplicate row.` | 11 | refusal |
+| `ship floor-batch: the check-run could not be written: <reason> — the floor is resolved and nothing published it.` | 8 | refusal |
+| `ship floor-batch: wrote <status>/<conclusion> to check-run <id> and GitHub echoed <status>/<conclusion> — what the PR shows is not what this run decided.` | 9 | refusal |
+| `ship floor-batch: posted check-run <id> at <sha> — the batch carries the context; no floor was resolved on it.` | 0 | notice |
+| `ship floor-batch: rewrote check-run <id> at <sha> — the batch carries the context; no floor was resolved on it.` | 0 | notice |
+
+**Scope** — the check-runs already at the batch head, and nothing else. No pull-request surface is
+read, and a unit test asserts that absence rather than assuming it.
+
+**Where it is enforced.** `.github/workflows/governance-floor.yml`, job `batch`, gated
+`if: github.event_name == 'merge_group'`. The `floor` job is gated to `pull_request` in the same
+change, so a batch event can never reach it with an empty `github.event.pull_request`.
+
+**Examples**
+
+```
+$ fabrika ship floor-batch --sha 03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c
+ship floor-batch: posted check-run 48899104 at 03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c — the batch carries the context; no floor was resolved on it.
+check	completed	success	48899104
+floor	batch	03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c
+ns	governance	-
+$ echo $?
+0
+```
+
+**Grounding**
+
+- #6968 — the freeze. Adding the context to the ruleset with no `merge_group:` arm on its producer
+  froze every merge in the repository until the flip was reverted.
+- ADR 0132, §CI-under-batch — "You **must** use the `merge_group` event to trigger your GitHub
+  Actions workflow when a pull request is added to a merge queue"; `ci.yml` and `leak-guard.yml` are
+  the in-repo precedents.
+- ADR 0318 — the check-run mechanism this verb reuses, name and read-back included.
+- ADR 0228 — the workflow relays; the name and the decision both live in the verb.
 
 ---
 

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -19,6 +19,7 @@ import {runCpApproval} from "./cp-approval-verb.ts";
 import {runDisarm} from "./disarm-verb.ts";
 import {runEnqueue} from "./enqueue-verb.ts";
 import {runEvidence} from "./evidence-verb.ts";
+import {runFloorBatch} from "./floor-batch.ts";
 import {floorRunner} from "./floor-check.ts";
 import {runGate} from "./gate-verb.ts";
 import {runMerge} from "./merge-verb.ts";
@@ -165,6 +166,23 @@ const floor = leafCommand(
 	Command.withShortDescription("Whether a governance-root diff carries its governance verdict."),
 	Command.withDescription(
 		"Decide whether the governance floor binds on this PR at one head, and seat the answer on an exit code a CI job can red on. Prints `floor\\t<satisfied|n/a>\\t<sha>` then `ns\\tgovernance\\t<pass|->`; `n/a` is a proven answer about the diff — it touches no governance root — and never a discharged verdict. The verdict itself is `ship gate`'s, asked for the one `governance` namespace, so this is not a second conjunction and it decides nothing about enqueue. Exits 7 (PR proven absent or closed, or zero changed files), 11 (the PR, its file list or the conjunction could not be read — the floor is UNKNOWN, never n/a), 13 (the changed-file enumeration is provably short — a governance root could sit in the part nobody read), 18 (the diff touches a governance root and its governance verdict is absent, stale or fail — the one refusal that means a human owes this PR a verdict, #5408). With --publish-check the same answer is seated on a check-run named `governance floor at head` instead (`checks: write` required): `satisfied`/`n/a` conclude success, `absent` leaves the check-run in_progress so \"no verdict yet\" reads as waiting rather than as a failure, `stale`/`fail` conclude failure, and UNKNOWN concludes failure too (ADR 0092). In that mode the process exits 0 whenever the check-run landed — a non-zero means the verb could not publish, never that the floor is unmet — and it seats 8 (the check-run could not be written) and 9 (GitHub echoed a state this run did not decide). Every other caller's exit semantics are unchanged (#6161). Example: fabrika ship floor 4321 --sha 03135b91",
+	),
+);
+
+const floorBatch = leafCommand(
+	"floor-batch",
+	{
+		sha: shaFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({sha, repo, json}) {
+		yield* emit(yield* runFloorBatch({sha, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Put the floor's required context on a merge queue's batch ref."),
+	Command.withDescription(
+		"Publish the `governance floor at head` check-run on a merge queue's batched `merge_group` head, concluded success (`checks: write` required). Prints `check\\t<status>\\t<conclusion>\\t<id>`, then `floor\\tbatch\\t<sha>` and `ns\\tgovernance\\t-`. It takes no PR number and resolves no floor, because a batch ref is not a pull request: no number, no comments, no reviews, so `ship floor` has no input on it at all. What holds the floor is unchanged — each PR in the batch was gated at its own head by `ship floor --publish-check`, and `ship gate` refuses a governance-root PR whose governance verdict is absent, stale or fail before `ship enqueue` is reached. Without this a workflow triggered on `pull_request` alone can never carry the required context on the batch and every queued merge hangs (ADR 0132; the 2026-08-21 freeze, #6968). Exits 1 (usage: --sha is not 7-40 lowercase hex, or no target repo resolves), 8 (the check-run could not be written), 9 (GitHub echoed a state this run did not decide), 11 (the check-runs at the head could not be enumerated, so nothing was published rather than a duplicate row). Example: fabrika ship floor-batch --sha 03135b91",
 	),
 );
 
@@ -418,6 +436,7 @@ export const shipCommand = Command.make("ship").pipe(
 		cpApproval,
 		gate,
 		floor,
+		floorBatch,
 		checks,
 		evidence,
 		threads,

--- a/packages/fabrika-cli/src/ship/floor-batch.ts
+++ b/packages/fabrika-cli/src/ship/floor-batch.ts
@@ -1,0 +1,82 @@
+/**
+ * `ship floor-batch` — the `governance floor at head` context on a merge queue's batch ref.
+ *
+ * A required status check is demanded on the queue's batched `merge_group` ref, not only on the PR
+ * ref, and a workflow only runs there if it carries a `merge_group:` trigger. `governance-floor.yml`
+ * had `pull_request:` alone, so the moment the floor was added to the ruleset's required set the
+ * batch could never carry the context and every queued merge hung toward the check timeout — the
+ * repo-wide freeze of 2026-08-21 (#6968). ADR 0132 records the identical failure for `ci-required`.
+ *
+ * **The batch ref has nothing to re-derive, so this verb resolves no floor.** A `merge_group` ref is
+ * not a pull request: it has no number, no changed-file list against a base a verdict was written
+ * over, no comments and no reviews. `ship floor` reads all four, so on a batch it has no input at
+ * all — the pass here is the absence of a question, not a question waved through.
+ *
+ * **What still holds the floor is the PR ref.** Each PR in a batch was floor-gated at its own head
+ * by `ship floor --publish-check`, and `ship gate` — the single merge authority — refuses a
+ * governance-root PR whose `governance` verdict is absent, stale or FAIL before `ship enqueue` is
+ * ever reached. Nothing about that changes here; this verb only puts the context where the queue
+ * looks for it.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {type CheckPlan, publishFloorCheck} from "./floor-check.ts";
+import {NAMESPACE} from "./floor-verb.ts";
+import {inspectedSha, NULL_TOKEN, resolveTargetRepo} from "./target.ts";
+
+const VERB = "ship floor-batch";
+
+export interface FloorBatchOptions {
+	/** The batch head — `github.event.merge_group.head_sha`, the commit that actually merges. */
+	readonly sha: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * The one plan this verb writes, as a value rather than a branch — there is no state to read, so a
+ * conditional here could only be a second answer about a ref that carries no question.
+ */
+export const BATCH_PLAN: CheckPlan = {
+	_tag: "Concluded",
+	conclusion: "success",
+	floor: "batch",
+	title: "The floor is not owed on a batch ref",
+	summary:
+		"A merge queue batch ref is not a pull request — no number, no comments, no reviews — so there is no governance verdict on it to read and nothing for `ship floor` to resolve. Every pull request in this batch was floor-gated at its own head by the same check-run, and `ship gate` refuses to enqueue a governance-root PR whose governance verdict is absent, stale or FAIL. This row puts the required context where the queue looks for it; it discharges nothing (ADR 0132, #6968).",
+};
+
+export const runFloorBatch = (
+	options: FloorBatchOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const bound = inspectedSha(VERB, options.sha);
+		if (typeof bound !== "string") return bound;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const published = yield* publishFloorCheck(VERB, resolved.repo, bound, BATCH_PLAN, []);
+		if (published._tag === "Refused") return published.outcome;
+		const {written, rewritten} = published;
+
+		const posted = `${VERB}: ${rewritten ? "rewrote" : "posted"} check-run ${written.id} at ${bound} — the batch carries the context; no floor was resolved on it.`;
+		return answer(
+			options.json
+				? JSON.stringify({
+						outcome: BATCH_PLAN.floor,
+						sha: bound,
+						namespace: NAMESPACE,
+						state: null,
+						checkRun: {
+							id: written.id,
+							name: written.name,
+							status: written.status,
+							conclusion: written.conclusion,
+						},
+					})
+				: `check\t${written.status}\t${written.conclusion ?? NULL_TOKEN}\t${written.id}\nfloor\t${BATCH_PLAN.floor}\t${bound}\nns\t${NAMESPACE}\t${NULL_TOKEN}`,
+			[posted],
+		);
+	});

--- a/packages/fabrika-cli/src/ship/floor-batch.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/floor-batch.unit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The batch verb's whole job is to put ONE named row on a ref, so the battery pins the two things a
+ * frozen merge queue would turn on: the row carries the name a branch protection matches, and no
+ * request to any pull-request surface is made on the way — a batch ref has none to read (#6968).
+ */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeSeams, type HttpReply, type Scripted, unconfigured} from "../fakes.test-support.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {checkRuns, ENV, HEAD} from "./fixtures.test-support.ts";
+import {BATCH_PLAN, runFloorBatch} from "./floor-batch.ts";
+import {CHECK_RUN_NAME} from "./floor-check.ts";
+
+const HEAD_CHECKS = /^GET \S+\/repos\/o\/r\/commits\/[0-9a-f]+\/check-runs\?/;
+const CREATE = /^POST \S+\/repos\/o\/r\/check-runs$/;
+const UPDATE = /^PATCH \S+\/repos\/o\/r\/check-runs\/\d+$/;
+
+const echoed = (status: string, conclusion: string | null, id = 77): HttpReply => ({
+	status: 201,
+	body: JSON.stringify({id, name: CHECK_RUN_NAME, status, conclusion}),
+});
+
+const NO_HELD_CHECK: Scripted = [
+	HEAD_CHECKS,
+	{
+		status: 200,
+		body: checkRuns(1, [{name: "ci", status: "completed", conclusion: "success"}]).stdout,
+	},
+];
+
+const options = {sha: HEAD, repo: null, json: false, env: ENV};
+
+const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options> = {}) => {
+	const seams = fakeSeams([...script]);
+	return Effect.runPromise(
+		Effect.provide(
+			runFloorBatch({...options, ...overrides}),
+			Layer.merge(seams.layer, unconfigured),
+		),
+	).then((outcome) => ({outcome, seams}));
+};
+
+const written = (seams: {
+	readonly requests: ReadonlyArray<string>;
+	readonly bodies: ReadonlyArray<string>;
+}) => {
+	const at = seams.requests.findIndex((call) => CREATE.test(call) || UPDATE.test(call));
+	return at === -1 ? null : JSON.parse(seams.bodies[at] ?? "{}");
+};
+
+describe("runFloorBatch publishes the required context and reads nothing about a PR", () => {
+	it("posts the floor's own check-run name, concluded success, at the batch head", async () => {
+		const {outcome, seams} = await run([NO_HELD_CHECK, [CREATE, echoed("completed", "success")]]);
+		expect(outcome.code).toBe(0);
+		expect(written(seams)).toMatchObject({
+			name: CHECK_RUN_NAME,
+			head_sha: HEAD,
+			status: "completed",
+			conclusion: "success",
+		});
+		expect(outcome.stdout).toContain(`floor\tbatch\t${HEAD}`);
+	});
+
+	// The freeze this verb exists to prevent came from a job asking `ship floor` about a PR that is
+	// not there. Reading the PR, its files, its comments or its reviews here would be that same bug
+	// with a different spelling, so the absence is asserted rather than assumed.
+	it("touches no pull-request surface — a batch ref has none", async () => {
+		const {seams} = await run([NO_HELD_CHECK, [CREATE, echoed("completed", "success")]]);
+		expect(seams.requests.filter((call) => /\/pulls\/|\/issues\//.test(call))).toEqual([]);
+	});
+
+	it("rewrites the row this head already carries instead of posting a second one", async () => {
+		const {outcome, seams} = await run([
+			[
+				HEAD_CHECKS,
+				{
+					status: 200,
+					body: checkRuns(1, [
+						{name: CHECK_RUN_NAME, status: "completed", conclusion: "success", id: 12},
+					]).stdout,
+				},
+			],
+			[UPDATE, echoed("completed", "success", 12)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(seams.requests.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("refuses without publishing when the head's check-runs cannot be enumerated", async () => {
+		const {outcome, seams} = await run([[HEAD_CHECKS, {status: 500, body: "boom"}]]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(written(seams)).toBeNull();
+	});
+
+	it("refuses when the write fails", async () => {
+		const {outcome} = await run([NO_HELD_CHECK, [CREATE, {status: 500, body: "boom"}]]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("refuses when GitHub echoes a state this run did not decide", async () => {
+		const {outcome} = await run([NO_HELD_CHECK, [CREATE, echoed("completed", "failure")]]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses a malformed --sha rather than matching every head", async () => {
+		const {outcome, seams} = await run([], {sha: ""});
+		expect(outcome.code).toBe(1);
+		expect(seams.requests).toEqual([]);
+	});
+});
+
+describe("BATCH_PLAN says what it is and what it is not", () => {
+	it("concludes success and names itself batch, never a discharged verdict", () => {
+		expect(BATCH_PLAN).toMatchObject({_tag: "Concluded", conclusion: "success", floor: "batch"});
+		expect(BATCH_PLAN.summary).toContain("discharges nothing");
+	});
+});

--- a/packages/fabrika-cli/src/ship/floor-check.ts
+++ b/packages/fabrika-cli/src/ship/floor-check.ts
@@ -36,6 +36,7 @@ import {
 	latestPerContext,
 	listShipCheckRuns,
 	updateCheckRun,
+	type WrittenCheckRun,
 } from "./github.ts";
 import {inspectedSha, NULL_TOKEN, resolveTargetRepo} from "./target.ts";
 
@@ -50,8 +51,13 @@ const VERB = "ship floor --publish-check";
  */
 export const CHECK_RUN_NAME = "governance floor at head";
 
-/** The floor word the payload carries — what was decided, beside how the check-run seats it. */
-export type FloorWord = "n/a" | "satisfied" | "blocked" | "unresolved";
+/**
+ * The floor word the payload carries — what was decided, beside how the check-run seats it.
+ *
+ * `batch` is the one word no diff produces: it is `ship floor-batch`'s answer about a merge-queue
+ * batch ref, which carries no pull request to resolve a floor over (`./floor-batch.ts`).
+ */
+export type FloorWord = "n/a" | "satisfied" | "blocked" | "unresolved" | "batch";
 
 /**
  * What to write, in the two shapes the platform distinguishes.
@@ -141,6 +147,90 @@ const draftFor = (plan: CheckPlan, headSha: string): CheckRunDraft =>
 				summary: plan.summary,
 			};
 
+/**
+ * What {@link publishFloorCheck} did, in the two shapes its caller routes on.
+ *
+ * The rendering stays outside: the two callers print different line grammars over the same write —
+ * the PR mode carries the resolved `governance` row, `ship floor-batch` has no namespace to report —
+ * and folding both in would put a second answer about the floor inside the thing that only publishes.
+ */
+export type Publication =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Written"; readonly written: WrittenCheckRun; readonly rewritten: boolean};
+
+/**
+ * Write one {@link CheckPlan} to a head as the `governance floor at head` check-run.
+ *
+ * Shared by the PR mode and `./floor-batch.ts` so the name, the one-row-per-head invariant and the
+ * read-back have one implementation. A branch protection matches a required context by name, so two
+ * copies of this drifting apart is a frozen merge queue rather than a cosmetic difference (#6968).
+ */
+export const publishFloorCheck = (
+	verb: string,
+	repo: string,
+	headSha: string,
+	plan: CheckPlan,
+	relayed: ReadonlyArray<string>,
+): Effect.Effect<Publication, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		// A check-run this head already carries is rewritten rather than duplicated, so the PR shows
+		// one row per head instead of a column of superseded ones. The exception is the backwards
+		// transition — a completed check-run being re-opened as pending — which the platform does not
+		// model: a `conclusion` already set is not cleared by an update, so that one posts a fresh run.
+		const listed = yield* listShipCheckRuns(repo, headSha);
+		if (listed._tag === "Failure") {
+			// An unreadable list is not a head carrying no row: collapsing the two would post a second
+			// check-run and quietly break the one-row-per-head invariant above. Every sibling reader of
+			// this seam refuses here too (`ship checks`, `heal-ci surface`, `governance post`), so the
+			// group holds one disposition for one read (#6161).
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot enumerate the check runs at ${headSha}: ${listed.reason} — nothing was published, so the floor stays UNKNOWN rather than posting a duplicate row.`,
+					relayed,
+				),
+			};
+		}
+		const held =
+			latestPerContext(listed.value.runs).find((run) => run.name === CHECK_RUN_NAME) ?? null;
+		const rewritable = held !== null && !(held.status === "completed" && plan._tag === "Pending");
+
+		const draft = draftFor(plan, headSha);
+		const written = yield* rewritable && held !== null
+			? updateCheckRun(repo, held.id, draft)
+			: createCheckRun(repo, draft);
+		if (written._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					WRITE_UNKNOWN,
+					`${verb}: the check-run could not be written: ${written.reason} — the floor is resolved and nothing published it.`,
+					relayed,
+				),
+			};
+		}
+
+		const expectedStatus = plan._tag === "Pending" ? "in_progress" : "completed";
+		const expectedConclusion = plan._tag === "Pending" ? null : plan.conclusion;
+		if (
+			written.value.name !== CHECK_RUN_NAME ||
+			written.value.status !== expectedStatus ||
+			written.value.conclusion !== expectedConclusion
+		) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					READBACK_MISMATCH,
+					`${verb}: wrote ${expectedStatus}/${expectedConclusion ?? NULL_TOKEN} to check-run ${written.value.id} and GitHub echoed ${written.value.status}/${written.value.conclusion ?? NULL_TOKEN} — what the PR shows is not what this run decided.`,
+					relayed,
+				),
+			};
+		}
+
+		return {_tag: "Written" as const, written: written.value, rewritten: rewritable};
+	});
+
 const stateOf = (resolution: FloorResolution): string =>
 	resolution._tag === "Bound" ? resolution.state : NULL_TOKEN;
 
@@ -169,53 +259,11 @@ export const runFloorCheck = (
 		const relayed =
 			resolution._tag === "Unresolved" ? resolution.outcome.stderr : [...resolution.stderr];
 
-		// A check-run this head already carries is rewritten rather than duplicated, so the PR shows
-		// one row per head instead of a column of superseded ones. The exception is the backwards
-		// transition — a completed check-run being re-opened as pending — which the platform does not
-		// model: a `conclusion` already set is not cleared by an update, so that one posts a fresh run.
-		const listed = yield* listShipCheckRuns(repo, bound);
-		if (listed._tag === "Failure") {
-			// An unreadable list is not a head carrying no row: collapsing the two would post a second
-			// check-run and quietly break the one-row-per-head invariant above. Every sibling reader of
-			// this seam refuses here too (`ship checks`, `heal-ci surface`, `governance post`), so the
-			// group holds one disposition for one read (#6161).
-			return refuse(
-				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot enumerate the check runs at ${bound}: ${listed.reason} — nothing was published, so the floor stays UNKNOWN rather than posting a duplicate row.`,
-				relayed,
-			);
-		}
-		const held =
-			latestPerContext(listed.value.runs).find((run) => run.name === CHECK_RUN_NAME) ?? null;
-		const rewritable = held !== null && !(held.status === "completed" && plan._tag === "Pending");
+		const published = yield* publishFloorCheck(VERB, repo, bound, plan, relayed);
+		if (published._tag === "Refused") return published.outcome;
+		const {written, rewritten} = published;
 
-		const draft = draftFor(plan, bound);
-		const written = yield* rewritable && held !== null
-			? updateCheckRun(repo, held.id, draft)
-			: createCheckRun(repo, draft);
-		if (written._tag === "Failure") {
-			return refuse(
-				WRITE_UNKNOWN,
-				`${VERB}: the check-run could not be written: ${written.reason} — the floor is resolved and nothing published it.`,
-				relayed,
-			);
-		}
-
-		const expectedStatus = plan._tag === "Pending" ? "in_progress" : "completed";
-		const expectedConclusion = plan._tag === "Pending" ? null : plan.conclusion;
-		if (
-			written.value.name !== CHECK_RUN_NAME ||
-			written.value.status !== expectedStatus ||
-			written.value.conclusion !== expectedConclusion
-		) {
-			return refuse(
-				READBACK_MISMATCH,
-				`${VERB}: wrote ${expectedStatus}/${expectedConclusion ?? NULL_TOKEN} to check-run ${written.value.id} and GitHub echoed ${written.value.status}/${written.value.conclusion ?? NULL_TOKEN} — what the PR shows is not what this run decided.`,
-				relayed,
-			);
-		}
-
-		const posted = `${VERB}: ${rewritable ? "rewrote" : "posted"} check-run ${written.value.id} — the job's own exit code no longer carries the floor (#6161).`;
+		const posted = `${VERB}: ${rewritten ? "rewrote" : "posted"} check-run ${written.id} — the job's own exit code no longer carries the floor (#6161).`;
 		return answer(
 			options.json
 				? JSON.stringify({
@@ -224,13 +272,13 @@ export const runFloorCheck = (
 						namespace: NAMESPACE,
 						state: resolution._tag === "Bound" ? resolution.state : null,
 						checkRun: {
-							id: written.value.id,
-							name: written.value.name,
-							status: written.value.status,
-							conclusion: written.value.conclusion,
+							id: written.id,
+							name: written.name,
+							status: written.status,
+							conclusion: written.conclusion,
 						},
 					})
-				: `check\t${written.value.status}\t${written.value.conclusion ?? NULL_TOKEN}\t${written.value.id}\nfloor\t${plan.floor}\t${bound}\nns\t${NAMESPACE}\t${stateOf(resolution)}`,
+				: `check\t${written.status}\t${written.conclusion ?? NULL_TOKEN}\t${written.id}\nfloor\t${plan.floor}\t${bound}\nns\t${NAMESPACE}\t${stateOf(resolution)}`,
 			[...relayed, posted],
 		);
 	});


### PR DESCRIPTION
`governance-floor.yml` triggered on `pull_request` only. The moment `governance floor at head` was added to the ruleset's required set on 2026-08-21, the merge queue's batched `merge_group` ref could never carry that context and every queued merge in the repo hung toward the check timeout — a ~40 minute freeze, ended by reverting the flip. Same failure ADR 0132 records for `ci-required`.

This gives the workflow a `merge_group` arm so the flip is safe to retry. The flip itself is still a founder admin action and is not part of this PR.

**What changed**

- `governance-floor.yml` gains `merge_group:`. The existing `floor` job is gated to `pull_request`, so a batch event can never reach it with an empty `github.event.pull_request` — that would ask the verb about PR #0 at an empty head.
- A new `batch` job, gated to `merge_group`, runs a new verb `fabrika ship floor-batch --sha <merge_group.head_sha>`, which publishes the `governance floor at head` check-run on the batch head concluded success.
- `publishFloorCheck` is extracted out of `runFloorCheck` so both modes share one implementation of the check-run's name, the one-row-per-head rewrite and the read-back.
- Contract section + verb-inventory row in `skills/ship/contract.md`.

**Why a verb and not a job named after the context**

A job named `governance floor at head` would satisfy the queue with no CLI change. It would also put a second copy of `CHECK_RUN_NAME` in YAML that nothing reds when it drifts, and — since a job skipped by its `if:` still reports — stack a second check of that name on every PR ref. A required context resolved from two producers is exactly the ambiguity this floor cannot afford. So the name stays in the verb and the workflow relays it (ADR 0228).

**Why the batch pass is legitimate**

The batch ref has nothing to derive from: no PR number, no changed-file list against a base a verdict was written over, no comments, no reviews. `ship floor` reads all four, so on a batch it has no input at all — the pass is the absence of a question, not a question waved through. The floor is still held at the PR ref by two independent things: the `floor` job gates each PR at its own head, and `ship gate` (the single merge authority) refuses a governance-root PR whose `governance` verdict is absent, stale or FAIL, before `ship enqueue` is reached.

**Verification**

`build check` green on all three surfaces present in the diff (`code`, `workflows`, `prose`); `actionlint` clean. Full `fabrika-cli` suite: 7886 tests pass. Seven new unit tests on the batch verb, including one asserting it touches no pull-request surface at all.

## Deviations

- **Known defect left unfixed** — **Said:** acceptance criterion 3 asks for a merge-queue dry run on a non-governance-root PR completing without the required-context hang. **Did:** did not run it; opened as `Part of #6968` rather than `Fixes`. **Why:** the hang only reproduces once `governance floor at head` is back in the ruleset's required set, and that flip is a founder-only admin action the issue's own triage note keeps out of scope. The `batch` job does run on this PR's own trip through the queue, so the first real observation lands at merge. **Disposition:** stated here; the issue stays open for the founder's flip retry and the observation that goes with it.
- **Out-of-scope change** — **Said:** #6968 names `governance-floor.yml`. **Did:** also refactored `floor-check.ts` (extracted `publishFloorCheck`) and added a `ship floor-batch` leaf plus its contract section. **Why:** the batch arm has to publish the same check-run name, and sharing the one publisher is what keeps the two producers from drifting into a frozen queue — the failure class this PR exists to close. **Disposition:** stated here; covered by seven new unit tests and the full suite.
