### PR TITLE
fix: ChatWindow forks the host view write from inside a setState updater, so a double-invoke writes twice

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -302,18 +302,25 @@ function ChatWindow({
 	const [older, setOlder] = useState<ReadonlyArray<TranscriptItem>>([]);
 	const [loading, setLoading] = useState(false);
 
+	// The last committed view, so `commit` can apply `next` and fork the host write out here rather
+	// than inside the `setViewLocal` updater. React documents an updater as pure and re-invokes it —
+	// `StrictMode` does so on every commit, and Tuval only ever runs in development (ADR 0345) — so
+	// a `runFork` in there is two `setView` calls per keystroke. The ref is written in the same tick
+	// as the state, which is what keeps two commits batched into one render composing: the debounced
+	// scroll offset and `toggleTool`'s expanded set both read what the previous commit wrote.
+	const viewRef = useRef(view);
+
 	const commit = useCallback((next: (current: ChatView) => ChatView) => {
-		setViewLocal((current) => {
-			const value = next(current);
-			// The identity has to stop the host write and not just the local one: `window.setView`
-			// rebuilds `ShellState` wholesale (`../core/machine.ts`), so a no-change write from
-			// `onScroll` re-renders every subscriber of the desk once per scroll frame — the cost
-			// the `scrollCommitMs` debounce beside it exists to bound — while React's bail-out on
-			// the returned identity hides it from this window.
-			if (value === current) return current;
-			void Effect.runFork(hostRef.current.setView(value));
-			return value;
-		});
+		const current = viewRef.current;
+		const value = next(current);
+		// The identity has to stop the host write and not just the local one: `window.setView`
+		// rebuilds `ShellState` wholesale (`../core/machine.ts`), so a no-change write from
+		// `onScroll` re-renders every subscriber of the desk once per scroll frame — the cost
+		// the `scrollCommitMs` debounce beside it exists to bound.
+		if (value === current) return;
+		viewRef.current = value;
+		void Effect.runFork(hostRef.current.setView(value));
+		setViewLocal(value);
 	}, []);
 
 	const dispatch = useCallback((msg: AiAgentSessionMsg) => {

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -13,7 +13,7 @@
 
 import {act, fireEvent, render, screen, waitFor, within} from "@testing-library/react";
 import {Effect, Stream} from "effect";
-import type {ReactElement} from "react";
+import {type ReactElement, StrictMode} from "react";
 import {afterEach, describe, expect, it} from "vitest";
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
 import {phases} from "../../ai-agent/core/state.ts";
@@ -55,6 +55,7 @@ const openWindow = async (
 	state: AiAgentSessionState,
 	options: ChatWindowOptions = {},
 	initialView?: ChatView,
+	mount: {readonly strict?: boolean} = {},
 ): Promise<Harness & {readonly view: () => ChatView}> => {
 	const process = await Effect.runPromise(
 		testProcess<AiAgentSessionState, AiAgentSessionMsg>(processId, state),
@@ -85,7 +86,7 @@ const openWindow = async (
 		...options,
 	};
 	const element = chatWindow(resolved).render(host) as ReactElement;
-	render(element);
+	render(element, mount.strict === true ? {wrapper: StrictMode} : undefined);
 	giveScrollBox(await screen.findByRole("log", {name: "Transcript"}));
 	return {process, host, scrolls, writes, keys, view: () => host.view()};
 };
@@ -714,5 +715,89 @@ describe("a group head's fold, as a control assistive tech can read", () => {
 			fireEvent.click(folds[1] as HTMLElement);
 		});
 		expect(document.getElementById("tuval-row-w1-leaf")).not.toBeNull();
+	});
+});
+
+/**
+ * React documents a state updater as pure and `StrictMode` re-invokes it, so a host write forked
+ * from inside one lands twice per commit (#8033). Tuval mounts under `StrictMode` and never deploys
+ * (ADR 0345), so that is every commit the desk makes, not a hypothetical.
+ */
+describe("the view slot's writer, under StrictMode", () => {
+	it("forks one host setView per commit on the tool-toggle path", async () => {
+		const {writes} = await openWindow(
+			withTranscript([userItem("a", "do it"), call("c")]),
+			{},
+			undefined,
+			{strict: true},
+		);
+		await settle();
+		const before = writes.length;
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", {name: "read_file ok"}));
+		});
+		await settle();
+
+		expect(writes.length).toBe(before + 1);
+		expect(writes[writes.length - 1]?.expanded).toEqual(["c"]);
+	});
+
+	it("forks one host setView per keystroke on the draft path", async () => {
+		const {writes, view} = await openWindow(withTranscript(transcriptOf(2)), {}, undefined, {
+			strict: true,
+		});
+		await settle();
+		const before = writes.length;
+
+		const input = composer();
+		for (const draft of ["s", "sh", "shi"]) {
+			await act(async () => {
+				fireEvent.change(input, {target: {value: draft}});
+			});
+		}
+		await settle();
+
+		expect(writes.length).toBe(before + 3);
+		expect(view().draft).toBe("shi");
+	});
+
+	// The other half of "exactly once": a `next` handing back what it was given writes nothing at
+	// all, so the doubled write is not traded for an unconditional one.
+	it("forks nothing when a commit changes no field", async () => {
+		const {writes, view} = await openWindow(withTranscript(transcriptOf(20)), {}, undefined, {
+			strict: true,
+		});
+		await scrollTo(400);
+		await waitFor(() => expect(view().pinned).toBe(false));
+		await settle();
+
+		const settled = writes.length;
+		await scrollTo(400);
+		await scrollTo(400);
+		await settle();
+
+		expect(writes.length).toBe(settled);
+	});
+
+	// Two commits inside one batch: the second composes off what the first wrote, not off the view
+	// this render was given. It reds against a ref written from an effect rather than in `commit`.
+	it("composes batched commits off the last committed value", async () => {
+		const {writes, view} = await openWindow(
+			withTranscript([userItem("a", "do it"), call("c"), call("d", {name: "grep"})]),
+			{},
+			undefined,
+			{strict: true},
+		);
+		await settle();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", {name: "read_file ok"}));
+			fireEvent.click(screen.getByRole("button", {name: "grep ok"}));
+		});
+		await settle();
+
+		expect(view().expanded).toEqual(["c", "d"]);
+		expect(writes[writes.length - 1]?.expanded).toEqual(["c", "d"]);
 	});
 });


