### PR TITLE
fix: reap's merge-base refusal names no shallow-clone cause, unlike the assembly read

### DIFF
--- a/packages/fabrika-cli/src/build/landed.ts
+++ b/packages/fabrika-cli/src/build/landed.ts
@@ -21,7 +21,7 @@
 import {Effect} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {isShallowClone, mergeBase, rangeCommits, resolveCommit, type Shell} from "../io/git.ts";
+import {mergeBase, noMergeBaseReason, rangeCommits, resolveCommit} from "../io/git.ts";
 import {epicBranch} from "../wire/lane-brief.ts";
 import {issueRefsIn} from "./commit-message.ts";
 import {defaultBranch} from "./github.ts";
@@ -48,30 +48,6 @@ export type Assembly =
 			readonly commits: number;
 	  }
 	| {readonly _tag: "Unreadable"; readonly branch: string; readonly reason: string};
-
-/**
- * Why a merge-base read named nothing, in the words that carry a remedy when there is one.
- *
- * A shallow clone's graft boundary is the one cause of this that the operator can repair without
- * touching a ref, a blocker or an issue: every traversal treats the boundary commit as a root, so a
- * common ancestor beyond it is unreachable and `git merge-base` names nothing rather than erroring
- * (the same split `traversedParents` documents, #6343). Reported as a generic unreadable reason it
- * cost a supervisor round-trip diagnosing git history depth from outside the verb (#7292).
- *
- * **Git's own reason is never dropped, and the shallow clause is a hypothesis beside it.** The probe
- * answers "is this clone shallow", which is a strictly weaker fact than "the shallowness is why
- * merge-base named nothing" — an absent `origin/<trunk>` ref and an unrelated-histories pair fail
- * here too, and a shallow CI checkout is exactly where the first is likeliest. Asserting the cause
- * would hand the operator a confident wrong diagnosis and lose the one piece of evidence that
- * corrects it. A shallow probe that itself fails drops the clause entirely: this names an unreadable
- * read more precisely, and never turns one into a readable one.
- */
-const noMergeBaseReason = (baseRef: string, reason: string): Shell<string> =>
-	Effect.map(isShallowClone, (shallow) =>
-		shallow._tag === "Ok" && shallow.value
-			? `no merge base with ${baseRef}: ${reason} — this clone is shallow, so if the common ancestor lies beyond its graft boundary git names none; \`git fetch --unshallow origin\` restores it, and nothing about the epic run needs changing`
-			: `no merge base with ${baseRef}: ${reason}`,
-	);
 
 /**
  * Read epic `epic`'s assembly branch in this tree, bounded to the commits the run put on it.

--- a/packages/fabrika-cli/src/build/reap-verb.ts
+++ b/packages/fabrika-cli/src/build/reap-verb.ts
@@ -33,6 +33,7 @@ import {
 	diffRange,
 	diffRangePaths,
 	mergeBase,
+	noMergeBaseReason,
 	originHeadRef,
 	patchIdsIn,
 	patchIdsOf,
@@ -288,7 +289,7 @@ const landingOf = (head: string, trunk: string): Effect.Effect<Landing, never, D
 		if (base._tag === "Failure") {
 			return {
 				_tag: "Unknown" as const,
-				reason: `it shares no merge base with ${trunk}: ${base.reason}`,
+				reason: `it shares ${yield* noMergeBaseReason(trunk, base.reason)}`,
 			};
 		}
 		const landed = yield* patchIdsIn(base.value, trunk, paths.value, TRUNK_SCAN);

--- a/packages/fabrika-cli/src/build/reap-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/reap-verb.unit.test.ts
@@ -1,6 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, once, type Scripted} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
 import {runReap} from "./reap-verb.ts";
 
@@ -14,6 +15,7 @@ const NAMES = /^git diff .*--name-only/;
 const MERGE_BASE = /^git merge-base origin\/main /;
 const LOG = /^git log --no-merges -p /;
 const PATCH_ID = /^git patch-id --stable$/;
+const SHALLOW = /^git rev-parse --is-shallow-repository$/;
 const REMOVE = /^git worktree remove /;
 
 const HERE = "/repo/.claude/worktrees/agent-self";
@@ -182,6 +184,57 @@ describe("runReap — what the trunk proves", () => {
 		expect(JSON.parse(out.stdout).kept).toMatchObject([{path: DEAD}]);
 		expect(out.stderr.join("\n")).toMatch(/UNKNOWN/);
 		expect(calls.some((line) => REMOVE.test(line))).toBe(false);
+	});
+});
+
+/**
+ * The merge base bounds the trunk scan, so a shallow clone's graft boundary stops the landing read
+ * before it starts. The tree is KEEP either way — the finding this seam was repaired for is that its
+ * reason names the one cause an operator can fix locally (#7407), the way the assembly read already
+ * did (#7292).
+ */
+describe("runReap — an unreachable merge base names its remedy when there is one", () => {
+	const beyondBoundary = (shallow: ExecResult): ReadonlyArray<Scripted> => [
+		...GROUND,
+		[TREES, trees(PRIMARY, {path: DEAD, head: AHEAD})],
+		[STATUS, okOut("")],
+		[ANCESTOR, errOut("exit 1")],
+		[DIFF, okOut("diff --git a/x b/x\n@@\n+x\n")],
+		[PATCH_ID, okOut("ffff 0000\n")],
+		[NAMES, okOut("x\0")],
+		[MERGE_BASE, errOut("git merge-base exited 1")],
+		[SHALLOW, shallow],
+	];
+
+	const keptReason = (out: {readonly stdout: string}): string =>
+		JSON.parse(out.stdout).kept[0]?.reason ?? "";
+
+	it("names the shallow clone and `git fetch --unshallow origin`", async () => {
+		const {out} = await run(beyondBoundary(okOut("true\n")));
+
+		const reason = keptReason(out);
+		expect(reason).toContain("this clone is shallow");
+		expect(reason).toContain("git fetch --unshallow origin");
+		// The probe proves shallowness, not causation — git's own words are the evidence that
+		// corrects the hypothesis when the cause is an absent ref or an unrelated history.
+		expect(reason).toContain("git merge-base exited 1");
+	});
+
+	it("carries git's reason alone when the clone is not shallow", async () => {
+		const {out} = await run(beyondBoundary(okOut("false\n")));
+
+		expect(keptReason(out)).toBe(
+			"whether its work landed is UNKNOWN: it shares no merge base with origin/main: git merge-base exited 1",
+		);
+	});
+
+	// A probe that cannot answer names an unreadable read no more precisely — and never less.
+	it("carries git's reason alone when the shallow probe itself fails", async () => {
+		const {out} = await run(beyondBoundary(errOut("rev-parse blew up")));
+
+		expect(keptReason(out)).toBe(
+			"whether its work landed is UNKNOWN: it shares no merge base with origin/main: git merge-base exited 1",
+		);
 	});
 });
 

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -618,6 +618,34 @@ export const isShallowClone: Shell<Attempt<boolean>> = Effect.gen(function* () {
 });
 
 /**
+ * Why a merge-base read named nothing, in the words that carry a remedy when there is one.
+ *
+ * A shallow clone's graft boundary is the one cause of this an operator can repair without touching
+ * a ref, a blocker or an issue: every traversal treats the boundary commit as a root, so a common
+ * ancestor beyond it is unreachable and {@link mergeBase} names nothing rather than erroring (the
+ * same split {@link traversedParents} documents, #6343). Reported as a generic reason it cost a
+ * supervisor round-trip diagnosing git history depth from outside the verb (#7292).
+ *
+ * **Git's own reason is never dropped, and the shallow clause is a hypothesis beside it.** The probe
+ * answers "is this clone shallow", which is a strictly weaker fact than "the shallowness is why
+ * merge-base named nothing" — an absent trunk ref and an unrelated-histories pair fail here too, and
+ * a shallow CI checkout is exactly where the first is likeliest. Asserting the cause would hand the
+ * operator a confident wrong diagnosis and lose the one piece of evidence that corrects it. A probe
+ * that itself fails drops the clause entirely: this names an unreadable read more precisely, and
+ * never turns one into a readable one.
+ *
+ * It lives here, beside the two reads it composes, so a third merge-base seam cannot be written
+ * without the diagnosis — the generic reason survived in `build reap` for exactly as long as the
+ * helper was private to one caller (#7407).
+ */
+export const noMergeBaseReason = (baseRef: string, reason: string): Shell<string> =>
+	Effect.map(isShallowClone, (shallow) =>
+		shallow._tag === "Ok" && shallow.value
+			? `no merge base with ${baseRef}: ${reason} — this clone is shallow, so if the common ancestor lies beyond its graft boundary git names none; \`git fetch --unshallow origin\` restores it, and no ref, blocker or issue needs changing`
+			: `no merge base with ${baseRef}: ${reason}`,
+	);
+
+/**
  * The parents git's *traversal* reports for one commit — the reading every ancestry answer rests on.
  *
  * Not the parents in the commit object: on a shallow clone's graft boundary the two disagree.


### PR DESCRIPTION
`build reap` refused a tree with `it shares no merge base with origin/main: <git's reason>` and named
no cause. On a shallow clone that failure has exactly one locally repairable cause — the graft
boundary makes every traversal treat the boundary commit as a root, so `git merge-base` names none —
and the sibling seam reading the same answer, `landed.ts`'s `readAssembly`, already says so (#7292,
PR #7406). `reap-verb.ts` was outside that PR's scope.

`noMergeBaseReason` moves out of `landed.ts` (module-private) into `packages/fabrika-cli/src/io/git.ts`,
beside the two reads it composes — `mergeBase` and `isShallowClone`. Both seams call it. Lifting
rather than copying is the point: a third merge-base read added later cannot skip the diagnosis.

Behaviour is unchanged on both sides of the probe. Git's own reason is never dropped, the shallow
clause is a hypothesis beside it, and a probe that itself fails drops the clause rather than
asserting a cause it did not prove.

Three unit tests drive `runReap` end to end with a failing `git merge-base` and each of the three
probe answers (shallow, not shallow, probe failed), asserting the KEEP reason the sweep prints.
`landed.ts`'s existing tests pass unmodified. Full `packages/fabrika-cli` suite green: 492 files,
8640 tests.

No doc surface pinned this string: `build reap`'s `--help` describes the per-tree reason generically,
and the two `contract.md` rows that paraphrase the shallow clause (`build eligible` / `build claim`)
describe git's-reason-plus-cause-plus-remedy, which still holds.

## Deviations

- **Scope narrowing** — **Said:** #7407's criterion 3 asks that `readAssembly`'s existing behaviour
  be unchanged. **Did:** the shallow clause's trailing reassurance changed from "and nothing about
  the epic run needs changing" to "and no ref, blocker or issue needs changing". **Why:** the old
  tail is epic-specific and reads as false in `build reap`, which sweeps worktrees and has no epic
  run; the replacement is the same assurance stated generically, and it is the wording the helper's
  own docblock already used for it ("the one cause an operator can repair without touching a ref, a
  blocker or an issue"). Both facts the clause carries — the shallow clone as likely cause and
  `git fetch --unshallow origin` as the remedy — are untouched, and `landed.ts`'s three existing
  assertions pass unmodified. **Disposition:** stated here.

Fixes #7407
