### PR TITLE
fix: Tuval's process send reports delivered for a dropped payload, and a died spawn leaves a live process unregistered

### DIFF
--- a/apps/tuval/src/commands/core/process.ts
+++ b/apps/tuval/src/commands/core/process.ts
@@ -193,32 +193,38 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 				),
 			);
 
-		const inboxes = new Map<string, Inbox>();
-		for (const [name, port] of Object.entries(row.ports)) {
-			if (port.direction !== "in") continue;
-			const receive = row.receive?.[name] as Receiver<Message> | undefined;
-			if (receive === undefined) {
-				// `launch` refuses this at boot with `NoReceiver`; there is no boot to refuse here, and a
-				// caller cannot act on another program's authoring bug — so it dies, as the executor dies
-				// on a spell whose value its own `result` schema refuses.
-				return yield* Effect.die(
-					`program "${row.id}" declares in-port "${name}" but no receiver for it`,
-				);
+		// The kernel process is running from here on, under a scope forked from the layer root or the
+		// parent's — nothing ties it to this effect, so a failure below would leave it holding its
+		// ports with no entry in `live` for `entryOf` to find. `onError` catches a defect as well as
+		// a failure, which is what the no-receiver die below is (#7761).
+		yield* Effect.gen(function* () {
+			const inboxes = new Map<string, Inbox>();
+			for (const [name, port] of Object.entries(row.ports)) {
+				if (port.direction !== "in") continue;
+				const receive = row.receive?.[name] as Receiver<Message> | undefined;
+				if (receive === undefined) {
+					// `launch` refuses this at boot with `NoReceiver`; there is no boot to refuse here, and a
+					// caller cannot act on another program's authoring bug — so it dies, as the executor dies
+					// on a spell whose value its own `result` schema refuses.
+					return yield* Effect.die(
+						`program "${row.id}" declares in-port "${name}" but no receiver for it`,
+					);
+				}
+				const queue = yield* Queue.make<unknown>({
+					capacity: port.bound.capacity,
+					strategy: port.bound.overflow,
+				});
+				yield* Scope.addFinalizer(handle.scope, Effect.asVoid(Queue.shutdown(queue)));
+				yield* pump(handle, queue, receive);
+				inboxes.set(name, {port, queue});
 			}
-			const queue = yield* Queue.make<unknown>({
-				capacity: port.bound.capacity,
-				strategy: port.bound.overflow,
-			});
-			yield* Scope.addFinalizer(handle.scope, Effect.asVoid(Queue.shutdown(queue)));
-			yield* pump(handle, queue, receive);
-			inboxes.set(name, {port, queue});
-		}
 
-		live.set(id, {handle, inboxes, outboxes});
-		yield* Scope.addFinalizer(
-			handle.scope,
-			Effect.sync(() => void live.delete(id)),
-		);
+			live.set(id, {handle, inboxes, outboxes});
+			yield* Scope.addFinalizer(
+				handle.scope,
+				Effect.sync(() => void live.delete(id)),
+			);
+		}).pipe(Effect.onError(() => handle.stop));
 		return id;
 	});
 
@@ -256,7 +262,15 @@ export class SpawnedProcesses extends Context.Service<
 			program: ProgramId,
 			parent: Option.Option<ProcessId>,
 		) => Effect.Effect<ProcessId, UnknownProgram | UnknownProcess | OpenError | HandlerFailed>;
