### PR TITLE
docs(depo): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/depo/README.md
+++ b/packages/depo/README.md
@@ -1,6 +1,6 @@
 # @kampus/depo
 
-The client for **depo** — kampus's internal asset store / CDN ([ADR 0144](../../.decisions/0144-depo-internal-asset-cdn.md)). A thin `put(file)` **library** plus a `depo` **bin** over it. **Not** a subcommand of any pipeline tool: depo is general infra, decoupled from any one consumer, so a caller that wants asset storage must not have to pull in the whole pipeline toolchain.
+The client for **depo** — kampus's internal asset store / CDN ([ADR 0144](../../.decisions/0144-depo-internal-asset-cdn.md)). A thin `put(file)` **library** plus a `depo` **bin** over it.
 
 ## What it is
 
@@ -12,24 +12,55 @@ https://depo.kamp.us/<sha256>.<ext>
 
 This package is the **write** client. It content-addresses a local file (sha256 + extension), presents a pasaport `apiKey`, and calls the [doorman](../../infra/depo/worker/) upload worker (`PUT https://up.depo.kamp.us/`). The **read** path needs no client — a depo URL is a plain anonymous `GET` off `depo.kamp.us`.
 
+Nothing here is compiled before use: the package resolves from committed source under the
+`development` export condition, and the `depo` bin points at `src/bin.ts`.
+
+The surfaces a consumer touches, file by file (`src/`):
+
+- **`client.ts`** — `put({path, apiKey})` (fs-reading wrapper) and `putBytes` (bytes-in core);
+  every doorman HTTP status maps to a typed outcome inside `putBytes`.
+- **`live.ts`** — `DoormanClientLive` (the real `PUT` over any `HttpClient`),
+  `resolveApiKey` (ADR 0045 credential precedence), `DOORMAN_URL`.
+- **`client.ts`'s `DoormanClient`** — the injectable transport seam between the two.
+- **`domain.ts`** — the allowlist (`ALLOWED_TYPES`: PNG / JPEG / WebP) and the content address
+  (`sha256Hex`, `contentAddressKey`, `publicUrl`, `PUBLIC_HOST`); pure, mirrors the doorman's own
+  `domain.ts`.
+- **`errors.ts`** — the typed failure set (`MissingCredential`, `UnsupportedFile`, `FileReadError`,
+  `DigestError`, `Unauthorized`, `UnsupportedMediaType`, `PayloadTooLarge`,
+  `ContentAddressConflict`, `UploadFailed`) — CLI-facing, no `FateWireCode` annotation.
+- **`command.ts` / `run.ts` / `bin.ts`** — the `depo put <file>` CLI: argument parsing, error
+  reporting, and the one place the real network layer is provided.
+
 ## Why it exists
 
-Agents upload Playwright screenshots so they render inside GitHub PR descriptions (and, later, pano/sözlük markdown images). The doorman speaks a small HTTP contract; this lib is the one place that speaks it, so a caller — an agent via the CLI, or a server-side product via `import` — never re-implements content-addressing, auth, or status mapping.
+Agents upload Playwright screenshots so they render inside GitHub PR descriptions (and, later,
+pano/sözlük markdown images). The doorman speaks a small HTTP contract; this lib is the one place
+that speaks it, so a caller — an agent via the CLI, or a server-side product via `import` — never
+re-implements content-addressing, auth, or status mapping ([ADR 0144](../../.decisions/0144-depo-internal-asset-cdn.md)).
 
-## Use — the CLI
+Scope boundary: depo is general infra, decoupled from any one consumer — **not** a subcommand of
+any pipeline tool, so a caller that wants asset storage must not have to pull in a pipeline
+toolchain. It owns the write path only: no read client (a depo URL is fetched anonymously), and no
+doorman internals (those live under [`infra/depo/worker/`](../../infra/depo/worker/)).
+
+## How to use it
+
+### CLI
 
 ```bash
 node src/bin.ts put ./shot.png
 # → https://depo.kamp.us/<sha256>.png   (stdout, nothing else)
 ```
 
-`depo put <file>` uploads an allowlisted image (PNG / JPEG / WebP) and prints **exactly** the public URL to stdout, so a caller can capture it:
+`depo put <file>` uploads an allowlisted image (PNG / JPEG / WebP) and prints **exactly** the
+public URL to stdout, so a caller can capture it:
 
 ```bash
 URL=$(node src/bin.ts put ./shot.png)
 ```
 
-A non-existent file, a non-image, or a rejected upload exits **non-zero** with a legible error on stderr.
+A non-existent file, a non-image, or a rejected upload exits **non-zero** with a legible error on
+stderr. `--token <key>` overrides the resolved credential for one call.
 
 ### Credential
 
