### PR TITLE
fix: Tuval removes permission cards before the backend answers

### DIFF
--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -597,7 +597,12 @@ declared data rather than hiding in a layer.
 layer. It holds no Effect and names no backend: each Cmd is the name of work a handler performs, and
 the Sub is the name of the layer's event stream. Every refusal is data — a prompt outside `ready`, an
 answer to a card nobody raised, a mode the agent does not offer each record an `AgentFailure` and
-emit no Cmd, so the window renders the refusal instead of a crash taking the process with it.
+emit no Cmd, so the window renders the refusal instead of a crash taking the process with it. A
+permission card is the one piece of that state with a lifetime of its own: answering marks it
+`answering` and it leaves only on a confirmation naming the same raising of it, so a card that
+disappears means the agent settled the request rather than that a decision was sent
+([#8006](https://github.com/kamp-us/phoenix/issues/8006)). A confirmation that never comes leaves it
+`unresolved`, which offers no second answer — the authorization may already stand.
 
 **The handlers.** `src/ai-agent/handlers/` is the one generic handler set. Each handler yields the
 service and calls one of its members; a layer's typed error becomes a `failed` Msg carrying the tag

--- a/apps/tuval/src/ai-agent-fixtures/permissions.ts
+++ b/apps/tuval/src/ai-agent-fixtures/permissions.ts
@@ -1,0 +1,35 @@
+/**
+ * Permission-card builders, for every tier that puts one in a session state.
+ *
+ * It lives beside the transcript builders rather than under `src/ai-agent/` for their reason: the
+ * modules under test are the ones that own these shapes, and a fixture they imported would be a
+ * second source for the type they declare.
+ */
+
+import type {
+	PendingPermission,
+	PermissionProgress,
+	PermissionRequest,
+} from "../ai-agent/ports/index.ts";
+
+export const permissionCard = (overrides: Partial<PermissionRequest> = {}): PermissionRequest => ({
+	title: "Run a command",
+	displayName: "bash",
+	description: "The agent wants to run a shell command in the project.",
+	input: {command: "rm -rf build"},
+	offersAlways: true,
+	...overrides,
+});
+
+/** One entry of `state.permissions`. `seq` defaults to the first raising of a fresh session. */
+export const pendingPermission = (
+	overrides: {
+		readonly request?: PermissionRequest;
+		readonly seq?: number;
+		readonly progress?: PermissionProgress;
+	} = {},
+): PendingPermission => ({
+	request: overrides.request ?? permissionCard(),
+	seq: overrides.seq ?? 1,
+	progress: overrides.progress ?? {status: "open"},
+});

--- a/apps/tuval/src/ai-agent/core/failures.ts
+++ b/apps/tuval/src/ai-agent/core/failures.ts
@@ -55,6 +55,24 @@ export const unknownRequest = (request: string): AgentFailure => ({
 	detail: `no permission request "${request}" is pending`,
 });
 
+/**
+ * A second answer to a card whose first one is not settled — a repeated click, or the other window
+ * over this process (#8006). It wears the answer call's own tag so the window renders it beside the
+ * card, and a `reason` no error class enumerates, exactly as `portRefused` does: the refusal is the
+ * core's, and no backend can raise it.
+ */
+export const answerNotOffered = (
+	request: string,
+	status: "answering" | "unresolved",
+): AgentFailure => ({
+	tag: UNKNOWN_REQUEST,
+	reason: status === "answering" ? "awaiting-confirmation" : "unresolved",
+	detail:
+		status === "answering"
+			? `permission request "${request}" is already answered and awaiting confirmation`
+			: `permission request "${request}" has an answer whose outcome is unknown; only the agent can settle it`,
+});
+
 export const modeUnsupported = (mode: string, available: ReadonlyArray<string>): AgentFailure => ({
 	tag: MODE_UNSUPPORTED,
 	reason: null,

--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -16,6 +16,8 @@ import type {AgentEvent, AgentFailure, Phase} from "../events.ts";
 import {isRefusal, planTranscriptWindow} from "../history/index.ts";
 import {
 	ItemId,
+	type PendingPermission,
+	type PermissionProgress,
 	type TranscriptItem,
 	type TranscriptPayload,
 	type UserItem,
@@ -112,6 +114,41 @@ export const dropRequest = (state: AiAgentSessionState, request: string): AiAgen
 	permissions: without(state.permissions, request),
 });
 
+/** A card whose answer is out. The narrowing is what lets a caller read the decision unguarded. */
+export type AnsweringPermission = PendingPermission & {
+	readonly progress: Extract<PermissionProgress, {readonly status: "answering"}>;
+};
+
+/**
+ * The card one answer's confirmation belongs to, or `null` when it belongs to nothing any more.
+ *
+ * Both operands have to match: the id says which card, and the `seq` says which *raising* of that
+ * id. A reply that outlived its own card is stale, and clearing whatever sits under the id would
+ * settle a request nobody has answered.
+ */
+export const awaitingAnswer = (
+	state: AiAgentSessionState,
+	request: string,
+	seq: number,
+): AnsweringPermission | null => {
+	const held = state.permissions[request];
+	if (held === undefined || held.seq !== seq) return null;
+	return held.progress.status === "answering" ? {...held, progress: held.progress} : null;
+};
+
+/** The card as it stands once its answer's outcome turns out to be unknown. */
+export const unresolvedAnswer = (
+	state: AiAgentSessionState,
+	request: string,
+	held: AnsweringPermission,
+): AiAgentSessionState => ({
+	...state,
+	permissions: {
+		...state.permissions,
+		[request]: {...held, progress: {status: "unresolved", decision: held.progress.decision}},
+	},
+});
+
 /**
  * The two phases only the core's own cells may enter. `start` and `reconnect` are what put a
  * session into an open, and `started` or `failed` are the only ways out of one, so a layer cannot
@@ -158,8 +195,20 @@ export const foldEvent = (
 			return {...state, transcript: foldItem(state.transcript, event.item, limits)};
 		case "phase":
 			return coreOwned(event.phase) ? state : {...state, phase: event.phase};
-		case "permission":
-			return {...state, permissions: {...state.permissions, [event.request]: event.detail}};
+		// A raising stamps the next `seq`, which is what makes a card's identity the raising rather
+		// than the id: a backend that re-uses a request id gets a second card, and the first card's
+		// answer can no longer settle it (#8006).
+		case "permission": {
+			const seq = state.permissionsRaised + 1;
+			return {
+				...state,
+				permissionsRaised: seq,
+				permissions: {
+					...state.permissions,
+					[event.request]: {request: event.detail, seq, progress: {status: "open"}},
+				},
+			};
+		}
 		case "permission-resolved":
 			return dropRequest(state, event.request);
 		case "mode":

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -14,14 +14,25 @@
 import {defineMachine, type Machine} from "@demlik/tea";
 import {sameModel} from "../ports/index.ts";
 import {
+	answerNotOffered,
 	modelUnsupported,
 	modeUnsupported,
 	noSessionToResume,
 	promptRefused,
 	startRefused,
+	UNKNOWN_REQUEST,
 	unknownRequest,
 } from "./failures.ts";
-import {foldEvent, foldItem, phaseAfterFailure, promptItem, type WindowLimits} from "./fold.ts";
+import {
+	awaitingAnswer,
+	dropRequest,
+	foldEvent,
+	foldItem,
+	phaseAfterFailure,
+	promptItem,
+	unresolvedAnswer,
+	type WindowLimits,
+} from "./fold.ts";
 import {
 	type AiAgentSessionCmd,
 	type AiAgentSessionMsg,
@@ -143,26 +154,62 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 			event: (state, msg) =>
 				state.phase === "gone" ? [state, noCmds] : [foldEvent(state, msg.event, limits), noCmds],
 
-			answer: (state, msg) =>
-				state.permissions[msg.request] === undefined
-					? [{...state, failure: unknownRequest(msg.request)}, noCmds]
-					: [
-							{
-								...state,
-								permissions: Object.fromEntries(
-									Object.entries(state.permissions).filter(([id]) => id !== msg.request),
-								),
-								failure: null,
-							},
-							[
-								{
-									type: "aiAgent.answer",
-									request: msg.request,
-									decision: msg.decision,
-									...(msg.message === undefined ? {} : {message: msg.message}),
-								},
-							],
-						],
+			// The card stays, marked `answering`, until a confirmation clears it (#8006): a card that
+			// left on the click would read as an answer that succeeded before its outcome was known,
+			// and the other window over this process would lose it too.
+			answer: (state, msg) => {
+				const held = state.permissions[msg.request];
+				if (held === undefined) return [{...state, failure: unknownRequest(msg.request)}, noCmds];
+				if (held.progress.status !== "open") {
+					return [{...state, failure: answerNotOffered(msg.request, held.progress.status)}, noCmds];
+				}
+				return [
+					{
+						...state,
+						permissions: {
+							...state.permissions,
+							[msg.request]: {...held, progress: {status: "answering", decision: msg.decision}},
+						},
+						failure: null,
+					},
+					// The republish goes first, for `reconnect`'s reason: the pending set is an outbound
+					// projection nothing but an event pushes, and the mark this commit just made rides
+					// no event, so a window routed over the port would never see it (#7979's shape).
+					[
+						{type: "aiAgent.republish"},
+						{
+							type: "aiAgent.answer",
+							request: msg.request,
+							seq: held.seq,
+							decision: msg.decision,
+							...(msg.message === undefined ? {} : {message: msg.message}),
+						},
+					],
+				];
+			},
+
+			answered: (state, msg) =>
+				awaitingAnswer(state, msg.request, msg.seq) === null
+					? [state, noCmds]
+					: [{...dropRequest(state, msg.request), failure: null}, [{type: "aiAgent.republish"}]],
+
+			// The three outcomes the criteria keep apart: the backend says the request is gone, so the
+			// card goes with it; anything else leaves the answer's fate unknown, and an `unresolved`
+			// card offers no second answer, because the authorization it carried may already stand.
+			answerFailed: (state, msg) => {
+				const held = awaitingAnswer(state, msg.request, msg.seq);
+				if (held === null) return [state, noCmds];
+				const settled = msg.failure.tag === UNKNOWN_REQUEST;
+				return [
+					{
+						...(settled
+							? dropRequest(state, msg.request)
+							: unresolvedAnswer(state, msg.request, held)),
+						failure: msg.failure,
+					},
+					[{type: "aiAgent.republish"}],
+				];
+			},
 
 			setMode: (state, msg) =>
 				state.modes.available.includes(msg.mode)

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -7,6 +7,7 @@
 
 import {applyCellChecked} from "@demlik/tea";
 import {describe, expect, it} from "vitest";
+import {pendingPermission} from "../../ai-agent-fixtures/permissions.ts";
 import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 import type {AgentEvent} from "../events.ts";
 import {Mode, type ModelRef, type PermissionRequest, type TranscriptItem} from "../ports/index.ts";
@@ -281,7 +282,9 @@ describe("event", () => {
 			sessionId: "session-1",
 			event: {kind: "permission", request: "req-1", detail: card},
 		});
-		expect(asked.permissions).toEqual({"req-1": card});
+		expect(asked.permissions).toEqual({
+			"req-1": {request: card, seq: 1, progress: {status: "open"}},
+		});
 		const [settled] = apply(asked, {
 			type: "event",
 			sessionId: "session-1",
@@ -342,15 +345,29 @@ describe("event", () => {
 });
 
 describe("answer", () => {
-	it("removes the card it answers and asks the layer to decide it", () => {
-		const pending = started({permissions: {"req-1": card}});
-		const [state, cmds] = apply(pending, {
-			type: "answer",
-			request: "req-1",
-			decision: "allow-once",
+	const raised = (over: Partial<AiAgentSessionState> = {}): AiAgentSessionState =>
+		started({
+			permissions: {"req-1": pendingPermission({request: card, seq: 4})},
+			permissionsRaised: 4,
+			...over,
 		});
-		expect(state.permissions).toEqual({});
-		expect(cmds).toEqual([{type: "aiAgent.answer", request: "req-1", decision: "allow-once"}]);
+
+	const answerOnce = (
+		state: AiAgentSessionState,
+	): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+		apply(state, {type: "answer", request: "req-1", decision: "allow-once"});
+
+	it("keeps the card, marks it answering and asks the layer to decide it", () => {
+		const [state, cmds] = answerOnce(raised());
+		expect(state.permissions["req-1"]).toEqual({
+			request: card,
+			seq: 4,
+			progress: {status: "answering", decision: "allow-once"},
+		});
+		expect(cmds).toEqual([
+			{type: "aiAgent.republish"},
+			{type: "aiAgent.answer", request: "req-1", seq: 4, decision: "allow-once"},
+		]);
 	});
 
 	it("refuses an id no card is pending under", () => {
@@ -361,6 +378,105 @@ describe("answer", () => {
 		});
 		expect(state.failure?.tag).toBe("tuval/ai-agent/UnknownRequest");
 		expect(cmds).toEqual([]);
+	});
+
+	// The second click, and the other window over this process: one shared card, one answer.
+	it("refuses a second answer while the first is awaiting confirmation", () => {
+		const [answering] = answerOnce(raised());
+		const [twice, cmds] = apply(answering, {
+			type: "answer",
+			request: "req-1",
+			decision: "deny",
+		});
+		expect(twice.failure?.reason).toBe("awaiting-confirmation");
+		expect(twice.permissions["req-1"]?.progress).toEqual({
+			status: "answering",
+			decision: "allow-once",
+		});
+		expect(cmds).toEqual([]);
+	});
+
+	it("refuses another answer to a card whose outcome is unknown", () => {
+		const [state, cmds] = answerOnce(
+			raised({
+				permissions: {
+					"req-1": pendingPermission({
+						request: card,
+						seq: 4,
+						progress: {status: "unresolved", decision: "deny"},
+					}),
+				},
+			}),
+		);
+		expect(state.failure?.reason).toBe("unresolved");
+		expect(cmds).toEqual([]);
+	});
+
+	it("drops the card on the confirmation that names its own raising", () => {
+		const [answering] = answerOnce(raised());
+		const [confirmed, cmds] = apply(answering, {type: "answered", request: "req-1", seq: 4});
+		expect(confirmed.permissions).toEqual({});
+		expect(confirmed.failure).toBeNull();
+		expect(cmds).toEqual([{type: "aiAgent.republish"}]);
+	});
+
+	// The card is still there while the confirmation is out — the delayed-confirmation case.
+	it("leaves the card standing until its confirmation arrives", () => {
+		const [answering] = answerOnce(raised());
+		expect(Object.keys(answering.permissions)).toEqual(["req-1"]);
+	});
+
+	it("lets the backend's own resolution settle a card whose answer is still out", () => {
+		const [answering] = answerOnce(raised());
+		const [settled] = apply(answering, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "permission-resolved", request: "req-1", decision: "allow-once"},
+		});
+		expect(settled.permissions).toEqual({});
+	});
+
+	it("refuses a confirmation for a later raising of the same id", () => {
+		const [answering] = answerOnce(raised());
+		const [reraised] = apply(answering, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "permission", request: "req-1", detail: card},
+		});
+		const [stale, cmds] = apply(reraised, {type: "answered", request: "req-1", seq: 4});
+		expect(stale.permissions["req-1"]).toEqual({
+			request: card,
+			seq: 5,
+			progress: {status: "open"},
+		});
+		expect(cmds).toEqual([]);
+	});
+
+	it("drops a card the layer says it no longer holds", () => {
+		const [answering] = answerOnce(raised());
+		const [state] = apply(answering, {
+			type: "answerFailed",
+			request: "req-1",
+			seq: 4,
+			failure: {tag: "tuval/ai-agent/UnknownRequest", reason: null, detail: "nothing pending"},
+		});
+		expect(state.permissions).toEqual({});
+		expect(state.failure?.tag).toBe("tuval/ai-agent/UnknownRequest");
+	});
+
+	it("leaves a card whose answer failed for any other reason unresolved", () => {
+		const [answering] = answerOnce(raised());
+		const [state] = apply(answering, {
+			type: "answerFailed",
+			request: "req-1",
+			seq: 4,
+			failure: {tag: "tuval/ai-agent/TransportError", reason: "disconnected", detail: "gone"},
+		});
+		expect(state.permissions["req-1"]?.progress).toEqual({
+			status: "unresolved",
+			decision: "allow-once",
+		});
+		expect(state.failure?.reason).toBe("disconnected");
 	});
 });
 
@@ -511,9 +627,38 @@ describe("the Cmd each Msg answers for", () => {
 			[],
 		],
 		[
-			started({permissions: {"req-1": card}}),
+			started({permissions: {"req-1": pendingPermission({request: card})}}),
 			{type: "answer", request: "req-1", decision: "deny"},
-			["aiAgent.answer"],
+			["aiAgent.republish", "aiAgent.answer"],
+		],
+		[
+			started({
+				permissions: {
+					"req-1": pendingPermission({
+						request: card,
+						progress: {status: "answering", decision: "deny"},
+					}),
+				},
+			}),
+			{type: "answered", request: "req-1", seq: 1},
+			["aiAgent.republish"],
+		],
+		[
+			started({
+				permissions: {
+					"req-1": pendingPermission({
+						request: card,
+						progress: {status: "answering", decision: "deny"},
+					}),
+				},
+			}),
+			{
+				type: "answerFailed",
+				request: "req-1",
+				seq: 1,
+				failure: {tag: "tuval/ai-agent/TransportError", reason: "disconnected", detail: "gone"},
+			},
+			["aiAgent.republish"],
 		],
 		[
 			started({modes: {current: null, available: [Mode.make("plan")]}}),

--- a/apps/tuval/src/ai-agent/core/messages.ts
+++ b/apps/tuval/src/ai-agent/core/messages.ts
@@ -34,6 +34,17 @@ export type AiAgentSessionMsg =
 			readonly decision: PermissionDecision;
 			readonly message?: string;
 	  }
+	/**
+	 * The answer's own confirmation, back from the call that carried it. `seq` names which raising
+	 * of the request was answered, so a reply that outlived its card settles nothing (#8006).
+	 */
+	| {readonly type: "answered"; readonly request: string; readonly seq: number}
+	| {
+			readonly type: "answerFailed";
+			readonly request: string;
+			readonly seq: number;
+			readonly failure: AgentFailure;
+	  }
 	| {readonly type: "setMode"; readonly mode: Mode}
 	| {readonly type: "setModel"; readonly model: ModelRef}
 	| {readonly type: "page"; readonly before: string | null; readonly limit: number}
@@ -59,6 +70,7 @@ export type AiAgentSessionCmd =
 	| {
 			readonly type: "aiAgent.answer";
 			readonly request: string;
+			readonly seq: number;
 			readonly decision: PermissionDecision;
 			readonly message?: string;
 	  }

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -11,10 +11,10 @@
 import {Predicate} from "effect";
 import {
 	isModelRef,
-	isPermissionRequest,
+	isPendingPermission,
 	isTranscriptItems,
 	isWindowOmission,
-	type PermissionRequest,
+	type PendingPermission,
 } from "../ports/index.ts";
 import {type AiAgentSessionState, type HistoryPage, phases, type UsageTotals} from "./state.ts";
 
@@ -31,8 +31,8 @@ const isUsage = (value: unknown): value is UsageTotals =>
 	isFiniteNumber(value.outputTokens) &&
 	isFiniteNumber(value.cost);
 
-const isPermissions = (value: unknown): value is Readonly<Record<string, PermissionRequest>> =>
-	Predicate.isObject(value) && Object.values(value).every(isPermissionRequest);
+const isPermissions = (value: unknown): value is Readonly<Record<string, PendingPermission>> =>
+	Predicate.isObject(value) && Object.values(value).every(isPendingPermission);
 
 const isModes = (value: unknown): boolean =>
 	Predicate.isObject(value) &&
@@ -73,6 +73,7 @@ export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionSt
 	isNullOrString(value.interrupted) &&
 	isUsage(value.usage) &&
 	isPermissions(value.permissions) &&
+	isFiniteNumber(value.permissionsRaised) &&
 	isModes(value.modes) &&
 	isModels(value.models) &&
 	isNullOrString(value.lastPrompt) &&

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -15,7 +15,7 @@ import type {
 	ItemId,
 	Mode,
 	ModelRef,
-	PermissionRequest,
+	PendingPermission,
 	TranscriptItem,
 	TranscriptPayload,
 	WindowOmission,
@@ -72,8 +72,13 @@ export interface AiAgentSessionState {
 	/** The assistant turn a restart cut short, so the window can offer the resend. */
 	readonly interrupted: ItemId | null;
 	readonly usage: UsageTotals;
-	/** Pending permission cards by request id: one arrives with an event, one leaves with an answer. */
-	readonly permissions: Readonly<Record<string, PermissionRequest>>;
+	/**
+	 * Pending permission cards by request id: one arrives with an event, and one leaves on the
+	 * confirmation of its answer rather than on the click that answered it (#8006).
+	 */
+	readonly permissions: Readonly<Record<string, PendingPermission>>;
+	/** How many cards this session has raised. Each entry's `seq` is stamped off it. */
+	readonly permissionsRaised: number;
 	readonly modes: ModeState;
 	readonly models: ModelState;
 	/** The text of the last prompt sent, for the resend affordance. */
@@ -109,6 +114,7 @@ export const initialState = (cwd: string): AiAgentSessionState => ({
 	interrupted: null,
 	usage: emptyUsage,
 	permissions: {},
+	permissionsRaised: 0,
 	modes: {current: null, available: []},
 	models: {current: null, available: []},
 	lastPrompt: null,
@@ -152,6 +158,10 @@ const markInterrupted = (
  * `failure` and `lastPage` are dropped. Both describe the run that ended: a refusal nobody can act
  * on any more, and a page the window asked a transport that no longer exists for.
  *
+ * A card that was `answering` comes back `unresolved`. The call carrying that answer went with the
+ * process, so whether the backend applied it is exactly what nobody knows — and an entry restored
+ * to `open` would offer a second answer to an authorization that may already stand (#8006).
+ *
  * Demlik's `init` may transform what the store loaded — that branch is the migration/parse hook —
  * but must emit no Cmds (`@demlik/tea` 0.12 `replay`, the "TEA contract violation" guard), so the
  * reconnect is a Msg the spawner dispatches (`../restore/checkpoint.ts`), never one scheduled here.
@@ -163,6 +173,14 @@ export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
 		phase: loaded.phase === "gone" ? "gone" : "idle",
 		transcript: {...loaded.transcript, items: markInterrupted(loaded.transcript.items, cut)},
 		interrupted: cut ?? loaded.interrupted,
+		permissions: Object.fromEntries(
+			Object.entries(loaded.permissions).map(([id, held]) => [
+				id,
+				held.progress.status === "answering"
+					? {...held, progress: {status: "unresolved", decision: held.progress.decision} as const}
+					: held,
+			]),
+		),
 		lastPage: null,
 		failure: null,
 	};

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -4,6 +4,7 @@
  */
 
 import {describe, expect, it} from "vitest";
+import {pendingPermission} from "../../ai-agent-fixtures/permissions.ts";
 import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 import type {Phase} from "../events.ts";
 import {Mode, type PermissionRequest} from "../ports/index.ts";
@@ -30,7 +31,8 @@ const saved: AiAgentSessionState = {
 		omitted: {items: 3, bytes: 120, reason: "item-limit"},
 	},
 	usage: {model: "claude-opus-5", inputTokens: 1_200, outputTokens: 340, cost: 0.031},
-	permissions: {"req-1": card},
+	permissions: {"req-1": pendingPermission({request: card, seq: 3})},
+	permissionsRaised: 3,
 	modes: {current: Mode.make("plan"), available: [Mode.make("plan"), Mode.make("build")]},
 	lastPrompt: "make the README",
 	lastPage: {items: [userItem("older-0")], hasMore: true},
@@ -41,7 +43,7 @@ describe("a save snapshot", () => {
 	it("round-trips through JSON with its permission cards and usage intact", () => {
 		const parsed = parseSessionState(JSON.parse(JSON.stringify(saved)));
 		expect(parsed).toEqual(saved);
-		expect(parsed?.permissions["req-1"]).toEqual(card);
+		expect(parsed?.permissions["req-1"]?.request).toEqual(card);
 		expect(parsed?.usage).toEqual(saved.usage);
 	});
 
@@ -54,6 +56,14 @@ describe("a save snapshot", () => {
 		expect(parseSessionState({...saved, phase: "thinking"})).toBeNull();
 		expect(parseSessionState({...saved, usage: {model: "m"}})).toBeNull();
 		expect(parseSessionState({...saved, permissions: {"req-1": {title: "no fields"}}})).toBeNull();
+		// A card with no answering state at all is the pre-#8006 shape, and it is not readable.
+		expect(parseSessionState({...saved, permissions: {"req-1": card}})).toBeNull();
+		expect(
+			parseSessionState({
+				...saved,
+				permissions: {"req-1": {request: card, seq: 1, progress: {status: "sent"}}},
+			}),
+		).toBeNull();
 		expect(
 			parseSessionState({...saved, transcript: {items: [{kind: "user"}], omitted: null}}),
 		).toBeNull();

--- a/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
@@ -274,8 +274,9 @@ describe("the AI agent handlers under a process", () => {
 					request: PERMISSION_REQUEST,
 					decision: "allow-once",
 				});
-				// The core drops the card on the `answer` Msg, but the port only clears once the
-				// layer's `permission-resolved` event has come back round the stream.
+				// The card is not dropped on the `answer` Msg any more (#8006): it is marked, published
+				// under that mark, and cleared only by the confirmation — the layer's
+				// `permission-resolved` event, or the answer call's own reply.
 				const clearedRequests = () => {
 					const latest = lastOn(log, aiAgentPortNames.permissionPending) as
 						| PermissionPayload
@@ -285,6 +286,19 @@ describe("the AI agent handlers under a process", () => {
 				yield* eventually(() => clearedRequests().length === 0);
 				assert.deepStrictEqual(clearedRequests(), []);
 				assert.deepStrictEqual(Object.keys(sessionOf(handle).permissions), []);
+
+				const announced = log
+					.filter((entry) => entry.port === aiAgentPortNames.permissionPending)
+					.map((entry) => entry.payload as PermissionPayload)
+					.flatMap((payload) =>
+						payload.kind === "pending"
+							? [payload.requests[PERMISSION_REQUEST]?.progress ?? null]
+							: [],
+					);
+				assert.deepStrictEqual(
+					announced.filter((progress) => progress?.status === "answering"),
+					[{status: "answering", decision: "allow-once"}],
+				);
 			}),
 		);
 	});

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -114,16 +114,23 @@ export const aiAgentHandlers = <RIn = never>(
 	const slot = agentSlot(options.layer);
 	const projection = transcriptProjection();
 
+	/**
+	 * `onFail` is how a call whose refusal belongs to something the core is holding open answers for
+	 * it. The default drops the failure into the session's own slot, which is right for a call that
+	 * left nothing behind; `aiAgent.answer` overrides it, because a card marked `answering` is
+	 * cleared by nothing else (#8006).
+	 */
 	const withAgent = <A>(
 		use: (agent: TuvalAiAgentApi) => Effect.Effect<A, AgentServiceError>,
 		onDone: (value: A) => Follow,
+		onFail: (failure: AgentFailure) => Follow = refusal,
 	): Effect.Effect<Follow, never, ProcessSelf> =>
 		Effect.gen(function* () {
 			const agent = yield* slot.current;
-			if (agent === null) return refusal(noSession);
+			if (agent === null) return onFail(noSession);
 			const answered = yield* Effect.result(use(agent));
 			return Result.isFailure(answered)
-				? refusal(failureOf(answered.failure))
+				? onFail(failureOf(answered.failure))
 				: onDone(answered.success);
 		});
 
@@ -177,11 +184,14 @@ export const aiAgentHandlers = <RIn = never>(
 
 		// The one handler that reads the committed state rather than folding forward from it: there
 		// is no event to fold, which is the whole point — a restored session's tail and its pending
-		// cards are already in state and nothing else will ever push them out (#7608).
+		// cards are already in state and nothing else will ever push them out (#7608). The answer
+		// cells emit it for the same reason one step on: an answer's own progress rides no event
+		// (#8006), and re-seeding is what keeps the Sub's projection from folding on past it.
 		"aiAgent.republish": () =>
 			Effect.gen(function* () {
 				const state = yield* readSession;
 				if (state === null) return nothing;
+				yield* projection.seed(state);
 				yield* emit(aiAgentPortNames.transcript, transcriptOf(state));
 				yield* emit(aiAgentPortNames.permissionPending, pendingOf(state));
 				yield* emit(aiAgentPortNames.modeState, modeStateOf(state));
@@ -218,7 +228,8 @@ export const aiAgentHandlers = <RIn = never>(
 				// The note rides the Cmd so nothing between the window and here loses it; #7875 tracks
 				// the last hop, which needs a ruling before that signature can widen.
 				(agent) => agent.answer(cmd.request, cmd.decision),
-				() => nothing,
+				() => [{type: "answered", request: cmd.request, seq: cmd.seq}],
+				(failure) => [{type: "answerFailed", request: cmd.request, seq: cmd.seq, failure}],
 			),
 
 		"aiAgent.setMode": (cmd) =>

--- a/apps/tuval/src/ai-agent/ports/index.ts
+++ b/apps/tuval/src/ai-agent/ports/index.ts
@@ -8,6 +8,7 @@
 export {isModelRef, type ModelRef, sameModel} from "./model.ts";
 export {
 	isModePayload,
+	isPendingPermission,
 	isPermissionPayload,
 	isPermissionRequest,
 	isPromptPayload,
@@ -16,8 +17,10 @@ export {
 	isWindowOmission,
 	Mode,
 	type ModePayload,
+	type PendingPermission,
 	type PermissionDecision,
 	type PermissionPayload,
+	type PermissionProgress,
 	type PermissionRequest,
 	type PromptPayload,
 	type TranscriptPagePayload,

--- a/apps/tuval/src/ai-agent/ports/payloads.ts
+++ b/apps/tuval/src/ai-agent/ports/payloads.ts
@@ -117,12 +117,37 @@ const decisions: ReadonlySet<string> = new Set<PermissionDecision>([
 ]);
 
 /**
+ * How far one card's answer has got. A card leaves the pending set on its confirmation and not on
+ * the click that answered it (#8006), so `answering` is the state a window renders while the
+ * decision is out and `unresolved` is the one it renders when that answer's outcome is unknown.
+ *
+ * `unresolved` offers no second answer: the authorization may have been applied, so re-sending one
+ * is a retry nobody asked for. Only the backend's own `permission-resolved` clears it.
+ */
+export type PermissionProgress =
+	| {readonly status: "open"}
+	| {readonly status: "answering"; readonly decision: PermissionDecision}
+	| {readonly status: "unresolved"; readonly decision: PermissionDecision};
+
+/** One card the window renders, how far its answer has got, and which raising of its id it is. */
+export interface PendingPermission {
+	readonly request: PermissionRequest;
+	/**
+	 * Which request this session has raised, counting from one. A confirmation names it, so an
+	 * answer whose reply arrives after its card was settled cannot clear a later card that happens
+	 * to carry the same request id.
+	 */
+	readonly seq: number;
+	readonly progress: PermissionProgress;
+}
+
+/**
  * `permission` — the pending set outbound, keyed by request id, and one answer inbound. A program
  * that never prompts emits an empty `pending` and is done; it declares the port all the same, so
  * the window's wiring does not change per program.
  */
 export type PermissionPayload =
-	| {readonly kind: "pending"; readonly requests: Readonly<Record<string, PermissionRequest>>}
+	| {readonly kind: "pending"; readonly requests: Readonly<Record<string, PendingPermission>>}
 	| {
 			readonly kind: "decision";
 			readonly request: string;
@@ -138,13 +163,26 @@ export const isPermissionRequest = (value: unknown): value is PermissionRequest 
 	isJsonValue(value.input) &&
 	typeof value.offersAlways === "boolean";
 
+const isProgress = (value: unknown): value is PermissionProgress =>
+	Predicate.isObject(value) &&
+	(value.status === "open" ||
+		((value.status === "answering" || value.status === "unresolved") &&
+			typeof value.decision === "string" &&
+			decisions.has(value.decision)));
+
+export const isPendingPermission = (value: unknown): value is PendingPermission =>
+	Predicate.isObject(value) &&
+	isPermissionRequest(value.request) &&
+	isNonNegativeInteger(value.seq) &&
+	isProgress(value.progress);
+
 export const isPermissionPayload = (value: unknown): value is PermissionPayload => {
 	if (!Predicate.isObject(value)) return false;
 	switch (value.kind) {
 		case "pending":
 			return (
 				Predicate.isObject(value.requests) &&
-				Object.values(value.requests).every(isPermissionRequest)
+				Object.values(value.requests).every(isPendingPermission)
 			);
 		case "decision":
 			return (

--- a/apps/tuval/src/ai-agent/ports/payloads.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/payloads.unit.test.ts
@@ -81,14 +81,47 @@ describe("permission payload", () => {
 		offersAlways: true,
 	};
 
+	const entry = {request, seq: 1, progress: {status: "open"}};
+
 	it("admits the pending set keyed by request id, empty included", () => {
-		expect(isPermissionPayload({kind: "pending", requests: {"req-1": request}})).toBe(true);
+		expect(isPermissionPayload({kind: "pending", requests: {"req-1": entry}})).toBe(true);
 		expect(isPermissionPayload({kind: "pending", requests: {}})).toBe(true);
+	});
+
+	it("admits a card whose answer is out and one whose answer's outcome is unknown", () => {
+		const progresses = [
+			{status: "answering", decision: "allow-once"},
+			{status: "unresolved", decision: "deny"},
+		];
+		expect(
+			progresses.map((progress) =>
+				isPermissionPayload({kind: "pending", requests: {"req-1": {...entry, progress}}}),
+			),
+		).toEqual([true, true]);
 	});
 
 	it("refuses a pending card missing a field the window renders", () => {
 		expect(
-			isPermissionPayload({kind: "pending", requests: {"req-1": {...request, displayName: 4}}}),
+			isPermissionPayload({
+				kind: "pending",
+				requests: {"req-1": {...entry, request: {...request, displayName: 4}}},
+			}),
+		).toBe(false);
+	});
+
+	it("refuses a card with no answering state, no raising, or an unknown one", () => {
+		expect(isPermissionPayload({kind: "pending", requests: {"req-1": request}})).toBe(false);
+		expect(
+			isPermissionPayload({
+				kind: "pending",
+				requests: {"req-1": {request, progress: entry.progress}},
+			}),
+		).toBe(false);
+		expect(
+			isPermissionPayload({
+				kind: "pending",
+				requests: {"req-1": {...entry, progress: {status: "answering"}}},
+			}),
 		).toBe(false);
 	});
 

--- a/apps/tuval/src/ai-agent/restore/checkpoint.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.ts
@@ -28,6 +28,7 @@ export const checkpointFields = [
 	"interrupted",
 	"usage",
 	"permissions",
+	"permissionsRaised",
 	"modes",
 	"models",
 	"lastPrompt",

--- a/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {describe, expect, it} from "vitest";
+import {pendingPermission} from "../../ai-agent-fixtures/permissions.ts";
 import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 import {
 	type AiAgentSessionState,
@@ -45,7 +46,8 @@ const saved: AiAgentSessionState = {
 		omitted: {items: 3, bytes: 120, reason: "item-limit"},
 	},
 	usage: {model: "claude-opus-5", inputTokens: 1_200, outputTokens: 340, cost: 0.031},
-	permissions: {"req-1": card},
+	permissions: {"req-1": pendingPermission({request: card, seq: 2})},
+	permissionsRaised: 2,
 	modes: {current: Mode.make("plan"), available: [Mode.make("plan"), Mode.make("build")]},
 	models: {
 		current: {provider: "anthropic", id: "claude-opus-5", name: "Opus 5"},
@@ -69,7 +71,7 @@ describe("what a checkpoint carries", () => {
 	it("round-trips through JSON with every field intact", () => {
 		const parsed = parseSessionState(JSON.parse(JSON.stringify(saved)));
 		expect(parsed).toEqual(saved);
-		expect(parsed?.permissions["req-1"]).toEqual(card);
+		expect(parsed?.permissions["req-1"]?.request).toEqual(card);
 		expect(parsed?.usage).toEqual(saved.usage);
 		expect(parsed?.transcript.items).toEqual(saved.transcript.items);
 		expect(parsed?.models).toEqual(saved.models);
@@ -97,6 +99,29 @@ describe("restoring a saved session", () => {
 		expect(restored.modes).toEqual(saved.modes);
 		expect(restored.models).toEqual(saved.models);
 		expect(restored.lastPrompt).toBe("make the README");
+	});
+
+	// The call carrying that answer went with the process, so whether it landed is unknown: the
+	// card comes back stating that rather than offering the buttons again (#8006).
+	it("brings a card whose answer was in flight back as unresolved", () => {
+		const inFlight: AiAgentSessionState = {
+			...saved,
+			permissions: {
+				"req-1": pendingPermission({
+					request: card,
+					seq: 2,
+					progress: {status: "answering", decision: "allow-always"},
+				}),
+			},
+		};
+		expect(restore(inFlight).permissions["req-1"]?.progress).toEqual({
+			status: "unresolved",
+			decision: "allow-always",
+		});
+	});
+
+	it("leaves a card nobody has answered exactly as it stood", () => {
+		expect(restore(saved).permissions).toEqual(saved.permissions);
 	});
 
 	it("marks the assistant turn the restart cut, in state and in the tail", () => {

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -43,6 +43,7 @@ const cutMidReply: AiAgentSessionState = {
 	interrupted: null,
 	usage: {model: "faux/faux-1", inputTokens: 10, outputTokens: 4, cost: 0},
 	permissions: {},
+	permissionsRaised: 0,
 	modes: {current: null, available: []},
 	models: {current: null, available: []},
 	lastPrompt: "read the readme",

--- a/apps/tuval/src/shell/chat/PermissionCards.tsx
+++ b/apps/tuval/src/shell/chat/PermissionCards.tsx
@@ -1,11 +1,15 @@
 /**
  * The pending permission requests, one card each.
  *
- * The card list is driven straight off `state.permissions` — the core drops a request the moment
- * its `answer` Msg lands (`../../ai-agent/core/machine.ts`), so a card disappears because the state
- * no longer holds it and never because this component remembers having answered. That is what makes
- * two windows over one process agree: they render the same map, and either one's answer clears it
- * from both.
+ * The card list is driven straight off `state.permissions`, and a card leaves it on the
+ * confirmation of its answer rather than on the click that answered it (#8006) — so a disappearing
+ * card means the agent settled the request, never that a decision has been sent. Answering marks
+ * the card instead, and every window over the process renders the same mark from the same shared
+ * state: whichever one clicks, both stop offering the buttons.
+ *
+ * An `unresolved` card offers no second answer. Its first answer may or may not have been applied,
+ * so another click would be a retry of an authorization nobody asked to repeat; only the agent's
+ * own resolution clears it.
  *
  * Each card is a named `region`: `Card` renders as a `section` labelled by its own visible title, so
  * a screen reader's landmark list distinguishes two pending requests instead of listing two unnamed
@@ -16,7 +20,7 @@
 import {Button, Card, Input} from "@kampus/design";
 import type {ReactElement} from "react";
 import {useCallback, useId, useState} from "react";
-import type {PermissionDecision, PermissionRequest} from "../../ai-agent/ports/index.ts";
+import type {PendingPermission, PermissionDecision} from "../../ai-agent/ports/index.ts";
 
 export interface PermissionAnswer {
 	readonly request: string;
@@ -24,17 +28,45 @@ export interface PermissionAnswer {
 	readonly message?: string;
 }
 
+const decisionLabel: Readonly<Record<PermissionDecision, string>> = {
+	"allow-once": "Allow once",
+	"allow-always": "Allow always",
+	deny: "Deny",
+};
+
+/** What the card says about an answer that has left but not landed. `open` says nothing. */
+function ProgressLine({
+	progress,
+}: {
+	readonly progress: PendingPermission["progress"];
+}): ReactElement | null {
+	if (progress.status === "open") return null;
+	const decision = decisionLabel[progress.decision];
+	return progress.status === "answering" ? (
+		<p className="tuval-chat-permission-progress" data-status="answering" role="status">
+			Sending “{decision}” — waiting for the agent to confirm it.
+		</p>
+	) : (
+		<p className="tuval-chat-permission-progress" data-status="unresolved" role="alert">
+			“{decision}” was not confirmed and may or may not have been applied. Only the agent can settle
+			this request now.
+		</p>
+	);
+}
+
 function PermissionCard({
 	id,
-	request,
+	pending,
 	onAnswer,
 }: {
 	readonly id: string;
-	readonly request: PermissionRequest;
+	readonly pending: PendingPermission;
 	readonly onAnswer: (answer: PermissionAnswer) => void;
 }): ReactElement {
 	const titleId = useId();
 	const [message, setMessage] = useState("");
+	const {request, progress} = pending;
+	const open = progress.status === "open";
 	const answer = useCallback(
 		(decision: PermissionDecision) => {
 			const trimmed = message.trim();
@@ -45,7 +77,12 @@ function PermissionCard({
 		[id, message, onAnswer],
 	);
 	return (
-		<Card as="section" className="tuval-chat-permission" aria-labelledby={titleId}>
+		<Card
+			as="section"
+			className="tuval-chat-permission"
+			aria-labelledby={titleId}
+			data-status={progress.status}
+		>
 			<h3 id={titleId} className="tuval-chat-permission-title">
 				{request.title}
 			</h3>
@@ -55,26 +92,41 @@ function PermissionCard({
 			<Input
 				label="Message (optional)"
 				value={message}
+				disabled={!open}
 				onChange={(event) => setMessage(event.currentTarget.value)}
 			/>
 			<div className="tuval-chat-permission-actions">
-				<Button type="button" variant="primary" size="sm" onClick={() => answer("allow-once")}>
-					Allow once
+				<Button
+					type="button"
+					variant="primary"
+					size="sm"
+					disabled={!open}
+					onClick={() => answer("allow-once")}
+				>
+					{decisionLabel["allow-once"]}
 				</Button>
 				{request.offersAlways ? (
 					<Button
 						type="button"
 						variant="secondary"
 						size="sm"
+						disabled={!open}
 						onClick={() => answer("allow-always")}
 					>
-						Allow always
+						{decisionLabel["allow-always"]}
 					</Button>
 				) : null}
-				<Button type="button" variant="danger" size="sm" onClick={() => answer("deny")}>
-					Deny
+				<Button
+					type="button"
+					variant="danger"
+					size="sm"
+					disabled={!open}
+					onClick={() => answer("deny")}
+				>
+					{decisionLabel.deny}
 				</Button>
 			</div>
+			<ProgressLine progress={progress} />
 		</Card>
 	);
 }
@@ -88,15 +140,15 @@ export function PermissionCards({
 	permissions,
 	onAnswer,
 }: {
-	readonly permissions: Readonly<Record<string, PermissionRequest>>;
+	readonly permissions: Readonly<Record<string, PendingPermission>>;
 	readonly onAnswer: (answer: PermissionAnswer) => void;
 }): ReactElement | null {
 	const entries = Object.entries(permissions);
 	if (entries.length === 0) return null;
 	return (
 		<div className="tuval-chat-permissions">
-			{entries.map(([id, request]) => (
-				<PermissionCard key={id} id={id} request={request} onAnswer={onAnswer} />
+			{entries.map(([id, pending]) => (
+				<PermissionCard key={id} id={id} pending={pending} onAnswer={onAnswer} />
 			))}
 		</div>
 	);

--- a/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
@@ -20,7 +20,15 @@ import {installDomShims, TEST_VIEWPORT} from "../ui/dom.testing.ts";
 import {type TestProcess, testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
-import {call, models, modes, permissionRequest, userItem, withTranscript} from "./chat.testing.ts";
+import {
+	call,
+	models,
+	modes,
+	pendingPermission,
+	permissionRequest,
+	userItem,
+	withTranscript,
+} from "./chat.testing.ts";
 import {initialChatView} from "./view.ts";
 
 installDomShims();
@@ -150,7 +158,7 @@ describe("permission cards", () => {
 		withTranscript([userItem("u1", "go")], {permissions: requests});
 
 	it("renders the request's fields as a named region", async () => {
-		await open(pending({r1: permissionRequest()}));
+		await open(pending({r1: pendingPermission()}));
 		const card = await screen.findByRole("region", {name: "Run a command"});
 		expect(within(card).getByText("bash")).toBeDefined();
 		expect(
@@ -160,7 +168,7 @@ describe("permission cards", () => {
 	});
 
 	it("dispatches exactly one answer per action, carrying the decision", async () => {
-		const {process} = await open(pending({r1: permissionRequest()}));
+		const {process} = await open(pending({r1: pendingPermission()}));
 		const card = await screen.findByRole("region", {name: "Run a command"});
 		await click(within(card).getByRole("button", {name: "Allow once"}));
 		await waitFor(() => expect(process.inbox().length).toBe(1));
@@ -168,7 +176,7 @@ describe("permission cards", () => {
 	});
 
 	it("carries the operator's optional message when one was typed", async () => {
-		const {process} = await open(pending({r1: permissionRequest()}));
+		const {process} = await open(pending({r1: pendingPermission()}));
 		const card = await screen.findByRole("region", {name: "Run a command"});
 		await act(async () => {
 			fireEvent.change(within(card).getByRole("textbox", {name: /Message/}), {
@@ -186,20 +194,56 @@ describe("permission cards", () => {
 	});
 
 	it("offers allow-always only when the request says it is on offer", async () => {
-		await open(pending({r1: permissionRequest({offersAlways: false})}));
+		await open(
+			pending({r1: pendingPermission({request: permissionRequest({offersAlways: false})})}),
+		);
 		const card = await screen.findByRole("region", {name: "Run a command"});
 		expect(within(card).queryByRole("button", {name: "Allow always"})).toBeNull();
 		expect(within(card).getByRole("button", {name: "Allow once"})).toBeDefined();
 		expect(within(card).getByRole("button", {name: "Deny"})).toBeDefined();
 	});
 
+	it("stops offering an answer while one is awaiting confirmation, and says so", async () => {
+		await open(
+			pending({
+				r1: pendingPermission({progress: {status: "answering", decision: "allow-once"}}),
+			}),
+		);
+		const card = await screen.findByRole("region", {name: "Run a command"});
+		for (const name of ["Allow once", "Allow always", "Deny"]) {
+			expect(within(card).getByRole("button", {name}).getAttribute("disabled")).not.toBeNull();
+		}
+		expect(
+			within(card)
+				.getByRole("textbox", {name: /Message/})
+				.getAttribute("disabled"),
+		).not.toBeNull();
+		expect(within(card).getByText(/waiting for the agent to confirm/i)).toBeDefined();
+	});
+
+	// No retry: the answer may already have been applied, so the card states the doubt instead of
+	// offering a second authorization (#8006).
+	it("offers no second answer to a card whose outcome is unknown", async () => {
+		await open(
+			pending({r1: pendingPermission({progress: {status: "unresolved", decision: "deny"}})}),
+		);
+		const card = await screen.findByRole("region", {name: "Run a command"});
+		expect(
+			within(card).getByRole("button", {name: "Deny"}).getAttribute("disabled"),
+		).not.toBeNull();
+		expect(within(card).getByText(/was not confirmed/i)).toBeDefined();
+	});
+
 	it("drops a card when the state drops it, and renders none when a process raises none", async () => {
 		const {process} = await open(
-			pending({r1: permissionRequest(), r2: permissionRequest({title: "Read a file"})}),
+			pending({
+				r1: pendingPermission(),
+				r2: pendingPermission({request: permissionRequest({title: "Read a file"})}),
+			}),
 		);
 		expect(await screen.findByRole("region", {name: "Read a file"})).toBeDefined();
 		await act(async () => {
-			await Effect.runPromise(process.commit(pending({r1: permissionRequest()})));
+			await Effect.runPromise(process.commit(pending({r1: pendingPermission()})));
 		});
 		await waitFor(() => expect(screen.queryByRole("region", {name: "Read a file"})).toBeNull());
 		expect(screen.getByRole("region", {name: "Run a command"})).toBeDefined();
@@ -313,7 +357,7 @@ describe("the composer's model picker", () => {
 describe("two windows over one process", () => {
 	it("keep their own expanded rows and share the cards and the mode", async () => {
 		const state = withTranscript([call("t1"), call("t2", {name: "grep"})], {
-			permissions: {r1: permissionRequest()},
+			permissions: {r1: pendingPermission()},
 			modes: modes(["plan", "build"], "plan"),
 		});
 		const shared = await Effect.runPromise(
@@ -351,6 +395,25 @@ describe("two windows over one process", () => {
 		await click(within(cards[0] as HTMLElement).getByRole("button", {name: "Deny"}));
 		await waitFor(() => expect(shared.inbox().length).toBe(1));
 		expect(shared.inbox()[0]).toEqual({type: "answer", request: "r1", decision: "deny"});
+
+		// And the mark that answer leaves reaches both windows, so neither offers a second one.
+		await act(async () => {
+			await Effect.runPromise(
+				shared.commit({
+					...state,
+					permissions: {
+						r1: pendingPermission({progress: {status: "answering", decision: "deny"}}),
+					},
+				}),
+			);
+		});
+		await waitFor(() => {
+			for (const card of screen.getAllByRole("region", {name: "Run a command"})) {
+				expect(
+					within(card).getByRole("button", {name: "Deny"}).getAttribute("disabled"),
+				).not.toBeNull();
+			}
+		});
 		expect(TEST_VIEWPORT.height).toBe(1_000);
 	});
 });

--- a/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
@@ -30,7 +30,7 @@ import {installDomShims} from "../ui/dom.testing.ts";
 import {testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {chatWindow} from "./ChatWindow.tsx";
-import {call, models, modes, permissionRequest, userItem, withTranscript} from "./chat.testing.ts";
+import {call, models, modes, pendingPermission, userItem, withTranscript} from "./chat.testing.ts";
 import {type ChatView, initialChatView} from "./view.ts";
 
 installDomShims();
@@ -70,7 +70,9 @@ const stateArb: fc.Arbitrary<AiAgentSessionState> = fc
 			[userItem("u1", "go"), ...calls.map((options, index) => call(`t${index}`, options))],
 			{
 				phase,
-				permissions: Object.fromEntries(requests.map((request, index) => [`r${index}`, request])),
+				permissions: Object.fromEntries(
+					requests.map((request, index) => [`r${index}`, pendingPermission({request})]),
+				),
 				modes: modes(available),
 			},
 		),
@@ -207,7 +209,7 @@ describe("the window's own primitives hold the enforced pillar-4 invariants", ()
 			const state = withTranscript(
 				[userItem("u1", "go"), call("t0", {name: "bash", input: {command: "ls"}})],
 				{
-					permissions: {r0: permissionRequest()},
+					permissions: {r0: pendingPermission()},
 					modes: modes(["plan", "build"], "plan"),
 				},
 			);

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -341,6 +341,18 @@
 	padding-block-start: var(--s-2);
 }
 
+/* Where an answer that has left but not landed says so. Colour is the second signal: the line's
+ * own words carry the state, so a card reads the same without it. */
+.tuval-chat-permission-progress {
+	margin: var(--s-2) 0 0;
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}
+
+.tuval-chat-permission-progress[data-status="unresolved"] {
+	color: var(--danger);
+}
+
 .tuval-chat-head {
 	display: flex;
 	gap: var(--s-2);

--- a/apps/tuval/src/shell/chat/chat.testing.ts
+++ b/apps/tuval/src/shell/chat/chat.testing.ts
@@ -7,14 +7,9 @@
 
 import type {AiAgentSessionState} from "../../ai-agent/core/state.ts";
 import {initialState} from "../../ai-agent/core/state.ts";
-import type {
-	JsonValue,
-	PermissionRequest,
-	ToolItem,
-	ToolStatus,
-	TranscriptItem,
-} from "../../ai-agent/ports/index.ts";
+import type {JsonValue, ToolItem, ToolStatus, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {boundToolResult, ItemId, Mode} from "../../ai-agent/ports/index.ts";
+import {pendingPermission, permissionCard} from "../../ai-agent-fixtures/permissions.ts";
 import {
 	assistantItem,
 	systemItem,
@@ -22,7 +17,14 @@ import {
 	userItem,
 } from "../../ai-agent-fixtures/transcripts.ts";
 
-export {assistantItem, systemItem, toolItem, userItem};
+export {
+	assistantItem,
+	pendingPermission,
+	permissionCard as permissionRequest,
+	systemItem,
+	toolItem,
+	userItem,
+};
 
 /** An exchange per index, so a transcript of `n` items is `n` distinct ids in a known order. */
 export const transcriptOf = (count: number, prefix = "i"): ReadonlyArray<TranscriptItem> =>
@@ -66,17 +68,6 @@ export const call = (
 	result: boundToolResult(options.output ?? "ok", options.resultLimit),
 	status: options.status ?? "ok",
 	...(options.parentId === undefined ? {} : {parentId: ItemId.make(options.parentId)}),
-});
-
-export const permissionRequest = (
-	overrides: Partial<PermissionRequest> = {},
-): PermissionRequest => ({
-	title: "Run a command",
-	displayName: "bash",
-	description: "The agent wants to run a shell command in the project.",
-	input: {command: "rm -rf build"},
-	offersAlways: true,
-	...overrides,
 });
 
 export const modes = (

--- a/apps/tuval/src/shell/chat/proof/main.tsx
+++ b/apps/tuval/src/shell/chat/proof/main.tsx
@@ -25,7 +25,7 @@ import {
 	assistantItem,
 	call,
 	modes,
-	permissionRequest,
+	pendingPermission,
 	userItem,
 	withTranscript,
 } from "../chat.testing.ts";
@@ -56,7 +56,7 @@ const state: AiAgentSessionState = withTranscript(
 		assistantItem("a2", "Done — the guard is per-window now."),
 	],
 	{
-		permissions: {"req-1": permissionRequest()},
+		permissions: {"req-1": pendingPermission()},
 		modes: modes(["default", "plan", "accept edits"], "default"),
 	},
 );


### PR DESCRIPTION
Fixes #8006.

Answering a permission card no longer removes it. The card is marked `answering` in the shared
session state and leaves only when a confirmation arrives — the answer call's own reply, or the
backend's `permission-resolved` event — so a card that disappears means the agent settled the
request, never that a decision was merely sent.

**What changed**

- `state.permissions` now holds a `PendingPermission` (`request` + `seq` + `progress`) instead of a
  bare `PermissionRequest`. `progress` is `open` / `answering` / `unresolved`, so a card that is not
  answerable cannot be represented as one that is.
- `seq` is the raising this entry belongs to, stamped from the session's `permissionsRaised`
  counter. A confirmation names it, so a reply that outlived its card settles nothing — a later
  raising of the same request id is a different card.
- The `answer` cell refuses a second answer while one is out (a repeated click, or the other window
  over the same process) and records the refusal as data under the answer's own tag.
- On the call's reply: an `UnknownRequest` drops the card (the backend no longer holds it), and any
  other failure leaves it `unresolved`. An `unresolved` card offers no second answer, because the
  authorization it carried may already stand; only the backend's own resolution clears it.
- `restore` brings an in-flight `answering` card back as `unresolved`, since the call went with the
  process.
- The card's mark rides no event, so the two answer cells emit `aiAgent.republish` — the same
  mechanism `reconnect` uses — and that handler now re-seeds the Sub's projection so the
  `permissionPending` port and the committed state cannot drift.
- `PermissionCards` disables the buttons and the note field off the shared mark and states what is
  happening: "waiting for the agent to confirm it" while an answer is out, and a `role="alert"` line
  when its outcome is unknown.

Nothing here names a backend: the obsolete/uncertain split reads the core's own `UNKNOWN_REQUEST`
tag, which `failureOf` writes for any layer's `UnknownRequest`. The Pi adapter still raises no
permission requests and its window test still asserts no card renders.

**Tests** — the answer lifecycle at the core (marking, duplicate refusal, delayed confirmation,
stale `seq`, `UnknownRequest`, and every other failure), restore's in-flight card, the port
predicate over the new shape, the handler round trip asserting the `answering` mark is published,
and the window cases including two windows over one process agreeing on the mark.

One consequence worth naming: a checkpoint written before this change holds bare `PermissionRequest`
values and no `permissionsRaised`, so `parseSessionState` refuses it and the store starts that
session fresh. Tuval is a local app with no shipped sessions, and the refusal is the predicate's
documented `null` rather than a crash.

## Deviations

- **Out-of-scope change** — **Said:** #8006 names the answer's confirmation state. **Did:** also
  made `aiAgent.republish` re-seed the Sub's transcript projection, which it did not do before.
  **Why:** the answer cells now emit that Cmd, and without the re-seed the Sub folds forward from a
  projection that is missing the mark the commit just made — the same drift #7979 fixed for the
  operator's own turn. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** distinguish a definite refusal, an obsolete request and
  an uncertain outcome. **Did:** the only failure `TuvalAiAgentApi.answer` can return is
  `UnknownRequest`, so through a live layer the uncertain arm is reachable only when the process
  holds no agent at all; the restore path is the other producer. **Why:** widening that error
  channel is a change to the pinned interface signature (#7570 ruling 3) and is not this issue's.
  **Disposition:** stated here; the uncertain arm is covered deterministically at the core and the
  restore tier.
