### PR TITLE
fix: aiAgentProgram's layer parameter closes the row's inferred R, so the claude row cannot let the kernel bridge ride it

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -44,13 +44,22 @@ const launched = yield* launch(compiled, wiring, {services: kernel}).pipe(
 through, and handing them over is a wiring decision rather than a capability grant — local program
 code is fully trusted, there is no sandbox (#7484 R1.1).
 
-**Every spawner hands over that same kernel context, so a program a picker may open may require
-kernel services** (#7951). `restore` gets it from `start` for the checkpointed processes the graph
-did not plan; the picker passes on the context its own shell process was launched with
-(`src/shell/picker/open.ts`). `src/demo/counter.ts` is the example: its `announce` handler wants
-`ProcessPorts`, and it comes up under either spawner. What each of those two paths does *not* pass on
-is the spawner's own `ProcessPorts` — a port binding emits from one node — so each builds the process
-one of its own, un-wired where the graph owns no route (#7789).
+**Two of the three spawners hand that same kernel context over, so a program a picker may open may
+require kernel services** (#7951). `start` passes it to `restore` for the checkpointed processes the
+graph did not plan (`src/boot.ts`); the picker passes on the context its own shell process was
+launched with (`src/shell/picker/open.ts`). The third does not: the `process spawn` spell hands its
+child `Context.make(ProcessPorts, ports)` and nothing else (`src/commands/core/process.ts`), so under
+the spawner an agent program itself reaches for, a row needing a kernel service still dies at its
+handler.
+
+`ProcessPorts` is the one service those first two refuse to pass down — a port binding emits from one
+node, so a child holding its spawner's would emit out of the wrong one — and they refuse it
+differently. `restore` merges an `unwired` `ProcessPorts` in second, so a restored process has one
+and an emit fails `PortNotWired` where the graph owns no route (#7789). The picker only removes the
+service (`Context.omit(ProcessPorts)`), and `Processes.spawn` puts back only `ProcessSelf`, so a
+picker-opened process is spawned with no `ProcessPorts` at all. `src/demo/counter.ts` is the example
+under both: its `announce` handler wants `ProcessPorts`, which comes back un-wired under `restore`
+and is absent from the spawn context under the picker.
 
 **Nothing checks the pairing, so the failure is at the handler.** `SpawnOptions.services` is typed
 `Context.Context<never>`, which every context satisfies, so a row asking for a service its spawner

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -26,11 +26,11 @@ One rule holds the whole picture together: **the desk is the shell process's sta
 a view of it.** Nothing on the page is authoritative, which is why two tabs show one desk and why a
 dropped socket is repaired by attaching again rather than by replaying anything.
 
-## A program row's `R` is satisfied at launch, not by the row
+## A program row's `R` is satisfied at spawn, not by the row
 
 `shellProgram({effects})` needs `Registry`, `Processes` and `ProcessTable` to run `openProgram` and
 `attachProcess` — the picker spawns. A row is pure data built before the kernel exists, so it cannot
-close over them; it declares them as its `R` instead, and `launch` provides them:
+close over them; it declares them as its `R` instead, and the spawner provides them:
 
 ```ts
 // src/boot.ts
@@ -40,14 +40,24 @@ const launched = yield* launch(compiled, wiring, {services: kernel}).pipe(
 ```
 
 `launch` merges that context into each spawn's `SpawnOptions.services` beside the node's own
-`ProcessPorts`. This is the only seam a program row's requirements can arrive through, and it is a
-wiring decision rather than a capability grant — local program code is fully trusted, there is no
-sandbox (#7484 R1.1).
+`ProcessPorts`. `SpawnOptions.services` is the only seam a program row's requirements can arrive
+through, and handing them over is a wiring decision rather than a capability grant — local program
+code is fully trusted, there is no sandbox (#7484 R1.1).
 
-**A restored process gets no such context.** `restore` spawns checkpointed processes the graph did
-not plan (everything the picker opened), with no services. So a program that a *picker* may open must
-have handlers that need nothing — `src/demo/log.ts` qualifies, `src/demo/counter.ts` does not, since
-its `announce` handler wants `ProcessPorts`.
+**Every spawner hands over that same kernel context, so a program a picker may open may require
+kernel services** (#7951). `restore` gets it from `start` for the checkpointed processes the graph
+did not plan; the picker passes on the context its own shell process was launched with
+(`src/shell/picker/open.ts`). `src/demo/counter.ts` is the example: its `announce` handler wants
+`ProcessPorts`, and it comes up under either spawner. What each of those two paths does *not* pass on
+is the spawner's own `ProcessPorts` — a port binding emits from one node — so each builds the process
+one of its own, un-wired where the graph owns no route (#7789).
+
+**Nothing checks the pairing, so the failure is at the handler.** `SpawnOptions.services` is typed
+`Context.Context<never>`, which every context satisfies, so a row asking for a service its spawner
+does not hold spawns fine and dies on the first handler that reaches for it. Where the requirement is
+visible is the row's own type: `aiAgentProgram` is generic over the leftover requirement of the layer
+it is handed (`src/ai-agent/program.ts`), so an agent row over a layer that still needs `SpellBridge`
+says `SpellBridge` on its services rather than closing it.
 
 ## Which Cmds the kernel runs, and which the surface does
 

--- a/apps/tuval/src/ai-agent/handlers/boundary.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/boundary.unit.test.ts
@@ -9,20 +9,26 @@
  * `R`: `TuvalAiAgent` must not appear on it, because `aiAgentProgram` provides the layer itself and
  * a row still asking for the service would make every spawn need one.
  *
- * The import scan is the third: nothing under this directory names a backend, so the one generic
+ * The third reads the other half of that `R`: a layer's *own* leftover requirement does ride out
+ * onto the row, so a row built over one needing `SpellBridge` says so and a context lacking it
+ * cannot satisfy the spawn (#7951).
+ *
+ * The import scan is the fourth: nothing under this directory names a backend, so the one generic
  * handler set stays generic by construction rather than by intention.
  */
 
 import {readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
-import type {Effect, Layer, Stream} from "effect";
+import {Context, Effect, Layer, type Stream} from "effect";
 import {describe, expect, expectTypeOf, it} from "vitest";
+import {SpellBridge} from "../../commands/bridge/index.ts";
 import type {ProcessPorts} from "../../ports/index.ts";
 import type {ProcessSelf} from "../../process/self.ts";
 import type {JsonValue} from "../ports/index.ts";
 import type {AgentPortPayload} from "../ports/ports.ts";
-import type {AiAgentProgram} from "../program.ts";
-import type {TuvalAiAgent} from "../service/index.ts";
+import {type AiAgentProgram, aiAgentProgram} from "../program.ts";
+import {plainReply} from "../service/fixtures/scripts.ts";
+import {ScriptedAiAgent, type TuvalAiAgent} from "../service/index.ts";
 import type {AiAgentHandlerServices} from "./index.ts";
 
 type Primitive = string | number | boolean | null | undefined;
@@ -77,6 +83,47 @@ describe("the row's inferred requirements", () => {
 			? R
 			: never;
 		expectTypeOf<Extract<RowServices, TuvalAiAgent>>().toEqualTypeOf<never>();
+	});
+});
+
+/**
+ * The agent layer behind a `SpellBridge` it never closes — the shape a Claude row's layer has, with
+ * no Claude import. `Layer.unwrap` defers the effect, so building this runs nothing.
+ */
+const requiringLayer = Layer.unwrap(
+	Effect.map(SpellBridge, () => ScriptedAiAgent.layer(plainReply)),
+);
+
+const requiringRow = aiAgentProgram({
+	id: "requires-spell-bridge",
+	layer: requiringLayer,
+	config: {cwd: "/tmp"},
+});
+
+describe("a row over a layer that still asks for a service", () => {
+	it("carries that requirement out instead of closing it", () => {
+		expectTypeOf(requiringLayer).toEqualTypeOf<Layer.Layer<TuvalAiAgent, never, SpellBridge>>();
+		expectTypeOf(requiringRow).toEqualTypeOf<AiAgentProgram<SpellBridge>>();
+		expectTypeOf<AiAgentHandlerServices<SpellBridge>>().toEqualTypeOf<
+			ProcessSelf | ProcessPorts | SpellBridge
+		>();
+	});
+
+	it("still keeps the agent service off its own R", () => {
+		expectTypeOf<
+			Extract<AiAgentHandlerServices<SpellBridge>, TuvalAiAgent>
+		>().toEqualTypeOf<never>();
+	});
+
+	it("cannot be spawned with a context that lacks the service", () => {
+		// `Processes.spawn` erases `services` to `Context.Context<never>`, so the pairing is only
+		// checkable where the row's own `R` is still named. `Context` is contravariant in its services
+		// (`effect/Context` rc.112 declares `Context<in Services>`), so one missing a member of that
+		// union is not assignable.
+		const spawnServices = (_services: Context.Context<AiAgentHandlerServices<SpellBridge>>) => {};
+		// @ts-expect-error — `Context.empty()` names no `SpellBridge`.
+		spawnServices(Context.empty());
+		expect(typeof spawnServices).toBe("function");
 	});
 });
 

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -54,28 +54,35 @@ import {agentSlot} from "./session.ts";
 
 /** What every handler on this row may fail with, and what it needs to run. */
 export type AiAgentHandlerError = PayloadRejected;
-export type AiAgentHandlerServices = ProcessSelf | ProcessPorts;
+/**
+ * The process's own two services, plus whatever the layer under the row still asks for.
+ *
+ * `RIn` rides out rather than being closed here, so a row built over a layer that needs a kernel
+ * service says so and the spawner supplies it (#7951). A layer that needs nothing leaves `RIn`
+ * `never`, which is the union unchanged.
+ */
+export type AiAgentHandlerServices<RIn = never> = ProcessSelf | ProcessPorts | RIn;
 
-export interface AiAgentHandlerOptions extends WindowLimits {
-	readonly layer: Layer.Layer<TuvalAiAgent>;
+export interface AiAgentHandlerOptions<RIn = never> extends WindowLimits {
+	readonly layer: Layer.Layer<TuvalAiAgent, never, RIn>;
 	/** The working directory the Sub's projection falls back to when nothing is checkpointed. */
 	readonly cwd: string;
 	/** Declared data, read by `start` and the reconnect that repeats it (#7371). */
 	readonly policy?: AiAgentRetryPolicy;
 }
 
-export interface AiAgentHandlerSet {
+export interface AiAgentHandlerSet<RIn = never> {
 	readonly handlers: HostHandlers<
 		AiAgentSessionMsg,
 		AiAgentSessionCmd,
 		AiAgentHandlerError,
-		AiAgentHandlerServices
+		AiAgentHandlerServices<RIn>
 	>;
 	readonly subs: HostSubs<
 		AiAgentSessionMsg,
 		AiAgentSessionSub,
 		AiAgentHandlerError,
-		AiAgentHandlerServices
+		AiAgentHandlerServices<RIn>
 	>;
 }
 
@@ -92,7 +99,9 @@ const noSession: AgentFailure = {
 	detail: "no agent has been started in this process",
 };
 
-export const aiAgentHandlers = (options: AiAgentHandlerOptions): AiAgentHandlerSet => {
+export const aiAgentHandlers = <RIn = never>(
+	options: AiAgentHandlerOptions<RIn>,
+): AiAgentHandlerSet<RIn> => {
 	const policy = options.policy ?? defaultRetryPolicy;
 	const limits: WindowLimits = {
 		...(options.itemLimit === undefined ? {} : {itemLimit: options.itemLimit}),
@@ -118,7 +127,10 @@ export const aiAgentHandlers = (options: AiAgentHandlerOptions): AiAgentHandlerS
 	 * "rebuild the layer, then start": the transport lives in the layer's build, so resuming a
 	 * session id against the handle a disconnect already killed reaches nothing.
 	 */
-	const open = (cwd: string, resume: string | null): Effect.Effect<Follow, never, ProcessSelf> =>
+	const open = (
+		cwd: string,
+		resume: string | null,
+	): Effect.Effect<Follow, never, ProcessSelf | RIn> =>
 		Effect.gen(function* () {
 			const agent = yield* slot.rebuild;
 			const started = yield* Effect.result(
@@ -146,7 +158,7 @@ export const aiAgentHandlers = (options: AiAgentHandlerOptions): AiAgentHandlerS
 		return {kind: "page", items: planned.items, omitted: planned.omitted, next};
 	};
 
-	const handlers: AiAgentHandlerSet["handlers"] = {
+	const handlers: AiAgentHandlerSet<RIn>["handlers"] = {
 		// The one handler that calls nothing. It answers the fresh `init`'s Cmd with the Msg that
 		// opens the session, and the `start` cell does the rest — including refusing a second open.
 		// Doing the work here instead would run it inside the spawn (`host/actor.ts` awaits an init

--- a/apps/tuval/src/ai-agent/handlers/session.ts
+++ b/apps/tuval/src/ai-agent/handlers/session.ts
@@ -20,9 +20,15 @@ import {Context, Effect, Exit, Layer, Scope} from "effect";
 import {ProcessSelf} from "../../process/self.ts";
 import {TuvalAiAgent, type TuvalAiAgentApi} from "../service/index.ts";
 
-export interface AgentSlot {
-	/** Tear down this process's previous connection, then build the layer into a fresh child Scope. */
-	readonly rebuild: Effect.Effect<TuvalAiAgentApi, never, ProcessSelf>;
+export interface AgentSlot<RIn = never> {
+	/**
+	 * Tear down this process's previous connection, then build the layer into a fresh child Scope.
+	 *
+	 * `RIn` is what the layer still asks for. `Layer.buildWithScope` puts a layer's leftover
+	 * requirement on the built Effect's own `R` (`effect/Layer` rc.112), and the row carries it out
+	 * to the spawn instead of closing it here (#7951).
+	 */
+	readonly rebuild: Effect.Effect<TuvalAiAgentApi, never, ProcessSelf | RIn>;
 	/** What the last `rebuild` left for this process, or `null` when nothing has opened one yet. */
 	readonly current: Effect.Effect<TuvalAiAgentApi | null, never, ProcessSelf>;
 }
@@ -32,7 +38,9 @@ interface Connection {
 	readonly agent: TuvalAiAgentApi;
 }
 
-export const agentSlot = (layer: Layer.Layer<TuvalAiAgent>): AgentSlot => {
+export const agentSlot = <RIn = never>(
+	layer: Layer.Layer<TuvalAiAgent, never, RIn>,
+): AgentSlot<RIn> => {
 	const held = new WeakMap<Scope.Scope, Connection>();
 
 	const rebuild = Effect.gen(function* () {

--- a/apps/tuval/src/ai-agent/program.ts
+++ b/apps/tuval/src/ai-agent/program.ts
@@ -61,9 +61,14 @@ export interface AiAgentProgramConfig {
 	readonly policy?: AiAgentRetryPolicy;
 }
 
-export interface AiAgentProgramOptions {
+export interface AiAgentProgramOptions<RIn = never> {
 	readonly id: string;
-	readonly layer: Layer.Layer<TuvalAiAgent>;
+	/**
+	 * What this row runs on. A leftover requirement is not closed here: it lands on the row's own
+	 * services and is satisfied at spawn, which is how a Claude row reaches the kernel services its
+	 * bridge needs (#7951).
+	 */
+	readonly layer: Layer.Layer<TuvalAiAgent, never, RIn>;
 	readonly config: AiAgentProgramConfig;
 	readonly renderer?: RendererRef;
 	/** Merged over the row's own identity, for a caller that ships this program in its package. */
@@ -71,14 +76,14 @@ export interface AiAgentProgramOptions {
 	readonly capabilities?: ReadonlyArray<CapabilityRequest>;
 }
 
-export type AiAgentProgram = Program<
+export type AiAgentProgram<RIn = never> = Program<
 	AiAgentSessionState,
 	AiAgentSessionMsg,
 	AiAgentSessionCmd,
 	AiAgentSessionSub,
 	unknown,
 	AiAgentHandlerError,
-	AiAgentHandlerServices
+	AiAgentHandlerServices<RIn>
 >;
 
 /**
@@ -111,8 +116,10 @@ const portsOf = (): Readonly<Record<string, PortSchema>> => ({
 	[aiAgentPortNames.modeSet]: mode.inbound(),
 });
 
-export const aiAgentProgram = (options: AiAgentProgramOptions): AiAgentProgram => {
-	const {handlers, subs} = aiAgentHandlers({
+export const aiAgentProgram = <RIn = never>(
+	options: AiAgentProgramOptions<RIn>,
+): AiAgentProgram<RIn> => {
+	const {handlers, subs} = aiAgentHandlers<RIn>({
 		layer: options.layer,
 		cwd: options.config.cwd,
 		...(options.config.itemLimit === undefined ? {} : {itemLimit: options.config.itemLimit}),

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -1,6 +1,6 @@
 import {homedir} from "node:os";
 import {join} from "node:path";
-import {Context, Effect, type FileSystem, Layer} from "effect";
+import {type Context, Effect, type FileSystem, Layer} from "effect";
 import type {BindingError, BindingSource} from "./commands/bindings/index.ts";
 import {everyRegistered, SpellBridge} from "./commands/bridge/index.ts";
 import {helpSpells} from "./commands/core/index.ts";
@@ -127,9 +127,10 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	const launched = yield* launch(compiled, wiring, {services: kernel}).pipe(
 		Effect.provideContext(kernel),
 	);
-	// Boot holds no ambient per-process services of its own, so what a restored process gets is
-	// the `ProcessPorts` restore builds for it — un-wired, since the graph does not own it (#7789).
-	const restored = yield* restore(Context.empty()).pipe(Effect.provideContext(kernel));
+	// The same kernel a launched process gets, so a row's `R` is satisfied whichever spawner brings
+	// it up (#7951). What still differs is the ports: the graph does not own a restored process, so
+	// restore builds it an un-wired `ProcessPorts` of its own (#7789).
+	const restored = yield* restore(kernel).pipe(Effect.provideContext(kernel));
 	return {kernel, launched, restored} satisfies Started;
 });
 

--- a/apps/tuval/src/durability/restore-services.unit.test.ts
+++ b/apps/tuval/src/durability/restore-services.unit.test.ts
@@ -1,10 +1,15 @@
 /**
- * Restore's services half (#7789), over the two boots that make it visible: a process the picker
- * spawned is no graph node, so `restore` is the only thing that brings it back, and what it brings
- * back has to carry the `ProcessPorts` its handlers require. The fixture is the demo counter, whose
- * `announce` both requires that service and emits on it.
+ * Restore's services, over the two boots that make them visible: a process the picker spawned is no
+ * graph node, so `restore` is the only thing that brings it back, and what it brings back has to
+ * carry what its handlers require.
+ *
+ * Two halves. The `ProcessPorts` one (#7789) runs on the demo counter, whose `announce` both
+ * requires that service and emits on it. The kernel-context one (#7951) runs on a local probe row
+ * whose handler needs a kernel service: both spawners now hand over the same kernel context, so the
+ * restored process resolves it exactly as the freshly spawned one did.
  */
 
+import {defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
 import {Context, Effect, Layer, Option} from "effect";
 import {SpawnedProcesses} from "../commands/core/process.ts";
@@ -15,16 +20,30 @@ import {HandlerFailed} from "../process/errors.ts";
 import {Processes} from "../process/Processes.ts";
 import {ProcessTable} from "../process/ProcessTable.ts";
 import type {ProcessId} from "../process/process.ts";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
 import {Checkpoints} from "./Checkpoints.ts";
 import {restore} from "./restore.ts";
 import {type CheckpointStores, memoryStores} from "./stores.ts";
 
-const rows = [counterProgram({everyMs: null})];
+const counterRows = [counterProgram({everyMs: null})];
+
+/**
+ * A kernel service `restore` itself does not need — `SpellBridge` is the real one (`src/boot.ts`),
+ * and this stands in for it without dragging the spell machinery into this file. Being outside
+ * restore's own four requirements is what makes the probe below falsifiable: the context around a
+ * restore already holds those four, so a handler needing one of them would resolve it whatever
+ * `SpawnOptions.services` said.
+ */
+class ProbeMark extends Context.Service<ProbeMark, {readonly label: string}>()(
+	"tuval/test/ProbeMark",
+) {
+	static readonly layer = Layer.succeed(ProbeMark, {label: "from-the-kernel"});
+}
 
 /** One boot's kernel; the state dir is the caller's, so two of these share what was checkpointed. */
-const kernel = (stores: CheckpointStores) =>
-	SpawnedProcesses.layer({readTimeout: "1 second"}).pipe(
+const kernel = (stores: CheckpointStores, rows: ReadonlyArray<AnyProgram>) =>
+	Layer.mergeAll(SpawnedProcesses.layer({readTimeout: "1 second"}), ProbeMark.layer).pipe(
 		Layer.provideMerge(Processes.layer),
 		Layer.provideMerge(Layer.mergeAll(Registry.layer(rows), Checkpoints.layer(stores))),
 	);
@@ -34,7 +53,7 @@ const firstBoot = (stores: CheckpointStores) =>
 	Effect.gen(function* () {
 		const spawned = yield* SpawnedProcesses;
 		return yield* spawned.spawn(counterId, Option.none());
-	}).pipe(Effect.provide(kernel(stores)), Effect.orDie);
+	}).pipe(Effect.provide(kernel(stores, counterRows)), Effect.orDie);
 
 /**
  * The second boot: restore, then tick the process back. `announce` is a Cmd handler, so what its
@@ -53,7 +72,7 @@ const secondBoot = (id: ProcessId, stores: CheckpointStores) =>
 		const failure = raised as HandlerFailed;
 		const live = yield* ProcessTable.use((table) => table.list);
 		return {failure, state: handle.getState(), live: live.map((row) => row.id)};
-	}).pipe(Effect.provide(kernel(stores)), Effect.orDie);
+	}).pipe(Effect.provide(kernel(stores, counterRows)), Effect.orDie);
 
 describe("restore's services", () => {
 	it.effect("a picker-spawned process comes back with the ProcessPorts its handler requires", () =>
@@ -85,6 +104,102 @@ describe("restore's services", () => {
 			assert.strictEqual(cause.node, NodeId.make(id));
 			assert.strictEqual(cause.port, "ticks");
 			assert.include(cause.message, "ticks");
+		}),
+	);
+});
+
+const probeId = ProgramId.make("kernel-probe");
+
+interface ProbeState {
+	readonly looks: number;
+}
+type ProbeMsg = {readonly type: "look"};
+type ProbeCmd = {readonly type: "count"};
+
+/**
+ * A row whose one handler needs a kernel service and no ports — the shape a picker-opened Claude row
+ * has once its layer's own requirement rides out onto the row (#7951). It reports through a sink the
+ * test owns rather than a follow-up Msg: the host dispatches follow-ups unawaited
+ * (`src/host/actor.ts`), so a state read after `dispatch` would race one.
+ */
+const probeProgram = (sink: Array<string>): AnyProgram =>
+	({
+		id: probeId,
+		core: defineMachine<ProbeState, ProbeMsg, ProbeCmd, never, unknown>({
+			init: (loaded) => [loaded ?? {looks: 0}, []],
+			update: {look: (state) => [{looks: state.looks + 1}, [{type: "count"}]]},
+			subs: [],
+			interpret: {count: () => Promise.resolve()},
+		}),
+		ports: {},
+		handlers: {
+			count: () =>
+				Effect.gen(function* () {
+					const mark = yield* ProbeMark;
+					sink.push(mark.label);
+					return [] as ReadonlyArray<ProbeMsg>;
+				}),
+		},
+		capabilities: [],
+		renderer: {kind: "host-native", ref: "tuval/test/kernel-probe"},
+		identity: {
+			package: "@kampus/tuval",
+			program: "kernel-probe",
+			version: "1.0.0",
+			digest: "sha256:kernel-probe",
+		},
+		placement: {host: "local"},
+	}) satisfies Program<ProbeState, ProbeMsg, ProbeCmd, never, unknown, never, ProbeMark>;
+
+const probeKernel = (stores: CheckpointStores, sink: Array<string>) =>
+	Layer.build(kernel(stores, [probeProgram(sink)]));
+
+/** The picker's open path (`src/shell/picker/open.ts`): a process under no node, given the kernel. */
+const probeFirstBoot = (stores: CheckpointStores, sink: Array<string>) =>
+	Effect.gen(function* () {
+		const kernelContext = yield* probeKernel(stores, sink);
+		const handle = yield* Context.get(kernelContext, Processes).spawn(probeId, {
+			services: kernelContext,
+		});
+		yield* handle.dispatch({type: "look"});
+		return handle.id;
+	}).pipe(Effect.scoped, Effect.orDie);
+
+/**
+ * Boot's restore path (`src/boot.ts`): the same kernel context, to what the graph never planned.
+ * `restore` itself is run over its own four requirements and nothing else, so `ProbeMark` can only
+ * reach the process through `services` — which is what makes the assertion below falsifiable.
+ */
+const probeSecondBoot = (stores: CheckpointStores, sink: Array<string>) =>
+	Effect.gen(function* () {
+		const kernelContext = yield* probeKernel(stores, sink);
+		const restored = yield* restore(kernelContext).pipe(
+			Effect.provideContext(
+				Context.pick(Checkpoints, Processes, ProcessTable, Registry)(kernelContext),
+			),
+		);
+		const handle = restored[0]!;
+		yield* handle.dispatch({type: "look"});
+		return {id: handle.id, state: handle.getState()};
+	}).pipe(Effect.scoped, Effect.orDie);
+
+describe("restore's kernel context", () => {
+	it.effect("a restored picker-opened process resolves the kernel service its handler needs", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+			const fresh: Array<string> = [];
+			const id = yield* probeFirstBoot(stores, fresh);
+
+			const restored: Array<string> = [];
+			const second = yield* probeSecondBoot(stores, restored);
+
+			assert.strictEqual(second.id, id);
+			// The handler resolved the service on both boots, so what the restored process was given
+			// is what the freshly spawned one was given.
+			assert.deepStrictEqual(fresh, ["from-the-kernel"]);
+			assert.deepStrictEqual(restored, ["from-the-kernel"]);
+			// Two looks, one per boot — the second folded onto the state the first checkpointed.
+			assert.deepStrictEqual(second.state, {looks: 2});
 		}),
 	);
 });

--- a/apps/tuval/src/shell/picker/open.ts
+++ b/apps/tuval/src/shell/picker/open.ts
@@ -70,8 +70,9 @@ const open = Effect.fn("Tuval.Picker.open")(function* (
 	// `internal/effect.ts`), which is why nothing here has to name what it passes on.
 	//
 	// `ProcessPorts` is the one thing dropped rather than passed: a port binding emits from *this*
-	// node, so handing it down would send the child's payloads out of the shell's own ports. Restore
-	// drops it the same way and builds the process an un-wired one (`src/durability/restore.ts`).
+	// node, so handing it down would send the child's payloads out of the shell's own ports. Removing
+	// it leaves the child with none, where restore overrides the inherited one with an un-wired
+	// `ProcessPorts` of its own (`src/durability/restore.ts`).
 	const services = Context.omit(ProcessPorts)(yield* Effect.context());
 	const spawned = yield* Effect.result(
 		processes.spawn(programId, {parent: options.shellProcessId, services}),

--- a/apps/tuval/src/shell/picker/open.ts
+++ b/apps/tuval/src/shell/picker/open.ts
@@ -10,6 +10,7 @@
  */
 
 import {Context, Effect} from "effect";
+import {ProcessPorts} from "../../ports/ProcessPorts.ts";
 import {Processes} from "../../process/Processes.ts";
 import {ProcessTable} from "../../process/ProcessTable.ts";
 import type {ProcessId} from "../../process/process.ts";
@@ -63,12 +64,17 @@ const open = Effect.fn("Tuval.Picker.open")(function* (
 	if (row._tag === "Failure") return refuse(windowId, options, unknownProgram(programId));
 	if (!showsInAWindow(row.success)) return refuse(windowId, options, programHeadless(programId));
 
-	// Nothing ambient to give: a picker-opened process is not in the graph, so it comes back from a
-	// checkpoint with no services either, and a program the picker may open must need none
-	// (`.patterns/tuval-shell-assembly.md`). Said with `Context.empty()` rather than by omission —
-	// the silent omission is what #7789 closed.
+	// A picker-opened program may require kernel services, and this is where they arrive: the shell
+	// process's own context is the kernel one `launch` handed it (`src/boot.ts`), so the child gets
+	// the same. `Effect.context()` reads the running fiber's whole services map (`effect` rc.112,
+	// `internal/effect.ts`), which is why nothing here has to name what it passes on.
+	//
+	// `ProcessPorts` is the one thing dropped rather than passed: a port binding emits from *this*
+	// node, so handing it down would send the child's payloads out of the shell's own ports. Restore
+	// drops it the same way and builds the process an un-wired one (`src/durability/restore.ts`).
+	const services = Context.omit(ProcessPorts)(yield* Effect.context());
 	const spawned = yield* Effect.result(
-		processes.spawn(programId, {parent: options.shellProcessId, services: Context.empty()}),
+		processes.spawn(programId, {parent: options.shellProcessId, services}),
 	);
 	return spawned._tag === "Failure"
 		? refuse(windowId, options, spawnFailed(programId, spawned.failure.message))


### PR DESCRIPTION
Fixes #7951.

The ai-agent row factory closed the layer's remaining requirement, so a `claude-session` row had no
way to let its `KernelBridge` ride out to the spawn — the divergence #7510 / grill #7578 R2.2 named.
Founder ruling on the issue, 2026-09-05 ("ok go with A"): Option A together with Option B.

Four signatures now thread one requirement parameter end to end. `AiAgentProgramOptions.layer`
accepts a `Layer.Layer<TuvalAiAgent, never, RIn>`; `AiAgentHandlerServices<RIn>` is
`ProcessSelf | ProcessPorts | RIn`; `AiAgentHandlerOptions` / `AiAgentHandlerSet` carry the same
parameter; and `agentSlot`'s `rebuild` widens to `Effect<TuvalAiAgentApi, never, ProcessSelf | RIn>`,
which is where `Layer.buildWithScope` already puts a layer's leftover `RIn` in effect `4.0.0-rc.112`.
Every parameter defaults to `never`, so the Pi row, the proofs and the existing type pins are
untouched.

Both `Context.empty()` spawn sites now hand the process the kernel context. Boot's restore takes the
one `start` already holds. The picker passes on the context its own shell process was launched with,
read off the running fiber — minus that process's `ProcessPorts`, because a port binding emits from
one node and handing it down would send the child's payloads out of the shell's own ports.

`.patterns/tuval-shell-assembly.md` is rewritten to match: the heading says spawn, "a picker-openable
program must need nothing" is gone, and `src/demo/counter.ts` is now the example of a row that does
require a service and comes up under either spawner. It also states the thing the ruling's
"fails at compile time" does not cover: `SpawnOptions.services` is `Context.Context<never>`, so
nothing checks the pairing and a mismatched row still dies at its handler.

Two proofs. `apps/tuval/src/ai-agent/handlers/boundary.unit.test.ts` builds a row over a layer that
still needs `SpellBridge` and pins both directions — the row's inferred type names `SpellBridge`, and
a context lacking it fails to satisfy the row's services under a `@ts-expect-error`. The existing
probe (`TuvalAiAgent` off the row's `R`) still holds, for the requiring row as well.
`apps/tuval/src/durability/restore-services.unit.test.ts` gains a two-boot proof over a row whose
handler needs a kernel service: the restored process resolves it exactly as the freshly spawned one
did. Both halves of that proof were built falsifiable on purpose — the first draft passed with
`Context.empty()` because the dispatching fiber carried the kernel ambiently, so the fixture now
builds the kernel into a context value and dispatches from a fiber holding none of it, over a service
`restore` itself does not require.

Reviewer's first look: `apps/tuval/src/shell/picker/open.ts`, where the child's services are
assembled — that is the one place in this diff deciding what a picker-opened process may reach.

## Deviations

- **Out-of-scope change** — **Said:** #7951 asks the picker's open path to spawn with the kernel
  context instead of `Context.empty()`. **Did:** also dropped `ProcessPorts` from what it passes on.
  **Why:** the ambient context in a shell handler is the kernel context *plus* that process's own
  ports, and a port binding emits from one node — passing it down would send a picker-opened
  process's payloads out of the shell's own ports. **Disposition:** stated here, and stated at the
  line in `open.ts`.
- **Declined guidance** — **Said:** the founder's accepted trade-off reads "a missing service now
  fails at compile time rather than at open". **Did:** wrote the pattern doc to say the requirement
  is visible in the *row's* type while nothing checks it at the spawn seam, because
  `SpawnOptions.services` is `Context.Context<never>` and `Context` is contravariant, so every
  context satisfies it. **Why:** the compile-time check is real for building the row and absent for
  pairing it with a spawner; a doc claiming the stronger thing would send its reader somewhere the
  types do not go. **Disposition:** stated here; the ruling itself is unchanged and the code does
  what it says.
