### PR TITLE
feat: Finished subagents' worktrees are never reaped and can hold live PR branches

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -206,6 +206,14 @@ Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build
 | `build pr` / `pr-body` / `note` | the guarded, read-back PR write surfaces |
 | `build verdicts` | the latest gate verdict per namespace at a PR's live head |
 | `build clear` | the founder's clearance of one extra repair round |
+| `build reap` | which finished `.claude/worktrees/agent-*` trees are provably safe to remove — a dry run unless `--execute` |
+
+`build reap` is the bulk counterpart to `build retire`. `retire` targets the trees holding ONE
+number's lane branch and needs a board statement to release them; `reap` sweeps the whole agent
+population, which usually holds no lane branch at all (the harness detaches those trees), and asks
+git instead: a tree goes only when it is clean, unlocked, and its HEAD is on the trunk — reachable
+from `origin/HEAD`, or landed there as a squash, matched on patch identity. Every other case, and
+every read that failed, is KEEP.
 
 **Exit codes.** The shared table, plus: `13` uncommitted changes at a `--require-clean` open ·
 `14` the checked-out branch is not this lane's · `15` this session does not hold the claim ·

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -36,6 +36,7 @@ import {runNote} from "./note-verb.ts";
 import {runPick} from "./pick-verb.ts";
 import {runPr, runPrBody} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
+import {runReap} from "./reap-verb.ts";
 import {runRetire} from "./retire-verb.ts";
 import {
 	ADMISSION_EXIT_CODES,
@@ -265,6 +266,25 @@ const retire = leafCommand(
 	Command.withShortDescription("Take back the checkout an orphaned build worktree is holding."),
 	Command.withDescription(
 		'Retire the working trees of this clone that hold #<n>\'s lane branch, so a repair lane refused at "build branch --resume-lane" can stand where it needs to (ADR 0323). Two licenses, both written positive board states and never an inference from a tree that looks idle: the ticket is TERMINAL (a closed issue, a merged PR), or an authorized ADR 0295 build-adopt marker on #<n> names the session whose claim carries that branch\'s lane nonce. DIRTINESS IS NOT A REFUSAL — an agent routinely leaves a worktree dirty after its ticket merged — and it costs nobody their only copy either: ADR 0321\'s salvage runs first, committing whatever the tree holds uncommitted onto its own branch, and only then is the tree removed WITHOUT --force, which that ADR bans on every path. A removal that still refuses (a locked tree does, however clean) is reported as an incident to file, never overridden. The removal takes the tree, never the branch. It first prunes registrations whose directory is already gone, never removes the tree the run is standing in, and reads every removal back off a second worktree list. A worktree-isolated caller may run it — the harness rule that refuses a typed cross-worktree git does not bind a verb\'s own child process. Prints {"answer":"retired"|"held"|"none","number":n,"retired":[…],"held":[…]}. Exits 7 (#<n> proven absent), 8 (the salvage or the removal failed — UNKNOWN), 9 (git reported a removal and the registration survives), 11 (a precondition read failed), 33 (a tree still holds the branch and the board licenses no release). Example: fabrika build retire 6567',
+	),
+);
+
+const reap = leafCommand(
+	"reap",
+	{
+		execute: Flag.boolean("execute").pipe(
+			Flag.withDescription(
+				"actually remove the trees classified REMOVE (default: false — print the classification and mutate nothing)",
+			),
+		),
+	},
+	Effect.fn(function* ({execute}) {
+		yield* emit(yield* runReap({execute}));
+	}),
+).pipe(
+	Command.withShortDescription("Reclaim the finished agent worktrees this clone never removed."),
+	Command.withDescription(
+		'Sweep the registrations under .claude/worktrees/agent-* and classify each KEEP or REMOVE. REMOVE needs THREE positive proofs together: the tree holds nothing uncommitted, it carries no lock, and its HEAD is already on the trunk — reachable from origin/HEAD, or landed there as a squash (ADR 0048), matched by comparing the patch id of what the HEAD adds against the trunk\'s own patches over exactly those paths. The subject is the HEAD COMMIT, not a branch: the harness detaches the trees it registers, so a branch-keyed rule would judge almost none of them. EVERYTHING ELSE IS KEEP, per tree — dirty, locked, prunable, unlanded, and every read that failed — so one unreadable directory costs its own row and not the sweep. THE DEFAULT RUN MUTATES NOTHING: it prints the per-tree classification with its reason and stops; --execute is what removes. Each removal runs plain `git worktree remove` and NEVER --force, which ADR 0321 bans on every path; a removal git refuses leaves the tree registered and is reported, and every removal is read back off a second worktree list. The removal takes the tree, never the branch. Both halves of the report — what went and what was deliberately kept — are on stderr on every path, so a survivor is visible without re-running. Prints {"answer":"planned"|"reaped"|"none","executed":bool,"trunk":"origin/main","scanned":n,"removable"|"removed":[…],"kept":[…]}. Exits 8 (git refused a removal — the tree stays), 9 (git reported a removal and the registration survives, or the read-back failed), 11 (this run\'s own root, the registrations, or the trunk could not be read — nothing was removed). Example: fabrika build reap --execute',
 	),
 );
 
@@ -706,6 +726,7 @@ export const buildCommand = Command.make("build").pipe(
 		release,
 		adopt,
 		retire,
+		reap,
 		issue,
 		branch,
 		scratch,

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -122,6 +122,75 @@ export const worktreeCheckouts: Shell<Attempt<ReadonlyArray<WorktreeCheckout>>> 
 	},
 );
 
