### PR TITLE
fix: The Claude layer's session phase comes only from the per-turn init frame, so a turn never ends at ready

### DIFF
--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -321,7 +321,16 @@ const make = (
 					const step = toAgentEvents(pulled.message, mapping, {at: Date.now()});
 					mapping = step.mapping;
 					yield* emit(open, step.events);
-					if (pulled.message.type === "result") current.state.settled = true;
+					if (pulled.message.type === "result") {
+						current.state.settled = true;
+						// A turn's end is the layer's to narrate, and `result` is where it lands:
+						// `SDKResultMessage` is "the outcome of a turn … treat it as the turn-complete
+						// signal" (`sdk.d.ts`). The discriminant is the whole test, so every
+						// `SDKResultError` subtype ends the turn exactly as a success does — a failed
+						// turn that stayed at `prompting` would refuse every later prompt (#7963).
+						// After `step.events`, so the turn's own spend or failure line precedes it.
+						yield* emit(open, [{kind: "phase", phase: "ready"}]);
+					}
 				}
 			});
 

--- a/apps/tuval/src/claude/agent/events.unit.test.ts
+++ b/apps/tuval/src/claude/agent/events.unit.test.ts
@@ -13,10 +13,10 @@ import {CWD, MODES, messages, OPENED_EVENTS, on, settled} from "./fixtures/harne
 
 /**
  * The tool turn's four frames after `init`, folded: the call opens `running`, its answer settles it
- * `ok`, the reply lands, and the result reports spend. The first assistant frame carries only the
- * `tool_use` block, so it earns no text item of its own.
+ * `ok`, the reply lands, and the result reports spend and then ends the turn. The first assistant
+ * frame carries only the `tool_use` block, so it earns no text item of its own.
  */
