### PR TITLE
feat(design): render agent markdown replies in the Tuval transcript

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -35,7 +35,7 @@
  * as far as recovery goes.
  */
 
-import {AgentChatInput, Button, DesignTranslationProvider, Kbd} from "@kampus/design";
+import {AgentChatInput, Button, DesignTranslationProvider, Kbd, Markdown} from "@kampus/design";
 import {useVirtualizer, type VirtualizerOptions} from "@tanstack/react-virtual";
 import {Effect, Fiber, Stream} from "effect";
 import type {ReactElement, KeyboardEvent as ReactKeyboardEvent, ReactNode, UIEvent} from "react";
@@ -176,6 +176,45 @@ const who: Readonly<Record<TranscriptItem["kind"], string>> = {
 	system: "session",
 };
 
+/**
+ * The three treatments an item's body gets. An agent reply is markdown by default and renders
+ * through the shared block, which paints synchronously so the row's measurement still holds
+ * (#8012); a `user` or `system` line is shown exactly as it arrived, so what the operator typed is
+ * never reinterpreted as syntax.
+ */
+function ItemBody({
+	item,
+	expanded,
+	fold,
+	onToggleTool,
+}: {
+	readonly item: TranscriptItem;
+	readonly expanded: boolean;
+	readonly fold: ToolFold | null;
+	readonly onToggleTool: (id: string, open: boolean) => void;
+}): ReactElement {
+	if (item.kind === "tool") {
+		return (
+			<ToolRow
+				item={item}
+				expanded={expanded}
+				fold={fold}
+				onToggle={(open) => onToggleTool(item.id, open)}
+			/>
+		);
+	}
+	if (item.kind === "assistant") {
+		// The transcript is a region inside the desk, so a `#` heading in a reply is a subsection of
+		// it rather than a page title.
+		return (
+			<Markdown className="tuval-chat-markdown" headingBase={3}>
+				{item.text}
+			</Markdown>
+		);
+	}
+	return <p className="tuval-chat-text">{item.text}</p>;
+}
+
 function ItemRow({
 	item,
 	interrupted,
@@ -197,16 +236,7 @@ function ItemRow({
 		<>
 			{/* A nested row says whose call it was in words; the indent beside it is the second signal. */}
 			<span className="tuval-chat-who">{nested ? "subagent" : who[item.kind]}</span>
-			{item.kind === "tool" ? (
-				<ToolRow
-					item={item}
-					expanded={expanded}
-					fold={fold}
-					onToggle={(open) => onToggleTool(item.id, open)}
-				/>
-			) : (
-				<p className="tuval-chat-text">{item.text}</p>
-			)}
+			<ItemBody item={item} expanded={expanded} fold={fold} onToggleTool={onToggleTool} />
 			{interrupted ? (
 				<span className="tuval-chat-interrupted">
 					<span className="tuval-chat-interrupted-mark">interrupted</span>
@@ -678,90 +708,93 @@ function ChatWindow({
 		// composer's textarea keeps focus. A named `section` is what that owes a screen reader: the
 		// phase line, the transcript and the composer are one named region, and every control inside
 		// it is a real `button` or `textarea` with its own keyboard behaviour.
-		<section
-			className="tuval-chat"
-			aria-label="Agent chat"
-			data-scheme="dark"
-			data-window={host.windowId}
-			onKeyDown={onKeyDown}
-		>
-			<div className="tuval-chat-bar">
-				<p className="tuval-chat-phase" data-phase={phase} role="status">
-					<span className="tuval-chat-phase-dot" aria-hidden="true" />
-					{statusLine({
-						phase,
-						failure: state?.failure ?? null,
-						interruption,
-						now: options.now(),
-					})}
-				</p>
-				<div className="tuval-chat-bar-end">
-					{options.extras === null ? null : options.extras(process.state)}
-					<ModeSwitch modes={process.state.modes} onSetMode={setMode} />
-				</div>
-			</div>
-			<div
-				ref={scrollRef}
-				className="tuval-chat-transcript"
-				onScroll={onScroll}
-				onKeyDown={swallowBareCharacter}
-				role="log"
-				aria-label="Transcript"
-				// The scroll container is the only way to older turns on a plain transcript, so a
-				// keyboard user must be able to focus it (axe scrollable-region-focusable).
-				// biome-ignore lint/a11y/noNoninteractiveTabindex: a scroll region must take keyboard focus
-				tabIndex={0}
+		// The provider sits above the whole window, not just the composer: a design primitive the
+		// transcript mounts (a table's scroller name) reads this catalog too, and the package's own
+		// default is Turkish.
+		<DesignTranslationProvider translate={tuvalDesignTranslate}>
+			<section
+				className="tuval-chat"
+				aria-label="Agent chat"
+				data-scheme="dark"
+				data-window={host.windowId}
+				onKeyDown={onKeyDown}
 			>
-				<div className="tuval-chat-spacer" style={{height: `${totalSize}px`}}>
-					{virtualizer.getVirtualItems().map((virtual) => {
-						const row = rows[virtual.index];
-						if (row === undefined) return null;
-						return (
-							<div
-								key={virtual.key}
-								id={row.kind === "item" ? rowDomId(host.windowId, row.item.id) : undefined}
-								className="tuval-chat-row"
-								data-index={virtual.index}
-								data-kind={row.kind === "item" ? row.item.kind : row.kind}
-								data-nested={row.kind === "item" && row.nested ? "true" : undefined}
-								ref={virtualizer.measureElement}
-								style={{
-									transform: `translateY(${virtual.start}px)`,
-									// One indent step per fold the row sits inside, so a subagent's own subagent
-									// reads as a further step in rather than as another row at the same level.
-									...(row.kind === "item" && row.depth > 0 ? {"--nest-depth": row.depth} : {}),
-								}}
-							>
-								<RowView
-									row={row}
-									windowId={host.windowId}
-									interruptedId={interruptedId}
-									onResend={lastPrompt === null ? null : resend}
-									onOlder={requestOlder}
-									expanded={expanded}
-									unfolded={unfolded}
-									onToggleTool={toggleTool}
-									onToggleFold={toggleFold}
-								/>
-							</div>
-						);
-					})}
+				<div className="tuval-chat-bar">
+					<p className="tuval-chat-phase" data-phase={phase} role="status">
+						<span className="tuval-chat-phase-dot" aria-hidden="true" />
+						{statusLine({
+							phase,
+							failure: state?.failure ?? null,
+							interruption,
+							now: options.now(),
+						})}
+					</p>
+					<div className="tuval-chat-bar-end">
+						{options.extras === null ? null : options.extras(process.state)}
+						<ModeSwitch modes={process.state.modes} onSetMode={setMode} />
+					</div>
 				</div>
-			</div>
-			{isWorking(phase) ? (
-				// Visual only. The phase line above is the announced surface for the running turn, so a
-				// live region here would narrate that same turn twice; what this adds is the tell at
-				// the end of the transcript, where the eye already is while a turn runs.
-				<p className="tuval-chat-working" aria-hidden="true">
-					<span className="tuval-chat-working-dots">
-						<span />
-						<span />
-						<span />
-					</span>
-					{interruption === null ? "Working…" : "Interrupting…"}
-				</p>
-			) : null}
-			<DesignTranslationProvider translate={tuvalDesignTranslate}>
+				<div
+					ref={scrollRef}
+					className="tuval-chat-transcript"
+					onScroll={onScroll}
+					onKeyDown={swallowBareCharacter}
+					role="log"
+					aria-label="Transcript"
+					// The scroll container is the only way to older turns on a plain transcript, so a
+					// keyboard user must be able to focus it (axe scrollable-region-focusable).
+					// biome-ignore lint/a11y/noNoninteractiveTabindex: a scroll region must take keyboard focus
+					tabIndex={0}
+				>
+					<div className="tuval-chat-spacer" style={{height: `${totalSize}px`}}>
+						{virtualizer.getVirtualItems().map((virtual) => {
+							const row = rows[virtual.index];
+							if (row === undefined) return null;
+							return (
+								<div
+									key={virtual.key}
+									id={row.kind === "item" ? rowDomId(host.windowId, row.item.id) : undefined}
+									className="tuval-chat-row"
+									data-index={virtual.index}
+									data-kind={row.kind === "item" ? row.item.kind : row.kind}
+									data-nested={row.kind === "item" && row.nested ? "true" : undefined}
+									ref={virtualizer.measureElement}
+									style={{
+										transform: `translateY(${virtual.start}px)`,
+										// One indent step per fold the row sits inside, so a subagent's own subagent
+										// reads as a further step in rather than as another row at the same level.
+										...(row.kind === "item" && row.depth > 0 ? {"--nest-depth": row.depth} : {}),
+									}}
+								>
+									<RowView
+										row={row}
+										windowId={host.windowId}
+										interruptedId={interruptedId}
+										onResend={lastPrompt === null ? null : resend}
+										onOlder={requestOlder}
+										expanded={expanded}
+										unfolded={unfolded}
+										onToggleTool={toggleTool}
+										onToggleFold={toggleFold}
+									/>
+								</div>
+							);
+						})}
+					</div>
+				</div>
+				{isWorking(phase) ? (
+					// Visual only. The phase line above is the announced surface for the running turn, so a
+					// live region here would narrate that same turn twice; what this adds is the tell at
+					// the end of the transcript, where the eye already is while a turn runs.
+					<p className="tuval-chat-working" aria-hidden="true">
+						<span className="tuval-chat-working-dots">
+							<span />
+							<span />
+							<span />
+						</span>
+						{interruption === null ? "Working…" : "Interrupting…"}
+					</p>
+				) : null}
 				<PermissionCards permissions={process.state.permissions} onAnswer={answerPermission} />
 				<UnsentMessages
 					windowId={host.windowId}
@@ -777,8 +810,8 @@ function ChatWindow({
 						commit((current) => (current.draft === draft ? current : {...current, draft}))
 					}
 				/>
-			</DesignTranslationProvider>
-		</section>
+			</section>
+		</DesignTranslationProvider>
 	);
 }
 

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -145,6 +145,13 @@
 	overflow-wrap: anywhere;
 }
 
+/* The agent reply is a rendered markdown block (`@kampus/design`). It carries its own type and
+   spacing; what it needs from the row is a width to wrap and scroll inside. */
+.tuval-chat-markdown {
+	min-inline-size: 0;
+	max-inline-size: 100%;
+}
+
 .tuval-chat-row[data-kind="user"] .tuval-chat-text {
 	color: var(--text-secondary);
 }

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -10,7 +10,11 @@
  * composer, silently.
  *
  * So this scope re-declares the roles the package's sheets read, in the package's own shape, off
- * Tuval's own scale. It is the only place the two layers meet; nothing under `.tuval-chat` may use
+ * Tuval's own scale. A role this block *omits* fails the other way and quieter: it resolves from
+ * the package's `:root`, where the family is already substituted to IBM Plex, so the element renders
+ * in a second typeface beside Tuval's `system-ui` (#8012 shipped that with `--t-h-feed`). Every
+ * `--t-*` a package sheet reads under this scope belongs here.
+ * It is the only place the two layers meet; nothing under `.tuval-chat` may use
  * Tuval's two-part `font: var(--t-body) system-ui, sans-serif` form, because inside this scope
  * `--t-body` already carries a family.
  */
@@ -27,6 +31,7 @@
 	--t-meta: 12px / 1.4 var(--font-body);
 	--t-micro: 11px / 1.4 var(--font-body);
 	--t-mono: 13px / 1.5 var(--font-mono);
+	--t-h-feed: 16px / 1.35 var(--font-body);
 
 	--r-lg: 6px;
 	--s-8: 40px;

--- a/apps/tuval/src/shell/chat/copy.ts
+++ b/apps/tuval/src/shell/chat/copy.ts
@@ -32,6 +32,8 @@ const messages: Readonly<Record<DesignCatalogKey, string>> = {
 	"ui.draftRestore.text": "You have a saved draft. Restore it?",
 	"ui.draftRestore.restore": "restore the draft",
 	"ui.draftRestore.dismiss": "dismiss",
+	"ui.markdown.table": "table",
+	"ui.markdown.code": "code block",
 	"admin.agent.label": "Agent composer",
 	"admin.agent.scope": "this window only",
 	"admin.agent.compose.label": "Write a message to the agent",

--- a/apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * What a transcript row does with the markdown an agent replies in (#8012), rendered through the
+ * same window-contract double the rest of this slice uses (`../window/fixtures.ts`).
+ *
+ * Every assertion here reads the DOM straight after `render`, with no `waitFor` and no `act` past
+ * the mount. That is deliberate: the transcript is virtualized and each row is measured at the
+ * height it painted, so content that arrived later would leave the measurement stale. A row that
+ * only becomes complete under `waitFor` would pass a laxer test and still break the scroll.
+ */
+
+import {render, screen, within} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
+import {assistantItem, systemItem, userItem, withTranscript} from "./chat.testing.ts";
+import {tuvalDesignMessages} from "./copy.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+const openWindow = async (state: AiAgentSessionState): Promise<void> => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
+	);
+	const host: ChatWindowHost = await Effect.runPromise(
+		process.window<ChatView>(WindowId.make("w1"), {...initialChatView, pinned: true}),
+	);
+	render(chatWindow({scrollToFn: () => {}}).render(host) as ReactElement);
+};
+
+const TABLE_REPLY = [
+	"**Needs you (1)**:",
+	"",
+	"| issue | priority |",
+	"|---|---|",
+	"| [#7890](https://github.com/kamp-us/phoenix/issues/7890) | p1 |",
+].join("\n");
+
+describe("an agent reply renders as markdown", () => {
+	it("renders a table as a table and a link as an anchor carrying its href", async () => {
+		await openWindow(withTranscript([assistantItem("a1", TABLE_REPLY)]));
+
+		const table = screen.getByRole("table");
+		expect(within(table).getByRole("columnheader", {name: "issue"})).toBeDefined();
+		const link = within(table).getByRole("link", {name: "#7890"});
+		expect(link.getAttribute("href")).toBe("https://github.com/kamp-us/phoenix/issues/7890");
+		expect(link.getAttribute("target")).toBe("_blank");
+		expect(link.getAttribute("rel")).toBe("noreferrer");
+		expect(screen.queryByText("|---|---|")).toBeNull();
+	});
+
+	it("names the table's scroller from Tuval's own catalog, not the package's Turkish default", async () => {
+		await openWindow(withTranscript([assistantItem("a1", TABLE_REPLY)]));
+
+		// Read off `copy.ts` rather than a literal: this asserts the provider is above the transcript,
+		// which is the wiring that breaks silently. The second line is the language the name must be
+		// in, which a catalog edit could break on its own.
+		const name = tuvalDesignMessages["ui.markdown.table"];
+		expect(screen.getByRole("region", {name}).contains(screen.getByRole("table"))).toBe(true);
+		expect(name).toBe("table");
+	});
+
+	it("renders emphasis, headings, lists and fenced code as elements", async () => {
+		const reply = [
+			"# Report",
+			"",
+			"Some **bold** text.",
+			"",
+			"- one",
+			"- two",
+			"",
+			"1. first",
+			"",
+			"```ts",
+			"const x = 1;",
+			"```",
+		].join("\n");
+		await openWindow(withTranscript([assistantItem("a1", reply)]));
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		expect(within(row).getByRole("heading", {name: "Report"})).toBeDefined();
+		expect(within(row).getByText("bold").tagName).toBe("STRONG");
+		expect(within(row).getAllByRole("list")).toHaveLength(2);
+		expect(within(row).getAllByRole("listitem")).toHaveLength(3);
+		const code = within(row).getByText("const x = 1;");
+		expect(code.tagName).toBe("CODE");
+		expect(code.parentElement?.tagName).toBe("PRE");
+	});
+
+	it("names the fenced block's scroller from Tuval's own catalog", async () => {
+		await openWindow(withTranscript([assistantItem("a1", "```ts\nconst x = 1;\n```")]));
+
+		const name = tuvalDesignMessages["ui.markdown.code"];
+		const region = screen.getByRole("region", {name});
+		expect(region.tagName).toBe("PRE");
+		expect(region.tabIndex).toBe(0);
+		expect(name).toBe("code block");
+	});
+
+	it("prints raw HTML in a reply as text rather than markup", async () => {
+		await openWindow(
+			withTranscript([
+				assistantItem("a1", "before\n\n<script>alert(1)</script>\n\n<b>x</b> after"),
+			]),
+		);
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		expect(row.querySelector("script")).toBeNull();
+		expect(row.querySelector("b")).toBeNull();
+		expect(row.textContent).toContain("<script>alert(1)</script>");
+		expect(row.textContent).toContain("<b>x</b>");
+	});
+
+	it("refuses an anchor to a javascript: link, keeping its text", async () => {
+		await openWindow(withTranscript([assistantItem("a1", "[click me](javascript:alert(1))")]));
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		expect(within(row).queryByRole("link")).toBeNull();
+		expect(row.textContent).toContain("click me");
+	});
+
+	it("leaves a typed message and a session line as plain text", async () => {
+		await openWindow(
+			withTranscript([
+				userItem("u1", "**not bold** | a | b |"),
+				systemItem("s1", "# not a heading"),
+			]),
+		);
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		expect(within(row).queryByRole("table")).toBeNull();
+		expect(within(row).queryByRole("heading")).toBeNull();
+		expect(within(row).getByText("**not bold** | a | b |").className).toBe("tuval-chat-text");
+		expect(within(row).getByText("# not a heading").className).toBe("tuval-chat-text");
+	});
+});

--- a/apps/web/src/i18n/en/account.ts
+++ b/apps/web/src/i18n/en/account.ts
@@ -195,4 +195,6 @@ export const account = {
 	"ui.draftRestore.text": "you have a saved draft. want to restore it?",
 	"ui.draftRestore.restore": "restore the draft",
 	"ui.draftRestore.dismiss": "ignore",
+	"ui.markdown.table": "table",
+	"ui.markdown.code": "code block",
 } satisfies Record<AccountKey, string>;

--- a/apps/web/src/i18n/tr/account.ts
+++ b/apps/web/src/i18n/tr/account.ts
@@ -196,6 +196,8 @@ export const account = {
 	"ui.draftRestore.text": "kaydedilmiş bir taslağın var. geri yüklemek ister misin?",
 	"ui.draftRestore.restore": "taslağı geri yükle",
 	"ui.draftRestore.dismiss": "yoksay",
+	"ui.markdown.table": "tablo",
+	"ui.markdown.code": "kod bloğu",
 };
 
 /** `tr` is the source of truth for the key set; `en/account.ts` is checked against this. */

--- a/apps/web/src/lab/atolye/exhibits/Markdown.exhibit.test.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Markdown.exhibit.test.tsx
@@ -1,0 +1,38 @@
+import {render, screen, within} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {ExhibitStage} from "../ExhibitStage";
+import {getExhibit} from "../registry";
+
+// The exhibit exists so a reviewer can see every markdown block at once. A sample that quietly
+// loses one still renders a plausible-looking stage, so the coverage is asserted rather than read.
+describe("Markdown exhibit — the stage shows every block a reviewer has to see", () => {
+	const exhibit = getExhibit("markdown");
+
+	it("is registered under the markdown slug", () => {
+		expect(exhibit).toBeDefined();
+	});
+
+	it("renders bold, a link, inline code, a table, a list and a fenced block", () => {
+		const {container} = render(<ExhibitStage exhibit={exhibit!} />);
+		const stage = screen.getByTestId("exhibit-stage");
+
+		expect(within(stage).getByText("Kalın metin").tagName).toBe("STRONG");
+
+		const link = within(stage).getByRole("link", {name: "bağlantı"});
+		expect(link.getAttribute("href")).toBe("https://github.com/kamp-us/phoenix");
+
+		const table = within(stage).getByRole("table");
+		expect(within(table).getAllByRole("columnheader")).toHaveLength(3);
+
+		expect(container.querySelectorAll(".kp-markdown ul > li").length).toBeGreaterThan(2);
+
+		const fenced = container.querySelector(".kp-markdown pre > code");
+		expect(fenced?.className).toContain("language-ts");
+
+		// The inline `kod` span is a `<code>` that is not the fenced one.
+		const inline = [...container.querySelectorAll(".kp-markdown code")].filter(
+			(node) => node.parentElement?.tagName !== "PRE",
+		);
+		expect(inline.length).toBeGreaterThan(0);
+	});
+});

--- a/apps/web/src/lab/atolye/exhibits/Markdown.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Markdown.exhibit.tsx
@@ -1,0 +1,42 @@
+import {Markdown} from "@kampus/design";
+import type * as React from "react";
+import {defineExhibit} from "../exhibit";
+
+/**
+ * The source covers every block the renderer emits that a reviewer has to be able to see at a
+ * glance — bold, a link, inline code, a table, a list, a fenced block — because the stage is the
+ * only place this component is judged rendered rather than through jsdom.
+ */
+const SAMPLE = `# Ajanın yanıtı
+
+**Kalın metin**, bir [bağlantı](https://github.com/kamp-us/phoenix) ve satır içi \`kod\` aynı
+paragrafta.
+
+| Kapı | Durum | Gecikme |
+| --- | :---: | ---: |
+| \`/fate\` | açık | 12 ms |
+| \`/fate/live\` | açık | 48 ms |
+| \`/api/health\` | kapalı | — |
+
+- Listenin ilk maddesi
+- İkinci madde, içinde \`inline\` kod
+- Üçüncü madde
+
+\`\`\`ts
+export const greet = (name: string): string => {
+	return \`merhaba, \${name}\`;
+};
+\`\`\`
+`;
+
+export const markdownExhibit = defineExhibit<React.ComponentProps<typeof Markdown>>({
+	id: "markdown",
+	title: "Markdown",
+	summary:
+		"Ajan çıktısı için salt-okunur markdown bloğu — kaynaktaki ham HTML metin olarak basılır.",
+	component: Markdown,
+	knobs: {
+		headingBase: {kind: "number", label: "Heading base", default: 2, min: 1, max: 6, step: 1},
+	},
+	fixedProps: {children: SAMPLE},
+});

--- a/apps/web/src/lab/atolye/registry.ts
+++ b/apps/web/src/lab/atolye/registry.ts
@@ -16,6 +16,7 @@ import {draftRestoreBannerExhibit} from "./exhibits/DraftRestoreBanner.exhibit";
 import {editedIndicatorExhibit} from "./exhibits/EditedIndicator.exhibit";
 import {emptyStateExhibit} from "./exhibits/EmptyState.exhibit";
 import {formExhibit} from "./exhibits/Form.exhibit";
+import {markdownExhibit} from "./exhibits/Markdown.exhibit";
 import {menuExhibit} from "./exhibits/Menu.exhibit";
 import {metaRowExhibit} from "./exhibits/MetaRow.exhibit";
 import {reportButtonExhibit} from "./exhibits/ReportButton.exhibit";
@@ -44,6 +45,7 @@ const exhibits: readonly AnyExhibit[] = [
 	editedIndicatorExhibit,
 	emptyStateExhibit,
 	formExhibit,
+	markdownExhibit,
 	menuExhibit,
 	metaRowExhibit,
 	reportButtonExhibit,

--- a/design-system-inventory.md
+++ b/design-system-inventory.md
@@ -194,6 +194,15 @@ _Source: packages/design/src/atoms.tsx_
 **Slots:**
 - `children` — The highlighted text.
 
+## Markdown
+
+_Source: packages/design/src/Markdown.tsx_
+
+**When to use:** Read-only display of markdown an agent produced — a chat transcript row, a tool result, any surface that shows model output. It is a renderer, not an editor: for authoring reach for the app's editor instead.
+
+**Slots:**
+- `children` — The markdown source. Not sanitized upstream and not required to be: raw HTML in it renders as text, never as markup.
+
 ## Menu
 
 _Source: packages/design/src/Menu.tsx_

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -12,6 +12,7 @@ entries and ownership boundaries.
 | `@kampus/design/fonts.css` | First-party IBM Plex Sans and JetBrains Mono faces |
 | `AgentChatInputBridge` | App-owned Pi RPC transport supplied to `AgentChatInput` |
 | `CommandPalette` | Modal, keyboard-first search surface over caller-owned results |
+| `Markdown` | Read-only renderer for agent markdown — raw HTML in the source prints as text |
 | `design-token-lint.config.json` | The token guard's package-owned baseline and allow-list |
 | `src/a11y/` | Property-based accessibility suite and its posture/registry |
 

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -24,7 +24,8 @@
 		"@manti-ui/react": "catalog:",
 		"@fontsource/ibm-plex-sans": "catalog:",
 		"@fontsource/jetbrains-mono": "catalog:",
-		"lucide-react": "catalog:"
+		"lucide-react": "catalog:",
+		"marked": "catalog:"
 	},
 	"devDependencies": {
 		"@effect/tsgo": "catalog:",

--- a/packages/design/src/Markdown.css
+++ b/packages/design/src/Markdown.css
@@ -129,12 +129,6 @@
 	contain: inline-size;
 }
 
-.kp-markdown pre:focus-visible,
-.kp-markdown__scroller:focus-visible {
-	outline: var(--manti-focus-ring-width) solid var(--manti-focus-ring);
-	outline-offset: var(--manti-focus-ring-offset);
-}
-
 .kp-markdown table {
 	border-collapse: collapse;
 	font: var(--t-body-sm);

--- a/packages/design/src/Markdown.css
+++ b/packages/design/src/Markdown.css
@@ -1,0 +1,171 @@
+/* The read-only markdown block for agent output. Element selectors rather than a class per node:
+   the elements are generated from a token stream, so there is nothing to hang a class on. Role
+   tokens only — the block inherits its host's surface and reads correctly in either scheme. */
+.kp-markdown {
+	font: var(--t-body);
+	color: var(--text-primary);
+	overflow-wrap: anywhere;
+	min-inline-size: 0;
+	/* Fill the host, never shrink-wrap: the two scrollable blocks below are inline-size-contained,
+	   so they contribute nothing to an intrinsic width and a shrink-to-fit host would size the
+	   whole document to its longest paragraph, scrolling code that had room to sit flat. */
+	inline-size: 100%;
+}
+
+.kp-markdown > :first-child {
+	margin-block-start: 0;
+}
+
+.kp-markdown > :last-child {
+	margin-block-end: 0;
+}
+
+.kp-markdown p,
+.kp-markdown ul,
+.kp-markdown ol,
+.kp-markdown pre,
+.kp-markdown blockquote,
+.kp-markdown__scroller {
+	margin-block: var(--s-2);
+}
+
+.kp-markdown h1,
+.kp-markdown h2,
+.kp-markdown h3 {
+	font: var(--t-h-feed);
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-block: var(--s-3) var(--s-2);
+}
+
+.kp-markdown h4,
+.kp-markdown h5,
+.kp-markdown h6 {
+	font: var(--t-body);
+	font-weight: 600;
+	color: var(--text-secondary);
+	margin-block: var(--s-3) var(--s-1);
+}
+
+.kp-markdown a {
+	color: var(--link);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.kp-markdown strong {
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.kp-markdown del {
+	color: var(--text-muted);
+}
+
+.kp-markdown ul,
+.kp-markdown ol {
+	padding-inline-start: var(--s-5);
+}
+
+.kp-markdown li {
+	margin-block: var(--s-1);
+}
+
+/* A list item holds block children, so its paragraphs would otherwise open a gap per bullet. */
+.kp-markdown li > p {
+	margin-block: 0;
+}
+
+.kp-markdown code {
+	font: var(--t-mono);
+	background: var(--surface-raised);
+	border-radius: var(--r-sm);
+	padding: 0 var(--s-1);
+}
+
+/* `pre code` is `white-space: pre`, so a long code line is one unbreakable box — the same
+   min-content leak the table scroller below carries, and the reason for the same containment. */
+.kp-markdown pre {
+	background: var(--surface-sunken);
+	border: 1px solid var(--border-faint);
+	border-radius: var(--r-md);
+	padding: var(--s-2) var(--s-3);
+	overflow-x: auto;
+	contain: inline-size;
+}
+
+.kp-markdown pre code {
+	background: none;
+	padding: 0;
+	white-space: pre;
+}
+
+.kp-markdown blockquote {
+	border-inline-start: 2px solid var(--border-strong);
+	padding-inline-start: var(--s-3);
+	color: var(--text-secondary);
+	margin-inline: 0;
+}
+
+.kp-markdown hr {
+	border: 0;
+	border-block-start: 1px solid var(--border-faint);
+	margin-block: var(--s-3);
+}
+
+/* A wide table scrolls inside its wrapper rather than stretching the row it sits in — the
+   transcript row is measured at its rendered height, and a row wider than the viewport would push
+   the whole transcript sideways. The scroll lives on the wrapper so the table keeps its own
+   display, and with it the implicit role `display: block` would drop (see `Markdown.tsx`).
+
+   `contain: inline-size`, not `max-inline-size: 100%`: a scroll container still reports its
+   content's width as its min-content size, and that travels up to the nearest grid or flex item
+   with an auto minimum, which then grows past the viewport. A percentage max resolves to none
+   during intrinsic sizing, so it cannot stop that — measured at 390px, a long `th` took the page
+   to 624px with the percentage max in place. Inline-size containment makes the box size as if
+   empty in that axis, which is what caps it. */
+.kp-markdown__scroller {
+	overflow-x: auto;
+	contain: inline-size;
+}
+
+.kp-markdown pre:focus-visible,
+.kp-markdown__scroller:focus-visible {
+	outline: var(--manti-focus-ring-width) solid var(--manti-focus-ring);
+	outline-offset: var(--manti-focus-ring-offset);
+}
+
+.kp-markdown table {
+	border-collapse: collapse;
+	font: var(--t-body-sm);
+}
+
+.kp-markdown th,
+.kp-markdown td {
+	border: 1px solid var(--border-faint);
+	padding: var(--s-1) var(--s-2);
+	text-align: start;
+	vertical-align: top;
+}
+
+.kp-markdown th {
+	background: var(--surface-raised);
+	color: var(--text-secondary);
+	font-weight: 600;
+	white-space: nowrap;
+}
+
+.kp-markdown [data-align="center"] {
+	text-align: center;
+}
+
+.kp-markdown [data-align="right"] {
+	text-align: end;
+}
+
+/* Raw HTML the source carried, printed as the text it is (see `Markdown.tsx`). */
+.kp-markdown__raw {
+	font: var(--t-mono);
+	color: var(--text-muted);
+	white-space: pre-wrap;
+}

--- a/packages/design/src/Markdown.test.tsx
+++ b/packages/design/src/Markdown.test.tsx
@@ -1,0 +1,167 @@
+import {render, screen, within} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Markdown} from "./Markdown";
+
+describe("Markdown", () => {
+	it("renders blocks as elements, not as source", () => {
+		render(
+			<Markdown>
+				{[
+					"## Heading",
+					"",
+					"A **bold** word, an *emphasised* one and `code`.",
+					"",
+					"> quoted",
+					"",
+					"---",
+				].join("\n")}
+			</Markdown>,
+		);
+
+		expect(screen.getByRole("heading", {level: 2, name: "Heading"})).toBeDefined();
+		expect(screen.getByText("bold").tagName).toBe("STRONG");
+		expect(screen.getByText("emphasised").tagName).toBe("EM");
+		expect(screen.getByText("code").tagName).toBe("CODE");
+		expect(screen.getByText("quoted").closest("blockquote")).not.toBeNull();
+		expect(screen.getByRole("separator")).toBeDefined();
+	});
+
+	it("renders a table with its header cells and alignment", () => {
+		render(<Markdown>{"| a | b |\n|:-:|--:|\n| 1 | 2 |"}</Markdown>);
+
+		const table = screen.getByRole("table");
+		expect(within(table).getByRole("columnheader", {name: "a"}).dataset.align).toBe("center");
+		expect(within(table).getByRole("cell", {name: "2"}).dataset.align).toBe("right");
+	});
+
+	// A wide table has to scroll somewhere, and doing it on the table itself costs the table role in
+	// Chrome and Safari. jsdom applies no CSS, so the structure is what a test can hold: the scroller
+	// is a wrapper around the table, and it is focusable and named (#8012 criterion 9).
+	it("puts a table's horizontal scroller on a named, focusable wrapper rather than the table", () => {
+		render(<Markdown>{"| a | b |\n|---|---|\n| 1 | 2 |"}</Markdown>);
+
+		const table = screen.getByRole("table");
+		const scroller = screen.getByRole("region");
+		expect(scroller.contains(table)).toBe(true);
+		expect(table.parentElement).toBe(scroller);
+		expect(scroller.tabIndex).toBe(0);
+		expect(scroller.getAttribute("aria-label")).toBeTruthy();
+	});
+
+	it("renders ordered and unordered lists, honouring an ordered list's start", () => {
+		render(<Markdown>{"- one\n- two\n\n3. three\n4. four"}</Markdown>);
+
+		const [unordered, ordered] = screen.getAllByRole("list");
+		expect(unordered?.tagName).toBe("UL");
+		expect(ordered?.tagName).toBe("OL");
+		expect(ordered?.getAttribute("start")).toBe("3");
+	});
+
+	it("keeps a task list's state as its source marker", () => {
+		render(<Markdown>{"- [x] done\n- [ ] todo"}</Markdown>);
+
+		const [done, todo] = screen.getAllByRole("listitem");
+		expect(done?.textContent).toBe("[x] done");
+		expect(todo?.textContent).toBe("[ ] todo");
+	});
+
+	it("opens a link in the browser without leaking the referrer", () => {
+		render(<Markdown>{"[kamp.us](https://kamp.us/x)"}</Markdown>);
+
+		const link = screen.getByRole("link", {name: "kamp.us"});
+		expect(link.getAttribute("href")).toBe("https://kamp.us/x");
+		expect(link.getAttribute("target")).toBe("_blank");
+		expect(link.getAttribute("rel")).toBe("noreferrer");
+	});
+
+	it.each([
+		["javascript:alert(1)", "a script URL"],
+		["JaVaScRiPt:alert(1)", "a script URL in mixed case"],
+		[" javascript:alert(1)", "a script URL behind leading whitespace"],
+		["data:text/html,<script>alert(1)</script>", "a data URL"],
+		["vbscript:msgbox(1)", "a vbscript URL"],
+	])("renders %s as text because it is %s, never as an anchor", (href) => {
+		render(<Markdown>{`[click](${href})`}</Markdown>);
+
+		expect(screen.queryByRole("link")).toBeNull();
+		expect(screen.getByText("click")).toBeDefined();
+	});
+
+	it.each([
+		"https://kamp.us",
+		"mailto:x@kamp.us",
+		"/sozluk",
+		"#section",
+	])("keeps %s as a live href", (href) => {
+		render(<Markdown>{`[go](${href})`}</Markdown>);
+
+		expect(screen.getByRole("link", {name: "go"}).getAttribute("href")).toBe(href);
+	});
+
+	it("prints raw HTML as text, so nothing in the source becomes markup", () => {
+		const {container} = render(
+			<Markdown>
+				{"<script>alert(1)</script>\n\nan <b>inline</b> tag\n\n<img src=x onerror=y>"}
+			</Markdown>,
+		);
+
+		expect(container.querySelector("script")).toBeNull();
+		expect(container.querySelector("b")).toBeNull();
+		expect(container.querySelector("img")).toBeNull();
+		expect(container.textContent).toContain("<script>alert(1)</script>");
+		expect(container.textContent).toContain("<b>inline</b>");
+	});
+
+	it("renders an image as a link, so no late-loading box changes the block's height", () => {
+		const {container} = render(<Markdown>{"![a cat](https://kamp.us/cat.png)"}</Markdown>);
+
+		expect(container.querySelector("img")).toBeNull();
+		expect(screen.getByRole("link", {name: "a cat"}).getAttribute("href")).toBe(
+			"https://kamp.us/cat.png",
+		);
+	});
+
+	it("renders a fenced block as pre/code tagged with its language", () => {
+		render(<Markdown>{"```ts\nconst x = 1;\n```"}</Markdown>);
+
+		const code = screen.getByText("const x = 1;");
+		expect(code.tagName).toBe("CODE");
+		expect(code.className).toBe("language-ts");
+		expect(code.parentElement?.tagName).toBe("PRE");
+	});
+
+	// A long code line makes the fence a horizontal scroller, and a scroller with no tab stop is
+	// content a keyboard-only operator cannot read (WCAG 2.1.1). jsdom applies no CSS, so the
+	// structure is what a test can hold — the same shape the table scroller carries.
+	it("makes a fenced block a named, focusable scroll region", () => {
+		render(<Markdown>{"```ts\nconst x = 1;\n```"}</Markdown>);
+
+		const pre = screen.getByText("const x = 1;").parentElement;
+		expect(pre?.tagName).toBe("PRE");
+		expect(pre?.getAttribute("role")).toBe("region");
+		expect(pre?.tabIndex).toBe(0);
+		expect(pre?.getAttribute("aria-label")).toBeTruthy();
+	});
+
+	// The fence's language reaches the renderer intact, which is the whole seam a diagram fence
+	// needs: #8128 branches on it and leaves every other fence on this path.
+	it("keeps a fence's language on the rendered block, mermaid included", () => {
+		render(<Markdown>{"```mermaid\ngraph TD;\n```"}</Markdown>);
+
+		expect(screen.getByText("graph TD;").className).toBe("language-mermaid");
+	});
+
+	it("steps headings down from headingBase and clamps them at h6", () => {
+		render(<Markdown headingBase={3}>{"# one\n\n## two\n\n##### five"}</Markdown>);
+
+		expect(screen.getByRole("heading", {level: 3, name: "one"})).toBeDefined();
+		expect(screen.getByRole("heading", {level: 4, name: "two"})).toBeDefined();
+		expect(screen.getByRole("heading", {level: 6, name: "five"})).toBeDefined();
+	});
+
+	it("renders nothing but an empty block for empty source", () => {
+		const {container} = render(<Markdown>{""}</Markdown>);
+
+		expect(container.querySelector(".kp-markdown")?.textContent).toBe("");
+	});
+});

--- a/packages/design/src/Markdown.tsx
+++ b/packages/design/src/Markdown.tsx
@@ -1,0 +1,228 @@
+/**
+ * `Markdown` — the shared read-only markdown block for agent output (founder ruling 2026-09-05 on
+ * [#8012](https://github.com/kamp-us/phoenix/issues/8012)).
+ *
+ * Two things here are not obvious from the code.
+ *
+ * **No HTML string is ever produced, so none can be executed.** This renders `marked`'s *token
+ * stream* to React elements and never calls `marked()` itself, so there is no `innerHTML` seam to
+ * sanitize: an `<script>` in the source arrives as an `html` token and is rendered as the text it
+ * is. Safety is a property of the shape rather than of a filter that has to be kept correct.
+ *
+ * **Everything paints on the first render.** Agent transcripts are virtualized and measured after
+ * paint, so a block that swapped content in later — an async-highlighted code fence, a remote
+ * image — would leave the measured row height stale. Lexing is synchronous and images render as
+ * links, so the element tree is final the moment it mounts.
+ */
+
+import {lexer, type MarkedToken, type Token, type Tokens} from "marked";
+import {Fragment, type ReactElement, type ReactNode, useMemo} from "react";
+import {useDesignT} from "./i18n";
+import "./Markdown.css";
+
+/**
+ * marked's `Token` union carries an open `Tokens.Generic` member whose `type` is `string`, so a
+ * `switch` on the discriminant never eliminates it and every field it narrows to degrades to `any`.
+ * The lexer emits only the closed `MarkedToken` set unless an extension registers another, and this
+ * module registers none — so the union is narrowed once here instead of at every field access.
+ */
+const closed = (token: Token): MarkedToken => token as MarkedToken;
+
+/**
+ * A markdown token has no identity of its own — two sibling list items may carry byte-identical
+ * source — so position is the only key available, and a block re-renders whole in any case.
+ */
+const keyed = <T,>(items: readonly T[], render: (item: T) => ReactNode): ReactNode =>
+	items.map((item, index) => <Fragment key={index}>{render(item)}</Fragment>);
+
+/**
+ * The one place a URL out of agent output becomes a live `href`. Everything outside the allow-list
+ * — `javascript:`, `data:`, `vbscript:` — renders as text instead, so a link can never carry
+ * execution into the page. Control characters and spaces go first, because the URL parser strips
+ * them too: a scheme split by an embedded tab reads as a foreign one to a check that keeps them and
+ * as `javascript:` to the browser, and that gap is the whole trick.
+ */
+const safeHref = (href: string): string | null => {
+	const clean = [...href].filter((character) => character > " ").join("");
+	if (clean === "") return null;
+	const relative =
+		clean.startsWith("#") ||
+		clean.startsWith("/") ||
+		clean.startsWith("./") ||
+		clean.startsWith("../");
+	if (relative) return clean;
+	return /^(?:https?|mailto):/i.test(clean) ? clean : null;
+};
+
+/** The founder's ruling: agent links are real anchors and open in the browser. */
+const Anchor = ({href, children}: {readonly href: string; readonly children: ReactNode}) => {
+	const safe = safeHref(href);
+	if (safe === null) return <>{children}</>;
+	return (
+		<a href={safe} target="_blank" rel="noreferrer">
+			{children}
+		</a>
+	);
+};
+
+const inlines = (tokens: readonly Token[]): ReactNode =>
+	keyed(tokens, (token) => <Inline token={closed(token)} />);
+
+function Inline({token}: {readonly token: MarkedToken}): ReactNode {
+	switch (token.type) {
+		case "text":
+			return token.tokens === undefined ? token.text : inlines(token.tokens);
+		case "escape":
+			return token.text;
+		case "strong":
+			return <strong>{inlines(token.tokens)}</strong>;
+		case "em":
+			return <em>{inlines(token.tokens)}</em>;
+		case "del":
+			return <del>{inlines(token.tokens)}</del>;
+		case "codespan":
+			return <code>{token.text}</code>;
+		case "br":
+			return <br />;
+		case "link":
+			return <Anchor href={token.href}>{inlines(token.tokens)}</Anchor>;
+		// An `<img>` settles its own height after the network answers, which is exactly the late
+		// layout shift a measured transcript row cannot absorb — so the image is offered as a link.
+		case "image":
+			return <Anchor href={token.href}>{token.text === "" ? token.href : token.text}</Anchor>;
+		case "html":
+			return token.text;
+		default:
+			return token.raw;
+	}
+}
+
+/**
+ * `pre code` is `white-space: pre`, so a long line makes the fence a horizontal scroller (see
+ * `Markdown.css`) — and a scroll container no keyboard can focus is content a keyboard-only
+ * operator cannot read at all (WCAG 2.1.1), the same hazard the table wrapper below answers. The
+ * tab stop sits on the `<pre>` itself rather than on a wrapper because the `<pre>` *is* the
+ * scroller, and arrow keys scroll the focused element only. Unlike `<table>`, `<pre>` carries no
+ * implicit role that `role="region"` costs.
+ */
+function CodeBlock({token}: {readonly token: Tokens.Code}): ReactElement {
+	const t = useDesignT();
+	const lang = token.lang === undefined || token.lang === "" ? undefined : token.lang;
+	return (
+		// biome-ignore lint/a11y/noNoninteractiveTabindex: the tab stop is the point — see the docblock above.
+		// biome-ignore lint/a11y/useSemanticElements: a `<section>` wrapper would take the tab stop off the box that actually scrolls — see the docblock above.
+		<pre tabIndex={0} role="region" aria-label={t("ui.markdown.code")}>
+			<code className={lang === undefined ? undefined : `language-${lang}`}>{token.text}</code>
+		</pre>
+	);
+}
+
+/**
+ * The scroller is the wrapper, never the `<table>`: `display: block` on a table drops its implicit
+ * table role in Chrome and Safari, so the assistive-tech reading of an agent's table would be the
+ * cost of making a wide one fit. The wrapper is focusable and named because a scroll container no
+ * keyboard can reach is content a keyboard-only operator cannot read at all (WCAG 2.1.1).
+ */
+function TableBlock({token}: {readonly token: Tokens.Table}): ReactElement {
+	const t = useDesignT();
+	return (
+		// biome-ignore lint/a11y/noNoninteractiveTabindex: the tab stop is the point — a scroll container no keyboard can focus is content a keyboard-only operator cannot reach at all (WCAG 2.1.1), and the accessible name keeps it from being an unexplained stop.
+		<section className="kp-markdown__scroller" tabIndex={0} aria-label={t("ui.markdown.table")}>
+			<table>
+				<thead>
+					<tr>
+						{keyed(token.header, (cell) => (
+							<th data-align={cell.align ?? undefined}>{inlines(cell.tokens)}</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					{keyed(token.rows, (row) => (
+						<tr>
+							{keyed(row, (cell) => (
+								<td data-align={cell.align ?? undefined}>{inlines(cell.tokens)}</td>
+							))}
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</section>
+	);
+}
+
+const blocks = (tokens: readonly Token[], headingBase: number): ReactNode =>
+	keyed(tokens, (token) => <Block token={closed(token)} headingBase={headingBase} />);
+
+function Block({
+	token,
+	headingBase,
+}: {
+	readonly token: MarkedToken;
+	readonly headingBase: number;
+}): ReactNode {
+	switch (token.type) {
+		case "space":
+		case "def":
+			return null;
+		case "hr":
+			return <hr />;
+		case "heading": {
+			const level = Math.min(6, headingBase + token.depth - 1);
+			const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+			return <Heading>{inlines(token.tokens)}</Heading>;
+		}
+		case "paragraph":
+			return <p>{inlines(token.tokens)}</p>;
+		case "blockquote":
+			return <blockquote>{blocks(token.tokens, headingBase)}</blockquote>;
+		case "code":
+			return <CodeBlock token={token} />;
+		// A task marker stays the text it was written as. A real `<input type="checkbox">` would be
+		// an unlabelled control in a read-only block, and its state would reach a screen reader only
+		// by duplicating the item's own text as a name.
+		case "checkbox":
+			return token.raw;
+		case "list": {
+			const items = keyed(token.items, (item) => <li>{blocks(item.tokens, headingBase)}</li>);
+			return token.ordered ? (
+				<ol start={token.start === "" ? undefined : token.start}>{items}</ol>
+			) : (
+				<ul>{items}</ul>
+			);
+		}
+		case "table":
+			return <TableBlock token={token} />;
+		// Raw HTML is content, not markup: it prints as the source it is (see the module docblock).
+		case "html":
+			return <p className="kp-markdown__raw">{token.text}</p>;
+		case "text":
+			return token.tokens === undefined ? token.text : inlines(token.tokens);
+		default:
+			return token.raw;
+	}
+}
+
+/**
+ * @component Markdown
+ * @whenToUse Read-only display of markdown an agent produced — a chat transcript row, a tool
+ *   result, any surface that shows model output. It is a renderer, not an editor: for authoring
+ *   reach for the app's editor instead.
+ * @slot children The markdown source. Not sanitized upstream and not required to be: raw HTML in it
+ *   renders as text, never as markup.
+ */
+export function Markdown({
+	children,
+	className = "",
+	headingBase = 1,
+}: {
+	readonly children: string;
+	readonly className?: string;
+	/**
+	 * The level a top-level (`#`) markdown heading renders at, so a block nested inside a page's
+	 * outline does not emit an `<h1>` under it. Deeper headings step down from here and clamp at 6.
+	 */
+	readonly headingBase?: number;
+}): ReactElement {
+	const tokens = useMemo(() => lexer(children), [children]);
+	return <div className={`kp-markdown ${className}`.trim()}>{blocks(tokens, headingBase)}</div>;
+}

--- a/packages/design/src/a11y/registry.tsx
+++ b/packages/design/src/a11y/registry.tsx
@@ -13,6 +13,7 @@ import {Badge} from "../Badge";
 import {Button} from "../Button";
 import {Card, Surface} from "../Card";
 import {CountToggle} from "../CountToggle";
+import {Markdown} from "../Markdown";
 import {MetaRow} from "../MetaRow";
 import {NumberInput} from "../NumberInput";
 import {ScrollArea} from "../ScrollArea";
@@ -187,6 +188,29 @@ const scrollAreaArb: fc.Arbitrary<ReactElement> = text.map((children) => (
 	<ScrollArea orientation="vertical">{children}</ScrollArea>
 ));
 
+/**
+ * Markdown source covering every block the renderer emits, so the invariants run over really
+ * rendered markdown rather than a stand-in. Headings stay at one level on purpose: axe's
+ * `heading-order` judges a document outline, so a generator that shuffled levels would red on the
+ * fixture rather than on the block.
+ */
+const markdownArb: fc.Arbitrary<ReactElement> = fc
+	.array(
+		fc.constantFrom(
+			"## a heading",
+			"some **bold** body text",
+			"- one\n- two",
+			"1. first\n2. second",
+			"| a | b |\n|---|---|\n| 1 | 2 |",
+			"```ts\nconst x = 1;\n```",
+			"> quoted",
+			"[kamp.us](https://kamp.us)",
+			"---",
+		),
+		{minLength: 1, maxLength: 4},
+	)
+	.map((parts) => <Markdown>{parts.join("\n\n")}</Markdown>);
+
 const COMPOUND_REASON =
 	"Manti machine primitive — needs required items/trigger/content props or a portal interaction to render a representative surface; covered by composed-usage tests.";
 
@@ -204,6 +228,7 @@ export const REGISTRY: Readonly<Record<string, PrimitiveSpec>> = {
 
 	Surface: {kind: "presentational", arb: surfaceArb},
 	Card: {kind: "presentational", arb: cardArb},
+	Markdown: {kind: "presentational", arb: markdownArb},
 	MetaRow: {kind: "presentational", arb: metaRowArb},
 	SandboxMarker: {
 		kind: "deferred",

--- a/packages/design/src/i18n.tsx
+++ b/packages/design/src/i18n.tsx
@@ -15,6 +15,8 @@ export const designTrMessages = {
 	"ui.draftRestore.text": "kaydedilmiş bir taslağın var. geri yüklemek ister misin?",
 	"ui.draftRestore.restore": "taslağı geri yükle",
 	"ui.draftRestore.dismiss": "yoksay",
+	"ui.markdown.table": "tablo",
+	"ui.markdown.code": "kod bloğu",
 	"admin.agent.label": "Agent chat input",
 	"admin.agent.scope": "yalnızca yerel atölye",
 	"admin.agent.compose.label": "Pi'ye mesaj yaz",

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -51,6 +51,7 @@ export type {
 	DesignTranslate,
 } from "./i18n";
 export {DesignTranslationProvider} from "./i18n";
+export {Markdown} from "./Markdown";
 export type {MenuItem, MenuProps} from "./Menu";
 export {Menu} from "./Menu";
 export type {MetaRowProps} from "./MetaRow";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ catalogs:
     lucide-react:
       specifier: 1.23.0
       version: 1.23.0
+    marked:
+      specifier: 18.0.5
+      version: 18.0.5
     react:
       specifier: 19.2.6
       version: 19.2.6
@@ -864,6 +867,9 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
+      marked:
+        specifier: 'catalog:'
+        version: 18.0.5
       react:
         specifier: 'catalog:'
         version: 19.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,10 @@ catalog:
   jsdom: ^26.1.0
   lefthook: ^2.1.9
   lucide-react: 1.23.0
+  # Pinned to the exact 18.0.5 an existing lockfile parent already links (@earendil-works/pi-tui),
+  # so no third `marked` enters the tree beside it and @tiptap/markdown's 17.0.6. @kampus/design's
+  # `Markdown` uses the lexer only — the token stream, never `marked()`'s HTML string (#8012).
+  marked: 18.0.5
   react: 19.2.6
   react-dom: 19.2.6
   react-fate: 1.3.1


### PR DESCRIPTION
Closes #8012.
Closes #8129.

> **Overlap, read this first.** PR #8022 is an open PR on the same issue whose lane parked after five repair rounds died on branch conflicts. Its content applies cleanly to today's `main` (926d85a2), so this branch **adopts that work**, rebuilt on current main and re-verified end to end, plus one added test. **Land one and close the other** — this PR if you want the clean branch, #8022 if you'd rather keep its review history.

## What was wrong

`ItemRow` in `apps/tuval/src/shell/chat/ChatWindow.tsx` sent every non-`tool` item to one line — `<p className="tuval-chat-text">{item.text}</p>`. Nothing between the transcript port and that `<p>` parsed anything, so an agent reply printed as source: a table arrived as pipes and dashes, `**bold**` kept its asterisks, a link stayed `[text](url)`.

## What changed

- **`packages/design/src/Markdown.tsx`** — a new shared read-only markdown block, exported from `index.ts` beside `AgentChatInput` so apps/web can reuse it (the founder's ruling on the layout question).
- **`ItemRow`** now routes by kind through a small `ItemBody`: `tool` → `ToolRow`, `assistant` → `<Markdown headingBase={3}>`, everything else keeps the plain-text `<p>`. Typed input is still shown exactly as typed. The edit to `ChatWindow.tsx` is deliberately minimal and additive — two other branches are live on this file.
- **`apps/web/src/lab/atolye/exhibits/Markdown.exhibit.tsx`** — an atölye exhibit, so the block is judged rendered and not only through jsdom.

### Library: `marked`, lexer only

Already in the lockfile as a transitive dep of `@earendil-works/pi-tui`, so it is catalogued at that parent's exact version (`marked: 18.0.5`) and no third copy enters the tree beside `@tiptap/markdown`'s 17.0.6. Consumed as `catalog:` in `packages/design/package.json`.

**The renderer walks `marked`'s token stream to React elements and never calls `marked()`.** There is no HTML string and so no `innerHTML` seam to sanitize — a `<script>` in a reply arrives as an `html` token and renders as the text it is. Safety is a property of the shape, not of a filter someone has to keep correct. Separately, `safeHref` strips control characters and spaces first (a scheme split by an embedded tab reads foreign to a naive check and as `javascript:` to the browser) and then allows only `https?:`, `mailto:` and relative URLs; anything else renders as text with no anchor.

### Virtualization

Lexing is synchronous, nothing is async-highlighted, and images render as links rather than `<img>` — so the element tree is final the moment the row mounts and `virtualizer.measureElement` measures a real height. No late layout shift.

### Accessibility

- Real semantics throughout: `<table>`/`<th>`/`<td>`, `<ol>`/`<ul>`, `<h3>`–`<h6>` (stepped down from `headingBase` so a `#` in a reply is a subsection of the transcript, not a page title), `<pre><code>`, `<strong>`/`<em>`/`<code>`, real `<a>` with `target="_blank" rel="noreferrer"`.
- A wide table scrolls in a **wrapper**, never via `display: block` on the `<table>` — that drops the implicit table role in Chrome and Safari. The wrapper is `tabIndex={0}` + `aria-label`, so a keyboard-only operator can scroll it (WCAG 2.1.1). A long code fence gets the same treatment on the `<pre>` itself, which is the element that actually scrolls.
- The scroller's accessible name comes from Tuval's own `copy.ts` through `DesignTranslationProvider`, so a Tuval transcript announces the English noun and never the package's Turkish `tablo` fallback (ADR 0347).
- `role="log"`, the focusable scroll region and `swallowBareCharacter` are untouched.

## How it was verified

- `pnpm typecheck` — 23/23 tasks green, 0 errors.
- `pnpm lint` — clean, no fixes applied.
- `apps/tuval` `pnpm test` — **187 files, 1586 tests passed**.
- `packages/design` `pnpm test` — **22 files, 143 tests passed** (21 in `Markdown.test.tsx`).
- New `apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx` (7 cases) covers: table → `<table>`, link → `<a>` with href, headings/lists/emphasis/fenced code as elements, both scrollers' English accessible names, raw HTML printed as text, a `javascript:` link refused an anchor while keeping its text, and `user`/`system` rows still plain.
- **Looked at it rendered, in both apps.** Screenshotted `/lab/atolye/markdown` on an `apps/web`-only vite (port 4399), and `apps/tuval`'s `proof:chat` harness on port 4400 with a markdown-bearing fixture (local only, reverted). The heading, bold, an underlined link, inline-code chips, a real bordered table with per-column alignment honoured (centred `Durum`, right-aligned `Gecikme`), a bullet list and a fenced block in its own panel all render on-system. Nothing printed as source.

## Repair round — two review defects fixed

**1. The per-component focus ring is gone (SEV2, `review-ui`/design law).** `Markdown.css` hand-rolled a `:focus-visible` outline. It was the first ring any stylesheet in `@kampus/design` had ever painted — every other one writes only `outline: none` — and because both apps paint theirs at near-zero specificity, the per-component rule won the cascade in both. It looked correct only because `--manti-focus-ring` and `--focus-ring` happen to resolve identically today; tuning an app's ring would have silently left this one component behind. That coincidence was the defect. The rule is deleted and the app-level ring paints the scrollers. Verified by computed style on a focused scroller and a focused fence:

| App | Rule that paints it | Computed |
| --- | --- | --- |
| `apps/web` | `:where(…, [tabindex]):focus-visible` in `styles/global.css` | `2px solid rgb(229,77,46)`, offset `2px` |
| `apps/tuval` | `.tuval-surface :focus-visible` in `shell/ui/tokens.css` | `2px solid rgb(59,158,255)`, offset `2px` |

Both keep a visible ring, so no fallback to the shared token was needed.

**2. Two typefaces in one reply (SEV2).** `Markdown.css` sets `font: var(--t-h-feed)` on h1–h3, and `chat.css`'s adapter block did not re-declare that role — so it resolved from the design package's `:root` with the family already substituted to IBM Plex. Measured at the previous head: a `#` heading rendered `16px "IBM Plex Sans"` against `14px system-ui` for everything else in the window. `chat.css` now declares `--t-h-feed: 16px / 1.35 var(--font-body)`, and its docblock gains the omission case — the hazard it already described is a *dropped* shorthand, whereas a *missing* role fails the other way and quieter. Re-measured in `proof:chat`: h3 `16px system-ui`, h4/p/`.tuval-chat-text` all `14px system-ui`.

**A note on the token gate.** It passed on the font defect, and correctly so: `--t-h-feed` is a real role read through a real `var()`, and a role that resolves right in one app while carrying the wrong family into another is invisible to a per-file scan. The catch needs the cross-app resolution, which is what `review-ui`'s render gave it.

## Deviations

- **Declined guidance** — the builder-side visual check did not go through `fabrika ui render`.
  **Said:** rendered surfaces are checked through the repo's UI render harness.
  **Did:** booted `apps/web`'s vite alone on port 4399, and `apps/tuval`'s `proof:chat` harness on port 4400, and drove both with Playwright for pixels and computed styles.
  **Why:** I read `design-harness.json`'s `command` as an unfiltered `pnpm dev`, which turbo fans across every package — including `apps/tuval`'s `dev`, booting a second Tuval desk that contends for 5173 with the founder's live desk (#7992). That reasoning was wrong for this gate: `review-ui render` hits the PR's preview deployment, not `pnpm dev`, so the contention was never in the path.
  **Disposition:** accepted for the builder-side check only, and it cost nothing — the `review-ui` gate ran its own render against the preview. No follow-up owed.

- **Guard or gate bypassed** — three new `biome-ignore` suppressions in `packages/design/src/Markdown.tsx`.
  **Said:** biome's a11y rules pass unsuppressed.
  **Did:** suppressed `lint/a11y/noNoninteractiveTabindex` at lines 112 and 129 (the `<pre>` and the table `<section>`) and `lint/a11y/useSemanticElements` at line 113 (`role="region"` on the `<pre>`). The scan reports a fourth hit, `ChatWindow.tsx:746` — that is the transcript's pre-existing `role="log"` tab stop, unchanged on `main` at line 712 and moved only by this diff's line shift.
  **Why:** the tab stop is the feature, not an oversight — a scroll container no keyboard can focus is content a keyboard-only operator cannot read at all (WCAG 2.1.1), which is criterion 9 of the issue and the whole of #8129. It sits on the `<pre>` rather than a wrapper because the `<pre>` is the scroller and arrow keys scroll the focused element only. Each suppression carries its reason inline, with the argument in the docblock above it.
  **Disposition:** kept. Removing them means removing the tab stops, which fails the criterion they exist for.

- **Out-of-scope change** — this branch adopts PR #8022's content rather than being authored from scratch.
  **Said:** a build lands its own work.
  **Did:** applied #8022's diff to today's `main` (it applies clean), re-verified every gate from scratch, and added one test — a mermaid fence keeps its language, pinning the #8128 seam. At this PR's first head, 19 of 20 files were byte-identical to #8022's; `Markdown.css` and `chat.css` now differ by the two repairs above.
  **Why:** #8022 is an open PR on this same issue whose lane parked after five repair rounds died on branch conflicts, not on its content. Rewriting a reviewed renderer from scratch would have produced a worse one and thrown away five rounds of a11y findings.
  **Disposition:** disclosed, not hidden. Land one and close the other — this PR for the clean branch, #8022 to keep its review history.

## Known follow-ups (raised in review, deliberately not fixed here)

- **Heading steps collapse below h3.** `Markdown.css` gives h4/h5/h6 one declaration, so under the transcript's `headingBase={3}` a `##` (h4) and a `###` (h5) render identically — and both match a paragraph at 14px. Measured, not inferred.
- **Both scroll wrappers take a tab stop unconditionally.** That is a coherent consequence of the paint-synchronously constraint (nothing may measure overflow after mount), but it leaves dead stops on short tables and one-line fences in a long transcript.

## What #8128 (mermaid fences) still needs

Left shaped as a small follow-up, not a rewrite. A fence reaches one place — `CodeBlock`, with `token.lang` already in hand and emitted as `language-<lang>` on the `<code>`. #8128 is a branch on `lang === "mermaid"` at that single site, rendering a diagram instead of the `<pre>`; every other fence stays on the current path. `Markdown.test.tsx` pins that seam with a test asserting a `mermaid` fence keeps its language on the rendered block. The one constraint to respect: whatever it renders must paint synchronously or explicitly re-measure, since the transcript row's height is measured after paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



