### PR TITLE
fix: review-ui's CANT-SEE terminal maps to no event, so an unrenderable lane strands silently

### DIFF
--- a/packages/fabrika-cli/src/lane/report-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report-verb.unit.test.ts
@@ -20,13 +20,16 @@ const ROOT = ".fabrika/lanes";
 const WORKFLOW = `${ROOT}/42/workflow.json`;
 const LOG = `${ROOT}/42/events.jsonl`;
 
-const logLine = (event: string): string =>
-	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at: "2026-08-16T00:00:00.000Z"})}\n`;
+const logLine = (event: string, classes?: ReadonlyArray<string>): string =>
+	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at: "2026-08-16T00:00:00.000Z", ...(classes === undefined ? {} : {classes})})}\n`;
 
 /** The log prefix that folds the coder lane's task into the state each shell reports out of. */
-const LOG_AT: Readonly<Record<"build" | "review" | "ship", string>> = {
+const LOG_AT: Readonly<Record<"build" | "review" | "review:ui" | "ship", string>> = {
 	build: logLine("WIP"),
 	review: logLine("WIP") + logLine("DONE"),
+	// The same path as `review` with `ui` standing from the `WIP`, so the `PASS` out of `review`
+	// takes the class-guarded arm into the rendered gate's own cell.
+	"review:ui": logLine("WIP", ["ui"]) + logLine("DONE") + logLine("PASS"),
 	ship: logLine("WIP") + logLine("DONE") + logLine("PASS"),
 };
 
@@ -91,9 +94,10 @@ const appendedLine = (fs: ReturnType<typeof fakeFs>): string =>
 	fs.written.get(LOG)?.trim().split("\n").at(-1) ?? "";
 
 describe("lane report — every shell terminal token maps to one operator event", () => {
-	const stateFor: Readonly<Record<keyof typeof SHELL_VOCABULARIES, "build" | "review" | "ship">> = {
+	const stateFor: Readonly<Record<keyof typeof SHELL_VOCABULARIES, keyof typeof LOG_AT>> = {
 		builder: "build",
 		reviewer: "review",
+		"ui-reviewer": "review:ui",
 		shipper: "ship",
 	};
 

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -14,7 +14,8 @@ import type {OperatorEvent} from "./machine.ts";
 /**
  * Every recognised terminal token, grouped by the shell skill that owns its vocabulary — the
  * builder's (`build/SKILL.md`), the reviewer's (`review/SKILL.md`), the shipper's
- * (`ship/SKILL.md`). Documentation and test surface; the lookup below flattens it.
+ * (`ship/SKILL.md`), the UI reviewer's (`review-ui/SKILL.md`). Documentation and test surface; the
+ * lookup below flattens it.
  */
 export const SHELL_VOCABULARIES = {
 	builder: {
@@ -36,6 +37,20 @@ export const SHELL_VOCABULARIES = {
 		STALE: "BLOCKED",
 		UNBINDABLE: "BLOCKED",
 		ROUTED: "BLOCKED",
+	},
+	// The rendered gate's six terminals (#7403). Three of them named no event at all until this
+	// group existed, so an unrenderable `review:ui` lane hit the refusal and stayed `active` with no
+	// live shell — the park it actually was reached nobody. Each of the three is the reviewer
+	// group's own BLOCKED shape: no verdict landed and a human is owed the render, the manifest or
+	// the route. The three that re-spell the reviewer's agree with it, which is why flattening still
+	// reports `Flat`.
+	"ui-reviewer": {
+		PASS: "PASS",
+		FAIL: "FAIL",
+		"CANT-SEE": "BLOCKED",
+		ESCALATED: "BLOCKED",
+		"BLOCKED-NO-MANIFEST": "BLOCKED",
+		"ROUTED-ELSEWHERE": "BLOCKED",
 	},
 	shipper: {
 		"ALREADY-MERGED": "DONE",

--- a/packages/fabrika-cli/src/lane/report.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report.unit.test.ts
@@ -1,3 +1,5 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {EPIC_RULES} from "../wire/lane-brief.ts";
 import {eventForToken, flattenVocabularies, SHELL_VOCABULARIES} from "./report.ts";
@@ -104,5 +106,47 @@ describe("flattening the per-shell vocabularies", () => {
 			_tag: "Collision",
 			collisions: ["ROUTED: shipper reports FAIL, reviewer reports BLOCKED"],
 		});
+	});
+});
+
+describe("the UI reviewer's vocabulary against the skill that owns it", () => {
+	// Parsing the skill rather than restating it is what makes a seventh terminal fail here instead
+	// of stranding the next lane that ends on it — three of these six named no event at all, so an
+	// unrenderable lane's report hit the refusal and the lane stayed `active` forever (#7403).
+	const SKILL = fileURLToPath(
+		new URL("../../../../claude-plugins/fabrika/skills/review-ui/SKILL.md", import.meta.url),
+	);
+	const section = /\n## Terminal vocabulary\n([\s\S]*?)(?=\n## )/.exec(
+		readFileSync(SKILL, "utf8"),
+	)?.[1];
+	const declared = [...(section ?? "").matchAll(/\*\*(?:verdict )?([A-Z][A-Z-]+)\*\*/g)].flatMap(
+		(match) => (match[1] === undefined ? [] : [match[1]]),
+	);
+
+	it("reads the section and the six terminals it names", () => {
+		expect(section).toBeDefined();
+		expect(new Set(declared)).toEqual(
+			new Set(["PASS", "FAIL", "CANT-SEE", "ESCALATED", "BLOCKED-NO-MANIFEST", "ROUTED-ELSEWHERE"]),
+		);
+	});
+
+	it("resolves every terminal the skill declares, none to the refusal", () => {
+		for (const token of declared) {
+			expect(eventForToken(token)).toMatchObject({_tag: "Mapped", token});
+		}
+	});
+
+	it("holds exactly those terminals in the ui-reviewer group", () => {
+		expect(new Set(Object.keys(SHELL_VOCABULARIES["ui-reviewer"]))).toEqual(new Set(declared));
+	});
+
+	it("parks the three terminals that land no verdict and owe a human something", () => {
+		expect(eventForToken("CANT-SEE")).toEqual({
+			_tag: "Mapped",
+			token: "CANT-SEE",
+			event: "BLOCKED",
+		});
+		expect(eventForToken("BLOCKED-NO-MANIFEST")).toMatchObject({event: "BLOCKED"});
+		expect(eventForToken("ROUTED-ELSEWHERE")).toMatchObject({event: "BLOCKED"});
 	});
 });


### PR DESCRIPTION
`SHELL_VOCABULARIES` in `packages/fabrika-cli/src/lane/report.ts` had three groups — builder,
reviewer, shipper — and none for the `ui-reviewer` shell. The map is total over the tokens it lists
and refuses everything else, so three of `review-ui`'s six terminals (`CANT-SEE`,
`BLOCKED-NO-MANIFEST`, `ROUTED-ELSEWHERE`) could never be recorded: a `review:ui` lane that hit one
stayed `active` with no live shell and no event owed to anyone.

This adds the fourth group with all six terminals. The three unmapped ones fold to `BLOCKED`, on the
precedent the reviewer group already sets — the gate landed no verdict and a human is owed the
render, the manifest, or the route. `PASS`/`FAIL`/`ESCALATED` are re-spelled in the new group and
agree with the groups that already hold them, so flattening still reports `Flat`. The group comment
now names `review-ui/SKILL.md` alongside the three skills it already listed.

Two test surfaces:

- `report.unit.test.ts` parses `review-ui/SKILL.md`'s `## Terminal vocabulary` section and asserts
  every terminal it declares resolves to a non-refusal, and that the group holds exactly that set.
  A seventh terminal added to the skill fails the suite instead of stranding the next lane.
- `report-verb.unit.test.ts` already drives every token of every group through `lane report` from a
  lane folded into that shell's state; it now carries a `review:ui` fixture, so all six record end
  to end.

Reviewer's first look: the `review:ui` log fixture in `report-verb.unit.test.ts` — `ui` stands from
the `WIP`, so the `PASS` out of `review` takes the class-guarded arm and the lane folds into the
rendered gate's cell.

A `PARK_CAUSES` row for "the gate cannot render this surface" is out of scope per the issue's triage
note, and the two UI skills' missing `lane report` record step is #6891's.

Fixes #7403

## Deviations

- **Out-of-scope change** — **Said:** #7403 names `report.ts` and a new unit test in
  `packages/fabrika-cli/src/lane/`. **Did:** also extended `report-verb.unit.test.ts` with a
  `review:ui` log fixture and a `stateFor` row. **Why:** that file's table-driven test iterates
  `SHELL_VOCABULARIES` and types `stateFor` as total over its keys, so a fourth group fails
  `pnpm typecheck` until it names the lane state that group reports out of. **Disposition:** stated
  here; it is the criterion-5 typecheck pass, not a separate change.
