### PR TITLE
docs(authz): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -1,38 +1,38 @@
 # @kampus/authz
 
-The **vocab-free** capability-as-Effect authorization mechanism — [ADR 0107](../../.decisions/0107-capability-authz-framework.md).
-It names **no** kamp.us noun, no fate, no D1. The kamp.us capability instances
-(`OpenTerm`/`AddEntry`/`Moderate`/`Admin`), the wire-coded errors, and the `*Live`
-adapter Layers live in `features/kunye`, not here.
-
-> The shape of this mechanism — builder → discharge verb → sealed `Grant` → `Grant.provide`,
-> the compile-error guarantee, and the one audited cast — is the
-> [authz-capability-as-effect.md](../../.patterns/authz-capability-as-effect.md) pattern.
+The **vocab-free** capability-as-Effect authorization mechanism —
+[ADR 0107](../../.decisions/0107-capability-authz-framework.md).
 
 ## What it is
 
 A privileged op requires an unforgeable proof, `Grant`, in its requirements (R)
-channel. The only way to obtain one is to discharge a check; **omitting the proof is a
-compile error**. The proof flows through context via the single canonical
-`Grant.provide(grant)` — the `provideService` idiom of effect-smol's `HttpApiMiddleware`
-Authorization fixture (check → provide a typed proof), never a field on the op's domain
-input. (`Grant.provide` is generic over `Grant<C>`: it reads the capability `Context.Key`
-the grant carries and discharges it — one verb across every capability, not one per right.)
+channel. The only way to obtain one is to discharge a capability check;
+**omitting the proof is a compile error**. The proof flows through context via the
+single canonical `Grant.provide(grant)`, never a field on the op's domain input.
+Capabilities are **nominally distinct**: the sealed tag carries each capability's
+id literal, so `Grant<X>` is not `Grant<Y>` and a wrong-right proof is a compile
+error too (#1483, fixed in #1523).
 
-| Piece | Role |
-| --- | --- |
-| `Actor` | `Unauthenticated \| Authenticated(Human \| Agent)` — the dispatch root; the agent arm is the dormant v1 seam |
-| `Resource` | a generic recursive tree; `covers`/`ancestry` give relation authority its scope |
-| `Scale` (Level) | an ordered ladder with `gte` — the RBAC/MLS-shaped earned-standing axis |
-| `Relation` + `RelationStore` | the ReBAC `(subject, relation, object)` primitive + its storage-blind port |
-| `Grant` | the **sealed** proof: constructor never exported (the type + the `Grant.provide` discharge verb escape, never `mint`), **not** a `Schema` (a decodable proof would be forgeable) |
-| `Capability.Class` / `.Level` / `.Relation` | the class-as-capability builders — one declaration yields the proof tag, the `Grant` type, and the discharge verb (discharge into R is the shared `Grant.provide`) |
-| `CurrentActor` / `RelationStore` / `AgentAuthority` | the ports (`Context.Service`s), adapted in `features/kunye` |
+The shape of the mechanism — builder → discharge verb → sealed `Grant` →
+`Grant.provide`, the compile-error guarantee, and the one audited cast — is the
+[authz-capability-as-effect](../../.patterns/authz-capability-as-effect.md)
+pattern; read it there rather than here.
 
-Capabilities key off **`Context.Key<Self, Grant<Self>>`** (effect-smol v4) — `Context.Tag`
-is a v3 type that does not exist in v4.
+## Why it exists
 
-## Declaring a capability (in `features/kunye`)
+ADR 0107 makes "forgot to check" a compile error and lets authorization grow by
+adding modules, superseding the role-column and better-auth-AC approaches. This
+package is the mechanism half of that decision, and it is deliberately vocab-free:
+it names **no** kamp.us noun, no fate, no D1. The kamp.us capability instances
+(`OpenTerm`/`AddEntry`/`Moderate`/`Admin`), the wire-coded errors, and the `*Live`
+adapter Layers live in `features/kunye`, not here. The Human/Agent split is a
+dormant v1 seam: every discharge verb already routes the `Agent` arm through the
+`AgentAuthority` port, whose **v1 Layer is fail-closed** (no agent gets any
+authority) — v1.1 is that one Layer swapped, with no edit here.
+
+## How to use it
+
+Declare a capability (in `features/kunye`) and discharge it:
 
 ```ts
 class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
@@ -49,17 +49,35 @@ const grant = yield* OpenTerm.require;
 openTerm.pipe(Grant.provide(grant)); // R: never
 ```
 
-`.require` discharges a `Level`, `.over(resource)` a `Relation`, `.authorize(check)` the
-generic `Class`. Each dispatches exhaustively on the `Actor`: anonymous denies, a human
-checks directly, and an agent reads its human root's standing and consults
-`AgentAuthority` — whose **v1 Layer is fail-closed**, so v1 grants no agent any authority.
-v1.1 is that one Layer swapped, with no edit here.
+`.require` discharges a `Level`, `.over(resource)` a `Relation`, `.authorize(check)`
+the generic `Class`. Each dispatches exhaustively on the `Actor`: anonymous denies,
+a human checks directly, and an agent reads its human root's standing and consults
+`AgentAuthority`. `Grant.provide` is generic over `Grant<C>`: it routes by the
+capability key the grant itself carries — one verb across every capability, and a
+wrong-capability grant leaves the requirement unsatisfied and fails loud instead of
+silently passing.
 
-## Tests
+## Surface
 
-`pnpm test` — pure-primitive unit tests: the `Grant` seal, `Scale` ordering, `Resource`
-ancestry/covers, the builders' exhaustive Actor dispatch + `Grant` provision into context.
-`Capability.typetest.ts` is the compile-error assertion (checked by `pnpm typecheck`):
-omitting `Grant.provide` fails to compile. (`Grant.provide` routes each proof by the
-capability `Context.Key` the grant carries, so a wrong-capability grant fails to discharge
-at runtime; the type-level wrong-proof distinction is a known gap — see #1483.)
+| Piece | Role |
+| --- | --- |
+| `Actor` | `Unauthenticated \| Authenticated(Human \| Agent)` — the dispatch root; built with `unauthenticated`/`human(id)`/`agent(id, root)`, matched exhaustively with `matchActor` |
+| `Resource` | a generic recursive tree; `covers`/`ancestry` give relation authority its scope, `resource`/`key`/`platform`/`sameNode` build and compare nodes |
+| `Scale` (Level) | an ordered ladder with `gte` — the RBAC/MLS-shaped earned-standing axis |
+| `Relation` + `RelationStore` | the ReBAC `(subject, relation, object)` primitive + its storage-blind port: `has` (one tuple; discharge walks `ancestry`, asking once per ancestor), `hasSubjects` (the batched form — one read for N subjects, no ancestry walk), `subjectsOf` (the open-set read: every subject holding a tuple, the mod fan-out primitive — #1699) |
+| `Grant` | the **sealed** proof: constructor never exported (the type, `isGrant`, and the `Grant.provide` discharge verb escape, never `mint`), **not** a `Schema` (a decodable proof would be forgeable) |
+| `Capability.Class` / `.Level` / `.Relation` | the class-as-capability builders — one declaration yields the proof tag, the `Grant` type, and the discharge verb (discharge into R is the shared `Grant.provide`) |
+| `CurrentActor` / `RelationStore` / `AgentAuthority` | the ports (`Context.Service`s), adapted in `features/kunye` |
+
+Capabilities key off **`Context.ServiceClass<Self, Id, Grant<Self>>`** (effect v4 —
+`Context.Tag` is a v3 type that does not exist in v4). The tag carries the `Id`
+string literal, which is what keeps each capability's `Grant` a distinct type.
+
+## Testing
+
+`pnpm test` — pure-primitive unit tests: the `Grant` seal, `Scale` ordering,
+`Resource` ancestry/covers, the builders' exhaustive Actor dispatch + `Grant`
+provision into context. `Capability.typetest.ts` is the compile-time assertion
+(checked by `pnpm typecheck`): omitting `Grant.provide` leaves the capability in R,
+providing it collapses R to `never`, and a second capability's `Grant` is a
+distinct type — the wrong-proof gate.


### PR DESCRIPTION
## Summary

Truth pass + Diátaxis-lite restructure of `packages/authz/README.md`, grounded in `packages/authz/src/**` and its `package.json` at head. Docs-only; no file under `src/**` changes.

**Truth pass** (drift window re-derived at head: `aa1c63d0` → `ce52b58b4`, 5 source commits):
- The "type-level wrong-proof distinction is a known gap — see #1483" claim is gone: `dd0a4033` re-nominalized `CapabilityTag` (the tag now carries the `Id` literal), so a wrong-right proof is a compile error, pinned by `Capability.typetest.ts`. README now states the fixed behaviour.
- The tag's type claim corrected: capabilities key off `Context.ServiceClass<Self, Id, Grant<Self>>`, not a bare `Context.Key<Self, Grant<Self>>`.
- Additive half: `RelationStore.subjectsOf` (landed in `236b2848`, the mod fan-out open-set read, #1699) and `hasSubjects` (the batched form) are now on the `RelationStore` row; `isGrant` named on the `Grant` row; `Actor`/`Resource` helper exports (`matchActor`, `human`/`agent`/`unauthenticated`, `resource`/`key`/`platform`/`sameNode`) named on their rows. The remaining window commits (`a0b34f69`, `49e6ea22`, `ce52b58b`) introduced no public surface.
- Command claims verified in this tree: `pnpm test` (25 passed) and `pnpm typecheck` (clean) both run as documented.

**Structure pass** — the canonical order from `.patterns/package-readme-shape.md`: identity line → `What it is` → `Why it exists` (ADR 0107 cited; scope/non-goals — vocab-free, instances live in `features/kunye` — moved here) → `How to use it` (the `Declaring a capability` how-to that lived mid-page) → `Surface` reference table → `Testing`. The mechanism's shape is cited to `.patterns/authz-capability-as-effect.md` rather than restated. Diataxis classification of the result: single dominant mode (explanation), how-to and reference held to their shape-sanctioned tail sections, no unresolved type-mixing flag.

Fixes #4087

## Deviations

- **Scope narrowing** — **Said:** the acceptance criteria name `pipeline-cli readme-guard check`. **Did:** ran `fabrika guard readme-guard check` (passes: all 18 workspace members carry a README). **Why:** the v1 `pipeline-cli` was deleted with its package (#6100); the fabrika verb is the same guard's current home (ADR 0305). **Disposition:** stated here.
