### PR TITLE
fix: CI e2e sign-ups poison the preview D1 that preview-seed test-account guards

### DIFF
--- a/packages/d1-rest/README.md
+++ b/packages/d1-rest/README.md
@@ -25,7 +25,9 @@ consumer touches:
   The deploy stack writes that name and the caller cannot, which is what makes it usable
   as evidence about what a database *is* — `@kampus/preview-seed`'s throwaway fence keys
   on it (#7740). A record that comes back without a name throws rather than returning a
-  value a fence would have to interpret.
+  value a fence would have to interpret. The answer is a `ResolvedDatabaseName`, and these
+  two functions are its only mint — a fence takes that type so a label the caller composed
+  is a plain `string` and does not fit.
 - `readYourWrite(read, isConsistent, options?)` — a bounded read-your-writes poll for callers
   that need read-after-write consistency over this transport. The REST `/query` endpoint
   carries no D1 session bookmark (that Sessions API primitive is Workers-binding-only), so an

--- a/packages/d1-rest/src/index.ts
+++ b/packages/d1-rest/src/index.ts
@@ -205,6 +205,15 @@ export const readYourWrite = async <T>(
 	return value;
 };
 
+declare const ResolvedDatabaseNameBrand: unique symbol;
+/**
+ * A D1 name that came back from Cloudflare's record for a database id, minted only by
+ * {@link resolveDatabaseName}. A fence keying on the name is only as good as the name's origin, so
+ * the origin is carried in the type: a label a caller composed is a `string` and does not fit
+ * (`@kampus/preview-seed`'s `provisionTestAccounts`, issue #7740).
+ */
+export type ResolvedDatabaseName = string & {readonly [ResolvedDatabaseNameBrand]: true};
+
 /**
  * The `name` Cloudflare has recorded for one D1 database id — the deploy stack's name, never the
  * caller's word for it, which is what makes it usable as evidence about what a database IS
@@ -214,7 +223,7 @@ export const readYourWrite = async <T>(
  * nullable field, so an answer without one is UNKNOWN rather than "no name": it throws instead of
  * returning a value a fence would then have to interpret.
  */
-export const resolveDatabaseName = async (config: D1RestConfig): Promise<string> => {
+export const resolveDatabaseName = async (config: D1RestConfig): Promise<ResolvedDatabaseName> => {
 	const {accountId, databaseId, layer} = config;
 	const response = await Effect.runPromise(
 		d1.getDatabase({accountId, databaseId}).pipe(Effect.provide(layer)),
@@ -225,11 +234,12 @@ export const resolveDatabaseName = async (config: D1RestConfig): Promise<string>
 			`D1 ${databaseId} resolved to no name — Cloudflare returned a database record without one, so nothing can be decided from it.`,
 		);
 	}
-	return name;
+	// The one mint: the brand is asserted here and nowhere else, on the value the API answered with.
+	return name as ResolvedDatabaseName;
 };
 
 /** {@link resolveDatabaseName} over the env-credentialed REST layer, like {@link makeD1RestFromEnv}. */
 export const resolveDatabaseNameFromEnv = (target: {
 	accountId: string;
 	databaseId: string;
-}): Promise<string> => resolveDatabaseName({...target, layer: d1RestLayerFromEnv});
+}): Promise<ResolvedDatabaseName> => resolveDatabaseName({...target, layer: d1RestLayerFromEnv});

--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -235,6 +235,14 @@ Cloudflare's record for the id, written by the deploy stack, so there is nothing
 for a caller to assert. A flag would hand the decision back to the caller, which is
 the hole both versions of this fence exist to close.
 
+That origin is a type, not a convention. `provisionTestAccounts` takes a
+`ResolvedDatabaseName`, which `@kampus/d1-rest`'s `resolveDatabaseName` is the only
+thing that mints, so a label a caller composed does not fit the parameter and is
+refused by the compiler before any rule about its shape is applied. The shape rule
+itself — `isThrowawayDatabaseName` — stays a predicate over any string, because it
+answers a question about text; where the text has to have come from Cloudflare is the
+fence's own signature.
+
 **Each token is a live credential on a running preview.** Every one is read only
 from its own environment variable (never a flag, so it stays out of process
 listings), must be at least 32 characters, and is refused if it carries whitespace,

