### PR TITLE
chore: review-ui renders the preview anonymous and flag-off, so a dark-shipped feature's real pixels are never judged

### DIFF
--- a/.decisions/0336-review-ui-renders-flag-gated-states.md
+++ b/.decisions/0336-review-ui-renders-flag-gated-states.md
@@ -1,0 +1,49 @@
+---
+id: 0336
+title: review-ui Renders a Flag-Gated Feature's Real States — Override at Capture
+status: accepted
+date: 2026-08-29
+tags: [pipeline, review-ui, feature-flags]
+---
+
+# 0336 — review-ui Renders a Flag-Gated Feature's Real States — Override at Capture
+
+**What this decides:** `fabrika review-ui render` gains a flag-override plus seeded-session path so a dark-shipped feature's real states paint under the gate, and until that path ships a `review-ui` verdict must name the states that did not render.
+
+## Context
+
+ADR [0083](0083-agents-deploy-humans-release.md) makes default-off dark-ship the norm: a user-facing change lands behind a flag nobody has flipped. `fabrika review-ui render` captures the PR's preview deployment as an anonymous visitor with every flag at its default, and its options carry no auth and no flag seam (`packages/fabrika-cli/src/review-ui/render-verb.ts` takes `--pr`, `--out`, `--surface`, `--app`, `--repo`). Flags resolve server-side (`apps/web/src/flags/useFlag.ts`, ADR [0179](0179-edge-resolved-shell-state-boot-contract.md)), so no client-side override exists either.
+
+The two norms compose into a hole: the gate that exists to judge pixels sees only the off-path, and it says so in a verdict shaped like a judgment.
+
+The instance is PR #6434 (head `74ecd143`, epic #4306). Six surfaces captured cleanly; four compositions the PR adds never painted — `/caylak-gorunurlugu` self-404'd behind its own gate, `/profile` served the auth wall, and `/pano` and `/sozluk` correctly showed no çaylak marker, because an anonymous viewer with the flag off is exactly who never sees one. The only judgeable new paint was `CaylakBadge`, and only because the builder happened to add an atölye exhibit that renders outside the flag. Nothing required that exhibit.
+
+The `review-ui` skill's disclosure fork keyed on the verb reporting a surface *unreachable*. A flag-off capture is not unreachable — it renders, and it renders the wrong state cleanly — so the fork had no case for it and the run read as clean coverage.
+
+The gap was reported as #6541; the founder ruled on it at [this comment](https://github.com/kamp-us/phoenix/issues/6541#issuecomment-5363127455).
+
+## Decision
+
+**`review-ui render` gets a flag-override plus seeded-session path, so a dark-shipped feature's real states paint under the gate.**
+
+1. **Override at capture.** The verb grows a preview-scoped flag override and a seeded session, so gated and behind-auth states become reachable during a gate run. The implementation lands on its own build ticket against `render-verb.ts`, not under the decision issue.
+
+2. **The interim rider.** Until that path ships, a `review-ui` verdict must name the states that did not render. This is not optional politeness — an unnamed hole in the evidence is indistinguishable from a clean read, which is exactly how #6434 passed.
+
+3. **The disclosure fork covers the clean-but-wrong state.** `claude-plugins/fabrika/skills/review-ui/SKILL.md` forked only on the verb's `unreachable` outcome. A surface that renders its flag-off or logged-out state is not a judged surface either, and the verdict owes the same naming.
+
+### Considered and not chosen
+
+Two other directions were on the table. Neither was taken, and neither should be re-litigated without a new ruling.
+
+- **Require a renderable escape hatch** — make an atölye exhibit a required deliverable for any flag-gated UI slice, so the paint is always renderable outside the flag. Rejected as the primary close: it taxes every builder to work around a gate limitation, and an exhibit renders a component in isolation, not the composition a user meets.
+- **Record a deferred-until-flip obligation** — have the gate emit an explicit obligation the founder's flag flip must discharge. Rejected as the primary close: it moves "look at the pixels" to the flip, which is the moment when looking is most expensive and least reversible.
+
+The interim rider in §2 is the deferred direction's honest half — disclosure, not deferral — and it retires when §1 ships.
+
+## Consequences
+
+- The gate can judge what a user will actually meet, instead of judging the off-path and reporting a PASS.
+- `render-verb.ts` grows an auth and flag seam it does not have today, which is real surface area on a verb that is otherwise read-only against a preview.
+- Until that lands, `review-ui` verdicts get longer: every unpainted state is named. That is the point.
+- The accidental coverage an atölye exhibit provides stays useful and stays optional.

--- a/.decisions/0336-review-ui-renders-flag-gated-states.md
+++ b/.decisions/0336-review-ui-renders-flag-gated-states.md
@@ -26,7 +26,7 @@ The gap was reported as #6541; the founder ruled on it at [this comment](https:/
 
 **`review-ui render` gets a flag-override plus seeded-session path, so a dark-shipped feature's real states paint under the gate.**
 
