### PR TITLE
chore: Eight shipped lanes never replay, so reconcile and migrate both skip them forever

### DIFF
--- a/.decisions/0352-an-unreplayable-lane-is-archived-not-sealed.md
+++ b/.decisions/0352-an-unreplayable-lane-is-archived-not-sealed.md
@@ -1,0 +1,77 @@
+---
+id: 0352
+title: An unreplayable lane is archived, not sealed
+status: accepted
+date: 2026-09-04
+---
+
+# 0352 — An unreplayable lane is archived, not sealed
+
+## Context
+
+Eight lane ledgers under `.fabrika/lanes` carry events their own machine cannot replay. Five (5991,
+6005, 6037, 6100, 6462) hold an `ISSUE.DONE` appended after the fold had already reached `frozen`;
+three (6226, 6374, 6759) hold an `ISSUE.PASS` while the machine reads `build`. Every one shipped in
+August 2026 and every issue is closed.
+
+`frozen` is a `final` state in both committed templates and its only cell is `PARK_SWEEP.UNBLOCKED`,
+so `foldLog` fails and `lane reconcile` classifies the lane `unreadable`; `lane migrate` refuses the
+same eight through `judgeMigration`'s `Unreplayable` verdict. They are noise on every sweep and
+nothing in the pipeline can clear them, because the fault is in an append-only log neither verb may
+rewrite. The cost is eight rows a run; the risk is that a genuinely broken lane later hides among
+them.
+
+Two routes were named on [#7803](https://github.com/kamp-us/phoenix/issues/7803) and neither was
+ruled: seal each lane with a closing line so its log replays again, or move it out of the swept
+roots. They are opposite in what they treat the ledger as — a record that may be repaired, versus
+one that is closed and set aside — so the choice was a ruling, not an implementation detail.
+
+## Decision
+
+**A lane whose log will never replay leaves the sweep's scope by moving, never by a line appended to
+its log and never by widening the machine.** Ruled by the founder in
+[#7803's ruling comment](https://github.com/kamp-us/phoenix/issues/7803#issuecomment-5544645381).
+
+`fabrika lane archive <lane>` moves one lane directory from the lanes root to an archived root
+(`.fabrika/lanes-archived`). It refuses, non-zero and with the directory where it was, unless **both**
+hold:
+
+- the lane's issue reads **closed** on the board (exit `49` when it is open), and
+- the log **does not replay**, judged by the same `judgeMigration` that `lane migrate` makes — through
+  the lane's own machine or through the committed template (exit `50` when it replays).
+
+The judgement runs before the board read, because it is local and free. An unreadable board, an
+unreadable template, or a machine no candidate can be built for is UNKNOWN at exit `11` and moves
+nothing.
+
+The archived root is a **sibling** of the lanes root, never a directory under it. `lane reconcile`
+and `lane migrate` sweep the roots they are handed, and neither is ever handed this one — so no sweep
+learns a skip rule it could get wrong. The record stays readable: `lane history` and `lane brief`
+take `--root`, so an archived lane is read by pointing them at the archived root.
+
+Only an issue lane is archivable. A chore lane drives no issue, so the closed-issue gate can never
+hold for one, and the verb refuses it at exit `19` rather than pretending otherwise.
+
+## Rejected
+
+**A sealing line** — a `CORRECTED`-shaped or new `SEALED` event appended to a terminal lane whose
+issue is closed, so the log replays again. Rejected: it writes a line describing history that did not
+happen, which is exactly what ADR [0350](0350-a-correction-supersedes-a-recorded-line.md) governs. A
+correction supersedes a line that *was* recorded; there is no recorded line here to supersede.
+
+**A `frozen` → `DONE` cell** — give the final state the update cell the appended events want.
+Rejected: `frozen` is where a lane lands at its retry cap, and the cell would let such a lane ship
+without the `UNBLOCKED` that cap exists to force. That is the guard, not an oversight
+(ADR [0313](0313-a-queue-dwell-is-a-wait-not-a-park.md)).
+
+## Consequences
+
+- The eight lanes leave both sweeps, and a later lane in the same state does too — one call each, no
+  hand-editing of an append-only log anywhere.
+- A genuinely broken lane still shows up on every sweep, because both gates must hold. An open issue
+  or a replaying log is refused, so an archive can never quietly hide live work.
+- The archived ledger is out of every sweep, which means nothing watches it. That is the point, and
+  it is why the closed-issue gate is not negotiable.
+- `lane migrate`'s unsafe refusal now names `lane archive` as the route for a closed, unreplayable
+  lane, in place of "decide each unsafe lane's state by hand".
+- Two exit codes are added to the lane table: `49` the issue is open, `50` the log replays.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -467,7 +467,11 @@ node <fabrika> lane migrate           # migrate the ones the swap provably does 
 
 It writes only where the lane's own event log folds to the same state through both machines. Exit
 `37` names the lanes it would have moved and leaves them alone — that is a human's call, not a
-re-run's.
+re-run's. One of those calls is now a verb: a lane whose issue is closed AND whose log will never
+replay leaves both sweeps through `node <fabrika> lane archive <lane>`, which moves its directory to
+the archived root and touches no log (ADR
+[0352](../../../../.decisions/0352-an-unreplayable-lane-is-archived-not-sealed.md)). It refuses at
+`49` on an open issue and `50` on a log that replays, so it can never hide live work.
 
 The sweep also judges each issue-keyed lane's machine against its issue's type and sub-issue links,
 because staleness was the only wrongness it could see and a coder-template lane booted on an epic

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -575,6 +575,7 @@ snapshot. Lane state is local and never committed.
 | `lane integrate` | one reviewed child merged into that worktree, its dependencies reconciled from the merged lockfile, then judged by the repo's `codeValidators` — last stdout line on exit 0 is `INTEGRATE-VERDICT: MERGED`, the line above it the merged head; every refusal below the merge resets the branch to `ORIG_HEAD` and pushes nothing |
 | `lane stale` | which lanes have gone quiet with something owed on them — offline, or `--claims` to pair each non-terminal lane with the claim standing on its issue |
 | `lane reconcile` | which lanes recorded a merge closure the board never confirmed, and the `<TASK>.CORRECTED` line that records what the board says — `partial: true` sends the lane round again (`corrected`), `partial: false` confirms the closure and moves no task (`confirmed`); either way the lane stops nominating, so a sweep costs one PR read per never-confirmed lane rather than hundreds every time (ADR 0351). `--check` reports and appends nothing, so it buys nothing for the next sweep and pays the same reads twice; a read that proves no closure is `unknown`, never `closes`; ordered after `lane migrate`, which is what an `unmigrated` row names (ADR 0350) |
+| `lane archive` | one lane whose log will never replay, moved out of the swept root — refused unless BOTH the lane's issue reads closed AND the log fails the same `Unreplayable` judgement `lane migrate` makes, so a genuinely broken lane still shows up on every sweep. The archived root is a sibling of the lanes root, so `reconcile` and `migrate` are never handed it and need no skip rule; the record stays readable through `lane history --root <archived-root>` (ADR 0352) |
 | `lane claim` / `release` | who is driving this lane |
 
 **Exit codes.** `4` the lane read in full and is not the shape · `7` the lane is absent · `8` the
@@ -593,7 +594,7 @@ outside the closed park-cause set · `36` the `UNBLOCKED` would restore a state 
 — read the refusal for which budget: retries want a recorded `CLEARED` (`build clear`), waits want
 the grant on this same resume (`--grant-wait`, else `recipe unpark`) · `47` the `--grant-wait` is
 not a whole grant of at least one wait, or rides on an event that is not `UNBLOCKED`
-· `37` a booted lane's machine cannot be replaced by the template without moving the lane · `38`
+· `37` a booted lane's machine cannot be replaced by the template without moving the lane · `49` an archive was aimed at a lane whose issue is still open · `50` an archive was aimed at a lane whose log replays, so every sweep can judge it · `38`
 the `--class` is outside the review classes · `39` the cwd is not in a repository · `40` another
 writer held the lane's lock for the whole wait · `41` no working tree holds the run's assembly
 branch · `42` the child conflicts and the merge was aborted · `43` the merged lockfile does not

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -84,6 +84,8 @@ export interface FakeFsOptions {
 	readonly directories?: ReadonlyArray<string>;
 	/** Paths whose removal fails — distinct from a removal that lands and leaves the path behind. */
 	readonly unremovable?: ReadonlyArray<string>;
+	/** Paths whose rename fails — a move that did not land, distinct from one that landed nowhere. */
+	readonly unrenamable?: ReadonlyArray<string>;
 	/** Paths a removal is scripted to NOT actually remove, so the re-probe has something to catch. */
 	readonly survivesRemoval?: ReadonlyArray<string>;
 	/**
@@ -150,6 +152,50 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 				return Effect.void;
 			},
 			realPath: (path: string) => Effect.succeed(options.real?.[path] ?? path),
+			// A directory rename moves everything under the prefix, which is the whole reason a lane
+			// archive is one call: a per-file copy would touch the log's bytes.
+			rename: (path: string, to: string) => {
+				if (options.unrenamable?.includes(path) === true) return denied("rename", path);
+				if (!directories.has(path) && !Object.hasOwn(dirs, path) && !Object.hasOwn(files, path)) {
+					return notFound("rename", path);
+				}
+				const moved = (key: string): string | null =>
+					key === path ? to : key.startsWith(`${path}/`) ? `${to}${key.slice(path.length)}` : null;
+				for (const key of Object.keys(files)) {
+					const next = moved(key);
+					if (next === null) continue;
+					const text = files[key] ?? null;
+					files[next] = text;
+					written.set(next, text ?? "");
+					delete files[key];
+				}
+				for (const key of Object.keys(dirs)) {
+					const next = moved(key);
+					if (next === null) continue;
+					dirs[next] = dirs[key] ?? null;
+					delete dirs[key];
+				}
+				for (const key of [...directories]) {
+					const next = moved(key);
+					if (next === null) continue;
+					directories.add(next);
+					directories.delete(key);
+				}
+				// The parent listings move with it, because a sweep reads `readDirectory` and a fake
+				// that still listed the moved entry under its old parent would green a sweep that
+				// cannot happen — the exact claim an archive rests on.
+				const parent = (of: string): [string, string] => {
+					const cut = of.lastIndexOf("/");
+					return cut === -1 ? ["", of] : [of.slice(0, cut), of.slice(cut + 1)];
+				};
+				const [fromDir, fromName] = parent(path);
+				const [toDir, toName] = parent(to);
+				const listed = dirs[fromDir];
+				if (listed != null) dirs[fromDir] = listed.filter((name) => name !== fromName);
+				const target = dirs[toDir];
+				if (target != null) dirs[toDir] = [...target, toName];
+				return Effect.void;
+			},
 			remove: (path: string) => {
 				if (options.unremovable?.includes(path) === true) return denied("remove", path);
 				if (options.survivesRemoval?.includes(path) === true) return Effect.void;

--- a/packages/fabrika-cli/src/io/fs.ts
+++ b/packages/fabrika-cli/src/io/fs.ts
@@ -207,3 +207,25 @@ export const writeFile = (
 	}).pipe(
 		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
 	);
+
+/**
+ * Move `path` to `to`, creating the destination's parent.
+ *
+ * The one primitive that relocates a directory without reading it: a copy-then-remove would read
+ * every byte of an append-only log and re-emit it, which is a rewrite the reader cannot tell from
+ * the original. A rename moves the inode, so the bytes a caller moved are provably the bytes that
+ * were there. Like every write here, a rename that did not land FAILS — a caller never reports the
+ * path as moved.
+ */
+export const rename = (
+	path: string,
+	to: string,
+): Effect.Effect<void, WriteFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathService = yield* Path.Path;
+		yield* fs.makeDirectory(pathService.dirname(to), {recursive: true});
+		yield* fs.rename(path, to);
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
+	);

--- a/packages/fabrika-cli/src/lane/archive-verb.ts
+++ b/packages/fabrika-cli/src/lane/archive-verb.ts
@@ -1,0 +1,207 @@
+/**
+ * `lane archive` — move one lane whose log will never replay out of the swept root.
+ *
+ * The route ADR 0352 ruled for a lane no sweep can judge. `lane reconcile` reports such a lane
+ * `unreadable` and `lane migrate` refuses it `unsafe` on every run, forever, because the fault is in
+ * a log neither may rewrite: an `ISSUE.DONE` appended after the fold reached `frozen` has no update
+ * cell and never will. Sealing it would mean appending a line for something that did not happen
+ * (ADR 0350 forbids that), and giving `frozen` the cell would let a lane at its retry cap ship with
+ * no unblock. So the lane leaves the sweep's scope by moving, and the log is never touched.
+ *
+ * **Both gates hold or nothing moves**, and that is what keeps a genuinely broken lane visible: a
+ * lane whose issue is still open, or whose log replays, is refused with the directory where it was.
+ * The archived root is a SIBLING of the swept one, so no sweep learns a skip rule — `reconcile` and
+ * `migrate` read the roots they are handed, and the archived one is not among them.
+ *
+ * The order of the two gates is a cost decision: the replay judgement is local and free, the closure
+ * read is one request, so a replaying lane is refused before the board is ever asked.
+ */
+import {Effect, type FileSystem, Path, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists, readFile, rename} from "../io/fs.ts";
+import {getIssue, resolveRepo} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {judgeArchive} from "./archive.ts";
+import {
+	APPEND_UNKNOWN,
+	ISSUE_LIVE,
+	ISSUE_UNRESOLVED,
+	LANE_EXISTS,
+	LANE_UNREADABLE,
+	LOG_REPLAYS,
+	MARKER_READBACK,
+} from "./codes.ts";
+import {loadRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane archive";
+
+/** Whether the issue this lane drives is closed on the board. A read that failed is `Unknown`. */
+export type ClosureState =
+	| {readonly _tag: "Closed"; readonly reason: string | null}
+	| {readonly _tag: "Open"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+export type ClosedReader<R> = (issue: number) => Effect.Effect<ClosureState, never, R>;
+
+/**
+ * The board-backed reader: one `getIssue`, and its `state` is the whole answer.
+ *
+ * A reader the caller passes rather than a seam this verb reaches through on its own, the shape
+ * `lane open` and `lane migrate` established — so every refusal above is testable without a network,
+ * and an unreadable board is `Unknown`, never an open issue and never a closed one.
+ */
+export const closedReader = (
+	repo: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): ClosedReader<ChildProcessSpawner.ChildProcessSpawner> => {
+	let resolved: string | null = null;
+	return (issue) =>
+		Effect.gen(function* () {
+			if (resolved === null) {
+				const attempt = yield* resolveRepo(repo, env);
+				if (attempt._tag === "Failure") {
+					return {
+						_tag: "Unknown" as const,
+						reason: "no target repo resolves — set CLAUDE_PIPELINE_REPO, or pass --repo owner/name",
+					};
+				}
+				resolved = attempt.value;
+			}
+			const record = yield* getIssue(resolved, issue);
+			if (record._tag !== "Present") {
+				return {
+					_tag: "Unknown" as const,
+					reason:
+						record._tag === "Absent"
+							? `#${issue} is not present on ${resolved}`
+							: `cannot read #${issue}: ${record.reason}`,
+				};
+			}
+			return record.value.state === "closed"
+				? {_tag: "Closed" as const, reason: record.value.stateReason}
+				: {_tag: "Open" as const};
+		});
+};
+
+export interface ArchiveOptions<R = never> {
+	readonly ref: LaneRef;
+	/** Where the lane moves to — the archived root, which no sweep is handed. */
+	readonly archivedRoot: string;
+	/** The committed templates this root's lanes may have booted from; the lane's `id` picks. */
+	readonly templatePaths: ReadonlyArray<string>;
+	/** The issue this lane drives, or `null` for a key that names none. */
+	readonly issue: number | null;
+	readonly closed: ClosedReader<R>;
+}
+
+export const runArchive = <R = never>(
+	options: ArchiveOptions<R>,
+): Effect.Effect<VerbOutcome, never, R | FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const {ref, issue} = options;
+		if (issue === null) {
+			return refuse(
+				ISSUE_UNRESOLVED,
+				`${VERB}: "${ref.lane}" names no issue, and an archive turns on that issue reading closed — a chore lane can never satisfy it, so there is nothing here to prove. Nothing was moved.`,
+			);
+		}
+
+		const loaded = yield* loadLane(ref);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+
+		const workflowPath = path.join(loaded.dir, "workflow.json");
+		const laneText = yield* Effect.result(readFile(workflowPath));
+		if (Result.isFailure(laneText)) {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot re-read ${workflowPath}: ${laneText.failure.reason} — whether this lane replays is UNKNOWN. Nothing was moved.`,
+			);
+		}
+		const templateTexts: string[] = [];
+		for (const templatePath of options.templatePaths) {
+			const template = yield* Effect.result(readFile(templatePath));
+			if (Result.isFailure(template)) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot read the committed template at ${templatePath}: ${template.failure.reason} — nothing was moved.`,
+				);
+			}
+			templateTexts.push(template.success);
+		}
+
+		const judged = judgeArchive(templateTexts, laneText.success, loaded.lane, loaded.entries);
+		if (judged._tag === "Unjudgeable") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot judge whether ${loaded.logPath} replays: ${judged.reason} — refusing to move over UNKNOWN.`,
+			);
+		}
+		if (judged._tag === "Replays") {
+			return refuse(
+				LOG_REPLAYS,
+				`${VERB}: ${loaded.logPath} replays through this lane's own machine and through the committed template, so every sweep can judge it — this is not a lane to move out of their scope. Nothing was moved.`,
+			);
+		}
+
+		const closure = yield* options.closed(issue);
+		if (closure._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot establish whether #${issue} is closed: ${closure.reason} — refusing to move over UNKNOWN.`,
+			);
+		}
+		if (closure._tag === "Open") {
+			return refuse(
+				ISSUE_LIVE,
+				`${VERB}: #${issue} is open, so this lane is live work — an archived lane is beyond every sweep, and a live one belongs where the sweeps can see it. Drive the lane, or close the issue first. Nothing was moved.`,
+			);
+		}
+
+		const destination = path.join(options.archivedRoot, ref.lane);
+		const occupied = yield* Effect.result(exists(destination));
+		if (Result.isFailure(occupied)) {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot establish whether ${destination} is already there: ${occupied.failure.reason} — refusing to move over UNKNOWN.`,
+			);
+		}
+		if (occupied.success) {
+			return refuse(
+				LANE_EXISTS,
+				`${VERB}: ${destination} already holds an archived lane — a move onto it would bury a record this verb exists to keep. Nothing was moved.`,
+			);
+		}
+
+		const moved = yield* Effect.result(rename(loaded.dir, destination));
+		if (Result.isFailure(moved)) {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${VERB}: the move of ${loaded.dir} to ${destination} did not land: ${moved.failure.reason} — the lane is NOT archived.`,
+			);
+		}
+		const landed = yield* Effect.result(exists(path.join(destination, "workflow.json")));
+		if (Result.isFailure(landed) || !landed.success) {
+			return refuse(
+				MARKER_READBACK,
+				`${VERB}: the move of ${loaded.dir} reported success and ${destination}/workflow.json does not read back — where this lane's record now is needs a human eye before anything else touches it.`,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "archived",
+				lane: ref.lane,
+				issue,
+				from: loaded.dir,
+				to: destination,
+				through: judged.through,
+				defects: judged.defects,
+			}),
+			[
+				`${VERB}: moved ${loaded.dir} to ${destination}; #${issue} is closed${closure.reason === null ? "" : ` (${closure.reason})`} and the log does not replay through the ${judged.through === "current" ? "lane's own machine" : "committed template"}.`,
+				`${VERB}: read it back with \`fabrika lane history ${ref.lane} --root ${options.archivedRoot}\`.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/lane/archive.ts
+++ b/packages/fabrika-cli/src/lane/archive.ts
@@ -1,0 +1,75 @@
+/**
+ * The archive judgement — is this lane's log one no sweep can ever judge?
+ *
+ * Half of what `lane archive` needs before it moves a directory; the other half (the issue reads
+ * closed) is a board fact and lives at the verb. This module reads no disk and writes none.
+ *
+ * The judgement is [`migrate.ts`](migrate.ts)'s, deliberately and by call rather than by
+ * re-derivation: the lanes an archive is for are exactly the ones `lane migrate` already refuses as
+ * `Unreplayable`, so if the two ever answered differently, the sweep would keep reporting a lane the
+ * archive had already taken out of scope, or take one out that the sweep still judges fine (ADR
+ * 0352).
+ *
+ * The lane's own machine is folded first, and that ordering is the one thing this adds. A generated
+ * epic machine has no committed template to be a candidate ({@link graftContext} answers `Foreign`),
+ * so asking for a candidate first would leave every emitted lane unjudgeable — including one whose
+ * log genuinely does not replay through the only machine it has.
+ */
+import {foldLog, type LogEntry} from "./fold.ts";
+import {type CompiledLane, compileText} from "./machine.ts";
+import {graftContext, judgeMigration} from "./migrate.ts";
+
+export type ArchiveVerdict =
+	/** The log does not replay, and `through` names which machine refused it. */
+	| {
+			readonly _tag: "Unreplayable";
+			readonly through: "current" | "candidate";
+			readonly defects: ReadonlyArray<string>;
+	  }
+	/** The log replays through every machine that can be built for it — nothing to archive. */
+	| {readonly _tag: "Replays"}
+	/** No candidate could be built, so replayability through the template is UNKNOWN, never proven. */
+	| {readonly _tag: "Unjudgeable"; readonly reason: string};
+
+/**
+ * Judge one lane for archiving. `templateTexts` are the committed templates the lane's root binds;
+ * the lane's own document `id` picks among them, exactly as the migrate sweep lets it.
+ */
+export const judgeArchive = (
+	templateTexts: ReadonlyArray<string>,
+	laneText: string,
+	current: CompiledLane,
+	entries: ReadonlyArray<LogEntry>,
+): ArchiveVerdict => {
+	const own = foldLog(current, entries);
+	if (own._tag !== "Folded") {
+		return {_tag: "Unreplayable", through: "current", defects: own.defects};
+	}
+
+	const grafts = templateTexts.map((text) => graftContext(text, laneText));
+	const ungraftable = grafts.find((candidate) => candidate._tag === "Ungraftable");
+	if (ungraftable !== undefined) return {_tag: "Unjudgeable", reason: ungraftable.reason};
+	const graft = grafts.find((candidate) => candidate._tag === "Grafted");
+	if (graft === undefined) {
+		const foreign = grafts.find((candidate) => candidate._tag === "Foreign");
+		return {
+			_tag: "Unjudgeable",
+			reason:
+				foreign === undefined
+					? "no committed template was offered for this root"
+					: `machine "${foreign.id}" was generated, not booted, so it has no committed template to be judged against`,
+		};
+	}
+	const candidate = compileText(graft.text);
+	if (candidate._tag === "Malformed") {
+		return {
+			_tag: "Unjudgeable",
+			reason: `the committed template does not compile: ${candidate.defects.join("; ")}`,
+		};
+	}
+
+	const judged = judgeMigration(current, candidate.lane, entries);
+	return judged._tag === "Unreplayable"
+		? {_tag: "Unreplayable", through: judged.through, defects: judged.defects}
+		: {_tag: "Replays"};
+};

--- a/packages/fabrika-cli/src/lane/archive.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/archive.unit.test.ts
@@ -1,0 +1,320 @@
+/** The archive judgement, and the verb whose two gates decide whether a lane directory moves. */
+import {Effect, type FileSystem, type Path} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {judgeArchive} from "./archive.ts";
+import {type ClosureState, runArchive} from "./archive-verb.ts";
+import {
+	APPEND_UNKNOWN,
+	ISSUE_LIVE,
+	ISSUE_UNRESOLVED,
+	LANE_ABSENT,
+	LANE_EXISTS,
+	LANE_UNREADABLE,
+	LOG_REPLAYS,
+	MARKER_READBACK,
+	MIGRATION_UNSAFE,
+} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import type {LogEntry} from "./fold.ts";
+import {runHistory} from "./history-verb.ts";
+import {type CompiledLane, compileText} from "./machine.ts";
+import {runMigrate} from "./migrate-verb.ts";
+import {runReconcile} from "./reconcile-verb.ts";
+import {DEFAULT_ARCHIVED_LANES_ROOT, DEFAULT_LANES_ROOT} from "./store.ts";
+
+const ROOT = DEFAULT_LANES_ROOT;
+const ARCHIVED = DEFAULT_ARCHIVED_LANES_ROOT;
+const DIR = `${ROOT}/6037`;
+const MOVED = `${ARCHIVED}/6037`;
+const TEMPLATE = "/repo/templates/coder.workflow.json";
+const CHORE_TEMPLATE = "/repo/templates/chore.workflow.json";
+
+const compiled = (text: string): CompiledLane => {
+	const result = compileText(text);
+	if (result._tag === "Malformed") throw new Error(result.defects.join("; "));
+	return result.lane;
+};
+
+const log = (...events: ReadonlyArray<string>): ReadonlyArray<LogEntry> =>
+	events.map((event) => ({task: "issue", event: `ISSUE.${event}`, at: "2026-08-19T00:00:00.000Z"}));
+
+const logText = (...events: ReadonlyArray<string>): string =>
+	`${log(...events)
+		.map((entry) => JSON.stringify(entry))
+		.join("\n")}\n`;
+
+/**
+ * A lane machine carrying a cell the committed template does not: the shape whose log replays
+ * through the lane's own machine and refuses through the template.
+ */
+const widenedLaneText = (): string => {
+	const document = JSON.parse(coderTemplateText());
+	document.machine.states.pipeline.states.issue.states.queued.on["ISSUE.PASS"] = "shipped";
+	return JSON.stringify(document, null, "\t");
+};
+
+describe("judgeArchive", () => {
+	it("names the lane's own machine when the log will not replay through it", () => {
+		const text = coderTemplateText();
+
+		expect(judgeArchive([text], text, compiled(text), log("PASS"))).toMatchObject({
+			_tag: "Unreplayable",
+			through: "current",
+		});
+	});
+
+	it("names the committed template when only that machine refuses the log", () => {
+		const lane = widenedLaneText();
+
+		expect(judgeArchive([coderTemplateText()], lane, compiled(lane), log("PASS"))).toMatchObject({
+			_tag: "Unreplayable",
+			through: "candidate",
+		});
+	});
+
+	it("answers `Replays` for a log both machines fold, so nothing is archivable", () => {
+		const text = coderTemplateText();
+
+		expect(judgeArchive([text], text, compiled(text), log("WIP", "DONE"))).toEqual({
+			_tag: "Replays",
+		});
+	});
+
+	it("folds the lane's own machine BEFORE looking for a candidate, so a generated one still judges", () => {
+		const emitted = JSON.parse(coderTemplateText());
+		emitted.id = "epic-5817";
+		const text = JSON.stringify(emitted, null, "\t");
+
+		expect(judgeArchive([coderTemplateText()], text, compiled(text), log("PASS"))).toMatchObject({
+			_tag: "Unreplayable",
+			through: "current",
+		});
+	});
+
+	it("is UNKNOWN, never `Replays`, when a generated machine's replaying log has no candidate", () => {
+		const emitted = JSON.parse(coderTemplateText());
+		emitted.id = "epic-5817";
+		const text = JSON.stringify(emitted, null, "\t");
+
+		expect(
+			judgeArchive([coderTemplateText()], text, compiled(text), log("WIP", "DONE")),
+		).toMatchObject({_tag: "Unjudgeable"});
+	});
+});
+
+const closes = (state: ClosureState) => () => Effect.succeed(state);
+const closed = closes({_tag: "Closed", reason: "completed"});
+
+const OPTIONS = {
+	ref: {root: ROOT, lane: "6037"},
+	archivedRoot: ARCHIVED,
+	templatePaths: [TEMPLATE],
+	issue: 6037,
+	closed,
+};
+
+/** A lane on disk whose `ISSUE.PASS` from `queued` no machine has a cell for — the #7803 shape. */
+const brokenLane = (
+	extra: Record<string, string | null> = {},
+	directories: ReadonlyArray<string> = [],
+) =>
+	fakeFs({
+		files: {
+			[TEMPLATE]: coderTemplateText(),
+			[`${DIR}/workflow.json`]: coderTemplateText(),
+			[`${DIR}/events.jsonl`]: logText("PASS"),
+			...extra,
+		},
+		dirs: {[ROOT]: ["6037"], [ARCHIVED]: []},
+		directories: [ROOT, ARCHIVED, DIR, ...directories],
+	});
+
+const run = (
+	fs: ReturnType<typeof fakeFs>,
+	eff: Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path>,
+) => Effect.runPromise(Effect.provide(eff, fs.layer));
+
+describe("lane archive", () => {
+	it("moves the lane to the archived root with both gates held, and touches no log", async () => {
+		const fs = brokenLane();
+		const out = await run(fs, runArchive(OPTIONS));
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "archived",
+			lane: "6037",
+			issue: 6037,
+			from: DIR,
+			to: MOVED,
+			through: "current",
+		});
+		// The bytes reached the destination unchanged, and nothing was written to the log in place.
+		expect(fs.written.get(`${MOVED}/events.jsonl`)).toBe(logText("PASS"));
+		expect(fs.written.has(`${DIR}/events.jsonl`)).toBe(false);
+	});
+
+	it("leaves the archived record readable through `lane history` at the archived root", async () => {
+		const fs = brokenLane();
+		await run(fs, runArchive(OPTIONS));
+		const out = await run(fs, runHistory({root: ARCHIVED, lane: "6037"}));
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual([...log("PASS")]);
+	});
+
+	it("takes the lane out of both sweeps, neither of which is ever handed the archived root", async () => {
+		// A machine that differs from the template, so the migrate sweep reaches its judgement
+		// instead of reading the lane `current` — the state the eight lanes of #7803 are in.
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				[`${DIR}/workflow.json`]: widenedLaneText(),
+				[`${DIR}/events.jsonl`]: logText("PASS"),
+			},
+			dirs: {[ROOT]: ["6037"], [ARCHIVED]: []},
+			directories: [ROOT, ARCHIVED, DIR],
+		});
+		const migrate = () =>
+			runMigrate({
+				roots: [{root: ROOT, templatePaths: [TEMPLATE]}],
+				check: true,
+				expectations: null,
+			});
+		const reconcile = () =>
+			runReconcile({
+				roots: [{root: ROOT, templatePaths: [TEMPLATE]}],
+				check: true,
+				now: "2026-09-04T00:00:00.000Z",
+				closures: () => Effect.succeed({_tag: "Unknown", reason: "never asked"} as const),
+			});
+
+		const migrateBefore = await run(fs, migrate());
+		const reconcileBefore = await run(fs, reconcile());
+		const archived = await run(fs, runArchive(OPTIONS));
+		const migrateAfter = await run(fs, migrate());
+		const reconcileAfter = await run(fs, reconcile());
+
+		expect(migrateBefore.code).toBe(MIGRATION_UNSAFE);
+		expect(JSON.parse(reconcileBefore.stdout).lanes).toHaveLength(1);
+		expect(archived.code).toBe(0);
+		expect(migrateAfter.code).toBe(0);
+		expect(JSON.parse(migrateAfter.stdout).lanes).toEqual([]);
+		expect(JSON.parse(reconcileAfter.stdout).lanes).toEqual([]);
+	});
+
+	it("refuses an open issue, leaving the directory where it was", async () => {
+		const fs = brokenLane();
+		const out = await run(fs, runArchive({...OPTIONS, closed: closes({_tag: "Open"})}));
+
+		expect(out.code).toBe(ISSUE_LIVE);
+		expect(out.stdout).toBe("");
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a log that replays, before the board is ever asked", async () => {
+		let asked = 0;
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				[`${DIR}/workflow.json`]: coderTemplateText(),
+				[`${DIR}/events.jsonl`]: logText("WIP", "DONE"),
+			},
+			dirs: {[ROOT]: ["6037"], [ARCHIVED]: []},
+			directories: [ROOT, ARCHIVED, DIR],
+		});
+		const out = await run(
+			fs,
+			runArchive({
+				...OPTIONS,
+				closed: () => {
+					asked += 1;
+					return Effect.succeed({_tag: "Closed", reason: null} as const);
+				},
+			}),
+		);
+
+		expect(out.code).toBe(LOG_REPLAYS);
+		expect(asked).toBe(0);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses an UNKNOWN board read rather than moving over it", async () => {
+		const fs = brokenLane();
+		const out = await run(
+			fs,
+			runArchive({...OPTIONS, closed: closes({_tag: "Unknown", reason: "rate limited"})}),
+		);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a chore key, whose lane can never satisfy the closed-issue gate", async () => {
+		const fs = brokenLane();
+		const out = await run(fs, runArchive({...OPTIONS, issue: null}));
+
+		expect(out.code).toBe(ISSUE_UNRESOLVED);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a lane that is not there", async () => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText()},
+			dirs: {[ROOT]: []},
+			directories: [ROOT, ARCHIVED],
+		});
+		const out = await run(fs, runArchive(OPTIONS));
+
+		expect(out.code).toBe(LANE_ABSENT);
+	});
+
+	it("refuses rather than moving onto an archived lane already at the destination", async () => {
+		const fs = brokenLane({[`${MOVED}/workflow.json`]: coderTemplateText()}, [MOVED]);
+		const out = await run(fs, runArchive(OPTIONS));
+
+		expect(out.code).toBe(LANE_EXISTS);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a move that did not land, and never reports the lane as archived", async () => {
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				[`${DIR}/workflow.json`]: coderTemplateText(),
+				[`${DIR}/events.jsonl`]: logText("PASS"),
+			},
+			dirs: {[ROOT]: ["6037"], [ARCHIVED]: []},
+			directories: [ROOT, ARCHIVED, DIR],
+			unrenamable: [DIR],
+		});
+		const out = await run(fs, runArchive(OPTIONS));
+
+		expect(out.code).toBe(APPEND_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a move that reported success and does not read back", async () => {
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				[`${DIR}/workflow.json`]: coderTemplateText(),
+				[`${DIR}/events.jsonl`]: logText("PASS"),
+			},
+			dirs: {[ROOT]: ["6037"], [ARCHIVED]: []},
+			directories: [ROOT, ARCHIVED, DIR],
+			unprobeable: [`${MOVED}/workflow.json`],
+		});
+		const out = await run(fs, runArchive(OPTIONS));
+
+		expect(out.code).toBe(MARKER_READBACK);
+	});
+
+	it("judges a relocated root's lane by its own machine id, with both templates offered", async () => {
+		const fs = brokenLane({[CHORE_TEMPLATE]: coderTemplateText()});
+		const out = await run(fs, runArchive({...OPTIONS, templatePaths: [CHORE_TEMPLATE, TEMPLATE]}));
+
+		expect(out.code).toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -387,3 +387,21 @@ export const GRANT_REFUSED = 47;
  * the parent's is the one to drive, and a second boot is exactly the harm.
  */
 export const LANE_IS_CHILD = 48;
+
+/**
+ * `lane archive` was pointed at a lane whose issue is still open on the board.
+ *
+ * An archive moves a lane out of every sweep, so the closed issue is half of what makes that safe:
+ * a live lane put beyond `reconcile` and `migrate` is work nothing watches any more. Its own seat
+ * because the remedy is to drive the lane, not to fix the record (ADR 0352).
+ */
+export const ISSUE_LIVE = 49;
+
+/**
+ * `lane archive` was pointed at a lane whose log replays.
+ *
+ * The other half: only a lane no sweep can ever judge leaves the sweep's scope. A replaying lane is
+ * one every sweep judges fine, and archiving it would hide a lane the pipeline still reads. The
+ * remedy is to leave it where it is (ADR 0352).
+ */
+export const LOG_REPLAYS = 50;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -16,6 +16,7 @@ import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
 import {SHIP_CLASS_NAMES} from "../review/classes.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
+import {closedReader, runArchive} from "./archive-verb.ts";
 import {runAssembly} from "./assembly-verb.ts";
 import {runBrief} from "./brief-verb.ts";
 import {runLaneAdopt, runLaneClaim, runLaneRelease} from "./claim-verb.ts";
@@ -25,7 +26,7 @@ import {expectationReader} from "./expectation.ts";
 import {deriveRepoRoot, onGround, repoGroundRefusal, resolveRootOrRefuse} from "./ground.ts";
 import {runHistory} from "./history-verb.ts";
 import {runIntegrate} from "./integrate-verb.ts";
-import {defaultRoot, type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
+import {archivedRoot, defaultRoot, type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
 import {runMigrate} from "./migrate-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
@@ -38,7 +39,12 @@ import {runReport} from "./report-verb.ts";
 import {DEFAULT_STALE_MINUTES} from "./stale.ts";
 import {runStale} from "./stale-verb.ts";
 import {runStatus} from "./status-verb.ts";
-import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
+import {
+	DEFAULT_ARCHIVED_LANES_ROOT,
+	DEFAULT_CHORES_ROOT,
+	DEFAULT_LANES_ROOT,
+	type LaneRef,
+} from "./store.ts";
 import {runTransition} from "./transition-verb.ts";
 import {DEFAULT_VIEW_PORT, listeningAt, runView} from "./view-verb.ts";
 
@@ -763,6 +769,67 @@ const migrate = leafCommand(
 	),
 );
 
+const archive = leafCommand(
+	"archive",
+	{
+		lane: laneArgument,
+		root: rootFlag,
+		archivedRoot: Flag.string("archived-root").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				`where the lane moves to (default: the owning repository's ${DEFAULT_ARCHIVED_LANES_ROOT}, a sibling of the lanes root and swept by nothing)`,
+			),
+		),
+		repo: Flag.string("repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the owner/name the closure read reads (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+			),
+		),
+	},
+	Effect.fn(function* ({lane, root, archivedRoot: archived, repo}) {
+		const parsed = parseKey(lane);
+		if (parsed._tag === "Malformed") {
+			yield* emit(keyRefusal(parsed));
+			return;
+		}
+		const path = yield* Path.Path;
+		let source: string;
+		let destination: string;
+		if (Option.isSome(root) && Option.isSome(archived)) {
+			source = root.value;
+			destination = archived.value;
+		} else {
+			const ground = yield* deriveRepoRoot(process.cwd());
+			if (ground._tag !== "Derived") {
+				yield* emit(repoGroundRefusal("fabrika lane archive", ground));
+				return;
+			}
+			source = Option.getOrElse(root, () => path.join(ground.repoRoot, defaultRoot(parsed.key)));
+			destination = Option.getOrElse(archived, () => path.join(ground.repoRoot, archivedRoot()));
+		}
+		const ref = laneRef(parsed.key, source);
+		yield* emit(
+			yield* onGround("archive", [ref.root, destination], process.cwd(), () =>
+				runArchive({
+					ref,
+					archivedRoot: destination,
+					// A relocated root holds whatever was opened into it, so both templates are
+					// candidates and the lane's own machine id picks — never the root's position.
+					templatePaths: [templatePath("Issue"), templatePath("Chore")],
+					issue: parsed.key._tag === "Issue" ? Number(parsed.key.lane) : null,
+					closed: closedReader(Option.getOrNull(repo), process.env),
+				}),
+			),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Move one lane whose log will never replay out of the swept root."),
+	Command.withDescription(
+		'Move one lane directory from the lanes root to the archived root, so the sweeps stop reporting a lane they can never judge. `lane reconcile` reads such a lane "unreadable" and `lane migrate` "unsafe" on every run, forever: the fault is an event the machine has no cell for, and neither verb may rewrite an append-only log to fix it — sealing writes a line for something that did not happen (ADR 0350) and widening `frozen` lets a lane at its retry cap ship with no unblock. So the record moves aside instead, and nothing in it is touched (ADR 0352). BOTH gates hold or nothing moves: the lane\'s issue must read closed on the board, AND the log must fail to replay under the same judgement `lane migrate` makes — through the lane\'s own machine or through the committed template. Anything else is refused with the directory where it was, so a genuinely broken lane still shows up on every sweep. The replay judgement runs first because it is local and free, so a replaying lane costs no board read. The archived root is a SIBLING of the lanes root, never a directory under it, which is why no sweep needs a skip rule: `reconcile` and `migrate` read the roots they are handed and are never handed this one. The record stays readable — `fabrika lane history <lane> --root <archived-root>` and `fabrika lane brief` read an archived lane when pointed at it. stdout is {answer:"archived", lane, issue, from, to, through, defects}, where `through` is "current" or "candidate" — which machine refused the log — and `defects` names why. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there), 8 (the move did not land — the lane is NOT archived), 9 (the move reported success and the destination does not read back), 11 (the lane, a committed template, the destination probe or the board could not be read, or no candidate machine could be built to judge the log against — UNKNOWN, never a move), 14 (the archived root already holds a lane by this key — a move onto it would bury a record), 19 (the key names no issue, so the closed-issue gate can never be satisfied; a chore lane is not archivable), 21 (the key is not a lane key), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default roots), 49 (the lane\'s issue is open — drive the lane, or close it first), 50 (the log replays, so every sweep can judge it and there is nothing to move out of scope). Example: fabrika lane archive 6037',
+	),
+);
+
 const reconcile = leafCommand(
 	"reconcile",
 	{
@@ -876,6 +943,7 @@ export const laneCommand = Command.make("lane").pipe(
 		stale,
 		migrate,
 		reconcile,
+		archive,
 		claim,
 		release,
 		adopt,

--- a/packages/fabrika-cli/src/lane/key.ts
+++ b/packages/fabrika-cli/src/lane/key.ts
@@ -12,7 +12,12 @@
  * anything carrying a separator, a traversal, or shell-significant bytes is refused as malformed
  * rather than resolved into a path nobody meant.
  */
-import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
+import {
+	DEFAULT_ARCHIVED_LANES_ROOT,
+	DEFAULT_CHORES_ROOT,
+	DEFAULT_LANES_ROOT,
+	type LaneRef,
+} from "./store.ts";
 
 /** What marks an argument as naming a chore rather than an issue. */
 export const CHORE_PREFIX = "chore:";
@@ -55,6 +60,15 @@ export const parseKey = (raw: string): KeyResult => {
 /** The root a key lives under when the caller relocates nothing. */
 export const defaultRoot = (key: LaneKey): string =>
 	key._tag === "Chore" ? DEFAULT_CHORES_ROOT : DEFAULT_LANES_ROOT;
+
+/**
+ * Where an archived lane goes, for the one kind that can be archived.
+ *
+ * Only an issue lane: archiving turns on the lane's issue reading closed, and a chore lane drives no
+ * issue, so the gate can never hold for one (ADR 0352). There is deliberately no chore counterpart
+ * to reach for.
+ */
+export const archivedRoot = (): string => DEFAULT_ARCHIVED_LANES_ROOT;
 
 /** Where a key puts its lane — the caller's `--root` wins over the kind's default. */
 export const laneRef = (key: LaneKey, root: string | null): LaneRef => ({

--- a/packages/fabrika-cli/src/lane/migrate-verb.ts
+++ b/packages/fabrika-cli/src/lane/migrate-verb.ts
@@ -319,7 +319,7 @@ export const runMigrate = <R = never>(
 				options.check
 					? `${acted.length} other lane(s) are stale and safe to migrate.`
 					: `${acted.length} other lane(s) were migrated: ${acted.map((row) => row.key).join(", ") || "none"}.`
-			} Decide each unsafe lane's state by hand — re-run to sweep the rest.`,
+			} A lane whose issue is closed and whose log will never replay leaves this sweep's scope through \`fabrika lane archive <lane>\`, which moves its directory to the archived root and touches no log (ADR 0352); any other unsafe lane is a state to decide by hand. Re-run to sweep the rest.`,
 			stderr,
 		);
 	});

--- a/packages/fabrika-cli/src/lane/store.ts
+++ b/packages/fabrika-cli/src/lane/store.ts
@@ -27,6 +27,15 @@ export const DEFAULT_LANES_ROOT = ".fabrika/lanes";
 /** Where a chore lane lives: keyed by name, because a chore has no issue number (#5840). */
 export const DEFAULT_CHORES_ROOT = ".fabrika/chores";
 
+/**
+ * Where an archived lane lives — a SIBLING of the lanes root, never a directory under it.
+ *
+ * That placement is the whole mechanism: `lane reconcile` and `lane migrate` sweep the roots they
+ * are handed and nothing above them, so a lane moved to a sibling is out of both sweeps without
+ * either verb learning a skip rule it could get wrong (ADR 0352).
+ */
+export const DEFAULT_ARCHIVED_LANES_ROOT = ".fabrika/lanes-archived";
+
 export interface LaneRef {
 	/** The lanes root — `.fabrika/lanes`, or `.fabrika/chores` for a chore key. */
 	readonly root: string;


### PR DESCRIPTION
Eight lane ledgers carry events their own machine cannot replay, so `lane reconcile` reports them
`unreadable` and `lane migrate` refuses them `unsafe` on every sweep, forever. The founder ruled the
archive route in
[#7803's ruling comment](https://github.com/kamp-us/phoenix/issues/7803#issuecomment-5544645381):
such a lane leaves the sweep's scope by moving, never by a line appended to its log and never by
giving `frozen` a cell it does not have. This transcribes that ruling and ships the verb it names.

## What changed

`fabrika lane archive <lane>` moves one lane directory from `.fabrika/lanes` to
`.fabrika/lanes-archived`. It refuses — non-zero, log untouched, directory unmoved — unless **both**
gates hold: the lane's issue reads closed on the board (exit `49` when it is open), and the log fails
the same `judgeMigration` verdict `lane migrate` makes, through the lane's own machine or through the
committed template (exit `50` when it replays). The replay judgement runs first, so a replaying lane
costs no board read.

The archived root is a **sibling** of the lanes root, never a directory under it. That is the whole
mechanism for "the sweeps do not scan it": `reconcile` and `migrate` read the roots they are handed
and are never handed this one, so neither learns a skip rule it could get wrong. The record stays
readable — `lane history` and `lane brief` already take `--root`.

- `lane/archive.ts` — the pure judgement, which calls `judgeMigration` rather than re-deriving it, so
  the archive and the sweep can never disagree about one lane. It folds the lane's own machine
  *before* looking for a candidate, which is what lets a generated epic machine (no committed
  template) still be judged.
- `lane/archive-verb.ts` — the verb, its refusals, and the board reader.
- `lane/migrate-verb.ts` — the `37` refusal now names `lane archive` for a closed, unreplayable lane
  in place of "decide each unsafe lane's state by hand".
- `io/fs.ts` — a `rename` primitive. A copy-then-remove would read and re-emit every byte of an
  append-only log; a rename moves the inode, so the bytes archived are provably the bytes that were
  there.
- ADR [0352](.decisions/0352-an-unreplayable-lane-is-archived-not-sealed.md) — the ruling and both
  rejected routes (a sealing line, a `frozen` → `DONE` cell).

## Verification

17 new unit tests drive every refusal arm and the success arm; the full `fabrika-cli` suite is 8788
passing. `build check` is green on `--surface code` and `--surface prose`.

The verb was then run against the operator's own ledger — the eight lanes named on the issue, all
eight moved, `through` splitting exactly as the issue predicted (`current` for 5991/6005/6037/6100/6462,
`candidate` for 6226/6374/6759). The sweep afterwards:

```
migrate --check   {"current":300,"stale":0,"generated":20,"mismatched":0,"unsafe":0,"unreadable":0}
reconcile --check {"current":320,"unmigrated":0,"unknown":1,"unreadable":0}
```

Zero `unsafe`, zero `unreadable`, zero `unmigrated`. The one remaining `unknown` is #5909, which the
issue already names as a separate row and which no gate here touches.

## Deviations

- **Scope narrowing** — **Said:** the criterion reads "`fabrika lane archive <lane>` moves one lane
  directory". **Did:** only an **issue** lane is archivable; a chore key refuses at exit `19`.
  **Why:** archiving turns on the lane's issue reading closed, and a chore lane drives no issue, so
  the gate can never hold for one — refusing plainly beats a code path that could never succeed.
  **Disposition:** stated here and in the ADR.
- **Known gap left untested** — **Said:** the criterion names `lane history` *and* `lane brief`.
  **Did:** the test proves `lane history` reads an archived lane at the archived root; `lane brief`
  is not exercised. **Why:** both resolve their root through the same `onKey` adapter and the same
  `--root` flag, so `brief` needs no change and works by construction — but a `brief` test would need
  a lane in a briefable state, which none of the eight is (they are all terminal or frozen).
  **Disposition:** stated here; a test would assert the adapter, not the archive.
- **Out-of-scope change** — **Said:** the diff is the verb and its docs. **Did:** also moved the
  eight named lane directories in the operator's local, gitignored `.fabrika/lanes` ledger.
  **Why:** the second acceptance criterion is a claim about a sweep over that ledger, and it cannot
  be discharged without running the verb there; the driver's brief authorized it explicitly.
  **Disposition:** stated here — the ledger is not in git, so none of it is in this diff.
- **Pre-existing test fixture changed** — **Said:** the diff adds a verb. **Did:** the shared
  `fakeFs` gained a `rename` implementation that also moves parent directory listings.
  **Why:** without the listing move the fake would still list an archived lane under its old parent,
  which would green the sweep claim this PR rests on. All 8788 existing tests still pass.
  **Disposition:** stated here.

Fixes #7803
