### PR TITLE
fix: Tuval shell spells require ShellDispatch, which no composition root provides

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -533,9 +533,21 @@ picker put them so the argument grammar would sit beside the handler that consum
 reads their name, sentence and argument kind off that list rather than re-typing them.
 
 `shellSpells` wraps each row as a spell whose `execute` builds the Msg and hands it to
-`ShellDispatch`, an interface this slice declares and whoever runs the desk implements — the same
-shape `WindowIndex` takes above. `AnySpell` erases that requirement, so the composition root that
-builds the registry owes the service.
+`ShellDispatch`, an interface this slice declares — the same shape `WindowIndex` takes above.
+`AnySpell` erases that requirement, so the composition root that builds the registry owes the
+service, and [`boot.ts`](../apps/tuval/src/boot.ts) pays it: `ShellDispatch.kernel(shellId)` sits in
+the same merge as `SpellBridge`, finds the live process of the shell's program row through
+`ProcessTable` per dispatch, and puts the Msg on it. `Kernel` names `ShellDispatch` and `Context` is
+contravariant in its services, so dropping that layer stops `start` compiling rather than leaving a
+defect for the first caller.
+
+`dispatch` fails typed rather than dying, because a desk is a process: a config that registers the
+shell row but plans no node for it answers `NoDesk`, and a desk that stopped mid-call answers the
+actor's own `DispatchError`. Either way the executor turns it into a `SpellReplyError`, so `help`,
+a typed line and an agent's bridge all read a refusal instead of meeting a defect. The proof is
+[`src/shell/proof/dispatch.unit.test.ts`](../apps/tuval/src/shell/proof/dispatch.unit.test.ts),
+which boots, calls a row through both the executor and the bridge, reads the desk back, and takes
+the service out of the returned kernel to show the same call dying without it.
 
 ## The palette
 

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -24,6 +24,8 @@ import {ProcessTable} from "./process/ProcessTable.ts";
 import type {ProcessHandle} from "./process/process.ts";
 import type {AnyProgram} from "./registry/program.ts";
 import {Registry} from "./registry/Registry.ts";
+import {ShellDispatch} from "./shell/commands/dispatch.ts";
+import {shellId} from "./shell/program.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 
 /** The global config module, `~/.tuval/tuval.config.ts`; the home dir is a parameter so a test can point it elsewhere. */
@@ -46,7 +48,11 @@ export type Kernel =
 	| SpellRegistry
 	| WindowIndex
 	| SpellExecutor
-	| SpellBridge;
+	| SpellBridge
+	// Naming it here is what makes the provider load-bearing to the checker: `Context` is
+	// contravariant in its services, so dropping `ShellDispatch.kernel` below stops `start`'s
+	// answer from satisfying `Started` rather than leaving a defect for the first caller (#7774).
+	| ShellDispatch;
 
 /** The spells the kernel registers itself: discovery, then the three generic process tools. */
 export const coreSpells: ReadonlyArray<AnySpell> = [...helpSpells, ...processSpells];