+/** One registration of `git worktree list`, read whole rather than folded to a branch. */
+export interface WorktreeRegistration {
+	readonly path: string;
+	/** The commit it stands on, or `""` when the record named none (a bare repo). */
+	readonly head: string;
+	/** The branch it holds, or `null` when its HEAD is detached. */
+	readonly branch: string | null;
+	/** git's own lock reason, `""` when locked without one, `null` when unlocked. */
+	readonly locked: string | null;
+	/** Set when git already considers the record stale — its working directory is gone. */
+	readonly prunable: boolean;
+}
+
+/**
+ * Every registration of this clone, with the four facts a bulk sweep judges on.
+ *
+ * {@link worktreeCheckouts} answers a narrower question — who holds a branch — and drops the
+ * detached majority on the floor. The harness detaches the trees it registers, so a reclaimer built
+ * on that reader would be blind to most of what it exists to reclaim.
+ */
+export const worktreeRegistrations: Shell<Attempt<ReadonlyArray<WorktreeRegistration>>> =
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["worktree", "list", "--porcelain"]);
+		if (!r.ok) return fail(r.reason);
+		const records: Array<WorktreeRegistration> = [];
+		let open: {path: string; head: string; branch: string | null; locked: string | null} | null =
+			null;
+		let prunable = false;
+		const close = () => {
+			if (open !== null) records.push({...open, prunable});
+			open = null;
+			prunable = false;
+		};
+		for (const line of r.stdout.split("\n")) {
+			if (line.startsWith("worktree ")) {
+				close();
+				open = {path: line.slice("worktree ".length).trim(), head: "", branch: null, locked: null};
+			} else if (open === null) continue;
+			else if (line.startsWith("HEAD ")) open.head = line.slice("HEAD ".length).trim();
+			else if (line.startsWith("branch refs/heads/")) {
+				open.branch = line.slice("branch refs/heads/".length).trim();
+			} else if (line === "locked" || line.startsWith("locked ")) {
+				open.locked = line.slice("locked".length).trim();
+			} else if (line === "prunable" || line.startsWith("prunable ")) prunable = true;
+		}
+		close();
+		return ok(records);
+	});
+
+/**
+ * How many paths another worktree has uncommitted, read **without touching its index**.
+ *
+ * `--no-optional-locks` is the whole difference from {@link worktreeDirtyPaths}: an ordinary
+ * `git status` refreshes that tree's index as a side effect, and a dry run that says it mutates
+ * nothing may not write into a tree it is only reporting on.
+ */
+export const worktreeStatusPaths = (path: string): Shell<Attempt<number>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"-C",
+			path,
+			"--no-optional-locks",
+			"status",
+			"--porcelain",
+		]);
+		if (!r.ok) return fail(r.reason);
+		return ok(r.stdout.split("\n").filter((line) => line.trim() !== "").length);
+	});
+
 /**
  * Drop the registrations whose working directory is gone — git's own definition of a stale record.
  *

--- a/packages/fabrika-cli/src/build/reap-verb.ts
+++ b/packages/fabrika-cli/src/build/reap-verb.ts
@@ -1,0 +1,305 @@
+/**
+ * `build reap` — reclaim the finished agent worktrees this clone never removed.
+ *
+ * The leak is #6833: the harness registers a worktree per spawned agent under
+ * `.claude/worktrees/agent-*` and nothing removes one when its agent finishes, so registrations pile
+ * up until a live lane has to reason about whether a dead checkout is a sibling holding its branch —
+ * a false signal sitting directly upstream of a force-push decision (PR #6823).
+ *
+ * `build retire` does not cover this: that verb targets the trees holding ONE number's lane branch
+ * and needs a board statement about that number to release them. A finished agent tree usually holds
+ * no lane branch at all — the harness detaches it — so there is no number to ask the board about.
+ * This verb asks git instead, and reclaims only what git can prove.
+ *
+ * The order is the contract:
+ *
+ *   1. This run's own tree root is read, so no pass can remove the checkout it is standing in.
+ *   2. Every registration is read whole (`./git.ts`) and narrowed to the agent population.
+ *   3. The trunk is derived from `origin/HEAD`, never spelled — a wrong ref resolves to nothing and
+ *      would make every tree look unlanded.
+ *   4. Each tree's uncommitted count and its HEAD's landing are read, and {@link classify} seats it.
+ *      **Every read that fails is a KEEP**, per-tree: a sweep of seventy trees must not lose its
+ *      whole answer to one unreadable directory.
+ *   5. Nothing is removed at all without `--execute`. The default run prints classifications.
+ *   6. Each removal runs plain `git worktree remove` — never `--force`, which ADR 0321 bans on every
+ *      path — and every one is read back off a second `worktree list`.
+ *
+ * It removes the tree and leaves the branch, exactly as `build retire` does: a removal frees a
+ * checkout, it does not delete a ref.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	diffRange,
+	diffRangePaths,
+	mergeBase,
+	originHeadRef,
+	patchIdsIn,
+	patchIdsOf,
+} from "../io/git.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {isAncestor, removeWorktree, worktreeRegistrations, worktreeStatusPaths} from "./git.ts";
+import {
+	classify,
+	isAgentWorktree,
+	type Landing,
+	type License,
+	type TreeFacts,
+	type Uncommitted,
+	unprovenAmong,
+	type Verdict,
+} from "./reap.ts";
+import {readTree} from "./tree.ts";
+
+const VERB = "fabrika build reap";
+
+/**
+ * How far back along the trunk a squash is looked for.
+ *
+ * Bounded because the scan reads patches, not commit names. Past it the answer is "not found",
+ * which classifies KEEP — the fail-safe direction, and the reason a bound is allowed to exist here
+ * at all.
+ */
+const TRUNK_SCAN = 200;
+
+export interface ReapOptions {
+	/** Removals happen only under this flag. Default is a dry run that mutates nothing. */
+	readonly execute: boolean;
+}
+
+type Deps = ChildProcessSpawner.ChildProcessSpawner;
+
+export const runReap = (options: ReapOptions): Effect.Effect<VerbOutcome, never, Deps> =>
+	Effect.gen(function* () {
+		const self = yield* readTree;
+		if (self._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read this run's own tree root: ${self.reason} — a run that cannot recognise itself must remove nothing.`,
+			);
+		}
+		const selfPaths = new Set([self.value.root]);
+
+		const registrations = yield* worktreeRegistrations;
+		if (registrations._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read this clone's worktree registrations: ${registrations.reason} — what is registered is UNKNOWN.`,
+			);
+		}
+		const population = registrations.value.filter((tree) => isAgentWorktree(tree.path));
+		const scope = `${VERB}: scanned ${registrations.value.length} registration(s); ${population.length} under .claude/worktrees/agent-*.`;
+		if (population.length === 0) {
+			return answer(
+				JSON.stringify({answer: "none", executed: options.execute, removed: [], kept: []}),
+				[scope, `${VERB}: no agent worktree is registered in this clone — nothing to reap.`],
+			);
+		}
+
+		const trunk = yield* originHeadRef;
+		if (trunk._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot name this clone's trunk: ${trunk.reason} — whether any tree's work landed is UNKNOWN, and an unnameable trunk must reap nothing.`,
+				[scope],
+			);
+		}
+
+		const seated: Array<{facts: TreeFacts; verdict: Verdict}> = [];
+		for (const tree of population) {
+			const facts: TreeFacts = {
+				path: tree.path,
+				branch: tree.branch,
+				locked: tree.locked,
+				prunable: tree.prunable,
+				uncommitted: yield* uncommittedIn(tree.path, tree.prunable),
+				landing: yield* landingOf(tree.head, trunk.value),
+			};
+			seated.push({facts, verdict: classify(facts, trunk.value, selfPaths)});
+		}
+
+		const removable = seated.flatMap(({facts, verdict}) =>
+			verdict._tag === "Remove" ? [{path: facts.path, license: verdict.license}] : [],
+		);
+		const kept = seated.flatMap(({facts, verdict}) =>
+			verdict._tag === "Keep"
+				? [{path: facts.path, branch: facts.branch, reason: verdict.because}]
+				: [],
+		);
+		const keptLines = seated.flatMap(({facts, verdict}) =>
+			verdict._tag === "Keep"
+				? [`${VERB}: KEEP ${facts.path}${branchOf(facts)} — ${verdict.because}.`]
+				: [],
+		);
+
+		if (!options.execute) {
+			const planned = seated.flatMap(({facts, verdict}) =>
+				verdict._tag === "Remove"
+					? [`${VERB}: REMOVE ${facts.path}${branchOf(facts)} — ${verdict.because}.`]
+					: [],
+			);
+			return answer(
+				JSON.stringify({
+					answer: "planned",
+					executed: false,
+					trunk: trunk.value,
+					scanned: population.length,
+					removable,
+					kept,
+				}),
+				[
+					scope,
+					...planned,
+					...keptLines,
+					`${VERB}: ${removable.length} removable, ${kept.length} kept — nothing was removed; re-run with --execute to remove them.`,
+				],
+			);
+		}
+
+		const removed: Array<{path: string; license: License}> = [];
+		const failed: Array<{path: string; reason: string}> = [];
+		for (const candidate of removable) {
+			const gone = yield* removeWorktree(candidate.path);
+			if (gone._tag === "Failure") failed.push({path: candidate.path, reason: gone.reason});
+			else removed.push(candidate);
+		}
+
+		let unproven: ReadonlyArray<string> = [];
+		if (removed.length > 0) {
+			const after = yield* worktreeRegistrations;
+			if (after._tag === "Failure") {
+				return refuse(
+					READBACK_MISMATCH,
+					`${VERB}: ${removed.length} tree(s) were removed and the registrations could not be read back: ${after.reason} — the removals are NOT proven.`,
+					[scope, ...keptLines],
+				);
+			}
+			unproven = unprovenAmong(
+				removed.map((row) => row.path),
+				after.value.map((tree) => tree.path),
+			);
+		}
+
+		const report = [
+			scope,
+			...removed
+				.filter((row) => !unproven.includes(row.path))
+				.map((row) => `${VERB}: removed ${row.path} (${row.license}).`),
+			...failed.map(
+				(row) =>
+					`${VERB}: FAILED to remove ${row.path}: ${row.reason} — the tree stays registered, and ADR 0321 bans --force on every path.`,
+			),
+			...unproven.map(
+				(path) =>
+					`${VERB}: UNPROVEN — git reported ${path} removed and it is still registered; this clone needs a human.`,
+			),
+			...keptLines,
+		];
+
+		if (unproven.length > 0) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: ${unproven.length} removal(s) read back as still registered — reported as failures, never successes.`,
+				report,
+			);
+		}
+		if (failed.length > 0) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: git refused ${failed.length} removal(s); ${removed.length} were removed and proven. Each refusal is an incident to file (/report), not an override.`,
+				report,
+			);
+		}
+		return answer(
+			JSON.stringify({
+				answer: "reaped",
+				executed: true,
+				trunk: trunk.value,
+				scanned: population.length,
+				removed,
+				failed,
+				kept,
+			}),
+			[...report, `${VERB}: ${removed.length} removed, ${kept.length} kept.`],
+		);
+	});
+
+const branchOf = (facts: TreeFacts): string =>
+	facts.branch === null ? " (detached)" : ` (${facts.branch})`;
+
+/**
+ * A tree's uncommitted count, or the reason it is UNKNOWN.
+ *
+ * A registration git already calls prunable has no directory to read, so it is not asked: the
+ * failure would be noise on a tree {@link classify} keeps for a different reason anyway.
+ */
+const uncommittedIn = (path: string, prunable: boolean): Effect.Effect<Uncommitted, never, Deps> =>
+	Effect.gen(function* () {
+		if (prunable) return {_tag: "Unknown" as const, reason: "its directory is gone"};
+		const dirty = yield* worktreeStatusPaths(path);
+		return dirty._tag === "Failure"
+			? {_tag: "Unknown" as const, reason: dirty.reason}
+			: {_tag: "Read" as const, paths: dirty.value};
+	});
+
+/**
+ * What `trunk` says about one HEAD commit — the three positive answers, or why there is none.
+ *
+ * The ancestor test comes first because it is one cheap call and it settles the majority: a detached
+ * agent tree usually stands on the trunk commit it was spawned at. Only what survives it costs the
+ * patch reads.
+ *
+ * The squash arm is patch-identity, not ancestry, and it was measured rather than reasoned about:
+ * on `build/4082-db-schema-readme-diataxis-43cc4b51` the branch's own net patch id and the trunk
+ * commit's path-limited one are both `d18b491a48c861494a35740f571a90a45b596aae`. The pathspec is
+ * what makes those two comparable — limited to the paths the branch touches, a squash commit's diff
+ * is that branch's net diff exactly. A squash landed on top of an intervening change to the same
+ * paths will not match, and answers `Unlanded`, which is the fail-safe direction.
+ */
+const landingOf = (head: string, trunk: string): Effect.Effect<Landing, never, Deps> =>
+	Effect.gen(function* () {
+		if (head === "") return {_tag: "Unknown" as const, reason: "its record names no HEAD commit"};
+		if (yield* isAncestor(head, trunk)) return {_tag: "Ancestor" as const};
+
+		const diff = yield* diffRange(trunk, head);
+		if (diff._tag === "Failure") {
+			return {_tag: "Unknown" as const, reason: `cannot diff it against ${trunk}: ${diff.reason}`};
+		}
+		if (diff.value.trim() === "") return {_tag: "NoChange" as const};
+
+		const own = yield* patchIdsOf(diff.value);
+		const mine = own._tag === "Ok" ? own.value[0] : undefined;
+		if (mine === undefined) {
+			return {
+				_tag: "Unknown" as const,
+				reason: `cannot compute the patch id of what its HEAD adds${own._tag === "Failure" ? `: ${own.reason}` : ""}`,
+			};
+		}
+
+		const paths = yield* diffRangePaths(trunk, head);
+		if (paths._tag === "Failure") {
+			return {
+				_tag: "Unknown" as const,
+				reason: `cannot list the paths it changes: ${paths.reason}`,
+			};
+		}
+		const base = yield* mergeBase(trunk, head);
+		if (base._tag === "Failure") {
+			return {
+				_tag: "Unknown" as const,
+				reason: `it shares no merge base with ${trunk}: ${base.reason}`,
+			};
+		}
+		const landed = yield* patchIdsIn(base.value, trunk, paths.value, TRUNK_SCAN);
+		if (landed._tag === "Failure") {
+			return {
+				_tag: "Unknown" as const,
+				reason: `cannot scan ${trunk} for the patch it adds: ${landed.reason}`,
+			};
+		}
+		const match = landed.value.find((row) => row.patch === mine.patch);
+		return match === undefined
+			? {_tag: "Unlanded" as const}
+			: {_tag: "Squashed" as const, commit: match.commit};
+	});

--- a/packages/fabrika-cli/src/build/reap-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/reap-verb.unit.test.ts
@@ -1,0 +1,341 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once, type Scripted} from "../fakes.test-support.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {runReap} from "./reap-verb.ts";
+
+const SELF = /^git rev-parse --path-format=absolute/;
+const TREES = /^git worktree list --porcelain$/;
+const TRUNK = /^git symbolic-ref --short refs\/remotes\/origin\/HEAD$/;
+const STATUS = /^git -C \S+ --no-optional-locks status --porcelain$/;
+const ANCESTOR = /^git merge-base --is-ancestor /;
+const DIFF = /^git diff .* origin\/main\.\.\./;
+const NAMES = /^git diff .*--name-only/;
+const MERGE_BASE = /^git merge-base origin\/main /;
+const LOG = /^git log --no-merges -p /;
+const PATCH_ID = /^git patch-id --stable$/;
+const REMOVE = /^git worktree remove /;
+
+const HERE = "/repo/.claude/worktrees/agent-self";
+const DEAD = "/repo/.claude/worktrees/agent-dead";
+const OTHER = "/repo/.claude/worktrees/agent-other";
+const LANDED = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const AHEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+interface Record {
+	readonly path: string;
+	readonly head?: string;
+	readonly branch?: string;
+	readonly locked?: string | null;
+	readonly prunable?: boolean;
+}
+
+/** `git worktree list --porcelain`, as the blocks git prints for each registration. */
+const trees = (...records: ReadonlyArray<Record>) =>
+	okOut(
+		records
+			.map((r) =>
+				[
+					`worktree ${r.path}`,
+					`HEAD ${r.head ?? LANDED}`,
+					r.branch === undefined ? "detached" : `branch refs/heads/${r.branch}`,
+					...(r.locked === undefined || r.locked === null
+						? []
+						: [r.locked === "" ? "locked" : `locked ${r.locked}`]),
+					...(r.prunable === true ? ["prunable gitdir file points to non-existent location"] : []),
+				].join("\n"),
+			)
+			.join("\n\n"),
+	);
+
+/** The primary checkout is always registered, and is never in the population. */
+const PRIMARY: Record = {path: "/repo", branch: "main"};
+
+/** What `git rev-parse` names for THIS run's checkout — the tree no sweep may remove. */
+const here = okOut([`${HERE}/.git`, HERE].join("\n"));
+
+const GROUND: ReadonlyArray<Scripted> = [
+	[SELF, here],
+	[TRUNK, okOut("origin/main\n")],
+];
+
+const run = (script: ReadonlyArray<Scripted>, execute = false) => {
+	const shell = fakeShell(script as ReadonlyArray<readonly [RegExp, never]>);
+	return Effect.runPromise(Effect.provide(runReap({execute}), shell.layer)).then((out) => ({
+		out,
+		calls: shell.calls,
+	}));
+};
+
+describe("runReap — the dry run mutates nothing", () => {
+	it("classifies a clean, unlocked, landed tree REMOVE and removes nothing", async () => {
+		const {out, calls} = await run([
+			...GROUND,
+			[TREES, trees(PRIMARY, {path: DEAD})],
+			[STATUS, okOut("")],
+			[ANCESTOR, okOut("")],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "planned",
+			executed: false,
+			trunk: "origin/main",
+			scanned: 1,
+			removable: [{path: DEAD, license: "ancestor"}],
+			kept: [],
+		});
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+		expect(out.stderr.join("\n")).toMatch(/re-run with --execute/);
+	});
+
+	it("reads another tree's status WITHOUT refreshing its index", async () => {
+		const {calls} = await run([
+			...GROUND,
+			[TREES, trees(PRIMARY, {path: DEAD})],
+			[STATUS, okOut("")],
+			[ANCESTOR, okOut("")],
+		]);
+
+		expect(calls).toContain(`git -C ${DEAD} --no-optional-locks status --porcelain`);
+	});
+
+	it("names both halves of the report — what would go and what is kept", async () => {
+		const {out} = await run([
+			...GROUND,
+			[TREES, trees(PRIMARY, {path: DEAD}, {path: OTHER, head: AHEAD})],
+			[STATUS, okOut("")],
+			[new RegExp(`^git merge-base --is-ancestor ${LANDED} `), okOut("")],
+			[ANCESTOR, errOut("exit 1")],
+			[NAMES, okOut("x\0")],
+			[DIFF, okOut("diff --git a/x b/x\n@@\n+x\n")],
+			[PATCH_ID, okOut("ffff 0000\n")],
+			[MERGE_BASE, okOut(`${LANDED}\n`)],
+			[LOG, okOut("")],
+		]);
+
+		const report = out.stderr.join("\n");
+		expect(report).toMatch(new RegExp(`REMOVE ${DEAD}`));
+		expect(report).toMatch(new RegExp(`KEEP ${OTHER}`));
+		expect(JSON.parse(out.stdout).kept).toMatchObject([{path: OTHER}]);
+	});
+});
+
+describe("runReap — what the trunk proves", () => {
+	it("reaps a squash-landed branch whose patch id matches a trunk commit's", async () => {
+		const {out} = await run(
+			[
+				...GROUND,
+				[once(TREES), trees(PRIMARY, {path: DEAD, head: AHEAD, branch: "build/4082-x-43cc"})],
+				[STATUS, okOut("")],
+				[ANCESTOR, errOut("exit 1")],
+				[NAMES, okOut("packages/db-schema/README.md\0")],
+				[DIFF, okOut("diff --git a/README b/README\n@@\n+a\n")],
+				[once(PATCH_ID), okOut("d18b491 0000000\n")],
+				[MERGE_BASE, okOut(`${LANDED}\n`)],
+				[LOG, okOut("commit 99ef1f6\ndiff --git a/README b/README\n@@\n+a\n")],
+				[PATCH_ID, okOut("d18b491 99ef1f6\n")],
+				[REMOVE, okOut("")],
+				[TREES, trees(PRIMARY)],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).removed).toMatchObject([{path: DEAD, license: "squashed"}]);
+	});
+
+	it("keeps a tree whose patch matches nothing on the trunk", async () => {
+		const {out, calls} = await run(
+			[
+				...GROUND,
+				[TREES, trees(PRIMARY, {path: DEAD, head: AHEAD})],
+				[STATUS, okOut("")],
+				[ANCESTOR, errOut("exit 1")],
+				[NAMES, okOut("x\0")],
+				[DIFF, okOut("diff --git a/x b/x\n@@\n+x\n")],
+				[once(PATCH_ID), okOut("ffff 0000\n")],
+				[MERGE_BASE, okOut(`${LANDED}\n`)],
+				[LOG, okOut("commit 99ef1f6\ndiff --git a/x b/x\n@@\n+y\n")],
+				[PATCH_ID, okOut("eeee 99ef1f6\n")],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "reaped", removed: []});
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+
+	it("keeps a tree whose landing read failed — UNKNOWN is never 'landed'", async () => {
+		const {out, calls} = await run(
+			[
+				...GROUND,
+				[TREES, trees(PRIMARY, {path: DEAD, head: AHEAD})],
+				[STATUS, okOut("")],
+				[ANCESTOR, errOut("exit 1")],
+				[DIFF, errOut("bad object")],
+			],
+			true,
+		);
+
+		expect(JSON.parse(out.stdout).kept).toMatchObject([{path: DEAD}]);
+		expect(out.stderr.join("\n")).toMatch(/UNKNOWN/);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+});
+
+describe("runReap — one unreadable tree costs its own row, not the sweep", () => {
+	it("keeps the tree whose status failed and still reaps the readable one", async () => {
+		const {out} = await run(
+			[
+				...GROUND,
+				[once(TREES), trees(PRIMARY, {path: DEAD}, {path: OTHER})],
+				[new RegExp(`^git -C ${DEAD} `), errOut("not a git repository")],
+				[STATUS, okOut("")],
+				[ANCESTOR, okOut("")],
+				[REMOVE, okOut("")],
+				[TREES, trees(PRIMARY, {path: DEAD})],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "reaped",
+			removed: [{path: OTHER}],
+			kept: [{path: DEAD}],
+		});
+	});
+});
+
+describe("runReap — the removals are proven, never reported", () => {
+	it("removes WITHOUT --force — ADR 0321 bans it on every path", async () => {
+		const {calls} = await run(
+			[
+				...GROUND,
+				[once(TREES), trees(PRIMARY, {path: DEAD})],
+				[STATUS, okOut("")],
+				[ANCESTOR, okOut("")],
+				[REMOVE, okOut("")],
+				[TREES, trees(PRIMARY)],
+			],
+			true,
+		);
+
+		expect(calls.filter((line) => REMOVE.test(line))).toEqual([`git worktree remove ${DEAD}`]);
+		expect(calls.some((line) => line.includes("--force"))).toBe(false);
+	});
+
+	it("reports a refused removal, leaves the tree registered, and still counts the one that went", async () => {
+		const {out} = await run(
+			[
+				...GROUND,
+				[once(TREES), trees(PRIMARY, {path: DEAD}, {path: OTHER})],
+				[STATUS, okOut("")],
+				[ANCESTOR, okOut("")],
+				[new RegExp(`^git worktree remove ${DEAD}$`), errOut("cannot remove a locked tree")],
+				[REMOVE, okOut("")],
+				[TREES, trees(PRIMARY, {path: DEAD})],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		const report = out.stderr.join("\n");
+		expect(report).toMatch(new RegExp(`FAILED to remove ${DEAD}: cannot remove a locked tree`));
+		expect(report).toMatch(new RegExp(`removed ${OTHER}`));
+	});
+
+	it("is READBACK_MISMATCH when git exits 0 and the registration survives", async () => {
+		const {out} = await run(
+			[
+				...GROUND,
+				[once(TREES), trees(PRIMARY, {path: DEAD})],
+				[STATUS, okOut("")],
+				[ANCESTOR, okOut("")],
+				[REMOVE, okOut("")],
+				[TREES, trees(PRIMARY, {path: DEAD})],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.join("\n")).toMatch(/UNPROVEN/);
+	});
+
+	it("is READBACK_MISMATCH when the registrations cannot be read back at all", async () => {
+		const {out} = await run(
+			[
+				...GROUND,
+				[once(TREES), trees(PRIMARY, {path: DEAD})],
+				[STATUS, okOut("")],
+				[ANCESTOR, okOut("")],
+				[REMOVE, okOut("")],
+				[TREES, errOut("index.lock exists")],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.join("\n")).toMatch(/NOT proven/);
+	});
+});
+
+describe("runReap — what it refuses to touch", () => {
+	it("never removes the tree this run is standing in", async () => {
+		const {out, calls} = await run(
+			[
+				...GROUND,
+				[TREES, trees(PRIMARY, {path: HERE})],
+				[STATUS, okOut("")],
+				[ANCESTOR, okOut("")],
+			],
+			true,
+		);
+
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+		expect(out.stderr.join("\n")).toMatch(/standing in/);
+	});
+
+	it("answers none — never a refusal — when no agent tree is registered", async () => {
+		const {out, calls} = await run([...GROUND, [TREES, trees(PRIMARY)]]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "none", removed: [], kept: []});
+		expect(calls.some((line) => TRUNK.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when this run cannot recognise its own tree", async () => {
+		const {out, calls} = await run([[SELF, errOut("not a git repository")]]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.some((line) => TREES.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when the registrations cannot be read", async () => {
+		const {out} = await run([
+			[SELF, here],
+			[TREES, errOut("index.lock exists")],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toMatch(/UNKNOWN/);
+	});
+
+	it("is UNKNOWN — and reaps nothing — when the trunk cannot be named", async () => {
+		const {out, calls} = await run(
+			[
+				[SELF, here],
+				[TREES, trees(PRIMARY, {path: DEAD})],
+				[TRUNK, errOut("ref refs/remotes/origin/HEAD is not a symbolic ref")],
+			],
+			true,
+		);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toMatch(/remote set-head/);
+		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/build/reap.ts
+++ b/packages/fabrika-cli/src/build/reap.ts
@@ -1,0 +1,164 @@
+/**
+ * The reclamation predicate `build reap` turns on: is this finished agent worktree provably safe to
+ * remove?
+ *
+ * Pure, and separated from the verb because the whole fail-safe rule lives here — **anything short
+ * of a positive proof is KEEP.** Dirty, locked, detached-and-unlanded, or any read that failed all
+ * answer KEEP, so a tree is removed only when three positive facts hold together: nothing
+ * uncommitted in it, no lock on it, and its HEAD already carried by the trunk.
+ *
+ * That is the opposite polarity from `./retire.ts`, and deliberately: a retirement is a *targeted*
+ * act against one number the board has spoken about, so ADR 0323 rules dirtiness out of it. A reap
+ * is a *bulk* act over trees nobody named, so it has no board statement to lean on and reads
+ * dirtiness as the strongest evidence it has that somebody is still using the tree.
+ */
+
+/** Where the harness registers a spawned agent's worktree. The one population this verb sweeps. */
+const AGENT_DIR = "/.claude/worktrees/";
+const AGENT_PREFIX = "agent-";
+
+/** Whether a registration's path is a harness-provisioned agent worktree. */
+export const isAgentWorktree = (path: string): boolean => {
+	const at = path.lastIndexOf(AGENT_DIR);
+	if (at < 0) return false;
+	const name = path.slice(at + AGENT_DIR.length).split("/")[0] ?? "";
+	return name.startsWith(AGENT_PREFIX) && name.length > AGENT_PREFIX.length;
+};
+
+/**
+ * What the trunk says about a tree's HEAD commit.
+ *
+ * The subject is the **commit**, not the branch name, because most of the leaked population holds no
+ * branch at all: the harness detaches the trees it registers, so a rule keyed on a branch would
+ * classify 52 of this clone's 74 agent trees as unjudgeable and reclaim none of them. A tree that
+ * does hold a branch has that branch's tip as its HEAD, so the branch case is the same read.
+ *
+ * `Squashed` is the case that matters: a lane branch lands as one squash commit (ADR 0048), so its
+ * own commits are never ancestors of the trunk however completely their content merged.
+ */
+export type Landing =
+	| {readonly _tag: "Ancestor"}
+	| {readonly _tag: "Squashed"; readonly commit: string}
+	/** The HEAD diverges from the trunk and adds no content to it — nothing here is only here. */
+	| {readonly _tag: "NoChange"}
+	| {readonly _tag: "Unlanded"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/** What one tree's own directory answered about uncommitted work. */
+export type Uncommitted =
+	| {readonly _tag: "Read"; readonly paths: number}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/** Everything the sweep read about one registered agent worktree. */
+export interface TreeFacts {
+	readonly path: string;
+	/** The branch it holds, or `null` when its HEAD is detached. Reported, never judged. */
+	readonly branch: string | null;
+	/** git's own lock reason, `""` when locked without one, `null` when unlocked. */
+	readonly locked: string | null;
+	/** Set when git already considers the registration stale — its directory is gone. */
+	readonly prunable: boolean;
+	readonly uncommitted: Uncommitted;
+	readonly landing: Landing;
+}
+
+/** Why a tree may be reaped. One constructor per positive proof the trunk can give. */
+export type License = "ancestor" | "squashed" | "no-change";
+
+export type Verdict =
+	| {readonly _tag: "Remove"; readonly license: License; readonly because: string}
+	| {readonly _tag: "Keep"; readonly because: string};
+
+/**
+ * Seat one tree against the trunk.
+ *
+ * The self arm comes first for `./retire.ts`'s reason: a process cannot pull the checkout out from
+ * under itself, and git would refuse one step later with a worse message. The rest is a conjunction
+ * written as a chain of refusals, so the report names the *first* reason a tree survived rather than
+ * a list a reader has to weigh.
+ */
+export const classify = (
+	facts: TreeFacts,
+	trunk: string,
+	selfPaths: ReadonlySet<string>,
+): Verdict => {
+	if (selfPaths.has(facts.path)) {
+		return {_tag: "Keep", because: "it is the tree this run is standing in"};
+	}
+	if (facts.prunable) {
+		return {
+			_tag: "Keep",
+			because:
+				"its directory is already gone, so there is no tree to remove — `git worktree prune` clears the registration",
+		};
+	}
+	if (facts.locked !== null) {
+		return {
+			_tag: "Keep",
+			because: `it is locked${facts.locked === "" ? "" : ` (${facts.locked})`}, and git refuses to remove a locked tree without --force`,
+		};
+	}
+	if (facts.landing._tag === "Unknown") {
+		return {_tag: "Keep", because: `whether its work landed is UNKNOWN: ${facts.landing.reason}`};
+	}
+	if (facts.landing._tag === "Unlanded") {
+		return {
+			_tag: "Keep",
+			because: `it carries work ${trunk} does not — no commit there matches what its HEAD adds`,
+		};
+	}
+	if (facts.uncommitted._tag === "Unknown") {
+		return {
+			_tag: "Keep",
+			because: `whether it holds uncommitted work is UNKNOWN: ${facts.uncommitted.reason}`,
+		};
+	}
+	if (facts.uncommitted.paths > 0) {
+		return {
+			_tag: "Keep",
+			because: `it holds ${facts.uncommitted.paths} uncommitted path(s), which is the only signal a bulk sweep has that somebody is still using it`,
+		};
+	}
+	return {
+		_tag: "Remove",
+		license: licenseOf(facts.landing),
+		because: whyLanded(facts.landing, trunk),
+	};
+};
+
+const licenseOf = (landing: Landing): License => {
+	switch (landing._tag) {
+		case "Ancestor":
+			return "ancestor";
+		case "Squashed":
+			return "squashed";
+		default:
+			return "no-change";
+	}
+};
+
+const whyLanded = (landing: Landing, trunk: string): string => {
+	switch (landing._tag) {
+		case "Ancestor":
+			return `it is clean, unlocked, and its HEAD is reachable from ${trunk}`;
+		case "Squashed":
+			return `it is clean, unlocked, and what its HEAD adds landed on ${trunk} as ${landing.commit}`;
+		default:
+			return `it is clean, unlocked, and its HEAD adds nothing ${trunk} does not already carry`;
+	}
+};
+
+/**
+ * The removals whose registration survived the read-back.
+ *
+ * They are reported as failures, never successes, and never folded in with the removals git itself
+ * refused: those two have different remedies, and a run that folded them would lose the one case
+ * where this clone needs a human.
+ */
+export const unprovenAmong = (
+	attempted: ReadonlyArray<string>,
+	stillRegistered: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+	const survivors = new Set(stillRegistered);
+	return attempted.filter((path) => survivors.has(path));
+};

--- a/packages/fabrika-cli/src/build/reap.unit.test.ts
+++ b/packages/fabrika-cli/src/build/reap.unit.test.ts
@@ -1,0 +1,126 @@
+import {describe, expect, it} from "vitest";
+import {classify, isAgentWorktree, type TreeFacts, unprovenAmong} from "./reap.ts";
+
+const TRUNK = "origin/main";
+const PATH = "/repo/.claude/worktrees/agent-a9bd";
+const NOBODY: ReadonlySet<string> = new Set();
+
+const facts = (over: Partial<TreeFacts> = {}): TreeFacts => ({
+	path: PATH,
+	branch: null,
+	locked: null,
+	prunable: false,
+	uncommitted: {_tag: "Read", paths: 0},
+	landing: {_tag: "Ancestor"},
+	...over,
+});
+
+describe("isAgentWorktree", () => {
+	it("admits a harness-provisioned agent tree", () => {
+		expect(isAgentWorktree("/repo/.claude/worktrees/agent-a9bd")).toBe(true);
+	});
+
+	it("refuses the primary checkout and a sibling scratch checkout", () => {
+		expect(isAgentWorktree("/repo")).toBe(false);
+		expect(isAgentWorktree("/private/tmp/phoenix-7166-build")).toBe(false);
+	});
+
+	it("refuses a worktrees sibling that is not an agent tree", () => {
+		expect(isAgentWorktree("/repo/.claude/worktrees/manual-spike")).toBe(false);
+	});
+
+	it("refuses a bare `agent-` with no name after it", () => {
+		expect(isAgentWorktree("/repo/.claude/worktrees/agent-")).toBe(false);
+	});
+
+	it("matches the directory, never a path that merely mentions it", () => {
+		expect(isAgentWorktree("/repo/docs/.claude-worktrees-agent-notes.md")).toBe(false);
+	});
+});
+
+describe("classify — the three positive proofs", () => {
+	it("removes a clean, unlocked tree whose HEAD is reachable from the trunk", () => {
+		expect(classify(facts(), TRUNK, NOBODY)).toMatchObject({_tag: "Remove", license: "ancestor"});
+	});
+
+	it("removes a tree whose work landed as a squash, naming the trunk commit that carries it", () => {
+		const verdict = classify(
+			facts({landing: {_tag: "Squashed", commit: "99ef1f6"}, branch: "build/4082-x-43cc4b51"}),
+			TRUNK,
+			NOBODY,
+		);
+		expect(verdict).toMatchObject({_tag: "Remove", license: "squashed"});
+		expect(verdict._tag === "Remove" && verdict.because).toMatch(/99ef1f6/);
+	});
+
+	it("removes a tree whose HEAD adds nothing the trunk does not already carry", () => {
+		expect(classify(facts({landing: {_tag: "NoChange"}}), TRUNK, NOBODY)).toMatchObject({
+			_tag: "Remove",
+			license: "no-change",
+		});
+	});
+});
+
+describe("classify — everything short of a proof is KEEP", () => {
+	it("keeps the tree this run is standing in, however landed and clean", () => {
+		const verdict = classify(facts(), TRUNK, new Set([PATH]));
+		expect(verdict._tag).toBe("Keep");
+		expect(verdict.because).toMatch(/standing in/);
+	});
+
+	it("keeps a locked tree and quotes git's own lock reason", () => {
+		const verdict = classify(facts({locked: "held by the harness"}), TRUNK, NOBODY);
+		expect(verdict._tag).toBe("Keep");
+		expect(verdict.because).toMatch(/held by the harness/);
+	});
+
+	it("keeps a locked tree that carries no reason", () => {
+		expect(classify(facts({locked: ""}), TRUNK, NOBODY)._tag).toBe("Keep");
+	});
+
+	it("keeps a dirty tree — the only signal a bulk sweep has that somebody is still using it", () => {
+		const verdict = classify(facts({uncommitted: {_tag: "Read", paths: 3}}), TRUNK, NOBODY);
+		expect(verdict._tag).toBe("Keep");
+		expect(verdict.because).toMatch(/3 uncommitted/);
+	});
+
+	it("keeps a tree carrying work the trunk does not", () => {
+		expect(classify(facts({landing: {_tag: "Unlanded"}}), TRUNK, NOBODY)._tag).toBe("Keep");
+	});
+
+	it("keeps a tree whose landing could not be read — UNKNOWN is never 'landed'", () => {
+		const verdict = classify(
+			facts({landing: {_tag: "Unknown", reason: "no merge base"}}),
+			TRUNK,
+			NOBODY,
+		);
+		expect(verdict._tag).toBe("Keep");
+		expect(verdict.because).toMatch(/UNKNOWN: no merge base/);
+	});
+
+	it("keeps a tree whose dirtiness could not be read — UNKNOWN is never 'clean'", () => {
+		const verdict = classify(
+			facts({uncommitted: {_tag: "Unknown", reason: "not a git repository"}}),
+			TRUNK,
+			NOBODY,
+		);
+		expect(verdict._tag).toBe("Keep");
+		expect(verdict.because).toMatch(/UNKNOWN: not a git repository/);
+	});
+
+	it("keeps a registration git already calls prunable — there is no tree to remove", () => {
+		const verdict = classify(facts({prunable: true}), TRUNK, NOBODY);
+		expect(verdict._tag).toBe("Keep");
+		expect(verdict.because).toMatch(/worktree prune/);
+	});
+});
+
+describe("unprovenAmong", () => {
+	it("names a removal whose registration survived the read-back", () => {
+		expect(unprovenAmong(["/a", "/b"], ["/b", "/repo"])).toEqual(["/b"]);
+	});
+
+	it("names none when every attempted removal is gone", () => {
+		expect(unprovenAmong(["/a", "/b"], ["/repo"])).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -14,7 +14,7 @@
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {execCapture} from "./exec.ts";
+import {execCapture, execCaptureInput} from "./exec.ts";
 
 export type Failure = {readonly _tag: "Failure"; readonly reason: string};
 export type Ok<A> = {readonly _tag: "Ok"; readonly value: A};
@@ -518,6 +518,90 @@ export const commitStatuses = (
 			dir,
 		]);
 		return r.ok ? ok(parseNameStatus(r.stdout)) : fail(r.reason);
+	});
+
+/**
+ * The trunk this clone's `origin` points its HEAD at, as a ref name (`origin/main`).
+ *
+ * Derived, never defaulted to a spelling: a clone whose `origin/HEAD` is unset answers a failure
+ * carrying git's own remedy, because guessing `origin/main` in a repo whose trunk is called
+ * something else would compare every branch against a ref that resolves to nothing.
+ */
+export const originHeadRef: Shell<Attempt<string>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+	if (!r.ok) {
+		return fail(
+			`this clone's origin/HEAD names no branch (${r.reason}) — \`git remote set-head origin -a\` sets it`,
+		);
+	}
+	const ref = r.stdout.trim();
+	return ref === "" ? fail("`git symbolic-ref` exited 0 and named no ref") : ok(ref);
+});
+
+/** One patch, and the commit git attributed it to — all-zeroes for a diff that names no commit. */
+export interface PatchIdentity {
+	readonly patch: string;
+	readonly commit: string;
+}
+
+const parsePatchIds = (stdout: string): ReadonlyArray<PatchIdentity> =>
+	stdout
+		.split("\n")
+		.map((line) => line.trim().split(/\s+/))
+		.flatMap(([patch, commit]) =>
+			patch === undefined || patch === "" ? [] : [{patch, commit: commit ?? ""}],
+		);
+
+/**
+ * The stable patch identities of a stream of diffs, read by handing the bytes to `git patch-id`.
+ *
+ * `--stable` is load-bearing: the default id depends on the order git happened to emit the file
+ * hunks in, so two runs over the same content can disagree, and a comparison across two *different*
+ * commands (a branch's own diff against a trunk commit's) would be comparing nothing.
+ *
+ * The bytes are piped in rather than shelled through a `|`, so no shell is spawned and the input is
+ * whatever the caller read — there is no second command whose flags could drift from the first's.
+ */
+export const patchIdsOf = (diffs: string): Shell<Attempt<ReadonlyArray<PatchIdentity>>> =>
+	Effect.gen(function* () {
+		if (diffs.trim() === "") return ok([]);
+		const r = yield* execCaptureInput("git", ["patch-id", "--stable"], diffs);
+		return r.ok ? ok(parsePatchIds(r.stdout)) : fail(r.reason);
+	});
+
+/**
+ * The patches the commits in `base..ref` apply to `paths`, newest first, at most `limit` of them.
+ *
+ * The pathspec is what makes the answer comparable to a branch's own net diff: limited to exactly
+ * the paths that branch touches, a squash commit's diff IS that net diff, byte for byte, so their
+ * patch ids agree. It is also what keeps the read small — an unbounded `log -p` over this repo's
+ * trunk is tens of megabytes.
+ *
+ * An empty `paths` is refused rather than widened. A pathspec that silently becomes "everything" is
+ * the same defect ADR 0092 names on the guard side: a scope nobody chose, read as an answer.
+ */
+export const patchIdsIn = (
+	base: string,
+	ref: string,
+	paths: ReadonlyArray<string>,
+	limit: number,
+): Shell<Attempt<ReadonlyArray<PatchIdentity>>> =>
+	Effect.gen(function* () {
+		if (paths.length === 0) return fail("no paths to bound the trunk scan with");
+		const log = yield* execCapture("git", [
+			"log",
+			"--no-merges",
+			"-p",
+			...DIFF_FLAGS,
+			"--format=commit %H",
+			"-n",
+			`${limit}`,
+			`${base}..${ref}`,
+			"--",
+			...paths,
+		]);
+		if (!log.ok) return fail(log.reason);
+		return yield* patchIdsOf(log.stdout);
 	});
 
 /** One commit's own unified diff, under the same config-proof flags every range read uses. */


