### PR TITLE
fix: A reviewer's CI-wait sleeps outlive its run and re-notify the driver

### DIFF
--- a/claude-plugins/fabrika/docs/skill-conventions.md
+++ b/claude-plugins/fabrika/docs/skill-conventions.md
@@ -433,8 +433,19 @@ skill the wrong fix, because the copies drift.
 on an `Effect.sleep` cadence
 ([`packages/fabrika-cli/src/ship/reconcile-verb.ts`](../../../packages/fabrika-cli/src/ship/reconcile-verb.ts)),
 and that is correct: the verb owns its own loop, bounds it by a poll count, and returns one answer
-to a caller that made one call. That is the shape a skill-side wait converts into — a verb whose
-waiting is bounded and whose caller blocks on nothing else.
+to a caller that made one call. `review ci --wait`
+([`packages/fabrika-cli/src/review/ci-verb.ts`](../../../packages/fabrika-cli/src/review/ci-verb.ts))
+is the same shape over a queued check set, bounded by a wall-clock budget instead of a count, and it
+is where this rule was actually converted: the reviewer's wait was the gap that produced the
+[#7260](https://github.com/kamp-us/phoenix/issues/7260) timers, and moving the loop into the verb is
+what closed it rather than parking the lane on a human
+([#7282](https://github.com/kamp-us/phoenix/issues/7282)). That is the shape a skill-side wait
+converts into — a verb whose waiting is bounded and whose caller blocks on nothing else.
+
+**A bound that runs out is its own answer, never the permissive one.** Both verbs say so in their
+output: `ship reconcile` returns `unresolved`, `review ci --wait` returns `settle
+budget-exhausted` beside a rollup that still reads `pending`. A wait that converts "I ran out of
+time" into "it passed" is worse than the `sleep` it replaced.
 
 ## What these conventions deliberately do not cover
 

--- a/claude-plugins/fabrika/docs/skill-conventions.md
+++ b/claude-plugins/fabrika/docs/skill-conventions.md
@@ -406,6 +406,36 @@ this stays a note rather than a defence.
 Read out of the installed Claude Code build (2.1.233) frontmatter schema; observations recorded on
 [#5588](https://github.com/kamp-us/phoenix/issues/5588), the M45 native-shell campaign.
 
+## 14. A skill never sleeps and never polls on a timer
+
+**No fabrika skill runs `sleep`, foreground or background, and none re-reads a lane, a check or any
+other state on a timer.** This section is where that rule lives; a skill contract cites it and does
+not restate it. A spawned shell returns its result to whoever spawned it, so that return *is* the
+wait — there is no interval to fill. Where a wait genuinely has to block, a CLI verb does the
+blocking in-process and the skill calls that verb once.
+
+The rule binds every skill, not just the ones that spawn. Two incidents, one on each side of a
+spawn, are why:
+
+- **[#6696](https://github.com/kamp-us/phoenix/issues/6696), driver side.** An operator waiting on a
+  reviewer spawned `sleep 575` in the background about every nine seconds, waited on none of them,
+  and left ~55 live shells on the founder's machine while no lane state moved.
+- **[#7260](https://github.com/kamp-us/phoenix/issues/7260), spawned side.** A reviewer waiting on a
+  queued `ci-required` aggregator left background timers behind. Two fired after the run had already
+  reported its verdict and terminated, re-notifying the driver each time with nothing to route.
+
+Neither skill's text asked for a sleep. The harness refuses a foreground one, so a background
+`sleep` is what a model reaches for when a step leaves it a wait to fill and no rule against filling
+it — which makes the absence of this rule from a skill the defect, and copying the rule into each
+skill the wrong fix, because the copies drift.
+
+**The one legitimate `sleep` is inside a CLI verb.** `ship reconcile --wait` polls the merge queue
+on an `Effect.sleep` cadence
+([`packages/fabrika-cli/src/ship/reconcile-verb.ts`](../../../packages/fabrika-cli/src/ship/reconcile-verb.ts)),
+and that is correct: the verb owns its own loop, bounds it by a poll count, and returns one answer
+to a caller that made one call. That is the shape a skill-side wait converts into — a verb whose
+waiting is bounded and whose caller blocks on nothing else.
+
 ## What these conventions deliberately do not cover
 
 - **What a verb owes its caller** — `--help` discoverability, output contracts, usage examples —

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -228,13 +228,10 @@ seats on those codes. Each is a park naming what the verb named — never a prom
 instead. Parallel active tasks brief and spawn in parallel.
 
 **Then do nothing until a spawn returns — and never `sleep`.** A shell spawned with the Agent tool
-returns its result to you, so that return *is* the wait: there is no interval to fill and nothing to
-poll. Never run `sleep`, foreground or background, and never re-read `lane status` on a timer while
-a spawn is in flight — a timed `lane status` is the same defect wearing a fabrika verb. The harness
-refuses a foreground `sleep`, which makes a background one the shape this goes wrong in: an operator
-waiting on a reviewer spawned `sleep 575` in the background about every nine seconds, waited on none
-of them, and left ~55 live shells on the founder's machine while no lane state moved
-([#6696](https://github.com/kamp-us/phoenix/issues/6696)). So dispatch every task the fold routed,
+returns its result to you, so that return *is* the wait. The rule and both incidents behind it are
+[§14 of the skill conventions](../../docs/skill-conventions.md#14-a-skill-never-sleeps-and-never-polls-on-a-timer);
+the one thing it adds for you is that a timed `lane status` is the same defect wearing a fabrika
+verb, so it is banned on the same terms as a bare `sleep`. So dispatch every task the fold routed,
 say in one line what you dispatched, and end the turn. Your next move is
 [§3](#3--verify-the-record-landed-and-record-what-no-shell-can)'s fresh `lane status`, once a spawn
 has returned.

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -124,7 +124,7 @@ green as this PR's. The code class's execution evidence is the structural CI-at-
 incomplete enumerations:
 
 ```bash
-fabrika review ci $pr_number --sha 03135b91
+fabrika review ci $pr_number --sha 03135b91 --wait
 ```
 
 **Its `green` now carries gate coverage, and the absence of coverage is its own answer.** A head
@@ -136,18 +136,29 @@ reporting on its own trigger. Treat that `16` as a blocked read, not a verdict �
 runs before anything can be judged on it, so end the class on `UNKNOWN — the artifact could not
 be read`, naming the `16`, rather than grading around it.
 
-**A `pending` is a read of this moment, and you never wait it out on a timer.** This verb is a point
-read, not a blocking one: there is no `--wait` here doing the blocking for you, so a queued
-`ci-required` aggregator leaves you a gap, and
+**A queued aggregator is waited out by the verb, never by you on a timer.** You are normally spawned
+minutes after the push, so a `pending` is the ordinary read, not a pathology — and the wait it opens
+is exactly the gap
 [§14 of the skill conventions](../../docs/skill-conventions.md#14-a-skill-never-sleeps-and-never-polls-on-a-timer)
-governs it — no `sleep`, foreground or background, and no re-read on a cadence. That rule is
+governs: no `sleep`, foreground or background, and no re-read on a cadence. That rule is
 load-bearing here because this skill's own text is where it was missing: a reviewer waiting on a
 queued aggregator left background timers that fired after its run had ended and re-notified the
 driver twice with nothing to route
-([#7260](https://github.com/kamp-us/phoenix/issues/7260)). So take the `pending` as the answer the
-head gives you now — the code class has no execution evidence yet, so it ends on `UNKNOWN — the
-artifact could not be read` exactly as the `16` path does, and the head is re-read by a later run,
-not by this one sleeping through the queue.
+([#7260](https://github.com/kamp-us/phoenix/issues/7260)). The `--wait` above is why one call is
+enough: the verb owns the loop, bounds it by a wall-clock budget, and prints a `settle` line ahead of
+the rollup. Each token routes on its own:
+
+- `settled` — CI concluded inside the budget. The `green` or `red` beside it is the code class's
+  execution evidence; judge on it.
+- `budget-exhausted` — the budget ran out with the head still `pending`. Nothing about this head was
+  proven, and a wait that long is a stuck queue rather than a race with one, so the class ends on
+  `UNKNOWN — the artifact could not be read`, naming the token. That is a park a human should see;
+  `heal-ci` is the lane that moves a stalled PR.
+- `head-moved` — the PR left the head you are judging. Re-read at the new head; a verdict binds only
+  what was inspected.
+
+The refusals reach you unchanged and on the first read — `--wait` polls a `pending` and nothing else,
+so a `16` head or a repo with no producer never burns the budget.
 
 No class checks out the head: content arrives through the verbs as bytes, so the PR's own
 instructions are never loaded to judge the PR. Every namespace's verdict is **comment-only** — no

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -136,6 +136,19 @@ reporting on its own trigger. Treat that `16` as a blocked read, not a verdict �
 runs before anything can be judged on it, so end the class on `UNKNOWN — the artifact could not
 be read`, naming the `16`, rather than grading around it.
 
+**A `pending` is a read of this moment, and you never wait it out on a timer.** This verb is a point
+read, not a blocking one: there is no `--wait` here doing the blocking for you, so a queued
+`ci-required` aggregator leaves you a gap, and
+[§14 of the skill conventions](../../docs/skill-conventions.md#14-a-skill-never-sleeps-and-never-polls-on-a-timer)
+governs it — no `sleep`, foreground or background, and no re-read on a cadence. That rule is
+load-bearing here because this skill's own text is where it was missing: a reviewer waiting on a
+queued aggregator left background timers that fired after its run had ended and re-notified the
+driver twice with nothing to route
+([#7260](https://github.com/kamp-us/phoenix/issues/7260)). So take the `pending` as the answer the
+head gives you now — the code class has no execution evidence yet, so it ends on `UNKNOWN — the
+artifact could not be read` exactly as the `16` path does, and the head is re-read by a later run,
+not by this one sleeping through the queue.
+
 No class checks out the head: content arrives through the verbs as bytes, so the PR's own
 instructions are never loaded to judge the PR. Every namespace's verdict is **comment-only** — no
 namespace posts a native APPROVE.

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -576,7 +576,8 @@ open	the retry guide documents the delay table
 **Invocation**
 
 ```
-fabrika review ci 4321 [--sha <head>] [--repo <owner/name>] [--json]
+fabrika review ci 4321 [--sha <head>] [--wait] [--budget-seconds <n>] [--cadence-seconds <n>]
+                       [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -585,16 +586,21 @@ fabrika review ci 4321 [--sha <head>] [--repo <owner/name>] [--json]
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number |
 | `--sha` | string | no | the PR's live head | the head to enumerate check runs at; give the inspected head so the answer binds to what is being judged |
+| `--wait` | boolean | no | `false` | poll a `pending` head until CI concludes or the budget expires, instead of answering with this moment's read |
+| `--budget-seconds` | integer | no | `600` | `--wait` only: total wall-clock budget, gh-call latency included |
+| `--cadence-seconds` | integer | no | `30` | `--wait` only: sleep between polls |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
-**Output** — machine channel. First line: `ci\t<sha>\t<green|red|pending|no-producer>`. Second line:
-`run\t<count>` — how many check runs were enumerated, so the line channel carries its own
-completeness proof. Then one line per status present —
+**Output** — machine channel. Under `--wait`, a first line
+`settle\t<settled|budget-exhausted|head-moved>`; without it that line is absent. Then
+`ci\t<sha>\t<green|red|pending|no-producer>`, then `run\t<count>` — how many check runs were
+enumerated, so the line channel carries its own completeness proof. Then one line per status present
+—
 `check\t<success|failure|neutral|cancelled|skipped|timed_out|action_required|in_progress|queued>\t<count>`.
 
 With `--json`:
-`{"outcome":"ci","sha":…,"rollup":…,"checks":{<status>:<count>…},"scanned":<n>,"declared":<m>,"gates":{"declared":<g>,"covered":<c>}|null}`.
+`{"outcome":"ci","sha":…,"rollup":…,"checks":{<status>:<count>…},"scanned":<n>,"declared":<m>,"gates":{"declared":<g>,"covered":<c>}|null,"settle":<token>|null}`.
 
 `checks` is an **evidence-array collapsed to a status tally** under ADR
 [0308](../../../../.decisions/0308-bounded-evidence-output-shape.md): this skill acts on `rollup`,
@@ -641,6 +647,29 @@ of its own has no gate to have missed, and says so on stderr at exit `0`. The re
 `red` rollup, which is already the answer a caller must act on; `green` and `pending` are the two
 words that read as "nothing to do here", and both are wrong over bytes no gate inspected (#6522).
 
+**`--wait` is the bounded in-verb wait, and it polls a `pending` and nothing else.** A `pending` is
+the ordinary state of a PR minutes after a push — exactly when a reviewer is spawned — so a caller
+that can only take this moment's read has a park on a human to offer for a condition that clears
+itself in minutes (#7282). The verb owns the loop, which is what keeps the ban in
+[`docs/skill-conventions.md` §14](../../docs/skill-conventions.md#14-a-skill-never-sleeps-and-never-polls-on-a-timer)
+whole: the skill makes one call and never sleeps. The budget is **wall clock**, gh-call latency
+included, so the verb cannot overrun the bound it claims to hold.
+
+The settle token says how the wait ended, and it is the whole difference between a proven answer and
+a bound that ran out:
+
+- `settled` — CI concluded inside the budget; the rollup beside it is `green` or `red` and is a
+  verdict.
+- `budget-exhausted` — the budget ran out with the head still `pending`. **Nothing was proven**, and
+  the rollup says so by still reading `pending`: this is a stuck or very slow queue, not a race with
+  it.
+- `head-moved` — the PR left the head this answer binds during the wait. The last read still binds
+  what it inspected; the caller re-reads at the new head rather than trusting a stale `settled`.
+
+Every refusal and the `no-producer` answer are states no waiting changes, so `--wait` returns them
+on the **first** read rather than burning the budget: the `16` head has no gate of this repo's coming
+at all, and a repo with no producer has no run to wait for.
+
 If `--sha` is given and does not prefix-match the PR's live head, a stderr notice names both —
 the caller is enumerating a head that has moved, which is a fact worth seeing at the read even
 though the `12` stale-refusal seat belongs to `review post`, the write seam.
@@ -684,6 +713,27 @@ $ fabrika review ci 4321 --sha 03135b91
 ci	03135b91	green
 run	3
 check	success	3
+```
+
+A head still queued at the read, waited out to its verdict:
+
+```
+$ fabrika review ci 4321 --sha 03135b91 --wait
+settle	settled
+ci	03135b91	green
+run	3
+check	success	3
+```
+
+The same call on a queue that never finishes — `pending` beside the token, and never a verdict:
+
+```
+$ fabrika review ci 4321 --sha 03135b91 --wait --budget-seconds 120
+settle	budget-exhausted
+ci	03135b91	pending
+run	3
+check	success	1
+check	queued	2
 ```
 
 **Grounding**

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -834,7 +834,7 @@ back. Contract:
 | `review scope` | head SHA, linked issue, the code / doc / skill partition of the changed files, and the `self` / `harness` flags |
 | `review diff` | the diff bytes at the bound commit, with truncation refused rather than passed through |
 | `review criteria` | the linked issue's acceptance-criteria block, through the registered wire format |
-| `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration |
+| `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration; `--wait` bounds a `pending` one in-verb and prefixes `settle\t<settled\|budget-exhausted\|head-moved>` |
 | `review verdicts` | every verdict marker on the PR, each with its `current` / `stale` / `unbindable` binding |
 | `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan |
 | `review post` | the single sanctioned verdict emit — compose, bind, one comment per namespace, read back |

--- a/packages/fabrika-cli/src/review/ci-verb.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.ts
@@ -11,8 +11,15 @@
  * skill acts on `rollup` and no skill iterates the rows — and a repo with 34 workflows paid ~20 rows
  * of it on every read. What the rows were *for*, naming the red and still-running checks, moves to
  * the notes channel below, the same split `ship checks` landed on.
+ *
+ * `--wait` is the bounded in-verb wait a reviewer spawned minutes after a push needs: a `pending`
+ * there is the ordinary state of a healthy PR, and a caller that cannot wait for it has only a park
+ * on a human to offer for a condition that clears itself (#7282). The verb owns the loop so no skill
+ * ever sleeps — `claude-plugins/fabrika/docs/skill-conventions.md` §14 — and it loops on `pending`
+ * alone: every refusal and the `no-producer` answer are states no amount of waiting changes, so they
+ * return on the first read rather than burning the budget.
  */
-import {Effect, type FileSystem, type Path} from "effect";
+import {Clock, Effect, type FileSystem, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {producerFor, resolveCi} from "../config/ci-producer.ts";
 import {type ReasonHistogram, reasonHistogram} from "../evidence.ts";
@@ -23,20 +30,44 @@ import {listRunsAtHead, listWorkflowPaths, listWorkflows} from "../ship/github.t
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {INCOMPLETE_SCAN, NO_GATE_COVERAGE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {gateCoverageOf} from "./gate-coverage.ts";
-import {isFailing, rollupOf, statusOf} from "./rollup.ts";
+import {isFailing, type Rollup, rollupOf, statusOf} from "./rollup.ts";
 import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 
 const VERB = "review ci";
 
+/**
+ * How a `--wait` ended — the token that keeps a waited answer distinguishable from a point read.
+ *
+ * `budget-exhausted` is the one a caller must not read as a verdict: the rollup beside it is still
+ * `pending`, so nothing about the head was proven, and the answer says the wait ran out rather than
+ * that CI concluded.
+ */
+export type Settle = "settled" | "budget-exhausted" | "head-moved";
+
 export interface CiOptions {
 	readonly pr: number;
 	readonly sha: string | null;
+	readonly wait: boolean;
+	readonly budgetSeconds: number;
+	readonly cadenceSeconds: number;
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
 	/** Where `.fabrika.jsonc` is looked for — the repo root above it, per `config/working-root.ts`. */
 	readonly cwd: string;
 }
+
+/** One enumeration at the bound head: an outcome no wait can change, or a rollup to route on. */
+type Sample =
+	| {readonly _tag: "Done"; readonly outcome: VerbOutcome}
+	| {
+			readonly _tag: "Read";
+			readonly rollup: Rollup;
+			readonly runs: ReadonlyArray<CheckRun>;
+			readonly declared: number;
+			readonly gates: {readonly declared: number; readonly covered: number} | null;
+			readonly notes: ReadonlyArray<string>;
+	  };
 
 /** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
 const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
@@ -45,7 +76,9 @@ const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.star
  * The rollup token for a repo that has opted out of having CI at all.
  *
  * Its own word, deliberately outside {@link rollupOf}'s three: a caller keying on `green` must not
- * see one here, and a caller keying on `pending` must not wait for a run that will never start.
+ * see one here, and a caller keying on `pending` must not wait for a run that will never start —
+ * which is why `--wait` returns this answer on the first read and carries no settle token, there
+ * having been nothing to wait for.
  */
 const NO_PRODUCER = "no-producer";
 
@@ -64,6 +97,7 @@ const noProducerAnswer = (
 					scanned: 0,
 					declared: 0,
 					gates: null,
+					settle: null,
 				}),
 				diagnostics,
 			)
@@ -134,115 +168,177 @@ export const runCi = (
 			}
 		}
 
-		const enumerated = yield* listCheckRuns(repo, sha);
-		if (enumerated._tag === "Failure") {
-			return refuse(
-				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot enumerate check runs at ${sha}: ${enumerated.reason} — CI state is UNKNOWN, never green.`,
-				diagnostics,
-			);
-		}
-		const {declared, runs} = enumerated.value;
-		diagnostics.push(scannedLine(VERB, runs.length, "check run", `${declared} declared`));
-		if (declared === 0) {
-			// The producer question is asked HERE and nowhere else on this path: an enumeration that
-			// returned runs already proves a producer. Empty is the one reading where "no CI at all"
-			// and "nothing has reported yet" are two different repos wearing one answer.
-			const inventory = yield* listWorkflows(repo);
-			if (inventory._tag === "Failure") {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot enumerate the workflow inventory of ${repo}: ${inventory.reason} — whether a producer exists is UNKNOWN, never green.`,
-					diagnostics,
+		const sample: Effect.Effect<
+			Sample,
+			never,
+			ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+		> = Effect.gen(function* () {
+			const done = (outcome: VerbOutcome): Sample => ({_tag: "Done", outcome});
+			const enumerated = yield* listCheckRuns(repo, sha);
+			if (enumerated._tag === "Failure") {
+				return done(
+					refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot enumerate check runs at ${sha}: ${enumerated.reason} — CI state is UNKNOWN, never green.`,
+						diagnostics,
+					),
 				);
 			}
-			const producer = producerFor(VERB, repo, inventory.value, yield* resolveCi(options.cwd));
-			if (producer._tag === "Unknown") {
-				return refuse(PRECONDITION_UNKNOWN, producer.reason, diagnostics);
+			const {declared, runs} = enumerated.value;
+			// Every poll re-reads the head, so the scanned line is this sample's, not the run's: it
+			// rides the sample's own notes and never accumulates one row per poll on the preamble.
+			const notes = [
+				...diagnostics,
+				scannedLine(VERB, runs.length, "check run", `${declared} declared`),
+			];
+			if (declared === 0) {
+				// The producer question is asked HERE and nowhere else on this path: an enumeration that
+				// returned runs already proves a producer. Empty is the one reading where "no CI at all"
+				// and "nothing has reported yet" are two different repos wearing one answer.
+				const inventory = yield* listWorkflows(repo);
+				if (inventory._tag === "Failure") {
+					return done(
+						refuse(
+							PRECONDITION_UNKNOWN,
+							`${VERB}: cannot enumerate the workflow inventory of ${repo}: ${inventory.reason} — whether a producer exists is UNKNOWN, never green.`,
+							notes,
+						),
+					);
+				}
+				const producer = producerFor(VERB, repo, inventory.value, yield* resolveCi(options.cwd));
+				if (producer._tag === "Unknown") {
+					return done(refuse(PRECONDITION_UNKNOWN, producer.reason, notes));
+				}
+				if (producer._tag === "Refused") return done(refuse(ZERO_SCOPE, producer.reason, notes));
+				if (producer._tag === "OptedOut") {
+					return done(noProducerAnswer(sha, json, [...notes, producer.note]));
+				}
+				return done(
+					refuse(
+						ZERO_SCOPE,
+						`${VERB}: zero check runs declared at ${sha} — refusing to report green over an empty enumeration (ADR 0092).`,
+						notes,
+					),
+				);
 			}
-			if (producer._tag === "Refused") return refuse(ZERO_SCOPE, producer.reason, diagnostics);
-			if (producer._tag === "OptedOut") {
-				return noProducerAnswer(sha, json, [...diagnostics, producer.note]);
+			if (runs.length < declared) {
+				return done(
+					refuse(
+						INCOMPLETE_SCAN,
+						`${VERB}: received ${runs.length} of ${declared} declared check runs at ${sha} — refusing the partial enumeration (#3999).`,
+						notes,
+					),
+				);
 			}
-			return refuse(
-				ZERO_SCOPE,
-				`${VERB}: zero check runs declared at ${sha} — refusing to report green over an empty enumeration (ADR 0092).`,
-				diagnostics,
-			);
-		}
-		if (runs.length < declared) {
-			return refuse(
-				INCOMPLETE_SCAN,
-				`${VERB}: received ${runs.length} of ${declared} declared check runs at ${sha} — refusing the partial enumeration (#3999).`,
-				diagnostics,
-			);
-		}
 
-		const rollup = rollupOf(runs);
-		const checks: ReasonHistogram = reasonHistogram(runs, statusOf);
-		const notes = [...diagnostics, ...namedLines(VERB, runs)];
-		// A red rollup is already the answer a caller must act on, so the coverage question is asked
-		// only where it changes one: `green` and `pending` are the two words that read as "nothing to
-		// do here", and both are wrong over bytes no gate inspected.
-		let gates: {readonly declared: number; readonly covered: number} | null = null;
-		if (rollup !== "red") {
-			const inventory = yield* listWorkflowPaths(repo);
-			if (inventory._tag === "Failure") {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot enumerate the workflow inventory of ${repo}: ${inventory.reason} — which gates exist is UNKNOWN, never green.`,
-					diagnostics,
+			const rollup = rollupOf(runs);
+			notes.push(...namedLines(VERB, runs));
+			// A red rollup is already the answer a caller must act on, so the coverage question is asked
+			// only where it changes one: `green` and `pending` are the two words that read as "nothing to
+			// do here", and both are wrong over bytes no gate inspected.
+			let gates: {readonly declared: number; readonly covered: number} | null = null;
+			if (rollup !== "red") {
+				const inventory = yield* listWorkflowPaths(repo);
+				if (inventory._tag === "Failure") {
+					return done(
+						refuse(
+							PRECONDITION_UNKNOWN,
+							`${VERB}: cannot enumerate the workflow inventory of ${repo}: ${inventory.reason} — which gates exist is UNKNOWN, never green.`,
+							notes,
+						),
+					);
+				}
+				const atHead = yield* listRunsAtHead(repo, sha);
+				if (atHead._tag === "Failure") {
+					return done(
+						refuse(
+							PRECONDITION_UNKNOWN,
+							`${VERB}: cannot enumerate the workflow runs at ${sha}: ${atHead.reason} — which gates ran is UNKNOWN, never green.`,
+							notes,
+						),
+					);
+				}
+				const coverage = gateCoverageOf(
+					inventory.value,
+					atHead.value.runs.map((run) => run.path),
 				);
+				if (coverage._tag === "Uncovered") {
+					// The `16` refusal is why `--wait` may not simply loop on "not green": a head no gate of
+					// this repo ran at has nothing coming, so waiting out the budget would answer nothing.
+					return done(
+						refuse(
+							NO_GATE_COVERAGE,
+							`${VERB}: none of the ${coverage.declared} workflow(s) ${repo} authors produced a run at ${sha} — the ${runs.length} check run(s) here came from elsewhere, so no gate inspected these bytes: the CI state is UNKNOWN, never green (#6522).`,
+							notes,
+						),
+					);
+				}
+				if (coverage._tag === "NoGates") {
+					notes.push(
+						`${VERB}: ${repo} authors no workflow of its own — every run at ${sha} is platform-provided, so there is no gate coverage to judge.`,
+					);
+				} else {
+					gates = {declared: coverage.declared, covered: coverage.covered};
+					notes.push(
+						`${VERB}: ${coverage.covered} of ${coverage.declared} workflow(s) ${repo} authors produced a run at ${sha}.`,
+					);
+				}
 			}
-			const atHead = yield* listRunsAtHead(repo, sha);
-			if (atHead._tag === "Failure") {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot enumerate the workflow runs at ${sha}: ${atHead.reason} — which gates ran is UNKNOWN, never green.`,
-					diagnostics,
-				);
+			return {_tag: "Read", rollup, runs, declared, gates, notes} satisfies Sample;
+		});
+
+		const render = (read: Extract<Sample, {_tag: "Read"}>, settle: Settle | null): VerbOutcome => {
+			const checks: ReasonHistogram = reasonHistogram(read.runs, statusOf);
+			return json
+				? answer(
+						JSON.stringify({
+							outcome: "ci",
+							sha,
+							rollup: read.rollup,
+							checks,
+							scanned: read.runs.length,
+							declared: read.declared,
+							gates: read.gates,
+							settle,
+						}),
+						read.notes,
+					)
+				: answer(
+						[
+							...(settle === null ? [] : [`settle\t${settle}`]),
+							`ci\t${sha}\t${read.rollup}`,
+							`run\t${read.runs.length}`,
+							...Object.entries(checks).map(([status, count]) => `check\t${status}\t${count}`),
+						].join("\n"),
+						read.notes,
+					);
+		};
+
+		const first = yield* sample;
+		if (first._tag === "Done") return first.outcome;
+		if (!options.wait) return render(first, null);
+
+		// The budget is WALL CLOCK, gh-call latency included — counting only the sleeps is how a verb
+		// silently overruns the bound it claims to hold (`ship checks --wait` records the same lesson).
+		const startedAt = yield* Clock.currentTimeMillis;
+		let read = first;
+		for (;;) {
+			if (read.rollup !== "pending") return render(read, "settled");
+			const now = yield* Clock.currentTimeMillis;
+			if (now - startedAt >= options.budgetSeconds * 1000) {
+				return render(read, "budget-exhausted");
 			}
-			const coverage = gateCoverageOf(
-				inventory.value,
-				atHead.value.runs.map((run) => run.path),
-			);
-			if (coverage._tag === "Uncovered") {
-				return refuse(
-					NO_GATE_COVERAGE,
-					`${VERB}: none of the ${coverage.declared} workflow(s) ${repo} authors produced a run at ${sha} — the ${runs.length} check run(s) here came from elsewhere, so no gate inspected these bytes: the CI state is UNKNOWN, never green (#6522).`,
-					diagnostics,
-				);
+			yield* Effect.sleep(`${options.cadenceSeconds} seconds`);
+
+			const moved = yield* openPull(VERB, repo, pr, {requireOpen: false, requireFiles: false});
+			if (moved._tag === "Refused") return moved.outcome;
+			if (!prefixMatch(moved.pull.headSha, sha)) {
+				// The wait was for a tree the PR no longer is: the last read still binds what it inspected,
+				// and the caller is told the head moved rather than handed a stale `settled`.
+				return render(read, "head-moved");
 			}
-			if (coverage._tag === "NoGates") {
-				notes.push(
-					`${VERB}: ${repo} authors no workflow of its own — every run at ${sha} is platform-provided, so there is no gate coverage to judge.`,
-				);
-			} else {
-				gates = {declared: coverage.declared, covered: coverage.covered};
-				notes.push(
-					`${VERB}: ${coverage.covered} of ${coverage.declared} workflow(s) ${repo} authors produced a run at ${sha}.`,
-				);
-			}
+			const next = yield* sample;
+			if (next._tag === "Done") return next.outcome;
+			read = next;
 		}
-		return json
-			? answer(
-					JSON.stringify({
-						outcome: "ci",
-						sha,
-						rollup,
-						checks,
-						scanned: runs.length,
-						declared,
-						gates,
-					}),
-					notes,
-				)
-			: answer(
-					[
-						`ci\t${sha}\t${rollup}`,
-						`run\t${runs.length}`,
-						...Object.entries(checks).map(([status, count]) => `check\t${status}\t${count}`),
-					].join("\n"),
-					notes,
-				);
 	});

--- a/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs, fakeSeams, type HttpReply, type Scripted} from "../fakes.test-support.ts";
+import {fakeFs, fakeSeams, type HttpReply, once, type Scripted} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {workflows} from "../ship/fixtures.test-support.ts";
 import {runCi} from "./ci-verb.ts";
@@ -45,6 +45,9 @@ const GATED: ReadonlyArray<Scripted> = [
 const options = {
 	pr: 4321,
 	sha: null as string | null,
+	wait: false,
+	budgetSeconds: 600,
+	cadenceSeconds: 30,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
@@ -396,5 +399,118 @@ describe("the no-producer split", () => {
 		const out = await run(empty, [[WORKFLOWS, BAD_GATEWAY]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("whether a producer exists is UNKNOWN, never green");
+	});
+});
+
+/**
+ * The bounded wait of #7282: a `pending` is the ordinary state of a PR minutes after a push, and a
+ * caller that cannot wait for it has only a park on a human to offer for a condition that clears
+ * itself. The verb owns the loop so no skill ever sleeps (`docs/skill-conventions.md` §14).
+ */
+describe("the bounded --wait", () => {
+	const PENDING = runs(3, [
+		{name: "lint / format / typecheck", status: "completed", conclusion: "success"},
+		{name: "unit tests", status: "queued", conclusion: null},
+		{name: "leak-guard", status: "in_progress", conclusion: null},
+	]);
+
+	it("answers a pending head with this moment's read, and no settle token, without --wait", async () => {
+		const out = await run(
+			[
+				[PULL, served(pull())],
+				[RUNS, PENDING],
+			],
+			GATED,
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`ci\t${HEAD}\tpending`);
+		expect(out.stdout).not.toContain("settle\t");
+	});
+
+	it("stays in the loop and settles on the head's own verdict once CI concludes", async () => {
+		const out = await run(
+			[
+				[PULL, served(pull())],
+				[once(RUNS), PENDING],
+				[RUNS, GREEN],
+			],
+			GATED,
+			{wait: true, cadenceSeconds: 0},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n").slice(0, 2)).toEqual(["settle\tsettled", `ci\t${HEAD}\tgreen`]);
+	});
+
+	/**
+	 * The whole point of the settle token: an exhausted bound must not read as a verdict. The rollup
+	 * beside it is still `pending`, so nothing about the head was proven — the wait ran out.
+	 */
+	it("exhausts the bound on a head that never concludes, still pending and never green", async () => {
+		const out = await run(
+			[
+				[PULL, served(pull())],
+				[RUNS, PENDING],
+			],
+			GATED,
+			{wait: true, cadenceSeconds: 0, budgetSeconds: 0},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n").slice(0, 2)).toEqual([
+			"settle\tbudget-exhausted",
+			`ci\t${HEAD}\tpending`,
+		]);
+		expect(out.stdout).not.toContain("green");
+	});
+
+	it("stops when the PR leaves the head this answer binds", async () => {
+		const out = await run(
+			[
+				[once(PULL), served(pull())],
+				[PULL, served(pull({head: OLD_HEAD}))],
+				[RUNS, PENDING],
+			],
+			GATED,
+			{wait: true, cadenceSeconds: 0},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n").slice(0, 2)).toEqual([
+			"settle\thead-moved",
+			`ci\t${HEAD}\tpending`,
+		]);
+	});
+
+	/**
+	 * The `16` head has nothing coming — no gate of this repo ran at it — so a wait would answer
+	 * nothing. A cadence no test could sit through proves the refusal is taken on the first read.
+	 */
+	it("refuses an ungated head on 16 at once, without entering the loop", async () => {
+		const out = await run(
+			[
+				[PULL, served(pull())],
+				[RUNS, PENDING],
+			],
+			[
+				[WORKFLOWS, served(inventory(CI_YML, CODEQL))],
+				[AT_HEAD, served(runsAtHead(CODEQL))],
+			],
+			{wait: true, cadenceSeconds: 86_400},
+		);
+		expect(out.code).toBe(NO_GATE_COVERAGE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("returns no-producer at once — a caller must not wait for a run that will never start", async () => {
+		const out = await run(
+			[
+				[PULL, served(pull())],
+				[RUNS, runs(0, [])],
+			],
+			[[WORKFLOWS, served(workflows())]],
+			{wait: true, cadenceSeconds: 86_400},
+			{[CONFIG]: '{"ci": {"noProducer": "degrade"}}'},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe([`ci\t${HEAD}\tno-producer`, "run\t0", ""].join("\n"));
+		expect(out.stdout).not.toContain("settle\t");
 	});
 });

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -129,14 +129,30 @@ const ci = leafCommand(
 				"the head to enumerate check runs at (default: the PR's live head); give the inspected head so the answer binds to what is being judged",
 			),
 		),
+		wait: Flag.boolean("wait").pipe(
+			Flag.withDescription(
+				"poll a `pending` head until CI concludes or the budget expires, instead of answering with this moment's read",
+			),
+		),
+		budgetSeconds: Flag.integer("budget-seconds").pipe(
+			Flag.withDefault(600),
+			Flag.withDescription("--wait only: total wall-clock budget, gh-call latency included"),
+		),
+		cadenceSeconds: Flag.integer("cadence-seconds").pipe(
+			Flag.withDefault(30),
+			Flag.withDescription("--wait only: sleep between polls"),
+		),
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({pr, sha, repo, json}) {
+	Effect.fn(function* ({pr, sha, wait, budgetSeconds, cadenceSeconds, repo, json}) {
 		yield* emit(
 			yield* runCi({
 				pr,
 				sha: Option.getOrNull(sha),
+				wait,
+				budgetSeconds,
+				cadenceSeconds,
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -145,9 +161,11 @@ const ci = leafCommand(
 		);
 	}),
 ).pipe(
-	Command.withShortDescription("Roll up the live check runs at a head, fail-closed."),
+	Command.withShortDescription(
+		"Roll up a head's check runs, fail-closed; --wait waits out a pending.",
+	),
 	Command.withDescription(
-		'Enumerate the live check runs at a head and roll them up green / red / pending, fail-closed on the ambiguous rows — a cancelled or unrecognised conclusion is red, never green. First stdout line is `ci\\t<sha>\\t<rollup>`, then `run\\t<count>` and one `check\\t<status>\\t<count>` line per status present — a status tally under ADR 0308, with the failing and still-running runs named on stderr. An empty enumeration asks whether the repo produces CI at all: with zero workflows it refuses, unless `.fabrika.jsonc` declares `ci.noProducer: "degrade"`, which rolls up `no-producer` — never green. A rollup that is not red then asks which gates ran: with at least one run from a workflow this repo authors, the covered-of-declared count is on stderr (and `gates` under `--json`); with none it refuses on 16; a repo that authors no workflow of its own has no gate to have missed and says so on stderr at exit 0. Exits 7 (PR or --sha proven absent, zero check runs declared, or zero workflows — ADR 0092), 11 (the enumeration, the workflow inventory, the workflow runs at the head, or `.fabrika.jsonc` could not be read — CI state is UNKNOWN, never green), 13 (received fewer runs than declared — #3999), 16 (the enumeration is complete, but no workflow this repo authors produced a run at the head — no gate inspected these bytes, so the answer is neither green nor pending; #6522). Example: fabrika review ci 4321 --sha 03135b91',
+		'Enumerate the live check runs at a head and roll them up green / red / pending, fail-closed on the ambiguous rows — a cancelled or unrecognised conclusion is red, never green. First stdout line is `ci\\t<sha>\\t<rollup>`, then `run\\t<count>` and one `check\\t<status>\\t<count>` line per status present — a status tally under ADR 0308, with the failing and still-running runs named on stderr. An empty enumeration asks whether the repo produces CI at all: with zero workflows it refuses, unless `.fabrika.jsonc` declares `ci.noProducer: "degrade"`, which rolls up `no-producer` — never green. A rollup that is not red then asks which gates ran: with at least one run from a workflow this repo authors, the covered-of-declared count is on stderr (and `gates` under `--json`); with none it refuses on 16; a repo that authors no workflow of its own has no gate to have missed and says so on stderr at exit 0. `--wait` turns a `pending` read into a bounded in-verb wait — the verb owns the loop so no caller ever sleeps (`docs/skill-conventions.md` §14) — and prepends `settle\\t<settled|budget-exhausted|head-moved>` to the answer (`settle` under `--json`, null without `--wait`). It polls ONLY a `pending`: every refusal and the `no-producer` answer are states no waiting changes, so they return on the first read rather than burning the budget. `budget-exhausted` still prints `pending` — the wait ran out, CI did not conclude, and it is never a verdict; `head-moved` says the PR left the head this answer binds. Exits 7 (PR or --sha proven absent, zero check runs declared, or zero workflows — ADR 0092), 11 (the enumeration, the workflow inventory, the workflow runs at the head, or `.fabrika.jsonc` could not be read — CI state is UNKNOWN, never green), 13 (received fewer runs than declared — #3999), 16 (the enumeration is complete, but no workflow this repo authors produced a run at the head — no gate inspected these bytes, so the answer is neither green nor pending; #6522). Example: fabrika review ci 4321 --sha 03135b91',
 	),
 );
 

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -68,6 +68,19 @@ const PATCH = /PATCH .*\/repos\/o\/r\/issues\/4287$/;
 
 const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
 
+/** The point read `review ci` answers with by default — no `--wait`, so the bound is unused. */
+const POINT_READ = {
+	pr: 4321,
+	sha: null,
+	wait: false,
+	budgetSeconds: 600,
+	cadenceSeconds: 30,
+	repo: null,
+	json: false,
+	env: ENV,
+	cwd: "/repo",
+};
+
 /** The pinned write instant, and the stamp `review post` emits from it under every verdict body. */
 const NOW = Effect.succeed(Date.parse("2026-08-09T06:30:00.412Z"));
 const STAMP = "Verdict-written: 2026-08-09T06:30:00Z";
@@ -132,11 +145,7 @@ describe("the CI rollup's fail-closed buckets", () => {
 
 	it("reds a cancelled check — a check that proved nothing must not read green", async () => {
 		const {runCi} = await import("./ci-verb.ts");
-		const out = await withShell(
-			runCi({pr: 4321, sha: null, repo: null, json: false, env: ENV, cwd: "/repo"}),
-			script,
-			http,
-		);
+		const out = await withShell(runCi(POINT_READ), script, http);
 		expect(out.stdout.split("\n")[0]).toBe(`ci\t${HEAD}\tred`);
 	});
 
@@ -145,11 +154,7 @@ describe("the CI rollup's fail-closed buckets", () => {
 			rollupOf: (runs) => actual.rollupOf(runs.filter((run) => run.conclusion !== "cancelled")),
 		}));
 		const {runCi} = await import("./ci-verb.ts");
-		const out = await withShell(
-			runCi({pr: 4321, sha: null, repo: null, json: false, env: ENV, cwd: "/repo"}),
-			script,
-			http,
-		);
+		const out = await withShell(runCi(POINT_READ), script, http);
 		// The intended death, named exactly: the answer flips to the permissive token, at exit 0.
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe(`ci\t${HEAD}\tgreen`);
@@ -171,11 +176,7 @@ describe("the CI rollup's gate-coverage refusal", () => {
 
 	it("refuses a head no gate inspected — a passing check set is not gate coverage", async () => {
 		const {runCi} = await import("./ci-verb.ts");
-		const out = await withShell(
-			runCi({pr: 4321, sha: null, repo: null, json: false, env: ENV, cwd: "/repo"}),
-			script,
-			http,
-		);
+		const out = await withShell(runCi(POINT_READ), script, http);
 		expect(out.code).toBe(NO_GATE_COVERAGE);
 		expect(out.stdout).toBe("");
 	});
@@ -185,11 +186,7 @@ describe("the CI rollup's gate-coverage refusal", () => {
 			gateCoverageOf: () => ({_tag: "Covered", declared: 1, covered: 1}),
 		}));
 		const {runCi} = await import("./ci-verb.ts");
-		const out = await withShell(
-			runCi({pr: 4321, sha: null, repo: null, json: false, env: ENV, cwd: "/repo"}),
-			script,
-			http,
-		);
+		const out = await withShell(runCi(POINT_READ), script, http);
 		// The intended death: the ungated head reports the permissive token, at exit 0.
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe(`ci\t${HEAD}\tgreen`);


### PR DESCRIPTION
Fixes #7260

A spawned reviewer waiting on a queued `ci-required` aggregator left background `sleep` timers
behind. Two fired after its run had already reported its verdict and terminated, re-notifying the
driver with nothing to route. Same defect as #6696, one shell over — #6696 fixed the operator and
was deliberately scoped to a single file, so `operate/SKILL.md` was the only file in the corpus
carrying the rule.

The fix hoists rather than copies.

- `docs/skill-conventions.md` gains **§14 — A skill never sleeps and never polls on a timer**. It
  states the rule once for the whole corpus, in the §11 cite-not-restate shape ("This section is
  where that rule lives; a skill contract cites it and does not restate it"). It carries both
  incidents (#6696's ~55 live shells, #7260's stale re-notifications), the diagnosis they share
  (neither skill's text asked for a sleep — a background one is what a model reaches for when a
  step leaves a wait to fill and no rule against filling it), and the one legitimate exception: a
  `sleep` inside a CLI verb, with `ship reconcile --wait`'s `Effect.sleep` at
  `packages/fabrika-cli/src/ship/reconcile-verb.ts:107` as the worked case.
- `skills/review/SKILL.md` reaches the rule at the CI-wait step — right after the `review ci` block,
  where a `pending` leaves the gap. It names the section, notes there is no `--wait` here doing the
  blocking, and says what to do instead: take the `pending` as the read the head gives now, ending
  the code class on the same `UNKNOWN` the existing `16` path ends on.
- `skills/operate/SKILL.md` keeps the rule at §2's dispatch step, but its paragraph is now the
  imperative plus a citation instead of a second full statement. The one thing it still states
  locally is the operator-specific extension: a timed `lane status` is the same defect wearing a
  fabrika verb.

The full statement now lives in exactly one place; both skills cite it.

## Deviations

- **Out-of-scope change** — **Said:** criterion 4 asks only that `review/SKILL.md` reach the rule at
  the CI-wait point. **Did:** also stated what a reviewer does with a `pending` instead of waiting,
  routing it to the `UNKNOWN` terminal the adjacent `16` paragraph already uses. **Why:** a ban with
  no alternative leaves the same gap the issue diagnoses — a wait to fill and nothing to fill it
  with. **Disposition:** stated here; it reuses the existing terminal rather than adding one.
- **Scope narrowing** — **Said:** the issue body's prose suggests citing the rule from "the skills
  that spawn or wait". **Did:** cited it from `review` and `operate` only. **Why:** the acceptance
  criteria name exactly those two, and no other skill in the corpus mentions `sleep` today, so there
  is no third mention to convert to a citation. **Disposition:** stated here; a later skill that
  gains a wait cites §14 when it does.

- **Guard or gate bypassed** — **Said:** `build claim`'s rule is that a `lost` race means back off,
  including when the winner shares your session. **Did:** released the standing claim marker with its
  own token and re-claimed. **Why:** the marker belonged to a lane that had already reported
  `BLOCKED` on lane 7260 46 minutes earlier and left no worktree holding the branch — a stale marker,
  not a live lane; the driver spawned this run for exactly this repair. **Disposition:** stated here;
  no other lane's work was touched, and the released token is named in the amendment below.
- **Out-of-scope change** — **Said:** #7282 asks for a bounded `--wait` on `review ci` and the
  matching `review/SKILL.md` paragraph. **Did:** also changed that section's existing `review ci`
  fence to carry `--wait`, and updated `contract.md`, `README.md` and the verb's help strings.
  **Why:** two fences with different flags invite picking the wrong one, and a change to what a verb
  prints owes every surface in `.patterns/verb-output-pin-surfaces.md` in the same PR.
  **Disposition:** stated here.

---

## Amendment — 2026-08-29, repair round for #7282

The first round's `review/SKILL.md` paragraph routed a `pending` CI read to
`UNKNOWN — the artifact could not be read`, which parks the lane on a human. A `pending` is the
ordinary state of a PR minutes after a push — exactly when `operate` spawns a reviewer — so the
common case parked. This PR's own reviewer run hit it: `review ci` printed `pending` over 22 success
/ 8 queued / 7 skipped / 5 in_progress, a healthy PR.

Ruled direction: **option (a)** from #7282 — a bounded in-verb wait, the shape §14 already sanctions.
Option (b), splitting `review`'s terminal vocabulary, reaches ADR 0329 and stays out of scope.

What this round adds, at head `68d57a5ccaee532eeac72e9d59601c18bcddf01f`:

- **`review ci` gains `--wait`** (`packages/fabrika-cli/src/review/ci-verb.ts`), opt-in — the default
  stays the point read. It polls a `pending` and nothing else: every refusal and the `no-producer`
  answer return on the first read, so the `16` head and a repo with no producer never burn the
  budget, keeping line 48's "a caller keying on `pending` must not wait for a run that will never
  start" true. `--budget-seconds` defaults to 600, `--cadence-seconds` to 30, and the budget is wall
  clock so the verb cannot overrun the bound it claims to hold.
- **The bound-exhausted answer is `settle\tbudget-exhausted` beside a rollup that still reads
  `pending`.** A new first line, `settle\t<settled|budget-exhausted|head-moved>`, appears only under
  `--wait` (`"settle"` in the `--json` object, `null` without it). `settled` carries the `green` or
  `red` the caller judges on; `budget-exhausted` proves nothing and says so by keeping the `pending`;
  `head-moved` says the PR left the head this answer binds. So an exhausted wait is never mistakable
  for a verdict, and never for a resolved one.
- **The `review/SKILL.md` paragraph now routes on those three tokens.** §14's ban, its citation and
  the #7260 incident are unchanged — that half was reviewed PASS. What changed is the tail: instead
  of parking every `pending`, the reviewer makes one `--wait` call and routes `settled` (judge on it)
  / `budget-exhausted` (a stuck queue — `UNKNOWN`, naming the token, and `heal-ci` is the lane that
  moves a stalled PR) / `head-moved` (re-read at the new head). The rare case still parks; the
  ordinary one no longer does.
- **§14 names `review ci --wait` beside `ship reconcile --wait`** as a worked case, and adds that a
  bound that runs out is its own answer — `unresolved` there, `budget-exhausted` here — never the
  permissive one.
- **Pin surfaces** — `review/contract.md` (the Output paragraph, the flag table and two new worked
  examples), `packages/fabrika-cli/README.md`'s row, both `command.ts` help strings, and the verb's
  docblocks, per `.patterns/verb-output-pin-surfaces.md`.

Six new unit tests in `packages/fabrika-cli/src/review/ci-verb.unit.test.ts` cover the settle, the
exhausted bound, the moved head, the point read's absent settle line, and the two states that must
not enter the loop. `pnpm typecheck` and the full fabrika-cli suite (8205 tests) pass.

Lane note: this round released a stale `build claim` marker
(`build:f9c33a36-…:0fb7cbc6-4a19-478b-a057-1c28accdc63b`, posted 06:47Z by a lane that reported
`BLOCKED` at 06:47:58Z and left no worktree on the branch) and re-claimed under
`…:71d310af-fc2a-45bf-beef-d454f5c7d40b`. Disclosed as a deviation above.
