### PR TITLE
reports: i18n options for apps/web (#7527)

### DIFF
--- a/reports/2026-09-02-i18n-options.md
+++ b/reports/2026-09-02-i18n-options.md
@@ -1,0 +1,146 @@
+# i18n options for apps/web — research spike before #7527
+
+**Date:** 2026-09-02 · **Epic:** [#7519](https://github.com/kamp-us/phoenix/issues/7519) · **Child:**
+[#7527](https://github.com/kamp-us/phoenix/issues/7527)
+
+Question: Turkish-default, English-opt-in user copy in `apps/web` (React 19 + Vite 8 SPA on a
+Cloudflare Worker, Biome, pnpm catalog deps). Which pipeline? The plan on #7519 picks a hand-rolled
+typed catalog under `apps/web/src/i18n`. This report checks that pick against five libraries.
+
+Point-in-time: versions and dates are what npm and GitHub reported on 2026-09-02.
+
+## What the codebase gives us
+
+- Copy today: ~900 lines of inline Turkish JSX across `apps/web/src`, plus `fate/wireMessages.ts`
+  (`Record<FateWireCode, string>`, exhaustive by construction) and `pages/usernameMessages.ts`.
+- A persistence idiom already exists: `lib/themeStorage.ts` / `lib/densityStorage.ts` store a
+  validated choice under `kampus.theme` / `kampus.density` with a try/catch around `localStorage`.
+  A `kampus.locale` key follows it one-for-one.
+- `index.html` is `lang="tr"`. Routing is `react-router` `<Route path="/pano/...">` etc. in
+  `apps/web/src/App.tsx`, no locale prefix anywhere.
+- `tsconfig.json` sets `erasableSyntaxOnly` and `verbatimModuleSyntax`; Biome 2.4.15 runs custom
+  GritQL plugins (`no-type-assertions` among them). A generated dir would need a `biome.json`
+  `files.includes` exclusion like `!**/__generated__` already has.
+- Plural needs are small. `Intl.PluralRules` on the Node in use (26.2, ICU 78.3) reports
+  cardinal categories `["one","other"]` for both `tr` and `en`; ordinal `["other"]` for `tr`.
+  Turkish has no gendered or case-driven plural forms, so a two-arm `one/other` helper covers it.
+- No i18n dep exists in `pnpm-workspace.yaml`'s catalog; anything added goes through `catalog:`.
+
+## The candidates
+
+| | Hand-rolled catalog (plan) | Paraglide JS (inlang) | Lingui | i18next + react-i18next | react-intl (FormatJS) | typesafe-i18n |
+|---|---|---|---|---|---|---|
+| Latest release (npm) | n/a | 2.25.0, 2026-08-27 | core/react 6.6.0, 2026-07-24; swc-plugin 6.7.0, 2026-08-27 | 26.4.1 / 17.0.13, 2026-09-01 | 10.1.25, 2026-08-30 | 5.27.1, 2026-02-11 |
+| Repo health (GitHub) | n/a | `opral/inlang`: 7 open issues, pushed 2026-08-31 | `lingui/js-lingui`: 69 open, pushed 2026-09-02 | `i18next/*`: 2 + 1 open, pushed 2026-09-02 | `formatjs/formatjs`: 4 open, pushed 2026-09-03 | `codingcommons/typesafe-i18n` (fork home): 41 open, pushed 2026-03-22; original author died 2023 |
+| Typed keys | `Record<Key, string>` per locale; missing key = type error, no codegen | Compiled functions per message; `emitTsDeclarations: true` (TS 5.6+) | Opt-in `Register.messageIds` augmentation pointing at a catalog JSON; no codegen | `CustomTypeOptions.resources` augmentation; needs `strict`; big resources can slow tsc / OOM | Global namespace override `ids: keyof typeof messages` | Generator emits `.d.ts` from base locale |
+| Runtime cost (bundlephobia, min+gz) | ~0 (a lookup + interpolation helper) | Near zero; docs claim 47 KB vs 205 KB for i18next at 5 locales × 200 msgs | core 2.0 KB + react 1.7 KB | i18next 13.7 KB + react-i18next 10.2 KB | 14.7 KB (parser removable with precompiled AST, "~40% less") | ~1 KB core + 1.6 KB react adapter |
+| Per-locale lazy load in Vite | `import("./en")` = one chunk; tr stays in main | Default `message-modules` output tree-shakes per message; per-locale splitting is `experimentalMiddlewareLocaleSplitting` (SSR, "not production-ready") | Documented: `await import(\`./locales/${locale}/messages\`)` yields one chunk per locale | Standard: dynamic import + `addResourceBundle` | Standard: dynamic import of a messages JSON | Documented per-locale loaders |
+| Vite integration | none needed | `paraglideVitePlugin` in `vite.config.ts`, writes `outdir` | `@lingui/vite-plugin` plus a Babel (`@lingui/babel-plugin-lingui-macro`) or SWC (`@lingui/swc-plugin`) transform for macros | none needed | none needed (Babel plugin optional for extraction) | generator watcher |
+| Message format / ICU | plain strings + `{name}` interpolation | inlang JSON with `declarations`/`selectors`/`match`; ICU MF1 via plugin | ICU MessageFormat | i18next own syntax; plurals via `_one/_other` suffixes on `Intl.PluralRules` | ICU MessageFormat | own `{{count}}` plural syntax |
+| Turkish plurals | `one/other` helper on `Intl.PluralRules` | `local x = count: plural` selector, `Intl.PluralRules` under the hood | ICU `plural` | `_one` / `_other` | ICU `plural` | supported |
+| Extraction tooling | none; the epic's fail-closed guard (#7536) is the enforcement | Sherlock (VS Code), Fink editor, CLI machine translation | `lingui extract` CLI, ESLint plugin | `i18next-parser` (third party) | `@formatjs/cli extract` | generator |
+| Biome fit | clean; plain TS | must exclude `outdir` from `biome.json`; project file `project.inlang/` | macros are ordinary imports, so Biome lints them fine; the ESLint plugin's rules have no Biome twin | clean | clean | generated files need exclusion |
+| Brand nouns untranslated | unit test over both catalogs (planned) | same nouns typed into both locale JSONs; no built-in invariant | same | same | same | same |
+
+Sources: [paraglidejs.com](https://paraglidejs.com/), [strategy](https://paraglidejs.com/strategy),
+[variants](https://paraglidejs.com/variants), [compiler options](https://paraglidejs.com/compiler-options),
+[react-router guide](https://paraglidejs.com/react-router); [lingui.dev/introduction](https://lingui.dev/introduction),
+[typed message ids](https://lingui.dev/guides/typed-message-ids),
+[dynamic loading](https://lingui.dev/guides/dynamic-loading-catalogs),
+[Vite setup](https://lingui.dev/tutorials/setup-vite); [i18next TypeScript](https://www.i18next.com/overview/typescript);
+[react-intl](https://formatjs.github.io/docs/react-intl/),
+[FormatJS advanced usage](https://formatjs.github.io/docs/guides/advanced-usage);
+[typesafe-i18n](https://github.com/ivanhofer/typesafe-i18n); sizes from
+`bundlephobia.com/api/size?package=<name>`; release dates from `pnpm view <pkg> time`; repo
+counts from `gh api repos/<owner>/<repo>`.
+
+## Reading the table
+
+- **i18next and react-intl** are the heaviest and solve problems we do not have: runtime message
+  parsers, namespaces, backends, ICU `select`/`selectordinal`. Their typing is augmentation over a
+  resources object, which is the same thing the hand-rolled `Record` gives for free. ~25 KB gz
+  (i18next pair) or ~15 KB gz (react-intl) for a two-locale app with `one/other` plurals is pure
+  overhead.
+- **typesafe-i18n** is the closest in spirit (tiny, generated types) but the original author died in
+  2023, the package now lives in a fork org, and the last release is seven months old. Not a
+  dependency to add in 2026.
+- **Lingui** is well maintained and small at runtime, but its ergonomics come from macros, which
+  means a Babel or SWC transform in the Vite React plugin, a `.po`/JSON catalog cycle
+  (`extract` → translate → `compile`), and an ESLint plugin we cannot run under Biome. Typed IDs are
+  opt-in and only meaningful with explicit IDs, which is exactly the hand-rolled shape anyway.
+- **Paraglide** is the one real alternative. Compile-time, tree-shakable message functions, typed
+  keys via emitted declarations, strategies that include `localStorage` and `url`, and a router
+  guide. Costs: an `project.inlang/` settings dir, a generated `outdir` we must exclude from Biome
+  and keep out of the diff, message JSON with its own variant syntax instead of TS, and a Vite
+  plugin on the build path next to `fate()`. Per-locale splitting is experimental; the default
+  ships every locale's function bodies unless `experimentalStaticLocale` is set, which fits two
+  locales but is not the "tr stays byte-identical" story the plan promises.
+- **Hand-rolled** needs two things nobody writes for us: a `{name}` interpolation helper and a
+  `one/other` plural helper on `Intl.PluralRules`. Both are under 30 lines and unit-testable
+  DOM-free. Type parity is `const en = {...} satisfies Record<keyof typeof tr, string>` (a
+  `satisfies` clause is erasable syntax, so it passes `erasableSyntaxOnly`). The English catalog can
+  be a lazy `import("./en")` chunk, so the Turkish path ships zero extra bytes. What it lacks is
+  extraction tooling; the epic already answers that with a fail-closed guard (#7536) instead of an
+  extractor.
+
+## Recommendation
+
+**Keep the plan: hand-rolled typed catalog, no runtime dependency.** Confidence 80%.
+
+Why: two locales, `one/other` plurals only, ~1000 strings, and a repo that already treats an
+exhaustive `Record` as the type-safety mechanism (`wireMessages.ts`). Every library in the table
+either brings a parser we do not need or a codegen/plugin surface that fights Biome and the
+`catalog:` rule for no gain at this size. The plan's rabbit-hole note ("a typed message catalog
+beats a runtime framework at this size") holds up against the sources.
+
+Tradeoffs:
+
+- If a third locale or ICU `select`/gender ever lands, the helper grows; that is the point to
+  migrate to Paraglide, whose message-function shape (`m.key({params})`) is the same call shape as
+  `t("key", params)`, so the migration is mechanical. Confidence that Paraglide is the fallback
+  rather than Lingui: 70%.
+- No extractor means a builder can forget to add an `en` string only if they also skip the type
+  check; the `satisfies` parity rule makes that a `pnpm typecheck` failure, so the practical hole is
+  a string that is never keyed at all, which is #7536's guard.
+
+## Locale: URL segment, user setting, or both?
+
+**User setting only, for now.** Confidence 85%.
+
+- SEO is a non-goal today, and the only thing a URL segment buys is crawlable per-locale pages.
+- A `/en/...` prefix touches every `<Route>` in `App.tsx`, every `<Link>`, `returnTo.ts`, the
+  shared-link identity of a post (`/pano/:id` should mean the same thing regardless of who reads
+  it), and the worker's asset routing. That is a cross-cutting change for a benefit nobody asked
+  for.
+- `localStorage` under `kampus.locale` mirrors `kampus.theme` exactly, is what Paraglide's own
+  `strategy: ["localStorage", ..., "baseLocale"]` chain does for SPAs, and moves to an account
+  preference later without touching URLs.
+- If SEO ever becomes a goal, add the URL segment then as its own epic; the catalog does not care
+  where the locale comes from, so nothing built now is thrown away.
+
+## What changes in #7527's acceptance criteria
+
+Keep all six as written. Add or tighten:
+
+1. **Parity mechanism is named.** "A key present in `tr` but absent in `en` (or the reverse) fails
+   `pnpm typecheck`" becomes: `tr` is the source of truth for the key set; `en` is checked with
+   `satisfies Record<keyof typeof tr, string>` (no type assertion, per the Biome plugin). The
+   reverse direction (a key only in `en`) is also a type error because `satisfies` rejects excess
+   properties on an object literal.
+2. **Turkish path ships no English bytes.** The `en` catalog is loaded via dynamic `import()`; a
+   test or the existing `bundle:assert` style check proves the main chunk contains no `en` catalog
+   string. This is what makes "the `tr` path is byte-identical to today" true at the bundle level,
+   not only in rendered output.
+3. **Plural helper is grounded.** `t` supports `{count, plural, one {...} other {...}}`-equivalent
+   via an explicit `plural(locale, n, {one, other})` helper backed by `Intl.PluralRules`, with a
+   unit test asserting `tr` and `en` both resolve to `one`/`other`. No ICU parser.
+4. **Storage key and shape.** `kampus.locale`, validated against `"tr" | "en"`, read/written
+   through a `localeStorage.ts` module with the same try/catch shape as `themeStorage.ts`.
+5. **Brand-noun source.** The invariant test reads the noun list from one exported constant
+   (`i18n/brandNouns.ts`) that a later doc step can cross-check against `.glossary/LANGUAGE.md` §3,
+   rather than parsing the markdown table at test time.
+6. **Explicit non-goal in the child body.** No third-party i18n dep, no URL locale segment; this
+   report is the citation.
+
+The ADR from #7526 should record the library decision with this report as its evidence and name
+Paraglide as the migration target if the two-locale, `one/other` assumption ever breaks.


### PR DESCRIPTION
Part of #7519

Dated research report behind epic #7519's foundation child #7527: compares the plan's hand-rolled typed catalog against Paraglide, Lingui, i18next, react-intl and typesafe-i18n for a React 19 + Vite SPA on Workers with Turkish default and English opt-in. Recommendation: keep the typed catalog, no runtime dep; locale as a user setting, not a URL segment. Pointer comment on #7527.

Founder reviews and merges directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)