### PR TITLE
fix: The shared CommandPalette marks its active row by colour alone

### DIFF
--- a/apps/tuval/src/palette/palette.css
+++ b/apps/tuval/src/palette/palette.css
@@ -54,23 +54,6 @@
 	min-width: 0;
 }
 
-/*
- * The active row is marked twice: the shared component's filled background, and a leading caret
- * glyph added here. Pillar 4 forbids signalling state by colour alone, so the glyph is not
- * decoration — it is the second channel.
- */
-.tuval-palette .kp-command-palette__option[data-active]::before {
-	content: "\203A";
-	color: var(--accent);
-	font: var(--t-mono);
-}
-
-.tuval-palette .kp-command-palette__option:not([data-active])::before {
-	content: "";
-	/* Reserves the caret's column so accepting a row does not shift the list sideways. */
-	inline-size: 1ch;
-}
-
 /* The component scrolls the active row into view itself, and this pins that to a jump whatever an
    ancestor asks for: nothing here carries meaning on motion (Pillar 4), so a reduced-motion reader
    and everyone else get the same instant move. */

--- a/packages/design/src/CommandPalette.css
+++ b/packages/design/src/CommandPalette.css
@@ -131,6 +131,22 @@
 	background: var(--accent-faint);
 }
 
+/* Every row reserves the caret's column, so moving the active row cannot shift the list sideways.
+   The mono font is what makes `1ch` and the glyph's advance the same width. */
+.kp-command-palette__option::before {
+	content: "";
+	flex: none;
+	inline-size: 1ch;
+	font: var(--t-mono);
+}
+
+/* Pillar 4 forbids signalling state by colour alone, so this glyph is the second channel beside
+   the fill above — not decoration, and not a swap for it. */
+.kp-command-palette__option[data-active]::before {
+	content: "\203A";
+	color: var(--accent);
+}
+
 .kp-command-palette__option[aria-disabled="true"] {
 	color: var(--text-muted);
 	cursor: not-allowed;


### PR DESCRIPTION
The shared `CommandPalette` marked its active result row with `background: var(--accent-faint)` and
nothing else. Pillar 4 forbids signalling state by colour alone, and the palette is keyboard-first —
which row Enter takes is the most important thing on the surface, and it was the one thing carried on
colour. Tuval already added a caret in its own stylesheet, so the fix existed at the wrong layer and
the shared component's other consumer, the atolye exhibit, got none of it.

Both rules now live unscoped in `packages/design/src/CommandPalette.css` and Tuval's copy is deleted.
The fill is untouched; the caret is added beside it, not swapped in for it.

LAW-SOURCE: manifest-prose (`fabrika ui law` exits 13 — this repo ships no typed
`design-prohibitions.json`, so `design-system-manifest.md`'s prose prohibitions are the law read).

## What the rendered surface does now

`/lab/atolye/command-palette` with the palette open, measured in the running app:

| | active row | inactive rows |
|---|---|---|
| `::before` content | `"›"` | `""` |
| `::before` width | 7.797px | 7.797px |
| `::before` colour | `rgb(229, 77, 46)` = `--accent` | inherited |
| row left edge | 335px | 335px |

Every row's column is the same width, so moving the active row does not shift the list horizontally.
`aria-selected` is still carried, and no page errors were raised.

## Held out of scope, per the issue's triage notes

Whether `--accent-faint` against `--surface-raised` clears a non-text contrast floor is not measured
here, and `--accent-faint` was not weakened on the strength of the caret landing. The
`.kp-command-palette__scope[data-active]` rules at lines 263 and 280 are a different element and were
not touched.

## Deviations

- **Said:** move both of Tuval's rules across, the active `::before` and the `:not([data-active])::before` reservation. **Did:** put the reservation on every row rather than mirroring `:not([data-active])`, gave it `font: var(--t-mono)`, and added `flex: none`. **Why:** Tuval's reservation set `1ch` without a font, which was safe only because Tuval's whole palette is mono. In the shared component the rest of the row is `--t-body`, so `1ch` would have been measured in one font and the glyph's advance in another — the exact horizontal shift the first acceptance criterion forbids. One shared `::before` makes both states one width; `flex: none` stops a cramped row shrinking the column. Tuval renders identically either way. **Disposition:** carried into this PR; the measurements above are the check.
- **Said:** attach `fabrika ui render` captures as evidence via `fabrika ui evidence`. **Did:** opened this PR with no captures and no evidence comment. **Why:** the verb exits 11 on the first run and the re-run. `design-harness.json` gates readiness on `/api/health`, which Vite proxies to the `alchemy dev` worker on :1337, and in this environment that worker cannot boot — the Cloudflare API returns `Unauthorized: Authentication error` on `GET /accounts/{account_id}/flagship/apps`. The surface itself is reachable: the SPA route answers 200 while `/api/health` answers 502, so a client-only surface is blocked by a backend precondition it does not use. **Disposition:** named here rather than shipped silently; follow-up filed on the harness coupling. `review-ui` owns whether an unattached-evidence PR is acceptable.
- **Said:** render, look, fix — and never judge from CSS alone as if you looked. **Did:** rendered the surface against the Vite dev server and read it from the pixels plus the computed `::before` metrics, before and after the change. **Why:** the harness's record channel was unavailable and this shell carries no `claude-in-chrome` tools, so the choice was between an unsanctioned look and no look at all. From the image: the caret sits in its own gutter, icons and copy hold the same x and the same baseline across active and inactive rows, and the glyph reads clearly in accent against the fill. **Disposition:** the look happened; it is not a substitute for the verb's validated captures, and it is not offered as evidence.
- **Said:** Pillar 2 — never ship a Unicode functional glyph as an icon. **Did:** shipped the caret glyph as the active-row marker, as the issue's scope and acceptance criteria name. **Why:** the reading taken is that a state marker in a row's gutter is not an icon in the idiom's sense — it names no function, is not a control, and is not one of the three partitions ADR 0166 draws (function / affect / key-legend). Tuval already ships this exact glyph. Substituting a Lucide chevron would have meant changing `CommandPalette.tsx` against an issue that scoped the work to CSS. **Disposition:** flagged because the boundary is genuinely unruled; follow-up filed. If `review-ui` reads it the other way, the fix is a component change and a new ticket.

## Checks

- `pnpm typecheck` — 0 errors across 1003 files
- `pnpm lint` — clean
- `@kampus/design` tests — 112 passed, including `kp-class-coverage`
- `fabrika build check --surface code` refuses rather than greens: no surface validates a CSS-only
  diff, so the three commands above were run directly

Fixes #7983
