### PR TITLE
feat: review-ui render captures at one viewport, so no responsive state is judgeable

### DIFF
--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -91,8 +91,18 @@ builder's attached captures are externally-authored content you deliberately do 
 you render independently or you have not looked.
 
 ```bash
-fabrika review-ui render --pr $pr_number --out judged --surface /pano --surface /pano/yeni
+fabrika review-ui render --pr $pr_number --out judged --surface /pano --surface /pano/yeni --viewport desktop --viewport mobile
 ```
+
+**Ask for the narrow shot when the composition's risk is width.** `--viewport mobile` shoots the
+same surfaces at 390×844 beside (or instead of) the 1280×800 default, and the two cross: two surfaces
+and two viewports is one set of four captures, each manifest entry labelled with the width it is of.
+Omitting the operand renders at desktop alone. Reach for `mobile` whenever an acceptance criterion is
+phrased about a phone, or the change adds a long string, a nowrap run, a fixed width, or anything to
+a persistent chrome like the topbar — before this operand existed, every such criterion ended the
+gate as disclosed-UNKNOWN, and PR #7388 took a FAIL its own branch could not repair (#7706). The
+width a shot records is read back off its own PNG bytes, so a capture under a viewport label is a
+proven render at that width and a mismatch is `19`, never a desktop layout judged as a phone's.
 
 **A surface behind login is named, not skipped, and the name carries the tier.** A surface id may
 carry a realized state, and there are two: `--surface /pano:auth` renders the route as the

--- a/claude-plugins/fabrika/skills/review-ui/contract.md
+++ b/claude-plugins/fabrika/skills/review-ui/contract.md
@@ -242,7 +242,7 @@ anchor at all is the proven `16`.
 **Invocation**
 
 ```
-fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/yeni [--flag <key>=<on|off>] [--app web] [--repo <owner/name>]
+fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/yeni [--viewport desktop --viewport mobile] [--flag <key>=<on|off>] [--app web] [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -252,6 +252,7 @@ fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/
 | `--pr` | integer | yes | — | the pull request whose preview is judged |
 | `--out` | string | yes | — | kebab-case capture-set name; captures land under `<OS temp>/fabrika-review-ui/<pr>-<head8>/<set>/` |
 | `--surface` | string, repeatable | yes (≥1) | — | a surface id: a route (`/pano`), or a route plus a realized tier state (`/pano:auth`, `/pano:auth-caylak`); zero operands is `1` — no tool guesses surfaces from a diff |
+| `--viewport` | string, repeatable | no | `desktop` alone | a viewport to shoot every `--surface` at, over the closed set `desktop` (1280×800) and `mobile` (390×844); crossed with `--surface`, so two of each is four captures. A name outside the set, or one passed twice, is `10` |
 | `--flag` | string, repeatable | no | every flag at its default | force one flag for this run: `<key>=on` or `<key>=off`; anything else, or a key forced twice, is `10` |
 | `--app` | string | no | the sole app in the preview comment; ambiguity refuses on `11` | which app's sub-line of the preview comment to resolve |
 | `--repo` | string | no | resolved | the repository |
@@ -276,6 +277,28 @@ non-200, an unreadable body, a user with no tier, a user at another tier — ref
 `11` and records no capture under that surface id. A cookie that did not authenticate renders the
 visitor's page and one that authenticated as the wrong identity renders somebody else's, and both are
 perfectly valid PNGs no byte check can tell from the real one.
+
+**`--viewport` is the width axis, and it is closed for the same reason `:state` is.** The narrow half
+of the design law — a sub-36px tap target, a nowrap string that overflows, spacing that goes off-grid
+— is only answerable from narrow pixels, and before this operand existed every shot was 1280 wide, so
+an acceptance criterion phrased about a phone ended the gate as disclosed-UNKNOWN rather than PASS or
+FAIL (#7706, and PR #7388 took a FAIL that no change to its branch could repair). Omitting it renders
+at `desktop` alone, exactly as every invocation written before it did. The two realized names resolve
+to the constants in `capture/plan.ts`; a third name would have to fall back to some width, and a shot
+at the fallback width filed under the asked-for label is coverage claimed and not held. Repeating one
+name is `10` too — the second shot would overwrite the first's file and its evidence.
+
+Viewports **cross** the surfaces rather than pairing with them: two surfaces and two viewports is one
+set of four captures. Nothing collides, because the PNG file name has always carried the viewport
+label (`pano@desktop.png`, `pano@mobile.png`) and each manifest entry now records it beside the
+surface id — so a set can say what width each of its shots is of, and the evidence gallery heads each
+one `<surface> @ <viewport>`.
+
+Asking for a width is not the same as rendering at it, so — like the session and the override — the
+shot proves its own. The recorded width is read back from the captured PNG's own header, never echoed
+from the request, and a shot whose width is not the requested viewport's is refused on `19` and
+recorded nowhere. A desktop-width capture filed under `mobile` is a perfectly valid PNG of a layout
+nobody asked about, and no byte check downstream can tell it from the real thing.
 
 **`--flag` forces a dark-shipped flag on, so the state the PR adds paints** (ADR 0336, #7218). It
 rides the worker's existing `phoenix_flag_overrides` cookie — no route is added and
@@ -309,8 +332,8 @@ still refuses every `:state`.
 {"set": "judged", "pr": 4321, "head": "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c",
  "previewUrl": "https://phoenix-pr-4321.kampus.workers.dev",
  "captures": [
-   {"surface": "/pano", "path": "<abs>/judged/pano.png", "width": 1280, "height": 2140,
-    "sha256": "…", "pageErrors": {"rows": [], "more": 0}}
+   {"surface": "/pano", "viewport": "desktop", "path": "<abs>/judged/pano@desktop.png",
+    "width": 1280, "height": 2140, "sha256": "…", "pageErrors": {"rows": [], "more": 0}}
  ]}
 ```
 
@@ -318,11 +341,13 @@ still refuses every `:state`.
 `11`). Resolve the preview comment for `--app` (paginated sweep; anchor absent → `16`, anchor
 present but unparseable → `11`). **Bind the preview to the head**: the comment's deployed SHA
 must equal the live head — a preview that lags the push is `12`, because pixels of an old tree
-bound to a new SHA are the stale-verdict class at the capture seam. For each `--surface`, in the
-provisioned headless browser at the machinery's default viewport: navigate to
+bound to a new SHA are the stale-verdict class at the capture seam. For each `--surface` at each
+`--viewport`, in the provisioned headless browser sized to that viewport: navigate to
 `<previewUrl><route>`; status ≥ 400 or failed navigation is **unreachable** (`14`); an uncaught
