### PR TITLE
fix: Pi chat window still shows the sent message only with the reply after #7997 landed

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -12,7 +12,7 @@
  * (#7978). That is the item `upsertItem`'s echo join exists for.
  */
 
-import type {AgentEvent, Phase} from "../events.ts";
+import type {AgentEvent, AgentFailure, Phase} from "../events.ts";
 import {isRefusal, planTranscriptWindow} from "../history/index.ts";
 import {
 	ItemId,
@@ -21,6 +21,7 @@ import {
 	type UserItem,
 	type WindowOmission,
 } from "../ports/index.ts";
+import {START_ERROR} from "./failures.ts";
 import type {AiAgentSessionState, UsageTotals} from "./state.ts";
 
 /** How much tail one session keeps. Absent, the window module's own defaults apply. */
@@ -124,6 +125,29 @@ export const dropRequest = (state: AiAgentSessionState, request: string): AiAgen
  */
 const coreOwned = (phase: Phase): boolean => phase === "starting" || phase === "reconnecting";
 
+/** The backend does not hold the session this resume named. */
+const sessionGone = (failure: AgentFailure): boolean =>
+	failure.tag === START_ERROR && failure.reason === "session-not-found";
+
+/**
+ * Where a failure leaves a session: back where it was before the act that failed.
+ *
+ * A resume is the exception, because there is nowhere before it to go back to. A refused resume
+ * ends the session at `gone` — the id the checkpoint carried names nothing the backend still
+ * holds, and the one thing that must never happen is a fresh session opening quietly in its place
+ * (#7514). Any other reconnect failure is a transport that can be tried again, so it lands on
+ * `idle` rather than staying at `reconnecting`, which the reconnect guard itself would refuse.
+ */
+export const phaseAfterFailure = (
+	state: AiAgentSessionState,
+	failure: AgentFailure,
+): AiAgentSessionState["phase"] => {
+	if (state.phase === "reconnecting") return sessionGone(failure) ? "gone" : "idle";
+	if (state.phase === "starting") return "idle";
+	if (state.phase === "prompting") return "ready";
+	return state.phase;
+};
+
 export const foldEvent = (
 	state: AiAgentSessionState,
 	event: AgentEvent,
@@ -142,5 +166,15 @@ export const foldEvent = (
 			return {...state, modes: {current: event.current, available: event.available}};
 		case "usage":
 			return {...state, usage: addUsage(state.usage, event)};
+		// The same landing the `failed` Msg gives a failure the handlers saw, so a refusal reads the
+		// same to the window whichever channel carried it. Routing it through `event` is what keeps
+		// the machine's identity filter over it: a late refusal from a session this process has
+		// already replaced is dropped rather than failing its successor (#8018).
+		case "failure":
+			return {
+				...state,
+				phase: phaseAfterFailure(state, event.failure),
+				failure: event.failure,
+			};
 	}
 };

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -16,24 +16,17 @@ import {
 	modeUnsupported,
 	noSessionToResume,
 	promptRefused,
-	START_ERROR,
 	startRefused,
 	unknownRequest,
 } from "./failures.ts";
-import {foldEvent, foldItem, promptItem, type WindowLimits} from "./fold.ts";
+import {foldEvent, foldItem, phaseAfterFailure, promptItem, type WindowLimits} from "./fold.ts";
 import {
 	type AiAgentSessionCmd,
 	type AiAgentSessionMsg,
 	type AiAgentSessionSub,
 	eventsSub,
 } from "./messages.ts";
-import {
-	type AgentFailure,
-	type AiAgentSessionState,
-	initialState,
-	lastAssistantId,
-	restore,
-} from "./state.ts";
+import {type AiAgentSessionState, initialState, lastAssistantId, restore} from "./state.ts";
 
 export interface AiAgentSessionOptions extends WindowLimits {
 	/** The working directory a fresh session starts in. */
@@ -59,29 +52,6 @@ const busy = (state: AiAgentSessionState): boolean =>
 /** An open is already in flight, so a second one would build a second transport. */
 const opening = (state: AiAgentSessionState): boolean =>
 	state.phase === "starting" || state.phase === "reconnecting";
-
-/** The backend does not hold the session this resume named. */
-const sessionGone = (failure: AgentFailure): boolean =>
-	failure.tag === START_ERROR && failure.reason === "session-not-found";
-
-/**
- * Where a failure leaves a session: back where it was before the act that failed.
- *
- * A resume is the exception, because there is nowhere before it to go back to. A refused resume
- * ends the session at `gone` — the id the checkpoint carried names nothing the backend still
- * holds, and the one thing that must never happen is a fresh session opening quietly in its place
- * (#7514). Any other reconnect failure is a transport that can be tried again, so it lands on
- * `idle` rather than staying at `reconnecting`, which the reconnect guard itself would refuse.
- */
-const phaseAfterFailure = (
-	state: AiAgentSessionState,
-	failure: AgentFailure,
-): AiAgentSessionState["phase"] => {
-	if (state.phase === "reconnecting") return sessionGone(failure) ? "gone" : "idle";
-	if (state.phase === "starting") return "idle";
-	if (state.phase === "prompting") return "ready";
-	return state.phase;
-};
 
 export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSessionMachine => {
 	const limits: WindowLimits = {

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -10,7 +10,7 @@
  * plus the running total of what the bounds dropped.
  */
 
-import type {Phase} from "../events.ts";
+import type {AgentFailure, Phase} from "../events.ts";
 import type {
 	ItemId,
 	Mode,
@@ -34,17 +34,8 @@ export interface ModeState {
 	readonly available: ReadonlyArray<Mode>;
 }
 
-/**
- * The last thing that went wrong, as data. The layer's typed errors are classes; the core keeps
- * only the tag, the case and the detail, because the window renders by tag (ruling 3, #7570) and
- * a class instance is not something a checkpoint can carry.
- */
-export interface AgentFailure {
-	readonly tag: string;
-	/** The error's own `reason` case, or `null` for an error class that enumerates none. */
-	readonly reason: string | null;
-	readonly detail: string;
-}
+// A layer pushes one of these on the event stream too, so it is declared beside `Phase`.
+export type {AgentFailure} from "../events.ts";
 
 /** One page of older history exactly as the backend returned it. Replaced, never accumulated. */
 export interface HistoryPage {

--- a/apps/tuval/src/ai-agent/events.ts
+++ b/apps/tuval/src/ai-agent/events.ts
@@ -10,6 +10,11 @@
  * exactly what the interface refuses to put on a port so one window can render any agent — and it
  * is consumed only by the core, which owns the cumulative totals.
  *
+ * `failure` is how a live session reports a turn that went wrong. Ending the stream is the other
+ * way, and it is reserved for a transport that is actually gone: a queue failed once stays failed,
+ * and the host will not re-arm the Sub under the same id, so failing it for a refusal the session
+ * survived leaves a window that renders nothing ever again (#8018).
+ *
  * It sits above `service/` rather than inside it because both sides of the seam speak it: the
  * layers push it and the core machine folds it, and the core may import nothing from `service/`
  * (#7601).
@@ -54,6 +59,31 @@ export interface ModeEvent {
 	readonly available: ReadonlyArray<Mode>;
 }
 
+/**
+ * The last thing that went wrong, as data. The layer's typed errors are classes; this keeps only
+ * the tag, the case and the detail, because the window renders by tag (ruling 3, #7570) and a
+ * class instance is not something a checkpoint can carry.
+ *
+ * It lives here beside `Phase` rather than in `core/state.ts` because both sides of the seam now
+ * speak it: the core stores it, and a layer reporting a failed turn puts one on this stream.
+ */
+export interface AgentFailure {
+	readonly tag: string;
+	/** The error's own `reason` case, or `null` for an error class that enumerates none. */
+	readonly reason: string | null;
+	readonly detail: string;
+}
+
+/**
+ * A turn failed and the session is still live — the non-terminal half of what used to be a failed
+ * queue. The core folds it exactly as it folds the `failed` Msg, so the window renders the same
+ * refusal, and the next turn's items still arrive on this same stream.
+ */
+export interface FailureEvent {
+	readonly kind: "failure";
+	readonly failure: AgentFailure;
+}
+
 /** Plain numbers and a plain model name: no backend's usage type reaches the core. */
 export interface UsageEvent {
 	readonly kind: "usage";
@@ -69,4 +99,5 @@ export type AgentEvent =
 	| PermissionEvent
 	| PermissionResolvedEvent
 	| ModeEvent
-	| UsageEvent;
+	| UsageEvent
+	| FailureEvent;

--- a/apps/tuval/src/ai-agent/handlers/failures.ts
+++ b/apps/tuval/src/ai-agent/handlers/failures.ts
@@ -1,10 +1,15 @@
 /**
- * The one crossing point between the layer's typed errors and the core's `AgentFailure` data.
+ * Where the layer's typed errors cross into the core's `AgentFailure` data — for every error the
+ * handlers themselves see: a Cmd's refusal, a deadline, and the stream's own terminal failure.
  *
  * Ruling 3 (#7570) makes the error tag the thing the window renders by, so a failure crosses as
  * `{tag, reason, detail}` and the class instance stops here: an error class is not something a
  * checkpoint can carry, and letting one into a Msg would put a non-plain value on the core's data
  * surfaces, which `core/boundary.unit.test.ts` reds on.
+ *
+ * A layer that reports a failed turn on the event stream (`failure`, #8018) has no handler between
+ * it and the core, so it maps its own error to the same triple in its own refusals module — the
+ * shape is the contract, and this is not the only place that writes one.
  *
  * A deadline is not one of the layer's errors — it is the row's declared policy firing — so it is
  * written against the tag of the call that timed out, with that call's own transport-ish reason.

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -46,6 +46,12 @@ export interface TranscriptPage {
 export interface TuvalAiAgentApi {
 	readonly start: (options: StartOptions) => Effect.Effect<StartedSession, StartError>;
 	/**
+	 * Returns at the send, never at the end of the turn (#8018). The generic host awaits a Cmd
+	 * handler before publishing the commit that handler came from, so a layer that resolves this at
+	 * the turn's end holds the operator's own message off the window until the reply lands. A
+	 * backend whose send is one turn-long call forks the await and routes what it can no longer
+	 * return onto `events`.
+	 *
 	 * `key` is the idempotency key (ruling 2): a second prompt carrying a key this session already
 	 * saw is dropped rather than re-sent, so a transport-level retry of one send is free. A
 	 * deliberate resend — the one the window offers after an interrupted turn — mints a new key.

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -48,7 +48,13 @@ import {
 } from "../server/index.ts";
 import {pageItems} from "./entries.ts";
 import {emptyProjection, eventsOf} from "./items.ts";
-import {promptErrorOf, startErrorOf, storeUnreadable, transportErrorOf} from "./refusals.ts";
+import {
+	promptErrorOf,
+	promptRefusalOf,
+	startErrorOf,
+	storeUnreadable,
+	transportErrorOf,
+} from "./refusals.ts";
 
 /** A model this process may run, named the way Pi's catalog names one. */
 export interface ModelSelection {
@@ -221,14 +227,23 @@ const make = (
 				// key recorded after `pi.prompt` resolves could never see it.
 				yield* Ref.update(keys, (seen) => new Set(seen).add(key));
 			}
-			// The pin answers a `prompt` request with the snapshot the turn ended on, so this
-			// resolves at the end of the turn rather than at the send. The events the turn produced
-			// have already been pushed and folded by then; nothing waits on this returning.
-			yield* pi.prompt(current.id, text).pipe(
-				Effect.mapError(promptErrorOf),
-				// A send that never landed is not a turn this session has seen, so the key goes
-				// back and a retry of it is admitted.
-				Effect.tapError(() => (key === undefined ? Effect.void : Ref.update(keys, without(key)))),
+			const open = yield* Ref.get(queue);
+			// The pin answers a `prompt` request with the snapshot the turn ended on, so awaiting it
+			// here would return at the end of the turn rather than at the send — and the generic
+			// host awaits a Cmd handler before it publishes the commit that handler came from, so
+			// the operator's own message would not paint until the reply landed (#8018). Forked into
+			// the layer's scope, this returns at the send, as the Claude layer's does. The turn's
+			// own events are pushed by `follow` and nothing reads the snapshot this discards.
+			yield* Effect.forkIn(
+				pi.prompt(current.id, text).pipe(
+					Effect.mapError(promptErrorOf),
+					// A send that never landed is not a turn this session has seen, so the key goes
+					// back and a retry of it is admitted.
+					Effect.tapError(() => (key === undefined ? Effect.void : Ref.update(keys, without(key)))),
+					Effect.catch((refusal) => Queue.fail(open, promptRefusalOf(refusal))),
+					Effect.asVoid,
+				),
+				scope,
 			);
 		});
 

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -14,7 +14,10 @@
  * `TransportError` and nothing dials again; the generic handlers decide to reconnect, and the way
  * back in is another `start({cwd, resume})`, which re-dials and reacquires the session by id. That
  * is why `events` resolves the live queue at subscription time rather than closing over one: a
- * subscription taken after the re-`start` is live, and one taken before is not resurrected.
+ * subscription taken after the re-`start` is live, and one taken before is not resurrected. That
+ * exit is the dropped socket's alone: a turn the session refuses rides `events` as a `failure`
+ * event, because the session is still there and every later turn still has to reach the window
+ * (#8018).
  *
  * Pi offers no permission prompts and no modes at this pin, so `permission` emits nothing, `mode`
  * advertises an empty list, and `answer` and `setMode` refuse as data rather than throwing.
@@ -49,8 +52,9 @@ import {
 import {pageItems} from "./entries.ts";
 import {emptyProjection, eventsOf} from "./items.ts";
 import {
+	promptDropOf,
 	promptErrorOf,
-	promptRefusalOf,
+	promptFailureOf,
 	startErrorOf,
 	storeUnreadable,
 	transportErrorOf,
@@ -240,7 +244,16 @@ const make = (
 					// A send that never landed is not a turn this session has seen, so the key goes
 					// back and a retry of it is admitted.
 					Effect.tapError(() => (key === undefined ? Effect.void : Ref.update(keys, without(key)))),
-					Effect.catch((refusal) => Queue.fail(open, promptRefusalOf(refusal))),
+					// The refusal has no caller left to raise to, so it rides the stream the send's own
+					// turn would have used. It rides it as an event, not as the queue's failure: a
+					// failed queue is terminal and its Sub is never re-armed under the same id, so
+					// ending it here would take every later turn's output with it (#8018). Only a
+					// dead transport takes that exit, because for that one there is no later turn.
+					Effect.catch((refusal) =>
+						refusal.reason === "disconnected"
+							? Queue.fail(open, promptDropOf(refusal))
+							: emit(open, [{kind: "failure", failure: promptFailureOf(refusal)}]),
+					),
 					Effect.asVoid,
 				),
 				scope,

--- a/apps/tuval/src/pi/ai-agent/pi-ai-agent.integration.test.ts
+++ b/apps/tuval/src/pi/ai-agent/pi-ai-agent.integration.test.ts
@@ -92,8 +92,31 @@ const droppable = (url: string): {factory: ByteTransportFactory; drop: () => voi
 };
 
 /**
+ * How many model turns have run.
+ *
+ * `prompt` returns at the send rather than at the turn's end (#8018), so a settled call is no
+ * longer a settled turn and a test that reads history or sends again has to wait for one. The faux
+ * provider counts its own calls, which is a read off nobody's stream — the drains below own the
+ * events, and a second consumer of that one queue would take frames from them.
+ */
+const turnsRan = (faux: ReturnType<typeof fauxProvider>, calls: number) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 200 && faux.state.callCount < calls; attempt += 1) {
+			yield* Effect.sleep("50 millis");
+		}
+		assert.strictEqual(
+			faux.state.callCount,
+			calls,
+			`timed out waiting for ${calls} model turn(s) to run`,
+		);
+		// The session appends the turn to its JSONL and pushes the closing snapshot after the model
+		// call returns, so the count leads both by a tick.
+		yield* Effect.sleep(SETTLE);
+	});
+
+/**
  * Everything the agent has pushed so far. The layer's queue is unbounded and buffers from `start`,
- * so a subscription taken after a settled prompt still sees the whole run in order — which makes
+ * so a subscription taken after a settled turn still sees the whole run in order — which makes
  * this a drain rather than a race.
  */
 const drain = (agent: TuvalAiAgentApi) =>
@@ -122,6 +145,7 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 				assert.isNotEmpty(started.sessionId);
 
 				yield* agent.prompt("read the readme", "key-1");
+				yield* turnsRan(faux, 2);
 				const events = yield* drain(agent);
 
 				assert.deepEqual(
@@ -178,9 +202,14 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 			return Effect.gen(function* () {
 				const agent = yield* TuvalAiAgent;
 				yield* agent.start({cwd});
+				// One at a time: the page walk below reads the JSONL these turns write, and three
+				// concurrent sends would race each other into it.
 				yield* agent.prompt("first question");
+				yield* turnsRan(faux, 1);
 				yield* agent.prompt("second question");
+				yield* turnsRan(faux, 2);
 				yield* agent.prompt("third question");
+				yield* turnsRan(faux, 3);
 
 				const newest = yield* agent.page(null, 2);
 				assert.isTrue(newest.hasMore, "three exchanges do not fit in a two-item page");
@@ -230,6 +259,7 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 					const started = yield* owner.start({cwd});
 					const stream = yield* Stream.toQueue(owner.events, {capacity: "unbounded"});
 					yield* owner.prompt("first question");
+					yield* turnsRan(faux, 1);
 
 					yield* Effect.gen(function* () {
 						const intruder = yield* TuvalAiAgent;
@@ -275,6 +305,7 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 					const resumed = yield* owner.start({cwd, resume: started.sessionId});
 					assert.strictEqual(resumed.sessionId, started.sessionId);
 					yield* owner.prompt("second question");
+					yield* turnsRan(faux, 2);
 					const after = yield* drain(owner);
 					assert.isTrue(
 						items(after).some((item) => item.kind === "user" && item.text === "first question"),

--- a/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
@@ -1,0 +1,291 @@
+/**
+ * What a Pi send owes the window before its turn ends (#8018).
+ *
+ * The founder sent a message in a Pi window and saw nothing until the reply landed. The layer was
+ * the whole of it: the pin answers a `prompt` request with the snapshot the turn ended on, the
+ * generic host awaits a Cmd handler before publishing the commit that handler came from, and
+ * `enqueue` holds one transition permit for the whole step — so a `prompt` that resolved at the
+ * turn's end held back the operator's own message *and* every event the turn produced.
+ *
+ * So this hosts the row as a real process over the real Pi mapping layer, on a pin whose `prompt`
+ * does not settle until a latch opens, and reads the published states off `ProcessTable.changes` —
+ * the same stream the chat window renders from (`shell/chat/ChatWindow.tsx`). The assertions are
+ * about the host's publish rather than the port emits, because a window paints off process state.
+ *
+ * The host is not the subject and is unchanged: `commit` still runs `runInterpret` before
+ * `onCommit`, and `enqueue` still takes one permit. What changed is that the layer no longer parks
+ * inside either.
+ */
+
+import type {SessionSnapshot} from "@earendil-works/pi-protocol";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Deferred, Effect, Layer, Queue, Stream} from "effect";
+import {type AiAgentSessionState, isAiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {aiAgentPortNames} from "../../ai-agent/handlers/index.ts";
+import {aiAgentProgram} from "../../ai-agent/program.ts";
+import {Checkpoints} from "../../durability/Checkpoints.ts";
+import {memoryStores} from "../../durability/stores.ts";
+import {NodeId} from "../../ports/graph.ts";
+import {PortNotWired, ProcessPorts} from "../../ports/index.ts";
+import {Processes, type ProcessHandle, ProcessTable} from "../../process/index.ts";
+import {ProgramId} from "../../registry/program.ts";
+import {Registry} from "../../registry/Registry.ts";
+import {
+	type PiClientApi,
+	PiClientService,
+	type PiSessionRef,
+	SessionLocked,
+} from "../client/index.ts";
+import {aiAgentOverClient} from "./PiAiAgent.ts";
+
+const PROGRAM = "pi-ai-agent-publishes-the-send-test";
+const CWD = "/tuval/send";
+const TRANSPORT_ERROR = "tuval/ai-agent/TransportError";
+const SESSION: PiSessionRef = {id: "session-8018", cwd: CWD};
+
+const wired: ReadonlySet<string> = new Set(Object.values(aiAgentPortNames));
+
+const ports = ProcessPorts.of({
+	emit: (port) =>
+		wired.has(port)
+			? Effect.succeed([])
+			: Effect.fail(new PortNotWired({node: NodeId.make("test"), port})),
+});
+
+const snapshotOf = (
+	transcript: SessionSnapshot["transcript"],
+	phase: SessionSnapshot["phase"],
+	revision: number,
+): SessionSnapshot => ({
+	id: SESSION.id,
+	cwd: CWD,
+	createdAt: 0,
+	updatedAt: 0,
+	phase,
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+	attached: true,
+	locked: false,
+	revision,
+	transcript,
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+const reply = (text: string): SessionSnapshot["transcript"][number] => ({
+	id: "pi-item-1",
+	role: "assistant",
+	content: [{type: "text", text}],
+	model: {provider: "faux", id: "faux-1"},
+	timestamp: 11,
+	status: "complete",
+	stopReason: "stop",
+});
+
+interface Pin {
+	readonly services: Context.Context<never>;
+	/** Read synchronously: every wait below polls, and an Effect read cannot ride a predicate. */
+	readonly sends: ReadonlyArray<string>;
+	readonly push: (snapshot: SessionSnapshot) => Effect.Effect<void>;
+	readonly endTurn: Effect.Effect<void>;
+	/**
+	 * Whether the turn has ended. Read rather than inferred: every assertion here is worth nothing
+	 * unless the turn really was still open when it ran, and this is what proves it.
+	 */
+	readonly hasEnded: () => boolean;
+}
+
+/** A `PiClientService` whose turn ends only when the test says so. */
+const pin = (options: {readonly refuse?: boolean} = {}): Effect.Effect<Pin> =>
+	Effect.gen(function* () {
+		const sends: Array<string> = [];
+		const turn = yield* Deferred.make<void>();
+		const pushed = yield* Queue.unbounded<SessionSnapshot>();
+		const state = {ended: false};
+
+		const api: PiClientApi = {
+			connect: Effect.void,
+			reconnect: Effect.void,
+			connected: Effect.succeed(true),
+			createSession: () => Effect.succeed(SESSION),
+			attachSession: () => Effect.succeed(SESSION),
+			prompt: (_sessionId, text) =>
+				Effect.gen(function* () {
+					sends.push(text);
+					if (options.refuse === true) {
+						return yield* new SessionLocked({
+							sessionId: SESSION.id,
+							detail: "another connection holds the lease",
+						});
+					}
+					yield* Deferred.await(turn);
+					state.ended = true;
+					return snapshotOf([], "idle", 9);
+				}),
+			abort: () => Effect.never,
+			snapshots: () => Stream.fromQueue(pushed),
+			disconnections: Stream.never,
+		};
+
+		return {
+			services: Context.add(Context.make(ProcessPorts, ports), PiClientService, api),
+			get sends() {
+				return sends;
+			},
+			push: (snapshot) => Effect.asVoid(Queue.offer(pushed, snapshot)),
+			endTurn: Effect.asVoid(Deferred.succeed(turn, undefined)),
+			hasEnded: () => state.ended,
+		};
+	});
+
+const row = aiAgentProgram({
+	id: PROGRAM,
+	layer: aiAgentOverClient(),
+	config: {cwd: CWD},
+});
+
+const kernel = Processes.layer.pipe(
+	Layer.provideMerge(Checkpoints.layer(memoryStores())),
+	Layer.provideMerge(Registry.layer([row])),
+);
+
+/** A spent budget asserts rather than falling through, so a timeout names what it waited for. */
+const eventually = (what: string, check: () => boolean) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 400 && !check(); attempt += 1) yield* Effect.sleep("5 millis");
+		assert.isTrue(check(), `timed out after 2s waiting for ${what}`);
+	});
+
+const sessionOf = (handle: ProcessHandle): AiAgentSessionState => {
+	const state = handle.getState();
+	assert.isTrue(isAiAgentSessionState(state), "the process is not holding an agent session state");
+	return state as AiAgentSessionState;
+};
+
+const userText = (state: AiAgentSessionState): ReadonlyArray<string> =>
+	state.transcript.items.flatMap((item) => (item.kind === "user" ? [item.text] : []));
+
+const assistantText = (state: AiAgentSessionState): ReadonlyArray<string> =>
+	state.transcript.items.flatMap((item) => (item.kind === "assistant" ? [item.text] : []));
+
+const prompted = (handle: ProcessHandle, text: string, key: string, timestamp: number) =>
+	handle.dispatch({type: "prompt", text, key, timestamp}).pipe(Effect.orDie);
+
+/**
+ * The row, spawned and ready, with every state it publishes collected from before the spawn — so
+ * nothing this watcher misses can be mistaken for a commit that never published.
+ */
+const onAReadySession = <A, E>(
+	options: {readonly refuse?: boolean},
+	body: (
+		handle: ProcessHandle,
+		pinned: Pin,
+		published: ReadonlyArray<AiAgentSessionState>,
+	) => Effect.Effect<A, E>,
+) =>
+	Effect.gen(function* () {
+		const pinned = yield* pin(options);
+		const table = yield* ProcessTable;
+		const published: Array<AiAgentSessionState> = [];
+		yield* Effect.forkScoped(
+			Stream.runForEach(table.changes, (change) =>
+				Effect.sync(() => {
+					if (change.kind !== "state-changed") return;
+					const state = change.row.stateSummary().state;
+					if (isAiAgentSessionState(state)) published.push(state);
+				}),
+			),
+		);
+
+		const processes = yield* Processes;
+		const handle = yield* processes.spawn(ProgramId.make(PROGRAM), {services: pinned.services});
+		yield* eventually(
+			"the spawned session to reach ready",
+			() => sessionOf(handle).phase === "ready",
+		);
+		// The opening commits are the watcher's own handshake: it is subscribed by the time one of
+		// them has landed, so a later miss is the publish and not the subscription.
+		yield* eventually("the watcher to see the opening commits", () => published.length > 0);
+
+		return yield* body(handle, pinned, published);
+	}).pipe(Effect.scoped, Effect.provide(kernel));
+
+describe("a Pi send whose turn has not ended", () => {
+	it.live("publishes the operator's own message at the send", () =>
+		onAReadySession({}, (handle, pinned, published) =>
+			Effect.gen(function* () {
+				// Forked: on the shape this test exists to refuse, `dispatch` parks for the whole
+				// turn, and a failed assertion says more than a suite timeout.
+				yield* Effect.forkChild(prompted(handle, "hello", "k1", 1));
+
+				yield* eventually("the operator's message on a published state", () =>
+					published.some((state) => userText(state).includes("hello")),
+				);
+				assert.isFalse(
+					pinned.hasEnded(),
+					"the turn ended before the assertion could mean anything",
+				);
+				// The send rides its own fiber now, so it lands after the publish rather than before
+				// it — which is the whole point, and why this waits rather than reads.
+				yield* eventually("the send to reach the pin", () => pinned.sends.length > 0);
+				assert.deepStrictEqual(pinned.sends, ["hello"], "the prompt reached the pin once");
+
+				yield* pinned.endTurn;
+			}),
+		),
+	);
+
+	it.live("publishes a transcript item that arrives mid-turn", () =>
+		onAReadySession({}, (handle, pinned, published) =>
+			Effect.gen(function* () {
+				yield* Effect.forkChild(prompted(handle, "hello", "k1", 1));
+				yield* eventually("the operator's message on a published state", () =>
+					published.some((state) => userText(state).includes("hello")),
+				);
+
+				// A streamed reply pushed while the turn is still open: `turn` rather than `idle`,
+				// so nothing about this snapshot says the turn ended.
+				yield* pinned.push(snapshotOf([reply("thinking out loud")], "turn", 2));
+
+				yield* eventually("the mid-turn reply on a published state", () =>
+					published.some((state) => assistantText(state).includes("thinking out loud")),
+				);
+				assert.isFalse(
+					pinned.hasEnded(),
+					"the turn ended before the assertion could mean anything",
+				);
+
+				yield* pinned.endTurn;
+			}),
+		),
+	);
+});
+
+describe("a Pi send the pin refuses", () => {
+	it.live("reaches the window as a failed Msg and gives the idempotency key back", () =>
+		onAReadySession({refuse: true}, (handle, pinned) =>
+			Effect.gen(function* () {
+				yield* prompted(handle, "hello", "k1", 1);
+
+				yield* eventually(
+					"the refusal to reach the window",
+					() => sessionOf(handle).failure !== null,
+				);
+				const failure = sessionOf(handle).failure;
+				assert.strictEqual(failure?.tag, TRANSPORT_ERROR);
+				assert.strictEqual(failure?.reason, "refused");
+				assert.strictEqual(
+					sessionOf(handle).phase,
+					"ready",
+					"a refused send leaves the session where it was rather than stuck prompting",
+				);
+
+				// The same key again: one the refusal had not given back would drop this send
+				// silently, and the operator's retry would reach nothing.
+				yield* prompted(handle, "hello", "k1", 2);
+				yield* eventually("the retry to reach the pin", () => pinned.sends.length === 2);
+				assert.deepStrictEqual(pinned.sends, ["hello", "hello"]);
+			}),
+		),
+	);
+});

--- a/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
@@ -40,7 +40,7 @@ import {aiAgentOverClient} from "./PiAiAgent.ts";
 
 const PROGRAM = "pi-ai-agent-publishes-the-send-test";
 const CWD = "/tuval/send";
-const TRANSPORT_ERROR = "tuval/ai-agent/TransportError";
+const PROMPT_ERROR = "tuval/ai-agent/PromptError";
 const SESSION: PiSessionRef = {id: "session-8018", cwd: CWD};
 
 const wired: ReadonlySet<string> = new Set(Object.values(aiAgentPortNames));
@@ -95,8 +95,12 @@ interface Pin {
 	readonly hasEnded: () => boolean;
 }
 
-/** A `PiClientService` whose turn ends only when the test says so. */
-const pin = (options: {readonly refuse?: boolean} = {}): Effect.Effect<Pin> =>
+/**
+ * A `PiClientService` whose turn ends only when the test says so, and which refuses its first
+ * `refusals` sends. Counted rather than a flag, because the case #8018's last round missed is the
+ * send *after* a refusal: a pin that refuses forever cannot tell a live stream from a dead one.
+ */
+const pin = (options: {readonly refusals?: number} = {}): Effect.Effect<Pin> =>
 	Effect.gen(function* () {
 		const sends: Array<string> = [];
 		const turn = yield* Deferred.make<void>();
@@ -112,7 +116,7 @@ const pin = (options: {readonly refuse?: boolean} = {}): Effect.Effect<Pin> =>
 			prompt: (_sessionId, text) =>
 				Effect.gen(function* () {
 					sends.push(text);
-					if (options.refuse === true) {
+					if (sends.length <= (options.refusals ?? 0)) {
 						return yield* new SessionLocked({
 							sessionId: SESSION.id,
 							detail: "another connection holds the lease",
@@ -176,7 +180,7 @@ const prompted = (handle: ProcessHandle, text: string, key: string, timestamp: n
  * nothing this watcher misses can be mistaken for a commit that never published.
  */
 const onAReadySession = <A, E>(
-	options: {readonly refuse?: boolean},
+	options: {readonly refusals?: number},
 	body: (
 		handle: ProcessHandle,
 		pinned: Pin,
@@ -263,7 +267,7 @@ describe("a Pi send whose turn has not ended", () => {
 
 describe("a Pi send the pin refuses", () => {
 	it.live("reaches the window as a failed Msg and gives the idempotency key back", () =>
-		onAReadySession({refuse: true}, (handle, pinned) =>
+		onAReadySession({refusals: 1}, (handle, pinned) =>
 			Effect.gen(function* () {
 				yield* prompted(handle, "hello", "k1", 1);
 
@@ -272,7 +276,7 @@ describe("a Pi send the pin refuses", () => {
 					() => sessionOf(handle).failure !== null,
 				);
 				const failure = sessionOf(handle).failure;
-				assert.strictEqual(failure?.tag, TRANSPORT_ERROR);
+				assert.strictEqual(failure?.tag, PROMPT_ERROR);
 				assert.strictEqual(failure?.reason, "refused");
 				assert.strictEqual(
 					sessionOf(handle).phase,
@@ -285,6 +289,47 @@ describe("a Pi send the pin refuses", () => {
 				yield* prompted(handle, "hello", "k1", 2);
 				yield* eventually("the retry to reach the pin", () => pinned.sends.length === 2);
 				assert.deepStrictEqual(pinned.sends, ["hello", "hello"]);
+			}),
+		),
+	);
+
+	/**
+	 * The regression the fix's first round shipped: the refusal rode the event queue's *failure*
+	 * channel, which is terminal. `Stream.fromQueue` ended, the generic events Sub's `runForEach`
+	 * returned, and the host will not re-arm a Sub under an id whose lifetime ended — so the window
+	 * sat at `ready` with no stream, and every later turn painted nothing.
+	 */
+	it.live("leaves the stream alive, so the next turn still reaches the window", () =>
+		onAReadySession({refusals: 1}, (handle, pinned, published) =>
+			Effect.gen(function* () {
+				yield* prompted(handle, "hello", "k1", 1);
+				yield* eventually(
+					"the refusal to reach the window",
+					() => sessionOf(handle).failure !== null,
+				);
+
+				// Forked: this send is not refused, so its handler is the one that used to park.
+				yield* Effect.forkChild(prompted(handle, "again", "k2", 2));
+				yield* eventually("the second send to reach the pin", () => pinned.sends.length === 2);
+
+				yield* pinned.push(snapshotOf([reply("still here")], "turn", 2));
+				yield* eventually("the next turn's reply on a published state", () =>
+					published.some((state) => assistantText(state).includes("still here")),
+				);
+				assert.isFalse(
+					pinned.hasEnded(),
+					"the turn ended before the assertion could mean anything",
+				);
+
+				// Phase too, and `ready` is the one the core cannot have set itself: the second
+				// prompt put it at `prompting`, so only a live stream brings it back.
+				yield* pinned.push(snapshotOf([reply("still here")], "idle", 3));
+				yield* eventually(
+					"the turn's end to reach the window",
+					() => sessionOf(handle).phase === "ready",
+				);
+
+				yield* pinned.endTurn;
 			}),
 		),
 	);

--- a/apps/tuval/src/pi/ai-agent/refusals.ts
+++ b/apps/tuval/src/pi/ai-agent/refusals.ts
@@ -44,6 +44,20 @@ export const promptErrorOf = (refusal: SessionRefusal): PromptError => {
 export const transportErrorOf = (dropped: Disconnected): TransportError =>
 	new TransportError({reason: "disconnected", detail: dropped.detail});
 
+/**
+ * A refused send, as the event stream's own failure.
+ *
+ * `prompt` returns at the send (#8018), so by the time the pin refuses one there is no caller left
+ * holding a `PromptError` channel. The event stream is the only outbound channel the layer still
+ * owns, and failing it is what the generic Sub turns into the `failed` Msg the window renders —
+ * the same route a dropped socket takes, and the same way back in.
+ */
+export const promptRefusalOf = (refusal: PromptError): TransportError =>
+	new TransportError({
+		reason: refusal.reason === "disconnected" ? "disconnected" : "refused",
+		detail: refusal.detail,
+	});
+
 export const storeUnreadable = (cause: unknown): PageError =>
 	new PageError({
 		reason: "store-unreadable",

--- a/apps/tuval/src/pi/ai-agent/refusals.ts
+++ b/apps/tuval/src/pi/ai-agent/refusals.ts
@@ -7,6 +7,7 @@
  * `tuval/pi/client/*` error never reaches a caller of `TuvalAiAgent`.
  */
 
+import type {AgentFailure} from "../../ai-agent/events.ts";
 import {PageError, PromptError, StartError, TransportError} from "../../ai-agent/service/index.ts";
 import type {ConnectionRefusal, Disconnected, SessionRefusal} from "../client/index.ts";
 
@@ -45,21 +46,32 @@ export const transportErrorOf = (dropped: Disconnected): TransportError =>
 	new TransportError({reason: "disconnected", detail: dropped.detail});
 
 /**
- * A refused send, as the event stream's own failure.
+ * A refused send, as the plain failure the event stream carries.
  *
  * `prompt` returns at the send (#8018), so by the time the pin refuses one there is no caller left
- * holding a `PromptError` channel. The event stream is the only outbound channel the layer still
- * owns, and failing it is what the generic Sub turns into the `failed` Msg the window renders —
- * the same route a dropped socket takes, and the same way back in.
+ * holding a `PromptError` channel and the event stream is the only outbound channel the layer
+ * still owns. It rides that stream as a `failure` event rather than failing the queue: the session
+ * is still there and the next turn still has to reach the window. Only a lost transport ends the
+ * stream, and `transportErrorOf` is the one that does it.
  */
-export const promptRefusalOf = (refusal: PromptError): TransportError =>
-	new TransportError({
-		reason: refusal.reason === "disconnected" ? "disconnected" : "refused",
-		detail: refusal.detail,
-	});
+export const promptFailureOf = (refusal: PromptError): AgentFailure => ({
+	tag: refusal._tag,
+	reason: refusal.reason,
+	detail: refusal.message,
+});
 
 export const storeUnreadable = (cause: unknown): PageError =>
 	new PageError({
 		reason: "store-unreadable",
 		detail: cause instanceof Error ? cause.message : String(cause),
 	});
+
+/**
+ * A send refused because the socket is gone, as the terminal failure that ends the event stream.
+ *
+ * The one refusal that takes the exit `follow` takes on `pi.disconnections`, and for the same
+ * reason: nothing dials again, so leaving the stream open would leave a window waiting on a
+ * transport that is not coming back. The way back in is another `start({cwd, resume})`.
+ */
+export const promptDropOf = (refusal: PromptError): TransportError =>
+	new TransportError({reason: "disconnected", detail: refusal.detail});


### PR DESCRIPTION
Fixes #8018

The founder sent a message in a Pi chat window and saw nothing until the reply landed. PR #7997 fixed the Claude half; this is the Pi half.

## What was wrong

`PiAiAgent.prompt` awaited `pi.prompt`, and the pin answers a `prompt` request with the snapshot the turn ended on — so the call resolved at the end of the turn. The generic host awaits a Cmd handler before publishing the commit that handler came from (`host/actor.ts`'s `commit`), and `enqueue` wraps the whole step in `tail.withPermits(1)`, so a parked Pi prompt handler held the single transition permit for the entire turn. Nothing committed and nothing published until the turn ended: the operator's own message *and* every event the turn produced arrived at once. `ClaudeAiAgent.prompt` pushes onto its streaming-input iterable and returns at the send, which is why only Pi showed it.

## What changed

`PiAiAgent.prompt` forks the turn-end await into the layer's scope and returns at the send, matching the Claude shape. The host is untouched — `runInterpret` still precedes `onCommit` and `enqueue` still takes one permit.

A refused send no longer has a caller holding its `PromptError` channel, so it releases the idempotency key and reports itself on the layer's event stream. It rides that stream as a new `failure` event rather than failing the queue: `Queue.fail` is terminal, and the host will not re-arm the events Sub under an id whose lifetime ended, so failing it for a refusal the session survived left the window at `ready` with a dead stream and nothing painting ever again. `AgentEvent` gains a `failure` kind carrying the plain `AgentFailure` triple, `foldEvent` lands it exactly where the `failed` Msg lands one, and routing it through the `event` Msg keeps the machine's identity filter over it. Only a lost transport still ends the stream, which is the case those terminal semantics were written for.

The interface docblock on `TuvalAiAgent.prompt` now states "returns at the send", since the unstated contract is what let the two layers disagree.

## Proof

`publishes-the-send.unit.test.ts` hosts `aiAgentProgram` as a real process over the real Pi mapping layer, on a client stub whose `prompt` does not settle until a latch opens, and reads published states off `ProcessTable.changes` — the stream `ChatWindow.tsx` renders from. It asserts the operator's `user` item is published, and a transcript item pushed mid-turn is committed and published, both with the turn provably still open. Both fail without the fix (verified by reverting the fork in-tree). A refused send reaches the window as `failed` and gives its key back, and a fourth case sends again after a refusal and asserts the next turn's transcript item and its phase still arrive — the assertion the terminal-queue route fails.

`pnpm --filter @kampus/tuval test` (1346) and `pnpm typecheck` pass.

## Deviations

- **Pre-existing defect left unfixed** — **Said:** #8018 asks for a green `pnpm --filter @kampus/tuval test`. **Did:** left `src/claude/restore/claude-restore-proof.unit.test.ts` alone. **Why:** it timed out collecting once in three full-suite runs under parallel load and passes on its own; it is a Claude-side file this change does not touch. **Disposition:** stated here, filed as a follow-up.
- **Pre-existing test or fixture changed** — **Said:** nothing about `pi-ai-agent.integration.test.ts`. **Did:** added a `turnsRan` wait after each `agent.prompt` there. **Why:** a settled `prompt` is no longer a settled turn, so the page walk and the drop sequence would read history three concurrent sends were still writing. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8018 names the `PiAiAgent.ts:224-226` docblock. **Did:** also added the "returns at the send" line to `TuvalAiAgentApi.prompt`. **Why:** the contract being unstated on the interface is what let the Pi layer and the Claude layer mean different things by one signature. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8018's route is "match the Claude shape at the Pi layer". **Did:** widened the shared `AgentEvent` union, moved `AgentFailure` from `core/state.ts` up to `events.ts` (re-exported, so no import moved), and moved `phaseAfterFailure` from `machine.ts` into `fold.ts`. **Why:** criterion 7 asks the Pi layer to report a refusal without ending the stream, and the stream's own union had no failure kind — the payload is now vocabulary both sides speak, so it belongs beside `Phase`, and the fold needs the same phase rule the `failed` reducer already used. **Disposition:** stated here.
