### PR TITLE
feat: tuval host: bring the in-tree Effect host to ADR 0346 (subFailure policy, failed/ended marks, definition name)

### DIFF
--- a/.patterns/tuval-program-row-effects.md
+++ b/.patterns/tuval-program-row-effects.md
@@ -24,6 +24,17 @@ Both records' `E` and `R` are inferred onto the row (`Program<S, M, C, U, Ctx, E
 program's failures and its service needs fall out of the code rather than being hand-declared. Never
 widen `R` by hand to make a spawn typecheck — the spawn is what has to supply it.
 
+**A Sub handler's failure ends the process, so treat returning as the only clean exit.** ADR
+[0346](../.decisions/0346-sub-failure-policy-actor-identity.md) makes a failed Sub the machine's Msg
+or the process's death, never a host retry: the host reports the `Cause` under `"sub-fiber"`, marks
+that Sub's id `failed`, and — with no `subFailure` projection to address it — closes the process's
+Scope with the failure as its Exit. Marked ids are never re-armed, `ended` ones included, so a Sub
+that returns normally does not restart while the state keeps desiring it. Restart is data: emit the
+Sub under a new id (an attempt counter in the id, or in the dep-keyed `deps` slice) and reconcile
+arms it fresh, which is what makes the retry replay. Catch inside the handler anything you mean to
+survive; let out only what should end the process. Declaring `subFailure` on a program row's `core`
+is not reachable yet — [#7933](https://github.com/kamp-us/phoenix/issues/7933) carries it.
+
 **A Sub that needs a service belongs in `subs`, not on the machine.** Demlik 0.12's own `subscribe`
 map is Promise-shaped and synchronous (`host/demlik-bridges.ts` is the whole translation), so a cell
 there has nowhere to ask for a service. `Processes` prefers a row's `subs` entry over the bridged

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -180,9 +180,17 @@ they keep going under the rows they were spawned from.
 
 `src/host/` runs a Demlik core machine as an Effect actor: `make(definition)` is a scoped Effect
 yielding an `ActorHandle`, and `layer(key, definition)` provides that handle as a service. A
-definition is `defineActor({machine, interpret, subscribe, store?})` — the machine is Demlik's pure
-core (`init`, `update`, dep-keyed `subs`, `identity`, `subscriptions`), the handlers are
-Effect-valued, and their error and service requirements fall out onto the handle.
+definition is `defineActor({name, machine, interpret, subscribe, store?})` — the machine is Demlik's
+pure core (`init`, `update`, dep-keyed `subs`, `identity`, `subscriptions`), the handlers are
+Effect-valued, and their error and service requirements fall out onto the handle. The `name` is the
+definition's nominal identity, unique per process; the instance id is the process's, minted at spawn.
+
+A Sub that fails is the machine's Msg or the process's death, never a host retry (ADR 0346). The
+machine declares `subFailure(sub, failure)` beside `identity` and gets the failure as plain data —
+`id`, `type`, `reason`, `message`, nothing Effect-shaped. Returning a Msg dispatches it as an
+ordinary follow-up; returning `undefined`, or declaring nothing, closes the process's Scope with
+the failure as its Exit. Either way the Sub's id is marked `failed` and reconcile never re-arms it:
+a restart is a new id from the reducer, so it replays.
 
 It stands in for Demlik's own `tea-effect` until kamp-us/demlik#36 ships. The places it still
 speaks Demlik 0.12's Promise and disposer shapes live in `src/host/demlik-bridges.ts`, which is the

--- a/apps/tuval/src/host/actor.ts
+++ b/apps/tuval/src/host/actor.ts
@@ -21,7 +21,18 @@ import {
 	type Supervision,
 	structuralHash,
 } from "@demlik/tea";
-import {Cause, type Context, Effect, Exit, Latch, Layer, Result, Scope, Semaphore} from "effect";
+import {
+	Cause,
+	type Context,
+	Effect,
+	Exit,
+	type Fiber,
+	Latch,
+	Layer,
+	Result,
+	Scope,
+	Semaphore,
+} from "effect";
 import type {
 	ActorDefinition,
 	ErrorOf,
@@ -29,6 +40,7 @@ import type {
 	InterpretHandlers,
 	OnError,
 	ServicesOf,
+	SubFailure,
 	SubscribeHandlers,
 } from "./definition.ts";
 import {subDisposerBridge} from "./demlik-bridges.ts";
@@ -80,6 +92,35 @@ type Reduced<S, C> =
 
 type Probe = {readonly kind: "inactive"} | {readonly kind: "active"; readonly id: string};
 
+/**
+ * A Sub the host has armed. `mark` is its lifetime: `"running"` until its fiber exits, then
+ * `"failed"` or `"ended"` — and reconcile re-arms neither, because the same id means the same
+ * lifetime (ADR 0346). The Scope outlives the mark: it is the Sub's registration, and its close is
+ * where a Demlik-bridged `Dispose` runs, so only the state ceasing to desire the Sub releases it.
+ */
+type ArmedSub = {
+	readonly scope: Scope.Closeable;
+	readonly mark: "running" | "failed" | "ended";
+};
+
+/**
+ * One armed Sub as the failure policy sees it. `declared` is the `U` the machine's `subFailure`
+ * projection takes, and a dep-keyed Sub has none — Demlik keys those on a state slice, not on a
+ * declared Sub value — so a dep-keyed failure can never be addressed and always ends the process.
+ */
+type SubSite<U> = {
+	readonly id: string;
+	readonly type: string;
+	readonly declared: U | undefined;
+	/** Records the mark, or answers `false` when this Sub's entry has already moved on. */
+	readonly settle: (mark: "failed" | "ended") => boolean;
+};
+
+const squashMessage = (cause: Cause.Cause<unknown>): string => {
+	const squashed = Cause.squash(cause);
+	return squashed instanceof Error ? squashed.message : String(squashed);
+};
+
 export const make = Effect.fn("Tuval.host.make")(function* <
 	S,
 	M extends {type: string},
@@ -110,15 +151,22 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 	let stopping = false;
 	let pending = 0;
 	let inFlightCmds = 0;
-	const manualSubs = new Map<string, Scope.Closeable>();
-	const keyedSubs = new Map<number, {readonly id: string; readonly scope: Scope.Closeable}>();
+	const manualSubs = new Map<string, ArmedSub>();
+	const keyedSubs = new Map<number, ArmedSub & {readonly id: string}>();
 
 	const report = (error: unknown, phase: HostErrorPhase) =>
 		onError(error, {phase}).pipe(
 			Effect.catchCause((cause) => Effect.logError(Cause.squash(cause))),
 		);
+	/**
+	 * A cause carrying nothing but interrupts is a stop the host asked for, so `onError` never sees
+	 * it: squashing one yields `All fibers interrupted without error`, which read as a real failure
+	 * at ERROR on every clean teardown (#7779).
+	 */
 	const reportCause = (phase: HostErrorPhase) => (cause: Cause.Cause<unknown>) =>
-		report(Cause.squash(cause), phase);
+		Cause.hasInterruptsOnly(cause)
+			? Effect.logDebug(Cause.pretty(cause))
+			: report(Cause.squash(cause), phase);
 
 	const enter = (): void => {
 		pending++;
@@ -152,6 +200,100 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 			),
 		);
 	};
+
+	/** `subFailure`'s answer, or `undefined` when it is undeclared, has no `U` to read, or throws. */
+	const addressFailure = (site: SubSite<U>, cause: Cause.Cause<unknown>) =>
+		Effect.suspend((): Effect.Effect<M | undefined> => {
+			const project = machine.subFailure;
+			const declared = site.declared;
+			if (project === undefined || declared === undefined) return Effect.succeed(undefined);
+			const failure: SubFailure = {
+				id: site.id,
+				type: site.type,
+				reason: Cause.hasFails(cause) ? "failure" : "defect",
+				message: squashMessage(cause),
+			};
+			return Effect.try({
+				try: () => project(declared, failure) ?? undefined,
+				catch: (thrown) => new UserCodeThrew({cause: thrown}),
+			}).pipe(
+				Effect.catch((error: UserCodeThrew) =>
+					report(error, "sub-fiber").pipe(Effect.as(undefined)),
+				),
+			);
+		});
+
+	/**
+	 * ADR 0346 §Decision, mechanics 1 to 5 in their stated order: report the `Cause` under
+	 * `"sub-fiber"`, mark the id `failed`, hand the machine its `subFailure` Msg through the same
+	 * unawaited follow-up path a Sub's own `dispatch` uses, and close the process's Scope with the
+	 * failure as its Exit when nothing addressed it.
+	 */
+	const onSubFailure = (site: SubSite<U>, cause: Cause.Cause<unknown>) =>
+		Effect.gen(function* () {
+			yield* report(Cause.squash(cause), "sub-fiber");
+			if (!site.settle("failed")) return;
+			const msg = yield* addressFailure(site, cause);
+			if (msg !== undefined) {
+				dispatchUnawaited(msg);
+				return;
+			}
+			yield* Scope.close(scope, Exit.failCause(cause));
+		});
+
+	/**
+	 * Fork one Sub's work into its own Scope. `startImmediately` runs the handler's synchronous head
+	 * before this returns (`forkIn`, `effect/Effect` rc.112), which is what lets the dep-keyed caller
+	 * read an open failure straight off the fiber.
+	 */
+	const armSub = (
+		work: Effect.Effect<void, E, R | Scope.Scope>,
+		child: Scope.Closeable,
+	): Effect.Effect<Fiber.Fiber<void, E>> =>
+		Effect.forkIn(
+			work.pipe(Effect.provideService(Scope.Scope, child), Effect.provideContext(services)),
+			child,
+			{startImmediately: true},
+		);
+
+	/**
+	 * The Sub's exit, read from a detached fiber: the unaddressed branch closes the process Scope,
+	 * and a fiber living under that Scope would end up waiting on its own interruption.
+	 */
+	const observeSub = (fiber: Fiber.Fiber<void, E>, site: SubSite<U>): void => {
+		fiber.addObserver((exit) => {
+			if (Exit.isSuccess(exit)) {
+				site.settle("ended");
+				return;
+			}
+			if (Cause.hasInterruptsOnly(exit.cause)) return;
+			Effect.runFork(onSubFailure(site, exit.cause));
+		});
+	};
+
+	const manualSite = (sub: U, child: Scope.Closeable): SubSite<U> => ({
+		id: sub.id,
+		type: sub.type,
+		declared: sub,
+		settle: (mark) => {
+			const armed = manualSubs.get(sub.id);
+			if (armed?.scope !== child) return false;
+			manualSubs.set(sub.id, {scope: child, mark});
+			return true;
+		},
+	});
+
+	const keyedSite = (index: number, id: string, child: Scope.Closeable): SubSite<U> => ({
+		id,
+		type: "dep-keyed",
+		declared: undefined,
+		settle: (mark) => {
+			const armed = keyedSubs.get(index);
+			if (armed?.scope !== child) return false;
+			keyedSubs.set(index, {id, scope: child, mark});
+			return true;
+		},
+	});
 
 	const runInterpret = Effect.fn("Tuval.host.interpret")(function* (cmds: readonly C[]) {
 		for (const cmd of cmds) {
@@ -203,16 +345,18 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 			if (keyedSubs.get(index)?.id === probe.id) continue;
 			yield* disposeKeyed(index);
 			const child = yield* Scope.fork(subsScope);
-			const opened = yield* subDisposerBridge(entry, state, dispatchUnawaited, ctx).pipe(
-				Effect.provideService(Scope.Scope, child),
-				Effect.exit,
-			);
-			if (Exit.isFailure(opened)) {
+			keyedSubs.set(index, {id: probe.id, scope: child, mark: "running"});
+			const fiber = yield* armSub(subDisposerBridge(entry, state, dispatchUnawaited, ctx), child);
+			// The source has already run, so an Exit here is the open throwing — which Demlik
+			// propagates out of reconcile with nothing registered (`reconcileDepSubs`, 0.12).
+			const opened = fiber.pollUnsafe();
+			if (opened !== undefined && Exit.isFailure(opened)) {
 				firstError ??= Cause.squash(opened.cause);
+				keyedSubs.delete(index);
 				yield* closeSub(child);
 				continue;
 			}
-			keyedSubs.set(index, {id: probe.id, scope: child});
+			observeSub(fiber, keyedSite(index, probe.id, child));
 		}
 
 		if (machine.subscriptions) {
@@ -225,31 +369,25 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 				}
 				desiredTypeById.set(sub.id, sub.type);
 			}
-			for (const [id, running] of manualSubs) {
+			for (const [id, armed] of manualSubs) {
 				if (desiredTypeById.has(id)) continue;
 				manualSubs.delete(id);
-				yield* closeSub(running);
+				yield* closeSub(armed.scope);
 			}
 			for (const sub of desired) {
+				// A `failed` or `ended` id keeps its entry, so this is also the re-arm refusal: the
+				// same id means the same lifetime, and a restart is a new id from the reducer.
 				if (manualSubs.has(sub.id)) continue;
 				const handler = definition.subscribe[sub.type as U["type"]];
 				if (!handler) continue;
 				const child = yield* Scope.fork(subsScope);
+				manualSubs.set(sub.id, {scope: child, mark: "running"});
 				const work = handler(
 					sub as Extract<U, {type: U["type"]}>,
 					ctx,
 					dispatchUnawaited,
 				) as Effect.Effect<void, E, R | Scope.Scope>;
-				yield* Effect.forkIn(
-					work.pipe(
-						Effect.provideService(Scope.Scope, child),
-						Effect.provideContext(services),
-						Effect.catchCause(reportCause("sub-fiber")),
-					),
-					child,
-					{startImmediately: true},
-				);
-				manualSubs.set(sub.id, child);
+				observeSub(yield* armSub(work, child), manualSite(sub, child));
 			}
 		}
 		if (firstError !== null) return yield* Effect.die(firstError);

--- a/apps/tuval/src/host/actor.unit.test.ts
+++ b/apps/tuval/src/host/actor.unit.test.ts
@@ -23,6 +23,7 @@ describe("host actor", () => {
 				};
 				const actor = yield* make(
 					defineActor({
+						name: "test/serialized",
 						machine,
 						interpret: {
 							slow: (cmd) =>
@@ -57,6 +58,7 @@ describe("host actor", () => {
 					state.type === "on" ? [{id: subId("ticker"), type: "ticker"}] : [],
 			};
 			const definition = defineActor({
+				name: "test/sub-scope",
 				machine,
 				interpret: {},
 				subscribe: {
@@ -97,6 +99,7 @@ describe("host actor", () => {
 			const live = layer(
 				Counter,
 				defineActor({
+					name: "test/layered",
 					machine: counterMachine(log),
 					store: recordingStore(saves),
 					interpret: {notify: () => Effect.succeed<Msg>({type: "acked"})},
@@ -124,6 +127,7 @@ describe("host actor", () => {
 				Effect.gen(function* () {
 					const actor = yield* make(
 						defineActor({
+							name: "test/snapshots",
 							machine: counterMachine([]),
 							store: recordingStore(saves),
 							interpret: {notify: () => Effect.succeed<Msg>({type: "acked"})},
@@ -148,6 +152,7 @@ describe("host actor", () => {
 			"test/Clock",
 		) {}
 		const definition = defineActor({
+			name: "test/typed",
 			machine: counterMachine([]),
 			interpret: {
 				notify: (cmd) =>
@@ -176,6 +181,7 @@ describe("host actor", () => {
 				const log: string[] = [];
 				const actor = yield* make(
 					defineActor({
+						name: "test/commits",
 						machine: counterMachine([]),
 						interpret: {
 							notify: (cmd) =>

--- a/apps/tuval/src/host/definition.ts
+++ b/apps/tuval/src/host/definition.ts
@@ -23,6 +23,20 @@ import type {
 	UpdateForm,
 } from "@demlik/tea";
 import type {Effect, Scope} from "effect";
+import {ActorNameCollisionError} from "./errors.ts";
+
+/**
+ * A Sub fiber's failure as the reducer sees it: plain data, so the machine stays pure. ADR 0346
+ * makes the absence of a `Cause`, an `Error` instance, a Fiber or a Scope here a binding
+ * constraint — the full `Cause` goes to `onError` under `"sub-fiber"` and stops there.
+ */
+export interface SubFailure {
+	readonly id: string;
+	readonly type: string;
+	/** `"failure"` is the handler's error channel; `"defect"` is a throw or a die. */
+	readonly reason: "failure" | "defect";
+	readonly message: string;
+}
 
 /**
  * A Demlik `Machine` minus its Promise-shaped `interpret` and `subscribe` — the pure core plus
@@ -35,6 +49,11 @@ export interface CoreMachine<S, M extends {type: string}, C extends Cmd, U exten
 	readonly subs?: ReadonlyArray<DepKeyedSub<S, M, Ctx>>;
 	readonly identity?: Identity<S, M>;
 	readonly subscriptions?: (state: S) => readonly U[];
+	/**
+	 * What a failed Sub becomes (ADR 0346). Returning a Msg hands the failure to `update`;
+	 * returning `undefined`, or declaring nothing, ends the process instead.
+	 */
+	readonly subFailure?: (sub: U, failure: SubFailure) => M | undefined;
 	readonly __form?: UpdateForm;
 }
 
@@ -95,6 +114,12 @@ export type ActorDefinition<
 	I extends InterpretHandlers<M, C, Ctx>,
 	B extends SubscribeHandlers<M, U, Ctx>,
 > = CtxArg<Ctx> & {
+	/**
+	 * The definition's nominal identity, unique per process and never derived from state (ADR
+	 * 0346). Demlik's `tea-effect` will mint a service key from it; in Tuval it is the registry
+	 * row's `ProgramId`. The instance id is the host's and lives in the process table.
+	 */
+	readonly name: string;
 	readonly machine: CoreMachine<S, M, C, U, Ctx>;
 	readonly interpret: I;
 	readonly subscribe: B;
@@ -121,6 +146,11 @@ export type DefinitionServices<
 	D extends {readonly interpret: unknown; readonly subscribe: unknown},
 > = ServicesOf<D["interpret"]> | ServicesOf<D["subscribe"]>;
 
+const definedNames = new Set<string>();
+
+/** A bundler re-evaluating this module is not a second definition; Demlik's `definePort` reads the same escape. */
+const underHmr = (): boolean => (import.meta as {hot?: unknown}).hot != null;
+
 export const defineActor = <
 	S,
 	M extends {type: string},
@@ -131,4 +161,10 @@ export const defineActor = <
 	const B extends SubscribeHandlers<M, U, Ctx>,
 >(
 	definition: ActorDefinition<S, M, C, U, Ctx, I, B>,
-): ActorDefinition<S, M, C, U, Ctx, I, B> => definition;
+): ActorDefinition<S, M, C, U, Ctx, I, B> => {
+	if (!underHmr() && definedNames.has(definition.name)) {
+		throw new ActorNameCollisionError({actorName: definition.name});
+	}
+	definedNames.add(definition.name);
+	return definition;
+};

--- a/apps/tuval/src/host/demlik-bridges.ts
+++ b/apps/tuval/src/host/demlik-bridges.ts
@@ -51,6 +51,12 @@ const noDispatch = (): void => {};
  * close — as a scoped acquisition. Opening runs the source under `Effect.acquireRelease`
  * (`LLMS.md` "Managing resources and Scopes"); the Scope's close awaits the `Dispose`, Promise or
  * not, so Demlik's disposer and the Effect finalizer are one shutdown step.
+ *
+ * It then holds instead of returning, so the effect's lifetime is the Sub's lifetime and its error
+ * channel is the Sub's post-open failure channel — the one the host routes through the ADR 0346
+ * policy. A dep-keyed `source` returning a `Dispose` has nothing to put on that channel yet; a
+ * manual `subscribe` handler does return, and its return is the `ended` mark, which is why
+ * `subscribeDisposerBridge` below does not hold.
  */
 export const subDisposerBridge = <S, M, Ctx>(
 	sub: DepKeyedSub<S, M, Ctx>,
@@ -67,7 +73,7 @@ export const subDisposerBridge = <S, M, Ctx>(
 				},
 				catch: (cause) => new SubDisposeError({cause}),
 			}).pipe(Effect.orDie),
-	).pipe(Effect.asVoid);
+	).pipe(Effect.andThen(Effect.never));
 
 /**
  * The same disposer bridge for the manual-Sub map: Demlik 0.12's `subscribe[type]` cells, each

--- a/apps/tuval/src/host/errors.ts
+++ b/apps/tuval/src/host/errors.ts
@@ -22,6 +22,20 @@ export class UserCodeThrew extends Schema.TaggedError<UserCodeThrew>()("tuval/ho
 	cause: Schema.Defect(),
 }) {}
 
+/**
+ * `defineActor` was handed a name this process already defined (ADR 0346). Thrown, not failed:
+ * a definition is built at module scope, outside any Effect, the way Demlik's `definePort` throws
+ * `PortNameCollisionError`.
+ */
+export class ActorNameCollisionError extends Schema.TaggedError<ActorNameCollisionError>()(
+	"tuval/host/ActorNameCollisionError",
+	{actorName: Schema.String},
+) {
+	override get message(): string {
+		return `defineActor: an actor named "${this.actorName}" was already defined. Each definition needs a unique name; two modules needing one actor import it from the module that defines it.`;
+	}
+}
+
 /** A Demlik `Dispose` threw or rejected; surfaces from the Sub scope's close for the host to route. */
 export class SubDisposeError extends Schema.TaggedError<SubDisposeError>()(
 	"tuval/host/SubDisposeError",

--- a/apps/tuval/src/host/index.ts
+++ b/apps/tuval/src/host/index.ts
@@ -10,6 +10,7 @@ export {
 	type HostErrorPhase,
 	type InterpretHandlers,
 	type OnError,
+	type SubFailure,
 	type SubscribeHandlers,
 } from "./definition.ts";
 export {
@@ -18,4 +19,9 @@ export {
 	subscribeDisposerBridge,
 	toDemlikMachine,
 } from "./demlik-bridges.ts";
-export {ActorStoppedError, StoreError, SubDisposeError} from "./errors.ts";
+export {
+	ActorNameCollisionError,
+	ActorStoppedError,
+	StoreError,
+	SubDisposeError,
+} from "./errors.ts";

--- a/apps/tuval/src/host/parity.unit.test.ts
+++ b/apps/tuval/src/host/parity.unit.test.ts
@@ -21,8 +21,9 @@ const script: readonly Msg[] = [
 	{type: "halt"},
 ];
 
-const definitionFor = (log: string[], store: Store<State>) =>
+const definitionFor = (name: string, log: string[], store: Store<State>) =>
 	defineActor({
+		name,
 		machine: counterMachine(log),
 		store,
 		interpret: {
@@ -39,7 +40,7 @@ const throughHost = Effect.scoped(
 	Effect.gen(function* () {
 		const log: string[] = [];
 		const saves: State[] = [];
-		const actor = yield* make(definitionFor(log, recordingStore(saves)));
+		const actor = yield* make(definitionFor("parity/host", log, recordingStore(saves)));
 		const states: State[] = [];
 		for (const msg of script) {
 			yield* actor.dispatch(msg);
@@ -61,8 +62,10 @@ const throughDemlik = Effect.tryPromise({
 		const log: string[] = [];
 		const saves: State[] = [];
 		const store = recordingStore(saves);
-		const runtime = await run(toDemlikMachine(definitionFor(log, store), Context.empty()), {store})
-			.ready;
+		const runtime = await run(
+			toDemlikMachine(definitionFor("parity/demlik", log, store), Context.empty()),
+			{store},
+		).ready;
 		const states: State[] = [];
 		for (const msg of script) {
 			await runtime.dispatch(msg);

--- a/apps/tuval/src/host/sub-failure.unit.test.ts
+++ b/apps/tuval/src/host/sub-failure.unit.test.ts
@@ -1,0 +1,236 @@
+/** The ADR 0346 Sub-failure policy and the definition name, branch by branch. */
+
+import {type DepKeyedSub, type NoCtx, type SubId, subId} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit, Schema, Scope} from "effect";
+import {make} from "./actor.ts";
+import {type CoreMachine, defineActor, type HostErrorPhase, type OnError} from "./definition.ts";
+import {subDisposerBridge} from "./demlik-bridges.ts";
+import {counterMachine} from "./fixtures.ts";
+
+class Boom extends Schema.TaggedError<Boom>()("test/Boom", {}) {}
+
+type State = {readonly armed: boolean; readonly seen: readonly string[]};
+type Msg = {readonly type: "arm"} | {readonly type: "noted"; readonly note: string};
+type Ticker = {readonly id: SubId; readonly type: "ticker"};
+
+const TICKER: Ticker = {id: subId("ticker"), type: "ticker"};
+
+const machineWith = (
+	subFailure?: CoreMachine<State, Msg, never, Ticker, NoCtx>["subFailure"],
+): CoreMachine<State, Msg, never, Ticker, NoCtx> => ({
+	init: () => [{armed: false, seen: []}, []],
+	update: {
+		arm: (state: State) => [{...state, armed: true}, []],
+		noted: (state: State, msg: Extract<Msg, {type: "noted"}>) => [
+			{...state, seen: [...state.seen, msg.note]},
+			[],
+		],
+	},
+	subscriptions: (state) => (state.armed ? [TICKER] : []),
+	...(subFailure === undefined ? {} : {subFailure}),
+});
+
+type Reported = {readonly error: unknown; readonly phase: HostErrorPhase};
+
+const recordingOnError =
+	(into: Reported[]): OnError =>
+	(error, context) =>
+		Effect.sync(() => void into.push({error, phase: context.phase}));
+
+/** The policy runs on a detached fiber, so a dispatch's own quiescence does not cover it. */
+const settle = Effect.sleep("20 millis");
+
+describe("Sub-failure policy", () => {
+	it.live("reports the Cause under sub-fiber, then hands subFailure's Msg to the reducer", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const reported: Reported[] = [];
+				let opened = 0;
+				const actor = yield* make(
+					defineActor({
+						name: "sub-failure/addressed",
+						machine: machineWith((sub, failure) => ({
+							type: "noted",
+							note: `${sub.type}:${failure.reason}:${failure.id}`,
+						})),
+						interpret: {},
+						subscribe: {
+							ticker: () =>
+								Effect.suspend(() => {
+									opened++;
+									return new Boom({});
+								}),
+						},
+						onError: recordingOnError(reported),
+					}),
+				);
+				yield* actor.dispatch({type: "arm"});
+				yield* settle;
+				yield* actor.idle;
+
+				assert.deepStrictEqual(
+					reported.map((entry) => entry.phase),
+					["sub-fiber"],
+				);
+				assert.instanceOf(reported[0]?.error, Boom);
+				assert.deepStrictEqual(actor.getState().seen, ["ticker:failure:ticker"]);
+				// Still desired, and still not re-armed: the same id is the same lifetime.
+				yield* actor.dispatch({type: "arm"});
+				yield* settle;
+				assert.strictEqual(opened, 1);
+			}),
+		),
+	);
+
+	it.live("closes the process Scope with the failure as its Exit when nothing addresses it", () =>
+		Effect.gen(function* () {
+			const reported: Reported[] = [];
+			const exits: Array<Exit.Exit<unknown, unknown>> = [];
+			const scope = yield* Scope.make();
+			yield* Scope.addFinalizerExit(scope, (exit) => Effect.sync(() => void exits.push(exit)));
+			const actor = yield* make(
+				defineActor({
+					name: "sub-failure/unaddressed",
+					machine: machineWith(),
+					interpret: {},
+					subscribe: {ticker: () => new Boom({})},
+					onError: recordingOnError(reported),
+				}),
+			).pipe(Effect.provideService(Scope.Scope, scope));
+
+			yield* actor.dispatch({type: "arm"});
+			yield* settle;
+
+			assert.lengthOf(exits, 1);
+			const failed = exits.filter(Exit.isFailure);
+			assert.lengthOf(failed, 1);
+			for (const exit of failed) assert.instanceOf(Cause.squash(exit.cause), Boom);
+			const refused = yield* actor.dispatch({type: "arm"}).pipe(Effect.flip);
+			assert.strictEqual(refused._tag, "tuval/host/ActorStoppedError");
+		}),
+	);
+
+	it.live("reports a throwing subFailure as UserCodeThrew and takes the unaddressed branch", () =>
+		Effect.gen(function* () {
+			const reported: Reported[] = [];
+			const exits: Array<Exit.Exit<unknown, unknown>> = [];
+			const scope = yield* Scope.make();
+			yield* Scope.addFinalizerExit(scope, (exit) => Effect.sync(() => void exits.push(exit)));
+			yield* make(
+				defineActor({
+					name: "sub-failure/throwing-policy",
+					machine: machineWith(() => {
+						// biome-ignore lint/plugin: the throw is the subject — this is the user-code-threw branch.
+						throw new Error("the policy itself broke");
+					}),
+					interpret: {},
+					subscribe: {ticker: () => new Boom({})},
+					onError: recordingOnError(reported),
+				}),
+			).pipe(
+				Effect.provideService(Scope.Scope, scope),
+				Effect.flatMap((actor) => actor.dispatch({type: "arm"})),
+			);
+			yield* settle;
+
+			assert.deepStrictEqual(
+				reported.map((entry) => entry.phase),
+				["sub-fiber", "sub-fiber"],
+			);
+			assert.instanceOf(reported[0]?.error, Boom);
+			assert.strictEqual(
+				(reported[1]?.error as {readonly _tag?: string})._tag,
+				"tuval/host/UserCodeThrew",
+			);
+			assert.lengthOf(exits, 1);
+		}),
+	);
+
+	it.live("marks a Sub that completes normally ended, sends no Msg, and never re-arms it", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const reported: Reported[] = [];
+				let opened = 0;
+				const actor = yield* make(
+					defineActor({
+						name: "sub-failure/ended",
+						machine: machineWith(() => ({type: "noted", note: "should not happen"})),
+						interpret: {},
+						subscribe: {
+							ticker: () => Effect.sync(() => void opened++),
+						},
+						onError: recordingOnError(reported),
+					}),
+				);
+				yield* actor.dispatch({type: "arm"});
+				yield* settle;
+				yield* actor.dispatch({type: "arm"});
+				yield* settle;
+				yield* actor.idle;
+
+				assert.strictEqual(opened, 1);
+				assert.deepStrictEqual(actor.getState().seen, []);
+				assert.deepStrictEqual(reported, []);
+			}),
+		),
+	);
+
+	it.live("says nothing on a clean teardown: an interruption-only cause is not a failure", () =>
+		Effect.gen(function* () {
+			const reported: Reported[] = [];
+			yield* Effect.scoped(
+				Effect.gen(function* () {
+					const actor = yield* make(
+						defineActor({
+							name: "sub-failure/quiet-teardown",
+							machine: machineWith(),
+							interpret: {},
+							subscribe: {ticker: () => Effect.never},
+							onError: recordingOnError(reported),
+						}),
+					);
+					yield* actor.dispatch({type: "arm"});
+				}),
+			);
+			yield* settle;
+			assert.deepStrictEqual(reported, []);
+		}),
+	);
+
+	it.effect("holds a dep-keyed Sub's fiber open, so its error channel is live after the open", () =>
+		Effect.gen(function* () {
+			const log: string[] = [];
+			const sub: DepKeyedSub<null, never, NoCtx> = {
+				deps: () => ({}),
+				source: () => {
+					log.push("open");
+					return () => void log.push("dispose");
+				},
+			};
+			const scope = yield* Scope.make();
+			const fiber = yield* Effect.forkIn(
+				subDisposerBridge(sub, null, () => {}, {}).pipe(Effect.provideService(Scope.Scope, scope)),
+				scope,
+				{startImmediately: true},
+			);
+
+			assert.deepStrictEqual(log, ["open"]);
+			assert.isUndefined(fiber.pollUnsafe());
+			yield* Scope.close(scope, Exit.void);
+			assert.deepStrictEqual(log, ["open", "dispose"]);
+		}),
+	);
+
+	it("refuses a definition name this process has already seen", () => {
+		const build = () =>
+			defineActor({
+				name: "sub-failure/duplicate",
+				machine: counterMachine([]),
+				interpret: {notify: () => Effect.void},
+				subscribe: {},
+			});
+		build();
+		assert.throws(build, /already defined/);
+	});
+});

--- a/apps/tuval/src/process/Processes.ts
+++ b/apps/tuval/src/process/Processes.ts
@@ -157,6 +157,10 @@ const toDefinition = (
 			);
 	}
 	return {
+		// The definition's nominal identity is the registry row's `ProgramId` (ADR 0346). Built as a
+		// literal, not through `defineActor`: one program is one definition and many processes, and
+		// `defineActor`'s per-process name registry would read the second spawn as a collision.
+		name: program.id,
 		machine: core,
 		store,
 		ctx: {},


### PR DESCRIPTION
Brings `apps/tuval/src/host/` to ADR 0346, which designed the Sub-failure policy and the definition
name and left the host unchanged. Until now a manual Sub that failed was logged under `"sub-fiber"`
and its id stayed registered — dead and still armed — which is the silent failure Demlik's invariant
6 forbids.

**The policy.** `CoreMachine` gains `subFailure?: (sub, failure) => M | undefined` and the host runs
ADR 0346 §Decision's mechanics 1 to 5 in order: report the full `Cause` to `onError` under
`"sub-fiber"` first, mark the Sub's id `failed`, dispatch `subFailure`'s Msg through the same
unawaited follow-up path a Sub's own `dispatch` uses, and — when `subFailure` is undeclared, returns
`undefined`, or throws (reported as `UserCodeThrew`) — close the process's Scope with the failure as
its Exit. `SubFailure` is plain data: `id`, `type`, `reason`, a squashed `message`, and nothing
Effect-shaped. A Sub that returns normally is marked `ended`. Neither mark is ever re-armed under the
same id; a restart is a new id from the reducer, so it replays. No `Effect.retry` appears anywhere
under `src/host/`.

**The name.** `defineActor` takes a required `name: string` and refuses one it has already seen in
the process, throwing `ActorNameCollisionError` — the shape of Demlik's `definePort`, HMR escape
included, read at the 0.12 pin. `Processes.toDefinition` builds its row literal with
`name: program.id` rather than through `defineActor`, because one program is one definition and many
processes.

**The quiet teardown** (#7779, folded into this issue's amendment): `reportCause` now sends an
interruption-only cause to `logDebug`, so a clean stop no longer prints
`Error: All fibers interrupted without error` with a stack at ERROR. `logError` is left for a cause
that carries a real failure.

**Grounding**, all read at the `catalog:tuval` pin `effect@4.0.0-rc.112` in this tree:
`Scope.close`'s signature takes a plain `Scope` and its `scopeCloseUnsafe` is idempotent on an
already-closed one, which is what lets the host close the process Scope it was handed and what makes
the outer `Effect.scoped` a no-op afterwards. `Fiber.addObserver` fires immediately when the fiber
has already exited, so an observer attached after a `startImmediately` fork never misses the exit.
`forkIn` evaluates synchronously under `startImmediately`, so `pollUnsafe()` distinguishes a
dep-keyed source that threw at open from one that opened and is holding.

Worth a reviewer's first look: `observeSub` runs the policy on a **detached** fiber. The unaddressed
branch closes the process Scope, which interrupts every fiber under it, so a fiber living there would
end up waiting on its own interruption.

Tests are `apps/tuval/src/host/sub-failure.unit.test.ts`, one per branch. `parity.unit.test.ts` still
passes unchanged in substance (its two definitions just needed distinct names).

Fixes #7619

## Deviations

- **Scope narrowing** — **Said:** criterion 8 asks the dep-keyed Sub path in `demlik-bridges.ts` to
  route a post-open failure through the same policy. **Did:** wired the channel — the bridge now
  holds after acquiring instead of completing, so the dep-keyed Sub gets a fiber whose lifetime is
  the Sub's lifetime and whose exit `observeSub` routes through the same policy — but shipped no test
  driving an actual dep-keyed post-open failure. **Why:** Demlik 0.12's dep-keyed `source` returns a
  synchronous `Dispose` (`DepKeyedSub.source` at the pin), so after the open its only failure is a
  `Dispose` that rejects, and ADR 0346's own ground puts that on `"sub-cleanup"` — nothing in the
  0.12 shape can produce a post-open failure to test. **Disposition:** the test asserts the property
  that makes the channel real (the fiber is still live after the open, and the `Dispose` still runs
  exactly once at Scope close); the first producer arrives with kamp-us/demlik#36.
- **Known defect left unfixed** — **Said:** the criteria cover the host. **Did:** left
  `Program.core` in `apps/tuval/src/registry/program.ts` typed as Demlik's `Machine`, so no program
  row can declare `subFailure` and every program's Sub failure takes the unaddressed branch.
  **Why:** that slice's docblock forbids importing from the host slice, so closing it needs a
  decision about where `SubFailure` lives — not a line this PR can just write. **Disposition:** filed
  as #7933 and named in `.patterns/tuval-program-row-effects.md`, so a program author reading the
  pattern is not sent at a type that does not exist.
- **Out-of-scope change** — **Said:** #7619 names `apps/tuval/src/host/`. **Did:** also touched
  `apps/tuval/src/process/Processes.ts`, `apps/tuval/README.md` and
  `.patterns/tuval-program-row-effects.md`. **Why:** `name` is required, so the one definition built
  outside `host/` had to supply it, and the README's `defineActor` signature plus the pattern doc's
  account of a Sub's lifetime both became false with this change. **Disposition:** stated here; all
  three are follow-on edits this change forced, none of them new behaviour.
