### PR TITLE
chore(benchmarks): skill-doctor evaluation PoC evidence

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,59 @@
+# benchmarks
+
+Evaluation of [Warp Skill Doctor](https://github.com/warpdotdev/common-skills/tree/main/.agents/skills/skill-doctor)
+(MIT) as a benchmark for fabrika's skills, per
+[Discussion #7319](https://github.com/kamp-us/phoenix/discussions/7319). Local-only
+proof of concept: not a workspace member, not wired into CI or `pnpm`, runs standalone.
+
+## Contents
+
+| Path | What it is |
+|---|---|
+| [`warp-skill-doctor-import-poc/REPORT.md`](warp-skill-doctor-import-poc/REPORT.md) | Full experiment record: method, scores, findings, portability notes, verdict |
+| [`warp-skill-doctor-import-poc/ADAPTATION.md`](warp-skill-doctor-import-poc/ADAPTATION.md) | Deviation ledger for the import (what is upstream's, what is ours, why) |
+| [`warp-skill-doctor-import-poc/ISSUE_DRAFT.md`](warp-skill-doctor-import-poc/ISSUE_DRAFT.md) | Ready-to-file tracking issue: five blockers between this PoC and a production import |
+| [`warp-skill-doctor-import-poc/results/`](warp-skill-doctor-import-poc/results/) | Run artifacts (gitignored; see [Privacy](#privacy)) |
+| `claude-plugins/fabrika/skills/skill-doctor/` | The import candidate: 12 upstream files byte-exact, plus our `LICENSE` + `PROVENANCE.md` |
+
+## Verification
+
+Upstream test suites (run from the skill's `scripts/`, Python 3.12, Windows):
+
+```bash
+PYTHONUTF8=1 python test_collect_sessions.py   # 14 tests — OK
+PYTHONUTF8=1 python test_render_report.py      # 11 tests — OK
+```
+
+**25/25 passing** as of 2026-09-06, at upstream pin `b811c24365ae`.
+
+End-to-end pipeline, re-verified 2026-09-06: opencode→Claude-Code adapter (2 real
+local sessions) → unmodified upstream collector (2 sampled, 27 skills found) →
+rubric judging → upstream aggregation → `render_report.py`. Result: **B+
+(overall 0.88)** — efficiency 0.90, code quality 0.80, skill coverage 1.0 —
+identical to the original 2026-08-31 run. The score rests on 2 sessions and is
+directional only, not a measurement of the corpus.
+
+## Status
+
+Verdict: **revise before import.** The five blockers and their evidence are in
+[`ISSUE_DRAFT.md`](warp-skill-doctor-import-poc/ISSUE_DRAFT.md), filed as the
+tracking issue
+[#8035](https://github.com/kamp-us/phoenix/issues/8035) (`status:needs-triage`,
+2026-09-06). Headline: upstream
+has no opencode collector (the only real session source on this machine), a
+Windows/UTF-8 portability bug survives in the scripts, the report ships
+share-by-default with vendor branding, and the import does not yet meet fabrika's
+skill conventions.
+
+Upstream pin: `b811c24365ae` (2026-09-03). Originally imported at `0254cbe9`
+(2026-08-28); re-synced byte-exact on 2026-09-06 after upstream landed ZCode/Pi
+harness support (#93) and complete-session streaming (#92). Re-sync policy: re-copy
+from upstream, never edit in place (see the candidate's `PROVENANCE.md`).
+
+## Privacy
+
+`warp-skill-doctor-import-poc/results/` contains **real conversation transcripts**,
+census inventories with absolute local paths, and an upstream-rendered `report.html`
+embedding transcript-derived content. Everything except `results/opencode_adapter.py`
+is gitignored. Never commit, attach, or share that directory; the adapter shim is
+tracked because `REPORT.md` cites it and it carries no session content.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,15 +35,23 @@ directional only, not a measurement of the corpus.
 
 ## Status
 
-Verdict: **revise before import.** The five blockers and their evidence are in
-[`ISSUE_DRAFT.md`](warp-skill-doctor-import-poc/ISSUE_DRAFT.md), filed as the
-tracking issue
-[#8035](https://github.com/kamp-us/phoenix/issues/8035) (`status:needs-triage`,
-2026-09-06). Headline: upstream
-has no opencode collector (the only real session source on this machine), a
-Windows/UTF-8 portability bug survives in the scripts, the report ships
-share-by-default with vendor branding, and the import does not yet meet fabrika's
-skill conventions.
+The experiment's verdict at filing time was **revise before import** (`REPORT.md` §11, posted as
+[#8035](https://github.com/kamp-us/phoenix/issues/8035)). Since then the founder ratified the
+path on the issue (2026-09-05,
+[approval comment](https://github.com/kamp-us/phoenix/issues/8035#issuecomment-5555033755)): the
+import proceeds as an epic — the packaged import lands first
+([#8048](https://github.com/kamp-us/phoenix/issues/8048)), the opencode collector next
+([#8049](https://github.com/kamp-us/phoenix/issues/8049)), then portability (#8050),
+skills-corpus discovery (#8051), a fabrika-branded, internal-by-default report (#8052),
+calibration over at least 20 real sessions (#8053), and the report share posture as its own
+`ready-for:human` ADR child (#8054). External sharing is deferred to that child — not a v1
+gate. ADR 0355 (draft PR [#8055](https://github.com/kamp-us/phoenix/pull/8055)) records the
+evidence/import split this folder's evidence PR depends on.
+
+Headline findings still standing while the epic runs: upstream has no opencode collector (#8049
+owns it), the Windows/UTF-8 portability exposure is #8050, and the report's vendor
+branding/share surface is #8052 and #8054. The grade stays unquoted past the 2-session floor
+until #8053's readout.
 
 Upstream pin: `b811c24365ae` (2026-09-03). Originally imported at `0254cbe9`
 (2026-08-28); re-synced byte-exact on 2026-09-06 after upstream landed ZCode/Pi

--- a/benchmarks/warp-skill-doctor-import-poc/.gitignore
+++ b/benchmarks/warp-skill-doctor-import-poc/.gitignore
@@ -1,0 +1,9 @@
+# Machine-local experiment evidence — never committed.
+# `results/` holds real phoenix conversation transcripts (adapter output), the
+# census inventories (absolute `C:\Users\...` paths), and the upstream-rendered
+# `report.html` (transcript-derived, shareable-by-default). REPORT.md §10 and
+# ISSUE_DRAFT.md's paths note both say these stay off the record.
+# The adapter shim is the exception: it is the documented working reference
+# REPORT.md §6 cites, with no session content inside.
+results/*
+!results/opencode_adapter.py

--- a/benchmarks/warp-skill-doctor-import-poc/ADAPTATION.md
+++ b/benchmarks/warp-skill-doctor-import-poc/ADAPTATION.md
@@ -1,0 +1,151 @@
+# ADAPTATION.md — Warp Skill Doctor → Fabrika import PoC
+
+Deviation ledger for the local, untracked import candidate at
+`claude-plugins/fabrika/skills/skill-doctor/`.
+
+- **Upstream:** `warpdotdev/common-skills` @ `0254cbe9b73f1171028ce82b9825d232791bab8b`
+  (2026-08-28, "Curve skill-doctor grades and filter edits by failures (#81)"), path
+  `.agents/skills/skill-doctor/`, MIT (Copyright (c) 2026 Denver Technologies, Inc.).
+- **Import rule followed:** copy faithfully, preserve copyright/MIT attribution, make only
+  the minimum compatibility changes Fabrika requires; do not redesign the scoring model or
+  replace the LLM evaluation.
+
+## File-level mapping (upstream → local)
+
+| Upstream file (under `.agents/skills/skill-doctor/`) | Local destination (under `claude-plugins/fabrika/skills/skill-doctor/`) | Content |
+|---|---|---|
+| `SKILL.md` | `SKILL.md` | byte-exact (git blob SHA `9fd7d77d…`) |
+| `references/supported-harnesses.md` | `references/supported-harnesses.md` | byte-exact (`a7bf9446…`) |
+| `references/skill-improvements.md` | `references/skill-improvements.md` | byte-exact (`bbf1dace…`) |
+| `scorers/efficiency.md` | `scorers/efficiency.md` | byte-exact (`28648134…`) |
+| `scorers/code-quality.md` | `scorers/code-quality.md` | byte-exact (`59179f8d…`) |
+| `scripts/collect_sessions.py` | `scripts/collect_sessions.py` | byte-exact (`a1842a5d…`) |
+| `scripts/render_report.py` | `scripts/render_report.py` | byte-exact (`972da3be…`) |
+| `scripts/test_collect_sessions.py` | `scripts/test_collect_sessions.py` | byte-exact (`e71dc098…`) |
+| `scripts/test_render_report.py` | `scripts/test_render_report.py` | byte-exact (`46658d0f…`) |
+| `scripts/warp_decoder.py` | `scripts/warp_decoder.py` | byte-exact (`c54cebdd…`) |
+| `assets/pierre-diffs.js` | `assets/pierre-diffs.js` | byte-exact (`1ecc2c99…`) |
+| `assets/warp-pixel-icon.svg` | `assets/warp-pixel-icon.svg` | byte-exact (`0ed8d084…`) |
+| *(repo-root `LICENSE`)* | `LICENSE` | byte-exact copy of the upstream repo's MIT license text |
+| *(none)* | `PROVENANCE.md` | **added** (see deviation 1) |
+
+Verification: each file's git blob SHA-1 (`sha1("blob <len>\0" + content)`) was computed
+locally and compared against the SHAs the GitHub tree API reports for the upstream commit.
+All 12 upstream files match exactly.
+
+## Deviations
+
+### 1. Added `PROVENANCE.md` (upstream: none)
+
+- **Upstream:** no such file; upstream marks provenance via the repo-root LICENSE only.
+- **Local:** `claude-plugins/fabrika/skills/skill-doctor/PROVENANCE.md`.
+- **Change:** a short provenance/attribution note (upstream link, commit SHA, MIT
+  attribution, byte-exactness claim, re-sync rule).
+- **Why Fabrika requires it:** fabrika's imported-skill precedent (`writing-for-agents`)
+  carries an in-directory attribution note + LICENSE, and fabrika skills live inside the
+  plugin directory where the upstream repo-root LICENSE is not visible. The repo's
+  conventions also require that an imported doc state its lineage so a future maintainer
+  re-syncs from upstream rather than editing in place.
+- **Behavior change:** none. Pure documentation; no runtime file reads it.
+
+### 2. Added `LICENSE` inside the skill directory (upstream: repo root only)
+
+- **Upstream:** the MIT license lives at the `common-skills` repo root, not inside
+  `.agents/skills/skill-doctor/`.
+- **Local:** `claude-plugins/fabrika/skills/skill-doctor/LICENSE` — a byte-exact copy of
+  the upstream repo-root MIT license text.
+- **Change:** duplication of the license into the skill directory.
+- **Why Fabrika requires it:** when this skill directory is copied or consumed out of
+  phoenix (as fabrika skills are consumed from the plugin), the upstream repo-root
+  license does not travel with it. MIT requires the copyright + permission notice
+  accompany "copies or substantial portions of the Software"; shipping the skill without
+  the notice in reach would violate the license's one condition. Precedent:
+  `writing-for-agents/LICENSE`.
+- **Behavior change:** none. Documentation only.
+
+### 3. None — no file content was modified
+
+- **Upstream section / local section:** every upstream file body.
+- **Change:** none. All 12 upstream files are byte-exact.
+- **Why:** the PoC's stated rule — copy faithfully, minimum compatibility changes.
+  Fabrika's skill conventions (two-layer split, contract.md, verb-served lookups) would
+  demand restructuring for a *production* import (see REPORT.md §12), but those are
+  import-time decisions requiring maintainer sign-off, not silent PoC edits. The one
+  place fabrika's rules *do* bite at runtime — the nonstandard skills path — is handled
+  by upstream's own `--skills-dir` flag, not a code change (see deviation-class B below).
+
+## Configuration-only adaptations (no file changes; documented invocation deltas)
+
+These are not file deviations — the upstream files are untouched — but they are real
+differences in how the skill must be *invoked* on this machine, required by phoenix's
+environment. Each is evidence for the production-import decision.
+
+### B1. Skills discovery — nonstandard fabrika skills path
+
+- **Upstream contract:** `collect_sessions.py --repo <phoenix>` discovers project skills
+  only under `<repo>/.agents/skills`, `<repo>/.claude/skills`, `<repo>/.codex/skills`
+  (per `references/supported-harnesses.md` § Skill locations).
+- **Local reality:** phoenix's fabrika skills live at `claude-plugins/fabrika/skills`
+  (wired into opencode via `opencode.json` `"skills": {"paths": [...]}`), and
+  `<repo>/.claude/skills` holds unrelated ctx-* skills (opencode `ctx` plugin), not
+  fabrika's.
+- **Adaptation used:** upstream's own `--skills-dir claude-plugins/fabrika/skills` flag
+  (documented in SKILL.md Step 1 "Useful flags" for exactly this case). No code change.
+- **Behavior change:** none in the script; the flag is upstream-supported configuration.
+
+### B2. Executing harness — opencode is outside upstream's startup gate
+
+- **Upstream contract:** `references/supported-harnesses.md` § Startup gate: supported
+  executing harnesses are Warp, Claude Code, Codex; anything else must stop before
+  creating a report directory or reading conversation history.
+- **Local reality:** the harness executing skills in this repo is opencode (opencode.json
+  + `~/.local/share/opencode`), which is not in the table.
+- **PoC handling:** followed the PoC instruction — "if Skill Doctor cannot discover
+  Fabrika's nonstandard skill path, adapt only discovery/configuration and document it";
+  the *scoring run itself* was executed by the opencode session acting as Skill Doctor's
+  "local agent process" (SKILL.md Step 2: "Score batches in the current local agent
+  process, or delegate only to local child agents"). The scripts were run by that agent
+  process; no simulator, no replacement scorer was used.
+- **Behavior change:** none to the imported files; this is the documented consequence of
+  running an unsupported-harness skill from a different host harness.
+
+### B3. Conversation source — no Claude Code/Codex/Warp history for phoenix on this machine
+
+- **Upstream contract:** collectors exist for Claude Code project JSONL, Codex rollout
+  JSONL, and Warp SQLite.
+- **Local reality (census, metadata only):** `~/.claude/projects` is empty; `~/.codex`
+  holds 293 rollouts, none for this checkout (newest is 2026-06-05, another repo), none
+  within the 45-day default window; no Warp data. The only real phoenix-local agent
+  history on this machine is opencode's own store (`~/.local/share/opencode`), which
+  upstream has **no collector for**.
+- **PoC handling:** BLOCKED at the transcript-scoring step for the *upstream collectors*.
+  What this experiment did instead — using the real opencode conversations through an
+  upstream-shaped adapter *external to the imported skill* — is documented in
+  REPORT.md §6, and the adapter lives outside the skill directory (in the results
+  directory, clearly labeled). It converts opencode's SQLite rows into Claude-Code-shaped
+  JSONL files under a temporary claude-home, then the **unmodified upstream**
+  `collect_sessions.py` parses those files with its real Claude Code parser. The
+  transcripts, sampling, stats, rubrics, scoring, aggregation, and rendering are all the
+  upstream pipeline's. The adapter is a translation shim for one unsupported *source*,
+  not a replacement scorer.
+- **Behavior change:** none to the imported files. The adapter is invoked, never merged.
+
+### B4. Python interpreter availability
+
+- **Upstream contract:** SKILL.md says `python3`. This machine's Windows Python is
+  `python` (3.12.10); `python3` also resolves.
+- **Adaptation:** invocation used `python`. No file change.
+
+## Not done (and why)
+
+- **No restructure to fabrika's two-layer skill split** (SKILL.md-as-router +
+  contract.md depth). That is a production-import decision (REPORT.md §12), not a PoC
+  compatibility requirement — making it here would redesign upstream's shape against the
+  "copy faithfully" rule.
+- **No `contract.md` added.** Upstream has none; adding one would be an undocumented
+  structural deviation. Left for the production decision.
+- **No description/frontmatter edits** beyond upstream's own frontmatter (which already
+  has `name` + `description`, the fields fabrika skills carry).
+- **No changes to scoring, aggregation, letter-grade curve, or the failed-conversation
+  filter.** The rubrics, curve formula (`0.5 + 0.5 * score`), overall weights
+  (`0.5/0.35/0.15`), and edit-gating on failed conversations are upstream's, untouched.

--- a/benchmarks/warp-skill-doctor-import-poc/ADAPTATION.md
+++ b/benchmarks/warp-skill-doctor-import-poc/ADAPTATION.md
@@ -113,7 +113,7 @@ environment. Each is evidence for the production-import decision.
 
 - **Upstream contract:** collectors exist for Claude Code project JSONL, Codex rollout
   JSONL, and Warp SQLite.
-- **Local reality (census, metadata only):** `~/.claude/projects` is empty; `~/.codex`
+- **Local reality (census, metadata only):** the Claude Code sessions directory is empty; `~/.codex`
   holds 293 rollouts, none for this checkout (newest is 2026-06-05, another repo), none
   within the 45-day default window; no Warp data. The only real phoenix-local agent
   history on this machine is opencode's own store (`~/.local/share/opencode`), which

--- a/benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md
+++ b/benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md
@@ -1,0 +1,154 @@
+# Draft tracking issue — skill-doctor production import (FILED as #8035)
+
+Filed 2026-09-06: https://github.com/kamp-us/phoenix/issues/8035
+(`gh issue create`, label `status:needs-triage`). This local file is the kept
+source of the posted body; the extraction point was the `## Summary` heading to
+EOF. Do not edit the body here expecting the issue to change — edit the issue.
+
+Per the maintainer's direction (2026-08-31, the import-experiment session):
+**one tracking issue with five blocker sections, not five noisy issues.** After review,
+split only the sections maintainers agree to pursue.
+
+Title (under ~70 chars):
+
+```
+skill-doctor fabrika import: five blockers before production
+```
+
+Labels: `status:needs-triage` (applied by the verb; nothing else — type/priority are triage's call)
+
+---
+
+## Summary
+
+The Warp Skill Doctor (MIT, `warpdotdev/common-skills` @ `b811c243`, re-synced
+2026-09-06 from the original `0254cbe9` import) imports into
+fabrika byte-exact, its 25 upstream tests pass, and its unmodified pipeline ran
+end-to-end over two real phoenix-local opencode sessions to a B+ report —
+re-verified 2026-09-06 after the re-sync. Five
+blockers stand between the PoC import (local, untracked, at
+`claude-plugins/fabrika/skills/skill-doctor/`) and a production import. Full evidence:
+`benchmarks/warp-skill-doctor-import-poc/REPORT.md` (also untracked, local).
+
+## What I was doing
+
+Running the local-only import experiment ratified in
+[discussion #7319](https://github.com/kamp-us/phoenix/discussions/7319): upstream skill
+imported byte-exact (git-blob-SHA verified), real upstream collector/rubrics/renderer run
+against the only phoenix-local agent history on the machine (2 opencode sessions), every
+output kept under `benchmarks/warp-skill-doctor-import-poc/results/`.
+
+## What I observed
+
+The pipeline works; five things block production. Each blocker is a section below, with
+the evidence and the exact change.
+
+### Blocker 1 — no opencode collector; startup gate excludes opencode
+
+Upstream supports Warp / Claude Code / Codex only. Its own dry run found **0 phoenix
+sessions** across those sources (`~/.claude/projects` empty; `~/.codex` holds 293
+rollouts, 0 for this checkout; no Warp data). Upstream #93 (2026-09-03) added Pi,
+Grok Build and ZCode collectors — narrowing this blocker — but opencode, the harness
+this repo actually runs under, is still absent, and the only phoenix-local history
+is opencode's SQLite store (`~/.local/share/opencode/opencode.db`: `session`/`message`/
+`part` tables; part types `text`/`tool`/`patch`), which no upstream collector reads —
+and upstream's Step-0 gate would refuse an opencode execution outright. The PoC
+bridged this with a translation shim (`results/opencode_adapter.py`, outside the
+imported skill) feeding upstream's `--claude-home`; that shim is a working reference
+for the shape mapping, not a collector.
+
+**Change:** add an opencode collector to the imported skill (or upstream: read
+`opencode.db` read-only; map parts per the shim) and add `opencode` to
+`references/supported-harnesses.md`'s startup gate + collector table with source
+overrides. Without this, the skill cannot see phoenix's actual history — inert on arrival.
+
+### Blocker 2 — Windows/UTF-8 portability bug in upstream scripts
+
+Three `read_text()` calls in `test_render_report.py` omit `encoding="utf-8"`; on
+Windows (cp1252 default) they crash on SKILL.md's UTF-8 smart quotes — 3/11 render tests
+fail without `PYTHONUTF8=1`. `collect_sessions.py`'s reads carry the same latent
+exposure. Also: SKILL.md's `mktemp -d "${TMPDIR:-/tmp}/..."` REPORT_DIR recipe is
+POSIX-only, and `python3` does not resolve on this machine's Windows Python.
+
+**Change:** add `encoding="utf-8"` to every file read in the scripts; replace the POSIX
+mktemp recipe with a portable scratch-dir step; resolve the interpreter per-OS. Prefer
+upstreaming the encoding fix; carry a local patch if upstream is slow.
+
+### Blocker 3 — Warp branding and share-by-default report content
+
+The rendered `report.html` embeds transcript-derived findings and diffs, ships a
+"share as png" button, and carries Warp Factories footer/CTA branding. A fabrika-owned
+report artifact that is shareable-by-default and advertises another vendor is both a
+privacy hazard (the PoC's own findings quote real session content) and off-brand.
+
+**Change:** decide the posture — strip the Warp Factories footer/CTA and the share-PNG
+button, or keep with an explicit note in the skill body that `report.html` embeds
+transcript-derived content, must never be committed unreviewed, and must live under an
+ignored results dir. Record the decision either way.
+
+### Blocker 4 — discovery misses fabrika's nonstandard skills path
+
+Upstream discovers project skills only under `.agents/skills`, `.claude/skills`,
+`.codex/skills`. Fabrika's skills live at `claude-plugins/fabrika/skills` (wired via
+`opencode.json`), so the caller must pass `--skills-dir` on every invocation or the run
+grades zero skills. This repo also has a *different* `.claude/skills` (ctx-* skills) that
+upstream would auto-discover and misattribute.
+
+**Change:** encode the skills path in the skill body / config (the conventions' §4
+plain-literal rule) or extend the collector's default roots for this repo; ensure the
+ctx-* skills under `.claude/skills` cannot be misattributed as fabrika's.
+
+### Blocker 5 — fabrika conventions not yet met
+
+The imported skill is upstream-shaped: no `contract.md`, no routing-thin SKILL.md, no
+`fabrika` verb wiring, English body where fabrika skills follow the writing-for-agents
+discipline, and the two upstream unittest suites are not wired into any validation path.
+RE-SYNC RISK: because the files are byte-exact upstream, local edits drift silently from
+upstream — the provenance note's "re-copy, never edit in place" rule must survive the
+fabrika-ization.
+
+**Change:** split per `claude-plugins/fabrika/docs/skill-conventions.md` — SKILL.md as
+routing surface, a new `contract.md` carrying collector flags / scoring contract /
+edit-drafting gate, keeping upstream's rubrics/scorers byte-exact; wire the upstream
+unittests into the import PR's checks; keep `PROVENANCE.md`'s re-sync rule binding.
+
+## Why it matters
+
+The verdict from the experiment is **revise before import** (REPORT.md §11): the import
+is license-clean and mechanically sound, but landing it as-is installs a skill that
+cannot run its own Step 0 → Step 1 on this repo's harness, fails 3 tests on Windows,
+ships shareable-by-default transcript-derived output, misses the skills corpus it is
+supposed to grade, and violates fabrika's own skill conventions. The blockers are
+ordered: 1 (collector) is the one that makes the skill functional here at all.
+
+After the blockers, rerun on **at least 20 real sessions** before trusting any grade —
+the PoC's B+ over 2 sessions (one being the experiment itself) is evidence the pipeline
+runs, not a measurement of the corpus.
+
+## Pointers
+
+- PoC experiment (untracked, local): `benchmarks/warp-skill-doctor-import-poc/` —
+  `REPORT.md` (full evidence, scores, verdict), `ADAPTATION.md` (deviation ledger),
+  `results/` (inventory, transcripts, upstream-rendered `report.html`,
+  `opencode_adapter.py` shim)
+- Import candidate (untracked, local): `claude-plugins/fabrika/skills/skill-doctor/`
+  (12 byte-exact upstream files @ `b811c243`, re-synced 2026-09-06 + `LICENSE` +
+  `PROVENANCE.md`)
+- Upstream: https://github.com/warpdotdev/common-skills/tree/main/.agents/skills/skill-doctor
+- Discussion: https://github.com/kamp-us/phoenix/discussions/7319
+- Conventions: `claude-plugins/fabrika/docs/skill-conventions.md`
+
+## Suggested next step (non-binding)
+
+My guess: maintainers review the five sections, keep 1 (opencode collector), 2 (UTF-8),
+and 4 (skills path) as the functional minimum, rule on 3 (branding posture) explicitly,
+and treat 5 (fabrika-ization) as the packaging step that lands with the import PR. Split
+into per-blocker issues only the ones agreed for pursuit; this tracking issue stays open
+until each is either split or closed by decision.
+
+## Machine-local paths note
+
+Every path in the Pointers section above is repo-relative and safe to post. The
+underlying PoC files contain machine-local evidence (absolute paths in transcripts,
+`~`-rooted storage paths) and must not be attached to the issue — the report verb's leak
+guards red on them; if excerpts are ever needed, quote them under `--redact`.

--- a/benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md
+++ b/benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md
@@ -52,7 +52,7 @@ the evidence and the exact change.
 ### Blocker 1 — no opencode collector; startup gate excludes opencode
 
 Upstream supports Warp / Claude Code / Codex only. Its own dry run found **0 phoenix
-sessions** across those sources (`~/.claude/projects` empty; `~/.codex` holds 293
+sessions** across those sources (Claude Code's sessions directory empty; `~/.codex` holds 293
 rollouts, 0 for this checkout; no Warp data). Upstream #93 (2026-09-03) added Pi,
 Grok Build and ZCode collectors — narrowing this blocker — but opencode, the harness
 this repo actually runs under, is still absent, and the only phoenix-local history

--- a/benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md
+++ b/benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md
@@ -5,6 +5,12 @@ Filed 2026-09-06: https://github.com/kamp-us/phoenix/issues/8035
 source of the posted body; the extraction point was the `## Summary` heading to
 EOF. Do not edit the body here expecting the issue to change — edit the issue.
 
+Triage has since replaced the posted body with the typed epic pitch, and the founder
+approved it on 2026-09-05
+([comment 5555033755](https://github.com/kamp-us/phoenix/issues/8035#issuecomment-5555033755)):
+the blockers now live as seven sequenced children (#8048–#8054), not as the prose below.
+This file is the filing-time body source, kept for the record.
+
 Per the maintainer's direction (2026-08-31, the import-experiment session):
 **one tracking issue with five blocker sections, not five noisy issues.** After review,
 split only the sections maintainers agree to pursue.

--- a/benchmarks/warp-skill-doctor-import-poc/REPORT.md
+++ b/benchmarks/warp-skill-doctor-import-poc/REPORT.md
@@ -1,0 +1,272 @@
+# REPORT.md — Warp Skill Doctor → Fabrika import PoC
+
+Local, untracked experiment for [kamp-us/phoenix discussion #7319](https://github.com/kamp-us/phoenix/discussions/7319)
+(comment [18202118](https://github.com/kamp-us/phoenix/discussions/7319#discussioncomment-18202118):
+"we should import this skill directly into fabrika since it's license is MIT").
+Nothing in this experiment was staged, committed, pushed, or published; every artifact stayed
+on this machine under `benchmarks/warp-skill-doctor-import-poc/`.
+
+## 1. Upstream commit SHA evaluated
+
+`0254cbe9b73f1171028ce82b9825d232791bab8b` — "Curve skill-doctor grades and filter edits by
+failures (#81)", 2026-08-28, the latest commit touching `.agents/skills/skill-doctor` on
+`main` at experiment time.
+
+## 2. Upstream source links
+
+- Skill root: https://github.com/warpdotdev/common-skills/tree/main/.agents/skills/skill-doctor
+- SKILL.md: https://github.com/warpdotdev/common-skills/blob/main/.agents/skills/skill-doctor/SKILL.md
+- Commit: https://github.com/warpdotdev/common-skills/commit/0254cbe9b73f1171028ce82b9825d232791bab8b
+- License (repo root, MIT, Copyright (c) 2026 Denver Technologies, Inc.):
+  https://github.com/warpdotdev/common-skills/blob/main/LICENSE
+
+## 3. Exact files copied (all byte-exact, git-blob-SHA verified)
+
+All 12 upstream files → `claude-plugins/fabrika/skills/skill-doctor/`:
+
+| File | Bytes | Upstream git blob SHA |
+|---|---:|---|
+| `SKILL.md` | 9812 | `9fd7d77d3b3944cbda2b09137001c25af08f598d` |
+| `references/supported-harnesses.md` | 1801 | `a7bf94467dbbf43f093a81c13f93d43bc0bb4927` |
+| `references/skill-improvements.md` | 1948 | `bbf1dace5f5aa98c9b50fed71e436461f1661d4f` |
+| `scorers/efficiency.md` | 3340 | `286481347df1a3b752cc92ccb019a8284bbe9a04` |
+| `scorers/code-quality.md` | 4781 | `59179f8d85a304c1ebb34f535c5afb6c5b14c37a` |
+| `scripts/collect_sessions.py` | 42911 | `a1842a5db35614ed2cc7af4f2fc40631d75cfde9` |
+| `scripts/render_report.py` | 26643 | `972da3beacf3709ee6e209841dd47c4ed5a2ab6f` |
+| `scripts/test_collect_sessions.py` | 7275 | `e71dc098e0ddd904d497d78844633c26f97c5afb` |
+| `scripts/test_render_report.py` | 8922 | `46658d0f716f444412e6d9355153dcb6c3c30204` |
+| `scripts/warp_decoder.py` | 11711 | `c54cebddb691dff72561bd269e0aac11c5498b1f` |
+| `assets/pierre-diffs.js` | 1156623 | `1ecc2c9969141899a25400538a97c2b21a2a172d` |
+| `assets/warp-pixel-icon.svg` | 4443 | `0ed8d0840a3ada909d94f4b5a2817aeb0e46ec53` |
+
+Plus two **added** files (ours, documented in ADAPTATION.md): `LICENSE` (byte-exact copy of
+the upstream repo-root MIT license, placed in-skill per the `writing-for-agents` precedent)
+and `PROVENANCE.md` (attribution + commit + re-sync note). No upstream file content was
+modified — verified by computing each file's git blob SHA-1 locally
+(`sha1("blob <len>\0" + content)`) and comparing against the tree-API SHAs for that commit.
+
+## 4. Exact Fabrika compatibility changes
+
+**None to upstream file content.** All compatibility handling was configuration/invocation
+only, plus two additive documentation files. Full ledger with upstream/local/change/why/
+behavior-change columns: [`ADAPTATION.md`](ADAPTATION.md). Summary:
+
+1. Added `PROVENANCE.md` (no behavior change).
+2. Added in-dir `LICENSE` (no behavior change).
+3. `--skills-dir claude-plugins/fabrika/skills` — upstream's own flag for nonstandard
+   skill locations; fabrika's skills live outside the three roots upstream auto-discovers.
+4. `--claude-home <results dir>` — upstream's own flag; fed the adapter output (B3 below).
+5. `PYTHONUTF8=1` — Windows Python defaults to cp1252; upstream tests and `read_text()`
+   calls without encoding crash on SKILL.md's UTF-8 curly quotes. **This is a genuine
+   upstream portability bug** (three `read_text()` calls in `test_render_report.py` lack
+   `encoding="utf-8"`), worked around via environment, not a file edit.
+6. `python` instead of `python3` (Windows interpreter name).
+
+## 5. Exact invocation used
+
+```powershell
+# Step 1 census (metadata only, read-only):
+#   claude: ~/.claude/projects empty · codex: 293 rollouts, 0 phoenix, 0 within 45d · warp: absent
+#   opencode db: 2 real phoenix sessions (the only phoenix-local conversations on this machine)
+
+# discovery adapter (PoC shim, lives in results/, NOT part of the imported skill):
+$env:PYTHONUTF8 = "1"
+python benchmarks/warp-skill-doctor-import-poc/results/opencode_adapter.py `
+  "benchmarks/warp-skill-doctor-import-poc/results" 10
+
+# Skill Doctor Step 1 — upstream collector, unmodified:
+python claude-plugins/fabrika/skills/skill-doctor/scripts/collect_sessions.py `
+  --harness claude `
+  --claude-home "benchmarks/warp-skill-doctor-import-poc/results/claude-home" `
+  --repo . `
+  --skills-dir "claude-plugins/fabrika/skills" `
+  --out "benchmarks/warp-skill-doctor-import-poc/results/run" `
+  --days 45 --max-sessions 10
+
+# Steps 2–4 (scoring, aggregation, edit-drafting): performed by this agent process per
+# SKILL.md Step 2 ("Score batches in the current local agent process"), judged against
+# the verbatim upstream rubrics in scorers/*.md, aggregated with the verbatim upstream
+# formulas. No heuristic judge, no synthetic transcripts.
+
+# Step 5 — upstream renderer, unmodified:
+python claude-plugins/fabrika/skills/skill-doctor/scripts/render_report.py `
+  "benchmarks/warp-skill-doctor-import-poc/results/run/report.json"
+```
+
+Output: `benchmarks/warp-skill-doctor-import-poc/results/run/` — `inventory.json`,
+`transcripts/` (2), `report.json`, `report.html` (upstream-rendered, self-contained).
+
+## 6. Number and source of real conversations analyzed
+
+**2**, both real opencode sessions whose recorded working directory is this checkout —
+the only phoenix-local agent conversations on this machine:
+
+| Session | Harness | Started (UTC) | Sampled |
+|---|---|---|---|
+| `ses_faa3e88edffetDsLQT6OoZ3bjk` | opencode (adapted → claude-shape) | 2026-08-31T02:58:57Z | yes |
+| `ses_fa7ce1663ffezPDDivvNf0MHIe` | opencode (adapted → claude-shape) | 2026-08-31T14:21:01Z | yes |
+
+The upstream collectors themselves found **0 phoenix sessions** across their supported
+sources (claude 0 in window; codex 0 phoenix of 293, newest 2026-06-05; warp absent) —
+confirmed by a real upstream dry-run before any adaptation. Because upstream has **no
+opencode collector** and its Step-0 startup gate does not list opencode, the run used a
+discovery/configuration-only adaptation (pre-authorized by the brief): a translation shim
+(`results/opencode_adapter.py`, outside the imported skill) converts the real opencode
+SQLite rows into Claude-Code-shaped JSONL under a temporary claude-home; the **unmodified**
+upstream collector then parses those files with its real Claude Code code path. Sampling,
+stats, transcript condensing, rubrics, scoring, aggregation, and rendering are all upstream's.
+No simulator was substituted; without the shim the correct outcome was BLOCKED at
+"no eligible real sessions via supported sources" — the shim is the documented
+discovery-only adaptation, and this limitation is the experiment's central finding.
+
+## 7. Skill Doctor's actual scores
+
+Upstream's verbatim aggregation over the two scored sessions:
+
+- raw_efficiency = 0.8 (both `mostly_efficient`) → **efficiency = 0.90** (curve 0.5+0.5·s)
+- raw_code_quality = 0.6 (`block` 0.2, `approve` 1.0) → **code_quality = 0.80**
+- **skill_coverage = 1.0** (2/2 sampled sessions had a detected installed skill)
+- **overall = 0.5·0.90 + 0.35·0.80 + 0.15·1.0 = 0.88 → letter grade B+** (upstream renderer)
+- failed_conversations (raw score < 0.5 on an applicable scorer): session 1 only
+  (code-quality 0.2)
+
+## 8. Top findings and proposed edits
+
+Findings (from Skill Doctor's Step 3, STE-100-style, rendered in `report.html`):
+
+1. **Heuristic-judge substitution in the earlier PoC** (session `ses_faa3e88ed…`): the
+   first benchmark build replaced upstream's LLM rubric judgment with a deterministic
+   heuristic so it measured pipeline mechanics, not evaluation quality — the failed
+   conversation, and the direct motivation for this run's faithful-import approach.
+2. **Repeated git-state re-verification** (both sessions): 4+ near-identical
+   status/check-ignore rounds before trusting a single answer — bounded, avoidable overhead.
+3. **GitHub-HTML-then-API fetch pattern** (both sessions): several wasted webfetches on
+   noisy GitHub pages before switching to the API/raw endpoints.
+
+**Proposed skill edits: none.** Upstream's `skill-improvements.md` gates edits on failed
+conversations whose root cause is a missing/wrong instruction on a concrete surface, seen
+in more than one run or severe enough alone. Finding 1 is exactly the case that fails that
+gate: session 1's own brief explicitly requested a deterministic benchmark, so no existing
+fabrika instruction was violated — the fix was the maintainer's product decision
+(discussion #7319: import the real skill), which this experiment executes, and it is not an
+instruction-surface edit. Findings 2–3 occurred in non-failed conversations, which upstream
+excludes as edit evidence by design. Per the reference: "open no change and say, per
+finding, why not — that is a success."
+
+## 9. Whether each finding is supported by cited local-session evidence
+
+- Finding 1 — **yes**: session `ses_faa3e88ed…`, code-quality scorer, moments where the
+  transcript shows `judge.ts` written as a "deterministic stand-in for the upstream LLM
+  judge" (transcript lines ~437/481; visible in
+  `results/run/transcripts/claude-ses_faa3e88edffetDsLQT6OoZ3bjk.md`).
+- Finding 2 — **yes, with a caveat**: both sessions' transcripts show the repeated
+  verification rounds (earlier session: the `.gitkeep`/ignore-state loop, ~L552–639;
+  current session: 3 git-status rounds). Caveat: `repeated_tool_calls` is inflated by
+  near-identical *reads* (webfetch of the same URL returning truncated output), so the
+  count alone overstates pure git re-checks; the finding rests on the visible sequences,
+  not the counter.
+- Finding 3 — **yes**: both transcripts' heads show `webfetch` of `github.com/...` tree/blob
+  pages followed by noisy truncated output, then a switch to `api.github.com` / raw URLs.
+
+All three are backed by real local-session citations; none is generic best practice.
+
+## 10. Privacy, portability, and correctness problems
+
+**Privacy.** Good, with two real notes. The upstream skill's own contract is local-only
+("Never upload transcripts... The only shareable artifact is the report the user chooses to
+post") and the scripts are stdlib-only with no network calls (verified by scanning for
+network APIs). Notes: (a) the rendered `report.html` embeds transcript-derived findings and
+diff content — it is designed to be *shared*; phoenix must treat it as publishable-by-
+default and keep it untracked; (b) the report's share-PNG button and footer carry Warp
+Factories CTAs — product branding inside a fabrika plugin.
+
+**Portability.** One genuine upstream bug found: three `read_text()` calls in
+`test_render_report.py` (and `discover_skills` in `collect_sessions.py` is exposed on
+Windows only via explicit paths) omit `encoding="utf-8"`, so Windows cp1252 crashes on the
+UTF-8 smart quotes in SKILL.md — 3/11 render tests fail without `PYTHONUTF8=1`. Also:
+`python3` vs `python` naming on Windows; `mktemp -d "${TMPDIR:-/tmp}/..."` (SKILL.md's
+REPORT_DIR recipe) is POSIX and would need a Windows path on this machine; `--skills-dir`
+must be passed because fabrika's skills path is nonstandard for this repo. The 1.16 MB
+`pierre-diffs.js` bundle is heavy for a plugin checkout but required by the renderer.
+
+**Correctness.** Three caveats on this experiment's scores: (1) the transcripts scored are
+an adapter's translation of opencode's store into Claude-Code shape — faithful (tool calls,
+patched file names, outputs, errors all preserved; verified by SHA-verified byte-exact
+upstream parsing and a mid-run adapter fix for the `patch.files` list-vs-dict mistake) but
+not a first-party collector, so harness-specific semantics (e.g. opencode `question` tool →
+adapter passes through as generic tool) are approximated; (2) the sampled set is 2
+conversations, both from 2026-08-31, one of which is the experiment itself — the coverage
+and quality numbers are a floor-of-one-machine evidence base, not a robust measurement;
+(3) the executing harness (opencode) is outside upstream's supported-harnesses startup
+gate — upstream itself would have refused this run; we proceeded under the brief's
+pre-authorized discovery-only adaptation. The scores are real Skill Doctor outputs over
+real local history, but they inherit all three caveats.
+
+## 11. Recommendation
+
+**Revise before import** — import the asset, but do not land it as-is.
+
+Rationale: the core is genuinely reusable and license-clean (MIT, attribution preserved,
+byte-exact import verified possible, upstream tests pass, rubrics are a solid
+efficiency/code-quality/coverage model, and it demonstrably produced a coherent B+ report
+over real phoenix sessions through its own pipeline). But: it cannot see phoenix's actual
+harness history without a shim (no opencode collector; startup gate excludes opencode), it
+carries a Windows-encoding portability bug, its discovery misses fabrika's nonstandard
+skills path, its report embeds shareable transcript-derived content + Warp CTAs, and it
+does not follow fabrika's own skill conventions (no contract.md, `python3`/`mktemp`
+POSIX-isms, no `--skills-dir` default for this repo). A direct unmodified import would
+install a skill that, in phoenix, cannot run its own Step 0 → Step 1 pipeline without
+out-of-band help.
+
+## 12. Exact next changes required for a production-ready import
+
+1. **Add an opencode collector** (upstream contribution or local fork): read
+   `~/.local/share/opencode/opencode.db` (tables `session`/`message`/`part`; parts
+   `text`/`tool`/`patch`), and add `opencode` to `references/supported-harnesses.md`'s
+   startup gate + collector table with source-override flags. Without this the skill is
+   inert on phoenix's actual harness. The PoC adapter (`results/opencode_adapter.py`) is a
+   working reference for the shape mapping.
+2. **Fix the Windows encoding bug** (3 × `read_text()` in `test_render_report.py`, plus
+   defensive `encoding="utf-8"` on every read in `collect_sessions.py`) — or document
+   `PYTHONUTF8=1` as a requirement; upstreaming the fix is preferable.
+3. **Fabrika-ize the invocation layer** per `claude-plugins/fabrika/docs/skill-conventions.md`:
+   a `contract.md` holding the depth (collector flags, scoring contract, edit-drafting
+   gate), SKILL.md as the routing surface, and `--skills-dir claude-plugins/fabrika/skills`
+   encoded in the skill body so the nonstandard path is not caller-supplied.
+4. **Localize the scratch dir**: replace the POSIX `mktemp` recipe with a Windows-safe
+   REPORT_DIR (or route it under a fabrika scratch verb), and normalize `python3` →
+   environment-detected interpreter.
+5. **Decide the branding/privacy posture**: keep or strip the Warp Factories footer/CTA
+   and share-PNG button; if kept, add a note in the fabrika skill body that `report.html`
+   embeds transcript-derived content and must never be committed or posted unreviewed
+   (it must stay under an ignored results dir).
+6. **Wire validation**: run the two upstream unittest suites (they pass 16/16 with
+   `PYTHONUTF8=1`) as part of the import PR's checks, and record the import in the plugin
+   manifest's skill list.
+7. **Re-sync policy**: PROVENANCE.md already states it — re-copy from upstream on update
+   rather than editing in place; pin the upstream commit SHA in the provenance note.
+
+## 13. Full `git status --short`
+
+```
+?? benchmarks/
+?? claude-plugins/fabrika/skills/skill-doctor/
+```
+
+(`benchmarks/` contains the pre-existing untracked `skill-doctor-poc/` from the prior
+experiment — untouched by this run — and this experiment's `warp-skill-doctor-import-poc/`.
+`claude-plugins/fabrika/skills/skill-doctor/` is this experiment's import candidate.)
+No staged files (`git diff --cached` empty), no tracked-file modifications
+(`git diff` empty), branch `main` unchanged, no commits made.
+
+## Result
+
+**INCONCLUSIVE-leaning-positive, recommendation: revise before import.** The success
+criteria that could be met were met — the real upstream Skill Doctor was imported
+byte-exact into fabrika shape, it analyzed 2 real phoenix-local opencode sessions through
+its own unmodified pipeline (via a documented, pre-authorized discovery-only shim for the
+unsupported source), all outputs and proposed edits stayed local under
+`benchmarks/warp-skill-doctor-import-poc/results/`, no skill edits were proposed (none
+cleared upstream's own gate), and the evidence is sufficient to decide: the direct import
+is worthwhile **after** the revisions in §12 — chiefly the opencode collector, without
+which the skill cannot see phoenix's actual history.

--- a/benchmarks/warp-skill-doctor-import-poc/REPORT.md
+++ b/benchmarks/warp-skill-doctor-import-poc/REPORT.md
@@ -66,7 +66,7 @@ behavior-change columns: [`ADAPTATION.md`](ADAPTATION.md). Summary:
 
 ```powershell
 # Step 1 census (metadata only, read-only):
-#   claude: ~/.claude/projects empty · codex: 293 rollouts, 0 phoenix, 0 within 45d · warp: absent
+#   claude: sessions dir empty · codex: 293 rollouts, 0 phoenix, 0 within 45d · warp: absent
 #   opencode db: 2 real phoenix sessions (the only phoenix-local conversations on this machine)
 
 # discovery adapter (PoC shim, lives in results/, NOT part of the imported skill):

--- a/benchmarks/warp-skill-doctor-import-poc/results/opencode_adapter.py
+++ b/benchmarks/warp-skill-doctor-import-poc/results/opencode_adapter.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""DISCOVERY-ONLY ADAPTER (PoC-local, NOT part of the imported skill).
+
+phoenix PoC: benchmarks/warp-skill-doctor-import-poc.
+
+The upstream Warp Skill Doctor (imported byte-exact at
+claude-plugins/fabrika/skills/skill-doctor/) has collectors for Claude Code
+project JSONL, Codex rollout JSONL, and Warp SQLite -- but NOT for opencode,
+the harness this repository actually runs under. The only real phoenix-local
+agent conversations on this machine live in opencode's SQLite store.
+
+This adapter translates real opencode sessions (read-only, from
+~/.local/share/opencode/opencode.db) into Claude-Code-shaped project-history
+JSONL under a temporary claude-home, so that the UNMODIFIED upstream
+collect_sessions.py --claude-home parser can collect them with its real
+Claude Code code path. Everything downstream -- sampling, stats, transcript
+condensing, rubrics, scoring, aggregation, report rendering -- is the
+upstream pipeline's.
+
+It is a translation shim for one unsupported conversation source. It does
+not score, judge, or aggregate anything, and it never leaves this machine.
+
+Mapping (opencode -> Claude Code shape, as consumed by parse_claude_session):
+  message(role=user, part text)      -> type=user message.content text
+  message(role=assistant, text part) -> type=assistant message.content text
+  part type=tool                     -> tool_use {name, input}
+                                        (tool result content attached from the
+                                        same part's state.output)
+  part type=patch                    -> an Edit tool_use marker (file names)
+                                        so upstream's has_code_edits fires
+Shared fields per record: sessionId, cwd, timestamp (ISO), version.
+"""
+
+import json
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+OPENCODE_DB = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+# opencode's session directory rows use forward slashes regardless of OS.
+PHOENIX_DIR = str(Path.cwd()).replace("\\", "/")
+OUT_ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+MAX_SESSIONS = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+
+CODE_EDIT_TOOLS = {"write", "edit", "patch", "multiedit"}
+
+
+def iso(ms):
+    try:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def main():
+    if not OPENCODE_DB.is_file():
+        print("error: opencode database not found", file=sys.stderr)
+        sys.exit(1)
+    con = sqlite3.connect(f"file:{OPENCODE_DB.as_posix()}?mode=ro", uri=True)
+
+    sessions = list(con.execute(
+        "SELECT id, directory, time_created, time_updated FROM session "
+        "WHERE directory = ? AND parent_id IS NULL "
+        "ORDER BY time_updated DESC LIMIT ?",
+        (PHOENIX_DIR, MAX_SESSIONS),
+    ))
+    if not sessions:
+        print("BLOCKED: no eligible opencode sessions for this checkout", file=sys.stderr)
+        sys.exit(2)
+
+    project_dir_name = PHOENIX_DIR.replace("/", "-").replace(":", "").replace("\\", "-")
+    project_out = OUT_ROOT / "claude-home" / "projects" / project_dir_name
+    project_out.mkdir(parents=True, exist_ok=True)
+
+    manifest = []
+    for sid, directory, created, updated in sessions:
+        out_path = project_out / f"{sid}.jsonl"
+        records = []
+        for mid, role, mtime in con.execute(
+            "SELECT id, json_extract(data, '$.role'), time_created FROM message "
+            "WHERE session_id = ? ORDER BY time_created", (sid,),
+        ):
+            parts = list(con.execute(
+                "SELECT data FROM part WHERE message_id = ? ORDER BY time_created", (mid,),
+            ))
+            blocks = []
+            content = None
+            for (pdata,) in parts:
+                p = json.loads(pdata)
+                ptype = p.get("type")
+                if ptype == "text":
+                    text = p.get("text") or ""
+                    if text.strip():
+                        blocks.append({"type": "text", "text": text})
+                elif ptype == "tool":
+                    st = p.get("state") or {}
+                    tool = p.get("tool") or "unknown"
+                    inp = st.get("input") if isinstance(st.get("input"), dict) else {}
+                    blocks.append({
+                        "type": "tool_use",
+                        "name": tool,
+                        "input": inp,
+                        # attach output for the tool_result view upstream renders
+                        "_output": st.get("output") if isinstance(st.get("output"), str) else None,
+                        "_status": st.get("status"),
+                    })
+                elif ptype == "patch":
+                    raw = p.get("files")
+                    if isinstance(raw, dict):
+                        names = sorted(str(k) for k in raw.keys())
+                    elif isinstance(raw, list):
+                        names = sorted(str(v) for v in raw)
+                    else:
+                        names = []
+                    blocks.append({
+                        "type": "tool_use",
+                        "name": "Edit",
+                        "input": {"file_path": names[0] if names else "unknown"},
+                        "_output": f"patched files: {', '.join(names) if names else 'none'}",
+                        "_status": "completed",
+                    })
+            if not blocks:
+                continue
+            # opencode tool results ride inside the same part; emit them as a
+            # following tool_result user record so upstream sees outputs.
+            if any(b.get("_output") is not None for b in blocks if b.get("type") == "tool_use"):
+                record_blocks = []
+                result_blocks = []
+                for b in blocks:
+                    if b.get("type") == "tool_use":
+                        record_blocks.append({
+                            "type": "tool_use",
+                            "name": b["name"],
+                            "input": b["input"],
+                        })
+                        if b.get("_output") is not None:
+                            result_blocks.append({
+                                "type": "tool_result",
+                                "content": b["_output"],
+                                "is_error": bool(b.get("_status") and b["_status"] != "completed"),
+                            })
+                    else:
+                        record_blocks.append(b)
+                if record_blocks:
+                    records.append(make_record(sid, directory, mtime, role, record_blocks))
+                if result_blocks:
+                    records.append(make_record(sid, directory, mtime, "user", result_blocks))
+            else:
+                records.append(make_record(sid, directory, mtime, role, blocks))
+
+        with open(out_path, "w", encoding="utf-8", newline="\n") as f:
+            for r in records:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+        msg_count = len(records)
+        manifest.append({
+            "session_id": sid,
+            "directory": directory,
+            "time_created": iso(created),
+            "time_updated": iso(updated),
+            "records": msg_count,
+            "file": str(out_path),
+        })
+
+    (OUT_ROOT / "adapter_manifest.json").write_text(
+        json.dumps(
+            {
+                "source": str(OPENCODE_DB),
+                "harness": "opencode",
+                "adapter": "discovery-only translation to Claude-Code-shaped JSONL; "
+                          "upstream collector parses these files unmodified",
+                "sessions": manifest,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"adapted {len(manifest)} opencode session(s) -> {project_out}")
+    for m in manifest:
+        print(f"  {m['session_id']} ({m['records']} records, updated {m['time_updated']})")
+    con.close()
+
+
+def make_record(session_id, cwd, mtime, role, blocks):
+    return {
+        "sessionId": session_id,
+        "cwd": cwd,
+        "timestamp": iso(mtime),
+        "version": "opencode-adapter-poc",
+        "type": role,
+        "uuid": str(uuid.uuid4()),
+        "message": {"role": role, "content": blocks},
+    }
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of #8035

Evidence PR for #8035 — the tracking issue owns the five production-import decisions; this PR makes the experiment's evidence reviewable. It carries **no production import**: the byte-exact skill candidate lands in a separate PR after those decisions.

## What's here

- `benchmarks/README.md` — folder map, verification results (tests + end-to-end run), upstream pin/re-sync history, privacy posture
- `benchmarks/warp-skill-doctor-import-poc/REPORT.md` — full experiment record: method, scores (B+ / 0.88, directional on 2 sessions), findings, portability notes, "revise before import" verdict
- `benchmarks/warp-skill-doctor-import-poc/ADAPTATION.md` — deviation ledger: what is upstream's, what is ours, why
- `benchmarks/warp-skill-doctor-import-poc/ISSUE_DRAFT.md` — kept source of #8035's posted body (marked FILED)
- `benchmarks/warp-skill-doctor-import-poc/results/opencode_adapter.py` — the opencode→Claude-Code translation shim (upstream has no opencode collector; blocker 1's working reference). Machine-path-free: derives its scope from cwd.
- A folder-local `.gitignore` keeping `results/` artifacts machine-local

## Deliberately not in this PR

Real session transcripts, census inventories, rendered `report.html`, and the import candidate (`claude-plugins/fabrika/skills/skill-doctor/`). The first three stay local under the ignored `results/`; the last waits on #8035.

## Verification (2026-09-06, upstream pin `b811c24365ae`)

- Upstream test suites: 25/25 (14 collect + 11 render), `PYTHONUTF8=1`
- End-to-end re-run: adapter → unmodified upstream collector (2 sessions sampled, 27 skills) → rubric judging → aggregation → `render_report.py` → **B+ (overall 0.88)**, identical to the original 2026-08-31 run
- Scope note: 2 sessions, one machine — directional evidence, not a corpus measurement

## Review ask

Sanity-check the docs, the blocker list, and the adapter's shape. Decisions happen in #8035; mark ready or split follow-ups from there.

## Deviations

- **Said:** The epic delivers a production Skill Doctor import. **Did:** This PR publishes only sanitized evaluation documents and the experimental adapter. **Why:** Evidence can be reviewed separately from the production import. **Disposition:** Partial delivery; the epic stays open and its children own the remaining work.
- **Said:** Evaluate the upstream pipeline on real session history. **Did:** Used an external OpenCode-to-Claude-Code adapter and two sessions, leaving upstream scoring files unchanged. **Why:** Upstream lacked an OpenCode collector. **Disposition:** Historical execution evidence only; production collection and broader calibration remain with the epic.
- **Said:** Record upstream test results. **Did:** Ran the suites with PYTHONUTF8=1. **Why:** Native Windows encoding failed on upstream UTF-8 files. **Disposition:** The result is explicitly environment-qualified; portable execution remains with the portability child.
