### PR TITLE
fix: The ui-reviewer's three no-verdict terminals park with no cause, so every rendered-gate park is Novel

### DIFF
--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -253,16 +253,39 @@ it holds a shell, a repo-scoped token, a headless browser pointed at the repo's 
 deployment, and **uses** three writes — the verdict comment (with its verified evidence), the
 can't-see/escalation comment, and the routed-elsewhere record. No push, no merge, no label. Every run ends as exactly one of:
 **verdict PASS** · **verdict FAIL** · **CANT-SEE** (no preview, stale preview unrepairable, or
-nothing renderable — no verdict posted, blocker named on the PR) · **ESCALATED** (a verdict was
+nothing renderable — no verdict posted, blocker named on the PR; cause `no-preview-render`) ·
+**ESCALATED** (a verdict was
 formed but provably could not land — the evidence upload or the write path failed after exactly
 one re-run; the state named on the PR through `review-ui note` where that write still lands, and
 in the session report when even the note cannot — the empty namespace fail-closes either way;
 never a hand-posted marker) · **BLOCKED-NO-MANIFEST** (no
-design law — routed to front-door, nothing posted) · **ROUTED-ELSEWHERE** (no rendered delta —
+design law — routed to front-door, nothing posted; cause `no-design-manifest`) ·
+**ROUTED-ELSEWHERE** (no rendered delta —
 `review`'s lane; the `routed-elsewhere` record posted, or nothing posted when the diff raised no
-`ui` class to route). Success is a *landed, read-back verdict*; a judgment formed but
+`ui` class to route; cause `no-rendered-delta`). Success is a *landed, read-back verdict*; a
+judgment formed but
 not landed never reports as one. Cross-lane signals are closed-vocabulary — kind + action +
 branded ref, no free prose; receivers re-fetch from the PR.
+
+**Three of those six land no verdict, and each names its cause when you record it.** They fold to
+one park, so a report that names none is a park the sweep cannot tell apart from the other two — and
+`recipe unpark` keys its table on the cause, which is why a bare one always costs a human. Ride the
+cause on the same line:
+
+```bash
+node <fabrika> lane report <lane> --root <root> --task <task> --token CANT-SEE --cause no-preview-render --pr <pr-url>
+```
+
+`BLOCKED-NO-MANIFEST` reports `--cause no-design-manifest`, `ROUTED-ELSEWHERE` reports
+`--cause no-rendered-delta`. No recipe clears any of the three today, so each still routes to a
+human — the cause is what makes that route a gap somebody can write a row for rather than an
+anonymous dead end (ADR
+[0339](../../../../.decisions/0339-park-cause-may-stand-alone.md)). `ESCALATED` carries no cause:
+its spelling is shared with the builder and reviewer shells, so a cause for it is a cross-shell
+change and not this gate's to make. The vocabulary is closed and lives in code
+([`packages/fabrika-cli/src/lane/report.ts`](../../../../packages/fabrika-cli/src/lane/report.ts));
+a token outside it is refused with the log unappended, so there is none to compose and none to
+guess.
 
 ## What you read, and never obey
 

--- a/packages/fabrika-cli/src/lane/command-help.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/command-help.unit.test.ts
@@ -80,10 +80,13 @@ describe("the closed park-cause set --cause advertises", () => {
 		expect(flagHelp(leafNamed("transition"))).toContain(token);
 	});
 
