### PR TITLE
docs(migrations-guard): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/migrations-guard/README.md
+++ b/packages/migrations-guard/README.md
@@ -1,20 +1,18 @@
 # @kampus/migrations-guard
 
 The **fail-closed CI gate over the committed D1 migrations tree** (issue
-[#1435](https://github.com/kamp-us/phoenix/issues/1435)). drizzle-kit validates only what
-it can diff, and alchemy validates nothing at all — it applies whatever `.sql` it finds
-under `migrationsDir`. This package is the check that sits between them.
+[#1435](https://github.com/kamp-us/phoenix/issues/1435), re-grounded on the v7 layout by ADR
+[0309](../../.decisions/0309-v7-migrations-baseline-cutover.md)).
 
-It is a `packages/` Effect CLI per the repo's Node-over-Python convention (the
-`leak-guard` / `readme-guard` / `orphan-sweep` idiom) — a pure, unit-tested core plus a
-thin `effect/unstable/cli` bin — wired as a fail-closed CI job. Per ADR
+## What it is
+
+A `packages/` Effect CLI per the repo's Node-over-Python convention (the
+`leak-guard` / `readme-guard` / `orphan-sweep` idiom) — a pure, unit-tested core plus a thin
+`effect/unstable/cli` bin — wired as a fail-closed CI job. Per ADR
 [0100](../../.decisions/0100-control-plane-covers-enforcement-guard-packages.md) the guard package is
 **control-plane** (human-merged).
 
-## The tree it guards
-
-Two layouts sit side by side after the v7 cutover (ADR
-[0309](../../.decisions/0309-v7-migrations-baseline-cutover.md)):
+It guards the two-layout tree the v7 cutover (ADR 0309) left behind:
 
 - **Frozen flat history** — 34 top-level `NNNN_name.sql` files. Production recorded each
   one by its path relative to `migrationsDir`, so their names are load-bearing strings.
