### PR TITLE
fix: Tuval's executor flattens an untagged spell failure onto a tag that names nothing

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -21,7 +21,7 @@ moved.
 | [`spell-set.ts`](../apps/tuval/src/commands/spell-set.ts) | `SpellSet`: the table and the key bindings compiled against it, in one cell |
 | [`scope.ts`](../apps/tuval/src/commands/scope.ts) | `WindowIndex`, `WindowPlacement`, `Client`, `resolveScope` |
 | [`executor.ts`](../apps/tuval/src/commands/executor.ts) | `SpellExecutor`: one `SpellCall` in, one `SpellReply` out |
-| [`errors.ts`](../apps/tuval/src/commands/errors.ts) | `DuplicateSpellPath`, `SpellNotDescribable`, `SpellNotFound`, `NoSuchWindow`, `UnknownSpell`, `BadArgs`, `BadResult` |
+| [`errors.ts`](../apps/tuval/src/commands/errors.ts) | `DuplicateSpellPath`, `SpellNotDescribable`, `SpellNotFound`, `NoSuchWindow`, `UnknownSpell`, `BadArgs`, `BadResult`, `SpellFailed` |
 | [`index.ts`](../apps/tuval/src/commands/index.ts) | a partial barrel: `bindings/`, `errors`, `executor`, `parse/`, `registry`, `scope` and `spell`, but not `core/` or `bridge/`, which are imported from their own directories |
 | [`parse/tokenize.ts`](../apps/tuval/src/commands/parse/tokenize.ts) | the command line's lexer |
 | [`parse/reading.ts`](../apps/tuval/src/commands/parse/reading.ts) | the single walk `parse` and `complete` share |
@@ -170,11 +170,17 @@ The steps are lookup, decode the args, resolve the scope, run, encode the result
 | no spell at the path | `UnknownSpell`, carrying the nearest registered path when one is near enough. The measure is Levenshtein and the budget is `Math.max(1, Math.ceil(path.length / 3))`, so a short path still tolerates one edit |
 | `params` refuses the args | `BadArgs`, carrying the offending argument and what was expected |
 | the window is unknown | `NoSuchWindow` |
-| the spell's own error | a failure whose `tag` and `message` come off the error |
+| the spell's own tagged error | a failure whose `tag` and `message` come off the error |
+| the spell's own untagged failure (a bare string, a plain record, a thrown value) | `SpellFailed`, carrying the value on `original` and rendering it into the message; the executor also logs it through `Effect.logError` |
 | `result` refuses the return value | `BadResult`, and the fiber **dies**; that is the spell author's bug, not the caller's |
 
 A failure's `path` is always the call's own, so a spell's private error cannot claim a different
 one.
+
+Every `tag` a reply can carry is read off an error object's `_tag`, never composed as a literal:
+`AnySpell` erases the spell's error type, so a failure with no `_tag` is wrapped in `SpellFailed`
+before the reply is built. That is what keeps a page's `switch` on `tag` matching names that
+resolve to a declared class.
 
 `AnySpell` erases each spell's requirements, so nothing checks that the runtime carries what a
 registered spell needs. The composition root that builds the registry owes those services.

--- a/apps/tuval/src/commands/errors.ts
+++ b/apps/tuval/src/commands/errors.ts
@@ -1,4 +1,5 @@
 import {Schema} from "effect";
+import {stringifyJson} from "../protocol/json.ts";
 
 export class DuplicateSpellPath extends Schema.TaggedError<DuplicateSpellPath>()(
 	"tuval/commands/DuplicateSpellPath",
@@ -83,5 +84,29 @@ export class BadResult extends Schema.TaggedError<BadResult>()("tuval/commands/B
 }) {
 	override get message(): string {
 		return `spell "${this.path}" returned a result its own schema refuses: ${this.reason}`;
+	}
+}
+
+/** An untagged failure value as one phrase, so a reply says more than its tag repeated back. */
+const describeValue = (value: unknown): string => {
+	if (typeof value === "string") return value.length === 0 ? "an empty string" : `"${value}"`;
+	if (value instanceof Error && value.message.length > 0) return value.message;
+	// A spell fails with whatever it likes, so a cycle or a BigInt reaches this; `stringifyJson` is
+	// the boundary that survives one.
+	const json = stringifyJson(value);
+	return json._tag === "Stringified" ? json.text : `an unprintable ${typeof value}`;
+};
+
+/**
+ * A spell failed with a value carrying no `_tag`, so it names no error class of its own. The reply
+ * then carries this class's tag instead of a literal the executor invented, and the value rides
+ * `original` rather than being dropped on the way out.
+ */
+export class SpellFailed extends Schema.TaggedError<SpellFailed>()("tuval/commands/SpellFailed", {
+	path: Schema.String,
+	original: Schema.Unknown,
+}) {
+	override get message(): string {
+		return `spell "${this.path}" failed with ${describeValue(this.original)}`;
 	}
 }

