### PR TITLE
chore: Thirteen Tuval test files use Effect.runPromise inside it, which .patterns/effect-testing.md rules against

### DIFF
--- a/apps/tuval/src/ai-agent/ports/ports.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/ports.unit.test.ts
@@ -1,5 +1,5 @@
+import {assert, describe, expect, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {agentSide, windowSide} from "../../ai-agent-fixtures/programs.ts";
 import {compile} from "../../ports/compile.ts";
 import {IncompatibleRoute} from "../../ports/errors.ts";
@@ -20,9 +20,8 @@ const node = (id: string, program: string, on: Graph["nodes"][number]["on"] = []
 
 const to = (node: string, port: string) => ({node: NodeId.make(node), port});
 
-const compiled = (graph: Graph) => Effect.runPromise(Effect.provide(compile(graph), registry));
-const refusal = (graph: Graph) =>
-	Effect.runPromise(Effect.flip(Effect.provide(compile(graph), registry)));
+const compiled = (graph: Graph) => Effect.provide(compile(graph), registry);
+const refusal = (graph: Graph) => Effect.flip(Effect.provide(compile(graph), registry));
 
 describe("the five AI agent ports", () => {
 	it("declares five ports, each with its own kind", () => {
@@ -65,34 +64,39 @@ describe("the five AI agent ports", () => {
 });
 
 describe("route compatibility over the five ports", () => {
-	it("compiles the whole interface when the two halves mirror each other", async () => {
-		const graph = await compiled({
-			nodes: [
-				node("agent", "ai-agent-fixture", [
-					{port: "transcript", to: to("window", "transcript")},
-					{port: "pageReply", to: to("window", "pageReply")},
-					{port: "permissionPending", to: to("window", "permissionPending")},
-					{port: "modeState", to: to("window", "modeState")},
-				]),
-				node("window", "ai-agent-window-fixture", [
-					{port: "prompt", to: to("agent", "prompt")},
-					{port: "pageRequest", to: to("agent", "pageRequest")},
-					{port: "permissionDecision", to: to("agent", "permissionDecision")},
-					{port: "modeSet", to: to("agent", "modeSet")},
-				]),
-			],
-		});
-		expect(graph.routes.map((route) => route.kind)).toEqual([
-			transcript.kind,
-			transcriptPage.kind,
-			permission.kind,
-			mode.kind,
-			prompt.kind,
-			transcriptPage.kind,
-			permission.kind,
-			mode.kind,
-		]);
-	});
+	it.effect("compiles the whole interface when the two halves mirror each other", () =>
+		Effect.gen(function* () {
+			const graph = yield* compiled({
+				nodes: [
+					node("agent", "ai-agent-fixture", [
+						{port: "transcript", to: to("window", "transcript")},
+						{port: "pageReply", to: to("window", "pageReply")},
+						{port: "permissionPending", to: to("window", "permissionPending")},
+						{port: "modeState", to: to("window", "modeState")},
+					]),
+					node("window", "ai-agent-window-fixture", [
+						{port: "prompt", to: to("agent", "prompt")},
+						{port: "pageRequest", to: to("agent", "pageRequest")},
+						{port: "permissionDecision", to: to("agent", "permissionDecision")},
+						{port: "modeSet", to: to("agent", "modeSet")},
+					]),
+				],
+			});
+			assert.deepStrictEqual(
+				graph.routes.map((route) => route.kind),
+				[
+					transcript.kind,
+					transcriptPage.kind,
+					permission.kind,
+					mode.kind,
+					prompt.kind,
+					transcriptPage.kind,
+					permission.kind,
+					mode.kind,
+				],
+			);
+		}),
+	);
 
 	const agentNode = {node: "agent", program: "ai-agent-fixture"} as const;
 	const windowNode = {node: "window", program: "ai-agent-window-fixture"} as const;
@@ -150,28 +154,29 @@ describe("route compatibility over the five ports", () => {
 		{at: windowNode, from: "modeSet", to: agentNode, into: "prompt", src: mode, dst: prompt},
 	] as const;
 
-	it.each(
-		crossings,
-	)("refuses $from routed into a $into port before boot, naming both kinds", async ({
-		at,
-		from,
-		to: target,
-		into,
-		src,
-		dst,
-	}) => {
-		const error = await refusal({
-			nodes: [
-				node(at.node, at.program, [{port: from, to: to(target.node, into)}]),
-				node(target.node, target.program),
-			],
-		});
-		expect(error).toBeInstanceOf(IncompatibleRoute);
-		expect(error).toMatchObject({
-			source: {program: at.program, port: from, kind: src.kind},
-			target: {program: target.program, port: into, kind: dst.kind},
-		});
-		expect(error.message).toContain(src.kind);
-		expect(error.message).toContain(dst.kind);
-	});
+	it.effect.each(crossings)(
+		"refuses $from routed into a $into port before boot, naming both kinds",
+		({at, from, to: target, into, src, dst}) =>
+			Effect.gen(function* () {
+				const error = yield* refusal({
+					nodes: [
+						node(at.node, at.program, [{port: from, to: to(target.node, into)}]),
+						node(target.node, target.program),
+					],
+				});
+				assert.instanceOf(error, IncompatibleRoute);
+				assert.deepStrictEqual(error.source, {
+					program: ProgramId.make(at.program),
+					port: from,
+					kind: src.kind,
+				});
+				assert.deepStrictEqual(error.target, {
+					program: ProgramId.make(target.program),
+					port: into,
+					kind: dst.kind,
+				});
+				assert.include(error.message, src.kind);
+				assert.include(error.message, dst.kind);
+			}),
+	);
 });

--- a/apps/tuval/src/boot.unit.test.ts
+++ b/apps/tuval/src/boot.unit.test.ts
@@ -4,8 +4,9 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {NodeFileSystem} from "@effect/platform-node";
-import {Effect} from "effect";
-import {afterEach, describe, expect, it} from "vitest";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Schema} from "effect";
+import {afterEach, expect} from "vitest";
 import {boot, coreSpells, defaultGlobalConfig, projectConfig, projectDir} from "./boot.ts";
 import {shellSpells} from "./shell/commands/spells.ts";
 
@@ -111,30 +112,35 @@ const seededProject = (version: string) => {
 	return project;
 };
 
+class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defect()}) {}
+
+const io = <A>(run: () => Promise<A>) =>
+	Effect.tryPromise({try: run, catch: (cause) => new TestIo({cause})});
+
 const bootDirect = (global: string, project: string) =>
-	Effect.runPromise(
-		boot({global, project}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer)),
-	);
+	boot({global, project}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
 
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) rmSync(dir, {recursive: true, force: true});
 });
 
 describe("boot", () => {
-	it("registers the rows the config module exports and reports their count", async () => {
-		const project = freshProject();
-		const {report} = await bootDirect(fixture("two-rows"), project);
-		expect(report).toEqual({
-			sources: [fixture("two-rows")],
-			programCount: 2,
-			spellCount: CORE_SPELLS,
-			bindingCount: 0,
-			bindingErrors: [],
-			stateDir: projectDir(project),
-			processCount: 0,
-			restoredCount: 0,
-		});
-	});
+	it.effect("registers the rows the config module exports and reports their count", () =>
+		Effect.gen(function* () {
+			const project = freshProject();
+			const {report} = yield* bootDirect(fixture("two-rows"), project);
+			assert.deepStrictEqual(report, {
+				sources: [fixture("two-rows")],
+				programCount: 2,
+				spellCount: CORE_SPELLS,
+				bindingCount: 0,
+				bindingErrors: [],
+				stateDir: projectDir(project),
+				processCount: 0,
+				restoredCount: 0,
+			});
+		}),
+	);
 
 	it("exits on its own when the config plans no process", () => {
 		const project = freshProject();
@@ -208,26 +214,27 @@ describe("boot", () => {
 		spawnBudget(2),
 	);
 
-	it(
+	it.effect(
 		"restores every checkpointed process from the project's state through Demlik's fileStore",
-		async () => {
-			const project = seededProject("1.0.0");
-			const {report} = await bootDirect(fixture("one-counter"), project);
-			expect(report).toMatchObject({processCount: 1, restoredCount: 1});
-			const result = await runUntilRunning([
-				"--config",
-				fixture("one-counter"),
-				"--project",
-				project,
-			]);
-			expect(result.status).toBe(0);
-			expect(result.stdout).toContain(
-				`tuval: booted — 1 program(s), ${CORE_SPELLS} spell(s) registered from ${fixture("one-counter")}; 1 process(es) live, 1 restored from ${projectDir(project)}\n`,
-			);
-			expect(result.stdout).toContain(
-				"tuval: process p-1 program=counter parent=- ports=- state=running@0\n",
-			);
-		},
+		() =>
+			Effect.gen(function* () {
+				const project = seededProject("1.0.0");
+				const {report} = yield* bootDirect(fixture("one-counter"), project);
+				assert.strictEqual(report.processCount, 1);
+				assert.strictEqual(report.restoredCount, 1);
+				const result = yield* io(() =>
+					runUntilRunning(["--config", fixture("one-counter"), "--project", project]),
+				);
+				assert.strictEqual(result.status, 0);
+				assert.include(
+					result.stdout,
+					`tuval: booted — 1 program(s), ${CORE_SPELLS} spell(s) registered from ${fixture("one-counter")}; 1 process(es) live, 1 restored from ${projectDir(project)}\n`,
+				);
+				assert.include(
+					result.stdout,
+					"tuval: process p-1 program=counter parent=- ports=- state=running@0\n",
+				);
+			}),
 		spawnBudget(1),
 	);
 

--- a/apps/tuval/src/claude/tools/server.unit.test.ts
+++ b/apps/tuval/src/claude/tools/server.unit.test.ts
@@ -3,14 +3,14 @@
  * Nothing here reaches a kernel — `KernelBridge.scripted` is the whole world, which is what makes
  * every assertion below deterministic.
  *
- * These are plain async tests rather than `it.effect` ones: a tool handler is a `Promise`, which is
- * the whole point of the seam, and awaiting one inside an Effect would mean `Effect.promise`, which
- * this repo bans.
+ * A tool handler answers a `Promise`, which is the whole point of the seam, so each call is lifted
+ * back into the test's Effect through `answered` below — object-notation `Effect.tryPromise` plus
+ * `orDie`, the repo's sanctioned stand-in for the banned `Effect.promise` (#2736).
  */
 
+import {assert, describe, it} from "@effect/vitest";
 import type {CallToolResult} from "@modelcontextprotocol/sdk/types.js";
-import {Effect} from "effect";
-import {assert, describe, it} from "vitest";
+import {type Context, Effect, Schema} from "effect";
 import {ProcessId} from "../../process/process.ts";
 import {ProgramId} from "../../registry/program.ts";
 import {KernelBridge, type ScriptedKernel} from "./KernelBridge.ts";
@@ -30,26 +30,37 @@ const table: ScriptedKernel = {
 	},
 };
 
-/** The per-process runtime, plus a count, so a handler that ran its Effect elsewhere is visible. */
-const countingRuntime = (): ToolRuntime & {readonly runs: () => number} => {
+/**
+ * The per-process runtime, plus a count, so a handler that ran its Effect elsewhere is visible. It
+ * is built the way `ClaudeAiAgent` builds the real one — `Effect.runPromiseWith` over the services
+ * the caller was running under — so a handler here keeps this test's fiber services rather than
+ * running on a bare default runtime.
+ */
+const countingRuntime = (
+	services: Context.Context<never>,
+): ToolRuntime & {readonly runs: () => number} => {
 	let runs = 0;
+	const run = Effect.runPromiseWith(services);
 	return {
 		runPromise: (effect) => {
 			runs++;
-			return Effect.runPromise(effect);
+			return run(effect);
 		},
 		runs: () => runs,
 	};
 };
 
+class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defect()}) {}
+
+const answered = <A>(call: () => Promise<A>): Effect.Effect<A> =>
+	Effect.tryPromise({try: call, catch: (cause) => new TestIo({cause})}).pipe(Effect.orDie);
+
 const server = () =>
-	Effect.runPromise(
-		Effect.gen(function* () {
-			const bridge = yield* KernelBridge;
-			const run = countingRuntime();
-			return {tools: tuvalToolServer(bridge, run), run};
-		}).pipe(Effect.provide(KernelBridge.scripted(table))),
-	);
+	Effect.gen(function* () {
+		const bridge = yield* KernelBridge;
+		const run = countingRuntime(yield* Effect.context<never>());
+		return {tools: tuvalToolServer(bridge, run), run};
+	}).pipe(Effect.provide(KernelBridge.scripted(table)));
 
 const textOf = (result: CallToolResult): string => {
 	const first = result.content[0];
@@ -58,95 +69,118 @@ const textOf = (result: CallToolResult): string => {
 };
 
 describe("the tuval tool server", () => {
-	it("registers exactly the three tools, on the tuval server, at their wire names", async () => {
-		const {tools} = await server();
-		assert.strictEqual(tools.name, "tuval");
-		assert.deepStrictEqual(
-			tools.tools.map((one) => one.name),
-			["spawn", "send", "read"],
-		);
-		assert.deepStrictEqual(tools.wireNames, [
-			"mcp__tuval__spawn",
-			"mcp__tuval__send",
-			"mcp__tuval__read",
-		]);
-		assert.strictEqual(wireNameOf("spawn"), "mcp__tuval__spawn");
-		assert.strictEqual(tools.server.name, "tuval");
-		assert.isDefined(tools.server.instance, "the server carries no in-process instance");
-		for (const one of tools.tools) {
-			assert.isAbove(one.description.length, 0, `${one.name} carries no description`);
-			assert.notInclude(one.description, scriptedProgram, `${one.name} names a program`);
-		}
-	});
+	it.effect("registers exactly the three tools, on the tuval server, at their wire names", () =>
+		Effect.gen(function* () {
+			const {tools} = yield* server();
+			assert.strictEqual(tools.name, "tuval");
+			assert.deepStrictEqual(
+				tools.tools.map((one) => one.name),
+				["spawn", "send", "read"],
+			);
+			assert.deepStrictEqual(tools.wireNames, [
+				"mcp__tuval__spawn",
+				"mcp__tuval__send",
+				"mcp__tuval__read",
+			]);
+			assert.strictEqual(wireNameOf("spawn"), "mcp__tuval__spawn");
+			assert.strictEqual(tools.server.name, "tuval");
+			assert.isDefined(tools.server.instance, "the server carries no in-process instance");
+			for (const one of tools.tools) {
+				assert.isAbove(one.description.length, 0, `${one.name} carries no description`);
+				assert.notInclude(one.description, scriptedProgram, `${one.name} names a program`);
+			}
+		}),
+	);
 
-	it("every handler runs its Effect through the runtime it was given", async () => {
-		const {tools, run} = await server();
-		await tools.handlers.spawn({program: scriptedProgram});
-		await tools.handlers.send({process: scriptedProcess, port: "words", payload: "hi"});
-		await tools.handlers.read({process: scriptedProcess, port: "echoed"});
-		assert.strictEqual(run.runs(), 3, "a handler ran its Effect outside the supplied runtime");
-	});
+	it.effect("every handler runs its Effect through the runtime it was given", () =>
+		Effect.gen(function* () {
+			const {tools, run} = yield* server();
+			yield* answered(() => tools.handlers.spawn({program: scriptedProgram}));
+			yield* answered(() =>
+				tools.handlers.send({process: scriptedProcess, port: "words", payload: "hi"}),
+			);
+			yield* answered(() => tools.handlers.read({process: scriptedProcess, port: "echoed"}));
+			assert.strictEqual(run.runs(), 3, "a handler ran its Effect outside the supplied runtime");
+		}),
+	);
 
-	it("each handler answers a CallToolResult carrying the bridge's own answer", async () => {
-		const {tools} = await server();
+	it.effect("each handler answers a CallToolResult carrying the bridge's own answer", () =>
+		Effect.gen(function* () {
+			const {tools} = yield* server();
 
-		const spawned = await tools.handlers.spawn({program: scriptedProgram});
-		assert.isNotTrue(spawned.isError);
-		assert.deepStrictEqual(JSON.parse(textOf(spawned)), {process: scriptedProcess});
+			const spawned = yield* answered(() => tools.handlers.spawn({program: scriptedProgram}));
+			assert.isNotTrue(spawned.isError);
+			assert.deepStrictEqual(JSON.parse(textOf(spawned)), {process: scriptedProcess});
 
-		const sent = await tools.handlers.send({
-			process: scriptedProcess,
-			port: "words",
-			payload: "hi",
-		});
-		assert.isNotTrue(sent.isError);
-		assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true});
+			const sent = yield* answered(() =>
+				tools.handlers.send({
+					process: scriptedProcess,
+					port: "words",
+					payload: "hi",
+				}),
+			);
+			assert.isNotTrue(sent.isError);
+			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true});
 
-		const held = await tools.handlers.read({process: scriptedProcess, port: "echoed"});
-		assert.isNotTrue(held.isError);
-		assert.deepStrictEqual(JSON.parse(textOf(held)), {empty: false, value: "HI"});
-	});
+			const held = yield* answered(() =>
+				tools.handlers.read({process: scriptedProcess, port: "echoed"}),
+			);
+			assert.isNotTrue(held.isError);
+			assert.deepStrictEqual(JSON.parse(textOf(held)), {empty: false, value: "HI"});
+		}),
+	);
 
-	it("a bridge refusal is an isError result carrying the tag, never a throw", async () => {
-		const {tools} = await server();
+	it.effect("a bridge refusal is an isError result carrying the tag, never a throw", () =>
+		Effect.gen(function* () {
+			const {tools} = yield* server();
 
-		const missing = await tools.handlers.spawn({program: "nothing-registered"});
-		assert.isTrue(missing.isError);
-		assert.include(textOf(missing), "tuval/claude/UnknownProgram");
+			const missing = yield* answered(() => tools.handlers.spawn({program: "nothing-registered"}));
+			assert.isTrue(missing.isError);
+			assert.include(textOf(missing), "tuval/claude/UnknownProgram");
 
-		// A payload of the wrong kind: the tag and the kind the port takes both reach the model.
-		const refused = await tools.handlers.send({
-			process: scriptedProcess,
-			port: "words",
-			payload: 7,
-		});
-		assert.isTrue(refused.isError);
-		assert.include(textOf(refused), "tuval/claude/PortRefused");
-		assert.include(textOf(refused), WORD_KIND);
+			// A payload of the wrong kind: the tag and the kind the port takes both reach the model.
+			const refused = yield* answered(() =>
+				tools.handlers.send({
+					process: scriptedProcess,
+					port: "words",
+					payload: 7,
+				}),
+			);
+			assert.isTrue(refused.isError);
+			assert.include(textOf(refused), "tuval/claude/PortRefused");
+			assert.include(textOf(refused), WORD_KIND);
 
-		const nowhere = await tools.handlers.read({process: scriptedProcess, port: "absent"});
-		assert.isTrue(nowhere.isError);
-		assert.include(textOf(nowhere), "tuval/claude/UnknownPort");
-	});
+			const nowhere = yield* answered(() =>
+				tools.handlers.read({process: scriptedProcess, port: "absent"}),
+			);
+			assert.isTrue(nowhere.isError);
+			assert.include(textOf(nowhere), "tuval/claude/UnknownPort");
+		}),
+	);
 
 	// The test's own timeout is the assertion: a `read` that waited on an empty port would run out
 	// of it rather than answering.
-	it("read on a port that has said nothing answers empty rather than waiting", {
-		timeout: 1000,
-	}, async () => {
-		const {tools} = await server();
-		const held = await tools.handlers.read({process: scriptedProcess, port: "quiet"});
-		assert.isNotTrue(held.isError);
-		assert.deepStrictEqual(JSON.parse(textOf(held)), {empty: true});
-	});
-
-	it("the scripted bridge takes whatever program id it is handed", async () => {
-		const spawned = await Effect.runPromise(
+	it.effect(
+		"read on a port that has said nothing answers empty rather than waiting",
+		() =>
 			Effect.gen(function* () {
+				const {tools} = yield* server();
+				const held = yield* answered(() =>
+					tools.handlers.read({process: scriptedProcess, port: "quiet"}),
+				);
+				assert.isNotTrue(held.isError);
+				assert.deepStrictEqual(JSON.parse(textOf(held)), {empty: true});
+			}),
+		{timeout: 1000},
+	);
+
+	it.effect("the scripted bridge takes whatever program id it is handed", () =>
+		Effect.gen(function* () {
+			const spawned = yield* Effect.gen(function* () {
 				const bridge = yield* KernelBridge;
 				return yield* bridge.spawn(ProgramId.make(scriptedProgram));
-			}).pipe(Effect.provide(KernelBridge.scripted(table))),
-		);
-		assert.strictEqual(spawned, scriptedProcess);
-	});
+			}).pipe(Effect.provide(KernelBridge.scripted(table)));
+			assert.strictEqual(spawned, scriptedProcess);
+		}),
+	);
 });

--- a/apps/tuval/src/commands/bindings/compile.unit.test.ts
+++ b/apps/tuval/src/commands/bindings/compile.unit.test.ts
@@ -1,5 +1,5 @@
+import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {type AnySpell, renderPath} from "../spell.ts";
 import {type BindingSource, compileBindings, type KeyBindings} from "./compile.ts";
 import {renderBindingErrors} from "./errors.ts";
@@ -8,98 +8,127 @@ import {registry, spells} from "./fixtures.ts";
 const FILE = "global .tuval/tuval.config.ts";
 
 const compile = (bindings: KeyBindings, only?: ReadonlyArray<AnySpell>) =>
