### PR TITLE
fix: Tuval boot demo test times out at 5s when the whole unit suite runs under the pre-push gate

### DIFF
--- a/apps/tuval/src/boot.unit.test.ts
+++ b/apps/tuval/src/boot.unit.test.ts
@@ -30,6 +30,16 @@ interface Run {
 const run = (args: ReadonlyArray<string>, env: NodeJS.ProcessEnv = process.env): Run =>
 	spawnSync(process.execPath, [bin, ...args], {encoding: "utf8", env});
 
+/** How long one `runUntilRunning` waits before it SIGKILLs the child and reports what it captured. */
+const SPAWN_GUARD_MS = 15_000;
+
+/**
+ * A spawning test's vitest budget must outlast every spawn's guard, or vitest kills the test first
+ * and the reader gets a bare `Test timed out` instead of the child's stdout/stderr (#7742). Slack
+ * covers the unspawned work — a `bootDirect`, the temp dirs, the assertions.
+ */
+const spawnBudget = (spawns: number) => spawns * SPAWN_GUARD_MS + 5_000;
+
 /** A boot with live processes stays up until a signal: send SIGINT once it says it is running. */
 const runUntilRunning = (
 	args: ReadonlyArray<string>,
@@ -43,7 +53,7 @@ const runUntilRunning = (
 		const timer = setTimeout(() => {
 			child.kill("SIGKILL");
 			reject(new Error(`bin never said it was running:\n${stdout}\n${stderr}`));
-		}, 15_000);
+		}, SPAWN_GUARD_MS);
 		child.stdout!.setEncoding("utf8").on("data", (chunk: string) => {
 			stdout += chunk;
 			if (!signalled && stdout.includes("tuval: running")) {
@@ -165,53 +175,61 @@ describe("boot", () => {
 		);
 	});
 
-	it("boots the box config: the shell and the two demo processes, the table on the terminal, and all three back after a restart", async () => {
-		const project = freshProject();
-		const args = ["--config", boxConfig, "--project", project];
-		const first = await runUntilRunning(args);
-		expect(first.stderr).toBe("");
-		expect(first.status).toBe(0);
-		expect(first.stdout).toContain(
-			`tuval: booted — 3 program(s), ${BOX_SPELLS} spell(s) registered from ${boxConfig}; 3 process(es) live, 0 restored from ${projectDir(project)}\n`,
-		);
-		expect(first.stdout).toContain(
-			"tuval: process shell program=shell parent=- ports=- state=running@0\n",
-		);
-		expect(first.stdout).toContain(
-			"tuval: process counter program=counter parent=- ports=ticks:out(count/v1) state=running@0\n",
-		);
-		expect(first.stdout).toContain(
-			"tuval: process log program=log parent=counter ports=ticks:in(count/v1) state=running@0\n",
-		);
-		expect(first.stdout).toContain("tuval: running — Ctrl-C stops and checkpoints\n");
-		expect(first.stdout.trimEnd().endsWith("tuval: stopping")).toBe(true);
+	it(
+		"boots the box config: the shell and the two demo processes, the table on the terminal, and all three back after a restart",
+		async () => {
+			const project = freshProject();
+			const args = ["--config", boxConfig, "--project", project];
+			const first = await runUntilRunning(args);
+			expect(first.stderr).toBe("");
+			expect(first.status).toBe(0);
+			expect(first.stdout).toContain(
+				`tuval: booted — 3 program(s), ${BOX_SPELLS} spell(s) registered from ${boxConfig}; 3 process(es) live, 0 restored from ${projectDir(project)}\n`,
+			);
+			expect(first.stdout).toContain(
+				"tuval: process shell program=shell parent=- ports=- state=running@0\n",
+			);
+			expect(first.stdout).toContain(
+				"tuval: process counter program=counter parent=- ports=ticks:out(count/v1) state=running@0\n",
+			);
+			expect(first.stdout).toContain(
+				"tuval: process log program=log parent=counter ports=ticks:in(count/v1) state=running@0\n",
+			);
+			expect(first.stdout).toContain("tuval: running — Ctrl-C stops and checkpoints\n");
+			expect(first.stdout.trimEnd().endsWith("tuval: stopping")).toBe(true);
 
-		const second = await runUntilRunning(args);
-		expect(second.status).toBe(0);
-		expect(second.stdout).toContain(
-			`tuval: booted — 3 program(s), ${BOX_SPELLS} spell(s) registered from ${boxConfig}; 3 process(es) live, 3 restored from ${projectDir(project)}\n`,
-		);
-		expect(second.stdout).toContain("tuval: process log program=log parent=counter");
-	}, 20_000);
+			const second = await runUntilRunning(args);
+			expect(second.status).toBe(0);
+			expect(second.stdout).toContain(
+				`tuval: booted — 3 program(s), ${BOX_SPELLS} spell(s) registered from ${boxConfig}; 3 process(es) live, 3 restored from ${projectDir(project)}\n`,
+			);
+			expect(second.stdout).toContain("tuval: process log program=log parent=counter");
+		},
+		spawnBudget(2),
+	);
 
-	it("restores every checkpointed process from the project's state through Demlik's fileStore", async () => {
-		const project = seededProject("1.0.0");
-		const {report} = await bootDirect(fixture("one-counter"), project);
-		expect(report).toMatchObject({processCount: 1, restoredCount: 1});
-		const result = await runUntilRunning([
-			"--config",
-			fixture("one-counter"),
-			"--project",
-			project,
-		]);
-		expect(result.status).toBe(0);
-		expect(result.stdout).toContain(
-			`tuval: booted — 1 program(s), ${CORE_SPELLS} spell(s) registered from ${fixture("one-counter")}; 1 process(es) live, 1 restored from ${projectDir(project)}\n`,
-		);
-		expect(result.stdout).toContain(
-			"tuval: process p-1 program=counter parent=- ports=- state=running@0\n",
-		);
-	}, 20_000);
+	it(
+		"restores every checkpointed process from the project's state through Demlik's fileStore",
+		async () => {
+			const project = seededProject("1.0.0");
+			const {report} = await bootDirect(fixture("one-counter"), project);
+			expect(report).toMatchObject({processCount: 1, restoredCount: 1});
+			const result = await runUntilRunning([
+				"--config",
+				fixture("one-counter"),
+				"--project",
+				project,
+			]);
+			expect(result.status).toBe(0);
+			expect(result.stdout).toContain(
+				`tuval: booted — 1 program(s), ${CORE_SPELLS} spell(s) registered from ${fixture("one-counter")}; 1 process(es) live, 1 restored from ${projectDir(project)}\n`,
+			);
+			expect(result.stdout).toContain(
+				"tuval: process p-1 program=counter parent=- ports=- state=running@0\n",
+			);
+		},
+		spawnBudget(1),
+	);
 
 	it("refuses to boot on a snapshot under another program version, naming the process and both versions", () => {
 		const project = seededProject("0.9.0");


### PR DESCRIPTION
`apps/tuval/src/boot.unit.test.ts` has a helper, `runUntilRunning`, that spawns the Tuval binary and arms a 15s `setTimeout` to SIGKILL the child and reject with everything it captured — a deliberate, diagnosable failure. Both tests that use it carried a flat `20_000` vitest budget.

That works for the one-spawn test but not the box-config one, which spawns twice. Its second spawn's guard fires at roughly `first-run-duration + 15s`, past the 20s budget, so vitest kills the test first and the reader gets a bare `Test timed out in 20000ms` instead of the child's stdout/stderr — exactly the failure mode #7742 reports (it was 5s at filing time; an unrelated epic commit, 7ebbde6911, has since raised both call sites to 20s without tying them to the guard).

The fix names the guard and derives each budget from it:

- `SPAWN_GUARD_MS = 15_000`, now used by `runUntilRunning` itself instead of a literal.
- `spawnBudget = (spawns) => spawns * SPAWN_GUARD_MS + 5_000`, with the slack covering the unspawned work (a `bootDirect`, temp dirs, assertions).
- The box-config restart test takes `spawnBudget(2)`; the fileStore-restore test takes `spawnBudget(1)`.

The pure, non-spawning tests are untouched and keep the 5s default — no blanket `testTimeout` on the `unit` project. `pnpm --filter @kampus/tuval test:unit` passes: 1003 tests, 122 files, ~8.5s. Biome reflowed the box-config `it(...)` call across lines because the third argument no longer fits, which is most of the diff's line count.

Reviewers: the load-bearing bit is that a test's budget must outlast every spawn's guard, not just one.

Fixes #7742

## Deviations

- **Out-of-scope change** — **Said:** #7742 names the two `it(...)` call sites and `vitest.config.ts` as the places the widened budget may land. **Did:** also replaced the `15_000` literal inside `runUntilRunning` with the new `SPAWN_GUARD_MS` constant. **Why:** the budget is derived from that number, and leaving it duplicated as a literal is how the two drift back apart. **Disposition:** stated here.