-page exception is **crashed** (`13`); otherwise screenshot full-page to `<set>/<route-slug>.png`
-and validate (exists, non-zero bytes, decodable, non-zero area — `15` on any failure).
+page exception is **crashed** (`13`); otherwise screenshot full-page to
+`<set>/<route-slug>@<viewport>.png` and validate (exists, non-zero bytes, decodable, non-zero area —
+`15` on any failure), then **read the width back off those bytes** and refuse a shot that is not the
+requested viewport's width (`19`).
 `console.error` output is **recorded per capture in `pageErrors`, never a gate outcome** — the
 crash/advisory split is the machinery's page-error module, and an empty list is only ever
 written from a successfully-read error channel (v1's extractor returned empty on a parse failure,
@@ -333,7 +358,7 @@ per-surface line counts the **whole** tally, not the kept rows. **Write the set 
 byte-identical to the stdout JSON — `post` reads the set through it, and a set without its
 manifest is not a set.
 
-Exit 0 requires **every** requested surface captured and valid. `12` and `16` are run-level
+Exit 0 requires **every** requested surface captured and valid at **every** requested viewport. `12` and `16` are run-level
 refusals decided before the per-surface loop and never mix with its outcomes. When per-surface
 outcomes mix, the reported code is the smallest applicable of `13`/`14`/`15` and stderr carries
 every surface's outcome — the code routes, the stderr enumerates. Dropping a surface is the skill's explicit
@@ -344,13 +369,14 @@ re-invocation without it, on the record; never the tool's tolerance.
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed |
-| `10` | `--out` not kebab-case; a `--surface` names a `:state` outside the realized set (`auth`, `auth-caylak`); a `--flag` operand is not a `<key>=<on\|off>` pair, or forces one key twice; or `--flag` was passed beside an anonymous surface |
+| `10` | `--out` not kebab-case; a `--surface` names a `:state` outside the realized set (`auth`, `auth-caylak`); a `--viewport` names a viewport outside the closed set (`desktop`, `mobile`) or is passed twice; a `--flag` operand is not a `<key>=<on\|off>` pair, or forces one key twice; or `--flag` was passed beside an anonymous surface |
 | `11` | the PR/head/comment read failed; the preview comment is present but malformed for `--app`, or `--app` is omitted while the comment names several apps; the browser provision is broken; a capture's validity could not be determined; a tier-naming surface was requested while that tier's session token or `BETTER_AUTH_SECRET` is unset; a tier-naming surface's session proof did not come back signed in, or came back at a tier the surface did not name; or a forced flag evaluated at its default anyway |
 | `12` | proven: the preview comment's deployed SHA is not the PR's live head — stale preview; re-render after the preview catches up |
 | `13` | proven: at least one surface threw an uncaught page error |
 | `14` | proven: at least one surface is unreachable (status ≥ 400, failed navigation, no route, dark flag, gated tier) |
 | `15` | proven: at least one capture is invalid (zero bytes, undecodable, zero area) |
 | `16` | proven: no comment carrying the preview anchor exists on the PR — this repo, or this PR, has no preview to judge |
+| `19` | proven: a capture's PNG width, read back from its own bytes, is not the requested viewport's width — the requested viewport's render is UNKNOWN, and nothing was recorded under that label |
 
 **Errors**
 
@@ -360,22 +386,25 @@ re-invocation without it, on the record; never the tool's tolerance.
 | `review-ui render: PR #<n> is closed — nothing to judge.` | 7 | refusal |
 | `review-ui render: --surface "<id>" names a :state nothing renders — the realized states are auth, auth-caylak; render the bare route.` | 10 | refusal |
 | `review-ui render: a tier-naming surface was requested but its credentials are incomplete (unset: <names>) — the named tier's render is UNKNOWN, never a seeded substitute.` | 11 | refusal |
-| `review-ui render: surface "<id>" did not render signed in (<reason>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
-| `review-ui render: surface "<id>" named tier <wanted> and rendered as <rendered> — the named tier's render is UNKNOWN, never another tier's.` | 11 | refusal |
+| `review-ui render: surface "<id>" at <viewport> did not render signed in (<reason>) — the authenticated render is UNKNOWN, never the anonymous one.` | 11 | refusal |
+| `review-ui render: surface "<id>" at <viewport> named tier <wanted> and rendered as <rendered> — the named tier's render is UNKNOWN, never another tier's.` | 11 | refusal |
 | `review-ui render: --flag "<token>" is not a <key>=<on\|off> pair (<reason>) — an operand nothing can force would shoot the default state under the forced name.` | 10 | refusal |
 | `review-ui render: --flag was passed with the anonymous surface "<id>" — the preview honors an override only for an authorized platform-admin actor, so an anonymous surface would render the default state silently; name a tier state (auth, auth-caylak) on every surface.` | 10 | refusal |
-| `review-ui render: surface "<id>" did not render with its forced flags (<reason>) — the forced render is UNKNOWN, never the default one.` | 11 | refusal |
+| `review-ui render: surface "<id>" at <viewport> did not render with its forced flags (<reason>) — the forced render is UNKNOWN, never the default one.` | 11 | refusal |
+| `review-ui render: --viewport "<name>" is not a viewport this repo renders — the names are desktop, mobile.` | 10 | refusal |
+| `review-ui render: --viewport "<name>" was passed twice — the second shot would overwrite the first's file and evidence.` | 10 | refusal |
+| `review-ui render: surface "<id>" at <viewport> was asked for at <wanted>px and its bytes read back <actual>px wide — the requested viewport's render is UNKNOWN, never another width's.` | 19 | refusal |
 | `review-ui render: --out "<value>" is not a kebab-case set name.` | 10 | refusal |
 | `review-ui render: cannot read <what> for #<n>: <reason> — the render is UNKNOWN.` | 11 | refusal |
 | `review-ui render: the preview comment names apps <list> — pass --app to pick one.` | 11 | refusal |
 | `review-ui render: the preview comment carries the anchor but no parseable URL + SHA for app "<app>" — a malformed announcement is unreadable, not absent.` | 11 | refusal |
 | `review-ui render: the preview deploys <deployed-sha7>, the live head is <head7> — stale preview; pixels of an old tree must not bind a new head (#4808's class).` | 12 | refusal |
-| `review-ui render: surface "<id>" threw during render: <first page error> — the render is red; a broken page is not composition to judge.` | 13 | refusal |
-| `review-ui render: surface "<id>" is unreachable at the preview (<reason>) — judge what renders, and hold the gap against the PR's Deviations (#4305).` | 14 | refusal |
-| `review-ui render: surface "<id>" captured invalid bytes (<detail>) — a capture nobody can open is not evidence (#3925's class).` | 15 | refusal |
+| `review-ui render: surface "<id>" at <viewport> threw during render: <first page error> — the render is red; a broken page is not composition to judge.` | 13 | refusal |
+| `review-ui render: surface "<id>" at <viewport> is unreachable at the preview (<reason>) — judge what renders, and hold the gap against the PR's Deviations (#4305).` | 14 | refusal |
+| `review-ui render: surface "<id>" at <viewport> captured invalid bytes (<detail>) — a capture nobody can open is not evidence (#3925's class).` | 15 | refusal |
 | `review-ui render: no preview-deploy comment on PR #<n> — nothing to judge without running the PR's code; the run is CANT-SEE.` | 16 | refusal |
 
-**Scope** — exactly the `--surface` operands against one PR's announced preview. Zero operands
+**Scope** — exactly the `--surface` × `--viewport` cross product against one PR's announced preview. Zero operands
 is `1`, so "rendered nothing, found nothing wrong" is unrepresentable (ADR 0092). The
 per-surface outcome enumeration goes to stderr on every path, success included.
 
@@ -383,21 +412,28 @@ per-surface outcome enumeration goes to stderr on every path, success included.
 
 ```
 $ fabrika review-ui render --pr 4321 --out judged --surface /pano
-{"set":"judged","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/pano","path":"/tmp/fabrika-review-ui/4321-03135b91/judged/pano.png","width":1280,"height":2140,"sha256":"9c41…","pageErrors":{"rows":[],"more":0}}]}
+{"set":"judged","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/pano","viewport":"desktop","path":"/tmp/fabrika-review-ui/4321-03135b91/judged/pano@desktop.png","width":1280,"height":2140,"sha256":"9c41…","pageErrors":{"rows":[],"more":0}}]}
 ```
 
 ```
 $ fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /yonetim
-review-ui render: surface "/pano" captured: 1280x2140, 0 page errors
-review-ui render: surface "/yonetim" is unreachable at the preview (status 404) — judge what renders, and hold the gap against the PR's Deviations (#4305).
+review-ui render: surface "/pano" at desktop captured: 1280x2140, 0 page errors
+review-ui render: surface "/yonetim" at desktop is unreachable at the preview (status 404) — judge what renders, and hold the gap against the PR's Deviations (#4305).
 $ echo $?
 14
 ```
 
 ```
+$ fabrika review-ui render --pr 4321 --out narrow --surface /pano --viewport desktop --viewport mobile
+review-ui render: surface "/pano" at desktop captured: 1280x2140, 0 page errors
+review-ui render: surface "/pano" at mobile captured: 390x3180, 0 page errors
+{"set":"narrow","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/pano","viewport":"desktop","path":"/tmp/fabrika-review-ui/4321-03135b91/narrow/pano@desktop.png","width":1280,"height":2140,"sha256":"9c41…","pageErrors":{"rows":[],"more":0}},{"surface":"/pano","viewport":"mobile","path":"/tmp/fabrika-review-ui/4321-03135b91/narrow/pano@mobile.png","width":390,"height":3180,"sha256":"1f7b…","pageErrors":{"rows":[],"more":0}}]}
+```
+
+```
 $ fabrika review-ui render --pr 4321 --out forced --surface /hosgeldin:auth --flag phoenix-welcome=on
-review-ui render: surface "/hosgeldin:auth" captured: 1280x1640, 0 page errors
-{"set":"forced","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/hosgeldin:auth","path":"/tmp/fabrika-review-ui/4321-03135b91/forced/hosgeldin-auth.png","width":1280,"height":1640,"sha256":"1f7b…","pageErrors":{"rows":[],"more":0}}]}
+review-ui render: surface "/hosgeldin:auth" at desktop captured: 1280x1640, 0 page errors
+{"set":"forced","pr":4321,"head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","previewUrl":"https://phoenix-pr-4321.kampus.workers.dev","captures":[{"surface":"/hosgeldin:auth","viewport":"desktop","path":"/tmp/fabrika-review-ui/4321-03135b91/forced/hosgeldin-auth@desktop.png","width":1280,"height":1640,"sha256":"1f7b…","pageErrors":{"rows":[],"more":0}}]}
 ```
 
 ```

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -868,7 +868,7 @@ Judge a UI pull request over its preview deployment. Contract:
 
 | Verb | Answers |
 |---|---|
-| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized tier state (`/pano:auth` renders as the yazar test account, `/pano:auth-caylak` as the çaylak one), refusing on `11` unless the preview's own session read proves the shot came back signed in *and* at the tier the surface named. `--flag <key>=<on\|off>` forces a dark-shipped flag for the run, refusing on `10` unless every surface names a tier state and on `11` unless the preview's own evaluation says the key took |
+| `review-ui render` | the named surfaces captured from a PR's preview deployment — a route, or a route plus a realized tier state (`/pano:auth` renders as the yazar test account, `/pano:auth-caylak` as the çaylak one), refusing on `11` unless the preview's own session read proves the shot came back signed in *and* at the tier the surface named. `--flag <key>=<on\|off>` forces a dark-shipped flag for the run, refusing on `10` unless every surface names a tier state and on `11` unless the preview's own evaluation says the key took. `--viewport <name>` picks the widths, over the closed set `desktop` (1280×800) and `mobile` (390×844), crossed with `--surface` and defaulting to `desktop` alone; a name outside the set or repeated is `10`, and a shot whose PNG width reads back as another width is `19` |
 | `review-ui post` | the `review-ui` verdict on stdin, appended into this namespace's one comment |
 | `review-ui note` | a typed blocker note when the surfaces cannot be seen |
 | `review-ui route` | a head-bound `routed-elsewhere` record: this PR renders nothing, so no verdict is owed |

--- a/packages/fabrika-cli/src/capture/plan.ts
+++ b/packages/fabrika-cli/src/capture/plan.ts
@@ -5,9 +5,10 @@
  * unit-tested selection logic the review-design gate (ADR 0165) reasons about;
  * `capture.ts` drives Playwright over the plan this produces.
  *
- * One record per surface (the contract #2246 codes against), NOT a viewport
- * cross-product: a surface is a route + an optional state variant, captured at a
- * single viewport.
+ * One record per surface per viewport: a surface is a route + an optional state
+ * variant, and a plan shoots that set at one viewport. A caller wanting several
+ * viewports builds a plan per viewport and concatenates them — the file name
+ * carries the viewport label, so the shots never collide (#7706).
  *
  * The grammar here parses ANY state token; which ones a capture can actually put
  * on screen is `states.ts`'s closed list (`auth` today), and `review-ui render`
@@ -59,6 +60,31 @@ export interface Viewport {
 export const DESKTOP_VIEWPORT: Viewport = {label: "desktop", width: 1280, height: 800};
 export const MOBILE_VIEWPORT: Viewport = {label: "mobile", width: 390, height: 844};
 export const DEFAULT_VIEWPORT: Viewport = DESKTOP_VIEWPORT;
+
+/**
+ * The closed set a `--viewport` operand names, keyed by the label a file name and
+ * a manifest entry carry. Closed for the reason `states.ts` is closed: a name
+ * nothing resolves would have to fall back to some width, and a shot at the
+ * fallback width recorded under the asked-for name is coverage claimed and not
+ * held. `review-ui render` refuses a name outside it on `10` (#7706).
+ *
+ * Both realized widths fall inside the repo's one narrow breakpoint
+ * (`@media (max-width: 640px)`), so a third row buys no new CSS branch today.
+ */
+export const VIEWPORTS = {
+	desktop: DESKTOP_VIEWPORT,
+	mobile: MOBILE_VIEWPORT,
+} as const satisfies Readonly<Record<string, Viewport>>;
+
+export type ViewportName = keyof typeof VIEWPORTS;
+export const VIEWPORT_NAMES = Object.keys(VIEWPORTS) as ReadonlyArray<ViewportName>;
+
+export const isViewportName = (name: string): name is ViewportName =>
+	Object.hasOwn(VIEWPORTS, name);
+
+/** The viewport a name resolves to, or `null` when the name is outside the set. */
+export const viewportOf = (name: string): Viewport | null =>
+	isViewportName(name) ? VIEWPORTS[name] : null;
 
 /** A crop rectangle in CSS pixels — the changed region the capture is narrowed to. */
 export interface CaptureClip {

--- a/packages/fabrika-cli/src/capture/plan.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/plan.unit.test.ts
@@ -8,11 +8,14 @@ import {
 	buildCapturePlan,
 	DEFAULT_VIEWPORT,
 	DESKTOP_VIEWPORT,
+	isViewportName,
 	joinPreviewUrl,
 	MOBILE_VIEWPORT,
 	parseSurfaceSpec,
 	type Surface,
 	surfaceFileName,
+	VIEWPORT_NAMES,
+	viewportOf,
 } from "./plan.ts";
 
 describe("parseSurfaceSpec", () => {
@@ -125,7 +128,7 @@ describe("buildCapturePlan", () => {
 		assert.deepStrictEqual(DEFAULT_VIEWPORT, DESKTOP_VIEWPORT);
 	});
 
-	it("produces exactly one shot per surface (no viewport cross-product)", () => {
+	it("produces exactly one shot per surface at the plan's one viewport", () => {
 		const plan = buildCapturePlan("https://pr-9.web.kamp.us", surfaces);
 		assert.strictEqual(plan.length, surfaces.length);
 	});
@@ -159,5 +162,31 @@ describe("buildCapturePlan", () => {
 			{surface: "/x", route: "/x", state: null},
 		];
 		assert.throws(() => buildCapturePlan("https://x.dev", dup), /duplicate surface/);
+	});
+});
+
+describe("the viewport vocabulary", () => {
+	it("resolves each realized name to its constant", () => {
+		assert.deepStrictEqual(viewportOf("desktop"), DESKTOP_VIEWPORT);
+		assert.deepStrictEqual(viewportOf("mobile"), MOBILE_VIEWPORT);
+	});
+
+	// Closed for `states.ts`'s reason: an unresolved name would have to fall back to some width, and
+	// a shot at the fallback width under the asked-for label is coverage claimed and not held.
+	it("answers null for a name outside the set rather than falling back to a width", () => {
+		assert.strictEqual(viewportOf("tablet"), null);
+		assert.isFalse(isViewportName("tablet"));
+	});
+
+	it("names every realized viewport, so a refusal can list them", () => {
+		assert.deepStrictEqual([...VIEWPORT_NAMES], ["desktop", "mobile"]);
+	});
+
+	it("gives the two viewports of one surface distinct file names", () => {
+		const surface: Surface = {surface: "/pano", route: "/pano", state: null};
+		assert.notStrictEqual(
+			surfaceFileName(surface, DESKTOP_VIEWPORT),
+			surfaceFileName(surface, MOBILE_VIEWPORT),
+		);
 	});
 });

--- a/packages/fabrika-cli/src/review-ui/codes.ts
+++ b/packages/fabrika-cli/src/review-ui/codes.ts
@@ -89,3 +89,15 @@ export const UPLOAD_FAILED = 17;
  * step 4 have already run by then, which is a spent upload rather than a landed verdict.
  */
 export const SUPERSEDES_VERDICT = 18;
+/**
+ * Refused, proven: a shot's PNG width, read back from its own bytes, is not the width of the
+ * viewport that was asked for.
+ *
+ * Its own seat rather than the wrong-page `11`, because unlike a wrong tier or an inert override
+ * this one is decided against the recorded artifact rather than against a probe the preview
+ * answered — the readback is the same shape as `INVALID_CAPTURE`'s, one question further on. A shot
+ * at the wrong width is a valid PNG of a layout nobody asked about, and recording it under a
+ * viewport label would make the narrow half of the design law answerable from desktop pixels
+ * (#7706).
+ */
+export const WRONG_VIEWPORT = 19;

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -58,6 +58,14 @@ const render = leafCommand(
 				"a surface id to capture — a route such as /pano, or a route plus a tier state (/pano:auth renders as the yazar test account, /pano:auth-caylak as the çaylak one), each proved signed in AND at the named tier against the preview's session endpoint before the shot is recorded; repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
 			),
 		),
+		// `atLeast(0)` is the repeatable form with no floor: omitting it renders at desktop alone,
+		// which is what every invocation written before this operand asked for implicitly.
+		viewport: Flag.string("viewport").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"a viewport to shoot every --surface at — desktop (1280x800) or mobile (390x844), repeatable and crossed with --surface; each shot proves its own width off the captured PNG's bytes before it is recorded (default: desktop alone)",
+			),
+		),
 		// `atLeast(0)` is the repeatable form with no floor: forcing nothing is the ordinary run.
 		flag: Flag.string("flag").pipe(
 			Flag.atLeast(0),
@@ -73,12 +81,13 @@ const render = leafCommand(
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({pr, out, surface, flag, app, repo}) {
+	Effect.fn(function* ({pr, out, surface, viewport, flag, app, repo}) {
 		yield* emit(
 			yield* runRender({
 				pr,
 				out,
 				surfaces: surface,
+				viewports: viewport,
 				flags: flag,
 				app: Option.getOrNull(app),
 				repo: Option.getOrNull(repo),
@@ -91,7 +100,7 @@ const render = leafCommand(
 ).pipe(
 	Command.withShortDescription("Capture the named surfaces from a PR's preview deployment."),
 	Command.withDescription(
-		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, a --surface names a :state nothing renders — the realized set is auth, auth-caylak, a --flag operand is not a <key>=<on|off> pair, or --flag was passed with an anonymous surface), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, a tier-naming surface was requested with that tier's session token or BETTER_AUTH_SECRET unset, a tier-naming surface's session proof did not come back signed in or came back at another tier, or a forced flag evaluated at its default anyway), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
+		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface per viewport, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per shot (surface, viewport, path, dimensions, sha256, page errors); every shot's outcome is enumerated on stderr. --viewport is crossed with --surface, so two of each is four captures whose file names carry the viewport label. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, a --surface names a :state nothing renders — the realized set is auth, auth-caylak, a --viewport names a viewport outside the closed set desktop, mobile or is passed twice, a --flag operand is not a <key>=<on|off> pair, or --flag was passed with an anonymous surface), 11 (a read failed, the preview comment is malformed or names several apps, a capture's validity is undeterminable, a tier-naming surface was requested with that tier's session token or BETTER_AUTH_SECRET unset, a tier-naming surface's session proof did not come back signed in or came back at another tier, or a forced flag evaluated at its default anyway), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route), 19 (a capture's PNG width read back from its own bytes is not the requested viewport's width). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano --viewport desktop --viewport mobile",
 	),
 );
 

--- a/packages/fabrika-cli/src/review-ui/manifest.ts
+++ b/packages/fabrika-cli/src/review-ui/manifest.ts
@@ -30,6 +30,12 @@ export const PAGE_ERROR_CAP = 3;
 /** One captured surface, as both the stdout object and the manifest record it. */
 export interface CaptureEntry {
 	readonly surface: string;
+	/**
+	 * The viewport label this shot was taken at (`plan.ts`'s closed set). A set is a
+	 * surface × viewport cross-product, so the surface id alone no longer identifies an entry —
+	 * without this a manifest cannot say what width its pixels are of (#7706).
+	 */
+	readonly viewport: string;
 	readonly path: string;
 	readonly width: number;
 	readonly height: number;
@@ -86,6 +92,7 @@ const toEntry = (value: unknown): CaptureEntry | null => {
 	const record = value as Record<string, unknown>;
 	if (
 		typeof record.surface !== "string" ||
+		typeof record.viewport !== "string" ||
 		typeof record.path !== "string" ||
 		typeof record.width !== "number" ||
 		typeof record.height !== "number" ||
@@ -96,6 +103,7 @@ const toEntry = (value: unknown): CaptureEntry | null => {
 	}
 	return {
 		surface: record.surface,
+		viewport: record.viewport,
 		path: record.path,
 		width: record.width,
 		height: record.height,

--- a/packages/fabrika-cli/src/review-ui/manifest.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/manifest.unit.test.ts
@@ -1,5 +1,6 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
+	type CaptureEntry,
 	type CaptureManifest,
 	isKebabSetName,
 	manifestPath,
@@ -20,10 +21,20 @@ const manifest: CaptureManifest = {
 	captures: [
 		{
 			surface: "/pano",
-			path: "/tmp/fabrika-review-ui/4321-03135b91/judged/pano.png",
+			viewport: "desktop",
+			path: "/tmp/fabrika-review-ui/4321-03135b91/judged/pano@desktop.png",
 			width: 1280,
 			height: 2140,
 			sha256: "9c41",
+			pageErrors: {rows: [], more: 0},
+		},
+		{
+			surface: "/pano",
+			viewport: "mobile",
+			path: "/tmp/fabrika-review-ui/4321-03135b91/judged/pano@mobile.png",
+			width: 390,
+			height: 3200,
+			sha256: "1f7b",
 			pageErrors: {rows: [], more: 0},
 		},
 	],
@@ -51,9 +62,19 @@ describe("the set path", () => {
 });
 
 describe("the manifest round-trip", () => {
-	it("parses back exactly what it serialized", () => {
+	it("parses back exactly what it serialized, viewport label and all", () => {
 		const read = parseManifest(serializeManifest(manifest));
 		assert.deepStrictEqual(read, {_tag: "Manifest", value: manifest});
+	});
+
+	// Two shots of one surface differ only by the label, so an entry that lost it could not say what
+	// width its pixels are of — and the two would read as one capture recorded twice (#7706).
+	it("refuses an entry carrying no viewport label", () => {
+		const {viewport: _dropped, ...unlabelled} = manifest.captures[0] as CaptureEntry;
+		assert.strictEqual(
+			parseManifest(JSON.stringify({...manifest, captures: [unlabelled]}))._tag,
+			"Malformed",
+		);
 	});
 
 	it("refuses a document it cannot read whole, rather than defaulting a field", () => {

--- a/packages/fabrika-cli/src/review-ui/post-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/post-verb.ts
@@ -201,17 +201,19 @@ const mismatchOf = (
 	return bytes;
 };
 
-/** The evidence gallery: per surface, the **verified** hosted URL — never a local path. */
+/**
+ * The evidence gallery: per shot, the **verified** hosted URL — never a local path. A set is a
+ * surface × viewport cross-product (#7706), so the heading names both: two shots of one surface
+ * under one heading would read as a duplicate rather than as the two widths they are.
+ */
 const gallery = (hosted: ReadonlyArray<readonly [CaptureEntry, string]>): string =>
 	[
 		"## Evidence",
 		"",
-		...hosted.flatMap(([entry, url]) => [
-			`### ${entry.surface}`,
-			"",
-			`![${entry.surface}](${url})`,
-			"",
-		]),
+		...hosted.flatMap(([entry, url]) => {
+			const shot = `${entry.surface} @ ${entry.viewport}`;
+			return [`### ${shot}`, "", `![${shot}](${url})`, ""];
+		}),
 	]
 		.join("\n")
 		.replace(/\n+$/, "");

