### PR TITLE
fix: A reviewer's scratchpad diff file was overwritten mid-read with another PR's bytes

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -122,8 +122,7 @@ the verdict it was heading for would have carried the right head over the wrong 
 nothing downstream can detect (#7246).
 
 ```bash
-staged=$(fabrika review scratch $pr_number --slug diff --lane <lane> --sha 03135b91)
-fabrika review diff $pr_number --sha 03135b91 > "$staged"
+fabrika review scratch $pr_number --slug diff --lane <lane> --sha 03135b91
 ```
 
 `<lane>` is the lane key your spawn brief's `## Task` section carries, and `--sha` is step 1's head:
@@ -131,6 +130,14 @@ the first separates you from the other reviewers of this session, the second fro
 round. The verb prints one absolute path, creates its directory, and **refuses rather than handing
 back the session-wide directory** when either is missing. A run whose caller named no lane cannot
 stage: read the diff in place instead, and never substitute a name of your own.
+
+Then read that path off the verb and redirect the diff into it, typing the path out literally —
+`fabrika review diff $pr_number --sha 03135b91 > <the path it printed>`. **Never capture the
+allocation into a shell variable and never redirect through one.** Command substitution and a
+variable the verifier cannot resolve are each on their own enough for a worktree-isolated shell to
+refuse the line, so a fence built that way does not run for the reviewer it is written for (ADR
+[0235](../../../../.decisions/0235-fences-carry-zero-expansions.md)). A redirect whose target is the
+literal path carries no expansion and runs.
 
 The path is machine-local, so it never appears in what you post — `review post` and
 `review append-criterion` red on it at `5`.

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -114,6 +114,27 @@ to each class's slice: code → [rubrics/code.md](rubrics/code.md) · doc →
 any prose surface: apply **fabrika's** shared writing rubric skill verbatim, never v1's copy; the
 doc rubric's prose-craft line is the fallback until it lands.
 
+<!-- anchor: STAGE-ONLY-UNDER-THE-ALLOCATED-PATH --> **A diff too large for one read is staged under
+the path this verb allocates, and never under a name you chose.** The session scratchpad is shared
+by every lane in the session, so a generic `diff.txt` there is a name a concurrent lane writes too:
+on PR #7232 a reviewer's file was replaced with an unrelated PR's diff between two offset reads, and
+the verdict it was heading for would have carried the right head over the wrong bytes — which
+nothing downstream can detect (#7246).
+
+```bash
+staged=$(fabrika review scratch $pr_number --slug diff --lane <lane> --sha 03135b91)
+fabrika review diff $pr_number --sha 03135b91 > "$staged"
+```
+
+`<lane>` is the lane key your spawn brief's `## Task` section carries, and `--sha` is step 1's head:
+the first separates you from the other reviewers of this session, the second from your own earlier
+round. The verb prints one absolute path, creates its directory, and **refuses rather than handing
+back the session-wide directory** when either is missing. A run whose caller named no lane cannot
+stage: read the diff in place instead, and never substitute a name of your own.
+
+The path is machine-local, so it never appears in what you post — `review post` and
+`review append-criterion` red on it at `5`.
+
 **A contract you need while grading arrives one section at a time** — including a `contract.md` the
 diff itself edits. Take each heading the judgment touches with
 `fabrika wire doc-section --heading "…" < <skill-base>/contract.md`, never the whole file (ADR

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -1221,7 +1221,7 @@ call.
 
 ```
 $ fabrika review scratch 4321 --slug diff --lane 4287 --sha 03135b91
-/var/folders/kx/T/fabrika-review/s-9f2e/4321-8c1d4a90f27b/diff
+/var/folders/kx/T/fabrika-review/s-9f2e/4321-8c9e018c5568/diff
 
 $ fabrika review scratch 4321 --slug diff --lane "" --sha 03135b91
 review scratch: --lane is blank — this run names no lane, so the only namespace left is the

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -30,6 +30,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `review deviations` | the PR body's `## Deviations` section state (found / absent / malformed), its entries, and the Tier-M token scan over the diff | section detection and token scanning are mechanical; matching entry *substance* against findings is judgment (Tier R) |
 | `review post` | the single sanctioned verdict emit: compose through the `verdict-marker` wire format, bind to the inspected head at post time, post one comment per namespace at that head, read it back | marker composition, head re-resolution, leak scan and read-back are a protocol; the polarity and clause are judgment |
 | `review append-criterion` | append one reviewer-authored acceptance criterion to the linked issue under the four fences (append-only · ACL-gated fail-closed · frozen at `src/retry-budget.ts`'s `CAP_ROUND`), with provenance tag | the fences and the diff-guarded append are mechanical (ADR 0079); whether a finding is in-scope is judgment |
+| `review scratch` | the per-lane directory this reviewer's staged files go under, allocated fail-closed | deriving a namespace no second lane resolves to, and refusing when it cannot be derived, is mechanical; what to stage there is judgment |
 
 ### Considered and deliberately not derived
 
@@ -108,7 +109,7 @@ Stated once rather than repeated per block.
 
 ### The shared exit taxonomy
 
-All eight verbs allocate from one internal table, so a code means one thing across *this group*.
+All nine verbs allocate from one internal table, so a code means one thing across *this group*.
 Repo-wide the same number does not — `wire`'s `3`–`8` are its own — but where this group's codes overlap
 **`report`'s and `triage`'s writing verbs** (`3`, `5`, `6`,
 `7`, `8`, `9`, `11`) they match them deliberately, code for code, read from the **shipped
@@ -218,7 +219,9 @@ newlines) is the one a re-derivation drops, and dropping it fires exit `9` on cl
 `review post` and `review append-criterion` share the leak predicate **already implemented** at
 `packages/fabrika-cli/src/report/leaks.ts` — import it, never re-derive it. A verdict body that
 must *cite* a leak found in the diff cites it by class root or repo-relative form; the refusal
-message says so (#3785 is the incident where review prose tripped the guard).
+message says so (#3785 is the incident where review prose tripped the guard). `review scratch`'s
+answer is a path under one of those roots, so a verdict quoting where the diff was staged reds on
+`5` — the same refusal `build pr` and `build note` make.
 
 ---
 
@@ -1167,6 +1170,80 @@ escalated-frozen	4287	3
   (the S8 scar) — a first-class verb is the difference between a fence and a fence description.
 - ADR 0055 — authority from the ACL check; a below-write author or a failed lookup skips the
   append entirely, fail-closed.
+
+---
+
+## `review scratch`
+
+**Invocation**
+
+```
+fabrika review scratch 4321 --slug <leaf> --lane <lane-key> --sha <head>
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| *(positional)* | integer | yes | — | the pull request this lane is reviewing |
+| `--slug` | string | yes | — | the file's leaf name: kebab-case, no path separators |
+| `--lane` | string | yes | — | the lane key from this reviewer's spawn brief |
+| `--sha` | string | yes | — | the head `review scope` bound, 7–40 hex |
+
+**Output** — machine channel. One absolute path on stdout:
+`<temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>`. The directory is created if
+absent; the leaf is not. `<lane-nonce>` is twelve hex of `sha256(<lane> \n <sha>)`. No `--json`:
+the path is the answer.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `1` | the directory could not be created, `--lane` is blank, the positional is not a PR number, or no session id is set (the `FABRIKA_SESSION_ID` → `CLAUDE_CODE_SESSION_ID` → `PI_SUBAGENT_PARENT_SESSION` chain) or the id is not one path segment |
+| `10` | `--slug` carries a path separator or is not kebab-case, or `--sha` is not a head SHA |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `review scratch: <n> is not a pull-request number.` | 1 | refusal |
+| `review scratch: --lane is blank — this run names no lane, so the only namespace left is the session's, which is the one two reviewers share; refusing to allocate it.` | 1 | refusal |
+| `review scratch: no session id is set — … — refusing to key a scratch namespace on an unattributable session.` | 1 | refusal |
+| `review scratch: the session id is not one path segment — it cannot name a directory of its own.` | 1 | refusal |
+| `review scratch: cannot create <dir>: <reason>` | 1 | refusal |
+| `review scratch: --slug "<v>" must be a kebab-case leaf, no path separators.` | 10 | refusal |
+| `review scratch: --sha "<v>" is not a head SHA — expected 7–40 hex characters.` | 10 | refusal |
+
+**Scope** — one directory, allocated. It writes no file, reads no board state, and makes no network
+call.
+
+**Examples**
+
+```
+$ fabrika review scratch 4321 --slug diff --lane 4287 --sha 03135b91
+/var/folders/kx/T/fabrika-review/s-9f2e/4321-8c1d4a90f27b/diff
+
+$ fabrika review scratch 4321 --slug diff --lane "" --sha 03135b91
+review scratch: --lane is blank — this run names no lane, so the only namespace left is the
+session's, which is the one two reviewers share; refusing to allocate it.
+$ echo $?
+1
+```
+
+**Grounding**
+
+- #7246 — a reviewer redirected `review diff` to a generic `diff.txt` in the session scratchpad and
+  read it in two passes; between the reads a concurrent lane replaced the bytes with another PR's
+  diff. The verdict would have graded one PR's criteria against another PR's bytes while carrying
+  the correct head, which nothing downstream — `ship`'s re-derivation included — can detect. Caught
+  only by an unrelated cross-check against `gh pr view --json files`. Live on PR #7232.
+- `build scratch` (#4516, #4544, #4875, #4692, #6037) and `triage scratch` (#6630) took the same
+  fix before this group did, both keyed on a claim token's nonce. This group ships no claim verb, so
+  the key is derived from `--lane` and `--sha` instead: same namespace shape, a source this lane can
+  actually name.
+- The alternative — have `review diff` verify staged bytes on re-read — was offered on #7246 and not
+  filed. It re-derives *detection* where the namespace makes the collision unconstructible, which is
+  the route both prior fixes took.
 
 ---
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -834,6 +834,7 @@ back. Contract:
 | `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan |
 | `review post` | the single sanctioned verdict emit — compose, bind, one comment per namespace, read back |
 | `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
+| `review scratch` | the per-lane directory a reviewer's staged files go under — `<temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>` |
 
 **Exit codes.** The shared table, plus `12` the live head moved past the inspected `--sha` · `13`
 the read completed and its scope is provably incomplete · `14` the invoking token is below `write`,
@@ -852,6 +853,11 @@ append-only fence. `4` is a deliberate gap.
 - **Every guard is demonstrated failing.**
   [`src/review/mutation.unit.test.ts`](./src/review/mutation.unit.test.ts) plants a counterexample
   per guard, breaks exactly that guard, and asserts the verb returns the specific wrong answer.
+- **`scratch`'s nonce is derived, not claimed.** This group ships no claim verb, so there is no
+  token to key on: the nonce is twelve hex of `sha256(--lane, --sha)` — `--lane` separating two
+  reviewers of one session, `--sha` separating two rounds of one lane. Both are required, and a
+  blank `--lane` refuses rather than degrading to the session-wide directory two reviewers share
+  (#7246).
 
 ## The `review-ui` group
 

--- a/packages/fabrika-cli/src/review/codes.ts
+++ b/packages/fabrika-cli/src/review/codes.ts
@@ -1,5 +1,5 @@
 /**
- * The one exit table all eight `review` verbs allocate from, so a code means one thing across this
+ * The one exit table all nine `review` verbs allocate from, so a code means one thing across this
  * group whichever verb produced it.
  *
  * **The overlap with `report` and `triage` is re-exported, never re-typed.** Where this group's

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -9,6 +9,7 @@
  * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
  * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
  */
+import {tmpdir} from "node:os";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {emit} from "../emit.ts";
@@ -22,6 +23,7 @@ import {runDeviations} from "./deviations-verb.ts";
 import {runDiff} from "./diff-verb.ts";
 import {runPost} from "./post-verb.ts";
 import {runScope} from "./scope-verb.ts";
+import {runScratch} from "./scratch-verb.ts";
 import {runVerdicts} from "./verdicts-verb.ts";
 
 /**
@@ -300,6 +302,36 @@ const appendCriterion = leafCommand(
 	),
 );
 
+const scratch = leafCommand(
+	"scratch",
+	{
+		pr: Argument.integer("pr").pipe(
+			Argument.withDescription("the pull request this lane is reviewing"),
+		),
+		slug: Flag.string("slug").pipe(
+			Flag.withDescription("the file's leaf name: kebab-case, no path separators"),
+		),
+		lane: Flag.string("lane").pipe(
+			Flag.withDescription(
+				"the lane key from this reviewer's spawn brief — what tells two reviewers of ONE session apart",
+			),
+		),
+		sha: Flag.string("sha").pipe(
+			Flag.withDescription(
+				"the head `review scope` bound (7–40 hex) — what tells two review ROUNDS of one lane apart",
+			),
+		),
+	},
+	Effect.fn(function* ({pr, slug, lane, sha}) {
+		yield* emit(yield* runScratch({pr, slug, lane, sha, env: process.env, tmpRoot: tmpdir()}));
+	}),
+).pipe(
+	Command.withShortDescription("The per-lane scratch path a reviewer's staged files go under."),
+	Command.withDescription(
+		"The per-lane scratch path, allocated fail-closed: <temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>, one absolute path on stdout, the directory created if absent. The nonce is twelve hex of sha256(--lane, --sha), because this group ships no claim verb to take one from: --lane is what keys the namespace per LANE rather than per session, so two reviewers of one session cannot clobber each other's fixed-name files, and --sha is what keys it per ROUND, so round 2 cannot read round 1's staged diff under the same name. Both are required — a default for either returns a path shared with whatever that axis separates. The printed path is machine-local and must never reach a posted artifact; `review post` and `review append-criterion` red on it at 5. Exits 1 (the directory could not be created, --lane is blank, the positional is not a PR number, or no session id is set (the FABRIKA_SESSION_ID → CLAUDE_CODE_SESSION_ID → PI_SUBAGENT_PARENT_SESSION chain) or the id is not one path segment), 10 (--slug carries a path separator or is not kebab-case, or --sha is not a head SHA). Example: fabrika review scratch 4321 --slug diff --lane 4287 --sha 03135b91",
+	),
+);
+
 export const reviewCommand = Command.make("review").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
@@ -311,9 +343,10 @@ export const reviewCommand = Command.make("review").pipe(
 		deviations,
 		post,
 		appendCriterion,
+		scratch,
 	]),
 	Command.withShortDescription("Read what a text review needs off one pull request."),
 	Command.withDescription(
-		"Read everything a text review needs off one pull request — scope, diff, criteria, CI, verdicts, deviations — and emit the verdict or a reviewer-authored criterion through the one sanctioned write path",
+		"Read everything a text review needs off one pull request — scope, diff, criteria, CI, verdicts, deviations — allocate the per-lane scratch path its staged reads go under, and emit the verdict or a reviewer-authored criterion through the one sanctioned write path",
 	),
 );

--- a/packages/fabrika-cli/src/review/scratch-verb.ts
+++ b/packages/fabrika-cli/src/review/scratch-verb.ts
@@ -1,0 +1,130 @@
+/**
+ * `review scratch` — the per-lane scratch path a reviewer stages verb output under.
+ *
+ * `<temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>`, the shape `build scratch` and
+ * `triage scratch` already print. The review lane was the one staging lane that never got it: a
+ * reviewer whose diff exceeded one read picked a generic filename in the session scratchpad, a
+ * concurrent lane writing the same name replaced the bytes between two offset reads, and the verdict
+ * graded one PR's criteria against another PR's diff while carrying the correct head — which nothing
+ * downstream, `ship`'s re-derivation included, can detect (#7246, live on PR #7232).
+ *
+ * **The nonce is derived, because this group has no claim to take it from.** `build scratch` and
+ * `triage scratch` key on the nonce of a claim token their lane holds; `review` ships no claim verb,
+ * so there is no token to copy that derivation from. The key is instead the two facts a review lane
+ * already carries and a second lane cannot both repeat:
+ *
+ *  - **`--lane`**, the lane key out of the spawn brief. Two reviewers running at once are two lanes,
+ *    so this is what separates two lanes of one session — the axis the incident turned on.
+ *  - **`--sha`**, the head `review scope` bound and every later verb is passed. Two review rounds of
+ *    one lane are two reviews of two trees, and without the head in the key round 2 reads round 1's
+ *    staged diff under the same slug — the same wrong-tree read, one round later.
+ *
+ * Both are required: a default for either would hand back a path shared with whatever the missing
+ * axis was supposed to separate, which is the failure this verb exists to make unconstructible. When
+ * no lane can be named the verb refuses (`1`) rather than degrading to a session-wide directory.
+ *
+ * The printed path is machine-local. `review post` and `review append-criterion` red on it through
+ * the shared `report/leaks.ts` predicate (`5`), the same refusal `build pr` and `build note` make.
+ */
+import {createHash} from "node:crypto";
+import {Effect, FileSystem} from "effect";
+import {isKebabSlug} from "../build/lane.ts";
+import {sessionIdFrom, sessionIdUnset} from "../io/session-id.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {OFF_VOCABULARY} from "./codes.ts";
+
+const VERB = "review scratch";
+
+/** A session id fit to be one directory segment — a `/` in it would nest the namespace elsewhere. */
+const isPathSegment = (value: string): boolean => /^[A-Za-z0-9._-]+$/.test(value);
+
+/** The shape every `review` verb's `--sha` takes, checked here without a network read. */
+const isHeadSha = (value: string): boolean => /^[0-9a-f]{7,40}$/.test(value);
+
+/**
+ * The lane's nonce: twelve hex of `sha256(lane \n sha)`.
+ *
+ * Hashed rather than interpolated because a lane key is free-form — `chore:<name>` carries a colon,
+ * and a key with a separator in it would nest the namespace somewhere nobody named. Deterministic
+ * because every call in one lane must resolve to the one directory: a random nonce would hand the
+ * same lane a new directory per call, which is a leak, not a separation.
+ */
+export const laneNonce = (lane: string, sha: string): string =>
+	createHash("sha256").update(`${lane}\n${sha}`).digest("hex").slice(0, 12);
+
+/** This lane's namespace, exported so a caller derives the path rather than restating the formula. */
+export const laneScratchDir = (
+	tmpRoot: string,
+	session: string,
+	pr: number,
+	nonce: string,
+): string => `${tmpRoot.replace(/\/+$/, "")}/fabrika-review/${session}/${pr}-${nonce}`;
+
+export interface ScratchOptions {
+	readonly pr: number;
+	readonly slug: string;
+	/** The lane key out of the spawn brief — what tells two reviewers of ONE session apart. */
+	readonly lane: string;
+	/** The head `review scope` bound — what tells two rounds of ONE lane apart. */
+	readonly sha: string;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The OS temp root, read by the adapter — the one machine fact this verb does not derive. */
+	readonly tmpRoot: string;
+}
+
+export const runScratch = (
+	options: ScratchOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const {pr, slug} = options;
+
+		if (!Number.isInteger(pr) || pr <= 0) {
+			return refuse(FAILED, `${VERB}: ${pr} is not a pull-request number.`);
+		}
+		if (slug.includes("/") || slug.includes("\\") || !isKebabSlug(slug)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --slug "${slug}" must be a kebab-case leaf, no path separators.`,
+			);
+		}
+
+		const lane = options.lane.trim();
+		if (lane === "") {
+			return refuse(
+				FAILED,
+				`${VERB}: --lane is blank — this run names no lane, so the only namespace left is the session's, which is the one two reviewers share; refusing to allocate it.`,
+			);
+		}
+
+		const sha = options.sha.trim().toLowerCase();
+		if (!isHeadSha(sha)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --sha "${options.sha}" is not a head SHA — expected 7–40 hex characters.`,
+			);
+		}
+
+		const session = sessionIdFrom(options.env);
+		if (session === null) {
+			return refuse(
+				FAILED,
+				`${VERB}: ${sessionIdUnset} — refusing to key a scratch namespace on an unattributable session.`,
+			);
+		}
+		if (!isPathSegment(session)) {
+			return refuse(
+				FAILED,
+				`${VERB}: the session id is not one path segment — it cannot name a directory of its own.`,
+			);
+		}
+
+		const dir = laneScratchDir(options.tmpRoot, session, pr, laneNonce(lane, sha));
+		const fs = yield* FileSystem.FileSystem;
+		const failure: string | null = yield* fs.makeDirectory(dir, {recursive: true}).pipe(
+			Effect.as(null),
+			Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)),
+		);
+		return failure === null
+			? answer(`${dir}/${slug}`)
+			: refuse(FAILED, `${VERB}: cannot create ${dir}: ${failure}`);
+	});

--- a/packages/fabrika-cli/src/review/scratch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scratch-verb.unit.test.ts
@@ -1,0 +1,129 @@
+import {Effect, FileSystem, PlatformError} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {FAILED} from "../verb.ts";
+import {type AuthoredSurface, leakRefusal} from "./authored.ts";
+import {LEAKED_PATH, OFF_VOCABULARY} from "./codes.ts";
+import {runScratch} from "./scratch-verb.ts";
+
+const SHA = "03135b91aa1c4d6f8e2b7c9d0a1e3f5b7c9d0a1e";
+
+const options = {
+	pr: 4321,
+	slug: "diff",
+	lane: "4287",
+	sha: SHA,
+	env: {CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<string, string | undefined>,
+	tmpRoot: "/scratch-root",
+};
+
+const run = (overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runScratch({...options, ...overrides}), fakeFs({}).layer));
+
+describe("runScratch", () => {
+	it("prints one absolute path under the group's own namespace", async () => {
+		const out = await run();
+		expect(out.code).toBe(0);
+		expect(out.stdout).toMatch(
+			/^\/scratch-root\/fabrika-review\/s-9f2e\/4321-[0-9a-f]{12}\/diff\n$/,
+		);
+	});
+
+	/**
+	 * The axis the incident turned on: a reviewer staged `diff.txt` in the session scratchpad and a
+	 * concurrent lane replaced the bytes between two offset reads (#7246, live on PR #7232).
+	 */
+	it("resolves two lanes of ONE session to different directories", async () => {
+		const first = await run({lane: "4287"});
+		const second = await run({lane: "5830", pr: 4321, sha: SHA});
+		expect(first.code).toBe(0);
+		expect(second.code).toBe(0);
+		expect(first.stdout).not.toBe(second.stdout);
+	});
+
+	/** Two rounds of one lane are two reviews of two trees, so round 2 must not read round 1's bytes. */
+	it("resolves two rounds of ONE lane to different directories", async () => {
+		const first = await run();
+		const second = await run({sha: "9f2c1abbb3d4e5f60718293a4b5c6d7e8f901234"});
+		expect(first.stdout).not.toBe(second.stdout);
+	});
+
+	it("resolves every call of one lane to the SAME directory", async () => {
+		expect((await run({slug: "diff"})).stdout.replace(/diff\n$/, "")).toBe(
+			(await run({slug: "notes"})).stdout.replace(/notes\n$/, ""),
+		);
+	});
+
+	it("refuses a blank --lane on 1 rather than falling back to the session's directory", async () => {
+		const out = await run({lane: "   "});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("--lane is blank");
+	});
+
+	it("refuses an unset session id on 1 — an unattributable session names no lane either", async () => {
+		const out = await run({env: {}});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("no session id is set");
+	});
+
+	it("refuses a session id that is not one path segment on 1", async () => {
+		const out = await run({env: {CLAUDE_CODE_SESSION_ID: "s/9f2e"}});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toContain("not one path segment");
+	});
+
+	it("refuses a slug carrying a path separator on 10", async () => {
+		const out = await run({slug: "notes/inner"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			'review scratch: --slug "notes/inner" must be a kebab-case leaf, no path separators.',
+		);
+	});
+
+	it("refuses a non-kebab slug on 10", async () => {
+		expect((await run({slug: "Notes"})).code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses a --sha that is not a head SHA on 10", async () => {
+		const out = await run({sha: "not-a-sha"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("is not a head SHA");
+	});
+
+	it("refuses an unmakeable directory on the universal 1 — never a path it could not allocate", async () => {
+		const unmakeable = FileSystem.layerNoop({
+			makeDirectory: (path: string) =>
+				Effect.fail(
+					PlatformError.systemError({
+						_tag: "PermissionDenied",
+						module: "FileSystem",
+						method: "makeDirectory",
+						pathOrDescriptor: path,
+					}),
+				),
+		});
+		const out = await Effect.runPromise(Effect.provide(runScratch(options), unmakeable));
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("review scratch: cannot create ");
+	});
+
+	/**
+	 * The path is machine-local, and the group's writing verbs already red on one — this pins that the
+	 * shape THIS verb prints is inside that predicate rather than beside it.
+	 */
+	it("prints a path the group's writing verbs refuse in a body", async () => {
+		const surface: AuthoredSurface = {
+			verb: "review post",
+			noun: "the assembled comment",
+			emptyMessage: "empty",
+			bareAtMessage: "bare @",
+			leakCorrection: "cite it repo-relative or by class root.",
+		};
+		const path = (await run({tmpRoot: "/var/folders/kx"})).stdout.trim();
+		const refusal = leakRefusal(surface, `PASS — staged the diff at ${path}`);
+		expect(refusal?.code).toBe(LEAKED_PATH);
+	});
+});


### PR DESCRIPTION
Fixes #7246

The review lane had no scratch allocator, so a reviewer whose diff was too big for one read picked
its own filename in the session scratchpad. That scratchpad is shared by every lane in the session:
on PR #7232 a reviewer's `diff.txt` was replaced with an unrelated PR's diff between two offset
reads, and the verdict it was heading for would have carried the right head over the wrong bytes —
which nothing downstream, `ship`'s re-derivation included, can detect. `build scratch` and `triage
scratch` both took this fix already; `review` was the one staging lane that never got it.

`fabrika review scratch <pr> --slug <leaf> --lane <lane> --sha <head>` prints
`<temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>` and creates the directory — the
same shape the two sibling allocators print.

**Where the nonce comes from.** The siblings key on the nonce of a claim token their lane holds.
This group ships no claim verb, so there is nothing to copy that derivation from. The nonce is
twelve hex of `sha256(--lane, --sha)` instead, over the two facts a review lane already carries:
`--lane`, the lane key out of the spawn brief, separates two reviewers of one session — the axis the
incident turned on — and `--sha`, the head `review scope` bound, separates two rounds of one lane, so
round 2 cannot read round 1's staged diff under the same slug. Both are required. A default for
either would hand back a path shared with whatever the missing axis was supposed to separate, which
is the failure the verb exists to make unconstructible; a blank `--lane` refuses on `1` rather than
degrading to the session-wide directory.

The path is machine-local, and `review post` / `review append-criterion` already red on one through
the shared `report/leaks.ts` predicate — the same refusal `build pr` and `build note` make. A test
pins that the shape this verb prints is inside that predicate rather than beside it.

`SKILL.md` §3 now names the allocator at the point the reviewer would reach for a filename, and says
a run whose caller named no lane reads the diff in place rather than substituting a name of its own.

The verb-output surfaces are all walked: the source docblock, both `Command.with*Description`
strings, the README group row and its exit-code note, the contract's verb inventory and a full
`## review scratch` section, and the two "all eight verbs" counts that are now nine.

## Deviations

- **Out-of-scope change** — **Said:** #7246 scopes to a per-lane namespace for the review lane and
  the skill step that makes the reviewer use it. **Did:** also put `--sha` in the key, which
  separates two review *rounds* of one lane rather than two lanes. **Why:** without it a generic
  slug survives the round, so round 2 reads round 1's diff at round 2's head — the same wrong-tree
  read the issue reports, one round later, and the fix is one field in a key I was building anyway.
  **Disposition:** stated here.
