### PR TITLE
fix: Tuval's SpellBridge allowlist is fixed at boot and goes stale on a config reload

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -76,7 +76,7 @@ stores that, because one table holds spells of every shape.
 The `capabilities` list reuses the kernel's `CapabilityRequest` record from
 [`registry/program.ts`](../apps/tuval/src/registry/program.ts). Nothing grants it, nothing checks
 it, nothing denies it. It is not a security boundary. The only thing standing between a calling
-program and the registry today is the bridge's allowlist, and that list is whatever the caller
+program and the registry today is the bridge's allowance, and that allowance is whatever the caller
 passed to `SpellBridge.layer({allow})`, not a check the kernel makes.
 
 ## A program declares its spells
@@ -230,8 +230,8 @@ which compiles the bindings against the table it is about to store:
 | `SpellSet.reload(input)` | a fresh table from new program rows, fresh bindings, installed in one write |
 | `SpellRegistry.swap(table)` | the narrower entry, which recompiles the bindings rather than leaving them behind, holding the cell across the compile so a concurrent reload cannot land inside it |
 
-`everyPath(table)` is the whole registry as an allowlist, which is what `src/boot.ts` passes the
-bridge today.
+`everyRegistered` is the whole registry as an allowance, which is what `src/boot.ts` passes the
+bridge today — a rule the bridge re-reads per call, so the reload below moves it too.
 
 Boot joins the set, the executor, the bridge and `SpawnedProcesses` to the kernel's layers
 (`start` in [`boot.ts`](../apps/tuval/src/boot.ts)), reports the spell count beside the program
@@ -376,20 +376,23 @@ spells as one list.
 `list` and `call`, and neither mentions a program. An agent program's SDK tool is a wrapper over it,
 so a second agent program costs an adapter and no new spell.
 
-`call(path, args, scope)` refuses a path outside the allowlist with `SpellNotAllowed`
+`call(path, args, scope)` refuses a path outside the allowance with `SpellNotAllowed`
 ([`bridge/errors.ts`](../apps/tuval/src/commands/bridge/errors.ts)) before the executor is reached.
-`SpellBridge.layer({allow})` takes that allowlist from whoever builds the layer, and no program
-row's field is wired into it: `src/boot.ts` passes `everyPath` over the table as it stands at boot,
-and `bridge/bridge.unit.test.ts` passes its own. What makes the file program-blind is that no
+`SpellBridge.layer({allow})` takes that allowance from whoever builds the layer, and no program
+row's field is wired into it. A `SpellAllowance` is a rule and never a snapshot, which is what keeps
+`list` and `call` answering from one config: `everyRegistered` is re-read from the registry on every
+call, so a reload moves both halves together, and `onlyPaths([…])` names constants the caller wrote
+down, which nothing can make stale. `src/boot.ts` passes `everyRegistered`;
+`bridge/bridge.unit.test.ts` passes its own paths, and
+[`bridge/allowlist-reload.unit.test.ts`](../apps/tuval/src/commands/bridge/allowlist-reload.unit.test.ts)
+reloads through the real `SpellSet` in both directions. What makes the file program-blind is that no
 program id is written in it. The intent recorded in the module's own docblock is that a calling
