### PR TITLE
docs(admin-grant): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/admin-grant/README.md
+++ b/packages/admin-grant/README.md
@@ -3,49 +3,60 @@
 Offline direct-D1 CLI that grants/revokes **platform-admin authority** and lists
 the current admins (issue #1236).
 
-Admin authority is the relation-backed `Admin` capability (ADR 0107): a subject
-is an admin iff it holds the `(subject, "admin", "platform:platform")` tuple in
-`relation_tuple`, which the worker's `Admin.over(platform)` discharge reads fresh
-per call. So granting/revoking admin is minting/dropping that one tuple. This is
-**not** better-auth's AC model — ADR 0107 supersedes ADR 0102's better-auth-AC
-authorization substrate; better-auth stays for authn + the user-management UI.
+## What it is
 
-It is granted only by a **server-side direct-D1 script, never a runtime worker
-route** — per CLAUDE.md's "Sözlük seed" section, the admin mutation routes were
-deleted as a fail-open hole, so the tuple is written by an operator who holds the
-D1 write token. There is no in-product way to make someone an admin; this package
-is that path. It is the `admin` twin of `@kampus/founder-seed` (which writes the
-`moderates` relation), authored as Node tooling — an Effect CLI
-(`effect/unstable/cli`) — not Python, not an ad-hoc script.
+Node tooling — an Effect CLI (`effect/unstable/cli`), the `admin` twin of
+[@kampus/founder-seed](../founder-seed/README.md) (which writes the `moderates`
+relation), not Python, not an ad-hoc script. Admin authority is the relation-backed
+`Admin` capability ([ADR 0107](../../.decisions/0107-capability-authz-framework.md)):
+a subject is an admin iff it holds the `(subject, "admin", "platform:platform")`
+tuple in `relation_tuple`, which the worker's `Admin.over(platform)` discharge reads
+fresh per call. So granting/revoking admin is minting/dropping that one tuple.
 
-## What it does
-
-| Command  | Effect                                                                  |
-| -------- | ----------------------------------------------------------------------- |
+| Command  | Effect                                                                           |
+| -------- | -------------------------------------------------------------------------------- |
 | `grant`  | mints `(subject, "admin", "platform:platform")` (by `--username` or `--user-id`) |
-| `revoke` | drops that tuple                                                        |
-| `list`   | prints the current admin subjects                                       |
+| `revoke` | drops that tuple                                                                 |
+| `list`   | prints the current admin subjects                                                |
 
-The selector is resolved to the subject's user id through the `user` table, so
-"no such user" (`subject: null`) reads distinctly from a real grant, and an admin
-tuple is never minted for a non-existent user. `grant` is idempotent
-(`onConflictDoNothing`), so a re-run reads `inserted: 0`.
+The surfaces a consumer touches, file by file:
 
-## Architecture
+- **`src/grant.ts`** — the pure, unit-tested core: `assignAdmin` / `revokeAdmin` /
+  `listAdmins` over a `D1Database` slice, plus `makeGrantDb`, the drizzle handle.
+  The object key is `@kampus/authz`'s canonical `key(platform)` — the SAME encoding
+  the worker's `RelationStoreLive` reads with, so a granted tuple is found by
+  `Admin.over(platform)` (the write→read seam). Re-exported through **`src/index.ts`**
+  together with the `ADMIN` / `PLATFORM` constants and the result types
+  (`AssignResult`, `RevokeResult`, `Selector`, …).
+- **`src/schema.ts`** — the `relation_tuple` + `user` columns this writes/reads (a
+  narrow local copy of the canonical `apps/web/worker/db/drizzle/schema.ts`, which is
+  not an exported subpath).
+- **`src/bin.ts`** — the `admin-grant grant|revoke|list` CLI the operator runs.
 
-A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
+The selector resolves to the subject's user id through the `user` table, so "no such
+user" (`subject: null`) reads distinctly from a real grant and no tuple is ever
+minted for a non-existent user. `grant` is idempotent (`onConflictDoNothing`), so a
+re-run reads `inserted: 0`.
 
-- `src/grant.ts` — the pure core: `assignAdmin`/`revokeAdmin`/`listAdmins` over a
-  `D1Database` slice. The object key is `@kampus/authz`'s canonical `key(platform)`,
-  the SAME encoding the worker's `RelationStoreLive` reads with, so a granted tuple
-  is found by `Admin.over(platform)` (the write→read seam).
-- `src/schema.ts` — the `relation_tuple` + `user` columns this writes/reads (a
-  narrow local copy of the canonical `apps/web/worker/db/drizzle/schema.ts`).
-- `src/bin.ts` — the `admin-grant grant|revoke|list` CLI.
+## Why it exists
 
-## Running it
+[ADR 0107](../../.decisions/0107-capability-authz-framework.md) made authority
+relation-backed, so an admin is exactly a tuple-holder — there is nothing else to
+flip. The tuple is granted only by a **server-side direct-D1 script, never a runtime
+worker route**: per [CLAUDE.md](../../CLAUDE.md)'s "Sözlük seed" section, the admin
+mutation routes were deleted as a fail-open hole, so the tuple is written by an
+operator who holds the D1 write token. There is no in-product way to make someone an
+admin; this package is that path. This is **not** better-auth's AC model — ADR 0107
+supersedes [ADR 0102](../../.decisions/0102-admin-via-better-auth-plugin.md)'s
+better-auth-AC authorization substrate; better-auth stays for authn + the
+user-management UI.
 
-Targets a **named stage's D1** (never prod-hardcoded).
+Scope: the CLI targets a **named stage's D1, never prod-hardcoded** — the caller
+supplies `--database-id` on every invocation.
+
+## How to use it
+
+Run the bin directly (or through the package's `grant` / `revoke` / `list` scripts):
 
 ```bash
 node packages/admin-grant/src/bin.ts grant  --username <handle> --database-id <stage-d1-uuid>
@@ -54,14 +65,36 @@ node packages/admin-grant/src/bin.ts revoke --username <handle> --database-id <s
 node packages/admin-grant/src/bin.ts list                       --database-id <stage-d1-uuid>
 ```
 
+Each run prints one line: `ok — …` on a change, `… was already an admin` /
+`… was not an admin` / `no user matched …` on a no-op, so every outcome reads
+distinctly.
+
+## Reference
+
+Flags and environment the bin reads:
+
 - `--database-id` (required) — the deployed stage's D1 UUID (resolve from the
   alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
 - `--username` / `--user-id` (`grant`/`revoke`) — pass exactly one; the selector
-  the grant is keyed on.
+  the grant is keyed on. Missing both fails with `SelectorRequired`.
 - `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
 - `$CLOUDFLARE_API_TOKEN` — the minted token (carries `D1 Write`); read by
   `CredentialsFromEnv`.
 
 Transport is the Cloudflare D1 REST query API via alchemy's already-installed
-`@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
-migrations to a deployed D1, so no new Cloudflare dependency and no workerd.
+`@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply migrations
+to a deployed D1, so no new Cloudflare dependency and no workerd. A rejected REST
+call surfaces as the bin's typed `D1RestError`, not an unhandled defect.
+
+## Testing
+
+```bash
+pnpm --filter @kampus/admin-grant test              # the unit tier — pure statement-building, boots no SQL engine
+pnpm --filter @kampus/admin-grant test:integration  # real remote Cloudflare D1 over the production REST transport
+pnpm --filter @kampus/admin-grant typecheck
+```
+
+Unit tests need nothing. Integration tests provision a per-file D1-only stack via
+alchemy's `Test.make` and migrate it with the worker's own migrations dir, so they
+require `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `ALCHEMY_PASSWORD` — CI
+secrets; off-CI they fail at `Unauthorized` by design.


### PR DESCRIPTION
docs(admin-grant): README truth re-ground + Diátaxis-lite structure pass

Re-grounds `packages/admin-grant/README.md` against the package's own source at
head and restructures it into the Diátaxis-lite shape pinned in
`.patterns/package-readme-shape.md`. Docs-only — nothing under
`packages/admin-grant/src/**` changes.

**Truth pass.** Every claim re-verified against `src/**` + `package.json`: commands,
flags (`--database-id`, `--username`/`--user-id`, `--account-id`), env vars
(`$CLOUDFLARE_API_TOKEN`, `$CLOUDFLARE_ACCOUNT_ID`), exports (`index.ts` unchanged
since the last truth pass), the tuple encoding via `key(platform)`, and the
write→read seam against the worker's `RelationStoreLive` / `Admin.over(platform)`.
No removed behaviour was claimed at head; the twin-package pointer was already fixed
by #6396. Additive sweep re-derived at head: commits touching the package after the
README's last truth pass (`d3d27bfdc`, 2026-06-27) are `bc441a56d` (drizzle rc.4
relations wiring — internal), `48c819bf0` (integration harness — tests),
`74edeef0e` (typed `SelectorRequired`/`D1RestError` faults in the bin), `49e6ea227`
(tsgo→tsc), `2c7e41eed` (comment pointers). None introduced a new public export,
CLI command/subcommand, flag, or config key; the typed-fault surfaces and the
distinct per-outcome CLI output lines are now described in the Reference section.
Newly represented: a **Testing** section (the package ships unit + integration
tiers the old README never mentioned) and the package scripts.

**Structure pass.** Canonical order applied: identity → *What it is* (explanation +
file-by-file surfaces) → *Why it exists* (ADR 0107 forcing constraint, scope and
non-goals) → *How to use it* (runnable commands) → reference tail → *Testing*.
Diátaxis classification over the result: single dominant mode (explanation) with
the pattern-sanctioned how-to/reference tails; no tutorial blended in, no
type-mixing flag.

**Verified in-tree:** `fabrika guard readme-guard check` green (all 18 packages
carry a README); `pnpm --filter @kampus/admin-grant typecheck` clean; unit tier
12/12 green; `node src/bin.ts` boots and its subcommand list matches the documented
commands exactly. The `grant`/`revoke`/`list` invocations themselves need real
stage-D1 credentials, which this lane does not hold; the printed blocks are verbatim
against `bin.ts`'s contract and unchanged from the previously verified form.

Fixes #4086

## Deviations

- **Governing-shape departure** — **Said:** the issue's truth-pass paragraph says to keep the same *What it does* / *Architecture* / *Running it* section names as the other grant CLIs so the family reads identically. **Did:** restructured to the canonical `.patterns/package-readme-shape.md` order (*What it is* / *Why it exists* / *How to use it* + reference/Testing tails) instead. **Why:** acceptance criterion 2 binds this README to the pattern file's canonical shape, and the pattern's own exemplars (cf-credentials, composer, depo) use that order; the sibling grant CLIs still on the older shape have their own lanes in epic #4073 and will converge there. **Disposition:** stated here.
- **Renamed gate invocation** — **Said:** the criteria name `pipeline-cli readme-guard check`. **Did:** ran `fabrika guard readme-guard check`. **Why:** that is the same fail-closed gate after the CLI's rename to `fabrika`; no separate pipeline-cli binary exists in the tree. **Disposition:** stated here.
