### PR TITLE
feat: Tuval commands: boot wiring and the agent proof — an AI agent process enumerates and calls every spell a human can

### DIFF
--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -175,7 +175,7 @@ Tuval is the local runnable app under `apps/tuval` (ADR [0345](../.decisions/034
 
 | Doc | Topic | Read when |
 |---|---|---|
-| [tuval-spells.md](./tuval-spells.md) | **Reference.** The command framework: `defineSpell` and a spell's fields, how a program row declares `spells`, `buildRegistry` and the atomically swapped `SpellRegistry`, `Scope` and the kernel-side `WindowIndex`, the executor's call-in/reply-out contract and its error table, key bindings compiled at config load with per-binding recovery, the parser and the two completion ranking rules, and the four Tuval protocol messages | Writing a spell, wiring the registry, or touching anything under `apps/tuval/src/commands/` or `apps/tuval/src/protocol/` (ADR [0348](../.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md)) |
+| [tuval-spells.md](./tuval-spells.md) | **Reference.** The command framework: `defineSpell` and a spell's fields, how a program row declares `spells`, `buildRegistry` and the atomically swapped `SpellRegistry`, `Scope` and the kernel-side `WindowIndex`, the executor's call-in/reply-out contract and its error table, key bindings compiled at config load with per-binding recovery, the one cell `SpellSet` holds the table and those bindings in so a reload replaces both at once, the parser and the two completion ranking rules, and the four Tuval protocol messages | Writing a spell, wiring the registry, or touching anything under `apps/tuval/src/commands/` or `apps/tuval/src/protocol/` (ADR [0348](../.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md)) |
 
 ## Index — docs & meta patterns
 

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -17,7 +17,8 @@ moved.
 | File | What is in it |
 |---|---|
 | [`spell.ts`](../apps/tuval/src/commands/spell.ts) | `Spell`, `defineSpell`, `SpellPath`, `Scope`, `renderPath`, the `WindowId` / `WorkspaceId` / `ClientId` brands |
-| [`registry.ts`](../apps/tuval/src/commands/registry.ts) | `buildRegistry`, `SpellRegistry`, `SpellRow`, `SpellNode`, `RegistryTable`, `describeSpell` |
+| [`registry.ts`](../apps/tuval/src/commands/registry.ts) | `buildRegistry`, `SpellRegistry`, `SpellRow`, `SpellNode`, `RegistryTable`, `lookupRow`, `describeSpell` |
+| [`spell-set.ts`](../apps/tuval/src/commands/spell-set.ts) | `SpellSet`: the table and the key bindings compiled against it, in one cell |
 | [`scope.ts`](../apps/tuval/src/commands/scope.ts) | `WindowIndex`, `WindowPlacement`, `Client`, `resolveScope` |
 | [`executor.ts`](../apps/tuval/src/commands/executor.ts) | `SpellExecutor`: one `SpellCall` in, one `SpellReply` out |
 | [`errors.ts`](../apps/tuval/src/commands/errors.ts) | `DuplicateSpellPath`, `SpellNotFound`, `NoSuchWindow`, `UnknownSpell`, `BadArgs`, `BadResult` |
@@ -114,8 +115,12 @@ Two spells claiming one path fail with `DuplicateSpellPath`, which names the pat
 Every read is a single `Ref.get` and `swap` is a single `Ref.set`, so a config reload replaces every
 program's spells at once and no reader ever walks a half-replaced table.
 
-Two layers build it: `SpellRegistry.layer(table)` over an already-built table, and
-`SpellRegistry.scripted(spells)` over a bare core list, which is the test seam.
+`lookupRow(table, path)` is the trie walk itself, exported so the registry, the binding compiler
+and `SpellSet` take one walk rather than three.
+
+Three layers build the service. `SpellRegistry.layer(table)` holds a table of its own and
+`SpellRegistry.scripted(spells)` builds one from a bare core list, which is the test seam; the
+third is `SpellSet.layer`, below, which is what boot uses.
 
 `describeSpell(row)` is the serializable face of a spell: its path, its sentence, its `params`
 rendered by `Schema.toJsonSchemaDocument`, and its capability list. The closure never leaves the
@@ -193,8 +198,44 @@ the layer plus the path *inside* that layer's directory and falls back to the ba
 than leaking an absolute path.
 
 The reading is the parser's own `parse`, so a binding is read by exactly the rules a typed line will be read
-by. Compilation is against the registry as it stands, so re-run it after a `swap`: a
-spell that went away turns its binding into an error on the next compile.
+by. Compilation is against the registry as it stands, so a spell that goes away turns its binding
+into an error on the next compile — which is why nothing calls `compileBindings` directly except
+`SpellSet`, below, where re-running it is not something a caller can forget.
+
+## The set boot holds
+
+`SpellSet` ([`spell-set.ts`](../apps/tuval/src/commands/spell-set.ts)) is the registry table, the
+config's key sources and the bindings compiled from them, held in **one** `Ref` and written in one
+`Ref.set`. Two cells would be two states to keep in step, and keeping them in step is the whole
+job: a binding is only ever as valid as the table it was compiled against.
+
+Its layer hands out `SpellSet` **and** `SpellRegistry`, both reading that one cell, so a reader's
+single `Ref.get` sees both halves of one config. Every write goes through the same private step,
+which compiles the bindings against the table it is about to store:
+
+| Entry | What it does |
+|---|---|
+| `SpellSet.read` | the table, its key sources and the compiled bindings, as one value |
+| `SpellSet.reload(input)` | a fresh table from new program rows, fresh bindings, installed in one write |
+| `SpellRegistry.swap(table)` | the narrower entry, which recompiles the bindings rather than leaving them behind |
+
+`everyPath(table)` is the whole registry as an allowlist, which is what `src/boot.ts` passes the
+bridge today.
+
+Boot joins the set, the executor, the bridge and `SpawnedProcesses` to the kernel's layers
+(`start` in [`boot.ts`](../apps/tuval/src/boot.ts)), reports the spell count beside the program
+count, and prints one line per key binding that did not compile. `Booted.reload` reads the config
+layers again and calls `SpellSet.reload`; it replaces the spells and the bindings and nothing else,
+so processes already running keep running under the rows they were spawned from. The two proofs are
+[`src/reload-proof.unit.test.ts`](../apps/tuval/src/reload-proof.unit.test.ts) (the swap, with a
+reader watching across it) and
+[`src/commands/agent-proof.unit.test.ts`](../apps/tuval/src/commands/agent-proof.unit.test.ts) (a
+scripted program enumerating the registry over the wire and calling every spell in it).
+
+A config module is imported with a per-load number on its URL
+([`config.ts`](../apps/tuval/src/config.ts)), because Node caches an ES module by URL for the life
+of the process and a reload of the same path would otherwise answer with the config the first boot
+read.
 
 ## The parser
 
@@ -307,11 +348,13 @@ so a second agent program costs an adapter and no new spell.
 
 `call(path, args, scope)` refuses a path outside the allowlist with `SpellNotAllowed`
 ([`bridge/errors.ts`](../apps/tuval/src/commands/bridge/errors.ts)) before the executor is reached.
-`SpellBridge.layer({allow})` takes that allowlist from whoever builds the layer, and today the only
-caller in the tree is `bridge/bridge.unit.test.ts`: nothing wires a program row's field into `allow`
-yet. What makes the file program-blind is that no program id is written in it. The intent recorded
-in the module's own docblock is that a calling program's registry row will supply the list, and that
-wiring is a later child's.
+`SpellBridge.layer({allow})` takes that allowlist from whoever builds the layer, and no program
+row's field is wired into it: `src/boot.ts` passes `everyPath` over the table as it stands at boot,
+and `bridge/bridge.unit.test.ts` passes its own. What makes the file program-blind is that no
+program id is written in it. The intent recorded in the module's own docblock is that a calling
+program's registry row will supply the list, and that wiring is a later child's. Because the layer
+captures the list at build, a config reload leaves it behind while the registry moves on —
+[#7743](https://github.com/kamp-us/phoenix/issues/7743) is filed on that.
 
 `call` puts only the scope's window on the wire, so the executor re-resolves the process exactly as
 it does for a page.

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -43,7 +43,7 @@ refusals; `--project <dir>` runs against another project's `.tuval/`. A path nam
 must exist.
 
 ```
-tuval: booted — 2 program(s) registered from …/apps/tuval/.tuval/tuval.config.ts; 2 process(es) live, 0 restored from …/apps/tuval/.tuval
+tuval: booted — 2 program(s), 6 spell(s) registered from …/apps/tuval/.tuval/tuval.config.ts; 2 process(es) live, 0 restored from …/apps/tuval/.tuval
 tuval: process counter program=counter parent=- ports=ticks:out(count/v1) state=running@0
 tuval: process log program=log parent=counter ports=ticks:in(count/v1) state=running@0
 tuval: running — Ctrl-C stops and checkpoints
@@ -69,7 +69,8 @@ This repo's `apps/tuval/.tuval/tuval.config.ts` is the project layer `pnpm dev` 
 the checkpoints land beside it (that dir is gitignored except for the config).
 
 A config module default-exports one versioned object, `TuvalConfigInput` from `src/config.ts`:
-`version: 1`, `programs`, and an optional `graph`. A row is a `Program` (`src/registry/program.ts`):
+`version: 1`, `programs`, an optional `graph`, and an optional `keys` (see "Spells"). A row is a
+`Program` (`src/registry/program.ts`):
 one stable id, a private Demlik core machine, public typed ports, a `receive` map that turns what
 arrives on each in-port into the program's own Msg, host handlers, a capability request list, an
 optional renderer reference, and the identity / capability / placement records as inert data — the
@@ -98,6 +99,61 @@ place and the reason:
 tuval: refusing to boot — config module /path/to/tuval.config.ts: module threw while loading: boom
 tuval: refusing to boot — config module /path/to/tuval.config.ts: not a v1 config at graph: Expected object
 ```
+
+## Spells
+
+A spell is one command anything can call by path: `window close`, `spell list`, `process spawn`.
+It carries a sentence describing itself, an Effect `Schema` for its arguments, another for its
+result, and the Effect that runs it — so the same definition is what the command line completes
+against, what a key binding compiles to, and what a program calls over the wire. The kernel
+registers its own list at boot (`help`, `spell list`, `spell describe`, `process spawn`,
+`process send`, `process read`), and boot reports the total beside the program count.
+
+A program row declares its own in a `spells` field, and each one is registered under the program's
+id, so `echo`'s `repeat` is `echo repeat` and no program can collide with another or with the
+kernel's list:
+
+```ts
+import {Effect, Schema} from "effect";
+import {defineSpell} from "../src/commands/spell.ts";
+
+const repeat = defineSpell({
+	path: ["repeat"],
+	describe: "Answer with the word it was given, doubled.",
+	params: Schema.Struct({word: Schema.String}),
+	result: Schema.Struct({word: Schema.String}),
+	execute: (args) => Effect.succeed({word: `${args.word}${args.word}`}),
+	capabilities: [],
+});
+```
+
+A config's `keys` block binds a key to a command written the way a person types it. Each one is
+compiled against the registry at boot, so a mistake is reported while you are looking at the config
+rather than under a key you press hours later, and recovery is per binding: the ones that compile
+run, and the one that does not is named with the module, the key, where in the command string
+reading stopped, what was expected, and the nearest thing you may have meant.
+
+```ts
+export default {
+	version: 1,
+	programs: [...],
+	keys: {"ctrl-h": "help", "ctrl-x": {command: "workspace next", repeat: true}},
+} satisfies TuvalConfigInput;
+```
+
+`:help` lists every registered spell with its arguments and its own sentence — there is no help
+text written anywhere, because a row's description is the spell's own. An agent asks the same
+registry the same way: `spell list` describes every spell, `spell describe <path>` describes one,
+including its parameters as JSON Schema, and calling one is the same `SpellCall` message the
+command line sends. There is no second catalogue for programs to read, and
+`src/commands/agent-proof.unit.test.ts` is the proof: a scripted program enumerates the registry
+over the wire and calls every spell in it, generating each call's arguments from that spell's own
+parameter schema.
+
+Reading a config again replaces the registry and the compiled key bindings in one step, so a
+reader never sees new spells beside bindings compiled against the old ones
+(`src/reload-proof.unit.test.ts`). What a reload does not touch is the processes already running:
+they keep going under the rows they were spawned from.
 
 ## The host
 

--- a/apps/tuval/src/bin.ts
+++ b/apps/tuval/src/bin.ts
@@ -15,6 +15,7 @@ import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Cause, Console, Effect, Exit, Option, Runtime} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {boot, defaultGlobalConfig} from "./boot.ts";
+import {renderBindingErrors} from "./commands/bindings/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 import type {TableRow} from "./table/row.ts";
 
@@ -60,8 +61,13 @@ const tuval = Command.make(
 		);
 		const from = report.sources.length === 0 ? "no config module" : report.sources.join(" + ");
 		yield* Console.log(
-			`tuval: booted — ${report.programCount} program(s) registered from ${from}; ${report.processCount} process(es) live, ${report.restoredCount} restored from ${report.stateDir}`,
+			`tuval: booted — ${report.programCount} program(s), ${report.spellCount} spell(s) registered from ${from}; ${report.processCount} process(es) live, ${report.restoredCount} restored from ${report.stateDir}`,
 		);
+		// A binding that did not compile costs its own key and nothing else, so this is a report and
+		// not a refusal: boot goes on with the bindings that did compile.
+		for (const line of renderBindingErrors(report.bindingErrors)) {
+			yield* Console.log(`tuval: ${line}`);
+		}
 		const rows = yield* ProcessTablePort.use((port) => port.rows).pipe(
 			Effect.provideContext(kernel),
 		);

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -1,7 +1,17 @@
 import {homedir} from "node:os";
 import {join} from "node:path";
-import {type Context, Effect, Layer} from "effect";
-import {loadLayeredConfig} from "./config.ts";
+import {Context, Effect, type FileSystem, Layer} from "effect";
+import type {BindingError, BindingSource} from "./commands/bindings/index.ts";
+import {SpellBridge} from "./commands/bridge/index.ts";
+import {helpSpells} from "./commands/core/index.ts";
+import {processSpells, SpawnedProcesses} from "./commands/core/process.ts";
+import type {DuplicateSpellPath} from "./commands/errors.ts";
+import {SpellExecutor} from "./commands/executor.ts";
+import type {SpellRegistry} from "./commands/registry.ts";
+import {WindowIndex} from "./commands/scope.ts";
+import type {AnySpell} from "./commands/spell.ts";
+import {everyPath, SpellSet} from "./commands/spell-set.ts";
+import {type ConfigLoadError, loadLayeredConfig} from "./config.ts";
 import {Checkpoints} from "./durability/Checkpoints.ts";
 import {restore} from "./durability/restore.ts";
 import {fileStores} from "./durability/stores.ts";
@@ -25,12 +35,34 @@ export const projectDir = (project: string): string => join(project, ".tuval");
 export const projectConfig = (project: string): string =>
 	join(projectDir(project), "tuval.config.ts");
 
-export type Kernel = Registry | Checkpoints | Processes | ProcessTable | ProcessTablePort;
+export type Kernel =
+	| Registry
+	| Checkpoints
+	| Processes
+	| ProcessTable
+	| ProcessTablePort
+	| SpawnedProcesses
+	| SpellSet
+	| SpellRegistry
+	| WindowIndex
+	| SpellExecutor
+	| SpellBridge;
+
+/** The spells the kernel registers itself: discovery, then the three generic process tools. */
+export const coreSpells: ReadonlyArray<AnySpell> = [...helpSpells, ...processSpells];
+
+/** How long `process read` waits on a port that has said nothing yet before answering none. */
+const READ_TIMEOUT = "1 second";
 
 export interface StartOptions {
 	readonly programs: ReadonlyArray<AnyProgram>;
 	readonly graph: Graph;
 	readonly stateDir: string;
+	/**
+	 * The config's key bindings, one source per layer, compiled against the registered spells.
+	 * Absent for a caller that has no config layers to offer, which is every caller but `boot`.
+	 */
+	readonly keys?: ReadonlyArray<BindingSource>;
 }
 
 export interface Started {
@@ -52,12 +84,29 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	programs,
 	graph,
 	stateDir,
+	keys,
 }: StartOptions) {
 	const registry = yield* Layer.build(Registry.layer(programs));
 	const compiled = yield* compile(graph).pipe(Effect.provideContext(registry));
 	const wiring = yield* open(compiled);
+	const spells = yield* Layer.build(SpellSet.layer({core: coreSpells, programs, keys: keys ?? []}));
+	// The bridge's allowlist is whoever builds the layer's, and no program row supplies one yet
+	// (`.patterns/tuval-spells.md`, "The bridge"), so boot allows the whole registry as it stands.
+	// A reload does not revisit it — #7743.
+	const {table} = yield* Context.get(spells, SpellSet).read;
+	const commands = Layer.mergeAll(
+		SpellBridge.layer({allow: everyPath(table)}),
+		SpawnedProcesses.layer({readTimeout: READ_TIMEOUT}),
+	).pipe(
+		Layer.provideMerge(SpellExecutor.layer),
+		Layer.provideMerge(
+			// No shell holds windows yet (#7499), so the index is empty: a call naming a window is
+			// `NoSuchWindow`, and a call naming none is workspace-wide.
+			Layer.mergeAll(Layer.succeedContext(spells), WindowIndex.scripted({})),
+		),
+	);
 	const kernel = yield* Layer.build(
-		ProcessTablePort.layer.pipe(
+		Layer.mergeAll(ProcessTablePort.layer, commands).pipe(
 			Layer.provideMerge(Processes.layer),
 			Layer.provideMerge(Checkpoints.layer(fileStores(stateDir))),
 			Layer.provideMerge(Layer.succeedContext(registry)),
@@ -79,36 +128,83 @@ export interface BootReport {
 	/** The config modules that existed and were merged, global first. */
 	readonly sources: ReadonlyArray<string>;
 	readonly programCount: number;
+	/** Every registered spell: the kernel's own, plus the ones the config's programs declare. */
+	readonly spellCount: number;
+	readonly bindingCount: number;
+	/** One per key binding that did not compile; the binding is dropped and the rest still run. */
+	readonly bindingErrors: ReadonlyArray<BindingError>;
 	readonly stateDir: string;
 	readonly processCount: number;
 	readonly restoredCount: number;
 }
 
+/** What a reload replaced. The running processes are not among them; see `Booted.reload`. */
+export interface ReloadReport {
+	readonly sources: ReadonlyArray<string>;
+	readonly spellCount: number;
+	readonly bindingCount: number;
+	readonly bindingErrors: ReadonlyArray<BindingError>;
+}
+
 export interface Booted {
 	readonly report: BootReport;
 	readonly kernel: Context.Context<Kernel>;
+	/**
+	 * The config read again, its spells registered and its bindings compiled against them in one
+	 * write. It replaces the spell registry and the binding table and nothing else: the processes
+	 * the first boot launched keep running under the program rows they were spawned from.
+	 */
+	readonly reload: Effect.Effect<
+		ReloadReport,
+		ConfigLoadError | DuplicateSpellPath,
+		FileSystem.FileSystem
+	>;
 }
 
 /** `start` from the layered config: the `pnpm dev` path. */
 export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
-	const config = yield* loadLayeredConfig({
-		global: options.global,
-		project: projectConfig(options.project),
-	});
+	const layers = {global: options.global, project: projectConfig(options.project)};
+	const config = yield* loadLayeredConfig(layers);
 	// Config rows are trusted local code (#7484 R1.1); the loader checks each row's id, not its shape.
 	const programs = config.programs as ReadonlyArray<AnyProgram>;
 	const stateDir = projectDir(options.project);
-	const started = yield* start({programs, graph: config.graph, stateDir});
+	const started = yield* start({programs, graph: config.graph, stateDir, keys: config.keys});
 	const live = yield* ProcessTable.use((table) => table.list).pipe(
 		Effect.provideContext(started.kernel),
 	);
+	const spells = yield* SpellSet.use((set) => set.read).pipe(Effect.provideContext(started.kernel));
 	const report: BootReport = {
 		sources: config.sources,
 		programCount: programs.length,
+		spellCount: spells.table.rows.length,
+		bindingCount: spells.bindings.bindings.length,
+		bindingErrors: spells.bindings.errors,
 		stateDir,
 		processCount: live.length,
 		restoredCount:
 			started.launched.filter((process) => process.restored).length + started.restored.length,
 	};
-	return {report, kernel: started.kernel} satisfies Booted;
+
+	const reload = Effect.fn("Tuval.reload")(function* () {
+		const next = yield* loadLayeredConfig(layers);
+		const set = yield* SpellSet;
+		yield* set.reload({
+			core: coreSpells,
+			programs: next.programs as ReadonlyArray<AnyProgram>,
+			keys: next.keys,
+		});
+		const current = yield* set.read;
+		return {
+			sources: next.sources,
+			spellCount: current.table.rows.length,
+			bindingCount: current.bindings.bindings.length,
+			bindingErrors: current.bindings.errors,
+		} satisfies ReloadReport;
+	});
+
+	return {
+		report,
+		kernel: started.kernel,
+		reload: reload().pipe(Effect.provideContext(started.kernel)),
+	} satisfies Booted;
 });

--- a/apps/tuval/src/boot.unit.test.ts
+++ b/apps/tuval/src/boot.unit.test.ts
@@ -6,7 +6,10 @@ import {fileURLToPath} from "node:url";
 import {NodeFileSystem} from "@effect/platform-node";
 import {Effect} from "effect";
 import {afterEach, describe, expect, it} from "vitest";
-import {boot, defaultGlobalConfig, projectConfig, projectDir} from "./boot.ts";
+import {boot, coreSpells, defaultGlobalConfig, projectConfig, projectDir} from "./boot.ts";
+
+/** Every boot registers these, whatever the config declares; no fixture program declares a spell. */
+const CORE_SPELLS = coreSpells.length;
 
 const fixture = (name: string) =>
 	fileURLToPath(new URL(`./config-fixtures/${name}.ts`, import.meta.url));
@@ -111,6 +114,9 @@ describe("boot", () => {
 		expect(report).toEqual({
 			sources: [fixture("two-rows")],
 			programCount: 2,
+			spellCount: CORE_SPELLS,
+			bindingCount: 0,
+			bindingErrors: [],
 			stateDir: projectDir(project),
 			processCount: 0,
 			restoredCount: 0,
@@ -122,7 +128,7 @@ describe("boot", () => {
 		const result = run(["--config", fixture("two-rows"), "--project", project]);
 		expect(result.status).toBe(0);
 		expect(result.stdout).toBe(
-			`tuval: booted — 2 program(s) registered from ${fixture("two-rows")}; 0 process(es) live, 0 restored from ${projectDir(project)}\n`,
+			`tuval: booted — 2 program(s), ${CORE_SPELLS} spell(s) registered from ${fixture("two-rows")}; 0 process(es) live, 0 restored from ${projectDir(project)}\n`,
 		);
 	});
 
@@ -142,7 +148,7 @@ describe("boot", () => {
 		expect(result.stderr).toBe("");
 		expect(result.status).toBe(0);
 		expect(result.stdout).toBe(
-			`tuval: booted — 3 program(s) registered from ${defaultGlobalConfig(home)} + ${projectConfig(project)}; 0 process(es) live, 0 restored from ${projectDir(project)}\n`,
+			`tuval: booted — 3 program(s), ${CORE_SPELLS} spell(s) registered from ${defaultGlobalConfig(home)} + ${projectConfig(project)}; 0 process(es) live, 0 restored from ${projectDir(project)}\n`,
 		);
 	});
 
@@ -152,7 +158,7 @@ describe("boot", () => {
 		const result = run(["--project", project], {...process.env, HOME: home});
 		expect(result.status).toBe(0);
 		expect(result.stdout).toBe(
-			`tuval: booted — 0 program(s) registered from no config module; 0 process(es) live, 0 restored from ${projectDir(project)}\n`,
+			`tuval: booted — 0 program(s), ${CORE_SPELLS} spell(s) registered from no config module; 0 process(es) live, 0 restored from ${projectDir(project)}\n`,
 		);
 	});
 
@@ -163,7 +169,7 @@ describe("boot", () => {
 		expect(first.stderr).toBe("");
 		expect(first.status).toBe(0);
 		expect(first.stdout).toContain(
-			`tuval: booted — 2 program(s) registered from ${demoConfig}; 2 process(es) live, 0 restored from ${projectDir(project)}\n`,
+			`tuval: booted — 2 program(s), ${CORE_SPELLS} spell(s) registered from ${demoConfig}; 2 process(es) live, 0 restored from ${projectDir(project)}\n`,
 		);
 		expect(first.stdout).toContain(
 			"tuval: process counter program=counter parent=- ports=ticks:out(count/v1) state=running@0\n",
@@ -177,10 +183,10 @@ describe("boot", () => {
 		const second = await runUntilRunning(args);
 		expect(second.status).toBe(0);
 		expect(second.stdout).toContain(
-			`tuval: booted — 2 program(s) registered from ${demoConfig}; 2 process(es) live, 2 restored from ${projectDir(project)}\n`,
+			`tuval: booted — 2 program(s), ${CORE_SPELLS} spell(s) registered from ${demoConfig}; 2 process(es) live, 2 restored from ${projectDir(project)}\n`,
 		);
 		expect(second.stdout).toContain("tuval: process log program=log parent=counter");
-	});
+	}, 20_000);
 
 	it("restores every checkpointed process from the project's state through Demlik's fileStore", async () => {
 		const project = seededProject("1.0.0");
@@ -194,12 +200,12 @@ describe("boot", () => {
 		]);
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain(
-			`tuval: booted — 1 program(s) registered from ${fixture("one-counter")}; 1 process(es) live, 1 restored from ${projectDir(project)}\n`,
+			`tuval: booted — 1 program(s), ${CORE_SPELLS} spell(s) registered from ${fixture("one-counter")}; 1 process(es) live, 1 restored from ${projectDir(project)}\n`,
 		);
 		expect(result.stdout).toContain(
 			"tuval: process p-1 program=counter parent=- ports=- state=running@0\n",
 		);
-	});
+	}, 20_000);
 
 	it("refuses to boot on a snapshot under another program version, naming the process and both versions", () => {
 		const project = seededProject("0.9.0");

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -1,0 +1,418 @@
+/**
+ * The epic's done condition, proved: an agent process running inside Tuval enumerates and calls
+ * every spell a human can (#7645).
+ *
+ * The agent is a plain scripted process — an ordinary program row, registered by the config like
+ * the counter and the log, whose script sends `SpellCall`s over the wire. It is deliberately not a
+ * process built on the `TuvalAiAgent` service: `aiAgentProgram` and `ScriptedAiAgent.layer` are the
+ * Pi epic's (#7599, #7603), and re-running this proof on one of those is a later child's, per the
+ * founder's ruling of 2026-09-03 recorded on #7645. What makes it an agent proof is what the script
+ * does, which is what an AI agent would do with no help from the kernel: ask what exists, ask what
+ * each thing takes, then call every one of them with arguments it generates from the schema it was
+ * given.
+ *
+ * Every call leaves as JSON and every reply arrives as JSON, both directions through
+ * `protocol/codec.ts`, so nothing here reaches past the wire a browser page uses.
+ */
+
+import {randomUUID} from "node:crypto";
+import {defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Deferred, Effect, Layer, Schema} from "effect";
+import {coreSpells} from "../boot.ts";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {memoryStores} from "../durability/stores.ts";
+import type {PayloadRejected, PortNotWired} from "../ports/errors.ts";
+import {ProcessPorts} from "../ports/ProcessPorts.ts";
+import {Processes} from "../process/Processes.ts";
+import {ProcessId} from "../process/process.ts";
+import {
+	decodeKernelMessage,
+	decodePageMessage,
+	encodeKernelMessage,
+	encodePageMessage,
+} from "../protocol/codec.ts";
+import {CallId} from "../protocol/ids.ts";
+import {PROTOCOL_VERSION, SpellCall, type SpellFailure, SpellReply} from "../protocol/messages.ts";
+import {RegistryDescription, type SpellDescription} from "../protocol/registry-description.ts";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
+import {Registry} from "../registry/Registry.ts";
+import {HelpRows} from "./core/help.ts";
+import {SpawnedProcesses} from "./core/process.ts";
+import {SpellExecutor} from "./executor.ts";
+import {type ParamSpec, readParams} from "./parse/spell-index.ts";
+import {SpellRegistry, type SpellRow} from "./registry.ts";
+import {type Client, WindowIndex, type WindowPlacement} from "./scope.ts";
+import {ClientId, defineSpell, renderPath, type SpellPath, WindowId, WorkspaceId} from "./spell.ts";
+import {SpellSet} from "./spell-set.ts";
+
+const workspace = WorkspaceId.make("ws-1");
+const agentWindow = WindowId.make("w-agent");
+const agentProcess = ProcessId.make("p-agent");
+const client: Client = {id: ClientId.make("agent"), workspace};
+
+const placements: Readonly<Record<string, WindowPlacement>> = {
+	[agentWindow]: {process: agentProcess, workspace},
+};
+
+const WORD_KIND = "text/v1";
+const isWord = (payload: unknown): payload is string => typeof payload === "string";
+
+type EchoState = {readonly heard: ReadonlyArray<string>};
+type EchoMsg = {readonly type: "hear"; readonly word: string};
+type Say = {readonly type: "say"; readonly word: string};
+
+const echoId = ProgramId.make("echo");
+
+/** One spell declared by a program row, so the proof enumerates more than the kernel's own list. */
+const repeatSpell = defineSpell({
+	path: ["repeat"],
+	describe: "Answer with the word it was given, doubled.",
+	params: Schema.Struct({word: Schema.String}),
+	result: Schema.Struct({word: Schema.String}),
+	execute: (args: {readonly word: string}) => Effect.succeed({word: `${args.word}${args.word}`}),
+	capabilities: [],
+});
+
+/** The agent's target: a program with an in-port, an out-port and a spell of its own. */
+const echoProgram = (): AnyProgram =>
+	({
+		id: echoId,
+		core: defineMachine<EchoState, EchoMsg, Say, never, unknown>({
+			init: (loaded) => [loaded ?? {heard: []}, []],
+			update: {
+				hear: (state, msg) => [
+					{heard: [...state.heard, msg.word]},
+					[{type: "say", word: msg.word.toUpperCase()}],
+				],
+			},
+			interpret: {say: () => Promise.resolve()},
+		}),
+		ports: {
+			words: {
+				kind: WORD_KIND,
+				direction: "in",
+				accepts: isWord,
+				bound: {capacity: 4, overflow: "suspend"},
+			},
+			echoed: {kind: WORD_KIND, direction: "out", accepts: isWord},
+		},
+		receive: {words: (word: string): EchoMsg => ({type: "hear", word})},
+		handlers: {
+			say: (cmd: Say) =>
+				Effect.gen(function* () {
+					const ports = yield* ProcessPorts;
+					yield* ports.emit("echoed", cmd.word);
+					return [] as ReadonlyArray<EchoMsg>;
+				}),
+		},
+		spells: [repeatSpell],
+		capabilities: [],
+		identity: {
+			package: "@kampus/tuval",
+			program: "echo",
+			version: "1.0.0",
+			digest: "sha256:echo",
+		},
+		placement: {host: "local"},
+	}) satisfies Program<
+		EchoState,
+		EchoMsg,
+		Say,
+		never,
+		unknown,
+		PayloadRejected | PortNotWired,
+		ProcessPorts
+	>;
+
+/** One line of the agent's transcript: what it sent, and what came back. */
+interface Exchange {
+	readonly path: string;
+	readonly args: Readonly<Record<string, unknown>>;
+	readonly reply: SpellReply;
+}
+
+/**
+ * The facts about this desk that no schema states: which program to spawn, which ports that
+ * program has, and what its in-port takes. A real agent reads them from its prompt or its task; the
+ * completion engine's live values (`.patterns/tuval-spells.md`, "Completion") are the same idea for
+ * a person. Keyed by `<spell path>.<parameter>`, so two spells can want different values under one
+ * parameter name — `process send`'s port is an in-port and `process read`'s is an out-port.
+ */
+const world: Readonly<Record<string, unknown>> = {
+	"process.spawn.program": echoId,
+	"process.send.port": "words",
+	"process.send.payload": "hi",
+	"process.read.port": "echoed",
+	"echo.repeat.word": "ha",
+};
+
+/**
+ * One argument, from the parameter's own schema first and the desk second: an enum takes its first
+ * literal, a parameter naming a spell path takes a registered one, and anything the schema cannot
+ * settle comes from the desk or from what an earlier call in this script returned.
+ */
+const argumentFor = (
+	spell: string,
+	param: ParamSpec,
+	learned: Readonly<Record<string, unknown>>,
+	firstPath: string,
+): unknown => {
+	const named = world[`${spell}.${param.name}`];
+	if (named !== undefined) return named;
+	if (param.literals !== undefined) return param.literals[0];
+	if (param.name === "path") return firstPath;
+	const carried = learned[param.name];
+	return carried === undefined ? "" : carried;
+};
+
+const argumentsFor = (
+	description: SpellDescription,
+	learned: Readonly<Record<string, unknown>>,
+	firstPath: string,
+): Readonly<Record<string, unknown>> => {
+	const spell = description.path.join(".");
+	const args: Record<string, unknown> = {};
+	for (const param of readParams(description.params)) {
+		args[param.name] = argumentFor(spell, param, learned, firstPath);
+	}
+	return args;
+};
+
+const asPath = (segments: ReadonlyArray<string>): SpellPath => {
+	const [head, ...rest] = segments;
+	assert.isDefined(head, "a description with an empty path");
+	return [head ?? "", ...rest];
+};
+
+/**
+ * One call, encoded to JSON, decoded by the kernel, answered, encoded back and decoded by the
+ * caller. A refusal on either codec is a bug in this proof rather than an answer the agent could
+ * act on, so it dies rather than becoming an outcome.
+ */
+const overTheWire = Effect.fn("agentProof.call")(function* (
+	path: SpellPath,
+	args: Readonly<Record<string, unknown>>,
+) {
+	const executor = yield* SpellExecutor;
+	const sent = yield* encodePageMessage(
+		new SpellCall({
+			type: "spell.call",
+			version: PROTOCOL_VERSION,
+			id: CallId.make(randomUUID()),
+			path,
+			args,
+			window: agentWindow,
+		}),
+	).pipe(Effect.orDie);
+	const received = yield* decodePageMessage(sent).pipe(Effect.orDie);
+	const reply = yield* executor.execute(received, client);
+	const answered = yield* encodeKernelMessage(reply).pipe(Effect.orDie);
+	const back = yield* decodeKernelMessage(answered).pipe(Effect.orDie);
+	assert.instanceOf(back, SpellReply, "the kernel answered a call with something else");
+	return back as SpellReply;
+});
+
+const resultOf = (reply: SpellReply): unknown =>
+	reply.outcome.ok ? reply.outcome.result : undefined;
+
+/**
+ * The agent's whole script. It knows the two discovery spells by name — that is the one thing an
+ * agent is told — and everything after that comes off the registry it was handed.
+ */
+const script = Effect.fn("agentProof.script")(function* () {
+	const transcript: Array<Exchange> = [];
+	const learned: Record<string, unknown> = {};
+
+	const call = Effect.fn("agentProof.exchange")(function* (
+		path: SpellPath,
+		args: Readonly<Record<string, unknown>>,
+	) {
+		const reply = yield* overTheWire(path, args);
+		transcript.push({path: renderPath(path), args, reply});
+		return reply;
+	});
+
+	const listed = yield* call(["spell", "list"], {});
+	const described = yield* Schema.decodeUnknownEffect(RegistryDescription)(resultOf(listed)).pipe(
+		Effect.orDie,
+	);
+	const firstPath = described[0]?.path.join(" ") ?? "";
+
+	for (const description of described) {
+		yield* call(["spell", "describe"], {path: description.path.join(" ")});
+	}
+
+	for (const description of described) {
+		const path = asPath(description.path);
+		const reply = yield* call(path, argumentsFor(description, learned, firstPath));
+		// `process spawn` is the one call whose answer another call needs, and it is registered
+		// ahead of `process send` and `process read`, so the id is learned before they are reached.
+		if (renderPath(path) === "process.spawn") {
+			const spawned = (resultOf(reply) as {readonly process?: unknown} | undefined)?.process;
+			if (spawned !== undefined) learned.process = spawned;
+		}
+	}
+
+	return transcript as ReadonlyArray<Exchange>;
+});
+
+type AgentState = {readonly started: boolean};
+type AgentMsg = {readonly type: "begin"} | {readonly type: "finished"};
+type Drive = {readonly type: "drive"};
+
+const agentId = ProgramId.make("agent");
+
+/**
+ * The agent as a program row: a `begin` message turns into the one Cmd whose handler is the script,
+ * and the host reports a failure inside it as this process's own. A message drives it rather than
+ * `init` because the script starts a process of its own, and a process started from inside its
+ * parent's own boot has no live parent to hang on yet.
+ */
+const agentProgram = (done: Deferred.Deferred<ReadonlyArray<Exchange>>): AnyProgram =>
+	({
+		id: agentId,
+		core: defineMachine<AgentState, AgentMsg, Drive, never, unknown>({
+			init: (loaded) => [loaded ?? {started: true}, []],
+			update: {
+				begin: (state) => [state, [{type: "drive"}]],
+				finished: (state) => [state, []],
+			},
+			interpret: {drive: () => Promise.resolve()},
+		}),
+		ports: {},
+		handlers: {
+			drive: () =>
+				Effect.map(
+					Effect.flatMap(script(), (transcript) => Deferred.succeed(done, transcript)),
+					() => [{type: "finished"}] as ReadonlyArray<AgentMsg>,
+				),
+		},
+		capabilities: [{family: "model"}],
+		identity: {
+			package: "@kampus/tuval",
+			program: "agent",
+			version: "1.0.0",
+			digest: "sha256:agent",
+		},
+		placement: {host: "local"},
+	}) satisfies Program<AgentState, AgentMsg, Drive, never, unknown, never, SpellExecutor>;
+
+/** The layer set boot builds, over an in-memory state dir and the two rows this proof registers. */
+const app = (rows: ReadonlyArray<AnyProgram>) =>
+	Layer.mergeAll(SpawnedProcesses.layer({readTimeout: "1 second"})).pipe(
+		Layer.provideMerge(SpellExecutor.layer),
+		Layer.provideMerge(
+			Layer.mergeAll(
+				SpellSet.layer({core: coreSpells, programs: rows, keys: []}),
+				WindowIndex.scripted(placements),
+			),
+		),
+		Layer.provideMerge(Processes.layer),
+		Layer.provideMerge(Layer.mergeAll(Registry.layer(rows), Checkpoints.layer(memoryStores()))),
+		Layer.orDie,
+	);
+
+/** One `begin` starts the script, so awaiting the transcript is awaiting the agent's whole run. */
+const runAgent = Effect.gen(function* () {
+	const done = yield* Deferred.make<ReadonlyArray<Exchange>>();
+	const rows = [agentProgram(done), echoProgram()];
+	return yield* Effect.gen(function* () {
+		const processes = yield* Processes;
+		const executor = yield* SpellExecutor;
+		const agent = yield* processes.spawn(agentId, {
+			id: agentProcess,
+			services: Context.make(SpellExecutor, executor),
+		});
+		yield* agent.dispatch({type: "begin"});
+		const transcript = yield* Deferred.await(done);
+		const rowsInRegistry = yield* SpellRegistry.use((registry) => registry.list);
+		const help = yield* overTheWire(["help"], {});
+		return {transcript, rowsInRegistry, help};
+	}).pipe(Effect.provide(app(rows)));
+});
+
+const failureOf = (reply: SpellReply): SpellFailure | undefined =>
+	reply.outcome.ok ? undefined : reply.outcome.error;
+
+// `it.live`, not `it.effect`: `process read` waits on a real timeout for a port that has said
+// nothing yet, and under the test clock no wall time passes, so that wait never ends.
+describe("the agent proof", () => {
+	it.live("enumerates every spell over the wire and calls each one, every reply decoding", () =>
+		Effect.gen(function* () {
+			const {transcript, rowsInRegistry, help} = yield* runAgent;
+
+			const registered = rowsInRegistry.map((row) => renderPath(row.path));
+			assert.includeMembers(
+				registered,
+				["help", "spell.list", "spell.describe", "process.spawn", "echo.repeat"],
+				"the registry the agent read is not the one boot builds",
+			);
+
+			for (const exchange of transcript) {
+				assert.isTrue(
+					exchange.reply.outcome.ok,
+					`${exchange.path} failed: ${JSON.stringify(failureOf(exchange.reply))}`,
+				);
+			}
+
+			// A set, because `spell describe` is itself one of the spells the second pass calls, so
+			// one path is described twice: once in the describe pass and once as an argument there.
+			const describedEvery = new Set(
+				transcript
+					.filter((exchange) => exchange.path === "spell.describe")
+					.map((exchange) => String(exchange.args.path)),
+			);
+			assert.deepStrictEqual(
+				[...describedEvery].sort(),
+				rowsInRegistry.map((row) => row.path.join(" ")).sort(),
+				"the agent did not describe every path",
+			);
+
+			// The set it called, against the set a person reading `help` is shown.
+			const helpRows = yield* Schema.decodeUnknownEffect(HelpRows)(resultOf(help)).pipe(
+				Effect.orDie,
+			);
+			const called = new Set(transcript.map((exchange) => exchange.path));
+			assert.deepStrictEqual(
+				[...called].sort(),
+				helpRows.map((row) => row.path.split(" ").join(".")).sort(),
+				"the set the agent called is not the set help lists",
+			);
+
+			// Every reply against the spell's own `result`, which the agent never held: the wire
+			// carried the parameter schema, and the kernel is answerable for the result schema.
+			const byPath = new Map<string, SpellRow>(
+				rowsInRegistry.map((row) => [renderPath(row.path), row]),
+			);
+			for (const exchange of transcript) {
+				const row = byPath.get(exchange.path);
+				assert.isDefined(row, `${exchange.path} is not a registered spell`);
+				yield* Schema.decodeUnknownEffect(row?.spell.result ?? Schema.Unknown)(
+					resultOf(exchange.reply),
+				).pipe(
+					Effect.mapError(
+						(error) => new Error(`${exchange.path} answered off its result: ${error.message}`),
+					),
+					Effect.orDie,
+				);
+			}
+		}),
+	);
+
+	it.live("calls the process spells against a real process it spawned itself", () =>
+		Effect.gen(function* () {
+			const {transcript} = yield* runAgent;
+			const answerAt = (path: string): unknown => {
+				const exchange = transcript.find((entry) => entry.path === path);
+				assert.isDefined(exchange, `the agent never called ${path}`);
+				return exchange === undefined ? undefined : resultOf(exchange.reply);
+			};
+
+			const spawned = answerAt("process.spawn") as {readonly process: string};
+			assert.isString(spawned.process);
+			assert.deepStrictEqual(answerAt("process.send"), {delivered: true});
+			assert.deepStrictEqual(answerAt("echo.repeat"), {word: "haha"});
+		}),
+	);
+});

--- a/apps/tuval/src/commands/bindings/compile.ts
+++ b/apps/tuval/src/commands/bindings/compile.ts
@@ -21,7 +21,7 @@ import {WorkspaceId} from "../../protocol/ids.ts";
 import {firstSchemaIssue} from "../../protocol/issue.ts";
 import {PROTOCOL_VERSION, Snapshot} from "../../protocol/messages.ts";
 import {buildSpellIndex, describeExpected, parse, tokenize} from "../parse/index.ts";
-import {describeSpell, type RegistryTable, type SpellNode, type SpellRow} from "../registry.ts";
+import {describeSpell, lookupRow, type RegistryTable} from "../registry.ts";
 import type {SpellPath} from "../spell.ts";
 import {BindingError} from "./errors.ts";
 
@@ -77,15 +77,6 @@ const NO_DESK = new Snapshot({
 	registry: [],
 });
 
-const lookup = (table: RegistryTable, path: SpellPath): SpellRow | undefined => {
-	let node: SpellNode | undefined = table.root;
-	for (const segment of path) {
-		node = node.children.get(segment);
-		if (node === undefined) return undefined;
-	}
-	return node.row;
-};
-
 const normalize = (entry: KeyBindingInput): {command: string; repeat?: boolean} =>
 	typeof entry === "string" ? {command: entry} : entry;
 
@@ -140,7 +131,7 @@ const compileOne = Effect.fn("Tuval.Commands.compileBinding")(function* (
 	}
 
 	const {path, args} = reading.call;
-	const row = lookup(table, path);
+	const row = lookupRow(table, path);
 	// The index is built from this table, so a completed path is registered in it.
 	if (row === undefined) return refuse(0, "a registered spell");
 

--- a/apps/tuval/src/commands/registry.ts
+++ b/apps/tuval/src/commands/registry.ts
@@ -39,6 +39,19 @@ export interface RegistryTable {
 	readonly rows: ReadonlyArray<SpellRow>;
 }
 
+/**
+ * The row registered at exactly this path, or none. Every reader of a table walks it this way, so
+ * the walk lives here rather than once per caller.
+ */
+export const lookupRow = (table: RegistryTable, path: SpellPath): SpellRow | undefined => {
+	let node: SpellNode | undefined = table.root;
+	for (const segment of path) {
+		node = node.children.get(segment);
+		if (node === undefined) return undefined;
+	}
+	return node.row;
+};
+
 /** The serializable face of one spell: what a client is told without being handed the closure. */
 export interface SpellDescription {
 	readonly path: ReadonlyArray<string>;
@@ -121,14 +134,10 @@ const make = Effect.fn("Tuval.SpellRegistry.make")(function* (initial: RegistryT
 	return SpellRegistry.of({
 		lookup: (path) =>
 			Effect.flatMap(Ref.get(table), (current) => {
-				let node: SpellNode | undefined = current.root;
-				for (const segment of path) {
-					node = node.children.get(segment);
-					if (node === undefined) break;
-				}
-				return node?.row === undefined
+				const row = lookupRow(current, path);
+				return row === undefined
 					? Effect.fail(new SpellNotFound({path: renderPath(path)}))
-					: Effect.succeed(node.row);
+					: Effect.succeed(row);
 			}),
 		list: Effect.map(Ref.get(table), (current) => current.rows),
 		describe: Effect.map(Ref.get(table), (current) => current.rows.map(describeSpell)),

--- a/apps/tuval/src/commands/spell-set.ts
+++ b/apps/tuval/src/commands/spell-set.ts
@@ -1,0 +1,128 @@
+/**
+ * The registered spells and the key bindings compiled against them, held in one cell and replaced
+ * in one write (#7645).
+ *
+ * A binding is only ever as valid as the table it was compiled against, so the two are not two
+ * pieces of state that a reload has to remember to update together: they are one value. Every
+ * write goes through `install`, which compiles the bindings against the table it is about to
+ * store, so a reader can never see a new table beside bindings compiled against the old one.
+ *
+ * The `SpellRegistry` this module's layer provides reads that same cell, which is why the layer
+ * hands out both services: two cells would be two states to keep in step, and keeping them in step
+ * is the whole job.
+ */
+
+import {Context, Effect, Layer, Ref} from "effect";
+import type {AnyProgram} from "../registry/program.ts";
+import {type BindingSource, type CompiledBindings, compileBindings} from "./bindings/index.ts";
+import {type DuplicateSpellPath, SpellNotFound} from "./errors.ts";
+import {
+	buildRegistry,
+	describeSpell,
+	lookupRow,
+	type RegistryTable,
+	SpellRegistry,
+} from "./registry.ts";
+import {type AnySpell, renderPath, type SpellPath} from "./spell.ts";
+
+/** What one config produces: the spells its programs declare, and the keys they are bound to. */
+export interface SpellSetInput {
+	/** The spells the kernel itself registers, under no program id. */
+	readonly core: ReadonlyArray<AnySpell>;
+	readonly programs: ReadonlyArray<AnyProgram>;
+	/** One source per config layer, so a binding error names the module its author wrote it in. */
+	readonly keys: ReadonlyArray<BindingSource>;
+}
+
+/** The whole state, read in one go: the table, the sources it was compiled from, and the result. */
+export interface SpellSetState {
+	readonly table: RegistryTable;
+	readonly keys: ReadonlyArray<BindingSource>;
+	readonly bindings: CompiledBindings;
+}
+
+/**
+ * Every layer's bindings against one table, in layer order. A later layer's binding for a key a
+ * lower layer also bound wins the same way its program row does, because it comes later in the
+ * list a key router reads.
+ */
+const compileAll = Effect.fn("Tuval.SpellSet.compileAll")(function* (
+	table: RegistryTable,
+	keys: ReadonlyArray<BindingSource>,
+) {
+	const bindings: Array<CompiledBindings["bindings"][number]> = [];
+	const errors: Array<CompiledBindings["errors"][number]> = [];
+	for (const source of keys) {
+		const compiled = yield* compileBindings(source, table);
+		bindings.push(...compiled.bindings);
+		errors.push(...compiled.errors);
+	}
+	return {bindings, errors} satisfies CompiledBindings;
+});
+
+const make = Effect.fn("Tuval.SpellSet.make")(function* (input: SpellSetInput) {
+	const build = Effect.fn("Tuval.SpellSet.build")(function* (
+		table: RegistryTable,
+		keys: ReadonlyArray<BindingSource>,
+	) {
+		return {table, keys, bindings: yield* compileAll(table, keys)} satisfies SpellSetState;
+	});
+
+	const initial = yield* build(
+		yield* buildRegistry({core: input.core, programs: input.programs}),
+		input.keys,
+	);
+	// One cell, so the single `Ref.set` in `install` is the only way either half changes and a
+	// reader's single `Ref.get` sees both halves of one config.
+	const cell = yield* Ref.make<SpellSetState>(initial);
+	const install = (state: SpellSetState) => Ref.set(cell, state);
+
+	const registry = SpellRegistry.of({
+		lookup: (path) =>
+			Effect.flatMap(Ref.get(cell), (state) => {
+				const row = lookupRow(state.table, path);
+				return row === undefined
+					? Effect.fail(new SpellNotFound({path: renderPath(path)}))
+					: Effect.succeed(row);
+			}),
+		list: Effect.map(Ref.get(cell), (state) => state.table.rows),
+		describe: Effect.map(Ref.get(cell), (state) => state.table.rows.map(describeSpell)),
+		// The registry's own `swap` recompiles the bindings against the table it is installing, so
+		// even this narrower entry cannot leave the two halves disagreeing.
+		swap: (table) =>
+			Effect.flatMap(Ref.get(cell), (state) => Effect.flatMap(build(table, state.keys), install)),
+	});
+
+	const set = SpellSet.of({
+		read: Ref.get(cell),
+		reload: Effect.fn("Tuval.SpellSet.reload")(function* (next: SpellSetInput) {
+			const table = yield* buildRegistry({core: next.core, programs: next.programs});
+			yield* install(yield* build(table, next.keys));
+		}),
+	});
+
+	return Context.make(SpellSet, set).pipe(Context.add(SpellRegistry, registry));
+});
+
+export class SpellSet extends Context.Service<
+	SpellSet,
+	{
+		/** The table, its key sources and their compiled bindings, as one value. */
+		readonly read: Effect.Effect<SpellSetState>;
+		/** A reloaded config: a fresh table and fresh bindings, installed in one write. */
+		readonly reload: (input: SpellSetInput) => Effect.Effect<void, DuplicateSpellPath>;
+	}
+>()("tuval/SpellSet") {
+	/**
+	 * The set and the `SpellRegistry` over it. Both come from one layer because both read one cell;
+	 * `SpellRegistry.layer` builds a registry over a cell of its own and stays the seam for a test
+	 * that has no bindings to keep in step.
+	 */
+	static readonly layer = (
+		input: SpellSetInput,
+	): Layer.Layer<SpellSet | SpellRegistry, DuplicateSpellPath> => Layer.effectContext(make(input));
+}
+
+/** Every registered path, which is what a caller allowed the whole registry passes the bridge. */
+export const everyPath = (table: RegistryTable): ReadonlyArray<SpellPath> =>
+	table.rows.map((row) => row.path);

--- a/apps/tuval/src/commands/spell.unit.test.ts
+++ b/apps/tuval/src/commands/spell.unit.test.ts
@@ -98,6 +98,7 @@ describe("commands vocabulary", () => {
 			"index.ts",
 			"registry.ts",
 			"scope.ts",
+			"spell-set.ts",
 			"spell.ts",
 		]);
 	});

--- a/apps/tuval/src/commands/wire-proof.unit.test.ts
+++ b/apps/tuval/src/commands/wire-proof.unit.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The wire, end to end: a scripted page speaks JSON to the executor and reads JSON back (#7645).
+ *
+ * The four messages and the codec have their own tests (`protocol/protocol.unit.test.ts`); what is
+ * proved here is the round trip they only make together — a call encoded by a page, decoded by the
+ * kernel, answered, encoded back and decoded by the page, with the registry riding in a `Snapshot`
+ * and a `Patch` carrying what a mutation changed.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer, Ref, Schema} from "effect";
+import {
+	decodeKernelMessage,
+	decodePageMessage,
+	encodeKernelMessage,
+	encodePageMessage,
+} from "../protocol/codec.ts";
+import {counterRow, workspace as deskWorkspace, leftWindow} from "../protocol/fixtures.ts";
+import {CallId, Revision} from "../protocol/ids.ts";
+import {Patch, PROTOCOL_VERSION, Snapshot, SpellCall, SpellReply} from "../protocol/messages.ts";
+import {applyPatch} from "../protocol/patch.ts";
+import type {RegistryDescription} from "../protocol/registry-description.ts";
+import {SpellExecutor} from "./executor.ts";
+import {SpellRegistry} from "./registry.ts";
+import {type Client, WindowIndex} from "./scope.ts";
+import {ClientId, defineSpell, type SpellPath, WorkspaceId} from "./spell.ts";
+
+const client: Client = {id: ClientId.make("page"), workspace: WorkspaceId.make("ws-1")};
+
+/** The state a mutation writes, so a `Patch` has a real change to carry rather than a staged one. */
+class Counter extends Context.Service<
+	Counter,
+	{readonly read: Effect.Effect<number>; readonly bump: Effect.Effect<number>}
+>()("tuval/wireProof/Counter") {
+	static readonly layer: Layer.Layer<Counter> = Layer.effect(
+		Counter,
+		Effect.map(Ref.make(0), (cell) =>
+			Counter.of({read: Ref.get(cell), bump: Ref.updateAndGet(cell, (count) => count + 1)}),
+		),
+	);
+}
+
+const readCount = defineSpell({
+	path: ["count", "read"],
+	describe: "Answer the current count.",
+	params: Schema.Struct({}),
+	result: Schema.Struct({count: Schema.Number}),
+	execute: () =>
+		Effect.map(
+			Effect.flatMap(Counter, (counter) => counter.read),
+			(count) => ({count}),
+		),
+	capabilities: [],
+});
+
+const bumpCount = defineSpell({
+	path: ["count", "bump"],
+	describe: "Add one to the count.",
+	params: Schema.Struct({}),
+	result: Schema.Struct({count: Schema.Number}),
+	execute: () =>
+		Effect.map(
+			Effect.flatMap(Counter, (counter) => counter.bump),
+			(count) => ({count}),
+		),
+	capabilities: [],
+});
+
+const app = Layer.mergeAll(SpellExecutor.layer, Counter.layer).pipe(
+	Layer.provideMerge(
+		Layer.mergeAll(SpellRegistry.scripted([readCount, bumpCount]), WindowIndex.scripted({})),
+	),
+	Layer.orDie,
+);
+
+/** One exchange as a page makes it: JSON out, JSON back, nothing shared but the text. */
+const exchange = Effect.fn("wireProof.exchange")(function* (
+	id: string,
+	path: SpellPath,
+	args: unknown,
+) {
+	const callId = CallId.make(id);
+	const request = yield* encodePageMessage(
+		new SpellCall({type: "spell.call", version: PROTOCOL_VERSION, id: callId, path, args}),
+	).pipe(Effect.orDie);
+	const call = yield* decodePageMessage(request).pipe(Effect.orDie);
+	const executor = yield* SpellExecutor;
+	const reply = yield* executor.execute(call, client);
+	const response = yield* encodeKernelMessage(reply).pipe(Effect.orDie);
+	const back = yield* decodeKernelMessage(response).pipe(Effect.orDie);
+	assert.instanceOf(back, SpellReply, "the kernel answered a call with something else");
+	return {callId, reply: back as SpellReply};
+});
+
+/** The desk a page is holding when the registry arrives: the protocol fixtures' own, plus rows. */
+const snapshotOf = (rev: number, registry: RegistryDescription): Snapshot =>
+	new Snapshot({
+		type: "snapshot",
+		version: PROTOCOL_VERSION,
+		rev: Revision.make(rev),
+		desk: {
+			workspaces: {
+				[deskWorkspace]: {
+					id: deskWorkspace,
+					name: "count 0",
+					layout: {kind: "leaf", window: leftWindow},
+					focused: leftWindow,
+				},
+			},
+			activeWorkspace: deskWorkspace,
+		},
+		windows: {[leftWindow]: {id: leftWindow}},
+		processes: [counterRow],
+		registry,
+	});
+
+describe("the wire", () => {
+	it.effect("answers one reply per call, each carrying that call's own id", () =>
+		Effect.gen(function* () {
+			const first = yield* exchange("c-1", ["count", "read"], {});
+			const second = yield* exchange("c-2", ["count", "bump"], {});
+
+			assert.strictEqual(first.reply.id, first.callId, "a reply carried another call's id");
+			assert.strictEqual(second.reply.id, second.callId, "a reply carried another call's id");
+			assert.deepStrictEqual(first.reply.outcome, {ok: true, result: {count: 0}});
+			assert.deepStrictEqual(second.reply.outcome, {ok: true, result: {count: 1}});
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("carries the registry in a Snapshot, over the same codec", () =>
+		Effect.gen(function* () {
+			const registry = yield* SpellRegistry.use((held) => held.describe);
+			const sent = yield* encodeKernelMessage(snapshotOf(1, registry)).pipe(Effect.orDie);
+			const back = yield* decodeKernelMessage(sent).pipe(Effect.orDie);
+
+			assert.instanceOf(back, Snapshot);
+			const carried = (back as Snapshot).registry;
+			assert.deepStrictEqual(
+				carried.map((description) => description.path.join(".")),
+				["count.read", "count.bump"],
+				"the snapshot did not carry the registry the kernel holds",
+			);
+			assert.isDefined(carried[0]?.params, "a description reached the page without its params");
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("delivers what a mutation changed as a Patch the page applies over its snapshot", () =>
+		Effect.gen(function* () {
+			const registry = yield* SpellRegistry.use((held) => held.describe);
+			const before = snapshotOf(1, registry);
+
+			const {reply} = yield* exchange("c-3", ["count", "bump"], {});
+			assert.deepStrictEqual(reply.outcome, {ok: true, result: {count: 1}});
+
+			const sent = yield* encodeKernelMessage(
+				new Patch({
+					type: "patch",
+					version: PROTOCOL_VERSION,
+					rev: Revision.make(2),
+					changes: [
+						{op: "replace", path: ["desk", "workspaces", deskWorkspace, "name"], value: "count 1"},
+					],
+				}),
+			).pipe(Effect.orDie);
+			const delivered = yield* decodeKernelMessage(sent).pipe(Effect.orDie);
+			assert.instanceOf(delivered, Patch);
+
+			const after = yield* applyPatch(before, delivered as Patch);
+			assert.strictEqual(after.rev, 2);
+			assert.strictEqual(after.desk.workspaces[deskWorkspace]?.name, "count 1");
+			assert.strictEqual(
+				before.desk.workspaces[deskWorkspace]?.name,
+				"count 0",
+				"applying a patch rewrote the snapshot it was applied over",
+			);
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("refuses an undecodable message and says why, rather than half-reading it", () =>
+		Effect.gen(function* () {
+			const notJson = yield* Effect.flip(decodePageMessage("{"));
+			assert.strictEqual(notJson.direction, "page-to-kernel");
+			assert.include(notJson.reason, "not JSON");
+
+			const missingPath = yield* Effect.flip(
+				decodePageMessage(JSON.stringify({type: "spell.call", version: 1, id: "c-1"})),
+			);
+			assert.include(missingPath.message, "page-to-kernel");
+			assert.isTrue(missingPath.reason.length > 0, "a refusal arrived with no reason");
+
+			const otherBuild = yield* Effect.flip(
+				decodePageMessage(
+					JSON.stringify({
+						type: "spell.call",
+						version: PROTOCOL_VERSION + 1,
+						id: "c-1",
+						path: ["count", "read"],
+						args: {},
+					}),
+				),
+			);
+			assert.isTrue(
+				otherBuild.reason.length > 0,
+				"a message from another build was admitted without a reason",
+			);
+		}),
+	);
+});

--- a/apps/tuval/src/config-fixtures/keys.ts
+++ b/apps/tuval/src/config-fixtures/keys.ts
@@ -1,0 +1,6 @@
+/** A config layer that binds two keys: one bare command string, one with the repeat flag. */
+export default {
+	version: 1,
+	programs: [],
+	keys: {"ctrl-h": "help", "ctrl-x": {command: "spell list", repeat: true}},
+};

--- a/apps/tuval/src/config-fixtures/reloadable.ts
+++ b/apps/tuval/src/config-fixtures/reloadable.ts
@@ -1,0 +1,64 @@
+/**
+ * The reload proof's config layer. Which programs it registers, which spells each one declares and
+ * which keys are bound to them are read at import from the JSON file `TUVAL_RELOAD_FIXTURE` names,
+ * so rewriting that file and loading the config again is a config change — the module stays put and
+ * nothing has to be kept in step with it.
+ */
+
+import {readFileSync} from "node:fs";
+import {defineMachine} from "@demlik/tea";
+import {Effect, Schema} from "effect";
+import {defineSpell} from "../commands/spell.ts";
+import type {TuvalConfigInput} from "../config.ts";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
+
+/** One generation of the fixture: what the JSON file holds. */
+export interface DeclaredConfig {
+	readonly programs: ReadonlyArray<{readonly id: string; readonly spells: ReadonlyArray<string>}>;
+	readonly keys: Readonly<Record<string, string>>;
+}
+
+type State = {readonly seen: number};
+type Msg = {readonly type: "tick"};
+type Notify = {readonly type: "notify"};
+
+const spellNamed = (name: string) =>
+	defineSpell({
+		path: [name],
+		describe: `Answer with the name of this spell, which is "${name}".`,
+		params: Schema.Struct({}),
+		result: Schema.Struct({name: Schema.String}),
+		execute: () => Effect.succeed({name}),
+		capabilities: [],
+	});
+
+const program = (row: DeclaredConfig["programs"][number]): AnyProgram =>
+	({
+		id: ProgramId.make(row.id),
+		core: defineMachine<State, Msg, Notify, never, unknown>({
+			init: (loaded) => [loaded ?? {seen: 0}, []],
+			update: {tick: (state) => [{seen: state.seen + 1}, []]},
+			interpret: {notify: () => Promise.resolve()},
+		}),
+		ports: {},
+		handlers: {notify: () => Effect.succeed([] as ReadonlyArray<Msg>)},
+		spells: row.spells.map(spellNamed),
+		capabilities: [],
+		identity: {
+			package: "@kampus/tuval",
+			program: row.id,
+			version: "1.0.0",
+			digest: `sha256:${row.id}`,
+		},
+		placement: {host: "local"},
+	}) satisfies Program<State, Msg, Notify, never, unknown, never, never>;
+
+const declared = JSON.parse(
+	readFileSync(process.env.TUVAL_RELOAD_FIXTURE ?? "", "utf8"),
+) as DeclaredConfig;
+
+export default {
+	version: 1,
+	programs: declared.programs.map(program),
+	keys: declared.keys,
+} satisfies TuvalConfigInput;

--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -4,7 +4,7 @@
  * under the cwd's `.tuval`, project over global.
  *
  * Configuration is code the user owns (the Neovim model, #7484 R1.1): a TypeScript module whose
- * default export is a `{version: 1, programs, graph?}` config. Loading refuses on any defect the
+ * default export is a `{version: 1, programs, graph?, keys?}` config. Loading refuses on any defect the
  * loader can see — the module throwing, no default export, an export the schema rejects — and
  * every refusal names the module and the reason, so boot never runs on a half-read config. A
  * module that is not there is an empty layer, never a refusal: the layer is optional and the bin
@@ -15,8 +15,15 @@
  * decoded structurally; the ports slice refuses a malformed one when it compiles.
  */
 
+import {dirname} from "node:path";
 import {pathToFileURL} from "node:url";
 import {Effect, FileSystem, Option, Predicate, Schema, SchemaIssue} from "effect";
+import {
+	type BindingSource,
+	type ConfigLayer,
+	describeFile,
+	KeyBindings,
+} from "./commands/bindings/index.ts";
 import {type Graph, NodeId} from "./ports/graph.ts";
 import {ProgramId} from "./registry/program.ts";
 
@@ -43,6 +50,8 @@ export const TuvalConfig = Schema.Struct({
 	version: Schema.Literal(1),
 	programs: Schema.Array(ProgramRow),
 	graph: GraphSchema.pipe(Schema.withDecodingDefaultKey(Effect.succeed({nodes: []}))),
+	/** Key to command string, read by the parser and compiled against the registry at boot. */
+	keys: KeyBindings.pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
 });
 
 export type TuvalConfig = typeof TuvalConfig.Type;
@@ -113,9 +122,26 @@ export interface ConfigLayers {
 export interface LoadedConfig {
 	readonly programs: ReadonlyArray<unknown>;
 	readonly graph: Graph;
+	/**
+	 * One binding source per layer that existed, global first. They stay apart rather than merging
+	 * into one record so a binding error names the module its author wrote it in; a later layer's
+	 * binding for a key a lower layer also bound wins, because a key router reads the list in order.
+	 */
+	readonly keys: ReadonlyArray<BindingSource>;
 	/** The layer modules that existed and were merged, global first. */
 	readonly sources: ReadonlyArray<string>;
 }
+
+/**
+ * A config module sits at `<base>/.tuval/tuval.config.ts`, so its base is two directories up and
+ * an error names it `global .tuval/tuval.config.ts`. A module somewhere else falls back to its bare
+ * file name inside `describeFile`, which is the rule keeping a machine's directory layout out of a
+ * line people paste into issues.
+ */
+const bindingSource = (layer: ConfigLayer, path: string, keys: KeyBindings): BindingSource => ({
+	file: describeFile({layer, path, base: dirname(dirname(path))}),
+	bindings: keys,
+});
 
 const rowId = (row: unknown): string => (row as {readonly id: string}).id;
 
@@ -139,12 +165,16 @@ export const loadLayeredConfig = Effect.fn("Tuval.loadLayeredConfig")(function* 
 ) {
 	const global = yield* loadOptional(layers.global);
 	const project = yield* loadOptional(layers.project);
-	const empty: TuvalConfig = {version: 1, programs: [], graph: {nodes: []}};
+	const empty: TuvalConfig = {version: 1, programs: [], graph: {nodes: []}, keys: {}};
 	const base = Option.getOrElse(global, () => empty);
 	const over = Option.getOrElse(project, () => empty);
 	return {
 		programs: mergeById(base.programs, over.programs, rowId),
 		graph: {nodes: mergeById(base.graph.nodes, over.graph.nodes, (node) => node.id)},
+		keys: [
+			...(Option.isSome(global) ? [bindingSource("global", layers.global, base.keys)] : []),
+			...(Option.isSome(project) ? [bindingSource("project", layers.project, over.keys)] : []),
+		],
 		sources: [
 			...(Option.isSome(global) ? [layers.global] : []),
 			...(Option.isSome(project) ? [layers.project] : []),

--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -96,10 +96,26 @@ const describeIssue = (error: Schema.SchemaError): string => {
 
 const decodeConfig = Schema.decodeUnknownEffect(TuvalConfig);
 
-export const loadConfigModule = Effect.fn("Tuval.loadConfigModule")(function* (modulePath: string) {
+/**
+ * Node caches an ES module by URL for the life of the process, so a second load of the same path
+ * would answer with the config the first one read and a reload could never see an edit. Each load
+ * stamps its own number on the URL to read the file as it stands now; the copy it replaces stays in
+ * Node's cache, which is what reading a config twice costs. The number is per load and not per
+ * module, so one load importing both layers imports a module they share exactly once.
+ */
+let loads = 0;
+const nextLoad = (): number => (loads += 1);
+
+const moduleUrl = (modulePath: string, load: number): string =>
+	`${pathToFileURL(modulePath).href}?tuval-load=${load}`;
+
+export const loadConfigModule = Effect.fn("Tuval.loadConfigModule")(function* (
+	modulePath: string,
+	load: number = nextLoad(),
+) {
 	const refuse = (reason: string) => new ConfigLoadError({module: modulePath, reason});
 	const loaded = yield* Effect.tryPromise({
-		try: (): Promise<Record<string, unknown>> => import(pathToFileURL(modulePath).href),
+		try: (): Promise<Record<string, unknown>> => import(moduleUrl(modulePath, load)),
 		catch: (cause) => refuse(`module threw while loading: ${thrownMessage(cause)}`),
 	});
 	if (!("default" in loaded)) {
@@ -153,18 +169,21 @@ const mergeById = <T>(base: ReadonlyArray<T>, over: ReadonlyArray<T>, key: (item
 	return [...merged, ...over.filter((item) => !baseKeys.has(key(item)))];
 };
 
-const loadOptional = Effect.fn("Tuval.loadOptional")(function* (modulePath: string) {
+const loadOptional = Effect.fn("Tuval.loadOptional")(function* (modulePath: string, load: number) {
 	const fs = yield* FileSystem.FileSystem;
 	const present = yield* fs.exists(modulePath).pipe(Effect.orElseSucceed(() => false));
-	return present ? Option.some(yield* loadConfigModule(modulePath)) : Option.none<TuvalConfig>();
+	return present
+		? Option.some(yield* loadConfigModule(modulePath, load))
+		: Option.none<TuvalConfig>();
 });
 
 /** Both layers, absent ones empty, merged project-over-global by program id and node id. */
 export const loadLayeredConfig = Effect.fn("Tuval.loadLayeredConfig")(function* (
 	layers: ConfigLayers,
 ) {
-	const global = yield* loadOptional(layers.global);
-	const project = yield* loadOptional(layers.project);
+	const load = nextLoad();
+	const global = yield* loadOptional(layers.global, load);
+	const project = yield* loadOptional(layers.project, load);
 	const empty: TuvalConfig = {version: 1, programs: [], graph: {nodes: []}, keys: {}};
 	const base = Option.getOrElse(global, () => empty);
 	const over = Option.getOrElse(project, () => empty);

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -7,6 +7,9 @@ import {ConfigLoadError, loadConfigModule, loadLayeredConfig} from "./config.ts"
 const fixture = (name: string) =>
 	fileURLToPath(new URL(`./config-fixtures/${name}.ts`, import.meta.url));
 
+/** How `describeFile` names a fixture module: relative to the directory two levels above it. */
+const layerName = (name: string) => `config-fixtures/${name}.ts`;
+
 const refusal = async (name: string): Promise<ConfigLoadError> => {
 	const error = await Effect.runPromise(Effect.flip(loadConfigModule(fixture(name))));
 	expect(error).toBeInstanceOf(ConfigLoadError);
@@ -21,7 +24,12 @@ const layered = (global: string, project: string) =>
 describe("loadConfigModule", () => {
 	it("returns the rows a well-formed module exports, and an empty graph when it exports none", async () => {
 		const config = await Effect.runPromise(loadConfigModule(fixture("two-rows")));
-		expect(config).toEqual({version: 1, programs: [{id: "a"}, {id: "b"}], graph: {nodes: []}});
+		expect(config).toEqual({
+			version: 1,
+			programs: [{id: "a"}, {id: "b"}],
+			graph: {nodes: []},
+			keys: {},
+		});
 	});
 
 	it("returns the graph a module exports beside its rows", async () => {
@@ -30,6 +38,7 @@ describe("loadConfigModule", () => {
 			version: 1,
 			programs: [{id: "a"}],
 			graph: {nodes: [{id: "n", program: "a", on: []}]},
+			keys: {},
 		});
 	});
 
@@ -78,6 +87,10 @@ describe("loadLayeredConfig", () => {
 					{id: "m", program: "a", on: []},
 				],
 			},
+			keys: [
+				{file: `global ${layerName("global-layer")}`, bindings: {}},
+				{file: `project ${layerName("project-layer")}`, bindings: {}},
+			],
 			sources: [fixture("global-layer"), fixture("project-layer")],
 		});
 	});
@@ -87,18 +100,31 @@ describe("loadLayeredConfig", () => {
 		expect(await layered(missing, fixture("with-graph"))).toEqual({
 			programs: [{id: "a"}],
 			graph: {nodes: [{id: "n", program: "a", on: []}]},
+			keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
 			sources: [fixture("with-graph")],
 		});
 		expect(await layered(fixture("two-rows"), missing)).toEqual({
 			programs: [{id: "a"}, {id: "b"}],
 			graph: {nodes: []},
+			keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
 			sources: [fixture("two-rows")],
 		});
 		expect(await layered(missing, missing)).toEqual({
 			programs: [],
 			graph: {nodes: []},
+			keys: [],
 			sources: [],
 		});
+	});
+
+	it("carries each layer's key bindings as its own source, named for the layer", async () => {
+		const config = await layered(fixture("keys"), fixture("does-not-exist"));
+		expect(config.keys).toEqual([
+			{
+				file: `global ${layerName("keys")}`,
+				bindings: {"ctrl-h": "help", "ctrl-x": {command: "spell list", repeat: true}},
+			},
+		]);
 	});
 
 	it("still refuses a layer that exists and is broken", async () => {

--- a/apps/tuval/src/reload-proof.unit.test.ts
+++ b/apps/tuval/src/reload-proof.unit.test.ts
@@ -1,0 +1,230 @@
+/**
+ * The reload proof: a config read again replaces the spell registry and the key bindings in one
+ * step, and a reader watching across the swap never catches one of them new beside the other old
+ * (#7645).
+ *
+ * The config layer is `config-fixtures/reloadable.ts`, whose programs, spells and keys come from a
+ * JSON file this test rewrites between the two loads, so the second load is a genuinely different
+ * config rather than a second call over the same one.
+ */
+
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Fiber, type FileSystem, Schema, type Scope} from "effect";
+import {afterEach} from "vitest";
+import {type Booted, boot, coreSpells, projectDir} from "./boot.ts";
+import {HelpRows} from "./commands/core/help.ts";
+import {SpellExecutor} from "./commands/executor.ts";
+import {ClientId, renderPath, WorkspaceId} from "./commands/spell.ts";
+import {SpellSet} from "./commands/spell-set.ts";
+import type {DeclaredConfig} from "./config-fixtures/reloadable.ts";
+import {CallId} from "./protocol/ids.ts";
+import {PROTOCOL_VERSION, SpellCall} from "./protocol/messages.ts";
+
+const reloadable = fileURLToPath(new URL("./config-fixtures/reloadable.ts", import.meta.url));
+
+const client = {id: ClientId.make("test"), workspace: WorkspaceId.make("ws-1")};
+
+const tempDirs: string[] = [];
+const freshDir = (prefix: string) => {
+	const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+	tempDirs.push(dir);
+	return dir;
+};
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, {recursive: true, force: true});
+	delete process.env.TUVAL_RELOAD_FIXTURE;
+});
+
+/** Two programs, one spell each, both bound to a key. */
+const first: DeclaredConfig = {
+	programs: [
+		{id: "alpha", spells: ["say"]},
+		{id: "beta", spells: ["greet"]},
+	],
+	keys: {"ctrl-a": "alpha say", "ctrl-b": "beta greet"},
+};
+
+/**
+ * `alpha`'s spell is renamed, so the key still bound to the old name no longer compiles. The new
+ * name is one edit away and the old name is not a prefix of it, which is what makes the refusal
+ * carry a suggestion: a name the old one still prefixes reads as a line someone is halfway through
+ * typing, and that refusal has nothing to suggest.
+ */
+const second: DeclaredConfig = {
+	programs: [
+		{id: "alpha", spells: ["sey"]},
+		{id: "beta", spells: ["greet"]},
+	],
+	keys: first.keys,
+};
+
+const declare = (path: string, config: DeclaredConfig) =>
+	writeFileSync(path, JSON.stringify(config));
+
+/** A booted app over the reloadable layer, its fixture file already holding `first`. */
+const bootReloadable = Effect.fnUntraced(function* () {
+	const project = freshDir("tuval-reload-");
+	mkdirSync(projectDir(project));
+	const declaration = join(freshDir("tuval-declared-"), "config.json");
+	declare(declaration, first);
+	process.env.TUVAL_RELOAD_FIXTURE = declaration;
+	const booted = yield* boot({global: reloadable, project});
+	return {booted, declaration};
+});
+
+const spellPaths = (booted: Booted) =>
+	SpellSet.use((set) => set.read).pipe(
+		Effect.map((state) => state.table.rows.map((row) => renderPath(row.path))),
+		Effect.provideContext(booted.kernel),
+	);
+
+/** `help` as a person runs it, through the executor the kernel wired. */
+const help = (booted: Booted) =>
+	Effect.gen(function* () {
+		const executor = yield* SpellExecutor;
+		const reply = yield* executor.execute(
+			new SpellCall({
+				type: "spell.call",
+				version: PROTOCOL_VERSION,
+				id: CallId.make("help-1"),
+				path: ["help"],
+				args: {},
+			}),
+			client,
+		);
+		assert.isTrue(reply.outcome.ok, "help failed");
+		return yield* Schema.decodeUnknownEffect(HelpRows)(
+			reply.outcome.ok ? reply.outcome.result : undefined,
+		).pipe(Effect.orDie);
+	}).pipe(Effect.provideContext(booted.kernel));
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Scope.Scope>) =>
+	effect.pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
+
+describe("a config reload", () => {
+	it.live("registers the reloaded config's spells and drops the ones it removed", () =>
+		run(
+			Effect.gen(function* () {
+				const {booted, declaration} = yield* bootReloadable();
+				assert.strictEqual(booted.report.spellCount, coreSpells.length + 2);
+				assert.deepStrictEqual(booted.report.bindingErrors, []);
+				assert.strictEqual(booted.report.bindingCount, 2);
+				assert.includeMembers(yield* spellPaths(booted), ["alpha.say", "beta.greet"]);
+				assert.includeMembers(
+					(yield* help(booted)).map((row) => row.path),
+					["alpha say", "beta greet"],
+					"help did not list the config's spells",
+				);
+
+				declare(declaration, second);
+				const report = yield* booted.reload;
+
+				assert.strictEqual(report.spellCount, coreSpells.length + 2);
+				const paths = yield* spellPaths(booted);
+				assert.includeMembers(paths, ["alpha.sey", "beta.greet"]);
+				assert.notInclude(paths, "alpha.say", "the renamed spell is still registered");
+				const rows = (yield* help(booted)).map((row) => row.path);
+				assert.includeMembers(rows, ["alpha sey"], "help did not reflect the reload");
+				assert.notInclude(rows, "alpha say", "help still lists the spell the reload removed");
+			}),
+		),
+	);
+
+	it.live(
+		"reports the binding that stopped compiling with all five of its parts, and keeps the rest",
+		() =>
+			run(
+				Effect.gen(function* () {
+					const {booted, declaration} = yield* bootReloadable();
+					declare(declaration, second);
+					const report = yield* booted.reload;
+
+					assert.strictEqual(report.bindingErrors.length, 1, "expected one binding to have broken");
+					const [broken] = report.bindingErrors;
+					assert.isDefined(broken);
+					assert.strictEqual(broken?.key, "ctrl-a");
+					assert.strictEqual(broken?.file, "global config-fixtures/reloadable.ts");
+					assert.isTrue((broken?.position ?? -1) >= 0, "the error points at no position");
+					assert.isTrue((broken?.expected ?? "").length > 0, "the error expects nothing");
+					assert.strictEqual(broken?.didYouMean, "sey");
+					assert.strictEqual(
+						broken?.message,
+						'global config-fixtures/reloadable.ts: cannot bind "ctrl-a": at character 6, expected sey; did you mean "sey"?',
+						"the five parts did not render in order",
+					);
+					assert.notInclude(
+						broken?.message ?? "",
+						tmpdir(),
+						"a binding error named a machine path",
+					);
+
+					const state = yield* SpellSet.use((set) => set.read).pipe(
+						Effect.provideContext(booted.kernel),
+					);
+					assert.deepStrictEqual(
+						state.bindings.bindings.map((binding) => binding.key),
+						["ctrl-b"],
+						"the binding that still compiles did not survive the reload",
+					);
+				}),
+			),
+	);
+
+	it.live("swaps the registry and the binding table in one step, with no window between them", () =>
+		run(
+			Effect.gen(function* () {
+				const {booted, declaration} = yield* bootReloadable();
+				declare(declaration, second);
+
+				const observations: Array<{
+					readonly paths: ReadonlyArray<string>;
+					readonly bound: ReadonlyArray<string>;
+				}> = [];
+				const watch = SpellSet.use((set) => set.read).pipe(
+					Effect.flatMap((state) =>
+						Effect.sync(() => {
+							observations.push({
+								paths: state.table.rows.map((row) => renderPath(row.path)),
+								bound: state.bindings.bindings.map((binding) => renderPath(binding.path)),
+							});
+						}),
+					),
+					Effect.provideContext(booted.kernel),
+				);
+				const reader = yield* Effect.forkChild(Effect.forever(watch));
+
+				yield* booted.reload;
+				// The reader has to run once more after the swap, or the last sample it took is the
+				// one from before it and the check below would pass without ever seeing the new pair.
+				yield* Effect.sleep("5 millis");
+				yield* Fiber.interrupt(reader);
+
+				assert.isTrue(observations.length > 1, "the reader took no samples across the reload");
+				for (const observed of observations) {
+					// The one thing a half-replaced pair would show: a binding compiled against a table
+					// that no longer holds the spell it points at.
+					for (const bound of observed.bound) {
+						assert.include(
+							observed.paths,
+							bound,
+							"a binding was observed beside a registry that does not hold its spell",
+						);
+					}
+				}
+				const last = observations.at(-1);
+				assert.include(last?.paths ?? [], "alpha.sey", "the reader never saw the reloaded table");
+				assert.deepStrictEqual(
+					last?.bound,
+					["beta.greet"],
+					"the reader never saw the reloaded bindings",
+				);
+			}),
+		),
+	);
+});


### PR DESCRIPTION
Fixes #7645

Tuval's command framework is wired into the app entry, and the epic's done condition is proved: a
scripted program running inside Tuval enumerates every spell a human can see and calls each one,
over the wire only.

**Boot.** `start` joins the spell registry, the executor, the bridge and the three process spells to
the kernel's layers, and boot reports the spell count beside the program count:

```
tuval: booted — 2 program(s), 6 spell(s) registered from …/apps/tuval/.tuval/tuval.config.ts; 2 process(es) live, 0 restored from …/apps/tuval/.tuval
```

**One cell, not two.** A key binding is only ever as valid as the registry table it was compiled
against, so `SpellSet` (`apps/tuval/src/commands/spell-set.ts`) holds the table, the config's key
sources and the bindings compiled from them in a single `Ref`, written in a single `Ref.set`. Its
layer hands out `SpellSet` and `SpellRegistry`, both reading that one cell, so a reader's single
`Ref.get` sees both halves of one config and there is no window in which one is new and the other
old. `SpellRegistry.swap` recompiles rather than leaving the bindings behind, so even the narrower
entry cannot break the pair.

**A config's `keys`.** The config schema gains an optional `keys` block, one binding source per
layer so an error names the module its author wrote it in, compiled at boot and again on every
reload. A binding that does not compile costs its own key and is reported with all five parts;
boot prints one line per broken binding and goes on.

**The three proofs.**

- `apps/tuval/src/commands/agent-proof.unit.test.ts` — an ordinary program row whose script calls
  `spell list`, then `spell describe` on every path it was given, then every spell with arguments
  generated from that spell's own `params`. Every call is encoded to JSON, decoded by the kernel,
  answered, encoded back and decoded again. The set it calls equals the set `help` lists, and every
  reply decodes against the spell's `result`, which the agent never held.
- `apps/tuval/src/reload-proof.unit.test.ts` — boot on a config, rewrite it, reload: the new spells
  are registered, `help` reflects them, the binding that stopped compiling is reported with its
  module, key, position, expectation and suggestion, the other binding survives, and a reader
  forked across the swap never sees a binding beside a registry that does not hold its spell.
- `apps/tuval/src/commands/wire-proof.unit.test.ts` — one reply per call each carrying its own id, a
  `Snapshot` carrying the registry, a `Patch` applied over that snapshot after a mutation, and an
  undecodable message refused with its reason.

**Base branch.** This targets `epic/7627`, not `main`. `fabrika build pr` has no `--base` (#7733),
so the PR was opened against the default branch and retargeted with `gh api -X PATCH` immediately
after.

Patterns: [tuval-spells.md](.patterns/tuval-spells.md) (extended here with the `SpellSet` cell, the
shared `lookupRow`, boot's wiring and the module-cache note), [effect-context-service.md](.patterns/effect-context-service.md),
[effect-layer-composition.md](.patterns/effect-layer-composition.md),
[effect-fn-tracing.md](.patterns/effect-fn-tracing.md), [effect-errors.md](.patterns/effect-errors.md),
[effect-testing.md](.patterns/effect-testing.md), [effect-schema-validation.md](.patterns/effect-schema-validation.md),
[ci-legible-integration-tests.md](.patterns/ci-legible-integration-tests.md) (its fail-fast-and-name-the-cause
discipline, applied to the unit tier: every wait is capped and every assertion carries the message
that names its cause).

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 2 ends "the test is green in CI on
  `ScriptedAiAgent`". **Did:** the proof's agent is a plain scripted program row, and nothing here
  touches `ScriptedAiAgent` or `aiAgentProgram`. **Why:** the issue's 2026-09-04 amendment records
  the founder's ruling that the agent is a plain scripted process sending `SpellCall`s over the
  wire, and drops the graph edge on #7603 so this epic no longer waits on the Pi epic. The
  amendment supersedes that clause. **Disposition:** stated here; the amendment also owes a
  follow-up, that once #7603 lands a Pi child re-runs this proof on `ScriptedAiAgent.layer`, and
  that follow-up is the amendment's own rather than this PR's.
- **Pre-existing test or fixture changed** — **Said:** every existing kernel test still passes
  unchanged. **Did:** three test files changed. `boot.unit.test.ts` expects the new boot line and
  the new report fields; `config.unit.test.ts` expects the loader's new `keys` output;
  `commands/spell.unit.test.ts` lists `spell-set.ts` in its module scan. **Why:** each is forced by
  something the issue asks for — the spell count printed beside the program count, `keys` in the
  config, a new module in the commands slice. `src/demo/e2e.unit.test.ts` and every other kernel
  test are untouched and green. **Disposition:** stated here; `StartOptions.keys` is optional so
  `start`'s existing callers keep compiling with no edit.
- **Out-of-scope change** — **Said:** #7645 is boot wiring and the proofs. **Did:** also extracted
  `lookupRow` into `commands/registry.ts` and pointed `bindings/compile.ts` at it. **Why:** the trie
  walk was already written twice and `SpellSet` needed it a third time; exporting the one walk was
  the alternative to a third copy. **Disposition:** stated here, and the pattern doc's registry
  section names `lookupRow` as the one walk every reader takes.
- **Known defect left unfixed** — **Said:** the bridge joins the kernel's layers. **Did:** it does,
  with `everyPath` over the boot-time table, and a config reload leaves that allowlist behind while
  the registry moves on. **Why:** the allowlist is captured at layer build, and where it should come
  from instead is a design question `.patterns/tuval-spells.md` already says a later child owns.
  Nothing consumes the bridge in the shipped app yet. **Disposition:** filed as
  https://github.com/kamp-us/phoenix/issues/7743 and noted in the pattern doc.
- **Governing-ADR departure** — **Said:** nothing in ADR 0348 asks the config loader to change.
  **Did:** a config module is now imported with a per-load number on its URL. **Why:** Node caches
  an ES module by URL for the life of the process, so without it a reload answers with the config
  the first boot read and the reload proof would be proving nothing. **Disposition:** stated here
  and at the code; the cost is real, that each reload leaves the previous copy in Node's module
  cache, so a process reloading its config all day grows.