@@ -97,6 +103,11 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	const commands = Layer.mergeAll(
 		SpellBridge.layer({allow: everyPath(table)}),
 		SpawnedProcesses.layer({readTimeout: READ_TIMEOUT}),
+		// Every shell command row is registered as a spell whose `execute` needs this, and the
+		// registry erases that requirement, so the composition root is where it is owed (#7774).
+		// The desk stays a program row like any other: a config that registers no shell row leaves
+		// this dispatcher with no process to find, which is a `NoDesk` refusal, not a failed boot.
+		ShellDispatch.kernel(shellId),
 	).pipe(
 		Layer.provideMerge(SpellExecutor.layer),
 		Layer.provideMerge(

--- a/apps/tuval/src/commands/executor.ts
+++ b/apps/tuval/src/commands/executor.ts
@@ -7,7 +7,10 @@
  *
  * `AnySpell` erases each spell's requirements, so nothing checks that the runtime carries what a
  * registered spell needs — the composition root that builds the registry owes those services, and
- * the single conversion in `runSpell` is where that obligation is spent.
+ * the single conversion in `runSpell` is where that obligation is spent. `src/boot.ts` is that
+ * root and discharges it there: `WindowIndex` and `ShellDispatch.kernel` are built into the same
+ * `Kernel` context a caller runs a spell under, and `Kernel` names both, so a dropped provider is
+ * a compile error at `start` rather than a defect at the first call (#7774).
  */
 
 import {Context, Effect, Layer, Schema} from "effect";

--- a/apps/tuval/src/shell/commands/dispatch.ts
+++ b/apps/tuval/src/shell/commands/dispatch.ts
@@ -2,20 +2,72 @@
  * The one thing a command row's spell needs from the world: somewhere to put the Msg it built.
  *
  * A row is pure and the registry is program-blind, so neither can hold the running shell process.
- * `ShellDispatch` is the seam between them — declared here and implemented by whoever runs the desk
- * (the browser surface, #7559), the same shape `WindowIndex` takes in the framework: an interface
- * one slice declares, another implements, and a `scripted` layer stands in for under test.
+ * `ShellDispatch` is the seam between them — declared here and implemented at the composition root
+ * by `ShellDispatch.kernel`, which `src/boot.ts` builds into the kernel beside `SpellExecutor`
+ * (#7774). It is the same shape `WindowIndex` takes in the framework: an interface one slice
+ * declares, another implements, and a `scripted` layer stands in for under test.
+ *
+ * A desk is a process, so it can be absent — a config that drops the shell row boots without one —
+ * or stopped mid-call. `dispatch` therefore fails typed rather than dying, and the executor turns
+ * that failure into a `SpellReplyError`: asking a desk-less kernel to close a window is answered
+ * with a refusal a caller can read, never a defect.
  */
 
-import {Context, Effect, Layer} from "effect";
+import {Context, Effect, Layer, Option, Schema} from "effect";
+import type {DispatchError} from "../../host/actor.ts";
+import type {HandlerFailed} from "../../process/errors.ts";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessTable} from "../../process/ProcessTable.ts";
+import type {ProgramId} from "../../registry/program.ts";
 import type {ShellMsg} from "../core/machine.ts";
+
+/** No process of the desk's program row is running, so the Msg has nowhere to land. */
+export class NoDesk extends Schema.TaggedError<NoDesk>()("tuval/shell/NoDesk", {
+	program: Schema.String,
+}) {
+	override get message(): string {
+		return `no "${this.program}" process is running, so there is no desk to dispatch to`;
+	}
+}
+
+/** Every way putting a Msg on the desk can be refused: no desk, or the desk's own dispatch. */
+export type ShellDispatchError = NoDesk | DispatchError<HandlerFailed>;
 
 export class ShellDispatch extends Context.Service<
 	ShellDispatch,
 	{
-		readonly dispatch: (msg: ShellMsg) => Effect.Effect<void>;
+		readonly dispatch: (msg: ShellMsg) => Effect.Effect<void, ShellDispatchError>;
 	}
 >()("tuval/shell/ShellDispatch") {
+	/**
+	 * The real one: the Msg goes to the live process of the desk's program row.
+	 *
+	 * The row is resolved per dispatch rather than at layer build, because the kernel is built
+	 * before any process exists and a desk can be stopped and spawned again under the same program
+	 * id. `program` is a parameter because `shellId` lives in `../program.ts`, which imports this
+	 * module — boot names it, and a boot whose config registered no shell row answers `NoDesk`.
+	 */
+	static readonly kernel = (
+		program: ProgramId,
+	): Layer.Layer<ShellDispatch, never, Processes | ProcessTable> =>
+		Layer.effect(
+			ShellDispatch,
+			Effect.gen(function* () {
+				const processes = yield* Processes;
+				const table = yield* ProcessTable;
+				return ShellDispatch.of({
+					dispatch: (msg) =>
+						Effect.gen(function* () {
+							const rows = yield* table.list;
+							const row = rows.find((candidate) => candidate.programId === program);
+							const handle = row === undefined ? Option.none() : yield* processes.handle(row.id);
+							if (Option.isNone(handle)) return yield* new NoDesk({program});
+							yield* handle.value.dispatch(msg);
+						}),
+				});
+			}),
+		);
+
 	/**
 	 * A dispatcher that appends to a list. The list is the test's, so a spell run through this layer
 	 * is read by looking at what landed in it rather than at what the spell returned.

--- a/apps/tuval/src/shell/program.ts
+++ b/apps/tuval/src/shell/program.ts
@@ -109,7 +109,8 @@ export interface ShellProgramOptions<E = never, R = never> {
  * `spells` is the command table (`./commands/`), so every named row is registered under
  * `[shellId, ...path]` and reachable through the one registry — the palette, `help`, and an agent's
  * bridge all read the shell's commands there rather than from a second catalogue. Running one needs
- * `ShellDispatch`, which `AnySpell` erases: whoever builds the registry owes that service.
+ * `ShellDispatch`, which `AnySpell` erases; `src/boot.ts` owes it and pays it with
+ * `ShellDispatch.kernel(shellId)`, which finds this row's live process and dispatches into it.
  */
 export const shellProgram = <E = never, R = never>({
 	table = defaultPrefixTable,

--- a/apps/tuval/src/shell/proof/dispatch.unit.test.ts
+++ b/apps/tuval/src/shell/proof/dispatch.unit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The shell's command rows, called against a real boot (#7774).
+ *
+ * Every row is registered as a spell whose `execute` needs `ShellDispatch`, and `AnySpell` erases
+ * that requirement, so nothing but a running call can show the composition root actually pays it.
+ * These are that call: `start` builds the kernel the app boots with, and each spell goes in through
+ * `SpellExecutor.execute` or `SpellBridge.call` — the two doors a page and an agent use — with the
+ * desk read afterwards to prove the Msg landed rather than merely being answered.
+ *
+ * The provider is load-bearing twice over. In the checker, `boot.ts`'s `Kernel` names
+ * `ShellDispatch` and `Context` is contravariant in its services, so dropping the layer stops
+ * `start` compiling. At runtime, the third test here takes the service back out of the very kernel
+ * `start` returned and shows the same call dying — which is what a missing provider is, and what
+ * the other tests would meet if boot stopped building it.
+ */
+
+import {mkdtemp, rm} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Context, Effect, Exit, Option, Schema} from "effect";
+import {start} from "../../boot.ts";
+import {SpellBridge} from "../../commands/bridge/index.ts";
+import {SpellExecutor} from "../../commands/executor.ts";
+import type {Client} from "../../commands/scope.ts";
+import {
+	ClientId,
+	type SpellPath,
+	type Scope as SpellScope,
+	WorkspaceId,
+} from "../../commands/spell.ts";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessId} from "../../process/process.ts";
+import {CallId} from "../../protocol/ids.ts";
+import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../../protocol/messages.ts";
+import {ShellDispatch} from "../commands/dispatch.ts";
+import {activeWorkspace, windowIds} from "../core/index.ts";
+import {wiredShellEffects} from "../host/effects.ts";
+import {shellGraphNode, shellId, shellNode, shellProgram, shellStateOf} from "../program.ts";
+
+class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defect()}) {}
+
+const io = <A>(run: () => Promise<A>) =>
+	Effect.tryPromise({try: run, catch: (cause) => new TestIo({cause})});
+
+const tempDir = Effect.acquireRelease(
+	io(() => mkdtemp(join(tmpdir(), "tuval-shell-dispatch-"))),
+	(dir) => Effect.ignore(io(() => rm(dir, {recursive: true, force: true}))),
+);
+
+/** The shell is spawned at its graph node's id, so the desk's process id is known before boot. */
+const shellProcessId = ProcessId.make(shellNode);
+
+const workspace = WorkspaceId.make("ws-1");
+const client: Client = {id: ClientId.make("proof"), workspace};
+const scope: SpellScope = {client: client.id, workspace};
+
+const call = (path: SpellPath, args: unknown): SpellCall =>
+	new SpellCall({
+		type: "spell.call",
+		version: PROTOCOL_VERSION,
+		id: CallId.make("c-1"),
+		path,
+		args,
+	});
+
+/**
+ * One app, as `.tuval/tuval.config.ts` builds it minus the demo rows. `withDesk: false` registers
+ * the same shell row against a graph that plans no node for it, which is the config that boots
+ * without a desk — the row's spells are still registered, so the call has somewhere to arrive and
+ * nowhere to land.
+ */
+const bootDesk = Effect.fn("proof.bootDesk")(function* (withDesk = true) {
+	const stateDir = yield* tempDir;
+	return yield* start({
+		programs: [shellProgram({effects: wiredShellEffects({shellProcessId})})],
+		graph: {nodes: withDesk ? [shellGraphNode] : []},
+		stateDir,
+	});
+});
+
+/** The desk as its own process holds it, which is the state a spell's Msg has to have moved. */
+const readDesk = Effect.fn("proof.readDesk")(function* (kernel: Context.Context<Processes>) {
+	const handle = yield* Context.get(kernel, Processes).handle(shellProcessId);
+	assert.isTrue(Option.isSome(handle), "the shell process is running");
+	const state = shellStateOf(Option.getOrThrow(handle).getState());
+	assert.isNotNull(state, "the shell process holds a shell state");
+	return state;
+});
+
+const windowCount = (state: ReturnType<typeof shellStateOf>): number => {
+	const active = state === null ? undefined : activeWorkspace(state);
+	assert.isDefined(active, "the desk has an active workspace");
+	return active === undefined ? 0 : windowIds(active).length;
+};
+
+const failureOf = (reply: SpellReply) => {
+	assert.isFalse(reply.ok, `expected a refusal, got ${JSON.stringify(reply)}`);
+	return reply.ok ? undefined : reply.error;
+};
+
+describe("a shell command row, called against the kernel boot builds", () => {
+	it.effect("answers a reply and lands its Msg on the running desk", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			assert.strictEqual(windowCount(yield* readDesk(kernel)), 1);
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([shellId, "window", "split-vertical"], {}), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.isTrue(reply.ok, `the call was refused: ${JSON.stringify(reply)}`);
+			assert.deepStrictEqual(reply.ok ? reply.result : undefined, {msg: "window.split"});
+			assert.strictEqual(windowCount(yield* readDesk(kernel)), 2);
+		}),
+	);
+
+	it.effect("answers a reply through SpellBridge, the door an agent calls through", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			const bridge = Context.get(kernel, SpellBridge);
+
+			const answered = yield* bridge
+				.call([shellId, "window", "split-vertical"], {}, scope)
+				.pipe(Effect.provideContext(kernel));
+			assert.deepStrictEqual(answered, {msg: "window.split"});
+			assert.strictEqual(windowCount(yield* readDesk(kernel)), 2);
+
+			// A refusal is a value on the bridge's error channel, never a defect: the caller is an
+			// agent's tool, and a tool that dies takes its whole session with it.
+			const exit = yield* Effect.exit(
+				bridge
+					.call([shellId, "window", "focus"], {window: ""}, scope)
+					.pipe(Effect.provideContext(kernel)),
+			);
+			assert.isTrue(Exit.isFailure(exit), "the bridge accepted an argument the row refuses");
+			assert.isFalse(
+				Exit.isFailure(exit) && Cause.hasDies(exit.cause),
+				"the bridge died on a bad argument instead of refusing",
+			);
+			assert.strictEqual(windowCount(yield* readDesk(kernel)), 2);
+		}),
+	);
+
+	it.effect("dies on the same call once the provider is taken back out of the kernel", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			const withoutDispatch = Context.omit(ShellDispatch)(kernel);
+
+			const exit = yield* Effect.exit(
+				Context.get(kernel, SpellExecutor)
+					.execute(call([shellId, "window", "split-vertical"], {}), client)
+					.pipe(Effect.provideContext(withoutDispatch)),
+			);
+
+			assert.isTrue(Exit.isFailure(exit), "a kernel missing ShellDispatch answered the call");
+			assert.strictEqual(windowCount(yield* readDesk(kernel)), 1);
+		}),
+	);
+
+	it.effect("refuses in the typed channel when the config planned no desk", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk(false);
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([shellId, "window", "split-vertical"], {}), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.strictEqual(failureOf(reply)?.tag, "tuval/shell/NoDesk");
+		}),
+	);
+});


