### PR TITLE
feat: Tuval's Claude window shows subagent tool calls flat among the main agent's, with no nesting

### DIFF
--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -57,12 +57,18 @@ export interface AssistantItem extends ItemBase {
 	readonly interrupted?: boolean;
 }
 
+/**
+ * `parentId` is the id of the tool call this one ran *inside*, when a backend nests calls — an
+ * agent-spawning tool whose worker makes calls of its own. Absent means the call is the agent's
+ * own, which is every call a backend with no nesting concept ever emits.
+ */
 export interface ToolItem extends ItemBase {
 	readonly kind: "tool";
 	readonly name: string;
 	readonly input: JsonValue;
 	readonly result: ToolResult;
 	readonly status: ToolStatus;
+	readonly parentId?: ItemId;
 }
 
 export interface SystemItem extends ItemBase {
@@ -145,7 +151,8 @@ export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 				isJsonValue(value.input) &&
 				isToolResult(value.result) &&
 				typeof value.status === "string" &&
-				statuses.has(value.status)
+				statuses.has(value.status) &&
+				(value.parentId === undefined || isId(value.parentId))
 			);
 		default:
 			return false;

--- a/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
@@ -49,6 +49,14 @@ describe("transcript item union", () => {
 		expect(isTranscriptItem({...tool, status: "pending"})).toBe(false);
 	});
 
