### PR TITLE
fix(tuval): the page stays Node-free, with the kernel ShellDispatch moved out of its tag's module (#7910)

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -551,11 +551,15 @@ reads their name, sentence and argument kind off that list rather than re-typing
 `shellSpells` wraps each row as a spell whose `execute` builds the Msg and hands it to
 `ShellDispatch`, an interface this slice declares — the same shape `WindowIndex` takes above.
 `AnySpell` erases that requirement, so the composition root that builds the registry owes the
-service, and [`boot.ts`](../apps/tuval/src/boot.ts) pays it: `ShellDispatch.kernel(shellId)` sits in
-the same merge as `SpellBridge`, finds the live process of the shell's program row through
+service, and [`boot.ts`](../apps/tuval/src/boot.ts) pays it: `shellDispatchKernel(shellId)`
+([`shell/commands/kernel.ts`](../apps/tuval/src/shell/commands/kernel.ts)) sits in the same merge
+as `SpellBridge`, finds the live process of the shell's program row through
 `ProcessTable` per dispatch, and puts the Msg on it. `Kernel` names `ShellDispatch` and `Context` is
 contravariant in its services, so dropping that layer stops `start` compiling rather than leaving a
-defect for the first caller.
+defect for the first caller. The layer lives in its own module rather than beside the tag because
+`dispatch.ts` is on the page's import path and the process table reads `node:crypto` at load; the
+page's boundary test walks the runtime import graph from `src/page/main.tsx` and refuses any
+`node:` specifier, so the split is proven rather than remembered (#7910).
 
 `dispatch` fails typed rather than dying, because a desk is a process: a config that registers the
 shell row but plans no node for it answers `NoDesk`, and a desk that stopped mid-call answers the

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -24,7 +24,8 @@ import {ProcessTable} from "./process/ProcessTable.ts";
 import type {ProcessHandle} from "./process/process.ts";
 import type {AnyProgram} from "./registry/program.ts";
 import {Registry} from "./registry/Registry.ts";
-import {ShellDispatch} from "./shell/commands/dispatch.ts";
+import type {ShellDispatch} from "./shell/commands/dispatch.ts";
+import {shellDispatchKernel} from "./shell/commands/kernel.ts";
 import {shellId} from "./shell/program.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 
@@ -50,7 +51,7 @@ export type Kernel =
 	| SpellExecutor
 	| SpellBridge
 	// Naming it here is what makes the provider load-bearing to the checker: `Context` is
-	// contravariant in its services, so dropping `ShellDispatch.kernel` below stops `start`'s
+	// contravariant in its services, so dropping `shellDispatchKernel` below stops `start`'s
 	// answer from satisfying `Started` rather than leaving a defect for the first caller (#7774).
 	| ShellDispatch;
 
@@ -107,7 +108,7 @@ export const start = Effect.fn("Tuval.start")(function* ({
 		// registry erases that requirement, so the composition root is where it is owed (#7774).
 		// The desk stays a program row like any other: a config that registers no shell row leaves
 		// this dispatcher with no process to find, which is a `NoDesk` refusal, not a failed boot.
-		ShellDispatch.kernel(shellId),
+		shellDispatchKernel(shellId),
 	).pipe(
 		Layer.provideMerge(SpellExecutor.layer),
 		Layer.provideMerge(

--- a/apps/tuval/src/commands/executor.ts
+++ b/apps/tuval/src/commands/executor.ts
@@ -8,7 +8,7 @@
  * `AnySpell` erases each spell's requirements, so nothing checks that the runtime carries what a
  * registered spell needs — the composition root that builds the registry owes those services, and
  * the single conversion in `runSpell` is where that obligation is spent. `src/boot.ts` is that
- * root and discharges it there: `WindowIndex` and `ShellDispatch.kernel` are built into the same
+ * root and discharges it there: `WindowIndex` and `shellDispatchKernel` are built into the same
  * `Kernel` context a caller runs a spell under, and `Kernel` names both, so a dropped provider is
  * a compile error at `start` rather than a defect at the first call (#7774).
  */

--- a/apps/tuval/src/page/boundary.unit.test.ts
+++ b/apps/tuval/src/page/boundary.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The page is Node-free, proven by walking its runtime import graph. Vite externalizes a `node:`
+ * module in client code and the first property read throws at load, so a kernel-side layer placed
+ * beside a tag the page reaches blanks the whole desk with green CI behind it (#7910: `Processes`
+ * reached `src/shell/commands/dispatch.ts` through `shell/ui/CommandLine.tsx`). Walking the graph from
+ * the entry names the offending chain rather than the symptom.
+ *
+ * Only runtime edges count: an `import type` is erased by the bundler and reaches nothing.
+ */
+
+import {existsSync, readFileSync} from "node:fs";
+import {builtinModules} from "node:module";
+import {dirname, join, relative, resolve} from "node:path";
+import {describe, expect, it} from "vitest";
+
+const ENTRY = resolve(import.meta.dirname, "main.tsx");
+const SRC = resolve(import.meta.dirname, "..");
+const BUILTINS = new Set(builtinModules);
+
+const stripComments = (text: string): string =>
+	text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+/** Every runtime specifier a module imports: `import x from`, `import "side-effect"`, `export … from`. */
+const specifiersOf = (file: string): ReadonlyArray<string> => {
+	const code = stripComments(readFileSync(file, "utf8"));
+	const found: Array<string> = [];
+	for (const match of code.matchAll(/^\s*(import|export)\s+([\s\S]*?)from\s+["']([^"']+)["']/gm)) {
+		if (/^type\s/.test(match[2] ?? "")) continue;
+		found.push(match[3] as string);
+	}
+	for (const match of code.matchAll(/^\s*import\s+["']([^"']+)["']/gm))
+		found.push(match[1] as string);
+	return found;
+};
+
+const resolveRelative = (from: string, specifier: string): string | undefined => {
+	const base = resolve(dirname(from), specifier);
+	for (const candidate of [base, `${base}.ts`, `${base}.tsx`, join(base, "index.ts")]) {
+		if (existsSync(candidate) && !candidate.endsWith(".css")) return candidate;
+	}
+	return undefined;
+};
+
+const isNodeOnly = (specifier: string): boolean =>
+	specifier.startsWith("node:") || BUILTINS.has(specifier);
+
+/** Depth-first over relative imports, recording each `node:` edge with the chain that reached it. */
+const walk = (): {
+	readonly modules: ReadonlyArray<string>;
+	readonly leaks: ReadonlyArray<string>;
+} => {
+	const seen = new Set<string>();
+	const leaks: Array<string> = [];
+	const visit = (file: string, chain: ReadonlyArray<string>): void => {
+		if (seen.has(file)) return;
+		seen.add(file);
+		const here = [...chain, relative(SRC, file)];
+		for (const specifier of specifiersOf(file)) {
+			if (isNodeOnly(specifier)) {
+				leaks.push(`${here.join(" -> ")} -> ${specifier}`);
+				continue;
+			}
+			if (!specifier.startsWith(".")) continue;
+			const next = resolveRelative(file, specifier);
+			if (next !== undefined) visit(next, here);
+		}
+	};
+	visit(ENTRY, []);
+	return {modules: [...seen].map((file) => relative(SRC, file)), leaks};
+};
+
+describe("the page's import graph", () => {
+	const graph = walk();
+
+	it("reaches the shell, so the walk is not vacuous", () => {
+		expect(graph.modules.length).toBeGreaterThan(20);
+		expect(graph.modules).toEqual(
+			expect.arrayContaining(["shell/commands/index.ts", "shell/commands/dispatch.ts"]),
+		);
+	});
+
+	it("never reaches a Node-only module", () => {
+		expect(graph.leaks).toEqual([]);
+	});
+
+	it("reads runtime edges only: an import type is not an edge", () => {
+		// Flip-verified: `commands/kernel.ts` reads the process table, so a walk that counted its
+		// runtime edge from a page module would list it; the page reaches no such edge.
+		expect(graph.modules).not.toContain("shell/commands/kernel.ts");
+		expect(graph.modules).not.toContain("process/Processes.ts");
+	});
+});

--- a/apps/tuval/src/page/boundary.unit.test.ts
+++ b/apps/tuval/src/page/boundary.unit.test.ts
@@ -84,9 +84,11 @@ describe("the page's import graph", () => {
 	});
 
 	it("reads runtime edges only: an import type is not an edge", () => {
-		// Flip-verified: `commands/kernel.ts` reads the process table, so a walk that counted its
-		// runtime edge from a page module would list it; the page reaches no such edge.
+		// `shell/commands/dispatch.ts` is in the graph and type-imports `process/errors.ts`; a walk
+		// that counted that edge would list the target. Flip-verified by dropping the `type` test in
+		// `specifiersOf`: the module appears and this fails.
+		expect(graph.modules).toContain("shell/commands/dispatch.ts");
+		expect(graph.modules).not.toContain("process/errors.ts");
 		expect(graph.modules).not.toContain("shell/commands/kernel.ts");
-		expect(graph.modules).not.toContain("process/Processes.ts");
 	});
 });

--- a/apps/tuval/src/shell/commands/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/commands/boundary.unit.test.ts
@@ -74,6 +74,7 @@ describe("command row boundary", () => {
 			"dispatch.ts",
 			"errors.ts",
 			"index.ts",
+			"kernel.ts",
 			"line.ts",
 			"row.ts",
 			"spells.ts",

--- a/apps/tuval/src/shell/commands/dispatch.ts
+++ b/apps/tuval/src/shell/commands/dispatch.ts
@@ -3,9 +3,13 @@
  *
  * A row is pure and the registry is program-blind, so neither can hold the running shell process.
  * `ShellDispatch` is the seam between them — declared here and implemented at the composition root
- * by `ShellDispatch.kernel`, which `src/boot.ts` builds into the kernel beside `SpellExecutor`
- * (#7774). It is the same shape `WindowIndex` takes in the framework: an interface one slice
- * declares, another implements, and a `scripted` layer stands in for under test.
+ * by `shellDispatchKernel` (`./kernel.ts`), which `src/boot.ts` builds into the kernel beside
+ * `SpellExecutor` (#7774). It is the same shape `WindowIndex` takes in the framework: an interface
+ * one slice declares, another implements, and a `scripted` layer stands in for under test.
+ *
+ * This module is on the page's import path (`../ui/CommandLine.tsx` reaches it through `./index.ts`), so it holds the tag, the
+ * errors and the scripted stand-in and nothing that touches the process table: the kernel-side
+ * layer lives in `./kernel.ts`, which only `boot.ts` imports (#7910).
  *
  * A desk is a process, so it can be absent — a config that drops the shell row boots without one —
  * or stopped mid-call. `dispatch` therefore fails typed rather than dying, and the executor turns
@@ -13,12 +17,9 @@
  * with a refusal a caller can read, never a defect.
  */
 
-import {Context, Effect, Layer, Option, Schema} from "effect";
+import {Context, Effect, Layer, Schema} from "effect";
 import type {DispatchError} from "../../host/actor.ts";
 import type {HandlerFailed} from "../../process/errors.ts";
-import {Processes} from "../../process/Processes.ts";
-import {ProcessTable} from "../../process/ProcessTable.ts";
-import type {ProgramId} from "../../registry/program.ts";
 import type {ShellMsg} from "../core/machine.ts";
 
 /** No process of the desk's program row is running, so the Msg has nowhere to land. */
@@ -39,35 +40,6 @@ export class ShellDispatch extends Context.Service<
 		readonly dispatch: (msg: ShellMsg) => Effect.Effect<void, ShellDispatchError>;
 	}
 >()("tuval/shell/ShellDispatch") {
-	/**
-	 * The real one: the Msg goes to the live process of the desk's program row.
-	 *
-	 * The row is resolved per dispatch rather than at layer build, because the kernel is built
-	 * before any process exists and a desk can be stopped and spawned again under the same program
-	 * id. `program` is a parameter because `shellId` lives in `../program.ts`, which imports this
-	 * module — boot names it, and a boot whose config registered no shell row answers `NoDesk`.
-	 */
-	static readonly kernel = (
-		program: ProgramId,
-	): Layer.Layer<ShellDispatch, never, Processes | ProcessTable> =>
-		Layer.effect(
-			ShellDispatch,
-			Effect.gen(function* () {
-				const processes = yield* Processes;
-				const table = yield* ProcessTable;
-				return ShellDispatch.of({
-					dispatch: (msg) =>
-						Effect.gen(function* () {
-							const rows = yield* table.list;
-							const row = rows.find((candidate) => candidate.programId === program);
-							const handle = row === undefined ? Option.none() : yield* processes.handle(row.id);
-							if (Option.isNone(handle)) return yield* new NoDesk({program});
-							yield* handle.value.dispatch(msg);
-						}),
-				});
-			}),
-		);
-
 	/**
 	 * A dispatcher that appends to a list. The list is the test's, so a spell run through this layer
 	 * is read by looking at what landed in it rather than at what the spell returned.

--- a/apps/tuval/src/shell/commands/kernel.ts
+++ b/apps/tuval/src/shell/commands/kernel.ts
@@ -16,7 +16,8 @@ import {NoDesk, ShellDispatch} from "./dispatch.ts";
 /**
  * The row is resolved per dispatch rather than at layer build, because the kernel is built before
  * any process exists and a desk can be stopped and spawned again under the same program id.
- * `program` is a parameter because `shellId` lives in `../program.ts`, which the page also reaches — boot names it, and a boot whose config registered no shell row answers `NoDesk`.
+ * `program` is a parameter so this module stays a layer over the process table and nothing else:
+ * boot names the shell row's id, and a boot whose config registered no shell row answers `NoDesk`.
  */
 export const shellDispatchKernel = (
 	program: ProgramId,

--- a/apps/tuval/src/shell/commands/kernel.ts
+++ b/apps/tuval/src/shell/commands/kernel.ts
@@ -1,0 +1,40 @@
+/**
+ * The kernel's `ShellDispatch`: the Msg goes to the live process of the desk's program row.
+ *
+ * Kept apart from `./dispatch.ts` because that module is on the page's import path and this one
+ * reaches the process table, which reads `node:crypto` at load; the page's boundary test
+ * (`src/page/boundary.unit.test.ts`) is what keeps them apart (#7910). Only `src/boot.ts` imports
+ * this.
+ */
+
+import {Effect, Layer, Option} from "effect";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessTable} from "../../process/ProcessTable.ts";
+import type {ProgramId} from "../../registry/program.ts";
+import {NoDesk, ShellDispatch} from "./dispatch.ts";
+
+/**
+ * The row is resolved per dispatch rather than at layer build, because the kernel is built before
+ * any process exists and a desk can be stopped and spawned again under the same program id.
+ * `program` is a parameter because `shellId` lives in `../program.ts`, which the page also reaches — boot names it, and a boot whose config registered no shell row answers `NoDesk`.
+ */
+export const shellDispatchKernel = (
+	program: ProgramId,
+): Layer.Layer<ShellDispatch, never, Processes | ProcessTable> =>
+	Layer.effect(
+		ShellDispatch,
+		Effect.gen(function* () {
+			const processes = yield* Processes;
+			const table = yield* ProcessTable;
+			return ShellDispatch.of({
+				dispatch: (msg) =>
+					Effect.gen(function* () {
+						const rows = yield* table.list;
+						const row = rows.find((candidate) => candidate.programId === program);
+						const handle = row === undefined ? Option.none() : yield* processes.handle(row.id);
+						if (Option.isNone(handle)) return yield* new NoDesk({program});
+						yield* handle.value.dispatch(msg);
+					}),
+			});
+		}),
+	);

--- a/apps/tuval/src/shell/program.ts
+++ b/apps/tuval/src/shell/program.ts
@@ -110,7 +110,7 @@ export interface ShellProgramOptions<E = never, R = never> {
  * `[shellId, ...path]` and reachable through the one registry — the palette, `help`, and an agent's
  * bridge all read the shell's commands there rather than from a second catalogue. Running one needs
  * `ShellDispatch`, which `AnySpell` erases; `src/boot.ts` owes it and pays it with
- * `ShellDispatch.kernel(shellId)`, which finds this row's live process and dispatches into it.
+ * `shellDispatchKernel(shellId)`, which finds this row's live process and dispatches into it.
  */
 export const shellProgram = <E = never, R = never>({
 	table = defaultPrefixTable,


### PR DESCRIPTION
Closes #7910.

## What broke
PR #7895 (for #7774) put `ShellDispatch.kernel` beside the `ShellDispatch` tag in `apps/tuval/src/shell/commands/dispatch.ts`, importing `process/Processes.ts`, which reads `node:crypto` at module top. The page reaches `dispatch.ts` through `shell/ui/CommandLine.tsx` -> `shell/commands/index.ts`, so Vite externalized `node:crypto` and `origin/main` (5a2ffd2fa8) rendered a blank desk with this in the console:

```
Error: Module "node:crypto" has been externalized for browser compatibility. Cannot access "node:crypto.randomUUID" in client code.
    at /src/process/Processes.ts:1:50
```

CI was green because nothing walked the page's import graph.

## What this does
- Moves the kernel-side layer to `shellDispatchKernel` in `apps/tuval/src/shell/commands/kernel.ts`; only `boot.ts` imports it. `dispatch.ts` keeps the tag, `NoDesk`, and `scripted`.
- Adds `apps/tuval/src/page/boundary.unit.test.ts`: walks runtime imports (type-only edges skipped) from `src/page/main.tsx`, refuses any `node:` or Node builtin specifier and prints the chain that reached it. Flip-verified against main's `dispatch.ts`: it reports `page/main.tsx -> shell/ui/index.ts -> shell/ui/CommandLine.tsx -> shell/commands/index.ts -> shell/commands/dispatch.ts -> process/Processes.ts -> node:crypto`.
- Updates the slice's module list in `shell/commands/boundary.unit.test.ts`, the comments that named `ShellDispatch.kernel`, and `.patterns/tuval-spells.md`.

## Proof
- `vitest run` over `src/page`, `src/shell/commands`, `src/shell/proof`, `src/boot.unit.test.ts`: 9 files, 64 tests green. `tsc` clean on both tuval tsconfigs (the 8 pre-existing `packages/design` errors aside). Biome clean.
- Real browser on this head: desk loads with the shell window focused, Cmd+K opens the design palette and Escape closes it, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWpocvhfpBpQL153qLGyks

## Deviations
None.
