### PR TITLE
chore: The epic tail's human:epic-review final has no UNBLOCKED handler, so the park it names cannot be resumed

### DIFF
--- a/.decisions/0341-a-failed-epic-review-is-a-park.md
+++ b/.decisions/0341-a-failed-epic-review-is-a-park.md
@@ -1,0 +1,88 @@
+---
+id: 0341
+title: A twice-failed epic review is a park, not the end of the run
+status: accepted
+date: 2026-08-29
+tags: [fabrika, lane, pipeline, state-machine, epics]
+---
+
+# 0341 — A twice-failed epic review is a park, not the end of the run
+
+**What this decides:** `human:epic-review` gets the same `UNBLOCKED` door `frozen` has. An epic run
+whose tail spends its review budget is parked for a human, and `operate` reads it `LANE-PARKED`.
+
+## Context
+
+The epic tail's three `FAIL` arms — `review`, `ship`, `ship:queued` — all fall through to
+`human:epic-review` once retries are spent
+([`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts), `epicRegion`).
+That state was emitted as `{type: "final"}` with no `on` block, while its three sibling parks in the
+same region (`blocked`, `human:cp-approval`, `human:queue-stall`) each carry
+`UNBLOCKED → hist`. So a tail that failed twice landed in a state `lane transition` refuses at exit
+`12`, and the lane read finished.
+
+The omission was deliberate and said so in the source: `human:epic-review` was the safe placeholder
+[#5793](https://github.com/kamp-us/phoenix/issues/5793) asked for, and #5793's own acceptance
+criteria deferred the routing to a follow-up ruling.
+[#6790](https://github.com/kamp-us/phoenix/issues/6790) is that follow-up.
+
+The gap had a second half. `operate`'s SKILL.md routed the state twice, oppositely: §4 said "every
+other error final has no door and ends `LANE-TERMINAL`", while the terminal vocabulary keyed
+`LANE-PARKED` on `blocked`, `human:*` or `frozen`. `human:epic-review` satisfies both, and the same
+section says a park reported as a terminal destroys the caller's routing. Which rule wins is
+downstream of the door question, so both settle here.
+
+## Decision
+
+The founder ruled it on
+[#6790](https://github.com/kamp-us/phoenix/issues/6790#issuecomment-5465608202): option 1, the
+sibling door.
+
+**`human:epic-review` keeps `"type": "final"` and gains `"<TASK>.UNBLOCKED": "hist"`** — exactly the
+shape ADR [0297](0297-frozen-is-a-park-not-an-end.md) ruled for `frozen`, and for the same reason:
+dropping `final` would take the state out of both `finals` and `errorFinals`, so a failed tail would
+stop reading as tripped and the phase would never fold at all. It stays an error final, the tail
+phase still trips on it, and the door out stays walkable.
+
+**The door grants no retries.** The resume runs through the region's `hist` cell, which copies the
+task's retry count forward, so a resumed tail walks back into the state it left with its budget
+still spent. Budget comes from a founder clearance recorded with `build clear` and from nowhere
+else. Because the state is an error final whose resume lands in a guarded state, a bare `UNBLOCKED`
+with no `CLEARED` behind it is refused on exit `36` — the ADR
+[0312](0312-event-anchored-retry-budget.md) gate, which now covers two parks instead of one.
+
+**`operate` reads it `LANE-PARKED`.** The terminal vocabulary's `human:*` clause wins; §4's
+"every other error final" sentence gains `human:epic-review` beside `frozen` as its second named
+exception. The routing table gets its own row, so a driver reading the fold does not have to derive
+the shape from the state's name.
+
+**`recipe unpark` gets no `KNOWN_PARKS` row.** `isPark` already answers true for the leaf — it
+starts with `human:` — so `classifyPark` seats it as Novel, and the verb refuses with the ledger
+untouched and routes it to a human. That is the right answer: the clearing condition here is a
+founder's judgment that the tail deserves another round, which is what `human:cp-approval` waits on
+too and which no recipe may grant. Recognised, never cleared autonomously.
+
+Today that classification is not what the verb actually reaches on this park. A lane whose only
+unfinished task is the tail folds to the `tripped` terminal, and `leafOf` answers `Finished` for a
+terminal `stateValue`, so `recipe unpark` refuses at `NOT_PARKED` before it ever classifies the
+leaf. The outcome is the same — a human — and the gap is pre-existing and shared with every
+`frozen` park that trips its whole lane, so it is
+[#7347](https://github.com/kamp-us/phoenix/issues/7347)'s to close, not this ruling's.
+
+## Consequences
+
+An epic run carrying a fully-reviewed range of children can be recovered after a bad tail review
+instead of needing its ledger hand-edited — which is the thing the ledger-is-the-only-state design
+exists to avoid. The tail is the most expensive state in the pipeline to lose, and it now has the
+recovery every cheaper state already had.
+
+The cost is the one ADR 0297 already accepted: the door can be walked repeatedly, each pass ending
+in the same park, and only a recorded clearance buys a round.
+
+`human:epic-review` has trapped no real lane yet, so nothing needs migrating; a lane emitted before
+this change carries the old doorless state and is re-emitted, not patched.
+
+## Records
+
+No vocabulary impact. `LANE-PARKED` and `LANE-TERMINAL` are the `operate` skill's own terminal
+vocabulary, defined there rather than in `.glossary/TERMS.md`.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -209,7 +209,8 @@ active phase** (future phases read `waiting`; leave them alone), route on the le
 | `integrate` | land the child on the assembly branch yourself — the epic run, below |
 | a state `recipe route` names | apply that recipe verb — the chore drive, below |
 | a task's own final — `landed`, `shipped` | nothing to route and no event to record: that task is finished, and its phase advances when every task in it is final |
-| `frozen` | park — step 4. It is an error final, so it trips the phase where it sits and the fold says so; it is also the one final with a door out (ADR [0297](../../../../.decisions/0297-frozen-is-a-park-not-an-end.md)), and walking it is a human's `UNBLOCKED`, never yours |
+| `frozen` | park — step 4. It is an error final, so it trips the phase where it sits and the fold says so; it is also a final with a door out (ADR [0297](../../../../.decisions/0297-frozen-is-a-park-not-an-end.md)), and walking it is a human's `UNBLOCKED`, never yours |
+| `human:epic-review` | park — step 4, and the same shape as `frozen`: an error final that trips the epic's tail phase, carrying an `UNBLOCKED` door a human walks (ADR [0341](../../../../.decisions/0341-a-failed-epic-review-is-a-park.md)) |
 | `human:*` | park — step 4 |
 | `blocked` | park — step 4 |
 | any other name | end `STOPPED` naming the state — never guess a shell for a state you do not recognise, and never a park: `LANE-PARKED` promises a fold in `blocked`/`human:*`/`frozen`, which an unrecognised state cannot honour (Terminal vocabulary, below) |
@@ -834,11 +835,13 @@ not yours (ADR [0228](../../../../.decisions/0228-scripts-relay-never-derive.md)
 
 You cannot clear a park by hand: post on the driven issue what is needed and from whom (the parking
 spawn's report names both; for `human:cp-approval` it is a control-plane approval at the PR's
-current head; for `frozen` it is a founder-cleared repair round, recorded with `build clear`, which
-appends a `<TASK>.CLEARED` event to the lane's log and moves the task nowhere — the door out is
+current head; for `frozen` and for the epic tail's `human:epic-review` (ADR
+[0341](../../../../.decisions/0341-a-failed-epic-review-is-a-park.md)) it is a founder-cleared
+repair round, recorded with `build clear`, which appends a `<TASK>.CLEARED` event to the lane's log
+and moves the task nowhere — the door out is
 still the human's `UNBLOCKED`, and the two land in either order. Without a `CLEARED` behind it that
 `UNBLOCKED` is **refused** on exit `36`: the resume would restore the state and not the budget, so
-every guarded route out falls straight back to `frozen` (ADR
+every guarded route out falls straight back to the park (ADR
 [0312](../../../../.decisions/0312-event-anchored-retry-budget.md)). Read that code as "the grant
 has not been recorded yet", never as an event to retype). One park class names its
 owner here, not off the spawn's
@@ -898,8 +901,9 @@ issue to land on: print the same two verbs and hand their bytes to your caller, 
 chore's transcript is posted.
 
 **A `tripped` fold is not automatically a terminal** — read which state its error task sits in. On
-`frozen` the run ends `LANE-PARKED` with the transcript and the need posted (the founder-cleared
-round above); every other error final has no door and ends `LANE-TERMINAL`.
+`frozen` and on `human:epic-review` the run ends `LANE-PARKED` with the transcript and the need
+posted (the founder-cleared round above, which both of them need); every other error final has no
+door and ends `LANE-TERMINAL`.
 
 **Resume is a re-spawn.** There is no handoff and no memory: resuming a lane is spawning the
 operator again with the same issue number — step 1 tolerates the existing lane, and the fold says
@@ -971,10 +975,11 @@ unroutable state, or a `BLOCKED` refused with exit `12` — the code or state na
 guessed, no event recorded, the fold unchanged). An unroutable state ends `STOPPED`, never
 `LANE-PARKED`: a park promises an `UNBLOCKED` resume, which a state this skill does not recognise
 cannot honour — and appending `BLOCKED` toward cells you do not know is exactly the guess step 2's
-routing table forbids. That resume is mechanical from `blocked` and `human:*` only. From `frozen` it
-needs a recorded `CLEARED` behind it first — a bare `UNBLOCKED` is refused on exit `36`, per the
-park-clearing paragraph in step 4 above — so a `frozen` park's promise is "the founder grants the
-round, then the resume walks", not "the next driver records `UNBLOCKED`". A park reported as a
+routing table forbids. That resume is mechanical from `blocked` and from the `human:*` parks that
+are not error finals. From `frozen` and from `human:epic-review` — the two error finals with a door
+— it needs a recorded `CLEARED` behind it first: a bare `UNBLOCKED` is refused on exit `36`, per the
+park-clearing paragraph in step 4 above, so their promise is "the founder grants the round, then the
+resume walks", not "the next driver records `UNBLOCKED`". A park reported as a
 terminal destroys the caller's routing: the two differ in exactly who acts next. Follow-up
 observations leave through `/report` the moment you see them — never through scope creep in a
 lane you are only driving.

--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -336,7 +336,10 @@
 								"type": "final"
 							},
 							"human:epic-review": {
-								"type": "final"
+								"type": "final",
+								"on": {
+									"EPIC_4300.UNBLOCKED": "hist"
+								}
 							}
 						}
 					}

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -126,9 +126,9 @@ const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<str
  * `review` FAIL is a two-arm guarded array so the fallthrough final is an *error* final by the
  * compiler's own structural read; a plain target would leave a failed epic review folding to
  * `complete`. The retry arm is `review` itself: a repair round happens outside the machine and the
- * next verdict is another review. Where the fallthrough goes — `human:epic-review`, a park-shaped
- * final that trips the lane for a human — is deliberately the safe placeholder #5793 asked for, not
- * a resolved answer: what a failing epic review *means* is still an open founder question.
+ * next verdict is another review. The fallthrough is `human:epic-review`, and it carries the same
+ * `final` + `UNBLOCKED` door `frozen` does: a twice-failed epic review is a park a human resumes,
+ * not the end of the run (ADR 0341, settling the question #5793 deferred).
  */
 const epicRegion = (ns: string): Record<string, unknown> => ({
 	initial: "review",
@@ -173,7 +173,7 @@ const epicRegion = (ns: string): Record<string, unknown> => ({
 		"human:queue-stall": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
 		hist: {type: "history"},
 		shipped: {type: "final"},
-		"human:epic-review": {type: "final"},
+		"human:epic-review": {type: "final", on: {[`${ns}.UNBLOCKED`]: "hist"}},
 	},
 });
 

--- a/packages/fabrika-cli/src/lane/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit.unit.test.ts
@@ -6,9 +6,9 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
 import {readGoldenFixture} from "../golden-fixture.ts";
-import {RETRY_BUDGET} from "../retry-budget.ts";
+import {CAP_ROUND, RETRY_BUDGET} from "../retry-budget.ts";
 import {type EmitResult, emitMachine} from "./emit.ts";
-import {applyEvent, deriveStatus, foldLog, type LogEntry} from "./fold.ts";
+import {applyClearance, applyEvent, deriveStatus, foldLog, type LogEntry} from "./fold.ts";
 import {type CompiledLane, compileText} from "./machine.ts";
 import {runTransition} from "./transition-verb.ts";
 
@@ -58,23 +58,45 @@ const laneOf = (text: string): CompiledLane => {
 	return compiled.lane;
 };
 
-/** Drive a sequence through `applyEvent`, asserting every step is accepted, and fold the result. */
-const drive = (
+const AT = "2026-08-17T00:00:00.000Z";
+
+const statesOf = (compiled: CompiledLane, entries: ReadonlyArray<LogEntry>) => {
+	const fold = foldLog(compiled, entries);
+	if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
+	return fold.states;
+};
+
+/** Drive a sequence through `applyEvent`, asserting every step is accepted, and keep the log. */
+const driveLog = (
 	compiled: CompiledLane,
 	steps: ReadonlyArray<readonly [string, string]>,
-): ReturnType<typeof deriveStatus> => {
-	const log: LogEntry[] = [];
-	const statesOf = (entries: ReadonlyArray<LogEntry>) => {
-		const fold = foldLog(compiled, entries);
-		if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
-		return fold.states;
-	};
+	from: ReadonlyArray<LogEntry> = [],
+): ReadonlyArray<LogEntry> => {
+	const log: LogEntry[] = [...from];
 	for (const [task, event] of steps) {
-		const applied = applyEvent(compiled, statesOf(log), task, event, "2026-08-17T00:00:00.000Z");
+		const applied = applyEvent(compiled, statesOf(compiled, log), task, event, AT);
 		if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
 		log.push(applied.entry);
 	}
-	return deriveStatus(compiled, statesOf(log));
+	return log;
+};
+
+const drive = (
+	compiled: CompiledLane,
+	steps: ReadonlyArray<readonly [string, string]>,
+): ReturnType<typeof deriveStatus> =>
+	deriveStatus(compiled, statesOf(compiled, driveLog(compiled, steps)));
+
+/** Append one founder-cleared round the way `build clear` does — an event, never a context edit. */
+const grant = (
+	compiled: CompiledLane,
+	log: ReadonlyArray<LogEntry>,
+	task: string,
+	round: number,
+): ReadonlyArray<LogEntry> => {
+	const applied = applyClearance(compiled, log, task, round, AT);
+	if (applied._tag !== "Appendable") throw new Error(`grant ${round}: ${applied._tag}`);
+	return [...log, applied.entry];
 };
 
 /** One child driven queued → build → review → integrate → landed. */
@@ -318,7 +340,7 @@ describe("emitMachine", () => {
 					},
 				},
 				shipped: {type: "final"},
-				"human:epic-review": {type: "final"},
+				"human:epic-review": {type: "final", on: {"EPIC_4300.UNBLOCKED": "hist"}},
 			},
 		});
 	});
@@ -362,6 +384,33 @@ describe("emitMachine", () => {
 		const spent = drive(compiled, [...LAND_ALL, ...fails, ["epic_4300", "FAIL"]]);
 		expect(spent).toMatchObject({stateValue: "tripped", status: "done"});
 		expect(spent.context.errors).toEqual(["epic_4300"]);
+	});
+
+	it("walks the epic-review park back into review on a granted round (ADR 0341)", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		const parked = driveLog(compiled, [
+			...LAND_ALL,
+			...Array.from({length: CAP_ROUND}, () => ["epic_4300", "FAIL"] as const),
+		]);
+		expect(deriveStatus(compiled, statesOf(compiled, parked))).toMatchObject({
+			stateValue: "tripped",
+			status: "done",
+		});
+
+		// The door is walkable and the budget still gates it, exactly as `frozen`'s does (ADR 0312).
+		expect(
+			applyEvent(compiled, statesOf(compiled, parked), "epic_4300", "UNBLOCKED", AT),
+		).toMatchObject({_tag: "Refused", kind: "unbudgeted-resume"});
+
+		const resumed = driveLog(
+			compiled,
+			[["epic_4300", "UNBLOCKED"]],
+			grant(compiled, parked, "epic_4300", CAP_ROUND),
+		);
+		expect(deriveStatus(compiled, statesOf(compiled, resumed))).toMatchObject({
+			stateValue: {epic: {epic_4300: "review"}},
+			status: "active",
+		});
 	});
 
 	it("terminates a partly-built epic — every child closed still leaves the epic review to run", () => {


### PR DESCRIPTION
The epic tail's `human:epic-review` was emitted as a doorless `{type: "final"}`, while its three sibling parks in the same region each carry `UNBLOCKED → hist`. A run whose tail failed its review twice landed in a state `lane transition` refuses at exit `12`, so an epic carrying a fully-reviewed range of children could only be recovered by hand-editing the ledger.

The founder ruled option 1 on #6790 ([ruling comment](https://github.com/kamp-us/phoenix/issues/6790#issuecomment-5465608202)): the sibling door. This transcribes it.

- `emit.ts` — `human:epic-review` keeps `"type": "final"` and gains `"<TASK>.UNBLOCKED": "hist"`, the shape ADR 0297 ruled for `frozen`. It stays in `finals` and `errorFinals`, so the tail phase still trips on it; the resume runs through `hist`, so the retry budget comes back spent and a bare `UNBLOCKED` with no `CLEARED` behind it is still refused on exit `36`.
- `operate/SKILL.md` — the two rules that disagreed now agree in the park direction. The state gets its own routing-table row, §4 names it beside `frozen` as the second error final that ends `LANE-PARKED`, and the terminal-vocabulary passage about which resumes are mechanical names both error finals instead of `frozen` alone.
- `.decisions/0341-a-failed-epic-review-is-a-park.md` — the ruling recorded, answering all three of the issue's criteria: the door, which `operate` rule wins, retries (none), and `recipe unpark` (recognised, no `KNOWN_PARKS` row — the clearing condition is a founder's judgment no recipe may grant).
- `emit.unit.test.ts` — the tail-region assertion now pins the door, and a new case drives the tail past its budget, proves the bare `UNBLOCKED` is refused as `unbudgeted-resume`, and proves a granted round walks it back into `review`.
- The `epic-4300` golden fixture is regenerated from the emitter.

Reviewer's first stop: the `emit.ts` one-liner and the ADR's "recipe unpark gets no row" paragraph, which is the criterion with the least room in the ruling.

Fixes #6790

## Deviations

- **Out-of-scope change** — **Said:** the ruling names the `emit.ts` arm, the two operate-skill edits and the ADR. **Did:** also touched a third `operate` passage (the step-4 park-clearing paragraph naming who owns a `frozen` clearance) and regenerated the golden fixture. **Why:** both are the same edit's other half — the clearance paragraph is what the terminal-vocabulary sentence points at, and the fixture is emitter output that would otherwise fail its own test. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the third criterion asks whether `recipe unpark` should recognise the park. **Did:** answered "recognised, never cleared autonomously" and left the verb untouched, after finding that it cannot reach either door-carrying park at all — a lane folded to `tripped` reads `Finished` in `leafOf` before the leaf is classified. **Why:** the gap is pre-existing and shared with every `frozen` park that trips its whole lane, and closing it is a change to the recipe reader, not to this ruling. **Disposition:** filed as #7347 and cited in the ADR.
