### PR TITLE
fix: report dedup answers none while an open triaged issue covers the observation

### DIFF
--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -224,15 +224,24 @@ fewer than 2 surviving tokens ⇒ `indeterminate`.
 
 With `--json`, one object with keys `outcome` (the token), `candidates` (array of
 `{number, source, score, title}`, empty unless `outcome` is `candidates`), `reason` (the
-explanatory string for `none` and `indeterminate`, else `null`), `tokens` (the keywords actually
-used), `truncated` (boolean), `queueCount` and `searchCount`.
+explanatory string for `none` and `indeterminate`, else `null`), `tokens` (the ranking keywords),
+`searchTokens` (the narrower slice sent to the search query — `[]` on `indeterminate`, where neither
+source was read), `truncated` (boolean), `queueCount` and `searchCount`.
 
 **Matching.** `--query` is lowercased and split on any run of non-letter, non-number characters over
 the **full Unicode letter class**, not ASCII — Turkish is a product-copy language in this repo, and
 an ASCII-only split shreds a Turkish stem into sub-threshold fragments and drops it entirely.
 Tokens shorter than 3 characters and stopwords in **both** repo languages are dropped; the
-remainder is deduped in first-seen order and capped at 12, because GitHub's search AND-joins its
-terms and an over-long query matches nothing. A query token matches a title token on an exact hit or
+remainder is deduped in first-seen order and capped at 12.
+
+**Ranking and search get different lists.** Scoring counts how many query tokens a title carries, so
+more tokens sharpen it; GitHub AND-joins its search terms, so every added token narrows the result
+set toward zero. Ranking therefore gets all 12, while the search query gets only the **leading 4** —
+measured against `kamp-us/phoenix` on 2026-08-28, where the collapse lands between 4 and 5 terms. The
+distinctiveness floor is evaluated against the ranking list, so narrowing the search send never
+pushes a usable query into `indeterminate`.
+
+A query token matches a title token on an exact hit or
 a shared prefix of at least 5 characters, which is what lets an agglutinative Turkish inflection
 match a bare stem without a morphological analyzer while staying off short English derivational
 overlaps. A queue row is kept only when its title overlaps (score > 0); a search row already matched
@@ -277,8 +286,9 @@ label queue is read-after-write consistent and catches an issue filed seconds ag
 index is eventually consistent — it lags fresh issues but reaches older open issues that have
 already left the queue. An empty intake queue is a normal state, so `none` at exit 0 is an answer;
 a queue or index that could not be read is exit 27 or 28 with **nothing** on stdout. The scope line
-goes to stderr on every run, naming both source counts, the tokens actually used, and whether the
-list was truncated.
+goes to stderr on every run, naming both source counts, the ranking tokens, the narrower list
+actually sent to search when the two differ (`; sent to search: <tokens>`), and whether the list was
+truncated.
 
 **Examples**
 
