### PR TITLE
fix: build repair refuses one-PR epics with multiple closing refs

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -454,7 +454,8 @@ build claim: subject: PR #<repair-pr> serves #<served-issue> (fixes|part-of) —
 Consume it as a cross-check against the two Ground operands already retained. If the line is absent,
 malformed, repeated, or names any other PR or issue, stop `STOPPED` before mutation; never guess an
 operand from a partial answer. The line proves which subject the claim admitted, not that the live PR
-body has one unique linkage — the two-subject `build tree` proof below still owns that stronger fact.
+body links the retained served issue — the two-subject `build tree` proof below still owns that
+membership fact over the live linkage set.
 
 **Step 1's refusal of a `type:decision` is about picking one up fresh, and it does not reach here.**
 An ADR PR is served by a decision issue, and repairing it is the ordinary path: the claim admits it
@@ -486,9 +487,10 @@ fabrika build tree --issue <served-issue> --repair <repair-pr>
 
 Proceed only on the documented JSON answer whose `claim.number` is `<repair-pr>` and whose
 `servedIssue.number` is `<served-issue>`; this is one verb proving that the resumed branch names the
-PR, carries that PR claim's nonce, and the live PR uniquely serves the issue. Do not parse any
-incidental diagnostic. Exit `4` means the unique linkage is malformed, `7` means the PR or issue is
-absent/closed, `10` means the repair PR lacked its issue operand, `11` means a claim/linkage read is
+PR, carries that PR claim's nonce, and the live PR's served-issue set contains the explicitly
+requested issue. Do not parse any incidental diagnostic. Exit `4` means the linkage is absent, `7`
+means the PR or issue is absent/closed, `10` means the repair PR lacked its issue operand, `11` means
+a claim/linkage read is
 UNKNOWN, `14` means the branch, nonce, PR, or issue relationship is wrong, and `15` means the PR
 claim is foreign: stop on every one before
 mutation, naming the code. Re-run this same two-subject proof before each later git mutation.

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -441,7 +441,7 @@ PR number as the issue, never claim the issue as a substitute, and never guess f
 Claim the PR's number first — repair mutates a shared lane exactly like a build does:
 
 ```bash
-fabrika build claim <repair-pr>
+fabrika build claim <repair-pr> --issue <served-issue>
 fabrika build verdicts --pr <repair-pr>
 ```
 
@@ -453,9 +453,10 @@ build claim: subject: PR #<repair-pr> serves #<served-issue> (fixes|part-of) —
 
 Consume it as a cross-check against the two Ground operands already retained. If the line is absent,
 malformed, repeated, or names any other PR or issue, stop `STOPPED` before mutation; never guess an
-operand from a partial answer. The line proves which subject the claim admitted, not that the live PR
-body links the retained served issue — the two-subject `build tree` proof below still owns that
-membership fact over the live linkage set.
+operand from a partial answer. The `--issue` operand makes admission select the retained served issue
+from the live linkage set, independent of reference order. The line proves which subject the claim
+admitted; the two-subject
+`build tree` proof below re-proves that membership after the branch is resumed.
 
 **Step 1's refusal of a `type:decision` is about picking one up fresh, and it does not reach here.**
 An ADR PR is served by a decision issue, and repairing it is the ordinary path: the claim admits it

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -853,18 +853,21 @@ because retracting another lane's claim is the one write this protocol must neve
 
 ```
 fabrika build claim 4312 [--repo <owner/name>] [--purpose plan|gate|build] [--token <token>]
+                         [--issue <served-issue>]
                          [--override <reason> --override-lane <lane>]
 fabrika build confirm 4312 --token <token> [--repo <owner/name>]
 fabrika build release 4312 --token <token> [--repo <owner/name>]
 fabrika build adopt 4312 --session <dead-session> --reason <text> [--repo <owner/name>]
 ```
 
-**Inputs** — the first two rows are identical for all three verbs; the last three are `claim`'s alone:
+**Inputs** — the first two rows are identical for all three verbs; `--issue` and the final three
+rows are `claim`'s alone:
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the issue (or, in repair, the PR) the claim concerns |
 | `--repo` | string | no | the `origin` remote's `owner/name` | the repository whose markers are read and written |
