### PR TITLE
fix: worktree-base.git.test.ts parallel-spawn test flakes on a ref-lock error in CI

### DIFF
--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -528,8 +528,14 @@ created and arrived dep-less.
 - **Its base never travels through `FETCH_HEAD`.** That name is one file in the shared `.git` dir and
   every parallel spawn fetches the same clone, so a sibling's fetch truncated it mid-read and the
   loser's spawn died on `fatal: invalid reference: FETCH_HEAD`. The fetch lands in a per-spawn ref
-  under `refs/fabrika/worktree-base/`, which is resolved to a commit id and dropped before the slow
-  `git worktree add` runs at that id ([#6081](https://github.com/kamp-us/phoenix/issues/6081)).
+  named `refs/fabrika/worktree-base-<slug>-<nonce>`, which is resolved to a commit id and dropped
+  before the slow `git worktree add` runs at that id
+  ([#6081](https://github.com/kamp-us/phoenix/issues/6081)). That leaf sits *directly* in
+  `refs/fabrika/` rather than one level down, because `git update-ref -d` removes every parent
+  directory its deletion empties and stops two components in — so a nested prefix was a directory the
+  last spawn to finish rmdir'd out from under a sibling's in-flight fetch, which then died on
+  `cannot lock ref … No such file or directory`
+  ([#7428](https://github.com/kamp-us/phoenix/issues/7428)).
 - **Two sibling-worktree faults are recovered from, and only those two.** A `git worktree add`
   registers `.git/worktrees/<name>/` before it checks out, and while that entry is half-built any
   concurrent command against the clone can die on it — a fetch's connectivity check on the null-oid

--- a/packages/fabrika-cli/src/hook/worktree-base.git.test.ts
+++ b/packages/fabrika-cli/src/hook/worktree-base.git.test.ts
@@ -9,6 +9,11 @@
  * FETCH_HEAD`. Measured here on git 2.40.1 before the fix, 12 of 320 concurrent fetch-then-resolve
  * pairs came back empty; point {@link fetchBaseArgs} back at `FETCH_HEAD` and this file goes red.
  *
+ * The per-spawn ref that fixed it left a second, rarer race on the directory those names *shared*,
+ * which surfaced here as an intermittent `cannot lock ref` (#7428). That one is settled by where
+ * {@link baseRefFor} puts its leaf, so it is pinned in the last describe rather than raced for: the
+ * observed rate was one loss in 320 pairs, far below what this file's load would catch reliably.
+ *
  * What is exercised is the derivation the verb performs — the argv from {@link fetchBaseArgs},
  * {@link resolveBaseArgs} and {@link dropBaseRefArgs}, and the guard in {@link isCommitId}. The
  * Effect wrapper around them folds the same pieces over a scripted spawner elsewhere; running it
@@ -22,6 +27,8 @@
  * subject (#7331), over the same {@link openClone} fixture.
  */
 import {execFile, execFileSync} from "node:child_process";
+import {existsSync} from "node:fs";
+import {join} from "node:path";
 import {promisify} from "node:util";
 import {afterAll, describe, expect, it} from "vitest";
 import {GIT_ENV, openClone, removeClones} from "./throwaway-clone.test-support.ts";
@@ -100,5 +107,25 @@ describe("the per-spawn base ref", () => {
 				execFileSync("git", ["check-ref-format", ref], {env: GIT_ENV, stdio: "ignore"}),
 			).not.toThrow();
 		}
+	});
+
+	// #7428: a per-spawn *name* still left a shared *directory* for `update-ref -d` to rmdir out from
+	// under a sibling's in-flight fetch. What makes the leaf safe is which component it sits in, so
+	// that is what is pinned — a future nesting that reintroduces the race reds here.
+	it("puts its leaf directly in `refs/fabrika/`, the deepest directory `update-ref -d` cannot prune", () => {
+		const ref = baseRefFor("agent", "0123456789ab");
+		expect(ref.startsWith("refs/fabrika/")).toBe(true);
+		expect(ref.split("/")).toHaveLength(3);
+	});
+
+	it("leaves the directory its leaf lived in behind, so a sibling's fetch can still lock a ref there", async () => {
+		const {clone, tip} = openClone();
+		expect(await resolveBase(clone, "agent-alone", "0123456789ab")).toBe(tip);
+
+		// `update-ref -d` prunes every parent it empties, floored two components in. That leaf was the
+		// only ref under its directory, so a prunable directory would be gone by now.
+		const ref = baseRefFor("agent-alone", "0123456789ab");
+		const leafDir = join(clone, ".git", ref.slice(0, ref.lastIndexOf("/")));
+		expect(existsSync(leafDir)).toBe(true);
 	});
 });

--- a/packages/fabrika-cli/src/hook/worktree-create.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create.ts
@@ -40,7 +40,8 @@ export const worktreePathFor = (repoRoot: string, name: string): string =>
 	`${repoRoot}/.claude/worktrees/${name}`;
 
 /**
- * Where this spawn's fetched base lands — a ref **no sibling spawn can write**.
+ * Where this spawn's fetched base lands — a ref **no sibling spawn can write**, under a directory
+ * **no sibling spawn can remove**.
  *
  * `FETCH_HEAD` is one file in the shared `.git` dir and every parallel spawn fetches against the same
  * clone, so one spawn reads it while a sibling's fetch has it truncated and the read returns nothing.
@@ -48,12 +49,29 @@ export const worktreePathFor = (repoRoot: string, name: string): string =>
  * fetch-then-resolve pairs lost the base that way (#6081). Serializing the pair would fix it too, but
  * a per-spawn name removes the shared write instead of taking turns at it.
  *
+ * A per-spawn *name* left a shared *directory*, which is a second race (#7428). `git update-ref -d`
+ * deletes the loose ref and then walks upward removing every parent it just emptied — but its walk
+ * has a floor: `try_remove_empty_parents` in git's `refs/files-backend.c` advances its pointer past
+ * the refname's first **two** components — the `for (i = 0; i < 2; i++)` loop commented
+ * `refs/{heads,tags,...}` — before pruning anything, identical on v2.40.1 and v2.51.0. So the
+ * deepest directory it can ever remove is the third
+ * component's. The leaf therefore sits directly in `refs/fabrika/`, which is component two and out of
+ * reach; a nested `refs/fabrika/worktree-base/<leaf>` put the shared directory one level lower, where
+ * the last spawn to finish rmdir'd it out from under a sibling's in-flight `git fetch` — between that
+ * fetch's mkdir and its `<leaf>.lock` create — and the sibling died on `cannot lock ref … No such file
+ * or directory`. Measured across 720 concurrent spawns against one clone on git 2.40.1: nested, the
+ * shared directory was absent in 363 of 4635 polls; flat under `refs/fabrika/`, 0 of 4894.
+ *
+ * `concurrencyArm` deliberately does not classify that diagnostic: this shape removes the race rather
+ * than recovering from it, and prune-and-backoff would not have helped a fetch whose parent directory
+ * was gone.
+ *
  * The slug is folded to `[A-Za-z0-9-]` so it cannot carry a `..` or a `.lock` suffix into a refname,
  * and the nonce — not the slug — is what makes the name unique: two slugs that differ only in
  * punctuation fold together, which would put the shared write straight back.
  */
 export const baseRefFor = (name: string, nonce: string): string =>
-	`refs/fabrika/worktree-base/${name.replace(/[^A-Za-z0-9]+/g, "-")}-${nonce}`;
+	`refs/fabrika/worktree-base-${name.replace(/[^A-Za-z0-9]+/g, "-")}-${nonce}`;
 
 /** The fully-qualified source is deliberate: an unqualified `main` also matches a tag named `main`. */
 export const fetchBaseArgs = (base: string, baseRef: string): ReadonlyArray<string> => [


### PR DESCRIPTION
Two spawns resolving their base against the same clone could collide on the `refs/fabrika/worktree-base/` **directory**. One spawn's `git update-ref -d` removed the now-empty directory, and a sibling's in-flight `git fetch` — already past its `mkdir`, not yet at its `<leaf>.lock` create — died on `cannot lock ref … No such file or directory`. `concurrencyArm` matches neither of its two patterns against that diagnostic, so the fail-closed `null` refused the spawn outright: a flaky test in CI, and a hard provisioning refusal in a live fan-out.

This takes the ref-naming route, which deletes the failure mode rather than classifying it. `baseRefFor` now returns `refs/fabrika/worktree-base-<slug>-<nonce>` — the leaf sits *directly* in `refs/fabrika/` instead of one level below it.

## Why that is safe, measured

`git update-ref -d` deletes the loose ref and then walks upward removing every parent it emptied, but the walk has a floor. `try_remove_empty_parents` in git's `refs/files-backend.c` advances its pointer past the refname's first **two** components before pruning anything (the `for (i = 0; i < 2; i++)` loop commented `refs/{heads,tags,...}`), identical at [v2.40.1](https://github.com/git/git/blob/v2.40.1/refs/files-backend.c#L1077-L1094) and [v2.51.0](https://github.com/git/git/blob/v2.51.0/refs/files-backend.c#L1220-L1237). So the deepest directory it can ever remove is the third component's, and a leaf in `refs/fabrika/` has no prunable parent at all.

Run rather than reasoned about, on git 2.40.1, 720 concurrent spawns against one clone with the verb's own three commands and a poller watching the shared directory:

| ref shape | shared directory observed missing |
|---|---|
| `refs/fabrika/worktree-base/<leaf>` (before) | 363 of 4635 polls |
| `refs/fabrika/worktree-base-<leaf>` (after) | 0 of 4894 polls |

Directly: deleting the only ref under `refs/fabrika/worktree-base/` removes that directory and leaves `refs/fabrika/`; deleting `refs/fabrika/worktree-base-<leaf>` leaves `refs/fabrika/` standing across repeated rounds.

## What a reviewer should look at first

The two new tests in the last `describe` of `worktree-base.git.test.ts`. The race is one loss in 320 pairs as observed, far below what this file's load catches reliably, so it is pinned as an invariant rather than raced for: one asserts the leaf is a three-component ref under `refs/fabrika/`, the other runs a real resolve and asserts the leaf's directory survives the delete. Both go red on the old shape — the old ref splits into four components, and its directory is gone by the time the assertion runs.

`concurrencyArm` is deliberately untouched. Prune-and-backoff would not have helped a fetch whose parent directory was removed, and the docblock now says so.

The existing `for-each-ref refs/fabrika/` test still passes unchanged: that prefix still matches the new leaf. `check-ref-format` accepts every ref the folded slug produces, which the existing test covers and I re-checked against the flat shape directly.

Fixes #7428

## Deviations

None.