@@ -303,7 +313,7 @@ $ echo $?
 
 ```
 $ fabrika report dedup --query "retry helper abort reason" --json
-{"outcome":"candidates","candidates":[{"number":4312,"source":"both","score":4,"title":"Abort reason lost when the worker retry helper re-wraps the request"}],"reason":null,"tokens":["retry","helper","abort","reason"],"truncated":false,"queueCount":31,"searchCount":6}
+{"outcome":"candidates","candidates":[{"number":4312,"source":"both","score":4,"title":"Abort reason lost when the worker retry helper re-wraps the request"}],"reason":null,"tokens":["retry","helper","abort","reason"],"searchTokens":["retry","helper","abort","reason"],"truncated":false,"queueCount":31,"searchCount":6}
 ```
 
 ```

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -792,8 +792,13 @@ File one follow-up observation into the intake queue. Contract:
 **Exit codes.** The shared table this group defines, plus `27` the intake queue could not be read ·
 `28` the search index could not be read.
 
-Five behaviours are worth knowing:
+Six behaviours are worth knowing:
 
+- **`dedup` ranks against more tokens than it searches with.** Scoring gets sharper with every token
+  and GitHub's AND-joined search gets narrower, so ranking receives up to 12 and the search query
+  receives only the leading 4. Twelve AND-joined terms matched nothing on essentially every real
+  call, which made `none` a negative resting on one source. The stderr scope line and `--json`'s
+  `searchTokens` both name the narrower list whenever it differs.
 - **The body is a value, never a path.** The three writing verbs take it on **stdin only** — no
   `--body`, no `--body-file`. A flag that accepts a path turns the body into a string the verb
   could post verbatim. A shell redirect is fine: the *shell* reads the file.

--- a/packages/fabrika-cli/src/report/dedup-verb.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.ts
@@ -8,6 +8,10 @@
  * The two halves are read for different reasons. The **label queue** is read-after-write consistent
  * and catches an issue filed seconds ago; the **search index** is eventually consistent — it lags
  * fresh issues but reaches older open issues that have already left the queue.
+ *
+ * The search half is sent a **narrower token list than ranking scores against** (#7213), so the
+ * stderr scope line and `--json` both carry `searchTokens` beside `tokens` whenever the two differ —
+ * a diagnostic naming a scope the run did not read is worse than none.
  */
 
 import {Effect} from "effect";
@@ -15,7 +19,7 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {listLabels, openIssuesWithLabel, resolveRepo, searchOpenIssues} from "../io/issues.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {NO_TARGET, QUEUE_UNREADABLE, SEARCH_UNREADABLE} from "./codes.ts";
-import {rank, renderCandidate, tokenize} from "./dedup.ts";
+import {rank, renderCandidate, searchTokens, tokenize} from "./dedup.ts";
 
 /**
  * `--label` does not exist in `--repo`, so the queue half has **no scope** — and a scope of zero
@@ -88,6 +92,9 @@ export const runDedup = (
 							candidates: [],
 							reason: result.reason,
 							tokens,
+							// Neither source was read, so nothing reached the search query — not the
+							// slice this query would have produced.
+							searchTokens: [],
 							truncated: false,
 							queueCount: 0,
 							searchCount: 0,
@@ -97,8 +104,9 @@ export const runDedup = (
 				: answer(result.outcome, diagnostics);
 		}
 
+		const sent = searchTokens(tokens);
 		const queue = yield* openIssuesWithLabel(repo, label);
-		const search = yield* searchOpenIssues(repo, tokens);
+		const search = yield* searchOpenIssues(repo, sent);
 
 		// The queue is the load-bearing half — it is the one that catches an issue filed seconds ago —
 		// so when both fail its code is the one reported, and the reason names both failures so
@@ -120,7 +128,8 @@ export const runDedup = (
 
 		const result = rank({tokens, queue: queue.value, search: search.value, limit, label, exclude});
 		const excluded = exclude === null ? "" : `; #${exclude} excluded from both sources`;
-		const scope = `report dedup: ${repo}, ${queue.value.length} open issue(s) in the ${label} queue, ${search.value.length} search hit(s)${excluded}; tokens: ${tokens.join(", ")}${result.truncated ? `; list TRUNCATED to --limit ${limit}` : ""}.`;
+		const narrowed = sent.length === tokens.length ? "" : `; sent to search: ${sent.join(", ")}`;
+		const scope = `report dedup: ${repo}, ${queue.value.length} open issue(s) in the ${label} queue, ${search.value.length} search hit(s)${excluded}; tokens: ${tokens.join(", ")}${narrowed}${result.truncated ? `; list TRUNCATED to --limit ${limit}` : ""}.`;
 		const diagnostics =
 			result.reason === null ? [scope] : [scope, `report dedup: ${result.reason}.`];
 
