### PR TITLE
fix: A Tuval binding refusal prints the same word twice: expected X, did you mean X

### DIFF
--- a/apps/tuval/src/commands/parse/parse.unit.test.ts
+++ b/apps/tuval/src/commands/parse/parse.unit.test.ts
@@ -1,11 +1,31 @@
 import {describe, expect, it} from "vitest";
 import {complete} from "./complete.ts";
 import {didYouMean} from "./did-you-mean.ts";
-import {registry, snapshot} from "./fixtures.ts";
+import {jsonSchema, registry, snapshot} from "./fixtures.ts";
 import {parse} from "./parse.ts";
 import {buildSpellIndex} from "./spell-index.ts";
 
 const run = (input: string) => parse(input, registry, snapshot);
+
+/**
+ * One spell, reached through a node with a single child, taking a parameter with a single literal
+ * beside one with two. It is the shape where a suggestion can only repeat the expectation, on both
+ * the segment path and the literal path, with the two-literal parameter as the control.
+ */
+const solo = buildSpellIndex([
+	{
+		path: ["alpha", "sey"],
+		describe: "Say something.",
+		params: jsonSchema(
+			{
+				mode: {type: "string", enum: ["wide"]},
+				size: {type: "string", enum: ["small", "large"]},
+			},
+			["mode"],
+		),
+		capabilities: [],
+	},
+]);
 
 describe("parse", () => {
 	it("completes a spell that takes no arguments", () => {
@@ -65,6 +85,30 @@ describe("parse", () => {
 			position: 0,
 			expected: "window|workspace|process|wizard-inspect",
 			didYouMean: "window",
+		});
+	});
+
+	it("drops a suggestion that only repeats the expectation, on both paths that can produce one", () => {
+		// One candidate makes the expectation and the nearest match the same string, so the line
+		// would read `expected sey; did you mean "sey"?` — a refusal for the word it just asked for.
+		expect(parse("alpah sey", solo, snapshot)).toEqual({
+			_tag: "Refused",
+			position: 0,
+			expected: "alpha",
+		});
+		expect(parse("alpha sey wode", solo, snapshot)).toEqual({
+			_tag: "Refused",
+			position: 10,
+			expected: "wide",
+		});
+	});
+
+	it("keeps a literal's suggestion when it says something the expectation does not", () => {
+		expect(parse("alpha sey wide size=smoll", solo, snapshot)).toEqual({
+			_tag: "Refused",
+			position: 15,
+			expected: "small|large",
+			didYouMean: "small",
 		});
 	});
 

--- a/apps/tuval/src/commands/parse/reading.ts
+++ b/apps/tuval/src/commands/parse/reading.ts
@@ -59,12 +59,20 @@ export interface Reading {
 const describeSegments = (segments: ReadonlyArray<string>): string =>
 	segments.length === 0 || segments.length > 6 ? "<segment>" : segments.join("|");
 
+/**
+ * A suggestion equal to the expectation is dropped here, where the two are computed, rather than at
+ * each surface that renders them. With one candidate — a node with a single child, a parameter with
+ * a single literal — the expectation and the nearest match are the same string, and the line reads
+ * `expected sey; did you mean "sey"?`: the reader is refused for the word they were just asked for,
+ * and the distinction the two fields carry (what shape belongs here, versus a guess at the typo) is
+ * erased (#7745).
+ */
 const refused = (
 	position: number,
 	expected: string,
 	suggestion?: string,
 ): Extract<ReadingCore, {kind: "Refused"}> =>
-	suggestion === undefined
+	suggestion === undefined || suggestion === expected
 		? {kind: "Refused", position, expected}
 		: {kind: "Refused", position, expected, didYouMean: suggestion};
 

--- a/apps/tuval/src/reload-proof.unit.test.ts
+++ b/apps/tuval/src/reload-proof.unit.test.ts
@@ -137,7 +137,7 @@ describe("a config reload", () => {
 	);
 
 	it.live(
-		"reports the binding that stopped compiling with all five of its parts, and keeps the rest",
+		"reports the binding that stopped compiling, pointing at the segment that went away, and keeps the rest",
 		() =>
 			run(
 				Effect.gen(function* () {
@@ -152,11 +152,13 @@ describe("a config reload", () => {
 					assert.strictEqual(broken?.file, "global config-fixtures/reloadable.ts");
 					assert.isTrue((broken?.position ?? -1) >= 0, "the error points at no position");
 					assert.isTrue((broken?.expected ?? "").length > 0, "the error expects nothing");
-					assert.strictEqual(broken?.didYouMean, "sey");
+					// `alpha` has exactly one child after the rename, so the nearest match to `say` is the
+					// expectation itself and the hint is dropped rather than repeating it (#7745).
+					assert.isUndefined(broken?.didYouMean, "the hint repeated the expectation");
 					assert.strictEqual(
 						broken?.message,
-						'global config-fixtures/reloadable.ts: cannot bind "ctrl-a": at character 6, expected sey; did you mean "sey"?',
-						"the five parts did not render in order",
+						'global config-fixtures/reloadable.ts: cannot bind "ctrl-a": at character 6, expected sey',
+						"the parts did not render in order",
 					);
 					assert.notInclude(
 						broken?.message ?? "",


### PR DESCRIPTION
Fixes #7745

A Tuval binding refusal could print the same word twice — `expected sey; did you mean "sey"?` —
reading as if the config author typed exactly the right thing and was refused for it.

The collision happens whenever there is exactly one candidate: `describeSegments` joins a node's
child names with `|` and `describeExpected` joins a parameter's literals the same way, so with one
of either the join *is* that name, and `didYouMean` over the same list returns it too.

The fix drops the suggestion in `refused()` in `apps/tuval/src/commands/parse/reading.ts` — the one
helper all four refusal sites hand both fields to. That covers the single-child segment path and
both single-literal parameter paths (the committed-token branch and the `pending` branch) in one
edit, and it keeps the invariant where the two values are computed rather than at each surface that
renders them, so the redundant pair never reaches a `BindingError`, the palette, or a future reader.

`reload-proof.unit.test.ts` pinned the doubled line and now pins the de-duplicated one. Two tests
were added to `parse.unit.test.ts`: one covering both collision paths, and one control where the
suggestion genuinely differs from the expectation and the hint survives. Both new assertions were
checked to fail against the old `refused()` and pass against the new one, so the change is provably
not a blanket drop of the hint.

`pnpm typecheck`, `pnpm lint` and the full Tuval unit suite (1039 tests) are green.

## Deviations

- **Declined guidance** — **Said:** the issue argues render-side (`BindingError.message`) is one
  edit while producer-side needs three call sites touched. **Did:** fixed producer-side in one edit,
  in the `refused()` helper. **Why:** `refused()` is the single funnel all four `reading.ts` refusal
  sites already pass both fields through, so the three-call-site cost the issue priced in does not
  exist; fixing it there also removes the redundant `didYouMean` from the data rather than only from
  one renderer, which the palette and `parse`'s own `Refused` result both read.
  **Disposition:** stated here; the issue's criteria pin the outcome, not the site, and every one
  is met.
