### PR TITLE
fix: Agent worktrees arrive without node_modules — 0178's WorktreeCreate provisioning retired with the v1 plugin and was never rehomed

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
 	"enabledPlugins": {
 		"fabrika@kampus": true,
 		"kampus-pipeline@kampus": false
+	},
+	"hooks": {
+		"WorktreeCreate": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "fabrika hook worktree-create",
+						"timeout": 600
+					}
+				]
+			}
+		]
 	}
 }

--- a/.decisions/0178-worktreecreate-hook-provisioning.md
+++ b/.decisions/0178-worktreecreate-hook-provisioning.md
@@ -1,7 +1,7 @@
 ---
 id: 0178
 title: A WorktreeCreate Hook Provisions isolation:worktree, Giving the Deps Install a 600s Budget Instead of Racing the Default-Path Timeout
-status: superseded by [0303](0303-retire-kampus-pipeline-plugin.md)
+status: superseded by [0303](0303-retire-kampus-pipeline-plugin.md), mechanism restored by [0337](0337-worktree-provisioning-rehomed-onto-repo-settings.md)
 superseded_by: 0303
 date: 2026-07-12
 tags: [pipeline, worktree, tooling, harness]
@@ -142,3 +142,23 @@ Two follow-ons close the loop this ADR opened:
    remote tip, never local `main` — which is why this is preferred over any "sync/fast-forward local
    main" approach (there is no local ref to clobber). The `--detach` rationale above is unchanged;
    only the base commit-ish moves from the stale cached ref to the fresh `FETCH_HEAD`.
