### PR TITLE
fix: The composer's model picker opens as an unbounded list the height of the viewport in Tuval

### DIFF
--- a/apps/tuval/src/shell/chat/chat-picker-menu-cap.unit.test.ts
+++ b/apps/tuval/src/shell/chat/chat-picker-menu-cap.unit.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer's setting pickers open as a bounded, scrollable box (#8064).
+ *
+ * The rule under test is `@kampus/design`'s, not Tuval's, so this file reads the shipped
+ * stylesheets off disk and puts them in the document, the way
+ * `chat-composer-width.unit.test.tsx` does — under Vitest's default `css: false` the component's
+ * own `import "./AgentChatInput.css"` resolves to an empty module, and every assertion over the
+ * cascade would be vacuous. Resolving through `import.meta.resolve("@kampus/design")` keeps the
+ * test pointed at the same files the component imports.
+ *
+ * The popover is portaled and rendered only while open, and jsdom runs no layout engine, so this
+ * builds the menu's own anatomy directly rather than driving the composer: what jsdom does resolve
+ * is the cascade's declared values, and the defect lived entirely there — neither
+ * `AgentChatInput.css` nor `Menu.css` capped the panel, so a 30-model catalogue grew the popover
+ * to the height of the transcript column.
+ *
+ * The anatomy's attribute names are Zag's, not this repo's: `@zag-js/anatomy` builds every part's
+ * `data-part` by kebab-casing the part name declared in `@zag-js/menu`'s `menu.anatomy.ts`, which
+ * is why the group label below is `item-group-label`.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {beforeAll, describe, expect, it} from "vitest";
+
+const designCss = (name: string): string => {
+	const entry = fileURLToPath(import.meta.resolve("@kampus/design"));
+	return readFileSync(entry.replace(/index\.ts$/, name), "utf8");
+};
+
+beforeAll(() => {
+	for (const name of ["Menu.css", "AgentChatInput.css"]) {
+		const style = document.createElement("style");
+		style.textContent = designCss(name);
+		document.head.appendChild(style);
+	}
+});
+
+const part = (name: string): HTMLElement => {
+	const element = document.createElement("div");
+	element.dataset.scope = "menu";
+	element.dataset.part = name;
+	return element;
+};
+
+/** The open picker panel: one labelled radio group of `rows`, the last of them checked. */
+const openPicker = (rows: number): HTMLElement => {
+	const content = part("content");
+	content.className = "kp-agent-chat__picker-menu";
+	const group = part("item-group");
+	group.append(part("item-group-label"));
+	for (let index = 0; index < rows; index += 1) {
+		const item = part("item");
+		item.setAttribute("role", "menuitemradio");
+		item.dataset.state = index === rows - 1 ? "checked" : "unchecked";
+		group.append(item);
+	}
+	content.append(group);
+	document.body.append(content);
+	return content;
+};
+
+interface Cap {
+	/** The absolute term's px value, resolved at jsdom's 16px root font size. */
+	readonly absolutePx: number;
+	/** The viewport-relative term as a percentage of the viewport's block size. */
+	readonly viewportPercent: number;
+}
+
+/**
+ * Reads the declared `max-height` in the `min(<absolute>, <viewport>)` shape
+ * `CommandPalette.css` already uses. A cap outside that shape has one of the two terms missing,
+ * so it is reported as absent rather than coerced into a number that would pass the bounds below.
+ */
+const declaredCap = (element: HTMLElement): Cap | null => {
+	const declared = getComputedStyle(element).getPropertyValue("max-height").trim();
+	const match = /^min\(\s*([\d.]+)rem\s*,\s*([\d.]+)d?vh\s*\)$/.exec(declared);
+	return match === null
+		? null
+		: {absolutePx: Number(match[1]) * 16, viewportPercent: Number(match[2])};
+};
+
+describe("the composer's setting picker", () => {
+	it("caps and scrolls a 30-model catalogue inside the box that holds the rows", () => {
+		const content = openPicker(30);
+		const style = getComputedStyle(content);
+
+		expect(content.querySelectorAll('[data-part="item"]')).toHaveLength(30);
+		expect(style.getPropertyValue("overflow-y")).toBe("auto");
+		expect(style.getPropertyValue("overscroll-behavior")).toBe("contain");
+
+		const cap = declaredCap(content);
+		expect(cap).not.toBeNull();
+		// Strictly under the viewport: the panel opens upward from the composer, so a cap at or
+		// over 100 would still run off a short window, which is the defect.
+		expect(cap?.viewportPercent).toBeLessThan(100);
+		expect(cap?.absolutePx).toBeGreaterThan(0);
+	});
+
+	it("scrolls the rows rather than the transcript behind them", () => {
+		const content = openPicker(30);
+		const checked = content.querySelector('[data-state="checked"]');
+
+		expect(checked).not.toBeNull();
+		// The cap is on `content` because that is the `rootEl` Zag's menu machine scrolls a
+		// highlighted item within, so arrow-keying below the fold moves this element and nothing
+		// above it.
+		expect(content.contains(checked)).toBe(true);
+		expect(declaredCap(document.body)).toBeNull();
+	});
+
+	it("leaves the group label unpinned, so no row scrolls under a sticky header", () => {
+		const content = openPicker(30);
+		const label = content.querySelector<HTMLElement>('[data-part="item-group-label"]');
+
+		expect(label).not.toBeNull();
+		expect(label && getComputedStyle(label).getPropertyValue("position")).not.toBe("sticky");
+	});
+
+	it("leaves the thinking picker's short list under the same cap, unchanged", () => {
+		const thinking = openPicker(7);
+		const model = openPicker(30);
+
+		// One rule serves both pickers, so the short list gains a cap it never reaches rather than
+		// a second declaration that could drift from the model picker's.
+		expect(declaredCap(thinking)).toEqual(declaredCap(model));
+		expect(getComputedStyle(thinking).getPropertyValue("overflow-y")).toBe("auto");
+	});
+});

