### PR TITLE
docs(d1-rest): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/d1-rest/README.md
+++ b/packages/d1-rest/README.md
@@ -5,7 +5,32 @@ backed by the Cloudflare D1 REST query API. It lets a plain Node process run dri
 reads/writes against real D1 with no workerd, implementing only the slice `drizzle-orm/d1`
 drives — `prepare` / `bind` / `all` / `run` / `raw` / `first` and `batch`.
 
-## Why this package exists
+## What it is
+
+One module (`src/index.ts`, exported through the package root) holds every surface a
+consumer touches:
+
+- `makeD1Rest(config)` — build a `D1Database` over the REST API for a given
+  `{accountId, databaseId, layer}`; `layer` provides `Credentials | HttpClient`. A single
+  statement is one REST `/query` POST; a drizzle `batch([...])` collects every statement's
+  sql+params into ONE REST batch call, which D1 runs as a single atomic transaction.
+  `run()` carries D1's real row-change count into `meta.changes` (defaulting to 0);
+  outside the drizzle-driven slice only inert stubs exist (`exec`, `dump`), so widening to
+  the full binding type happens once, at the assembly point.
+- `makeD1RestFromEnv(target)` / `d1RestLayerFromEnv` — the env-credentialed convenience
+  (`$CLOUDFLARE_API_TOKEN` via `CredentialsFromEnv` + a Fetch client) a bin and its
+  integration test both run the real direct-D1 work through.
+- `readYourWrite(read, isConsistent, options?)` — a bounded read-your-writes poll for callers
+  that need read-after-write consistency over this transport. The REST `/query` endpoint
+  carries no D1 session bookmark (that Sessions API primitive is Workers-binding-only), so an
+  immediate read after a write has no ordering guarantee; a caller that knows the post-write
+  truth polls the read until it reflects it. Returns the last read either way — it waits out
+  latency, it never masks a wrong read (#3075 / #3078).
+- `toRestParams` / `assertRestParam` — the REST-wire param transform and its strict-`string[]`
+  null guard (#569).
+- `D1RestConfig` / `D1RestServices` / `ReadYourWriteOptions` types.
+
+## Why it exists
 
 Before it, three packages each hand-maintained their **own copy** of the same transport —
 `packages/preview-seed/src/d1-rest.ts`, `packages/fts-backfill/src/d1-rest.ts`, and a
@@ -20,7 +45,7 @@ Now there is **one** transport. A transport fix is **one edit here**, reflected 
 consumer by construction. This is the same per-package-copy consolidation #859 did for the
 Drizzle schema into `@kampus/db-schema`, under the same drift-guard thinking as #903 / #930.
 
-## Why a leaf (the load-bearing constraint)
+### Why a leaf (the load-bearing constraint)
 
 `@kampus/fts-backfill` **prod-depends on `@kampus/web`**, and the repo deliberately keeps
 `apps/web → fts-backfill` **off** the dependency graph (it would be a cycle). So the shared
@@ -30,28 +55,69 @@ transport **cannot** depend on `@kampus/web` or anything that pulls it — it ha
 alchemy) and `effect`. The three consumers then depend on this leaf, and the dep graph stays
 acyclic.
 
-## API
+Scope boundary: this package owns the transport only — no credential management beyond the
+env layer above, no query building (drizzle owns that in each consumer), and no read-your-writes
+guarantee in the wire itself (the REST endpoint accepts no session bookmark; ordering is the
+caller's job through `readYourWrite`).
 
-- `makeD1Rest(config)` — build a `D1Database` over the REST API for a given
-  `{accountId, databaseId, layer}`; `layer` provides `Credentials | HttpClient`.
-- `makeD1RestFromEnv(target)` / `d1RestLayerFromEnv` — the env-credentialed convenience
-  (`$CLOUDFLARE_API_TOKEN` via `CredentialsFromEnv` + a Fetch client) a bin and its
-  integration test both run the real direct-D1 work through.
-- `toRestParams` / `assertRestParam` — the REST-wire param transform and its strict-`string[]`
-  null guard (#569).
-- `readYourWrite(read, isConsistent, options?)` — a bounded read-your-writes poll for callers that
-  need read-after-write consistency over this transport. The REST `/query` endpoint carries no D1
-  session bookmark (that Sessions API primitive is Workers-binding-only), so an immediate read after
-  a write has no ordering guarantee; a caller that knows the post-write truth polls the read until it
-  reflects it. Returns the last read either way — it waits out latency, it never masks a wrong read
-  (#3075 / #3078).
-- `D1RestConfig` / `D1RestServices` / `ReadYourWriteOptions` types.
+## How to use it
 
-## Consumers
+Point a bin or integration test at a real D1 over the env-credentialed layer (requires
+`$CLOUDFLARE_API_TOKEN` in the environment):
 
-- `@kampus/preview-seed` — runs `seed(d1)` over this transport (bin + integration tier).
-- `@kampus/fts-backfill` — runs the FTS5 re-index batch over it; its bin uses
-  `makeD1RestFromEnv`.
+```ts
+import {makeD1RestFromEnv} from "@kampus/d1-rest";
+
+const d1 = makeD1RestFromEnv({
+	accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+	databaseId: "<stage-d1-uuid>",
+});
+
+const row = await d1.prepare("select id from user where email = ?").bind(email).first();
+```
+
+Or supply your own `Credentials | HttpClient` layer:
+
+```ts
+import {d1RestLayerFromEnv, makeD1Rest} from "@kampus/d1-rest";
+
+const d1 = makeD1Rest({accountId, databaseId, layer: d1RestLayerFromEnv});
+```
+
+After a write whose read-back must already reflect it, poll instead of reading immediately:
+
+```ts
+import {readYourWrite} from "@kampus/d1-rest";
+
+const user = await readYourWrite(
+	() => findByEmail(db, email),
+	(u) => u?.role === "yazar",
+);
+```
+
+## Reference
+
+Consumers (every workspace dependent today):
+
+| Consumer                 | Runs over this transport                                                        |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `@kampus/preview-seed`   | `seed(d1)` (bin + integration tier)                                              |
+| `@kampus/fts-backfill`   | the FTS5 re-index batch; its bin uses `makeD1RestFromEnv`                         |
+| `@kampus/founder-seed`   | its bin builds the transport with `makeD1Rest`                                    |
+| `@kampus/admin-grant`    | `grant` / `revoke` / `list` writes; its bin uses `makeD1Rest`                     |
+| `apps/web`               | integration tests drive real D1 through `makeD1Rest` and order reads with `readYourWrite` |
+
+`readYourWrite` options (all optional):
+
+| Option         | Default            | Meaning                                                       |
+| -------------- | ------------------ | ------------------------------------------------------------- |
+| `maxAttempts`  | `6`                | max poll attempts, counting the first read                    |
+| `baseDelayMs`  | `100`              | base of the exponential backoff, in ms                        |
+| `sleep`        | real `setTimeout`  | injected for tests                                            |
+
+Wire contract: bound params travel as a strict `string[]`; a `null`/`undefined` element
+rejects (#569) — render SQL NULL inline by leaving the nullable column unset so drizzle
+emits a literal `NULL`, never a bound `null`.
 
 ## Tests
 
@@ -61,3 +127,8 @@ engine — ADR 0082 unit tier): the `meta.changes` mapping (carried + defaulting
 read-your-writes poll (re-reads until consistent; returns the last value on exhaustion so a real
 absence is never masked). Each consumer's integration tier still exercises the real transport
 against real D1 end to end.
+
+```bash
+pnpm --filter @kampus/d1-rest test       # the unit tier — offline, fake Fetch
+pnpm --filter @kampus/d1-rest typecheck
+```


### PR DESCRIPTION
docs(d1-rest): README truth + Diátaxis-lite structure pass

Wave-1 Diátaxis README pass for `@kampus/d1-rest` (epic #4073), same shape as the
merged sister passes (#7102 / #7103 / #7104 / #7105).

**Truth pass.** Every claim re-verified against `packages/d1-rest/src/**` and the
package's `package.json`. The one real drift found: the **Consumers** section listed
only `preview-seed` and `fts-backfill`, but three more dependents landed since —
`@kampus/founder-seed`, `@kampus/admin-grant`, and `apps/web`'s integration tier
(verified via `workspace:*` deps and actual `@kampus/d1-rest` imports). All five are
now in a reference table. Also made explicit that outside the drizzle-driven slice
only inert stubs (`exec`, `dump`) exist, matching the source's assembly point.

**Structure pass** (per `.patterns/package-readme-shape.md`): identity line →
`What it is` (explanation, surfaces export-by-export) → `Why it exists` (the
triplicate story + the why-a-leaf constraint and scope boundary, now in the
explanation half) → `How to use it` (runnable import-and-call snippets, previously
absent entirely) → reference tail (consumers table, `readYourWrite` options table,
wire contract) → testing tail with runnable commands.

**Diátaxis classification:** single-mode: explanation — how-to and reference content
each confined to their own sections; no tutorial walkthrough at package scale; no
unresolved type-mixing flag.

Fixes #4100

## Deviations

None.
