### PR TITLE
fix: The Pi-type re-export scan misses a re-export of the two module-level doors

### DIFF
--- a/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
@@ -69,10 +69,26 @@ describe("the Pi AI agent layer's surface", () => {
 
 	it("re-exports no Pi type through its entry point", () => {
 		const entry = readFileSync(join(import.meta.dirname, "index.ts"), "utf8");
-		expect(entry).not.toMatch(/@earendil-works/);
-		// A re-export from the server or client module reaches Pi's own types one hop further out,
-		// which the `@earendil-works` scan alone cannot see.
-		expect(entry).not.toMatch(/from\s+"\.\.\/(server|client)\//);
+		// The exact set, not a scan for forbidden substrings: the scan this replaced looked for
+		// `@earendil-works` and `from "../server|client/"`, and `export {aiAgentOverHost} from
+		// "./PiAiAgent.ts";` carries neither, so the one escape route the module has stayed green
+		// under it (#7791). A positive set reds on any fourth name however it is spelled — do not
+		// restore the regexes.
+		expect(exportedNames(entry)).toEqual(["ModelSelection", "PiAiAgent", "PiAiAgentOptions"]);
+		// The control: each departure appended to the real entry text, so the set above is what reds
+		// on it. `aiAgentOverHost` and `aiAgentOverClient` both publish a Pi-typed `R`, and a star
+		// re-export publishes whatever `PiAiAgent.ts` grows next.
+		expect(
+			[
+				'export {aiAgentOverHost} from "./PiAiAgent.ts";',
+				'export {aiAgentOverClient} from "./PiAiAgent.ts";',
+				'export * from "./PiAiAgent.ts";',
+			].map((departure) => exportedNames(`${entry}\n${departure}\n`)),
+		).toEqual([
+			["ModelSelection", "PiAiAgent", "PiAiAgentOptions", "aiAgentOverHost"],
+			["ModelSelection", "PiAiAgent", "PiAiAgentOptions", "aiAgentOverClient"],
+			["*", "ModelSelection", "PiAiAgent", "PiAiAgentOptions"],
+		]);
 	});
 });
 
@@ -93,6 +109,34 @@ const sources = (): ReadonlyArray<{name: string; text: string}> => {
 	return readdirSync(dir)
 		.filter((name) => name.endsWith(".ts") && !name.includes(".test."))
 		.map((name) => ({name, text: readFileSync(join(dir, name), "utf8")}));
+};
+
+/**
+ * Every name a module's text publishes, sorted. Two of the three names `index.ts` exports are types
+ * and carry no runtime key, so the set is read off the text rather than off the imported module. A
+ * star re-export enumerates nothing, so it reports the literal `*` — a name no ruled set carries,
+ * which is what makes `export * from "./PiAiAgent.ts";` red rather than pass unseen.
+ */
+const exportedNames = (text: string): ReadonlyArray<string> => {
+	const clauses =
+		/^export\s+(?:(\*(?:\s+as\s+\w+)?)|\{([^}]*)\}|(default)\b|(?:declare\s+)?(?:async\s+)?(?:type|interface|const|let|var|function\*?|class|enum|namespace)\s+(\w+))/gm;
+	const names: Array<string> = [];
+	for (const [, star, clause, fallback, declared] of stripComments(text).matchAll(clauses)) {
+		if (star !== undefined) names.push("*");
+		else if (clause !== undefined) names.push(...clause.split(",").flatMap(exportedName));
+		else names.push(fallback ?? declared ?? "");
+	}
+	return names.sort();
+};
+
+/** One specifier out of an `export {...}` clause: `type A`, `A as B` and `A` all name what lands. */
+const exportedName = (specifier: string): ReadonlyArray<string> => {
+	const named = specifier
+		.trim()
+		.replace(/^type\s+/, "")
+		.split(/\s+as\s+/);
+	const landed = named.at(-1) ?? "";
+	return landed === "" ? [] : [landed];
 };
 
 const stripComments = (text: string): string =>

