### PR TITLE
fix: The design package uses kp-visually-hidden but does not ship its rule, so Tuval's page scrolls sideways

### DIFF
--- a/apps/tuval/src/page/main.tsx
+++ b/apps/tuval/src/page/main.tsx
@@ -29,6 +29,10 @@ import {pageRenderers} from "./renderers.tsx";
 import "@manti-ui/styles/index.css";
 import "@kampus/design/fonts.css";
 import "@kampus/design/tokens.css";
+// Tuval's own markup carries `kp-visually-hidden` too (`shell/chat/ToolRow.tsx`), so the page takes
+// the package's rule directly rather than inheriting it from whichever design component happens to
+// be in the bundle (#7984).
+import "@kampus/design/visually-hidden.css";
 import "../shell/ui/tokens.css";
 import "./page.css";
 

--- a/apps/tuval/src/shell/chat/chat-visually-hidden.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-visually-hidden.unit.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer's screen-reader-only text resolves to the hidden box, not to the container's width.
+ *
+ * `@kampus/design` marks that text with `kp-visually-hidden` and used to ship no rule for it, so in
+ * Tuval every such element laid out at full width and the page scrolled sideways — 2026 CSS px of
+ * `scrollWidth` against a 1333 px viewport (#7984). The rule now lives in the package, and one of
+ * its sites is a Manti field ROOT (`AgentChatInput.tsx` puts the class on an `Input`), which this
+ * directory's own `.tuval-chat [data-scope="field"][data-part="root"]` rule outranks on
+ * specificity. So this file loads BOTH real stylesheets and reads the cascade's answer.
+ *
+ * jsdom has no layout, but it does resolve the cascade for `getComputedStyle` — which is the
+ * question here, the defect having been a losing declaration rather than a wrong number. One limit
+ * is load-bearing enough to state: cssstyle does not know `inline-size`, so it neither maps it onto
+ * `width` (a browser does, in horizontal-tb) nor honours `!important` on it. The window's field-root
+ * rule is written in exactly that spelling, so the collision itself is not decidable here. The
+ * third test covers what jsdom cannot: that the shipped rule declares the box `!important` at all,
+ * which is what makes it unoutrankable in the browser. The browser measurement in the PR body is
+ * the ground truth for the resolved layout.
+ */
+
+import {readFileSync} from "node:fs";
+import {createRequire} from "node:module";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {beforeAll, describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
+import {userItem, withTranscript} from "./chat.testing.ts";
+import type {ChatView} from "./view.ts";
+
+installDomShims();
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolved through the package's `exports` map, so a package that stops publishing the stylesheet
+ * fails here rather than falling back to a path that happens to exist.
+ */
+const packageRule = createRequire(import.meta.url).resolve("@kampus/design/visually-hidden.css");
+
+beforeAll(() => {
+	for (const path of [packageRule, join(here, "chat.css")]) {
+		const style = document.createElement("style");
+		style.textContent = readFileSync(path, "utf8");
+		document.head.appendChild(style);
+	}
+});
+
+const openComposer = async (): Promise<void> => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+			ProcessId.make("p1"),
+			withTranscript([userItem("a", "do it")]),
+		),
+	);
+	const view: ChatView = {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []};
+	const host: ChatWindowHost = await Effect.runPromise(
+		process.window<ChatView>(WindowId.make("w1"), view),
+	);
+	render(chatWindow({scrollCommitMs: 0, scrollToFn: () => {}}).render(host) as ReactElement);
+	await screen.findByRole("log", {name: "Transcript"});
+};
+
+const hidden = (): ReadonlyArray<HTMLElement> =>
+	Array.from(document.querySelectorAll<HTMLElement>(".tuval-chat .kp-visually-hidden"));
+
+describe("the composer's visually-hidden text", () => {
+	it("resolves to the hidden box on every element that carries the class", async () => {
+		await openComposer();
+		expect(hidden().length).toBeGreaterThan(0);
+		for (const element of hidden()) {
+			const style = getComputedStyle(element);
+			expect({
+				tag: element.tagName,
+				position: style.position,
+				width: style.width,
+				height: style.height,
+				overflow: style.overflow,
+				clip: style.clip,
+			}).toEqual({
+				tag: element.tagName,
+				position: "absolute",
+				width: "1px",
+				height: "1px",
+				overflow: "hidden",
+				clip: "rect(0px, 0px, 0px, 0px)",
+			});
+		}
+	});
+
+	it("covers the file input, whose class lands on the field root rather than a span", async () => {
+		await openComposer();
+		const fieldRoots = hidden().filter((element) => element.getAttribute("data-part") === "root");
+		expect(fieldRoots.length).toBeGreaterThan(0);
+		for (const root of fieldRoots) {
+			expect(root.querySelector("input[type='file']")).not.toBeNull();
+			expect(getComputedStyle(root).width).toBe("1px");
+		}
+	});
+
+	it("is declared important, which is what no consumer selector can outrank", async () => {
+		const rule = readFileSync(packageRule, "utf8");
+		const declarations = rule.slice(rule.indexOf("{"), rule.indexOf("}"));
+		const box = ["position", "width", "height", "overflow", "clip", "clip-path"];
+		for (const property of box) {
+			expect(declarations).toMatch(new RegExp(`\\n\\t${property}:[^;]+!important;`));
+		}
+	});
+});

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -85,24 +85,6 @@
 	inline-size: 100%;
 }
 
-/*
- * `@kampus/design` components mark a screen-reader-only label with this class, but the rule that
- * hides it lives in apps/web's own `global.css` — app-owned by the #7561 extraction, and Tuval is
- * not that app. Without it every hidden label paints: a real browser load showed "Add an image" and
- * the file input's own chrome sitting in the composer. Same clip-rect declaration as the web app's.
- */
-.tuval-chat .kp-visually-hidden {
-	position: absolute;
-	inline-size: 1px;
-	block-size: 1px;
-	margin: -1px;
-	padding: 0;
-	border: 0;
-	overflow: hidden;
-	clip-path: inset(50%);
-	white-space: nowrap;
-}
-
 /* Manti's field root is inline-sized by the consuming app's own reset; the composer fills its box. */
 .tuval-chat [data-scope="field"][data-part="root"] {
 	inline-size: 100%;

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -3,6 +3,7 @@
 
 @import "@kampus/design/fonts.css";
 @import "@kampus/design/tokens.css";
+@import "@kampus/design/visually-hidden.css";
 
 *,
 *::before,
@@ -104,21 +105,6 @@ select {
 [data-scope="field"][data-part="root"]:has(:focus-visible) [data-part="control"] {
 	outline: var(--focus-ring);
 	outline-offset: var(--focus-ring-offset);
-}
-
-/* Visually-hidden but AT-readable text (#2169). Standard clip-rect: stays in the
-   accessibility tree + reading order while taking no visual space, for a text
-   suffix that names state a sighted user reads from color/position alone. */
-.kp-visually-hidden {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	padding: 0;
-	border: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
 }
 
 /* Reduced motion — global, unconditional a11y baseline (WCAG 2.3.3).

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -8,7 +8,8 @@
 		".": "./src/index.ts",
 		"./a11y": "./src/a11y/check.ts",
 		"./tokens.css": "./src/tokens.css",
-		"./fonts.css": "./src/fonts.css"
+		"./fonts.css": "./src/fonts.css",
+		"./visually-hidden.css": "./src/visually-hidden.css"
 	},
 	"scripts": {
 		"typecheck": "tsc -p tsconfig.json && effect-tsgo diagnostics --project tsconfig.json --strict",

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -49,6 +49,7 @@ import {type DesignCatalogKey, type DesignTranslate, useDesignT} from "./i18n";
 import {Menu, type MenuItem} from "./Menu";
 import {Select, type SelectItem} from "./Select";
 import "./AgentChatInput.css";
+import "./visually-hidden.css";
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 

--- a/packages/design/src/CaylakBadge.tsx
+++ b/packages/design/src/CaylakBadge.tsx
@@ -8,6 +8,7 @@
 import {Badge} from "./Badge";
 import {useDesignT} from "./i18n";
 import "./CaylakBadge.css";
+import "./visually-hidden.css";
 
 /**
  * @component CaylakBadge

--- a/packages/design/src/kp-class-coverage.test.ts
+++ b/packages/design/src/kp-class-coverage.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Every `kp-*` class a component under `src/` names must be declared by a stylesheet under `src/`.
+ *
+ * The package shipped `kp-visually-hidden` for months with its only declaration in `apps/web`'s
+ * app-owned `global.css`, so every consumer that was not that app rendered the hidden text at full
+ * width — Tuval's composer pushed the page into horizontal scroll (#7984). Nothing caught it
+ * because a class reference and a class declaration live in different files and no check compared
+ * them. This is that comparison.
+ *
+ * Two limits, both deliberate. A class assembled from a template literal (`kp-surface--tone-${t}`)
+ * is not checked, because its full name does not exist in the source; the static prefix is skipped
+ * rather than reported as missing. And a class with no rule is not always a defect — some are
+ * consumer-facing hooks — so those are named in `UNSTYLED_HOOKS` with a reason each, never
+ * tolerated silently.
+ */
+
+import {readdirSync, readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Classes a component names purely as a hook — no rule in this package, and none owed. Each entry
+ * carries why; an entry that gains a rule loses its place here.
+ */
+const UNSTYLED_HOOKS: Readonly<Record<string, string>> = {
+	"kp-card": "Card's naming hook over Surface, which carries every rule the card renders with.",
+	"kp-edited-indicator": "Marker for consumers to target; the indicator's own styling is Tag's.",
+	"kp-agent-chat__delivery": "Hook on the delivery Select; the control's styling is Manti's.",
+	"kp-agent-chat__error": "Hook on the error Alert; the styling is Alert's own.",
+	"kp-agent-chat__setting-select--model":
+		"Modifier hook beside the styled `kp-agent-chat__setting-select` base.",
+};
+
+const walk = (dir: string): ReadonlyArray<string> =>
+	readdirSync(dir, {withFileTypes: true}).flatMap((entry) =>
+		entry.isDirectory() ? walk(join(dir, entry.name)) : [join(dir, entry.name)],
+	);
+
+/** Block and line comments are prose, not class references — a name inside one is not a use. */
+const withoutComments = (source: string): string =>
+	source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+
+const files = walk(SRC);
+
+const referenced = (): ReadonlyMap<string, ReadonlyArray<string>> => {
+	const found = new Map<string, Array<string>>();
+	for (const file of files) {
+		if (!/\.tsx?$/.test(file) || /\.test\.tsx?$/.test(file)) continue;
+		// The lookahead drops the static head of an interpolated name, which is not a class. It has
+		// to bar a name character too: without that, `kp-tone-${t}` backtracks one character and
+		// reports `kp-tone` as a missing class.
+		for (const match of withoutComments(readFileSync(file, "utf8")).matchAll(
+			/\bkp-[A-Za-z0-9_-]+(?![A-Za-z0-9_-]|\$\{)/g,
+		)) {
+			const sites = found.get(match[0]) ?? [];
+			sites.push(file.slice(SRC.length + 1));
+			found.set(match[0], sites);
+		}
+	}
+	return found;
+};
+
+const declared = (): ReadonlySet<string> => {
+	const found = new Set<string>();
+	for (const file of files) {
+		if (!file.endsWith(".css")) continue;
+		for (const [, name] of readFileSync(file, "utf8").matchAll(/\.(kp-[A-Za-z0-9_-]+)/g)) {
+			if (name !== undefined) found.add(name);
+		}
+	}
+	return found;
+};
+
+describe("every kp-* class a component names", () => {
+	it("is declared by a stylesheet this package ships", () => {
+		const rules = declared();
+		const undeclared = [...referenced()]
+			.filter(([name]) => !rules.has(name) && !(name in UNSTYLED_HOOKS))
+			.map(([name, sites]) => `${name} (${sites.join(", ")})`)
+			.sort();
+		expect(undeclared).toEqual([]);
+	});
+
+	it("covers the visually-hidden class, whose absence was the defect", () => {
+		expect(declared().has("kp-visually-hidden")).toBe(true);
+		expect([...referenced().keys()]).toContain("kp-visually-hidden");
+	});
+
+	it("leaves no stale entry in the unstyled-hook list", () => {
+		const rules = declared();
+		const used = referenced();
+		const stale = Object.keys(UNSTYLED_HOOKS).filter((name) => rules.has(name) || !used.has(name));
+		expect(stale).toEqual([]);
+	});
+});

--- a/packages/design/src/visually-hidden.css
+++ b/packages/design/src/visually-hidden.css
@@ -1,0 +1,25 @@
+/* Visually-hidden but AT-readable text (#2169), owned by the package that uses the class (#7984).
+   Standard clip-rect: stays in the accessibility tree + reading order while taking no visual space.
+
+   Every declaration is `!important` because this class must win wherever it lands, and one of its
+   sites is not an element the package controls: `AgentChatInput.tsx` puts it on a Manti `Input`,
+   which forwards it to the field ROOT, and a consuming app's own `[data-scope="field"]
+   [data-part="root"]` rule is (0,3,0) against this selector's (0,1,0). Tuval's composer painted at
+   the container's full width for exactly that reason and pushed the page into horizontal scroll.
+   Importance sits above specificity in the cascade, so no consumer selector can outrank this —
+   including one written in the logical spelling, since `inline-size` and `width` are the same
+   property in horizontal-tb. */
+/* biome-ignore-start lint/complexity/noImportantStyles: see above — a consuming app's field-root selector outranks this one on specificity, and the hidden box must not be outrankable. */
+.kp-visually-hidden {
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	margin: -1px !important;
+	padding: 0 !important;
+	border: 0 !important;
+	overflow: hidden !important;
+	clip: rect(0, 0, 0, 0) !important;
+	clip-path: inset(50%) !important;
+	white-space: nowrap !important;
+}
+/* biome-ignore-end lint/complexity/noImportantStyles: end of the block above. */


### PR DESCRIPTION
`@kampus/design` marked its screen-reader-only text with `kp-visually-hidden` and shipped no rule
for it. The only declaration in the repo was `apps/web`'s app-owned `global.css`, so every consumer
that was not that app rendered the "hidden" text at full width. In Tuval that pushed the document
past the viewport and the desk scrolled off to the left.

The rule now lives in the package that uses the class: `packages/design/src/visually-hidden.css`,
imported by `AgentChatInput.tsx` and `CaylakBadge.tsx` so a consumer that imports nothing but the
components gets hidden text hidden, and exported as `@kampus/design/visually-hidden.css` for an app
that carries the class in its own markup. Both app copies of the declaration are gone; `apps/web`'s
`global.css` and Tuval's `page/main.tsx` import the package's instead.

## Why every declaration is `!important`

Tuval already carried a scoped copy (#7861) and still overflowed, because of one element.
`AgentChatInput.tsx:977` puts the class on a Manti `Input`, which lands it on the field **root**,
and a consuming app's `[data-scope="field"][data-part="root"] { inline-size: 100% }` is (0,3,0)
against the hidden rule's (0,1,0) — the wider selector won and the file-input root painted at the
container's width. Importance sits above specificity in the cascade, so nothing a consumer writes
can outrank it. That is the one thing the acceptance criteria ask for that specificity alone cannot
give.

## Browser measurement

Tuval's chat proof harness (`pnpm --filter @kampus/tuval proof:chat`), headless Chromium at a
1333 CSS-px viewport, two chat windows open — the same shape as the report's harness run. Measured
on the untouched base `8785178131` and again on this branch:

| | `scrollWidth` | `clientWidth` | elements past the right edge |
|---|---|---|---|
| base `8785178131` | 2025 | 1333 | 6 — both `DIV.kp-visually-hidden` field roots at `w=1333`, each with its `INPUT` at `w=1331` |
| this branch | 1333 | 1333 | 0 |

The two field roots go from `w=1333 h=1` to `w=1 h=1`, and all 12 `.kp-visually-hidden` elements
resolve to `position: absolute; overflow: hidden; clip-path: inset(50%)`.

## The check that would have caught it

`packages/design/src/kp-class-coverage.test.ts` compares every `kp-*` class a component under
`src/` names against every `kp-*` class a stylesheet under `src/` declares. Proven red before
green: adding `kp-not-a-real-class` to `CaylakBadge.tsx` fails it with
`+ "kp-not-a-real-class (CaylakBadge.tsx)"`, and removing it goes green.

Five classes are referenced with no rule and none owed — `kp-card`, `kp-edited-indicator` and three
`kp-agent-chat__*` hooks. They are named in `UNSTYLED_HOOKS` with a reason each rather than
tolerated silently, and a third test reds if an entry there becomes stale.

## Tuval's rendered assertion

`apps/tuval/src/shell/chat/chat-visually-hidden.unit.test.tsx` renders the real `ChatWindow`,
loads both real stylesheets, and reads the cascade's answer for every `.kp-visually-hidden` in the
composer, the file-input field root included. All three of its tests red when the package rule is
removed.

## Verification

- `pnpm typecheck` green across all 23 tasks; `pnpm lint` green.
- `packages/design`: 101 unit + 19 a11y tests green.
- `apps/web`: 2801 unit + 362 client tests green, `SozlukAlphabet.test.tsx` among them.
- `apps/tuval`: 1294 unit tests green.
- `guard design-token-guard`, `readme-guard`, `catalog-guard`, `i18n-guard`, `fanout-guard` all green.
- `apps/web` build green, and the built CSS carries the rule.

LAW-SOURCE: manifest-prose (`fabrika ui law` reports no `design-prohibitions.json`; the manifest's
prose prohibitions are the law).

## Deviations

- **Scope narrowing** — **Said:** the criteria ask the `apps/web` test suite to be green.
  **Did:** ran `test:unit` (2801) and `test:client` (362); the `integration` project was not run.
  **Why:** its `globalSetup` deploys a real Cloudflare stack and this worktree has no
  `CLOUDFLARE_API_TOKEN`, so the run aborts at setup with `Unauthorized` before any test executes.
  Nothing in this diff reaches the worker. **Disposition:** CI's integration job is the authority.
- **Declined guidance** — **Said:** `build-ui`'s loop attaches `fabrika ui render` captures as
  evidence. **Did:** measured with headless Chromium against Tuval's own `proof:chat` harness and
  put the numbers in the table above; no `ui evidence` comment is attached. **Why:**
  `design-harness.json` declares only `apps/web` (`url` localhost:3000, `command` `pnpm dev`), so
  no Tuval surface is reachable through it — already filed as #7992 — and the verb proved it here
  too: `fabrika ui render --out after --surface /` exits `11`, the harness could not start, because
  `pnpm dev` needs the Cloudflare credentials this worktree lacks. **Disposition:** stated here;
  the render gap is on the record and the measurement the issue asked for is above.
- **Known defect left unfixed** — **Said:** nothing. **Did:** hit repeated red pre-push runs
  (`boot.unit.test.ts`, `chat-a11y.unit.test.tsx`, both restore proofs) that all pass in isolation
  and passed in the final push, which was green across 163 Tuval and 327 web files. **Why:** it is
  the load-dependent fixed-attempt poll of #7964, which I reproduced on the untouched base
  `8785178131` and noted there; the box was at load average 158 from sibling lanes.
  **Disposition:** noted on #7964, not fixed here.
- **Out-of-scope change** — **Said:** #7984 names `packages/design` and the two app copies.
  **Did:** also added `import "@kampus/design/visually-hidden.css"` to `apps/tuval/src/page/main.tsx`.
  **Why:** Tuval's own `shell/chat/ToolRow.tsx` carries the class in Tuval's markup, not the
  package's, so without it the page would depend on a design component happening to be in the
  bundle — the same accidental coupling this issue is about. **Disposition:** stated here.

Fixes #7984