--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -294,6 +294,12 @@
 .kp-agent-chat__picker-menu:where([data-scope="menu"][data-part="content"]) {
 	width: calc(var(--s-8) * 6);
 	max-width: calc(100vw - var(--s-4));
+	/* The cap belongs on `content`: that is the `rootEl` Zag's menu machine scrolls a highlighted
+	   item within, so an inner scroll box would leave arrow-key navigation scrolling the wrong
+	   element. */
+	max-height: min(26.25rem, 55dvh);
+	overflow-y: auto;
+	overscroll-behavior: contain;
 }
 
 .kp-agent-chat__picker-menu:focus-visible {


### PR DESCRIPTION
Tuval's composer pickers went through `SettingMenu`, whose popover was sized entirely by its
content — the one rule styling it set width and nothing else, and `Menu.css`'s base block declares
no `max-height` or `overflow` either. With Pi's ~30-model catalogue the panel grew to the height of
the transcript column and would run off a short window.

This caps it the way `CommandPalette.css:99` already caps its own list: `max-height:
min(26.25rem, 55dvh)`, `overflow-y: auto`, and `overscroll-behavior: contain` so a scroll at the
list's end does not carry into the transcript behind it. The cap sits on the `content` part rather
than an inner box because that is the `rootEl` Zag's menu machine scrolls a highlighted item within
(`@zag-js/menu` `menu.machine.js`, `scrollToHighlightedItem` → `scrollIntoView(itemEl, {rootEl:
contentEl, block: "nearest"})`), so arrow-keying to a row below the fold scrolls the element that
now has the overflow. Nothing in `Menu.css` or `AgentChatInput.css` gives the group heading
`position: sticky`, so no row scrolls under a pinned header. The thinking picker shares the rule and
its 5-7 rows sit well under the cap.

`apps/tuval/src/shell/chat/chat-picker-menu-cap.unit.test.ts` follows the harness in
`chat-composer-width.unit.test.tsx`: it reads the shipped `Menu.css` and `AgentChatInput.css` off
disk through `import.meta.resolve("@kampus/design")`, builds the menu's own anatomy with 30 radio
rows, and asserts the declared cap, `overflow-y`, `overscroll-behavior`, the non-sticky heading, and
that the 7-row thinking picker resolves the identical cap. Removing the three declarations reddens
two of its four cases, so it is not vacuous. The anatomy's attribute names are Zag's own, kebab-cased
by `@zag-js/anatomy`'s `build()`.

`pnpm typecheck` and `pnpm lint` pass.

## Deviations

- **Known defect left unfixed** — **Said:** an acceptance criterion asks that "the checked radio row
  is scrolled into view when the menu opens". **Did:** shipped the arrow-key half of that criterion
  (Zag scrolls the highlighted row within the capped `content`) and left the open-time scroll
  unfixed; opening a long picker still starts at the top. **Why:** Zag's machine drives this from
  `highlightedValue`, and `@manti-ui/react@0.9.0`'s `Menu` forwards no such prop — the whole bundle
  contains no `highlighted` at all — while `contentProps` and `itemProps` are plain
  `HTMLAttributes`, which carry no `ref`. Reaching the panel from `SettingMenu` would mean querying
  the portal against Zag's private `menu:${id}:content` id template, a coupling to a transitive
  dependency's internals I did not want to introduce unruled. **Disposition:** filed as
  https://github.com/kamp-us/phoenix/issues/8078 with the upstream fix written up; this PR is
  `Part of #8064` rather than closing it.
- **Out-of-scope change** — **Said:** #8064 names the popover's box. **Did:** changed nothing else,
  but while checking the group-label criterion I found that
  `.kp-agent-chat__picker-menu [data-part="group-label"]` matches no element — Zag emits
  `item-group-label` — so that block has been dead since it landed. **Why:** fixing it would change
  a rendered surface this ticket does not cover, and it does not affect the cap. **Disposition:**
  filed as https://github.com/kamp-us/phoenix/issues/8077, not fixed here; the new test asserts the
  heading is unpinned against the attribute Zag actually emits.

Part of #8064