@@ -39,9 +70,10 @@ The `apiKey` is resolved in [ADR 0045](../../.decisions/0045-kampus-client-cli.m
 2. `KAMPUS_TOKEN` env var
 3. the stored `~/.config/kampus/token` credential
 
-(`$XDG_CONFIG_HOME` is honored when set.) No key at any rung → a non-zero exit with a `MissingCredential` message; the CLI never sends an empty bearer.
+(`$XDG_CONFIG_HOME` is honored when set.) No key at any rung → a non-zero exit with a
+`MissingCredential` message; the CLI never sends an empty bearer.
 
-## Use — the library
+### Library
 
 Server-side products `import` the lib and never touch the CLI:
 
@@ -58,7 +90,9 @@ const url = await Effect.runPromise(
 );
 ```
 
-`put` (and the bytes-in `putBytes`) talk to the doorman through the injectable `DoormanClient` seam, so the core unit-tests with the seam substituted and **no live worker** — provide `DoormanClientLive` (over any `HttpClient`) for the real upload, or a stub in a test.
+`put` (and the bytes-in `putBytes`) talk to the doorman through the injectable `DoormanClient`
+seam, so the core unit-tests with the seam substituted and **no live worker** — provide
+`DoormanClientLive` (over any `HttpClient`) for the real upload, or a stub in a test.
 
 ## The doorman contract it speaks
 
@@ -74,12 +108,16 @@ The client maps the doorman's HTTP status to a typed outcome ([`infra/depo/worke
 | `409` | a differing body at an existing content address | `ContentAddressConflict` |
 | other / transport | 5xx or a network fault | `UploadFailed` |
 
-The content-address key (`<sha256>.<ext>`) and allowlist (PNG / JPEG / WebP) mirror the doorman's own `domain.ts`, so the key the client computes is the key the server stores.
+The content-address key (`<sha256>.<ext>`) and allowlist (PNG / JPEG / WebP) mirror the doorman's
+own `domain.ts`, so the key the client computes is the key the server stores.
 
-## Develop
+## Testing
 
 ```bash
 pnpm --filter @kampus/depo test        # vitest unit tier
 pnpm --filter @kampus/depo typecheck   # tsc
 pnpm --filter @kampus/depo build       # tsc → dist/
 ```
+
+The unit tier runs with the `DoormanClient` seam substituted — no live worker: the suite asserts
+the request the client sends and a case per doorman status in the table above.


### PR DESCRIPTION
Re-grounds `packages/depo/README.md` against the package's own source and restructures it to the Diátaxis-lite shape pinned in `.patterns/package-readme-shape.md`. Docs-only: nothing under `packages/depo/src/**` or its `package.json` changes.

## Truth pass

Every claim in the README was re-verified against `packages/depo/src/**` and `package.json` at this head:

- **CLI surface** — `node src/bin.ts put <file>`, the allowlist (PNG/JPEG/WebP), exact-URL-on-stdout, non-zero exit on failure, and the ADR 0045 credential precedence (`--token` → `KAMPUS_TOKEN` → stored token, `$XDG_CONFIG_HOME` honored) each checked against `command.ts`/`live.ts`; the failure paths were executed for real (non-existent file → legible stderr + exit 1; non-image → `UnsupportedFile`; missing credential → `MissingCredential`).
- **Library surface** — the import-and-call snippet's exports (`DoormanClientLive`, `put`, `resolveApiKey`) confirmed present on the public entry by loading `@kampus/depo` under the `development` condition and enumerating every export; `resolveApiKey()`'s typed `MissingCredential` reproduced through the lib path. `pnpm test` (18/18), `typecheck`, and `build` all green.
- **Doorman contract table** — each row re-checked against `client.ts`'s status mapping and the worker (`infra/depo/worker/`): 201 first write / 200 byte-length-proven idempotent re-PUT / 401 / 415 / 413 (~10 MB cap = `SIZE_CAP_BYTES`) / 409 conflict / catch-all `UploadFailed`.

The additive half was **re-derived against this head**, as the amended criterion requires: the plan-time baseline (README last touch 2026-07-04) is stale — the tree shows two later README touches (`#tsgo`→`#tsc`, 2026-08-10; pipeline-cli wording repair, 2026-08-19). Against the true window, three load-bearing surfaces landed after the README last described the source and are now represented: the `DigestError` public export (0d5d343f9), the `development` export condition resolving committed source (5f2aa3e55), and the `depo` bin pointing at committed `src/bin.ts` rather than gitignored `dist/` (8e31430cc).

## Structure pass

Section order now follows `.patterns/package-readme-shape.md` exactly: identity line → **What it is** (explanation; surfaces named file-by-file) → **Why it exists** (ADR 0144 citation; scope boundary moved into the explanation half) → **How to use it** (the CLI and library how-tos consolidated under one heading, credential rungs as a subsection) → reference tail (**The doorman contract it speaks** table) → **Testing**. No tutorial walkthrough at package scale; each section holds one dominant mode under the `diataxis` classification — explanation sections explain, the how-to instructs, the tables enumerate.

Fixes #4081

## Deviations

- **Guard successor** — **Said:** the acceptance criteria name `pipeline-cli readme-guard check`. **Did:** ran its successor, `fabrika guard readme-guard check`. **Why:** `packages/pipeline-cli` was deleted (#6326) and the existence-only guard now lives in fabrika-cli; the literal command no longer exists at this head. **Disposition:** stated here; the gate passed (all 18 `packages/*` members carry a README).
