### PR TITLE
chore: A Tuval program row cannot declare subFailure: Program.core is Demlik's Machine, which has no such field

### DIFF
--- a/.patterns/tuval-program-row-effects.md
+++ b/.patterns/tuval-program-row-effects.md
@@ -32,8 +32,28 @@ Scope with the failure as its Exit. Marked ids are never re-armed, `ended` ones 
 that returns normally does not restart while the state keeps desiring it. Restart is data: emit the
 Sub under a new id (an attempt counter in the id, or in the dep-keyed `deps` slice) and reconcile
 arms it fresh, which is what makes the retry replay. Catch inside the handler anything you mean to
-survive; let out only what should end the process. Declaring `subFailure` on a program row's `core`
-is not reachable yet — [#7933](https://github.com/kamp-us/phoenix/issues/7933) carries it.
+survive; let out only what should end the process.
+
+**A row declares the policy on its `core`, and the type it writes against lives in
+[`src/sub-failure.ts`](../apps/tuval/src/sub-failure.ts).** `SubFailure` and `SubFailurePolicy` sit
+there rather than in the host, so the registry can name them while still importing nothing from the
+slice that runs a program (`registry/boundary.unit.test.ts` holds that line). A row's `core` is typed
+`ProgramCore`, which is Demlik's `Machine` widened by the optional `subFailure` field:
+
+```ts
+core: {
+  init: (loaded) => [loaded ?? {armed: false, seen: []}, []],
+  update: {…},
+  subscriptions: (state) => (state.armed ? [TICKER] : []),
+  subscribe: {ticker: () => () => {}},
+  subFailure: (sub, failure) => ({type: "noted", note: `${sub.type}:${failure.reason}`}),
+} satisfies ProgramCore<State, Msg, Cmd<never>, Ticker, unknown>,
+```
+
+Write that core as a plain literal, not through `defineMachine` — the helper takes Demlik's
+`Machine`, which has no `subFailure`, and the host detects the update form when `__form` is absent.
+The policy is only consulted for a Sub the `subscriptions` aggregate declared; a dep-keyed Sub has no
+`U` value to hand it, so its failure takes the unaddressed branch.
 
 **A Sub that needs a service belongs in `subs`, not on the machine.** Demlik 0.12's own `subscribe`
 map is Promise-shaped and synchronous (`host/demlik-bridges.ts` is the whole translation), so a cell

--- a/apps/tuval/src/host/definition.ts
+++ b/apps/tuval/src/host/definition.ts
@@ -23,20 +23,11 @@ import type {
 	UpdateForm,
 } from "@demlik/tea";
 import type {Effect, Scope} from "effect";
+import type {SubFailurePolicy} from "../sub-failure.ts";
 import {ActorNameCollisionError} from "./errors.ts";
 
-/**
- * A Sub fiber's failure as the reducer sees it: plain data, so the machine stays pure. ADR 0346
- * makes the absence of a `Cause`, an `Error` instance, a Fiber or a Scope here a binding
- * constraint — the full `Cause` goes to `onError` under `"sub-fiber"` and stops there.
- */
-export interface SubFailure {
-	readonly id: string;
-	readonly type: string;
-	/** `"failure"` is the handler's error channel; `"defect"` is a throw or a die. */
-	readonly reason: "failure" | "defect";
-	readonly message: string;
-}
+/** ADR 0346's failure types live outside both slices (`src/sub-failure.ts`); the host names them here as before. */
+export type {SubFailure, SubFailurePolicy} from "../sub-failure.ts";
 
 /**
  * A Demlik `Machine` minus its Promise-shaped `interpret` and `subscribe` — the pure core plus
@@ -49,11 +40,7 @@ export interface CoreMachine<S, M extends {type: string}, C extends Cmd, U exten
 	readonly subs?: ReadonlyArray<DepKeyedSub<S, M, Ctx>>;
 	readonly identity?: Identity<S, M>;
 	readonly subscriptions?: (state: S) => readonly U[];
-	/**
-	 * What a failed Sub becomes (ADR 0346). Returning a Msg hands the failure to `update`;
-	 * returning `undefined`, or declaring nothing, ends the process instead.
-	 */
-	readonly subFailure?: (sub: U, failure: SubFailure) => M | undefined;
+	readonly subFailure?: SubFailurePolicy<M, U>;
 	readonly __form?: UpdateForm;
 }
 

--- a/apps/tuval/src/process/Processes.ts
+++ b/apps/tuval/src/process/Processes.ts
@@ -134,6 +134,11 @@ const toDefinition = (
 				Effect.provideContext(services),
 			);
 	}
