### PR TITLE
feat: review-ui default-state captures leave interaction states unjudged

### DIFF
--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -94,6 +94,14 @@ you render independently or you have not looked.
 fabrika review-ui render --pr $pr_number --out judged --surface /pano --surface /pano/yeni
 ```
 
+**A surface behind login is named, not skipped.** A surface id may carry a realized state, and
+`auth` is the one realized today: `--surface /pano:auth` renders the same route as the moderator-tier
+test account instead of a visitor, so a delta that only exists signed in is judged rather than
+missed. Anything else after the colon is refused on `10` — a state nothing renders would shoot the
+default pixels under a variant's name. `:auth` needs `PREVIEW_TEST_SESSION_TOKEN` and
+`BETTER_AUTH_SECRET` in the environment; with either unset the verb refuses `11` rather than handing
+you an anonymous shot that reads as the signed-in one.
+
 The verb captures the PR's **preview deployment** at the inspected head — never a checkout, never
 the PR's code run on your machine. Every surface returns a proven outcome — captured, crashed
 (13), unreachable (14), invalid capture (15) — and two run-level refusals precede the per-surface

--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -98,9 +98,21 @@ fabrika review-ui render --pr $pr_number --out judged --surface /pano --surface 
 `auth` is the one realized today: `--surface /pano:auth` renders the same route as the moderator-tier
 test account instead of a visitor, so a delta that only exists signed in is judged rather than
 missed. Anything else after the colon is refused on `10` — a state nothing renders would shoot the
-default pixels under a variant's name. `:auth` needs `PREVIEW_TEST_SESSION_TOKEN` and
-`BETTER_AUTH_SECRET` in the environment; with either unset the verb refuses `11` rather than handing
-you an anonymous shot that reads as the signed-in one.
+default pixels under a variant's name.
+
+Two environment values make `:auth` work, and both come from somewhere specific:
+`PREVIEW_TEST_SESSION_TOKEN` is the token an operator passed to
+`node packages/preview-seed/src/bin.ts test-account --database-id <preview-d1>`, which is what puts
+the account and its session row on this PR's preview D1; `BETTER_AUTH_SECRET` is the **preview
+worker's** secret, not your local one, because it is the worker that verifies the cookie's signature.
+Neither is yours to mint — if you do not have them, you have not been handed the account, and
+`review-ui note` is the honest route.
+
+**You never have to judge whether the shot came back signed in.** The verb hits the preview's own
+session endpoint from the same browser context before it records anything, and refuses `11` when the
+answer is not a user — an unset credential, a wrong or expired token, an account absent from this
+preview's D1 all land there. So a `:auth` capture in a manifest is a proven signed-in render, and a
+missing one is a refusal you read, never a silent anonymous shot.
 
 The verb captures the PR's **preview deployment** at the inspected head — never a checkout, never
 the PR's code run on your machine. Every surface returns a proven outcome — captured, crashed

--- a/claude-plugins/fabrika/skills/review-ui/contract.md
+++ b/claude-plugins/fabrika/skills/review-ui/contract.md
@@ -204,9 +204,10 @@ Per the tandem ruling (both briefs, 2026-08-09), declared identically to `build-
   capture sets only, so the attach path has one validated producer.
 - **`:auth` surfaces need two environment values**, both unset by default: `PREVIEW_TEST_SESSION_TOKEN`
   (the session token `preview-seed test-account` wrote onto the preview D1) and `BETTER_AUTH_SECRET`