@@ -131,6 +140,7 @@ export const runDedup = (
 					candidates: result.candidates,
 					reason: result.reason,
 					tokens,
+					searchTokens: sent,
 					truncated: result.truncated,
 					queueCount: queue.value.length,
 					searchCount: search.value.length,

--- a/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
@@ -43,6 +43,13 @@ const run = (script: ReadonlyArray<Scripted>, overrides: Partial<typeof options>
 
 const labelsOk = [LABELS, labelSet("status:needs-triage", "type:bug", "p0")] as const;
 
+/** #7213's reported query, whose twelve AND-joined terms matched nothing. */
+const LONG_QUERY =
+	"review render seed authenticated notification rows state suffix reserved unimplemented exit capture";
+
+const searchQuery = (requests: ReadonlyArray<string>): string =>
+	decodeURIComponent(requests.find((call) => SEARCH.test(call)) ?? "");
+
 describe("runDedup", () => {
 	it("exits 0 with a ranked candidates list", async () => {
 		const out = await run([
@@ -159,6 +166,73 @@ describe("runDedup", () => {
 		expect(payload.searchCount).toBe(0);
 		expect(payload.tokens).toContain("retry");
 		expect(out.stderr.join("")).not.toContain('"outcome"');
+	});
+
+	it("sends ONLY the leading slice to the AND-joined search query (#7213)", async () => {
+		const seams = fakeSeams([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]]);
+		await Effect.runPromise(Effect.provide(runDedup({...options, query: LONG_QUERY}), seams.layer));
+		const sent = searchQuery(seams.requests);
+		expect(sent).toContain("is:open review render seed authenticated");
+		expect(sent).not.toContain("notification");
+	});
+
+	it("still ranks against the FULL token list, so narrowing does not blunt scoring", async () => {
+		const out = await run(
+			[labelsOk, [QUEUE, issueRows([4312, LONG_QUERY])], [SEARCH, searchHits()]],
+			{query: LONG_QUERY},
+		);
+		expect(out.stdout).toContain("4312\tqueue\t12\t");
+	});
+
+	it("retrieves a search row an over-long AND-join would have lost", async () => {
+		// Scripted to answer only the NARROWED query: a twelve-term send falls through to the
+		// unscripted 500 and refuses, so the row can only be reached by the slice.
+		const narrowOnly = /search\/issues\?q=[^"]*authenticated(?!.*notification)/;
+		const out = await run(
+			[
+				labelsOk,
+				[QUEUE, issueRows()],
+				[
+					narrowOnly,
+					searchHits([7051, "review-ui default-state captures leave interaction states unjudged"]),
+				],
+			],
+			{query: LONG_QUERY},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("candidates");
+		expect(out.stdout).toContain("7051\tsearch\t");
+	});
+
+	it("names the tokens actually SENT to search on the scope line when they differ", async () => {
+		const out = await run([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]], {
+			query: LONG_QUERY,
+		});
+		expect(out.stderr[0]).toContain("sent to search: review, render, seed, authenticated");
+	});
+
+	it("says nothing about a narrowed send when the whole list went to search", async () => {
+		const out = await run([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]], {
+			query: "retry helper abort reason",
+		});
+		expect(out.stderr[0]).not.toContain("sent to search");
+	});
+
+	it("--json carries the two lists apart", async () => {
+		const out = await run([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]], {
+			query: LONG_QUERY,
+			json: true,
+		});
+		const payload = JSON.parse(out.stdout);
+		expect(payload.tokens).toHaveLength(12);
+		expect(payload.searchTokens).toEqual(["review", "render", "seed", "authenticated"]);
+	});
+
+	it("evaluates the indeterminate floor against the RANKING list, never the narrowed slice", async () => {
+		const out = await run([labelsOk, [QUEUE, issueRows()], [SEARCH, searchHits()]], {
+			query: LONG_QUERY,
+		});
+		expect(out.stdout.split("\n")[0]).toBe("none");
 	});
 
 	it("says on stderr when the cap truncated the list", async () => {

--- a/packages/fabrika-cli/src/report/dedup.ts
+++ b/packages/fabrika-cli/src/report/dedup.ts
@@ -9,12 +9,40 @@
  * tokenizes to nothing was never compared; a query that tokenizes to one generic term is AND-joined
  * into a match on everything or nothing, and neither carries information about *this* observation.
  * Reporting either as `none` is the degenerate-silence trap this token exists to close.
+ *
+ * **Two token lists, not one.** {@link tokenize} produces the ranking list, capped at
+ * {@link MAX_TOKENS}; {@link searchTokens} narrows it to the {@link SEARCH_TOKENS} prefix the
+ * AND-joined search query gets. The floor above is evaluated against the ranking list, so narrowing
+ * for search never pushes a usable query into `indeterminate`.
  */
 
 /** Beneath this many surviving tokens a run carries no information about the query. */
 export const TOKEN_FLOOR = 2;
-/** GitHub AND-joins search terms, so an over-long query matches nothing. */
+/** How many tokens ranking may score against — more tokens make {@link scoreTitle} sharper. */
 export const MAX_TOKENS = 12;
+/**
+ * How many of those tokens reach the AND-joined search query.
+ *
+ * Ranking and search pull opposite ways: `scoreTitle` counts how many query tokens a title carries,
+ * so more is sharper, while GitHub AND-joins the free-text terms, so every added token narrows the
+ * result set. One list served both jobs until #7213, and at twelve AND-joined terms the search half
+ * returned zero rows on essentially every real call — a `none` resting on one source.
+ *
+ * Four is measured, not guessed. Replaying #7213's reported query against `kamp-us/phoenix` on
+ * 2026-08-28: 3 tokens → 17 hits, 4 → 5 hits with the missed issue #7051 ranked first, 5 → 1 hit
+ * and #7051 gone. The collapse lands between 4 and 5, so 4 is the widest slice that still
+ * discriminates.
+ */
+export const SEARCH_TOKENS = 4;
+
+/**
+ * The prefix of a ranking token list that is sent to the AND-joined search query.
+ *
+ * `tokenize` keeps first-seen order, so the slice is the caller's own leading keywords — the ones a
+ * filer writes first and the ones most likely to name the observation.
+ */
+export const searchTokens = (tokens: ReadonlyArray<string>): ReadonlyArray<string> =>
+	tokens.slice(0, SEARCH_TOKENS);
 export const DEFAULT_LIMIT = 20;
 /** What a shared prefix must reach to count as a match. */
 const PREFIX = 5;

--- a/packages/fabrika-cli/src/report/dedup.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup.unit.test.ts
@@ -1,5 +1,14 @@
 import {describe, expect, it} from "vitest";
-import {MAX_TOKENS, rank, renderCandidate, scoreTitle, tokenize, tokensMatch} from "./dedup.ts";
+import {
+	MAX_TOKENS,
+	rank,
+	renderCandidate,
+	SEARCH_TOKENS,
+	scoreTitle,
+	searchTokens,
+	tokenize,
+	tokensMatch,
+} from "./dedup.ts";
 
 describe("tokenize", () => {
 	it("lowercases, drops short tokens and English stopwords, and dedupes first-seen", () => {
@@ -25,9 +34,25 @@ describe("tokenize", () => {
 		expect(tokenize("sözlük için bir tanım ve çok şey")).toEqual(["sözlük", "tanım"]);
 	});
 
-	it("caps at 12 tokens, because GitHub AND-joins and an over-long query matches nothing", () => {
+	it("caps at 12 tokens, the width ranking scores against", () => {
 		const query = Array.from({length: 30}, (_, i) => `token${i}`).join(" ");
 		expect(tokenize(query)).toHaveLength(MAX_TOKENS);
+	});
+});
+
+describe("searchTokens", () => {
+	it("narrows a full ranking list to the leading slice the AND-joined query gets (#7213)", () => {
+		const ranking = tokenize(
+			"review render seed authenticated notification rows state suffix reserved unimplemented exit capture",
+		);
+		expect(ranking).toHaveLength(MAX_TOKENS);
+		expect(searchTokens(ranking)).toEqual(ranking.slice(0, SEARCH_TOKENS));
+		expect(searchTokens(ranking)).toHaveLength(SEARCH_TOKENS);
+	});
+
+	it("leaves a list already at or below the slice size alone", () => {
+		const short = ["retry", "helper"];
+		expect(searchTokens(short)).toEqual(short);
 	});
 });
 


### PR DESCRIPTION
`report dedup` fed one capped token list to two jobs that pull opposite ways. `scoreTitle` gets
sharper with every token; GitHub AND-joins its search terms, so every added token narrows the
result set. At twelve terms the search half returned zero rows on essentially every real call, and
the verb printed `none` — a proven negative resting on the queue half alone.

The two lists are now separate. `rank` still receives the full `MAX_TOKENS = 12` list, so scoring is
unblunted and the `TOKEN_FLOOR = 2` `indeterminate` rule is still evaluated against it. The
AND-joined query receives `searchTokens(tokens)` — the leading `SEARCH_TOKENS = 4`.

Four is measured, not guessed. Replaying #7213's reported query against `kamp-us/phoenix` on
2026-08-28: 3 tokens → 17 hits, 4 → 5 hits with the missed issue #7051 ranked first, 5 → 1 hit and
#7051 gone. The collapse lands between 4 and 5, so 4 is the widest slice that still discriminates.
The constant carries that measurement in its docblock.

The diagnostic moves with the change: the stderr scope line appends `; sent to search: <tokens>`
whenever the sent list differs from the ranking list, and `--json` carries `searchTokens` beside
`tokens`. On `indeterminate` neither source is read, so `searchTokens` is `[]` rather than the slice
a query would have produced.

Verified live from this tree — the filer's own query now returns #7051 as a candidate:

```
$ fabrika report dedup --repo kamp-us/phoenix --exclude 7213 --query "review-ui render cannot seed authenticated notification rows state suffix reserved unimplemented exit 10 capture"
report dedup: kamp-us/phoenix, 4 open issue(s) in the status:needs-triage queue, 5 search hit(s); #7213 excluded from both sources; tokens: review, render, seed, authenticated, notification, rows, state, suffix, reserved, unimplemented, exit, capture; sent to search: review, render, seed, authenticated.
candidates
7218	search	4	review-ui render has no flag-override or seeded-session path, so gated states cannot be captured
7051	search	3	review-ui default-state captures leave interaction states unjudged
…
```

Pin surfaces swept per `.patterns/verb-output-pin-surfaces.md`: the contract's `--json` key list,
its Matching and Scope paragraphs and its `--json` worked example; the `report` group's README
section. `packages/fabrika-cli/src/io/issues.ts` is untouched — the open-vs-closed scope is #6923's.

New tests: the slice is what reaches the request; the full list still reaches `rank` (a 12-token
title scores 12); a search row scripted to answer only the narrowed query is retrieved, so a
twelve-term send would refuse instead of finding it; the scope line and `--json` both carry the
distinction and both stay silent when the lists match.

Fixes #7213

## Deviations

None.