-		/** `false` only under a `dropping` in-port bound: the queue was full and refused the payload. */
+		/**
+		 * `Queue.offer`'s own answer, and it covers less than a reader expects. `false` is one of two
+		 * things: a `dropping` in-port at capacity refusing the payload, or a queue that is no longer
+		 * open — the process stopped and the finalizer shut its in-port queues down. `true` is not
+		 * "nothing was lost": a `sliding` bound at capacity takes the oldest queued payload off,
+		 * appends this one and answers `true`, so a payload is dropped and no caller can learn it
+		 * (`Queue.offer` at the `effect@4.0.0-rc.112` pin). Whether `process send` should surface that
+		 * eviction is an open contract question (#7761).
+		 */
 		readonly send: (
 			process: ProcessId,
 			port: string,

--- a/apps/tuval/src/commands/core/process.unit.test.ts
+++ b/apps/tuval/src/commands/core/process.unit.test.ts
@@ -8,7 +8,7 @@ import {readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
 import {defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
-import {Context, Effect, Fiber, Layer, Option} from "effect";
+import {Context, Effect, Exit, Fiber, Layer, Option} from "effect";
 import {TestClock} from "effect/testing";
 import {counterId, counterProgram} from "../../demo/counter.ts";
 import {logId, logProgram} from "../../demo/log.ts";
@@ -89,6 +89,22 @@ const echoProgram = (): AnyProgram =>
 		ProcessPorts
 	>;
 
+const deafId = ProgramId.make("deaf");
+
+/**
+ * `echo` with its receiver taken away: an in-port nothing translates for. `launch` refuses that
+ * shape at boot with `NoReceiver`, and `process spawn` has no boot to refuse at — so its wiring
+ * loop dies with the kernel process already running.
+ */
+const deafProgram = (): AnyProgram => {
+	const {receive: _unwired, ...rest} = echoProgram();
+	return {
+		...rest,
+		id: deafId,
+		identity: {...rest.identity, program: "deaf", digest: "sha256:deaf"},
+	};
+};
+
 const workspace = WorkspaceId.make("ws-1");
 const agentWindow = WindowId.make("w-1");
 const caller = ProcessId.make("p-1");
@@ -103,6 +119,7 @@ const rows: ReadonlyArray<AnyProgram> = [
 	counterProgram({everyMs: null}),
 	logProgram({write: () => Effect.void}),
 	echoProgram(),
+	deafProgram(),
 ];
 
 const kernel = SpawnedProcesses.layer({readTimeout: "1 second"}).pipe(
@@ -276,6 +293,23 @@ describe("the process spells", () => {
 				yield* invoke(["process", "send"], {process: caller, port: "ticks", payload: 1}),
 			);
 			assert.strictEqual(error?.tag, "tuval/commands/UnknownProcess");
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("a spawn that dies wiring an unwired in-port leaves no process running", () =>
+		Effect.gen(function* () {
+			yield* startCaller;
+			const spawned = yield* SpawnedProcesses;
+			const table = yield* ProcessTable;
+
+			// Through the service, not the spell: the die is a defect, and the executor lets it through.
+			const exit = yield* Effect.exit(spawned.spawn(deafId, Option.some(caller)));
+			assert.isTrue(Exit.hasDies(exit), `expected a die, got ${JSON.stringify(exit)}`);
+
+			// The kernel process the loop died halfway through is stopped, not orphaned holding its
+			// ports with nothing able to address it — the table has no row of that program left.
+			const orphans = (yield* table.list).filter((row) => row.programId === deafId);
+			assert.deepStrictEqual(orphans, []);
 		}).pipe(Effect.provide(app)),
 	);
 


### PR DESCRIPTION
`SpawnedProcesses.spawn` started the kernel process, then wired its in-ports — and the wiring loop
could die partway, on a program that declares an in-port with no receiver. `live.set` sat below the
loop, so it never ran, while the kernel process kept running under a scope forked from the layer
root: it held its ports and its scope, and `send`/`read` answered `UnknownProcess` for it because
`entryOf` reads the map the entry never reached.

The wiring loop plus the registration now run under `Effect.onError(() => handle.stop)`. `onError`
filters any failing cause, defects included (`onExitFilter(self, exitFilterCause, …)` in
`effect/src/internal/effect.ts` at the `4.0.0-rc.112` pin apps/tuval sits on), so the no-receiver
die closes the process's scope on its way out. `Processes.spawn` already uses the same idiom one
layer down. After the die the process is stopped, not addressable-but-unknown.

The `send` docblock said `false` was "only under a `dropping` in-port bound". Read against
`Queue.offer` at rc.112: a queue whose state is not `Open` also answers `false`, and a `sliding`
bound at capacity takes the oldest queued payload off, appends the new one and answers `true`. So
`true` was never "nothing was lost". The docblock now states both, and points at #7761 for the open
question of whether `process send` should surface an eviction — the spell's `{delivered}` result
schema is untouched.

The new test spawns a receiver-less program through the service (the spell path would let the defect
through and take the test with it), asserts the exit dies, and asserts the process table holds no row
of that program. It fails against the pre-fix code with the orphan row still listed.

## Deviations

- **Declined guidance** — **Said:** the third acceptance criterion asks the docblock to state what
  `false` covers "at the `effect@4.0.0-beta.92` pin". **Did:** wrote `effect@4.0.0-rc.112`.
  **Why:** apps/tuval is on `catalog:tuval`, which pins `4.0.0-rc.112` (`pnpm-workspace.yaml`), so
  beta.92 is not the pin this code runs against; the semantics the criterion describes were read off
  `apps/tuval/node_modules/effect/src/Queue.ts` at rc.112 and hold there. **Disposition:** stated
  here; the docblock cites the version the code actually resolves.

Fixes #7761
