### PR TITLE
fix: A fourth doc still calls alchemy dev offline: cloudflare-deploy-time-iac.md

### DIFF
--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -246,10 +246,12 @@ class):
 `Cloudflare.state()` vs `Alchemy.localState()` from the **dev-vs-deploy** signal
 alone — **not** `CI`, and (since ADR 0082) **not** `VITEST`. Only `alchemy dev`
 (its `ALCHEMY_EXEC_OPTIONS.dev` flag, or the coarser `ALCHEMY_DEV` override)
-resolves to offline `localState()`. A Vitest integration run resolves to the
-shared Cloudflare store exactly like a real deploy, because it deploys to real
-remote Cloudflare. The Stack's baked state and `Test.make`'s `state` option
-therefore agree on `Cloudflare.state()`.
+resolves to `Alchemy.localState()` — the *state store*, not the loop: the
+worker still binds real Cloudflare D1 and DO namespaces in your personal stage
+(ADR [0032](../.decisions/0032-alchemy-beta45-and-dev-model.md)). A Vitest
+integration run resolves to the shared Cloudflare store exactly like a real
+deploy, because it deploys to real remote Cloudflare. The Stack's baked state
+and `Test.make`'s `state` option therefore agree on `Cloudflare.state()`.
 
 ## The harness contract (`tests/integration/_harness.ts`)
 

--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -247,10 +247,15 @@ class):
 alone — **not** `CI`, and (since ADR 0082) **not** `VITEST`. Only `alchemy dev`
 (its `ALCHEMY_EXEC_OPTIONS.dev` flag, or the coarser `ALCHEMY_DEV` override)
 resolves to `Alchemy.localState()` — the *state store*, not the loop: the
-worker still binds real Cloudflare D1 and DO namespaces in your personal stage
-(ADR [0032](../.decisions/0032-alchemy-beta45-and-dev-model.md)). A Vitest
-integration run resolves to the shared Cloudflare store exactly like a real
-deploy, because it deploys to real remote Cloudflare. The Stack's baked state
+worker still binds a **real** Cloudflare D1 in your personal stage, while its DO
+namespaces run on a local provider (`alchemy@2.0.0-beta.59 —
+src/Cloudflare/Workers/LocalWorkerProvider.ts`, where `case "d1"` returns
+`D1.remote(...)` and `case "durable_object_namespace"` returns
+`DurableObjectNamespace.local(...)`; ADR
+[0032](../.decisions/0032-alchemy-beta45-and-dev-model.md) names D1/R2/KV as the
+real resources). [`alchemy-stack-deploy.md`](alchemy-stack-deploy.md) states the
+same split. A Vitest integration run resolves to the shared Cloudflare store
+exactly like a real deploy, because it deploys to real remote Cloudflare. The Stack's baked state
 and `Test.make`'s `state` option therefore agree on `Cloudflare.state()`.
 
 ## The harness contract (`tests/integration/_harness.ts`)

--- a/.patterns/cloudflare-deploy-time-iac.md
+++ b/.patterns/cloudflare-deploy-time-iac.md
@@ -63,7 +63,7 @@ return domain === undefined ? props : {...props, domain};
 ```
 
 The second clause (`resolveStateMode(...) === "local"`) skips the derivation
-offline too: `alchemy dev` runs the props-Effect in `"plan"` but has no real CF
+in dev too: `alchemy dev` runs the props-Effect in `"plan"` but has no real CF
 zone, so it mirrors the same dev-vs-deploy signal the state-store selector uses
 (see [worker-environment-pattern.md](./worker-environment-pattern.md) for
 `resolveStateMode`).
@@ -149,8 +149,8 @@ gate.
 ## When you're adding a deploy-time resource
 
 - Does it derive a worker **prop** from a deploy-only service (`Stage`, …)? Put
-  the read in the props-Effect behind `ALCHEMY_PHASE === "plan"` (and the offline
-  `resolveStateMode` clause), returning plain props at runtime.
+  the read in the props-Effect behind `ALCHEMY_PHASE === "plan"` (and the
+  `resolveStateMode(...) === "local"` clause), returning plain props at runtime.
 - Does it **provision external/un-revokable state** (a domain, a cert, a
   reputation-bearing subdomain)? Attach it production-only via the
   `ENVIRONMENT === "production"` fail-closed test — never to `it-*`/`pr-*`.


### PR DESCRIPTION
Three lines in `.patterns/` still labelled the `alchemy dev` loop "offline". ADR [0032](.decisions/0032-alchemy-beta45-and-dev-model.md) says the opposite: the worker runs locally in `workerd`, but the D1/R2/KV it binds are real Cloudflare resources in your personal stage, and there is no maintained offline emulator. PR #7439 fixed the three surfaces #7412 named; these two files were outside its criteria.

- `.patterns/cloudflare-deploy-time-iac.md:66` — "skips the derivation offline too" → "skips the derivation in dev too". The claim it modifies (a personal dev stage has no real CF zone, so the `customHostname` derivation is skipped) is untouched.
- `.patterns/cloudflare-deploy-time-iac.md:152` — the checklist bullet's "the offline `resolveStateMode` clause" → "the `resolveStateMode(...) === \"local\"` clause", which names the clause the code actually has instead of describing it with the wrong adjective.
- `.patterns/alchemy-test-harness.md:249` — **reworded**, not annotated. The criterion allowed either. Rewording won because the sentence's subject is `alchemy dev`, so any adjective sitting after "resolves to" reads as describing the loop no matter what caveat follows it; the store/loop distinction now carries the sentence instead of qualifying it. The word "offline" is gone from the line rather than re-stated and denied, so `.patterns/alchemy-stack-deploy.md:104` stays the one place that phrases the denial.

## Round 2 — criterion 7

Round 1's replacement traded the wrong adjective for a wrong binding list: it said `alchemy dev` binds real Cloudflare **D1 and DO namespaces**. Only the D1 half is true. In this repo's pin, `alchemy@2.0.0-beta.59`, `src/Cloudflare/Workers/LocalWorkerProvider.ts` splits them:

```ts
case "d1":
  return D1.remote(b.name, b.databaseId);
case "durable_object_namespace":
  return DurableObjectNamespace.local({ binding: b.name, className: b.className, ... });
```

`kv_namespace` and `r2_bucket` are `.remote` too; the DO arm is the only `.local` one of the four. That matches `.patterns/alchemy-stack-deploy.md:104` ("only the Worker (and DO namespaces, and Queues) has a local dev provider; D1 has none") and ADR 0032, which names D1/R2/KV and never DOs.

The line now **states the split** rather than narrowing to D1 alone, because the DO half is the part a reader is most likely to get wrong and the sentence is where they will be standing when they need it. It cites the provider file and both arms, and links the sibling doc as the fuller treatment. The paragraph's next sentence is rewrapped to fit; its words are unchanged.

`.decisions/0031-local-first-dev-state.md` is unchanged — it is the superseded decision and `.decisions/` is the history surface.

After the change, `git grep -n offline -- .patterns` leaves only unrelated hits: the `unit`/`client` Vitest-project lines in `alchemy-test-harness.md`, `effect-testing.md` and `index.md`, `pnpm install --prefer-offline` in `worktree-agent-constraints.md`, and `alchemy-stack-deploy.md:104`, which denies the claim rather than making it.

Docs-only diff. `build check --surface prose` green with nothing unvalidated.

Fixes #7443

## Deviations

None.
