### PR TITLE
chore: Tuval commands: the .patterns doc, the framework ADR and the glossary terms

### DIFF
--- a/.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md
+++ b/.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md
@@ -28,8 +28,10 @@ rounds on 2026-09-03 and the founder ruled on all thirteen questions. The sessio
 epic [#7627](https://github.com/kamp-us/phoenix/issues/7627), whose children built the framework:
 the registry (#7636), the protocol (#7637), the executor and scope (#7638), the parser and
 completion (#7639), the key bindings (#7640), the discovery spells (#7641), and the process spells
-and bridge (#7642). This ADR is written after those landed, so every claim below is the code's, not
-the plan's.
+and bridge (#7642). Three more children sit outside that list: the palette (#7643, re-sequenced off
+this epic's tail), this record and its companion pattern doc (#7644), and the proof (#7645). This
+ADR is written after the seven code children landed, so every claim below is the code's, not the
+plan's.
 
 ### Prior art, read and not imported
 
@@ -56,9 +58,9 @@ answer, and where the code that implements it lives. The full ruling comments ar
 | Ruling | What was decided | Where it landed |
 |---|---|---|
 | **R1.1** | A spell is `{path, describe, params, result, execute, capabilities}`, the `@usirin/spellbook` shape rewritten on Effect Schema. Founder: "yes, next question" | [`commands/spell.ts`](../apps/tuval/src/commands/spell.ts) |
-| **R1.2** | Programs declare their spells at registration time, on the program row, swapped whole on config reload; never invented at runtime from inside a process. Founder: "this also makes things easy to type I guess" | `spells` on [`registry/program.ts`](../apps/tuval/src/registry/program.ts); `buildRegistry` and `swap` in [`commands/registry.ts`](../apps/tuval/src/commands/registry.ts) |
+| **R1.2** | Programs declare their spells at registration time, on the program row, swapped whole on config reload; never invented at runtime from inside a process. Founder: "Okay, this also makes things easy to type I guess" | `spells` on [`registry/program.ts`](../apps/tuval/src/registry/program.ts); `buildRegistry` and `swap` in [`commands/registry.ts`](../apps/tuval/src/commands/registry.ts) |
 | **R1.3** | A spell call is the only page-to-kernel message, so windows, keys and the command line all speak one wire; all desk state lives in the kernel and a tab keeps only tab-ephemeral state. Founder: "I love it" | `SpellCall` and `PageToKernel` in [`protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts) |
-| **R1.4** | A key binding is a `{path, args}` record compiled once at config load, not a command string parsed at keypress. Recovery is per binding: valid ones load, each bad one is dropped and reported with its position, and only an unimportable file or a top-level schema error keeps the last good config. Founder: "I like this, but we gotta make sure that like we err with good error messages" | [`commands/bindings/compile.ts`](../apps/tuval/src/commands/bindings/compile.ts), [`commands/bindings/errors.ts`](../apps/tuval/src/commands/bindings/errors.ts) |
+| **R1.4** | A key binding is a `{path, args}` record compiled once at config load, not a command string parsed at keypress. Recovery is per binding: valid ones load, each bad one is dropped and reported with its position, and only an unimportable file or a top-level schema error keeps the last good config. Founder: "Yeah, I like this, but we gotta make sure that like we err with good error messages" | [`commands/bindings/compile.ts`](../apps/tuval/src/commands/bindings/compile.ts), [`commands/bindings/errors.ts`](../apps/tuval/src/commands/bindings/errors.ts) |
 | **R1.5** | Completion uses exact prefix on the names the system defines (spell path segments, program ids, enum literals) and fuzzy ranking on the values a user named (window, process and workspace ids and names), both synchronous against the snapshot the page already holds. Founder: "Oof, I love this UX man" | [`commands/parse/complete.ts`](../apps/tuval/src/commands/parse/complete.ts) |
 | **R1.6** | A spell carries a `capabilities` field, declared now and enforced by nothing in this epic. Founder: "yes, next question" | `capabilities` in [`commands/spell.ts`](../apps/tuval/src/commands/spell.ts), mirrored on the wire in [`protocol/registry-description.ts`](../apps/tuval/src/protocol/registry-description.ts) |
 | **R2.1** | `help` is a spell, rendered from every spell's own `describe`, and the palette's inline description is the same string. There is no hand-written help table anywhere. Founder: "i fucking love it dude" | [`commands/core/help.ts`](../apps/tuval/src/commands/core/help.ts), pinned by `no-handwritten-help.unit.test.ts` |
@@ -84,7 +86,8 @@ Everything else in R2.3 stands: focus trapped, Esc restores focus, a listbox wit
 snapshot. The palette also waits on `packages/design`
 ([#7561](https://github.com/kamp-us/phoenix/issues/7561)) rather than shipping on plain components
 and migrating later, and a second 2026-09-03 ruling took it off this epic's tail: it lands as its
-own PR against main after #7556 and #7561 close.
+own PR against main once three things are true, that #7556 and #7561 have closed and that the epic
+PR [#7687](https://github.com/kamp-us/phoenix/pull/7687) has merged.
 
 ### What the framework is, as built
 
@@ -93,12 +96,12 @@ The shapes are documented as reference in
 rulings above:
 
 - **One registry, one description, one help text.** `describeSpell` renders a spell's parameters as
-  JSON Schema, and that same `SpellDescription` feeds `help`, `spell list`, `spell describe`, the
-  palette's inline text and the parser's index. A spell's sentence is written once, at its
-  `defineSpell` site.
+  JSON Schema, and that same `SpellDescription` feeds `help`, `spell list`, `spell describe` and the
+  parser's index today, and the palette's inline text when the palette is built. A spell's sentence
+  is written once, at its `defineSpell` site.
 - **The page and the kernel parse identically.** The parser's index is built from the protocol's
-  `RegistryDescription`, which is exactly what a `Snapshot` carries, so the palette cannot accept a
-  line the kernel would reject.
+  `RegistryDescription`, which is exactly what a `Snapshot` carries, so a page running this parser
+  cannot accept a line the kernel would reject.
 - **The kernel decides scope.** The wire lets a page name a window and nothing else. A spell that
   legitimately targets another process takes that id as a parameter of its own `params` and is
   answerable for it. That parameter is precisely what a capability check will guard later.
@@ -113,24 +116,27 @@ Named here so nobody reads the framework as more than it is.
 - **Capability enforcement.** `capabilities` on a spell and `CapabilityRequest` on a program row are
   inert data: stored, described, and checked by nothing. Local program code is fully trusted and
   there is no sandbox (#7484 R1.1, the Neovim model). Until enforcement exists, the only thing
-  between a calling program and the registry is the bridge's allowlist, and that allowlist is data
-  the calling program's own row supplies, not a check the kernel makes on the caller's identity. A
-  later epic owns enforcement; this ADR does not design it.
+  between a calling program and the registry is the bridge's allowlist. `SpellBridge.layer({allow})`
+  takes that list from whoever builds the layer, and as this ADR is written the only caller in the
+  tree is the bridge's own unit test: nothing reads a program row into it yet. Wiring it to the
+  calling program's registry row is the intent recorded in the module's docblock and is a later
+  child's work, and enforcement proper is a later epic's. This ADR designs neither.
 - **Scripting and macros.** No way to compose spells into a script, bind a sequence, or record one.
   R4.2 puts it out of the first epic and no child was cut for it.
 - **Binary channels on the protocol.** JSON text is the whole wire. wormhole needed framing and
   channels because it carries raw terminal bytes; Tuval carries spell calls and desk state, which
   are structured values, and a second framing layer would buy nothing but a second thing to version.
   A program that streams raw bytes is what reopens this, and it will be its own ADR.
-- **The palette itself.** #7643, off this epic's tail, after `packages/design`.
+- **The palette itself.** #7643, off this epic's tail: it lands after #7556 and #7561 close and
+  after epic PR #7687 merges.
 - **The shell's `:` line and the agents' SDK tools.** #7555 and #7620 adopt the registry as they are
   built. R4.2 says nothing already planned is re-planned for this framework.
 
 ## Consequences
 
-- A new command is a `defineSpell` and a row in a program's `spells`. It is reachable from the
-  palette, a key binding, `help` and an AI agent the moment it is registered, with no second
-  catalogue to update.
+- A new command is a `defineSpell` and a row in a program's `spells`. It is reachable from `help`,
+  `spell list`, a compiled key binding and the bridge the moment it is registered, and from the
+  palette when the palette is built, with no second catalogue to update.
 - The protocol is a versioned contract from its first commit. `PROTOCOL_VERSION` is `1`, every
   message carries it, and a page and kernel from different builds refuse each other by decode rather
   than by behaviour. Changing a message's shape means bumping it.

--- a/.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md
+++ b/.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md
@@ -1,0 +1,145 @@
+---
+id: 0348
+title: The Tuval command framework is a spell registry on Effect Schema with one versioned protocol
+status: accepted
+date: 2026-09-03
+tags: [tuval, commands, protocol, effect-schema]
+---
+
+# 0348 — The Tuval command framework is a spell registry on Effect Schema with one versioned protocol
+
+**What this decides:** every command in Tuval is a *spell*, a schema-typed record in one registry
+built from config; the page and the kernel talk over one named, versioned protocol of four Effect
+Schema messages; and the palette, the key bindings and an AI agent's tools all run the same spells
+through the same registry.
+
+## Context
+
+Tuval is being rebuilt under `apps/tuval` (ADR [0345](0345-tuval-lives-under-apps.md)) against the
+program/process contract of epic [#7496](https://github.com/kamp-us/phoenix/issues/7496). The kernel
+landed with programs, processes, ports and a registry, and no way to *ask it for anything*. The
+shell's command line ([#7555](https://github.com/kamp-us/phoenix/issues/7555)) and the AI agents'
+tools ([#7620](https://github.com/kamp-us/phoenix/issues/7620)) were both about to grow their own
+dispatch, which would have meant two catalogues of what Tuval can do, drifting from each other from
+the first week.
+
+Grilling [#7617](https://github.com/kamp-us/phoenix/issues/7617) worked that fog down over four
+rounds on 2026-09-03 and the founder ruled on all thirteen questions. The session graduated into
+epic [#7627](https://github.com/kamp-us/phoenix/issues/7627), whose children built the framework:
+the registry (#7636), the protocol (#7637), the executor and scope (#7638), the parser and
+completion (#7639), the key bindings (#7640), the discovery spells (#7641), and the process spells
+and bridge (#7642). This ADR is written after those landed, so every claim below is the code's, not
+the plan's.
+
+### Prior art, read and not imported
+
+Two of the founder's own projects supplied the shape, and neither is a dependency. Nothing is
+imported or copied from either; both are cited by repository and path.
+
+- **`@usirin/spellbook`** (`usirin/monorepo`, `packages/spellbook/src/spellbook.ts`) supplied the
+  spell shape: an addressable command with a path, a description, a parameter schema, a result
+  schema and an execute function. Its schemas are Standard Schema and its `execute` returns a
+  Promise. The rewrite here is on Effect Schema with an Effect `execute`, so a spell's failures and
+  service requirements ride its own type and there is only one validation stack in the app.
+- **wormhole** (`usirin/wormhole`, `packages/wormhole/src/Protocol.ts`) supplied the protocol shape:
+  one `Schema.Class` per message, one union per direction, a decode that refuses rather than
+  coercing. Its binary framing and channels are deliberately left behind; see the fifth ruling
+  below.
+
+## Decision
+
+### The thirteen rulings
+
+Each row is a question from [#7617](https://github.com/kamp-us/phoenix/issues/7617), the founder's
+answer, and where the code that implements it lives. The full ruling comments are on that issue.
+
+| Ruling | What was decided | Where it landed |
+|---|---|---|
+| **R1.1** | A spell is `{path, describe, params, result, execute, capabilities}`, the `@usirin/spellbook` shape rewritten on Effect Schema. Founder: "yes, next question" | [`commands/spell.ts`](../apps/tuval/src/commands/spell.ts) |
+| **R1.2** | Programs declare their spells at registration time, on the program row, swapped whole on config reload; never invented at runtime from inside a process. Founder: "this also makes things easy to type I guess" | `spells` on [`registry/program.ts`](../apps/tuval/src/registry/program.ts); `buildRegistry` and `swap` in [`commands/registry.ts`](../apps/tuval/src/commands/registry.ts) |
+| **R1.3** | A spell call is the only page-to-kernel message, so windows, keys and the command line all speak one wire; all desk state lives in the kernel and a tab keeps only tab-ephemeral state. Founder: "I love it" | `SpellCall` and `PageToKernel` in [`protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts) |
+| **R1.4** | A key binding is a `{path, args}` record compiled once at config load, not a command string parsed at keypress. Recovery is per binding: valid ones load, each bad one is dropped and reported with its position, and only an unimportable file or a top-level schema error keeps the last good config. Founder: "I like this, but we gotta make sure that like we err with good error messages" | [`commands/bindings/compile.ts`](../apps/tuval/src/commands/bindings/compile.ts), [`commands/bindings/errors.ts`](../apps/tuval/src/commands/bindings/errors.ts) |
+| **R1.5** | Completion uses exact prefix on the names the system defines (spell path segments, program ids, enum literals) and fuzzy ranking on the values a user named (window, process and workspace ids and names), both synchronous against the snapshot the page already holds. Founder: "Oof, I love this UX man" | [`commands/parse/complete.ts`](../apps/tuval/src/commands/parse/complete.ts) |
+| **R1.6** | A spell carries a `capabilities` field, declared now and enforced by nothing in this epic. Founder: "yes, next question" | `capabilities` in [`commands/spell.ts`](../apps/tuval/src/commands/spell.ts), mirrored on the wire in [`protocol/registry-description.ts`](../apps/tuval/src/protocol/registry-description.ts) |
+| **R2.1** | `help` is a spell, rendered from every spell's own `describe`, and the palette's inline description is the same string. There is no hand-written help table anywhere. Founder: "i fucking love it dude" | [`commands/core/help.ts`](../apps/tuval/src/commands/core/help.ts), pinned by `no-handwritten-help.unit.test.ts` |
+| **R2.2** | A spell runs with a typed `Scope` (`{window?, process?, workspace, client}`) the kernel resolves from the call's `window`. The page never names a process. Founder: "yes, next question" | [`commands/scope.ts`](../apps/tuval/src/commands/scope.ts), applied in [`commands/executor.ts`](../apps/tuval/src/commands/executor.ts) |
+| **R2.3** | The palette is a floating layer over the desk, `:` opens, Esc closes and restores focus, Enter runs, the last error renders inline under the input. Founder: "awesome" | not built; [#7643](https://github.com/kamp-us/phoenix/issues/7643) owns it, corrected below |
+| **R2.4** | The AI agents' generic tools become the spells `process spawn` / `process send` / `process read`, and the SDK tool is a thin bridge over the same registry; `spell list` and `spell describe` let an agent discover it. Founder: "Yeah, next" | [`commands/core/process.ts`](../apps/tuval/src/commands/core/process.ts), [`commands/core/spell.ts`](../apps/tuval/src/commands/core/spell.ts), [`commands/bridge/SpellBridge.ts`](../apps/tuval/src/commands/bridge/SpellBridge.ts) |
+| **R3.1** | The page-kernel wire is named **the Tuval protocol**: one module, four versioned Effect Schema messages (`SpellCall`, `SpellReply`, `Snapshot`, `Patch`), one union per direction, with the registry riding in the snapshot so the palette completes offline. Founder: "awesome" | [`protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts), [`protocol/codec.ts`](../apps/tuval/src/protocol/codec.ts) |
+| **R4.1** | The command framework epic sequences before the shell's command-line child (#7555) and the agent-tools child (#7620), so both build on the registry rather than their own dispatch. The kernel does not wait. Founder: "yes" | epic #7627 ordering |
+| **R4.2** | The first epic's scope is exactly: registry, incremental parser, completion engine, protocol module, palette UI, `help`, `spell list`, `spell describe`. Out: capability enforcement, scripting and macros, and re-cutting the already-planned shell children. Founder: "yes" | see "What is left out" below |
+
+### The palette correction, 2026-09-03
+
+R2.3 said the palette floats over the *focused window*. The founder corrected that in a walk the
+same day, recorded on [#7643](https://github.com/kamp-us/phoenix/issues/7643): a window "might just
+change or might be really small", and the palette should work "similar to how neovim, tmux, vscode
+works". Ruled: **the palette is one desk-level overlay at the top center of the whole app, fixed
+width, never anchored to a window's box.** The focused window supplies scope only, so a spell run
+from the palette still targets the focused window because scope comes from focus, not from where the
+palette sits.
+
+Everything else in R2.3 stands: focus trapped, Esc restores focus, a listbox with
+`aria-activedescendant`, prefix on paths and fuzzy on live values, synchronous against the local
+snapshot. The palette also waits on `packages/design`
+([#7561](https://github.com/kamp-us/phoenix/issues/7561)) rather than shipping on plain components
+and migrating later, and a second 2026-09-03 ruling took it off this epic's tail: it lands as its
+own PR against main after #7556 and #7561 close.
+
+### What the framework is, as built
+
+The shapes are documented as reference in
+[`.patterns/tuval-spells.md`](../.patterns/tuval-spells.md). The load-bearing consequences of the
+rulings above:
+
+- **One registry, one description, one help text.** `describeSpell` renders a spell's parameters as
+  JSON Schema, and that same `SpellDescription` feeds `help`, `spell list`, `spell describe`, the
+  palette's inline text and the parser's index. A spell's sentence is written once, at its
+  `defineSpell` site.
+- **The page and the kernel parse identically.** The parser's index is built from the protocol's
+  `RegistryDescription`, which is exactly what a `Snapshot` carries, so the palette cannot accept a
+  line the kernel would reject.
+- **The kernel decides scope.** The wire lets a page name a window and nothing else. A spell that
+  legitimately targets another process takes that id as a parameter of its own `params` and is
+  answerable for it. That parameter is precisely what a capability check will guard later.
+- **A bad key binding costs its own key.** Per-binding recovery, and every error names the module,
+  the key, the character offset, what was expected and the nearest thing the author may have meant.
+  The module name is layer-relative, never a machine-local absolute path.
+
+## What is left out, and who owns it later
+
+Named here so nobody reads the framework as more than it is.
+
+- **Capability enforcement.** `capabilities` on a spell and `CapabilityRequest` on a program row are
+  inert data: stored, described, and checked by nothing. Local program code is fully trusted and
+  there is no sandbox (#7484 R1.1, the Neovim model). Until enforcement exists, the only thing
+  between a calling program and the registry is the bridge's allowlist, and that allowlist is data
+  the calling program's own row supplies, not a check the kernel makes on the caller's identity. A
+  later epic owns enforcement; this ADR does not design it.
+- **Scripting and macros.** No way to compose spells into a script, bind a sequence, or record one.
+  R4.2 puts it out of the first epic and no child was cut for it.
+- **Binary channels on the protocol.** JSON text is the whole wire. wormhole needed framing and
+  channels because it carries raw terminal bytes; Tuval carries spell calls and desk state, which
+  are structured values, and a second framing layer would buy nothing but a second thing to version.
+  A program that streams raw bytes is what reopens this, and it will be its own ADR.
+- **The palette itself.** #7643, off this epic's tail, after `packages/design`.
+- **The shell's `:` line and the agents' SDK tools.** #7555 and #7620 adopt the registry as they are
+  built. R4.2 says nothing already planned is re-planned for this framework.
+
+## Consequences
+
+- A new command is a `defineSpell` and a row in a program's `spells`. It is reachable from the
+  palette, a key binding, `help` and an AI agent the moment it is registered, with no second
+  catalogue to update.
+- The protocol is a versioned contract from its first commit. `PROTOCOL_VERSION` is `1`, every
+  message carries it, and a page and kernel from different builds refuse each other by decode rather
+  than by behaviour. Changing a message's shape means bumping it.
+- The registry is a pure function of config. `:help` is complete before any process runs, and a
+  reload swaps every program's spells in one write.
+- A spell whose meaning depends on process state takes a process id as an argument rather than
+  inventing itself at runtime. That is the cost of R1.2 and it was accepted with it.
+- The parser's reading of a JSON-Schema `params` depends on two properties of
+  `Schema.toJsonSchemaDocument` at the `catalogs.tuval` pin (effect `4.0.0-rc.112`): `properties`
+  key order is `Schema.Struct` declaration order, and a `Schema.Literals` parameter renders as
+  `{"type": "string", "enum": [...]}`. Both are read off that source and pinned by the parser's
+  tests. An Effect bump has to re-check them.

--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -423,7 +423,7 @@ slice of epic [#7496](https://github.com/kamp-us/phoenix/issues/7496) under `app
 means program (definition) or process (running instance). "Grain" (Orleans' virtual actor) is
 noted as a future-feeling alternative and is not adopted.
 
-### Tuval: spell, palette, the Tuval protocol
+### Tuval: spell, registry, palette, scope, the Tuval protocol
 
 Tuval's command-framework nouns, ruled by the thirteen decisions on grilling
 [#7617](https://github.com/kamp-us/phoenix/issues/7617) and built by epic
@@ -431,11 +431,26 @@ Tuval's command-framework nouns, ruled by the thirteen decisions on grilling
 ADR [0348](../.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md); the
 shapes are [`.patterns/tuval-spells.md`](../.patterns/tuval-spells.md).
 
-- **spell** — one addressable command in Tuval's registry: a path, a one-sentence description, an
-  Effect Schema for its parameters and one for its result, an Effect `execute`, and an inert
+- **spell** — one addressable command in Tuval's spell registry: a path, a one-sentence description,
+  an Effect Schema for its parameters and one for its result, an Effect `execute`, and an inert
   capability list. Source: [`apps/tuval/src/commands/spell.ts`](../apps/tuval/src/commands/spell.ts).
-- **palette** — the desk-level command overlay at the top center of the app, fixed width and never
-  anchored to a window, where a person types a spell and picks from ranked completions.
+- **registry** — ambiguous on its own in Tuval prose, so always qualify it. The **spell registry**
+  is the one table of every callable spell, keyed by path, built from the core spell list plus each
+  program row's `spells` and replaced whole on a config reload
+  ([`apps/tuval/src/commands/registry.ts`](../apps/tuval/src/commands/registry.ts)). The **program
+  registry** is the separate kernel table of program rows
+  ([`apps/tuval/src/registry/Registry.ts`](../apps/tuval/src/registry/Registry.ts)); it never reads
+  a row's spells.
+- **palette (the Tuval palette)** — Tuval's desk-level command overlay at the top center of the app,
+  fixed width and never anchored to a window, where a person types a spell and picks from ranked
+  completions. Not apps/web's ⌘K command palette (ADR
+  [0186](../.decisions/0186-command-palette-single-search-contract.md)) and not a reaction palette
+  (ADR [0139](../.decisions/0139-reaction-curated-palette.md)); a bare "palette" in Tuval prose is
+  this one.
+- **scope** — where one spell call came from, as the kernel decides it: the workspace and client
+  always, plus the window and process when the caller was inside one. The page names a window and
+  nothing else; the kernel resolves the rest, so a page cannot address a process by putting its id
+  on the wire. Source: [`apps/tuval/src/commands/scope.ts`](../apps/tuval/src/commands/scope.ts).
 - **the Tuval protocol** — the one versioned page-to-kernel wire: four Effect Schema messages
   (`SpellCall`, `SpellReply`, `Snapshot`, `Patch`), one union per direction, JSON text only. Source:
   [`apps/tuval/src/protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts).

--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -423,6 +423,23 @@ slice of epic [#7496](https://github.com/kamp-us/phoenix/issues/7496) under `app
 means program (definition) or process (running instance). "Grain" (Orleans' virtual actor) is
 noted as a future-feeling alternative and is not adopted.
 
+### Tuval: spell, palette, the Tuval protocol
+
+Tuval's command-framework nouns, ruled by the thirteen decisions on grilling
+[#7617](https://github.com/kamp-us/phoenix/issues/7617) and built by epic
+[#7627](https://github.com/kamp-us/phoenix/issues/7627). English technical terms, per §3. The why is
+ADR [0348](../.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md); the
+shapes are [`.patterns/tuval-spells.md`](../.patterns/tuval-spells.md).
+
+- **spell** — one addressable command in Tuval's registry: a path, a one-sentence description, an
+  Effect Schema for its parameters and one for its result, an Effect `execute`, and an inert
+  capability list. Source: [`apps/tuval/src/commands/spell.ts`](../apps/tuval/src/commands/spell.ts).
+- **palette** — the desk-level command overlay at the top center of the app, fixed width and never
+  anchored to a window, where a person types a spell and picks from ranked completions.
+- **the Tuval protocol** — the one versioned page-to-kernel wire: four Effect Schema messages
+  (`SpellCall`, `SpellReply`, `Snapshot`, `Patch`), one union per direction, JSON text only. Source:
+  [`apps/tuval/src/protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts).
+
 
 ---
 

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -169,6 +169,14 @@ The infra layer beneath the domain and fate layers. phoenix runs on [alchemy-eff
 - **One service per feature folder.** Reads + writes coexist.
 - **Testing strategy:** **two tiers** ([ADR 0082](../.decisions/0082-two-test-tiers-unit-integration.md)). `unit` — pure logic and Effect control flow with **no database**, substituting the `Drizzle` seam directly (`*.unit.test.ts`, offline in the `unit` Vitest project under `@effect/vitest`); `integration` — real behavior against **real remote D1** and the deployed worker (black-box HTTP, [alchemy-test-harness.md](./alchemy-test-harness.md)). `node:sqlite` / `makeSqliteTestDb` is **banned** as a backing. Litmus: *could this be wrong even if the DB behaved perfectly?* yes → `unit`, only-wrong-if-real-D1-differs → `integration`. See [effect-testing.md](./effect-testing.md).
 
+## Index — Tuval
+
+Tuval is the local runnable app under `apps/tuval` (ADR [0345](../.decisions/0345-tuval-lives-under-apps.md)): a program/process kernel plus the shell that drives it. It shares none of the fate/worker layers above.
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [tuval-spells.md](./tuval-spells.md) | **Reference.** The command framework: `defineSpell` and a spell's fields, how a program row declares `spells`, `buildRegistry` and the atomically swapped `SpellRegistry`, `Scope` and the kernel-side `WindowIndex`, the executor's call-in/reply-out contract and its error table, key bindings compiled at config load with per-binding recovery, the parser and the two completion ranking rules, and the four Tuval protocol messages | Writing a spell, wiring the registry, or touching anything under `apps/tuval/src/commands/` or `apps/tuval/src/protocol/` (ADR [0348](../.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md)) |
+
 ## Index — docs & meta patterns
 
 | Doc | Topic | Read when |

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -21,7 +21,7 @@ moved.
 | [`scope.ts`](../apps/tuval/src/commands/scope.ts) | `WindowIndex`, `WindowPlacement`, `Client`, `resolveScope` |
 | [`executor.ts`](../apps/tuval/src/commands/executor.ts) | `SpellExecutor`: one `SpellCall` in, one `SpellReply` out |
 | [`errors.ts`](../apps/tuval/src/commands/errors.ts) | `DuplicateSpellPath`, `SpellNotFound`, `NoSuchWindow`, `UnknownSpell`, `BadArgs`, `BadResult` |
-| [`index.ts`](../apps/tuval/src/commands/index.ts) | the slice's public surface |
+| [`index.ts`](../apps/tuval/src/commands/index.ts) | a partial barrel: `bindings/`, `errors`, `executor`, `parse/`, `registry`, `scope` and `spell`, but not `core/` or `bridge/`, which are imported from their own directories |
 | [`parse/tokenize.ts`](../apps/tuval/src/commands/parse/tokenize.ts) | the command line's lexer |
 | [`parse/reading.ts`](../apps/tuval/src/commands/parse/reading.ts) | the single walk `parse` and `complete` share |
 | [`parse/parse.ts`](../apps/tuval/src/commands/parse/parse.ts) | `parse`, `ParseResult`, `SpellCallDraft` |
@@ -74,8 +74,8 @@ stores that, because one table holds spells of every shape.
 The `capabilities` list reuses the kernel's `CapabilityRequest` record from
 [`registry/program.ts`](../apps/tuval/src/registry/program.ts). Nothing grants it, nothing checks
 it, nothing denies it. It is not a security boundary. The only thing standing between a calling
-program and the registry today is the bridge's allowlist, and that is data the calling program's own
-row supplies rather than a check the kernel makes.
+program and the registry today is the bridge's allowlist, and that list is whatever the caller
+passed to `SpellBridge.layer({allow})`, not a check the kernel makes.
 
 ## A program declares its spells
 
@@ -85,8 +85,9 @@ kernel's own `Registry` never reads it; only the spell registry does. Each entry
 `[programId, ...spell.path]`, so a program's spells are namespaced by its id and cannot collide with
 the core list by accident.
 
-The import is type-only, so the runtime dependency between the two slices stays one-directional:
-`commands/` depends on `registry/`, never the reverse.
+`registry/program.ts` imports `AnySpell` with `import type`, so nothing crosses at runtime in that
+direction and the runtime dependency stays one way: `commands/` reaches into `registry/`, never the
+reverse.
 
 ## The registry
 
@@ -156,7 +157,7 @@ The steps are lookup, decode the args, resolve the scope, run, encode the result
 
 | Failure | Becomes |
 |---|---|
-| no spell at the path | `UnknownSpell`, carrying the nearest registered path when one is near enough (Levenshtein, budget one third of the candidate's length) |
+| no spell at the path | `UnknownSpell`, carrying the nearest registered path when one is near enough. The measure is Levenshtein and the budget is `Math.max(1, Math.ceil(path.length / 3))`, so a short path still tolerates one edit |
 | `params` refuses the args | `BadArgs`, carrying the offending argument and what was expected |
 | the window is unknown | `NoSuchWindow` |
 | the spell's own error | a failure whose `tag` and `message` come off the error |
@@ -191,8 +192,8 @@ from `describeFile` ([`bindings/file.ts`](../apps/tuval/src/commands/bindings/fi
 the layer plus the path *inside* that layer's directory and falls back to the bare file name rather
 than leaking an absolute path.
 
-The reading is the parser's own `parse`, so a binding is read by exactly the rules the palette reads
-a typed line by. Compilation is against the registry as it stands, so re-run it after a `swap`: a
+The reading is the parser's own `parse`, so a binding is read by exactly the rules a typed line will be read
+by. Compilation is against the registry as it stands, so re-run it after a `swap`: a
 spell that went away turns its binding into an error on the next compile.
 
 ## The parser
@@ -217,12 +218,13 @@ single walk `parse` and `complete` share. Two rules make it incremental:
    Positional arguments fill parameters in declaration order; a token shaped `name=value` whose
    `name` is an unbound parameter binds by name. Rule 1 outranks rule 2 where they meet.
 
-Arguments bind as text. The only value the parser refuses is one outside an enum parameter's
-literals, which is the check the kernel would make anyway, made here so the palette cannot accept
-what the kernel rejects.
+Arguments bind as text. The only *value* the parser refuses is one outside an enum parameter's
+literals, which is the check the kernel would make anyway, made here so a page running this parser cannot
+accept what the kernel rejects. It also refuses a token with no parameter left to bind to, with
+`no further arguments`.
 
-`parse(input, index, snapshot)` ([`parse/parse.ts`](../apps/tuval/src/commands/parse/parse.ts))
-answers one of three:
+`parse(input, registry, snapshot)` ([`parse/parse.ts`](../apps/tuval/src/commands/parse/parse.ts))
+answers one of three (the second parameter is named `registry` and its type is `SpellIndex`):
 
 | `_tag` | Carries |
 |---|---|
@@ -249,7 +251,7 @@ module is total.
 
 ## Completion
 
-`complete(input, index, snapshot)`
+`complete(input, registry, snapshot)`
 ([`parse/complete.ts`](../apps/tuval/src/commands/parse/complete.ts)) ranks the candidates for the
 token under the caret. Two rules, and they never mix:
 
@@ -264,8 +266,10 @@ Which live set a parameter draws from is decided by its own name: a parameter na
 process, a program or a workspace offers that set, and one named for none of them offers no live
 values.
 
-Ties fall back to snapshot order, and `Array.prototype.sort` does it: ECMA-262 requires the sort to
-be stable (§23.1.3.30), so two calls over one snapshot return one list.
+Only the fuzzy rule sorts. The prefix rule is a plain `.filter`, so it hands back the registry or
+snapshot order untouched. In the fuzzy rule, ties fall back to snapshot order because
+`Array.prototype.sort` is required to be stable (ECMA-262 §23.1.3.30), so two calls over one
+snapshot return one list.
 
 A `Candidate` carries `value` (the text that replaces the caret's token), a `kind`
 (`segment` / `program` / `literal` / `window` / `process` / `workspace`), and the spell's sentence on
@@ -282,11 +286,12 @@ spells as one list.
 - **`help [path]`** ([`core/help.ts`](../apps/tuval/src/commands/core/help.ts)) lists every spell, or
   only the ones under one path. There is no help text in the file: a row's `describe` is the
   registry's own, and `usage` is derived by running `readParams` and `describeExpected` over the
-  description. A prefix that matches nothing answers `UnknownSpell` with a suggestion.
-  `segmentsOf` accepts both separators, because the palette reads spaces and a refusal renders dots.
+  description. A prefix that matches nothing answers `UnknownSpell`, carrying a suggestion only when
+  one is near enough. `segmentsOf` accepts both separators, because a typed line uses spaces and a
+  refusal renders dots.
 - **`spell list`** and **`spell describe <path>`**
   ([`core/spell.ts`](../apps/tuval/src/commands/core/spell.ts)) hand the same table to a program.
-  An agent driving Tuval discovers what it can call over exactly the wire a human's palette uses.
+  An agent driving Tuval discovers what it can call over exactly the wire a human's command line uses.
 - **`process spawn` / `process send` / `process read`**
   ([`core/process.ts`](../apps/tuval/src/commands/core/process.ts)) are the generic tools an agent
   program calls, written once for every program. Nothing in the file names a program. A
@@ -302,9 +307,14 @@ so a second agent program costs an adapter and no new spell.
 
 `call(path, args, scope)` refuses a path outside the allowlist with `SpellNotAllowed`
 ([`bridge/errors.ts`](../apps/tuval/src/commands/bridge/errors.ts)) before the executor is reached.
-The allowlist comes from the calling program's own registry row at layer build, which is what makes
-the bridge program-blind. `call` puts only the scope's window on the wire, so the executor
-re-resolves the process exactly as it does for a page.
+`SpellBridge.layer({allow})` takes that allowlist from whoever builds the layer, and today the only
+caller in the tree is `bridge/bridge.unit.test.ts`: nothing wires a program row's field into `allow`
+yet. What makes the file program-blind is that no program id is written in it. The intent recorded
+in the module's own docblock is that a calling program's registry row will supply the list, and that
+wiring is a later child's.
+
+`call` puts only the scope's window on the wire, so the executor re-resolves the process exactly as
+it does for a page.
 
 `SpellBridge.scripted(table)` answers from a fixed table and runs nothing, so it has no allowlist to
 enforce.
@@ -330,11 +340,11 @@ one shape. `PageToKernel` is the union of that one; `KernelToPage` is the union 
 
 `SpellOutcome` holds `ok` and its payload together, so a reply carrying both a result and an error
 cannot be built or decoded. `SpellFailure` carries `tag`, `message`, and optionally `path`,
-`expected` and `didYouMean`, which is enough to render an error inline under the palette input.
+`expected` and `didYouMean`, which is enough for a client to render an error inline under its input.
 
 The registry rides in the `Snapshot` as a `RegistryDescription`
 ([`protocol/registry-description.ts`](../apps/tuval/src/protocol/registry-description.ts)), so the
-palette completes without a round trip.
+parser's index is built without a round trip.
 
 JSON text is the whole wire. There is no binary framing and there are no channels. A program that
 streams raw bytes is what reopens that.
@@ -359,8 +369,14 @@ string, so `"tuval/ProcessId"` here and in `src/process/process.ts` are one type
 `applyPatch(snapshot, patch)` ([`protocol/patch.ts`](../apps/tuval/src/protocol/patch.ts)) encodes,
 walks each replace path, then decodes the result back as a `Snapshot`. The decode is the point: a
 patch that would leave the desk in a shape the protocol does not admit is refused with
-`PatchRefused` rather than delivered. A replace never creates a key, and a patch whose `rev` does
-not follow the snapshot's is refused.
+`PatchRefused` rather than delivered. A replace never creates a key.
+
+The revision check is `patch.rev <= snapshot.rev` and nothing more, so a patch is refused only when
+its `rev` is not strictly ahead of the snapshot's. A gap is admitted: a patch at `rev + 7` applies
+over `rev`. The message on the refusal, and the comment on `Patch` in
+[`protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts), both say "follow", which reads as
+successor and is wider than the check.
+[#7689](https://github.com/kamp-us/phoenix/issues/7689) is filed on the gap.
 
 [`protocol/issue.ts`](../apps/tuval/src/protocol/issue.ts) turns an Effect `SchemaError` into
 `{expected, at}`, which is what every refusal in the slice interpolates.
@@ -372,6 +388,9 @@ a window's box, the way VS Code, Neovim and tmux do it. The focused window suppl
 spell run from the palette still targets the focused window, because scope comes from focus and not
 from where the palette sits.
 
-It is not built yet. [#7643](https://github.com/kamp-us/phoenix/issues/7643) owns it, and it waits
-on `packages/design`. What the parser and the completion engine above owe it is already here: a
+It is not built yet. [#7643](https://github.com/kamp-us/phoenix/issues/7643) owns it, and it lands
+once [#7556](https://github.com/kamp-us/phoenix/issues/7556) and
+[#7561](https://github.com/kamp-us/phoenix/issues/7561) close and the epic PR
+[#7687](https://github.com/kamp-us/phoenix/pull/7687) merges. What the parser and the completion
+engine above owe it is already here: a
 total per-keystroke read, ranked candidates, and a refusal that points at a character offset.

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -1,0 +1,377 @@
+# Tuval spells: the command framework
+
+**Reference.** What the pieces of Tuval's command framework are, field by field, so a builder
+writing a new spell can look one up without reading the whole slice. The *why* (the thirteen
+[#7617](https://github.com/kamp-us/phoenix/issues/7617) rulings) is ADR
+[0348](../.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md); this page
+carries no argument for the design.
+
+Everything below is read off the code under [`apps/tuval/src/commands/`](../apps/tuval/src/commands)
+and [`apps/tuval/src/protocol/`](../apps/tuval/src/protocol). A companion unit test,
+[`apps/tuval/src/commands/pattern-doc-paths.unit.test.ts`](../apps/tuval/src/commands/pattern-doc-paths.unit.test.ts),
+asserts that every path this page cites is on disk, so the page cannot drift into naming a file that
+moved.
+
+## The pieces, by file
+
+| File | What is in it |
+|---|---|
+| [`spell.ts`](../apps/tuval/src/commands/spell.ts) | `Spell`, `defineSpell`, `SpellPath`, `Scope`, `renderPath`, the `WindowId` / `WorkspaceId` / `ClientId` brands |
+| [`registry.ts`](../apps/tuval/src/commands/registry.ts) | `buildRegistry`, `SpellRegistry`, `SpellRow`, `SpellNode`, `RegistryTable`, `describeSpell` |
+| [`scope.ts`](../apps/tuval/src/commands/scope.ts) | `WindowIndex`, `WindowPlacement`, `Client`, `resolveScope` |
+| [`executor.ts`](../apps/tuval/src/commands/executor.ts) | `SpellExecutor`: one `SpellCall` in, one `SpellReply` out |
+| [`errors.ts`](../apps/tuval/src/commands/errors.ts) | `DuplicateSpellPath`, `SpellNotFound`, `NoSuchWindow`, `UnknownSpell`, `BadArgs`, `BadResult` |
+| [`index.ts`](../apps/tuval/src/commands/index.ts) | the slice's public surface |
+| [`parse/tokenize.ts`](../apps/tuval/src/commands/parse/tokenize.ts) | the command line's lexer |
+| [`parse/reading.ts`](../apps/tuval/src/commands/parse/reading.ts) | the single walk `parse` and `complete` share |
+| [`parse/parse.ts`](../apps/tuval/src/commands/parse/parse.ts) | `parse`, `ParseResult`, `SpellCallDraft` |
+| [`parse/complete.ts`](../apps/tuval/src/commands/parse/complete.ts) | `complete`, `Candidate`, the two ranking rules |
+| [`parse/spell-index.ts`](../apps/tuval/src/commands/parse/spell-index.ts) | `buildSpellIndex`, `readParams`, `ParamSpec`, `describeExpected` |
+| [`parse/did-you-mean.ts`](../apps/tuval/src/commands/parse/did-you-mean.ts) | the one suggestion a refusal carries |
+| [`bindings/compile.ts`](../apps/tuval/src/commands/bindings/compile.ts) | `compileBindings`, `Binding`, `KeyBindings` |
+| [`bindings/errors.ts`](../apps/tuval/src/commands/bindings/errors.ts) | `BindingError`, `renderBindingErrors` |
+| [`bindings/file.ts`](../apps/tuval/src/commands/bindings/file.ts) | `describeFile`: how a config module is named in an error |
+| [`core/help.ts`](../apps/tuval/src/commands/core/help.ts) | the `help` spell and its row rendering |
+| [`core/spell.ts`](../apps/tuval/src/commands/core/spell.ts) | `spell list` and `spell describe` |
+| [`core/process.ts`](../apps/tuval/src/commands/core/process.ts) | `process spawn`, `process send`, `process read` |
+| [`core/index.ts`](../apps/tuval/src/commands/core/index.ts) | `helpSpells`, the three discovery spells as a list |
+| [`bridge/SpellBridge.ts`](../apps/tuval/src/commands/bridge/SpellBridge.ts) | the program-blind `list` / `call` surface an agent's SDK tool wraps |
+| [`bridge/errors.ts`](../apps/tuval/src/commands/bridge/errors.ts) | `SpellNotAllowed` |
+| [`protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts) | the four messages, the two unions, `PROTOCOL_VERSION` |
+| [`protocol/codec.ts`](../apps/tuval/src/protocol/codec.ts) | the four total encode / decode functions |
+| [`protocol/ids.ts`](../apps/tuval/src/protocol/ids.ts) | the wire's branded ids and scalars |
+| [`protocol/desk.ts`](../apps/tuval/src/protocol/desk.ts) | `Desk`, `Workspace`, `Window`, the layout tree |
+| [`protocol/process-row.ts`](../apps/tuval/src/protocol/process-row.ts) | `ProcessRow` as a snapshot carries it |
+| [`protocol/registry-description.ts`](../apps/tuval/src/protocol/registry-description.ts) | `SpellDescription`, `RegistryDescription`, `CapabilityRequest` |
+| [`protocol/patch.ts`](../apps/tuval/src/protocol/patch.ts) | `applyPatch` |
+| [`protocol/issue.ts`](../apps/tuval/src/protocol/issue.ts) | `firstSchemaIssue`, `describeSchemaError` |
+| [`protocol/json.ts`](../apps/tuval/src/protocol/json.ts) | the one `try`/`catch` JSON boundary |
+| [`protocol/errors.ts`](../apps/tuval/src/protocol/errors.ts) | `ProtocolRefused`, `PatchRefused` |
+| [`registry/program.ts`](../apps/tuval/src/registry/program.ts) | the program row, including its optional `spells` |
+
+## A spell
+
+`defineSpell` in [`spell.ts`](../apps/tuval/src/commands/spell.ts) is the identity function. Its
+whole job is inference: an `execute` that returns a Promise, or a `params` that is not an Effect
+`Schema`, is a compile error at the definition site.
+
+| Field | Type | Notes |
+|---|---|---|
+| `path` | `readonly [string, ...string[]]` | non-empty in the type, so an empty path is unrepresentable; lowercase English segments (`["window", "close"]`) |
+| `describe` | `string` | one user-facing sentence, written once and rendered by every surface |
+| `params` | `Schema.Top` | an Effect `Schema`; the executor decodes the call's `args` against it |
+| `result` | `Schema.Top` | the executor encodes the return value against it |
+| `execute` | `(args, scope) => Effect` | failures and service needs ride the spell's own type |
+| `capabilities` | `ReadonlyArray<CapabilityRequest>` | **declared and checked by nothing**; see below |
+
+`renderPath` is how a path reads in a refusal or a description: `window.close`.
+
+`AnySpell` is the spell with its parameter, result, error and requirement types erased. The registry
+stores that, because one table holds spells of every shape.
+
+### Capabilities are inert
+
+The `capabilities` list reuses the kernel's `CapabilityRequest` record from
+[`registry/program.ts`](../apps/tuval/src/registry/program.ts). Nothing grants it, nothing checks
+it, nothing denies it. It is not a security boundary. The only thing standing between a calling
+program and the registry today is the bridge's allowlist, and that is data the calling program's own
+row supplies rather than a check the kernel makes.
+
+## A program declares its spells
+
+A program row's optional `spells` field
+([`registry/program.ts`](../apps/tuval/src/registry/program.ts)) is a list of `AnySpell`. The
+kernel's own `Registry` never reads it; only the spell registry does. Each entry is registered under
+`[programId, ...spell.path]`, so a program's spells are namespaced by its id and cannot collide with
+the core list by accident.
+
+The import is type-only, so the runtime dependency between the two slices stays one-directional:
+`commands/` depends on `registry/`, never the reverse.
+
+## The registry
+
+`buildRegistry({core, programs})` in
+[`registry.ts`](../apps/tuval/src/commands/registry.ts) is registration. It is a pure Effect over
+the core spell list and the program rows, and it produces a `RegistryTable`:
+
+- `root`, a trie of `SpellNode`s keyed by path segment; a node carries a `SpellRow` when a spell is
+  registered at exactly its path.
+- `rows`, the flat list `list` and `describe` read.
+
+Two spells claiming one path fail with `DuplicateSpellPath`, which names the path and both sources
+(`describeSource` renders "the core spell list" or `program "<id>"`).
+
+`SpellRegistry` is a `Context.Service` over one `Ref` holding the table:
+
+| Member | Answers |
+|---|---|
+| `lookup(path)` | the `SpellRow`, or `SpellNotFound` |
+| `list` | every `SpellRow` |
+| `describe` | every row as a `SpellDescription` |
+| `swap(table)` | replaces the whole table |
+
+Every read is a single `Ref.get` and `swap` is a single `Ref.set`, so a config reload replaces every
+program's spells at once and no reader ever walks a half-replaced table.
+
+Two layers build it: `SpellRegistry.layer(table)` over an already-built table, and
+`SpellRegistry.scripted(spells)` over a bare core list, which is the test seam.
+
+`describeSpell(row)` is the serializable face of a spell: its path, its sentence, its `params`
+rendered by `Schema.toJsonSchemaDocument`, and its capability list. The closure never leaves the
+kernel.
+
+## Scope, and who resolves it
+
+`Scope` ([`spell.ts`](../apps/tuval/src/commands/spell.ts)) is where a call came from:
+
+```ts
+interface Scope {
+	readonly window?: WindowId;
+	readonly process?: ProcessId;
+	readonly workspace: WorkspaceId;
+	readonly client: ClientId;
+}
+```
+
+A workspace and a client are always known. A window and a process are known only when the caller was
+inside one.
+
+`resolveScope` ([`scope.ts`](../apps/tuval/src/commands/scope.ts)) builds it. The wire lets a page
+name the window it called from and nothing else: the process and the workspace are looked up through
+`WindowIndex`, so a page cannot address another process by putting an id on the wire. A spell that
+legitimately targets another process takes that id as a parameter of its own `params`.
+
+`WindowIndex` is an interface this slice declares and the shell implements. Until the shell adopts
+it, `WindowIndex.scripted(table)` answers from a fixture. A window the index does not hold is
+`NoSuchWindow`.
+
+## The executor
+
+`SpellExecutor.execute(call, client)`
+([`executor.ts`](../apps/tuval/src/commands/executor.ts)) is a `SpellCall` in and a `SpellReply`
+out. Its error channel is `never`: every way a call can go wrong becomes a failed outcome on the
+reply, so a caller has exactly one thing to read.
+
+The steps are lookup, decode the args, resolve the scope, run, encode the result.
+
+| Failure | Becomes |
+|---|---|
+| no spell at the path | `UnknownSpell`, carrying the nearest registered path when one is near enough (Levenshtein, budget one third of the candidate's length) |
+| `params` refuses the args | `BadArgs`, carrying the offending argument and what was expected |
+| the window is unknown | `NoSuchWindow` |
+| the spell's own error | a failure whose `tag` and `message` come off the error |
+| `result` refuses the return value | `BadResult`, and the fiber **dies**; that is the spell author's bug, not the caller's |
+
+A failure's `path` is always the call's own, so a spell's private error cannot claim a different
+one.
+
+`AnySpell` erases each spell's requirements, so nothing checks that the runtime carries what a
+registered spell needs. The composition root that builds the registry owes those services.
+
+## Key bindings
+
+A binding is written the way a person types it (`"window close"`), and a key router needs
+`{path, args}`. `compileBindings(source, table)`
+([`bindings/compile.ts`](../apps/tuval/src/commands/bindings/compile.ts)) does that conversion once,
+at config load.
+
+A `KeyBindings` record maps a key string to either a command string or
+`{command, repeat?}`. The output is `{bindings, errors}`:
+
+- Each compiled `Binding` carries `key`, `path`, `args` decoded against the spell's real `params`
+  (so a `count` is a number, not `"3"`), and `repeat` only when the config asked for it.
+- Each command that does not compile becomes a `BindingError` and is dropped. Recovery is per
+  binding: a bad one costs its own key and nothing else. The loader's whole-config fallback stays
+  reserved for an unimportable module or a top-level schema error.
+
+`BindingError` ([`bindings/errors.ts`](../apps/tuval/src/commands/bindings/errors.ts)) carries five
+things and renders them in that order: which module, which key, the character offset inside the
+command string, what was expected, and the nearest thing the author may have meant. `file` comes
+from `describeFile` ([`bindings/file.ts`](../apps/tuval/src/commands/bindings/file.ts)), which names
+the layer plus the path *inside* that layer's directory and falls back to the bare file name rather
+than leaking an absolute path.
+
+The reading is the parser's own `parse`, so a binding is read by exactly the rules the palette reads
+a typed line by. Compilation is against the registry as it stands, so re-run it after a `swap`: a
+spell that went away turns its binding into an error on the next compile.
+
+## The parser
+
+The parser is total, synchronous and never throws, because the page runs it on every keystroke and
+the kernel runs it over the key bindings at load.
+
+`tokenize(input)` ([`parse/tokenize.ts`](../apps/tuval/src/commands/parse/tokenize.ts)) is the
+lexer. Whitespace separates, double quotes group, a backslash escapes the next character inside a
+quoted run as well as outside one. Every `Token` carries `text` (quotes and escapes resolved) plus
+the raw `start` and `end` offsets, because a refusal points at a position on a line the user is
+still typing. The `Tokenization` also reports `trailingSeparator` (the caret sits on a fresh empty
+token) and `openQuote`.
+
+`read(input, registry)` ([`parse/reading.ts`](../apps/tuval/src/commands/parse/reading.ts)) is the
+single walk `parse` and `complete` share. Two rules make it incremental:
+
+1. **The caret's token is still being typed.** It is the last token, or a fresh empty one when the
+   line ends on a separator. A committed token that names nothing is a refusal; the caret's token
+   only has to be a prefix of something.
+2. **The deepest registered spell on the walk wins**, and every token after its path is an argument.
+   Positional arguments fill parameters in declaration order; a token shaped `name=value` whose
+   `name` is an unbound parameter binds by name. Rule 1 outranks rule 2 where they meet.
+
+Arguments bind as text. The only value the parser refuses is one outside an enum parameter's
+literals, which is the check the kernel would make anyway, made here so the palette cannot accept
+what the kernel rejects.
+
+`parse(input, index, snapshot)` ([`parse/parse.ts`](../apps/tuval/src/commands/parse/parse.ts))
+answers one of three:
+
+| `_tag` | Carries |
+|---|---|
+| `Complete` | a `SpellCallDraft`: `path` plus `args` as token text. The correlation id and the calling window are the caller's, so they are not on the draft |
+| `Partial` | the spell named so far when there is one, the parameter the caret is on, and the ranked candidates |
+| `Refused` | the offending token's offset, what was expected, and a suggestion when there is one |
+
+### The spell index
+
+`buildSpellIndex(descriptions)`
+([`parse/spell-index.ts`](../apps/tuval/src/commands/parse/spell-index.ts)) builds the trie the
+parser walks, from the protocol's `RegistryDescription`. That is the same value a `Snapshot`
+carries, so the page and the kernel run this parser over identical input. A `RegistryTable` would
+carry richer types and the page cannot hold one: it has descriptions, never closures.
+
+`readParams` flattens a description's JSON-Schema `params` to an ordered `ParamSpec` list. Two
+properties of that rendering are load-bearing, both read off `Schema.toJsonSchemaDocument` at the
+`catalogs.tuval` pin (effect `4.0.0-rc.112`): the `properties` key order is the declaration order of
+`Schema.Struct`, which is the positional order of the parameters, and a `Schema.Literals` parameter
+arrives as `{"type": "string", "enum": [...]}`. Everything else is read defensively, because the
+module is total.
+
+`describeExpected(param)` renders one slot: `<name>`, or the literals joined by `|`.
+
+## Completion
+
+`complete(input, index, snapshot)`
+([`parse/complete.ts`](../apps/tuval/src/commands/parse/complete.ts)) ranks the candidates for the
+token under the caret. Two rules, and they never mix:
+
+1. **Exact prefix, for names the system defines.** Spell path segments, program ids, and an enum
+   parameter's literals. A name is offered only when the caret's text is a prefix of it, in registry
+   or snapshot order. `win` never reaches `wizard-inspect`.
+2. **Fuzzy subsequence, for values a user named.** Window ids, process ids, workspace ids and
+   workspace names off the snapshot. The caret's characters must appear in order; the tighter and
+   earlier the run, the higher the rank. `scr` reaches `scratch`.
+
+Which live set a parameter draws from is decided by its own name: a parameter named for a window, a
+process, a program or a workspace offers that set, and one named for none of them offers no live
+values.
+
+Ties fall back to snapshot order, and `Array.prototype.sort` does it: ECMA-262 requires the sort to
+be stable (§23.1.3.30), so two calls over one snapshot return one list.
+
+A `Candidate` carries `value` (the text that replaces the caret's token), a `kind`
+(`segment` / `program` / `literal` / `window` / `process` / `workspace`), and the spell's sentence on
+a segment that completes a whole spell.
+
+Both rules run synchronously against the snapshot the page already holds, so completion needs no
+round trip.
+
+## The core spells
+
+`helpSpells` ([`core/index.ts`](../apps/tuval/src/commands/core/index.ts)) is the three discovery
+spells as one list.
+
+- **`help [path]`** ([`core/help.ts`](../apps/tuval/src/commands/core/help.ts)) lists every spell, or
+  only the ones under one path. There is no help text in the file: a row's `describe` is the
+  registry's own, and `usage` is derived by running `readParams` and `describeExpected` over the
+  description. A prefix that matches nothing answers `UnknownSpell` with a suggestion.
+  `segmentsOf` accepts both separators, because the palette reads spaces and a refusal renders dots.
+- **`spell list`** and **`spell describe <path>`**
+  ([`core/spell.ts`](../apps/tuval/src/commands/core/spell.ts)) hand the same table to a program.
+  An agent driving Tuval discovers what it can call over exactly the wire a human's palette uses.
+- **`process spawn` / `process send` / `process read`**
+  ([`core/process.ts`](../apps/tuval/src/commands/core/process.ts)) are the generic tools an agent
+  program calls, written once for every program. Nothing in the file names a program. A
+  `SpawnedProcesses` service retains the handle of every process it spawns, because the process
+  table exposes rows and no dispatch; `send` and `read` answer `UnknownProcess` for a process this
+  service did not spawn.
+
+### The bridge
+
+`SpellBridge` ([`bridge/SpellBridge.ts`](../apps/tuval/src/commands/bridge/SpellBridge.ts)) is
+`list` and `call`, and neither mentions a program. An agent program's SDK tool is a wrapper over it,
+so a second agent program costs an adapter and no new spell.
+
+`call(path, args, scope)` refuses a path outside the allowlist with `SpellNotAllowed`
+([`bridge/errors.ts`](../apps/tuval/src/commands/bridge/errors.ts)) before the executor is reached.
+The allowlist comes from the calling program's own registry row at layer build, which is what makes
+the bridge program-blind. `call` puts only the scope's window on the wire, so the executor
+re-resolves the process exactly as it does for a page.
+
+`SpellBridge.scripted(table)` answers from a fixed table and runs nothing, so it has no allowlist to
+enforce.
+
+## The Tuval protocol
+
+One versioned page-to-kernel wire
+([`protocol/messages.ts`](../apps/tuval/src/protocol/messages.ts)). `PROTOCOL_VERSION` is `1` and
+every message carries it, so a page and a kernel from different builds refuse each other by decode
+rather than by behaviour.
+
+Four messages, one `Schema.Class` each:
+
+| Message | Direction | Fields |
+|---|---|---|
+| `SpellCall` | page to kernel | `id`, `path`, `args` (opaque here), optional `window` |
+| `SpellReply` | kernel to page | `id`, `outcome`: `{ok: true, result}` or `{ok: false, error}` |
+| `Snapshot` | kernel to page | `rev`, `desk`, `windows`, `processes`, `registry` |
+| `Patch` | kernel to page | `rev`, `changes`: path-addressed replaces |
+
+`SpellCall` is the only page-to-kernel message: windows, keys and the command line all speak this
+one shape. `PageToKernel` is the union of that one; `KernelToPage` is the union of the other three.
+
+`SpellOutcome` holds `ok` and its payload together, so a reply carrying both a result and an error
+cannot be built or decoded. `SpellFailure` carries `tag`, `message`, and optionally `path`,
+`expected` and `didYouMean`, which is enough to render an error inline under the palette input.
+
+The registry rides in the `Snapshot` as a `RegistryDescription`
+([`protocol/registry-description.ts`](../apps/tuval/src/protocol/registry-description.ts)), so the
+palette completes without a round trip.
+
+JSON text is the whole wire. There is no binary framing and there are no channels. A program that
+streams raw bytes is what reopens that.
+
+### Codec, ids, patch
+
+[`protocol/codec.ts`](../apps/tuval/src/protocol/codec.ts) exports four functions,
+`decodePageMessage` / `decodeKernelMessage` / `encodePageMessage` / `encodeKernelMessage`. A decode
+is total: it answers with the message or with `ProtocolRefused`
+([`protocol/errors.ts`](../apps/tuval/src/protocol/errors.ts)) naming the direction and the schema
+issue. Nothing throws and nothing resolves a malformed frame to a partial value.
+
+[`protocol/json.ts`](../apps/tuval/src/protocol/json.ts) holds the one native `try`/`catch`, on
+purpose: parsing an untrusted string needs it, the repo bans it inside Effect control flow, so the
+boundary lives in its own module with no `effect` import and the codec wraps it.
+
+[`protocol/ids.ts`](../apps/tuval/src/protocol/ids.ts) re-declares `ProcessId` and `ProgramId`
+rather than importing them from the kernel slices, which keeps the protocol module independent by
+construction. It costs nothing at the type level: `Schema.brand` is keyed on the literal brand
+string, so `"tuval/ProcessId"` here and in `src/process/process.ts` are one type to the checker.
+
+`applyPatch(snapshot, patch)` ([`protocol/patch.ts`](../apps/tuval/src/protocol/patch.ts)) encodes,
+walks each replace path, then decodes the result back as a `Snapshot`. The decode is the point: a
+patch that would leave the desk in a shape the protocol does not admit is refused with
+`PatchRefused` rather than delivered. A replace never creates a key, and a patch whose `rev` does
+not follow the snapshot's is refused.
+
+[`protocol/issue.ts`](../apps/tuval/src/protocol/issue.ts) turns an Effect `SchemaError` into
+`{expected, at}`, which is what every refusal in the slice interpolates.
+
+## The palette
+
+The palette is one desk-level overlay at the top center of the whole app, fixed width, never tied to
+a window's box, the way VS Code, Neovim and tmux do it. The focused window supplies scope only: a
+spell run from the palette still targets the focused window, because scope comes from focus and not
+from where the palette sits.
+
+It is not built yet. [#7643](https://github.com/kamp-us/phoenix/issues/7643) owns it, and it waits
+on `packages/design`. What the parser and the completion engine above owe it is already here: a
+total per-keystroke read, ranked candidates, and a refusal that points at a character offset.

--- a/apps/tuval/src/commands/pattern-doc-paths.unit.test.ts
+++ b/apps/tuval/src/commands/pattern-doc-paths.unit.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The drift guard on `.patterns/tuval-spells.md`: every repo path that page links to has to exist.
+ *
+ * A reference page whose file table names a module that moved sends its reader nowhere, and nothing
+ * else in CI reads it. So this resolves each markdown link target the doc carries and stats it. The
+ * doc must also carry at least one, otherwise a page that lost its whole table would pass silently.
+ */
+
+import {existsSync} from "node:fs";
+import {readFile} from "node:fs/promises";
+import {join, normalize, resolve} from "node:path";
+import {describe, expect, it} from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const docPath = join(repoRoot, ".patterns/tuval-spells.md");
+
+/** Every `[text](target)` whose target is a relative path, deduped, in document order. */
+const linkedPaths = (markdown: string): ReadonlyArray<string> => {
+	const targets = new Set<string>();
+	for (const match of markdown.matchAll(/\]\((\.[^)\s]+)\)/g)) {
+		const target = match[1];
+		if (target !== undefined) targets.add(target.split("#")[0] ?? target);
+	}
+	return [...targets];
+};
+
+describe(".patterns/tuval-spells.md", () => {
+	it("links only to paths that exist", async () => {
+		const markdown = await readFile(docPath, "utf8");
+		const targets = linkedPaths(markdown);
+
+		expect(targets.length).toBeGreaterThan(0);
+
+		const missing = targets.filter(
+			(target) => !existsSync(normalize(join(repoRoot, ".patterns", target))),
+		);
+		expect(missing).toEqual([]);
+	});
+
+	it("cites the code it describes", async () => {
+		const markdown = await readFile(docPath, "utf8");
+		const cited = linkedPaths(markdown).filter((target) => target.includes("apps/tuval/src/"));
+
+		expect(cited.length).toBeGreaterThan(20);
+	});
+});


### PR DESCRIPTION
The two documents that make Tuval's command framework a shape a future builder reads before writing a spell, plus the glossary rows, written after the code landed so every claim is grounded in `epic/7627` rather than the plan.

**`.patterns/tuval-spells.md`** is **reference** (Diátaxis): a look-it-up account of the machinery structured to match the code, with no ordered sequence for a reader to perform and no argument for the design. It covers `defineSpell` and a spell's six fields, how a program row declares `spells`, `buildRegistry` and the atomically swapped `SpellRegistry`, `Scope` and the kernel-side `WindowIndex`, the executor's call-in/reply-out contract and its failure table, key bindings compiled at config load with per-binding recovery, the tokenizer/reading/parse/complete split and the two ranking rules, the core spells and the program-blind bridge, and the four Tuval protocol messages. Every code reference is a link to the file the shape lives in. Indexed under a new `## Index — Tuval` heading in `.patterns/index.md`.

**ADR 0348** is the why: the thirteen #7617 rulings in one table, each with the founder's own answer and the file it landed in, plus the 2026-09-03 walk correction on #7643 that supersedes R2.3's placement (the palette is one desk-level overlay at the top center of the whole app, VS Code style, never anchored to a window; the focused window supplies scope only). It names `@usirin/spellbook` (`usirin/monorepo`, `packages/spellbook/src/spellbook.ts`) and wormhole (`usirin/wormhole`, `packages/wormhole/src/Protocol.ts`) as prior art read and rewritten, never imported, and lists what is deliberately left out: capability enforcement, scripting and macros, binary channels on the protocol, the palette itself, and the shell and agent children that adopt the registry as they are built.

**`.glossary/LANGUAGE.md`** gains `spell`, `registry`, `palette`, `scope` and `the Tuval protocol`, one English entry each, beside the existing program/process/window rows. `registry` is ambiguous in Tuval prose, so its entry disambiguates the spell registry from the kernel's program registry; `palette` is qualified against apps/web's ⌘K palette (ADR 0186) and the reaction palette (ADR 0139).

**The drift guard** is `apps/tuval/src/commands/pattern-doc-paths.unit.test.ts`: it resolves every relative markdown link the pattern doc carries and asserts the target exists, and asserts the doc still cites more than twenty `apps/tuval/src/` paths so a page that lost its whole file table cannot pass. Flip-verified by adding a link to a file that does not exist and watching it red.

**Repair round 1** answers the review-doc FAIL at `cdc1ee2d`. D1: added the `registry` and `scope` rows. D2: the bridge allowlist now says what the code does, `SpellBridge.layer({allow})` takes it from its caller and no composition root wires a program row into it, in both documents. D3: the patch rule is stated as `patch.rev <= snapshot.rev`, so a gap is admitted, with #7689 named. All ten non-blocking imprecisions are fixed, and every remaining claim that named the palette as a working surface is reworded, since the palette is not built.

**Reviewer, start here:** the ADR's ruling table against the #7617 comments, and the pattern doc's claims against the source. Two claims are the ones most worth checking: that the registry's `swap` is a single `Ref.set` so no reader walks a half-replaced table (`commands/registry.ts`), and the two `Schema.toJsonSchemaDocument` properties the parser leans on at the `catalogs.tuval` rc.112 pin (`parse/spell-index.ts`).

Patterns: [.patterns/index.md](.patterns/index.md) (the "when to add a new pattern doc" admission criteria, current-shape path), [.patterns/effect-testing.md](.patterns/effect-testing.md) (unit tier, `*.unit.test.ts`, no database), [.patterns/unconditional-test-assertions.md](.patterns/unconditional-test-assertions.md) (no `expect` nested in an `if`), [.patterns/worktree-agent-constraints.md](.patterns/worktree-agent-constraints.md) (the Bash-cwd-reset rule for a worktree lane).

Fixes #7644

## Deviations

- **Out-of-scope change** — **Said:** #7644 names the pattern doc, the ADR, the glossary rows and one unit test. **Did:** also added a `## Index — Tuval` section heading to `.patterns/index.md` rather than filing the new row under an existing heading. **Why:** every existing heading names a phoenix layer (Effect domain, fate, UI, alchemy, CI) and Tuval shares none of them, so the row had no honest home. **Disposition:** stated here.
- **Declined guidance** — **Said:** the brief asks for no em dashes in new prose. **Did:** kept the em dash in the new `.glossary/LANGUAGE.md` term rows (`**spell** — one addressable command...`) and in the ADR's `# NNNN — title` heading. **Why:** both are the file's own structural separator, matched by every sibling row and every other ADR; breaking it in those rows would read as a typo. All other new prose carries none. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** acceptance criterion 4 on #7644 asks for `spell`, `palette` and `the Tuval protocol`, and the 2026-09-03 founder-walk amendment on the same issue names `spell`, `registry`, `palette`, `scope`. **Did:** landed the union of both, five entries, and qualified `registry` across its two Tuval senses and `palette` against ADRs 0186 and 0139. **Why:** the criteria list and the amendment disagree on which rows are owed, and every one of the five is a noun the new prose leans on; round 1 shipped only the criteria's three, which the reviewer correctly read as an undisclosed gap against the amendment. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the doc describes `applyPatch`'s revision rule. **Did:** described the rule the code has (`patch.rev <= snapshot.rev`, so a revision gap is admitted) and named #7689 rather than tightening the check, and left the "does not follow" wording in `protocol/patch.ts`'s own refusal message and `protocol/messages.ts`'s comment untouched. **Why:** #7644 is a docs child and the source lives on merged sibling children; changing either would be an unreviewed code change on this PR. **Disposition:** stated here, tracked on #7689.