-1. **Override at capture.** The verb grows a preview-scoped flag override and a seeded session, so gated and behind-auth states become reachable during a gate run. The implementation lands on its own build ticket against `render-verb.ts`, not under the decision issue.
+1. **Override at capture.** The verb grows a preview-scoped flag override and a seeded session, so gated and behind-auth states become reachable during a gate run. The implementation lands on its own build ticket, [#7218](https://github.com/kamp-us/phoenix/issues/7218), not under the decision issue.
 
 2. **The interim rider.** Until that path ships, a `review-ui` verdict must name the states that did not render. This is not optional politeness — an unnamed hole in the evidence is indistinguishable from a clean read, which is exactly how #6434 passed.
 

--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -111,6 +111,24 @@ run-level refusal and what makes a capture valid are the verb's section
 `--heading "review-ui note"`). The two render paths this needs are
 `--heading "Required environment — the two render paths"`.
 
+**A surface that renders cleanly is not yet a judged surface.** The verb captures as an anonymous
+visitor with every flag at its default, and under ADR
+[0083](../../../../.decisions/0083-agents-deploy-humans-release.md)'s dark-ship norm that is exactly
+who never sees the feature. So a flag-gated route serving its own 404, a signed-in view serving the
+auth wall, and a feed row correctly showing no new marker all come back `captured` — a clean
+capture of the state the PR did not add. The verb reports none of them as unreachable, so the
+disclosure fork above never fires and the run reads as coverage it does not have (#6541, on PR
+#6434: six surfaces captured, four of the PR's compositions never painted).
+
+Derive the states the PR adds from the diff, and check each one against what actually painted.
+**Every state that did not paint is named in your verdict**, with why — flag off, signed out,
+seeded data absent. Name them and judge what did paint; a verdict that stays silent about them
+claims a judgment nobody made. When nothing the PR adds painted, that is CANT-SEE, on the same
+terms as an every-surface-unreachable render. ADR
+[0336](../../../../.decisions/0336-review-ui-renders-flag-gated-states.md) records why this is a
+disclosure rule today and what retires it: a flag-override plus seeded-session path on `review-ui
+render`, after which the gate reaches these states instead of naming them.
+
 **Two eyes, one record:** when this session's tool surface carries the `claude-in-chrome` tools you
 may additionally inspect the preview live — navigate, probe states, look closer. Detection is tool
 presence, nothing else; absent Chrome you use the captures silently. Chrome pixels never substitute
@@ -166,7 +184,7 @@ are simply no row. `surface` refusing on `11` is UNKNOWN coverage, never a clean
 
 ```bash
 fabrika review-ui post $pr_number --polarity FAIL --sha 03135b91 --clause "changes-requested" --evidence judged <<'EOF'
-…per-row table with pixel evidence, coverage table (rendered / unreachable+disclosed), advisories…
+…per-row table with pixel evidence, coverage table (judged / unreachable+disclosed / captured-but-not-the-PR's-state, each with why), advisories…
 EOF
 ```
 


### PR DESCRIPTION
Transcribes the founder ruling on #6541 into the decision corpus and closes the disclosure hole the ruling's interim rider names.

The gap: `fabrika review-ui render` captures a PR's preview as an anonymous visitor with every flag at its default. Under ADR 0083's dark-ship norm that is exactly who never sees the feature, so a gated feature's real states never paint and the gate reports a clean read of the off-path. On PR #6434 six surfaces captured and four of the PR's compositions never painted.

The founder ruled direction 1, override at capture, at https://github.com/kamp-us/phoenix/issues/6541#issuecomment-5363127455.

Two files:

- `.decisions/0336-review-ui-renders-flag-gated-states.md` — the ruling recorded, linking the ruling comment. Names the two directions not taken (requiring an atölye exhibit as a `build-ui` deliverable; a deferred-until-flip obligation) and why, so nobody re-litigates them. Carries the interim rider: until the override path ships, a `review-ui` verdict must name the states that did not render.
- `claude-plugins/fabrika/skills/review-ui/SKILL.md` — the disclosure fork forked only on the verb reporting a surface *unreachable*. A flag-off capture is not unreachable; it renders the wrong state cleanly, so the fork never fired. Adds that case, and updates the verdict's coverage table to separate a judged surface from one that captured a state the PR did not add.

The implementation of the override itself is #7218, filed out of this issue and named in the ADR. No behaviour change lands here in `render-verb.ts` or `useFlag.ts` — the issue's own criteria forbid it.

Fixes #6541

## Deviations

- **Out-of-scope change** — **Said:** the criteria name only the `review-ui` skill's unreachable-surface disclosure fork. **Did:** also updated the verdict-emission line's coverage table in the same file, from `rendered / unreachable+disclosed` to a three-way split naming the captured-but-wrong-state case. **Why:** the new fork owes a disclosure the verdict shape had no column for, so leaving the table at two columns would have made the amended fork unrecordable at the one place it lands. **Disposition:** stated here.
