### PR TITLE
chore: The kernel-before-restore ordering in Tuval's boot has no test pinning it

### DIFF
--- a/apps/tuval/src/config-fixtures/kernel-restore.ts
+++ b/apps/tuval/src/config-fixtures/kernel-restore.ts
@@ -1,0 +1,70 @@
+/**
+ * A config whose graph plans no node, holding one row whose handler needs a kernel service outside
+ * `restore`'s own four. Boot's launcher has nothing to bring back here, so a checkpointed process
+ * of this row can only return through `restore` — and can only run its handler if the context
+ * `boot.ts` hands `restore` still carries the kernel (`boot-restore-context.unit.test.ts`).
+ */
+
+import {defineMachine} from "@demlik/tea";
+import {Effect} from "effect";
+import {SpellBridge} from "../commands/bridge/index.ts";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
+
+export const bridgeProbeId = ProgramId.make("bridge-probe");
+
+/** `marks` is what the first boot writes; `spells` is what only a kernel-carrying restore can fill. */
+export interface BridgeProbeState {
+	readonly marks: number;
+	readonly spells: number;
+}
+
+export type BridgeProbeMsg =
+	| {readonly type: "mark"}
+	| {readonly type: "resumed"}
+	| {readonly type: "saw"; readonly spells: number};
+
+type BridgeProbeCmd = {readonly type: "count-spells"};
+
+const bridgeProbe = {
+	id: bridgeProbeId,
+	core: defineMachine<BridgeProbeState, BridgeProbeMsg, BridgeProbeCmd, never, unknown>({
+		init: (loaded) => [loaded ?? {marks: 0, spells: 0}, []],
+		update: {
+			mark: (state) => [{...state, marks: state.marks + 1}, []],
+			resumed: (state) => [state, [{type: "count-spells"}]],
+			saw: (state, msg) => [{...state, spells: msg.spells}, []],
+		},
+		interpret: {"count-spells": () => Promise.resolve()},
+	}),
+	ports: {},
+	handlers: {
+		"count-spells": () =>
+			Effect.map(
+				Effect.flatMap(SpellBridge, (bridge) => bridge.list),
+				(rows) => [{type: "saw", spells: rows.length}] as ReadonlyArray<BridgeProbeMsg>,
+			),
+	},
+	// The spawner's own last step: what a restored process is sent, and the only thing that reaches
+	// the handler above without a test dispatching into the process by hand.
+	resume: () => [{type: "resumed"}] as ReadonlyArray<BridgeProbeMsg>,
+	capabilities: [],
+	identity: {
+		package: "@kampus/tuval",
+		program: "bridge-probe",
+		version: "1.0.0",
+		digest: "sha256:bridge-probe",
+	},
+	placement: {host: "local"},
+} satisfies Program<
+	BridgeProbeState,
+	BridgeProbeMsg,
+	BridgeProbeCmd,
+	never,
+	unknown,
+	never,
+	SpellBridge
+>;
+
+const programs: ReadonlyArray<AnyProgram> = [bridgeProbe];
+
+export default {version: 1, programs};