+	it("takes a tool item with or without a parent, and refuses an empty parent id", () => {
+		expect(isTranscriptItem({...tool, parentId: "toolu_agent"})).toBe(true);
+		expect(isTranscriptItem({...tool, parentId: undefined})).toBe(true);
+		expect(isTranscriptItem({...tool, parentId: ""})).toBe(false);
+		expect(isTranscriptItem({...tool, parentId: 7})).toBe(false);
+		expect(isTranscriptItem({...tool, parentId: null})).toBe(false);
+	});
+
 	it("refuses a tool result past the per-item byte bound, however it was built", () => {
 		const oversized = "x".repeat(TOOL_RESULT_BYTE_LIMIT + 1);
 		expect(isTranscriptItem({...tool, result: {text: oversized, omitted: {bytes: 0}}})).toBe(false);

--- a/apps/tuval/src/claude/history/blocks.ts
+++ b/apps/tuval/src/claude/history/blocks.ts
@@ -97,6 +97,19 @@ export const outputOf = (structured: unknown): string => {
 	return stdout.length > 0 ? stdout : stderr;
 };
 
+/**
+ * The `tool_use` a frame was produced inside, or `null` at the top level.
+ *
+ * `SDKAssistantMessage` and `SDKUserMessage` both carry `parent_tool_use_id`, "non-null when the
+ * message was produced inside a subagent started by that tool_use" (`sdk.d.ts`,
+ * `@anthropic-ai/claude-agent-sdk@0.3.259`). This is the only place the SDK's own name for it is
+ * read; everything downstream of `map.ts` calls it `parentId`, because the item union is model-blind.
+ */
+export const parentToolUseIdOf = (message: unknown): string | null => {
+	if (!isRecord(message)) return null;
+	return isNonEmptyString(message.parent_tool_use_id) ? message.parent_tool_use_id : null;
+};
+
 /** Epoch milliseconds off a message's own ISO `timestamp`, or the caller's clock when it has none. */
 export const timestampOf = (message: unknown, fallback: number): number => {
 	if (!isRecord(message) || typeof message.timestamp !== "string") return fallback;

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -222,6 +222,44 @@ describe("toAgentEvents over the captured failure frames", () => {
 	});
 });
 
+describe("toAgentEvents over a subagent's frames", () => {
+	/**
+	 * No committed capture holds a non-null `parent_tool_use_id`, because forcing one needs a live
+	 * subagent run — an operator act with real spend (`fixtures/PROVENANCE.md`). So this case is the
+	 * golden `tool-turn` stream with exactly that one field stamped over its assistant and user
+	 * frames. The SDK types it `string | null` on both `SDKAssistantMessage` and `SDKUserMessage`,
+	 * "non-null when the message was produced inside a subagent started by that tool_use"
+	 * (`sdk.d.ts`, 0.3.259), and the capture already carries it as `null` — so the value is the whole
+	 * difference and every other key stays the captured shape.
+	 */
+	const PARENT = "toolu_01SubagentParent";
+
+	const insideSubagent = (stream: ReadonlyArray<SDKMessage>): ReadonlyArray<SDKMessage> =>
+		stream.map((one) =>
+			one.type === "assistant" || one.type === "user"
+				? ({...one, parent_tool_use_id: PARENT} as SDKMessage)
+				: one,
+		);
+
+	const toolItems = (stream: ReadonlyArray<SDKMessage>) =>
+		items(run(stream).events).filter((one) => one.kind === "tool");
+
+	it("marks every tool row a subagent opened with the call that spawned it", () => {
+		const tools = toolItems(insideSubagent(messages("tool-turn")));
+		expect(tools.length).toBeGreaterThan(0);
+		expect(tools.map((one) => one.kind === "tool" && one.parentId)).toEqual(
+			tools.map(() => PARENT),
+		);
+		expect(tools.map((one) => one.kind === "tool" && one.status)).toContain("ok");
+	});
+
+	it("leaves the captured top-level stream carrying no parent at all", () => {
+		const tools = toolItems(messages("tool-turn"));
+		expect(tools.length).toBeGreaterThan(0);
+		expect(tools.map((one) => "parentId" in one)).toEqual(tools.map(() => false));
+	});
+});
+
 describe("toAgentEvents over a message it has no shape for", () => {
 	it("emits nothing, counts it, and does not throw", () => {
 		const step = toAgentEvents(message("unknown-message"), emptyMapping, {at: AT});

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -46,6 +46,14 @@ Everything else — `stop_reason`, the `usage` and `modelUsage` blocks, `total_c
 `is_error`, `subtype`, `aborted`, `tool_use_result` — is verbatim. `boundary.unit.test.ts` reds if
 any operator path returns and if the fixture set loses a member.
 
+## What is not captured
+
+**A subagent's frames.** Every capture here is a top-level run, so `parent_tool_use_id` is `null` on
+all of them. `events.unit.test.ts` covers the non-null case by stamping that one field over the
+golden `tool-turn` stream, which is a derived shape and says so at the case. Forcing a real one needs
+a run that spawns the Agent tool, so it is an operator act like every other capture below —
+[#8038](https://github.com/kamp-us/phoenix/issues/8038) tracks taking it.
+
 ## Re-capturing
 
 There is no committed capture script: a run needs live credentials and writes real spend, so it is

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -16,7 +16,15 @@
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {boundToolOutput} from "../../ai-agent/history/index.ts";
 import type {ItemId, JsonValue, TranscriptItem} from "../../ai-agent/ports/index.ts";
-import {isRecord, outputOf, textOf, timestampOf, toolResultsOf, toolUsesOf} from "./blocks.ts";
+import {
+	isRecord,
+	outputOf,
+	parentToolUseIdOf,
+	textOf,
+	timestampOf,
+	toolResultsOf,
+	toolUsesOf,
+} from "./blocks.ts";
 
 /** `ports` mints an `ItemId` through an effect `Schema` brand, and this directory imports no effect. */
 const itemId = (value: string): ItemId => value as ItemId;
@@ -30,6 +38,8 @@ export interface ToolCall {
 	readonly name: string;
 	readonly input: JsonValue;
 	readonly at: number;
+	/** The subagent-spawning call this one ran inside, or `null` for one the agent made itself. */
+	readonly parentId: string | null;
 }
 
 export interface Mapping {
@@ -106,9 +116,10 @@ export const assistantEvents = (
 			}),
 		);
 	}
+	const parentId = parentToolUseIdOf(message);
 	let toolCalls = mapping.toolCalls;
 	for (const use of toolUsesOf(body)) {
-		toolCalls = withCall(toolCalls, use.id, {name: use.name, input: use.input, at});
+		toolCalls = withCall(toolCalls, use.id, {name: use.name, input: use.input, at, parentId});
 		events.push(
 			item(
 				boundToolOutput(
@@ -120,6 +131,7 @@ export const assistantEvents = (
 						input: use.input,
 						status: "running",
 						output: "",
+						...(parentId === null ? {} : {parentId: itemId(parentId)}),
 					},
 					options.toolResultLimit,
 				),
@@ -151,6 +163,7 @@ export const userEvents = (
 		const id = typeof message.uuid === "string" ? message.uuid : `user-${at}`;
 		return {mapping, events: [item({kind: "user", id: itemId(id), timestamp: at, text})]};
 	}
+	const framedParentId = parentToolUseIdOf(message);
 	let toolCalls = mapping.toolCalls;
 	let skipped = mapping.skipped;
 	const events: AgentEvent[] = [];
@@ -161,6 +174,10 @@ export const userEvents = (
 			continue;
 		}
 		toolCalls = withoutCall(toolCalls, result.toolUseId);
+		// The call that opened the row is authoritative — the row must not change parent when it
+		// settles — and this frame's own field is the fallback, so a result arriving on a subagent
+		// frame is still marked when the call it answers was opened without one.
+		const parentId = call.parentId ?? framedParentId;
 		events.push(
 			item(
 				boundToolOutput(
@@ -172,6 +189,7 @@ export const userEvents = (
 						input: call.input,
 						status: result.failed ? "error" : "ok",
 						output: result.text.length > 0 ? result.text : outputOf(message.tool_use_result),
+						...(parentId === null ? {} : {parentId: itemId(parentId)}),
 					},
 					options.toolResultLimit,
 				),

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -46,7 +46,7 @@ import {
 	rowIndexOfItem,
 	rowKey,
 } from "./rows.ts";
-import {ToolRow} from "./ToolRow.tsx";
+import {type ToolFold, ToolRow} from "./ToolRow.tsx";
 import {asChatView, type ChatView} from "./view.ts";
 import "./chat.css";
 
@@ -156,7 +156,7 @@ function ItemRow({
 	interrupted,
 	onResend,
 	expanded,
-	nestedCount,
+	fold,
 	nested,
 	onToggleTool,
 }: {
@@ -164,7 +164,7 @@ function ItemRow({
 	readonly interrupted: boolean;
 	readonly onResend: (() => void) | null;
 	readonly expanded: boolean;
-	readonly nestedCount: number;
+	readonly fold: ToolFold | null;
 	readonly nested: boolean;
 	readonly onToggleTool: (id: string, open: boolean) => void;
 }): ReactElement {
@@ -176,7 +176,7 @@ function ItemRow({
 				<ToolRow
 					item={item}
 					expanded={expanded}
-					nestedCount={nestedCount}
+					fold={fold}
 					onToggle={(open) => onToggleTool(item.id, open)}
 				/>
 			) : (
@@ -196,20 +196,32 @@ function ItemRow({
 	);
 }
 
+/**
+ * The DOM id of the row carrying one item, scoped to the window so two windows over one process
+ * never mint the same id. A group head's fold points `aria-controls` at these.
+ */
+const rowDomId = (windowId: string, itemId: string): string => `tuval-row-${windowId}-${itemId}`;
+
 function RowView({
 	row,
+	windowId,
 	interruptedId,
 	onResend,
 	onOlder,
 	expanded,
+	unfolded,
 	onToggleTool,
+	onToggleFold,
 }: {
 	readonly row: ChatRow;
+	readonly windowId: string;
 	readonly interruptedId: string | null;
 	readonly onResend: (() => void) | null;
 	readonly onOlder: () => void;
 	readonly expanded: ReadonlySet<string>;
+	readonly unfolded: ReadonlySet<string>;
 	readonly onToggleTool: (id: string, open: boolean) => void;
+	readonly onToggleFold: (id: string, open: boolean) => void;
 }): ReactElement {
 	if (row.kind === "loading") {
 		return (
@@ -228,13 +240,22 @@ function RowView({
 			</span>
 		);
 	}
+	const open = unfolded.has(row.item.id);
 	return (
 		<ItemRow
 			item={row.item}
 			interrupted={row.item.id === interruptedId}
 			onResend={row.item.id === interruptedId ? onResend : null}
 			expanded={expanded.has(row.item.id)}
-			nestedCount={row.nestedCount}
+			fold={
+				row.nestedIds.length === 0
+					? null
+					: {
+							rowIds: row.nestedIds.map((id) => rowDomId(windowId, id)),
+							open,
+							onToggle: (next) => onToggleFold(row.item.id, next),
+						}
+			}
 			nested={row.nested}
 			onToggleTool={onToggleTool}
 		/>
@@ -273,6 +294,7 @@ function ChatWindow({
 	}, []);
 
 	const expanded = useMemo(() => new Set(view.expanded), [view.expanded]);
+	const unfolded = useMemo(() => new Set(view.unfolded), [view.unfolded]);
 
 	/** The row just opened, until the layout effect below has scrolled its trigger back into view. */
 	const openedRef = useRef<string | null>(null);
@@ -294,6 +316,23 @@ function ChatWindow({
 		[commit],
 	);
 
+	const toggleFold = useCallback(
+		(id: string, open: boolean) => {
+			if (open) openedRef.current = id;
+			commit((current) => {
+				const held = current.unfolded.includes(id);
+				if (held === open) return current;
+				return {
+					...current,
+					unfolded: open
+						? [...current.unfolded, id]
+						: current.unfolded.filter((other) => other !== id),
+				};
+			});
+		},
+		[commit],
+	);
+
 	const answerPermission = useCallback(
 		(answer: PermissionAnswer) => dispatch({type: "answer", ...answer}),
 		[dispatch],
@@ -309,9 +348,9 @@ function ChatWindow({
 				omitted: state?.transcript.omitted.items ?? 0,
 				loading,
 				atOldest: view.atOldest,
-				expanded,
+				unfolded,
 			}),
-		[older, state, loading, view.atOldest, expanded],
+		[older, state, loading, view.atOldest, unfolded],
 	);
 
 	/** The row the viewport was resting on when the current page was asked for. */
@@ -388,10 +427,10 @@ function ChatWindow({
 		openedRef.current = null;
 		const index = rowIndexOfItem(rows, opened);
 		if (index >= 0) virtualizer.scrollToIndex(index, {align: "start"});
-		// `view.expanded` is the dependency that matters: opening an ordinary row leaves `rows`
-		// untouched — the list is the same items — so an effect keyed on `rows` alone would never run
-		// for it. A group head is the case where both change, and the index lookup covers either.
-	}, [view.expanded, rows, virtualizer]);
+		// `view.expanded` and `view.unfolded` are the dependencies that matter: opening an ordinary row
+		// leaves `rows` untouched — the list is the same items — so an effect keyed on `rows` alone
+		// would never run for it. A fold is the case where both change, and the lookup covers either.
+	}, [view.expanded, view.unfolded, rows, virtualizer]);
 
 	// First paint lands where a chat belongs: on the newest turn, or back on the offset this window
 	// was left at. Once, and never again — a later re-render must not yank the operator's scroll.
@@ -525,20 +564,29 @@ function ChatWindow({
 						return (
 							<div
 								key={virtual.key}
+								id={row.kind === "item" ? rowDomId(host.windowId, row.item.id) : undefined}
 								className="tuval-chat-row"
 								data-index={virtual.index}
 								data-kind={row.kind === "item" ? row.item.kind : row.kind}
 								data-nested={row.kind === "item" && row.nested ? "true" : undefined}
 								ref={virtualizer.measureElement}
-								style={{transform: `translateY(${virtual.start}px)`}}
+								style={{
+									transform: `translateY(${virtual.start}px)`,
+									// One indent step per fold the row sits inside, so a subagent's own subagent
+									// reads as a further step in rather than as another row at the same level.
+									...(row.kind === "item" && row.depth > 0 ? {"--nest-depth": row.depth} : {}),
+								}}
 							>
 								<RowView
 									row={row}
+									windowId={host.windowId}
 									interruptedId={interruptedId}
 									onResend={lastPrompt === null ? null : resend}
 									onOlder={requestOlder}
 									expanded={expanded}
+									unfolded={unfolded}
 									onToggleTool={toggleTool}
+									onToggleFold={toggleFold}
 								/>
 							</div>
 						);

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -156,19 +156,29 @@ function ItemRow({
 	interrupted,
 	onResend,
 	expanded,
+	nestedCount,
+	nested,
 	onToggleTool,
 }: {
 	readonly item: TranscriptItem;
 	readonly interrupted: boolean;
 	readonly onResend: (() => void) | null;
 	readonly expanded: boolean;
+	readonly nestedCount: number;
+	readonly nested: boolean;
 	readonly onToggleTool: (id: string, open: boolean) => void;
 }): ReactElement {
 	return (
 		<>
-			<span className="tuval-chat-who">{who[item.kind]}</span>
+			{/* A nested row says whose call it was in words; the indent beside it is the second signal. */}
+			<span className="tuval-chat-who">{nested ? "subagent" : who[item.kind]}</span>
 			{item.kind === "tool" ? (
-				<ToolRow item={item} expanded={expanded} onToggle={(open) => onToggleTool(item.id, open)} />
+				<ToolRow
+					item={item}
+					expanded={expanded}
+					nestedCount={nestedCount}
+					onToggle={(open) => onToggleTool(item.id, open)}
+				/>
 			) : (
 				<p className="tuval-chat-text">{item.text}</p>
 			)}
@@ -224,6 +234,8 @@ function RowView({
 			interrupted={row.item.id === interruptedId}
 			onResend={row.item.id === interruptedId ? onResend : null}
 			expanded={expanded.has(row.item.id)}
+			nestedCount={row.nestedCount}
+			nested={row.nested}
 			onToggleTool={onToggleTool}
 		/>
 	);
@@ -297,8 +309,9 @@ function ChatWindow({
 				omitted: state?.transcript.omitted.items ?? 0,
 				loading,
 				atOldest: view.atOldest,
+				expanded,
 			}),
-		[older, state, loading, view.atOldest],
+		[older, state, loading, view.atOldest, expanded],
 	);
 
 	/** The row the viewport was resting on when the current page was asked for. */
@@ -375,8 +388,9 @@ function ChatWindow({
 		openedRef.current = null;
 		const index = rowIndexOfItem(rows, opened);
 		if (index >= 0) virtualizer.scrollToIndex(index, {align: "start"});
-		// `view.expanded` is the dependency that matters: opening a row leaves `rows` untouched —
-		// the list is the same items — so an effect keyed on `rows` alone would never run.
+		// `view.expanded` is the dependency that matters: opening an ordinary row leaves `rows`
+		// untouched — the list is the same items — so an effect keyed on `rows` alone would never run
+		// for it. A group head is the case where both change, and the index lookup covers either.
 	}, [view.expanded, rows, virtualizer]);
 
 	// First paint lands where a chat belongs: on the newest turn, or back on the offset this window
@@ -514,6 +528,7 @@ function ChatWindow({
 								className="tuval-chat-row"
 								data-index={virtual.index}
 								data-kind={row.kind === "item" ? row.item.kind : row.kind}
+								data-nested={row.kind === "item" && row.nested ? "true" : undefined}
 								ref={virtualizer.measureElement}
 								style={{transform: `translateY(${virtual.start}px)`}}
 							>

--- a/apps/tuval/src/shell/chat/ToolRow.tsx
+++ b/apps/tuval/src/shell/chat/ToolRow.tsx
@@ -73,13 +73,20 @@ function DetailView({detail}: {readonly detail: ToolDetail}): ReactElement {
 	);
 }
 
+/** The group head's own line: the volume the fold is hiding, as words rather than a bare number. */
+const foldedLine = (nestedCount: number): string =>
+	nestedCount === 1 ? "1 nested call" : `${nestedCount} nested calls`;
+
 export function ToolRow({
 	item,
 	expanded,
+	nestedCount,
 	onToggle,
 }: {
 	readonly item: ToolItem;
 	readonly expanded: boolean;
+	/** How many subagent rows are folded under this one; zero means it heads no group. */
+	readonly nestedCount: number;
 	readonly onToggle: (open: boolean) => void;
 }): ReactElement {
 	const detail = toolDetail(item);
@@ -95,6 +102,9 @@ export function ToolRow({
 					<span className="tuval-chat-tool-status" data-status={item.status}>
 						{item.status}
 					</span>
+					{nestedCount > 0 ? (
+						<span className="tuval-chat-tool-folded">{foldedLine(nestedCount)}</span>
+					) : null}
 				</span>
 			}
 		>

--- a/apps/tuval/src/shell/chat/ToolRow.tsx
+++ b/apps/tuval/src/shell/chat/ToolRow.tsx
@@ -9,9 +9,16 @@
  * Open/closed is **controlled** rather than the primitive's own uncontrolled state, because the
  * fact lives in the window's `view` slot: two windows over one process open the same call
  * independently, and a window switched away from and back to comes back opened the way it was left.
+ *
+ * A group head carries a **second, separate** disclosure for the subagent rows folded under it. The
+ * two cannot share one control: `Collapsible` wires `aria-expanded`/`aria-controls` over the content
+ * it owns, and the folded rows are siblings in the virtualized list outside that content, so a
+ * shared trigger announces the input panel while N unrelated rows appear unannounced (#8027, ADR
+ * 0162 Pillar 4). The fold button names the rows in `aria-controls` and states the act it performs
+ * in its own text, so reading the call's input no longer bursts the group open as a side effect.
  */
 
-import {Collapsible} from "@kampus/design";
+import {Button, Collapsible} from "@kampus/design";
 import type {ReactElement} from "react";
 import type {ToolItem} from "../../ai-agent/ports/index.ts";
 import {omissionLine, type ToolDetail, toolDetail} from "./tool-detail.ts";
@@ -73,47 +80,74 @@ function DetailView({detail}: {readonly detail: ToolDetail}): ReactElement {
 	);
 }
 
-/** The group head's own line: the volume the fold is hiding, as words rather than a bare number. */
-const foldedLine = (nestedCount: number): string =>
-	nestedCount === 1 ? "1 nested call" : `${nestedCount} nested calls`;
+/**
+ * The fold button's own text, which is also its accessible name. It names the act rather than the
+ * state, because the button is the only thing that says these rows exist at all.
+ */
+const foldLine = (count: number, open: boolean): string =>
+	`${open ? "Hide" : "Show"} ${count} nested ${count === 1 ? "call" : "calls"}`;
+
+/** A group head's fold, absent on a row that heads no group — so a count without rows cannot exist. */
+export interface ToolFold {
+	/** The DOM ids of the rows this fold reveals, in list order. */
+	readonly rowIds: ReadonlyArray<string>;
+	readonly open: boolean;
+	readonly onToggle: (open: boolean) => void;
+}
 
 export function ToolRow({
 	item,
 	expanded,
-	nestedCount,
+	fold,
 	onToggle,
 }: {
 	readonly item: ToolItem;
 	readonly expanded: boolean;
-	/** How many subagent rows are folded under this one; zero means it heads no group. */
-	readonly nestedCount: number;
+	/** The subagent rows folded under this one, or `null` on a row that heads no group. */
+	readonly fold: ToolFold | null;
 	readonly onToggle: (open: boolean) => void;
 }): ReactElement {
 	const detail = toolDetail(item);
 	const omitted = omissionLine(item.result.omitted.bytes);
 	return (
-		<Collapsible
-			className="tuval-chat-tool"
-			open={expanded}
-			onOpenChange={onToggle}
-			trigger={
-				<span className="tuval-chat-tool-head">
-					<span className="tuval-chat-tool-name">{item.name}</span>
-					<span className="tuval-chat-tool-status" data-status={item.status}>
-						{item.status}
+		<>
+			<Collapsible
+				className="tuval-chat-tool"
+				open={expanded}
+				onOpenChange={onToggle}
+				trigger={
+					<span className="tuval-chat-tool-head">
+						<span className="tuval-chat-tool-name">{item.name}</span>
+						<span className="tuval-chat-tool-status" data-status={item.status}>
+							{item.status}
+						</span>
 					</span>
-					{nestedCount > 0 ? (
-						<span className="tuval-chat-tool-folded">{foldedLine(nestedCount)}</span>
-					) : null}
-				</span>
-			}
-		>
-			<DetailView detail={detail} />
-			<div className="tuval-chat-tool-detail">
-				<p className="tuval-chat-tool-label">{detail.kind === "shell" ? "output" : "result"}</p>
-				<pre className="tuval-chat-pre">{item.result.text}</pre>
-				{omitted === null ? null : <p className="tuval-chat-omission">{omitted}</p>}
-			</div>
-		</Collapsible>
+				}
+			>
+				<DetailView detail={detail} />
+				<div className="tuval-chat-tool-detail">
+					<p className="tuval-chat-tool-label">{detail.kind === "shell" ? "output" : "result"}</p>
+					<pre className="tuval-chat-pre">{item.result.text}</pre>
+					{omitted === null ? null : <p className="tuval-chat-omission">{omitted}</p>}
+				</div>
+			</Collapsible>
+			{fold === null ? null : (
+				<Button
+					type="button"
+					variant="tertiary"
+					size="sm"
+					className="tuval-chat-tool-fold"
+					aria-expanded={fold.open}
+					// Only while open, because the rows are the referents and they do not exist collapsed.
+					// The virtualizer renders a window of them, so an open fold taller than the viewport
+					// resolves the ids it has mounted and leaves the rest dangling, which assistive tech
+					// ignores rather than mis-reads. #8057 tracks carrying the whole set.
+					aria-controls={fold.open ? fold.rowIds.join(" ") : undefined}
+					onClick={() => fold.onToggle(!fold.open)}
+				>
+					{foldLine(fold.rowIds.length, fold.open)}
+				</Button>
+			)}
+		</>
 	);
 }

--- a/apps/tuval/src/shell/chat/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/chat/boundary.unit.test.ts
@@ -30,6 +30,7 @@ const chatViewFitsTheSlot: ViewState = {
 	cursor: null,
 	atOldest: false,
 	expanded: [],
+	unfolded: [],
 } satisfies ChatView;
 
 /**
@@ -50,6 +51,7 @@ const asInterface = {
 	cursor: null,
 	atOldest: false,
 	expanded: [],
+	unfolded: [],
 } as ChatViewAsInterface;
 // @ts-expect-error — an interface-shaped view record is not a `Schema.Json` member, so no window
 // could hold it and `ChatView` must not become one.
@@ -103,6 +105,7 @@ describe("chat window boundary", () => {
 			cursor: null,
 			atOldest: false,
 			expanded: [],
+			unfolded: [],
 		});
 		expect(interfaceMisfitsTheSlot).toBe(asInterface);
 		expect(isWindowRenderer).toBe(true);

--- a/apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-composer-width.unit.test.tsx
@@ -46,7 +46,14 @@ beforeAll(() => {
 	document.head.appendChild(style);
 });
 
-const emptyView: ChatView = {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []};
+const emptyView: ChatView = {
+	scroll: 0,
+	draft: "",
+	cursor: null,
+	atOldest: false,
+	expanded: [],
+	unfolded: [],
+};
 
 /** Mounts the window inside a parent of a known inline size, the way a desk window sizes it. */
 const openWindowIn = async (parentWidth: number): Promise<void> => {

--- a/apps/tuval/src/shell/chat/chat-visually-hidden.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-visually-hidden.unit.test.tsx
@@ -62,7 +62,14 @@ const openComposer = async (): Promise<void> => {
 			withTranscript([userItem("a", "do it")]),
 		),
 	);
-	const view: ChatView = {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []};
+	const view: ChatView = {
+		scroll: 0,
+		draft: "",
+		cursor: null,
+		atOldest: false,
+		expanded: [],
+		unfolded: [],
+	};
 	const host: ChatWindowHost = await Effect.runPromise(
 		process.window<ChatView>(WindowId.make("w1"), view),
 	);

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -23,7 +23,14 @@ import {installDomShims, TEST_VIEWPORT} from "../ui/dom.testing.ts";
 import {type TestProcess, testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {type ChatWindowHost, type ChatWindowOptions, chatWindow} from "./ChatWindow.tsx";
-import {assistantItem, toolItem, transcriptOf, userItem, withTranscript} from "./chat.testing.ts";
+import {
+	assistantItem,
+	call,
+	toolItem,
+	transcriptOf,
+	userItem,
+	withTranscript,
+} from "./chat.testing.ts";
 import {phaseLines} from "./phase.ts";
 import type {ChatView} from "./view.ts";
 
@@ -55,7 +62,14 @@ const openWindow = async (
 	const host = await Effect.runPromise(
 		process.window<ChatView>(
 			WindowId.make("w1"),
-			initialView ?? {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []},
+			initialView ?? {
+				scroll: 0,
+				draft: "",
+				cursor: null,
+				atOldest: false,
+				expanded: [],
+				unfolded: [],
+			},
 		),
 	);
 	const resolved: ChatWindowOptions = {
@@ -255,6 +269,7 @@ describe("the composer", () => {
 				cursor: null,
 				atOldest: false,
 				expanded: [],
+				unfolded: [],
 			},
 		);
 		expect(composer().value).toBe("half-written");
@@ -360,7 +375,14 @@ describe("the phase line and the contract's two placeholders", () => {
 			processId,
 			readProcess: Stream.never,
 			dispatch: () => Effect.succeed({_tag: "Delivered"} as const),
-			view: () => ({scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []}),
+			view: () => ({
+				scroll: 0,
+				draft: "",
+				cursor: null,
+				atOldest: false,
+				expanded: [],
+				unfolded: [],
+			}),
 			setView: () => Effect.void,
 		};
 		render(chatWindow({}).render(silent) as ReactElement);
@@ -392,7 +414,14 @@ describe("two windows over one process", () => {
 		const process = await Effect.runPromise(
 			testProcess<AiAgentSessionState, AiAgentSessionMsg>(processId, state),
 		);
-		const initial: ChatView = {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []};
+		const initial: ChatView = {
+			scroll: 0,
+			draft: "",
+			cursor: null,
+			atOldest: false,
+			expanded: [],
+			unfolded: [],
+		};
 		const left = await Effect.runPromise(process.window<ChatView>(WindowId.make("left"), initial));
 		const right = await Effect.runPromise(
 			process.window<ChatView>(WindowId.make("right"), initial),
@@ -484,5 +513,79 @@ describe("two windows over one process", () => {
 		expect(within(windowBox("right")).getByText("Loading earlier messages…")).toBeDefined();
 		expect(within(windowBox("right")).queryByText("older prompt")).toBeNull();
 		expect(right.view().cursor).toBeNull();
+	});
+});
+
+describe("a group head's fold, as a control assistive tech can read", () => {
+	const group = [
+		call("agent", {name: "Agent"}),
+		call("child-1", {name: "bash", parentId: "agent"}),
+		call("child-2", {name: "grep", parentId: "agent"}),
+	];
+
+	const foldButton = (): HTMLElement => screen.getByRole("button", {name: /nested calls?$/});
+
+	it("names the rows it reveals and announces the reveal, separately from the call's own panel", async () => {
+		await openWindow(withTranscript(group));
+
+		const fold = foldButton();
+		expect(fold.textContent).toBe("Show 2 nested calls");
+		expect(fold.getAttribute("aria-expanded")).toBe("false");
+		// Collapsed, the rows do not exist, so the control names nothing rather than naming ghosts.
+		expect(fold.getAttribute("aria-controls")).toBeNull();
+		expect(document.getElementById("tuval-row-w1-child-1")).toBeNull();
+
+		await act(async () => {
+			fireEvent.click(fold);
+		});
+
+		const opened = foldButton();
+		expect(opened.textContent).toBe("Hide 2 nested calls");
+		expect(opened.getAttribute("aria-expanded")).toBe("true");
+		const controls = opened.getAttribute("aria-controls")?.split(" ") ?? [];
+		expect(controls).toEqual(["tuval-row-w1-child-1", "tuval-row-w1-child-2"]);
+		for (const id of controls) expect(document.getElementById(id)).not.toBeNull();
+	});
+
+	it("leaves the call's own input panel shut, so reading a row does not burst its group open", async () => {
+		const harness = await openWindow(withTranscript(group));
+
+		const trigger = screen.getByRole("button", {name: /^Agent/});
+		await act(async () => {
+			fireEvent.click(trigger);
+		});
+		expect(harness.view().expanded).toEqual(["agent"]);
+		expect(harness.view().unfolded).toEqual([]);
+		expect(document.getElementById("tuval-row-w1-child-1")).toBeNull();
+
+		await act(async () => {
+			fireEvent.click(foldButton());
+		});
+		expect(harness.view().unfolded).toEqual(["agent"]);
+		expect(harness.view().expanded).toEqual(["agent"]);
+	});
+
+	it("gives a folded row that heads its own group a fold of its own", async () => {
+		await openWindow(
+			withTranscript([
+				call("agent", {name: "Agent"}),
+				call("inner", {name: "Agent", parentId: "agent"}),
+				call("leaf", {name: "bash", parentId: "inner"}),
+			]),
+			{},
+			{scroll: 0, draft: "", cursor: null, atOldest: false, expanded: [], unfolded: ["agent"]},
+		);
+
+		const folds = screen.getAllByRole("button", {name: /nested calls?$/});
+		expect(folds.map((button) => button.textContent)).toEqual([
+			"Hide 1 nested call",
+			"Show 1 nested call",
+		]);
+		expect(document.getElementById("tuval-row-w1-leaf")).toBeNull();
+
+		await act(async () => {
+			fireEvent.click(folds[1] as HTMLElement);
+		});
+		expect(document.getElementById("tuval-row-w1-leaf")).not.toBeNull();
 	});
 });

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -122,11 +122,13 @@
 }
 
 /*
- * A subagent's row, indented under the call that spawned it. The indent is the second signal only —
- * the row already says "subagent" in words above it (ADR 0162, Pillar 4).
+ * A subagent's row, indented under the call that spawned it, one step per fold it sits inside. The
+ * indent is the second signal only — the row already says "subagent" in words above it (ADR 0162,
+ * Pillar 4). `--nest-depth` is set per row by `ChatWindow`; the fallback keeps the rule honest for a
+ * row marked nested whose head is older than the pages this window walked back to.
  */
 .tuval-chat-row[data-nested="true"] {
-	padding-inline-start: var(--s-6);
+	padding-inline-start: calc(var(--s-6) * var(--nest-depth, 1));
 	border-inline-start: 2px solid var(--border-faint);
 }
 
@@ -201,8 +203,13 @@
 	color: var(--accent);
 }
 
-.tuval-chat-tool-folded {
-	color: var(--text-muted);
+/*
+ * The group head's second control, under the tool line rather than inside it: a button cannot nest
+ * inside the `Collapsible` trigger, which is itself a button, and the two disclosures are separate
+ * facts (#8027).
+ */
+.tuval-chat-tool-fold {
+	align-self: flex-start;
 }
 
 .tuval-chat-tool-detail {

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -121,6 +121,15 @@
 	gap: var(--s-1);
 }
 
+/*
+ * A subagent's row, indented under the call that spawned it. The indent is the second signal only —
+ * the row already says "subagent" in words above it (ADR 0162, Pillar 4).
+ */
+.tuval-chat-row[data-nested="true"] {
+	padding-inline-start: var(--s-6);
+	border-inline-start: 2px solid var(--border-faint);
+}
+
 .tuval-chat-who {
 	font: var(--t-micro);
 	color: var(--text-muted);
@@ -190,6 +199,10 @@
 
 .tuval-chat-tool-status[data-status="running"] {
 	color: var(--accent);
+}
+
+.tuval-chat-tool-folded {
+	color: var(--text-muted);
 }
 
 .tuval-chat-tool-detail {

--- a/apps/tuval/src/shell/chat/chat.testing.ts
+++ b/apps/tuval/src/shell/chat/chat.testing.ts
@@ -54,6 +54,8 @@ export const call = (
 		readonly output?: string;
 		readonly resultLimit?: number;
 		readonly status?: ToolStatus;
+		/** The call this one ran inside, for the subagent-fold cases. */
+		readonly parentId?: string;
 	} = {},
 ): ToolItem => ({
 	kind: "tool",
@@ -63,6 +65,7 @@ export const call = (
 	input: options.input ?? {path: "README.md"},
 	result: boundToolResult(options.output ?? "ok", options.resultLimit),
 	status: options.status ?? "ok",
+	...(options.parentId === undefined ? {} : {parentId: ItemId.make(options.parentId)}),
 });
 
 export const permissionRequest = (

--- a/apps/tuval/src/shell/chat/proof/main.tsx
+++ b/apps/tuval/src/shell/chat/proof/main.tsx
@@ -61,7 +61,14 @@ const state: AiAgentSessionState = withTranscript(
 	},
 );
 
-const view: ChatView = {scroll: 0, draft: "", cursor: null, atOldest: false, expanded: []};
+const view: ChatView = {
+	scroll: 0,
+	draft: "",
+	cursor: null,
+	atOldest: false,
+	expanded: [],
+	unfolded: [],
+};
 
 const mount = Effect.gen(function* () {
 	const host = document.getElementById("proof");

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -21,10 +21,16 @@ export type ChatRow =
 	| {
 			readonly kind: "item";
 			readonly item: TranscriptItem;
-			/** How many rows are folded under this one. Zero for everything but a group head. */
-			readonly nestedCount: number;
+			/**
+			 * The rows folded directly under this one, in list order. Empty for everything but a group
+			 * head. The ids rather than a count, so "the head says 14" and "14 rows appear" cannot
+			 * disagree, and so the head's disclosure can name the rows it controls (#8027).
+			 */
+			readonly nestedIds: ReadonlyArray<ItemId>;
 			/** This row ran inside another tool call — a subagent's, not the agent's own. */
 			readonly nested: boolean;
+			/** How many folds deep this row sits. Zero for a row the agent itself opened. */
+			readonly depth: number;
 	  };
 
 export interface ChatRowsInput {
@@ -36,8 +42,8 @@ export interface ChatRowsInput {
 	readonly omitted: number;
 	readonly loading: boolean;
 	readonly atOldest: boolean;
-	/** The ids of the rows this window has expanded, off its own view slot. */
-	readonly expanded?: ReadonlySet<string>;
+	/** The ids of the group heads whose folded rows are showing, off this window's own view slot. */
+	readonly unfolded?: ReadonlySet<string>;
 }
 
 /**
@@ -69,14 +75,23 @@ const parentOf = (item: TranscriptItem): ItemId | undefined =>
  *
  * A tool row naming a parent that is also in this list is **folded under it** (founder ruling,
  * 2026-09-05): the group head carries the count and the folded rows appear only while it is
- * expanded, which is what keeps a fifty-call subagent from flooding the window. A row whose parent
+ * unfolded, which is what keeps a fifty-call subagent from flooding the window. A row whose parent
  * is not in the list — its group head is older than the pages walked back to — stays where it is,
  * marked nested, because dropping it would hide work that happened.
+ *
+ * The walk is depth-first, which is what makes that last sentence true of *every* shape the backend
+ * can mark rather than only of a one-level fold: a subagent that spawns a subagent gives a folded
+ * row children of its own, counted and rendered like any other head.
+ *
+ * `reachable` is walked separately from the render because the two ask different questions. A row
+ * behind a folded head is hidden on purpose and must stay hidden; a row whose parent chain loops
+ * back on itself belongs to no head at all and would otherwise vanish. Only the second is swept in
+ * at the end, so no marked row is dropped and none is un-hidden.
  */
 export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	const inTail = new Set(input.tail.map((item) => item.id));
 	const items = [...input.older.filter((item) => !inTail.has(item.id)), ...input.tail];
-	const expanded = input.expanded ?? new Set<string>();
+	const unfolded = input.unfolded ?? new Set<string>();
 	const present = new Set(items.map((item) => item.id));
 	const folded = new Map<string, Array<TranscriptItem>>();
 	for (const item of items) {
@@ -90,13 +105,35 @@ export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	if (!input.atOldest && items.length > 0) {
 		rows.push(input.loading ? {kind: "loading"} : {kind: "older", items: input.omitted});
 	}
-	for (const item of items) {
+	const roots = items.filter((item) => {
 		const parent = parentOf(item);
-		if (parent !== undefined && present.has(parent)) continue;
+		return parent === undefined || !present.has(parent);
+	});
+	const reachable = new Set<string>();
+	const mark = (item: TranscriptItem): void => {
+		if (reachable.has(item.id)) return;
+		reachable.add(item.id);
+		for (const child of folded.get(item.id) ?? []) mark(child);
+	};
+	for (const item of roots) mark(item);
+	const seen = new Set<string>();
+	const emit = (item: TranscriptItem, depth: number): void => {
+		if (seen.has(item.id)) return;
+		seen.add(item.id);
 		const group = folded.get(item.id) ?? [];
-		rows.push({kind: "item", item, nestedCount: group.length, nested: parent !== undefined});
-		if (!expanded.has(item.id)) continue;
-		for (const child of group) rows.push({kind: "item", item: child, nestedCount: 0, nested: true});
+		rows.push({
+			kind: "item",
+			item,
+			nestedIds: group.map((child) => child.id),
+			nested: depth > 0,
+			depth,
+		});
+		if (!unfolded.has(item.id)) return;
+		for (const child of group) emit(child, depth + 1);
+	};
+	for (const item of roots) emit(item, parentOf(item) === undefined ? 0 : 1);
+	for (const item of items) {
+		if (!reachable.has(item.id)) emit(item, 1);
 	}
 	return rows;
 };

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -11,14 +11,21 @@
  * is in flight, and both disappear at the beginning of history (founder ruling, 2026-09-02).
  */
 
-import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import type {ItemId, TranscriptItem} from "../../ai-agent/ports/index.ts";
 
 export type ChatRow =
 	/** There is more history behind this point; `items` is what the live-tail bound already dropped. */
 	| {readonly kind: "older"; readonly items: number}
 	/** A `page` request is out. */
 	| {readonly kind: "loading"}
-	| {readonly kind: "item"; readonly item: TranscriptItem};
+	| {
+			readonly kind: "item";
+			readonly item: TranscriptItem;
+			/** How many rows are folded under this one. Zero for everything but a group head. */
+			readonly nestedCount: number;
+			/** This row ran inside another tool call — a subagent's, not the agent's own. */
+			readonly nested: boolean;
+	  };
 
 export interface ChatRowsInput {
 	/** Pages this window has walked back through, oldest-first. */
@@ -29,6 +36,8 @@ export interface ChatRowsInput {
 	readonly omitted: number;
 	readonly loading: boolean;
 	readonly atOldest: boolean;
+	/** The ids of the rows this window has expanded, off its own view slot. */
+	readonly expanded?: ReadonlySet<string>;
 }
 
 /**
@@ -50,18 +59,45 @@ export const mergeOlder = (
 	return fresh.length === 0 ? held : [...fresh, ...held];
 };
 
+/** The call a tool row ran inside, when the backend marked one. Nothing else nests. */
+const parentOf = (item: TranscriptItem): ItemId | undefined =>
+	item.kind === "tool" ? item.parentId : undefined;
+
 /**
  * The list the window renders. The tail wins on a collision: an item that reached the live stream is
  * the newer copy of itself, and a page that happens to overlap the tail must not double it.
+ *
+ * A tool row naming a parent that is also in this list is **folded under it** (founder ruling,
+ * 2026-09-05): the group head carries the count and the folded rows appear only while it is
+ * expanded, which is what keeps a fifty-call subagent from flooding the window. A row whose parent
+ * is not in the list — its group head is older than the pages walked back to — stays where it is,
+ * marked nested, because dropping it would hide work that happened.
  */
 export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	const inTail = new Set(input.tail.map((item) => item.id));
 	const items = [...input.older.filter((item) => !inTail.has(item.id)), ...input.tail];
+	const expanded = input.expanded ?? new Set<string>();
+	const present = new Set(items.map((item) => item.id));
+	const folded = new Map<string, Array<TranscriptItem>>();
+	for (const item of items) {
+		const parent = parentOf(item);
+		if (parent === undefined || !present.has(parent)) continue;
+		const group = folded.get(parent);
+		if (group === undefined) folded.set(parent, [item]);
+		else group.push(item);
+	}
 	const rows: Array<ChatRow> = [];
 	if (!input.atOldest && items.length > 0) {
 		rows.push(input.loading ? {kind: "loading"} : {kind: "older", items: input.omitted});
 	}
-	for (const item of items) rows.push({kind: "item", item});
+	for (const item of items) {
+		const parent = parentOf(item);
+		if (parent !== undefined && present.has(parent)) continue;
+		const group = folded.get(item.id) ?? [];
+		rows.push({kind: "item", item, nestedCount: group.length, nested: parent !== undefined});
+		if (!expanded.has(item.id)) continue;
+		for (const child of group) rows.push({kind: "item", item: child, nestedCount: 0, nested: true});
+	}
 	return rows;
 };
 

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {assistantItem, transcriptOf, userItem} from "./chat.testing.ts";
+import {assistantItem, call, transcriptOf, userItem} from "./chat.testing.ts";
 import {chatRows, mergeOlder, oldestLoadedId, rowIndexOfItem, rowKey} from "./rows.ts";
 
 const base = {older: [], tail: [], omitted: 0, loading: false, atOldest: false};
@@ -42,6 +42,59 @@ describe("chatRows", () => {
 			"b",
 			"c",
 			"d",
+		]);
+	});
+});
+
+describe("chatRows folds a subagent's calls under the call that spawned it", () => {
+	const group = [
+		call("agent", {name: "Agent"}),
+		call("child-1", {parentId: "agent"}),
+		call("child-2", {parentId: "agent"}),
+		call("own", {name: "Bash"}),
+	];
+
+	it("shows the group head with its count and hides the calls under it while collapsed", () => {
+		const rows = chatRows({...base, tail: group, atOldest: true});
+		expect(rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []))).toEqual([
+			"agent",
+			"own",
+		]);
+		const head = rows[0];
+		expect(head?.kind === "item" && head.nestedCount).toBe(2);
+		expect(head?.kind === "item" && head.nested).toBe(false);
+	});
+
+	it("lays the folded calls out under the head once it is expanded, marked nested", () => {
+		const rows = chatRows({
+			...base,
+			tail: group,
+			atOldest: true,
+			expanded: new Set(["agent"]),
+		});
+		expect(rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []))).toEqual([
+			"agent",
+			"child-1",
+			"child-2",
+			"own",
+		]);
+		expect(rows.flatMap((row) => (row.kind === "item" && row.nested ? [row.item.id] : []))).toEqual(
+			["child-1", "child-2"],
+		);
+	});
+
+	it("leaves a row whose parent is not loaded in place, marked nested and heading nothing", () => {
+		const orphan = call("child-1", {parentId: "agent"});
+		const rows = chatRows({...base, tail: [orphan], atOldest: true});
+		expect(rows).toEqual([{kind: "item", item: orphan, nestedCount: 0, nested: true}]);
+	});
+
+	it("leaves a transcript with no parent marked on it exactly as it was", () => {
+		const flat = [call("a"), call("b")];
+		const rows = chatRows({...base, tail: flat, atOldest: true});
+		expect(rows).toEqual([
+			{kind: "item", item: flat[0], nestedCount: 0, nested: false},
+			{kind: "item", item: flat[1], nestedCount: 0, nested: false},
 		]);
 	});
 });
@@ -88,7 +141,9 @@ describe("the page cursor and the prepend anchor", () => {
 
 describe("rowKey", () => {
 	it("keys an item on its own id, so a status update does not remount its row", () => {
-		expect(rowKey({kind: "item", item: assistantItem("x")})).toBe("item:x");
+		expect(rowKey({kind: "item", item: assistantItem("x"), nestedCount: 0, nested: false})).toBe(
+			"item:x",
+		);
 		expect(rowKey({kind: "loading"})).toBe("loading");
 		expect(rowKey({kind: "older", items: 3})).toBe("older");
 	});

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -61,8 +61,9 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 			"own",
 		]);
 		const head = rows[0];
-		expect(head?.kind === "item" && head.nestedCount).toBe(2);
+		expect(head?.kind === "item" && head.nestedIds).toEqual(["child-1", "child-2"]);
 		expect(head?.kind === "item" && head.nested).toBe(false);
+		expect(head?.kind === "item" && head.depth).toBe(0);
 	});
 
 	it("lays the folded calls out under the head once it is expanded, marked nested", () => {
@@ -70,7 +71,7 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 			...base,
 			tail: group,
 			atOldest: true,
-			expanded: new Set(["agent"]),
+			unfolded: new Set(["agent"]),
 		});
 		expect(rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []))).toEqual([
 			"agent",
@@ -86,15 +87,54 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 	it("leaves a row whose parent is not loaded in place, marked nested and heading nothing", () => {
 		const orphan = call("child-1", {parentId: "agent"});
 		const rows = chatRows({...base, tail: [orphan], atOldest: true});
-		expect(rows).toEqual([{kind: "item", item: orphan, nestedCount: 0, nested: true}]);
+		expect(rows).toEqual([{kind: "item", item: orphan, nestedIds: [], nested: true, depth: 1}]);
+	});
+
+	it("gives a folded row that is itself a group head its own count and its own children", () => {
+		// The one-level fold used to drop this shape whole: the grandchild was skipped by the head
+		// loop because its parent was present, and pushed by no other loop, so it appeared nowhere and
+		// its parent's head line read no count (#8027).
+		const deep = [
+			call("agent", {name: "Agent"}),
+			call("inner", {name: "Agent", parentId: "agent"}),
+			call("leaf", {parentId: "inner"}),
+		];
+		const both = chatRows({
+			...base,
+			tail: deep,
+			atOldest: true,
+			unfolded: new Set(["agent", "inner"]),
+		});
+		expect(both).toEqual([
+			{kind: "item", item: deep[0], nestedIds: ["inner"], nested: false, depth: 0},
+			{kind: "item", item: deep[1], nestedIds: ["leaf"], nested: true, depth: 1},
+			{kind: "item", item: deep[2], nestedIds: [], nested: true, depth: 2},
+		]);
+
+		const outerOnly = chatRows({...base, tail: deep, atOldest: true, unfolded: new Set(["agent"])});
+		expect(outerOnly.flatMap((row) => (row.kind === "item" ? [row.item.id] : []))).toEqual([
+			"agent",
+			"inner",
+		]);
+		expect(outerOnly[1]?.kind === "item" && outerOnly[1].nestedIds).toEqual(["leaf"]);
+	});
+
+	it("emits every marked row exactly once even when the parent chain loops back on itself", () => {
+		const cycle = [call("a", {parentId: "b"}), call("b", {parentId: "a"}), call("free")];
+		const rows = chatRows({...base, tail: cycle, atOldest: true, unfolded: new Set(["a", "b"])});
+		expect(rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []))).toEqual([
+			"free",
+			"a",
+			"b",
+		]);
 	});
 
 	it("leaves a transcript with no parent marked on it exactly as it was", () => {
 		const flat = [call("a"), call("b")];
 		const rows = chatRows({...base, tail: flat, atOldest: true});
 		expect(rows).toEqual([
-			{kind: "item", item: flat[0], nestedCount: 0, nested: false},
-			{kind: "item", item: flat[1], nestedCount: 0, nested: false},
+			{kind: "item", item: flat[0], nestedIds: [], nested: false, depth: 0},
+			{kind: "item", item: flat[1], nestedIds: [], nested: false, depth: 0},
 		]);
 	});
 });
@@ -141,9 +181,9 @@ describe("the page cursor and the prepend anchor", () => {
 
 describe("rowKey", () => {
 	it("keys an item on its own id, so a status update does not remount its row", () => {
-		expect(rowKey({kind: "item", item: assistantItem("x"), nestedCount: 0, nested: false})).toBe(
-			"item:x",
-		);
+		expect(
+			rowKey({kind: "item", item: assistantItem("x"), nestedIds: [], nested: false, depth: 0}),
+		).toBe("item:x");
 		expect(rowKey({kind: "loading"})).toBe("loading");
 		expect(rowKey({kind: "older", items: 3})).toBe("older");
 	});

--- a/apps/tuval/src/shell/chat/view.ts
+++ b/apps/tuval/src/shell/chat/view.ts
@@ -1,11 +1,15 @@
 /**
  * What one chat window keeps in its own `view` slot, and how a slot of unknown shape is read back.
  *
- * Four facts live here and nothing else: where the transcript was scrolled to, what was typed and
- * not yet sent, how far back into history this window has walked, and which tool rows it has opened.
- * Two windows over one process share the transcript and own one of these each (#7484 R1.1), so
- * everything here is per-window — including `expanded`, which is why the same tool call can be open
- * in one window and closed in the other.
+ * Five facts live here and nothing else: where the transcript was scrolled to, what was typed and
+ * not yet sent, how far back into history this window has walked, which tool rows it has opened, and
+ * which group heads have their folded rows showing. Two windows over one process share the
+ * transcript and own one of these each (#7484 R1.1), so everything here is per-window — including
+ * `expanded`, which is why the same tool call can be open in one window and closed in the other.
+ *
+ * `expanded` and `unfolded` are two facts, not one: opening a call's input panel and revealing the
+ * subagent rows it heads are different asks, and one control doing both is what left the revealed
+ * rows unannounced to assistive tech (#8027).
  *
  * `ChatView` is a **type alias and not an interface** on purpose. The slot is `Schema.Json`
  * (`../window/host.ts`), and TypeScript gives an object *type alias* the implicit index signature
@@ -26,6 +30,8 @@ export type ChatView = {
 	readonly atOldest: boolean;
 	/** The ids of the tool rows this window has expanded. A row absent from it is collapsed. */
 	readonly expanded: ReadonlyArray<string>;
+	/** The ids of the group heads whose folded rows this window is showing. Absent means folded. */
+	readonly unfolded: ReadonlyArray<string>;
 };
 
 export const initialChatView: ChatView = {
@@ -34,6 +40,7 @@ export const initialChatView: ChatView = {
 	cursor: null,
 	atOldest: false,
 	expanded: [],
+	unfolded: [],
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -53,6 +60,9 @@ export const asChatView = (value: ViewState | undefined): ChatView => {
 		atOldest: value.atOldest === true,
 		expanded: Array.isArray(value.expanded)
 			? value.expanded.filter((id): id is string => typeof id === "string")
+			: [],
+		unfolded: Array.isArray(value.unfolded)
+			? value.unfolded.filter((id): id is string => typeof id === "string")
 			: [],
 	};
 };

--- a/apps/tuval/src/shell/chat/view.unit.test.ts
+++ b/apps/tuval/src/shell/chat/view.unit.test.ts
@@ -17,6 +17,7 @@ describe("asChatView", () => {
 				cursor: "i7",
 				atOldest: true,
 				expanded: ["t1", "t2"],
+				unfolded: ["t3"],
 			}),
 		).toEqual({
 			scroll: 420,
@@ -24,6 +25,7 @@ describe("asChatView", () => {
 			cursor: "i7",
 			atOldest: true,
 			expanded: ["t1", "t2"],
+			unfolded: ["t3"],
 		});
 	});
 
@@ -40,7 +42,14 @@ describe("asChatView", () => {
 
 	it("keeps the fields it recognises and defaults the rest, field by field", () => {
 		expect(
-			asChatView({scroll: "far", draft: 3, cursor: 9, atOldest: "yes", expanded: "t1"}),
+			asChatView({
+				scroll: "far",
+				draft: 3,
+				cursor: 9,
+				atOldest: "yes",
+				expanded: "t1",
+				unfolded: "t3",
+			}),
 		).toEqual(initialChatView);
 		expect(asChatView({scroll: 12, cursor: "i1"})).toEqual({
 			scroll: 12,
@@ -48,11 +57,13 @@ describe("asChatView", () => {
 			cursor: "i1",
 			atOldest: false,
 			expanded: [],
+			unfolded: [],
 		});
 	});
 
-	it("keeps only the string ids out of an expanded list another writer left something else in", () => {
+	it("keeps only the string ids out of an id list another writer left something else in", () => {
 		expect(asChatView({expanded: ["t1", 7, null, "t2", {}]}).expanded).toEqual(["t1", "t2"]);
+		expect(asChatView({unfolded: ["t1", 7, null, "t2", {}]}).unfolded).toEqual(["t1", "t2"]);
 	});
 
 	it("refuses a non-finite scroll offset, which would take the virtualizer with it", () => {


### PR DESCRIPTION
Fixes #8027

Tuval's Claude window showed a subagent's tool calls as ordinary top-level rows, so a founder running triage batches from one window could not tell his own conversation from the workers Claude spawned.

The SDK already marks them: `parent_tool_use_id` is non-null on any assistant or user frame produced inside a subagent (`sdk.d.ts`, `@anthropic-ai/claude-agent-sdk@0.3.259`). Nothing in Tuval read it. This carries it through, under a generic name, and folds the marked rows away.

**The mapping.** `blocks.ts` gains `parentToolUseIdOf`, the one place the SDK's own field name is read. `map.ts` stamps it onto every tool row an assistant frame opens, remembers it on the open call, and carries it onto the settled row from the user frame — the call is authoritative, so a row cannot change parent when it settles.

**The port.** `ToolItem` gains an optional `parentId: ItemId`. No SDK name reaches `ai-agent/ports/`, and `boundary.unit.test.ts` passes unchanged.

**The render** follows the founder's ruling of 2026-09-05 (collapse, not inline marking). `chatRows` folds a tool row whose parent is also in the list under that parent. The walk is depth-first, so a folded row that heads its own group renders its own children and carries its own count; reachability is marked separately from the render, so a row a collapsed head is hiding stays hidden while a row whose parent chain reaches no head at all is still emitted rather than dropped. A folded row renders one indent step per fold it sits inside, labelled `subagent` in words above it. A row whose parent is not loaded — its head is older than the pages walked back to — stays in place, marked nested.

**The fold is its own disclosure**, separate from the call's input panel. `Collapsible` wires `aria-expanded`/`aria-controls` over the content it owns, and the folded rows are siblings in the virtualized list outside that content, so one shared trigger announced the input panel while N unrelated rows appeared unannounced. The head now carries a second button — `aria-expanded`, `aria-controls` naming the rows it reveals, and `Show 14 nested calls` / `Hide 14 nested calls` as its own text — and `view.unfolded` holds that fact beside `expanded`, so reading a call's input no longer bursts its group open.

A row with no parent is untouched: no `data-nested`, no fold, same markup as before. Pi sets no parent, so its window does not change.

Reviewer's first stop: `chatRows` in `apps/tuval/src/shell/chat/rows.ts` — it decides which rows exist, and the virtualizer's row count moves when a fold opens.

## Deviations

- **Out-of-scope change** — **Said:** #8027 names the mapping, the port and the render. **Did:** also added a `## What is not captured` section to `apps/tuval/src/claude/history/fixtures/PROVENANCE.md`. **Why:** the new mapping case does not read a captured subagent frame, and a provenance doc that does not say so is wrong about its own fixtures. **Disposition:** stated here; the capture itself is filed as #8038.
- **Pre-existing test or fixture changed** — **Said:** golden fixtures are captured, never hand-authored (`.patterns/golden-real-payload-fixtures.md`, ADR 0180). **Did:** the subagent case in `events.unit.test.ts` stamps `parent_tool_use_id` over the golden `tool-turn` stream's assistant and user frames instead of loading a captured subagent run. **Why:** no committed capture spawns a subagent, and forcing one needs live credentials and real spend, which PROVENANCE.md already calls an operator act. The key set stays captured; one documented scalar changes value. **Disposition:** stated here and at the case itself; #8038 tracks taking the real capture.
- **Out-of-scope change** — **Said:** rendered-visual construction is `build-ui`'s modality. **Did:** built the render half here — `ToolRow.tsx`, `ChatWindow.tsx` and the `chat.css` rules — under `build`'s law, in a shell carrying only `build`. **Why:** the deliverable is transcript-model attribution whose visual half is an indent, a word label and a disclosure, generated from role tokens and idioms already in these exact files; splitting it would have left the port change unusable. **Disposition:** stated here. The round-1 review confirmed no rendered gate routes to `apps/tuval` at all, so there is nowhere to re-run this, and it named that gap as why the missing disclosure semantics got through. The a11y defect it let through is fixed in round 2; the routing gap is the pipeline's and is filed separately.
- **Guard or gate bypassed** — **Said:** publish the branch through `fabrika build push`. **Did:** on round 1 the verb reported `the remote ref did not move` twice with no error, so the branch was published by hand and the verb re-run, which read the remote back and printed `PUSH-VERDICT: MOVED`. **Why:** the repo's pre-push hook runs the full changed-unit suite (about 150s) and the verb appears not to survive it; the hook itself ran to completion and passed. **Disposition:** stated here; noted on #6626, which already tracks this verb swallowing the hook's answer. On round 2 a plain re-run of the verb carried it, with no hand push.
- **Known defect left unfixed** — **Said:** the tree should be green. **Did:** left one `apps/tuval` proof test failing on a timeout under a full parallel `vitest run` — `src/shell/program.unit.test.ts` on round 1, `src/ai-agent/restore/restore-proof.unit.test.ts` on round 2. **Why:** each passes alone in about a second, references nothing on this branch, and is a load-sensitive wall-clock poll rather than a defect this change caused. **Disposition:** filed as #8040.
- **Known defect left unfixed** — **Said:** the fold's disclosure semantics reach the folded rows it reveals (criterion 7). **Did:** `aria-controls` names every folded row's DOM id, but the virtualizer mounts only the rows around the viewport, so an open fold taller than the viewport leaves the rest of those ids resolving to nothing. **Why:** assistive tech ignores a dangling idref rather than mis-reading it, so the control still announces correctly and this is strictly better than the nothing that was there before. Carrying the whole relationship means tree semantics over the transcript — `aria-expanded` on a node whose children are absent from the DOM is what ARIA's tree pattern is for — which moves the container off `role="log"` and is larger than a repair round. **Disposition:** filed as #8057; the code comment at the `aria-controls` line points there.
- **Out-of-scope change** — **Said:** round 1's two findings are the fold's recursion and its a11y. **Did:** also moved the nested-call count out of the `Collapsible` trigger and into the new fold button's own text. **Why:** forced rather than chosen — a button cannot nest inside the trigger, which is itself a button, so splitting the two disclosures moves the count with the control it belongs to. The volume is still readable at a glance and now names the act as well. **Disposition:** stated here.
