### PR TITLE
feat: Re-run the Tuval agent spell proof on ScriptedAiAgent once the Pi agent row factory lands

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -234,8 +234,10 @@ layers again and calls `SpellSet.reload`; it replaces the spells and the binding
 so processes already running keep running under the rows they were spawned from. The two proofs are
 [`src/reload-proof.unit.test.ts`](../apps/tuval/src/reload-proof.unit.test.ts) (the swap, with a
 reader watching across it) and
-[`src/commands/agent-proof.unit.test.ts`](../apps/tuval/src/commands/agent-proof.unit.test.ts) (a
-scripted program enumerating the registry over the wire and calling every spell in it).
+[`src/commands/agent-proof.unit.test.ts`](../apps/tuval/src/commands/agent-proof.unit.test.ts),
+which runs one script twice: once as a plain scripted program sending `SpellCall`s over the wire,
+and once as a process built by `aiAgentProgram` over `ScriptedAiAgent.layer`, reaching the same
+spells through `SpellBridge`.
 
 A config module is imported with a per-load number on its URL
 ([`config.ts`](../apps/tuval/src/config.ts)), because Node caches an ES module by URL for the life
@@ -373,6 +375,13 @@ it does for a page.
 
 `SpellBridge.scripted(table)` answers from a fixed table and runs nothing, so it has no allowlist to
 enforce.
+
+An AI agent process reaches the bridge through its `TuvalAiAgent` layer, which is where a real
+program's SDK tool would sit. `ScriptedAiAgent` has no SDK, so its script says what to call: a
+turn's optional `plan` ([`ai-agent/service/script.ts`](../apps/tuval/src/ai-agent/service/script.ts))
+names one spell at a time out of the answers the turn already has, and the script's `spells` holds
+the `SpellBridgeApi` those calls go through plus the `Scope` each one carries. Every answer lands on
+the session's transcript as a `tool` item, so the run reads back as the conversation it was.
 
 ## The Tuval protocol
 

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
@@ -9,11 +9,27 @@
  * A prompt replays its turn's events verbatim, so a fixture reads as the conversation it stands
  * for. The three calls that carry an argument the script cannot know — `answer`, `setMode`, and
  * `start`'s resume — emit events built from that argument, and nothing else is synthesized.
+ *
+ * A turn may also carry a `plan`, and then this layer is where a scripted session reaches the
+ * kernel: the plan names one spell at a time out of what it has already been answered, the call
+ * goes through the same `SpellBridge` a real agent program's tool wraps, and each answer lands on
+ * the transcript as a `tool` item. That is the whole difference between a scripted backend and a
+ * model — which spell to call next is a fixture's decision here and the model's there.
  */
 
-import {type Cause, Effect, Layer, Queue, Ref, type Scope, Stream} from "effect";
+import {type Cause, Effect, Layer, Queue, Ref, Result, type Scope, Stream} from "effect";
+import {renderPath} from "../../commands/spell.ts";
 import type {AgentEvent} from "../events.ts";