+	// Kept for the erasure, not for `subFailure` — the row's own type carries the policy now
+	// (`registry/program.ts`). `AnyProgram` erases S/M/C/U to `any`, and an `any`-parameterised
+	// `update` is the union of `Reducer` and `Transitions`, which no annotation accepts as either
+	// (TS2322 without the cast). `Machine`'s Promise `subscribe` rides along because `CoreMachine`
+	// drops it and the bridge below still needs it.
 	const core = program.core as CoreMachine<unknown, Message, Cmd, Sub, unknown> & {
 		readonly subscribe?: Subscribe<Message, Sub, unknown>;
 	};

--- a/apps/tuval/src/process/row-sub-failure.unit.test.ts
+++ b/apps/tuval/src/process/row-sub-failure.unit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ADR 0346's two branches, proven through a registry row rather than a host-internal definition
+ * literal (#7933): a row's `core.subFailure` is what the host consults when the row's own Effect Sub
+ * handler fails. `host/sub-failure.unit.test.ts` covers the host in isolation; this covers the seam.
+ */
+
+import {type Cmd, type Sub, subId} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer, Schema} from "effect";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {memoryStores} from "../durability/stores.ts";
+import {type AnyProgram, type Program, type ProgramCore, ProgramId} from "../registry/program.ts";
+import {Registry} from "../registry/Registry.ts";
+import {Processes} from "./Processes.ts";
+import {ProcessTable} from "./ProcessTable.ts";
+
+class Boom extends Schema.TaggedError<Boom>()("test/Boom", {}) {}
+
+type State = {readonly armed: boolean; readonly seen: ReadonlyArray<string>};
+type Msg = {readonly type: "arm"} | {readonly type: "noted"; readonly note: string};
+type Ticker = Sub<"ticker">;
+
+const TICKER: Ticker = {id: subId("ticker"), type: "ticker"};
+
+/**
+ * A plain literal, not `defineMachine`: that helper takes Demlik's `Machine`, which has no
+ * `subFailure`. The host detects the update form when `__form` is absent (`host/definition.ts`).
+ */
+const coreWith = (
+	subFailure?: ProgramCore<State, Msg, Cmd<never>, Ticker, unknown>["subFailure"],
+): ProgramCore<State, Msg, Cmd<never>, Ticker, unknown> => ({
+	init: (loaded) => [loaded ?? {armed: false, seen: []}, []],
+	update: {
+		arm: (state: State) => [{...state, armed: true}, []],
+		noted: (state: State, msg: Extract<Msg, {type: "noted"}>) => [
+			{...state, seen: [...state.seen, msg.note]},
+			[],
+		],
+	},
+	subscriptions: (state) => (state.armed ? [TICKER] : []),
+	// Demlik's `Machine` demands a cell beside the row's `subs`; the row's Effect handler wins (#7576).
+	subscribe: {ticker: () => () => {}},
+	...(subFailure === undefined ? {} : {subFailure}),
+});
+
+const rowWith = (
+	id: string,
+	subFailure?: ProgramCore<State, Msg, Cmd<never>, Ticker, unknown>["subFailure"],
+): AnyProgram =>
+	({
+		id: ProgramId.make(id),
+		core: coreWith(subFailure),
+		ports: {},
+		handlers: {},
+		subs: {ticker: () => new Boom({})},
+		capabilities: [],
+		identity: {package: "@kampus/tuval", program: id, version: "1.0.0", digest: `sha256:${id}`},
+		placement: {host: "local"},
+	}) satisfies Program<State, Msg, Cmd<never>, Ticker, unknown, Boom, never>;
+
+const withKernel = <A, E>(
+	rows: ReadonlyArray<AnyProgram>,
+	body: Effect.Effect<A, E, Processes | ProcessTable>,
+) =>
+	body.pipe(
+		Effect.provide(
+			Processes.layer.pipe(
+				Layer.provide([Registry.layer(rows), Checkpoints.layer(memoryStores())]),
+			),
+		),
+	);
+
+/** The policy runs on a detached fiber, so a dispatch's own quiescence does not cover it. */
+const settle = Effect.sleep("20 millis");
+
+describe("a program row's Sub-failure policy", () => {
+	it.live("hands the Msg a row's subFailure returns to that process's update", () =>
+		Effect.scoped(
+			withKernel(
+				[
+					rowWith("addressed", (sub, failure) => ({
+						type: "noted",
+						note: `${sub.type}:${failure.reason}`,
+					})),
+				],
+				Effect.gen(function* () {
+					const processes = yield* Processes;
+					const handle = yield* processes.spawn(ProgramId.make("addressed"), {
+						services: Context.empty(),
+					});
+					yield* handle.dispatch({type: "arm"});
+					yield* settle;
+
+					assert.deepStrictEqual((handle.getState() as State).seen, ["ticker:failure"]);
+				}),
+			),
+		),
+	);
+
+	it.live("ends the process when a row's subFailure returns undefined", () =>
+		Effect.scoped(
+			withKernel(
+				[rowWith("unaddressed", () => undefined)],
+				Effect.gen(function* () {
+					const processes = yield* Processes;
+					const handle = yield* processes.spawn(ProgramId.make("unaddressed"), {
+						services: Context.empty(),
+					});
+					yield* handle.dispatch({type: "arm"});
+					yield* settle;
+
+					const refused = yield* Effect.flip(handle.dispatch({type: "arm"}));
+					assert.strictEqual(refused._tag, "tuval/host/ActorStoppedError");
+				}),
+			),
+		),
+	);
+});

