### PR TITLE
docs(roadmap): flip the old Tuval campaign (#51) to done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ flowchart TD
 		camp_lane_integrity["Lane integrity"]:::active
 		camp_epic_lanes["Epic lanes"]:::active
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
-		camp_tuval["Tuval"]:::active
+		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
 	end
 	ext_3642["#3642"]:::external
@@ -113,7 +113,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Lane integrity | #48 | active |
 | Epic lanes | #49 | active |
 | Diátaxis README passes | #50 | active |
-| Tuval | #51 | active |
+| Tuval | #51 | done |
 | Tuval first slice | #52 | active |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:


### PR DESCRIPTION
Flips \`| Tuval | #51 |\` to \`done\` and restyles \`camp_tuval\` \`:::done\` in the dependency graph. Milestone #51 is closed and its POC backlog closed; the replacement campaign (#52, active) landed in #7505.

Cites the founder's marker: https://github.com/kamp-us/phoenix/issues/7364#issuecomment-5519598152

Written with \`fabrika campaign state '#51' --to done\`. Trivial roadmap row, no reviewer pass per the founder's ruling this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mfMGZRMENidQC75dAqXwi