--- a/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
@@ -77,16 +77,22 @@ describe("the Pi AI agent layer's surface", () => {
 		expect(exportedNames(entry)).toEqual(["ModelSelection", "PiAiAgent", "PiAiAgentOptions"]);
 		// The control: each departure appended to the real entry text, so the set above is what reds
 		// on it. `aiAgentOverHost` and `aiAgentOverClient` both publish a Pi-typed `R`, and a star
-		// re-export publishes whatever `PiAiAgent.ts` grows next.
+		// re-export publishes whatever `PiAiAgent.ts` grows next. The last two are the type-only
+		// spellings — the form the rest of the repo uses, and the one the first cut of this case
+		// could not see at all (#7791).
 		expect(
 			[
 				'export {aiAgentOverHost} from "./PiAiAgent.ts";',
 				'export {aiAgentOverClient} from "./PiAiAgent.ts";',
 				'export * from "./PiAiAgent.ts";',
+				'export type {PiAiAgentOptions as Leaked} from "@earendil-works/pi";',
+				'export type * from "@earendil-works/pi";',
 			].map((departure) => exportedNames(`${entry}\n${departure}\n`)),
 		).toEqual([
 			["ModelSelection", "PiAiAgent", "PiAiAgentOptions", "aiAgentOverHost"],
 			["ModelSelection", "PiAiAgent", "PiAiAgentOptions", "aiAgentOverClient"],
+			["*", "ModelSelection", "PiAiAgent", "PiAiAgentOptions"],
+			["Leaked", "ModelSelection", "PiAiAgent", "PiAiAgentOptions"],
 			["*", "ModelSelection", "PiAiAgent", "PiAiAgentOptions"],
 		]);
 	});