--- a/packages/preview-seed/src/test-account.ts
+++ b/packages/preview-seed/src/test-account.ts
@@ -23,7 +23,9 @@
  * caller-asserted "this is a preview" proves nothing, so the fence reads a fact the deploy stack
  * sets and the caller cannot: Cloudflare's own record for the given `--database-id`. A per-PR
  * preview is `phoenix-phoenix-db-pr-<n>-…`; anything else — `…-prod-…`, a renamed stage, a name
- * the API declines to give — is refused before any write. It replaced an emptiness check that
+ * the API declines to give — is refused before any write. `ResolvedDatabaseName` holds that origin
+ * open in the type: `resolveDatabaseName` is its only mint, so the fence's own parameter refuses a
+ * name a caller composed before any rule about its shape is applied. It replaced an emptiness check that
  * could never pass in practice, because CI's e2e suite signs human users up on every preview it
  * tests — see ADR 0349 (#7740, founder ruling
  * https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5535874078).
@@ -35,6 +37,7 @@
  * carries credentials for signing IN, which this path skips by construction.
  */
 import {key, platform} from "@kampus/authz";
+import type {ResolvedDatabaseName} from "@kampus/d1-rest";
 import {eq} from "drizzle-orm";
 import type {BatchItem} from "drizzle-orm/batch";
 import {drizzle} from "drizzle-orm/d1";
@@ -197,6 +200,10 @@ export const PREVIEW_NAME_MARKER = "-pr-";
  * Whether a D1 name is a throwaway per-PR preview's. Fail closed: only a name carrying
  * {@link PREVIEW_NAME_MARKER} is throwaway, and everything else — production, a renamed stage, an
  * empty string — is not.
+ *
+ * `string`, not {@link ResolvedDatabaseName}, and deliberately: this is the shape rule, total over
+ * any text, and it answers `false` for text no mint could ever produce. Where the name has to have
+ * come from Cloudflare is {@link provisionTestAccounts}'s parameter, which is the fence itself.
  */
 export const isThrowawayDatabaseName = (name: string): boolean =>
 	name.includes(PREVIEW_NAME_MARKER);