-const TURN_EVENTS = 4;
+const TURN_EVENTS = 5;
 
 describe("events over a captured tool turn", () => {
 	it.effect("carries the turn's items and its usage in one ordered stream", () =>
@@ -28,9 +28,9 @@ describe("events over a captured tool turn", () => {
 				);
 				assert.deepStrictEqual(
 					events.map((event) => event.kind),
-					// The start's own three, then the first turn's `init` — its ready phase and the
-					// model it names — and then the turn itself.
-					["phase", "phase", "mode", "phase", "usage", "item", "item", "item", "usage"],
+					// The start's own three, then the first turn's `init` — the model it names, and
+					// nothing else — then the turn, which ends on the `ready` its `result` carries.
+					["phase", "phase", "mode", "usage", "item", "item", "item", "usage", "phase"],
 				);
 			}),
 		),
@@ -64,7 +64,8 @@ describe("events over a captured tool turn", () => {
 				const events = yield* Stream.runCollect(
 					Stream.take(agent.events, OPENED_EVENTS + TURN_EVENTS),
 				);
-				const usage = events[OPENED_EVENTS + TURN_EVENTS - 1];
+				// Second to last: the turn's own `ready` is the last event on it.
+				const usage = events[OPENED_EVENTS + TURN_EVENTS - 2];
 				assert.strictEqual(usage?.kind, "usage");
 				assert.strictEqual(usage?.kind === "usage" ? usage.model : "", "claude-fable-5-1");
 			}),
@@ -101,12 +102,12 @@ describe("every kind rides the one stream", () => {
 						"phase",
 						"phase",
 						"mode",
+						"usage",
+						"item",
+						"item",
+						"item",
+						"usage",
 						"phase",
-						"usage",
-						"item",
-						"item",
-						"item",
-						"usage",
 						"permission",
 						"permission-resolved",
 						"mode",

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -29,13 +29,14 @@ export const MODES: ReadonlyArray<Mode> = [
 export const START_EVENTS = 3;
 
 /**
- * Those three plus the `system`/`init` frame's own two — its ready phase and the model it names.
+ * Those three plus the one event the `system`/`init` frame carries: the model it names.
  *
- * The two are no longer part of `start`: the frame belongs to the first turn (`sdk.d.ts`), so on a
- * scripted run whose `opening` begins with `init` the pump emits them just after, and a test that
- * wants the turn behind them counts from here.
+ * That one is not part of `start` — the frame belongs to the first turn (`sdk.d.ts`), so on a
+ * scripted run whose `opening` begins with `init` the pump emits it just after, and a test that
+ * wants the turn behind it counts from here. `init` carries no phase: a turn's `ready` rides its
+ * `result` instead (#7963).
  */
-export const OPENED_EVENTS = START_EVENTS + 2;
+export const OPENED_EVENTS = START_EVENTS + 1;
 
 export const messages = (name: Parameters<typeof loadFixture>[0]): ReadonlyArray<SDKMessage> =>
 	loadFixture(name) as ReadonlyArray<SDKMessage>;

--- a/apps/tuval/src/claude/agent/phases.unit.test.ts
+++ b/apps/tuval/src/claude/agent/phases.unit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Where a Claude turn begins and ends, as the layer narrates it (#7963).
+ *
+ * `SDKResultMessage` is "the outcome of a turn … treat it as the turn-complete signal"
+ * (`sdk.d.ts` at the `0.3.259` pin `sdk.ts` records), and `SDKSystemMessage`/`init` is "session
+ * metadata the CLI emits at the start of each turn" — so `result` is the turn's end and `init` is
+ * not. Every case replays a golden fixture through the scripted SDK, so nothing calls a model
+ * (`../history/fixtures/PROVENANCE.md`).
+ *
+ * The last two fold what the layer emitted through the real core, because the phase's whole job is
+ * the `prompt` guard in `../../ai-agent/core/machine.ts`: a stream that reads right and still leaves
+ * the core refusing prompts has proved nothing.
+ */
+
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {applyCellChecked} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Stream} from "effect";
+import {
+	type AiAgentSessionCmd,
+	type AiAgentSessionMsg,
+	type AiAgentSessionState,
+	aiAgentSessionMachine,
+	initialState,
+} from "../../ai-agent/core/index.ts";
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {CWD, message, messages, on, SESSION_ID, START_EVENTS} from "./fixtures/harness.ts";
+
+/**
+ * Start, let the open's own three events go by, prompt, and collect the turn that answers.
+ *
+ * `deferOpening` withholds every frame until the prompt lands, which is the real CLI's shape and
+ * the one that puts `init` inside the turn rather than ahead of it.
+ */
+const promptedTurn = (opening: ReadonlyArray<SDKMessage>, count: number) =>
+	on({opening, deferOpening: true}, (agent) =>
+		Effect.gen(function* () {
+			yield* agent.start({cwd: CWD});
+			yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+			yield* agent.prompt("hello");
+			return [...(yield* Stream.runCollect(Stream.take(agent.events, count)))];
+		}),
+	);
+
+/**
+ * `assistant-turn.json` is init, one assistant frame and one `success` result — four events out:
+ * the model init names, the reply, the turn's spend, and the `ready` that ends it.
+ */
+const ASSISTANT_TURN_EVENTS = 4;
+
+const machine = aiAgentSessionMachine({cwd: CWD});
+
+const apply = (
+	state: AiAgentSessionState,
+	msg: AiAgentSessionMsg,
+): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
+
+const opened: AiAgentSessionState = {...initialState(CWD), phase: "ready", sessionId: SESSION_ID};
+
+const fold = (state: AiAgentSessionState, events: ReadonlyArray<AgentEvent>): AiAgentSessionState =>
+	events.reduce(
+		(carried, event) => apply(carried, {type: "event", sessionId: SESSION_ID, event})[0],
+		state,
+	);
+
+describe("a turn ends on its result", () => {
+	it.effect("emits exactly one ready, after the result and nowhere before it", () =>
+		Effect.gen(function* () {
+			const events = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
+			assert.deepStrictEqual(
+				events.map((event) => event.kind),
+				["usage", "item", "usage", "phase"],
+			);
+			assert.deepStrictEqual(
+				events.filter((event) => event.kind === "phase"),
+				[{kind: "phase", phase: "ready"}],
+			);
+		}),
+	);
+
+	it.effect("ends a failing turn the same way, so no error subtype wedges the session", () =>
+		Effect.gen(function* () {
+			// `error_max_turns`, one of `SDKResultError`'s four subtypes: a system line for the
+			// failure, then the same `ready` a success carries.
+			const events = yield* promptedTurn([message("error-result")], 2);
+			assert.deepStrictEqual(
+				events.map((event) => event.kind),
+				["item", "phase"],
+			);
+			assert.deepStrictEqual(events[1], {kind: "phase", phase: "ready"});
+		}),
+	);
+});
+
+describe("the core over what the layer emitted", () => {
+	// `prompting` is the whole claim the window's stop control and its Escape branch read:
+	// `isWorking` is `phase === "prompting"`, and that it is true of that phase alone is pinned in
+	// `../../shell/chat/phase.unit.test.ts`. It is not called here because the browser chat slice is
+	// excluded from this project's lens (`apps/tuval/tsconfig.json`).
+	it.effect("keeps the session prompting for the whole turn, so the window reads working", () =>
+		Effect.gen(function* () {
+			const events = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
+			const [prompting] = apply(opened, {type: "prompt", text: "hello", key: "k1"});
+			// Every event but the last, which is the turn's own end.
+			const running = fold(prompting, events.slice(0, -1));
+			assert.strictEqual(running.phase, "prompting");
+		}),
+	);
+
+	it.effect("admits a second prompt once the turn's result has landed", () =>
+		Effect.gen(function* () {
+			const events = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
+			const [prompting] = apply(opened, {type: "prompt", text: "hello", key: "k1"});
+			const settled = fold(prompting, events);
+			assert.strictEqual(settled.phase, "ready");
+			const [next, cmds] = apply(settled, {type: "prompt", text: "and again", key: "k2"});
+			assert.isNull(next.failure);
+			assert.deepStrictEqual(cmds, [{type: "aiAgent.prompt", text: "and again", key: "k2"}]);
+		}),
+	);
+});

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -188,8 +188,7 @@ describe("start against a CLI that says nothing until the first prompt", () => {
 						yield* agent.start({cwd: CWD});
 						yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
 						yield* agent.prompt("hello");
-						assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, 2)), [
-							{kind: "phase", phase: "ready"},
+						assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, 1)), [
 							{
 								kind: "usage",
 								model: "claude-fable-5-1",

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -37,10 +37,9 @@ const items = (events: ReadonlyArray<AgentEvent>) =>
 	events.flatMap((event) => (event.kind === "item" ? [event.item] : []));
 
 describe("toAgentEvents over a captured init", () => {
-	it("reports the ready phase and the model the session named", () => {
+	it("reports the model the session named, and no phase", () => {
 		const {events, mapping} = run([message("init")]);
 		expect(events).toEqual([
-			{kind: "phase", phase: "ready"},
 			{kind: "usage", model: "claude-fable-5-1", inputTokens: 0, outputTokens: 0, cost: 0},
 		]);
 		expect(mapping.model).toBe("claude-fable-5-1");
@@ -49,9 +48,24 @@ describe("toAgentEvents over a captured init", () => {
 	it("reads a resumed session's init the same way", () => {
 		const {events} = run([message("resumed-init")]);
 		expect(events).toEqual([
-			{kind: "phase", phase: "ready"},
 			{kind: "usage", model: "claude-fable-5-1", inputTokens: 0, outputTokens: 0, cost: 0},
 		]);
+	});
+});
+
+describe("the mapping narrates no phase at all", () => {
+	// A phase is a session's, and this file reads one message at a time: `init` leads a turn and
+	// `result` ends one, so a phase read out of either here would fire on a history replay too
+	// (#7963). The layer says where a turn ends; `phases.unit.test.ts` is where that is proven.
+	it("emits no phase event over any captured stream", () => {
+		const streams = [
+			run([message("init")]),
+			run(messages("assistant-turn")),
+			run(messages("tool-turn")),
+			run([message("error-result")]),
+			run([message("permission-denied")]),
+		];
+		expect(streams.flatMap(({events}) => events.filter((one) => one.kind === "phase"))).toEqual([]);
 	});
 });
 

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -13,7 +13,7 @@
  * `init`.
  */
 
-import type {AgentEvent, Phase} from "../../ai-agent/events.ts";
+import type {AgentEvent} from "../../ai-agent/events.ts";
 import {boundToolOutput} from "../../ai-agent/history/index.ts";
 import type {ItemId, JsonValue, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {isRecord, outputOf, textOf, timestampOf, toolResultsOf, toolUsesOf} from "./blocks.ts";
@@ -239,17 +239,20 @@ export const resultEvents = (
 	};
 };
 
-/** `init` is where a session says which model it is, and the only place it ever says so. */
+/**
+ * `init` is where a session says which model it is, and the only place it ever says so.
+ *
+ * It carries no phase. `init` is "session metadata the CLI emits at the start of each turn"
+ * (`sdk.d.ts`), so a `ready` here fires mid-turn and never at a turn's end — the binding that left
+ * the core at `prompting` after every reply (#7963). Where a turn ends is the layer's to say, off
+ * the `result` message the SDK calls the turn-complete signal.
+ */
 export const initEvents = (message: unknown, mapping: Mapping): MappingStep => {
 	if (!isRecord(message)) return skipMessage(mapping);
 	const model = typeof message.model === "string" ? message.model : mapping.model;
-	const ready: Phase = "ready";
 	return {
 		mapping: {...mapping, model},
-		events: [
-			{kind: "phase", phase: ready},
-			{kind: "usage", model, inputTokens: 0, outputTokens: 0, cost: 0},
-		],
+		events: [{kind: "usage", model, inputTokens: 0, outputTokens: 0, cost: 0}],
 	};
 };
 

--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -326,10 +326,12 @@ const attachSession = Effect.fn("claudeVertical.attachSession")(function* (
 /**
  * One prompt and the one reply it must produce.
  *
- * The wait is on the reply *count* rather than on the phase, because a turn can end with the core
- * still at `prompting`, and on the count rather than on the reply's text, because a boot's script
- * starts at the head — the same text can legitimately appear twice in one transcript across a
- * restart, and a text match would have passed on the older copy.
+ * The wait is on the reply *count* rather than on the phase, because the phase this turn ends at is
+ * the one it started from: a `ready` seen while waiting can be the session's own pre-prompt frame,
+ * and the count moves only once the turn has produced something. It is on the count rather than on
+ * the reply's text because a boot's script starts at the head — the same text can legitimately
+ * appear twice in one transcript across a restart, and a text match would have passed on the older
+ * copy.
  */
 const chat = Effect.fn("claudeVertical.chat")(function* (
 	session: Session,


### PR DESCRIPTION
The Claude layer narrated its session phase off the per-turn `init` frame, which is the wrong
carrier in both directions: `init` fires mid-turn, so a running turn reported `Ready.` and the
window's stop control and Escape-to-interrupt were wrong for the whole turn; and `init` never fires
at a turn's end, so a session that got no fresh `init` sat at `prompting` after the reply already
landed, with `machine.ts`'s `prompt` guard refusing every further message.

**The fix moves the turn-end phase to where the SDK says a turn ends.** `sdk.d.ts` at
`@anthropic-ai/claude-agent-sdk@0.3.259` — the pin recorded as `SDK_VERSION` in
`apps/tuval/src/claude/agent/sdk.ts` — documents `SDKResultMessage` as *"The outcome of a turn. The
CLI emits exactly one result message per turn, after that turn's assistant, user and stream_event
messages; treat it as the turn-complete signal"*, and `SDKSystemMessage`/`init` as *"Session
metadata the CLI emits at the start of each turn"*. So:

- `drive` in `ClaudeAiAgent.ts` emits `{kind: "phase", phase: "ready"}` on the `result` message,
  onto the same queue and after that turn's own item and usage events. The test is the discriminant
  `pulled.message.type === "result"`, so every `SDKResultError` subtype (`error_during_execution`,
  `error_max_turns`, `error_max_budget_usd`, `error_max_structured_output_retries`) ends a turn
  exactly as a `success` does — a subtype list would be a thing to get wrong later.
- `initEvents` in `history/map.ts` emits no `phase`. It still records the model on the `Mapping` and
  emits its `usage` event, since `init` is the only place a session names its model.

That split is also the cleaner boundary: the history mapping speaks transcript, the layer speaks
session lifetime. `toAgentEvents` now emits no `phase` at all, which a new case in
`history/events.unit.test.ts` pins over every captured stream.

`start`'s narration is untouched — an open still reaches `ready` off the SDK handshake with no
prompt sent (#7962). `OPENED_EVENTS` drops to `START_EVENTS + 1` because `init` now carries one
event rather than two, with its docblock re-grounded on what is actually emitted.

New proof in `apps/tuval/src/claude/agent/phases.unit.test.ts`, all on the scripted SDK with golden
fixtures and zero model spend: `assistant-turn.json` through a prompt yields exactly one `ready`,
positioned after the turn's `result` and nowhere between the prompt and it, asserted on the whole
event sequence; `error-result.json` yields the same `ready` after its failure line; and the events
the layer actually emitted are folded through the real `aiAgentSessionMachine` to show the session
holds `prompting` for the turn and admits a second `prompt` once the `result` has landed.

Patterns followed: `.patterns/golden-real-payload-fixtures.md` (every fixture is a captured run, per
`history/fixtures/PROVENANCE.md`) and `.patterns/effect-testing.md`'s unit tier. No CI job added or
changed reaches the real Claude CLI; that check remains the founder's own `proof:claude-real` run
under #7625's criterion 7.

Follow-up filed while building: https://github.com/kamp-us/phoenix/issues/7968 — the contract that a
layer owes a phase event at a turn's end is written down nowhere, which is why this layer and the Pi
layer (#7897) broke it independently.

Fixes #7963

## Deviations

- **Scope narrowing** — **Said:** criterion 7 asks the proof to show the folded phase is `prompting`
  mid-turn *and* that `isWorking` (`apps/tuval/src/shell/chat/phase.ts`) reads true for it. **Did:**
  `phases.unit.test.ts` asserts the folded phase is `prompting` and does not call `isWorking`.
  **Why:** `src/shell/chat` is excluded from the Node lens in `apps/tuval/tsconfig.json`, so a test
  under `src/claude/agent` that imports it is a `TS6307` typecheck error. `isWorking` is
  `phase === "prompting"`, and that it is true of that phase alone is already pinned in
  `src/shell/chat/phase.unit.test.ts` under the lens that owns it. **Disposition:** stated here, and
  the test carries a comment naming the lens and the pin it defers to.
- **Out-of-scope change** — **Said:** #7963 names the Claude layer and its own tests. **Did:** also
  updated `apps/tuval/src/claude/agent/start.unit.test.ts`, `events.unit.test.ts` and
  `history/events.unit.test.ts` expectations. **Why:** each asserted the exact event sequence the
  `init` frame produced, so every one of them reds on the phase this PR removes — not fixing them is
  not an option. **Disposition:** stated here; no assertion was weakened, and each still pins the
  full sequence.