@@ -115,11 +121,14 @@ const sources = (): ReadonlyArray<{name: string; text: string}> => {
  * Every name a module's text publishes, sorted. Two of the three names `index.ts` exports are types
  * and carry no runtime key, so the set is read off the text rather than off the imported module. A
  * star re-export enumerates nothing, so it reports the literal `*` — a name no ruled set carries,
- * which is what makes `export * from "./PiAiAgent.ts";` red rather than pass unseen.
+ * which is what makes `export * from "./PiAiAgent.ts";` red rather than pass unseen. The `type`
+ * prefix reaches both re-export forms, not just a declaration: `export type {X} from "…";` and
+ * `export type * from "…";` are how the rest of this repo writes a type re-export, and a clause
+ * regex that read `type` only as a declaration keyword saw neither line at all (#7791).
  */
 const exportedNames = (text: string): ReadonlyArray<string> => {
 	const clauses =
-		/^export\s+(?:(\*(?:\s+as\s+\w+)?)|\{([^}]*)\}|(default)\b|(?:declare\s+)?(?:async\s+)?(?:type|interface|const|let|var|function\*?|class|enum|namespace)\s+(\w+))/gm;
+		/^export\s+(?:(?:type\s+)?(?:(\*(?:\s+as\s+\w+)?)|\{([^}]*)\})|(default)\b|(?:declare\s+)?(?:async\s+)?(?:type|interface|const|let|var|function\*?|class|enum|namespace)\s+(\w+))/gm;
 	const names: Array<string> = [];
 	for (const [, star, clause, fallback, declared] of stripComments(text).matchAll(clauses)) {
 		if (star !== undefined) names.push("*");


### PR DESCRIPTION
The `re-exports no Pi type through its entry point` case in
`apps/tuval/src/pi/ai-agent/boundary.unit.test.ts` scanned `index.ts` for two forbidden
substrings — `@earendil-works` and `from "../server|client/"`. Neither pattern sees the one escape
route the module actually has: `aiAgentOverHost` and `aiAgentOverClient` live in the sibling
`./PiAiAgent.ts`, and both publish a layer whose `R` only a Pi-typed value satisfies.

The case now reads the export set off `index.ts`'s own text and asserts it equals exactly
`ModelSelection`, `PiAiAgent`, `PiAiAgentOptions`. Two of those three are types and carry no runtime
key, so the set comes from the text rather than from the imported module. A star re-export
enumerates no names, so the helper reports the literal `*` — a name the ruled set does not carry,
which is what makes `export * from "./PiAiAgent.ts";` red instead of pass unseen. A control beside
the assertion appends each of the three departures to the real entry text and pins the set each one
produces, so the assertion above cannot quietly stop discriminating.

`index.ts` is untouched: the only file in this diff is the test.

## Demonstrated red

Each departure was appended to `apps/tuval/src/pi/ai-agent/index.ts` in turn, the case run, and the
file restored. Command each time, from `apps/tuval`:

```
pnpm vitest run --project unit src/pi/ai-agent/boundary.unit.test.ts
```

- `export {aiAgentOverHost} from "./PiAiAgent.ts";` → `1 failed | 4 passed`, `AssertionError` on the
  export-set line, received `+ "aiAgentOverHost"`.
- `export {aiAgentOverClient} from "./PiAiAgent.ts";` → `1 failed | 4 passed`, received
  `+ "aiAgentOverClient"`.
- `export * from "./PiAiAgent.ts";` → `1 failed | 4 passed`, received `+ "*"`.

After reverting: `5 passed`. The whole tuval unit project is `68 files / 494 tests` green, and
`effect-tsgo diagnostics --project apps/tuval/tsconfig.json --strict` reports `0 errors, 0 warnings`.

## Deviations

- **Out-of-scope change** — **Said:** #7791 names only the test case. **Did:** also left the
  repository's shared primary checkout standing on a superseded lane branch,
  `build/7791-entry-export-set-pin-fe8d2c60`, at `origin/main`'s commit with a clean tree. **Why:**
  an early `build branch` call ran against the shared checkout rather than this lane's worktree, and
  the worktree isolation guard then refused every command that would have put that checkout back on
  `main`; the claim was released, re-taken for a fresh nonce, and the lane rebuilt in the worktree.
  Nothing was committed on the superseded branch and it was never pushed. **Disposition:** stated
  here — an operator switches that checkout back to `main` and deletes the stale local branch.

Closes #7791


## Repair round 1 (2026-09-04)

`review-code` FAIL at `027e9406` found that `exportedNames` could not see a type-only re-export.
`export type {X} from "…";` and `export type * from "…";` both reached the clause regex's
declaration branch, which requires `\s+(\w+)` after the `type` keyword, so neither line matched at
all — not an empty name, no match — and each published a name past the ruled set while the case
stayed green.

The fix is one regex change: an optional `type\s+` prefix now reaches the `*` and `{` alternatives,
so both re-export spellings parse. Both forms joined the control list beside the existing three
departures, and the helper's docblock says why the prefix is there.

Demonstrated the same way as the first three — each appended to the real
`apps/tuval/src/pi/ai-agent/index.ts`, the case run from `apps/tuval` with
`pnpm vitest run --project unit src/pi/ai-agent/boundary.unit.test.ts`, then reverted:

- `export type {PiAiAgentOptions as Leaked} from "@earendil-works/pi";` → `1 failed | 4 passed`,
  `AssertionError` at `boundary.unit.test.ts:77:32`, expected `[ 'ModelSelection', 'PiAiAgent', …(1) ]`,
  received `[ 'Leaked', 'ModelSelection', …(2) ]`, diff line `+ "Leaked",`.
- `export type * from "@earendil-works/pi";` → `1 failed | 4 passed`, `AssertionError` at
  `boundary.unit.test.ts:77:32`, received `[ '*', 'ModelSelection', …(2) ]`, diff line `+ "*",`.

After reverting, `index.ts` is byte-identical to the branch version and the whole tuval unit project
is `68 files / 494 tests` green. `effect-tsgo diagnostics --project apps/tuval/tsconfig.json
--strict` reports `0 errors, 0 warnings` over 227 files, with no message naming the edited file.
`build check --surface code` is green with nothing unvalidated.

No new deviations this round; the section above stands unchanged.