--- a/apps/tuval/src/durability/boot-restore-context.unit.test.ts
+++ b/apps/tuval/src/durability/boot-restore-context.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The context `boot.ts` hands `restore`, pinned from `boot` itself rather than from a hand-built
+ * kernel. `restore` takes `Context.Context<never>` and accepts whatever it is given, so the
+ * guarantee that a restored process gets the whole kernel is positional and the checker has no
+ * opinion about it — it has been got wrong twice (#7951, #7976) and nothing failed (#7993).
+ *
+ * What makes it falsifiable is the config: `config-fixtures/kernel-restore.ts` plans no graph node,
+ * so the launcher has nothing to bring back and `restore` is the only route the checkpointed row
+ * has. Its handler needs `SpellBridge`, a kernel service outside restore's own four (`Checkpoints`,
+ * `Processes`, `ProcessTable`, `Registry`) — narrow the context `boot.ts` restores under and the
+ * second boot dies with `Service not found: tuval/SpellBridge`.
+ *
+ * The narrowing has to be of both routes at once, because `boot.ts` carries the kernel on two:
+ * `restore`'s `services` argument, and the ambient `Effect.provideContext(kernel)` around the call.
+ * `Effect.provideContext` merges into the fiber's context rather than replacing it
+ * (`effect` `src/internal/effect.ts`'s `provideContext`, `updateContext(self, Context.merge(…))`),
+ * so a handler that misses the argument still resolves off the ambient and each route masks the
+ * other. That a spawner's `services` is a floor rather than the set is #7972's, not this test's.
+ */
+
+import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Option} from "effect";
+import {afterEach} from "vitest";
+import {boot, coreSpells, projectDir} from "../boot.ts";
+import {SpawnedProcesses} from "../commands/core/process.ts";
+import {bridgeProbeId} from "../config-fixtures/kernel-restore.ts";
+import {Processes} from "../process/Processes.ts";
+import type {ProcessId} from "../process/process.ts";
+
+const config = fileURLToPath(new URL("../config-fixtures/kernel-restore.ts", import.meta.url));
+
+const tempDirs: string[] = [];
+
+/** A project dir whose `.tuval/` exists and is empty: no project config, nothing checkpointed yet. */
+const freshProject = () => {
+	// realpath: macOS resolves /var to /private/var, and the boot reports the dir it is given.
+	const project = realpathSync(mkdtempSync(join(tmpdir(), "tuval-restore-context-")));
+	tempDirs.push(project);
+	mkdirSync(projectDir(project));
+	return project;
+};
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, {recursive: true, force: true});
+});
+
+const handleOf = (id: ProcessId) =>
+	Effect.map(
+		Processes.use((processes) => processes.handle(id)),
+		Option.getOrThrowWith(() => new Error(`no live handle for process "${id}"`)),
+	);
+
+/**
+ * The first boot: nothing is planned and nothing is checkpointed, so the probe is spawned the way
+ * the picker spawns one — under no node — and marked twice, which is the state the next boot has
+ * to find. Its handler is never reached here: `SpawnedProcesses` hands a spawn its ports and
+ * nothing else, so `mark` is deliberately a Msg that emits no Cmd.
+ */
+const firstBoot = (project: string) =>
+	Effect.gen(function* () {
+		const booted = yield* boot({global: config, project});
+		const id = yield* SpawnedProcesses.use((spawned) =>
+			spawned.spawn(bridgeProbeId, Option.none()),
+		).pipe(Effect.provideContext(booted.kernel));
+		const handle = yield* handleOf(id).pipe(Effect.provideContext(booted.kernel));
+		yield* handle.dispatch({type: "mark"});
+		yield* handle.dispatch({type: "mark"});
+		return {id, report: booted.report, state: handle.getState()};
+	}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer), Effect.orDie);
+
+/**
+ * The second boot over the same state dir: `restore` spawns the probe back and dispatches the row's
+ * own `resume`, whose Cmd handler asks the kernel for `SpellBridge`. `handle.dispatch` runs to idle,
+ * so the follow-up is folded into the state before `boot` returns.
+ */
+const secondBoot = (project: string, id: ProcessId) =>
+	Effect.gen(function* () {
+		const booted = yield* boot({global: config, project});
+		const handle = yield* handleOf(id).pipe(Effect.provideContext(booted.kernel));
+		return {report: booted.report, state: handle.getState()};
+	}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer), Effect.orDie);
+
+describe("the kernel context boot hands restore", () => {
+	it.effect("a restored process the graph never planned resumes on the whole kernel", () =>
+		Effect.gen(function* () {
+			const project = freshProject();
+
+			const first = yield* firstBoot(project);
+			// Nothing was planned and nothing was checkpointed, so neither spawner brought anything
+			// back — the row below is the only thing the second boot can restore.
+			assert.strictEqual(first.report.processCount, 0);
+			assert.strictEqual(first.report.restoredCount, 0);
+			assert.deepStrictEqual(first.state, {marks: 2, spells: 0});
+
+			const second = yield* secondBoot(project, first.id);
+
+			// One process back, and `restore` is what brought it: the graph plans no node, so the
+			// launcher had nothing to spawn at all.
+			assert.strictEqual(second.report.processCount, 1);
+			assert.strictEqual(second.report.restoredCount, 1);
+			// A boot registering no core spell would make the `spells` row below read 0 either way,
+			// which is the reading that would pass with the bridge never resolved.
+			assert.isAbove(coreSpells.length, 0);
+			// `marks` is the checkpointed state coming back; `spells` is the resume's handler having
+			// resolved `SpellBridge` out of the context `boot.ts` restored under.
+			assert.deepStrictEqual(second.state, {marks: 2, spells: coreSpells.length});
+		}),
+	);
+});


