### PR TITLE
fix(tuval): a message written while the agent works queues instead of vanishing

### DIFF
--- a/.decisions/0357-tuval-prompts-queue-during-turn.md
+++ b/.decisions/0357-tuval-prompts-queue-during-turn.md
@@ -1,0 +1,49 @@
+---
+id: 0357
+title: A prompt written during a turn queues in the session, never refused and never a transcript row
+status: accepted
+date: 2026-09-06
+tags: [tuval, ai-agent, ux]
+---
+
+# 0357 — A prompt written during a turn queues in the session, never refused and never a transcript row
+
+**What this decides:** When you type into the Tuval chat composer while the agent is still working, the message waits in the session's own queue — visible, unsent — and goes out when that turn ends, instead of being refused as data.
+
+## Context
+
+The `ai-agent-session` core refused every `prompt` outside `ready`, `prompting` included. The composer it drives (`AgentChatInput`, `@kampus/design`) does the opposite: a submit while working is coerced to `follow_up`, sent through the bridge anyway, and optimistically logged as "The next prompt was queued." (`admin.agent.activity.followUpQueued`). Tuval's bridge dropped the delivery mode, the core refused the prompt, and the operator was told "queued" by one surface and "This message was not sent." by another, for the same keystroke — with their words in no transcript and no queue (#8159).
+
+Two candidate homes for the queue were rejected. The composer already believes it queues, and a queue kept there would be one window's optimism: the other window over the same process would never see it, and a checkpoint would not carry it. The transcript is the other, and it is worse — a tail row for a message no backend has heard of claims a turn that does not exist, and the echo join (`core/fold.ts`) would then be reconciling against a turn nobody sent.
+
+The session state is the home for the same reason it holds `sends` and `permissions`: Tuval's core owns state and a window renders it (ADR [0345](0345-tuval-lives-under-apps.md) puts that core in `apps/tuval`), and every field on it is plain data that a checkpoint round-trips.
+
+## Decision
+
+**A prompt the operator writes while the session is `prompting` is queued in `AiAgentSessionState.queued`; the running turn's own end is the only thing that admits one, and anything that breaks that continuity releases the whole queue back to the operator as an unsent send.**
+
+The queue is `ReadonlyArray<QueuedPrompt>` (`key`, `text`, `timestamp`) — the same three facts an admission needs, so a flush is the ordinary admission path and not a second one. It is a checkpoint field like any other.
+
+Admission is one function (`admit` in `core/machine.ts`), reached from two places: the `prompt` cell on a `ready` session, and the queue settle that runs after every cell which can land the session somewhere the queue's answer changes (`started`, `sent`, `event`, `failed`). Landing on `ready` admits the head; landing on `gone` or `idle` releases everything.
+
+A released prompt becomes a `refused` `SendOutcome` under its own key, never `uncertain`: the text was never handed to a layer, so "it might have run" is not among the things nobody knows about it. The window is already holding each key's copy (`shell/chat/outgoing.ts`), so a release surfaces as the existing Restore / Discard bar rather than as silence. Three events release: an `interrupt` (stopping a turn is not asking the next one to start), a session that goes `gone` or `idle` under the queue, and a `restore` — the turn a queue was waiting for ended with the process.
+
+**Binding constraints.**
+
+- A queued prompt is **not** a transcript item. `promptItem` runs at admission, never at enqueue.
+- Nothing but a turn's end flushes the queue. No timer, no reconnect shortcut, and no window-side resend.
+- The queue is bounded (`queueLimit`). At the bound the **newest** prompt is refused against its own key; the oldest is never evicted, because silently dropping what an operator already wrote is the defect this record answers.
+- A release is `refused`, never `uncertain`, and never an automatic resend.
+- A window renders `state.queued` and holds no queue of its own.
+
+## Consequences
+
+Sending a follow-up mid-turn becomes the ordinary act the composer already advertises, and the two surfaces stop disagreeing. Both windows over one process show the same waiting text, and it survives a restart as a recoverable unsent message rather than vanishing.
+
+The cost is that `prompting` is no longer a refusing phase, which changed four pinned cases in `core/machine.unit.test.ts` and the item-accounting predicate in `core/properties.unit.test.ts` (a prompt's item is now counted off the `aiAgent.prompt` Cmd, which is emitted at admission whether the prompt came from the cell or the queue). Every future cell that can land the session on `ready` must route its result through the queue settle, or a queued prompt sits there while the agent looks idle.
+
+Steer and follow-up are still one thing to Tuval. The generic `TuvalAiAgent` interface has no steer — injecting into a running turn is a capability no port declares — so both delivery modes queue, which is at least what the copy now truthfully says.
+
+## Records
+
+no vocabulary impact

--- a/apps/tuval/src/ai-agent/core/failures.ts
+++ b/apps/tuval/src/ai-agent/core/failures.ts
@@ -64,6 +64,25 @@ export const promptRefused = (phase: string): AgentFailure => ({
 	detail: `the session is ${phase}, not ready`,
 });
 
+/**
+ * The queue behind a running turn is full, so this prompt waits nowhere (`./queue.ts`).
+ *
+ * `refused` rather than `no-session`, because the session is perfectly alive and the text provably
+ * never crossed — which is also what routes it to the recoverable arm in `./sends.ts`.
+ */
+export const promptQueueFull = (limit: number): AgentFailure => ({
+	tag: PROMPT_ERROR,
+	reason: "refused",
+	detail: `${limit} messages are already waiting behind the running turn`,
+});
+
+/** A queued prompt released back to its window because the turn it was waiting for will not end. */
+export const promptUnqueued = (why: string): AgentFailure => ({
+	tag: PROMPT_ERROR,
+	reason: "refused",
+	detail: `the queued message was not sent: ${why}`,
+});
+
 export const unknownRequest = (request: string): AgentFailure => ({
 	tag: UNKNOWN_REQUEST,
 	reason: null,

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -10,6 +10,8 @@ export {
 	PAGE_ERROR,
 	PROMPT_ERROR,
 	portRefused,
+	promptQueueFull,
+	promptUnqueued,
 	START_ERROR,
 	THINKING_UNSUPPORTED,
 	TRANSPORT_ERROR,
@@ -37,6 +39,13 @@ export {
 	eventsSub,
 	eventsSubId,
 } from "./messages.ts";
+export {
+	enqueue,
+	isQueueFull,
+	type QueuedPrompt,
+	queueLimit,
+	releaseQueued,
+} from "./queue.ts";
 export {
 	noteSend,
 	pendingSend,

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -6,9 +6,12 @@
  * Each Cmd is the name of work a handler on the program row performs; the Sub is the name of the
  * layer's event stream, keyed by session id.
  *
- * Every refusal is data. A prompt outside `ready`, an answer to a card nobody raised, a mode the
- * agent does not offer: each records an `AgentFailure` and emits no Cmd, so a window renders the
+ * Every refusal is data. A prompt the session cannot take, an answer to a card nobody raised, a mode
+ * the agent does not offer: each records an `AgentFailure` and emits no Cmd, so a window renders the
  * refusal instead of a crash taking the process with it.
+ *
+ * A prompt written *during* a turn is the one that is not a refusal: it queues (`./queue.ts`), and
+ * the turn's own end admits it.
  */
 
 import {defineMachine, type Machine} from "@demlik/tea";
@@ -18,7 +21,9 @@ import {
 	modelUnsupported,
 	modeUnsupported,
 	noSessionToResume,
+	promptQueueFull,
 	promptRefused,
+	promptUnqueued,
 	startRefused,
 	thinkingUnsupported,
 	UNKNOWN_REQUEST,
@@ -41,6 +46,7 @@ import {
 	type AiAgentSessionSub,
 	eventsSub,
 } from "./messages.ts";
+import {enqueue, isQueueFull, type QueuedPrompt, queueLimit, releaseQueued} from "./queue.ts";
 import {noteSend, settledBy, settlePending} from "./sends.ts";
 import {loadCheckpoint} from "./snapshot.ts";
 import {type AiAgentSessionState, initialState, lastAssistantId} from "./state.ts";
@@ -62,6 +68,8 @@ const noCmds = [] as const;
 
 const noWork = (): Promise<void> => Promise.resolve();
 
+type Step = readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>];
+
 /** A phase a start would trample: a session is already opening, open or coming back. */
 const busy = (state: AiAgentSessionState): boolean =>
 	state.phase !== "idle" && state.phase !== "gone";
@@ -75,6 +83,55 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 		...(options.itemLimit === undefined ? {} : {itemLimit: options.itemLimit}),
 		...(options.byteLimit === undefined ? {} : {byteLimit: options.byteLimit}),
 	};
+
+	/** One prompt admitted: the tail records the turn, the send goes pending, the layer is told. */
+	const admit = (state: AiAgentSessionState, prompt: QueuedPrompt): Step => [
+		{
+			...state,
+			phase: "prompting",
+			lastPrompt: prompt.text,
+			interrupted: null,
+			interruption: null,
+			transcript: foldItem(state.transcript, promptItem(prompt), limits),
+			sends: noteSend(state.sends, {key: prompt.key, state: "pending"}),
+			failure: null,
+		},
+		[{type: "aiAgent.prompt", text: prompt.text, key: prompt.key}],
+	];
+
+	/**
+	 * What a committed transition owes the queue, applied to every cell that can land the session
+	 * somewhere the queue's answer changes.
+	 *
+	 * A session back at `ready` is the running turn having ended, which is the one event a queued
+	 * prompt waits for — so its head is admitted here, on the same commit, and the window never sees
+	 * a gap where the agent looks idle with work still queued. A session at `gone` or `idle` will
+	 * never end that turn, so what is queued is released to the operator instead (`./queue.ts`).
+	 * Every other phase leaves the queue exactly where it stands.
+	 */
+	const settleQueue = (step: Step): Step => {
+		const [state, cmds] = step;
+		const [head, ...rest] = state.queued;
+		if (head === undefined) return step;
+		if (state.phase === "ready") {
+			const [next, admitted] = admit({...state, queued: rest}, head);
+			return [next, [...cmds, ...admitted]];
+		}
+		if (state.phase !== "gone" && state.phase !== "idle") return step;
+		return [
+			{
+				...state,
+				queued: [],
+				sends: releaseQueued(
+					state.queued,
+					state.sends,
+					promptUnqueued("the session ended before the turn it was waiting for did"),
+				),
+			},
+			cmds,
+		];
+	};
+
 	return defineMachine<
 		AiAgentSessionState,
 		AiAgentSessionMsg,
@@ -125,7 +182,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 			started: (state, msg) =>
 				state.phase === "gone"
 					? [state, noCmds]
-					: [
+					: settleQueue([
 							{
 								...state,
 								phase: "ready",
@@ -135,40 +192,50 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 								failure: null,
 							},
 							noCmds,
-						],
+						]),
 
-			// The turn goes onto the tail here, not when a layer reports it back: the message exists
-			// because the operator sent it, and a backend's echo habits are not what a chat window
-			// showing your own message should depend on (#7978).
+			// The turn goes onto the tail in `admit`, not when a layer reports it back: the message
+			// exists because the operator sent it, and a backend's echo habits are not what a chat
+			// window showing your own message should depend on (#7978).
 			//
-			// Both arms record the send under its key (`./sends.ts`), because both are outcomes the
-			// window that minted that key is waiting on: an admission refusal is final, and an
-			// admitted send is in the layer's hands until `sent` says otherwise. Without it the
-			// window has only "I dispatched something", which is what cleared a draft the core then
-			// refused (#8005).
-			prompt: (state, msg) =>
-				state.phase !== "ready"
-					? [
+			// A prompt written while the turn runs waits rather than being refused (#8159). Its send
+			// is recorded by nothing yet — neither refused nor in the layer's hands is the truth about
+			// it, and `readHeld` (`shell/chat/outgoing.ts`) reads a key it has no outcome for as
+			// "wait", which is exactly right. The refusing arms do record one, because a refusal is
+			// final and the window that minted the key is waiting on it (#8005).
+			prompt: (state, msg) => {
+				if (state.phase === "prompting") {
+					if (!isQueueFull(state.queued)) {
+						return [
+							{
+								...state,
+								queued: enqueue(state.queued, {
+									key: msg.key,
+									text: msg.text,
+									timestamp: msg.timestamp,
+								}),
+								failure: null,
+							},
+							noCmds,
+						];
+					}
+					const full = promptQueueFull(queueLimit);
+					return [
+						{...state, failure: full, sends: noteSend(state.sends, settledBy(msg.key, full))},
+						noCmds,
+					];
+				}
+				return state.phase === "ready"
+					? admit(state, msg)
+					: [
 							{
 								...state,
 								failure: promptRefused(state.phase),
 								sends: noteSend(state.sends, settledBy(msg.key, promptRefused(state.phase))),
 							},
 							noCmds,
-						]
-					: [
-							{
-								...state,
-								phase: "prompting",
-								lastPrompt: msg.text,
-								interrupted: null,
-								interruption: null,
-								transcript: foldItem(state.transcript, promptItem(msg), limits),
-								sends: noteSend(state.sends, {key: msg.key, state: "pending"}),
-								failure: null,
-							},
-							[{type: "aiAgent.prompt", text: msg.text, key: msg.key}],
-						],
+						];
+			},
 
 			// The prompt handler's own answer, and the only refusal that arrives already correlated
 			// to the send it is about. A refusal lands the session exactly where the `failed` cell
@@ -184,7 +251,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 			sent: (state, msg) =>
 				msg.failure === null
 					? [state, noCmds]
-					: [
+					: settleQueue([
 							{
 								...state,
 								phase: phaseAfterFailure(state, msg.failure),
@@ -192,12 +259,14 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 								sends: noteSend(state.sends, settledBy(msg.key, msg.failure)),
 							},
 							noCmds,
-						],
+						]),
 
 			// A closed session keeps whatever it ended with: a late frame from a torn-down transport
 			// must not resurrect a phase or grow a tail nobody is watching.
 			event: (state, msg) =>
-				state.phase === "gone" ? [state, noCmds] : [foldEvent(state, msg.event, limits), noCmds],
+				state.phase === "gone"
+					? [state, noCmds]
+					: settleQueue([foldEvent(state, msg.event, limits), noCmds]),
 
 			// The card stays, marked `answering`, until a confirmation clears it (#8006): a card that
 			// left on the click would read as an answer that succeeded before its outcome was known,
@@ -311,6 +380,10 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 			 * press re-sends the abort and keeps the first `requestedAt`: the window measures how
 			 * long the interruption has been outstanding, and that clock starts when they first
 			 * asked.
+			 *
+			 * The queue goes, because an operator asking a turn to stop is not asking the next queued
+			 * one to start. It is released rather than dropped, so every word is still theirs to take
+			 * back (`./queue.ts`).
 			 */
 			interrupt: (state, msg) =>
 				state.phase !== "prompting"
@@ -320,6 +393,12 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 								...state,
 								interrupted: state.interrupted ?? lastAssistantId(state.transcript.items),
 								interruption: state.interruption ?? {requestedAt: msg.at},
+								queued: [],
+								sends: releaseQueued(
+									state.queued,
+									state.sends,
+									promptUnqueued("the turn it was waiting for was interrupted"),
+								),
 							},
 							[{type: "aiAgent.interrupt"}],
 						],
@@ -342,7 +421,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 
 			failed: (state, msg) => {
 				const phase = phaseAfterFailure(state, msg.failure);
-				return [
+				return settleQueue([
 					{
 						...state,
 						phase,
@@ -351,7 +430,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 						sends: settlePending(state.sends, msg.failure),
 					},
 					noCmds,
-				];
+				]);
 			},
 		},
 

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -15,6 +15,7 @@ import {checkpointUnreadable} from "./failures.ts";
 import {promptItemId} from "./fold.ts";
 import {aiAgentSessionMachine} from "./machine.ts";
 import type {AiAgentSessionCmd, AiAgentSessionMsg} from "./messages.ts";
+import {queueLimit} from "./queue.ts";
 import {isAiAgentSessionState, loadCheckpoint} from "./snapshot.ts";
 import {type AiAgentSessionState, checkpointFields, initialState} from "./state.ts";
 
@@ -234,7 +235,7 @@ describe("prompt", () => {
 	});
 
 	it("is refused as data outside ready, and emits nothing", () => {
-		for (const phase of ["idle", "starting", "prompting", "reconnecting", "gone"] as const) {
+		for (const phase of ["idle", "starting", "reconnecting", "gone"] as const) {
 			const [state, cmds] = apply(started({phase}), prompt("hi", "k"));
 			expect(state.failure?.tag).toBe("tuval/ai-agent/PromptError");
 			expect(state.phase).toBe(phase);
@@ -246,6 +247,138 @@ describe("prompt", () => {
 	it("clears the interrupted marker, because a resend is a new send", () => {
 		const [state] = apply(started({interrupted: assistantItem("a1").id}), prompt("again", "k2"));
 		expect(state.interrupted).toBeNull();
+	});
+});
+
+/**
+ * #8159: a prompt written during a turn is the one prompt outside `ready` that is not a refusal.
+ * The composer offers a "queue" button, so the core keeps a queue — and the turn's own end is the
+ * only thing that admits from it.
+ */
+describe("a prompt written while the turn runs", () => {
+	const prompt = (text: string, key: string): AiAgentSessionMsg => ({
+		type: "prompt",
+		text,
+		key,
+		timestamp: SENT_AT,
+	});
+
+	const running = (over: Partial<AiAgentSessionState> = {}): AiAgentSessionState =>
+		apply(started(over), prompt("make the README", "k1"))[0];
+
+	const turnEnded: AiAgentSessionMsg = {
+		type: "event",
+		sessionId: "session-1",
+		event: {kind: "phase", phase: "ready"},
+	};
+
+	it("waits in the queue rather than being refused, and reaches no layer yet", () => {
+		const [state, cmds] = apply(running(), prompt("then the CHANGELOG", "k2"));
+		expect(state.queued).toEqual([{key: "k2", text: "then the CHANGELOG", timestamp: SENT_AT}]);
+		expect(state.failure).toBeNull();
+		expect(cmds).toEqual([]);
+	});
+
+	// Nothing has been sent, so nothing claims a turn: the item lands with the admission.
+	it("is not on the tail while it waits, and is on it once it is sent", () => {
+		const [queued] = apply(running(), prompt("then the CHANGELOG", "k2"));
+		expect(queued.transcript.items.map((item) => item.id)).toEqual([promptItemId("k1")]);
+		const [sent, cmds] = apply(queued, turnEnded);
+		expect(sent.transcript.items.map((item) => item.id)).toEqual([
+			promptItemId("k1"),
+			promptItemId("k2"),
+		]);
+		expect(sent).toMatchObject({phase: "prompting", lastPrompt: "then the CHANGELOG", queued: []});
+		expect(cmds).toEqual([{type: "aiAgent.prompt", text: "then the CHANGELOG", key: "k2"}]);
+	});
+
+	it("leaves its send unsettled while it waits, and pending once it is sent", () => {
+		const [queued] = apply(running(), prompt("then the CHANGELOG", "k2"));
+		expect(queued.sends).toEqual([{key: "k1", state: "pending"}]);
+		const [sent] = apply(queued, turnEnded);
+		expect(sent.sends).toEqual([
+			{key: "k1", state: "accepted"},
+			{key: "k2", state: "pending"},
+		]);
+	});
+
+	it("goes one at a time, in the order it was written", () => {
+		const [first] = apply(running(), prompt("second", "k2"));
+		const [both] = apply(first, prompt("third", "k3"));
+		const [sent, cmds] = apply(both, turnEnded);
+		expect(cmds).toEqual([{type: "aiAgent.prompt", text: "second", key: "k2"}]);
+		expect(sent.queued).toEqual([{key: "k3", text: "third", timestamp: SENT_AT}]);
+		const [after, more] = apply(sent, turnEnded);
+		expect(more).toEqual([{type: "aiAgent.prompt", text: "third", key: "k3"}]);
+		expect(after.queued).toEqual([]);
+	});
+
+	// The newest is refused rather than the oldest evicted: silently dropping what an operator
+	// already wrote is the bug the queue exists to fix, and a refusal is recoverable.
+	it("refuses the one past the bound, against its own key", () => {
+		let state = running();
+		for (let index = 0; index < queueLimit; index += 1) {
+			[state] = apply(state, prompt(`queued ${index}`, `q${index}`));
+		}
+		const [full, cmds] = apply(state, prompt("one too many", "k-over"));
+		expect(full.queued).toHaveLength(queueLimit);
+		expect(cmds).toEqual([]);
+		expect(full.failure?.tag).toBe("tuval/ai-agent/PromptError");
+		expect(full.sends).toContainEqual({
+			key: "k-over",
+			state: "refused",
+			failure: full.failure,
+		});
+	});
+
+	it("is released to its window when the operator interrupts, not started behind the stop", () => {
+		const [queued] = apply(running(), prompt("then the CHANGELOG", "k2"));
+		const [cut] = apply(queued, {type: "interrupt", at: SENT_AT});
+		expect(cut.queued).toEqual([]);
+		expect(cut.sends).toContainEqual({
+			key: "k2",
+			state: "refused",
+			failure: {
+				tag: "tuval/ai-agent/PromptError",
+				reason: "refused",
+				detail: "the queued message was not sent: the turn it was waiting for was interrupted",
+			},
+		});
+		const [ended, cmds] = apply(cut, turnEnded);
+		expect(cmds).toEqual([]);
+		expect(ended.queued).toEqual([]);
+	});
+
+	// A prompt written *after* the stop request is the operator's "never mind, do this": it queues
+	// like any other and runs once the turn they stopped actually ends.
+	it("still queues while an interruption is outstanding", () => {
+		const [cut] = apply(running(), {type: "interrupt", at: SENT_AT});
+		const [queued, cmds] = apply(cut, prompt("never mind, do this", "k2"));
+		expect(queued.queued).toEqual([{key: "k2", text: "never mind, do this", timestamp: SENT_AT}]);
+		expect(cmds).toEqual([]);
+		const [sent, sentCmds] = apply(queued, turnEnded);
+		expect(sentCmds).toEqual([{type: "aiAgent.prompt", text: "never mind, do this", key: "k2"}]);
+		expect(sent.queued).toEqual([]);
+	});
+
+	it("is released when the session goes away under it", () => {
+		const [queued] = apply(running(), prompt("then the CHANGELOG", "k2"));
+		const [gone] = apply(queued, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "gone"},
+		});
+		expect(gone.queued).toEqual([]);
+		expect(gone.sends).toContainEqual({
+			key: "k2",
+			state: "refused",
+			failure: {
+				tag: "tuval/ai-agent/PromptError",
+				reason: "refused",
+				detail:
+					"the queued message was not sent: the session ended before the turn it was waiting for did",
+			},
+		});
 	});
 });
 
@@ -673,7 +806,9 @@ describe("interrupt", () => {
 		expect(cmds).toEqual([{type: "aiAgent.interrupt"}]);
 	});
 
-	it("keeps refusing a prompt while the interruption is outstanding", () => {
+	// The prompt waits rather than being refused (#8159), and the stop request stands over it: an
+	// outstanding interruption is still the session's answer about the turn that is running.
+	it("sends nothing new while the interruption is outstanding", () => {
 		const [asked] = apply(running(), {type: "interrupt", at: SENT_AT});
 		const [next, cmds] = apply(asked, {
 			type: "prompt",
@@ -681,7 +816,8 @@ describe("interrupt", () => {
 			key: "k9",
 			timestamp: SENT_AT + 1,
 		});
-		expect(next.failure?.reason).toBe("no-session");
+		expect(next.queued).toHaveLength(1);
+		expect(next.interruption).toEqual({requestedAt: SENT_AT});
 		expect(cmds).toEqual([]);
 	});
 
@@ -850,7 +986,7 @@ describe("a send's outcome, under its own key", () => {
 	});
 
 	it("records an admission refusal against the key that earned it", () => {
-		const [refused, cmds] = apply(started({phase: "prompting"}), prompt("k1"));
+		const [refused, cmds] = apply(started({phase: "idle"}), prompt("k1"));
 		expect(cmds).toEqual([]);
 		expect(refused.sends).toEqual([{key: "k1", state: "refused", failure: refused.failure}]);
 		expect(refused.failure?.tag).toBe("tuval/ai-agent/PromptError");
@@ -994,23 +1130,21 @@ describe("a send's outcome, under its own key", () => {
 	});
 
 	/**
-	 * The two-window race, at the core. One window's prompt is admitted and the other's is refused
-	 * because the session is no longer `ready`; both outcomes stand, each under its own key, so
-	 * neither window can read the other's answer as its own.
+	 * The two-window race, at the core. One window's prompt is admitted and the other's queues
+	 * behind it; each outcome stands under its own key, so neither window can read the other's
+	 * answer as its own.
 	 */
 	it("keeps two racing windows' outcomes apart", () => {
 		const [first] = apply(started(), prompt("k-left"));
 		const [both] = apply(first, prompt("k-right"));
-		expect(both.sends).toEqual([
-			{key: "k-left", state: "pending"},
-			{key: "k-right", state: "refused", failure: both.failure},
-		]);
+		expect(both.sends).toEqual([{key: "k-left", state: "pending"}]);
+		expect(both.queued.map((waiting) => waiting.key)).toEqual(["k-right"]);
 
 		const [handed] = apply(both, {type: "sent", key: "k-left", failure: null});
 		const [answered] = apply(handed, turnEnded);
 		expect(answered.sends).toEqual([
-			{key: "k-right", state: "refused", failure: both.failure},
 			{key: "k-left", state: "accepted"},
+			{key: "k-right", state: "pending"},
 		]);
 	});
 });

--- a/apps/tuval/src/ai-agent/core/properties.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/properties.unit.test.ts
@@ -168,14 +168,15 @@ const drive = (seed: number, steps: number): Run => {
 	let items = 0;
 	for (let step = 0; step < steps; step += 1) {
 		const {msg, newItem} = randomMsg(random, step);
-		const [next] = applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(
-			machine,
-			state,
-			msg,
-		);
-		// A prompt on a `ready` session records the operator's own turn (#7978), which is an item the
-		// tail has to account for exactly like one a layer reported.
-		const recorded = msg.type === "prompt" && state.phase === "ready";
+		const [next, cmds] = applyCellChecked<
+			AiAgentSessionState,
+			AiAgentSessionMsg,
+			AiAgentSessionCmd
+		>(machine, state, msg);
+		// An admitted prompt records the operator's own turn (#7978), which is an item the tail has to
+		// account for exactly like one a layer reported. The Cmd is the predicate rather than the Msg,
+		// because a prompt written during a turn is admitted later, out of the queue (#8159).
+		const recorded = cmds.some((cmd) => cmd.type === "aiAgent.prompt");
 		if ((newItem || recorded) && next.phase !== "gone") items += 1;
 		state = next;
 	}

--- a/apps/tuval/src/ai-agent/core/queue.ts
+++ b/apps/tuval/src/ai-agent/core/queue.ts
@@ -1,0 +1,61 @@
+/**
+ * The prompts an operator wrote while a turn was running, waiting for that turn to end.
+ *
+ * A composer that offers a "queue" button and a core that refuses every prompt outside `ready` were
+ * two halves of one lie: the send was logged as queued, refused as data, and the operator's words
+ * appeared in no transcript and no queue (#8159). A queued prompt is session state rather than a
+ * view's optimism, so both windows over one process see the same queue and a checkpoint carries it.
+ *
+ * It is deliberately *not* a transcript item. Nothing has been sent, and a tail that showed it would
+ * be claiming a turn the backend has never heard of; the item lands the moment the queue flushes,
+ * through the same `promptItem` every deliberate send goes through.
+ *
+ * See ADR 0357 (`.decisions/0357-tuval-prompts-queue-during-turn.md`).
+ *
+ * The queue flushes on exactly one event — the running turn's own end. Anything else that breaks
+ * that continuity releases what is queued back to the operator as an unsent send (`./sends.ts`), so
+ * one recovery path covers a refused prompt and an abandoned queue alike.
+ */
+
+import type {AgentFailure} from "../events.ts";
+import {noteSend, type SendOutcome} from "./sends.ts";
+
+/** One prompt waiting its turn, carrying everything its admission will need. */
+export interface QueuedPrompt {
+	readonly key: string;
+	readonly text: string;
+	readonly timestamp: number;
+}
+
+/**
+ * How many prompts may wait at once. Reaching it refuses the newest rather than evicting the
+ * oldest: a queue that silently drops what an operator already wrote is the bug this module exists
+ * to fix, and a refusal is recoverable — it reaches the window as an unsent message.
+ */
+export const queueLimit = 5;
+
+export const isQueueFull = (queued: ReadonlyArray<QueuedPrompt>): boolean =>
+	queued.length >= queueLimit;
+
+export const enqueue = (
+	queued: ReadonlyArray<QueuedPrompt>,
+	prompt: QueuedPrompt,
+): ReadonlyArray<QueuedPrompt> => [...queued, prompt];
+
+/**
+ * Hand every queued prompt back to the window that wrote it, as a send that never crossed.
+ *
+ * `refused` and not `uncertain`: the text was never handed to a layer, so "it might have run" is
+ * not one of the things nobody knows about it. The window is already holding each key's copy
+ * (`shell/chat/outgoing.ts`), so this is what turns an abandoned queue into a Restore rather than
+ * into silence.
+ */
+export const releaseQueued = (
+	queued: ReadonlyArray<QueuedPrompt>,
+	sends: ReadonlyArray<SendOutcome>,
+	failure: AgentFailure,
+): ReadonlyArray<SendOutcome> =>
+	queued.reduce(
+		(carried, prompt) => noteSend(carried, {key: prompt.key, state: "refused", failure}),
+		sends,
+	);

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -106,6 +106,14 @@ const isSend = (value: unknown): boolean =>
 
 const isSends = (value: unknown): boolean => Array.isArray(value) && value.every(isSend);
 
+const isQueuedPrompt = (value: unknown): boolean =>
+	Predicate.isObject(value) &&
+	typeof value.key === "string" &&
+	typeof value.text === "string" &&
+	isFiniteNumber(value.timestamp);
+
+const isQueued = (value: unknown): boolean => Array.isArray(value) && value.every(isQueuedPrompt);
+
 export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionState =>
 	Predicate.isObject(value) &&
 	typeof value.phase === "string" &&
@@ -125,6 +133,7 @@ export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionSt
 	isThinking(value.thinking) &&
 	isNullOrString(value.lastPrompt) &&
 	isSends(value.sends) &&
+	isQueued(value.queued) &&
 	isPage(value.lastPage) &&
 	isFailure(value.failure);
 

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -22,6 +22,8 @@ import type {
 	TranscriptPayload,
 	WindowOmission,
 } from "../ports/index.ts";
+import {promptUnqueued} from "./failures.ts";
+import {type QueuedPrompt, releaseQueued} from "./queue.ts";
 import type {SendOutcome} from "./sends.ts";
 
 /** Cumulative for the session: the core owns the running totals, the layer reports the deltas. */
@@ -126,6 +128,12 @@ export interface AiAgentSessionState {
 	 * a refused or unconfirmed prompt recoverable instead of cleared at dispatch.
 	 */
 	readonly sends: ReadonlyArray<SendOutcome>;
+	/**
+	 * The prompts written while the turn was running, in the order they were written (`./queue.ts`).
+	 * The head is admitted when the turn ends; nothing here has been sent, so nothing here is in the
+	 * transcript yet.
+	 */
+	readonly queued: ReadonlyArray<QueuedPrompt>;
 	/** The last page `page` asked for and `paged` delivered. Not part of the live tail. */
 	readonly lastPage: HistoryPage | null;
 	readonly failure: AgentFailure | null;
@@ -175,6 +183,7 @@ export const checkpointFields = [
 	"thinking",
 	"lastPrompt",
 	"sends",
+	"queued",
 	"lastPage",
 	"failure",
 ] as const satisfies ReadonlyArray<keyof AiAgentSessionState>;
@@ -202,6 +211,7 @@ export const initialState = (cwd: string): AiAgentSessionState => ({
 	thinking: {current: null, available: []},
 	lastPrompt: null,
 	sends: [],
+	queued: [],
 	lastPage: null,
 	failure: null,
 });
@@ -243,6 +253,10 @@ const markInterrupted = (
  * refusal nobody can act on any more, a page the window asked a transport that no longer exists
  * for, and an abort in flight to a backend this process no longer holds a transport to.
  *
+ * A queued prompt does not come back queued. The turn it was waiting for ended with the process, so
+ * there is nothing left to flush it, and it is released to its window as an unsent send the same way
+ * an interrupted queue is — recoverable, never resent on the operator's behalf.
+ *
  * A send still in flight comes back `uncertain` rather than dropped. The process went away between
  * handing the text to the layer and hearing what became of it, so nobody can say whether it landed
  * — and a window that reopens on this session offers its operator that text rather than resending
@@ -264,8 +278,13 @@ export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
 		transcript: {...loaded.transcript, items: markInterrupted(loaded.transcript.items, cut)},
 		interrupted: cut ?? loaded.interrupted,
 		interruption: null,
-		sends: loaded.sends.map((send) =>
-			send.state === "pending" ? {key: send.key, state: "uncertain", failure: null} : send,
+		queued: [],
+		sends: releaseQueued(
+			loaded.queued,
+			loaded.sends.map((send) =>
+				send.state === "pending" ? {key: send.key, state: "uncertain", failure: null} : send,
+			),
+			promptUnqueued("the process went away before the turn it was waiting for ended"),
 		),
 		permissions: Object.fromEntries(
 			Object.entries(loaded.permissions).map(([id, held]) => [

--- a/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
@@ -126,6 +126,27 @@ describe("restoring a saved session", () => {
 		]);
 	});
 
+	// The turn the queue was waiting for ended with the process, so nothing is left to flush it: the
+	// text goes back to the window that wrote it rather than running unasked on the next open.
+	it("releases a queued prompt to its window rather than bringing the queue back", () => {
+		const waiting: AiAgentSessionState = {
+			...saved,
+			queued: [{key: "send-2", text: "then the CHANGELOG", timestamp: 1_700_000_000_000}],
+		};
+		const restored = restore(waiting);
+		expect(restored.queued).toEqual([]);
+		expect(restored.sends).toContainEqual({
+			key: "send-2",
+			state: "refused",
+			failure: {
+				tag: "tuval/ai-agent/PromptError",
+				reason: "refused",
+				detail:
+					"the queued message was not sent: the process went away before the turn it was waiting for ended",
+			},
+		});
+	});
+
 	// The call carrying that answer went with the process, so whether it landed is unknown: the
 	// card comes back stating that rather than offering the buttons again (#8006).
 	it("brings a card whose answer was in flight back as unresolved", () => {

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -51,6 +51,7 @@ const cutMidReply: AiAgentSessionState = {
 	thinking: {current: null, available: []},
 	lastPrompt: "read the readme",
 	sends: [{key: "send-0", state: "pending"}],
+	queued: [],
 	lastPage: null,
 	failure: null,
 };

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -50,6 +50,7 @@ import {ModeSwitch} from "./ModeSwitch.tsx";
 import {dropSend, holdSend, readHeld, recoverInto} from "./outgoing.ts";
 import {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
 import {interruptionGraceMillis, isWorking, statusLine} from "./phase.ts";
+import {QueuedMessages} from "./QueuedMessages.tsx";
 import {
 	type ChatRow,
 	chatRows,
@@ -763,6 +764,7 @@ function ChatWindow({
 			) : null}
 			<DesignTranslationProvider translate={tuvalDesignTranslate}>
 				<PermissionCards permissions={process.state.permissions} onAnswer={answerPermission} />
+				<QueuedMessages queued={process.state.queued} />
 				<UnsentMessages
 					windowId={host.windowId}
 					unsent={held.unsent}

--- a/apps/tuval/src/shell/chat/QueuedMessages.tsx
+++ b/apps/tuval/src/shell/chat/QueuedMessages.tsx
@@ -1,0 +1,46 @@
+/**
+ * The messages the operator wrote while the turn was running, waiting to be sent (#8159).
+ *
+ * It renders the session's own queue (`ai-agent/core/queue.ts`) rather than anything this window
+ * remembers, so both windows over one process show the same waiting text and a window opened after
+ * the send shows it too. Nothing here is a transcript row: none of it has reached the agent, and a
+ * tail that showed it would be claiming a turn the backend has never heard of.
+ *
+ * It sits directly above the composer, where `UnsentMessages` sits, because both answer the same
+ * question — where did the words I just typed go — and an operator who has to look in two places
+ * for that answer is the state this surface exists to end.
+ */
+
+import type {ReactElement} from "react";
+
+export interface QueuedMessage {
+	readonly key: string;
+	readonly text: string;
+}
+
+/** A window with an empty queue renders nothing: the ordinary case earns no permanent chrome. */
+export function QueuedMessages({
+	queued,
+}: {
+	readonly queued: ReadonlyArray<QueuedMessage>;
+}): ReactElement | null {
+	if (queued.length === 0) return null;
+	return (
+		<div className="tuval-chat-queued">
+			{/* The live region is this line alone. The messages themselves are the operator's own
+			    words read back, and announcing each one re-reads what they just typed. */}
+			<p className="tuval-chat-queued-lead" role="status">
+				{queued.length === 1
+					? "1 message is waiting for the turn to end."
+					: `${queued.length} messages are waiting for the turn to end.`}
+			</p>
+			<ul className="tuval-chat-queued-list" aria-label="Queued messages">
+				{queued.map((message) => (
+					<li key={message.key} className="tuval-chat-queued-item">
+						{message.text}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -1093,3 +1093,45 @@ describe("the view slot's writer, under StrictMode", () => {
 		expect(writes[writes.length - 1]?.expanded).toEqual(["c", "d"]);
 	});
 });
+
+/**
+ * #8159. The composer offers a "queue" button while a turn runs, so the words an operator writes
+ * then have to be somewhere they can see. They are in the session's queue, and the window renders
+ * that queue rather than anything it remembers itself — which is what makes the same waiting text
+ * visible in the other window over the same process.
+ */
+describe("the messages waiting for the running turn to end", () => {
+	const waiting = (
+		queued: AiAgentSessionState["queued"],
+		over: Partial<AiAgentSessionState> = {},
+	): AiAgentSessionState => withTranscript(transcriptOf(2), {phase: "prompting", queued, ...over});
+
+	it("renders each one, off the session's own queue", async () => {
+		await openWindow(
+			waiting([
+				{key: "q1", text: "then the CHANGELOG", timestamp: SENT_AT},
+				{key: "q2", text: "and tag it", timestamp: SENT_AT + 1},
+			]),
+		);
+		const list = screen.getByRole("list", {name: "Queued messages"});
+		expect(
+			within(list)
+				.getAllByRole("listitem")
+				.map((row) => row.textContent),
+		).toEqual(["then the CHANGELOG", "and tag it"]);
+		expect(screen.getByText("2 messages are waiting for the turn to end.")).toBeDefined();
+	});
+
+	// The ordinary case — everything sent — earns no permanent strip of chrome (ADR 0162, Pillar 3).
+	it("renders nothing at all on an empty queue", async () => {
+		await openWindow(waiting([]));
+		expect(screen.queryByRole("list", {name: "Queued messages"})).toBeNull();
+	});
+
+	// A queued message has reached no backend, so it is not a turn: the tail must not claim one.
+	it("keeps them off the transcript until they are sent", async () => {
+		await openWindow(waiting([{key: "q1", text: "then the CHANGELOG", timestamp: SENT_AT}]));
+		const transcript = screen.getByRole("log", {name: "Transcript"});
+		expect(within(transcript).queryByText("then the CHANGELOG")).toBeNull();
+	});
+});

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -341,6 +341,38 @@
 	padding-block-start: var(--s-2);
 }
 
+/* Where a message waits for the running turn to end. It is not a transcript row and must not read
+ * as one: no bubble, no author, and the accent that says "not yet" rather than "went wrong". */
+.tuval-chat-queued {
+	max-block-size: 20vh;
+	overflow-y: auto;
+}
+
+.tuval-chat-queued-lead {
+	margin: 0 0 var(--s-1);
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}
+
+.tuval-chat-queued-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.tuval-chat-queued-item {
+	padding: var(--s-2);
+	border: 1px dashed var(--border-faint);
+	border-radius: var(--r-lg);
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
 .tuval-chat-unsent {
 	max-block-size: 30vh;
 	overflow-y: auto;

--- a/apps/tuval/src/shell/chat/index.ts
+++ b/apps/tuval/src/shell/chat/index.ts
@@ -15,6 +15,7 @@ export {tuvalDesignMessages, tuvalDesignTranslate} from "./copy.ts";
 export {ModeSwitch} from "./ModeSwitch.tsx";
 export {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
 export {isWorking, phaseLine, phaseLines, statusLine} from "./phase.ts";
+export {type QueuedMessage, QueuedMessages} from "./QueuedMessages.tsx";
 export {
 	type ChatRow,
 	type ChatRowsInput,


### PR DESCRIPTION
Closes #8159

## Mechanism

Three seams lined up into one drop:

1. `packages/design/src/AgentChatInput.tsx` `submit()` does not block while the agent is working. In the `focused` variant Tuval mounts, a submit mid-turn is coerced to `type: "follow_up"`, handed to `bridge.sendPiPrompt`, and optimistically logged as `admin.agent.activity.followUpQueued` — "The next prompt was queued."
2. `apps/tuval/src/shell/chat/composer-bridge.ts` destructures `{message}` only, so the delivery mode is dropped and a follow-up degrades to a plain prompt.
3. The `prompt` cell in `apps/tuval/src/ai-agent/core/machine.ts` refused every prompt outside `ready`, `prompting` included: `promptRefused` recorded, no Cmd emitted, nothing on the tail.

So the composer said "queued", the unsent bar said "This message was not sent.", and the operator's words were in neither the transcript nor any queue. There was no queue anywhere in `apps/tuval/src` — the copy keys were the only trace of the idea.

## What changed

A queued prompt is now first-class session state (ADR [0357](.decisions/0357-tuval-prompts-queue-during-turn.md)).

- **`ai-agent/core/queue.ts`** (new) — `QueuedPrompt` (`key`, `text`, `timestamp`), the bound, and the release that turns an abandoned queue into recoverable unsent sends.
- **`core/machine.ts`** — `prompt` while `prompting` enqueues rather than refusing. One `admit` function serves both the `prompt` cell and the queue, and a `settleQueue` pass runs after every cell that can land the session where the queue's answer changes (`started`, `sent`, `event`, `failed`): landing on `ready` admits the head, landing on `gone`/`idle` releases everything. `interrupt` releases the queue — stopping a turn is not asking the next one to start.
- **`core/state.ts` / `snapshot.ts`** — `queued` is a checkpoint field with its own predicate; `restore` releases it, because the turn it was waiting for ended with the process.
- **`shell/chat/QueuedMessages.tsx`** (new) — renders `state.queued` above the composer, off core state so both windows over one process show the same waiting text. It is not a transcript row: nothing has been sent.
- At the bound the **newest** prompt is refused against its own key; the oldest is never evicted.

`packages/design` is untouched — the composer's claim is now true rather than rewritten.

## How it is tested

- `core/machine.unit.test.ts` — a new `a prompt written while the turn runs` block: it queues rather than being refused, stays off the tail until sent, its send goes pending only at admission, the queue drains one at a time in order, the bound refuses the newest against its own key, an interrupt releases it, a prompt written after the stop request still queues, and a session going away releases it. Four pinned cases changed for the deliberate behaviour change (`prompting` is no longer a refusing phase).
- `core/properties.unit.test.ts` — the item-accounting predicate now reads the `aiAgent.prompt` Cmd, which is emitted at admission whether the prompt came from the cell or the queue.
- `ai-agent/restore/checkpoint.unit.test.ts` — a queued prompt comes back released, not queued.
- `shell/chat/chat-window.unit.test.tsx` — a new block: the strip renders each queued message off the session's queue, renders nothing on an empty queue, and keeps them off the transcript.

`pnpm typecheck` 23/23 green, `pnpm lint` clean, `pnpm --filter @kampus/tuval test` 1591 passed / 186 files.

## Deviations

Five pre-existing pins moved, all of them for the one narrowing ADR [0357](.decisions/0357-tuval-prompts-queue-during-turn.md) records in its Consequences: `prompting` is no longer a refusing phase. Two of them are Tier-M removed assertions.

- **Pre-existing test or fixture changed** — **Said:** `core/machine.unit.test.ts`, "is refused as data outside ready, and emits nothing" walked `["idle", "starting", "prompting", "reconnecting", "gone"]` and asserted a `PromptError`, an unchanged phase, an empty transcript and no Cmds for each. **Did:** dropped `"prompting"` from the list; the other four phases keep every assertion unchanged. **Why:** a prompt written during a turn is now admitted to the queue instead of refused, so the case would have been asserting the behaviour this PR removes. What `prompting` does instead is pinned by the new `a prompt written while the turn runs` block, which asserts the queue entry, the absent failure and the absent Cmd. **Disposition:** stated here.

- **Pre-existing test or fixture changed** *(Tier-M removed assertion, `machine.unit.test.ts:684`)* — **Said:** "keeps refusing a prompt while the interruption is outstanding" asserted `expect(next.failure?.reason).toBe("no-session")`. **Did:** removed that assertion, renamed the case to "sends nothing new while the interruption is outstanding", and added `expect(next.queued).toHaveLength(1)` and `expect(next.interruption).toEqual({requestedAt: SENT_AT})`. The `expect(cmds).toEqual([])` line is untouched. **Why:** a prompt written after the stop request is the operator's "never mind, do this" and now queues. The thing the case was really guarding — nothing new reaches the layer while the abort is outstanding, and the request stays on the record — is still asserted, by the unchanged Cmd assertion plus the interruption marker. **Disposition:** stated here.

- **Pre-existing test or fixture changed** — **Said:** "records an admission refusal against the key that earned it" drove its refusal from `started({phase: "prompting"})`. **Did:** changed the fixture phase to `idle`; every assertion in the case is unchanged. **Why:** the case is about an admission refusal being keyed to the send that earned it, which is phase-independent — it needed any still-refusing phase, and `idle` is the nearest one. **Disposition:** stated here.

- **Pre-existing test or fixture changed** *(Tier-M removed assertion, `machine.unit.test.ts:1004`)* — **Said:** "keeps two racing windows' outcomes apart" asserted `both.sends` held two rows, the second window's `refused`. **Did:** it now asserts `both.sends` holds only `{key: "k-left", state: "pending"}` and that `both.queued` names `k-right`; the post-turn assertion becomes k-left `accepted`, k-right `pending`. **Why:** the losing window's prompt queues rather than being refused, so the old row no longer exists to assert. The property the case exists for — two windows' outcomes never merge under one key, and neither can read the other's answer as its own — is asserted throughout, in the new vocabulary. **Disposition:** stated here.

- **Pre-existing test or fixture changed** — **Said:** `core/properties.unit.test.ts` counted an operator's recorded turn with `msg.type === "prompt" && state.phase === "ready"`. **Did:** it now counts off the emitted Cmd, `cmds.some((cmd) => cmd.type === "aiAgent.prompt")`. **Why:** admission and the Msg are no longer simultaneous — a queued prompt records its transcript item later, when the turn's end flushes it — so the old predicate undercounted and reddened the invariant. The Cmd is emitted at admission on both paths, cell and queue, which makes it the true predicate. The invariant itself (kept plus omitted equals every item seen) is unchanged and still fails when an item is dropped. **Disposition:** stated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
