### PR TITLE
fix: CI e2e sign-ups poison the preview D1 that preview-seed test-account guards

### DIFF
--- a/.decisions/0349-preview-seed-fence-keys-on-d1-name.md
+++ b/.decisions/0349-preview-seed-fence-keys-on-d1-name.md
@@ -1,0 +1,69 @@
+---
+id: 0349
+title: preview-seed's throwaway fence keys on the D1 database name, not on human-row count
+status: accepted
+date: 2026-09-03
+tags: [preview-seed, review-ui, security, ci, d1]
+---
+
+# 0349 — preview-seed's throwaway fence keys on the D1 database name, not on human-row count
+
+**What this decides:** `preview-seed test-account` refuses a target whose Cloudflare-recorded D1
+name does not carry the per-PR preview segment `-pr-`. It no longer counts human `user` rows.
+
+## Context
+
+The fence exists so nobody can mint a moderator identity plus a live session token in a real
+database. Its first form was emptiness: refuse any target holding a human `user` row that is none
+of the test identities. The reasoning was that a preview D1 deploys empty, so rows are evidence of
+somebody's real world.
+
+CI falsified that premise. The Playwright e2e job runs against the same per-PR preview D1 the
+capture route seeds — `.github/workflows/ci.yml` hands it `E2E_D1_DATABASE_ID:
+${{ steps.preview.outputs.db }}` — and 30 specs sign real users up through
+`/api/auth/sign-up/email` via `apps/web/tests/e2e/_helpers/auth.ts`. Nothing in `.github/` ever
+invoked `test-account`, so provisioning only ever happened after those sign-ups. Every preview
+whose e2e job had run refused forever, which is most of them, and `review-ui render --surface
+<route>:auth` / `:auth-caylak` — the whole point of #7398 — had nowhere left to run. #7708 and
+#7045 both parked on this wall, and every ticket under epic #4304 met it (issue
+[#7740](https://github.com/kamp-us/phoenix/issues/7740)).
+
+Four shapes were on the table: re-key the fence on the name, seed the identities in CI before e2e,
+give the capture its own D1, or have e2e tag its sign-ups.
+
+## Decision
+
+Key it on the name. Founder ruling, 2026-09-04:
+[#7740 comment](https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5535874078) — a database
+whose name contains `-pr-` (the per-PR preview shape `phoenix-phoenix-db-pr-<n>-…`) is throwaway;
+anything else, including `…-prod-…` and any renamed stage, refuses, fail closed.
+
+The name is resolved from Cloudflare's own record for the given `--database-id`
+(`GET /accounts/{account_id}/d1/database/{id}`, through `@kampus/d1-rest`'s `resolveDatabaseName`),
+never composed by the caller. A record that comes back with no name is UNKNOWN and refuses too.
+
+## Why this is not a relaxation the README argued against
+
+`packages/preview-seed/README.md` carried a standing argument that there must be no override flag,
+because an override puts the decision back in the caller's hands. That argument survives intact and
+is the reason this shape was picked over "tag the e2e sign-ups" or a `--yes-really` flag: the deploy
+stack writes the database's name and the caller cannot, so there is still nothing here a caller can
+assert their way past. What changes is which fact about the target the fence reads, not who gets to
+decide.
+
+The reach is narrower in one direction and wider in another, and both are stated in the README:
+production and every named stage are caught, because none of them carries `-pr-`; a database
+somebody deliberately named to look like a per-PR preview is not caught, exactly as the old check
+did not catch an empty non-throwaway. The operator still owns which `--database-id` they pass.
+
+## Consequences
+
+- A preview full of e2e sign-ups provisions cleanly, which is the normal case the old fence
+  refused.
+- The refusal now names the database's name rather than a row count, so an operator reads why
+  directly.
+- `countForeignAccounts` is gone from `@kampus/preview-seed`; the fence is
+  `isThrowawayDatabaseName`, a pure predicate, decided before any token is read.
+- `test-account` needs D1 *read* on the account token as well as write, for the name lookup.
+- Seeding the identities in CI ahead of e2e (shape 2) is no longer needed for this wall, and is not
+  taken here.

--- a/.decisions/0349-preview-seed-fence-keys-on-d1-name.md
+++ b/.decisions/0349-preview-seed-fence-keys-on-d1-name.md
@@ -2,7 +2,7 @@
 id: 0349
 title: preview-seed's throwaway fence keys on the D1 database name, not on human-row count
 status: accepted
-date: 2026-09-03
+date: 2026-09-04
 tags: [preview-seed, review-ui, security, ci, d1]
 ---
 
@@ -63,7 +63,12 @@ did not catch an empty non-throwaway. The operator still owns which `--database-
 - The refusal now names the database's name rather than a row count, so an operator reads why
   directly.
 - `countForeignAccounts` is gone from `@kampus/preview-seed`; the fence is
-  `isThrowawayDatabaseName`, a pure predicate, decided before any token is read.
-- `test-account` needs D1 *read* on the account token as well as write, for the name lookup.
+  `isThrowawayDatabaseName`, a pure predicate. The `test-account` bin resolves the name and
+  decides the fence before it reads either tier token, so a refused run never parses a live
+  preview credential; `provisionTestAccounts` re-decides it for any other caller.
+- No new permission group. `GET /accounts/{account_id}/d1/database/{id}` accepts `D1 Read`
+  *or* `D1 Write` ([Cloudflare API reference](https://developers.cloudflare.com/api/resources/d1/subresources/database/methods/get/),
+  "Accepted Permissions (at least one required)"), so the CI token's existing `D1 Write` grant
+  in `infra/ci-credentials/permission-groups.ts` covers the name lookup unchanged.
 - Seeding the identities in CI ahead of e2e (shape 2) is no longer needed for this wall, and is not
   taken here.

--- a/packages/d1-rest/README.md
+++ b/packages/d1-rest/README.md
@@ -20,6 +20,12 @@ consumer touches:
 - `makeD1RestFromEnv(target)` / `d1RestLayerFromEnv` — the env-credentialed convenience
   (`$CLOUDFLARE_API_TOKEN` via `CredentialsFromEnv` + a Fetch client) a bin and its
   integration test both run the real direct-D1 work through.
+- `resolveDatabaseName(config)` / `resolveDatabaseNameFromEnv(target)` — the `name`
+  Cloudflare has recorded for a database id (`GET /accounts/{id}/d1/database/{id}`).
+  The deploy stack writes that name and the caller cannot, which is what makes it usable
+  as evidence about what a database *is* — `@kampus/preview-seed`'s throwaway fence keys
+  on it (#7740). A record that comes back without a name throws rather than returning a
+  value a fence would have to interpret.
 - `readYourWrite(read, isConsistent, options?)` — a bounded read-your-writes poll for callers
   that need read-after-write consistency over this transport. The REST `/query` endpoint
   carries no D1 session bookmark (that Sessions API primitive is Workers-binding-only), so an

--- a/packages/d1-rest/src/index.ts
+++ b/packages/d1-rest/src/index.ts
@@ -204,3 +204,32 @@ export const readYourWrite = async <T>(
 	}
 	return value;
 };
+
+/**
+ * The `name` Cloudflare has recorded for one D1 database id — the deploy stack's name, never the
+ * caller's word for it, which is what makes it usable as evidence about what a database IS
+ * (`@kampus/preview-seed`'s throwaway fence, issue #7740).
+ *
+ * `GET /accounts/{account_id}/d1/database/{databaseId}` returns `result.name` as an optional
+ * nullable field, so an answer without one is UNKNOWN rather than "no name": it throws instead of
+ * returning a value a fence would then have to interpret.
+ */
+export const resolveDatabaseName = async (config: D1RestConfig): Promise<string> => {
+	const {accountId, databaseId, layer} = config;
+	const response = await Effect.runPromise(
+		d1.getDatabase({accountId, databaseId}).pipe(Effect.provide(layer)),
+	);
+	const name = response.name;
+	if (typeof name !== "string" || name.length === 0) {
+		throw new Error(
+			`D1 ${databaseId} resolved to no name — Cloudflare returned a database record without one, so nothing can be decided from it.`,
+		);
+	}
+	return name;
+};
+
+/** {@link resolveDatabaseName} over the env-credentialed REST layer, like {@link makeD1RestFromEnv}. */
+export const resolveDatabaseNameFromEnv = (target: {
+	accountId: string;
+	databaseId: string;
+}): Promise<string> => resolveDatabaseName({...target, layer: d1RestLayerFromEnv});

--- a/packages/d1-rest/src/index.unit.test.ts
+++ b/packages/d1-rest/src/index.unit.test.ts
@@ -12,7 +12,13 @@ import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
 import {assert, describe, it} from "@effect/vitest";
 import {Layer} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
-import {assertRestParam, makeD1Rest, readYourWrite, toRestParams} from "./index.ts";
+import {
+	assertRestParam,
+	makeD1Rest,
+	readYourWrite,
+	resolveDatabaseName,
+	toRestParams,
+} from "./index.ts";
 
 const restD1 = (fetch: typeof globalThis.fetch): D1Database =>
 	makeD1Rest({
@@ -169,5 +175,54 @@ describe("readYourWrite — bounded read-your-writes poll (#3075/#3078)", () => 
 		assert.strictEqual(value, false);
 		assert.strictEqual(reads, 4);
 		assert.deepStrictEqual(delays, [50, 100, 200]);
+	});
+});
+
+// The name is evidence about what a database IS — `@kampus/preview-seed`'s throwaway fence keys on
+// it (#7740) — so an answer carrying no name must not reach a caller as a value to interpret.
+describe("resolveDatabaseName — the name Cloudflare has recorded for a database id", () => {
+	const target = (fetch: typeof globalThis.fetch) => ({
+		accountId: "acc",
+		databaseId: "db",
+		layer: Layer.mergeAll(
+			FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch)(fetch))),
+			fromApiToken({apiToken: "test-token"}),
+		),
+	});
+
+	const respond =
+		(result: unknown): typeof globalThis.fetch =>
+		async () =>
+			new Response(JSON.stringify({result}), {
+				status: 200,
+				headers: {"content-type": "application/json"},
+			});
+
+	it("returns the name off the database record", async () => {
+		const name = "phoenix-phoenix-db-pr-7717-td6ketak4e75f6i4";
+		assert.strictEqual(await resolveDatabaseName(target(respond({uuid: "db", name}))), name);
+	});
+
+	it("reads the record for the requested account and database", async () => {
+		let seen = "";
+		const spy: typeof globalThis.fetch = async (input) => {
+			seen = typeof input === "string" ? input : String((input as Request).url ?? input);
+			return new Response(JSON.stringify({result: {name: "n-pr-1-x"}}), {
+				status: 200,
+				headers: {"content-type": "application/json"},
+			});
+		};
+		await resolveDatabaseName(target(spy));
+		assert.include(seen, "/accounts/acc/d1/database/db");
+	});
+
+	it("throws rather than returning an empty name", async () => {
+		for (const result of [{uuid: "db"}, {uuid: "db", name: null}, {uuid: "db", name: ""}]) {
+			const thrown = await resolveDatabaseName(target(respond(result))).then(
+				() => null,
+				(error: unknown) => error,
+			);
+			assert.instanceOf(thrown, Error, `${JSON.stringify(result)} must throw`);
+		}
 	});
 });

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -51,8 +51,10 @@ node packages/preview-seed/src/bin.ts run --database-id <stage-d1-uuid>
   alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
 - `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
 - `$CLOUDFLARE_API_TOKEN` — the minted CI token (carries `D1 Write`); read by
-  `CredentialsFromEnv`. `test-account` also reads the database's name through it, so
-  the token needs `D1 Read` on the account as well.
+  `CredentialsFromEnv`. `test-account` also reads the database's name through it, and
+  `GET /accounts/{id}/d1/database/{id}` lists `D1 Read` and `D1 Write` under
+  ["Accepted Permissions (at least one required)"](https://developers.cloudflare.com/api/resources/d1/subresources/database/methods/get/),
+  so the existing grant already covers the lookup and no new permission group is needed.
 
 Transport is the Cloudflare D1 REST query API via alchemy's already-installed
 `@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
@@ -167,7 +169,10 @@ ruling of 2026-09-04 re-keyed it on the name —
 Say the reach exactly, because the argument against an override flag rests on it.
 The check is *the name Cloudflare has recorded for this database id contains `-pr-`*.
 It catches every production and stage database, because none of them carries that
-segment, and it is decided before the tokens are even read. It does **not** catch a
+segment. The verb decides it before it reads either tier token, so a run against a real
+database refuses on the target alone and no live preview credential is parsed into the
+process first (`src/bin.ts` resolves the name and refuses ahead of `readTierToken`; the
+same check runs again inside `provisionTestAccounts`, for every other caller). It does **not** catch a
 database somebody deliberately named to look like a per-PR preview, and it does not
 care what rows the target holds — a preview full of e2e sign-ups passes, which is the
 whole point. The operator still owns which `--database-id` they pass.

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -51,7 +51,8 @@ node packages/preview-seed/src/bin.ts run --database-id <stage-d1-uuid>
   alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
 - `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
 - `$CLOUDFLARE_API_TOKEN` — the minted CI token (carries `D1 Write`); read by
-  `CredentialsFromEnv`.
+  `CredentialsFromEnv`. `test-account` also reads the database's name through it, so
+  the token needs `D1 Read` on the account as well.
 
 Transport is the Cloudflare D1 REST query API via alchemy's already-installed
 `@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
@@ -71,8 +72,10 @@ PREVIEW_TEST_CAYLAK_SESSION_TOKEN=<a different 32+ char secret> \
   node packages/preview-seed/src/bin.ts test-account --database-id <preview-d1-uuid>
 ```
 
-Every write lands in one atomic D1 `batch`: a `user` row and a `session` row per
-tier, plus the `(id, "moderates", "platform:platform")` tuple that is the real
+The target must be a per-PR preview: the verb resolves the id's name through the
+Cloudflare API first and refuses anything that is not `…-db-pr-<n>-…` (the guard
+boundary below). Every write lands in one atomic D1 `batch`: a `user` row and a
+`session` row per tier, plus the `(id, "moderates", "platform:platform")` tuple that is the real
 moderation authority (ADR 0107 §4; `user.role` is vestigial and written only so a
 coarse read agrees). Re-running it upserts the same rows, so a token is rotated by
 re-running with a new one.
@@ -144,28 +147,37 @@ fail-open security hole (CLAUDE.md, "Sözlük seed"). Nothing in this path may b
 rebuilt as a worker endpoint — an account-minting route on the public worker is
 strictly worse than the seeder routes that were removed.
 
-**Throwaway stages and previews only, and the fence is not the caller's word for
-it.** A caller-asserted "this is a preview" proves nothing, so the verb reads the
-target instead: a preview/stage D1 deploys empty and this package's content
-fixtures denormalize their author, so a throwaway carries **no human `user` row at
-all**. Finding one that is none of the test identities, the verb refuses and writes
-nothing — that database is somebody's real world.
+**Per-PR previews only, and the fence is the database's name — never the caller's
+word for it.** A caller-asserted "this is a preview" proves nothing, so the verb
+resolves `--database-id` through the Cloudflare D1 API and reads the name the deploy
+stack gave it. alchemy composes a per-PR preview as `phoenix-phoenix-db-pr-<n>-<hash>`,
+so a name carrying `-pr-` is a throwaway; production (`…-db-prod-…`), a named dev
+stage, and a record the API returns with no name at all are each refused before any
+write.
 
-**The tier axis widens the identity list and nothing else.** Every seeded tier is
-excluded from that count, which is what keeps a re-run idempotent once both are on
-the D1 — a check that knew only one of them would call the other somebody's real
-world and refuse every subsequent run. It excludes exactly the fixed ids in the
-table above, so it does not admit one further row.
+**Why the name and not the rows.** The fence used to be emptiness — no human `user`
+row other than the test identities — and it could not survive contact with CI. The
+Playwright e2e job runs against the same preview D1 and signs real users up through
+`/api/auth/sign-up/email`, so by the time any seat can run this verb the preview holds
+dozens of human rows: the check refused every preview it was built for, and the `:auth`
+/ `:auth-caylak` captures were unreachable in practice (issue #7740). The founder
+ruling of 2026-09-04 re-keyed it on the name —
+[#7740 comment](https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5535874078).
 
 Say the reach exactly, because the argument against an override flag rests on it.
-The check is *no human `user` row other than the test identities*. It catches any
-database anyone has ever signed into, which is every real one in practice. It does
-**not** catch an empty database that is not a throwaway — a fresh apex deploy
-before the first sign-up, a wiped stage, a mistyped `--database-id` that resolves
-to a real-but-unpopulated D1 all pass it. The operator still owns which
-`--database-id` they pass. What the fence removes is the failure that actually
-happens: pointing at a live database and minting a moderator in it. There is no
-override flag, and adding one would be adding back the hole the check closes.
+The check is *the name Cloudflare has recorded for this database id contains `-pr-`*.
+It catches every production and stage database, because none of them carries that
+segment, and it is decided before the tokens are even read. It does **not** catch a
+database somebody deliberately named to look like a per-PR preview, and it does not
+care what rows the target holds — a preview full of e2e sign-ups passes, which is the
+whole point. The operator still owns which `--database-id` they pass.
+
+**There is still no override flag, and that argument survives the re-keying
+unchanged.** What the old check bought was that a caller cannot talk their way past
+the fence, and that is exactly what the name keeps: the name comes back from
+Cloudflare's record for the id, written by the deploy stack, so there is nothing here
+for a caller to assert. A flag would hand the decision back to the caller, which is
+the hole both versions of this fence exist to close.
 
 **Each token is a live credential on a running preview.** Every one is read only
 from its own environment variable (never a flag, so it stays out of process

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -12,6 +12,7 @@ import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {seed} from "./seed.ts";
 import {
+	isThrowawayDatabaseName,
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
 	PREVIEW_NAME_MARKER,
@@ -117,16 +118,27 @@ const testAccount = Command.make(
 		const resolvedAccount = Option.isSome(accountId)
 			? accountId.value
 			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+		const target = {accountId: resolvedAccount, databaseId, layer: restLayer};
+		const databaseName = yield* Effect.tryPromise({
+			try: () => resolveDatabaseName(target),
+			catch: (cause) => new D1RestError({cause}),
+		});
+		// The fence runs ahead of the token reads, not just ahead of the write: a run against a real
+		// database refuses on the target alone, so no live preview credential is parsed into this
+		// process first. `provisionTestAccounts` re-decides it for every other caller of the package.
+		if (!isThrowawayDatabaseName(databaseName)) {
+			return yield* new NotThrowawayError({databaseName, databaseId});
+		}
+
 		const credentials: PreviewCredentials = Object.fromEntries(
 			(yield* Effect.forEach(PREVIEW_TIERS, (tier) =>
 				readTierToken(tier).pipe(Effect.map((token) => [tier, token] as const)),
 			)).filter(([, token]) => token !== null),
 		);
 
-		const target = {accountId: resolvedAccount, databaseId, layer: restLayer};
 		const db = makeTestAccountDb(makeD1Rest(target));
 		const outcome = yield* Effect.tryPromise({
-			try: async () => provisionTestAccounts(db, await resolveDatabaseName(target), credentials),
+			try: () => provisionTestAccounts(db, databaseName, credentials),
 			catch: (cause) => new D1RestError({cause}),
 		});
 		if (outcome._tag === "NoCredentials") return yield* new NoCredentialsError();

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -6,7 +6,7 @@
  */
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {makeD1Rest} from "@kampus/d1-rest";
+import {makeD1Rest, resolveDatabaseName} from "@kampus/d1-rest";
 import {Config, Console, Effect, Layer, Option, Redacted, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
@@ -14,6 +14,7 @@ import {seed} from "./seed.ts";
 import {
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
+	PREVIEW_NAME_MARKER,
 	PREVIEW_TIERS,
 	type PreviewCredentials,
 	type PreviewTier,
@@ -70,13 +71,13 @@ const TIER_TOKEN_ENV: Readonly<Record<PreviewTier, string>> = {
 	çaylak: "PREVIEW_TEST_CAYLAK_SESSION_TOKEN",
 };
 
-/** The target is not a throwaway — a database holding somebody's accounts is never provisioned. */
+/** The target is not a per-PR preview — anything else is somebody's real world, and is refused. */
 class NotThrowawayError extends Schema.TaggedErrorClass<NotThrowawayError>()(
 	"@kampus/preview-seed/NotThrowawayError",
-	{foreignAccounts: Schema.Number, databaseId: Schema.String},
+	{databaseName: Schema.String, databaseId: Schema.String},
 ) {
 	override get message(): string {
-		return `preview-seed: D1 ${this.databaseId} holds ${this.foreignAccounts} account(s) that are none of the test identities — that is not a throwaway preview/stage, and no test account was written. Target a freshly deployed preview D1.`;
+		return `preview-seed: D1 ${this.databaseId} is named "${this.databaseName}", which is not a per-PR preview (a preview name carries "${PREVIEW_NAME_MARKER}") — no test account was written. Target the D1 a PR's preview-deploy comment names.`;
 	}
 }
 
@@ -122,16 +123,15 @@ const testAccount = Command.make(
 			)).filter(([, token]) => token !== null),
 		);
 
-		const db = makeTestAccountDb(
-			makeD1Rest({accountId: resolvedAccount, databaseId, layer: restLayer}),
-		);
+		const target = {accountId: resolvedAccount, databaseId, layer: restLayer};
+		const db = makeTestAccountDb(makeD1Rest(target));
 		const outcome = yield* Effect.tryPromise({
-			try: () => provisionTestAccounts(db, credentials),
+			try: async () => provisionTestAccounts(db, await resolveDatabaseName(target), credentials),
 			catch: (cause) => new D1RestError({cause}),
 		});
 		if (outcome._tag === "NoCredentials") return yield* new NoCredentialsError();
 		if (outcome._tag === "NotThrowaway") {
-			return yield* new NotThrowawayError({foreignAccounts: outcome.foreignAccounts, databaseId});
+			return yield* new NotThrowawayError({databaseName: outcome.databaseName, databaseId});
 		}
 		const provisioned = outcome.report.tiers
 			.map((tier) => `@${TEST_ACCOUNTS[tier].username} at ${tier}`)
@@ -143,7 +143,7 @@ const testAccount = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Provision the review-ui test accounts + their sessions on a throwaway preview/stage D1, one per tier whose token is set ($PREVIEW_TEST_SESSION_TOKEN for yazar, $PREVIEW_TEST_CAYLAK_SESSION_TOKEN for çaylak) — idempotent, refuses a database holding real accounts, and prints the tiers provisioned plus any left unseeded",
+		"Provision the review-ui test accounts + their sessions on a per-PR preview D1, one per tier whose token is set ($PREVIEW_TEST_SESSION_TOKEN for yazar, $PREVIEW_TEST_CAYLAK_SESSION_TOKEN for çaylak) — idempotent, refuses any database Cloudflare does not name as a per-PR preview, and prints the tiers provisioned plus any left unseeded",
 	),
 );
 

--- a/packages/preview-seed/src/index.ts
+++ b/packages/preview-seed/src/index.ts
@@ -20,9 +20,10 @@ export type {
 	TestAccount,
 } from "./test-account.ts";
 export {
-	countForeignAccounts,
+	isThrowawayDatabaseName,
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
+	PREVIEW_NAME_MARKER,
 	PREVIEW_TIERS,
 	parseSessionToken,
 	provisionTestAccounts,

--- a/packages/preview-seed/src/test-account.ts
+++ b/packages/preview-seed/src/test-account.ts
@@ -14,12 +14,14 @@
  * (ADR 0107 §4); the vestigial column is written beside it only so a coarse role read agrees. Only
  * the yazar identity carries that tuple: a çaylak with moderation authority is not a çaylak.
  *
- * The throwaway fence is the load-bearing part. A caller-asserted "this is a preview" proves
- * nothing, so the refusal is grounded in the database itself: a preview/stage D1 is deployed
- * empty and this package's content fixtures denormalize their author, so a throwaway carries no
- * human `user` row at all. One that carries somebody else's account is somebody's real world and
- * is refused before any write. The check is emptiness, not throwaway-ness — the README's
- * "guard boundary" section states its exact reach, and the operator still owns `--database-id`.
+ * The throwaway fence is the load-bearing part, and what it reads is the database's NAME. A
+ * caller-asserted "this is a preview" proves nothing, so the fence reads a fact the deploy stack
+ * sets and the caller cannot: Cloudflare's own record for the given `--database-id`. A per-PR
+ * preview is `phoenix-phoenix-db-pr-<n>-…`; anything else — `…-prod-…`, a renamed stage, a name
+ * the API declines to give — is refused before any write. It replaced an emptiness check that
+ * could never pass in practice, because CI's e2e suite signs human users up on every preview it
+ * tests — see ADR 0349 (#7740, founder ruling
+ * https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5535874078).
  *
  * No `account` row is written, and that is deliberate rather than an omission: better-auth
  * resolves a session through `internalAdapter.findSession` (`dist/db/internal-adapter.mjs` at the
@@ -28,7 +30,6 @@
  * carries credentials for signing IN, which this path skips by construction.
  */
 import {key, platform} from "@kampus/authz";
-import {and, eq, notInArray} from "drizzle-orm";
 import type {BatchItem} from "drizzle-orm/batch";
 import {drizzle} from "drizzle-orm/d1";
 import {defineRelations} from "drizzle-orm/relations";
@@ -94,8 +95,6 @@ export const TEST_ACCOUNTS = {
 	},
 } as const satisfies Record<PreviewTier, TestAccount>;
 
-const TEST_ACCOUNT_IDS = PREVIEW_TIERS.map((tier) => TEST_ACCOUNTS[tier].id);
-
 declare const SessionTokenBrand: unique symbol;
 /** A session token that has passed {@link parseSessionToken} — the only thing provisioning accepts. */
 export type SessionToken = string & {readonly [SessionTokenBrand]: true};
@@ -127,26 +126,29 @@ export interface ProvisionReport {
 
 /**
  * Three arms, never one: a refusal must not read as a provision that wrote nothing. `NotThrowaway`
- * names how many foreign accounts were found, which is the fact the operator acts on, and
+ * names the database name that failed the fence, which is the fact the operator acts on, and
  * `NoCredentials` says the run named no tier at all rather than seeding a default one.
  */
 export type ProvisionOutcome =
 	| {readonly _tag: "Provisioned"; readonly report: ProvisionReport}
-	| {readonly _tag: "NotThrowaway"; readonly foreignAccounts: number}
+	| {readonly _tag: "NotThrowaway"; readonly databaseName: string}
 	| {readonly _tag: "NoCredentials"};
 
 /**
- * Accounts on this database that are none of the test identities and not the `@[silinen]` migration
- * sentinel (ADR 0097) — the evidence the target is somebody's real world.
+ * The substring that makes a D1 name a per-PR preview's. alchemy composes a preview database as
+ * `phoenix-phoenix-db-pr-<n>-<hash>`, so the PR segment is the one part of the name no other stage
+ * carries: production is `…-db-prod-…` and a named dev stage is `…-db-<stage>-…`, neither of which
+ * contains it.
  */
-export const countForeignAccounts = async (db: SeedDb): Promise<number> => {
-	const rows = await db
-		.select({id: user.id})
-		.from(user)
-		.where(and(notInArray(user.id, TEST_ACCOUNT_IDS), eq(user.type, "human")))
-		.all();
-	return rows.length;
-};
+export const PREVIEW_NAME_MARKER = "-pr-";
+
+/**
+ * Whether a D1 name is a throwaway per-PR preview's. Fail closed: only a name carrying
+ * {@link PREVIEW_NAME_MARKER} is throwaway, and everything else — production, a renamed stage, an
+ * empty string — is not.
+ */
+export const isThrowawayDatabaseName = (name: string): boolean =>
+	name.includes(PREVIEW_NAME_MARKER);
 
 type Statement = BatchItem<"sqlite">;
 
@@ -184,20 +186,25 @@ const accountRows = (
 	];
 };
 
+/**
+ * `databaseName` is Cloudflare's record for the target id, resolved by the caller — never a label
+ * the caller composed. The fence is decided first, so a run against a real database is refused on
+ * the same answer whatever tokens it was handed.
+ */
 export const provisionTestAccounts = async (
 	db: SeedDb,
+	databaseName: string,
 	credentials: PreviewCredentials,
 	now: Date = new Date(),
 ): Promise<ProvisionOutcome> => {
+	if (!isThrowawayDatabaseName(databaseName)) return {_tag: "NotThrowaway", databaseName};
+
 	const requested = PREVIEW_TIERS.flatMap((tier) => {
 		const token = credentials[tier];
 		return token === undefined ? [] : [{tier, token}];
 	});
 	const [head, ...rest] = requested;
 	if (head === undefined) return {_tag: "NoCredentials"};
-
-	const foreignAccounts = await countForeignAccounts(db);
-	if (foreignAccounts > 0) return {_tag: "NotThrowaway", foreignAccounts};
 
 	const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
 	const rows = [

--- a/packages/preview-seed/src/test-account.unit.test.ts
+++ b/packages/preview-seed/src/test-account.unit.test.ts
@@ -1,12 +1,14 @@
 /**
  * The test-account provisioner's three refusable facts: a token weak enough to be guessed, a target
- * that is not a throwaway, and a run naming no tier at all. Each must be decided BEFORE any write,
- * so the fake below records every statement it is handed and the assertions read that record.
+ * whose name is not a per-PR preview's, and a run naming no tier at all. Each must be decided
+ * BEFORE any write, so the fake below records every statement it is handed and the assertions read
+ * that record.
  */
 
 import {assert, describe, it} from "@effect/vitest";
 import {toRestParams} from "@kampus/d1-rest";
 import {
+	isThrowawayDatabaseName,
 	MIN_SESSION_TOKEN_LEN,
 	makeTestAccountDb,
 	parseSessionToken,
@@ -14,6 +16,10 @@ import {
 	SESSION_TTL_MS,
 	TEST_ACCOUNTS,
 } from "./test-account.ts";
+
+/** A per-PR preview's real shape: alchemy's `phoenix-phoenix-db-pr-<n>-<hash>` (PR #7717's). */
+const PREVIEW_NAME = "phoenix-phoenix-db-pr-7717-td6ketak4e75f6i4";
+const PROD_NAME = "phoenix-phoenix-db-prod-9f2c1a7be4d05613";
 
 interface Recorded {
 	readonly sql: string;
@@ -73,33 +79,47 @@ describe("parseSessionToken", () => {
 
 const CAYLAK_TOKEN = parseSessionToken("c".repeat(MIN_SESSION_TOKEN_LEN));
 
+describe("isThrowawayDatabaseName", () => {
+	it("admits a per-PR preview and refuses production, a named stage and an empty name", () => {
+		assert.isTrue(isThrowawayDatabaseName(PREVIEW_NAME));
+		assert.isFalse(isThrowawayDatabaseName(PROD_NAME));
+		assert.isFalse(isThrowawayDatabaseName("phoenix-phoenix-db-umut-2f1c9de4ab7705ff"));
+		assert.isFalse(isThrowawayDatabaseName(""));
+	});
+});
+
 describe("provisionTestAccounts", () => {
-	it("refuses a database holding a foreign account, writing nothing", async () => {
+	/**
+	 * The fence's whole job: a real database is refused on its name, and the tokens it was handed
+	 * never get it past that — production carries no `-pr-` segment however the run is invoked.
+	 */
+	it("refuses a production database on its name, writing nothing", async () => {
 		assert.isNotNull(TOKEN);
-		const {d1, batched} = fakeD1([{id: "somebody-real"}]);
-		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN});
+		const {d1, batched, selected} = fakeD1([]);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), PROD_NAME, {yazar: TOKEN});
 		assert.strictEqual(outcome._tag, "NotThrowaway");
-		assert.strictEqual(outcome._tag === "NotThrowaway" ? outcome.foreignAccounts : -1, 1);
+		assert.strictEqual(outcome._tag === "NotThrowaway" ? outcome.databaseName : "", PROD_NAME);
 		assert.lengthOf(batched, 0);
+		assert.lengthOf(selected, 0);
 	});
 
 	/**
-	 * The re-run case: after both tiers are seeded the database holds two test identities, and a
-	 * throwaway check that only knew one of them would call the other somebody's real world and
-	 * refuse every subsequent run.
+	 * The failure that put the fence on the name (#7740): CI's e2e suite signs human users up on
+	 * every preview it tests, so a preview holding accounts is the normal case, not a refusable one.
 	 */
-	it("excludes every test identity from the foreign count, so a re-run stays idempotent", async () => {
+	it("provisions a preview that already holds signed-up human accounts", async () => {
 		assert.isNotNull(TOKEN);
-		const {d1, selected} = fakeD1([]);
-		await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN});
-		const params = selected.flatMap((stmt) => stmt.params);
-		assert.include(params, TEST_ACCOUNTS.yazar.id);
-		assert.include(params, TEST_ACCOUNTS.çaylak.id);
+		const {d1, batched} = fakeD1([{id: "e2e-signup-1"}, {id: "e2e-signup-2"}]);
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), PREVIEW_NAME, {
+			yazar: TOKEN,
+		});
+		assert.strictEqual(outcome._tag, "Provisioned");
+		assert.lengthOf(batched, 3);
 	});
 
 	it("names no tier rather than falling back to one when no token is supplied", async () => {
 		const {d1, batched, selected} = fakeD1([]);
-		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {});
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), PREVIEW_NAME, {});
 		assert.strictEqual(outcome._tag, "NoCredentials");
 		assert.lengthOf(batched, 0);
 		assert.lengthOf(selected, 0);
@@ -109,7 +129,12 @@ describe("provisionTestAccounts", () => {
 		assert.isNotNull(TOKEN);
 		const now = new Date("2026-08-28T00:00:00.000Z");
 		const {d1, batched} = fakeD1([]);
-		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN}, now);
+		const outcome = await provisionTestAccounts(
+			makeTestAccountDb(d1),
+			PREVIEW_NAME,
+			{yazar: TOKEN},
+			now,
+		);
 		assert.strictEqual(outcome._tag, "Provisioned");
 		if (outcome._tag !== "Provisioned") return;
 		assert.strictEqual(outcome.report.expiresAt.getTime(), now.getTime() + SESSION_TTL_MS);
@@ -130,7 +155,7 @@ describe("provisionTestAccounts", () => {
 		assert.isNotNull(TOKEN);
 		assert.isNotNull(CAYLAK_TOKEN);
 		const {d1, batched} = fakeD1([]);
-		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), PREVIEW_NAME, {
 			yazar: TOKEN,
 			çaylak: CAYLAK_TOKEN,
 		});
@@ -151,7 +176,9 @@ describe("provisionTestAccounts", () => {
 	it("seeds only the tier it holds a token for, leaving the other unwritten", async () => {
 		assert.isNotNull(CAYLAK_TOKEN);
 		const {d1, batched} = fakeD1([]);
-		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), {çaylak: CAYLAK_TOKEN});
+		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), PREVIEW_NAME, {
+			çaylak: CAYLAK_TOKEN,
+		});
 		assert.strictEqual(outcome._tag, "Provisioned");
 		if (outcome._tag !== "Provisioned") return;
 		assert.deepStrictEqual(outcome.report.tiers, ["çaylak"]);
@@ -167,7 +194,10 @@ describe("provisionTestAccounts", () => {
 		assert.isNotNull(TOKEN);
 		assert.isNotNull(CAYLAK_TOKEN);
 		const {d1, batched} = fakeD1([]);
-		await provisionTestAccounts(makeTestAccountDb(d1), {yazar: TOKEN, çaylak: CAYLAK_TOKEN});
+		await provisionTestAccounts(makeTestAccountDb(d1), PREVIEW_NAME, {
+			yazar: TOKEN,
+			çaylak: CAYLAK_TOKEN,
+		});
 		batched.forEach((stmt, i) => {
 			stmt.params.forEach((p, j) => {
 				assert.isNotNull(p, `batch[${i}].params[${j}] is null`);


### PR DESCRIPTION
`preview-seed test-account` refused every per-PR preview it was built for. Its fence asked
whether the target D1 held any human `user` row that was not a test identity — but CI's
Playwright e2e job runs against that same preview D1 and signs 30 specs' worth of real users
up through `/api/auth/sign-up/email`. Once a PR's e2e job had run, the authenticated
`review-ui` capture states `:auth` and `:auth-caylak` were unreachable on that preview for
good.

Per the founder ruling on #7740
(https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5535874078), the fence now reads
the **name** Cloudflare has recorded for the target id: a name carrying `-pr-` (alchemy's
per-PR shape `phoenix-phoenix-db-pr-<n>-<hash>`) is a throwaway; production, a named stage, and
a record with no name at all each refuse, fail closed.

What changed:

- `@kampus/d1-rest` gains `resolveDatabaseName` / `resolveDatabaseNameFromEnv` — the name off
  `GET /accounts/{id}/d1/database/{id}`. It throws on a record with no name rather than handing
  a fence a value to interpret.
- `provisionTestAccounts` takes the resolved name and decides the fence first, before any token
  is read. `countForeignAccounts` is gone.
- `packages/preview-seed/README.md`'s guard-boundary section is rewritten: the new reach, why
  the name and not the rows, and the no-override-flag argument restated in the ruling's terms —
  the name is written by the deploy stack, so there is still nothing a caller can assert past.
- ADR 0349 records the ruling and why this is not the relaxation the README argued against.

Reviewer's first look: the guard-boundary section of `packages/preview-seed/README.md` against
`isThrowawayDatabaseName` in `src/test-account.ts`.

## Live proof against this PR's own preview

This PR's e2e job (`e2e (reads + authed + flows, blocking)`, run
https://github.com/kamp-us/phoenix/actions/runs/33839530955) passed at head `34ce33b`, so its
preview D1 `15c12e5b-5b6a-4743-9c0c-7082f4ec3ec2` holds real e2e sign-ups — 41 human `user`
rows that are none of the test identities. That is the exact state the old fence refused.

`node packages/preview-seed/src/bin.ts test-account --database-id
15c12e5b-5b6a-4743-9c0c-7082f4ec3ec2` then printed:

```
preview-seed: ok — provisioned @onizleme-mod at yazar, @onizleme-caylak at çaylak on D1
15c12e5b-5b6a-4743-9c0c-7082f4ec3ec2, … sessions valid to 2026-09-11T05:19:28.022Z
```

Both session rows read back live off the D1, unexpired.

**Acceptance criterion 5 is not discharged here.** `fabrika review-ui render --pr 7767 --surface
/pano:auth-caylak` refuses on exit `11`: *"the preview answered the seeded cookie as a
visitor"*. The seed is not the cause — the `preview-test-caylak` user and session rows are on
that D1 and unexpired. The render signs the tier token with the `BETTER_AUTH_SECRET` in the
running environment (`packages/fabrika-cli/src/capture/auth.ts`, better-call's
`signCookieValue`), and the preview worker verifies that signature with the secret its own
deploy set. This seat's secret is not that worker's, so the cookie reads as unsigned and the
tier proof refuses — correctly. Discharging criterion 5 needs a seat holding the preview
worker's own `BETTER_AUTH_SECRET`.

Part of #7740

## Deviations

- **Known defect left unfixed** — **Said:** nothing; found while proving criterion 2. **Did:**
  left it. **Why:** `test-account`'s success line prints `NaN new moderates tuple(s)` against
  real D1, because `makeD1Rest`'s `batch()` returns `meta: {}` per statement and the tuple count
  sums `meta.changes` off it. Pre-existing, cosmetic, and a separate surface from this fence.
  **Disposition:** filed as https://github.com/kamp-us/phoenix/issues/7768.
- **Known defect left unfixed** — **Said:** criterion 5 asks for a signed-in capture cited here.
  **Did:** ran it, and it refuses on exit `11` for a reason outside this diff (the seat's
  `BETTER_AUTH_SECRET` is not the preview worker's). **Why:** the fence this PR changes is
  proven discharged by the criterion-2 run above; the remaining wall is a credential the build
  seat does not hold. **Disposition:** stated here and in the section above; the PR stays
  `Part of #7740`.
- **Out-of-scope change** — **Said:** #7740 names `packages/preview-seed`. **Did:** also added
  `resolveDatabaseName` to `@kampus/d1-rest` and documented it in that package's README.
  **Why:** the fence needs the D1's name, and `@kampus/d1-rest` is this repo's one canonical D1
  REST transport — a second hand-rolled REST call in preview-seed is the per-package-copy shape
  that package exists to end. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the acceptance criteria ask for code, a test and a README
  rewrite. **Did:** also wrote ADR 0349. **Why:** the ruling re-keys a deliberate security fence
  whose standing argument lives in a README; a future reader needs the why on the `.decisions/`
  surface, per CLAUDE.md. **Disposition:** stated here.