-	Effect.runPromise(
-		Effect.flatMap(registry(only), (table) =>
-			compileBindings({file: FILE, bindings} satisfies BindingSource, table),
-		),
+	Effect.flatMap(registry(only), (table) =>
+		compileBindings({file: FILE, bindings} satisfies BindingSource, table),
 	);
 
 const withoutSwap = spells.filter((spell) => renderPath(spell.path) !== "window.swap");
 
 describe("compileBindings", () => {
-	it("compiles the valid bindings and reports the one naming an unknown spell", async () => {
-		const {bindings, errors} = await compile({
-			"ctrl+w": "window close",
-			"ctrl+n": "workspace next",
-			"ctrl+l": "window swap right",
-			"ctrl+x": "windwo close",
-		});
+	it.effect("compiles the valid bindings and reports the one naming an unknown spell", () =>
+		Effect.gen(function* () {
+			const {bindings, errors} = yield* compile({
+				"ctrl+w": "window close",
+				"ctrl+n": "workspace next",
+				"ctrl+l": "window swap right",
+				"ctrl+x": "windwo close",
+			});
 
-		expect(bindings.map((binding) => binding.key)).toEqual(["ctrl+w", "ctrl+n", "ctrl+l"]);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toMatchObject({
-			file: FILE,
-			key: "ctrl+x",
-			position: 0,
-			expected: "window|workspace",
-			didYouMean: "window",
-		});
-	});
+			assert.deepStrictEqual(
+				bindings.map((binding) => binding.key),
+				["ctrl+w", "ctrl+n", "ctrl+l"],
+			);
+			assert.lengthOf(errors, 1);
+			const [error] = errors;
+			assert.strictEqual(error?.file, FILE);
+			assert.strictEqual(error?.key, "ctrl+x");
+			assert.strictEqual(error?.position, 0);
+			assert.strictEqual(error?.expected, "window|workspace");
+			assert.strictEqual(error?.didYouMean, "window");
+		}),
+	);
 
-	it("carries the arguments the spell's params decoded, not the token text", async () => {
-		const {bindings, errors} = await compile({"ctrl+.": "window grow 3"});
+	it.effect("carries the arguments the spell's params decoded, not the token text", () =>
+		Effect.gen(function* () {
+			const {bindings, errors} = yield* compile({"ctrl+.": "window grow 3"});
 
-		expect(errors).toEqual([]);
-		expect(bindings).toEqual([{key: "ctrl+.", path: ["window", "grow"], args: {columns: 3}}]);
-	});
+			assert.deepStrictEqual(errors, []);
+			assert.deepStrictEqual(bindings, [
+				{key: "ctrl+.", path: ["window", "grow"], args: {columns: 3}},
+			]);
+		}),
+	);
 
-	it("reports an argument the spell's params refuse, pointing at the argument's own token", async () => {
-		const {bindings, errors} = await compile({"ctrl+.": "window grow wide"});
+	it.effect(
+		"reports an argument the spell's params refuse, pointing at the argument's own token",
+		() =>
+			Effect.gen(function* () {
+				const {bindings, errors} = yield* compile({"ctrl+.": "window grow wide"});
 
-		expect(bindings).toEqual([]);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toMatchObject({file: FILE, key: "ctrl+.", position: 12});
-		expect(errors[0]?.message).toContain("at character 12");
-	});
+				assert.deepStrictEqual(bindings, []);
+				assert.lengthOf(errors, 1);
+				const [error] = errors;
+				assert.strictEqual(error?.file, FILE);
+				assert.strictEqual(error?.key, "ctrl+.");
+				assert.strictEqual(error?.position, 12);
+				assert.include(error?.message ?? "", "at character 12");
+			}),
+	);
 
-	it("sets `repeat` from the object form and leaves it unset for a bare string", async () => {
-		const {bindings, errors} = await compile({
-			"ctrl+n": {command: "workspace next", repeat: true},
-			"ctrl+w": "window close",
-		});
+	it.effect("sets `repeat` from the object form and leaves it unset for a bare string", () =>
+		Effect.gen(function* () {
+			const {bindings, errors} = yield* compile({
+				"ctrl+n": {command: "workspace next", repeat: true},
+				"ctrl+w": "window close",
+			});
 
-		expect(errors).toEqual([]);
-		expect(bindings).toEqual([
-			{key: "ctrl+n", path: ["workspace", "next"], args: {}, repeat: true},
-			{key: "ctrl+w", path: ["window", "close"], args: {}},
-		]);
-	});
+			assert.deepStrictEqual(errors, []);
+			assert.deepStrictEqual(bindings, [
+				{key: "ctrl+n", path: ["workspace", "next"], args: {}, repeat: true},
+				{key: "ctrl+w", path: ["window", "close"], args: {}},
+			]);
+		}),
+	);
 
-	it("reports a binding that never finished naming its arguments", async () => {
-		const {bindings, errors} = await compile({"ctrl+1": "workspace activate"});
+	it.effect("reports a binding that never finished naming its arguments", () =>
+		Effect.gen(function* () {
+			const {bindings, errors} = yield* compile({"ctrl+1": "workspace activate"});
 
-		expect(bindings).toEqual([]);
-		expect(errors[0]).toMatchObject({
-			key: "ctrl+1",
-			position: "workspace activate".length,
-			expected: "<workspace>",
-		});
-	});
+			assert.deepStrictEqual(bindings, []);
+			const [error] = errors;
+			assert.strictEqual(error?.key, "ctrl+1");
+			assert.strictEqual(error?.position, "workspace activate".length);
+			assert.strictEqual(error?.expected, "<workspace>");
+		}),
+	);
 
-	it("re-validates every binding against the registry it is handed", async () => {
-		const bindings: KeyBindings = {
-			"ctrl+w": "window close",
-			"ctrl+l": "window swap right",
-			"ctrl+n": "workspace next",
-		};
+	it.effect("re-validates every binding against the registry it is handed", () =>
+		Effect.gen(function* () {
+			const bindings: KeyBindings = {
+				"ctrl+w": "window close",
+				"ctrl+l": "window swap right",
+				"ctrl+n": "workspace next",
+			};
 
-		const before = await compile(bindings);
-		expect(before.errors).toEqual([]);
-		expect(before.bindings).toHaveLength(3);
+			const before = yield* compile(bindings);
+			assert.deepStrictEqual(before.errors, []);
+			assert.lengthOf(before.bindings, 3);
 
-		const after = await compile(bindings, withoutSwap);
-		expect(after.bindings.map((binding) => binding.key)).toEqual(["ctrl+w", "ctrl+n"]);
-		expect(after.errors.map((error) => error.key)).toEqual(["ctrl+l"]);
-	});
+			const after = yield* compile(bindings, withoutSwap);
+			assert.deepStrictEqual(
+				after.bindings.map((binding) => binding.key),
+				["ctrl+w", "ctrl+n"],
+			);
+			assert.deepStrictEqual(
+				after.errors.map((error) => error.key),
+				["ctrl+l"],
+			);
+		}),
+	);
 
-	it("names no absolute path in any line it renders", async () => {
-		const {errors} = await compile({"ctrl+x": "windwo close", "ctrl+1": "workspace activate"});
-		const lines = renderBindingErrors(errors);
+	it.effect("names no absolute path in any line it renders", () =>
+		Effect.gen(function* () {
+			const {errors} = yield* compile({
+				"ctrl+x": "windwo close",
+				"ctrl+1": "workspace activate",
+			});
+			const lines = renderBindingErrors(errors);
 
-		expect(lines).toHaveLength(2);
-		for (const line of lines) {
-			expect(line.startsWith(FILE)).toBe(true);
-			expect(line).not.toMatch(/(^|\s)[/~]/);
-		}
-	});
+			assert.lengthOf(lines, 2);
+			for (const line of lines) {
+				assert.strictEqual(line.startsWith(FILE), true);
+				assert.notMatch(line, /(^|\s)[/~]/);
+			}
+		}),
+	);
 });

--- a/apps/tuval/src/commands/bindings/errors.unit.test.ts
+++ b/apps/tuval/src/commands/bindings/errors.unit.test.ts
@@ -1,5 +1,5 @@
+import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {compileBindings, type KeyBindings} from "./compile.ts";
 import {renderBindingErrors} from "./errors.ts";
 import {describeFile} from "./file.ts";
@@ -12,51 +12,52 @@ const file = describeFile({
 });
 
 const lines = (bindings: KeyBindings) =>
-	Effect.runPromise(
-		Effect.flatMap(registry(), (table) =>
-			Effect.map(compileBindings({file, bindings}, table), (compiled) =>
-				renderBindingErrors(compiled.errors),
-			),
+	Effect.flatMap(registry(), (table) =>
+		Effect.map(compileBindings({file, bindings}, table), (compiled) =>
+			renderBindingErrors(compiled.errors),
 		),
 	);
 
 describe("renderBindingErrors", () => {
-	it("renders a mistyped spell with the nearest one it holds", async () => {
-		expect(await lines({"ctrl+x": "windwo close"})).toMatchInlineSnapshot(`
-			[
-			  "global .tuval/tuval.config.ts: cannot bind "ctrl+x": at character 0, expected window|workspace; did you mean "window"?",
-			]
-		`);
-	});
+	it.effect("renders a mistyped spell with the nearest one it holds", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(yield* lines({"ctrl+x": "windwo close"}), [
+				'global .tuval/tuval.config.ts: cannot bind "ctrl+x": at character 0, expected window|workspace; did you mean "window"?',
+			]);
+		}),
+	);
 
-	it("renders a binding that stops before an argument it owes", async () => {
-		expect(await lines({"ctrl+1": "workspace activate"})).toMatchInlineSnapshot(`
-			[
-			  "global .tuval/tuval.config.ts: cannot bind "ctrl+1": at character 18, expected <workspace>",
-			]
-		`);
-	});
+	it.effect("renders a binding that stops before an argument it owes", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(yield* lines({"ctrl+1": "workspace activate"}), [
+				'global .tuval/tuval.config.ts: cannot bind "ctrl+1": at character 18, expected <workspace>',
+			]);
+		}),
+	);
 
-	it("renders an argument outside the choices its parameter allows", async () => {
-		expect(await lines({"ctrl+l": "window swap sideways"})).toMatchInlineSnapshot(`
-			[
-			  "global .tuval/tuval.config.ts: cannot bind "ctrl+l": at character 12, expected left|right|up|down",
-			]
-		`);
-	});
+	it.effect("renders an argument outside the choices its parameter allows", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(yield* lines({"ctrl+l": "window swap sideways"}), [
+				'global .tuval/tuval.config.ts: cannot bind "ctrl+l": at character 12, expected left|right|up|down',
+			]);
+		}),
+	);
 
-	it("renders one line per error, in the order the config wrote them", async () => {
-		expect(
-			await lines({"ctrl+x": "windwo close", "ctrl+1": "workspace activate"}),
-		).toMatchInlineSnapshot(`
-			[
-			  "global .tuval/tuval.config.ts: cannot bind "ctrl+x": at character 0, expected window|workspace; did you mean "window"?",
-			  "global .tuval/tuval.config.ts: cannot bind "ctrl+1": at character 18, expected <workspace>",
-			]
-		`);
-	});
+	it.effect("renders one line per error, in the order the config wrote them", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(
+				yield* lines({"ctrl+x": "windwo close", "ctrl+1": "workspace activate"}),
+				[
+					'global .tuval/tuval.config.ts: cannot bind "ctrl+x": at character 0, expected window|workspace; did you mean "window"?',
+					'global .tuval/tuval.config.ts: cannot bind "ctrl+1": at character 18, expected <workspace>',
+				],
+			);
+		}),
+	);
 
-	it("renders nothing when every binding compiled", async () => {
-		expect(await lines({"ctrl+w": "window close"})).toEqual([]);
-	});
+	it.effect("renders nothing when every binding compiled", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(yield* lines({"ctrl+w": "window close"}), []);
+		}),
+	);
 });

--- a/apps/tuval/src/commands/core/help.unit.test.ts
+++ b/apps/tuval/src/commands/core/help.unit.test.ts
@@ -1,95 +1,111 @@
+import {assert, describe, expect, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {SpellRegistry} from "../registry.ts";
 import {scope, smallerTable, table} from "./fixtures.ts";
 import {helpSpell, renderHelp} from "./help.ts";
 
 const ask = (path?: string) =>
-	Effect.runPromise(
-		Effect.flatMap(table, (built) =>
-			helpSpell
-				.execute(path === undefined ? {} : {path}, scope)
-				.pipe(Effect.provide(SpellRegistry.layer(built))),
-		),
+	Effect.flatMap(table, (built) =>
+		helpSpell
+			.execute(path === undefined ? {} : {path}, scope)
+			.pipe(Effect.provide(SpellRegistry.layer(built))),
 	);
 
 describe("help", () => {
-	it("lists every registered spell once, grouped by first segment and sorted", async () => {
-		const rows = await ask();
-		expect(rows.map((row) => row.path)).toEqual([
-			"editor buffer next",
-			"editor save",
-			"help",
-			"spell describe",
-			"spell list",
-			"window close",
-			"window focus",
-			"window swap",
-		]);
-	});
+	it.effect("lists every registered spell once, grouped by first segment and sorted", () =>
+		Effect.gen(function* () {
+			const rows = yield* ask();
+			assert.deepStrictEqual(
+				rows.map((row) => row.path),
+				[
+					"editor buffer next",
+					"editor save",
+					"help",
+					"spell describe",
+					"spell list",
+					"window close",
+					"window focus",
+					"window swap",
+				],
+			);
+		}),
+	);
 
-	it("derives the usage column from each spell's own params", async () => {
-		const rows = await ask("window");
-		expect(rows).toEqual([
-			{path: "window close", usage: "", describe: "Close the focused window"},
-			{
-				path: "window focus",
-				usage: "left|right|up|down [<count>]",
-				describe: "Focus the neighbour in one direction",
-			},
-			{
-				path: "window swap",
-				usage: "<dir>",
-				describe: "Swap with the neighbour: left|right|up|down",
-			},
-		]);
-	});
+	it.effect("derives the usage column from each spell's own params", () =>
+		Effect.gen(function* () {
+			const rows = yield* ask("window");
+			assert.deepStrictEqual(rows, [
+				{path: "window close", usage: "", describe: "Close the focused window"},
+				{
+					path: "window focus",
+					usage: "left|right|up|down [<count>]",
+					describe: "Focus the neighbour in one direction",
+				},
+				{
+					path: "window swap",
+					usage: "<dir>",
+					describe: "Swap with the neighbour: left|right|up|down",
+				},
+			]);
+		}),
+	);
 
-	it("renders the subtree as the aligned table the palette shows", async () => {
-		expect(renderHelp(await ask("window"))).toMatchInlineSnapshot(`
-			"window close                                Close the focused window
-			window focus left|right|up|down [<count>]   Focus the neighbour in one direction
-			window swap <dir>                           Swap with the neighbour: left|right|up|down"
-		`);
-	});
+	it.effect("renders the subtree as the aligned table the palette shows", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(
+				renderHelp(yield* ask("window")),
+				[
+					"window close                                Close the focused window",
+					"window focus left|right|up|down [<count>]   Focus the neighbour in one direction",
+					"window swap <dir>                           Swap with the neighbour: left|right|up|down",
+				].join("\n"),
+			);
+		}),
+	);
 
-	it("reads a path written with either separator", async () => {
-		expect((await ask("window.close")).map((row) => row.path)).toEqual(["window close"]);
-		expect((await ask("spell describe")).map((row) => row.path)).toEqual(["spell describe"]);
-	});
+	it.effect("reads a path written with either separator", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(
+				(yield* ask("window.close")).map((row) => row.path),
+				["window close"],
+			);
+			assert.deepStrictEqual(
+				(yield* ask("spell describe")).map((row) => row.path),
+				["spell describe"],
+			);
+		}),
+	);
 
-	it("refuses a path no spell answers to, naming the nearest group", async () => {
-		const error = await Effect.runPromise(
-			Effect.flatMap(table, (built) =>
+	it.effect("refuses a path no spell answers to, naming the nearest group", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flatMap(table, (built) =>
 				helpSpell
 					.execute({path: "windwo"}, scope)
 					.pipe(Effect.provide(SpellRegistry.layer(built)), Effect.flip),
-			),
-		);
-		expect(error.path).toBe("windwo");
-		expect(error.didYouMean).toBe("window");
-	});
+			);
+			assert.strictEqual(error.path, "windwo");
+			assert.strictEqual(error.didYouMean, "window");
+		}),
+	);
 
