### PR TITLE
fix: A Tuval union decode reports only the first member's issue, so a bad type names the wrong shape

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -495,6 +495,19 @@ the revision just below it") have always said; the check used to be wider than b
 [`protocol/issue.ts`](../apps/tuval/src/protocol/issue.ts) turns an Effect `SchemaError` into
 `{expected, at}`, which is what every refusal in the slice interpolates.
 
+It takes the failing input as a second operand, and that operand serves one case: a direction union
+whose discriminants rule out every member. The parser narrows a union by its literal fields before
+it tries a member, so when `type` or `version` matches nothing there is no member left to fail and
+the `AnyOf` carries no issue — Effect then formats it as a dump of all four candidate shapes, at no
+path. `issue.ts` reads that empty `AnyOf` itself: it re-derives each member's literal fields off the
+public `SchemaAST` nodes, narrows them in declaration order against the input, and answers with the
+field that emptied the set — `Expected 1, got 2 at version` for a snapshot from a different build,
+`Expected "spell.call", got "spell.cast" at type` for a name nothing owns. A message whose
+discriminants do pick a member keeps that member's own issue unchanged. A non-object frame keeps the
+dump: no field is at fault there. Why this is worth the AST walk is
+[#7760](https://github.com/kamp-us/phoenix/issues/7760) — `version` is exactly what
+`PROTOCOL_VERSION` exists to catch, and the dump never mentioned it.
+
 ## The shell's command rows
 
 The shell declares its named commands under

--- a/apps/tuval/src/protocol/codec.ts
+++ b/apps/tuval/src/protocol/codec.ts
@@ -20,7 +20,7 @@ const decodeFor =
 			return Effect.fail(refuse(`not JSON: ${parsed.reason}`));
 		}
 		return Schema.decodeUnknownEffect(schema)(parsed.value).pipe(
-			Effect.mapError((error) => refuse(describeSchemaError(error))),
+			Effect.mapError((error) => refuse(describeSchemaError(error, parsed.value))),
 		);
 	};
 
