### PR TITLE
chore: Tuval declares SpellPath twice with incompatible types and bridges them with a cast

### DIFF
--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -206,12 +206,6 @@ const argumentsFor = (
 	return args;
 };
 
-const asPath = (segments: ReadonlyArray<string>): SpellPath => {
-	const [head, ...rest] = segments;
-	assert.isDefined(head, "a description with an empty path");
-	return [head ?? "", ...rest];
-};
-
 /**
  * One call, encoded to JSON, decoded by the kernel, answered, encoded back and decoded by the
  * caller. A refusal on either codec is a bug in this proof rather than an answer the agent could
@@ -270,7 +264,7 @@ const script = Effect.fn("agentProof.script")(function* () {
 	}
 
 	for (const description of described) {
-		const path = asPath(description.path);
+		const path = description.path;
 		const reply = yield* call(path, argumentsFor(description, learned, firstPath));
 		// `process spawn` is the one call whose answer another call needs, and it is registered
 		// ahead of `process send` and `process read`, so the id is learned before they are reached.
@@ -488,7 +482,7 @@ const planStep: ScriptedPlan = (answered) => {
 	}
 	const target = listed[rest.length - listed.length];
 	if (target === undefined) return null;
-	return {path: asPath(target.path), args: argumentsFor(target, learnedFrom(answered), firstPath)};
+	return {path: target.path, args: argumentsFor(target, learnedFrom(answered), firstPath)};
 };
 
 /** The events reach the transcript through a Sub, so the tail settles after `dispatch` returns. */

--- a/apps/tuval/src/commands/executor.ts
+++ b/apps/tuval/src/commands/executor.ts
@@ -70,9 +70,7 @@ const isNamed = (value: unknown): value is NamedError =>
  * reply's tag is an error object and no reply can carry a tag naming nothing in the tree.
  */
 const named = (call: SpellCall, error: unknown): NamedError =>
-	isNamed(error)
-		? error
-		: new SpellFailed({path: renderPath(call.path as SpellPath), original: error});
+	isNamed(error) ? error : new SpellFailed({path: renderPath(call.path), original: error});
 
 const messageOf = (error: NamedError): string =>
 	typeof error.message === "string" && error.message.length > 0