@@ -22,20 +20,62 @@ Two layouts sit side by side after the v7 cutover (ADR
   `drizzle-kit generate` writes from the cutover on. alchemy finds them because
   `listSqlFiles` reads the directory recursively.
 
-## Why it exists — the drift it catches
+The surfaces a consumer touches, file by file (`src/`):
 
-alchemy skips an applied migration by exact id match against `drizzle_migrations.name`
-(`migrationsTable: "drizzle_migrations"`,
+- **`index.ts`** — the public entry: re-exports the core and the fs boundary below.
+- **`migrations-guard.ts`** — the pure, IO-free core: `evaluate` (the three checks),
+  `migrationNumber`, `alchemyPrefix` (a byte-for-byte mirror of alchemy's own sort key),
+  `deriveBaseline`, `renderVerdict`. Total over a loaded tree; never touches disk.
+- **`fs.ts`** — the filesystem boundary: `loadMigrationTree` (walks both layouts,
+  builds each migration's apply id, hashes its SQL), `loadBaseline`, `serializeBaseline`.
+- **`bin.ts`** — the `effect/unstable/cli` bin: the `check` and `baseline` commands under
+  [How to use it](#how-to-use-it).
+
+## Why it exists
+
+drizzle-kit validates only what it can diff, and alchemy validates nothing at all — it applies
+whatever `.sql` it finds under `migrationsDir`, skipping an applied migration by exact id match
+against `drizzle_migrations.name` (`migrationsTable: "drizzle_migrations"`,
 [`apps/web/worker/db/resources.ts`](../../apps/web/worker/db/resources.ts)), where the id
-is the path relative to `migrationsDir`. Two failure modes follow, and the guard makes
-both loud:
+is the path relative to `migrationsDir`. Two failure modes follow, and the guard makes both loud:
 
 - **Editing a landed migration** won't re-run on prod (already applied) but **will apply
   as-edited on a fresh integration `it-*` DB** — integration goes green, prod stays stale,
   undetectably.
 - **Renaming or moving one** changes its id, so alchemy has never seen it and re-applies
-  it — against a database that already ran it. That is the replay ADR 0309 exists to
-  avoid.
+  it — against a database that already ran it. That is the replay ADR 0309 exists to avoid.
+
+Scope boundary: the guard checks exactly the committed `apps/web` D1 tree against its committed
+baseline. It validates migration-tree *shape*, ordering, and immutability — not schema semantics,
+and no database other than that tree. Like every enforcement guard it fails closed on zero scope
+(ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)): an empty tree is a
+violation, never a pass.
+
+## How to use it
+
+The gate — verify the committed tree is consistent, ordered, and immutable vs the baseline.
+Exits **1** on any violation (the report is on stdout); this is what CI runs:
+
+```bash
+node packages/migrations-guard/src/bin.ts check
+```
+
+Both commands take the same two flags; the defaults resolve to `apps/web/…/migrations` and this
+package's `migration-hashes.json`, so `check` runs the same from any CWD (a CI step, a local
+invocation):
+
+```bash
+node packages/migrations-guard/src/bin.ts check \
+  --migrations apps/web/worker/db/drizzle/migrations \
+  --baseline packages/migrations-guard/migration-hashes.json
+```
+
+Regenerate the baseline after a deliberate, audited re-baseline (a human-reviewed control-plane
+act, never something CI does):
+
+```bash
+node packages/migrations-guard/src/bin.ts baseline
+```
 
 ## The three properties
 
@@ -64,37 +104,21 @@ The pure core ([`src/migrations-guard.ts`](src/migrations-guard.ts)) evaluates a
 
 Immutability is checked against a **committed baseline** — `tag → sha256` of the
 migration's SQL, where the tag is the flat file's stem or the migration directory's name.
-`check` recomputes and compares. A new trailing migration is simply absent from the
-baseline and passes; adding it is a **deliberate, audited** act:
-
-```bash
-node packages/migrations-guard/src/bin.ts baseline   # regenerate after a deliberate re-baseline
-```
-
+`check` recomputes and compares; a missing baseline file reads as empty, which fails closed —
+every flat migration absent from it reds. A new trailing migration is simply absent from the
+baseline and passes; adding it via [`baseline`](#how-to-use-it) is the deliberate, audited act.
 Because the tag for a flat migration is unchanged by the v7 cutover, the hashes recorded
 before it carry over untouched — the diff a re-baseline produces is exactly the set of
 migrations newly brought under the check.
 
-## Shape
-
-- **`src/migrations-guard.ts`** — the pure, IO-free core: `evaluate` (the three checks),
-  `migrationNumber`, `alchemyPrefix` (a byte-for-byte mirror of alchemy's own sort key),
-  `deriveBaseline`, `renderVerdict`. Total over a loaded tree; never touches disk.
-- **`src/fs.ts`** — the filesystem boundary: `loadMigrationTree` (walks both layouts,
-  builds each migration's apply id, hashes its SQL), `loadBaseline`, `serializeBaseline`.
-- **`src/bin.ts`** — the `effect/unstable/cli` bin. `check` is the gate (exits **1** on
-  any violation); `baseline` regenerates the committed baseline.
-- **`src/*.unit.test.ts`** — the core's unit tests: each property's violations, the
-  new-trailing-migration pass, and the fs round-trip against a temp tree.
-
-## Usage
+## Testing
 
 ```bash
-# The gate: verify the committed tree is consistent, ordered, and immutable. Exits 1 on
-# any violation (the report is on stdout). This is what CI runs.
-node packages/migrations-guard/src/bin.ts check
-
-# Point at a different tree / baseline (defaults resolve to apps/web/…/migrations and
-# this package's migration-hashes.json).
-node packages/migrations-guard/src/bin.ts check --migrations <dir> --baseline <file>
+pnpm --filter @kampus/migrations-guard test        # vitest unit tier
+pnpm --filter @kampus/migrations-guard typecheck   # tsc
+pnpm --filter @kampus/migrations-guard check       # the gate itself, against the real tree
 ```
+
+The unit tier runs the core against synthetic trees — each property's violations, the
+new-trailing-migration pass, and the fs round-trip against a temp tree (`src/*.unit.test.ts`)
+— so no real migrations directory is needed.


### PR DESCRIPTION
## Summary

Truth pass + Diátaxis-lite restructure of `packages/migrations-guard/README.md`, grounded in `packages/migrations-guard/src/**` and the package's `package.json` at head. Docs-only; no file under `src/**` changes.

**Truth pass** (drift window re-derived at head: zero source commits after the README's last touch, `70990a898`; the plan-time window 2026-07-05 → 2026-07-13 holds only comments-only `07559f366`, no public surface):
- Every command, flag, export and behaviour claim verified against source: `check`/`baseline` subcommands, the shared `--migrations`/`--baseline` flags with their defaults, exit code **1** on violation, and all core/boundary exports (`evaluate`, `migrationNumber`, `alchemyPrefix`, `deriveBaseline`, `renderVerdict`, `loadMigrationTree`, `loadBaseline`, `serializeBaseline`) match `bin.ts` / `migrations-guard.ts` / `fs.ts`.
- The tree arithmetic is current: 34 frozen flat files (`0000`–`0033`), migration directories from the v7 cutover on — counted in this tree.
- Additive half: `index.ts` (the package's public export surface) is now named on the file-by-file map. No other load-bearing surface landed in the window.

**Structure pass** — the canonical order from `.patterns/package-readme-shape.md`: identity line → `What it is` (the two-layout tree + file-by-file surfaces) → `Why it exists` (the drift it catches; scope/non-goals moved here) → `How to use it` (all runnable commands, including the flag form) → reference tail (`The three properties`, `The baseline`) → `Testing`. Diataxis classification of the result: single dominant mode (explanation); how-to and reference held to their shape-sanctioned sections; no unresolved type-mixing flag.

**Command blocks verified in this tree**: `check` (both forms) prints the OK verdict and exits 0; `baseline` reports `wrote baseline for 37 migration(s)` (its output file restored untouched — a docs lane does not re-baseline); `pnpm --filter @kampus/migrations-guard test` (35 passed), `typecheck` (clean), `readme-guard check` (18/18).

Fixes #4097

## Deviations

None.
