### PR TITLE
feat: No verb retires a superseded epic-child lane branch, so ADR 0324's ruling has no implementation

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -550,8 +550,14 @@ tiebreak to your own prior claim and refuses on `15`.
 `--resume` is checked against the board, not trusted: on a child holding no standing `FAIL` the claim
 step refuses on `31`, so the entry can never be run past the fence. `--resume-lane` **re-keys** the
 branch the prior lane built on to this claim's nonce instead of cutting a second one — two branches
-carrying one child's commits is the range `lane prove` calls underivable, and that refusal cannot be
-cleared from inside a worktree. It refuses on `7` when no branch in this clone's refs was cut for the
+carrying one child's commits is the range `lane prove` calls underivable. **A clone already in that
+state has one move, and it is yours to take**: `fabrika build retire-branch <n>` renames the
+superseded branches out of `build/` — never deletes them — so one carrying branch is left and the
+range locates (ADR [0324](../../../../.decisions/0324-retire-superseded-lane-branch.md)). It picks
+the survivor off the board, so it refuses on `34` rather than guess when no authorized claim marker
+carries a candidate's lane nonce, and on `33` when a worktree still holds a branch it would rename,
+naming `fabrika build retire` as the act that clears that hold.
+`--resume-lane` refuses on `7` when no branch in this clone's refs was cut for the
 number — refs are shared across every worktree, so that means the branch is gone, not that you are
 standing in the wrong tree — and on `11` when another worktree still holds the branch, which it
 proves **before** re-keying: `git branch -m` does not refuse there, it renames the branch out from

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -347,6 +347,8 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `30` | proven: not admitted on the type axis — the issue is `type:decision` or `type:epic`, whose deliverable is not a pull request a build lane produces |
 | `31` | proven: the claim's mode and the child's standing range verdict disagree — a fresh build over a child holding a `FAIL`, or a `--resume` over a child holding none |
 | `32` | proven: not admitted on the criteria axis — the issue body carries no readable `### Acceptance criteria` block, absent or malformed, so there is no contract to build against |
+| `33` | proven: a working tree of this clone holds the lane branch, and the board licenses no release of it |
+| `34` | proven: no authorized claim marker attests a single survivor among a child's lane branches, so none is superseded |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -1504,7 +1506,7 @@ number, which is the number repair mode claims.
 | `build branch: --resume-lane takes over the local branch of an epic child, which has no PR — it cannot be combined with --resume <pr>.` | 10 | refusal |
 | `build branch: --resume-lane reads the slug off the branch it takes over — drop --slug "<value>".` | 10 | refusal |
 | `build branch: no branch anywhere in this clone's refs was cut for #<n> — the build to resume is gone. …` | 7 | refusal |
-| `build branch: <a>, <b> were all cut for #<n> — which one this lane resumes is not derivable here; retire the superseded branches, then re-run.` | 11 | refusal |
+| `build branch: <a>, <b> were all cut for #<n> — which one this lane resumes is not derivable here; retire the superseded branches with "fabrika build retire-branch <n>", which renames them out of build/ without deleting anything (ADR 0324), then re-run.` | 11 | refusal |
 | `build branch: <branch> is checked out in the worktree <path>, so re-keying it here would rename the branch out from under that lane rather than fail — retiring or releasing that worktree is an operator's act, not this lane's. Nothing was changed.` | 11 | refusal |
 | `build branch: cannot read which worktree holds <branch>: <reason> — re-keying it could silently retarget another lane's HEAD, so whether the take-over is safe is UNKNOWN; nothing was changed.` | 11 | refusal |
 | `build branch: cannot re-key <old> to <new>: <reason> — nothing was changed.` | 11 | refusal |

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -208,6 +208,14 @@ Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build
 | `build verdicts` | the latest gate verdict per namespace at a PR's live head |
 | `build clear` | the founder's clearance of one extra repair round |
 | `build reap` | which finished `.claude/worktrees/agent-*` trees are provably safe to remove — a dry run unless `--execute` |
+| `build retire-branch` | which of an epic child's lane branches the board attests to, and the rename that moves the rest out of `build/` |
+
+`build retire-branch` is the recovery ADR [0324](../../.decisions/0324-retire-superseded-lane-branch.md)
+rules for a clone already in the two-branch state, where `lane prove` refuses because two branches
+carry one child's commits. It **renames** the superseded ones into `retired/` and deletes nothing, so
+a mistaken retirement costs a rename back rather than a child's only copy of its work. The survivor
+is the candidate whose lane nonce an authorized claim marker carries — where the board attests none,
+or attests two, it renames nothing and refuses.
 
 `build reap` is the bulk counterpart to `build retire`. `retire` targets the trees holding ONE
 number's lane branch and needs a board statement to release them; `reap` sweeps the whole agent
