### PR TITLE
fix: A freshly spawned Tuval agent process never opens its session, so a picker-opened chat sits idle forever

### DIFF
--- a/.patterns/tuval-program-row-effects.md
+++ b/.patterns/tuval-program-row-effects.md
@@ -91,6 +91,39 @@ there is nothing to fail into. A payload the port's predicate admits but this en
 refusal as data, never a throw: a throw here happens inside the launcher's pump, where nobody is
 waiting for it.
 
+## Starting fresh: the boot Cmd a fresh `init` emits
+
+A process whose whole point is a live connection has to open one, and the place that decides to is
+the machine's **fresh** `init` arm. Demlik's guard is scoped to rehydration — it reds only on a
+non-null `loaded` whose `init` returned Cmds (`replay` in `@demlik/tea` 0.12) — so a fresh `init`
+emitting a Cmd is inside the contract, and it is the one place in the tree that knows the process is
+new. `aiAgentSessionMachine` is the worked example: `loaded === null` answers with
+`[{type: "aiAgent.boot", cwd}]`, and a restored one still answers `noCmds` and leaves the reconnect
+to the resume rule below.
+
+**Put it there rather than on a spawn path.** A hook on one spawner is a hook the next spawner
+forgets, and that is not hypothetical: `pi-session` shipped with no production `start` caller at all,
+so the picker opened a window over a session that never began and refused every prompt
+([#7925](https://github.com/kamp-us/phoenix/issues/7925)). The core covers the picker, the launcher
+and a test kernel at once, and there is no second place to keep in step. A window is not the home
+either — two windows over one process would race into a refusal, and a window is a view rather than
+the owner of a session's lifetime.
+
+**The Cmd's handler answers with a Msg and does no work.** `runInterpret` awaits an init Cmd's
+handler before `make` returns (`host/actor.ts`), and a spawn runs inside the *spawning* process's
+serial step — so a boot handler that opened the connection itself would freeze the shell for as long
+as the backend took, or for the row's whole start deadline when the open fails. Answering with the
+Msg instead costs nothing at spawn and puts the real work on the new process's own tail: the boot
+Cmd is a trampoline from `init`, which cannot dispatch a Msg, into the cell that already owns the
+transition and its "one open at a time" guard.
+
+**A follow-up Msg can be interrupted before its fiber starts, so count it on the Exit.** The host
+forks each unawaited follow-up into the process Scope and settles its pending count on the fiber's
+Exit rather than inside its body: a stop taken in the same tick as the dispatch — ordinary once a
+session opens itself at spawn — interrupts a fiber that never ran, which produces an Exit and runs no
+`ensuring`, and an in-body decrement leaves the actor's stop waiting on a count that never reaches
+zero.
+
 ## Coming back from a checkpoint: a resume Msg, and a Cmd that republishes
 
 Durability is the kernel's ([`durability/Checkpoints.ts`](../apps/tuval/src/durability/Checkpoints.ts)),
@@ -109,7 +142,11 @@ work is still running.
 **Whatever the restore has to *do* is a Msg someone dispatches after the spawn** — that is the route
 the guard's own error message names. Keep it as a pure function of the restored state — Tuval's is
 `resumeMessages(state)` — so a spawner asks the row what to send instead of encoding the row's
-lifecycle at the call site, and a state with nothing to resume answers with an empty list.
+lifecycle at the call site, and a state with nothing to resume answers with an empty list. It is
+also where the fresh arm's counterpart goes: a checkpoint written before the session ever opened has
+no id to reconnect to and none a fresh open could duplicate, so it answers with the same open a
+fresh spawn takes — the boot Cmd above belongs to `init`'s fresh arm alone, and a rehydrating one
+may emit none.
 
 **That function belongs on the row, under `resume`, or nothing sends it.** A rule only a test calls
 is not a restore: for two months every caller of `resumeMessages` was a proof, so a real restart

--- a/.patterns/tuval-program-row-effects.md
+++ b/.patterns/tuval-program-row-effects.md
@@ -124,6 +124,16 @@ session opens itself at spawn — interrupts a fiber that never ran, which produ
 `ensuring`, and an in-body decrement leaves the actor's stop waiting on a count that never reaches
 zero.
 
+**The core owns the phases that mean "an open is in flight"; a layer's event may not enter one.**
+Every layer narrates its own open on the same event stream it publishes everything else on —
+`PiAiAgent.start` and `ClaudeAiAgent.start` both emit `starting` and then `ready` — but that stream
+is a Sub the core opens only once `started` has committed, which is *after* the open answered. So
+the `starting` a Sub reads first is always a report about an open that is already finished, and
+folding it walks a ready session backwards into a phase that refuses the first prompt the founder
+types. `foldEvent` therefore drops a `phase` event carrying `starting` or `reconnecting`: those two
+belong to the `start` and `reconnect` cells, and `started` or `failed` are the only ways out of
+them. Every other phase the layer reports is news and folds normally.
+
 ## Coming back from a checkpoint: a resume Msg, and a Cmd that republishes
 
 Durability is the kernel's ([`durability/Checkpoints.ts`](../apps/tuval/src/durability/Checkpoints.ts)),

--- a/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
@@ -159,9 +159,15 @@ const agentRow = (script: AgentScript) =>
 		config: {cwd: "/work"},
 	});
 
