### PR TITLE
fix: Tuval boots with an empty WindowIndex, so every spell call naming a window is NoSuchWindow

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -393,11 +393,11 @@ frames, so "the card opened and closed exactly once" cannot be asked of the queu
 frames that would answer it are gone. The watcher pushes each published value into an array as well
 as the queue, and the count is taken off the array at the end.
 
-**Standing a second `SpellExecutor` up over a booted kernel needs two deliberate moves.** A proof that
-must resolve a caller's window — to parent a `process spawn`, say — supplies its own `WindowIndex`,
-because `boot` builds that index empty until the shell owns one (#7894). Composing it with
-`Layer.provide` does not work and does not look broken: `SpellExecutor.layer` is one module-level
-`Layer` value `boot` has already built, so the build hands back the memoized executor holding the
-empty index, and every call answers `NoSuchWindow` while the wiring reads correct. Wrap it in
-`Layer.fresh`, and merge the contexts one step at a time — `Context.merge(self, that)` lets `that`
-override, so each step names its winner rather than leaving it to composition order.
+**Standing a second `SpellExecutor` up over a booted kernel needs two deliberate moves.** `boot`'s
+own `WindowIndex` reads the running desk (#7894), so a proof with no desk — one that names a window
+and the process behind it directly, to parent a `process spawn` — has to supply its own. Composing
+it with `Layer.provide` does not work and does not look broken: `SpellExecutor.layer` is one
+module-level `Layer` value `boot` has already built, so the build hands back the memoized executor
+holding boot's index, and every call answers `NoSuchWindow` while the wiring reads correct. Wrap it
+in `Layer.fresh`, and merge the contexts one step at a time — `Context.merge(self, that)` lets
+`that` override, so each step names its winner rather than leaving it to composition order.

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -152,9 +152,17 @@ name the window it called from and nothing else: the process and the workspace a
 `WindowIndex`, so a page cannot address another process by putting an id on the wire. A spell that
 legitimately targets another process takes that id as a parameter of its own `params`.
 
-`WindowIndex` is an interface this slice declares and the shell implements. Until the shell adopts
-it, `WindowIndex.scripted(table)` answers from a fixture. A window the index does not hold is
-`NoSuchWindow`.
+`WindowIndex` is an interface this slice declares and the shell implements:
+`shellWindowIndexKernel(shellId)`
+([`shell/commands/kernel.ts`](../apps/tuval/src/shell/commands/kernel.ts)) reads the desk process's
+live state per resolve, and [`boot.ts`](../apps/tuval/src/boot.ts) provides it beside
+`shellDispatchKernel` for the same reasons and out of the same module (#7894). It answers a window's
+own workspace, plus the process that window shows when the table still holds it; a window bound to a
+process that has stopped resolves to its workspace and no process, the way the desk keeps such a
+window as a placeholder. A window the index does not hold — including every window when no desk is
+running — is `NoSuchWindow`. `WindowIndex.scripted(table)` stays, for a test that wants a fixed
+table rather than a running desk. The proof is
+[`src/shell/proof/window-index.unit.test.ts`](../apps/tuval/src/shell/proof/window-index.unit.test.ts).
 
 ## The executor
 

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -8,7 +8,7 @@ import {processSpells, SpawnedProcesses} from "./commands/core/process.ts";
 import type {DuplicateSpellPath, SpellNotDescribable} from "./commands/errors.ts";
 import {SpellExecutor} from "./commands/executor.ts";
 import type {SpellRegistry} from "./commands/registry.ts";
-import {WindowIndex} from "./commands/scope.ts";
+import type {WindowIndex} from "./commands/scope.ts";
 import type {AnySpell} from "./commands/spell.ts";
 import {SpellSet} from "./commands/spell-set.ts";
 import {type ConfigLoadError, loadLayeredConfig} from "./config.ts";
@@ -25,7 +25,7 @@ import type {ProcessHandle} from "./process/process.ts";
 import type {AnyProgram} from "./registry/program.ts";
 import {Registry} from "./registry/Registry.ts";
 import type {ShellDispatch} from "./shell/commands/dispatch.ts";
-import {shellDispatchKernel} from "./shell/commands/kernel.ts";
+import {shellDispatchKernel, shellWindowIndexKernel} from "./shell/commands/kernel.ts";
 import {shellId} from "./shell/program.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 
@@ -110,9 +110,7 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	).pipe(
 		Layer.provideMerge(SpellExecutor.layer),
 		Layer.provideMerge(
-			// No shell holds windows yet (#7499), so the index is empty: a call naming a window is
-			// `NoSuchWindow`, and a call naming none is workspace-wide.
-			Layer.mergeAll(Layer.succeedContext(spells), WindowIndex.scripted({})),
+			Layer.mergeAll(Layer.succeedContext(spells), shellWindowIndexKernel(shellId)),
 		),
 	);
 	const kernel = yield* Layer.build(

--- a/apps/tuval/src/claude/proof/kernel-tools.ts
+++ b/apps/tuval/src/claude/proof/kernel-tools.ts
@@ -8,14 +8,11 @@
  * window on it and the executor re-resolves the process through `WindowIndex` (#7617 R2.2) — so a
  * spawn is parented by the index and by nothing else.
  *
- * `boot` builds that index empty, because the shell does not own one yet: the comment at
- * `src/boot.ts`'s `WindowIndex.scripted({})` says so, and `src/commands/scope.ts` names the shell
- * (#7499) as the implementer. So this module stands one up over the kernel's own registry — the
- * real `SpellExecutor` over the real `Registry`, `Processes` and `SpawnedProcesses` — with the one
- * entry the desk actually holds: the window the picker bound to the Claude process. Everything a
- * call then touches is the booted kernel's; the only thing supplied here is the answer to "whose
- * child is this", which the shell will supply once it adopts the registry
- * ([#7894](https://github.com/kamp-us/phoenix/issues/7894)).
+ * `boot` now builds a live index over the running desk (`shellWindowIndexKernel`, #7894), so a
+ * process this proof reached through a real desk window would resolve there. This module still
+ * stands its own up over the kernel's own registry — the real `SpellExecutor` over the real
+ * `Registry`, `Processes` and `SpawnedProcesses` — because it has no desk: it names the window and
+ * the process directly, which is the one thing a proof with no shell row cannot read off state.
  *
  * Two things below look like ceremony and are not. The contexts are merged one step at a time
  * rather than composed with `Layer.provide`, because the booted kernel already carries a
@@ -23,7 +20,7 @@
  * which of each pair wins: `Context.merge(self, that)` is documented to let `that` override, so
  * each step names its winner. And `SpellExecutor.layer` is wrapped in `Layer.fresh`, because it is
  * one module-level `Layer` value that `boot` has already built — without the wrapper the build
- * hands back boot's memoized executor, the one holding the empty index, and every `spawn` here
+ * hands back boot's memoized executor, the one holding boot's own index, and every `spawn` here
  * answers `NoSuchWindow` while looking correctly wired.
  */
 

--- a/apps/tuval/src/commands/scope.ts
+++ b/apps/tuval/src/commands/scope.ts
@@ -7,8 +7,9 @@
  * `params` and is answerable for it.
  *
  * The kernel has no window noun (#7632 R1.2), so `WindowIndex` is an interface this slice declares
- * and the shell (#7499) implements when it adopts the registry. Until then `WindowIndex.scripted`
- * answers from a fixture — the founder's 2026-09-03 ruling on #7638.
+ * and the shell implements: `shellWindowIndexKernel` (`../shell/commands/kernel.ts`) reads the live
+ * desk, and boot provides it (#7894). `WindowIndex.scripted` answers from a fixture, for a test
+ * that wants a fixed table rather than a running desk.
  */
 
 import {Context, Effect, Layer} from "effect";

--- a/apps/tuval/src/shell/commands/kernel.ts
+++ b/apps/tuval/src/shell/commands/kernel.ts
@@ -1,16 +1,25 @@
 /**
- * The kernel's `ShellDispatch`: the Msg goes to the live process of the desk's program row.
+ * The two kernel-side services the desk backs: `ShellDispatch`, whose Msg goes to the live process
+ * of the desk's program row, and `WindowIndex`, which reads that same process's state to say where
+ * a window is.
  *
  * Kept apart from `./dispatch.ts` because that module is on the page's import path and this one
  * reaches the process table, which reads `node:crypto` at load; the page's boundary test
- * (`src/page/boundary.unit.test.ts`) is what keeps them apart (#7910). Only `src/boot.ts` imports
- * this.
+ * (`src/page/boundary.unit.test.ts`) is what keeps them apart (#7910). `src/commands/scope.ts` is
+ * on that path too, which is why the index's implementation is here and not beside its tag. Only
+ * `src/boot.ts` imports this.
  */
 
 import {Effect, Layer, Option} from "effect";
+import {NoSuchWindow} from "../../commands/errors.ts";
+import {WindowIndex, type WindowPlacement} from "../../commands/scope.ts";
+import {type WindowId, WorkspaceId} from "../../commands/spell.ts";
 import {Processes} from "../../process/Processes.ts";
 import {ProcessTable} from "../../process/ProcessTable.ts";
+import {ProcessId} from "../../process/process.ts";
 import type {ProgramId} from "../../registry/program.ts";
+import {hasWindow, processOf, type ShellState} from "../core/index.ts";
+import {shellStateOf} from "../program.ts";
 import {NoDesk, ShellDispatch} from "./dispatch.ts";
 
 /**
@@ -35,6 +44,57 @@ export const shellDispatchKernel = (
 						const handle = row === undefined ? Option.none() : yield* processes.handle(row.id);
 						if (Option.isNone(handle)) return yield* new NoDesk({program});
 						yield* handle.value.dispatch(msg);
+					}),
+			});
+		}),
+	);
+
+/**
+ * The window as the desk holds it, or `undefined` when no workspace holds it at all. The layout
+ * tree's ids are plain strings and the kernel's are branded (#7700), so the brands' own
+ * constructors do the one conversion — there is no `as` anywhere on this path.
+ */
+const placementOf = (state: ShellState, window: WindowId): WindowPlacement | undefined => {
+	for (const workspaceId of state.order) {
+		const workspace = state.workspaces[workspaceId];
+		if (workspace === undefined || !hasWindow(workspace, window)) continue;
+		const process = processOf(workspace, window);
+		return {
+			workspace: WorkspaceId.make(workspace.id),
+			...(process === null ? {} : {process: ProcessId.make(process)}),
+		};
+	}
+	return undefined;
+};
+
+/**
+ * The kernel's `WindowIndex`, read off the desk's own live state — the same row `shellDispatchKernel`
+ * dispatches into, resolved per call for the same reason (#7894).
+ *
+ * A window bound to a process the table no longer holds resolves to its workspace and no process
+ * rather than failing: the desk keeps such a window as a placeholder (`windowBindings`), so the
+ * scope a spell sees has to say the same thing. A boot whose config registered no shell row has no
+ * state to read, which is `NoSuchWindow` for every window — the index's shape of `NoDesk`.
+ */
+export const shellWindowIndexKernel = (
+	program: ProgramId,
+): Layer.Layer<WindowIndex, never, Processes | ProcessTable> =>
+	Layer.effect(
+		WindowIndex,
+		Effect.gen(function* () {
+			const processes = yield* Processes;
+			const table = yield* ProcessTable;
+			return WindowIndex.of({
+				resolve: (window) =>
+					Effect.gen(function* () {
+						const rows = yield* table.list;
+						const desk = rows.find((candidate) => candidate.programId === program);
+						const state = desk === undefined ? null : shellStateOf(desk.stateSummary().state);
+						const placement = state === null ? undefined : placementOf(state, window);
+						if (placement === undefined) return yield* new NoSuchWindow({window});
+						if (placement.process === undefined) return placement;
+						const handle = yield* processes.handle(placement.process);
+						return Option.isNone(handle) ? {workspace: placement.workspace} : placement;
 					}),
 			});
 		}),

--- a/apps/tuval/src/shell/proof/window-index.unit.test.ts
+++ b/apps/tuval/src/shell/proof/window-index.unit.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The scope a spell is handed, against a real boot (#7894).
+ *
+ * `WindowIndex` is what turns the one thing on the wire — the caller's window — into the process
+ * and workspace a spell sees, so nothing but a running call can show boot providing an index that
+ * reads the desk rather than an empty fixture. These are that call: `start` builds the kernel the
+ * app boots with, a probe program reports the scope its `execute` received, and `process spawn`
+ * shows the same resolution deciding who a spawned process is a child of.
+ */
+
+import {mkdtemp, rm} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Option, Schema} from "effect";
+import {start} from "../../boot.ts";
+import {SpellBridge} from "../../commands/bridge/index.ts";
+import {SpellExecutor} from "../../commands/executor.ts";
+import type {Client} from "../../commands/scope.ts";
+import {
+	ClientId,
+	defineSpell,
+	type SpellPath,
+	type Scope as SpellScope,
+	WindowId,
+	WorkspaceId,
+} from "../../commands/spell.ts";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessTable} from "../../process/ProcessTable.ts";
+import {ProcessId} from "../../process/process.ts";
+import {CallId} from "../../protocol/ids.ts";
+import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../../protocol/messages.ts";
+import {type AnyProgram, ProgramId} from "../../registry/program.ts";
+import {ShellDispatch} from "../commands/dispatch.ts";
+import {activeWorkspace} from "../core/index.ts";
+import {wiredShellEffects} from "../host/effects.ts";
+import {shellGraphNode, shellNode, shellProgram, shellStateOf} from "../program.ts";
+
+class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defect()}) {}
+
+const io = <A>(run: () => Promise<A>) =>
+	Effect.tryPromise({try: run, catch: (cause) => new TestIo({cause})});
+
+const tempDir = Effect.acquireRelease(
+	io(() => mkdtemp(join(tmpdir(), "tuval-window-index-"))),
+	(dir) => Effect.ignore(io(() => rm(dir, {recursive: true, force: true}))),
+);
+
+const shellProcessId = ProcessId.make(shellNode);
+
+const probeId = ProgramId.make("scope-probe");
+
+/**
+ * The scope as `execute` received it, on the wire. A spell is the only place a resolved `Scope` is
+ * observable — the executor builds one per call and hands it nowhere else — so reporting it as the
+ * result is what makes the resolution assertable.
+ */
+const scopeSpell = defineSpell({
+	path: ["scope"],
+	describe: "Answer the scope the kernel resolved for this call.",
+	params: Schema.Struct({}),
+	result: Schema.Struct({
+		window: Schema.optionalKey(Schema.String),
+		process: Schema.optionalKey(Schema.String),
+		workspace: Schema.String,
+	}),
+	execute: (_args, scope) =>
+		Effect.succeed({
+			...(scope.window === undefined ? {} : {window: scope.window}),
+			...(scope.process === undefined ? {} : {process: scope.process}),
+			workspace: scope.workspace,
+		}),
+	capabilities: [],
+});
+
+/** A row that carries the probe spell and is spawnable, so one program serves both halves. */
+const probeProgram: AnyProgram = {
+	id: probeId,
+	core: defineMachine<Record<string, never>, {readonly type: "noop"}, never, never, unknown>({
+		init: (loaded) => [loaded ?? {}, []],
+		update: {noop: (state) => [state, []]},
+		interpret: {},
+	}),
+	ports: {},
+	spells: [scopeSpell],
+	handlers: {},
+	capabilities: [],
+	renderer: {kind: "host-native", ref: "tuval/proof/scope-probe"},
+	identity: {
+		package: "@kampus/tuval",
+		program: "scope-probe",
+		version: "1.0.0",
+		digest: "sha256:scope-probe",
+	},
+	placement: {host: "local"},
+};
+
+const workspaceOnTheWire = WorkspaceId.make("ws-off-desk");
+const client: Client = {id: ClientId.make("proof"), workspace: workspaceOnTheWire};
+
+const call = (path: SpellPath, window?: WindowId): SpellCall =>
+	new SpellCall({
+		type: "spell.call",
+		version: PROTOCOL_VERSION,
+		id: CallId.make("c-1"),
+		path,
+		args: {},
+		...(window === undefined ? {} : {window}),
+	});
+
+const bootDesk = Effect.fn("proof.bootDesk")(function* (withDesk = true) {
+	const stateDir = yield* tempDir;
+	return yield* start({
+		programs: [shellProgram({effects: wiredShellEffects({shellProcessId})}), probeProgram],
+		graph: {nodes: withDesk ? [shellGraphNode] : []},
+		stateDir,
+	});
+});
+
+/**
+ * The desk's active workspace and focused window, branded as the kernel names them. Each read is a
+ * `getOrThrow`: a desk that is not running or holds no workspace is a broken fixture, and a throw
+ * reds the test at the line that read it rather than at the assertion three lines down.
+ */
+const readDesk = Effect.fn("proof.readDesk")(function* (kernel: Context.Context<Processes>) {
+	const handle = yield* Context.get(kernel, Processes).handle(shellProcessId);
+	const state = shellStateOf(Option.getOrThrow(handle).getState());
+	const workspace = Option.getOrThrow(
+		Option.fromNullishOr(state === null ? undefined : activeWorkspace(state)),
+	);
+	return {workspace: WorkspaceId.make(workspace.id), focused: WindowId.make(workspace.focused)};
+});
+
+/** A live process of the probe program, spawned through the kernel's own spell from no window. */
+const spawnFromNowhere = Effect.fn("proof.spawnFromNowhere")(function* (
+	kernel: Context.Context<SpellBridge>,
+) {
+	const spawned = yield* Context.get(kernel, SpellBridge)
+		.call(
+			["process", "spawn"],
+			{program: probeId},
+			{client: client.id, workspace: client.workspace},
+		)
+		.pipe(Effect.provideContext(kernel));
+	return (spawned as {readonly process: ProcessId}).process;
+});
+
+const failureOf = (reply: SpellReply) => {
+	assert.isFalse(reply.ok, `expected a refusal, got ${JSON.stringify(reply)}`);
+	return reply.ok ? undefined : reply.error;
+};
+
+const resultOf = (reply: SpellReply) => {
+	assert.isTrue(reply.ok, `the call was refused: ${JSON.stringify(reply)}`);
+	return reply.ok ? (reply.result as Record<string, string>) : undefined;
+};
+
+describe("the scope a spell is handed, over the index boot provides", () => {
+	it.effect("carries the window, its workspace and the process it shows", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			const process = yield* spawnFromNowhere(kernel);
+			const desk = yield* readDesk(kernel);
+			yield* Context.get(kernel, ShellDispatch).dispatch({type: "window.bind", processId: process});
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([probeId, "scope"], desk.focused), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.deepStrictEqual(resultOf(reply), {
+				window: desk.focused,
+				process,
+				workspace: desk.workspace,
+			});
+		}),
+	);
+
+	it.effect("drops the process once the table no longer holds it, and keeps the workspace", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			const process = yield* spawnFromNowhere(kernel);
+			const desk = yield* readDesk(kernel);
+			yield* Context.get(kernel, ShellDispatch).dispatch({type: "window.bind", processId: process});
+			yield* Context.get(kernel, Processes).stop(process);
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([probeId, "scope"], desk.focused), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.deepStrictEqual(resultOf(reply), {window: desk.focused, workspace: desk.workspace});
+		}),
+	);
+
+	it.effect("refuses a window the desk does not hold", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([probeId, "scope"], WindowId.make("window-nobody-opened")), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.strictEqual(failureOf(reply)?.tag, "tuval/commands/NoSuchWindow");
+		}),
+	);
+
+	it.effect("refuses every window when the config planned no desk", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk(false);
+			const rows = yield* Context.get(kernel, ProcessTable).list;
+			assert.deepStrictEqual([...rows], [], "the boot planned a process after all");
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([probeId, "scope"], WindowId.make("window-1")), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.strictEqual(failureOf(reply)?.tag, "tuval/commands/NoSuchWindow");
+		}),
+	);
+
+	it.effect("leaves a call naming no window workspace-wide, with no window and no process", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			const process = yield* spawnFromNowhere(kernel);
+			yield* Context.get(kernel, ShellDispatch).dispatch({type: "window.bind", processId: process});
+
+			const reply = yield* Context.get(kernel, SpellExecutor)
+				.execute(call([probeId, "scope"]), client)
+				.pipe(Effect.provideContext(kernel));
+
+			assert.deepStrictEqual(resultOf(reply), {workspace: workspaceOnTheWire});
+		}),
+	);
+});
+
+describe("process spawn, parented by the index and by nothing else", () => {
+	it.effect("makes the spawned process a child of the calling window's process", () =>
+		Effect.gen(function* () {
+			const {kernel} = yield* bootDesk();
+			const parent = yield* spawnFromNowhere(kernel);
+			const desk = yield* readDesk(kernel);
+			yield* Context.get(kernel, ShellDispatch).dispatch({type: "window.bind", processId: parent});
+
+			// The bridge puts only the window on the wire, so nothing here names the parent: the
+			// scope below carries no process and the index is what supplies one.
+			const scope: SpellScope = {
+				client: client.id,
+				workspace: client.workspace,
+				window: desk.focused,
+			};
+			const spawned = yield* Context.get(kernel, SpellBridge)
+				.call(["process", "spawn"], {program: probeId}, scope)
+				.pipe(Effect.provideContext(kernel));
+
+			const child = (spawned as {readonly process: ProcessId}).process;
+			const row = yield* Context.get(kernel, ProcessTable).get(child);
+			assert.deepStrictEqual(row.parentId, Option.some(parent));
+
+			const rootRow = yield* Context.get(kernel, ProcessTable).get(parent);
+			assert.isTrue(Option.isNone(rootRow.parentId), "the windowless spawn parented itself");
+		}),
+	);
+});


