### PR TITLE
fix: verb-reference's review-group exit-code paragraph still omits 17

### DIFF
--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -833,14 +833,15 @@ back. Contract:
 | `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration; `--wait` bounds a `pending` one in-verb and prefixes `settle\t<settled\|budget-exhausted\|head-moved\|governance-owed\|governance-stale>` |
 | `review verdicts` | every verdict marker on the PR — standing and superseded alike — each with its `current` / `stale` / `unbindable` binding |
 | `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan |
-| `review post` | the single sanctioned verdict emit — compose, bind, append into one comment per namespace, read back |
+| `review post` | the single sanctioned verdict emit — compose, bind, append into one comment per namespace, read back; with `--base`/`--tip` the positional is the child issue and the marker binds the range instead of a head |
 | `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
 | `review scratch` | the per-lane directory a reviewer's staged files go under — `<temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>` |
 
 **Exit codes.** The shared table, plus `12` the live head moved past the inspected `--sha` · `13`
 the read completed and its scope is provably incomplete · `14` the invoking token is below `write`,
 or the ACL lookup failed (ADR 0055) · `15` the write is not provably the prior rows plus one — the
-append-only fence. `4` is a deliberate gap.
+append-only fence · `17` a standing verdict of the opposite polarity at this head, or over this
+range, would be retired and `--supersede` was not passed. `4` is a deliberate gap.
 
 - **A check that cannot see what it is looking for does not return a plausible value.** An
   unreadable response, a provably short read and a non-conforming payload each resolve to their own


### PR DESCRIPTION
`packages/fabrika-cli/docs/verb-reference.md`'s `## The review group` **Exit codes** paragraph named
`12` / `13` / `14` / `15` and never `17`, which `review post` has emitted since #7247. The
`governance` group's paragraph in the same file already named it, and both groups get the constant
from one import (`src/governance/codes.ts` imports `SUPERSEDES_VERDICT` from `src/review/codes.ts`),
so the reference gave two answers about one value.

Two edits, both in that file:

- The `review` group's exit-code paragraph now names `17` in the `governance` paragraph's own
  wording — "a standing verdict of the opposite polarity at this head, or over this range, would be
  retired and `--supersede` was not passed". Both triggers are real: `src/review/post-verb.ts:434`
  fires it at a head, `src/review/range-post.ts:231` over a range. `4` stays named as a deliberate
  gap.
- The `review post` table row now describes the range-scoped form as well as the per-head one,
  quoting `post-verb.ts`'s module docblock: with `--base`/`--tip` the positional is the child issue
  and the marker binds the range.

Reviewer: check the `17` clause against the `governance` group's paragraph ~60 lines up in the same
file, and against `src/review/codes.ts`'s docblock for `SUPERSEDES_VERDICT`.

Fixes #7452

## Deviations

None.