### PR DESCRIPTION
`ChatWindow.commit` forked the host view write from inside the `setViewLocal` updater. React
documents a state updater as pure and re-invokes it, and Tuval mounts under `StrictMode` and never
deploys (ADR 0345) — so every commit ran `window.setView` twice, and each of those rebuilds
`ShellState` wholesale and re-renders the desk. The composer commits on every keystroke, so typing
cost two full shell rebuilds per character.

`commit` now reads the last committed view out of a ref, applies `next` outside the updater, forks
the host write once, and hands `setViewLocal` a value. The updater is gone. The identity check keeps
its old job: a `next` that returns what it was given writes nothing to the host at all.

The ref is written in `commit`, in the same tick as the state, rather than from an effect. That is
what keeps two commits batched into one render composing — the debounced scroll offset and
`toggleTool`'s expanded set both read what the previous commit wrote, not the view the render was
handed. A ref written from an effect would reintroduce the stale read the issue flagged.

Four tests under `StrictMode` in `chat-window.unit.test.tsx` hold it: one `setView` per commit on
the tool-toggle path and per keystroke on the draft path, no write at all on a no-change commit,
and two batched toggles composing to `["c", "d"]`. The first two red at 2 and 6 against the old
shape; the last reds against a ref written from an effect.

Verified: `pnpm typecheck`, `pnpm lint`, and the full `apps/tuval` unit suite (1469 tests).

Fixes #8033

## Deviations

None.