-	it("reflects a swapped table with no restart", async () => {
-		const paths = await Effect.runPromise(
-			Effect.gen(function* () {
-				const built = yield* table;
-				const next = yield* smallerTable;
-				return yield* Effect.gen(function* () {
-					const before = yield* helpSpell.execute({}, scope);
-					const registry = yield* SpellRegistry;
-					yield* registry.swap(next);
-					const after = yield* helpSpell.execute({}, scope);
-					return {
-						before: before.map((row) => row.path),
-						after: after.map((row) => row.path),
-					};
-				}).pipe(Effect.provide(SpellRegistry.layer(built)));
-			}),
-		);
-		expect(paths.before).toContain("window close");
-		expect(paths.after).toEqual(["help", "spell describe", "spell list"]);
-	});
+	it.effect("reflects a swapped table with no restart", () =>
+		Effect.gen(function* () {
+			const built = yield* table;
+			const next = yield* smallerTable;
+			const paths = yield* Effect.gen(function* () {
+				const before = yield* helpSpell.execute({}, scope);
+				const registry = yield* SpellRegistry;
+				yield* registry.swap(next);
+				const after = yield* helpSpell.execute({}, scope);
+				return {
+					before: before.map((row) => row.path),
+					after: after.map((row) => row.path),
+				};
+			}).pipe(Effect.provide(SpellRegistry.layer(built)));
+			assert.include(paths.before, "window close");
+			assert.deepStrictEqual(paths.after, ["help", "spell describe", "spell list"]);
+		}),
+	);
 });
 
 describe("renderHelp", () => {

--- a/apps/tuval/src/commands/core/spell.unit.test.ts
+++ b/apps/tuval/src/commands/core/spell.unit.test.ts
@@ -1,60 +1,70 @@
+import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {SpellRegistry} from "../registry.ts";
 import {scope, table} from "./fixtures.ts";
 import {spellDescribe, spellList} from "./spell.ts";
 
 const run = <A, E>(body: Effect.Effect<A, E, SpellRegistry>) =>
-	Effect.runPromise(
-		Effect.flatMap(table, (built) => body.pipe(Effect.provide(SpellRegistry.layer(built)))),
-	);
+	Effect.flatMap(table, (built) => body.pipe(Effect.provide(SpellRegistry.layer(built))));
 
 describe("spell list", () => {
-	it("returns exactly what the registry describes", async () => {
-		const {listed, described} = await run(
-			Effect.gen(function* () {
-				const registry = yield* SpellRegistry;
-				return {
-					listed: yield* spellList.execute({}, scope),
-					described: yield* registry.describe,
-				};
-			}),
-		);
-		expect(listed).toEqual(described);
-	});
+	it.effect("returns exactly what the registry describes", () =>
+		Effect.gen(function* () {
+			const {listed, described} = yield* run(
+				Effect.gen(function* () {
+					const registry = yield* SpellRegistry;
+					return {
+						listed: yield* spellList.execute({}, scope),
+						described: yield* registry.describe,
+					};
+				}),
+			);
+			assert.deepStrictEqual(listed, described);
+		}),
+	);
 });
 
 describe("spell describe", () => {
-	it("returns one spell's description including its params schema", async () => {
-		const found = await run(spellDescribe.execute({path: "window close"}, scope));
-		expect(found.path).toEqual(["window", "close"]);
-		expect(found.describe).toBe("Close the focused window");
-		expect(found.capabilities).toEqual([]);
-		expect(found.params).toEqual(
-			await run(
-				Effect.map(
-					Effect.flatMap(SpellRegistry, (registry) => registry.describe),
-					(rows) => rows.find((row) => row.path.join(" ") === "window close")?.params,
+	it.effect("returns one spell's description including its params schema", () =>
+		Effect.gen(function* () {
+			const found = yield* run(spellDescribe.execute({path: "window close"}, scope));
+			assert.deepStrictEqual(found.path, ["window", "close"]);
+			assert.strictEqual(found.describe, "Close the focused window");
+			assert.deepStrictEqual(found.capabilities, []);
+			assert.deepStrictEqual(
+				found.params,
+				yield* run(
+					Effect.map(
+						Effect.flatMap(SpellRegistry, (registry) => registry.describe),
+						(rows) => rows.find((row) => row.path.join(" ") === "window close")?.params,
+					),
 				),
-			),
-		);
-	});
+			);
+		}),
+	);
 
-	it("carries the parameter names a caller has to supply", async () => {
-		const found = await run(spellDescribe.execute({path: "window focus"}, scope));
-		expect(found.params).toMatchObject({
-			schema: {properties: {direction: {enum: ["left", "right", "up", "down"]}}},
-		});
-	});
+	it.effect("carries the parameter names a caller has to supply", () =>
+		Effect.gen(function* () {
+			const found = yield* run(spellDescribe.execute({path: "window focus"}, scope));
+			const schema = found.params.schema as {
+				readonly properties?: {readonly direction?: {readonly enum?: unknown}};
+			};
+			assert.deepStrictEqual(schema.properties?.direction?.enum, ["left", "right", "up", "down"]);
+		}),
+	);
 
-	it("refuses an unregistered path with the nearest one", async () => {
-		const error = await run(Effect.flip(spellDescribe.execute({path: "windwo close"}, scope)));
-		expect(error.path).toBe("windwo close");
-		expect(error.didYouMean).toBe("window close");
-	});
+	it.effect("refuses an unregistered path with the nearest one", () =>
+		Effect.gen(function* () {
+			const error = yield* run(Effect.flip(spellDescribe.execute({path: "windwo close"}, scope)));
+			assert.strictEqual(error.path, "windwo close");
+			assert.strictEqual(error.didYouMean, "window close");
+		}),
+	);
 
-	it("offers nothing when no registered path is near", async () => {
-		const error = await run(Effect.flip(spellDescribe.execute({path: "teapot"}, scope)));
-		expect(error.didYouMean).toBeUndefined();
-	});
+	it.effect("offers nothing when no registered path is near", () =>
+		Effect.gen(function* () {
+			const error = yield* run(Effect.flip(spellDescribe.execute({path: "teapot"}, scope)));
+			assert.strictEqual(error.didYouMean, undefined);
+		}),
+	);
 });

--- a/apps/tuval/src/commands/executor.unit.test.ts
+++ b/apps/tuval/src/commands/executor.unit.test.ts
@@ -1,5 +1,5 @@
-import {Effect, Layer, Schema} from "effect";
-import {describe, expect, expectTypeOf, it} from "vitest";
+import {assert, describe, expect, expectTypeOf, it} from "@effect/vitest";
+import {Cause, Effect, Exit, Layer, Schema} from "effect";
 import {ProcessId} from "../process/process.ts";
 import {CallId} from "../protocol/ids.ts";
 import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../protocol/messages.ts";
@@ -111,14 +111,13 @@ const call = (fields: {
 		...(fields.window === undefined ? {} : {window: fields.window}),
 	});
 
-const execute = (one: SpellCall): Promise<SpellReply> => {
-	seen = undefined;
-	return Effect.runPromise(
-		Effect.flatMap(SpellExecutor, (executor) => executor.execute(one, client)).pipe(
+const execute = (one: SpellCall) =>
+	Effect.suspend(() => {
+		seen = undefined;
+		return Effect.flatMap(SpellExecutor, (executor) => executor.execute(one, client)).pipe(
 			Effect.provide(layer),
-		),
-	);
-};
+		);
+	});
 
 const failure = (reply: SpellReply) => {
 	if (reply.ok) throw new Error(`expected a refusal, got ${JSON.stringify(reply)}`);
@@ -132,89 +131,107 @@ describe("SpellExecutor", () => {
 		>();
 	});
 
-	it("takes the process and workspace from the index when the call names a window", async () => {
-		const reply = await execute(
-			call({path: ["window", "close"], args: {id: "w-1"}, window: leftWindow}),
-		);
-		expect(reply.ok).toBe(true);
-		expect(reply.ok ? reply.result : undefined).toEqual({closed: true});
-		expect(seen).toEqual({
-			window: leftWindow,
-			process: counterProcess,
-			workspace: otherWorkspace,
-			client: client.id,
-		});
-	});
-
-	it("runs a windowless call in the client's workspace, naming no process", async () => {
-		await execute(call({path: ["window", "close"], args: {id: "w-1"}}));
-		expect(seen).toEqual({workspace, client: client.id});
-	});
-
-	it("never reads the scope off the call's args — a forged process is ignored", async () => {
-		await execute(
-			call({
-				path: ["window", "close"],
-				args: {id: "w-1", process: forgedProcess},
+	it.effect("takes the process and workspace from the index when the call names a window", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(
+				call({path: ["window", "close"], args: {id: "w-1"}, window: leftWindow}),
+			);
+			assert.strictEqual(reply.ok, true);
+			assert.deepStrictEqual(reply.ok ? reply.result : undefined, {closed: true});
+			assert.deepStrictEqual(seen, {
 				window: leftWindow,
-			}),
-		);
-		expect(seen?.process).toBe(counterProcess);
-	});
+				process: counterProcess,
+				workspace: otherWorkspace,
+				client: client.id,
+			});
+		}),
+	);
 
-	it("refuses a window the index does not hold", async () => {
-		const reply = await execute(
-			call({path: ["window", "close"], args: {id: "w-1"}, window: missingWindow}),
-		);
-		expect(failure(reply)).toEqual({
-			tag: "tuval/commands/NoSuchWindow",
-			message: 'no window "w-9" is open',
-			path: ["window", "close"],
-		});
-		expect(seen).toBeUndefined();
-	});
+	it.effect("runs a windowless call in the client's workspace, naming no process", () =>
+		Effect.gen(function* () {
+			yield* execute(call({path: ["window", "close"], args: {id: "w-1"}}));
+			assert.deepStrictEqual(seen, {workspace, client: client.id});
+		}),
+	);
 
-	it("refuses an unknown path, naming the nearest one it holds", async () => {
-		const reply = await execute(call({path: ["window", "clos"], args: {id: "w-1"}}));
-		const error = failure(reply);
-		expect(error.tag).toBe("tuval/commands/UnknownSpell");
-		expect(error.didYouMean).toBe("window.close");
-		expect(error.path).toEqual(["window", "clos"]);
-	});
+	it.effect("never reads the scope off the call's args — a forged process is ignored", () =>
+		Effect.gen(function* () {
+			yield* execute(
+				call({
+					path: ["window", "close"],
+					args: {id: "w-1", process: forgedProcess},
+					window: leftWindow,
+				}),
+			);
+			assert.strictEqual(seen?.process, counterProcess);
+		}),
+	);
 
-	it("refuses args the spell's params refuse, naming the argument and the expectation", async () => {
-		const reply = await execute(call({path: ["window", "close"], args: {id: 3}}));
-		const error = failure(reply);
-		expect(error.tag).toBe("tuval/commands/BadArgs");
-		expect(error.expected).toMatch(/string/i);
-		expect(error.message).toContain('"id"');
-		expect(error.message).toContain('"window.close"');
-	});
+	it.effect("refuses a window the index does not hold", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(
+				call({path: ["window", "close"], args: {id: "w-1"}, window: missingWindow}),
+			);
+			assert.deepStrictEqual(failure(reply), {
+				tag: "tuval/commands/NoSuchWindow",
+				message: 'no window "w-9" is open',
+				path: ["window", "close"],
+			});
+			assert.strictEqual(seen, undefined);
+		}),
+	);
 
-	it("carries a spell's own tagged error through as the refusal's tag", async () => {
-		const reply = await execute(call({path: ["window", "explode"], args: {}}));
-		expect(failure(reply)).toEqual({
-			tag: "test/Refused",
-			message: "refused: the window is pinned",
-			path: ["window", "explode"],
-		});
-	});
+	it.effect("refuses an unknown path, naming the nearest one it holds", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(call({path: ["window", "clos"], args: {id: "w-1"}}));
+			const error = failure(reply);
+			assert.strictEqual(error.tag, "tuval/commands/UnknownSpell");
+			assert.strictEqual(error.didYouMean, "window.close");
+			assert.deepStrictEqual(error.path, ["window", "clos"]);
+		}),
+	);
 
-	it("names SpellFailed when a spell fails with a bare string, and quotes the string", async () => {
-		const reply = await execute(call({path: ["window", "swear"], args: {}}));
-		expect(failure(reply)).toEqual({
-			tag: "tuval/commands/SpellFailed",
-			message: 'spell "window.swear" failed with "the compositor said no"',
-			path: ["window", "swear"],
-		});
-	});
+	it.effect("refuses args the spell's params refuse, naming the argument and the expectation", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(call({path: ["window", "close"], args: {id: 3}}));
+			const error = failure(reply);
+			assert.strictEqual(error.tag, "tuval/commands/BadArgs");
+			assert.match(error.expected ?? "", /string/i);
+			assert.include(error.message, '"id"');
+			assert.include(error.message, '"window.close"');
+		}),
+	);
 
-	it("names SpellFailed when a spell fails with an untagged record, and renders it", async () => {
-		const error = failure(await execute(call({path: ["window", "mutter"], args: {}})));
-		expect(error.tag).toBe("tuval/commands/SpellFailed");
-		expect(error.message).toContain("the disk is full");
-		expect(error.message).not.toBe(`the call failed with ${error.tag}`);
-	});
+	it.effect("carries a spell's own tagged error through as the refusal's tag", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(call({path: ["window", "explode"], args: {}}));
+			assert.deepStrictEqual(failure(reply), {
+				tag: "test/Refused",
+				message: "refused: the window is pinned",
+				path: ["window", "explode"],
+			});
+		}),
+	);
+
+	it.effect("names SpellFailed when a spell fails with a bare string, and quotes the string", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(call({path: ["window", "swear"], args: {}}));
+			assert.deepStrictEqual(failure(reply), {
+				tag: "tuval/commands/SpellFailed",
+				message: 'spell "window.swear" failed with "the compositor said no"',
+				path: ["window", "swear"],
+			});
+		}),
+	);
+
+	it.effect("names SpellFailed when a spell fails with an untagged record, and renders it", () =>
+		Effect.gen(function* () {
+			const error = failure(yield* execute(call({path: ["window", "mutter"], args: {}})));
+			assert.strictEqual(error.tag, "tuval/commands/SpellFailed");
+			assert.include(error.message, "the disk is full");
+			assert.notStrictEqual(error.message, `the call failed with ${error.tag}`);
+		}),
+	);
 
 	it("keeps the untagged value on the error rather than dropping it", () => {
 		const original = {reason: "the disk is full"};
@@ -223,14 +240,21 @@ describe("SpellExecutor", () => {
 		expect(failed._tag).toBe("tuval/commands/SpellFailed");
 	});
 
-	it("falls back to the tag only when a named error carries no message", async () => {
-		const reply = await execute(call({path: ["window", "hush"], args: {}}));
-		expect(failure(reply).message).toBe("the call failed with test/Silent");
-	});
+	it.effect("falls back to the tag only when a named error carries no message", () =>
+		Effect.gen(function* () {
+			const reply = yield* execute(call({path: ["window", "hush"], args: {}}));
+			assert.strictEqual(failure(reply).message, "the call failed with test/Silent");
+		}),
+	);
 
-	it("dies rather than replies when a spell's value its own result schema refuses", async () => {
-		await expect(execute(call({path: ["window", "lie"], args: {}}))).rejects.toThrow(
-			/result its own schema refuses/,
-		);
-	});
+	it.effect("dies rather than replies when a spell's value its own result schema refuses", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(execute(call({path: ["window", "lie"], args: {}})));
+			assert.strictEqual(Exit.isFailure(exit), true);
+			assert.match(
+				Exit.isFailure(exit) ? Cause.pretty(exit.cause) : "",
+				/result its own schema refuses/,
+			);
+		}),
+	);
 });

--- a/apps/tuval/src/commands/registry.unit.test.ts
+++ b/apps/tuval/src/commands/registry.unit.test.ts
@@ -1,6 +1,6 @@
 import {type Cmd, defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
 import {Effect, Schema} from "effect";
-import {describe, expect, it} from "vitest";
 import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
 import {DuplicateSpellPath, SpellNotDescribable, SpellNotFound} from "./errors.ts";
 import {buildRegistry, type RegistryTable, SpellRegistry} from "./registry.ts";
@@ -39,226 +39,257 @@ const program = (id: string, spells: ReadonlyArray<AnySpell>): AnyProgram =>
 const paths = (table: RegistryTable): ReadonlyArray<string> =>
 	table.rows.map((row) => renderPath(row.path));
 
-const build = (input: Parameters<typeof buildRegistry>[0]) =>
-	Effect.runPromise(buildRegistry(input));
+const build = (input: Parameters<typeof buildRegistry>[0]) => buildRegistry(input);
 
-const refusal = (input: Parameters<typeof buildRegistry>[0]) =>
-	Effect.runPromise(Effect.flip(buildRegistry(input)));
+const refusal = (input: Parameters<typeof buildRegistry>[0]) => Effect.flip(buildRegistry(input));
 
 const withRegistry = <A, E>(
 	table: RegistryTable,
 	body: (registry: SpellRegistry["Service"]) => Effect.Effect<A, E>,
-) =>
-	Effect.runPromise(
-		Effect.flatMap(SpellRegistry, body).pipe(Effect.provide(SpellRegistry.layer(table))),
-	);
+) => Effect.flatMap(SpellRegistry, body).pipe(Effect.provide(SpellRegistry.layer(table)));
 
 describe("buildRegistry", () => {
-	it("places core spells at their path and each program's spells under its id", async () => {
-		const table = await build({
-			core: [spell(["window", "close"]), spell(["quit"])],
-			programs: [
-				program("editor", [spell(["save"]), spell(["buffer", "next"])]),
-				program("terminal", [spell(["save"])]),
-			],
-		});
-		expect(paths(table)).toEqual([
-			"window.close",
-			"quit",
-			"editor.save",
-			"editor.buffer.next",
-			"terminal.save",
-		]);
-		expect(table.rows.map((row) => row.source)).toEqual([
-			{kind: "core"},
-			{kind: "core"},
-			{kind: "program", programId: "editor"},
-			{kind: "program", programId: "editor"},
-			{kind: "program", programId: "terminal"},
-		]);
-	});
+	it.effect("places core spells at their path and each program's spells under its id", () =>
+		Effect.gen(function* () {
+			const table = yield* build({
+				core: [spell(["window", "close"]), spell(["quit"])],
+				programs: [
+					program("editor", [spell(["save"]), spell(["buffer", "next"])]),
+					program("terminal", [spell(["save"])]),
+				],
+			});
+			assert.deepStrictEqual(paths(table), [
+				"window.close",
+				"quit",
+				"editor.save",
+				"editor.buffer.next",
+				"terminal.save",
+			]);
+			assert.deepStrictEqual(
+				table.rows.map((row) => row.source),
+				[
+					{kind: "core"},
+					{kind: "core"},
+					{kind: "program", programId: "editor"},
+					{kind: "program", programId: "editor"},
+					{kind: "program", programId: "terminal"},
+				],
+			);
+		}),
+	);
 
-	it("registers a program that declares no spells as contributing none", async () => {
-		const table = await build({core: [], programs: [program("empty", [])]});
-		expect(paths(table)).toEqual([]);
-	});
+	it.effect("registers a program that declares no spells as contributing none", () =>
+		Effect.gen(function* () {
+			const table = yield* build({core: [], programs: [program("empty", [])]});
+			assert.deepStrictEqual(paths(table), []);
+		}),
+	);
 
-	it("refuses a core path a program also claims, naming both sources", async () => {
-		const error = await refusal({
-			core: [spell(["editor", "save"])],
-			programs: [program("editor", [spell(["save"])])],
-		});
-		expect(error).toBeInstanceOf(DuplicateSpellPath);
-		expect(error).toMatchObject({
-			path: "editor.save",
-			first: "the core spell list",
-			second: 'program "editor"',
-		});
-		expect(error.message).toBe(
-			'spell path "editor.save" is already registered by the core spell list; refusing program "editor"',
-		);
-	});
+	it.effect("refuses a core path a program also claims, naming both sources", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal({
+				core: [spell(["editor", "save"])],
+				programs: [program("editor", [spell(["save"])])],
+			});
+			assert.instanceOf(error, DuplicateSpellPath);
+			assert.strictEqual(error.path, "editor.save");
+			assert.strictEqual(error.first, "the core spell list");
+			assert.strictEqual(error.second, 'program "editor"');
+			assert.strictEqual(
+				error.message,
+				'spell path "editor.save" is already registered by the core spell list; refusing program "editor"',
+			);
+		}),
+	);
 
-	it("registers a program whose `spells` field is absent as contributing none", async () => {
-		const {spells: _spells, ...withoutSpells} = program("empty", []);
-		const table = await build({core: [], programs: [withoutSpells as AnyProgram]});
-		expect(paths(table)).toEqual([]);
-	});
+	it.effect("registers a program whose `spells` field is absent as contributing none", () =>
+		Effect.gen(function* () {
+			const {spells: _spells, ...withoutSpells} = program("empty", []);
+			const table = yield* build({core: [], programs: [withoutSpells as AnyProgram]});
+			assert.deepStrictEqual(paths(table), []);
+		}),
+	);
 
-	it("refuses a spell whose params no JSON Schema can describe, naming the spell and its source", async () => {
-		// A number-keyed record has no JSON Schema form at the pin: `toJsonSchemaDocument` throws on
-		// its index signature. Registering it would defect `describe`, and with it `help`, `spell
-		// list` and every `Snapshot`.
-		const unrepresentable = defineSpell({
-			path: ["window", "sizes"],
-			describe: "Report the size of every window.",
-			params: Schema.Record(Schema.Number, Schema.String),
-			result: Schema.Struct({ok: Schema.Boolean}),
-			execute: () => Effect.succeed({ok: true}),
-			capabilities: [],
-		});
+	it.effect(
+		"refuses a spell whose params no JSON Schema can describe, naming the spell and its source",
+		() =>
+			Effect.gen(function* () {
+				// A number-keyed record has no JSON Schema form at the pin: `toJsonSchemaDocument` throws on
+				// its index signature. Registering it would defect `describe`, and with it `help`, `spell
+				// list` and every `Snapshot`.
+				const unrepresentable = defineSpell({
+					path: ["window", "sizes"],
+					describe: "Report the size of every window.",
+					params: Schema.Record(Schema.Number, Schema.String),
+					result: Schema.Struct({ok: Schema.Boolean}),
+					execute: () => Effect.succeed({ok: true}),
+					capabilities: [],
+				});
 
-		const fromCore = await refusal({core: [unrepresentable], programs: []});
-		expect(fromCore).toBeInstanceOf(SpellNotDescribable);
-		expect(fromCore).toMatchObject({path: "window.sizes", source: "the core spell list"});
-		expect(fromCore.message).toContain('spell "window.sizes" from the core spell list');
+				const fromCore = yield* refusal({core: [unrepresentable], programs: []});
+				assert.instanceOf(fromCore, SpellNotDescribable);
+				assert.strictEqual(fromCore.path, "window.sizes");
+				assert.strictEqual(fromCore.source, "the core spell list");
+				assert.include(fromCore.message, 'spell "window.sizes" from the core spell list');
 
-		const fromProgram = await refusal({
-			core: [],
-			programs: [program("editor", [unrepresentable])],
-		});
-		expect(fromProgram).toBeInstanceOf(SpellNotDescribable);
-		expect(fromProgram).toMatchObject({
-			path: "editor.window.sizes",
-			source: 'program "editor"',
-		});
-	});
+				const fromProgram = yield* refusal({
+					core: [],
+					programs: [program("editor", [unrepresentable])],
+				});
+				assert.instanceOf(fromProgram, SpellNotDescribable);
+				assert.strictEqual(fromProgram.path, "editor.window.sizes");
+				assert.strictEqual(fromProgram.source, 'program "editor"');
+			}),
+	);
 
-	it("describes every registered spell without throwing, from the row's own document", async () => {
-		const table = await build({core: [spell(["window", "close"])], programs: []});
-		const described = await withRegistry(table, (registry) => registry.describe);
-		expect(described).toEqual([
-			{
-				path: ["window", "close"],
-				describe: "Run window.close.",
-				params: Schema.toJsonSchemaDocument(Schema.Struct({id: Schema.String})),
-				capabilities: [{family: "process-control"}],
-			},
-		]);
-	});
+	it.effect("describes every registered spell without throwing, from the row's own document", () =>
+		Effect.gen(function* () {
+			const table = yield* build({core: [spell(["window", "close"])], programs: []});
+			const described = yield* withRegistry(table, (registry) => registry.describe);
+			assert.deepStrictEqual(described, [
+				{
+					path: ["window", "close"],
+					describe: "Run window.close.",
+					params: Schema.toJsonSchemaDocument(Schema.Struct({id: Schema.String})),
+					capabilities: [{family: "process-control"}],
+				},
+			]);
+		}),
+	);
 
