### PR TITLE
fix: A Pi turn can end with the agent core still at phase prompting

### DIFF
--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -35,6 +35,7 @@
 import {readdirSync} from "node:fs";
 import {join} from "node:path";
 import {getAgentDir, ModelRuntime, SessionManager} from "@earendil-works/pi-coding-agent";
+import type {SessionSnapshot} from "@earendil-works/pi-protocol";
 import {type Cause, Effect, Fiber, Layer, Queue, Redacted, Ref, type Scope, Stream} from "effect";
 import {isRefusal, planTranscriptPage} from "../../ai-agent/history/index.ts";
 import type {
@@ -106,6 +107,17 @@ export interface PiAiAgentOptions {
 }
 
 type EventQueue = Queue.Queue<AgentEvent, TransportError | Cause.Done>;
+
+/**
+ * What one session's fold reads. `sent` is the turn's start as a fact rather than as a difference
+ * between snapshots, and it is what makes the turn's *end* a difference at all: the server's push
+ * for a whole turn can coalesce into a single read taken after it finished, so the projection would
+ * otherwise sit at `ready` from before the send to after it and emit nothing, while the core moved
+ * itself to `prompting` at the send and stayed there — refusing every later message (#7897).
+ */
+type FoldInput =
+	| {readonly _tag: "snapshot"; readonly snapshot: SessionSnapshot}
+	| {readonly _tag: "sent"};
 
 /**
  * Read one session's branch out of Pi's JSONL, oldest-first.
@@ -183,6 +195,7 @@ const make = (
 		const keys = yield* Ref.make<ReadonlySet<string>>(new Set());
 		const dialled = yield* Ref.make(false);
 		const pump = yield* Ref.make<Fiber.Fiber<void, never> | null>(null);
+		const inbox = yield* Ref.make<Queue.Queue<FoldInput> | null>(null);
 
 		const queue = yield* Effect.acquireRelease(
 			Ref.make<EventQueue>(yield* Queue.unbounded<AgentEvent, TransportError | Cause.Done>()),
@@ -197,15 +210,31 @@ const make = (
 		 * The snapshot fan for one session, racing the first disconnection. A drop wins the race,
 		 * fails the queue exactly once and interrupts the fan, which is the whole of "one
 		 * `Disconnected` and no reconnect until `start` is called again".
+		 *
+		 * Everything the projection folds arrives through `feed`, including the server's own
+		 * pushes: one queue is what keeps a `sent` mark and a snapshot in the order they happened,
+		 * and one consumer is what keeps two arrivals from interleaving a revision.
 		 */
-		const follow = (sessionId: string, open: EventQueue): Effect.Effect<void> =>
+		const follow = (
+			sessionId: string,
+			open: EventQueue,
+			feed: Queue.Queue<FoldInput>,
+		): Effect.Effect<void> =>
 			Effect.gen(function* () {
 				const projection = yield* Ref.make(emptyProjection);
-				const snapshots = pi.snapshots(sessionId).pipe(
-					Stream.runForEach((snapshot) =>
+				const pushes = pi
+					.snapshots(sessionId)
+					.pipe(Stream.runForEach((snapshot) => Queue.offer(feed, {_tag: "snapshot", snapshot})));
+				const folding = Stream.fromQueue(feed).pipe(
+					Stream.runForEach((input) =>
 						Effect.gen(function* () {
 							const previous = yield* Ref.get(projection);
-							const folded = eventsOf(previous, snapshot);
+							if (input._tag === "sent") {
+								if (previous.phase === "prompting") return;
+								yield* Ref.set(projection, {...previous, phase: "prompting"});
+								return yield* emit(open, [{kind: "phase", phase: "prompting"}]);
+							}
+							const folded = eventsOf(previous, input.snapshot);
 							yield* Ref.set(projection, folded.next);
 							yield* emit(open, folded.events);
 						}),
@@ -215,7 +244,7 @@ const make = (
 					Stream.take(1),
 					Stream.runForEach((drop) => Queue.fail(open, transportErrorOf(drop))),
 				);
-				yield* Effect.race(snapshots, dropped);
+				yield* Effect.race(Effect.race(pushes, folding), dropped);
 			});
 
 		/**
@@ -296,6 +325,8 @@ const make = (
 			const previous = yield* Ref.get(pump);
 			if (previous !== null) yield* Fiber.interrupt(previous);
 			yield* Effect.flatMap(Ref.get(queue), Queue.shutdown);
+			const stale = yield* Ref.get(inbox);
+			if (stale !== null) yield* Queue.shutdown(stale);
 
 			const open = yield* Queue.unbounded<AgentEvent, TransportError | Cause.Done>();
 			yield* Ref.set(queue, open);
@@ -340,9 +371,11 @@ const make = (
 			yield* Ref.set(pendingThinking, null);
 
 			yield* Ref.set(session, {...ref, model: running, thinkingLevel: thinking});
+			const feed = yield* Queue.unbounded<FoldInput>();
+			yield* Ref.set(inbox, feed);
 			// Forked into the layer's own scope, not the caller's, so the fan lives exactly as long
 			// as the transport it reads and dies with it.
-			yield* Ref.set(pump, yield* Effect.forkIn(follow(ref.id, open), scope));
+			yield* Ref.set(pump, yield* Effect.forkIn(follow(ref.id, open, feed), scope));
 			const offered = catalog.map(refOf);
 			yield* emit(open, [
 				{kind: "mode", current: null, available: []},
@@ -369,18 +402,30 @@ const make = (
 				yield* Ref.update(keys, (seen) => new Set(seen).add(key));
 			}
 			const open = yield* Ref.get(queue);
+			// Read here rather than inside the fork, so a `start` that lands while this send is in
+			// flight cannot route the old session's turn into the new session's fold.
+			const feed = yield* Ref.get(inbox);
+			// The turn has begun, and this is the only unlosable statement of that: see `FoldInput`.
+			if (feed !== null) yield* Queue.offer(feed, {_tag: "sent"});
 			// The pin answers a `prompt` request with the snapshot the turn ended on, so awaiting it
 			// here would return at the end of the turn rather than at the send — and the generic
 			// host awaits a Cmd handler before it publishes the commit that handler came from, so
 			// the operator's own message would not paint until the reply landed (#8018). Forked into
-			// the layer's scope, this returns at the send, as the Claude layer's does. The turn's
-			// own events are pushed by `follow` and nothing reads the snapshot this discards.
+			// the layer's scope, this returns at the send, as the Claude layer's does.
+			//
+			// That answer is the turn's end, and it goes into the same fold rather than being
+			// dropped: the push carrying it can be coalesced away, and then nothing else ever says
+			// the turn finished. Re-folding a snapshot the pushes already delivered emits nothing,
+			// because the projection emits only a difference.
 			yield* Effect.forkIn(
 				pi.prompt(current.id, text).pipe(
 					Effect.mapError(promptErrorOf),
 					// A send that never landed is not a turn this session has seen, so the key goes
 					// back and a retry of it is admitted.
 					Effect.tapError(() => (key === undefined ? Effect.void : Ref.update(keys, without(key)))),
+					Effect.tap((snapshot) =>
+						feed === null ? Effect.void : Queue.offer(feed, {_tag: "snapshot", snapshot}),
+					),
 					// The refusal has no caller left to raise to, so it rides the stream the send's own
 					// turn would have used. It rides it as an event, not as the queue's failure: a
 					// failed queue is terminal and its Sub is never re-armed under the same id, so

--- a/apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The end of a Pi turn, when the pushes that would have carried it coalesce away.
+ *
+ * `ready` used to exist only as a difference between two *received* snapshots, and the server
+ * signals a session's changes through a capacity-1 sliding queue — so a whole turn can collapse
+ * into one read taken after it finished. The projection then sits at `ready` from before the send
+ * to after it and emits nothing at all, while the core moved itself to `prompting` at the send.
+ * Its `prompt` guard admits a session at `ready` only, so the next message is silently refused
+ * (#7897).
+ *
+ * The interleaving is what a socket will not hand a test on demand, so these run over a stub
+ * `PiClientService`: the snapshot stream is a queue the test pushes, and `prompt` settles when the
+ * test says so, with the snapshot the turn ended on.
+ */
+
+import type {
+	TranscriptItem as PiTranscriptItem,
+	SessionSnapshot,
+} from "@earendil-works/pi-protocol";
+import {assert, describe, it} from "@effect/vitest";
+import {type Cause, Deferred, Effect, Layer, Option, Queue, Stream} from "effect";
+import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
+import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {aiAgentOverClient} from "./PiAiAgent.ts";
+
+const CWD = "/tuval/turn-end";
+const SESSION: PiSessionRef = {
+	id: "session-7897",
+	cwd: CWD,
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+};
+
+const user: PiTranscriptItem = {
+	id: "item-0",
+	role: "user",
+	content: [{type: "text", text: "say hello"}],
+	timestamp: 10,
+};
+
+const reply: PiTranscriptItem = {
+	id: "item-1",
+	role: "assistant",
+	content: [{type: "text", text: "hello"}],
+	model: SESSION.model,
+	timestamp: 11,
+	status: "complete",
+	stopReason: "stop",
+};
+
+const snapshot = (
+	transcript: ReadonlyArray<PiTranscriptItem>,
+	phase: SessionSnapshot["phase"],
+	revision: number,
+): SessionSnapshot => ({
+	id: SESSION.id,
+	cwd: CWD,
+	createdAt: 0,
+	updatedAt: 0,
+	phase,
+	model: SESSION.model,
+	thinkingLevel: "off",
+	attached: true,
+	locked: true,
+	revision,
+	transcript: [...transcript],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+/** The stub server: a snapshot stream the test feeds, and a `prompt` the test settles. */
+const stub = Effect.gen(function* () {
+	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const ended = yield* Deferred.make<SessionSnapshot>();
+	const api: PiClientApi = {
+		connect: Effect.void,
+		reconnect: Effect.void,
+		connected: Effect.succeed(true),
+		createSession: () => Effect.succeed(SESSION),
+		attachSession: () => Effect.succeed(SESSION),
+		prompt: () => Deferred.await(ended),
+		abort: () => Effect.never,
+		setModel: () => Effect.never,
+		setThinkingLevel: () => Effect.never,
+		models: Effect.succeed([]),
+		snapshots: () => Stream.fromQueue(pushes),
+		disconnections: Stream.never,
+	};
+	return {
+		layer: Layer.succeed(PiClientService, api),
+		push: (value: SessionSnapshot) => Queue.offer(pushes, value),
+		/** Settle the send with the snapshot the turn ended on, as the server's answer does. */
+		endTurn: (value: SessionSnapshot) => Deferred.succeed(ended, value),
+	};
+});
+
+type Events = Queue.Dequeue<AgentEvent, TransportError | Cause.Done>;
+
+/**
+ * Every event up to and including the first one `found` accepts. Bounded, so a transition that
+ * never arrives fails on the line that names it rather than hanging the suite out to a timeout.
+ */
+const collectTo = (events: Events, what: string, found: (event: AgentEvent) => boolean) =>
+	Effect.gen(function* () {
+		const seen: Array<AgentEvent> = [];
+		while (true) {
+			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("5 seconds"));
+			if (Option.isNone(next)) {
+				assert.fail(`timed out waiting for ${what}; saw ${JSON.stringify(seen)}`);
+			}
+			const event = next.value;
+			seen.push(event);
+			if (found(event)) return seen;
+		}
+	});
+
+const isReady = (event: AgentEvent): boolean => event.kind === "phase" && event.phase === "ready";
+const isReply = (event: AgentEvent): boolean =>
+	event.kind === "item" && event.item.kind === "assistant";
+
+const readies = (events: ReadonlyArray<AgentEvent>): number => events.filter(isReady).length;
+
+describe("a Pi turn whose pushes coalesced away", () => {
+	it.live("still ends at ready, with the reply above it", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				// The open's own `ready`, so what follows belongs to the turn.
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("say hello");
+				// Nothing is pushed for the whole turn: the sliding change signal collapsed every
+				// read into the one taken after it finished, which is the send's own answer.
+				yield* client.endTurn(snapshot([user, reply], "idle", 1));
+
+				const turn = yield* collectTo(events, "the turn's ready", isReady);
+				assert.strictEqual(readies(turn), 1, "the end of the turn reached the core more than once");
+				assert.isTrue(
+					turn.findIndex(isReply) < turn.findIndex(isReady),
+					"ready landed above the reply it belongs under",
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	it.live("emits ready once when the pushes did land, not twice", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("say hello");
+				yield* client.push(snapshot([user], "turn", 1));
+				// The whole turn, pushed: the transition is already on the stream before the send's
+				// answer re-folds the same snapshot.
+				yield* client.push(snapshot([user, reply], "idle", 2));
+				const pushed = yield* collectTo(events, "the turn's ready", isReady);
+				assert.strictEqual(readies(pushed), 1, "the push emitted the transition more than once");
+				assert.isTrue(
+					pushed.findIndex(isReply) < pushed.findIndex(isReady),
+					"ready landed above the reply it belongs under",
+				);
+
+				yield* client.endTurn(snapshot([user, reply], "idle", 3));
+				// The answer re-folds a snapshot the projection has already seen, so it is worth no
+				// event at all — a window rendering in arrival order shows one `ready`, once.
+				const after = yield* Queue.take(events).pipe(
+					Effect.orDie,
+					Effect.timeoutOption("250 millis"),
+				);
+				assert.isTrue(
+					Option.isNone(after),
+					`the settled snapshot repainted something already folded: ${JSON.stringify(after)}`,
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+});

--- a/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
+++ b/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
@@ -177,25 +177,31 @@ const runFirstBoot = (project: string): Effect.Effect<FirstRun, unknown, FileSys
 		yield* until("the Pi session to open", () => sessionOf(agent).sessionId !== null, seen);
 		yield* until("the session to be ready", () => sessionOf(agent).phase === "ready", seen);
 
-		// Each turn is waited out on what it wrote, not on the phase settling back to `ready`: a Pi
-		// turn can end with the core still at `prompting`, because `ready` is only emitted when a
-		// pushed snapshot's phase differs from the last one and the snapshot that would carry it can
-		// be coalesced away (#7897). The tail is the deterministic signal.
-		const assistants = () =>
-			sessionOf(agent).transcript.items.filter((item) => item.kind === "assistant").length;
+		// Each turn is waited out on the phase, in two steps: the send moves the core to `prompting`
+		// on its own, so `ready` alone could be the one this turn has not left yet. The end of a
+		// turn is a fact the send's own answer carries even when the push that would have said so is
+		// coalesced away (#7897), so this is the signal and the tail is what the assertions read.
+		const turn = (what: string) =>
+			Effect.gen(function* () {
+				yield* until(`${what} to start`, () => sessionOf(agent).phase === "prompting", seen);
+				yield* until(`${what} to finish`, () => sessionOf(agent).phase === "ready", seen);
+			});
 
 		yield* say(window, "read the readme", "k1");
-		yield* until("the first turn's reply", () => assistants() >= 1, seen);
+		yield* turn("the first turn");
 		yield* quiet(window);
+		assert.isTrue(
+			sessionOf(agent).transcript.items.some((item) => item.kind === "assistant"),
+			"the first turn settled with no reply in the tail",
+		);
 
 		yield* say(window, "now run the tool", "k2");
-		yield* until(
-			"the tool turn's row and its follow-up reply",
-			() =>
-				assistants() >= 3 && sessionOf(agent).transcript.items.some((item) => item.kind === "tool"),
-			seen,
-		);
+		yield* turn("the tool turn");
 		yield* quiet(window);
+		assert.isTrue(
+			sessionOf(agent).transcript.items.some((item) => item.kind === "tool"),
+			"the tool turn settled with no tool row in the tail",
+		);
 
 		const state = sessionOf(agent);
 		assert.isNotNull(state.sessionId, "the first run never opened a session");
@@ -247,12 +253,13 @@ const runFromTheCheckpoint = (
 
 		const before = new Set(rendered(window));
 		yield* say(window, "and once more", "k3");
-		yield* until(
-			"the new turn's reply",
-			() => textsIn(window).includes("and once more") && rendered(window).length > before.size + 1,
-			seen,
-		);
+		yield* until("the new turn to start", () => sessionOf(agent).phase === "prompting", seen);
+		yield* until("the new turn to finish", () => sessionOf(agent).phase === "ready", seen);
 		yield* quiet(window);
+		assert.isTrue(
+			textsIn(window).includes("and once more"),
+			"the new turn settled without the prompt reaching the window",
+		);
 
 		return {
 			restored,


### PR DESCRIPTION
Fixes #7897.

A Pi turn could finish with every item folded and the core still at `phase: "prompting"`.
The core's `prompt` guard admits a session at `ready` only, so the next message was
silently refused, and a checkpoint taken there read on the next boot as an interrupted
turn.

## What was actually wrong

The layer emitted `phase` only where two *received* snapshots disagreed. The server
signals a session's changes through a capacity-1 sliding queue, so a whole turn can
collapse into one read taken after it finished. The projection then sits at `ready`
from before the send to after it and emits nothing at all — while the core moved
*itself* to `prompting` at the send and never heard otherwise.

The headless restore proof reproduces it: over the tool turn, every snapshot the client
received said `idle`, so the terminal one was worth no event.

Feeding the send's answer back into the fold is necessary but not sufficient on its own,
because that answer is `idle` too. The turn's *start* has to be a fact as well.

## The fix

`follow` now folds one queue carrying three things in the order they happened: the
server's pushes, a `sent` mark written when a prompt goes out, and the snapshot the
send's own answer carries.

- The `sent` mark moves the projection to `prompting`, so the turn's end is a difference
  again.
- The answer's snapshot guarantees the terminal `idle` arrives even when no push does.
- One queue and one consumer keep the two sources from interleaving a revision, and the
  projection still emits only differences, so a push that did land is not repainted.

## Tests

- `apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts` — new. The first case pushes nothing
  for the whole turn and settles the send with the terminal snapshot; it hangs and fails
  at the previous head. The second case pushes the turn normally and pins that exactly one
  `ready` is emitted, below the reply, and that the answer's re-fold emits nothing.
- `apps/tuval/src/pi/restore/pi-restore.integration.test.ts` — each turn now waits on the
  phase (`prompting`, then `ready`) instead of on the transcript tail, and the tail is
  what the assertions read afterwards.

## Deviations

- **Out-of-scope change** — **Said:** #7897 names the restore proof's first-boot turns as
  the assertion to restore. **Did:** also moved the second boot's "and once more" turn onto
  the same phase wait. **Why:** it waited on the window's rendered tail for the same reason,
  and leaving one of the three on the old signal would have kept a live reader of this file
  believing the phase is untrustworthy. **Disposition:** stated here.
