### PR TITLE
chore: Five Tuval proofs assert less than their names claim

### DIFF
--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -178,7 +178,13 @@ const world: Readonly<Record<string, unknown>> = {
  * One argument, from the parameter's own schema first and the desk second: an enum takes its first
  * literal, a parameter naming a spell path takes a registered one, and anything the schema cannot
  * settle comes from the desk or from what an earlier call in this script returned.
+ *
+ * A parameter none of those settle is `unsettled`, never an empty string. Substituting `""` let the
+ * proof pass on a spell nobody had taught it: the kernel was handed empty text for a value the
+ * script knew nothing about, and the run counted the call as a spell the agent had reached.
  */
+const unsettled = Symbol("unsettled");
+
 const argumentFor = (
 	spell: string,
 	param: ParamSpec,
@@ -190,20 +196,31 @@ const argumentFor = (
 	if (param.literals !== undefined) return param.literals[0];
 	if (param.name === "path") return firstPath;
 	const carried = learned[param.name];
-	return carried === undefined ? "" : carried;
+	return carried === undefined ? unsettled : carried;
 };
 
-const argumentsFor = (
+/** The generated call, plus every parameter neither the world map nor the schema could settle. */
+interface Generated {
+	readonly args: Readonly<Record<string, unknown>>;
+	readonly unsettled: ReadonlyArray<string>;
+}
+
+const generateArguments = (
 	description: SpellDescription,
 	learned: Readonly<Record<string, unknown>>,
 	firstPath: string,
-): Readonly<Record<string, unknown>> => {
+): Generated => {
 	const spell = description.path.join(".");
 	const args: Record<string, unknown> = {};
+	const missing: Array<string> = [];
 	for (const param of readParams(description.params)) {
-		args[param.name] = argumentFor(spell, param, learned, firstPath);
+		const value = argumentFor(spell, param, learned, firstPath);
+		// Left out rather than filled with a placeholder, so the kernel refuses the call against its
+		// own `params` and the transcript cannot record an unsettled parameter as a reply.
+		if (value === unsettled) missing.push(`${spell}.${param.name}`);
+		else args[param.name] = value;
 	}
-	return args;
+	return {args, unsettled: missing};
 };
 
 const asPath = (segments: ReadonlyArray<string>): SpellPath => {
@@ -249,6 +266,7 @@ const resultOf = (reply: SpellReply): unknown => (reply.ok ? reply.result : unde
 const script = Effect.fn("agentProof.script")(function* () {
 	const transcript: Array<Exchange> = [];
 	const learned: Record<string, unknown> = {};
+	const unfilled: Array<string> = [];
 
 	const call = Effect.fn("agentProof.exchange")(function* (
 		path: SpellPath,
@@ -271,7 +289,9 @@ const script = Effect.fn("agentProof.script")(function* () {
 
 	for (const description of described) {
 		const path = asPath(description.path);
-		const reply = yield* call(path, argumentsFor(description, learned, firstPath));
+		const generated = generateArguments(description, learned, firstPath);
+		unfilled.push(...generated.unsettled);
+		const reply = yield* call(path, generated.args);
 		// `process spawn` is the one call whose answer another call needs, and it is registered
 		// ahead of `process send` and `process read`, so the id is learned before they are reached.
 		if (renderPath(path) === "process.spawn") {
@@ -280,8 +300,17 @@ const script = Effect.fn("agentProof.script")(function* () {
 		}
 	}
 
-	return transcript as ReadonlyArray<Exchange>;
+	return {
+		transcript: transcript as ReadonlyArray<Exchange>,
+		unsettled: unfilled as ReadonlyArray<string>,
+	};
 });
+
+/** What the script produced: the exchanges it made, and the parameters it could not generate. */
+interface Run {
+	readonly transcript: ReadonlyArray<Exchange>;
+	readonly unsettled: ReadonlyArray<string>;
+}
 
 type AgentState = {readonly started: boolean};
 type AgentMsg = {readonly type: "begin"} | {readonly type: "finished"};
@@ -295,7 +324,7 @@ const agentId = ProgramId.make("agent");
  * `init` because the script starts a process of its own, and a process started from inside its
  * parent's own boot has no live parent to hang on yet.
  */
-const agentProgram = (done: Deferred.Deferred<ReadonlyArray<Exchange>>): AnyProgram =>
+const agentProgram = (done: Deferred.Deferred<Run>): AnyProgram =>
 	({
 		id: agentId,
 		core: defineMachine<AgentState, AgentMsg, Drive, never, unknown>({
@@ -341,7 +370,7 @@ const app = (rows: ReadonlyArray<AnyProgram>) =>
 
 /** One `begin` starts the script, so awaiting the transcript is awaiting the agent's whole run. */
 const runAgent = Effect.gen(function* () {
-	const done = yield* Deferred.make<ReadonlyArray<Exchange>>();
+	const done = yield* Deferred.make<Run>();
 	const rows = [agentProgram(done), echoProgram()];
 	return yield* Effect.gen(function* () {
 		const processes = yield* Processes;
@@ -351,10 +380,10 @@ const runAgent = Effect.gen(function* () {
 			services: Context.make(SpellExecutor, executor),
 		});
 		yield* agent.dispatch({type: "begin"});
-		const transcript = yield* Deferred.await(done);
+		const {transcript, unsettled} = yield* Deferred.await(done);
 		const rowsInRegistry = yield* SpellRegistry.use((registry) => registry.list);
 		const help = yield* overTheWire(["help"], {});
-		return {transcript, rowsInRegistry, help};
+		return {transcript, unsettled, rowsInRegistry, help};
 	}).pipe(Effect.provide(app(rows)));
 });
 
@@ -366,7 +395,15 @@ const failureOf = (reply: SpellReply): SpellFailure | undefined =>
 describe("the agent proof", () => {
 	it.live("enumerates every spell over the wire and calls each one, every reply decoding", () =>
 		Effect.gen(function* () {
-			const {transcript, rowsInRegistry, help} = yield* runAgent;
+			const {transcript, unsettled, rowsInRegistry, help} = yield* runAgent;
+
+			// Before the replies, because a call whose argument the script could not generate is a
+			// spell this proof never reached — and one filled with a placeholder answers anyway.
+			assert.deepStrictEqual(
+				[...unsettled],
+				[],
+				"the script could not generate an argument for these parameters",
+			);
 
 			const registered = rowsInRegistry.map((row) => renderPath(row.path));
 			assert.includeMembers(
@@ -475,21 +512,25 @@ const learnedFrom = (
  * describe per listed path, then one call per listed spell. Registry order puts `process spawn`
  * ahead of `process send` and `process read`, so the process id is learned before they are reached.
  */
-const planStep: ScriptedPlan = (answered) => {
-	const [listing, ...rest] = answered;
-	if (listing === undefined) return {path: ["spell", "list"], args: {}};
-	const listed = readList(listing.answer);
-	const firstPath = listed[0]?.path.join(" ") ?? "";
-	if (rest.length < listed.length) {
-		const next = listed[rest.length];
-		return next === undefined
-			? null
-			: {path: ["spell", "describe"], args: {path: next.path.join(" ")}};
-	}
-	const target = listed[rest.length - listed.length];
-	if (target === undefined) return null;
-	return {path: asPath(target.path), args: argumentsFor(target, learnedFrom(answered), firstPath)};
-};
+const planStep =
+	(unfilled: Array<string>): ScriptedPlan =>
+	(answered) => {
+		const [listing, ...rest] = answered;
+		if (listing === undefined) return {path: ["spell", "list"], args: {}};
+		const listed = readList(listing.answer);
+		const firstPath = listed[0]?.path.join(" ") ?? "";
+		if (rest.length < listed.length) {
+			const next = listed[rest.length];
+			return next === undefined
+				? null
+				: {path: ["spell", "describe"], args: {path: next.path.join(" ")}};
+		}
+		const target = listed[rest.length - listed.length];
+		if (target === undefined) return null;
+		const generated = generateArguments(target, learnedFrom(answered), firstPath);
+		unfilled.push(...generated.unsettled);
+		return {path: asPath(target.path), args: generated.args};
+	};
 
 /** The events reach the transcript through a Sub, so the tail settles after `dispatch` returns. */
 const eventually = (check: () => boolean) =>
@@ -509,6 +550,7 @@ const lastTranscript = (emitted: ReadonlyArray<Emission>): TranscriptPayload | u
 
 const runServiceAgent = Effect.gen(function* () {
 	const emitted: Array<Emission> = [];
+	const unfilled: Array<string> = [];
 	let answered: ReadonlyArray<ScriptedAnswer> = [];
 	const latch = yield* Deferred.make<SpellBridgeApi>();
 	// The bridge reaches the executor this same app builds, and the row has to exist before that
@@ -529,7 +571,7 @@ const runServiceAgent = Effect.gen(function* () {
 				events: [],
 				plan: (seen) => {
 					answered = seen;
-					return planStep(seen);
+					return planStep(unfilled)(seen);
 				},
 			},
 		],
@@ -570,14 +612,26 @@ const runServiceAgent = Effect.gen(function* () {
 		yield* agent.dispatch({type: "prompt", text: "call every spell you can", key: "k1"});
 		yield* eventually(() => (lastTranscript(emitted)?.items.length ?? 0) >= answered.length);
 		const help = yield* overTheWire(["help"], {});
-		return {answered, rowsInRegistry, help, transcript: lastTranscript(emitted)};
+		return {
+			answered,
+			unsettled: unfilled as ReadonlyArray<string>,
+			rowsInRegistry,
+			help,
+			transcript: lastTranscript(emitted),
+		};
 	}).pipe(Effect.provide(app(rows)));
 });
 
 describe("the agent proof, on the agent service", () => {
 	it.live("reaches every spell through SpellBridge from an aiAgentProgram process", () =>
 		Effect.gen(function* () {
-			const {answered, rowsInRegistry, help} = yield* runServiceAgent;
+			const {answered, unsettled, rowsInRegistry, help} = yield* runServiceAgent;
+
+			assert.deepStrictEqual(
+				[...unsettled],
+				[],
+				"the script could not generate an argument for these parameters",
+			);
 
 			for (const entry of answered) {
 				assert.isTrue(

--- a/apps/tuval/src/commands/parse/property.unit.test.ts
+++ b/apps/tuval/src/commands/parse/property.unit.test.ts
@@ -5,6 +5,10 @@
  * failure names one seed and one case, and adding a property costs no dependency in a package whose
  * Effect pin already sits on its own catalog. Every prefix of every generated line is checked, which
  * is the whole space for that line rather than a sample of it.
+ *
+ * Arguments are written in all four spellings a config author can use — bare, quoted, backslash
+ * escaped, and `name=value` — because those are the four places `tokenize.ts` and `reading.ts`
+ * hand-roll, and a corpus of bare lowercase words never reaches any of them.
  */
 
 import {describe, expect, it} from "vitest";
@@ -30,15 +34,50 @@ const SEGMENTS = ["window", "workspace", "process", "layout", "focus", "swap", "
 const VALUES = ["ax-1", "ax-2", "zeta", "quux-3", "vv", "nought"];
 const LITERALS = ["left", "right", "up", "down"];
 
+/**
+ * Values that only survive the round trip if the lexer's quoting and escaping work: a separator
+ * inside a value, a quote, a backslash, and an `=` that must not be read as a parameter name —
+ * `a` is not a parameter of any generated spell, so `a=b` is one positional value and not a
+ * binding.
+ */
+const AWKWARD = ["ax 1", 'say "hi"', "c:\\tmp", "a=b", "two  spaces"];
+
+/** A value the lexer reads back unchanged with no quoting and no escaping. */
+const BARE = /^[A-Za-z0-9_-]+$/;
+
+const quoted = (value: string): string => `"${value.replace(/[\\"]/g, (mark) => `\\${mark}`)}"`;
+
+const escaped = (value: string): string => value.replace(/[\\"\s]/g, (mark) => `\\${mark}`);
+
+/**
+ * How one argument is written on the line. `named` is the only spelling that changes where the
+ * value binds; the other three are four ways of writing the same token text.
+ */
+type Spelling = "bare" | "quoted" | "escaped" | "named";
+
+const write = (value: string, spelling: Spelling, name: string): string => {
+	if (spelling === "bare") return BARE.test(value) ? value : quoted(value);
+	if (spelling === "quoted") return quoted(value);
+	if (spelling === "escaped") return escaped(value);
+	return `${name}=${BARE.test(value) ? value : quoted(value)}`;
+};
+
+/** One generated line: the text, and the call the parser owes for it. */
+interface Case {
+	readonly line: string;
+	readonly path: ReadonlyArray<string>;
+	readonly args: Readonly<Record<string, string>>;
+}
+
 interface Generated {
 	readonly registry: SpellIndex;
-	readonly lines: ReadonlyArray<string>;
+	readonly cases: ReadonlyArray<Case>;
 }
 
 const generate = (seed: number): Generated => {
 	const next = seeded(seed);
 	const descriptions: Array<RegistryDescription[number]> = [];
-	const lines: Array<string> = [];
+	const cases: Array<Case> = [];
 	const taken = new Set<string>();
 
 	for (let index = 0; index < 12; index += 1) {
@@ -69,23 +108,89 @@ const generate = (seed: number): Generated => {
 			capabilities: [],
 		});
 
-		const args = names.map((_, position) =>
-			position === enumAt ? LITERALS[next(LITERALS.length)]! : VALUES[next(VALUES.length)]!,
-		);
-		lines.push([...path, ...args].join(" "));
+		const args: Record<string, string> = {};
+		const written = names.map((name, position) => {
+			// An enum parameter refuses anything outside its literals, so its value is always one of
+			// them; only how it is written varies. `named` is left to the free parameters, whose
+			// value is unconstrained and so cannot turn a truncated prefix into a refusal.
+			const isEnum = position === enumAt;
+			const value = isEnum
+				? LITERALS[next(LITERALS.length)]!
+				: next(2) === 0
+					? VALUES[next(VALUES.length)]!
+					: AWKWARD[next(AWKWARD.length)]!;
+			const spelling: Spelling = isEnum
+				? (["bare", "quoted", "escaped"] as const)[next(3)]!
+				: (["bare", "quoted", "escaped", "named"] as const)[next(4)]!;
+			args[name] = value;
+			return write(value, spelling, name);
+		});
+		cases.push({line: [...path, ...written].join(" "), path, args});
 	}
 
-	return {registry: buildSpellIndex(descriptions), lines};
+	return {registry: buildSpellIndex(descriptions), cases};
 };
+
+const corpus = (seeds: number): ReadonlyArray<Generated> =>
+	Array.from({length: seeds}, (_, index) => generate(index + 1));
+
+describe("the generated corpus", () => {
+	it("reaches the syntax the lexer and the reader hand-roll", () => {
+		const lines = corpus(40).flatMap((generated) => generated.cases.map((one) => one.line));
+		const values = corpus(40).flatMap((generated) =>
+			generated.cases.flatMap((one) => Object.values(one.args)),
+		);
+
+		expect(
+			lines.some((line) => line.includes('"')),
+			"no line carries a quote",
+		).toBe(true);
+		expect(
+			lines.some((line) => line.includes("\\")),
+			"no line carries a backslash",
+		).toBe(true);
+		expect(
+			lines.some((line) => line.includes("=")),
+			"no line carries an =",
+		).toBe(true);
+		expect(
+			lines.some((line) => / (?:workspace|second)=/.test(line)),
+			"no line binds an argument by name",
+		).toBe(true);
+		// A line can carry a quote without any value needing one, so the values are checked too: a
+		// corpus whose quotes are all decoration proves nothing about the unquoting.
+		expect(
+			values.some((value) => / /.test(value)),
+			"no value carries a separator",
+		).toBe(true);
+		expect(
+			values.some((value) => value.includes('"')),
+			"no value carries a quote",
+		).toBe(true);
+		expect(
+			values.some((value) => value.includes("\\")),
+			"no value carries a backslash",
+		).toBe(true);
+		expect(
+			values.some((value) => value.includes("=")),
+			"no value carries an =",
+		).toBe(true);
+	});
+});
 
 describe("every prefix of a complete line is Partial or Complete", () => {
 	it("never refuses and never throws, over 40 generated registries", () => {
 		const offenders: Array<string> = [];
 		for (let seed = 1; seed <= 40; seed += 1) {
-			const {registry, lines} = generate(seed);
-			for (const line of lines) {
-				// The line itself must parse, or the case proves nothing about its prefixes.
-				expect(parse(line, registry, snapshot)._tag, `seed ${seed}: ${line}`).toBe("Complete");
+			const {registry, cases} = generate(seed);
+			for (const {line, path, args} of cases) {
+				// The line itself must parse, and to the call it was written for: a quoted or escaped
+				// value read back as its raw text is a Complete line carrying the wrong arguments.
+				const whole = parse(line, registry, snapshot);
+				expect(whole._tag, `seed ${seed}: ${line}`).toBe("Complete");
+				if (whole._tag === "Complete") {
+					expect(whole.call, `seed ${seed}: ${line}`).toEqual({path, args});
+				}
 				for (let length = 0; length <= line.length; length += 1) {
 					const prefix = line.slice(0, length);
 					const result = parse(prefix, registry, snapshot);
@@ -100,8 +205,8 @@ describe("every prefix of a complete line is Partial or Complete", () => {
 describe("ranking is deterministic", () => {
 	it("returns an equal list for equal input and snapshot, over every generated prefix", () => {
 		for (let seed = 1; seed <= 20; seed += 1) {
-			const {registry, lines} = generate(seed);
-			for (const line of lines) {
+			const {registry, cases} = generate(seed);
+			for (const {line} of cases) {
 				for (let length = 0; length <= line.length; length += 1) {
 					const prefix = line.slice(0, length);
 					expect(complete(prefix, registry, snapshot)).toEqual(

--- a/apps/tuval/src/commands/pattern-doc-paths.unit.test.ts
+++ b/apps/tuval/src/commands/pattern-doc-paths.unit.test.ts
@@ -1,9 +1,11 @@
 /**
- * The drift guard on `.patterns/tuval-spells.md`: every repo path that page links to has to exist.
+ * The drift guard on `.patterns/tuval-spells.md`: every repo path that page links to has to exist,
+ * and every row of its file table has to still describe the module it points at.
  *
  * A reference page whose file table names a module that moved sends its reader nowhere, and nothing
- * else in CI reads it. So this resolves each markdown link target the doc carries and stats it. The
- * doc must also carry at least one, otherwise a page that lost its whole table would pass silently.
+ * else in CI reads it. So this resolves each markdown link target the doc carries and stats it, then
+ * walks the table row by row — a row's own link is its citation, and the identifiers the row lists
+ * have to be findable in the file it cites.
  */
 
 import {existsSync} from "node:fs";
@@ -24,6 +26,44 @@ const linkedPaths = (markdown: string): ReadonlyArray<string> => {
 	return [...targets];
 };
 
+/** One row of the `## The pieces, by file` table: the module it names, and what it claims is in it. */
+interface Row {
+	readonly module: string;
+	readonly target: string;
+	readonly claims: ReadonlyArray<string>;
+}
+
+/**
+ * The table rows, read as rows rather than as loose links. A count over the page's links cannot
+ * tell a table that lost half its rows from one that never had them; a row can.
+ */
+const fileTable = (markdown: string): ReadonlyArray<Row> => {
+	const section = markdown.split("## The pieces, by file")[1]?.split("\n## ")[0] ?? "";
+	const rows: Array<Row> = [];
+	for (const line of section.split("\n")) {
+		// Every row of the table, not only the ones that still carry a link: a row filter keyed on
+		// `| [` drops the row that lost its link, which is the drift this whole read is for.
+		if (!line.startsWith("|") || /^\|[\s|:-]*$/.test(line)) continue;
+		const [, first = "", second = ""] = line.split("|");
+		if (first.trim() === "File") continue;
+		const link = /^\s*\[`([^`]+)`\]\(([^)]+)\)\s*$/.exec(first);
+		if (link === null) {
+			rows.push({module: first.trim(), target: "", claims: []});
+			continue;
+		}
+		rows.push({
+			module: link[1] ?? "",
+			target: link[2] ?? "",
+			// Only identifier-shaped backticks: a row also backticks directory names (`core/`) and
+			// prose, and neither is a name to look for in a file.
+			claims: [...second.matchAll(/`([A-Za-z_][A-Za-z0-9_]*)`/g)].map((match) => match[1] ?? ""),
+		});
+	}
+	return rows;
+};
+
+const pathOf = (target: string): string => normalize(join(repoRoot, ".patterns", target));
+
 describe(".patterns/tuval-spells.md", () => {
 	it("links only to paths that exist", async () => {
 		const markdown = await readFile(docPath, "utf8");
@@ -31,16 +71,45 @@ describe(".patterns/tuval-spells.md", () => {
 
 		expect(targets.length).toBeGreaterThan(0);
 
-		const missing = targets.filter(
-			(target) => !existsSync(normalize(join(repoRoot, ".patterns", target))),
-		);
+		const missing = targets.filter((target) => !existsSync(pathOf(target)));
 		expect(missing).toEqual([]);
 	});
 
-	it("cites the code it describes", async () => {
+	it("cites the code each of its file-table rows describes", async () => {
 		const markdown = await readFile(docPath, "utf8");
-		const cited = linkedPaths(markdown).filter((target) => target.includes("apps/tuval/src/"));
+		const rows = fileTable(markdown);
 
-		expect(cited.length).toBeGreaterThan(20);
+		expect(rows.length, "the file table has no rows").toBeGreaterThan(0);
+
+		const uncited = rows.filter((row) => row.target === "");
+		expect(
+			uncited.map((row) => row.module),
+			"a table row names a module it does not link",
+		).toEqual([]);
+
+		const mispointed = rows.filter(
+			(row) => !row.target.endsWith(`/${row.module}`) || !row.target.includes("apps/tuval/src/"),
+		);
+		expect(
+			mispointed.map((row) => `${row.module} -> ${row.target}`),
+			"a table row links somewhere other than the module it names",
+		).toEqual([]);
+	});
+
+	it("names, in each row, identifiers that are still in that row's module", async () => {
+		const markdown = await readFile(docPath, "utf8");
+		const rows = fileTable(markdown);
+		const claimed = rows.reduce((total, row) => total + row.claims.length, 0);
+		expect(claimed, "no row names anything the module has to hold").toBeGreaterThan(0);
+
+		const gone: Array<string> = [];
+		for (const row of rows) {
+			if (row.claims.length === 0) continue;
+			const source = await readFile(pathOf(row.target), "utf8");
+			for (const claim of row.claims) {
+				if (!source.includes(claim)) gone.push(`${row.module}: ${claim}`);
+			}
+		}
+		expect(gone, "a table row names something its module no longer holds").toEqual([]);
 	});
 });

--- a/apps/tuval/src/commands/spell-set.unit.test.ts
+++ b/apps/tuval/src/commands/spell-set.unit.test.ts
@@ -1,0 +1,234 @@
+/**
+ * `SpellSet`: the registry table and the key bindings compiled against it, in one cell.
+ *
+ * The claim under test is that the two are one value and not two pieces of state kept in step —
+ * every write recompiles, every read returns both halves of one config, and the `SpellRegistry` the
+ * same layer hands out reads that same cell rather than a second one. `reload-proof.unit.test.ts`
+ * watches a real boot across a real config reload; this file drives the module directly, including
+ * the narrower `swap` entry that no config path reaches.
+ */
+
+import {defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schema} from "effect";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
+import {spells} from "./bindings/fixtures.ts";
+import type {BindingSource} from "./bindings/index.ts";
+import {SpellNotFound} from "./errors.ts";
+import {buildRegistry, SpellRegistry} from "./registry.ts";
+import {type AnySpell, defineSpell, renderPath} from "./spell.ts";
+import {everyPath, SpellSet, type SpellSetInput} from "./spell-set.ts";
+
+type State = {readonly ticks: number};
+type Msg = {readonly type: "tick"};
+
+const talker = ProgramId.make("talker");
+
+const echo = defineSpell({
+	path: ["echo"],
+	describe: "Answer with the word it was given.",
+	params: Schema.Struct({word: Schema.String}),
+	result: Schema.Struct({word: Schema.String}),
+	execute: (args: {readonly word: string}) => Effect.succeed(args),
+	capabilities: [],
+});
+
+const program = (list: ReadonlyArray<AnySpell>): AnyProgram =>
+	({
+		id: talker,
+		core: defineMachine<State, Msg, never, never, unknown>({
+			init: (loaded) => [loaded ?? {ticks: 0}, []],
+			update: {tick: (state) => [{ticks: state.ticks + 1}, []]},
+		}),
+		ports: {},
+		handlers: {},
+		spells: list,
+		capabilities: [],
+		identity: {
+			package: "@kampus/tuval",
+			program: "talker",
+			version: "1.0.0",
+			digest: "sha256:talker",
+		},
+		placement: {host: "local"},
+	}) satisfies Program<State, Msg, never, never, unknown, never, never>;
+
+const source = (file: string, bindings: Readonly<Record<string, string>>): BindingSource => ({
+	file,
+	bindings,
+});
+
+/** One config: the fixture spells, a program that declares `echo`, and one layer of key bindings. */
+const config: SpellSetInput = {
+	core: spells,
+	programs: [program([echo])],
+	keys: [
+		source("global", {
+			"ctrl-c": "window close",
+			"ctrl-g": "window grow 3",
+			"ctrl-e": "talker echo hello",
+		}),
+	],
+};
+
+const on = <A, E>(input: SpellSetInput, body: Effect.Effect<A, E, SpellSet | SpellRegistry>) =>
+	body.pipe(Effect.provide(Layer.orDie(SpellSet.layer(input))));
+
+const keysOf = (state: {readonly bindings: {readonly bindings: ReadonlyArray<{key: string}>}}) =>
+	state.bindings.bindings.map((binding) => binding.key);
+
+describe("SpellSet", () => {
+	it.effect("hands back the table, its key sources and their compiled bindings as one value", () =>
+		on(
+			config,
+			Effect.gen(function* () {
+				const state = yield* SpellSet.use((set) => set.read);
+
+				assert.includeMembers(
+					state.table.rows.map((row) => renderPath(row.path)),
+					["window.close", "window.grow", "talker.echo"],
+					"a program's spell is not pathed under its program id",
+				);
+				assert.deepStrictEqual(
+					state.keys.map((held) => held.file),
+					["global"],
+					"the state does not carry the sources its bindings were compiled from",
+				);
+				assert.deepStrictEqual(state.bindings.errors, []);
+				assert.deepStrictEqual(keysOf(state).sort(), ["ctrl-c", "ctrl-e", "ctrl-g"]);
+
+				// Decoded against the spell's own `params`, not carried as the token text a config
+				// author wrote: `window grow 3` reaches a key router as the number 3.
+				const grow = state.bindings.bindings.find((binding) => binding.key === "ctrl-g");
+				assert.deepStrictEqual(grow?.args, {columns: 3});
+			}),
+		),
+	);
+
+	it.effect("costs a binding that does not compile its own key and nothing else", () =>
+		on(
+			{...config, keys: [source("global", {"ctrl-c": "window close", "ctrl-x": "window vanish"})]},
+			Effect.gen(function* () {
+				const state = yield* SpellSet.use((set) => set.read);
+
+				assert.deepStrictEqual(keysOf(state), ["ctrl-c"]);
+				assert.strictEqual(state.bindings.errors.length, 1);
+				assert.strictEqual(state.bindings.errors[0]?.key, "ctrl-x");
+				assert.strictEqual(state.bindings.errors[0]?.file, "global");
+			}),
+		),
+	);
+
+	it.effect(
+		"keeps every layer's bindings, in layer order, so a later layer wins a shared key",
+		() =>
+			on(
+				{
+					...config,
+					keys: [
+						source("global", {"ctrl-c": "window close"}),
+						source("project", {"ctrl-c": "workspace next"}),
+					],
+				},
+				Effect.gen(function* () {
+					const state = yield* SpellSet.use((set) => set.read);
+					assert.deepStrictEqual(
+						state.bindings.bindings.map((binding) => [binding.key, renderPath(binding.path)]),
+						[
+							["ctrl-c", "window.close"],
+							["ctrl-c", "workspace.next"],
+						],
+						"the layers' bindings are not in layer order",
+					);
+				}),
+			),
+	);
+
+	it.effect("installs a reloaded table and its freshly compiled bindings in one read's worth", () =>
+		on(
+			config,
+			Effect.gen(function* () {
+				const set = yield* SpellSet;
+				yield* set.reload({
+					core: spells,
+					programs: [program([])],
+					keys: config.keys,
+				});
+				const state = yield* SpellSet.use((held) => held.read);
+
+				assert.notInclude(
+					state.table.rows.map((row) => renderPath(row.path)),
+					"talker.echo",
+					"the reloaded table still holds the spell the program stopped declaring",
+				);
+				// The recompile is the point: the binding for the spell that went away is an error in
+				// the same read that shows the table without it.
+				assert.deepStrictEqual(keysOf(state).sort(), ["ctrl-c", "ctrl-g"]);
+				assert.deepStrictEqual(
+					state.bindings.errors.map((error) => error.key),
+					["ctrl-e"],
+					"the reload left a binding compiled against the table it replaced",
+				);
+			}),
+		),
+	);
+
+	it.effect("recompiles the bindings on the registry's own swap, not only on a reload", () =>
+		on(
+			config,
+			Effect.gen(function* () {
+				const registry = yield* SpellRegistry;
+				yield* registry.swap(yield* buildRegistry({core: spells, programs: []}).pipe(Effect.orDie));
+				const state = yield* SpellSet.use((set) => set.read);
+
+				assert.deepStrictEqual(keysOf(state).sort(), ["ctrl-c", "ctrl-g"]);
+				assert.deepStrictEqual(
+					state.bindings.errors.map((error) => error.key),
+					["ctrl-e"],
+					"the narrower swap entry left the two halves disagreeing",
+				);
+			}),
+		),
+	);
+
+	it.effect("serves the registry off the same cell the set reads", () =>
+		on(
+			config,
+			Effect.gen(function* () {
+				const set = yield* SpellSet;
+				const registry = yield* SpellRegistry;
+
+				const row = yield* registry.lookup(["talker", "echo"]);
+				assert.strictEqual(renderPath(row.path), "talker.echo");
+
+				yield* set.reload({core: spells, programs: [program([])], keys: config.keys});
+
+				const gone = yield* Effect.flip(registry.lookup(["talker", "echo"]));
+				assert.instanceOf(gone, SpellNotFound);
+				assert.strictEqual(gone.path, "talker.echo");
+				assert.notInclude(
+					(yield* registry.list).map((held) => renderPath(held.path)),
+					"talker.echo",
+					"the registry is reading a cell of its own",
+				);
+				assert.notInclude(
+					(yield* registry.describe).map((held) => held.path.join(".")),
+					"talker.echo",
+				);
+			}),
+		),
+	);
+
+	it.effect("names every registered path, which is what a whole-registry allow list is", () =>
+		on(
+			config,
+			Effect.gen(function* () {
+				const state = yield* SpellSet.use((set) => set.read);
+				assert.deepStrictEqual(
+					everyPath(state.table).map(renderPath).sort(),
+					state.table.rows.map((row) => renderPath(row.path)).sort(),
+				);
+			}),
+		),
+	);
+});

--- a/apps/tuval/src/commands/wire-proof.unit.test.ts
+++ b/apps/tuval/src/commands/wire-proof.unit.test.ts
@@ -39,16 +39,78 @@ const resultOf = (reply: SpellReply): unknown => {
 	return reply.ok ? reply.result : undefined;
 };
 
-/** The state a mutation writes, so a `Patch` has a real change to carry rather than a staged one. */
+/** The desk at one count: the protocol fixtures' own, with the workspace name that count implies. */
+const snapshotOf = (rev: number, registry: RegistryDescription, count: number): Snapshot =>
+	new Snapshot({
+		type: "snapshot",
+		version: PROTOCOL_VERSION,
+		rev: Revision.make(rev),
+		desk: {
+			workspaces: {
+				[deskWorkspace]: {
+					id: deskWorkspace,
+					name: `count ${count}`,
+					layout: {kind: "leaf", window: leftWindow},
+					focused: leftWindow,
+				},
+			},
+			activeWorkspace: deskWorkspace,
+		},
+		windows: {[leftWindow]: {id: leftWindow, recency: 1}},
+		processes: [counterRow],
+		registry,
+	});
+
+/**
+ * The kernel's state behind the two count spells: the count, the desk whose workspace name it
+ * names, and the patches its mutations emitted.
+ *
+ * `bump` writes all three in one step, which is what lets the `Patch` leg below assert over the
+ * patch the mutation produced. A patch the test writes proves only that `applyPatch` applies a
+ * patch: a kernel emitting the wrong change, or none, passes it unchanged.
+ */
 class Counter extends Context.Service<
 	Counter,
-	{readonly read: Effect.Effect<number>; readonly bump: Effect.Effect<number>}
+	{
+		readonly read: Effect.Effect<number>;
+		readonly bump: Effect.Effect<number>;
+		/** The desk as the kernel holds it now — what a page that applied every patch must match. */
+		readonly desk: Effect.Effect<Snapshot>;
+		readonly emitted: Effect.Effect<ReadonlyArray<Patch>>;
+	}
 >()("tuval/wireProof/Counter") {
-	static readonly layer: Layer.Layer<Counter> = Layer.effect(
+	static readonly layer: Layer.Layer<Counter, never, SpellRegistry> = Layer.effect(
 		Counter,
-		Effect.map(Ref.make(0), (cell) =>
-			Counter.of({read: Ref.get(cell), bump: Ref.updateAndGet(cell, (count) => count + 1)}),
-		),
+		Effect.gen(function* () {
+			const registry = yield* SpellRegistry.use((held) => held.describe);
+			const desk = yield* Ref.make(snapshotOf(1, registry, 0));
+			const patches = yield* Ref.make<ReadonlyArray<Patch>>([]);
+			const count = yield* Ref.make(0);
+			return Counter.of({
+				read: Ref.get(count),
+				desk: Ref.get(desk),
+				emitted: Ref.get(patches),
+				bump: Effect.gen(function* () {
+					const next = yield* Ref.updateAndGet(count, (held) => held + 1);
+					const current = yield* Ref.get(desk);
+					const patch = new Patch({
+						type: "patch",
+						version: PROTOCOL_VERSION,
+						rev: Revision.make(current.rev + 1),
+						changes: [
+							{
+								op: "replace",
+								path: ["desk", "workspaces", deskWorkspace, "name"],
+								value: `count ${next}`,
+							},
+						],
+					});
+					yield* Ref.set(desk, snapshotOf(patch.rev, registry, next));
+					yield* Ref.update(patches, (held) => [...held, patch]);
+					return next;
+				}),
+			});
+		}),
 	);
 }
 
@@ -104,28 +166,6 @@ const exchange = Effect.fn("wireProof.exchange")(function* (
 	return {callId, reply: back as SpellReply};
 });
 
-/** The desk a page is holding when the registry arrives: the protocol fixtures' own, plus rows. */
-const snapshotOf = (rev: number, registry: RegistryDescription): Snapshot =>
-	new Snapshot({
-		type: "snapshot",
-		version: PROTOCOL_VERSION,
-		rev: Revision.make(rev),
-		desk: {
-			workspaces: {
-				[deskWorkspace]: {
-					id: deskWorkspace,
-					name: "count 0",
-					layout: {kind: "leaf", window: leftWindow},
-					focused: leftWindow,
-				},
-			},
-			activeWorkspace: deskWorkspace,
-		},
-		windows: {[leftWindow]: {id: leftWindow, recency: 1}},
-		processes: [counterRow],
-		registry,
-	});
-
 describe("the wire", () => {
 	it.effect("answers one reply per call, each carrying that call's own id", () =>
 		Effect.gen(function* () {
@@ -142,7 +182,7 @@ describe("the wire", () => {
 	it.effect("carries the registry in a Snapshot, over the same codec", () =>
 		Effect.gen(function* () {
 			const registry = yield* SpellRegistry.use((held) => held.describe);
-			const sent = yield* encodeKernelMessage(snapshotOf(1, registry)).pipe(Effect.orDie);
+			const sent = yield* encodeKernelMessage(snapshotOf(1, registry, 0)).pipe(Effect.orDie);
 			const back = yield* decodeKernelMessage(sent).pipe(Effect.orDie);
 
 			assert.instanceOf(back, Snapshot);
@@ -158,27 +198,39 @@ describe("the wire", () => {
 
 	it.effect("delivers what a mutation changed as a Patch the page applies over its snapshot", () =>
 		Effect.gen(function* () {
-			const registry = yield* SpellRegistry.use((held) => held.describe);
-			const before = snapshotOf(1, registry);
+			const counter = yield* Counter;
+			const before = yield* counter.desk;
+			assert.deepStrictEqual(yield* counter.emitted, [], "a patch was emitted before any call");
+
+			yield* exchange("c-4", ["count", "read"], {});
+			assert.deepStrictEqual(
+				yield* counter.emitted,
+				[],
+				"a read emitted a patch, so a patch is not what a mutation changed",
+			);
 
 			const {reply} = yield* exchange("c-3", ["count", "bump"], {});
 			assert.deepStrictEqual(resultOf(reply), {count: 1});
 
-			const sent = yield* encodeKernelMessage(
-				new Patch({
-					type: "patch",
-					version: PROTOCOL_VERSION,
-					rev: Revision.make(2),
-					changes: [
-						{op: "replace", path: ["desk", "workspaces", deskWorkspace, "name"], value: "count 1"},
-					],
-				}),
-			).pipe(Effect.orDie);
+			const emitted = yield* counter.emitted;
+			assert.strictEqual(emitted.length, 1, "the mutation did not emit exactly one patch");
+			const [produced] = emitted;
+			assert.isDefined(produced, "the mutation emitted no patch");
+			if (produced === undefined) return;
+
+			const sent = yield* encodeKernelMessage(produced).pipe(Effect.orDie);
 			const delivered = yield* decodeKernelMessage(sent).pipe(Effect.orDie);
 			assert.instanceOf(delivered, Patch);
 
 			const after = yield* applyPatch(before, delivered as Patch);
-			assert.strictEqual(after.rev, 2);
+			// The page's rebuilt desk against the kernel's own: a patch that carried less than the
+			// mutation changed leaves the two disagreeing, which no assertion over the patch's own
+			// text would show.
+			assert.deepStrictEqual(
+				after,
+				yield* counter.desk,
+				"the page that applied the patch is not holding the desk the kernel holds",
+			);
 			assert.strictEqual(after.desk.workspaces[deskWorkspace]?.name, "count 1");
 			assert.strictEqual(
 				before.desk.workspaces[deskWorkspace]?.name,

--- a/apps/tuval/src/reload-proof.unit.test.ts
+++ b/apps/tuval/src/reload-proof.unit.test.ts
@@ -17,6 +17,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Fiber, type FileSystem, Schema, type Scope} from "effect";
 import {afterEach} from "vitest";
 import {type Booted, boot, coreSpells, projectDir} from "./boot.ts";
+import type {Binding} from "./commands/bindings/index.ts";
 import {HelpRows} from "./commands/core/help.ts";
 import {SpellExecutor} from "./commands/executor.ts";
 import {ClientId, renderPath, WorkspaceId} from "./commands/spell.ts";
@@ -83,6 +84,43 @@ const spellPaths = (booted: Booted) =>
 		Effect.map((state) => state.table.rows.map((row) => renderPath(row.path))),
 		Effect.provideContext(booted.kernel),
 	);
+
+/** A compiled binding fired the way a key router fires it: its own path and args, no re-parsing. */
+const fire = (booted: Booted, binding: Binding) =>
+	Effect.gen(function* () {
+		const executor = yield* SpellExecutor;
+		return yield* executor.execute(
+			new SpellCall({
+				type: "spell.call",
+				version: PROTOCOL_VERSION,
+				id: CallId.make(`binding-${binding.key}`),
+				path: binding.path,
+				args: binding.args,
+			}),
+			client,
+		);
+	}).pipe(Effect.provideContext(booted.kernel));
+
+/**
+ * Which of the two configs an observed half came from. The table is told apart by the spell only
+ * one generation registers, the bindings by the key only the first still compiles.
+ *
+ * Pairing the two is what catches the direction a membership check cannot see. The second
+ * generation's bindings are a *subset* of the first generation's table, so an old table observed
+ * beside new bindings resolves every one of them and looks entirely well — only the generations
+ * disagree.
+ */
+type Generation = "first" | "second" | "neither";
+
+const tableGeneration = (paths: ReadonlyArray<string>): Generation => {
+	if (paths.includes("alpha.say")) return "first";
+	return paths.includes("alpha.sey") ? "second" : "neither";
+};
+
+const bindingGeneration = (keys: ReadonlyArray<string>): Generation => {
+	if (keys.includes("ctrl-a")) return "first";
+	return keys.includes("ctrl-b") ? "second" : "neither";
+};
 
 /** `help` as a person runs it, through the executor the kernel wired. */
 const help = (booted: Booted) =>
@@ -169,10 +207,23 @@ describe("a config reload", () => {
 					const state = yield* SpellSet.use((set) => set.read).pipe(
 						Effect.provideContext(booted.kernel),
 					);
+					assert.strictEqual(
+						state.bindings.bindings.length,
+						1,
+						"the reload kept a binding it should have dropped, or dropped one it should have kept",
+					);
+					const [surviving] = state.bindings.bindings;
+					assert.isDefined(surviving, "the binding that still compiles did not survive the reload");
+					if (surviving === undefined) return;
+
+					// Running it, not finding its key in the list: a binding whose path or args the
+					// recompile got wrong is still in that list, under the right key, and does nothing.
+					const reply = yield* fire(booted, surviving);
+					assert.isTrue(reply.ok, "the surviving binding did not run");
 					assert.deepStrictEqual(
-						state.bindings.bindings.map((binding) => binding.key),
-						["ctrl-b"],
-						"the binding that still compiles did not survive the reload",
+						reply.ok ? reply.result : undefined,
+						{name: "greet"},
+						"the surviving binding ran something other than the spell it names",
 					);
 				}),
 			),
@@ -187,6 +238,7 @@ describe("a config reload", () => {
 				const observations: Array<{
 					readonly paths: ReadonlyArray<string>;
 					readonly bound: ReadonlyArray<string>;
+					readonly keys: ReadonlyArray<string>;
 				}> = [];
 				const watch = SpellSet.use((set) => set.read).pipe(
 					Effect.flatMap((state) =>
@@ -194,11 +246,15 @@ describe("a config reload", () => {
 							observations.push({
 								paths: state.table.rows.map((row) => renderPath(row.path)),
 								bound: state.bindings.bindings.map((binding) => renderPath(binding.path)),
+								keys: state.bindings.bindings.map((binding) => binding.key),
 							});
 						}),
 					),
 					Effect.provideContext(booted.kernel),
 				);
+				// One sample taken here rather than left to the forked reader to win a race with the
+				// reload: without it the whole pairing below can pass having only ever seen one config.
+				yield* watch;
 				const reader = yield* Effect.forkChild(Effect.forever(watch));
 
 				yield* booted.reload;
@@ -208,9 +264,14 @@ describe("a config reload", () => {
 				yield* Fiber.interrupt(reader);
 
 				assert.isTrue(observations.length > 1, "the reader took no samples across the reload");
+				assert.deepStrictEqual(
+					[...new Set(observations.map((observed) => tableGeneration(observed.paths)))].sort(),
+					["first", "second"],
+					"the reader never saw both configs, so it never watched across the swap",
+				);
 				for (const observed of observations) {
-					// The one thing a half-replaced pair would show: a binding compiled against a table
-					// that no longer holds the spell it points at.
+					// One direction: a binding compiled against a table that no longer holds the spell it
+					// points at — a new table beside old bindings.
 					for (const bound of observed.bound) {
 						assert.include(
 							observed.paths,
@@ -218,6 +279,13 @@ describe("a config reload", () => {
 							"a binding was observed beside a registry that does not hold its spell",
 						);
 					}
+					// The other: an old table beside new bindings, which the check above cannot see
+					// because the second config's bindings all resolve against the first config's table.
+					assert.strictEqual(
+						bindingGeneration(observed.keys),
+						tableGeneration(observed.paths),
+						"one config's table was observed beside the other config's bindings",
+					);
 				}
 				const last = observations.at(-1);
 				assert.include(last?.paths ?? [], "alpha.sey", "the reader never saw the reloaded table");


### PR DESCRIPTION
Five Tuval proofs asserted less than their names claimed, and `spell-set.ts` had no test. Each is fixed in place; no production code changed.

**`reload-proof.unit.test.ts`** — the atomicity check only caught a new table beside old bindings. The second config's bindings are a subset of the first config's table, so an old table beside new bindings resolved every binding and looked well. Each observation now classifies both halves by generation and asserts they agree, which catches both directions; the reader also takes one sample before forking, and the test asserts it saw both configs, so the pairing can't pass vacuously. The surviving binding is now fired through the executor and its result checked, instead of finding `ctrl-b` in the compiled list.

**`wire-proof.unit.test.ts`** — the `Patch` leg asserted over a patch the test wrote. The `Counter` service now holds the kernel's desk and emits the patch `count.bump` produced; the leg asserts a read emits none, the mutation emits exactly one, and that the page's desk after applying it equals the kernel's own.

**`parse/property.unit.test.ts`** — the corpus was bare lowercase words, missing exactly the four cases `tokenize.ts` and `reading.ts` hand-roll. Arguments are now written bare, quoted, backslash-escaped or as `name=value`, over values carrying a space, a quote, a backslash and an `=`. A new leg asserts the corpus actually reaches all four, and the prefix property now also pins the args each full line parses to — a quoted value read back as raw text is a Complete line with the wrong call. Both properties hold over the wider corpus; no tokenizer defect surfaced.

**`pattern-doc-paths.unit.test.ts`** — `toBeGreaterThan(20)` passed on a doc that lost half its citations. The file table is now read row by row: every row must link, link to the module it names under `apps/tuval/src/`, and the identifiers it lists must still be findable in that file. Verified by temporarily stripping one row's link — the test fails and names the row.

**`agent-proof.unit.test.ts`** — `argumentFor` returned `""` for a parameter neither the world map nor the schema could settle, so a future spell would pass trivially. It now returns an `unsettled` sentinel; the parameter is left out of the call (so the kernel refuses it) and named in a list both runs assert is empty. Verified by temporarily removing a world entry — both the plain-row and service-agent runs fail and name the parameter.

**`spell-set.unit.test.ts`** — new. Covers the one-cell invariant directly: table plus sources plus compiled bindings in one read, decoded binding args, a broken binding costing only its key, layer order, `reload` recompiling in one write, the narrower `registry.swap` recompiling too, and the registry reading that same cell.

`pnpm --filter @kampus/tuval test` is green (131 files, 1067 tests).

## Deviations

- **Out-of-scope change** — **Said:** #7765 asks for a per-module check on `pattern-doc-paths.unit.test.ts`. **Did:** also widened the row parser to match every table row, not only rows starting with `| [`. **Why:** a filter keyed on the link prefix silently skips a row that lost its link, which is the exact drift the check exists to catch — the narrower parser passed on a doc I had broken. **Disposition:** stated here.

Fixes #7765
