### PR TITLE
docs(roadmap): declare campaign "Tuval first slice" paused against milestone #52

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,6 +113,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Epic lanes | #49 | active |
 | Diátaxis README passes | #50 | active |
 | Tuval | #51 | active |
+| Tuval first slice | #52 | paused |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
## Summary

Appends one `## Campaigns` row to `ROADMAP.md`: `Tuval first slice | #52 | paused`. Written by `fabrika campaign open` past the founder's `campaign-approve: #52 paused` marker at https://github.com/kamp-us/phoenix/issues/7364#issuecomment-5519454725. `fabrika guard roadmap-guard check` is green with the row (I1–I5).

The five graduated epics on #52 (#7496–#7500) are edge-blocked and cannot be planned until this row exists: `fabrika build claim --purpose plan` refused #7496 on the scope axis (#7502). Flipping the row to `active` is a separate founder act per ADR 0304 and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mfMGZRMENidQC75dAqXwi