### PR TITLE
feat(fabrika): the render harness can carry a session

### DIFF
--- a/claude-plugins/fabrika/skills/build-ui/contract.md
+++ b/claude-plugins/fabrika/skills/build-ui/contract.md
@@ -213,6 +213,7 @@ evidence lives — the portable replacement for v1's phoenix-hardcoded "alchemy 
 | `readyPath` | string | no (default `/`) | path polled for HTTP 200 to detect readiness; not ready within 60s is `11` |
 | `viewport` | object `{width, height}` | no (default `{1280, 900}`) | the capture viewport in CSS px |
 | `evidenceStore` | string | no | base URL of a content-addressed evidence store (the ADR 0144/0183 idiom); see `ui evidence` for the two-tier upload protocol |
+| `storageState` | string | no | repo-root-relative path to a Playwright storage-state JSON, seeded into every capture context so surfaces behind a login render as a signed-in user; declared-but-absent is `11` from `ui render`, never a screenshot of the login page. The file is a credential — the repo gitignores it, and the cookies are never inlined here |
 
 A file that exists but violates this schema is `4` from `ui render` — same whole-file rule as the
 registry.

--- a/packages/fabrika-cli/src/ui/browser.ts
+++ b/packages/fabrika-cli/src/ui/browser.ts
@@ -11,6 +11,11 @@
  *
  * A missing browser provision surfaces here as `Unknown` carrying the exact remediation command —
  * never a silent skip, and never a "surface is fine" reading.
+ *
+ * The context is fresh per shot — isolation is the point — so a repo whose surfaces sit behind a
+ * login seeds it from the harness's `storageState` file. The verb has already proven that file
+ * exists; a session that is present but expired lands the login page, which the surface's own
+ * assertions catch.
  */
 import {mkdir, writeFile} from "node:fs/promises";
 import {dirname} from "node:path";
@@ -36,7 +41,12 @@ const isProvisionFailure = (message: string): boolean =>
 	message.includes("Executable doesn't exist") || message.includes("playwright install");
 
 const shoot = async (browser: Browser, request: ShotRequest): Promise<ShotOutcome> => {
-	const context = await attempt(browser.newContext({viewport: {...request.viewport}}));
+	const context = await attempt(
+		browser.newContext({
+			viewport: {...request.viewport},
+			...(request.storageState === null ? {} : {storageState: request.storageState}),
+		}),
+	);
 	if (context instanceof Error) return {_tag: "Unknown", reason: context.message};
 	const page = await attempt(context.newPage());
 	if (page instanceof Error) return {_tag: "Unknown", reason: page.message};

--- a/packages/fabrika-cli/src/ui/harness.ts
+++ b/packages/fabrika-cli/src/ui/harness.ts
@@ -4,6 +4,10 @@
  * The portable replacement for v1's phoenix-hardcoded "alchemy dev" knowledge: the command, the base
  * URL and the readiness probe are the repo's own declaration, so the render leg needs no knowledge of
  * any particular stack. Validated whole-file, the same rule the registry gets.
+ *
+ * `storageState` is the one key naming a file rather than a value: a Playwright storage-state
+ * snapshot, so a repo whose surfaces sit behind a login can be rendered as a logged-in user. It is a
+ * credential, so it is a path the repo gitignores — never the cookies inline.
  */
 import {Effect, Result, Schema, SchemaGetter, SchemaIssue} from "effect";
 import {parseJsonOrReason} from "../io/json.ts";
@@ -30,6 +34,7 @@ const VIOLATION = {
 	width: '"viewport.width" is not a positive integer',
 	height: '"viewport.height" is not a positive integer',
 	evidenceStore: '"evidenceStore" is not a string',
+	storageState: '"storageState" is not a repo-root-relative path',
 } as const;
 
 const KEY_PLACEHOLDER = "%key%";
@@ -65,6 +70,15 @@ const Harness = Schema.Struct({
 	viewport: Viewport,
 	evidenceStore: Schema.NullOr(Schema.String)
 		.annotate({message: VIOLATION.evidenceStore})
+		.pipe(Schema.withDecodingDefaultTypeKey(Effect.succeed(null))),
+	storageState: Schema.NullOr(
+		Schema.String.check(
+			Schema.makeFilter((value) => value.trim() !== "" && !value.startsWith("/"), {
+				message: VIOLATION.storageState,
+			}),
+		),
+	)
+		.annotate({message: VIOLATION.storageState})
 		.pipe(Schema.withDecodingDefaultTypeKey(Effect.succeed(null))),
 }).annotate({message: VIOLATION.topLevel, messageUnexpectedKey: VIOLATION.unknownKey});
 

--- a/packages/fabrika-cli/src/ui/harness.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/harness.unit.test.ts
@@ -15,8 +15,16 @@ describe("parseHarness", () => {
 				readyPath: "/",
 				viewport: DEFAULT_VIEWPORT,
 				evidenceStore: null,
+				storageState: null,
 			},
 		});
