### PR TITLE
fix: Tuval restore spawns a checkpointed process with no services, so a restored picker-spawned program's handlers can die

### DIFF
--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -113,7 +113,9 @@ export const start = Effect.fn("Tuval.start")(function* ({
 		),
 	);
 	const launched = yield* launch(compiled, wiring).pipe(Effect.provideContext(kernel));
-	const restored = yield* restore.pipe(Effect.provideContext(kernel));
+	// Boot holds no ambient per-process services of its own, so what a restored process gets is
+	// the `ProcessPorts` restore builds for it — un-wired, since the graph does not own it (#7789).
+	const restored = yield* restore(Context.empty()).pipe(Effect.provideContext(kernel));
 	return {kernel, launched, restored} satisfies Started;
 });
 

--- a/apps/tuval/src/commands/core/process.unit.test.ts
+++ b/apps/tuval/src/commands/core/process.unit.test.ts
@@ -8,7 +8,7 @@ import {readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
 import {defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Fiber, Layer, Option} from "effect";
+import {Context, Effect, Fiber, Layer, Option} from "effect";
 import {TestClock} from "effect/testing";
 import {counterId, counterProgram} from "../../demo/counter.ts";
 import {logId, logProgram} from "../../demo/log.ts";
@@ -146,7 +146,7 @@ const failure = (reply: SpellReply) => {
 
 /** The caller itself: a live process the window points at, spawned outside the spells. */
 const startCaller = Effect.flatMap(Processes, (processes) =>
-	processes.spawn(counterId, {id: caller}),
+	processes.spawn(counterId, {id: caller, services: Context.empty()}),
 );
 
 const spawnThrough = (program: ProgramId) =>

--- a/apps/tuval/src/durability/durability.unit.test.ts
+++ b/apps/tuval/src/durability/durability.unit.test.ts
@@ -3,7 +3,7 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Option, Schema} from "effect";
+import {Context, Effect, Layer, Option, Schema} from "effect";
 import {Processes} from "../process/Processes.ts";
 import {ProcessTable} from "../process/ProcessTable.ts";
 import {ProcessId} from "../process/process.ts";
@@ -78,7 +78,7 @@ describe("durability", () => {
 		const probe = probeOf();
 		return Effect.gen(function* () {
 			const processes = yield* Processes;
-			const handle = yield* processes.spawn(counter);
+			const handle = yield* processes.spawn(counter, {services: Context.empty()});
 			probe.watched = handle.id;
 			yield* handle.dispatch({type: "tick"});
 			yield* handle.dispatch({type: "tick"});
@@ -95,13 +95,15 @@ describe("durability", () => {
 			return Effect.gen(function* () {
 				const processes = yield* Processes;
 				const id = ProcessId.make("fixed");
-				const first = yield* processes.spawn(counter, {id});
-				const held = yield* processes.spawn(counter, {id}).pipe(Effect.flip);
+				const first = yield* processes.spawn(counter, {id, services: Context.empty()});
+				const held = yield* processes
+					.spawn(counter, {id, services: Context.empty()})
+					.pipe(Effect.flip);
 				assert.instanceOf(held, CheckpointHeld);
 				assert.strictEqual(held.processId, id);
 
 				yield* first.stop;
-				const again = yield* processes.spawn(counter, {id});
+				const again = yield* processes.spawn(counter, {id, services: Context.empty()});
 				assert.strictEqual(again.id, id);
 			}).pipe(Effect.provide(kernel([counterProgram(probe, stores)], stores)));
 		},
@@ -116,8 +118,11 @@ describe("durability", () => {
 			return Effect.gen(function* () {
 				const before = yield* Effect.gen(function* () {
 					const processes = yield* Processes;
-					const root = yield* processes.spawn(counter);
-					const child = yield* processes.spawn(counter, {parent: root.id});
+					const root = yield* processes.spawn(counter, {services: Context.empty()});
+					const child = yield* processes.spawn(counter, {
+						parent: root.id,
+						services: Context.empty(),
+					});
 					yield* root.dispatch({type: "tick"});
 					yield* root.dispatch({type: "tick"});
 					yield* child.dispatch({type: "tick"});
@@ -127,7 +132,7 @@ describe("durability", () => {
 
 				yield* Effect.gen(function* () {
 					const table = yield* ProcessTable;
-					const restored = yield* restore;
+					const restored = yield* restore(Context.empty());
 					assert.deepStrictEqual(
 						restored.map((handle) => handle.id),
 						[before.root, before.child],
@@ -160,14 +165,14 @@ describe("durability", () => {
 			return Effect.gen(function* () {
 				const id = yield* Effect.gen(function* () {
 					const processes = yield* Processes;
-					const handle = yield* processes.spawn(counter);
+					const handle = yield* processes.spawn(counter, {services: Context.empty()});
 					yield* handle.dispatch({type: "tick"});
 					return handle.id;
 				}).pipe(Effect.provide(kernel([counterProgram(probe, stores)], stores)));
 
 				yield* Effect.gen(function* () {
 					const table = yield* ProcessTable;
-					const refused = yield* restore.pipe(Effect.flip);
+					const refused = yield* restore(Context.empty()).pipe(Effect.flip);
 					assert.instanceOf(refused, SnapshotRefused);
 					assert.strictEqual(refused.processId, id);
 					assert.deepStrictEqual(refused.found, {programId: "counter", version: "1.0.0"});
@@ -209,7 +214,7 @@ describe("durability", () => {
 				const stores = fileStores(dir);
 				yield* Effect.gen(function* () {
 					const table = yield* ProcessTable;
-					const refused = yield* restore.pipe(Effect.flip);
+					const refused = yield* restore(Context.empty()).pipe(Effect.flip);
 					assert.instanceOf(refused, SnapshotMalformed);
 					assert.strictEqual(refused.processId, id);
 					assert.deepStrictEqual(yield* table.list, []);
@@ -228,7 +233,7 @@ describe("durability", () => {
 
 			const id = yield* Effect.gen(function* () {
 				const processes = yield* Processes;
-				const handle = yield* processes.spawn(counter);
+				const handle = yield* processes.spawn(counter, {services: Context.empty()});
 				yield* handle.dispatch({type: "tick"});
 				return handle.id;
 			}).pipe(Effect.provide(kernel(rows, stores)));
@@ -247,7 +252,7 @@ describe("durability", () => {
 			);
 
 			yield* Effect.gen(function* () {
-				const restored = yield* restore;
+				const restored = yield* restore(Context.empty());
 				assert.strictEqual(restored[0]!.id, id);
 				assert.deepStrictEqual(restored[0]!.getState(), {count: 1, acks: 1});
 				assert.deepStrictEqual(probe.log, ["notify:1"]);

--- a/apps/tuval/src/durability/restore-services.unit.test.ts
+++ b/apps/tuval/src/durability/restore-services.unit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Restore's services half (#7789), over the two boots that make it visible: a process the picker
+ * spawned is no graph node, so `restore` is the only thing that brings it back, and what it brings
+ * back has to carry the `ProcessPorts` its handlers require. The fixture is the demo counter, whose
+ * `announce` both requires that service and emits on it.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer, Option} from "effect";
+import {SpawnedProcesses} from "../commands/core/process.ts";
+import {counterId, counterProgram} from "../demo/counter.ts";
+import {PortNotWired} from "../ports/errors.ts";
+import {NodeId} from "../ports/graph.ts";
+import {HandlerFailed} from "../process/errors.ts";
+import {Processes} from "../process/Processes.ts";
+import {ProcessTable} from "../process/ProcessTable.ts";
+import type {ProcessId} from "../process/process.ts";
+import {Registry} from "../registry/Registry.ts";
+import {Checkpoints} from "./Checkpoints.ts";
+import {restore} from "./restore.ts";
+import {type CheckpointStores, memoryStores} from "./stores.ts";
+
+const rows = [counterProgram({everyMs: null})];
+
+/** One boot's kernel; the state dir is the caller's, so two of these share what was checkpointed. */
+const kernel = (stores: CheckpointStores) =>
+	SpawnedProcesses.layer({readTimeout: "1 second"}).pipe(
+		Layer.provideMerge(Processes.layer),
+		Layer.provideMerge(Layer.mergeAll(Registry.layer(rows), Checkpoints.layer(stores))),
+	);
+
+/** The picker's spawn path: a process under no node, checkpointed, then left for the next boot. */
+const firstBoot = (stores: CheckpointStores) =>
+	Effect.gen(function* () {
+		const spawned = yield* SpawnedProcesses;
+		return yield* spawned.spawn(counterId, Option.none());
+	}).pipe(Effect.provide(kernel(stores)), Effect.orDie);
+
+/**
+ * The second boot: restore, then tick the process back. `announce` is a Cmd handler, so what its
+ * emit fails with reaches the dispatcher wrapped in `HandlerFailed`.
+ */
+const secondBoot = (id: ProcessId, stores: CheckpointStores) =>
+	Effect.gen(function* () {
+		const restored = yield* restore(Context.empty());
+		assert.deepStrictEqual(
+			restored.map((handle) => handle.id),
+			[id],
+		);
+		const handle = restored[0]!;
+		const raised = yield* handle.dispatch({type: "tick"}).pipe(Effect.flip);
+		assert.instanceOf(raised, HandlerFailed);
+		const failure = raised as HandlerFailed;
+		const live = yield* ProcessTable.use((table) => table.list);
+		return {failure, state: handle.getState(), live: live.map((row) => row.id)};
+	}).pipe(Effect.provide(kernel(stores)), Effect.orDie);
+
+describe("restore's services", () => {
+	it.effect("a picker-spawned process comes back with the ProcessPorts its handler requires", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+			const id = yield* firstBoot(stores);
+
+			const {failure, state, live} = yield* secondBoot(id, stores);
+
+			// Reaching the emit is the proof the service was there: before #7789 the handler died on
+			// the empty context restore spawned it with, one step earlier.
+			assert.strictEqual(failure.programId, counterId);
+			assert.strictEqual(failure.cmdType, "announce");
+			assert.instanceOf(failure.cause, PortNotWired);
+			assert.deepStrictEqual(state, {count: 1});
+			assert.deepStrictEqual(live, [id]);
+		}),
+	);
+
+	it.effect("its emit fails PortNotWired naming the restored process and the port", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+			const id = yield* firstBoot(stores);
+
+			const {failure} = yield* secondBoot(id, stores);
+
+			const cause = failure.cause as PortNotWired;
+			assert.instanceOf(cause, PortNotWired);
+			assert.strictEqual(cause.node, NodeId.make(id));
+			assert.strictEqual(cause.port, "ticks");
+			assert.include(cause.message, "ticks");
+		}),
+	);
+});

--- a/apps/tuval/src/durability/restore.ts
+++ b/apps/tuval/src/durability/restore.ts
@@ -1,5 +1,7 @@
-import {Effect} from "effect";
+import {Context, Effect} from "effect";
 import type {StoreError} from "../host/errors.ts";
+import {NodeId} from "../ports/graph.ts";
+import {ProcessPorts, unwired} from "../ports/ProcessPorts.ts";
 import {Processes, type SpawnError} from "../process/Processes.ts";
 import {ProcessTable} from "../process/ProcessTable.ts";
 import {type ProcessHandle, ProcessId} from "../process/process.ts";
@@ -13,22 +15,35 @@ import type {ManifestMalformed} from "./errors.ts";
  * fails the restore right there — loudly, with nothing fresh-booted in its place (#7467).
  * An entry already live — a planned process the launcher spawned back at its own id
  * (`src/launch/`) — is already restored, so it is left alone.
+ *
+ * `services` is the caller's ambient context for every process this brings back; each spawn also
+ * gets a `ProcessPorts` of its own. What the graph does not own has no route to bind, so those
+ * ports are `unwired`: the process comes back either way, and an emit fails `PortNotWired` at the
+ * first call rather than dropping the payload (#7789).
  */
-export const restore: Effect.Effect<
+export const restore = (
+	services: Context.Context<never>,
+): Effect.Effect<
 	ReadonlyArray<ProcessHandle>,
 	SpawnError | ManifestMalformed | StoreError,
 	Checkpoints | Processes | ProcessTable
-> = Effect.gen(function* () {
-	const checkpoints = yield* Checkpoints;
-	const processes = yield* Processes;
-	const table = yield* ProcessTable;
-	const live = new Set((yield* table.list).map((row) => row.id));
-	const handles: ProcessHandle[] = [];
-	for (const entry of yield* checkpoints.list) {
-		const id = ProcessId.make(entry.id);
-		if (live.has(id)) continue;
-		const options = entry.parentId === null ? {id} : {id, parent: ProcessId.make(entry.parentId)};
-		handles.push(yield* processes.spawn(ProgramId.make(entry.programId), options));
-	}
-	return handles;
-}).pipe(Effect.withSpan("Tuval.durability.restore"));
+> =>
+	Effect.gen(function* () {
+		const checkpoints = yield* Checkpoints;
+		const processes = yield* Processes;
+		const table = yield* ProcessTable;
+		const live = new Set((yield* table.list).map((row) => row.id));
+		const handles: ProcessHandle[] = [];
+		for (const entry of yield* checkpoints.list) {
+			const id = ProcessId.make(entry.id);
+			if (live.has(id)) continue;
+			handles.push(
+				yield* processes.spawn(ProgramId.make(entry.programId), {
+					id,
+					...(entry.parentId === null ? {} : {parent: ProcessId.make(entry.parentId)}),
+					services: Context.merge(services, Context.make(ProcessPorts, unwired(NodeId.make(id)))),
+				}),
+			);
+		}
+		return handles;
+	}).pipe(Effect.withSpan("Tuval.durability.restore"));

--- a/apps/tuval/src/ports/ProcessPorts.ts
+++ b/apps/tuval/src/ports/ProcessPorts.ts
@@ -1,12 +1,19 @@
 /**
  * The wiring as one running process sees it: emit on its own out-ports by name, and nothing
  * else. A program's Cmd handler requires this service and never a node id or the `Wiring`, so
- * which node it is running as stays the launcher's knowledge (`src/launch/`), which provides
- * one of these per process at spawn.
+ * which node it is running as stays its spawner's knowledge.
+ *
+ * Two spawners provide one per process. `src/launch/` binds a graph node's to the wiring, and
+ * `src/commands/core/process.ts` binds a picker-spawned process's to that process's latches. A
+ * process the graph does not own comes back through `src/durability/restore.ts`, which has no
+ * routes to bind it to and hands it `unwired` below: every emit fails `PortNotWired` at the port
+ * it named, so the process learns it has nowhere to talk at its first emit rather than losing the
+ * payload to a silent no-op (#7789).
  */
 
-import {Context, type Effect} from "effect";
-import type {PayloadRejected, PortNotWired} from "./errors.ts";
+import {Context, Effect} from "effect";
+import {type PayloadRejected, PortNotWired} from "./errors.ts";
+import type {NodeId} from "./graph.ts";
 import type {Delivery} from "./wiring.ts";
 
 export class ProcessPorts extends Context.Service<
@@ -18,3 +25,7 @@ export class ProcessPorts extends Context.Service<
 		) => Effect.Effect<ReadonlyArray<Delivery>, PayloadRejected | PortNotWired>;
 	}
 >()("tuval/ProcessPorts") {}
+
+/** The ports of a process no wiring reaches: `emit` fails `PortNotWired` naming `node` and the port. */
+export const unwired = (node: NodeId): Context.Service.Shape<typeof ProcessPorts> =>
+	ProcessPorts.of({emit: (port) => Effect.fail(new PortNotWired({node, port}))});

--- a/apps/tuval/src/ports/index.ts
+++ b/apps/tuval/src/ports/index.ts
@@ -19,5 +19,5 @@ export type {
 	PortRef,
 } from "./graph.ts";
 export {NodeId} from "./graph.ts";
-export {ProcessPorts} from "./ProcessPorts.ts";
+export {ProcessPorts, unwired} from "./ProcessPorts.ts";
 export {type Delivery, open, type Wiring} from "./wiring.ts";

--- a/apps/tuval/src/process/Processes.ts
+++ b/apps/tuval/src/process/Processes.ts
@@ -32,8 +32,13 @@ export interface SpawnOptions {
 	readonly parent?: ProcessId;
 	/** Restore's: the id the process was checkpointed under. A fresh spawn mints its own. */
 	readonly id?: ProcessId;
-	/** Provided to this process's handlers: the services its program's `R` names, per process. */
-	readonly services?: Context.Context<never>;
+	/**
+	 * Provided to this process's handlers: the services its program's `R` names, per process.
+	 * Never optional — a spawner with nothing to give says so with `Context.empty()`. Omission
+	 * used to be silent, and `restore` took it, so a restored process's first handler died on a
+	 * missing service one boot later (#7789).
+	 */
+	readonly services: Context.Context<never>;
 }
 
 /**
@@ -48,7 +53,7 @@ export class Processes extends Context.Service<
 	{
 		readonly spawn: (
 			programId: ProgramId,
-			options?: SpawnOptions,
+			options: SpawnOptions,
 		) => Effect.Effect<ProcessHandle, SpawnError>;
 		readonly stop: (id: ProcessId) => Effect.Effect<void, ProcessNotFound>;
 	}
@@ -150,13 +155,12 @@ function makeServices() {
 
 		const spawn = Effect.fn("Tuval.Processes.spawn")(function* (
 			programId: ProgramId,
-			options?: SpawnOptions,
+			options: SpawnOptions,
 		) {
 			const program = yield* registry.resolve(programId);
-			const parent = options?.parent === undefined ? undefined : yield* lookup(options.parent);
-			const id = options?.id ?? ProcessId.make(randomUUID());
+			const parent = options.parent === undefined ? undefined : yield* lookup(options.parent);
+			const id = options.id ?? ProcessId.make(randomUUID());
 			const parentId = Option.fromNullishOr(parent?.row.id);
-			const services = options?.services ?? Context.empty();
 			const scope = yield* Scope.fork(parent?.scope ?? root);
 			let lifecycle: Lifecycle = "running";
 			let revision = 0;
@@ -184,7 +188,9 @@ function makeServices() {
 					parentId,
 					version: program.identity.version,
 				});
-				return yield* makeActor(toDefinition(program, checkpoint.store, services, onCommit));
+				return yield* makeActor(
+					toDefinition(program, checkpoint.store, options.services, onCommit),
+				);
 			}).pipe(
 				Effect.provideService(Scope.Scope, scope),
 				Effect.onError((cause) => Scope.close(scope, Exit.failCause(cause))),

--- a/apps/tuval/src/process/Processes.unit.test.ts
+++ b/apps/tuval/src/process/Processes.unit.test.ts
@@ -1,6 +1,6 @@
 import {type Cmd, defineMachine, type Sub, subId} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Option, Scope} from "effect";
+import {Context, Effect, Layer, Option, Scope} from "effect";
 import {Checkpoints} from "../durability/Checkpoints.ts";
 import {memoryStores} from "../durability/stores.ts";
 import {ProgramNotFound} from "../registry/errors.ts";
@@ -144,7 +144,7 @@ describe("Processes", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const table = yield* ProcessTable;
-				const handle = yield* processes.spawn(counter);
+				const handle = yield* processes.spawn(counter, {services: Context.empty()});
 				const again = yield* table.get(handle.id);
 				const listed = yield* table.list;
 				assert.strictEqual(again.id, handle.id);
@@ -165,8 +165,8 @@ describe("Processes", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const table = yield* ProcessTable;
-				const a = yield* processes.spawn(counter);
-				const b = yield* processes.spawn(counter);
+				const a = yield* processes.spawn(counter, {services: Context.empty()});
+				const b = yield* processes.spawn(counter, {services: Context.empty()});
 				assert.notStrictEqual(a.id, b.id);
 
 				yield* a.dispatch({type: "start", runId: "a"});
@@ -189,14 +189,16 @@ describe("Processes", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const table = yield* ProcessTable;
-				const root = yield* processes.spawn(counter);
-				const child = yield* processes.spawn(counter, {parent: root.id});
+				const root = yield* processes.spawn(counter, {services: Context.empty()});
+				const child = yield* processes.spawn(counter, {parent: root.id, services: Context.empty()});
 				assert.deepStrictEqual(child.parentId, Option.some(root.id));
 				assert.deepStrictEqual(root.parentId, Option.none());
 				assert.deepStrictEqual((yield* table.get(child.id)).parentId, Option.some(root.id));
 
 				const orphan = ProcessId.make("nobody");
-				const refused = yield* processes.spawn(counter, {parent: orphan}).pipe(Effect.flip);
+				const refused = yield* processes
+					.spawn(counter, {parent: orphan, services: Context.empty()})
+					.pipe(Effect.flip);
 				assert.instanceOf(refused, ProcessNotFound);
 				assert.strictEqual(refused.id, orphan);
 			}),
@@ -212,7 +214,7 @@ describe("Processes", () => {
 				Effect.gen(function* () {
 					const processes = yield* Processes;
 					const table = yield* ProcessTable;
-					const handle = yield* processes.spawn(counter);
+					const handle = yield* processes.spawn(counter, {services: Context.empty()});
 					let finalized = 0;
 					yield* Scope.addFinalizer(
 						handle.scope,
@@ -245,9 +247,12 @@ describe("Processes", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const table = yield* ProcessTable;
-				const root = yield* processes.spawn(counter);
-				const child = yield* processes.spawn(counter, {parent: root.id});
-				const grandchild = yield* processes.spawn(counter, {parent: child.id});
+				const root = yield* processes.spawn(counter, {services: Context.empty()});
+				const child = yield* processes.spawn(counter, {parent: root.id, services: Context.empty()});
+				const grandchild = yield* processes.spawn(counter, {
+					parent: child.id,
+					services: Context.empty(),
+				});
 				yield* root.dispatch({type: "start", runId: "root"});
 				yield* child.dispatch({type: "start", runId: "child"});
 				yield* grandchild.dispatch({type: "start", runId: "grandchild"});
@@ -273,7 +278,7 @@ describe("Processes", () => {
 			[counterProgram(probe)],
 			Effect.gen(function* () {
 				const processes = yield* Processes;
-				const handle = yield* processes.spawn(counter);
+				const handle = yield* processes.spawn(counter, {services: Context.empty()});
 				yield* handle.dispatch({type: "start", runId: "r1"});
 				yield* handle.dispatch({type: "tick"});
 				assert.strictEqual(probe.reduced, 1);
@@ -298,7 +303,9 @@ describe("Processes", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const missing = ProgramId.make("ghost");
-				const refused = yield* processes.spawn(missing).pipe(Effect.flip);
+				const refused = yield* processes
+					.spawn(missing, {services: Context.empty()})
+					.pipe(Effect.flip);
 				assert.instanceOf(refused, ProgramNotFound);
 				assert.strictEqual(refused.id, missing);
 			}),
@@ -312,8 +319,8 @@ describe("Processes", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const table = yield* ProcessTable;
-				const root = yield* processes.spawn(counter);
-				const child = yield* processes.spawn(counter, {parent: root.id});
+				const root = yield* processes.spawn(counter, {services: Context.empty()});
+				const child = yield* processes.spawn(counter, {parent: root.id, services: Context.empty()});
 				yield* child.dispatch({type: "start", runId: "c"});
 
 				const row = yield* table.get(child.id);
@@ -341,7 +348,9 @@ describe("Processes", () => {
 				[tickerProgram(log)],
 				Effect.gen(function* () {
 					const processes = yield* Processes;
-					const handle = yield* processes.spawn(ProgramId.make("ticker"));
+					const handle = yield* processes.spawn(ProgramId.make("ticker"), {
+						services: Context.empty(),
+					});
 					yield* handle.dispatch({type: "toggle"});
 					assert.deepStrictEqual(log, ["ticker:open"]);
 					yield* handle.dispatch({type: "toggle"});

--- a/apps/tuval/src/table/ProcessTablePort.unit.test.ts
+++ b/apps/tuval/src/table/ProcessTablePort.unit.test.ts
@@ -1,5 +1,5 @@
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Fiber, Layer, Option, Stream} from "effect";
+import {Context, Effect, Fiber, Layer, Option, Stream} from "effect";
 import {expectTypeOf} from "vitest";
 import {Checkpoints} from "../durability/Checkpoints.ts";
 import {memoryStores} from "../durability/stores.ts";
@@ -54,8 +54,11 @@ describe("ProcessTablePort", () => {
 			Effect.gen(function* () {
 				const processes = yield* Processes;
 				const port = yield* ProcessTablePort;
-				const root = yield* processes.spawn(counterId);
-				const child = yield* processes.spawn(counterId, {parent: root.id});
+				const root = yield* processes.spawn(counterId, {services: Context.empty()});
+				const child = yield* processes.spawn(counterId, {
+					parent: root.id,
+					services: Context.empty(),
+				});
 				yield* child.dispatch({type: "tick"});
 
 				const rows = yield* port.rows;
@@ -94,7 +97,7 @@ describe("ProcessTablePort", () => {
 				const port = yield* ProcessTablePort;
 				const events = yield* collect(port.changes, 3);
 
-				const handle = yield* processes.spawn(counterId);
+				const handle = yield* processes.spawn(counterId, {services: Context.empty()});
 				yield* handle.dispatch({type: "tick"});
 				yield* processes.stop(handle.id);
 
@@ -143,7 +146,7 @@ describe("ProcessTablePort", () => {
 					});
 					const inbox = yield* wiring.inbox({node: NodeId.make("v"), port: "table"});
 
-					const handle = yield* processes.spawn(counterId);
+					const handle = yield* processes.spawn(counterId, {services: Context.empty()});
 					yield* handle.dispatch({type: "tick"});
 					yield* processes.stop(handle.id);
 
@@ -212,8 +215,11 @@ describe("ProcessTablePort", () => {
 			[counter],
 			Effect.gen(function* () {
 				const processes = yield* Processes;
-				const root = yield* processes.spawn(counterId);
-				const child = yield* processes.spawn(counterId, {parent: root.id});
+				const root = yield* processes.spawn(counterId, {services: Context.empty()});
+				const child = yield* processes.spawn(counterId, {
+					parent: root.id,
+					services: Context.empty(),
+				});
 				yield* child.dispatch({type: "tick"});
 				assert.deepStrictEqual(yield* ps, [
 					`${root.id} counter - [ticks:out:tick/v1,verdicts:in:verdict/v1] running@0`,


### PR DESCRIPTION
`restore` brought every checkpointed process back with an empty context, so a process the
picker spawned — never a graph node, so restore is the only thing that returns it — came back
with no `ProcessPorts`, and its first service-requiring handler died on the second boot.

The founder ruled option 1 on the issue: a restored process outside the graph gets a
`ProcessPorts` whose `emit` fails `PortNotWired`. Loud at the first emit, never a silent drop,
and restore still brings the process back over it.

## What changed

- `restore` now takes a services context and passes it on every spawn, merged with a
  `ProcessPorts` it builds per process. Those ports are `unwired` (new, in
  `ports/ProcessPorts.ts`): `emit` fails `PortNotWired` naming the restored process's own id and
  the port. `start` supplies `Context.empty()` — see the deviation below.
- `SpawnOptions.services` is no longer optional. An omission is a type error now, and every
  spawner names what it gives; the two that already wired their own ports (`launch`, the picker's
  `SpawnedProcesses`) are unchanged.
- `ProcessPorts`'s docblock no longer says the launcher is the only provider — it names all three
  and what a restored process's `emit` does.
- Two unit tests in `apps/tuval/src/durability/restore-services.unit.test.ts` over two boots with
  one shared state dir: the demo counter is picker-spawned on the first, restored on the second,
  and its `announce` handler reaches `ProcessPorts` and fails at the emit with `PortNotWired`
  carrying its id and `ticks`. Both fail without the fix (verified by reverting the merge locally —
  the handler dies on the missing service instead).

Option 4 — a wiring identity for un-graphed processes — is out of scope, per the ruling.

Patterns leaned on: [`.patterns/effect-context-service.md`](.patterns/effect-context-service.md)
for the Effect 4 `Context.Service` class form (`ProcessPorts.of`, `Context.Service.Shape`, grounded
in `Context.d.ts` at the `catalogs.tuval` rc.112 pin) and
[`.patterns/effect-errors.md`](.patterns/effect-errors.md) for the tagged-error failure channel
`PortNotWired` travels in.

## Deviations

- **Scope narrowing** — **Said:** the criteria say `start` supplies restore's services context
  "the same way it already supplies `launch`'s". **Did:** `start` passes `Context.empty()`.
  **Why:** `start` supplies `launch` no services context at all — `launch` builds each node's
  `ProcessPorts` itself from the wiring, and what `start` hands both is the kernel context via
  `Effect.provideContext`. There is no ambient per-process context on main to thread, and
  inventing a `StartOptions.services` no caller sets would be a knob nobody turns.
  **Disposition:** stated here; `restore` takes the parameter, so the day boot does hold ambient
  services there is one place to pass them.
- **Pre-existing test or fixture changed** — **Said:** make `SpawnOptions.services` non-optional if
  the type admits a clean way. **Did:** made it required, which forced ~25 spawn call sites across
  four existing test files to name `services: Context.empty()`. **Why:** the criterion's first
  branch was the clean one; the churn is mechanical and each site now states that its program
  requires nothing. No test's assertions changed. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the ports barrel. **Did:** also exported
  `unwired` from `apps/tuval/src/ports/index.ts`. **Why:** the barrel is the slice's surface and
  already exports `ProcessPorts`; leaving its new companion off would be an inconsistency a reader
  trips on. **Disposition:** stated here.

Closes #7789