-import type {Mode, PermissionDecision, PermissionRequest} from "../ports/index.ts";
+import {
+	boundToolResult,
+	ItemId,
+	isJsonValue,
+	type JsonValue,
+	type Mode,
+	type PermissionDecision,
+	type PermissionRequest,
+	type TranscriptItem,
+} from "../ports/index.ts";
 import {
 	ModeUnsupported,
 	PageError,
@@ -22,7 +38,7 @@ import {
 	type TransportError,
 	UnknownRequest,
 } from "./errors.ts";
-import type {AgentScript} from "./script.ts";
+import type {AgentScript, ScriptedAnswer, ScriptedPlan} from "./script.ts";
 import {TuvalAiAgent, type TuvalAiAgentApi} from "./TuvalAiAgent.ts";
 
 interface ScriptState {
@@ -59,6 +75,22 @@ const foldPending = (
 	return next;
 };
 
+/** One answered call as the transcript carries it: what was asked, and what came back. */
+const toolItem = (id: string, answered: ScriptedAnswer): TranscriptItem => ({
+	kind: "tool",
+	id: ItemId.make(id),
+	timestamp: Date.now(),
+	name: renderPath(answered.request.path),
+	// The wire takes JSON either way, so args that are not JSON are the fixture's own bug and are
+	// recorded as the nothing they can be rendered as, rather than crashing the item's predicate.
+	input: isJsonValue(answered.request.args) ? (answered.request.args as JsonValue) : null,
+	result: boundToolResult(JSON.stringify(answered.answer) ?? "null"),
+	status: answered.ok ? "ok" : "error",
+});
+
+/** A plan that never ends is a fixture bug; the cap turns a hung run into a named failure. */
+const PLAN_CALL_LIMIT = 1_000;
+
 const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.Scope> =>
 	Effect.gen(function* () {
 		// Acquired against the caller's Scope, so closing it shuts the queue: this layer's whole
@@ -75,6 +107,31 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 				concurrency: 1,
 				discard: true,
 			});
+
+		const runPlan = Effect.fn("TuvalAiAgent.plan")(function* (plan: ScriptedPlan, turn: number) {
+			const spells = script.spells;
+			if (spells === undefined) {
+				return yield* Effect.die(
+					new Error(`turn ${turn} plans a spell call and the script names no spells to reach`),
+				);
+			}
+			const answered: Array<ScriptedAnswer> = [];
+			for (let request = plan(answered); request !== null; request = plan(answered)) {
+				if (answered.length >= PLAN_CALL_LIMIT) {
+					return yield* Effect.die(
+						new Error(`turn ${turn} planned more than ${PLAN_CALL_LIMIT} calls`),
+					);
+				}
+				const outcome = yield* Effect.result(
+					spells.bridge.call(request.path, request.args, spells.scope),
+				);
+				const entry: ScriptedAnswer = Result.isSuccess(outcome)
+					? {request, ok: true, answer: outcome.success}
+					: {request, ok: false, answer: outcome.failure};
+				answered.push(entry);
+				yield* emit([{kind: "item", item: toolItem(`call-${turn}-${answered.length}`, entry)}]);
+			}
+		});
 
 		const start = Effect.fn("TuvalAiAgent.start")(function* (options: {
 			readonly cwd: string;
@@ -137,6 +194,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 				live: turn.disconnect === undefined,
 			}));
 			yield* emit(turn.events);
+			if (turn.plan !== undefined) yield* runPlan(turn.plan, current.turn);
 			if (turn.disconnect !== undefined) yield* Queue.fail(queue, turn.disconnect);
 		});
 

--- a/apps/tuval/src/ai-agent/service/index.ts
+++ b/apps/tuval/src/ai-agent/service/index.ts
@@ -26,7 +26,15 @@ export {
 	UnknownRequest,
 } from "./errors.ts";
 export {ScriptedAiAgent} from "./ScriptedAiAgent.ts";
