### PR TITLE
fix: `ledger open` sends its full token list to the AND-joined search, the blunting #7213 fixed in `report dedup`

### DIFF
--- a/packages/fabrika-cli/src/ledger/open-verb.ts
+++ b/packages/fabrika-cli/src/ledger/open-verb.ts
@@ -23,7 +23,7 @@ import {cycleDocOr} from "../config/paths.ts";
 import {searchOpenIssues} from "../io/issues.ts";
 import {probeCycleDoc} from "../plan/github.ts";
 import {sectionCount} from "../plan/ledger.ts";
-import {rank, tokenize} from "../report/dedup.ts";
+import {rank, searchTokens, tokenize} from "../report/dedup.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, REGION_UNRESOLVABLE, STALE_GROUND} from "./codes.ts";
 import {bodyDigest} from "./digest.ts";
@@ -111,6 +111,7 @@ export const runOpen = (
 		const cycleDoc = yield* probeCycleDoc(repo, cycle.path, options.env);
 
 		const tokens = tokenize(epic.title);
+		const sent = searchTokens(tokens);
 		const backlog = yield* openBacklog(options.env, repo);
 		if (backlog._tag === "Failure") {
 			return refuse(
@@ -119,7 +120,7 @@ export const runOpen = (
 				notes,
 			);
 		}
-		const search = yield* searchOpenIssues(repo, tokens);
+		const search = yield* searchOpenIssues(repo, sent);
 		if (search._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
@@ -127,6 +128,7 @@ export const runOpen = (
 				notes,
 			);
 		}
+		const narrowed = sent.length === tokens.length ? "" : `; sent to search: ${sent.join(", ")}`;
 		const ranked = rank({
 			tokens,
 			queue: backlog.value,
@@ -214,7 +216,7 @@ export const runOpen = (
 					VERB,
 					children.value.length,
 					"existing child",
-					`${backlog.value.length} open backlog issue(s) and ${search.value.length} search hit(s) ranked`,
+					`${backlog.value.length} open backlog issue(s) and ${search.value.length} search hit(s) ranked${narrowed}`,
 				),
 			],
 		);

--- a/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
@@ -64,7 +64,12 @@ const run = (
 			runOpen({number: 4300, token: TOKEN, repo: null, cwd: "/repo", env}),
 			Layer.mergeAll(shell.layer, fs.layer),
 		),
-	).then((outcome) => ({outcome, written: fs.written, calls: shell.calls}));
+	).then((outcome) => ({
+		outcome,
+		written: fs.written,
+		calls: shell.calls,
+		requests: shell.requests,
+	}));
 };
 
 describe("runOpen", () => {
@@ -252,5 +257,37 @@ describe("runOpen", () => {
 		const {candidates} = JSON.parse(outcome.stdout);
 		expect(candidates.outcome).toBe("candidates");
 		expect(candidates.items.map((item: {number: number}) => item.number)).toEqual([4180]);
+	});
+
+	/**
+	 * The two lists pull opposite ways (#7213): GitHub ANDs the search terms, so every extra one
+	 * narrows toward zero, while `scoreTitle` gets sharper with more. `report dedup` split them and
+	 * this verb was the second call site still sending one list to both — the guard is here so a
+	 * third does not drift back.
+	 */
+	it("sends only the SEARCH_TOKENS prefix to search while rank keeps the full list", async () => {
+		const {outcome, requests} = await run([
+			[EPIC_READ, epic({title: "moderation queue triage backlog dashboard rewrite"})],
+			...CLEAN.slice(1).filter(([pattern]) => pattern !== BACKLOG),
+			[BACKLOG, backlogPage([4180, "dashboard rewrite notes"])],
+		]);
+		const query = requests.find((line) => SEARCH.test(line)) ?? "";
+		expect(decodeURIComponent(query)).toContain("moderation queue triage backlog");
+		expect(decodeURIComponent(query)).not.toContain("dashboard");
+		const {candidates} = JSON.parse(outcome.stdout);
+		expect(candidates.items).toEqual([{number: 4180, title: "dashboard rewrite notes", score: 2}]);
+	});
+
+	it("names the tokens actually sent when the search list is shorter than the ranking list", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, epic({title: "moderation queue triage backlog dashboard rewrite"})],
+			...CLEAN.slice(1),
+		]);
+		expect(outcome.stderr.at(-1)).toContain("sent to search: moderation, queue, triage, backlog");
+	});
+
+	it("says nothing about a narrowed send when the whole list went to search", async () => {
+		const {outcome} = await run(CLEAN);
+		expect(outcome.stderr.at(-1)).not.toContain("sent to search");
 	});
 });


### PR DESCRIPTION
Fixes #7249

`fabrika ledger open` built one token list from the epic title and sent all of it to
`searchOpenIssues`, which joins the terms into a GitHub search query GitHub ANDs. Every added term
narrows the result set, so the search half of the candidate ranking returned nothing and the run's
`… and 0 search hit(s) ranked` note read as "no related work exists" rather than "the query was too
narrow to match". Triage measured it against the board: all 15 epics open there tokenize past four
terms, shortest 5, median 11 — so the search half contributed nothing on every epic currently open.

This is the second call site of the defect [#7213](https://github.com/kamp-us/phoenix/issues/7213)
diagnosed; PR [#7248](https://github.com/kamp-us/phoenix/pull/7248) fixed the first (`report dedup`)
and shipped the `searchTokens` helper this change imports.

## What changed

- `open-verb.ts` sends `searchTokens(tokens)` to `searchOpenIssues` and keeps the full
  `tokenize(epic.title)` list on `rank`, so candidate scoring is unchanged.
- `SEARCH_TOKENS` / `searchTokens` come from `src/report/dedup.ts` — the same module `open-verb.ts`
  already imports `rank` and `tokenize` from. No second constant, no local slice.
- The scanned line gains `; sent to search: <terms>` when the sent list is shorter than the ranking
  list, using the same literal `report dedup`'s scope line uses so a grep finds both.
- Three unit tests in `src/ledger/open-verb.unit.test.ts`: the prefix reaches search while the full
  list reaches `rank` (proven by a backlog row that scores only on beyond-slice tokens), the note
  names the sent terms when they differ, and it says nothing when they do not.

`src/io/issues.ts` is untouched — the narrowing stays caller-side, as the issue rules, because a
callee that silently truncates its argument hides the failure at the call site.

I checked the six pin surfaces in
[`.patterns/verb-output-pin-surfaces.md`](.patterns/verb-output-pin-surfaces.md) for the changed
scanned line: `plan-epic/contract.md`, `plan-epic/SKILL.md`, `packages/fabrika-cli/README.md` and
`src/ledger/command.ts` all document `ledger open`'s JSON answer and its refusal lines, and none of
them quotes the notes-channel scanned line. Nothing outside the two changed files needed updating.

Both new guards were verified to bite: reverting the send to the full list fails the prefix test, and
dropping the narrowed suffix fails the note test.

## Deviations

None.
