### PR TITLE
fix: A real claude-session never reaches ready: the CLI sends no init before the first prompt, and start waits for one

### DIFF
--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -26,6 +26,7 @@
  * is the same atomicity a `Ref` would buy.
  */
 
+import {randomUUID} from "node:crypto";
 import type {
 	PermissionMode,
 	PermissionResult,
@@ -58,16 +59,18 @@ import {
 	type ClaudeAiAgentOptions,
 	openingMode,
 	queryOptionsOf,
+	type SessionChoice,
 	sessionEnv,
 } from "./options.ts";
 import {
 	controlRefused,
+	detailOf,
 	noSession,
 	noSessionToPage,
 	promptDisconnected,
 	sessionNotFound,
 	startTransport,
-	startWithoutInit,
+	startWithoutHandshake,
 	storeUnreadable,
 	streamFailed,
 	subprocessGone,
@@ -94,6 +97,11 @@ interface TurnState {
 	closing: boolean;
 }
 
+/** Whether the `system`/`init` frame has been read yet. It arrives once per turn; this logs once. */
+interface IntroState {
+	seen: boolean;
+}
+
 interface Session {
 	readonly id: string;
 	readonly cwd: string;
@@ -101,6 +109,7 @@ interface Session {
 	readonly input: InputChannel;
 	readonly watch: SubprocessWatch | null;
 	readonly state: TurnState;
+	readonly intro: IntroState;
 	/**
 	 * The pump's scope, which is this session's and not the layer's.
 	 *
@@ -258,6 +267,35 @@ const make = (
 				void runtime.runPromise(publish([{kind: "permission", request, detail: card}]));
 			});
 
+		/**
+		 * The first `init` frame of a session, which is the first turn's rather than the open's.
+		 *
+		 * It carries the two values the handshake does not — `SDKControlInitializeResponse` declares
+		 * neither `session_id` nor `claude_code_version` (`sdk.d.ts`) — so the drift line is written
+		 * here. The id is checked rather than adopted: the layer told the CLI which session to open
+		 * (`--session-id`), the events Sub and every later store read are keyed on it, and a CLI that
+		 * named a different one has broken the resume path silently.
+		 */
+		const readIntro = (
+			current: Session,
+			message: Extract<SDKMessage, {type: "system"; subtype: "init"}>,
+		): Effect.Effect<void> =>
+			Effect.suspend(() => {
+				if (current.intro.seen) return Effect.void;
+				current.intro.seen = true;
+				const line = Effect.logInfo(
+					`claude session ${message.session_id} opened — SDK ${sdk.version}, CLI ${message.claude_code_version}`,
+				);
+				return message.session_id === current.id
+					? line
+					: Effect.andThen(
+							line,
+							Effect.logWarning(
+								`the CLI opened session ${message.session_id}, not the ${current.id} this session is keyed on`,
+							),
+						);
+			});
+
 		const drive = (
 			open: EventQueue,
 			iterator: AsyncIterator<SDKMessage>,
@@ -279,6 +317,7 @@ const make = (
 							: Queue.fail(open, subprocessGone(exitDetail(current.watch?.exit() ?? null)));
 						return;
 					}
+					if (isInit(pulled.message)) yield* readIntro(current, pulled.message);
 					const step = toAgentEvents(pulled.message, mapping, {at: Date.now()});
 					mapping = step.mapping;
 					yield* emit(open, step.events);
@@ -287,14 +326,16 @@ const make = (
 			});
 
 		/**
-		 * Open the session and read it up to its `init`, which is the only frame that names the
-		 * session id. The frames read on the way are the session's first events and are handed back
-		 * rather than dropped.
+		 * Open the session, and wait for the CLI's connect-time handshake rather than for a message.
+		 *
+		 * Nothing is read off the message iterator here. In streaming-input mode every frame belongs
+		 * to a turn, `init` included, and there is no turn before a prompt — so an open that waited
+		 * for `init` waited for a prompt the machine would not let anyone send, which is the deadlock
+		 * this replaces (#7962). The whole message stream is the pump's from the first frame on.
 		 */
 		const open = Effect.fn("TuvalAiAgent.start.open")(function* (
 			cwd: string,
 			resume: string | undefined,
-			out: EventQueue,
 			held: Mode | null,
 		) {
 			const stale: Array<string> = [];
@@ -310,6 +351,13 @@ const make = (
 				stale.push(...unsettledToolIds(items).filter((id) => !parked.has(id)));
 			}
 
+			// A resumed session already has the CLI's id; a fresh one is opened under an id this layer
+			// mints, which is what lets `started` name a session before the first turn exists.
+			const choice: SessionChoice =
+				resume === undefined
+					? {kind: "fresh", sessionId: (options.newSessionId ?? randomUUID)()}
+					: {kind: "resume", sessionId: resume};
+
 			const watch = options.spawn === undefined ? null : watchSubprocess(options.spawn);
 			const input = inputChannel();
 			const handle = yield* Effect.try({
@@ -322,7 +370,7 @@ const make = (
 							canUseTool,
 							env: sessionEnv(),
 							held,
-							...(resume === undefined ? {} : {resume}),
+							session: choice,
 							...(watch === null ? {} : {spawn: watch.spawn}),
 						}),
 					}),
@@ -333,41 +381,25 @@ const make = (
 				handle.close();
 			});
 
-			const iterator = handle[Symbol.asyncIterator]();
-			const first: Array<AgentEvent> = [];
-			let mapping = emptyMapping;
-			while (true) {
-				const pulled = yield* pull(iterator);
-				if (pulled.kind === "failed") {
-					yield* abandon;
-					return yield* startTransport(cwd, pulled.error.detail);
-				}
-				if (pulled.kind === "done") {
-					yield* abandon;
-					return yield* startWithoutInit(cwd, exitDetail(watch?.exit() ?? null));
-				}
-				const step = toAgentEvents(pulled.message, mapping, {at: Date.now()});
-				mapping = step.mapping;
-				first.push(...step.events);
-				if (!isInit(pulled.message)) continue;
+			yield* Effect.tryPromise({
+				try: () => handle.initializationResult(),
+				catch: (cause) => startWithoutHandshake(cwd, detailOf(cause)),
+			}).pipe(Effect.tapError(() => abandon));
 
-				const current: Session = {
-					id: pulled.message.session_id,
+			return {
+				session: {
+					id: choice.sessionId,
 					cwd,
 					handle,
 					input,
 					watch,
 					state: {settled: false, closing: false},
+					intro: {seen: false},
 					scope: yield* Scope.make(),
-				};
-				// The one line that makes SDK/CLI drift visible: the pin is ours, the CLI is whatever
-				// is on PATH, and nothing else in the run reports the pair (founder ruling on #7580).
-				yield* Effect.logInfo(
-					`claude session ${current.id} opened — SDK ${sdk.version}, CLI ${pulled.message.claude_code_version}`,
-				);
-				yield* emit(out, first);
-				return {session: current, iterator, mapping, stale: stale as ReadonlyArray<string>};
-			}
+				} satisfies Session,
+				iterator: handle[Symbol.asyncIterator](),
+				stale: stale as ReadonlyArray<string>,
+			};
 		});
 
 		const start = Effect.fn("TuvalAiAgent.start")(function* (startOptions: {
@@ -388,7 +420,7 @@ const make = (
 			const held = yield* Ref.get(mode);
 			// One stream carries everything (ruling 1, #7570), so a failed start owes it a terminal
 			// phase: without this every subscriber sits on `starting` for the life of the layer.
-			const opened = yield* open(startOptions.cwd, startOptions.resume, out, held).pipe(
+			const opened = yield* open(startOptions.cwd, startOptions.resume, held).pipe(
 				Effect.tapError((_error: StartError) => emit(out, [{kind: "phase", phase: "gone"}])),
 			);
 
@@ -398,13 +430,11 @@ const make = (
 			// keys were recorded under is the one case that keeps them.
 			const continuing = previous !== null && startOptions.resume === previous.id;
 			if (!continuing) yield* Ref.set(keys, new Set<string>());
-			// Forked into the session's own scope, so the fan lives exactly as long as the
-			// subprocess it reads and dies with it.
-			yield* Effect.forkIn(
-				drive(out, opened.iterator, opened.mapping, opened.session),
-				opened.session.scope,
-			);
 
+			// The layer's own narration of the open, which the handshake is: the core is already
+			// `ready` off the `started` this call answers, and `coreOwned` drops a layer `starting`
+			// (`ai-agent/core/fold.ts`, #7948) but not this.
+			yield* emit(out, [{kind: "phase", phase: "ready"}]);
 			// The announced mode is resolved by the same call `open` opened the query with, never the
 			// raw `held`: `held` is null until an operator calls `setMode`, so a row carrying any
 			// non-default `permissionMode` would run on that mode and tell every subscriber it has
@@ -418,6 +448,14 @@ const make = (
 				opened.stale.map(
 					(request) => ({kind: "permission-resolved", request, decision: "deny"}) as const,
 				),
+			);
+
+			// Last, and forked into the session's own scope: the fan lives exactly as long as the
+			// subprocess it reads and dies with it, and starting it after the emits above is what
+			// keeps the session's own opening frames behind them on the one stream.
+			yield* Effect.forkIn(
+				drive(out, opened.iterator, emptyMapping, opened.session),
+				opened.session.scope,
 			);
 			return {sessionId: opened.session.id};
 		});

--- a/apps/tuval/src/claude/agent/events.unit.test.ts
+++ b/apps/tuval/src/claude/agent/events.unit.test.ts
@@ -9,7 +9,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Stream} from "effect";
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {Mode} from "../../ai-agent/ports/index.ts";
-import {CWD, MODES, messages, on, START_EVENTS, settled} from "./fixtures/harness.ts";
+import {CWD, MODES, messages, OPENED_EVENTS, on, settled} from "./fixtures/harness.ts";
 
 /**
  * The tool turn's four frames after `init`, folded: the call opens `running`, its answer settles it
@@ -24,11 +24,13 @@ describe("events over a captured tool turn", () => {
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				const events = yield* Stream.runCollect(
-					Stream.take(agent.events, START_EVENTS + TURN_EVENTS),
+					Stream.take(agent.events, OPENED_EVENTS + TURN_EVENTS),
 				);
 				assert.deepStrictEqual(
 					events.map((event) => event.kind),
-					["phase", "phase", "usage", "mode", "item", "item", "item", "usage"],
+					// The start's own three, then the first turn's `init` — its ready phase and the
+					// model it names — and then the turn itself.
+					["phase", "phase", "mode", "phase", "usage", "item", "item", "item", "usage"],
 				);
 			}),
 		),
@@ -39,7 +41,7 @@ describe("events over a captured tool turn", () => {
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				const events = yield* Stream.runCollect(
-					Stream.take(agent.events, START_EVENTS + TURN_EVENTS),
+					Stream.take(agent.events, OPENED_EVENTS + TURN_EVENTS),
 				);
 				const tools = events.flatMap((event: AgentEvent) =>
 					event.kind === "item" && event.item.kind === "tool" ? [event.item] : [],
@@ -60,9 +62,9 @@ describe("events over a captured tool turn", () => {
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				const events = yield* Stream.runCollect(
-					Stream.take(agent.events, START_EVENTS + TURN_EVENTS),
+					Stream.take(agent.events, OPENED_EVENTS + TURN_EVENTS),
 				);
-				const usage = events[START_EVENTS + TURN_EVENTS - 1];
+				const usage = events[OPENED_EVENTS + TURN_EVENTS - 1];
 				assert.strictEqual(usage?.kind, "usage");
 				assert.strictEqual(usage?.kind === "usage" ? usage.model : "", "claude-fable-5-1");
 			}),
@@ -76,7 +78,7 @@ describe("every kind rides the one stream", () => {
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				const turn = yield* Stream.runCollect(
-					Stream.take(agent.events, START_EVENTS + TURN_EVENTS),
+					Stream.take(agent.events, OPENED_EVENTS + TURN_EVENTS),
 				);
 				const ask = scripted.opened[0]?.record.options.canUseTool as CanUseTool;
 				const pending = ask(
@@ -98,8 +100,9 @@ describe("every kind rides the one stream", () => {
 					[
 						"phase",
 						"phase",
-						"usage",
 						"mode",
+						"phase",
+						"usage",
 						"item",
 						"item",
 						"item",

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -12,7 +12,7 @@ import {KernelBridge} from "../../tools/index.ts";
 import {ClaudeAiAgent} from "../ClaudeAiAgent.ts";
 import type {ClaudeAiAgentOptions} from "../options.ts";
 import type {SpawnClaudeCodeProcess} from "../subprocess.ts";
-import {type ScriptedSdk, scriptedSdk} from "./scripted-query.ts";
+import {type ScriptedBehaviour, type ScriptedSdk, scriptedSdk} from "./scripted-query.ts";
 
 export const CWD = "/tmp/tuval-capture";
 export const SESSION_ID = "00000000-0000-4000-8000-000000000001";
@@ -25,8 +25,17 @@ export const MODES: ReadonlyArray<Mode> = [
 	Mode.make("plan"),
 ];
 
-/** `start` emits: starting, the init's ready phase, the init's usage, then the mode list. */
-export const START_EVENTS = 4;
+/** What `start` itself emits: starting, the handshake's ready phase, then the mode list. */
+export const START_EVENTS = 3;
+
+/**
+ * Those three plus the `system`/`init` frame's own two — its ready phase and the model it names.
+ *
+ * The two are no longer part of `start`: the frame belongs to the first turn (`sdk.d.ts`), so on a
+ * scripted run whose `opening` begins with `init` the pump emits them just after, and a test that
+ * wants the turn behind them counts from here.
+ */
+export const OPENED_EVENTS = START_EVENTS + 2;
 
 export const messages = (name: Parameters<typeof loadFixture>[0]): ReadonlyArray<SDKMessage> =>
 	loadFixture(name) as ReadonlyArray<SDKMessage>;
@@ -37,7 +46,11 @@ export const message = (name: Parameters<typeof loadFixture>[0]): SDKMessage =>
 export const rows = (): ReadonlyArray<SessionMessage> =>
 	loadFixture("session-messages") as ReadonlyArray<SessionMessage>;
 
-export interface HarnessOptions {
+export interface HarnessOptions extends ScriptedBehaviour {
+	/**
+	 * What the query puts on its stream. Empty by default, because a real session says nothing until
+	 * a turn starts — a test that wants the `init` frame names it.
+	 */
 	readonly opening?: ReadonlyArray<SDKMessage>;
 	readonly rows?: ReadonlyArray<SessionMessage>;
 	readonly readFails?: Error;
@@ -69,6 +82,9 @@ const buildOptions = (harness: HarnessOptions, scripted: ScriptedSdk): ClaudeAiA
 	modes: harness.modes ?? MODES,
 	allowedTools: harness.allowedTools ?? [],
 	sdk: scripted.sdk,
+	// Pinned rather than random so the id the layer opens under is the one the captured `init`
+	// fixtures name, which is what lets a test read the two as one session.
+	newSessionId: () => SESSION_ID,
 	...(harness.model === undefined ? {} : {model: harness.model}),
 	...(harness.spawn === undefined ? {} : {spawn: harness.spawn}),
 });
@@ -83,10 +99,12 @@ export const on = <A, E>(
 ): Effect.Effect<A, E> =>
 	Effect.suspend(() => {
 		const scripted = scriptedSdk({
-			opening: harness.opening ?? [message("init")],
+			opening: harness.opening ?? [],
 			...(harness.rows === undefined ? {} : {rows: harness.rows}),
 			...(harness.readFails === undefined ? {} : {readFails: harness.readFails}),
 			...(harness.version === undefined ? {} : {version: harness.version}),
+			...(harness.deferOpening === undefined ? {} : {deferOpening: harness.deferOpening}),
+			...(harness.endsAtOnce === undefined ? {} : {endsAtOnce: harness.endsAtOnce}),
 		});
 		return Effect.gen(function* () {
 			const agent = yield* TuvalAiAgent;

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -41,11 +41,27 @@ export interface QueryRecord {
 	readonly child: SpawnedProcess | null;
 }
 
+/** How a scripted query behaves at the two seams a real one has: the handshake and the first turn. */
+export interface ScriptedBehaviour {
+	/**
+	 * `true` withholds `opening` until the first user message is written, which is what the real CLI
+	 * does in streaming-input mode — `init` is "session metadata the CLI emits at the start of each
+	 * turn" (`sdk.d.ts`), and there is no turn before a prompt.
+	 */
+	readonly deferOpening?: boolean;
+	/**
+	 * `true` ends the query the moment it is opened, as a subprocess that died on spawn does — which
+	 * takes the handshake down with it, exactly as tearing a real query down does.
+	 */
+	readonly endsAtOnce?: boolean;
+}
+
 export const scriptedQuery = (
 	params: {readonly prompt: AsyncIterable<SDKUserMessage>; readonly options: Options},
 	opening: ReadonlyArray<SDKMessage>,
+	behaviour: ScriptedBehaviour = {},
 ): ScriptedQuery => {
-	const buffered: Array<SDKMessage> = [...opening];
+	const buffered: Array<SDKMessage> = behaviour.deferOpening === true ? [] : [...opening];
 	let waiting: ((message: SDKMessage | null) => void) | null = null;
 	let stopped = false;
 
@@ -68,11 +84,16 @@ export const scriptedQuery = (
 		child,
 	};
 
-	// The operator's turns are read off the input iterable exactly as the SDK reads them, so a test
-	// asserts what `prompt` actually sent rather than what it meant to send.
-	void (async () => {
-		for await (const message of params.prompt) record.prompts.push(message);
-	})();
+	// The `initialize` control request, as a promise settled the way the SDK settles it: it comes
+	// back on connect, and tearing the query down rejects it along with every other pending control
+	// request (`sdk.mjs`, `performCleanup`). The `catch` is the SDK's own guard against an unhandled
+	// rejection on a query nobody asked the handshake of.
+	let refuseHandshake: ((cause: unknown) => void) | null = null;
+	const handshake = new Promise<unknown>((resolve, reject) => {
+		if (behaviour.endsAtOnce !== true) resolve({commands: [], agents: [], models: []});
+		refuseHandshake = reject;
+	});
+	handshake.catch(() => {});
 
 	const deliver = (message: SDKMessage | null): void => {
 		const waiter = waiting;
@@ -83,6 +104,16 @@ export const scriptedQuery = (
 		waiting = null;
 		waiter(message);
 	};
+
+	// The operator's turns are read off the input iterable exactly as the SDK reads them, so a test
+	// asserts what `prompt` actually sent rather than what it meant to send.
+	void (async () => {
+		for await (const message of params.prompt) {
+			const first = record.prompts.length === 0;
+			record.prompts.push(message);
+			if (first && behaviour.deferOpening === true) for (const frame of opening) deliver(frame);
+		}
+	})();
 
 	const next = (): Promise<SDKMessage | null> => {
 		const held = buffered.shift();
@@ -104,7 +135,11 @@ export const scriptedQuery = (
 		}
 	}
 
+	const abandonHandshake = (): void =>
+		refuseHandshake?.(new Error("Query closed before response received"));
+
 	const query: ScriptedQuery = Object.assign(stream(), {
+		initializationResult: () => handshake,
 		interrupt: async () => {
 			record.interrupts += 1;
 			return undefined;
@@ -116,16 +151,19 @@ export const scriptedQuery = (
 			record.closes += 1;
 			stopped = true;
 			child?.kill("SIGTERM");
+			abandonHandshake();
 			deliver(null);
 		},
 		say: (message: SDKMessage) => deliver(message),
 		stop: () => {
 			stopped = true;
+			abandonHandshake();
 			deliver(null);
 		},
 		record,
 	});
 
+	if (behaviour.endsAtOnce === true) query.stop();
 	return query;
 };
 
@@ -137,8 +175,8 @@ export interface ScriptedSdk {
 	readonly reads: Array<{sessionId: string; dir: string | undefined}>;
 }
 
-export interface ScriptedSdkOptions {
-	/** The messages a fresh `query()` replays before the layer stops reading, ending with `init`. */
+export interface ScriptedSdkOptions extends ScriptedBehaviour {
+	/** The messages a fresh `query()` puts on its stream, in order. */
 	readonly opening: ReadonlyArray<SDKMessage>;
 	/** What `getSessionMessages` answers. Absent answers an empty session, which is the resume miss. */
 	readonly rows?: ReadonlyArray<SessionMessage>;
@@ -156,7 +194,7 @@ export const scriptedSdk = (options: ScriptedSdkOptions): ScriptedSdk => {
 		sdk: {
 			version: options.version ?? "0.0.0-scripted",
 			query: (params) => {
-				const query = scriptedQuery(params, options.opening);
+				const query = scriptedQuery(params, options.opening, options);
 				opened.push(query);
 				return query;
 			},

--- a/apps/tuval/src/claude/agent/lifetime.unit.test.ts
+++ b/apps/tuval/src/claude/agent/lifetime.unit.test.ts
@@ -11,7 +11,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit, Option, Stream} from "effect";
 import {DENIED_MESSAGE} from "./cards.ts";
 import {fakeSpawn} from "./fixtures/fake-spawn.ts";
-import {CWD, message, onScripted, START_EVENTS, settled} from "./fixtures/harness.ts";
+import {CWD, onScripted, START_EVENTS, settled} from "./fixtures/harness.ts";
 import {scriptedSdk} from "./fixtures/scripted-query.ts";
 
 const options = (spawn: ReturnType<typeof fakeSpawn>) => ({spawn: spawn.spawn});
@@ -20,7 +20,7 @@ describe("closing the Scope", () => {
 	it.effect("calls Query.close exactly once and kills the subprocess", () =>
 		Effect.gen(function* () {
 			const spawn = fakeSpawn();
-			const scripted = scriptedSdk({opening: [message("init")]});
+			const scripted = scriptedSdk({opening: []});
 			yield* onScripted(options(spawn), scripted, (agent) => agent.start({cwd: CWD}));
 			assert.lengthOf(spawn.spawns, 1);
 			assert.strictEqual(scripted.opened[0]?.record.closes, 1);
@@ -31,7 +31,7 @@ describe("closing the Scope", () => {
 	it.effect("closes once even when the run already asked for a second session", () =>
 		Effect.gen(function* () {
 			const spawn = fakeSpawn();
-			const scripted = scriptedSdk({opening: [message("init")]});
+			const scripted = scriptedSdk({opening: []});
 			yield* onScripted(options(spawn), scripted, (agent) =>
 				Effect.gen(function* () {
 					yield* agent.start({cwd: CWD});
@@ -49,7 +49,7 @@ describe("closing the Scope", () => {
 	it.effect("resolves every parked permission as denied, so nothing stays blocked", () =>
 		Effect.gen(function* () {
 			const spawn = fakeSpawn();
-			const scripted = scriptedSdk({opening: [message("init")]});
+			const scripted = scriptedSdk({opening: []});
 			let parked: Promise<unknown> | null = null;
 			yield* onScripted(options(spawn), scripted, (agent) =>
 				Effect.gen(function* () {
@@ -80,7 +80,7 @@ describe("a subprocess that goes before its turn produced a result", () => {
 	it.effect("fails the stream with a TransportError naming the exit", () =>
 		Effect.gen(function* () {
 			const spawn = fakeSpawn();
-			const scripted = scriptedSdk({opening: [message("init")]});
+			const scripted = scriptedSdk({opening: []});
 			const exit = yield* onScripted(options(spawn), scripted, (agent) =>
 				Effect.gen(function* () {
 					yield* agent.start({cwd: CWD});
@@ -104,7 +104,7 @@ describe("a subprocess that goes before its turn produced a result", () => {
 	it.effect("does not respawn: one spawn, one query, and no second open", () =>
 		Effect.gen(function* () {
 			const spawn = fakeSpawn();
-			const scripted = scriptedSdk({opening: [message("init")]});
+			const scripted = scriptedSdk({opening: []});
 			yield* onScripted(options(spawn), scripted, (agent) =>
 				Effect.gen(function* () {
 					yield* agent.start({cwd: CWD});
@@ -122,7 +122,7 @@ describe("a subprocess that goes before its turn produced a result", () => {
 	it.effect("ends the stream cleanly when the turn had already settled", () =>
 		Effect.gen(function* () {
 			const spawn = fakeSpawn();
-			const scripted = scriptedSdk({opening: [message("init")]});
+			const scripted = scriptedSdk({opening: []});
 			const exit = yield* onScripted(options(spawn), scripted, (agent) =>
 				Effect.gen(function* () {
 					yield* agent.start({cwd: CWD});

--- a/apps/tuval/src/claude/agent/options.ts
+++ b/apps/tuval/src/claude/agent/options.ts
@@ -38,6 +38,11 @@ export interface ClaudeAiAgentOptions {
 	readonly sdk?: AgentSdk;
 	/** Absent leaves the SDK's own local spawn, which is what runs the `claude` on `PATH`. */
 	readonly spawn?: SpawnClaudeCodeProcess;
+	/**
+	 * The id a fresh session opens under. Absent mints a v4 UUID, which is what a run does; a test
+	 * pins it so the scripted `init` frame and the id the layer opened on name one session.
+	 */
+	readonly newSessionId?: () => string;
 }
 
 /** The modes this row actually offers, in the order it named them, minus the two never offered. */
@@ -80,9 +85,21 @@ export const sessionEnv = (
 	USER: base.USER === undefined || base.USER.length === 0 ? username() : base.USER,
 });
 
+/**
+ * Which session one `query()` opens, as the one shape that cannot name both.
+ *
+ * The SDK refuses the pair: `sessionId` "cannot be used with `continue` or `resume` unless
+ * `forkSession` is also set" (`sdk.d.ts`, `Options.sessionId`), and this layer never forks. A
+ * `fresh` id goes to the CLI as its own `--session-id`, which is what gives the session an id
+ * before the first turn; a `resume` id is the id the CLI already stored, and goes to `resume`.
+ */
+export type SessionChoice =
+	| {readonly kind: "fresh"; readonly sessionId: string}
+	| {readonly kind: "resume"; readonly sessionId: string};
+
 export interface QueryOptionsInput {
 	readonly cwd: string;
-	readonly resume?: string | undefined;
+	readonly session: SessionChoice;
 	readonly server: TuvalToolServer;
 	readonly canUseTool: NonNullable<Options["canUseTool"]>;
 	readonly env: Record<string, string | undefined>;
@@ -103,9 +120,11 @@ export const queryOptionsOf = (
 		mcpServers: servers,
 		canUseTool: input.canUseTool,
 		env: input.env,
+		...(input.session.kind === "fresh"
+			? {sessionId: input.session.sessionId}
+			: {resume: input.session.sessionId}),
 		// `exactOptionalPropertyTypes` refuses an explicit `undefined` on an optional field, so an
 		// absent option stays absent rather than being forwarded as one.
-		...(input.resume === undefined ? {} : {resume: input.resume}),
 		...(options.model === undefined ? {} : {model: options.model}),
 		...(input.spawn === undefined ? {} : {spawnClaudeCodeProcess: input.spawn}),
 	};

--- a/apps/tuval/src/claude/agent/refusals.ts
+++ b/apps/tuval/src/claude/agent/refusals.ts
@@ -28,8 +28,14 @@ export const sessionNotFound = (cwd: string, resume: string): StartError =>
 export const startTransport = (cwd: string, cause: unknown): StartError =>
 	new StartError({reason: "transport", cwd, detail: detailOf(cause)});
 
-/** The session ended before it said which session it was, so there is nothing to hand back. */
-export const startWithoutInit = (cwd: string, detail: string): StartError =>
+/**
+ * The query ended before its `initialize` control request came back, so it never opened.
+ *
+ * That rejection is the SDK's own: tearing a query down rejects every pending control request with
+ * "Query closed before response received" (`sdk.mjs`, `performCleanup`), and the handshake is one
+ * of them.
+ */
+export const startWithoutHandshake = (cwd: string, detail: string): StartError =>
 	new StartError({reason: "transport", cwd, detail});
 
 export const noSession = (): PromptError =>

--- a/apps/tuval/src/claude/agent/sdk.ts
+++ b/apps/tuval/src/claude/agent/sdk.ts
@@ -28,9 +28,19 @@ export const SDK_VERSION = "0.3.259";
  *
  * Narrower than the SDK's own `Query`, which declares two dozen control requests: a scripted
  * stand-in has to implement what the layer calls, not everything the CLI can be asked. The real
- * `Query` satisfies this structurally, so the seam's default needs no adapter.
+ * `Query` satisfies this structurally, so the seam's default needs no adapter. The return types are
+ * `unknown` where the layer reads nothing off the answer, which keeps a stand-in from having to
+ * mint an SDK payload it never uses.
+ *
+ * `initializationResult` is the layer's opened-ness signal. `sdk.d.ts` at the `0.3.259` pin
+ * documents it as returning "the cached first-connect result" (the contrast `Query.reinitialize`
+ * draws against itself), so the `initialize` control request it settles completes on connect with
+ * no prompt sent. The `system`/`init` message is the other thing and cannot serve: the same file
+ * calls it "session metadata the CLI emits at the start of each turn", and there is no turn before
+ * a prompt.
  */
 export interface AgentSession extends AsyncGenerator<SDKMessage, void> {
+	initializationResult(): Promise<unknown>;
 	interrupt(): Promise<unknown>;
 	setPermissionMode(mode: PermissionMode): Promise<void>;
 	close(): void;

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -3,7 +3,7 @@
  *
  * Every message the scripted `Query` replays is a golden fixture captured from a real run
  * (`../history/fixtures/PROVENANCE.md`): the `Options` object is ours to assert, but the frames the
- * layer reads to find the session id are not something a test may invent.
+ * layer folds are not something a test may invent.
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -13,7 +13,9 @@ import {TUVAL_SERVER_NAME, wireNameOf} from "../tools/index.ts";
 import {
 	CWD,
 	MODES,
+	message,
 	messages,
+	OPENED_EVENTS,
 	on,
 	rows,
 	SESSION_ID,
@@ -47,7 +49,7 @@ const failure = (exit: Exit.Exit<unknown, unknown>): {_tag?: string; reason?: st
 		: {};
 
 describe("start opens one streaming query", () => {
-	it.effect("resolves the session id the init frame named", () =>
+	it.effect("resolves the session id it opened the query under", () =>
 		on({}, (agent) =>
 			Effect.gen(function* () {
 				const session = yield* agent.start({cwd: CWD});
@@ -95,9 +97,18 @@ describe("start opens one streaming query", () => {
 		),
 	);
 
-	it.effect("logs the SDK pin beside the CLI version the init frame named", () =>
+	it.effect("logs the SDK pin beside the CLI version, once the init frame names one", () =>
 		Effect.gen(function* () {
-			const lines = yield* logged(on({version: "9.9.9-test"}, (agent) => agent.start({cwd: CWD})));
+			const lines = yield* logged(
+				on({version: "9.9.9-test", opening: [message("init")]}, (agent) =>
+					Effect.gen(function* () {
+						yield* agent.start({cwd: CWD});
+						// The pair rides the `init` frame, which belongs to the first turn rather than to
+						// the open, so the line lands only once the pump has read it.
+						yield* Stream.runCollect(Stream.take(agent.events, OPENED_EVENTS));
+					}),
+				),
+			);
 			// `claude_code_version` off the captured `init` fixture, which is a real run's frame.
 			const line = lines.find((each) => each.includes("SDK 9.9.9-test"));
 			assert.isDefined(line);
@@ -106,14 +117,13 @@ describe("start opens one streaming query", () => {
 		}),
 	);
 
-	it.effect("emits starting, the init's own events, then the mode list", () =>
+	it.effect("emits starting, the handshake's ready phase, then the mode list", () =>
 		on({modes: MODES}, (agent) =>
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS)), [
 					{kind: "phase", phase: "starting"},
 					{kind: "phase", phase: "ready"},
-					{kind: "usage", model: "claude-fable-5-1", inputTokens: 0, outputTokens: 0, cost: 0},
 					// The opening mode, not the layer's raw held `null`: nothing has called `setMode`, so
 					// what the query opened on is the row's own `permissionMode` (#7828).
 					{kind: "mode", current: Mode.make("default"), available: MODES},
@@ -135,6 +145,76 @@ describe("start opens one streaming query", () => {
 				});
 			}),
 		),
+	);
+});
+
+describe("start against a CLI that says nothing until the first prompt", () => {
+	// The defect this shape exists for (#7962): in streaming-input mode `init` is a turn's frame, the
+	// machine refuses a prompt outside `ready`, and an open that waited for `init` was waiting for
+	// the prompt only a ready session could send.
+	const withheld = {opening: [message("init")], deferOpening: true} as const;
+
+	it.effect("reaches ready with no prompt sent", () =>
+		on(withheld, (agent, scripted) =>
+			Effect.gen(function* () {
+				const session = yield* agent.start({cwd: CWD});
+				assert.strictEqual(session.sessionId, SESSION_ID);
+				assert.lengthOf(scripted.opened[0]?.record.prompts ?? [], 0);
+				assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS)), [
+					{kind: "phase", phase: "starting"},
+					{kind: "phase", phase: "ready"},
+					{kind: "mode", current: Mode.make("default"), available: MODES},
+				]);
+			}),
+		),
+	);
+
+	it.effect("opens the query under the id it hands back, which is the CLI's own", () =>
+		on(withheld, (agent, scripted) =>
+			Effect.gen(function* () {
+				const session = yield* agent.start({cwd: CWD});
+				assert.strictEqual(scripted.opened[0]?.record.options.sessionId, session.sessionId);
+				// The two cannot ride one query (`sdk.d.ts`, `Options.sessionId`).
+				assert.isUndefined(scripted.opened[0]?.record.options.resume);
+			}),
+		),
+	);
+
+	it.effect("records the session id and the CLI version once the init frame arrives", () =>
+		Effect.gen(function* () {
+			const lines = yield* logged(
+				on(withheld, (agent) =>
+					Effect.gen(function* () {
+						yield* agent.start({cwd: CWD});
+						yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+						yield* agent.prompt("hello");
+						assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, 2)), [
+							{kind: "phase", phase: "ready"},
+							{
+								kind: "usage",
+								model: "claude-fable-5-1",
+								inputTokens: 0,
+								outputTokens: 0,
+								cost: 0,
+							},
+						]);
+					}),
+				),
+			);
+			const line = lines.find((each) => each.includes(SESSION_ID));
+			assert.isDefined(line);
+			assert.include(line ?? "", "CLI 2.1.259");
+		}),
+	);
+
+	it.effect("fails the start when the query ends before its handshake comes back", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				on({...withheld, endsAtOnce: true}, (agent) => agent.start({cwd: CWD})),
+			);
+			assert.strictEqual(failure(exit)._tag, "tuval/ai-agent/StartError");
+			assert.strictEqual(failure(exit).reason, "transport");
+		}),
 	);
 });
 

--- a/apps/tuval/src/claude/agent/turns.unit.test.ts
+++ b/apps/tuval/src/claude/agent/turns.unit.test.ts
@@ -7,8 +7,16 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Cause, Effect, Exit, Option} from "effect";
-import {CWD, message, on, rows, SESSION_ID, TOOL_SESSION_ID} from "./fixtures/harness.ts";
+import {Cause, Effect, Exit, Logger, Option, Stream} from "effect";
+import {
+	CWD,
+	message,
+	OPENED_EVENTS,
+	on,
+	rows,
+	SESSION_ID,
+	TOOL_SESSION_ID,
+} from "./fixtures/harness.ts";
 
 const sent = (prompts: ReadonlyArray<{message: {content: unknown}}>): ReadonlyArray<unknown> =>
 	prompts.map((one) => one.message.content);
@@ -124,17 +132,48 @@ describe("page", () => {
 		),
 	);
 
-	it.effect("reads through the id the init frame named, not the one resume asked for", () =>
+	it.effect("reads through the id it resumed, which is the id the CLI hands back", () =>
 		on({rows: rows(), opening: [message("resumed-init")]}, (agent, scripted) =>
 			Effect.gen(function* () {
-				yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+				yield* agent.start({cwd: CWD, resume: SESSION_ID});
 				yield* agent.page(null, 10);
-				// The pre-open existence check reads what `resume` asked for; every later read goes
-				// through the session the CLI actually opened, which only `init` names.
-				assert.deepStrictEqual(scripted.reads[0], {sessionId: TOOL_SESSION_ID, dir: CWD});
-				assert.deepStrictEqual(scripted.reads[1], {sessionId: SESSION_ID, dir: CWD});
+				// A plain `resume` keeps the session's id — `resumed-init.json` is a real second
+				// `query()` over the same id (`../history/fixtures/PROVENANCE.md`) — so the existence
+				// check, the query's `resume` and every later store read are one session.
+				assert.strictEqual(scripted.opened[0]?.record.options.resume, SESSION_ID);
+				assert.deepStrictEqual(scripted.reads, [
+					{sessionId: SESSION_ID, dir: CWD},
+					{sessionId: SESSION_ID, dir: CWD},
+				]);
 			}),
 		),
+	);
+
+	it.effect("warns when the CLI's init frame names a session other than the one opened", () =>
+		Effect.gen(function* () {
+			const warnings: Array<string> = [];
+			yield* on({rows: rows(), opening: [message("resumed-init")]}, (agent) =>
+				Effect.gen(function* () {
+					// `resumed-init` names SESSION_ID, so resuming TOOL_SESSION_ID is a CLI that opened
+					// a session other than the one the layer is keyed on — silent, and it would break
+					// every later read.
+					yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+					yield* Stream.runCollect(Stream.take(agent.events, OPENED_EVENTS));
+				}),
+			).pipe(
+				Effect.provide(
+					Logger.layer([
+						Logger.make(({logLevel, message: line}) => {
+							if (logLevel !== "Warn") return;
+							warnings.push(String(Array.isArray(line) ? line[0] : line));
+						}),
+					]),
+				),
+			);
+			const warned = warnings.find((each) => each.includes(SESSION_ID));
+			assert.isDefined(warned);
+			assert.include(warned ?? "", TOOL_SESSION_ID);
+		}),
 	);
 
 	it.effect("refuses a cursor no item in the store carries", () =>

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -37,7 +37,7 @@ import {composerBridge} from "./composer-bridge.ts";
 import {tuvalDesignTranslate} from "./copy.ts";
 import {ModeSwitch} from "./ModeSwitch.tsx";
 import {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
-import {isWorking, phaseLine} from "./phase.ts";
+import {isWorking, statusLine} from "./phase.ts";
 import {
 	type ChatRow,
 	chatRows,
@@ -470,7 +470,7 @@ function ChatWindow({
 			<div className="tuval-chat-bar">
 				<p className="tuval-chat-phase" data-phase={phase} role="status">
 					<span className="tuval-chat-phase-dot" aria-hidden="true" />
-					{phaseLine(phase)}
+					{statusLine(phase, state?.failure ?? null)}
 				</p>
 				<div className="tuval-chat-bar-end">
 					{options.extras === null ? null : options.extras(process.state)}

--- a/apps/tuval/src/shell/chat/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/chat/boundary.unit.test.ts
@@ -137,6 +137,23 @@ describe("chat window boundary", () => {
 		expect(offenders).toEqual([]);
 	});
 
+	it("writes only failure tags the core's own refusals declare", () => {
+		const failures = readFileSync(
+			join(import.meta.dirname, "..", "..", "ai-agent", "core", "failures.ts"),
+			"utf8",
+		);
+		const declared = new Set(
+			[...failures.matchAll(/"(tuval\/ai-agent\/[A-Za-z]+)"/g)].map((match) => match[1]),
+		);
+		const written = sourceFiles().flatMap(([name, source]) =>
+			[...source.matchAll(/"(tuval\/ai-agent\/[A-Za-z]+)"/g)].map(
+				(match) => [name, match[1]] as const,
+			),
+		);
+		expect(written.length).toBeGreaterThan(0);
+		expect(written.filter(([, tag]) => tag === undefined || !declared.has(tag))).toEqual([]);
+	});
+
 	it("every agent import is type-only, so no agent code reaches the browser bundle", () => {
 		const offenders = sourceFiles().flatMap(([name, source]) =>
 			importLines(source)

--- a/apps/tuval/src/shell/chat/index.ts
+++ b/apps/tuval/src/shell/chat/index.ts
@@ -14,7 +14,7 @@ export {type ComposerBridge, type ComposerHandlers, composerBridge} from "./comp
 export {tuvalDesignMessages, tuvalDesignTranslate} from "./copy.ts";
 export {ModeSwitch} from "./ModeSwitch.tsx";
 export {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
-export {isWorking, phaseLine, phaseLines} from "./phase.ts";
+export {isWorking, phaseLine, phaseLines, statusLine} from "./phase.ts";
 export {
 	type ChatRow,
 	type ChatRowsInput,

--- a/apps/tuval/src/shell/chat/phase.ts
+++ b/apps/tuval/src/shell/chat/phase.ts
@@ -7,7 +7,15 @@
  * and never names a backend, which is what lets one window render any of them.
  */
 
+import type {AgentFailure} from "../../ai-agent/core/index.ts";
 import type {Phase} from "../../ai-agent/events.ts";
+
+/**
+ * `StartError`'s tag, as a literal for the same reason `ai-agent/core/failures.ts` writes them as
+ * literals: every agent import from this directory is type-only, so the window carries no agent
+ * code into the browser bundle. `boundary.unit.test.ts` reds if this stops naming a declared tag.
+ */
+const START_ERROR = "tuval/ai-agent/StartError";
 
 export const phaseLines: Readonly<Record<Phase, string>> = {
 	idle: "Not started.",
@@ -19,6 +27,32 @@ export const phaseLines: Readonly<Record<Phase, string>> = {
 };
 
 export const phaseLine = (phase: Phase): string => phaseLines[phase];
+
+/**
+ * The lead a failed start reads under, per phase the failure left the session in.
+ *
+ * `phaseAfterFailure` (`ai-agent/core/machine.ts`) walks a failed `starting` back to `idle` and a
+ * refused resume to `gone`, and both then render the phase's own sentence — so the 30 s start
+ * deadline reads as "Not started.", which is what a session nobody ever started reads as (#7962).
+ */
+const startFailedLeads: Readonly<Partial<Record<Phase, string>>> = {
+	idle: "The session could not start",
+	gone: "The session is gone",
+};
+
+/**
+ * The phase line, or what went wrong when the phase alone would misreport it.
+ *
+ * Only a `StartError` earns the failure line, and only where the session came to rest: any other
+ * refusal is about one act (a prompt, a mode, an answer) rather than about the session, and the
+ * phase is still the true thing to say.
+ */
+export const statusLine = (phase: Phase, failure: AgentFailure | null): string => {
+	const lead = startFailedLeads[phase];
+	return failure === null || failure.tag !== START_ERROR || lead === undefined
+		? phaseLine(phase)
+		: `${lead} — ${failure.detail}`;
+};
 
 /**
  * Is a turn running? The composer's stop control and its Escape-to-interrupt branch both key on

--- a/apps/tuval/src/shell/chat/phase.unit.test.ts
+++ b/apps/tuval/src/shell/chat/phase.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The status line: what the bar says for each phase, and when the phase alone would misreport it.
+ *
+ * The case that forced this is a start that failed its 30 s deadline (#7962): `phaseAfterFailure`
+ * walks a failed `starting` back to `idle`, which reads as "Not started." — the same sentence a
+ * session nobody ever started reads as, with the reason nowhere on screen.
+ */
+
+import {describe, expect, it} from "vitest";
+import type {AgentFailure} from "../../ai-agent/core/index.ts";
+import type {Phase} from "../../ai-agent/events.ts";
+import {isWorking, phaseLines, statusLine} from "./phase.ts";
+
+const startFailure = (detail: string, reason: string): AgentFailure => ({
+	tag: "tuval/ai-agent/StartError",
+	reason,
+	detail,
+});
+
+describe("the status line", () => {
+	it("is the phase's own sentence while nothing has failed", () => {
+		const phases: ReadonlyArray<Phase> = ["idle", "starting", "ready", "prompting", "gone"];
+		expect(phases.map((phase) => statusLine(phase, null))).toEqual(
+			phases.map((phase) => phaseLines[phase]),
+		);
+	});
+
+	it("reads as pending while a start is in flight, not as never started", () => {
+		expect(statusLine("starting", null)).toBe("Starting the session…");
+		expect(statusLine("starting", null)).not.toBe(phaseLines.idle);
+	});
+
+	it("names the reason a start failed rather than reading as never started", () => {
+		const line = statusLine(
+			"idle",
+			startFailure("the call did not answer within 30000ms", "deadline"),
+		);
+		expect(line).toContain("could not start");
+		expect(line).toContain("30000ms");
+		expect(line).not.toBe(phaseLines.idle);
+	});
+
+	it("names the reason a resume was refused, where that failure leaves the session", () => {
+		const line = statusLine(
+			"gone",
+			startFailure('no session "abc" is stored for this working directory', "session-not-found"),
+		);
+		expect(line).toContain("no session");
+	});
+
+	// A refused prompt, a refused mode, an unknown card: each is about one act rather than about the
+	// session, so the phase is still the true thing the bar can say.
+	it("leaves a failure that is not a start's to the surface that owns it", () => {
+		const refused: AgentFailure = {
+			tag: "tuval/ai-agent/PromptError",
+			reason: "no-session",
+			detail: "the session is idle, not ready",
+		};
+		expect(statusLine("idle", refused)).toBe(phaseLines.idle);
+	});
+
+	it("says a turn is running for prompting and for nothing else", () => {
+		const phases: ReadonlyArray<Phase> = [
+			"idle",
+			"starting",
+			"ready",
+			"prompting",
+			"reconnecting",
+			"gone",
+		];
+		expect(phases.filter(isWorking)).toEqual(["prompting"]);
+	});
+});


### PR DESCRIPTION
`ClaudeAiAgent.open` pulled the message iterator until a `system`/`init` message arrived before it
reported the session opened. In streaming-input mode that frame belongs to a turn, and the core
refuses a prompt outside `ready` — so against the real CLI the open was waiting for the prompt only
a ready session could send, and no `claude-session` ever started. `ScriptedAiAgent` emits `init` at
once, which is why CI never saw it.

## What changed

**The opened-ness signal is the handshake.** `open` now awaits `Query.initializationResult()`, which
`sdk.d.ts` at the `0.3.259` pin documents as returning "the cached first-connect result" — the
contrast `Query.reinitialize` draws against itself, so the `initialize` control request settles on
connect with no prompt sent. Nothing is read off the message iterator during the open any more; the
whole stream is the pump's from the first frame on.

**The session id exists before the first turn.** `SDKControlInitializeResponse` carries neither
`session_id` nor `claude_code_version`, so a fresh session is now opened under an id the layer mints
and hands the CLI as `Options.sessionId` — documented as "use a specific session ID for the
conversation instead of an auto-generated one", and wired to `--session-id=` in `sdk.mjs`. That id is
the CLI's own, so `started`, the events Sub key, the `resume` option and every `getSessionMessages`
read stay one session. `queryOptionsOf` takes a `SessionChoice` (`fresh` | `resume`) rather than an
optional `resume`, because the SDK refuses the two together and this makes that unrepresentable.

**The init frame still lands, with the values only it carries.** `drive` reads the first one, writes
the `claude session … opened — SDK …, CLI …` line, and warns when the CLI names a session other than
the one the layer is keyed on — which would silently break the resume path.

**The window says why a start failed.** `phaseAfterFailure` walks a failed `starting` back to `idle`,
which rendered as "Not started." — the same sentence a session nobody started reads as. A new
`statusLine` reports a `StartError` with its reason; every other refusal is about one act rather than
the session, so the phase line still owns those. The `starting`-off-the-stream fold #7948 landed is
untouched.

## Real-CLI evidence for criterion 1

The load-bearing claim is not that the SDK *sends* `initialize` at connect — that is readable in
`sdk.mjs` — but that the `claude` binary *answers* it before the first turn. Only a run against the
real CLI can say so, so here is one. Against the pinned SDK on the real `claude`, one `query()` whose
prompt is an async iterable that never yields, with two watchers on it and no prompt ever written —
so no model call and no spend:

```
node v26.2.0 · @anthropic-ai/claude-agent-sdk 0.3.259 · claude 2.1.260 (Claude Code)
query({prompt: <async iterable that never yields>, options: {cwd, permissionMode: "default"}})

{"handshake":"RESOLVED","ms":1009,"hasSessionId":false,"hasVersion":false}
{"iterator":"TIMEOUT","ms":12000}
```

The handshake settled in ~1 s with no prompt sent; the message iterator said nothing in 12 s. That is
the defect and the fix in one measurement — the signal `open` used to await never arrives, the one it
awaits now arrives at once. A separate run of the same probe printed the resolved response's keys,
and `session_id` and `claude_code_version` are absent from them, which is why those two are still
read off the `system`/`init` frame when the first turn brings it:

```
["account","agents","analytics_disabled","available_output_styles","commands",
 "current_permission_mode","fast_mode_disabled_reason","fast_mode_state",
 "ide_rc_auto_enable_gate","models","output_style","pid","remote_control_auto_enable",
 "remote_control_auto_on_by_default","remote_control_available","session_state"]
```

## Reviewing

`apps/tuval/src/claude/agent/ClaudeAiAgent.ts` is the change; `sdk.ts`, `options.ts` and the scripted
stand-in are the seam moving with it. The new `start.unit.test.ts` describe block drives the layer
over a scripted SDK that withholds `init` until the first user message — the defect's own shape — and
asserts `ready` before any prompt, then the id and CLI version once the frame arrives.

Two counts changed in the test harness: `START_EVENTS` is 3 (starting, ready, mode) because the
init's `ready`/`usage` pair now rides the first turn, and `OPENED_EVENTS` is those three plus that
pair for a scripted run whose opening begins with `init`. The harness's default opening is now empty,
which is what a real session says before a turn.

`pnpm typecheck`, `pnpm lint` and the tuval suite pass. One pre-existing flake,
`restore-proof.unit.test.ts`, times out under a loaded parallel run — it fails the same way at this
branch's base and passes alone; filed as #7964.

Filed while here: #7963 — with the session now reaching `ready`, the next thing an operator hits is
that the Claude layer's only `phase` event comes from the per-turn init frame, so a turn ends still
at `prompting`.

Fixes #7962

## Deviations

- **Out-of-scope change** — **Said:** #7962 names the layer, the seam and the window's start copy.
  **Did:** also added an import-boundary assertion to `apps/tuval/src/shell/chat/boundary.unit.test.ts`
  pinning that the chat slice writes only failure tags the core declares. **Why:** the window now
  compares a failure's tag, and that directory's own rule is that every agent import is type-only, so
  the tag is a literal there — the same shape `ai-agent/core/failures.ts` uses, and it pins its
  literals the same way. Without the pin a renamed tag would silently stop matching.
  **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** criterion 5 asks that the restore arm's
  behaviour be unchanged. **Did:** deleted two standing assertions in
  `apps/tuval/src/claude/agent/turns.unit.test.ts` (the `scripted.reads[0]` / `scripted.reads[1]`
  pair at lines 134–135) and rewrote the test around them. **Why:** they encoded the old design,
  where `resume` asked for one id and the `init` frame named another, so the pre-open existence check
  read `TOOL_SESSION_ID` and every later read went through `SESSION_ID`. Under one-session-per-resume
  that split no longer exists and the pair asserts a state the layer can no longer reach. The
  replacement is wider, not narrower — it pins the whole `reads` array *and* the query's `resume`
  option to the one id — and the case the old pair was reaching for, a CLI naming a session other
  than the one opened, is now its own test asserting the drift warning.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** criterion 8 asks that a start in flight read as pending
  and a failed start read as its reason. **Did:** both, but did not touch what the phase reads
  *during* a turn. **Why:** the Claude layer emits no end-of-turn `ready`, so a turn ends at
  `prompting` and the per-turn init reads `ready` mid-turn. That is a separate mechanism in the
  history mapping, it is pre-existing, and #7962's criteria are about opening the session.
  **Disposition:** filed as #7963.
