### PR TITLE
fix: Nothing in fabrika names the merge ref, so a repair lane can "disprove" a real CI red at the head

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -469,6 +469,31 @@ UNKNOWN exit means the verdict state is unread — **never "nothing to fix"**. T
 fold's own `capReached` field, never a number you carry: on `true`, end `ESCALATED` and post the
 escalation via `fabrika build note <repair-pr> --token <claim-token>` instead of another push.
 
+**A CI red is produced from the merge ref, not from your head — reproduce it there before you call
+it false.** A `pull_request`-triggered workflow runs with `GITHUB_REF` set to `refs/pull/<n>/merge`
+and `GITHUB_SHA` set to that merge commit — the prospective merge of your head into the base — so a
+plain `actions/checkout` builds the *merged* tree while every check run it produces is labelled with
+the head SHA
+([GitHub, "Events that trigger workflows", `pull_request`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)).
+A job that pins `ref:` to the head sha is the exception and reads what its name says. So a failure
+you cannot reproduce at the head is **not thereby a false finding**: fetch the merge ref, reproduce
+it there, and only a failure absent from *that* tree is one to report.
+
+```bash
+git fetch origin refs/pull/<n>/merge && git checkout FETCH_HEAD
+```
+
+That ref is recomputed as base moves, so the tree you fetch is the merge of your head with base
+*now* — the same tree CI used only if nothing landed since, and absent entirely while the PR is
+conflicted. Neither case makes the red false; both mean you have not reproduced it yet.
+
+The shape that puts you here carries no textual conflict to warn you: a branch renames a symbol
+while main adds call sites on the old name, git merges both sides clean, and the merged file defines
+the new name and calls the old one. It is invisible in the head blob and invisible in the diff, and
+it exists only in the merge ref. Epic #6629's PR #6690 spent a whole repair round filing that
+correct FAIL as a gate misreading its own SHA
+([#6794](https://github.com/kamp-us/phoenix/issues/6794)).
+
 **A founder can clear one more round, and you read that through the same field.** The clearance is
 data on the PR — an authorized account records it with `fabrika build clear`, and the fold counts it,
 so `capReached: false` beside a `clearances` row *is* the granted round and you simply build it. What

--- a/claude-plugins/fabrika/skills/heal-ci/SKILL.md
+++ b/claude-plugins/fabrika/skills/heal-ci/SKILL.md
@@ -148,6 +148,15 @@ flake. There is no path from an ambiguous log to "safe to rerun". Each token lic
 Only **gating** reds reach this lane — an informational context is red without blocking anything,
 and treating one as healable is how a non-failure stalled a mergeable PR.
 
+**The logs you are classifying came from `refs/pull/<n>/merge`, not from the PR's head.** A
+`pull_request` workflow builds the prospective merge of head into base and labels the runs with the
+head SHA, so a `logic` red naming a symbol or a line nobody can find at the head is still a real
+failure of the tree that must merge — the head being clean disproves nothing, and reclassifying on
+that basis is how a correct FAIL gets filed as a gate misreading its own SHA
+([#6794](https://github.com/kamp-us/phoenix/issues/6794)). Route it to repair as the `logic` it is;
+reproducing it against that ref is the repair lane's step, stated with its citation and worked
+example in [`build`'s Repair section](../build/SKILL.md#repair).
+
 ## 4 — The one rerun, and why the verb owns the guard
 
 ```bash

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -164,6 +164,14 @@ reporting on its own trigger. Treat that `16` as a blocked read, not a verdict �
 runs before anything can be judged on it, so end the class on `UNKNOWN — the artifact could not
 be read`, naming the `16`, rather than grading around it.
 
+**"At the head" names how those runs are keyed, not the tree they judged.** A `pull_request`
+workflow builds `refs/pull/<n>/merge` — this head merged into base — and labels every run it
+produces with the head SHA, so the read is at-head by key and merge-ref by content. That gap is why
+a red here can be real while the head blob is clean, and why disproving one takes a reproduction
+against that ref rather than a look at the head. The full statement, its citation and the worked
+example live in [`build`'s Repair section](../build/SKILL.md#repair); do not re-derive them, and
+never grade a red as the gate misreading its own SHA.
+
 **A queued aggregator is waited out by the verb, never by you on a timer.** You are normally spawned
 minutes after the push, so a `pending` is the ordinary read, not a pathology — and the wait it opens
 is exactly the gap


### PR DESCRIPTION
Three fabrika skills said "CI at head" and nothing said which tree those runs were built from. A
`pull_request` workflow builds `refs/pull/<n>/merge` and labels the runs with the head SHA, so a red
can be real while the head blob is clean. A repair lane hit exactly that on PR #6690, checked out
the head, found nothing, and filed the correct FAIL as a gate misreading its own SHA.

What changed, all prose:

- `build/SKILL.md` Repair — the full statement, cited to GitHub's own "Events that trigger
  workflows" docs, the `git fetch origin refs/pull/<n>/merge` line to reproduce against, the caveat
  that the ref is recomputed as base moves (and is absent while conflicted), and the rename-collision
  worked example: a branch renames a symbol while main adds call sites on the old name, git merges
  clean, and the break lives only in the merge ref.
- `review/SKILL.md` — "at the head" is now stated as how the runs are keyed, not the tree they
  judged, pointing at build's Repair section rather than restating it.
- `heal-ci/SKILL.md` §3 — the logs being classified came from the merge ref, so a `logic` red naming
  a line absent at the head is still real and routes to repair unchanged.

No behaviour change: `packages/fabrika-cli/src/review/ci-verb.ts` is untouched.

Fixes #6794

## Deviations

None.
