### PR TITLE
feat: review-ui can only render a yazar, so any caylak-gated surface captures clean while unjudged

### DIFF
--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -94,29 +94,34 @@ you render independently or you have not looked.
 fabrika review-ui render --pr $pr_number --out judged --surface /pano --surface /pano/yeni
 ```
 
-**A surface behind login is named, not skipped.** A surface id may carry a realized state, and
-`auth` is the one realized today: `--surface /pano:auth` renders the same route as the moderator-tier
-test account instead of a visitor, so a delta that only exists signed in is judged rather than
-missed. Anything else after the colon is refused on `10` — a state nothing renders would shoot the
-default pixels under a variant's name.
+**A surface behind login is named, not skipped, and the name carries the tier.** A surface id may
+carry a realized state, and there are two: `--surface /pano:auth` renders the route as the
+yazar+moderator test account, `--surface /pano:auth-caylak` as the çaylak one. **Pick the tier the
+composition is for.** A nudge, a vouch prompt or an onboarding ask that a yazar never sees is
+suppressed for `:auth` by the product rule, so an `:auth` shot of it comes back clean showing nothing
+— the failure that reads as a judged surface (#7398). Anything else after the colon is refused on
+`10`, because a state nothing renders would shoot the default pixels under a variant's name.
 
-Two environment values make `:auth` work, and both come from somewhere specific:
-`PREVIEW_TEST_SESSION_TOKEN` is the token an operator passed to
-`node packages/preview-seed/src/bin.ts test-account --database-id <preview-d1>`, which is what puts
-the account and its session row on this PR's preview D1; `BETTER_AUTH_SECRET` is the **preview
-worker's** secret, not your local one, because it is the worker that verifies the cookie's signature.
-Neither is yours to mint — if you do not have them, you have not been handed the account, and
-`review-ui note` is the honest route. A `--flag` run needs one thing more: that account holding
-platform admin on this preview's D1, granted offline with
-`node packages/admin-grant/src/bin.ts grant --user-id preview-test-moderator --database-id <preview-d1>`.
+The values that make a tier state work come from somewhere specific. `BETTER_AUTH_SECRET` is the
+**preview worker's** secret, not your local one, because it is the worker that verifies the cookie's
+signature. Each tier's session token is what an operator passed to
+`node packages/preview-seed/src/bin.ts test-account --database-id <preview-d1>` —
+`PREVIEW_TEST_SESSION_TOKEN` for yazar, `PREVIEW_TEST_CAYLAK_SESSION_TOKEN` for çaylak — which is
+what puts that account and its session row on this PR's preview D1. **One tier's token never stands
+in for another's**: an unset one means that tier was not seeded here, and the verb refuses on `11`
+rather than shooting the tier it does hold. None of them is yours to mint — if you do not have them,
+you have not been handed the account, and `review-ui note` is the honest route. A `--flag` run needs
+one thing more: that tier's account holding platform admin on this preview's D1, granted offline with
+`node packages/admin-grant/src/bin.ts grant --user-id <preview-test-moderator|preview-test-caylak> --database-id <preview-d1>`.
 That is an operator's act against a throwaway preview, never yours and never against a database
 holding real accounts.
 
-**You never have to judge whether the shot came back signed in.** The verb hits the preview's own
-session endpoint from the same browser context before it records anything, and refuses `11` when the
-answer is not a user — an unset credential, a wrong or expired token, an account absent from this
-preview's D1 all land there. So a `:auth` capture in a manifest is a proven signed-in render, and a
-missing one is a refusal you read, never a silent anonymous shot.
+**You never have to judge whether the shot came back signed in, or as whom.** The verb hits the
+preview's own session endpoint from the same browser context before it records anything, and refuses
+`11` when the answer is not a user at the tier the surface named — an unset credential, a wrong or
+expired token, an account absent from this preview's D1, a shot that came back at another tier all
+land there. So a tier-state capture in a manifest is a proven render of that tier, and a missing one
+is a refusal you read, never a silent shot of the wrong audience.
 
 The verb captures the PR's **preview deployment** at the inspected head — never a checkout, never
 the PR's code run on your machine. Every surface returns a proven outcome — captured, crashed

--- a/claude-plugins/fabrika/skills/review-ui/contract.md
+++ b/claude-plugins/fabrika/skills/review-ui/contract.md
@@ -202,19 +202,26 @@ Per the tandem ruling (both briefs, 2026-08-09), declared identically to `build-
   verb changes behavior based on it. Chrome absent means the default path, silently.
 - Chrome output never enters `review-ui post --evidence`: evidence comes from `review-ui render`
   capture sets only, so the attach path has one validated producer.