@@ -168,8 +166,7 @@ const make = Effect.fn("Tuval.SpellExecutor.make")(function* () {
 		client: Client,
 	) {
 		const attempt = Effect.gen(function* () {
-			// The wire schema checks the path is non-empty, so an empty one is unrepresentable here.
-			const row = yield* lookup(call.path as SpellPath);
+			const row = yield* lookup(call.path);
 			const args = yield* decodeArgs(row, call);
 			const scope = yield* resolveScope(call, client);
 			const value = yield* runSpell(row, args, scope);

--- a/apps/tuval/src/commands/executor.unit.test.ts
+++ b/apps/tuval/src/commands/executor.unit.test.ts
@@ -1,7 +1,7 @@
 import {Effect, Layer, Schema} from "effect";
 import {describe, expect, expectTypeOf, it} from "vitest";
 import {ProcessId} from "../process/process.ts";
-import {CallId} from "../protocol/ids.ts";
+import {CallId, type SpellPath} from "../protocol/ids.ts";
 import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../protocol/messages.ts";
 import {SpellFailed} from "./errors.ts";
 import {SpellExecutor} from "./executor.ts";
@@ -98,7 +98,7 @@ const layer = SpellExecutor.layer.pipe(
 );
 
 const call = (fields: {
-	readonly path: ReadonlyArray<string>;
+	readonly path: SpellPath;
 	readonly args: unknown;
 	readonly window?: WindowId;
 }): SpellCall =>

--- a/apps/tuval/src/commands/parse/fixtures.ts
+++ b/apps/tuval/src/commands/parse/fixtures.ts
@@ -6,7 +6,7 @@
  * against a real `Schema.Struct` so this hand-written form cannot quietly drift from it.
  */
 
-import {ProcessId, ProgramId, WindowId, WorkspaceId} from "../../protocol/ids.ts";
+import {ProcessId, ProgramId, type SpellPath, WindowId, WorkspaceId} from "../../protocol/ids.ts";
 import {PROTOCOL_VERSION, Snapshot} from "../../protocol/messages.ts";
 import type {ProcessRow} from "../../protocol/process-row.ts";
 import type {RegistryDescription, SpellDescription} from "../../protocol/registry-description.ts";
@@ -29,11 +29,12 @@ export const jsonSchema = (
 const text: Property = {type: "string"};
 const direction: Property = {type: "string", enum: ["left", "right", "up", "down"]};
 
-const spell = (
-	path: ReadonlyArray<string>,
-	describe: string,
-	params: unknown,
-): SpellDescription => ({path, describe, params, capabilities: []});
+const spell = (path: SpellPath, describe: string, params: unknown): SpellDescription => ({
+	path,
+	describe,
+	params,
+	capabilities: [],
+});
 
 export const descriptions: RegistryDescription = [
 	spell(["window", "close"], "Close the focused window.", jsonSchema({}, [])),

--- a/apps/tuval/src/commands/parse/property.unit.test.ts
+++ b/apps/tuval/src/commands/parse/property.unit.test.ts
@@ -8,6 +8,7 @@
  */
 
 import {describe, expect, it} from "vitest";
+import type {SpellPath} from "../../protocol/ids.ts";
 import type {RegistryDescription} from "../../protocol/registry-description.ts";
 import {complete} from "./complete.ts";
 import {jsonSchema, snapshot} from "./fixtures.ts";
@@ -43,7 +44,8 @@ const generate = (seed: number): Generated => {
 
 	for (let index = 0; index < 12; index += 1) {
 		const depth = 1 + next(3);
-		const path = Array.from({length: depth}, () => SEGMENTS[next(SEGMENTS.length)]!);
+		const segment = () => SEGMENTS[next(SEGMENTS.length)]!;
+		const path: SpellPath = [segment(), ...Array.from({length: depth - 1}, segment)];
 		const key = path.join("\u0000");
 		// A path that already carries a spell, or that runs through one, would re-address it.
 		if (taken.has(key)) continue;

--- a/apps/tuval/src/commands/parse/spell-index.ts
+++ b/apps/tuval/src/commands/parse/spell-index.ts
@@ -124,11 +124,7 @@ export const buildSpellIndex = (descriptions: RegistryDescription): SpellIndex =
 	const spells: Array<IndexedSpell> = [];
 
 	for (const description of descriptions) {
-		const [head, ...rest] = description.path;
-		// The protocol's `SpellPath` is non-empty by decode, but the type only says `readonly
-		// string[]`, so an undecoded row can still reach here. Dropping it keeps the parser total.
-		if (head === undefined) continue;
-		const path: SpellPath = [head, ...rest];
+		const path: SpellPath = description.path;
 		const spell: IndexedSpell = {
 			path,
 			describe: description.describe,

--- a/apps/tuval/src/commands/parse/spell-index.unit.test.ts
+++ b/apps/tuval/src/commands/parse/spell-index.unit.test.ts
@@ -1,7 +1,7 @@
 import {Schema} from "effect";
 import {describe, expect, it} from "vitest";
 import {registry} from "./fixtures.ts";
-import {buildSpellIndex, describeExpected, readParams} from "./spell-index.ts";
+import {describeExpected, readParams} from "./spell-index.ts";
 
 describe("readParams", () => {
 	// The whole index rests on two properties of the JSON Schema a `SpellDescription` carries, so
@@ -82,13 +82,5 @@ describe("buildSpellIndex", () => {
 		expect([...(window?.children.keys() ?? [])]).toEqual(["close", "move", "focus"]);
 		expect(window?.spell).toBeUndefined();
 		expect(window?.children.get("close")?.spell?.path).toEqual(["window", "close"]);
-	});
-
-	it("drops a row whose path decode would have refused, staying total", () => {
-		const index = buildSpellIndex([
-			{path: [], describe: "unreachable", params: undefined, capabilities: []},
-			{path: ["ok"], describe: "reachable", params: undefined, capabilities: []},
-		]);
-		expect(index.spells.map((spell) => spell.path)).toEqual([["ok"]]);
 	});
 });

--- a/apps/tuval/src/commands/registry.ts
+++ b/apps/tuval/src/commands/registry.ts
@@ -60,14 +60,14 @@ export const lookupRow = (table: RegistryTable, path: SpellPath): SpellRow | und
 
 /** The serializable face of one spell: what a client is told without being handed the closure. */
 export interface SpellDescription {
-	readonly path: ReadonlyArray<string>;
+	readonly path: SpellPath;
 	readonly describe: string;
 	readonly params: JsonSchema.Document<"draft-2020-12">;
 	readonly capabilities: ReadonlyArray<CapabilityRequest>;
 }
 
 export const describeSpell = (row: SpellRow): SpellDescription => ({
-	path: [...row.path],
+	path: row.path,
 	describe: row.spell.describe,
 	params: row.paramsDocument,
 	capabilities: [...row.spell.capabilities],

--- a/apps/tuval/src/palette/fixtures.ts
+++ b/apps/tuval/src/palette/fixtures.ts
@@ -8,7 +8,7 @@
 
 import {jsonSchema} from "../commands/parse/fixtures.ts";
 import {buildSpellIndex, type SpellIndex} from "../commands/parse/spell-index.ts";
-import {ProcessId, ProgramId, WindowId, WorkspaceId} from "../protocol/ids.ts";
+import {ProcessId, ProgramId, type SpellPath, WindowId, WorkspaceId} from "../protocol/ids.ts";
 import {PROTOCOL_VERSION, Snapshot} from "../protocol/messages.ts";
 import type {ProcessRow} from "../protocol/process-row.ts";
 import type {RegistryDescription, SpellDescription} from "../protocol/registry-description.ts";
@@ -16,11 +16,12 @@ import type {RegistryDescription, SpellDescription} from "../protocol/registry-d
 const text = {type: "string"} as const;
 const direction = {type: "string", enum: ["left", "right", "up", "down"]} as const;
 
-const spell = (
-	path: ReadonlyArray<string>,
-	describe: string,
-	params: unknown,
-): SpellDescription => ({path, describe, params, capabilities: []});
+const spell = (path: SpellPath, describe: string, params: unknown): SpellDescription => ({
+	path,
+	describe,
+	params,
+	capabilities: [],
+});
 
 export const descriptions: RegistryDescription = [
 	spell(["window", "close"], "Close the focused window.", jsonSchema({}, [])),

--- a/apps/tuval/src/protocol/ids.ts
+++ b/apps/tuval/src/protocol/ids.ts
@@ -42,5 +42,5 @@ export const Recency = Schema.Number.check(Schema.isUint32());
 export type Recency = typeof Recency.Type;
 
 /** A spell path: at least one segment, lowercase English words the registry keys on. */
-export const SpellPath = Schema.Array(Schema.String).check(Schema.isMinLength(1));
+export const SpellPath = Schema.NonEmptyArray(Schema.String);
 export type SpellPath = typeof SpellPath.Type;

--- a/apps/tuval/src/protocol/protocol.unit.test.ts
+++ b/apps/tuval/src/protocol/protocol.unit.test.ts
@@ -159,6 +159,14 @@ describe("refusals", () => {
 		}),
 	);
 
+	it.effect("an empty spell path, page to kernel", () =>
+		Effect.gen(function* () {
+			const refusal = yield* refusalOf(decodePageMessage(withField(callBody, "path", [])));
+			assert.strictEqual(refusal.direction, "page-to-kernel");
+			assert.include(refusal.reason, "path");
+		}),
+	);
+
 	it.effect("a missing field, kernel to page", () =>
 		Effect.gen(function* () {
 			const {ok: _ok, ...withoutOk} = replyBody;

--- a/apps/tuval/src/shell/commands/spells.unit.test.ts
+++ b/apps/tuval/src/shell/commands/spells.unit.test.ts
@@ -10,7 +10,7 @@ import {SpellExecutor} from "../../commands/executor.ts";
 import {buildRegistry, SpellRegistry} from "../../commands/registry.ts";
 import {type Client, WindowIndex} from "../../commands/scope.ts";
 import {ClientId, WorkspaceId} from "../../commands/spell.ts";
-import {CallId} from "../../protocol/ids.ts";
+import {CallId, type SpellPath} from "../../protocol/ids.ts";
 import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../../protocol/messages.ts";
 import type {ShellMsg} from "../core/machine.ts";
 import {ShellDispatch} from "./dispatch.ts";
@@ -20,7 +20,7 @@ import {shellCommands} from "./table.ts";
 
 const client: Client = {id: ClientId.make("cli"), workspace: WorkspaceId.make("ws-1")};
 
-const call = (path: ReadonlyArray<string>, args: unknown): SpellCall =>
+const call = (path: SpellPath, args: unknown): SpellCall =>
 	new SpellCall({
 		type: "spell.call",
 		version: PROTOCOL_VERSION,
@@ -39,7 +39,7 @@ const layerFor = (dispatched: Array<ShellMsg>) =>
 
 /** Run one call against the shell's spells alone, collecting whatever it dispatched. */
 const run = async (
-	path: ReadonlyArray<string>,
+	path: SpellPath,
 	args: unknown,
 ): Promise<{readonly reply: SpellReply; readonly dispatched: ReadonlyArray<ShellMsg>}> => {
 	const dispatched: Array<ShellMsg> = [];


### PR DESCRIPTION
Fixes #7759

`SpellPath` was declared twice with two different types: a non-empty tuple in
`apps/tuval/src/commands/spell.ts`, and `Schema.Array(Schema.String).check(isMinLength(1))`
in `apps/tuval/src/protocol/ids.ts`, whose `.Type` is a plain `readonly string[]`. The
decode refused an empty path but the type it produced did not carry that, so every
consumer re-asserted the fact by hand.

The protocol declaration is now `Schema.NonEmptyArray(Schema.String)`. Grounded in the
`NonEmptyArray` interface in `effect@4.0.0-rc.112`'s `dist/Schema.d.ts` (the
`catalogs.tuval` pin): its `.Type` is `readonly [S["Type"], ...Array<S["Type"]>]`, the
same shape `spell.ts` declares. The two agree, so all three bridges delete rather than
move:

- `executor.ts` — both `as SpellPath` casts gone (the `lookup` call and the `SpellFailed`
  path render), along with the comment that explained the first one.
- `parse/spell-index.ts` — the destructure, the `head === undefined` guard that could not
  fire after a decode, and its comment are gone; the path is `description.path`.
- `commands/agent-proof.unit.test.ts` — the `asPath` assert helper was the same assertion
  a third time and goes with them.

A fourth seam turned up while typechecking: `commands/registry.ts` declared its own
`SpellDescription.path` as `ReadonlyArray<string>` and built it with `[...row.path]`, so
the spread dropped the guarantee one module further on. That interface now takes
`SpellPath` and hands `row.path` straight through.

`protocol.unit.test.ts` gains a refusal case for an empty `path` on a `spell.call`, so
the wire-level refusal stays pinned now that no downstream guard covers it. The
`spell-index` test that asserted the dead guard's behaviour is deleted — an empty path is
no longer constructible there.

Test fixtures and helpers that typed a path as `ReadonlyArray<string>` now type it as
`SpellPath`; the property test's generator draws the head first and the rest after, so the
seeded corpus is unchanged.

`pnpm typecheck` and `pnpm lint` are clean, and all 1063 Tuval unit tests pass at the merged head.

## Deviations

- **Out-of-scope change** — **Said:** #7759 names `ids.ts`, `executor.ts` and
  `spell-index.ts`. **Did:** also changed `commands/registry.ts`'s own `SpellDescription`
  and the `asPath` helper in `agent-proof.unit.test.ts`. **Why:** `registry.ts`'s
  `[...row.path]` spread re-widens the path to `readonly string[]`, so the issue's fix does
  not compile without it; `asPath` is the same hand-assertion the issue's criterion 4
  forbids, one file over. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about existing tests beyond
  keeping them passing. **Did:** deleted `spell-index.unit.test.ts`'s "drops a row whose
  path decode would have refused" case, and retyped path parameters in five fixtures and
  test helpers. **Why:** the deleted case constructs `{path: []}`, which criterion 3 makes
  unrepresentable; the retyped helpers took `ReadonlyArray<string>` only because the
  protocol type was wide. The wire-level refusal it stood in for is now covered directly in
  `protocol.unit.test.ts`. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** the entry above disclosed deleting
  the `spell-index` dead-guard case against the branch point. **Did:** merged `main` in to
  clear a conflict and carried that deletion forward against main's live copy of the case,
  dropping the `emptyParams` import it orphaned. **Why:** `epic/7627` landed on `main` and
  moved the tuval fixtures on, so the branch went conflicting; main still carries a case
  building a `{path: []}` row, which criterion 3 makes unrepresentable. The two fixture
  conflicts kept both sides — main's `JsonSchemaDocument` typing of `params`, this
  branch's `SpellPath` typing of `path`. **Disposition:** stated here.