@@ -225,7 +233,9 @@ outside all three surfaces' validators · `23` the local head would drop publish
 `24` `git commit` ran and HEAD did not move · `25` this account may not clear a cap · `26` the
 quoted authorization is empty or undated · `29` the grant is on the PR and the local lane did not
 take it · `30` the deliverable is not a pull request a build lane produces · `31` the claim's mode
-and the child's standing verdict disagree. `12` is a retired seat.
+and the child's standing verdict disagree · `32` the issue body carries no readable acceptance
+criteria · `33` a working tree holds the lane branch and the board licenses no release · `34` the
+board attests no single survivor among a child's lane branches. `12` is a retired seat.
 
 ## The `ci` group
 

--- a/packages/fabrika-cli/src/build/branch-verb.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.ts
@@ -195,7 +195,7 @@ export const runBranch = (
 			if (rest.length > 0) {
 				return refuse(
 					PRECONDITION_UNKNOWN,
-					`${VERB}: ${candidates.join(", ")} were all cut for #${issue} — which one this lane resumes is not derivable here; retire the superseded branches, then re-run.`,
+					`${VERB}: ${candidates.join(", ")} were all cut for #${issue} — which one this lane resumes is not derivable here; retire the superseded branches with "fabrika build retire-branch ${issue}", which renames them out of build/ without deleting anything (ADR 0324), then re-run.`,
 					held.notes,
 				);
 			}

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -197,3 +197,14 @@ export const NO_ACCEPTANCE_CRITERIA = 32;
  * is standing where you need to be, with the board declining to move it.
  */
 export const WORKTREE_HELD = 33;
+/**
+ * Proven: the board attests no survivor among a child's lane branches, so none is superseded.
+ *
+ * A *proven* refusal about the board — the markers were read in full and the ACL resolved — so it
+ * never borrows {@link PRECONDITION_UNKNOWN}. Its own seat rather than {@link CLAIM_NOT_MINE}'s:
+ * `15` is about the caller's own claim, and this verb runs against a branch its lane never cut, so
+ * whether the caller holds anything is not the question. The remedy is unlike every neighbour's —
+ * the live lane re-claims through `build resume-child`, and until some authorized marker carries a
+ * candidate's lane nonce there is nothing to rename (ADR 0324).
+ */
+export const SURVIVOR_UNATTESTED = 34;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -38,6 +38,7 @@ import {runPr, runPrBody} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
 import {runReap} from "./reap-verb.ts";
 import {runResumeChild} from "./resume-child-verb.ts";
+import {runRetireBranch} from "./retire-branch-verb.ts";
 import {runRetire} from "./retire-verb.ts";
 import {
 	ADMISSION_EXIT_CODES,
@@ -267,6 +268,19 @@ const retire = leafCommand(
 	Command.withShortDescription("Take back the checkout an orphaned build worktree is holding."),
 	Command.withDescription(
 		'Retire the working trees of this clone that hold #<n>\'s lane branch, so a repair lane refused at "build branch --resume-lane" can stand where it needs to (ADR 0323). Two licenses, both written positive board states and never an inference from a tree that looks idle: the ticket is TERMINAL (a closed issue, a merged PR), or an authorized ADR 0295 build-adopt marker on #<n> names the session whose claim carries that branch\'s lane nonce. DIRTINESS IS NOT A REFUSAL — an agent routinely leaves a worktree dirty after its ticket merged — and it costs nobody their only copy either: ADR 0321\'s salvage runs first, committing whatever the tree holds uncommitted onto its own branch, and only then is the tree removed WITHOUT --force, which that ADR bans on every path. A removal that still refuses (a locked tree does, however clean) is reported as an incident to file, never overridden. The removal takes the tree, never the branch. It first prunes registrations whose directory is already gone, never removes the tree the run is standing in, and reads every removal back off a second worktree list. A worktree-isolated caller may run it — the harness rule that refuses a typed cross-worktree git does not bind a verb\'s own child process. Prints {"answer":"retired"|"held"|"none","number":n,"retired":[…],"held":[…]}. Exits 7 (#<n> proven absent), 8 (the salvage or the removal failed — UNKNOWN), 9 (git reported a removal and the registration survives), 11 (a precondition read failed), 33 (a tree still holds the branch and the board licenses no release). Example: fabrika build retire 6567',
+	),
+);
+
+const retireBranch = leafCommand(
+	"retire-branch",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runRetireBranch({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Retire an epic child's superseded lane branches out of build/."),
+	Command.withDescription(
+		'Clear the two-branch deadlock on epic child #<n> by RENAMING each superseded lane branch out of the build/ namespace into retired/ (ADR 0324). NO PATH OF THIS VERB DELETES A BRANCH: after the rename every commit is still there and still reachable by the new name, so a mistaken retirement costs a rename back rather than the work — which matters because a child opens no PR (ADR 0285) and its branch is the only copy. WHICH BRANCH IS SUPERSEDED IS PROVEN, NEVER GUESSED: the survivor is the candidate whose lane nonce an AUTHORIZED claim marker on #<n> carries, and where no marker attests one — or where several do — nothing is renamed and the verb refuses. Before any rename it proves no working tree of this clone holds a branch it is about to move: `git branch -m` does not refuse a held branch, it renames and silently retargets that tree\'s HEAD. Fewer than two branches is not a deadlock — zero is a refusal, one answers "none". Every rename is read back off a second local-branch read. A worktree-isolated lane may run it against a branch it never cut; refs are shared across every worktree of a clone. Prints {"answer":"retired"|"none","number":n,"survivor":"<branch>","retired":[{"from":…,"to":…}]}. Exits 7 (no branch in this clone was cut for #<n>), 8 (git refused a rename — UNKNOWN), 9 (git reported a rename and the read-back disagrees), 11 (a precondition read failed), 33 (a working tree holds a branch to be renamed — clear it with fabrika build retire <n>), 34 (the board attests no single survivor). Example: fabrika build retire-branch 6296',
 	),
 );
 
@@ -761,6 +775,7 @@ export const buildCommand = Command.make("build").pipe(
 		release,
 		adopt,
 		retire,
+		retireBranch,
 		reap,
 		issue,
 		branch,

--- a/packages/fabrika-cli/src/build/retire-branch-verb.ts
+++ b/packages/fabrika-cli/src/build/retire-branch-verb.ts
@@ -1,0 +1,198 @@
+/**
+ * `build retire-branch` — clear the two-branch deadlock on an epic child by renaming the superseded
+ * lane branches out of `build/`.
+ *
+ * The residue this clears is #6296 / #6298: two local branches both carry one child's commits,
+ * `traceRange` answers `Many`, `locateRange` maps that to `Ambiguous`, and `lane prove` refuses
+ * because which range the lane built is not derivable. `build branch --resume-lane` already printed
+ * the remedy and nothing performed it. ADR 0324 is the ruling; this is the verb.
+ *
+ * The order is the contract:
+ *
+ *   1. This clone's local branches are read, and `childLaneBranches` (`./lane.ts`, never a second
+ *      regex) nominates exactly the candidate set `locateRange` nominates.
+ *   2. Fewer than two candidates is not a deadlock: zero is `ZERO_SCOPE`, one answers `none`.
+ *   3. The board's authorized claim markers are read once, and {@link supersede} seats the
+ *      candidates against them. **Nothing is renamed on an `Unattested`** — a survivor nobody
+ *      attests to would be a guess, and a wrong guess moves the only copy of a child's work.
+ *   4. Stale worktree registrations are pruned, and no branch about to be renamed may be checked
+ *      out anywhere. `renameBranch` (`./git.ts`) exits 0 on a held branch and silently retargets
+ *      that worktree's `HEAD`, so skipping this proof is destructive in the one way ADR 0324 bans.
+ *   5. Each superseded branch is renamed into `retired/`. **No path here deletes a branch** — the
+ *      commits survive, and a mistaken retirement costs a rename back rather than the work.
+ *   6. Every rename is read back off a second `localBranches` — a retirement this verb reports is
+ *      one it proved, never one `git` exited 0 on.
+ *
+ * A worktree-isolated lane may run it against a branch it never cut: every step is a read or a
+ * rename in the shared ref store, and refs are common to every worktree of a clone.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {localBranches} from "../io/git.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {readClaimants} from "./claim.ts";
+import {
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	SURVIVOR_UNATTESTED,
+	WORKTREE_HELD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {pruneWorktrees, renameBranch, worktreeCheckouts} from "./git.ts";
+import {childLaneBranches} from "./lane.ts";
+import {sessionsByNonce} from "./retire.ts";
+import {retiredBranchName, supersede} from "./retire-branch.ts";
+import {badNumber, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "fabrika build retire-branch";
+
+export interface RetireBranchOptions {
+	/** The epic child whose lane branches are in the two-branch state. */
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+type Deps = ChildProcessSpawner.ChildProcessSpawner;
+
+interface Retired {
+	readonly from: string;
+	readonly to: string;
+}
+
+export const runRetireBranch = (
+	options: RetireBranchOptions,
+): Effect.Effect<VerbOutcome, never, Deps> =>
+	Effect.gen(function* () {
+		const {number} = options;
+		const bad = badNumber(VERB, "an issue number", number);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {repo} = resolved;
+
+		const branches = yield* localBranches;
+		if (branches._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read this clone's local branches: ${branches.reason} — which branches were cut for #${number} is UNKNOWN; nothing was renamed.`,
+			);
+		}
+		const candidates = childLaneBranches(number, branches.value);
+		const scope = scannedLine(
+			VERB,
+			branches.value.length,
+			"local branch",
+			`${candidates.length} cut for #${number}`,
+		);
+		if (candidates.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: no branch in this clone's refs was cut for #${number} — there is no lane branch to retire.`,
+				[scope],
+			);
+		}
+		if (candidates.length === 1) {
+			return answer(
+				JSON.stringify({answer: "none", number, survivor: candidates[0], retired: []}),
+				[
+					scope,
+					`${VERB}: ${candidates[0]} is the only branch cut for #${number} — the range is already derivable, and nothing is superseded.`,
+				],
+			);
+		}
+
+		const claimants = yield* readClaimants(repo, number);
+		if (claimants._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the claim markers on #${number}: ${claimants.reason} — which branch a live lane cut is UNKNOWN, never "none of them"; nothing was renamed.`,
+				[scope],
+			);
+		}
+		const seated = supersede(number, candidates, sessionsByNonce(claimants.claimants));
+		if (seated._tag === "Unattested") {
+			return refuse(
+				SURVIVOR_UNATTESTED,
+				`${VERB}: ${seated.why} — nothing was renamed, because a survivor picked without an attestation is a guess, and a child's branch is the only copy of its work (ADR 0324).`,
+				[scope],
+			);
+		}
+
+		const pruned = yield* pruneWorktrees;
+		if (pruned._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot prune this clone's worktree registrations: ${pruned.reason} — which trees hold #${number}'s lane branches is UNKNOWN; nothing was renamed.`,
+				[scope],
+			);
+		}
+		const checkouts = yield* worktreeCheckouts;
+		if (checkouts._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read which working tree holds what: ${checkouts.reason} — whether one holds a branch about to be renamed is UNKNOWN; nothing was renamed.`,
+				[scope],
+			);
+		}
+		const held = checkouts.value.filter((checkout) => seated.superseded.includes(checkout.branch));
+		const [first] = held;
+		if (first !== undefined) {
+			return refuse(
+				WORKTREE_HELD,
+				`${VERB}: ${held.map((row) => `${row.path} holds ${row.branch}`).join("; ")} — git renames a held branch without refusing and silently retargets that tree's HEAD, so nothing was renamed. Take that checkout back first: fabrika build retire ${number}.`,
+				[scope],
+			);
+		}
+
+		const retired: Array<Retired> = [];
+		for (const from of seated.superseded) {
+			const to = retiredBranchName(from);
+			if (to === null) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: "${from}" is not in the build/ namespace, so there is no name to retire it to — nothing further was renamed.`,
+					[scope],
+				);
+			}
+			const renamed = yield* renameBranch(from, to);
+			if (renamed._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: git refused to rename ${from} to ${to}: ${renamed.reason} — whether that branch moved is UNKNOWN. ${retired.length} branch(es) were retired before it.`,
+					[scope],
+				);
+			}
+			retired.push({from, to});
+		}
+
+		const after = yield* localBranches;
+		if (after._tag === "Failure") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: ${retired.length} branch(es) were renamed and this clone's branches could not be read back: ${after.reason} — the retirement is NOT proven.`,
+				[scope],
+			);
+		}
+		const unproven = retired.find(
+			(row) => after.value.includes(row.from) || !after.value.includes(row.to),
+		);
+		if (unproven !== undefined) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: git reported ${unproven.from} renamed to ${unproven.to} and the read-back disagrees — the retirement is NOT proven, and this clone needs a human.`,
+				[scope],
+			);
+		}
+
+		return answer(JSON.stringify({answer: "retired", number, survivor: seated.survivor, retired}), [
+			scope,
+			...retired.map(
+				(row) =>
+					`${VERB}: retired ${row.from} — renamed to ${row.to}, never deleted, so every commit it carries is still reachable by that name.`,
+			),
+			`${VERB}: ${seated.survivor} is the survivor — an authorized claim marker on #${number} carries its lane nonce.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/build/retire-branch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/retire-branch-verb.unit.test.ts
@@ -1,0 +1,243 @@
+import {readFileSync} from "node:fs";
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeSeams, okOut, once, type Scripted} from "../fakes.test-support.ts";
+import {
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	SURVIVOR_UNATTESTED,
+	WORKTREE_HELD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	comments,
+	GH_TOKEN_ENV,
+	LANE_UUID,
+	marker,
+	NONCE,
+	SIBLING_NONCE,
+	SIBLING_UUID,
+	served,
+} from "./fixtures.test-support.ts";
+import {RETIRED_PREFIX} from "./retire-branch.ts";
+import {runRetireBranch} from "./retire-branch-verb.ts";
+
+const BRANCHES = /^git for-each-ref --format=%\(refname:short\) refs\/heads$/;
+const PRUNE = /^git worktree prune$/;
+const TREES = /^git worktree list --porcelain$/;
+const RENAME = /^git branch -m /;
+const COMMENTS = /^GET \S+\/repos\/o\/r\/issues\/6296\/comments/;
+const PERM = /^GET \S+\/repos\/o\/r\/collaborators\/agent\/permission/;
+
+const LIVE = `build/6296-editor-focus-loss-${NONCE}`;
+const STALE = `build/6296-editor-focus-loss-${SIBLING_NONCE}`;
+const RETIRED = `${RETIRED_PREFIX}6296-editor-focus-loss-${SIBLING_NONCE}`;
+
+const options = {
+	number: 6296,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", ...GH_TOKEN_ENV} as Record<string, string | undefined>,
+};
+
+const refs = (...names: ReadonlyArray<string>) => okOut([...names, "main"].join("\n"));
+
+/** `git worktree list --porcelain`, as blocks of `worktree`/`HEAD`/`branch` lines. */
+const trees = (...held: ReadonlyArray<{path: string; branch: string}>) =>
+	okOut(
+		held
+			.map((tree) => `worktree ${tree.path}\nHEAD 0000000\nbranch refs/heads/${tree.branch}\n`)
+			.join("\n"),
+	);
+
+/** One authorized claim marker on #6296, carrying the live lane's nonce. */
+const CLAIMED: ReadonlyArray<Scripted> = [
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, served({permission: "write"})],
+];
+
+const run = (script: ReadonlyArray<Scripted>) => {
+	const shell = fakeSeams(script);
+	return Effect.runPromise(Effect.provide(runRetireBranch(options), shell.layer)).then((out) => ({
+		out,
+		calls: shell.calls,
+	}));
+};
+
+describe("runRetireBranch — the attested survivor", () => {
+	it("renames the unattested branch out of build/ and reads the rename back", async () => {
+		const {out, calls} = await run([
+			[once(BRANCHES), refs(STALE, LIVE)],
+			...CLAIMED,
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/repo", branch: "main"})],
+			[RENAME, okOut("")],
+			[BRANCHES, refs(RETIRED, LIVE)],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "retired",
+			number: 6296,
+			survivor: LIVE,
+			retired: [{from: STALE, to: RETIRED}],
+		});
+		expect(calls).toContain(`git branch -m ${STALE} ${RETIRED}`);
+	});
+
+	it("proves no worktree holds a branch it is about to rename, BEFORE renaming it", async () => {
+		const {calls} = await run([
+			[once(BRANCHES), refs(STALE, LIVE)],
+			...CLAIMED,
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/repo", branch: "main"})],
+			[RENAME, okOut("")],
+			[BRANCHES, refs(RETIRED, LIVE)],
+		]);
+
+		expect(calls.findIndex((line) => TREES.test(line))).toBeLessThan(
+			calls.findIndex((line) => RENAME.test(line)),
+		);
+	});
+
+	it("refuses a held branch and names the act that clears the hold", async () => {
+		const {out, calls} = await run([
+			[BRANCHES, refs(STALE, LIVE)],
+			...CLAIMED,
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/trees/agent-a9bd", branch: STALE})],
+		]);
+
+		expect(out.code).toBe(WORKTREE_HELD);
+		expect(out.stderr.join("\n")).toContain("fabrika build retire 6296");
+		expect(calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+});
+
+describe("runRetireBranch — a survivor nobody attests to is never guessed", () => {
+	it("renames nothing when no authorized marker carries a candidate's lane nonce", async () => {
+		const {out, calls} = await run([
+			[BRANCHES, refs(STALE, LIVE)],
+			[COMMENTS, comments()],
+		]);
+
+		expect(out.code).toBe(SURVIVOR_UNATTESTED);
+		expect(out.stderr.join("\n")).toMatch(/no authorized claim marker/);
+		expect(calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+
+	it("counts no marker from an account below write — content is not authority (ADR 0055)", async () => {
+		const {out} = await run([
+			[BRANCHES, refs(STALE, LIVE)],
+			[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+			[PERM, served({permission: "read"})],
+		]);
+
+		expect(out.code).toBe(SURVIVOR_UNATTESTED);
+	});
+
+	it("renames nothing when two candidates are each attested by a live claim", async () => {
+		const {out, calls} = await run([
+			[BRANCHES, refs(STALE, LIVE)],
+			[
+				COMMENTS,
+				comments(
+					{id: 1, body: marker("s-9f2e", LANE_UUID)},
+					{id: 2, body: marker("s-other", SIBLING_UUID)},
+				),
+			],
+			[PERM, served({permission: "write"})],
+		]);
+
+		expect(out.code).toBe(SURVIVOR_UNATTESTED);
+		expect(calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+
+	it("is UNKNOWN when the claim markers cannot be read — never 'nobody attests'", async () => {
+		const {out, calls} = await run([
+			[BRANCHES, refs(STALE, LIVE)],
+			[COMMENTS, {status: 502, body: '{"message":"Bad gateway"}'}],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toMatch(/never "none of them"/);
+		expect(calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+});
+
+describe("runRetireBranch — fewer than two branches is not a deadlock", () => {
+	it("answers none on a single candidate, reading no board state at all", async () => {
+		const {out, calls} = await run([[BRANCHES, refs(LIVE)]]);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "none", survivor: LIVE, retired: []});
+		expect(calls.some((line) => COMMENTS.test(line))).toBe(false);
+	});
+
+	it("is ZERO_SCOPE when no branch in this clone was cut for the child", async () => {
+		const {out} = await run([[BRANCHES, refs()]]);
+
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("is UNKNOWN when the local branches cannot be read", async () => {
+		const {out} = await run([[BRANCHES, errOut("not a git repository")]]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});
+
+describe("runRetireBranch — the rename is proven, never reported", () => {
+	it("is WRITE_UNKNOWN when git refuses the rename", async () => {
+		const {out} = await run([
+			[BRANCHES, refs(STALE, LIVE)],
+			...CLAIMED,
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/repo", branch: "main"})],
+			[RENAME, errOut(`a branch named '${RETIRED}' already exists`)],
+		]);
+
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("is READBACK_MISMATCH when git exits 0 and the old name survives", async () => {
+		const {out} = await run([
+			[once(BRANCHES), refs(STALE, LIVE)],
+			...CLAIMED,
+			[PRUNE, okOut("")],
+			[TREES, trees({path: "/repo", branch: "main"})],
+			[RENAME, okOut("")],
+			[BRANCHES, refs(STALE, LIVE)],
+		]);
+
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.join("\n")).toMatch(/NOT proven/);
+	});
+});
+
+describe("runRetireBranch — no path deletes a branch (ADR 0324, first binding constraint)", () => {
+	// The pin is over the source rather than a run: a delete path that exists but is unreachable in
+	// the cases these tests script is exactly the defect the ruling bans, and no fake can prove its
+	// absence. Both modules are read whole, so a delete added to either reds this.
+	const source = [
+		new URL("./retire-branch-verb.ts", import.meta.url),
+		new URL("./retire-branch.ts", import.meta.url),
+	].map((at) => readFileSync(at, "utf8"));
+
+	it.each([
+		["git branch -d", /["'`\s]-d["'`\s,\]]/],
+		["git branch -D", /["'`\s]-D["'`\s,\]]/],
+		["update-ref -d", /update-ref/],
+		["branch --delete", /--delete/],
+		["push --delete", /"push"/],
+	])("carries no %s", (_name, forbidden) => {
+		for (const text of source) expect(text).not.toMatch(forbidden);
+	});
+
+	it("reaches git through renameBranch and nothing else that writes a ref", () => {
+		const [verb] = source;
+		expect(verb).toContain("renameBranch");
+		expect(verb).not.toMatch(/execCapture/);
+	});
+});

--- a/packages/fabrika-cli/src/build/retire-branch.ts
+++ b/packages/fabrika-cli/src/build/retire-branch.ts
@@ -1,0 +1,75 @@
+/**
+ * Which of an epic child's lane branches is superseded, and what a retired branch is named.
+ *
+ * Pure, and split from the verb because ADR 0324's whole safety argument sits here: the survivor is
+ * a branch the board **attests** to, never the one a heuristic prefers. A child's branch is never
+ * pushed (ADR 0285), so a wrong pick moves the only copy of somebody's work out from under the lane
+ * still building on it — which is why an unattested set supersedes nothing and refuses instead.
+ *
+ * Retirement is a rename out of `build/`. Nothing here deletes: after it the branch still exists,
+ * still carries every commit, and is still reachable by name; what changes is that
+ * `childLaneBranches` (`./lane.ts`) no longer nominates it, so `traceRange` (`../lane/prove.ts`) is
+ * left with one candidate and `lane prove` locates the range instead of refusing.
+ */
+
+import {parseLaneBranch} from "./lane.ts";
+
+const BUILD_PREFIX = "build/";
+
+/** The namespace a retired branch moves into. Any namespace but `build/` would do; one is picked. */
+export const RETIRED_PREFIX = "retired/";
+
+/** Where `branch` goes when it is retired, or `null` when it is not in the `build/` namespace. */
+export const retiredBranchName = (branch: string): string | null =>
+	branch.startsWith(BUILD_PREFIX) ? RETIRED_PREFIX + branch.slice(BUILD_PREFIX.length) : null;
+
+/**
+ * The survivor and what it supersedes, or the refusal.
+ *
+ * `Unattested` covers both directions of the same missing fact — no candidate carries an authorized
+ * marker's nonce, or several do — because the act is identical either way: rename nothing. The two
+ * `why` clauses differ so an operator reads which side of it they are on.
+ */
+export type Supersession =
+	| {
+			readonly _tag: "Settled";
+			readonly survivor: string;
+			readonly superseded: ReadonlyArray<string>;
+	  }
+	| {readonly _tag: "Unattested"; readonly why: string};
+
+/**
+ * Seat the candidates against the board's authorized claim markers.
+ *
+ * `sessionByNonce` is `sessionsByNonce`'s map (`./retire.ts`) — the earliest authorized marker per
+ * lane nonce, which is the same holder every other ownership question resolves against. A retracted
+ * claim leaves no marker, so a nonce in that map is a live lane naming the branch it cut.
+ */
+export const supersede = (
+	issue: number,
+	candidates: ReadonlyArray<string>,
+	sessionByNonce: Readonly<Record<string, string>>,
+): Supersession => {
+	const attested = candidates.filter((branch) => {
+		const lane = parseLaneBranch(branch);
+		return lane !== null && sessionByNonce[lane.nonce] !== undefined;
+	});
+	const [survivor, ...rest] = attested;
+	if (survivor === undefined) {
+		return {
+			_tag: "Unattested",
+			why: `no authorized claim marker on #${issue} carries the lane nonce of ${candidates.join(", ")} — nothing on the board says which of them a live lane cut`,
+		};
+	}
+	if (rest.length > 0) {
+		return {
+			_tag: "Unattested",
+			why: `${attested.join(", ")} each carry the lane nonce of an authorized claim marker on #${issue} — two live claims name two branches, and which one supersedes the other is not derivable from the board`,
+		};
+	}
+	return {
+		_tag: "Settled",
+		survivor,
+		superseded: candidates.filter((branch) => branch !== survivor),
+	};
+};

--- a/packages/fabrika-cli/src/build/retire-branch.unit.test.ts
+++ b/packages/fabrika-cli/src/build/retire-branch.unit.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from "vitest";
+import {traceRange} from "../lane/prove.ts";
+import {NONCE, SIBLING_NONCE} from "./fixtures.test-support.ts";
+import {childLaneBranches} from "./lane.ts";
+import {RETIRED_PREFIX, retiredBranchName, supersede} from "./retire-branch.ts";
+
+const LIVE = `build/6296-editor-focus-loss-${NONCE}`;
+const STALE = `build/6296-editor-focus-loss-${SIBLING_NONCE}`;
+
+describe("retiredBranchName", () => {
+	it("moves a lane branch out of build/ and keeps every other character", () => {
+		expect(retiredBranchName(LIVE)).toBe(`${RETIRED_PREFIX}6296-editor-focus-loss-${NONCE}`);
+	});
+
+	it("names no target for a branch that is not in build/ — there is nothing to retire", () => {
+		expect(retiredBranchName("main")).toBeNull();
+		expect(retiredBranchName(`${RETIRED_PREFIX}6296-editor-focus-loss-${NONCE}`)).toBeNull();
+	});
+});
+
+describe("supersede", () => {
+	it("keeps the branch an authorized marker's nonce names and supersedes the rest", () => {
+		expect(supersede(6296, [STALE, LIVE], {[NONCE]: "s-9f2e"})).toEqual({
+			_tag: "Settled",
+			survivor: LIVE,
+			superseded: [STALE],
+		});
+	});
+
+	it("supersedes nothing when no marker carries any candidate's nonce", () => {
+		const seated = supersede(6296, [STALE, LIVE], {});
+
+		expect(seated._tag).toBe("Unattested");
+		expect(seated._tag === "Unattested" && seated.why).toContain("no authorized claim marker");
+	});
+
+	it("supersedes nothing when two candidates are each attested — two live claims, no order", () => {
+		const seated = supersede(6296, [STALE, LIVE], {[NONCE]: "s-9f2e", [SIBLING_NONCE]: "s-other"});
+
+		expect(seated._tag).toBe("Unattested");
+		expect(seated._tag === "Unattested" && seated.why).toContain("two live claims");
+	});
+});
+
+describe("a retired branch leaves the candidate set — the deadlock ADR 0324 clears", () => {
+	const fact = (branch: string) => ({
+		branch,
+		base: "664eb9d",
+		tip: branch === LIVE ? "03135b9" : "8f1c2ad",
+		messages: ["feat(lane): do the thing (#6296)"],
+		contains: [],
+	});
+
+	it("is Many while both branches sit in build/, and One once the superseded one is renamed", () => {
+		const before = childLaneBranches(6296, [STALE, LIVE, "main"]);
+		expect(traceRange(6296, "epic/6200", before.map(fact))).toMatchObject({_tag: "Many"});
+
+		const retired = retiredBranchName(STALE);
+		if (retired === null) throw new Error(`${STALE} has no retired name`);
+		const after = childLaneBranches(6296, [retired, LIVE, "main"]);
+
+		expect(after).toEqual([LIVE]);
+		expect(traceRange(6296, "epic/6200", after.map(fact))).toMatchObject({
+			_tag: "One",
+			branch: LIVE,
+		});
+	});
+});


### PR DESCRIPTION
`fabrika build retire-branch <n>` clears the two-branch deadlock ADR 0324 ruled on: when two local
branches both carry one epic child's commits, `traceRange` answers `Many`, `locateRange` maps it to
`Ambiguous`, and `lane prove` refuses. The verb **renames** the superseded branches out of `build/`
into `retired/` and deletes nothing, so every commit stays reachable and a mistaken retirement costs
a rename back rather than a child's only copy of its work.

Which branch survives is read off the board, never guessed: the survivor is the candidate whose lane
nonce an authorized claim marker on the issue carries (`sessionsByNonce` + `readClaimants`, the same
positive attestation `build retire` uses). Where the board attests none — or attests two — nothing is
renamed and the verb exits `34`. Before any rename it proves no working tree of this clone holds a
branch it is about to move: `renameBranch`'s own docblock records that `git branch -m` exits 0 on a
held branch and silently retargets that tree's `HEAD` (measured against git 2.40.1 on #6386), so a
held branch exits `33` naming `fabrika build retire <n>` as the act that clears the hold. Every
rename is read back off a second `localBranches`.

`build branch --resume-lane`'s "retire the superseded branches, then re-run" now names the verb by
its full invocation, and the pinned copy of that message in the build contract moves with it.

Where to look first: `supersede` in `packages/fabrika-cli/src/build/retire-branch.ts` is the whole
survivor rule, and the `no path deletes a branch` block in `retire-branch-verb.unit.test.ts` pins the
first binding constraint over the source rather than over a scripted run — no fake can prove the
absence of a delete path that exists but is unreached.

Fixes #6889

## Deviations

- **Scope narrowing** — **Said:** the criteria say the verb is registered in
  `packages/fabrika-cli/src/registry.ts`. **Did:** registered it in
  `packages/fabrika-cli/src/build/command.ts`; `registry.ts` is unchanged. **Why:** `registry.ts`
  registers verb *groups*, not verbs, and `buildCommand` is already a row there — the leaf goes in
  the group's own command module. **Disposition:** the criterion's stated outcome holds and is
  verifiable: `fabrika build --help` lists `retire-branch`.
- **Out-of-scope change** — **Said:** #6889 names the new verb and the `--resume-lane` remedy line.
  **Did:** also backfilled exit codes `32` and `33` into `packages/fabrika-cli/README.md`'s build
  exit list and `33` into the build contract's shared exit matrix, both of which predate this
  change. **Why:** this PR adds `34` to both lists, and a list that jumps from `31` to `34` reads as
  a drafting error rather than as the table it claims to be. **Disposition:** stated here.
- **Declined guidance** — **Said:** the criteria say the verb "allocates its exits from the existing
  table in `packages/fabrika-cli/src/build/codes.ts` rather than minting a parallel one". **Did:**
  allocated seat `34` (`SURVIVOR_UNATTESTED`) inside that same table rather than reusing an existing
  seat. **Why:** no existing seat states the fact — `15` is about the caller's own claim and this
  verb runs against a branch its lane never cut, and `11` is reserved for a read that failed while
  here the markers were read in full. `codes.ts`'s own doctrine is a seat per distinct remedy.
  **Disposition:** stated here; no parallel table was minted.