-export type {AgentScript, ScriptedModes, ScriptedTurn} from "./script.ts";
+export type {
+	AgentScript,
+	ScriptedAnswer,
+	ScriptedModes,
+	ScriptedPlan,
+	ScriptedRequest,
+	ScriptedSpells,
+	ScriptedTurn,
+} from "./script.ts";
 export {
 	type StartedSession,
 	type StartOptions,

--- a/apps/tuval/src/ai-agent/service/script.ts
+++ b/apps/tuval/src/ai-agent/service/script.ts
@@ -3,16 +3,54 @@
  * each prompt answers with.
  *
  * A script is plain data with no Effect in it, so a fixture is readable as a transcript of the
- * conversation it stands for and a test asserts against the very array it handed the layer.
+ * conversation it stands for and a test asserts against the very array it handed the layer. The
+ * one exception is `spells`: a script whose turns call the kernel has to be handed the kernel, and
+ * that reach is a service value, not a literal.
  */
 
+import type {SpellBridgeApi} from "../../commands/bridge/index.ts";
+import type {SpellPath, Scope as SpellScope} from "../../commands/spell.ts";
 import type {AgentEvent} from "../events.ts";
 import type {Mode, TranscriptItem} from "../ports/index.ts";
 import type {TransportError} from "./errors.ts";
 
+/** One spell a turn calls: the path and the args, exactly as they cross the wire. */
+export interface ScriptedRequest {
+	readonly path: SpellPath;
+	readonly args: unknown;
+}
+
+/** What one such call answered: the request it belongs to, and the reply's own outcome. */
+export interface ScriptedAnswer {
+	readonly request: ScriptedRequest;
+	readonly ok: boolean;
+	/** The reply's result when `ok`, and the failure it carried otherwise. */
+	readonly answer: unknown;
+}
+
+/**
+ * The next spell a turn calls, given every answer it has already had; `null` ends the turn.
+ *
+ * A step rather than a list, because an agent picks its second call out of its first one's reply:
+ * a fixture that had to name every call up front could not enumerate a registry it has not read
+ * yet. It is a pure function, so a script stays something a test can read and re-run.
+ */
+export type ScriptedPlan = (answered: ReadonlyArray<ScriptedAnswer>) => ScriptedRequest | null;
+
+/** What a script's calls reach, and the scope each one carries. */
+export interface ScriptedSpells {
+	readonly bridge: SpellBridgeApi;
+	readonly scope: SpellScope;
+}
+
 /** One prompt's answer: the events it emits, in order, and whether the transport dies after them. */
 export interface ScriptedTurn {
 	readonly events: ReadonlyArray<AgentEvent>;
+	/**
+	 * The spells this turn calls, after its `events` are out. Each call becomes one `tool` item on
+	 * the transcript, so the session records what it asked and what came back.
+	 */
+	readonly plan?: ScriptedPlan;
 	/**
 	 * When set, the stream fails with this error once the turn's events are out, and the session
 	 * stays down: nothing reconnects on its own, so a later call fails rather than quietly working.
@@ -35,6 +73,11 @@ export interface AgentScript {
 	readonly modes: ScriptedModes;
 	/** One entry per prompt, consumed in order. */
 	readonly turns: ReadonlyArray<ScriptedTurn>;
+	/**
+	 * What this session's turns call, and from where. A script whose turns carry no `plan` needs
+	 * none; a turn that plans a call while this is absent is a fixture bug the layer dies on.
+	 */
+	readonly spells?: ScriptedSpells;
 	/** What `interrupt` emits — normally the cut-short assistant item carrying `interrupted`. */
 	readonly interrupt: ReadonlyArray<AgentEvent>;
 }

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -19,6 +19,12 @@ import {randomUUID} from "node:crypto";
 import {defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
 import {Context, Deferred, Effect, Layer, Schema} from "effect";
+import {isAiAgentSessionState} from "../ai-agent/core/index.ts";
+import {aiAgentPortNames} from "../ai-agent/handlers/index.ts";
+import type {TranscriptPayload} from "../ai-agent/ports/index.ts";
+import {aiAgentProgram} from "../ai-agent/program.ts";
+import type {AgentScript, ScriptedAnswer, ScriptedPlan} from "../ai-agent/service/index.ts";
+import {ScriptedAiAgent} from "../ai-agent/service/index.ts";
 import {coreSpells} from "../boot.ts";
 import {Checkpoints} from "../durability/Checkpoints.ts";
 import {memoryStores} from "../durability/stores.ts";
@@ -43,13 +49,22 @@ import {
 import {RegistryDescription, type SpellDescription} from "../protocol/registry-description.ts";
 import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
+import {SpellBridge, type SpellBridgeApi} from "./bridge/index.ts";
 import {HelpRows} from "./core/help.ts";
 import {SpawnedProcesses} from "./core/process.ts";
 import {SpellExecutor} from "./executor.ts";
 import {type ParamSpec, readParams} from "./parse/spell-index.ts";
 import {SpellRegistry, type SpellRow} from "./registry.ts";
 import {type Client, WindowIndex, type WindowPlacement} from "./scope.ts";
-import {ClientId, defineSpell, renderPath, type SpellPath, WindowId, WorkspaceId} from "./spell.ts";
+import {
+	ClientId,
+	defineSpell,
+	renderPath,
+	type SpellPath,
+	type Scope as SpellScope,
+	WindowId,
+	WorkspaceId,
+} from "./spell.ts";
 import {SpellSet} from "./spell-set.ts";
 
 const workspace = WorkspaceId.make("ws-1");
@@ -57,8 +72,14 @@ const agentWindow = WindowId.make("w-agent");
 const agentProcess = ProcessId.make("p-agent");
 const client: Client = {id: ClientId.make("agent"), workspace};
 
+/** The second run's process, built by `aiAgentProgram` rather than written out as a row here. */
+const serviceAgentId = ProgramId.make("ai-agent");
+const serviceProcess = ProcessId.make("p-ai-agent");
+const serviceWindow = WindowId.make("w-ai-agent");
+
 const placements: Readonly<Record<string, WindowPlacement>> = {
 	[agentWindow]: {process: agentProcess, workspace},
+	[serviceWindow]: {process: serviceProcess, workspace},
 };
 
 const WORD_KIND = "text/v1";
@@ -418,6 +439,218 @@ describe("the agent proof", () => {
 			assert.isString(spawned.process);
 			assert.deepStrictEqual(answerAt("process.send"), {delivered: true});
 			assert.deepStrictEqual(answerAt("echo.repeat"), {word: "haha"});
+		}),
+	);
+});
+
+/**
+ * The same script, re-run on the real agent service (#7731).
+ *
+ * The process above is a plain program row standing in for an agent. This one is built by
+ * `aiAgentProgram` over `ScriptedAiAgent.layer` — the factory and the layer every AI agent program
+ * in Tuval uses — and it reaches the registry through `SpellBridge`, which is what an agent
+ * program's SDK tool wraps. What the script does is unchanged: `spell list`, `spell describe` on
+ * every path it returned, then every listed spell with args generated from its `params`.
+ */
+
+const serviceScope: SpellScope = {
+	client: ClientId.make("ai-agent"),
+	workspace,
+	window: serviceWindow,
+};
+
+const readList = Schema.decodeUnknownSync(RegistryDescription);
+
+/** What `process spawn` answered, which is the one argument a later call in the pass needs. */
+const learnedFrom = (
+	answered: ReadonlyArray<ScriptedAnswer>,
+): Readonly<Record<string, unknown>> => {
+	const spawned = answered.find((entry) => renderPath(entry.request.path) === "process.spawn");
+	const id = (spawned?.answer as {readonly process?: unknown} | undefined)?.process;
+	return id === undefined ? {} : {process: id};
+};
+
+/**
+ * The agent's next call, out of what it has already been answered: discovery first, then a
+ * describe per listed path, then one call per listed spell. Registry order puts `process spawn`
+ * ahead of `process send` and `process read`, so the process id is learned before they are reached.
+ */
+const planStep: ScriptedPlan = (answered) => {
+	const [listing, ...rest] = answered;
+	if (listing === undefined) return {path: ["spell", "list"], args: {}};
+	const listed = readList(listing.answer);
+	const firstPath = listed[0]?.path.join(" ") ?? "";
+	if (rest.length < listed.length) {
+		const next = listed[rest.length];
+		return next === undefined
+			? null
+			: {path: ["spell", "describe"], args: {path: next.path.join(" ")}};
+	}
+	const target = listed[rest.length - listed.length];
+	if (target === undefined) return null;
+	return {path: asPath(target.path), args: argumentsFor(target, learnedFrom(answered), firstPath)};
+};
+
+/** The events reach the transcript through a Sub, so the tail settles after `dispatch` returns. */
+const eventually = (check: () => boolean) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 400 && !check(); attempt += 1) yield* Effect.sleep("5 millis");
+	});
+
+interface Emission {
+	readonly port: string;
+	readonly payload: unknown;
+}
+
+const lastTranscript = (emitted: ReadonlyArray<Emission>): TranscriptPayload | undefined =>
+	[...emitted].reverse().find((entry) => entry.port === aiAgentPortNames.transcript)?.payload as
+		| TranscriptPayload
+		| undefined;
+
+const runServiceAgent = Effect.gen(function* () {
+	const emitted: Array<Emission> = [];
+	let answered: ReadonlyArray<ScriptedAnswer> = [];
+	const latch = yield* Deferred.make<SpellBridgeApi>();
+	// The bridge reaches the executor this same app builds, and the row has to exist before that
+	// app can be built at all, so the row holds a latch the app fills on its way in.
+	const reach: SpellBridgeApi = {
+		list: Effect.flatMap(Deferred.await(latch), (bridge) => bridge.list),
+		call: (path, args, scope) =>
+			Effect.flatMap(Deferred.await(latch), (bridge) => bridge.call(path, args, scope)),
+	};
+	const script: AgentScript = {
+		sessionId: "spell-proof",
+		history: [],
+		modes: {current: null, available: []},
+		interrupt: [],
+		spells: {bridge: reach, scope: serviceScope},
+		turns: [
+			{
+				events: [],
+				plan: (seen) => {
+					answered = seen;
+					return planStep(seen);
+				},
+			},
+		],
+	};
+	const rows = [
+		aiAgentProgram({
+			id: serviceAgentId,
+			layer: ScriptedAiAgent.layer(script),
+			// Bounds above anything this registry can produce, so the tail a window would render is
+			// the whole run rather than a cut of it.
+			config: {cwd: "/tuval", itemLimit: 500, byteLimit: 5_000_000},
+		}),
+		echoProgram(),
+	];
+	return yield* Effect.gen(function* () {
+		const processes = yield* Processes;
+		const rowsInRegistry = yield* SpellRegistry.use((registry) => registry.list);
+		const bridge = yield* Effect.provide(
+			SpellBridge,
+			SpellBridge.layer({allow: rowsInRegistry.map((row) => row.path)}),
+		);
+		yield* Deferred.succeed(latch, bridge);
+		const agent = yield* processes.spawn(serviceAgentId, {
+			id: serviceProcess,
+			services: Context.make(ProcessPorts, {
+				emit: (port: string, payload: unknown) =>
+					Effect.sync(() => {
+						emitted.push({port, payload});
+						return [];
+					}),
+			}),
+		});
+		yield* agent.dispatch({type: "start", cwd: "/tuval", resume: null});
+		yield* eventually(() => {
+			const state = agent.getState();
+			return isAiAgentSessionState(state) && state.sessionId !== null;
+		});
+		yield* agent.dispatch({type: "prompt", text: "call every spell you can", key: "k1"});
+		yield* eventually(() => (lastTranscript(emitted)?.items.length ?? 0) >= answered.length);
+		const help = yield* overTheWire(["help"], {});
+		return {answered, rowsInRegistry, help, transcript: lastTranscript(emitted)};
+	}).pipe(Effect.provide(app(rows)));
+});
+
+describe("the agent proof, on the agent service", () => {
+	it.live("reaches every spell through SpellBridge from an aiAgentProgram process", () =>
+		Effect.gen(function* () {
+			const {answered, rowsInRegistry, help} = yield* runServiceAgent;
+
+			for (const entry of answered) {
+				assert.isTrue(
+					entry.ok,
+					`${renderPath(entry.request.path)} failed: ${JSON.stringify(entry.answer)}`,
+				);
+			}
+
+			const registered = rowsInRegistry.map((row) => row.path.join(" "));
+			const calls = answered.map((entry) => renderPath(entry.request.path));
+			assert.strictEqual(calls[0], "spell.list", "the agent did not start by asking what exists");
+			assert.strictEqual(
+				answered.length,
+				1 + registered.length * 2,
+				"the run is not one discovery call, one describe per path and one call per spell",
+			);
+
+			const describedEvery = answered
+				.slice(1, 1 + registered.length)
+				.map((entry) => String((entry.request.args as {readonly path?: unknown}).path));
+			assert.deepStrictEqual(
+				[...describedEvery].sort(),
+				[...registered].sort(),
+				"the agent did not describe every path it was listed",
+			);
+
+			const helpRows = yield* Schema.decodeUnknownEffect(HelpRows)(resultOf(help)).pipe(
+				Effect.orDie,
+			);
+			assert.deepStrictEqual(
+				[...new Set(calls)].sort(),
+				helpRows.map((row) => row.path.split(" ").join(".")).sort(),
+				"the set the agent process called is not the set help lists",
+			);
+
+			const byPath = new Map<string, SpellRow>(
+				rowsInRegistry.map((row) => [renderPath(row.path), row]),
+			);
+			for (const entry of answered) {
+				const rendered = renderPath(entry.request.path);
+				const row = byPath.get(rendered);
+				assert.isDefined(row, `${rendered} is not a registered spell`);
+				yield* Schema.decodeUnknownEffect(row?.spell.result ?? Schema.Unknown)(entry.answer).pipe(
+					Effect.mapError(
+						(error) => new Error(`${rendered} answered off its result: ${error.message}`),
+					),
+					Effect.orDie,
+				);
+			}
+		}),
+	);
+
+	it.live("records every call and every reply on the session's own transcript", () =>
+		Effect.gen(function* () {
+			const {answered, transcript} = yield* runServiceAgent;
+			assert.isDefined(transcript, "the agent published no transcript");
+			const items = transcript?.items ?? [];
+			assert.deepStrictEqual(
+				items.map((item) => (item.kind === "tool" ? item.name : item.kind)),
+				answered.map((entry) => renderPath(entry.request.path)),
+				"the transcript is not the run the agent made",
+			);
+			items.forEach((item, index) => {
+				const entry = answered[index];
+				assert.strictEqual(item.kind, "tool");
+				if (item.kind !== "tool" || entry === undefined) return;
+				assert.strictEqual(item.status, "ok");
+				assert.deepStrictEqual(item.input, entry.request.args);
+				assert.isTrue(
+					JSON.stringify(entry.answer)?.startsWith(item.result.text) ?? false,
+					`${item.name} recorded a reply that is not the one it was answered`,
+				);
+			});
 		}),
 	);
 });

