### PR TITLE
fix: A refused Tuval checkpoint is overwritten by the gone state on the very next line

### DIFF
--- a/.patterns/tuval-program-row-effects.md
+++ b/.patterns/tuval-program-row-effects.md
@@ -159,7 +159,8 @@ them. Every other phase the layer reports is news and folds normally.
 Durability is the kernel's ([`durability/Checkpoints.ts`](../apps/tuval/src/durability/Checkpoints.ts)),
 so a row does not write its own snapshot. What a row owes is the other half: what its state means
 after a restart, and what has to happen before it is usable again. Three rules, all of them visible
-in [`ai-agent/restore/`](../apps/tuval/src/ai-agent/restore/).
+in [`ai-agent/restore/`](../apps/tuval/src/ai-agent/restore/), plus one rule about the
+checkpoint a row *cannot* read.
 
 **The rehydrating `init` transforms and emits nothing.** Demlik throws on a non-null `loaded` whose
 `init` returns any Cmd (`@demlik/tea` 0.12 `runtime-types.ts`) — that branch is the migration and
@@ -189,6 +190,21 @@ whose checkpoint existed, `durability/restore.ts` for a checkpointed process the
 plan. Launch dispatches after **every** node is spawned and pumped, never inside the loop, because a
 resume republishes on its out-ports and a reader that has not launched yet would leave those
 payloads in a queue nobody drains.
