### PR TITLE
fix: ui evidence refuses in every build-ui repair round: resume branch name never equals the PR head ref

### DIFF
--- a/claude-plugins/fabrika/skills/build-ui/contract.md
+++ b/claude-plugins/fabrika/skills/build-ui/contract.md
@@ -620,8 +620,11 @@ never edited in place.
 Preconditions: the lane precondition of the shared conventions (`18`/`11`) — the claim is the
 one **the checked-out branch names** (the issue number in first-ship mode, the PR number in
 resume mode), never "a claim on `--pr`". Additionally the verb resolves `--pr`'s current head
-branch and refuses on `18` when it is not the checked-out lane branch — an evidence comment on
-another lane's PR is a cross-lane write. PR open (`7`).
+branch and refuses on `18` when the lane branch does not publish there — an evidence comment on
+another lane's PR is a cross-lane write. **Where the lane publishes is its branch's tracked
+upstream, else `origin/<branch>`** — the same resolution `build push` performs, so a repair round's
+`build/pr-<pr>-<nonce>` branch, whose local name is never the PR's head ref, passes on its upstream
+rather than refusing every time (#7402). PR open (`7`).
 
 **Exit status** (beyond the universal four)
 

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -313,6 +313,20 @@ export const upstreamOf = (branch: string): Shell<{remote: string; ref: string} 
 		return split === null ? null : {remote: split.remote, ref: split.ref};
 	});
 
+/**
+ * The remote branch a lane publishes to: its tracked upstream, else `origin/<branch>`.
+ *
+ * Resume mode's local name is `build/pr-<pr>-<nonce>`, which by construction is never the PR's head
+ * ref, so any check that reads the local name back calls every repair round a foreign lane —
+ * `build push`'s false `17` (#5222) and `ui evidence`'s false `LANE_NOT_MINE` (#7402) are the same
+ * bug found twice. The fallback keeps a fresh lane, whose branch carries no upstream until its first
+ * push, answering its own name.
+ */
+export const publishTarget = (branch: string): Shell<{remote: string; ref: string}> =>
+	Effect.gen(function* () {
+		return (yield* upstreamOf(branch)) ?? {remote: "origin", ref: branch};
+	});
+
 /** The SHA a remote's ref points at, read from the remote itself — the push's independent witness. */
 export const remoteSha = (remote: string, ref: string): Shell<Attempt<string | null>> =>
 	Effect.gen(function* () {

--- a/packages/fabrika-cli/src/build/push-verb.ts
+++ b/packages/fabrika-cli/src/build/push-verb.ts
@@ -33,9 +33,9 @@ import {
 	ensureCommitPresent,
 	headSha,
 	isAncestor,
+	publishTarget,
 	push,
 	remoteSha,
-	upstreamOf,
 } from "./git.ts";
 import {requireLane} from "./lane-guard.ts";
 import {resolveTargetRepo} from "./target.ts";
@@ -77,12 +77,7 @@ export const runPush = (
 			);
 		}
 
-		// The push TARGET is the tracked upstream when there is one — resume mode's local name differs
-		// from the PR's remote head branch, and reading back the local name would call every repair
-		// push a false `17`.
-		const upstream = yield* upstreamOf(lane.branch);
-		const remote = upstream?.remote ?? "origin";
-		const ref = upstream?.ref ?? lane.branch;
+		const {remote, ref} = yield* publishTarget(lane.branch);
 
 		const before = yield* remoteSha(remote, ref);
 		if (before._tag === "Failure") {

--- a/packages/fabrika-cli/src/ui/evidence-verb.ts
+++ b/packages/fabrika-cli/src/ui/evidence-verb.ts
@@ -18,10 +18,11 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {requireSession} from "../build/claim.ts";
 import {contentOf, gate} from "../build/content-gate.ts";
+import {publishTarget} from "../build/git.ts";
 import {laneScratchDir} from "../build/scratch-verb.ts";
 import {resolveTargetRepo} from "../build/target.ts";
 import {designHarnessOr} from "../config/paths.ts";
-import {createComment, currentBranch, getComment} from "../io/issues.ts";
+import {createComment, getComment} from "../io/issues.ts";
 import {getPullRequest} from "../io/pulls.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
@@ -217,7 +218,7 @@ export const runEvidence = (
 				lane.notes,
 			);
 		}
-		const branch = yield* currentBranch;
+		const target = yield* publishTarget(lane.branch);
 		const headBranch = yield* pullHeadRef(options.env, resolved.repo, options.pr);
 		if (headBranch._tag === "Unknown") {
 			return refuse(
@@ -226,10 +227,13 @@ export const runEvidence = (
 				lane.notes,
 			);
 		}
-		if (headBranch.ref !== branch) {
+		// The lane publishes to its branch's tracked upstream, so that is what the PR's head is
+		// compared against; the checked-out name is a repair round's `build/pr-<pr>-<nonce>`, which
+		// never equals the head ref (#7402).
+		if (headBranch.ref !== target.ref) {
 			return refuse(
 				LANE_NOT_MINE,
-				`${VERB}: this session does not hold the claim on #${options.pr} (PR #${options.pr} is on "${headBranch.ref}", not the checked-out "${branch ?? "detached HEAD"}") — the lane is not yours.`,
+				`${VERB}: this session does not hold the claim on #${options.pr} (PR #${options.pr} is on "${headBranch.ref}", but "${lane.branch}" publishes to "${target.remote}/${target.ref}") — the lane is not yours.`,
 				lane.notes,
 			);
 		}

--- a/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
@@ -366,3 +366,72 @@ describe("runEvidence", () => {
 		).toBe(false);
 	});
 });
