### PR TITLE
feat: Allow patterns to guide code before first implementation

### DIFF
--- a/.decisions/0273-fabrika-ships-as-an-installed-plugin.md
+++ b/.decisions/0273-fabrika-ships-as-an-installed-plugin.md
@@ -254,3 +254,26 @@ rather than thirty-two tables, so the checkable violations above read against
 `surfaceDispositions` — a surface fabrika reads with no entry there, or an entry that contradicts
 what its verb does — rather than against a skill's own section. The `undeclared` row and the reader
 that emitted it are gone with the tables.
+
+## Amendment (2026-08-28) — prospective pattern grounding may read a supplied source checkout
+
+The founder ruling on [#7197](https://github.com/kamp-us/phoenix/issues/7197), clarified in
+[the issue thread](https://github.com/kamp-us/phoenix/issues/7197#issuecomment-5449904461), creates
+one narrow exception to this ADR's repo-resident-input rule. `write-pattern` may accept an optional
+caller-supplied local checkout of authoritative dependency source. The exception exists so a binding
+technology or shape decision can be documented before its first implementation; generic framework
+advice, speculative convention, obvious description, and intuition-only rules remain inadmissible.
+There is no fixed current-call-site count for either current-source or prospective admission.
+
+The local path is an invocation input, never durable evidence. Before authoring from it, the verb must
+resolve the checkout's Git root and derive source, test, documentation, origin, commit, package, and
+version evidence from one commit tree. A missing or unusable supplied checkout refuses without a
+write; no local path enters CLI answer text intended for the document or the committed pattern. The
+portable origin, full commit, package version, and repository-relative inspected paths are the only
+derived evidence that may cross the checkout boundary.
+
+`authoritative-source-checkout` records this optional surface in `surfaceDispositions`: omission
+degrades to the existing recurrence-based authoring path, while an explicitly supplied checkout that
+cannot produce the required portable evidence fails loudly. The broader rule still stands for every
+other fabrika input: installed skills do not gain general permission to read machine-local state,
+hosted infrastructure, or files outside the repository they run in.

--- a/.fabrika.schema.json
+++ b/.fabrika.schema.json
@@ -215,6 +215,7 @@
 					"git-worktree",
 					"git-origin",
 					"git-history",
+					"authoritative-source-checkout",
 					"collaborator-permissions",
 					"issue-dependencies",
 					"settings-patch",

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -168,14 +168,23 @@ The infra layer beneath the domain and fate layers. phoenix runs on [alchemy-eff
 
 ## When to add a new pattern doc here
 
-Add a doc when:
+A pattern may enter through either source-backed path:
 
-- A pattern is used in **2+ places** and future agents will need to know it.
-- The pattern is **non-obvious from reading the codebase** — it codifies a design choice rather than describing existing structure.
-- A future agent would otherwise **invent a worse version** if they didn't know about it.
+- **Current shape:** in-repo source and tests demonstrate a reusable shape that future agents need.
+  Cite representative paths and state where the shape stops applying; no fixed call-site count is an
+  admission prerequisite.
+- **Prospective shape:** a cited binding decision names the technology or shape before its first
+  implementation, and authoritative dependency source or docs ground every rule. State the intended
+  scope without inventing current call sites.
 
-Don't add a doc for:
+Both paths must also clear the same two bars:
 
-- One-off implementation details.
-- Things that are obvious from reading the code.
-- Migration steps (those go in vault grill/RFC artifacts, not here).
+- The pattern is **non-obvious** — it codifies a choice rather than narrating code or generic
+  framework guidance.
+- A future agent would otherwise **invent a foreseeable worse version**.
+
+Don't add obvious descriptions, generic framework advice, speculative or undocumented conventions,
+intuition-only rules, one-off implementation details, or migration steps. Every claim must trace to
+the cited current source/tests or authoritative dependency source/docs; if that evidence is unusable,
+decline rather than fall back to intuition. Migration steps belong in vault grill/RFC artifacts, not
+here.

--- a/claude-plugins/fabrika/skills/write-pattern/SKILL.md
+++ b/claude-plugins/fabrika/skills/write-pattern/SKILL.md
@@ -161,18 +161,20 @@ the doc in place instead. The scaffold's exact bytes are the verb's section
 When authoritative source is available as a local checkout, pass it before authoring:
 
 ```bash
-fabrika pattern new worker-queue-retry --decision <binding-decision-url> --source-repo <path> --source-package <pkg>
+fabrika pattern new worker-queue-retry --decision <binding-decision-url> --source-repo <path> --source-package <pkg> --json
 ```
 
 `--source-package` may be omitted only when the checkout has one unambiguous versioned public
 package. The verb resolves the validated repository root, reads tracked source, tests and docs at
-`HEAD`, and derives only portable evidence: canonical origin URL, full commit, relevant package
-version and repo-relative inspected paths. It writes that evidence and the dependency anchor into
-the scaffold; the supplied path is never serialized. Exit `17` is a proven refusal before any write
-when the path, Git root, origin, source/test/docs set, package selection, or version is unusable.
-Never continue from that refusal by reading intuition instead. For manual follow-up reads, resolve
-the root with `git -C <path> rev-parse --show-toplevel`, then use
-`git -C <validated-root> show HEAD:<repo-relative-path>` so a changed cwd cannot redirect inspection.
+`HEAD`, and returns portable evidence in the JSON answer's `sourceEvidence`: canonical origin URL,
+full `commit`, relevant package version and repo-relative inspected paths. It writes that evidence
+and the dependency anchor into the scaffold; the supplied path is never serialized. Exit `17` is a
+proven refusal before any write when the path, Git root, origin, source/test/docs set, package
+selection, or version is unusable. Never continue from that refusal by reading intuition instead.
+The returned `sourceEvidence.commit` binds every follow-up source, test and docs read. Resolve the
+root with `git -C <path> rev-parse --show-toplevel`, then read each path with
+`git -C <validated-root> show <sourceEvidence.commit>:<repo-relative-path>`. Never re-resolve `HEAD`
+after the verb returns; a moving checkout must not change the bytes behind the recorded evidence.
 
 **The source is the authority and the doc is the claim.** When they disagree the doc is wrong, and
 that holds with particular force during a re-grounding: the doc you are fixing is the least

--- a/claude-plugins/fabrika/skills/write-pattern/SKILL.md
+++ b/claude-plugins/fabrika/skills/write-pattern/SKILL.md
@@ -38,16 +38,12 @@ small to earn its own record has none. Neither is routed; both are `DECLINED-BEL
 already carries it. And if the target surface does not exist in this repo, say so rather than routing
 into a directory nobody will create.
 
-**The already-carried decline is bounded to single-home material.** Before you decline on it, count
-the sites the material spans — the places a reader meets it, not the places its *why* happens to be
-written down. One site is a home and the decline stands. **Two or more and the decline is not
-available to you**: the recurrence is itself the pattern signal, and a comment at each site carries
-the *why* at that site while saying nothing about the shape a reader meets across all of them. That
-material falls through to the admission bar below and is decided there, on the merits. The bar's
-first criterion is *used in 2+ places*; declining a repetition here for being locally commented
-would put the very material that criterion was written for out of its reach. Falling through is not
-admission — the bar still declines it if it is short. Single-home material, and material too small
-to earn a record anywhere, decline here exactly as before.
+**The already-carried decline is bounded to material with no reusable or prospective shape.** A
+current shape can be demonstrated by representative in-repo source and tests without meeting a
+numeric call-site quota. A prospective shape can exist before any call site when a cited binding
+decision names it and authoritative dependency source or docs ground it. Either falls through to
+the admission bar below; neither is admitted merely by falling through. Material that is only a
+local rationale, and material too small to earn a record anywhere, still declines here.
 
 Route when another surface genuinely owns it. Decline when nothing does. A skill that routes
 everything with a *why* in it never declines anything, and declining is the job.
@@ -64,19 +60,19 @@ skill does** — a corpus grows by accretion and nobody ever removes a doc. The 
 authority: read it in `.patterns/index.md` under *"When to add a new pattern doc here"* and apply it
 as written, softening nothing.
 
-The three below are the **fallback for a repo that declares no bar**, and in a repo that does declare
-one they are the gloss on how to apply it against source — not a second copy of it. Answer each
-against the source rather than against how the material feels:
+The fallback for a repo that declares no bar has two admission paths. Choose one and answer it
+against evidence rather than against how the material feels:
 
-- **Used in 2+ places** — name both, with paths. One call site is an implementation detail wearing a
-  pattern's clothes, and it is the most common thing that gets written here by mistake.
-- **Non-obvious from reading the code** — it codifies a *choice*. If a reader would derive it in a
-  minute from the file itself, the doc is a second copy of the code that can now drift from it.
-- **A future agent would otherwise invent a worse version.** This is the load-bearing one: it is
-  what separates a pattern from a description.
+- **Current shape:** representative in-repo source and tests demonstrate a reusable shape and its
+  boundary. No fixed number of pre-existing call sites is required.
+- **Prospective shape:** a cited binding decision names the technology or shape, and authoritative
+  dependency source or docs ground it before the first implementation. State intended scope and do
+  not invent current call sites.
 
-Fail any of them and end at `DECLINED-BELOW-BAR`, naming which one and what you saw. Writing nothing
-is the correct outcome, not a failure to deliver.
+Both paths must be non-obvious choices and prevent a foreseeable worse implementation. Obvious
+code narration, generic framework advice, speculative conventions, and intuition-only rules are
+below bar. Every rule traces to current in-repo source/tests or authoritative dependency source/docs.
+Fail any part and end at `DECLINED-BELOW-BAR`, naming what you saw; writing nothing is correct.
 
 ## 3 — Read the library before you add to it
 
@@ -150,10 +146,33 @@ in-repo path. Do not treat one as a stale pointer.
 fabrika pattern new worker-queue-retry
 ```
 
-Scaffolds the file and nothing else; it never touches the index and never overwrites. **A
+Scaffolds the current-shape form. For a prospective pattern, cite the binding decision so the
+scaffold states intended scope without pretending current call sites exist:
+
+```bash
+fabrika pattern new worker-queue-retry --decision <binding-decision-url>
+```
+
+The verb writes the file and nothing else; it never touches the index and never overwrites. **A
 re-grounding does not run this** — the file already exists, so `new` would refuse at exit `13`; edit
 the doc in place instead. The scaffold's exact bytes are the verb's section
 (`fabrika wire doc-section --heading "pattern new" < <skill-base>/contract.md`).
+
+When authoritative source is available as a local checkout, pass it before authoring:
+
+```bash
+fabrika pattern new worker-queue-retry --decision <binding-decision-url> --source-repo <path> --source-package <pkg>
+```
+
+`--source-package` may be omitted only when the checkout has one unambiguous versioned public
+package. The verb resolves the validated repository root, reads tracked source, tests and docs at
+`HEAD`, and derives only portable evidence: canonical origin URL, full commit, relevant package
+version and repo-relative inspected paths. It writes that evidence and the dependency anchor into
+the scaffold; the supplied path is never serialized. Exit `17` is a proven refusal before any write
+when the path, Git root, origin, source/test/docs set, package selection, or version is unusable.
+Never continue from that refusal by reading intuition instead. For manual follow-up reads, resolve
+the root with `git -C <path> rev-parse --show-toplevel`, then use
+`git -C <validated-root> show HEAD:<repo-relative-path>` so a changed cwd cannot redirect inspection.
 
 **The source is the authority and the doc is the claim.** When they disagree the doc is wrong, and
 that holds with particular force during a re-grounding: the doc you are fixing is the least
@@ -171,7 +190,8 @@ Match the house style the corpus already has rather than importing a shape: flat
 `.patterns/<slug>.md`, no frontmatter, prose with fenced examples. Where the doc is derived from a
 pinned dependency, pass `--anchor <pkg>@<version>` and let the verb write the anchor line — its
 bytes are `pattern anchor`'s grammar, and the writer and the reader of that line have one home
-between them, so they cannot drift apart.
+between them, so they cannot drift apart. A source checkout derives the same anchor automatically;
+an explicit conflicting `--anchor` refuses instead of bypassing pin-bump re-verification.
 
 ## 6 — Register it, or nobody finds it
 
@@ -227,12 +247,12 @@ it needs most.
 | `PATTERN-REGROUNDED` | success | every verb answered `0`; an existing doc now matches the source it describes; edits left uncommitted |
 | `DECLINED-BELOW-BAR` | success | reached at `0`; the material fails the index's admission bar (step 2), **or** step 1's tiebreak found it has no destination — a *why* already carried at its single home, or too small to earn a record anywhere. Name which; **nothing written**, tree as found |
 | `ROUTED-ELSEWHERE` | success | reached at `0`; the material belongs to another surface, named; **nothing written here** |
-| `HALTED-REFUSED` | back-off | a verb **proved** a refusal this session could not correct (`12`, `13`) before anything was written; tree as found |
+| `HALTED-REFUSED` | back-off | a verb **proved** a refusal this session could not correct (`12`, `13`, `17`) before anything was written; tree as found |
 | `HALTED-UNKNOWN` | back-off | a verb could not establish the answer (`1`, `8`, `9`, `11`, `126`, `127`). Tree as found, **except** after `8` or `9`, where a write was already attempted — name the path so a human can look |
 
 A non-zero exit is never the permissive reading. It splits two ways, and the split is the point:
 `1`, `8`, `9`, `11`, `126` and `127` are **UNKNOWN** — nothing was established, so re-run once. `10`
-and `12` through `16` are **proven** refusals; re-running changes nothing and the fix is to correct the input
+and `12` through `17` are **proven** refusals; re-running changes nothing and the fix is to correct the input
 or accept the narrower ending. Which verb raises which code is the matrix
 (`fabrika wire doc-section --heading "The shared exit matrix" < <skill-base>/contract.md`). Improvising past a verb that refused is how a session writes a doc
 against a corpus it never read.

--- a/claude-plugins/fabrika/skills/write-pattern/contract.md
+++ b/claude-plugins/fabrika/skills/write-pattern/contract.md
@@ -7,7 +7,7 @@ The verbs sit under a `pattern` subcommand group in `packages/fabrika-cli/`, who
 [`registry.ts`](../../../../packages/fabrika-cli/src/registry.ts) at authoring time — at the time of
 writing the registered groups are `adr build epic hook ledger plan report review review-ui ship
 spend status triage ui wire`, though that list grows most weeks, so read the file rather than this
-sentence. The [CLI interface convention](../../docs/cli-interface-convention.md) governs all five;
+sentence. The [CLI interface convention](../../docs/cli-interface-convention.md) governs all five verbs;
 where this spec and that doc disagree, the doc wins and this spec is the bug.
 
 **`fabrika` calls `pipeline-cli` nowhere, and neither does the skill.** Every verb below is
@@ -135,6 +135,7 @@ restated per verb is a shared matrix that can drift from itself.
 | `14` | `MULTI_LINE_DIFF` | the edit would have changed a line beyond the one row — aborted before writing |
 | `15` | `INDEX_UNPARSEABLE` | proven: the index is absent, or holds no parseable table |
 | `16` | `SECTION_AMBIGUOUS` | proven: the named section matches more than one heading — the index needs disambiguating, not the flag |
+| `17` | `SOURCE_REPOSITORY_REFUSED` | proven: a supplied source checkout cannot yield complete portable grounding evidence; nothing was written |
 
 **The seats map to register.** `pattern` declares exactly these four shared seats, and this is the
 map the alignment registry needs — an implementer should not have to infer it:
@@ -168,7 +169,7 @@ oversight:
 | `6` `BARE_AT_PATH` | follows from `3` — nothing here composes a body from authored input |
 | `7` `ZERO_SCOPE` | **the important one.** No verb here judges over a corpus, so none has a vacuous pass to prevent. An empty or absent `.patterns/` is a *fact* this group reports at exit `0`, and refusing there would leave a repo adopting fabrika unable to write its first pattern doc on the documented path — the first-run dead-end the portability rules forbid, and the same correction #5254 applied to `adr next`. Where a question genuinely cannot be answered, the group says so in **vocabulary** — `unanchored`, `unknown` — never by falling silent. |
 
-**Private codes are group-local.** `12`–`16` mean what this table says within `pattern` and carry no
+**Private codes are group-local.** `12`–`17` mean what this table says within `pattern` and carry no
 cross-group obligation; `review` seats `12` as `STALE_HEAD` and `build` retired its own `12`,
 and those are separate namespaces rather than one collision.
 
@@ -645,7 +646,7 @@ $ fabrika pattern anchor worker-queue-retry --json --dir packages/fabrika-cli/te
 **Invocation**
 
 ```
-fabrika pattern new worker-queue-retry [--dir <path>] [--title <text>] [--anchor <pkg@version>] [--json]
+fabrika pattern new worker-queue-retry [--dir <path>] [--title <text>] [--anchor <pkg@version>] [--decision <url>] [--source-repo <path>] [--source-package <name>] [--json]
 ```
 
 **Inputs**
@@ -655,12 +656,16 @@ fabrika pattern new worker-queue-retry [--dir <path>] [--title <text>] [--anchor
 | `<slug>` | positional string | yes | — | the kebab-case basename the doc takes, without `.md` |
 | `--dir` | string | no | `.patterns` | the directory to write the doc into, created when absent |
 | `--title` | string | no | derived from the slug | the H1 text. The derivation: replace each `-` with a space, then upper-case the first character and leave every other character as it is. `worker-queue-retry` becomes `Worker queue retry`; `fate-effect-server` becomes `Fate effect server`. No acronym or digit special-casing — a doc wanting one passes `--title` |
-| `--anchor` | string | no | none | a `<pkg>@<version>` this doc is derived from; adds the anchor line `pattern anchor` reads. Validated by `pattern anchor`'s step-2 rule — split at the **last** `@`, both halves non-empty — so the writer and the reader accept exactly the same strings |
+| `--anchor` | string | no | none | a `<pkg>@<version>` this doc is derived from; adds the line `pattern anchor` reads. When source evidence exists it derives this token automatically; an explicit conflict refuses |
+| `--decision` | string | no | none | the cited binding decision; selects the prospective scaffold |
+| `--source-repo` | string | no | none | a local authoritative Git checkout to inspect before writing; its path is never serialized |
+| `--source-package` | string | no | inferred only when unique | the relevant package name; requires `--source-repo` and resolves monorepo ambiguity |
 | `--json` | boolean | no | `false` | emit the write record instead of the bare path |
 
 **Output** — one line, the path written, newline-terminated. With `--json`, one object with keys
-`path`, `slug`, `title`, and `anchored` — the latter the `<pkg>@<version>` string when `--anchor`
-was given, and `null` when it was not.
+`path`, `slug`, `title`, `anchored`, `decision`, and `sourceEvidence`. `sourceEvidence` is `null` or
+`{origin, commit, package, version, inspected: {source, tests, docs}}`; every path under `inspected`
+is repository-relative. The supplied local path is absent from both this object and the scaffold.
 
 The file's bytes are the canonical template, and **this block is that template's single home** — the
 skill carries no copy to drift against:
@@ -676,7 +681,7 @@ skill carries no copy to drift against:
 
 ## When this applies
 
-<The two or more places it is used, by path, and the boundary where it stops applying.>
+<The current in-repo scope, representative source paths, and the boundary where it stops applying.>
 
 ## Why it is not obvious
 
@@ -687,12 +692,21 @@ With `--anchor`, one more line is appended, and its bytes are exactly the gramma
 parses: a blockquote marker, `Derived from `, the backticked `<pkg>@<version>`, then
 ` — re-verify on pin bump.`
 
-**The three body headings mirror the admission bar** the skill applies in step 2 — used in 2+ places,
-non-obvious, a future agent would invent worse — so a doc that cannot fill them is a doc that did not
-clear the bar. **This is a starting shape and not a validated grammar**: nothing here or at any gate
-checks a pattern doc's headings, an existing doc keeps whatever shape it has, and exit `4` is a
-deliberate gap for that reason. The corpus is 83 docs with no shared skeleton, and imposing one
-retroactively would fail in every repo that is not this one.
+With `--decision`, `## When this applies` becomes `## Prospective scope`, followed by a
+`## Binding decision` section linking the citation. Its prompts require intended scope and forbid
+invented current call sites. With `--source-repo`, the verb first resolves the checkout's Git root,
+full `HEAD`, canonical network origin, tracked manifests, and representative source/test/docs files.
+It reads those files at `HEAD`, resolves `--source-package` by manifest name (or the sole versioned
+public package), then appends this portable grammar plus the ordinary anchor line:
+
+```
+> Source checkout evidence: <canonical-origin> at `<full-commit>`; package `<pkg>@<version>`; inspected `<source-path>`, `<test-path>`, and `<docs-path>`.
+> Derived from `<pkg>@<version>` — re-verify on pin bump.
+```
+
+The current and prospective forms are starting shapes, not a validated heading grammar. Both still
+require non-obviousness and a foreseeable worse alternative; obvious narration, generic framework
+advice, speculative conventions and intuition-only rules remain below the skill's bar.
 
 **Exit status**
 
@@ -701,6 +715,7 @@ retroactively would fail in every repo that is not this one.
 | `8` | the file could not be written, so whether anything landed is UNKNOWN |
 | `11` | the target-path existence check itself failed, so whether `<path>` exists is UNKNOWN — never read as absent, and never `13`, which is proven |
 | `13` | the target path already exists — refused, never overwritten |
+| `17` | the supplied checkout is absent/unreadable/non-Git, has no parseable network origin, full commit, tracked source/tests/docs, or uniquely resolvable package version, or conflicts with `--anchor`; nothing was written |
 
 **Errors**
 
@@ -710,6 +725,9 @@ retroactively would fail in every repo that is not this one.
 | `pattern new: cannot check <path>: <reason> — nothing was written.` | 11 | refusal |
 | `pattern new: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 | `pattern new: --anchor "<value>" is not <pkg>@<version>.` | 1 | usage error |
+| `pattern new: --source-package requires --source-repo.` | 1 | usage error |
+| `pattern new: supplied source repository refused: <reason> — nothing was written.` | 17 | refusal |
+| `pattern new: --anchor <token> conflicts with source evidence <token> — nothing was written.` | 17 | refusal |
 | `pattern new: cannot write <path>: <reason> — whether anything landed is UNKNOWN.` | 8 | refusal |
 
 **Scope** — not a judging verb. It writes exactly one file and never edits another; the index row is
@@ -733,12 +751,12 @@ $ echo $?
 
 ```
 $ fabrika pattern new worker-queue-retry --json
-{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":null}
+{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":null,"decision":null,"sourceEvidence":null}
 ```
 
 ```
 $ fabrika pattern new worker-queue-retry --anchor acme-queue@4.2.0 --json
-{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":"acme-queue@4.2.0"}
+{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":"acme-queue@4.2.0","decision":null,"sourceEvidence":null}
 ```
 
 **Grounding**
@@ -750,7 +768,10 @@ $ fabrika pattern new worker-queue-retry --anchor acme-queue@4.2.0 --json
   adopting fabrika has no `.patterns/`, and its first pattern doc has to be writable on the documented
   path. Refusing there is the first-run dead-end the portability rules forbid.
 - The `--anchor` line's bytes are pinned to `pattern anchor`'s grammar in one place, so the writer and
-  the reader of that line cannot disagree.
+  the reader of that line cannot disagree. Source evidence complements this pin-bump anchor rather
+  than bypassing it.
+- Git always runs with `-C <validated-root>` after root resolution. Evidence contains only the
+  canonical origin, full commit, package/version and repo-relative paths, never the supplied path.
 
 ---
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -693,13 +693,14 @@ Read and write the pattern library. A **pattern doc** is one flat `<slug>.md` un
 | `pattern corpus` | the library at a base ref: every doc, its registration, its section, its last-touching commit |
 | `pattern drift` | whether the in-repo source a doc cites moved since the doc was last written |
 | `pattern anchor` | whether the dependency version a doc declares still matches what the workspace pins |
-| `pattern new` | scaffolds `<dir>/<slug>.md` from the canonical template |
+| `pattern new` | scaffolds a current or prospective doc; optional local-source inspection emits portable grounding evidence |
 | `pattern register` | inserts the doc's row into `<dir>/index.md` under a named section |
 
 **Exit codes.** `8`–`11` from the shared table, plus `12` the named slug has no doc file · `13` the
 target path already exists · `14` the edit would have changed a line beyond the one row, aborted
 before writing · `15` the index is absent or holds no parseable table · `16` the named section
-matches more than one heading.
+matches more than one heading · `17` a supplied source checkout cannot yield complete portable
+evidence, so nothing is written.
 
 Four behaviours are worth knowing:
 
@@ -717,7 +718,12 @@ Four behaviours are worth knowing:
   resolution alone.
 
 `corpus`, `drift` and `anchor` read at a fetched `--base`; `new` and `register` write the **working
-tree**, so a doc created by `new` is invisible to `corpus` until it is committed.
+tree**, so a doc created by `new` is invisible to `corpus` until it is committed. `pattern new
+--decision <url>` selects the prospective scaffold. `--source-repo <path>` validates a local Git
+checkout and records only its canonical origin, full HEAD, relevant package/version and
+repo-relative source/test/docs paths; use `--source-package` when a monorepo is ambiguous. The local
+path never enters the scaffold or JSON evidence, and the derived package token also uses the
+existing dependency anchor so pin bumps still demand re-verification.
 
 ## The `plan` group
 

--- a/packages/fabrika-cli/src/config/keys/surface-dispositions.ts
+++ b/packages/fabrika-cli/src/config/keys/surface-dispositions.ts
@@ -89,6 +89,11 @@ export const SURFACE_REGISTRY: ReadonlyArray<SurfaceSpec> = [
 		note: "history for the doc surface plus a resolvable base ref; `pattern drift` reports a doc unaged instead of refusing",
 	},
 	{
+		id: "authoritative-source-checkout",
+		disposition: "degrade",
+		note: "an optional local Git checkout supplied to `pattern new`; omission keeps recurrence-based authoring available, while a supplied checkout that cannot yield HEAD-bound origin, package, source, test, and docs evidence refuses at exit 17",
+	},
+	{
 		id: "collaborator-permissions",
 		disposition: "fail-loud",
 		note: "`repos/<repo>/collaborators/<login>/permission` readable; every ACL-resolved claim and ruling is UNKNOWN without it, never permissive (ADR 0055)",

--- a/packages/fabrika-cli/src/config/keys/surface-dispositions.unit.test.ts
+++ b/packages/fabrika-cli/src/config/keys/surface-dispositions.unit.test.ts
@@ -69,6 +69,14 @@ describe("what the key refuses whole", () => {
 });
 
 describe("the registry itself", () => {
+	it("declares the optional authoritative source checkout and its refusal boundary", () => {
+		const surface = SURFACE_REGISTRY.find(
+			(candidate) => candidate.id === "authoritative-source-checkout",
+		);
+		expect(surface).toMatchObject({disposition: "degrade"});
+		expect(surface?.note).toContain("exit 17");
+	});
+
 	it("carries one entry per id, with no duplicate", () => {
 		const ids = SURFACE_REGISTRY.map((surface) => surface.id);
 		expect(new Set(ids).size).toBe(ids.length);

--- a/packages/fabrika-cli/src/pattern/codes.ts
+++ b/packages/fabrika-cli/src/pattern/codes.ts
@@ -8,8 +8,8 @@
  * `../exit-codes.ts`, with `OFF_VOCABULARY` named locally over the registry's `CLASSIFIED` — this
  * group reads section names, not labels.
  *
- * This group shares four seats over `8`-`11` and adds `12`-`16` for facts about a doc, an index and
- * a one-row edit. `3`-`7` are deliberate gaps, each for a stated reason: no verb reads stdin (`3`),
+ * This group shares four seats over `8`-`11` and adds `12`-`17` for facts about a doc, an index, a
+ * one-row edit, and a supplied source checkout. `3`-`7` are deliberate gaps, each for a stated reason: no verb reads stdin (`3`),
  * none validates a doc's heading grammar (`4`), the repo's leak gate is the authority over
  * `.patterns/` (`5`), nothing composes a body from authored input (`6`) — and `7` `ZERO_SCOPE`
  * stays unseated because no verb here judges over a corpus, so none has a vacuous pass to prevent.
@@ -57,3 +57,5 @@ export const INDEX_UNPARSEABLE = 15;
  * disambiguating.
  */
 export const SECTION_AMBIGUOUS = 16;
+/** Proven: a supplied source checkout cannot yield complete portable grounding evidence. */
+export const SOURCE_REPOSITORY_REFUSED = 17;

--- a/packages/fabrika-cli/src/pattern/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/codes.unit.test.ts
@@ -62,6 +62,7 @@ describe("the shared seats are the base's", () => {
 			codes.MULTI_LINE_DIFF,
 			codes.INDEX_UNPARSEABLE,
 			codes.SECTION_AMBIGUOUS,
+			codes.SOURCE_REPOSITORY_REFUSED,
 		]) {
 			expect(occupied.has(code)).toBe(false);
 		}

--- a/packages/fabrika-cli/src/pattern/command.ts
+++ b/packages/fabrika-cli/src/pattern/command.ts
@@ -116,15 +116,45 @@ const create = leafCommand(
 				"a <pkg>@<version> this doc is derived from; adds the anchor line pattern anchor reads",
 			),
 		),
+		decision: Flag.string("decision").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the binding-decision citation for a prospective pattern; selects the prospective scaffold",
+			),
+		),
+		sourceRepo: Flag.string("source-repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"a local authoritative Git checkout to inspect before writing; its path is never serialized",
+			),
+		),
+		sourcePackage: Flag.string("source-package").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the relevant package name in --source-repo; required when package selection is ambiguous",
+			),
+		),
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({slug, dir, title, anchor: anchorToken, json}) {
+	Effect.fn(function* ({
+		slug,
+		dir,
+		title,
+		anchor: anchorToken,
+		decision,
+		sourceRepo,
+		sourcePackage,
+		json,
+	}) {
 		yield* emit(
 			yield* runNew({
 				slug,
 				dir,
 				title: Option.getOrNull(title),
 				anchor: Option.getOrNull(anchorToken),
+				decision: Option.getOrNull(decision),
+				sourceRepo: Option.getOrNull(sourceRepo),
+				sourcePackage: Option.getOrNull(sourcePackage),
 				json,
 			}),
 		);
@@ -132,7 +162,7 @@ const create = leafCommand(
 ).pipe(
 	Command.withShortDescription("Scaffold a new pattern doc from the canonical template."),
 	Command.withDescription(
-		"Scaffold <dir>/<slug>.md from the canonical template, creating <dir> when it is absent. Prints the path written. Writes exactly one file and never edits another — the index row is pattern register's. Exits 8 (the write failed, so whether anything landed is UNKNOWN), 13 (the target already exists — refused, never overwritten). Example: fabrika pattern new worker-queue-retry --anchor acme-queue@4.2.0",
+		"Scaffold <dir>/<slug>.md for a current pattern, or a prospective pattern with --decision. Optional --source-repo inspection derives a canonical origin, full HEAD commit, relevant package version and representative source/test/docs paths without serializing the local path; use --source-package when a monorepo is ambiguous. Writes exactly one file. Exits 8 (write UNKNOWN), 13 (target exists), 17 (source evidence refused). Example: fabrika pattern new worker-queue-retry --decision https://github.com/acme/repo/issues/1 --source-repo ../acme --source-package acme-queue",
 	),
 );
 

--- a/packages/fabrika-cli/src/pattern/doc.ts
+++ b/packages/fabrika-cli/src/pattern/doc.ts
@@ -45,7 +45,7 @@ export const ANCHOR_PREFIX = "> Derived from ";
 export const anchorLine = (token: string): string =>
 	`${ANCHOR_PREFIX}\`${token}\` — re-verify on pin bump.`;
 
-const TEMPLATE_BODY = `<One sentence: what shape this describes, and where in the tree it applies.>
+const CURRENT_BODY = `<One sentence: what shape this describes, and where in the tree it applies.>
 
 ## The shape
 
@@ -53,20 +53,41 @@ const TEMPLATE_BODY = `<One sentence: what shape this describes, and where in th
 
 ## When this applies
 
-<The two or more places it is used, by path, and the boundary where it stops applying.>
+<The current in-repo scope, representative source paths, and the boundary where it stops applying.>
+`;
 
+const prospectiveBody = (
+	decision: string,
+): string => `<One sentence: what prospective shape this describes and where it is intended to apply.>
+
+## The shape
+
+<The pattern itself, with a fenced example grounded in authoritative source or docs.>
+
+## Prospective scope
+
+<The intended scope and boundary. Do not claim current call sites that do not exist.>
+
+## Binding decision
+
+<Explain how [the binding decision](${decision}) requires this shape.>
+`;
+
+const WHY_BODY = `
 ## Why it is not obvious
 
 <What a reader would otherwise invent, and why that version is worse.>
 `;
 
-/**
- * The canonical pattern doc, ready to write.
- *
- * The three body headings mirror the admission bar the skill applies — used in 2+ places,
- * non-obvious, a future agent would invent worse — so a doc that cannot fill them is a doc that did
- * not clear the bar. It is a **starting shape and not a validated grammar**: nothing here or at any
- * gate checks a pattern doc's headings, which is why `4` is a deliberate gap in `codes.ts`.
- */
-export const docTemplate = (title: string, anchorToken: string | null): string =>
-	`# ${title}\n\n${TEMPLATE_BODY}${anchorToken === null ? "" : `\n${anchorLine(anchorToken)}\n`}`;
+/** The canonical pattern doc, ready to write for either admitted authoring path. */
+export const docTemplate = (
+	title: string,
+	anchorToken: string | null,
+	decision: string | null = null,
+	sourceEvidence: string | null = null,
+): string => {
+	const body = decision === null ? CURRENT_BODY : prospectiveBody(decision);
+	const evidence = sourceEvidence === null ? "" : `\n${sourceEvidence}\n`;
+	const anchor = anchorToken === null ? "" : `\n${anchorLine(anchorToken)}\n`;
+	return `# ${title}\n\n${body}${WHY_BODY}${evidence}${anchor}`;
+};

--- a/packages/fabrika-cli/src/pattern/doc.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/doc.unit.test.ts
@@ -57,13 +57,27 @@ describe("the anchor line is composed and parsed from one home", () => {
 });
 
 describe("docTemplate", () => {
-	it("writes the four headings and nothing else without --anchor", () => {
+	it("writes the current-scope scaffold without --anchor", () => {
 		const text = docTemplate("Worker queue retry", null);
 		expect(text.startsWith("# Worker queue retry\n\n")).toBe(true);
 		expect(text).toContain("## The shape");
 		expect(text).toContain("## When this applies");
 		expect(text).toContain("## Why it is not obvious");
 		expect(text).not.toContain("Derived from");
+		expect(text).not.toContain("two or more places");
+	});
+
+	it("writes intended scope and a binding-decision citation for prospective patterns", () => {
+		const text = docTemplate(
+			"Worker queue retry",
+			null,
+			"https://github.com/acme/repo/issues/1#issuecomment-1",
+		);
+		expect(text).toContain("## Prospective scope");
+		expect(text).toContain("Do not claim current call sites that do not exist");
+		expect(text).toContain(
+			"[the binding decision](https://github.com/acme/repo/issues/1#issuecomment-1)",
+		);
 	});
 
 	it("appends the anchor line in the exact bytes pattern anchor parses", () => {

--- a/packages/fabrika-cli/src/pattern/new-verb.ts
+++ b/packages/fabrika-cli/src/pattern/new-verb.ts
@@ -7,24 +7,38 @@
  * adopting fabrika has no `.patterns/`, and its first doc has to be writable on the documented path.
  */
 import {Effect, type FileSystem, type Path, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
 import {exists, writeFile} from "../io/fs.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {ALREADY_EXISTS, PRECONDITION_UNKNOWN, WRITE_UNKNOWN} from "./codes.ts";
+import {
+	ALREADY_EXISTS,
+	PRECONDITION_UNKNOWN,
+	SOURCE_REPOSITORY_REFUSED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
 import {docTemplate, isKebabCase, splitAnchorToken, titleFrom} from "./doc.ts";
+import {inspectSourceRepository, sourceEvidenceLine} from "./source.ts";
 
 export interface NewOptions {
 	readonly slug: string;
 	readonly dir: string;
 	readonly title: string | null;
 	readonly anchor: string | null;
+	readonly decision: string | null;
+	readonly sourceRepo: string | null;
+	readonly sourcePackage: string | null;
 	readonly json: boolean;
 }
 
 export const runNew = (
 	options: NewOptions,
-): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> =>
 	Effect.gen(function* () {
-		const {slug, dir, anchor, json} = options;
+		const {slug, dir, anchor, decision, sourceRepo, sourcePackage, json} = options;
 		if (!isKebabCase(slug)) {
 			return refuse(
 				FAILED,
@@ -36,6 +50,27 @@ export const runNew = (
 		if (anchor !== null && splitAnchorToken(anchor) === null) {
 			return refuse(FAILED, `pattern new: --anchor "${anchor}" is not <pkg>@<version>.`);
 		}
+		if (sourcePackage !== null && sourceRepo === null) {
+			return refuse(FAILED, "pattern new: --source-package requires --source-repo.");
+		}
+
+		const inspection =
+			sourceRepo === null ? null : yield* inspectSourceRepository(sourceRepo, sourcePackage);
+		if (inspection?._tag === "Refused") {
+			return refuse(
+				SOURCE_REPOSITORY_REFUSED,
+				`pattern new: supplied source repository refused: ${inspection.reason} — nothing was written.`,
+			);
+		}
+		const evidence = inspection?._tag === "Evidence" ? inspection.evidence : null;
+		const evidenceAnchor = evidence === null ? null : `${evidence.package}@${evidence.version}`;
+		if (anchor !== null && evidenceAnchor !== null && anchor !== evidenceAnchor) {
+			return refuse(
+				SOURCE_REPOSITORY_REFUSED,
+				`pattern new: --anchor ${anchor} conflicts with source evidence ${evidenceAnchor} — nothing was written.`,
+			);
+		}
+		const resolvedAnchor = anchor ?? evidenceAnchor;
 
 		const path = `${dir.replace(/\/+$/, "")}/${slug}.md`;
 		const present = yield* Effect.result(exists(path));
@@ -52,7 +87,17 @@ export const runNew = (
 		}
 
 		const title = options.title ?? titleFrom(slug);
-		const written = yield* Effect.result(writeFile(path, docTemplate(title, anchor)));
+		const written = yield* Effect.result(
+			writeFile(
+				path,
+				docTemplate(
+					title,
+					resolvedAnchor,
+					decision,
+					evidence === null ? null : sourceEvidenceLine(evidence),
+				),
+			),
+		);
 		if (Result.isFailure(written)) {
 			return refuse(
 				WRITE_UNKNOWN,
@@ -60,7 +105,19 @@ export const runNew = (
 			);
 		}
 
-		return answer(json ? JSON.stringify({path, slug, title, anchored: anchor}) : path, [
-			`pattern new: wrote ${path}${anchor === null ? "" : ` with the anchor line for ${anchor}`}; the index row is pattern register's.`,
-		]);
+		return answer(
+			json
+				? JSON.stringify({
+						path,
+						slug,
+						title,
+						anchored: resolvedAnchor,
+						decision,
+						sourceEvidence: evidence,
+					})
+				: path,
+			[
+				`pattern new: wrote ${path}${resolvedAnchor === null ? "" : ` with the anchor line for ${resolvedAnchor}`}${evidence === null ? "" : ` and portable source evidence from ${evidence.origin}`}; the index row is pattern register's.`,
+			],
+		);
 	});

--- a/packages/fabrika-cli/src/pattern/new-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/new-verb.unit.test.ts
@@ -1,7 +1,12 @@
-import {Effect} from "effect";
+import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
-import {ALREADY_EXISTS, PRECONDITION_UNKNOWN, WRITE_UNKNOWN} from "./codes.ts";
+import {type FakeFsOptions, fakeFs, fakeShell} from "../fakes.test-support.ts";
+import {
+	ALREADY_EXISTS,
+	PRECONDITION_UNKNOWN,
+	SOURCE_REPOSITORY_REFUSED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
 import {ANCHOR_DECLARATION} from "./doc.ts";
 import {type NewOptions, runNew} from "./new-verb.ts";
 
@@ -10,14 +15,18 @@ const options: NewOptions = {
 	dir: ".patterns",
 	title: null,
 	anchor: null,
+	decision: null,
+	sourceRepo: null,
+	sourcePackage: null,
 	json: false,
 };
 
 const run = (opts: Partial<typeof options> = {}, fs: FakeFsOptions = {}) => {
 	const fake = fakeFs(fs);
-	return Effect.runPromise(Effect.provide(runNew({...options, ...opts}), fake.layer)).then(
-		(outcome) => ({outcome, written: fake.written}),
-	);
+	const shell = fakeShell([]);
+	return Effect.runPromise(
+		Effect.provide(runNew({...options, ...opts}), Layer.merge(fake.layer, shell.layer)),
+	).then((outcome) => ({outcome, written: fake.written}));
 };
 
 describe("runNew", () => {
@@ -48,10 +57,10 @@ describe("runNew", () => {
 	// The contract's third and fourth worked examples.
 	it("carries the write record through --json, with and without an anchor", async () => {
 		expect((await run({json: true})).outcome.stdout).toBe(
-			'{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":null}\n',
+			'{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":null,"decision":null,"sourceEvidence":null}\n',
 		);
 		expect((await run({json: true, anchor: "acme-queue@4.2.0"})).outcome.stdout).toBe(
-			'{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":"acme-queue@4.2.0"}\n',
+			'{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":"acme-queue@4.2.0","decision":null,"sourceEvidence":null}\n',
 		);
 	});
 
@@ -103,5 +112,27 @@ describe("runNew", () => {
 		expect(
 			written.get(".patterns/worker-queue-retry.md")?.startsWith("# Fate (Effect) server\n"),
 		).toBe(true);
+	});
+
+	it("selects the prospective scaffold from a binding-decision citation", async () => {
+		const {written} = await run({decision: "https://github.com/acme/repo/issues/1"});
+		const text = written.get(".patterns/worker-queue-retry.md") ?? "";
+		expect(text).toContain("## Prospective scope");
+		expect(text).toContain("[the binding decision](https://github.com/acme/repo/issues/1)");
+		expect(text).toContain("Do not claim current call sites that do not exist");
+	});
+
+	it("refuses an unusable source checkout before writing", async () => {
+		const fake = fakeFs({});
+		const shell = fakeShell([]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runNew({...options, sourceRepo: "/missing/source"}),
+				Layer.merge(fake.layer, shell.layer),
+			),
+		);
+		expect(outcome.code).toBe(SOURCE_REPOSITORY_REFUSED);
+		expect(outcome.stdout).toBe("");
+		expect(fake.written.size).toBe(0);
 	});
 });

--- a/packages/fabrika-cli/src/pattern/pattern.cli.test.ts
+++ b/packages/fabrika-cli/src/pattern/pattern.cli.test.ts
@@ -54,7 +54,7 @@ describe("fabrika pattern, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, (
 		expect(run.stderr).toContain("is not kebab-case");
 	});
 
-	it("derives portable prospective evidence from a temporary monorepo checkout", () => {
+	it("derives portable prospective evidence from HEAD despite a staged index addition", () => {
 		const root = mkdtempSync(join(tmpdir(), "fabrika-pattern-source-"));
 		const upstream = join(root, "xyflow");
 		try {
@@ -91,6 +91,12 @@ describe("fabrika pattern, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, (
 				"-qm",
 				"fixture",
 			]);
+			mkdirSync(join(upstream, "packages/index-only"), {recursive: true});
+			writeFileSync(
+				join(upstream, "packages/index-only/package.json"),
+				'{"name":"@xyflow/react","version":"99.0.0"}\n',
+			);
+			execFileSync("git", ["-C", upstream, "add", "packages/index-only/package.json"]);
 
 			const run = fabrika(
 				[

--- a/packages/fabrika-cli/src/pattern/pattern.cli.test.ts
+++ b/packages/fabrika-cli/src/pattern/pattern.cli.test.ts
@@ -2,11 +2,14 @@
  * The end-to-end half: the **exit status and the bytes on each channel** a shell caller reads.
  *
  * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
- * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns, both about facts no
- * in-process test can establish: that the group is reachable by its registration alone, and that a
- * refusal really does leave stdout empty across the process boundary.
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Three spawns cover facts no
+ * in-process test can establish: registration, empty stdout on refusal, and non-leakage across the
+ * real CLI boundary while reading a temporary Git checkout.
  */
 import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
@@ -20,12 +23,13 @@ interface Run {
 }
 
 /** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
-const fabrika = (args: ReadonlyArray<string>): Run => {
+const fabrika = (args: ReadonlyArray<string>, cwd?: string): Run => {
 	try {
 		const stdout = execFileSync(process.execPath, [BIN, ...args], {
 			encoding: "utf8",
 			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
 			stdio: ["pipe", "pipe", "pipe"],
+			cwd,
 		});
 		return {code: 0, stdout, stderr: ""};
 	} catch (err) {
@@ -48,5 +52,72 @@ describe("fabrika pattern, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, (
 		expect(run.code).toBe(1);
 		expect(run.stdout).toBe("");
 		expect(run.stderr).toContain("is not kebab-case");
+	});
+
+	it("derives portable prospective evidence from a temporary monorepo checkout", () => {
+		const root = mkdtempSync(join(tmpdir(), "fabrika-pattern-source-"));
+		const upstream = join(root, "xyflow");
+		try {
+			mkdirSync(join(upstream, "packages/react/src"), {recursive: true});
+			writeFileSync(
+				join(upstream, "package.json"),
+				'{"name":"@xyflow/monorepo","version":"0.0.0","private":true}\n',
+			);
+			writeFileSync(
+				join(upstream, "packages/react/package.json"),
+				'{"name":"@xyflow/react","version":"12.11.5"}\n',
+			);
+			writeFileSync(join(upstream, "packages/react/src/index.ts"), "export {};\n");
+			writeFileSync(join(upstream, "packages/react/src/index.test.ts"), "export {};\n");
+			writeFileSync(join(upstream, "packages/react/README.md"), "# React\n");
+			execFileSync("git", ["init", "-q", upstream]);
+			execFileSync("git", [
+				"-C",
+				upstream,
+				"remote",
+				"add",
+				"origin",
+				"git@github.com:xyflow/xyflow.git",
+			]);
+			execFileSync("git", ["-C", upstream, "add", "."]);
+			execFileSync("git", [
+				"-C",
+				upstream,
+				"-c",
+				"user.name=Pattern Test",
+				"-c",
+				"user.email=pattern@example.invalid",
+				"commit",
+				"-qm",
+				"fixture",
+			]);
+
+			const run = fabrika(
+				[
+					"pattern",
+					"new",
+					"react-flow-shape",
+					"--decision",
+					"https://github.com/kamp-us/phoenix/issues/7197",
+					"--source-repo",
+					upstream,
+					"--source-package",
+					"@xyflow/react",
+					"--json",
+				],
+				root,
+			);
+			expect(run.code).toBe(0);
+			expect(run.stdout).toContain('"origin":"https://github.com/xyflow/xyflow"');
+			expect(run.stdout).toContain('"package":"@xyflow/react","version":"12.11.5"');
+			expect(run.stdout).not.toContain(upstream);
+			const scaffold = readFileSync(join(root, ".patterns/react-flow-shape.md"), "utf8");
+			expect(scaffold).toContain("## Prospective scope");
+			expect(scaffold).toContain("https://github.com/xyflow/xyflow");
+			expect(scaffold).toContain("`@xyflow/react@12.11.5`");
+			expect(scaffold).not.toContain(upstream);
+		} finally {
+			rmSync(root, {recursive: true, force: true});
+		}
 	});
 });

--- a/packages/fabrika-cli/src/pattern/source-model.ts
+++ b/packages/fabrika-cli/src/pattern/source-model.ts
@@ -1,0 +1,44 @@
+export interface SourceManifest {
+	readonly path: string;
+	readonly name: string;
+	readonly version: string;
+	readonly private: boolean;
+}
+
+/** Turn a network Git remote into a credential-free, portable HTTPS origin. */
+export const canonicalOriginUrl = (value: string): string | null => {
+	const input = value.trim();
+	if (input === "") return null;
+	const scp = input.includes("://") ? null : /^(?:[^@/]+@)?([^:/]+):(.+)$/.exec(input);
+	if (scp !== null) {
+		const host = scp[1];
+		const repoPath = scp[2]?.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+		return host === undefined || repoPath === undefined || !repoPath.includes("/")
+			? null
+			: `https://${host}/${repoPath}`;
+	}
+	try {
+		const url = new URL(input);
+		if (!["http:", "https:", "ssh:", "git:"].includes(url.protocol)) return null;
+		const repoPath = url.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+		return url.hostname === "" || !repoPath.includes("/")
+			? null
+			: `https://${url.hostname}/${repoPath}`;
+	} catch {
+		return null;
+	}
+};
+
+export const parseSourceManifest = (path: string, text: string): SourceManifest | null => {
+	try {
+		const value = JSON.parse(text) as Record<string, unknown>;
+		return typeof value.name === "string" &&
+			value.name !== "" &&
+			typeof value.version === "string" &&
+			value.version !== ""
+			? {path, name: value.name, version: value.version, private: value.private === true}
+			: null;
+	} catch {
+		return null;
+	}
+};

--- a/packages/fabrika-cli/src/pattern/source.ts
+++ b/packages/fabrika-cli/src/pattern/source.ts
@@ -39,8 +39,8 @@ const isSource = (path: string, root: string): boolean =>
 	/(^|\/)(src|source|lib)\//i.test(path.slice(root === "" ? 0 : root.length + 1)) &&
 	!isTest(path);
 
-const readAtHead = (root: string, path: string) =>
-	execCapture("git", ["-C", root, "show", `HEAD:${path}`]);
+const readAtCommit = (root: string, commit: string, path: string) =>
+	execCapture("git", ["-C", root, "show", `${commit}:${path}`]);
 
 export const inspectSourceRepository = (
 	repoPath: string,
@@ -72,8 +72,16 @@ export const inspectSourceRepository = (
 		const origin = canonicalOriginUrl(originRead.stdout);
 		if (origin === null) return refused("the origin remote is absent, local, or unparseable");
 
-		const filesRead = yield* execCapture("git", ["-C", root, "ls-files", "-z"]);
-		if (!filesRead.ok) return refused(`cannot enumerate tracked source: ${filesRead.reason}`);
+		const filesRead = yield* execCapture("git", [
+			"-C",
+			root,
+			"ls-tree",
+			"-r",
+			"-z",
+			"--name-only",
+			commit,
+		]);
+		if (!filesRead.ok) return refused(`cannot enumerate source at HEAD: ${filesRead.reason}`);
 		const files = filesRead.stdout.split("\0").filter((path) => path !== "");
 		const manifestPaths = files.filter(
 			(path) => path === "package.json" || path.endsWith("/package.json"),
@@ -82,7 +90,7 @@ export const inspectSourceRepository = (
 
 		const manifests: SourceManifest[] = [];
 		for (const path of manifestPaths) {
-			const read = yield* readAtHead(root, path);
+			const read = yield* readAtCommit(root, commit, path);
 			if (!read.ok) return refused(`cannot read ${path} at HEAD: ${read.reason}`);
 			const manifest = parseSourceManifest(path, read.stdout);
 			if (manifest !== null) manifests.push(manifest);
@@ -121,7 +129,7 @@ export const inspectSourceRepository = (
 		if (docs === undefined) return refused("the checkout has no tracked docs or examples");
 
 		for (const path of [source, tests, docs]) {
-			const read = yield* readAtHead(root, path);
+			const read = yield* readAtCommit(root, commit, path);
 			if (!read.ok) return refused(`cannot read ${path} at HEAD: ${read.reason}`);
 		}
 		return {

--- a/packages/fabrika-cli/src/pattern/source.ts
+++ b/packages/fabrika-cli/src/pattern/source.ts
@@ -1,0 +1,140 @@
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {execCapture} from "../io/exec.ts";
+import {isObjectName} from "../io/git.ts";
+import {canonicalOriginUrl, parseSourceManifest, type SourceManifest} from "./source-model.ts";
+
+export {canonicalOriginUrl} from "./source-model.ts";
+
+export interface SourceEvidence {
+	readonly origin: string;
+	readonly commit: string;
+	readonly package: string;
+	readonly version: string;
+	readonly inspected: {
+		readonly source: string;
+		readonly tests: string;
+		readonly docs: string;
+	};
+}
+
+export type SourceInspection =
+	| {readonly _tag: "Evidence"; readonly evidence: SourceEvidence}
+	| {readonly _tag: "Refused"; readonly reason: string};
+
+const refused = (reason: string): SourceInspection => ({_tag: "Refused", reason});
+
+const packageRoot = (manifestPath: string): string => {
+	const slash = manifestPath.lastIndexOf("/");
+	return slash < 0 ? "" : manifestPath.slice(0, slash);
+};
+
+const under = (path: string, root: string): boolean => root === "" || path.startsWith(`${root}/`);
+const isTest = (path: string): boolean =>
+	/(^|\/)(test|tests|__tests__)(\/|$)/i.test(path) || /\.(test|spec)\.[^/]+$/i.test(path);
+const isDocs = (path: string): boolean =>
+	/(^|\/)(docs?|examples?)(\/|$)/i.test(path) || /(^|\/)(readme|contributing)\.md$/i.test(path);
+const isSource = (path: string, root: string): boolean =>
+	under(path, root) &&
+	/(^|\/)(src|source|lib)\//i.test(path.slice(root === "" ? 0 : root.length + 1)) &&
+	!isTest(path);
+
+const readAtHead = (root: string, path: string) =>
+	execCapture("git", ["-C", root, "show", `HEAD:${path}`]);
+
+export const inspectSourceRepository = (
+	repoPath: string,
+	packageName: string | null,
+): Effect.Effect<SourceInspection, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const rootRead = yield* execCapture("git", ["-C", repoPath, "rev-parse", "--show-toplevel"]);
+		if (!rootRead.ok || rootRead.stdout.trim() === "") {
+			return refused(
+				`cannot resolve the supplied path as a readable Git checkout: ${rootRead.reason}`,
+			);
+		}
+		const root = rootRead.stdout.trim();
+		const headRead = yield* execCapture("git", [
+			"-C",
+			root,
+			"rev-parse",
+			"--verify",
+			"HEAD^{commit}",
+		]);
+		const commit = headRead.stdout.trim();
+		if (!headRead.ok || !isObjectName(commit)) {
+			return refused(
+				`cannot derive a full HEAD commit: ${headRead.reason || "git returned no object name"}`,
+			);
+		}
+		const originRead = yield* execCapture("git", ["-C", root, "remote", "get-url", "origin"]);
+		if (!originRead.ok) return refused(`cannot read an origin remote: ${originRead.reason}`);
+		const origin = canonicalOriginUrl(originRead.stdout);
+		if (origin === null) return refused("the origin remote is absent, local, or unparseable");
+
+		const filesRead = yield* execCapture("git", ["-C", root, "ls-files", "-z"]);
+		if (!filesRead.ok) return refused(`cannot enumerate tracked source: ${filesRead.reason}`);
+		const files = filesRead.stdout.split("\0").filter((path) => path !== "");
+		const manifestPaths = files.filter(
+			(path) => path === "package.json" || path.endsWith("/package.json"),
+		);
+		if (manifestPaths.length === 0) return refused("the checkout has no tracked package.json");
+
+		const manifests: SourceManifest[] = [];
+		for (const path of manifestPaths) {
+			const read = yield* readAtHead(root, path);
+			if (!read.ok) return refused(`cannot read ${path} at HEAD: ${read.reason}`);
+			const manifest = parseSourceManifest(path, read.stdout);
+			if (manifest !== null) manifests.push(manifest);
+		}
+		const candidates =
+			packageName === null
+				? manifests.filter((manifest) => !manifest.private)
+				: manifests.filter((manifest) => manifest.name === packageName);
+		if (candidates.length === 0) {
+			return refused(
+				packageName === null
+					? "no versioned public package can be derived from the checkout"
+					: `package ${packageName} has no unique versioned manifest in the checkout`,
+			);
+		}
+		if (candidates.length !== 1) {
+			return refused(
+				packageName === null
+					? `package selection is ambiguous across ${candidates.length} versioned public manifests; pass --source-package`
+					: `package ${packageName} is ambiguous across ${candidates.length} manifests`,
+			);
+		}
+		const selected = candidates[0];
+		if (selected === undefined) return refused("package selection produced no manifest");
+		const rootPrefix = packageRoot(selected.path);
+		const source = files.find((path) => isSource(path, rootPrefix));
+		if (source === undefined)
+			return refused(`package ${selected.name} has no tracked source files`);
+		const tests =
+			files.find((path) => under(path, rootPrefix) && isTest(path)) ??
+			files.find((path) => isTest(path));
+		if (tests === undefined) return refused("the checkout has no tracked tests");
+		const docs =
+			files.find((path) => under(path, rootPrefix) && isDocs(path)) ??
+			files.find((path) => isDocs(path));
+		if (docs === undefined) return refused("the checkout has no tracked docs or examples");
+
+		for (const path of [source, tests, docs]) {
+			const read = yield* readAtHead(root, path);
+			if (!read.ok) return refused(`cannot read ${path} at HEAD: ${read.reason}`);
+		}
+		return {
+			_tag: "Evidence",
+			evidence: {
+				origin,
+				commit,
+				package: selected.name,
+				version: selected.version,
+				inspected: {source, tests, docs},
+			},
+		};
+	});
+
+export const sourceEvidenceLine = (evidence: SourceEvidence): string =>
+	`> Source checkout evidence: ${evidence.origin} at \`${evidence.commit}\`; package \`${evidence.package}@${evidence.version}\`; inspected \`${evidence.inspected.source}\`, \`${evidence.inspected.tests}\`, and \`${evidence.inspected.docs}\`.`;

--- a/packages/fabrika-cli/src/pattern/source.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/source.unit.test.ts
@@ -16,21 +16,30 @@ const script = [
 	[/git -C \/local\/xyflow rev-parse --show-toplevel$/, okOut("/upstream\n")],
 	[/git -C \/upstream rev-parse --verify HEAD\^\{commit\}$/, okOut(`${SHA}\n`)],
 	[/git -C \/upstream remote get-url origin$/, okOut("git@github.com:xyflow/xyflow.git\n")],
-	[/git -C \/upstream ls-files -z$/, okOut(`${FILES}\0`)],
 	[
-		/git -C \/upstream show HEAD:package.json$/,
+		/git -C \/upstream ls-tree -r -z --name-only b1b99e9773040e25bd6099762491ab23d8ea6910$/,
+		okOut(`${FILES}\0`),
+	],
+	[
+		/git -C \/upstream show b1b99e9773040e25bd6099762491ab23d8ea6910:package.json$/,
 		okOut('{"name":"@xyflow/monorepo","version":"0.0.0","private":true}'),
 	],
 	[
-		/git -C \/upstream show HEAD:packages\/react\/package.json$/,
+		/git -C \/upstream show b1b99e9773040e25bd6099762491ab23d8ea6910:packages\/react\/package.json$/,
 		okOut('{"name":"@xyflow/react","version":"12.11.5"}'),
 	],
-	[/git -C \/upstream show HEAD:packages\/react\/src\/index.ts$/, okOut("export {}")],
 	[
-		/git -C \/upstream show HEAD:packages\/react\/src\/index.test.ts$/,
+		/git -C \/upstream show b1b99e9773040e25bd6099762491ab23d8ea6910:packages\/react\/src\/index.ts$/,
+		okOut("export {}"),
+	],
+	[
+		/git -C \/upstream show b1b99e9773040e25bd6099762491ab23d8ea6910:packages\/react\/src\/index.test.ts$/,
 		okOut("test('x', () => {})"),
 	],
-	[/git -C \/upstream show HEAD:packages\/react\/README.md$/, okOut("# React")],
+	[
+		/git -C \/upstream show b1b99e9773040e25bd6099762491ab23d8ea6910:packages\/react\/README.md$/,
+		okOut("# React"),
+	],
 ] as const;
 
 describe("canonicalOriginUrl", () => {
@@ -69,9 +78,13 @@ describe("inspectSourceRepository", () => {
 				},
 			},
 		});
-		expect(shell.calls).toContain("git -C /upstream show HEAD:packages/react/src/index.ts");
-		expect(shell.calls).toContain("git -C /upstream show HEAD:packages/react/src/index.test.ts");
-		expect(shell.calls).toContain("git -C /upstream show HEAD:packages/react/README.md");
+		expect(shell.calls).toContain(`git -C /upstream ls-tree -r -z --name-only ${SHA}`);
+		expect(shell.calls).toContain(`git -C /upstream show ${SHA}:packages/react/src/index.ts`);
+		expect(shell.calls).toContain(`git -C /upstream show ${SHA}:packages/react/src/index.test.ts`);
+		expect(shell.calls).toContain(`git -C /upstream show ${SHA}:packages/react/README.md`);
+		expect(
+			shell.calls.some((call) => call.includes("ls-files") || call.includes("show HEAD:")),
+		).toBe(false);
 	});
 
 	it("keeps the local checkout path out of portable evidence", async () => {
@@ -93,13 +106,16 @@ describe("inspectSourceRepository", () => {
 			[/git -C \/local\/mono rev-parse --show-toplevel$/, okOut("/mono\n")],
 			[/git -C \/mono rev-parse --verify HEAD\^\{commit\}$/, okOut(`${SHA}\n`)],
 			[/git -C \/mono remote get-url origin$/, okOut("https://github.com/acme/mono.git\n")],
-			[/git -C \/mono ls-files -z$/, okOut(`${files}\0`)],
 			[
-				/git -C \/mono show HEAD:packages\/a\/package.json$/,
+				/git -C \/mono ls-tree -r -z --name-only b1b99e9773040e25bd6099762491ab23d8ea6910$/,
+				okOut(`${files}\0`),
+			],
+			[
+				/git -C \/mono show b1b99e9773040e25bd6099762491ab23d8ea6910:packages\/a\/package.json$/,
 				okOut('{"name":"a","version":"1.0.0"}'),
 			],
 			[
-				/git -C \/mono show HEAD:packages\/b\/package.json$/,
+				/git -C \/mono show b1b99e9773040e25bd6099762491ab23d8ea6910:packages\/b\/package.json$/,
 				okOut('{"name":"b","version":"2.0.0"}'),
 			],
 		]);
@@ -119,8 +135,14 @@ describe("inspectSourceRepository", () => {
 			[/git -C \/local\/pkg rev-parse --show-toplevel$/, okOut("/pkg\n")],
 			[/git -C \/pkg rev-parse --verify HEAD\^\{commit\}$/, okOut(`${SHA}\n`)],
 			[/git -C \/pkg remote get-url origin$/, okOut("https://github.com/acme/pkg.git\n")],
-			[/git -C \/pkg ls-files -z$/, okOut(`${files}\0`)],
-			[/git -C \/pkg show HEAD:package.json$/, okOut('{"name":"pkg"}')],
+			[
+				/git -C \/pkg ls-tree -r -z --name-only b1b99e9773040e25bd6099762491ab23d8ea6910$/,
+				okOut(`${files}\0`),
+			],
+			[
+				/git -C \/pkg show b1b99e9773040e25bd6099762491ab23d8ea6910:package.json$/,
+				okOut('{"name":"pkg"}'),
+			],
 		]);
 		const result = await Effect.runPromise(
 			Effect.provide(inspectSourceRepository("/local/pkg", "pkg"), shell.layer),

--- a/packages/fabrika-cli/src/pattern/source.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/source.unit.test.ts
@@ -1,0 +1,133 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeShell, okOut} from "../fakes.test-support.ts";
+import {canonicalOriginUrl, inspectSourceRepository, sourceEvidenceLine} from "./source.ts";
+
+const SHA = "b1b99e9773040e25bd6099762491ab23d8ea6910";
+const FILES = [
+	"package.json",
+	"packages/react/package.json",
+	"packages/react/src/index.ts",
+	"packages/react/src/index.test.ts",
+	"packages/react/README.md",
+].join("\0");
+
+const script = [
+	[/git -C \/local\/xyflow rev-parse --show-toplevel$/, okOut("/upstream\n")],
+	[/git -C \/upstream rev-parse --verify HEAD\^\{commit\}$/, okOut(`${SHA}\n`)],
+	[/git -C \/upstream remote get-url origin$/, okOut("git@github.com:xyflow/xyflow.git\n")],
+	[/git -C \/upstream ls-files -z$/, okOut(`${FILES}\0`)],
+	[
+		/git -C \/upstream show HEAD:package.json$/,
+		okOut('{"name":"@xyflow/monorepo","version":"0.0.0","private":true}'),
+	],
+	[
+		/git -C \/upstream show HEAD:packages\/react\/package.json$/,
+		okOut('{"name":"@xyflow/react","version":"12.11.5"}'),
+	],
+	[/git -C \/upstream show HEAD:packages\/react\/src\/index.ts$/, okOut("export {}")],
+	[
+		/git -C \/upstream show HEAD:packages\/react\/src\/index.test.ts$/,
+		okOut("test('x', () => {})"),
+	],
+	[/git -C \/upstream show HEAD:packages\/react\/README.md$/, okOut("# React")],
+] as const;
+
+describe("canonicalOriginUrl", () => {
+	it("normalizes SSH and HTTPS GitHub origins without credentials or .git", () => {
+		expect(canonicalOriginUrl("git@github.com:xyflow/xyflow.git")).toBe(
+			"https://github.com/xyflow/xyflow",
+		);
+		expect(canonicalOriginUrl("https://github.com/xyflow/xyflow.git")).toBe(
+			"https://github.com/xyflow/xyflow",
+		);
+	});
+
+	it("refuses local and unparseable origins", () => {
+		expect(canonicalOriginUrl("/Users/me/src/xyflow")).toBeNull();
+		expect(canonicalOriginUrl("file:///Users/me/src/xyflow")).toBeNull();
+	});
+});
+
+describe("inspectSourceRepository", () => {
+	it("derives the selected monorepo package and reads source, tests, and docs at HEAD", async () => {
+		const shell = fakeShell(script);
+		const result = await Effect.runPromise(
+			Effect.provide(inspectSourceRepository("/local/xyflow", "@xyflow/react"), shell.layer),
+		);
+		expect(result).toEqual({
+			_tag: "Evidence",
+			evidence: {
+				origin: "https://github.com/xyflow/xyflow",
+				commit: SHA,
+				package: "@xyflow/react",
+				version: "12.11.5",
+				inspected: {
+					source: "packages/react/src/index.ts",
+					tests: "packages/react/src/index.test.ts",
+					docs: "packages/react/README.md",
+				},
+			},
+		});
+		expect(shell.calls).toContain("git -C /upstream show HEAD:packages/react/src/index.ts");
+		expect(shell.calls).toContain("git -C /upstream show HEAD:packages/react/src/index.test.ts");
+		expect(shell.calls).toContain("git -C /upstream show HEAD:packages/react/README.md");
+	});
+
+	it("keeps the local checkout path out of portable evidence", async () => {
+		const shell = fakeShell(script);
+		const result = await Effect.runPromise(
+			Effect.provide(inspectSourceRepository("/local/xyflow", "@xyflow/react"), shell.layer),
+		);
+		expect(result._tag).toBe("Evidence");
+		if (result._tag === "Evidence") {
+			const serialized = JSON.stringify(result.evidence) + sourceEvidenceLine(result.evidence);
+			expect(serialized).not.toContain("/local/xyflow");
+			expect(serialized).not.toContain("/upstream");
+		}
+	});
+
+	it("refuses ambiguous monorepos instead of choosing a root or first package", async () => {
+		const files = ["packages/a/package.json", "packages/b/package.json"].join("\0");
+		const shell = fakeShell([
+			[/git -C \/local\/mono rev-parse --show-toplevel$/, okOut("/mono\n")],
+			[/git -C \/mono rev-parse --verify HEAD\^\{commit\}$/, okOut(`${SHA}\n`)],
+			[/git -C \/mono remote get-url origin$/, okOut("https://github.com/acme/mono.git\n")],
+			[/git -C \/mono ls-files -z$/, okOut(`${files}\0`)],
+			[
+				/git -C \/mono show HEAD:packages\/a\/package.json$/,
+				okOut('{"name":"a","version":"1.0.0"}'),
+			],
+			[
+				/git -C \/mono show HEAD:packages\/b\/package.json$/,
+				okOut('{"name":"b","version":"2.0.0"}'),
+			],
+		]);
+		const result = await Effect.runPromise(
+			Effect.provide(inspectSourceRepository("/local/mono", null), shell.layer),
+		);
+		expect(result).toEqual({
+			_tag: "Refused",
+			reason:
+				"package selection is ambiguous across 2 versioned public manifests; pass --source-package",
+		});
+	});
+
+	it("refuses a selected package whose version cannot be derived", async () => {
+		const files = ["package.json", "src/index.ts", "src/index.test.ts", "README.md"].join("\0");
+		const shell = fakeShell([
+			[/git -C \/local\/pkg rev-parse --show-toplevel$/, okOut("/pkg\n")],
+			[/git -C \/pkg rev-parse --verify HEAD\^\{commit\}$/, okOut(`${SHA}\n`)],
+			[/git -C \/pkg remote get-url origin$/, okOut("https://github.com/acme/pkg.git\n")],
+			[/git -C \/pkg ls-files -z$/, okOut(`${files}\0`)],
+			[/git -C \/pkg show HEAD:package.json$/, okOut('{"name":"pkg"}')],
+		]);
+		const result = await Effect.runPromise(
+			Effect.provide(inspectSourceRepository("/local/pkg", "pkg"), shell.layer),
+		);
+		expect(result).toEqual({
+			_tag: "Refused",
+			reason: "package pkg has no unique versioned manifest in the checkout",
+		});
+	});
+});


### PR DESCRIPTION
Allows pattern guidance to precede implementation when a cited binding decision and authoritative source ground the intended shape. The current-pattern path keeps its evidence bars without a fixed call-site count.

`pattern new` now supports prospective scaffolds and optional fail-closed local-checkout inspection, emitting only canonical origin, full commit, relevant package/version, and repository-relative source/test/docs evidence while retaining dependency pin-bump anchors.

Fixes #7197

## Deviations

None.
