### PR TITLE
fix: Repair claim and issue-bound tree proof use different subjects

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -42,8 +42,9 @@ Done when it printed this tree's root. Work wherever you were spawned; where tha
 the operator's call, not yours. On exit 13 (dirty) or 14 (wrong lane) **stop and report the
 code** — never clean up an unauthored hunk, never build on another lane's branch.
 Re-prove before every mutation. Before `build branch` has cut the lane branch, use
-`fabrika build tree --require-clean`; there is no branch identity for `--issue` to prove yet. Once
-the lane branch exists, use `fabrika build tree --issue <n>` so the lane check arms too.
+`fabrika build tree --require-clean`; there is no branch identity to prove yet. Once the lane branch
+exists, a fresh build uses `fabrika build tree --issue <n>`. A PR repair uses the complete relationship
+proof in Repair: `fabrika build tree --issue <served-issue> --repair <pr>`.
 
 ```bash
 fabrika build pick
@@ -214,9 +215,10 @@ fabrika build branch $issue_or_pr_number --slug editor-focus-loss --token <claim
 
 Construct. Match the surrounding artifact's idiom; for code: domain logic in domain objects,
 invalid states unrepresentable. Before the first `build branch` cut, re-run
-`fabrika build tree --require-clean`; after that cut, re-run
-`fabrika build tree --issue $issue_or_pr_number` before every git mutation. The cwd resets between
-shell calls, so the tree you proved is not the tree you are standing in until you prove it again.
+`fabrika build tree --require-clean`; after that cut, re-run `fabrika build tree --issue
+$issue_or_pr_number` before every fresh-build git mutation. PR repair uses the two-subject form in
+Repair instead. The cwd resets between shell calls, so the tree you proved is not the tree you are
+standing in until you prove it again.
 
 **A lane never runs `git stash` — not scoped, not any form.** `refs/stash` lives in the common git
 dir, so every worktree of this clone shares one stack: between your push and your pop a sibling
@@ -427,11 +429,16 @@ a run whose caller named no lane prints the token only and records nothing.
 
 ## Repair
 
+A repair brief carries two distinct Ground URLs: the PR being repaired and the issue it serves.
+Retain them as `<repair-pr>` and `<served-issue>`; they are operands, not values to rediscover from a
+stderr subject line. If the brief does not name exactly one of each, stop `STOPPED`: never reuse the
+PR number as the issue, never claim the issue as a substitute, and never guess from a branch name.
+
 Claim the PR's number first — repair mutates a shared lane exactly like a build does:
 
 ```bash
-fabrika build claim $issue_or_pr_number
-fabrika build verdicts --pr $issue_or_pr_number
+fabrika build claim <repair-pr>
+fabrika build verdicts --pr <repair-pr>
 ```
 
 **Step 1's refusal of a `type:decision` is about picking one up fresh, and it does not reach here.**
@@ -454,15 +461,30 @@ you never do is grant one: `build clear` is the operator's verb, it refuses an a
 repo's configured set or below `write` at the ACL, and an escalation is your whole move when the cap
 is reached. One grant is one
 round — it survives the push it permits, and the next FAIL round spends it, so a second round needs a
-second grant. Fix findings on the same branch
-(`fabrika build tree --issue $issue_or_pr_number`, then `fabrika build branch --resume $issue_or_pr_number --token <claim-token>`), re-validate with
-`fabrika build check --surface <yours>`, push with `fabrika build push --force-with-lease`, answer
-the findings in a `fabrika build note $issue_or_pr_number --token <claim-token>` naming each one
-addressed, then release with `fabrika build release $issue_or_pr_number --token <claim-token>`. Exit `23` on that push
-means your head **drops commits the PR already published** — `build branch --resume` again so you
-rebuild on the published head, never `--drop-remote-commits`, which is for a rewrite you actually
-intend. The fold's `frozenCriteria` rows are the review-appended criteria past the freeze — note
-them, do not chase them.
+second grant. Before the branch mutation, re-run `build confirm <repair-pr> --token <claim-token>`
+and `build tree --require-clean`; then resume and arm the complete repair proof:
+
+```bash
+fabrika build branch --resume <repair-pr> --token <claim-token>
+fabrika build tree --issue <served-issue> --repair <repair-pr>
+```
+
+Proceed only on the documented JSON answer whose `claim.number` is `<repair-pr>` and whose
+`servedIssue.number` is `<served-issue>`; this is one verb proving that the resumed branch names the
+PR, carries that PR claim's nonce, and the live PR uniquely serves the issue. Do not parse any
+incidental diagnostic. Exit `4` means the unique linkage is malformed, `7` means the PR or issue is
+absent/closed, `10` means the repair PR lacked its issue operand, `11` means a claim/linkage read is
+UNKNOWN, `14` means the branch, nonce, PR, or issue relationship is wrong, and `15` means the PR
+claim is foreign: stop on every one before
+mutation, naming the code. Re-run this same two-subject proof before each later git mutation.
+
+Then re-validate with `fabrika build check --surface <yours>`, push with `fabrika build push
+--force-with-lease`, answer the findings in a `fabrika build note <repair-pr> --token <claim-token>`
+naming each one addressed, then release with `fabrika build release <repair-pr> --token
+<claim-token>`. Exit `23` on that push means your head **drops commits the PR already published** —
+`build branch --resume` again so you rebuild on the published head, never
+`--drop-remote-commits`, which is for a rewrite you actually intend. The fold's `frozenCriteria`
+rows are the review-appended criteria past the freeze — note them, do not chase them.
 
 **When the whole fix is the PR body, the route is `fabrika build pr-body <pr>` and nothing else.**
 The recurring one is a FAIL reading `deviations malformed`: the head does not need to move, so a

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -360,7 +360,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 **Invocation**
 
 ```
