### PR TITLE
fix: operator shell has no subagent spawn tool for lane brief dispatch

### DIFF
--- a/.opencode/agent/operator.md
+++ b/.opencode/agent/operator.md
@@ -4,6 +4,7 @@ description: The operator — spawn target for the fabrika `operate` skill, the 
 mode: subagent
 permission:
   edit: deny
+  task: allow
 ---
 
 An agent shell: the **operator** is a spawn target that exists so a driver can address the fabrika
@@ -11,4 +12,4 @@ An agent shell: the **operator** is a spawn target that exists so a driver can a
 The shell names the actor and never the skill it loads, so the `operator` shell runs the `operate`
 skill. Every step, rubric and terminal token is the skill's. Read it there.
 
-This is the opencode mirror of [`claude-plugins/fabrika/agents/operator.md`](../../claude-plugins/fabrika/agents/operator.md). opencode has no tool allowlist; the source list's load-bearing line — the lane loop mutates GitHub state through verbs, never repo files — survives as `permission: edit deny`.
+This is the opencode mirror of [`claude-plugins/fabrika/agents/operator.md`](../../claude-plugins/fabrika/agents/operator.md). opencode has no tool allowlist, so the source list's two load-bearing lines survive as permission rules: the lane loop mutates GitHub state through verbs and never repo files (`edit: deny`), and every route in the loop is a spawn of another shell (`task: allow`). The `task` grant is not cosmetic — opencode denies the task tool to every spawned subagent whose own definition names no `task` rule, so without this line the operator's toolset carries no spawn primitive at all ([#6980](https://github.com/kamp-us/phoenix/issues/6980); the mechanism is in [docs/agent-shells.md](../../claude-plugins/fabrika/docs/agent-shells.md)).

--- a/claude-plugins/fabrika/docs/agent-shells.md
+++ b/claude-plugins/fabrika/docs/agent-shells.md
@@ -79,6 +79,35 @@ bundle, which also carries `aliases: ["Task"]`. Both strings grant the tool; `Ag
 choice. An unrecognised `tools:` entry drops silently — no warning, no non-zero exit — so a grant
 is proven by spawning, not by the file parsing.
 
+### The opencode mirror spells the same grant `task: allow`
+
+The mirrors under [`../../../.opencode/agent/`](../../../.opencode/agent/) carry no `tools:` list,
+because opencode has no tool allowlist. It has something that bites harder: **a spawned subagent is
+denied the task tool unless its own definition names a `task` rule.** So the ADR 0311 baseline is
+not free here — a mirror that says nothing about `task` ships an operator that cannot dispatch
+anything, which is what [#6980](https://github.com/kamp-us/phoenix/issues/6980) hit.
+
+Read at opencode `v1.18.21`, the pinned version, the chain is three hops:
+
+1. `packages/opencode/src/agent/subagent-permissions.ts` — `deriveSubagentSessionPermission` appends
+   `{permission: "task", pattern: "*", action: "deny"}` to the child session unless the subagent's
+   own ruleset carries a rule whose `permission` is the exact string `task`. The `"*": "allow"`
+   default every agent inherits does not satisfy that check; it is string equality, not a wildcard
+   match.
+2. `packages/opencode/src/session/llm/request.ts` — `resolveTools` merges the agent's ruleset with
+   the session's and drops whatever `Permission.disabled` names.
+3. `packages/opencode/src/permission/index.ts` — `disabled` hides any tool whose last matching rule
+   is pattern `*` with action `deny`.
+
+`subagent_depth` is a separate, later gate inside the task tool's own body
+(`packages/opencode/src/tool/task.ts`): it decides whether a *call* is allowed, and never puts a
+hidden tool back. A repo running the fabrika shells needs both — `task: allow` on the operator
+mirror, and `subagent_depth` of at least `2` in `opencode.json`, since the operator is already one
+level down when it spawns.
+
+`opencode debug agent operator` will not show this. It resolves against the agent ruleset alone, so
+it prints `task: true` either way; the deny is injected into the *session* at spawn time.
+
 ## Fields a plugin-scope shell may not use
 
 `permissionMode:`, `hooks:` and `mcpServers:` are dropped for plugin-scope agent definitions with

--- a/packages/fabrika-opencode/README.md
+++ b/packages/fabrika-opencode/README.md
@@ -28,10 +28,18 @@ The plugin's `config()` hook runs at startup and:
 - registers each bundled agent shell as a subagent — the shell markdown under `dist/agents/`
   becomes the agent's prompt;
 - appends the bundled skills dir (`dist/skills/`) to `skills.paths`, leaving paths you
-  already configured in place.
+  already configured in place;
+- raises `subagent_depth` to `2` if you have it lower or unset.
 
 Agent shells that share a name with one of your own agents resolve to the plugin's
 definition; rename yours if you need both.
+
+The depth raise is not a preference. The `operator` shell drives a lane by spawning the
+other shells, and it is already one level down when it does — opencode's default depth of
+`1` refuses that call, so every lane stalls with work recorded and no builder running
+(issue [#6980](https://github.com/kamp-us/phoenix/issues/6980)). The `operator` mirror
+pairs it with a `task: allow` permission, without which opencode strips the spawn tool
+from any subagent whose definition does not name `task`.
 
 ## Fallback: clone-and-point
 

--- a/packages/fabrika-opencode/src/agents.unit.test.ts
+++ b/packages/fabrika-opencode/src/agents.unit.test.ts
@@ -66,4 +66,11 @@ describe("authored agent shell mirrors", () => {
 		expect(shell.description).toBeTruthy();
 		expect(shell.prompt.length).toBeGreaterThan(0);
 	});
+
+	// opencode denies the task tool to any spawned subagent whose own ruleset names no `task`
+	// rule, so dropping this key leaves the operator with no spawn primitive at all (#6980).
+	it("the operator mirror declares a task permission so its spawn tool survives the spawn", () => {
+		const shell = parseAgentMarkdown(readFileSync(join(AGENT_SHELLS_DIR, "operator.md"), "utf8"));
+		expect(shell.permission?.task).toBe("allow");
+	});
 });

--- a/packages/fabrika-opencode/src/index.ts
+++ b/packages/fabrika-opencode/src/index.ts
@@ -3,15 +3,17 @@ import {dirname, join, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
 import type {Config, Plugin} from "@opencode-ai/plugin";
 import {parseAgentMarkdown} from "./agents.ts";
+import {raiseSubagentDepth} from "./subagent-depth.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const agentsDir = resolve(here, "./agents");
 const skillsDir = resolve(here, "./skills");
 
-// The runtime config schema carries `skills.paths` (opencode core v1 config; this repo's
-// own opencode.json sets it), but @opencode-ai/sdk@1.18.21's generated Config type does
-// not declare it yet — so the one key this plugin appends goes through this narrow view.
+// The runtime config schema carries `skills.paths` and `subagent_depth` (opencode core v1
+// config; this repo's own opencode.json sets both), but @opencode-ai/sdk@1.18.21's generated
+// Config type declares neither — so the keys this plugin writes go through these narrow views.
 type SkillsConfigView = {paths?: string[]};
+type DepthConfigView = {subagent_depth?: number};
 
 type AgentEntry = NonNullable<NonNullable<Config["agent"]>[string]>;
 
@@ -36,6 +38,9 @@ export const FabrikaOpenCodePlugin: Plugin = async () => {
 				skills.paths.push(skillsDir);
 			}
 			(cfg as Config & {skills?: SkillsConfigView}).skills = skills;
+
+			const depth = cfg as Config & DepthConfigView;
+			depth.subagent_depth = raiseSubagentDepth(depth.subagent_depth);
 		},
 	};
 };

--- a/packages/fabrika-opencode/src/subagent-depth.ts
+++ b/packages/fabrika-opencode/src/subagent-depth.ts
@@ -1,0 +1,13 @@
+/**
+ * The depth floor the fabrika shells need, and the one function that applies it.
+ *
+ * opencode's task tool refuses a spawn once the calling session's parent chain is already
+ * `subagent_depth` deep (`packages/opencode/src/tool/task.ts`, read at v1.18.21). The operator
+ * spawned by a primary agent sits at depth 1 and every route in its loop is a spawn of another
+ * shell, so a host repo left on opencode's default of 1 registers all eight shells and can still
+ * dispatch nothing (#6980).
+ */
+export const FABRIKA_SUBAGENT_DEPTH = 2;
+
+export const raiseSubagentDepth = (configured: number | undefined): number =>
+	Math.max(configured ?? 1, FABRIKA_SUBAGENT_DEPTH);

--- a/packages/fabrika-opencode/src/subagent-depth.unit.test.ts
+++ b/packages/fabrika-opencode/src/subagent-depth.unit.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from "vitest";
+import {FABRIKA_SUBAGENT_DEPTH, raiseSubagentDepth} from "./subagent-depth.ts";
+
+describe("raiseSubagentDepth", () => {
+	it("raises an unset depth off opencode's default of 1", () => {
+		expect(raiseSubagentDepth(undefined)).toBe(FABRIKA_SUBAGENT_DEPTH);
+	});
+
+	it("raises a host depth below the floor", () => {
+		expect(raiseSubagentDepth(1)).toBe(FABRIKA_SUBAGENT_DEPTH);
+	});
+
+	it("leaves a host depth at or above the floor alone", () => {
+		expect(raiseSubagentDepth(2)).toBe(2);
+		expect(raiseSubagentDepth(4)).toBe(4);
+	});
+});


### PR DESCRIPTION
The `operator` shell under opencode had no spawn tool, so an epic lane could claim and boot and then stall forever at dispatch. This grants it the one permission rule opencode checks for, and raises the depth floor the shipped plugin needs.

Part of #6980

## The diagnosis

Read at opencode `v1.18.21`, the version this repo pins in `pnpm-workspace.yaml` and the version installed locally. Three hops, all in `packages/opencode/src`:

1. `agent/subagent-permissions.ts` — `deriveSubagentSessionPermission` appends `{permission: "task", pattern: "*", action: "deny"}` to a spawned subagent's **session** ruleset unless the subagent's own ruleset carries a rule whose `permission` is the exact string `task`. `tool/task.ts` appends the same deny a second time when building the child session. The `"*": "allow"` default every agent inherits does not satisfy that check: it is string equality on the rule's `permission` field, not a wildcard match.
2. `session/llm/request.ts` — `resolveTools` merges the agent ruleset with the session ruleset and drops whatever `Permission.disabled` names.
3. `permission/index.ts` — `disabled` hides any tool whose last matching rule is pattern `*` with action `deny`.

So the tool is not refused at call time, it is removed from the toolset before the model ever sees it. That matches the reported symptom exactly: bash, glob, grep, read, skill, webfetch, websearch and no task tool. `todowrite` goes the same way, for the same reason.

`subagent_depth: 2` was never the missing piece. That value is read inside the task tool's own body (`tool/task.ts`), so it decides whether a *call* is allowed and never puts a hidden tool back.

The limitation is not upstream: opencode gives a shell the way to say it. The mirrors just never said it, because the note in each of them ("opencode has no tool allowlist") read the absence of a `tools:` list as meaning nothing needed carrying over, and ADR 0311's baseline `Agent` grant had no opencode counterpart.

### Verified against the pinned binary

`opencode debug agent operator` on this branch resolves the operator with `[{"permission":"task","action":"allow","pattern":"*"}]`, which is the exact rule the `.some()` check above looks for. The unchanged `reviewer` mirror resolves with an empty task-rule list, which is the pre-fix operator state.

One trap worth recording: that command prints `tools.task: true` for **both** shells. It resolves against the agent ruleset alone (`cli/cmd/debug/agent.handler.ts`), and the deny is injected into the session at spawn time, so it cannot see this bug. Do not use it as the proof; read the rule list.

## What changed

- `.opencode/agent/operator.md` — `task: allow` in the permission block, and the mirror note now says why both rules are there.
- `packages/fabrika-opencode/src/subagent-depth.ts` (new) — raises a host repo's `subagent_depth` to at least 2. This repo's own `opencode.json` already sets it, but a consumer installing the plugin gets opencode's default of 1, and an operator spawned by a primary agent is already at depth 1, so every dispatch would fail the depth check with the shells registered and looking fine.
- `packages/fabrika-opencode/src/index.ts` — applies that floor in the config hook, through the same narrow-view cast the file already uses for `skills.paths` (the SDK's generated `Config` type declares neither key at 1.18.21).
- `packages/fabrika-opencode/src/agents.unit.test.ts` — a regression guard that the operator mirror declares the `task` rule.
- `claude-plugins/fabrika/docs/agent-shells.md`, `packages/fabrika-opencode/README.md` — the mechanism and the depth requirement, so the next reader of "which shells carry a spawn tool" is not told the opencode side is free.

Unit suite: 18 passing. `build check` green on `--surface code` and `--surface prose`; every changed file is covered by one of the two.

## Deviations

- **Known defect left unfixed** — **Said:** criterion 4 asks for one epic lane drive re-run end to end under opencode, or the exact stall state recorded. **Did:** verified the fix against the pinned opencode binary's own agent resolution, but ran no epic lane drive. **Why:** a lane drive from a build lane would claim a real epic, spawn shells and mutate board state, which is outside this lane's capability set. **Disposition:** stated here; the run belongs to whoever next drives a lane under opencode, and #6980 stays open for it.
- **Out-of-scope change** — **Said:** #6980 names the operator shell's dispatch. **Did:** also raised `subagent_depth` in the shipped plugin. **Why:** criterion 2 names `packages/fabrika-opencode/` as a landing surface, and without the floor a consumer repo gets the `task` grant and still cannot dispatch, so the fix would only work in this repo. **Disposition:** stated here.
- **Scope narrowing** — **Said:** ADR 0311 makes the spawn-tool grant baseline for every shell. **Did:** granted `task` on the operator only. **Why:** at depth 2 a shell the operator spawns is already at the limit, so the grant would be inert on the other seven; closing that parity gap means deciding whether to raise the depth further, which is a separate call. **Disposition:** filed as a follow-up.
