### PR TITLE
docs(composer): README truth + Diátaxis-lite structure pass

### DIFF
--- a/packages/composer/README.md
+++ b/packages/composer/README.md
@@ -1,32 +1,50 @@
 # @kampus/composer
 
-The shared **headless composer base** — one tiptap-wrapped editor every kamp.us
-product composes from.
+The shared **headless composer base** — one tiptap-wrapped editor (an editable
+composer and a read-only reader over the same render path) every kamp.us product
+composes from.
 
 ## What it is
 
-A minimal, headless rich-text base built on [tiptap](https://tiptap.dev), exposed as a
-single stable surface:
+A minimal, headless rich-text base built on [tiptap](https://tiptap.dev), exposed
+as a single stable surface of root imports from `@kampus/composer` — no deep-path
+imports, and **nothing imports tiptap directly**: the handle keeps `@tiptap`'s own
+types and methods off consumer call sites.
 
-- `baseKit()` — the shared StarterKit + `@tiptap/markdown` config,
-- `useComposerEditor()` — a factory hook that returns a `ComposerHandle`,
+- `baseKit()` — the shared StarterKit + `@tiptap/markdown` config; the only kit v1 ships,
+- `useComposerEditor()` — a factory hook that returns a `ComposerHandle | null`,
 - `ComposerHandle` — the markdown/JSON I/O surface (`getMarkdown()` /
-  `setContent(md)` / `toJSON()`),
+  `setContent(md)` / `toJSON()`, plus an `editor` escape hatch),
 - `<Composer>` — a headless component that renders only the editor surface (no chrome,
-  no styling opinions).
-
-Everything a consumer needs is a **root import** from `@kampus/composer` — no deep-path
-imports, and **nothing imports tiptap directly**: the handle keeps `@tiptap`'s own types
-and methods off consumer call sites.
+  no styling opinions),
+- `<ReadOnlyComposer>` — the same baseKit path with editing switched off: renders
+  stored markdown non-editably (the mecmua reader half, #2581),
+- `renderTestMarkdown` — the canonical render-test fixture every element round-trips.
 
 ## Why it exists
 
 kamp.us composers are **in-house** — no external editor framework (founder ruling,
 epic [#2476](https://github.com/kamp-us/phoenix/issues/2476)). tiptap is the
 in-house-wrapped base, wrapped **headlessly** here so every product composes from one
-editor definition and **consumers never import tiptap directly**. v1 is emergent:
-`baseKit()` only (StarterKit + `@tiptap/markdown`), no speculative tagging / embedding
-/ mention kits (design [#2464](https://github.com/kamp-us/phoenix/issues/2464)).
+editor definition and **consumers never import tiptap directly**.
+
+Read and write share **one render path**: `<ReadOnlyComposer>` is the editor with
+`editable: false`, so a rendered post body and the editor that produced it cannot
+re-diverge (the two-render-path bug #2578, closed structurally by #2581).
+
+v1 is emergent, enforced in code rather than convention:
+
+- **One kit, markdown only.** `baseKit()` (StarterKit + `@tiptap/markdown`) is the
+  single exported kit, no speculative tagging / embedding / mention kits (design
+  [#2464](https://github.com/kamp-us/phoenix/issues/2464)). `ComposerContentType`
+  narrows tiptap's `'json' | 'html' | 'markdown'` to the `"markdown"` literal, so a
+  call site reaching for another content type is a **compile error**.
+- **No styling opinions.** The base renders only the contenteditable (or read-only)
+  region; chrome and CSS live app-side via `className`.
+
+Speculative marks slot in later as a **new named kit** alongside `baseKit()` (e.g. a
+`mentionKit()`), composed by that consumer's own wiring — never by widening
+`baseKit()` itself (rule of three).
 
 `react` / `react-dom` are `peerDependencies` — the base does not own React; the
 consuming app does.
@@ -46,7 +64,7 @@ function MyComposer() {
 	const markdown = composer ? composer.getMarkdown() : "";
 	const json = composer ? composer.toJSON() : null;
 
-	// markdown in
+	// markdown in — a no-op once the editor instance is torn down (#2593)
 	function load(md: string) {
 		composer?.setContent(md);
 	}
@@ -56,93 +74,71 @@ function MyComposer() {
 }
 ```
 
-### Surface
+To render stored markdown without editing affordances, use the reader half — it owns
+its own handle and re-seeds when `content` changes:
+
+```tsx
+import {ReadOnlyComposer} from "@kampus/composer";
+
+function PostBody({markdown}: {markdown: string}) {
+	return <ReadOnlyComposer content={markdown} className="post-body" />;
+}
+```
+
+A second consumer adopts the base cold: hold the `ComposerHandle`, render
+`<Composer>`, and read/write markdown through the handle. A product supplies only its
+own chrome and persistence — markdown is the source of truth the product persists
+(`getMarkdown()`); `toJSON()` is available when a product wants the structural doc as
+a render-fast cache. A composer draft that writes a fanned entity must publish the
+`/fate/live` invalidation and be classified in
+[`apps/web/worker/features/fate-live/fanned-mutations.ts`](../../apps/web/worker/features/fate-live/fanned-mutations.ts)
+— the base owns editing, the product owns persistence.
+
+[`/lab/composer`](../../apps/web/src/pages/LabComposerPage.tsx) is the live proof of
+the whole surface — kept + canonical under the `/lab/*` public convention
+([#2469](https://github.com/kamp-us/phoenix/issues/2469) / PR #2474).
+
+## Surface
 
 | export                | what it is                                                            |
 | --------------------- | -------------------------------------------------------------------- |
-| `useComposerEditor`   | factory hook → `ComposerHandle \| null` wired to `baseKit()`         |
-| `ComposerHandle`      | the I/O handle: `getMarkdown()` / `setContent(md)` / `toJSON()`      |
+| `useComposerEditor`   | factory hook → `ComposerHandle \| null` wired to `baseKit()`; options are `content?`, `onUpdate?`, and `editable?` (`false` gives the read-only mode) |
+| `UseComposerEditorOptions` | the hook options (`content`, `onUpdate`, `editable`)             |
+| `ComposerHandle`      | the I/O handle: `getMarkdown()` / `setContent(md)` / `toJSON()`, plus the raw `editor` escape hatch for advanced tiptap use |
 | `Composer`            | headless `<EditorContent>` wrapper taking the handle (no chrome)     |
+| `ComposerProps`       | the `<Composer>` props                                               |
+| `ReadOnlyComposer`    | the reader half: same baseKit path, `editable: false`; re-seeds on `content` change |
+| `ReadOnlyComposerProps` | the `<ReadOnlyComposer>` props (`content`, `className`)            |
 | `baseKit`             | the shared editor config (StarterKit + Markdown, markdown I/O)       |
 | `BaseKitOptions`      | the `baseKit()` return type                                          |
-| `UseComposerEditorOptions` | the hook options (`content`, `onUpdate`)                         |
-| `ComposerProps`       | the `<Composer>` props                                               |
-| `ComposerContentType` | `"markdown"` — the only content type v1 accepts (see below)          |
+| `ComposerContentType` | `"markdown"` — the only content type v1 accepts                      |
 | `ComposerJSON`        | the ProseMirror JSON doc type `toJSON()` returns                     |
 | `SetContentOptions`   | `setContent()`'s options (`{contentType?}`)                          |
 | `renderTestMarkdown`  | the canonical render-test fixture (see below)                        |
 
 `useComposerEditor` returns `null` until the editor mounts (SSR / first render) — guard
-it, as the example does.
+it, as the example does. Once an editor instance is destroyed (StrictMode/remount
+teardown), further `setContent` calls on its stale handle are a **no-op**, not a crash
+(#2593); remount and use the fresh handle instead.
 
-## Consuming it (mecmua / sözlük / pano adoption path)
+### Render-test fixture
 
-A second consumer adopts the base cold — no need to re-derive the wiring from
-[`/lab/composer`](../../apps/web/src/pages/LabComposerPage.tsx)'s source. The pattern is
-identical everywhere: hold the `ComposerHandle`, render `<Composer>`, and read/write
-markdown through the handle. A product supplies only its own chrome and persistence.
+`renderTestMarkdown` exercises every block + inline element `baseKit()` round-trips —
+headings h1–h6, bold/italic/strikethrough, inline + fenced code,
+ordered/unordered/nested lists, plain + nested blockquotes, horizontal rule, and links.
+It is the **single source** for that content:
+[`/lab/composer`](../../apps/web/src/pages/LabComposerPage.tsx) seeds its playground from
+it and the base's round-trip test drives it, so the public render checklist and the base
+fixture can never drift.
 
-```tsx
-import {Composer, useComposerEditor} from "@kampus/composer";
-import {useState} from "react";
+Task-lists and tables are **not** in the fixture — the v1 set is StarterKit-only, which
+ships no such node, so they'd be dropped by the markdown parser rather than round-trip;
+they land here only when a kit that round-trips them does.
 
-// e.g. mecmua's entry editor — the composer is the base; the save button + styling are the product.
-function MecmuaEntryEditor({initialMarkdown, onSave}: {initialMarkdown: string; onSave: (md: string) => void}) {
-	const composer = useComposerEditor({content: initialMarkdown});
-	const [, setRev] = useState(0);
+## Testing
 
-	return (
-		<div className="mecmua-entry">
-			<Composer composer={composer} className="mecmua-entry__body" />
-			<button
-				type="button"
-				onClick={() => composer && onSave(composer.getMarkdown())}
-				onMouseDown={() => setRev((n) => n + 1)}
-			>
-				kaydet
-			</button>
-		</div>
-	);
-}
-```
-
-Markdown is the source of truth the product persists (`getMarkdown()`); `toJSON()` is
-available when a product wants the structural doc as a render-fast cache. A composer draft
-that writes a fanned entity must publish the `/fate/live` invalidation and be classified in
-`apps/web/worker/features/fate-live/fanned-mutations.ts` — the base owns editing, the
-product owns persistence.
-
-## Emergent discipline — one kit, markdown only
-
-v1 is deliberately **`baseKit()`-only** and stores **markdown only** — StarterKit's common
-nodes plus `@tiptap/markdown`, nothing more. This is enforced in code, not just documented:
-`baseKit()` is the single exported kit, and `ComposerContentType` narrows tiptap's
-`'json' | 'html' | 'markdown'` to the `"markdown"` literal, so a call site that reaches for
-another content type is a **compile error** (`pnpm typecheck` fails).
-
-Speculative marks — tagging, embedding, `@mentions` — are **not** built here (design
-[#2464](https://github.com/kamp-us/phoenix/issues/2464) founder ruling). When a real
-consumer needs one (rule of three), it slots in as a **new named kit** alongside `baseKit()`
-(e.g. a `mentionKit()` returning its own `Extensions`), composed by that consumer's own
-`useEditor` wiring — never by widening `baseKit()` itself. Until then, the surface stays
-emergent.
-
-## Render-test fixture — `renderTestMarkdown`
-
-`renderTestMarkdown` is a shared markdown document exercising every block + inline element
-`baseKit()` round-trips — headings h1–h6, bold/italic/strikethrough, inline + fenced code,
-ordered/unordered/nested lists, plain + nested blockquotes, horizontal rule, and links. It is
-the **single source** for that content: [`/lab/composer`](../../apps/web/src/pages/LabComposerPage.tsx)
-seeds its playground from it and the base's round-trip test drives it, so the public render
-checklist and the base fixture can never drift. A downstream consumer (mecmua / sözlük / pano)
-reuses it to prove the base round-trips before depending on it.
-
-Task-lists and tables are **not** in the fixture — the v1 set is StarterKit-only, which ships
-no such node, so they'd be dropped by the markdown parser rather than round-trip; they land here
-only when a kit that round-trips them does (the emergent discipline above).
-
-## First consumer
-
-[`/lab/composer`](../../apps/web/src/pages/LabComposerPage.tsx) is the live proof —
-kept + canonical under the `/lab/*` public convention
-([#2469](https://github.com/kamp-us/phoenix/issues/2469) / PR #2474).
+`pnpm test` in this package runs the vitest suite: the pinned public-export surface,
+markdown round-trip + `toJSON()` through the handle, the read-only mode's serialization
+parity with the editable path, `setContent` teardown readiness, and the render tests
+over `renderTestMarkdown`. `pnpm typecheck` asserts the compile-error guarantees
+(non-markdown content types don't type).


### PR DESCRIPTION
docs(composer): README truth pass + Diátaxis-lite structure

Fixes #4089

## Summary

Re-grounded `packages/composer/README.md` against the package's own source (`src/**` + `package.json`) and restructured it to the Diátaxis-lite README shape from `.patterns/package-readme-shape.md`, following the pattern of the merged sisters (#7102 / #7105 / #7103 / #7104).

**Truth pass (additive half).** Three surfaces landed in the package after the README's last touch (2026-07-11) and were absent from it; all are now represented:

- `<ReadOnlyComposer>` + `ReadOnlyComposerProps` — the read-only render mode (#2581), now listed in *What it is*, given a runnable snippet, and tabled in *Surface*.
- The `editable?` option on `UseComposerEditorOptions` (#2581) — named on its Surface row.
- The `setContent` teardown guard (#2593) — stale handles no-op instead of crashing; stated under *Surface* and noted at the call site in the how-to snippet.

Also added for truth: the `ComposerHandle.editor` escape hatch (a public surface the table omitted), and the `tsc` typecheck script (the compiler collapse #5370 changed it; nothing in the README had claimed the old one).

**Truth pass (subtractive half).** No claim about removed behaviour survived: every export row was checked against `src/index.ts`, both code snippets against `useComposerEditor.ts` / `ReadOnlyComposer.tsx`, and behaviour claims against the tests. The `/lab/composer` seed claim and the `fanned-mutations.ts` path were re-verified against the tree.

**Structure pass.** Canonical order now holds: identity → *What it is* (explanation, surfaces export-by-export) → *Why it exists* (explanation; absorbed the "Emergent discipline" section as scope/non-goals with the #2476/#2464 citations) → *How to use it* (how-to; the editable snippet, the read-only snippet, and a compressed adoption paragraph replacing the second full walkthrough example) → *Surface* (reference tail incl. the render-test fixture notes) → *Testing*. The old "Consuming it", "Emergent discipline", "Render-test fixture" and "First consumer" sprawl sections are gone; their load-bearing facts live in the sections above.

**Diátaxis classification.** Run over the result per the `diataxis` skill: the page holds the pinned front-door shape — explanation leads, how-to follows, reference trails — each section serves exactly one mode (no tutorial blended into the body, no reference arguing, no explanation hardening into steps). Single dominant reader-shape, no unresolved type-mixing flag.

Docs-only lane: no file under `packages/composer/src/**` changes.

## Deviations

None.
