### PR TITLE
feat: review-ui render has no flag-override or seeded-session path, so gated states cannot be captured

### DIFF
--- a/.decisions/0336-review-ui-renders-flag-gated-states.md
+++ b/.decisions/0336-review-ui-renders-flag-gated-states.md
@@ -47,3 +47,38 @@ The interim rider in §2 is the deferred direction's honest half — disclosure,
 - `render-verb.ts` grows an auth and flag seam it does not have today, which is real surface area on a verb that is otherwise read-only against a preview.
 - Until that lands, `review-ui` verdicts get longer: every unpainted state is named. That is the point.
 - The accidental coverage an atölye exhibit provides stays useful and stays optional.
+
+## Amendment — 2026-08-29: §1 shipped, so §2 and §3 retire
+
+[#7218](https://github.com/kamp-us/phoenix/issues/7218) landed §1, so the two interim clauses this
+ADR wrote against that absence are spent. Recorded here rather than by rewriting the body: what the
+gate did while it could not see is part of the record.
+
+**What replaced §2's interim rider.** `review-ui render` takes `--flag <key>=<on|off>`, repeatable.
+It rides the worker's existing `phoenix_flag_overrides` cookie into the capture context, so no route
+was added and `flagship/override-authz.ts` was not touched — its verdict still derives only from the
+environment and the actor's stored platform-admin relation, and an attacker-supplied cookie still
+cannot self-authorize. A flag-off state is therefore now a state the gate renders. What still owes
+disclosure is narrower and unchanged in kind: a state nothing here can put on screen — seeded data
+absent, credentials not handed over, a state with no mechanism.
+
+**What that gate costs, stated plainly.** On a deployed stage the override cookie is honored only
+for a request whose actor holds platform `Admin`, and `preview-seed test-account` provisions
+moderation authority, not admin. So a forced run is an authenticated admin's capture: every
+`--surface` must name `:auth` (a bare route beside `--flag` is refused on `10`), and the operator
+grants platform admin to the test account on that throwaway preview D1 through the offline
+`admin-grant` path ADR [0107](0107-capability-authz-framework.md) already sanctions. Two consequences worth
+naming: the admin grant is opt-in, so an ordinary `:auth` capture stays a plain yazar+moderator's
+view; and a forced capture shows admin-only affordances, which is the trade the operand buys and the
+reason it is not the default.
+
+**Why the override proves itself.** An override the preview dropped renders the flag-off page
+cleanly, which is a valid PNG under the flag-on name — the same class as the `:auth` cookie that did
+not authenticate ([#7051](https://github.com/kamp-us/phoenix/issues/7051)). So the shot asks the
+preview's own `/api/flags/evaluate` from the same context, with each forced key's default set to the
+opposite value, and refuses on `11` when a key came back at its default. The alternative was
+trusting the seeding, which is exactly the assumption §2 existed to stop.
+
+**§3's disclosure fork retires with it.** `claude-plugins/fabrika/skills/review-ui/SKILL.md` no
+longer forks on a flag-off capture; it directs the reviewer to render that state. The fork on an
+*unreachable* surface — the older #4305 rule — is untouched.

--- a/apps/web/worker/features/flagship/override-authz.unit.test.ts
+++ b/apps/web/worker/features/flagship/override-authz.unit.test.ts
@@ -68,6 +68,25 @@ describe("overridesAuthorized — may this request honor its per-browser cookie 
 			assert.strictEqual(allowed, false);
 		}),
 	);
+
+	// `preview` and `audit` are deployed stages too (ADR 0088), and a PR preview is now a place
+	// somebody seeds this cookie on purpose (#7218) — so the "development is the only free arm"
+	// half of the invariant is proven for every deployed class, not for `production` alone.
+	for (const environment of ["preview", "audit"] as const) {
+		it.effect(`${environment}, non-admin: NOT authorized — only development is free`, () =>
+			Effect.gen(function* () {
+				const allowed = yield* authorize(environment, {isAdmin: false, actor: human("user-1")});
+				assert.strictEqual(allowed, false);
+			}),
+		);
+
+		it.effect(`${environment}, admin: authorized — the one path a forced capture rides`, () =>
+			Effect.gen(function* () {
+				const allowed = yield* authorize(environment, {isAdmin: true, actor: human("admin-1")});
+				assert.strictEqual(allowed, true);
+			}),
+		);
+	}
 });
 
 const OVERRIDDEN_FLAG = "phoenix-reactions";
@@ -94,6 +113,12 @@ describe("makeRequestFlagsContext — the verdict gates cookie parsing (#2741)",
 		Effect.gen(function* () {
 			const overrides = yield* contextOverrides("production", true);
 			assert.deepStrictEqual(overrides, {[OVERRIDDEN_FLAG]: true});
+		}),
+	);
+
+	it.effect("preview, verdict false: the cookie is dropped — a seeded one is inert too", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* contextOverrides("preview", false), undefined);
 		}),
 	);
 });

--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -106,7 +106,11 @@ Two environment values make `:auth` work, and both come from somewhere specific:
 the account and its session row on this PR's preview D1; `BETTER_AUTH_SECRET` is the **preview
 worker's** secret, not your local one, because it is the worker that verifies the cookie's signature.
 Neither is yours to mint — if you do not have them, you have not been handed the account, and
-`review-ui note` is the honest route.
+`review-ui note` is the honest route. A `--flag` run needs one thing more: that account holding
+platform admin on this preview's D1, granted offline with
+`node packages/admin-grant/src/bin.ts grant --user-id preview-test-moderator --database-id <preview-d1>`.
+That is an operator's act against a throwaway preview, never yours and never against a database
+holding real accounts.
 
 **You never have to judge whether the shot came back signed in.** The verb hits the preview's own
 session endpoint from the same browser context before it records anything, and refuses `11` when the
@@ -131,23 +135,38 @@ run-level refusal and what makes a capture valid are the verb's section
 `--heading "review-ui note"`). The two render paths this needs are
 `--heading "Required environment — the two render paths"`.
 
-**A surface that renders cleanly is not yet a judged surface.** The verb captures as an anonymous
-visitor with every flag at its default, and under ADR
+**A surface that renders cleanly is not yet a judged surface.** By default the verb captures as an
+anonymous visitor with every flag at its default, and under ADR
 [0083](../../../../.decisions/0083-agents-deploy-humans-release.md)'s dark-ship norm that is exactly
 who never sees the feature. So a flag-gated route serving its own 404, a signed-in view serving the
 auth wall, and a feed row correctly showing no new marker all come back `captured` — a clean
