### PR TITLE
docs(worker-relevance): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/worker-relevance/README.md
+++ b/packages/worker-relevance/README.md
@@ -4,6 +4,28 @@ The pure classifier for whether a PR's diff **can affect the `apps/web` worker**
 so CI's `changes` job can skip the slow real-D1 `integration` / `e2e` tiers for a
 diff confined to packages the worker never imports (issue #1014).
 
+## What it is
+
+A zero-runtime-dependency package in the repo tooling idiom — a pure, unit-tested
+core plus a thin Node bin the CI step runs without `pnpm install`:
+
+- **`src/worker-relevance.ts`** — the pure, IO-free core. `classify` maps a
+  `ClassifyInput` (changed files + lockfile-changed flag + lockfile unified diff +
+  the test-import closure) to a `ClassifyResult` (`verdict` + `trigger` +
+  `reason`); same inputs ⇒ same verdict. Also exported: `parseChangedFiles`
+  (NUL/newline-separated path list → array), `extractKampusPackages` (every
+  `@kampus/<name>` specifier in TS/JS text, deliberately over-inclusive),
+  `parseTestImportedPackages`, `inputFromEnv` (the CI step's `env:` →
+  `ClassifyInput`), the `INTEGRATION_RELEVANT_PACKAGES` set, and the `LOCKFILE`
+  constant.
+- **`src/bin.ts`** — the IO shell ci.yml runs. It walks
+  `apps/web/tests/integration/` and `apps/web/tests/e2e/`, computes the
+  test-import closure from the real imports it finds, reads
+  `CHANGED_FILES` / `LOCKFILE_DIFF` from the environment, classifies, prints what
+  it scanned plus the verdict reason, and emits `worker_relevant=true|false` to
+  `$GITHUB_OUTPUT`. Exits 0 always — a classifier, not a gate.
+- **`src/index.ts`** — the public barrel re-exporting the core above.
+
 ## Why it exists
 
 The `backend` / `e2e` path filters in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
@@ -17,81 +39,96 @@ flake) despite touching nothing the worker runs. This classifier distinguishes a
 lockfile delta confined to non-worker importer blocks from one that touches a
 worker dependency, and decides whether the tiers can skip.
 
-## Fail-safe to running
+**Fail-safe to running** — the load-bearing invariant: a wrong skip is a missed
+worker regression, so the verdict is `irrelevant` (safe to skip) **only** when the
+whole diff is provably confined to worker-irrelevant surfaces. Any non-package
+path, any relevant package, any lockfile change outside an irrelevant importer
+block, any ambiguity or parse failure ⇒ `relevant` (RUN). When unsure, run.
 
-The load-bearing invariant: a **wrong skip is a missed worker regression**, so the
-verdict is `irrelevant` (safe to skip) **only** when the whole diff is provably
-confined to worker-irrelevant surfaces. Any non-package path, any worker-relevant
-package, any lockfile change outside a non-worker importer block, any ambiguity or
-parse failure ⇒ `relevant` (RUN). When unsure, run.
+**Two closures — worker-import ∪ test-import** ([ADR 0114](../../.decisions/0114-test-import-closure-gates-test-consumed-packages.md)).
+The relevance verdict unions:
 