-	it("refuses one program claiming a path twice, naming both sources", async () => {
-		const error = await refusal({
-			core: [],
-			programs: [program("editor", [spell(["save"]), spell(["save"], "Save again.")])],
-		});
-		expect(error).toBeInstanceOf(DuplicateSpellPath);
-		expect(error.message).toBe(
-			'spell path "editor.save" is already registered by program "editor"; refusing program "editor"',
-		);
-	});
+	it.effect("refuses one program claiming a path twice, naming both sources", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal({
+				core: [],
+				programs: [program("editor", [spell(["save"]), spell(["save"], "Save again.")])],
+			});
+			assert.instanceOf(error, DuplicateSpellPath);
+			assert.strictEqual(
+				error.message,
+				'spell path "editor.save" is already registered by program "editor"; refusing program "editor"',
+			);
+		}),
+	);
 });
 
 describe("SpellRegistry", () => {
-	it("looks a spell up by its path and fails an unregistered one with a typed error", async () => {
-		const table = await build({
-			core: [spell(["window", "close"])],
-			programs: [program("editor", [spell(["save"])])],
-		});
-		const [core, fromProgram, missing, partial] = await withRegistry(table, (registry) =>
-			Effect.all(
-				[
-					registry.lookup(["window", "close"]),
-					registry.lookup(["editor", "save"]),
-					Effect.flip(registry.lookup(["window", "open"])),
-					Effect.flip(registry.lookup(["window"])),
-				],
-				{concurrency: "unbounded"},
-			),
-		);
-		expect(renderPath(core.path)).toBe("window.close");
-		expect(renderPath(fromProgram.path)).toBe("editor.save");
-		expect(missing).toBeInstanceOf(SpellNotFound);
-		expect(missing.message).toBe('no spell is registered at path "window.open"');
-		// `window` is an interior node of the trie: it routes to `window.close` and holds no spell.
-		expect(partial).toBeInstanceOf(SpellNotFound);
-	});
-
-	it("replaces the whole table in one write — a concurrent reader never sees a mix", async () => {
-		const before = await build({core: [spell(["a"]), spell(["b"])], programs: []});
-		const after = await build({
-			core: [spell(["c"])],
-			programs: [program("editor", [spell(["d"]), spell(["e"])])],
-		});
-		const seen = await withRegistry(before, (registry) => {
-			const observations: Array<ReadonlyArray<string>> = [];
-			const read = Effect.gen(function* () {
-				for (let round = 0; round < 200; round++) {
-					const rows = yield* registry.list;
-					observations.push(rows.map((row) => renderPath(row.path)));
-					yield* Effect.yieldNow;
-				}
+	it.effect("looks a spell up by its path and fails an unregistered one with a typed error", () =>
+		Effect.gen(function* () {
+			const table = yield* build({
+				core: [spell(["window", "close"])],
+				programs: [program("editor", [spell(["save"])])],
 			});
-			return Effect.as(
-				Effect.all([read, read, registry.swap(after)], {concurrency: "unbounded"}),
-				observations,
+			const [core, fromProgram, missing, partial] = yield* withRegistry(table, (registry) =>
+				Effect.all(
+					[
+						registry.lookup(["window", "close"]),
+						registry.lookup(["editor", "save"]),
+						Effect.flip(registry.lookup(["window", "open"])),
+						Effect.flip(registry.lookup(["window"])),
+					],
+					{concurrency: "unbounded"},
+				),
 			);
-		});
-		const [oldPaths, newPaths] = [paths(before), paths(after)];
-		for (const observation of seen) {
-			expect([oldPaths, newPaths]).toContainEqual(observation);
-		}
-		expect(seen.at(0)).toEqual(oldPaths);
-		expect(seen.at(-1)).toEqual(newPaths);
-	});
+			assert.strictEqual(renderPath(core.path), "window.close");
+			assert.strictEqual(renderPath(fromProgram.path), "editor.save");
+			assert.instanceOf(missing, SpellNotFound);
+			assert.strictEqual(missing.message, 'no spell is registered at path "window.open"');
+			// `window` is an interior node of the trie: it routes to `window.close` and holds no spell.
+			assert.instanceOf(partial, SpellNotFound);
+		}),
+	);
 
-	it("describes every spell as JSON that survives a stringify/parse round trip", async () => {
-		const table = await build({
-			core: [spell(["window", "close"])],
-			programs: [program("editor", [spell(["save"])])],
-		});
-		const described = await withRegistry(table, (registry) => registry.describe);
-		expect(described).toEqual(JSON.parse(JSON.stringify(described)));
-		expect(described).toEqual([
-			{
-				path: ["window", "close"],
-				describe: "Run window.close.",
-				params: {
-					dialect: "draft-2020-12",
-					schema: {
-						type: "object",
-						properties: {id: {type: "string"}},
-						required: ["id"],
-						additionalProperties: false,
-					},
-					definitions: {},
-				},
-				capabilities: [{family: "process-control"}],
-			},
-			{
-				path: ["editor", "save"],
-				describe: "Run save.",
-				params: {
-					dialect: "draft-2020-12",
-					schema: {
-						type: "object",
-						properties: {id: {type: "string"}},
-						required: ["id"],
-						additionalProperties: false,
-					},
-					definitions: {},
-				},
-				capabilities: [{family: "process-control"}],
-			},
-		]);
-	});
+	it.effect("replaces the whole table in one write — a concurrent reader never sees a mix", () =>
+		Effect.gen(function* () {
+			const before = yield* build({core: [spell(["a"]), spell(["b"])], programs: []});
+			const after = yield* build({
+				core: [spell(["c"])],
+				programs: [program("editor", [spell(["d"]), spell(["e"])])],
+			});
+			const seen = yield* withRegistry(before, (registry) =>
+				Effect.gen(function* () {
+					const observations: Array<ReadonlyArray<string>> = [];
+					const observe = Effect.gen(function* () {
+						const rows = yield* registry.list;
+						observations.push(rows.map((row) => renderPath(row.path)));
+					});
+					const read = Effect.gen(function* () {
+						for (let round = 0; round < 200; round++) {
+							yield* observe;
+							yield* Effect.yieldNow;
+						}
+					});
+					// The bracketing reads sit outside the race, so "first sees the old table, last sees
+					// the new one" is true by sequencing rather than by how the scheduler happened to
+					// interleave three fibers. `Effect.all` joins every fiber it forked, so the swap has
+					// landed before the closing read runs.
+					yield* observe;
+					yield* Effect.all([read, read, registry.swap(after)], {concurrency: "unbounded"});
+					yield* observe;
+					return observations;
+				}),
+			);
+			const [oldPaths, newPaths] = [paths(before), paths(after)];
+			for (const observation of seen) {
+				assert.deepInclude([oldPaths, newPaths], observation);
+			}
+			assert.deepStrictEqual(seen.at(0), oldPaths);
+			assert.deepStrictEqual(seen.at(-1), newPaths);
+		}),
+	);
 
-	it("`scripted` builds the registry over a bare core list", async () => {
-		const listed = await Effect.runPromise(
-			Effect.flatMap(SpellRegistry, (registry) => registry.list).pipe(
+	it.effect("describes every spell as JSON that survives a stringify/parse round trip", () =>
+		Effect.gen(function* () {
+			const table = yield* build({
+				core: [spell(["window", "close"])],
+				programs: [program("editor", [spell(["save"])])],
+			});
+			const described = yield* withRegistry(table, (registry) => registry.describe);
+			assert.deepStrictEqual(described, JSON.parse(JSON.stringify(described)));
+			assert.deepStrictEqual(described, [
+				{
+					path: ["window", "close"],
+					describe: "Run window.close.",
+					params: {
+						dialect: "draft-2020-12",
+						schema: {
+							type: "object",
+							properties: {id: {type: "string"}},
+							required: ["id"],
+							additionalProperties: false,
+						},
+						definitions: {},
+					},
+					capabilities: [{family: "process-control"}],
+				},
+				{
+					path: ["editor", "save"],
+					describe: "Run save.",
+					params: {
+						dialect: "draft-2020-12",
+						schema: {
+							type: "object",
+							properties: {id: {type: "string"}},
+							required: ["id"],
+							additionalProperties: false,
+						},
+						definitions: {},
+					},
+					capabilities: [{family: "process-control"}],
+				},
+			]);
+		}),
+	);
+
+	it.effect("`scripted` builds the registry over a bare core list", () =>
+		Effect.gen(function* () {
+			const listed = yield* Effect.flatMap(SpellRegistry, (registry) => registry.list).pipe(
 				Effect.provide(SpellRegistry.scripted([spell(["quit"])])),
-			),
-		);
-		expect(listed.map((row) => renderPath(row.path))).toEqual(["quit"]);
-	});
+			);
+			assert.deepStrictEqual(
+				listed.map((row) => renderPath(row.path)),
+				["quit"],
+			);
+		}),
+	);
 });

--- a/apps/tuval/src/commands/spell-set.unit.test.ts
+++ b/apps/tuval/src/commands/spell-set.unit.test.ts
@@ -15,8 +15,8 @@
  * several yields and a second writer always gets its window.
  */
 
+import {assert, describe, it} from "@effect/vitest";
 import {Effect, Schema} from "effect";
-import {describe, expect, it} from "vitest";
 import {type BindingSource, type CompiledBindings, compileBindings} from "./bindings/index.ts";
 import {buildRegistry, type RegistryTable, SpellRegistry} from "./registry.ts";
 import {type AnySpell, defineSpell, renderPath, type SpellPath} from "./spell.ts";
@@ -96,13 +96,11 @@ const withSet = <A, E>(
 		readonly set: SpellSet["Service"];
 		readonly registry: SpellRegistry["Service"];
 	}) => Effect.Effect<A, E>,
-): Promise<A> =>
-	Effect.runPromise(
-		Effect.all({set: SpellSet, registry: SpellRegistry}, {concurrency: 1}).pipe(
-			Effect.flatMap(body),
-			Effect.provide(SpellSet.layer(input)),
-			Effect.orDie,
-		),
+): Effect.Effect<A> =>
+	Effect.all({set: SpellSet, registry: SpellRegistry}, {concurrency: 1}).pipe(
+		Effect.flatMap(body),
+		Effect.provide(SpellSet.layer(input)),
+		Effect.orDie,
 	);
 
 /**
@@ -114,131 +112,139 @@ const distinct = (states: ReadonlyArray<SpellSetState>): ReadonlyArray<SpellSetS
 	states.filter((state, index) => state !== states[index - 1]);
 
 /** Fails unless a state's bindings are what its own table and sources compile to. */
-const expectWhole = (state: SpellSetState): Promise<void> =>
-	Effect.runPromise(
-		Effect.map(recompile(state.table, state.keys), (fresh) => {
-			expect(state.bindings).toEqual(fresh);
+const expectWhole = (state: SpellSetState): Effect.Effect<void> =>
+	Effect.map(recompile(state.table, state.keys), (fresh) => {
+		assert.deepStrictEqual(state.bindings, fresh);
+	});
+
+describe("SpellSet.read", () => {
+	it.effect("returns the table, its sources and their bindings as one generation", () =>
+		Effect.gen(function* () {
+			const state = yield* withSet(gen0.input, ({set}) => set.read);
+			yield* expectWhole(state);
+			assert.deepStrictEqual(paths(state.table), [gen0.path]);
+			assert.deepStrictEqual(keysOf(state), [gen0.source.file]);
+			assert.deepStrictEqual(boundKeys(state), gen0.keys);
 		}),
 	);
 
-describe("SpellSet.read", () => {
-	it("returns the table, its sources and their bindings as one generation", async () => {
-		const state = await withSet(gen0.input, ({set}) => set.read);
-		await expectWhole(state);
-		expect(paths(state.table)).toEqual([gen0.path]);
-		expect(keysOf(state)).toEqual([gen0.source.file]);
-		expect(boundKeys(state)).toEqual(gen0.keys);
-	});
+	it.effect("never returns a table beside bindings compiled from another generation", () =>
+		Effect.gen(function* () {
+			const seen = yield* withSet(gen0.input, ({set}) =>
+				Effect.gen(function* () {
+					const observations: Array<SpellSetState> = [];
+					const read = Effect.gen(function* () {
+						for (let round = 0; round < 200; round++) {
+							observations.push(yield* set.read);
+							yield* Effect.yieldNow;
+						}
+					});
+					yield* Effect.all([read, read, set.reload(gen1.input)], {concurrency: "unbounded"});
+					return observations;
+				}),
+			);
 
-	it("never returns a table beside bindings compiled from another generation", async () => {
-		const seen = await withSet(gen0.input, ({set}) =>
-			Effect.gen(function* () {
-				const observations: Array<SpellSetState> = [];
-				const read = Effect.gen(function* () {
-					for (let round = 0; round < 200; round++) {
-						observations.push(yield* set.read);
-						yield* Effect.yieldNow;
-					}
-				});
-				yield* Effect.all([read, read, set.reload(gen1.input)], {concurrency: "unbounded"});
-				return observations;
-			}),
-		);
-
-		for (const state of distinct(seen)) {
-			await expectWhole(state);
-			// A generation is the pair, so both halves must name the same one and every binding it
-			// declares must have compiled — a table beside another generation's source compiles to
-			// no bindings at all.
-			const which = keysOf(state).at(0) === gen0.source.file ? gen0 : gen1;
-			expect(paths(state.table)).toEqual([which.path]);
-			expect(boundKeys(state)).toEqual(which.keys);
-		}
-		expect(keysOf(seen[0] as SpellSetState)).toEqual([gen0.source.file]);
-		expect(keysOf(seen.at(-1) as SpellSetState)).toEqual([gen1.source.file]);
-	});
+			for (const state of distinct(seen)) {
+				yield* expectWhole(state);
+				// A generation is the pair, so both halves must name the same one and every binding it
+				// declares must have compiled — a table beside another generation's source compiles to
+				// no bindings at all.
+				const which = keysOf(state).at(0) === gen0.source.file ? gen0 : gen1;
+				assert.deepStrictEqual(paths(state.table), [which.path]);
+				assert.deepStrictEqual(boundKeys(state), which.keys);
+			}
+			assert.deepStrictEqual(keysOf(seen[0] as SpellSetState), [gen0.source.file]);
+			assert.deepStrictEqual(keysOf(seen.at(-1) as SpellSetState), [gen1.source.file]);
+		}),
+	);
 });
 
 describe("SpellSet.reload", () => {
-	it("installs the fresh table and the freshly compiled bindings together", async () => {
-		const [before, after] = await withSet(gen0.input, ({set}) =>
-			Effect.gen(function* () {
-				const first = yield* set.read;
-				yield* set.reload(gen1.input);
-				return [first, yield* set.read] as const;
-			}),
-		);
+	it.effect("installs the fresh table and the freshly compiled bindings together", () =>
+		Effect.gen(function* () {
+			const [before, after] = yield* withSet(gen0.input, ({set}) =>
+				Effect.gen(function* () {
+					const first = yield* set.read;
+					yield* set.reload(gen1.input);
+					return [first, yield* set.read] as const;
+				}),
+			);
 
-		expect(paths(before.table)).toEqual([gen0.path]);
-		expect(boundKeys(before)).toEqual(gen0.keys);
-		expect(paths(after.table)).toEqual([gen1.path]);
-		expect(keysOf(after)).toEqual([gen1.source.file]);
-		expect(boundKeys(after)).toEqual(gen1.keys);
-		await expectWhole(after);
-	});
+			assert.deepStrictEqual(paths(before.table), [gen0.path]);
+			assert.deepStrictEqual(boundKeys(before), gen0.keys);
+			assert.deepStrictEqual(paths(after.table), [gen1.path]);
+			assert.deepStrictEqual(keysOf(after), [gen1.source.file]);
+			assert.deepStrictEqual(boundKeys(after), gen1.keys);
+			yield* expectWhole(after);
+		}),
+	);
 });
 
 describe("SpellRegistry over the set", () => {
-	it("reads the installed generation after a reload", async () => {
-		const answers = await withSet(gen0.input, ({set, registry}) =>
-			Effect.gen(function* () {
-				const missing = yield* Effect.flip(registry.lookup(["window", gen1.name]));
-				yield* set.reload(gen1.input);
-				return {
-					missing: missing.path,
-					found: renderPath((yield* registry.lookup(["window", gen1.name])).path),
-					gone: (yield* Effect.flip(registry.lookup(["window", gen0.name]))).path,
-					listed: (yield* registry.list).map((row) => renderPath(row.path)),
-					described: (yield* registry.describe).map((one) => one.path.join(".")),
-				};
-			}),
-		);
+	it.effect("reads the installed generation after a reload", () =>
+		Effect.gen(function* () {
+			const answers = yield* withSet(gen0.input, ({set, registry}) =>
+				Effect.gen(function* () {
+					const missing = yield* Effect.flip(registry.lookup(["window", gen1.name]));
+					yield* set.reload(gen1.input);
+					return {
+						missing: missing.path,
+						found: renderPath((yield* registry.lookup(["window", gen1.name])).path),
+						gone: (yield* Effect.flip(registry.lookup(["window", gen0.name]))).path,
+						listed: (yield* registry.list).map((row) => renderPath(row.path)),
+						described: (yield* registry.describe).map((one) => one.path.join(".")),
+					};
+				}),
+			);
 
-		expect(answers.missing).toBe(gen1.path);
-		expect(answers.found).toBe(gen1.path);
-		expect(answers.gone).toBe(gen0.path);
-		expect(answers.listed).toEqual([gen1.path]);
-		expect(answers.described).toEqual([gen1.path]);
-	});
+			assert.strictEqual(answers.missing, gen1.path);
+			assert.strictEqual(answers.found, gen1.path);
+			assert.strictEqual(answers.gone, gen0.path);
+			assert.deepStrictEqual(answers.listed, [gen1.path]);
+			assert.deepStrictEqual(answers.described, [gen1.path]);
+		}),
+	);
 
-	it("loses no update when two swaps and a reload race", async () => {
-		const tableA = await Effect.runPromise(tableOf(genA));
-		const tableB = await Effect.runPromise(tableOf(genB));
+	it.effect("loses no update when two swaps and a reload race", () =>
+		Effect.gen(function* () {
+			const tableA = yield* tableOf(genA);
+			const tableB = yield* tableOf(genB);
 
-		const {observations, final} = await withSet(gen0.input, ({set, registry}) =>
-			Effect.gen(function* () {
-				const seen: Array<SpellSetState> = [];
-				const read = Effect.gen(function* () {
-					for (let round = 0; round < 200; round++) {
-						seen.push(yield* set.read);
-						yield* Effect.yieldNow;
-					}
-				});
-				// The reload goes first on purpose. `swap` carries the sources forward, so the only
-				// update it can drop belongs to a writer that changes them, and it drops that one
-				// only by reading before that write and storing after it. Starting the reload ahead
-				// of the swaps puts its write inside their compiles, which is that window exactly.
-				yield* Effect.all(
-					[set.reload(gen1.input), registry.swap(tableA), registry.swap(tableB), read],
-					{concurrency: "unbounded"},
-				);
-				return {observations: seen, final: yield* set.read};
-			}),
-		);
+			const {observations, final} = yield* withSet(gen0.input, ({set, registry}) =>
+				Effect.gen(function* () {
+					const seen: Array<SpellSetState> = [];
+					const read = Effect.gen(function* () {
+						for (let round = 0; round < 200; round++) {
+							seen.push(yield* set.read);
+							yield* Effect.yieldNow;
+						}
+					});
+					// The reload goes first on purpose. `swap` carries the sources forward, so the only
+					// update it can drop belongs to a writer that changes them, and it drops that one
+					// only by reading before that write and storing after it. Starting the reload ahead
+					// of the swaps puts its write inside their compiles, which is that window exactly.
+					yield* Effect.all(
+						[set.reload(gen1.input), registry.swap(tableA), registry.swap(tableB), read],
+						{concurrency: "unbounded"},
+					);
+					return {observations: seen, final: yield* set.read};
+				}),
+			);
 
-		expect(keysOf(final)).toEqual([gen1.source.file]);
-		await expectWhole(final);
-		expect([[genA.path], [genB.path], [gen1.path]]).toContainEqual(paths(final.table));
+			assert.deepStrictEqual(keysOf(final), [gen1.source.file]);
+			yield* expectWhole(final);
+			assert.deepInclude([[genA.path], [genB.path], [gen1.path]], paths(final.table));
 
-		// No reader ever walks back either: once the reload's sources are installed nothing
-		// reinstates the generation they replaced, and every state on the way is whole.
-		let reloaded = false;
-		for (const state of distinct(observations)) {
-			await expectWhole(state);
-			const isReloaded = keysOf(state).at(0) === gen1.source.file;
-			expect(isReloaded || !reloaded).toBe(true);
-			reloaded ||= isReloaded;
-		}
-		expect(reloaded).toBe(true);
-	});
+			// No reader ever walks back either: once the reload's sources are installed nothing
+			// reinstates the generation they replaced, and every state on the way is whole.
+			let reloaded = false;
+			for (const state of distinct(observations)) {
+				yield* expectWhole(state);
+				const isReloaded = keysOf(state).at(0) === gen1.source.file;
+				assert.isTrue(isReloaded || !reloaded);
+				reloaded ||= isReloaded;
+			}
+			assert.isTrue(reloaded);
+		}),
+	);
 });

--- a/apps/tuval/src/commands/spell.unit.test.ts
+++ b/apps/tuval/src/commands/spell.unit.test.ts
@@ -6,8 +6,8 @@
 
 import {readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
+import {assert, describe, expect, expectTypeOf, it} from "@effect/vitest";
 import {Effect, Schema} from "effect";
-import {describe, expect, expectTypeOf, it} from "vitest";
 import {defineSpell, type Scope, type Spell} from "./spell.ts";
 
 const scope: Scope = {
@@ -55,18 +55,20 @@ describe("defineSpell", () => {
 		>();
 	});
 
-	it("is the identity function — the value it returns is the value it was given", async () => {
-		const spell = {
-			path: ["window", "close"],
-			describe: "Close the focused window.",
-			params: Schema.Struct({id: Schema.String}),
-			result: Schema.Struct({closed: Schema.Boolean}),
-			execute: () => Effect.succeed({closed: true}),
-			capabilities: [],
-		} as const;
-		expect(defineSpell(spell)).toBe(spell);
-		expect(await Effect.runPromise(closeWindow.execute({id: "w1"}, scope))).toEqual({closed: true});
-	});
+	it.effect("is the identity function — the value it returns is the value it was given", () =>
+		Effect.gen(function* () {
+			const spell = {
+				path: ["window", "close"],
+				describe: "Close the focused window.",
+				params: Schema.Struct({id: Schema.String}),
+				result: Schema.Struct({closed: Schema.Boolean}),
+				execute: () => Effect.succeed({closed: true}),
+				capabilities: [],
+			} as const;
+			assert.strictEqual(defineSpell(spell), spell);
+			assert.deepStrictEqual(yield* closeWindow.execute({id: "w1"}, scope), {closed: true});
+		}),
+	);
 
 	it("carries `capabilities` as inert data no part of this slice reads", () => {
 		expectTypeOf<Spell<Schema.Top, Schema.Top, never, never>["capabilities"]>().toEqualTypeOf<

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -1,8 +1,10 @@
 import {fileURLToPath} from "node:url";
 import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {ConfigLoadError, loadConfigModule, loadLayeredConfig} from "./config.ts";
+import {NodeId} from "./ports/graph.ts";
+import {ProgramId} from "./registry/program.ts";
 
 const fixture = (name: string) =>
 	fileURLToPath(new URL(`./config-fixtures/${name}.ts`, import.meta.url));
@@ -10,132 +12,156 @@ const fixture = (name: string) =>
 /** How `describeFile` names a fixture module: relative to the directory two levels above it. */
 const layerName = (name: string) => `config-fixtures/${name}.ts`;
 
-const refusal = async (name: string): Promise<ConfigLoadError> => {
-	const error = await Effect.runPromise(Effect.flip(loadConfigModule(fixture(name))));
-	expect(error).toBeInstanceOf(ConfigLoadError);
-	return error;
-};
+const refusal = (name: string) =>
+	Effect.map(Effect.flip(loadConfigModule(fixture(name))), (error) => {
+		assert.instanceOf(error, ConfigLoadError);
+		return error;
+	});
 
 const layered = (global: string, project: string) =>
-	Effect.runPromise(
-		loadLayeredConfig({global, project}).pipe(Effect.provide(NodeFileSystem.layer)),
-	);
+	loadLayeredConfig({global, project}).pipe(Effect.provide(NodeFileSystem.layer));
 
 describe("loadConfigModule", () => {
-	it("returns the rows a well-formed module exports, and an empty graph when it exports none", async () => {
-		const config = await Effect.runPromise(loadConfigModule(fixture("two-rows")));
-		expect(config).toEqual({
-			version: 1,
-			programs: [{id: "a"}, {id: "b"}],
-			graph: {nodes: []},
-			keys: {},
-		});
-	});
+	it.effect(
+		"returns the rows a well-formed module exports, and an empty graph when it exports none",
+		() =>
+			Effect.gen(function* () {
+				const config = yield* loadConfigModule(fixture("two-rows"));
+				assert.deepStrictEqual(config, {
+					version: 1,
+					programs: [{id: "a"}, {id: "b"}],
+					graph: {nodes: []},
+					keys: {},
+				});
+			}),
+	);
 
-	it("returns the graph a module exports beside its rows", async () => {
-		const config = await Effect.runPromise(loadConfigModule(fixture("with-graph")));
-		expect(config).toEqual({
-			version: 1,
-			programs: [{id: "a"}],
-			graph: {nodes: [{id: "n", program: "a", on: []}]},
-			keys: {},
-		});
-	});
+	it.effect("returns the graph a module exports beside its rows", () =>
+		Effect.gen(function* () {
+			const config = yield* loadConfigModule(fixture("with-graph"));
+			assert.deepStrictEqual(config, {
+				version: 1,
+				programs: [{id: "a"}],
+				graph: {nodes: [{id: NodeId.make("n"), program: ProgramId.make("a"), on: []}]},
+				keys: {},
+			});
+		}),
+	);
 
-	it("refuses a graph that is not a graph, naming where and what it got", async () => {
-		const error = await refusal("bad-graph");
-		expect(error.reason).toBe("not a v1 config at graph: Expected object");
-	});
+	it.effect("refuses a graph that is not a graph, naming where and what it got", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal("bad-graph");
+			assert.strictEqual(error.reason, "not a v1 config at graph: Expected object");
+		}),
+	);
 
-	it("refuses a version the schema does not know", async () => {
-		const error = await refusal("wrong-version");
-		expect(error.reason).toBe("not a v1 config at version: Expected 1");
-	});
+	it.effect("refuses a version the schema does not know", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal("wrong-version");
+			assert.strictEqual(error.reason, "not a v1 config at version: Expected 1");
+		}),
+	);
 
-	it("refuses a module that throws, naming the module and the thrown reason", async () => {
-		const error = await refusal("throws");
-		expect(error.module).toBe(fixture("throws"));
-		expect(error.reason).toBe("module threw while loading: boom at import time");
-		expect(error.message).toBe(
-			`config module ${fixture("throws")}: module threw while loading: boom at import time`,
-		);
-	});
+	it.effect("refuses a module that throws, naming the module and the thrown reason", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal("throws");
+			assert.strictEqual(error.module, fixture("throws"));
+			assert.strictEqual(error.reason, "module threw while loading: boom at import time");
+			assert.strictEqual(
+				error.message,
+				`config module ${fixture("throws")}: module threw while loading: boom at import time`,
+			);
+		}),
+	);
 
-	it("refuses a default export that is not a v1 config, naming the missing key", async () => {
-		const error = await refusal("wrong-shape");
-		expect(error.module).toBe(fixture("wrong-shape"));
-		expect(error.reason).toBe("not a v1 config at version: Missing key");
-	});
+	it.effect("refuses a default export that is not a v1 config, naming the missing key", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal("wrong-shape");
+			assert.strictEqual(error.module, fixture("wrong-shape"));
+			assert.strictEqual(error.reason, "not a v1 config at version: Missing key");
+		}),
+	);
 
-	it("refuses a module with no default export", async () => {
-		const error = await refusal("no-default");
-		expect(error.module).toBe(fixture("no-default"));
-		expect(error.reason).toBe(
-			"no default export; export default a {version: 1, programs: [...]} config",
-		);
-	});
+	it.effect("refuses a module with no default export", () =>
+		Effect.gen(function* () {
+			const error = yield* refusal("no-default");
+			assert.strictEqual(error.module, fixture("no-default"));
+			assert.strictEqual(
+				error.reason,
+				"no default export; export default a {version: 1, programs: [...]} config",
+			);
+		}),
+	);
 });
 
 describe("loadLayeredConfig", () => {
-	it("merges the project layer over the global one by program id and node id, global order first", async () => {
-		const config = await layered(fixture("global-layer"), fixture("project-layer"));
-		expect(config).toEqual({
-			programs: [{id: "a"}, {id: "b", core: "project"}],
-			graph: {
-				nodes: [
-					{id: "n", program: "b", on: []},
-					{id: "m", program: "a", on: []},
-				],
-			},
-			keys: [
-				{file: `global ${layerName("global-layer")}`, bindings: {}},
-				{file: `project ${layerName("project-layer")}`, bindings: {}},
-			],
-			sources: [fixture("global-layer"), fixture("project-layer")],
-		});
-	});
+	it.effect(
+		"merges the project layer over the global one by program id and node id, global order first",
+		() =>
+			Effect.gen(function* () {
+				const config = yield* layered(fixture("global-layer"), fixture("project-layer"));
+				assert.deepStrictEqual(config, {
+					programs: [{id: "a"}, {id: "b", core: "project"}],
+					graph: {
+						nodes: [
+							{id: NodeId.make("n"), program: ProgramId.make("b"), on: []},
+							{id: NodeId.make("m"), program: ProgramId.make("a"), on: []},
+						],
+					},
+					keys: [
+						{file: `global ${layerName("global-layer")}`, bindings: {}},
+						{file: `project ${layerName("project-layer")}`, bindings: {}},
+					],
+					sources: [fixture("global-layer"), fixture("project-layer")],
+				});
+			}),
+	);
 
-	it("treats an absent layer as empty and names only the layers it found", async () => {
-		const missing = fixture("does-not-exist");
-		expect(await layered(missing, fixture("with-graph"))).toEqual({
-			programs: [{id: "a"}],
-			graph: {nodes: [{id: "n", program: "a", on: []}]},
-			keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
-			sources: [fixture("with-graph")],
-		});
-		expect(await layered(fixture("two-rows"), missing)).toEqual({
-			programs: [{id: "a"}, {id: "b"}],
-			graph: {nodes: []},
-			keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
-			sources: [fixture("two-rows")],
-		});
-		expect(await layered(missing, missing)).toEqual({
-			programs: [],
-			graph: {nodes: []},
-			keys: [],
-			sources: [],
-		});
-	});
+	it.effect("treats an absent layer as empty and names only the layers it found", () =>
+		Effect.gen(function* () {
+			const missing = fixture("does-not-exist");
+			assert.deepStrictEqual(yield* layered(missing, fixture("with-graph")), {
+				programs: [{id: "a"}],
+				graph: {nodes: [{id: NodeId.make("n"), program: ProgramId.make("a"), on: []}]},
+				keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
+				sources: [fixture("with-graph")],
+			});
+			assert.deepStrictEqual(yield* layered(fixture("two-rows"), missing), {
+				programs: [{id: "a"}, {id: "b"}],
+				graph: {nodes: []},
+				keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
+				sources: [fixture("two-rows")],
+			});
+			assert.deepStrictEqual(yield* layered(missing, missing), {
+				programs: [],
+				graph: {nodes: []},
+				keys: [],
+				sources: [],
+			});
+		}),
+	);
 
-	it("carries each layer's key bindings as its own source, named for the layer", async () => {
-		const config = await layered(fixture("keys"), fixture("does-not-exist"));
-		expect(config.keys).toEqual([
-			{
-				file: `global ${layerName("keys")}`,
-				bindings: {"ctrl-h": "help", "ctrl-x": {command: "spell list", repeat: true}},
-			},
-		]);
-	});
+	it.effect("carries each layer's key bindings as its own source, named for the layer", () =>
+		Effect.gen(function* () {
+			const config = yield* layered(fixture("keys"), fixture("does-not-exist"));
+			assert.deepStrictEqual(config.keys, [
+				{
+					file: `global ${layerName("keys")}`,
+					bindings: {"ctrl-h": "help", "ctrl-x": {command: "spell list", repeat: true}},
+				},
+			]);
+		}),
+	);
 
-	it("still refuses a layer that exists and is broken", async () => {
-		const error = await Effect.runPromise(
-			Effect.flip(
+	it.effect("still refuses a layer that exists and is broken", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(
 				loadLayeredConfig({global: fixture("throws"), project: fixture("two-rows")}).pipe(
 					Effect.provide(NodeFileSystem.layer),
 				),
-			),
-		);
-		expect(error).toBeInstanceOf(ConfigLoadError);
-		expect(error.module).toBe(fixture("throws"));
-	});
+			);
+			assert.instanceOf(error, ConfigLoadError);
+			assert.strictEqual(error.module, fixture("throws"));
+		}),
+	);
 });

