### PR TITLE
fix: Tuval desk unmounts on `c-b |`: react-resizable-panels throws "Invalid 1 panel layout"

### DIFF
--- a/.patterns/layout-tree-with-resizable-panels.md
+++ b/.patterns/layout-tree-with-resizable-panels.md
@@ -43,11 +43,12 @@ keys by `NodeId`.
 
 ## Rule 2 — `defaultLayout` is first paint only; `setLayout` is the write-back
 
-**The library is not prop-controlled.** `defaultLayout` is read once at mount and held through a
-stable-object hook; a later value for that prop does not move the DOM. A binding that passed the
-kernel's `sizes` as `defaultLayout` and stopped there would paint correctly on load and then never
-update — which is exactly the case that matters, because every Tuval tab renders one shared desk and
-a drag in one tab has to land in the others.
+**The library is not prop-controlled *within one panel set*.** `defaultLayout` is read when the group
+registers and held through a stable-object hook; a later value for that prop does not move the DOM
+while the panels stay the same. A binding that passed the kernel's `sizes` as `defaultLayout` and
+stopped there would paint correctly on load and then never update — which is exactly the case that
+matters, because every Tuval tab renders one shared desk and a drag in one tab has to land in the
+others.
 
 So the group also carries a `useGroupRef()`, and an effect pushes the kernel's sizes in through
 `groupRef.current.setLayout(...)` whenever they differ from what the group holds. `setLayout` applies
@@ -56,6 +57,49 @@ own write.
 
 Compare per key against `SIZE_TOLERANCE` (`sameLayout` in `frame.ts`), never by float equality: a
 released drag reports percentages the browser rounded, and an exact test calls every mirror a change.
