### PR TITLE
fix: The composer's model picker lists the same Pi models twice

### DIFF
--- a/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
@@ -144,6 +144,26 @@ describe("composerBridge", () => {
 		expect(handlers.onSetModel.mock.calls).toEqual([[sonnet]]);
 	});
 
+	it("resolves each of two providers' same-named models to its own ref", async () => {
+		const handlers = seam();
+		const openaiLuna: ModelRef = {provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna"};
+		const codexLuna: ModelRef = {
+			provider: "openai-codex",
+			id: "gpt-5.6-luna",
+			name: "GPT-5.6 Luna",
+		};
+		const composer = composerBridge({
+			...handlers,
+			initialPhase: "ready",
+			initialModels: {current: openaiLuna, available: [openaiLuna, codexLuna]},
+		});
+
+		await composer.bridge.setPiModel({provider: "openai-codex", id: "gpt-5.6-luna", name: "!"});
+		await composer.bridge.setPiModel({provider: "openai", id: "gpt-5.6-luna", name: "!"});
+
+		expect(handlers.onSetModel.mock.calls).toEqual([[codexLuna], [openaiLuna]]);
+	});
+
 	it("drops a pick the session does not offer rather than rejecting it", async () => {
 		const handlers = seam();
 		const composer = composerBridge({

--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -291,6 +291,21 @@
 	white-space: nowrap;
 }
 
+.kp-agent-chat__picker-option {
+	display: flex;
+	align-items: baseline;
+	gap: var(--s-1);
+	min-width: 0;
+}
+
+.kp-agent-chat__picker-note {
+	overflow: hidden;
+	color: var(--text-secondary);
+	font: var(--t-meta);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .kp-agent-chat__picker-menu:where([data-scope="menu"][data-part="content"]) {
 	width: calc(var(--s-8) * 6);
 	max-width: calc(100vw - var(--s-4));

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -161,6 +161,38 @@ function lateCatalogBridge(): {
 	return {bridge, push: (event) => listener?.(event)};
 }
 
+/**
+ * Two providers offering one display name — the founder's desk, where `openai` and `openai-codex`
+ * both carry `GPT-5.6 Luna` (#8065). A row's name alone cannot name one of them.
+ */
+function collidingCatalogBridge(): {
+	bridge: AgentChatInputBridge;
+	picks: Array<{readonly provider: string; readonly id: string}>;
+} {
+	const luna = {provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna"};
+	const codexLuna = {provider: "openai-codex", id: "gpt-5.6-luna", name: "GPT-5.6 Luna"};
+	const picks: Array<{readonly provider: string; readonly id: string}> = [];
+	let model = luna;
+	const bridge: AgentChatInputBridge = {
+		loadPiState: async () => ({isStreaming: false, model, thinkingLevel: "medium"}),
+		loadPiCommands: async () => [],
+		loadPiModels: async () => [luna, codexLuna],
+		loadPiThinkingLevels: async () => ["medium", "high"],
+		loadPiFiles: async () => [],
+		setPiModel: async (next) => {
+			picks.push({provider: next.provider, id: next.id});
+			model = {provider: next.provider, id: next.id, name: next.name};
+		},
+		setPiThinkingLevel: async () => undefined,
+		setPiProjectTrust: async () => undefined,
+		sendPiPrompt: async () => undefined,
+		abortPi: async () => undefined,
+		answerPiExtension: async () => undefined,
+		subscribeToPiEvents: () => () => undefined,
+	};
+	return {bridge, picks};
+}
+
 afterEach(() => vi.unstubAllGlobals());
 
 describe("AgentChatInput", () => {
@@ -415,5 +447,56 @@ describe("AgentChatInput", () => {
 			),
 		);
 		expect(drafts).toEqual([]);
+	});
+
+	it("tells two providers' same-named models apart in the select list", async () => {
+		const {bridge, picks} = collidingCatalogBridge();
+		render(<AgentChatInput bridge={bridge} />);
+
+		fireEvent.click(await screen.findByRole("combobox", {name: "Pi modeli"}));
+		const rows = await screen.findAllByRole("option");
+		expect(rows.map((row) => row.textContent)).toEqual([
+			"GPT-5.6 Luna (openai)",
+			"GPT-5.6 Luna (openai-codex)",
+		]);
+
+		fireEvent.click(screen.getByRole("option", {name: "GPT-5.6 Luna (openai-codex)"}));
+		await waitFor(() => expect(picks).toEqual([{provider: "openai-codex", id: "gpt-5.6-luna"}]));
+	});
+
+	it("renders the provider as a row's secondary text in the focused picker", async () => {
+		const {bridge, picks} = collidingCatalogBridge();
+		render(<AgentChatInput bridge={bridge} variant="focused" />);
+
+		fireEvent.click(await screen.findByRole("button", {name: "model: GPT-5.6 Luna (openai)"}));
+		const rows = await screen.findAllByRole("menuitemradio");
+		expect(
+			rows.map((row) => row.querySelector(".kp-agent-chat__picker-note")?.textContent),
+		).toEqual(["openai", "openai-codex"]);
+		// The name stays the row's own text; the provider is a sibling span, not part of it.
+		expect(
+			rows.map((row) => row.querySelector(".kp-agent-chat__picker-option > span")?.textContent),
+		).toEqual(["GPT-5.6 Luna", "GPT-5.6 Luna"]);
+
+		fireEvent.click(rows[1] as HTMLElement);
+		await waitFor(() => expect(picks).toEqual([{provider: "openai-codex", id: "gpt-5.6-luna"}]));
+	});
+
+	it("names the running model with its provider once two providers are offered", async () => {
+		const {bridge} = collidingCatalogBridge();
+		render(<AgentChatInput bridge={bridge} />);
+
+		expect(await screen.findByText(/Pi hazır · GPT-5\.6 Luna \(openai\)/)).toBeTruthy();
+	});
+
+	it("leaves a single-provider catalog's rows bare", async () => {
+		const {bridge} = installHarnessFetch();
+		render(<AgentChatInput bridge={bridge} />);
+
+		fireEvent.click(await screen.findByRole("combobox", {name: "Pi modeli"}));
+		expect((await screen.findAllByRole("option")).map((row) => row.textContent)).toEqual([
+			"GPT-5",
+			"GPT-5.6",
+		]);
 	});
 });

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -147,6 +147,8 @@ interface Activity {
 interface PickerItem {
 	readonly value: string;
 	readonly label: string;
+	/** Secondary text beside the label, for a row the label alone does not tell apart. */
+	readonly note?: string;
 	readonly icon?: LucideIcon;
 }
 
@@ -222,6 +224,14 @@ function modelValue(model: Pick<PiModel, "provider" | "id">): string {
 	return `${model.provider}/${model.id}`;
 }
 
+/**
+ * Two providers can offer the same display name, and then the name alone names two rows. The
+ * provider is the fact that tells them apart, so it rides every row once a second one is offered.
+ */
+function providersCollide(models: readonly PiModel[]): boolean {
+	return new Set(models.map((model) => model.provider)).size > 1;
+}
+
 /** A pushed catalog, admitted row by row. A malformed push leaves the held list alone. */
 function modelList(value: unknown): readonly PiModel[] | undefined {
 	if (!Array.isArray(value)) return undefined;
@@ -261,6 +271,18 @@ function modelName(state: Record<string, unknown> | undefined): string | undefin
 	return (
 		stringValue(model, "displayName") ?? stringValue(model, "name") ?? stringValue(model, "id")
 	);
+}
+
+/** The running model as the status line names it: bare name, or name + provider once two collide. */
+function runningModelLabel(
+	state: Record<string, unknown> | undefined,
+	models: readonly PiModel[],
+): string | undefined {
+	const name = modelName(state);
+	if (!name || !providersCollide(models)) return name;
+	const model = state && isRecord(state.model) ? state.model : undefined;
+	const provider = model && stringValue(model, "provider");
+	return provider ? `${name} (${provider})` : name;
 }
 
 function assistantMessageText(value: unknown): string | undefined {
@@ -815,9 +837,18 @@ export function AgentChatInput({
 		}
 	}
 
-	const model = modelName(state);
+	const model = runningModelLabel(state, models);
+	// Manti's `SelectItem.label` is `string`, and the select collection stringifies it for typeahead
+	// (`itemToString: (item) => item.label`), so this list carries the provider in the label itself
+	// while the Menu-backed picker below renders it as its own dimmed span. See #8065.
 	const modelItems = useMemo<SelectItem[]>(
-		() => models.map((candidate) => ({value: modelValue(candidate), label: candidate.name})),
+		() =>
+			models.map((candidate) => ({
+				value: modelValue(candidate),
+				label: providersCollide(models)
+					? `${candidate.name} (${candidate.provider})`
+					: candidate.name,
+			})),
 		[models],
 	);
 	const thinkingItems = useMemo<SelectItem[]>(
@@ -825,7 +856,12 @@ export function AgentChatInput({
 		[thinkingLevels, t],
 	);
 	const focusedModelItems = useMemo<PickerItem[]>(
-		() => models.map((candidate) => ({value: modelValue(candidate), label: candidate.name})),
+		() =>
+			models.map((candidate) => ({
+				value: modelValue(candidate),
+				label: candidate.name,
+				...(providersCollide(models) ? {note: candidate.provider} : {}),
+			})),
 		[models],
 	);
 	const focusedThinkingItems = useMemo<PickerItem[]>(
@@ -1228,6 +1264,11 @@ function SettingMenu({
 	const t = useDesignT();
 	const [open, setOpen] = useState(false);
 	const selected = items.find((item) => item.value === value);
+	const selectedName = selected
+		? selected.note
+			? `${selected.label} (${selected.note})`
+			: selected.label
+		: t("admin.agent.picker.loading");
 	return (
 		<Menu
 			open={open}
@@ -1241,11 +1282,14 @@ function SettingMenu({
 					variant="tertiary"
 					size="sm"
 					className="kp-agent-chat__picker-trigger"
-					aria-label={`${label}: ${selected?.label ?? t("admin.agent.picker.loading")}`}
+					aria-label={`${label}: ${selectedName}`}
 					disabled={disabled}
 				>
 					{selected?.icon ? <Icon icon={selected.icon} size={14} /> : null}
 					<span>{selected?.label ?? "…"}</span>
+					{selected?.note ? (
+						<span className="kp-agent-chat__picker-note">{selected.note}</span>
+					) : null}
 					<Icon icon={open ? ChevronUp : ChevronDown} size={14} />
 				</Button>
 			}
@@ -1256,7 +1300,14 @@ function SettingMenu({
 					items: items.map((item) => ({
 						type: "radio",
 						value: item.value,
-						label: item.label,
+						label: item.note ? (
+							<span className="kp-agent-chat__picker-option">
+								<span>{item.label}</span>
+								<span className="kp-agent-chat__picker-note">{item.note}</span>
+							</span>
+						) : (
+							item.label
+						),
 						checked: item.value === value,
 						...(item.icon ? {icon: <Icon icon={item.icon} size={16} />} : {}),
 					})),


### PR DESCRIPTION
Fixes #8065

The composer's model picker labelled every row with the model's display name alone, so two
providers offering one model rendered two rows nobody could tell apart — `GPT-5.6 Luna` under both
`openai` and `openai-codex` on the founder's desk. The values were always distinct
(`${provider}/${id}`), so picking routed correctly; only the label was lossy.

Once a catalog offers more than one provider, the provider now rides every model row:

- The focused variant's Menu-backed picker renders it as its own dimmed span beside the name
  (`PickerItem.note`, new `.kp-agent-chat__picker-note`), so the model name stays the row's primary
  scannable text. The picker trigger carries it too, and its accessible name reads
  `model: GPT-5.6 Luna (openai)`.
- The harness variant's `Select` carries it inside the label string. Manti types `SelectItem.label`
  as `string` and its select collection stringifies it for typeahead
  (`itemToString: (item) => item.label`, `@manti-ui/react@0.9.0`
  `dist/components/Select/Select.d.ts` plus the bundled collection config), so a dimmed sibling span
  is not reachable there without changing the dependency. See the deviation below.
- The harness status line names the running model as `Pi hazır · GPT-5.6 Luna (openai)`.

A single-provider catalog is untouched — rows stay bare, which is what every existing test asserts.

`refOf` in `apps/tuval/src/shell/chat/composer-bridge.ts` already matched on provider + id; a new
unit test pins that each same-named pick resolves to its own `ModelRef`.

## Deviations

- **Declined guidance** — **Said:** #8065's criterion 2 asks that the provider read as secondary
  (dimmed/smaller) and never be folded into the name string, in both picker lists. **Did:** the
  focused Menu list renders it as a dimmed sibling span; the harness `Select` list folds it into the
  label as `Name (provider)`. **Why:** `SelectItem.label` is typed `string` in
  `@manti-ui/react@0.9.0` and the select collection calls `itemToString: (item) => item.label` for
  typeahead, so a `ReactNode` label is both a type error and a runtime break — a dimmed span there
  needs a change to the dependency, which is outside this issue. **Disposition:** stated here;
  follow-up filed as #8084.
- **Out-of-scope change** — **Said:** #8065 names the two picker lists and the status text.
  **Did:** also carried the provider into the focused picker's trigger. **Why:** the focused variant
  renders no status line, so the trigger is where that variant states its running model; leaving it
  bare would have left criterion 3 unmet on the surface the bug was reported from.
  **Disposition:** stated here.
- **Guard or gate bypassed** — **Said:** `build push` is the verb that publishes the lane branch.
  **Did:** published the branch by hand once, after two `build push` runs each reported the remote
  ref absent while exiting 0. **Why:** both verb runs sat behind the lefthook pre-push legs
  (whole-repo `pnpm typecheck` plus `vitest --changed`) long enough that the ref read back before
  the publish landed; the hand run showed both legs passing and the branch creating.
  **Disposition:** re-ran `build push` afterwards and it printed `PUSH-VERDICT: MOVED` against
  `fe88715`, so the verb, not the hand run, is what this PR stands on.