--- a/apps/tuval/src/registry/boundary.unit.test.ts
+++ b/apps/tuval/src/registry/boundary.unit.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The boundary this slice keeps: nothing under `src/registry/` imports `src/host/`. The slice
+ * describes a program and never runs one, and the founder's 2026-09-05 ruling on #7933 kept that
+ * rule when ADR 0346's Sub-failure policy needed a type both slices could name — the type moved to
+ * `src/sub-failure.ts` rather than the import moving here.
+ */
+
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import type {Cmd, NoCtx, Sub, SubId} from "@demlik/tea";
+import {describe, expect, expectTypeOf, it} from "vitest";
+import type {SubFailure} from "../sub-failure.ts";
+import type {Program} from "./program.ts";
+
+type State = {readonly armed: boolean};
+type Msg = {readonly type: "noted"; readonly note: string};
+type Ticker = {readonly id: SubId; readonly type: "ticker"};
+type Row = Program<State, Msg, Cmd<never>, Ticker, NoCtx, never, never>;
+
+describe("registry boundary", () => {
+	it("types a row's subFailure at the shared policy, so a row may declare one", () => {
+		expectTypeOf<NonNullable<Row["core"]["subFailure"]>>().toEqualTypeOf<
+			(sub: Ticker, failure: SubFailure) => Msg | undefined
+		>();
+		// A Sub the policy is not written against is not one it can be handed.
+		expectTypeOf<NonNullable<Row["core"]["subFailure"]>>().parameter(0).not.toEqualTypeOf<Sub>();
+	});
+
+	it("nothing in src/registry/ imports from src/host/", () => {
+		const dir = import.meta.dirname;
+		const offenders = readdirSync(dir)
+			.filter((name) => name.endsWith(".ts"))
+			.flatMap((name) => {
+				const source = readFileSync(join(dir, name), "utf8");
+				const specifiers = [...source.matchAll(/from\s+"([^"]+)"/g)].map((m) => m[1] ?? "");
+				return specifiers.filter((s) => /(^|\/)host(\/|$)/.test(s)).map((s) => `${name}: ${s}`);
+			});
+		expect(offenders).toEqual([]);
+	});
+});

