### PR TITLE
fix: Tuval's binding refusal points at the first argument token when a nested parameter is at fault

### DIFF
--- a/apps/tuval/src/commands/bindings/compile.ts
+++ b/apps/tuval/src/commands/bindings/compile.ts
@@ -18,7 +18,7 @@
 
 import {Effect, Schema} from "effect";
 import {WorkspaceId} from "../../protocol/ids.ts";
-import {firstSchemaIssue} from "../../protocol/issue.ts";
+import {firstSchemaIssue, parameterOf} from "../../protocol/issue.ts";
 import {PROTOCOL_VERSION, Snapshot} from "../../protocol/messages.ts";
 import {buildSpellIndex, describeExpected, parse, tokenize} from "../parse/index.ts";
 import {describeSpell, lookupRow, type RegistryTable} from "../registry.ts";
@@ -144,7 +144,9 @@ const compileOne = Effect.fn("Tuval.Commands.compileBinding")(function* (
 
 	if (decoded._tag === "Failure") {
 		const {expected, at} = firstSchemaIssue(decoded.failure);
-		return refuse(argumentPosition(command, path, args[at]), expected);
+		// `at` reaches inside the decoded value; `args` is the parser's flat record, one entry per
+		// parameter, so only the parameter the path opens on can be looked up in it.
+		return refuse(argumentPosition(command, path, args[parameterOf(at)]), expected);
 	}
 
 	const binding: Binding = {

--- a/apps/tuval/src/commands/bindings/compile.unit.test.ts
+++ b/apps/tuval/src/commands/bindings/compile.unit.test.ts
@@ -52,6 +52,24 @@ describe("compileBindings", () => {
 		expect(errors[0]?.message).toContain("at character 12");
 	});
 
+	it("points at the nested parameter's own token, not at the first argument", async () => {
+		const command = "window place main 3,wide";
+		const {bindings, errors} = await compile({"ctrl+p": command});
+
+		expect(bindings).toEqual([]);
+		// `at` is `at.row` here and `args` is keyed by the bare `at`: without resolving the path to
+		// its parameter the lookup misses and the caret falls back to `main`, which is fine.
+		expect(errors[0]).toMatchObject({key: "ctrl+p", position: command.indexOf("3,wide")});
+	});
+
+	it("points at the token behind an indexed path segment", async () => {
+		const command = "window fit main 3,wide";
+		const {errors} = await compile({"ctrl+f": command});
+
+		// `sizes[1]` opens on the same parameter name, so `[` ends it exactly as `.` does.
+		expect(errors[0]).toMatchObject({key: "ctrl+f", position: command.indexOf("3,wide")});
+	});
+
 	it("sets `repeat` from the object form and leaves it unset for a bare string", async () => {
 		const {bindings, errors} = await compile({
 			"ctrl+n": {command: "workspace next", repeat: true},

--- a/apps/tuval/src/commands/bindings/fixtures.ts
+++ b/apps/tuval/src/commands/bindings/fixtures.ts
@@ -6,7 +6,7 @@
  * that schema and a description alone cannot prove the decoded value differs from the token text.
  */
 
-import {Effect, Schema} from "effect";
+import {Effect, Schema, SchemaTransformation} from "effect";
 import {buildRegistry, type RegistryTable} from "../registry.ts";
 import {type AnySpell, defineSpell} from "../spell.ts";
 
@@ -23,6 +23,41 @@ const spell = (
 		execute: () => Effect.void,
 		capabilities: [],
 	});
+
+/**
+ * The two spells whose `params` reach past one level. A parameter is always bound to a whole token,
+ * so a nesting only exists where the schema reads a structure out of that token's text: these split
+ * `"3,4"` on the comma, and a bad half then fails at `at.row` or at `sizes[1]` rather than at the
+ * parameter itself. Both separators `renderPath` emits are covered, `.` and `[`.
+ *
+ * Each takes a plain `workspace` first so the nested parameter is never the first argument token:
+ * a lookup that misses falls back to that first token, which would otherwise be the right answer
+ * by accident and grade a broken caret green.
+ */
+const numbers = (text: string): ReadonlyArray<number> => text.split(",").map(Number);
+
+const Point = Schema.String.pipe(
+	Schema.decodeTo(
+		Schema.Struct({column: Schema.Finite, row: Schema.Finite}),
+		SchemaTransformation.transform({
+			decode: (text: string) => {
+				const [column = Number.NaN, row = Number.NaN] = numbers(text);
+				return {column, row};
+			},
+			encode: (point: {column: number; row: number}) => `${point.column},${point.row}`,
+		}),
+	),
+);
+
+const Sizes = Schema.String.pipe(
+	Schema.decodeTo(
+		Schema.Array(Schema.Finite),
+		SchemaTransformation.transform({
+			decode: numbers,
+			encode: (sizes: ReadonlyArray<number>) => sizes.join(","),
+		}),
+	),
+);
 
 export const spells: ReadonlyArray<AnySpell> = [
 	spell(["window", "close"], "Close the focused window.", Schema.Struct({})),
@@ -44,6 +79,16 @@ export const spells: ReadonlyArray<AnySpell> = [
 		Schema.Struct({workspace: Schema.String}),
 	),
 	spell(["workspace", "next"], "Switch to the next workspace.", Schema.Struct({})),
+	spell(
+		["window", "place"],
+		"Move a workspace's focused window to a cell.",
+		Schema.Struct({workspace: Schema.String, at: Point}),
+	),
+	spell(
+		["window", "fit"],
+		"Resize a workspace's focused window.",
+		Schema.Struct({workspace: Schema.String, sizes: Sizes}),
+	),
 ];
 
 export const registry = (only: ReadonlyArray<AnySpell> = spells): Effect.Effect<RegistryTable> =>

--- a/apps/tuval/src/protocol/index.ts
+++ b/apps/tuval/src/protocol/index.ts
@@ -25,7 +25,12 @@ export {
 	WindowId,
 	WorkspaceId,
 } from "./ids.ts";
-export {describeSchemaError, firstSchemaIssue, type SchemaIssueSummary} from "./issue.ts";
+export {
+	describeSchemaError,
+	firstSchemaIssue,
+	parameterOf,
+	type SchemaIssueSummary,
+} from "./issue.ts";
 export {
 	isSpellReply,
 	KernelToPage,

--- a/apps/tuval/src/protocol/issue.ts
+++ b/apps/tuval/src/protocol/issue.ts
@@ -30,6 +30,17 @@ export const firstSchemaIssue = (error: Schema.SchemaError): SchemaIssueSummary 
 	};
 };
 
+/**
+ * The parameter an `at` blames — its leading segment, or `""` when it blames no single one.
+ *
+ * The inverse of `renderPath`, and it lives beside it so the two cannot drift: a caller holding a
+ * flat record keyed by parameter name has to strip the nesting before it can look the value up,
+ * and `renderPath` is the only thing that decides where a name ends. Both separators it can emit
+ * end one — `.` before a key, `[` before an index — and a path opening on `[` names an index
+ * rather than a parameter, so it blames none.
+ */
+export const parameterOf = (at: string): string => at.split(/[.[]/, 1)[0] ?? "";
+
 /** The first issue as one line — what was wrong, and where. A refusal interpolates this. */
 export const describeSchemaError = (error: Schema.SchemaError): string => {
 	const {expected, at} = firstSchemaIssue(error);

--- a/apps/tuval/src/protocol/issue.unit.test.ts
+++ b/apps/tuval/src/protocol/issue.unit.test.ts
@@ -1,0 +1,51 @@
+import {Result, Schema} from "effect";
+import {describe, expect, it} from "vitest";
+import {firstSchemaIssue, parameterOf} from "./issue.ts";
+
+const failureOf = (schema: Schema.Codec<unknown>, value: unknown) => {
+	const decoded = Schema.decodeUnknownResult(schema)(value);
+	if (!Result.isFailure(decoded)) throw new Error("expected the decode to fail");
+	return firstSchemaIssue(decoded.failure);
+};
+
+describe("parameterOf", () => {
+	it("names nothing when the whole value is at fault", () => {
+		expect(parameterOf("")).toBe("");
+	});
+
+	it("returns a single segment unchanged", () => {
+		expect(parameterOf("columns")).toBe("columns");
+	});
+
+	it("ends the name at either separator `renderPath` emits", () => {
+		expect(parameterOf("target.name")).toBe("target");
+		expect(parameterOf("items[0]")).toBe("items");
+		expect(parameterOf("rows[2].cells[1].text")).toBe("rows");
+	});
+
+	it("names nothing when the path opens on an index", () => {
+		expect(parameterOf("[0].name")).toBe("");
+	});
+});
+
+describe("firstSchemaIssue", () => {
+	// `parameterOf` reads what `renderPath` writes, so the two separators are pinned against real
+	// decodes rather than against a hand-written path.
+	it("renders a nested key path its leading parameter can be read back out of", () => {
+		const {at} = failureOf(Schema.Struct({target: Schema.Struct({name: Schema.String})}), {
+			target: {name: 3},
+		});
+
+		expect(at).toBe("target.name");
+		expect(parameterOf(at)).toBe("target");
+	});
+
+	it("renders an indexed path its leading parameter can be read back out of", () => {
+		const {at} = failureOf(Schema.Struct({items: Schema.Array(Schema.Finite)}), {
+			items: [1, "x"],
+		});
+
+		expect(at).toBe("items[1]");
+		expect(parameterOf(at)).toBe("items");
+	});
+});


### PR DESCRIPTION
A binding whose nested parameter fails schema decoding got a caret on the first argument token
instead of on the token that actually carries the bad value.

`compileOne` ends with `args[at]`, where `at` comes from `firstSchemaIssue`. That is a path into the
decoded value, not a parameter name — `renderPath` joins segments as `a.b.c` and renders a numeric
one as `[0]` — while `args` is the parser's flat record, one entry per parameter keyed by the bare
name. So a nested parameter's `target.name` matched no key, the lookup returned `undefined`, and
`argumentPosition` took its documented last resort: the first argument token, with nothing in the
message saying the position was a fallback.

The fix is `parameterOf` in `apps/tuval/src/protocol/issue.ts` — the leading segment of a rendered
path. It lives beside the `renderPath` that writes that grammar, because `renderPath` is the only
thing that decides where a name ends and a reader living anywhere else would drift from it. It ends
the name at either separator, and names nothing for an empty path or one opening on an index, so the
first-token fallback stays exactly where it was on both.

Two fixture spells exercise it: `window place <workspace> <at>` splits `"3,4"` into
`{column, row}`, and `window fit <workspace> <sizes>` into an array of numbers, covering `.` and `[`
respectively. Each takes a plain `workspace` first on purpose — with the nested parameter as the
only argument, the missed lookup's fallback lands on the right token by accident and grades a broken
caret green. That is not hypothetical: the first version of these tests passed against the unfixed
code. Against the old code they now fail at 13 and 11 where the fix gives 18 and 16.

The existing flat-parameter test (`window grow wide`, position 12) is unchanged, and `parameterOf`'s
own unit tests pin the empty path, a single segment, both separators, and a path opening on an index
against real decodes rather than hand-written strings.

`pnpm typecheck` is clean and the Tuval unit suite is green at 1031 tests.

## Deviations

- **Known defect left unfixed** — **Said:** #7763 names `apps/tuval/src/commands/bindings/compile.ts`
  and its token-pointing logic. **Did:** left the same class of bug in
  `apps/tuval/src/shell/commands/line.ts`, which does `args[parameters.indexOf(at)]` and falls back
  to `input.length`, so a nested parameter puts its caret past the end of the typed line.
  **Why:** it is a second file with its own refusal message that also interpolates the raw path as a
  parameter name, and deciding that copy question needs acceptance criteria this issue does not
  carry. **Disposition:** filed as #7913, which names `parameterOf` as the ready-made fix for its
  position lookup.

Fixes #7763
