### PR TITLE
feat: The composer's slash-command picker is empty in Tuval: neither backend's commands reach it

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -218,11 +218,11 @@ Three files, and the split between them is forced rather than stylistic.
   re-runs all four of its loads whenever that object's identity changes, so a bridge rebuilt per
   state change drops the composer back to `loading` on every turn.
   `src/shell/chat/composer-bridge.ts` is therefore built once in a `useMemo` whose dependencies are
-  only the dispatch closures — `phase` and `models` *seed* it and are deliberately not dependencies
-  — and each later change reaches the mounted composer through a setter that pushes one event at the
-  bridge's own subscription: `setPhase` pushes `agent_start` / `agent_settled`, `setModels` pushes a
-  `harness_status` carrying the offered catalog and the current model (#7981). Two rules make that
-  work. The bridge answers a capability it does not have **empty, never a rejection** — a rejection
+  only the dispatch closures — `phase`, `models` and `commands` *seed* it and are deliberately not
+  dependencies — and each later change reaches the mounted composer through a setter that pushes one
+  event at the bridge's own subscription: `setPhase` pushes `agent_start` / `agent_settled`, and
+  `setModels` / `setCommands` push a `harness_status` carrying the offered models with the current
+  one (#7981) and the slash-command catalog (#8060). Two rules make that work. The bridge answers a capability it does not have **empty, never a rejection** — a rejection
   puts the composer in `unavailable` and disables the send button, while an empty answer only hides
   the control. And a setter **also replays on subscribe**: the composer subscribes *after* its four
   loads resolve, so a catalog that landed in that window was pushed at a listener that did not exist

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -222,11 +222,13 @@ Three files, and the split between them is forced rather than stylistic.
   dependencies — and each later change reaches the mounted composer through a setter that pushes one
   event at the bridge's own subscription: `setPhase` pushes `agent_start` / `agent_settled`, and
   `setModels` / `setCommands` push a `harness_status` carrying the offered models with the current
-  one (#7981) and the slash-command catalog (#8060). Two rules make that work. The bridge answers a capability it does not have **empty, never a rejection** — a rejection
-  puts the composer in `unavailable` and disables the send button, while an empty answer only hides
-  the control. And a setter **also replays on subscribe**: the composer subscribes *after* its four
-  loads resolve, so a catalog that landed in that window was pushed at a listener that did not exist
-  yet, and on a session nobody switches again the next event never comes.
+  one (#7981) and the slash-command catalog (#8060).
+  Two rules make that work. The bridge answers a capability it does not have **empty, never a
+  rejection** — a rejection puts the composer in `unavailable` and disables the send button, while
+  an empty answer only hides the control. And a setter **also replays on subscribe**: the composer
+  subscribes *after* its four loads resolve, so a catalog that landed in that window was pushed at a
+  listener that did not exist yet, and on a session nobody switches again the next event never
+  comes.
 
 ## A program declares three renderers; the shell composes two of them
 

--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -166,6 +166,10 @@ export const foldEvent = (
 			return {...state, modes: {current: event.current, available: event.available}};
 		case "model":
 			return {...state, models: {current: event.current, available: event.available}};
+		// Replaced, never merged: the push carries the whole list, so a merge would keep a command
+		// the backend has just withdrawn.
+		case "commands":
+			return {...state, commands: event.available};
 		case "usage":
 			return {...state, usage: addUsage(state.usage, event)};
 		// The same landing the `failed` Msg gives a failure the handlers saw, so a refusal reads the

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -10,6 +10,7 @@
 
 import {Predicate} from "effect";
 import {
+	isCommandRef,
 	isModelRef,
 	isPermissionRequest,
 	isTranscriptItems,
@@ -46,6 +47,8 @@ const isModels = (value: unknown): boolean =>
 	Array.isArray(value.available) &&
 	value.available.every(isModelRef);
 
+const isCommands = (value: unknown): boolean => Array.isArray(value) && value.every(isCommandRef);
+
 const isTranscript = (value: unknown): boolean =>
 	Predicate.isObject(value) && isTranscriptItems(value.items) && isWindowOmission(value.omitted);
 
@@ -75,6 +78,7 @@ export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionSt
 	isPermissions(value.permissions) &&
 	isModes(value.modes) &&
 	isModels(value.models) &&
+	isCommands(value.commands) &&
 	isNullOrString(value.lastPrompt) &&
 	isPage(value.lastPage) &&
 	isFailure(value.failure);

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -12,6 +12,7 @@
 
 import type {AgentFailure, Phase} from "../events.ts";
 import type {
+	CommandRef,
 	ItemId,
 	Mode,
 	ModelRef,
@@ -76,6 +77,12 @@ export interface AiAgentSessionState {
 	readonly permissions: Readonly<Record<string, PermissionRequest>>;
 	readonly modes: ModeState;
 	readonly models: ModelState;
+	/**
+	 * The slash commands this session offers the composer, whole (#8060). A flat list rather than a
+	 * `current`/`available` pair like the two above: nothing selects a command, the picker inserts
+	 * one as prompt text.
+	 */
+	readonly commands: ReadonlyArray<CommandRef>;
 	/** The text of the last prompt sent, for the resend affordance. */
 	readonly lastPrompt: string | null;
 	/** The last page `page` asked for and `paged` delivered. Not part of the live tail. */
@@ -111,6 +118,7 @@ export const initialState = (cwd: string): AiAgentSessionState => ({
 	permissions: {},
 	modes: {current: null, available: []},
 	models: {current: null, available: []},
+	commands: [],
 	lastPrompt: null,
 	lastPage: null,
 	failure: null,

--- a/apps/tuval/src/ai-agent/events.ts
+++ b/apps/tuval/src/ai-agent/events.ts
@@ -21,6 +21,7 @@
  */
 
 import type {
+	CommandRef,
 	Mode,
 	ModelRef,
 	PermissionDecision,
@@ -77,6 +78,21 @@ export interface ModelEvent {
 }
 
 /**
+ * What the session offers the composer's slash-command picker, whole.
+ *
+ * Replaced on arrival, never merged: the Agent SDK's `commands_changed` push is documented as the
+ * full list and tells clients to replace their cached one (`sdk.d.ts` at the `0.3.259` pin), and a
+ * merge would keep a command the backend has just withdrawn.
+ *
+ * It rides this stream rather than a member of its own for the reason every other catalog does —
+ * one subscription, one ordering (ruling 1, #7570).
+ */
+export interface CommandsEvent {
+	readonly kind: "commands";
+	readonly available: ReadonlyArray<CommandRef>;
+}
+
+/**
  * The last thing that went wrong, as data. The layer's typed errors are classes; this keeps only
  * the tag, the case and the detail, because the window renders by tag (ruling 3, #7570) and a
  * class instance is not something a checkpoint can carry.
@@ -117,5 +133,6 @@ export type AgentEvent =
 	| PermissionResolvedEvent
 	| ModeEvent
 	| ModelEvent
+	| CommandsEvent
 	| UsageEvent
 	| FailureEvent;

--- a/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
@@ -52,9 +52,11 @@ interface Probe {
 	released: number;
 	/** Prompts the layer was actually asked for; a refused prompt has to reach none of them. */
 	prompts: number;
+	/** The text of each, so a test reads what the backend was sent rather than that it was sent. */
+	sent: Array<string>;
 }
 
-const probeOf = (): Probe => ({acquired: 0, released: 0, prompts: 0});
+const probeOf = (): Probe => ({acquired: 0, released: 0, prompts: 0, sent: []});
 
 /** A backend that holds no session at all, whatever it is asked to open. */
 const refusesEveryStart = (options: StartOptions) =>
@@ -96,6 +98,7 @@ const countingLayer = (
 				prompt: (text: string, key?: string) =>
 					Effect.suspend(() => {
 						probe.prompts += 1;
+						probe.sent.push(text);
 						return agent.prompt(text, key);
 					}),
 			};
@@ -325,6 +328,30 @@ describe("the AI agent handlers under a process", () => {
 				yield* eventually(() => sessionOf(handle).models.current?.id === sonnet.id);
 				assert.deepStrictEqual(sessionOf(handle).models.current, sonnet);
 				assert.isNull(sessionOf(handle).failure);
+			}),
+		);
+	});
+
+	// The picker's half of this — a pick becoming a `prompt` Msg carrying `/compact` — is proven in
+	// `shell/chat/agent-controls.unit.test.tsx`; this is the other half, that such a Msg reaches the
+	// backend as prompt text and as nothing else. A command runs as a prompt, so no port carries it.
+	it.live("folds the catalog into state and sends a picked command as ordinary prompt text", () => {
+		const probe = probeOf();
+		const compact = {name: "compact", description: "Summarise the conversation."};
+		return withKernel({...plainReply, commands: [compact]}, probe, (spawn) =>
+			Effect.gen(function* () {
+				const handle = yield* spawn;
+				yield* eventually(() => sessionOf(handle).commands.length === 1);
+				assert.deepStrictEqual(sessionOf(handle).commands, [compact]);
+
+				yield* handle.dispatch({
+					type: "prompt",
+					text: "/compact",
+					key: "k1",
+					timestamp: Date.now(),
+				});
+				yield* eventually(() => probe.sent.length === 1);
+				assert.deepStrictEqual(probe.sent, ["/compact"]);
 			}),
 		);
 	});

--- a/apps/tuval/src/ai-agent/ports/command.ts
+++ b/apps/tuval/src/ai-agent/ports/command.ts
@@ -1,0 +1,26 @@
+/**
+ * `CommandRef` — one slash command, named the way a picker names one.
+ *
+ * Like `ModelRef` beside it, this rides no port: the picker lives in the window, which already
+ * reads the whole `AiAgentSessionState`, so a sixth port would buy nothing (#8060).
+ *
+ * `name` carries no leading slash — the composer writes the sigil itself, and a ref that carried
+ * one would render `//compact`. `argumentHint` is a hint, never an argument editor: the picker
+ * inserts the command and the operator types the rest.
+ */
+
+import {Predicate} from "effect";
+
+export interface CommandRef {
+	readonly name: string;
+	readonly description?: string;
+	/** What the command expects after it, e.g. `<file>`. Absent when the backend names none. */
+	readonly argumentHint?: string;
+}
+
+export const isCommandRef = (value: unknown): value is CommandRef =>
+	Predicate.isObject(value) &&
+	typeof value.name === "string" &&
+	value.name.length > 0 &&
+	(value.description === undefined || typeof value.description === "string") &&
+	(value.argumentHint === undefined || typeof value.argumentHint === "string");

--- a/apps/tuval/src/ai-agent/ports/index.ts
+++ b/apps/tuval/src/ai-agent/ports/index.ts
@@ -5,6 +5,7 @@
  * implementation. `boundary.unit.test.ts` holds that closure.
  */
 
+export {type CommandRef, isCommandRef} from "./command.ts";
 export {isModelRef, type ModelRef, sameModel} from "./model.ts";
 export {
 	isModePayload,

--- a/apps/tuval/src/ai-agent/records-the-operators-turn.unit.test.ts
+++ b/apps/tuval/src/ai-agent/records-the-operators-turn.unit.test.ts
@@ -35,8 +35,8 @@ import {type AgentScript, ScriptedAiAgent, TuvalAiAgent} from "./service/index.t
 const CWD = "/work";
 const SENT_AT = 1_700_000_000_000;
 
-/** `start` queues four events before any turn: starting, the mode list, the model list, ready. */
-const START_EVENTS = 4;
+/** `start` queues five before any turn: starting, the mode, model and command lists, ready. */
+const START_EVENTS = 5;
 
 const machine = aiAgentSessionMachine({cwd: CWD});
 

--- a/apps/tuval/src/ai-agent/restore/checkpoint.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.ts
@@ -30,6 +30,7 @@ export const checkpointFields = [
 	"permissions",
 	"modes",
 	"models",
+	"commands",
 	"lastPrompt",
 	"lastPage",
 	"failure",

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
@@ -23,6 +23,7 @@ import {renderPath} from "../../commands/spell.ts";
 import type {AgentEvent} from "../events.ts";
 import {
 	boundToolResult,
+	type CommandRef,
 	ItemId,
 	isJsonValue,
 	type JsonValue,
@@ -54,6 +55,8 @@ interface ScriptState {
 	readonly pending: ReadonlyMap<string, PermissionRequest>;
 	readonly mode: Mode | null;
 	readonly model: ModelRef | null;
+	/** What the last `commands` event carried, which is what the `commands` read answers. */
+	readonly commands: ReadonlyArray<CommandRef>;
 	/** False once a scripted disconnect landed. Nothing sets it back — that is the point. */
 	readonly live: boolean;
 }
@@ -65,6 +68,7 @@ const initial = (script: AgentScript): ScriptState => ({
 	pending: new Map(),
 	mode: script.modes.current,
 	model: script.models.current,
+	commands: [],
 	live: true,
 });
 
@@ -107,12 +111,22 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 		);
 		const state = yield* Ref.make(initial(script));
 
+		// The `commands` read answers whatever the last `commands` event carried, so the one funnel
+		// every event passes through is where it is remembered: a turn pushing a second catalog
+		// replaces the first here, with no second place for a script to say so.
+		const remember = (events: ReadonlyArray<AgentEvent>): Effect.Effect<void> =>
+			Effect.forEach(
+				events.filter((event) => event.kind === "commands"),
+				(event) => Ref.update(state, (previous) => ({...previous, commands: event.available})),
+				{concurrency: 1, discard: true},
+			);
+
 		const emit = (events: ReadonlyArray<AgentEvent>): Effect.Effect<void> =>
 			// Serial on purpose: one subscription, one ordering — a parallel offer would shuffle a turn.
 			Effect.forEach(events, (event) => Queue.offer(queue, event), {
 				concurrency: 1,
 				discard: true,
-			});
+			}).pipe(Effect.andThen(remember(events)));
 
 		const runPlan = Effect.fn("TuvalAiAgent.plan")(function* (plan: ScriptedPlan, turn: number) {
 			const spells = script.spells;
@@ -171,6 +185,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 			yield* emit([
 				{kind: "mode", current: current.mode, available: script.modes.available},
 				{kind: "model", current: current.model, available: script.models.available},
+				{kind: "commands", available: script.commands ?? []},
 				{kind: "phase", phase: "ready"},
 			]);
 			yield* Ref.update(state, (previous) => ({
@@ -291,6 +306,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 			answer,
 			setMode,
 			setModel,
+			commands: Effect.map(Ref.get(state), (current) => current.commands),
 			page,
 			events: Stream.fromQueue(queue),
 		};

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.unit.test.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.unit.test.ts
@@ -42,8 +42,8 @@ import {TuvalAiAgent, type TuvalAiAgentApi} from "./TuvalAiAgent.ts";
 
 const CWD = "/workspace/phoenix";
 
-/** What `start` emits before any turn: starting, the mode list, the model list, ready. */
-const START_EVENTS = 4;
+/** What `start` emits before any turn: starting, the mode, model and command lists, ready. */
+const START_EVENTS = 5;
 
 const on = <A, E>(
 	script: AgentScript,
@@ -54,7 +54,7 @@ const on = <A, E>(
 		return yield* body(agent);
 	}).pipe(Effect.provide(ScriptedAiAgent.layer(script)), Effect.scoped);
 
-/** The events a turn queued, with `start`'s four dropped. */
+/** The events a turn queued, with `start`'s five dropped. */
 const afterStart = (agent: TuvalAiAgentApi, count: number) =>
 	Effect.map(Stream.runCollect(Stream.take(agent.events, START_EVENTS + count)), (events) =>
 		events.slice(START_EVENTS),
@@ -73,7 +73,7 @@ const causeError = (exit: Exit.Exit<unknown, unknown>): {_tag?: string; reason?:
 		: {};
 
 describe("start", () => {
-	it.effect("returns the script's session id and announces the mode and model lists", () =>
+	it.effect("returns the script's session id and announces the mode, model and command lists", () =>
 		on(plainReply, (agent) =>
 			Effect.gen(function* () {
 				const session = yield* agent.start({cwd: CWD});
@@ -82,6 +82,7 @@ describe("start", () => {
 					{kind: "phase", phase: "starting"},
 					{kind: "mode", current: modes.current, available: modes.available},
 					{kind: "model", current: models.current, available: models.available},
+					{kind: "commands", available: []},
 					{kind: "phase", phase: "ready"},
 				]);
 			}),
@@ -240,12 +241,46 @@ describe("models", () => {
 				// not the script's opening one — the switch outlives the turn it was made between.
 				yield* agent.start({cwd: CWD, resume: SESSION_ID});
 				const resumed = yield* take(agent, START_EVENTS + history.length);
-				assert.deepStrictEqual(resumed.at(-2), {
+				assert.deepStrictEqual(resumed.at(-3), {
 					kind: "model",
 					current: sonnet,
 					available: models.available,
 				});
 			}),
+		),
+	);
+});
+
+describe("commands", () => {
+	const compact = {name: "compact", description: "Summarise the conversation."};
+	const review = {name: "skill:review", description: "Review it."};
+	const offering: AgentScript = {...plainReply, commands: [compact, review]};
+
+	it.effect("announces the script's catalog at start and answers the read with it", () =>
+		on(offering, (agent) =>
+			Effect.gen(function* () {
+				assert.deepStrictEqual(yield* agent.commands, []);
+				yield* agent.start({cwd: CWD});
+				const events = yield* take(agent, START_EVENTS);
+				assert.deepStrictEqual(events.at(-2), {kind: "commands", available: [compact, review]});
+				assert.deepStrictEqual(yield* agent.commands, [compact, review]);
+			}),
+		),
+	);
+
+	it.effect("replaces the catalog a later event carries rather than merging into it", () =>
+		on(
+			{
+				...offering,
+				turns: [{events: [{kind: "commands", available: [review]}]}],
+			},
+			(agent) =>
+				Effect.gen(function* () {
+					yield* agent.start({cwd: CWD});
+					yield* agent.prompt("re-read the skills");
+					yield* afterStart(agent, 1);
+					assert.deepStrictEqual(yield* agent.commands, [review]);
+				}),
 		),
 	);
 });

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -17,7 +17,13 @@
 
 import {Context, type Effect, type Stream} from "effect";
 import type {AgentEvent} from "../events.ts";
-import type {Mode, ModelRef, PermissionDecision, TranscriptItem} from "../ports/index.ts";
+import type {
+	CommandRef,
+	Mode,
+	ModelRef,
+	PermissionDecision,
+	TranscriptItem,
+} from "../ports/index.ts";
 import type {
 	ModelUnsupported,
 	ModeUnsupported,
@@ -71,6 +77,17 @@ export interface TuvalAiAgentApi {
 	 * event, exactly as the mode list does.
 	 */
 	readonly setModel: (model: ModelRef) => Effect.Effect<void, ModelUnsupported>;
+	/**
+	 * The slash commands this session offers, as the composer's picker lists them — the ninth member
+	 * (#8060). A read rather than a setter, because nothing selects a command: the picker inserts one
+	 * and it reaches the backend as ordinary prompt text.
+	 *
+	 * The catalog is the session's, so this answers empty before `start` and on a backend that offers
+	 * none. Changes arrive on `events` as a `commands` event rather than down a second stream — one
+	 * subscription, one ordering (ruling 1, #7570) — and this read always answers what the last such
+	 * event carried.
+	 */
+	readonly commands: Effect.Effect<ReadonlyArray<CommandRef>>;
 	/**
 	 * History is backend-owned (ruling 5): this reads the backend's own store through the
 	 * transport. Tuval keeps no second copy beyond the live tail the core holds.

--- a/apps/tuval/src/ai-agent/service/boundary.unit.test.ts
+++ b/apps/tuval/src/ai-agent/service/boundary.unit.test.ts
@@ -12,7 +12,7 @@ import {join} from "node:path";
 import type {Effect, Stream} from "effect";
 import {describe, expect, expectTypeOf, it} from "vitest";
 import type {AgentEvent} from "../events.ts";
-import type {Mode, ModelRef, PermissionDecision} from "../ports/index.ts";
+import type {CommandRef, Mode, ModelRef, PermissionDecision} from "../ports/index.ts";
 import type {
 	ModelUnsupported,
 	ModeUnsupported,
@@ -30,13 +30,14 @@ import type {
 } from "./TuvalAiAgent.ts";
 
 /**
- * The founder's seven grew to eight on #7981: he wants the agent's model picked from the chat
- * composer, and a picker over a generic window has to read and write the model through the generic
- * interface. `setModel` is that eighth member, and both pins below count eight so the growth reads
- * as the deliberate act it was rather than as drift.
+ * The founder's seven grew to eight on #7981 and to nine on #8060: he wants the agent's model
+ * picked from the chat composer and its slash commands offered there, and a picker over a generic
+ * window has to reach both through the generic interface. `setModel` is the eighth member and
+ * `commands` the ninth, and both pins below count nine so each growth reads as the deliberate act
+ * it was rather than as drift.
  */
 describe("the TuvalAiAgent surface", () => {
-	it("carries the founder's seven members plus #7981's eighth, each at its declared type", () => {
+	it("carries the seven, #7981's eighth and #8060's ninth, each at its declared type", () => {
 		expectTypeOf<TuvalAiAgentApi["start"]>().toEqualTypeOf<
 			(options: StartOptions) => Effect.Effect<StartedSession, StartError>
 		>();
@@ -53,6 +54,9 @@ describe("the TuvalAiAgent surface", () => {
 		expectTypeOf<TuvalAiAgentApi["setModel"]>().toEqualTypeOf<
 			(model: ModelRef) => Effect.Effect<void, ModelUnsupported>
 		>();
+		expectTypeOf<TuvalAiAgentApi["commands"]>().toEqualTypeOf<
+			Effect.Effect<ReadonlyArray<CommandRef>>
+		>();
 		expectTypeOf<TuvalAiAgentApi["page"]>().toEqualTypeOf<
 			(before: string | null, limit: number) => Effect.Effect<TranscriptPage, PageError>
 		>();
@@ -61,9 +65,17 @@ describe("the TuvalAiAgent surface", () => {
 		>();
 	});
 
-	it("has exactly those eight members and no ninth", () => {
+	it("has exactly those nine members and no tenth", () => {
 		expectTypeOf<keyof TuvalAiAgentApi>().toEqualTypeOf<
-			"start" | "prompt" | "interrupt" | "answer" | "setMode" | "setModel" | "page" | "events"
+			| "start"
+			| "prompt"
+			| "interrupt"
+			| "answer"
+			| "setMode"
+			| "setModel"
+			| "commands"
+			| "page"
+			| "events"
 		>();
 	});
 });

--- a/apps/tuval/src/ai-agent/service/script.ts
+++ b/apps/tuval/src/ai-agent/service/script.ts
@@ -11,7 +11,7 @@
 import type {SpellBridgeApi} from "../../commands/bridge/index.ts";
 import type {SpellPath, Scope as SpellScope} from "../../commands/spell.ts";
 import type {AgentEvent} from "../events.ts";
-import type {Mode, ModelRef, TranscriptItem} from "../ports/index.ts";
+import type {CommandRef, Mode, ModelRef, TranscriptItem} from "../ports/index.ts";
 import type {TransportError} from "./errors.ts";
 
 /** One spell a turn calls: the path and the args, exactly as they cross the wire. */
@@ -84,6 +84,11 @@ export interface AgentScript {
 	readonly resumed?: ReadonlyArray<AgentEvent>;
 	readonly modes: ScriptedModes;
 	readonly models: ScriptedModels;
+	/**
+	 * What this scripted backend offers the slash-command picker, announced by `start`. Absent is a
+	 * backend with no commands — the shape every fixture written before #8060 stands for.
+	 */
+	readonly commands?: ReadonlyArray<CommandRef>;
 	/** One entry per prompt, consumed in order. */
 	readonly turns: ReadonlyArray<ScriptedTurn>;
 	/**

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -37,6 +37,7 @@ import {type Cause, Effect, Exit, Layer, Queue, Ref, Scope, Stream} from "effect
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {isRefusal, planTranscriptPage} from "../../ai-agent/history/index.ts";
 import type {
+	CommandRef,
 	Mode,
 	ModelRef,
 	PermissionDecision,
@@ -53,7 +54,13 @@ import {
 	type TuvalAiAgentApi,
 	UnknownRequest,
 } from "../../ai-agent/service/index.ts";
-import {emptyMapping, type Mapping, toAgentEvents, toHistoryItems} from "../history/index.ts";
+import {
+	commandsOf,
+	emptyMapping,
+	type Mapping,
+	toAgentEvents,
+	toHistoryItems,
+} from "../history/index.ts";
 import {KernelBridge, type ToolRuntime, tuvalToolServer} from "../tools/index.ts";
 import {cardOf, resultOf} from "./cards.ts";
 import {type InputChannel, inputChannel, userMessage} from "./input.ts";
@@ -189,6 +196,7 @@ const make = (
 		// between sessions, has to survive to the next `start` and be re-announced there.
 		const model = yield* Ref.make<ModelRef | null>(null);
 		const models = yield* Ref.make<ReadonlyArray<ModelRef>>([]);
+		const commands = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
 		const parked = new Map<string, Parked>();
 
 		const emit = (open: EventQueue, events: ReadonlyArray<AgentEvent>): Effect.Effect<void> =>
@@ -213,6 +221,24 @@ const make = (
 					Effect.as(
 						Effect.logWarning(`the model catalog could not be read: ${refusal.detail}`),
 						[] as ReadonlyArray<ModelRef>,
+					),
+				),
+			);
+
+		/**
+		 * The session's slash commands, read once per open. A CLI that cannot answer leaves the picker
+		 * empty rather than failing the open, exactly as the model catalog does.
+		 */
+		const readCommands = (current: Session): Effect.Effect<ReadonlyArray<CommandRef>> =>
+			Effect.tryPromise({
+				try: () => current.handle.supportedCommands(),
+				catch: controlRefused,
+			}).pipe(
+				Effect.map(commandsOf),
+				Effect.catch((refusal) =>
+					Effect.as(
+						Effect.logWarning(`the command catalog could not be read: ${refusal.detail}`),
+						[] as ReadonlyArray<CommandRef>,
 					),
 				),
 			);
@@ -358,6 +384,11 @@ const make = (
 					if (isInit(pulled.message)) yield* readIntro(current, pulled.message);
 					const step = toAgentEvents(pulled.message, mapping, {at: Date.now()});
 					mapping = step.mapping;
+					// The SDK's `commands_changed` push carries the whole list, so the cached one is
+					// replaced by it rather than merged into — reading it off the mapped event keeps one
+					// path for the catalog whatever produced it.
+					const pushed = step.events.findLast((event) => event.kind === "commands");
+					if (pushed !== undefined) yield* Ref.set(commands, pushed.available);
 					yield* emit(open, step.events);
 					if (pulled.message.type === "result") {
 						current.state.settled = true;
@@ -507,6 +538,9 @@ const make = (
 						: spawned;
 			yield* Ref.set(model, opening);
 			yield* emit(out, [{kind: "model", current: opening, available: offered}]);
+			const catalog = yield* readCommands(opened.session);
+			yield* Ref.set(commands, catalog);
+			yield* emit(out, [{kind: "commands", available: catalog}]);
 			// A card the layer does not hold cannot be answered, so a window restored with one would
 			// wedge on it. Resolving it is what lets the generic restore drop it (#7608).
 			yield* emit(
@@ -646,6 +680,7 @@ const make = (
 			answer,
 			setMode,
 			setModel,
+			commands: Ref.get(commands),
 			page,
 			events: Stream.unwrap(Effect.map(Ref.get(queue), (held) => Stream.fromQueue(held))),
 		};

--- a/apps/tuval/src/claude/agent/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/agent/boundary.unit.test.ts
@@ -57,9 +57,17 @@ describe("the layer's type", () => {
 		expectTypeOf(composed).toEqualTypeOf<Layer.Layer<TuvalAiAgent, never, SpellBridge>>();
 	});
 
-	it("implements exactly the eight generic members, and no ninth", () => {
+	it("implements exactly the nine generic members, and no tenth", () => {
 		expectTypeOf<keyof TuvalAiAgentApi>().toEqualTypeOf<
-			"start" | "prompt" | "interrupt" | "answer" | "setMode" | "setModel" | "page" | "events"
+			| "start"
+			| "prompt"
+			| "interrupt"
+			| "answer"
+			| "setMode"
+			| "setModel"
+			| "commands"
+			| "page"
+			| "events"
 		>();
 	});
 });

--- a/apps/tuval/src/claude/agent/events.unit.test.ts
+++ b/apps/tuval/src/claude/agent/events.unit.test.ts
@@ -28,9 +28,21 @@ describe("events over a captured tool turn", () => {
 				);
 				assert.deepStrictEqual(
 					events.map((event) => event.kind),
-					// The start's own four, then the first turn's `init` — the model it names, and
+					// The start's own five, then the first turn's `init` — the model it names, and
 					// nothing else — then the turn, which ends on the `ready` its `result` carries.
-					["phase", "phase", "mode", "model", "usage", "item", "item", "item", "usage", "phase"],
+					[
+						"phase",
+						"phase",
+						"mode",
+						"model",
+						"commands",
+						"usage",
+						"item",
+						"item",
+						"item",
+						"usage",
+						"phase",
+					],
 				);
 			}),
 		),
@@ -103,6 +115,7 @@ describe("every kind rides the one stream", () => {
 						"phase",
 						"mode",
 						"model",
+						"commands",
 						"usage",
 						"item",
 						"item",

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -25,11 +25,14 @@ export const MODES: ReadonlyArray<Mode> = [
 	Mode.make("plan"),
 ];
 
-/** What `start` itself emits: starting, ready, the mode list, then the model list (#7981). */
-export const START_EVENTS = 4;
+/**
+ * What `start` itself emits: starting, ready, the mode list, the model list (#7981), then the
+ * slash-command catalog (#8060).
+ */
+export const START_EVENTS = 5;
 
 /**
- * Those four plus the one event the `system`/`init` frame carries: the model it names.
+ * Those five plus the one event the `system`/`init` frame carries: the model it names.
  *
  * That one is not part of `start` — the frame belongs to the first turn (`sdk.d.ts`), so on a
  * scripted run whose `opening` begins with `init` the pump emits it just after, and a test that
@@ -111,6 +114,8 @@ export const on = <A, E>(
 				? {}
 				: {modelSwitchFails: harness.modelSwitchFails}),
 			...(harness.catalogFails === undefined ? {} : {catalogFails: harness.catalogFails}),
+			...(harness.commands === undefined ? {} : {commands: harness.commands}),
+			...(harness.commandsFail === undefined ? {} : {commandsFail: harness.commandsFail}),
 		});
 		return Effect.gen(function* () {
 			const agent = yield* TuvalAiAgent;

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -20,6 +20,7 @@ import type {
 	SDKMessage,
 	SDKUserMessage,
 	SessionMessage,
+	SlashCommand,
 	SpawnedProcess,
 } from "@anthropic-ai/claude-agent-sdk";
 import type {AgentSdk, AgentSession} from "../sdk.ts";
@@ -63,6 +64,10 @@ export interface ScriptedBehaviour {
 	readonly modelSwitchFails?: Error;
 	/** A `supportedModels()` that throws, which is a session with no picker rather than no session. */
 	readonly catalogFails?: Error;
+	/** What `supportedCommands()` answers. Absent is a CLI that offers none. */
+	readonly commands?: ReadonlyArray<SlashCommand>;
+	/** A `supportedCommands()` that throws — a session with no slash picker, not a failed open. */
+	readonly commandsFail?: Error;
 }
 
 export const scriptedQuery = (
@@ -164,6 +169,10 @@ export const scriptedQuery = (
 		supportedModels: async () => {
 			if (behaviour.catalogFails !== undefined) throw behaviour.catalogFails;
 			return behaviour.models ?? [];
+		},
+		supportedCommands: async () => {
+			if (behaviour.commandsFail !== undefined) throw behaviour.commandsFail;
+			return behaviour.commands ?? [];
 		},
 		close: () => {
 			record.closes += 1;

--- a/apps/tuval/src/claude/agent/sdk.ts
+++ b/apps/tuval/src/claude/agent/sdk.ts
@@ -18,6 +18,7 @@ import type {
 	SDKMessage,
 	SDKUserMessage,
 	SessionMessage,
+	SlashCommand,
 } from "@anthropic-ai/claude-agent-sdk";
 import {getSessionMessages, query} from "@anthropic-ai/claude-agent-sdk";
 
@@ -52,6 +53,12 @@ export interface AgentSession extends AsyncGenerator<SDKMessage, void> {
 	 */
 	setModel(model?: string): Promise<void>;
 	supportedModels(): Promise<ReadonlyArray<ModelInfo>>;
+	/**
+	 * The session's slash commands, declared beside `supportedModels` and read the same way — once
+	 * per open. The pin's `sdk.d.ts` documents it as tracking the latest `commands_changed` push, so
+	 * a re-fetch and that push answer the same list and either one is a whole catalog (#8060).
+	 */
+	supportedCommands(): Promise<ReadonlyArray<SlashCommand>>;
 	close(): void;
 }
 

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -117,7 +117,7 @@ describe("start opens one streaming query", () => {
 		}),
 	);
 
-	it.effect("emits starting, the handshake's ready phase, then the mode and model lists", () =>
+	it.effect("emits starting, the handshake's ready phase, then the three catalogs", () =>
 		on({modes: MODES}, (agent) =>
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
@@ -128,6 +128,7 @@ describe("start opens one streaming query", () => {
 					// what the query opened on is the row's own `permissionMode` (#7828).
 					{kind: "mode", current: Mode.make("default"), available: MODES},
 					{kind: "model", current: null, available: []},
+					{kind: "commands", available: []},
 				]);
 			}),
 		),
@@ -138,7 +139,7 @@ describe("start opens one streaming query", () => {
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
-				const announced = events[START_EVENTS - 2];
+				const announced = events[START_EVENTS - 3];
 				assert.deepStrictEqual(announced, {
 					kind: "mode",
 					current: Mode.make(scripted.opened[0]?.record.options.permissionMode ?? ""),
@@ -166,6 +167,7 @@ describe("start against a CLI that says nothing until the first prompt", () => {
 					{kind: "phase", phase: "ready"},
 					{kind: "mode", current: Mode.make("default"), available: MODES},
 					{kind: "model", current: null, available: []},
+					{kind: "commands", available: []},
 				]);
 			}),
 		),
@@ -292,7 +294,7 @@ describe("setModel", () => {
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
-				assert.deepStrictEqual(events[START_EVENTS - 1], {
+				assert.deepStrictEqual(events[START_EVENTS - 2], {
 					kind: "model",
 					current: null,
 					available: [
@@ -358,7 +360,7 @@ describe("setModel", () => {
 				const session = yield* agent.start({cwd: CWD});
 				assert.strictEqual(session.sessionId, SESSION_ID);
 				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
-				assert.deepStrictEqual(events[START_EVENTS - 1], {
+				assert.deepStrictEqual(events[START_EVENTS - 2], {
 					kind: "model",
 					current: null,
 					available: [],
@@ -390,6 +392,75 @@ describe("setModel", () => {
 				// The query still opens on the row's static model — the SDK's `sessionId`/`resume`
 				// options carry no model — so the switch is re-applied against the new session.
 				assert.deepStrictEqual(scripted.opened[1]?.record.models, ["sonnet"]);
+			}),
+		),
+	);
+});
+
+describe("commands", () => {
+	const COMMANDS = [
+		{name: "compact", description: "Summarise the conversation.", argumentHint: ""},
+		{name: "skill:review", description: "Review it.", argumentHint: "<pr>"},
+	];
+
+	/** The SDK's mid-session push, exactly as `sdk.d.ts` declares `SDKCommandsChangedMessage`. */
+	const changed = (commands: ReadonlyArray<Record<string, unknown>>) => ({
+		type: "system" as const,
+		subtype: "commands_changed" as const,
+		commands,
+		uuid: "00000000-0000-4000-8000-0000000000c1" as const,
+		session_id: SESSION_ID,
+	});
+
+	it.effect("fills the catalog from supportedCommands at the open", () =>
+		on({commands: COMMANDS}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				// The empty `argumentHint` the CLI sends for a command taking none is dropped rather
+				// than carried as an empty string the picker would have to special-case.
+				assert.deepStrictEqual(events[START_EVENTS - 1], {
+					kind: "commands",
+					available: [
+						{name: "compact", description: "Summarise the conversation."},
+						{name: "skill:review", description: "Review it.", argumentHint: "<pr>"},
+					],
+				});
+				assert.deepStrictEqual(yield* agent.commands, [
+					{name: "compact", description: "Summarise the conversation."},
+					{name: "skill:review", description: "Review it.", argumentHint: "<pr>"},
+				]);
+			}),
+		),
+	);
+
+	it.effect("opens on an empty catalog when the CLI cannot list its commands", () =>
+		on({commandsFail: new Error("supportedCommands blew up")}, (agent) =>
+			Effect.gen(function* () {
+				// An absent picker is a session you can still prompt, so the open resolves.
+				const session = yield* agent.start({cwd: CWD});
+				assert.strictEqual(session.sessionId, SESSION_ID);
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(events[START_EVENTS - 1], {kind: "commands", available: []});
+			}),
+		),
+	);
+
+	it.effect("replaces the cached list on a commands_changed push rather than merging", () =>
+		on({commands: COMMANDS}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				scripted.opened[0]?.say(
+					changed([{name: "clear", description: "Clear it.", argumentHint: ""}]) as never,
+				);
+				const pushed = yield* Stream.runCollect(Stream.take(agent.events, 1));
+				assert.deepStrictEqual(pushed[0], {
+					kind: "commands",
+					available: [{name: "clear", description: "Clear it."}],
+				});
+				// Replaced: neither command the open announced survives the push.
+				assert.deepStrictEqual(yield* agent.commands, [{name: "clear", description: "Clear it."}]);
 			}),
 		),
 	);
@@ -430,7 +501,7 @@ describe("setMode", () => {
 				yield* agent.start({cwd: CWD});
 				assert.strictEqual(scripted.opened[0]?.record.options.permissionMode, "plan");
 				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
-				assert.deepStrictEqual(events[START_EVENTS - 2], {
+				assert.deepStrictEqual(events[START_EVENTS - 3], {
 					kind: "mode",
 					current: Mode.make("plan"),
 					available: MODES,
@@ -461,7 +532,7 @@ describe("setMode", () => {
 					Effect.gen(function* () {
 						yield* agent.start({cwd: CWD});
 						const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
-						assert.deepStrictEqual(events[START_EVENTS - 2], {
+						assert.deepStrictEqual(events[START_EVENTS - 3], {
 							kind: "mode",
 							current: Mode.make("default"),
 							available: [Mode.make("default")],

--- a/apps/tuval/src/claude/history/events.ts
+++ b/apps/tuval/src/claude/history/events.ts
@@ -6,7 +6,7 @@
  *
  * The SDK's union is open — `SDKMessage` names three dozen members at
  * `@anthropic-ai/claude-agent-sdk@0.3.259` and grows every release — so the dispatch is over the
- * five this transcript has a shape for, and everything else is counted rather than refused. A new
+ * six this transcript has a shape for, and everything else is counted rather than refused. A new
  * message kind must never take a session down.
  *
  * Partial assistant frames are among the counted: streaming granularity here is one whole
@@ -16,6 +16,7 @@
 import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
 import {
 	assistantEvents,
+	commandsChangedEvents,
 	initEvents,
 	type Mapping,
 	type MappingOptions,
@@ -43,6 +44,7 @@ export const toAgentEvents = (
 			if (message.subtype === "permission_denied") {
 				return permissionDeniedEvents(message, mapping, options);
 			}
+			if (message.subtype === "commands_changed") return commandsChangedEvents(message, mapping);
 			return skipMessage(mapping);
 		default:
 			return skipMessage(mapping);

--- a/apps/tuval/src/claude/history/index.ts
+++ b/apps/tuval/src/claude/history/index.ts
@@ -10,6 +10,7 @@ export {
 	toHistoryItems,
 } from "./items.ts";
 export {
+	commandsOf,
 	emptyMapping,
 	type Mapping,
 	type MappingOptions,

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -15,7 +15,7 @@
 
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {boundToolOutput} from "../../ai-agent/history/index.ts";
-import type {ItemId, JsonValue, TranscriptItem} from "../../ai-agent/ports/index.ts";
+import type {CommandRef, ItemId, JsonValue, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {
 	isRecord,
 	outputOf,
@@ -273,6 +273,39 @@ export const initEvents = (message: unknown, mapping: Mapping): MappingStep => {
 		events: [{kind: "usage", model, inputTokens: 0, outputTokens: 0, cost: 0}],
 	};
 };
+
+/**
+ * `SlashCommand` rows as the interface's backend-blind `CommandRef`. A row with no usable `name` is
+ * dropped rather than taking the whole push down: the composer would render a bare `/` for it.
+ */
+export const commandsOf = (value: unknown): ReadonlyArray<CommandRef> => {
+	if (!Array.isArray(value)) return [];
+	const rows: Array<CommandRef> = [];
+	for (const row of value) {
+		if (!isRecord(row)) continue;
+		const name = typeof row.name === "string" ? row.name : "";
+		if (name.length === 0) continue;
+		rows.push({
+			name,
+			...(typeof row.description === "string" && row.description.length > 0
+				? {description: row.description}
+				: {}),
+			...(typeof row.argumentHint === "string" && row.argumentHint.length > 0
+				? {argumentHint: row.argumentHint}
+				: {}),
+		});
+	}
+	return rows;
+};
+
+/**
+ * The SDK's mid-session command push, which carries the whole list — its own docstring tells clients
+ * to replace their cached one — so this emits the catalog and the fold replaces on it (#8060).
+ */
+export const commandsChangedEvents = (message: unknown, mapping: Mapping): MappingStep =>
+	isRecord(message)
+		? {mapping, events: [{kind: "commands", available: commandsOf(message.commands)}]}
+		: skipMessage(mapping);
 
 /** A denial the operator never got to answer. The line names the tool, which is the whole point. */
 export const permissionDeniedEvents = (

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -403,6 +403,19 @@ const make = (
 				Effect.fail(new UnknownRequest({request})),
 			setMode: (mode: Mode) => Effect.fail(new ModeUnsupported({mode, available: []})),
 			setModel,
+			/**
+			 * Empty by ruling, not by omission (founder, 2026-09-05, #8060). Pi's slash commands live
+			 * inside its `AgentSession` — extension commands, skills, prompt templates — and the wire
+			 * Tuval reaches it over carries no list of them: at `@earendil-works/pi-protocol@0.84.3`
+			 * `ServerSnapshotSchema` is `{serverId, protocolVersion, revision, sessions, models}` and
+			 * `CommandSchema` is a closed nine-verb union. Filling this needs an upstream protocol
+			 * change, which is its own ticket; vendoring or forking that dep is a no-go.
+			 *
+			 * Only the *catalog* is missing. Running one already works: `expandPromptTemplates`
+			 * (default true, `agent-session.d.ts`) dispatches extension commands and expands skill
+			 * commands on the prompt text itself, so a `/skill:foo` the operator types lands.
+			 */
+			commands: Effect.succeed([]),
 			page,
 			events: Stream.unwrap(Effect.map(Ref.get(queue), (open) => Stream.fromQueue(open))),
 		};

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -45,6 +45,7 @@ const cutMidReply: AiAgentSessionState = {
 	permissions: {},
 	modes: {current: null, available: []},
 	models: {current: null, available: []},
+	commands: [],
 	lastPrompt: "read the readme",
 	lastPage: null,
 	failure: null,

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -465,11 +465,13 @@ function ChatWindow({
 
 	const phase = state?.phase ?? "idle";
 	const models = state?.models ?? null;
+	const commands = state?.commands ?? null;
 	const composer = useMemo(
 		() =>
 			composerBridge({
 				initialPhase: phase,
 				initialModels: models ?? {current: null, available: []},
+				initialCommands: commands ?? [],
 				onPrompt: (text) => {
 					dispatch({type: "prompt", text, key: options.newKey(), timestamp: options.now()});
 					commit((current) => (current.draft === "" ? current : {...current, draft: ""}));
@@ -477,15 +479,19 @@ function ChatWindow({
 				onInterrupt: () => dispatch({type: "interrupt"}),
 				onSetModel: (model) => dispatch({type: "setModel", model}),
 			}),
-		// `phase` and `models` seed the bridge and are deliberately not dependencies: `AgentChatInput`
-		// re-runs its whole load on a new bridge identity, so a bridge rebuilt per change would drop
-		// the composer back into `loading` on every turn. Both reach it through the setters below.
+		// `phase`, `models` and `commands` seed the bridge and are deliberately not dependencies:
+		// `AgentChatInput` re-runs its whole load on a new bridge identity, so a bridge rebuilt per
+		// change would drop the composer back into `loading` on every turn. All three reach it
+		// through the setters below.
 		[dispatch, commit, options.newKey, options.now],
 	);
 	useEffect(() => composer.setPhase(phase), [composer, phase]);
 	useEffect(() => {
 		if (models !== null) composer.setModels(models);
 	}, [composer, models]);
+	useEffect(() => {
+		if (commands !== null) composer.setCommands(commands);
+	}, [composer, commands]);
 
 	const interruptedId = state?.interrupted ?? null;
 	const lastPrompt = state?.lastPrompt ?? null;

--- a/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  *
- * The four agent controls the window adds on top of the transcript: the collapsible tool row, the
- * permission cards, the mode switch, and the composer's model picker. Same test double as the
- * transcript's own tests (`../window/fixtures.ts`) — no kernel, no socket, no agent layer.
+ * The five agent controls the window adds on top of the transcript: the collapsible tool row, the
+ * permission cards, the mode switch, and the composer's model and slash-command pickers. Same test
+ * double as the transcript's own tests (`../window/fixtures.ts`) — no kernel, no socket, no layer.
  *
  * Every control here is Manti-backed, so a click and a same-tick read prove nothing: Zag defers the
  * transition by at least one microtask (`.patterns/zag-machine-interaction-tests.md`). Each
@@ -20,7 +20,15 @@ import {installDomShims, TEST_VIEWPORT} from "../ui/dom.testing.ts";
 import {type TestProcess, testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
-import {call, models, modes, permissionRequest, userItem, withTranscript} from "./chat.testing.ts";
+import {
+	call,
+	commands,
+	models,
+	modes,
+	permissionRequest,
+	userItem,
+	withTranscript,
+} from "./chat.testing.ts";
 import {initialChatView} from "./view.ts";
 
 installDomShims();
@@ -307,6 +315,62 @@ describe("the composer's model picker", () => {
 		await waitFor(() =>
 			expect(screen.getByRole("button", {name: "model: claude-sonnet-5"})).toBeTruthy(),
 		);
+	});
+});
+
+describe("the composer's slash-command picker", () => {
+	const composer = () => screen.findByLabelText("Write a message to the agent");
+
+	const type = async (value: string): Promise<HTMLElement> => {
+		const input = await composer();
+		await act(async () => {
+			fireEvent.change(input, {target: {value}});
+		});
+		return input;
+	};
+
+	it("offers the session's catalog and writes the pick into the draft", async () => {
+		await open(withTranscript([userItem("u1", "go")], {commands: commands(["compact", "clear"])}));
+		const input = await type("/comp");
+		await click(await screen.findByRole("option", {name: /\/compact/}));
+		expect((input as HTMLTextAreaElement).value).toBe("/compact ");
+	});
+
+	it("sends a picked command to the backend as ordinary prompt text", async () => {
+		const {process} = await open(
+			withTranscript([userItem("u1", "go")], {commands: commands(["compact"])}),
+		);
+		await type("/comp");
+		await click(await screen.findByRole("option", {name: /\/compact/}));
+		await act(async () => {
+			fireEvent.submit((await composer()).closest("form") as HTMLFormElement);
+		});
+		await waitFor(() => expect(process.inbox().length).toBe(1));
+		const sent = process.inbox()[0] as {type: string; text: string};
+		expect([sent.type, sent.text]).toEqual(["prompt", "/compact"]);
+	});
+
+	it("advertises no sigil and opens no menu on a backend offering no commands", async () => {
+		await open(withTranscript([userItem("u1", "go")], {commands: []}));
+		const hint = await screen.findByText(/file/);
+		expect(hint.textContent).not.toContain("command");
+		await type("/");
+		expect(screen.queryByRole("listbox", {name: "Completions"})).toBeNull();
+	});
+
+	it("takes a catalog that arrives after mount without re-entering loading", async () => {
+		const state = withTranscript([userItem("u1", "go")], {commands: []});
+		const {process} = await open(state);
+		// The send button is the composer's `loading` tell: it is disabled while the load runs and
+		// enabled once it resolves, so a bridge rebuilt by the catalog would disable it again.
+		const send = await screen.findByRole("button", {name: /send/i});
+		await waitFor(() => expect(send.getAttribute("disabled")).toBeNull());
+		await act(async () => {
+			await Effect.runPromise(process.commit({...state, commands: commands(["compact"])}));
+		});
+		expect(send.getAttribute("disabled")).toBeNull();
+		await type("/comp");
+		expect(await screen.findByRole("option", {name: /\/compact/})).toBeTruthy();
 	});
 });
 

--- a/apps/tuval/src/shell/chat/chat.testing.ts
+++ b/apps/tuval/src/shell/chat/chat.testing.ts
@@ -95,6 +95,9 @@ export const models = (
 	available: available.map((id) => ({provider: "anthropic", id, name: id})),
 });
 
+export const commands = (names: ReadonlyArray<string>): AiAgentSessionState["commands"] =>
+	names.map((name) => ({name, description: `what /${name} does`}));
+
 export const withTranscript = (
 	items: ReadonlyArray<TranscriptItem>,
 	overrides: Partial<AiAgentSessionState> = {},

--- a/apps/tuval/src/shell/chat/composer-bridge.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.ts
@@ -9,16 +9,17 @@
  * the two events the composer keys its working/ready state on.
  *
  * Everything the composer asks for and this window does not have (thinking levels, project trust,
- * file completions) — and a backend that offers no commands — is answered empty rather than refused: an empty answer hides the control, a
- * rejection would put the composer in its `unavailable` state and disable the send button.
+ * file completions) — and a backend that offers no commands — is answered empty rather than
+ * refused: an empty answer hides the control, a rejection would put the composer in its
+ * `unavailable` state and disable the send button.
  *
  * Models (#7981) and slash commands (#8060) are the two capabilities this window does have. Both
  * lists are the session's own — `AiAgentSessionState.models` and `.commands`, fed by each layer's
- * `model` and `commands` events — and a model pick becomes a `setModel` Msg while a command pick is
- * just text the composer writes into the draft. Both arrive after mount, because the agent has not
- * started when the composer runs its loads, so they are *pushed* through the same subscription the
- * phase is: `AgentChatInput` re-runs its whole load on a new bridge identity, and rebuilding the
- * bridge per state change would drop the composer back to `loading` on every turn.
+ * `model` and `commands` events — and a model pick becomes a `setModel` Msg while a command pick
+ * is just text the composer writes into the draft. Both arrive after mount, because the agent has
+ * not started when the composer runs its loads, so they are *pushed* through the same subscription
+ * the phase is: `AgentChatInput` re-runs its whole load on a new bridge identity, and rebuilding
+ * the bridge per state change would drop the composer back to `loading` on every turn.
  *
  * Nothing here is React. It is a plain object with a setter, so its behaviour is unit-testable
  * without a DOM — which is what `composer-bridge.unit.test.ts` does.

--- a/apps/tuval/src/shell/chat/composer-bridge.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.ts
@@ -9,13 +9,14 @@
  * the two events the composer keys its working/ready state on.
  *
  * Everything the composer asks for and this window does not have (thinking levels, project trust,
- * file completions) is answered empty rather than refused: an empty answer hides the control, a
+ * file completions) — and a backend that offers no commands — is answered empty rather than refused: an empty answer hides the control, a
  * rejection would put the composer in its `unavailable` state and disable the send button.
  *
- * Models are the one capability this window does have (#7981). The offered list and the current
- * model are the session's own — `AiAgentSessionState.models`, fed by each layer's `model` event —
- * and a pick becomes a `setModel` Msg. The list arrives after mount, because the agent has not
- * started when the composer runs its loads, so it is *pushed* through the same subscription the
+ * Models (#7981) and slash commands (#8060) are the two capabilities this window does have. Both
+ * lists are the session's own — `AiAgentSessionState.models` and `.commands`, fed by each layer's
+ * `model` and `commands` events — and a model pick becomes a `setModel` Msg while a command pick is
+ * just text the composer writes into the draft. Both arrive after mount, because the agent has not
+ * started when the composer runs its loads, so they are *pushed* through the same subscription the
  * phase is: `AgentChatInput` re-runs its whole load on a new bridge identity, and rebuilding the
  * bridge per state change would drop the composer back to `loading` on every turn.
  *
@@ -23,10 +24,10 @@
  * without a DOM — which is what `composer-bridge.unit.test.ts` does.
  */
 
-import type {AgentChatInputBridge, PiEvent, PiModel} from "@kampus/design";
+import type {AgentChatInputBridge, PiCommand, PiEvent, PiModel} from "@kampus/design";
 import type {ModelState} from "../../ai-agent/core/index.ts";
 import type {Phase} from "../../ai-agent/events.ts";
-import type {ModelRef} from "../../ai-agent/ports/index.ts";
+import type {CommandRef, ModelRef} from "../../ai-agent/ports/index.ts";
 import {isWorking} from "./phase.ts";
 
 export interface ComposerHandlers {
@@ -38,6 +39,7 @@ export interface ComposerHandlers {
 	readonly onSetModel: (model: ModelRef) => void;
 	readonly initialPhase: Phase;
 	readonly initialModels: ModelState;
+	readonly initialCommands: ReadonlyArray<CommandRef>;
 }
 
 /**
@@ -57,11 +59,22 @@ const refOf = (model: PiModel, offered: ReadonlyArray<ModelRef>): ModelRef | nul
 			composerModel(candidate).provider === model.provider && candidate.id === model.id,
 	) ?? null;
 
+/**
+ * The composer's command rows. `argumentHint` is dropped rather than folded into the description:
+ * the picker inserts the command and the operator types the arguments, so a hint rendered as prose
+ * would read as part of what the command does.
+ */
+const composerCommand = (command: CommandRef): PiCommand => ({
+	name: command.name,
+	...(command.description === undefined ? {} : {description: command.description}),
+});
+
 /** The one event the composer takes a catalog on: its `harness_status` arm. */
-const modelStatus = (models: ModelState): PiEvent => ({
+const catalogStatus = (models: ModelState, commands: ReadonlyArray<CommandRef>): PiEvent => ({
 	type: "harness_status",
 	status: {
 		models: models.available.map(composerModel),
+		commands: commands.map(composerCommand),
 		...(models.current === null ? {} : {model: composerModel(models.current)}),
 	},
 });
@@ -79,6 +92,8 @@ export interface ComposerBridge {
 	 * mount — the agent has not started — so this is the only way it reaches the picker.
 	 */
 	readonly setModels: (models: ModelState) => void;
+	/** Same push, same reason: the slash catalog is not known until the session opens. */
+	readonly setCommands: (commands: ReadonlyArray<CommandRef>) => void;
 }
 
 const none =
@@ -89,6 +104,7 @@ const none =
 export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 	let phase = handlers.initialPhase;
 	let models = handlers.initialModels;
+	let commands = handlers.initialCommands;
 	let listener: ((event: PiEvent) => void) | null = null;
 
 	const bridge: AgentChatInputBridge = {
@@ -97,7 +113,7 @@ export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 				isStreaming: isWorking(phase),
 				...(models.current === null ? {} : {model: composerModel(models.current)}),
 			}),
-		loadPiCommands: none([]),
+		loadPiCommands: () => Promise.resolve(commands.map(composerCommand)),
 		loadPiModels: () => Promise.resolve(models.available.map(composerModel)),
 		loadPiThinkingLevels: none([]),
 		loadPiFiles: none([]),
@@ -123,8 +139,10 @@ export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 			listener = onEvent;
 			// The composer subscribes *after* its four loads resolve, so a catalog that landed in
 			// between was pushed at a listener that did not exist yet and would be lost until the
-			// next model event — which, on a session nobody switches, never comes.
-			if (models.available.length > 0) onEvent(modelStatus(models));
+			// next catalog event — which, on a session nobody switches, never comes.
+			if (models.available.length > 0 || commands.length > 0) {
+				onEvent(catalogStatus(models, commands));
+			}
 			return () => {
 				if (listener === onEvent) listener = null;
 			};
@@ -142,7 +160,11 @@ export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 		},
 		setModels: (next) => {
 			models = next;
-			listener?.(modelStatus(next));
+			listener?.(catalogStatus(next, commands));
+		},
+		setCommands: (next) => {
+			commands = next;
+			listener?.(catalogStatus(models, next));
 		},
 	};
 };

--- a/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
@@ -70,7 +70,7 @@ describe("composerBridge", () => {
 		expect(seen).toEqual([]);
 	});
 
-	it("answers every capability it does not have as empty, never as a rejection", async () => {
+	it("answers an unheld capability, and a held empty one, empty not rejected", async () => {
 		const {bridge} = composerBridge({...seam(), initialPhase: "ready"});
 		expect(await bridge.loadPiThinkingLevels()).toEqual([]);
 		expect(await bridge.loadPiFiles("src")).toEqual([]);

--- a/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
@@ -7,7 +7,7 @@
 
 import {describe, expect, it, vi} from "vitest";
 import type {ModelState} from "../../ai-agent/core/index.ts";
-import type {ModelRef} from "../../ai-agent/ports/index.ts";
+import type {CommandRef, ModelRef} from "../../ai-agent/ports/index.ts";
 import {composerBridge} from "./composer-bridge.ts";
 
 const opus: ModelRef = {provider: "anthropic", id: "claude-opus-5", name: "Opus 5"};
@@ -17,11 +17,14 @@ const bare: ModelRef = {id: "haiku", name: "Haiku"};
 
 const noModels: ModelState = {current: null, available: []};
 
+const compact: CommandRef = {name: "compact", description: "Summarise the conversation."};
+const review: CommandRef = {name: "skill:review", description: "Review it.", argumentHint: "<pr>"};
+
 const seam = () => {
 	const onPrompt = vi.fn<(text: string) => void>();
 	const onInterrupt = vi.fn<() => void>();
 	const onSetModel = vi.fn<(model: ModelRef) => void>();
-	return {onPrompt, onInterrupt, onSetModel, initialModels: noModels};
+	return {onPrompt, onInterrupt, onSetModel, initialModels: noModels, initialCommands: []};
 };
 
 describe("composerBridge", () => {
@@ -69,7 +72,6 @@ describe("composerBridge", () => {
 
 	it("answers every capability it does not have as empty, never as a rejection", async () => {
 		const {bridge} = composerBridge({...seam(), initialPhase: "ready"});
-		expect(await bridge.loadPiCommands()).toEqual([]);
 		expect(await bridge.loadPiThinkingLevels()).toEqual([]);
 		expect(await bridge.loadPiFiles("src")).toEqual([]);
 		expect(await bridge.setPiThinkingLevel("high")).toBeUndefined();
@@ -79,6 +81,35 @@ describe("composerBridge", () => {
 		// rejecting: a rejection puts the composer in `unavailable` and disables the send button.
 		expect(await bridge.loadPiModels()).toEqual([]);
 		expect(await bridge.setPiModel({provider: "x", id: "y", name: "Y"})).toBeUndefined();
+		// Commands it has too (#8060), and a backend offering none answers the same empty list —
+		// which is exactly Pi's answer while `pi-protocol` carries no command catalog.
+		expect(await bridge.loadPiCommands()).toEqual([]);
+	});
+
+	it("answers the picker with the session's own command catalog", async () => {
+		const composer = composerBridge({
+			...seam(),
+			initialPhase: "ready",
+			initialCommands: [compact, review],
+		});
+		// `argumentHint` is the session's, not the picker's: the composer inserts the command and the
+		// operator types the arguments, so a hint rendered as description would misread as one.
+		expect(await composer.bridge.loadPiCommands()).toEqual([
+			{name: "compact", description: "Summarise the conversation."},
+			{name: "skill:review", description: "Review it."},
+		]);
+	});
+
+	it("replaces the catalog a later push carries instead of merging into it", async () => {
+		const composer = composerBridge({
+			...seam(),
+			initialPhase: "ready",
+			initialCommands: [compact, review],
+		});
+		composer.setCommands([review]);
+		expect(await composer.bridge.loadPiCommands()).toEqual([
+			{name: "skill:review", description: "Review it."},
+		]);
 	});
 
 	it("answers the picker with the session's offered list and its current model", async () => {
@@ -125,11 +156,53 @@ describe("composerBridge", () => {
 						{provider: "anthropic", id: "claude-opus-5", name: "Opus 5"},
 						{provider: "anthropic", id: "claude-sonnet-5", name: "Sonnet 5"},
 					],
+					commands: [],
 					model: {provider: "anthropic", id: "claude-opus-5", name: "Opus 5"},
 				},
 			},
 		]);
 		expect((await composer.bridge.loadPiModels()).length).toBe(2);
+	});
+
+	it("pushes a command catalog that arrives after mount on the same subscription", async () => {
+		const composer = composerBridge({...seam(), initialPhase: "ready"});
+		const seen: Array<unknown> = [];
+		composer.bridge.subscribeToPiEvents(
+			(event) => seen.push(event),
+			() => undefined,
+		);
+		composer.setCommands([compact]);
+		expect(seen).toEqual([
+			{
+				type: "harness_status",
+				status: {
+					models: [],
+					commands: [{name: "compact", description: "Summarise the conversation."}],
+				},
+			},
+		]);
+	});
+
+	it("re-pushes a catalog that landed before the composer subscribed", () => {
+		const composer = composerBridge({
+			...seam(),
+			initialPhase: "ready",
+			initialCommands: [compact],
+		});
+		const seen: Array<unknown> = [];
+		composer.bridge.subscribeToPiEvents(
+			(event) => seen.push(event),
+			() => undefined,
+		);
+		expect(seen).toEqual([
+			{
+				type: "harness_status",
+				status: {
+					models: [],
+					commands: [{name: "compact", description: "Summarise the conversation."}],
+				},
+			},
+		]);
 	});
 
 	it("turns a pick into one setModel carrying the session's own ref", async () => {

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -302,6 +302,34 @@ describe("AgentChatInput", () => {
 		expect(await screen.findByRole("menuitemradio", {name: "Opus 5"})).toBeTruthy();
 	});
 
+	it("takes a command catalog pushed after mount and offers it to the picker", async () => {
+		const {bridge, push} = lateCatalogBridge();
+		render(<AgentChatInput bridge={bridge} />);
+		const input = await screen.findByLabelText("Pi'ye mesaj yaz");
+
+		fireEvent.change(input, {target: {value: "/comp"}});
+		expect(screen.queryByRole("option", {name: /\/compact/})).toBeNull();
+
+		push({
+			type: "harness_status",
+			status: {commands: [{name: "compact", description: "Konuşmayı özetle."}]},
+		});
+
+		fireEvent.click(await screen.findByRole("option", {name: /\/compact/}));
+		expect((input as HTMLTextAreaElement).value).toBe("/compact ");
+	});
+
+	it("drops the slash hint on a harness that offers no commands", async () => {
+		const {bridge} = lateCatalogBridge();
+		render(<AgentChatInput bridge={bridge} variant="harness" />);
+		await screen.findByLabelText("Pi'ye mesaj yaz");
+
+		// The hint is the only thing advertising the sigil; typing `/` against an empty catalog opens
+		// nothing, so a hint promising a picker reads as a fault rather than as a feature.
+		const hint = screen.getByText(/dosya/);
+		expect(hint.textContent).not.toContain("komut");
+	});
+
 	it("omits off effort returned by the bridge on load and model refresh", async () => {
 		const {fetch, bridge} = installHarnessFetch();
 		render(<AgentChatInput bridge={bridge} variant="focused" />);

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -232,7 +232,7 @@ function providersCollide(models: readonly PiModel[]): boolean {
 	return new Set(models.map((model) => model.provider)).size > 1;
 }
 
-/** A pushed catalog, admitted row by row. A malformed push leaves the held list alone. */
+/** A pushed command catalog, admitted row by row. A malformed push leaves the held list alone. */
 function commandList(value: unknown): readonly PiCommand[] | undefined {
 	if (!Array.isArray(value)) return undefined;
 	const rows: PiCommand[] = [];
@@ -247,6 +247,7 @@ function commandList(value: unknown): readonly PiCommand[] | undefined {
 	return rows;
 }
 
+/** A pushed model catalog, admitted row by row. A malformed push leaves the held list alone. */
 function modelList(value: unknown): readonly PiModel[] | undefined {
 	if (!Array.isArray(value)) return undefined;
 	const rows: PiModel[] = [];

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -223,6 +223,20 @@ function modelValue(model: Pick<PiModel, "provider" | "id">): string {
 }
 
 /** A pushed catalog, admitted row by row. A malformed push leaves the held list alone. */
+function commandList(value: unknown): readonly PiCommand[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const rows: PiCommand[] = [];
+	for (const row of value) {
+		if (!isRecord(row)) return undefined;
+		const name = stringValue(row, "name");
+		if (!name) return undefined;
+		const description = stringValue(row, "description");
+		const source = stringValue(row, "source");
+		rows.push({name, ...(description ? {description} : {}), ...(source ? {source} : {})});
+	}
+	return rows;
+}
+
 function modelList(value: unknown): readonly PiModel[] | undefined {
 	if (!Array.isArray(value)) return undefined;
 	const rows: PiModel[] = [];
@@ -489,6 +503,14 @@ export function AgentChatInput({
 	}, [commands, completion, completionDismissed, files]);
 	const activeSuggestionId =
 		suggestions.length > 0 ? `${suggestionsId}-${activeSuggestion}` : undefined;
+	// A harness that offers no commands does not advertise the sigil: typing `/` against an empty
+	// catalog opens nothing, and a hint promising a picker that never appears reads as a fault.
+	const commandHint =
+		commands.length > 0 ? (
+			<>
+				<Kbd>/</Kbd> {t("admin.agent.hint.command")} ·{" "}
+			</>
+		) : null;
 
 	useEffect(() => setActiveSuggestion(0), [completion?.kind, completion?.query]);
 
@@ -536,6 +558,10 @@ export function AgentChatInput({
 			// other way in that does not restart the whole composer.
 			const nextModels = status && modelList(status.models);
 			if (nextModels) setModels(nextModels);
+			// Replaced, never merged: a host pushes its whole command list, so a merge would keep one
+			// it has just withdrawn.
+			const nextCommands = status && commandList(status.commands);
+			if (nextCommands) setCommands(nextCommands);
 			const nextModel = status && isRecord(status.model) ? status.model : undefined;
 			if (nextModel) setState((current) => ({...(current ?? {}), model: nextModel}));
 			if (status && booleanValue(status, "available") === false) setConnection("unavailable");
@@ -1167,13 +1193,13 @@ export function AgentChatInput({
 				{variant === "harness" ? (
 					<p className="kp-agent-chat__hint">
 						<Kbd>Enter</Kbd> {t("admin.agent.hint.send")} · <Kbd>Shift+Enter</Kbd>{" "}
-						{t("admin.agent.hint.newline")} · <Kbd>/</Kbd> {t("admin.agent.hint.command")} ·{" "}
+						{t("admin.agent.hint.newline")} · {commandHint}
 						<Kbd>@</Kbd> {t("admin.agent.hint.file")} · {t("admin.agent.hint.pasteImage")}
 					</p>
 				) : (
 					<p className="kp-agent-chat__hint">
-						<Kbd>/</Kbd> {t("admin.agent.hint.command")} · <Kbd>@</Kbd> {t("admin.agent.hint.file")}{" "}
-						· {t("admin.agent.hint.addOrPasteImage")}
+						{commandHint}
+						<Kbd>@</Kbd> {t("admin.agent.hint.file")} · {t("admin.agent.hint.addOrPasteImage")}
 					</p>
 				)}
 				{error ? (


### PR DESCRIPTION
Typing `/` in Tuval's chat composer offered nothing: the picker exists in `@kampus/design`, and
Tuval's composer bridge answered its command load with a hardcoded empty list. This wires Claude's
slash commands through to it.

Fixes #8060

Scope follows the founder's ruling of 2026-09-05 (issue comment
https://github.com/kamp-us/phoenix/issues/8060#issuecomment-5555482318): "yes to both" — ship
Claude-only commands now, and leave Pi's picker empty until `pi-protocol` carries a command list
upstream.

## What changed

`TuvalAiAgentApi` gains a ninth member, `commands`, at a new backend-blind `CommandRef`
(`{name, description?, argumentHint?}`). The list itself rides the existing `events` stream as a
new `commands` event and folds into `AiAgentSessionState.commands`, because ruling 1 of #7570 gives
this interface one subscription and one ordering — a second stream would be a second one.

- **Claude** reads the catalog from the SDK's `supportedCommands()` at the open, and the SDK's
  mid-session `system`/`commands_changed` push replaces the cached list rather than merging into
  it, which is what that message's own docstring asks clients to do (`sdk.d.ts` line 3381 at the
  `0.3.259` pin). A CLI that cannot answer either leaves the picker empty rather than failing the
  open, exactly as the model catalog already does.
- **Pi** answers an explicit empty list, with the protocol gap written at the code: at
  `@earendil-works/pi-protocol@0.84.3` the server snapshot carries `models` and no commands, and
  `CommandSchema` is a closed nine-verb union. Running a Pi command already works — the session
  expands prompt templates and skill commands on the prompt text itself — so only the catalog is
  missing.
- **The composer bridge** answers `loadPiCommands` from that state, and a catalog arriving after
  the composer mounts is pushed at the bridge's own subscription through `harness_status`, not by
  rebuilding the bridge, which would drop the composer back to `loading` on every turn.
- **The design package** reads a `commands` list off `harness_status`, and drops the `/ command`
  hint on a harness offering none — that hint was the only thing advertising a picker that opened
  on nothing.

A picked command is inserted into the draft and sent as ordinary prompt text; no port carries it.

## Proof

All through `ScriptedAiAgent` and the scripted `Query` — no CLI, no token, no model API. The Claude
layer's open, its empty-catalog fallback and the `commands_changed` replacement are in
`start.unit.test.ts`; the picker's pick-and-send, the hidden hint and the no-loading-re-entry case
are DOM tests over the real `ChatWindow`; the handlers test proves a picked command reaches the
backend as prompt text and nothing else.

## Deviations

- **Scope narrowing** — **Said:** the issue's shape says the commands member is "the available list
  plus the change signal". **Did:** the member is a read (`Effect<ReadonlyArray<CommandRef>>`) and
  the change signal rides the existing `events` stream as a `commands` event, rather than the member
  itself being a stream. **Why:** `events.ts` records founder ruling 1 of #7570 — one subscription,
  one ordering — so a second stream on the interface would need a second host Sub and would
  contradict a recorded ruling. **Disposition:** stated here and in the member's own docblock.
- **Out-of-scope change** — **Said:** #8060 names Tuval and the composer bridge. **Did:** also added
  the `commands` arm to `harness_status` and the conditional hint in
  `packages/design/src/AgentChatInput.tsx`. **Why:** the acceptance criteria require a pushed
  catalog to reach the picker and require the control to be hidden on an empty catalog, and both
  live in the design package — the bridge alone cannot satisfy either. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about test flakiness. **Did:** left
  `src/shell/program.unit.test.ts` and `src/boot.unit.test.ts` failing intermittently under a loaded
  full-suite run (they passed on re-run and in isolation; both are load-dependent, not caused by
  this diff). **Why:** already filed and diagnosed on #7964, which names both files and reproduces
  on an untouched `origin/main`. **Disposition:** left to #7964.
- **Declined guidance** — **Said:** both review verdicts asked for a rebase onto main. **Did:**
  merged `origin/main` into the branch instead, resolving the same one conflict
  (`agent-controls.unit.test.tsx`'s import list, a union of both sides). **Why:** `build push`
  refuses a rebased head at exit `23` because it drops the commit the PR already published, and the
  skill's repair rule says never to force past that with `--drop-remote-commits`. A merge clears the
  conflict — the branch is `MERGEABLE` again and the repo's workflows run at the new head — without
  rewriting published history. **Disposition:** stated here.
