### PR TITLE
fix: "kefil ol" button stays clickable after a successful vouch

### DIFF
--- a/apps/web/src/components/divan/CaylakDetail.promote-refresh.test.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.promote-refresh.test.tsx
@@ -89,7 +89,14 @@ afterEach(() => {
 });
 
 function renderDetail() {
-	return render(<CaylakDetail authorId="u-1" viewerTier={undefined} viewerIsModerator={true} />);
+	return render(
+		<CaylakDetail
+			authorId="u-1"
+			viewerTier={undefined}
+			viewerIsModerator={true}
+			viewerVouched={false}
+		/>,
+	);
 }
 
 describe("CaylakDetail promote refresh (#7036)", () => {

--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -28,7 +28,10 @@ import {
 	promoteOutcomeMessage,
 	promoteRefreshWarranted,
 	promoteVisible,
-	vouchVisible,
+	type VouchOutcome,
+	vouchLanded,
+	vouchTriggerLabel,
+	vouchTriggerState,
 } from "./divanGating";
 import {
 	BacklogConnectionView,
@@ -61,10 +64,16 @@ export function CaylakDetail({
 	authorId,
 	viewerTier,
 	viewerIsModerator,
+	viewerVouched,
 }: {
 	readonly authorId: string;
 	readonly viewerTier: Tier | undefined;
 	readonly viewerIsModerator: boolean;
+	/**
+	 * Off the roster row this detail was opened from, so the durable "already a kefil"
+	 * state rides the roster's own batched read — no by-id read of this çaylak (ADR 0021).
+	 */
+	readonly viewerVouched: boolean;
 }) {
 	const result = useRequest(divanBacklogRequest(authorId));
 	const [items] = useListView(BacklogConnectionView, result["divan.backlog"]);
@@ -83,6 +92,7 @@ export function CaylakDetail({
 					authorId={authorId}
 					viewerTier={viewerTier}
 					viewerIsModerator={viewerIsModerator}
+					viewerVouched={viewerVouched}
 				/>
 			</header>
 
@@ -104,13 +114,18 @@ function ReviewerActions({
 	authorId,
 	viewerTier,
 	viewerIsModerator,
+	viewerVouched,
 }: {
 	readonly authorId: string;
 	readonly viewerTier: Tier | undefined;
 	readonly viewerIsModerator: boolean;
+	readonly viewerVouched: boolean;
 }) {
 	const fate = useFateClient();
 	const [vouchOpen, setVouchOpen] = useState(false);
+	// OR-ed with the prop rather than seeded from it, so a landed confirm shows immediately
+	// AND a refreshed roster row still wins after this component remounts on re-selection.
+	const [justVouched, setJustVouched] = useState(false);
 	const [busy, setBusy] = useState(false);
 	const [message, setMessage] = useState("");
 
@@ -145,8 +160,17 @@ function ReviewerActions({
 		}
 	}
 
+	function onVouchResolved(outcome: VouchOutcome) {
+		if (!vouchLanded(outcome)) return;
+		setJustVouched(true);
+		// Fire-and-forget, as the promote path does: the vouch DID land, so a failed
+		// re-pull must leave the surface alone — the local flag already told the truth.
+		void refreshDivanReview(fate, authorId).catch(() => undefined);
+	}
+
 	const showPromote = promoteVisible(viewerIsModerator);
-	const showVouch = vouchVisible(viewerTier);
+	const vouchState = vouchTriggerState(viewerTier, viewerVouched || justVouched);
+	const showVouch = vouchState !== "hidden";
 
 	if (!showPromote && !showVouch) return null;
 
@@ -169,9 +193,10 @@ function ReviewerActions({
 						variant="secondary"
 						size="sm"
 						onClick={() => setVouchOpen(true)}
+						disabled={vouchState === "done"}
 						data-testid="vouch-button"
 					>
-						kefil ol
+						{vouchTriggerLabel(vouchState)}
 					</Button>
 				) : null}
 			</div>
@@ -186,7 +211,12 @@ function ReviewerActions({
 				</Alert>
 			) : null}
 			{showVouch ? (
-				<VouchSheet open={vouchOpen} onOpenChange={setVouchOpen} candidateId={authorId} />
+				<VouchSheet
+					open={vouchOpen}
+					onOpenChange={setVouchOpen}
+					candidateId={authorId}
+					onResolved={onVouchResolved}
+				/>
 			) : null}
 		</div>
 	);

--- a/apps/web/src/components/divan/CaylakDetail.vouch-trigger.test.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.vouch-trigger.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Regression pin for #7373: the divan trigger must report whether the viewer is
+ * ALREADY this çaylak's kefil, both durably (off the roster row's viewer-scoped
+ * `viewerVouched`) and immediately after a confirm, and it must never offer a
+ * withdraw action in the done state.
+ *
+ * react-fate is stubbed at its boundary (the `CaylakDetail.promote-refresh` idiom), so
+ * the REAL `VouchSheet` + gating flow through the component.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {CaylakDetail} from "./CaylakDetail";
+
+const h = vi.hoisted(() => {
+	const state = {
+		vouch: (() => ({
+			result: {userId: "u-1", promoted: false, vouchRecorded: true},
+			error: null,
+		})) as () => unknown,
+	};
+	const clientRequests: Array<{request: unknown; options: unknown}> = [];
+	return {state, clientRequests};
+});
+
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {
+		...actual,
+		useRequest: (request: Record<string, unknown>) =>
+			Object.fromEntries(Object.keys(request).map((root) => [root, Symbol("connection")])),
+		useListView: () => [[], null],
+		useView: (_view: unknown, ref: unknown) =>
+			ref && typeof ref === "object" && "__typename" in (ref as object)
+				? {userId: "u-1", displayName: "Çaylak Kişi", username: "caylak", totalKarma: 7}
+				: ref,
+		useFateClient: () =>
+			({
+				mutations: {
+					user: {
+						vouch: () => h.state.vouch(),
+						promote: () => Promise.resolve({result: null, error: null}),
+					},
+					divan: {vote: () => Promise.resolve({result: null, error: null})},
+					report: {submit: () => Promise.resolve({result: null, error: null})},
+				},
+				request: (request: unknown, options?: unknown) => {
+					h.clientRequests.push({request, options});
+					return Promise.resolve({});
+				},
+				ref: (_type: string, id: string) => ({__typename: "Profile", id}),
+			}) as never,
+	};
+});
+
+beforeEach(() => {
+	h.clientRequests.length = 0;
+	h.state.vouch = () => ({
+		result: {userId: "u-1", promoted: false, vouchRecorded: true},
+		error: null,
+	});
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+const renderDetail = (opts: {tier?: string; vouched?: boolean} = {}) =>
+	render(
+		<CaylakDetail
+			authorId="u-1"
+			viewerTier={(opts.tier ?? "yazar") as never}
+			viewerIsModerator={false}
+			viewerVouched={opts.vouched ?? false}
+		/>,
+	);
+
+const trigger = () => screen.getByTestId("vouch-button") as HTMLButtonElement;
+
+describe("CaylakDetail vouch trigger — the already-vouched state (#7373)", () => {
+	it("a yazar who has not vouched is offered the enabled action", () => {
+		renderDetail();
+		expect(trigger().textContent).toContain("kefil ol");
+		expect(trigger().disabled).toBe(false);
+	});
+
+	it("a yazar already holding this çaylak's vouch sees the disabled past tense", () => {
+		renderDetail({vouched: true});
+		expect(trigger().textContent).toContain("kefil oldun");
+		expect(trigger().disabled).toBe(true);
+	});
+
+	it("the done state offers no withdraw affordance — one trigger, no second action", () => {
+		renderDetail({vouched: true});
+		expect(screen.queryAllByTestId("vouch-button")).toHaveLength(1);
+		expect(screen.queryByText(/geri çek/i)).toBeNull();
+	});
+
+	it("a non-yazar sees no trigger at all", () => {
+		renderDetail({tier: "çaylak"});
+		expect(screen.queryByTestId("vouch-button")).toBeNull();
+	});
+
+	it("a landed confirm flips the trigger without a reload, and re-pulls the roster", async () => {
+		renderDetail();
+		fireEvent.click(trigger());
+		fireEvent.click(await screen.findByTestId("vouch-confirm-button"));
+		await waitFor(() => expect(trigger().textContent).toContain("kefil oldun"));
+		expect(trigger().disabled).toBe(true);
+		expect(h.clientRequests).toHaveLength(1);
+		expect(h.clientRequests[0]?.options).toEqual({mode: "network-only"});
+	});
+
+	it("a cap denial leaves the trigger offering the action, and re-pulls nothing", async () => {
+		h.state.vouch = () => ({
+			result: null,
+			error: {code: "VOUCH_LIMIT_REACHED", message: "x"},
+		});
+		renderDetail();
+		fireEvent.click(trigger());
+		fireEvent.click(await screen.findByTestId("vouch-confirm-button"));
+		await waitFor(() =>
+			expect(screen.getByTestId("vouch-status").textContent).toContain("üç kişiye"),
+		);
+		expect(trigger().textContent).toContain("kefil ol");
+		expect(trigger().disabled).toBe(false);
+		expect(h.clientRequests).toHaveLength(0);
+	});
+});

--- a/apps/web/src/components/divan/DivanRoster.tsx
+++ b/apps/web/src/components/divan/DivanRoster.tsx
@@ -15,7 +15,7 @@ export function DivanRoster({
 	onSelect,
 }: {
 	readonly selectedId: string | null;
-	readonly onSelect: (authorId: string) => void;
+	readonly onSelect: (authorId: string, viewerVouched: boolean) => void;
 }) {
 	const result = useRequest(divanRosterRequest());
 	const [items] = useListView(RosterConnectionView, result["divan.roster"]);
@@ -44,7 +44,7 @@ function RosterRow({
 }: {
 	readonly node: ViewRef<"DivanCaylak">;
 	readonly selectedId: string | null;
-	readonly onSelect: (authorId: string) => void;
+	readonly onSelect: (authorId: string, viewerVouched: boolean) => void;
 }) {
 	const data = useView(RosterRowView, node);
 	const selected = selectedId === data.authorId;
@@ -56,7 +56,7 @@ function RosterRow({
 				variant="tertiary"
 				block
 				className="kp-divan__roster-row"
-				onClick={() => onSelect(data.authorId)}
+				onClick={() => onSelect(data.authorId, data.viewerVouched)}
 				aria-current={selected ? "true" : undefined}
 				data-testid={`divan-caylak-${data.authorId}`}
 			>

--- a/apps/web/src/components/divan/divanGating.test.ts
+++ b/apps/web/src/components/divan/divanGating.test.ts
@@ -9,8 +9,11 @@ import {
 	promoteOutcomeMessage,
 	promoteVisible,
 	shouldProbeDivanRoster,
+	vouchLanded,
 	vouchOutcome,
 	vouchOutcomeMessage,
+	vouchTriggerLabel,
+	vouchTriggerState,
 	vouchVisible,
 } from "./divanGating";
 
@@ -197,5 +200,39 @@ describe("vouchOutcome — the user.vouch receipt/code → outcome", () => {
 			expect(msg).toBe(msg.toLowerCase());
 			expect(msg.length).toBeGreaterThan(0);
 		}
+	});
+});
+
+describe("vouchTriggerState — the trigger's honesty about an already-held vouch (#7373)", () => {
+	it("a non-yazar sees no trigger at all, vouched or not", () => {
+		expect(vouchTriggerState("çaylak", false)).toBe("hidden");
+		expect(vouchTriggerState("çaylak", true)).toBe("hidden");
+		expect(vouchTriggerState(undefined, true)).toBe("hidden");
+	});
+
+	it("a yazar who has not vouched is offered the action", () => {
+		expect(vouchTriggerState("yazar", false)).toBe("offer");
+	});
+
+	it("a yazar who already vouched for this çaylak is done", () => {
+		expect(vouchTriggerState("yazar", true)).toBe("done");
+	});
+
+	it("labels the done state as the past tense, so the button reports rather than invites", () => {
+		expect(vouchTriggerLabel("done")).toBe("kefil oldun");
+		expect(vouchTriggerLabel("offer")).toBe("kefil ol");
+	});
+});
+
+describe("vouchLanded — which confirm outcomes leave the viewer holding a vouch (#7373)", () => {
+	it("a recorded vouch and a tandem-promoting one both landed", () => {
+		expect(vouchLanded("recorded")).toBe(true);
+		expect(vouchLanded("promoted")).toBe(true);
+	});
+
+	it("a cap denial, an authority denial and a transport error landed nothing", () => {
+		expect(vouchLanded("limit")).toBe(false);
+		expect(vouchLanded("denied")).toBe(false);
+		expect(vouchLanded("error")).toBe(false);
 	});
 });

--- a/apps/web/src/components/divan/divanGating.ts
+++ b/apps/web/src/components/divan/divanGating.ts
@@ -38,6 +38,25 @@ export function canVouch(tier: Tier | undefined, detailOpened: boolean): boolean
 	return vouchVisible(tier) && detailOpened;
 }
 
+/**
+ * The vouch trigger's three states (#7373). `done` is the honest end state — the viewer
+ * already holds this çaylak's vouch — and it stays a disabled label, never a withdraw
+ * control: whether withdrawal gets a surface is a separate product call.
+ */
+export type VouchTriggerState = "hidden" | "offer" | "done";
+
+export function vouchTriggerState(
+	tier: Tier | undefined,
+	alreadyVouched: boolean,
+): VouchTriggerState {
+	if (!vouchVisible(tier)) return "hidden";
+	return alreadyVouched ? "done" : "offer";
+}
+
+export function vouchTriggerLabel(state: VouchTriggerState): string {
+	return state === "done" ? "kefil oldun" : "kefil ol";
+}
+
 // Keyed off `isModerator`, never `tier`: a dual-role yazar+moderator reads `tier: "yazar"`
 // (#1320), so a tier check wrongly hid promote from them.
 export function promoteVisible(isModerator: boolean): boolean {
@@ -116,6 +135,16 @@ export function vouchOutcome(
 	if (code === "FORBIDDEN" || code === "UNAUTHORIZED") return "denied";
 	if (failed) return "error";
 	return promoted ? "promoted" : "recorded";
+}
+
+/**
+ * Which confirm outcomes leave the viewer holding a vouch row. `recorded` covers the
+ * idempotent re-vouch too (the server answers `alreadyVouched` with `vouchRecorded: false`
+ * and no promotion), so both mean "you are this çaylak's kefil" — which is what the trigger
+ * reports. A cap denial, an authority denial and a transport error say nothing landed.
+ */
+export function vouchLanded(outcome: VouchOutcome): boolean {
+	return outcome === "recorded" || outcome === "promoted";
 }
 
 export function vouchOutcomeMessage(outcome: VouchOutcome): string {

--- a/apps/web/src/components/divan/divanReads.ts
+++ b/apps/web/src/components/divan/divanReads.ts
@@ -31,6 +31,7 @@ export const RosterRowView = view<DivanCaylak>()({
 	postCount: true,
 	commentCount: true,
 	totalCount: true,
+	viewerVouched: true,
 });
 
 export const RosterConnectionView = {items: {node: RosterRowView}} as const;

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -31,7 +31,14 @@ export function DivanPage() {
 
 function DivanWorkspace() {
 	const {me} = useMe();
-	const [selectedId, setSelectedId] = useState<string | null>(null);
+	// The open çaylak carries the roster row's viewer-scoped `viewerVouched` with it, so the
+	// detail's "kefil oldun" state comes off the roster's batched read rather than a second
+	// by-id read of that çaylak (#7373, ADR 0021).
+	const [selected, setSelected] = useState<{
+		readonly authorId: string;
+		readonly viewerVouched: boolean;
+	} | null>(null);
+	const selectedId = selected?.authorId ?? null;
 	// Gate raporlar on the server-side isModerator signal, never on tier.
 	const raporlarVisible = me?.isModerator ?? false;
 	const [section, setSection] = useState<"caylaklar" | "raporlar">("caylaklar");
@@ -140,12 +147,15 @@ function DivanWorkspace() {
 								fallback={<p className="kp-divan__loading">yükleniyor…</p>}
 								error={({code}) => <AccessError code={code} />}
 							>
-								<DivanRoster selectedId={selectedId} onSelect={setSelectedId} />
+								<DivanRoster
+									selectedId={selectedId}
+									onSelect={(authorId, viewerVouched) => setSelected({authorId, viewerVouched})}
+								/>
 							</Screen>
 						</section>
 
 						<section className="kp-divan__detail-pane" aria-label="çaylak incelemesi">
-							{selectedId === null ? (
+							{selected === null ? (
 								<p className="kp-divan__hint" data-testid="divan-detail-hint">
 									incelemek için bir çaylak seç.
 								</p>
@@ -156,9 +166,10 @@ function DivanWorkspace() {
 									error={({code}) => <AccessError code={code} />}
 								>
 									<CaylakDetail
-										authorId={selectedId}
+										authorId={selected.authorId}
 										viewerTier={me?.tier}
 										viewerIsModerator={me?.isModerator ?? false}
+										viewerVouched={selected.viewerVouched}
 									/>
 								</Screen>
 							)}

--- a/apps/web/worker/features/divan/lists.ts
+++ b/apps/web/worker/features/divan/lists.ts
@@ -5,13 +5,14 @@
  *
  * Both are single-page private reads, so the `ConnectionResult` is `hasNext: false`.
  */
-import {Fate} from "@kampus/fate-effect";
+import {CurrentUser, Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {targetKey} from "../../db/target-kind.ts";
 import {UserId} from "../../lib/ids.ts";
 import {Denied} from "../kunye/errors.ts";
+import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Divan} from "./Divan.ts";
 import {requireDivanAccess, ViewDivan} from "./gate.ts";
 import type {DivanItem, DivanRosterRow} from "./roster.ts";
@@ -33,7 +34,7 @@ const BacklogArgs = Schema.Struct({
 
 // The handler stamps `__typename` itself: an inline-resolved entity has no source
 // that would stamp it.
-const toCaylak = (e: DivanRosterRow): DivanCaylak => ({
+const toCaylak = (e: DivanRosterRow, viewerVouched: boolean): DivanCaylak => ({
 	__typename: "DivanCaylak",
 	id: e.authorId,
 	authorId: e.authorId,
@@ -44,6 +45,20 @@ const toCaylak = (e: DivanRosterRow): DivanCaylak => ({
 	postCount: e.postCount,
 	commentCount: e.commentCount,
 	totalCount: e.totalCount,
+	viewerVouched,
+});
+
+/**
+ * The reading actor's whole vouch set in ONE ledger read, so `viewerVouched` costs the
+ * roster a single extra statement rather than a per-row probe (ADR 0021). An anonymous or
+ * moderator-only reader simply has none: the yazar floor lives in `user.vouch`, and this
+ * read only reports what already exists.
+ */
+const vouchedByViewer = Effect.fn("divan.vouchedByViewer")(function* () {
+	const {user} = yield* CurrentUser;
+	if (!user) return new Set<string>();
+	const ledger = yield* VouchLedger;
+	return new Set(yield* ledger.candidatesVouchedBy(user.id));
 });
 
 const toItem = (i: DivanItem): DivanBacklogItem => ({
@@ -59,9 +74,10 @@ const rosterGated = Effect.fn("divan.rosterGated")(function* () {
 	yield* ViewDivan;
 	const divan = yield* Divan;
 	const roster = yield* divan.roster();
+	const vouched = yield* vouchedByViewer();
 	return {
 		items: roster.map((e) => {
-			const node = toCaylak(e);
+			const node = toCaylak(e, vouched.has(e.authorId));
 			return {cursor: node.id, node};
 		}),
 		pagination: {hasNext: false, hasPrevious: false},

--- a/apps/web/worker/features/divan/lists.unit.test.ts
+++ b/apps/web/worker/features/divan/lists.unit.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `divan.roster` — the viewer-scoped `viewerVouched` field (#7373), driven through the
+ * REAL `requireDivanAccess` gate. The `VouchLedger` double dies on any method but
+ * `candidatesVouchedBy`, so "the whole roster is marked from ONE ledger read, never a
+ * per-row `has`" (ADR 0021's no-waterfalls contract) is asserted by construction.
+ *
+ * The gate disjunction itself is `gate.unit.test.ts`'s; the backlog predicate is
+ * `Divan.unit.test.ts`'s.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	human,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {CurrentUser} from "@kampus/fate-effect";
+import {Effect, Exit, Layer} from "effect";
+import {UserId} from "../../lib/ids.ts";
+import type {Denied} from "../kunye/errors.ts";
+import {Kunye} from "../kunye/Kunye.ts";
+import type {Tier} from "../kunye/standing.ts";
+import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
+import {Divan} from "./Divan.ts";
+import {lists} from "./lists.ts";
+import type {DivanRosterRow} from "./roster.ts";
+import type {DivanCaylak} from "./views.ts";
+
+const rosterList = lists["divan.roster"];
+
+const rosterRow = (authorId: string): DivanRosterRow => ({
+	authorId: UserId.make(authorId),
+	username: authorId,
+	displayName: null,
+	totalKarma: 0,
+	definitionCount: 1,
+	postCount: 0,
+	commentCount: 0,
+	totalCount: 1,
+});
+
+const divanStub = (authorIds: ReadonlyArray<string>): Layer.Layer<Divan> =>
+	// biome-ignore lint/plugin: a service double — only the roster read is on this path.
+	Layer.succeed(Divan, {
+		roster: () => Effect.succeed(authorIds.map(rosterRow)),
+	} as unknown as typeof Divan.Service);
+
+const resolveAs = (
+	actor: Actor,
+	opts: {
+		readonly tier?: Tier;
+		readonly mods?: ReadonlyArray<string>;
+		readonly roster?: ReadonlyArray<string>;
+		readonly vouched?: ReadonlyArray<string>;
+		readonly ledgerCalls?: Array<string>;
+	} = {},
+): Exit.Exit<{readonly items: ReadonlyArray<{readonly node: DivanCaylak}>}, Denied> =>
+	Effect.runSyncExit(
+		rosterList.resolve({args: {first: 50}, select: []}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					divanStub(opts.roster ?? []),
+					makeVouchLedgerStub({
+						candidatesVouchedBy: (voucherId: string) => {
+							opts.ledgerCalls?.push(voucherId);
+							return Effect.succeed(opts.vouched ?? []);
+						},
+					}),
+				),
+			),
+			Effect.provideService(CurrentUser, {
+				user:
+					actor._tag === "Authenticated" && actor.principal._tag === "Human"
+						? ({id: actor.principal.id} as never)
+						: undefined,
+			}),
+			Effect.provideService(CurrentActor, {actor}),
+			Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+			Effect.provideService(Kunye, {
+				tierOf: () => Effect.succeed(opts.tier ?? ("visitor" as const)),
+				karmaOf: (_id: string) => Effect.die(new Error("divan gate must not read karma")),
+				rootOf: (id: string) => Effect.succeed(id),
+			}),
+			Effect.provideService(RelationStore, {
+				has: (tuple) =>
+					Effect.succeed(
+						tuple.relation === "moderates" &&
+							tuple.object.type === "platform" &&
+							(opts.mods ?? []).includes(tuple.subject),
+					),
+				hasSubjects: ({subjects, relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform"
+								? subjects.filter((s) => (opts.mods ?? []).includes(s))
+								: [],
+						),
+					),
+				subjectsOf: ({relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform" ? (opts.mods ?? []) : [],
+						),
+					),
+			}),
+		),
+	) as Exit.Exit<{readonly items: ReadonlyArray<{readonly node: DivanCaylak}>}, Denied>;
+
+const vouchedFlags = (
+	exit: Exit.Exit<{readonly items: ReadonlyArray<{readonly node: DivanCaylak}>}, Denied>,
+): ReadonlyArray<readonly [string, boolean]> => {
+	assert.isTrue(Exit.isSuccess(exit));
+	if (!Exit.isSuccess(exit)) return [];
+	return exit.value.items.map((i) => [i.node.authorId, i.node.viewerVouched] as const);
+};
+
+describe("divan.roster — viewerVouched marks the reader's own vouches (#7373)", () => {
+	it("marks exactly the çaylaks the reading yazar already holds a vouch row for", () => {
+		const exit = resolveAs(human("u-yazar"), {
+			tier: "yazar",
+			roster: ["c-1", "c-2", "c-3"],
+			vouched: ["c-2"],
+		});
+		assert.deepStrictEqual(vouchedFlags(exit), [
+			["c-1", false],
+			["c-2", true],
+			["c-3", false],
+		]);
+	});
+
+	it("reads the ledger ONCE for the whole roster, keyed on the READING actor", () => {
+		const ledgerCalls: string[] = [];
+		resolveAs(human("u-yazar"), {
+			tier: "yazar",
+			roster: ["c-1", "c-2", "c-3"],
+			vouched: [],
+			ledgerCalls,
+		});
+		assert.deepStrictEqual(ledgerCalls, ["u-yazar"]);
+	});
+
+	it("a moderator who has vouched for nobody gets an all-false roster, not a denial", () => {
+		const exit = resolveAs(human("u-mod"), {
+			tier: "çaylak",
+			mods: ["u-mod"],
+			roster: ["c-1"],
+			vouched: [],
+		});
+		assert.deepStrictEqual(vouchedFlags(exit), [["c-1", false]]);
+	});
+
+	it("an ungated reader is still denied — the field widens nobody's access", () => {
+		assert.isTrue(Exit.isFailure(resolveAs(unauthenticated)));
+		assert.isTrue(Exit.isFailure(resolveAs(human("u"), {tier: "çaylak"})));
+	});
+});

--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -27,6 +27,12 @@ export type DivanCaylakViewRow = ViewRow<
 		postCount: number;
 		commentCount: number;
 		totalCount: number;
+		/**
+		 * Viewer-scoped, like `DivanVoteReceipt.myVote`: TRUE iff the READING yazar already
+		 * holds a vouch row for this çaylak. Resolved in the roster's own batch, never a
+		 * per-row `VouchLedger.has` (ADR 0021's no-waterfalls contract).
+		 */
+		viewerVouched: boolean;
 	}
 >;
 
@@ -38,6 +44,7 @@ export class DivanCaylakView extends FateDataView<DivanCaylakViewRow>()("DivanCa
 	postCount: true,
 	commentCount: true,
 	totalCount: true,
+	viewerVouched: true,
 } as const satisfies {[K in keyof DivanCaylakViewRow]: true}) {}
 
 export const divanCaylakDataView = DivanCaylakView.view;

--- a/apps/web/worker/features/kunye/VouchLedger.testing.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.testing.ts
@@ -16,6 +16,7 @@ const die =
 const failOnContact: VouchLedgerShape = {
 	castVouch: die("castVouch"),
 	has: die("has"),
+	candidatesVouchedBy: die("candidatesVouchedBy"),
 	activeCountFor: die("activeCountFor"),
 	hasActiveFor: die("hasActiveFor"),
 	withdraw: die("withdraw"),

--- a/apps/web/worker/features/kunye/VouchLedger.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.ts
@@ -42,6 +42,13 @@ export class VouchLedger extends Context.Service<
 
 		readonly has: (input: VouchKey) => Effect.Effect<boolean>;
 
+		/**
+		 * Every candidate this voucher has a row for, in ONE read. The divan roster needs the
+		 * whole set to mark its rows, and a per-row {@link has} would be the waterfall ADR 0021
+		 * forbids.
+		 */
+		readonly candidatesVouchedBy: (voucherId: string) => Effect.Effect<ReadonlyArray<string>>;
+
 		/** The cap input: vouches whose candidate is still `çaylak`. */
 		readonly activeCountFor: (voucherId: string) => Effect.Effect<number>;
 
@@ -125,6 +132,21 @@ export const VouchLedgerLive = Layer.effect(VouchLedger)(
 						.get(),
 				);
 				return row !== undefined;
+			}),
+
+			// Unfiltered by tier, unlike `activeCountFor`: the roster marks "you vouched for
+			// this person", which a promotion does not undo.
+			candidatesVouchedBy: Effect.fn("VouchLedger.candidatesVouchedBy")(function* (
+				voucherId: string,
+			) {
+				const rows = yield* run((db) =>
+					db
+						.select({candidateId: schema.authorshipVouch.candidateId})
+						.from(schema.authorshipVouch)
+						.where(eq(schema.authorshipVouch.voucherId, voucherId))
+						.all(),
+				);
+				return rows.map((r) => r.candidateId);
 			}),
 
 			// The inner-join to `user` is what makes a promotion return the slot without


### PR DESCRIPTION
Fixes #7373

After a yazar vouched for a çaylak, the divan detail's trigger still read `kefil ol` and stayed clickable — the button was gated only on tier, and nothing on the read said "this viewer already vouched for this candidate".

**Server.** `DivanCaylakView` gains a viewer-scoped `viewerVouched` boolean, in the same shape as `DivanVoteReceipt.myVote`. The `divan.roster` resolver marks the whole roster from ONE new `VouchLedger.candidatesVouchedBy(voucherId)` read — never a per-row `VouchLedger.has`, which would be the waterfall ADR 0021 forbids. The gate is untouched: the field widens nobody's access, and a moderator who has vouched for nobody just reads an all-false roster.

**Client.** The roster row carries its `viewerVouched` up through `onSelect`, so the open detail's durable state comes off the roster's existing batched read rather than a second by-id read of that çaylak. `vouchTriggerState` (pure, in `divanGating`) resolves `hidden` / `offer` / `done`; `done` renders a disabled `kefil oldun` and nothing else — no withdraw affordance. A landed confirm sets a local flag (immediate) and fires the existing `refreshDivanReview` network-only re-pull (durable across a later re-selection), mirroring what the promote path already does. A cap or authority denial leaves the trigger offering the action.

Reviewer's first stop: `apps/web/worker/features/divan/lists.ts` (the batched resolution) and `apps/web/src/components/divan/CaylakDetail.tsx` (the trigger).

## Deviations

None.
