### PR TITLE
fix: One stray keystroke kills an agent window: forwardKey sends key to a machine with no key cell and the actor closes its gate

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -90,9 +90,21 @@ kernel sent it, and no other (ADR 0353). Three consequences a caller must hold:
 ## `forwardKey` delivers a program's own `key` Msg
 
 With the prefix unarmed every key belongs to the focused window, and the core answers with a
-`forwardKey` Cmd naming the window's process. The host dispatches `{type: "key", key}` into it. A
-program that wants the keyboard declares a `key` cell; one that does not simply drops the key at
+`forwardKey` Cmd naming the window's process. The host dispatches `{type: "key", key}` into it.
+
+**A program is only sent a key it asked for, and asking is a row field.** `Program.takesKeys`
+(`src/registry/program.ts`) is `true` or absent; the picker reads it off the row it just resolved
+and the `window.bind` Msg carries it, so the window node holds it beside `processId` and the core's
+`keys.press` cell emits `forwardKey` only for a window that declared one. A program with no `key`
+cell — every agent session — is therefore never sent a key at all (#7973). Best-effort delivery
+stays underneath that: a process that stopped between the Cmd and the dispatch drops the key at
 debug, because a keystroke is not worth ending a desk over and the shell's error channel is `never`.
+
+The declaration is the shell's half. The host's half is that a wire `Msg` with no update cell fails
+that one dispatch as `MsgNotAcceptedError` (`src/host/errors.ts`) instead of reaching supervision as
+`UserCodeThrew` — Demlik throws `NoCellError` before any of the machine's own code runs, so it says
+the program does not take the Msg, never that the program is faulty. Without that split one stray
+key closed the process gate under the `stop` default and every later prompt was refused.
 
 **One keystroke has two deliveries, and only one of them is the Cmd.** Beside the kernel's dispatch
 into the process, the page hands the same key to that window's React renderer — off its own

--- a/apps/tuval/src/demo/counter.ts
+++ b/apps/tuval/src/demo/counter.ts
@@ -63,6 +63,7 @@ export const counterProgram = ({everyMs}: CounterOptions): AnyProgram =>
 				}),
 		},
 		capabilities: [],
+		takesKeys: true,
 		// A row with no renderer is headless and can never bind a window (`../shell/picker/entries.ts`),
 		// so a demo program the shell opens declares one. The reference is what the page's own table
 		// answers by name (`../page/renderers.tsx`); nothing here names React.

--- a/apps/tuval/src/demo/log.ts
+++ b/apps/tuval/src/demo/log.ts
@@ -70,6 +70,7 @@ export const logProgram = ({write}: LogOptions): AnyProgram =>
 			print: (cmd: Print) => Effect.as(write(cmd.line), [] as ReadonlyArray<LogMsg>),
 		},
 		capabilities: [],
+		takesKeys: true,
 		// Headless rows never bind a window (`../shell/picker/entries.ts`); this reference is the name
 		// the page's renderer table answers to, as `./counter.ts` says.
 		renderer: {kind: "host-native", ref: "tuval/demo/log"} satisfies RendererRef,