+
+## Amendment (2026-08-28, #7220) — the mechanism is restored, in a different home
+
+`superseded_by: 0303` still reads right for the **script**: `create-worktree.sh` is deleted and no
+path under `claude-plugins/kampus-pipeline/` survives. What it read wrong is the *decision*. ADR
+[0303](0303-retire-kampus-pipeline-plugin.md) retired this hook as collateral of deleting a plugin,
+not as a call to stop provisioning worktrees, and for the months between that deletion and this
+amendment **nothing provisioned a harness worktree at all** — every `isolation: worktree` shell
+arrived dep-less and paid an install before its first verb, or failed on it (#7220).
+
+ADR [0337](0337-worktree-provisioning-rehomed-onto-repo-settings.md) restores what this ADR decided:
+the `WorktreeCreate` trigger, the 600s budget, the `--detach` base, the #3621 fresh-base fetch, and
+ADR [0109](0109-worktree-deps-provision-not-share.md)'s install reused rather than reimplemented.
+Three things did not come back, and each for a reason 0337 states: the trigger is a `fabrika` verb
+rather than a shell script, its home is this repo's `.claude/settings.json` rather than a plugin's
+`hooks.json` (a plugin-declared provider preempts git in every adopting repo), and the owner stamp is
+dropped because its only consumer left with `packages/pipeline-cli/`.
+
+Read this file for the *why* — the race, the fail-closed polarity, the `--detach` rationale, the
+documented-vs-undocumented split — all of which 0337 rests on. Read 0337 for what is live.

--- a/.decisions/0303-retire-kampus-pipeline-plugin.md
+++ b/.decisions/0303-retire-kampus-pipeline-plugin.md
@@ -63,3 +63,22 @@ The remaining pipeline-cli verbs whose only callers were v1 scripts (e.g. `drive
 `worktree-sweep`'s hook path) are left registered; sweeping them is separate follow-up work.
 ADRs and dated reports keep their references to the deleted tree as history — `.decisions/` is
 the why + history surface, and history does not get rewritten when its subject dies.
+
+## Amendment (2026-08-28, #7220) — one deleted hook was load-bearing, and its absence went unnoticed
+
+The deletion above is unchanged and still right. What it did not weigh is that **one** of the ten
+retired hooks was not a v1 convenience: `create-worktree.sh` was ADR
+[0178](0178-worktreecreate-hook-provisioning.md)'s `WorktreeCreate` provider, the thing that gave a
+worktree's `pnpm install` a 600s budget so ADR
+[0109](0109-worktree-deps-provision-not-share.md)'s `post-checkout` install could actually run.
+
+Deleting it did not fall back to something else. The harness's own worktree path execs git hooks with
+a stripped `PATH`, so `bootstrap-deps` clean-SKIPs at exit 0 (0109 §3) — silently. So from this
+deletion until #7220, **every `isolation: worktree` shell arrived without `node_modules`**, and the
+only signal was each shell paying an install or failing on its first verb.
+
+The "Hooks" bullet reads as a clean removal of v1 apparatus. For nine of the ten it was. For this one
+the entry it should have carried is: *this hook has a live consumer, and nothing replaces it.* ADR
+[0337](0337-worktree-provisioning-rehomed-onto-repo-settings.md) rehomes the mechanism onto a fabrika
+verb declared in this repo's own `.claude/settings.json`, and records why the plugin's `hooks.json` is
+the one surface it may **not** live on.

--- a/.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md
+++ b/.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md
@@ -89,6 +89,16 @@ prepended to the inherited `PATH` (never a per-machine volta/fnm shim — 0109's
 only remote-tracking refs, never the primary's local `main`, so the #2143/#2144 corruption class is
 not reintroduced. `<base>` is read from `refs/remotes/origin/HEAD` and falls back to `main`.
 
+That fetch needs credentials, and the child inherits nothing it is not handed, so the allowlist
+carries the ssh-agent channel (`SSH_AUTH_SOCK`, `SSH_AGENT_PID`, `GIT_SSH`, `GIT_SSH_COMMAND`)
+alongside what the install needs. phoenix's `origin` is SSH-only — `url.git@github.com:.insteadof`
+rewrites every HTTPS remote — so an omitted socket is not a slower path, it is no path. Forwarding it
+is only half: the child has no tty and no askpass, so an ssh that decides to prompt blocks until the
+540s child timeout and every spawn becomes a nine-minute refusal. `GIT_TERMINAL_PROMPT=0` and ssh
+`BatchMode=yes` make the same miss fail in seconds, at exit `16` with the reason on stderr. A lone
+`GIT_SSH` wrapper is left as-is, since git prefers `GIT_SSH_COMMAND` and synthesising one would
+silently outrank the operator's choice.
+
 **5. Every failure arm refuses, and a refusal blocks the spawn.** Including the last one, which is
 what makes the guarantee more than a hope: **`git worktree add` succeeding proves nothing about the
 install**, so the verb checks `node_modules/.pnpm` in the new tree and exits `18` if it is absent. A

--- a/.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md
+++ b/.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md
@@ -1,0 +1,114 @@
+---
+id: 0337
+title: Worktree Provisioning Is Rehomed onto This Repo's Own Settings, Not fabrika's Plugin Surface
+status: accepted
+date: 2026-08-28
+tags: [fabrika, hooks, worktree, tooling, harness]
+---
+
+# 0337 — Worktree Provisioning Is Rehomed onto This Repo's Own Settings, Not fabrika's Plugin Surface
+
+## Context
+
+**Every `isolation: worktree` shell arrives without `node_modules`, and has since the v1 plugin was
+deleted.** Three lanes in one session hit it — a builder at exit `126` on its first `build tree`, and
+two shippers ([#7220](https://github.com/kamp-us/phoenix/issues/7220)). It is not intermittent.
+
+The mechanism that used to prevent it is ADR [0178](0178-worktreecreate-hook-provisioning.md): a
+`WorktreeCreate` hook with a 600s timeout that ran `git worktree add` itself, so ADR
+[0109](0109-worktree-deps-provision-not-share.md)'s `post-checkout` `bootstrap-deps` install ran
+under a generous budget instead of racing the harness default path's ~13s readiness limit. That
+hook's script lived under `claude-plugins/kampus-pipeline/hooks/`, and ADR
+[0303](0303-retire-kampus-pipeline-plugin.md) deleted that plugin — hooks and all. **0303 retired the
+hook as collateral of deleting a plugin, not as a decision to stop provisioning**, and 0178's
+mechanism was never rehomed.
+
+**What the harness does instead, verified in this tree rather than inferred.** The worktree this ADR
+was written in sits on a `worktree-agent-<hex>` branch, which is the harness's own internal
+provisioning path and not the `--detach` head a hook produces, and it arrived with no
+`node_modules`. The reason the harness's path leaves it dep-less is ADR 0109 §3: `git worktree add`
+execs git hooks with a stripped `PATH` (#787–#789), so `bootstrap-deps` finds no corepack, no pinned
+pnpm and no npm, and **clean-SKIPs at exit 0**. A skip is silent, so a dep-less tree and a
+provisioned one are byte-identical from outside.
+
+### The blocker this had to get past, and why it is real
+
+fabrika's hook surface **deliberately refused** `WorktreeCreate`
+([#5589](https://github.com/kamp-us/phoenix/issues/5589),
+[`hook-surface.md`](../claude-plugins/fabrika/docs/hook-surface.md)), and the refusal is correct on
+its own terms. A declared `WorktreeCreate` hook **preempts git wherever it is declared** — there is
+no fallback — so declaring it in `claude-plugins/fabrika/hooks.json` makes fabrika take over worktree
+creation in **every repo that installs the plugin**. On that event there is no fail-open form: the
+harness reads every non-zero exit as a creation failure, including the two codes the interface
+convention reserves for *the verb never ran* (`127` with no install, `126` cross-checkout). A machine
+with no fabrika would lose `--worktree` outright — the inverse of ADR
+[0250](0250-fabrika-hook-cannot-run-fails-open.md)'s ruled polarity.
+
+That argument binds the **plugin** surface, which travels. It does not bind **this repo's own**
+`.claude/settings.json`, which travels nowhere: phoenix's whole pipeline already requires fabrika, so
+a phoenix checkout without it is broken before any worktree is asked for.
+
+### Read first-hand, on the build this repo runs
+
+Against Claude Code **2.1.251**, by live capture rather than from docs (ADR
+[0180](0180-capture-real-runtime-artifact-before-coding.md)):
+
+- The payload is `{session_id, transcript_path, cwd, hook_event_name, name}` — a slug, and **no**
+  `worktree_path`, **no** `base_ref`. Committed at
+  [`../packages/fabrika-cli/src/hook/__fixtures__/worktree-create.payload.golden.json`](../packages/fabrika-cli/src/hook/__fixtures__/worktree-create.payload.golden.json)
+  with its method beside it.
+- A hook that creates `<cwd>/.claude/worktrees/<name>` and echoes it is **adopted**: the round trip
+  was run, the session started, and `git worktree list` showed the tree.
+- A hook that emits no path **blocks** creation (`Error creating worktree: …`), which is the
+  fail-closed property the whole design rests on.
+- A per-hook `timeout` overrides the runner's default (`e.timeout ? e.timeout * 1000 : <default>`),
+  so the 600s budget is real.
+
+## Decision
+
+**1. The `WorktreeCreate` provider is declared in `.claude/settings.json` — this repo's own hook
+surface — and never in `claude-plugins/fabrika/hooks.json`.** The plugin surface's refusal stands
+unchanged for adopters, and #5589's reasoning is preserved rather than overturned. The split is the
+whole decision: the event is safe where the toolchain is guaranteed and unsafe where it is not, so it
+is declared exactly where the guarantee holds.
+
+**2. The trigger is a verb, not a script** — `fabrika hook worktree-create`, a plain literal
+`fabrika <group> <verb>` command, so `cli-interface-convention.md` rule 5 binds it in settings
+exactly as it binds a plugin hook. `declaration.ts` now reads both documents, and the golden test
+asserts per document which events each may declare — the plugin surface carries no `Worktree*` event,
+by test, not by review.
+
+**3. ADR 0109's install is reused, never reimplemented.** The verb runs `git worktree add`, which
+fires the same `post-checkout` `bootstrap-deps`; `--ignore-scripts` and the pinned major are
+untouched. What the verb adds is the environment that install needs: the OS-standard toolchain dirs
+prepended to the inherited `PATH` (never a per-machine volta/fnm shim — 0109's prohibition), so
+`bootstrap-deps` resolves a runner instead of clean-SKIPping.
+
+**4. The base is fetched before it is branched from**, carrying ADR 0178's #3621 amendment forward:
+`git fetch --quiet origin <base>` then `git worktree add --detach <path> FETCH_HEAD`. The fetch moves
+only remote-tracking refs, never the primary's local `main`, so the #2143/#2144 corruption class is
+not reintroduced. `<base>` is read from `refs/remotes/origin/HEAD` and falls back to `main`.
+
+**5. Every failure arm refuses, and a refusal blocks the spawn.** Including the last one, which is
+what makes the guarantee more than a hope: **`git worktree add` succeeding proves nothing about the
+install**, so the verb checks `node_modules/.pnpm` in the new tree and exits `18` if it is absent. A
+dep-less tree is never presented as ready.
+
+## Consequences
+
+- **A worktree spawn now costs ~10s of out-of-band provisioning and arrives usable.** Measured in
+  this repo: 9.65s wall, 589 virtual-store entries, and `.pnpm/node_modules/@kampus/db-schema`
+  resolving **worktree-local** — ADR 0109's correctness property, checked rather than assumed.
+- **On a phoenix checkout where `fabrika` does not resolve, `--worktree` stops working.** This is the
+  real, accepted cost of taking an event with no fail-open form, and it is narrower than ADR 0250's
+  exposure only because it is confined to this repo. The escape hatch is one edit: drop the `hooks`
+  block from `.claude/settings.json`. Named here so a future reader meets it as a decision rather
+  than as a mystery.
+- **ADR 0178 is restored in substance and superseded in form.** Its mechanism, budget and fresh-base
+  fetch all survive; its script, its plugin home and its owner stamp do not. The stamp is not
+  rehomed: its consumer was `worktree-sweep`, which retired with `packages/pipeline-cli/`, so
+  stamping would write a record nothing reads.
+- **`.claude/settings.json` is control-plane.** Classification is the merge gate's, per CODEOWNERS.
+- **This is one more surface that goes stale silently when the harness changes.** No gate here
+  executes Claude Code (ADR 0180's own premise), so the fixture and the round trip are dated evidence
+  from 2.1.251; `PROVENANCE.md` says how to re-capture.

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -26,10 +26,14 @@ see [issue #801](https://github.com/kamp-us/phoenix/issues/801) for the trace).
 So for the default worktree base the constraint stands, and the in-session fix is
 the Bash-write workaround below — not a setting.
 
-**There is one relocation lever, but it is a scoped, coordinated change, not a
-flip.** Claude Code supports a `WorktreeCreate` hook that replaces the default
-worktree-creation logic and can land worktrees outside `.claude/` (a base path with
-no `.claude/` substring would dodge the protected-path guard entirely). Adopting it
+**There is one relocation lever, and this repo already holds it — but pulling it is
+still a scoped, coordinated change, not a flip.** The `WorktreeCreate` hook that
+replaces the default worktree-creation logic is declared and live (ADR
+[0337](../.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md)), so the
+base path is now ours to choose; it deliberately keeps laying trees at
+`<repo>/.claude/worktrees/<name>`, because moving them is a separate decision from
+provisioning them. A base with no `.claude/` substring would dodge the protected-path
+guard entirely. Making that move
 is NOT free: the biome config and [ADR 0060](../.decisions/0060-worktree-lint-changed-paths.md)
 key on the literal base segment `/.claude/worktrees/`, so both would have to track a new base in
 lockstep. That is a control-plane (`.claude/settings.json` hook) change to scope and review
@@ -232,29 +236,42 @@ hook **consumer**, never a hook **generator**. Two operational corollaries:
   untracked, so this is a one-time **operator** step, not a committed change — the
   `prepare` guard then prevents the pollution from recurring.
 
-## Your worktree arrives auto-provisioned — verify before installing, never symlink
+## Your worktree arrives provisioned by a hook this repo declares — verify, never symlink
 
-A current `isolation:worktree` spawn arrives with `node_modules` **already provisioned** by the
-harness at `git worktree add` time (a real, version-pinned `pnpm install` — its virtual-store
-`@kampus/*` links resolve worktree-local and correct, per
-[ADR 0109](../.decisions/0109-worktree-deps-provision-not-share.md)). That provisioning runs
-**out-of-band, before your first turn**, so it costs your metered run nothing
+A worktree's deps come from **one** thing, and knowing which one is the difference between a wasted
+turn and a lane that dies on its first verb.
+
+The provider is `fabrika hook worktree-create`, declared on `WorktreeCreate` in this repo's own
+[`.claude/settings.json`](../.claude/settings.json) with a 600s timeout (ADR
+[0337](../.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md), restoring ADR
+[0178](../.decisions/0178-worktreecreate-hook-provisioning.md)'s mechanism). It runs `git worktree
+add` itself under a `PATH` that resolves the toolchain, which is what lets lefthook's
+`post-checkout` `bootstrap-deps` run the real, version-pinned install (ADR
+[0109](../.decisions/0109-worktree-deps-provision-not-share.md)) instead of clean-SKIPping. It
+refuses unless `node_modules/.pnpm` actually landed, so a dep-less tree is never handed to an agent
+— and because a refusal blocks creation, you either get a usable tree or no tree at all. That work
+happens **out-of-band, before your first turn**, so it costs your metered run nothing
 ([token-economics-measurement.md §6](../reports/token-economics-measurement.md)).
 
-So **do not reflexively run `pnpm install`** on entry — it is redundant setup overhead (≈170 tokens
-of ingested output, plus a wasted Bash turn) that the harness already paid for you, and it is the
-recurring per-spawn cost the token-economics audit ([#1487](https://github.com/kamp-us/phoenix/issues/1487))
-flagged. **Verify, then install only if actually missing:**
+**The harness's own path provisions nothing.** When the hook does not fire — settings not reloaded
+since it landed, a checkout where `fabrika` does not resolve, a session started before this — the
+harness provisions internally, and its `git worktree add` execs git hooks with a **stripped `PATH`**
+(#787–#789), so `bootstrap-deps` finds no corepack, no pinned pnpm and no npm and **clean-SKIPs at
+exit 0** (ADR 0109 §3). The skip is silent, so a dep-less tree looks exactly like a provisioned one.
+That was the live state for months after ADR [0303](../.decisions/0303-retire-kampus-pipeline-plugin.md)
+deleted the v1 hook, and it cost three lanes in one session
+([#7220](https://github.com/kamp-us/phoenix/issues/7220)) — one at exit `126` on its first
+`build tree`. A worktree on a `worktree-agent-<hex>` branch was made by that internal path; one at a
+detached head came from the hook.
+
+**So check the artifact, don't assume either way.** One line, and it is correct under both:
 
 ```bash
-# install ONLY if the worktree truly arrived without deps (the rare non-auto-provisioned path);
-# otherwise the harness already provisioned it — running install again is pure overhead.
 [ -d node_modules/.pnpm ] || pnpm install --prefer-offline --ignore-scripts
 ```
 
-Just run the real command you need (`pnpm typecheck` / `pnpm lint:worktree` / `pnpm build`) — if it
-fails because deps are genuinely absent, *then* install with the line above, with `--ignore-scripts`
-(a worktree shares `.git/hooks`, so a bare install would regenerate the **shared** hooks — #1243).
+`--ignore-scripts` matters: a worktree shares `.git/hooks`, so a bare install would regenerate the
+**shared** hooks (#1243).
 
 **Never symlink the primary checkout's `node_modules` into your worktree.** It looks like a shortcut
 to skip the install, but it is **silently incorrect**: pnpm's virtual store holds *relative* links
@@ -305,9 +322,9 @@ locked at all** (`review-head materialize` runs `git worktree add --detach`, no 
 leaves the `review-head-idle` removal path able to take a **live reviewer's** tree with no lock
 protection whatsoever. Two live shipper worktrees were removed mid-run; **which** reaper and which
 signal state produced those two removals is not established. Presence rides the owner, per
-[ADR 0191](../.decisions/0191-crew-claim-lifecycle.md): `create-worktree.sh` stamps
+[ADR 0191](../.decisions/0191-crew-claim-lifecycle.md): the v1 `create-worktree.sh` stamped
 the owning `sessionId` into the tree's git admin dir (`<gitdir>/kampus-owner.json`, invisible to
-`git status`), and the sweep resolves it against the harness's live-session registry
+`git status`), and the sweep resolved it against the harness's live-session registry
 (`$CLAUDE_CONFIG_DIR`, else the agent tool's default config home → `sessions/<pid>.json`, one file
 per running session).
 **The three-state resolution is the safety property:** `alive` and `unknown` both KEEP, and only
@@ -315,14 +332,16 @@ per running session).
 could not execute leaks an orphan rather than destroying a live tree. A sweep that removes nothing
 and reports `registry UNRESOLVED` is the gate working, not a no-op.
 
-**The stamp has no live producer right now ([#4180](https://github.com/kamp-us/phoenix/issues/4180)).**
-The paragraph above describes the code contract, not the runtime: the harness provisions agent
-worktrees on its own internal path — every registered tree sits on a harness-made
-`worktree-<name>` branch, which `create-worktree.sh`'s `git worktree add --detach` never produces —
-so the `WorktreeCreate` hook does not run and no tree is stamped (272 registered, 0 stamped). Read
-"the sweep resolves the owner from the stamp" as what the code *would* do; in the field it resolves
-`owner-unknown` every time and KEEPs. Safe direction, but the sweep is effectively lock-only today,
-so `0 reapable` is partly an absence of evidence.
+**The stamp has no producer at all now, and no consumer either.** The paragraph above is history, not
+runtime. It was already inert when [#4180](https://github.com/kamp-us/phoenix/issues/4180) measured
+it — 272 trees registered, 0 stamped, because the harness's internal path leaves a
+`worktree-<name>` branch and the v1 hook never ran — and both halves have since been deleted:
+`create-worktree.sh` with the v1 plugin (ADR
+[0303](../.decisions/0303-retire-kampus-pipeline-plugin.md)) and `worktree-sweep`, its only reader,
+with `packages/pipeline-cli/`. The `WorktreeCreate` provider ADR
+[0337](../.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md) restores deliberately
+does **not** stamp: a record nothing reads is not worth writing. Read the owner-presence gate as the
+reasoning a future reaper should follow, not as a mechanism that runs.
 
 **Expect near-silence, and not only from legacy trees.** The stamp carries the **launcher's**
 session id, so a long-lived launcher makes every tree it provisioned read `alive` for the

--- a/claude-plugins/fabrika/docs/hook-surface.md
+++ b/claude-plugins/fabrika/docs/hook-surface.md
@@ -15,7 +15,13 @@ Both rules are checked as **data**, not by eye: [`../../../packages/fabrika-cli/
 
 ### The declared hooks, and how they are proven
 
-One hook is declared today.
+One hook is declared **on this surface** today. This repo declares a second on its own, in
+[`.claude/settings.json`](../../../.claude/settings.json) — `fabrika hook worktree-create` on
+`WorktreeCreate` — for the reason [below](#worktreecreate--a-provider-hook-left-undeclared): that
+event is safe where the toolchain is guaranteed and unsafe where it is not, so it lives where the
+guarantee holds and never here. Both documents are read by the same
+[`declaration.ts`](../../../packages/fabrika-cli/src/hook/declaration.ts) and judged against the same
+two rules; what differs is which events each may carry.
 
 `fabrika hook check` on `SessionStart` is this surface's proof — it reads the envelope the harness writes to a hook's stdin and answers whether it is one fabrika can act on ([`../../../packages/fabrika-cli/src/hook/check-verb.ts`](../../../packages/fabrika-cli/src/hook/check-verb.ts)).
 
@@ -69,7 +75,9 @@ That failure mode is not survivable, and the reason is sharper than "it would be
 WorktreeCreate hook failed: hook is configured but did not run (workspace not trusted, disableAllHooks set, or matcher mismatch)
 ```
 
-A machine with no fabrika install would therefore lose `--worktree` entirely, which is the inverse of ADR [0250](../../../.decisions/0250-fabrika-hook-cannot-run-fails-open.md). Left undeclared.
+A machine with no fabrika install would therefore lose `--worktree` entirely, which is the inverse of ADR [0250](../../../.decisions/0250-fabrika-hook-cannot-run-fails-open.md). **Left undeclared on this surface, and that refusal is unchanged.**
+
+> **The event is now declared elsewhere, and the distinction is the whole reason it could be (ADR [0337](../../../.decisions/0337-worktree-provisioning-rehomed-onto-repo-settings.md), #7220).** Everything above binds a *plugin* declaration, which travels to every adopting repo — that is what makes the no-fail-open exposure unbounded. phoenix's own [`.claude/settings.json`](../../../.claude/settings.json) travels nowhere, and a phoenix checkout without fabrika is already broken, so the same event carries a bounded cost there: it declares `fabrika hook worktree-create` with a 600s timeout, which provisions the worktree ADR [0109](../../../.decisions/0109-worktree-deps-provision-not-share.md)'s install would otherwise leave dep-less. rule 5 binds that command exactly as it binds one here, and [`declaration.ts`](../../../packages/fabrika-cli/src/hook/declaration.ts) reads both documents — so the golden test asserts, per document, that no `Worktree*` event ever appears on **this** surface. That assertion is the refusal above, with teeth.
 
 #### `WorktreeRemove` — the teardown counterpart, also a provider, left undeclared
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -552,15 +552,25 @@ surface's convention lives in
 |---|---|
 | `hook check` | whether the envelope on stdin is one fabrika can act on |
 | `hook codes` | the exit taxonomy every verb in the group allocates from |
+| `hook worktree-create` | the absolute path of the provisioned worktree the envelope named |
 
 **Exit codes.** `3` stdin held nothing · `12` bytes arrived and are provably not an envelope ·
 `13` fd 0 could not be read · `14` a readable envelope arrived and is not the event this verb
 judges. Three failure codes rather than one, so an unread pipe cannot pass for a bad payload.
+`worktree-create` adds four proven refusals of its own: `15` the envelope names no creatable
+worktree · `16` the base could not be fetched · `17` `git worktree add` failed · `18` the tree was
+created and arrived dep-less.
 
-- **The required fields are captured, not assumed.** They are the keys present in both real
-  envelopes committed at `src/hook/__fixtures__/`, with their capture method and harness version
-  beside them (ADR 0180). The golden test runs the argv it reads out of the committed `hooks.json`,
-  so a green test cannot be exercising a verb the surface does not declare.
+- **The required fields are captured, not assumed.** They are the keys present in every real
+  envelope committed at `src/hook/__fixtures__/`, with each capture's method and harness version
+  beside it (ADR 0180). The golden test runs the argv it reads out of the committed declarations, so
+  a green test cannot be exercising a verb no surface declares.
+- **`hook worktree-create` is the one verb that writes.** It creates the `isolation: worktree` tree
+  and prints the path the harness adopts, so every failure arm refuses and a refusal blocks the
+  spawn — including the last one, which reds when `git worktree add` succeeded and
+  `node_modules/.pnpm` is still absent. It is declared in phoenix's own `.claude/settings.json` and
+  deliberately **not** in the plugin's `hooks.json`, because a plugin-declared provider preempts git
+  worktree creation in every adopting repo (ADR 0337).
 - **No verb here decides anything about a spawn.** `hook spawn` — the model-allowlist guard on
   `PreToolUse` — is retired, decision and declaration both (ADR
   [0331](../../.decisions/0331-fabrika-spawn-hook-retired.md)). Model choice is a per-run human

--- a/packages/fabrika-cli/src/hook/__fixtures__/PROVENANCE.md
+++ b/packages/fabrika-cli/src/hook/__fixtures__/PROVENANCE.md
@@ -11,6 +11,7 @@ before trusting any fixture here; a fixture with no provenance beside it is an a
 | [`pre-tool-use.payload.golden.json`](pre-tool-use.payload.golden.json) | `PreToolUse` | `Bash` | [1](#capture-1--the-surface-envelopes) |
 | [`pre-tool-use-spawn.payload.golden.json`](pre-tool-use-spawn.payload.golden.json) | `PreToolUse` (a subagent spawn, `model: "opus"`) | `Task` | [2](#capture-2--the-spawn-envelopes) |
 | [`pre-tool-use-spawn-unset-model.payload.golden.json`](pre-tool-use-spawn-unset-model.payload.golden.json) | `PreToolUse` (a subagent spawn, no model passed) | `Task` | [2](#capture-2--the-spawn-envelopes) |
+| [`worktree-create.payload.golden.json`](worktree-create.payload.golden.json) | `WorktreeCreate` | — | [3](#capture-3--the-worktreecreate-envelope) |
 
 **Sanitization — one substitution, and only one, in every fixture here.** The operator's
 home-directory segment inside `transcript_path` is replaced with `<operator>`; nothing else is
@@ -56,13 +57,40 @@ guard filtering on `tool_name === "Task"` would never run. And the model arrives
 **`opus`**, never the canonical `claude-opus-4-8` — which is the fact the alias map in
 [`../../models.ts`](../../models.ts) exists for.
 
+<a id="capture-3--the-worktreecreate-envelope"></a>
+## Capture 3 — the `WorktreeCreate` envelope
+
+**Captured:** 2026-08-28, against **Claude Code 2.1.251**.
+
+**How:** a throwaway git repository at `/private/tmp/fabrika-worktree-capture/repo` (one commit, no
+remote), and `claude -p "say ok" --worktree capture-probe` against a `--settings` file whose `hooks`
+block registered `{"type": "command", "command": "cat > <sink>", "timeout": 30}` on `WorktreeCreate`.
+The probe writes stdin and prints no path, so the harness refused the creation with
+`WorktreeCreate hook failed: hook succeeded but returned no worktree path` — the envelope is captured
+and no worktree is made, which is the same shape capture 2 used for the blocked spawns.
+
+**Why a temp directory outside the session scratchpad:** this repo commits no operator or
+machine-local path, and the payload's `cwd` is *the repo the probe ran in*, verbatim. Capturing under
+a path that carried an operator segment would have forced a second edit to a captured value. Only
+`transcript_path` carries the home, so the elision below stays the single substitution it is
+everywhere else here.
+
+**A second run proved the mechanism the fixture only describes.** With the probe replaced by a script
+that ran `git worktree add --detach "$cwd/.claude/worktrees/$name" HEAD` and echoed that path,
+`claude --worktree roundtrip` started normally and `git worktree list` showed the tree at
+`…/repo/.claude/worktrees/roundtrip`. So the constructed layout in
+[`../worktree-create.ts`](../worktree-create.ts) is an observed round trip, not an inference from the
+harness's default path.
+
 ## What is golden here, and what is not
 
 The golden part is the **key set** — which keys the harness sends and which it does not. `PreToolUse`
 carries `prompt_id`, `permission_mode` and `effort`, none of which the hand-authored envelope in v1's
 spawn-guard test knew about; `SessionStart` carries `source` and carries **no** `tool_name`,
 `tool_input` or `prompt_id`; a spawn's `tool_input` carries `subagent_type` and `run_in_background`
-beside the optional `model`. Those presences and absences are what
+beside the optional `model`; `WorktreeCreate` carries `name`, a slug, and carries **no**
+`worktree_path` and **no** `base_ref` — the two fields v1's first handler was built to, which
+fail-closed every worktree spawn crew-wide (#2925). Those presences and absences are what
 [`../envelope.golden.test.ts`](../envelope.golden.test.ts) pins. The values are illustrative — except
 `tool_input.model`, whose alias spelling is itself part of what was captured.
 

--- a/packages/fabrika-cli/src/hook/__fixtures__/worktree-create.payload.golden.json
+++ b/packages/fabrika-cli/src/hook/__fixtures__/worktree-create.payload.golden.json
@@ -1,0 +1,7 @@
+{
+	"session_id": "80f40b22-8788-40d0-ac1c-08ab808d6086",
+	"transcript_path": "/Users/<operator>/.claude/projects/-private-tmp-fabrika-worktree-capture-repo/80f40b22-8788-40d0-ac1c-08ab808d6086.jsonl",
+	"cwd": "/private/tmp/fabrika-worktree-capture/repo",
+	"hook_event_name": "WorktreeCreate",
+	"name": "capture-probe"
+}

--- a/packages/fabrika-cli/src/hook/codes.ts
+++ b/packages/fabrika-cli/src/hook/codes.ts
@@ -59,6 +59,39 @@ export const ENVELOPE_UNKNOWN = 13;
  */
 export const WRONG_EVENT = 14;
 
+/**
+ * A readable `WorktreeCreate` envelope arrived and no worktree can be planned from it — an absent or
+ * relative `cwd`, an absent `name`, or a `name` that is not a plain slug.
+ *
+ * Apart from {@link MALFORMED_ENVELOPE} because the envelope is well-formed: every field
+ * `../hook/envelope.ts` requires is present, and it is the *per-event* half this verb needs that is
+ * unusable. Collapsing them would report a harness sending garbage when it sent a fine envelope.
+ */
+export const UNPLANNABLE_WORKTREE = 15;
+
+/**
+ * The pre-branch `git fetch` failed, so the base is possibly stale and nothing was created.
+ *
+ * Its own seat because it is the one refusal that protects a *correctness* property rather than the
+ * provisioning: branching a lane off a cached tip silently bases it on state missing a sibling's
+ * just-merged commit, and the two collide only at ship time (#3620/#3678).
+ */
+export const BASE_FETCH_FAILED = 16;
+
+/** `git worktree add` failed. The tree does not exist, so no path may be emitted (ADR 0092). */
+export const WORKTREE_ADD_FAILED = 17;
+
+/**
+ * The tree was created and its deps were **not** provisioned — `node_modules/.pnpm` is absent after
+ * `git worktree add` returned.
+ *
+ * The whole point of the hook is that this state never reaches an agent, so it is a refusal and not
+ * a warning: `bootstrap-deps` clean-SKIPs at exit 0 when it finds no toolchain (ADR 0109 §3), which
+ * makes a successful `git worktree add` byte-identical to a provisioned one. Checking the artifact
+ * is the only way to tell them apart.
+ */
+export const DEPS_NOT_PROVISIONED = 18;
+
 /** The verb never ran (unresolved binary). The shell's, not this process's — no constant owns it. */
 const NEVER_RAN = 127;
 
@@ -79,6 +112,10 @@ export const HOOK_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
 	},
 	{code: ENVELOPE_UNKNOWN, meaning: "fd 0 could not be read — UNKNOWN, never malformed"},
 	{code: WRONG_EVENT, meaning: "the envelope is a harness event this verb does not judge"},
+	{code: UNPLANNABLE_WORKTREE, meaning: "the envelope names no worktree this verb can create"},
+	{code: BASE_FETCH_FAILED, meaning: "the base ref could not be fetched — the base would be stale"},
+	{code: WORKTREE_ADD_FAILED, meaning: "`git worktree add` failed — no worktree exists"},
+	{code: DEPS_NOT_PROVISIONED, meaning: "the worktree was created and its deps were not installed"},
 	{code: NO_IMPLEMENTATION, meaning: "no implementation could be resolved"},
 	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},
 ];