--- a/apps/tuval/src/page/attached-desk.unit.test.tsx
+++ b/apps/tuval/src/page/attached-desk.unit.test.tsx
@@ -6,9 +6,9 @@
  * the socket itself is proven end to end in `../shell/proof/`.
  */
 
+import {assert, describe, it} from "@effect/vitest";
 import {act, render, screen} from "@testing-library/react";
-import {Effect, Option, Stream, SubscriptionRef} from "effect";
-import {describe, expect, it} from "vitest";
+import {Effect, Option, Schema, Stream, SubscriptionRef} from "effect";
 import {counterId} from "../demo/counter.ts";
 import {ProcessId} from "../process/process.ts";
 import {ProgramId} from "../registry/program.ts";
@@ -153,203 +153,260 @@ const scripted = Effect.fn("test.scripted")(function* (options?: {
 	return {page, shell, attaches, sent} satisfies Scripted;
 });
 
-/** Let the forked stream fibers deliver before asserting; each is one microtask hop, not a clock. */
-const settle = async (): Promise<void> => {
-	for (let hop = 0; hop < 8; hop++) await act(async () => await Promise.resolve());
-};
+class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defect()}) {}
+
+/**
+ * Let the forked stream fibers deliver before asserting; each is one microtask hop, not a clock.
+ * `act` answers a `Promise`, so the lift is object-notation `tryPromise` + `orDie` — the sanctioned
+ * stand-in for the banned `Effect.promise` (#2736).
+ */
+const settle = Effect.gen(function* () {
+	for (let hop = 0; hop < 8; hop++) {
+		yield* Effect.tryPromise({
+			try: () => act(async () => await Promise.resolve()),
+			catch: (cause) => new TestIo({cause}),
+		}).pipe(Effect.orDie);
+	}
+});
 
 describe("the attached desk", () => {
-	it("opens one subscription for a process shown in two windows, and mounts its renderer in both", async () => {
-		const app = await Effect.runPromise(scripted());
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
+	it.effect(
+		"opens one subscription for a process shown in two windows, and mounts its renderer in both",
+		() =>
+			Effect.gen(function* () {
+				const app = yield* scripted();
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
 
-		expect(app.attaches).toEqual([counterProcess]);
-		const windows = screen.getAllByRole("region", {name: /^Window /});
-		expect(windows.map((node) => node.getAttribute("data-window-id"))).toEqual([
-			"window-1",
-			"window-2",
-		]);
-		// One process, one state, two windows showing it.
-		expect(screen.getAllByLabelText("Counter value").map((node) => node.textContent)).toEqual([
-			"7",
-			"7",
-		]);
-	});
-
-	it("offers every program the kernel sent, by id and label, instead of the empty-section message", async () => {
-		const app = await Effect.runPromise(scripted({state: emptyDesk(), rows: []}));
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
-
-		const programs = screen.getByRole("group", {name: "Programs"});
-		expect(
-			[...programs.querySelectorAll('[role="option"]')].map((node) =>
-				node.getAttribute("aria-label"),
-			),
-		).toEqual([
-			`Counter — program ${counterId}`,
-			"Log — program tuval/log",
-			"Scratch — program tuval/scratch",
-		]);
-		expect(screen.queryByText("No registered program can fill a window.")).toBeNull();
-	});
-
-	it("resolves a window's renderer by the reference its program names, never by the program id", async () => {
-		// `tuval/scratch` is a program this page has no entry for; its row names the counter demo's
-		// renderer, and that reference is the whole of what the page resolves against.
-		const scratchRow: TableRow = {...counterRow, programId: ProgramId.make("tuval/scratch")};
-		const app = await Effect.runPromise(scripted({rows: [scratchRow]}));
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
-
-		expect(screen.getAllByLabelText("Counter value").map((node) => node.textContent)).toEqual([
-			"7",
-			"7",
-		]);
-	});
-
-	it("holds the window with a placeholder when the process's program is not in the catalog", async () => {
-		// The empty catalog is also the transient: `programs` replays its initial value, so a table row
-		// can reach the page a frame before the registry frame does.
-		const app = await Effect.runPromise(scripted({programs: []}));
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
-
-		expect(
-			screen.getAllByText(
-				`Process ${counterProcess} is running, but no catalog entry on this page for program ${counterId}.`,
-			),
-		).toHaveLength(2);
-		expect(screen.queryByLabelText("Counter value")).toBeNull();
-	});
-
-	it("holds the window with a placeholder when the page answers to no renderer of that name", async () => {
-		const app = await Effect.runPromise(
-			scripted({
-				programs: [
-					{
-						programId: counterId,
-						label: "Counter",
-						renderer: {kind: "host-native", ref: "tuval/demo/absent"},
-					},
-				],
+				assert.deepStrictEqual(app.attaches, [counterProcess]);
+				const windows = screen.getAllByRole("region", {name: /^Window /});
+				assert.deepStrictEqual(
+					windows.map((node) => node.getAttribute("data-window-id")),
+					["window-1", "window-2"],
+				);
+				// One process, one state, two windows showing it.
+				assert.deepStrictEqual(
+					screen.getAllByLabelText("Counter value").map((node) => node.textContent),
+					["7", "7"],
+				);
 			}),
-		);
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
+	);
 
-		expect(
-			screen.getAllByText(
-				`Process ${counterProcess} is running, but this page answers to no renderer named tuval/demo/absent.`,
-			),
-		).toHaveLength(2);
-		expect(screen.queryByLabelText("Counter value")).toBeNull();
-	});
+	it.effect(
+		"offers every program the kernel sent, by id and label, instead of the empty-section message",
+		() =>
+			Effect.gen(function* () {
+				const app = yield* scripted({state: emptyDesk(), rows: []});
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
 
-	it("choosing a program from the picker asks for the same open the command line asks for", async () => {
-		const app = await Effect.runPromise(scripted({state: emptyDesk(), rows: []}));
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
+				const programs = screen.getByRole("group", {name: "Programs"});
+				assert.deepStrictEqual(
+					[...programs.querySelectorAll('[role="option"]')].map((node) =>
+						node.getAttribute("aria-label"),
+					),
+					[
+						`Counter — program ${counterId}`,
+						"Log — program tuval/log",
+						"Scratch — program tuval/scratch",
+					],
+				);
+				assert.isNull(screen.queryByText("No registered program can fill a window."));
+			}),
+	);
 
-		act(() => {
-			document.dispatchEvent(new KeyboardEvent("keydown", {key: "Enter", bubbles: true}));
-		});
-		const chosen = app.sent.find((msg) => msg.type === "window.open");
-		expect(chosen).toEqual({type: "window.open", windowId: "window-1", programId: counterId});
+	it.effect(
+		"resolves a window's renderer by the reference its program names, never by the program id",
+		() =>
+			Effect.gen(function* () {
+				// `tuval/scratch` is a program this page has no entry for; its row names the counter
+				// demo's renderer, and that reference is the whole of what the page resolves against.
+				const scratchRow: TableRow = {...counterRow, programId: ProgramId.make("tuval/scratch")};
+				const app = yield* scripted({rows: [scratchRow]});
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
 
-		// The typed line reaches the same Msg, and the core turns both into one `openProgram` Cmd —
-		// the kernel handler that spawns and binds (`../shell/host/effects.ts`).
-		const typed = readCommandLine(`window:open ${counterId}`);
-		expect(typed._tag).toBe("Msg");
-		const cmds = (msg: ShellMsg): readonly ShellCmd[] =>
-			applyMsg(defaultPrefixTable, emptyDesk(), msg)[1];
-		expect(cmds(chosen as ShellMsg)).toEqual([
-			{type: "openProgram", windowId: "window-1", programId: counterId},
-		]);
-		expect(typed._tag === "Msg" ? cmds(typed.msg) : []).toEqual(cmds(chosen as ShellMsg));
-	});
+				assert.deepStrictEqual(
+					screen.getAllByLabelText("Counter value").map((node) => node.textContent),
+					["7", "7"],
+				);
+			}),
+	);
 
-	it("sends a window's own view write back as a Msg, so the two windows' slots stay the kernel's", async () => {
-		const app = await Effect.runPromise(scripted());
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
+	it.effect(
+		"holds the window with a placeholder when the process's program is not in the catalog",
+		() =>
+			Effect.gen(function* () {
+				// The empty catalog is also the transient: `programs` replays its initial value, so a table
+				// row can reach the page a frame before the registry frame does.
+				const app = yield* scripted({programs: []});
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
 
-		expect(app.sent).toEqual([]);
-		// The desk's own listener is the page's only input path, and it goes to the kernel.
-		act(() => {
-			document.dispatchEvent(new KeyboardEvent("keydown", {key: "j", bubbles: true}));
-		});
-		expect(app.sent).toEqual([{type: "keys.press", key: expect.objectContaining({key: "j"})}]);
-	});
+				assert.lengthOf(
+					screen.getAllByText(
+						`Process ${counterProcess} is running, but no catalog entry on this page for program ${counterId}.`,
+					),
+					2,
+				);
+				assert.isNull(screen.queryByLabelText("Counter value"));
+			}),
+	);
 
-	it("shows no desk until the kernel has sent its key grammar, and no key reaches the kernel", async () => {
-		const app = await Effect.runPromise(scripted({keys: null}));
-		render(
-			<AttachedDesk
-				page={app.page}
-				shell={app.shell}
-				renderers={demoRenderers}
-				reducedMotion={true}
-			/>,
-		);
-		await settle();
+	it.effect(
+		"holds the window with a placeholder when the page answers to no renderer of that name",
+		() =>
+			Effect.gen(function* () {
+				const app = yield* scripted({
+					programs: [
+						{
+							programId: counterId,
+							label: "Counter",
+							renderer: {kind: "host-native", ref: "tuval/demo/absent"},
+						},
+					],
+				});
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
 
-		// The snapshot arrived; only the grammar did not, and that alone holds the desk back.
-		expect(screen.queryAllByRole("region", {name: /^Window /})).toEqual([]);
-		expect(screen.getByRole("status").textContent).toBe("Attaching to the Tuval kernel…");
-		act(() => {
-			document.dispatchEvent(new KeyboardEvent("keydown", {key: "j", bubbles: true}));
-		});
-		expect(app.sent).toEqual([]);
-	});
+				assert.lengthOf(
+					screen.getAllByText(
+						`Process ${counterProcess} is running, but this page answers to no renderer named tuval/demo/absent.`,
+					),
+					2,
+				);
+				assert.isNull(screen.queryByLabelText("Counter value"));
+			}),
+	);
+
+	it.effect(
+		"choosing a program from the picker asks for the same open the command line asks for",
+		() =>
+			Effect.gen(function* () {
+				const app = yield* scripted({state: emptyDesk(), rows: []});
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
+
+				act(() => {
+					document.dispatchEvent(new KeyboardEvent("keydown", {key: "Enter", bubbles: true}));
+				});
+				const chosen = app.sent.find((msg) => msg.type === "window.open");
+				assert.deepStrictEqual(chosen, {
+					type: "window.open",
+					windowId: "window-1",
+					programId: counterId,
+				});
+
+				// The typed line reaches the same Msg, and the core turns both into one `openProgram` Cmd —
+				// the kernel handler that spawns and binds (`../shell/host/effects.ts`).
+				const typed = readCommandLine(`window:open ${counterId}`);
+				assert.strictEqual(typed._tag, "Msg");
+				const cmds = (msg: ShellMsg): readonly ShellCmd[] =>
+					applyMsg(defaultPrefixTable, emptyDesk(), msg)[1];
+				assert.deepStrictEqual(cmds(chosen as ShellMsg), [
+					{type: "openProgram", windowId: "window-1", programId: counterId},
+				]);
+				assert.deepStrictEqual(
+					typed._tag === "Msg" ? cmds(typed.msg) : [],
+					cmds(chosen as ShellMsg),
+				);
+			}),
+	);
+
+	it.effect(
+		"sends a window's own view write back as a Msg, so the two windows' slots stay the kernel's",
+		() =>
+			Effect.gen(function* () {
+				const app = yield* scripted();
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
+
+				assert.deepStrictEqual(app.sent, []);
+				// The desk's own listener is the page's only input path, and it goes to the kernel.
+				act(() => {
+					document.dispatchEvent(new KeyboardEvent("keydown", {key: "j", bubbles: true}));
+				});
+				assert.lengthOf(app.sent, 1);
+				const press = app.sent.at(0);
+				assert.strictEqual(press?.type, "keys.press");
+				assert.include(press?.type === "keys.press" ? press.key : {}, {key: "j"});
+			}),
+	);
+
+	it.effect(
+		"shows no desk until the kernel has sent its key grammar, and no key reaches the kernel",
+		() =>
+			Effect.gen(function* () {
+				const app = yield* scripted({keys: null});
+				render(
+					<AttachedDesk
+						page={app.page}
+						shell={app.shell}
+						renderers={demoRenderers}
+						reducedMotion={true}
+					/>,
+				);
+				yield* settle;
+
+				// The snapshot arrived; only the grammar did not, and that alone holds the desk back.
+				assert.deepStrictEqual(screen.queryAllByRole("region", {name: /^Window /}), []);
+				assert.strictEqual(
+					screen.getByRole("status").textContent,
+					"Attaching to the Tuval kernel…",
+				);
+				act(() => {
+					document.dispatchEvent(new KeyboardEvent("keydown", {key: "j", bubbles: true}));
+				});
+				assert.deepStrictEqual(app.sent, []);
+			}),
+	);
 });

--- a/apps/tuval/src/ports/compile.unit.test.ts
+++ b/apps/tuval/src/ports/compile.unit.test.ts
@@ -1,5 +1,5 @@
+import {assert, describe, it} from "@effect/vitest";
 import {Effect, Option} from "effect";
-import {describe, expect, it} from "vitest";
 import {type AnyProgram, ProgramId, ProgramNotFound} from "../registry/index.ts";
 import {Registry} from "../registry/Registry.ts";
 import {compile} from "./compile.ts";
@@ -16,7 +16,7 @@ import type {Graph} from "./graph.ts";
 import {NodeId} from "./graph.ts";
 
 const compileWith = (rows: ReadonlyArray<AnyProgram>, graph: Graph) =>
-	Effect.runPromise(Effect.flip(Effect.provide(compile(graph), Registry.layer(rows))));
+	Effect.flip(Effect.provide(compile(graph), Registry.layer(rows)));
 
 const node = (id: string, programId: string, on: Graph["nodes"][number]["on"] = []) => ({
 	id: NodeId.make(id),
@@ -27,9 +27,9 @@ const node = (id: string, programId: string, on: Graph["nodes"][number]["on"] = 
 const to = (nodeId: string, port: string) => ({node: NodeId.make(nodeId), port});
 
 describe("ports.compile", () => {
-	it("compiles a compatible route into one normalized route carrying both program ids", async () => {
-		const compiled = await Effect.runPromise(
-			Effect.provide(
+	it.effect("compiles a compatible route into one normalized route carrying both program ids", () =>
+		Effect.gen(function* () {
+			const compiled = yield* Effect.provide(
 				compile({
 					nodes: [
 						node("p", "producer", [{port: "ticks", to: to("c", "ticks")}]),
@@ -37,126 +37,177 @@ describe("ports.compile", () => {
 					],
 				}),
 				Registry.layer([producer, consumer()]),
-			),
-		);
-		expect(compiled.routes).toEqual([
-			{
-				kind: "tick/v1",
-				source: {node: "p", port: "ticks", program: "producer"},
-				target: {node: "c", port: "ticks", program: "consumer"},
-			},
-		]);
-		expect(compiled.nodes.map((n) => n.id)).toEqual(["p", "c"]);
-	});
+			);
+			assert.deepStrictEqual(compiled.routes, [
+				{
+					kind: "tick/v1",
+					source: {node: "p", port: "ticks", program: "producer"},
+					target: {node: "c", port: "ticks", program: "consumer"},
+				},
+			]);
+			assert.deepStrictEqual(
+				compiled.nodes.map((n) => n.id),
+				["p", "c"],
+			);
+		}),
+	);
 
-	it("refuses an incompatible route before boot, naming both kinds and both program ids", async () => {
-		const error = await compileWith([producer, judge], {
-			nodes: [
-				node("p", "producer", [{port: "ticks", to: to("j", "verdicts")}]),
-				node("j", "judge"),
-			],
-		});
-		expect(error).toBeInstanceOf(IncompatibleRoute);
-		expect(error).toMatchObject({
-			source: {program: "producer", port: "ticks", kind: "tick/v1"},
-			target: {program: "judge", port: "verdicts", kind: "verdict/v1"},
-		});
-		expect(error.message).toBe(
-			'route producer.ticks -> judge.verdicts is incompatible: source kind "tick/v1" does not match target kind "verdict/v1"',
-		);
-	});
+	it.effect(
+		"refuses an incompatible route before boot, naming both kinds and both program ids",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* compileWith([producer, judge], {
+					nodes: [
+						node("p", "producer", [{port: "ticks", to: to("j", "verdicts")}]),
+						node("j", "judge"),
+					],
+				});
+				assert.instanceOf(error, IncompatibleRoute);
+				const incompatible = error as IncompatibleRoute;
+				assert.strictEqual(incompatible.source.program, "producer");
+				assert.strictEqual(incompatible.source.port, "ticks");
+				assert.strictEqual(incompatible.source.kind, "tick/v1");
+				assert.strictEqual(incompatible.target.program, "judge");
+				assert.strictEqual(incompatible.target.port, "verdicts");
+				assert.strictEqual(incompatible.target.kind, "verdict/v1");
+				assert.strictEqual(
+					error.message,
+					'route producer.ticks -> judge.verdicts is incompatible: source kind "tick/v1" does not match target kind "verdict/v1"',
+				);
+			}),
+	);
 
-	it("refuses a route leaving a port the source program does not declare, naming port and program", async () => {
-		const error = await compileWith([producer, consumer()], {
-			nodes: [
-				node("p", "producer", [{port: "beats", to: to("c", "ticks")}]),
-				node("c", "consumer"),
-			],
-		});
-		expect(error).toBeInstanceOf(UndeclaredPort);
-		expect(error).toMatchObject({program: "producer", port: "beats", direction: "out"});
-		expect(error.message).toBe('program "producer" declares no out-port "beats"');
-	});
+	it.effect(
+		"refuses a route leaving a port the source program does not declare, naming port and program",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* compileWith([producer, consumer()], {
+					nodes: [
+						node("p", "producer", [{port: "beats", to: to("c", "ticks")}]),
+						node("c", "consumer"),
+					],
+				});
+				assert.instanceOf(error, UndeclaredPort);
+				const undeclared = error as UndeclaredPort;
+				assert.strictEqual(undeclared.program, "producer");
+				assert.strictEqual(undeclared.port, "beats");
+				assert.strictEqual(undeclared.direction, "out");
+				assert.strictEqual(error.message, 'program "producer" declares no out-port "beats"');
+			}),
+	);
 
-	it("refuses a route into a port the target program does not declare", async () => {
-		const error = await compileWith([producer, consumer()], {
-			nodes: [
-				node("p", "producer", [{port: "ticks", to: to("c", "beats")}]),
-				node("c", "consumer"),
-			],
-		});
-		expect(error).toBeInstanceOf(UndeclaredPort);
-		expect(error).toMatchObject({program: "consumer", port: "beats", direction: "in"});
-	});
+	it.effect("refuses a route into a port the target program does not declare", () =>
+		Effect.gen(function* () {
+			const error = yield* compileWith([producer, consumer()], {
+				nodes: [
+					node("p", "producer", [{port: "ticks", to: to("c", "beats")}]),
+					node("c", "consumer"),
+				],
+			});
+			assert.instanceOf(error, UndeclaredPort);
+			const undeclared = error as UndeclaredPort;
+			assert.strictEqual(undeclared.program, "consumer");
+			assert.strictEqual(undeclared.port, "beats");
+			assert.strictEqual(undeclared.direction, "in");
+		}),
+	);
 
-	it("an in-port is not an outbound port: routing from it is refused as undeclared", async () => {
-		const error = await compileWith([producer, consumer()], {
-			nodes: [node("c", "consumer", [{port: "ticks", to: to("c", "ticks")}])],
-		});
-		expect(error).toBeInstanceOf(UndeclaredPort);
-		expect(error).toMatchObject({program: "consumer", port: "ticks", direction: "out"});
-	});
+	it.effect("an in-port is not an outbound port: routing from it is refused as undeclared", () =>
+		Effect.gen(function* () {
+			const error = yield* compileWith([producer, consumer()], {
+				nodes: [node("c", "consumer", [{port: "ticks", to: to("c", "ticks")}])],
+			});
+			assert.instanceOf(error, UndeclaredPort);
+			const undeclared = error as UndeclaredPort;
+			assert.strictEqual(undeclared.program, "consumer");
+			assert.strictEqual(undeclared.port, "ticks");
+			assert.strictEqual(undeclared.direction, "out");
+		}),
+	);
 
-	it("refuses a route to a node the graph does not declare", async () => {
-		const error = await compileWith([producer], {
-			nodes: [node("p", "producer", [{port: "ticks", to: to("ghost", "ticks")}])],
-		});
-		expect(error).toBeInstanceOf(UnknownNode);
-		expect(error).toMatchObject({from: "p", to: "ghost"});
-	});
+	it.effect("refuses a route to a node the graph does not declare", () =>
+		Effect.gen(function* () {
+			const error = yield* compileWith([producer], {
+				nodes: [node("p", "producer", [{port: "ticks", to: to("ghost", "ticks")}])],
+			});
+			assert.instanceOf(error, UnknownNode);
+			const unknown = error as UnknownNode;
+			assert.strictEqual(unknown.from, "p");
+			assert.strictEqual(unknown.to, "ghost");
+		}),
+	);
 
-	it("refuses a node naming a program the registry does not hold", async () => {
-		const error = await compileWith([producer], {nodes: [node("x", "missing")]});
-		expect(error).toBeInstanceOf(ProgramNotFound);
-	});
+	it.effect("refuses a node naming a program the registry does not hold", () =>
+		Effect.gen(function* () {
+			const error = yield* compileWith([producer], {nodes: [node("x", "missing")]});
+			assert.instanceOf(error, ProgramNotFound);
+		}),
+	);
 
-	it("refuses a duplicate node id", async () => {
-		const error = await compileWith([producer], {
-			nodes: [node("p", "producer"), node("p", "producer")],
-		});
-		expect(error).toBeInstanceOf(DuplicateNodeId);
-		expect(error).toMatchObject({node: "p"});
-	});
+	it.effect("refuses a duplicate node id", () =>
+		Effect.gen(function* () {
+			const error = yield* compileWith([producer], {
+				nodes: [node("p", "producer"), node("p", "producer")],
+			});
+			assert.instanceOf(error, DuplicateNodeId);
+			assert.strictEqual((error as DuplicateNodeId).node, "p");
+		}),
+	);
 
-	it("refuses an in-port whose bound is not a positive integer", async () => {
-		const unbounded = program("sink", {
-			ticks: {
-				kind: "tick/v1",
-				direction: "in",
-				accepts: isNumber,
-				bound: {capacity: 0, overflow: "suspend"},
-			},
-		});
-		const error = await compileWith([unbounded], {nodes: [node("s", "sink")]});
-		expect(error).toBeInstanceOf(InvalidBound);
-		expect(error).toMatchObject({program: "sink", port: "ticks", capacity: 0});
-	});
+	it.effect("refuses an in-port whose bound is not a positive integer", () =>
+		Effect.gen(function* () {
+			const unbounded = program("sink", {
+				ticks: {
+					kind: "tick/v1",
+					direction: "in",
+					accepts: isNumber,
+					bound: {capacity: 0, overflow: "suspend"},
+				},
+			});
+			const error = yield* compileWith([unbounded], {nodes: [node("s", "sink")]});
+			assert.instanceOf(error, InvalidBound);
+			const invalid = error as InvalidBound;
+			assert.strictEqual(invalid.program, "sink");
+			assert.strictEqual(invalid.port, "ticks");
+			assert.strictEqual(invalid.capacity, 0);
+		}),
+	);
 
-	it("carries a node's parent when it is declared earlier, as none when it has one", async () => {
-		const compiled = await Effect.runPromise(
-			Effect.provide(
+	it.effect("carries a node's parent when it is declared earlier, as none when it has one", () =>
+		Effect.gen(function* () {
+			const compiled = yield* Effect.provide(
 				compile({
 					nodes: [node("p", "producer"), {...node("c", "consumer"), parent: NodeId.make("p")}],
 				}),
 				Registry.layer([producer, consumer()]),
-			),
-		);
-		expect(compiled.nodes.map((n) => n.parent)).toEqual([Option.none(), Option.some("p")]);
-	});
+			);
+			assert.deepStrictEqual(
+				compiled.nodes.map((n) => n.parent),
+				[Option.none(), Option.some("p")],
+			);
+		}),
+	);
 
-	it("refuses a parent the graph does not declare before the child, whether later or never", async () => {
-		const later = await compileWith([producer, consumer()], {
-			nodes: [{...node("c", "consumer"), parent: NodeId.make("p")}, node("p", "producer")],
-		});
-		expect(later).toBeInstanceOf(UnknownParent);
-		expect(later).toMatchObject({node: "c", parent: "p"});
-		expect(later.message).toBe(
-			'node "c" names parent "p", which the graph does not declare before it',
-		);
+	it.effect(
+		"refuses a parent the graph does not declare before the child, whether later or never",
+		() =>
+			Effect.gen(function* () {
+				const later = yield* compileWith([producer, consumer()], {
+					nodes: [{...node("c", "consumer"), parent: NodeId.make("p")}, node("p", "producer")],
+				});
+				assert.instanceOf(later, UnknownParent);
+				const unknownParent = later as UnknownParent;
+				assert.strictEqual(unknownParent.node, "c");
+				assert.strictEqual(unknownParent.parent, "p");
+				assert.strictEqual(
+					later.message,
+					'node "c" names parent "p", which the graph does not declare before it',
+				);
 
-		const never = await compileWith([consumer()], {
-			nodes: [{...node("c", "consumer"), parent: NodeId.make("ghost")}],
-		});
-		expect(never).toBeInstanceOf(UnknownParent);
-	});
+				const never = yield* compileWith([consumer()], {
+					nodes: [{...node("c", "consumer"), parent: NodeId.make("ghost")}],
+				});
+				assert.instanceOf(never, UnknownParent);
+			}),
+	);
 });

--- a/apps/tuval/src/ports/wiring.unit.test.ts
+++ b/apps/tuval/src/ports/wiring.unit.test.ts
@@ -1,5 +1,5 @@
+import {assert, describe, it} from "@effect/vitest";
 import {Effect, Fiber, Queue} from "effect";
-import {describe, expect, it} from "vitest";
 import {type AnyProgram, type PortBound, ProgramId} from "../registry/index.ts";
 import {Registry} from "../registry/Registry.ts";
 import {compile} from "./compile.ts";
@@ -40,10 +40,8 @@ const wired = <A, E>(
 	graph: Graph,
 	body: (wiring: Wiring) => Effect.Effect<A, E>,
 ) =>
-	Effect.runPromise(
-		Effect.scoped(Effect.flatMap(Effect.flatMap(compile(graph), open), body)).pipe(
-			Effect.provide(Registry.layer(rows)),
-		),
+	Effect.scoped(Effect.flatMap(Effect.flatMap(compile(graph), open), body)).pipe(
+		Effect.provide(Registry.layer(rows)),
 	);
 
 const drain = (wiring: Wiring, at: typeof c): Effect.Effect<ReadonlyArray<unknown>, PortNotWired> =>
@@ -54,58 +52,74 @@ const drain = (wiring: Wiring, at: typeof c): Effect.Effect<ReadonlyArray<unknow
 	);
 
 describe("ports.open", () => {
-	it("delivers a compatible route's messages in emit order", async () => {
-		const received = await wired([producer, consumer()], oneRoute, (wiring) =>
-			Effect.gen(function* () {
-				for (const n of [1, 2, 3, 4, 5]) {
-					yield* wiring.emit(p, n);
-				}
-				return yield* drain(wiring, c);
-			}),
-		);
-		expect(received).toEqual([1, 2, 3, 4, 5]);
-	});
-
-	it("fans one emit out to every target in compiled route order, each keeping its own order", async () => {
-		const [deliveries, atC, atD] = await wired(
-			[producer, consumer(), consumer("consumer-d")],
-			fanOut,
-			(wiring) =>
+	it.effect("delivers a compatible route's messages in emit order", () =>
+		Effect.gen(function* () {
+			const received = yield* wired([producer, consumer()], oneRoute, (wiring) =>
 				Effect.gen(function* () {
-					const first = yield* wiring.emit(p, 1);
-					yield* wiring.emit(p, 2);
-					return [first, yield* drain(wiring, c), yield* drain(wiring, d)] as const;
+					for (const n of [1, 2, 3, 4, 5]) {
+						yield* wiring.emit(p, n);
+					}
+					return yield* drain(wiring, c);
 				}),
-		);
-		expect(deliveries).toEqual([
-			{to: c, accepted: true},
-			{to: d, accepted: true},
-		]);
-		expect(atC).toEqual([1, 2]);
-		expect(atD).toEqual([1, 2]);
-	});
+			);
+			assert.deepStrictEqual(received, [1, 2, 3, 4, 5]);
+		}),
+	);
 
-	it("rejects a payload the target's predicate refuses, naming node, program, port and kind", async () => {
-		const error = await wired([producer, consumer()], oneRoute, (wiring) =>
-			Effect.flip(wiring.emit(p, "not a number")),
-		);
-		expect(error).toBeInstanceOf(PayloadRejected);
-		expect(error).toMatchObject({node: "c", program: "consumer", port: "ticks", kind: "tick/v1"});
-	});
+	it.effect(
+		"fans one emit out to every target in compiled route order, each keeping its own order",
+		() =>
+			Effect.gen(function* () {
+				const [deliveries, atC, atD] = yield* wired(
+					[producer, consumer(), consumer("consumer-d")],
+					fanOut,
+					(wiring) =>
+						Effect.gen(function* () {
+							const first = yield* wiring.emit(p, 1);
+							yield* wiring.emit(p, 2);
+							return [first, yield* drain(wiring, c), yield* drain(wiring, d)] as const;
+						}),
+				);
+				assert.deepStrictEqual(deliveries, [
+					{to: c, accepted: true},
+					{to: d, accepted: true},
+				]);
+				assert.deepStrictEqual(atC, [1, 2]);
+				assert.deepStrictEqual(atD, [1, 2]);
+			}),
+	);
 
-	it("refuses an emit from a port that was never wired, and an inbox for one", async () => {
-		const [emit, inbox] = await wired([producer, consumer()], oneRoute, (wiring) =>
-			Effect.all(
-				[
-					Effect.flip(wiring.emit({node: p.node, port: "beats"}, 1)),
-					Effect.flip(wiring.inbox({node: c.node, port: "beats"})),
-				],
-				{concurrency: 1},
-			),
-		);
-		expect(emit).toBeInstanceOf(PortNotWired);
-		expect(inbox).toBeInstanceOf(PortNotWired);
-	});
+	it.effect(
+		"rejects a payload the target's predicate refuses, naming node, program, port and kind",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* wired([producer, consumer()], oneRoute, (wiring) =>
+					Effect.flip(wiring.emit(p, "not a number")),
+				);
+				assert.instanceOf(error, PayloadRejected);
+				const rejected = error as PayloadRejected;
+				assert.strictEqual(rejected.node, "c");
+				assert.strictEqual(rejected.program, "consumer");
+				assert.strictEqual(rejected.port, "ticks");
+				assert.strictEqual(rejected.kind, "tick/v1");
+			}),
+	);
+
+	it.effect("refuses an emit from a port that was never wired, and an inbox for one", () =>
+		Effect.gen(function* () {
+			const [emit, inbox] = yield* wired([producer, consumer()], oneRoute, (wiring) =>
+				Effect.all(
+					[
+						Effect.flip(wiring.emit({node: p.node, port: "beats"}, 1)),
+						Effect.flip(wiring.inbox({node: c.node, port: "beats"})),
+					],
+					{concurrency: 1},
+				),
+			);
+			assert.instanceOf(emit, PortNotWired);
+			assert.instanceOf(inbox, PortNotWired);
+		}),
+	);
 
 	const overCapacity = (bound: PortBound) =>
 		wired([producer, consumer("consumer", bound)], oneRoute, (wiring) =>
@@ -123,39 +137,47 @@ describe("ports.open", () => {
 			}),
 		);
 
-	it("dropping: an over-capacity write is refused and the queue does not grow", async () => {
-		const result = await overCapacity({capacity: 2, overflow: "dropping"});
-		expect(result).toEqual({accepted: [true, true, false], size: 2, held: [1, 2]});
-	});
+	it.effect("dropping: an over-capacity write is refused and the queue does not grow", () =>
+		Effect.gen(function* () {
+			const result = yield* overCapacity({capacity: 2, overflow: "dropping"});
+			assert.deepStrictEqual(result, {accepted: [true, true, false], size: 2, held: [1, 2]});
+		}),
+	);
 
-	it("sliding: an over-capacity write evicts the oldest and the queue does not grow", async () => {
-		const result = await overCapacity({capacity: 2, overflow: "sliding"});
-		expect(result).toEqual({accepted: [true, true, true], size: 2, held: [2, 3]});
-	});
+	it.effect("sliding: an over-capacity write evicts the oldest and the queue does not grow", () =>
+		Effect.gen(function* () {
+			const result = yield* overCapacity({capacity: 2, overflow: "sliding"});
+			assert.deepStrictEqual(result, {accepted: [true, true, true], size: 2, held: [2, 3]});
+		}),
+	);
 
-	it("suspend: an over-capacity write waits for a take instead of growing the queue", async () => {
-		const result = await wired(
-			[producer, consumer("consumer", {capacity: 2, overflow: "suspend"})],
-			oneRoute,
-			(wiring) =>
-				Effect.gen(function* () {
-					yield* wiring.emit(p, 1);
-					yield* wiring.emit(p, 2);
-					const third = yield* Effect.forkChild(wiring.emit(p, 3));
-					yield* Effect.yieldNow;
-					const inbox = yield* wiring.inbox(c);
-					const sizeWhileBlocked = yield* Queue.size(inbox);
-					const first = yield* Queue.take(inbox);
-					yield* Fiber.join(third);
-					return {sizeWhileBlocked, first, rest: yield* Queue.takeAll(inbox)};
-				}),
-		);
-		expect(result).toEqual({sizeWhileBlocked: 2, first: 1, rest: [2, 3]});
-	});
+	it.effect("suspend: an over-capacity write waits for a take instead of growing the queue", () =>
+		Effect.gen(function* () {
+			const result = yield* wired(
+				[producer, consumer("consumer", {capacity: 2, overflow: "suspend"})],
+				oneRoute,
+				(wiring) =>
+					Effect.gen(function* () {
+						yield* wiring.emit(p, 1);
+						yield* wiring.emit(p, 2);
+						const third = yield* Effect.forkChild(wiring.emit(p, 3));
+						yield* Effect.yieldNow;
+						const inbox = yield* wiring.inbox(c);
+						const sizeWhileBlocked = yield* Queue.size(inbox);
+						const first = yield* Queue.take(inbox);
+						yield* Fiber.join(third);
+						return {sizeWhileBlocked, first, rest: yield* Queue.takeAll(inbox)};
+					}),
+			);
+			assert.deepStrictEqual(result, {sizeWhileBlocked: 2, first: 1, rest: [2, 3]});
+		}),
+	);
 
-	it("shuts every inbox down when the scope closes", async () => {
-		const inbox = await wired([producer, consumer()], oneRoute, (wiring) => wiring.inbox(c));
-		const offered = await Effect.runPromise(Queue.offer(inbox as Queue.Queue<unknown>, 1));
-		expect(offered).toBe(false);
-	});
+	it.effect("shuts every inbox down when the scope closes", () =>
+		Effect.gen(function* () {
+			const inbox = yield* wired([producer, consumer()], oneRoute, (wiring) => wiring.inbox(c));
+			const offered = yield* Queue.offer(inbox as Queue.Queue<unknown>, 1);
+			assert.strictEqual(offered, false);
+		}),
+	);
 });

--- a/apps/tuval/src/registry/Registry.unit.test.ts
+++ b/apps/tuval/src/registry/Registry.unit.test.ts
@@ -1,6 +1,6 @@
 import {type Cmd, defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {DuplicateProgramId, ProgramNotFound} from "./errors.ts";
 import {type AnyProgram, type Program, ProgramId, provenanceOf} from "./program.ts";
 import {Registry} from "./Registry.ts";
@@ -33,46 +33,51 @@ const row = (id: string, version = "1.0.0"): AnyProgram =>
 const withRegistry = <A, E>(
 	rows: ReadonlyArray<AnyProgram>,
 	body: (registry: Registry["Service"]) => Effect.Effect<A, E>,
-) => Effect.runPromise(Effect.flatMap(Registry, body).pipe(Effect.provide(Registry.layer(rows))));
+) => Effect.flatMap(Registry, body).pipe(Effect.provide(Registry.layer(rows)));
 
 describe("Registry", () => {
-	it("registers two distinct programs and resolves both", async () => {
-		const [a, b] = [row("a"), row("b")];
-		const resolved = await withRegistry([a, b], (registry) =>
-			Effect.all(
-				[
-					registry.resolve(ProgramId.make("a")),
-					registry.resolve(ProgramId.make("b")),
-					registry.list,
-				],
-				{concurrency: "unbounded"},
-			),
-		);
-		expect(resolved).toEqual([a, b, [a, b]]);
-	});
+	it.effect("registers two distinct programs and resolves both", () =>
+		Effect.gen(function* () {
+			const [a, b] = [row("a"), row("b")];
+			const resolved = yield* withRegistry([a, b], (registry) =>
+				Effect.all(
+					[
+						registry.resolve(ProgramId.make("a")),
+						registry.resolve(ProgramId.make("b")),
+						registry.list,
+					],
+					{concurrency: "unbounded"},
+				),
+			);
+			assert.deepStrictEqual(resolved, [a, b, [a, b]]);
+		}),
+	);
 
-	it("refuses a duplicate id at registration, naming the id and both rows' provenance", async () => {
-		const [first, second] = [row("a", "1.0.0"), row("a", "2.0.0")];
-		const error = await Effect.runPromise(
-			Effect.flip(Effect.provide(Effect.succeed(undefined), Registry.layer([first, second]))),
-		);
-		expect(error).toBeInstanceOf(DuplicateProgramId);
-		expect(error).toMatchObject({
-			id: "a",
-			first: provenanceOf(first),
-			second: provenanceOf(second),
-		});
-		expect(error.message).toBe(
-			'program id "a" is already registered by @kampus/tuval/a@1.0.0 (sha256:a-1.0.0); refusing @kampus/tuval/a@2.0.0 (sha256:a-2.0.0)',
-		);
-	});
+	it.effect("refuses a duplicate id at registration, naming the id and both rows' provenance", () =>
+		Effect.gen(function* () {
+			const [first, second] = [row("a", "1.0.0"), row("a", "2.0.0")];
+			const error = yield* Effect.flip(
+				Effect.provide(Effect.succeed(undefined), Registry.layer([first, second])),
+			);
+			assert.instanceOf(error, DuplicateProgramId);
+			assert.strictEqual(error.id, "a");
+			assert.deepStrictEqual(error.first, provenanceOf(first));
+			assert.deepStrictEqual(error.second, provenanceOf(second));
+			assert.strictEqual(
+				error.message,
+				'program id "a" is already registered by @kampus/tuval/a@1.0.0 (sha256:a-1.0.0); refusing @kampus/tuval/a@2.0.0 (sha256:a-2.0.0)',
+			);
+		}),
+	);
 
-	it("fails an unknown id with a typed error, never undefined", async () => {
-		const error = await withRegistry([row("a")], (registry) =>
-			Effect.flip(registry.resolve(ProgramId.make("missing"))),
-		);
-		expect(error).toBeInstanceOf(ProgramNotFound);
-		expect(error.id).toBe("missing");
-		expect(error.message).toBe('no program is registered under id "missing"');
-	});
+	it.effect("fails an unknown id with a typed error, never undefined", () =>
+		Effect.gen(function* () {
+			const error = yield* withRegistry([row("a")], (registry) =>
+				Effect.flip(registry.resolve(ProgramId.make("missing"))),
+			);
+			assert.instanceOf(error, ProgramNotFound);
+			assert.strictEqual(error.id, "missing");
+			assert.strictEqual(error.message, 'no program is registered under id "missing"');
+		}),
+	);
 });

--- a/apps/tuval/src/shell/commands/spells.unit.test.ts
+++ b/apps/tuval/src/shell/commands/spells.unit.test.ts
@@ -4,8 +4,8 @@
  * by dispatching exactly the Msg the row would have produced on its own.
  */
 
+import {assert, describe, expect, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
-import {describe, expect, it} from "vitest";
 import {SpellExecutor} from "../../commands/executor.ts";
 import {buildRegistry, SpellRegistry} from "../../commands/registry.ts";
 import {type Client, WindowIndex} from "../../commands/scope.ts";
@@ -38,18 +38,16 @@ const layerFor = (dispatched: Array<ShellMsg>) =>
 	Layer.mergeAll(executorLayer, ShellDispatch.scripted(dispatched));
 
 /** Run one call against the shell's spells alone, collecting whatever it dispatched. */
-const run = async (
-	path: ReadonlyArray<string>,
-	args: unknown,
-): Promise<{readonly reply: SpellReply; readonly dispatched: ReadonlyArray<ShellMsg>}> => {
-	const dispatched: Array<ShellMsg> = [];
-	const reply = await Effect.runPromise(
-		Effect.flatMap(SpellExecutor, (executor) => executor.execute(call(path, args), client)).pipe(
+const run = (path: ReadonlyArray<string>, args: unknown) =>
+	Effect.suspend(() => {
+		const dispatched: Array<ShellMsg> = [];
+		return Effect.flatMap(SpellExecutor, (executor) =>
+			executor.execute(call(path, args), client),
+		).pipe(
 			Effect.provide(layerFor(dispatched)),
-		),
-	);
-	return {reply, dispatched};
-};
+			Effect.map((reply) => ({reply, dispatched: dispatched as ReadonlyArray<ShellMsg>})),
+		);
+	});
 
 const failure = (reply: SpellReply) => {
 	if (reply.ok) throw new Error(`expected a refusal, got ${JSON.stringify(reply)}`);
@@ -66,35 +64,47 @@ describe("the shell's rows as spells", () => {
 		);
 	});
 
-	it("registers, and every one describes without throwing", async () => {
-		const table = await Effect.runPromise(buildRegistry({core: shellSpells, programs: []}));
-		expect(table.rows.map((row) => row.path.join(":"))).toEqual(
-			shellCommands.map((command) => String(commandName(command.path))),
-		);
-		for (const row of table.rows) {
-			expect(`${row.path.join(":")}: ${typeof row.paramsDocument}`).toBe(
-				`${row.path.join(":")}: object`,
+	it.effect("registers, and every one describes without throwing", () =>
+		Effect.gen(function* () {
+			const table = yield* buildRegistry({core: shellSpells, programs: []});
+			assert.deepStrictEqual(
+				table.rows.map((row) => row.path.join(":")),
+				shellCommands.map((command) => String(commandName(command.path))),
 			);
-		}
-	});
+			for (const row of table.rows) {
+				assert.strictEqual(
+					`${row.path.join(":")}: ${typeof row.paramsDocument}`,
+					`${row.path.join(":")}: object`,
+				);
+			}
+		}),
+	);
 });
 
 describe("running a row's spell", () => {
-	it("dispatches exactly the Msg the row builds, and answers with its type", async () => {
-		const {reply, dispatched} = await run(["workspace", "activate"], {workspace: "ws-2"});
-		expect(dispatched).toEqual([{type: "workspace.activate", workspaceId: "ws-2"}]);
-		expect(reply.ok ? reply.result : failure(reply)).toEqual({msg: "workspace.activate"});
-	});
+	it.effect("dispatches exactly the Msg the row builds, and answers with its type", () =>
+		Effect.gen(function* () {
+			const {reply, dispatched} = yield* run(["workspace", "activate"], {workspace: "ws-2"});
+			assert.deepStrictEqual(dispatched, [{type: "workspace.activate", workspaceId: "ws-2"}]);
+			assert.deepStrictEqual(reply.ok ? reply.result : failure(reply), {
+				msg: "workspace.activate",
+			});
+		}),
+	);
 
-	it("refuses arguments the row's own schema refuses, without dispatching", async () => {
-		const {reply, dispatched} = await run(["workspace", "activate"], {workspace: ""});
-		expect(dispatched).toEqual([]);
-		expect(failure(reply).tag).toBe("tuval/commands/BadArgs");
-	});
+	it.effect("refuses arguments the row's own schema refuses, without dispatching", () =>
+		Effect.gen(function* () {
+			const {reply, dispatched} = yield* run(["workspace", "activate"], {workspace: ""});
+			assert.deepStrictEqual(dispatched, []);
+			assert.strictEqual(failure(reply).tag, "tuval/commands/BadArgs");
+		}),
+	);
 
-	it("refuses a path no row carries", async () => {
-		const {reply, dispatched} = await run(["window", "quit"], {});
-		expect(dispatched).toEqual([]);
-		expect(failure(reply).tag).toBe("tuval/commands/UnknownSpell");
-	});
+	it.effect("refuses a path no row carries", () =>
+		Effect.gen(function* () {
+			const {reply, dispatched} = yield* run(["window", "quit"], {});
+			assert.deepStrictEqual(dispatched, []);
+			assert.strictEqual(failure(reply).tag, "tuval/commands/UnknownSpell");
+		}),
+	);
 });

--- a/apps/tuval/src/shell/desk/compose.unit.test.ts
+++ b/apps/tuval/src/shell/desk/compose.unit.test.ts
@@ -4,8 +4,8 @@
  * the bar's left and right the shell's (#7500 rulings 4 and 5).
  */
 
+import {assert, describe, expect, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import {ProcessId} from "../../process/process.ts";
 import type {AnyWindowHost} from "../window/host.ts";
 import {WindowId} from "../window/host.ts";
@@ -43,109 +43,127 @@ const declaredDesk = (host: AnyWindowHost, overrides: Partial<DeskSnapshot> = {}
 	});
 
 describe("inspectorFor", () => {
-	it("resolves the focused window's program renderer and the host it mounts into", async () => {
-		const host = await Effect.runPromise(testHost());
-		const region = inspectorFor(declaredDesk(host));
-		expect(region._tag).toBe("Inspector");
-		const rendered =
-			region._tag === "Inspector" ? region.renderer.render(region.host) : {panel: "unreached"};
-		expect(rendered).toEqual({panel: "inspecting window-1"});
-	});
+	it.effect("resolves the focused window's program renderer and the host it mounts into", () =>
+		Effect.gen(function* () {
+			const host = yield* testHost();
+			const region = inspectorFor(declaredDesk(host));
+			assert.strictEqual(region._tag, "Inspector");
+			const rendered =
+				region._tag === "Inspector" ? region.renderer.render(region.host) : {panel: "unreached"};
+			assert.deepStrictEqual(rendered, {panel: "inspecting window-1"});
+		}),
+	);
 
-	it("answers the typed empty case at every step of the walk that does not resolve", async () => {
-		const host = await Effect.runPromise(testHost());
-		const reasonOf = (snapshot: DeskSnapshot): string => {
-			const region = inspectorFor(snapshot);
-			return region._tag === "NoInspector" ? region.reason : "resolved";
-		};
+	it.effect("answers the typed empty case at every step of the walk that does not resolve", () =>
+		Effect.gen(function* () {
+			const host = yield* testHost();
+			const reasonOf = (snapshot: DeskSnapshot): string => {
+				const region = inspectorFor(snapshot);
+				return region._tag === "NoInspector" ? region.reason : "resolved";
+			};
 
-		expect([
-			reasonOf(deskSnapshot({focused: null})),
-			reasonOf(
-				deskSnapshot({
-					focused: {windowId: WindowId.make("window-1"), processId: null, host: null},
-				}),
-			),
-			reasonOf(deskSnapshot({focused: focusedOn(host), processes: {}})),
-			reasonOf(deskSnapshot({focused: focusedOn(host), programs: {}})),
-			reasonOf(deskSnapshot({focused: focusedOn(host)})),
-			reasonOf(declaredDesk(host, {inspectors: {}})),
-			reasonOf(
-				declaredDesk(host, {
-					inspectors: {"counter/inspector": {...inspector, kind: "isolated-frame"}},
-				}),
-			),
-		]).toEqual([
-			"no-focused-window",
-			"window-unbound",
-			"process-unknown",
-			"program-unknown",
-			"not-declared",
-			"unknown-ref",
-			"kind-mismatch",
-		]);
-	});
+			assert.deepStrictEqual(
+				[
+					reasonOf(deskSnapshot({focused: null})),
+					reasonOf(
+						deskSnapshot({
+							focused: {windowId: WindowId.make("window-1"), processId: null, host: null},
+						}),
+					),
+					reasonOf(deskSnapshot({focused: focusedOn(host), processes: {}})),
+					reasonOf(deskSnapshot({focused: focusedOn(host), programs: {}})),
+					reasonOf(deskSnapshot({focused: focusedOn(host)})),
+					reasonOf(declaredDesk(host, {inspectors: {}})),
+					reasonOf(
+						declaredDesk(host, {
+							inspectors: {"counter/inspector": {...inspector, kind: "isolated-frame"}},
+						}),
+					),
+				],
+				[
+					"no-focused-window",
+					"window-unbound",
+					"process-unknown",
+					"program-unknown",
+					"not-declared",
+					"unknown-ref",
+					"kind-mismatch",
+				],
+			);
+		}),
+	);
 
-	it("does not throw on a program that declares no inspector", async () => {
-		const host = await Effect.runPromise(testHost());
-		const region = inspectorFor(deskSnapshot({focused: focusedOn(host)}));
-		expect(region).toEqual({_tag: "NoInspector", reason: "not-declared"});
-	});
+	it.effect("does not throw on a program that declares no inspector", () =>
+		Effect.gen(function* () {
+			const host = yield* testHost();
+			const region = inspectorFor(deskSnapshot({focused: focusedOn(host)}));
+			assert.deepStrictEqual(region, {_tag: "NoInspector", reason: "not-declared"});
+		}),
+	);
 });
 
 describe("statusFor", () => {
-	it("puts the program's segments in the middle and composes the shell's own two sides", async () => {
-		const host = await Effect.runPromise(testHost());
-		const bar = statusFor(declaredDesk(host));
-		expect(bar.left).toEqual([{id: "workspace", text: "workspace-0"}]);
-		expect(bar.middle).toEqual([
-			{id: "mode", text: "normal"},
-			{id: "window", text: "window-1"},
-		]);
-		expect(bar.right).toEqual([
-			{id: "processes", text: "1 process"},
-			{id: "revision", text: "rev 7"},
-		]);
-		expect(bar.middleEmpty).toBeNull();
-	});
+	it.effect(
+		"puts the program's segments in the middle and composes the shell's own two sides",
+		() =>
+			Effect.gen(function* () {
+				const host = yield* testHost();
+				const bar = statusFor(declaredDesk(host));
+				assert.deepStrictEqual(bar.left, [{id: "workspace", text: "workspace-0"}]);
+				assert.deepStrictEqual(bar.middle, [
+					{id: "mode", text: "normal"},
+					{id: "window", text: "window-1"},
+				]);
+				assert.deepStrictEqual(bar.right, [
+					{id: "processes", text: "1 process"},
+					{id: "revision", text: "rev 7"},
+				]);
+				assert.strictEqual(bar.middleEmpty, null);
+			}),
+	);
 
-	it("a program cannot write the left or the right, whatever segments it returns", async () => {
-		const host = await Effect.runPromise(testHost());
-		const greedy = statusRenderer("host-native", () => [
-			{id: "workspace", text: "hijacked"},
-			{id: "processes", text: "hijacked"},
-			{id: "revision", text: "hijacked"},
-		]);
-		const shellOnly = statusFor(deskSnapshot({focused: focusedOn(host)}));
-		const withProgram = statusFor(declaredDesk(host, {statuses: {"counter/status": greedy}}));
+	it.effect("a program cannot write the left or the right, whatever segments it returns", () =>
+		Effect.gen(function* () {
+			const host = yield* testHost();
+			const greedy = statusRenderer("host-native", () => [
+				{id: "workspace", text: "hijacked"},
+				{id: "processes", text: "hijacked"},
+				{id: "revision", text: "hijacked"},
+			]);
+			const shellOnly = statusFor(deskSnapshot({focused: focusedOn(host)}));
+			const withProgram = statusFor(declaredDesk(host, {statuses: {"counter/status": greedy}}));
 
-		expect(withProgram.left).toEqual(shellOnly.left);
-		expect(withProgram.right).toEqual(shellOnly.right);
-		expect(withProgram.middle.map((segment) => segment.text)).toEqual([
-			"hijacked",
-			"hijacked",
-			"hijacked",
-		]);
-	});
+			assert.deepStrictEqual(withProgram.left, shellOnly.left);
+			assert.deepStrictEqual(withProgram.right, shellOnly.right);
+			assert.deepStrictEqual(
+				withProgram.middle.map((segment) => segment.text),
+				["hijacked", "hijacked", "hijacked"],
+			);
+		}),
+	);
 
-	it("leaves the middle empty and says why when no program fills it", async () => {
-		const host = await Effect.runPromise(testHost());
-		const bar = statusFor(deskSnapshot({focused: focusedOn(host)}));
-		expect(bar.middle).toEqual([]);
-		expect(bar.middleEmpty).toBe("not-declared");
-		expect(bar.left).toEqual([{id: "workspace", text: "workspace-0"}]);
-		expect(statusFor(deskSnapshot({focused: null})).middleEmpty).toBe("no-focused-window");
-	});
+	it.effect("leaves the middle empty and says why when no program fills it", () =>
+		Effect.gen(function* () {
+			const host = yield* testHost();
+			const bar = statusFor(deskSnapshot({focused: focusedOn(host)}));
+			assert.deepStrictEqual(bar.middle, []);
+			assert.strictEqual(bar.middleEmpty, "not-declared");
+			assert.deepStrictEqual(bar.left, [{id: "workspace", text: "workspace-0"}]);
+			assert.strictEqual(statusFor(deskSnapshot({focused: null})).middleEmpty, "no-focused-window");
+		}),
+	);
 
-	it("reads the program's own selection state out of the host's view slot", async () => {
-		const host = await Effect.runPromise(testHost());
-		await Effect.runPromise(host.setView({selected: "node-4"}));
-		const selecting = statusRenderer("host-native", (mounted: AnyWindowHost) => [
-			{id: "selected", text: String((mounted.view() as Selection).selected)},
-		]);
-		const bar = statusFor(declaredDesk(host, {statuses: {"counter/status": selecting}}));
-		expect(bar.middle).toEqual([{id: "selected", text: "node-4"}]);
-	});
+	it.effect("reads the program's own selection state out of the host's view slot", () =>
+		Effect.gen(function* () {
+			const host = yield* testHost();
+			yield* host.setView({selected: "node-4"});
+			const selecting = statusRenderer("host-native", (mounted: AnyWindowHost) => [
+				{id: "selected", text: String((mounted.view() as Selection).selected)},
+			]);
+			const bar = statusFor(declaredDesk(host, {statuses: {"counter/status": selecting}}));
+			assert.deepStrictEqual(bar.middle, [{id: "selected", text: "node-4"}]);
+		}),
+	);
 
 	it("counts a desk with no process as unbound rather than resolving a stale program", () => {
 		const bar = statusFor(

--- a/apps/tuval/src/shell/picker/entries.unit.test.ts
+++ b/apps/tuval/src/shell/picker/entries.unit.test.ts
@@ -1,5 +1,5 @@
+import {assert, describe, expect, it} from "@effect/vitest";
 import {Effect, Option} from "effect";
-import {describe, expect, it} from "vitest";
 import {ProcessId} from "../../process/process.ts";
 import {ProgramId} from "../../registry/program.ts";
 import type {TableRow} from "../../table/row.ts";
@@ -54,9 +54,9 @@ describe("picker entries", () => {
 		]);
 	});
 
-	it("reads both lists off the live registry and process table", async () => {
-		const answer = await Effect.runPromise(
-			Effect.scoped(
+	it.effect("reads both lists off the live registry and process table", () =>
+		Effect.gen(function* () {
+			const answer = yield* Effect.scoped(
 				Effect.gen(function* () {
 					const harness = yield* pickerHarness([
 						programRow("counter", {label: "Counter"}),
@@ -66,10 +66,16 @@ describe("picker entries", () => {
 					yield* harness.seed("p-9", "indexer");
 					return yield* readEntries.pipe(Effect.provide(harness.layer));
 				}),
-			),
-		);
-		expect(answer.programs.map((entry) => entry.programId)).toEqual([ProgramId.make("counter")]);
-		expect(answer.processes.map((entry) => entry.processId)).toEqual(["p-1"]);
-		expect(flatten(answer)).toHaveLength(2);
-	});
+			);
+			assert.deepStrictEqual(
+				answer.programs.map((entry) => entry.programId),
+				[ProgramId.make("counter")],
+			);
+			assert.deepStrictEqual(
+				answer.processes.map((entry) => entry.processId),
+				["p-1"],
+			);
+			assert.lengthOf(flatten(answer), 2);
+		}),
+	);
 });

--- a/apps/tuval/src/shell/picker/mount.unit.test.ts
+++ b/apps/tuval/src/shell/picker/mount.unit.test.ts
@@ -5,8 +5,8 @@
  * model's door: two windows over the process it binds share one state and keep two `view` slots.
  */
 
+import {assert, describe, expect, it} from "@effect/vitest";
 import {Effect, Stream} from "effect";
-import {describe, expect, it} from "vitest";
 import {ProcessId} from "../../process/process.ts";
 import {testProcess} from "../window/fixtures.ts";
 import {readEntries} from "./entries.ts";
@@ -19,9 +19,9 @@ import {mountPicker} from "./view.ts";
 const window = windowId("window-1");
 
 describe("a mount reads the world fresh", () => {
-	it("a second mount after a registry change lists the new rows and none of the old", async () => {
-		const listed = await Effect.runPromise(
-			Effect.scoped(
+	it.effect("a second mount after a registry change lists the new rows and none of the old", () =>
+		Effect.gen(function* () {
+			const listed = yield* Effect.scoped(
 				Effect.gen(function* () {
 					const before = yield* pickerHarness([programRow("counter", {label: "Counter"})]);
 					const first = yield* readEntries.pipe(Effect.provide(before.layer));
@@ -33,17 +33,26 @@ describe("a mount reads the world fresh", () => {
 					const second = yield* readEntries.pipe(Effect.provide(after.layer));
 					return [first, second] as const;
 				}),
-			),
-		);
-		const [first, second] = listed;
-		expect(first.programs.map((entry) => entry.label)).toEqual(["Counter"]);
-		expect(second.programs.map((entry) => entry.label)).toEqual(["Pi", "Claude"]);
+			);
+			const [first, second] = listed;
+			assert.deepStrictEqual(
+				first.programs.map((entry) => entry.label),
+				["Counter"],
+			);
+			assert.deepStrictEqual(
+				second.programs.map((entry) => entry.label),
+				["Pi", "Claude"],
+			);
 
-		// The frame is the mount's whole output, so the stale row cannot survive anywhere else.
-		const frame = pickerFrame(window, second, mountPicker());
-		expect(frame.groups[0]?.options.map((option) => option.detail)).toEqual(["pi", "claude"]);
-		expect(frame.activeDescendant).toBe("picker-window-1-option-0");
-	});
+			// The frame is the mount's whole output, so the stale row cannot survive anywhere else.
+			const frame = pickerFrame(window, second, mountPicker());
+			assert.deepStrictEqual(
+				frame.groups[0]?.options.map((option) => option.detail),
+				["pi", "claude"],
+			);
+			assert.strictEqual(frame.activeDescendant, "picker-window-1-option-0");
+		}),
+	);
 
 	it("a fresh mount starts at the top with no refusal, whatever the last one ended on", () => {
 		expect(mountPicker()).toEqual({cursor: 0, refusal: null});
@@ -52,9 +61,9 @@ describe("a mount reads the world fresh", () => {
 });
 
 describe("attaching gives one process a second window", () => {
-	it("both windows read one state and each keeps its own view slot", async () => {
-		const answer = await Effect.runPromise(
-			Effect.scoped(
+	it.effect("both windows read one state and each keeps its own view slot", () =>
+		Effect.gen(function* () {
+			const answer = yield* Effect.scoped(
 				Effect.gen(function* () {
 					const harness = yield* pickerHarness([programRow("counter", {label: "Counter"})]);
 					const id = yield* harness.seed("p-1", "counter");
@@ -78,15 +87,18 @@ describe("attaching gives one process a second window", () => {
 					);
 					return {bind, seen, views: [one.view(), two.view()]};
 				}),
-			),
-		);
+			);
 
-		expect(answer.bind).toEqual([{type: "window.bind", windowId: "window-2", processId: "p-1"}]);
-		expect(
-			answer.seen.map((head) =>
-				head._tag === "Some" && head.value._tag === "Live" ? head.value.state : null,
-			),
-		).toEqual([{count: 7}, {count: 7}]);
-		expect(answer.views).toEqual([{scroll: 0}, {scroll: 42}]);
-	});
+			assert.deepStrictEqual(answer.bind, [
+				{type: "window.bind", windowId: "window-2", processId: "p-1"},
+			]);
+			assert.deepStrictEqual(
+				answer.seen.map((head) =>
+					head._tag === "Some" && head.value._tag === "Live" ? head.value.state : null,
+				),
+				[{count: 7}, {count: 7}],
+			);
+			assert.deepStrictEqual(answer.views, [{scroll: 0}, {scroll: 42}]);
+		}),
+	);
 });

--- a/apps/tuval/src/shell/picker/open.unit.test.ts
+++ b/apps/tuval/src/shell/picker/open.unit.test.ts
@@ -4,8 +4,8 @@
  * "the same handler" is the claim this slice exists to keep and nothing in the types enforces it.
  */
 
+import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {describe, expect, it} from "vitest";
 import type {AnyProgram} from "../../registry/program.ts";
 import {readCommandLine} from "../commands/line.ts";
 import type {ShellMsg} from "../core/machine.ts";
@@ -40,112 +40,128 @@ const run = (
 		readonly seed?: ReadonlyArray<readonly [string, string, string | undefined]>;
 		readonly spawnFails?: string;
 	},
-): Promise<Run> =>
-	Effect.runPromise(
-		Effect.scoped(
-			Effect.gen(function* () {
-				const harness = yield* pickerHarness(
-					rows,
-					options?.spawnFails === undefined ? undefined : {spawnFails: options.spawnFails},
-				);
-				for (const [id, program, parent] of options?.seed ?? []) {
-					yield* harness.seed(id, program, parent);
-				}
-				const msgs = yield* runPickerIntent(intent, {shellProcessId}).pipe(
-					Effect.provide(harness.layer),
-				);
-				return {
-					msgs,
-					spawns: harness
-						.spawns()
-						.map((call) => ({programId: call.programId, parent: call.parent})),
-				};
-			}),
-		),
+): Effect.Effect<Run> =>
+	Effect.scoped(
+		Effect.gen(function* () {
+			const harness = yield* pickerHarness(
+				rows,
+				options?.spawnFails === undefined ? undefined : {spawnFails: options.spawnFails},
+			);
+			for (const [id, program, parent] of options?.seed ?? []) {
+				yield* harness.seed(id, program, parent);
+			}
+			const msgs = yield* runPickerIntent(intent, {shellProcessId}).pipe(
+				Effect.provide(harness.layer),
+			);
+			return {
+				msgs,
+				spawns: harness.spawns().map((call) => ({programId: call.programId, parent: call.parent})),
+			};
+		}),
 	);
 
 describe("choosing a program", () => {
-	it("spawns exactly one process under the shell process and binds it to the window", async () => {
-		const answer = await run(openProgram(window, programId("counter")));
-		expect(answer.spawns).toEqual([{programId: "counter", parent: shellProcessId}]);
-		expect(answer.msgs).toEqual([{type: "window.bind", windowId: window, processId: "process-1"}]);
-	});
+	it.effect("spawns exactly one process under the shell process and binds it to the window", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(openProgram(window, programId("counter")));
+			assert.deepStrictEqual(answer.spawns, [{programId: "counter", parent: shellProcessId}]);
+			assert.deepStrictEqual(answer.msgs, [
+				{type: "window.bind", windowId: window, processId: "process-1"},
+			]);
+		}),
+	);
 
-	it("refuses an unknown program in the window, and spawns nothing", async () => {
-		const answer = await run(openProgram(window, programId("ghost")));
-		expect(answer.spawns).toEqual([]);
-		expect(answer.msgs).toEqual([
-			{
-				type: "window.setView",
-				windowId: window,
-				view: {cursor: 0, refusal: {_tag: "UnknownProgram", programId: "ghost"}},
-			},
-		]);
-	});
+	it.effect("refuses an unknown program in the window, and spawns nothing", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(openProgram(window, programId("ghost")));
+			assert.deepStrictEqual(answer.spawns, []);
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "UnknownProgram", programId: "ghost"}},
+				},
+			]);
+		}),
+	);
 
-	it("refuses a headless program, which runs but can never fill a window", async () => {
-		const answer = await run(openProgram(window, programId("indexer")));
-		expect(answer.spawns).toEqual([]);
-		expect(answer.msgs).toEqual([
-			{
-				type: "window.setView",
-				windowId: window,
-				view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "indexer"}},
-			},
-		]);
-	});
+	it.effect("refuses a headless program, which runs but can never fill a window", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(openProgram(window, programId("indexer")));
+			assert.deepStrictEqual(answer.spawns, []);
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "indexer"}},
+				},
+			]);
+		}),
+	);
 