@@ -29,7 +29,7 @@ const encodeFor =
 	(message: S["Type"]): Effect.Effect<string, ProtocolRefused> =>
 		Schema.encodeEffect(schema)(message).pipe(
 			Effect.mapError(
-				(error) => new ProtocolRefused({direction, reason: describeSchemaError(error)}),
+				(error) => new ProtocolRefused({direction, reason: describeSchemaError(error, message)}),
 			),
 			Effect.flatMap((encoded) => {
 				const written = stringifyJson(encoded);

--- a/apps/tuval/src/protocol/issue.ts
+++ b/apps/tuval/src/protocol/issue.ts
@@ -1,4 +1,4 @@
-import {type Schema, SchemaIssue} from "effect";
+import {type Schema, SchemaAST, SchemaIssue} from "effect";
 
 const formatIssues = SchemaIssue.makeFormatterStandardSchemaV1({
 	leafHook: SchemaIssue.defaultLeafHook,
@@ -20,9 +20,93 @@ export interface SchemaIssueSummary {
 	readonly at: string;
 }
 
-/** The first issue of a schema failure. Every decode this app runs answers on the first one. */
-export const firstSchemaIssue = (error: Schema.SchemaError): SchemaIssueSummary => {
-	const [first] = formatIssues(error.issue).issues;
+/** A field whose schema is one literal, so its value alone can rule a union member out. */
+interface Discriminant {
+	readonly key: PropertyKey;
+	readonly literal: SchemaAST.LiteralValue;
+}
+
+/**
+ * Re-derives what `SchemaAST`'s union candidate index reads off a member: the non-optional fields
+ * typed as a single literal, taken past the encoding chain, and for a nested union only the ones
+ * every one of its members agrees on. `SchemaAST.collectSentinels` does this inside the parser but
+ * is `@internal` and absent from the published `.d.ts`, so it is re-derived here off public nodes.
+ */
+const discriminantsOf = (ast: SchemaAST.AST): ReadonlyArray<Discriminant> => {
+	const encoded = ast.encoding?.at(-1);
+	if (encoded !== undefined) return discriminantsOf(encoded.to);
+	if (SchemaAST.isUnion(ast)) {
+		const members = ast.types.map(discriminantsOf);
+		const [first] = members;
+		if (first === undefined) return [];
+		return first.filter((d) =>
+			members.every((ds) => ds.some((o) => o.key === d.key && o.literal === d.literal)),
+		);
+	}
+	if (SchemaAST.isObjects(ast)) {
+		return ast.propertySignatures.flatMap((ps) =>
+			SchemaAST.isLiteral(ps.type) && ps.type.context?.isOptional !== true
+				? [{key: ps.name, literal: ps.type.literal}]
+				: [],
+		);
+	}
+	return [];
+};
+
+const renderValue = (value: unknown): string => {
+	const rendered = JSON.stringify(value);
+	return rendered === undefined ? String(value) : rendered;
+};
+
+/**
+ * Which discriminant ruled out the last surviving member, for a union whose candidate index left the
+ * parser nothing to try — the `AnyOf` that carries no member issue and formats as a dump of every
+ * candidate shape. Narrows in declaration order, so the field it names is the one that eliminated
+ * the members still standing, and the values it offers are only theirs.
+ */
+const unmatchedUnionIssue = (
+	ast: SchemaAST.Union,
+	input: unknown,
+): SchemaIssueSummary | undefined => {
+	if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
+	const record = input as Record<PropertyKey, unknown>;
+	let candidates = ast.types.map(discriminantsOf).filter((ds) => ds.length > 0);
+	for (const key of new Set(candidates.flatMap((ds) => ds.map((d) => d.key)))) {
+		const owned = candidates.flatMap((ds) => ds.filter((d) => d.key === key));
+		const present = Object.hasOwn(record, key);
+		const survivors = candidates.filter((ds) => {
+			const own = ds.find((d) => d.key === key);
+			return own === undefined || (present && own.literal === record[key]);
+		});
+		if (survivors.length > 0) {
+			candidates = survivors;
+			continue;
+		}
+		const at = renderPath([key]);
+		if (!present) return {expected: "Missing key", at};
+		const expected = [...new Set(owned.map((d) => renderValue(d.literal)))].join(" | ");
+		return {expected: `Expected ${expected}, got ${renderValue(record[key])}`, at};
+	}
+	return undefined;
+};
+
+/**
+ * The first issue of a schema failure. Every decode this app runs answers on the first one.
+ *
+ * `input` is the value that failed, and it buys one thing: when a union's discriminants rule out
+ * every member the failure carries no member issue to be first, and the input is what names the
+ * field that did the ruling out (#7760). Only a union at the root of the failure is read this way.
+ */
+export const firstSchemaIssue = (
+	error: Schema.SchemaError,
+	input?: unknown,
+): SchemaIssueSummary => {
+	const {issue} = error;
+	if (issue._tag === "AnyOf" && issue.issues.length === 0) {
+		const unmatched = unmatchedUnionIssue(issue.ast, input);
+		if (unmatched !== undefined) return unmatched;
+	}
+	const [first] = formatIssues(issue).issues;
 	if (first === undefined) return {expected: "does not match the schema", at: ""};
 	return {
 		expected: first.message,
@@ -31,7 +115,7 @@ export const firstSchemaIssue = (error: Schema.SchemaError): SchemaIssueSummary 
 };
 
 /** The first issue as one line — what was wrong, and where. A refusal interpolates this. */
-export const describeSchemaError = (error: Schema.SchemaError): string => {
-	const {expected, at} = firstSchemaIssue(error);
+export const describeSchemaError = (error: Schema.SchemaError, input?: unknown): string => {
+	const {expected, at} = firstSchemaIssue(error, input);
 	return at.length === 0 ? expected : `${expected} at ${at}`;
 };

--- a/apps/tuval/src/protocol/protocol.unit.test.ts
+++ b/apps/tuval/src/protocol/protocol.unit.test.ts
@@ -115,11 +115,15 @@ describe("refusals", () => {
 		result: null,
 	};
 
+	// Each `reason` here asserts on the offending *value*, never on the field name alone: the
+	// candidate-shape dump this refusal used to be renders every field name, so a name-only
+	// assertion passed while the reason said nothing (#7760).
 	it.effect("a wrong version, page to kernel", () =>
 		Effect.gen(function* () {
 			const refusal = yield* refusalOf(decodePageMessage(withField(callBody, "version", 2)));
 			assert.strictEqual(refusal.direction, "page-to-kernel");
-			assert.include(refusal.reason, "version");
+			assert.include(refusal.reason, "got 2");
+			assert.include(refusal.reason, "at version");
 		}),
 	);
 
@@ -127,7 +131,16 @@ describe("refusals", () => {
 		Effect.gen(function* () {
 			const refusal = yield* refusalOf(decodeKernelMessage(withField(replyBody, "version", 2)));
 			assert.strictEqual(refusal.direction, "kernel-to-page");
-			assert.include(refusal.reason, "version");
+			assert.include(refusal.reason, "got 2");
+			assert.include(refusal.reason, "at version");
+		}),
+	);
+
+	it.effect("a wrong version names only the shape its type picked", () =>
+		Effect.gen(function* () {
+			const snapshotBody = JSON.parse(yield* encodeKernelMessage(fixtures.snapshot));
+			const refusal = yield* refusalOf(decodeKernelMessage(withField(snapshotBody, "version", 2)));
+			assert.strictEqual(refusal.reason, `Expected ${PROTOCOL_VERSION}, got 2 at version`);
 		}),
 	);
 
@@ -137,7 +150,8 @@ describe("refusals", () => {
 				decodePageMessage(withField(callBody, "type", "spell.cast")),
 			);
 			assert.strictEqual(refusal.direction, "page-to-kernel");
-			assert.include(refusal.reason, "type");
+			assert.include(refusal.reason, `"spell.cast"`);
+			assert.include(refusal.reason, "at type");
 		}),
 	);
 
@@ -147,6 +161,16 @@ describe("refusals", () => {
 				decodeKernelMessage(withField(replyBody, "type", "snapshut")),
 			);
 			assert.strictEqual(refusal.direction, "kernel-to-page");
+			assert.include(refusal.reason, `"snapshut"`);
+			assert.include(refusal.reason, "at type");
+		}),
+	);
+
+	it.effect("a message whose type picks one member keeps that member's own issue", () =>
+		Effect.gen(function* () {
+			const snapshotBody = JSON.parse(yield* encodeKernelMessage(fixtures.snapshot));
+			const refusal = yield* refusalOf(decodeKernelMessage(withField(snapshotBody, "rev", "nope")));
+			assert.strictEqual(refusal.reason, "Expected number at rev");
 		}),
 	);
 


### PR DESCRIPTION
When a Tuval direction union rules out every member on its discriminants, Effect fails with an
`AnyOf` carrying no member issue and the formatter renders one message listing all four candidate
shapes, at no path. So a snapshot from a build with a different `PROTOCOL_VERSION` — the exact case
`PROTOCOL_VERSION` exists to catch — refused with a four-shape dump that never mentioned `version`.

`apps/tuval/src/protocol/issue.ts` now reads that empty `AnyOf` itself. It re-derives each member's
literal fields off the public `SchemaAST` nodes (the same fields the parser's candidate index reads;
`collectSentinels` does this inside the parser but is `@internal` and absent from the published
`.d.ts`), narrows them in declaration order against the input, and answers with the field that
emptied the set:

| input to `KernelToPage` | before | after |
|---|---|---|
| `{type:"snapshot", version:2}` | dump of four shapes | `Expected 1, got 2 at version` |
| `{type:"snapshut", …}` | dump of four shapes | `Expected "spell.reply" \| "snapshot" \| "patch", got "snapshut" at type` |
| `{type:"snapshot", rev:"nope"}` | `Expected number at rev` | unchanged |

`describeSchemaError` / `firstSchemaIssue` take the failing input as an optional second operand, and
the codec passes it; every other caller keeps the one-argument call and today's answer. A non-object
frame keeps the dump — no field is at fault there.

The three existing `reason` assertions asserted on a field *name*, which the dump itself renders, so
all three passed while the reason said nothing. They now assert on the offending value (`got 2`,
`"spell.cast"`), and "an unknown type, kernel to page" gained the `reason` assertion its siblings
have. Two exact-equality tests pin that the version case names `version` and `2` with no shape dump,
and that a message whose type picks one member keeps that member's own issue.

`.patterns/tuval-spells.md` states what a refusal reports when no union member matches.

Fixes #7760

## Deviations

- **Out-of-scope change** — **Said:** #7760 names `apps/tuval/src/protocol/issue.ts` and its tests.
  **Did:** also changed `apps/tuval/src/protocol/codec.ts`, two lines. **Why:** the failing input is
  the operand the analysis needs and the codec is the only holder of it; without those two lines the
  fix is unreachable. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the criteria describe the direction unions. **Did:** only a union
  at the root of the failure is read this way; a union nested under a struct field keeps today's
  answer. **Why:** indexing the input down to a nested union needs a path walk no protocol shape
  exercises. **Disposition:** stated here and in the function's doc comment.