-- **`:auth` surfaces need two environment values**, both unset by default: `PREVIEW_TEST_SESSION_TOKEN`
-  (the session token `preview-seed test-account` wrote onto the preview D1) and `BETTER_AUTH_SECRET`
-  (the preview worker's, so the cookie signature verifies). With neither or one set, an `:auth`
-  request refuses `11` rather than substituting the anonymous render; with no `:auth` surface asked
-  for, every surface renders anonymously as before. Setting both is necessary and not sufficient —
-  whether the cookie authenticated is the per-shot session proof's answer, also an `11`.
-- **`--flag` needs those same two values plus one grant on the preview D1.** The override cookie is
+- **A tier-naming surface needs `BETTER_AUTH_SECRET` plus that tier's own session token**, all unset
+  by default. `BETTER_AUTH_SECRET` is the preview worker's, so the cookie signature verifies; the
+  token is the one `preview-seed test-account` wrote onto the preview D1 for that tier —
+  `PREVIEW_TEST_SESSION_TOKEN` for `:auth` (yazar), `PREVIEW_TEST_CAYLAK_SESSION_TOKEN` for
+  `:auth-caylak` (çaylak). **One variable per tier, and an unset one is never satisfied by
+  another's**: an unset tier token means that tier was not seeded on this preview, and falling back
+  to a seeded identity would render the audience the surface said it was not (#7398). With any of
+  them unset the request refuses `11` rather than substituting; with no tier-naming surface asked
+  for, every surface renders anonymously as before. Setting them is necessary and not sufficient —
+  whether the cookie authenticated, and at which tier, is the per-shot session proof's answer, also
+  an `11`.
+- **`--flag` needs those same values plus one grant on the preview D1.** The override cookie is
   honored only for a platform admin (`flagship/override-authz.ts`, unchanged by #7218), and
-  `preview-seed test-account` provisions moderation authority, not admin. So a forced run is
-  preceded by `node packages/admin-grant/src/bin.ts grant --user-id preview-test-moderator
-  --database-id <preview-d1>` — offline and direct-D1, on a throwaway preview only, never against a
-  database holding real accounts. The grant is what makes the forced capture an admin's view as well
-  as a moderator's, which is the trade the operand asks for and the reason it is not the default.
+  `preview-seed test-account` provisions moderation authority to the yazar identity and nothing at
+  all to the çaylak one. So a forced run is preceded by `node packages/admin-grant/src/bin.ts grant
+  --user-id <the tier's account id> --database-id <preview-d1>` — offline and direct-D1, on a
+  throwaway preview only, never against a database holding real accounts. Admin is a relation tuple,
+  not a tier, so granting it to `preview-test-caylak` leaves that identity a çaylak and the tier
+  proof still binds. The grant is what makes the forced capture an admin's view as well, which is
+  the trade the operand asks for and the reason it is not the default.
 
 **The preview-deploy convention.** The repo announces each PR's preview as a sticky PR comment
 carrying the anchor `<!-- preview-deploy:<app> -->`, whose body names, per app: the deployed URL
@@ -243,33 +250,43 @@ fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/
 |---|---|---|---|---|
 | `--pr` | integer | yes | — | the pull request whose preview is judged |
 | `--out` | string | yes | — | kebab-case capture-set name; captures land under `<OS temp>/fabrika-review-ui/<pr>-<head8>/<set>/` |
-| `--surface` | string, repeatable | yes (≥1) | — | a surface id: a route (`/pano`), or a route plus a realized state (`/pano:auth`); zero operands is `1` — no tool guesses surfaces from a diff |
+| `--surface` | string, repeatable | yes (≥1) | — | a surface id: a route (`/pano`), or a route plus a realized tier state (`/pano:auth`, `/pano:auth-caylak`); zero operands is `1` — no tool guesses surfaces from a diff |
 | `--flag` | string, repeatable | no | every flag at its default | force one flag for this run: `<key>=on` or `<key>=off`; anything else, or a key forced twice, is `10` |
 | `--app` | string | no | the sole app in the preview comment; ambiguity refuses on `11` | which app's sub-line of the preview comment to resolve |
 | `--repo` | string | no | resolved | the repository |
 
 A `:state` suffix is admitted **only for a state something here actually puts on screen**, and
-refused on `10` otherwise. The realized set is `auth` and nothing else (#7051): an `:auth` surface
-renders with the moderator-tier test account's better-auth session cookie seeded into the capture
-context. The account is provisioned direct-D1 by `preview-seed test-account`, never by a worker
-route.
+refused on `10` otherwise. The realized set is `auth` and `auth-caylak` (#7051, #7398), and **each
+one names the tier it renders at**: `:auth` is the yazar+moderator identity, `:auth-caylak` the
+çaylak one. Each seeds that identity's own better-auth session cookie into the capture context, and
+each account is provisioned direct-D1 by `preview-seed test-account`, never by a worker route.
 
-Seeding a cookie is not the same as being signed in, so the shot proves it rather than assuming it.
-From the same browser context, before the shot is classified, the verb reads the preview's own
-`/api/auth/get-session` and requires a user back; anything else — a bare `null`, a non-200, an
-unreadable body — refuses the surface on `11` and records no capture. This is what makes the pixels a
-signed-in yazar+moderator's: a cookie that did not authenticate renders the visitor's page, and that
-page is a perfectly valid PNG no byte check can tell from the real one.
+The tier is an axis of the surface id because a tier is an audience. A surface whose whole point is
+that it renders *below* yazar — a çaylak nudge, a pre-promotion prompt, an onboarding ask — is
+suppressed for anyone clearing the floor, so a yazar's shot of it comes back valid, decodable and
+showing the state the PR did not add. That is the dangerous failure this axis closes: a clean-looking
+capture of the wrong audience.
+
+Seeding a cookie is not the same as being signed in, and being signed in is not the same as being
+signed in *as that tier*, so the shot proves both rather than assuming either. From the same browser
+context, before the shot is classified, the verb reads the preview's own `/api/auth/get-session` and
+requires a user back **whose `tier` is the one the surface named**; anything else — a bare `null`, a
+non-200, an unreadable body, a user with no tier, a user at another tier — refuses the surface on
+`11` and records no capture under that surface id. A cookie that did not authenticate renders the
+visitor's page and one that authenticated as the wrong identity renders somebody else's, and both are
+perfectly valid PNGs no byte check can tell from the real one.
 
 **`--flag` forces a dark-shipped flag on, so the state the PR adds paints** (ADR 0336, #7218). It
 rides the worker's existing `phoenix_flag_overrides` cookie — no route is added and
 `flagship/override-authz.ts` is untouched — and that gate is why the operand carries a fence of its
 own: on a deployed stage the cookie is honored only for a request whose actor holds platform
 `Admin`, so an anonymous surface would drop it and render the default state cleanly under the
-forced name. Every `--surface` in a forced run must therefore name `:auth`, and a bare route beside
-a `--flag` is `10`. The preview test account holds moderation authority, not admin, so a forced run
-also needs `admin-grant grant --user-id preview-test-moderator --database-id <preview-d1>` against
-that throwaway preview D1 — offline, direct-D1, the same sanctioned path ADR 0107 already names.
+forced name. Every `--surface` in a forced run must therefore name a tier state, and a bare route
+beside a `--flag` is `10`. Neither preview test account holds admin, so a forced run also needs
+`admin-grant grant --user-id <that tier's account id> --database-id <preview-d1>` against that
+throwaway preview D1 — offline, direct-D1, the same sanctioned path ADR 0107 already names. Admin is
+a relation tuple and not a tier, so a granted `preview-test-caylak` is still a çaylak and still
+passes the tier proof.
 
 Seeding an override is not the same as the override taking, so — like the session — the shot proves
 it. From the same context, before the shot is classified, the verb POSTs the preview's own
@@ -326,8 +343,8 @@ re-invocation without it, on the record; never the tool's tolerance.
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed |
-| `10` | `--out` not kebab-case; a `--surface` names a `:state` outside the realized set (`auth`); a `--flag` operand is not a `<key>=<on\|off>` pair, or forces one key twice; or `--flag` was passed beside an anonymous surface |
-| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; an `:auth` surface was requested while `PREVIEW_TEST_SESSION_TOKEN` / `BETTER_AUTH_SECRET` is unset; an `:auth` surface's session proof did not come back signed in; or a forced flag evaluated at its default anyway |
+| `10` | `--out` not kebab-case; a `--surface` names a `:state` outside the realized set (`auth`, `auth-caylak`); a `--flag` operand is not a `<key>=<on\|off>` pair, or forces one key twice; or `--flag` was passed beside an anonymous surface |
+| `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; a tier-naming surface was requested while that tier's session token or `BETTER_AUTH_SECRET` is unset; a tier-naming surface's session proof did not come back signed in, or came back at a tier the surface did not name; or a forced flag evaluated at its default anyway |
 | `12` | proven: the preview comment's deployed SHA is not the PR's live head — stale preview; re-render after the preview catches up |
 | `13` | proven: at least one surface threw an uncaught page error |
 | `14` | proven: at least one surface is unreachable (status ≥ 400, failed navigation, no route, dark flag, gated tier) |
@@ -340,11 +357,12 @@ re-invocation without it, on the record; never the tool's tolerance.
 |---|---|---|
 | `review-ui render: PR #<n> not found in <repo>.` | 7 | refusal |
 | `review-ui render: PR #<n> is closed — nothing to judge.` | 7 | refusal |
-| `review-ui render: --surface "<id>" names a :state nothing renders — the realized states are auth; render the bare route.` | 10 | refusal |
-| `review-ui render: an :auth surface was requested but its credentials are incomplete (unset: <names>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
+| `review-ui render: --surface "<id>" names a :state nothing renders — the realized states are auth, auth-caylak; render the bare route.` | 10 | refusal |
+| `review-ui render: a tier-naming surface was requested but its credentials are incomplete (unset: <names>) — the named tier's render is UNKNOWN, never a seeded substitute.` | 11 | refusal |
 | `review-ui render: surface "<id>" did not render signed in (<reason>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
+| `review-ui render: surface "<id>" named tier <wanted> and rendered as <rendered> — the named tier's render is UNKNOWN, never another tier's.` | 11 | refusal |
 | `review-ui render: --flag "<token>" is not a <key>=<on\|off> pair (<reason>) — an operand nothing can force would shoot the default state under the forced name.` | 10 | refusal |
-| `review-ui render: --flag was passed with the anonymous surface "<id>" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name every surface :auth.` | 10 | refusal |
+| `review-ui render: --flag was passed with the anonymous surface "<id>" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name a tier state (auth, auth-caylak) on every surface.` | 10 | refusal |
 | `review-ui render: surface "<id>" did not render with its forced flags (<reason>) — the forced render is UNKNOWN, never the default one.` | 11 | refusal |
 | `review-ui render: --out "<value>" is not a kebab-case set name.` | 10 | refusal |
 | `review-ui render: cannot read <what> for #<n>: <reason> — the render is UNKNOWN.` | 11 | refusal |
@@ -382,8 +400,28 @@ review-ui render: surface "/hosgeldin:auth" captured: 1280x1640, 0 page errors
 ```
 
 ```
+$ fabrika review-ui render --pr 4321 --out caylak --surface /hosgeldin:auth-caylak
+review-ui render: surface "/hosgeldin:auth-caylak" captured: 1280x1640, 0 page errors
+{"set":"caylak","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/hosgeldin:auth-caylak","path":"/tmp/fabrika-review-ui/4321-03135b91/caylak/hosgeldin-auth-caylak.png","width":1280,"height":1640,"sha256":"4d02…","pageErrors":{"rows":[],"more":0}}]}
+```
+
+```
+$ fabrika review-ui render --pr 4321 --out caylak --surface /hosgeldin:auth-caylak
+review-ui render: a tier-naming surface was requested but its credentials are incomplete (unset: PREVIEW_TEST_CAYLAK_SESSION_TOKEN) — the named tier's render is UNKNOWN, never a seeded substitute.
+$ echo $?
+11
+```
+
+```
+$ fabrika review-ui render --pr 4321 --out caylak --surface /hosgeldin:auth-caylak
+review-ui render: surface "/hosgeldin:auth-caylak" named tier çaylak and rendered as yazar — the named tier's render is UNKNOWN, never another tier's.
+$ echo $?
+11
+```
+
+```
 $ fabrika review-ui render --pr 4321 --out forced --surface /hosgeldin --flag phoenix-welcome=on
-review-ui render: --flag was passed with the anonymous surface "/hosgeldin" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name every surface :auth.
+review-ui render: --flag was passed with the anonymous surface "/hosgeldin" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name a tier state (auth, auth-caylak) on every surface.
 $ echo $?
 10
 ```
@@ -407,6 +445,10 @@ $ echo $?
 - #6541 / ADR 0336 — the verb captured every flag at its default, so under the dark-ship norm the
   gate judged the off-path and said PASS. `--flag` is that ruling's implementation (#7218), and its
   own proof exists because an override the preview dropped is the same clean-but-wrong capture.
+- #7398 — one identity at one tier meant a çaylak-only surface could not be rendered at all, and the
+  yazar's shot of it came back `captured`, valid and decodable, showing the state the PR did not add.
+  The tier rides the surface id, one seeded identity per tier, and the session proof reads the tier
+  back — the third instance of the same class the two bullets above name.
 
 ---
 

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -848,7 +848,7 @@ Judge a UI pull request over its preview deployment. Contract:
 
 | Verb | Answers |
 |---|---|
-| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized state (`/pano:auth` renders signed in as the test moderator, refusing on `11` unless the session proves it took). `--flag <key>=<on\|off>` forces a dark-shipped flag for the run, refusing on `10` unless every surface is `:auth` and on `11` unless the preview's own evaluation says the key took |
+| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized tier state (`/pano:auth` renders as the yazar test account, `/pano:auth-caylak` as the çaylak one), refusing on `11` unless the preview's own session read proves the shot came back signed in *and* at the tier the surface named. `--flag <key>=<on\|off>` forces a dark-shipped flag for the run, refusing on `10` unless every surface names a tier state and on `11` unless the preview's own evaluation says the key took |
 | `review-ui post` | the `review-ui` verdict on stdin, posted as one comment |
 | `review-ui note` | a typed blocker note when the surfaces cannot be seen |
 | `review-ui route` | a head-bound `routed-elsewhere` record: this PR renders nothing, so no verdict is owed |

--- a/packages/fabrika-cli/src/capture/auth.ts
+++ b/packages/fabrika-cli/src/capture/auth.ts
@@ -17,6 +17,7 @@
  */
 import {createHmac} from "node:crypto";
 import type {CaptureCookie} from "./capture.ts";
+import {CAPTURE_TIERS, type CaptureTier} from "./states.ts";
 
 export const SESSION_COOKIE_BASENAME = "better-auth.session_token";
 export const SECURE_COOKIE_PREFIX = "__Secure-";
@@ -45,23 +46,45 @@ export const sessionCookies = (
 };
 
 /**
- * The credentials an authenticated capture needs, or the names of whichever are unset. Both or
- * neither: a token with no secret cannot be signed, and a secret with no token names no session, so
- * a complete pair is the only arm that renders signed in — one unset name and two are the same
- * refusal, differing only in what they list.
+ * The environment variable carrying each tier's session token. One variable per tier, because the
+ * token IS the identity: an unset one means `preview-seed test-account` did not seed that tier on
+ * this preview, so the refusal below is what stops a surface naming it from falling back to the
+ * seeded identity and shooting the wrong audience clean (#7398). `preview-seed`'s bin reads the
+ * same names on the provisioning side — the two lists move together.
+ */
+export const TIER_TOKEN_ENV: Readonly<Record<CaptureTier, string>> = {
+	yazar: "PREVIEW_TEST_SESSION_TOKEN",
+	çaylak: "PREVIEW_TEST_CAYLAK_SESSION_TOKEN",
+};
+
+/**
+ * The credentials an authenticated capture needs for the tiers a run asks for, or the names of
+ * whichever are unset. All or nothing: a token with no secret cannot be signed, a secret with no
+ * token names no session, and a tier with no token of its own is a tier this preview does not
+ * carry — so one unset name and three are the same refusal, differing only in what they list.
  */
 export type IdentityRead =
-	| {readonly _tag: "Identity"; readonly token: string; readonly secret: string}
+	| {
+			readonly _tag: "Identity";
+			readonly tokens: Readonly<Partial<Record<CaptureTier, string>>>;
+			readonly secret: string;
+	  }
 	| {readonly _tag: "Missing"; readonly names: readonly string[]};
 
-export const readIdentity = (env: Readonly<Record<string, string | undefined>>): IdentityRead => {
-	const token = env.PREVIEW_TEST_SESSION_TOKEN ?? "";
+export const readIdentity = (
+	env: Readonly<Record<string, string | undefined>>,
+	tiers: readonly CaptureTier[],
+): IdentityRead => {
+	const wanted = CAPTURE_TIERS.filter((tier) => tiers.includes(tier));
 	const secret = env.BETTER_AUTH_SECRET ?? "";
+	const found = wanted.map((tier) => [tier, env[TIER_TOKEN_ENV[tier]] ?? ""] as const);
 	const names = [
-		...(token.length === 0 ? ["PREVIEW_TEST_SESSION_TOKEN"] : []),
+		...found.flatMap(([tier, token]) => (token.length === 0 ? [TIER_TOKEN_ENV[tier]] : [])),
 		...(secret.length === 0 ? ["BETTER_AUTH_SECRET"] : []),
 	];
-	return names.length === 0 ? {_tag: "Identity", token, secret} : {_tag: "Missing", names};
+	return names.length === 0
+		? {_tag: "Identity", tokens: Object.fromEntries(found), secret}
+		: {_tag: "Missing", names};
 };
 
 /**
@@ -75,13 +98,22 @@ export const readIdentity = (env: Readonly<Record<string, string | undefined>>):
 export const SESSION_PROBE_PATH = "/api/auth/get-session";
 
 /**
- * Whether a capture context is signed in, decided from the probe's own answer.
+ * Whether a capture context is signed in **and at which tier**, decided from the probe's own
+ * answer. The tier rides here because signed-in is not the whole question: an `:auth` surface whose
+ * audience is defined by *not* clearing the yazar floor renders clean and wrong when the shot came
+ * back as somebody above it (#7398).
+ *
+ * `user.tier` is on the answer because `additionalUserFields` in
+ * `apps/web/worker/features/pasaport/better-auth-live.ts` declares it without `returned: false` —
+ * the flag `promotedAt` carries and `tier` deliberately does not.
  *
  * Three arms, not two: a probe that could not be read is UNKNOWN and must not collapse into
- * "anonymous", because both would refuse but only one of them is a fact about the session.
+ * "anonymous", because both would refuse but only one of them is a fact about the session. A signed
+ * in user whose tier the answer does not carry is Unreadable for the same reason — the tier is
+ * unknown, not wrong.
  */
 export type SessionProof =
-	| {readonly _tag: "SignedIn"; readonly userId: string}
+	| {readonly _tag: "SignedIn"; readonly userId: string; readonly tier: string}
 	| {readonly _tag: "Anonymous"}
 	| {readonly _tag: "Unreadable"; readonly reason: string};
 
@@ -100,7 +132,11 @@ export const readSessionProof = (status: number, body: string): SessionProof => 
 	const user = (parsed as {user?: unknown}).user;
 	if (user === null || user === undefined) return {_tag: "Anonymous"};
 	const id = (user as {id?: unknown}).id;
-	return typeof id === "string" && id.length > 0
-		? {_tag: "SignedIn", userId: id}
-		: {_tag: "Unreadable", reason: "probe named a user with no id"};
+	if (typeof id !== "string" || id.length === 0) {
+		return {_tag: "Unreadable", reason: "probe named a user with no id"};
+	}
+	const tier = (user as {tier?: unknown}).tier;
+	return typeof tier === "string" && tier.length > 0
+		? {_tag: "SignedIn", userId: id, tier}
+		: {_tag: "Unreadable", reason: "probe named a user with no tier"};
 };

--- a/packages/fabrika-cli/src/capture/auth.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/auth.unit.test.ts
@@ -72,29 +72,54 @@ describe("sessionCookies", () => {
 
 describe("readIdentity", () => {
 	it("names both unset halves rather than reading as a complete anonymous default", () => {
-		expect(readIdentity({})).toEqual({
+		expect(readIdentity({}, ["yazar"])).toEqual({
 			_tag: "Missing",
 			names: ["PREVIEW_TEST_SESSION_TOKEN", "BETTER_AUTH_SECRET"],
 		});
 	});
 
 	it("names the one missing half", () => {
-		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN})).toEqual({
+		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN}, ["yazar"])).toEqual({
 			_tag: "Missing",
 			names: ["BETTER_AUTH_SECRET"],
 		});
-		expect(readIdentity({BETTER_AUTH_SECRET: SECRET})).toEqual({
+		expect(readIdentity({BETTER_AUTH_SECRET: SECRET}, ["yazar"])).toEqual({
 			_tag: "Missing",
 			names: ["PREVIEW_TEST_SESSION_TOKEN"],
 		});
 	});
 
 	it("reads a complete pair", () => {
-		expect(readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN, BETTER_AUTH_SECRET: SECRET})).toEqual({
+		expect(
+			readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN, BETTER_AUTH_SECRET: SECRET}, ["yazar"]),
+		).toEqual({_tag: "Identity", tokens: {yazar: TOKEN}, secret: SECRET});
+	});
+
+	/**
+	 * A tier with no token of its own is a tier `preview-seed test-account` did not seed on this
+	 * preview. Reading it as satisfied by the yazar's token is the exact fallback #7398 exists to
+	 * refuse — the shot would come back clean as the audience the surface said it was not.
+	 */
+	it("names the çaylak token when a çaylak surface is asked for and only the yazar's is set", () => {
+		expect(
+			readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN, BETTER_AUTH_SECRET: SECRET}, ["çaylak"]),
+		).toEqual({_tag: "Missing", names: ["PREVIEW_TEST_CAYLAK_SESSION_TOKEN"]});
+	});
+
+	it("reads a token per asked-for tier, and asks for none of a tier no surface named", () => {
+		const env = {
+			PREVIEW_TEST_SESSION_TOKEN: TOKEN,
+			PREVIEW_TEST_CAYLAK_SESSION_TOKEN: `${TOKEN}-caylak`,
+			BETTER_AUTH_SECRET: SECRET,
+		};
+		expect(readIdentity(env, ["çaylak", "yazar"])).toEqual({
 			_tag: "Identity",
-			token: TOKEN,
+			tokens: {yazar: TOKEN, çaylak: `${TOKEN}-caylak`},
 			secret: SECRET,
 		});
+		expect(
+			readIdentity({PREVIEW_TEST_SESSION_TOKEN: TOKEN, BETTER_AUTH_SECRET: SECRET}, []),
+		).toEqual({_tag: "Identity", tokens: {}, secret: SECRET});
 	});
 });
 
@@ -109,10 +134,23 @@ describe("readSessionProof", () => {
 		expect(readSessionProof(200, "null")).toEqual({_tag: "Anonymous"});
 	});
 
-	it("reads a session payload as signed in, naming the user", () => {
-		expect(readSessionProof(200, JSON.stringify({session: {id: "s1"}, user: {id: "u1"}}))).toEqual({
-			_tag: "SignedIn",
-			userId: "u1",
+	it("reads a session payload as signed in, naming the user and its tier", () => {
+		expect(
+			readSessionProof(
+				200,
+				JSON.stringify({session: {id: "s1"}, user: {id: "u1", tier: "çaylak"}}),
+			),
+		).toEqual({_tag: "SignedIn", userId: "u1", tier: "çaylak"});
+	});
+
+	/**
+	 * A signed-in answer carrying no tier is UNKNOWN, not "the default tier": guessing here would
+	 * hand the caller a tier fact nobody read, which is the shape #7398 was filed about.
+	 */
+	it("reads a tier-less user as unreadable, never as a tier", () => {
+		expect(readSessionProof(200, JSON.stringify({user: {id: "u1"}}))).toEqual({
+			_tag: "Unreadable",
+			reason: "probe named a user with no tier",
 		});
 	});
 

--- a/packages/fabrika-cli/src/capture/states.ts
+++ b/packages/fabrika-cli/src/capture/states.ts
@@ -1,32 +1,63 @@
 /**
  * The closed vocabulary of `<route>:<state>` variants a capture can actually put on screen, and the
- * mechanism each one carries (#7051).
+ * mechanism each one carries (#7051, #7398).
  *
  * The list is short on purpose. `plan.ts` has always parsed a state off a surface token, but
  * parsing one is not rendering one: a state with no mechanism captures the default pixels under a
- * variant's file name, which is coverage claimed and not held — the exact defect this ticket was
- * filed about. So a state enters this list only once something here makes the page render
+ * variant's file name, which is coverage claimed and not held — the exact defect this vocabulary
+ * was filed about. So a state enters this list only once something here makes the page render
  * differently, and every other token stays refused as reserved grammar.
  *
- * `auth` is the first: the capture context presents the moderator-tier test account's session
- * cookie (`auth.ts`) and proves the session took before the shot is recorded, so the surface renders
- * as a signed-in yazar+moderator instead of a visitor. The account is provisioned direct-D1 by
- * `preview-seed test-account`, never by a worker route.
+ * Every realized state today is a seeded session, and **the state names the tier it renders at**,
+ * because a tier is an audience: a surface whose whole point is that it renders below yazar — a
+ * çaylak nudge, a pre-promotion prompt — cannot be judged from a yazar's pixels, and the shot comes
+ * back clean showing the state the PR did not add (#7398). Each identity is provisioned direct-D1
+ * by `preview-seed test-account`, never by a worker route, and each shot proves the tier it
+ * actually rendered at before it is recorded.
+ *
+ * `auth` keeps naming the yazar+moderator identity #7051 shipped, so every invocation written
+ * against that ticket still means what it said.
  */
 import {parseSurfaceSpec} from "./plan.ts";
 
-export const REALIZED_STATES = ["auth"] as const;
-export type RealizedState = (typeof REALIZED_STATES)[number];
-
-export const isRealizedState = (state: string): state is RealizedState =>
-	(REALIZED_STATES as readonly string[]).includes(state);
+/**
+ * The authorship tiers a capture identity can render at — `preview-seed`'s `PREVIEW_TIERS`, which
+ * is the `user.tier` enum. Spelled as the stored values because the session probe compares against
+ * what the preview's own session read returns.
+ */
+export const CAPTURE_TIERS = ["yazar", "çaylak"] as const;
+export type CaptureTier = (typeof CAPTURE_TIERS)[number];
 
 /**
- * Whether a state's mechanism is the seeded session, so its shot owes a proof the session took.
- * `auth` is the whole of it today; a future state realized some other way owes a different proof,
- * not this one.
+ * Each realized state and the tier its identity renders at. The state token is ASCII while the tier
+ * it names is not: a `--surface` operand is typed at a shell by hand, and `çaylak` on the operand
+ * would make the fence depend on the caller's keyboard.
  */
-export const provesSession = (state: string | null): boolean => state === "auth";
+export const STATE_TIERS = {
+	auth: "yazar",
+	"auth-caylak": "çaylak",
+} as const satisfies Readonly<Record<string, CaptureTier>>;
+
+export const REALIZED_STATES = Object.keys(STATE_TIERS) as ReadonlyArray<RealizedState>;
+export type RealizedState = keyof typeof STATE_TIERS;
+
+export const isRealizedState = (state: string): state is RealizedState =>
+	Object.hasOwn(STATE_TIERS, state);
+
+/**
+ * The tier a state renders at, or `null` when the state names no seeded identity — the default
+ * (anonymous, visitor) render, or a token outside the vocabulary, which the caller refuses before
+ * anything is shot.
+ */
+export const tierOf = (state: string | null): CaptureTier | null =>
+	state !== null && isRealizedState(state) ? STATE_TIERS[state] : null;
+
+/**
+ * Whether a state's mechanism is a seeded session, so its shot owes a proof the session took and
+ * came back at the named tier. A future state realized some other way owes a different proof, not
+ * this one.
+ */
+export const provesSession = (state: string | null): boolean => tierOf(state) !== null;
 
 /**
  * The state a surface token names, or `null` for the default (anonymous, visitor) render. Read

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -55,14 +55,14 @@ const render = leafCommand(
 		surface: Flag.string("surface").pipe(
 			Flag.atLeast(1),
 			Flag.withDescription(
-				"a surface id to capture — a route such as /pano, or /pano:auth for the signed-in render (proved against the preview's session endpoint before the shot is recorded); repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
+				"a surface id to capture — a route such as /pano, or a route plus a tier state (/pano:auth renders as the yazar test account, /pano:auth-caylak as the çaylak one), each proved signed in AND at the named tier against the preview's session endpoint before the shot is recorded; repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
 			),
 		),
 		// `atLeast(0)` is the repeatable form with no floor: forcing nothing is the ordinary run.
 		flag: Flag.string("flag").pipe(
 			Flag.atLeast(0),
 			Flag.withDescription(
-				"force one flag for this run — <key>=on|off, repeatable; rides the preview's phoenix_flag_overrides cookie, which is honored only for an authorized platform-admin actor, so every --surface must name :auth and each forced key is proved against the preview's own evaluation before the shot is recorded",
+				"force one flag for this run — <key>=on|off, repeatable; rides the preview's phoenix_flag_overrides cookie, which is honored only for an authorized platform-admin actor, so every --surface must name a tier state and each forced key is proved against the preview's own evaluation before the shot is recorded",
 			),
 		),
 		app: Flag.string("app").pipe(
@@ -91,7 +91,7 @@ const render = leafCommand(
 ).pipe(
 	Command.withShortDescription("Capture the named surfaces from a PR's preview deployment."),
 	Command.withDescription(
-		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, a --surface names a :state nothing renders — the realized set is auth, a --flag operand is not a <key>=<on|off> pair, or --flag was passed with an anonymous surface), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, an :auth surface was requested with PREVIEW_TEST_SESSION_TOKEN/BETTER_AUTH_SECRET unset, an :auth surface's session proof did not come back signed in, or a forced flag evaluated at its default anyway), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
+		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, a --surface names a :state nothing renders — the realized set is auth, auth-caylak, a --flag operand is not a <key>=<on|off> pair, or --flag was passed with an anonymous surface), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, a tier-naming surface was requested with that tier's session token or BETTER_AUTH_SECRET unset, a tier-naming surface's session proof did not come back signed in or came back at another tier, or a forced flag evaluated at its default anyway), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
 	),
 );
 

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -24,7 +24,7 @@ import {
 	parseSurfaceSpec,
 } from "../capture/plan.ts";
 import {validateCaptureBytes} from "../capture/png.ts";
-import {provesSession} from "../capture/states.ts";
+import {tierOf} from "../capture/states.ts";
 import {capAndCount} from "../evidence.ts";
 import {PAGE_ERROR_CAP, sha256Hex} from "./manifest.ts";
 import type {RenderLeg, SurfaceRender} from "./render-verb.ts";
@@ -69,13 +69,13 @@ export const makeCaptureRenderLeg =
 
 			// A seeded session is asked to prove itself, because pixels cannot: a cookie that does not
 			// authenticate renders the visitor's page, and that is a valid PNG under the `:auth` name.
-			const probing = provesSession(plan[0]?.surface.state ?? null);
+			const wantedTier = tierOf(plan[0]?.surface.state ?? null);
 			// Same reason one layer over: an override the preview dropped renders the flag-off page,
 			// and that page is a valid PNG under the flag-on name.
 			const forcing = isForcing(request.forcedFlags);
 			const captured = yield* capture(plan, request.outDir, {
 				cookies: request.cookies,
-				...(probing
+				...(wantedTier !== null
 					? {sessionProbeUrl: joinPreviewUrl(request.previewUrl, SESSION_PROBE_PATH)}
 					: {}),
 				...(forcing
@@ -104,7 +104,7 @@ export const makeCaptureRenderLeg =
 			}
 			// Classified before the bytes: an anonymous shot under a signed-in name is a valid PNG of
 			// the wrong page, so validating it first would answer a question nobody asked.
-			if (probing) {
+			if (wantedTier !== null) {
 				const proof = shot.sessionProof;
 				if (proof === undefined || proof._tag !== "SignedIn") {
 					return {
@@ -115,6 +115,16 @@ export const makeCaptureRenderLeg =
 								: proof._tag === "Anonymous"
 									? "the preview answered the seeded cookie as a visitor"
 									: proof.reason,
+					} satisfies SurfaceRender;
+				}
+				// Signed in is not the whole question. A surface whose audience is defined by NOT
+				// clearing a floor renders perfectly for somebody above it, so the tier the preview
+				// itself reports back decides whether these are the pixels the surface id named.
+				if (proof.tier !== wantedTier) {
+					return {
+						_tag: "WrongTier",
+						wanted: wantedTier,
+						rendered: proof.tier,
 					} satisfies SurfaceRender;
 				}
 			}

--- a/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
@@ -132,7 +132,7 @@ describe("captureRenderLeg — the :auth session proof", () => {
 		const asked: Array<string | undefined> = [];
 		const spy: CaptureShots = (_plan, _outDir, options) => {
 			asked.push(options?.sessionProbeUrl);
-			return authShot({sessionProof: {_tag: "SignedIn", userId: "u1"}})([], "", {});
+			return authShot({sessionProof: {_tag: "SignedIn", userId: "u1", tier: "yazar"}})([], "", {});
 		};
 		runAuth(spy);
 		run(spy);
@@ -141,9 +141,9 @@ describe("captureRenderLeg — the :auth session proof", () => {
 	});
 
 	it("records the shot only when the proof came back signed in", () => {
-		expect(runAuth(authShot({sessionProof: {_tag: "SignedIn", userId: "u1"}}))._tag).toBe(
-			"Rendered",
-		);
+		expect(
+			runAuth(authShot({sessionProof: {_tag: "SignedIn", userId: "u1", tier: "yazar"}}))._tag,
+		).toBe("Rendered");
 	});
 
 	it("refuses a visitor's render under the :auth name", () => {
@@ -162,6 +162,51 @@ describe("captureRenderLeg — the :auth session proof", () => {
 });
 
 /**
+ * The tier half of the same proof (#7398). Every arm here IS signed in and decodes fine — the whole
+ * defect is that a yazar's render of a çaylak-only surface is a clean, valid capture of the audience
+ * the feature is designed never to show.
+ */
+describe("captureRenderLeg — the rendered actor's tier", () => {
+	const caylakRequest = {...request, surface: "/hosgeldin:auth-caylak"};
+	const caylakShot =
+		(tier: string): CaptureShots =>
+		() =>
+			Effect.succeed([
+				{
+					surface: "/hosgeldin:auth-caylak",
+					route: "/hosgeldin",
+					state: "auth-caylak",
+					localPath: "/tmp/shots/hosgeldin-auth-caylak.png",
+					fileName: "hosgeldin-auth-caylak.png",
+					pngBytes: pngHeader(),
+					pageErrors: [],
+					status: 200,
+					sessionProof: {_tag: "SignedIn" as const, userId: "u1", tier},
+				},
+			]);
+	const runCaylak = (capture: CaptureShots): SurfaceRender =>
+		Effect.runSync(makeCaptureRenderLeg(capture)(caylakRequest));
+
+	it("records the shot when the preview reports the tier the surface named", () => {
+		expect(runCaylak(caylakShot("çaylak"))._tag).toBe("Rendered");
+	});
+
+	it("refuses a yazar's render under the çaylak name — a clean capture of the wrong audience", () => {
+		expect(runCaylak(caylakShot("yazar"))).toEqual({
+			_tag: "WrongTier",
+			wanted: "çaylak",
+			rendered: "yazar",
+		});
+	});
+
+	it("refuses a çaylak's render under the yazar-tier :auth name too — the fence runs both ways", () => {
+		expect(
+			runAuth(authShot({sessionProof: {_tag: "SignedIn", userId: "u1", tier: "çaylak"}})),
+		).toEqual({_tag: "WrongTier", wanted: "yazar", rendered: "çaylak"});
+	});
+});
+
+/**
  * One layer over the session proof and for the same reason: a preview that dropped the override
  * cookie renders the flag-off page, and that page is a valid PNG under the flag-on name (#7218).
  */
@@ -170,7 +215,7 @@ describe("captureRenderLeg — the forced-flag proof", () => {
 	const forcedRequest = {...authRequest, forcedFlags: FORCED};
 	const runForced = (capture: CaptureShots): SurfaceRender =>
 		Effect.runSync(makeCaptureRenderLeg(capture)(forcedRequest));
-	const signedIn = {_tag: "SignedIn", userId: "u1"} as const;
+	const signedIn = {_tag: "SignedIn", userId: "u1", tier: "yazar"} as const;
 
 	it("asks the preview's own evaluation seam, and asks nothing when no flag is forced", () => {
 		const asked: Array<unknown> = [];

--- a/packages/fabrika-cli/src/review-ui/render-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.ts
@@ -14,10 +14,13 @@
  * A surface may name a state (`/pano:auth`), but only one this repo can actually put on screen —
  * the vocabulary and its mechanism live in `capture/states.ts`. Anything else is refused rather
  * than shot, because a state nothing renders captures the default pixels under a variant's name,
- * which is coverage claimed and not held (#7051). An `:auth` surface is refused twice over: on `11`
- * before a browser launches when the credentials are incomplete, and on `11` again when the shot's
- * own session proof does not come back signed in — a cookie that failed to authenticate produces a
- * perfectly valid PNG of the visitor's page, which no byte check can tell from the real thing.
+ * which is coverage claimed and not held (#7051). Every realized state names the **tier** it renders
+ * at, and a tier-naming surface is refused three times over, all on `11`: before a browser launches
+ * when that tier's credentials are incomplete — an unset tier token is a tier `preview-seed
+ * test-account` did not seed, and falling back to the seeded one would shoot the wrong audience
+ * clean (#7398); when the shot's own session proof does not come back signed in; and when that proof
+ * comes back at a different tier than the surface named. Each produces a perfectly valid PNG of a
+ * page nobody asked for, which no byte check can tell from the real thing.
  *
  * `--flag <key>=<on|off>` forces a dark-shipped flag for the run (ADR 0336, #7218), and it is
  * refused twice over on the same shape: on `10` when an operand is unreadable or names an anonymous
@@ -36,7 +39,14 @@ import {
 	overrideCookies,
 	parseFlagOperands,
 } from "../capture/flag-override.ts";
-import {isRealizedState, provesSession, REALIZED_STATES, stateOf} from "../capture/states.ts";
+import {
+	type CaptureTier,
+	isRealizedState,
+	provesSession,
+	REALIZED_STATES,
+	stateOf,
+	tierOf,
+} from "../capture/states.ts";
 import {writeFile} from "../io/fs.ts";
 import {listComments} from "../io/issues.ts";
 import {openPull, resolveTargetRepo, scannedLine} from "../review/target.ts";
@@ -88,6 +98,7 @@ export type SurfaceRender =
 	| {readonly _tag: "Crashed"; readonly firstError: string}
 	| {readonly _tag: "Invalid"; readonly detail: string}
 	| {readonly _tag: "Unauthenticated"; readonly reason: string}
+	| {readonly _tag: "WrongTier"; readonly wanted: CaptureTier; readonly rendered: string}
 	| {readonly _tag: "OverrideInert"; readonly reason: string}
 	| {readonly _tag: "Failed"; readonly reason: string};
 
@@ -147,6 +158,8 @@ const outcomeLine = (surface: string, render: SurfaceRender): string => {
 			return `${VERB}: surface "${surface}" captured invalid bytes (${render.detail}) — a capture nobody can open is not evidence (#3925's class).`;
 		case "Unauthenticated":
 			return `${VERB}: surface "${surface}" did not render signed in (${render.reason}) — the authenticated render is UNKNOWN, never the anonymous one.`;
+		case "WrongTier":
+			return `${VERB}: surface "${surface}" named tier ${render.wanted} and rendered as ${render.rendered} — the named tier's render is UNKNOWN, never another tier's.`;
 		case "OverrideInert":
 			return `${VERB}: surface "${surface}" did not render with its forced flags (${render.reason}) — the forced render is UNKNOWN, never the default one.`;
 		case "Failed":
@@ -209,7 +222,7 @@ export const runRender = (
 			if (anonymous !== undefined) {
 				return refuse(
 					OFF_VOCABULARY,
-					`${VERB}: --flag was passed with the anonymous surface "${anonymous}" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name every surface :auth.`,
+					`${VERB}: --flag was passed with the anonymous surface "${anonymous}" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name a tier state (${REALIZED_STATES.join(", ")}) on every surface.`,
 				);
 			}
 		}
@@ -266,38 +279,44 @@ export const runRender = (
 			);
 		}
 
-		// An `:auth` surface rendered without credentials would come back as the visitor's page under
-		// the signed-in name — the "unseen ground reading as clean" this whole axis exists to stop —
-		// so an incomplete pair is UNKNOWN here, before a browser launches.
-		const wantsAuth = options.surfaces.some((surface) => provesSession(stateOf(surface)));
-		const identity = readIdentity(options.env);
-		if (wantsAuth && identity._tag === "Missing") {
+		// A tier-naming surface rendered without that tier's credentials would come back as the
+		// visitor's page — or worse, as the one tier this preview did seed — under the named tier's
+		// name. That is the "unseen ground reading as clean" this whole axis exists to stop, so an
+		// incomplete credential set is UNKNOWN here, before a browser launches. A tier whose token is
+		// unset is a tier `preview-seed test-account` did not seed on this preview (#7398).
+		const wantedTiers = options.surfaces.flatMap((surface) => {
+			const tier = tierOf(stateOf(surface));
+			return tier === null ? [] : [tier];
+		});
+		const identity = readIdentity(options.env, wantedTiers);
+		if (wantedTiers.length > 0 && identity._tag === "Missing") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: an :auth surface was requested but its credentials are incomplete (unset: ${identity.names.join(", ")}) — the authenticated render is UNKNOWN, never the anonymous one.`,
+				`${VERB}: a tier-naming surface was requested but its credentials are incomplete (unset: ${identity.names.join(", ")}) — the named tier's render is UNKNOWN, never a seeded substitute.`,
 				[scanned],
 			);
 		}
-		const authCookies: readonly CaptureCookie[] =
-			identity._tag === "Identity"
-				? sessionCookies(announced.url, identity.token, identity.secret)
-				: [];
+		const cookiesFor = (tier: CaptureTier): readonly CaptureCookie[] => {
+			if (identity._tag !== "Identity") return [];
+			const token = identity.tokens[tier];
+			return token === undefined ? [] : sessionCookies(announced.url, token, identity.secret);
+		};
 		const forcedCookies = overrideCookies(announced.url, forcedFlags);
 
 		const setDir = setDirectory(options.tmpRoot, pr, head, options.out);
 		const renders: SurfaceRender[] = [];
 		for (const surface of options.surfaces) {
-			// Only the `:auth` variant carries the session and the override; a bare route stays the
-			// visitor's render at every flag's default, so the two are genuinely different pixels
-			// rather than one shot twice.
-			const authenticated = provesSession(stateOf(surface));
+			// Only a tier-naming variant carries a session and the override, and it carries ITS OWN
+			// tier's session: a bare route stays the visitor's render at every flag's default, so each
+			// is genuinely different pixels rather than one shot repeated.
+			const tier = tierOf(stateOf(surface));
 			renders.push(
 				yield* options.render({
 					surface,
 					previewUrl: announced.url,
 					outDir: setDir,
-					cookies: authenticated ? [...authCookies, ...forcedCookies] : [],
-					forcedFlags: authenticated ? forcedFlags : NO_FORCED_FLAGS,
+					cookies: tier === null ? [] : [...cookiesFor(tier), ...forcedCookies],
+					forcedFlags: tier === null ? NO_FORCED_FLAGS : forcedFlags,
 				}),
 			);
 		}
@@ -316,9 +335,12 @@ export const runRender = (
 		}
 		// Ahead of the proven-red codes below, and deliberately: the shot is a fine PNG of the wrong
 		// page, so routing it as a red surface would accuse the PR of a defect the render never saw.
-		// The two arms are one class — wrong session, wrong flag state — and route alike.
+		// The three arms are one class — wrong session, wrong tier, wrong flag state — and route alike.
 		const wrongPage = renders.findIndex(
-			(render) => render._tag === "Unauthenticated" || render._tag === "OverrideInert",
+			(render) =>
+				render._tag === "Unauthenticated" ||
+				render._tag === "WrongTier" ||
+				render._tag === "OverrideInert",
 		);
 		if (wrongPage !== -1) {
 			return refuse(

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -180,6 +180,61 @@ describe("runRender", () => {
 		expect(seen.get("/pano:auth")).toBe(2);
 	});
 
+	// A tier with no token of its own is a tier `preview-seed test-account` did not seed on this
+	// preview. Reading it as satisfied by the yazar's token would render the audience the surface
+	// said it was not, and the capture would come back clean (#7398).
+	it("refuses a çaylak surface whose tier token is unset, naming it rather than falling back", async () => {
+		const {outcome} = await run(happy(), {
+			surfaces: ["/hosgeldin:auth-caylak"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("PREVIEW_TEST_CAYLAK_SESSION_TOKEN");
+	});
+
+	it("seeds each tier's own session, so two tiers are two identities and not one shot twice", async () => {
+		const seen = new Map<string, string | undefined>();
+		const {outcome} = await run(happy(), {
+			surfaces: ["/hosgeldin:auth", "/hosgeldin:auth-caylak"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_SESSION_TOKEN: "t".repeat(32),
+				PREVIEW_TEST_CAYLAK_SESSION_TOKEN: "c".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: (request) => {
+				seen.set(request.surface, request.cookies[0]?.value);
+				return Effect.succeed(rendered(request.surface, request.outDir));
+			},
+		});
+		expect(outcome.code).toBe(0);
+		expect(seen.get("/hosgeldin:auth")).not.toBe(seen.get("/hosgeldin:auth-caylak"));
+	});
+
+	// The credential check only proves each tier's token was SET. Which tier actually rendered is the
+	// shot's own answer, and a shot that came back above the named floor is UNKNOWN — the page
+	// rendered fine, it is just not the audience the surface id named (#7398).
+	it("refuses a wrong-tier shot on 11, recording no capture under that surface id", async () => {
+		const {outcome, written} = await run(happy(), {
+			surfaces: ["/hosgeldin:auth-caylak"],
+			env: {
+				CLAUDE_PIPELINE_REPO: "o/r",
+				PREVIEW_TEST_CAYLAK_SESSION_TOKEN: "c".repeat(32),
+				BETTER_AUTH_SECRET: "s".repeat(32),
+			},
+			render: legOf({
+				"/hosgeldin:auth-caylak": {_tag: "WrongTier", wanted: "çaylak", rendered: "yazar"},
+			}),
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("named tier çaylak and rendered as yazar");
+		expect(written.size).toBe(0);
+	});
+
 	// The credential check only proves the pair was SET. Whether the cookie actually authenticated is
 	// the shot's own answer, and a shot that came back a visitor's is UNKNOWN — never a red surface,
 	// because the page rendered fine, and never a Rendered entry under the `:auth` id (#7051).

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -35,7 +35,7 @@ A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
   of the canonical `apps/web/worker/db/drizzle/migrations` columns).
 - `src/seed.ts` — idempotent upserts; runs against any `D1Database` (in-memory
   test fake or REST adapter) and also emits `{sql, params}` for the REST batch.
-- `src/test-account.ts` — the review-ui test account + its session row.
+- `src/test-account.ts` — the review-ui test accounts, one per tier, + their session rows.
 - `src/bin.ts` — the `preview-seed run` and `preview-seed test-account` CLI.
 
 ## Running it
@@ -57,53 +57,84 @@ Transport is the Cloudflare D1 REST query API via alchemy's already-installed
 `@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
 migrations to a deployed D1, so no new Cloudflare dependency and no workerd.
 
-## The review-ui test account
+## The review-ui test accounts
 
 `review-ui render` judges what renders, and until now that could only be the
 anonymous view: a per-PR preview deploys an empty D1, so nothing behind login
 existed to shoot and a UI delta that only appears signed in ended a review as
-unseen ground reading clean (issue #7051). This verb provisions the one account
-that render authenticates as.
+unseen ground reading clean (issue #7051). This verb provisions the accounts that
+render authenticates as.
 
 ```bash
 PREVIEW_TEST_SESSION_TOKEN=<32+ char secret> \
+PREVIEW_TEST_CAYLAK_SESSION_TOKEN=<a different 32+ char secret> \
   node packages/preview-seed/src/bin.ts test-account --database-id <preview-d1-uuid>
 ```
 
-It writes three rows in one atomic D1 `batch` — the `user` row at
-`moderator` + `yazar`, its `session` row carrying the supplied token, and the
-`(id, "moderates", "platform:platform")` tuple that is the real moderation
-authority (ADR 0107 §4; `user.role` is vestigial and written only so a coarse
-read agrees). Re-running it upserts the same rows, so the token can be rotated by
+Every write lands in one atomic D1 `batch`: a `user` row and a `session` row per
+tier, plus the `(id, "moderates", "platform:platform")` tuple that is the real
+moderation authority (ADR 0107 §4; `user.role` is vestigial and written only so a
+coarse read agrees). Re-running it upserts the same rows, so a token is rotated by
 re-running with a new one.
 
-`review-ui render --surface /pano:auth` then signs that same token with the
+`review-ui render --surface /pano:auth` then signs that tier's token with the
 preview worker's `$BETTER_AUTH_SECRET` and seeds it as the better-auth session
 cookie. Before it records the shot it asks the preview's own
-`/api/auth/get-session` from that same browser context and requires a user back,
-so a token that is wrong, expired or missing from this D1 refuses the render as
-UNKNOWN instead of filing the visitor's pixels under the `:auth` name.
+`/api/auth/get-session` from that same browser context and requires a user back at
+the tier the surface named, so a token that is wrong, expired or missing from this
+D1 — or a shot that came back as another tier — refuses the render as UNKNOWN
+instead of filing somebody else's pixels under that surface id.
+
+### The tier axis — one identity per audience
+
+A tier is an audience, so one identity is not enough (issue #7398). A surface whose
+whole point is that it renders *below* yazar — a çaylak nudge, a vouch prompt, a
+pre-promotion affordance — is suppressed for anyone clearing the floor, so a
+yazar's capture of it comes back `captured`, valid and decodable, showing the
+state the PR did not add. That is the dangerous shape: a clean-looking capture of
+the wrong audience.
+
+| Tier | Account id | Username | `moderates` tuple | Token variable | Surface state |
+| --- | --- | --- | --- | --- | --- |
+| `yazar` | `preview-test-moderator` | `onizleme-mod` | yes | `$PREVIEW_TEST_SESSION_TOKEN` | `:auth` |
+| `çaylak` | `preview-test-caylak` | `onizleme-caylak` | no | `$PREVIEW_TEST_CAYLAK_SESSION_TOKEN` | `:auth-caylak` |
+
+The çaylak gets no moderation tuple, and that is the point of the tier: an identity
+holding moderation authority renders a moderator's affordances whatever its `tier`
+column says.
+
+**A tier with no token is left unseeded, and nothing substitutes for it.** This verb
+seeds exactly the tiers whose variable is set and names the rest in its output; a
+run with none set refuses rather than picking a default. On the capture side the
+same variable is the fence: `review-ui render` refuses a surface naming a tier whose
+token is unset — on `11`, before a browser launches — instead of falling back to the
+seeded identity. The two lists are hand-kept in step, here and in `fabrika-cli`'s
+`src/capture/auth.ts`.
 
 ### Forcing a dark-shipped flag needs one more grant
 
 `review-ui render --flag <key>=on` forces a flag for the capture (issue #7218, ADR
 0336) through the worker's `phoenix_flag_overrides` cookie, and a deployed stage
 honors that cookie only for a request whose actor holds **platform admin** —
-`moderates` is a different relation. This account is provisioned with moderation
-authority and nothing more, deliberately: an ordinary `:auth` capture should show
-a plain yazar+moderator's view, not an admin's affordances.
+`moderates` is a different relation. Neither account is provisioned with admin,
+deliberately: an ordinary tier capture should show that tier's plain view, not an
+admin's affordances.
 
 So the admin grant is a separate, opt-in step on the same throwaway preview D1,
-minted offline through the sanctioned path (ADR 0107 §4):
+minted offline through the sanctioned path (ADR 0107 §4), against whichever tier's
+account the run renders as:
 
 ```bash
 node packages/admin-grant/src/bin.ts grant \
   --user-id preview-test-moderator --database-id <preview-d1-uuid>
 ```
 
+Admin is a relation tuple and not a tier, so a granted `preview-test-caylak` is
+still a çaylak and the render's tier proof still binds.
+
 The same guard boundary applies and is not relaxed by anything here: the target is
 a throwaway preview, `override-authz.ts` is untouched, and no worker route mints
-either the account or the grant.
+either the accounts or the grant.
 
 ### The guard boundary — load-bearing
 
@@ -117,11 +148,17 @@ strictly worse than the seeder routes that were removed.
 it.** A caller-asserted "this is a preview" proves nothing, so the verb reads the
 target instead: a preview/stage D1 deploys empty and this package's content
 fixtures denormalize their author, so a throwaway carries **no human `user` row at
-all**. Finding one that is not the test identity, the verb refuses and writes
+all**. Finding one that is none of the test identities, the verb refuses and writes
 nothing — that database is somebody's real world.
 
+**The tier axis widens the identity list and nothing else.** Every seeded tier is
+excluded from that count, which is what keeps a re-run idempotent once both are on
+the D1 — a check that knew only one of them would call the other somebody's real
+world and refuse every subsequent run. It excludes exactly the fixed ids in the
+table above, so it does not admit one further row.
+
 Say the reach exactly, because the argument against an override flag rests on it.
-The check is *no human `user` row other than the test identity*. It catches any
+The check is *no human `user` row other than the test identities*. It catches any
 database anyone has ever signed into, which is every real one in practice. It does
 **not** catch an empty database that is not a throwaway — a fresh apex deploy
 before the first sign-up, a wiped stage, a mistyped `--database-id` that resolves
@@ -130,8 +167,9 @@ to a real-but-unpopulated D1 all pass it. The operator still owns which
 happens: pointing at a live database and minting a moderator in it. There is no
 override flag, and adding one would be adding back the hole the check closes.
 
-**The token is a live moderator credential.** It is read only from
-`$PREVIEW_TEST_SESSION_TOKEN` (never a flag, so it stays out of process listings),
-must be at least 32 characters, and is refused if it carries whitespace, `;` or
-`,`. Treat it like any other CI secret: scope it to preview, rotate it by
-re-running the verb.
+**Each token is a live credential on a running preview.** Every one is read only
+from its own environment variable (never a flag, so it stays out of process
+listings), must be at least 32 characters, and is refused if it carries whitespace,
+`;` or `,`. Give each tier a different one — sharing a value across two identities
+makes a leak of either a leak of both. Treat them like any other CI secret: scope
+them to preview, rotate one by re-running the verb.

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -1,8 +1,8 @@
 /**
  * `preview-seed run` seeds a deployed stage's D1 with the fixtures the unauthenticated read e2e
- * specs sample; `preview-seed test-account` provisions the moderator-tier account an authenticated
- * `review-ui` capture renders as (#7051). Both talk to D1 over the REST query API, never a worker
- * route: the admin seeder routes were deleted as a fail-open hole (CLAUDE.md, "Sözlük seed").
+ * specs sample; `preview-seed test-account` provisions the per-tier accounts an authenticated
+ * `review-ui` capture renders as (#7051, #7398). Both talk to D1 over the REST query API, never a
+ * worker route: the admin seeder routes were deleted as a fail-open hole (CLAUDE.md, "Sözlük seed").
  */
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
@@ -14,9 +14,13 @@ import {seed} from "./seed.ts";
 import {
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
+	PREVIEW_TIERS,
+	type PreviewCredentials,
+	type PreviewTier,
 	parseSessionToken,
-	provisionTestAccount,
-	TEST_ACCOUNT,
+	provisionTestAccounts,
+	type SessionToken,
+	TEST_ACCOUNTS,
 } from "./test-account.ts";
 
 class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
@@ -55,25 +59,55 @@ const run = Command.make(
 	}),
 ).pipe(Command.withDescription("Seed a stage's D1 with the unauth read-flow fixtures"));
 
+/**
+ * The environment variable carrying each tier's session token. One variable per tier, because the
+ * token IS the identity: a single variable reused across tiers would make a mistyped run provision
+ * the wrong audience under the right name. `review-ui render` reads the same names on the capture
+ * side (`fabrika-cli`'s `capture/auth.ts`) — the two lists move together.
+ */
+const TIER_TOKEN_ENV: Readonly<Record<PreviewTier, string>> = {
+	yazar: "PREVIEW_TEST_SESSION_TOKEN",
+	çaylak: "PREVIEW_TEST_CAYLAK_SESSION_TOKEN",
+};
+
 /** The target is not a throwaway — a database holding somebody's accounts is never provisioned. */
 class NotThrowawayError extends Schema.TaggedErrorClass<NotThrowawayError>()(
 	"@kampus/preview-seed/NotThrowawayError",
 	{foreignAccounts: Schema.Number, databaseId: Schema.String},
 ) {
 	override get message(): string {
-		return `preview-seed: D1 ${this.databaseId} holds ${this.foreignAccounts} account(s) that are not the test identity — that is not a throwaway preview/stage, and no test account was written. Target a freshly deployed preview D1.`;
+		return `preview-seed: D1 ${this.databaseId} holds ${this.foreignAccounts} account(s) that are none of the test identities — that is not a throwaway preview/stage, and no test account was written. Target a freshly deployed preview D1.`;
 	}
 }
 
 /** The supplied token is too short or carries a cookie-illegal character — refused before any write. */
 class WeakSessionTokenError extends Schema.TaggedErrorClass<WeakSessionTokenError>()(
 	"@kampus/preview-seed/WeakSessionTokenError",
+	{variable: Schema.String},
+) {
+	override get message(): string {
+		return `preview-seed: $${this.variable} must be at least ${MIN_SESSION_TOKEN_LEN} characters with no whitespace, ';' or ',' — it is the whole credential for a live preview identity.`;
+	}
+}
+
+/** No tier was named — a run that seeds nothing must say so, never fall back to a default tier. */
+class NoCredentialsError extends Schema.TaggedErrorClass<NoCredentialsError>()(
+	"@kampus/preview-seed/NoCredentialsError",
 	{},
 ) {
 	override get message(): string {
-		return `preview-seed: $PREVIEW_TEST_SESSION_TOKEN must be at least ${MIN_SESSION_TOKEN_LEN} characters with no whitespace, ';' or ',' — it is the whole credential for a moderator on a live preview.`;
+		return `preview-seed: no tier token is set — set at least one of ${PREVIEW_TIERS.map((tier) => `$${TIER_TOKEN_ENV[tier]}`).join(", ")}. A tier with no token is left unseeded, and review-ui refuses a surface naming it.`;
 	}
 }
+
+/** Read one tier's token: absent ⇒ this run does not seed the tier; present-but-weak ⇒ refused. */
+const readTierToken = Effect.fn(function* (tier: PreviewTier) {
+	const raw = yield* Config.option(Config.redacted(TIER_TOKEN_ENV[tier]));
+	if (Option.isNone(raw)) return null;
+	const token = parseSessionToken(Redacted.value(raw.value));
+	if (token === null) return yield* new WeakSessionTokenError({variable: TIER_TOKEN_ENV[tier]});
+	return token satisfies SessionToken;
+});
 
 const testAccount = Command.make(
 	"test-account",
@@ -82,34 +116,41 @@ const testAccount = Command.make(
 		const resolvedAccount = Option.isSome(accountId)
 			? accountId.value
 			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
-		const raw = yield* Config.redacted("PREVIEW_TEST_SESSION_TOKEN");
-		const token = parseSessionToken(Redacted.value(raw));
-		if (token === null) return yield* new WeakSessionTokenError();
+		const credentials: PreviewCredentials = Object.fromEntries(
+			(yield* Effect.forEach(PREVIEW_TIERS, (tier) =>
+				readTierToken(tier).pipe(Effect.map((token) => [tier, token] as const)),
+			)).filter(([, token]) => token !== null),
+		);
 
 		const db = makeTestAccountDb(
 			makeD1Rest({accountId: resolvedAccount, databaseId, layer: restLayer}),
 		);
 		const outcome = yield* Effect.tryPromise({
-			try: () => provisionTestAccount(db, token),
+			try: () => provisionTestAccounts(db, credentials),
 			catch: (cause) => new D1RestError({cause}),
 		});
+		if (outcome._tag === "NoCredentials") return yield* new NoCredentialsError();
 		if (outcome._tag === "NotThrowaway") {
 			return yield* new NotThrowawayError({foreignAccounts: outcome.foreignAccounts, databaseId});
 		}
+		const provisioned = outcome.report.tiers
+			.map((tier) => `@${TEST_ACCOUNTS[tier].username} at ${tier}`)
+			.join(", ");
+		const unseeded = PREVIEW_TIERS.filter((tier) => !outcome.report.tiers.includes(tier));
 		yield* Console.log(
-			`preview-seed: ok — @${TEST_ACCOUNT.username} provisioned as moderator+yazar on D1 ${databaseId}, ${outcome.report.tuples} new moderates tuple(s), session valid to ${outcome.report.expiresAt.toISOString()}`,
+			`preview-seed: ok — provisioned ${provisioned} on D1 ${databaseId}, ${outcome.report.tuples} new moderates tuple(s), sessions valid to ${outcome.report.expiresAt.toISOString()}${unseeded.length === 0 ? "" : `; unseeded: ${unseeded.join(", ")}`}`,
 		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Provision the moderator-tier review-ui test account + its session on a throwaway preview/stage D1 — idempotent, refuses a database holding real accounts",
+		"Provision the review-ui test accounts + their sessions on a throwaway preview/stage D1, one per tier whose token is set ($PREVIEW_TEST_SESSION_TOKEN for yazar, $PREVIEW_TEST_CAYLAK_SESSION_TOKEN for çaylak) — idempotent, refuses a database holding real accounts, and prints the tiers provisioned plus any left unseeded",
 	),
 );
 
 const cli = Command.make("preview-seed").pipe(
 	Command.withSubcommands([run, testAccount]),
 	Command.withDescription(
-		"Direct-D1 seed for the preview stage's unauthenticated read flows (#521) and its review-ui test account (#7051)",
+		"Direct-D1 seed for the preview stage's unauthenticated read flows (#521) and its per-tier review-ui test accounts (#7051, #7398)",
 	),
 );
 

--- a/packages/preview-seed/src/index.ts
+++ b/packages/preview-seed/src/index.ts
@@ -11,13 +11,21 @@ export type {SeedSchema} from "./schema.ts";
 export {seedSchema} from "./schema.ts";
 export type {SeedDb, SeedReport} from "./seed.ts";
 export {buildSeedStatements, makeSeedDb, seed} from "./seed.ts";
-export type {ProvisionOutcome, ProvisionReport, SessionToken} from "./test-account.ts";
+export type {
+	PreviewCredentials,
+	PreviewTier,
+	ProvisionOutcome,
+	ProvisionReport,
+	SessionToken,
+	TestAccount,
+} from "./test-account.ts";
 export {
 	countForeignAccounts,
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
+	PREVIEW_TIERS,
 	parseSessionToken,
-	provisionTestAccount,
+	provisionTestAccounts,
 	SESSION_TTL_MS,
-	TEST_ACCOUNT,
+	TEST_ACCOUNTS,
 } from "./test-account.ts";

--- a/packages/preview-seed/src/test-account.ts
+++ b/packages/preview-seed/src/test-account.ts
@@ -1,10 +1,18 @@
 /**
- * Provision the single moderator-tier test account a `review-ui` capture authenticates as,
- * and the session row whose token becomes that capture's cookie (issue #7051).
+ * Provision the tier-keyed test accounts a `review-ui` capture authenticates as, and the session
+ * row whose token becomes that capture's cookie (issues #7051, #7398).
+ *
+ * **One account per tier, because a tier is an audience.** A surface whose whole point is that it
+ * renders *below* yazar — a çaylak nudge, a pre-promotion prompt — cannot be rendered by an
+ * identity that clears the floor, and the shot comes back clean showing the state the PR did not
+ * add (#7398). So the identity set is keyed by {@link PREVIEW_TIERS} and a caller provisions
+ * whichever tiers it holds a token for; a tier with no token is left unseeded, and the capture verb
+ * refuses a surface naming it rather than falling back to a seeded one.
  *
  * Direct-D1 like the rest of this package — never a runtime worker route (CLAUDE.md, "Sözlük
  * seed"). Moderation authority is the `(id, "moderates", key(platform))` tuple, not `user.role`
- * (ADR 0107 §4); the vestigial column is written beside it only so a coarse role read agrees.
+ * (ADR 0107 §4); the vestigial column is written beside it only so a coarse role read agrees. Only
+ * the yazar identity carries that tuple: a çaylak with moderation authority is not a çaylak.
  *
  * The throwaway fence is the load-bearing part. A caller-asserted "this is a preview" proves
  * nothing, so the refusal is grounded in the database itself: a preview/stage D1 is deployed
@@ -20,7 +28,8 @@
  * carries credentials for signing IN, which this path skips by construction.
  */
 import {key, platform} from "@kampus/authz";
-import {and, eq, ne} from "drizzle-orm";
+import {and, eq, notInArray} from "drizzle-orm";
+import type {BatchItem} from "drizzle-orm/batch";
 import {drizzle} from "drizzle-orm/d1";
 import {defineRelations} from "drizzle-orm/relations";
 import {relationTuple, seedSchema, session, user} from "./schema.ts";
@@ -38,26 +47,62 @@ export const PLATFORM = key(platform);
 export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * The one test identity. Fixed so every provision is an upsert on the same row rather than a new
- * account per run, and `.invalid` per RFC 2606 so the address can never reach a mailbox.
+ * The authorship tiers a preview identity can be provisioned at — the `user.tier` enum's own
+ * values, so a tier that does not exist in the schema cannot be named here.
  */
-export const TEST_ACCOUNT = {
-	id: "preview-test-moderator",
-	email: "preview-test-moderator@preview.invalid",
-	username: "onizleme-mod",
-	name: "Önizleme Moderatörü",
-	role: "moderator",
-	tier: "yazar",
-	sessionId: "preview-test-moderator-session",
-} as const;
+export const PREVIEW_TIERS = ["yazar", "çaylak"] as const;
+export type PreviewTier = (typeof PREVIEW_TIERS)[number];
+
+export interface TestAccount {
+	readonly id: string;
+	readonly email: string;
+	readonly username: string;
+	readonly name: string;
+	readonly role: "member" | "moderator";
+	readonly tier: PreviewTier;
+	readonly sessionId: string;
+	/** Whether this identity is granted the platform `moderates` tuple. */
+	readonly moderates: boolean;
+}
+
+/**
+ * The test identities, one per tier. Each is fixed so every provision is an upsert on the same row
+ * rather than a new account per run, and `.invalid` per RFC 2606 so no address can reach a mailbox.
+ * The yazar's id is the one #7051 shipped and is unchanged — `admin-grant` invocations and preview
+ * D1s in flight name it.
+ */
+export const TEST_ACCOUNTS = {
+	yazar: {
+		id: "preview-test-moderator",
+		email: "preview-test-moderator@preview.invalid",
+		username: "onizleme-mod",
+		name: "Önizleme Moderatörü",
+		role: "moderator",
+		tier: "yazar",
+		sessionId: "preview-test-moderator-session",
+		moderates: true,
+	},
+	çaylak: {
+		id: "preview-test-caylak",
+		email: "preview-test-caylak@preview.invalid",
+		username: "onizleme-caylak",
+		name: "Önizleme Çaylağı",
+		role: "member",
+		tier: "çaylak",
+		sessionId: "preview-test-caylak-session",
+		moderates: false,
+	},
+} as const satisfies Record<PreviewTier, TestAccount>;
+
+const TEST_ACCOUNT_IDS = PREVIEW_TIERS.map((tier) => TEST_ACCOUNTS[tier].id);
 
 declare const SessionTokenBrand: unique symbol;
 /** A session token that has passed {@link parseSessionToken} — the only thing provisioning accepts. */
 export type SessionToken = string & {readonly [SessionTokenBrand]: true};
 
 /**
- * better-auth mints a 32-byte session token, and this one is the whole credential for a moderator
- * on a live preview, so a short one is refused rather than written.
+ * better-auth mints a 32-byte session token, and each one here is the whole credential for a live
+ * preview identity, so a short one is refused rather than written.
  */
 export const MIN_SESSION_TOKEN_LEN = 32;
 
@@ -66,80 +111,118 @@ export const parseSessionToken = (raw: string): SessionToken | null =>
 		? (raw.trim() as SessionToken)
 		: null;
 
+/**
+ * One token per tier to provision. A tier absent here is a tier this run does not seed — the
+ * record shape is what makes "the same tier twice" unrepresentable.
+ */
+export type PreviewCredentials = Partial<Readonly<Record<PreviewTier, SessionToken>>>;
+
 export interface ProvisionReport {
-	/** `user` rows written — always 1 (the upsert reports the row it touched). */
-	readonly account: number;
-	/** `session` rows written — always 1; the token is refreshed to the one just supplied. */
-	readonly session: number;
-	/** `moderates` tuples newly minted — `0` on a re-run. */
+	/** The tiers provisioned, in {@link PREVIEW_TIERS} order — one `user` + one `session` row each. */
+	readonly tiers: readonly PreviewTier[];
+	/** `moderates` tuples newly minted — `0` on a re-run, and `0` when no moderating tier was seeded. */
 	readonly tuples: number;
 	readonly expiresAt: Date;
 }
 
 /**
- * Two arms, never one: a refusal must not read as a provision that wrote nothing. `NotThrowaway`
- * names how many foreign accounts were found, which is the fact the operator acts on.
+ * Three arms, never one: a refusal must not read as a provision that wrote nothing. `NotThrowaway`
+ * names how many foreign accounts were found, which is the fact the operator acts on, and
+ * `NoCredentials` says the run named no tier at all rather than seeding a default one.
  */
 export type ProvisionOutcome =
 	| {readonly _tag: "Provisioned"; readonly report: ProvisionReport}
-	| {readonly _tag: "NotThrowaway"; readonly foreignAccounts: number};
+	| {readonly _tag: "NotThrowaway"; readonly foreignAccounts: number}
+	| {readonly _tag: "NoCredentials"};
 
 /**
- * Accounts on this database that are not the test identity and not the `@[silinen]` migration
+ * Accounts on this database that are none of the test identities and not the `@[silinen]` migration
  * sentinel (ADR 0097) — the evidence the target is somebody's real world.
  */
 export const countForeignAccounts = async (db: SeedDb): Promise<number> => {
 	const rows = await db
 		.select({id: user.id})
 		.from(user)
-		.where(and(ne(user.id, TEST_ACCOUNT.id), eq(user.type, "human")))
+		.where(and(notInArray(user.id, TEST_ACCOUNT_IDS), eq(user.type, "human")))
 		.all();
 	return rows.length;
 };
 
-export const provisionTestAccount = async (
-	db: SeedDb,
-	token: SessionToken,
-	now: Date = new Date(),
-): Promise<ProvisionOutcome> => {
-	const foreignAccounts = await countForeignAccounts(db);
-	if (foreignAccounts > 0) return {_tag: "NotThrowaway", foreignAccounts};
+type Statement = BatchItem<"sqlite">;
 
-	const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+const accountRows = (
+	db: SeedDb,
+	tier: PreviewTier,
+	token: SessionToken,
+	now: Date,
+	expiresAt: Date,
+): readonly [Statement, Statement] => {
+	const account = TEST_ACCOUNTS[tier];
 	const accountRow = {
-		id: TEST_ACCOUNT.id,
-		name: TEST_ACCOUNT.name,
-		email: TEST_ACCOUNT.email,
+		id: account.id,
+		name: account.name,
+		email: account.email,
 		type: "human",
-		role: TEST_ACCOUNT.role,
-		tier: TEST_ACCOUNT.tier,
+		role: account.role,
+		tier: account.tier,
 		emailVerified: true,
-		username: TEST_ACCOUNT.username,
+		username: account.username,
 		createdAt: now,
 		updatedAt: now,
 	} as const;
 	const sessionRow = {
-		id: TEST_ACCOUNT.sessionId,
-		userId: TEST_ACCOUNT.id,
+		id: account.sessionId,
+		userId: account.id,
 		token,
 		expiresAt,
 		createdAt: now,
 		updatedAt: now,
 	};
-
-	// One `batch` so the account, its session and its moderation tuple land together or not at all
-	// — a session pointing at an unpromoted account renders a çaylak's view and reads as a defect.
-	const [, , tuple] = await db.batch([
+	return [
 		db.insert(user).values(accountRow).onConflictDoUpdate({target: user.id, set: accountRow}),
 		db.insert(session).values(sessionRow).onConflictDoUpdate({target: session.id, set: sessionRow}),
-		db
-			.insert(relationTuple)
-			.values({subject: TEST_ACCOUNT.id, relation: MODERATES, object: PLATFORM})
-			.onConflictDoNothing(),
-	]);
+	];
+};
+
+export const provisionTestAccounts = async (
+	db: SeedDb,
+	credentials: PreviewCredentials,
+	now: Date = new Date(),
+): Promise<ProvisionOutcome> => {
+	const requested = PREVIEW_TIERS.flatMap((tier) => {
+		const token = credentials[tier];
+		return token === undefined ? [] : [{tier, token}];
+	});
+	const [head, ...rest] = requested;
+	if (head === undefined) return {_tag: "NoCredentials"};
+
+	const foreignAccounts = await countForeignAccounts(db);
+	if (foreignAccounts > 0) return {_tag: "NotThrowaway", foreignAccounts};
+
+	const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+	const rows = [
+		...accountRows(db, head.tier, head.token, now, expiresAt),
+		...rest.flatMap(({tier, token}) => accountRows(db, tier, token, now, expiresAt)),
+	] as const;
+	const tuples = requested
+		.filter(({tier}) => TEST_ACCOUNTS[tier].moderates)
+		.map(({tier}) =>
+			db
+				.insert(relationTuple)
+				.values({subject: TEST_ACCOUNTS[tier].id, relation: MODERATES, object: PLATFORM})
+				.onConflictDoNothing(),
+		);
+
+	// One `batch` so every account, its session and its moderation tuple land together or not at all
+	// — a session pointing at an unpromoted account renders a çaylak's view under the yazar's name.
+	const results = await db.batch([...rows, ...tuples]);
 
 	return {
 		_tag: "Provisioned",
-		report: {account: 1, session: 1, tuples: tuple.meta.changes, expiresAt},
+		report: {
+			tiers: requested.map(({tier}) => tier),
+			tuples: results.slice(rows.length).reduce((total, result) => total + result.meta.changes, 0),
+			expiresAt,
+		},
 	};
 };

--- a/packages/preview-seed/src/test-account.unit.test.ts
+++ b/packages/preview-seed/src/test-account.unit.test.ts
@@ -1,7 +1,7 @@
 /**
- * The test-account provisioner's two refusable facts: a token weak enough to be guessed, and a
- * target that is not a throwaway. Both must be decided BEFORE any write, so the fake below records
- * every statement it is handed and the assertions read that record.
+ * The test-account provisioner's three refusable facts: a token weak enough to be guessed, a target
+ * that is not a throwaway, and a run naming no tier at all. Each must be decided BEFORE any write,
+ * so the fake below records every statement it is handed and the assertions read that record.
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -10,9 +10,9 @@ import {
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
 	parseSessionToken,
-	provisionTestAccount,
+	provisionTestAccounts,
 	SESSION_TTL_MS,
-	TEST_ACCOUNT,
+	TEST_ACCOUNTS,
 } from "./test-account.ts";
 
 interface Recorded {
@@ -71,36 +71,103 @@ describe("parseSessionToken", () => {
 	});
 });
 
-describe("provisionTestAccount", () => {
+const CAYLAK_TOKEN = parseSessionToken("c".repeat(MIN_SESSION_TOKEN_LEN));
+
+describe("provisionTestAccounts", () => {
 	it("refuses a database holding a foreign account, writing nothing", async () => {
 		assert.isNotNull(TOKEN);
 		const {d1, batched} = fakeD1([{id: "somebody-real"}]);
-		const outcome = await provisionTestAccount(makeTestAccountDb(d1), TOKEN);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN});
 		assert.strictEqual(outcome._tag, "NotThrowaway");
 		assert.strictEqual(outcome._tag === "NotThrowaway" ? outcome.foreignAccounts : -1, 1);
 		assert.lengthOf(batched, 0);
+	});
+
+	/**
+	 * The re-run case: after both tiers are seeded the database holds two test identities, and a
+	 * throwaway check that only knew one of them would call the other somebody's real world and
+	 * refuse every subsequent run.
+	 */
+	it("excludes every test identity from the foreign count, so a re-run stays idempotent", async () => {
+		assert.isNotNull(TOKEN);
+		const {d1, selected} = fakeD1([]);
+		await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN});
+		const params = selected.flatMap((stmt) => stmt.params);
+		assert.include(params, TEST_ACCOUNTS.yazar.id);
+		assert.include(params, TEST_ACCOUNTS.çaylak.id);
+	});
+
+	it("names no tier rather than falling back to one when no token is supplied", async () => {
+		const {d1, batched, selected} = fakeD1([]);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {});
+		assert.strictEqual(outcome._tag, "NoCredentials");
+		assert.lengthOf(batched, 0);
+		assert.lengthOf(selected, 0);
 	});
 
 	it("provisions account, session and moderates tuple in one batch on an empty database", async () => {
 		assert.isNotNull(TOKEN);
 		const now = new Date("2026-08-28T00:00:00.000Z");
 		const {d1, batched} = fakeD1([]);
-		const outcome = await provisionTestAccount(makeTestAccountDb(d1), TOKEN, now);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN}, now);
 		assert.strictEqual(outcome._tag, "Provisioned");
 		if (outcome._tag !== "Provisioned") return;
 		assert.strictEqual(outcome.report.expiresAt.getTime(), now.getTime() + SESSION_TTL_MS);
+		assert.deepStrictEqual(outcome.report.tiers, ["yazar"]);
 		assert.lengthOf(batched, 3);
 		assert.include(batched[0]?.sql ?? "", '"user"');
 		assert.include(batched[1]?.sql ?? "", '"session"');
 		assert.include(batched[2]?.sql ?? "", "relation_tuple");
 		assert.include(batched[1]?.params ?? [], TOKEN);
-		assert.include(batched[2]?.params ?? [], TEST_ACCOUNT.id);
+		assert.include(batched[2]?.params ?? [], TEST_ACCOUNTS.yazar.id);
+	});
+
+	/**
+	 * The çaylak carries no `moderates` tuple, and that is the point of the tier: an identity with
+	 * moderation authority renders a moderator's affordances whatever its `tier` column says.
+	 */
+	it("gives each tier its own account + session, and the tuple only to the moderating one", async () => {
+		assert.isNotNull(TOKEN);
+		assert.isNotNull(CAYLAK_TOKEN);
+		const {d1, batched} = fakeD1([]);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {
+			yazar: TOKEN,
+			çaylak: CAYLAK_TOKEN,
+		});
+		assert.strictEqual(outcome._tag, "Provisioned");
+		if (outcome._tag !== "Provisioned") return;
+		assert.deepStrictEqual(outcome.report.tiers, ["yazar", "çaylak"]);
+		assert.lengthOf(batched, 5);
+		assert.include(batched[2]?.params ?? [], TEST_ACCOUNTS.çaylak.id);
+		assert.include(batched[3]?.params ?? [], CAYLAK_TOKEN);
+		assert.include(batched[4]?.sql ?? "", "relation_tuple");
+		assert.include(batched[4]?.params ?? [], TEST_ACCOUNTS.yazar.id);
+		assert.notInclude(
+			batched.flatMap((stmt) => (stmt.sql.includes("relation_tuple") ? stmt.params : [])),
+			TEST_ACCOUNTS.çaylak.id,
+		);
+	});
+
+	it("seeds only the tier it holds a token for, leaving the other unwritten", async () => {
+		assert.isNotNull(CAYLAK_TOKEN);
+		const {d1, batched} = fakeD1([]);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {çaylak: CAYLAK_TOKEN});
+		assert.strictEqual(outcome._tag, "Provisioned");
+		if (outcome._tag !== "Provisioned") return;
+		assert.deepStrictEqual(outcome.report.tiers, ["çaylak"]);
+		assert.strictEqual(outcome.report.tuples, 0);
+		assert.lengthOf(batched, 2);
+		assert.notInclude(
+			batched.flatMap((stmt) => stmt.params),
+			TEST_ACCOUNTS.yazar.id,
+		);
 	});
 
 	it("binds no null param — D1 REST rejects one and the batch would die mid-provision (#569)", async () => {
 		assert.isNotNull(TOKEN);
+		assert.isNotNull(CAYLAK_TOKEN);
 		const {d1, batched} = fakeD1([]);
-		await provisionTestAccount(makeTestAccountDb(d1), TOKEN);
+		await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN, çaylak: CAYLAK_TOKEN});
 		batched.forEach((stmt, i) => {
 			stmt.params.forEach((p, j) => {
 				assert.isNotNull(p, `batch[${i}].params[${j}] is null`);


### PR DESCRIPTION
Fixes #7398.

`review-ui render` could only authenticate as one identity, and that identity is a `yazar`. Any
surface whose whole point is that it renders *below* that tier — a çaylak nudge, a vouch prompt, a
pre-promotion affordance — came back `captured`, valid and decodable, showing the state the PR did
not add. This makes the tier an axis of the surface id and proves it per shot.

**The vocabulary.** Realized states are now `auth` (yazar+moderator, the identity #7051 shipped,
unchanged) and `auth-caylak` (çaylak). Each names the tier it renders at; anything else after the
colon is still `10`.

**The identities.** `preview-seed test-account` provisions one account per tier, keyed by the
`user.tier` enum, in one atomic D1 batch. Only the yazar carries the `moderates` tuple — an identity
with moderation authority renders a moderator's affordances whatever its tier column says. The
throwaway fence now excludes both fixed ids, which is what keeps a re-run idempotent once both are
on the D1. Direct-D1 throughout; no worker route anywhere in the path.

**The credentials.** One environment variable per tier — `PREVIEW_TEST_SESSION_TOKEN` for yazar,
`PREVIEW_TEST_CAYLAK_SESSION_TOKEN` for çaylak — on both the provisioning side and the capture side.
An unset one means that tier was not seeded on this preview, so `render` refuses on `11` before a
browser launches instead of falling back to the seeded identity. `test-account` seeds exactly the
tiers whose variable is set, names the rest in its output, and refuses a run with none set.

**The proof.** `readSessionProof` now reads `user.tier` off the same `/api/auth/get-session` answer
the session proof already read (`tier` is an `additionalUserFields` entry without `returned: false`,
unlike `promotedAt`). A shot whose tier is not the one the surface named is the new `WrongTier`
outcome, routed with `Unauthenticated`/`OverrideInert` as UNKNOWN on `11` — the page rendered fine,
it is just not the audience asked for — so no capture is recorded under that surface id. A signed-in
answer carrying no tier is `Unreadable`, not a guessed default.

Reviewers: the interesting seam is `packages/fabrika-cli/src/capture/states.ts`, where the state→tier
table is the single source both the credential fence and the per-shot proof read.

All six verb-output pin surfaces are in this PR: the contract's prose + worked examples, `SKILL.md`,
the `withDescription` help strings, the `verb-reference.md` row, and the source docblocks.

## Deviations

- **Out-of-scope change** — **Said:** #7398 names the render path's tier axis. **Did:** also
  reworded the `--flag`-beside-an-anonymous-surface refusal from "name every surface :auth" to naming
  the tier-state set. **Why:** that message enumerated the old one-state vocabulary, so leaving it
  would have sent a caller after a spelling that no longer covers both states. **Disposition:**
  stated here.
- **Scope narrowing** — **Said:** criterion 3 says a wrong-tier render "never writes pixels under
  that surface id". **Did:** the classification runs before the capture entry is built, so no entry
  and no manifest is written under that id, but the PNG file itself is already on disk in the set
  dir when the tier is judged. **Why:** the tier proof is taken from the capture leg's return value,
  the same seam the existing `Unauthenticated` fence uses; aborting mid-capture would restructure the
  impure Playwright leg for a file no reader of the set can reach. **Disposition:** stated here.