-capture of the state the PR did not add. The verb reports none of them as unreachable, so the
-disclosure fork above never fires and the run reads as coverage it does not have (#6541, on PR
+capture of the state the PR did not add, which the verb reports as no kind of problem (#6541, on PR
 #6434: six surfaces captured, four of the PR's compositions never painted).
 
-Derive the states the PR adds from the diff, and check each one against what actually painted.
-**Every state that did not paint is named in your verdict**, with why — flag off, signed out,
-seeded data absent. Name them and judge what did paint; a verdict that stays silent about them
-claims a judgment nobody made. When nothing the PR adds painted, that is CANT-SEE, on the same
-terms as an every-surface-unreachable render. ADR
-[0336](../../../../.decisions/0336-review-ui-renders-flag-gated-states.md) records why this is a
-disclosure rule today and what retires it: a flag-override plus seeded-session path on `review-ui
-render`, after which the gate reaches these states instead of naming them.
+**So derive the states the PR adds from the diff, and render each one rather than disclosing it.**
+`:auth` reaches what is behind login, and `--flag <key>=<on|off>` forces a dark-shipped flag on:
+
+```bash
+fabrika review-ui render --pr $pr_number --out forced --surface /hosgeldin:auth --flag phoenix-welcome=on
+```
+
+Both fences hold, so neither can quietly hand you the default pixels. A forced run must name
+`:auth` on every surface — the preview honors the override only for an authorized platform-admin
+actor — and each forced key is proved against the preview's own evaluation before a shot is
+recorded, so an override that got dropped is `11`, never a flag-off capture under the flag-on name.
+Those two `10`/`11` refusals are the whole grammar; the rest is the verb's section.
+
+The credentials are the operator's, not yours (see below), and one more grant rides with them:
+platform admin on that throwaway preview D1, minted offline. Without it a `--flag` run refuses on
+`11` and the honest route is `review-ui note` — the same answer as any other credential you were
+not handed.
+
+**What still owes disclosure is a state you could not render.** Seeded data absent, a state with no
+mechanism, a preview you hold no credentials for: name each one in the verdict, with why, and judge
+what did paint. When nothing the PR adds painted, that is CANT-SEE, on the same terms as an
+every-surface-unreachable render. ADR
+[0336](../../../../.decisions/0336-review-ui-renders-flag-gated-states.md) ruled the override in and
+its own interim rider out: a flag-off state is now a state you render, not one you disclose.
 
 **Two eyes, one record:** when this session's tool surface carries the `claude-in-chrome` tools you
 may additionally inspect the preview live — navigate, probe states, look closer. Detection is tool
@@ -204,7 +223,7 @@ are simply no row. `surface` refusing on `11` is UNKNOWN coverage, never a clean
 
 ```bash
 fabrika review-ui post $pr_number --polarity FAIL --sha 03135b91 --clause "changes-requested" --evidence judged <<'EOF'
-…per-row table with pixel evidence, coverage table (judged / unreachable+disclosed / captured-but-not-the-PR's-state, each with why), advisories…
+…per-row table with pixel evidence, coverage table (judged / unreachable+disclosed / could-not-render, each with why), advisories…
 EOF
 ```
 

--- a/claude-plugins/fabrika/skills/review-ui/contract.md
+++ b/claude-plugins/fabrika/skills/review-ui/contract.md
@@ -208,6 +208,13 @@ Per the tandem ruling (both briefs, 2026-08-09), declared identically to `build-
   request refuses `11` rather than substituting the anonymous render; with no `:auth` surface asked
   for, every surface renders anonymously as before. Setting both is necessary and not sufficient —
   whether the cookie authenticated is the per-shot session proof's answer, also an `11`.
+- **`--flag` needs those same two values plus one grant on the preview D1.** The override cookie is
+  honored only for a platform admin (`flagship/override-authz.ts`, unchanged by #7218), and
+  `preview-seed test-account` provisions moderation authority, not admin. So a forced run is
+  preceded by `node packages/admin-grant/src/bin.ts grant --user-id preview-test-moderator
+  --database-id <preview-d1>` — offline and direct-D1, on a throwaway preview only, never against a
+  database holding real accounts. The grant is what makes the forced capture an admin's view as well
+  as a moderator's, which is the trade the operand asks for and the reason it is not the default.
 
 **The preview-deploy convention.** The repo announces each PR's preview as a sticky PR comment
 carrying the anchor `<!-- preview-deploy:<app> -->`, whose body names, per app: the deployed URL
@@ -227,7 +234,7 @@ anchor at all is the proven `16`.
 **Invocation**
 
 ```
-fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/yeni [--app web] [--repo <owner/name>]
+fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/yeni [--flag <key>=<on|off>] [--app web] [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -237,6 +244,7 @@ fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/
 | `--pr` | integer | yes | — | the pull request whose preview is judged |
 | `--out` | string | yes | — | kebab-case capture-set name; captures land under `<OS temp>/fabrika-review-ui/<pr>-<head8>/<set>/` |
 | `--surface` | string, repeatable | yes (≥1) | — | a surface id: a route (`/pano`), or a route plus a realized state (`/pano:auth`); zero operands is `1` — no tool guesses surfaces from a diff |
+| `--flag` | string, repeatable | no | every flag at its default | force one flag for this run: `<key>=on` or `<key>=off`; anything else, or a key forced twice, is `10` |
 | `--app` | string | no | the sole app in the preview comment; ambiguity refuses on `11` | which app's sub-line of the preview comment to resolve |
 | `--repo` | string | no | resolved | the repository |
 
@@ -252,6 +260,23 @@ From the same browser context, before the shot is classified, the verb reads the
 unreadable body — refuses the surface on `11` and records no capture. This is what makes the pixels a
 signed-in yazar+moderator's: a cookie that did not authenticate renders the visitor's page, and that
 page is a perfectly valid PNG no byte check can tell from the real one.
+
+**`--flag` forces a dark-shipped flag on, so the state the PR adds paints** (ADR 0336, #7218). It
+rides the worker's existing `phoenix_flag_overrides` cookie — no route is added and
+`flagship/override-authz.ts` is untouched — and that gate is why the operand carries a fence of its
+own: on a deployed stage the cookie is honored only for a request whose actor holds platform
+`Admin`, so an anonymous surface would drop it and render the default state cleanly under the
+forced name. Every `--surface` in a forced run must therefore name `:auth`, and a bare route beside
+a `--flag` is `10`. The preview test account holds moderation authority, not admin, so a forced run
+also needs `admin-grant grant --user-id preview-test-moderator --database-id <preview-d1>` against
+that throwaway preview D1 — offline, direct-D1, the same sanctioned path ADR 0107 already names.
+
+Seeding an override is not the same as the override taking, so — like the session — the shot proves
+it. From the same context, before the shot is classified, the verb POSTs the preview's own
+`/api/flags/evaluate` asking each forced key with the **opposite** value as its default: a dropped
+cookie answers `!forced` for every key, which is `11` naming the inert keys. A key the probe leaves
+unevaluated, or a probe that cannot be read, is `11` too and is never folded into "the override was
+dropped" — that would be a fact about the override read off a probe nobody could read.
 
 The refusal on every other token is the same fence v1 stated, kept for the same reason: v1 demanded
 `:focus-visible` captures with no mechanism to prove the state was realized, and a state that
@@ -301,8 +326,8 @@ re-invocation without it, on the record; never the tool's tolerance.
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed |
-| `10` | `--out` not kebab-case, or a `--surface` names a `:state` outside the realized set (`auth`) |
-| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; an `:auth` surface was requested while `PREVIEW_TEST_SESSION_TOKEN` / `BETTER_AUTH_SECRET` is unset; or an `:auth` surface's session proof did not come back signed in |
+| `10` | `--out` not kebab-case; a `--surface` names a `:state` outside the realized set (`auth`); a `--flag` operand is not a `<key>=<on\|off>` pair, or forces one key twice; or `--flag` was passed beside an anonymous surface |
+| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; an `:auth` surface was requested while `PREVIEW_TEST_SESSION_TOKEN` / `BETTER_AUTH_SECRET` is unset; an `:auth` surface's session proof did not come back signed in; or a forced flag evaluated at its default anyway |
 | `12` | proven: the preview comment's deployed SHA is not the PR's live head — stale preview; re-render after the preview catches up |
 | `13` | proven: at least one surface threw an uncaught page error |
 | `14` | proven: at least one surface is unreachable (status ≥ 400, failed navigation, no route, dark flag, gated tier) |
@@ -318,6 +343,9 @@ re-invocation without it, on the record; never the tool's tolerance.
 | `review-ui render: --surface "<id>" names a :state nothing renders — the realized states are auth; render the bare route.` | 10 | refusal |
 | `review-ui render: an :auth surface was requested but its credentials are incomplete (unset: <names>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
 | `review-ui render: surface "<id>" did not render signed in (<reason>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
+| `review-ui render: --flag "<token>" is not a <key>=<on\|off> pair (<reason>) — an operand nothing can force would shoot the default state under the forced name.` | 10 | refusal |
+| `review-ui render: --flag was passed with the anonymous surface "<id>" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name every surface :auth.` | 10 | refusal |
+| `review-ui render: surface "<id>" did not render with its forced flags (<reason>) — the forced render is UNKNOWN, never the default one.` | 11 | refusal |
 | `review-ui render: --out "<value>" is not a kebab-case set name.` | 10 | refusal |
 | `review-ui render: cannot read <what> for #<n>: <reason> — the render is UNKNOWN.` | 11 | refusal |
 | `review-ui render: the preview comment names apps <list> — pass --app to pick one.` | 11 | refusal |
@@ -347,6 +375,19 @@ $ echo $?
 14
 ```
 
+```
+$ fabrika review-ui render --pr 4321 --out forced --surface /hosgeldin:auth --flag phoenix-welcome=on
+review-ui render: surface "/hosgeldin:auth" captured: 1280x1640, 0 page errors
+{"set":"forced","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/hosgeldin:auth","path":"/tmp/fabrika-review-ui/4321-03135b91/forced/hosgeldin-auth.png","width":1280,"height":1640,"sha256":"1f7b…","pageErrors":{"rows":[],"more":0}}]}
+```
+
+```
+$ fabrika review-ui render --pr 4321 --out forced --surface /hosgeldin --flag phoenix-welcome=on
+review-ui render: --flag was passed with the anonymous surface "/hosgeldin" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name every surface :auth.
+$ echo $?
+10
+```
+
 **Grounding**
 
 - #3925 / v1 S1–S2 — v1's capture invocation carried no status assertion and no capture-count
@@ -363,6 +404,9 @@ $ echo $?
   never a silent skip; the disclosure fork (Deviations-named vs undisclosed) is the skill's.
 - v1 S4 — v1's captures lived in an unrecorded `mktemp -d`: a PASS whose evidence upload failed
   was unauditable. The set path here is deterministic from PR + head, and the manifest records it.
+- #6541 / ADR 0336 — the verb captured every flag at its default, so under the dark-ship norm the
+  gate judged the off-path and said PASS. `--flag` is that ruling's implementation (#7218), and its
+  own proof exists because an override the preview dropped is the same clean-but-wrong capture.
 
 ---
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -887,7 +887,7 @@ Judge a UI pull request over its preview deployment. Contract:
 
 | Verb | Answers |
 |---|---|
-| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized state (`/pano:auth` renders signed in as the test moderator, refusing on `11` unless the session proves it took) |
+| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized state (`/pano:auth` renders signed in as the test moderator, refusing on `11` unless the session proves it took). `--flag <key>=<on\|off>` forces a dark-shipped flag for the run, refusing on `10` unless every surface is `:auth` and on `11` unless the preview's own evaluation says the key took |
 | `review-ui post` | the `review-ui` verdict on stdin, posted as one comment |
 | `review-ui note` | a typed blocker note when the surfaces cannot be seen |
 | `review-ui route` | a head-bound `routed-elsewhere` record: this PR renders nothing, so no verdict is owed |

--- a/packages/fabrika-cli/src/capture/capture.ts
+++ b/packages/fabrika-cli/src/capture/capture.ts
@@ -16,6 +16,12 @@ import {type BrowserContext, chromium} from "@playwright/test";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {readSessionProof, type SessionProof} from "./auth.ts";
+import {
+	type ForcedFlags,
+	flagProbeBody,
+	type OverrideProof,
+	readOverrideProof,
+} from "./flag-override.ts";
 import {type PageError, toPageError} from "./page-errors.ts";
 import type {Shot} from "./plan.ts";
 
@@ -45,6 +51,12 @@ export interface CapturedSurface {
 	 * visitor's page, which is a valid PNG under the signed-in name (#7051).
 	 */
 	readonly sessionProof?: SessionProof;
+	/**
+	 * Whether the forced flags took, present only when the caller forced any. Pixels cannot answer
+	 * it either: an unhonored override renders the flag-off page, a valid PNG under the flag-on
+	 * name (#7218).
+	 */
+	readonly overrideProof?: OverrideProof;
 }
 
 /** A Playwright launch/navigation/screenshot/write failure — surfaced, never swallowed. */
@@ -74,9 +86,9 @@ export interface CaptureOptions {
 	/** Full-page screenshot (default) vs. above-the-fold only. */
 	readonly fullPage?: boolean;
 	/**
-	 * Cookies seeded into every shot's browser context before navigation — how the
-	 * local render harness honors the `phoenix_flag_overrides` dev-override cookie so
-	 * flag-gated surfaces render under `alchemy dev` (#2963). Absent ⇒ no cookies.
+	 * Cookies seeded into every shot's browser context before navigation — the session cookie an
+	 * `:auth` shot presents (`auth.ts`) and the `phoenix_flag_overrides` cookie a forced shot
+	 * carries (`flag-override.ts`, #2963/#7218). Absent ⇒ no cookies.
 	 */
 	readonly cookies?: readonly CaptureCookie[];
 	/**
@@ -84,6 +96,12 @@ export interface CaptureOptions {
 	 * and before it navigates. Absent ⇒ no proof is taken and `sessionProof` stays absent.
 	 */
 	readonly sessionProbeUrl?: string;
+	/**
+	 * The flag-evaluation probe to run from each shot's context once the cookies are seeded — the
+	 * URL to ask, and the flags whose forced values the answer is checked against. Absent ⇒ no proof
+	 * is taken and `overrideProof` stays absent.
+	 */
+	readonly flagProbe?: {readonly url: string; readonly flags: ForcedFlags};
 }
 
 /**
@@ -102,6 +120,30 @@ const proveSession = (context: BrowserContext, probeUrl: string): Promise<Sessio
 			(cause): SessionProof => ({
 				_tag: "Unreadable",
 				reason: `session probe failed: ${String(cause)}`,
+			}),
+		);
+
+/**
+ * Ask the preview what the forced flags evaluated to for this context. Same context, same cookie
+ * jar, and total on the same terms as {@link proveSession}: a rejected probe is a fact about the
+ * probe, and letting it throw would accuse the page of being unreachable.
+ */
+const proveOverride = (
+	context: BrowserContext,
+	probe: {readonly url: string; readonly flags: ForcedFlags},
+): Promise<OverrideProof> =>
+	context.request
+		.post(probe.url, {
+			headers: {"content-type": "application/json"},
+			data: flagProbeBody(probe.flags),
+		})
+		.then(async (response) =>
+			readOverrideProof(response.status(), await response.text(), probe.flags),
+		)
+		.catch(
+			(cause): OverrideProof => ({
+				_tag: "Unreadable",
+				reason: `flag probe failed: ${String(cause)}`,
 			}),
 		);
 
@@ -150,6 +192,10 @@ export const captureShots = (
 								options.sessionProbeUrl === undefined
 									? undefined
 									: await proveSession(context, options.sessionProbeUrl);
+							const overrideProof =
+								options.flagProbe === undefined
+									? undefined
+									: await proveOverride(context, options.flagProbe);
 							const page = await context.newPage();
 							// Listen across the WHOLE navigation window (attached before goto), so a
 							// runtime error thrown during mount/init is caught even when the frame
@@ -186,6 +232,7 @@ export const captureShots = (
 									pageErrors,
 									...(response === null ? {} : {status: response.status()}),
 									...(sessionProof === undefined ? {} : {sessionProof}),
+									...(overrideProof === undefined ? {} : {overrideProof}),
 								};
 							} finally {
 								await context.close();

--- a/packages/fabrika-cli/src/capture/flag-override.ts
+++ b/packages/fabrika-cli/src/capture/flag-override.ts
@@ -1,0 +1,160 @@
+/**
+ * Force a flag for a capture, so a dark-shipped surface paints the state the PR actually adds
+ * (#7218, ADR 0336). Pure — no browser, no network; `capture.ts` seeds the cookie this builds and
+ * hands the probe's raw answer back to {@link readOverrideProof}.
+ *
+ * The mechanism is the worker's existing `phoenix_flag_overrides` cookie and nothing new. The wire
+ * value is `encodeURIComponent(JSON.stringify({key: boolean}))`, which is exactly what
+ * `apps/web/worker/features/flagship/dev-override.ts`'s `parseOverrideCookie` reads back, and the
+ * gate that decides whether to honor it (`override-authz.ts`) is untouched: on a deployed stage it
+ * answers `true` only for a request whose actor holds platform `Admin`. So a forced capture is an
+ * authorized admin's capture or it is nothing.
+ *
+ * "Or it is nothing" is why the proof exists. A dropped cookie renders the flag-off page cleanly,
+ * which is a valid PNG under the flag-on name — the #7051 class one layer over, and no byte check
+ * can tell the two apart.
+ */
+import type {CaptureCookie} from "./capture.ts";
+
+export const FLAG_OVERRIDE_COOKIE = "phoenix_flag_overrides";
+
+/** The flags a capture forces, and the value each is forced to. */
+export type ForcedFlags = Readonly<Record<string, boolean>>;
+
+export const NO_FORCED_FLAGS: ForcedFlags = {};
+
+export const isForcing = (flags: ForcedFlags): boolean => Object.keys(flags).length > 0;
+
+/** The closed value vocabulary. `true`/`1`/`yes` are refused rather than guessed at. */
+export const FORCED_VALUES = ["on", "off"] as const;
+
+/**
+ * Two arms, never a tolerant one: an operand this cannot read is refused before a browser launches,
+ * because the alternative is a run that renders the default state under the forced name.
+ */
+export type FlagOperandRead =
+	| {readonly _tag: "Forced"; readonly flags: ForcedFlags}
+	| {readonly _tag: "Malformed"; readonly token: string; readonly reason: string};
+
+/**
+ * Bounded before the shape test so the linear scan below stays linear on any input, the same
+ * clamp-then-match discipline `plan.ts`'s file-name sanitizer states (CodeQL alert #24).
+ */
+const MAX_KEY_LENGTH = 128;
+
+/** A single greedy quantifier over a negated-free class — linear, no backtracking. */
+const KEY_SHAPE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export const parseFlagOperands = (tokens: readonly string[]): FlagOperandRead => {
+	const flags: Record<string, boolean> = {};
+	for (const token of tokens) {
+		const equals = token.indexOf("=");
+		if (equals === -1) {
+			return {_tag: "Malformed", token, reason: "no = separating the key from its value"};
+		}
+		const key = token.slice(0, equals);
+		const value = token.slice(equals + 1);
+		if (key.length > MAX_KEY_LENGTH) {
+			return {_tag: "Malformed", token, reason: `the key exceeds ${MAX_KEY_LENGTH} characters`};
+		}
+		if (!KEY_SHAPE.test(key)) {
+			return {_tag: "Malformed", token, reason: `"${key}" is not a flag key`};
+		}
+		if (value !== "on" && value !== "off") {
+			return {
+				_tag: "Malformed",
+				token,
+				reason: `"${value}" is not ${FORCED_VALUES.join(" or ")}`,
+			};
+		}
+		// Last-wins would resolve two operands for one key into a state the caller never asked for,
+		// and the losing one would never be reported.
+		if (Object.hasOwn(flags, key)) {
+			return {_tag: "Malformed", token, reason: `"${key}" is forced more than once`};
+		}
+		flags[key] = value === "on";
+	}
+	return {_tag: "Forced", flags};
+};
+
+/**
+ * The override cookie for a preview base URL, or nothing when no flag is forced.
+ *
+ * It carries no `expires` and no `max-age`, so it is a session cookie in the throwaway browser
+ * context `capture.ts` opens and closes around each shot: the override's whole lifetime is that
+ * context's, and the server records none of it — the cookie is read per request and never stored.
+ */
+export const overrideCookies = (
+	previewUrl: string,
+	flags: ForcedFlags,
+): readonly CaptureCookie[] => {
+	if (!isForcing(flags)) return [];
+	return [
+		{
+			name: FLAG_OVERRIDE_COOKIE,
+			value: encodeURIComponent(JSON.stringify(flags)),
+			url: previewUrl,
+			secure: new URL(previewUrl).protocol === "https:",
+		},
+	];
+};
+
+/**
+ * The preview endpoint that answers what a flag evaluated to for THIS context — the same seam the
+ * SPA reads through, so its answer is the one the pixels were painted from
+ * (`apps/web/worker/features/flagship/route.ts`, ADR 0179 AC2).
+ */
+export const FLAG_PROBE_PATH = "/api/flags/evaluate";
+
+/**
+ * The probe body: every forced key asked for with the **opposite** value as its default. The route
+ * resolves a key it cannot evaluate to the default it was asked with
+ * (`flagship/evaluate-contract.ts`), so a dropped cookie answers `!forced` for every key and the
+ * inertness is decidable from the body rather than inferred from a picture.
+ */
+export const flagProbeBody = (flags: ForcedFlags): string =>
+	JSON.stringify({
+		keys: Object.entries(flags).map(([key, forced]) => ({key, default: !forced})),
+	});
+
+/**
+ * Whether the forced flags actually took, decided from the preview's own answer.
+ *
+ * Three arms, not two: a probe that could not be read is UNKNOWN and must not collapse into
+ * "the override was dropped" — both refuse, but only one is a fact about the override.
+ */
+export type OverrideProof =
+	| {readonly _tag: "Forced"}
+	| {readonly _tag: "Inert"; readonly keys: readonly string[]}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+export const readOverrideProof = (
+	status: number,
+	body: string,
+	flags: ForcedFlags,
+): OverrideProof => {
+	if (status !== 200) return {_tag: "Unreadable", reason: `probe answered ${status}`};
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return {_tag: "Unreadable", reason: "probe body is not JSON"};
+	}
+	if (typeof parsed !== "object" || parsed === null) {
+		return {_tag: "Unreadable", reason: "probe body is not an evaluation object"};
+	}
+	const evaluated = (parsed as {flags?: unknown}).flags;
+	if (typeof evaluated !== "object" || evaluated === null) {
+		return {_tag: "Unreadable", reason: "probe body names no flags"};
+	}
+	const answers = evaluated as Record<string, unknown>;
+	const inert: string[] = [];
+	for (const [key, forced] of Object.entries(flags)) {
+		const value = answers[key];
+		if (typeof value !== "boolean") {
+			return {_tag: "Unreadable", reason: `probe left "${key}" unevaluated`};
+		}
+		if (value !== forced) inert.push(key);
+	}
+	return inert.length === 0 ? {_tag: "Forced"} : {_tag: "Inert", keys: inert};
+};

--- a/packages/fabrika-cli/src/capture/flag-override.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/flag-override.unit.test.ts
@@ -1,0 +1,144 @@
+import {describe, expect, it} from "vitest";
+import {
+	FLAG_OVERRIDE_COOKIE,
+	flagProbeBody,
+	NO_FORCED_FLAGS,
+	overrideCookies,
+	parseFlagOperands,
+	readOverrideProof,
+} from "./flag-override.ts";
+
+const PREVIEW = "https://pr-4321-web.example.test";
+
+describe("parseFlagOperands", () => {
+	it("reads a <key>=<on|off> pair into the value the preview is asked to force", () => {
+		expect(parseFlagOperands(["phoenix-welcome=on", "phoenix-flags-probe=off"])).toEqual({
+			_tag: "Forced",
+			flags: {"phoenix-welcome": true, "phoenix-flags-probe": false},
+		});
+	});
+
+	it("reads no operands as forcing nothing, which is the ordinary anonymous-default run", () => {
+		expect(parseFlagOperands([])).toEqual({_tag: "Forced", flags: {}});
+	});
+
+	it.each([
+		["phoenix-welcome", "no = separating the key from its value"],
+		["=on", '"" is not a flag key'],
+		["-phoenix=on", '"-phoenix" is not a flag key'],
+		["phoenix welcome=on", '"phoenix welcome" is not a flag key'],
+		["phoenix;welcome=on", '"phoenix;welcome" is not a flag key'],
+	])("refuses %s rather than guessing at it", (token, reason) => {
+		expect(parseFlagOperands([token])).toEqual({_tag: "Malformed", token, reason});
+	});
+
+	it.each([
+		"true",
+		"1",
+		"yes",
+		"ON",
+		"",
+	])("refuses %s as a value — the vocabulary is on|off and nothing else", (value) => {
+		expect(parseFlagOperands([`phoenix-welcome=${value}`])).toEqual({
+			_tag: "Malformed",
+			token: `phoenix-welcome=${value}`,
+			reason: `"${value}" is not on or off`,
+		});
+	});
+
+	it("refuses a key forced twice — last-wins would drop an operand nobody hears about", () => {
+		expect(parseFlagOperands(["phoenix-welcome=on", "phoenix-welcome=off"])).toEqual({
+			_tag: "Malformed",
+			token: "phoenix-welcome=off",
+			reason: '"phoenix-welcome" is forced more than once',
+		});
+	});
+
+	it("refuses an unbounded key rather than matching over it", () => {
+		const token = `${"a".repeat(129)}=on`;
+		expect(parseFlagOperands([token])).toMatchObject({_tag: "Malformed", token});
+	});
+
+	it("keeps a value's = intact, so only the first = splits the pair", () => {
+		expect(parseFlagOperands(["a=b=on"])).toMatchObject({
+			_tag: "Malformed",
+			reason: '"b=on" is not on or off',
+		});
+	});
+});
+
+describe("overrideCookies", () => {
+	it("writes the worker's wire value, which parseOverrideCookie reads back verbatim", () => {
+		const [cookie] = overrideCookies(PREVIEW, {"phoenix-welcome": true});
+		expect(cookie).toEqual({
+			name: FLAG_OVERRIDE_COOKIE,
+			value: encodeURIComponent(JSON.stringify({"phoenix-welcome": true})),
+			url: PREVIEW,
+			secure: true,
+		});
+		expect(JSON.parse(decodeURIComponent(cookie?.value ?? ""))).toEqual({
+			"phoenix-welcome": true,
+		});
+	});
+
+	/**
+	 * The scoping mechanism, asserted rather than described: no `expires` and no `max-age` makes it a
+	 * session cookie in the throwaway context `capture.ts` closes around each shot, and the server
+	 * stores nothing — so the override cannot outlive the gate run.
+	 */
+	it("carries no expiry, so its whole lifetime is the capture context's", () => {
+		const [cookie] = overrideCookies(PREVIEW, {"phoenix-welcome": true});
+		expect(Object.keys(cookie ?? {}).sort()).toEqual(["name", "secure", "url", "value"]);
+	});
+
+	it("drops the secure attribute for an http preview, which Playwright would reject with it", () => {
+		expect(overrideCookies("http://localhost:8787", {a: true})[0]?.secure).toBe(false);
+	});
+
+	it("seeds nothing when nothing is forced", () => {
+		expect(overrideCookies(PREVIEW, NO_FORCED_FLAGS)).toEqual([]);
+	});
+});
+
+describe("flagProbeBody", () => {
+	/**
+	 * The opposite value is the whole trick: the evaluate route resolves a key it cannot answer to
+	 * the default it was asked with, so a dropped cookie comes back `!forced` for every key.
+	 */
+	it("asks each forced key with the opposite value as its default", () => {
+		expect(JSON.parse(flagProbeBody({a: true, b: false}))).toEqual({
+			keys: [
+				{key: "a", default: false},
+				{key: "b", default: true},
+			],
+		});
+	});
+});
+
+describe("readOverrideProof", () => {
+	const forced = {"phoenix-welcome": true};
+	const body = (flags: Record<string, unknown>) => JSON.stringify({flags});
+
+	it("answers Forced when every key came back at the value it was forced to", () => {
+		expect(readOverrideProof(200, body({"phoenix-welcome": true}), forced)).toEqual({
+			_tag: "Forced",
+		});
+	});
+
+	it("names every inert key, not just the first — the caller acts on the whole list", () => {
+		expect(
+			readOverrideProof(200, body({a: false, b: true, c: false}), {a: true, b: true, c: true}),
+		).toEqual({_tag: "Inert", keys: ["a", "c"]});
+	});
+
+	it.each([
+		[500, body({"phoenix-welcome": true}), "probe answered 500"],
+		[200, "not json", "probe body is not JSON"],
+		[200, "null", "probe body is not an evaluation object"],
+		[200, JSON.stringify({}), "probe body names no flags"],
+		[200, body({}), 'probe left "phoenix-welcome" unevaluated'],
+		[200, body({"phoenix-welcome": "on"}), 'probe left "phoenix-welcome" unevaluated'],
+	])("keeps an unreadable probe UNKNOWN rather than folding it into Inert", (status, raw, reason) => {
+		expect(readOverrideProof(status, raw, forced)).toEqual({_tag: "Unreadable", reason});
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -58,6 +58,13 @@ const render = leafCommand(
 				"a surface id to capture — a route such as /pano, or /pano:auth for the signed-in render (proved against the preview's session endpoint before the shot is recorded); repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
 			),
 		),
+		// `atLeast(0)` is the repeatable form with no floor: forcing nothing is the ordinary run.
+		flag: Flag.string("flag").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"force one flag for this run — <key>=on|off, repeatable; rides the preview's phoenix_flag_overrides cookie, which is honored only for an authorized platform-admin actor, so every --surface must name :auth and each forced key is proved against the preview's own evaluation before the shot is recorded",
+			),
+		),
 		app: Flag.string("app").pipe(
 			Flag.optional,
 			Flag.withDescription(
@@ -66,12 +73,13 @@ const render = leafCommand(
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({pr, out, surface, app, repo}) {
+	Effect.fn(function* ({pr, out, surface, flag, app, repo}) {
 		yield* emit(
 			yield* runRender({
 				pr,
 				out,
 				surfaces: surface,
+				flags: flag,
 				app: Option.getOrNull(app),
 				repo: Option.getOrNull(repo),
 				env: process.env,
@@ -83,7 +91,7 @@ const render = leafCommand(
 ).pipe(
 	Command.withShortDescription("Capture the named surfaces from a PR's preview deployment."),
 	Command.withDescription(
-		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface names a :state nothing renders — the realized set is auth), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, an :auth surface was requested with PREVIEW_TEST_SESSION_TOKEN/BETTER_AUTH_SECRET unset, or an :auth surface's session proof did not come back signed in), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
+		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, a --surface names a :state nothing renders — the realized set is auth, a --flag operand is not a <key>=<on|off> pair, or --flag was passed with an anonymous surface), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, an :auth surface was requested with PREVIEW_TEST_SESSION_TOKEN/BETTER_AUTH_SECRET unset, an :auth surface's session proof did not come back signed in, or a forced flag evaluated at its default anyway), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
 	),
 );
 

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -15,6 +15,7 @@
 import {Effect} from "effect";
 import {SESSION_PROBE_PATH} from "../capture/auth.ts";
 import {captureShots} from "../capture/capture.ts";
+import {FLAG_PROBE_PATH, isForcing} from "../capture/flag-override.ts";
 import {isRenderCrash} from "../capture/page-errors.ts";
 import {
 	buildCapturePlan,
@@ -69,10 +70,21 @@ export const makeCaptureRenderLeg =
 			// A seeded session is asked to prove itself, because pixels cannot: a cookie that does not
 			// authenticate renders the visitor's page, and that is a valid PNG under the `:auth` name.
 			const probing = provesSession(plan[0]?.surface.state ?? null);
+			// Same reason one layer over: an override the preview dropped renders the flag-off page,
+			// and that page is a valid PNG under the flag-on name.
+			const forcing = isForcing(request.forcedFlags);
 			const captured = yield* capture(plan, request.outDir, {
 				cookies: request.cookies,
 				...(probing
 					? {sessionProbeUrl: joinPreviewUrl(request.previewUrl, SESSION_PROBE_PATH)}
+					: {}),
+				...(forcing
+					? {
+							flagProbe: {
+								url: joinPreviewUrl(request.previewUrl, FLAG_PROBE_PATH),
+								flags: request.forcedFlags,
+							},
+						}
 					: {}),
 			}).pipe(Effect.catch((error) => Effect.succeed(error.message)));
 			if (typeof captured === "string") {
@@ -102,6 +114,20 @@ export const makeCaptureRenderLeg =
 								? "the capture returned no session proof"
 								: proof._tag === "Anonymous"
 									? "the preview answered the seeded cookie as a visitor"
+									: proof.reason,
+					} satisfies SurfaceRender;
+				}
+			}
+			if (forcing) {
+				const proof = shot.overrideProof;
+				if (proof === undefined || proof._tag !== "Forced") {
+					return {
+						_tag: "OverrideInert",
+						reason:
+							proof === undefined
+								? "the capture returned no override proof"
+								: proof._tag === "Inert"
+									? `the preview evaluated ${proof.keys.join(", ")} at the default`
 									: proof.reason,
 					} satisfies SurfaceRender;
 				}

--- a/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
@@ -1,13 +1,20 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {type CapturedSurface, CaptureError} from "../capture/capture.ts";
+import {NO_FORCED_FLAGS} from "../capture/flag-override.ts";
 import {PAGE_ERROR_CAP} from "./manifest.ts";
 import {type CaptureShots, makeCaptureRenderLeg} from "./render-leg.ts";
 import type {SurfaceRender} from "./render-verb.ts";
 
 const PREVIEW = "https://pr-4321-web.example.test";
 
-const request = {surface: "/pano", previewUrl: PREVIEW, outDir: "/tmp/shots", cookies: []};
+const request = {
+	surface: "/pano",
+	previewUrl: PREVIEW,
+	outDir: "/tmp/shots",
+	cookies: [],
+	forcedFlags: NO_FORCED_FLAGS,
+};
 
 const failing =
 	(message: string): CaptureShots =>
@@ -151,5 +158,68 @@ describe("captureRenderLeg — the :auth session proof", () => {
 			runAuth(authShot({sessionProof: {_tag: "Unreadable", reason: "probe answered 502"}})),
 		).toEqual({_tag: "Unauthenticated", reason: "probe answered 502"});
 		expect(runAuth(authShot({}))._tag).toBe("Unauthenticated");
+	});
+});
+
+/**
+ * One layer over the session proof and for the same reason: a preview that dropped the override
+ * cookie renders the flag-off page, and that page is a valid PNG under the flag-on name (#7218).
+ */
+describe("captureRenderLeg — the forced-flag proof", () => {
+	const FORCED = {"phoenix-welcome": true};
+	const forcedRequest = {...authRequest, forcedFlags: FORCED};
+	const runForced = (capture: CaptureShots): SurfaceRender =>
+		Effect.runSync(makeCaptureRenderLeg(capture)(forcedRequest));
+	const signedIn = {_tag: "SignedIn", userId: "u1"} as const;
+
+	it("asks the preview's own evaluation seam, and asks nothing when no flag is forced", () => {
+		const asked: Array<unknown> = [];
+		const spy: CaptureShots = (_plan, _outDir, options) => {
+			asked.push(options?.flagProbe);
+			return authShot({sessionProof: signedIn, overrideProof: {_tag: "Forced"}})([], "", {});
+		};
+		runForced(spy);
+		runAuth(spy);
+		expect(asked[0]).toEqual({url: `${PREVIEW}/api/flags/evaluate`, flags: FORCED});
+		expect(asked[1]).toBeUndefined();
+	});
+
+	it("records the shot only when every forced key came back forced", () => {
+		expect(
+			runForced(authShot({sessionProof: signedIn, overrideProof: {_tag: "Forced"}}))._tag,
+		).toBe("Rendered");
+	});
+
+	it("refuses a default-state render under the forced name, naming the inert keys", () => {
+		expect(
+			runForced(
+				authShot({
+					sessionProof: signedIn,
+					overrideProof: {_tag: "Inert", keys: ["phoenix-welcome"]},
+				}),
+			),
+		).toEqual({
+			_tag: "OverrideInert",
+			reason: "the preview evaluated phoenix-welcome at the default",
+		});
+	});
+
+	it("refuses an unreadable probe and an absent one — neither is a proof", () => {
+		expect(
+			runForced(
+				authShot({
+					sessionProof: signedIn,
+					overrideProof: {_tag: "Unreadable", reason: "probe answered 502"},
+				}),
+			),
+		).toEqual({_tag: "OverrideInert", reason: "probe answered 502"});
+		expect(runForced(authShot({sessionProof: signedIn}))._tag).toBe("OverrideInert");
+	});
+
+	it("keeps the session refusal ahead of the override one — a visitor's page proves no flag", () => {
+		expect(
+			runForced(authShot({sessionProof: {_tag: "Anonymous"}, overrideProof: {_tag: "Forced"}}))
+				._tag,
+		).toBe("Unauthenticated");
 	});
 });

--- a/packages/fabrika-cli/src/review-ui/render-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.ts
@@ -18,11 +18,24 @@
  * before a browser launches when the credentials are incomplete, and on `11` again when the shot's
  * own session proof does not come back signed in — a cookie that failed to authenticate produces a
  * perfectly valid PNG of the visitor's page, which no byte check can tell from the real thing.
+ *
+ * `--flag <key>=<on|off>` forces a dark-shipped flag for the run (ADR 0336, #7218), and it is
+ * refused twice over on the same shape: on `10` when an operand is unreadable or names an anonymous
+ * surface — the preview honors the override cookie only for an authorized platform-admin actor — and
+ * on `11` when the shot's own flag probe says the forced key evaluated at its default anyway.
  */
 import {Effect, type FileSystem, type Path, Result} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {readIdentity, sessionCookies} from "../capture/auth.ts";
 import type {CaptureCookie} from "../capture/capture.ts";
+import {
+	FORCED_VALUES,
+	type ForcedFlags,
+	isForcing,
+	NO_FORCED_FLAGS,
+	overrideCookies,
+	parseFlagOperands,
+} from "../capture/flag-override.ts";
 import {isRealizedState, provesSession, REALIZED_STATES, stateOf} from "../capture/states.ts";
 import {writeFile} from "../io/fs.ts";
 import {listComments} from "../io/issues.ts";
@@ -57,6 +70,11 @@ export interface SurfaceRenderRequest {
 	readonly outDir: string;
 	/** Seeded into the capture context before navigation. Empty ⇒ the anonymous render. */
 	readonly cookies: readonly CaptureCookie[];
+	/**
+	 * The flags {@link cookies}' override cookie forces, so the leg can ask the preview what they
+	 * evaluated to. Empty ⇒ nothing was forced and no proof is owed.
+	 */
+	readonly forcedFlags: ForcedFlags;
 }
 
 /**
@@ -70,6 +88,7 @@ export type SurfaceRender =
 	| {readonly _tag: "Crashed"; readonly firstError: string}
 	| {readonly _tag: "Invalid"; readonly detail: string}
 	| {readonly _tag: "Unauthenticated"; readonly reason: string}
+	| {readonly _tag: "OverrideInert"; readonly reason: string}
 	| {readonly _tag: "Failed"; readonly reason: string};
 
 export type RenderLeg = (request: SurfaceRenderRequest) => Effect.Effect<SurfaceRender>;
@@ -78,6 +97,8 @@ export interface RenderOptions {
 	readonly pr: number;
 	readonly out: string;
 	readonly surfaces: readonly string[];
+	/** Raw `--flag` operands, each a `<key>=<on|off>` pair. Empty ⇒ every flag at its default. */
+	readonly flags: readonly string[];
 	readonly app: string | null;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -126,6 +147,8 @@ const outcomeLine = (surface: string, render: SurfaceRender): string => {
 			return `${VERB}: surface "${surface}" captured invalid bytes (${render.detail}) — a capture nobody can open is not evidence (#3925's class).`;
 		case "Unauthenticated":
 			return `${VERB}: surface "${surface}" did not render signed in (${render.reason}) — the authenticated render is UNKNOWN, never the anonymous one.`;
+		case "OverrideInert":
+			return `${VERB}: surface "${surface}" did not render with its forced flags (${render.reason}) — the forced render is UNKNOWN, never the default one.`;
 		case "Failed":
 			return `${VERB}: surface "${surface}" could not be rendered: ${render.reason} — the outcome is UNKNOWN.`;
 	}
@@ -166,6 +189,29 @@ export const runRender = (
 				OFF_VOCABULARY,
 				`${VERB}: --surface "${unrealized}" names a :state nothing renders — the realized states are ${REALIZED_STATES.join(", ")}; render the bare route.`,
 			);
+		}
+
+		const operands = parseFlagOperands(options.flags);
+		if (operands._tag === "Malformed") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --flag "${operands.token}" is not a <key>=<${FORCED_VALUES.join("|")}> pair (${operands.reason}) — an operand nothing can force would shoot the default state under the forced name.`,
+			);
+		}
+		const forcedFlags = operands.flags;
+		// The override rides the `phoenix_flag_overrides` cookie, which a deployed stage honors only
+		// for a request whose actor holds platform Admin (`flagship/override-authz.ts`, untouched).
+		// So an anonymous surface cannot carry a forced flag at all — it would render the default
+		// state cleanly under the forced name, which is the coverage-claimed-and-not-held class this
+		// verb already refuses a stateless `:state` for (#7051, #7218).
+		if (isForcing(forcedFlags)) {
+			const anonymous = options.surfaces.find((surface) => !provesSession(stateOf(surface)));
+			if (anonymous !== undefined) {
+				return refuse(
+					OFF_VOCABULARY,
+					`${VERB}: --flag was passed with the anonymous surface "${anonymous}" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name every surface :auth.`,
+				);
+			}
 		}
 
 		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
@@ -236,18 +282,22 @@ export const runRender = (
 			identity._tag === "Identity"
 				? sessionCookies(announced.url, identity.token, identity.secret)
 				: [];
+		const forcedCookies = overrideCookies(announced.url, forcedFlags);
 
 		const setDir = setDirectory(options.tmpRoot, pr, head, options.out);
 		const renders: SurfaceRender[] = [];
 		for (const surface of options.surfaces) {
+			// Only the `:auth` variant carries the session and the override; a bare route stays the
+			// visitor's render at every flag's default, so the two are genuinely different pixels
+			// rather than one shot twice.
+			const authenticated = provesSession(stateOf(surface));
 			renders.push(
 				yield* options.render({
 					surface,
 					previewUrl: announced.url,
 					outDir: setDir,
-					// Only the `:auth` variant carries the session; a bare route stays the visitor's
-					// render, so the two are genuinely different pixels rather than one shot twice.
-					cookies: provesSession(stateOf(surface)) ? authCookies : [],
+					cookies: authenticated ? [...authCookies, ...forcedCookies] : [],
+					forcedFlags: authenticated ? forcedFlags : NO_FORCED_FLAGS,
 				}),
 			);
 		}
@@ -266,11 +316,14 @@ export const runRender = (
 		}
 		// Ahead of the proven-red codes below, and deliberately: the shot is a fine PNG of the wrong
 		// page, so routing it as a red surface would accuse the PR of a defect the render never saw.
-		const anonymous = renders.findIndex((render) => render._tag === "Unauthenticated");
-		if (anonymous !== -1) {
+		// The two arms are one class — wrong session, wrong flag state — and route alike.
+		const wrongPage = renders.findIndex(
+			(render) => render._tag === "Unauthenticated" || render._tag === "OverrideInert",
+		);
+		if (wrongPage !== -1) {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				outcomeLine(options.surfaces[anonymous] as string, renders[anonymous] as SurfaceRender),
+				outcomeLine(options.surfaces[wrongPage] as string, renders[wrongPage] as SurfaceRender),
 				enumerated,
 			);
 		}

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -68,6 +68,7 @@ const options = {
 	pr: 4321,
 	out: "judged",
 	surfaces: ["/pano"],
+	flags: [] as readonly string[],
 	app: null,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
@@ -218,6 +219,89 @@ describe("runRender", () => {
 			}),
 		});
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	// The operand's own refusals, decided before a browser launches. Both are `10`: an operand
+	// nothing can force and an operand the preview would silently drop are the same defect — the
+	// default state shot under the forced name (#7218).
+	it("refuses a malformed --flag operand on 10, naming the token and why", async () => {
+		const {outcome} = await run(happy(), {surfaces: ["/pano:auth"], flags: ["phoenix-welcome"]});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.join("\n")).toContain("no = separating the key from its value");
+		expect((await run(happy(), {surfaces: ["/pano:auth"], flags: ["a=true"]})).outcome.code).toBe(
+			OFF_VOCABULARY,
+		);
+	});
+
+	it("refuses --flag beside an anonymous surface on 10 — the preview would drop the cookie", async () => {
+		const {outcome} = await run(happy(), {
+			surfaces: ["/pano:auth", "/hosgeldin"],
+			flags: ["phoenix-welcome=on"],
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.join("\n")).toContain('anonymous surface "/hosgeldin"');
+	});
+
+	it("composes the override with the seeded session — one signed-in, flag-on shot", async () => {
+		const seen = new Map<string, {cookies: number; forced: Record<string, boolean>}>();
+		const {outcome} = await run(happy(), {
+			surfaces: ["/hosgeldin:auth"],
+			flags: ["phoenix-welcome=on"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: (request) => {
+				seen.set(request.surface, {
+					cookies: request.cookies.length,
+					forced: request.forcedFlags,
+				});
+				return Effect.succeed(rendered(request.surface, request.outDir));
+			},
+		});
+		expect(outcome.code).toBe(0);
+		// Two session cookies (prefixed and bare) plus the one override cookie.
+		expect(seen.get("/hosgeldin:auth")).toEqual({
+			cookies: 3,
+			forced: {"phoenix-welcome": true},
+		});
+	});
+
+	it("forces nothing when no --flag is passed, so the default run is untouched", async () => {
+		const seen: Array<Record<string, boolean>> = [];
+		const {outcome} = await run(happy(), {
+			render: (request) => {
+				seen.push(request.forcedFlags);
+				return Effect.succeed(rendered(request.surface, request.outDir));
+			},
+		});
+		expect(outcome.code).toBe(0);
+		expect(seen).toEqual([{}]);
+	});
+
+	// A fine PNG of the flag-off page is not a defect in the PR, so it routes UNKNOWN beside a red one.
+	it("refuses an inert override on 11, recording no capture", async () => {
+		const {outcome, written} = await run(happy(), {
+			surfaces: ["/hosgeldin:auth", "/b:auth"],
+			flags: ["phoenix-welcome=on"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: legOf({
+				"/hosgeldin:auth": {
+					_tag: "OverrideInert",
+					reason: "the preview evaluated phoenix-welcome at the default",
+				},
+				"/b:auth": {_tag: "Crashed", firstError: "TypeError: x is null"},
+			}),
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(written.size).toBe(0);
+		expect(outcome.stderr.at(-1)).toMatch(/did not render with its forced flags/);
 	});
 
 	it("refuses a closed PR on 7 — a closed PR is provably not reviewable scope", async () => {

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -84,6 +84,27 @@ cookie. Before it records the shot it asks the preview's own
 so a token that is wrong, expired or missing from this D1 refuses the render as
 UNKNOWN instead of filing the visitor's pixels under the `:auth` name.
 
+### Forcing a dark-shipped flag needs one more grant
+
+`review-ui render --flag <key>=on` forces a flag for the capture (issue #7218, ADR
+0336) through the worker's `phoenix_flag_overrides` cookie, and a deployed stage
+honors that cookie only for a request whose actor holds **platform admin** —
+`moderates` is a different relation. This account is provisioned with moderation
+authority and nothing more, deliberately: an ordinary `:auth` capture should show
+a plain yazar+moderator's view, not an admin's affordances.
+
+So the admin grant is a separate, opt-in step on the same throwaway preview D1,
+minted offline through the sanctioned path (ADR 0107 §4):
+
+```bash
+node packages/admin-grant/src/bin.ts grant \
+  --user-id preview-test-moderator --database-id <preview-d1-uuid>
+```
+
+The same guard boundary applies and is not relaxed by anything here: the target is
+a throwaway preview, `override-authz.ts` is untouched, and no worker route mints
+either the account or the grant.
+
 ### The guard boundary — load-bearing
 
 **Direct-D1, never a runtime route.** Same rule as `run` above and for the same


### PR DESCRIPTION
`fabrika review-ui render` captured every flag at its default, so under ADR 0083's dark-ship norm the gate judged the off-path and reported a PASS. This is the implementation ADR 0336 ruled in.

## What it does

`review-ui render --flag <key>=<on|off>` (repeatable) forces a flag for the run. It rides the worker's existing `phoenix_flag_overrides` cookie into the capture browser context — **no new route on the public worker, and `apps/web/worker/features/flagship/override-authz.ts` is not changed.**

Two fences, both refusals rather than tolerances, because a silently-dropped override renders the flag-off page cleanly and that PNG is indistinguishable from the real one:

- **`10`** — a `--flag` operand that is not a `<key>=<on|off>` pair, forces one key twice, or sits beside an anonymous surface. That last one is the load-bearing arm: a deployed stage honors the cookie only for a request whose actor holds platform `Admin`, so an anonymous surface would drop it. Every `--surface` in a forced run must name `:auth`.
- **`11`** — the shot's own proof. From the same browser context, before the shot is classified, the verb POSTs the preview's own `/api/flags/evaluate` asking each forced key with the **opposite** value as its default. A dropped cookie answers `!forced` for every key. A probe that could not be read stays `Unreadable` and never folds into "the override was dropped".

## The security posture

`overridesAuthorized` is untouched, so its verdict still derives only from the environment and the actor's stored platform-admin relation — an attacker-supplied cookie still cannot self-authorize on any deployed stage. I added coverage rather than code: the existing tests proved the invariant for `production` only, and `preview` is now a stage where somebody seeds this cookie on purpose, so `preview` and `audit` are proven too (non-admin denied, admin allowed, and the cookie dropped when the verdict is false).

The authority the run needs comes from the sanctioned offline path, not from a widened gate: `admin-grant grant --user-id preview-test-moderator --database-id <preview-d1>` on the throwaway preview D1 (ADR 0107 §4). It is opt-in, so an ordinary `:auth` capture stays a plain yazar+moderator's view — a forced capture shows admin affordances, which is the trade the operand buys.

**Scoping:** the override is a session cookie in the throwaway Playwright context `capture.ts` opens and closes around each shot. No `expires`, no `max-age`, and nothing stored server-side — the cookie is read per request. `flag-override.unit.test.ts` asserts the cookie's key set, so an expiry cannot be added without failing.

## What retires

ADR 0336's interim disclosure rider and the matching fork in `claude-plugins/fabrika/skills/review-ui/SKILL.md`. A flag-off state is now a state the gate renders, not one it names. What still owes disclosure is narrower: a state nothing here can put on screen. The amendment on `.decisions/0336-review-ui-renders-flag-gated-states.md` records what replaced them; the older #4305 unreachable-surface fork is untouched.

## Where to look first

`packages/fabrika-cli/src/capture/flag-override.ts` — the parse, the cookie codec and the proof, all pure. Then the two fences in `packages/fabrika-cli/src/review-ui/render-verb.ts`.

Fixes #7218

## Deviations

- **Known defect left unfixed** — **Said:** acceptance criterion 2 asks the override be proven by a capture whose pixels differ from the same surface captured without it. **Did:** proved the mechanism instead — the preview's own `/api/flags/evaluate` answer, checked per forced key, which is what decides whether a shot is recorded at all. No live two-run pixel comparison was performed. **Why:** the run needs a seeded preview D1, the preview worker's `BETTER_AUTH_SECRET` and an admin grant, none of which a build lane holds; #7224 is the adjacent live-preview proof for the `:auth` half and this half owes the same. **Disposition:** stated here; a follow-up for the live proof is filed.
- **Scope narrowing** — **Said:** criterion 1 asks the operand be threaded through `RenderOptions` **and** `SurfaceRenderRequest`. **Did:** `RenderOptions.flags` carries the raw operands; `SurfaceRenderRequest` carries `forcedFlags` plus the built cookie in its existing `cookies` field, rather than a second raw-operand field. **Why:** the cookie codec runs once in the verb, mirroring exactly how `sessionCookies` is built there for `:auth`; a raw operand on the per-surface seam would put the codec on both sides of it. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #7218 names the fabrika-cli surface and the retirement. **Did:** also added `preview`/`audit` cases to `apps/web/worker/features/flagship/override-authz.unit.test.ts`. **Why:** criterion 4 requires that gate stay fail-safe on **any** deployed stage, and the tests only covered `production`. No source file under `apps/web/worker/` changed. **Disposition:** stated here.
