### PR TITLE
chore: PiAiAgent's host() docblock overstates what ModelRuntime.create accepts

### DIFF
--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -300,13 +300,16 @@ const transport = (
 /**
  * Pi's model runtime and the session host over it, created inside this layer's own Scope.
  *
- * This is what keeps ruling 4's `R` empty. `ModelRuntime.create` takes plain paths and flags and
- * nothing else at 0.84.3 (`CreateModelRuntimeOptions`, `dist/core/model-runtime.d.ts:3-18`), so the
- * strings on `PiAiAgentOptions` are the whole of what a process supplies and no Pi value ever
- * crosses back out to it. The two paths are Pi's own, rebased on `agentDir` so an overridden
- * directory moves the credentials and the catalog together (`getAuthPath`/`getModelsPath` are
- * `join(getAgentDir(), …)`, `dist/config.js:432-438`). The runtime holds nothing to release — it
- * declares no `dispose` or `close` — so it is created rather than acquired.
+ * This is what keeps ruling 4's `R` empty. The call site supplies `authPath` and `modelsPath` and
+ * nothing further, so the strings on `PiAiAgentOptions` are the whole of what a process gives Pi
+ * and no Pi value ever crosses back out to it. `CreateModelRuntimeOptions` does declare three
+ * options that are neither a path nor a flag — `credentials`, `modelsStore` and `signal` — and
+ * leaving all three unset is what keeps this seam string-only at 0.84.3
+ * (`dist/core/model-runtime.d.ts:3-18`). The two paths are Pi's own, rebased on `agentDir` so an
+ * overridden directory moves the credentials and the catalog together
+ * (`getAuthPath`/`getModelsPath` are `join(getAgentDir(), …)`, `dist/config.js:432-438`). The
+ * runtime holds nothing to release — it declares no `dispose` or `close` — so it is created rather
+ * than acquired.
  */
 const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost> =>
 	Layer.unwrap(


### PR DESCRIPTION
The `host()` docblock in `apps/tuval/src/pi/ai-agent/PiAiAgent.ts` said `ModelRuntime.create`
takes plain paths and flags "and nothing else" at 0.84.3, and cited the type that says otherwise.
`CreateModelRuntimeOptions` declares ten fields, three of which are neither a path nor a flag:
`credentials?: CredentialStore`, `modelsStore?: ModelsStore` (both from `@earendil-works/pi-ai`)
and `signal?: AbortSignal`.

The sentence now states what the call site supplies — `authPath` and `modelsPath`, nothing
further — which is what the `R`-empty argument actually needs, and names the three Pi-typed
options as existing and deliberately unset. The `dist/core/model-runtime.d.ts:3-18` citation is
kept; it was accurate, and re-reading the file at the pin confirms lines 3-18 are exactly the
interface declaration through its last field.

Comment-only. No non-comment line changed; the surrounding lines were rewrapped to stay inside
Biome's 100-column limit. `pnpm typecheck` and `biome check` pass in `apps/tuval`.

Closes #7790

## Deviations

None.