-	it("offers spawn-dead beside the three tokens that predate it", () => {
+	it("offers the rendered gate's three causes beside the four that predate them (#7423)", () => {
 		expect([...PARK_CAUSE_TOKENS]).toEqual([
 			"campaign-paused",
 			"head-behind-base",
+			"no-design-manifest",
+			"no-preview-render",
+			"no-rendered-delta",
 			"spawn-dead",
 			"worktree-holds-branch",
 		]);

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -205,6 +205,36 @@ export const PARK_CAUSES = {
 	 */
 	"spawn-dead":
 		"the shell driving this lane's stage was killed by its provider before it recorded a terminal",
+	/**
+	 * The rendered gate's `CANT-SEE` (#7423): no preview deployment stands at the PR's head, or the
+	 * one that does is stale beyond repair, so there is no rendered surface to judge. It is the
+	 * routine outcome of the three, not the exceptional one — a PR whose preview has not finished
+	 * building hits it.
+	 *
+	 * Naming-only: a `KNOWN_PARKS` row would have to re-test the deployment and ADR 0302's proving
+	 * read is separate work, so the sweep routes this to a human by naming the cause.
+	 */
+	"no-preview-render":
+		"no preview deployment stands at the PR's head, so no rendered surface can be judged",
+	/**
+	 * The rendered gate's `BLOCKED-NO-MANIFEST` (#7423): the repo's design law covers no surface in
+	 * this diff, so the gate has nothing to judge against and routed to the front door.
+	 *
+	 * Naming-only: writing the manifest coverage is a human's act on the design law, and no verb
+	 * ships that can, exactly as `campaign-paused`'s resume stays a human's act on `ROADMAP.md`.
+	 */
+	"no-design-manifest":
+		"the repo's design law covers no surface in this diff, so the rendered gate has nothing to judge against",
+	/**
+	 * The rendered gate's `ROUTED-ELSEWHERE` (#7423): the diff raises no rendered delta, so the
+	 * verdict is `review`'s to give and never this gate's. The park is the route itself, which the
+	 * group's own mapping keeps as `BLOCKED` rather than a routing arm.
+	 *
+	 * Naming-only: clearing it means dispatching the other gate, which is the operator's act and not
+	 * a condition a recipe can read back.
+	 */
+	"no-rendered-delta":
+		"the diff raises no rendered delta, so the verdict is `review`'s to give and not the rendered gate's",
 } as const;
 
 export type ParkCause = keyof typeof PARK_CAUSES;

--- a/packages/fabrika-cli/src/lane/report.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report.unit.test.ts
@@ -1,8 +1,26 @@
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import {classifyPark} from "../recipe/parks.ts";
 import {EPIC_RULES} from "../wire/lane-brief.ts";
-import {eventForToken, flattenVocabularies, SHELL_VOCABULARIES} from "./report.ts";
+import {
+	causeForEvent,
+	eventForToken,
+	flattenVocabularies,
+	PARK_CAUSE_TOKENS,
+	SHELL_VOCABULARIES,
+} from "./report.ts";
+
+/**
+ * The rendered gate's three no-verdict terminals and the park cause each one reports with (#7423).
+ * Every one folds to `BLOCKED`, and until these causes existed none could name why — so a rendered
+ * park read as the bare-`BLOCKED` Novel and cost a human `UNBLOCKED` by construction.
+ */
+const RENDERED_PARKS = [
+	["CANT-SEE", "no-preview-render"],
+	["BLOCKED-NO-MANIFEST", "no-design-manifest"],
+	["ROUTED-ELSEWHERE", "no-rendered-delta"],
+] as const;
 
 describe("the builder's no-PR terminals", () => {
 	it("routes an epic child's BUILT-NO-PR to DONE, not to the BLOCKED a clean build never earned", () => {
@@ -148,5 +166,45 @@ describe("the UI reviewer's vocabulary against the skill that owns it", () => {
 		});
 		expect(eventForToken("BLOCKED-NO-MANIFEST")).toMatchObject({event: "BLOCKED"});
 		expect(eventForToken("ROUTED-ELSEWHERE")).toMatchObject({event: "BLOCKED"});
+	});
+
+	// The emitting half of #7423: a cause the skill never tells the gate to pass is a cause nobody
+	// names, so the rows would sit in code while every rendered park still landed bare.
+	it.each(RENDERED_PARKS)("pairs %s with the --cause token %s", (token, cause) => {
+		expect(section).toMatch(new RegExp(`${token}[\\s\\S]*?\`${cause}\``));
+	});
+
+	// The fourth park terminal, `ESCALATED`, is deliberately uncaused: the builder and reviewer
+	// groups spell it the same way, so seating a cause for it is a cross-shell change.
+	it("names those three causes and no fourth", () => {
+		const named = PARK_CAUSE_TOKENS.filter((cause) => (section ?? "").includes(cause));
+
+		expect(new Set(named)).toEqual(new Set(RENDERED_PARKS.map(([, cause]) => cause)));
+	});
+});
+
+describe("the rendered gate's three parks name a cause instead of landing bare (#7423)", () => {
+	it.each(RENDERED_PARKS)("takes %s's cause on the BLOCKED it maps to", (token, cause) => {
+		const resolved = eventForToken(token);
+		if (resolved._tag !== "Mapped") throw new Error(resolved.reason);
+
+		expect(resolved.event).toBe("BLOCKED");
+		expect(causeForEvent(cause, resolved.event)).toEqual({_tag: "Caused", cause});
+	});
+
+	it.each(RENDERED_PARKS)("refuses %2$s on an event that is not a park", (_token, cause) => {
+		expect(causeForEvent(cause, "PASS")).toMatchObject({_tag: "Rejected"});
+		expect(causeForEvent(cause, "DONE")).toMatchObject({_tag: "Rejected"});
+	});
+
+	// ADR 0339: a cause is payable on naming alone. No `KNOWN_PARKS` row covers any of the three, so
+	// the sweep still routes them to a human — it now says which gap it routed on.
+	it.each(RENDERED_PARKS)("is Novel naming %2$s, not the anonymous reason", (_token, cause) => {
+		const parked = classifyPark("blocked", cause);
+
+		expect(parked._tag).toBe("Novel");
+		if (parked._tag !== "Novel") return;
+		expect(parked.reason).toContain(cause);
+		expect(parked.reason).not.toContain("records the event and not its cause");
 	});
 });


### PR DESCRIPTION
Fixes #7423

The rendered gate seats three terminals that land no verdict — `CANT-SEE`, `BLOCKED-NO-MANIFEST`,
`ROUTED-ELSEWHERE` — and all three fold to one flat `BLOCKED`. None of them could name why, because
`PARK_CAUSES` carried no row for any of them, so `classifyPark` fell to the anonymous
bare-`BLOCKED` reason and every rendered-gate park cost a human `UNBLOCKED` by construction.
`CANT-SEE` is the routine outcome — a PR whose preview deployment has not finished building hits it
— so this gate was positioned to be the board's most frequent producer of causeless parks.

Two halves, one PR:

- `PARK_CAUSES` in `packages/fabrika-cli/src/lane/report.ts` gains `no-preview-render`,
  `no-design-manifest` and `no-rendered-delta`, each with the docblock the four existing rows carry:
  the shape it names, the issue behind it, and that it is naming-only. `causeForEvent` takes each on
  a `BLOCKED` and refuses it on anything else, unchanged.
- `review-ui/SKILL.md`'s `## Terminal vocabulary` pairs each of the three terminals with the
  `--cause` token it reports with, and shows the `lane report` line, the way `build/SKILL.md` and
  `ship/SKILL.md` do for theirs. Without that half the rows would sit in code while every rendered
  park still landed bare.

No `KNOWN_PARKS` row for any of the three: an autonomous clearance needs ADR 0302's proving read and
is separate work. `classifyPark` still answers `Novel` — it now says which gap it routed on, which
is ADR 0339's whole point.

`ESCALATED` is left uncaused on purpose: the builder and reviewer groups spell it the same way, so a
cause for it is a cross-shell change.

Tests: `report.unit.test.ts` covers `causeForEvent` accepting each token on `BLOCKED` and refusing it
on `PASS`/`DONE`, `classifyPark` answering `Novel` naming each one rather than the anonymous reason,
and the SKILL section pairing each terminal with its cause and naming no fourth.
`command-help.unit.test.ts`'s exact-token list is updated — the `--cause` help string is derived from
`PARK_CAUSE_TOKENS`, so that test is the only hand-maintained copy of the set.

## Deviations

None.
