### PR TITLE
fix: Tuval's fuzzy completion score is greedy, and its prefix rule is case-sensitive while the fuzzy one is not

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -314,6 +314,16 @@ token under the caret. Two rules, and they never mix:
    workspace names off the snapshot. The caret's characters must appear in order; the tighter and
    earlier the run, the higher the rank. `scr` reaches `scratch`.
 
+**Both rules ignore case** (#7757). One `fold` in the module lowercases each side for the prefix
+filter and the subsequence scorer alike, so `W` offers exactly what `w` offers at a segment, a
+literal, a program id and a window id. Rule 1's "recall, don't search" argument is about the matching
+rule, not about capitalization.
+
+**The fuzzy rank is over the tightest run in the value, not the first run found** (#7757). The scorer
+tries every start the query's first character reaches and keeps the lowest
+`(span * 1000) + first` — `a-xb-ab` matches `ab` scattered at 0-3 and contiguous at 5-6, and it is
+ranked by 5-6.
+
 Which live set a parameter draws from is decided by its own name: a parameter named for a window, a
 process, a program or a workspace offers that set, and one named for none of them offers no live
 values.

--- a/apps/tuval/src/commands/parse/complete.ts
+++ b/apps/tuval/src/commands/parse/complete.ts
@@ -9,6 +9,13 @@
  *    workspace names the snapshot carries. The caret's characters must appear in order; the tighter
  *    and earlier the run, the higher the rank. `scr` reaches `scratch`.
  *
+ * Both rules ignore case, through the one `fold` below (#7757). `W` offers exactly what `w` offers,
+ * at a segment and at a window alike: the recall-don't-search argument behind rule 1 is about the
+ * matching rule, not about capitalization, and a capitalized id offering nothing reads as broken.
+ *
+ * The fuzzy rank is over the *tightest* run in the value, not the first one found. `a-xb-ab` matches
+ * `ab` at 0-3 and again at 5-6, and the run it is ranked by is 5-6.
+ *
  * A fuzzy tie breaks on recency, most recent first (#7617 R1.5): every window and process row on the
  * snapshot carries the kernel's `recency` stamp, so two equally tight matches are ordered by which
  * one was focused or spawned last. Values with no stamp of their own — a workspace name, a
@@ -91,30 +98,42 @@ const liveValues = (param: ParamSpec, snapshot: Snapshot): LiveSet => {
 	return EMPTY;
 };
 
-/** How tightly `query` sits inside `value` as a subsequence: `undefined` when it does not. */
-const subsequenceScore = (value: string, query: string): number | undefined => {
+/** The one case rule both matchers apply. */
+const fold = (text: string): string => text.toLowerCase();
+
+/**
+ * How tightly `query` sits inside `value` as a subsequence: `undefined` when it does not.
+ *
+ * Exported for the ranking tests, which pin the score of a named value against the run they name.
+ */
+export const subsequenceScore = (value: string, query: string): number | undefined => {
 	if (query === "") return 0;
-	const haystack = value.toLowerCase();
-	const needle = query.toLowerCase();
-	let first = -1;
-	let cursor = 0;
-	for (let index = 0; index < haystack.length && cursor < needle.length; index += 1) {
-		if (haystack[index] !== needle[cursor]) continue;
-		if (first < 0) first = index;
-		cursor += 1;
-		if (cursor === needle.length) {
-			// Earlier beats later, and a tight run beats a scattered one; the span dominates so a
-			// contiguous match late in a name still outranks a scattered one near its front.
-			return (index - first) * 1000 + first;
+	const haystack = fold(value);
+	const needle = fold(query);
+	let best: number | undefined;
+	for (let start = 0; start < haystack.length; start += 1) {
+		if (haystack[start] !== needle[0]) continue;
+		let cursor = 1;
+		let index = start + 1;
+		for (; index < haystack.length && cursor < needle.length; index += 1) {
+			if (haystack[index] === needle[cursor]) cursor += 1;
 		}
+		// A start that cannot complete leaves every later start less room, so none can either.
+		if (cursor < needle.length) break;
+		// Earlier beats later, and a tight run beats a scattered one; the span dominates so a
+		// contiguous match late in a name still outranks a scattered one near its front.
+		const score = (index - 1 - start) * 1000 + start;
+		if (best === undefined || score < best) best = score;
 	}
-	return undefined;
+	return best;
 };
 
-const byPrefix = (values: ReadonlyArray<Ranked>, query: string): ReadonlyArray<Candidate> =>
-	values
-		.filter((ranked) => ranked.candidate.value.startsWith(query))
+const byPrefix = (values: ReadonlyArray<Ranked>, query: string): ReadonlyArray<Candidate> => {
+	const needle = fold(query);
+	return values
+		.filter((ranked) => fold(ranked.candidate.value).startsWith(needle))
 		.map((ranked) => ranked.candidate);
+};
 
 const byFuzz = (values: ReadonlyArray<Ranked>, query: string): ReadonlyArray<Candidate> =>
 	values

--- a/apps/tuval/src/commands/parse/complete.unit.test.ts
+++ b/apps/tuval/src/commands/parse/complete.unit.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {complete} from "./complete.ts";
+import {complete, subsequenceScore} from "./complete.ts";
 import {registry, snapshot} from "./fixtures.ts";
 
 const values = (input: string) => complete(input, registry, snapshot).map((c) => c.value);
@@ -63,6 +63,30 @@ describe("complete — fuzzy subsequence over user-named values", () => {
 
 	it("offers nothing for a parameter that names no live set", () => {
 		expect(values("workspace rename ws-2 ")).toEqual([]);
+	});
+
+	it("scores the tightest run in the value, not the first run it finds (#7757)", () => {
+		// `ab` sits in `a-xb-ab` twice: scattered at 0-3, contiguous at 5-6. The greedy walk locked
+		// on the first `a` and answered 3000; the tightest run is 5-6.
+		expect(subsequenceScore("a-xb-ab", "ab")).toBe(1005);
+	});
+
+	it("ranks a tight run behind a looser earlier one ahead of an only-looser value (#7757)", () => {
+		// `a-b` matches at 0-2 and nowhere tighter, so it trails `a-xb-ab`'s contiguous run.
+		expect(values("workspace activate ab")).toEqual(["a-xb-ab", "a-b"]);
+	});
+});
+
+describe("complete — one case rule over both matchers (#7757)", () => {
+	it("matches a prefix-ranked kind regardless of case", () => {
+		expect(values("W")).toEqual(values("w"));
+		expect(values("window move L")).toEqual(["left"]);
+		expect(values("process spawn C")).toEqual(["counter"]);
+	});
+
+	it("matches a fuzzy-ranked kind regardless of case", () => {
+		expect(values("workspace activate SCR")).toEqual(values("workspace activate scr"));
+		expect(values("workspace activate SCR")).toEqual(["scratch", "super-carrier"]);
 	});
 });
 

--- a/apps/tuval/src/commands/parse/fixtures.ts
+++ b/apps/tuval/src/commands/parse/fixtures.ts
@@ -61,6 +61,8 @@ export const registry: SpellIndex = buildSpellIndex(descriptions);
 const carrier = WorkspaceId.make("ws-1");
 const scratch = WorkspaceId.make("ws-2");
 const main = WorkspaceId.make("ws-3");
+const tightLate = WorkspaceId.make("ws-4");
+const looseEarly = WorkspaceId.make("ws-5");
 export const leftWindow = WindowId.make("w-left");
 export const rightWindow = WindowId.make("w-right");
 export const counterProcess = ProcessId.make("p-counter");
@@ -93,6 +95,11 @@ export const snapshot = new Snapshot({
 			[carrier]: workspace(carrier, "super-carrier"),
 			[scratch]: workspace(scratch, "scratch"),
 			[main]: workspace(main, "main"),
+			// The greedy-scorer case of #7757, verbatim: `a-xb-ab` holds `ab` scattered at 0-3 and
+			// contiguous at 5-6, and `a-b` holds one looser run. Ranked by the tightest run,
+			// `a-xb-ab` (1005) comes first; ranked by the first run found, `a-b` (2000) would.
+			[tightLate]: workspace(tightLate, "a-xb-ab"),
+			[looseEarly]: workspace(looseEarly, "a-b"),
 		},
 		activeWorkspace: main,
 	},


### PR DESCRIPTION
Fixes #7757

Tuval's completion scorer walked the value once and locked onto the first character match it found,
so it ranked a scattered early run instead of the tightest run in the value. For `a-xb-ab` and the
query `ab` it answered `3000` (the run at 0-3) when the contiguous run at 5-6 scores `1005`. The
scorer now tries every start the query's first character reaches and keeps the lowest
`(span * 1000) + first`.

The two matchers also disagreed on case: `subsequenceScore` lowercased both sides while `byPrefix`
used raw `startsWith`, so `W` offered every window but nothing at a segment, a program id or an enum
literal. Both now fold through one `fold` helper, which is the rule triage read as the right one —
"recall, don't search" is an argument about fuzzy-vs-prefix, not about capitalization. The rule is
stated in `complete.ts`'s module docblock and in `.patterns/tuval-spells.md` under "Completion".

The fixture snapshot gains two workspaces, `a-xb-ab` and `a-b`, which carry the issue's case through
the public `complete` entry point. Neither matches any query the existing cases use, and all 48
parse tests pass unchanged.

## Deviations

- **Out-of-scope change** — **Said:** #7757 names the two defects and the tests that pin them.
  **Did:** also exported `subsequenceScore`, which was module-private. **Why:** the first acceptance
  criterion is about the score the function returns (`1005`, not `3000`) for a value it names, and
  an ordering assertion through `complete` proves only that the score fell in a band, not that it is
  that number. **Disposition:** stated here; the export carries a line saying the tests are its
  reason, and the ordering case through `complete` is there too, so the criterion is covered both
  ways if a reviewer would rather the export came back out.