--- a/apps/tuval/src/host/actor.ts
+++ b/apps/tuval/src/host/actor.ts
@@ -13,6 +13,7 @@ import {
 	type Cmd,
 	DispatchDiscardedError,
 	IdentityDropNotice,
+	NoCellError,
 	RuntimeDiscardedError,
 	RuntimeDiscardNotice,
 	type Store,
@@ -44,9 +45,14 @@ import type {
 	SubscribeHandlers,
 } from "./definition.ts";
 import {subDisposerBridge} from "./demlik-bridges.ts";
-import {ActorStoppedError, StoreError, UserCodeThrew} from "./errors.ts";
+import {ActorStoppedError, MsgNotAcceptedError, StoreError, UserCodeThrew} from "./errors.ts";
 
-export type DispatchError<E> = E | StoreError | DispatchDiscardedError | ActorStoppedError;
+export type DispatchError<E> =
+	| E
+	| StoreError
+	| DispatchDiscardedError
+	| ActorStoppedError
+	| MsgNotAcceptedError;
 
 export interface ActorHandle<S, M extends {type: string}, E = never> {
 	/** Apply `msg`, then wait for every transitive follow-up — Demlik's `dispatch`. */
@@ -428,12 +434,20 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 				const [next, cmds] = applyCellChecked<S, M, C>(machine, state, msg);
 				return {kind: "applied", next, cmds};
 			},
-			catch: (cause) => new UserCodeThrew({cause}),
+			// Demlik throws `NoCellError` before any of the machine's own code runs, so it says the
+			// program does not take this Msg — never that the program is faulty. Supervision must not
+			// see it: one stray wire Msg would otherwise close the gate under the `stop` default (#7973).
+			catch: (cause): UserCodeThrew | MsgNotAcceptedError =>
+				cause instanceof NoCellError
+					? new MsgNotAcceptedError({msgType: cause.msgType, stateName: cause.stateName})
+					: new UserCodeThrew({cause}),
 		});
 
 	const step = Effect.fn("Tuval.host.step")(function* (msg: M) {
 		const reduced = yield* reduce(msg).pipe(Effect.result);
 		if (Result.isFailure(reduced)) {
+			if (reduced.failure instanceof MsgNotAcceptedError)
+				return yield* Effect.fail(reduced.failure);
 			const error = reduced.failure.cause;
 			yield* report(error, "reduce");
 			switch (supervision.strategy) {

--- a/apps/tuval/src/host/actor.unit.test.ts
+++ b/apps/tuval/src/host/actor.unit.test.ts
@@ -4,7 +4,7 @@ import {Context, Effect, Exit, Fiber, Schema, type Scope} from "effect";
 import {expectTypeOf} from "vitest";
 import {type ActorHandle, layer, make} from "./actor.ts";
 import {type CoreMachine, defineActor} from "./definition.ts";
-import type {ActorStoppedError, StoreError} from "./errors.ts";
+import type {ActorStoppedError, MsgNotAcceptedError, StoreError} from "./errors.ts";
 import {counterMachine, type Msg, recordingStore, type State} from "./fixtures.ts";
 
 describe("host actor", () => {
@@ -120,6 +120,57 @@ describe("host actor", () => {
 		}),
 	);
 
+	it.effect("refuses a Msg with no cell and leaves the process open (#7973)", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				type S = {readonly count: number};
+				// The wire shape a forwarded key arrives in. `Reducer` demands a cell per member of a
+				// closed `M`, so the machine that meets this bug is one whose Msg type is open — which
+				// is what a process handle erased to `AnyProgram` hands the shell's `forwardKey`.
+				type M = {readonly type: string; readonly key?: string};
+				const machine: CoreMachine<S, M, never, never, NoCtx> = {
+					init: () => [{count: 0}, []],
+					update: {tick: (state) => [{count: state.count + 1}, []]},
+				};
+				const actor = yield* make(
+					defineActor({name: "test/no-cell", machine, interpret: {}, subscribe: {}}),
+				);
+
+				const refused = yield* actor.dispatch({type: "key", key: "x"}).pipe(Effect.flip);
+				assert.strictEqual(refused._tag, "tuval/host/MsgNotAcceptedError");
+
+				yield* actor.dispatch({type: "tick"});
+				assert.deepStrictEqual(actor.getState(), {count: 1});
+			}),
+		),
+	);
+
+	it.effect("a cell that genuinely throws still closes the gate under the stop default", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				type S = {readonly count: number};
+				type M = {readonly type: "tick"};
+				const machine: CoreMachine<S, M, never, never, NoCtx> = {
+					init: () => [{count: 0}, []],
+					update: {
+						tick: () => {
+							throw new Error("boom");
+						},
+					},
+				};
+				const actor = yield* make(
+					defineActor({name: "test/throwing-cell", machine, interpret: {}, subscribe: {}}),
+				);
+
+				const died = yield* Effect.exit(actor.dispatch({type: "tick"}));
+				assert.isTrue(Exit.isFailure(died));
+
+				const refused = yield* actor.dispatch({type: "tick"}).pipe(Effect.flip);
+				assert.strictEqual(refused._tag, "tuval/host/ActorStoppedError");
+			}),
+		),
+	);
+
 	it.effect("keeps every save snapshot JSON-round-trippable", () =>
 		Effect.gen(function* () {
 			const saves: State[] = [];
@@ -170,7 +221,7 @@ describe("host actor", () => {
 		expectTypeOf<Effect.Success<typeof built>>().toEqualTypeOf<ActorHandle<State, Msg, Boom>>();
 		type Dispatched = ReturnType<Effect.Success<typeof built>["dispatch"]>;
 		expectTypeOf<Effect.Error<Dispatched>>().toEqualTypeOf<
-			Boom | StoreError | DispatchDiscardedError | ActorStoppedError
+			Boom | StoreError | DispatchDiscardedError | ActorStoppedError | MsgNotAcceptedError
 		>();
 		expectTypeOf<Effect.Services<Dispatched>>().toEqualTypeOf<never>();
 	});

--- a/apps/tuval/src/host/errors.ts
+++ b/apps/tuval/src/host/errors.ts
@@ -11,6 +11,20 @@ export class ActorStoppedError extends Schema.TaggedError<ActorStoppedError>()(
 	}
 }
 
+/**
+ * The machine has no update cell for this Msg in its current state — Demlik's own `NoCellError`
+ * (`@demlik/tea` 0.12), typed. A Msg a program never wrote a cell for is the sender's mistake, not
+ * a fault in the program, so it fails that one dispatch and leaves the process open (#7973).
+ */
+export class MsgNotAcceptedError extends Schema.TaggedError<MsgNotAcceptedError>()(
+	"tuval/host/MsgNotAcceptedError",
+	{msgType: Schema.String, stateName: Schema.String},
+) {
+	override get message(): string {
+		return `program has no update cell for Msg "${this.msgType}" in state "${this.stateName}"`;
+	}
+}
+
 /** A `Store` rejected. Demlik lets the rejection propagate to the dispatcher; here it is typed. */
 export class StoreError extends Schema.TaggedError<StoreError>()("tuval/host/StoreError", {
 	operation: Schema.Literals(["load", "save"]),

--- a/apps/tuval/src/registry/program.ts
+++ b/apps/tuval/src/registry/program.ts
@@ -179,6 +179,14 @@ export interface Program<
 	 */
 	readonly resume?: (state: S) => ReadonlyArray<M>;
 	readonly capabilities: ReadonlyArray<CapabilityRequest>;
+	/**
+	 * The program takes keys the shell forwards from its focused window, as its own `key` Msg. Only
+	 * `true` or absent: a row that never asked for keys is never sent one, so a keystroke landing on
+	 * a window outside its composer cannot reach a program with no cell for it (#7973). The row
+	 * carries the declaration and nothing else, as it does for `renderer` — what a forwarded key
+	 * becomes is the program's own Msg, and the shell never reads it.
+	 */
+	readonly takesKeys?: true;
 	readonly renderer?: RendererRef;
 	/**
 	 * The two desk-level renderers, both optional: what this program shows in the desk inspector,
@@ -199,6 +207,9 @@ export interface Program<
  * holds programs of every shape. The host recovers the concrete types when it runs one.
  */
 export type AnyProgram = Program<any, any, any, any, any, any, any>;
+
+/** Does the shell forward a key to a window bound to this program? Declared on the row, or not at all. */
+export const takesForwardedKeys = (row: AnyProgram): boolean => row.takesKeys === true;
 
 /** The row's provenance as a refusal names it: `package/program@version (digest)`. */
 export const provenanceOf = (row: AnyProgram): string =>

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -123,6 +123,17 @@ const useProcessView = (host: ChatWindowHost): ProcessView<AiAgentSessionState> 
 	return view;
 };
 
+/**
+ * A bare printable character typed on the transcript belongs to nobody: the scroll region has no
+ * text to take it, and letting it reach the desk's one keyboard listener either arms the prefix or
+ * forwards it into the window's process (#7973). Modified keys are somebody else's — the desk
+ * prefix is Ctrl-keyed and Alt+R is the window's — and so is every named key the region scrolls on.
+ */
+const swallowBareCharacter = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+	const bare = !event.ctrlKey && !event.metaKey && !event.altKey && [...event.key].length === 1;
+	if (bare) event.stopPropagation();
+};
+
 const Placeholder = ({children}: {readonly children: ReactNode}): ReactElement => (
 	<p className="tuval-chat-placeholder" role="status">
 		{children}
@@ -481,6 +492,7 @@ function ChatWindow({
 				ref={scrollRef}
 				className="tuval-chat-transcript"
 				onScroll={onScroll}
+				onKeyDown={swallowBareCharacter}
 				role="log"
 				aria-label="Transcript"
 				// The scroll container is the only way to older turns on a plain transcript, so a

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -14,7 +14,7 @@
 import {act, fireEvent, render, screen, waitFor, within} from "@testing-library/react";
 import {Effect, Stream} from "effect";
 import type {ReactElement} from "react";
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it} from "vitest";
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
 import {phases} from "../../ai-agent/core/state.ts";
 import {ItemId} from "../../ai-agent/ports/index.ts";
@@ -249,6 +249,45 @@ describe("the composer", () => {
 			},
 		);
 		expect(composer().value).toBe("half-written");
+	});
+});
+
+describe("keys typed on the transcript", () => {
+	const seen: string[] = [];
+	const listener = (event: Event): void => void seen.push((event as KeyboardEvent).key);
+
+	afterEach(() => {
+		globalThis.document.removeEventListener("keydown", listener);
+		seen.length = 0;
+	});
+
+	/** Every keydown the desk's one document listener would have seen (`../ui/Desk.tsx`). */
+	const watchDesk = (): ReadonlyArray<string> => {
+		globalThis.document.addEventListener("keydown", listener);
+		return seen;
+	};
+
+	it("keeps a bare character off the desk's listener, and lets the rest through (#7973)", async () => {
+		await openWindow(withTranscript(transcriptOf(2)));
+		const transcript = screen.getByRole("log", {name: "Transcript"});
+		const reached = watchDesk();
+
+		await act(async () => {
+			fireEvent.keyDown(transcript, {key: "x"});
+			fireEvent.keyDown(transcript, {key: "b", ctrlKey: true});
+			fireEvent.keyDown(transcript, {key: "Escape"});
+			fireEvent.keyDown(transcript, {key: "r", altKey: true});
+		});
+
+		expect(reached).toEqual(["b", "Escape", "r"]);
+	});
+
+	it("still interrupts on Escape typed on the transcript", async () => {
+		const {process} = await openWindow(withTranscript(transcriptOf(2), {phase: "prompting"}));
+		await act(async () => {
+			fireEvent.keyDown(screen.getByRole("log", {name: "Transcript"}), {key: "Escape"});
+		});
+		await waitFor(() => expect(process.inbox()).toEqual([{type: "interrupt"}]));
 	});
 });
 