### PR DESCRIPTION
The Tuval shell registers its 16 command rows as spells whose `execute` requires `ShellDispatch`, and nothing built that service. Any call reaching one through the registry — an agent over `SpellBridge`, `help`, `spell describe` driving a shell path — died on a missing service instead of answering a `SpellReply`.

**What changed.** `ShellDispatch.kernel(programId)` resolves the live process of the desk's program row through `ProcessTable` on each dispatch and puts the Msg on it, and `boot.ts` builds it into the kernel in the same merge as `SpellBridge`. The row is looked up per dispatch rather than at layer build because the kernel is built before any process exists.

`Kernel` now names `ShellDispatch`. `Context` is contravariant in its services, so dropping the layer stops `start` compiling — I checked this by deleting the line and running `tsc`, which reddens in three places, including `reload-proof.unit.test.ts`. That is what makes the provider load-bearing rather than a convention.

`dispatch` fails typed instead of dying. A config that registers the shell row but plans no graph node for it answers `NoDesk`; a desk stopped mid-call answers the actor's own `DispatchError`. The executor turns either into a `SpellReplyError`, so a bridge caller reads a refusal it can act on rather than losing its session to a defect.

**Where to look first.** `apps/tuval/src/shell/proof/dispatch.unit.test.ts` is the boot-level proof: it calls a row through `SpellExecutor.execute` and through `SpellBridge.call`, reads the desk's own state back to show the Msg landed, takes `ShellDispatch` out of the returned kernel with `Context.omit` to show the same call dying, and boots a desk-less config to show the `NoDesk` refusal.

The docblocks in `commands/executor.ts`, `shell/commands/dispatch.ts` and `shell/program.ts` named #7559 as the future implementer; they now name where the obligation is actually paid. `.patterns/tuval-spells.md` carries the same.

Fixes #7774

## Deviations

- **Out-of-scope change** — **Said:** #7774 names `boot.ts`, a boot-level test and the two docblocks in `executor.ts` and `dispatch.ts`. **Did:** also updated the obligation sentence in `apps/tuval/src/shell/program.ts` and the "The shell's command rows" section of `.patterns/tuval-spells.md`. **Why:** both state the same undone obligation in the same words the two named docblocks did, so leaving them would have left the repo saying two different things about one seam. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about `WindowIndex`. **Did:** left `boot.ts`'s `WindowIndex.scripted({})` and its now-stale comment ("No shell holds windows yet") in place. **Why:** the shell does hold windows now, so every spell call naming a window is refused as `NoSuchWindow` — the same shape as this bug, but a separate seam needing its own live implementation. **Disposition:** filed as #7894.