--- a/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
@@ -41,6 +41,7 @@ const manifest = (overrides: Partial<CaptureManifest> = {}): CaptureManifest => 
 	captures: [
 		{
 			surface: "/pano",
+			viewport: "desktop",
 			path: CAPTURE_PATH,
 			width: 1280,
 			height: 2140,
@@ -167,7 +168,8 @@ const run = (
 	).then((outcome) => ({outcome, requests: seams.requests, bodies: seams.bodies}));
 };
 
-const COMPOSED = `review-ui: FAIL @ ${HEAD} — changes-requested\n\n${BODY.trimEnd()}\n\n## Evidence\n\n### /pano\n\n![/pano](${HOSTED})`;
+const SHOT = "/pano @ desktop";
+const COMPOSED = `review-ui: FAIL @ ${HEAD} — changes-requested\n\n${BODY.trimEnd()}\n\n## Evidence\n\n### ${SHOT}\n\n![${SHOT}](${HOSTED})`;
 
 const happy = (): ReadonlyArray<Scripted> => [
 	[PULL, pull()],
@@ -194,7 +196,7 @@ describe("runPost", () => {
 		const write = bodies[requests.findIndex((request) => CREATE.test(request))] ?? "";
 		const body = String(JSON.parse(write).body);
 		expect(body.split("\n")[0]).toBe(`review-ui: FAIL @ ${HEAD} — changes-requested`);
-		expect(body).toContain(`![/pano](${HOSTED})`);
+		expect(body).toContain(`![${SHOT}](${HOSTED})`);
 		// The gallery embeds the hosted URL, never the local path the reviewer judged.
 		expect(body).not.toContain(CAPTURE_PATH);
 	});

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -17,12 +17,7 @@ import {SESSION_PROBE_PATH} from "../capture/auth.ts";
 import {captureShots} from "../capture/capture.ts";
 import {FLAG_PROBE_PATH, isForcing} from "../capture/flag-override.ts";
 import {isRenderCrash} from "../capture/page-errors.ts";
-import {
-	buildCapturePlan,
-	DEFAULT_VIEWPORT,
-	joinPreviewUrl,
-	parseSurfaceSpec,
-} from "../capture/plan.ts";
+import {buildCapturePlan, joinPreviewUrl, parseSurfaceSpec} from "../capture/plan.ts";
 import {validateCaptureBytes} from "../capture/png.ts";
 import {tierOf} from "../capture/states.ts";
 import {capAndCount} from "../evidence.ts";
@@ -59,7 +54,7 @@ export const makeCaptureRenderLeg =
 					buildCapturePlan(
 						request.previewUrl,
 						[parseSurfaceSpec(request.surface)],
-						DEFAULT_VIEWPORT,
+						request.viewport,
 					),
 				catch: (cause) => String(cause),
 			}).pipe(Effect.catch((reason) => Effect.succeed(reason)));