-program's registry row will supply the list, and that wiring is a later child's. Because the layer
-captures the list at build, a config reload leaves it behind while the registry moves on —
-[#7743](https://github.com/kamp-us/phoenix/issues/7743) is filed on that.
+program's registry row will supply the allowance, and that wiring is a later child's.
 
 `call` puts only the scope's window on the wire, so the executor re-resolves the process exactly as
 it does for a page.
 
-`SpellBridge.scripted(table)` answers from a fixed table and runs nothing, so it has no allowlist to
+`SpellBridge.scripted(table)` answers from a fixed table and runs nothing, so it has no allowance to
 enforce.
 
 An AI agent process reaches the bridge through its `TuvalAiAgent` layer, which is where a real

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -2,7 +2,7 @@ import {homedir} from "node:os";
 import {join} from "node:path";
 import {Context, Effect, type FileSystem, Layer} from "effect";
 import type {BindingError, BindingSource} from "./commands/bindings/index.ts";
-import {SpellBridge} from "./commands/bridge/index.ts";
+import {everyRegistered, SpellBridge} from "./commands/bridge/index.ts";
 import {helpSpells} from "./commands/core/index.ts";
 import {processSpells, SpawnedProcesses} from "./commands/core/process.ts";
 import type {DuplicateSpellPath, SpellNotDescribable} from "./commands/errors.ts";
@@ -10,7 +10,7 @@ import {SpellExecutor} from "./commands/executor.ts";
 import type {SpellRegistry} from "./commands/registry.ts";
 import {WindowIndex} from "./commands/scope.ts";
 import type {AnySpell} from "./commands/spell.ts";
-import {everyPath, SpellSet} from "./commands/spell-set.ts";
+import {SpellSet} from "./commands/spell-set.ts";
 import {type ConfigLoadError, loadLayeredConfig} from "./config.ts";
 import {Checkpoints} from "./durability/Checkpoints.ts";
 import {restore} from "./durability/restore.ts";
@@ -96,12 +96,10 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	const compiled = yield* compile(graph).pipe(Effect.provideContext(registry));
 	const wiring = yield* open(compiled);
 	const spells = yield* Layer.build(SpellSet.layer({core: coreSpells, programs, keys: keys ?? []}));
-	// The bridge's allowlist is whoever builds the layer's, and no program row supplies one yet
-	// (`.patterns/tuval-spells.md`, "The bridge"), so boot allows the whole registry as it stands.
-	// A reload does not revisit it — #7743.
-	const {table} = yield* Context.get(spells, SpellSet).read;
+	// No program row supplies an allowance yet (`.patterns/tuval-spells.md`, "The bridge"), so boot
+	// allows the whole registry — as a rule the bridge re-reads, so a reload moves it (#7743).
 	const commands = Layer.mergeAll(
-		SpellBridge.layer({allow: everyPath(table)}),
+		SpellBridge.layer({allow: everyRegistered}),
 		SpawnedProcesses.layer({readTimeout: READ_TIMEOUT}),
 		// Every shell command row is registered as a spell whose `execute` needs this, and the
 		// registry erases that requirement, so the composition root is where it is owed (#7774).

--- a/apps/tuval/src/claude/tools/bridge.unit.test.ts
+++ b/apps/tuval/src/claude/tools/bridge.unit.test.ts
@@ -19,7 +19,7 @@ import {defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
 import {Context, Effect, Layer, Option} from "effect";
 import {coreSpells} from "../../boot.ts";
-import {SpellBridge} from "../../commands/bridge/index.ts";
+import {onlyPaths, SpellBridge} from "../../commands/bridge/index.ts";
 import {SpawnedProcesses} from "../../commands/core/process.ts";
 import {SpellExecutor} from "../../commands/executor.ts";
 import {type Client, WindowIndex, type WindowPlacement} from "../../commands/scope.ts";
@@ -138,7 +138,7 @@ const rows: ReadonlyArray<AnyProgram> = [callerProgram(), echoProgram()];
 
 /** The layer set boot builds, over in-memory checkpoints and these two rows. */
 const kernel = Layer.mergeAll(
-	SpellBridge.layer({allow}),
+	SpellBridge.layer({allow: onlyPaths(allow)}),
 	SpawnedProcesses.layer({readTimeout: "1 second"}),
 ).pipe(
 	Layer.provideMerge(SpellExecutor.layer),

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -49,7 +49,7 @@ import {
 import {RegistryDescription, type SpellDescription} from "../protocol/registry-description.ts";
 import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
-import {SpellBridge, type SpellBridgeApi} from "./bridge/index.ts";
+import {everyRegistered, SpellBridge, type SpellBridgeApi} from "./bridge/index.ts";
 import {HelpRows} from "./core/help.ts";
 import {SpawnedProcesses} from "./core/process.ts";
 import {SpellExecutor} from "./executor.ts";
@@ -547,10 +547,7 @@ const runServiceAgent = Effect.gen(function* () {
 	return yield* Effect.gen(function* () {
 		const processes = yield* Processes;
 		const rowsInRegistry = yield* SpellRegistry.use((registry) => registry.list);
-		const bridge = yield* Effect.provide(
-			SpellBridge,
-			SpellBridge.layer({allow: rowsInRegistry.map((row) => row.path)}),
-		);
+		const bridge = yield* Effect.provide(SpellBridge, SpellBridge.layer({allow: everyRegistered}));
 		yield* Deferred.succeed(latch, bridge);
 		const agent = yield* processes.spawn(serviceAgentId, {
 			id: serviceProcess,

--- a/apps/tuval/src/commands/bridge/SpellBridge.ts
+++ b/apps/tuval/src/commands/bridge/SpellBridge.ts
@@ -4,8 +4,13 @@
  * `list` and `call` are the whole surface, and neither mentions a program: the Claude program's
  * `KernelBridge` (#7620) is a wrapper over this, and a second agent program costs an adapter and
  * no new spell (founder's walk on #7642, 2026-09-03). What makes it program-blind is where the
- * allowlist comes from — the calling program's own registry row supplies it at layer build, so no
- * program id is written in this directory.
+ * allowlist comes from — the calling program's own registry row supplies it, so no program id is
+ * written in this directory.
+ *
+ * The allowance is a rule, never a snapshot: `call` resolves it at the moment of the call, so a
+ * config reload that moves the registry moves what the bridge allows with it. Holding a list read
+ * out of the live registry at layer build is what let `list` and `call` answer from two eras of one
+ * config (#7743).
  *
  * `call` takes the caller's `Scope` and puts only its window on the wire: the executor re-resolves
  * the process from that window through `WindowIndex`, exactly as it does for a page, so a caller
@@ -28,14 +33,35 @@ export interface ScriptedCall {
 	readonly answer: unknown;
 }
 
+/**
+ * What `call` may reach. Both arms are rules rather than lists the layer holds: `every-registered`
+ * is re-read from the registry on each call, and `paths` names constants the caller wrote down, so
+ * neither can be a stale reading of state that has since moved.
+ */
+export type SpellAllowance =
+	| {readonly kind: "every-registered"}
+	| {readonly kind: "paths"; readonly paths: ReadonlyArray<SpellPath>};
+
+/** Whatever the registry holds when the call is made — a reload moves `list` and `call` together. */
+export const everyRegistered: SpellAllowance = {kind: "every-registered"};
+
+/** Exactly these paths, whatever the registry holds. */
+export const onlyPaths = (paths: ReadonlyArray<SpellPath>): SpellAllowance => ({
+	kind: "paths",
+	paths,
+});
+
 const clientOf = (scope: Scope): Client => ({id: scope.client, workspace: scope.workspace});
 
 const make = Effect.fn("Tuval.SpellBridge.make")(function* (options: {
-	readonly allow: ReadonlyArray<SpellPath>;
+	readonly allow: SpellAllowance;
 }) {
 	const executor = yield* SpellExecutor;
 	const registry = yield* SpellRegistry;
-	const allowed = new Set(options.allow.map(renderPath));
+	const allowed: Effect.Effect<ReadonlySet<string>> =
+		options.allow.kind === "paths"
+			? Effect.succeed(new Set(options.allow.paths.map(renderPath)))
+			: Effect.map(registry.list, (rows) => new Set(rows.map((row) => renderPath(row.path))));
 
 	const call = Effect.fn("Tuval.SpellBridge.call")(function* (
 		path: SpellPath,
@@ -44,7 +70,7 @@ const make = Effect.fn("Tuval.SpellBridge.make")(function* (options: {
 	) {
 		const rendered = renderPath(path);
 		// Refused before the executor is reached, so a path outside the allowlist never runs.
-		if (!allowed.has(rendered)) return yield* new SpellNotAllowed({path: rendered});
+		if (!(yield* allowed).has(rendered)) return yield* new SpellNotAllowed({path: rendered});
 		const reply = yield* executor.execute(
 			new SpellCall({
 				type: "spell.call",
@@ -77,7 +103,7 @@ export class SpellBridge extends Context.Service<SpellBridge, SpellBridgeApi>()(
 	"tuval/SpellBridge",
 ) {
 	static readonly layer = (options: {
-		readonly allow: ReadonlyArray<SpellPath>;
+		readonly allow: SpellAllowance;
 	}): Layer.Layer<SpellBridge, never, SpellExecutor | SpellRegistry> =>
 		Layer.effect(SpellBridge, make(options));
 

--- a/apps/tuval/src/commands/bridge/allowlist-reload.unit.test.ts
+++ b/apps/tuval/src/commands/bridge/allowlist-reload.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The allowlist across a config reload (#7743): the bridge is built once and the registry moves
+ * under it, so what `call` allows has to be read at the call and not held from layer build.
+ *
+ * Both directions reload through the real `SpellSet`, which is the only way the proof is about the
+ * bridge: rebuilding the layer would pass whatever the layer captured.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schema} from "effect";
+import {SpellExecutor} from "../executor.ts";
+import {type Client, WindowIndex, type WindowPlacement} from "../scope.ts";
+import {ClientId, defineSpell, type Scope, WindowId, WorkspaceId} from "../spell.ts";
+import {SpellSet, type SpellSetInput} from "../spell-set.ts";
+import {SpellNotAllowed} from "./errors.ts";
+import {everyRegistered, SpellBridge} from "./SpellBridge.ts";
+
+const workspace = WorkspaceId.make("ws-1");
+const agentWindow = WindowId.make("w-1");
+const client: Client = {id: ClientId.make("agent"), workspace};
+const scope: Scope = {window: agentWindow, workspace, client: client.id};
+
+const placements: Readonly<Record<string, WindowPlacement>> = {
+	[agentWindow]: {workspace},
+};
+
+/** How many times the reloaded spell ran — the only way to prove a refusal did not execute it. */
+const runs = {reloaded: 0};
+
+const baseSpell = defineSpell({
+	path: ["window", "close"],
+	describe: "Close the named window.",
+	params: Schema.Struct({}),
+	result: Schema.Boolean,
+	execute: () => Effect.succeed(true),
+	capabilities: [],
+});
+
+const reloadedSpell = defineSpell({
+	path: ["workspace", "wipe"],
+	describe: "Delete the workspace.",
+	params: Schema.Struct({}),
+	result: Schema.Boolean,
+	execute: () =>
+		Effect.sync(() => {
+			runs.reloaded++;
+			return true;
+		}),
+	capabilities: [],
+});
+
+const withSpells = (core: SpellSetInput["core"]) =>
+	SpellBridge.layer({allow: everyRegistered}).pipe(
+		Layer.provideMerge(SpellExecutor.layer),
+		Layer.provideMerge(
+			Layer.mergeAll(
+				SpellSet.layer({core, programs: [], keys: []}),
+				WindowIndex.scripted(placements),
+			),
+		),
+		Layer.orDie,
+	);
+
+describe("SpellBridge allowlist over a reload", () => {
+	it.effect("a spell the reloaded config adds reaches the executor", () =>
+		Effect.gen(function* () {
+			runs.reloaded = 0;
+			const bridge = yield* SpellBridge;
+			const set = yield* SpellSet;
+			const before = yield* Effect.flip(bridge.call(reloadedSpell.path, {}, scope));
+			assert.instanceOf(before, SpellNotAllowed);
+			yield* set
+				.reload({core: [baseSpell, reloadedSpell], programs: [], keys: []})
+				.pipe(Effect.orDie);
+			assert.strictEqual(yield* bridge.call(reloadedSpell.path, {}, scope), true);
+			assert.strictEqual(runs.reloaded, 1);
+		}).pipe(Effect.provide(withSpells([baseSpell]))),
+	);
+
+	it.effect("a spell the reloaded config removes is refused at the gate, not by the registry", () =>
+		Effect.gen(function* () {
+			runs.reloaded = 0;
+			const bridge = yield* SpellBridge;
+			const set = yield* SpellSet;
+			assert.strictEqual(yield* bridge.call(reloadedSpell.path, {}, scope), true);
+			yield* set.reload({core: [baseSpell], programs: [], keys: []}).pipe(Effect.orDie);
+			const refused = yield* Effect.flip(bridge.call(reloadedSpell.path, {}, scope));
+			assert.instanceOf(refused, SpellNotAllowed);
+			assert.include((refused as SpellNotAllowed).message, "workspace.wipe");
+			assert.strictEqual(runs.reloaded, 1);
+		}).pipe(Effect.provide(withSpells([baseSpell, reloadedSpell]))),
+	);
+
+	it.effect("what the bridge lists is what it allows, on both sides of a reload", () =>
+		Effect.gen(function* () {
+			const bridge = yield* SpellBridge;
+			const set = yield* SpellSet;
+			assert.deepStrictEqual(
+				(yield* bridge.list).map((row) => row.path),
+				[["window", "close"]],
+			);
+			yield* set
+				.reload({core: [baseSpell, reloadedSpell], programs: [], keys: []})
+				.pipe(Effect.orDie);
+			assert.deepStrictEqual(
+				(yield* bridge.list).map((row) => row.path),
+				[
+					["window", "close"],
+					["workspace", "wipe"],
+				],
+			);
+		}).pipe(Effect.provide(withSpells([baseSpell]))),
+	);
+});

--- a/apps/tuval/src/commands/bridge/bridge.unit.test.ts
+++ b/apps/tuval/src/commands/bridge/bridge.unit.test.ts
@@ -5,7 +5,7 @@ import {SpellRegistry} from "../registry.ts";
 import {type Client, WindowIndex, type WindowPlacement} from "../scope.ts";
 import {type AnySpell, ClientId, defineSpell, type Scope, WindowId, WorkspaceId} from "../spell.ts";
 import {SpellNotAllowed} from "./errors.ts";
-import {SpellBridge} from "./SpellBridge.ts";
+import {onlyPaths, SpellBridge} from "./SpellBridge.ts";
 
 const workspace = WorkspaceId.make("ws-1");
 const agentWindow = WindowId.make("w-1");
@@ -49,7 +49,7 @@ const spells: ReadonlyArray<AnySpell> = [allowedSpell, forbiddenSpell];
 
 const registry = SpellRegistry.scripted(spells);
 
-const app = SpellBridge.layer({allow: [allowedSpell.path]}).pipe(
+const app = SpellBridge.layer({allow: onlyPaths([allowedSpell.path])}).pipe(
 	Layer.provideMerge(
 		Layer.mergeAll(
 			SpellExecutor.layer.pipe(

--- a/apps/tuval/src/commands/bridge/index.ts
+++ b/apps/tuval/src/commands/bridge/index.ts
@@ -1,2 +1,9 @@
 export {SpellNotAllowed} from "./errors.ts";
-export {type ScriptedCall, SpellBridge, type SpellBridgeApi} from "./SpellBridge.ts";
+export {
+	everyRegistered,
+	onlyPaths,
+	type ScriptedCall,
+	type SpellAllowance,
+	SpellBridge,
+	type SpellBridgeApi,
+} from "./SpellBridge.ts";

--- a/apps/tuval/src/commands/spell-set.ts
+++ b/apps/tuval/src/commands/spell-set.ts
@@ -23,7 +23,7 @@ import {
 	type RegistryTable,
 	SpellRegistry,
 } from "./registry.ts";
-import {type AnySpell, renderPath, type SpellPath} from "./spell.ts";
+import {type AnySpell, renderPath} from "./spell.ts";
 
 /** What one config produces: the spells its programs declare, and the keys they are bound to. */
 export interface SpellSetInput {
@@ -128,7 +128,3 @@ export class SpellSet extends Context.Service<
 	): Layer.Layer<SpellSet | SpellRegistry, DuplicateSpellPath | SpellNotDescribable> =>
 		Layer.effectContext(make(input));
 }
-
-/** Every registered path, which is what a caller allowed the whole registry passes the bridge. */
-export const everyPath = (table: RegistryTable): ReadonlyArray<SpellPath> =>
-	table.rows.map((row) => row.path);


### PR DESCRIPTION
`SpellBridge.layer({allow})` built its allowlist into a `Set` once, at layer build, while the same
bridge's `list` delegated straight to `SpellRegistry.describe` — a read of the live cell. After a
`SpellSet.reload`, `list` and `call` therefore answered from two different eras of one config: a
spell the new config added was listed and callable through the executor but refused by the bridge
with `SpellNotAllowed`, and a spell it removed stayed allowed.

The fix makes the allowance a rule the call resolves rather than a list the layer holds. `allow` is
now a `SpellAllowance` with two arms:

- `everyRegistered` — whatever the registry holds at the moment of the call, read through the same
  `SpellRegistry` the bridge's `list` reads, so a reload moves both halves together.
- `onlyPaths([…])` — exactly these paths, constants the caller wrote down, which nothing can make
  stale.

`src/boot.ts` passes `everyRegistered` and no longer reads the table before building the layer.
`everyPath` in `spell-set.ts` existed only to make that snapshot, so it goes with it. The three
existing call sites move over: the two bridge tests to `onlyPaths`, and `agent-proof`'s
`SpellBridge.layer({allow: rowsInRegistry.map(…)})` — the same snapshot shape — to `everyRegistered`.

`bridge/allowlist-reload.unit.test.ts` is the new proof. Both directions reload through the real
`SpellSet` rather than rebuilding the layer, which is what makes the test about the bridge: an add
that was refused before the reload reaches the executor after it, and a removal is refused at the
gate (`SpellNotAllowed`, not `SpellNotFound`) with the spell's run counter proving it never ran.
`SpellBridge.scripted` is untouched — it enforces no allowance by construction — and its test is
unchanged.

`.patterns/tuval-spells.md` "The bridge" now describes the allowance as a rule and no longer names
this issue as an open gap.

Full `apps/tuval` suite: 1061 tests, 131 files, all passing. `pnpm typecheck --force` and
`pnpm lint:worktree` green in this tree.

Fixes #7743

## Deviations

- **Out-of-scope change** — **Said:** #7743 names the bridge, `boot.ts` and the pattern doc.
  **Did:** also deleted `everyPath` from `apps/tuval/src/commands/spell-set.ts`. **Why:** its only
  caller was the boot snapshot this PR removes, and it is the exported helper whose whole job was
  reading the live table into a fixed list — leaving it invites the same bug back. **Disposition:**
  stated here.
- **Out-of-scope change** — **Said:** the criteria name a test in `bridge/` and leave the other
  call sites alone. **Did:** changed `apps/tuval/src/commands/agent-proof.unit.test.ts` and
  `apps/tuval/src/claude/tools/bridge.unit.test.ts`. **Why:** widening `allow` to `SpellAllowance`
  is a type change every call site has to follow; `agent-proof`'s was itself a snapshot of
  `registry.list` and became `everyRegistered`. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about the docblock's intent line. **Did:** left
  "the calling program's own registry row supplies it" in place. **Why:** wiring the allowance to a
  program row is shape 2 in the issue body, explicitly the larger change and a later child's; this
  PR closes the staleness without pre-empting it. **Disposition:** stated here.
