### PR TITLE
fix: The desk picker offers the shell's own row, and opening it binds a window the page cannot render

### DIFF
--- a/apps/tuval/src/shell/picker/entries.unit.test.ts
+++ b/apps/tuval/src/shell/picker/entries.unit.test.ts
@@ -3,6 +3,7 @@ import {Effect, Option} from "effect";
 import {ProcessId} from "../../process/process.ts";
 import {ProgramId} from "../../registry/program.ts";
 import type {TableRow} from "../../table/row.ts";
+import {shellId, shellProgram, unwiredShellEffects} from "../program.ts";
 import {flatten, processEntries, programEntries, readEntries} from "./entries.ts";
 import {pickerHarness, programRow} from "./fixtures.ts";
 
@@ -76,6 +77,28 @@ describe("picker entries", () => {
 				["p-1"],
 			);
 			assert.lengthOf(flatten(answer), 2);
+		}),
+	);
+
+	it.effect("offers neither the shell's own row nor its running process (#7946)", () =>
+		Effect.gen(function* () {
+			const shell = shellProgram({effects: unwiredShellEffects});
+			const answer = yield* Effect.scoped(
+				Effect.gen(function* () {
+					const harness = yield* pickerHarness([shell, programRow("counter")]);
+					yield* harness.seed("shell-process", shellId);
+					yield* harness.seed("p-1", "counter");
+					return yield* readEntries.pipe(Effect.provide(harness.layer));
+				}),
+			);
+			assert.deepStrictEqual(
+				answer.programs.map((entry) => entry.programId),
+				[ProgramId.make("counter")],
+			);
+			assert.deepStrictEqual(
+				answer.processes.map((entry) => entry.processId),
+				["p-1"],
+			);
 		}),
 	);
 });

--- a/apps/tuval/src/shell/picker/open.unit.test.ts
+++ b/apps/tuval/src/shell/picker/open.unit.test.ts
@@ -9,6 +9,7 @@ import {Effect} from "effect";
 import type {AnyProgram} from "../../registry/program.ts";
 import {readCommandLine} from "../commands/line.ts";
 import type {ShellMsg} from "../core/machine.ts";
+import {shellId, shellProgram, unwiredShellEffects} from "../program.ts";
 import {noEntries, type PickerEntries, programEntries} from "./entries.ts";
 import {
 	pickerHarness,
@@ -28,6 +29,11 @@ const rows: ReadonlyArray<AnyProgram> = [
 	programRow("counter", {label: "Counter"}),
 	programRow("indexer", {renderer: false}),
 ];
+/** The registry a real desk serves: the shipped shell row beside the rows a window can hold. */
+const withShell: ReadonlyArray<AnyProgram> = [
+	shellProgram({effects: unwiredShellEffects}),
+	...rows,
+];
 
 interface Run {
 	readonly msgs: ReadonlyArray<ShellMsg>;
@@ -37,6 +43,7 @@ interface Run {
 const run = (
 	intent: PickerIntent,
 	options?: {
+		readonly rows?: ReadonlyArray<AnyProgram>;
 		readonly seed?: ReadonlyArray<readonly [string, string, string | undefined]>;
 		readonly spawnFails?: string;
 	},
@@ -44,7 +51,7 @@ const run = (
 	Effect.scoped(
 		Effect.gen(function* () {
 			const harness = yield* pickerHarness(
-				rows,
+				options?.rows ?? rows,
 				options?.spawnFails === undefined ? undefined : {spawnFails: options.spawnFails},
 			);
 			for (const [id, program, parent] of options?.seed ?? []) {
@@ -99,6 +106,20 @@ describe("choosing a program", () => {
 		}),
 	);
 
+	it.effect("refuses the shell's own row, so no second desk is spawned into a window (#7946)", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(openProgram(window, shellId), {rows: withShell});
+			assert.deepStrictEqual(answer.spawns, []);
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "shell"}},
+				},
+			]);
+		}),
+	);
+
 	it.effect("turns a failed spawn into a refusal rather than a failure the caller must catch", () =>
 		Effect.gen(function* () {
 			const answer = yield* run(openProgram(window, programId("counter")), {
@@ -143,6 +164,22 @@ describe("attaching to a running process", () => {
 					type: "window.setView",
 					windowId: window,
 					view: {cursor: 0, refusal: {_tag: "ProcessGone", processId: "p-gone"}},
+				},
+			]);
+		}),
+	);
+
+	it.effect("refuses the live shell process, which is the desk and not a window's contents", () =>
+		Effect.gen(function* () {
+			const answer = yield* run(attachProcess(window, shellProcessId), {
+				rows: withShell,
+				seed: [[shellProcessId, shellId, undefined]],
+			});
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "shell"}},
 				},
 			]);
 		}),
@@ -198,6 +235,24 @@ describe("the picker row and the command line are one handler", () => {
 			assert.deepStrictEqual(fromRow.spawns, [{programId: "counter", parent: shellProcessId}]);
 			assert.deepStrictEqual(fromLine.spawns, fromRow.spawns);
 			assert.deepStrictEqual(fromLine.msgs, fromRow.msgs);
+		}),
+	);
+
+	it.effect("`open shell` is refused on the command line too, not just in the picker (#7946)", () =>
+		Effect.gen(function* () {
+			const typed = typedIntent("open shell");
+			assert.isNotNull(typed);
+			if (typed === null) return;
+
+			const answer = yield* run(typed, {rows: withShell});
+			assert.deepStrictEqual(answer.spawns, []);
+			assert.deepStrictEqual(answer.msgs, [
+				{
+					type: "window.setView",
+					windowId: window,
+					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "shell"}},
+				},
+			]);
 		}),
 	);
 