@@ -150,10 +145,21 @@ export const makeCaptureRenderLeg =
 			if (validity._tag === "Invalid") {
 				return {_tag: "Invalid", detail: validity.reason} satisfies SurfaceRender;
 			}
+			// The width comes off the PNG header, never echoed from the request — the same readback
+			// discipline the tier proof runs one layer up. A shot the browser took at another width is
+			// a valid image of a layout nobody asked about.
+			if (validity.width !== request.viewport.width) {
+				return {
+					_tag: "WrongViewport",
+					wanted: request.viewport.width,
+					rendered: validity.width,
+				} satisfies SurfaceRender;
+			}
 			return {
 				_tag: "Rendered",
 				entry: {
 					surface: request.surface,
+					viewport: request.viewport.label,
 					path: shot.localPath,
 					width: validity.width,
 					height: validity.height,

--- a/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
@@ -2,6 +2,7 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {type CapturedSurface, CaptureError} from "../capture/capture.ts";
 import {NO_FORCED_FLAGS} from "../capture/flag-override.ts";
+import {DESKTOP_VIEWPORT, MOBILE_VIEWPORT} from "../capture/plan.ts";
 import {PAGE_ERROR_CAP} from "./manifest.ts";
 import {type CaptureShots, makeCaptureRenderLeg} from "./render-leg.ts";
 import type {SurfaceRender} from "./render-verb.ts";
@@ -10,6 +11,7 @@ const PREVIEW = "https://pr-4321-web.example.test";
 
 const request = {
 	surface: "/pano",
+	viewport: DESKTOP_VIEWPORT,
 	previewUrl: PREVIEW,
 	outDir: "/tmp/shots",
 	cookies: [],
@@ -21,13 +23,17 @@ const failing =
 	() =>
 		Effect.fail(new CaptureError({message}));
 
-/** A 24-byte PNG header declaring 8x4 — enough for `validateCaptureBytes`, no codec needed. */
-const pngHeader = (): Uint8Array => {
+/**
+ * A 24-byte PNG header declaring the given size — enough for `validateCaptureBytes`, no codec
+ * needed. The width defaults to the desktop viewport's, because the leg now reads the width back
+ * off these very bytes and refuses a shot that is not the width it asked for.
+ */
+const pngHeader = (width = DESKTOP_VIEWPORT.width, height = 2140): Uint8Array => {
 	const bytes = new Uint8Array(24);
 	bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
 	bytes.set([0x49, 0x48, 0x44, 0x52], 12);
-	bytes[19] = 8;
-	bytes[23] = 4;
+	new DataView(bytes.buffer).setUint32(16, width);
+	new DataView(bytes.buffer).setUint32(20, height);
 	return bytes;
 };
 
@@ -119,6 +125,46 @@ describe("captureRenderLeg", () => {
 			_tag: "Rendered",
 			entry: {pageErrors: {rows: one, more: 0}},
 		});
+	});
+});
+
+/**
+ * The width half of the same readback discipline (#7706): the requested viewport is what the plan
+ * asked for, the recorded width is what the bytes say, and a shot that answers the narrow question
+ * from desktop pixels is a valid PNG no byte check downstream can tell from the real thing.
+ */
+describe("captureRenderLeg — the shot's own width", () => {
+	const mobileRequest = {...request, viewport: MOBILE_VIEWPORT};
+	const runMobile = (capture: CaptureShots): SurfaceRender =>
+		Effect.runSync(makeCaptureRenderLeg(capture)(mobileRequest));
+
+	it("plans the shot at the viewport it was handed, never a hardcoded default", () => {
+		const planned: number[] = [];
+		const spy: CaptureShots = (plan, _outDir, _options) => {
+			planned.push(plan[0]?.viewport.width ?? 0);
+			return succeeding({status: 200, pngBytes: pngHeader(MOBILE_VIEWPORT.width)})([], "", {});
+		};
+		runMobile(spy);
+		expect(planned).toEqual([MOBILE_VIEWPORT.width]);
+	});
+
+	it("records the shot when its bytes read back at the requested width", () => {
+		const render = runMobile(succeeding({status: 200, pngBytes: pngHeader(MOBILE_VIEWPORT.width)}));
+		expect(render).toMatchObject({_tag: "Rendered", entry: {viewport: "mobile", width: 390}});
+	});
+
+	it("refuses a desktop-width shot filed under mobile, naming both widths", () => {
+		expect(runMobile(succeeding({status: 200, pngBytes: pngHeader(1280)}))).toEqual({
+			_tag: "WrongViewport",
+			wanted: 390,
+			rendered: 1280,
+		});
+	});
+
+	// Undecodable comes first: "invalid bytes" is the truer answer than "the wrong width", and a
+	// width read off bytes that failed validation would be a number nobody proved.
+	it("keeps an invalid capture on the Invalid arm rather than the width one", () => {
+		expect(run(succeeding({status: 200, pngBytes: new Uint8Array(0)}))._tag).toBe("Invalid");
 	});
 });
 