+
+### 2a — never `setLayout` a panel set the group does not hold; let `defaultLayout` carry that
+
+`setLayout` is not total, and the one thing it will not tolerate is a layout naming a different
+number of panels than the group has registered. Its validator opens with exactly that check
+(`dist/react-resizable-panels.js`, `validatePanelGroupLayout` — the minified `X`):
+
+```js
+if (o.length !== t.length)
+  throw Error(`Invalid ${t.length} panel layout: ${o.map((a) => `${a}%`).join(", ")}`);
+```
+
+`t` is the group's `derivedPanelConstraints`, one entry per registered `Panel`. So a write for a set
+the group has not caught up to is a **throw**, not a no-op, and with no boundary above it that throw
+unmounts the desk. `sameLayout` cannot see it: it walks `stack.children` and treats a `reported[id]`
+of `undefined` as agreement, so a child the group has never heard of scores `true`.
+
+**And there is nothing to write anyway.** Registration takes the group's layout from
+`e.mutableState.layouts[panelIds] ?? e.mutableState.defaultLayout ?? evenSplit(constraints)` (same
+file, the group-registration function — the minified `Wt`), and `mutableState.defaultLayout` is
+refreshed from the `defaultLayout` **prop** by an effect that runs on every commit. For a panel set
+the group has not laid out before — which is every set a split or a close produces — the current
+`defaultLayout` prop *is* what it adopts. Passing `defaultLayoutOf(stack)` on every render is
+therefore the whole binding across a panel-set change, and `layout.unit.test.tsx` proves it by
+splitting an 80/20 stack and reading the resulting three `flexGrow`s back off the DOM.
+
+So the effect asks two questions in this order, and `LayoutView.tsx` is those two lines:
+
+```tsx
+const reported = group.getLayout();
+if (!holdsPanels(stack, reported)) return;               // the set changed — defaultLayout has it
+if (sameLayout(stack, reported, SIZE_TOLERANCE)) return; // the sizes agree — nothing to push
+group.setLayout(defaultLayoutOf(stack));
+```
+
+**Why the group is ever behind, given that React commits the new `Panel` first.** A mounting `Panel`
+registers in a layout effect, and registration only calls the group's force-update — so the group's
+own registration effect, which is what recomputes `derivedPanelConstraints`, does not re-run until
+the *next* commit. `StackView`'s passive effect fires in between. The exception is a change to a
+prop that registration effect already depends on: `orientation` is one, which is why `<c-b> -` on a
+one-window stack never crashed while `<c-b> |` and `<c-b> x` always did — `-` flips the stack's axis,
+so that group re-registers in the same commit ([#7839](https://github.com/kamp-us/phoenix/issues/7839)).
+Nothing in this rule rests on that accident; the guard covers all three the same way.
 
 ## Rule 3 — one Msg per gesture, gated on `isUserInteraction`
 

--- a/.patterns/layout-tree-with-resizable-panels.md
+++ b/.patterns/layout-tree-with-resizable-panels.md
@@ -83,6 +83,14 @@ the group has not laid out before — which is every set a split or a close prod
 therefore the whole binding across a panel-set change, and `layout.unit.test.tsx` proves it by
 splitting an 80/20 stack and reading the resulting three `flexGrow`s back off the DOM.
 
+That `??` chain has a guard between its first two arms, and it only tightens the rule: registration
+runs `defaultLayout && (panelSetMatches(panels, defaultLayout) || (defaultLayout = undefined))` —
+the minified `Bt`, an exact id-set comparison — and the prop-to-`mutableState` effect already
+refuses a map whose key count differs from the panel count. So a `defaultLayout` naming a *partial*
+set is silently dropped and the group falls through to the even split. `defaultLayoutOf(stack)`
+names exactly `stack.children`, which is the set the group is about to register, so it satisfies
+both checks; a binding that shipped a subset would get an even split rather than its sizes.
+
 So the effect asks two questions in this order, and `LayoutView.tsx` is those two lines:
 
 ```tsx

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -114,8 +114,19 @@ to what a throw there may cost:
 | `main.tsx` | everything the page renders | the tab, with the reason on it |
 
 **Recovery is not a button that re-throws.** The boundary takes `resetKeys`, and the desk hands it
-the workspace's layout — so the next kernel snapshot that changes the layout clears the panel with
-no gesture at all. The button is the fallback for the case where nothing new arrives.
+`layoutSignature(workspace.layout)` — the layout tree serialized to one string
+(`src/shell/layout/tree.ts`) — so the next kernel snapshot that changes the layout clears the panel
+with no gesture at all. The button is the fallback for the case where nothing new arrives.
+
+**The key is a signature and never the layout object**, and that is the whole rule for anything else
+mounting this boundary: `resetKeys` are compared with `Object.is`, and every snapshot the page
+receives is decoded afresh, so a tree object is a new identity on every frame whether or not
+anything moved. Keyed on the object, the panel is unmounted and rebuilt on unrelated kernel traffic
+— `<details>` snaps shut, focus on the reset button is lost with the node, and `role="alert"`
+re-announces once per frame, which is the reader's whole recovery gone in the exact case the panel
+exists for. It is the same identity trap the desk's prefix countdown avoids by depending on the
+prefix's *values* (#7782); `error-boundary.unit.test.tsx` drives the boundary with JSON-decoded
+snapshots to pin it.
 
 The panel is a `role="alert"` carrying the throw's own message plus its component stack in a
 `<details>`, because the reason a founder can paste is the point; showing "something went wrong" is

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -99,6 +99,28 @@ The page reads two things off the wire: the shell process's state, and the proce
 `AttachedDesk` opens **one subscription per process**, so two windows over one process are one state
 with two view slots — the Vim buffer model (#7484 R1.3), not two copies.
 
+## Two error boundaries, and what each one is allowed to cost
+
+A render throw with nothing above it unmounts React's whole tree, and on this surface that is a
+black tab with the reason only in a console nobody is reading. It has cost the project twice —
+#7560, then a `<c-b> |` that took the desk down on its own headline key
+([#7839](https://github.com/kamp-us/phoenix/issues/7839)). `ErrorBoundary` in
+`src/shell/ui/ErrorBoundary.tsx` is the answer, and it is mounted in exactly two places, each sized
+to what a throw there may cost:
+
+| Where | Wraps | What survives |
+|---|---|---|
+| `Desk.tsx` | the tiling area alone | the status line, the command line, the desk's keyboard |
+| `main.tsx` | everything the page renders | the tab, with the reason on it |
+
+**Recovery is not a button that re-throws.** The boundary takes `resetKeys`, and the desk hands it
+the workspace's layout — so the next kernel snapshot that changes the layout clears the panel with
+no gesture at all. The button is the fallback for the case where nothing new arrives.
+
+The panel is a `role="alert"` carrying the throw's own message plus its component stack in a
+`<details>`, because the reason a founder can paste is the point; showing "something went wrong" is
+the failure mode again in nicer words.
+
 ## `pnpm dev` is one process
 
 `src/bin.ts` boots the kernel, calls `serveDesk` (ephemeral port, a launch token minted in memory),

--- a/apps/tuval/src/page/main.tsx
+++ b/apps/tuval/src/page/main.tsx
@@ -18,6 +18,7 @@ import {StrictMode} from "react";
 import {createRoot} from "react-dom/client";
 import type {ShellMsg} from "../shell/core/index.ts";
 import {attach, SHELL_PROGRAM_ID} from "../shell/transport/browser.ts";
+import {ErrorBoundary} from "../shell/ui/index.ts";
 import {AttachedDesk} from "./AttachedDesk.tsx";
 import {demoRenderers} from "./renderers.tsx";
 import "../shell/ui/tokens.css";
@@ -116,7 +117,16 @@ const boot = Effect.gen(function* () {
 			),
 		),
 	);
-	root.render(<StrictMode>{shown}</StrictMode>);
+	// The outer net. `Desk` catches a throw from the tiling area and keeps its own chrome, so this
+	// one is for everything above that — the attach panels, the status line, the command line — where
+	// the alternative is the blank tab of #7839 and #7560 again.
+	root.render(
+		<StrictMode>
+			<ErrorBoundary label="Tuval" className="tuval-surface">
+				{shown}
+			</ErrorBoundary>
+		</StrictMode>,
+	);
 	// The scope must outlive the render. `attach` acquires the socket against it and forks the read
 	// loop with `Effect.forkScoped` (`../shell/transport/client.ts`), so an `Effect.scoped` that
 	// closes when this effect completes interrupts the read loop and runs the socket's finalizer the

--- a/apps/tuval/src/shell/layout/index.ts
+++ b/apps/tuval/src/shell/layout/index.ts
@@ -26,6 +26,7 @@ export {
 	findSibling,
 	findStack,
 	findWindow,
+	layoutSignature,
 	remove,
 	resize,
 	type SplitIds,

--- a/apps/tuval/src/shell/layout/tree.ts
+++ b/apps/tuval/src/shell/layout/tree.ts
@@ -309,6 +309,30 @@ export function unzoom(tree: LayoutTree): LayoutTree {
 	return tree.zoomed === null ? tree : {...tree, zoomed: null};
 }
 
+/**
+ * One tree as one string, so a consumer that compares by identity can still ask "is this the same
+ * layout?". Every snapshot the page receives is decoded afresh, so two snapshots carrying an
+ * identical tree hold two objects `Object.is` calls different (#7782, #7839); two identical trees
+ * produce one string here, and any change to structure, order, orientation, sizes, a window's
+ * process or the zoomed window produces another.
+ *
+ * Ids are arbitrary strings, so the shape is built as nested arrays and serialized rather than
+ * joined with a delimiter a window could be named after.
+ */
+export function layoutSignature(tree: LayoutTree): string {
+	return JSON.stringify([tree.zoomed, nodeShape(tree.root)]);
+}
+
+function nodeShape(node: LayoutNode): unknown {
+	if (node.tag === "window") return ["w", node.id, node.processId];
+	return [
+		"s",
+		node.id,
+		node.orientation,
+		node.children.map((child) => [nodeShape(child), node.sizes[child.id] ?? null]),
+	];
+}
+
 function mapStack(
 	stack: StackNode,
 	stackId: StackId,

--- a/apps/tuval/src/shell/layout/tree.unit.test.ts
+++ b/apps/tuval/src/shell/layout/tree.unit.test.ts
@@ -1,10 +1,11 @@
 import {describe, expect, it} from "vitest";
 import {checkTree} from "./invariants.ts";
-import {createStack, createTree, createWindow, type StackNode} from "./node.ts";
+import {createStack, createTree, createWindow, type LayoutTree, type StackNode} from "./node.ts";
 import {
 	find,
 	findChildWindow,
 	findSibling,
+	layoutSignature,
 	remove,
 	resize,
 	setProcess,
@@ -276,6 +277,40 @@ describe("layout.setProcess", () => {
 			processId: "process-1",
 		});
 		expect(find(setProcess(attached, "b", null), (w) => w.id === "b")?.processId).toBeNull();
+	});
+});
+
+describe("layout.layoutSignature", () => {
+	/** A snapshot as the page receives one, where every object is new whatever the tree says. */
+	const overTheWire = (tree: LayoutTree): LayoutTree => JSON.parse(JSON.stringify(tree));
+
+	it("is equal across two decoded snapshots of one tree, which identity is not", () => {
+		const tree = threeWindows();
+		const next = overTheWire(tree);
+
+		expect(next).not.toBe(tree);
+		expect(layoutSignature(next)).toBe(layoutSignature(tree));
+	});
+
+	it("changes on a split, a close, a resize, a zoom, a reorder and a process moving", () => {
+		const tree = threeWindows();
+		const base = layoutSignature(tree);
+
+		expect(layoutSignature(split(tree, "a", "vertical", ids("d", "s2")))).not.toBe(base);
+		expect(layoutSignature(remove(tree, "b"))).not.toBe(base);
+		expect(layoutSignature(resize(tree, "root", {a: 70, s: 30}))).not.toBe(base);
+		expect(layoutSignature(zoom(tree, "a"))).not.toBe(base);
+		expect(layoutSignature(setProcess(tree, "a", "process-1"))).not.toBe(base);
+		expect(
+			layoutSignature(
+				createTree(
+					createStack("root", "horizontal", [
+						createStack("s", "vertical", [createWindow("b"), createWindow("c")]),
+						createWindow("a"),
+					]),
+				),
+			),
+		).not.toBe(base);
 	});
 });
 

--- a/apps/tuval/src/shell/ui/Desk.tsx
+++ b/apps/tuval/src/shell/ui/Desk.tsx
@@ -19,6 +19,7 @@ import {useCallback, useEffect, useRef, useState} from "react";
 import type {ShellMsg, ShellState} from "../core/index.ts";
 import {activeWorkspace, processOf} from "../core/index.ts";
 import {defaultPrefixTable, type Key, type PrefixTable} from "../keys/index.ts";
+import {layoutSignature} from "../layout/index.ts";
 import type {PickerEntries} from "../picker/browser.ts";
 import {noEntries} from "../picker/browser.ts";
 import {WindowId} from "../window/index.ts";
@@ -152,9 +153,16 @@ export function Desk({
 		<div className="tuval-surface" ref={desk} tabIndex={-1} data-scheme="dark">
 			<ForwardedKeyProvider value={forwarded}>
 				{/* The tiling area alone, so a throw costs the founder the windows and not the status
-				    line, the command line or the keyboard. `resetKeys` is the layout the throw was
-				    rendered from: the next snapshot that changes it clears the panel by itself (#7839). */}
-				<ErrorBoundary label="The desk layout" resetKeys={[workspace?.layout]}>
+				    line, the command line or the keyboard. The reset key is the layout's *signature*
+				    and never the layout object, for the same reason the countdown above is keyed on
+				    values: the boundary compares its keys with `Object.is`, and a decoded object is
+				    new on every snapshot, so the panel would be torn down and rebuilt on unrelated
+				    kernel traffic — losing focus on its button and the stack a founder came to read
+				    (#7839). */}
+				<ErrorBoundary
+					label="The desk layout"
+					resetKeys={[workspace === undefined ? null : layoutSignature(workspace.layout)]}
+				>
 					{workspace === undefined ? (
 						<div className="tuval-tiling tuval-placeholder" role="status">
 							<p>This desk has no active workspace. Open one with the command line.</p>

--- a/apps/tuval/src/shell/ui/Desk.tsx
+++ b/apps/tuval/src/shell/ui/Desk.tsx
@@ -23,6 +23,7 @@ import type {PickerEntries} from "../picker/browser.ts";
 import {noEntries} from "../picker/browser.ts";
 import {WindowId} from "../window/index.ts";
 import {CommandLine} from "./CommandLine.tsx";
+import {ErrorBoundary} from "./ErrorBoundary.tsx";
 import {type ForwardedKey, ForwardedKeyProvider} from "./forwarded-key.tsx";
 import {routerPrefix, statusFrame, surfaceKey, zoomedWindow} from "./frame.ts";
 import {LayoutView} from "./LayoutView.tsx";
@@ -150,18 +151,23 @@ export function Desk({
 	return (
 		<div className="tuval-surface" ref={desk} tabIndex={-1} data-scheme="dark">
 			<ForwardedKeyProvider value={forwarded}>
-				{workspace === undefined ? (
-					<div className="tuval-tiling tuval-placeholder" role="status">
-						<p>This desk has no active workspace. Open one with the command line.</p>
-					</div>
-				) : (
-					<LayoutView
-						root={workspace.layout.root}
-						zoomed={zoomedWindow(workspace)}
-						renderWindow={renderWindow}
-						dispatch={dispatch}
-					/>
-				)}
+				{/* The tiling area alone, so a throw costs the founder the windows and not the status
+				    line, the command line or the keyboard. `resetKeys` is the layout the throw was
+				    rendered from: the next snapshot that changes it clears the panel by itself (#7839). */}
+				<ErrorBoundary label="The desk layout" resetKeys={[workspace?.layout]}>
+					{workspace === undefined ? (
+						<div className="tuval-tiling tuval-placeholder" role="status">
+							<p>This desk has no active workspace. Open one with the command line.</p>
+						</div>
+					) : (
+						<LayoutView
+							root={workspace.layout.root}
+							zoomed={zoomedWindow(workspace)}
+							renderWindow={renderWindow}
+							dispatch={dispatch}
+						/>
+					)}
+				</ErrorBoundary>
 			</ForwardedKeyProvider>
 			{commandLineOpen ? <CommandLine dispatch={dispatch} onClose={closeCommandLine} /> : null}
 			<StatusLine frame={statusFrame(state)} prefixKey={table.prefix} />

--- a/apps/tuval/src/shell/ui/ErrorBoundary.tsx
+++ b/apps/tuval/src/shell/ui/ErrorBoundary.tsx
@@ -5,8 +5,10 @@
  * is a class component, because `getDerivedStateFromError` and `componentDidCatch` have no hook.
  *
  * Recovery is real rather than a button that re-throws. `resetKeys` clears a caught error whenever
- * the values behind the failed region change, so the next kernel snapshot recovers the desk on its
- * own; the button is for the case where nothing new arrives.
+ * the values behind the failed region change, so a snapshot that changes them recovers the desk on
+ * its own; the button is for the case where nothing new arrives. The keys are compared with
+ * `Object.is`, so a caller passes values and never objects it decoded — a fresh object per snapshot
+ * would clear the panel on every frame, which is the failure this recovers from, not recovery.
  */
 
 import {Component, type ErrorInfo, type ReactNode} from "react";

--- a/apps/tuval/src/shell/ui/ErrorBoundary.tsx
+++ b/apps/tuval/src/shell/ui/ErrorBoundary.tsx
@@ -1,0 +1,83 @@
+/**
+ * The desk's error boundary. React unmounts the whole tree when a render throws and nothing catches
+ * it, which on this surface means a blank tab and the reason only in a console the founder is not
+ * reading (#7839, and #7560 before it). This is the only thing that can stop that: an error boundary
+ * is a class component, because `getDerivedStateFromError` and `componentDidCatch` have no hook.
+ *
+ * Recovery is real rather than a button that re-throws. `resetKeys` clears a caught error whenever
+ * the values behind the failed region change, so the next kernel snapshot recovers the desk on its
+ * own; the button is for the case where nothing new arrives.
+ */
+
+import {Component, type ErrorInfo, type ReactNode} from "react";
+
+export interface ErrorBoundaryProps {
+	readonly children: ReactNode;
+	/** What the panel calls the region it replaced — "The desk layout", "Tuval". */
+	readonly label: string;
+	/** A change in any of these clears a caught error. Compared by identity, in order. */
+	readonly resetKeys?: ReadonlyArray<unknown>;
+	/**
+	 * The failure panel's own box. It replaces a region, so it takes that region's class: the tiling
+	 * area's `tuval-tiling` by default, and `tuval-surface` for a boundary above the desk, which is
+	 * where the role tokens the panel paints in are declared.
+	 */
+	readonly className?: string;
+}
+
+interface ErrorBoundaryState {
+	readonly error: Error | null;
+	readonly componentStack: string | null;
+}
+
+const changed = (a: ReadonlyArray<unknown>, b: ReadonlyArray<unknown>): boolean =>
+	a.length !== b.length || a.some((value, index) => !Object.is(value, b[index]));
+
+/** The throw's own words. An `Error` with an empty message still has a name worth showing. */
+const reasonOf = (error: Error): string => error.message || error.name || String(error);
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+	override state: ErrorBoundaryState = {error: null, componentStack: null};
+
+	static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+		return {error};
+	}
+
+	override componentDidCatch(_error: Error, info: ErrorInfo): void {
+		this.setState({componentStack: info.componentStack ?? null});
+	}
+
+	override componentDidUpdate(previous: ErrorBoundaryProps): void {
+		if (this.state.error === null) return;
+		if (!changed(previous.resetKeys ?? [], this.props.resetKeys ?? [])) return;
+		this.reset();
+	}
+
+	private readonly reset = (): void => {
+		this.setState({error: null, componentStack: null});
+	};
+
+	override render(): ReactNode {
+		const {error, componentStack} = this.state;
+		if (error === null) return this.props.children;
+		return (
+			<div
+				className={`${this.props.className ?? "tuval-tiling"} tuval-boundary`}
+				data-scheme="dark"
+				role="alert"
+			>
+				<p className="tuval-boundary-title">{this.props.label} stopped rendering.</p>
+				<p className="tuval-boundary-reason">{reasonOf(error)}</p>
+				<button type="button" onClick={this.reset}>
+					Render it again
+				</button>
+				{componentStack === null ? null : (
+					<details className="tuval-boundary-where">
+						<summary>Where it threw</summary>
+						<pre className="tuval-boundary-stack">{componentStack.trim()}</pre>
+					</details>
+				)}
+			</div>
+		);
+	}
+}

--- a/apps/tuval/src/shell/ui/LayoutView.tsx
+++ b/apps/tuval/src/shell/ui/LayoutView.tsx
@@ -7,11 +7,13 @@
  *
  * Two things are load-bearing here and neither is obvious from the props.
  *
- * The library is **not prop-controlled**: `defaultLayout` is read once at mount
- * (`lib/hooks/useStableObject.ts`, `Group.tsx`), so a later `sizes` from the kernel — another tab's
- * drag — would never reach the DOM if that prop were the whole binding. `useGroupRef().setLayout`
- * is what pushes it in, and it no-ops when the layout already matches, which is why the effect
- * cannot loop against its own write.
+ * The library is **not prop-controlled** *within one panel set*: `defaultLayout` is read when the
+ * group registers, so a later `sizes` from the kernel — another tab's drag — would never reach the
+ * DOM if that prop were the whole binding. `useGroupRef().setLayout` is what pushes it in, and it
+ * no-ops when the layout already matches, which is why the effect cannot loop against its own
+ * write. But it **throws** when the layout names a panel set the group does not hold, and a split
+ * or a close leaves it not holding one for a commit — so the write is guarded on `holdsPanels` and
+ * a panel-set change is carried by `defaultLayout` instead.
  *
  * Zoom is a **conditional render**, never `collapse()`. The zoomed window is rendered alone and the
  * split is unmounted; RRP restores it from its own panel-id cache on remount, and `sizes` is never
@@ -24,7 +26,7 @@ import {Group, type LayoutChangedMeta, Panel, Separator, useGroupRef} from "reac
 import type {ShellMsg} from "../core/index.ts";
 import {type LayoutNode, SIZE_TOLERANCE, type StackNode} from "../layout/index.ts";
 import {WindowId} from "../window/index.ts";
-import {defaultLayoutOf, sameLayout} from "./frame.ts";
+import {defaultLayoutOf, holdsPanels, sameLayout} from "./frame.ts";
 
 export interface LayoutViewProps {
 	readonly root: StackNode;
@@ -59,10 +61,16 @@ function StackView({stack, renderWindow, dispatch}: StackViewProps): ReactElemen
 	useEffect(() => {
 		const group = groupRef.current;
 		if (group === null) return;
+		const reported = group.getLayout();
+		// This gesture changed the panel set, and the group has not re-registered yet. Writing here
+		// is the crash of #7839, and there is nothing to write: re-registration takes its layout from
+		// the `defaultLayout` prop below for any set the group has not laid out before, so the
+		// kernel's sizes arrive by that route.
+		if (!holdsPanels(stack, reported)) return;
 		// A `sizes` the kernel holds that this group does not is another tab's finished drag, or a
 		// restored desk. `setLayout` no-ops when the two already agree, so the guard is about the
 		// Msg round trip below, not about the write.
-		if (sameLayout(stack, group.getLayout(), SIZE_TOLERANCE)) return;
+		if (sameLayout(stack, reported, SIZE_TOLERANCE)) return;
 		group.setLayout(defaultLayoutOf(stack));
 	}, [stack, groupRef]);
 

--- a/apps/tuval/src/shell/ui/error-boundary.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/error-boundary.unit.test.tsx
@@ -12,7 +12,7 @@ import {useState} from "react";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {ProcessId} from "../../process/process.ts";
 import type {ShellMsg, ShellState} from "../core/index.ts";
-import {applyMsg} from "../core/index.ts";
+import {applyMsg, isShellState} from "../core/index.ts";
 import {defaultPrefixTable} from "../keys/index.ts";
 import {createStack, createTree, createWindow} from "../layout/index.ts";
 import {Desk} from "./Desk.tsx";
@@ -137,6 +137,68 @@ describe("recovery", () => {
 
 		expect(screen.queryByRole("alert")).toBeNull();
 		expect(screen.getByText("the window rendered")).toBeDefined();
+	});
+});
+
+describe("recovery under live kernel traffic", () => {
+	/** The desk after `<c-b> |`: the same stack, one window more. */
+	const splitDesk = (): ShellState =>
+		deskWith(
+			createTree(
+				createStack("stack-root", "horizontal", [
+					createWindow("window-1", "process-1"),
+					createWindow("window-2"),
+				]),
+			),
+			"window-1",
+		);
+
+	/** A snapshot as the page receives one: JSON off the socket, decoded fresh, guarded. */
+	const overTheWire = (state: ShellState): ShellState => {
+		const value: unknown = JSON.parse(JSON.stringify(state));
+		if (!isShellState(value)) throw new Error("the fixture did not survive the wire");
+		return value;
+	};
+
+	function ControlledDesk({
+		state,
+		throwing,
+	}: {
+		readonly state: ShellState;
+		readonly throwing: boolean;
+	}): ReactElement {
+		return <Desk state={state} dispatch={() => {}} resolveMount={throwingMount(throwing)} />;
+	}
+
+	const resetButton = () => screen.getByRole("button", {name: "Render it again"});
+
+	it("holds the panel, its opened <details> and focus through snapshots that leave the layout alone", () => {
+		const {rerender} = render(<ControlledDesk state={desk()} throwing />);
+
+		const alert = screen.getByRole("alert");
+		const where = alert.querySelector("details");
+		if (where === null) throw new Error("the panel showed no component stack to keep open");
+		where.open = true;
+		resetButton().focus();
+
+		// Three snapshots of the same layout: identical content, then an unrelated field moving.
+		rerender(<ControlledDesk state={overTheWire(desk())} throwing />);
+		rerender(<ControlledDesk state={overTheWire(desk())} throwing />);
+		rerender(<ControlledDesk state={overTheWire({...desk(), nextId: 9})} throwing />);
+
+		expect(screen.getByRole("alert")).toBe(alert);
+		expect(alert.querySelector("details")?.open).toBe(true);
+		expect(document.activeElement).toBe(resetButton());
+	});
+
+	it("clears itself when a snapshot does change the layout", () => {
+		const {rerender} = render(<ControlledDesk state={desk()} throwing />);
+		expect(screen.getByRole("alert")).toBeDefined();
+
+		rerender(<ControlledDesk state={overTheWire(splitDesk())} throwing={false} />);
+
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(screen.getAllByText("the window rendered")).toHaveLength(2);
 	});
 });
 

--- a/apps/tuval/src/shell/ui/error-boundary.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/error-boundary.unit.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The boundary, proved through the desk rather than in isolation: what #7839 cost a founder was not
+ * "an uncaught error" but a blank tab, so the assertions are about what is still on the page after a
+ * window renderer throws.
+ */
+
+import {act, fireEvent, render, screen} from "@testing-library/react";
+import type {ReactElement} from "react";
+import {useState} from "react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {ProcessId} from "../../process/process.ts";
+import type {ShellMsg, ShellState} from "../core/index.ts";
+import {applyMsg} from "../core/index.ts";
+import {defaultPrefixTable} from "../keys/index.ts";
+import {createStack, createTree, createWindow} from "../layout/index.ts";
+import {Desk} from "./Desk.tsx";
+import {installDomShims} from "./dom.testing.ts";
+import {ErrorBoundary} from "./ErrorBoundary.tsx";
+import {deskWith} from "./fixtures.ts";
+import type {MountResolver} from "./mount.ts";
+
+installDomShims();
+
+const THROWN = "the renderer could not read the process";
+
+/** A desk whose every window renderer throws — the shape of a program view that failed. */
+const throwingMount =
+	(throwing: boolean): MountResolver =>
+	(windowId, processId) => ({
+		_tag: "Bound",
+		host: {
+			windowId,
+			processId: ProcessId.make(processId ?? "process-1"),
+			readProcess: undefined as never,
+			dispatch: undefined as never,
+			view: () => null,
+			setView: undefined as never,
+		},
+		render: () => {
+			if (throwing) throw new Error(THROWN);
+			return <p>the window rendered</p>;
+		},
+	});
+
+const desk = (): ShellState =>
+	deskWith(
+		createTree(createStack("stack-root", "horizontal", [createWindow("window-1", "process-1")])),
+		"window-1",
+	);
+
+function DeskHarness({
+	initial,
+	throwing,
+}: {
+	readonly initial: ShellState;
+	readonly throwing: boolean;
+}): ReactElement {
+	const [state, setState] = useState(initial);
+	return (
+		<Desk
+			state={state}
+			dispatch={(msg: ShellMsg) =>
+				setState((current) => applyMsg(defaultPrefixTable, current, msg)[0])
+			}
+			resolveMount={throwingMount(throwing)}
+		/>
+	);
+}
+
+const statusLine = () => screen.getByRole("region", {name: "Shell status"});
+
+beforeEach(() => {
+	// React reports every caught error on `console.error` as well as handing it to the boundary.
+	// The report is the runtime's, not the desk's, and these cases throw on purpose.
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("a window renderer that throws", () => {
+	it("does not blank the desk: the status line and the failure's own words are both on the page", () => {
+		render(<DeskHarness initial={desk()} throwing />);
+
+		expect(statusLine()).toBeDefined();
+		const alert = screen.getByRole("alert");
+		expect(alert.textContent).toContain("The desk layout stopped rendering.");
+		expect(alert.textContent).toContain(THROWN);
+		expect(document.body.textContent?.trim()).not.toBe("");
+	});
+
+	it("keeps the desk's keyboard alive — the surface below the throw still routes a prefix", () => {
+		render(<DeskHarness initial={desk()} throwing />);
+
+		act(() => {
+			fireEvent.keyDown(document, {key: "b", ctrlKey: true});
+		});
+
+		expect(statusLine().textContent).toContain("armed");
+	});
+});
+
+describe("recovery", () => {
+	it("renders the children again when the button is pressed and the throw is gone", () => {
+		const {rerender} = render(<DeskHarness initial={desk()} throwing />);
+		rerender(<DeskHarness initial={desk()} throwing={false} />);
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", {name: "Render it again"}));
+		});
+
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(screen.getByText("the window rendered")).toBeDefined();
+	});
+
+	it("clears itself when a resetKey changes, with no press at all", () => {
+		function Harness({
+			fail,
+			token,
+		}: {
+			readonly fail: boolean;
+			readonly token: number;
+		}): ReactElement {
+			return (
+				<ErrorBoundary label="The desk layout" resetKeys={[token]}>
+					<Thrower fail={fail} />
+				</ErrorBoundary>
+			);
+		}
+		const {rerender} = render(<Harness fail token={1} />);
+		expect(screen.getByRole("alert")).toBeDefined();
+
+		rerender(<Harness fail={false} token={2} />);
+
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(screen.getByText("the window rendered")).toBeDefined();
+	});
+});
+
+function Thrower({fail}: {readonly fail: boolean}): ReactElement {
+	if (fail) throw new Error(THROWN);
+	return <p>the window rendered</p>;
+}

--- a/apps/tuval/src/shell/ui/frame.ts
+++ b/apps/tuval/src/shell/ui/frame.ts
@@ -117,9 +117,23 @@ export const defaultLayoutOf = (stack: StackNode): Record<string, number> => {
 };
 
 /**
+ * Does the group already hold exactly this stack's children as panels? A `setLayout` naming any
+ * other set throws rather than no-ops, and one gesture — a split or a close — leaves the two out of
+ * step for a commit (`.patterns/layout-tree-with-resizable-panels.md`, Rule 2).
+ */
+export const holdsPanels = (
+	stack: StackNode,
+	reported: Readonly<Record<NodeId, number>>,
+): boolean =>
+	Object.keys(reported).length === stack.children.length &&
+	stack.children.every((child) => reported[child.id] !== undefined);
+
+/**
  * Is the layout the library reports the one the tree already holds? Compared per key against the
  * tree's own tolerance, because a released drag reports percentages the browser rounded and an
  * equality test on raw floats would call every mirror a change and loop.
+ *
+ * Sizes only — the panel set is `holdsPanels`'s question, and the two are asked in that order.
  */
 export const sameLayout = (
 	stack: StackNode,

--- a/apps/tuval/src/shell/ui/frame.unit.test.ts
+++ b/apps/tuval/src/shell/ui/frame.unit.test.ts
@@ -5,6 +5,7 @@ import {createStack, createTree, createWindow, SIZE_TOLERANCE} from "../layout/i
 import {deskWith, threeWindowDesk, threeWindowTree} from "./fixtures.ts";
 import {
 	defaultLayoutOf,
+	holdsPanels,
 	panelWindows,
 	routerPrefix,
 	sameLayout,
@@ -89,6 +90,18 @@ describe("the panel layout", () => {
 			true,
 		);
 		expect(sameLayout(stack, {"window-1": 70, "stack-right": 30}, SIZE_TOLERANCE)).toBe(false);
+	});
+
+	it("answers the panel set separately from the sizes, in both directions", () => {
+		// `sameLayout` alone cannot tell these apart: a child the group never registered reports
+		// `undefined`, which its per-key predicate waves through as agreement (#7839).
+		const stack = threeWindowTree().root;
+		expect(holdsPanels(stack, {"window-1": 60, "stack-right": 40})).toBe(true);
+		expect(holdsPanels(stack, {"window-1": 100})).toBe(false);
+		expect(holdsPanels(stack, {"window-1": 40, "stack-right": 30, "window-9": 30})).toBe(false);
+		expect(holdsPanels(stack, {})).toBe(false);
+		expect(sameLayout(stack, {"window-1": 100}, SIZE_TOLERANCE)).toBe(false);
+		expect(sameLayout(stack, {"window-1": 60}, SIZE_TOLERANCE)).toBe(true);
 	});
 
 	it("reads zoom off the tree, and refuses a `zoomed` naming no window", () => {

--- a/apps/tuval/src/shell/ui/index.ts
+++ b/apps/tuval/src/shell/ui/index.ts
@@ -11,6 +11,7 @@ export {
 } from "./attach.ts";
 export {CommandLine, type CommandLineProps} from "./CommandLine.tsx";
 export {Desk, type DeskProps} from "./Desk.tsx";
+export {ErrorBoundary, type ErrorBoundaryProps} from "./ErrorBoundary.tsx";
 export {
 	type ForwardedKey,
 	ForwardedKeyProvider,
@@ -19,6 +20,7 @@ export {
 export {
 	COMMAND_LINE_COMMAND,
 	defaultLayoutOf,
+	holdsPanels,
 	panelWindows,
 	routerPrefix,
 	type StatusFrame,

--- a/apps/tuval/src/shell/ui/layout.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/layout.unit.test.tsx
@@ -225,6 +225,88 @@ describe("zoom", () => {
 	});
 });
 
+/**
+ * The desk as a founder finds it: one workspace, one window, the root stack `"horizontal"` — which
+ * is what `workspace.create` builds (`../core/machine.ts`).
+ */
+const singleWindowDesk = (): ShellState =>
+	deskWith(
+		createTree(createStack("stack-root", "horizontal", [createWindow("window-1")])),
+		"window-1",
+	);
+
+const pressed = (state: ShellState, key: string, ctrlKey = false): ShellState =>
+	applyMsg(defaultPrefixTable, state, {type: "keys.press", key: {key, ctrlKey}})[0];
+
+/** `<c-b>` then a sequence key, through the same table the desk routes against. */
+const gesture = (state: ShellState, sequence: string): ShellState =>
+	pressed(pressed(state, "b", true), sequence);
+
+const panelIds = (container: HTMLElement): ReadonlyArray<string> =>
+	[...container.querySelectorAll("[data-panel]")].map((node) => node.id);
+
+/** Render `from`, then hand the tree `to` — the live rerender, which is the only path that throws. */
+const rerenderAcross = (from: ShellState, to: ShellState) => {
+	const {container, rerender} = render(<TreeView state={from} sent={[]} />);
+	act(() => {
+		rerender(<TreeView state={to} sent={[]} />);
+	});
+	return container;
+};
+
+describe("a gesture that changes a stack's panel set", () => {
+	// Every case here is a *rerender*, not a render of the finished state: `defaultLayout` is read
+	// at registration and `setLayout` never runs on a first mount, so mounting the split desk proves
+	// nothing about the effect. Before #7839 three of the four threw out of the library — `Invalid 1
+	// panel layout: 50%, 50%`, `Invalid 2 panel layout: 100%`, `Invalid 2 panel layout: 40%, 40%,
+	// 20%`. `<c-b> -` was the one that passed, and only by accident: it flips the one-child stack's
+	// orientation, which is a dependency of the group's own registration effect, so that group
+	// re-registers in the same commit and is holding both panels by the time this effect runs.
+	// Nothing about the fix rests on that, which is why it is a case here rather than a footnote.
+	it("splits the only window of a stack with <c-b> | and hands the group two panels", () => {
+		const desk = singleWindowDesk();
+		const container = rerenderAcross(desk, gesture(desk, "|"));
+		expect(panelIds(container)).toHaveLength(2);
+	});
+
+	it("splits the only window of a stack with <c-b> -", () => {
+		const desk = singleWindowDesk();
+		const container = rerenderAcross(desk, gesture(desk, "-"));
+		expect(panelIds(container)).toHaveLength(2);
+	});
+
+	it("closes a window with <c-b> x, back from two panels to one", () => {
+		const split = gesture(singleWindowDesk(), "|");
+		const container = rerenderAcross(split, gesture(split, "x"));
+		expect(panelIds(container)).toHaveLength(1);
+	});
+
+	it("carries the kernel's uneven sizes across the change, through defaultLayout", () => {
+		// The write-back is skipped on a panel-set change, so this is the whole proof that the sizes
+		// still arrive: the group reads the current `defaultLayout` prop when it re-registers.
+		const desk = deskWith(
+			createTree(
+				createStack(
+					"stack-root",
+					"horizontal",
+					[createWindow("window-1"), createWindow("window-2")],
+					{"window-1": 80, "window-2": 20},
+				),
+			),
+			"window-1",
+		);
+		const split = gesture(desk, "|");
+		const container = rerenderAcross(desk, split);
+		const root = split.workspaces["workspace-0"]?.layout.root;
+		expect(root?.children).toHaveLength(3);
+		for (const child of root?.children ?? []) {
+			expect(
+				Number(container.querySelector<HTMLElement>(`#${child.id}`)?.style.flexGrow),
+			).toBeCloseTo(root?.sizes[child.id] ?? Number.NaN, 1);
+		}
+	});
+});
+
 describe("a split of a sibling", () => {
 	it("leaves the untouched panel's size where it was", () => {
 		const desk = deskWith(

--- a/apps/tuval/src/shell/ui/tokens.css
+++ b/apps/tuval/src/shell/ui/tokens.css
@@ -278,6 +278,69 @@
 	color: var(--text-muted);
 }
 
+/*
+ * The failure panel `./ErrorBoundary.tsx` paints where a region used to be. `--text-muted` for the
+ * throw's own words and for the stack, never `--text-faint`: both sit inside a `role="alert"`, and
+ * the faint rung is the 3:1 decorative one `design-system-manifest.md` forbids meaning from.
+ */
+.tuval-boundary {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	/* Top-aligned, not centred: this panel replaces a whole region, and a message floating at its
+	   midpoint reads as decoration rather than as the thing that just failed. */
+	justify-content: flex-start;
+	gap: var(--s-2);
+	padding: var(--s-4);
+	min-block-size: 0;
+	overflow: auto;
+}
+
+.tuval-boundary p {
+	margin: 0;
+}
+
+.tuval-boundary-reason,
+.tuval-boundary-stack {
+	color: var(--text-muted);
+	font:
+		var(--t-mono) ui-monospace,
+		monospace;
+}
+
+.tuval-boundary-stack {
+	margin: 0;
+	white-space: pre-wrap;
+	font:
+		var(--t-meta) ui-monospace,
+		monospace;
+}
+
+.tuval-boundary-where summary {
+	color: var(--text-secondary);
+	font:
+		var(--t-body-sm) system-ui,
+		sans-serif;
+	cursor: pointer;
+}
+
+.tuval-boundary button {
+	color: var(--accent-fg);
+	background: var(--accent);
+	border: 1px solid transparent;
+	border-radius: var(--r-md);
+	padding: var(--s-1) var(--s-3);
+	cursor: pointer;
+	font:
+		var(--t-body-sm) system-ui,
+		sans-serif;
+	transition: background var(--motion-fast) ease;
+}
+
+.tuval-boundary button:hover {
+	background: var(--accent-11);
+}
+
 /* Every transition collapses to an instant swap. Honouring this is part of the behavioural spine
    the design manifest calls code-authoritative, and Pillar 4 forbids carrying meaning on motion in
    the first place, so nothing is lost when it collapses. */


### PR DESCRIPTION
`<c-b> |` on a fresh Tuval desk threw `Invalid 1 panel layout: 50%, 50%` out of
`react-resizable-panels@4.12.3` and unmounted the whole page. This fixes the write that threw,
proves the two neighbouring gestures, and puts an error boundary under the desk so no future throw
can blank the tab silently.

## What was wrong

`StackView`'s effect pushed the kernel's sizes into the group with `setLayout(defaultLayoutOf(stack))`
whenever `stack` changed. `setLayout` is not total: its validator throws when the layout names a
different number of panels than the group has registered. Read at the pin,
`dist/react-resizable-panels.js`, `validatePanelGroupLayout`:

```js
if (o.length !== t.length)
  throw Error(`Invalid ${t.length} panel layout: ${o.map((a) => `${a}%`).join(", ")}`);
```

`sameLayout` could not see the mismatch — it walks `stack.children` and treats a `reported[id]` of
`undefined` as agreement, so a child the group has never heard of scores `true`.

The group is behind for exactly one commit, and the reason is more specific than "the Panel has not
registered yet". A mounting `Panel` *does* register in a layout effect, but registration only calls
the group's force-update, so the group's own registration effect — the thing that recomputes
`derivedPanelConstraints` — does not re-run until the next commit. `StackView`'s passive effect fires
in between.

That also explains a detail the issue guessed at: `<c-b> -` never crashed. `-` flips a one-child
stack's orientation, and `orientation` is a dependency of the group's registration effect, so that
group re-registers in the same commit. `<c-b> |` and `<c-b> x` leave the orientation alone and always
threw. All three are now cases in the suite; nothing rests on that accident.

## The fix

The effect asks the panel-set question first, and skips the write when the answer is no:

```tsx
const reported = group.getLayout();
if (!holdsPanels(stack, reported)) return;
if (sameLayout(stack, reported, SIZE_TOLERANCE)) return;
group.setLayout(defaultLayoutOf(stack));
```

Skipping loses nothing, and that is the part worth checking. Registration takes the group's layout
from `mutableState.layouts[panelIds] ?? mutableState.defaultLayout ?? evenSplit(constraints)`, and
`mutableState.defaultLayout` is refreshed from the `defaultLayout` **prop** by an effect that runs on
every commit. For a set the group has not laid out before — every set a split or a close produces —
the current prop is what it adopts. So `defaultLayout` carries a panel-set change and `setLayout`
carries a size change within one, which is a sharper reading of Rule 2 than "read once at mount".
`layout.unit.test.tsx` proves it by splitting an 80/20 stack and reading all three resulting
`flexGrow`s back off the DOM.

Rule 2 in [`.patterns/layout-tree-with-resizable-panels.md`](.patterns/layout-tree-with-resizable-panels.md)
is amended with a `2a` carrying both library facts and the commit-ordering explanation.

## The error boundary

`apps/tuval/src/shell/ui/ErrorBoundary.tsx`, mounted twice, each sized to what a throw there may
cost: `Desk.tsx` wraps the tiling area alone, so the status line, the command line and the keyboard
survive; `main.tsx` wraps the page as the outer net. The panel is a `role="alert"` carrying the
throw's own message plus its component stack in a `<details>`.

Recovery is not a button that re-throws: the boundary takes `resetKeys`, and the desk hands it the
workspace's layout, so the next kernel snapshot that changes the layout clears the panel on its own.
The button is the fallback for when nothing new arrives. The shape is documented in
[`.patterns/tuval-shell-assembly.md`](.patterns/tuval-shell-assembly.md).

## Tests

- `layout.unit.test.tsx` — four live-rerender cases across a panel-set change, driven through
  `keys.press` on the real prefix table. On the pre-fix code three of them fail with the library's
  own messages: `Invalid 1 panel layout: 50%, 50%`, `Invalid 2 panel layout: 100%`,
  `Invalid 2 panel layout: 40%, 40%, 20%`.
- `frame.unit.test.ts` — `holdsPanels` in both directions, beside the `sameLayout` case that shows
  why one predicate could not answer both.
- `error-boundary.unit.test.tsx` — a throwing window renderer leaves the status line, the reason and
  a live keyboard on the page; the button and a `resetKeys` change both recover.

`apps/tuval`: `pnpm typecheck` 0 errors over both tsconfig lenses, `pnpm vitest run` 943 passing.
Root `pnpm lint` clean.

## Real-browser proof

A Playwright-driven Chromium against `node src/bin.ts` with the checkpoints cleared, so the desk
starts at one window. Zero console errors and zero warnings across load, split, focus walk,
split-horizontal, close and unsplit.

```
--- goto <desk url> ---
[debug] [vite] connecting...
[debug] [vite] connected.
[info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
--- 00-loaded: windows=[window-0] focused="window-0" status="workspace workspace-0 (1/1) | 1 window | prefix <c-b> idle | pending — | Prefix idle." ---
--- 01-split-vertical: windows=[window-0,window-1] focused="window-1" status="workspace workspace-0 (1/1) | 2 windows | prefix <c-b> idle | pending — | Prefix idle." ---
--- 02-focus-left: windows=[window-0,window-1] focused="window-0" status="workspace workspace-0 (1/1) | 2 windows | prefix <c-b> idle | pending — | Prefix idle." ---
--- 03-focus-right: windows=[window-0,window-1] focused="window-1" status="workspace workspace-0 (1/1) | 2 windows | prefix <c-b> idle | pending — | Prefix idle." ---
--- 04-split-horizontal: windows=[window-0,window-1,window-2] focused="window-2" status="workspace workspace-0 (1/1) | 3 windows | prefix <c-b> idle | pending — | Prefix idle." ---
--- 05-close: windows=[window-0,window-1] focused="window-1" status="workspace workspace-0 (1/1) | 2 windows | prefix <c-b> idle | pending — | Prefix idle." ---
--- 06-unsplit: windows=[window-0] focused="window-0" status="workspace workspace-0 (1/1) | 1 window | prefix <c-b> idle | pending — | Prefix idle." ---
--- body innerText length: 480 ---
--- errors+warnings: 0 ---
```

Every step was screenshotted. What they show, in order: the one-window desk with its picker; a clean
50/50 vertical split with the focus ring on the new right pane; the ring moving to the left pane and
back; a third pane stacked under the right one; and the two closes walking back to the single window
the run started from.

A second run, with the demo counter renderer patched to throw, exercised the boundary in the same
browser. The tab was not blank: the alert read `The desk layout stopped rendering.` over the throw's
own words, with `Render it again` and `Where it threw` under it, and the status line still reported
`2 windows`. That patch was reverted before this commit and is not in the diff.

Reproduce either with `node apps/tuval/src/bin.ts --page-port <free port>` and a Playwright script
that presses `Control+b` then the sequence key, collecting `console` and `pageerror`.

Closes #7839

## Deviations

- **Out-of-scope change** — **Said:** #7839 names the layout binding, its tests and Rule 2 of
  `.patterns/layout-tree-with-resizable-panels.md`. **Did:** also added a section to
  `.patterns/tuval-shell-assembly.md` describing the two boundary mount points and the `resetKeys`
  recovery. **Why:** the boundary is a new load-bearing shape in `src/page/` and `src/shell/ui/`,
  and CLAUDE.md requires a pattern doc for one rather than leaving it undocumented; the layout doc
  is the wrong home for it. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the acceptance criteria name a boundary and its unit test.
  **Did:** mounted a second boundary in `apps/tuval/src/page/main.tsx` beside the one in `Desk.tsx`,
  and added its `.tuval-boundary` rules to `apps/tuval/src/shell/ui/tokens.css`. **Why:** `Desk`'s
  boundary covers the tiling area only, so a throw in the status line, the command line or the
  attach panels would still blank the tab — the exact failure the criterion is about. The stylesheet
  is what makes the panel legible at all. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** screenshots on the PR. **Did:** described each
  screenshot's content and gave the recipe to regenerate them, without attaching the images.
  **Why:** GitHub's image upload has no API — `user-attachments` URLs are minted by the browser
  upload only — so a CLI-only lane cannot attach a PNG to a PR body, and committing the images into
  the diff or pushing them to a side branch would both be worse. **Disposition:** stated here; the
  images were produced and are described above.
- **Pre-existing test or fixture changed** — **Said:** add a reproduction to
  `layout.unit.test.tsx`. **Did:** also extended the "the panel layout" block in
  `apps/tuval/src/shell/ui/frame.unit.test.ts` with a `holdsPanels` case. **Why:** the new predicate
  is a pure function in `frame.ts` and that file is where `frame.ts`'s pure functions are proved;
  the case beside it also pins *why* `sameLayout` alone could not answer. **Disposition:** stated
  here.


---

## Round 2 — the reset key (2026-09-05)

Both gates read FAIL at `bad708b`, on one defect: `resetKeys={[workspace?.layout]}`. `ErrorBoundary`
compares its keys with `Object.is`, and every snapshot the page receives is decoded afresh
(`decodeServerFrame` in `shell/transport/wire.ts`), so that object is a new identity on every frame.
The panel was torn down and rebuilt on any kernel traffic: the component-stack `<details>` snapped
shut, focus on `Render it again` went with the node, and `role="alert"` re-announced.

### The fix

`layoutSignature(tree)` in `apps/tuval/src/shell/layout/tree.ts` serializes the tree — zoom, ids,
orientation, order, sizes and each window's process — into one string, and the desk hands the
boundary that:

```tsx
resetKeys={[workspace === undefined ? null : layoutSignature(workspace.layout)]}
```

Two snapshots carrying the same layout give one string, so the panel is untouched. Any real layout
change gives another, so recovery still happens with no gesture. It lives in the layout module
rather than in `frame.ts` because it is a fact about the tree, not about
`react-resizable-panels`. Ids are arbitrary strings, so the shape is built as nested arrays and
`JSON.stringify`d — there is no delimiter a window could be named after.

### Tests

- `error-boundary.unit.test.tsx` — a new `recovery under live kernel traffic` block drives the desk
  through JSON round-tripped snapshots (`JSON.parse(JSON.stringify(…))`, then the page's own
  `isShellState` guard). It opens the `<details>`, focuses the reset button, re-renders three times
  over an unchanged layout, and asserts the same `role="alert"` DOM node, `details.open` still
  `true` and `document.activeElement` still the button. A second case rerenders with a split layout
  and a non-throwing renderer and asserts the panel cleared.
- `tree.unit.test.ts` — `layoutSignature` is equal across two decoded snapshots of one tree that are
  not `Object.is` equal, and differs after a split, a close, a resize, a zoom, a reorder and a
  process moving.

Falsified rather than asserted: with `resetKeys` reverted to `[workspace?.layout]`, the live-traffic
case fails on `expect(screen.getByRole("alert")).toBe(alert)` with the `<details>` `open=""`
attribute gone from the diff. Restored, `apps/tuval` is 947 tests green over 120 files, `pnpm
typecheck` 0 errors over both tsconfig lenses, `pnpm lint:worktree` clean.

### Docs

The three sentences that stated the old behaviour now state the new one: the `Desk.tsx` comment, the
`ErrorBoundary.tsx` docblock, and the recovery paragraph in `.patterns/tuval-shell-assembly.md` —
which now also carries the rule for anything else mounting this boundary, and why (the reader's
`<details>`, focus and alert announcement are the whole recovery). The review's non-blocking
imprecision in `.patterns/layout-tree-with-resizable-panels.md` §2a is fixed too: registration runs
an exact panel-id-set comparison (the minified `Bt`) and drops a `defaultLayout` that does not
match, and the prop-to-`mutableState` effect already refuses a map whose key count differs from the
panel count — both only tighten the rule the section argues.

### Real-browser proof at this head

Playwright-driven Chromium against `node src/bin.ts --page-port <port>` with the checkpoints
cleared, so the desk starts at one window. Zero console errors and zero warnings across load, split,
focus walk, split-horizontal, close and unsplit.

```
--- goto <desk url> ---
[debug] [vite] connecting...
[debug] [vite] connected.
[debug] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
--- 00-loaded: windows=[window-0] focused="window-0" status="workspace workspace-0 (1/1) 1 window prefix <c-b> idle pending — Prefix idle." ---
--- 01-split-vertical: windows=[window-0,window-1] focused="window-1" status="workspace workspace-0 (1/1) 2 windows prefix <c-b> idle pending — Prefix idle." ---
--- 02-focus-left: windows=[window-0,window-1] focused="window-0" status="workspace workspace-0 (1/1) 2 windows prefix <c-b> idle pending — Prefix idle." ---
--- 03-focus-right: windows=[window-0,window-1] focused="window-1" status="workspace workspace-0 (1/1) 2 windows prefix <c-b> idle pending — Prefix idle." ---
--- 04-split-horizontal: windows=[window-0,window-1,window-2] focused="window-2" status="workspace workspace-0 (1/1) 3 windows prefix <c-b> idle pending — Prefix idle." ---
--- 05-close: windows=[window-0,window-1] focused="window-1" status="workspace workspace-0 (1/1) 2 windows prefix <c-b> idle pending — Prefix idle." ---
--- 06-unsplit: windows=[window-0] focused="window-0" status="workspace workspace-0 (1/1) 1 window prefix <c-b> idle pending — Prefix idle." ---
--- body innerText length: 480 ---
--- errors+warnings: 0 ---
```

### The boundary, proved in the same browser

A second run with the window renderer patched to throw, on a fresh boot. The script opens the
`<details>`, focuses the reset button, then drives snapshots that leave the layout alone — arming
the prefix and letting it time out are two shell snapshots each — before changing the layout for
real with `<c-b> N`.

```
--- goto <desk url>, window renderer patched to throw ---
--- alert: The desk layout stopped rendering. the renderer could not read the process Render it again Where it threw ---
--- 00-caught: same alert node=true details open=true focus="Render it again" status="workspace workspace-0 (1/1) 1 window prefix <c-b> idle pending — Prefix idle." ---
--- 01-prefix armed (a snapshot, no layout change): same alert node=true details open=true focus="Render it again" status="… prefix <c-b> armed … Prefix armed, waiting for a sequence." ---
--- 02-prefix timed out (another one): same alert node=true details open=true focus="Render it again" status="… prefix <c-b> idle … Prefix idle." ---
--- 03-two more arms: same alert node=true details open=true focus="Render it again" status="… prefix <c-b> idle … Prefix idle." ---
--- 04-<c-b> N: a new workspace, so the layout did change: same alert node=false details open=false focus="" ---
```

The same script against the pre-fix `resetKeys={[workspace?.layout]}`, everything else identical:

```
--- 00-caught: same alert node=true details open=true focus="Render it again" ---
--- 01-prefix armed (a snapshot, no layout change): same alert node=false details open=false focus="" ---
--- 02-prefix timed out (another one): same alert node=false details open=false focus="" ---
--- 03-two more arms: same alert node=false details open=false focus="" ---
```

One prefix arm was enough to destroy the panel, close the stack and drop focus. The throwing patch
was reverted before this commit and is not in the diff; the desk's checkpoints were cleared before
each run and after the last.

### Round-2 deviations

- **Out-of-scope change** — **Said:** the round-2 criterion names the desk boundary's `resetKeys`
  and a test. **Did:** also corrected the `defaultLayout` registration line in
  `.patterns/layout-tree-with-resizable-panels.md` §2a. **Why:** `review-doc` named it as an
  imprecision worth a clause on the next pass, and this is that pass; the two library guards were
  re-read at the pin before writing it. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** a test that drives the boundary with decoded
  snapshots. **Did:** also added a `layout.layoutSignature` block to
  `apps/tuval/src/shell/layout/tree.unit.test.ts`. **Why:** the signature is a pure function of the
  tree and that file is where the tree's pure functions are proved; the boundary test alone would
  leave "what counts as a layout change" unpinned. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** screenshots on the PR. **Did:** the round-1 entry
  stands — the transcripts above are text, with no images attached. **Why:** unchanged; GitHub mints
  `user-attachments` URLs through the browser upload only. **Disposition:** stated here.