-fabrika build tree [--require-clean] [--issue <n>]
+fabrika build tree [--require-clean] [--issue <n> [--repair <pr>]]
 ```
 
 **Inputs**
@@ -368,32 +368,47 @@ fabrika build tree [--require-clean] [--issue <n>]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--require-clean` | boolean | no | `false` | additionally refuse a tree with any uncommitted change — the lane-open posture |
-| `--issue` | integer | no | — | additionally prove the checked-out branch carries this claim's nonce — the pre-mutation posture |
+| `--issue` | integer | no | — | additionally prove the checked-out branch serves this issue — the pre-mutation posture |
+| `--repair` | integer | no | — | with `--issue`, prove this repair PR's claim, resumed branch and unique served-issue linkage as one relationship |
 
-**Output** — machine. One line, the tree root's absolute path, newline-terminated. This verb
-**reads and never repairs**: it creates nothing, cleans nothing, removes nothing. It also asserts
-nothing about *where* the tree is — that is the operator's call, not fabrika's (#5386).
+**Output** — machine. With neither `--issue` nor `--repair`, one line containing the tree root's
+absolute path. With `--issue`, one JSON object:
+`{"answer":"proven","root":"<absolute>","branch":"<name>","claim":{"number":<issue-or-pr>,"nonce":"<nonce>"},"servedIssue":{"number":<issue>,"kind":"issue|fixes|part-of"}}`.
+A fresh proof puts the issue number in both `claim.number` and `servedIssue.number`, with kind
+`issue`. A repair proof puts the PR in `claim.number`, the issue in `servedIssue.number`, and the
+live PR body's unique winning reference kind in `servedIssue.kind`. This is the whole successful
+repair answer; the skill consumes this object, never a scope line or incidental diagnostic.
 
-The two assertions, each proven from git state alone:
+This verb **reads and never repairs**: it creates nothing, cleans nothing, removes nothing. It also
+asserts nothing about *where* the tree is — that is the operator's call, not fabrika's (#5386).
+
+The assertions:
 
 1. **Clean at open** (`--require-clean`) — any uncommitted change is `13`. A fresh tree carrying
    an unauthored hunk is not yours to keep *or* to clean (#2666).
-2. **This lane's branch** (`--issue`) — the checked-out branch parses as a lane branch whose
-   number is `--issue` and whose nonce matches the confirmed claim (the lane-identity rule, defined
-   in `build branch`); a non-lane, wrong-number, or nonce-mismatched branch is `14`. **The branch's
-   own nonce is the identity the claim is read under** — the question is whether the winning marker
-   belongs to THIS lane, not to this session (#6037) — so a claim won by a sibling lane of the same
-   session is `14` as well, and only another session's claim is `15`. No stamp file exists to check:
-   ownership is derivable, not recorded.
+2. **Fresh lane** (`--issue`, without `--repair`) — the checked-out create branch names that issue
+   and carries that issue's winning claim nonce. A non-lane, wrong-number, or nonce mismatch is `14`.
+3. **Repair lane** (`--issue <n> --repair <pr>`) — one fail-closed flow proves all subjects: the
+   checked-out resume branch names `<pr>`; its nonce owns `<pr>`'s winning claim; the live, open PR
+   names exactly one issue through the same closing-keyword/`Part of` grammar review reads; that issue
+   is `<n>`, is live and readable, and is an issue rather than another pull request. The PR is never passed as the issue operand, the issue is never
+   queried for the repair claim, and no branch number is guessed into a served issue.
+
+**The branch's own nonce is the identity the claim is read under** — the question is whether the
+winning marker belongs to THIS lane, not to this session (#6037). A sibling lane of the same session
+is `14`; only another session's claim is `15`. No stamp file exists to check.
 
 **Exit status** (beyond the universal four)
 
 | Code | Trigger |
 |---|---|
-| `11` | the tree root could not be read, or with `--issue` the claim state could not be read — UNKNOWN |
+| `4` | the PR body names zero or several served issues — no unique repair subject |
+| `7` | the repair PR or its uniquely linked served issue is proven absent or closed |
+| `10` | `--repair` was given without its required `--issue` operand |
+| `11` | the tree root, claim state, repair PR, or linked served issue could not be read — UNKNOWN |
 | `13` | proven: uncommitted changes present at a `--require-clean` open |
-| `14` | proven: the checked-out branch is not a lane branch, or does not carry the winning claim's nonce (including a sibling lane of this session) |
-| `15` | proven: the claim on `--issue` is held by another session |
+| `14` | proven: non-lane/wrong-number branch, nonce mismatch, wrong repair PR branch, or PR linked to an issue other than `--issue` |
+| `15` | proven: the issue claim in fresh mode or PR claim in repair mode is held by another session |
 
 **Errors**
 
@@ -401,18 +416,38 @@ The two assertions, each proven from git state alone:
 |---|---|---|
 | `build tree: cannot read the tree root: <reason> — the ground is UNKNOWN.` | 11 | refusal |
 | `build tree: <n> uncommitted change(s) at open — refusing; an unauthored hunk is not yours to keep or clean.` | 13 | refusal |
+| `build tree: --repair <pr> requires --issue <n>.` | 10 | refusal |
 | `build tree: the checked-out branch "<name>" is not a lane branch — wrong lane.` | 14 | refusal |
+| `build tree: the checked-out branch "<name>" names claim #<actual>, not issue #<n>|repair PR #<pr> — wrong lane.` | 14 | refusal |
 | `build tree: the checked-out branch "<name>" does not carry claim <token>'s nonce — wrong lane.` | 14 | refusal |
 | `build tree: cannot read the claim markers on #<n>: <reason> — the lane is UNKNOWN.` | 11 | refusal |
 | `build tree: #<n> is held by <winning token>, not by the lane on nonce <nonce>.` | 15 | refusal |
+| `build tree: cannot read repair PR #<pr>: <reason> — its served issue is UNKNOWN; nothing is proven.` | 11 | refusal |
+| `build tree: PR #<pr> is proven absent or closed.` | 7 | refusal |
+| `build tree: repair PR #<pr> names <count> served issues through <kind>; exactly one is required, so the repair subject is not uniquely readable.` | 4 | refusal |
+| `build tree: repair PR #<pr> serves issue #<actual>, not requested issue #<n> — wrong lane.` | 14 | refusal |
+| `build tree: cannot read issue #<n>, which repair PR #<pr> serves: <reason> — the repair subject is UNKNOWN; nothing is proven.` | 11 | refusal |
+| `build tree: issue #<n> is proven absent or closed.` | 7 | refusal |
+| `build tree: repair PR #<pr> links #<n>, but that record is itself a pull request, not the served issue — wrong lane.` | 14 | refusal |
 
-**Scope** — not a judging verb: it reads this process's git state and, with `--issue`, one claim.
+**Scope** — not a judging verb: it reads this process's git state, one claim, and in repair the live
+PR plus its one served issue.
 
 **Examples**
 
 ```
 $ fabrika build tree --require-clean
 /private/var/<redacted>/lanes/build-4312
+```
+
+```
+$ fabrika build tree --issue 4312
+{"answer":"proven","root":"/private/var/<redacted>/lanes/build-4312","branch":"build/4312-editor-focus-loss-c1a4d6f8","claim":{"number":4312,"nonce":"c1a4d6f8"},"servedIssue":{"number":4312,"kind":"issue"}}
+```
+
+```
+$ fabrika build tree --issue 7181 --repair 7182
+{"answer":"proven","root":"/private/var/<redacted>/lanes/repair-7182","branch":"build/pr-7182-c1a4d6f8","claim":{"number":7182,"nonce":"c1a4d6f8"},"servedIssue":{"number":7181,"kind":"fixes"}}
 ```
 
 ```
@@ -428,6 +463,8 @@ $ echo $?
 - #4500 — eight trees under one stamp; the nonce comparison has no stamp to duplicate.
 - #4162 — the cwd resets between shell calls, so the skill re-runs this verb before every git
   mutation: a pass is a fact about this invocation and nothing later.
+- #7183 — a repair branch carries a PR claim nonce while its contract belongs to a distinct issue;
+  the repair proof binds both subjects instead of weakening either one.
 - 2026-08-13 ruling on #5386 — fabrika holds no worktree opinion; `12` is retired and this verb
   asserts nothing about where the tree sits.
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -194,7 +194,7 @@ Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build
 
 | Verb | Answers |
 |---|---|
-| `build tree` | whether the ground is clean and this lane's, wherever it sits |
+| `build tree` | whether the ground is clean and the complete fresh issue or repair PR→issue lane relationship is proven |
 | `build pick` | the ranked candidate pool, with every excluded issue under the axis that refused it |
 | `build eligible` | whether one issue's dependency gate is open |
 | `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, re-prove it, retract it, or take a dead session's |

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -87,25 +87,34 @@ const tree = leafCommand(
 		issue: Flag.integer("issue").pipe(
 			Flag.optional,
 			Flag.withDescription(
-				"additionally prove the checked-out branch carries this claim's nonce — the pre-mutation posture",
+				"additionally prove the checked-out branch serves this issue — the pre-mutation posture",
+			),
+		),
+		repair: Flag.integer("repair").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the repair PR whose claim and resumed branch must uniquely serve --issue",
 			),
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({requireClean, issue, repo}) {
+	Effect.fn(function* ({requireClean, issue, repair, repo}) {
 		yield* emit(
 			yield* runTree({
 				requireClean,
 				issue: Option.getOrNull(issue),
+				repair: Option.getOrNull(repair),
 				repo: Option.getOrNull(repo),
 				env: process.env,
 			}),
 		);
 	}),
 ).pipe(
-	Command.withShortDescription("Prove the ground is clean and this lane's, wherever it sits."),
+	Command.withShortDescription(
+		"Prove clean ground and the complete fresh or repair lane relationship.",
+	),
 	Command.withDescription(
-		"Prove the ground: optionally clean, optionally this lane's. Where the tree sits is not asserted — isolation is the operator's call, not fabrika's. Prints the tree root's absolute path on stdout. Reads and NEVER repairs — it cleans, creates and removes nothing. Exits 11 (the tree root could not be read, or with --issue the claim state could not be read — UNKNOWN), 13 (proven: uncommitted changes at a --require-clean open), 14 (proven: the checked-out branch is not a lane branch, or does not carry the winning claim's nonce), 15 (proven: the claim on --issue is held by another session). Example: fabrika build tree --require-clean",
+		'Prove the ground: optionally clean; with --issue, prove the checked-out branch, winning claim, and served issue as one relationship. Add --repair <pr> on a resumed repair branch: the branch must name that PR, carry that PR claim\'s nonce, and the live PR must uniquely serve --issue. Armed success prints {"answer":"proven","root":"<absolute>","branch":"<name>","claim":{"number":<issue-or-pr>,"nonce":"<nonce>"},"servedIssue":{"number":<issue>,"kind":"issue|fixes|part-of"}}. An unarmed success prints only the absolute root. Reads and NEVER repairs. Exits 4 (repair linkage malformed or not unique), 7 (repair PR or served issue absent/closed), 10 (--repair without --issue), 11 (ground, claim, PR, or served issue unreadable — UNKNOWN), 13 (dirty at --require-clean), 14 (wrong branch, nonce, PR, or served issue), 15 (claim foreign). Example: fabrika build tree --issue 7181 --repair 7182',
 	),
 );
 

--- a/packages/fabrika-cli/src/build/tree-verb.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.ts
@@ -1,10 +1,12 @@
 /**
- * `build tree` — the ground, proven from git state and one claim, and never repaired.
+ * `build tree` — the ground, proven from git state and one whole lane relationship, and never repaired.
  *
  * Two assertions, each with its own code so a caller can act on which one failed: a clean tree at a
- * `--require-clean` open (`13`), and a checked-out branch carrying this claim's nonce (`14`). Both are
- * location-neutral — where the lane runs is the operator's call, not fabrika's (#5386). It reads and
- * never repairs: no clean, no create, no remove.
+ * `--require-clean` open (`13`), and a checked-out branch carrying this claim's nonce (`14`). A fresh
+ * proof binds one issue branch to that issue's claim. A repair proof additionally binds the resumed
+ * branch to the named PR, that PR's winning claim, and the one issue its live body serves (#7183).
+ * Both are location-neutral — where the lane runs is the operator's call, not fabrika's (#5386). It
+ * reads and never repairs: no clean, no create, no remove.
  *
  * The skill re-runs this before every git mutation because the shell's cwd resets between calls, so a
  * pass here is a fact about *this* invocation and nothing later.
@@ -12,19 +14,22 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {currentBranch} from "../io/issues.ts";
+import {issueRefsOf} from "../review/classes.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {laneCaller, requireClaim, requireSession} from "./claim.ts";
-import {WRONG_LANE} from "./codes.ts";
-import {parseLaneBranch} from "./lane.ts";
-import {resolveTargetRepo} from "./target.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, WRONG_LANE} from "./codes.ts";
+import {laneNumber, parseLaneBranch} from "./lane.ts";
+import {openIssue, openPull, resolveTargetRepo} from "./target.ts";
 import {assertGround} from "./tree.ts";
 
 const VERB = "build tree";
 
 export interface TreeOptions {
 	readonly requireClean: boolean;
-	/** Additionally prove the checked-out branch carries this claim's nonce — the pre-mutation posture. */
+	/** Additionally prove the checked-out branch serves this issue — the pre-mutation posture. */
 	readonly issue: number | null;
+	/** In repair, the PR claim and resumed branch that must uniquely serve `issue`. */
+	readonly repair: number | null;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
@@ -35,7 +40,11 @@ export const runTree = (
 	Effect.gen(function* () {
 		const ground = yield* assertGround(VERB, options.requireClean);
 		if (ground._tag === "Refused") return ground.outcome;
-		if (options.issue === null) return answer(ground.root);
+		if (options.issue === null) {
+			return options.repair === null
+				? answer(ground.root)
+				: refuse(OFF_VOCABULARY, `${VERB}: --repair <pr> requires --issue <n>.`);
+		}
 
 		const session = requireSession(VERB, options.env);
 		if (session._tag === "Refused") return session.outcome;
@@ -54,10 +63,26 @@ export const runTree = (
 			);
 		}
 
+		const repair = options.repair;
+		const issueNumber = options.issue;
+		const expectedClaim = repair ?? issueNumber;
+		const correctBranch =
+			repair === null
+				? lane._tag === "Create" && lane.number === issueNumber
+				: lane._tag === "Resume" && lane.pr === repair;
+		if (!correctBranch) {
+			return refuse(
+				WRONG_LANE,
+				`${VERB}: the checked-out branch "${branch}" names claim #${laneNumber(lane)}, not ${
+					repair === null ? `issue #${issueNumber}` : `repair PR #${repair}`
+				} — wrong lane.`,
+			);
+		}
+
 		const held = yield* requireClaim(
 			VERB,
 			resolved.repo,
-			options.issue,
+			expectedClaim,
 			laneCaller(session.id, lane.nonce),
 		);
 		if (held._tag === "Refused") {
@@ -69,5 +94,75 @@ export const runTree = (
 					)
 				: held.outcome;
 		}
-		return answer(ground.root, held.notes);
+
+		if (repair === null) {
+			return answer(
+				JSON.stringify({
+					answer: "proven",
+					root: ground.root,
+					branch,
+					claim: {number: issueNumber, nonce: lane.nonce},
+					servedIssue: {number: issueNumber, kind: "issue"},
+				}),
+				held.notes,
+			);
+		}
+
+		const pull = yield* openPull(
+			VERB,
+			resolved.repo,
+			repair,
+			(reason) =>
+				`${VERB}: cannot read repair PR #${repair}: ${reason} — its served issue is UNKNOWN; nothing is proven.`,
+		);
+		if (pull._tag === "Refused") return pull.outcome;
+		const linkage = issueRefsOf(pull.pull.body);
+		if (linkage.numbers.length !== 1) {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: repair PR #${repair} names ${linkage.numbers.length} served issues through ${linkage.kind}; exactly one is required, so the repair subject is not uniquely readable.`,
+				held.notes,
+			);
+		}
+		const servedIssue = linkage.numbers[0];
+		if (servedIssue === undefined) {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: repair PR #${repair}'s served issue disappeared while reading its linkage — nothing is proven.`,
+				held.notes,
+			);
+		}
+		if (servedIssue !== issueNumber) {
+			return refuse(
+				WRONG_LANE,
+				`${VERB}: repair PR #${repair} serves issue #${servedIssue}, not requested issue #${issueNumber} — wrong lane.`,
+				held.notes,
+			);
+		}
+		const issue = yield* openIssue(
+			VERB,
+			resolved.repo,
+			servedIssue,
+			(reason) =>
+				`${VERB}: cannot read issue #${servedIssue}, which repair PR #${repair} serves: ${reason} — the repair subject is UNKNOWN; nothing is proven.`,
+		);
+		if (issue._tag === "Refused") return issue.outcome;
+		if (issue.issue.isPullRequest) {
+			return refuse(
+				WRONG_LANE,
+				`${VERB}: repair PR #${repair} links #${servedIssue}, but that record is itself a pull request, not the served issue — wrong lane.`,
+				held.notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "proven",
+				root: ground.root,
+				branch,
+				claim: {number: repair, nonce: lane.nonce},
+				servedIssue: {number: servedIssue, kind: linkage.kind},
+			}),
+			held.notes,
+		);
 	});

--- a/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
@@ -360,8 +360,20 @@ describe("runTree", () => {
 	});
 
 	it("does not accept the PR number as the served issue", async () => {
-		const out = await run(repairProof(), {issue: 7182, repair: 7182});
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, repairBranch],
+				[REPAIR_CLAIM, repairClaim],
+				[REPAIR_COMMENTS, repairMine],
+				[PERM, WRITE],
+				[REPAIR_PULL, repairPull("Fixes #7182\n\n## Deviations\nNone.\n")],
+				[REPAIR_CLAIM, repairClaim],
+			],
+			{issue: 7182, repair: 7182},
+		);
 		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("that record is itself a pull request");
 	});
 
 	it("does not accept the served issue as the repair claim subject", async () => {

--- a/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
@@ -2,7 +2,14 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
 import {FAILED} from "../verb.ts";
-import {CLAIM_NOT_MINE, DIRTY_TREE, PRECONDITION_UNKNOWN, WRONG_LANE} from "./codes.ts";
+import {
+	BAD_SECTIONS,
+	CLAIM_NOT_MINE,
+	DIRTY_TREE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	WRONG_LANE,
+} from "./codes.ts";
 import {
 	comments,
 	GATEWAY,
@@ -11,6 +18,7 @@ import {
 	LANE_UUID,
 	marker,
 	NONCE,
+	pull,
 	served,
 } from "./fixtures.test-support.ts";
 import {runTree} from "./tree-verb.ts";
@@ -24,6 +32,10 @@ const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
 const ISSUE = /GET .*\/repos\/o\/r\/issues\/4312$/;
 const COMMENTS = /GET .*\/repos\/o\/r\/issues\/4312\/comments/;
 const PERM = /GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+const REPAIR_CLAIM = /GET .*\/repos\/o\/r\/issues\/7182$/;
+const REPAIR_COMMENTS = /GET .*\/repos\/o\/r\/issues\/7182\/comments/;
+const REPAIR_PULL = /GET .*\/repos\/o\/r\/pulls\/7182$/;
+const SERVED_ISSUE = /GET .*\/repos\/o\/r\/issues\/7181$/;
 
 const LANE_BRANCH = okOut(`build/4312-editor-focus-loss-${NONCE}\n`);
 const MINE = comments({id: 1, body: marker("s-9f2e", LANE_UUID)});
@@ -31,6 +43,7 @@ const MINE = comments({id: 1, body: marker("s-9f2e", LANE_UUID)});
 const options = {
 	requireClean: false,
 	issue: null as number | null,
+	repair: null as number | null,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
 		string,
@@ -90,7 +103,25 @@ describe("runTree", () => {
 			{issue: 4312},
 		);
 		expect(out.code).toBe(0);
-		expect(out.stdout).toBe("/repo/trees/lane-a\n");
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "proven",
+			root: "/repo/trees/lane-a",
+			branch: `build/4312-editor-focus-loss-${NONCE}`,
+			claim: {number: 4312, nonce: NONCE},
+			servedIssue: {number: 4312, kind: "issue"},
+		});
+	});
+
+	it("refuses a fresh branch naming another issue on 14", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, okOut(`build/9999-editor-focus-loss-${NONCE}\n`)],
+			],
+			{issue: 4312},
+		);
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("not issue #4312");
 	});
 
 	it("refuses a branch carrying another claim's nonce on 14", async () => {
@@ -139,6 +170,12 @@ describe("runTree", () => {
 		expect(out.stderr.at(-1)).toContain("the lane is UNKNOWN");
 	});
 
+	it("refuses --repair without --issue on 10", async () => {
+		const out = await run([[REV_PARSE, GIT_DIRS]], {repair: 7182});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("requires --issue");
+	});
+
 	it("refuses a missing session id on 1, never on 15", async () => {
 		const out = await run([[REV_PARSE, GIT_DIRS]], {
 			issue: 4312,
@@ -148,5 +185,193 @@ describe("runTree", () => {
 		expect(out.stderr.at(-1)).toContain(
 			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION are all unset",
 		);
+	});
+
+	const repairBranch = okOut(`build/pr-7182-${NONCE}\n`);
+	const repairClaim = issue({
+		number: 7182,
+		title: "repair PR",
+		html_url: "https://github.com/o/r/pull/7182",
+		body: "Fixes #7181\n\n## Deviations\nNone.\n",
+		pull_request: {url: "https://api.github.com/repos/o/r/pulls/7182"},
+	});
+	const repairMine = comments({id: 7182, body: marker("s-9f2e", LANE_UUID)});
+	const repairPull = (body = "Fixes #7181\n\n## Deviations\nNone.\n") => pull({number: 7182, body});
+	const servedIssue = issue({number: 7181, html_url: "https://github.com/o/r/issues/7181"});
+	const repairProof = (body?: string): ReadonlyArray<Scripted> => [
+		[REV_PARSE, GIT_DIRS],
+		[BRANCH, repairBranch],
+		[REPAIR_CLAIM, repairClaim],
+		[REPAIR_COMMENTS, repairMine],
+		[PERM, WRITE],
+		[REPAIR_PULL, repairPull(body)],
+		[SERVED_ISSUE, servedIssue],
+	];
+
+	it("proves issue #7181 through PR #7182's winning claim and resumed branch", async () => {
+		const out = await run(repairProof(), {issue: 7181, repair: 7182});
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "proven",
+			root: "/repo/trees/lane-a",
+			branch: `build/pr-7182-${NONCE}`,
+			claim: {number: 7182, nonce: NONCE},
+			servedIssue: {number: 7181, kind: "fixes"},
+		});
+	});
+
+	it("retains issue #7162 / PR #7180 as distinct repair identifiers", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, okOut(`build/pr-7180-${NONCE}\n`)],
+				[
+					/GET .*\/repos\/o\/r\/issues\/7180$/,
+					issue({
+						number: 7180,
+						title: "existing repair PR",
+						html_url: "https://github.com/o/r/pull/7180",
+						body: "Fixes #7162\n\n## Deviations\nNone.\n",
+						pull_request: {url: "https://api.github.com/repos/o/r/pulls/7180"},
+					}),
+				],
+				[
+					/GET .*\/repos\/o\/r\/issues\/7180\/comments/,
+					comments({id: 7180, body: marker("s-9f2e", LANE_UUID)}),
+				],
+				[PERM, WRITE],
+				[
+					/GET .*\/repos\/o\/r\/pulls\/7180$/,
+					pull({
+						number: 7180,
+						body: "Fixes #7162\n\n## Deviations\nNone.\n",
+					}),
+				],
+				[
+					/GET .*\/repos\/o\/r\/issues\/7162$/,
+					issue({
+						number: 7162,
+						html_url: "https://github.com/o/r/issues/7162",
+					}),
+				],
+			],
+			{issue: 7162, repair: 7180},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			claim: {number: 7180},
+			servedIssue: {number: 7162},
+		});
+	});
+
+	it("refuses a wrong repair PR branch before reading claim or linkage", async () => {
+		const seams = fakeSeams([
+			[REV_PARSE, GIT_DIRS],
+			[BRANCH, okOut(`build/pr-7180-${NONCE}\n`)],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runTree({...options, issue: 7181, repair: 7182}), seams.layer),
+		);
+		expect(out.code).toBe(WRONG_LANE);
+		expect(seams.calls.some((call) => call.includes("/issues/7182"))).toBe(false);
+	});
+
+	it("refuses a repair nonce that does not own the PR claim on 14", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, repairBranch],
+				[REPAIR_CLAIM, repairClaim],
+				[
+					REPAIR_COMMENTS,
+					comments({id: 7182, body: marker("s-9f2e", "deadbeef-3b7e-4a19-9c2d-5e8f0a1b2c3d")}),
+				],
+				[PERM, WRITE],
+			],
+			{issue: 7181, repair: 7182},
+		);
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("does not carry claim");
+	});
+
+	it("refuses a PR serving another issue on 14", async () => {
+		const out = await run(repairProof("Fixes #7162\n\n## Deviations\nNone.\n"), {
+			issue: 7181,
+			repair: 7182,
+		});
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("serves issue #7162, not requested issue #7181");
+	});
+
+	it.each([
+		["no linkage", "Summary only\n\n## Deviations\nNone.\n", 0],
+		["ambiguous linkage", "Fixes #7181\nFixes #7162\n\n## Deviations\nNone.\n", 2],
+	])("refuses %s on 4", async (_name, body, count) => {
+		const out = await run(repairProof(body), {issue: 7181, repair: 7182});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toContain(`names ${count} served issues`);
+	});
+
+	it("refuses unreadable PR claim state on 11", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, repairBranch],
+				[REPAIR_CLAIM, repairClaim],
+				[REPAIR_COMMENTS, GATEWAY],
+			],
+			{issue: 7181, repair: 7182},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the lane is UNKNOWN");
+	});
+
+	it("refuses unreadable PR linkage on 11", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, repairBranch],
+				[REPAIR_CLAIM, repairClaim],
+				[REPAIR_COMMENTS, repairMine],
+				[PERM, WRITE],
+				[REPAIR_PULL, GATEWAY],
+			],
+			{issue: 7181, repair: 7182},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("served issue is UNKNOWN");
+	});
+
+	it("refuses an unreadable served issue on 11", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, repairBranch],
+				[REPAIR_CLAIM, repairClaim],
+				[REPAIR_COMMENTS, repairMine],
+				[PERM, WRITE],
+				[REPAIR_PULL, repairPull()],
+				[SERVED_ISSUE, GATEWAY],
+			],
+			{issue: 7181, repair: 7182},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("repair subject is UNKNOWN");
+	});
+
+	it("does not accept the PR number as the served issue", async () => {
+		const out = await run(repairProof(), {issue: 7182, repair: 7182});
+		expect(out.code).toBe(WRONG_LANE);
+	});
+
+	it("does not accept the served issue as the repair claim subject", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, GIT_DIRS],
+				[BRANCH, repairBranch],
+			],
+			{issue: 7181, repair: 7181},
+		);
+		expect(out.code).toBe(WRONG_LANE);
 	});
 });


### PR DESCRIPTION
Makes `build tree` prove the complete lane relationship instead of forcing repair callers to choose between the served issue and the PR claim. Repair proofs now bind the resumed PR branch, its winning claim nonce, and its one live served issue in a documented JSON answer, while fresh issue proofs retain their refusal semantics.

The regression suite models issue #7181 with PR #7182, covers every fail-closed repair outcome, and preserves issue #7162 with PR #7180 as distinct-identifier evidence. The build skill, contract, CLI help, and package reference now consume and describe the same grammar.

Fixes #7183

## Deviations

- **Pre-existing test or fixture changed** — **Said:** The fresh `build tree --issue` test expected root-path stdout. **Did:** replaced that assertion with the documented structured JSON answer. **Why:** the acceptance criteria require machine output for the armed proof while preserving unarmed root-only output. **Disposition:** stated here.