### PR DESCRIPTION
Fixes #7993

`apps/tuval/src/boot.ts` builds the kernel and then restores under it. Nothing failed if that
context was narrowed — `restore` takes `Context.Context<never>` and accepts whatever it is handed,
so the guarantee was positional and the checker had no opinion about it. The ordering has been got
wrong twice (#7951, #7976), and the proof that would have caught the second went away with the
retired PR #7988.

Two new files, no production change:

- `apps/tuval/src/config-fixtures/kernel-restore.ts` — a config whose graph plans **no node**, with
  one row whose Cmd handler needs `SpellBridge`. Nothing is planned, so the launcher has nothing to
  bring back and `restore` is the only route a checkpointed row of it has. `SpellBridge` sits
  outside restore's own four requirements (`Checkpoints`, `Processes`, `ProcessTable`, `Registry`),
  so a context around the restore cannot supply it. The row declares `resume`, so `restore`'s last
  step dispatches into it and the handler runs before `boot` returns.
- `apps/tuval/src/durability/boot-restore-context.unit.test.ts` — two `boot()` calls over one temp
  project dir. The first spawns the row the way the picker does (under no node) and marks it twice;
  the second asserts `restoredCount` is 1 and that the process came back holding both `marks: 2`
  (the checkpointed state) and `spells: coreSpells.length` (the resume's handler having resolved
  the bridge). No real Claude or Pi CLI, no model spend, no CLI subprocess — it runs in CI.

`pnpm typecheck`, `pnpm lint` and the full `apps/tuval` suite (172 files, 1333 tests) are green.

## How it reds

With `boot.ts` restoring under a context that drops `SpellBridge`:

```ts
const narrow = Context.pick(Checkpoints, Processes, ProcessTable, Registry)(kernel);
const restored = yield* restore(narrow).pipe(Effect.provideContext(narrow));
```

```
Error: Service not found: tuval/SpellBridge
    at Tuval.host.interpret (apps/tuval/src/host/actor.ts:417:10)
    at Tuval.host.commit (apps/tuval/src/host/actor.ts:466:10)
    at Tuval.Processes.spawn (apps/tuval/src/durability/restore.ts:51:30)
```

## Deviations

- **Scope narrowing** — **Said:** criterion 4 asks the test to red "with `boot.ts` handing `restore`
  a context missing that kernel service". **Did:** the red proof narrows *both* the `services`
  argument and the ambient `Effect.provideContext(kernel)` around the call; narrowing either one
  alone leaves the test green, and I measured all three. **Why:** `boot.ts` carries the kernel on
  both routes at once, and `Effect.provideContext` merges into the fiber's context rather than
  replacing it (`effect` `src/internal/effect.ts`, `provideContext` = `updateContext(self,
  Context.merge(context))`), so each route masks the other. No test can red on the argument alone
  while the ambient still carries the service. **Disposition:** stated here and in the test's
  docblock; the underlying "a spawner's `services` is a floor, not the set" is already filed as
  #7972, and I added the three measurements to it —
  https://github.com/kamp-us/phoenix/issues/7972#issuecomment-5554455606.