+| `--issue` | positive integer | repair `claim` only | — | the served issue retained independently from the repair PR; it must be a member of the PR body's complete winning linkage set, and selects the admission subject without reference-order dependence |
 | `--token` | string | required on `confirm` / `release`, optional on `claim` | — | the token `claim` handed this lane — which lane is asking. On `claim` it is the token this lane ALREADY holds, and makes the re-claim idempotent (below); omitted, the run is a fresh lane. Not a claim token, or one carrying another session id, is `1` |
 | `--purpose` | `plan` \| `gate` \| `build` | no | `build` | why this lane claims; the audience axis binds `build` only (#5175). An off-enum value is `10`, never a fallback |
 | `--override` | string | no | — | claim an issue the admission test refused on either axis, naming why; requires `--override-lane` |
@@ -874,8 +877,10 @@ fabrika build adopt 4312 --session <dead-session> --reason <text> [--repo <owner
 any marker is posted**, `claim` puts `<number>` through the
 [admission test](#admission-test--scope-admission-and-the-audience-axis) — the same imported
 module `build pick` filters on, every axis, never a second derivation. In repair, `<number>` is a PR,
-and the test judges the issue that PR serves rather than the PR's own empty home — a PR naming no
-readable issue is `refused: no-served-issue` at `20`. A `refused: out-of-scope` is
+and the test judges the issue that PR serves rather than the PR's own empty home. The repair skill
+passes that retained subject as `--issue`; the verb requires membership in the PR body's complete
+winning linkage set before admission, so an epic-first and epic-last body select the same issue. A PR
+naming no readable issue is `refused: no-served-issue` at `20`. A `refused: out-of-scope` is
 `20` and a
 `refused: audience-not-agent` is `21`, a `refused: no-acceptance-criteria` is `32`, each named on
 stderr; an unreadable declaration or home is `11` and a malformed declaration is `4`, and neither
@@ -1006,13 +1011,12 @@ A successful PR claim also writes this deterministic subject diagnostic to stder
 build claim: subject: PR #<pr> serves #<issue> (fixes|part-of) — the admission test judges that issue, not the PR's own empty home.
 ```
 
-The repair skill consumes exactly one such line as a cross-check against the PR and served-issue
-operands retained from its two Ground URLs. An absent, malformed, repeated, or mismatched line stops
-the lane before mutation; it is never a source from which to guess a missing operand. The line proves
-the admission subject, while `build tree --issue <issue> --repair <pr>` re-reads the live PR with the
-plural linkage parser and requires that the complete set contain the explicit issue operand. These are
-consecutive proofs, not substitutes: neither the scalar diagnostic nor the Ground URLs weaken the
-live relationship.
+The repair skill passes its retained issue as `build claim <pr> --issue <issue>` and consumes exactly
+one such line as a cross-check against the two Ground operands. An absent, malformed, repeated, or
+mismatched line stops the lane before mutation; it is never a source from which to guess a missing
+operand. Claim selects that explicit member with the plural linkage parser before admission, while
+`build tree --issue <issue> --repair <pr>` re-reads the same live membership after branch resume.
+These are consecutive proofs, not substitutes.
 
 - `claim` on a win: `{"answer": "won", "number": 4312, "token": "build:<sid>:<uuid>", "purpose":
   "build"}` — plus `"override": {"lane": "<lane>", "reason": "<reason>"}` when the win came through
@@ -1040,8 +1044,9 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `7` | the issue is proven absent (404) or closed |
 | `8` | the marker write failed — it may or may not have landed; run `confirm` with the token named on stderr before anything else, and never re-run `claim` |
 | `9` | the marker landed but the read-back does not match |
-| `10` | `claim` only: `--purpose` is off the `plan` \| `gate` \| `build` enum — a refusal, never a fallback to `build` |
+| `10` | `claim` only: `--purpose` is off the `plan` \| `gate` \| `build` enum, or `--issue` was passed for a non-PR target |
 | `11` | the marker set could not be read — ownership is UNKNOWN, never "unclaimed"; or, `claim` only, the campaigns table or the issue's home could not be read — scope admission is UNKNOWN, never admitted; or, `claim` against an issue only, its `blocked_by` list or a blocker's own state could not be read — blockedness is UNKNOWN, never "not blocked" |
+| `14` | `claim --issue` only: the repair PR's complete linkage set does not contain the explicitly requested served issue — no marker was written |
 | `15` | proven: another lane's earlier authorized marker wins (`claim`), holds (`confirm`), or `release` was asked for a token this lane does not hold. `claim` also refuses here over a claim this lane has *adopted* — release it first |
 | `16` | `claim` against an **issue** only, proven: a `blocked_by` blocker is still open — every one is named on stderr, and no marker was written. Not overridable: the remedy is waiting, and the edge clears when the blocker closes or its work lands on the epic run's assembly branch |
 | `20` | `claim` only, proven: the issue's home is pinned by no `active` campaign row — no marker was written |
@@ -1112,6 +1117,8 @@ the pieces is what handed a builder an ordering decision it then got wrong (#718
 | `build claim: --override was given without a lane — pass --override-lane "<lane>" so the escape hatch names who took it.` | 1 | usage error |
 | `build claim: --override-lane was given without --override — a lane names no override on its own.` | 1 | usage error |
 | `build claim: --purpose "<value>" is not one of plan \| gate \| build — an unrecognised purpose refuses, and never falls back to build.` | 10 | usage error |
+| `build claim: --issue is repair-only, but #<n> is an issue rather than a pull request; nothing was written.` | 10 | refusal |
+| `build claim: PR #<pr> does not serve requested issue #<issue> through <kind>; it serves <actual> instead — nothing was written.` | 14 | refusal |
 | `build claim: the marker write failed: <reason> — the claim state is UNKNOWN; run "fabrika build confirm <n> --token <minted token>" before any further action.` — preceded by `build claim: the token this run minted is <minted token> — it addresses the marker the failed write may still have landed. Do not re-run "fabrika build claim <n>": it mints a second token, and if the first marker landed the race resolves to that earlier one, leaving a claim no lane holds a token for.` | 8 | refusal |
 | `build claim: cannot read the claim markers on #<n>: <reason> — ownership is UNKNOWN, never "unclaimed".` | 11 | refusal |
 | `build claim: #<n> already carries a build a reviewer failed — <gate> <polarity> over <base>..<tip> (comment <id>); …. A fresh build would re-implement it; run "fabrika build resume-child <n>" instead, which takes the repair lane and stands this tree on the branch that build left, in the one order those steps work in (#7187). Nothing was written.` — every standing verdict is named, `PASS` ones included, whenever at least one is a `FAIL` | 31 | refusal |

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -370,15 +370,16 @@ fabrika build tree [--require-clean] [--issue <n> [--repair <pr>]]
 |---|---|---|---|---|
 | `--require-clean` | boolean | no | `false` | additionally refuse a tree with any uncommitted change — the lane-open posture |
 | `--issue` | integer | no | — | additionally prove the checked-out branch serves this issue — the pre-mutation posture |
-| `--repair` | integer | no | — | with `--issue`, prove this repair PR's claim, resumed branch and unique served-issue linkage as one relationship |
+| `--repair` | integer | no | — | with `--issue`, prove this repair PR's claim, resumed branch and membership of the requested issue in its served-issue linkage set |
 
 **Output** — machine. With neither `--issue` nor `--repair`, one line containing the tree root's
 absolute path. With `--issue`, one JSON object:
 `{"answer":"proven","root":"<absolute>","branch":"<name>","claim":{"number":<issue-or-pr>,"nonce":"<nonce>"},"servedIssue":{"number":<issue>,"kind":"issue|fixes|part-of"}}`.
 A fresh proof puts the issue number in both `claim.number` and `servedIssue.number`, with kind
-`issue`. A repair proof puts the PR in `claim.number`, the issue in `servedIssue.number`, and the
-live PR body's unique winning reference kind in `servedIssue.kind`. This is the whole successful
-repair answer; the skill consumes this object, never a scope line or incidental diagnostic.
+`issue`. A repair proof puts the PR in `claim.number`, the explicitly requested issue in
+`servedIssue.number`, and the live PR body's winning reference kind in `servedIssue.kind`. This is
+the whole successful repair answer; the skill consumes this object, never a scope line or incidental
+diagnostic.
 
 This verb **reads and never repairs**: it creates nothing, cleans nothing, removes nothing. It also
 asserts nothing about *where* the tree is — that is the operator's call, not fabrika's (#5386).
@@ -390,10 +391,10 @@ The assertions:
 2. **Fresh lane** (`--issue`, without `--repair`) — the checked-out create branch names that issue
    and carries that issue's winning claim nonce. A non-lane, wrong-number, or nonce mismatch is `14`.
 3. **Repair lane** (`--issue <n> --repair <pr>`) — one fail-closed flow proves all subjects: the
-   checked-out resume branch names `<pr>`; its nonce owns `<pr>`'s winning claim; the live, open PR
-   names exactly one issue through the same closing-keyword/`Part of` grammar review reads; that issue
-   is `<n>`, is live and readable, and is an issue rather than another pull request. The PR is never passed as the issue operand, the issue is never
-   queried for the repair claim, and no branch number is guessed into a served issue.
+   checked-out resume branch names `<pr>`; its nonce owns `<pr>`'s winning claim; the live, open PR's
+   complete closing-keyword/`Part of` set contains `<n>`; and `<n>` is live, readable, and an issue
+   rather than another pull request. The PR is never passed as the issue operand, the issue is never
+   queried for the repair claim, and reference order never selects a different served issue.
 
 **The branch's own nonce is the identity the claim is read under** — the question is whether the
 winning marker belongs to THIS lane, not to this session (#6037). A sibling lane of the same session
@@ -403,8 +404,8 @@ is `14`; only another session's claim is `15`. No stamp file exists to check.
 
 | Code | Trigger |
 |---|---|
-| `4` | the PR body names zero or several served issues — no unique repair subject |
-| `7` | the repair PR or its uniquely linked served issue is proven absent or closed |
+| `4` | the PR body names no served issue — the requested repair subject is not linked |
+| `7` | the repair PR or explicitly requested served issue is proven absent or closed |
 | `10` | `--repair` was given without its required `--issue` operand |
 | `11` | the tree root, claim state, repair PR, or linked served issue could not be read — UNKNOWN |
 | `13` | proven: uncommitted changes present at a `--require-clean` open |
@@ -425,14 +426,14 @@ is `14`; only another session's claim is `15`. No stamp file exists to check.
 | `build tree: #<n> is held by <winning token>, not by the lane on nonce <nonce>.` | 15 | refusal |
 | `build tree: cannot read repair PR #<pr>: <reason> — its served issue is UNKNOWN; nothing is proven.` | 11 | refusal |
 | `build tree: PR #<pr> is proven absent or closed.` | 7 | refusal |
-| `build tree: repair PR #<pr> names <count> served issues through <kind>; exactly one is required, so the repair subject is not uniquely readable.` | 4 | refusal |
-| `build tree: repair PR #<pr> serves issue #<actual>, not requested issue #<n> — wrong lane.` | 14 | refusal |
+| `build tree: repair PR #<pr> names no served issues through <kind>, so requested issue #<n> is not proven.` | 4 | refusal |
+| `build tree: repair PR #<pr> does not serve requested issue #<n> through <kind>; it serves #<actual>[, #<actual>...] instead — wrong lane.` | 14 | refusal |
 | `build tree: cannot read issue #<n>, which repair PR #<pr> serves: <reason> — the repair subject is UNKNOWN; nothing is proven.` | 11 | refusal |
 | `build tree: issue #<n> is proven absent or closed.` | 7 | refusal |
 | `build tree: repair PR #<pr> links #<n>, but that record is itself a pull request, not the served issue — wrong lane.` | 14 | refusal |
 
 **Scope** — not a judging verb: it reads this process's git state, one claim, and in repair the live
-PR plus its one served issue.
+PR plus the explicitly requested issue in its served-issue set.
 
 **Examples**
 
@@ -445,6 +446,9 @@ $ fabrika build tree --require-clean
 $ fabrika build tree --issue 4312
 {"answer":"proven","root":"/private/var/<redacted>/lanes/build-4312","branch":"build/4312-editor-focus-loss-c1a4d6f8","claim":{"number":4312,"nonce":"c1a4d6f8"},"servedIssue":{"number":4312,"kind":"issue"}}
 ```
+
+For a PR body that closes both `#7162` and `#7181`, either reference may appear first; the explicit
+issue operand selects the repair subject:
 
 ```
 $ fabrika build tree --issue 7181 --repair 7182
@@ -466,6 +470,8 @@ $ echo $?
   mutation: a pass is a fact about this invocation and nothing later.
 - #7183 — a repair branch carries a PR claim nonce while its contract belongs to a distinct issue;
   the repair proof binds both subjects instead of weakening either one.
+- #7309 — a one-PR epic closes the epic and its landed children; the explicit issue operand selects
+  the repair subject by membership rather than reference order or singularity.
 - 2026-08-13 ruling on #5386 — fabrika holds no worktree opinion; `12` is retired and this verb
   asserts nothing about where the tree sits.
 
@@ -1004,8 +1010,9 @@ The repair skill consumes exactly one such line as a cross-check against the PR 
 operands retained from its two Ground URLs. An absent, malformed, repeated, or mismatched line stops
 the lane before mutation; it is never a source from which to guess a missing operand. The line proves
 the admission subject, while `build tree --issue <issue> --repair <pr>` re-reads the live PR with the
-plural linkage parser and refuses zero or several served issues on `4`. These are consecutive proofs,
-not substitutes: neither the scalar diagnostic nor the Ground URLs weaken the unique live relationship.
+plural linkage parser and requires that the complete set contain the explicit issue operand. These are
+consecutive proofs, not substitutes: neither the scalar diagnostic nor the Ground URLs weaken the
+live relationship.
 
 - `claim` on a win: `{"answer": "won", "number": 4312, "token": "build:<sid>:<uuid>", "purpose":
   "build"}` — plus `"override": {"lane": "<lane>", "reason": "<reason>"}` when the win came through

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -879,9 +879,9 @@ any marker is posted**, `claim` puts `<number>` through the
 module `build pick` filters on, every axis, never a second derivation. In repair, `<number>` is a PR,
 and the test judges the issue that PR serves rather than the PR's own empty home. The repair skill
 passes that retained subject as `--issue`; the verb requires membership in the PR body's complete
-winning linkage set before admission, so an epic-first and epic-last body select the same issue. A PR
-naming no readable issue is `refused: no-served-issue` at `20`. A `refused: out-of-scope` is
-`20` and a
+winning linkage set before admission, so an epic-first and epic-last body select the same issue. An
+empty linkage set fails that explicit membership check at `14`, before admission. A `refused:
+out-of-scope` is `20` and a
 `refused: audience-not-agent` is `21`, a `refused: no-acceptance-criteria` is `32`, each named on
 stderr; an unreadable declaration or home is `11` and a malformed declaration is `4`, and neither
 ever proceeds. Nothing is written on any refusal: the issue carries no marker, so a refused claim

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -194,7 +194,7 @@ Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build
 
 | Verb | Answers |
 |---|---|
-| `build tree` | whether the ground is clean and the complete fresh issue or repair PR→issue lane relationship is proven |
+| `build tree` | whether the ground is clean and the complete fresh issue or repair PR→explicit issue-in-linkage-set relationship is proven |
 | `build pick` | the ranked candidate pool, with every excluded issue under the axis that refused it |
 | `build eligible` | whether one issue's dependency gate is open |
 | `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, re-prove it, retract it, or take a dead session's |

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -197,7 +197,7 @@ Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build
 | `build tree` | whether the ground is clean and the complete fresh issue or repair PR→explicit issue-in-linkage-set relationship is proven |
 | `build pick` | the ranked candidate pool, with every excluded issue under the axis that refused it |
 | `build eligible` | whether one issue's dependency gate is open |
-| `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, re-prove it, retract it, or take a dead session's |
+| `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, explicitly select a repair PR's served issue, re-prove it, retract it, or take a dead session's |
 | `build claimants` | who holds an issue's claim, read by a caller holding none — no token, no write, no clearance |
 | `build issue` | the claimed issue's body and its criteria — `found` / `absent` / `malformed`, all on exit 0 |
 | `build branch` / `scratch` | the lane's branch off a fresh base, and its scratch directory |

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -46,8 +46,9 @@
  * same derivation `build eligible` answers from: without it the two seams disagreed on one edge, and
  * every sequential epic tracer after the first parked at a human (#7035).
  *
- * In repair the number is a **PR**, which carries no home and no audience of its
- * own, so the test runs over the issue that PR serves (#5562) — and when that issue is
+ * In repair the number is a **PR**, which carries no home and no audience of its own, so the test
+ * runs over the issue that PR serves (#5562). The repair route passes that issue explicitly and the
+ * plural linkage reader selects it without reference-order dependence — and when that issue is
  * `type:decision` the audience axis does not bind, because triage routes a decision to
  * `ready-for:human` by default and a repair lane would otherwise fail a fence it had no way to
  * satisfy (#5914). The default is not an exclusion — a decision issue carrying a founder ruling
@@ -65,6 +66,7 @@ import {
 	listComments,
 } from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
+import {issueRefsOf} from "../review/classes.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	BUILD_CLAIM,
@@ -87,6 +89,7 @@ import {
 	PRIOR_BUILD_MISMATCH,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
+	WRONG_LANE,
 } from "./codes.ts";
 import {readDischargedGate} from "./discharge.ts";
 import {currentBranch, detachHead} from "./git.ts";
@@ -114,6 +117,8 @@ import {openIssue, resolveAdmissionSubject, resolveTargetRepo, scannedLine} from
 
 export interface ClaimOptions {
 	readonly number: number;
+	/** Repair only: the served issue retained independently from the PR's linkage order. */
+	readonly issue: number | null;
 	readonly repo: string | null;
 	/** Where to look for `.fabrika.jsonc` — the checkout this run stands in. */
 	readonly cwd: string;
@@ -161,7 +166,16 @@ export interface ClaimOptions {
 // release / adopt ask about a marker rather than about what this repo admits.
 export type ProtocolOptions = Omit<
 	ClaimOptions,
-	"uuid" | "at" | "purpose" | "override" | "overrideLane" | "cites" | "token" | "cwd" | "resume"
+	| "uuid"
+	| "at"
+	| "purpose"
+	| "override"
+	| "overrideLane"
+	| "cites"
+	| "token"
+	| "cwd"
+	| "resume"
+	| "issue"
 > & {
 	/** The token `build claim` handed this lane — the identity it is asking under (#6037). */
 	readonly token: string;
@@ -377,6 +391,26 @@ export const runClaim = (
 		if (ready._tag === "Refused") return ready.outcome;
 		const {repo, session} = ready;
 		const {number} = options;
+		if (options.issue !== null) {
+			if (!Number.isInteger(options.issue) || options.issue <= 0) {
+				return refuse(FAILED, `${CLAIM}: --issue ${options.issue} is not a positive integer.`);
+			}
+			if (!ready.issue.isPullRequest) {
+				return refuse(
+					OFF_VOCABULARY,
+					`${CLAIM}: --issue is repair-only, but #${number} is an issue rather than a pull request; nothing was written.`,
+				);
+			}
+			const refs = issueRefsOf(ready.issue.body);
+			if (!refs.numbers.includes(options.issue)) {
+				const actual =
+					refs.numbers.length === 0 ? "no served issues" : `#${refs.numbers.join(", #")}`;
+				return refuse(
+					WRONG_LANE,
+					`${CLAIM}: PR #${number} does not serve requested issue #${options.issue} through ${refs.kind}; it serves ${actual} instead — nothing was written.`,
+				);
+			}
+		}
 
 		// Already THIS LANE's: answer with the marker that owns it and write nothing. A second marker
 		// would leave `claim` printing one nonce while `confirm`/`requireClaim` read the earliest
@@ -417,7 +451,13 @@ export const runClaim = (
 			);
 		}
 		const scopeLine = dispatchScopeLine(CLAIM, read.dispatch);
-		const subject = yield* resolveAdmissionSubject(CLAIM, repo, read.dispatch, ready.issue);
+		const subject = yield* resolveAdmissionSubject(
+			CLAIM,
+			repo,
+			read.dispatch,
+			ready.issue,
+			options.issue,
+		);
 		const judged = subject._tag === "Judged" ? subject.facts : ready.issue;
 		const repair = subject._tag === "Judged" ? subject.repair : NOT_REPAIR;
 		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(judged), repair);

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -25,6 +25,7 @@ import {
 	READBACK_MISMATCH,
 	TYPE_NOT_BUILDABLE,
 	WRITE_UNKNOWN,
+	WRONG_LANE,
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {
@@ -114,6 +115,7 @@ const unblocked = (script: ReadonlyArray<Scripted>) => fakeSeams([...script, NO_
 
 const options = {
 	number: 4312,
+	issue: null as number | null,
 	repo: null,
 	cwd: "/repo",
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e", ...GH_TOKEN_ENV} as Record<
@@ -660,6 +662,24 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		expect(out.stderr.some((line) => line.includes("PR #4312 serves #5553 (fixes)"))).toBe(true);
 	});
 
+	it.each([
+		["first", "Fixes #5553\nFixes #5554\n"],
+		["last", "Fixes #5554\nFixes #5553\n"],
+	])("admits an explicitly retained served issue when it appears %s", async (_order, body) => {
+		const {out} = await claimPull(body, servedTicket(44), {issue: 5553});
+		expect(out.code).toBe(0);
+		expect(out.stderr.some((line) => line.includes("PR #4312 serves #5553 (fixes)"))).toBe(true);
+	});
+
+	it("refuses an explicit issue outside the PR linkage set before writing", async () => {
+		const {out, shell} = await claimPull("Fixes #5553\nFixes #5554\n", servedTicket(44), {
+			issue: 5555,
+		});
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("does not serve requested issue #5555");
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
+	});
+
 	it("reads Part of #<n> too — the partial-PR shape build --partial emits", async () => {
 		const {out} = await claimPull("Part of #5553\n", servedTicket(44));
 		expect(out.code).toBe(0);
@@ -731,6 +751,16 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		expect(out.stderr.some((line) => line.includes("this issue carries ready-for:agent"))).toBe(
 			true,
 		);
+	});
+
+	it("refuses --issue on a non-PR target before writing", async () => {
+		const shell = unblocked([[ISSUE, issue()]]);
+		const out = await Effect.runPromise(
+			Effect.provide(runClaim({...options, issue: 4312}), Layer.merge(shell.layer, IN_SCOPE.layer)),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("--issue is repair-only");
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("leaves an issue target reading its own record — the resolution never fires on one", async () => {

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -156,6 +156,12 @@ const claim = leafCommand(
 	"claim",
 	{
 		number: issueArg,
+		issue: Flag.integer("issue").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"repair only: the served issue retained from the repair brief, selected from the PR's complete linkage set",
+			),
+		),
 		token: tokenFlag.pipe(
 			Flag.optional,
 			Flag.withDescription(
@@ -193,10 +199,21 @@ const claim = leafCommand(
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, token, purpose, override, overrideLane, cites, resume, repo}) {
+	Effect.fn(function* ({
+		number,
+		issue,
+		token,
+		purpose,
+		override,
+		overrideLane,
+		cites,
+		resume,
+		repo,
+	}) {
 		yield* emit(
 			yield* runClaim({
 				number,
+				issue: Option.getOrNull(issue),
 				repo: Option.getOrNull(repo),
 				cwd: process.cwd(),
 				env: process.env,
@@ -212,9 +229,11 @@ const claim = leafCommand(
 		);
 	}),
 ).pipe(
-	Command.withShortDescription("Race the claim marker on an issue and win it or name the winner."),
+	Command.withShortDescription(
+		"Race the claim marker on an issue or explicitly selected repair subject.",
+	),
 	Command.withDescription(
-		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<session-id>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. The type axis binds a build claim against an ISSUE only, so ${DECISION_TYPE_LABEL} and ${EPIC_TYPE_LABEL} refuse before any marker is written; --cites ${CITATION_GRAMMAR} opens it on a decision whose choice a founder already recorded on that issue, and the URL must name this repository and the issue being judged. It is not an override: it says the refusal does not apply, and it is never accepted for an epic. The criteria axis binds a fresh build claim against an ISSUE only: a body with no readable \`### Acceptance criteria\` block refuses on 32 before any marker, absent or malformed, and it is not overridable — the repair belongs on the issue (triage enrich, triage repair-criteria), not on a branch (#6554). Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used and "cites" when a ruling was cited. --token makes the re-claim idempotent per LANE: handed the token this lane already holds, a number that lane already owns answers won with that same marker and writes nothing (#5782), while a same-session marker under another nonce is a sibling lane and races normally. A lost race retracts this run's own marker and exits 15, never 0 — including when the winner is another lane of THIS session, since ownership turns on the whole token and never the session id (#6037); no session id is set (FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION), a --token that is not a claim token of this session, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. After the admission test, and only against an ISSUE, a blockedness gate reads the native blocked_by graph (ADR 0301): a number with any blocker still open refuses on 16 naming every one of them, and an edge list that could not be read is 11 — never "not blocked". An open blocker whose work already landed on the parent epic's assembly branch is discharged off the same derivation build eligible answers from (ADR 0285, #7035), so the two seams cannot disagree about one edge; an unreadable branch, an unnameable trunk and a standalone issue all leave every edge as the board read it, and a parent that could not be read is 11. It is not overridable, because the remedy is waiting rather than an edit. Then, on a fresh build-purpose claim only, a prior-build gate reads the number's range-scoped verdict comments — where an epic child's review lands, since a child opens no PR (ADR 0285/0276): a child carrying ANY standing verdict refuses on 31, naming each namespace, polarity, range and comment id — a FAIL points at "--resume", a PASS-only child points at the epic driver's fold and never at --resume (#6715) — and --resume on a child holding no standing FAIL refuses on 31 too. Unreadable comments are 11, never "no prior build", and neither direction is overridable — --override admits a scope refusal, and this is not one. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), 16 (proven blocked), 31 (the claim's mode and the child's standing verdict disagree), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
+		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<session-id>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. In repair, --issue <served-issue> selects that explicit member of the PR body's complete linkage set before admission, independent of reference order; a missing member refuses on 14. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. The type axis binds a build claim against an ISSUE only, so ${DECISION_TYPE_LABEL} and ${EPIC_TYPE_LABEL} refuse before any marker is written; --cites ${CITATION_GRAMMAR} opens it on a decision whose choice a founder already recorded on that issue, and the URL must name this repository and the issue being judged. It is not an override: it says the refusal does not apply, and it is never accepted for an epic. The criteria axis binds a fresh build claim against an ISSUE only: a body with no readable \`### Acceptance criteria\` block refuses on 32 before any marker, absent or malformed, and it is not overridable — the repair belongs on the issue (triage enrich, triage repair-criteria), not on a branch (#6554). Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used and "cites" when a ruling was cited. --token makes the re-claim idempotent per LANE: handed the token this lane already holds, a number that lane already owns answers won with that same marker and writes nothing (#5782), while a same-session marker under another nonce is a sibling lane and races normally. A lost race retracts this run's own marker and exits 15, never 0 — including when the winner is another lane of THIS session, since ownership turns on the whole token and never the session id (#6037); no session id is set (FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION), a --token that is not a claim token of this session, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. After the admission test, and only against an ISSUE, a blockedness gate reads the native blocked_by graph (ADR 0301): a number with any blocker still open refuses on 16 naming every one of them, and an edge list that could not be read is 11 — never "not blocked". An open blocker whose work already landed on the parent epic's assembly branch is discharged off the same derivation build eligible answers from (ADR 0285, #7035), so the two seams cannot disagree about one edge; an unreadable branch, an unnameable trunk and a standalone issue all leave every edge as the board read it, and a parent that could not be read is 11. It is not overridable, because the remedy is waiting rather than an edit. Then, on a fresh build-purpose claim only, a prior-build gate reads the number's range-scoped verdict comments — where an epic child's review lands, since a child opens no PR (ADR 0285/0276): a child carrying ANY standing verdict refuses on 31, naming each namespace, polarity, range and comment id — a FAIL points at "--resume", a PASS-only child points at the epic driver's fold and never at --resume (#6715) — and --resume on a child holding no standing FAIL refuses on 31 too. Unreadable comments are 11, never "no prior build", and neither direction is overridable — --override admits a scope refusal, and this is not one. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum or --issue names a non-PR target), 14 (the requested served issue is absent from the repair PR linkage), 15 (proven lost), 16 (proven blocked), 31 (the claim's mode and the child's standing verdict disagree), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
 	),
 );
 

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -88,7 +88,7 @@ const tree = leafCommand(
 		repair: Flag.integer("repair").pipe(
 			Flag.optional,
 			Flag.withDescription(
-				"the repair PR whose claim and resumed branch must uniquely serve --issue",
+				"the repair PR whose claim, resumed branch, and linkage set must contain --issue",
 			),
 		),
 		repo: repoFlag,
@@ -109,7 +109,7 @@ const tree = leafCommand(
 		"Prove clean ground and the complete fresh or repair lane relationship.",
 	),
 	Command.withDescription(
-		'Prove the ground: optionally clean; with --issue, prove the checked-out branch, winning claim, and served issue as one relationship. Add --repair <pr> on a resumed repair branch: the branch must name that PR, carry that PR claim\'s nonce, and the live PR must uniquely serve --issue. Armed success prints {"answer":"proven","root":"<absolute>","branch":"<name>","claim":{"number":<issue-or-pr>,"nonce":"<nonce>"},"servedIssue":{"number":<issue>,"kind":"issue|fixes|part-of"}}. An unarmed success prints only the absolute root. Reads and NEVER repairs. Exits 4 (repair linkage malformed or not unique), 7 (repair PR or served issue absent/closed), 10 (--repair without --issue), 11 (ground, claim, PR, or served issue unreadable — UNKNOWN), 13 (dirty at --require-clean), 14 (wrong branch, nonce, PR, or served issue), 15 (claim foreign). Example: fabrika build tree --issue 7181 --repair 7182',
+		'Prove the ground: optionally clean; with --issue, prove the checked-out branch, winning claim, and served issue as one relationship. Add --repair <pr> on a resumed repair branch: the branch must name that PR, carry that PR claim\'s nonce, and the live PR\'s served-issue linkage set must contain --issue. Armed success prints {"answer":"proven","root":"<absolute>","branch":"<name>","claim":{"number":<issue-or-pr>,"nonce":"<nonce>"},"servedIssue":{"number":<issue>,"kind":"issue|fixes|part-of"}}. An unarmed success prints only the absolute root. Reads and NEVER repairs. Exits 4 (repair linkage absent), 7 (repair PR or served issue absent/closed), 10 (--repair without --issue), 11 (ground, claim, PR, or served issue unreadable — UNKNOWN), 13 (dirty at --require-clean), 14 (wrong branch, nonce, PR, or served issue), 15 (claim foreign). Example: fabrika build tree --issue 7181 --repair 7182',
 	),
 );
 

--- a/packages/fabrika-cli/src/build/repair-identifiers.data.unit.test.ts
+++ b/packages/fabrika-cli/src/build/repair-identifiers.data.unit.test.ts
@@ -48,14 +48,14 @@ describe("build skill repair identifiers (#7162 / PR #7180)", () => {
 		assert.notMatch(rendered, /fabrika build pr \d+/);
 	});
 
-	it("consumes the documented claim subject and still requires the unique proof", () => {
+	it("consumes the documented claim subject and still requires the live membership proof", () => {
 		assert.include(contract, "build claim: subject: PR #<pr> serves #<issue> (fixes|part-of)");
 		assert.include(mainRepair, "Consume it as a cross-check against the two Ground operands");
 		for (const defect of ["absent", "malformed", "repeated"]) {
 			assert.include(mainRepair, defect);
 		}
-		assert.include(contract, "refuses zero or several served issues on `4`");
-		assert.include(mainRepair, "the live PR uniquely serves the issue");
-		assert.include(mainRepair, "Exit `4` means the unique linkage is malformed");
+		assert.include(contract, "complete set contain the explicit issue operand");
+		assert.include(mainRepair, "served-issue set contains the explicitly");
+		assert.include(mainRepair, "Exit `4` means the linkage is absent");
 	});
 });

--- a/packages/fabrika-cli/src/build/repair-identifiers.data.unit.test.ts
+++ b/packages/fabrika-cli/src/build/repair-identifiers.data.unit.test.ts
@@ -27,7 +27,8 @@ describe("build skill repair identifiers (#7162 / PR #7180)", () => {
 		assert.notInclude(mainRepair, "$issue_or_pr_number");
 	});
 
-	it("proves the PR claim and served issue together after resuming", () => {
+	it("preserves the served issue through claim and proves both subjects after resuming", () => {
+		assert.include(rendered, `fabrika build claim ${PR} --issue ${ISSUE}`);
 		assert.include(rendered, `fabrika build tree --issue ${ISSUE} --repair ${PR}`);
 		assert.notInclude(rendered, `fabrika build tree --issue ${PR}`);
 		assert.isBelow(
@@ -54,7 +55,7 @@ describe("build skill repair identifiers (#7162 / PR #7180)", () => {
 		for (const defect of ["absent", "malformed", "repeated"]) {
 			assert.include(mainRepair, defect);
 		}
-		assert.include(contract, "complete set contain the explicit issue operand");
+		assert.include(contract, "Claim selects that explicit member with the plural linkage parser");
 		assert.include(mainRepair, "served-issue set contains the explicitly");
 		assert.include(mainRepair, "Exit `4` means the linkage is absent");
 	});

--- a/packages/fabrika-cli/src/build/resume-child-verb.ts
+++ b/packages/fabrika-cli/src/build/resume-child-verb.ts
@@ -88,6 +88,7 @@ export const runResumeChild = (
 		// marker, so the entry cannot open a repair lane over a child nobody failed.
 		const claimed = yield* runClaim({
 			number: issue,
+			issue: null,
 			repo,
 			cwd: options.cwd,
 			env,

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -32,7 +32,7 @@ import {Effect, type FileSystem, type Path, Result} from "effect";
 import {CONFIG_PATH} from "../config/document.ts";
 import {readRoadmapFile} from "../config/paths.ts";
 import {exists, type ReadFailed, readFile} from "../io/fs.ts";
-import {issueRefOf} from "../review/classes.ts";
+import {issueRefsOf} from "../review/classes.ts";
 import {READY_FOR_AGENT, READY_FOR_PREFIX} from "../triage/audience.ts";
 import {EPIC_TYPE_LABEL} from "../triage/facets.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
@@ -250,20 +250,26 @@ export interface SubjectFacts {
  * label, so a fence reading the PR's own record refused **every** repair claim while any focus was
  * declared (#5562). A PR's lane serves a ticket, and that ticket's home is the campaign membership
  * the fence is actually asking about — so the PR resolves to it, through the same body reference
- * `review scope` reads (`issueRefOf`), never a second parser.
+ * `review scope` reads (`issueRefsOf`), never a second parser. A repair caller may retain the served
+ * issue explicitly; selecting that member here keeps admission independent of body order while an
+ * ordinary PR claim retains the scalar first-reference behavior.
  */
 export type ScopeSubject =
 	| {readonly _tag: "Own"}
 	| {readonly _tag: "Served"; readonly number: number; readonly kind: "fixes" | "part-of"}
-	/** A PR whose body names no issue at all — there is nothing to resolve to. */
+	/** A PR whose body names no issue at all, or not the explicitly requested one. */
 	| {readonly _tag: "Unserved"};
 
-export const scopeSubjectOf = (target: SubjectFacts): ScopeSubject => {
+export const scopeSubjectOf = (
+	target: SubjectFacts,
+	requestedIssue: number | null = null,
+): ScopeSubject => {
 	if (!target.isPullRequest) return {_tag: "Own"};
-	const ref = issueRefOf(target.body);
-	return ref.kind === "none" || ref.number === null
+	const refs = issueRefsOf(target.body);
+	const number = requestedIssue ?? refs.numbers[0] ?? null;
+	return number === null || refs.kind === "none" || !refs.numbers.includes(number)
 		? {_tag: "Unserved"}
-		: {_tag: "Served", number: ref.number, kind: ref.kind};
+		: {_tag: "Served", number, kind: refs.kind};
 };
 
 /** An issue's home: its open milestone's number as a string, or its standing lane. */

--- a/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
@@ -724,6 +724,23 @@ describe("scopeSubjectOf", () => {
 		});
 	});
 
+	it.each([
+		["first", "Fixes #4312\nFixes #4313\n"],
+		["last", "Fixes #4313\nFixes #4312\n"],
+	])("selects an explicitly requested issue when it appears %s", (_order, body) => {
+		expect(scopeSubjectOf(pull(body), 4312)).toEqual({
+			_tag: "Served",
+			number: 4312,
+			kind: "fixes",
+		});
+	});
+
+	it("does not substitute another linked issue for the explicitly requested one", () => {
+		expect(scopeSubjectOf(pull("Fixes #4312\nFixes #4313\n"), 4314)).toEqual({
+			_tag: "Unserved",
+		});
+	});
+
 	it("resolves a partial PR through Part of #<n>, the reference review scope reads", () => {
 		expect(scopeSubjectOf(pull("Part of #4312\n"))).toEqual({
 			_tag: "Served",

--- a/packages/fabrika-cli/src/build/target.ts
+++ b/packages/fabrika-cli/src/build/target.ts
@@ -131,10 +131,11 @@ export const resolveAdmissionSubject = (
 	repo: string,
 	dispatch: Dispatch,
 	target: IssueRecord,
+	requestedIssue: number | null = null,
 ): Effect.Effect<AdmissionSubject, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
 		const own = {_tag: "Judged" as const, facts: target, note: null, repair: NOT_REPAIR};
-		const subject = scopeSubjectOf(target);
+		const subject = scopeSubjectOf(target, requestedIssue);
 		if (subject._tag === "Own") return own;
 		const unresolved = (reason: string): AdmissionSubject =>
 			dispatch._tag === "Active"

--- a/packages/fabrika-cli/src/build/tree-verb.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.ts
@@ -4,7 +4,8 @@
  * Two assertions, each with its own code so a caller can act on which one failed: a clean tree at a
  * `--require-clean` open (`13`), and a checked-out branch carrying this claim's nonce (`14`). A fresh
  * proof binds one issue branch to that issue's claim. A repair proof additionally binds the resumed
- * branch to the named PR, that PR's winning claim, and the one issue its live body serves (#7183).
+ * branch to the named PR, that PR's winning claim, and the explicitly requested issue in its live
+ * body's served-issue set (#7183, #7309).
  * Both are location-neutral — where the lane runs is the operator's call, not fabrika's (#5386). It
  * reads and never repairs: no clean, no create, no remove.
  *
@@ -28,7 +29,7 @@ export interface TreeOptions {
 	readonly requireClean: boolean;
 	/** Additionally prove the checked-out branch serves this issue — the pre-mutation posture. */
 	readonly issue: number | null;
-	/** In repair, the PR claim and resumed branch that must uniquely serve `issue`. */
+	/** In repair, the PR claim and resumed branch whose linkage set must contain `issue`. */
 	readonly repair: number | null;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -117,28 +118,21 @@ export const runTree = (
 		);
 		if (pull._tag === "Refused") return pull.outcome;
 		const linkage = issueRefsOf(pull.pull.body);
-		if (linkage.numbers.length !== 1) {
+		if (linkage.numbers.length === 0) {
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: repair PR #${repair} names ${linkage.numbers.length} served issues through ${linkage.kind}; exactly one is required, so the repair subject is not uniquely readable.`,
+				`${VERB}: repair PR #${repair} names no served issues through ${linkage.kind}, so requested issue #${issueNumber} is not proven.`,
 				held.notes,
 			);
 		}
-		const servedIssue = linkage.numbers[0];
-		if (servedIssue === undefined) {
-			return refuse(
-				BAD_SECTIONS,
-				`${VERB}: repair PR #${repair}'s served issue disappeared while reading its linkage — nothing is proven.`,
-				held.notes,
-			);
-		}
-		if (servedIssue !== issueNumber) {
+		if (!linkage.numbers.includes(issueNumber)) {
 			return refuse(
 				WRONG_LANE,
-				`${VERB}: repair PR #${repair} serves issue #${servedIssue}, not requested issue #${issueNumber} — wrong lane.`,
+				`${VERB}: repair PR #${repair} does not serve requested issue #${issueNumber} through ${linkage.kind}; it serves ${linkage.numbers.map((number) => `#${number}`).join(", ")} instead — wrong lane.`,
 				held.notes,
 			);
 		}
+		const servedIssue = issueNumber;
 		const issue = yield* openIssue(
 			VERB,
 			resolved.repo,

--- a/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
@@ -294,22 +294,35 @@ describe("runTree", () => {
 		expect(out.stderr.at(-1)).toContain("does not carry claim");
 	});
 
-	it("refuses a PR serving another issue on 14", async () => {
-		const out = await run(repairProof("Fixes #7162\n\n## Deviations\nNone.\n"), {
+	it.each([
+		["epic first", "Fixes #7181\nFixes #7162\n\n## Deviations\nNone.\n"],
+		["epic last", "Fixes #7162\nFixes #7181\n\n## Deviations\nNone.\n"],
+	])("proves the explicitly requested issue when it is %s in a multi-linkage body", async (_name, body) => {
+		const out = await run(repairProof(body), {issue: 7181, repair: 7182});
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).servedIssue).toEqual({number: 7181, kind: "fixes"});
+	});
+
+	it("refuses a served-issue set that does not contain the requested issue on 14", async () => {
+		const out = await run(repairProof("Fixes #7162\nFixes #7163\n\n## Deviations\nNone.\n"), {
 			issue: 7181,
 			repair: 7182,
 		});
 		expect(out.code).toBe(WRONG_LANE);
-		expect(out.stderr.at(-1)).toContain("serves issue #7162, not requested issue #7181");
+		expect(out.stderr.at(-1)).toContain(
+			"does not serve requested issue #7181 through fixes; it serves #7162, #7163 instead",
+		);
 	});
 
-	it.each([
-		["no linkage", "Summary only\n\n## Deviations\nNone.\n", 0],
-		["ambiguous linkage", "Fixes #7181\nFixes #7162\n\n## Deviations\nNone.\n", 2],
-	])("refuses %s on 4", async (_name, body, count) => {
-		const out = await run(repairProof(body), {issue: 7181, repair: 7182});
+	it("refuses a body with no served-issue linkage on 4", async () => {
+		const out = await run(repairProof("Summary only\n\n## Deviations\nNone.\n"), {
+			issue: 7181,
+			repair: 7182,
+		});
 		expect(out.code).toBe(BAD_SECTIONS);
-		expect(out.stderr.at(-1)).toContain(`names ${count} served issues`);
+		expect(out.stderr.at(-1)).toContain(
+			"names no served issues through none, so requested issue #7181 is not proven",
+		);
 	});
 
 	it("refuses unreadable PR claim state on 11", async () => {

--- a/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
@@ -416,6 +416,7 @@ describe("a driver's claim and the builder it spawns", () => {
 			Effect.provide(
 				runClaim({
 					number: 5492,
+					issue: null,
 					repo: null,
 					cwd: "/repo",
 					env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-b1"},


### PR DESCRIPTION
Make repair relationship proof carry the explicitly retained served issue through both claim admission and the resumed-tree check, so one-PR epics remain independent of closing-reference order.

Keep zero-linkage, wrong-subject, and ordinary single-issue repairs fail-closed while publishing the same contract across the CLI and build skill.

Fixes #7309

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #7309 requires epic-first, epic-last, wrong-subject, no-linkage, and single-issue coverage. **Did:** replaced pre-existing singular-linkage assertions in the repair-identifier and tree-verb tests, then added claim-admission coverage for both reference orders. **Why:** those assertions encoded the obsolete unique-linkage contract and could not coexist with explicit membership selection. **Disposition:** stated here.
