### PR TITLE
fix: Epic repair builder stalls on pre-branch tree proof

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -507,9 +507,19 @@ On a standing `FAIL` there is a repair to take, and the route the refusal names 
 ```bash
 fabrika build claim $issue_or_pr_number --resume
 fabrika build verdicts --issue $issue_or_pr_number
-fabrika build tree --issue $issue_or_pr_number
+fabrika build confirm $issue_or_pr_number --token <claim-token>
+fabrika build tree --require-clean
 fabrika build branch $issue_or_pr_number --resume-lane --token <claim-token>
+fabrika build tree --issue $issue_or_pr_number
 ```
+
+That order separates the generic isolated checkout from the lane branch it does not stand on yet.
+`confirm` proves the repair claim before the branch mutation, and `tree --require-clean` proves the
+generic checkout without arming lane identity. Only `--resume-lane` may re-key and check out the
+prior branch. After it succeeds, the armed `tree --issue` proof checks the child number, the current
+repair-claim nonce, and live claim ownership. Re-run that armed proof before every later git
+mutation; never move it ahead of `--resume-lane`, and never weaken wrong-lane exit `14` to admit a
+generic harness branch.
 
 `--resume` is checked against the board, not trusted: on a child holding no standing `FAIL` it
 refuses on `31` too, so the flag can never be typed past the fence. `--resume-lane` **re-keys** the

--- a/packages/fabrika-cli/src/build/epic-child-repair-order.data.unit.test.ts
+++ b/packages/fabrika-cli/src/build/epic-child-repair-order.data.unit.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The epic-child repair route is executable data in the checked-in build skill. `tree --issue`
+ * requires the lane branch, while `branch --resume-lane` is the transition that establishes it;
+ * pinning their order here prevents a generic isolated checkout from stalling before that transition
+ * (#7185).
+ */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+const BUILD_SKILL = fileURLToPath(
+	new URL("../../../../claude-plugins/fabrika/skills/build/SKILL.md", import.meta.url),
+);
+
+const standingFailCommands = (): ReadonlyArray<string> => {
+	const source = readFileSync(BUILD_SKILL, "utf8");
+	const route = source.indexOf("On a standing `FAIL` there is a repair to take");
+	assert.isAtLeast(route, 0, "the epic-child standing-FAIL route is absent");
+
+	const fence = source.indexOf("```bash\n", route);
+	assert.isAtLeast(fence, 0, "the epic-child standing-FAIL route has no bash fence");
+	const commandsStart = fence + "```bash\n".length;
+	const fenceEnd = source.indexOf("\n```", commandsStart);
+	assert.isAtLeast(fenceEnd, 0, "the epic-child standing-FAIL route has no closing fence");
+
+	return source
+		.slice(commandsStart, fenceEnd)
+		.split("\n")
+		.filter((line) => line.startsWith("fabrika build "));
+};
+
+describe("the build skill's epic-child standing-FAIL entry (#7185)", () => {
+	it("proves cleanliness before resume-lane and arms lane identity only after checkout", () => {
+		assert.deepStrictEqual(standingFailCommands(), [
+			"fabrika build claim $issue_or_pr_number --resume",
+			"fabrika build verdicts --issue $issue_or_pr_number",
+			"fabrika build confirm $issue_or_pr_number --token <claim-token>",
+			"fabrika build tree --require-clean",
+			"fabrika build branch $issue_or_pr_number --resume-lane --token <claim-token>",
+			"fabrika build tree --issue $issue_or_pr_number",
+		]);
+	});
+});


### PR DESCRIPTION
The epic-child standing-FAIL route now proves the repair claim and generic checkout cleanliness before `--resume-lane`, then arms the issue-specific lane proof only after the prior branch is re-keyed and checked out. This lets isolated repair workers reach the sanctioned branch transition without weakening wrong-lane rejection.

A data test reads the checked-in build skill and pins the complete command order so the issue-specific proof cannot drift ahead of checkout again.

Fixes #7185

## Deviations

None.