--- a/apps/tuval/src/shell/program.ts
+++ b/apps/tuval/src/shell/program.ts
@@ -16,7 +16,7 @@ import {Effect} from "effect";
 import type {GraphNode} from "../ports/graph.ts";
 import {NodeId} from "../ports/graph.ts";
 import {ProcessId} from "../process/process.ts";
-import type {AnyProgram, HostHandlers, Program, RendererRef} from "../registry/program.ts";
+import type {AnyProgram, HostHandlers, Program} from "../registry/program.ts";
 import {ProgramId} from "../registry/program.ts";
 import {shellSpells} from "./commands/spells.ts";
 import {
@@ -44,12 +44,6 @@ export const shellNode = NodeId.make("shell");
  * the old one rather than replaying it into a changed state shape (#7467).
  */
 export const SHELL_VERSION = "1.1.0";
-
-/**
- * The surface's renderer, by reference. The reference is all a row carries: the browser surface
- * (#7559) owns the table that resolves this name to a renderer, so this module names React nowhere.
- */
-export const shellRenderer: RendererRef = {kind: "host-native", ref: "tuval/shell"};
 
 /**
  * What the core asks its host to do, as the kernel's own handler shape. `E` and `R` ride through to
@@ -106,6 +100,11 @@ export interface ShellProgramOptions<E = never, R = never> {
  * The shell's registry row. No public ports and no capability requests: nothing addresses the shell
  * over a port, and the #7467 records ride along as the inert data every row carries.
  *
+ * No `renderer` either, which makes the row headless: the shell *is* the desk, mounted by the page
+ * off its own process (`src/page/main.tsx`), never a window inside itself. A declared renderer put
+ * the row in both picker lists and bound a window to a name the page's table cannot resolve
+ * (#7946).
+ *
  * `spells` is the command table (`./commands/`), so every named row is registered under
  * `[shellId, ...path]` and reachable through the one registry — the palette, `help`, and an agent's
  * bridge all read the shell's commands there rather than from a second catalogue. Running one needs
@@ -123,7 +122,6 @@ export const shellProgram = <E = never, R = never>({
 		spells: shellSpells,
 		handlers: effects,
 		capabilities: [],
-		renderer: shellRenderer,
 		identity: {
 			package: "@kampus/tuval",
 			program: "shell",

--- a/apps/tuval/src/shell/program.unit.test.ts
+++ b/apps/tuval/src/shell/program.unit.test.ts
@@ -27,6 +27,7 @@ import type {AnyProgram} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
 import {applyMsg, initialState, type ShellMsg} from "./core/index.ts";
 import {defaultPrefixTable} from "./keys/index.ts";
+import {showsInAWindow} from "./picker/entries.ts";
 import {
 	SHELL_VERSION,
 	shellId,
@@ -102,11 +103,13 @@ describe("the shell as a program row", () => {
 		}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer)),
 	);
 
-	it("declares no port, requests no capability, names its renderer and is placed where the kernel runs", () => {
+	it("declares no port, requests no capability, is headless and is placed where the kernel runs", () => {
 		const shell = row();
 		assert.deepStrictEqual(shell.ports, {});
 		assert.deepStrictEqual(shell.capabilities, []);
-		assert.deepStrictEqual(shell.renderer, {kind: "host-native", ref: "tuval/shell"});
+		// The desk is not a window it can be opened inside (#7946).
+		assert.isUndefined(shell.renderer);
+		assert.isFalse(showsInAWindow(shell));
 		// The kernel's word for the Node host is `local`; there is no `node` arm on `Placement`.
 		assert.deepStrictEqual(shell.placement, {host: "local"});
 		assert.strictEqual(shell.identity.version, SHELL_VERSION);


### PR DESCRIPTION
Fixes #7946

The desk picker offered `shell` under PROGRAMS and its live process under RUNNING PROCESSES, and picking either bound the window to a process the page has no renderer for — a dead pane that survived reload, because the bind is checkpointed.

`shellProgram`'s row no longer declares a `renderer`, which makes it headless. Every gate that judges "can this fill a window" already reads `showsInAWindow`, so one removal closes all three routes at once: `programEntries` and `processEntries` drop the row and its process, `registryFrame` leaves it out of the wire catalog, and `open.ts` answers the existing `programHeadless` refusal for both `window:open shell` and `window:attach <shell-process>` before it spawns anything. The `shellRenderer` constant went with it — nothing else read it.

The desk still mounts: `main.tsx` resolves the shell process off the process-table stream by program id, never through `pageRenderers`, and the table frame is unfiltered.

Tests: the shipped `shellProgram` row now goes into the picker's own harness, so the exclusion is proven against the real row rather than a fixture — one over `readEntries` (both lists), one per refusal route in `open.unit.test.ts`, plus the typed `open shell` command line. `program.unit.test.ts` asserts the row is headless in place of its `tuval/shell` ref assertion. Full `apps/tuval` suite: 1418 passing.

## Deviations

- **Out-of-scope change** — **Said:** the criteria name `window:open shell` through `open.ts`. **Did:** also added a test for attaching to the running shell process, and one for the `open shell` command line. **Why:** both land in the same `open.ts` handler on the same `showsInAWindow` gate, and the process-row attach is the second symptom the original report named. **Disposition:** stated here.