+	});
+
+	it("carries a declared storageState through", () => {
+		const parsed = parseHarness(config({storageState: ".fabrika/design-session.json"}));
+		expect(parsed._tag).toBe("Config");
+		if (parsed._tag !== "Config") return;
+		expect(parsed.config.storageState).toBe(".fabrika/design-session.json");
 	});
 
 	it("carries a declared viewport, readyPath and evidenceStore through", () => {
@@ -52,6 +60,16 @@ describe("parseHarness", () => {
 			'"viewport.width" is not a positive integer',
 		],
 		["an unknown key", config({browser: "chromium"}), 'unknown key "browser"'],
+		[
+			"an absolute storageState",
+			config({storageState: "/Users/someone/session.json"}),
+			'"storageState" is not a repo-root-relative path',
+		],
+		[
+			"an empty storageState",
+			config({storageState: "   "}),
+			'"storageState" is not a repo-root-relative path',
+		],
 		[
 			"a non-string command",
 			config({command: 3}),

--- a/packages/fabrika-cli/src/ui/render-verb.ts
+++ b/packages/fabrika-cli/src/ui/render-verb.ts
@@ -48,6 +48,8 @@ export interface ShotRequest {
 	readonly url: string;
 	readonly outPath: string;
 	readonly viewport: {readonly width: number; readonly height: number};
+	/** Absolute path to a Playwright storage-state file, or `null` to browse signed out. */
+	readonly storageState: string | null;
 }
 
 /** The injected browser leg: navigate, classify, screenshot to `outPath`. */
@@ -124,6 +126,7 @@ export const checkOperands = (options: RenderOptions): VerbOutcome | null => {
 const shoot = (
 	options: RenderOptions,
 	config: HarnessConfig,
+	root: string,
 	setDir: string,
 	surface: string,
 ): Effect.Effect<SurfaceResult, never, FileSystem.FileSystem> =>
@@ -133,6 +136,7 @@ const shoot = (
 			url: `${config.url}${surface}`,
 			outPath,
 			viewport: config.viewport,
+			storageState: config.storageState === null ? null : atRoot(root, config.storageState),
 		});
 		if (shot._tag === "Unreachable") {
 			return {
@@ -250,6 +254,24 @@ export const runRender = (
 			);
 		}
 
+		if (harness.config.storageState !== null) {
+			const sessionProbe = yield* probe(lane.root, harness.config.storageState);
+			if (sessionProbe._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot probe ${harness.config.storageState}: ${sessionProbe.reason} — the render path is UNKNOWN.`,
+					lane.notes,
+				);
+			}
+			if (sessionProbe._tag === "Absent") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: ${harnessPath} declares storageState ${harness.config.storageState}, and no file is there — every surface behind a login would capture the login page. Re-authenticate and write the file, or drop the key.`,
+					lane.notes,
+				);
+			}
+		}
+
 		const setDir = `${laneScratchDir(options.tmpRoot, session.id, lane.number, lane.nonce)}/${options.out}`;
 		const started = yield* options.startHarness(harness.config, lane.root);
 		if (started._tag === "Failed") {
@@ -269,7 +291,7 @@ export const runRender = (
 
 		const results = yield* Effect.forEach(
 			options.surfaces,
-			(surface) => shoot(options, harness.config, setDir, surface),
+			(surface) => shoot(options, harness.config, lane.root, setDir, surface),
 			{concurrency: 1},
 		).pipe(Effect.ensuring(started.stop));
 

--- a/packages/fabrika-cli/src/ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/render-verb.unit.test.ts
@@ -82,6 +82,12 @@ const run = (
 	);
 
 const harnessFile = JSON.stringify({command: "pnpm dev", url: "http://127.0.0.1:5173"});
+const SESSION = `${ROOT}/.fabrika/design-session.json`;
+const withSession = JSON.stringify({
+	command: "pnpm dev",
+	url: "http://127.0.0.1:5173",
+	storageState: ".fabrika/design-session.json",
+});
 const captured = {files: {[HARNESS]: harnessFile, [`${SET_DIR}/pano.png`]: PNG}};
 
 describe("runRender operands", () => {
@@ -201,6 +207,42 @@ describe("runRender", () => {
 	it("refuses a harness that violates its schema on 4", async () => {
 		const outcome = await run(LANE_OK, {files: {[HARNESS]: "{}"}});
 		expect(outcome.code).toBe(BAD_SECTIONS);
+	});
+
+	it("refuses on 11 when the harness declares a storageState no file backs", async () => {
+		const outcome = await run(LANE_OK, {
+			files: {...captured.files, [HARNESS]: withSession},
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("would capture the login page");
+	});
+
+	it("hands the resolved storageState path to the browse leg", async () => {
+		const seen: Array<string | null> = [];
+		const outcome = await run(
+			LANE_OK,
+			{files: {...captured.files, [HARNESS]: withSession, [SESSION]: PNG}},
+			{
+				browse: (request) => {
+					seen.push(request.storageState);
+					return Effect.succeed({_tag: "Captured"});
+				},
+			},
+		);
+		expect(outcome.code).toBe(0);
+		expect(seen).toEqual([SESSION]);
+	});
+
+	it("browses signed out when no storageState is declared", async () => {
+		const seen: Array<string | null> = [];
+		const outcome = await run(LANE_OK, captured, {
+			browse: (request) => {
+				seen.push(request.storageState);
+				return Effect.succeed({_tag: "Captured"});
+			},
+		});
+		expect(outcome.code).toBe(0);
+		expect(seen).toEqual([null]);
 	});
 
 	it("refuses a foreign lane on 18", async () => {


### PR DESCRIPTION
Closes #7194

`design-harness.json` declared how a repo starts and where it listens, and nothing else. `ui render`
opens a fresh Chromium context per shot — correct for isolation, fatal for auth — so any surface
behind a login redirected, and the capture came back `Unreachable` or as a screenshot of the login
page. A product repo could only point the harness at something unauthenticated, which is exactly the
surface a placement or hierarchy law has nothing to say about.

The obvious workaround does not exist either. Injecting a session cookie with a reverse proxy fixes
same-origin requests only; a dashboard that calls its auth service cross-origin needs the *browser's*
origin to sit inside the cookie's domain, and proxying to `127.0.0.1` breaks precisely that. It has
to be the browser holding the cookie — which is what `storageState` is for.

## The change

`storageState`: a repo-root-relative path to a Playwright storage-state JSON, defaulting to `null`.
Threaded through `ShotRequest` into `newContext`.

```json
{
  "command": "pnpm dev",
  "url": "https://local.example.io:4000",
  "storageState": ".fabrika/design-session.json"
}
```

Two properties are load-bearing:

**Absolute paths are refused by the schema.** A machine-local path in a committed config is a leak,
and the harness is committed.

**Declared-but-absent refuses on `11` before a single surface is opened**, naming what would
otherwise happen. This is the same rule the readiness probe already follows: a render loop that
silently captures the login page reports green on a page nobody has seen, and that is the failure
this verb exists to make impossible. A session that is present but *expired* still lands the login
page — the surface's own assertions catch that, and no amount of config can tell the two apart ahead
of time.

The file is a credential. It is a path, never inlined cookies, and the repo gitignores it.

## Verification

`pnpm --filter @kampus/fabrika-cli exec vitest run src/ui/` — 114 pass, 13 files. New cases:

- the schema carries a declared `storageState` through, and defaults it to `null`
- an absolute path and an empty string are both violations, with the field's own wording
- a declared `storageState` no file backs refuses on `11`
- the resolved absolute path reaches the browse leg
- no declaration browses signed out

`pnpm lint` and `tsc --noEmit` clean.

## Found while

Adopting `build-ui` / `review-ui` in another repo whose every dashboard route requires a session —
the manifest and the placement law were written, the harness was the thing that could not be built.