--- a/apps/tuval/src/registry/index.ts
+++ b/apps/tuval/src/registry/index.ts
@@ -11,6 +11,7 @@ export type {
 	PortBound,
 	PortSchema,
 	Program,
+	ProgramCore,
 	Receiver,
 	RendererKind,
 	RendererRef,

--- a/apps/tuval/src/registry/program.ts
+++ b/apps/tuval/src/registry/program.ts
@@ -8,6 +8,7 @@ import type {Cmd, Machine, Sub} from "@demlik/tea";
 import {type Effect, Schema, type Scope} from "effect";
 // Type-only, so the commands slice's runtime dependency on this file stays one-directional.
 import type {AnySpell} from "../commands/spell.ts";
+import type {SubFailurePolicy} from "../sub-failure.ts";
 
 // Type-only brand: a plain string at runtime, a distinct type to the checker (`.patterns/effect-schema-validation.md`).
 export const ProgramId = Schema.String.pipe(Schema.brand("tuval/ProgramId"));
@@ -121,6 +122,19 @@ export interface Placement {
 	readonly host: "local" | "browser";
 }
 
+/**
+ * The core a row carries: Demlik's `Machine` widened by ADR 0346's Sub-failure policy. The policy's
+ * type lives in `src/sub-failure.ts`, owned by neither slice, so a row declaring `subFailure` still
+ * imports nothing from the host that reads it.
+ */
+export type ProgramCore<
+	S,
+	M extends {readonly type: string},
+	C extends Cmd,
+	U extends Sub,
+	Ctx,
+> = Machine<S, M, C, U, Ctx> & {readonly subFailure?: SubFailurePolicy<M, U>};
+
 export interface Program<
 	S,
 	M extends {readonly type: string},
@@ -134,7 +148,7 @@ export interface Program<
 	/** What a surface calls this program. Absent means `identity.program` — read it through `programLabel`. */
 	readonly label?: string;
 	/** Private: read by the host that runs the program and by no other process. */
-	readonly core: Machine<S, M, C, U, Ctx>;
+	readonly core: ProgramCore<S, M, C, U, Ctx>;
 	/** Public: the only thing another process may see of this program. */
 	readonly ports: Readonly<Record<string, PortSchema>>;
 	/**

--- a/apps/tuval/src/sub-failure.ts
+++ b/apps/tuval/src/sub-failure.ts
@@ -1,0 +1,27 @@
+/**
+ * ADR 0346's Sub-failure policy as a type neither slice owns: `src/registry/` writes a program row
+ * against it and `src/host/` runs it. It sits here rather than in the host because the registry
+ * describes a program and never runs one, so it imports nothing from the host slice — the founder's
+ * 2026-09-05 ruling on #7933.
+ */
+
+import type {Sub} from "@demlik/tea";
+
+/**
+ * A Sub fiber's failure as the reducer sees it: plain data, so the machine stays pure. ADR 0346
+ * makes the absence of a `Cause`, an `Error` instance, a Fiber or a Scope here a binding
+ * constraint — the full `Cause` goes to `onError` under `"sub-fiber"` and stops there.
+ */
+export interface SubFailure {
+	readonly id: string;
+	readonly type: string;
+	/** `"failure"` is the handler's error channel; `"defect"` is a throw or a die. */
+	readonly reason: "failure" | "defect";
+	readonly message: string;
+}
+
+/**
+ * What a failed Sub becomes (ADR 0346). Returning a Msg hands the failure to `update`; returning
+ * `undefined`, or declaring nothing, ends the process instead.
+ */
+export type SubFailurePolicy<M, U extends Sub> = (sub: U, failure: SubFailure) => M | undefined;


### PR DESCRIPTION
ADR 0346's Sub-failure policy was live in the Tuval host but unreachable from a program row: the row's `core` is Demlik's `Machine`, which has no `subFailure`, and the registry slice imports nothing from the host where `SubFailure` was declared. The founder ruled on 2026-09-05 that the type moves to a module neither slice owns and the registry's no-host-imports rule stands.

- `apps/tuval/src/sub-failure.ts` is new and type-only: it declares `SubFailure` and `SubFailurePolicy<M, U>`. `host/definition.ts` now takes both from there and re-exports them, so `SubFailure` stays importable from `host/definition.ts` and `host/index.ts` exactly as before.
- `registry/program.ts` types `core` as a new exported `ProgramCore<S, M, C, U, Ctx>` — Demlik's `Machine` widened by the optional `subFailure`. Its only new import is type-only to `../sub-failure.ts`; nothing reaches the host, and the slice docblock is unchanged.
- `registry/boundary.unit.test.ts` is new, in the shape of `ports/boundary.unit.test.ts`: a type-level assertion that a row's `subFailure` is the shared policy over that row's own Msg and Sub, plus a directory scan that reds on any `.ts` in `src/registry/` importing the host. Flip-verified by adding a throwaway file importing `../host/definition.ts` — the scan named it and the test failed.
- `process/row-sub-failure.unit.test.ts` is new: it builds two rows through `registry/program.ts`, spawns each through `Processes`, and asserts both ADR 0346 branches — the Msg a row's policy returns reaches `update`, and a row returning `undefined` ends the process (the next dispatch fails `ActorStoppedError`).
- `toDefinition`'s cast in `process/Processes.ts` is kept, with the reason now stated at the cast. I checked it empirically by replacing the cast with an annotation: `tsc` fails TS2322 because `AnyProgram` erases the row's parameters to `any`, and an `any`-parameterised `update` is the `Reducer | Transitions` union, which is assignable to neither arm. The cast was never about `subFailure`.
- `.patterns/tuval-program-row-effects.md`'s "not reachable yet" sentence is replaced by where the type lives, a worked `core` literal declaring the policy, and the two things a row author will otherwise get wrong: `defineMachine` cannot carry `subFailure` (it takes Demlik's `Machine`), so write the core as a plain literal; and the policy is only consulted for a Sub the `subscriptions` aggregate declared, since a dep-keyed Sub has no `U` value to hand it (`host/actor.ts`, `keyedSite`).

`pnpm typecheck` and `pnpm lint:worktree` are green in this tree, and the full `apps/tuval` suite passes (168 files, 1308 tests) — including `page/boundary.unit.test.ts`, which the new shared module stays clear of by being type-only.

Fixes #7933

## Deviations

None.
