### PR TITLE
fix: recipe unpark resolves a different lanes root than lane status, so a worktree driver gets a spurious exit 7

### DIFF
--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -755,7 +755,8 @@ precondition read failed · `12` the park's cause is outside the known-recipe se
 recipe whose clearing condition is not met yet · `14` the task's leaf state is not a park · `15`
 the task could not be resolved · `16`–`18` the `governance` verdict is absent, stale, or FAIL ·
 `19` no run at the head concluded in failure · `20` the machine refused the `UNBLOCKED` · `21` the
-rerun was requested and its outcome could not be re-read · `22` the state applies no recipe.
+rerun was requested and its outcome could not be re-read · `22` the state applies no recipe · `39`
+the cwd is not in a repository, so `unpark` has none to derive its default lanes root off.
 
 **Known clears, novel escalates, and both are exit codes.** `12` is nothing-written, route it to a
 human; `13` is wait. `recipe route --exit` folds the first to `BLOCKED` and the second to `WIP`, so

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -22,7 +22,7 @@ import {runLaneAdopt, runLaneClaim, runLaneRelease} from "./claim-verb.ts";
 import {CLASS_UNRECOGNISED} from "./codes.ts";
 import {runEmit} from "./emit-verb.ts";
 import {expectationReader} from "./expectation.ts";
-import {deriveRepoRoot, onGround, repoGroundRefusal} from "./ground.ts";
+import {deriveRepoRoot, onGround, repoGroundRefusal, resolveRootOrRefuse} from "./ground.ts";
 import {runHistory} from "./history-verb.ts";
 import {runIntegrate} from "./integrate-verb.ts";
 import {defaultRoot, type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
@@ -83,26 +83,6 @@ const onKey = <R>(
 		return yield* onGround(verb, [ref.root], process.cwd(), () => run(parsed.key, ref));
 	});
 };
-
-/**
- * The lanes root one verb invocation resolves when `--root` is absent: derived off the repository
- * the cwd belongs to (#5815), with the leaf joined under its primary checkout. An explicit `--root`
- * wins over whatever would be derived.
- */
-const resolveRootOrRefuse = (
-	verb: string,
-	root: Option.Option<string>,
-	leaf: string,
-): Effect.Effect<string | VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
-	Option.isSome(root)
-		? Effect.succeed(root.value)
-		: Effect.gen(function* () {
-				const path = yield* Path.Path;
-				const ground = yield* deriveRepoRoot(process.cwd());
-				return ground._tag === "Derived"
-					? path.join(ground.repoRoot, leaf)
-					: repoGroundRefusal(`fabrika lane ${verb}`, ground);
-			});
 
 /**
  * Resolve the `lane` argument for a verb whose ground is the **board**, not the disk — `claim` and
@@ -385,7 +365,12 @@ const emitLane = leafCommand(
 		),
 	},
 	Effect.fn(function* ({epic, root, repo}) {
-		const resolvedRoot = yield* resolveRootOrRefuse("fabrika lane emit", root, DEFAULT_LANES_ROOT);
+		const resolvedRoot = yield* resolveRootOrRefuse(
+			"fabrika lane emit",
+			root,
+			DEFAULT_LANES_ROOT,
+			process.cwd(),
+		);
 		if (typeof resolvedRoot !== "string") {
 			yield* emit(resolvedRoot);
 			return;
@@ -424,6 +409,7 @@ const assembly = leafCommand(
 			"fabrika lane assembly",
 			root,
 			DEFAULT_LANES_ROOT,
+			process.cwd(),
 		);
 		if (typeof resolvedRoot !== "string") {
 			yield* emit(resolvedRoot);
@@ -460,6 +446,7 @@ const integrate = leafCommand(
 			"fabrika lane integrate",
 			root,
 			DEFAULT_LANES_ROOT,
+			process.cwd(),
 		);
 		if (typeof resolvedRoot !== "string") {
 			yield* emit(resolvedRoot);
@@ -489,7 +476,12 @@ const pushLane = leafCommand(
 		root: rootFlag,
 	},
 	Effect.fn(function* ({epic, root}) {
-		const resolvedRoot = yield* resolveRootOrRefuse("fabrika lane push", root, DEFAULT_LANES_ROOT);
+		const resolvedRoot = yield* resolveRootOrRefuse(
+			"fabrika lane push",
+			root,
+			DEFAULT_LANES_ROOT,
+			process.cwd(),
+		);
 		if (typeof resolvedRoot !== "string") {
 			yield* emit(resolvedRoot);
 			return;
@@ -781,7 +773,12 @@ const view = leafCommand(
 	},
 	Effect.fn(function* ({root, port}) {
 		const chosen = Option.getOrElse(port, () => DEFAULT_VIEW_PORT);
-		const resolvedRoot = yield* resolveRootOrRefuse("fabrika lane view", root, DEFAULT_LANES_ROOT);
+		const resolvedRoot = yield* resolveRootOrRefuse(
+			"fabrika lane view",
+			root,
+			DEFAULT_LANES_ROOT,
+			process.cwd(),
+		);
 		if (typeof resolvedRoot !== "string") {
 			yield* emit(resolvedRoot);
 			return;

--- a/packages/fabrika-cli/src/lane/ground.ts
+++ b/packages/fabrika-cli/src/lane/ground.ts
@@ -12,7 +12,7 @@
  * An **absolute** root resolves against nothing, so no drift is expressible and no probe is owed —
  * `lane brief` hands a shell its driver's root absolute for exactly that reason.
  */
