### PR TITLE
fix: Epic integration checks run before new dependencies are installed

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -56,6 +56,14 @@
 		{ "command": ["pnpm", "lint:worktree"] }
 	],
 
+	// The install that reconciles a tree with the lockfile it carries. `fabrika lane integrate` runs
+	// it in the epic run's assembly worktree after a clean child merge and before the validators
+	// above, so they compile against the merged lockfile rather than the install the worktree was
+	// placed with (#7188). `--frozen-lockfile` is pnpm's fail-closed flag: an install that cannot
+	// honor the merged lockfile refuses instead of rewriting it, and the integration reads that as
+	// a FAIL.
+	"dependencyReconciler": { "command": ["pnpm", "install", "--frozen-lockfile"] },
+
 	// The repo's own commands that machine-read `.github/workflows/**`. `fabrika build check
 	// --surface workflows` runs each one over a workflows-touching diff, on top of `actionlint` when
 	// the tree has one (#5991), and `reads` names the exact workflow files that command opens — the

--- a/.fabrika.schema.json
+++ b/.fabrika.schema.json
@@ -177,6 +177,27 @@
 			"minLength": 1,
 			"pattern": "^(?!/)(?!\\.\\.).+"
 		},
+		"dependencyReconciler": {
+			"type": [
+				"object",
+				"null"
+			],
+			"description": "The repo's command that installs what its lockfile pins — `lane integrate` runs it in the assembly worktree after a clean child merge, before the code validators. Absent or null runs no install.",
+			"properties": {
+				"command": {
+					"type": "array",
+					"description": "The argv to spawn — e.g. [\"pnpm\", \"install\", \"--frozen-lockfile\"].",
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1
+				}
+			},
+			"required": [
+				"command"
+			],
+			"additionalProperties": false
+		},
 		"designHarness": {
 			"type": "string",
 			"description": "The design-harness file declaring the dev server `ui render` renders at, repo-relative.",

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -259,9 +259,11 @@ The verb is the merge and its whole verdict, so there is no hand-rolled `git mer
 children's ranges indistinguishable in the history the epic reviewer reads — and then judges the
 merged tree with the same commands every child's `build check --surface code` ran in its own
 worktree, run once over the assembly. Exit `0` prints the merged head with
-`INTEGRATE-VERDICT: MERGED` under it, and that is the `DONE` route; every other exit is the `FAIL`
-that re-enters `build` under the retry budget, which is why a cross-child collision resolves inside
-this run instead of at a merge queue.
+`INTEGRATE-VERDICT: MERGED` under it. Which event each exit is, is single-homed in
+[§3](#3--verify-the-record-landed-and-record-what-no-shell-can)'s `integrate` row and nowhere else —
+read it there rather than from this paragraph. Only `42`, `43` and `44` are the `FAIL` that re-enters
+`build` under the retry budget, which is why a cross-child collision resolves inside this run instead
+of at a merge queue.
 
 **Between the merge and those checks it reconciles the merged tree's dependencies**, running the
 repo's declared `dependencyReconciler` — in phoenix `pnpm install --frozen-lockfile` — in the
@@ -276,8 +278,9 @@ install that cannot honour the merged lockfile is exit `43` and a `FAIL`, and so
 Read which `FAIL` you have off the exit code, because they take different repairs: `42` the child
 conflicts and nothing was installed, `43` the merged lockfile does not install or the install
 changed a tracked file, `44` the merged tree failed a validator — the semantic collision, two ranges
-that each passed alone and do not hold together. `11` is UNKNOWN, never a `FAIL`: something on the
-path could not be read and the tree was never judged.
+that each passed alone and do not hold together. Those three are the whole `FAIL` set: they are the
+only exits that judge the merged tree, and every other one says something about the lane record, the
+worktrees or this checkout, which is never the child's to repair.
 
 **The assembly branch moves only on a `DONE`, and the verb is what keeps it there.** Every refusal
 below the merge resets the branch through `ORIG_HEAD` in the tree the merge happened in and reads
@@ -601,10 +604,29 @@ entered `build` — the artifact the builder's terminal names, read off the issu
 the report. An epic child's `BUILT-NO-PR` is the other proven `DONE` without a PR, and its artifact
 is the range's own commits — a child opens no PR to prove one against (#6019).
 
-**An `integrate` has no spawn to report**, so its row is `lane integrate`'s own exit: `0`, whose
-last stdout line is `INTEGRATE-VERDICT: MERGED`, is `DONE`; `42`, `43` and `44` are `FAIL`; `8` and
-`11` are UNKNOWN and end `STOPPED` naming the code. `lane prove` answers `not-required` for both
-recorded events — a `DONE` out of `integrate` claims
+**An `integrate` has no spawn to report**, so its row is `lane integrate`'s own exit, and this table
+is the one home for that mapping — the verb exits twelve ways and every one is here, so there is no
+code left over for a catch-all to guess at:
+
+| Exit | What it says | Record |
+| --- | --- | --- |
+| `0` | the merged tree holds — the last stdout line is `INTEGRATE-VERDICT: MERGED`, the line above it the merged head | `DONE` |
+| `42` | the child conflicts; the merge was aborted | `FAIL` |
+| `43` | the merged lockfile does not install, the reconciler could not be run, or it changed a tracked file | `FAIL` |
+| `44` | the merged tree failed a code validator | `FAIL` |
+| `4` · `7` · `8` · `11` · `22` · `33` · `39` · `41` | the lane record, the branch you passed, the worktrees or this checkout — never the merged tree | record **nothing** — end `STOPPED` naming the code |
+
+The bottom row is the whole reason this table is closed. Only `42`/`43`/`44` judge the child's
+content, so only those three may spend its retry budget; a `41` (no tree holds `epic/<n>`, placed
+with `lane assembly`), a `33` (the main checkout is standing on that branch) or a `22` (a `--child`
+branch that is not this repo's, so not the one `lane prove` printed) is the driver's own state, and
+recording a `FAIL` for it sends a child that is fine back through `build` — the exact harm
+[#7188](https://github.com/kamp-us/phoenix/issues/7188) exists to stop. `4` keeps the ruling
+[§1](#1--claim-the-lane-then-boot-or-resume) already gave it — a record read in full and not the
+shape, whose remedy is not `11`'s and not yours to guess — and `7` says no lane is there at all,
+which is a ledger to emit, not a child to send back.
+
+`lane prove` answers `not-required` for both recorded events — a `DONE` out of `integrate` claims
 no artifact a read could falsify — so it is still run and still gates the record.
 
 **Still binding** is one rule read against whichever artifact the subject has: on a PR, a verdict at

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -251,21 +251,39 @@ it by the path `lane assembly` just printed — never by switching the tree you 
 
 ```bash
 node <fabrika> lane assembly $lane_key
-git -C <the path it printed> merge --no-ff <evidence.branch>
+node <fabrika> lane integrate <epic> --child <evidence.branch>
 ```
 
-`--no-ff` because each landing should be one commit a reader can name; a fast-forward would leave
-two children's ranges indistinguishable in the history the epic reviewer reads. A conflict is the
-`FAIL` that re-enters `build` under the retry budget — that route is why a cross-child collision
-resolves inside this run instead of at a merge queue. A clean merge is only half the answer: the
-**semantic** collision is two ranges that each passed alone and do not hold together, and it reads
-as the merged tree failing the repo's own checks — the same commands every child's `build check
---surface code` ran in its worktree, now run once over the assembly, in the assembly worktree. Non-zero there is the same `FAIL`.
+The verb is the merge and its whole verdict, so there is no hand-rolled `git merge` here: it merges
+`--no-ff` — each landing is one commit a reader can name, where a fast-forward would leave two
+children's ranges indistinguishable in the history the epic reviewer reads — and then judges the
+merged tree with the same commands every child's `build check --surface code` ran in its own
+worktree, run once over the assembly. Exit `0` prints the merged head with
+`INTEGRATE-VERDICT: MERGED` under it, and that is the `DONE` route; every other exit is the `FAIL`
+that re-enters `build` under the retry budget, which is why a cross-child collision resolves inside
+this run instead of at a merge queue.
 
-**The assembly branch moves only on a `DONE`.** On either `FAIL`, put it back where it was, in the
-same tree the merge happened in — `git -C <assembly path> merge --abort` on a conflict,
-`git -C <assembly path> reset --hard ORIG_HEAD` on a clean merge the checks refused
-— so the recorded `FAIL` names a branch that never carried the bad merge. The repair builder is
+**Between the merge and those checks it reconciles the merged tree's dependencies**, running the
+repo's declared `dependencyReconciler` — in phoenix `pnpm install --frozen-lockfile` — in the
+assembly worktree. That step is not housekeeping: the worktree was placed before the child existed,
+so a child adding a workspace package leaves the tree installed against the pre-merge lockfile, and
+child #7162 failed `pnpm typecheck --force` with a missing type definition on a tree whose code was
+fine, spending a lane retry on stale worktree state
+([#7188](https://github.com/kamp-us/phoenix/issues/7188)). It stays fail-closed at both ends: an
+install that cannot honour the merged lockfile is exit `43` and a `FAIL`, and so is one that
+*rewrites* it, because an assembly branch never carries an install's own repair.
+
+Read which `FAIL` you have off the exit code, because they take different repairs: `42` the child
+conflicts and nothing was installed, `43` the merged lockfile does not install or the install
+changed a tracked file, `44` the merged tree failed a validator — the semantic collision, two ranges
+that each passed alone and do not hold together. `11` is UNKNOWN, never a `FAIL`: something on the
+path could not be read and the tree was never judged.
+
+**The assembly branch moves only on a `DONE`, and the verb is what keeps it there.** Every refusal
+below the merge resets the branch through `ORIG_HEAD` in the tree the merge happened in and reads
+its head back before answering, and a conflict is aborted the same way — so the recorded `FAIL`
+names a branch that never carried the bad merge, and an exit `8` means that restore did not take and
+nothing may be recorded against the tree at all. The repair builder is
 then the machine's own route out of `build`, and `lane brief` hands it both ranges: the child's
 issue, and the assembly branch, which by now carries every sibling that landed before it. Nothing
 reaches `landed` except back through `review`, because the resolution changes the content the
@@ -583,9 +601,10 @@ entered `build` — the artifact the builder's terminal names, read off the issu
 the report. An epic child's `BUILT-NO-PR` is the other proven `DONE` without a PR, and its artifact
 is the range's own commits — a child opens no PR to prove one against (#6019).
 
-**An `integrate` has no spawn to report**, so its row is the merge's own exit folded by the two
-rules step 2 named: a clean merge whose post-merge checks pass is `DONE`; a conflict, or a red
-check, is `FAIL`. `lane prove` answers `not-required` for both — a `DONE` out of `integrate` claims
+**An `integrate` has no spawn to report**, so its row is `lane integrate`'s own exit: `0`, whose
+last stdout line is `INTEGRATE-VERDICT: MERGED`, is `DONE`; `42`, `43` and `44` are `FAIL`; `8` and
+`11` are UNKNOWN and end `STOPPED` naming the code. `lane prove` answers `not-required` for both
+recorded events — a `DONE` out of `integrate` claims
 no artifact a read could falsify — so it is still run and still gates the record.
 
 **Still binding** is one rule read against whichever artifact the subject has: on a PR, a verdict at

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -576,6 +576,7 @@ snapshot. Lane state is local and never committed.
 | `lane open` / `emit` | boot a lane from a committed template, or generate an epic's machine from its board topology |
 | `lane brief` | the spawn prompt for one task's current leaf state |
 | `lane assembly` / `push` | an epic run's assembly worktree, and its published branch |
+| `lane integrate` | one reviewed child merged into that worktree, its dependencies reconciled from the merged lockfile, then judged by the repo's `codeValidators` — last stdout line on exit 0 is `INTEGRATE-VERDICT: MERGED`, the line above it the merged head; every refusal below the merge resets the branch to `ORIG_HEAD` and pushes nothing |
 | `lane stale` | which lanes have gone quiet with something owed on them — offline, or `--claims` to pair each non-terminal lane with the claim standing on its issue |
 | `lane claim` / `release` | who is driving this lane |
 
@@ -590,7 +591,13 @@ be resolved · `20` several open PRs claim the task's issue · `21` the lane key
 tree is not on the run's assembly branch · `29` the push would not fast-forward · `30` the push ran
 and the ref did not move · `31` this session does not hold the driver's claim · `32` the terminal
 token is no shell's · `33` an assembly git write was aimed at the main working tree · `34` the
-assembly branch tracks another ref and clearing that upstream did not take.
+assembly branch tracks another ref and clearing that upstream did not take · `35` the `--cause` is
+outside the closed park-cause set · `36` the `UNBLOCKED` would restore a state with no budget left
+· `37` a booted lane's machine cannot be replaced by the template without moving the lane · `38`
+the `--class` is outside the review classes · `39` the cwd is not in a repository · `40` another
+writer held the lane's lock for the whole wait · `41` no working tree holds the run's assembly
+branch · `42` the child conflicts and the merge was aborted · `43` the merged lockfile does not
+install, or the install changed a tracked file · `44` the merged tree failed a code validator.
 
 To open a lane, copy a template in and speak the operator's six events — `DONE` / `PASS` / `FAIL` /
 `BLOCKED` / `WIP` / `UNBLOCKED`:

--- a/packages/fabrika-cli/src/config/keys/dependency-reconciler.ts
+++ b/packages/fabrika-cli/src/config/keys/dependency-reconciler.ts
@@ -1,0 +1,67 @@
+/**
+ * `dependencyReconciler` — the repo's own command that installs what its lockfile pins.
+ *
+ * An epic's assembly worktree is placed once and merged into many times. A child that adds a
+ * workspace package moves the lockfile, and the tree's installed dependencies still predate it, so
+ * the validators that run next compile against the pre-merge install: child #7162's merge failed
+ * `pnpm typecheck --force` with `TS2688: Cannot find type definition file for 'node'` and passed all
+ * 22 typechecks after an install, with no source or lockfile change (#7188).
+ *
+ * Declared rather than compiled in, for the reason `codeValidators` is: the command is the repo's
+ * package manager and its own fail-closed flag — `--frozen-lockfile` is pnpm's, and a repo on
+ * another manager spells the same intent differently. Same `command` argv grammar, so the file has
+ * one shape for "a command fabrika spawns".
+ *
+ * **The shipped default is nothing declared, and nothing declared skips the step.** Unlike a
+ * validator's absence, which refuses UNKNOWN because a green would claim the code was checked, an
+ * absent reconciler claims nothing: a repo that vendors no dependencies has no install to run, and
+ * refusing every epic integration in it would be a fence around an empty field. What phoenix
+ * declares is the whole guarantee for phoenix.
+ */
+
+import {isRecord} from "../../io/json.ts";
+import {trimmedStrings} from "../entries.ts";
+import type {Decoded, KeyGroup} from "../key-group.ts";
+import type {Argv} from "./workflow-validators.ts";
+
+export const DEPENDENCY_RECONCILER = "dependencyReconciler";
+
+/** The declared install, or `null` when the repo declares none. */
+export type DependencyReconciler = {readonly argv: Argv} | null;
+
+const MALFORMED = `\`${DEPENDENCY_RECONCILER}\` is not {"command": [non-empty argv of strings]} — e.g. {"command": ["pnpm", "install", "--frozen-lockfile"]}`;
+
+const decode = (raw: unknown): Decoded<DependencyReconciler> => {
+	if (raw === null) return {_tag: "Value", value: null};
+	if (!isRecord(raw)) return {_tag: "Malformed", reason: MALFORMED};
+	const command = trimmedStrings(raw.command);
+	if (command === null) return {_tag: "Malformed", reason: MALFORMED};
+	const [binary, ...args] = command;
+	if (binary === undefined) return {_tag: "Malformed", reason: MALFORMED};
+	return {_tag: "Value", value: {argv: [binary, ...args]}};
+};
+
+export const SHIPPED_DEPENDENCY_RECONCILER: DependencyReconciler = null;
+
+export const dependencyReconcilerKey: KeyGroup<DependencyReconciler> = {
+	key: DEPENDENCY_RECONCILER,
+	shippedDefault: SHIPPED_DEPENDENCY_RECONCILER,
+	decode,
+	// `argv` is the spawn shape; the file's key is `command`, and a readout prints what the repo wrote.
+	render: (reconciler) => (reconciler === null ? null : {command: [...reconciler.argv]}),
+	jsonSchema: {
+		type: ["object", "null"],
+		description:
+			"The repo's command that installs what its lockfile pins — `lane integrate` runs it in the assembly worktree after a clean child merge, before the code validators. Absent or null runs no install.",
+		properties: {
+			command: {
+				type: "array",
+				description: 'The argv to spawn — e.g. ["pnpm", "install", "--frozen-lockfile"].',
+				items: {type: "string"},
+				minItems: 1,
+			},
+		},
+		required: ["command"],
+		additionalProperties: false,
+	},
+};

--- a/packages/fabrika-cli/src/config/keys/dependency-reconciler.unit.test.ts
+++ b/packages/fabrika-cli/src/config/keys/dependency-reconciler.unit.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from "vitest";
+import {dependencyReconcilerKey, SHIPPED_DEPENDENCY_RECONCILER} from "./dependency-reconciler.ts";
+
+const decode = (raw: unknown) => dependencyReconcilerKey.decode(raw);
+
+describe("dependencyReconciler", () => {
+	it("decodes a declared install to the argv the verb spawns", () => {
+		expect(decode({command: ["pnpm", "install", "--frozen-lockfile"]})).toEqual({
+			_tag: "Value",
+			value: {argv: ["pnpm", "install", "--frozen-lockfile"]},
+		});
+	});
+
+	it("reads an explicit null as `this repo has no install to run`", () => {
+		expect(decode(null)).toEqual({_tag: "Value", value: null});
+	});
+
+	it("ships nothing declared, so an absent key runs no install", () => {
+		expect(SHIPPED_DEPENDENCY_RECONCILER).toBe(null);
+	});
+
+	for (const raw of [{}, {command: []}, {command: "pnpm install"}, {command: ["  "]}, [], "pnpm"]) {
+		it(`refuses ${JSON.stringify(raw)} whole rather than spawning part of it`, () => {
+			expect(decode(raw)._tag).toBe("Malformed");
+		});
+	}
+
+	it("renders back the shape a repo writes, not the shape the verb holds", () => {
+		expect(dependencyReconcilerKey.render?.({argv: ["pnpm", "install"]})).toEqual({
+			command: ["pnpm", "install"],
+		});
+		expect(dependencyReconcilerKey.render?.(null)).toBe(null);
+	});
+});

--- a/packages/fabrika-cli/src/config/registry.ts
+++ b/packages/fabrika-cli/src/config/registry.ts
@@ -14,6 +14,7 @@ import {ciKey} from "./keys/ci.ts";
 import {codeValidatorsKey} from "./keys/code-validators.ts";
 import {containmentVocabularyKey} from "./keys/containment-vocabulary.ts";
 import {unreadableCodeownersKey} from "./keys/control-plane.ts";
+import {dependencyReconcilerKey} from "./keys/dependency-reconciler.ts";
 import {docLeakExemptKey} from "./keys/doc-leak-exempt.ts";
 import {governedRootsKey} from "./keys/governed-roots.ts";
 import {cycleDocKey, decisionsDirKey, designHarnessKey, roadmapFileKey} from "./keys/paths.ts";
@@ -30,6 +31,7 @@ export const KEY_GROUPS: ReadonlyArray<Registration> = [
 	register(containmentVocabularyKey),
 	register(cycleDocKey),
 	register(decisionsDirKey),
+	register(dependencyReconcilerKey),
 	register(designHarnessKey),
 	register(docLeakExemptKey),
 	register(governedRootsKey),

--- a/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
@@ -49,7 +49,7 @@ describe("reconcile", () => {
 	it("agrees when the committed file matches the assembled schema", () => {
 		const {outcome} = run({write: false, read: {_tag: "Text", text: committed}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\tagrees\t16");
+		expect(outcome.stdout).toContain("schema\tagrees\t17");
 	});
 
 	it("agrees whatever the committed file's whitespace, comparing content not bytes", () => {
@@ -87,7 +87,7 @@ describe("write", () => {
 	it("renders the file from the registry and reports written", () => {
 		const {outcome, saves} = run({write: true, read: {_tag: "Absent"}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\twritten\t16");
+		expect(outcome.stdout).toContain("schema\twritten\t17");
 		expect(saves).toHaveLength(1);
 		expect(saves[0]).toBe(committed);
 	});

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -199,6 +199,15 @@ export interface FakeShell {
 	 * file-free carrying path would be untestable at this seam (#5484).
 	 */
 	readonly inputs: ReadonlyArray<string>;
+	/**
+	 * The directory each spawn was given, aligned with {@link FakeShell.calls}; `null` when it
+	 * inherited the process's own.
+	 *
+	 * Without it, a command run in another tree is indistinguishable from the same command run here
+	 * — the argv is identical either way — so "the install ran in the assembly worktree" would be a
+	 * claim no test could hold (#7188).
+	 */
+	readonly cwds: ReadonlyArray<string | null>;
 }
 
 /** The bytes a command's `stdin` option carries, decoded; `""` for a mode string or no option. */
@@ -237,6 +246,7 @@ export const fakeShell = (
 ): FakeShell => {
 	const calls: string[] = [];
 	const inputs: string[] = [];
+	const cwds: Array<string | null> = [];
 	const layer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
 		ChildProcessSpawner.make(
 			Effect.fnUntraced(function* (command) {
@@ -246,6 +256,9 @@ export const fakeShell = (
 					cmd._tag === "StandardCommand" ? [cmd.command, ...cmd.args].join(" ") : "<piped>";
 				calls.push(line);
 				log.push(line);
+				cwds.push(
+					(cmd._tag === "StandardCommand" ? cmd.options.cwd : undefined) ?? (null as string | null),
+				);
 				inputs.push(
 					yield* pipedInput(cmd._tag === "StandardCommand" ? cmd.options.stdin : undefined),
 				);
@@ -275,7 +288,7 @@ export const fakeShell = (
 			}),
 		),
 	);
-	return {layer, calls, inputs};
+	return {layer, calls, inputs, cwds};
 };
 
 /**

--- a/packages/fabrika-cli/src/io/exec.ts
+++ b/packages/fabrika-cli/src/io/exec.ts
@@ -241,10 +241,15 @@ export type ExecStatus =
 export const execStatus = (
 	file: string,
 	args: ReadonlyArray<string>,
+	/** Where to run it; omitted, the child inherits this process's directory. */
+	cwd?: string,
 ): Effect.Effect<ExecStatus, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.scoped(
 		Effect.gen(function* () {
-			const handle = yield* ChildProcess.make(file, [...args]);
+			const handle =
+				cwd === undefined
+					? yield* ChildProcess.make(file, [...args])
+					: yield* ChildProcess.make(file, [...args], {cwd});
 			const [stdout, stderr, exitCode] = yield* Effect.all(
 				[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
 				{concurrency: "unbounded"},

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -295,3 +295,43 @@ export const NOT_A_REPO = 39;
  * the code is what lets a shell tell "retry me" from "rethink me" without parsing prose.
  */
 export const CONCURRENT_WRITE = 40;
+
+/**
+ * No working tree holds the run's assembly branch, so there is nowhere to merge a child into. A
+ * proven absence, not an unreadable one: the working trees were listed and none of them is on
+ * `epic/<n>`. Its own seat rather than {@link LANE_ABSENT}'s — the lane record is fine and the
+ * remedy is `lane assembly`, which places the tree back.
+ */
+export const ASSEMBLY_UNSEATED = 41;
+
+/**
+ * The child's range does not merge into the assembly: git left conflicts, and the merge was aborted
+ * with the branch back where it started. The one integration refusal that reaches no merged tree at
+ * all, which is why nothing was installed and no validator ran.
+ *
+ * Its own seat rather than {@link ASSEMBLY_RED}'s: a conflict is two ranges disagreeing on the same
+ * lines, and the repair builder resolves it; a red is two ranges that merged cleanly and do not hold
+ * together.
+ */
+export const MERGE_CONFLICT = 42;
+
+/**
+ * The merged tree's dependencies could not be reconciled from its own lockfile: the declared
+ * `dependencyReconciler` exited non-zero, could not be executed at all, or ran and left a tracked
+ * file changed. The clean merge is reset and the assembly branch is unpublished either way.
+ *
+ * All three are one seat because they take one remedy — the child's dependency declaration is what
+ * has to change — and none of them is a claim about the code: no validator ran, so the merged tree
+ * was never judged. A reconciliation that rewrites the lockfile is a refusal rather than a repair
+ * the assembly quietly carries (#7188).
+ */
+export const RECONCILE_REFUSED = 43;
+
+/**
+ * The merged tree failed the repo's own code validators — the semantic collision an epic run exists
+ * to catch: two ranges that each passed alone and do not hold together. Proven red, on a tree whose
+ * dependencies were reconciled first, so it is the code that failed and not the install.
+ *
+ * The clean merge is reset, so the recorded `FAIL` names a branch that never carried it.
+ */
+export const ASSEMBLY_RED = 44;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -22,6 +22,7 @@ import {CLASS_UNRECOGNISED} from "./codes.ts";
 import {runEmit} from "./emit-verb.ts";
 import {deriveRepoRoot, onGround, repoGroundRefusal} from "./ground.ts";
 import {runHistory} from "./history-verb.ts";
+import {runIntegrate} from "./integrate-verb.ts";
 import {defaultRoot, type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
 import {runMigrate} from "./migrate-verb.ts";
 import {runOpen} from "./open-verb.ts";
@@ -426,6 +427,44 @@ const assembly = leafCommand(
 	),
 );
 
+const integrate = leafCommand(
+	"integrate",
+	{
+		epic: Argument.integer("epic").pipe(
+			Argument.withDescription("the epic issue whose run owns the assembly branch"),
+		),
+		child: Flag.string("child").pipe(
+			Flag.withDescription(
+				"the child's branch to land, taken off `lane prove`'s PASS evidence (`evidence.branch`)",
+			),
+		),
+		root: rootFlag,
+	},
+	Effect.fn(function* ({epic, child, root}) {
+		const resolvedRoot = yield* resolveRootOrRefuse(
+			"fabrika lane integrate",
+			root,
+			DEFAULT_LANES_ROOT,
+		);
+		if (typeof resolvedRoot !== "string") {
+			yield* emit(resolvedRoot);
+			return;
+		}
+		yield* emit(
+			yield* onGround("integrate", [resolvedRoot], process.cwd(), () =>
+				runIntegrate({epic, child, root: resolvedRoot, lane: String(epic)}),
+			),
+		);
+	}),
+).pipe(
+	Command.withShortDescription(
+		"Merge one reviewed child into an epic run's assembly and prove it holds.",
+	),
+	Command.withDescription(
+		"Merge one reviewed child's branch into the epic run's assembly worktree — `epic/<n>` at the path `lane assembly` placed, both derived from the epic number and never taken from the caller — and prove the merged tree holds together before the branch keeps it. The order is the verb: `git merge --no-ff`, then the repo's declared `dependencyReconciler` (in phoenix `pnpm install --frozen-lockfile`) run IN that worktree so the install reads the lockfile the merge just brought, then the repo's declared `codeValidators` over the merged tree. Reconciling after the merge is the whole point: an assembly worktree placed before a child existed still holds the pre-merge install, so a child that adds a workspace package failed `pnpm typecheck --force` with a missing type definition on a tree whose code was fine, and spent a lane retry on stale worktree state (#7188). Every refusal below the merge resets the assembly branch to ORIG_HEAD and reads its head back, so a recorded FAIL names a branch that never carried the bad merge; nothing is ever pushed here — that is `lane push`, and recording the DONE is the driver's. On exit 0 the last stdout line is always `INTEGRATE-VERDICT: MERGED` and the line above it the merged head. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there — emit the run's machine first), 8 (a restore or a head read-back did not land — UNKNOWN, so nothing may be recorded), 11 (the working trees, the branches, the head, `.fabrika.jsonc` or a validator could not be read, or the repo declares no `codeValidators` — UNKNOWN, never green), 22 (no branch by that name — take it off `lane prove`'s evidence), 33 (`epic/<n>` is checked out in the main working tree), 41 (no working tree holds `epic/<n>` — place it with `lane assembly`), 42 (the child conflicts; the merge was aborted and nothing was installed), 43 (the merged lockfile does not install, the reconciler could not be run, or it changed a tracked file), 44 (the merged tree failed a code validator — the semantic collision), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default lanes root). Example: fabrika lane integrate 7140 --child build/7162-tuval-bootstrap-5558c9a2",
+	),
+);
+
 const pushLane = leafCommand(
 	"push",
 	{
@@ -749,6 +788,7 @@ export const laneCommand = Command.make("lane").pipe(
 		emitLane,
 		brief,
 		assembly,
+		integrate,
 		pushLane,
 		stale,
 		migrate,

--- a/packages/fabrika-cli/src/lane/integrate-verb.ts
+++ b/packages/fabrika-cli/src/lane/integrate-verb.ts
@@ -1,0 +1,358 @@
+/**
+ * `lane integrate` — land one reviewed child on an epic run's assembly branch, and prove the merged
+ * tree holds together before the branch keeps it.
+ *
+ * The order is the whole verb: merge, reconcile the merged tree's dependencies from the lockfile it
+ * now carries, then run the repo's code validators. Reversing the middle two steps is what #7162 hit
+ * — an assembly worktree placed before the child existed still had the pre-merge install, so
+ * `pnpm typecheck --force` failed with `TS2688` on a tree whose code was fine, and a valid child
+ * spent a lane retry on stale worktree state. Every refusal below the merge resets the branch
+ * through `ORIG_HEAD`, so a recorded `FAIL` names a branch that never carried the bad merge.
+ *
+ * On exit 0 the last stdout line is always `INTEGRATE-VERDICT: MERGED`, the line above it the merged
+ * head. Publishing that head is `lane push`'s and recording the `DONE` is the driver's: this verb
+ * neither pushes nor writes the lane's log, so its answer is a fact about a tree and nothing else.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {CONFIG_PATH} from "../config/document.ts";
+import {
+	CODE_VALIDATORS,
+	type CodeValidator,
+	codeValidatorsKey,
+} from "../config/keys/code-validators.ts";
+import {
+	DEPENDENCY_RECONCILER,
+	type DependencyReconciler,
+	dependencyReconcilerKey,
+} from "../config/keys/dependency-reconciler.ts";
+import {loadConfig, resolve} from "../config/load.ts";
+import {readConfigSource} from "../config/source.ts";
+import {execCapture, execStatus} from "../io/exec.ts";
+import {localBranches} from "../io/git.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {epicBranch} from "../wire/lane-brief.ts";
+import {assemblySeat, worktrees} from "./assembly.ts";
+import {
+	APPEND_UNKNOWN,
+	ASSEMBLY_RED,
+	ASSEMBLY_UNSEATED,
+	LANE_UNREADABLE,
+	MERGE_CONFLICT,
+	PRIMARY_CHECKOUT,
+	PROOF_ABSENT,
+	RECONCILE_REFUSED,
+} from "./codes.ts";
+import {loadRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane integrate";
+
+export interface IntegrateOptions extends LaneRef {
+	readonly epic: number;
+	/** The child's branch, taken off `lane prove`'s PASS evidence — never a name the caller composed. */
+	readonly child: string;
+}
+
+/** Diagnostics are the child's own; 40 lines is what a refusal can carry without burying its reason. */
+const DIAGNOSTIC_LINES = 40;
+
+const diagnostics = (output: string): ReadonlyArray<string> => {
+	const lines = output.split("\n").filter((line) => line.trim() !== "");
+	return lines.length <= DIAGNOSTIC_LINES
+		? lines
+		: [
+				...lines.slice(0, DIAGNOSTIC_LINES),
+				`… ${lines.length - DIAGNOSTIC_LINES} more line(s); re-run the command itself for the rest.`,
+			];
+};
+
+const headOf = (path: string) =>
+	Effect.map(execCapture("git", ["-C", path, "rev-parse", "HEAD"]), (read) =>
+		read.ok
+			? ({_tag: "Read", sha: read.stdout.trim()} as const)
+			: ({_tag: "Unreadable", reason: read.reason} as const),
+	);
+
+/**
+ * Put the assembly branch back where the merge found it, and prove it went.
+ *
+ * `reset --hard ORIG_HEAD` is the move; the re-read of HEAD against the sha captured before the
+ * merge is what makes it an answer rather than a claim. A branch that will not go back is UNKNOWN,
+ * never a plain `FAIL` — it may still carry the merge no verdict admits.
+ */
+const restore = (
+	path: string,
+	head: string,
+	outcome: VerbOutcome,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const reset = yield* execCapture("git", ["-C", path, "reset", "--hard", "ORIG_HEAD"]);
+		const after = yield* headOf(path);
+		if (after._tag === "Unreadable") {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${VERB}: reset ${path} to ORIG_HEAD and cannot re-read its HEAD: ${after.reason} — whether the assembly branch still carries the merge is UNKNOWN.`,
+				outcome.stderr,
+			);
+		}
+		if (after.sha !== head) {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${VERB}: ${path} is at ${after.sha}, not the pre-merge ${head}${reset.ok ? "" : `: ${reset.reason}`} — the assembly branch still carries the merge; it was NOT restored.`,
+				outcome.stderr,
+			);
+		}
+		return {
+			...outcome,
+			stderr: [...outcome.stderr, `${VERB}: reset ${path} back to ${head}; nothing was pushed.`],
+		};
+	});
+
+type ReconcileOutcome =
+	| {readonly _tag: "Reconciled"; readonly note: string}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/**
+ * Install what the merged lockfile pins, then prove the install changed no tracked file.
+ *
+ * The second half is the fail-closed half: a reconciliation that rewrites the lockfile has repaired
+ * the child's declaration rather than honoured it, and an assembly branch must never carry that
+ * repair (#7188). A repo declaring no reconciler has no install to run and is not refused — see
+ * `config/keys/dependency-reconciler.ts`.
+ */
+const reconcile = (
+	path: string,
+	declared: DependencyReconciler,
+): Effect.Effect<ReconcileOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		if (declared === null) {
+			return {
+				_tag: "Reconciled" as const,
+				note: `${VERB}: ${CONFIG_PATH} declares no \`${DEPENDENCY_RECONCILER}\` — no install to run, so the merged tree's dependencies are whatever it already had.`,
+			};
+		}
+		const label = declared.argv.join(" ");
+		const [binary, ...args] = declared.argv;
+		const ran = yield* execStatus(binary, args, path);
+		if (ran._tag === "Unstartable") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					RECONCILE_REFUSED,
+					`${VERB}: ${label} could not be executed in ${path}: ${ran.reason} — the merged tree's dependencies are still the pre-merge ones, so nothing it compiles would be about the merge.`,
+				),
+			};
+		}
+		if (!ran.ok) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					RECONCILE_REFUSED,
+					`${VERB}: ${label} failed in ${path} — the merged lockfile does not install; diagnostics above.`,
+					diagnostics(ran.output),
+				),
+			};
+		}
+		// `--untracked-files=no`: the claim is about what the install did to the repo's own dependency
+		// artifacts, and an untracked file a package manager scratched into the tree is not one.
+		const dirty = yield* execCapture("git", [
+			"-C",
+			path,
+			"status",
+			"--porcelain",
+			"--untracked-files=no",
+		]);
+		if (!dirty.ok) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					LANE_UNREADABLE,
+					`${VERB}: ran ${label} and cannot read whether it changed anything in ${path}: ${dirty.reason} — UNKNOWN, never a pass.`,
+				),
+			};
+		}
+		const changed = dirty.stdout.split("\n").filter((line) => line.trim() !== "");
+		if (changed.length > 0) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					RECONCILE_REFUSED,
+					`${VERB}: ${label} changed ${changed.length} tracked path(s) in ${path} — the merged lockfile is not what the manifests pin, and an assembly branch never carries an install's own repair.`,
+					changed,
+				),
+			};
+		}
+		return {
+			_tag: "Reconciled" as const,
+			note: `${VERB}: ${label} reconciled ${path} against the merged lockfile, changing nothing tracked.`,
+		};
+	});
+
+/** Run the repo's declared code validators over the merged tree; the first red is the answer. */
+const validate = (
+	path: string,
+	validators: ReadonlyArray<CodeValidator>,
+): Effect.Effect<VerbOutcome | null, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		for (const {argv} of validators) {
+			const label = argv.join(" ");
+			const [binary, ...args] = argv;
+			const ran = yield* execStatus(binary, args, path);
+			if (ran._tag === "Unstartable") {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: ${label} could not be executed in ${path}: ${ran.reason} — whether the merged tree holds together is UNKNOWN, never green.`,
+				);
+			}
+			if (!ran.ok) {
+				return refuse(
+					ASSEMBLY_RED,
+					`${VERB}: red — ${label} failed over the merged tree; diagnostics above.`,
+					diagnostics(ran.output),
+				);
+			}
+		}
+		return null;
+	});
+
+export const runIntegrate = (
+	options: IntegrateOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(options);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+
+		const branch = epicBranch(options.epic);
+		const listed = yield* worktrees;
+		if (listed._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read this repository's working trees: ${listed.reason} — where ${branch} is checked out is UNKNOWN, so nothing was merged.`,
+			);
+		}
+		const seat = assemblySeat(listed.value, options.epic, branch);
+		if (seat._tag === "Conscripted") {
+			return refuse(
+				PRIMARY_CHECKOUT,
+				`${VERB}: ${branch} is checked out in the main working tree (${seat.path}) — an integration never merges into the driver's checkout. Switch that tree off ${branch} and place the run's own with \`fabrika lane assembly ${options.epic}\`.`,
+			);
+		}
+		if (seat._tag !== "Isolated") {
+			return refuse(
+				ASSEMBLY_UNSEATED,
+				`${VERB}: no working tree holds ${branch} — place the run's assembly worktree with \`fabrika lane assembly ${options.epic}\` before integrating a child.`,
+			);
+		}
+		const path = seat.path;
+
+		const branches = yield* localBranches;
+		if (branches._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read this repository's branches: ${branches.reason} — whether ${options.child} exists is UNKNOWN, so nothing was merged.`,
+			);
+		}
+		if (!branches.value.includes(options.child)) {
+			return refuse(
+				PROOF_ABSENT,
+				`${VERB}: no branch named ${options.child} in this repository — take the child's branch off \`lane prove\`'s PASS evidence, never a name composed from the number.`,
+			);
+		}
+
+		const before = yield* headOf(path);
+		if (before._tag === "Unreadable") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read the head of ${path}: ${before.reason} — nothing was merged, because there would be nowhere proven to reset back to.`,
+			);
+		}
+		const head = before.sha;
+
+		// `--no-ff` so each landing is one commit a reader can name: a fast-forward would leave two
+		// children's ranges indistinguishable in the history the epic reviewer reads.
+		const merged = yield* execCapture("git", ["-C", path, "merge", "--no-ff", options.child]);
+		if (!merged.ok) {
+			const aborted = yield* execCapture("git", ["-C", path, "merge", "--abort"]);
+			const after = yield* headOf(path);
+			if (after._tag === "Unreadable" || after.sha !== head) {
+				return refuse(
+					APPEND_UNKNOWN,
+					`${VERB}: ${options.child} conflicts with ${branch} and the abort did not restore ${path}${aborted.ok ? "" : `: ${aborted.reason}`} — the tree's state is UNKNOWN, so nothing may be recorded against it.`,
+				);
+			}
+			return refuse(
+				MERGE_CONFLICT,
+				`${VERB}: ${options.child} conflicts with ${branch}; the merge was aborted and ${path} is back at ${head}. No install ran and no validator ran, because there is no merged tree to judge.`,
+				diagnostics(merged.reason),
+			);
+		}
+		const notes = [`${VERB}: merged ${options.child} into ${branch} at ${path}.`];
+
+		const source = loadConfig(yield* readConfigSource(path));
+		const reconciler = resolve(source, dependencyReconcilerKey);
+		if (reconciler._tag === "Unknown" || reconciler._tag === "Malformed") {
+			return yield* restore(
+				path,
+				head,
+				refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot read \`${DEPENDENCY_RECONCILER}\` from ${CONFIG_PATH} (${reconciler.reason}) — how the merged tree's dependencies are reconciled is UNKNOWN, so no validator ran.`,
+					notes,
+				),
+			);
+		}
+		const reconciled = yield* reconcile(path, reconciler.value);
+		if (reconciled._tag === "Refused") {
+			return yield* restore(path, head, {
+				...reconciled.outcome,
+				stderr: [...notes, ...reconciled.outcome.stderr],
+			});
+		}
+		notes.push(reconciled.note);
+
+		const declared = resolve(source, codeValidatorsKey);
+		if (declared._tag === "Unknown" || declared._tag === "Malformed") {
+			return yield* restore(
+				path,
+				head,
+				refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot read \`${CODE_VALIDATORS}\` from ${CONFIG_PATH} (${declared.reason}) — which commands judge the merged tree is UNKNOWN, never green.`,
+					notes,
+				),
+			);
+		}
+		if (declared.value.length === 0) {
+			return yield* restore(
+				path,
+				head,
+				refuse(
+					LANE_UNREADABLE,
+					`${VERB}: ${CONFIG_PATH} declares no \`${CODE_VALIDATORS}\` — the merged tree was never judged, so the integration is UNKNOWN, never green and never red.`,
+					notes,
+				),
+			);
+		}
+		const red = yield* validate(path, declared.value);
+		if (red !== null) {
+			return yield* restore(path, head, {...red, stderr: [...notes, ...red.stderr]});
+		}
+
+		const landed = yield* headOf(path);
+		if (landed._tag === "Unreadable") {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${VERB}: the merge and its checks passed and ${path}'s head cannot be read back: ${landed.reason} — what the assembly branch now carries is UNKNOWN.`,
+				notes,
+			);
+		}
+		return answer(`${landed.sha}\nINTEGRATE-VERDICT: MERGED\n`, [
+			...notes,
+			`${VERB}: ${declared.value.length} code validator(s) passed over the merged tree.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/lane/integrate-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/integrate-verb.unit.test.ts
@@ -1,0 +1,306 @@
+/**
+ * `lane integrate` — the merged tree's dependencies are reconciled before it is judged, and the
+ * assembly branch keeps nothing that did not pass.
+ */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	APPEND_UNKNOWN,
+	ASSEMBLY_RED,
+	ASSEMBLY_UNSEATED,
+	LANE_UNREADABLE,
+	MERGE_CONFLICT,
+	PRIMARY_CHECKOUT,
+	PROOF_ABSENT,
+	RECONCILE_REFUSED,
+} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runIntegrate} from "./integrate-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const EPIC = 7140;
+const BRANCH = `epic/${EPIC}`;
+const CHILD = "build/7162-tuval-bootstrap-5558c9a2";
+const MAIN = "/checkout/phoenix";
+const SEAT = `${MAIN}/.claude/worktrees/epic-${EPIC}`;
+const BEFORE = "aaaa111";
+const AFTER = "bbbb222";
+
+const INSTALL = "pnpm install --frozen-lockfile";
+const TYPECHECK = "pnpm typecheck --force";
+const CONFIG = JSON.stringify({
+	dependencyReconciler: {command: ["pnpm", "install", "--frozen-lockfile"]},
+	codeValidators: [{command: ["pnpm", "typecheck", "--force"]}],
+});
+
+const LANE_FILES = {
+	[`${ROOT}/${EPIC}/workflow.json`]: coderTemplateText(),
+	[`${SEAT}/.fabrika.jsonc`]: CONFIG,
+};
+
+const LIST = /^git worktree list --porcelain$/;
+const BRANCHES = /^git for-each-ref /;
+const HEAD = /^git -C .* rev-parse HEAD$/;
+const MERGE = /^git -C .* merge --no-ff /;
+const ABORT = /^git -C .* merge --abort$/;
+const RESET = /^git -C .* reset --hard ORIG_HEAD$/;
+const STATUS = /^git -C .* status --porcelain --untracked-files=no$/;
+const RECONCILE = /^pnpm install --frozen-lockfile$/;
+const VALIDATE = /^pnpm typecheck --force$/;
+
+const listing = (...blocks: ReadonlyArray<readonly [string, string]>): ExecResult =>
+	okOut(
+		blocks
+			.map(([path, branch]) => `worktree ${path}\nHEAD ${BEFORE}\nbranch refs/heads/${branch}\n`)
+			.join("\n"),
+	);
+
+const SEATED = listing([MAIN, "main"], [SEAT, BRANCH]);
+const UNSEATED = listing([MAIN, "main"]);
+const CONSCRIPTED = listing([MAIN, BRANCH]);
+const HAS_CHILD = okOut(`main\n${BRANCH}\n${CHILD}\n`);
+
+/**
+ * The reads every run makes before the merge: the seat, the branch list, the pre-merge head.
+ *
+ * A function rather than a constant because `once` carries its spent flag on the regex it returns,
+ * so one shared array would answer the second test's pre-merge read with the third entry.
+ */
+const upToMerge = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[LIST, SEATED],
+	[BRANCHES, HAS_CHILD],
+	[once(HEAD), okOut(BEFORE)],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	files: Record<string, string> = LANE_FILES,
+	unstartable: ReadonlyArray<RegExp> = [],
+) => {
+	const shell = fakeShell(script, undefined, unstartable);
+	return Effect.runPromise(
+		Effect.provide(
+			runIntegrate({epic: EPIC, child: CHILD, root: ROOT, lane: String(EPIC)}),
+			Layer.merge(shell.layer, fakeFs({files}).layer),
+		),
+	).then((outcome) => ({outcome, calls: shell.calls, cwds: shell.cwds}));
+};
+
+/** The command lines that judge or change the merged tree, in the order they ran. */
+const staged = (calls: ReadonlyArray<string>) =>
+	calls.filter(
+		(line) =>
+			line.includes(" merge ") ||
+			line.includes("reset --hard") ||
+			line === INSTALL ||
+			line === TYPECHECK,
+	);
+
+describe("runIntegrate", () => {
+	it("merges, reconciles from the merged lockfile, then validates — in that order", async () => {
+		const {outcome, calls, cwds} = await run([
+			...upToMerge(),
+			[MERGE, okOut("")],
+			[RECONCILE, okOut("")],
+			[STATUS, okOut("")],
+			[VALIDATE, okOut("")],
+			[HEAD, okOut(AFTER)],
+		]);
+
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout.trim().split("\n")).toEqual([AFTER, "INTEGRATE-VERDICT: MERGED"]);
+		expect(staged(calls)).toEqual([`git -C ${SEAT} merge --no-ff ${CHILD}`, INSTALL, TYPECHECK]);
+		// The install is worthless run anywhere else: it must read the lockfile the merge brought.
+		expect(cwds[calls.indexOf(INSTALL)]).toBe(SEAT);
+		expect(cwds[calls.indexOf(TYPECHECK)]).toBe(SEAT);
+	});
+
+	it("never pushes and never writes the lane's log — the answer is a fact about a tree", async () => {
+		const {calls} = await run([
+			...upToMerge(),
+			[MERGE, okOut("")],
+			[RECONCILE, okOut("")],
+			[STATUS, okOut("")],
+			[VALIDATE, okOut("")],
+			[HEAD, okOut(AFTER)],
+		]);
+
+		expect(calls.some((line) => line.includes("push"))).toBe(false);
+	});
+
+	it("resets the merge and runs no validator when the merged lockfile does not install", async () => {
+		const {outcome, calls} = await run([
+			...upToMerge(),
+			[MERGE, okOut("")],
+			[RECONCILE, errOut("ERR_PNPM_OUTDATED_LOCKFILE")],
+			[RESET, okOut("")],
+			[HEAD, okOut(BEFORE)],
+		]);
+
+		expect(outcome.code).toBe(RECONCILE_REFUSED);
+		expect(outcome.stdout).toBe("");
+		expect(staged(calls)).toEqual([
+			`git -C ${SEAT} merge --no-ff ${CHILD}`,
+			INSTALL,
+			`git -C ${SEAT} reset --hard ORIG_HEAD`,
+		]);
+	});
+
+	it("refuses a reconciliation that could not be executed at all", async () => {
+		const {outcome, calls} = await run(
+			[...upToMerge(), [MERGE, okOut("")], [RESET, okOut("")], [HEAD, okOut(BEFORE)]],
+			LANE_FILES,
+			[RECONCILE],
+		);
+
+		expect(outcome.code).toBe(RECONCILE_REFUSED);
+		expect(calls).toContain(`git -C ${SEAT} reset --hard ORIG_HEAD`);
+		expect(calls).not.toContain(TYPECHECK);
+	});
+
+	it("refuses an install that repaired the lockfile rather than honouring it", async () => {
+		const {outcome, calls} = await run([
+			...upToMerge(),
+			[MERGE, okOut("")],
+			[RECONCILE, okOut("")],
+			[STATUS, okOut(" M pnpm-lock.yaml\n")],
+			[RESET, okOut("")],
+			[HEAD, okOut(BEFORE)],
+		]);
+
+		expect(outcome.code).toBe(RECONCILE_REFUSED);
+		expect(outcome.stderr.join("\n")).toContain("pnpm-lock.yaml");
+		expect(calls).not.toContain(TYPECHECK);
+		expect(calls).toContain(`git -C ${SEAT} reset --hard ORIG_HEAD`);
+	});
+
+	it("aborts a conflicting merge and reconciles nothing — there is no merged tree to judge", async () => {
+		const {outcome, calls} = await run([
+			...upToMerge(),
+			[MERGE, errOut("CONFLICT (content): Merge conflict in packages/tuval/package.json")],
+			[ABORT, okOut("")],
+			[HEAD, okOut(BEFORE)],
+		]);
+
+		expect(outcome.code).toBe(MERGE_CONFLICT);
+		expect(calls).toContain(`git -C ${SEAT} merge --abort`);
+		expect(calls).not.toContain(INSTALL);
+		expect(calls).not.toContain(TYPECHECK);
+		expect(calls).not.toContain(`git -C ${SEAT} reset --hard ORIG_HEAD`);
+	});
+
+	it("resets the branch on a red validator — the semantic collision, after a good install", async () => {
+		const {outcome, calls} = await run([
+			...upToMerge(),
+			[MERGE, okOut("")],
+			[RECONCILE, okOut("")],
+			[STATUS, okOut("")],
+			[VALIDATE, errOut("src/x.ts(3,1): error TS2345")],
+			[RESET, okOut("")],
+			[HEAD, okOut(BEFORE)],
+		]);
+
+		expect(outcome.code).toBe(ASSEMBLY_RED);
+		expect(outcome.stderr.join("\n")).toContain("TS2345");
+		expect(staged(calls)).toEqual([
+			`git -C ${SEAT} merge --no-ff ${CHILD}`,
+			INSTALL,
+			TYPECHECK,
+			`git -C ${SEAT} reset --hard ORIG_HEAD`,
+		]);
+	});
+
+	it("is UNKNOWN, never a FAIL, when the reset leaves the merge on the branch", async () => {
+		const {outcome} = await run([
+			...upToMerge(),
+			[MERGE, okOut("")],
+			[RECONCILE, okOut("")],
+			[STATUS, okOut("")],
+			[VALIDATE, errOut("error")],
+			[RESET, errOut("fatal: Unable to write new index file")],
+			[HEAD, okOut(AFTER)],
+		]);
+
+		expect(outcome.code).toBe(APPEND_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("NOT restored");
+	});
+
+	it("refuses UNKNOWN when the merged tree's repo declares no code validator", async () => {
+		const {outcome, calls} = await run(
+			[
+				...upToMerge(),
+				[MERGE, okOut("")],
+				[RECONCILE, okOut("")],
+				[STATUS, okOut("")],
+				[RESET, okOut("")],
+				[HEAD, okOut(BEFORE)],
+			],
+			{
+				...LANE_FILES,
+				[`${SEAT}/.fabrika.jsonc`]: JSON.stringify({
+					dependencyReconciler: {command: ["pnpm", "install", "--frozen-lockfile"]},
+					codeValidators: [],
+				}),
+			},
+		);
+
+		expect(outcome.code).toBe(LANE_UNREADABLE);
+		expect(calls).toContain(`git -C ${SEAT} reset --hard ORIG_HEAD`);
+	});
+
+	it("skips the install in a repo that declares no reconciler, and still validates", async () => {
+		const {outcome, calls} = await run(
+			[...upToMerge(), [MERGE, okOut("")], [VALIDATE, okOut("")], [HEAD, okOut(AFTER)]],
+			{
+				...LANE_FILES,
+				[`${SEAT}/.fabrika.jsonc`]: JSON.stringify({
+					codeValidators: [{command: ["pnpm", "typecheck", "--force"]}],
+				}),
+			},
+		);
+
+		expect(outcome.code).toBe(0);
+		expect(calls).not.toContain(INSTALL);
+		expect(calls).toContain(TYPECHECK);
+	});
+
+	it("merges nothing when no working tree holds the assembly branch", async () => {
+		const {outcome, calls} = await run([
+			[LIST, UNSEATED],
+			[BRANCHES, HAS_CHILD],
+		]);
+
+		expect(outcome.code).toBe(ASSEMBLY_UNSEATED);
+		expect(calls.some((line) => line.includes(" merge "))).toBe(false);
+	});
+
+	it("refuses the main working tree standing on the assembly branch (#6163)", async () => {
+		const {outcome, calls} = await run([[LIST, CONSCRIPTED]]);
+
+		expect(outcome.code).toBe(PRIMARY_CHECKOUT);
+		expect(calls.some((line) => line.includes(" merge "))).toBe(false);
+	});
+
+	it("refuses a child branch this repository does not carry", async () => {
+		const {outcome, calls} = await run([
+			[LIST, SEATED],
+			[BRANCHES, okOut(`main\n${BRANCH}\n`)],
+		]);
+
+		expect(outcome.code).toBe(PROOF_ABSENT);
+		expect(calls.some((line) => line.includes(" merge "))).toBe(false);
+	});
+
+	it("merges nothing when the pre-merge head cannot be read — there is nowhere to reset back to", async () => {
+		const {outcome, calls} = await run([
+			[LIST, SEATED],
+			[BRANCHES, HAS_CHILD],
+			[HEAD, errOut("fatal: ambiguous argument 'HEAD'")],
+		]);
+
+		expect(outcome.code).toBe(LANE_UNREADABLE);
+		expect(calls.some((line) => line.includes(" merge "))).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/lane/integrate.cli.test.ts
+++ b/packages/fabrika-cli/src/lane/integrate.cli.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `lane integrate` against real git — the #7162 shape, reproduced.
+ *
+ * The unit tier pins the order the verb runs its steps in. What it cannot show is that the order is
+ * the thing that fixes anything, because a scripted spawner answers whatever the script says
+ * regardless of what the tree holds. Here the tree decides: the validator passes only when the
+ * install it reads was made from the lockfile the merge brought, so an assembly worktree carrying
+ * the pre-merge install reds, and the same tree reconciled first goes green — with no source and no
+ * lockfile change between the two runs (#7188).
+ */
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {ASSEMBLY_RED, RECONCILE_REFUSED} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+const EPIC = 7140;
+const CHILD = "build/7162-tuval-bootstrap";
+
+const git = (cwd: string, ...args: ReadonlyArray<string>) =>
+	execFileSync("git", args, {cwd, encoding: "utf8"}).trim();
+
+/** The install a repo declares: record what the lockfile currently pins. */
+const INSTALL = "cp lock.txt .installed\n";
+/** The install that repairs rather than honours the lockfile — the refusal of criterion 5. */
+const REWRITING_INSTALL = "cp lock.txt .installed\nprintf repaired > lock.txt\n";
+/** The validator: the tree only compiles when the install matches the lockfile beside it. */
+const VALIDATE = "cmp -s lock.txt .installed\n";
+
+const config = (reconciler: string | null) =>
+	JSON.stringify({
+		...(reconciler === null ? {} : {dependencyReconciler: {command: ["sh", reconciler]}}),
+		codeValidators: [{command: ["sh", "validate.sh"]}],
+	});
+
+interface Fixture {
+	readonly root: string;
+	readonly seat: string;
+	readonly lanes: string;
+	readonly base: string;
+}
+
+/**
+ * A repo whose assembly worktree was placed before the child existed, so its `.installed` is the
+ * pre-merge one — exactly the state #7162's lane was in when it merged.
+ */
+const fixture = (reconciler: string | null): Fixture => {
+	const root = join(mkdtempSync(join(tmpdir(), "lane-integrate-")), "checkout");
+	mkdirSync(root, {recursive: true});
+	git(root, "init", "--initial-branch=main", ".");
+	git(root, "config", "user.email", "integrate@example.test");
+	git(root, "config", "user.name", "integrate");
+	writeFileSync(join(root, ".gitignore"), ".installed\n.fabrika/\n");
+	writeFileSync(join(root, "lock.txt"), "v1");
+	writeFileSync(join(root, "install.sh"), INSTALL);
+	writeFileSync(join(root, "rewriting-install.sh"), REWRITING_INSTALL);
+	writeFileSync(join(root, "validate.sh"), VALIDATE);
+	writeFileSync(join(root, ".fabrika.jsonc"), config(reconciler));
+	git(root, "add", "-A");
+	git(root, "commit", "-m", "base");
+	const base = git(root, "rev-parse", "HEAD");
+
+	git(root, "branch", CHILD);
+	git(root, "checkout", CHILD);
+	mkdirSync(join(root, "pkg"), {recursive: true});
+	writeFileSync(join(root, "pkg", "package.json"), '{"name":"tuval"}\n');
+	writeFileSync(join(root, "lock.txt"), "v2");
+	git(root, "add", "-A");
+	git(root, "commit", "-m", "child adds a workspace package and moves the lockfile");
+	git(root, "checkout", "main");
+
+	const seat = join(root, "assembly");
+	git(root, "worktree", "add", "-b", `epic/${EPIC}`, seat, base);
+	// The whole defect: the seat's install predates the child, and nothing reconciles it.
+	writeFileSync(join(seat, ".installed"), "v1");
+
+	const lanes = join(root, ".fabrika", "lanes");
+	mkdirSync(join(lanes, String(EPIC)), {recursive: true});
+	writeFileSync(join(lanes, String(EPIC), "workflow.json"), coderTemplateText());
+	return {root, seat, lanes, base};
+};
+
+const integrate = ({root, lanes}: Fixture) => {
+	try {
+		const stdout = execFileSync(
+			process.execPath,
+			[
+				"--experimental-strip-types",
+				BIN,
+				"lane",
+				"integrate",
+				String(EPIC),
+				"--child",
+				CHILD,
+				"--root",
+				lanes,
+			],
+			{cwd: root, encoding: "utf8", env: process.env},
+		);
+		return {code: 0, stdout};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? ""};
+	}
+};
+
+describe("lane integrate over a real assembly worktree", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("reconciles the merged lockfile, so the validators judge the merge and not the stale install", () => {
+		const tree = fixture("install.sh");
+
+		const {code, stdout} = integrate(tree);
+
+		expect(code).toBe(0);
+		expect(stdout.trim().split("\n").at(-1)).toBe("INTEGRATE-VERDICT: MERGED");
+		expect(git(tree.seat, "rev-parse", "HEAD")).not.toBe(tree.base);
+		expect(git(tree.seat, "log", "-1", "--format=%s")).toContain("Merge");
+	});
+
+	it("is the #7162 red without that step: the same tree, the same child, no install between", () => {
+		const tree = fixture(null);
+
+		const {code} = integrate(tree);
+
+		expect(code).toBe(ASSEMBLY_RED);
+		// The refusal put the branch back, so the run's next act cannot publish the bad merge.
+		expect(git(tree.seat, "rev-parse", "HEAD")).toBe(tree.base);
+	});
+
+	it("refuses an install that rewrote the lockfile, leaving the branch unpublished and reset", () => {
+		const tree = fixture("rewriting-install.sh");
+
+		const {code} = integrate(tree);
+
+		expect(code).toBe(RECONCILE_REFUSED);
+		expect(git(tree.seat, "rev-parse", "HEAD")).toBe(tree.base);
+		expect(git(tree.seat, "status", "--porcelain", "--untracked-files=no")).toBe("");
+	});
+});


### PR DESCRIPTION
An epic child's `integrate` merged into the assembly worktree and ran the repo's validators
straight away. Nothing reconciled the tree's installed dependencies with the lockfile the merge
just brought, so child #7162 — which adds `packages/tuval` — failed `pnpm typecheck --force` with
`TS2688: Cannot find type definition file for 'node'` on a tree whose code was fine, and spent a
lane retry on stale worktree state.

The merge, the reconciliation and the checks are now one verb, `fabrika lane integrate <epic>
--child <branch>`, so the order is code rather than a paragraph an operator follows:

- `git merge --no-ff` in the assembly worktree; a conflict is aborted and answered on exit `42`,
  with nothing installed and no validator run.
- the repo's declared `dependencyReconciler` — phoenix declares `pnpm install --frozen-lockfile` —
  run **in that worktree**, so the install reads the merged lockfile. Fail-closed at both ends: an
  install that cannot honour the merged lockfile is exit `43`, and so is one that *rewrites* it or
  any other tracked file.
- the repo's declared `codeValidators` over the merged tree; a red is exit `44`.

Every refusal below the merge resets the branch through `ORIG_HEAD` and reads its head back before
answering, so a recorded `FAIL` names a branch that never carried the bad merge; a restore that did
not take is exit `8`, UNKNOWN. The verb never pushes and never writes the lane log — `lane push`
and the driver's `lane transition` still own those.

`packages/fabrika-cli/src/lane/integrate.cli.test.ts` reproduces the regression against real git: a
worktree carrying the pre-merge install, a child that adds a package and moves the lockfile, and a
validator that only passes when the install matches the lockfile beside it. The same tree reds
without the reconciliation step and goes green with it, with no source or lockfile change between
the two runs. The unit test beside it pins the successful order and both refusal orders.

Grounded in source, not intuition: the `cwd` option on `ChildProcess.make` is read off
`effect@4.0.0-beta.92`'s `unstable/process/ChildProcess.d.ts` at this repo's pin, and the config-key
shape follows `codeValidators`' own module rather than a new grammar.

What a reviewer should look at first: the reconciler-absent arm. A repo declaring no
`dependencyReconciler` skips the install and still validates, rather than refusing UNKNOWN the way
an absent `codeValidators` does — the reasoning is in the key's docblock, and phoenix declares one
so the guarantee holds here.

## Deviations

- **Out-of-scope change** — **Said:** #7188 names the epic integration path. **Did:** also filled in
  exit codes `35`–`40` in `packages/fabrika-cli/README.md`'s lane-group list. **Why:** the list had
  drifted to stop at `34`, and appending `41`–`44` after that gap would have shipped a list that
  reads as wrong at a glance. **Disposition:** stated here.

Fixes #7188
