### PR TITLE
chore: Tuval hand-rolls a record predicate in four modules under two clashing definitions, against the effect pin's own guidance

### DIFF
--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -8,6 +8,7 @@
  * beside it would be a second source that drifts. Composing the port predicates keeps one.
  */
 
+import {Predicate} from "effect";
 import {
 	isPermissionRequest,
 	isTranscriptItems,
@@ -16,9 +17,6 @@ import {
 } from "../ports/index.ts";
 import {type AiAgentSessionState, type HistoryPage, phases, type UsageTotals} from "./state.ts";
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
-
 const isNullOrString = (value: unknown): value is string | null =>
 	value === null || typeof value === "string";
 
@@ -26,37 +24,39 @@ const isFiniteNumber = (value: unknown): value is number =>
 	typeof value === "number" && Number.isFinite(value);
 
 const isUsage = (value: unknown): value is UsageTotals =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	isNullOrString(value.model) &&
 	isFiniteNumber(value.inputTokens) &&
 	isFiniteNumber(value.outputTokens) &&
 	isFiniteNumber(value.cost);
 
 const isPermissions = (value: unknown): value is Readonly<Record<string, PermissionRequest>> =>
-	isRecord(value) && Object.values(value).every(isPermissionRequest);
+	Predicate.isObject(value) && Object.values(value).every(isPermissionRequest);
 
 const isModes = (value: unknown): boolean =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	isNullOrString(value.current) &&
 	Array.isArray(value.available) &&
 	value.available.every((mode) => typeof mode === "string");
 
 const isTranscript = (value: unknown): boolean =>
-	isRecord(value) && isTranscriptItems(value.items) && isWindowOmission(value.omitted);
+	Predicate.isObject(value) && isTranscriptItems(value.items) && isWindowOmission(value.omitted);
 
 const isPage = (value: unknown): value is HistoryPage | null =>
 	value === null ||
-	(isRecord(value) && isTranscriptItems(value.items) && typeof value.hasMore === "boolean");
+	(Predicate.isObject(value) &&
+		isTranscriptItems(value.items) &&
+		typeof value.hasMore === "boolean");
 
 const isFailure = (value: unknown): boolean =>
 	value === null ||
-	(isRecord(value) &&
+	(Predicate.isObject(value) &&
 		typeof value.tag === "string" &&
 		isNullOrString(value.reason) &&
 		typeof value.detail === "string");
 
 export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionState =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.phase === "string" &&
 	(phases as ReadonlyArray<string>).includes(value.phase) &&
 	isNullOrString(value.sessionId) &&

--- a/apps/tuval/src/ai-agent/ports/payloads.ts
+++ b/apps/tuval/src/ai-agent/ports/payloads.ts
@@ -7,11 +7,10 @@
  * single route between two nodes serves the whole conversation.
  */
 
-import {Schema} from "effect";
+import {Predicate, Schema} from "effect";
 import {
 	isJsonValue,
 	isNonNegativeInteger,
-	isRecord,
 	isTranscriptItems,
 	type JsonValue,
 	type TranscriptItem,
@@ -31,7 +30,7 @@ const reasons: ReadonlySet<string> = new Set<WindowOmission["reason"]>([
 ]);
 
 export const isWindowOmission = (value: unknown): value is WindowOmission =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	isNonNegativeInteger(value.items) &&
 	isNonNegativeInteger(value.bytes) &&
 	typeof value.reason === "string" &&
@@ -44,7 +43,7 @@ export interface TranscriptPayload {
 }
 
 export const isTranscriptPayload = (value: unknown): value is TranscriptPayload =>
-	isRecord(value) && isTranscriptItems(value.items) && isWindowOmission(value.omitted);
+	Predicate.isObject(value) && isTranscriptItems(value.items) && isWindowOmission(value.omitted);
 
 /**
  * `transcript-page` — a request for older history and the page that answers it. `before` is the
@@ -64,7 +63,7 @@ const isCursor = (value: unknown): value is string | null =>
 	value === null || (typeof value === "string" && value.length > 0);
 
 export const isTranscriptPagePayload = (value: unknown): value is TranscriptPagePayload => {
-	if (!isRecord(value)) return false;
+	if (!Predicate.isObject(value)) return false;
 	switch (value.kind) {
 		case "request":
 			return isCursor(value.before) && Number.isInteger(value.limit) && (value.limit as number) > 0;
@@ -88,7 +87,7 @@ export interface PromptPayload {
 }
 
 export const isPromptPayload = (value: unknown): value is PromptPayload =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.text === "string" &&
 	(value.key === undefined || typeof value.key === "string");
 
@@ -125,7 +124,7 @@ export type PermissionPayload =
 	  };
 
 export const isPermissionRequest = (value: unknown): value is PermissionRequest =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.title === "string" &&
 	typeof value.displayName === "string" &&
 	typeof value.description === "string" &&
@@ -133,10 +132,13 @@ export const isPermissionRequest = (value: unknown): value is PermissionRequest 
 	typeof value.offersAlways === "boolean";
 
 export const isPermissionPayload = (value: unknown): value is PermissionPayload => {
-	if (!isRecord(value)) return false;
+	if (!Predicate.isObject(value)) return false;
 	switch (value.kind) {
 		case "pending":
-			return isRecord(value.requests) && Object.values(value.requests).every(isPermissionRequest);
+			return (
+				Predicate.isObject(value.requests) &&
+				Object.values(value.requests).every(isPermissionRequest)
+			);
 		case "decision":
 			return (
 				typeof value.request === "string" &&
@@ -165,7 +167,7 @@ export type ModePayload =
 const isMode = (value: unknown): value is Mode => typeof value === "string" && value.length > 0;
 
 export const isModePayload = (value: unknown): value is ModePayload => {
-	if (!isRecord(value)) return false;
+	if (!Predicate.isObject(value)) return false;
 	switch (value.kind) {
 		case "state":
 			return (

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -6,7 +6,7 @@
  * agent program. `boundary.unit.test.ts` is the proof.
  */
 
-import {Schema} from "effect";
+import {Predicate, Schema} from "effect";
 
 /** A stable per-item identity: an update to a tool row re-sends the same id with a new status. */
 export const ItemId = Schema.String.pipe(Schema.brand("tuval/ai-agent/ItemId"));
@@ -94,16 +94,13 @@ export const boundToolResult = (text: string, limit = TOOL_RESULT_BYTE_LIMIT): T
 	return {text: decoder.decode(bytes.subarray(0, end)), omitted: {bytes: bytes.length - end}};
 };
 
-export const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
-
 export const isJsonValue = (value: unknown): value is JsonValue => {
 	if (value === null) return true;
 	const type = typeof value;
 	if (type === "boolean" || type === "string") return true;
 	if (type === "number") return Number.isFinite(value);
 	if (Array.isArray(value)) return value.every(isJsonValue);
-	return isRecord(value) && Object.values(value).every(isJsonValue);
+	return Predicate.isObject(value) && Object.values(value).every(isJsonValue);
 };
 
 const isId = (value: unknown): value is ItemId => typeof value === "string" && value.length > 0;
@@ -112,9 +109,9 @@ export const isNonNegativeInteger = (value: unknown): boolean =>
 	typeof value === "number" && Number.isInteger(value) && value >= 0;
 
 const isToolResult = (value: unknown): value is ToolResult =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.text === "string" &&
-	isRecord(value.omitted) &&
+	Predicate.isObject(value.omitted) &&
 	isNonNegativeInteger(value.omitted.bytes) &&
 	byteLength(value.text) <= TOOL_RESULT_BYTE_LIMIT;
 
@@ -122,7 +119,8 @@ const statuses: ReadonlySet<string> = new Set<ToolStatus>(["running", "ok", "err
 
 /** The port predicate for one item: identity, clock, kind, and the tool result's own bound. */
 export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
-	if (!isRecord(value) || !isId(value.id) || !Number.isFinite(value.timestamp)) return false;
+	if (!Predicate.isObject(value) || !isId(value.id) || !Number.isFinite(value.timestamp))
+		return false;
 	switch (value.kind) {
 		case "user":
 		case "system":

--- a/apps/tuval/src/claude/history/blocks.ts
+++ b/apps/tuval/src/claude/history/blocks.ts
@@ -14,6 +14,13 @@
 
 import {isJsonValue, type JsonValue} from "../../ai-agent/ports/index.ts";
 
+/**
+ * The one hand-rolled record predicate left under `apps/tuval/src`; every other site reads
+ * `Predicate.isObject` off the `effect` pin, whose guidance bans writing this by hand. This
+ * directory may not import `effect` at all — `boundary.unit.test.ts` enforces it, so the mapping
+ * stays testable without a runtime — so it holds its own copy, defined exactly as
+ * `Predicate.isObject` is: arrays excluded (#7764).
+ */
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 

--- a/apps/tuval/src/commands/executor.ts
+++ b/apps/tuval/src/commands/executor.ts
@@ -13,7 +13,7 @@
  * a compile error at `start` rather than a defect at the first call (#7774).
  */
 
-import {Context, Effect, Layer, Schema} from "effect";
+import {Context, Effect, Layer, Predicate, Schema} from "effect";
 import {firstSchemaIssue} from "../protocol/issue.ts";
 import {
 	PROTOCOL_VERSION,
@@ -62,7 +62,7 @@ const nearestPath = (target: string, rows: ReadonlyArray<SpellRow>): string | un
 type NamedError = {readonly _tag: string; readonly message?: unknown};
 
 const isNamed = (value: unknown): value is NamedError =>
-	typeof value === "object" && value !== null && typeof (value as NamedError)._tag === "string";
+	Predicate.isObject(value) && typeof value._tag === "string";
 
 /**
  * The caught value as an error that names itself. One already carrying a `_tag` is its own;

--- a/apps/tuval/src/commands/parse/spell-index.ts
+++ b/apps/tuval/src/commands/parse/spell-index.ts
@@ -20,6 +20,7 @@
  * are read. Everything else is read defensively — this module is total.
  */
 
+import {Predicate} from "effect";
 import type {RegistryDescription} from "../../protocol/registry-description.ts";
 import type {SpellPath} from "../spell.ts";
 
@@ -52,10 +53,12 @@ export interface SpellIndex {
 export const describeExpected = (param: ParamSpec): string =>
 	param.literals === undefined ? `<${param.name}>` : param.literals.join("|");
 
+/**
+ * A JSON Schema node read as a record, or nothing. `Predicate.isObject` excludes arrays, which is
+ * what every caller here wants: an `enum` array is read as an array, never walked for properties.
+ */
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
-	typeof value === "object" && value !== null && !Array.isArray(value)
-		? (value as Record<string, unknown>)
-		: undefined;
+	Predicate.isObject(value) ? value : undefined;
 
 const stringLiterals = (property: unknown): ReadonlyArray<string> | undefined => {
 	const choices = asRecord(property)?.enum;

--- a/apps/tuval/src/protocol/json.ts
+++ b/apps/tuval/src/protocol/json.ts
@@ -38,6 +38,3 @@ export const stringifyJson = (value: unknown): JsonStringify => {
 		return {_tag: "Failed", reason: (cause as Error).message};
 	}
 };
-
-export const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/tuval/src/protocol/patch.ts
+++ b/apps/tuval/src/protocol/patch.ts
@@ -8,10 +8,9 @@
  * and a page that disagree about the shape should stop, not diverge quietly.
  */
 
-import {Effect, Schema} from "effect";
+import {Effect, Predicate, Schema} from "effect";
 import {PatchRefused, ProtocolRefused} from "./errors.ts";
 import {describeSchemaError} from "./issue.ts";
-import {isRecord} from "./json.ts";
 import type {Patch} from "./messages.ts";
 import {Snapshot} from "./messages.ts";
 
@@ -58,7 +57,7 @@ const replaceAt = (target: unknown, path: ReadonlyArray<string>, value: unknown)
 		next[index] = inner.value;
 		return {ok: true, value: next};
 	}
-	if (!isRecord(target)) return {ok: false, reason: `nothing addressable at "${head}"`};
+	if (!Predicate.isObject(target)) return {ok: false, reason: `nothing addressable at "${head}"`};
 	if (!Object.hasOwn(target, head)) return {ok: false, reason: `no key "${head}" there`};
 	const inner = replaceAt(target[head], rest, value);
 	if (!inner.ok) return inner;
@@ -107,7 +106,7 @@ export const applyPatch = (
 			}
 			current = replaced.value;
 		}
-		const withRevision = isRecord(current) ? {...current, rev: patch.rev} : current;
+		const withRevision = Predicate.isObject(current) ? {...current, rev: patch.rev} : current;
 		return yield* decodeSnapshot(withRevision).pipe(
 			Effect.mapError(
 				(error) =>

--- a/apps/tuval/src/shell/core/state.ts
+++ b/apps/tuval/src/shell/core/state.ts
@@ -13,6 +13,7 @@
  * a restored desk keeps minting where it left off.
  */
 
+import {Predicate} from "effect";
 import {type DeskState, isDeskState} from "../desk/state.ts";
 import {isLayoutTree, type LayoutTree, type WindowId, windows} from "../layout/index.ts";
 import {isViewState, type ViewState} from "../window/host.ts";
@@ -64,11 +65,8 @@ export interface ShellState {
 	readonly nextId: number;
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
-
 export const isPrefixSnapshot = (value: unknown): value is PrefixSnapshot => {
-	if (!isRecord(value)) return false;
+	if (!Predicate.isObject(value)) return false;
 	if (value.armed === false) return true;
 	return (
 		value.armed === true &&
@@ -79,7 +77,7 @@ export const isPrefixSnapshot = (value: unknown): value is PrefixSnapshot => {
 };
 
 export const isWorkspace = (value: unknown): value is Workspace =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.id === "string" &&
 	isLayoutTree(value.layout) &&
 	typeof value.focused === "string";
@@ -95,13 +93,13 @@ export const isWorkspace = (value: unknown): value is Workspace =>
  * answers `undefined` rather than throwing when a desk breaks them.
  */
 export const isShellState = (value: unknown): value is ShellState =>
-	isRecord(value) &&
-	isRecord(value.workspaces) &&
+	Predicate.isObject(value) &&
+	Predicate.isObject(value.workspaces) &&
 	Object.values(value.workspaces).every(isWorkspace) &&
 	Array.isArray(value.order) &&
 	value.order.every((id) => typeof id === "string") &&
 	typeof value.activeWorkspace === "string" &&
-	isRecord(value.views) &&
+	Predicate.isObject(value.views) &&
 	Object.values(value.views).every(isViewState) &&
 	isDeskState(value.desk) &&
 	isPrefixSnapshot(value.prefix) &&

--- a/apps/tuval/src/shell/desk/state.ts
+++ b/apps/tuval/src/shell/desk/state.ts
@@ -11,6 +11,8 @@
 /** One desk-level Msg today. It lands here, beside the state it writes, not in the core's own list. */
 export type DeskMsg = {readonly type: "desk.inspector.toggle"};
 
+import {Predicate} from "effect";
+
 export interface DeskState {
 	readonly inspectorOpen: boolean;
 }
@@ -19,10 +21,7 @@ export interface DeskState {
 export const initialDesk: DeskState = {inspectorOpen: false};
 
 export const isDeskState = (value: unknown): value is DeskState =>
-	typeof value === "object" &&
-	value !== null &&
-	!Array.isArray(value) &&
-	typeof (value as {readonly inspectorOpen?: unknown}).inspectorOpen === "boolean";
+	Predicate.isObject(value) && typeof value.inspectorOpen === "boolean";
 
 /** The whole reducer piece behind `desk.inspector.toggle`. */
 export const toggleInspector = (desk: DeskState): DeskState => ({

--- a/apps/tuval/src/shell/layout/node.ts
+++ b/apps/tuval/src/shell/layout/node.ts
@@ -5,9 +5,12 @@
  * to bottom. Studio inverts this at its render boundary — this port does not, and no orientation
  * flip appears anywhere here (#7551).
  *
- * Ids are plain strings: `Schema.brand` would pull Effect into a module the ticket keeps free of
- * it, and `.glossary/LANGUAGE.md` rejects the hand-rolled phantom-symbol brand as the substitute.
+ * Ids are plain strings: `Schema.brand` would put an Effect type on every id this module hands
+ * out, and `.glossary/LANGUAGE.md` rejects the hand-rolled phantom-symbol brand as the substitute.
+ * The one `effect` import here is `Predicate.isObject`, a pure guard the pin's own guidance says to
+ * use instead of a hand-rolled `isRecord` (#7764); it touches no id and pulls in no runtime.
  */
+import {Predicate} from "effect";
 
 /** A window id. The shell mints it; this module never generates one. */
 export type WindowId = string;
@@ -79,12 +82,9 @@ export function createTree(root: StackNode, zoomed: WindowId | null = null): Lay
 	return {root, zoomed};
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
-
 export function isWindowNode(value: unknown): value is WindowNode {
 	return (
-		isRecord(value) &&
+		Predicate.isObject(value) &&
 		value.tag === "window" &&
 		typeof value.id === "string" &&
 		(value.processId === null || typeof value.processId === "string")
@@ -93,13 +93,13 @@ export function isWindowNode(value: unknown): value is WindowNode {
 
 export function isStackNode(value: unknown): value is StackNode {
 	return (
-		isRecord(value) &&
+		Predicate.isObject(value) &&
 		value.tag === "stack" &&
 		typeof value.id === "string" &&
 		(value.orientation === "horizontal" || value.orientation === "vertical") &&
 		Array.isArray(value.children) &&
 		value.children.every(isLayoutNode) &&
-		isRecord(value.sizes) &&
+		Predicate.isObject(value.sizes) &&
 		Object.values(value.sizes).every((size) => typeof size === "number")
 	);
 }
@@ -117,7 +117,7 @@ export function isLayoutNode(value: unknown): value is LayoutNode {
 /** `sizes` is checked for number values and not for its sum — `resolveSizes` re-derives that. */
 export function isLayoutTree(value: unknown): value is LayoutTree {
 	return (
-		isRecord(value) &&
+		Predicate.isObject(value) &&
 		isStackNode(value.root) &&
 		(value.zoomed === null || typeof value.zoomed === "string")
 	);

--- a/apps/tuval/src/shell/picker/refusal.ts
+++ b/apps/tuval/src/shell/picker/refusal.ts
@@ -7,6 +7,8 @@
  * that puts one of these in the window, which is what "a typed refusal shown in the window" means.
  */
 
+import {Predicate} from "effect";
+
 export type PickerRefusal =
 	| {readonly _tag: "UnknownProgram"; readonly programId: string}
 	| {readonly _tag: "ProgramHeadless"; readonly programId: string}
@@ -38,9 +40,6 @@ export const unreadableCommand = (line: string, reason: string): PickerRefusal =
 	reason,
 });
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
-
 const strings = (value: Record<string, unknown>, fields: ReadonlyArray<string>): boolean =>
 	fields.every((field) => typeof value[field] === "string");
 
@@ -51,7 +50,7 @@ const strings = (value: Record<string, unknown>, fields: ReadonlyArray<string>):
  * an arm-shaped value missing a field would reach `refusalMessage` and render `undefined`.
  */
 export const isPickerRefusal = (value: unknown): value is PickerRefusal => {
-	if (!isRecord(value)) return false;
+	if (!Predicate.isObject(value)) return false;
 	switch (value._tag) {
 		case "UnknownProgram":
 		case "ProgramHeadless":

--- a/apps/tuval/src/shell/transport/wire.ts
+++ b/apps/tuval/src/shell/transport/wire.ts
@@ -21,7 +21,7 @@
  * ([ADR 0353](../../../../../.decisions/0353-kernel-sends-the-prefix-table.md)).
  */
 
-import {Duration, Option} from "effect";
+import {Duration, Option, Predicate} from "effect";
 import type {Lifecycle, ProcessId} from "../../process/process.ts";
 import type {ProgramId, RendererKind, RendererRef} from "../../registry/program.ts";
 import type {PortDeclaration, TableEvent, TableEventKind, TableRow} from "../../table/row.ts";
@@ -167,16 +167,13 @@ export type ServerFrame =
 	| RegistryFrame
 	| KeysFrame;
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null;
-
 const isProcessIdString = (value: unknown): value is ProcessId => typeof value === "string";
 
 const isMessage = (value: unknown): value is DispatchFrame["msg"] =>
-	isRecord(value) && typeof value.type === "string";
+	Predicate.isObject(value) && typeof value.type === "string";
 
 const isPortDeclaration = (value: unknown): value is PortDeclaration =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.kind === "string" &&
 	(value.direction === "in" || value.direction === "out");
 
@@ -194,51 +191,51 @@ const rendererKinds: ReadonlySet<string> = new Set<RendererKind>([
 ]);
 
 const isRendererRef = (value: unknown): value is RendererRef =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.kind === "string" &&
 	rendererKinds.has(value.kind) &&
 	typeof value.ref === "string";
 
 const isSummary = (value: unknown): value is WireRow["stateSummary"] =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.lifecycle === "string" &&
 	lifecycles.has(value.lifecycle) &&
 	typeof value.revision === "number";
 
 export const isWireRow = (value: unknown): value is WireRow =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.id === "string" &&
 	typeof value.programId === "string" &&
 	(value.parentId === null || typeof value.parentId === "string") &&
-	isRecord(value.ports) &&
+	Predicate.isObjectOrArray(value.ports) &&
 	Object.values(value.ports).every(isPortDeclaration) &&
 	isSummary(value.stateSummary);
 
 export const isAttachFrame = (value: unknown): value is AttachFrame =>
-	isRecord(value) && value.kind === ATTACH_KIND && isProcessIdString(value.processId);
+	Predicate.isObject(value) && value.kind === ATTACH_KIND && isProcessIdString(value.processId);
 
 export const isDetachFrame = (value: unknown): value is DetachFrame =>
-	isRecord(value) && value.kind === DETACH_KIND && isProcessIdString(value.processId);
+	Predicate.isObject(value) && value.kind === DETACH_KIND && isProcessIdString(value.processId);
 
 export const isDispatchFrame = (value: unknown): value is DispatchFrame =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	value.kind === DISPATCH_KIND &&
 	Number.isInteger(value.seq) &&
 	isProcessIdString(value.processId) &&
 	isMessage(value.msg);
 
 export const isTableFrame = (value: unknown): value is TableFrame =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	value.kind === TABLE_KIND &&
 	typeof value.event === "string" &&
 	tableEventKinds.has(value.event) &&
 	isWireRow(value.row);
 
 export const isProcessStateFrame = (value: unknown): value is ProcessStateFrame =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	value.kind === PROCESS_STATE_KIND &&
 	isProcessIdString(value.processId) &&
-	isRecord(value.view) &&
+	Predicate.isObject(value.view) &&
 	((value.view._tag === "Live" &&
 		typeof value.view.lifecycle === "string" &&
 		lifecycles.has(value.view.lifecycle) &&
@@ -247,42 +244,42 @@ export const isProcessStateFrame = (value: unknown): value is ProcessStateFrame 
 		value.view._tag === "ProcessGone");
 
 export const isAttachRefusedFrame = (value: unknown): value is AttachRefusedFrame =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	value.kind === ATTACH_REFUSED_KIND &&
 	isProcessIdString(value.processId) &&
-	isRecord(value.refusal) &&
+	Predicate.isObject(value.refusal) &&
 	((value.refusal.reason === "placement-unsupported" &&
 		typeof value.refusal.placement === "string") ||
 		value.refusal.reason === "no-such-process");
 
 export const isDispatchedFrame = (value: unknown): value is DispatchedFrame =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	value.kind === DISPATCHED_KIND &&
 	Number.isInteger(value.seq) &&
-	isRecord(value.result) &&
+	Predicate.isObject(value.result) &&
 	(value.result._tag === "Delivered" ||
 		(value.result._tag === "ProcessGone" && isProcessIdString(value.result.processId)));
 
 export const isWireProgram = (value: unknown): value is WireProgram =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.programId === "string" &&
 	typeof value.label === "string" &&
 	isRendererRef(value.renderer);
 
 export const isRegistryFrame = (value: unknown): value is RegistryFrame =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	value.kind === REGISTRY_KIND &&
 	Array.isArray(value.programs) &&
 	value.programs.every(isWireProgram);
 
 export const isWireBinding = (value: unknown): value is WireBinding =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.sequence === "string" &&
 	typeof value.command === "string" &&
 	typeof value.repeatable === "boolean";
 
 export const isWirePrefixTable = (value: unknown): value is WirePrefixTable =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.prefix === "string" &&
 	typeof value.repeatTimeoutMs === "number" &&
 	Number.isFinite(value.repeatTimeoutMs) &&
@@ -290,7 +287,7 @@ export const isWirePrefixTable = (value: unknown): value is WirePrefixTable =>
 	value.bindings.every(isWireBinding);
 
 export const isKeysFrame = (value: unknown): value is KeysFrame =>
-	isRecord(value) && value.kind === KEYS_KIND && isWirePrefixTable(value.table);
+	Predicate.isObject(value) && value.kind === KEYS_KIND && isWirePrefixTable(value.table);
 
 /** Decoded, or the one reason it was not. A refusal is a value: the caller decides what to close. */
 export type Decoded<F> =
@@ -322,7 +319,7 @@ const decodeWith =
 		const parsed = parse(text);
 		if (!parsed.ok) return undecodable("not-json");
 		const value = parsed.value;
-		if (!isRecord(value) || typeof value.kind !== "string" || !known.has(value.kind)) {
+		if (!Predicate.isObject(value) || typeof value.kind !== "string" || !known.has(value.kind)) {
 			return undecodable("unknown-kind");
 		}
 		for (const admits of predicates) {

--- a/apps/tuval/src/table/row.ts
+++ b/apps/tuval/src/table/row.ts
@@ -4,7 +4,7 @@
  * tells a Pi process from a Claude one by `programId` and by nothing else (#7498's stated risk).
  */
 
-import {Option} from "effect";
+import {Option, Predicate} from "effect";
 import type {Lifecycle, ProcessId, ProcessRow} from "../process/process.ts";
 import type {ProgramId} from "../registry/program.ts";
 
@@ -54,32 +54,29 @@ export const toTableRow = (row: ProcessRow): TableRow => {
 const kinds: ReadonlySet<string> = new Set<TableEventKind>(["spawned", "stopped", "state-changed"]);
 const lifecycles: ReadonlySet<string> = new Set<Lifecycle>(["running", "stopping"]);
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null;
-
 const isPortDeclaration = (value: unknown): value is PortDeclaration =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.kind === "string" &&
 	(value.direction === "in" || value.direction === "out");
 
 const isStateSummary = (value: unknown): value is TableStateSummary =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.lifecycle === "string" &&
 	lifecycles.has(value.lifecycle) &&
 	typeof value.revision === "number";
 
 export const isTableRow = (value: unknown): value is TableRow =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.id === "string" &&
 	typeof value.programId === "string" &&
 	Option.isOption(value.parentId) &&
-	isRecord(value.ports) &&
+	Predicate.isObjectOrArray(value.ports) &&
 	Object.values(value.ports).every(isPortDeclaration) &&
 	isStateSummary(value.stateSummary);
 
 /** The port predicate: the wire is nominal kind plus predicate, and this is the predicate. */
 export const isTableEvent = (value: unknown): value is TableEvent =>
-	isRecord(value) &&
+	Predicate.isObject(value) &&
 	typeof value.kind === "string" &&
 	kinds.has(value.kind) &&
 	isTableRow(value.row);


### PR DESCRIPTION
Every record predicate under `apps/tuval/src` now reads off the pinned effect release's
`Predicate` module instead of being hand-rolled. The pin (`catalogs.tuval`, `4.0.0-rc.112`)
ships both definitions the repo had collapsed onto one name — `Predicate.isObject` excludes
arrays, `Predicate.isObjectOrArray` admits them — and its `AGENTS.md` says never to write
either by hand.

Eleven sites changed, not the four the issue names: the tree moved since filing, and criterion
2 is repo-wide. `executor.ts` had already lost its `isRecord` to an inline `isNamed`; eight
modules outside the issue's list carried their own copy.

One hand-rolled copy remains, in `claude/history/blocks.ts`. That directory has a tested
boundary (`boundary.unit.test.ts`) barring any `effect` import so the mapping stays testable
without a runtime, so it holds the copy with a docblock saying why. `protocol/json.ts` — the
issue's suggested holder — needed no copy at all: its only consumer is `patch.ts`, which
already imports effect, so the export moved there and json.ts keeps its stated abstinence
untouched.

`pnpm --filter @kampus/tuval typecheck` and `test` both pass (1058 tests, 130 files).

Reviewer: start at `table/row.ts` and `shell/transport/wire.ts` — they are the two
array-admitting sites, and the deviation below explains why each uses both predicates.

Fixes #7764

## Deviations

- **Declined guidance** — **Said:** criterion 1 says `table/row.ts` uses
  `Predicate.isObjectOrArray`, with its array-admitting behaviour unchanged. **Did:** `row.ts`
  (and `wire.ts`, the other array-admitting site) uses `isObjectOrArray` only at `value.ports`,
  and `Predicate.isObject` at every property-read site. **Why:** `isObjectOrArray` narrows to
  `{[x: PropertyKey]: unknown} | Array<unknown>`, so `value.kind` after it is a TS2339 on the
  array branch — the criterion's two halves cannot both hold. `value.ports` is the one place an
  array was load-bearing: `Object.values([]).every(...)` is vacuously true, so an empty-array
  `ports` was admitted and still is. At every other site the array branch was already dead on
  the next property read, so behaviour is unchanged there too. **Disposition:** stated here.

- **Governing-ADR departure** — **Said:** `shell/layout/node.ts`'s docblock states the module is
  kept free of Effect. **Did:** it imports `Predicate` and the docblock is amended to say what
  abstinence it still holds. **Why:** the stated reason is that `Schema.brand` would put an
  Effect type on every id the module hands out; a pure `Predicate.isObject` guard touches no id
  and pulls in no runtime, and nothing tests that module's ban. **Disposition:** stated here.

- **Out-of-scope change** — **Said:** #7764 names four modules. **Did:** eleven sites across
  `shell/transport/wire.ts`, `shell/core/state.ts`, `shell/picker/refusal.ts`,
  `shell/layout/node.ts`, `shell/desk/state.ts`, `claude/history/blocks.ts`,
  `ai-agent/core/snapshot.ts`, `ai-agent/ports/transcript-item.ts`,
  `ai-agent/ports/payloads.ts`, `commands/executor.ts` and the four named ones. **Why:**
  criterion 2 is written repo-wide ("anywhere under `apps/tuval/src`"), and the tree carries
  ten declaration sites plus two inline copies (`desk/state.ts`'s `isDeskState`,
  `executor.ts`'s `isNamed`) rather than the four the filing saw. **Disposition:** stated here.

- **Pre-existing test or fixture changed** — **Said:** nothing about tests. **Did:** no test
  file changed. **Why:** noting it explicitly because `claude/history/boundary.unit.test.ts`
  caught the effect import there and the fix was to respect the guard, not to relax it.
  **Disposition:** stated here.
