### PR TITLE
fix: Tuval's patch walk coerces array indices with Number and recurses without a depth bound

### DIFF
--- a/apps/tuval/src/protocol/patch.ts
+++ b/apps/tuval/src/protocol/patch.ts
@@ -19,12 +19,37 @@ type Replaced =
 	| {readonly ok: true; readonly value: unknown}
 	| {readonly ok: false; readonly reason: string};
 
+declare const ArrayIndexOf: unique symbol;
+
+/** An in-range index of some array. `indexInto` is its only constructor, so there is no other way
+ * to reach `target[i]` — `Number` would have invented one out of `""`, `"0x2"`, `" 1 "` or `"1e0"`,
+ * and four spellings addressing one element makes a patch's meaning a coercion rule's to decide. */
+type ArrayIndex = number & {readonly [ArrayIndexOf]: true};
+
+/** One spelling per index: digits only, and a leading zero only when the index *is* zero. */
+const INDEX_SPELLING = /^(?:0|[1-9][0-9]*)$/;
+
+const indexInto = (target: ReadonlyArray<unknown>, segment: string): ArrayIndex | undefined => {
+	if (!INDEX_SPELLING.test(segment)) return undefined;
+	const index = Number(segment) as ArrayIndex;
+	return index < target.length ? index : undefined;
+};
+
+/** The walk recurses once per segment, and `Replace.path` is unbounded on the wire, so without a cap
+ * a long enough path overflows the page's stack — a `RangeError`, which is outside `applyPatch`'s
+ * error channel and so escapes as a defect rather than a refusal. The snapshot's own deepest
+ * addressable path is five segments. */
+const MAX_PATH_DEPTH = 32;
+
 const replaceAt = (target: unknown, path: ReadonlyArray<string>, value: unknown): Replaced => {
+	if (path.length > MAX_PATH_DEPTH) {
+		return {ok: false, reason: `a path deeper than ${MAX_PATH_DEPTH} segments is not walked`};
+	}
 	const [head, ...rest] = path;
 	if (head === undefined) return {ok: true, value};
 	if (Array.isArray(target)) {
-		const index = Number(head);
-		if (!Number.isInteger(index) || index < 0 || index >= target.length) {
+		const index = indexInto(target, head);
+		if (index === undefined) {
 			return {ok: false, reason: `"${head}" is not an index of the array there`};
 		}
 		const inner = replaceAt(target[index], rest, value);
@@ -67,6 +92,14 @@ export const applyPatch = (
 		for (const change of patch.changes) {
 			if (change.path.length === 0) {
 				return yield* new PatchRefused({path: [], reason: "a replace needs a path"});
+			}
+			if (change.path[0] === "rev") {
+				// The revision write below would clobber it, so accepting one reports a change applied
+				// that had no effect.
+				return yield* new PatchRefused({
+					path: change.path,
+					reason: "the revision is the patch's own field, not a replace target",
+				});
 			}
 			const replaced = replaceAt(current, change.path, change.value);
 			if (!replaced.ok) {

--- a/apps/tuval/src/protocol/patch.unit.test.ts
+++ b/apps/tuval/src/protocol/patch.unit.test.ts
@@ -114,6 +114,37 @@ describe("applyPatch", () => {
 		}),
 	);
 
+	it.effect("refuses every spelling of an index that is not digits", () =>
+		Effect.gen(function* () {
+			// Each of these is an index to `Number` — 0, 2, 1, 1 — and none of them is one here.
+			for (const segment of ["", "0x2", " 1 ", "1e0", "+0", "00", "1.0"]) {
+				const refusal = yield* Effect.flip(
+					applyPatch(snapshot, patchOf([replace(["processes", segment, "id"], "x")])),
+				);
+				assert.strictEqual(refusal._tag, "tuval/PatchRefused", segment);
+				assert.include(refusal.message, "is not an index of the array there");
+			}
+		}),
+	);
+
+	it.effect("refuses a path deeper than the walk's cap rather than recursing into it", () =>
+		Effect.gen(function* () {
+			const refusal = yield* Effect.flip(
+				applyPatch(snapshot, patchOf([replace(new Array(100_000).fill("desk"), 1)])),
+			);
+			assert.strictEqual(refusal._tag, "tuval/PatchRefused");
+			assert.include(refusal.message, "is not walked");
+		}),
+	);
+
+	it.effect("refuses a replace at the revision the patch itself carries", () =>
+		Effect.gen(function* () {
+			const refusal = yield* Effect.flip(applyPatch(snapshot, patchOf([replace(["rev"], 99)])));
+			assert.strictEqual(refusal._tag, "tuval/PatchRefused");
+			assert.include(refusal.message, "not a replace target");
+		}),
+	);
+
 	it.effect("refuses a replace that would leave the snapshot undecodable", () =>
 		Effect.gen(function* () {
 			const refusal = yield* Effect.flip(


### PR DESCRIPTION
`applyPatch`'s path walk in `apps/tuval/src/protocol/patch.ts` had three defects the file's own
docblock rules out — "a kernel and a page that disagree about the shape should stop, not diverge
quietly."

**Which element a patch writes was a coercion rule's call.** `const index = Number(head)` accepts
more spellings than the protocol does: `Number("")` is `0`, `Number("0x2")` is `2`, `Number(" 1 ")`
and `Number("1e0")` are both `1`. Four path strings addressed one element. There is now an
`ArrayIndex` type whose only constructor is `indexInto`, which matches the segment against a
digits-only pattern (one spelling per index, a leading zero only for zero) and bounds it against the
array it indexes. Nothing else can produce the value the walk uses to reach `target[i]`.

**A deep path overflowed the page's stack.** `Replace.path` is `Schema.Array(Schema.String)` with no
length bound, and the walk recursed once per segment, so a long enough path raised a `RangeError` —
outside `applyPatch`'s `PatchRefused | ProtocolRefused` channel, so it escaped as a defect rather
than a refusal. `replaceAt` now refuses past `MAX_PATH_DEPTH` (32; the snapshot's own deepest
addressable path is five segments) before it recurses at all.

**A replace at `["rev"]` was applied and then clobbered.** The encoded snapshot carries an own `rev`
key, so the walk reached it and returned `ok`, and then the revision write after the change loop
overwrote it — the patch reported applied with one change that had no effect. It is refused now.

Tests cover each refusal: every coerced spelling above plus `"+0"`, `"00"` and `"1.0"`, a
100,000-segment path, and a `["rev"]` replace. The nine cases already in the file still pass.

Fixes #7756

## Deviations

- **Out-of-scope change** — **Said:** the issue names `""`, `"0x2"`, `" 1 "` and `"1e0"`. **Did:**
  the digits-only pattern also refuses `"+0"`, `"00"` and `"1.0"`, and the test asserts those three
  too. **Why:** they are the same defect — each is a spelling `Number` turns into a valid index —
  and a pattern that admitted them would leave the "one spelling per index" property untrue.
  **Disposition:** stated here.
- **Declined guidance** — **Said:** the lane brief asks for an `umut/` branch prefix. **Did:** the
  branch is `build/7756-patch-walk-index-depth-5a9c2ad6`. **Why:** `fabrika build branch` names the
  lane branch itself, and `build tree --issue` proves the lane against that name, so a rename would
  break every later proof in the run. **Disposition:** stated here.
