### PR TITLE
fix: Long çaylak display names overflow the divan roster card

### DIFF
--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -224,6 +224,9 @@
 .kp-divan__roster-row {
 	display: flex;
 	flex-direction: column;
+	/* Manti's button root centres its children; this row is a left-aligned record, and
+	   stretch is also what bounds each child to the card's width. */
+	align-items: stretch;
 	gap: var(--s-1);
 	width: 100%;
 	padding: var(--s-2) var(--s-3);
@@ -248,6 +251,9 @@
 .kp-divan__counts {
 	font: var(--t-meta);
 	color: var(--text-muted);
+	/* Manti's button root sets white-space: nowrap; the counts are the row's decision data
+	   and wrap rather than run past the card. */
+	white-space: normal;
 }
 
 /* identity (handle + karma-on-others) ------------------------------------- */
@@ -256,12 +262,22 @@
 	display: inline-flex;
 	align-items: center;
 	gap: var(--s-2);
+	min-width: 0;
+	max-width: 100%;
 }
 
 .kp-divan__handle {
 	font: var(--t-body-sm);
 	font-weight: 600;
 	color: var(--text-primary);
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kp-divan__karma {
+	flex: none;
 }
 
 /* detail ------------------------------------------------------------------ */

--- a/apps/web/src/components/moderation/ActorIdentity.test.tsx
+++ b/apps/web/src/components/moderation/ActorIdentity.test.tsx
@@ -22,6 +22,22 @@ describe("ActorIdentity — the shared actor row", () => {
 		expect(karma.textContent).toContain("42");
 	});
 
+	it("carries the full label in a title, so a truncated handle stays readable", () => {
+		const long = "Bir Hayli Uzun Bir Çaylak Görünen Adı";
+		render(
+			<ActorIdentity
+				authorId="a3"
+				displayName={long}
+				username="uzun"
+				totalKarma={0}
+				fallbackLabel="çaylak"
+				handleClassName="kp-divan__handle"
+				karmaTestIdPrefix="divan-karma-"
+			/>,
+		);
+		expect(screen.getByText(long).getAttribute("title")).toBe(long);
+	});
+
 	it("degrades to the fallback noun and hides karma when showKarma is false", () => {
 		render(
 			<ActorIdentity

--- a/apps/web/src/components/moderation/ActorIdentity.tsx
+++ b/apps/web/src/components/moderation/ActorIdentity.tsx
@@ -33,7 +33,9 @@ export function ActorIdentity({
 
 	return (
 		<span className={identityClassName}>
-			<span className={handleClassName}>{label}</span>
+			<span className={handleClassName} title={label}>
+				{label}
+			</span>
 			{showKarma ? (
 				<Karma
 					value={totalKarma}


### PR DESCRIPTION
A long çaylak display name no longer runs past the divan roster card's border.

Three things were unbounded, and the roster row's `Button` base is why:

- Manti's `[data-scope=button][data-part=root]` (layered under `manti.components`) sets
  `align-items: center` and `white-space: nowrap`. Phoenix's CSS is unlayered, so
  `.kp-divan__roster-row`'s `display: flex; flex-direction: column` wins, but `align-items:
  center` survives — every child sizes to its content instead of the card's width, so an
  over-wide identity simply overflows.
- `.kp-divan__identity` had no `min-width: 0`, so as a flex item on the detail head it kept
  its intrinsic width and never shrank.
- `.kp-divan__handle` set font and colour only — nothing to truncate against.

The fix: `align-items: stretch` on the roster row (which `text-align: left` in the same rule
already states as the intent), `min-width: 0; max-width: 100%` on the identity, and the
`overflow: hidden; text-overflow: ellipsis; white-space: nowrap` trio on the handle — the
same idiom `.kp-wave__row-title` already uses in this sheet. `.kp-divan__karma` gets `flex:
none` so the chip holds its width, and `.kp-divan__counts` gets `white-space: normal` to
undo the button's `nowrap` so the counts wrap rather than run out of the card. No new type
or spacing values.

`ActorIdentity` — the one shared moderation actor row (ADR 0147) — now puts the resolved
label in a `title`, so a truncated handle stays readable. Its only mount is
`CaylakIdentity`, which serves both the roster and the çaylak detail head, so both surfaces
are covered by the one shared-component change; `.kp-actor__identity` in `ActorDrawer` is
hand-rolled markup, not this component, and is untouched.

Grounded in source, not intuition: the `white-space: nowrap` / `align-items: center` /
`@layer manti.components` claims are read off
`@manti-ui/styles@0.9.0/dist/index.css` at the pinned version.

Fixes #7372

## Deviations

- **Out-of-scope change** — **Said:** #7372 names the display name's own overflow. **Did:**
  also gave `.kp-divan__counts` `white-space: normal` and the row `align-items: stretch`.
  **Why:** both follow from the same Manti button base — the counts inherit its `nowrap` and
  would themselves cross the border at a narrow width, which acceptance criterion 1 forbids,
  and `stretch` is what bounds a child to the card at all. `stretch` also changes the row's
  resting alignment from centred to left, which is what the rule's own `text-align: left`
  intends. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left the pre-existing biome
  `noDescendingSpecificity` warning on `.kp-wave__check` (Divan.css:774) alone. **Why:**
  unrelated to this row and outside the issue. **Disposition:** stated here.