@@ -273,13 +280,15 @@ const standingRows = (
 };
 
 /**
- * `databaseName` is Cloudflare's record for the target id, resolved by the caller — never a label
- * the caller composed. The fence is decided first, so a run against a real database is refused on
- * the same answer whatever tokens it was handed.
+ * `databaseName` is Cloudflare's record for the target id, and {@link ResolvedDatabaseName} is what
+ * makes that a type fact rather than a docblock: `resolveDatabaseName` is the only mint, so a label
+ * the caller composed does not fit this parameter and cannot reach the fence. The fence is decided
+ * first, so a run against a real database is refused on the same answer whatever tokens it was
+ * handed.
  */
 export const provisionTestAccounts = async (
 	db: SeedDb,
-	databaseName: string,
+	databaseName: ResolvedDatabaseName,
 	credentials: PreviewCredentials,
 	standing: CaylakStanding | null = null,
 	now: Date = new Date(),

--- a/packages/preview-seed/src/test-account.unit.test.ts
+++ b/packages/preview-seed/src/test-account.unit.test.ts
@@ -5,8 +5,11 @@
  * statement it is handed and the assertions read that record.
  */
 
+import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
 import {assert, describe, it} from "@effect/vitest";
-import {toRestParams} from "@kampus/d1-rest";
+import {type ResolvedDatabaseName, resolveDatabaseName, toRestParams} from "@kampus/d1-rest";
+import {Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {
 	type CaylakStanding,
 	isThrowawayDatabaseName,
@@ -20,9 +23,35 @@ import {
 	TEST_ACCOUNTS,
 } from "./test-account.ts";
 
+/**
+ * Both names are minted the one way production mints one: through `resolveDatabaseName`, over a
+ * stubbed Cloudflare answer. Nothing here composes a `ResolvedDatabaseName` by hand, because nothing
+ * can — that is the invariant the fence's parameter now carries, so the tests exercise it by obeying
+ * it rather than by asserting about it (#7740).
+ */
+const resolved = (name: string): Promise<ResolvedDatabaseName> =>
+	resolveDatabaseName({
+		accountId: "acc",
+		databaseId: "db",
+		layer: Layer.mergeAll(
+			FetchHttpClient.layer.pipe(
+				Layer.provide(
+					Layer.succeed(FetchHttpClient.Fetch)(
+						async () =>
+							new Response(JSON.stringify({result: {uuid: "db", name}}), {
+								status: 200,
+								headers: {"content-type": "application/json"},
+							}),
+					),
+				),
+			),
+			fromApiToken({apiToken: "test-token"}),
+		),
+	});
+
 /** A per-PR preview's real shape: alchemy's `phoenix-phoenix-db-pr-<n>-<hash>` (PR #7717's). */
-const PREVIEW_NAME = "phoenix-phoenix-db-pr-7717-td6ketak4e75f6i4";
-const PROD_NAME = "phoenix-phoenix-db-prod-9f2c1a7be4d05613";
+const PREVIEW_NAME = await resolved("phoenix-phoenix-db-pr-7717-td6ketak4e75f6i4");
+const PROD_NAME = await resolved("phoenix-phoenix-db-prod-9f2c1a7be4d05613");
 
 interface Recorded {
 	readonly sql: string;


### PR DESCRIPTION
`provisionTestAccounts` documented in a docblock that its `databaseName` must be Cloudflare's
record for the target id and never a label the caller composed. The parameter was a bare `string`,
so nothing enforced it — the same file already carried the `SessionToken` / `parseSessionToken`
brand idiom for exactly this shape of invariant.

`@kampus/d1-rest` now declares `ResolvedDatabaseName`, and `resolveDatabaseName` /
`resolveDatabaseNameFromEnv` are its only mint. The fence takes that type, so a caller-composed
label no longer typechecks — proved by a probe run against the package's own `tsc`:

```
error TS2345: Argument of type 'string' is not assignable to parameter of type 'ResolvedDatabaseName'.
```

`isThrowawayDatabaseName` deliberately stays a predicate over any `string`: it answers a question
about text and must keep answering `false` for text no mint could produce (the empty name). Where
the name has to have come from Cloudflare is the fence's own signature.

`test-account.unit.test.ts` now mints both its preview and production names through
`resolveDatabaseName` over a stubbed Cloudflare answer, so the production-refusal test feeds the
guard a target built the one way production builds one. Both package READMEs state the new reach.

This closes acceptance criterion 6 (appended by review round 1 of #7767). Criterion 5 is still
owed — see Deviations.

## Deviations

- **Known defect left unfixed** — **Said:** #7740's criterion 5 asks for a
  `review-ui render --surface <route>:auth-caylak` capture against a live PR preview that has run
  e2e, cited here. **Did:** not discharged; no capture is cited. **Why:** the render signs the tier
  cookie with this seat's `BETTER_AUTH_SECRET`, while a PR preview's worker verifies with the
  `secrets.BETTER_AUTH_SECRET` its own deploy set (`.github/workflows/deploy.yml:416`), so the
  cookie reads as unsigned and the preview answers the seeded session as a visitor — the exit `11`
  the previous round diagnosed on #7767 with this same credential set.
  **Disposition:** stated here; the criterion stays unchecked on #7740 and needs a seat holding the
  preview worker's own secret.
- **Scope narrowing** — **Said:** the issue's remaining criteria are 5 and 6. **Did:** only 6.
  **Why:** 5 is walled on the credential above, not on anything a branch change reaches.
  **Disposition:** opened `Part of #7740` rather than `Fixes`, so the issue stays open.
- **Out-of-scope change** — **Said:** the criterion names `provisionTestAccounts`'s parameter.
  **Did:** also changed `resolveDatabaseName`'s return type and `packages/d1-rest/README.md`.
  **Why:** a brand with no mint is unusable; the minter lives in the other package, so the type and
  its one mint have to land together. **Disposition:** stated here.
