### PR TITLE
fix: Tuval's command palette matches only on the spell path prefix, so "zoom" finds no spell

### DIFF
--- a/.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md
+++ b/.decisions/0348-tuval-command-framework-spell-registry-versioned-protocol.md
@@ -89,6 +89,29 @@ and migrating later, and a second 2026-09-03 ruling took it off this epic's tail
 own PR against main once three things are true, that #7556 and #7561 have closed and that the epic
 PR [#7687](https://github.com/kamp-us/phoenix/pull/7687) has merged.
 
+### The palette matching correction, 2026-09-05
+
+R1.5 and the correction above both read as one rule over both surfaces: exact prefix on the paths the
+system defines. Built that way, the palette narrowed only on the segment under the caret, so `zoom`
+answered "No spell matches what you have typed" while `window zoom` sat in the unfiltered list — a
+reader who remembers the verb and not the group could reach nothing
+([#8002](https://github.com/kamp-us/phoenix/issues/8002)).
+
+Put to the founder as one question — does the listbox loosen while Tab stays exact-prefix? — and
+ruled 2026-09-05, "yes to both"
+([the ruling comment](https://github.com/kamp-us/phoenix/issues/8002#issuecomment-5554612396)).
+
+**R1.5's exact-prefix rule is scoped to completion, not to finding.** `candidatesFor` — Tab, the `:`
+line — stays exactly as R1.5 says. The palette's listbox ranks in three tiers: exact prefix on the
+next segment first, then a substring of the rest of the path, then a substring of the spell's
+`describe` sentence. Accepting any of them types the whole remaining path, so the parser reads what
+the palette listed. The value half of R1.5 is untouched: a window id or a workspace name still ranks
+fuzzily on recency.
+
+The argument behind R1.5's rule 1 survives the scoping. "A system name is something to recall, not
+something to search" is about what a *completion* offers to type next, where a loose offer types a
+word the reader did not mean. A palette is the surface where recall has already failed.
+
 ### The tail review rulings, 2026-09-03
 
 The tail review of the epic PR ([#7687](https://github.com/kamp-us/phoenix/pull/7687)) found two

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -618,8 +618,28 @@ already opens — never a second mechanism.
 the runnable thing, so `paletteCandidates` walks the trie past the matching segment and lists every
 spell beneath it with its `describe`: typing `win` offers `window close`, `window move` and
 `window focus`, not the bare word `window`. On a value slot it hands straight back to
-`candidatesFor`, so the fuzzy-on-recency rule is unchanged. Prefix on the paths the system defines,
-fuzzy on the values a user named — one rule per slot, the same split `complete` makes.
+`candidatesFor`, so the fuzzy-on-recency rule is unchanged.
+
+**The palette's path slot lists more than the prefix reaches; completion's does not.** Completion's
+rule 1 above is exact prefix and stays that way — Tab, the `:` line and `candidatesFor` are one
+behaviour. The palette's listbox adds two looser tiers underneath it, because a prefix-only listbox
+is unreachable for a reader who remembers the verb and not the group: `zoom` found nothing while
+`window zoom` sat in the unfiltered list
+([#8002](https://github.com/kamp-us/phoenix/issues/8002), the founder's
+[2026-09-05 ruling](https://github.com/kamp-us/phoenix/issues/8002#issuecomment-5554612396), which
+scopes ADR 0348's R1.5 to completion). The three tiers, in order:
+
+1. **Exact prefix on the next segment** — the completion rule, and it always ranks first.
+2. **Substring of the rest of the path** — `space` lists `workspace new` and `workspace activate`.
+3. **Substring of the `describe` sentence** — `focus` lists `window focus` on its path, then
+   `window close` and `window move` on "the focused window".
+
+All three fold case, and registry order survives inside a tier (`Array.prototype.sort` is stable,
+ECMA-262 §23.1.3.30). A row's `value` is the whole remaining path however it was matched, so
+accepting a sentence-matched row still leaves a line the parser reads as that spell's path.
+
+So: exact prefix wherever the system's names are being *completed*, a looser listing wherever they
+are being *found*, and fuzzy on the values a user named.
 
 **One field, and the rows are never focusable.** The ARIA combobox pattern: the caret stays in the
 input for the palette's whole life and the active row is named by `aria-activedescendant`. That is

--- a/apps/tuval/src/palette/candidates.ts
+++ b/apps/tuval/src/palette/candidates.ts
@@ -8,8 +8,16 @@
  * `window focus`, not the bare word `window`. On a value slot it hands straight back to
  * `candidatesFor`, so a window id or a workspace name still ranks fuzzily on recency (#7617 R1.5).
  *
- * That split is the founder's ruling made concrete: prefix on the paths the system defines, fuzzy on
- * the values a user named (the 2026-09-03 walk on #7643; ADR 0348, `.patterns/tuval-spells.md`).
+ * A path slot lists more than the prefix reaches. R1.5's exact-prefix rule is scoped to *completion*
+ * — Tab and the `:` line, where `candidatesFor` is untouched — while this listbox also lists a spell
+ * whose remaining path or whose sentence merely contains what was typed, so `zoom` finds
+ * `window zoom` (the founder's 2026-09-05 ruling on
+ * [#8002](https://github.com/kamp-us/phoenix/issues/8002#issuecomment-5554612396)). Three tiers, in
+ * this order: an exact prefix on the next segment, then a substring of the rest of the path, then a
+ * substring of the sentence.
+ *
+ * The value half is the founder's earlier ruling unchanged: fuzzy on the values a user named (the
+ * 2026-09-03 walk on #7643; ADR 0348, `.patterns/tuval-spells.md`).
  *
  * Everything here is pure and synchronous. The palette runs it on every keystroke against the
  * snapshot the page already holds, and never awaits the kernel to complete (#7617 R1.5).
@@ -72,6 +80,30 @@ const dedupe = (rows: ReadonlyArray<PaletteCandidate>): ReadonlyArray<PaletteCan
 	});
 };
 
+/** The one case rule every match here applies, the same fold `complete` applies to its own. */
+const fold = (text: string): string => text.toLowerCase();
+
+/**
+ * How a spell reached the list, low first. The order is the ruling: what the reader typed beats what
+ * they half-remembered of the path, which beats a word the palette only found in the sentence.
+ */
+const PREFIX = 0;
+const PATH = 1;
+const SENTENCE = 2;
+
+/** The tier a spell is listed at, or `undefined` for a spell the typed text does not reach at all. */
+const rankOf = (
+	needle: string,
+	prefixed: boolean,
+	remainingPath: string,
+	describe: string,
+): number | undefined => {
+	if (prefixed) return PREFIX;
+	if (fold(remainingPath).includes(needle)) return PATH;
+	if (fold(describe).includes(needle)) return SENTENCE;
+	return undefined;
+};
+
 export const paletteCandidates = (
 	input: string,
 	registry: SpellIndex,
@@ -92,19 +124,24 @@ export const paletteCandidates = (
 	// In a segment slot every token before the caret matched a segment, so the caret sits exactly
 	// `depth` segments deep and a spell's remaining path is what accepting the row types.
 	const {depth} = caretToken(input);
-	const rows: Array<PaletteCandidate> = [];
+	const needle = fold(slot.token.text);
+	const ranked: Array<{readonly rank: number; readonly row: PaletteCandidate}> = [];
 	for (const [segment, child] of slot.node.children) {
-		if (!segment.startsWith(slot.token.text)) continue;
+		const prefixed = fold(segment).startsWith(needle);
 		for (const spell of spellsUnder(child)) {
-			rows.push({
-				value: spell.path.slice(depth).join(" "),
-				label: spell.path.join(" "),
-				kind: "spell",
-				describe: spell.describe,
+			// Accepting any row types the whole remaining path, so a spell found through its sentence
+			// still leaves a line the parser reads as that spell's path.
+			const value = spell.path.slice(depth).join(" ");
+			const rank = rankOf(needle, prefixed, value, spell.describe);
+			if (rank === undefined) continue;
+			ranked.push({
+				rank,
+				row: {value, label: spell.path.join(" "), kind: "spell", describe: spell.describe},
 			});
 		}
 	}
-	return rows;
+	// Registry order survives inside a tier: ECMA-262 requires the sort to be stable (§23.1.3.30).
+	return ranked.sort((left, right) => left.rank - right.rank).map((entry) => entry.row);
 };
 
 /**

--- a/apps/tuval/src/palette/candidates.unit.test.ts
+++ b/apps/tuval/src/palette/candidates.unit.test.ts
@@ -4,11 +4,39 @@
  */
 
 import {describe, expect, it} from "vitest";
+import {jsonSchema} from "../commands/parse/fixtures.ts";
+import {buildSpellIndex} from "../commands/parse/spell-index.ts";
+import type {RegistryDescription} from "../protocol/registry-description.ts";
 import {acceptCandidate, paletteCandidates} from "./candidates.ts";
 import {registry, snapshot} from "./fixtures.ts";
 
 const labels = (input: string): ReadonlyArray<string> =>
 	paletteCandidates(input, registry, snapshot).map((candidate) => candidate.label);
+
+/**
+ * The desk the report was filed against (#8002): `window zoom` is the spell nobody could reach, and
+ * `desk reset`'s sentence names a window without its path saying so, which is the only pair that
+ * puts a prefix row and a sentence row in one list.
+ */
+const zoomDescriptions: RegistryDescription = [
+	{
+		path: ["window", "zoom"],
+		describe: "Render the focused window alone, or restore the split if one is already zoomed.",
+		params: jsonSchema({}, []),
+		capabilities: [],
+	},
+	{
+		path: ["desk", "reset"],
+		describe: "Drop every window back into the split.",
+		params: jsonSchema({}, []),
+		capabilities: [],
+	},
+];
+
+const zoomRegistry = buildSpellIndex(zoomDescriptions);
+
+const zoomLabels = (input: string): ReadonlyArray<string> =>
+	paletteCandidates(input, zoomRegistry, snapshot).map((candidate) => candidate.label);
 
 describe("paletteCandidates", () => {
 	it("lists the spells under a path prefix, not the bare segment", () => {
@@ -57,8 +85,26 @@ describe("paletteCandidates", () => {
 		expect(labels("window move l")).toEqual(["left"]);
 	});
 
-	it("offers nothing for a segment that prefixes nothing", () => {
+	it("offers nothing for a word that reaches no path and no sentence", () => {
 		expect(labels("zzz")).toEqual([]);
+	});
+
+	it("finds a spell by the last word of its path, not only the first (#8002)", () => {
+		expect(zoomLabels("zoom")).toEqual(["window zoom"]);
+	});
+
+	it("lists a spell a word reaches in the middle of its path", () => {
+		expect(labels("space")).toEqual(["workspace new", "workspace activate"]);
+	});
+
+	it("lists a spell matched only in its sentence, below every spell matched on its path", () => {
+		// `window focus` holds `focus` in its path; the other two hold it only in "the focused window".
+		expect(labels("focus")).toEqual(["window focus", "window close", "window move"]);
+	});
+
+	it("ranks an exact prefix above anything matched loosely", () => {
+		// `desk reset` reaches `window` only through its sentence, so it lands under the prefix row.
+		expect(zoomLabels("window")).toEqual(["window zoom", "desk reset"]);
 	});
 
 	it("shows one row per value, though a workspace offers both its name and its id", () => {
@@ -80,6 +126,11 @@ describe("acceptCandidate", () => {
 		const [first] = paletteCandidates("window cl", registry, snapshot);
 		expect(first === undefined ? "" : first.value).toBe("close");
 		expect(first === undefined ? "" : acceptCandidate("window cl", first)).toBe("window close ");
+	});
+
+	it("types the whole path of a loosely matched row, so the parser reads the spell", () => {
+		const [first] = paletteCandidates("zoom", zoomRegistry, snapshot);
+		expect(first === undefined ? "" : acceptCandidate("zoom", first)).toBe("window zoom ");
 	});
 
 	it("replaces the caret's token and leaves the line before it alone", () => {


### PR DESCRIPTION
Fixes #8002

The Cmd+K palette narrowed its list by prefix-matching only the segment under the caret, so a word
from the middle or the end of a spell's path found nothing: `zoom` answered "No spell matches what
you have typed" while `window zoom` sat in the unfiltered list. The `describe` sentence shown on
every row was never matched against at all.

`paletteCandidates` in `apps/tuval/src/palette/candidates.ts` now ranks a path slot in three tiers:

1. exact prefix on the next segment — the completion rule, always first;
2. a substring of the rest of the path — `space` lists `workspace new` and `workspace activate`;
3. a substring of the `describe` sentence — `focus` lists `window focus` on its path, then
   `window close` and `window move` on "the focused window".

Registry order survives inside a tier, and a row's `value` is the whole remaining path however it
was matched, so accepting a sentence-matched row leaves a line the parser reads as that spell's
full path.

`candidatesFor` is not touched: Tab, the `:` command line and the value slots behave exactly as
before. The founder ruled that scoping on 2026-09-05 — "yes to both", the listbox loosens while Tab
stays exact-prefix
([ruling](https://github.com/kamp-us/phoenix/issues/8002#issuecomment-5554612396)). ADR 0348 gets a
dated correction section scoping its R1.5 to completion, and `.patterns/tuval-spells.md` states the
two-rule split.

A reviewer should start at the three tiers in `candidates.ts` and the five new cases in
`candidates.unit.test.ts`.

## Deviations

- **Out-of-scope change** — **Said:** #8002 names only the prefix-vs-loose matching rule.
  **Did:** also case-folded the tier-1 prefix test (`fold(segment).startsWith(needle)`), which was
  case-sensitive before. **Why:** the two looser tiers fold case, and a palette where `Win` reaches a
  spell only through the substring tier while `win` reaches it through the prefix tier would rank the
  same spell differently for the same word; `complete.ts` already folds its own segment prefix
  (#7757). **Disposition:** stated here.
- **Scope narrowing** — **Said:** the criterion asks the test to cover the `zoom` to `window zoom`
  case. **Did:** built a two-spell registry local to `candidates.unit.test.ts` for that case instead
  of adding `window zoom` to the shared `apps/tuval/src/palette/fixtures.ts`. **Why:** that fixture
  is also read by `palette.unit.test.tsx` and `call.unit.test.ts`, which pin the registry's row count
  and its exact labels, and `palette.unit.test.tsx` is rewritten by the in-flight PR #7982.
  **Disposition:** stated here.