### PR DESCRIPTION
`fabrika build reap` sweeps the worktree registrations under
`.claude/worktrees/agent-*` and classifies each KEEP or REMOVE. Nothing removed a
finished agent's worktree before this, so registrations piled up until a live
lane had to decide whether a dead checkout was a sibling holding its branch
(PR #6823).

REMOVE needs three positive proofs together: the tree holds nothing uncommitted,
it carries no lock, and its HEAD is already on the trunk. Everything else is KEEP
— dirty, locked, prunable, unlanded, and every read that failed, per tree, so one
unreadable directory costs its own row and not the sweep.

The default run mutates nothing: it prints the per-tree classification with its
reason. `--execute` removes with plain `git worktree remove`, never `--force`,
leaves a refused removal registered and reported, and reads every removal back
off a second `worktree list`.

Two things worth a reviewer's eye first:

- **The subject is the HEAD commit, not a branch.** The harness detaches the
  trees it registers — 52 of this clone's 74 agent trees hold no branch — so a
  branch-keyed rule would judge almost none of the population.
- **Squash matching is patch identity, measured rather than reasoned about.** A
  lane branch lands as one squash commit, so its own commits are never ancestors
  of the trunk. The verb compares the patch id of what the HEAD adds against the
  trunk's own patches over exactly those paths. On
  `build/4082-db-schema-readme-diataxis-43cc4b51` both are
  `d18b491a48c861494a35740f571a90a45b596aae`. A live dry run over this clone
  scanned 75 registrations in 25s and classified 34 removable; one spot-check
  matched a detached tree's HEAD `afdb732` to trunk commit `e4992d6`, its own
  squash.

Fixes #6833

## Deviations

- **Out-of-scope change** — **Said:** #6833's criteria phrase the reachability
  test as "the checked-out branch's commits reachable from `origin/main`".
  **Did:** tested the tree's **HEAD commit** instead, which covers a detached
  tree too. **Why:** the harness detaches the trees it registers, so a strictly
  branch-keyed rule would classify 52 of this clone's 74 agent trees as
  unjudgeable and reclaim almost none of the leak the issue is about; a
  branch-holding tree's branch tip is its HEAD, so the criterion's own case is
  unchanged. **Disposition:** stated here.
- **Scope narrowing** — **Said:** classify every registration KEEP or REMOVE.
  **Did:** a registration git already calls `prunable` is always KEEP, with
  `git worktree prune` named as its remedy. **Why:** its directory is gone, so
  there is no tree to remove, and running `prune` would be a mutation on the
  path the issue requires to mutate nothing. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about the trunk being
  current. **Did:** the verb reads the local `origin/HEAD` and never fetches.
  **Why:** a fetch writes this clone's remote-tracking refs, which a dry run
  advertised as mutating nothing may not do. A stale trunk only makes trees look
  unlanded, which is the KEEP direction, and the answer names the trunk ref it
  used. **Disposition:** stated here.