-  (the preview worker's, so the cookie signature verifies). Absent both, every surface renders
-  anonymously as before; with exactly one set, an `:auth` request refuses `11` rather than
-  substituting the anonymous render.
+  (the preview worker's, so the cookie signature verifies). With neither or one set, an `:auth`
+  request refuses `11` rather than substituting the anonymous render; with no `:auth` surface asked
+  for, every surface renders anonymously as before. Setting both is necessary and not sufficient —
+  whether the cookie authenticated is the per-shot session proof's answer, also an `11`.
 
 **The preview-deploy convention.** The repo announces each PR's preview as a sticky PR comment
 carrying the anchor `<!-- preview-deploy:<app> -->`, whose body names, per app: the deployed URL
@@ -242,8 +243,15 @@ fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/
 A `:state` suffix is admitted **only for a state something here actually puts on screen**, and
 refused on `10` otherwise. The realized set is `auth` and nothing else (#7051): an `:auth` surface
 renders with the moderator-tier test account's better-auth session cookie seeded into the capture
-context, so the pixels are a signed-in yazar+moderator's rather than a visitor's. The account is
-provisioned direct-D1 by `preview-seed test-account`, never by a worker route.
+context. The account is provisioned direct-D1 by `preview-seed test-account`, never by a worker
+route.
+
+Seeding a cookie is not the same as being signed in, so the shot proves it rather than assuming it.
+From the same browser context, before the shot is classified, the verb reads the preview's own
+`/api/auth/get-session` and requires a user back; anything else — a bare `null`, a non-200, an
+unreadable body — refuses the surface on `11` and records no capture. This is what makes the pixels a
+signed-in yazar+moderator's: a cookie that did not authenticate renders the visitor's page, and that
+page is a perfectly valid PNG no byte check can tell from the real one.
 
 The refusal on every other token is the same fence v1 stated, kept for the same reason: v1 demanded
 `:focus-visible` captures with no mechanism to prove the state was realized, and a state that
@@ -294,7 +302,7 @@ re-invocation without it, on the record; never the tool's tolerance.
 |---|---|
 | `7` | the PR is proven absent (404) or closed |
 | `10` | `--out` not kebab-case, or a `--surface` names a `:state` outside the realized set (`auth`) |
-| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; or an `:auth` surface was requested while `PREVIEW_TEST_SESSION_TOKEN` / `BETTER_AUTH_SECRET` is unset |
+| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; an `:auth` surface was requested while `PREVIEW_TEST_SESSION_TOKEN` / `BETTER_AUTH_SECRET` is unset; or an `:auth` surface's session proof did not come back signed in |
 | `12` | proven: the preview comment's deployed SHA is not the PR's live head — stale preview; re-render after the preview catches up |
 | `13` | proven: at least one surface threw an uncaught page error |
 | `14` | proven: at least one surface is unreachable (status ≥ 400, failed navigation, no route, dark flag, gated tier) |
@@ -308,7 +316,8 @@ re-invocation without it, on the record; never the tool's tolerance.
 | `review-ui render: PR #<n> not found in <repo>.` | 7 | refusal |
 | `review-ui render: PR #<n> is closed — nothing to judge.` | 7 | refusal |
 | `review-ui render: --surface "<id>" names a :state nothing renders — the realized states are auth; render the bare route.` | 10 | refusal |
-| `review-ui render: an :auth surface was requested but <NAME> is unset — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
+| `review-ui render: an :auth surface was requested but its credentials are incomplete (unset: <names>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
+| `review-ui render: surface "<id>" did not render signed in (<reason>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
 | `review-ui render: --out "<value>" is not a kebab-case set name.` | 10 | refusal |
 | `review-ui render: cannot read <what> for #<n>: <reason> — the render is UNKNOWN.` | 11 | refusal |
 | `review-ui render: the preview comment names apps <list> — pass --app to pick one.` | 11 | refusal |

--- a/claude-plugins/fabrika/skills/review-ui/contract.md
+++ b/claude-plugins/fabrika/skills/review-ui/contract.md
@@ -168,7 +168,7 @@ sibling's numerals is not a goal the doctrine sets.
 | `7` | zero scope: the target is **proven** absent (404), or the PR is closed — a deliberate, declared widening of the base seat (existence-only) to closed-target, because a closed PR is provably not reviewable scope, matching the sibling `review` group's use |
 | `8` | a write was attempted and its outcome could not be proven — UNKNOWN |
 | `9` | the write landed but the read-back does not match |
-| `10` | a semantic refusal on a value or body: a supplied value off its closed vocabulary (a bad `--polarity`, `--carrier advisory` with FAIL, a non-kebab `--out`, a reserved `:state` suffix), or a `note` body whose first line parses as a verdict carrier |
+| `10` | a semantic refusal on a value or body: a supplied value off its closed vocabulary (a bad `--polarity`, `--carrier advisory` with FAIL, a non-kebab `--out`, a `:state` outside the realized set), or a `note` body whose first line parses as a verdict carrier |
 | `11` | a required read or execution failed — no outcome is proven: the PR, its head, the preview probe, the harness, a capture's validity, or (at post time) the upload target's state. The same deliberate widening the `ui` group states: an execution that never became answerable leaves the run UNKNOWN exactly as a failed read does |
 | `12` | refused, proven: the artifact is not the PR's current tree — the live head moved past `--sha` at post time, or the preview's deployed head is not the live head at render time |
 | `13` | proven: at least one surface threw an uncaught page error during render — the render is red |
@@ -202,6 +202,11 @@ Per the tandem ruling (both briefs, 2026-08-09), declared identically to `build-
   verb changes behavior based on it. Chrome absent means the default path, silently.
 - Chrome output never enters `review-ui post --evidence`: evidence comes from `review-ui render`
   capture sets only, so the attach path has one validated producer.
+- **`:auth` surfaces need two environment values**, both unset by default: `PREVIEW_TEST_SESSION_TOKEN`
+  (the session token `preview-seed test-account` wrote onto the preview D1) and `BETTER_AUTH_SECRET`
+  (the preview worker's, so the cookie signature verifies). Absent both, every surface renders
+  anonymously as before; with exactly one set, an `:auth` request refuses `11` rather than
+  substituting the anonymous render.
 
 **The preview-deploy convention.** The repo announces each PR's preview as a sticky PR comment
 carrying the anchor `<!-- preview-deploy:<app> -->`, whose body names, per app: the deployed URL
@@ -230,15 +235,22 @@ fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/
 |---|---|---|---|---|
 | `--pr` | integer | yes | — | the pull request whose preview is judged |
 | `--out` | string | yes | — | kebab-case capture-set name; captures land under `<OS temp>/fabrika-review-ui/<pr>-<head8>/<set>/` |
-| `--surface` | string, repeatable | yes (≥1) | — | a surface id: a bare route (`/pano`); zero operands is `1` — no tool guesses surfaces from a diff |
+| `--surface` | string, repeatable | yes (≥1) | — | a surface id: a route (`/pano`), or a route plus a realized state (`/pano:auth`); zero operands is `1` — no tool guesses surfaces from a diff |
 | `--app` | string | no | the sole app in the preview comment; ambiguity refuses on `11` | which app's sub-line of the preview comment to resolve |
 | `--repo` | string | no | resolved | the repository |
 
-A `:state` suffix on a surface id is **reserved and refused on `10`**, the same deferral as the
-`ui` group: realizing a named state needs its own convention, and refusing now keeps the grammar
-extensible. v1 demanded `:focus-visible` captures with no mechanism to prove the state was
-actually realized — a state that silently rendered unfocused PASSed its prohibition forever;
-this grammar refuses to pretend until a consumer builds the proof.
+A `:state` suffix is admitted **only for a state something here actually puts on screen**, and
+refused on `10` otherwise. The realized set is `auth` and nothing else (#7051): an `:auth` surface
+renders with the moderator-tier test account's better-auth session cookie seeded into the capture
+context, so the pixels are a signed-in yazar+moderator's rather than a visitor's. The account is
+provisioned direct-D1 by `preview-seed test-account`, never by a worker route.
+
+The refusal on every other token is the same fence v1 stated, kept for the same reason: v1 demanded
+`:focus-visible` captures with no mechanism to prove the state was realized, and a state that
+silently rendered unfocused PASSed its prohibition forever. Parsing a state is not rendering one —
+a token with no mechanism shoots the default pixels under a variant's name, which is coverage
+claimed and not held. The sibling `ui` group renders in-tree with no preview and no session, so it
+still refuses every `:state`.
 
 **Output** — machine. One JSON object on full success only:
 
@@ -281,8 +293,8 @@ re-invocation without it, on the record; never the tool's tolerance.
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed |
-| `10` | `--out` not kebab-case, or a `--surface` carries the reserved `:state` suffix |
-| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; or a capture's validity could not be determined |
+| `10` | `--out` not kebab-case, or a `--surface` names a `:state` outside the realized set (`auth`) |
+| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; or an `:auth` surface was requested while `PREVIEW_TEST_SESSION_TOKEN` / `BETTER_AUTH_SECRET` is unset |
 | `12` | proven: the preview comment's deployed SHA is not the PR's live head — stale preview; re-render after the preview catches up |
 | `13` | proven: at least one surface threw an uncaught page error |
 | `14` | proven: at least one surface is unreachable (status ≥ 400, failed navigation, no route, dark flag, gated tier) |
@@ -295,7 +307,8 @@ re-invocation without it, on the record; never the tool's tolerance.
 |---|---|---|
 | `review-ui render: PR #<n> not found in <repo>.` | 7 | refusal |
 | `review-ui render: PR #<n> is closed — nothing to judge.` | 7 | refusal |
-| `review-ui render: --surface "<id>" carries a :state suffix — states are a reserved grammar, not yet realized; render the bare route.` | 10 | refusal |
+| `review-ui render: --surface "<id>" names a :state nothing renders — the realized states are auth; render the bare route.` | 10 | refusal |
+| `review-ui render: an :auth surface was requested but <NAME> is unset — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
 | `review-ui render: --out "<value>" is not a kebab-case set name.` | 10 | refusal |
 | `review-ui render: cannot read <what> for #<n>: <reason> — the render is UNKNOWN.` | 11 | refusal |
 | `review-ui render: the preview comment names apps <list> — pass --app to pick one.` | 11 | refusal |

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -883,7 +883,7 @@ Judge a UI pull request over its preview deployment. Contract:
 
 | Verb | Answers |
 |---|---|
-| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized state (`/pano:auth` renders signed in as the test moderator) |
+| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized state (`/pano:auth` renders signed in as the test moderator, refusing on `11` unless the session proves it took) |
 | `review-ui post` | the `review-ui` verdict on stdin, posted as one comment |
 | `review-ui note` | a typed blocker note when the surfaces cannot be seen |
 | `review-ui route` | a head-bound `routed-elsewhere` record: this PR renders nothing, so no verdict is owed |

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -883,7 +883,7 @@ Judge a UI pull request over its preview deployment. Contract:
 
 | Verb | Answers |
 |---|---|
-| `review-ui render` | the named surfaces captured from a PR's preview deployment |
+| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized state (`/pano:auth` renders signed in as the test moderator) |
 | `review-ui post` | the `review-ui` verdict on stdin, posted as one comment |
 | `review-ui note` | a typed blocker note when the surfaces cannot be seen |
 | `review-ui route` | a head-bound `routed-elsewhere` record: this PR renders nothing, so no verdict is owed |

--- a/packages/fabrika-cli/src/capture/auth.ts
+++ b/packages/fabrika-cli/src/capture/auth.ts
@@ -45,26 +45,62 @@ export const sessionCookies = (
 };
 
 /**
- * The credentials an authenticated capture needs. Both or neither: a token with no secret cannot be
- * signed, and a secret with no token names no session, so the pair is the only representable state.
+ * The credentials an authenticated capture needs, or the names of whichever are unset. Both or
+ * neither: a token with no secret cannot be signed, and a secret with no token names no session, so
+ * a complete pair is the only arm that renders signed in — one unset name and two are the same
+ * refusal, differing only in what they list.
  */
-export interface CaptureIdentity {
-	readonly token: string;
-	readonly secret: string;
-}
+export type IdentityRead =
+	| {readonly _tag: "Identity"; readonly token: string; readonly secret: string}
+	| {readonly _tag: "Missing"; readonly names: readonly string[]};
 
-/**
- * Read the identity from the environment. Returns `null` when neither is set (the anonymous
- * capture, which is the default) and the name of the missing half when exactly one is — a half-set
- * pair is a misconfiguration that would otherwise render anonymously and read as a clean default.
- */
-export const readIdentity = (
-	env: Readonly<Record<string, string | undefined>>,
-): CaptureIdentity | null | {readonly missing: string} => {
+export const readIdentity = (env: Readonly<Record<string, string | undefined>>): IdentityRead => {
 	const token = env.PREVIEW_TEST_SESSION_TOKEN ?? "";
 	const secret = env.BETTER_AUTH_SECRET ?? "";
-	if (token.length === 0 && secret.length === 0) return null;
-	if (token.length === 0) return {missing: "PREVIEW_TEST_SESSION_TOKEN"};
-	if (secret.length === 0) return {missing: "BETTER_AUTH_SECRET"};
-	return {token, secret};
+	const names = [
+		...(token.length === 0 ? ["PREVIEW_TEST_SESSION_TOKEN"] : []),
+		...(secret.length === 0 ? ["BETTER_AUTH_SECRET"] : []),
+	];
+	return names.length === 0 ? {_tag: "Identity", token, secret} : {_tag: "Missing", names};
+};
+
+/**
+ * The preview endpoint that answers whether the seeded cookie actually authenticates.
+ *
+ * better-auth's `/get-session` (`dist/api/routes/session.mjs` at the `1.6.23` pin) reads the signed
+ * session cookie and returns a bare JSON `null` when it does not resolve to a session, or an object
+ * carrying `session` + `user` when it does — so the answer is decidable from the body alone, without
+ * reading a pixel. Mounted at `/api/auth/*` by `apps/web/worker/features/pasaport/route.ts`.
+ */
+export const SESSION_PROBE_PATH = "/api/auth/get-session";
+
+/**
+ * Whether a capture context is signed in, decided from the probe's own answer.
+ *
+ * Three arms, not two: a probe that could not be read is UNKNOWN and must not collapse into
+ * "anonymous", because both would refuse but only one of them is a fact about the session.
+ */
+export type SessionProof =
+	| {readonly _tag: "SignedIn"; readonly userId: string}
+	| {readonly _tag: "Anonymous"}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+export const readSessionProof = (status: number, body: string): SessionProof => {
+	if (status !== 200) return {_tag: "Unreadable", reason: `probe answered ${status}`};
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return {_tag: "Unreadable", reason: "probe body is not JSON"};
+	}
+	if (parsed === null) return {_tag: "Anonymous"};
+	if (typeof parsed !== "object") {
+		return {_tag: "Unreadable", reason: "probe body is not a session object"};
+	}
+	const user = (parsed as {user?: unknown}).user;
+	if (user === null || user === undefined) return {_tag: "Anonymous"};
+	const id = (user as {id?: unknown}).id;
+	return typeof id === "string" && id.length > 0
+		? {_tag: "SignedIn", userId: id}
+		: {_tag: "Unreadable", reason: "probe named a user with no id"};
 };

--- a/packages/fabrika-cli/src/capture/auth.ts
+++ b/packages/fabrika-cli/src/capture/auth.ts
@@ -1,0 +1,70 @@
+/**
+ * Build the better-auth session cookie a capture context presents, so `review-ui render` can shoot
+ * a surface behind login (#7051). Pure — no browser, no network; `capture.ts` seeds what this
+ * returns.
+ *
+ * The wire format is better-auth's, read at the pinned version rather than assumed:
+ * `setSessionCookie` writes the session row's `token` through `ctx.setSignedCookie(…,
+ * ctx.context.secret)` (better-auth `dist/cookies/index.mjs`), and `setSignedCookie` resolves to
+ * better-call's `signCookieValue` (`dist/crypto.mjs`) — `encodeURIComponent(`${value}.${base64(
+ * HMAC-SHA256(value, secret))}`)`. The read side (`dist/api/routes/session.mjs`) verifies that
+ * signature, so an unsigned token is simply not a session.
+ *
+ * Two cookie names are seeded, not one, and that is deliberate. The `__Secure-` prefix is chosen
+ * inside the worker isolate from `isProduction` when the app configures `baseURL` as an object —
+ * which phoenix does on preview (`deriveAuthUrlConfig`) — so it is a fact about the running worker
+ * that no caller out here can observe. The server reads exactly one name and ignores the other.
+ */
+import {createHmac} from "node:crypto";
+import type {CaptureCookie} from "./capture.ts";
+
+export const SESSION_COOKIE_BASENAME = "better-auth.session_token";
+export const SECURE_COOKIE_PREFIX = "__Secure-";
+
+/** The signed cookie value better-auth would have written for this session token. */
+export const signSessionToken = (token: string, secret: string): string =>
+	encodeURIComponent(
+		`${token}.${createHmac("sha256", secret).update(token, "utf8").digest("base64")}`,
+	);
+
+/**
+ * The session cookies to seed for a preview base URL — the prefixed and unprefixed names, both
+ * carrying the same signed value.
+ */
+export const sessionCookies = (
+	previewUrl: string,
+	token: string,
+	secret: string,
+): readonly CaptureCookie[] => {
+	const value = signSessionToken(token, secret);
+	const secure = new URL(previewUrl).protocol === "https:";
+	const names = secure
+		? [SESSION_COOKIE_BASENAME, `${SECURE_COOKIE_PREFIX}${SESSION_COOKIE_BASENAME}`]
+		: [SESSION_COOKIE_BASENAME];
+	return names.map((name) => ({name, value, url: previewUrl, secure}));
+};
+
+/**
+ * The credentials an authenticated capture needs. Both or neither: a token with no secret cannot be
+ * signed, and a secret with no token names no session, so the pair is the only representable state.
+ */
+export interface CaptureIdentity {
+	readonly token: string;
+	readonly secret: string;
+}
+
+/**
+ * Read the identity from the environment. Returns `null` when neither is set (the anonymous
+ * capture, which is the default) and the name of the missing half when exactly one is — a half-set
+ * pair is a misconfiguration that would otherwise render anonymously and read as a clean default.
+ */
+export const readIdentity = (
+	env: Readonly<Record<string, string | undefined>>,
+): CaptureIdentity | null | {readonly missing: string} => {
+	const token = env.PREVIEW_TEST_SESSION_TOKEN ?? "";
+	const secret = env.BETTER_AUTH_SECRET ?? "";
+	if (token.length === 0 && secret.length === 0) return null;
+	if (token.length === 0) return {missing: "PREVIEW_TEST_SESSION_TOKEN"};
+	if (secret.length === 0) return {missing: "BETTER_AUTH_SECRET"};
+	return {token, secret};
+};

--- a/packages/fabrika-cli/src/capture/auth.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/auth.unit.test.ts
@@ -9,6 +9,7 @@ import {webcrypto} from "node:crypto";
 import {describe, expect, it} from "vitest";
 import {
 	readIdentity,
+	readSessionProof,
 	SECURE_COOKIE_PREFIX,
 	SESSION_COOKIE_BASENAME,
 	sessionCookies,
@@ -16,7 +17,7 @@ import {
 } from "./auth.ts";
 
 const SECRET = "a-preview-better-auth-secret";
-const TOKEN = "sO7mQ2wV5xR9tY1uI3oP6aS8dF0gH4jK";
+const TOKEN = "t".repeat(32);
 const PREVIEW = "https://phoenix-pr-42.kampusinfra.workers.dev";
 
 const verify = async (signed: string): Promise<boolean> => {
@@ -70,23 +71,64 @@ describe("sessionCookies", () => {
 });
 
 describe("readIdentity", () => {
-	it("reads no identity as the anonymous default", () => {
-		expect(readIdentity({})).toBeNull();
+	it("names both unset halves rather than reading as a complete anonymous default", () => {
+		expect(readIdentity({})).toEqual({
+			_tag: "Missing",
+			names: ["PREVIEW_TEST_SESSION_TOKEN", "BETTER_AUTH_SECRET"],
+		});
 	});
 
-	it("names the missing half rather than falling back to anonymous", () => {
+	it("names the one missing half", () => {
 		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN})).toEqual({
-			missing: "BETTER_AUTH_SECRET",
+			_tag: "Missing",
+			names: ["BETTER_AUTH_SECRET"],
 		});
 		expect(readIdentity({BETTER_AUTH_SECRET: SECRET})).toEqual({
-			missing: "PREVIEW_TEST_SESSION_TOKEN",
+			_tag: "Missing",
+			names: ["PREVIEW_TEST_SESSION_TOKEN"],
 		});
 	});
 
 	it("reads a complete pair", () => {
 		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN, BETTER_AUTH_SECRET: SECRET})).toEqual({
+			_tag: "Identity",
 			token: TOKEN,
 			secret: SECRET,
+		});
+	});
+});
+
+/**
+ * The probe's answers are better-auth's own, read at the `1.6.23` pin: `/get-session` returns a bare
+ * JSON `null` when the signed cookie does not resolve to a session, and `{session, user}` when it
+ * does. A body that is neither is UNKNOWN and must not read as anonymous — that collapse is the
+ * whole defect this proof exists to close.
+ */
+describe("readSessionProof", () => {
+	it("reads better-auth's null answer as anonymous", () => {
+		expect(readSessionProof(200, "null")).toEqual({_tag: "Anonymous"});
+	});
+
+	it("reads a session payload as signed in, naming the user", () => {
+		expect(readSessionProof(200, JSON.stringify({session: {id: "s1"}, user: {id: "u1"}}))).toEqual({
+			_tag: "SignedIn",
+			userId: "u1",
+		});
+	});
+
+	it("reads a non-200 as unreadable, never as anonymous", () => {
+		expect(readSessionProof(404, "null")._tag).toBe("Unreadable");
+		expect(readSessionProof(500, "")._tag).toBe("Unreadable");
+	});
+
+	it("reads an unparseable or user-less body as unreadable", () => {
+		expect(readSessionProof(200, "<!doctype html>")._tag).toBe("Unreadable");
+		expect(readSessionProof(200, JSON.stringify({user: {}}))._tag).toBe("Unreadable");
+	});
+
+	it("reads an explicitly null user as anonymous", () => {
+		expect(readSessionProof(200, JSON.stringify({session: null, user: null}))).toEqual({
+			_tag: "Anonymous",
 		});
 	});
 });

--- a/packages/fabrika-cli/src/capture/auth.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/auth.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The session cookie must satisfy better-auth's READER, not merely round-trip through this module.
+ * So the assertions below are better-call's own acceptance rules (`dist/context.mjs`
+ * `getSignedCookie`: split at the last `.`, signature exactly 44 chars ending in `=`, HMAC verified
+ * against the secret) and the verification runs through WebCrypto — a different implementation than
+ * the `node:crypto` one that signed it, so a self-consistent-but-wrong signature cannot pass.
+ */
+import {webcrypto} from "node:crypto";
+import {describe, expect, it} from "vitest";
+import {
+	readIdentity,
+	SECURE_COOKIE_PREFIX,
+	SESSION_COOKIE_BASENAME,
+	sessionCookies,
+	signSessionToken,
+} from "./auth.ts";
+
+const SECRET = "a-preview-better-auth-secret";
+const TOKEN = "sO7mQ2wV5xR9tY1uI3oP6aS8dF0gH4jK";
+const PREVIEW = "https://phoenix-pr-42.kampusinfra.workers.dev";
+
+const verify = async (signed: string): Promise<boolean> => {
+	const decoded = decodeURIComponent(signed);
+	const cut = decoded.lastIndexOf(".");
+	const value = decoded.slice(0, cut);
+	const signature = decoded.slice(cut + 1);
+	const bytes = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
+	const key = await webcrypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(SECRET),
+		{name: "HMAC", hash: "SHA-256"},
+		false,
+		["verify"],
+	);
+	return webcrypto.subtle.verify("HMAC", key, bytes, new TextEncoder().encode(value));
+};
+
+describe("signSessionToken", () => {
+	it("produces a value better-call's getSignedCookie accepts and verifies", async () => {
+		const signed = signSessionToken(TOKEN, SECRET);
+		const decoded = decodeURIComponent(signed);
+		const cut = decoded.lastIndexOf(".");
+		expect(decoded.slice(0, cut)).toBe(TOKEN);
+		expect(decoded.slice(cut + 1)).toHaveLength(44);
+		expect(decoded.slice(cut + 1).endsWith("=")).toBe(true);
+		expect(await verify(signed)).toBe(true);
+	});
+
+	it("does not verify under a different secret", async () => {
+		expect(await verify(signSessionToken(TOKEN, "some-other-secret"))).toBe(false);
+	});
+});
+
+describe("sessionCookies", () => {
+	it("seeds both the prefixed and unprefixed name on an https preview", () => {
+		const cookies = sessionCookies(PREVIEW, TOKEN, SECRET);
+		expect(cookies.map((c) => c.name)).toEqual([
+			SESSION_COOKIE_BASENAME,
+			`${SECURE_COOKIE_PREFIX}${SESSION_COOKIE_BASENAME}`,
+		]);
+		expect(cookies.every((c) => c.secure === true)).toBe(true);
+		expect(new Set(cookies.map((c) => c.value)).size).toBe(1);
+	});
+
+	it("omits the __Secure- name on http, where the browser would reject it", () => {
+		const cookies = sessionCookies("http://localhost:3000", TOKEN, SECRET);
+		expect(cookies.map((c) => c.name)).toEqual([SESSION_COOKIE_BASENAME]);
+		expect(cookies[0]?.secure).toBe(false);
+	});
+});
+
+describe("readIdentity", () => {
+	it("reads no identity as the anonymous default", () => {
+		expect(readIdentity({})).toBeNull();
+	});
+
+	it("names the missing half rather than falling back to anonymous", () => {
+		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN})).toEqual({
+			missing: "BETTER_AUTH_SECRET",
+		});
+		expect(readIdentity({BETTER_AUTH_SECRET: SECRET})).toEqual({
+			missing: "PREVIEW_TEST_SESSION_TOKEN",
+		});
+	});
+
+	it("reads a complete pair", () => {
+		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN, BETTER_AUTH_SECRET: SECRET})).toEqual({
+			token: TOKEN,
+			secret: SECRET,
+		});
+	});
+});

