### PR TITLE
fix: A user turn no layer echoes keeps its local: id, so a history page shows it twice

### DIFF
--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -7,6 +7,13 @@
  * and "a page prepends without duplicating what the tail already holds" are decisions a test can
  * make without a DOM.
  *
+ * That second decision joins on **id, and then on text for a turn the layer never echoed** (#7998).
+ * Id alone cannot deliver it: the core records the operator's own turn at send time under a
+ * synthetic `local:<key>` id (`ai-agent/core/fold.ts`, `promptItem`), and a layer that emits no
+ * `user` item of its own never clears that marker — so the same turn comes back from the layer's
+ * history store under the layer's id and matches nothing in the tail. `unheld` below is the fold's
+ * `echoOf` join applied to the page/tail stitch, under the same two guards.
+ *
  * The head row is one row, never two: the loading row *replaces* the omitted-count line while a page
  * is in flight, and both disappear at the beginning of history (founder ruling, 2026-09-02).
  */
@@ -55,13 +62,63 @@ export interface ChatRowsInput {
 export const rowKey = (row: ChatRow): string =>
 	row.kind === "item" ? `item:${row.item.id}` : row.kind;
 
+/**
+ * How many still-unconfirmed turns `held` carries per text — the budget a page's own copies of
+ * those turns may claim. A count rather than a flag, so a turn sent twice can only ever cancel two
+ * page copies.
+ */
+const localTextBudget = (held: ReadonlyArray<TranscriptItem>): Map<string, number> => {
+	const budget = new Map<string, number>();
+	for (const item of held) {
+		if (item.kind !== "user" || item.local !== true) continue;
+		budget.set(item.text, (budget.get(item.text) ?? 0) + 1);
+	}
+	return budget;
+};
+
+/** Spend one unit of `budget` on `item`, or answer that it had none to spend. */
+const claimsLocal = (item: TranscriptItem, budget: Map<string, number>): boolean => {
+	if (item.kind !== "user" || item.local === true) return false;
+	const left = budget.get(item.text) ?? 0;
+	if (left === 0) return false;
+	budget.set(item.text, left - 1);
+	return true;
+};
+
+/**
+ * The `page` items `held` does not already carry, in page order.
+ *
+ * Two joins, and the second is the fold's `echoOf` with both of its guards intact: only a *layer's*
+ * item may claim a still-`local` held one, and a `local` item never claims another, so two
+ * deliberate sends of the same text stay two turns. The budget is what makes the claim one-to-one —
+ * one unconfirmed turn cancels one page copy, never every copy that shares its text.
+ *
+ * The walk is newest-first because the held `local` item is the operator's *most recent* send of
+ * that text: when a page carries several copies, the newest of them is the one that turn's echo
+ * would have been, and dropping an older copy instead would leave the same turn on screen twice.
+ */
+const unheld = (
+	held: ReadonlyArray<TranscriptItem>,
+	page: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> => {
+	const known = new Set<string>(held.map((item) => item.id));
+	const budget = localTextBudget(held);
+	const fresh: Array<TranscriptItem> = [];
+	for (let index = page.length - 1; index >= 0; index -= 1) {
+		const item = page[index];
+		if (item === undefined) continue;
+		if (known.has(item.id) || claimsLocal(item, budget)) continue;
+		fresh.push(item);
+	}
+	return fresh.reverse();
+};
+
 /** Prepend a page, dropping anything the window already holds. Oldest-first, in and out. */
 export const mergeOlder = (
 	held: ReadonlyArray<TranscriptItem>,
 	page: ReadonlyArray<TranscriptItem>,
 ): ReadonlyArray<TranscriptItem> => {
-	const known = new Set(held.map((item) => item.id));
-	const fresh = page.filter((item) => !known.has(item.id));
+	const fresh = unheld(held, page);
 	return fresh.length === 0 ? held : [...fresh, ...held];
 };
 
@@ -71,7 +128,9 @@ const parentOf = (item: TranscriptItem): ItemId | undefined =>
 
 /**
  * The list the window renders. The tail wins on a collision: an item that reached the live stream is
- * the newer copy of itself, and a page that happens to overlap the tail must not double it.
+ * the newer copy of itself, and a page that happens to overlap the tail must not double it. The
+ * collision is `unheld`'s — id, then text against a turn the tail still holds as `local` — so the
+ * surviving row keeps the `local:` id it has had since the send and its `rowKey` does not move.
  *
  * A tool row naming a parent that is also in this list is **folded under it** (founder ruling,
  * 2026-09-05): the group head carries the count and the folded rows appear only while it is
@@ -89,8 +148,7 @@ const parentOf = (item: TranscriptItem): ItemId | undefined =>
  * at the end, so no marked row is dropped and none is un-hidden.
  */
 export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
-	const inTail = new Set(input.tail.map((item) => item.id));
-	const items = [...input.older.filter((item) => !inTail.has(item.id)), ...input.tail];
+	const items = [...unheld(input.tail, input.older), ...input.tail];
 	const unfolded = input.unfolded ?? new Set<string>();
 	const present = new Set(items.map((item) => item.id));
 	const folded = new Map<string, Array<TranscriptItem>>();

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -5,11 +5,19 @@
  */
 
 import {describe, expect, it} from "vitest";
+import {promptItem} from "../../ai-agent/core/fold.ts";
 import {planTranscriptPage, planTranscriptWindow} from "../../ai-agent/history/index.ts";
 import {assistantItem, call, toolItem, transcriptOf, userItem} from "./chat.testing.ts";
+import type {ChatRow} from "./rows.ts";
 import {chatRows, mergeOlder, oldestLoadedId, rowIndexOfItem, rowKey} from "./rows.ts";
 
 const base = {older: [], tail: [], omitted: 0, loading: false, atOldest: false};
+
+/** The operator's turn exactly as the core records it on send: `local: true` under a `local:` id. */
+const sent = (key: string, text: string) => promptItem({text, key, timestamp: 1_756_000_000_000});
+
+const itemIds = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<string> =>
+	rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []));
 
 describe("chatRows", () => {
 	it("puts one head row above the transcript while there is history behind it", () => {
@@ -140,6 +148,61 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 	});
 });
 
+describe("a page carrying a turn the layer never echoed back", () => {
+	// The layer emits no `user` item, so the send keeps its `local:` id forever; the layer's own
+	// history store still returns that turn under the layer's id, and an id-only stitch renders
+	// both (#7998).
+	const local = sent("k1", "merhaba");
+	const fromLayer = userItem("uuid-1", "merhaba");
+
+	it("renders the turn once, keeping the copy the tail already holds", () => {
+		const rows = chatRows({...base, older: [fromLayer], tail: [local], atOldest: true});
+		expect(itemIds(rows)).toEqual(["local:k1"]);
+	});
+
+	it("keeps that row's key stable across the prepend, so the measurement cache survives", () => {
+		const beforePage = chatRows({...base, tail: [local], atOldest: true});
+		const afterPage = chatRows({
+			...base,
+			older: [userItem("uuid-0", "önce"), fromLayer],
+			tail: [local],
+			atOldest: true,
+		});
+		expect(beforePage.map(rowKey)).toEqual(["item:local:k1"]);
+		expect(afterPage.map(rowKey)).toEqual(["item:uuid-0", "item:local:k1"]);
+	});
+
+	it("leaves two deliberate sends of the same text as two rows", () => {
+		const rows = chatRows({
+			...base,
+			older: [userItem("uuid-1", "merhaba"), userItem("uuid-2", "merhaba")],
+			tail: [sent("k1", "merhaba"), sent("k2", "merhaba")],
+			atOldest: true,
+		});
+		expect(itemIds(rows)).toEqual(["local:k1", "local:k2"]);
+	});
+
+	it("spends one unconfirmed turn on one page copy, and drops the newest of them", () => {
+		const rows = chatRows({
+			...base,
+			older: [userItem("uuid-1", "merhaba"), userItem("uuid-2", "merhaba")],
+			tail: [sent("k2", "merhaba")],
+			atOldest: true,
+		});
+		expect(itemIds(rows)).toEqual(["uuid-1", "local:k2"]);
+	});
+
+	it("still joins a confirmed tail item by id alone, matching text or not", () => {
+		const rows = chatRows({
+			...base,
+			older: [userItem("uuid-1", "merhaba"), userItem("uuid-2", "merhaba")],
+			tail: [userItem("uuid-2", "merhaba")],
+			atOldest: true,
+		});
+		expect(itemIds(rows)).toEqual(["uuid-1", "uuid-2"]);
+	});
+});
+
 describe("mergeOlder", () => {
 	it("prepends a page oldest-first and never doubles an item it already holds", () => {
 		const held = [userItem("c"), assistantItem("d")];
@@ -150,6 +213,24 @@ describe("mergeOlder", () => {
 	it("returns the same array when the page adds nothing, so no re-render is provoked", () => {
 		const held = [userItem("a")];
 		expect(mergeOlder(held, [userItem("a")])).toBe(held);
+	});
+
+	it("drops a page copy of a turn it already holds as unconfirmed, and keeps dropping it", () => {
+		const held = [sent("k1", "merhaba"), assistantItem("d")];
+		const first = mergeOlder(held, [userItem("uuid-0", "önce"), userItem("uuid-1", "merhaba")]);
+		expect(first.map((item) => item.id)).toEqual(["uuid-0", "local:k1", "d"]);
+		expect(mergeOlder(first, [userItem("uuid-1", "merhaba")])).toBe(first);
+	});
+
+	it("leaves a page copy alone when the held turn is confirmed, whatever its text", () => {
+		const held = [userItem("b", "merhaba")];
+		expect(mergeOlder(held, [userItem("a", "merhaba")]).map((item) => item.id)).toEqual(["a", "b"]);
+	});
+
+	it("never lets one unconfirmed turn cancel two page copies of the same text", () => {
+		const held = [sent("k1", "merhaba")];
+		const merged = mergeOlder(held, [userItem("a", "merhaba"), userItem("b", "merhaba")]);
+		expect(merged.map((item) => item.id)).toEqual(["a", "local:k1"]);
 	});
 });
 


### PR DESCRIPTION
The page/tail stitch in `apps/tuval/src/shell/chat/rows.ts` joined on `item.id` alone. The core
records the operator's turn at send time under a synthetic `local:<key>` id, and a layer that never
emits a `user` item of its own never clears that marker — so when the same turn comes back from the
layer's own history store under the layer's id, it matches nothing in the tail and both copies
render.

`unheld` is now the one join both `chatRows` and `mergeOlder` run: id first, then the fold's
`echoOf` rule for a turn still marked `local`. Both of `echoOf`'s guards are kept — only a layer's
item may claim a `local` held one, and a `local` item never claims another, so two deliberate sends
of the same text stay two turns. A per-text budget makes the claim one-to-one, so one unconfirmed
turn cancels one page copy rather than every copy sharing its text, and the walk is newest-first
because the held `local` item is the operator's most recent send of that text.

The tail's copy is the one that survives, so the row keeps the `local:` id it has had since the send
and its `rowKey` does not move across the prepend.

Six tests cover it, and all six were run against the old id-only join first and failed there.

Fixes #7998

## Deviations

- **Out-of-scope change** — **Said:** #7998 names the page/tail join in `rows.ts`. **Did:** also
  added two `mergeOlder` cases the criteria did not ask for — a confirmed held turn leaving a
  same-text page copy alone, and one unconfirmed turn never cancelling two page copies.
  **Why:** the budget and the `local`-only guard are the two ways this join can go wrong silently,
  and criterion 5 asks `mergeOlder` to carry the same guards as `chatRows`. **Disposition:** stated
  here.
- **Known defect left unfixed** — **Said:** criterion 7 asks that `pnpm --filter @kampus/tuval test`
  pass. **Did:** it passes, but `src/shell/program.unit.test.ts` reds at random on a 5000ms timeout,
  roughly one run in three, on this branch and on an untouched `origin/main`. **Why:** it is a
  kernel-boot test under an oversubscribed fork pool, unrelated to this pure array join, and it is
  already filed with this exact file and line named — #7964. **Disposition:** left to #7964.
