### PR TITLE
roadmap: declare and start the Tuval campaign (#51)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@ flowchart TD
 		camp_lane_integrity["Lane integrity"]:::active
 		camp_epic_lanes["Epic lanes"]:::paused
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
+		camp_tuval["Tuval"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -111,6 +112,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Lane integrity | #48 | active |
 | Epic lanes | #49 | paused |
 | Diátaxis README passes | #50 | active |
+| Tuval | #51 | active |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Founder-ruled 2026-08-28 (chat): Tuval — the pi web GUI / agent-session canvas arc (epic #7140 family) — is the next vision and gets its own campaign.

- New `## Campaigns` row: **Tuval | #51 | active**, written by `fabrika campaign open` + `campaign state`, citing the two approval markers on #7140:
  - declare (paused): https://github.com/kamp-us/phoenix/issues/7140#issuecomment-5460245945
  - start (active): https://github.com/kamp-us/phoenix/issues/7140#issuecomment-5460246343
- Matching hand-maintained mermaid node `camp_tuval` (:::active) in the dependency graph.

Board side (already live): milestone **#51 Tuval** created; the 19 open family issues homed on it and taken off `wayfinder:backlog` (they are charted, in-build work — not fog — and the standing-lane label would have bypassed this campaign's fence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxMCAmgHrCufcoDawKRhAK