### PR TITLE
fix: Tuval chat composer sits at a fixed width with empty columns on both sides of its window

### DIFF
--- a/apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx
@@ -72,6 +72,8 @@ interface ComposerBox {
 	readonly centred: boolean;
 }
 
+/** Each field answers one question: a cap is reported by `capped`, never folded into the size. */
+
 const composerBox = (parentWidth: number): ComposerBox => {
 	const root = document.querySelector(".kp-agent-chat");
 	if (root === null) throw new Error("the composer root .kp-agent-chat did not render");
@@ -82,10 +84,9 @@ const composerBox = (parentWidth: number): ComposerBox => {
 
 	const size = resolve(declared("inline-size") || declared("width"));
 	const cap = declared("max-inline-size") || declared("max-width");
-	const isCap = cap !== "" && cap !== "none";
 	return {
-		inlineSize: isCap ? Number.NaN : (size ?? Number.NaN),
-		capped: isCap,
+		inlineSize: size ?? Number.NaN,
+		capped: cap !== "" && cap !== "none",
 		centred: [
 			declared("margin-inline-start") || declared("margin-left"),
 			declared("margin-inline-end") || declared("margin-right"),

--- a/apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer fills the chat window, at every window width (#7989).
+ *
+ * The rule under test is `@kampus/design`'s, not Tuval's, so this file reads the shipped
+ * `AgentChatInput.css` off disk and puts it in the document — the component's own
+ * `import "./AgentChatInput.css"` resolves to an empty module under Vitest's default `css: false`,
+ * so without this the window renders unstyled and every width assertion is vacuous. Resolving it
+ * through `import.meta.resolve("@kampus/design")` rather than a `../` climb keeps the test pointed
+ * at the same file the component imports.
+ *
+ * jsdom runs no layout engine, and this slice's shims (`../ui/dom.testing.ts`) hand every element
+ * one fixed 1000×1000 box, so `getBoundingClientRect` cannot answer what width the composer takes.
+ * What jsdom does resolve is the cascade's declared values, and the defect lived entirely there: a
+ * `max-width` plus `margin: 0 auto` on `.kp-agent-chat` capped and centred the box inside a
+ * full-width window. So `composerBox` resolves those declarations against a known parent width the
+ * way a layout engine would, and the assertions are over that.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {render} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {beforeAll, describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type TestProcess, testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {sessionState} from "./chat.testing.ts";
+import type {ChatView} from "./view.ts";
+
+installDomShims();
+
+const designCss = (name: string): string => {
+	const entry = fileURLToPath(import.meta.resolve("@kampus/design"));
+	return readFileSync(entry.replace(/index\.ts$/, name), "utf8");
+};
+
+beforeAll(() => {
+	const style = document.createElement("style");
+	style.textContent = designCss("AgentChatInput.css");
+	document.head.appendChild(style);
+});
+
+const emptyView: ChatView = {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []};
+
+/** Mounts the window inside a parent of a known inline size, the way a desk window sizes it. */
+const openWindowIn = async (parentWidth: number): Promise<void> => {
+	const process: TestProcess<AiAgentSessionState, AiAgentSessionMsg> = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), sessionState()),
+	);
+	const host = await Effect.runPromise(process.window<ChatView>(WindowId.make("w1"), emptyView));
+	const element = chatWindow({scrollCommitMs: 0, scrollToFn: () => {}}).render(
+		host,
+	) as ReactElement;
+	const parent = document.createElement("div");
+	parent.style.width = `${parentWidth}px`;
+	document.body.appendChild(parent);
+	render(element, {container: parent});
+};
+
+interface ComposerBox {
+	/** The inline size the declarations resolve to, in px, against the parent's own width. */
+	readonly inlineSize: number;
+	/** Whether anything on the root caps that size below the parent's. */
+	readonly capped: boolean;
+	/** Whether an `auto` inline margin centres what is left, leaving side gaps. */
+	readonly centred: boolean;
+}
+
+const composerBox = (parentWidth: number): ComposerBox => {
+	const root = document.querySelector(".kp-agent-chat");
+	if (root === null) throw new Error("the composer root .kp-agent-chat did not render");
+	const style = getComputedStyle(root);
+	const declared = (property: string): string => style.getPropertyValue(property).trim();
+	const resolve = (value: string): number | null =>
+		value.endsWith("%") ? (Number.parseFloat(value) / 100) * parentWidth : null;
+
+	const size = resolve(declared("inline-size") || declared("width"));
+	const cap = declared("max-inline-size") || declared("max-width");
+	const isCap = cap !== "" && cap !== "none";
+	return {
+		inlineSize: isCap ? Number.NaN : (size ?? Number.NaN),
+		capped: isCap,
+		centred: [
+			declared("margin-inline-start") || declared("margin-left"),
+			declared("margin-inline-end") || declared("margin-right"),
+		].includes("auto"),
+	};
+};
+
+// A phone-narrow window and a wide one. The bug was width-blind — the cap and the auto margins
+// applied identically at both — so a single width could not have told the two states apart.
+describe.each([
+	["a narrow window", 360],
+	["a wide window", 1440],
+])("the composer in %s", (_label, parentWidth) => {
+	it("fills its parent's inline size, uncapped and uncentred", async () => {
+		await openWindowIn(parentWidth);
+		expect(composerBox(parentWidth)).toEqual({
+			inlineSize: parentWidth,
+			capped: false,
+			centred: false,
+		});
+	});
+});

--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -5,13 +5,18 @@
 	color: var(--text-secondary);
 }
 
+/*
+ * The composer fills its parent's inline size, and the parent owns any reading-width cap. A
+ * package default that capped and auto-centred here was authored against apps/web's centred page
+ * and was wrong in every other host: Tuval's chat window is the whole width of a desk window, and
+ * the cap left dead columns beside a full-width transcript (#7989). A consumer that wants a
+ * reading width sets one on the element it mounts this into.
+ */
 .kp-agent-chat {
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-3);
-	width: 100%;
-	max-width: calc(var(--s-8) * 16);
-	margin: 0 auto;
+	inline-size: 100%;
 }
 
 .kp-agent-chat__composer {


### PR DESCRIPTION
Fixes #7989

`.kp-agent-chat` capped itself at `calc(var(--s-8) * 16)` and auto-centred what was left. The default was authored against apps/web's centred page and was wrong in every other host: Tuval's chat window is the whole width of a desk window, so the composer sat as a narrow centred box with dead columns beside a full-width transcript.

Both declarations are gone, and the rule now says `inline-size: 100%` — a consumer that wants a reading width sets one on the element it mounts this into.

## Measured, in a real browser

Tuval's own `pnpm proof:chat` page (two chat windows side by side, the shape the founder screenshotted), driven headless. Composer box vs the transcript directly above it, in the left pane:

| Window | Transcript | Composer before | Side gaps before | Composer after | Side gaps after |
|---|---|---|---|---|---|
| 900px | 426px | 426px | 0 / 0 | 426px | 0 / 0 |
| 1400px | 676px | 640px | 18 / 18 | 676px | 0 / 0 |
| 2000px | 976px | 640px | **168 / 168** | 976px | **0 / 0** |

At 900px the pane is narrower than the 640px cap, so the cap never bit there — which is why the defect reads as "wide windows waste a third of the row". At 2000px it pinned the composer to 640px with 168px of dead column on each side, matching the report.

Screenshots at 2000px, before and after, are attached below.

## The apps/web lab exhibit

`/lab/atolye/agent-chat-input`, captured the same way at a 1400px window: the exhibit stage measures 684px and the composer fills it at 650px — within a pixel or two of the 640px it had under the cap. The atölye page's own `--content-w` container plus the 16rem controls panel already constrain it from outside, so nothing had to be added there and the exhibit reads exactly as it did.

## Test

`apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx` renders Tuval's `ChatWindow` inside a parent of a known width, at 360px and 1440px, and asserts the composer root fills it — uncapped, uncentred. It reads the shipped `AgentChatInput.css` off disk and puts it in the document, because the component's own `import "./AgentChatInput.css"` resolves to an empty module under Vitest's default `css: false` and without that the assertions would be vacuous.

Proven red before green: against the rule as it stood, both cases failed with `{capped: true, centred: true}`.

jsdom runs no layout engine and this slice's shims hand every element one fixed 1000×1000 box, so `getBoundingClientRect` cannot answer what width the composer takes. The test resolves the cascade's declared values against a known parent width instead, which is where the defect lived entirely. The measured half of the claim is the browser table above.

## Repair round 1

Two changes since the first review:

- The probe's `inlineSize` no longer doubles as a cap flag. It used to return `Number.NaN` when a cap was present, so one field answered two questions and a red run printed a `NaN` instead of the defect. Each field answers one now, and the red was re-proved against the old rule at both widths — it fails on `capped` and `centred` with the real sizes shown.
- A new head, so CI runs again. The `unit + client tests` red at the previous head was `apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts:91` timing out, not this diff's code.

## Deviations

- **Scope narrowing** — **Said:** the issue's AC 5 asks for manual browser evidence of Tuval's desk at two window widths. **Did:** captured the evidence with a headless Chromium run against this tree's own `pnpm proof:chat` page and `apps/web` vite server, and posted the screenshots as PR comments, rather than through `fabrika ui evidence`. **Why:** the repo's declared render harness serves apps/web and gates on `/api/health`, which proxies to the `alchemy dev` worker on :1337; in this worktree that worker never became ready and port 3000 was held by a sibling worktree's server, so `fabrika ui render` exited 11 (harness never ready) on every attempt — UNKNOWN, never a passing render. **Disposition:** stated here with the proven exit code; the measured numbers and both screenshots are on this PR, and the design gate owns whether that channel is acceptable.
- **Scope narrowing** — **Said:** AC 2 asks that no layout measure in `AgentChatInput.css` derive from `--s-8` any more, or that the PR say in one line why one stays. **Did:** removed only the root's `max-width`, leaving five `--s-8` derivations (the textarea's `min-height`, the suggestion list's `max-height`, the setting-select trigger's `max-width`, the picker menu's `width`, the assistant text's `max-height`). **Why:** each of those is a control or content-block dimension that should grow with the density setting; only a reading width must not, and that one is gone. **Disposition:** accepted under the AC's own one-line escape hatch, which this entry is.
- **Known defect left unfixed** — **Said:** AC 7 asks that the `apps/tuval` suite pass. **Did:** shipped without fixing the timing-sensitive tuval proofs that go red under machine contention; the previous head's CI red was `src/ai-agent/restore/restore-proof.unit.test.ts:91` (`timed out waiting for the cut turn's half-written reply, committed`). **Why:** it is not this diff's — the diff is one CSS rule plus one new test file, neither on any path that file exercises. Confirmed by running it in this tree on the same code: the full `apps/tuval` suite failed once and then passed on a re-run (174 files, 1344 tests), and the file alone passes in 285ms against a 6s poll budget. Already tracked as #7964. **Disposition:** not fixed here; a fresh CI run at the new head is the only repair this PR can make, and `ci-required` still gates the merge on the same read.

LAW-SOURCE: manifest-prose (`design-system-manifest.md`; the repo ships no typed `design-prohibitions.json`, so `fabrika ui law` reported the law untyped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWpocvhfpBpQL153qLGyks
