### PR TITLE
fix: Tuval's Claude transcript goes empty mid-session, with only Load earlier messages left at the top

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The transcript half of the fold, over a turn that outgrows the bounds while it is still open.
+ *
+ * `foldItem` re-plans over `transcript.items` rather than over full history, so whatever a plan
+ * leaves out is gone from state and reachable only by paging (#8031). That makes an empty accepted
+ * plan unrecoverable, and this file is where that stays proven.
+ */
+
+import {describe, expect, it} from "vitest";
+import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
+import type {TranscriptItem, TranscriptPayload} from "../ports/index.ts";
+import {foldItem, type WindowLimits} from "./fold.ts";
+
+const empty: TranscriptPayload = {items: [], omitted: {items: 0, bytes: 0, reason: "none"}};
+
+/** Fold a stream item by item, answering the transcript after each one. */
+const foldAll = (
+	start: TranscriptPayload,
+	stream: ReadonlyArray<TranscriptItem>,
+	limits: WindowLimits,
+): ReadonlyArray<TranscriptPayload> => {
+	const steps: Array<TranscriptPayload> = [];
+	let transcript = start;
+	for (const item of stream) {
+		transcript = foldItem(transcript, item, limits);
+		steps.push(transcript);
+	}
+	return steps;
+};
+
+describe("folding a turn that outgrows the bounds", () => {
+	it("never empties the tail while the open group is still growing", () => {
+		const turn = [
+			userItem("u1"),
+			...Array.from({length: 11}, (_, index) => toolItem(`t${index}`)),
+			assistantItem("a1"),
+		];
+		const steps = foldAll(empty, turn, {itemLimit: 5});
+		expect(steps.map((step) => step.items.length)).toEqual(turn.map((_, index) => index + 1));
+		expect(steps.at(-1)?.items).toEqual(turn);
+		expect(steps.at(-1)?.omitted).toEqual({items: 0, bytes: 0, reason: "none"});
+	});
+
+	it("drops the exchange before it once, and keeps the growing one whole", () => {
+		const older = [userItem("u0"), assistantItem("a0")];
+		const turn = [userItem("u1"), ...Array.from({length: 8}, (_, index) => toolItem(`t${index}`))];
+		const seeded = foldAll(empty, older, {itemLimit: 5}).at(-1) ?? empty;
+		const steps = foldAll(seeded, turn, {itemLimit: 5});
+		expect(steps.every((step) => step.items.length > 0)).toBe(true);
+		expect(steps.at(-1)?.items).toEqual(turn);
+		expect(steps.at(-1)?.omitted.items).toBe(older.length);
+		expect(steps.at(-1)?.omitted.reason).toBe("item-limit");
+	});
+});

--- a/apps/tuval/src/ai-agent/history/window.ts
+++ b/apps/tuval/src/ai-agent/history/window.ts
@@ -6,6 +6,13 @@
  * through `planTranscriptPage`, never accumulated here. Re-derived by hand from the frozen POC
  * `packages/tuval/src/backend/coding-agent-transcript.ts` on `epic/7140`, which planned the same
  * two bounds over Pi's own transcript type; this one is model-blind and refuses instead of throwing.
+ *
+ * The newest group in range is the one exception to both bounds: it is carried whole even when it
+ * alone exceeds them, the same clause `planTranscriptPage` carries. One agentic turn is one group,
+ * so a turn of forty tool calls crosses the item bound on its own — and an empty tail is not a
+ * refusal, so `foldItem` would commit it and the operator's live transcript would collapse to the
+ * paging control with the tail unreachable from state (#8031). Exceeding a bound by one turn is
+ * recoverable; losing the turn is not.
  */
 
 import type {TranscriptItem, TranscriptPayload, WindowOmission} from "../ports/index.ts";
@@ -101,7 +108,7 @@ export const planTranscriptWindow = (
 		const group = groups[index];
 		if (group === undefined) break;
 		const stop = stoppedBy(group, {items, bytes}, {items: itemLimit, bytes: byteLimit});
-		if (stop !== null) {
+		if (stop !== null && taken.length > 0) {
 			reason = stop;
 			break;
 		}

--- a/apps/tuval/src/ai-agent/history/window.unit.test.ts
+++ b/apps/tuval/src/ai-agent/history/window.unit.test.ts
@@ -17,6 +17,16 @@ import {
 const bytesOf = (items: ReadonlyArray<TranscriptItem>) =>
 	items.reduce((total, item) => total + itemBytes(item), 0);
 
+/** One prompt and the tool calls it produced: `count` items the bounds may never cut apart. */
+const oneExchange = (
+	prefix: string,
+	count: number,
+	output = "ok",
+): ReadonlyArray<TranscriptItem> => [
+	userItem(`${prefix}-u`),
+	...Array.from({length: count - 1}, (_, index) => toolItem(`${prefix}-t${index}`, output)),
+];
+
 describe("the live-tail window", () => {
 	it("declares both bounds", () => {
 		expect(TRANSCRIPT_WINDOW_ITEM_LIMIT).toBe(40);
@@ -67,13 +77,47 @@ describe("the live-tail window", () => {
 		expect(plan.omitted.reason).toBe("byte-limit");
 	});
 
-	it("returns an empty window rather than half an exchange the bound cannot hold", () => {
+	it("keeps the newest exchange whole rather than emptying the tail the bound cannot hold", () => {
 		const history = [userItem("u1"), assistantItem("a1"), toolItem("t1")];
 		const plan = planTranscriptWindow(history, {itemLimit: 2});
 		expect(plan.kind).toBe("window");
 		if (plan.kind !== "window") return;
-		expect(plan.items).toEqual([]);
-		expect(plan.omitted).toEqual({items: 3, bytes: bytesOf(history), reason: "item-limit"});
+		expect(plan.items.map((item) => item.id)).toEqual(["u1", "a1", "t1"]);
+		expect(plan.omitted).toEqual({items: 0, bytes: 0, reason: "none"});
+	});
+
+	it("carries a turn of 45 tool calls whole, over the item bound on its own", () => {
+		const history = oneExchange("big", 45);
+		const plan = planTranscriptWindow(history);
+		expect(plan.kind).toBe("window");
+		if (plan.kind !== "window") return;
+		expect(history.length).toBeGreaterThan(TRANSCRIPT_WINDOW_ITEM_LIMIT);
+		expect(plan.items).toEqual(history);
+		expect(plan.omitted.items).toBe(0);
+	});
+
+	it("carries a turn past the byte bound whole too", () => {
+		const history = oneExchange("heavy", 34, "x".repeat(8_000));
+		const plan = planTranscriptWindow(history);
+		expect(plan.kind).toBe("window");
+		if (plan.kind !== "window") return;
+		expect(history.length).toBeLessThanOrEqual(TRANSCRIPT_WINDOW_ITEM_LIMIT);
+		expect(bytesOf(history)).toBeGreaterThan(TRANSCRIPT_WINDOW_BYTE_LIMIT);
+		expect(plan.items).toEqual(history);
+		expect(plan.omitted.items).toBe(0);
+	});
+
+	it("drops the older exchanges around a newest one the bounds cannot hold", () => {
+		const history = [userItem("u1"), assistantItem("a1"), ...oneExchange("big", 45)];
+		const plan = planTranscriptWindow(history, {itemLimit: 5});
+		expect(plan.kind).toBe("window");
+		if (plan.kind !== "window") return;
+		expect(plan.items).toEqual(history.slice(2));
+		expect(plan.omitted).toEqual({
+			items: 2,
+			bytes: bytesOf(history.slice(0, 2)),
+			reason: "item-limit",
+		});
 	});
 
 	it("ends just older than a cursor that opens a group", () => {
@@ -124,7 +168,7 @@ describe("the window refuses rather than cutting", () => {
 });
 
 describe("the window holds both bounds over random transcripts", () => {
-	it("never exceeds either bound and never splits a group, across 200 seeds", () => {
+	it("holds both bounds except over the newest group, and never splits one, across 200 seeds", () => {
 		const failures: Array<string> = [];
 		for (let seed = 1; seed <= 200; seed += 1) {
 			const random = randomStream(seed * 7919);
@@ -138,9 +182,16 @@ describe("the window holds both bounds over random transcripts", () => {
 			}
 			const ids = plan.items.map((item) => item.id);
 			const tail = history.slice(plan.start).map((item) => item.id);
-			if (plan.items.length > itemLimit)
+			const newest = groupTranscript(history).at(-1);
+			const newestIds = (newest?.items ?? []).map((item) => item.id);
+			// The newest group is the excepted one: a window that is exactly it may sit over either
+			// bound, and a window carrying anything older than it may not.
+			const exceptedByNewest = JSON.stringify(ids) === JSON.stringify(newestIds);
+			if (ids.length === 0) failures.push(`seed ${seed}: empty window over a live tail`);
+			if (!exceptedByNewest && plan.items.length > itemLimit)
 				failures.push(`seed ${seed}: ${ids.length} > ${itemLimit}`);
-			if (bytesOf(plan.items) > byteLimit) failures.push(`seed ${seed}: over the byte bound`);
+			if (!exceptedByNewest && bytesOf(plan.items) > byteLimit)
+				failures.push(`seed ${seed}: over the byte bound`);
 			if (JSON.stringify(ids) !== JSON.stringify(tail)) {
 				failures.push(`seed ${seed}: window is not the newest tail`);
 			}

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -5,7 +5,8 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {assistantItem, transcriptOf, userItem} from "./chat.testing.ts";
+import {planTranscriptPage, planTranscriptWindow} from "../../ai-agent/history/index.ts";
+import {assistantItem, toolItem, transcriptOf, userItem} from "./chat.testing.ts";
 import {chatRows, mergeOlder, oldestLoadedId, rowIndexOfItem, rowKey} from "./rows.ts";
 
 const base = {older: [], tail: [], omitted: 0, loading: false, atOldest: false};
@@ -91,5 +92,35 @@ describe("rowKey", () => {
 		expect(rowKey({kind: "item", item: assistantItem("x")})).toBe("item:x");
 		expect(rowKey({kind: "loading"})).toBe("loading");
 		expect(rowKey({kind: "older", items: 3})).toBe("older");
+	});
+});
+
+describe("a live tail carrying an exchange the bounds cannot hold", () => {
+	const older = [userItem("u0"), assistantItem("a0")];
+	const turn = [userItem("u1"), ...Array.from({length: 44}, (_, index) => toolItem(`t${index}`))];
+	const history = [...older, ...turn];
+
+	it("pages the exchange older than it and renders every item once", () => {
+		const live = planTranscriptWindow(history, {itemLimit: 5});
+		expect(live.kind).toBe("window");
+		if (live.kind !== "window") return;
+		expect(live.items).toEqual(turn);
+
+		const page = planTranscriptPage(history, {before: "u1", limit: 5});
+		expect(page.kind).toBe("page");
+		if (page.kind !== "page") return;
+		expect(page.items).toEqual(older);
+		expect(page.next).toBeNull();
+
+		const rows = chatRows({
+			older: mergeOlder([], page.items),
+			tail: live.items,
+			omitted: live.omitted.items,
+			loading: false,
+			atOldest: true,
+		});
+		const ids = rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []));
+		expect(ids).toEqual(history.map((item) => item.id));
+		expect(new Set(ids).size).toBe(ids.length);
 	});
 });


### PR DESCRIPTION
`planTranscriptWindow` walked the newest-first group loop with no floor under the newest group, so a single exchange that alone exceeded `TRANSCRIPT_WINDOW_ITEM_LIMIT` (40 items) or `TRANSCRIPT_WINDOW_BYTE_LIMIT` (256,000 bytes) stopped the loop on its first iteration and returned `items: []`. An empty window is not a refusal, so `foldItem` committed it — and since `foldItem` re-plans over `transcript.items` rather than full history, the tail was then gone from state and the rendered transcript collapsed to the "Load earlier messages" head row. One agentic turn is one group, so a turn of 40 tool calls did it on its own, several times a session.

The fix is the clause `planTranscriptPage` already carries: `if (stop !== null && taken.length > 0)`. The newest group in range is carried whole even when it alone exceeds a bound; every group older than it still has to fit. The invariant that mattered was never "never exceed a bound" — it was "never split a group", and that one is unchanged.

Tests:

- `window.unit.test.ts` — the old "returns an empty window rather than half an exchange" case is rewritten to assert the newest exchange is kept whole; two new cases cover a 45-item turn (item arm) and a 34-item turn over 256,000 bytes (byte arm); one more asserts older exchanges are still dropped around an oversized newest one. The 200-seed property now excepts the newest group from both bounds, asserts the window is never empty over a live tail, and keeps the never-split and omission-metadata checks as they were.
- `fold.unit.test.ts` (new) — drives `foldItem` item by item through a turn that crosses the item bound mid-turn and asserts the tail never drops to zero, with a second case that seeds an older exchange and asserts it is dropped exactly once while the growing turn stays whole.
- `rows.unit.test.ts` — pages over a tail carrying an oversized group: `planTranscriptPage` with `before` set at the group's opening item returns the exchange older than it, and `chatRows` renders every item exactly once.

Each new assertion was flip-verified: reverting the one-clause change reds 8 of them across the three files.

`pnpm --filter @kampus/tuval test` is green (1358 tests) and `pnpm typecheck` passes.

Fixes #8031

## Deviations

None.