--- a/packages/fabrika-cli/src/capture/capture.ts
+++ b/packages/fabrika-cli/src/capture/capture.ts
@@ -57,6 +57,8 @@ export interface CaptureCookie {
 	readonly url?: string;
 	readonly domain?: string;
 	readonly path?: string;
+	/** Required for a `__Secure-`-prefixed name — Playwright rejects one set without it. */
+	readonly secure?: boolean;
 }
 
 export interface CaptureOptions {

--- a/packages/fabrika-cli/src/capture/capture.ts
+++ b/packages/fabrika-cli/src/capture/capture.ts
@@ -12,9 +12,10 @@
  */
 import {mkdir, writeFile} from "node:fs/promises";
 import {join} from "node:path";
-import {chromium} from "@playwright/test";
+import {type BrowserContext, chromium} from "@playwright/test";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {readSessionProof, type SessionProof} from "./auth.ts";
 import {type PageError, toPageError} from "./page-errors.ts";
 import type {Shot} from "./plan.ts";
 
@@ -38,6 +39,12 @@ export interface CapturedSurface {
 	 * proven outcome instead of inferring it from an image.
 	 */
 	readonly status?: number;
+	/**
+	 * Whether this context was signed in when the shot was taken, present only when the caller asked
+	 * for the proof. Pixels cannot answer it: a cookie that does not authenticate renders the
+	 * visitor's page, which is a valid PNG under the signed-in name (#7051).
+	 */
+	readonly sessionProof?: SessionProof;
 }
 
 /** A Playwright launch/navigation/screenshot/write failure — surfaced, never swallowed. */
@@ -72,7 +79,31 @@ export interface CaptureOptions {
 	 * flag-gated surfaces render under `alchemy dev` (#2963). Absent ⇒ no cookies.
 	 */
 	readonly cookies?: readonly CaptureCookie[];
+	/**
+	 * Absolute URL of the session probe to hit from each shot's context after the cookies are seeded
+	 * and before it navigates. Absent ⇒ no proof is taken and `sessionProof` stays absent.
+	 */
+	readonly sessionProbeUrl?: string;
 }
+
+/**
+ * Ask the preview whether this context is signed in. The request goes through the context's own
+ * `request` fixture, which carries its cookie jar — a bare `fetch` would carry nothing and answer
+ * anonymous for every context alike.
+ */
+const proveSession = (context: BrowserContext, probeUrl: string): Promise<SessionProof> =>
+	context.request
+		.get(probeUrl)
+		.then(async (response) => readSessionProof(response.status(), await response.text()))
+		// Total on purpose, and not the enclosing `tryPromise`'s job: a rejected probe is a fact about
+		// the PROBE, and letting it throw would classify the surface `Unreachable` — an accusation
+		// against a page that may render perfectly well.
+		.catch(
+			(cause): SessionProof => ({
+				_tag: "Unreadable",
+				reason: `session probe failed: ${String(cause)}`,
+			}),
+		);
 
 /**
  * Launch one chromium instance, shoot every plan entry serially (each in its own
@@ -113,6 +144,12 @@ export const captureShots = (
 							if (options.cookies && options.cookies.length > 0) {
 								await context.addCookies(options.cookies);
 							}
+							// The proof runs on the same context the shot is taken from, so what it
+							// answers about is the seeded cookie and not a second, luckier one.
+							const sessionProof =
+								options.sessionProbeUrl === undefined
+									? undefined
+									: await proveSession(context, options.sessionProbeUrl);
 							const page = await context.newPage();
 							// Listen across the WHOLE navigation window (attached before goto), so a
 							// runtime error thrown during mount/init is caught even when the frame
@@ -148,6 +185,7 @@ export const captureShots = (
 									pngBytes: new Uint8Array(buffer),
 									pageErrors,
 									...(response === null ? {} : {status: response.status()}),
+									...(sessionProof === undefined ? {} : {sessionProof}),
 								};
 							} finally {
 								await context.close();

--- a/packages/fabrika-cli/src/capture/plan.ts
+++ b/packages/fabrika-cli/src/capture/plan.ts
@@ -6,24 +6,28 @@
  * `capture.ts` drives Playwright over the plan this produces.
  *
  * One record per surface (the contract #2246 codes against), NOT a viewport
- * cross-product: a surface is a route + an optional state variant
- * (`empty`, `focus-visible`, …), captured at a single viewport.
+ * cross-product: a surface is a route + an optional state variant, captured at a
+ * single viewport.
+ *
+ * The grammar here parses ANY state token; which ones a capture can actually put
+ * on screen is `states.ts`'s closed list (`auth` today), and `review-ui render`
+ * refuses the rest on `10`. Parsing a state is not rendering one.
  */
 
 /** A changed UI surface to shoot: a route + an optional state variant. */
 export interface Surface {
-	/** The raw `--surface` token (`/sozluk` or `/sozluk:empty`) — a stable id. */
+	/** The raw `--surface` token (`/sozluk` or `/sozluk:auth`) — a stable id. */
 	readonly surface: string;
 	/** The route/path on the preview deploy, e.g. `/sozluk`. */
 	readonly route: string;
-	/** The state variant (`empty`, `focus-visible`, …) or `null` for the default render. */
+	/** The state variant this token names, or `null` for the default render. */
 	readonly state: string | null;
 }
 
 /**
  * Parse a `--surface "<route>[:state]"` token into a {@link Surface}. The first
  * colon splits route from state (a route is a URL path and carries no colon), so
- * `/sozluk:empty` → route `/sozluk`, state `empty`; `/sozluk` → state `null`.
+ * `/sozluk:auth` → route `/sozluk`, state `auth`; `/sozluk` → state `null`.
  */
 export const parseSurfaceSpec = (token: string): Surface => {
 	if (token.length === 0) {

--- a/packages/fabrika-cli/src/capture/states.ts
+++ b/packages/fabrika-cli/src/capture/states.ts
@@ -9,9 +9,11 @@
  * differently, and every other token stays refused as reserved grammar.
  *
  * `auth` is the first: the capture context presents the moderator-tier test account's session
- * cookie (`auth.ts`), so the surface renders as a signed-in yazar+moderator instead of a visitor.
- * The account is provisioned direct-D1 by `preview-seed test-account`, never by a worker route.
+ * cookie (`auth.ts`) and proves the session took before the shot is recorded, so the surface renders
+ * as a signed-in yazar+moderator instead of a visitor. The account is provisioned direct-D1 by
+ * `preview-seed test-account`, never by a worker route.
  */
+import {parseSurfaceSpec} from "./plan.ts";
 
 export const REALIZED_STATES = ["auth"] as const;
 export type RealizedState = (typeof REALIZED_STATES)[number];
@@ -19,10 +21,25 @@ export type RealizedState = (typeof REALIZED_STATES)[number];
 export const isRealizedState = (state: string): state is RealizedState =>
 	(REALIZED_STATES as readonly string[]).includes(state);
 
-/** The state a surface token names, or `null` for the default (anonymous, visitor) render. */
+/**
+ * Whether a state's mechanism is the seeded session, so its shot owes a proof the session took.
+ * `auth` is the whole of it today; a future state realized some other way owes a different proof,
+ * not this one.
+ */
+export const provesSession = (state: string | null): boolean => state === "auth";
+
+/**
+ * The state a surface token names, or `null` for the default (anonymous, visitor) render. Read
+ * through `parseSurfaceSpec` rather than re-split here: one grammar, one parser.
+ *
+ * A token the grammar rejects outright (empty, or route-less) names no state — `buildCapturePlan`
+ * refuses it by its own message, and answering `null` here keeps that refusal the one the caller
+ * reads instead of a thrown defect from the state check that runs first.
+ */
 export const stateOf = (surface: string): string | null => {
-	const colon = surface.indexOf(":");
-	if (colon === -1) return null;
-	const state = surface.slice(colon + 1);
-	return state.length === 0 ? null : state;
+	try {
+		return parseSurfaceSpec(surface).state;
+	} catch {
+		return null;
+	}
 };

--- a/packages/fabrika-cli/src/capture/states.ts
+++ b/packages/fabrika-cli/src/capture/states.ts
@@ -1,0 +1,28 @@
+/**
+ * The closed vocabulary of `<route>:<state>` variants a capture can actually put on screen, and the
+ * mechanism each one carries (#7051).
+ *
+ * The list is short on purpose. `plan.ts` has always parsed a state off a surface token, but
+ * parsing one is not rendering one: a state with no mechanism captures the default pixels under a
+ * variant's file name, which is coverage claimed and not held — the exact defect this ticket was
+ * filed about. So a state enters this list only once something here makes the page render
+ * differently, and every other token stays refused as reserved grammar.
+ *
+ * `auth` is the first: the capture context presents the moderator-tier test account's session
+ * cookie (`auth.ts`), so the surface renders as a signed-in yazar+moderator instead of a visitor.
+ * The account is provisioned direct-D1 by `preview-seed test-account`, never by a worker route.
+ */
+
+export const REALIZED_STATES = ["auth"] as const;
+export type RealizedState = (typeof REALIZED_STATES)[number];
+
+export const isRealizedState = (state: string): state is RealizedState =>
+	(REALIZED_STATES as readonly string[]).includes(state);
+
+/** The state a surface token names, or `null` for the default (anonymous, visitor) render. */
+export const stateOf = (surface: string): string | null => {
+	const colon = surface.indexOf(":");
+	if (colon === -1) return null;
+	const state = surface.slice(colon + 1);
+	return state.length === 0 ? null : state;
+};

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -55,7 +55,7 @@ const render = leafCommand(
 		surface: Flag.string("surface").pipe(
 			Flag.atLeast(1),
 			Flag.withDescription(
-				"a surface id to capture — a bare route such as /pano; repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
+				"a surface id to capture — a route such as /pano, or /pano:auth for the signed-in render; repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
 			),
 		),
 		app: Flag.string("app").pipe(
@@ -83,7 +83,7 @@ const render = leafCommand(
 ).pipe(
 	Command.withShortDescription("Capture the named surfaces from a PR's preview deployment."),
 	Command.withDescription(
-		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface carries the reserved :state suffix), 11 (a read failed, the preview comment is malformed or names several apps, or a capture's validity is undeterminable), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
+		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface names a :state nothing renders — the realized set is auth), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, or an :auth surface was requested with PREVIEW_TEST_SESSION_TOKEN/BETTER_AUTH_SECRET unset), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
 	),
 );
 

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -55,7 +55,7 @@ const render = leafCommand(
 		surface: Flag.string("surface").pipe(
 			Flag.atLeast(1),
 			Flag.withDescription(
-				"a surface id to capture — a route such as /pano, or /pano:auth for the signed-in render; repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
+				"a surface id to capture — a route such as /pano, or /pano:auth for the signed-in render (proved against the preview's session endpoint before the shot is recorded); repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
 			),
 		),
 		app: Flag.string("app").pipe(
@@ -83,7 +83,7 @@ const render = leafCommand(
 ).pipe(
 	Command.withShortDescription("Capture the named surfaces from a PR's preview deployment."),
 	Command.withDescription(
-		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface names a :state nothing renders — the realized set is auth), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, or an :auth surface was requested with PREVIEW_TEST_SESSION_TOKEN/BETTER_AUTH_SECRET unset), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
+		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface names a :state nothing renders — the realized set is auth), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, an :auth surface was requested with PREVIEW_TEST_SESSION_TOKEN/BETTER_AUTH_SECRET unset, or an :auth surface's session proof did not come back signed in), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
 	),
 );
 

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -59,7 +59,7 @@ export const makeCaptureRenderLeg =
 				return {_tag: "Failed", reason: plan} satisfies SurfaceRender;
 			}
 
-			const captured = yield* capture(plan, request.outDir).pipe(
+			const captured = yield* capture(plan, request.outDir, {cookies: request.cookies}).pipe(
 				Effect.catch((error) => Effect.succeed(error.message)),
 			);
 			if (typeof captured === "string") {

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -13,10 +13,17 @@
  * unenumerated — the "judged nothing, found nothing wrong" shape (#3925) in a different disguise.
  */
 import {Effect} from "effect";
+import {SESSION_PROBE_PATH} from "../capture/auth.ts";
 import {captureShots} from "../capture/capture.ts";
 import {isRenderCrash} from "../capture/page-errors.ts";
-import {buildCapturePlan, DEFAULT_VIEWPORT, parseSurfaceSpec} from "../capture/plan.ts";
+import {
+	buildCapturePlan,
+	DEFAULT_VIEWPORT,
+	joinPreviewUrl,
+	parseSurfaceSpec,
+} from "../capture/plan.ts";
 import {validateCaptureBytes} from "../capture/png.ts";
+import {provesSession} from "../capture/states.ts";
 import {capAndCount} from "../evidence.ts";
 import {PAGE_ERROR_CAP, sha256Hex} from "./manifest.ts";
 import type {RenderLeg, SurfaceRender} from "./render-verb.ts";
@@ -59,9 +66,15 @@ export const makeCaptureRenderLeg =
 				return {_tag: "Failed", reason: plan} satisfies SurfaceRender;
 			}
 
-			const captured = yield* capture(plan, request.outDir, {cookies: request.cookies}).pipe(
-				Effect.catch((error) => Effect.succeed(error.message)),
-			);
+			// A seeded session is asked to prove itself, because pixels cannot: a cookie that does not
+			// authenticate renders the visitor's page, and that is a valid PNG under the `:auth` name.
+			const probing = provesSession(plan[0]?.surface.state ?? null);
+			const captured = yield* capture(plan, request.outDir, {
+				cookies: request.cookies,
+				...(probing
+					? {sessionProbeUrl: joinPreviewUrl(request.previewUrl, SESSION_PROBE_PATH)}
+					: {}),
+			}).pipe(Effect.catch((error) => Effect.succeed(error.message)));
 			if (typeof captured === "string") {
 				return captured.startsWith(NAVIGATION_FAILURE_PREFIX)
 					? ({_tag: "Unreachable", reason: captured} satisfies SurfaceRender)
@@ -76,6 +89,22 @@ export const makeCaptureRenderLeg =
 			}
 			if (shot.status !== undefined && shot.status >= UNREACHABLE_FLOOR) {
 				return {_tag: "Unreachable", reason: `status ${shot.status}`} satisfies SurfaceRender;
+			}
+			// Classified before the bytes: an anonymous shot under a signed-in name is a valid PNG of
+			// the wrong page, so validating it first would answer a question nobody asked.
+			if (probing) {
+				const proof = shot.sessionProof;
+				if (proof === undefined || proof._tag !== "SignedIn") {
+					return {
+						_tag: "Unauthenticated",
+						reason:
+							proof === undefined
+								? "the capture returned no session proof"
+								: proof._tag === "Anonymous"
+									? "the preview answered the seeded cookie as a visitor"
+									: proof.reason,
+					} satisfies SurfaceRender;
+				}
 			}
 			const crash = shot.pageErrors.find(isRenderCrash);
 			if (crash !== undefined) {

--- a/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
@@ -7,7 +7,7 @@ import type {SurfaceRender} from "./render-verb.ts";
 
 const PREVIEW = "https://pr-4321-web.example.test";
 
-const request = {surface: "/pano", previewUrl: PREVIEW, outDir: "/tmp/shots"};
+const request = {surface: "/pano", previewUrl: PREVIEW, outDir: "/tmp/shots", cookies: []};
 
 const failing =
 	(message: string): CaptureShots =>

--- a/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
@@ -43,6 +43,29 @@ const succeeding =
 const run = (capture: CaptureShots): SurfaceRender =>
 	Effect.runSync(makeCaptureRenderLeg(capture)(request));
 
+const authRequest = {...request, surface: "/pano:auth", cookies: []};
+
+/** A shot for the `:auth` request, so its `state` matches what the leg planned. */
+const authShot =
+	(shot: Partial<CapturedSurface>): CaptureShots =>
+	() =>
+		Effect.succeed([
+			{
+				surface: "/pano:auth",
+				route: "/pano",
+				state: "auth",
+				localPath: "/tmp/shots/pano-auth.png",
+				fileName: "pano-auth.png",
+				pngBytes: pngHeader(),
+				pageErrors: [],
+				status: 200,
+				...shot,
+			},
+		]);
+
+const runAuth = (capture: CaptureShots): SurfaceRender =>
+	Effect.runSync(makeCaptureRenderLeg(capture)(authRequest));
+
 describe("captureRenderLeg", () => {
 	// The wiring, not the seam: render-verb's own test INJECTS a `Failed` value, so it passes even
 	// when the only code that could produce one never does. These drive the real classification with
@@ -89,5 +112,44 @@ describe("captureRenderLeg", () => {
 			_tag: "Rendered",
 			entry: {pageErrors: {rows: one, more: 0}},
 		});
+	});
+});
+
+/**
+ * The bytes cannot answer this: an anonymous render of `/pano` is a valid PNG whichever name it is
+ * filed under, so every arm below decodes fine and the classification is the only thing separating a
+ * signed-in capture from the visitor's (#7051).
+ */
+describe("captureRenderLeg — the :auth session proof", () => {
+	it("asks for the proof on an :auth surface and for nothing on a bare route", () => {
+		const asked: Array<string | undefined> = [];
+		const spy: CaptureShots = (_plan, _outDir, options) => {
+			asked.push(options?.sessionProbeUrl);
+			return authShot({sessionProof: {_tag: "SignedIn", userId: "u1"}})([], "", {});
+		};
+		runAuth(spy);
+		run(spy);
+		expect(asked[0]).toBe(`${PREVIEW}/api/auth/get-session`);
+		expect(asked[1]).toBeUndefined();
+	});
+
+	it("records the shot only when the proof came back signed in", () => {
+		expect(runAuth(authShot({sessionProof: {_tag: "SignedIn", userId: "u1"}}))._tag).toBe(
+			"Rendered",
+		);
+	});
+
+	it("refuses a visitor's render under the :auth name", () => {
+		expect(runAuth(authShot({sessionProof: {_tag: "Anonymous"}}))).toEqual({
+			_tag: "Unauthenticated",
+			reason: "the preview answered the seeded cookie as a visitor",
+		});
+	});
+
+	it("refuses an unreadable probe too — a proof nobody could read is not a proof", () => {
+		expect(
+			runAuth(authShot({sessionProof: {_tag: "Unreadable", reason: "probe answered 502"}})),
+		).toEqual({_tag: "Unauthenticated", reason: "probe answered 502"});
+		expect(runAuth(authShot({}))._tag).toBe("Unauthenticated");
 	});
 });

--- a/packages/fabrika-cli/src/review-ui/render-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.ts
@@ -10,9 +10,17 @@
  *
  * The renderer is an injected seam ({@link RenderLeg}) so every refusal below is testable without a
  * browser; `render-leg.ts` is the one that drives the capture machinery.
+ *
+ * A surface may name a state (`/pano:auth`), but only one this repo can actually put on screen —
+ * the vocabulary and its mechanism live in `capture/states.ts`. Anything else is refused rather
+ * than shot, because a state nothing renders captures the default pixels under a variant's name,
+ * which is coverage claimed and not held (#7051).
  */
 import {Effect, type FileSystem, type Path, Result} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readIdentity, sessionCookies} from "../capture/auth.ts";
+import type {CaptureCookie} from "../capture/capture.ts";
+import {isRealizedState, REALIZED_STATES, stateOf} from "../capture/states.ts";
 import {writeFile} from "../io/fs.ts";
 import {listComments} from "../io/issues.ts";
 import {openPull, resolveTargetRepo, scannedLine} from "../review/target.ts";
@@ -40,10 +48,12 @@ const VERB = "review-ui render";
 
 /** What one surface's render is asked for: the preview it hangs off, and where its PNG belongs. */
 export interface SurfaceRenderRequest {
-	/** The surface id — a bare route, since `:state` is refused upstream. */
+	/** The surface id — `<route>` or `<route>:<state>`. */
 	readonly surface: string;
 	readonly previewUrl: string;
 	readonly outDir: string;
+	/** Seeded into the capture context before navigation. Empty ⇒ the anonymous render. */
+	readonly cookies: readonly CaptureCookie[];
 }
 
 /**
@@ -138,11 +148,16 @@ export const runRender = (
 				`${VERB}: --out "${options.out}" is not a kebab-case set name.`,
 			);
 		}
-		const stateful = options.surfaces.find((surface) => surface.includes(":"));
-		if (stateful !== undefined) {
+		// A state is admitted only when something puts it on screen. Parsing one and shooting the
+		// default pixels under a variant's name is coverage claimed and not held (#7051).
+		const unrealized = options.surfaces.find((surface) => {
+			const state = stateOf(surface);
+			return state !== null && !isRealizedState(state);
+		});
+		if (unrealized !== undefined) {
 			return refuse(
 				OFF_VOCABULARY,
-				`${VERB}: --surface "${stateful}" carries a :state suffix — states are a reserved grammar, not yet realized; render the bare route.`,
+				`${VERB}: --surface "${unrealized}" names a :state nothing renders — the realized states are ${REALIZED_STATES.join(", ")}; render the bare route.`,
 			);
 		}
 
@@ -198,10 +213,45 @@ export const runRender = (
 			);
 		}
 
+		// An `:auth` surface rendered without credentials would come back as the visitor's page under
+		// the signed-in name — the "unseen ground reading as clean" this whole axis exists to stop —
+		// so a missing half of the pair is UNKNOWN here, before a browser launches.
+		const wantsAuth = options.surfaces.some((surface) => stateOf(surface) === "auth");
+		const identity = readIdentity(options.env);
+		if (wantsAuth) {
+			if (identity === null) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: an :auth surface was requested but neither PREVIEW_TEST_SESSION_TOKEN nor BETTER_AUTH_SECRET is set — the authenticated render is UNKNOWN, never the anonymous one.`,
+					[scanned],
+				);
+			}
+			if ("missing" in identity) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: an :auth surface was requested but ${identity.missing} is unset — the authenticated render is UNKNOWN, never the anonymous one.`,
+					[scanned],
+				);
+			}
+		}
+		const authCookies: readonly CaptureCookie[] =
+			identity !== null && !("missing" in identity)
+				? sessionCookies(announced.url, identity.token, identity.secret)
+				: [];
+
 		const setDir = setDirectory(options.tmpRoot, pr, head, options.out);
 		const renders: SurfaceRender[] = [];
 		for (const surface of options.surfaces) {
-			renders.push(yield* options.render({surface, previewUrl: announced.url, outDir: setDir}));
+			renders.push(
+				yield* options.render({
+					surface,
+					previewUrl: announced.url,
+					outDir: setDir,
+					// Only the `:auth` variant carries the session; a bare route stays the visitor's
+					// render, so the two are genuinely different pixels rather than one shot twice.
+					cookies: stateOf(surface) === "auth" ? authCookies : [],
+				}),
+			);
 		}
 		const enumerated = [
 			scanned,

--- a/packages/fabrika-cli/src/review-ui/render-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.ts
@@ -14,13 +14,16 @@
  * A surface may name a state (`/pano:auth`), but only one this repo can actually put on screen —
  * the vocabulary and its mechanism live in `capture/states.ts`. Anything else is refused rather
  * than shot, because a state nothing renders captures the default pixels under a variant's name,
- * which is coverage claimed and not held (#7051).
+ * which is coverage claimed and not held (#7051). An `:auth` surface is refused twice over: on `11`
+ * before a browser launches when the credentials are incomplete, and on `11` again when the shot's
+ * own session proof does not come back signed in — a cookie that failed to authenticate produces a
+ * perfectly valid PNG of the visitor's page, which no byte check can tell from the real thing.
  */
 import {Effect, type FileSystem, type Path, Result} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {readIdentity, sessionCookies} from "../capture/auth.ts";
 import type {CaptureCookie} from "../capture/capture.ts";
-import {isRealizedState, REALIZED_STATES, stateOf} from "../capture/states.ts";
+import {isRealizedState, provesSession, REALIZED_STATES, stateOf} from "../capture/states.ts";
 import {writeFile} from "../io/fs.ts";
 import {listComments} from "../io/issues.ts";
 import {openPull, resolveTargetRepo, scannedLine} from "../review/target.ts";
@@ -57,14 +60,16 @@ export interface SurfaceRenderRequest {
 }
 
 /**
- * One surface's proven outcome. Four arms, never three: an execution that never became answerable
- * (`Failed`) is UNKNOWN and must not read as a surface that rendered badly.
+ * One surface's proven outcome. An execution that never became answerable (`Failed`) is UNKNOWN and
+ * must not read as a surface that rendered badly; `Unauthenticated` is UNKNOWN for the same reason,
+ * one layer up — the page rendered fine, it is just not the page that was asked for.
  */
 export type SurfaceRender =
 	| {readonly _tag: "Rendered"; readonly entry: CaptureEntry}
 	| {readonly _tag: "Unreachable"; readonly reason: string}
 	| {readonly _tag: "Crashed"; readonly firstError: string}
 	| {readonly _tag: "Invalid"; readonly detail: string}
+	| {readonly _tag: "Unauthenticated"; readonly reason: string}
 	| {readonly _tag: "Failed"; readonly reason: string};
 
 export type RenderLeg = (request: SurfaceRenderRequest) => Effect.Effect<SurfaceRender>;
@@ -119,6 +124,8 @@ const outcomeLine = (surface: string, render: SurfaceRender): string => {
 			return `${VERB}: surface "${surface}" threw during render: ${render.firstError} — the render is red; a broken page is not composition to judge.`;
 		case "Invalid":
 			return `${VERB}: surface "${surface}" captured invalid bytes (${render.detail}) — a capture nobody can open is not evidence (#3925's class).`;
+		case "Unauthenticated":
+			return `${VERB}: surface "${surface}" did not render signed in (${render.reason}) — the authenticated render is UNKNOWN, never the anonymous one.`;
 		case "Failed":
 			return `${VERB}: surface "${surface}" could not be rendered: ${render.reason} — the outcome is UNKNOWN.`;
 	}
@@ -215,27 +222,18 @@ export const runRender = (
 
 		// An `:auth` surface rendered without credentials would come back as the visitor's page under
 		// the signed-in name — the "unseen ground reading as clean" this whole axis exists to stop —
-		// so a missing half of the pair is UNKNOWN here, before a browser launches.
-		const wantsAuth = options.surfaces.some((surface) => stateOf(surface) === "auth");
+		// so an incomplete pair is UNKNOWN here, before a browser launches.
+		const wantsAuth = options.surfaces.some((surface) => provesSession(stateOf(surface)));
 		const identity = readIdentity(options.env);
-		if (wantsAuth) {
-			if (identity === null) {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: an :auth surface was requested but neither PREVIEW_TEST_SESSION_TOKEN nor BETTER_AUTH_SECRET is set — the authenticated render is UNKNOWN, never the anonymous one.`,
-					[scanned],
-				);
-			}
-			if ("missing" in identity) {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: an :auth surface was requested but ${identity.missing} is unset — the authenticated render is UNKNOWN, never the anonymous one.`,
-					[scanned],
-				);
-			}
+		if (wantsAuth && identity._tag === "Missing") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: an :auth surface was requested but its credentials are incomplete (unset: ${identity.names.join(", ")}) — the authenticated render is UNKNOWN, never the anonymous one.`,
+				[scanned],
+			);
 		}
 		const authCookies: readonly CaptureCookie[] =
-			identity !== null && !("missing" in identity)
+			identity._tag === "Identity"
 				? sessionCookies(announced.url, identity.token, identity.secret)
 				: [];
 
@@ -249,7 +247,7 @@ export const runRender = (
 					outDir: setDir,
 					// Only the `:auth` variant carries the session; a bare route stays the visitor's
 					// render, so the two are genuinely different pixels rather than one shot twice.
-					cookies: stateOf(surface) === "auth" ? authCookies : [],
+					cookies: provesSession(stateOf(surface)) ? authCookies : [],
 				}),
 			);
 		}
@@ -263,6 +261,16 @@ export const runRender = (
 			return refuse(
 				PRECONDITION_UNKNOWN,
 				`${VERB}: cannot read a capture's validity for #${pr}: ${failed.reason} — the render is UNKNOWN.`,
+				enumerated,
+			);
+		}
+		// Ahead of the proven-red codes below, and deliberately: the shot is a fine PNG of the wrong
+		// page, so routing it as a red surface would accuse the PR of a defect the render never saw.
+		const anonymous = renders.findIndex((render) => render._tag === "Unauthenticated");
+		if (anonymous !== -1) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				outcomeLine(options.surfaces[anonymous] as string, renders[anonymous] as SurfaceRender),
 				enumerated,
 			);
 		}

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -179,6 +179,47 @@ describe("runRender", () => {
 		expect(seen.get("/pano:auth")).toBe(2);
 	});
 