-import {Effect, type FileSystem, Path, Result} from "effect";
+import {Effect, type FileSystem, Option, Path, Result} from "effect";
 import {repositoryOf} from "../delegate/repository.ts";
 import {exists} from "../io/fs.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
@@ -125,6 +125,32 @@ export const repoGroundRefusal = (
 				LANE_UNREADABLE,
 				`${verb}: whether ${ground.cwd} belongs to a repository is UNKNOWN (${ground.reason}) — the lanes root stays unresolved rather than guessed from the cwd (#5815).`,
 			);
+
+/**
+ * The lanes root one verb invocation resolves when `--root` is absent: derived off the repository
+ * the cwd belongs to (#5815), with the leaf joined under its primary checkout. An explicit `--root`
+ * wins over whatever would be derived.
+ *
+ * Shared rather than private to the `lane` adapter, because a verb in another group resolving the
+ * same root its own way is how one lane key comes to name two directories: `recipe unpark` defaulted
+ * to a bare cwd-relative leaf and proved every worktree-driven lane absent (#7380). The verb label
+ * arrives whole, so a caller outside `lane` names itself.
+ */
+export const resolveRootOrRefuse = (
+	verb: string,
+	root: Option.Option<string>,
+	leaf: string,
+	cwd: string,
+): Effect.Effect<string | VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Option.isSome(root)
+		? Effect.succeed(root.value)
+		: Effect.gen(function* () {
+				const path = yield* Path.Path;
+				const ground = yield* deriveRepoRoot(cwd);
+				return ground._tag === "Derived"
+					? path.join(ground.repoRoot, leaf)
+					: repoGroundRefusal(verb, ground);
+			});
 
 /**
  * Run a rooted verb on ground it proved. The group-level guard ahead of every read and every boot,

--- a/packages/fabrika-cli/src/recipe/command-help.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/command-help.unit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * `--help` is the recipe adapter's public contract. `unpark` is the one verb here that takes a lanes
+ * root, and it must tell the same derivation story `lane`'s flag tells — a flag advertising a bare
+ * cwd-relative default is how an operator learns the wrong resolution rule (#7380).
+ */
+import {describe, expect, it} from "vitest";
+import type {CommandNode} from "../unknown-subcommand.ts";
+import {recipeCommand} from "./command.ts";
+
+interface FlagNode {
+	readonly description?: string | undefined;
+	readonly param?: FlagNode | undefined;
+}
+
+interface DescribedCommand extends Omit<CommandNode, "subcommands"> {
+	readonly description: string | undefined;
+	readonly config?: {readonly flags?: ReadonlyArray<FlagNode>} | undefined;
+	readonly subcommands: ReadonlyArray<{readonly commands: ReadonlyArray<DescribedCommand>}>;
+}
+
+const group: DescribedCommand = recipeCommand;
+const leaves = group.subcommands.flatMap((set) => set.commands);
+
+const leafNamed = (name: string): DescribedCommand => {
+	const leaf = leaves.find((candidate) => candidate.name === name);
+	if (leaf === undefined) throw new Error(`recipe ${name} is not registered`);
+	return leaf;
+};
+
+/** Every help string on a flag, following the combinator chain to the node that owns the text. */
+const flagHelp = (leaf: DescribedCommand): string => {
+	const text = (node: FlagNode | undefined): string =>
+		node === undefined ? "" : `${node.description ?? ""} ${text(node.param)}`;
+	return (leaf.config?.flags ?? []).map(text).join(" ");
+};
+
+describe("recipe unpark's repository-root help contract (#7380)", () => {
+	it("advertises the repository-owned --root default the lane group's flag carries", () => {
+		const help = flagHelp(leafNamed("unpark"));
+
+		expect(help).toContain("the owning repository's .fabrika/lanes");
+		expect(help).toContain("derived off the primary checkout");
+		expect(help).not.toContain("(default: .fabrika/lanes)");
+	});
+
+	it("seats the no-owning-repository refusal on its own exit rather than a lane's absence", () => {
+		const description = leafNamed("unpark").description ?? "";
+
+		expect(description).toContain("derive the default lanes root");
+		expect(description).toContain("unreadable repository identity is UNKNOWN at 11");
+	});
+});

