### PR TITLE
fix: review SKILL.md: the governance ordering rule sits 50 lines below the fence it governs

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -149,6 +149,12 @@ diff itself edits. Take each heading the judgment touches with
 `fabrika wire doc-section --heading "…" < <skill-base>/contract.md`, never the whole file (ADR
 [0296](../../../../.decisions/0296-contracts-are-read-by-section.md)).
 
+<!-- anchor: GOVERNANCE-BEFORE-THE-WAIT --> **Read §1's `governance` token before you run the next
+fence: on `required`, fire §6's governance skill first, then come back here.** The reason is stated
+once at the end of this section and once in §6, both below — this line exists only so a reader
+running fences in order meets the order before the fence rather than after it. On `not-required`
+there is nothing to fire: run the fence.
+
 **No class re-executes what CI enforces** — a local re-run can report another checkout's cached
 green as this PR's. The code class's execution evidence is the structural CI-at-head read, refusing
 incomplete enumerations:


### PR DESCRIPTION
The `review` skill told a reviewer to fire §6's governance verdict before the code class's
`review ci --wait`, but it said so 49 lines below the fence that runs the wait. A reader running
fences as it reaches them hit the fence first and paid the extra `review ci` round the rule exists
to prevent.

This adds one clause above the fence, gated on §1's `governance` token, that sends a
`governance: required` reviewer to §6 first and tells a `not-required` one to run the fence. It is a
pointer, not a move: the mechanism and the ADR 0318 reasoning stay where they already are, at the
end of §3 and in §6. No settle token is touched and `review ci` behaviour is unchanged.

Fixes #7431

## Deviations

None.