+	// The credential check only proves the pair was SET. Whether the cookie actually authenticated is
+	// the shot's own answer, and a shot that came back a visitor's is UNKNOWN — never a red surface,
+	// because the page rendered fine, and never a Rendered entry under the `:auth` id (#7051).
+	it("refuses an :auth shot that did not render signed in on 11, recording no capture", async () => {
+		const {outcome, written} = await run(happy(), {
+			surfaces: ["/pano:auth"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: legOf({
+				"/pano:auth": {
+					_tag: "Unauthenticated",
+					reason: "the preview answered the seeded cookie as a visitor",
+				},
+			}),
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(written.size).toBe(0);
+		expect(outcome.stderr.at(-1)).toMatch(/did not render signed in/);
+	});
+
+	// Routed ahead of the proven-red codes: a fine PNG of the wrong page is not a defect in the PR.
+	it("routes an unauthenticated surface as UNKNOWN even beside a crashed one", async () => {
+		const {outcome} = await run(happy(), {
+			surfaces: ["/a:auth", "/b"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: legOf({
+				"/a:auth": {_tag: "Unauthenticated", reason: "probe answered 500"},
+				"/b": {_tag: "Crashed", firstError: "TypeError: x is null"},
+			}),
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
 	it("refuses a closed PR on 7 — a closed PR is provably not reviewable scope", async () => {
 		const {outcome} = await run([
 			[PULL, pull("closed")],

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -141,9 +141,42 @@ describe("runRender", () => {
 		expect(outcome.code).toBe(1);
 	});
 
-	it("refuses a non-kebab --out and a reserved :state suffix on 10", async () => {
+	it("refuses a non-kebab --out and an unrealized :state suffix on 10", async () => {
 		expect((await run(happy(), {out: "Judged"})).outcome.code).toBe(OFF_VOCABULARY);
 		expect((await run(happy(), {surfaces: ["/pano:empty"]})).outcome.code).toBe(OFF_VOCABULARY);
+	});
+
+	// An `:auth` surface rendered anonymously is the "unseen ground reading as clean" defect
+	// (#7051), so a half-set or absent credential pair is UNKNOWN rather than a visitor's shot.
+	it("refuses an :auth surface with no credentials on 11, never the anonymous render", async () => {
+		expect((await run(happy(), {surfaces: ["/pano:auth"]})).outcome.code).toBe(
+			PRECONDITION_UNKNOWN,
+		);
+		const halfSet = await run(happy(), {
+			surfaces: ["/pano:auth"],
+			env: {CLAUDE_PIPELINE_REPO: "o/r", PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32)},
+		});
+		expect(halfSet.outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(halfSet.outcome.stderr.join("\n")).toContain("BETTER_AUTH_SECRET");
+	});
+
+	it("seeds the session cookie onto the :auth surface only, so the default stays the visitor's", async () => {
+		const seen = new Map<string, number>();
+		const {outcome} = await run(happy(), {
+			surfaces: ["/pano", "/pano:auth"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: (request) => {
+				seen.set(request.surface, request.cookies.length);
+				return Effect.succeed(rendered(request.surface, request.outDir));
+			},
+		});
+		expect(outcome.code).toBe(0);
+		expect(seen.get("/pano")).toBe(0);
+		expect(seen.get("/pano:auth")).toBe(2);
 	});
 
 	it("refuses a closed PR on 7 — a closed PR is provably not reviewable scope", async () => {

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -35,7 +35,8 @@ A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
   of the canonical `apps/web/worker/db/drizzle/migrations` columns).
 - `src/seed.ts` — idempotent upserts; runs against any `D1Database` (in-memory
   test fake or REST adapter) and also emits `{sql, params}` for the REST batch.
-- `src/bin.ts` — the `preview-seed run` CLI.
+- `src/test-account.ts` — the review-ui test account + its session row.
+- `src/bin.ts` — the `preview-seed run` and `preview-seed test-account` CLI.
 
 ## Running it
 
@@ -55,3 +56,50 @@ node packages/preview-seed/src/bin.ts run --database-id <stage-d1-uuid>
 Transport is the Cloudflare D1 REST query API via alchemy's already-installed
 `@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
 migrations to a deployed D1, so no new Cloudflare dependency and no workerd.
+
+## The review-ui test account
+
+`review-ui render` judges what renders, and until now that could only be the
+anonymous view: a per-PR preview deploys an empty D1, so nothing behind login
+existed to shoot and a UI delta that only appears signed in ended a review as
+unseen ground reading clean (issue #7051). This verb provisions the one account
+that render authenticates as.
+
+```bash
+PREVIEW_TEST_SESSION_TOKEN=<32+ char secret> \
+  node packages/preview-seed/src/bin.ts test-account --database-id <preview-d1-uuid>
+```
+
+It writes three rows in one atomic D1 `batch` — the `user` row at
+`moderator` + `yazar`, its `session` row carrying the supplied token, and the
+`(id, "moderates", "platform:platform")` tuple that is the real moderation
+authority (ADR 0107 §4; `user.role` is vestigial and written only so a coarse
+read agrees). Re-running it upserts the same rows, so the token can be rotated by
+re-running with a new one.
+
+`review-ui render --surface /pano:auth` then signs that same token with
+`$BETTER_AUTH_SECRET` and seeds it as the better-auth session cookie, so the
+capture browser is the signed-in moderator.
+
+### The guard boundary — load-bearing
+
+**Direct-D1, never a runtime route.** Same rule as `run` above and for the same
+reason: the `ENVIRONMENT`-gated `/api/admin/*` seeder routes were deleted as a
+fail-open security hole (CLAUDE.md, "Sözlük seed"). Nothing in this path may be
+rebuilt as a worker endpoint — an account-minting route on the public worker is
+strictly worse than the seeder routes that were removed.
+
+**Throwaway stages and previews only, and the fence is not the caller's word for
+it.** A caller-asserted "this is a preview" proves nothing, so the verb reads the
+target instead: a preview/stage D1 deploys empty and this package's content
+fixtures denormalize their author, so a throwaway carries **no human `user` row at
+all**. Finding one that is not the test identity, the verb refuses and writes
+nothing — that database is somebody's real world. Point it at a freshly deployed
+preview D1 instead; there is no override flag, and adding one would be adding the
+hole back.
+
+**The token is a live moderator credential.** It is read only from
+`$PREVIEW_TEST_SESSION_TOKEN` (never a flag, so it stays out of process listings),
+must be at least 32 characters, and is refused if it carries whitespace, `;` or
+`,`. Treat it like any other CI secret: scope it to preview, rotate it by
+re-running the verb.

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -77,9 +77,12 @@ authority (ADR 0107 §4; `user.role` is vestigial and written only so a coarse
 read agrees). Re-running it upserts the same rows, so the token can be rotated by
 re-running with a new one.
 
-`review-ui render --surface /pano:auth` then signs that same token with
-`$BETTER_AUTH_SECRET` and seeds it as the better-auth session cookie, so the
-capture browser is the signed-in moderator.
+`review-ui render --surface /pano:auth` then signs that same token with the
+preview worker's `$BETTER_AUTH_SECRET` and seeds it as the better-auth session
+cookie. Before it records the shot it asks the preview's own
+`/api/auth/get-session` from that same browser context and requires a user back,
+so a token that is wrong, expired or missing from this D1 refuses the render as
+UNKNOWN instead of filing the visitor's pixels under the `:auth` name.
 
 ### The guard boundary — load-bearing
 
@@ -94,9 +97,17 @@ it.** A caller-asserted "this is a preview" proves nothing, so the verb reads th
 target instead: a preview/stage D1 deploys empty and this package's content
 fixtures denormalize their author, so a throwaway carries **no human `user` row at
 all**. Finding one that is not the test identity, the verb refuses and writes
-nothing — that database is somebody's real world. Point it at a freshly deployed
-preview D1 instead; there is no override flag, and adding one would be adding the
-hole back.
+nothing — that database is somebody's real world.
+
+Say the reach exactly, because the argument against an override flag rests on it.
+The check is *no human `user` row other than the test identity*. It catches any
+database anyone has ever signed into, which is every real one in practice. It does
+**not** catch an empty database that is not a throwaway — a fresh apex deploy
+before the first sign-up, a wiped stage, a mistyped `--database-id` that resolves
+to a real-but-unpopulated D1 all pass it. The operator still owns which
+`--database-id` they pass. What the fence removes is the failure that actually
+happens: pointing at a live database and minting a moderator in it. There is no
+override flag, and adding one would be adding back the hole the check closes.
 
 **The token is a live moderator credential.** It is read only from
 `$PREVIEW_TEST_SESSION_TOKEN` (never a flag, so it stays out of process listings),

--- a/packages/preview-seed/package.json
+++ b/packages/preview-seed/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/platform-node": "catalog:",
+		"@kampus/authz": "workspace:*",
 		"@kampus/d1-rest": "workspace:*",
 		"@kampus/db-schema": "workspace:*",
 		"@kampus/web": "workspace:*",

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -1,15 +1,23 @@
 /**
- * `preview-seed run` — seeds a deployed stage's D1 with the fixtures the unauthenticated
- * read e2e specs sample. It talks to D1 over the REST query API, never a worker route:
- * the admin seeder routes were deleted as a fail-open hole (CLAUDE.md, "Sözlük seed").
+ * `preview-seed run` seeds a deployed stage's D1 with the fixtures the unauthenticated read e2e
+ * specs sample; `preview-seed test-account` provisions the moderator-tier account an authenticated
+ * `review-ui` capture renders as (#7051). Both talk to D1 over the REST query API, never a worker
+ * route: the admin seeder routes were deleted as a fail-open hole (CLAUDE.md, "Sözlük seed").
  */
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {makeD1Rest} from "@kampus/d1-rest";
-import {Config, Console, Effect, Layer, Option, Schema} from "effect";
+import {Config, Console, Effect, Layer, Option, Redacted, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {seed} from "./seed.ts";
+import {
+	MIN_SESSION_TOKEN_LEN,
+	makeTestAccountDb,
+	parseSessionToken,
+	provisionTestAccount,
+	TEST_ACCOUNT,
+} from "./test-account.ts";
 
 class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
 	"@kampus/preview-seed/D1RestError",
@@ -47,10 +55,61 @@ const run = Command.make(
 	}),
 ).pipe(Command.withDescription("Seed a stage's D1 with the unauth read-flow fixtures"));
 
-const cli = Command.make("preview-seed").pipe(
-	Command.withSubcommands([run]),
+/** The target is not a throwaway — a database holding somebody's accounts is never provisioned. */
+class NotThrowawayError extends Schema.TaggedErrorClass<NotThrowawayError>()(
+	"@kampus/preview-seed/NotThrowawayError",
+	{foreignAccounts: Schema.Number, databaseId: Schema.String},
+) {
+	override get message(): string {
+		return `preview-seed: D1 ${this.databaseId} holds ${this.foreignAccounts} account(s) that are not the test identity — that is not a throwaway preview/stage, and no test account was written. Target a freshly deployed preview D1.`;
+	}
+}
+
+/** The supplied token is too short or carries a cookie-illegal character — refused before any write. */
+class WeakSessionTokenError extends Schema.TaggedErrorClass<WeakSessionTokenError>()(
+	"@kampus/preview-seed/WeakSessionTokenError",
+	{},
+) {
+	override get message(): string {
+		return `preview-seed: $PREVIEW_TEST_SESSION_TOKEN must be at least ${MIN_SESSION_TOKEN_LEN} characters with no whitespace, ';' or ',' — it is the whole credential for a moderator on a live preview.`;
+	}
+}
+
+const testAccount = Command.make(
+	"test-account",
+	{databaseId: databaseIdFlag, accountId: accountIdFlag},
+	Effect.fn(function* ({databaseId, accountId}) {
+		const resolvedAccount = Option.isSome(accountId)
+			? accountId.value
+			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+		const raw = yield* Config.redacted("PREVIEW_TEST_SESSION_TOKEN");
+		const token = parseSessionToken(Redacted.value(raw));
+		if (token === null) return yield* new WeakSessionTokenError();
+
+		const db = makeTestAccountDb(
+			makeD1Rest({accountId: resolvedAccount, databaseId, layer: restLayer}),
+		);
+		const outcome = yield* Effect.tryPromise({
+			try: () => provisionTestAccount(db, token),
+			catch: (cause) => new D1RestError({cause}),
+		});
+		if (outcome._tag === "NotThrowaway") {
+			return yield* new NotThrowawayError({foreignAccounts: outcome.foreignAccounts, databaseId});
+		}
+		yield* Console.log(
+			`preview-seed: ok — @${TEST_ACCOUNT.username} provisioned as moderator+yazar on D1 ${databaseId}, ${outcome.report.tuples} new moderates tuple(s), session valid to ${outcome.report.expiresAt.toISOString()}`,
+		);
+	}),
+).pipe(
 	Command.withDescription(
-		"Direct-D1 seed for the preview stage's unauthenticated read flows (#521)",
+		"Provision the moderator-tier review-ui test account + its session on a throwaway preview/stage D1 — idempotent, refuses a database holding real accounts",
+	),
+);
+
+const cli = Command.make("preview-seed").pipe(
+	Command.withSubcommands([run, testAccount]),
+	Command.withDescription(
+		"Direct-D1 seed for the preview stage's unauthenticated read flows (#521) and its review-ui test account (#7051)",
 	),
 );
 

--- a/packages/preview-seed/src/index.ts
+++ b/packages/preview-seed/src/index.ts
@@ -11,3 +11,13 @@ export type {SeedSchema} from "./schema.ts";
 export {seedSchema} from "./schema.ts";
 export type {SeedDb, SeedReport} from "./seed.ts";
 export {buildSeedStatements, makeSeedDb, seed} from "./seed.ts";
+export type {ProvisionOutcome, ProvisionReport, SessionToken} from "./test-account.ts";
+export {
+	countForeignAccounts,
+	MIN_SESSION_TOKEN_LEN,
+	makeTestAccountDb,
+	parseSessionToken,
+	provisionTestAccount,
+	SESSION_TTL_MS,
+	TEST_ACCOUNT,
+} from "./test-account.ts";

--- a/packages/preview-seed/src/schema.ts
+++ b/packages/preview-seed/src/schema.ts
@@ -5,7 +5,7 @@
  * adds no cycle even though this package already prod-depends on `@kampus/web`.
  */
 import {definitionRecord, postRecord, termRecord} from "@kampus/db-schema";
-import {sqliteTable, text} from "drizzle-orm/sqlite-core";
+import {index, integer, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
 
 export {definitionRecord, postRecord, termRecord};
 
@@ -29,5 +29,67 @@ export const postSearch = sqliteTable("post_search", {
 	norm: text("norm").notNull(),
 });
 
-export const seedSchema = {termRecord, definitionRecord, postRecord, termSearch, postSearch};
+/**
+ * The auth slice the test-account provisioner writes — a narrow local copy of
+ * `apps/web/worker/db/drizzle/schema.ts`, the way `@kampus/founder-seed` keeps one: the
+ * worker's schema module is not an exported subpath, and pulling the worker graph into a
+ * `packages/` CLI is the anti-pattern `@kampus/admin-grant` avoids the same way.
+ *
+ * `session.token` is the value better-auth signs into the session cookie, so a row written
+ * here is exactly what an authenticated capture presents (see `test-account.ts`).
+ */
+const timestamp = (name: string) => integer(name, {mode: "timestamp"});
+
+export const user = sqliteTable("user", {
+	id: text("id").primaryKey(),
+	name: text("name"),
+	email: text("email").notNull(),
+	type: text("type", {enum: ["human", "bot", "system"]})
+		.notNull()
+		.default("human"),
+	role: text("role", {enum: ["member", "moderator"]})
+		.notNull()
+		.default("member"),
+	tier: text("tier", {enum: ["çaylak", "yazar"]})
+		.notNull()
+		.default("çaylak"),
+	emailVerified: integer("email_verified", {mode: "boolean"}),
+	username: text("username").unique(),
+	createdAt: timestamp("created_at"),
+	updatedAt: timestamp("updated_at"),
+});
+
+export const session = sqliteTable("session", {
+	id: text("id").primaryKey(),
+	userId: text("user_id").notNull(),
+	expiresAt: timestamp("expires_at").notNull(),
+	token: text("token").unique(),
+	createdAt: timestamp("created_at"),
+	updatedAt: timestamp("updated_at"),
+});
+
+/** Added by migration `0010_relation_tuple`; moderation authority lives here, not on `user.role` (ADR 0107 §4). */
+export const relationTuple = sqliteTable(
+	"relation_tuple",
+	{
+		subject: text("subject").notNull(),
+		relation: text("relation").notNull(),
+		object: text("object").notNull(),
+	},
+	(t) => [
+		primaryKey({columns: [t.subject, t.relation, t.object]}),
+		index("relation_tuple_object").on(t.object, t.relation),
+	],
+);
+
+export const seedSchema = {
+	termRecord,
+	definitionRecord,
+	postRecord,
+	termSearch,
+	postSearch,
+	user,
+	session,
+	relationTuple,
+};
 export type SeedSchema = typeof seedSchema;

--- a/packages/preview-seed/src/test-account.ts
+++ b/packages/preview-seed/src/test-account.ts
@@ -1,0 +1,138 @@
+/**
+ * Provision the single moderator-tier test account a `review-ui` capture authenticates as,
+ * and the session row whose token becomes that capture's cookie (issue #7051).
+ *
+ * Direct-D1 like the rest of this package — never a runtime worker route (CLAUDE.md, "Sözlük
+ * seed"). Moderation authority is the `(id, "moderates", key(platform))` tuple, not `user.role`
+ * (ADR 0107 §4); the vestigial column is written beside it only so a coarse role read agrees.
+ *
+ * The throwaway fence is the load-bearing part. A caller-asserted "this is a preview" proves
+ * nothing, so the refusal is grounded in the database itself: a preview/stage D1 is deployed
+ * empty and this package's content fixtures denormalize their author, so a throwaway carries no
+ * human `user` row at all. One that carries somebody else's account is somebody's real world and
+ * is refused before any write.
+ */
+import {key, platform} from "@kampus/authz";
+import {and, eq, ne} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {defineRelations} from "drizzle-orm/relations";
+import {relationTuple, seedSchema, session, user} from "./schema.ts";
+
+const relations = defineRelations(seedSchema);
+
+export type SeedDb = ReturnType<typeof drizzle<typeof relations>>;
+
+export const makeTestAccountDb = (d1: D1Database): SeedDb => drizzle(d1, {relations});
+
+export const MODERATES = "moderates";
+export const PLATFORM = key(platform);
+
+/** better-auth's default session lifetime (`sec("7d")`), so the row expires like a signed-in one. */
+export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * The one test identity. Fixed so every provision is an upsert on the same row rather than a new
+ * account per run, and `.invalid` per RFC 2606 so the address can never reach a mailbox.
+ */
+export const TEST_ACCOUNT = {
+	id: "preview-test-moderator",
+	email: "preview-test-moderator@preview.invalid",
+	username: "onizleme-mod",
+	name: "Önizleme Moderatörü",
+	role: "moderator",
+	tier: "yazar",
+	sessionId: "preview-test-moderator-session",
+} as const;
+
+declare const SessionTokenBrand: unique symbol;
+/** A session token that has passed {@link parseSessionToken} — the only thing provisioning accepts. */
+export type SessionToken = string & {readonly [SessionTokenBrand]: true};
+
+/**
+ * better-auth mints a 32-byte session token, and this one is the whole credential for a moderator
+ * on a live preview, so a short one is refused rather than written.
+ */
+export const MIN_SESSION_TOKEN_LEN = 32;
+
+export const parseSessionToken = (raw: string): SessionToken | null =>
+	raw.trim().length >= MIN_SESSION_TOKEN_LEN && !/[\s;,]/.test(raw.trim())
+		? (raw.trim() as SessionToken)
+		: null;
+
+export interface ProvisionReport {
+	/** `user` rows written — always 1 (the upsert reports the row it touched). */
+	readonly account: number;
+	/** `session` rows written — always 1; the token is refreshed to the one just supplied. */
+	readonly session: number;
+	/** `moderates` tuples newly minted — `0` on a re-run. */
+	readonly tuples: number;
+	readonly expiresAt: Date;
+}
+
+/**
+ * Two arms, never one: a refusal must not read as a provision that wrote nothing. `NotThrowaway`
+ * names how many foreign accounts were found, which is the fact the operator acts on.
+ */
+export type ProvisionOutcome =
+	| {readonly _tag: "Provisioned"; readonly report: ProvisionReport}
+	| {readonly _tag: "NotThrowaway"; readonly foreignAccounts: number};
+
+/**
+ * Accounts on this database that are not the test identity and not the `@[silinen]` migration
+ * sentinel (ADR 0097) — the evidence the target is somebody's real world.
+ */
+export const countForeignAccounts = async (db: SeedDb): Promise<number> => {
+	const rows = await db
+		.select({id: user.id})
+		.from(user)
+		.where(and(ne(user.id, TEST_ACCOUNT.id), eq(user.type, "human")))
+		.all();
+	return rows.length;
+};
+
+export const provisionTestAccount = async (
+	db: SeedDb,
+	token: SessionToken,
+	now: Date = new Date(),
+): Promise<ProvisionOutcome> => {
+	const foreignAccounts = await countForeignAccounts(db);
+	if (foreignAccounts > 0) return {_tag: "NotThrowaway", foreignAccounts};
+
+	const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+	const accountRow = {
+		id: TEST_ACCOUNT.id,
+		name: TEST_ACCOUNT.name,
+		email: TEST_ACCOUNT.email,
+		type: "human",
+		role: TEST_ACCOUNT.role,
+		tier: TEST_ACCOUNT.tier,
+		emailVerified: true,
+		username: TEST_ACCOUNT.username,
+		createdAt: now,
+		updatedAt: now,
+	} as const;
+	const sessionRow = {
+		id: TEST_ACCOUNT.sessionId,
+		userId: TEST_ACCOUNT.id,
+		token,
+		expiresAt,
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	// One `batch` so the account, its session and its moderation tuple land together or not at all
+	// — a session pointing at an unpromoted account renders a çaylak's view and reads as a defect.
+	const [, , tuple] = await db.batch([
+		db.insert(user).values(accountRow).onConflictDoUpdate({target: user.id, set: accountRow}),
+		db.insert(session).values(sessionRow).onConflictDoUpdate({target: session.id, set: sessionRow}),
+		db
+			.insert(relationTuple)
+			.values({subject: TEST_ACCOUNT.id, relation: MODERATES, object: PLATFORM})
+			.onConflictDoNothing(),
+	]);
+
+	return {
+		_tag: "Provisioned",
+		report: {account: 1, session: 1, tuples: tuple.meta.changes, expiresAt},
+	};
+};

--- a/packages/preview-seed/src/test-account.ts
+++ b/packages/preview-seed/src/test-account.ts
@@ -10,7 +10,14 @@
  * nothing, so the refusal is grounded in the database itself: a preview/stage D1 is deployed
  * empty and this package's content fixtures denormalize their author, so a throwaway carries no
  * human `user` row at all. One that carries somebody else's account is somebody's real world and
- * is refused before any write.
+ * is refused before any write. The check is emptiness, not throwaway-ness — the README's
+ * "guard boundary" section states its exact reach, and the operator still owns `--database-id`.
+ *
+ * No `account` row is written, and that is deliberate rather than an omission: better-auth
+ * resolves a session through `internalAdapter.findSession` (`dist/db/internal-adapter.mjs` at the
+ * `1.6.23` pin), which reads `session` by `token` with `join: {user: true}` and touches no
+ * `account` table. A session + its user is the whole of what a signed-in request needs; `account`
+ * carries credentials for signing IN, which this path skips by construction.
  */
 import {key, platform} from "@kampus/authz";
 import {and, eq, ne} from "drizzle-orm";

--- a/packages/preview-seed/src/test-account.unit.test.ts
+++ b/packages/preview-seed/src/test-account.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The test-account provisioner's two refusable facts: a token weak enough to be guessed, and a
+ * target that is not a throwaway. Both must be decided BEFORE any write, so the fake below records
+ * every statement it is handed and the assertions read that record.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {toRestParams} from "@kampus/d1-rest";
+import {
+	MIN_SESSION_TOKEN_LEN,
+	makeTestAccountDb,
+	parseSessionToken,
+	provisionTestAccount,
+	SESSION_TTL_MS,
+	TEST_ACCOUNT,
+} from "./test-account.ts";
+
+interface Recorded {
+	readonly sql: string;
+	readonly params: readonly unknown[];
+}
+
+/** A `D1Database` stand-in: `all()` serves the configured user rows, `batch()` records and reports. */
+const fakeD1 = (users: ReadonlyArray<{id: string}>) => {
+	const batched: Recorded[] = [];
+	const selected: Recorded[] = [];
+	const bound = (sql: string, params: readonly unknown[]) => ({
+		sql,
+		params,
+		all: async () => {
+			selected.push({sql, params});
+			return {results: users};
+		},
+		run: async () => ({success: true as const, meta: {changes: 1}, results: []}),
+		// drizzle's core select prepares in `arrays` mode, so a row reaches it through `raw()` as
+		// positional values, never through `all()` — a fake that only serves `all()` reads empty.
+		raw: async () => {
+			selected.push({sql, params});
+			return users.map((row) => Object.values(row));
+		},
+		first: async () => null,
+	});
+	const client = {
+		prepare: (sql: string) => ({
+			...bound(sql, []),
+			bind: (...params: unknown[]) => bound(sql, params),
+		}),
+		batch: async (stmts: ReadonlyArray<Recorded>) => {
+			for (const stmt of stmts) batched.push({sql: stmt.sql, params: stmt.params});
+			return stmts.map(() => ({success: true as const, meta: {changes: 1}, results: []}));
+		},
+	};
+	// biome-ignore lint/plugin: the stand-in implements only the slice drizzle-orm/d1 drives; the full `D1Database` interface is not structurally reachable here.
+	return {d1: client as unknown as D1Database, batched, selected};
+};
+
+const TOKEN = parseSessionToken("t".repeat(MIN_SESSION_TOKEN_LEN));
+
+describe("parseSessionToken", () => {
+	it("refuses a token below the minimum length", () => {
+		assert.isNull(parseSessionToken("t".repeat(MIN_SESSION_TOKEN_LEN - 1)));
+	});
+
+	it("refuses a token carrying a cookie-illegal character", () => {
+		assert.isNull(parseSessionToken(`${"t".repeat(MIN_SESSION_TOKEN_LEN)};evil=1`));
+		assert.isNull(parseSessionToken(`${"t".repeat(MIN_SESSION_TOKEN_LEN)} spaced`));
+	});
+
+	it("accepts a long token and trims it", () => {
+		assert.strictEqual(parseSessionToken(`  ${"t".repeat(40)}  `), "t".repeat(40));
+	});
+});
+
+describe("provisionTestAccount", () => {
+	it("refuses a database holding a foreign account, writing nothing", async () => {
+		assert.isNotNull(TOKEN);
+		const {d1, batched} = fakeD1([{id: "somebody-real"}]);
+		const outcome = await provisionTestAccount(makeTestAccountDb(d1), TOKEN);
+		assert.strictEqual(outcome._tag, "NotThrowaway");
+		assert.strictEqual(outcome._tag === "NotThrowaway" ? outcome.foreignAccounts : -1, 1);
+		assert.lengthOf(batched, 0);
+	});
+
+	it("provisions account, session and moderates tuple in one batch on an empty database", async () => {
+		assert.isNotNull(TOKEN);
+		const now = new Date("2026-08-28T00:00:00.000Z");
+		const {d1, batched} = fakeD1([]);
+		const outcome = await provisionTestAccount(makeTestAccountDb(d1), TOKEN, now);
+		assert.strictEqual(outcome._tag, "Provisioned");
+		if (outcome._tag !== "Provisioned") return;
+		assert.strictEqual(outcome.report.expiresAt.getTime(), now.getTime() + SESSION_TTL_MS);
+		assert.lengthOf(batched, 3);
+		assert.include(batched[0]?.sql ?? "", '"user"');
+		assert.include(batched[1]?.sql ?? "", '"session"');
+		assert.include(batched[2]?.sql ?? "", "relation_tuple");
+		assert.include(batched[1]?.params ?? [], TOKEN);
+		assert.include(batched[2]?.params ?? [], TEST_ACCOUNT.id);
+	});
+
+	it("binds no null param — D1 REST rejects one and the batch would die mid-provision (#569)", async () => {
+		assert.isNotNull(TOKEN);
+		const {d1, batched} = fakeD1([]);
+		await provisionTestAccount(makeTestAccountDb(d1), TOKEN);
+		batched.forEach((stmt, i) => {
+			stmt.params.forEach((p, j) => {
+				assert.isNotNull(p, `batch[${i}].params[${j}] is null`);
+				assert.notTypeOf(p, "undefined", `batch[${i}].params[${j}] is undefined`);
+			});
+			toRestParams(stmt.params).forEach((w, j) => {
+				assert.typeOf(w, "string", `batch[${i}] wire param[${j}] must be a string`);
+			});
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,9 @@ importers:
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=9557e68464da6a36ba3f9156d4a74af640d8c56091d612b87e392d7339434922))(ioredis@5.10.1)
+      '@kampus/authz':
+        specifier: workspace:*
+        version: link:../authz
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest


### PR DESCRIPTION
Part of #7051.

`review-ui render` could only ever shoot the anonymous view of a surface: a per-PR preview deploys
an empty D1, so nothing behind login existed to capture, and a UI delta that only appears signed in
ended a review as unseen ground reading clean. This gives the gate an account to render as.

**`preview-seed test-account`** provisions it — one moderator-tier account, its session row, and the
`(id, "moderates", "platform:platform")` tuple that is the real moderation authority (ADR 0107 §4),
written in one atomic D1 `batch`. Direct-D1, never a worker route. The throwaway fence is not the
caller's word for it: a preview/stage D1 deploys empty and this package's content fixtures
denormalize their author, so a throwaway carries no human `user` row at all. Finding one that is not
the test identity, the verb refuses and writes nothing. There is no override flag. The token is read
only from `$PREVIEW_TEST_SESSION_TOKEN`, so it stays out of process listings. What the check proves
is emptiness, not throwaway-ness — the README's guard-boundary section now states that reach
exactly, because the argument against an override flag rests on it.

**`review-ui render --surface /pano:auth`** signs that token with the preview worker's
`$BETTER_AUTH_SECRET` and seeds it as the better-auth session cookie. The cookie is built to
better-auth's own wire format read at the pin — `setSessionCookie` (`dist/cookies/index.mjs`) writes
the session `token` through `setSignedCookie`, which resolves to better-call's `signCookieValue`
(`dist/crypto.mjs`): `encodeURIComponent(value + "." + base64(HMAC-SHA256(value, secret)))`. The unit
tier verifies that signature through WebCrypto rather than the `node:crypto` call that produced it,
and asserts the 44-character base64 shape `getSignedCookie` requires.

**And the shot proves it took, which is the round's main change.** Seeding a cookie is not the same
as being signed in: a wrong, expired or unseeded token renders the visitor's page, and that page is a
perfectly valid PNG no byte check can tell from the real one — so the previous head could file it
under the `:auth` surface id with a sha256 and the gate would read unseen ground as clean. Every
`:auth` shot now reads the preview's own `/api/auth/get-session` from the same browser context, before
it is classified, and requires a user back. A bare `null`, a non-200 or an unreadable body refuses the
surface on `11` and records no capture. UNKNOWN, never a red surface: the page rendered fine, it is
just not the page that was asked for. That is #7051's fifth criterion, and it is now met.

**States are admitted one at a time, and only with a mechanism.** `capture/states.ts` declares the
realized set; `auth` is the only member. Every other `:state` token stays refused on `10` with the
same reasoning the old blanket refusal carried — parsing a state is not rendering one, and a token
with no mechanism shoots the default pixels under a variant's name. The grammar now has one parser:
`stateOf` reads through `parseSurfaceSpec` instead of re-splitting the token beside it. The sibling
`ui` group renders in-tree with no preview and no session, so it still refuses every `:state`.

Adjacent: #7218 asks for the flag-override *and* seeded-session halves of this seam (ADR 0336's
implementation ticket). This lands the seeded-session half only; the flag-override half is untouched.

## Deviations

- **Scope narrowing** — **Said:** #7051's third criterion asks that the review-scope derivation name
  the owed `:state` variants of each changed surface, so an uncaptured state reads UNKNOWN in the
  verdict record. **Did:** left it unbuilt; the PR is `Part of`, not `Fixes`, and that criterion box
  stays unchecked. **Why:** naming the owed variants *of a changed surface* needs a file-to-route
  map, and `apps/web/src/` has no file-based routing — no mechanical source derives `/pano` from
  `apps/web/src/pages/...`. The registry would have to be declared, and where it lives is a real
  design choice (a new `.fabrika.jsonc` key, a `design-harness.json` field on a file phoenix does not
  ship, or compiled-in beside `PRIORITY_SURFACES`), each with a different blast radius. Guessing one
  here would have shipped a derivation nobody asked for on a surface the merge gate reads.
  **Disposition:** stated here; the criterion stays open on #7051 for a lane that can settle the
  registry's home first.

- **Known defect left unfixed** — **Said:** nothing in #7051 about test tiers. **Did:** shipped the
  authenticated capture with a unit tier only — no integration run proves a live preview worker
  accepts the cookie. **Why:** one fact is still unobservable from outside the isolate: the
  `__Secure-` prefix is chosen from `isProduction` when `baseURL` is an object, which is what
  `deriveAuthUrlConfig` returns on preview, so the module seeds both the prefixed and unprefixed name
  and assumes one matches. The round's other unknown is now closed from source rather than deferred —
  better-auth `1.6.23`'s `internalAdapter.findSession` (`dist/db/internal-adapter.mjs`) reads `session`
  by `token` with `join: {user: true}` and touches no `account` table, so a session row with no
  `account` sibling resolves; that grounding is recorded in `test-account.ts`'s docblock.
  **Disposition:** stated here; the `__Secure-` half stays on #7224, and the new per-shot session
  proof means a preview where the guess is wrong now refuses the render rather than shooting it
  anonymously.

- **Pre-existing test or fixture changed** — **Said:** nothing about the fake D1 stand-in. **Did:**
  `packages/preview-seed/src/test-account.unit.test.ts:53` carries a `biome-ignore lint/plugin` on the
  `client as unknown as D1Database` cast. **Why:** the stand-in implements only the slice
  `drizzle-orm/d1` actually drives, and the full `D1Database` interface is not structurally reachable
  from a hand-written fake. **Disposition:** stated here — the previous round's Deviations section
  omitted it, which `review deviations` surfaced and `review-code` graded.

- **Out-of-scope change** — **Said:** #7051 names `review-ui render` and the provisioning verb.
  **Did:** also edited `review-ui/contract.md`, `review-ui/SKILL.md`, `fabrika-cli/README.md`, the
  `review-ui render` help string, and `capture/plan.ts`'s module docblock. **Why:** the `:state`
  refusal's grammar is hand-copied across those surfaces per
  `.patterns/verb-output-pin-surfaces.md`, and a copy left saying "reserved, not yet realized" would
  read as true to every reader while the verb had moved on. The `plan.ts` docblock is the sixth of
  those surfaces and the previous round missed it: it still named `empty` and `focus-visible` as
  state examples, the two tokens the verb now refuses on `10`.
  **Disposition:** stated here; all six copies land in this PR, which is what that pattern requires.
