### PR TITLE
fix: The Claude real-CLI harness crashes on the restart it exists to prove: a restored session opens before the kernel bridge is handed over

### DIFF
--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -1,6 +1,6 @@
 import {homedir} from "node:os";
 import {join} from "node:path";
-import {type Context, Effect, type FileSystem, Layer} from "effect";
+import {type Context, Effect, type FileSystem, Layer, type Scope} from "effect";
 import type {BindingError, BindingSource} from "./commands/bindings/index.ts";
 import {everyRegistered, SpellBridge} from "./commands/bridge/index.ts";
 import {helpSpells} from "./commands/core/index.ts";
@@ -70,6 +70,17 @@ export interface StartOptions {
 	 * Absent for a caller that has no config layers to offer, which is every caller but `boot`.
 	 */
 	readonly keys?: ReadonlyArray<BindingSource>;
+	/**
+	 * Run once the kernel context exists and before anything is spawned from it — before `launch`
+	 * and before `restore`.
+	 *
+	 * A row whose layer needs a kernel service that only the booting caller can supply has to be
+	 * given it before the first spawn builds that layer, and the first spawn is inside `start`. A
+	 * caller that filled its holder after `boot` returned was already too late for every
+	 * checkpointed row (#7976), so the ordering lives here rather than in a call site's discipline.
+	 * The hook runs in the caller's Scope, so it can register the teardown that clears what it set.
+	 */
+	readonly onKernel?: (kernel: Context.Context<Kernel>) => Effect.Effect<void, never, Scope.Scope>;
 }
 
 export interface Started {
@@ -86,12 +97,17 @@ export interface Started {
  * nothing written; the wiring opens next and the kernel after it, so a stop takes the processes
  * down — pumps included — before their queues close. A snapshot under another definition
  * refuses the boot at its spawn, with nothing fresh-booted (#7467, #7514).
+ *
+ * `onKernel` runs between the kernel's build and the first spawn — `launch`, then `restore` — so a
+ * caller that has to put a kernel service somewhere a row's layer reads has done it before any row
+ * is built (#7976).
  */
 export const start = Effect.fn("Tuval.start")(function* ({
 	programs,
 	graph,
 	stateDir,
 	keys,
+	onKernel,
 }: StartOptions) {
 	const registry = yield* Layer.build(Registry.layer(programs));
 	const compiled = yield* compile(graph).pipe(Effect.provideContext(registry));
@@ -120,6 +136,7 @@ export const start = Effect.fn("Tuval.start")(function* ({
 			Layer.provideMerge(Layer.succeedContext(registry)),
 		),
 	);
+	if (onKernel !== undefined) yield* onKernel(kernel);
 	// The kernel rides into every launched process's handlers: the shell row's Cmds spawn programs
 	// and read the process table, and a program row declares exactly those needs as its `R`.
 	const launched = yield* launch(compiled, wiring, {services: kernel}).pipe(
@@ -137,6 +154,8 @@ export interface BootOptions {
 	readonly global: string;
 	/** The project directory; its `.tuval/` holds the project config and the state. */
 	readonly project: string;
+	/** `StartOptions.onKernel`, handed through: the kernel exists, nothing has been spawned yet. */
+	readonly onKernel?: StartOptions["onKernel"];
 }
 
 export interface BootReport {
@@ -183,7 +202,13 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 	// Config rows are trusted local code (#7484 R1.1); the loader checks each row's id, not its shape.
 	const programs = config.programs as ReadonlyArray<AnyProgram>;
 	const stateDir = projectDir(options.project);
-	const started = yield* start({programs, graph: config.graph, stateDir, keys: config.keys});
+	const started = yield* start({
+		programs,
+		graph: config.graph,
+		stateDir,
+		keys: config.keys,
+		...(options.onKernel === undefined ? {} : {onKernel: options.onKernel}),
+	});
 	const live = yield* ProcessTable.use((table) => table.list).pipe(
 		Effect.provideContext(started.kernel),
 	);

--- a/apps/tuval/src/claude/proof/holder-desk.ts
+++ b/apps/tuval/src/claude/proof/holder-desk.ts
@@ -1,0 +1,62 @@
+/**
+ * The config the hand-over-ordering proof boots (`./holder-restart.integration.test.ts`): one agent
+ * session row whose layer reads the late holder, and nothing else.
+ *
+ * The row stands where `./real.ts`'s `claude-session` stands and reads the holder the same way it
+ * does — `Layer.provide(lateSpellBridge)` under a layer that genuinely needs `SpellBridge`, built
+ * at the moment a spawner builds the row. What it is *not* is the real CLI: the backend is
+ * `ScriptedAiAgent.layer`, so the proof calls no model API and spends nothing (founder ruling on
+ * #7582 and #7586), and the bridge it takes out of the holder is what a scripted turn's `plan`
+ * would call through.
+ *
+ * The graph plans no node, so the row's only route back after a restart is `restore` — which is the
+ * spawner the ordering bug reached ([#7976](https://github.com/kamp-us/phoenix/issues/7976)).
+ *
+ * A config module takes no arguments, so the caller's temp project root arrives in the environment
+ * under `CLAUDE_VERTICAL_PROOF_ROOT`, for the reason `./names.ts` states.
+ */
+
+import {Effect, Layer} from "effect";
+import {aiAgentProgram} from "../../ai-agent/program.ts";
+import {ScriptedAiAgent, type TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {SpellBridge} from "../../commands/bridge/index.ts";
+import {ClientId, type Scope as SpellScope, WorkspaceId} from "../../commands/spell.ts";
+import type {TuvalConfigInput} from "../../config.ts";
+import {lateSpellBridge} from "./late.ts";
+import {HOLDER_PROGRAM, HOLDER_SESSION, PROJECT_ROOT_VAR} from "./names.ts";
+
+const projectRoot = (): string => {
+	const root = process.env[PROJECT_ROOT_VAR];
+	if (root === undefined) throw new Error(`${PROJECT_ROOT_VAR} is not set`);
+	return root;
+};
+
+const root = projectRoot();
+
+const scope: SpellScope = {
+	workspace: WorkspaceId.make("default"),
+	client: ClientId.make("holder-restart-proof"),
+};
+
+/**
+ * A session that opens, resumes and prompts nothing. The proof's claim is about which boot step
+ * builds this layer, so a turn would only add a way for the case to fail for another reason.
+ */
+const onTheHolder: Layer.Layer<TuvalAiAgent> = Layer.unwrap(
+	Effect.map(SpellBridge, (bridge) =>
+		ScriptedAiAgent.layer({
+			sessionId: HOLDER_SESSION,
+			history: [],
+			modes: {current: null, available: []},
+			turns: [],
+			interrupt: [],
+			spells: {bridge, scope},
+		}),
+	),
+).pipe(Layer.provide(lateSpellBridge));
+
+export default {
+	version: 1,
+	programs: [aiAgentProgram({id: HOLDER_PROGRAM, layer: onTheHolder, config: {cwd: root}})],
+	graph: {nodes: []},
+} satisfies TuvalConfigInput;

--- a/apps/tuval/src/claude/proof/holder-restart.integration.test.ts
+++ b/apps/tuval/src/claude/proof/holder-restart.integration.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The restart the real-CLI harness exists to demonstrate, over a row whose layer reads the late
+ * holder: boot once against a project dir, open a session, stop, boot again against the same dir.
+ *
+ * Boot 2 is the whole case. The row is no graph node, so `restore` is what brings it back, and
+ * `restore` runs *inside* `boot` — so the holder has to be filled before the boot that reads it
+ * returns. A harness that filled it afterwards was one step too late and the row's layer died on
+ * an empty holder ([#7976](https://github.com/kamp-us/phoenix/issues/7976)); `boot`'s `onKernel`
+ * hook is where the fill sits now, and dropping it from the two calls below is what makes this
+ * case red again.
+ *
+ * It runs on `ScriptedAiAgent.layer` through `./holder-desk.ts`, so it calls no model API and
+ * spends nothing (founder ruling on #7582 and #7586). The real CLI is `./serve.ts`, the founder's
+ * own local run, and no workflow reaches it.
+ */
+
+import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, type FileSystem, Option, Scope} from "effect";
+import type {AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {boot, projectDir} from "../../boot.ts";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessTable} from "../../process/ProcessTable.ts";
+import type {ProcessHandle, ProcessId} from "../../process/process.ts";
+import {ProgramId} from "../../registry/program.ts";
+import {handOverKernel} from "./late.ts";
+import {HOLDER_PROGRAM, HOLDER_SESSION, PROJECT_ROOT_VAR} from "./names.ts";
+
+const TIMEOUT = 60_000;
+
+const configModule = fileURLToPath(new URL("./holder-desk.ts", import.meta.url));
+
+const tempDirs: string[] = [];
+
+const freshProject = (): string => {
+	const dir = realpathSync(mkdtempSync(join(tmpdir(), "tuval-holder-restart-")));
+	tempDirs.push(dir);
+	mkdirSync(projectDir(dir));
+	process.env[PROJECT_ROOT_VAR] = dir;
+	return dir;
+};
+
+const bootHolder = (project: string) =>
+	boot({global: configModule, project, onKernel: handOverKernel});
+
+const sessionOf = (handle: ProcessHandle): AiAgentSessionState =>
+	handle.getState() as AiAgentSessionState;
+
+/**
+ * The host dispatches a Cmd's follow-up Msgs unawaited (`../../host/actor.ts`), so both the fresh
+ * spawn's boot Cmd and the restore's reconnect settle after the call that started them returns.
+ */
+const settled = Effect.fn("holderRestart.settled")(function* (
+	handle: ProcessHandle,
+	what: string,
+	ready: (state: AiAgentSessionState) => boolean,
+) {
+	for (let attempt = 0; attempt < 500; attempt += 1) {
+		const state = sessionOf(handle);
+		if (ready(state)) return state;
+		yield* Effect.sleep("10 millis");
+	}
+	return yield* Effect.die(
+		new Error(`${what} never settled; last seen ${JSON.stringify(sessionOf(handle))}`),
+	);
+});
+
+const run = <A, E>(effect: Effect.Effect<A, E, Scope.Scope | FileSystem.FileSystem>) =>
+	effect.pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
+
+describe("a row whose layer reads the late holder, across a restart", () => {
+	it.live(
+		"comes back live on the second boot over the same project dir, resuming its own session",
+		() =>
+			run(
+				Effect.gen(function* () {
+					const project = freshProject();
+					let opened: ProcessId | null = null;
+
+					yield* Effect.scopedWith(
+						Effect.fnUntraced(function* (scope) {
+							const booted = yield* Scope.provide(bootHolder(project), scope);
+							// The picker's path: a process under no node, given the kernel
+							// (`../../shell/picker/open.ts`). Spawning is what opens the session (#7925).
+							const handle = yield* Context.get(booted.kernel, Processes).spawn(
+								ProgramId.make(HOLDER_PROGRAM),
+								{services: booted.kernel},
+							);
+							const ready = yield* settled(
+								handle,
+								"the first boot's session",
+								(state) => state.phase === "ready",
+							);
+							assert.strictEqual(ready.sessionId, HOLDER_SESSION);
+							opened = handle.id;
+						}),
+					);
+					assert.isNotNull(opened, "the first boot never opened a session to checkpoint");
+
+					const booted = yield* bootHolder(project);
+
+					assert.strictEqual(
+						booted.report.restoredCount,
+						1,
+						"the second boot did not bring the checkpointed row back",
+					);
+					const live = yield* ProcessTable.use((table) => table.list).pipe(
+						Effect.provideContext(booted.kernel),
+					);
+					assert.deepStrictEqual(
+						live.map((row) => row.id),
+						[opened],
+						"the restored process is not in the table under the id it was checkpointed at",
+					);
+
+					const handle = yield* Context.get(booted.kernel, Processes)
+						.handle(opened as ProcessId)
+						.pipe(Effect.map(Option.getOrNull));
+					assert.isNotNull(handle, "the restored row has no handle to dispatch into");
+					const restored = yield* settled(
+						handle as ProcessHandle,
+						"the restored session",
+						(state) => state.phase === "ready",
+					);
+
+					// Ready under the same id is the resume having gone through: `restore` dispatches
+					// `reconnect` (`../../durability/resume.ts`), the handler rebuilds this row's layer
+					// out of the holder, and the backend answers `start({resume: sessionId})`. A row
+					// that merely did not throw would sit at `idle` with its failure set.
+					assert.strictEqual(
+						restored.sessionId,
+						HOLDER_SESSION,
+						"the restart opened a new session instead of resuming the checkpointed one",
+					);
+					assert.isNull(restored.failure, "the restored session came back carrying a failure");
+					assert.isAbove(
+						restored.connection,
+						1,
+						"the restored session never stood a second transport up",
+					);
+				}),
+			),
+		TIMEOUT,
+	);
+});
+
+process.on("exit", () => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, {recursive: true, force: true});
+});

--- a/apps/tuval/src/claude/proof/late.ts
+++ b/apps/tuval/src/claude/proof/late.ts
@@ -6,7 +6,15 @@
  * `Layer<SpellBridge>` at the moment the config module is evaluated (`../program.ts`) — and the
  * loader evaluates that module inside `boot`, before there is a bridge to hand it. So the harness
  * boots, takes the bridge out of the kernel context, and puts it here; the row's layer is built
- * later, when the founder opens the window, and reads it then.
+ * later — when the founder opens the window, or when a restored row reconnects — and reads it then.
+ *
+ * **The hand-over happens inside `boot`, before `restore`.** `start` calls `handOverKernel` through
+ * its `onKernel` hook (`../../boot.ts`), between the kernel's build and the first spawn, because
+ * `restore` runs inside `boot` and its spawns build the rows' layers: a harness that filled this
+ * holder after `boot` returned was too late for every checkpointed row, which is the restart the
+ * harness exists to demonstrate ([#7976](https://github.com/kamp-us/phoenix/issues/7976)). The
+ * hook's Scope is the booted app's, so a stop empties the holder rather than leaving a dead
+ * kernel's bridge readable by the next boot.
  *
  * **This module is what makes that work, and only because the loader does not cache-bust it.**
  * `src/config.ts` stamps a load number on the *config module's* URL so each boot re-evaluates it;
@@ -19,16 +27,24 @@
  * [#7958](https://github.com/kamp-us/phoenix/issues/7958).
  */
 
-import {Context, Effect, Layer} from "effect";
+import {Context, Effect, Layer, type Scope} from "effect";
 import type {Kernel} from "../../boot.ts";
 import {SpellBridge} from "../../commands/bridge/index.ts";
 
 let held: Context.Context<SpellBridge> | null = null;
 
-/** Called once per boot by the harness, before any Claude window is opened. */
-export const handOverKernel = (kernel: Context.Context<Kernel>): void => {
-	held = Context.make(SpellBridge, Context.get(kernel, SpellBridge));
-};
+/** `boot`'s `onKernel` hook: fill the holder, and empty it again when the booted app stops. */
+export const handOverKernel = (
+	kernel: Context.Context<Kernel>,
+): Effect.Effect<void, never, Scope.Scope> =>
+	Effect.gen(function* () {
+		held = Context.make(SpellBridge, Context.get(kernel, SpellBridge));
+		yield* Effect.addFinalizer(() =>
+			Effect.sync(() => {
+				held = null;
+			}),
+		);
+	});
 
 /**
  * The bridge as a layer the row can hold before it exists. It dies rather than answering an empty

--- a/apps/tuval/src/claude/proof/late.unit.test.ts
+++ b/apps/tuval/src/claude/proof/late.unit.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The late holder's refusal arm: what `lateSpellBridge` does when nothing handed the kernel over.
+ *
+ * The holder is module state (`./late.ts` says why it has to be), so this file never calls
+ * `handOverKernel` — a fill anywhere in it would hold for every case after it and the arm under
+ * test would stop being reachable. The filled arm is proved where it matters instead, over two
+ * boots against one project dir (`./holder-restart.integration.test.ts`).
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {lateSpellBridge} from "./late.ts";
+
+describe("the late kernel holder", () => {
+	it.effect("dies, naming its own file, when nothing has handed the kernel over", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(Effect.scoped(Layer.build(lateSpellBridge)));
+
+			assert.isTrue(Exit.isFailure(exit), "an empty holder answered with a bridge");
+			assert.isTrue(
+				Exit.isFailure(exit) && Cause.hasDies(exit.cause),
+				"the empty holder refused in the error channel, where a caller could swallow it",
+			);
+			const defect = Exit.isFailure(exit) ? Cause.squash(exit.cause) : null;
+			assert.instanceOf(defect, Error);
+			assert.include(
+				(defect as Error).message,
+				"src/claude/proof/late.ts",
+				"the refusal does not name the file a reader has to open",
+			);
+		}),
+	);
+});

--- a/apps/tuval/src/claude/proof/names.ts
+++ b/apps/tuval/src/claude/proof/names.ts
@@ -22,6 +22,16 @@ export const PROJECT_ROOT_VAR = "CLAUDE_VERTICAL_PROOF_ROOT";
  */
 export const CHILD_PROGRAM = "ai-agent-session";
 
+/**
+ * The row `./holder-desk.ts` registers: an agent session whose layer reads the late holder the way
+ * `./real.ts`'s `claude-session` does. It is its own program rather than `claude-session` because
+ * that row's layer is the real CLI's, and the holder's ordering is what that proof is about.
+ */
+export const HOLDER_PROGRAM = "holder-session";
+
+/** The session id that row's scripted backend holds, and so the id its restart resumes. */
+export const HOLDER_SESSION = "holder-restart-proof-session";
+
 /** The permission request id the second turn raises, as the SDK spells a tool-use id. */
 export const CARD = "toolu_01claudevertical";
 

--- a/apps/tuval/src/claude/proof/serve.ts
+++ b/apps/tuval/src/claude/proof/serve.ts
@@ -59,9 +59,7 @@ const proof = Command.make(
 		mkdirSync(projectDir(project), {recursive: true});
 		process.env[PROJECT_ROOT_VAR] = project;
 
-		const booted = yield* boot({global: configModule, project});
-		// Before any window is opened, because the row's layer reads it when the founder opens one.
-		handOverKernel(booted.kernel);
+		const booted = yield* boot({global: configModule, project, onKernel: handOverKernel});
 
 		const transport = yield* serveDesk({kernel: booted.kernel, port: 0, table: defaultPrefixTable});
 		const page = yield* servePage({root: appRoot, transport, port: pagePort}).pipe(Effect.orDie);


### PR DESCRIPTION
`pnpm proof:claude-real` booted clean on a fresh `--project` dir and died on the second run
against the same one — the restart the harness exists to demonstrate. The kernel never finished
booting and the page port never opened.

## What was wrong

`restore` runs *inside* `boot`, and it spawns every checkpointed process. Spawning builds the
row's layer, and the `claude-session` row's layer reads `late.ts`'s holder. The harness filled
that holder from `serve.ts`, one step after `boot` returned — too late for every checkpointed
row, so the layer took the `Effect.die` arm and the whole boot went down with it. A fresh
project dir has no checkpoint, so `restore` spawns nothing and the holder is filled in time,
which is why only the restart hit it.

## What changed

Route 1 from the ticket. `StartOptions` gains an `onKernel` hook that `start` runs between the
kernel's build and the first spawn — before `launch`, before `restore` — and `boot` hands it
through. `serve.ts` passes `handOverKernel` there and no longer calls it after `boot`, so the
ordering is `start`'s and not a call site's discipline.

`handOverKernel` is now an Effect that also registers a finalizer clearing the holder. The hook
runs in the booted app's Scope, so a stop empties the holder rather than leaving a dead kernel's
bridge readable by whatever comes next. That is also what makes the two-boot proof below
falsifiable in one OS process: the holder is module state, so without the clear, boot 1's fill
would still be standing when boot 2 read it.

`late.ts` still dies when nothing hands the kernel over at all, and still points at #7958 as the
structural retirement that removes this file.

## The proofs

- `holder-restart.integration.test.ts` (new) boots twice over one temp project dir on scripted
  layers, no model spend. Boot 1 spawns a session row whose layer reads the holder the way
  `real.ts`'s does — `Layer.provide(lateSpellBridge)` under a layer that genuinely requires
  `SpellBridge` — waits for it to open, and closes the boot's Scope. Boot 2 restores it and
  asserts the process is back in the `ProcessTable` under its checkpointed id, its state is
  `ready`, its `sessionId` is the one it was checkpointed with, its `failure` is null and its
  `connection` counter moved, which together say the resume went through rather than that
  nothing threw. `holder-desk.ts` is its config module; the graph plans no node, so `restore` is
  the only route the row has back.
- `late.unit.test.ts` (new) covers the guard's own arm: an unfilled holder dies, in the defect
  channel, with a message naming `src/claude/proof/late.ts`.

I ran the new proof against the pre-fix ordering (holder filled after `boot` returned) and it
reds with the exact reported error, `the Claude real-CLI harness opened a session before handing
the kernel over`.

## Reviewer's first look

`apps/tuval/src/boot.ts` — where `onKernel` fires relative to `launch` and `restore`.

Grounded `Effect.addFinalizer`'s signature in the pinned source
(`apps/tuval/node_modules/effect/src/Effect.ts`, effect 4.0.0-rc.112): it returns
`Effect<void, never, R | Scope>`, which is why the hook's type names `Scope.Scope`.

`pnpm typecheck` and `pnpm lint` pass; the whole `apps/tuval` suite is green (172 files, 1325
tests), including `claude-vertical.integration.test.ts` and the `restore` unit tests.

Fixes #7976

## Deviations

- **Known defect left unfixed** — **Said:** the first criterion is `pnpm proof:claude-real
  --project <dir>` booting twice against the same dir and printing its `desk at …` line both
  times. **Did:** did not run it. **Why:** that harness spawns the real `claude` CLI on the
  operator's own login and spends model tokens; it is the founder's own local run and no
  workflow reaches it (founder ruling on #7582 and #7586). **Disposition:** stated here — the
  new integration proof is the scripted stand-in for exactly that sequence, and the ordering it
  exercises is the same one `serve.ts` now boots under.