-	it("turns a failed spawn into a refusal rather than a failure the caller must catch", async () => {
-		const answer = await run(openProgram(window, programId("counter")), {spawnFails: "counter"});
-		expect(answer.msgs).toEqual([
-			{
-				type: "window.setView",
-				windowId: window,
-				view: {
-					cursor: 0,
-					refusal: {
-						_tag: "SpawnFailed",
-						programId: "counter",
-						reason: 'no live process has id "counter"',
+	it.effect("turns a failed spawn into a refusal rather than a failure the caller must catch", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(openProgram(window, programId("counter")), {
+				spawnFails: "counter",
+			});
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {
+						cursor: 0,
+						refusal: {
+							_tag: "SpawnFailed",
+							programId: "counter",
+							reason: 'no live process has id "counter"',
+						},
 					},
 				},
-			},
-		]);
-	});
+			]);
+		}),
+	);
 });
 
 describe("attaching to a running process", () => {
-	it("binds the window to a live process and spawns nothing", async () => {
-		const answer = await run(attachProcess(window, processId("p-1")), {
-			seed: [["p-1", "counter", undefined]],
-		});
-		expect(answer.spawns).toEqual([]);
-		expect(answer.msgs).toEqual([{type: "window.bind", windowId: window, processId: "p-1"}]);
-	});
+	it.effect("binds the window to a live process and spawns nothing", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(attachProcess(window, processId("p-1")), {
+				seed: [["p-1", "counter", undefined]],
+			});
+			assert.deepStrictEqual(answer.spawns, []);
+			assert.deepStrictEqual(answer.msgs, [
+				{type: "window.bind", windowId: window, processId: "p-1"},
+			]);
+		}),
+	);
 
