### PR TITLE
fix: A Pi chat window shows the sent message only once the agent's reply arrives

### DIFF
--- a/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
@@ -223,7 +223,11 @@ describe("the AI agent interface over a compiled graph", () => {
 		onGraph(plainReply, (agent, window, seen) =>
 			Effect.gen(function* () {
 				yield* started(agent);
-				yield* window.say(aiAgentPortNames.prompt, {text: "hello", key: "k1"});
+				yield* window.say(aiAgentPortNames.prompt, {
+					text: "hello",
+					key: "k1",
+					timestamp: Date.now(),
+				});
 				yield* eventually("both turn items on the transcript port", () => {
 					const payload = latest(seen(), aiAgentPortNames.transcript) as
 						| TranscriptPayload
@@ -268,7 +272,11 @@ describe("the AI agent interface over a compiled graph", () => {
 		onGraph(permissionTurn, (agent, window, seen) =>
 			Effect.gen(function* () {
 				yield* started(agent);
-				yield* window.say(aiAgentPortNames.prompt, {text: "delete it", key: "k1"});
+				yield* window.say(aiAgentPortNames.prompt, {
+					text: "delete it",
+					key: "k1",
+					timestamp: Date.now(),
+				});
 				const pending = () =>
 					latest(seen(), aiAgentPortNames.permissionPending) as PermissionPayload | undefined;
 				const keys = () => {

--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -6,11 +6,21 @@
  * item goes through `planTranscriptWindow`, so the tail in state is whatever the bounds admit and
  * the running omission totals carry what they dropped. A refused plan leaves the tail as it was —
  * the planner answers with data rather than throwing, so this does too.
+ *
+ * The transcript has one other entrance, and it is here too: the operator's own turn, recorded by
+ * the `prompt` cell the moment they send it rather than when a layer gets round to echoing it
+ * (#7978). That is the item `upsertItem`'s echo join exists for.
  */
 
 import type {AgentEvent, Phase} from "../events.ts";
 import {isRefusal, planTranscriptWindow} from "../history/index.ts";
-import type {TranscriptItem, TranscriptPayload, WindowOmission} from "../ports/index.ts";
+import {
+	ItemId,
+	type TranscriptItem,
+	type TranscriptPayload,
+	type UserItem,
+	type WindowOmission,
+} from "../ports/index.ts";
 import type {AiAgentSessionState, UsageTotals} from "./state.ts";
 
 /** How much tail one session keeps. Absent, the window module's own defaults apply. */
@@ -19,12 +29,45 @@ export interface WindowLimits {
 	readonly byteLimit?: number;
 }
 
+/** A locally-recorded turn's id, derived from the prompt's idempotency key so it is stable. */
+export const promptItemId = (key: string): ItemId => ItemId.make(`local:${key}`);
+
+/** The operator's turn as the core records it on send, before any layer has confirmed it. */
+export const promptItem = (prompt: {
+	readonly text: string;
+	readonly key: string;
+	readonly timestamp: number;
+}): UserItem => ({
+	kind: "user",
+	id: promptItemId(prompt.key),
+	timestamp: prompt.timestamp,
+	text: prompt.text,
+	local: true,
+});
+
+/**
+ * Where a layer's echo of a locally-recorded turn belongs, or `-1`.
+ *
+ * Text is the only join the core has: the layer mints the turn under its own id, so an id lookup
+ * would append the echo beside the item it is a copy of. Matching is confined to items still
+ * carrying `local` — an echo that already landed cleared the flag — and a locally-recorded item
+ * never reconciles against another one, so two deliberate sends of the same text stay two turns.
+ */
+const echoOf = (items: ReadonlyArray<TranscriptItem>, item: TranscriptItem): number =>
+	item.kind !== "user" || item.local === true
+		? -1
+		: items.findIndex(
+				(candidate) =>
+					candidate.kind === "user" && candidate.local === true && candidate.text === item.text,
+			);
+
 /** An item with a known id supersedes the one it names, in place; anything else is the new tail. */
 export const upsertItem = (
 	items: ReadonlyArray<TranscriptItem>,
 	item: TranscriptItem,
 ): ReadonlyArray<TranscriptItem> => {
-	const at = items.findIndex((candidate) => candidate.id === item.id);
+	const byId = items.findIndex((candidate) => candidate.id === item.id);
+	const at = byId < 0 ? echoOf(items, item) : byId;
 	return at < 0
 		? [...items, item]
 		: items.map((candidate, index) => (index === at ? item : candidate));

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -12,7 +12,15 @@ export {
 	START_ERROR,
 	UNKNOWN_REQUEST,
 } from "./failures.ts";
-export {addUsage, foldEvent, foldItem, upsertItem, type WindowLimits} from "./fold.ts";
+export {
+	addUsage,
+	foldEvent,
+	foldItem,
+	promptItem,
+	promptItemId,
+	upsertItem,
+	type WindowLimits,
+} from "./fold.ts";
 export {
 	type AiAgentSessionMachine,
 	type AiAgentSessionOptions,

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -20,7 +20,7 @@ import {
 	startRefused,
 	unknownRequest,
 } from "./failures.ts";
-import {foldEvent, type WindowLimits} from "./fold.ts";
+import {foldEvent, foldItem, promptItem, type WindowLimits} from "./fold.ts";
 import {
 	type AiAgentSessionCmd,
 	type AiAgentSessionMsg,
@@ -148,6 +148,9 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 							noCmds,
 						],
 
+			// The turn goes onto the tail here, not when a layer reports it back: the message exists
+			// because the operator sent it, and a backend's echo habits are not what a chat window
+			// showing your own message should depend on (#7978).
 			prompt: (state, msg) =>
 				state.phase !== "ready"
 					? [{...state, failure: promptRefused(state.phase)}, noCmds]
@@ -157,6 +160,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 								phase: "prompting",
 								lastPrompt: msg.text,
 								interrupted: null,
+								transcript: foldItem(state.transcript, promptItem(msg), limits),
 								failure: null,
 							},
 							[{type: "aiAgent.prompt", text: msg.text, key: msg.key}],

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -9,12 +9,16 @@ import {applyCellChecked} from "@demlik/tea";
 import {describe, expect, it} from "vitest";
 import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 import type {AgentEvent} from "../events.ts";
-import {Mode, type PermissionRequest} from "../ports/index.ts";
+import {Mode, type PermissionRequest, type TranscriptItem} from "../ports/index.ts";
+import {promptItemId} from "./fold.ts";
 import {aiAgentSessionMachine} from "./machine.ts";
 import type {AiAgentSessionCmd, AiAgentSessionMsg} from "./messages.ts";
 import {type AiAgentSessionState, initialState} from "./state.ts";
 
 const machine = aiAgentSessionMachine({cwd: "/repo"});
+
+/** One fixed send clock, since a prompt now carries the timestamp its recorded turn wears. */
+const SENT_AT = 1_700_000_000_000;
 
 const apply = (
 	state: AiAgentSessionState,
@@ -106,32 +110,109 @@ describe("started", () => {
 });
 
 describe("prompt", () => {
+	const prompt = (text: string, key: string): AiAgentSessionMsg => ({
+		type: "prompt",
+		text,
+		key,
+		timestamp: SENT_AT,
+	});
+
 	it("sends the turn and remembers it for the resend", () => {
-		const [state, cmds] = apply(started({interrupted: null}), {
-			type: "prompt",
-			text: "make the README",
-			key: "k1",
-		});
+		const [state, cmds] = apply(started({interrupted: null}), prompt("make the README", "k1"));
 		expect(state).toMatchObject({phase: "prompting", lastPrompt: "make the README"});
 		expect(cmds).toEqual([{type: "aiAgent.prompt", text: "make the README", key: "k1"}]);
 	});
 
+	it("records the operator's turn on send, before any event is folded", () => {
+		const [state] = apply(started(), prompt("make the README", "k1"));
+		expect(state.transcript.items).toEqual([
+			{
+				kind: "user",
+				id: promptItemId("k1"),
+				timestamp: SENT_AT,
+				text: "make the README",
+				local: true,
+			},
+		]);
+	});
+
+	it("derives the recorded id from the idempotency key, so a replay lands on one item", () => {
+		const [once] = apply(started(), prompt("hi", "k1"));
+		const [twice] = apply({...once, phase: "ready"}, prompt("hi", "k1"));
+		expect(twice.transcript.items.map((item) => item.id)).toEqual([promptItemId("k1")]);
+	});
+
 	it("is refused as data outside ready, and emits nothing", () => {
 		for (const phase of ["idle", "starting", "prompting", "reconnecting", "gone"] as const) {
-			const [state, cmds] = apply(started({phase}), {type: "prompt", text: "hi", key: "k"});
+			const [state, cmds] = apply(started({phase}), prompt("hi", "k"));
 			expect(state.failure?.tag).toBe("tuval/ai-agent/PromptError");
 			expect(state.phase).toBe(phase);
+			expect(state.transcript.items).toEqual([]);
 			expect(cmds).toEqual([]);
 		}
 	});
 
 	it("clears the interrupted marker, because a resend is a new send", () => {
-		const [state] = apply(started({interrupted: assistantItem("a1").id}), {
-			type: "prompt",
-			text: "again",
-			key: "k2",
-		});
+		const [state] = apply(started({interrupted: assistantItem("a1").id}), prompt("again", "k2"));
 		expect(state.interrupted).toBeNull();
+	});
+});
+
+describe("the operator's turn once a layer echoes it", () => {
+	const sent = (over: Partial<AiAgentSessionState> = {}): AiAgentSessionState =>
+		apply(started(over), {
+			type: "prompt",
+			text: "make the README",
+			key: "k1",
+			timestamp: SENT_AT,
+		})[0];
+
+	const echo = (item: TranscriptItem): AiAgentSessionMsg => ({
+		type: "event",
+		sessionId: "session-1",
+		event: {kind: "item", item},
+	});
+
+	it("survives once, in place, under the layer's own id", () => {
+		const [state] = apply(sent(), echo(userItem("pi-7", "make the README")));
+		expect(state.transcript.items).toEqual([
+			{
+				kind: "user",
+				id: userItem("pi-7").id,
+				timestamp: userItem("pi-7").timestamp,
+				text: "make the README",
+			},
+		]);
+	});
+
+	it("keeps its position rather than moving to the end of the tail", () => {
+		const [replied] = apply(sent(), echo(assistantItem("a1", "on it")));
+		const [state] = apply(replied, echo(userItem("pi-7", "make the README")));
+		expect(state.transcript.items.map((item) => item.kind)).toEqual(["user", "assistant"]);
+	});
+
+	it("stays exactly once on a layer that never echoes it", () => {
+		const [replied] = apply(sent(), echo(assistantItem("a1", "on it")));
+		expect(replied.transcript.items).toMatchObject([
+			{kind: "user", id: promptItemId("k1"), local: true},
+			{kind: "assistant", id: assistantItem("a1").id},
+		]);
+	});
+
+	it("does not swallow a second deliberate send of the same text", () => {
+		const [again] = apply(
+			{...sent(), phase: "ready"},
+			{
+				type: "prompt",
+				text: "make the README",
+				key: "k2",
+				timestamp: SENT_AT + 1,
+			},
+		);
+		expect(again.transcript.items.map((item) => item.id)).toEqual([
+			promptItemId("k1"),
+			promptItemId("k2"),
+		]);
 	});
 });
 
@@ -226,7 +307,12 @@ describe("event", () => {
 		});
 		expect(state.phase).toBe("ready");
 
-		const [prompted, cmds] = apply(state, {type: "prompt", text: "hello", key: "k1"});
+		const [prompted, cmds] = apply(state, {
+			type: "prompt",
+			text: "hello",
+			key: "k1",
+			timestamp: SENT_AT,
+		});
 		expect(prompted.failure).toBeNull();
 		expect(cmds).toEqual([{type: "aiAgent.prompt", text: "hello", key: "k1"}]);
 	});
@@ -390,7 +476,7 @@ describe("the Cmd each Msg answers for", () => {
 	> = [
 		[initialState("/repo"), {type: "start", cwd: "/repo", resume: null}, ["aiAgent.start"]],
 		[started({phase: "starting"}), {type: "started", sessionId: "s"}, []],
-		[started(), {type: "prompt", text: "hi", key: "k"}, ["aiAgent.prompt"]],
+		[started(), {type: "prompt", text: "hi", key: "k", timestamp: SENT_AT}, ["aiAgent.prompt"]],
 		[
 			started(),
 			{type: "event", sessionId: "session-1", event: {kind: "phase", phase: "ready"}},

--- a/apps/tuval/src/ai-agent/core/messages.ts
+++ b/apps/tuval/src/ai-agent/core/messages.ts
@@ -15,8 +15,17 @@ import type {AgentFailure, HistoryPage} from "./state.ts";
 export type AiAgentSessionMsg =
 	| {readonly type: "start"; readonly cwd: string; readonly resume: string | null}
 	| {readonly type: "started"; readonly sessionId: string}
-	/** `key` is the idempotency key the window mints per deliberate send (ruling 2, #7570). */
-	| {readonly type: "prompt"; readonly text: string; readonly key: string}
+	/**
+	 * `key` is the idempotency key the window mints per deliberate send (ruling 2, #7570), and the
+	 * id of the turn the `prompt` cell records is derived from it. `timestamp` rides along because
+	 * that turn needs a clock and no update cell may read one (#7978).
+	 */
+	| {
+			readonly type: "prompt";
+			readonly text: string;
+			readonly key: string;
+			readonly timestamp: number;
+	  }
 	| {readonly type: "event"; readonly sessionId: string; readonly event: AgentEvent}
 	/** `message` is the operator's optional note; the window offers one on every decision. */
 	| {

--- a/apps/tuval/src/ai-agent/core/properties.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/properties.unit.test.ts
@@ -26,6 +26,7 @@ import {type AiAgentSessionState, initialState} from "./state.ts";
 
 const ITEM_LIMIT = 8;
 const BYTE_LIMIT = 4_000;
+const SENT_AT = 1_700_000_000_000;
 
 const machine = aiAgentSessionMachine({
 	cwd: "/repo",
@@ -56,7 +57,17 @@ const randomMsg = (
 		case 1:
 			return {msg: {type: "started", sessionId: "session-1"}, newItem: false};
 		case 2:
-			return {msg: {type: "prompt", text: "x".repeat(random.int(80)), key: id}, newItem: false};
+			// Whether this records an item depends on the phase it lands on, so `drive` decides it.
+			// The text is keyed to the step so no random `user` item can read as this turn's echo.
+			return {
+				msg: {
+					type: "prompt",
+					text: `prompt ${id}: ${"x".repeat(random.int(80))}`,
+					key: id,
+					timestamp: SENT_AT + step,
+				},
+				newItem: false,
+			};
 		case 3:
 			return {
 				msg: {
@@ -162,7 +173,10 @@ const drive = (seed: number, steps: number): Run => {
 			state,
 			msg,
 		);
-		if (newItem && next.phase !== "gone") items += 1;
+		// A prompt on a `ready` session records the operator's own turn (#7978), which is an item the
+		// tail has to account for exactly like one a layer reported.
+		const recorded = msg.type === "prompt" && state.phase === "ready";
+		if ((newItem || recorded) && next.phase !== "gone") items += 1;
 		state = next;
 	}
 	return {state, items};

--- a/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
@@ -210,7 +210,7 @@ describe("the AI agent handlers under a process", () => {
 			Effect.gen(function* () {
 				const handle = yield* spawn;
 				yield* eventually(() => sessionOf(handle).phase === "ready");
-				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1", timestamp: Date.now()});
 				yield* eventually(() => sessionOf(handle).transcript.items.length === 2);
 
 				assert.deepStrictEqual(
@@ -250,7 +250,12 @@ describe("the AI agent handlers under a process", () => {
 			Effect.gen(function* () {
 				const handle = yield* spawn;
 				yield* eventually(() => sessionOf(handle).phase === "ready");
-				yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1"});
+				yield* handle.dispatch({
+					type: "prompt",
+					text: "delete it",
+					key: "k1",
+					timestamp: Date.now(),
+				});
 				yield* eventually(() => sessionOf(handle).permissions[PERMISSION_REQUEST] !== undefined);
 
 				const pending = lastOn(log, aiAgentPortNames.permissionPending) as PermissionPayload;
@@ -353,7 +358,12 @@ describe("the AI agent handlers under a process", () => {
 				Effect.gen(function* () {
 					const handle = yield* spawn;
 					yield* eventually(() => sessionOf(handle).failure !== null);
-					yield* handle.dispatch({type: "prompt", text: "too early", key: "k1"});
+					yield* handle.dispatch({
+						type: "prompt",
+						text: "too early",
+						key: "k1",
+						timestamp: Date.now(),
+					});
 					assert.deepStrictEqual(
 						[sessionOf(handle).failure?.tag, probe.prompts],
 						["tuval/ai-agent/PromptError", 0],
@@ -369,7 +379,7 @@ describe("the AI agent handlers under a process", () => {
 			Effect.gen(function* () {
 				const handle = yield* spawn;
 				yield* eventually(() => sessionOf(handle).phase === "ready");
-				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1", timestamp: Date.now()});
 				yield* eventually(() => sessionOf(handle).failure?.tag === "tuval/ai-agent/TransportError");
 				assert.deepStrictEqual(
 					[sessionOf(handle).failure?.tag, sessionOf(handle).failure?.reason],
@@ -388,7 +398,7 @@ describe("the AI agent handlers under a process", () => {
 			Effect.gen(function* () {
 				const handle = yield* spawn;
 				yield* eventually(() => sessionOf(handle).phase === "ready");
-				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1", timestamp: Date.now()});
 				yield* eventually(() => sessionOf(handle).failure?.tag === "tuval/ai-agent/TransportError");
 				const downAt = log.length;
 
@@ -419,7 +429,7 @@ describe("the AI agent handlers under a process", () => {
 			Effect.gen(function* () {
 				const handle = yield* spawn;
 				yield* eventually(() => sessionOf(handle).phase === "ready");
-				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1", timestamp: Date.now()});
 				yield* eventually(() => sessionOf(handle).failure !== null);
 				yield* handle.dispatch({type: "reconnect"});
 				yield* eventually(() => probe.acquired === 2);
@@ -439,7 +449,7 @@ describe("the AI agent handlers under a process", () => {
 				Effect.gen(function* () {
 					const handle = yield* spawn;
 					yield* eventually(() => sessionOf(handle).phase === "ready");
-					yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+					yield* handle.dispatch({type: "prompt", text: "hello", key: "k1", timestamp: Date.now()});
 					yield* eventually(() => sessionOf(handle).transcript.items.length === 2);
 					assert.deepStrictEqual(log, []);
 				}),

--- a/apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts
+++ b/apps/tuval/src/ai-agent/opens-on-spawn.unit.test.ts
@@ -106,7 +106,7 @@ describe("a freshly spawned agent session", () => {
 					"the spawned session to reach ready",
 					() => sessionOf(handle).phase === "ready",
 				);
-				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1"});
+				yield* handle.dispatch({type: "prompt", text: "hello", key: "k1", timestamp: Date.now()});
 				yield* eventually(
 					"both turn items on the session transcript",
 					() => sessionOf(handle).transcript.items.length === 2,

--- a/apps/tuval/src/ai-agent/ports/payloads.ts
+++ b/apps/tuval/src/ai-agent/ports/payloads.ts
@@ -80,16 +80,23 @@ export const isTranscriptPagePayload = (value: unknown): value is TranscriptPage
  * `prompt` — one turn of operator text. `key` is the idempotency key: a second prompt carrying a
  * key the session already saw is dropped rather than re-sent, so a transport retry is free while
  * a deliberate resend mints a new key.
+ *
+ * Both `key` and `timestamp` are optional on the wire and refused by the receiver when absent
+ * (`program.ts`), because the payload predicate is the port's compatibility contract and a field
+ * required there is a sender this end can no longer read at all.
  */
 export interface PromptPayload {
 	readonly text: string;
 	readonly key?: string;
+	/** Epoch milliseconds, stamped by the sender: the turn's clock, since the core reads none. */
+	readonly timestamp?: number;
 }
 
 export const isPromptPayload = (value: unknown): value is PromptPayload =>
 	Predicate.isObject(value) &&
 	typeof value.text === "string" &&
-	(value.key === undefined || typeof value.key === "string");
+	(value.key === undefined || typeof value.key === "string") &&
+	(value.timestamp === undefined || Number.isFinite(value.timestamp));
 
 /** One card the window renders while the program waits for an answer. */
 export interface PermissionRequest {

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -40,9 +40,14 @@ interface ItemBase {
 	readonly timestamp: number;
 }
 
+/**
+ * `local` marks a turn the core recorded when the operator sent it, before any layer confirmed it.
+ * The flag is gone the moment the layer echoes the turn back, because the echo replaces the item.
+ */
 export interface UserItem extends ItemBase {
 	readonly kind: "user";
 	readonly text: string;
+	readonly local?: boolean;
 }
 
 /** `interrupted` marks a turn the operator cut short; the resend is a fresh prompt, not a retry. */
@@ -123,6 +128,10 @@ export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 		return false;
 	switch (value.kind) {
 		case "user":
+			return (
+				typeof value.text === "string" &&
+				(value.local === undefined || typeof value.local === "boolean")
+			);
 		case "system":
 			return typeof value.text === "string";
 		case "assistant":

--- a/apps/tuval/src/ai-agent/program.ts
+++ b/apps/tuval/src/ai-agent/program.ts
@@ -136,10 +136,25 @@ export const aiAgentProgram = <RIn = never>(
 		}),
 		ports: portsOf(),
 		receive: {
-			[aiAgentPortNames.prompt]: (payload: PromptPayload) =>
-				payload.key === undefined
-					? refuse(PROMPT_ERROR, `a prompt arrived with no idempotency key: "${payload.text}"`)
-					: {type: "prompt", text: payload.text, key: payload.key},
+			[aiAgentPortNames.prompt]: (payload: PromptPayload) => {
+				if (payload.key === undefined) {
+					return refuse(
+						PROMPT_ERROR,
+						`a prompt arrived with no idempotency key: "${payload.text}"`,
+					);
+				}
+				// Refused rather than stamped here: a receiver is a pure translation, and the turn the
+				// core records off this Msg needs a clock only its sender holds (#7978).
+				if (payload.timestamp === undefined) {
+					return refuse(PROMPT_ERROR, `a prompt arrived with no timestamp: "${payload.text}"`);
+				}
+				return {
+					type: "prompt",
+					text: payload.text,
+					key: payload.key,
+					timestamp: payload.timestamp,
+				};
+			},
 			[aiAgentPortNames.pageRequest]: (payload: TranscriptPagePayload) =>
 				payload.kind === "request"
 					? {type: "page", before: payload.before, limit: payload.limit}

--- a/apps/tuval/src/ai-agent/records-the-operators-turn.unit.test.ts
+++ b/apps/tuval/src/ai-agent/records-the-operators-turn.unit.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The operator's own turn, from the send to whatever the layer does about it (#7978).
+ *
+ * The events are the ones `ScriptedAiAgent` actually queues, collected before any of them is
+ * folded, so the two halves the fix has to hold are separable here in a way they are not in a
+ * running process: what the transcript says the moment the `prompt` Msg lands, and what it says
+ * once the turn's events have gone through `update`.
+ *
+ * Two backends, one core rule. `plainReply` echoes the user turn back under its own id, which is
+ * Pi's shape; `noEchoReply` never mentions it, which is Claude's.
+ */
+
+import {applyCellChecked} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Stream} from "effect";
+import {
+	type AiAgentSessionCmd,
+	type AiAgentSessionMsg,
+	type AiAgentSessionState,
+	aiAgentSessionMachine,
+	initialState,
+	promptItemId,
+} from "./core/index.ts";
+import type {AgentEvent} from "./events.ts";
+import type {TranscriptItem, UserItem} from "./ports/index.ts";
+import {
+	noEchoReply,
+	noEchoReplyTurn,
+	plainReply,
+	plainReplyTurn,
+	SESSION_ID,
+} from "./service/fixtures/scripts.ts";
+import {type AgentScript, ScriptedAiAgent, TuvalAiAgent} from "./service/index.ts";
+
+const CWD = "/work";
+const SENT_AT = 1_700_000_000_000;
+
+/** `start` queues three events before any turn: starting, the mode list, ready. */
+const START_EVENTS = 3;
+
+const machine = aiAgentSessionMachine({cwd: CWD});
+
+const apply = (
+	state: AiAgentSessionState,
+	msg: AiAgentSessionMsg,
+): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
+
+const ready: AiAgentSessionState = {...initialState(CWD), phase: "ready", sessionId: SESSION_ID};
+
+/** What one scripted turn puts on the stream, with `start`'s own three dropped. */
+const turnEvents = (
+	script: AgentScript,
+	text: string,
+	count: number,
+): Effect.Effect<ReadonlyArray<AgentEvent>> =>
+	Effect.gen(function* () {
+		const agent = yield* TuvalAiAgent;
+		yield* agent.start({cwd: CWD}).pipe(Effect.orDie);
+		yield* agent.prompt(text, "k1").pipe(Effect.orDie);
+		const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS + count)).pipe(
+			Effect.orDie,
+		);
+		return events.slice(START_EVENTS);
+	}).pipe(Effect.provide(ScriptedAiAgent.layer(script)), Effect.scoped);
+
+const foldAll = (
+	state: AiAgentSessionState,
+	events: ReadonlyArray<AgentEvent>,
+): AiAgentSessionState =>
+	events.reduce(
+		(carried, event) => apply(carried, {type: "event", sessionId: SESSION_ID, event})[0],
+		state,
+	);
+
+const usersIn = (items: ReadonlyArray<TranscriptItem>): ReadonlyArray<UserItem> =>
+	items.filter((item): item is UserItem => item.kind === "user");
+
+const send = (text: string): AiAgentSessionMsg => ({
+	type: "prompt",
+	text,
+	key: "k1",
+	timestamp: SENT_AT,
+});
+
+describe("a backend that echoes the operator's turn", () => {
+	it.effect("shows the send at once, then keeps it exactly once under the layer's id", () =>
+		Effect.gen(function* () {
+			const events = yield* turnEvents(plainReply, "hello", plainReplyTurn.length);
+			const echo = events[1];
+			assert.strictEqual(echo?.kind === "item" ? echo.item.kind : null, "user");
+
+			const [sent] = apply(ready, send("hello"));
+			assert.deepStrictEqual(
+				usersIn(sent.transcript.items).map((item) => [item.id, item.text, item.local]),
+				[[promptItemId("k1"), "hello", true]],
+			);
+
+			const settled = foldAll(sent, events);
+			assert.deepStrictEqual(
+				usersIn(settled.transcript.items).map((item) => [item.id, item.text, item.local]),
+				[["u1", "hello", undefined]],
+			);
+			assert.deepStrictEqual(
+				settled.transcript.items.map((item) => item.id),
+				["u1", "a1"],
+			);
+		}),
+	);
+});
+
+describe("a backend that never echoes it", () => {
+	it.effect("leaves the recorded turn standing, shown exactly once", () =>
+		Effect.gen(function* () {
+			const events = yield* turnEvents(noEchoReply, "hello", noEchoReplyTurn.length);
+			const [sent] = apply(ready, send("hello"));
+			const settled = foldAll(sent, events);
+
+			assert.deepStrictEqual(
+				usersIn(settled.transcript.items).map((item) => [item.id, item.text]),
+				[[promptItemId("k1"), "hello"]],
+			);
+			assert.deepStrictEqual(
+				settled.transcript.items.map((item) => item.id),
+				[promptItemId("k1"), "a4"],
+			);
+		}),
+	);
+});

--- a/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
@@ -8,7 +8,13 @@
 
 import {describe, expect, it} from "vitest";
 import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
-import {type AiAgentSessionState, initialState, parseSessionState, restore} from "../core/index.ts";
+import {
+	type AiAgentSessionState,
+	initialState,
+	parseSessionState,
+	promptItemId,
+	restore,
+} from "../core/index.ts";
 import {Mode, type PermissionRequest} from "../ports/index.ts";
 import {checkpointFields, resumeMessages} from "./checkpoint.ts";
 
@@ -111,6 +117,28 @@ describe("restoring a saved session", () => {
 
 	it("leaves a session the backend already refused gone", () => {
 		expect(restore({...saved, phase: "gone"}).phase).toBe("gone");
+	});
+
+	it("brings back a send no layer had echoed yet, once and unchanged", () => {
+		const unechoed: AiAgentSessionState = {
+			...saved,
+			transcript: {
+				...saved.transcript,
+				items: [
+					{...userItem(promptItemId("k1"), "make the README"), local: true},
+					assistantItem("i1"),
+				],
+			},
+		};
+		const restored = restore(unechoed);
+		expect(restored.transcript.items[0]).toEqual({
+			...userItem(promptItemId("k1"), "make the README"),
+			local: true,
+		});
+		expect(restored.transcript.items).toHaveLength(2);
+		// The cut-short marking is the other half of a `prompting` checkpoint and is untouched by it.
+		expect(restored.interrupted).toBe("i1");
+		expect(restored.transcript.items[1]).toEqual({...assistantItem("i1"), interrupted: true});
 	});
 });
 

--- a/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
@@ -127,7 +127,11 @@ const handlesOf = (booted: Booted) =>
 
 /** One prompt, sent the way a window sends one: out of the window's own out-port. */
 const say = (window: ProcessHandle, text: string, key: string) =>
-	window.dispatch({type: "say", port: aiAgentPortNames.prompt, payload: {text, key}});
+	window.dispatch({
+		type: "say",
+		port: aiAgentPortNames.prompt,
+		payload: {text, key, timestamp: Date.now()},
+	});
 
 interface FirstRun {
 	readonly phase: AiAgentSessionState["phase"];

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -153,7 +153,7 @@ const runToTheCut = (stores: CheckpointStores, starts: Array<StartOptions>) =>
 				services: Context.make(ProcessPorts, recorder(log)),
 			});
 			yield* eventually(() => sessionOf(handle.getState()).sessionId !== null);
-			yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1"});
+			yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1", timestamp: Date.now()});
 			yield* eventually(() => Object.keys(sessionOf(handle.getState()).permissions).length === 2);
 			assert.strictEqual(
 				sessionOf(handle.getState()).phase,

--- a/apps/tuval/src/ai-agent/service/fixtures/scripts.ts
+++ b/apps/tuval/src/ai-agent/service/fixtures/scripts.ts
@@ -51,6 +51,15 @@ export const plainReplyTurn: ReadonlyArray<AgentEvent> = [
 
 export const plainReply: AgentScript = {...empty, turns: [{events: plainReplyTurn}]};
 
+/** A backend that never echoes the operator's turn: the reply is the only item this one emits. */
+export const noEchoReplyTurn: ReadonlyArray<AgentEvent> = [
+	{kind: "phase", phase: "prompting"},
+	{kind: "item", item: item({kind: "assistant", id: id("a4"), timestamp: at(12), text: "on it"})},
+	{kind: "phase", phase: "ready"},
+];
+
+export const noEchoReply: AgentScript = {...empty, turns: [{events: noEchoReplyTurn}]};
+
 export const runningTool: ToolItem = {
 	kind: "tool",
 	id: id("t1"),

--- a/apps/tuval/src/claude/agent/phases.unit.test.ts
+++ b/apps/tuval/src/claude/agent/phases.unit.test.ts
@@ -58,6 +58,8 @@ const apply = (
 
 const opened: AiAgentSessionState = {...initialState(CWD), phase: "ready", sessionId: SESSION_ID};
 
+const SENT_AT = 1_700_000_000_000;
+
 const fold = (state: AiAgentSessionState, events: ReadonlyArray<AgentEvent>): AiAgentSessionState =>
 	events.reduce(
 		(carried, event) => apply(carried, {type: "event", sessionId: SESSION_ID, event})[0],
@@ -101,7 +103,12 @@ describe("the core over what the layer emitted", () => {
 	it.effect("keeps the session prompting for the whole turn, so the window reads working", () =>
 		Effect.gen(function* () {
 			const events = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
-			const [prompting] = apply(opened, {type: "prompt", text: "hello", key: "k1"});
+			const [prompting] = apply(opened, {
+				type: "prompt",
+				text: "hello",
+				key: "k1",
+				timestamp: SENT_AT,
+			});
 			// Every event but the last, which is the turn's own end.
 			const running = fold(prompting, events.slice(0, -1));
 			assert.strictEqual(running.phase, "prompting");
@@ -111,10 +118,20 @@ describe("the core over what the layer emitted", () => {
 	it.effect("admits a second prompt once the turn's result has landed", () =>
 		Effect.gen(function* () {
 			const events = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
-			const [prompting] = apply(opened, {type: "prompt", text: "hello", key: "k1"});
+			const [prompting] = apply(opened, {
+				type: "prompt",
+				text: "hello",
+				key: "k1",
+				timestamp: SENT_AT,
+			});
 			const settled = fold(prompting, events);
 			assert.strictEqual(settled.phase, "ready");
-			const [next, cmds] = apply(settled, {type: "prompt", text: "and again", key: "k2"});
+			const [next, cmds] = apply(settled, {
+				type: "prompt",
+				text: "and again",
+				key: "k2",
+				timestamp: SENT_AT,
+			});
 			assert.isNull(next.failure);
 			assert.deepStrictEqual(cmds, [{type: "aiAgent.prompt", text: "and again", key: "k2"}]);
 		}),

--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -73,6 +73,7 @@ import {
 	afterTheResend,
 	afterTheSecondTurn,
 	OFFERED,
+	RESEND_KEY,
 	SESSION,
 	SWITCHED_TO,
 	TOOL_ITEM,
@@ -340,7 +341,7 @@ const chat = Effect.fn("claudeVertical.chat")(function* (
 	key: string,
 ) {
 	const was = replies(before).length;
-	yield* session.send({type: "prompt", text, key});
+	yield* session.send({type: "prompt", text, key, timestamp: Date.now()});
 	const after = yield* liveWhere(
 		session.seen,
 		`the reply to "${text}"`,
@@ -748,7 +749,12 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 
 									// The third turn writes half a reply and never reports `ready`. Waiting on
 									// the committed item is what makes the stop land inside it.
-									yield* session.send({type: "prompt", text: PROMPT_3, key: "k3"});
+									yield* session.send({
+										type: "prompt",
+										text: PROMPT_3,
+										key: "k3",
+										timestamp: Date.now(),
+									});
 									const cut = yield* liveWhere(
 										session.seen,
 										"the cut turn's half-written reply",
@@ -799,10 +805,15 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 							);
 
 							// Not `chat`: the resend answers the prompt the restart cut, so its turn carries no
-							// user item and the tail must not grow a second copy of `u3`. What one deliberate
-							// send has to produce is one reply, and that is what is waited for.
+							// user item from the layer and the tail must not grow a second copy of `u3`. What
+							// one deliberate send has to produce is one reply, and that is what is waited for.
 							const was = replies(restored).length;
-							yield* session.send({type: "prompt", text: PROMPT_4, key: "k4"});
+							yield* session.send({
+								type: "prompt",
+								text: PROMPT_4,
+								key: RESEND_KEY,
+								timestamp: Date.now(),
+							});
 							const grown = yield* liveWhere(
 								session.seen,
 								`the reply to the resend "${PROMPT_4}"`,
@@ -960,7 +971,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 									tools.handlers.send({
 										process: spawned.process,
 										port: "prompt",
-										payload: {text: CHILD_PROMPT, key: "child-1"},
+										payload: {text: CHILD_PROMPT, key: "child-1", timestamp: Date.now()},
 									}),
 								),
 							) as {readonly delivered: boolean};

--- a/apps/tuval/src/claude/proof/script.ts
+++ b/apps/tuval/src/claude/proof/script.ts
@@ -13,6 +13,7 @@
  * (`./serve.ts`), never a CI job.
  */
 
+import {promptItemId} from "../../ai-agent/core/index.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import type {
 	ItemId,
@@ -120,7 +121,11 @@ const cutTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "item", item: assistant("a3", REPLY_3, 7)},
 ];
 
-/** The resend, one item long, so one deliberate send is one new emission on `transcript`. */
+/**
+ * The resend, one item long: Claude's mapping emits no user item of its own, so the reply is the
+ * whole of what this layer reports. The operator's half of that turn is the one the core recorded
+ * when they sent it (#7978), which is why `afterTheResend` names it under the send's own key.
+ */
 const resendTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
 	{kind: "item", item: assistant("a4", REPLY_4, 8)},
@@ -131,7 +136,8 @@ const resendTurn: ReadonlyArray<AgentEvent> = [
 export const afterTheFirstTurn = ["u1", "t1", "a1"];
 export const afterTheSecondTurn = [...afterTheFirstTurn, "u2", "a2"];
 export const afterTheCut = [...afterTheSecondTurn, "u3", "a3"];
-export const afterTheResend = [...afterTheCut, "a4"];
+export const RESEND_KEY = "k4";
+export const afterTheResend = [...afterTheCut, promptItemId(RESEND_KEY), "a4"];
 
 export const claudeScript: AgentScript = {
 	sessionId: SESSION,

--- a/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
@@ -130,7 +130,11 @@ const handlesOf = (booted: Booted) =>
 
 /** One prompt, sent the way a window sends one: out of the window's own out-port. */
 const say = (window: ProcessHandle, text: string, key: string) =>
-	window.dispatch({type: "say", port: aiAgentPortNames.prompt, payload: {text, key}});
+	window.dispatch({
+		type: "say",
+		port: aiAgentPortNames.prompt,
+		payload: {text, key, timestamp: Date.now()},
+	});
 
 const answerCard = (window: ProcessHandle) =>
 	window.dispatch({

--- a/apps/tuval/src/claude/window/claude-chat-window.unit.test.tsx
+++ b/apps/tuval/src/claude/window/claude-chat-window.unit.test.tsx
@@ -49,6 +49,8 @@ interface Opened {
 	readonly hosts: ReadonlyArray<ClaudeHost>;
 }
 
+const SENT_AT = 1_700_000_000_000;
+
 /** Deterministic keys, so two windows driven the same way produce byte-identical prompts. */
 const countingKeys = () => {
 	let next = 0;
@@ -67,6 +69,7 @@ const open = async (state: AiAgentSessionState, windows = 1): Promise<Opened> =>
 		scrollCommitMs: 0,
 		scrollToFn: () => undefined,
 		newKey: countingKeys(),
+		now: () => SENT_AT,
 	});
 	const hosts: Array<ClaudeHost> = [];
 	for (let index = 0; index < windows; index += 1) {
@@ -218,6 +221,7 @@ describe("what this binding adds to the shared window", () => {
 			scrollCommitMs: 0,
 			scrollToFn: () => undefined,
 			newKey: countingKeys(),
+			now: () => SENT_AT,
 		});
 		const rendered = render(renderer.render(host) as ReactElement);
 		await within(rendered.container).findByRole("log", {name: "Transcript"});
@@ -258,7 +262,7 @@ describe("what this binding adds to the shared window", () => {
 		expect(claude.process.inbox()).toEqual(shared.process.inbox());
 		// The drive is only a real test of "adds nothing" if it actually made the window send.
 		expect(shared.process.inbox()).toEqual([
-			{type: "prompt", text: "ship it", key: "k0"},
+			{type: "prompt", text: "ship it", key: "k0", timestamp: SENT_AT},
 			{type: "interrupt"},
 		]);
 	});

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -599,7 +599,12 @@ const runServiceAgent = Effect.gen(function* () {
 			const state = agent.getState();
 			return isAiAgentSessionState(state) && state.sessionId !== null;
 		});
-		yield* agent.dispatch({type: "prompt", text: "call every spell you can", key: "k1"});
+		yield* agent.dispatch({
+			type: "prompt",
+			text: "call every spell you can",
+			key: "k1",
+			timestamp: Date.now(),
+		});
 		yield* eventually(() => (lastTranscript(emitted)?.items.length ?? 0) >= answered.length);
 		const help = yield* overTheWire(["help"], {});
 		return {

--- a/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
+++ b/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
@@ -288,7 +288,7 @@ const chat = Effect.fn("piVertical.chat")(function* (
 	key: string,
 ) {
 	const was = replies(before).length;
-	yield* session.send({type: "prompt", text, key});
+	yield* session.send({type: "prompt", text, key, timestamp: Date.now()});
 	const after = yield* liveWhere(
 		session.seen,
 		`the reply to "${text}"`,

--- a/apps/tuval/src/pi/proof/serve.ts
+++ b/apps/tuval/src/pi/proof/serve.ts
@@ -133,7 +133,9 @@ const proof = Command.make(
 		yield* until("the Pi session to open", () => session().phase === "ready", seen);
 		for (const [index, text] of [PROMPT_1, PROMPT_2].entries()) {
 			const before = replies();
-			yield* agent.dispatch({type: "prompt", text, key: `harness-${index}`}).pipe(Effect.orDie);
+			yield* agent
+				.dispatch({type: "prompt", text, key: `harness-${index}`, timestamp: Date.now()})
+				.pipe(Effect.orDie);
 			yield* until(`the reply to "${text}"`, () => replies() > before, seen);
 		}
 

--- a/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
+++ b/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
@@ -112,7 +112,11 @@ const handlesOf = (booted: Booted) =>
 
 /** One prompt, sent the way a window sends one: out of the window's own out-port. */
 const say = (window: ProcessHandle, text: string, key: string) =>
-	window.dispatch({type: "say", port: aiAgentPortNames.prompt, payload: {text, key}});
+	window.dispatch({
+		type: "say",
+		port: aiAgentPortNames.prompt,
+		payload: {text, key, timestamp: Date.now()},
+	});
 
 const askForPage = (window: ProcessHandle, limit: number) =>
 	window.dispatch({

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -70,6 +70,8 @@ export interface ChatWindowOptions {
 	readonly extras?: (state: AiAgentSessionState) => ReactNode;
 	/** Mints one idempotency key per deliberate send (ruling 2, #7570). */
 	readonly newKey?: () => string;
+	/** The clock a send stamps its turn with, so no update cell has to read one (#7978). */
+	readonly now?: () => number;
 	readonly pageLimit?: number;
 	readonly overscan?: number;
 	/** First guess per row, before the row is rendered and measured. */
@@ -88,6 +90,7 @@ export interface ChatWindowOptions {
 interface ResolvedOptions {
 	readonly extras: ((state: AiAgentSessionState) => ReactNode) | null;
 	readonly newKey: () => string;
+	readonly now: () => number;
 	readonly pageLimit: number;
 	readonly overscan: number;
 	readonly estimateRowHeight: number;
@@ -99,6 +102,7 @@ interface ResolvedOptions {
 const resolve = (options: ChatWindowOptions): ResolvedOptions => ({
 	extras: options.extras ?? null,
 	newKey: options.newKey ?? (() => crypto.randomUUID()),
+	now: options.now ?? (() => Date.now()),
 	pageLimit: options.pageLimit ?? 50,
 	overscan: options.overscan ?? 6,
 	estimateRowHeight: options.estimateRowHeight ?? 72,
@@ -401,7 +405,7 @@ function ChatWindow({
 			composerBridge({
 				initialPhase: phase,
 				onPrompt: (text) => {
-					dispatch({type: "prompt", text, key: options.newKey()});
+					dispatch({type: "prompt", text, key: options.newKey(), timestamp: options.now()});
 					commit((current) => (current.draft === "" ? current : {...current, draft: ""}));
 				},
 				onInterrupt: () => dispatch({type: "interrupt"}),
@@ -409,7 +413,7 @@ function ChatWindow({
 		// `phase` seeds the bridge and is deliberately not a dependency: `AgentChatInput` re-runs its
 		// whole load on a new bridge identity, so a bridge rebuilt per phase would drop the composer
 		// back into `loading` on every turn. The phase reaches it through `setPhase` below instead.
-		[dispatch, commit, options.newKey],
+		[dispatch, commit, options.newKey, options.now],
 	);
 	useEffect(() => composer.setPhase(phase), [composer, phase]);
 
@@ -417,8 +421,8 @@ function ChatWindow({
 	const lastPrompt = state?.lastPrompt ?? null;
 	const resend = useCallback(() => {
 		if (lastPrompt === null) return;
-		dispatch({type: "prompt", text: lastPrompt, key: options.newKey()});
-	}, [dispatch, lastPrompt, options.newKey]);
+		dispatch({type: "prompt", text: lastPrompt, key: options.newKey(), timestamp: options.now()});
+	}, [dispatch, lastPrompt, options.newKey, options.now]);
 
 	const onKeyDown = useCallback(
 		(event: ReactKeyboardEvent<HTMLDivElement>) => {

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -39,6 +39,9 @@ interface Harness {
 	readonly keys: ReadonlyArray<string>;
 }
 
+/** The send clock every dispatched prompt in this file wears. */
+const SENT_AT = 1_700_000_000_000;
+
 const openWindow = async (
 	state: AiAgentSessionState,
 	options: ChatWindowOptions = {},
@@ -61,6 +64,7 @@ const openWindow = async (
 			keys.push(key);
 			return key;
 		},
+		now: () => SENT_AT,
 		scrollCommitMs: 0,
 		scrollToFn: (offset) => void scrolls.push(offset),
 		...options,
@@ -214,7 +218,12 @@ describe("the composer", () => {
 			fireEvent.keyDown(input, {key: "Enter"});
 		});
 		await waitFor(() => expect(process.inbox().length).toBe(1));
-		expect(process.inbox()[0]).toEqual({type: "prompt", text: "ship it", key: keys[0]});
+		expect(process.inbox()[0]).toEqual({
+			type: "prompt",
+			text: "ship it",
+			key: keys[0],
+			timestamp: SENT_AT,
+		});
 		await waitFor(() => expect(view().draft).toBe(""));
 		expect(input.value).toBe("");
 	});
@@ -272,7 +281,12 @@ describe("an interrupted turn", () => {
 			fireEvent.click(resend);
 		});
 		await waitFor(() => expect(process.inbox().length).toBe(1));
-		expect(process.inbox()[0]).toEqual({type: "prompt", text: "go", key: keys[0]});
+		expect(process.inbox()[0]).toEqual({
+			type: "prompt",
+			text: "go",
+			key: keys[0],
+			timestamp: SENT_AT,
+		});
 	});
 
 	it("resends on Alt+R from the composer, and on nothing else", async () => {
@@ -285,7 +299,7 @@ describe("an interrupted turn", () => {
 			fireEvent.keyDown(composer(), {key: "r", altKey: true});
 		});
 		await waitFor(() => expect(process.inbox().length).toBe(1));
-		expect(process.inbox()[0]).toEqual({type: "prompt", text: "go", key: "k0"});
+		expect(process.inbox()[0]).toEqual({type: "prompt", text: "go", key: "k0", timestamp: SENT_AT});
 	});
 });
 


### PR DESCRIPTION
Fixes #7978

A Pi chat window showed the operator's own message only when the agent's reply came back, because the core never recorded it — a prompt reached the transcript only if the backend echoed the turn. What the operator saw depended on a backend's echo habits rather than on the act of sending.

The `prompt` cell in `apps/tuval/src/ai-agent/core/machine.ts` now writes a `user` item onto the transcript when the session is `ready`, folded through the same `foldItem` / `planTranscriptWindow` path as any other item. Its `ItemId` is `local:<key>`, derived from the send's own idempotency key, so a replayed prompt lands on the item it already made rather than a second one.

Reconciliation is the part that is not a one-liner. `upsertItem` in `fold.ts` still matches by id first; when that misses and the incoming item is a `user` item the layer minted, it joins onto the first still-unconfirmed local user item with the same text and replaces it in place. The survivor is the layer's item, so it carries the layer's id and `chatRows` dedups it against a history page returning the same turn. A layer that never echoes leaves the local item standing, shown once.

The marker is `local?: boolean` on `UserItem`, the same shape `interrupted` already has on `AssistantItem` — plain data a checkpoint carries, cleared by the echo replacing the item. Two locally-recorded items never reconcile against each other, so two deliberate sends of the same text stay two turns.

No update cell reads a clock: the item's `timestamp` rides on the `prompt` Msg. `ChatWindow` stamps it from a new `now` option beside `newKey`. On the port path, `PromptPayload` gains an optional `timestamp` and the receiver refuses a prompt without one, exactly as it already refuses a prompt without a `key` — the receiver stays the pure translation its docblock says it is.

One fix covers both backends: Pi shows the message immediately and reconciles on the echo, and Claude shows it because nothing supersedes it. The Claude vertical proof's `afterTheResend` now names the recorded turn, which is that layer's half of #7979 falling out of this change.

Reviewer's first stop: `upsertItem`'s echo join in `apps/tuval/src/ai-agent/core/fold.ts` — the text match is the only join the core has, and its two guards (id first, never local-against-local) are what keep it from collapsing distinct turns.

Grounded in source, not intuition: the reconciliation constraint comes from `chatRows`' id-keyed dedup in `apps/tuval/src/shell/chat/rows.ts` and Pi's `itemOf` / `eventsOf` in `apps/tuval/src/pi/ai-agent/items.ts`, both read at this branch's base.

## Deviations

- **Out-of-scope change** — **Said:** #7978 names the core's recording rule and its reconciliation. **Did:** also added `timestamp` to `PromptPayload` and a refusal arm in the program's `receive`. **Why:** the criteria forbid a clock in any update cell, so the value has to arrive as data, and the port is one of the two ways a `prompt` Msg is made. **Disposition:** stated here; the refusal mirrors the `key` arm beside it exactly.
- **Known defect left unfixed** — **Said:** nothing about the `send` tool. **Did:** left it reporting `delivered: true` for a prompt payload the receiver then refuses. **Why:** it predates this change (`key` had the same shape) and fixing it is a port-contract decision, not this issue's. **Disposition:** filed as #7991.
- **Known defect left unfixed** — **Said:** the suites pass. **Did:** they do, but the pre-push hook's `unit-changed` run failed three times on timeouts before landing. **Why:** a pre-existing load flake — `boot.unit.test.ts`, `shell/program.unit.test.ts` and `chat-a11y.unit.test.tsx` each timed out under the parallel run and each passed alone; the identical command with `--maxWorkers=2` passed whole at 53 files / 468 tests. **Disposition:** reproduction added to #7964, which owns this flake.