-The worker's grounded in-repo import closure is exactly `{db-schema, fate-effect}`
-(`apps/web`'s only `@kampus/*` deps, both leaves), plus `preview-seed` which owns its
-**own** real-D1 integration tier (ADR
-[0082](../../.decisions/0082-two-test-tiers-unit-integration.md), #672). A
-change to any of those three is integration-relevant; everything else under
-`packages/**` is dev-tooling the worker never imports — **unless an integration/e2e
-test imports it** (see below).
-
-## Two closures — worker-import ∪ test-import (ADR 0114)
-
-The relevance verdict is the **union of two closures**, not one:
-
-1. **The worker-import closure** — the fixed four packages above
-   (`INTEGRATION_RELEVANT_PACKAGES`) the worker imports (or that own their own
-   real-D1 tier).
+1. **The worker-import closure** — the fixed three-package
+   `INTEGRATION_RELEVANT_PACKAGES` set: `{db-schema, fate-effect}` (the worker's
+   in-repo `@kampus/*` import closure) plus `preview-seed`, which owns its **own**
+   real-D1 integration tier ([ADR 0082](../../.decisions/0082-two-test-tiers-unit-integration.md),
+   #672).
 2. **The test-import closure** — the `packages/**` members imported under
-   `apps/web/tests/integration/**` and `apps/web/tests/e2e/**`, **computed from the
-   real imports** in those trees on every run (not a maintained list).
+   `apps/web/tests/integration/**` and `apps/web/tests/e2e/**`, **computed from
+   the real imports** in those trees on every run (not a maintained list).
 
 A `packages/<name>` change is integration-relevant iff `<name>` is in **either**
-closure. This closes the hole ADR
-[0114](../../.decisions/0114-test-import-closure-gates-test-consumed-packages.md)
-records: a package the **worker** never imports but an integration test **does**
-(e.g. `founder-seed`, imported by `apps/web/tests/integration/kunye-moderate-seam.test.ts`)
-used to classify `irrelevant` and skip the integration tier on the very PR that broke
-it — the #1352 → #1378/#1380 → #1383 incident chain. Because the test-import closure
-is computed from the actual `import`/`require` graph, a newly test-imported package
-joins the relevant set the instant a test imports it, with **no list to maintain and
-no silent-drift window** — the drift that was the root cause of #1352 is structurally
-removed.
+closure. This closes the hole ADR 0114 records: a package the **worker** never
+imports but an integration test **does** (e.g. `founder-seed`, imported by
+`apps/web/tests/integration/kunye-moderate-seam.test.ts`) used to classify
+`irrelevant` and skip the integration tier on the very PR that broke it — the
+#1352 → #1378/#1380 → #1383 incident chain. Because the closure comes off the
+actual `import` graph, a newly test-imported package joins the relevant set the
+instant a test imports it, with no list to maintain and no silent-drift window.
+Per the invariant, a **scan failure** resolves to `relevant` (RUN) — an
+unprovable test-import closure never yields a silent skip (a missing tree is not
+a failure: a repo with no e2e tree scans to empty).
 
-The scan is the **bin's** job (it walks the two test trees, extracts `@kampus/*`
-specifiers, and resolves each to a real `packages/**` workspace member); the pure
-core takes the computed closure as `ClassifyInput.testImportedPackages` and unions it
-into both the changed-path check and the lockfile importer-block attribution. Per the
-fail-safe-to-running invariant, a **scan failure** resolves to `relevant` (RUN) — an
-unprovable test-import closure never yields a silent skip.
+**Scope:** this package decides *skip-or-run* for the worker `integration`/`e2e`
+tiers and nothing else. It never fails a build (the bin exits 0 always) and owns
+no freshness gate over itself — the drift-guard question lives with #2627.
 
-## How it's used
+## How to use it
 
-The `changes` job passes the PR's changed-file list and the `pnpm-lock.yaml`
-unified diff into the bin's env, then runs the classifier with no install:
+In CI (the only production consumer), the `changes` job's classify step exports
+`CHANGED_FILES` and `LOCKFILE_DIFF` into the environment and runs the bin with no
+install:
 
 ```bash
 node packages/worker-relevance/src/bin.ts
 ```
 
-The bin computes the test-import closure off the checked-out test trees, prints the
-verdict + the triggering path (ADR 0092 §1 "emit what you scanned"), and emits the
-`relevant` / `irrelevant` decision the `changes` job reads to gate the worker
-`integration` / `e2e` tiers. No `ci.yml` change is needed — the bin reads the trees
-directly, so the closure stays in lockstep with the real imports.
+The bin prints the computed test-import closure and the verdict reason (ADR 0092
+§1 "emit what you scanned"), then emits the `worker_relevant=true|false` line the
+job's gating expressions read. Locally, the same shell is the package's
+`classify` script:
 
-## Architecture
+```bash
+pnpm --filter @kampus/worker-relevance classify
+```
 
-A pure, unit-tested core + a thin Node bin (the repo tooling idiom), **zero
-runtime dependencies** so the `changes` step runs it without `pnpm install`:
+Programmatically, import the pure core from the package root:
 
-- `src/worker-relevance.ts` — the pure, IO-free core: `classify` over a
-  `ClassifyInput` (changed files + lockfile diff + the test-import closure),
-  `parseChangedFiles`, the `INTEGRATION_RELEVANT_PACKAGES` set, the pure import
-  extractor `extractKampusPackages`, and `inputFromEnv`. Same inputs ⇒ same verdict,
-  no IO.
-- `src/bin.ts` — the thin Node shell: walk the test trees to compute the test-import
-  closure, read env, classify, print, emit the verdict (fail-safe to running on a
-  scan error).
-- `src/index.ts` — the package's public exports.
+```ts
+import {classify, type ClassifyInput} from "@kampus/worker-relevance";
+
+const result = classify({
+	changedFiles: ["packages/composer/src/x.ts"],
+	lockfileChanged: false,
+	lockfileDiff: "",
+}); // ⇒ { verdict: "irrelevant", trigger: null, reason: "irrelevant — …" }
+```
+
+## Reference
+
+Environment variables the bin reads (via `inputFromEnv`; all optional — absent
+inputs are empty):
+
+| Variable | Content |
+| --- | --- |
+| `CHANGED_FILES` | Changed paths, base...head, repo-root-relative, newline/NUL-separated |
+| `LOCKFILE_DIFF` | `git diff base...head -- pnpm-lock.yaml`; consulted only when the lockfile changed |
+| `TEST_IMPORTED_PACKAGES` | Pre-computed test-import closure override; normally unset — the bin computes it by scanning the test trees |
+
+Fail-safe rules (each row is `relevant` unless provably otherwise):
+
+| Input | Verdict |
+| --- | --- |
+| Any changed path outside `packages/<irrelevant>/` | `relevant` |
+| Lockfile hunk outside an irrelevant package's `importers:` block, or an unreadable diff | `relevant` |
+| Test-tree scan throws | `relevant` (bin short-circuits before classifying) |
+| Whole diff confined to irrelevant packages and their lockfile importer blocks | `irrelevant` |
+
+Public exports: `classify`, `parseChangedFiles`, `parseTestImportedPackages`,
+`extractKampusPackages`, `inputFromEnv`, `INTEGRATION_RELEVANT_PACKAGES`,
+`LOCKFILE`, and the `Verdict` / `ClassifyInput` / `ClassifyResult` types.
+
+## Testing
 
 ```bash
 pnpm --filter @kampus/worker-relevance test       # vitest over the pure core


### PR DESCRIPTION
## Summary

Re-grounds `packages/worker-relevance/README.md` against the package's own source and restructures it to the Diátaxis-lite README shape from `.patterns/package-readme-shape.md`, as part of the wave-1 README passes (issue #4091).

**Truth pass** — every claim re-verified against `src/**` and `package.json` at this head:

- Dropped the unverifiable grounding parenthetical ("`apps/web`'s only `@kampus/*` deps are `db-schema` and `fate-effect`"): `apps/web/package.json` now also carries `@kampus/authz` and `@kampus/composer`, so the README now describes the worker-import closure as what it is in code — the maintained three-package `INTEGRATION_RELEVANT_PACKAGES` set.
- Added the surfaces that had no README coverage: the package's `classify` npm script, the bin's full env contract (`CHANGED_FILES`, `LOCKFILE_DIFF`, `TEST_IMPORTED_PACKAGES`) and its `$GITHUB_OUTPUT` emission, the exits-0-always property, and the missing-tree-is-not-a-scan-failure rule.
- Every printed command was executed at this head with the documented result: the bin run, `classify`, `test` (40 passed), `typecheck`.

**Structure pass** — canonical order: one-line identity → `What it is` (file-by-file surfaces) → `Why it exists` (forcing constraint, ADR 0082/0114 citations, fail-safe-to-running + two-closures kept as explanation, scope/non-goals) → `How to use it` (CI invocation, local script, import-and-call snippet) → `Reference` tail (env vars, fail-safe rules table, export list) → `Testing`. Diátaxis classification: **explanation** is the single dominant mode — no ordered walkthrough, reference enumerations confined to their tail sections, no unresolved type-mixing flag. Standard markdown links throughout, no wikilinks.

No changes under `packages/worker-relevance/src/**`; docs-only diff.

Fixes #4091

## Deviations

- **Retired command in the acceptance criteria** — **Said:** the criteria name `pipeline-cli readme-guard check`. **Did:** ran the guard's current home instead, `node packages/fabrika-cli/src/bin.ts guard readme-guard check` (the scan moved to fabrika-cli's `guard` group when `packages/pipeline-cli` was deleted, #6326). **Why:** same check, successor verb; the named command no longer exists to run. **Disposition:** stated here; green with all 18 members carrying a README.