--- a/packages/fabrika-cli/src/hook/command.ts
+++ b/packages/fabrika-cli/src/hook/command.ts
@@ -15,6 +15,7 @@ import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import {runCheck} from "./check-verb.ts";
 import {runCodes} from "./codes-verb.ts";
+import {runWorktreeCreate} from "./worktree-create-verb.ts";
 
 const jsonFlag = Flag.boolean("json").pipe(
 	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
@@ -46,11 +47,35 @@ const codes = leafCommand(
 	),
 );
 
+const worktreeCreate = leafCommand(
+	"worktree-create",
+	{
+		dryRun: Flag.boolean("dry-run").pipe(
+			Flag.withDescription("print the path this would create, and create nothing"),
+		),
+	},
+	Effect.fn(function* ({dryRun}) {
+		yield* emitOutcome(
+			yield* runWorktreeCreate({
+				stdin: Effect.sync(readStdin),
+				dryRun,
+				env: globalThis.process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Provision the isolation worktree a WorktreeCreate envelope names."),
+	Command.withDescription(
+		"Create the `isolation: worktree` tree the WorktreeCreate envelope on STDIN names, with its deps installed, and print its absolute path on stdout — the path the harness adopts. Fetches the base before branching, runs `git worktree add --detach` under a PATH that resolves the toolchain so lefthook's post-checkout install runs, and refuses unless the virtual store landed. Exits 3 (stdin held nothing), 12 (not a hook envelope), 13 (fd 0 unreadable — UNKNOWN), 14 (a harness event this verb does not judge), 15 (the envelope names no creatable worktree), 16 (the base could not be fetched), 17 (`git worktree add` failed), 18 (the tree was created dep-less). Every non-zero exit blocks the spawn. Example: fabrika hook worktree-create",
+	),
+);
+
 export const hookCommand = Command.make("hook").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
 		check,
 		codes,
+		worktreeCreate,
 	]),
 	Command.withShortDescription("Own fabrika's Claude Code hook surface."),
 	Command.withDescription(

--- a/packages/fabrika-cli/src/hook/declaration.ts
+++ b/packages/fabrika-cli/src/hook/declaration.ts
@@ -1,5 +1,11 @@
 /**
- * Read `claude-plugins/fabrika/hooks.json` and judge it against the two rules that fix the surface.
+ * Read a hook declaration and judge it against the two rules that fix the surface.
+ *
+ * Two documents declare fabrika hooks and both are read here, because rule 5 binds a declared
+ * command wherever it is written: `claude-plugins/fabrika/hooks.json` is the **plugin** surface,
+ * which travels to every adopting repo, and phoenix's own `.claude/settings.json` carries the one
+ * event the plugin surface may not (ADR 0337). They share this shape exactly, so one reader serves
+ * both — what differs is which events each may declare, which the golden test asserts per document.
  *
  * This exists so the declaration is checked as *data* rather than by a reviewer's eye. The rules are
  * not restated here — they are cli-interface-convention rule 5 (a plain literal command string, and

--- a/packages/fabrika-cli/src/hook/envelope.golden.test.ts
+++ b/packages/fabrika-cli/src/hook/envelope.golden.test.ts
@@ -5,11 +5,13 @@
  * one of them be assumed:
  *
  *   1. The **committed declaration** is what gets run. The argv comes out of
- *      `claude-plugins/fabrika/hooks.json`, never out of a literal here — so a test that passes
- *      cannot be exercising a verb the declaration does not name (the false-green this campaign
- *      keeps paying for).
+ *      `claude-plugins/fabrika/hooks.json` for the plugin surface and `.claude/settings.json` for
+ *      this repo's own, never out of a literal here — so a test that passes cannot be exercising a
+ *      verb the declaration does not name (the false-green this campaign keeps paying for). Which
+ *      events each document may carry is asserted per document, because that split is a decision
+ *      (ADR 0337) and not a filing convenience.
  *   2. The **bytes** are the captured ones. `__fixtures__/*.golden.json` are what Claude Code
- *      2.1.226 actually wrote to a hook's stdin; `__fixtures__/PROVENANCE.md` says how. A
+ *      really wrote to a hook's stdin; `__fixtures__/PROVENANCE.md` says how, per build. A
  *      hand-authored envelope in the assertion path is the anti-pattern ADR 0180 exists for — v1's
  *      spawn-guard test hand-authored a `PreToolUse` envelope and so never knew the harness sends
  *      `prompt_id`, `permission_mode` and `effort`.
@@ -21,13 +23,15 @@ import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {loadGoldenPayload, readGoldenFixture} from "../golden-fixture.ts";
 import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
-import {MALFORMED_ENVELOPE} from "./codes.ts";
+import {MALFORMED_ENVELOPE, WRONG_EVENT} from "./codes.ts";
 import {argvOf, declaredHooks, violations} from "./declaration.ts";
 
 const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
 const HOOKS_JSON = "../../../../claude-plugins/fabrika/hooks.json";
+const SETTINGS_JSON = "../../../../.claude/settings.json";
 
 const surface = declaredHooks(JSON.parse(readGoldenFixture(import.meta.url, HOOKS_JSON)));
+const repoSurface = declaredHooks(JSON.parse(readGoldenFixture(import.meta.url, SETTINGS_JSON)));
 
 /**
  * The hook the declaration puts on `event`, or a throw.
@@ -36,10 +40,10 @@ const surface = declaredHooks(JSON.parse(readGoldenFixture(import.meta.url, HOOK
  * a hook re-orders the array, and an index would then silently exercise a different verb than the one
  * the assertions below are written about.
  */
-const declaredOn = (event: string) => {
-	const hook = surface.find((row) => row.event === event);
-	if (hook === undefined) throw new Error(`hooks.json declares no ${event} hook`);
-	return hook;
+const declaredOn = (event: string, rows: ReadonlyArray<{event: string}> = surface) => {
+	const hook = rows.find((row) => row.event === event);
+	if (hook === undefined) throw new Error(`the declaration carries no ${event} hook`);
+	return hook as (typeof surface)[number];
 };
 
 interface Run {
@@ -53,9 +57,13 @@ interface Run {
  * line a verdict rests on is only asserted if it is readable on the path that produced a verdict.
  * `FABRIKA_SKIP_INFER` pins the invocation to *this* copy rather than whatever the root resolves.
  */
-const runDeclared = (command: string, stdin: string): Run => {
+const runDeclared = (
+	command: string,
+	stdin: string,
+	extraArgs: ReadonlyArray<string> = [],
+): Run => {
 	const env: NodeJS.ProcessEnv = {...process.env, FABRIKA_SKIP_INFER: "1"};
-	const run = spawnSync(process.execPath, [BIN, ...argvOf(command)], {
+	const run = spawnSync(process.execPath, [BIN, ...argvOf(command), ...extraArgs], {
 		encoding: "utf8",
 		input: stdin,
 		env,
@@ -74,6 +82,90 @@ describe("the committed hook declaration", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}
 
 	it("declares every hook on an event whose real envelope is committed beside this test", () => {
 		expect([...new Set(surface.map((hook) => hook.event))].sort()).toEqual(["SessionStart"]);
+	});
+
+	/**
+	 * The plugin travels to every adopting repo, and a `WorktreeCreate` hook preempts git worktree
+	 * creation wherever it is declared — with no fail-open form, since the harness reads even the
+	 * convention's never-ran codes as a creation failure. So that event lives in phoenix's own
+	 * settings and may never be declared here (ADR 0337, ADR 0250).
+	 */
+	it("declares no provider event on the plugin surface, which adopting repos inherit", () => {
+		expect(surface.filter((hook) => hook.event.startsWith("Worktree"))).toEqual([]);
+	});
+});
+
+describe("this repo's own hook declaration", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("declares at least one hook — a surface with zero rows is never a pass (ADR 0092)", () => {
+		expect(repoSurface.length).toBeGreaterThan(0);
+	});
+
+	it("breaks neither rule 5 (plain literal) nor rule 6 (nothing outside fabrika)", () => {
+		expect(violations(repoSurface)).toEqual([]);
+	});
+
+	it("carries the WorktreeCreate provider and nothing else", () => {
+		expect([...new Set(repoSurface.map((hook) => hook.event))].sort()).toEqual(["WorktreeCreate"]);
+	});
+
+	/**
+	 * 600s, not the harness default. The budget is the whole reason the hook exists: `git worktree
+	 * add` fires lefthook's `post-checkout` install, which is far slower than the ~13s the harness's
+	 * default worktree path allows (ADR 0178).
+	 */
+	it("gives the provisioning install a budget the install can finish inside", () => {
+		const settings = JSON.parse(readGoldenFixture(import.meta.url, SETTINGS_JSON)) as {
+			hooks: {WorktreeCreate: Array<{hooks: Array<{timeout?: number}>}>};
+		};
+		expect(settings.hooks.WorktreeCreate[0]?.hooks[0]?.timeout).toBe(600);
+	});
+});
+
+describe("the WorktreeCreate provider, run against the captured envelope", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	const declared = declaredOn("WorktreeCreate", repoSurface);
+
+	/**
+	 * `--dry-run` is appended rather than declared: the harness adopts whatever path the hook prints,
+	 * so a run that mutated nothing and printed one anyway would be the false green this event is
+	 * most dangerous for. Rule 5's literal grammar cannot express a flag, so the declared command
+	 * can never carry it — which is what keeps the flag a test affordance rather than a live one.
+	 */
+	it("constructs the path the harness would adopt, from the captured envelope's own fields", () => {
+		const run = runDeclared(
+			declared.command,
+			readGoldenFixture(import.meta.url, "__fixtures__/worktree-create.payload.golden.json"),
+			["--dry-run"],
+		);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toBe(
+			"/private/tmp/fabrika-worktree-capture/repo/.claude/worktrees/capture-probe\n",
+		);
+	});
+
+	it("refuses an envelope for an event it does not judge, rather than provisioning from it", () => {
+		const run = runDeclared(
+			declared.command,
+			readGoldenFixture(import.meta.url, "__fixtures__/session-start.payload.golden.json"),
+			["--dry-run"],
+		);
+		expect(run.code).toBe(WRONG_EVENT);
+		expect(run.stdout).toBe("");
+	});
+
+	it("refuses a hand-authored envelope of the shape a doc-assumed contract would produce", () => {
+		const run = runDeclared(
+			declared.command,
+			JSON.stringify({
+				hook_event_name: "WorktreeCreate",
+				worktree_path: "/tmp/x",
+				base_ref: "main",
+			}),
+			["--dry-run"],
+		);
+		expect(run.code).toBe(MALFORMED_ENVELOPE);
+		expect(run.stdout).toBe("");
 	});
 });
 
@@ -180,8 +272,29 @@ describe("the captured envelope shape, pinned by exact key set", {
 		expect(payload.tool_input).not.toHaveProperty("model");
 	});
 
+	/**
+	 * The two fields a doc-assumed contract invents are what this pins. The harness sends `name`, a
+	 * slug — never `worktree_path` and never `base_ref` — so the path is *constructed* and the base
+	 * is the hook's own call. v1 shipped a handler built to the invented shape and it fail-closed
+	 * every worktree spawn (#2925).
+	 */
+	it("WorktreeCreate carries these keys and no others — `name`, not `worktree_path`", () => {
+		const payload = loadGoldenPayload(
+			import.meta.url,
+			"__fixtures__/worktree-create.payload.golden.json",
+		);
+		expect(Object.keys(payload).sort()).toEqual(
+			["cwd", "hook_event_name", "name", "session_id", "transcript_path"].sort(),
+		);
+		expect(payload.hook_event_name).toBe("WorktreeCreate");
+		for (const invented of ["worktree_path", "base_ref"]) {
+			expect(payload).not.toHaveProperty(invented);
+		}
+	});
+
 	it("carries no operator home path — the one sanitization, applied and still applied", () => {
 		for (const fixture of [
+			"__fixtures__/worktree-create.payload.golden.json",
 			"__fixtures__/session-start.payload.golden.json",
 			"__fixtures__/pre-tool-use.payload.golden.json",
 			"__fixtures__/pre-tool-use-spawn.payload.golden.json",

--- a/packages/fabrika-cli/src/hook/envelope.golden.test.ts
+++ b/packages/fabrika-cli/src/hook/envelope.golden.test.ts
@@ -104,8 +104,17 @@ describe("this repo's own hook declaration", {timeout: SUBPROCESS_TEST_TIMEOUT_M
 		expect(violations(repoSurface)).toEqual([]);
 	});
 
-	it("carries the WorktreeCreate provider and nothing else", () => {
-		expect([...new Set(repoSurface.map((hook) => hook.event))].sort()).toEqual(["WorktreeCreate"]);
+	/**
+	 * Asserted by containment, not exhaustively: a later unrelated repo hook is the repo's call to
+	 * make, and reddening this package's suite over one would say nothing about fabrika. The teeth
+	 * are the `Worktree*` bound — exactly one provisioning provider, here and nowhere else.
+	 */
+	it("carries the WorktreeCreate provider, and no second Worktree event beside it", () => {
+		const events = repoSurface.map((hook) => hook.event);
+		expect(events).toContain("WorktreeCreate");
+		expect([...new Set(events.filter((event) => event.startsWith("Worktree")))]).toEqual([
+			"WorktreeCreate",
+		]);
 	});
 
 	/**

--- a/packages/fabrika-cli/src/hook/worktree-create-verb.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create-verb.ts
@@ -1,0 +1,205 @@
+/**
+ * `hook worktree-create` — the provider verb behind phoenix's `WorktreeCreate` hook.
+ *
+ * It exists because the harness's own worktree path leaves the tree **dep-less**. That path execs
+ * git hooks with a stripped `PATH`, so lefthook's `post-checkout` `bootstrap-deps` finds no
+ * corepack, no pinned pnpm and no npm, and clean-SKIPs at exit 0 (ADR 0109 §3) — a silent skip that
+ * is byte-identical, from the outside, to a successful install. Every `isolation: worktree` shell
+ * then pays an install before its first verb, or fails at exit 126 on it (#7220).
+ *
+ * A `WorktreeCreate` hook **replaces** that path, and that is the whole mechanism: this verb runs
+ * `git worktree add` itself, under a `PATH` that resolves the toolchain and a 600s hook budget, so
+ * the same `bootstrap-deps` install ADR 0109 already owns actually runs. Nothing about *how* deps
+ * are installed changes — only who triggers it and with what environment (ADR 0178, rehomed by ADR
+ * 0337).
+ *
+ * **Every failure arm refuses, and a refusal blocks the spawn.** That is deliberate: the harness
+ * reads any non-zero exit as a creation failure and does not fall back to git, so a blocked spawn is
+ * the only honest alternative to handing an agent a tree this verb could not finish (ADR 0092). The
+ * last arm is the one that makes the guarantee real — `git worktree add` succeeding proves nothing
+ * about the install, so the deps are checked as an artifact before any path is emitted.
+ */
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type ChildOutcome, execRecord} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BASE_FETCH_FAILED,
+	DEPS_NOT_PROVISIONED,
+	EMPTY_STDIN,
+	ENVELOPE_UNKNOWN,
+	MALFORMED_ENVELOPE,
+	UNPLANNABLE_WORKTREE,
+	WORKTREE_ADD_FAILED,
+	WRONG_EVENT,
+} from "./codes.ts";
+import {classifyEnvelope, type EnvelopeRead} from "./envelope.ts";
+import {childEnv, planWorktree, type WorktreePlan} from "./worktree-create.ts";
+
+const VERB = "fabrika hook worktree-create";
+const EVENT = "WorktreeCreate";
+
+/** The hook's own budget is 600s; each child gets most of it, so a slow install is not a timeout. */
+const GIT_TIMEOUT_SECONDS = 540;
+const CAPTURE_BYTES = 64 * 1024;
+
+/** The proof deps landed. `bootstrap-deps` writes the virtual store; a clean SKIP writes nothing. */
+const VIRTUAL_STORE = "node_modules/.pnpm";
+
+export interface WorktreeCreateOptions {
+	readonly stdin: Effect.Effect<StdinRead>;
+	/** Plan and report, mutate nothing. The declared hook can never pass it — rule 5 forbids flags. */
+	readonly dryRun: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+type Requirements = ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem;
+
+const readEnvelope = (piped: StdinRead): EnvelopeRead =>
+	piped._tag === "Text" ? classifyEnvelope(piped.text) : {_tag: "Unknown", reason: piped.reason};
+
+/** The child's diagnostics, trimmed to one quotable line for the refusal that names them. */
+const firstLine = (bytes: Uint8Array): string => {
+	const text = new TextDecoder().decode(bytes);
+	return (text.split("\n").find((line) => line.trim() !== "") ?? "").trim();
+};
+
+const describe = (outcome: ChildOutcome): string => {
+	if (outcome._tag === "Unstartable") return `could not run git — ${outcome.reason}`;
+	if (outcome.timedOut) return `git did not finish within ${GIT_TIMEOUT_SECONDS}s`;
+	return firstLine(outcome.stderr) || `git exited ${outcome.exitCode}`;
+};
+
+const succeeded = (outcome: ChildOutcome): boolean =>
+	outcome._tag === "Ran" && !outcome.timedOut && outcome.exitCode === 0;
+
+const git = (
+	args: ReadonlyArray<string>,
+	cwd: string,
+	env: Record<string, string>,
+): Effect.Effect<ChildOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	execRecord({
+		file: "git",
+		args,
+		cwd,
+		env,
+		timeoutSeconds: GIT_TIMEOUT_SECONDS,
+		captureBytes: CAPTURE_BYTES,
+	});
+
+/**
+ * The branch `origin`'s HEAD points at, or `main`.
+ *
+ * Read rather than hardcoded so a repo whose default branch is not `main` provisions instead of
+ * refusing on every spawn — but the fallback is a plain default, not a guess dressed as a read: an
+ * unresolvable `origin/HEAD` is the ordinary state of a fresh clone, and the fetch below is what
+ * turns a wrong answer into a loud one.
+ */
+const baseBranch = (
+	repoRoot: string,
+	env: Record<string, string>,
+): Effect.Effect<string, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], repoRoot, env).pipe(
+		Effect.map((outcome) => {
+			if (!succeeded(outcome) || outcome._tag !== "Ran") return "main";
+			const ref = new TextDecoder().decode(outcome.stdout).trim();
+			const slash = ref.indexOf("/");
+			return slash > 0 ? ref.slice(slash + 1) : "main";
+		}),
+	);
+
+/**
+ * Provision the tree the plan names, or refuse with the arm that failed.
+ *
+ * The fetch is not a courtesy. The primary checkout's `origin/main` only advances on an explicit
+ * fetch and nothing fetches per spawn, so branching off the cached tip bases a lane on state missing
+ * a sibling lane's just-merged commit — two lanes then both go green in isolation and collide at
+ * ship time, or one silently reverts the other (#3620/#3678). `FETCH_HEAD` is exactly what the fetch
+ * just wrote, so freshness does not depend on any remote-tracking refspec, and the fetch never moves
+ * the primary's local `main`.
+ */
+const provision = (
+	plan: WorktreePlan,
+	env: Record<string, string>,
+): Effect.Effect<VerbOutcome, never, Requirements> =>
+	Effect.gen(function* () {
+		const base = yield* baseBranch(plan.repoRoot, env);
+
+		const fetched = yield* git(["fetch", "--quiet", "origin", base], plan.repoRoot, env);
+		if (!succeeded(fetched)) {
+			return refuse(
+				BASE_FETCH_FAILED,
+				`${VERB}: could not fetch origin/${base} — refusing to branch from a possibly stale base: ${describe(fetched)}`,
+			);
+		}
+
+		// `--detach`: a linked worktree cannot check out a local branch the primary already holds, and
+		// every lane re-branches at its own preflight anyway, so this base HEAD is throwaway.
+		const added = yield* git(
+			["worktree", "add", "--detach", plan.worktreePath, "FETCH_HEAD"],
+			plan.repoRoot,
+			env,
+		);
+		if (!succeeded(added)) {
+			return refuse(
+				WORKTREE_ADD_FAILED,
+				`${VERB}: git worktree add --detach ${plan.worktreePath} FETCH_HEAD failed: ${describe(added)}`,
+			);
+		}
+
+		const fs = yield* FileSystem.FileSystem;
+		const provisioned = yield* fs
+			.exists(`${plan.worktreePath}/${VIRTUAL_STORE}`)
+			.pipe(Effect.orElseSucceed(() => false));
+		if (!provisioned) {
+			return refuse(
+				DEPS_NOT_PROVISIONED,
+				`${VERB}: ${plan.worktreePath} has no ${VIRTUAL_STORE} — bootstrap-deps skipped or failed, so the tree would arrive dep-less (ADR 0109 §3)`,
+				[`${VERB}: remove the half-built tree with \`git worktree remove ${plan.worktreePath}\``],
+			);
+		}
+
+		return answer(plan.worktreePath, [
+			`${VERB}: provisioned ${plan.worktreePath} at origin/${base}`,
+		]);
+	});
+
+export const runWorktreeCreate = ({
+	stdin,
+	dryRun,
+	env,
+}: WorktreeCreateOptions): Effect.Effect<VerbOutcome, never, Requirements> =>
+	Effect.gen(function* () {
+		const read = readEnvelope(yield* stdin);
+
+		if (read._tag === "Empty") {
+			return refuse(EMPTY_STDIN, `${VERB}: stdin was read and held no ${EVENT} envelope`);
+		}
+		if (read._tag === "Unknown") {
+			return refuse(ENVELOPE_UNKNOWN, `${VERB}: envelope UNKNOWN — ${read.reason}`);
+		}
+		if (read._tag === "Malformed") {
+			return refuse(MALFORMED_ENVELOPE, `${VERB}: not a hook envelope — ${read.reason}`, [
+				`${VERB}: ${read.evidence}`,
+			]);
+		}
+		if (read.envelope.event !== EVENT) {
+			return refuse(
+				WRONG_EVENT,
+				`${VERB}: judges ${EVENT} and the envelope is ${read.envelope.event} — the declaration is wired to the wrong event`,
+			);
+		}
+
+		const planned = planWorktree(read.envelope.payload);
+		if (planned._tag === "Unplannable") {
+			return refuse(UNPLANNABLE_WORKTREE, `${VERB}: ${planned.reason}`);
+		}
+
+		const scope = `${VERB}: ${dryRun ? "would provision" : "provisioning"} ${planned.plan.worktreePath}`;
+		if (dryRun) return answer(planned.plan.worktreePath, [scope]);
+
+		return yield* provision(planned.plan, childEnv(env)).pipe(
+			Effect.map((outcome) => ({...outcome, stderr: [scope, ...outcome.stderr]})),
+		);
+	});

--- a/packages/fabrika-cli/src/hook/worktree-create.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create.ts
@@ -101,20 +101,61 @@ export const toolchainPath = (inherited: string | undefined, home: string | unde
 	return ordered.join(":");
 };
 
+/** What `bootstrap-deps` needs: the pnpm/corepack store under `HOME`, and a stable locale. */
+const INSTALL_KEYS: ReadonlyArray<string> = [
+	"HOME",
+	"LANG",
+	"LC_ALL",
+	"TMPDIR",
+	"COREPACK_HOME",
+	"XDG_CACHE_HOME",
+];
+
+/**
+ * What `git fetch origin` needs. phoenix's `origin` is SSH-only — `url.git@github.com:.insteadof`
+ * rewrites every HTTPS remote — so with no agent socket the fetch has no credential path at all.
+ */
+const CREDENTIAL_KEYS: ReadonlyArray<string> = [
+	"SSH_AUTH_SOCK",
+	"SSH_AGENT_PID",
+	"GIT_SSH",
+	"GIT_SSH_COMMAND",
+];
+
+/**
+ * The ssh command, forced non-interactive.
+ *
+ * A hook child has no tty and inherits no `SSH_ASKPASS`/`DISPLAY`, so an ssh that decides to ask for
+ * a passphrase cannot be answered — it just blocks until the 540s child timeout, turning every spawn
+ * into a nine-minute refusal. `BatchMode=yes` makes that same miss fail at once.
+ */
+const nonInteractiveSsh = (inherited: string | undefined): string => {
+	const command = inherited === undefined || inherited.trim() === "" ? "ssh" : inherited.trim();
+	return /batchmode/i.test(command) ? command : `${command} -o BatchMode=yes`;
+};
+
 /**
  * The environment the two git children run under.
  *
  * Nothing is inherited implicitly (`execRecord` sets `extendEnv: false`), so what is not here does
- * not reach `bootstrap-deps`. `HOME` carries the pnpm/corepack store — an install without it
- * re-downloads the world or fails outright — and `PATH` is the composed one above.
+ * not reach the children. Two jobs are served: the install's store and locale, and the fetch's
+ * credentials — which are forwarded *and* pinned non-interactive, so a credential miss refuses at
+ * `BASE_FETCH_FAILED` in seconds rather than hanging out the child timeout (ADR 0337).
  */
 export const childEnv = (
 	source: Readonly<Record<string, string | undefined>>,
 ): Record<string, string> => {
 	const env: Record<string, string> = {PATH: toolchainPath(source.PATH, source.HOME)};
-	for (const key of ["HOME", "LANG", "LC_ALL", "TMPDIR", "COREPACK_HOME", "XDG_CACHE_HOME"]) {
+	for (const key of [...INSTALL_KEYS, ...CREDENTIAL_KEYS]) {
 		const value = source[key];
 		if (value !== undefined && value !== "") env[key] = value;
+	}
+
+	env.GIT_TERMINAL_PROMPT = "0";
+	// An operator's `GIT_SSH` wrapper is the transport git would pick; injecting a `GIT_SSH_COMMAND`
+	// beside it would silently outrank it, so that one case is left exactly as it was inherited.
+	if (env.GIT_SSH === undefined || env.GIT_SSH_COMMAND !== undefined) {
+		env.GIT_SSH_COMMAND = nonInteractiveSsh(env.GIT_SSH_COMMAND);
 	}
 	return env;
 };

--- a/packages/fabrika-cli/src/hook/worktree-create.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create.ts
@@ -1,0 +1,120 @@
+/**
+ * The decisions behind `hook worktree-create`, with no subprocess and no fd in sight.
+ *
+ * `WorktreeCreate` is a **provider** hook: the harness hands it a slug and expects the worktree to
+ * exist and its path on stdout when the hook exits 0 (`../../../../claude-plugins/fabrika/docs/hook-surface.md`).
+ * So the verb beside this file runs two git commands, and everything it has to get *right* before it
+ * runs them — where the tree goes, what the child's `PATH` must carry — is decided here, where a
+ * unit test can drive it.
+ *
+ * Two facts this module encodes are captured, not assumed (ADR 0180): the payload carries `cwd` and
+ * `name` and **no** `worktree_path` or `base_ref`, and the path is therefore *constructed* rather
+ * than read. `__fixtures__/worktree-create.payload.golden.json` is the capture.
+ */
+
+/** Where a hook-provisioned worktree goes, and the repo the git commands run in. */
+export interface WorktreePlan {
+	/** The repository root the payload named. Every git command runs here, not in `process.cwd()`. */
+	readonly repoRoot: string;
+	/** The harness's suggested slug, verbatim. */
+	readonly name: string;
+	/** `<repoRoot>/.claude/worktrees/<name>` — the layout the harness's own default path uses. */
+	readonly worktreePath: string;
+}
+
+export type PlanRead =
+	| {readonly _tag: "Plan"; readonly plan: WorktreePlan}
+	| {readonly _tag: "Unplannable"; readonly reason: string};
+
+/**
+ * A slug that cannot escape `<repoRoot>/.claude/worktrees/`.
+ *
+ * The harness validates the path it gets *back* — it rejects dot segments — but a hook that built a
+ * traversing path has already run `git worktree add` at it by then, so the refusal must happen
+ * before the mutation, not after.
+ */
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** The one place the worktree path is composed. Both the verb and its test read it from here. */
+export const worktreePathFor = (repoRoot: string, name: string): string =>
+	`${repoRoot}/.claude/worktrees/${name}`;
+
+/**
+ * Turn a captured `WorktreeCreate` payload into the plan, or say why there is none.
+ *
+ * Every arm is fail-closed on purpose: the verb's caller is the harness, a refusal there blocks the
+ * spawn, and a spawn that never happens is strictly better than one landing in a tree this hook
+ * could not fully build (ADR 0092).
+ */
+export const planWorktree = (payload: Record<string, unknown>): PlanRead => {
+	const repoRoot = typeof payload.cwd === "string" ? payload.cwd.trim() : "";
+	const name = typeof payload.name === "string" ? payload.name.trim() : "";
+
+	if (repoRoot === "") return {_tag: "Unplannable", reason: "the payload carries no `cwd`"};
+	if (!repoRoot.startsWith("/")) {
+		return {_tag: "Unplannable", reason: `\`cwd\` is not an absolute path: ${repoRoot}`};
+	}
+	if (name === "") return {_tag: "Unplannable", reason: "the payload carries no `name`"};
+	if (!SAFE_NAME.test(name)) {
+		return {
+			_tag: "Unplannable",
+			reason: `\`name\` is not a plain worktree slug and could escape the worktree root: ${name}`,
+		};
+	}
+
+	return {_tag: "Plan", plan: {repoRoot, name, worktreePath: worktreePathFor(repoRoot, name)}};
+};
+
+/**
+ * The standard toolchain locations, prepended to whatever `PATH` the hook inherited.
+ *
+ * This is the whole reason provisioning works at all. `git worktree add` fires lefthook's
+ * `post-checkout` `bootstrap-deps`, and that hook **clean-SKIPs at exit 0** when it finds no
+ * corepack, no pinned pnpm and no npm on `PATH` (ADR 0109 §3) — which is precisely the harness's
+ * PATH-stripped `git worktree add` exec env (#787–#789). A skip there is silent, so the tree is
+ * created, adopted, and useless. Prepending the OS-standard bin dirs is what lets the install run.
+ *
+ * OS/standard dirs only, never a per-machine volta/fnm shim — ADR 0109's prohibition. The inherited
+ * `PATH` is kept **last** rather than dropped, so a machine whose toolchain lives somewhere else
+ * still resolves it.
+ */
+const STANDARD_BIN_DIRS: ReadonlyArray<string> = [
+	"/opt/homebrew/bin",
+	"/usr/local/bin",
+	"/bin",
+	"/usr/bin",
+];
+
+export const toolchainPath = (inherited: string | undefined, home: string | undefined): string => {
+	const localBin = home === undefined || home.trim() === "" ? [] : [`${home}/.local/bin`];
+	const seen = new Set<string>();
+	const ordered: string[] = [];
+	for (const dir of [
+		...STANDARD_BIN_DIRS,
+		...localBin,
+		...(inherited ?? "").split(":").filter((d) => d !== ""),
+	]) {
+		if (seen.has(dir)) continue;
+		seen.add(dir);
+		ordered.push(dir);
+	}
+	return ordered.join(":");
+};
+
+/**
+ * The environment the two git children run under.
+ *
+ * Nothing is inherited implicitly (`execRecord` sets `extendEnv: false`), so what is not here does
+ * not reach `bootstrap-deps`. `HOME` carries the pnpm/corepack store — an install without it
+ * re-downloads the world or fails outright — and `PATH` is the composed one above.
+ */
+export const childEnv = (
+	source: Readonly<Record<string, string | undefined>>,
+): Record<string, string> => {
+	const env: Record<string, string> = {PATH: toolchainPath(source.PATH, source.HOME)};
+	for (const key of ["HOME", "LANG", "LC_ALL", "TMPDIR", "COREPACK_HOME", "XDG_CACHE_HOME"]) {
+		const value = source[key];
+		if (value !== undefined && value !== "") env[key] = value;
+	}
+	return env;
+};

--- a/packages/fabrika-cli/src/hook/worktree-create.unit.test.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create.unit.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from "vitest";
+import {loadGoldenPayload} from "../golden-fixture.ts";
+import {childEnv, planWorktree, toolchainPath, worktreePathFor} from "./worktree-create.ts";
+
+describe("planning a worktree from a WorktreeCreate payload", () => {
+	it("constructs the path from the captured envelope's cwd and name", () => {
+		const payload = loadGoldenPayload(
+			import.meta.url,
+			"__fixtures__/worktree-create.payload.golden.json",
+		);
+		const read = planWorktree(payload);
+		expect(read).toEqual({
+			_tag: "Plan",
+			plan: {
+				repoRoot: "/private/tmp/fabrika-worktree-capture/repo",
+				name: "capture-probe",
+				worktreePath: "/private/tmp/fabrika-worktree-capture/repo/.claude/worktrees/capture-probe",
+			},
+		});
+	});
+
+	it("lays the tree where the harness's own default path lays it", () => {
+		expect(worktreePathFor("/repo", "agent-abc")).toBe("/repo/.claude/worktrees/agent-abc");
+	});
+
+	it.each([
+		["an absent cwd", {name: "agent-1"}, "carries no `cwd`"],
+		["a relative cwd", {cwd: "repo", name: "agent-1"}, "not an absolute path"],
+		["an absent name", {cwd: "/repo"}, "carries no `name`"],
+		["a blank name", {cwd: "/repo", name: "   "}, "carries no `name`"],
+	])("refuses %s rather than composing a path from it", (_label, payload, reason) => {
+		const read = planWorktree(payload);
+		expect(read._tag).toBe("Unplannable");
+		if (read._tag === "Unplannable") expect(read.reason).toContain(reason);
+	});
+
+	/**
+	 * The harness rejects a returned path with dot segments — but by then the hook has already run
+	 * `git worktree add` at it, so the refusal has to happen here, before the mutation.
+	 */
+	it.each([
+		["../escape"],
+		["a/b"],
+		["/absolute"],
+		[".hidden"],
+		["-leading-dash"],
+	])("refuses the traversing or odd slug %s before any git command runs", (name) => {
+		expect(planWorktree({cwd: "/repo", name})._tag).toBe("Unplannable");
+	});
+});
+
+describe("the PATH the git child runs under", () => {
+	it("prepends the standard toolchain dirs, since a stripped PATH makes bootstrap-deps clean-SKIP", () => {
+		expect(toolchainPath("/usr/bin", "/home/x").split(":")).toEqual([
+			"/opt/homebrew/bin",
+			"/usr/local/bin",
+			"/bin",
+			"/usr/bin",
+			"/home/x/.local/bin",
+		]);
+	});
+
+	it("keeps the inherited PATH last rather than dropping it — a toolchain elsewhere still resolves", () => {
+		expect(toolchainPath("/opt/node/bin", undefined)).toBe(
+			"/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin:/opt/node/bin",
+		);
+	});
+
+	it("composes a usable PATH even when the hook inherited none", () => {
+		expect(toolchainPath(undefined, undefined)).toBe(
+			"/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin",
+		);
+	});
+});
+
+describe("the environment the git child runs under", () => {
+	it("carries HOME, so the install reads the shared pnpm store instead of refetching the world", () => {
+		expect(childEnv({PATH: "/usr/bin", HOME: "/home/x"})).toMatchObject({HOME: "/home/x"});
+	});
+
+	it("passes through nothing the list does not name — the child inherits no ambient environment", () => {
+		expect(
+			Object.keys(childEnv({PATH: "/usr/bin", NODE_OPTIONS: "--x", GH_TOKEN: "t"})).sort(),
+		).toEqual(["PATH"]);
+	});
+
+	it("drops an empty value rather than handing the child a blank HOME", () => {
+		expect(childEnv({PATH: "/usr/bin", HOME: ""})).not.toHaveProperty("HOME");
+	});
+});

--- a/packages/fabrika-cli/src/hook/worktree-create.unit.test.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create.unit.test.ts
@@ -81,10 +81,46 @@ describe("the environment the git child runs under", () => {
 	it("passes through nothing the list does not name — the child inherits no ambient environment", () => {
 		expect(
 			Object.keys(childEnv({PATH: "/usr/bin", NODE_OPTIONS: "--x", GH_TOKEN: "t"})).sort(),
-		).toEqual(["PATH"]);
+		).toEqual(["GIT_SSH_COMMAND", "GIT_TERMINAL_PROMPT", "PATH"]);
 	});
 
 	it("drops an empty value rather than handing the child a blank HOME", () => {
 		expect(childEnv({PATH: "/usr/bin", HOME: ""})).not.toHaveProperty("HOME");
+	});
+
+	/**
+	 * phoenix's `origin` is SSH-only, so a fetch with no agent socket has no credential path at all —
+	 * and the hook is the only way any worktree gets created once it is declared.
+	 */
+	it("forwards the ssh-agent channel, so the fetch against an SSH-only origin can authenticate", () => {
+		expect(
+			childEnv({PATH: "/usr/bin", SSH_AUTH_SOCK: "/tmp/agent.7", SSH_AGENT_PID: "812"}),
+		).toMatchObject({SSH_AUTH_SOCK: "/tmp/agent.7", SSH_AGENT_PID: "812"});
+	});
+
+	it("refuses to prompt: a credential miss fails at once instead of hanging out the child timeout", () => {
+		expect(childEnv({PATH: "/usr/bin"})).toMatchObject({
+			GIT_TERMINAL_PROMPT: "0",
+			GIT_SSH_COMMAND: "ssh -o BatchMode=yes",
+		});
+	});
+
+	it("keeps an inherited GIT_SSH_COMMAND and adds BatchMode to it rather than replacing it", () => {
+		expect(
+			childEnv({PATH: "/usr/bin", GIT_SSH_COMMAND: "ssh -i /keys/deploy"}).GIT_SSH_COMMAND,
+		).toBe("ssh -i /keys/deploy -o BatchMode=yes");
+	});
+
+	it("adds no second BatchMode when the inherited command already sets one, in any case", () => {
+		expect(
+			childEnv({PATH: "/usr/bin", GIT_SSH_COMMAND: "ssh -o batchmode=YES"}).GIT_SSH_COMMAND,
+		).toBe("ssh -o batchmode=YES");
+	});
+
+	/** git prefers `GIT_SSH_COMMAND`, so synthesising one would silently outrank the operator's wrapper. */
+	it("leaves a lone GIT_SSH wrapper as the transport instead of overriding it", () => {
+		const env = childEnv({PATH: "/usr/bin", GIT_SSH: "/opt/bin/ssh-wrapper"});
+		expect(env.GIT_SSH).toBe("/opt/bin/ssh-wrapper");
+		expect(env).not.toHaveProperty("GIT_SSH_COMMAND");
 	});
 });


### PR DESCRIPTION
Every `isolation: worktree` shell has been arriving without `node_modules`. Not intermittent — every
fresh worktree, since ADR 0303 deleted the v1 plugin and took ADR 0178's `WorktreeCreate` provider
with it. Three lanes in one session hit it, one at exit 126 on its first `build tree`.

## What this does

Declares `fabrika hook worktree-create` on `WorktreeCreate` in **this repo's own**
`.claude/settings.json`, with a 600s timeout. The verb runs `git worktree add` itself under a PATH
that resolves the toolchain, which is what lets lefthook's `post-checkout` `bootstrap-deps` run the
real install (ADR 0109) instead of clean-SKIPping at exit 0 under the harness's stripped PATH. It
fetches the base first (ADR 0178's #3621 amendment), branches off `FETCH_HEAD` detached, and —
the arm that makes the guarantee real — refuses if `node_modules/.pnpm` is absent afterwards. A
successful `git worktree add` proves nothing about the install, so the artifact is checked.

## Why settings.json and not the plugin's hooks.json

`hook-surface.md` records a deliberate refusal of this event (#5589), and it is correct: a declared
`WorktreeCreate` hook preempts git wherever it is declared, with no fail-open form, so a
plugin-declared one would break `--worktree` in every adopting repo without fabrika installed — the
inverse of ADR 0250. That argument binds the *plugin* surface, which travels. It does not bind
phoenix's own settings, which travel nowhere. The refusal stands for the plugin, and the golden test
now asserts it per document rather than leaving it to a reviewer's eye.

## Verified live, not inferred

Against Claude Code 2.1.251: the payload was captured (`name`, and **no** `worktree_path` /
`base_ref` — the two fields v1's first handler was built to, #2925); a hook that creates
`<cwd>/.claude/worktrees/<name>` and echoes it is adopted, proven by a round-trip session; a hook
that emits no path blocks creation. The verb was then run against phoenix itself: 9.65s, 589
virtual-store entries, and `.pnpm/node_modules/@kampus/db-schema` resolving worktree-local — ADR
0109's correctness property, checked. The probe worktree was removed.

## Where to look first

`.claude/settings.json` and `packages/fabrika-cli/src/hook/worktree-create-verb.ts`, then the
per-document event assertions in `envelope.golden.test.ts`.

Fixes #7220

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 2 names the trigger as registered in
  "`claude-plugins/fabrika/hooks.json` and `.claude/settings.json`". **Did:** registered it in
  `.claude/settings.json` only, and added a test asserting the plugin surface declares no
  `Worktree*` event. **Why:** `hook-surface.md` records a live, reasoned refusal of this event on
  the plugin surface (#5589) — a plugin-declared provider preempts git worktree creation in every
  adopting repo, with no fail-open form on the codes the convention reserves for "the verb never
  ran", so a machine without fabrika loses `--worktree` entirely (the inverse of ADR 0250).
  Registering in both would also double-register the hook: two `git worktree add` calls at one path,
  one of which necessarily fails. **Disposition:** stated here and recorded as the central decision
  of ADR 0337, which preserves #5589's reasoning rather than overturning it.
- **Governing-ADR departure** — **Said:** ADR 0178 registered the hook in `.claude/settings.json`
  *and* mirrored it in the plugin's `hooks.json`, and stamped the owning session into the new tree's
  git admin dir (#3943). **Did:** one registration, and no owner stamp. **Why:** the mirror is the
  deviation above; the stamp's only consumer was `worktree-sweep`, which retired with
  `packages/pipeline-cli/`, so stamping would write a record nothing reads. **Disposition:** both
  recorded in ADR 0337's Consequences.
- **Out-of-scope change** — **Said:** #7220 names the provisioning, the pattern doc and the ADR
  status. **Did:** also corrected two further stale passages in
  `.patterns/worktree-agent-constraints.md` — the owner-stamp paragraph, which cites the deleted
  `create-worktree.sh` as a live producer, and the relocation-lever paragraph, which says this repo
  has no `WorktreeCreate` hook. **Why:** both are made false by this change, and a pattern doc that
  half-corrects reads as authoritative on the half that is still wrong. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the package README. **Did:** added the
  `hook worktree-create` row and its exit codes to `packages/fabrika-cli/README.md`. **Why:**
  `.patterns/verb-output-pin-surfaces.md` makes the README group table one of the six surfaces a
  new or changed verb output must land in the same PR. **Disposition:** stated here.
