### PR TITLE
docs(roadmap): declare campaign "phoenix i18n" against milestone #53 and flip it active (#7519)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,6 +115,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Diátaxis README passes | #50 | active |
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
+| phoenix i18n | #53 | paused |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,7 @@ flowchart TD
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
+		camp_phoenix_i18n["phoenix i18n"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,7 +115,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Diátaxis README passes | #50 | active |
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
-| phoenix i18n | #53 | paused |
+| phoenix i18n | #53 | active |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Part of #7519

Three commits, one PR, same shape as #7505: append the `phoenix i18n | #53` row to `ROADMAP.md` (written `paused` by `fabrika campaign open` past the founder's marker at https://github.com/kamp-us/phoenix/issues/7519#issuecomment-5520110716), flip it to `active` (written by `fabrika campaign state` past https://github.com/kamp-us/phoenix/issues/7519#issuecomment-5520113669), then add the node to the hand-maintained diagram. Two acts per ADR 0304, two cited comments.

Founder ruling on the epic: apps/web user copy becomes Turkish and English behind an i18n pipeline; milestones no longer need Turkish names. The epic and its 10 children are homed on milestone #53.

`fabrika guard roadmap-guard check` is green at head (I1–I5).

Founder said he reviews and merges this directly; no reviewer or shipper spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)