-	it("refuses a process id that no longer resolves, as a value and never a throw", async () => {
-		const answer = await run(attachProcess(window, processId("p-gone")));
-		expect(answer.msgs).toEqual([
-			{
-				type: "window.setView",
-				windowId: window,
-				view: {cursor: 0, refusal: {_tag: "ProcessGone", processId: "p-gone"}},
-			},
-		]);
-	});
+	it.effect("refuses a process id that no longer resolves, as a value and never a throw", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(attachProcess(window, processId("p-gone")));
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "ProcessGone", processId: "p-gone"}},
+				},
+			]);
+		}),
+	);
 
-	it("refuses a live process whose program has no renderer to mount", async () => {
-		const answer = await run(attachProcess(window, processId("p-9")), {
-			seed: [["p-9", "indexer", undefined]],
-		});
-		expect(answer.msgs).toEqual([
-			{
-				type: "window.setView",
-				windowId: window,
-				view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "indexer"}},
-			},
-		]);
-	});
+	it.effect("refuses a live process whose program has no renderer to mount", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(attachProcess(window, processId("p-9")), {
+				seed: [["p-9", "indexer", undefined]],
+			});
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "indexer"}},
+				},
+			]);
+		}),
+	);
 });
 
 describe("the picker row and the command line are one handler", () => {
@@ -167,43 +183,52 @@ describe("the picker row and the command line are one handler", () => {
 			: null;
 	};
 
-	it("`open counter` and choosing the counter row both produce one process", async () => {
-		const chosen = pickerKey(window, entries, mountPicker(), "<enter>");
-		const typed = typedIntent("open counter");
-		expect(chosen._tag).toBe("Chose");
-		expect(typed).not.toBeNull();
-		if (chosen._tag !== "Chose" || typed === null) return;
+	it.effect("`open counter` and choosing the counter row both produce one process", () =>
+		Effect.gen(function* () {
+			const chosen = pickerKey(window, entries, mountPicker(), "<enter>");
+			const typed = typedIntent("open counter");
+			assert.strictEqual(chosen._tag, "Chose");
+			assert.isNotNull(typed);
+			if (chosen._tag !== "Chose" || typed === null) return;
 
-		expect(chosen.intent).toEqual(typed);
-		const [fromRow, fromLine] = await Promise.all([run(chosen.intent), run(typed)]);
-		expect(fromRow.spawns).toEqual([{programId: "counter", parent: shellProcessId}]);
-		expect(fromLine.spawns).toEqual(fromRow.spawns);
-		expect(fromLine.msgs).toEqual(fromRow.msgs);
-	});
+			assert.deepStrictEqual(chosen.intent, typed);
+			const [fromRow, fromLine] = yield* Effect.all([run(chosen.intent), run(typed)], {
+				concurrency: 2,
+			});
+			assert.deepStrictEqual(fromRow.spawns, [{programId: "counter", parent: shellProcessId}]);
+			assert.deepStrictEqual(fromLine.spawns, fromRow.spawns);
+			assert.deepStrictEqual(fromLine.msgs, fromRow.msgs);
+		}),
+	);
 
-	it("`attach <id>` and choosing the process row both bind without spawning", async () => {
-		const withProcess: PickerEntries = {
-			...noEntries,
-			processes: [
-				{
-					_tag: "Process",
-					processId: processId("p-1"),
-					programId: programId("counter"),
-					label: "Counter",
-					parentId: null,
-				},
-			],
-		};
-		const chosen = pickerKey(window, withProcess, mountPicker(), "<enter>");
-		const typed = typedIntent("attach p-1");
-		expect(chosen._tag).toBe("Chose");
-		expect(typed).not.toBeNull();
-		if (chosen._tag !== "Chose" || typed === null) return;
+	it.effect("`attach <id>` and choosing the process row both bind without spawning", () =>
+		Effect.gen(function* () {
+			const withProcess: PickerEntries = {
+				...noEntries,
+				processes: [
+					{
+						_tag: "Process",
+						processId: processId("p-1"),
+						programId: programId("counter"),
+						label: "Counter",
+						parentId: null,
+					},
+				],
+			};
+			const chosen = pickerKey(window, withProcess, mountPicker(), "<enter>");
+			const typed = typedIntent("attach p-1");
+			assert.strictEqual(chosen._tag, "Chose");
+			assert.isNotNull(typed);
+			if (chosen._tag !== "Chose" || typed === null) return;
 
-		expect(chosen.intent).toEqual(typed);
-		const seed = [["p-1", "counter", undefined]] as const;
-		const [fromRow, fromLine] = await Promise.all([run(chosen.intent, {seed}), run(typed, {seed})]);
-		expect(fromRow.spawns).toEqual([]);
-		expect(fromLine.msgs).toEqual(fromRow.msgs);
-	});
+			assert.deepStrictEqual(chosen.intent, typed);
+			const seed = [["p-1", "counter", undefined]] as const;
+			const [fromRow, fromLine] = yield* Effect.all(
+				[run(chosen.intent, {seed}), run(typed, {seed})],
+				{concurrency: 2},
+			);
+			assert.deepStrictEqual(fromRow.spawns, []);
+			assert.deepStrictEqual(fromLine.msgs, fromRow.msgs);
+		}),
+	);
 });


### PR DESCRIPTION
Fixes #7766

Converts every Effect-running test body under `apps/tuval/src` to `@effect/vitest`'s
`it.effect`, which `.patterns/effect-testing.md` has ruled for all along.

A strict grep for `Effect.runPromise(` / `Effect.runSync(` under `apps/tuval/src` now
returns nothing. Three files still match a loose substring grep, and all three are
`Effect.runPromiseWith` — the production calls in `host/demlik-bridges.ts` and
`claude/agent/ClaudeAiAgent.ts`, plus the `ToolRuntime` test double in
`claude/tools/server.unit.test.ts`, which this PR rebuilt on `runPromiseWith` over the
caller's own services so it mirrors how `ClaudeAiAgent` builds the real one.

Module-level helpers that used to run their Effect (`bootDirect`, `compileWith`,
`wired`, `withRegistry`, `build`, `refusal`, `lines`, `ask`, `execute`, `run`, `server`,
`withSet`) now return it; callers `yield*`. Inside a converted body every `expect`
became an `assert.*` — a `toMatchObject` expands to one assertion per field the original
named, so no claim got weaker. A test body that runs no Effect stays a plain `it` with
`expect`, which is what the pattern doc says to do.

The one change that is more than mechanics is the swap-concurrency proof in
`commands/registry.unit.test.ts`. It used to rest `seen.at(0) === oldPaths` and
`seen.at(-1) === newPaths` on how the default scheduler happened to interleave two
readers and a `swap`. Now one read runs before the fork and one after `Effect.all`
joins every fiber, so both claims hold by sequencing. The 200-round racing window is
unchanged and still non-degenerate — a probe run observed the old table twice and the
new one 398 times inside it, so the "never sees a mix" assertion is still doing work.

`apps/tuval`'s `unit` project: 126 files, 1040 tests, same counts as before the change.
`pnpm typecheck` exits 0 for the package, including `effect-tsgo --strict`.

## Deviations

- **Declined guidance** — **Said:** `.patterns/effect-testing.md` line 171 says plain-vitest
  tests convert to `it.effect` "opportunistically — when a change next touches the file, not
  as a churn pass." **Did:** converted all 21 files in one sweep. **Why:** #7766 is a triaged
  ticket whose acceptance criteria ask for exactly that sweep, and two idioms side by side in
  one app is the thing it was filed to end. **Disposition:** stated here; the doc line still
  governs `apps/web`, where no sweep is ordered, so it was left as written.
- **Out-of-scope change** — **Said:** #7766 names twelve files. **Did:** converted 21.
  **Why:** the tree moved since filing — `epic/7627` landed on main and nine more files grew
  the same idiom. Acceptance criterion 1 is an absolute grep over `apps/tuval/src`, so the
  twelve alone would not have satisfied it. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** criterion 1 expects the loose grep to return only
  `host/demlik-bridges.ts`. **Did:** it returns `claude/agent/ClaudeAiAgent.ts` as well.
  **Why:** that file is production source using `Effect.runPromiseWith`, the same correct call
  the criterion carved out for `demlik-bridges.ts`; it postdates the ticket. The strict grep
  the criterion is a proxy for is empty. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** no behaviour changes.
  **Did:** four inline snapshots in `commands/bindings/errors.unit.test.ts` and one in
  `commands/core/help.unit.test.ts` became literal `assert.deepStrictEqual` /
  `assert.strictEqual` comparisons. **Why:** `assert` has no snapshot matcher, and criterion 3
  requires `assert.*` inside every converted body. The snapshots were already inline literals,
  so the expected values are byte-identical. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** test mechanics only. **Did:** the two `Effect.tryPromise`
  lifts added by this PR (`claude/tools/server.unit.test.ts`, `page/attached-desk.unit.test.tsx`)
  use a `TestIo` tagged error rather than returning the raw `unknown` cause. **Why:** the raw
  form reds `effect-tsgo --strict` with `unknownInEffectCatch`, which fails `pnpm typecheck`;
  `TestIo` is the existing house idiom from `demo/e2e.unit.test.ts`. **Disposition:** fixed here.
- **Known defect left unfixed** — **Said:** nothing about assertion strength.
  **Did:** left `"dies rather than replies…"` in `commands/executor.unit.test.ts` asserting
  `Exit.isFailure` rather than specifically a die. **Why:** that is exactly the strength the
  original `.rejects.toThrow` had, and #7765 owns assertion strength — #7766 says not to fold it.
  **Disposition:** left for #7765.
