### PR TITLE
fix: A timed-out git command can enter worktree-create's concurrency retry loop

### DIFF
--- a/packages/fabrika-cli/src/hook/worktree-create-verb.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create-verb.ts
@@ -57,7 +57,7 @@ const VERB = "fabrika hook worktree-create";
 const EVENT = "WorktreeCreate";
 
 /** The hook's own budget is 600s; each child gets most of it, so a slow install is not a timeout. */
-const GIT_TIMEOUT_SECONDS = 540;
+export const GIT_TIMEOUT_SECONDS = 540;
 const CAPTURE_BYTES = 64 * 1024;
 
 /** The proof deps landed. `bootstrap-deps` writes the virtual store; a clean SKIP writes nothing. */
@@ -81,7 +81,7 @@ const firstLine = (bytes: Uint8Array): string => {
 	return (text.split("\n").find((line) => line.trim() !== "") ?? "").trim();
 };
 
-const describe = (outcome: ChildOutcome): string => {
+export const describeOutcome = (outcome: ChildOutcome): string => {
 	if (outcome._tag === "Unstartable") return `could not run git — ${outcome.reason}`;
 	if (outcome.timedOut) return `git did not finish within ${GIT_TIMEOUT_SECONDS}s`;
 	return firstLine(outcome.stderr) || `git exited ${outcome.exitCode}`;
@@ -91,14 +91,21 @@ const succeeded = (outcome: ChildOutcome): boolean =>
 	outcome._tag === "Ran" && !outcome.timedOut && outcome.exitCode === 0;
 
 /**
- * A command's whole stderr, for classification — not {@link describe}'s one quotable line.
+ * A command's whole stderr, for classification — not {@link describeOutcome}'s one quotable line.
  *
  * git prints the connectivity-check failure across two lines, and which line is first is not
  * something this verb should depend on. An unstartable git carries no git diagnostic at all, so it
  * classifies as nothing and refuses at once, which is right: a missing binary is not transient.
+ *
+ * A timed-out run classifies as nothing for the same reason, and it is the arm that pays worst for
+ * getting this wrong: one timed-out command spends {@link GIT_TIMEOUT_SECONDS} of the hook's 600s
+ * budget, so a second attempt cannot finish inside what is left and the hook is killed partway
+ * through it, losing the refusal it would have emitted at once (#7408). Whatever stderr it captured
+ * before the clock ran out, a command that never exited is not evidence of a transient sibling
+ * window. {@link describeOutcome} renders it as the timeout it was.
  */
 const diagnostics = (outcome: ChildOutcome): string =>
-	outcome._tag === "Ran" ? new TextDecoder().decode(outcome.stderr) : "";
+	outcome._tag === "Ran" && !outcome.timedOut ? new TextDecoder().decode(outcome.stderr) : "";
 
 const git = (
 	args: ReadonlyArray<string>,
@@ -114,7 +121,7 @@ const git = (
 		captureBytes: CAPTURE_BYTES,
 	});
 
-interface Attempted {
+export interface Attempted {
 	readonly outcome: ChildOutcome;
 	readonly attempts: number;
 	/** Non-null only when every attempt lost to that arm — the recovery ran out, not a pass. */
@@ -133,8 +140,11 @@ interface Attempted {
  * Nothing is locked and nothing is serialised (see `RECOVERY_ATTEMPTS`). Any diagnostic
  * {@link concurrencyArm} does not recognise returns on the first attempt, so a genuine failure is
  * never delayed and never retried into looking like one of these.
+ *
+ * Exported for the unit test beside this file: the command is already this function's parameter, so
+ * a test hands it an outcome the spawner cannot express — a timed-out run — and counts the attempts.
  */
-const withConcurrencyRecovery = (
+export const withConcurrencyRecovery = (
 	command: Effect.Effect<ChildOutcome, never, ChildProcessSpawner.ChildProcessSpawner>,
 	repoRoot: string,
 	env: Record<string, string>,
@@ -219,7 +229,7 @@ const provision = (
 		if (!succeeded(fetched.outcome)) {
 			return refuse(
 				BASE_FETCH_FAILED,
-				`${VERB}: could not fetch origin/${base}${spent(fetched)} — refusing to branch from a possibly stale base: ${describe(fetched.outcome)}`,
+				`${VERB}: could not fetch origin/${base}${spent(fetched)} — refusing to branch from a possibly stale base: ${describeOutcome(fetched.outcome)}`,
 			);
 		}
 
@@ -232,7 +242,7 @@ const provision = (
 		if (!succeeded(resolved) || !isCommitId(baseCommit)) {
 			return refuse(
 				BASE_FETCH_FAILED,
-				`${VERB}: fetched origin/${base} and ${baseRef} named no commit — refusing to branch from a base this verb cannot prove: ${describe(resolved)}`,
+				`${VERB}: fetched origin/${base} and ${baseRef} named no commit — refusing to branch from a base this verb cannot prove: ${describeOutcome(resolved)}`,
 			);
 		}
 
@@ -246,7 +256,7 @@ const provision = (
 		if (!succeeded(added.outcome)) {
 			return refuse(
 				WORKTREE_ADD_FAILED,
-				`${VERB}: git worktree add --detach ${plan.worktreePath} ${baseCommit} failed${spent(added)}: ${describe(added.outcome)}`,
+				`${VERB}: git worktree add --detach ${plan.worktreePath} ${baseCommit} failed${spent(added)}: ${describeOutcome(added.outcome)}`,
 			);
 		}
 

--- a/packages/fabrika-cli/src/hook/worktree-create-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/hook/worktree-create-verb.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `withConcurrencyRecovery`'s decision to retry, over outcomes the spawner cannot produce.
+ *
+ * The command is the function's own parameter, so the outcomes are handed to it directly rather than
+ * scripted through `fakeShell`, which maps every answer onto a child that exits — it has no way to
+ * express the one this file is about, a run killed at its timeout with stderr already captured
+ * (#7408). The spawner is still provided, and it is an assertion in its own right: a recovery round
+ * spawns `git worktree prune`, so a scripted-empty `calls` array is the proof no round ran.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeShell} from "../fakes.test-support.ts";
+import type {ChildOutcome} from "../io/exec.ts";
+import {RECOVERY_ATTEMPTS} from "./worktree-create.ts";
+import {
+	describeOutcome,
+	GIT_TIMEOUT_SECONDS,
+	withConcurrencyRecovery,
+} from "./worktree-create-verb.ts";
+
+const PLACEHOLDER_HEAD = "fatal: bad object worktrees/agent-7f2/HEAD\n";
+const INCOMPLETE_ADMIN_DIR = "fatal: failed to read .git/worktrees/agent-7f2/commondir\n";
+
+const ran = (
+	stderr: string,
+	over: Partial<Extract<ChildOutcome, {_tag: "Ran"}>>,
+): ChildOutcome => ({
+	_tag: "Ran",
+	exitCode: 1,
+	timedOut: false,
+	stdout: new Uint8Array(),
+	stderr: new TextEncoder().encode(stderr),
+	truncated: false,
+	...over,
+});
+
+const timedOut = (stderr: string): ChildOutcome => ran(stderr, {exitCode: null, timedOut: true});
+
+const succeeded: ChildOutcome = ran("", {exitCode: 0});
+
+/** Replay one outcome per attempt, counting the attempts and holding the last after they run out. */
+const scripted = (outcomes: ReadonlyArray<ChildOutcome>) => {
+	const seen: ChildOutcome[] = [];
+	const command = Effect.sync(() => {
+		const next = outcomes[Math.min(seen.length, outcomes.length - 1)] as ChildOutcome;
+		seen.push(next);
+		return next;
+	});
+	return {
+		command,
+		get attempts() {
+			return seen.length;
+		},
+	};
+};
+
+const recover = (outcomes: ReadonlyArray<ChildOutcome>) => {
+	const script = scripted(outcomes);
+	const shell = fakeShell([]);
+	return Effect.runPromise(
+		Effect.provide(withConcurrencyRecovery(script.command, "/repo", {}), shell.layer),
+	).then((attempted) => ({attempted, attempts: script.attempts, spawned: shell.calls}));
+};
+
+describe("a timed-out git command", () => {
+	it.each([
+		["PlaceholderHead", PLACEHOLDER_HEAD],
+		["IncompleteAdminDir", INCOMPLETE_ADMIN_DIR],
+	])("is refused on its first attempt though its stderr matches %s", async (_arm, stderr) => {
+		const {attempted, attempts, spawned} = await recover([timedOut(stderr)]);
+		expect(attempts).toBe(1);
+		expect(attempted.attempts).toBe(1);
+		expect(attempted.exhausted).toBeNull();
+		expect(spawned).toEqual([]);
+	});
+
+	it("is refused as the timeout it was, not as the stderr it captured", () => {
+		expect(describeOutcome(timedOut(PLACEHOLDER_HEAD))).toBe(
+			`git did not finish within ${GIT_TIMEOUT_SECONDS}s`,
+		);
+	});
+});
+
+describe("a fast-failing git command", () => {
+	it.each([
+		["PlaceholderHead", PLACEHOLDER_HEAD],
+		["IncompleteAdminDir", INCOMPLETE_ADMIN_DIR],
+	])("is still pruned and re-attempted through a %s window", async (_arm, stderr) => {
+		const {attempted, attempts, spawned} = await recover([ran(stderr, {}), succeeded]);
+		expect(attempts).toBe(2);
+		expect(attempted.attempts).toBe(2);
+		expect(attempted.exhausted).toBeNull();
+		expect(spawned).toEqual(["git worktree prune"]);
+	});
+
+	it("still exhausts the bounded recovery when the window never closes", async () => {
+		const {attempted, attempts} = await recover([ran(PLACEHOLDER_HEAD, {})]);
+		expect(attempts).toBe(RECOVERY_ATTEMPTS);
+		expect(attempted.exhausted).toBe("PlaceholderHead");
+	}, 20_000);
+
+	it("refuses an unrecognised diagnostic on its first attempt", async () => {
+		const {attempts, spawned} = await recover([ran("fatal: could not read Username\n", {})]);
+		expect(attempts).toBe(1);
+		expect(spawned).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #7408

`hook worktree-create` classified a git command's stderr without reading whether that command timed
out. A `git fetch` that printed a sibling-worktree diagnostic and then hit its own 540s timeout was
retried as a transient sibling window — but one timed-out command already spends 540 of the hook's
600s budget, so the retry cannot finish and the hook is killed partway through it. The refusal that
names git's own diagnostic, which a fail-closed provisioning hook exists to deliver, is lost.

`diagnostics` now gates on the timeout flag exactly as `succeeded` already did, so a timed-out
outcome classifies as nothing and takes the same first-attempt refusal as any other unrecognised
failure. `describeOutcome` already rendered it as `git did not finish within 540s`, so the refusal
line needed no other change.

The new unit test drives outcomes the scripted spawner cannot produce — `fakeShell` maps every
answer onto a child that exits, and a run killed at its timeout is the one case this fix is about —
so it hands them straight to `withConcurrencyRecovery`, whose command is already a parameter. The
spawner is still provided and is an assertion in its own right: a recovery round spawns `git
worktree prune`, so an empty `calls` array proves no round ran. Reverting the one-line gate reds two
of its cases and nothing else.

Three exports were opened for it: `withConcurrencyRecovery`, `describeOutcome` (renamed from the
module-private `describe`, which would shadow vitest's), and `GIT_TIMEOUT_SECONDS`, so the test
binds to the constant rather than restating 540.

## Deviations

- **Out-of-scope change** — **Said:** #7408 names the one-line `diagnostics` gate and a unit test.
  **Did:** also renamed the module-private `describe` to `describeOutcome` at its three call sites.
  **Why:** acceptance criterion 2 asserts the refusal carries that helper's timeout wording, which
  needs it exported, and an exported `describe` shadows vitest's in the test file.
  **Disposition:** stated here; no behaviour changes, the rename is mechanical.
