### PR TITLE
fix: CI e2e sign-ups poison the preview D1 that preview-seed test-account guards

### DIFF
--- a/packages/preview-seed/src/test-account.unit.test.ts
+++ b/packages/preview-seed/src/test-account.unit.test.ts
@@ -170,6 +170,25 @@ describe("provisionTestAccounts", () => {
 		assert.lengthOf(batched, 3);
 	});
 
+	/**
+	 * The fence's parameter, pinned where a runtime assertion cannot reach: this label's TEXT would
+	 * pass `isThrowawayDatabaseName`, and the run below provisions on it, so the type is the only
+	 * thing refusing a name no `resolveDatabaseName` ever returned. Widen `databaseName` back to
+	 * `string` and the directive stops suppressing anything — TS2578 reds `pnpm typecheck` (#7740).
+	 */
+	it("refuses a caller-composed database name at the type level", async () => {
+		assert.isNotNull(TOKEN);
+		const {d1, batched} = fakeD1([]);
+		const outcome = await provisionTestAccounts(
+			makeTestAccountDb(d1),
+			// @ts-expect-error TS2345 — `resolveDatabaseName` is `ResolvedDatabaseName`'s only mint.
+			"phoenix-phoenix-db-pr-1-x",
+			{yazar: TOKEN},
+		);
+		assert.strictEqual(outcome._tag, "Provisioned");
+		assert.lengthOf(batched, 3);
+	});
+
 	it("names no tier rather than falling back to one when no token is supplied", async () => {
 		const {d1, batched, selected} = fakeD1([]);
 		const outcome = await provisionTestAccounts(makeTestAccountDb(d1), PREVIEW_NAME, {});


### PR DESCRIPTION
Fixes #7740

Criterion 7 of #7740, the last one open: the branded `databaseName` was proved only by a throwaway `tsc` probe quoted in #7806's body, which nothing re-runs. This commits that probe as a test.

`packages/preview-seed/src/test-account.unit.test.ts` gains one case that calls `provisionTestAccounts` with a hand-written `"phoenix-phoenix-db-pr-1-x"` under a `@ts-expect-error`. The label's *text* passes `isThrowawayDatabaseName` and the run provisions on it, so the assertions say plainly that the type is the only thing refusing a name no `resolveDatabaseName` ever returned.

Both polarities proved in-tree:

- As committed — `pnpm typecheck` in `packages/preview-seed` exits 0, and `vitest run --project unit` is 43 passed (4 files).
- With `databaseName` widened back to `string` in `test-account.ts` (edit made, run, reverted) — `src/test-account.unit.test.ts(184,4): error TS2578: Unused '@ts-expect-error' directive.`, exit 1. That was the only new diagnostic, so the pin is exactly the one thing standing.

The file is inside the package's `tsconfig.json` `include`, and `pnpm typecheck --force` is one of this repo's declared `codeValidators`, so the red reaches CI.

## Acceptance criteria

| # | Criterion | Discharged by |
| --- | --- | --- |
| 1 | Founder ruling recorded, README's no-override-flag argument survives it | Ruling https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5535874078, recorded as ADR 0349 in https://github.com/kamp-us/phoenix/pull/7767 |
| 2 | `test-account` succeeds against a preview D1 whose e2e job has run | https://github.com/kamp-us/phoenix/pull/7767 (re-proved live on https://github.com/kamp-us/phoenix/pull/7806) |
| 3 | Fence still refuses a production database, proved by a test | https://github.com/kamp-us/phoenix/pull/7767 |
| 4 | README "guard boundary" section rewritten to the new reach | https://github.com/kamp-us/phoenix/pull/7767 |
| 5 | `review-ui render --surface <route>:auth-caylak` capture against a live preview that has run e2e | Discharged by citation: https://github.com/kamp-us/phoenix/issues/7740#issuecomment-5544841864, citing the two runs at head `e8a577bc1f` in https://github.com/kamp-us/phoenix/issues/7708#issuecomment-5536648858 |
| 6 | `databaseName` is a branded type minted only by `resolveDatabaseName` | https://github.com/kamp-us/phoenix/pull/7806 |
| 7 | Committed type-level test pins the fence's parameter | This PR |

## Deviations

None.
