### PR TITLE
fix: SpellDescription.params is Schema.Unknown, so two Tuval fixture sets disagree about its shape unobserved

### DIFF
--- a/apps/tuval/src/commands/parse/fixtures.ts
+++ b/apps/tuval/src/commands/parse/fixtures.ts
@@ -7,6 +7,7 @@
  */
 
 import {ProcessId, ProgramId, WindowId, WorkspaceId} from "../../protocol/ids.ts";
+import type {JsonSchemaDocument} from "../../protocol/json-schema-document.ts";
 import {PROTOCOL_VERSION, Snapshot} from "../../protocol/messages.ts";
 import type {ProcessRow} from "../../protocol/process-row.ts";
 import type {RegistryDescription, SpellDescription} from "../../protocol/registry-description.ts";
@@ -20,7 +21,7 @@ interface Property {
 export const jsonSchema = (
 	properties: Readonly<Record<string, Property>>,
 	required: ReadonlyArray<string>,
-): unknown => ({
+): JsonSchemaDocument => ({
 	dialect: "draft-2020-12",
 	schema: {type: "object", properties, required, additionalProperties: false},
 	definitions: {},
@@ -32,7 +33,7 @@ const direction: Property = {type: "string", enum: ["left", "right", "up", "down
 const spell = (
 	path: ReadonlyArray<string>,
 	describe: string,
-	params: unknown,
+	params: JsonSchemaDocument,
 ): SpellDescription => ({path, describe, params, capabilities: []});
 
 export const descriptions: RegistryDescription = [

--- a/apps/tuval/src/commands/parse/parse.unit.test.ts
+++ b/apps/tuval/src/commands/parse/parse.unit.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {emptyParams} from "../../protocol/fixtures.ts";
 import {complete} from "./complete.ts";
 import {didYouMean} from "./did-you-mean.ts";
 import {registry, snapshot} from "./fixtures.ts";
@@ -87,13 +88,13 @@ describe("parse", () => {
 			{
 				path: ["focus", "layout"],
 				describe: "Show the layout.",
-				params: undefined,
+				params: emptyParams,
 				capabilities: [],
 			},
 			{
 				path: ["focus", "layout", "close"],
 				describe: "Close the layout view.",
-				params: undefined,
+				params: emptyParams,
 				capabilities: [],
 			},
 		]);

--- a/apps/tuval/src/commands/parse/spell-index.ts
+++ b/apps/tuval/src/commands/parse/spell-index.ts
@@ -8,8 +8,9 @@
  * founder's 2026-09-03 walk on #7639). A `RegistryTable` would carry richer types and the page
  * cannot hold one: it has descriptions, never the spells' closures.
  *
- * `SpellDescription.params` is `Schema.Unknown` on the wire, and what actually arrives is the
- * spell's `params` as JSON Schema. Two properties of that rendering are load-bearing and both were
+ * `SpellDescription.params` is a `JsonSchemaDocument` on the wire: the spell's `params` as the
+ * JSON Schema document `Schema.toJsonSchemaDocument` emits. Two properties of that rendering are
+ * load-bearing and both were
  * read off `Schema.toJsonSchemaDocument` at the `catalogs.tuval` pin (effect 4.0.0-rc.112): the
  * `properties` object's key order is the declaration order of `Schema.Struct`, which is the
  * positional order of the parameters, and a `Schema.Literals` parameter arrives as
@@ -89,7 +90,10 @@ const followRef = (schema: Record<string, unknown> | undefined, params: unknown)
 };
 
 export const readParams = (params: unknown): ReadonlyArray<ParamSpec> => {
-	const root = asRecord(asRecord(params)?.schema) ?? asRecord(params);
+	// Only the document's own `schema`, never a bare JSON Schema object: `SpellDescription.params`
+	// is a `JsonSchemaDocument` and the bare form is refused at decode (#7758). The argument stays
+	// `unknown` so an undecoded row still reads as no parameters rather than throwing.
+	const root = asRecord(asRecord(params)?.schema);
 	const schema = followRef(root, params);
 	const properties = asRecord(schema?.properties);
 	if (properties === undefined) return [];

--- a/apps/tuval/src/commands/parse/spell-index.unit.test.ts
+++ b/apps/tuval/src/commands/parse/spell-index.unit.test.ts
@@ -1,5 +1,6 @@
 import {Schema} from "effect";
 import {describe, expect, it} from "vitest";
+import {emptyParams} from "../../protocol/fixtures.ts";
 import {registry} from "./fixtures.ts";
 import {buildSpellIndex, describeExpected, readParams} from "./spell-index.ts";
 
@@ -58,6 +59,9 @@ describe("readParams", () => {
 		expect(readParams(undefined)).toEqual([]);
 		expect(readParams("not a schema")).toEqual([]);
 		expect(readParams({schema: {type: "object"}})).toEqual([]);
+		// The bare JSON Schema object the wire type refuses (#7758): the reader no longer reads it
+		// as a root, so the drift it used to hide cannot come back through here.
+		expect(readParams({type: "object", properties: {name: {type: "string"}}})).toEqual([]);
 		// A ref into definitions that hold nothing of that name stays total.
 		expect(readParams({schema: {$ref: "#/$defs/Missing"}, definitions: {}})).toEqual([]);
 	});
@@ -86,8 +90,8 @@ describe("buildSpellIndex", () => {
 
 	it("drops a row whose path decode would have refused, staying total", () => {
 		const index = buildSpellIndex([
-			{path: [], describe: "unreachable", params: undefined, capabilities: []},
-			{path: ["ok"], describe: "reachable", params: undefined, capabilities: []},
+			{path: [], describe: "unreachable", params: emptyParams, capabilities: []},
+			{path: ["ok"], describe: "reachable", params: emptyParams, capabilities: []},
 		]);
 		expect(index.spells.map((spell) => spell.path)).toEqual([["ok"]]);
 	});

--- a/apps/tuval/src/palette/fixtures.ts
+++ b/apps/tuval/src/palette/fixtures.ts
@@ -9,6 +9,7 @@
 import {jsonSchema} from "../commands/parse/fixtures.ts";
 import {buildSpellIndex, type SpellIndex} from "../commands/parse/spell-index.ts";
 import {ProcessId, ProgramId, WindowId, WorkspaceId} from "../protocol/ids.ts";
+import type {JsonSchemaDocument} from "../protocol/json-schema-document.ts";
 import {PROTOCOL_VERSION, Snapshot} from "../protocol/messages.ts";
 import type {ProcessRow} from "../protocol/process-row.ts";
 import type {RegistryDescription, SpellDescription} from "../protocol/registry-description.ts";
@@ -19,7 +20,7 @@ const direction = {type: "string", enum: ["left", "right", "up", "down"]} as con
 const spell = (
 	path: ReadonlyArray<string>,
 	describe: string,
-	params: unknown,
+	params: JsonSchemaDocument,
 ): SpellDescription => ({path, describe, params, capabilities: []});
 
 export const descriptions: RegistryDescription = [

--- a/apps/tuval/src/protocol/fixtures.ts
+++ b/apps/tuval/src/protocol/fixtures.ts
@@ -1,6 +1,14 @@
-/** One of each message, valid, for the tests to encode, decode and patch. */
+/**
+ * One of each message, valid, for the tests to encode, decode and patch.
+ *
+ * `spellDescription.params` is written at the shape `Schema.toJsonSchemaDocument` emits, because
+ * that is the only shape `SpellDescription` decodes; `registry-description.unit.test.ts` pins it
+ * against the real renderer.
+ */
 
+import {Schema} from "effect";
 import {CallId, ProcessId, ProgramId, WindowId, WorkspaceId} from "./ids.ts";
+import type {JsonSchemaDocument} from "./json-schema-document.ts";
 import {
 	Patch,
 	PROTOCOL_VERSION,
@@ -11,6 +19,13 @@ import {
 } from "./messages.ts";
 import type {ProcessRow} from "./process-row.ts";
 import type {SpellDescription} from "./registry-description.ts";
+
+/**
+ * The document a parameterless spell renders to, for a row that needs one and means nothing by it.
+ * Rendered rather than written out: `Schema.Struct({})` emits an `anyOf`, not the `type: "object"`
+ * a guess reaches for.
+ */
+export const emptyParams: JsonSchemaDocument = Schema.toJsonSchemaDocument(Schema.Struct({}));
 
 export const workspace = WorkspaceId.make("ws-1");
 export const leftWindow = WindowId.make("w-1");
@@ -29,7 +44,16 @@ export const counterRow: ProcessRow = {
 export const spellDescription: SpellDescription = {
 	path: ["window", "split"],
 	describe: "Split the focused window.",
-	params: {type: "object", properties: {orientation: {type: "string"}}},
+	params: {
+		dialect: "draft-2020-12",
+		schema: {
+			type: "object",
+			properties: {orientation: {type: "string"}},
+			required: ["orientation"],
+			additionalProperties: false,
+		},
+		definitions: {},
+	},
 	capabilities: [{family: "process-control"}],
 };
 

--- a/apps/tuval/src/protocol/index.ts
+++ b/apps/tuval/src/protocol/index.ts
@@ -26,6 +26,7 @@ export {
 	WorkspaceId,
 } from "./ids.ts";
 export {describeSchemaError, firstSchemaIssue, type SchemaIssueSummary} from "./issue.ts";
+export {JsonSchemaDocument, JsonSchemaNode} from "./json-schema-document.ts";
 export {
 	isSpellReply,
 	KernelToPage,

--- a/apps/tuval/src/protocol/json-schema-document.ts
+++ b/apps/tuval/src/protocol/json-schema-document.ts
@@ -1,0 +1,25 @@
+/**
+ * The JSON Schema document a rendered parameter schema rides in.
+ *
+ * This mirrors `JsonSchema.Document<"draft-2020-12">` at the `catalogs.tuval` pin (effect
+ * 4.0.0-rc.112, `dist/JsonSchema.d.ts`): `{dialect, schema, definitions}`, the root schema held
+ * apart from the definitions it points into with `#/$defs/<name>`. It is declared here rather than
+ * imported as a schema because effect exports `Document` as a type only — there is no `Schema` for
+ * it — and the wire needs one that decodes.
+ *
+ * The inner nodes stay open (`Record(String, Unknown)`): the protocol decides that a document
+ * arrived, not which JSON Schema keywords it used.
+ */
+
+import {Schema} from "effect";
+
+/** One JSON Schema node — an open record, as `JsonSchema.JsonSchema` is at the pin. */
+export const JsonSchemaNode = Schema.Record(Schema.String, Schema.Unknown);
+export type JsonSchemaNode = typeof JsonSchemaNode.Type;
+
+export const JsonSchemaDocument = Schema.Struct({
+	dialect: Schema.Literal("draft-2020-12"),
+	schema: JsonSchemaNode,
+	definitions: Schema.Record(Schema.String, JsonSchemaNode),
+});
+export type JsonSchemaDocument = typeof JsonSchemaDocument.Type;

--- a/apps/tuval/src/protocol/protocol.unit.test.ts
+++ b/apps/tuval/src/protocol/protocol.unit.test.ts
@@ -208,7 +208,11 @@ describe("Snapshot.registry", () => {
 		{
 			path: ["help"],
 			describe: "Show what a spell does.",
-			params: {type: "object", properties: {path: {type: "array"}}},
+			params: {
+				dialect: "draft-2020-12",
+				schema: {type: "object", properties: {path: {type: "array"}}, required: ["path"]},
+				definitions: {},
+			},
 			capabilities: [],
 		},
 		fixtures.spellDescription,

--- a/apps/tuval/src/protocol/registry-description.ts
+++ b/apps/tuval/src/protocol/registry-description.ts
@@ -4,8 +4,9 @@
  * The registry itself (#7636) is a sibling of this module and the founder's 2026-09-03 walk on
  * #7637 keeps the two independent — they meet only in the executor (#7638) — so the description is
  * declared here structurally rather than imported. `params` is the spell's own parameter schema
- * rendered as JSON Schema: the page completes and validates against it without holding the schema
- * value, and the executor still decodes the real arguments against the spell's `params`.
+ * rendered as the JSON Schema document `Schema.toJsonSchemaDocument` emits (`JsonSchemaDocument`):
+ * the page completes and validates against it without holding the schema value, and the executor
+ * still decodes the real arguments against the spell's `params`.
  *
  * `capabilities` mirrors the kernel's inert `CapabilityRequest` record (`src/registry/program.ts`):
  * requested is all it is, nothing grants or denies it (#7617 R1.6).
@@ -13,6 +14,7 @@
 
 import {Schema} from "effect";
 import {SpellPath} from "./ids.ts";
+import {JsonSchemaDocument} from "./json-schema-document.ts";
 
 export const CapabilityFamily = Schema.Literals([
 	"filesystem",
@@ -34,8 +36,7 @@ export const SpellDescription = Schema.Struct({
 	path: SpellPath,
 	/** One sentence, user-facing twice: the palette's inline description and `help` (#7617 R2.1). */
 	describe: Schema.String,
-	/** The spell's `params` as JSON Schema. */
-	params: Schema.Unknown,
+	params: JsonSchemaDocument,
 	capabilities: Schema.Array(CapabilityRequest),
 });
 export type SpellDescription = typeof SpellDescription.Type;

--- a/apps/tuval/src/protocol/registry-description.unit.test.ts
+++ b/apps/tuval/src/protocol/registry-description.unit.test.ts
@@ -1,0 +1,50 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Schema} from "effect";
+import {SpellDescription} from "./registry-description.ts";
+
+const decode = Schema.decodeUnknownSync(SpellDescription);
+
+const row = (params: unknown) => ({
+	path: ["window", "split"],
+	describe: "Split the focused window.",
+	params,
+	capabilities: [],
+});
+
+describe("SpellDescription.params", () => {
+	// The type is only worth what the real renderer emits, so it is pinned against that rather than
+	// against a hand-written document that could drift with the pin.
+	it("decodes what Schema.toJsonSchemaDocument emits", () => {
+		const params = Schema.toJsonSchemaDocument(
+			Schema.Struct({
+				orientation: Schema.Literals(["row", "column"]),
+				ratio: Schema.optionalKey(Schema.String),
+			}),
+		);
+		assert.deepStrictEqual(decode(row(params)).params, params);
+	});
+
+	it("decodes a document whose root is a $ref into its definitions", () => {
+		class SplitArgs extends Schema.Class<SplitArgs>("SplitArgs")({
+			orientation: Schema.String,
+		}) {}
+		const params = Schema.toJsonSchemaDocument(SplitArgs);
+		assert.isString((params.schema as {$ref?: unknown}).$ref);
+		assert.deepStrictEqual(decode(row(params)).params, params);
+	});
+
+	// The shape this issue exists for: a bare JSON Schema object is what a fixture reaches for and
+	// what the kernel never emits, so the wire type has to refuse it rather than let a reader paper
+	// over it (#7758).
+	it("refuses a bare JSON Schema object", () => {
+		assert.throws(() => decode(row({type: "object", properties: {orientation: {type: "string"}}})));
+	});
+
+	it("refuses a document tagged with another dialect", () => {
+		assert.throws(() => decode(row({dialect: "draft-07", schema: {}, definitions: {}})));
+	});
+
+	it("refuses a document missing its definitions", () => {
+		assert.throws(() => decode(row({dialect: "draft-2020-12", schema: {}})));
+	});
+});


### PR DESCRIPTION
`SpellDescription.params` was `Schema.Unknown`, so nothing on the wire decided what shape a spell's
rendered parameter schema arrives in. The kernel emits the full document
(`Schema.toJsonSchemaDocument` → `{dialect, schema, definitions}`), but `apps/tuval/src/protocol/fixtures.ts`
carried a bare `{type: "object", properties: {...}}`, and `readParams` accepted both — so no test
could see the drift.

This declares `JsonSchemaDocument` in `apps/tuval/src/protocol/json-schema-document.ts`, mirroring
effect's `JsonSchema.Document<"draft-2020-12">` at the `catalogs.tuval` pin (rc.112,
`dist/JsonSchema.d.ts`), and types `params` with it. The inner nodes stay open records: the protocol
decides that a document arrived, not which JSON Schema keywords it used.

- `apps/tuval/src/protocol/fixtures.ts` now carries the document shape, as does the hand-written row
  in `protocol.unit.test.ts`. The other fixture sets (`commands/parse`, `palette`) already did; their
  `params` parameters are now typed rather than `unknown`, so a bare object cannot come back.
- `apps/tuval/src/protocol/registry-description.unit.test.ts` is new: it decodes what
  `Schema.toJsonSchemaDocument` really emits (both a plain struct and a `Schema.Class` whose root is
  a `$ref`), and proves the bare-object form, a foreign dialect, and a missing `definitions` are all
  refused.
- `readParams` in `commands/parse/spell-index.ts` drops its bare-object fallback. The argument stays
  `unknown` and the reader stays total — an undecoded row still reads as no parameters — but it no
  longer accepts a shape the wire type refuses, which was the thing hiding the drift. Its existing
  tests pass unchanged, plus one new case pinning the removed fallback.
- `emptyParams` (a fixture for rows that need a document and mean nothing by it) lives in
  `protocol/fixtures.ts` and is rendered, not written out: `Schema.Struct({})` emits
  `{anyOf: [{type: "object"}, {type: "array"}]}`, not the `type: "object"` a guess reaches for.

`pnpm typecheck` and `pnpm lint` are clean; all 1042 tuval tests pass.

Fixes #7758

## Deviations

- **Out-of-scope change** — **Said:** the criteria name `protocol/fixtures.ts` and
  `commands/parse/fixtures.ts` as the two fixture sets. **Did:** also touched
  `palette/fixtures.ts`, `parse.unit.test.ts` and `protocol.unit.test.ts`. **Why:** they build
  `SpellDescription` rows too, so typing `params` breaks them at compile time — `palette/fixtures.ts`
  and `parse.unit.test.ts` needed typed helpers, and `protocol.unit.test.ts` carried the second
  bare-object row. **Disposition:** stated here; each is a shape fix, nothing else changed.
