### PR TITLE
fix: CLAUDE.md and alchemy.run.ts say alchemy dev boots offline; it needs Cloudflare credentials

### DIFF
--- a/.patterns/feature-flags.md
+++ b/.patterns/feature-flags.md
@@ -172,7 +172,7 @@ outage looks like every flag being off, never like a broken request.
 
 ## 5. Flip a flag locally (dev-only override, #622)
 
-Under offline `pnpm dev` the Flagship binding has no live evaluator, so every read degrades to its
+Under `pnpm dev` the Flagship binding has no live evaluator, so every read degrades to its
 safe default — you can't see the flag-*on* path. A **dev-only override** closes that gap: it forces a
 boolean flag on/off *for your browser only*, short-circuiting the real read before it falls back.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ pnpm install
 cp apps/web/.env.example apps/web/.env   # first run only — local dev env (gitignored)
 pnpm dev          # turbo-driven; two processes: `vite` (SPA/HMR) + `alchemy dev` (worker)
 pnpm dev:web      # just the Vite SPA dev server
-pnpm dev:worker   # just `alchemy dev` (the worker on a local workerd, offline)
+pnpm dev:worker   # just `alchemy dev` (the worker on a local workerd, real CF resources)
 pnpm build
 pnpm deploy       # pnpm build && alchemy deploy (use --stage <name> for isolation)
 pnpm typecheck
@@ -50,7 +50,11 @@ pnpm format       # biome check --write
 Deploy is alchemy-managed (ADR 0026–0031): `alchemy.run.ts` is the stack, there is
 no `wrangler.jsonc`. `alchemy deploy --stage <name>` yields an isolated worker + D1
 + DOs per stage; CI uses the Cloudflare-hosted state store, local dev uses
-`Alchemy.localState()` (offline).
+`Alchemy.localState()`. Only the *state store* is local — the resources it binds
+(D1, the DO namespaces) are real Cloudflare resources in your personal dev stage,
+so `alchemy dev` needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in your
+environment. There is no offline emulator (ADR
+[0032](.decisions/0032-alchemy-beta45-and-dev-model.md)).
 
 ## pnpm over npm
 

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -19,13 +19,16 @@
  *
  * State selection follows ADR 0031 (local-first dev): `Alchemy.localState()` is
  * a file-based store needing only `FileSystem`/`Path` — no credentials, no
- * network — so `alchemy dev` boots fully offline. A real `alchemy deploy` uses
- * the Cloudflare-hosted store for reproducible shared state.
+ * network. That is the *store* only: the resources it tracks are still
+ * reconciled against the Cloudflare API, so `alchemy dev` needs
+ * `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` and there is no offline
+ * emulator (ADR 0032). A real `alchemy deploy` uses the Cloudflare-hosted store
+ * for reproducible shared state.
  *
  * The store is selected from the **dev-vs-deploy** signal, not `CI` (see
  * `resolveStateMode` in `worker/env.ts`): `CI` is set for BOTH the deploy workflow
  * and the integration-test job, so it can't tell a real deploy from a test run.
- * Only `alchemy dev` resolves to `localState()` (offline); a real `alchemy deploy`
+ * Only `alchemy dev` resolves to `localState()`; a real `alchemy deploy`
  * — and the `Test.make` integration suite, which deploys to real remote Cloudflare
  * per ADR 0082 — uses the shared Cloudflare store. The selector runs synchronously
  * at module-eval, so it reads the dev signal off `process.env`


### PR DESCRIPTION
Three in-repo surfaces said `alchemy dev` runs offline. It does not: `PhoenixDb` is a plain `Cloudflare.D1.Database` (`apps/web/worker/db/resources.ts`), and `alchemy@2.0.0-beta.59`'s `src/Cloudflare/D1/Database.ts` carries no local/dev branch — both `create` and `read` hit `/accounts/{account_id}/d1/database`. Without `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` the worker leg never listens on `127.0.0.1:1337` and Vite's `/api` proxy 502s. `DEVELOPMENT.md` already says the true thing; this matches the others to it.

- `AGENTS.md` deploy paragraph: `Alchemy.localState()` is the *state store* only; the resources it binds are real Cloudflare resources in your personal dev stage, needing the two Cloudflare vars, with no offline emulator (ADR 0032).
- `AGENTS.md` commands block: the `pnpm dev:worker` comment no longer says `offline`.
- `apps/web/alchemy.run.ts` top docblock: the "State selection follows ADR 0031" paragraph no longer concludes "boots fully offline", and the `resolveStateMode` paragraph below it drops its `(offline)` parenthetical.
- `.patterns/feature-flags.md` §5: dropped "offline" from "Under offline `pnpm dev`".

`DEVELOPMENT.md` is untouched. `CLAUDE.md` is a symlink to `AGENTS.md`, so the diff reads as `AGENTS.md`. Comments and docs only — `pnpm typecheck` and `pnpm lint:worktree` green in-tree via `build check --surface code`, link + leak scan green via `--surface prose`.

Fixes #7412

## Deviations

- **Out-of-scope change** — **Said:** #7412's criteria name the `AGENTS.md` "Deploy is alchemy-managed" paragraph and the `apps/web/alchemy.run.ts` docblock. **Did:** also changed `AGENTS.md:40`'s `pnpm dev:worker` comment, which said `offline` too. **Why:** it is the same false claim in the same file the criterion repairs; leaving it would let the fixed paragraph and the line 12 above it disagree. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria name two files. **Did:** also dropped the word "offline" from `.patterns/feature-flags.md` §5's "Under offline `pnpm dev`". **Why:** a repo-wide grep for the claim found this third copy, which would still read as true after this PR. Only the adjective was removed — the sentence's flag claim (no live Flagship evaluator in dev) is untouched, because verifying it was outside this issue. **Disposition:** stated here.