--- a/apps/tuval/src/commands/executor.ts
+++ b/apps/tuval/src/commands/executor.ts
@@ -20,7 +20,7 @@ import {
 	SpellReplyError,
 	SpellReplyOk,
 } from "../protocol/messages.ts";
-import {BadArgs, BadResult, UnknownSpell} from "./errors.ts";
+import {BadArgs, BadResult, SpellFailed, UnknownSpell} from "./errors.ts";
 import {SpellRegistry, type SpellRow} from "./registry.ts";
 import {type Client, resolveScope, WindowIndex} from "./scope.ts";
 import {renderPath, type Scope, type SpellPath} from "./spell.ts";
@@ -55,26 +55,33 @@ const nearestPath = (target: string, rows: ReadonlyArray<SpellRow>): string | un
 	return best?.path;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null;
+/** An error that names itself: a `_tag` to discriminate on, and whatever it renders as. */
+type NamedError = {readonly _tag: string; readonly message?: unknown};
 
-const tagOf = (error: unknown): string =>
-	isRecord(error) && typeof error._tag === "string" ? error._tag : "tuval/commands/SpellFailed";
+const isNamed = (value: unknown): value is NamedError =>
+	typeof value === "object" && value !== null && typeof (value as NamedError)._tag === "string";
 
-const messageOf = (error: unknown, tag: string): string => {
-	const message = isRecord(error) ? error.message : undefined;
-	return typeof message === "string" && message.length > 0
-		? message
-		: `the call failed with ${tag}`;
-};
+/**
+ * The caught value as an error that names itself. One already carrying a `_tag` is its own;
+ * anything else becomes `SpellFailed`, a class `errors.ts` declares, so the only source of a
+ * reply's tag is an error object and no reply can carry a tag naming nothing in the tree.
+ */
+const named = (call: SpellCall, error: unknown): NamedError =>
+	isNamed(error)
+		? error
+		: new SpellFailed({path: renderPath(call.path as SpellPath), original: error});
+
+const messageOf = (error: NamedError): string =>
+	typeof error.message === "string" && error.message.length > 0
+		? error.message
+		: `the call failed with ${error._tag}`;
 
 /**
  * A failure as the page reads it. The spell path is always the call's own, so a spell's private
  * error cannot claim a different one; only the executor's own errors add `expected`/`didYouMean`.
  */
-const failureOf = (call: SpellCall, error: unknown): SpellFailure => {
-	const tag = tagOf(error);
-	const base = {tag, message: messageOf(error, tag), path: call.path};
+const failureOf = (call: SpellCall, error: NamedError): SpellFailure => {
+	const base = {tag: error._tag, message: messageOf(error), path: call.path};
 	if (error instanceof UnknownSpell && error.didYouMean !== undefined) {
 		return {...base, didYouMean: error.didYouMean};
 	}
@@ -167,7 +174,18 @@ const make = Effect.fn("Tuval.SpellExecutor.make")(function* () {
 		});
 		return yield* attempt.pipe(
 			Effect.provideService(WindowIndex, index),
-			Effect.catch((error) => Effect.succeed(refused(call, failureOf(call, error)))),
+			Effect.catch((error) => {
+				const failure = named(call, error);
+				const reply = refused(call, failureOf(call, failure));
+				// The reply carries only what the wire can hold, so the value itself is logged here
+				// or it is readable nowhere once this frame goes.
+				return failure instanceof SpellFailed
+					? Effect.logError("spell executor: a spell failed with an untagged value", {
+							path: failure.path,
+							original: failure.original,
+						}).pipe(Effect.as(reply))
+					: Effect.succeed(reply);
+			}),
 		);
 	});
 

--- a/apps/tuval/src/commands/executor.unit.test.ts
+++ b/apps/tuval/src/commands/executor.unit.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, expectTypeOf, it} from "vitest";
 import {ProcessId} from "../process/process.ts";
 import {CallId} from "../protocol/ids.ts";
 import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../protocol/messages.ts";
+import {SpellFailed} from "./errors.ts";
 import {SpellExecutor} from "./executor.ts";
 import {SpellRegistry} from "./registry.ts";
 import {type Client, WindowIndex, type WindowPlacement} from "./scope.ts";
@@ -52,6 +53,33 @@ const refuse = defineSpell({
 	capabilities: [],
 });
 