--- a/packages/fabrika-cli/src/review-ui/render-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.ts
@@ -22,6 +22,13 @@
  * comes back at a different tier than the surface named. Each produces a perfectly valid PNG of a
  * page nobody asked for, which no byte check can tell from the real thing.
  *
+ * `--viewport <name>` picks the widths the surfaces are shot at, over `plan.ts`'s closed set, and
+ * defaults to `desktop` alone so every caller written before it is unchanged (#7706). Viewports
+ * cross the surfaces: two of each is four captures in one set, distinguished on disk and in the
+ * manifest by the viewport label. Each shot then proves its own width off the PNG header — the
+ * narrow half of the design law is only answerable from narrow pixels, and a desktop-width shot
+ * filed under `mobile` would answer it from the wrong ones, on `19`.
+ *
  * `--flag <key>=<on|off>` forces a dark-shipped flag for the run (ADR 0336, #7218), and it is
  * refused twice over on the same shape: on `10` when an operand is unreadable or names an anonymous
  * surface — the preview honors the override cookie only for an authorized platform-admin actor — and
@@ -39,6 +46,7 @@ import {
 	overrideCookies,
 	parseFlagOperands,
 } from "../capture/flag-override.ts";
+import {DEFAULT_VIEWPORT, VIEWPORT_NAMES, type Viewport, viewportOf} from "../capture/plan.ts";
 import {
 	type CaptureTier,
 	isRealizedState,
@@ -59,6 +67,7 @@ import {
 	RENDER_CRASHED,
 	STALE_TREE,
 	SURFACE_UNREACHABLE,
+	WRONG_VIEWPORT,
 } from "./codes.ts";
 import {
 	type CaptureEntry,
@@ -76,6 +85,8 @@ const VERB = "review-ui render";
 export interface SurfaceRenderRequest {
 	/** The surface id — `<route>` or `<route>:<state>`. */
 	readonly surface: string;
+	/** The width this shot is asked for, and the width its bytes must read back at. */
+	readonly viewport: Viewport;
 	readonly previewUrl: string;
 	readonly outDir: string;
 	/** Seeded into the capture context before navigation. Empty ⇒ the anonymous render. */
@@ -99,6 +110,7 @@ export type SurfaceRender =
 	| {readonly _tag: "Invalid"; readonly detail: string}
 	| {readonly _tag: "Unauthenticated"; readonly reason: string}
 	| {readonly _tag: "WrongTier"; readonly wanted: CaptureTier; readonly rendered: string}
+	| {readonly _tag: "WrongViewport"; readonly wanted: number; readonly rendered: number}
 	| {readonly _tag: "OverrideInert"; readonly reason: string}
 	| {readonly _tag: "Failed"; readonly reason: string};
 
@@ -108,6 +120,8 @@ export interface RenderOptions {
 	readonly pr: number;
 	readonly out: string;
 	readonly surfaces: readonly string[];
+	/** Raw `--viewport` operands, each a name in `plan.ts`'s closed set. Empty ⇒ desktop alone. */
+	readonly viewports: readonly string[];
 	/** Raw `--flag` operands, each a `<key>=<on|off>` pair. Empty ⇒ every flag at its default. */
 	readonly flags: readonly string[];
 	readonly app: string | null;
@@ -142,28 +156,44 @@ const routeCode = (renders: readonly SurfaceRender[]): number | null => {
 	return null;
 };
 
-const outcomeLine = (surface: string, render: SurfaceRender): string => {
+/**
+ * One planned shot: a surface at a viewport. The set is the cross product of the two operand lists,
+ * so nothing downstream can name a surface without the width its pixels are of.
+ */
+interface PlannedShot {
+	readonly surface: string;
+	readonly viewport: Viewport;
+}
+
+/** Every enumeration and every refusal names the shot, and a shot is a surface at a viewport. */
+const shotName = (shot: PlannedShot): string =>
+	`surface "${shot.surface}" at ${shot.viewport.label}`;
+
+const outcomeLine = (shot: PlannedShot, render: SurfaceRender): string => {
+	const subject = shotName(shot);
 	switch (render._tag) {
 		case "Rendered": {
 			// The count is the whole tally, not the kept rows: the payload collapses the list, so a
 			// stderr count read off `rows` alone would under-report exactly when there is most to report.
 			const errors = render.entry.pageErrors;
-			return `${VERB}: surface "${surface}" captured: ${render.entry.width}x${render.entry.height}, ${errors.rows.length + errors.more} page error(s)`;
+			return `${VERB}: ${subject} captured: ${render.entry.width}x${render.entry.height}, ${errors.rows.length + errors.more} page error(s)`;
 		}
 		case "Unreachable":
-			return `${VERB}: surface "${surface}" is unreachable at the preview (${render.reason}) — judge what renders, and hold the gap against the PR's Deviations (#4305).`;
+			return `${VERB}: ${subject} is unreachable at the preview (${render.reason}) — judge what renders, and hold the gap against the PR's Deviations (#4305).`;
 		case "Crashed":
-			return `${VERB}: surface "${surface}" threw during render: ${render.firstError} — the render is red; a broken page is not composition to judge.`;
+			return `${VERB}: ${subject} threw during render: ${render.firstError} — the render is red; a broken page is not composition to judge.`;
 		case "Invalid":
-			return `${VERB}: surface "${surface}" captured invalid bytes (${render.detail}) — a capture nobody can open is not evidence (#3925's class).`;
+			return `${VERB}: ${subject} captured invalid bytes (${render.detail}) — a capture nobody can open is not evidence (#3925's class).`;
 		case "Unauthenticated":
-			return `${VERB}: surface "${surface}" did not render signed in (${render.reason}) — the authenticated render is UNKNOWN, never the anonymous one.`;
+			return `${VERB}: ${subject} did not render signed in (${render.reason}) — the authenticated render is UNKNOWN, never the anonymous one.`;
 		case "WrongTier":
-			return `${VERB}: surface "${surface}" named tier ${render.wanted} and rendered as ${render.rendered} — the named tier's render is UNKNOWN, never another tier's.`;
+			return `${VERB}: ${subject} named tier ${render.wanted} and rendered as ${render.rendered} — the named tier's render is UNKNOWN, never another tier's.`;
+		case "WrongViewport":
+			return `${VERB}: ${subject} was asked for at ${render.wanted}px and its bytes read back ${render.rendered}px wide — the requested viewport's render is UNKNOWN, never another width's.`;
 		case "OverrideInert":
-			return `${VERB}: surface "${surface}" did not render with its forced flags (${render.reason}) — the forced render is UNKNOWN, never the default one.`;
+			return `${VERB}: ${subject} did not render with its forced flags (${render.reason}) — the forced render is UNKNOWN, never the default one.`;
 		case "Failed":
-			return `${VERB}: surface "${surface}" could not be rendered: ${render.reason} — the outcome is UNKNOWN.`;
+			return `${VERB}: ${subject} could not be rendered: ${render.reason} — the outcome is UNKNOWN.`;
 	}
 };
 
@@ -203,6 +233,29 @@ export const runRender = (
 				`${VERB}: --surface "${unrealized}" names a :state nothing renders — the realized states are ${REALIZED_STATES.join(", ")}; render the bare route.`,
 			);
 		}
+
+		const unknownViewport = options.viewports.find((name) => viewportOf(name) === null);
+		if (unknownViewport !== undefined) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --viewport "${unknownViewport}" is not a viewport this repo renders — the names are ${VIEWPORT_NAMES.join(", ")}.`,
+			);
+		}
+		const repeated = options.viewports.find(
+			(name, index) => options.viewports.indexOf(name) !== index,
+		);
+		if (repeated !== undefined) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --viewport "${repeated}" was passed twice — the second shot would overwrite the first's file and evidence.`,
+			);
+		}
+		// Omitted is desktop alone, which is what every invocation written before this operand asked
+		// for implicitly (#7706).
+		const viewports: readonly Viewport[] =
+			options.viewports.length === 0
+				? [DEFAULT_VIEWPORT]
+				: options.viewports.map((name) => viewportOf(name) as Viewport);
 
 		const operands = parseFlagOperands(options.flags);
 		if (operands._tag === "Malformed") {
@@ -304,15 +357,20 @@ export const runRender = (
 		const forcedCookies = overrideCookies(announced.url, forcedFlags);
 
 		const setDir = setDirectory(options.tmpRoot, pr, head, options.out);
+		// Surface-major so a mixed-viewport enumeration reads one surface's widths together.
+		const shots: readonly PlannedShot[] = options.surfaces.flatMap((surface) =>
+			viewports.map((viewport) => ({surface, viewport})),
+		);
 		const renders: SurfaceRender[] = [];
-		for (const surface of options.surfaces) {
+		for (const shot of shots) {
 			// Only a tier-naming variant carries a session and the override, and it carries ITS OWN
 			// tier's session: a bare route stays the visitor's render at every flag's default, so each
 			// is genuinely different pixels rather than one shot repeated.
-			const tier = tierOf(stateOf(surface));
+			const tier = tierOf(stateOf(shot.surface));
 			renders.push(
 				yield* options.render({
-					surface,
+					surface: shot.surface,
+					viewport: shot.viewport,
 					previewUrl: announced.url,
 					outDir: setDir,
 					cookies: tier === null ? [] : [...cookiesFor(tier), ...forcedCookies],
@@ -322,7 +380,7 @@ export const runRender = (
 		}
 		const enumerated = [
 			scanned,
-			...options.surfaces.map((surface, i) => outcomeLine(surface, renders[i] as SurfaceRender)),
+			...shots.map((shot, i) => outcomeLine(shot, renders[i] as SurfaceRender)),
 		];
 
 		const failed = renders.find((render) => render._tag === "Failed");
@@ -345,7 +403,17 @@ export const runRender = (
 		if (wrongPage !== -1) {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				outcomeLine(options.surfaces[wrongPage] as string, renders[wrongPage] as SurfaceRender),
+				outcomeLine(shots[wrongPage] as PlannedShot, renders[wrongPage] as SurfaceRender),
+				enumerated,
+			);
+		}
+		// Its own code rather than the `11` above, because this one is proven against the recorded
+		// bytes rather than against a probe the preview answered.
+		const wrongWidth = renders.findIndex((render) => render._tag === "WrongViewport");
+		if (wrongWidth !== -1) {
+			return refuse(
+				WRONG_VIEWPORT,
+				outcomeLine(shots[wrongWidth] as PlannedShot, renders[wrongWidth] as SurfaceRender),
 				enumerated,
 			);
 		}
@@ -362,7 +430,7 @@ export const runRender = (
 			const index = renders.findIndex((render) => render._tag === tag);
 			return refuse(
 				routed,
-				outcomeLine(options.surfaces[index] as string, renders[index] as SurfaceRender),
+				outcomeLine(shots[index] as PlannedShot, renders[index] as SurfaceRender),
 				enumerated,
 			);
 		}

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -9,6 +9,7 @@ import {
 	RENDER_CRASHED,
 	STALE_TREE,
 	SURFACE_UNREACHABLE,
+	WRONG_VIEWPORT,
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {parseManifest} from "./manifest.ts";
@@ -46,12 +47,18 @@ const announcement = (sha: string = HEAD.slice(0, 7)): HttpReply => ({
 	]),
 });
 
-const rendered = (surface: string, outDir: string): SurfaceRender => ({
+const rendered = (
+	surface: string,
+	outDir: string,
+	viewport = "desktop",
+	width = 1280,
+): SurfaceRender => ({
 	_tag: "Rendered",
 	entry: {
 		surface,
-		path: `${outDir}/${surface.replace(/^\//, "")}.png`,
-		width: 1280,
+		viewport,
+		path: `${outDir}/${surface.replace(/^\//, "")}@${viewport}.png`,
+		width,
 		height: 2140,
 		sha256: "9c41",
 		pageErrors: {rows: [], more: 0},
@@ -62,12 +69,16 @@ const rendered = (surface: string, outDir: string): SurfaceRender => ({
 const legOf =
 	(answers: Readonly<Record<string, SurfaceRender>>): RenderLeg =>
 	(request) =>
-		Effect.succeed(answers[request.surface] ?? rendered(request.surface, request.outDir));
+		Effect.succeed(
+			answers[request.surface] ??
+				rendered(request.surface, request.outDir, request.viewport.label, request.viewport.width),
+		);
 
 const options = {
 	pr: 4321,
 	out: "judged",
 	surfaces: ["/pano"],
+	viewports: [] as readonly string[],
 	flags: [] as readonly string[],
 	app: null,
 	repo: null,
@@ -107,7 +118,8 @@ describe("runRender", () => {
 			_tag: "Rendered",
 			entry: {
 				surface: "/pano",
-				path: "/tmp/fabrika-review-ui/4321-03135b91/judged/pano.png",
+				viewport: "desktop",
+				path: "/tmp/fabrika-review-ui/4321-03135b91/judged/pano@desktop.png",
 				width: 1280,
 				height: 2140,
 				sha256: "9c41",
@@ -127,7 +139,7 @@ describe("runRender", () => {
 		);
 		// The stderr tally is the whole list, not the kept rows — the collapse must not shrink the count.
 		expect(outcome.stderr).toContain(
-			'review-ui render: surface "/pano" captured: 1280x2140, 13 page error(s)',
+			'review-ui render: surface "/pano" at desktop captured: 1280x2140, 13 page error(s)',
 		);
 	});
 
@@ -424,7 +436,7 @@ describe("runRender", () => {
 		expect(outcome.stderr.some((line) => line.includes("unreachable"))).toBe(true);
 		expect(outcome.stderr.some((line) => line.includes("invalid bytes"))).toBe(true);
 		// The refusal names a surface the ROUTED code applies to, not merely the first bad one.
-		expect(outcome.stderr.at(-1)).toMatch(/surface "\/b" threw during render/);
+		expect(outcome.stderr.at(-1)).toMatch(/surface "\/b" at desktop threw during render/);
 	});
 
 	it("seats an unreachable-only set on 14 and an invalid-only set on 15", async () => {
@@ -436,6 +448,69 @@ describe("runRender", () => {
 			render: legOf({"/pano": {_tag: "Invalid", detail: "zero bytes"}}),
 		});
 		expect(invalid.outcome.code).toBe(INVALID_CAPTURE);
+	});
+
+	// Omitting the operand is what every invocation written before it did, so the default must stay
+	// the single desktop shot rather than becoming a cross-product nobody asked for (#7706).
+	it("renders at desktop alone when no --viewport is passed", async () => {
+		const seen: string[] = [];
+		const {outcome} = await run(happy(), {
+			surfaces: ["/pano", "/pano/yeni"],
+			render: (request) => {
+				seen.push(`${request.surface}@${request.viewport.label}`);
+				return Effect.succeed(
+					rendered(request.surface, request.outDir, request.viewport.label, request.viewport.width),
+				);
+			},
+		});
+		expect(outcome.code).toBe(0);
+		expect(seen).toEqual(["/pano@desktop", "/pano/yeni@desktop"]);
+	});
+
+	it("crosses viewports with surfaces: two of each is four captures under four file names", async () => {
+		const {outcome} = await run(happy(), {
+			surfaces: ["/pano", "/pano/yeni"],
+			viewports: ["desktop", "mobile"],
+		});
+		expect(outcome.code).toBe(0);
+		const read = parseManifest(outcome.stdout);
+		expect(read._tag).toBe("Manifest");
+		const captures = read._tag === "Manifest" ? read.value.captures : [];
+		expect(captures).toHaveLength(4);
+		expect(captures.map((entry) => `${entry.surface}@${entry.viewport}`)).toEqual([
+			"/pano@desktop",
+			"/pano@mobile",
+			"/pano/yeni@desktop",
+			"/pano/yeni@mobile",
+		]);
+		expect(new Set(captures.map((entry) => entry.path)).size).toBe(4);
+	});
+
+	it("refuses an off-vocabulary --viewport on 10, listing the names it does render", async () => {
+		const {outcome} = await run(happy(), {viewports: ["tablet"]});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.join("\n")).toContain("the names are desktop, mobile");
+	});
+
+	it("refuses one --viewport passed twice on 10 — the second shot overwrites the first", async () => {
+		const {outcome} = await run(happy(), {viewports: ["mobile", "mobile"]});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.join("\n")).toContain('--viewport "mobile" was passed twice');
+	});
+
+	// A desktop-width shot filed under `mobile` answers the narrow half of the law from the wrong
+	// pixels, which no byte check downstream can tell from the real thing (#7706).
+	it("refuses a shot whose bytes read back at another width on 19, recording no capture", async () => {
+		const {outcome, written} = await run(happy(), {
+			viewports: ["mobile"],
+			render: legOf({"/pano": {_tag: "WrongViewport", wanted: 390, rendered: 1280}}),
+		});
+		expect(outcome.code).toBe(WRONG_VIEWPORT);
+		expect(outcome.stdout).toBe("");
+		expect(written.size).toBe(0);
+		expect(outcome.stderr.at(-1)).toContain(
+			'surface "/pano" at mobile was asked for at 390px and its bytes read back 1280px wide',
+		);
 	});
 
 	it("keeps a render that never became answerable UNKNOWN (11), not a bad render", async () => {


### PR DESCRIPTION
`review-ui render` shot everything at 1280×800 with no operand to ask for anything else, so any
acceptance criterion phrased about a phone ended the design gate as disclosed-UNKNOWN. This adds
`--viewport <name>` over a closed set, threads it end to end, and makes each shot prove its own
width.

**The operand.** `--viewport desktop|mobile`, repeatable, resolved to `plan.ts`'s existing
`DESKTOP_VIEWPORT` / `MOBILE_VIEWPORT` constants through a new closed vocabulary (`VIEWPORTS`,
`viewportOf`, `VIEWPORT_NAMES`) built on `capture/states.ts`'s pattern. Omitting it renders at
`desktop` alone, so every existing caller is byte-for-byte unchanged. An off-vocabulary name refuses
on `10` before a browser launches, listing the accepted names; so does one name passed twice, because
the second shot would overwrite the first's file and evidence.

**The cross product.** Viewports cross surfaces — two of each is four captures in one set. The PNG
file name already carried the viewport label (`pano@desktop.png`), so nothing collides, and
`CaptureEntry` now records the label beside the surface id, round-tripping through serialize/parse.
Because the surface id no longer identifies an entry on its own, the per-shot stderr lines and the
evidence gallery heading both name the width too.

**The width readback.** `render-leg.ts` compares the PNG width `validateCaptureBytes` reads out of the
captured bytes against the requested viewport's width, and refuses a mismatch on the new exit `19`
with both widths on the stderr line. This is the discipline the tier proof already ran, one layer
over: a desktop-width capture filed under `mobile` is a perfectly valid PNG of a layout nobody asked
about, and nothing downstream could tell it from the real thing.

Docs move with the verb, all six pin surfaces per
[`.patterns/verb-output-pin-surfaces.md`](.patterns/verb-output-pin-surfaces.md): the contract's
render section (inputs table, mechanism, exit table, errors table, worked examples), the skill's own
step 3, `command.ts`'s help string, the verb-reference row, and the module docblocks — including
`plan.ts`'s, whose "NOT a viewport cross-product" sentence was the invariant this changes.

Verified: `pnpm typecheck --force` and `pnpm lint:worktree` green in-tree, the full 8693-test
fabrika-cli suite green, and the `10` refusal exercised live through the real CLI (it lands before
any network call).

## Deviations

- **Out-of-scope change** — **Said:** #7706 scopes the operand, its threading, the manifest label,
  the width refusal, and the contract/skill text. **Did:** also changed `post-verb.ts`'s evidence
  gallery to head each shot `<surface> @ <viewport>` instead of `<surface>`. **Why:** a set is now a
  cross product, so two entries share a surface id — the old heading printed two identical `### /pano`
  sections for the two widths, which reads as a duplicate rather than as the two shots it is. The
  change introduces that defect, so the fix rides with it. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the triage note asks the builder to judge whether the closed set
  should also carry a 375 row against `apps/web/src/components/layout/Topbar.css`. **Did:** shipped
  `desktop` + `mobile` (390) only. **Why:** that file's only narrow block is
  `@media (max-width: 640px)`, and both 390 and 375 fall inside it, so a 375 row would buy no CSS
  branch the 390 shot does not already exercise. The set is closed and extending it is one entry.
  **Disposition:** stated here and in `plan.ts`'s `VIEWPORTS` docblock.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left the scope-derivation question —
  whether a given surface *owes* a narrow capture — unanswered. **Why:** the issue puts it explicitly
  out of scope, same shape as #7051's "name the owed states". The skill now says when to reach for
  `mobile`; nothing forces it. **Disposition:** stated here, out of scope per the issue.

Fixes #7706
