### PR TITLE
fix: A Claude chat window never shows the messages the founder sends

### DIFF
--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -14,9 +14,13 @@
  * seeded from the core's own state when the Sub opened. Same function, same seed, same order, so
  * the tail published on `transcript` is the tail the core commits — a read-back after `dispatch`
  * could not promise that, because the host applies a dispatched Msg on its own serial tail.
+ *
+ * The projection is the process's rather than the Sub's (`./projection.ts`), because the core's
+ * transcript has a second entrance no event carries: the operator's own turn, recorded by the
+ * `prompt` cell when they send it (#7978).
  */
 
-import {Effect, type Layer, Ref, Result, Stream} from "effect";
+import {Effect, type Layer, Result, Stream} from "effect";
 import type {PayloadRejected, ProcessPorts} from "../../ports/index.ts";
 import type {ProcessSelf} from "../../process/self.ts";
 import type {HostHandlers, HostSubs} from "../../registry/program.ts";
@@ -25,14 +29,13 @@ import {
 	type AiAgentEventsSub,
 	type AiAgentSessionCmd,
 	type AiAgentSessionMsg,
-	type AiAgentSessionState,
 	type AiAgentSessionSub,
 	foldEvent,
 	initialState,
 	START_ERROR,
 	type WindowLimits,
 } from "../core/index.ts";
-import {isRefusal, planTranscriptPage} from "../history/index.ts";
+import {isRefusal, planTranscriptPage, withoutLocalEchoes} from "../history/index.ts";
 import type {TranscriptPagePayload} from "../ports/index.ts";
 import {
 	type TranscriptPage,
@@ -42,6 +45,7 @@ import {
 } from "../service/index.ts";
 import {type AgentServiceError, deadlineFailure, failureOf, isTimeout} from "./failures.ts";
 import {type AiAgentRetryPolicy, defaultRetryPolicy, underPolicy} from "./policy.ts";
+import {transcriptProjection} from "./projection.ts";
 import {
 	aiAgentPortNames,
 	emit,
@@ -108,6 +112,7 @@ export const aiAgentHandlers = <RIn = never>(
 		...(options.byteLimit === undefined ? {} : {byteLimit: options.byteLimit}),
 	};
 	const slot = agentSlot(options.layer);
+	const projection = transcriptProjection();
 
 	const withAgent = <A>(
 		use: (agent: TuvalAiAgentApi) => Effect.Effect<A, AgentServiceError>,
@@ -183,11 +188,22 @@ export const aiAgentHandlers = <RIn = never>(
 				return nothing;
 			}),
 
+		// The turn the core recorded in the very commit that produced this Cmd (#7978) rides no
+		// layer event, so the Sub's projection would publish a tail with the operator's half
+		// missing (#7979). Re-seeding is sound here rather than a race: this Cmd is applied after
+		// every event Msg the projection has folded, so the committed state is never behind it.
 		"aiAgent.prompt": (cmd) =>
-			withAgent(
-				(agent) => agent.prompt(cmd.text, cmd.key),
-				() => nothing,
-			),
+			Effect.gen(function* () {
+				const state = yield* readSession;
+				if (state !== null) {
+					yield* projection.seed(state);
+					yield* emit(aiAgentPortNames.transcript, transcriptOf(state));
+				}
+				return yield* withAgent(
+					(agent) => agent.prompt(cmd.text, cmd.key),
+					() => nothing,
+				);
+			}),
 
 		"aiAgent.interrupt": () =>
 			withAgent(
@@ -219,10 +235,18 @@ export const aiAgentHandlers = <RIn = never>(
 				if (agent === null) return refusal(noSession);
 				const answered = yield* Effect.result(agent.page(cmd.before, cmd.limit));
 				if (Result.isFailure(answered)) return refusal(failureOf(answered.failure));
-				const page = answered.success;
+				// A backend that stores the conversation keeps its own copy of the turn the core
+				// recorded at the send, under its own id, and no id joins the two (#7979). Dropped
+				// here rather than at the window, so both routes one page takes — the `pageReply`
+				// port and the `paged` Msg — carry a single copy of it.
+				const held = yield* readSession;
+				const page = {
+					items: withoutLocalEchoes(answered.success.items, held?.transcript.items ?? []),
+					hasMore: answered.success.hasMore,
+				};
 				const payload = pagePayload(page, cmd.limit);
 				if (payload !== null) yield* emit(aiAgentPortNames.pageReply, payload);
-				return [{type: "paged", page: {items: page.items, hasMore: page.hasMore}}] satisfies Follow;
+				return [{type: "paged", page}] satisfies Follow;
 			}),
 	};
 
@@ -231,14 +255,13 @@ export const aiAgentHandlers = <RIn = never>(
 			const agent = yield* slot.current;
 			if (agent === null) return;
 			const seed = yield* readSession;
-			const projection = yield* Ref.make<AiAgentSessionState>(seed ?? initialState(options.cwd));
+			yield* projection.seed(seed ?? initialState(options.cwd));
 
 			yield* Stream.runForEach(agent.events, (event) =>
 				Effect.gen(function* () {
 					dispatch({type: "event", sessionId: sub.sessionId, event});
-					const next = yield* Ref.updateAndGet(projection, (state) =>
-						foldEvent(state, event, limits),
-					);
+					const next = yield* projection.fold((state) => foldEvent(state, event, limits));
+					if (next === null) return;
 					if (event.kind === "item") yield* emit(aiAgentPortNames.transcript, transcriptOf(next));
 					if (event.kind === "permission" || event.kind === "permission-resolved") {
 						yield* emit(aiAgentPortNames.permissionPending, pendingOf(next));

--- a/apps/tuval/src/ai-agent/handlers/projection.ts
+++ b/apps/tuval/src/ai-agent/handlers/projection.ts
@@ -1,0 +1,50 @@
+/**
+ * The tail this process publishes, held per process so the Sub and the handlers write one copy.
+ *
+ * The Sub folds layer events onto a seed of the core's committed state, which is what makes the
+ * `transcript` port carry the core's own tail in the core's own order (`./index.ts`). That holds
+ * only while every entrance to the transcript is an event, and since #7978 one is not: the `prompt`
+ * cell records the operator's turn when they send it, and no layer event ever carries it. A
+ * projection the Sub alone owns therefore publishes a transcript with the operator's half missing —
+ * the founder's own bug, one surface over from the window (#7979). So the projection lives here,
+ * where the `aiAgent.prompt` handler can put it back on the core's committed state.
+ *
+ * A plain map rather than a `Ref` for `agentSlot`'s reason (`./session.ts`): every read and write
+ * of it is synchronous, which on one JS thread is the atomicity a `Ref` would buy.
+ */
+
+import {Effect, type Scope} from "effect";
+import {ProcessSelf} from "../../process/self.ts";
+import type {AiAgentSessionState} from "../core/index.ts";
+
+export interface TranscriptProjection {
+	/** Put this process's projection at `state`, replacing whatever stood before. */
+	readonly seed: (state: AiAgentSessionState) => Effect.Effect<void, never, ProcessSelf>;
+	/**
+	 * Fold `step` over the standing projection and answer what it left, or `null` when this process
+	 * has none — which is every process whose events Sub has not opened yet.
+	 */
+	readonly fold: (
+		step: (state: AiAgentSessionState) => AiAgentSessionState,
+	) => Effect.Effect<AiAgentSessionState | null, never, ProcessSelf>;
+}
+
+export const transcriptProjection = (): TranscriptProjection => {
+	const held = new WeakMap<Scope.Scope, AiAgentSessionState>();
+
+	const seed = (state: AiAgentSessionState): Effect.Effect<void, never, ProcessSelf> =>
+		Effect.map(ProcessSelf, (self) => void held.set(self.scope, state));
+
+	const fold = (
+		step: (state: AiAgentSessionState) => AiAgentSessionState,
+	): Effect.Effect<AiAgentSessionState | null, never, ProcessSelf> =>
+		Effect.map(ProcessSelf, (self) => {
+			const standing = held.get(self.scope);
+			if (standing === undefined) return null;
+			const next = step(standing);
+			held.set(self.scope, next);
+			return next;
+		});
+
+	return {seed, fold};
+};

--- a/apps/tuval/src/ai-agent/history/index.ts
+++ b/apps/tuval/src/ai-agent/history/index.ts
@@ -13,6 +13,7 @@ export {
 	type NonEmpty,
 	type TranscriptGroup,
 } from "./groups.ts";
+export {withoutLocalEchoes} from "./local-turns.ts";
 export {
 	type PageOptions,
 	planTranscriptPage,

--- a/apps/tuval/src/ai-agent/history/local-turns.ts
+++ b/apps/tuval/src/ai-agent/history/local-turns.ts
@@ -1,0 +1,52 @@
+/**
+ * Joining a page of stored history to the turns the core recorded locally.
+ *
+ * The core writes the operator's turn at the send, under an id derived from the send's own
+ * idempotency key (`../core/fold.ts`, #7978). A backend that stores the conversation writes that
+ * same turn under an id of its own — the Claude CLI's transcript does, and `getSessionMessages`
+ * hands it straight back — so a reader holding both the live tail and a page over the same turn
+ * holds two rows for it (#7979).
+ *
+ * No id joins those two: the key is Tuval's and never reaches the backend's store, and the layer
+ * that held the send is rebuilt on every resume, so nothing survives a reconnect to re-key by. Text
+ * is the join the core itself uses for a layer's echo, so it is the join here.
+ */
+
+import type {TranscriptItem} from "../ports/index.ts";
+
+const localTurnCounts = (tail: ReadonlyArray<TranscriptItem>): Map<string, number> => {
+	const counts = new Map<string, number>();
+	for (const item of tail) {
+		if (item.kind === "user" && item.local === true) {
+			counts.set(item.text, (counts.get(item.text) ?? 0) + 1);
+		}
+	}
+	return counts;
+};
+
+/**
+ * `page` minus the rows that are the store's copy of a turn `tail` already holds locally.
+ *
+ * Bounded by count and walked newest-first, because text alone is not identity. A prompt sent twice
+ * leaves two local rows and drops two stored rows, so the two deliberate turns stay two. A turn
+ * whose local row has already fallen out of the bounded tail keeps its stored row — past the tail
+ * that row is the only place the operator's own words exist, and dropping it would hand back the
+ * very defect this join exists to close.
+ */
+export const withoutLocalEchoes = (
+	page: ReadonlyArray<TranscriptItem>,
+	tail: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> => {
+	const budget = localTurnCounts(tail);
+	if (budget.size === 0) return page;
+	const dropped = new Set<number>();
+	for (let index = page.length - 1; index >= 0; index -= 1) {
+		const item = page[index];
+		if (item === undefined || item.kind !== "user") continue;
+		const left = budget.get(item.text) ?? 0;
+		if (left === 0) continue;
+		budget.set(item.text, left - 1);
+		dropped.add(index);
+	}
+	return dropped.size === 0 ? page : page.filter((_, index) => !dropped.has(index));
+};

--- a/apps/tuval/src/ai-agent/history/local-turns.unit.test.ts
+++ b/apps/tuval/src/ai-agent/history/local-turns.unit.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `withoutLocalEchoes` on its own: which stored rows are the same turn as one the core already
+ * recorded, and — the half that matters more — which are not.
+ */
+
+import {describe, expect, it} from "vitest";
+import {assistantItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
+import type {TranscriptItem} from "../ports/index.ts";
+import {withoutLocalEchoes} from "./local-turns.ts";
+
+const local = (id: string, text: string): TranscriptItem => ({...userItem(id, text), local: true});
+const ids = (items: ReadonlyArray<TranscriptItem>) => items.map((item) => item.id);
+
+describe("withoutLocalEchoes", () => {
+	it("drops the stored copy of a turn the tail holds locally", () => {
+		const page = [userItem("store-1", "hello"), assistantItem("store-2", "hi")];
+		expect(ids(withoutLocalEchoes(page, [local("local:k1", "hello")]))).toEqual(["store-2"]);
+	});
+
+	it("keeps a stored turn no local row names, which is every turn past the tail", () => {
+		const page = [userItem("store-1", "older"), userItem("store-2", "hello")];
+		expect(ids(withoutLocalEchoes(page, [local("local:k1", "hello")]))).toEqual(["store-1"]);
+	});
+
+	it("drops one stored row per local row, so a prompt sent twice stays two turns", () => {
+		const page = [userItem("store-1", "again"), userItem("store-2", "again")];
+		expect(ids(withoutLocalEchoes(page, [local("local:k2", "again")]))).toEqual(["store-1"]);
+		expect(
+			ids(withoutLocalEchoes(page, [local("local:k2", "again"), local("local:k3", "again")])),
+		).toEqual([]);
+	});
+
+	it("drops the newest match first, so the oldest stored copy is the one that survives", () => {
+		const page = [
+			userItem("older", "again"),
+			assistantItem("a1", "ok"),
+			userItem("newer", "again"),
+		];
+		expect(ids(withoutLocalEchoes(page, [local("local:k2", "again")]))).toEqual(["older", "a1"]);
+	});
+
+	it("leaves a turn a layer already confirmed alone, since its local mark is gone", () => {
+		const page = [userItem("store-1", "hello")];
+		expect(ids(withoutLocalEchoes(page, [userItem("echoed-1", "hello")]))).toEqual(["store-1"]);
+	});
+
+	it("answers the page unchanged when the tail records nothing locally", () => {
+		const page = [userItem("store-1", "hello"), assistantItem("store-2", "hi")];
+		expect(withoutLocalEchoes(page, [assistantItem("live-1", "hi")])).toBe(page);
+	});
+});

--- a/apps/tuval/src/ai-agent/restore/fixtures/agent-desk.ts
+++ b/apps/tuval/src/ai-agent/restore/fixtures/agent-desk.ts
@@ -9,6 +9,7 @@
  * share: what carries across is the checkpoint on disk, which is the thing under test.
  */
 
+import {promptItemId} from "../../core/index.ts";
 import type {AgentEvent} from "../../events.ts";
 import type {ItemId, PermissionRequest, TranscriptItem} from "../../ports/index.ts";
 import {aiAgentProgram} from "../../program.ts";
@@ -81,7 +82,9 @@ export const resendTurn: ReadonlyArray<AgentEvent> = [
 
 /** The item ids the tail holds after the cut, and after the resend that follows the restore. */
 export const afterTheCut = ["u1", "a1", "u2", "a2", "u3", "a3"];
-export const afterTheResend = [...afterTheCut, "a4"];
+// The resend's own row is the core's, keyed on the send (#7978): this script's layer echoes the
+// three earlier turns and has no echo for this one, so it is the only turn named by its key here.
+export const afterTheResend = [...afterTheCut, promptItemId("k4"), "a4"];
 
 const script: AgentScript = {
 	sessionId: SESSION,

--- a/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
@@ -151,6 +151,8 @@ interface SecondRun {
 	readonly republishedCards: ReadonlyArray<ReadonlyArray<string>>;
 	/** How many `transcript` payloads the resend alone produced. */
 	readonly emissionsForTheResend: number;
+	/** The item ids the *first* of those emissions carried, which is the send's own. */
+	readonly firstEmissionForTheResend: ReadonlyArray<string>;
 	readonly afterResend: ReadonlyArray<string>;
 	readonly phaseAfterResend: AiAgentSessionState["phase"];
 }
@@ -226,6 +228,9 @@ const runFromTheCheckpoint = (
 			afterReconnect,
 			republishedCards,
 			emissionsForTheResend: transcriptsIn(arrivalsOf(window).slice(beforeResend)).length,
+			firstEmissionForTheResend:
+				transcriptsIn(arrivalsOf(window).slice(beforeResend))[0]?.items.map((item) => item.id) ??
+				[],
 			afterResend: rendered(window),
 			phaseAfterResend: sessionOf(agent).phase,
 		} satisfies SecondRun;
@@ -294,11 +299,18 @@ describe("the whole app, stopped mid-reply and booted back over its checkpoints"
 		).not.toContain("a4");
 	});
 
-	it("answers one resend with exactly one new emission", () => {
+	// Two, not one: the operator's own turn is published when they send it and the reply when it
+	// arrives (#7978/#7979). A single emission would mean the window shows your message only once
+	// the agent has answered, which is the wait the founder reported.
+	it("answers one resend with two emissions, the operator's turn before the reply", () => {
 		expect(
 			outcome.second.emissionsForTheResend,
-			"one deliberate resend did not produce exactly one transcript emission",
-		).toBe(1);
+			"one deliberate resend did not produce the send's emission and the reply's",
+		).toBe(2);
+		expect(
+			outcome.second.firstEmissionForTheResend,
+			"the send's own emission did not already carry the operator's turn",
+		).toEqual(outcome.second.afterResend.slice(0, -1));
 		expect(outcome.second.afterResend).toEqual(afterTheResend);
 		expect(outcome.second.phaseAfterResend).toBe("ready");
 	});

--- a/apps/tuval/src/claude/history/operator-turn.unit.test.ts
+++ b/apps/tuval/src/claude/history/operator-turn.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Where the operator's own turn comes from on a Claude session, pinned in both directions.
+ *
+ * The mapping is not what drops it. `userEvents` maps the exact `SDKUserMessage` that
+ * `../agent/input.ts` writes to a `user` item, bare-string `content` and all — the first case here.
+ * What no Claude session produces is a *frame* to map: the CLI does not echo a submitted prompt
+ * back on its output stream, so the second case drives a whole turn through the real layer and
+ * reads that absence off the pump. Together they say the transcript's user row is the core's, from
+ * the `prompt` cell (#7978), and never the layer's (#7979).
+ */
+
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Stream} from "effect";
+import {expect} from "vitest";
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {CWD, messages, OPENED_EVENTS, on, SESSION_ID} from "../agent/fixtures/harness.ts";
+import {userMessage} from "../agent/input.ts";
+import {toAgentEvents} from "./events.ts";
+import {emptyMapping} from "./map.ts";
+
+const AT = 1_700_000_000_000;
+const PROMPT = "read the readme";
+
+/** The tool turn's own five events after `init`, as `../agent/events.unit.test.ts` counts them. */
+const TURN_EVENTS = 5;
+
+const itemsIn = (events: ReadonlyArray<AgentEvent>) =>
+	events.flatMap((event) => (event.kind === "item" ? [event.item] : []));
+
+describe("the message the layer writes for one operator turn", () => {
+	it("maps to a user item carrying its text, so nothing in the mapping drops it", () => {
+		const step = toAgentEvents(userMessage(SESSION_ID, PROMPT), emptyMapping, {at: AT});
+		expect(step.events).toEqual([
+			{
+				kind: "item",
+				// The message carries no `uuid` — the layer writes it, the CLI has not stamped it yet
+				// — so the mapping falls back to the clock it was handed.
+				item: {kind: "user", id: `user-${AT}`, timestamp: AT, text: PROMPT},
+			},
+		]);
+		assert.strictEqual(step.mapping.skipped, 0, "the operator's own message was counted as unread");
+	});
+});
+
+describe("what a whole turn puts on the pump", () => {
+	it.effect("carries the operator's message in and no user item back out", () =>
+		on({opening: messages("tool-turn"), deferOpening: true}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				yield* agent.prompt(PROMPT, "k1");
+				const events = yield* Stream.runCollect(
+					Stream.take(agent.events, OPENED_EVENTS + TURN_EVENTS),
+				);
+
+				// In: the turn reached the CLI as the very message the first case just mapped.
+				const sent = scripted.opened[0]?.record.prompts ?? [];
+				assert.lengthOf(sent, 1);
+				assert.deepStrictEqual(sent[0], userMessage(SESSION_ID, PROMPT));
+
+				// Out: the turn's own `tool_result` frame is a user frame and lands as a tool row, so
+				// the absence below is the CLI never echoing the prompt rather than nothing arriving.
+				const items = itemsIn([...events]);
+				assert.deepStrictEqual(
+					items.map((item) => item.kind),
+					["tool", "tool", "assistant"],
+				);
+				assert.isEmpty(
+					items.filter((item) => item.kind === "user"),
+					"the Claude layer emitted a user item, so the transcript has two sources for one turn",
+				);
+			}),
+		),
+	);
+
+	it.effect("reads the same absence off the mapping over the turn's raw frames", () =>
+		Effect.sync(() => {
+			const frames: ReadonlyArray<SDKMessage> = messages("tool-turn");
+			let mapping = emptyMapping;
+			const events: AgentEvent[] = [];
+			for (const frame of frames) {
+				const step = toAgentEvents(frame, mapping, {at: AT});
+				mapping = step.mapping;
+				events.push(...step.events);
+			}
+			assert.isEmpty(
+				itemsIn(events).filter((item) => item.kind === "user"),
+				"a captured turn carries a frame the mapping reads as the operator's own text",
+			);
+		}),
+	);
+});

--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -73,6 +73,9 @@ import {
 	afterTheResend,
 	afterTheSecondTurn,
 	OFFERED,
+	PROMPT_1_KEY,
+	PROMPT_2_KEY,
+	PROMPT_3_KEY,
 	RESEND_KEY,
 	SESSION,
 	SWITCHED_TO,
@@ -521,7 +524,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 							);
 
 							// Turn one: the tool row runs and then settles under one item id.
-							const once = yield* chat(session, ready, PROMPT_1, "k1");
+							const once = yield* chat(session, ready, PROMPT_1, PROMPT_1_KEY);
 							assert.deepStrictEqual(ids(once), afterTheFirstTurn);
 							assert.strictEqual(
 								toolStatus(once, TOOL_ITEM),
@@ -532,7 +535,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 
 							// Turn two raises the card. The turn finishes either way; answering it is the
 							// operator's move, and the card stays open until they make it.
-							const twice = yield* chat(session, once, PROMPT_2, "k2");
+							const twice = yield* chat(session, once, PROMPT_2, PROMPT_2_KEY);
 							assert.deepStrictEqual(ids(twice), afterTheSecondTurn);
 							assert.deepStrictEqual(
 								openCards(twice),
@@ -744,15 +747,15 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 										"the session to open",
 										(s) => s.phase === "ready",
 									);
-									const once = yield* chat(session, ready, PROMPT_1, "k1");
-									yield* chat(session, once, PROMPT_2, "k2");
+									const once = yield* chat(session, ready, PROMPT_1, PROMPT_1_KEY);
+									yield* chat(session, once, PROMPT_2, PROMPT_2_KEY);
 
 									// The third turn writes half a reply and never reports `ready`. Waiting on
 									// the committed item is what makes the stop land inside it.
 									yield* session.send({
 										type: "prompt",
 										text: PROMPT_3,
-										key: "k3",
+										key: PROMPT_3_KEY,
 										timestamp: Date.now(),
 									});
 									const cut = yield* liveWhere(
@@ -885,7 +888,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 										"the session to open",
 										(s) => s.phase === "ready",
 									);
-									before = yield* chat(session, ready, PROMPT_1, "k1");
+									before = yield* chat(session, ready, PROMPT_1, PROMPT_1_KEY);
 									deskBefore = JSON.stringify(yield* settled(desk.seen, opened.desk));
 								}),
 							);
@@ -906,7 +909,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 								ids(left as AiAgentSessionState),
 								"the re-attached page saw a different transcript",
 							);
-							return yield* chat(session, seenAgain, PROMPT_2, "k2");
+							return yield* chat(session, seenAgain, PROMPT_2, PROMPT_2_KEY);
 						}),
 					);
 					noLiveHttp(calls);

--- a/apps/tuval/src/claude/proof/script.ts
+++ b/apps/tuval/src/claude/proof/script.ts
@@ -11,6 +11,15 @@
  * `ScriptedAiAgent.layer` is the whole backend (founder ruling on #7582 and #7586): the scripted
  * variant calls no model API and spends nothing, and the real CLI is the founder's own local run
  * (`./serve.ts`), never a CI job.
+ *
+ * **No turn and no history row here carries the operator's own text.** The Claude CLI never echoes
+ * a submitted prompt back on its output stream — `SDKUserMessage` is what the CLI "emits for
+ * user-role content it adds to the conversation itself, chiefly the `tool_result` blocks"
+ * (`@anthropic-ai/claude-agent-sdk@0.3.259`, `sdk.d.ts`) — and `ScriptedAiAgent` replays `history`
+ * as live item events on a resume, which is a second thing the real layer does not do. A user row
+ * in either place is traffic no Claude session can produce, so the proof asserted a tail the script
+ * itself supplied (#7979). The operator's half of every turn now comes from the one place that
+ * really produces it: the core's `prompt` cell, under `promptItemId(key)` (#7978).
  */
 
 import {promptItemId} from "../../ai-agent/core/index.ts";
@@ -24,18 +33,7 @@ import type {
 import {Mode} from "../../ai-agent/ports/index.ts";
 import type {AgentScript} from "../../ai-agent/service/index.ts";
 import {CLAUDE_MODES} from "../config.ts";
-import {
-	CARD,
-	CHILD_PROMPT,
-	CHILD_REPLY,
-	PROMPT_1,
-	PROMPT_2,
-	PROMPT_3,
-	REPLY_1,
-	REPLY_2,
-	REPLY_3,
-	REPLY_4,
-} from "./names.ts";
+import {CARD, CHILD_REPLY, REPLY_1, REPLY_2, REPLY_3, REPLY_4} from "./names.ts";
 
 export const SESSION = "claude-vertical-proof-session";
 export const CHILD_SESSION = "claude-vertical-proof-child-session";
@@ -48,13 +46,6 @@ export const OFFERED: ReadonlyArray<Mode> = CLAUDE_MODES.map((mode) => Mode.make
 
 const id = (value: string): ItemId => value as ItemId;
 const at = (offset: number): number => 1_760_000_000_000 + offset;
-
-const user = (value: string, text: string, offset: number): TranscriptItem => ({
-	kind: "user",
-	id: id(value),
-	timestamp: at(offset),
-	text,
-});
 
 const assistant = (value: string, text: string, offset: number): TranscriptItem => ({
 	kind: "assistant",
@@ -94,7 +85,6 @@ export const card: PermissionRequest = {
 /** Turn one: a tool call that runs and then settles under one item id. */
 const firstTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
-	{kind: "item", item: user("u1", PROMPT_1, 1)},
 	{kind: "item", item: runningRead},
 	{kind: "item", item: settledRead},
 	{kind: "item", item: assistant("a1", REPLY_1, 3)},
@@ -104,7 +94,6 @@ const firstTurn: ReadonlyArray<AgentEvent> = [
 /** Turn two: the card. The turn finishes either way — answering it is the operator's move. */
 const secondTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
-	{kind: "item", item: user("u2", PROMPT_2, 4)},
 	{kind: "permission", request: CARD, detail: card},
 	{kind: "item", item: assistant("a2", REPLY_2, 5)},
 	{kind: "phase", phase: "ready"},
@@ -117,7 +106,6 @@ const secondTurn: ReadonlyArray<AgentEvent> = [
  */
 const cutTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
-	{kind: "item", item: user("u3", PROMPT_3, 6)},
 	{kind: "item", item: assistant("a3", REPLY_3, 7)},
 ];
 
@@ -132,24 +120,25 @@ const resendTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "ready"},
 ];
 
-/** The item ids the tail holds after each turn, by position within one boot. */
-export const afterTheFirstTurn = ["u1", "t1", "a1"];
-export const afterTheSecondTurn = [...afterTheFirstTurn, "u2", "a2"];
-export const afterTheCut = [...afterTheSecondTurn, "u3", "a3"];
+/** The idempotency keys the proof sends its four prompts under; the tail names each turn by one. */
+export const PROMPT_1_KEY = "k1";
+export const PROMPT_2_KEY = "k2";
+export const PROMPT_3_KEY = "k3";
 export const RESEND_KEY = "k4";
+
+/** The item ids the tail holds after each turn, by position within one boot. */
+export const afterTheFirstTurn = [promptItemId(PROMPT_1_KEY), "t1", "a1"];
+export const afterTheSecondTurn = [...afterTheFirstTurn, promptItemId(PROMPT_2_KEY), "a2"];
+export const afterTheCut = [...afterTheSecondTurn, promptItemId(PROMPT_3_KEY), "a3"];
 export const afterTheResend = [...afterTheCut, promptItemId(RESEND_KEY), "a4"];
 
 export const claudeScript: AgentScript = {
 	sessionId: SESSION,
 	// The backend's own store: the turns that completed. The cut turn is not in it, because it
-	// never did — so replaying history on resume reconciles the tail without touching the cut.
-	history: [
-		user("u1", PROMPT_1, 1),
-		settledRead,
-		assistant("a1", REPLY_1, 3),
-		user("u2", PROMPT_2, 4),
-		assistant("a2", REPLY_2, 5),
-	],
+	// never did — so replaying history on resume reconciles the tail without touching the cut. The
+	// operator's own rows are absent for the reason at the top of this file: `ScriptedAiAgent`
+	// replays this array as live item events, and a Claude resume emits no user frame at all.
+	history: [settledRead, assistant("a1", REPLY_1, 3), assistant("a2", REPLY_2, 5)],
 	modes: {current: null, available: OFFERED},
 	interrupt: [],
 	turns: [{events: firstTurn}, {events: secondTurn}, {events: cutTurn}, {events: resendTurn}],
@@ -170,7 +159,6 @@ export const childScript: AgentScript = {
 		{
 			events: [
 				{kind: "phase", phase: "prompting"},
-				{kind: "item", item: user("c1", CHILD_PROMPT, 1)},
 				{kind: "item", item: assistant("c2", CHILD_REPLY, 2)},
 				{kind: "phase", phase: "ready"},
 			],

--- a/apps/tuval/src/claude/restore/claude-paged-turns.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-paged-turns.unit.test.ts
@@ -1,0 +1,184 @@
+/**
+ * A Claude window that prompts, reconnects and pages holds one row per prompt — the rule #7979 had
+ * to settle, and the seam it is settled at.
+ *
+ * Both halves are real. The tail is the core's own: a `prompt` Msg through the machine, taken
+ * through `restore`, which is what a reconnect leaves a window looking at. The page comes off a
+ * live `claude-session` row over `ClaudeAiAgent` and the captured `session-messages` rows, driven
+ * by the same `page` Msg a window dispatches — and the CLI's stored transcript does carry the
+ * operator's prompt rows, so the two halves genuinely name one turn under two ids.
+ *
+ * The rule chosen is neither of the two the ticket sketched. Re-keying the stored row onto the
+ * send's idempotency key cannot survive the reconnect it has to survive: the key is Tuval's, it is
+ * never written to the CLI's transcript, and the layer that held the send is rebuilt on resume
+ * (`../../ai-agent/handlers/session.ts`). Suppressing the stored user rows outright would hand the
+ * operator the same defect back on scroll-back, since past the core's bounded tail the store is the
+ * only place their own words exist. So the join is `withoutLocalEchoes`
+ * (`../../ai-agent/history/local-turns.ts`) — on text, bounded by count, which is the join the core
+ * itself uses for a layer's echo (`../../ai-agent/core/fold.ts`) — and the `aiAgent.page` handler
+ * applies it, so both routes a page takes carry one copy and no window has to know.
+ */
+
+import {applyCellChecked} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer} from "effect";
+import {
+	type AiAgentSessionCmd,
+	type AiAgentSessionMsg,
+	type AiAgentSessionState,
+	aiAgentSessionMachine,
+	initialState,
+	isAiAgentSessionState,
+	promptItemId,
+	restore,
+} from "../../ai-agent/core/index.ts";
+import {Mode, type TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {Checkpoints} from "../../durability/Checkpoints.ts";
+import {memoryStores} from "../../durability/stores.ts";
+import {NodeId} from "../../ports/graph.ts";
+import {PortNotWired, ProcessPorts} from "../../ports/index.ts";
+import {Processes} from "../../process/Processes.ts";
+import type {ProcessHandle} from "../../process/process.ts";
+import {Registry} from "../../registry/Registry.ts";
+import {rows, TOOL_SESSION_ID} from "../agent/fixtures/harness.ts";
+import {scriptedSdk} from "../agent/fixtures/scripted-query.ts";
+import {ClaudeAiAgent} from "../agent/index.ts";
+import {CLAUDE_MODES} from "../config.ts";
+import {claudeSession} from "../program.ts";
+import {KernelBridge} from "../tools/index.ts";
+
+const CWD = "/work";
+/** The operator's turn in the captured store, verbatim — the row `page` reads back. */
+const PROMPT = "Run the bash command: echo hello-tuval";
+const KEY = "k1";
+const AT = 1_760_000_000_000;
+
+const machine = aiAgentSessionMachine({cwd: CWD});
+
+const apply = (
+	state: AiAgentSessionState,
+	msg: AiAgentSessionMsg,
+): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
+
+/**
+ * The tail a reconnected window is looking at: a session that opened, was prompted, and came back
+ * off its checkpoint. `restore` is what a rehydrating `init` applies, so the turn under test has
+ * been through the round trip rather than been written by hand.
+ */
+const reconnectedTail = (): ReadonlyArray<TranscriptItem> => {
+	const [opened] = apply(
+		{...initialState(CWD), phase: "idle"},
+		{type: "start", cwd: CWD, resume: null},
+	);
+	const [ready] = apply(opened, {type: "started", sessionId: TOOL_SESSION_ID});
+	const [prompted] = apply(ready, {type: "prompt", text: PROMPT, key: KEY, timestamp: AT});
+	return restore(prompted).transcript.items;
+};
+
+/** A `ProcessPorts` wired to nothing, which the publisher swallows as it does in production. */
+const noPorts = ProcessPorts.of({
+	emit: (port) => Effect.fail(new PortNotWired({node: NodeId.make("test"), port})),
+});
+
+/** The `claude-session` row itself, over the real layer with the captured store under it. */
+const row = () =>
+	claudeSession({
+		cwd: CWD,
+		layer: ClaudeAiAgent.layer({
+			permissionMode: Mode.make("default"),
+			modes: CLAUDE_MODES.map((mode) => Mode.make(mode)),
+			allowedTools: [],
+			sdk: scriptedSdk({opening: [], rows: rows()}).sdk,
+			newSessionId: () => TOOL_SESSION_ID,
+		}).pipe(Layer.provide(KernelBridge.scripted({}))),
+	});
+
+const eventually = (check: () => boolean) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 400 && !check(); attempt += 1) yield* Effect.sleep("5 millis");
+	});
+
+const sessionOf = (handle: ProcessHandle): AiAgentSessionState => {
+	const state = handle.getState();
+	assert.isTrue(isAiAgentSessionState(state), "the process holds no ai-agent-session state");
+	return state as AiAgentSessionState;
+};
+
+/** Spawn the row, let it open, send one turn, then ask for the page a scroll-back would ask for. */
+const promptedThenPaged = Effect.fnUntraced(function* () {
+	const declared = row();
+	return yield* Effect.gen(function* () {
+		const processes = yield* Processes;
+		const handle = yield* processes.spawn(declared.id, {
+			services: Context.make(ProcessPorts, noPorts),
+		});
+		yield* eventually(() => sessionOf(handle).phase === "ready");
+		yield* handle.dispatch({type: "prompt", text: PROMPT, key: KEY, timestamp: AT});
+		yield* eventually(() => sessionOf(handle).transcript.items.length > 0);
+		yield* handle.dispatch({type: "page", before: null, limit: 50});
+		yield* eventually(() => sessionOf(handle).lastPage !== null);
+		return sessionOf(handle);
+	}).pipe(
+		Effect.scoped,
+		Effect.provide(
+			Processes.layer.pipe(
+				Layer.provideMerge(Checkpoints.layer(memoryStores())),
+				Layer.provideMerge(Registry.layer([declared])),
+			),
+		),
+	);
+});
+
+describe("the turn a Claude window prompted, after it reconnects and pages", () => {
+	it("is one row in the reconnected tail, under the send's own key", () => {
+		const tail = reconnectedTail();
+		assert.deepStrictEqual(
+			tail.map((item) => item.id),
+			[promptItemId(KEY)],
+			"the reconnected tail does not hold the operator's turn under the send's key",
+		);
+		assert.strictEqual(
+			tail[0]?.kind === "user" ? tail[0].local : false,
+			true,
+			"the restored turn lost the mark that says no layer has confirmed it",
+		);
+	});
+
+	it.live("leaves the store's copy of that turn out of the page it is asked for", () =>
+		Effect.gen(function* () {
+			const state = yield* promptedThenPaged();
+			const page = state.lastPage?.items ?? [];
+
+			assert.deepStrictEqual(
+				state.transcript.items.map((item) => item.id),
+				[promptItemId(KEY)],
+				"the live tail does not hold the operator's turn under the send's key",
+			);
+			assert.isEmpty(
+				page.filter((item) => item.kind === "user" && item.text === PROMPT),
+				"the page carries the store's copy of a turn the tail already holds",
+			);
+			assert.lengthOf(
+				[...page, ...state.transcript.items].filter(
+					(item) => item.kind === "user" && item.text === PROMPT,
+				),
+				1,
+				"one prompt reaches the window as more than one row",
+			);
+		}),
+	);
+
+	it.live("keeps every other stored row, so the page is not thinned to close the duplicate", () =>
+		Effect.gen(function* () {
+			const state = yield* promptedThenPaged();
+			const page = state.lastPage?.items ?? [];
+			assert.isNotEmpty(page, "the whole page went with the turn that was dropped from it");
+			assert.deepStrictEqual(
+				page.map((item) => item.kind),
+				["tool", "assistant"],
+				"the page lost a row that was never the operator's turn",
+			);
+		}),
+	);
+});

--- a/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
@@ -38,6 +38,7 @@ import {
 	afterTheResend,
 	CARD,
 	CWD,
+	KEYS,
 	OFFERED,
 	SESSION,
 	SWITCHED_TO,
@@ -170,6 +171,8 @@ interface SecondRun {
 	readonly afterReconnect: ReadonlyArray<string>;
 	readonly modeAfterReconnect: AiAgentSessionState["modes"];
 	readonly emissionsForTheResend: number;
+	/** The item ids the *first* of those emissions carried, which is the send's own. */
+	readonly firstEmissionForTheResend: ReadonlyArray<string>;
 	readonly afterResend: ReadonlyArray<string>;
 	readonly phaseAfterResend: AiAgentSessionState["phase"];
 }
@@ -184,7 +187,7 @@ const runToTheCut = (project: string): Effect.Effect<FirstRun, unknown, FileSyst
 		const {agent, window} = yield* handlesOf(booted);
 		yield* until("the session to open", () => sessionOf(agent).sessionId !== null);
 
-		yield* say(window, "read the readme", "k1");
+		yield* say(window, "read the readme", KEYS.first);
 		yield* until("the first reply", () => rendered(window).includes("a1"));
 		yield* until("the permission card", () =>
 			(pendingIn(arrivalsOf(window)).at(-1) ?? []).includes(CARD),
@@ -198,10 +201,10 @@ const runToTheCut = (project: string): Effect.Effect<FirstRun, unknown, FileSyst
 		yield* switchMode(window);
 		yield* until("the mode switch to commit", () => sessionOf(agent).modes.current === SWITCHED_TO);
 
-		yield* say(window, "now the tests", "k2");
+		yield* say(window, "now the tests", KEYS.second);
 		yield* until("the second reply", () => rendered(window).includes("a2"));
 
-		yield* say(window, "delete the build dir", "k3");
+		yield* say(window, "delete the build dir", KEYS.cut);
 		// The window's copy is published from the Sub's own projection, which runs ahead of the core
 		// committing the same event — so a stop taken on the window's word alone can checkpoint a
 		// tail without the cut turn in it. Wait for the committed state, which is what is saved.
@@ -241,7 +244,7 @@ const runFromTheCheckpoint = (
 		const modeAfterReconnect = sessionOf(agent).modes;
 		const beforeResend = arrivalsOf(window).length;
 
-		yield* say(window, "try that again", "k4");
+		yield* say(window, "try that again", KEYS.resend);
 		yield* until("the resent turn's reply", () => rendered(window).includes("a4"));
 		yield* until("the resend to settle", () => sessionOf(agent).phase === "ready");
 		yield* quiet(window);
@@ -252,6 +255,9 @@ const runFromTheCheckpoint = (
 			afterReconnect,
 			modeAfterReconnect,
 			emissionsForTheResend: transcriptsIn(arrivalsOf(window).slice(beforeResend)).length,
+			firstEmissionForTheResend:
+				transcriptsIn(arrivalsOf(window).slice(beforeResend))[0]?.items.map((item) => item.id) ??
+				[],
 			afterResend: rendered(window),
 			phaseAfterResend: sessionOf(agent).phase,
 		} satisfies SecondRun;
@@ -355,11 +361,18 @@ describe("the claude-session row, driven through ports and booted back over its 
 		).not.toContain("a4");
 	});
 
-	it("answers one resend with exactly one new emission", () => {
+	// Two, not one: the operator's own turn is published when they send it and the reply when it
+	// arrives (#7978/#7979). A single emission would mean the window shows your message only once
+	// the agent has answered, which is the wait the founder reported.
+	it("answers one resend with two emissions, the operator's turn before the reply", () => {
 		expect(
 			outcome.second.emissionsForTheResend,
-			"one deliberate resend did not produce exactly one transcript emission",
-		).toBe(1);
+			"one deliberate resend did not produce the send's emission and the reply's",
+		).toBe(2);
+		expect(
+			outcome.second.firstEmissionForTheResend,
+			"the send's own emission did not already carry the operator's turn",
+		).toEqual(outcome.second.afterResend.slice(0, -1));
 		expect(outcome.second.afterResend).toEqual(afterTheResend);
 		expect(outcome.second.phaseAfterResend).toBe("ready");
 	});

--- a/apps/tuval/src/claude/restore/fixtures/claude-desk.ts
+++ b/apps/tuval/src/claude/restore/fixtures/claude-desk.ts
@@ -10,9 +10,13 @@
  *
  * The script is Claude-shaped traffic rather than the generic one: a tool call that runs and then
  * settles, a permission card the operator answers, the four modes the row advertises, a turn the
- * restart cuts, and a resumed start.
+ * restart cuts, and a resumed start. No turn and no history row carries the operator's own text,
+ * for `../../proof/script.ts`'s reason: the Claude CLI never echoes a submitted prompt back, and a
+ * resume replays no user frame either, so the operator's half comes from the core's `prompt` cell
+ * under `promptItemId(key)` (#7978/#7979).
  */
 
+import {promptItemId} from "../../../ai-agent/core/index.ts";
 import type {AgentEvent} from "../../../ai-agent/events.ts";
 import type {
 	ItemId,
@@ -47,13 +51,6 @@ export const OFFERED: ReadonlyArray<Mode> = CLAUDE_MODES.map((mode) => Mode.make
 
 const id = (value: string): ItemId => value as ItemId;
 const at = (offset: number): number => 1_760_000_000_000 + offset;
-
-const user = (value: string, text: string, offset: number): TranscriptItem => ({
-	kind: "user",
-	id: id(value),
-	timestamp: at(offset),
-	text,
-});
 
 const assistant = (value: string, text: string, offset: number): TranscriptItem => ({
 	kind: "assistant",
@@ -91,7 +88,6 @@ export const card: PermissionRequest = {
 /** Turn one: a tool call that runs then settles, and the card the operator is asked to answer. */
 export const firstTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
-	{kind: "item", item: user("u1", "read the readme", 1)},
 	{kind: "item", item: runningRead},
 	{kind: "item", item: settledRead},
 	{kind: "permission", request: CARD, detail: card},
@@ -101,7 +97,6 @@ export const firstTurn: ReadonlyArray<AgentEvent> = [
 
 export const secondTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
-	{kind: "item", item: user("u2", "now the tests", 4)},
 	{kind: "item", item: assistant("a2", "all green", 5)},
 	{kind: "phase", phase: "ready"},
 ];
@@ -113,32 +108,36 @@ export const secondTurn: ReadonlyArray<AgentEvent> = [
  */
 export const cutTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
-	{kind: "item", item: user("u3", "delete the build dir", 6)},
 	{kind: "item", item: assistant("a3", "I was in the middle of", 7)},
 ];
 
-/** The resend, one item long, so one deliberate send is one new emission on `transcript`. */
+/** The resend, one item long: the layer reports the reply, and the core reported the send. */
 export const resendTurn: ReadonlyArray<AgentEvent> = [
 	{kind: "phase", phase: "prompting"},
 	{kind: "item", item: assistant("a4", "done, the dir is gone", 8)},
 	{kind: "phase", phase: "ready"},
 ];
 
+/** The idempotency keys the proof sends its four prompts under. */
+export const KEYS = {first: "k1", second: "k2", cut: "k3", resend: "k4"} as const;
+
 /** The item ids the tail holds after the cut, and after the resend that follows the restore. */
-export const afterTheCut = ["u1", "t1", "a1", "u2", "a2", "u3", "a3"];
-export const afterTheResend = [...afterTheCut, "a4"];
+export const afterTheCut = [
+	promptItemId(KEYS.first),
+	"t1",
+	"a1",
+	promptItemId(KEYS.second),
+	"a2",
+	promptItemId(KEYS.cut),
+	"a3",
+];
+export const afterTheResend = [...afterTheCut, promptItemId(KEYS.resend), "a4"];
 
 const script: AgentScript = {
 	sessionId: SESSION,
 	// The backend's own store: the turns that completed. The cut turn is not in it, because it
 	// never did — so replaying history on resume reconciles the tail without touching the cut.
-	history: [
-		user("u1", "read the readme", 1),
-		settledRead,
-		assistant("a1", "here it is", 3),
-		user("u2", "now the tests", 4),
-		assistant("a2", "all green", 5),
-	],
+	history: [settledRead, assistant("a1", "here it is", 3), assistant("a2", "all green", 5)],
 	modes: {current: null, available: OFFERED},
 	interrupt: [],
 	turns: [{events: firstTurn}, {events: secondTurn}, {events: cutTurn}, {events: resendTurn}],

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -605,7 +605,9 @@ const runServiceAgent = Effect.gen(function* () {
 			key: "k1",
 			timestamp: Date.now(),
 		});
-		yield* eventually(() => (lastTranscript(emitted)?.items.length ?? 0) >= answered.length);
+		// The operator's own turn opens the tail — the core records it at the send (#7978) — so the
+		// run's spell rows are what follows it.
+		yield* eventually(() => (lastTranscript(emitted)?.items.length ?? 0) > answered.length);
 		const help = yield* overTheWire(["help"], {});
 		return {
 			answered,
@@ -683,7 +685,13 @@ describe("the agent proof, on the agent service", () => {
 		Effect.gen(function* () {
 			const {answered, transcript} = yield* runServiceAgent;
 			assert.isDefined(transcript, "the agent published no transcript");
-			const items = transcript?.items ?? [];
+			const opened = transcript?.items ?? [];
+			assert.strictEqual(
+				opened[0]?.kind,
+				"user",
+				"the tail does not open on the prompt the run was given",
+			);
+			const items = opened.slice(1);
 			assert.deepStrictEqual(
 				items.map((item) => (item.kind === "tool" ? item.name : item.kind)),
 				answered.map((entry) => renderPath(entry.request.path)),


### PR DESCRIPTION
The founder's own messages never appeared in a `claude-session` window. #7978 fixed the half that
was the core's: the `prompt` cell now records the operator's turn when they send it. This is the
Claude half — the scripted proof stops asserting a row it supplied itself, and the two places that
still lost the recorded turn are closed.

**The proof stopped lying.** `apps/tuval/src/claude/proof/script.ts` hand-fed a `user` item on
every turn, and the Claude CLI produces no such frame: `SDKUserMessage` is what the CLI "emits for
user-role content it adds to the conversation itself, chiefly the `tool_result` blocks"
(`@anthropic-ai/claude-agent-sdk@0.3.259`, `sdk.d.ts`), never an echo of the submitted prompt. The
turn arrays lost those items, and so did the script's `history` — `ScriptedAiAgent` replays that
array as live item events on a resume, which is a second thing no Claude resume does. The
`afterThe…` arrays now name each turn by `promptItemId(key)`, so the tail is asserted against the
send's own key. `apps/tuval/src/claude/restore/fixtures/claude-desk.ts` carried the same two
fictions and got the same treatment.

**Two real losses fell out of that, and neither was visible while the script supplied the row.**

The published transcript lost every locally-recorded turn. The events Sub folded layer events onto
a projection it owned alone (`apps/tuval/src/ai-agent/handlers/index.ts`), and no event carries the
`prompt` cell's turn — so anything reading the `transcript` *port* saw the agent's half only. The
vertical proof's own delegation case caught it: the spawned child's transcript came back holding
the reply and not the prompt. The projection now lives per process
(`apps/tuval/src/ai-agent/handlers/projection.ts`) and the `aiAgent.prompt` handler puts it on the
core's committed state and publishes, which is also what makes the operator's row appear at the
send rather than at the reply.

A page over the CLI's store double-counted the turn. `getSessionMessages` does return the
operator's prompt rows, under the CLI's uuid, while the core holds the same turn under
`local:<key>` — one turn, two ids, and no id joins them. The rule chosen is neither of the two the
issue sketched, and the third acceptance criterion invited that ("whichever rule was chosen"):

- Re-keying the stored row onto the send's idempotency key cannot survive the reconnect it has to
  survive. The key is Tuval's, it is never written to the CLI's transcript, and the layer that held
  the send is rebuilt on every resume.
- Suppressing the stored user rows outright hands the operator the same defect back on scroll-back:
  past the core's bounded tail the store is the only place their own words exist.

So the join is `withoutLocalEchoes` (`apps/tuval/src/ai-agent/history/local-turns.ts`) — on text,
bounded by count, walked newest-first, which is the join the core itself already uses for a layer's
echo. The `aiAgent.page` handler applies it, so both routes one page takes carry a single copy and
no window has to know. It landed there rather than in the window's stitch because
`apps/tuval/src/shell/chat` may import from `ai-agent/` only as `import type` — a boundary its own
`boundary.unit.test.ts` enforces so no agent code reaches the browser bundle.

`apps/tuval/src/claude/history/map.ts` is unchanged. The issue's triage note falsifies the
dropped-frame reading and this PR found nothing to add to it: `userEvents` maps the exact message
`userMessage()` writes, bare-string `content` and all, which the first case of
`apps/tuval/src/claude/history/operator-turn.unit.test.ts` now pins.

No file under `apps/tuval/src/ai-agent/core/` is touched. `pnpm typecheck` and `pnpm lint` are
clean; the full `apps/tuval` suite is green at 1354 tests.

## Deviations

- **Out-of-scope change** — **Said:** #7979 owns the Claude half, and names
  `apps/tuval/src/claude/proof/script.ts` plus a page-path rule. **Did:** also fixed the transcript
  projection in `apps/tuval/src/ai-agent/handlers/`, which is generic to Pi and Claude, and updated
  three tests that asserted the old behaviour (`agent-proof.unit.test.ts`,
  `restore-proof.unit.test.ts`, `claude-restore-proof.unit.test.ts`) plus
  `ai-agent/restore/fixtures/agent-desk.ts`. **Why:** acceptance criterion 2 requires
  `claude-vertical.integration.test.ts` green, and its delegation case fails without the projection
  fix — with the script no longer supplying the row, nothing else put the operator's turn on the
  `transcript` port. Criterion 6 forbids only `apps/tuval/src/ai-agent/core/`, which is untouched.
  **Disposition:** stated here.
- **Declined guidance** — **Said:** criterion 4 names two candidate rules, id-keying against the
  prompt's idempotency key or the layer suppressing the history-sourced user row. **Did:** took
  neither, and joined on text at the `aiAgent.page` handler instead. **Why:** the key never reaches
  the CLI's store and the layer is rebuilt on resume, so id-keying cannot survive the reconnect the
  criterion names; suppression loses the operator's turns past the bounded tail, which is the
  reported bug on scroll-back. The criterion's own wording is "whichever rule was chosen".
  **Disposition:** stated here and argued in the test's own docblock,
  `apps/tuval/src/claude/restore/claude-paged-turns.unit.test.ts`.
- **Pre-existing test or fixture changed** — **Said:** criterion 1 names the four turn arrays in
  `apps/tuval/src/claude/proof/script.ts`. **Did:** also removed the operator's rows from that
  script's `history`, and from `apps/tuval/src/claude/restore/fixtures/claude-desk.ts` entirely.
  **Why:** `ScriptedAiAgent` replays `history` as live item events on a resume, so a user row there
  is the same fiction one step further on — and with it present the restart case's tail changes id
  across the restart, breaking the assertion that a new turn does not rewrite the tail it appends
  to. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** criterion 7 wants `pnpm typecheck` and `pnpm lint`
  clean, and criterion 2 the vertical proof green. **Did:** all of that, but the full `apps/tuval`
  suite reds non-deterministically under load in three files this change does not touch
  (`src/shell/program.unit.test.ts`, `src/boot.unit.test.ts`,
  `src/shell/chat/chat-a11y.unit.test.tsx`). **Why:** they are timeout-shaped, pass in isolation and
  pass on a repeat of the same full run; the flakiness predates this change and is filed as
  https://github.com/kamp-us/phoenix/issues/8028. **Disposition:** filed, not fixed here.

Fixes #7979