+
+**A checkpoint the row cannot read is never written over, and the row says so under `restorable`.**
+A row that parses its checkpoint has a refusal branch, and the state that branch returns is a
+perfectly ordinary state — so the save the host runs straight after `init` writes it over the bytes
+it just refused. That costs the operator the transcript with no copy left to diagnose from, and it
+silences the refusal one restart later: the saved refusal state parses fine on the next boot, and
+the restore transform drops `failure` off it, so the window falls from the refusal sentence to the
+bare phase line ([#8112](https://github.com/kamp-us/phoenix/issues/8112)). The row declares
+`restorable: (raw) => boolean` ([`registry/program.ts`](../apps/tuval/src/registry/program.ts)) —
+the same read its `init` does, answered before `init` runs — and a `false` seals that process's
+store: `Checkpoints` hands the host a store whose `save` writes nothing for the process's life, so
+the bytes stay on disk and every later boot re-reads and re-refuses them. Answer it off the one
+function `init` uses, never a second copy of the parse: a store sealing on a different verdict than
+the one the window renders would hold the wrong bytes. A row with no parse of its own omits the
+field and restores whatever loads.
 
 **A restored process publishes nothing until something republishes it.** Out-ports are event-driven:
 a projection leaves when the fold moves it. A process brought back from a checkpoint has a full

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -40,6 +40,7 @@ export {
 	isAiAgentSessionState,
 	loadCheckpoint,
 	parseSessionState,
+	readCheckpoint,
 	withCheckpointDefaults,
 } from "./snapshot.ts";
 export {

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -133,6 +133,16 @@ export const withCheckpointDefaults = (raw: unknown, cwd: string): unknown => {
 };
 
 /**
+ * The checkpoint read, as the defaulting and the predicate composed once: the session, or `null`.
+ *
+ * One function rather than two call sites of the same pair, because `loadCheckpoint` wants the
+ * session and the row's `restorable` (`../program.ts`) wants only the bit. A store that sealed on a
+ * different verdict than the one the window renders would hold the wrong bytes (#8112).
+ */
+export const readCheckpoint = (loaded: unknown, cwd: string): AiAgentSessionState | null =>
+	parseSessionState(withCheckpointDefaults(loaded, cwd));
+
+/**
  * What the store loaded, read as a session — or the refusal, when it is not one. The machine's
  * `init` rehydrate branch is this and nothing else.
  *
@@ -144,9 +154,12 @@ export const withCheckpointDefaults = (raw: unknown, cwd: string): unknown => {
  * one phase `resumeMessages` dispatches nothing into (`../restore/checkpoint.ts`), so the failure
  * survives to the window's status line — an `idle` refusal would trigger the fresh `start` that
  * clears `failure`, which is the silent fresh session over an unreadable checkpoint #7514 refuses.
+ *
+ * The refused bytes are not destroyed by the save that follows `init`: the row answers `restorable`
+ * off the same read, and durability seals the store on a `false` (#8112).
  */
 export const loadCheckpoint = (loaded: unknown, cwd: string): AiAgentSessionState => {
-	const checkpoint = parseSessionState(withCheckpointDefaults(loaded, cwd));
+	const checkpoint = readCheckpoint(loaded, cwd);
 	return checkpoint === null
 		? {...initialState(cwd), phase: "gone", failure: checkpointUnreadable}
 		: restore(checkpoint);

--- a/apps/tuval/src/ai-agent/program.ts
+++ b/apps/tuval/src/ai-agent/program.ts
@@ -30,6 +30,7 @@ import {
 	PAGE_ERROR,
 	PROMPT_ERROR,
 	portRefused,
+	readCheckpoint,
 	UNKNOWN_REQUEST,
 } from "./core/index.ts";
 import {
@@ -176,6 +177,7 @@ export const aiAgentProgram = <RIn = never>(
 		handlers,
 		subs,
 		resume: resumeMessages,
+		restorable: (raw) => readCheckpoint(raw, options.config.cwd) !== null,
 		capabilities: options.capabilities ?? [],
 		...(options.renderer === undefined ? {} : {renderer: options.renderer}),
 		identity: {

--- a/apps/tuval/src/ai-agent/restore/refused-checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/refused-checkpoint.unit.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A checkpoint the load refuses is never written over (#8112).
+ *
+ * Two boots over one seeded store. The first has to refuse the bytes without saving its own `gone`
+ * state on top of them, and the second has to read the same bytes and refuse them again: before
+ * the seal the refusal survived exactly one restart, because the saved `gone` state was itself a
+ * readable session, `restore` dropped its `failure`, and the status line fell from the refusal
+ * sentence to a bare "The session is gone."
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer, Schema} from "effect";
+import {Checkpoints} from "../../durability/Checkpoints.ts";
+import type {Snapshot} from "../../durability/snapshot.ts";
+import {type CheckpointStores, memoryStores} from "../../durability/stores.ts";
+import {NodeId} from "../../ports/graph.ts";
+import {PortNotWired, ProcessPorts} from "../../ports/index.ts";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessId} from "../../process/process.ts";
+import {ProgramId} from "../../registry/program.ts";
+import {Registry} from "../../registry/Registry.ts";
+import {checkpointUnreadable} from "../core/failures.ts";
+import {type AiAgentSessionState, initialState, isAiAgentSessionState} from "../core/index.ts";
+import {ItemId} from "../ports/index.ts";
+import {aiAgentProgram} from "../program.ts";
+import {plainReply} from "../service/fixtures/scripts.ts";
+import {ScriptedAiAgent} from "../service/index.ts";
+
+const PROGRAM = "ai-agent-refused-checkpoint-test";
+const PROCESS = ProcessId.make("agent-refused");
+const CWD = "/work";
+const VERSION = "1.0.0";
+
+/** One saved turn, so what the refusal would have destroyed is a transcript and not an empty state. */
+const withATranscript = (sessionId: string): AiAgentSessionState => {
+	const base = initialState(CWD);
+	return {
+		...base,
+		sessionId,
+		transcript: {
+			...base.transcript,
+			items: [
+				{kind: "user", id: ItemId.make("u1"), timestamp: 1_760_000_000_000, text: "the work"},
+			],
+		},
+	};
+};
+
+/**
+ * A saved session with one field of a type the predicate refuses. Defaulting fills only what is
+ * absent, so `commands` stays a number and the whole state stays unreadable — the false-negative
+ * shape #8112 is about, standing in for a predicate that tightens under a transcript someone still
+ * wants back. Everything else is a real session, so the refusal has exactly one cause.
+ */
+const refused: Snapshot = {
+	programId: PROGRAM,
+	version: VERSION,
+	state: {...withATranscript("session-lost"), commands: 3},
+};
+
+const readable: Snapshot = {
+	programId: PROGRAM,
+	version: VERSION,
+	state: withATranscript("session-kept"),
+};
+
+const row = aiAgentProgram({
+	id: PROGRAM,
+	layer: ScriptedAiAgent.layer(plainReply),
+	config: {cwd: CWD},
+	identity: {version: VERSION},
+});
+
+/** Nothing here dispatches, and a restored `init` emits no Cmds, so no port is ever reached. */
+const ports = ProcessPorts.of({
+	emit: (port) => Effect.fail(new PortNotWired({node: NodeId.make("test"), port})),
+});
+
+const kernel = (stores: CheckpointStores) =>
+	Processes.layer.pipe(
+		Layer.provideMerge(Checkpoints.layer(stores)),
+		Layer.provideMerge(Registry.layer([row])),
+	);
+
+const sessionOf = (state: unknown): AiAgentSessionState => {
+	assert.isTrue(isAiAgentSessionState(state), "the process is not holding an agent session state");
+	return state as AiAgentSessionState;
+};
+
+/** One boot at the fixed id, closed at the end so the stop-save flushes too. */
+const boot = (stores: CheckpointStores) =>
+	Effect.gen(function* () {
+		const processes = yield* Processes;
+		const handle = yield* processes.spawn(ProgramId.make(PROGRAM), {
+			id: PROCESS,
+			services: Context.make(ProcessPorts, ports),
+		});
+		return sessionOf(handle.getState());
+	}).pipe(Effect.scoped, Effect.provide(kernel(stores)));
+
+class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defect()}) {}
+
+const io = <A>(run: () => Promise<A>) =>
+	Effect.tryPromise({try: run, catch: (cause) => new TestIo({cause})});
+
+const stored = (stores: CheckpointStores) => io(() => stores.snapshot(PROCESS).load());
+
+describe("a checkpoint the agent's load refuses", () => {
+	it.live("comes back refused on every boot, over bytes neither boot overwrote", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+			yield* io(() => stores.snapshot(PROCESS).save(refused));
+
+			const first = yield* boot(stores);
+			assert.strictEqual(first.phase, "gone");
+			assert.deepStrictEqual(first.failure, checkpointUnreadable);
+
+			const second = yield* boot(stores);
+			assert.strictEqual(second.phase, "gone");
+			assert.deepStrictEqual(
+				second.failure,
+				checkpointUnreadable,
+				"the second boot lost the refusal, so the window reads the bare gone line",
+			);
+
+			assert.deepStrictEqual(
+				yield* stored(stores),
+				refused,
+				"the refused checkpoint was written over, so there is nothing left to diagnose",
+			);
+		}),
+	);
+
+	it.live("leaves a checkpoint that parses saved after init, as before", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+			yield* io(() => stores.snapshot(PROCESS).save(readable));
+
+			const restored = yield* boot(stores);
+			assert.strictEqual(restored.sessionId, "session-kept");
+
+			assert.deepStrictEqual(
+				yield* stored(stores),
+				{programId: PROGRAM, version: VERSION, state: restored},
+				"a readable checkpoint no longer takes the save that follows init",
+			);
+		}),
+	);
+});