--- a/apps/tuval/src/commands/bridge/SpellBridge.ts
+++ b/apps/tuval/src/commands/bridge/SpellBridge.ts
@@ -63,17 +63,19 @@ const make = Effect.fn("Tuval.SpellBridge.make")(function* (options: {
 	return SpellBridge.of({list: registry.describe, call});
 });
 
-export class SpellBridge extends Context.Service<
-	SpellBridge,
-	{
-		readonly list: Effect.Effect<ReadonlyArray<SpellDescription>>;
-		readonly call: (
-			path: SpellPath,
-			args: unknown,
-			scope: Scope,
-		) => Effect.Effect<unknown, SpellFailure | SpellNotAllowed>;
-	}
->()("tuval/SpellBridge") {
+/** The bridge's whole surface, named so a caller can hold one without holding the service. */
+export interface SpellBridgeApi {
+	readonly list: Effect.Effect<ReadonlyArray<SpellDescription>>;
+	readonly call: (
+		path: SpellPath,
+		args: unknown,
+		scope: Scope,
+	) => Effect.Effect<unknown, SpellFailure | SpellNotAllowed>;
+}
+
+export class SpellBridge extends Context.Service<SpellBridge, SpellBridgeApi>()(
+	"tuval/SpellBridge",
+) {
 	static readonly layer = (options: {
 		readonly allow: ReadonlyArray<SpellPath>;
 	}): Layer.Layer<SpellBridge, never, SpellExecutor | SpellRegistry> =>

--- a/apps/tuval/src/commands/bridge/index.ts
+++ b/apps/tuval/src/commands/bridge/index.ts
@@ -1,2 +1,2 @@
 export {SpellNotAllowed} from "./errors.ts";
-export {type ScriptedCall, SpellBridge} from "./SpellBridge.ts";
+export {type ScriptedCall, SpellBridge, type SpellBridgeApi} from "./SpellBridge.ts";


### PR DESCRIPTION
Re-runs #7645's agent spell proof on the real agent stack: a process built by `aiAgentProgram`
over `ScriptedAiAgent.layer`, reaching the registry through `SpellBridge`. The #7645 cases are
untouched and still run beside it, so one file now proves the same script twice — once over the
wire from a plain program row, once from the agent service.

## What the new run does

`spell list`, then `spell describe` on every path it returned, then a call to every listed spell
with args generated from that spell's `params`. Every reply decodes against the spell's `result`,
the set called equals the set `help` lists, and every call and reply lands on the session's own
transcript as a `tool` item published on the `transcript` port.

## Production wiring: yes, and it is small

The swap was not test-only. `TuvalAiAgent` has no tool surface — that seam is #7617/#7620's — so a
scripted session had no way to reach the bridge at all. One thing was added, under
`apps/tuval/src/ai-agent/service/`:

- `ScriptedTurn.plan` — an optional pure step, `(answers so far) => next call | null`. A step
  rather than a list because an agent picks its second call out of its first one's reply, and a
  fixture naming every call up front could not enumerate a registry it has not read yet.
- `AgentScript.spells` — the `SpellBridgeApi` those calls go through and the `Scope` each carries.
  A script with no plan needs none; a plan with no reach dies with that named.
- `ScriptedAiAgent` runs the plan after the turn's events and records each answer as a `tool` item.

`aiAgentProgram`, the handlers, the core and `TuvalAiAgentApi` are all untouched — the layer's
signature is still `Layer.Layer<TuvalAiAgent>`, so nothing about how a row is built moved.
`SpellBridge`'s service shape is now the named `SpellBridgeApi`, which is the only change under
`commands/`.

Patterns: [`.patterns/tuval-spells.md`](.patterns/tuval-spells.md),
[`.patterns/effect-layer-composition.md`](.patterns/effect-layer-composition.md),
[`.patterns/effect-testing.md`](.patterns/effect-testing.md),
[`.patterns/effect-context-service.md`](.patterns/effect-context-service.md),
[`.patterns/tuval-program-row-effects.md`](.patterns/tuval-program-row-effects.md).
`.patterns/tuval-spells.md` is updated for both: the proof now runs twice, and the bridge section
names how a scripted session reaches it.

## Deviations

- **Out-of-scope change** — **Said:** #7731 names the proof and whatever wiring it needs under
  `apps/tuval/src/ai-agent/`. **Did:** also named `SpellBridge`'s inline service shape as an
  exported `SpellBridgeApi` interface under `commands/bridge/`. **Why:** the script has to hold
  that surface as a value, and there was no name for it; no behaviour changed.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `.patterns/`. **Did:** updated
  `.patterns/tuval-spells.md`. **Why:** the page named the proof as "a scripted program" and the
  bridge as reached only by a future SDK tool, and both read false after this change.
  **Disposition:** stated here.

Closes #7731
