### PR TITLE
roadmap: resume the Epic lanes campaign (#49)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ flowchart TD
 		camp_fabrika_everywhere["fabrika everywhere"]:::active
 		camp_ge_it_product_push["Geçit product push"]:::active
 		camp_lane_integrity["Lane integrity"]:::active
-		camp_epic_lanes["Epic lanes"]:::paused
+		camp_epic_lanes["Epic lanes"]:::active
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
 		camp_tuval["Tuval"]:::active
 	end
@@ -110,7 +110,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | fabrika everywhere | #47 | active |
 | Geçit product push | #24 | active |
 | Lane integrity | #48 | active |
-| Epic lanes | #49 | paused |
+| Epic lanes | #49 | active |
 | Diátaxis README passes | #50 | active |
 | Tuval | #51 | active |
 


### PR DESCRIPTION
Founder-ruled 2026-08-28 (chat): flip Epic lanes #49 paused → active, opening dispatch so the parked p0 lane on #7035 can run.

Written by `fabrika campaign state`, citing https://github.com/kamp-us/phoenix/issues/7035#issuecomment-5460263166. Mermaid node `camp_epic_lanes` restyled to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxMCAmgHrCufcoDawKRhAK