### PR TITLE
fix: fabrika-pi is configured in release-please but no step dispatches its publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -229,10 +229,11 @@ jobs:
       # repo-wide `releases_created` would dispatch a publish for a package that did not
       # release.
       - name: Dispatch the npm publish for each tag this push released
-        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-opencode--release_created'] == 'true' }}
+        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-pi--release_created'] == 'true' || steps.release.outputs['packages/fabrika-opencode--release_created'] == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FABRIKA_CLI_TAG: ${{ steps.release.outputs['packages/fabrika-cli--tag_name'] }}
+          FABRIKA_PI_TAG: ${{ steps.release.outputs['packages/fabrika-pi--tag_name'] }}
           FABRIKA_OPENCODE_TAG: ${{ steps.release.outputs['packages/fabrika-opencode--tag_name'] }}
         run: |
           # `-e` spelled out because the runner sets it for us: a `run:` block with no
@@ -247,6 +248,7 @@ jobs:
           # so every configured package's tag rides the same loop.
           tags=()
           if [ -n "${FABRIKA_CLI_TAG:-}" ]; then tags+=("$FABRIKA_CLI_TAG"); fi
+          if [ -n "${FABRIKA_PI_TAG:-}" ]; then tags+=("$FABRIKA_PI_TAG"); fi
           if [ -n "${FABRIKA_OPENCODE_TAG:-}" ]; then tags+=("$FABRIKA_OPENCODE_TAG"); fi
 
           if [ "${#tags[@]}" -eq 0 ]; then
@@ -344,10 +346,11 @@ jobs:
       # The one gate in this file, keyed on the PER-PATH outputs. `releases_created`
       # appears nowhere.
       - name: Summarize which packages this push released
-        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-opencode--release_created'] == 'true' }}
+        if: ${{ steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-pi--release_created'] == 'true' || steps.release.outputs['packages/fabrika-opencode--release_created'] == 'true' }}
         env:
           PATHS_RELEASED: ${{ steps.release.outputs.paths_released }}
           FABRIKA_CLI_TAG: ${{ steps.release.outputs['packages/fabrika-cli--tag_name'] }}
+          FABRIKA_PI_TAG: ${{ steps.release.outputs['packages/fabrika-pi--tag_name'] }}
           FABRIKA_OPENCODE_TAG: ${{ steps.release.outputs['packages/fabrika-opencode--tag_name'] }}
         run: |
           set -uo pipefail
@@ -370,7 +373,7 @@ jobs:
             # shellcheck disable=SC2016
             printf -- '- `%s`\n' "${released[@]}"
             echo
-            echo "Tags: \`${FABRIKA_CLI_TAG:-none}\` \`${FABRIKA_OPENCODE_TAG:-none}\`"
+            echo "Tags: \`${FABRIKA_CLI_TAG:-none}\` \`${FABRIKA_PI_TAG:-none}\` \`${FABRIKA_OPENCODE_TAG:-none}\`"
             echo
             echo "Publishing is \`publish.yml\`, dispatched by this run at each tag above (ADR 0292)."
             echo "A human-cut release reaches the same workflow on the \`release: published\` event instead."

--- a/.patterns/release-path.md
+++ b/.patterns/release-path.md
@@ -117,7 +117,8 @@ pipeline-cli action on a fabrika-cli release.
 
 `release-please.yml`'s only condition keys on the per-path
 `<path>--release_created` outputs (`packages/fabrika-cli--release_created`,
-`packages/fabrika-opencode--release_created`) and reports from the `paths_released` JSON array.
+`packages/fabrika-pi--release_created`, `packages/fabrika-opencode--release_created`) and reports
+from the `paths_released` JSON array.
 `releases_created` appears nowhere in the file, deliberately. A later "simplification" back
 to the single output is the regression ADR 0239 §5 Hazard A names.
 
@@ -205,7 +206,7 @@ corrupted by it — no version is consumed, because nothing was published.
 
 ## Current state
 
-Two package roots are configured today (`fabrika-cli`, `fabrika-opencode`).
+Three package roots are configured today (`fabrika-cli`, `fabrika-pi`, `fabrika-opencode`).
 `pipeline-cli` was deleted from the repo with its release machinery (#6326) — its npm
 artifacts remain, so its history below stays recorded. Registrations that exist name this
 repo and this workflow file, but only some have ever been *exercised* by it, and those are
@@ -221,6 +222,13 @@ two different facts.
   for the package. `fabrika-cli@0.1.0` reached the registry through the bootstrap `pnpm publish`
   of step 4 above, not through this path (its artifact carries no attestations). Its **first**
   release run is the first use of that registration, and that run is the proof.
+- **`fabrika-pi` — wired, not yet bootstrapped
+  ([#7273](https://github.com/kamp-us/phoenix/issues/7273)).** The resolve arm, the release-please
+  root and manifest entry all exist; steps 4–5 do not. A human must run the bootstrap `pnpm publish`
+  of `0.1.0` from `packages/fabrika-pi`, then register the Trusted Publisher on npmjs.com. Until both
+  happen, a Release PR merge for the package creates a tag whose publish run 403s after install/build
+  pass — fail-closed, no version consumed. That the package ships to npm at all is ADR
+  [0332](../.decisions/0332-fabrika-pi-ships-as-npm-package.md).
 - **`fabrika-opencode` — wired, not yet bootstrapped (#6965).** The resolve arm, the
   release-please root and manifest entry all exist; steps 4–5 do not. A human must run the
   bootstrap `pnpm publish` of `0.1.0` from a checkout at the merge that introduced it, then

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
 	"packages/fabrika-cli": "0.5.0",
+	"packages/fabrika-pi": "0.1.0",
 	"packages/fabrika-opencode": "0.1.0"
 }


### PR DESCRIPTION
`packages/fabrika-pi` was configured in `release-please-config.json` but missing from
`.release-please-manifest.json` and from both per-path gates in
`.github/workflows/release-please.yml`. A release-please run that bumped only fabrika-pi would cut a
tag and dispatch nothing — green everywhere, and only the registry disagreeing.

This finishes step 3 of [`.patterns/release-path.md`](.patterns/release-path.md) §
"Adding a third published package". ADR
[0332](.decisions/0332-fabrika-pi-ships-as-npm-package.md) rules that `@kampus/fabrika-pi` ships to
npm, so the fix is to complete the wiring rather than unconfigure the package.

- `.release-please-manifest.json` gains `"packages/fabrika-pi": "0.1.0"`, matching the package's own
  `version`. Without an entry release-please reads the component as never-released and its first cut
  is `1.0.0` — the hazard holding release PR #6819.
- Both gates in `release-please.yml` — the publish dispatch and the summary — gain a third `if:` arm
  on `packages/fabrika-pi--release_created`, a `FABRIKA_PI_TAG` env var from
  `packages/fabrika-pi--tag_name`, and the tag in their accumulator / `Tags:` line. Both still key
  on per-path outputs only; no expression reads `releases_created`.
- `.patterns/release-path.md` § "Current state" now counts three roots and names all three,
  resolving the drift folded in from #7225, and gains a `fabrika-pi` bullet in the same shape as the
  `fabrika-opencode` one. Constraint 5's parenthetical list of per-path outputs picks up the third.

`publish.yml` is untouched — its `^fabrika-pi-v([0-9].*)$` resolve arm already exists.

Steps 4 and 5 stay outstanding and stay human: the bootstrap `pnpm publish` of `0.1.0` and the npm
Trusted Publisher registration. Neither is delivered here, and the doc bullet says so. Until both
land, a fabrika-pi tag's publish run 403s after install and build pass — fail-closed, no version
consumed. Tracked in #7273.

Validated in-tree, cache bypassed: `--surface workflows` (actionlint), `--surface prose` (link +
leak scan), `--surface code` (typecheck + lint) — one per file class in the diff, all green.

Fixes #7215

## Deviations

- **Out-of-scope change** — **Said:** the acceptance criteria name only §&nbsp;"Current state" in
  `.patterns/release-path.md`. **Did:** also added `packages/fabrika-pi--release_created` to
  constraint 5's parenthetical list of the per-path outputs `release-please.yml` keys on. **Why:**
  that list enumerates the very gates this PR widens, so leaving it at two would have re-created the
  same doc-versus-file drift the ticket exists to close. **Disposition:** stated here.