+
+/**
+ * The repair round's ground: `build branch --resume` checks out `build/pr-<pr>-<nonce>` and points
+ * its upstream at the PR's head ref, so the local name and the head ref never agree (#7402).
+ */
+const RESUME_BRANCH = `build/pr-4318-${NONCE}`;
+const RESUME_SCRATCH = `/tmp/fabrika-build/s-9f2e/4318-${NONCE}`;
+
+const resumeFiles = (): Record<string, Uint8Array | string> =>
+	Object.fromEntries(
+		Object.entries(files()).map(([path, bytes]) => [
+			path.replace(SCRATCH, RESUME_SCRATCH),
+			// The manifests name their captures by absolute path, so the rehome is of the bytes too.
+			typeof bytes === "string" ? bytes.replaceAll(SCRATCH, RESUME_SCRATCH) : bytes,
+		]),
+	);
+
+/** `null` leaves `@{upstream}` unscripted, which is a branch that tracks nothing. */
+const resumeScript = (upstream: string | null): ReadonlyArray<Scripted> => [
+	[/^git rev-parse --path-format=absolute/, GIT_DIRS],
+	[/^git rev-parse --abbrev-ref HEAD$/, okOut(`${RESUME_BRANCH}\n`)],
+	...(upstream === null
+		? []
+		: ([
+				[/^git rev-parse --abbrev-ref --symbolic-full-name /, okOut(`origin/${upstream}\n`)],
+				[/^git remote$/, okOut("origin\n")],
+			] as ReadonlyArray<Scripted>)),
+	[/GET .*\/repos\/o\/r\/issues\/4318$/, issue({number: 4318})],
+	[
+		/GET .*\/repos\/o\/r\/issues\/4318\/comments/,
+		comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
+	],
+	[
+		/GET .*\/repos\/o\/r\/collaborators\/agent\/permission/,
+		{status: 200, body: '{"permission":"write"}'},
+	],
+	[/GET .*\/repos\/o\/r\/pulls\/4318$/, pull({head: {sha: HEAD, ref: LANE}})],
+	[
+		/POST .*\/repos\/o\/r\/issues\/4318\/comments/,
+		{
+			status: 201,
+			body: JSON.stringify({
+				id: POSTED_ID,
+				html_url: "https://github.com/o/r/pull/4318#issuecomment-1",
+			}),
+		},
+	],
+];
+
+describe("runEvidence over a repair round's resume branch", () => {
+	it("attaches when the branch tracks the PR's head ref under another name", async () => {
+		const outcome = await run(
+			withReadback(resumeScript(LANE), () => EXPECTED_BODY),
+			{files: resumeFiles()},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).commentId).toBe(POSTED_ID);
+	});
+
+	it("refuses a branch tracking some other lane's ref on 18", async () => {
+		const outcome = await run(resumeScript("build/9999-other-aaaaaaaa"), {files: resumeFiles()});
+		expect(outcome.code).toBe(LANE_NOT_MINE);
+	});
+
+	it("refuses a branch that tracks nothing on 18 — its own name is not the head ref", async () => {
+		const outcome = await run(resumeScript(null), {files: resumeFiles()});
+		expect(outcome.code).toBe(LANE_NOT_MINE);
+	});
+});


### PR DESCRIPTION
`fabrika ui evidence` refused `LANE_NOT_MINE` in every `build-ui` repair round. It compared the
checked-out branch name against the PR's head ref, and `build branch --resume` checks out
`build/pr-<pr>-<nonce>` — a name that by construction is never the PR's head ref. So the skill's
"re-attach evidence at the new head" step could never run.

`build push` had already solved the same problem for the push target: it resolves the branch's
tracked upstream instead of reading the local name back. This PR lifts that resolution into one
shared helper and puts both call sites on it.

- `publishTarget(branch)` in `packages/fabrika-cli/src/build/git.ts` — the tracked upstream, else
  `origin/<branch>`. It carries the why both call sites need.
- `build push` now calls it instead of inlining the same `upstream?.ref ?? lane.branch`.
- `ui evidence` compares the PR's head ref against `publishTarget(lane.branch).ref`. The refusal
  message now names where the branch publishes, since the local name is no longer the thing being
  compared.

The claim is unchanged in strength. A branch tracking another lane's ref still refuses, and a branch
tracking nothing falls back to its own name — which is exactly today's behaviour, and keeps a
first-round lane (whose branch name *is* the head ref and carries no upstream until its first push)
passing.

Three unit tests cover the resume branch: it attaches when its upstream is the PR's head ref, and
refuses on 18 both when it tracks another lane's ref and when it tracks nothing.

`build-ui`'s `contract.md` said the verb "refuses on 18 when it is not the checked-out lane branch",
which the fix makes false; it now states the upstream resolution.

## Deviations

- **Out-of-scope change** — **Said:** #7402 names `ui evidence` as the one call site to fix.
  **Did:** also moved `build push` onto the extracted `publishTarget` helper. **Why:** the issue's
  acceptance criterion asks for "the same resolution `build push` performs", and two copies of one
  resolution is how they come to disagree — which is the bug being fixed. `build push`'s behaviour
  is byte-identical. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria are all code. **Did:** also corrected one
  paragraph in `claude-plugins/fabrika/skills/build-ui/contract.md`. **Why:** it documented the
  removed comparison as the verb's precondition, and `.patterns/verb-output-pin-surfaces.md` says a
  change to what a verb prints lands every surface in the same PR. **Disposition:** stated here.

Fixes #7402
