### PR TITLE
fix: Adding a required field to AiAgentSessionState silently drops every saved Tuval checkpoint

### DIFF
--- a/apps/tuval/src/ai-agent/core/failures.ts
+++ b/apps/tuval/src/ai-agent/core/failures.ts
@@ -37,6 +37,19 @@ export const startRefused = (phase: string): AgentFailure => ({
 	detail: `a session is already ${phase}`,
 });
 
+/**
+ * A checkpoint that is still not a session state once its absent fields are defaulted (#8095).
+ *
+ * It wears `START_ERROR` because the window's status line renders a start failure at the phase the
+ * session came to rest in (`shell/chat/phase.ts`), and a refused checkpoint rests at `gone`: the
+ * operator reads "The session is gone — …" instead of a fresh window that accounts for nothing.
+ */
+export const checkpointUnreadable: AgentFailure = {
+	tag: START_ERROR,
+	reason: "refused",
+	detail: "the saved checkpoint is not a readable session, so nothing was restored from it",
+};
+
 export const noSessionToResume: AgentFailure = {
 	tag: START_ERROR,
 	reason: "session-not-found",

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -35,10 +35,17 @@ export {
 	eventsSub,
 	eventsSubId,
 } from "./messages.ts";
-export {isAiAgentSessionState, parseSessionState} from "./snapshot.ts";
+export {
+	isAiAgentSessionState,
+	loadCheckpoint,
+	parseSessionState,
+	withCheckpointDefaults,
+} from "./snapshot.ts";
 export {
 	type AgentFailure,
 	type AiAgentSessionState,
+	type CheckpointField,
+	checkpointFields,
 	emptyUsage,
 	type HistoryPage,
 	type Interruption,

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -40,7 +40,8 @@ import {
 	type AiAgentSessionSub,
 	eventsSub,
 } from "./messages.ts";
-import {type AiAgentSessionState, initialState, lastAssistantId, restore} from "./state.ts";
+import {loadCheckpoint} from "./snapshot.ts";
+import {type AiAgentSessionState, initialState, lastAssistantId} from "./state.ts";
 
 export interface AiAgentSessionOptions extends WindowLimits {
 	/** The working directory a fresh session starts in. */
@@ -98,7 +99,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 		init: (loaded) =>
 			loaded === null
 				? [initialState(options.cwd), [{type: "aiAgent.boot", cwd: options.cwd}]]
-				: [restore(loaded), noCmds],
+				: [loadCheckpoint(loaded, options.cwd), noCmds],
 		update: {
 			start: (state, msg) =>
 				busy(state)

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -11,10 +11,12 @@ import {pendingPermission} from "../../ai-agent-fixtures/permissions.ts";
 import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 import type {AgentEvent} from "../events.ts";
 import {Mode, type ModelRef, type PermissionRequest, type TranscriptItem} from "../ports/index.ts";
+import {checkpointUnreadable} from "./failures.ts";
 import {promptItemId} from "./fold.ts";
 import {aiAgentSessionMachine} from "./machine.ts";
 import type {AiAgentSessionCmd, AiAgentSessionMsg} from "./messages.ts";
-import {type AiAgentSessionState, initialState} from "./state.ts";
+import {isAiAgentSessionState, loadCheckpoint} from "./snapshot.ts";
+import {type AiAgentSessionState, checkpointFields, initialState} from "./state.ts";
 
 const machine = aiAgentSessionMachine({cwd: "/repo"});
 
@@ -67,6 +69,91 @@ describe("init", () => {
 		expect(state.phase).toBe("idle");
 		expect(state.interrupted).toBe("a1");
 		expect(cmds).toEqual([]);
+	});
+
+	// The rehydrate branch is the defaulting parse and nothing else, so what the store read back is
+	// checked on the production load path rather than trusted for being typed as the state (#8095).
+	it("reads a loaded checkpoint through the parse, not around it", () => {
+		const loaded = started();
+		expect(machine.init(loaded, {})[0]).toEqual(loadCheckpoint(loaded, "/repo"));
+	});
+});
+
+/**
+ * The load path against checkpoints the running build did not write.
+ *
+ * These read `loadCheckpoint` rather than `init` because that is the only signature the raw object
+ * a store hands back fits: `init` is typed as taking the state, which is the very claim nothing had
+ * checked. The wiring — that `init`'s rehydrate branch is this function — is pinned above.
+ */
+describe("a checkpoint written by an older build", () => {
+	const older: Record<string, unknown> = {
+		...initialState("/desk"),
+		phase: "ready",
+		sessionId: "session-9",
+		transcript: {items: [userItem("u1")], omitted: initialState("/x").transcript.omitted},
+		modes: {current: Mode.make("plan"), available: [Mode.make("plan")]},
+		models: {current: opus, available: [opus, sonnet]},
+		lastPrompt: "make the README",
+	};
+
+	/** The desk's `5c26458b35` shape: the three fields that build's `checkpointFields` never had. */
+	const deskShaped = (): Record<string, unknown> => {
+		const {commands, permissionsRaised, interruption, ...rest} = older;
+		return rest;
+	};
+
+	const restoredFrom = (raw: Record<string, unknown>): AiAgentSessionState =>
+		loadCheckpoint(raw, "/desk");
+
+	// The session id is asserted beside the three defaults on purpose: `initialState` carries those
+	// same three values, so a refusal that wiped the checkpoint would satisfy them on its own.
+	it("comes back with each absent field at its empty default", () => {
+		const state = restoredFrom(deskShaped());
+		expect(state.commands).toEqual([]);
+		expect(state.permissionsRaised).toBe(0);
+		expect(state.interruption).toBeNull();
+		expect(state.sessionId).toBe("session-9");
+	});
+
+	it("carries every field it did save through untouched", () => {
+		const state = restoredFrom(deskShaped());
+		expect(state.transcript).toEqual(older.transcript);
+		expect(state.sessionId).toBe("session-9");
+		expect(state.cwd).toBe("/desk");
+		expect(state.modes).toEqual(older.modes);
+		expect(state.models).toEqual(older.models);
+		expect(state.lastPrompt).toBe("make the README");
+		// The saved `ready` becomes `idle` the way any restore does: the process holds no transport.
+		expect(state.phase).toBe("idle");
+	});
+
+	it("is a session state once defaulted, so nothing downstream reads an absent field", () => {
+		const state = restoredFrom(deskShaped());
+		expect(isAiAgentSessionState(state)).toBe(true);
+		// The refused state is a session state too, so the predicate alone would pass either way.
+		expect(state.sessionId).toBe("session-9");
+	});
+
+	// The fill supplies an absent field and never repairs a present one, so the predicate still has
+	// something to refuse — a checkpoint that is wrong rather than merely old.
+	it("is refused when a field it did save carries the wrong type", () => {
+		const state = restoredFrom({...deskShaped(), commands: 3});
+		expect(state.failure).toEqual(checkpointUnreadable);
+		// `gone`, so the spawner dispatches nothing: an `idle` refusal's fresh `start` would clear
+		// the failure before the operator ever read it.
+		expect(state.phase).toBe("gone");
+		expect(state.transcript.items).toEqual([]);
+	});
+
+	it("keeps a refusal the operator can read out of the restored session", () => {
+		expect(restoredFrom(deskShaped()).failure).toBeNull();
+	});
+
+	// Reds if a field is added to the state with no entry in `initialState` to default it from.
+	it("has a default for every field a checkpoint carries", () => {
+		const defaulted: ReadonlyArray<string> = Object.keys(initialState("/desk"));
+		expect(checkpointFields.filter((field) => !defaulted.includes(field))).toEqual([]);
 	});
 });
 

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -17,11 +17,15 @@ import {
 	isWindowOmission,
 	type PendingPermission,
 } from "../ports/index.ts";
+import {checkpointUnreadable} from "./failures.ts";
 import {
 	type AiAgentSessionState,
+	checkpointFields,
 	type HistoryPage,
 	type Interruption,
+	initialState,
 	phases,
+	restore,
 	type UsageTotals,
 } from "./state.ts";
 
@@ -97,3 +101,46 @@ export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionSt
 /** A snapshot the predicate refuses is `null`, never a throw — the store decides what to do. */
 export const parseSessionState = (raw: unknown): AiAgentSessionState | null =>
 	isAiAgentSessionState(raw) ? raw : null;
+
+/**
+ * An absent field takes its empty default, so a checkpoint written before that field landed is
+ * still a session (#8095).
+ *
+ * Nothing filled one before, and the load path trusted the type instead: a desk that had saved
+ * before `commands` landed came back with `commands: undefined`, which emptied the slash-command
+ * picker, and with `permissionsRaised: undefined`, which made `permissionsRaised + 1` `NaN` from
+ * the first card onward. `JSON` then dropped the `undefined` key on the save that follows `init`,
+ * so the hole was written back over the checkpoint.
+ *
+ * Derived, never a second list: `checkpointFields` is the field set and `initialState` is the
+ * defaults, so the next field added to the state is filled by this same walk. It supplies what is
+ * absent and repairs nothing — a field saved with the wrong type stays wrong, and
+ * `parseSessionState` still refuses it.
+ */
+export const withCheckpointDefaults = (raw: unknown, cwd: string): unknown => {
+	if (!Predicate.isObject(raw)) return raw;
+	const absent = checkpointFields.filter((field) => raw[field] === undefined);
+	if (absent.length === 0) return raw;
+	const defaults = initialState(cwd);
+	return {...raw, ...Object.fromEntries(absent.map((field) => [field, defaults[field]]))};
+};
+
+/**
+ * What the store loaded, read as a session — or the refusal, when it is not one. The machine's
+ * `init` rehydrate branch is this and nothing else.
+ *
+ * It takes `unknown` because that is what arrives: Demlik types `init`'s argument as the state, but
+ * the checkpoint store's `migrate` is identity and the envelope's parse never looks inside the
+ * state, so before #8095 the load path trusted a type nothing had checked.
+ *
+ * A checkpoint still invalid once defaulted comes back `gone` carrying the refusal. `gone` is the
+ * one phase `resumeMessages` dispatches nothing into (`../restore/checkpoint.ts`), so the failure
+ * survives to the window's status line — an `idle` refusal would trigger the fresh `start` that
+ * clears `failure`, which is the silent fresh session over an unreadable checkpoint #7514 refuses.
+ */
+export const loadCheckpoint = (loaded: unknown, cwd: string): AiAgentSessionState => {
+	const checkpoint = parseSessionState(withCheckpointDefaults(loaded, cwd));
+	return checkpoint === null
+		? {...initialState(cwd), phase: "gone", failure: checkpointUnreadable}
+		: restore(checkpoint);
+};

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -126,6 +126,41 @@ export const phases = [
 	"gone",
 ] as const satisfies ReadonlyArray<Phase>;
 
+/**
+ * Every field one checkpoint carries. Three things read it: the field-set test, which fails when a
+ * new field lands here without anyone deciding it survives a restart, the defaults fill on the load
+ * path (`snapshot.ts`), and a reader asking what a saved session is made of without walking the
+ * machine.
+ *
+ * Nothing wire-shaped is in it. Each entry is plain JSON by construction — the type-level proof is
+ * `boundary.unit.test.ts`, which reds when a service, a stream, an Effect or a closure reaches any
+ * depth of the state — so the whole checkpoint round-trips through `JSON`.
+ *
+ * It lives in the core, and `../restore/checkpoint.ts` re-exports it under the address callers read
+ * it by, for the reason `restoreSession` does: the core's import closure admits no sibling
+ * directory, and the fill that walks this list is the machine's own `init` branch.
+ */
+export const checkpointFields = [
+	"phase",
+	"sessionId",
+	"connection",
+	"cwd",
+	"transcript",
+	"interrupted",
+	"interruption",
+	"usage",
+	"permissions",
+	"permissionsRaised",
+	"modes",
+	"models",
+	"commands",
+	"lastPrompt",
+	"lastPage",
+	"failure",
+] as const satisfies ReadonlyArray<keyof AiAgentSessionState>;
+
+export type CheckpointField = (typeof checkpointFields)[number];
+
 export const emptyOmission: WindowOmission = {items: 0, bytes: 0, reason: "none"};
 
 export const emptyUsage: UsageTotals = {model: null, inputTokens: 0, outputTokens: 0, cost: 0};

--- a/apps/tuval/src/ai-agent/restore/checkpoint.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.ts
@@ -11,34 +11,11 @@
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../core/index.ts";
 
 /**
- * Every field one checkpoint carries. Two things read it: the field-set test, which fails when a
- * new field lands here without anyone deciding it survives a restart, and a reader asking what a
- * saved session is made of without walking the machine.
- *
- * Nothing wire-shaped is in it. Each entry is plain JSON by construction — the type-level proof is
- * `../core/boundary.unit.test.ts`, which reds when a service, a stream, an Effect or a closure
- * reaches any depth of the state — so the whole checkpoint round-trips through `JSON`.
+ * The checkpoint's field set, at the address this side reads it by. It lives in `../core/state.ts`
+ * because the defaults fill on the load path walks it and the core may import no sibling directory;
+ * re-exporting it here keeps one address, exactly as `../restore/index.ts` does for `restore`.
  */
-export const checkpointFields = [
-	"phase",
-	"sessionId",
-	"connection",
-	"cwd",
-	"transcript",
-	"interrupted",
-	"interruption",
-	"usage",
-	"permissions",
-	"permissionsRaised",
-	"modes",
-	"models",
-	"commands",
-	"lastPrompt",
-	"lastPage",
-	"failure",
-] as const satisfies ReadonlyArray<keyof AiAgentSessionState>;
-
-export type CheckpointField = (typeof checkpointFields)[number];
+export {type CheckpointField, checkpointFields} from "../core/index.ts";
 
 /**
  * What a spawner dispatches into a process the kernel just brought back.


### PR DESCRIPTION
Fixes #8095

An older checkpoint had no route back. `AiAgentSessionState` grows fields, and nothing on the load
path filled one a checkpoint written before that field does not carry — so `commands` came back
`undefined` and emptied the slash-command picker, `permissionsRaised` came back `undefined` and made
`permissionsRaised + 1` `NaN` from the first permission card onward, and the save that follows `init`
dropped the `undefined` key and wrote the hole back over the checkpoint.

The fix is at the seam `restore`'s own docblock already named and left empty: Demlik's `init`
rehydrate branch is the migration/parse hook. `loadCheckpoint` (`ai-agent/core/snapshot.ts`) is now
that whole branch. It takes `unknown`, because that is what actually arrives — the checkpoint store's
`migrate` is identity and the envelope's `parseSnapshot` never looks inside the state, so `init`'s
`AiAgentSessionState` argument type was a claim nothing had checked.

- **The fill is derived, not written.** `withCheckpointDefaults` walks `checkpointFields` and takes
  each absent field's value from `initialState`, so the next field added to the state is defaulted by
  the same walk with no second edit. It supplies what is absent and repairs nothing: a field saved
  with the wrong type stays wrong.
- **`parseSessionState` now runs on the production load path**, after the fill, so a checkpoint still
  invalid once defaulted is refused rather than restored half-shaped.
- **A refusal comes back `gone` carrying `checkpointUnreadable`.** `gone` is the one phase
  `resumeMessages` dispatches nothing into, so the failure survives to the window's status line,
  which already renders a `StartError` at rest as "The session is gone — …" (`shell/chat/phase.ts`).
  An `idle` refusal would have triggered the resume's fresh `start`, and that cell clears `failure` —
  the operator would never have read it. It is also the posture #7514/#7467 already take: never a
  silent fresh session over a checkpoint nobody could read.

`checkpointFields` moved from `ai-agent/restore/checkpoint.ts` into `ai-agent/core/state.ts` beside
`phases`, because the fill walks it and `core/boundary.unit.test.ts` admits no sibling directory in
the core's import closure. `restore/checkpoint.ts` re-exports it, so every existing address still
resolves — the same idiom `restore/index.ts` already uses for `restoreSession`, and for the same
reason.

Grounded in `@demlik/tea` 0.12's own types at the pin: `Machine.init` is
`(loaded: S | null, ctx: Ctx) => readonly [S, readonly C[]]` (`dist/core-*.d.ts`) and `Store.migrate`
is `(raw: unknown) => S | null` (`dist/runtime-types-*.d.ts`) — the two together are why the type at
`init` says more than anything had verified.

Tests are in `core/machine.unit.test.ts`, against the desk's `5c26458b35` shape. Each of the four
behavioural cases was checked to red with the fill disabled: two of them first passed vacuously,
because a refused checkpoint resolves to `initialState`, which carries those same three empty
defaults — so they now assert a saved field survived alongside.

## Deviations

- **Out-of-scope change** — **Said:** #8095 names the fill, the parse, and the visible refusal.
  **Did:** also moved `checkpointFields` from `ai-agent/restore/checkpoint.ts` into
  `ai-agent/core/state.ts`, leaving a re-export behind. **Why:** the acceptance criteria require the
  fill to derive from `checkpointFields`, and the fill runs inside the core, whose import closure
  (`core/boundary.unit.test.ts`) admits no sibling directory — so the list had to be reachable from
  the core or the criterion could not be met. **Disposition:** stated here; no caller's import path
  changed, and the existing field-set test still reads it from its old address.