--- a/packages/fabrika-cli/src/recipe/command.ts
+++ b/packages/fabrika-cli/src/recipe/command.ts
@@ -10,6 +10,7 @@ import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
+import {resolveRootOrRefuse} from "../lane/ground.ts";
 import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
 import {runRerun} from "./rerun-verb.ts";
 import {runRoute} from "./route-verb.ts";
@@ -29,8 +30,10 @@ const unpark = leafCommand(
 			Argument.withDescription("the lane id under the root — by convention the issue number"),
 		),
 		root: Flag.string("root").pipe(
-			Flag.withDefault(DEFAULT_LANES_ROOT),
-			Flag.withDescription(`the lanes root directory (default: ${DEFAULT_LANES_ROOT})`),
+			Flag.optional,
+			Flag.withDescription(
+				`the lanes root directory (default: the owning repository's ${DEFAULT_LANES_ROOT}, derived off the primary checkout so every worktree reads the same ledger)`,
+			),
 		),
 		task: Flag.string("task").pipe(
 			Flag.optional,
@@ -39,13 +42,27 @@ const unpark = leafCommand(
 		repo: repoFlag,
 	},
 	Effect.fn(function* ({lane, root, task, repo}) {
+		const cwd = process.cwd();
+		// The lane verbs this one relays derive their root off the owning repository, so deriving it
+		// any other way here makes one lane key name two directories and strands every worktree
+		// driver on a lane the ledger holds (#7380).
+		const resolvedRoot = yield* resolveRootOrRefuse(
+			"fabrika recipe unpark",
+			root,
+			DEFAULT_LANES_ROOT,
+			cwd,
+		);
+		if (typeof resolvedRoot !== "string") {
+			yield* emit(resolvedRoot);
+			return;
+		}
 		yield* emit(
 			yield* runUnpark({
-				root,
+				root: resolvedRoot,
 				lane,
 				task: Option.getOrNull(task),
 				repo: Option.getOrNull(repo),
-				cwd: process.cwd(),
+				cwd,
 				env: process.env,
 			}),
 		);
@@ -53,7 +70,7 @@ const unpark = leafCommand(
 ).pipe(
 	Command.withShortDescription("Clear a parked lane when the park is a known recipe."),
 	Command.withDescription(
-		"Clear one parked lane when its park matches the known-recipe table, and refuse with the ledger untouched when it does not. The park is seated by its leaf state AND the cause its parking event named (`lane report`/`lane transition --cause`, a closed set in code) — a BLOCKED with no cause keys on nothing and is novel. The recipe's clearing condition is read off the verb that owns it: `ship cp-approval`'s ADR 0175 discharge at the PR's live head for the §CP park, for the worktree-holds-branch park the same working-tree read `build branch --resume-lane` refuses on, and for the campaign-paused park the lane milestone's `## Campaigns` State cell at origin/main, which ADR 0304 makes the whole dispatch permission — cleared only on `active`, and never resumed here. The spawn-dead park is the one whose read is the lane rather than the cause: no verb can spawn an agent to ask whether the provider is back, so it proves only that the dead shell left nothing that would refuse the same brief being dispatched again — no build claim standing on the issue, and no working tree holding its lane branch (ADR 0339). The queue-stall park is the one row whose clear also GRANTS: its read is `ship reconcile`'s answer relayed, where `landed` and `ejected` clear and `unresolved` is exit 13, and because the park IS a spent wait budget the clear records the waits it buys on the very same UNBLOCKED — one event, so the resumed lane comes back one conclusive read below its budget instead of re-parking (ADR 0313). The clear is recorded through `lane transition … UNBLOCKED`, and the answer is emitted only after a second fold reads the task out of the park. stdout is `{lane, task, park, clearance, mechanism, current}`, plus `waitGrant` on a clear that granted. Respawning what the lane parked out of is the operator's, not this verb's. Exits 4 (a lane record was read in full and is not the shape), 7 (no lane there; the PR the park waits on is proven absent, or closed where the row needs it open — the queue-stall row nominates at open-or-merged scope, since a landed PR is closed; or the lane's issue is absent, homed on no milestone, or homed on one no ## Campaigns row pins), 8 (the UNBLOCKED append did not land — it is NOT recorded), 9 (the append landed and the re-fold does not prove the clear — the lane needs a human), 11 (a precondition could not be read — UNKNOWN, never cleared), 12 (the park's cause is outside the recipe table — nothing was written; route it to a human), 13 (a known recipe whose clearing condition is not met yet — nothing was written), 14 (the task is not parked), 15 (the task is not in the active phase, --task was omitted where it is required, or no issue number can be resolved), 20 (the machine refused the UNBLOCKED, log unappended). Example: fabrika recipe unpark 5847",
+		"Clear one parked lane when its park matches the known-recipe table, and refuse with the ledger untouched when it does not. The park is seated by its leaf state AND the cause its parking event named (`lane report`/`lane transition --cause`, a closed set in code) — a BLOCKED with no cause keys on nothing and is novel. The recipe's clearing condition is read off the verb that owns it: `ship cp-approval`'s ADR 0175 discharge at the PR's live head for the §CP park, for the worktree-holds-branch park the same working-tree read `build branch --resume-lane` refuses on, and for the campaign-paused park the lane milestone's `## Campaigns` State cell at origin/main, which ADR 0304 makes the whole dispatch permission — cleared only on `active`, and never resumed here. The spawn-dead park is the one whose read is the lane rather than the cause: no verb can spawn an agent to ask whether the provider is back, so it proves only that the dead shell left nothing that would refuse the same brief being dispatched again — no build claim standing on the issue, and no working tree holding its lane branch (ADR 0339). The queue-stall park is the one row whose clear also GRANTS: its read is `ship reconcile`'s answer relayed, where `landed` and `ejected` clear and `unresolved` is exit 13, and because the park IS a spent wait budget the clear records the waits it buys on the very same UNBLOCKED — one event, so the resumed lane comes back one conclusive read below its budget instead of re-parking (ADR 0313). The clear is recorded through `lane transition … UNBLOCKED`, and the answer is emitted only after a second fold reads the task out of the park. stdout is `{lane, task, park, clearance, mechanism, current}`, plus `waitGrant` on a clear that granted. Respawning what the lane parked out of is the operator's, not this verb's. Exits 4 (a lane record was read in full and is not the shape), 7 (no lane there; the PR the park waits on is proven absent, or closed where the row needs it open — the queue-stall row nominates at open-or-merged scope, since a landed PR is closed; or the lane's issue is absent, homed on no milestone, or homed on one no ## Campaigns row pins), 8 (the UNBLOCKED append did not land — it is NOT recorded), 9 (the append landed and the re-fold does not prove the clear — the lane needs a human), 11 (a precondition could not be read — UNKNOWN, never cleared), 12 (the park's cause is outside the recipe table — nothing was written; route it to a human), 13 (a known recipe whose clearing condition is not met yet — nothing was written), 14 (the task is not parked), 15 (the task is not in the active phase, --task was omitted where it is required, or no issue number can be resolved), 20 (the machine refused the UNBLOCKED, log unappended), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default lanes root; an unreadable repository identity is UNKNOWN at 11; NOT \"no lane here\", so never a park). Example: fabrika recipe unpark 5847",
 	),
 );
 

--- a/packages/fabrika-cli/src/recipe/unpark-root.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-root.unit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Where `recipe unpark` looks for the lane its caller named (#7380).
+ *
+ * The verb relays `lane status`, and those verbs derive their root off the owning repository, so a
+ * bare cwd-relative default here made one lane key name two directories: from a worktree the lane
+ * verbs folded the primary checkout's ledger while this one proved the same lane absent at 7 — an
+ * exit `operate` step 4 does not route, so a self-healing park cost a human instead.
+ */
+import {Effect, Layer, Option} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs, fakeSeams} from "../fakes.test-support.ts";
+import {NOT_A_REPO} from "../lane/codes.ts";
+import {resolveRootOrRefuse} from "../lane/ground.ts";
+import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
+import {ENV} from "../ship/fixtures.test-support.ts";
+import {PARK_NOVEL, TARGET_ABSENT} from "./codes.ts";
+import {LANE, laneTemplate, PARKED_BLOCKED} from "./fixtures.test-support.ts";
+import {runUnpark} from "./unpark-verb.ts";
+
+const VERB = "fabrika recipe unpark";
+const PRIMARY = "/primary";
+const WORKTREE = "/wt";
+const WORKTREE_CWD = `${WORKTREE}/packages/fabrika-cli`;
+
+/** A primary checkout carrying the parked lane, plus a linked worktree whose `.git` points home. */
+const repoFs = () =>
+	fakeFs({
+		directories: [`${PRIMARY}/.git`],
+		dirs: {
+			[PRIMARY]: [".git", ".fabrika"],
+			[`${PRIMARY}/.git/worktrees/wt`]: [],
+		},
+		files: {
+			[`${WORKTREE}/.git`]: "gitdir: /primary/.git/worktrees/wt",
+			[`${PRIMARY}/.git/worktrees/wt/commondir`]: "../..",
+			[`${PRIMARY}/${DEFAULT_LANES_ROOT}/${LANE}/workflow.json`]: laneTemplate(),
+			[`${PRIMARY}/${DEFAULT_LANES_ROOT}/${LANE}/events.jsonl`]: PARKED_BLOCKED,
+		},
+	});
+
+/** The adapter's own composition: resolve the root off the cwd, then hand the verb what it resolved. */
+const unparkFrom = (fs: ReturnType<typeof fakeFs>, cwd: string, root: Option.Option<string>) =>
+	Effect.runPromise(
+		Effect.provide(
+			Effect.gen(function* () {
+				const resolved = yield* resolveRootOrRefuse(VERB, root, DEFAULT_LANES_ROOT, cwd);
+				return typeof resolved === "string"
+					? yield* runUnpark({root: resolved, lane: LANE, task: null, repo: null, cwd, env: ENV})
+					: resolved;
+			}),
+			Layer.merge(fs.layer, fakeSeams([]).layer),
+		),
+	);
+
+describe("the lanes root recipe unpark resolves (#7380)", () => {
+	it("reaches the primary checkout's lane from a worktree cwd instead of proving it absent", async () => {
+		const out = await unparkFrom(repoFs(), WORKTREE_CWD, Option.none());
+
+		expect(out.code).toBe(PARK_NOVEL);
+		expect(out.code).not.toBe(TARGET_ABSENT);
+	});
+
+	it("resolves the same directory from the primary cwd as from the worktree", async () => {
+		const fromPrimary = await unparkFrom(repoFs(), `${PRIMARY}/packages/cli`, Option.none());
+		const fromWorktree = await unparkFrom(repoFs(), WORKTREE_CWD, Option.none());
+
+		expect(fromWorktree).toEqual(fromPrimary);
+	});
+
+	it("lets an explicit --root win over the derived one", async () => {
+		const out = await unparkFrom(
+			repoFs(),
+			WORKTREE_CWD,
+			Option.some(`${PRIMARY}/${DEFAULT_LANES_ROOT}`),
+		);
+
+		expect(out.code).toBe(PARK_NOVEL);
+	});
+
+	// The control: the bare relative leaf this verb used to default to, from the same cwd and the
+	// same tree the derived root reaches the lane in.
+	it("proves the lane absent under the cwd-relative leaf the defect defaulted to", async () => {
+		const out = await unparkFrom(repoFs(), WORKTREE_CWD, Option.some(DEFAULT_LANES_ROOT));
+
+		expect(out.code).toBe(TARGET_ABSENT);
+	});
+
+	it("refuses a cwd under no repository rather than resolving a relative path", async () => {
+		const out = await unparkFrom(
+			fakeFs({directories: ["/scratch"]}),
+			"/scratch/deep",
+			Option.none(),
+		);
+
+		expect(out.code).toBe(NOT_A_REPO);
+		expect(out.stderr.join("\n")).toContain(`${VERB}: /scratch/deep is not a repo`);
+		expect(out.stderr.join("\n")).not.toContain("fabrika lane fabrika");
+	});
+});

--- a/packages/fabrika-cli/src/recipe/unpark-verb.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.ts
@@ -55,7 +55,7 @@ import {openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 const VERB = "fabrika recipe unpark";
 
 export interface UnparkOptions {
-	/** The lanes root — `.fabrika/lanes` unless a caller relocates it. */
+	/** The lanes root, already resolved by the adapter — the caller's `--root`, else the derived one. */
 	readonly root: string;
 	/** The lane id under the root — by convention the issue number the lane drives. */
 	readonly lane: string;


### PR DESCRIPTION
`fabrika recipe unpark` declared its `--root` with `Flag.withDefault(".fabrika/lanes")` — a bare
cwd-relative path — while every `lane` verb it relays derives the root off the owning repository. Run
from a worktree the two disagreed: `lane status` folded the primary checkout's ledger, `recipe
unpark` looked in the worktree's empty `.fabrika/lanes` and relayed exit `7`. That exit is outside
the set `operate` step 4 routes on, so a worktree-run driver posted a park comment on a lane the
recipe might have cleared itself.

The flag is now `Flag.optional` and the adapter resolves it the way `lane` does: an explicit
`--root` wins, otherwise the root is derived off the cwd's repository and joined with the lanes leaf,
and a cwd under no repository refuses through `repoGroundRefusal` rather than resolving a relative
path nobody meant.

`lane`'s private `resolveRootOrRefuse` moved into `lane/ground.ts` beside `deriveRepoRoot` so the two
groups share one resolution rule instead of each writing its own — the divergence being fixed here is
exactly what two copies produce. It now takes the cwd as an argument rather than reading
`process.cwd()` itself, which is what makes the worktree case unit-testable.

**Chores root, the triage note's open question: out of scope, issue lanes only.** `recipe unpark`
takes a lane *id* (a directory name), not a `lane` key — it never calls `parseKey`, so a
`chore:<name>` argument would already resolve `.fabrika/lanes/chore:<name>` today, with or without
this change. And the chore drive's own table (`recipe/drive.ts`) points `unpark` at the issue lane a
sweep found, not at the chore lane running the sweep. Teaching this verb chore keys is a separate
change with its own contract; nothing here narrows what it accepted before.

Reviewer's first stop: the new `resolveRootOrRefuse` in `packages/fabrika-cli/src/lane/ground.ts`,
then `unpark-root.unit.test.ts`, whose last case is the control — the same tree and cwd under the
bare relative leaf still proves the lane absent at `7`.

Fixes #7380

## Deviations

- **Out-of-scope change** — **Said:** #7380 names `recipe unpark`'s `--root` flag. **Did:** also
  fixed a doubled verb prefix in the helper being shared. The old private
  `resolveRootOrRefuse` did `repoGroundRefusal(\`fabrika lane ${verb}\`, …)` while all five call
  sites already passed a full label ("fabrika lane emit"), so those refusals read "fabrika lane
  fabrika lane emit: …". **Why:** the shared helper has to take the verb label whole for a caller
  outside the `lane` group to name itself, so the doubling could not survive the move.
  **Disposition:** fixed, and `unpark-root.unit.test.ts` asserts no `fabrika lane fabrika` prefix
  reaches a refusal.
- **Out-of-scope change** — **Said:** the acceptance criteria name the flag's `--help` text.
  **Did:** also added exit `39` to `unpark`'s `Command.withDescription` exit table and to the recipe
  group's exit list in `packages/fabrika-cli/docs/verb-reference.md`. **Why:** the change gives the
  verb an exit it could not answer before, and `.patterns/verb-output-pin-surfaces.md` requires every
  surface stating a verb's printed contract to land in the same PR — an exit table missing a code the
  verb answers sends its reader nowhere. **Disposition:** stated here.