--- a/apps/tuval/src/shell/core/index.ts
+++ b/apps/tuval/src/shell/core/index.ts
@@ -20,6 +20,7 @@ export {
 	isPrefixSnapshot,
 	isShellState,
 	isWorkspace,
+	keyTargetOf,
 	type MintedIds,
 	mint,
 	type PrefixSnapshot,

--- a/apps/tuval/src/shell/core/machine.ts
+++ b/apps/tuval/src/shell/core/machine.ts
@@ -47,9 +47,9 @@ import {
 	activeWorkspace,
 	disarmed,
 	hasWindow,
+	keyTargetOf,
 	mint,
 	type PrefixSnapshot,
-	processOf,
 	type ShellState,
 	type Workspace,
 	type WorkspaceId,
@@ -114,7 +114,16 @@ export type ShellMsg =
 	| {readonly type: "window.close"; readonly windowId?: WindowId}
 	| {readonly type: "window.focus"; readonly windowId: WindowId}
 	| {readonly type: "window.focusDirection"; readonly direction: Direction}
-	| {readonly type: "window.bind"; readonly processId: string; readonly windowId?: WindowId}
+	| {
+			readonly type: "window.bind";
+			readonly processId: string;
+			readonly windowId?: WindowId;
+			/**
+			 * The bound program declared `takesKeys`. The picker reads it off the row it just resolved
+			 * (`../picker/open.ts`); absent means the shell forwards this window no keys (#7973).
+			 */
+			readonly takesKeys?: boolean;
+	  }
 	| {readonly type: "window.unbind"; readonly windowId?: WindowId}
 	| {readonly type: "window.setView"; readonly view: ViewState; readonly windowId?: WindowId}
 	| {
@@ -209,13 +218,17 @@ const bindWindow = (
 	state: ShellState,
 	windowId: WindowId | undefined,
 	processId: string | null,
+	takesKeys = false,
 ): Step => {
 	const workspace = activeWorkspace(state);
 	if (workspace === undefined) return [state, NO_CMDS];
 	const target = windowId ?? workspace.focused;
 	if (!hasWindow(workspace, target)) return [state, NO_CMDS];
 	return [
-		withActive(state, {...workspace, layout: setProcess(workspace.layout, target, processId)}),
+		withActive(state, {
+			...workspace,
+			layout: setProcess(workspace.layout, target, processId, takesKeys),
+		}),
 		NO_CMDS,
 	];
 };
@@ -412,8 +425,9 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 
 		if (answer._tag === "ToWindow") {
 			const workspace = activeWorkspace(routed);
-			const processId = workspace === undefined ? null : processOf(workspace, workspace.focused);
-			// An empty window has no process to forward to, so the key is dropped rather than queued.
+			const processId = workspace === undefined ? null : keyTargetOf(workspace, workspace.focused);
+			// An empty window has no process to forward to, and a window whose program never declared
+			// `takesKeys` has no cell for one, so the key is dropped rather than queued (#7973).
 			return [
 				routed,
 				processId === null || workspace === undefined
@@ -446,7 +460,7 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 		"window.close": closeWindow,
 		"window.focus": (state, msg) => focusWindow(state, msg.windowId),
 		"window.focusDirection": (state, msg) => focusDirection(state, msg.direction),
-		"window.bind": (state, msg) => bindWindow(state, msg.windowId, msg.processId),
+		"window.bind": (state, msg) => bindWindow(state, msg.windowId, msg.processId, msg.takesKeys),
 		"window.unbind": (state, msg) => bindWindow(state, msg.windowId, null),
 		"window.setView": setView,
 		"layout.resize": resizeStack,

--- a/apps/tuval/src/shell/core/machine.unit.test.ts
+++ b/apps/tuval/src/shell/core/machine.unit.test.ts
@@ -274,18 +274,41 @@ describe("shell core: workspaces", () => {
 
 describe("shell core: keys", () => {
 	it("an unarmed press forwards exactly one key to the focused window's process", () => {
-		const bound = fold(initialState(), {type: "window.bind", processId: "process-pi"});
+		const bound = fold(initialState(), {
+			type: "window.bind",
+			processId: "process-counter",
+			takesKeys: true,
+		});
 		const [after, cmds] = apply(bound, press("j"));
 
 		expect(cmds).toEqual([
 			{
 				type: "forwardKey",
-				processId: "process-pi",
+				processId: "process-counter",
 				windowId: active(bound).focused,
 				key: "j",
 			},
 		]);
 		expect(after.prefix).toEqual({armed: false});
+	});
+
+	it("a window whose program never declared keys is forwarded none (#7973)", () => {
+		const bound = fold(initialState(), {type: "window.bind", processId: "process-pi"});
+		const [after, cmds] = apply(bound, press("j"));
+
+		expect(cmds).toEqual([]);
+		expect(after.prefix).toEqual({armed: false});
+		expect(after.workspaces).toEqual(bound.workspaces);
+	});
+
+	it("unbinding drops the key declaration with the process", () => {
+		const rebound = fold(
+			initialState(),
+			{type: "window.bind", processId: "process-counter", takesKeys: true},
+			{type: "window.unbind"},
+			{type: "window.bind", processId: "process-pi"},
+		);
+		expect(apply(rebound, press("j"))[1]).toEqual([]);
 	});
 
 	it("an unarmed press over an empty window forwards nothing", () => {

--- a/apps/tuval/src/shell/core/state.ts
+++ b/apps/tuval/src/shell/core/state.ts
@@ -138,6 +138,18 @@ export const processOf = (workspace: Workspace, windowId: WindowId): string | nu
 	return null;
 };
 
+/**
+ * Where a forwarded key goes: the window's process, and only when the program bound to it declared
+ * it takes keys (`src/registry/program.ts`). `null` for an empty window, a window the tree does not
+ * hold, and — the case #7973 is about — a window whose program never asked for a key.
+ */
+export const keyTargetOf = (workspace: Workspace, windowId: WindowId): string | null => {
+	for (const window of windows(workspace.layout.root)) {
+		if (window.id === windowId) return window.takesKeys === true ? window.processId : null;
+	}
+	return null;
+};
+
 export const hasWindow = (workspace: Workspace, windowId: WindowId): boolean =>
 	windowIds(workspace).includes(windowId);
 

--- a/apps/tuval/src/shell/layout/node.ts
+++ b/apps/tuval/src/shell/layout/node.ts
@@ -38,6 +38,13 @@ export interface WindowNode {
 	readonly tag: "window";
 	readonly id: WindowId;
 	readonly processId: string | null;
+	/**
+	 * The bound program declared `takesKeys` (`src/registry/program.ts`), so the shell may forward a
+	 * key to this window's process. Written only beside `processId` and dropped with it, because it
+	 * describes the binding rather than the window; absent on an unbound window and on every window
+	 * bound before #7973, which is the safe reading — a key nobody declared for is not sent.
+	 */
+	readonly takesKeys?: true;
 }
 
 /**
@@ -61,8 +68,19 @@ export interface LayoutTree {
 	readonly zoomed: WindowId | null;
 }
 
-export function createWindow(id: WindowId, processId: string | null = null): WindowNode {
-	return {tag: "window", id, processId};
+/**
+ * A window node, bound or not. `setProcess` rebuilds through here rather than spreading the old
+ * node, so the pair can never drift: unbinding drops the declaration with the process, and a
+ * `takesKeys` handed in beside a `null` process is dropped too.
+ */
+export function createWindow(
+	id: WindowId,
+	processId: string | null = null,
+	takesKeys = false,
+): WindowNode {
+	return processId !== null && takesKeys
+		? {tag: "window", id, processId, takesKeys: true}
+		: {tag: "window", id, processId};
 }
 
 /**
@@ -87,7 +105,8 @@ export function isWindowNode(value: unknown): value is WindowNode {
 		Predicate.isObject(value) &&
 		value.tag === "window" &&
 		typeof value.id === "string" &&
-		(value.processId === null || typeof value.processId === "string")
+		(value.processId === null || typeof value.processId === "string") &&
+		(value.takesKeys === undefined || (value.takesKeys === true && value.processId !== null))
 	);
 }
 

--- a/apps/tuval/src/shell/layout/tree.ts
+++ b/apps/tuval/src/shell/layout/tree.ts
@@ -290,13 +290,19 @@ export function resize(
 	return root ? {...tree, root} : tree;
 }
 
-/** Attach or detach a window's process. A window carries no other payload. */
+/**
+ * Attach or detach a window's process, and with it whether that process's program takes forwarded
+ * keys. The two are one payload: `createWindow` drops the declaration whenever the process goes.
+ */
 export function setProcess(
 	tree: LayoutTree,
 	windowId: WindowId,
 	processId: string | null,
+	takesKeys = false,
 ): LayoutTree {
-	const root = mapWindow(tree.root, windowId, (window) => ({...window, processId}));
+	const root = mapWindow(tree.root, windowId, (window) =>
+		createWindow(window.id, processId, takesKeys),
+	);
 	return root ? {...tree, root} : tree;
 }
 

--- a/apps/tuval/src/shell/picker/mount.unit.test.ts
+++ b/apps/tuval/src/shell/picker/mount.unit.test.ts
@@ -90,7 +90,7 @@ describe("attaching gives one process a second window", () => {
 			);
 
 			assert.deepStrictEqual(answer.bind, [
-				{type: "window.bind", windowId: "window-2", processId: "p-1"},
+				{type: "window.bind", windowId: "window-2", processId: "p-1", takesKeys: false},
 			]);
 			assert.deepStrictEqual(
 				answer.seen.map((head) =>

--- a/apps/tuval/src/shell/picker/open.ts
+++ b/apps/tuval/src/shell/picker/open.ts
@@ -13,7 +13,7 @@ import {Context, Effect} from "effect";
 import {Processes} from "../../process/Processes.ts";
 import {ProcessTable} from "../../process/ProcessTable.ts";
 import type {ProcessId} from "../../process/process.ts";
-import type {ProgramId} from "../../registry/program.ts";
+import {type AnyProgram, type ProgramId, takesForwardedKeys} from "../../registry/program.ts";
 import {Registry} from "../../registry/Registry.ts";
 import type {ShellMsg} from "../core/machine.ts";
 import type {WindowId} from "../window/host.ts";
@@ -47,8 +47,16 @@ const refuse = (
 	{type: "window.setView", windowId, view: withRefusal(options.view ?? mountPicker(), refusal)},
 ];
 
-const bind = (windowId: WindowId, processId: ProcessId): ReadonlyArray<ShellMsg> => [
-	{type: "window.bind", windowId, processId},
+/**
+ * The binding carries the row's key declaration: a window may only be sent a key its program asked
+ * for, and this is the one place both are known at once (#7973).
+ */
+const bind = (
+	windowId: WindowId,
+	processId: ProcessId,
+	row: AnyProgram,
+): ReadonlyArray<ShellMsg> => [
+	{type: "window.bind", windowId, processId, takesKeys: takesForwardedKeys(row)},
 ];
 
 const open = Effect.fn("Tuval.Picker.open")(function* (
@@ -72,7 +80,7 @@ const open = Effect.fn("Tuval.Picker.open")(function* (
 	);
 	return spawned._tag === "Failure"
 		? refuse(windowId, options, spawnFailed(programId, spawned.failure.message))
-		: bind(windowId, spawned.success.id);
+		: bind(windowId, spawned.success.id, row.success);
 });
 
 const attach = Effect.fn("Tuval.Picker.attach")(function* (
@@ -90,7 +98,7 @@ const attach = Effect.fn("Tuval.Picker.attach")(function* (
 	const program = yield* Effect.result(registry.resolve(row.success.programId));
 	return program._tag === "Failure" || !showsInAWindow(program.success)
 		? refuse(windowId, options, programHeadless(row.success.programId))
-		: bind(windowId, processId);
+		: bind(windowId, processId, program.success);
 });
 
 /**

--- a/apps/tuval/src/shell/picker/open.unit.test.ts
+++ b/apps/tuval/src/shell/picker/open.unit.test.ts
@@ -66,7 +66,7 @@ describe("choosing a program", () => {
 			const answer = yield* run(openProgram(window, programId("counter")));
 			assert.deepStrictEqual(answer.spawns, [{programId: "counter", parent: shellProcessId}]);
 			assert.deepStrictEqual(answer.msgs, [
-				{type: "window.bind", windowId: window, processId: "process-1"},
+				{type: "window.bind", windowId: window, processId: "process-1", takesKeys: false},
 			]);
 		}),
 	);
@@ -130,7 +130,7 @@ describe("attaching to a running process", () => {
 			});
 			assert.deepStrictEqual(answer.spawns, []);
 			assert.deepStrictEqual(answer.msgs, [
-				{type: "window.bind", windowId: window, processId: "p-1"},
+				{type: "window.bind", windowId: window, processId: "p-1", takesKeys: false},
 			]);
 		}),
 	);


### PR DESCRIPTION
One keystroke landing on an agent window outside its composer killed that window's process, and nothing on screen said so. Fixed in two independent layers, either of which alone would stop the founder's incident.

**The host stops treating a foreign Msg as a fault.** `reduce` in `apps/tuval/src/host/actor.ts` now tells Demlik's `NoCellError` — thrown by `applyCell` before any of the machine's own code runs — apart from a genuine throw out of a reducer cell. The first becomes `MsgNotAcceptedError`, a new member of `DispatchError<E>` declared beside `ActorStoppedError` in `apps/tuval/src/host/errors.ts`, and `step` returns it to the caller without touching `gate` and without `Effect.die`. A cell that really throws still closes the gate under the `stop` default, unchanged.

**The shell stops sending keys nobody asked for.** `Program` carries `takesKeys?: true`. The picker reads it off the row it just resolved, `window.bind` carries it, and the window node holds it beside `processId` — so `keys.press` emits `forwardKey` only for a focused window whose program declared one. Unbinding drops the declaration with the process, which is why `createWindow` builds the node rather than a spread.

**The chat transcript stops feeding the desk router.** A bare printable character typed on the focusable `.tuval-chat-transcript` no longer reaches the desk's one keyboard listener. Ctrl-keyed sequences (the desk prefix), Escape and Alt+R route exactly as before, and the transcript keeps `tabIndex={0}`, `role="log"` and its label.

Grounded in `@demlik/tea` 0.12's own types at the pin: `NoCellError` is exported with `msgType`/`stateName` (`dist/core-Bjc0bS8j.d.ts:10-15`), and `Reducer`/`Transitions` both demand a cell per member of a closed `M` — which is why a machine missing one is only reachable across an erased wire, and why the actor's unit proof types its Msg open.

Proofs: two cases in `apps/tuval/src/host/actor.unit.test.ts` (the refusal leaves the process open and a later Msg still commits; a throwing cell still closes the gate), three in `apps/tuval/src/shell/core/machine.unit.test.ts` (declaring forwards, non-declaring does not, unbinding drops the declaration), two in `apps/tuval/src/shell/chat/chat-window.unit.test.tsx`. `chat-a11y.unit.test.tsx` is green unchanged. Full tuval suite green; typecheck and lint clean.

## Deviations

- **Declined guidance** — **Said:** the acceptance criteria list `apps/tuval/src/demo/log.ts` among the programs that must *not* declare it takes forwarded keys. **Did:** `log.ts` declares `takesKeys: true`. **Why:** the log has a working `key` cell (`apps/tuval/src/demo/log.ts:51-54`, recording the key and printing `key <k>`), and it is the program both end-to-end key proofs drive — `apps/tuval/src/shell/proof/end-to-end.integration.test.ts` asserts `key a`, `key b` and `key c` reach it across a restart and a re-attach. Withholding the declaration would have made the only whole-app proof of the `forwardKey` path fail, and the criterion's premise ("the demo counter is the only program written for this path") is contradicted by that source. The agent programs the bug is actually about — `ai-agent`, `pi`, `claude` — have no `key` cell and declare nothing, exactly as the criterion asks. **Disposition:** stated here; the reviewer may rule the other way, in which case the e2e proof needs re-pointing at the counter first.
- **Out-of-scope change** — **Said:** #7973 names the host, the registry row, the shell core and the chat window. **Did:** also rewrote the `forwardKey` section of `.patterns/tuval-shell-assembly.md`. **Why:** that section stated the now-false behaviour ("a program that does not [declare a `key` cell] simply drops the key at debug") as the shape of the code, and CLAUDE.md makes the source authoritative over the doc. **Disposition:** stated here.

Fixes #7973