### PR DESCRIPTION
`apps/tuval/src/boot.ts` built the kernel's `WindowIndex` from an empty fixture,
`WindowIndex.scripted({})`, under a comment saying no shell held windows yet. The shell has since
landed and its desk does hold windows, so `resolveScope` refused every call naming a real window
with `NoSuchWindow`, and a Claude tool call from a desk window could not reach the process behind
it — `process spawn` took its parent from `scope.process`, which was never set.

`shellWindowIndexKernel(program)` now lives beside `shellDispatchKernel` in
`apps/tuval/src/shell/commands/kernel.ts` and boot provides it where the fixture sat. It finds the
desk row in the process table by program id and reads that row's live `stateSummary().state` back
through `shellStateOf` on every resolve, so a desk stopped and spawned again under the same program
id is still found. It answers the window's own workspace, plus the process the window shows when
`Processes.handle` still holds it; a window bound to a process that has stopped resolves to its
workspace and no process, matching how the desk keeps such a window as a placeholder. An unknown
window — and every window when no desk is running — is `NoSuchWindow`, the index's shape of the
`NoDesk` its sibling gives. The layer lives in `kernel.ts` rather than beside the tag in
`commands/scope.ts` because that module is on the page's import path and this one reaches the
process table (#7912); `apps/tuval/src/page/boundary.unit.test.ts` stays green.

The branded ids convert through their own constructors — `WorkspaceId.make`, `ProcessId.make` — so
there is no `as` on the path.

`apps/tuval/src/shell/proof/window-index.unit.test.ts` is the proof, modelled on the sibling
`dispatch.unit.test.ts`: it boots the real kernel with the shell row plus a probe program whose
spell reports the scope its `execute` received, spawns a process through `process spawn` from no
window, binds it to the desk's focused window, and then reads the scope back through
`SpellExecutor`. It covers the window/workspace/process answer, the stopped-process answer, an
unknown window, a boot with no desk, and the windowless workspace-wide call. A sixth case goes
through `SpellBridge.call`, which puts only the window on the wire, and asserts the spawned
process's `parentId` is the calling window's process — with the windowless spawn still a root.
Flip-verified: restoring `WindowIndex.scripted({})` in boot reds three of the six.

Grounding: the per-resolve read and the `Processes | ProcessTable` shape follow
`shellDispatchKernel` in the same module; `Layer.effect` and `Context.Service.of` are the idiom
already used there.

Reviewer: start at `shellWindowIndexKernel` and `placementOf` in
`apps/tuval/src/shell/commands/kernel.ts`, then the spawn-parenting case at the foot of the proof.

Fixes #7894

## Deviations

- **Out-of-scope change** — **Said:** #7894 names `boot.ts`, `kernel.ts` and the two proofs.
  **Did:** also corrected three docblocks and two `.patterns/` sections that state boot's index is
  empty — `apps/tuval/src/commands/scope.ts`, `apps/tuval/src/claude/proof/kernel-tools.ts`,
  `.patterns/tuval-spells.md` and `.patterns/tuval-shell-assembly.md`. **Why:** each is a prose
  claim this change makes false, and CLAUDE.md requires `.patterns/` to agree with source. No code
  in the Claude proof changed — only its comment. **Disposition:** stated here.
