### PR TITLE
fix: Clicking a Tuval desk window does not focus it; focus moves only through prefix keys

### DIFF
--- a/apps/tuval/src/shell/commands/table.ts
+++ b/apps/tuval/src/shell/commands/table.ts
@@ -21,6 +21,7 @@ import type {ShellMsg} from "../core/machine.ts";
 import type {CommandName} from "../keys/table.ts";
 import type {Direction} from "../layout/index.ts";
 import {type PickerCommand, pickerCommands} from "../picker/intent.ts";
+import {WindowId} from "../window/index.ts";
 import {
 	type AnyShellCommand,
 	commandName,
@@ -102,6 +103,12 @@ export const shellCommands: ReadonlyArray<AnyShellCommand> = [
 	focusRow("right"),
 	focusRow("up"),
 	focusRow("down"),
+	defineCommand({
+		path: ["window", "focus"],
+		describe: "Move focus to the window with this id.",
+		params: Schema.Struct({window: Schema.NonEmptyString}),
+		toMsg: ({window}) => ({type: "window.focus", windowId: WindowId.make(window)}),
+	}),
 	...pickerCommands.map(pickerRow),
 	defineCommand({
 		path: ["workspace", "create"],

--- a/apps/tuval/src/shell/commands/table.unit.test.ts
+++ b/apps/tuval/src/shell/commands/table.unit.test.ts
@@ -27,6 +27,7 @@ describe("the command table", () => {
 			"window:focus-right",
 			"window:focus-up",
 			"window:focus-down",
+			"window:focus",
 			"window:open",
 			"window:attach",
 			"workspace:create",
@@ -86,6 +87,16 @@ describe("each row's Msg", () => {
 		expect(msgOf("window:focus-down")).toEqual({type: "window.focusDirection", direction: "down"});
 	});
 
+	it("focuses a window the caller names by id — the pointer's row, typeable and spell-visible", () => {
+		expect(msgOf("window:focus", {window: "window-2"})).toEqual({
+			type: "window.focus",
+			windowId: "window-2",
+		});
+		// A row with an argument cannot ride a key sequence, so the core leaves the name for a
+		// surface to open the command line over.
+		expect(msgForCommandName(commandName(["window", "focus"]))).toBeNull();
+	});
+
 	it("opens and attaches by naming the thing to show, leaving the spawn to the Cmd", () => {
 		expect(msgOf("window:open", {program: "counter"})).toEqual({
 			type: "window.open",
@@ -128,6 +139,7 @@ describe("resolving a name", () => {
 		expect(resolveVerb("attach")?.path).toEqual(["window", "attach"]);
 		expect(resolveVerb("reload")?.path).toEqual(["config", "reload"]);
 		expect(resolveVerb("create")?.path).toEqual(["workspace", "create"]);
+		expect(resolveVerb("focus")?.path).toEqual(["window", "focus"]);
 	});
 
 	it("resolves nothing for a name no row carries", () => {

--- a/apps/tuval/src/shell/ui/WindowView.tsx
+++ b/apps/tuval/src/shell/ui/WindowView.tsx
@@ -6,6 +6,13 @@
  *
  * The focused marker is carried twice: `data-focused` paints the border, and the `▸` in the title
  * plus `aria-current` say the same thing without colour (`design-system-manifest.md`, Pillar 4).
+ *
+ * A pointer-down here is the mouse's whole route to focus (#7848): it dispatches `window.focus` and
+ * does nothing else — no `preventDefault`, no `focus()` call, no tabindex. That restraint is the
+ * design. The gesture's own default still lands DOM focus wherever it pointed, so a click into a
+ * renderer's composer focuses the window without moving the caret out of it, and the focused
+ * window's picker claims DOM focus off the next snapshot (`./PickerView.tsx`) rather than from a
+ * second focus mechanism racing this one.
  */
 
 import type {ReactElement} from "react";
@@ -50,6 +57,9 @@ export function WindowView({
 	return (
 		<section
 			className="tuval-window"
+			// Already the focused window: the Msg would be a no-op in the core, and sending it anyway
+			// would put a snapshot on the wire for every click a founder makes inside one window.
+			onPointerDown={focused ? undefined : () => dispatch({type: "window.focus", windowId})}
 			data-focused={focused}
 			data-window-id={windowId}
 			aria-label={`Window ${windowId}`}

--- a/apps/tuval/src/shell/ui/desk.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/desk.unit.test.tsx
@@ -159,6 +159,120 @@ describe("the picker's activedescendant", () => {
 	});
 });
 
+/**
+ * A window renderer that reads its own keys, so a click can land inside a text entry the way it
+ * does in a chat composer. `boundEverywhere` renders a paragraph, which focuses nothing.
+ */
+const composerEverywhere: MountResolver = (windowId, processId) =>
+	processId === null
+		? empty
+		: {
+				_tag: "Bound",
+				host: {
+					windowId,
+					processId: ProcessId.make(processId),
+					readProcess: undefined as never,
+					dispatch: undefined as never,
+					view: () => null,
+					setView: undefined as never,
+				},
+				render: (host) => <input aria-label={`composer for ${String(host.processId)}`} />,
+			};
+
+const focusedWindowId = (): string | null => {
+	const marked = screen
+		.getAllByRole("region", {name: /^Window /})
+		.filter((node) => node.getAttribute("data-focused") === "true");
+	expect(marked).toHaveLength(1);
+	return marked[0]?.getAttribute("data-window-id") ?? null;
+};
+
+const focusMsgs = (sent: Array<ShellMsg>): Array<ShellMsg> =>
+	sent.filter((msg) => msg.type === "window.focus");
+
+describe("pointer focus (#7848)", () => {
+	it("focuses the window a pointer goes down on, and hands its renderer DOM focus", () => {
+		const sent: Array<ShellMsg> = [];
+		render(<Harness initial={threeWindowDesk("window-1")} sent={sent} />);
+		expect(focusedWindowId()).toBe("window-1");
+
+		fireEvent.pointerDown(screen.getByLabelText("Window window-2"));
+
+		expect(focusMsgs(sent)).toEqual([{type: "window.focus", windowId: "window-2"}]);
+		expect(focusedWindowId()).toBe("window-2");
+		// window-2 is the empty one, so its picker is the renderer — and desk focus and DOM focus
+		// agree without this handler ever calling `focus()`.
+		expect(document.activeElement).toBe(screen.getByRole("listbox", {name: /Open a program/}));
+	});
+
+	it("sends nothing when the window is already the focused one", () => {
+		const sent: Array<ShellMsg> = [];
+		render(<Harness initial={threeWindowDesk("window-1")} sent={sent} />);
+
+		fireEvent.pointerDown(screen.getByLabelText("Window window-1"));
+
+		expect(focusMsgs(sent)).toEqual([]);
+		expect(focusedWindowId()).toBe("window-1");
+	});
+
+	it("leaves focus alone for a separator press, and for a drag that travels over a window", () => {
+		const sent: Array<ShellMsg> = [];
+		const {container} = render(<Harness initial={threeWindowDesk("window-1")} sent={sent} />);
+		const separator = container.querySelector(".tuval-separator");
+		expect(separator).not.toBeNull();
+
+		// A separator is a sibling of the panels, never a descendant of a window, so the press does
+		// not bubble through one — and a drag fires no second pointerdown wherever it travels.
+		fireEvent.pointerDown(separator as Element);
+		const window2 = screen.getByLabelText("Window window-2");
+		fireEvent.pointerMove(window2);
+		fireEvent.pointerUp(window2);
+
+		expect(focusMsgs(sent)).toEqual([]);
+		expect(focusedWindowId()).toBe("window-1");
+	});
+
+	it("focuses the window a composer sits in without pulling DOM focus off the composer", () => {
+		const sent: Array<ShellMsg> = [];
+		render(
+			<Harness
+				initial={threeWindowDesk("window-1")}
+				sent={sent}
+				resolveMount={composerEverywhere}
+			/>,
+		);
+		const composer = screen.getByLabelText("composer for process-3");
+		// What the gesture's own default does before the desk re-renders: the caret is in the input.
+		composer.focus();
+
+		fireEvent.pointerDown(composer);
+
+		expect(focusMsgs(sent)).toEqual([{type: "window.focus", windowId: "window-3"}]);
+		expect(focusedWindowId()).toBe("window-3");
+		expect(document.activeElement).toBe(composer);
+	});
+
+	it("walks focus by keyboard exactly as before, with the pointer path in place", () => {
+		render(<Harness initial={threeWindowDesk("window-1")} sent={[]} />);
+
+		act(arm);
+		act(() => void fireEvent.keyDown(document, {key: "l", code: "KeyL"}));
+		expect(focusedWindowId()).toBe("window-2");
+
+		act(arm);
+		act(() => void fireEvent.keyDown(document, {key: "j", code: "KeyJ"}));
+		expect(focusedWindowId()).toBe("window-3");
+
+		act(arm);
+		act(() => void fireEvent.keyDown(document, {key: "ArrowUp", code: "ArrowUp"}));
+		expect(focusedWindowId()).toBe("window-2");
+
+		act(arm);
+		act(() => void fireEvent.keyDown(document, {key: "ArrowLeft", code: "ArrowLeft"}));
+		expect(focusedWindowId()).toBe("window-1");
+	});
+});
+
 describe("the single application-level keyboard listener", () => {
 	let added: Array<string>;
 
@@ -181,6 +295,13 @@ describe("the single application-level keyboard listener", () => {
 
 		fireEvent.keyDown(document, {key: "j"});
 		expect(sent).toEqual([{type: "keys.press", key: expect.objectContaining({key: "j"})}]);
+	});
+
+	it("adds none for the pointer path: a pointer handler is not a keyboard listener", () => {
+		render(<Harness initial={threeWindowDesk("window-1")} sent={[]} />);
+		fireEvent.pointerDown(screen.getByLabelText("Window window-2"));
+
+		expect(added.filter((type) => type === "keydown")).toHaveLength(1);
 	});
 
 	it("adds no second listener when the command line opens", () => {

--- a/apps/tuval/src/shell/ui/dom.testing.ts
+++ b/apps/tuval/src/shell/ui/dom.testing.ts
@@ -9,6 +9,13 @@
  * not found for panel index 0"). So the observer here *fires*, once, with the box below; a stub
  * that only records the callback leaves the library permanently unmeasured.
  *
+ * A separator is the one element that does not report that box. The library hit-tests every pointer
+ * event against each separator's measured rect, so a separator measuring the whole viewport claims
+ * every press anywhere on the desk — it flips itself to `data-separator="active"` and takes DOM
+ * focus, which is a lie about a 4px divider and would have hidden the pointer-focus path under a
+ * geometry artifact (#7848). It gets a band instead, away from the origin synthetic pointer events
+ * report; a test that means to press one still targets the element directly.
+ *
  * The `afterEach(cleanup)` is here rather than in a runner setup file because this project keeps
  * Vitest globals off, which is what Testing Library's auto-cleanup needs to fire on its own.
  */
@@ -19,18 +26,28 @@ import {afterEach} from "vitest";
 /** The one box every element reports. Square, so a row and a column both have room to split. */
 export const TEST_VIEWPORT = {width: 1000, height: 1000} as const;
 
-const box = (): DOMRect =>
+const rectAt = (left: number, right: number): DOMRect =>
 	({
-		x: 0,
+		x: left,
 		y: 0,
 		top: 0,
-		left: 0,
-		right: TEST_VIEWPORT.width,
+		left,
+		right,
 		bottom: TEST_VIEWPORT.height,
-		width: TEST_VIEWPORT.width,
+		width: right - left,
 		height: TEST_VIEWPORT.height,
 		toJSON: () => ({}),
 	}) as DOMRect;
+
+const box = (): DOMRect => rectAt(0, TEST_VIEWPORT.width);
+
+/** The separator's band: the painted 4px hairline, mid-viewport. */
+const SEPARATOR_BAND = {left: 500, right: 504} as const;
+
+const measure = (element: Element): DOMRect =>
+	element.getAttribute("role") === "separator"
+		? rectAt(SEPARATOR_BAND.left, SEPARATOR_BAND.right)
+		: box();
 
 class MeasuringResizeObserver implements ResizeObserver {
 	// A field and an assignment rather than a parameter property: `erasableSyntaxOnly` is on
@@ -65,7 +82,9 @@ export const installDomShims = (): void => {
 	const scope = globalThis as Record<string, unknown>;
 	scope.ResizeObserver = MeasuringResizeObserver;
 	scope.PointerEvent ??= globalThis.MouseEvent;
-	Element.prototype.getBoundingClientRect = box;
+	Element.prototype.getBoundingClientRect = function measured(this: Element): DOMRect {
+		return measure(this);
+	};
 	Element.prototype.scrollIntoView ??= function scrollIntoView(): void {};
 	Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
 		configurable: true,


### PR DESCRIPTION
Clicking a Tuval desk window did nothing: the core's `window.focus` Msg has always routed to
`focusWindow`, but nothing dispatched it, so focus moved only through the prefix keys.

Three changes:

- **`WindowView.tsx`** dispatches `window.focus` on `pointerdown`, and does nothing else — no
  `preventDefault`, no `focus()` call, no tabindex. The gesture's own default still lands DOM focus
  wherever it pointed, so a click into a renderer's composer focuses the window without moving the
  caret out of it, and the focused window's picker claims DOM focus off the next snapshot the way it
  already did. Keyboard focus order is untouched (nothing new is tabbable), and the focus ring stays
  the surface's one `:focus-visible` rule. A pointer-down on the already-focused window sends
  nothing, so holding the mouse inside one window puts no snapshots on the wire.
- **`commands/table.ts`** gains a `window:focus <id>` row beside the four directional ones, taking
  the id as a `Schema.NonEmptyString` argument the way `window:open` and `window:attach` take theirs.
  The command line and an agent's `spell describe` can now name a window directly.
- **`ui/dom.testing.ts`** stops reporting the whole viewport as a separator's box. The panel library
  hit-tests every pointer event against each separator's measured rect, so under the old shim a
  separator claimed every press anywhere on the desk — flipping itself to `data-separator="active"`
  and taking DOM focus. That is a lie about a 4px divider, and it would have hidden the pointer path
  under a geometry artifact.

Separators need no special handling: a `Separator` is a sibling of the `Panel`s, never a descendant
of a window, so a press on one does not bubble through a `.tuval-window`, and a drag fires no second
pointerdown wherever it travels. Both are locked by test rather than designed around.

## Browser proof

`node src/bin.ts --page-port 5199` from `apps/tuval`, driven with Playwright over headless Chromium.
Outgoing socket frames are counted in the page, so "no extra dispatch" is measured rather than
inferred.

```
loaded http://127.0.0.1:5199/
windows: [{"id":"window-0","focused":"true","ariaCurrent":"true"}]
status: workspace workspace-0 (1/1)1 windowprefix <c-b> idlepending —Prefix idle.
after <c-b> | — windows: [{"id":"window-0","focused":"false","ariaCurrent":null},{"id":"window-1","focused":"true","ariaCurrent":"true"}]
status: workspace workspace-0 (1/1)2 windowsprefix <c-b> idlepending —Prefix idle.
DOM focus: div[role=listbox] in window-1
focused=window-1 other=window-0
clicked window-0 — windows: [{"id":"window-0","focused":"true","ariaCurrent":"true"},{"id":"window-1","focused":"false","ariaCurrent":null}]
status: workspace workspace-0 (1/1)2 windowsprefix <c-b> idlepending —Prefix idle.
DOM focus: div[role=listbox] in window-0
window.focus messages on the wire: 1
clicked window-0 again — windows: [{"id":"window-0","focused":"true","ariaCurrent":"true"},{"id":"window-1","focused":"false","ariaCurrent":null}]
status: workspace workspace-0 (1/1)2 windowsprefix <c-b> idlepending —Prefix idle.
window.focus messages on the wire: 0
after <c-b> h — windows: [{"id":"window-0","focused":"true","ariaCurrent":"true"},{"id":"window-1","focused":"false","ariaCurrent":null}]
after <c-b> l — windows: [{"id":"window-0","focused":"false","ariaCurrent":null},{"id":"window-1","focused":"true","ariaCurrent":"true"}]
status: workspace workspace-0 (1/1)2 windowsprefix <c-b> idlepending —Prefix idle.
after <c-b> x — windows: [{"id":"window-0","focused":"true","ariaCurrent":"true"}]
status: workspace workspace-0 (1/1)1 windowprefix <c-b> idlepending —Prefix idle.
console:
  debug: [vite] connecting...
  debug: [vite] connected.
  info: %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
```

Reading it: the click moves `data-focused` and `aria-current` to `window-0` and DOM focus with them
(the empty window's picker listbox), on one `window.focus` frame; the second click on that same
window sends zero. `<c-b> h` finds no left neighbour and correctly leaves focus alone, `<c-b> l`
walks it back, and `<c-b> x` closes. The status line names the workspace and the window count, not
the focused window, so it reads unchanged across a focus move — the focus marker is the window's own
`data-focused` / `aria-current` / `▸`. Zero errors and zero warnings: the three console lines are
Vite's dev-server chatter and React's devtools notice, and no request failed (not even a favicon).

Lenses: `pnpm --filter @kampus/tuval typecheck` (both projects, 0 errors) and the tuval suite,
37 files / 360 tests green. The five new tests in `desk.unit.test.tsx` fail on the pre-fix
`WindowView`.

Fixes #7848

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #7848 names `WindowView.tsx`,
  `commands/table.ts` and `desk.unit.test.tsx`. **Did:** also changed `ui/dom.testing.ts` so a
  separator measures a 4px band instead of the whole viewport, and updated
  `commands/table.unit.test.ts`'s exhaustive row list. **Why:** the old shim made the panel library
  hit-test every press as a separator press and steal DOM focus, which made the text-entry criterion
  untestable; and the row list is an exhaustive assertion the new row must appear in.
  **Disposition:** stated here.