--- a/apps/tuval/src/durability/Checkpoints.ts
+++ b/apps/tuval/src/durability/Checkpoints.ts
@@ -6,6 +6,11 @@
  * snapshot, refuses one written under another definition, records the process in the manifest
  * and takes the hold; release drops the hold. A refusal fails the spawn — the process is never
  * fresh-booted over its own snapshot (#7467).
+ *
+ * A snapshot the program itself cannot restore (`CheckpointTarget.restorable`) is not refused
+ * here — the program boots on its own refusal — but the store is sealed against writing, so
+ * the bytes it could not read survive every later boot instead of being overwritten by the
+ * state that refused them (#8112).
  */
 
 import type {Store} from "@demlik/tea";
@@ -30,6 +35,12 @@ export interface CheckpointTarget {
 	readonly parentId: Option.Option<ProcessId>;
 	/** The program's current definition version; a snapshot under any other is refused. */
 	readonly version: string;
+	/**
+	 * The program's own read of a raw checkpoint (`Program.restorable`). A snapshot it answers
+	 * `false` for seals this store: nothing is written over those bytes for the process's life.
+	 * Absent means every snapshot is restorable, which is the answer for a program with no parse.
+	 */
+	readonly restorable?: (raw: unknown) => boolean;
 }
 
 export interface OpenedCheckpoint {
@@ -122,9 +133,13 @@ const makeService = (stores: CheckpointStores): Checkpoints["Service"] => {
 		const snapshot = yield* loadSnapshot(target, backing);
 		yield* record(target);
 		held.add(target.id);
+		const sealed = snapshot !== null && target.restorable?.(snapshot.state) === false;
 		const store: Store<unknown> = {
 			load: () => Promise.resolve(snapshot === null ? null : snapshot.state),
-			save: (state) => backing.save({programId: target.programId, version: target.version, state}),
+			save: (state) =>
+				sealed
+					? Promise.resolve()
+					: backing.save({programId: target.programId, version: target.version, state}),
 			migrate: (raw) => raw,
 		};
 		return {store, restored: snapshot !== null} satisfies OpenedCheckpoint;

--- a/apps/tuval/src/process/Processes.ts
+++ b/apps/tuval/src/process/Processes.ts
@@ -235,6 +235,7 @@ function makeServices() {
 					programId,
 					parentId,
 					version: program.identity.version,
+					...(program.restorable === undefined ? {} : {restorable: program.restorable}),
 				});
 				return yield* makeActor(toDefinition(program, checkpoint.store, handlerServices, onCommit));
 			}).pipe(

--- a/apps/tuval/src/registry/program.ts
+++ b/apps/tuval/src/registry/program.ts
@@ -178,6 +178,18 @@ export interface Program<
 	 * reads what the Msgs mean.
 	 */
 	readonly resume?: (state: S) => ReadonlyArray<M>;
+	/**
+	 * Whether this program could restore the raw checkpoint durability loaded for it — the same
+	 * verdict its `init` reaches, asked before `init` runs.
+	 *
+	 * `false` means the process boots on its own refusal, and durability holds the bytes for it: a
+	 * snapshot this refuses is never written over, so it stays on disk to be read and re-refused on
+	 * every later boot (`src/durability/Checkpoints.ts`, #8112). Without it the refusal was
+	 * one-shot — the state carrying it was saved straight back over the checkpoint it refused, and
+	 * the next boot restored that state with no failure on it. A row that omits the field restores
+	 * whatever loads, which is every program with no parse of its own.
+	 */
+	readonly restorable?: (raw: unknown) => boolean;
 	readonly capabilities: ReadonlyArray<CapabilityRequest>;
 	/**
 	 * The program takes keys the shell forwards from its focused window, as its own `key` Msg. Only


### PR DESCRIPTION
A checkpoint `loadCheckpoint` refuses is no longer destroyed by the save that runs on the very next
line. The rule: a checkpoint the program's own load refused is never written over.

## Where it lives

The refusal is the AI agent's, the write is the generic host's, and the seam between them is the
store `durability/Checkpoints.ts` hands the host. So the row declares the read and durability
enforces it; `host/actor.ts` is untouched.

- `registry/program.ts` — a new optional `restorable: (raw) => boolean` on the row, a sibling of the
  existing `resume`. It is the same verdict the row's `init` reaches, asked before `init` runs.
- `durability/Checkpoints.ts` — a snapshot the row answers `false` for **seals** that process's
  store: `save` writes nothing for the process's life. The snapshot is not refused (the spawn still
  succeeds and the program boots on its own refusal, which is what keeps #7514's "never a silent
  fresh session" true); only the write is withheld.
- `ai-agent/core/snapshot.ts` — `readCheckpoint` factors out the defaults-then-parse pair, so
  `loadCheckpoint` and the row's `restorable` answer off one function. Two copies of that read could
  drift, and a store sealing on a different verdict than the one the window renders would hold the
  wrong bytes.
- `ai-agent/program.ts` — the row answers `restorable` off `readCheckpoint`.
- `process/Processes.ts` — passes the row's declaration to `checkpoints.open`. A row that omits the
  field opens exactly as before.

Not overwriting cures the second half for free: the original bytes stay on disk, so every later
restart re-reads them, re-refuses them, and the status line keeps saying so instead of degrading to
the bare "The session is gone." No sibling key, per the issue's triage note.

## Tests

`ai-agent/restore/refused-checkpoint.unit.test.ts` boots the same process id twice over one seeded
store. The refused fixture is a real session with exactly one field of a refused type, so the
refusal has one cause. Both boots come back `gone` carrying `checkpointUnreadable`, and the stored
snapshot at the end is byte-identical to the seed. A second case seeds a checkpoint that parses and
asserts the store holds the state `init` produced — the normal save-after-init path is unchanged.
Checked non-vacuous: with the seal forced off, the first case fails.

`.patterns/tuval-program-row-effects.md` gains the rule beside the three restore rules it already
carries.

`apps/tuval`'s full unit suite passes (1494 tests), plus `pnpm typecheck --force` and
`pnpm lint:worktree` cache-bypassed in this tree.

## Grounding

`Store` is `{load, save, migrate}` and `migrate` returns `S | null` — read at the pin,
`@demlik/tea@0.12.0` `dist/runtime-types-Bxc637bp.d.ts` lines 259-262. `migrate` is not the seam
used here: it cannot distinguish "no checkpoint" from "an unreadable one", and collapsing the two
is the silent fresh session #7514 refuses.

Fixes #8112

## Deviations

- **Out-of-scope change** — **Said:** #8112 names `apps/tuval/src/ai-agent/` or
  `apps/tuval/src/durability/Checkpoints.ts` as where the fix lives. **Did:** also touched
  `registry/program.ts` and `process/Processes.ts`. **Why:** the refusal is knowable only on the
  AI-agent side and the write happens only through the store `Checkpoints` builds, so the two have
  to be connected; the row field plus one spread at the existing `checkpoints.open` call is that
  connection and carries no program-specific knowledge. The judgment (ai-agent) and the enforcement
  (Checkpoints) both land where the criterion asks, and `host/actor.ts` is unchanged.
  **Disposition:** stated here.
