### PR TITLE
chore: Pillar 2's Unicode-glyph ban does not say whether a CSS state marker counts as an icon

### DIFF
--- a/.decisions/0166-canonical-icon-idiom.md
+++ b/.decisions/0166-canonical-icon-idiom.md
@@ -1,7 +1,7 @@
 ---
 id: 0166
-title: "The canonical icon idiom — Lucide line-icons at native per-size stroke, monochrome role-token color, a drawn triangle vote glyph, and the function/affect/key-legend partition"
-status: proposed; amended-in-part by [0240](0240-icon-dense-tier.md)
+title: "The canonical icon idiom — Lucide line-icons at native per-size stroke, monochrome role-token color, a drawn triangle vote glyph, and the function/affect/key-legend/state-marker partition"
+status: proposed; amended-in-part by [0240](0240-icon-dense-tier.md); extended in place by §8 (state markers, ruled 2026-09-05)
 date: 2026-07-06
 tags: [design, frontend, cohesiveness, icons, tokens, control-plane]
 ---
@@ -99,7 +99,41 @@ Glyphs partition into exactly three classes, and the class decides the delivery:
   chip** — never free-floating, never an icon.
 
 A functional glyph is a Lucide icon; a reaction is a controlled emoji in the reaction bar only; a
-keycap is `<kbd>` typography. Nothing crosses those lines.
+keycap is `<kbd>` typography. Nothing crosses those lines. The partition grew a fourth class in §8;
+these three are unchanged by it.
+
+### 8. A state marker is not an icon — the fourth class (ruled 2026-09-05)
+
+§7 sorted every glyph three ways and left one shape homeless: a Unicode glyph doing **state** work
+— a `::before` caret marking the active row, a check standing for a set item, a dot marking an open
+section. It names no function, is not a reaction, and is not a keycap, so §1's ban neither covered
+it nor exempted it, and two live surfaces were left to per-agent reading (the palette caret of
+[#7983](https://github.com/kamp-us/phoenix/issues/7983), the markdown checkbox of
+[#8023](https://github.com/kamp-us/phoenix/issues/8023)). Founder ruling, transcribed here:
+<https://github.com/kamp-us/phoenix/issues/8073#issuecomment-5555958957>.
+
+**A CSS state marker is not an icon.** §1's ban is about a functional glyph standing in for
+iconography; a marker decorating a state the component already carries is typography, and it stays
+legal as CSS generated content. This is **not** a general exemption for Unicode glyphs — two
+conditions bound it, and a marker failing either is back under §1's ban:
+
+1. **It pairs with a non-visual state signal** — either the ARIA state the component already exposes
+   (`aria-selected`, `aria-checked`, `aria-expanded`) or a visually-hidden state word. The state
+   never rides on the glyph alone; this is 0162's Pillar 4 applied, not a new rule.
+2. **It never leaks into the accessible name** — either the alternative-text form
+   (`content: "\203A" / ""`) or a glyph rendered on an `aria-hidden` element. Generated content
+   carrying no alt text is folded into a name-from-content computation by design, so an unbounded
+   marker corrupts the name of the very row it decorates
+   ([#8079](https://github.com/kamp-us/phoenix/issues/8079)).
+
+A glyph that names a **function** is still a Lucide icon wherever it is drawn; a marker that fails
+either condition is not a state marker but a functional glyph in the wrong delivery.
+
+The two live cases follow from this. **#7983's active-row caret stays a CSS `content:` glyph** — not
+a Lucide chevron rendered from `packages/design/src/CommandPalette.tsx` — and owes the alt-text form
+plus the `aria-selected` the palette already sets. **#8023's ruled treatment** (a decorative glyph
+plus a visually-hidden state word) satisfies the same two conditions by the other arm of each, and
+stands.
 
 ## Alternatives considered (rejected)
 

--- a/.decisions/0166-canonical-icon-idiom.md
+++ b/.decisions/0166-canonical-icon-idiom.md
@@ -90,7 +90,8 @@ substitution.
 
 ### 7. The three-way partition — the boundary rule
 
-Glyphs partition into exactly three classes, and the class decides the delivery:
+Glyphs partition into exactly three classes, and the class decides the delivery. (The partition grew
+a fourth class in §8; these three are unchanged by it.)
 
 - **Function** → a **drawn Lucide icon**, legal anywhere.
 - **Affect** → the curated **six-emoji reaction set** (monochrome-controlled per ADR
@@ -99,8 +100,7 @@ Glyphs partition into exactly three classes, and the class decides the delivery:
   chip** — never free-floating, never an icon.
 
 A functional glyph is a Lucide icon; a reaction is a controlled emoji in the reaction bar only; a
-keycap is `<kbd>` typography. Nothing crosses those lines. The partition grew a fourth class in §8;
-these three are unchanged by it.
+keycap is `<kbd>` typography. Nothing crosses those lines.
 
 ### 8. A state marker is not an icon — the fourth class (ruled 2026-09-05)
 
@@ -112,9 +112,10 @@ it nor exempted it, and two live surfaces were left to per-agent reading (the pa
 [#8023](https://github.com/kamp-us/phoenix/issues/8023)). Founder ruling, transcribed here:
 <https://github.com/kamp-us/phoenix/issues/8073#issuecomment-5555958957>.
 
-**A CSS state marker is not an icon.** §1's ban is about a functional glyph standing in for
+**A state marker is not an icon.** §1's ban is about a functional glyph standing in for
 iconography; a marker decorating a state the component already carries is typography, and it stays
-legal as CSS generated content. This is **not** a general exemption for Unicode glyphs — two
+legal in either delivery the ruling names — **CSS generated content, or a decorative element kept
+out of the accessible name**. This is **not** a general exemption for Unicode glyphs — two
 conditions bound it, and a marker failing either is back under §1's ban:
 
 1. **It pairs with a non-visual state signal** — either the ARIA state the component already exposes

--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -166,9 +166,10 @@ until they land, the rule still governs (do not seed a fresh hand-built instance
 | A functional icon (vote / nav / toolbar / inline) | A drawn **Lucide** icon at the ruled size + role token (the [icon idiom](#the-canonical-icon-idiom) below) | Ship a Unicode functional glyph (`△` `↑` `→` `⌘` `↵`) or a hand-inlined SVG as an icon. |
 
 **One system throughout:** one type ramp, one four-level elevation system, one icon idiom — never
-a second type/elevation system or a fourth icon idiom. The icon idiom's **positive** definition —
-the set, stroke, sizes, color, vote glyph, and function/affect/key-legend partition — is
-[encoded below](#the-canonical-icon-idiom) (ADR [0166](https://github.com/kamp-us/phoenix/blob/main/.decisions/0166-canonical-icon-idiom.md)).
+a second type/elevation system or a fourth icon idiom — and a *partition class* is not an idiom, so
+the boundary rule's state-marker class below adds no second icon system. The icon idiom's
+**positive** definition — the set, stroke, sizes, color, vote glyph, and the
+function/affect/key-legend/state-marker partition — is [encoded below](#the-canonical-icon-idiom) (ADR [0166](https://github.com/kamp-us/phoenix/blob/main/.decisions/0166-canonical-icon-idiom.md)).
 
 ---
 
@@ -222,11 +223,19 @@ migration of the live glyph surfaces to this idiom is a **separate downstream ch
 - **Vote glyph — a drawn triangle** (not a chevron — the HN / lobste.rs vote lineage): filled-accent
   (`--accent`) when active, outline-secondary (`--text-secondary`) when inactive, up/down symmetry,
   36px hit area. This is the one affordance that needs real design; the rest is substitution.
-- **The three-way partition (the boundary rule).** **Function** → a drawn Lucide icon (anywhere).
+- **The four-way partition (the boundary rule).** **Function** → a drawn Lucide icon (anywhere).
   **Affect** → the curated six-emoji reaction set (monochrome-controlled per ADR
   [0139](https://github.com/kamp-us/phoenix/blob/main/.decisions/0139-reaction-curated-palette.md)),
   **only** in the reaction bar. **Key-legends** → `⌘` `⌥` `⇧` `↵` `⎋` are keycap typography, legal
-  **only** inside a `<kbd>` chip — never free-floating, never an icon.
+  **only** inside a `<kbd>` chip — never free-floating, never an icon. **State markers** → a glyph
+  doing **state** work (a `::before` caret on the active row, a check on a set item, a dot on an open
+  section) is **not** an icon and stays legal as CSS generated content — but **only** while both
+  bounds hold: it pairs with a non-visual state signal (the ARIA state the component already exposes
+  — `aria-selected`, `aria-checked`, `aria-expanded` — or a visually-hidden state word, so state
+  never rides on the glyph alone, Pillar 4), **and** it never reaches the accessible name (the
+  alternative-text form `content: "\203A" / ""`, or an `aria-hidden` element). Fail either bound and
+  it is a functional glyph again, under the ban. A glyph naming a *function* is a Lucide icon
+  wherever it is drawn (ADR [0166](https://github.com/kamp-us/phoenix/blob/main/.decisions/0166-canonical-icon-idiom.md) §8).
 
 ---
 
@@ -256,7 +265,13 @@ card / meta-row / count-pill by hand.
 - **Never** ship raw system-emoji glyphs as reaction affordances.
 - **Never** introduce a fourth icon idiom or a second type/elevation system.
 - **Never** ship a Unicode functional glyph (`△` `↑` `→` `⌘` `↵`) or a hand-inlined SVG as an
-  icon — functional icons are drawn Lucide (the [icon idiom](#the-canonical-icon-idiom)).
+  icon — functional icons are drawn Lucide (the [icon idiom](#the-canonical-icon-idiom)). A **state
+  marker** is not an icon and this does not reach it: a state glyph in CSS generated content is legal
+  under the boundary rule's fourth class, inside both of that class's bounds.
+- **Never** ship a state marker outside those bounds — it pairs with the ARIA state or a
+  visually-hidden word (never state on the glyph alone), and it stays out of the accessible name via
+  `content: "\203A" / ""` or an `aria-hidden` element. Outside them it is a functional glyph and the
+  line above governs it.
 - **Never** hardcode an icon's color — icons are `stroke: currentColor` driven by role tokens
   only (the active vote glyph's `--accent` fill is the one exception).
 - **Never** place a keycap glyph (`⌘` `⌥` `⇧` `↵` `⎋`) free-floating as an icon — it is legal only

--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -229,7 +229,8 @@ migration of the live glyph surfaces to this idiom is a **separate downstream ch
   **only** in the reaction bar. **Key-legends** → `⌘` `⌥` `⇧` `↵` `⎋` are keycap typography, legal
   **only** inside a `<kbd>` chip — never free-floating, never an icon. **State markers** → a glyph
   doing **state** work (a `::before` caret on the active row, a check on a set item, a dot on an open
-  section) is **not** an icon and stays legal as CSS generated content — but **only** while both
+  section) is **not** an icon and stays legal as typography — delivered either as CSS generated
+  content or on a decorative element kept out of the accessible name — but **only** while both
   bounds hold: it pairs with a non-visual state signal (the ARIA state the component already exposes
   — `aria-selected`, `aria-checked`, `aria-expanded` — or a visually-hidden state word, so state
   never rides on the glyph alone, Pillar 4), **and** it never reaches the accessible name (the
@@ -266,8 +267,9 @@ card / meta-row / count-pill by hand.
 - **Never** introduce a fourth icon idiom or a second type/elevation system.
 - **Never** ship a Unicode functional glyph (`△` `↑` `→` `⌘` `↵`) or a hand-inlined SVG as an
   icon — functional icons are drawn Lucide (the [icon idiom](#the-canonical-icon-idiom)). A **state
-  marker** is not an icon and this does not reach it: a state glyph in CSS generated content is legal
-  under the boundary rule's fourth class, inside both of that class's bounds.
+  marker** is not an icon and this does not reach it: a state glyph — in CSS generated content or on
+  a decorative element — is legal under the boundary rule's fourth class, inside both of that
+  class's bounds.
 - **Never** ship a state marker outside those bounds — it pairs with the ARIA state or a
   visually-hidden word (never state on the glyph alone), and it stays out of the accessible name via
   `content: "\203A" / ""` or an `aria-hidden` element. Outside them it is a functional glyph and the


### PR DESCRIPTION
Fixes #8073

Transcribes the founder ruling of 2026-09-05 on #8073: a CSS state marker is not an icon under
Pillar 2's Unicode-glyph ban.

The manifest's boundary rule sorted every glyph three ways — Function, Affect, Key-legend — and a
glyph doing *state* work (a `::before` caret on the active row, a check on a set item) fell through
all three. The ban is scoped "as an icon", so it neither covered nor exempted the shape, and two
live surfaces were left to per-agent reading: #7983's palette caret and #8023's markdown checkbox.

## What changed

**`design-system-manifest.md`**

- The boundary rule is now a four-way partition. The fourth class, **State markers**, is legal as
  CSS generated content only while both bounds hold: it pairs with a non-visual state signal (the
  ARIA state the component already exposes, or a visually-hidden state word), and it never reaches
  the accessible name (`content: "\203A" / ""`, or an `aria-hidden` element). Fail either bound and
  it is a functional glyph again, under the ban — so the class cannot be read as a general Unicode
  exemption.
- Pillar 2's prohibition list is amended to agree: the Unicode-glyph line says a state marker is not
  an icon and is not covered, and a new prohibition reds a state marker that carries state alone or
  leaks into the accessible name.
- The "one system throughout" line now says a partition class is not an idiom, so the new class does
  not read as the fourth icon idiom that sentence outlaws.

**`.decisions/0166-canonical-icon-idiom.md`**

- New §8 records the ruling and cites the founder comment. It names the consequence for both live
  cases: #7983's caret **stays a CSS `content:` glyph** (not a Lucide chevron rendered from
  `packages/design/src/CommandPalette.tsx`) and owes the alt-text form plus the `aria-selected` the
  palette already sets; #8023's ruled treatment satisfies the same two bounds by the other arm of
  each and stands.

Ruling cited in both artifacts:
https://github.com/kamp-us/phoenix/issues/8073#issuecomment-5555958957

Docs only — no component code moves here. #7983 and #8079 are the builds this unblocks.

## Deviations

- **Out-of-scope change** — **Said:** the criteria name §8's content, the manifest's boundary rule
  and Pillar 2's list. **Did:** also edited 0166's frontmatter `title` and `status` (the title's
  "function/affect/key-legend partition" → "…/state-marker partition"; the status gained "extended
  in place by §8"). **Why:** ADR discovery is `ls .decisions/` plus frontmatter (CLAUDE.md's
  Decisions section), so a title still naming a three-way partition sends that reader to a stale
  row. **Disposition:** stated here.
- **Declined guidance** — **Said:** the prose rubric's "an ADR is authored via `/adr`, never
  hand-dropped into `.decisions/` from here". **Did:** edited `.decisions/0166` directly, adding §8.
  **Why:** criterion 5 asks for 0166 amended *or* a new ADR; amending the file that owns the
  partition keeps one home for it, and the rubric line governs authoring a new ADR file, which this
  is not. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** Pillar 2 and the boundary rule must agree.
  **Did:** left `.decisions/0240-icon-dense-tier.md:46`'s phrase "the function / affect /
  key-legend partition" untouched. **Why:** that sentence is 0240's dated record of what it did
  *not* change in 0166, not a live rule surface; rewriting a landed ADR's account of a prior state
  would falsify the history. **Disposition:** stated here.
