### PR TITLE
chore(config): declare governedRoots — fix governance-derivation split (#4730-class)

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -8,6 +8,13 @@
 	// on #5959: the grant-author set is repo configuration, not a compiled-in "founder" concept —
 	// GitHub usernames and teams, both `@`-prefixed as GitHub writes them. In phoenix it is the
 	// three founder accounts. One grant buys exactly one round.
+	// The governed roots — declared verbatim per the shipped default (config/keys/governed-roots.ts):
+	// phoenix's four roots plus this file. Declared explicitly 2026-08-26 after the two-derivations
+	// mismatch (#4730-class) parked PRs #7085/#7114: ship gate raises governance from raw paths
+	// (#5036) while review scope/post dropped the namespace absent this declaration — the gate
+	// demanded what the reviewer verb could not emit.
+	"governedRoots": [".decisions/", ".claude/", ".github/", "claude-plugins/", ".fabrika.jsonc"],
+
 	"capClearAuthors": ["@usirin", "@notusirin", "@cansirin"],
 
 	// Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `campaign


### PR DESCRIPTION
## The deadlock

Two parked PRs tonight — #7085 and #7114 (documented at https://github.com/kamp-us/phoenix/pull/7114#issuecomment-5422802603):

- `ship gate` auto-raises the `governance` namespace when a diff touches a governed root (`.decisions/`, `.claude/`, `.github/`, `claude-plugins/` or this config) per #5036.
- `review scope` / `review post` **dropped** governance from their emitted namespace set because `.fabrika.jsonc` declared no `governedRoots`: `review scope 7085` literally printed "governance derived over 5 root(s) — the shipped governedRoots — .fabrika.jsonc declares no governedRoots" and still listed only review-code/review-doc. `review post --namespace governance` then exit-10'd: "not derived by #7085's diff (present: review-code, review-doc)".

Result: the gate demanded exactly what no reviewer verb could emit. Two derivations of one namespace, two answers (#4730-class).

## The fix

Declare `governedRoots` verbatim per its own shipped default ([config/keys/governed-roots.ts](packages/fabrika-cli/src/config/keys/governed-roots.ts)): phoenix's four roots plus `.fabrika.jsonc` itself. This widens emission to match what the gate already demands; it weakens no guard and changes no gate behavior.

Verified locally: after declaring, `fabrika review scope 7085` emits `namespace governance · required`.

Reference-only: fixes nothing externally; unblocks the two parked ships.