### PR TITLE
feat: No design-harness.json, so ui render refuses every surface and no build-ui lane can attach evidence

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -134,9 +134,11 @@ Run Biome through pnpm — `pnpm lint`, `pnpm format`, or `pnpm biome …` — w
 
 | Key | Value | Why |
 |---|---|---|
-| `command` | copy `apps/web/.env.example` to `.env` when none is there, then `pnpm dev` | Both dev legs. The copy is what makes a fresh worktree bootable — that file holds throwaway dev values only. Output is redirected to stderr, which is the stream a failed readiness probe quotes back. |
+| `command` | copy `apps/web/.env.example` to `.env` when none is there, then `pnpm exec turbo run dev dev:worker --filter=@kampus/web` | Both dev legs, and only those. The copy is what makes a fresh worktree bootable — that file holds throwaway dev values only. Output is redirected to stderr, which is the stream a failed readiness probe quotes back. |
 | `url` | `http://localhost:3000` | Vite's port, which also proxies `/api` and `/fate` to the worker. |
 | `readyPath` | `/api/health` | 200 only once **both** legs answer. `/` would go green on Vite alone, and every capture would then show `şu an yüklenemedi` where the data belongs. |
+
+The `--filter=@kampus/web` is load-bearing, not tidiness. Bare `pnpm dev` is `turbo run dev dev:worker` across every workspace member, and `apps/tuval`'s own `dev` is `node src/bin.ts` — Tuval's kernel, a persistent process with no part in rendering an `apps/web` page (ADR [0345](./.decisions/0345-tuval-lives-under-apps.md)). It also writes a counter to stderr about once a second, and stderr is the 2000-character window `server.ts` quotes back when readiness fails, so an unfiltered command spends that window on Tuval's counter instead of the reason the worker never came up.
 
 **Reachable today:** the routes a signed-out visitor can actually see — `/`, `/pano`, `/sozluk`, `/mecmua`, `/divan`, `/search`, `/auth` and `/lab/atolye` among them. Point the harness at one of those and the capture is what a visitor sees.
 
@@ -144,7 +146,9 @@ Run Biome through pnpm — `pnpm lint`, `pnpm format`, or `pnpm biome …` — w
 
 Exit `15` is real but narrower than a UI route: it needs a response that is genuinely `>= 400`, which under this harness means an `/api/*` or `/fate/*` path proxied to a worker that is down. It refuses per surface, so that one path names itself while the rest of the repo still renders, rather than everything falling back to the repo-wide `19`. No SPA path produces it — not even one the router has no route for, which renders `NotFoundPage` at 200.
 
-`alchemy dev` binds real Cloudflare resources — there is no offline emulator, as the Quickstart says — so `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` have to be in your environment. Without them the worker leg never comes up, readiness times out, and `ui render` exits `11` with alchemy's own error on stderr. That is UNKNOWN, not a capture to trust.
+`alchemy dev` binds real Cloudflare resources — there is no offline emulator, as the Quickstart says — so `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` have to be in your environment. **Set is not enough: the token also has to carry the permission `alchemy.run.ts` needs**, which begins with `GET /accounts/{account_id}/flagship/apps`. A token that `/user/tokens/verify` calls `valid and active` but that 401s on that endpoint fails exactly like an absent one — the worker leg never comes up and readiness times out. Either way `ui render` exits `11`, and that is UNKNOWN, never a capture to trust.
+
+**Do not expect alchemy's own error in the refusal's stderr tail.** Vite logs an `ECONNREFUSED` proxy error for every readiness poll while the worker is down — twice a second, against `server.ts`'s 2000-character tail — so the boot error that actually explains the failure is evicted long before the 60s bound is up. Run `pnpm dev:worker` on its own to read it. Narrowing that tail to the cause is tracked on [#8025](https://github.com/kamp-us/phoenix/issues/8025).
 
 ## Conventions
 

--- a/design-harness.json
+++ b/design-harness.json
@@ -1,5 +1,5 @@
 {
-	"command": "[ -f apps/web/.env ] || cp apps/web/.env.example apps/web/.env; pnpm dev 1>&2",
+	"command": "[ -f apps/web/.env ] || cp apps/web/.env.example apps/web/.env; pnpm exec turbo run dev dev:worker --filter=@kampus/web 1>&2",
 	"url": "http://localhost:3000",
 	"readyPath": "/api/health"
 }


### PR DESCRIPTION
Part of #7395

Issue #7395's criteria 2 and 3 have been open since PR #7414 landed, waiting on someone with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` to run `fabrika ui render` live and prove the shipped harness produces a real capture. This lane had both variables, ran the probe, and found two things.

**The harness command boots an app that has nothing to do with rendering.** `command` was bare `pnpm dev`, which is `turbo run dev dev:worker` across every workspace member. Since `apps/tuval` landed it has a `dev` of its own (`node src/bin.ts`, Tuval's kernel), so every `ui render` started a third persistent process that writes a counter to stderr about once a second. Criterion 2 asks for both dev legs; this brought up three. Scoping to `--filter=@kampus/web` fixes it — verified: `Packages in scope: @kampus/web`, both `@kampus/web:dev` and `@kampus/web:dev:worker` running, zero Tuval lines, and Vite answering 200 on `http://localhost:3000/`.

**The worker leg still cannot boot here, for a reason the docs did not name.** Both variables set is not sufficient. This token is `valid and active` per `/user/tokens/verify` and 401s on `GET /accounts/{account_id}/flagship/apps`, which is the first call `alchemy.run.ts` makes — so `alchemy dev` dies on `Unauthorized: Authentication error`, readiness times out, and `ui render` exits `11`. A present-but-under-scoped token fails identically to an absent one. `DEVELOPMENT.md` said only "without them", so it now says what the token actually has to carry.

The doc also claimed the refusal quotes "alchemy's own error on stderr". It does not, and cannot: Vite logs an `ECONNREFUSED` proxy error on every 500ms readiness poll, against a 2000-character tail in `server.ts`, so the boot error is evicted within seconds of a 60-second bound. That is a fabrika-cli defect rather than a harness one — no `command` value can fix noise the probe itself generates — so it is filed as #8025 and the doc now tells the reader to run `pnpm dev:worker` separately instead.

Criteria 1 and 4 re-proven after the change: `fabrika ui manifest` still reports `"harness":"design-harness.json"`. Criteria 5-8 are unchanged from #7414. Criteria 2 and 3 stay unproven live, which is why this is `Part of`.

## Deviations

- **Scope narrowing** — **Said:** #7395's criteria 2 and 3 want a live `ui render` exiting 0 with a valid capture. **Did:** fixed a real defect in the harness `command` and corrected the docs, but produced no capture. **Why:** the worker leg needs a Cloudflare token carrying the Flagship permission; the one available here is valid but 401s on that endpoint, which is a credential-provisioning act no build lane can perform. **Disposition:** stated here, PR is `Part of` not `Fixes`, and the issue stays open on exactly the two criteria it was already open on.
- **Out-of-scope change** — **Said:** the issue is about declaring a working harness. **Did:** also rewrote the credential paragraph in `DEVELOPMENT.md`'s "Rendering surfaces" section, including a claim about the stderr tail that the issue never mentions. **Why:** criterion 7 asks that section to state what the harness can and cannot reach today, and the probe proved two of its existing sentences false — leaving them would have the doc lie about the thing this PR touches. **Disposition:** stated here; the underlying tail defect is filed separately as #8025 rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWpocvhfpBpQL153qLGyks