+const swear = defineSpell({
+	path: ["window", "swear"],
+	describe: "Fail with a bare string.",
+	params: Schema.Struct({}),
+	result: Schema.Boolean,
+	execute: () => Effect.fail("the compositor said no"),
+	capabilities: [],
+});
+
+const mutter = defineSpell({
+	path: ["window", "mutter"],
+	describe: "Fail with a record carrying no tag.",
+	params: Schema.Struct({}),
+	result: Schema.Boolean,
+	execute: () => Effect.fail({reason: "the disk is full"}),
+	capabilities: [],
+});
+
+const hush = defineSpell({
+	path: ["window", "hush"],
+	describe: "Fail with a tag and no message.",
+	params: Schema.Struct({}),
+	result: Schema.Boolean,
+	execute: () => Effect.fail({_tag: "test/Silent"}),
+	capabilities: [],
+});
+
 // Written as an erased `AnySpell` rather than through `defineSpell`, which is exactly the compile
 // error this spell exists to get past: a spell whose value its own `result` refuses.
 const lie: AnySpell = {
@@ -63,7 +91,7 @@ const lie: AnySpell = {
 	capabilities: [],
 };
 
-const spells: ReadonlyArray<AnySpell> = [close, refuse, lie];
+const spells: ReadonlyArray<AnySpell> = [close, refuse, swear, mutter, hush, lie];
 
 const layer = SpellExecutor.layer.pipe(
 	Layer.provide(Layer.mergeAll(SpellRegistry.scripted(spells), WindowIndex.scripted(placements))),
@@ -170,6 +198,34 @@ describe("SpellExecutor", () => {
 			message: "refused: the window is pinned",
 			path: ["window", "explode"],
 		});
+	});
+
+	it("names SpellFailed when a spell fails with a bare string, and quotes the string", async () => {
+		const reply = await execute(call({path: ["window", "swear"], args: {}}));
+		expect(failure(reply)).toEqual({
+			tag: "tuval/commands/SpellFailed",
+			message: 'spell "window.swear" failed with "the compositor said no"',
+			path: ["window", "swear"],
+		});
+	});
+
+	it("names SpellFailed when a spell fails with an untagged record, and renders it", async () => {
+		const error = failure(await execute(call({path: ["window", "mutter"], args: {}})));
+		expect(error.tag).toBe("tuval/commands/SpellFailed");
+		expect(error.message).toContain("the disk is full");
+		expect(error.message).not.toBe(`the call failed with ${error.tag}`);
+	});
+
+	it("keeps the untagged value on the error rather than dropping it", () => {
+		const original = {reason: "the disk is full"};
+		const failed = new SpellFailed({path: "window.mutter", original});
+		expect(failed.original).toBe(original);
+		expect(failed._tag).toBe("tuval/commands/SpellFailed");
+	});
+
+	it("falls back to the tag only when a named error carries no message", async () => {
+		const reply = await execute(call({path: ["window", "hush"], args: {}}));
+		expect(failure(reply).message).toBe("the call failed with test/Silent");
 	});
 
 	it("dies rather than replies when a spell's value its own result schema refuses", async () => {


### PR DESCRIPTION
The executor no longer invents a tag. When a spell fails with something carrying no `_tag` — a bare
string, a plain record, a thrown value — the caught value is wrapped in a new `SpellFailed`
`Schema.TaggedError` declared in `apps/tuval/src/commands/errors.ts`, and the reply's tag is read off
that class like every other tag. The literal `"tuval/commands/SpellFailed"`, which named nothing in
the tree, is gone.

The original value survives two ways: it rides `SpellFailed.original`, and the executor logs it
through `Effect.logError` before building the reply, since the wire's `SpellFailure` has no field to
carry it. The message now renders the value (`spell "window.swear" failed with "the compositor said
no"`) instead of restating the tag.

`failureOf` and `messageOf` now take a `NamedError` — `{_tag: string, message?: unknown}` — rather
than `unknown`, so the tag can only come off an error object. There is no branch left where a string
literal can be composed into a tag.

Four cases added to `executor.unit.test.ts`: a bare-string failure, an untagged-record failure, the
`SpellFailed` class carrying its value, and a tagged error with no message (the `messageOf`
fallback). The existing tagged-error case is unchanged. `.patterns/tuval-spells.md`'s failure table
gains the untagged row and a note that every tag is read off an error object.

The value rendering reuses `stringifyJson` from `apps/tuval/src/protocol/json.ts` — the repo's
sanctioned JSON boundary — so a cycle or a BigInt does not throw out of a message getter.

Fixes #7754

## Deviations

- **Out-of-scope change** — **Said:** #7754 names the executor's fallback tag and the dropped value.
  **Did:** also removed `executor.ts`'s local `isRecord`, replacing it with an `isNamed` type guard.
  **Why:** `isRecord` existed only to serve `tagOf`/`messageOf`, and both were rewritten here, so
  leaving it would have left an unused helper. This is not a fix for #7764, which is about the three
  copies of `isRecord` across Tuval modules — the other two are untouched. **Disposition:** stated
  here.