-const eventually = (check: () => boolean) =>
+/**
+ * A wait that names what did not happen. Falling through on a spent budget leaves the body running
+ * against a state that never arrived, and the failure then surfaces as a `TypeError` several lines
+ * later instead of as the condition (#7925).
+ */
+const eventually = (what: string, check: () => boolean) =>
 	Effect.gen(function* () {
 		for (let i = 0; i < 400 && !check(); i++) yield* Effect.sleep("5 millis");
+		assert.isTrue(check(), `timed out after 2s waiting for ${what}`);
 	});
 
 const onGraph = <A, E>(
@@ -207,7 +213,7 @@ const latest = (seen: ReadonlyArray<Arrival>, port: string): unknown =>
 
 /** Spawning the row is what opens the session (#7925), so a caller only waits for it. */
 const started = (agent: {readonly state: () => unknown}) =>
-	eventually(() => {
+	eventually("the spawned session to reach ready", () => {
 		const state = agent.state();
 		return isAiAgentSessionState(state) && state.phase === "ready";
 	});
@@ -218,7 +224,7 @@ describe("the AI agent interface over a compiled graph", () => {
 			Effect.gen(function* () {
 				yield* started(agent);
 				yield* window.say(aiAgentPortNames.prompt, {text: "hello", key: "k1"});
-				yield* eventually(() => {
+				yield* eventually("both turn items on the transcript port", () => {
 					const payload = latest(seen(), aiAgentPortNames.transcript) as
 						| TranscriptPayload
 						| undefined;
@@ -243,7 +249,10 @@ describe("the AI agent interface over a compiled graph", () => {
 					before: null,
 					limit: 3,
 				});
-				yield* eventually(() => latest(seen(), aiAgentPortNames.pageReply) !== undefined);
+				yield* eventually(
+					"a page on the pageReply port",
+					() => latest(seen(), aiAgentPortNames.pageReply) !== undefined,
+				);
 				const page = latest(seen(), aiAgentPortNames.pageReply) as TranscriptPagePayload;
 				assert.strictEqual(page.kind, "page");
 				if (page.kind !== "page") return;
@@ -266,7 +275,9 @@ describe("the AI agent interface over a compiled graph", () => {
 					const payload = pending();
 					return payload?.kind === "pending" ? Object.keys(payload.requests) : null;
 				};
-				yield* eventually(() => (keys() ?? []).includes(PERMISSION_REQUEST));
+				yield* eventually("the permission card to be raised", () =>
+					(keys() ?? []).includes(PERMISSION_REQUEST),
+				);
 				assert.deepStrictEqual(keys(), [PERMISSION_REQUEST]);
 
 				yield* window.say(aiAgentPortNames.permissionDecision, {
@@ -274,7 +285,7 @@ describe("the AI agent interface over a compiled graph", () => {
 					request: PERMISSION_REQUEST,
 					decision: "allow-once",
 				});
-				yield* eventually(() => keys()?.length === 0);
+				yield* eventually("the answered card to close", () => keys()?.length === 0);
 				assert.deepStrictEqual(keys(), []);
 			}),
 		),
@@ -288,11 +299,11 @@ describe("the AI agent interface over a compiled graph", () => {
 					const payload = latest(seen(), aiAgentPortNames.modeState) as ModePayload | undefined;
 					return payload?.kind === "state" ? payload.current : null;
 				};
-				yield* eventually(() => current() === modes.current);
+				yield* eventually("the mode list on the modeState port", () => current() === modes.current);
 				assert.strictEqual(current(), modes.current);
 
 				yield* window.say(aiAgentPortNames.modeSet, {kind: "set", mode: modeBrand("plan")});
-				yield* eventually(() => current() === modeBrand("plan"));
+				yield* eventually("the set mode to come back", () => current() === modeBrand("plan"));
 				assert.strictEqual(current(), modeBrand("plan"));
 			}),
 		),

--- a/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
@@ -2,10 +2,10 @@
  * The five ports, end to end, over a real compiled graph: one `aiAgentProgram` node wired to a
  * stand-in window node, launched by the kernel, with every assertion made on what crossed a port.
  *
- * Nothing here reaches into the agent process's state. The point of the interface is that a window
- * can drive any agent knowing only the eight port keys, so the test drives it the same way — the
- * one call that is not a port is `start`, which the interface deliberately does not carry (the
- * shell opens a session; the five ports are what the conversation runs on).
+ * The point of the interface is that a window can drive any agent knowing only the eight port keys,
+ * so the test drives it the same way. The one read outside a port is the session's own phase, which
+ * is how a caller waits for the open the spawn started (#7925) — nothing dispatches `start`, and
+ * the interface deliberately does not carry it.
  *
  * It sits in the unit tier because it stands nothing up outside this process: the tiers split on
  * that, and the scripted layer talks to nothing.
@@ -24,6 +24,7 @@ import {open} from "../ports/wiring.ts";
 import {Processes} from "../process/Processes.ts";
 import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
+import {isAiAgentSessionState} from "./core/index.ts";
 import {aiAgentPortNames} from "./handlers/index.ts";
 import type {
 	ModePayload,
@@ -166,7 +167,10 @@ const eventually = (check: () => boolean) =>
 const onGraph = <A, E>(
 	script: AgentScript,
 	body: (
-		agent: {readonly dispatch: (msg: unknown) => Effect.Effect<void, unknown>},
+		agent: {
+			readonly dispatch: (msg: unknown) => Effect.Effect<void, unknown>;
+			readonly state: () => unknown;
+		},
 		window: {readonly say: (port: string, payload: unknown) => Effect.Effect<void, unknown>},
 		seen: () => ReadonlyArray<Arrival>,
 	) => Effect.Effect<A, E, Scope.Scope>,
@@ -182,7 +186,7 @@ const onGraph = <A, E>(
 		const agentHandle = agent!.handle;
 		const windowHandle = window!.handle;
 		return yield* body(
-			{dispatch: (msg) => agentHandle.dispatch(msg as never)},
+			{dispatch: (msg) => agentHandle.dispatch(msg as never), state: () => agentHandle.getState()},
 			{
 				say: (port, payload) => windowHandle.dispatch({type: "say", port, payload} as never),
 			},
@@ -201,8 +205,12 @@ const onGraph = <A, E>(
 const latest = (seen: ReadonlyArray<Arrival>, port: string): unknown =>
 	[...seen].reverse().find((arrival) => arrival.port === port)?.payload;
 
-const started = (agent: {readonly dispatch: (msg: unknown) => Effect.Effect<void, unknown>}) =>
-	agent.dispatch({type: "start", cwd: "/work", resume: null});
+/** Spawning the row is what opens the session (#7925), so a caller only waits for it. */
+const started = (agent: {readonly state: () => unknown}) =>
+	eventually(() => {
+		const state = agent.state();
+		return isAiAgentSessionState(state) && state.phase === "ready";
+	});
 
 describe("the AI agent interface over a compiled graph", () => {
 	it.live("carries a prompt in and the windowed transcript out", () =>

--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -8,7 +8,7 @@
  * the planner answers with data rather than throwing, so this does too.
  */
 
-import type {AgentEvent} from "../events.ts";
+import type {AgentEvent, Phase} from "../events.ts";
 import {isRefusal, planTranscriptWindow} from "../history/index.ts";
 import type {TranscriptItem, TranscriptPayload, WindowOmission} from "../ports/index.ts";
 import type {AiAgentSessionState, UsageTotals} from "./state.ts";
@@ -68,6 +68,19 @@ export const dropRequest = (state: AiAgentSessionState, request: string): AiAgen
 	permissions: without(state.permissions, request),
 });
 
+/**
+ * The two phases only the core's own cells may enter. `start` and `reconnect` are what put a
+ * session into an open, and `started` or `failed` are the only ways out of one, so a layer cannot
+ * tell the core about an open the core did not start.
+ *
+ * Every layer narrates its own open on the event stream — `PiAiAgent.start` and
+ * `ClaudeAiAgent.start` both emit `starting` and then `ready` — and that stream is opened by the
+ * `started` the open already answered (`machine.ts`, `subscriptions`). So the `starting` a Sub
+ * reads first is always a report about an open that is finished, and folding it walks a ready
+ * session backwards into a phase that refuses every prompt (#7925).
+ */
+const coreOwned = (phase: Phase): boolean => phase === "starting" || phase === "reconnecting";
+
 export const foldEvent = (
 	state: AiAgentSessionState,
 	event: AgentEvent,
@@ -77,7 +90,7 @@ export const foldEvent = (
 		case "item":
 			return {...state, transcript: foldItem(state.transcript, event.item, limits)};
 		case "phase":
-			return {...state, phase: event.phase};
+			return coreOwned(event.phase) ? state : {...state, phase: event.phase};
 		case "permission":
 			return {...state, permissions: {...state.permissions, [event.request]: event.detail}};
 		case "permission-resolved":

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -95,7 +95,26 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 		AiAgentSessionSub,
 		unknown
 	>({
-		init: (loaded) => [loaded === null ? initialState(options.cwd) : restore(loaded), noCmds],
+		/**
+		 * A fresh process opens its own session; a restored one is left to its resume rule.
+		 *
+		 * Spawning the program is the whole act (#7925): before this, every `start` in the tree was
+		 * a test's, so a picker-opened window sat at `idle` refusing every prompt. The fresh arm is
+		 * the home because it is the only place that knows the process is new, and it covers every
+		 * spawner at once — the picker, the launcher, a test kernel — where a hook on one spawn path
+		 * is a hook the next spawn path forgets, which is the bug itself. The window is not the home
+		 * either: two windows over one process would race into `startRefused`, and a window is a
+		 * view rather than the owner of a session's lifetime.
+		 *
+		 * Demlik allows this exactly here. Its guard reds only on a **non-null** `loaded` whose
+		 * `init` returns Cmds — the rehydrate branch is the migration/parse boundary (`replay` in
+		 * `@demlik/tea` 0.12) — so the restored arm stays `noCmds` and its reconnect stays the Msg
+		 * `restore/checkpoint.ts` hands a spawner.
+		 */
+		init: (loaded) =>
+			loaded === null
+				? [initialState(options.cwd), [{type: "aiAgent.boot", cwd: options.cwd}]]
+				: [restore(loaded), noCmds],
 		update: {
 			start: (state, msg) =>
 				busy(state)
@@ -225,6 +244,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 		// Demlik's `Machine` demands a Promise `interpret` and a `subscribe` beside the row's own
 		// Effect handlers; the host reads neither (#7576).
 		interpret: {
+			"aiAgent.boot": noWork,
 			"aiAgent.start": noWork,
 			"aiAgent.prompt": noWork,
 			"aiAgent.answer": noWork,

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -206,13 +206,38 @@ describe("event", () => {
 		expect(settled.permissions).toEqual({});
 	});
 
-	it("takes the phase the layer reports", () => {
+	it("takes a phase the layer reports that the core does not own", () => {
 		const [state] = apply(started(), {
 			type: "event",
 			sessionId: "session-1",
 			event: {kind: "phase", phase: "prompting"},
 		});
 		expect(state.phase).toBe("prompting");
+	});
+
+	// Every layer narrates its own open on the same stream (`PiAiAgent.start` emits `starting` then
+	// `ready`), and that stream is opened by the `started` the open already answered — so the
+	// `starting` a Sub reads first always lands on a session that is already ready (#7925).
+	it("ignores an opening phase the layer replays, so a ready session still takes a prompt", () => {
+		const [state] = apply(started(), {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "starting"},
+		});
+		expect(state.phase).toBe("ready");
+
+		const [prompted, cmds] = apply(state, {type: "prompt", text: "hello", key: "k1"});
+		expect(prompted.failure).toBeNull();
+		expect(cmds).toEqual([{type: "aiAgent.prompt", text: "hello", key: "k1"}]);
+	});
+
+	it("ignores a replayed reconnecting phase for the same reason", () => {
+		const [state] = apply(started(), {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "reconnecting"},
+		});
+		expect(state.phase).toBe("ready");
 	});
 
 	it("is discarded once the session is gone", () => {

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -38,10 +38,11 @@ const started = (over: Partial<AiAgentSessionState> = {}): AiAgentSessionState =
 });
 
 describe("init", () => {
-	it("opens a fresh session idle in the configured directory", () => {
+	it("opens a fresh session idle in the configured directory, and asks to boot it", () => {
 		const [state, cmds] = machine.init(null, {});
 		expect(state).toEqual(initialState("/repo"));
-		expect(cmds).toEqual([]);
+		// Spawning the program is the whole act: nothing else in the tree dispatches `start` (#7925).
+		expect(cmds).toEqual([{type: "aiAgent.boot", cwd: "/repo"}]);
 	});
 
 	it("restores a loaded state and emits no Cmd, as Demlik's rehydrate contract demands", () => {
@@ -402,10 +403,12 @@ describe("the Cmd each Msg answers for", () => {
 		}
 	});
 
-	it("emits every Cmd the union declares across the table", () => {
-		const emitted = new Set(
-			cases.flatMap(([state, msg]) => apply(state, msg)[1].map((c) => c.type)),
-		);
+	// `init` is the second emitter: the fresh arm's boot Cmd is the one no Msg answers for (#7925).
+	it("emits every Cmd the union declares, across the table and the fresh init", () => {
+		const emitted = new Set([
+			...machine.init(null, {})[1].map((cmd) => cmd.type),
+			...cases.flatMap(([state, msg]) => apply(state, msg)[1].map((c) => c.type)),
+		]);
 		expect(emitted).toEqual(new Set(Object.keys(machine.interpret ?? {})));
 	});
 });

--- a/apps/tuval/src/ai-agent/core/messages.ts
+++ b/apps/tuval/src/ai-agent/core/messages.ts
@@ -33,6 +33,17 @@ export type AiAgentSessionMsg =
 	| {readonly type: "failed"; readonly failure: AgentFailure};
 
 export type AiAgentSessionCmd =
+	/**
+	 * Open this process's session, because the process is new. The one Cmd a fresh `init` emits.
+	 *
+	 * Its handler does no backend work: it answers with the `start` Msg and nothing else. `init`
+	 * cannot dispatch a Msg — a Cmd is its only channel out — and the transition that opens a
+	 * session belongs to the `start` cell, which is also the one guard against a second open. So
+	 * this Cmd is the trampoline between them, and being trampoline-cheap is what keeps a spawn
+	 * from blocking on the session: the real `aiAgent.start` runs on the process's own tail after
+	 * the spawn has returned, rather than inside it.
+	 */
+	| {readonly type: "aiAgent.boot"; readonly cwd: string}
 	| {readonly type: "aiAgent.start"; readonly cwd: string; readonly resume: string | null}
 	| {readonly type: "aiAgent.prompt"; readonly text: string; readonly key: string}
 	| {

--- a/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
@@ -30,7 +30,13 @@ import {
 	plainReply,
 	SESSION_ID,
 } from "../service/fixtures/scripts.ts";
-import {type AgentScript, ScriptedAiAgent, TuvalAiAgent} from "../service/index.ts";
+import {
+	type AgentScript,
+	ScriptedAiAgent,
+	StartError,
+	type StartOptions,
+	TuvalAiAgent,
+} from "../service/index.ts";
 import {aiAgentPortNames} from "./publish.ts";
 
 const PROGRAM = "ai-agent-session-test";
@@ -38,14 +44,35 @@ const PROGRAM = "ai-agent-session-test";
 interface Probe {
 	acquired: number;
 	released: number;
+	/** Prompts the layer was actually asked for; a refused prompt has to reach none of them. */
+	prompts: number;
 }
 
+const probeOf = (): Probe => ({acquired: 0, released: 0, prompts: 0});
+
+/** A backend that holds no session at all, whatever it is asked to open. */
+const refusesEveryStart = (options: StartOptions) =>
+	new StartError({
+		reason: "session-not-found",
+		cwd: options.cwd,
+		detail: "this backend holds no session",
+	});
+
 /**
- * `ScriptedAiAgent.layer` with its build and its teardown counted. Wrapping rather than editing the
- * fixture keeps the count on this test's side of the seam: what is asserted is that the *row*
- * builds the layer once per process and closes it once, not anything about the script.
+ * `ScriptedAiAgent.layer` with its build, its teardown and its prompts counted. Wrapping rather
+ * than editing the fixture keeps the count on this test's side of the seam: what is asserted is
+ * that the *row* builds the layer once per process and closes it once, not anything about the
+ * script.
+ *
+ * `refuseStart` is the one behaviour the script itself cannot produce. A fresh session opens itself
+ * now (#7925), so no caller is left that can hand `start` an id the backend does not hold — the
+ * refusal a start answers with has to come from the layer.
  */
-const countingLayer = (script: AgentScript, probe: Probe): Layer.Layer<TuvalAiAgent> =>
+const countingLayer = (
+	script: AgentScript,
+	probe: Probe,
+	refuseStart = false,
+): Layer.Layer<TuvalAiAgent> =>
 	Layer.effect(
 		TuvalAiAgent,
 		Effect.gen(function* () {
@@ -55,7 +82,17 @@ const countingLayer = (script: AgentScript, probe: Probe): Layer.Layer<TuvalAiAg
 					probe.released += 1;
 				}),
 			);
-			return Context.get(yield* Layer.build(ScriptedAiAgent.layer(script)), TuvalAiAgent);
+			const agent = Context.get(yield* Layer.build(ScriptedAiAgent.layer(script)), TuvalAiAgent);
+			return {
+				...agent,
+				start: (options: StartOptions) =>
+					refuseStart ? Effect.fail(refusesEveryStart(options)) : agent.start(options),
+				prompt: (text: string, key?: string) =>
+					Effect.suspend(() => {
+						probe.prompts += 1;
+						return agent.prompt(text, key);
+					}),
+			};
 		}),
 	);
 
@@ -78,11 +115,21 @@ const recorder = (log: Array<Emitted>, wired: ReadonlySet<string>) =>
 
 const allPorts = new Set(Object.values(aiAgentPortNames));
 
-const row = (script: AgentScript, probe: Probe, itemLimit?: number) =>
+interface KernelOptions {
+	readonly itemLimit?: number;
+	readonly wired?: ReadonlySet<string>;
+	/** Every open this row's layer answers is refused, so the process never leaves `idle`. */
+	readonly refuseStart?: boolean;
+}
+
+const row = (script: AgentScript, probe: Probe, options: KernelOptions) =>
 	aiAgentProgram({
 		id: PROGRAM,
-		layer: countingLayer(script, probe),
-		config: {cwd: "/work", ...(itemLimit === undefined ? {} : {itemLimit})},
+		layer: countingLayer(script, probe, options.refuseStart ?? false),
+		config: {
+			cwd: "/work",
+			...(options.itemLimit === undefined ? {} : {itemLimit: options.itemLimit}),
+		},
 	});
 
 const withKernel = <A, E>(
@@ -92,13 +139,13 @@ const withKernel = <A, E>(
 		spawn: Effect.Effect<ProcessHandle, unknown>,
 		log: Array<Emitted>,
 	) => Effect.Effect<A, E, Processes | ProcessTable | Scope.Scope>,
-	options: {readonly itemLimit?: number; readonly wired?: ReadonlySet<string>} = {},
+	options: KernelOptions = {},
 ) => {
 	const log: Array<Emitted> = [];
 	const ports = recorder(log, options.wired ?? allPorts);
 	return Effect.gen(function* () {
 		const processes = yield* Processes;
-		const spawn = processes.spawn(row(script, probe, options.itemLimit).id, {
+		const spawn = processes.spawn(row(script, probe, options).id, {
 			services: Context.make(ProcessPorts, ports),
 		});
 		return yield* body(spawn, log);
@@ -107,7 +154,7 @@ const withKernel = <A, E>(
 		Effect.provide(
 			Processes.layer.pipe(
 				Layer.provideMerge(Checkpoints.layer(memoryStores())),
-				Layer.provideMerge(Registry.layer([row(script, probe, options.itemLimit)])),
+				Layer.provideMerge(Registry.layer([row(script, probe, options)])),
 			),
 		),
 	);
@@ -129,12 +176,10 @@ const lastOn = (log: ReadonlyArray<Emitted>, port: string): unknown =>
 
 describe("the AI agent handlers under a process", () => {
 	it.live("acquires the layer in the process's Scope and releases it once on stop", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(plainReply, probe, (spawn) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				assert.deepStrictEqual([probe.acquired, probe.released], [0, 0]);
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				assert.deepStrictEqual([probe.acquired, probe.released], [1, 0]);
 				yield* handle.stop;
@@ -146,13 +191,11 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("gives two processes of one row two agents", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(plainReply, probe, (spawn) =>
 			Effect.gen(function* () {
 				const first = yield* spawn;
-				const second = yield* spawn;
-				yield* first.dispatch({type: "start", cwd: "/work", resume: null});
-				yield* second.dispatch({type: "start", cwd: "/work", resume: null});
+				yield* spawn;
 				yield* eventually(() => probe.acquired === 2);
 				assert.strictEqual(probe.acquired, 2);
 				yield* first.stop;
@@ -162,11 +205,10 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("carries a prompt to the layer and the reply back on the transcript port", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(plainReply, probe, (spawn, log) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
 				yield* eventually(() => sessionOf(handle).transcript.items.length === 2);
@@ -182,11 +224,10 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("answers a transcript-page request on the page reply port", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(plainReply, probe, (spawn, log) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				yield* handle.dispatch({type: "page", before: null, limit: 3});
 				yield* eventually(() => sessionOf(handle).lastPage !== null);
@@ -204,11 +245,10 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("crosses a permission event out and an inbound answer back in", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(permissionTurn, probe, (spawn, log) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1"});
 				yield* eventually(() => sessionOf(handle).permissions[PERMISSION_REQUEST] !== undefined);
@@ -239,11 +279,10 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("crosses a mode event out and an inbound set back in", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(plainReply, probe, (spawn, log) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).modes.available.length === 2);
 
 				const state = lastOn(log, aiAgentPortNames.modeState) as ModePayload;
@@ -261,14 +300,18 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("windows a transcript past the limits and carries the omission out", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(
 			plainReply,
 			probe,
 			(spawn, log) =>
 				Effect.gen(function* () {
 					const handle = yield* spawn;
-					yield* handle.dispatch({type: "start", cwd: "/work", resume: SESSION_ID});
+					yield* eventually(() => sessionOf(handle).phase === "ready");
+					// The replayed history is what overruns the limit, and only a resumed open replays
+					// it. A fresh process opens itself with no resume now (#7925), so the reconnect is
+					// what asks the backend for the session it already holds.
+					yield* handle.dispatch({type: "reconnect"});
 					yield* eventually(() => sessionOf(handle).transcript.omitted.items > 0);
 
 					const tail = sessionOf(handle).transcript;
@@ -280,42 +323,51 @@ describe("the AI agent handlers under a process", () => {
 		);
 	});
 
-	it.live("turns a session-not-found resume into a failed Msg carrying the tag", () => {
-		const probe: Probe = {acquired: 0, released: 0};
-		return withKernel(plainReply, probe, (spawn) =>
-			Effect.gen(function* () {
-				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: "no-such-session"});
-				yield* eventually(() => sessionOf(handle).failure !== null);
-				assert.deepStrictEqual(
-					[sessionOf(handle).failure?.tag, sessionOf(handle).failure?.reason],
-					["tuval/ai-agent/StartError", "session-not-found"],
-				);
-				assert.strictEqual(sessionOf(handle).phase, "idle");
-			}),
+	it.live("turns a start the backend refuses into a failed Msg carrying the tag", () => {
+		const probe = probeOf();
+		return withKernel(
+			plainReply,
+			probe,
+			(spawn) =>
+				Effect.gen(function* () {
+					const handle = yield* spawn;
+					yield* eventually(() => sessionOf(handle).failure !== null);
+					assert.deepStrictEqual(
+						[sessionOf(handle).failure?.tag, sessionOf(handle).failure?.reason],
+						["tuval/ai-agent/StartError", "session-not-found"],
+					);
+					assert.strictEqual(sessionOf(handle).phase, "idle");
+				}),
+			{refuseStart: true},
 		);
 	});
 
+	// A refused open leaves the process at `idle`, which is the one phase a fresh session can still
+	// reach a prompt from — and the phase every prompt outside `ready` is refused from.
 	it.live("refuses a prompt outside ready as a failed Msg and sends nothing", () => {
-		const probe: Probe = {acquired: 0, released: 0};
-		return withKernel(plainReply, probe, (spawn) =>
-			Effect.gen(function* () {
-				const handle = yield* spawn;
-				yield* handle.dispatch({type: "prompt", text: "too early", key: "k1"});
-				assert.deepStrictEqual(
-					[sessionOf(handle).failure?.tag, probe.acquired],
-					["tuval/ai-agent/PromptError", 0],
-				);
-			}),
+		const probe = probeOf();
+		return withKernel(
+			plainReply,
+			probe,
+			(spawn) =>
+				Effect.gen(function* () {
+					const handle = yield* spawn;
+					yield* eventually(() => sessionOf(handle).failure !== null);
+					yield* handle.dispatch({type: "prompt", text: "too early", key: "k1"});
+					assert.deepStrictEqual(
+						[sessionOf(handle).failure?.tag, probe.prompts],
+						["tuval/ai-agent/PromptError", 0],
+					);
+				}),
+			{refuseStart: true},
 		);
 	});
 
 	it.live("turns a disconnected event stream into a failed Msg", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(disconnects, probe, (spawn) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
 				yield* eventually(() => sessionOf(handle).failure?.tag === "tuval/ai-agent/TransportError");
@@ -331,11 +383,10 @@ describe("the AI agent handlers under a process", () => {
 	// `prompt` and `page` all fail. So a reconnect that came back can only have rebuilt the layer,
 	// which is what ruling 4 (#7570) says restore is.
 	it.live("rebuilds the layer on reconnect and re-opens the event stream", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(disconnects, probe, (spawn, log) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
 				yield* eventually(() => sessionOf(handle).failure?.tag === "tuval/ai-agent/TransportError");
@@ -363,11 +414,10 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("counts the rebuilt transport once, not twice, when the process stops", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(disconnects, probe, (spawn) =>
 			Effect.gen(function* () {
 				const handle = yield* spawn;
-				yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 				yield* eventually(() => sessionOf(handle).phase === "ready");
 				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
 				yield* eventually(() => sessionOf(handle).failure !== null);
@@ -381,14 +431,13 @@ describe("the AI agent handlers under a process", () => {
 	});
 
 	it.live("publishes nothing and fails nothing when a port has no route", () => {
-		const probe: Probe = {acquired: 0, released: 0};
+		const probe = probeOf();
 		return withKernel(
 			plainReply,
 			probe,
 			(spawn, log) =>
 				Effect.gen(function* () {
 					const handle = yield* spawn;
-					yield* handle.dispatch({type: "start", cwd: "/work", resume: null});
 					yield* eventually(() => sessionOf(handle).phase === "ready");
 					yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
 					yield* eventually(() => sessionOf(handle).transcript.items.length === 2);

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -147,6 +147,13 @@ export const aiAgentHandlers = (options: AiAgentHandlerOptions): AiAgentHandlerS
 	};
 
 	const handlers: AiAgentHandlerSet["handlers"] = {
+		// The one handler that calls nothing. It answers the fresh `init`'s Cmd with the Msg that
+		// opens the session, and the `start` cell does the rest — including refusing a second open.
+		// Doing the work here instead would run it inside the spawn (`host/actor.ts` awaits an init
+		// Cmd's handler before `make` returns), which would hold the spawning process's own tail
+		// for as long as the backend takes to answer.
+		"aiAgent.boot": (cmd) => Effect.succeed([{type: "start", cwd: cmd.cwd, resume: null}]),
+
 		"aiAgent.start": (cmd) => open(cmd.cwd, cmd.resume),
 
 		"aiAgent.reconnect": (cmd) => open(cmd.cwd, cmd.sessionId),

--- a/apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts
+++ b/apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts
@@ -56,9 +56,11 @@ const kernel = Processes.layer.pipe(
 	Layer.provideMerge(Registry.layer([row])),
 );
 
-const eventually = (check: () => boolean) =>
+/** A spent budget asserts rather than falling through, so a timeout names itself (#7925). */
+const eventually = (what: string, check: () => boolean) =>
 	Effect.gen(function* () {
 		for (let attempt = 0; attempt < 400 && !check(); attempt += 1) yield* Effect.sleep("5 millis");
+		assert.isTrue(check(), `timed out after 2s waiting for ${what}`);
 	});
 
 const sessionOf = (handle: ProcessHandle): AiAgentSessionState => {
@@ -84,7 +86,10 @@ describe("a freshly spawned agent session", () => {
 	it.live("opens itself, with no caller dispatching start", () =>
 		onAFreshSpawn((handle) =>
 			Effect.gen(function* () {
-				yield* eventually(() => sessionOf(handle).phase === "ready");
+				yield* eventually(
+					"the spawned session to reach ready",
+					() => sessionOf(handle).phase === "ready",
+				);
 				const session = sessionOf(handle);
 				assert.strictEqual(session.phase, "ready", "the spawned session never opened");
 				assert.strictEqual(session.sessionId, SESSION_ID);
@@ -97,9 +102,15 @@ describe("a freshly spawned agent session", () => {
 	it.live("takes a prompt and puts the reply on the transcript port", () =>
 		onAFreshSpawn((handle, log) =>
 			Effect.gen(function* () {
-				yield* eventually(() => sessionOf(handle).phase === "ready");
+				yield* eventually(
+					"the spawned session to reach ready",
+					() => sessionOf(handle).phase === "ready",
+				);
 				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
-				yield* eventually(() => sessionOf(handle).transcript.items.length === 2);
+				yield* eventually(
+					"both turn items on the session transcript",
+					() => sessionOf(handle).transcript.items.length === 2,
+				);
 
 				const session = sessionOf(handle);
 				assert.isNull(session.failure, "the first prompt into a fresh session was refused");

--- a/apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts
+++ b/apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The fresh arm, end to end on `ScriptedAiAgent`: spawning the row is the whole act (#7925).
+ *
+ * Nothing here dispatches `start`. What the picker does is `processes.spawn` and then bind a
+ * window, so that is all this does — and what it has to show is a session that opened itself and a
+ * prompt that was answered rather than refused. The restored arm's counterpart is
+ * `restore/restore.unit.test.ts`; the checkpoint rule the two share is `restore/checkpoint.ts`.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer} from "effect";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {memoryStores} from "../durability/stores.ts";
+import {NodeId} from "../ports/graph.ts";
+import {PortNotWired, ProcessPorts} from "../ports/index.ts";
+import {Processes} from "../process/Processes.ts";
+import type {ProcessHandle} from "../process/process.ts";
+import {ProgramId} from "../registry/program.ts";
+import {Registry} from "../registry/Registry.ts";
+import {type AiAgentSessionState, isAiAgentSessionState} from "./core/index.ts";
+import {aiAgentPortNames} from "./handlers/index.ts";
+import type {TranscriptPayload} from "./ports/index.ts";
+import {aiAgentProgram} from "./program.ts";
+import {plainReply, SESSION_ID} from "./service/fixtures/scripts.ts";
+import {ScriptedAiAgent} from "./service/index.ts";
+
+const PROGRAM = "ai-agent-fresh-spawn-test";
+const CWD = "/work";
+
+interface Emitted {
+	readonly port: string;
+	readonly payload: unknown;
+}
+
+const wired: ReadonlySet<string> = new Set(Object.values(aiAgentPortNames));
+
+const recorder = (log: Array<Emitted>) =>
+	ProcessPorts.of({
+		emit: (port, payload) =>
+			wired.has(port)
+				? Effect.sync(() => {
+						log.push({port, payload});
+						return [];
+					})
+				: Effect.fail(new PortNotWired({node: NodeId.make("test"), port})),
+	});
+
+const row = aiAgentProgram({
+	id: PROGRAM,
+	layer: ScriptedAiAgent.layer(plainReply),
+	config: {cwd: CWD},
+});
+
+const kernel = Processes.layer.pipe(
+	Layer.provideMerge(Checkpoints.layer(memoryStores())),
+	Layer.provideMerge(Registry.layer([row])),
+);
+
+const eventually = (check: () => boolean) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 400 && !check(); attempt += 1) yield* Effect.sleep("5 millis");
+	});
+
+const sessionOf = (handle: ProcessHandle): AiAgentSessionState => {
+	const state = handle.getState();
+	assert.isTrue(isAiAgentSessionState(state), "the process is not holding an agent session state");
+	return state as AiAgentSessionState;
+};
+
+/** Spawn with no checkpoint and no `start`, exactly as `shell/picker/open.ts` does. */
+const onAFreshSpawn = <A, E>(
+	body: (handle: ProcessHandle, log: ReadonlyArray<Emitted>) => Effect.Effect<A, E>,
+) =>
+	Effect.gen(function* () {
+		const log: Array<Emitted> = [];
+		const processes = yield* Processes;
+		const handle = yield* processes.spawn(ProgramId.make(PROGRAM), {
+			services: Context.make(ProcessPorts, recorder(log)),
+		});
+		return yield* body(handle, log);
+	}).pipe(Effect.scoped, Effect.provide(kernel));
+
+describe("a freshly spawned agent session", () => {
+	it.live("opens itself, with no caller dispatching start", () =>
+		onAFreshSpawn((handle) =>
+			Effect.gen(function* () {
+				yield* eventually(() => sessionOf(handle).phase === "ready");
+				const session = sessionOf(handle);
+				assert.strictEqual(session.phase, "ready", "the spawned session never opened");
+				assert.strictEqual(session.sessionId, SESSION_ID);
+				assert.strictEqual(session.cwd, CWD);
+				assert.isNull(session.failure, "opening the session recorded a refusal");
+			}),
+		),
+	);
+
+	it.live("takes a prompt and puts the reply on the transcript port", () =>
+		onAFreshSpawn((handle, log) =>
+			Effect.gen(function* () {
+				yield* eventually(() => sessionOf(handle).phase === "ready");
+				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+				yield* eventually(() => sessionOf(handle).transcript.items.length === 2);
+
+				const session = sessionOf(handle);
+				assert.isNull(session.failure, "the first prompt into a fresh session was refused");
+				assert.deepStrictEqual(
+					session.transcript.items.map((item) => item.id),
+					["u1", "a1"],
+				);
+				const published = [...log]
+					.reverse()
+					.find((entry) => entry.port === aiAgentPortNames.transcript)?.payload as
+					| TranscriptPayload
+					| undefined;
+				assert.deepStrictEqual(published?.items, session.transcript.items);
+			}),
+		),
+	);
+});

--- a/apps/tuval/src/ai-agent/restore/checkpoint.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.ts
@@ -44,10 +44,19 @@ export type CheckpointField = (typeof checkpointFields)[number];
  * resume is "a Msg dispatched once from the host after the process is live" (`@demlik/tea` 0.12
  * `runtime-types.ts`, the "TEA contract violation" guard).
  *
- * A session with no id was never opened, and a `gone` one was refused on its last resume; neither
- * has anything to reconnect to, so neither gets a Msg. Everything else reconnects, and the machine
- * turns that into `start({cwd, resume: sessionId})` against a freshly built layer (ruling 4,
- * #7570) — never a new session, and never a re-sent prompt.
+ * A `gone` session was refused on its last resume, so it gets nothing: opening anything in its
+ * place is the silent fresh session #7514 refuses. Everything holding an id reconnects, and the
+ * machine turns that into `start({cwd, resume: sessionId})` against a freshly built layer (ruling
+ * 4, #7570) — never a new session, and never a re-sent prompt.
+ *
+ * A checkpoint with no id was never opened at all — the process was written down between its spawn
+ * and its first `started`. There is nothing to reconnect to and no id a fresh open could duplicate,
+ * so it takes the same route a fresh spawn takes (#7925). Without this it comes back wedged: the
+ * boot Cmd is the fresh `init`'s alone, and a rehydrating one may emit none.
  */
-export const resumeMessages = (state: AiAgentSessionState): ReadonlyArray<AiAgentSessionMsg> =>
-	state.sessionId === null || state.phase === "gone" ? [] : [{type: "reconnect"}];
+export const resumeMessages = (state: AiAgentSessionState): ReadonlyArray<AiAgentSessionMsg> => {
+	if (state.phase === "gone") return [];
+	return state.sessionId === null
+		? [{type: "start", cwd: state.cwd, resume: null}]
+		: [{type: "reconnect"}];
+};

--- a/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
@@ -119,8 +119,12 @@ describe("what a spawner dispatches into a restored process", () => {
 		expect(resumeMessages(restore(saved))).toEqual([{type: "reconnect"}]);
 	});
 
-	it("dispatches nothing into a session that was never opened", () => {
-		expect(resumeMessages(initialState("/repo"))).toEqual([]);
+	// Written down between the spawn and the first `started`: nothing to reconnect to, and no id a
+	// fresh open could duplicate, so it takes the route a fresh spawn takes (#7925).
+	it("starts a session that was checkpointed before it was ever opened", () => {
+		expect(resumeMessages(initialState("/repo"))).toEqual([
+			{type: "start", cwd: "/repo", resume: null},
+		]);
 	});
 
 	it("dispatches nothing into a session the backend already refused", () => {

--- a/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
@@ -9,9 +9,9 @@
  * new emission.
  *
  * There is no window and no renderer: a headless row runs the same as a rendered one (founder
- * ruling, #7557). The one thing not driven through a port is `start`, which the interface
- * deliberately does not carry — the shell opens a session, and the ports are what the conversation
- * runs on.
+ * ruling, #7557). Neither boot opens the session by hand: the first spawns fresh and opens itself
+ * (#7925), the second comes back checkpointed and reconnects, and the ports are what the
+ * conversation runs on either way.
  */
 
 import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
@@ -159,7 +159,6 @@ const runToTheCut = (project: string): Effect.Effect<FirstRun, unknown, FileSyst
 	Effect.gen(function* () {
 		const booted = yield* boot({global: configModule, project});
 		const {agent, window} = yield* handlesOf(booted);
-		yield* agent.dispatch({type: "start", cwd: CWD, resume: null});
 		yield* until("the session to open", () => sessionOf(agent).sessionId !== null);
 
 		yield* say(window, "list the files", "k1");

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -152,7 +152,6 @@ const runToTheCut = (stores: CheckpointStores, starts: Array<StartOptions>) =>
 				id: PROCESS,
 				services: Context.make(ProcessPorts, recorder(log)),
 			});
-			yield* handle.dispatch({type: "start", cwd: CWD, resume: null});
 			yield* eventually(() => sessionOf(handle.getState()).sessionId !== null);
 			yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1"});
 			yield* eventually(() => Object.keys(sessionOf(handle.getState()).permissions).length === 2);

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -595,7 +595,6 @@ const runServiceAgent = Effect.gen(function* () {
 					}),
 			}),
 		});
-		yield* agent.dispatch({type: "start", cwd: "/tuval", resume: null});
 		yield* eventually(() => {
 			const state = agent.getState();
 			return isAiAgentSessionState(state) && state.sessionId !== null;

--- a/apps/tuval/src/host/actor.ts
+++ b/apps/tuval/src/host/actor.ts
@@ -172,10 +172,11 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 		pending++;
 		quiet.closeUnsafe();
 	};
-	const leave = Effect.sync(() => {
+	const leave = (): void => {
 		pending--;
 		if (pending === 0) quiet.openUnsafe();
-	});
+	};
+	const leaving = Effect.sync(leave);
 
 	const closeSub = (sub: Scope.Closeable) =>
 		Scope.close(sub, Exit.void).pipe(Effect.catchCause(reportCause("sub-cleanup")));
@@ -187,16 +188,26 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 		}
 		enter();
 		Effect.runFork(
-			Effect.forkIn(
-				enqueue(msg).pipe(
-					Effect.catchCause((cause) => {
-						const error = Cause.squash(cause);
-						return report(error, error instanceof DispatchDiscardedError ? "discard" : "follow-up");
-					}),
-					Effect.ensuring(leave),
-					Effect.provideContext(services),
+			Effect.flatMap(
+				Effect.forkIn(
+					enqueue(msg).pipe(
+						Effect.catchCause((cause) => {
+							const error = Cause.squash(cause);
+							return report(
+								error,
+								error instanceof DispatchDiscardedError ? "discard" : "follow-up",
+							);
+						}),
+						Effect.provideContext(services),
+					),
+					scope,
 				),
-				scope,
+				// The count is settled on the fiber's Exit, never inside its body: a follow-up forked
+				// into the process Scope and interrupted before it ever starts — a stop taken in the
+				// same tick as the dispatch, which is what a session opening itself at spawn makes
+				// ordinary (#7925) — produces an Exit and runs no `ensuring`, so an in-body decrement
+				// leaves `pending` above zero and `stop` waits on `quiet` for ever.
+				(fiber) => Effect.sync(() => fiber.addObserver(leave)),
 			),
 		);
 	};
@@ -451,7 +462,7 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 	const dispatchOnce = (msg: M): Effect.Effect<void, DispatchError<E>> =>
 		Effect.suspend(() => {
 			enter();
-			return enqueue(msg).pipe(Effect.ensuring(leave), Effect.provideContext(services));
+			return enqueue(msg).pipe(Effect.ensuring(leaving), Effect.provideContext(services));
 		});
 
 	const idle: Effect.Effect<void> = quiet.await;

--- a/apps/tuval/src/host/actor.unit.test.ts
+++ b/apps/tuval/src/host/actor.unit.test.ts
@@ -1,6 +1,6 @@
 import {type DispatchDiscardedError, type NoCtx, subId} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
-import {Context, Effect, Schema, type Scope} from "effect";
+import {Context, Effect, Exit, Fiber, Schema, type Scope} from "effect";
 import {expectTypeOf} from "vitest";
 import {type ActorHandle, layer, make} from "./actor.ts";
 import {type CoreMachine, defineActor} from "./definition.ts";
@@ -206,5 +206,42 @@ describe("host actor", () => {
 				]);
 			}),
 		),
+	);
+
+	it.live(
+		"settles a follow-up interrupted before it ran, so a stop in the same tick completes",
+		() =>
+			Effect.gen(function* () {
+				type S = {readonly followed: boolean};
+				type M = {readonly type: "follow"};
+				type C = {readonly type: "boot"};
+				const machine: CoreMachine<S, M, C, never, NoCtx> = {
+					init: () => [{followed: false}, [{type: "boot"}]],
+					update: {follow: () => [{followed: true}, []]},
+				};
+				const definition = defineActor({
+					name: "test/stop-in-the-same-tick",
+					machine,
+					interpret: {boot: () => Effect.succeed({type: "follow"} as const)},
+					subscribe: {},
+				});
+
+				// The tick is the whole test: nothing is awaited between `make` returning and the scope
+				// closing, so the boot's follow-up — forked into that same scope — is interrupted before
+				// it ever starts. An in-body `ensuring` never registers on such a fiber, which leaves
+				// `pending` above zero and hangs `stop` on `quiet` for ever; `addObserver` settles it on
+				// the Exit instead (#7925).
+				// Detached, so a regression hangs this assertion rather than the test fiber's own teardown.
+				const running = yield* Effect.forkDetach(Effect.scoped(Effect.asVoid(make(definition))));
+				const stopped = yield* Fiber.join(running).pipe(
+					Effect.timeout("5 seconds"),
+					Effect.exit,
+					Effect.map(Exit.isSuccess),
+				);
+				assert.isTrue(
+					stopped,
+					"the actor's stop never completed: a pending follow-up never settled",
+				);
+			}),
 	);
 });

--- a/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
+++ b/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
@@ -388,7 +388,6 @@ describe("a Pi session in the Tuval shell, end to end", () => {
 							);
 
 							const session = yield* attachSession(page, agentId);
-							yield* session.send({type: "start", cwd: project, resume: null});
 							const ready = yield* liveWhere(
 								session.seen,
 								"the session to open",
@@ -485,7 +484,6 @@ describe("a Pi session in the Tuval shell, end to end", () => {
 									const opened = yield* openPiFromThePicker(desk, app.entries, only);
 									const agentId = opened.processId;
 									const session = yield* Scope.provide(attachSession(page, agentId), scope);
-									yield* session.send({type: "start", cwd: project, resume: null});
 									const ready = yield* liveWhere(
 										session.seen,
 										"the session to open",
@@ -581,7 +579,6 @@ describe("a Pi session in the Tuval shell, end to end", () => {
 									const opened = yield* openPiFromThePicker(desk, app.entries, window);
 									agentId = opened.processId;
 									const session = yield* Scope.provide(attachSession(page, agentId), scope);
-									yield* session.send({type: "start", cwd: project, resume: null});
 									const ready = yield* liveWhere(
 										session.seen,
 										"the session to open",

--- a/apps/tuval/src/pi/proof/serve.ts
+++ b/apps/tuval/src/pi/proof/serve.ts
@@ -130,7 +130,6 @@ const proof = Command.make(
 			session().transcript.items.filter((item) => item.kind === "assistant").length;
 
 		const seen = () => ({phase: session().phase, failure: session().failure, replies: replies()});
-		yield* agent.dispatch({type: "start", cwd: project, resume: null}).pipe(Effect.orDie);
 		yield* until("the Pi session to open", () => session().phase === "ready", seen);
 		for (const [index, text] of [PROMPT_1, PROMPT_2].entries()) {
 			const before = replies();

--- a/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
+++ b/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
@@ -165,7 +165,6 @@ const runFirstBoot = (project: string): Effect.Effect<FirstRun, unknown, FileSys
 	Effect.gen(function* () {
 		const booted = yield* boot({global: configModule, project});
 		const {agent, window} = yield* handlesOf(booted);
-		yield* agent.dispatch({type: "start", cwd: project, resume: null});
 		const seen = () => ({
 			phase: sessionOf(agent).phase,
 			failure: sessionOf(agent).failure,


### PR DESCRIPTION
A `pi-session` window opened from the Tuval picker sat at "Not started." for ever: the picker spawned the process and bound the window, and nothing ever dispatched `start`. Every `start` in the tree was a test's. This makes spawning the program the whole act.

## What changed

The machine's fresh `init` arm answers with one Cmd, `aiAgent.boot`, and its handler answers with the `start` Msg — nothing else. The restored arm still answers with no Cmds, which is what Demlik's guard is actually scoped to: `replay` reds only on a **non-null** `loaded` whose `init` returned Cmds.

Two things drove the placement:

- **The core, not a spawn path.** A hook on one spawner is a hook the next spawner forgets, which is this bug. `init` covers the picker, the launcher and a test kernel at once. The window is not the home either — two windows over one process race into `startRefused`.
- **A trampoline, not the work.** `runInterpret` awaits an init Cmd's handler before the actor is built, and a spawn runs inside the *spawning* process's serial step, so a boot handler that opened the connection itself would freeze the shell for the whole open — or for the row's 30s start deadline when it fails. Answering with a Msg puts the real work on the new process's own tail.

A restored session is untouched: it holds a session id, so `resumeMessages` still answers `reconnect` and no second id is minted. The one restore case that changed is a checkpoint written before the session ever opened — no id to reconnect to, none a fresh open could duplicate — which now takes the same open a fresh spawn takes instead of coming back wedged.

## Where a reviewer should look first

`apps/tuval/src/ai-agent/core/fold.ts`, the second round's fix. Every layer narrates its own open on the event stream — `PiAiAgent.start` and `ClaudeAiAgent.start` both emit `starting` and then `ready` — but the events Sub is keyed on the session id, so it opens only once `started` has already committed `ready`. The `starting` a Sub reads first is therefore always a report about an open that is finished, and folding it walked a ready session backwards into a phase that refuses the next prompt. That is a real product race the autostart made ordinary: the founder's first message into a freshly opened session could land in it and come back `promptRefused`. It is also what reddened `ai-agent-ports.unit.test.ts` at the previous head — the prompt was refused, so no transcript ever reached the window and the wait fell through onto an `undefined`. `foldEvent` now drops a `phase` event carrying `starting` or `reconnecting`: those two belong to the `start` and `reconnect` cells, and `started` or `failed` are the only ways out of them. Every other phase the layer reports still folds.

Then `apps/tuval/src/host/actor.ts`. Landing the fix surfaced a teardown deadlock: the host forked each unawaited follow-up into the process Scope and decremented its pending count with `Effect.ensuring` inside the fiber's body. A stop taken in the same tick as the dispatch interrupts a fiber that never started, which produces an Exit and runs no `ensuring`, so `pending` never reached zero and the actor's stop waited on its latch for ever. `pi/program.unit.test.ts` hung on exactly that, five seconds every run. The count now settles on the fiber's Exit through `addObserver`, which changes no execution ordering. Criterion 9 pins it: `actor.unit.test.ts`'s "settles a follow-up interrupted before it ran" fails against the old in-body `ensuring` and passes against the observer.

Then `apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts` — the headless proof of the fresh arm on `ScriptedAiAgent`: spawn, no `start`, the session opens and answers a prompt. Its polling waits, and those in `ai-agent-ports.unit.test.ts`, now assert their condition when the budget runs out instead of returning normally, so a future timeout names what did not happen rather than surfacing as a `TypeError` several lines later.

Every hand-dispatched `start` in the tree was read and either removed as redundant (the autostart now does it) or rewritten. Three in `handlers.unit.test.ts` needed real rework, because no caller can hand `start` a resume id from a fresh process any more: the windowing case drives the replay through `reconnect`, and the two refusal cases run under a layer whose every open is refused.

## Deviations

- **Out-of-scope change** — **Said:** #7925 names the fresh-start route and the tests around it. **Did:** also changed how `host/actor.ts` counts an unawaited follow-up, from an in-body `Effect.ensuring` to an Exit observer. **Why:** the autostart makes "spawn then stop in the same tick" ordinary, and the old accounting deadlocks the actor's stop on exactly that — the pre-existing hazard was unreachable before and is now hit by the suite. **Disposition:** stated here; no execution ordering changed, and both suites pass. Criterion 9, appended during review, now covers it.
- **Out-of-scope change** — **Said:** criterion 3 pins the restored arm to `reconnect`. **Did:** also gave `resumeMessages` a fresh-open arm for a checkpoint whose `sessionId` is null. **Why:** the boot Cmd is the fresh `init`'s alone, so without it a process checkpointed between its spawn and its first `started` comes back wedged for ever — the same defect this issue is about, on the other arm. It mints no second session id and records no `startRefused`, so criterion 3 holds. **Disposition:** stated here; `checkpoint.unit.test.ts`'s "dispatches nothing into a session that was never opened" flipped with it, under criterion 5's allowance.
- **Out-of-scope change** — **Said:** criterion 2 asks that a prompt into a freshly opened session is accepted. **Did:** also changed `core/fold.ts` so a layer's `phase` event carrying `starting` or `reconnecting` is dropped rather than folded. **Why:** that is what refuses the prompt. The events Sub opens after `started` has committed `ready`, so a layer's replayed `starting` always arrives late and walks the session backwards into a refusing phase. It is a live defect on the real Pi and Claude rows, not only in tests. **Disposition:** stated here; the two cells that own those phases are unchanged, every other reported phase still folds, and `machine.unit.test.ts` covers both the drop and the fold that stays.
- **Pre-existing test or fixture changed** — **Said:** criterion 6 covers the `start` sites in `handlers.unit.test.ts`. **Did:** also removed or rewrote the `start` sites in `ai-agent-ports.unit.test.ts`, `restore.unit.test.ts`, `restore-proof.unit.test.ts`, `commands/agent-proof.unit.test.ts`, the two pi integration suites and `pi/proof/serve.ts`. **Why:** with the session opening itself, every one of those dispatches is either redundant or lands a `startRefused` in the state the test then reads. **Disposition:** stated here; none of their assertions were weakened.

Fixes #7925
