### PR TITLE
fix: Stopping a Tuval Pi agent while a turn is in flight never returns

### DIFF
--- a/apps/tuval/src/pi/ai-agent/teardown.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/teardown.unit.test.ts
@@ -14,7 +14,7 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Stream} from "effect";
+import {Effect, Fiber, Layer, Option, Stream} from "effect";
 import {type AgentEvent, TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {makeScriptedHost} from "../server/fixtures.ts";
 import {aiAgentOverHost} from "./PiAiAgent.ts";
@@ -80,6 +80,49 @@ describe("closing the process's scope", () => {
 				[...host.disposals.entries()],
 				[[sessionId, 1]],
 				"the one session this run opened was disposed exactly once",
+			);
+			yield* settleTo(baseline);
+		});
+	});
+});
+
+/**
+ * The regression #7896 filed: a stop taken while a turn is in flight, rather than between turns.
+ * The scripted host's reply is still four seconds out when the scope closes, so the run either
+ * returns while the turn is unfinished or it is the reported hang.
+ *
+ * The run is forked and *awaited* under a bound rather than wrapped in `Effect.timeout`: a timeout
+ * interrupts its source and waits for it, and a scope finalizer is uninterruptible, so wrapping the
+ * hang would hang the wrapper too. Awaiting the fiber instead leaves the failure line as the
+ * diagnosis (`.patterns/ci-legible-integration-tests.md`).
+ */
+describe("closing the process's scope with a turn in flight", () => {
+	it.live("returns, and still disposes the session exactly once", () => {
+		const host = makeScriptedHost({promptDelayMs: 4_000});
+		return Effect.gen(function* () {
+			const baseline = sockets();
+			const run = Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				const started = yield* agent.start({cwd: CWD});
+				// `prompt` returns at the send (#8018), so the turn is running when this returns and
+				// the sleep is only there to let the host reach it before the scope closes.
+				yield* agent.prompt("mid-turn");
+				yield* Effect.sleep("250 millis");
+				return started.sessionId;
+			}).pipe(Effect.provide(aiAgentOverHost().pipe(Layer.provide(host.layer))), Effect.scoped);
+
+			const fiber = yield* Effect.forkDetach(run);
+			const stopped = yield* Fiber.awaitAll([fiber]).pipe(Effect.timeoutOption("20 seconds"));
+			assert.isTrue(
+				Option.isSome(stopped),
+				"closing the scope with a turn in flight never returned",
+			);
+			const sessionId = yield* Fiber.join(fiber);
+
+			assert.deepStrictEqual(
+				[...host.disposals.entries()],
+				[[sessionId, 1]],
+				"a stop mid-turn disposed the session other than exactly once",
 			);
 			yield* settleTo(baseline);
 		});

--- a/apps/tuval/src/pi/client/PiClientService.ts
+++ b/apps/tuval/src/pi/client/PiClientService.ts
@@ -32,6 +32,7 @@ import type {
 	ThinkingLevel,
 } from "@earendil-works/pi-protocol";
 import {Context, Effect, Layer, Queue, Schedule, type Scope, Stream} from "effect";
+import {boundedTeardown} from "../teardown.ts";
 import {
 	type ConnectionRefusal,
 	Disconnected,
@@ -172,13 +173,14 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 						},
 					}),
 			),
-			// A release has no error channel to model into, and the pin's `dispose` resolves an
-			// already-settled promise, so the fold exists to keep the ban's shape rather than to
-			// carry a failure that can happen.
+			// A release has no error channel to model into, so the settle is one arm either way: a
+			// rejection is nothing this scope can act on. The wait is the one thing that matters
+			// here and it runs under `../teardown.ts`'s ceiling, because a `dispose` that never
+			// resolves would hang the close for good.
 			(open) =>
-				Effect.tryPromise({try: () => open.dispose(), catch: connectionRefusalOf}).pipe(
-					Effect.ignore,
-				),
+				boundedTeardown("the Pi client's dispose", (settled) => {
+					open.dispose().then(settled, settled);
+				}),
 		);
 
 		yield* Effect.forkScoped(

--- a/apps/tuval/src/pi/restore/fixtures/pi-desk.ts
+++ b/apps/tuval/src/pi/restore/fixtures/pi-desk.ts
@@ -34,8 +34,8 @@ export const MODEL = FAUX_MODEL;
  *
  * A boot re-imports this module and mints a fresh provider, exactly as a restart would; what
  * carries across is the JSONL and the checkpoint, which is the thing under test. Every reply
- * completes, because a stop taken while a Pi turn is in flight never returns (#7896) — the proof
- * stops between turns and says so.
+ * completes, because the proof stops between turns — mid-turn state is unobservable through the
+ * actor's serial step (#7852), not because the stop itself would hang (#7896).
  */
 export const replies = [
 	fauxAssistantMessage("the readme is short"),

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -1,11 +1,11 @@
 /**
  * What a `pi-session` checkpoint taken mid-reply comes back as.
  *
- * This is a unit test rather than a stage of the proof beside it because a Pi turn cannot be cut
- * from a test today: a stop taken while one is in flight never returns (#7896), and mid-turn state
- * is unobservable anyway, since a Cmd handler runs inside the actor's serial step so nothing folds
- * until `prompt` resolves (#7852). So the checkpoint is written here, exactly as the store would
- * have held it, and the rule under test is the one the spawner applies to it.
+ * This is a unit test rather than a stage of the proof beside it because mid-turn state is
+ * unobservable from there: a Cmd handler runs inside the actor's serial step, so nothing folds
+ * until `prompt` resolves (#7852). The stop itself returns mid-turn — `../ai-agent/teardown.unit.test.ts`
+ * pins that (#7896). So the checkpoint is written here, exactly as the store would have held it,
+ * and the rule under test is the one the spawner applies to it.
  */
 
 import {assert, describe, it} from "@effect/vitest";

--- a/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
+++ b/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
@@ -159,11 +159,12 @@ interface ThirdRun {
  * Boot, run two turns — a plain one and one through the tool loop — and stop. Closing the scope is
  * the stop: the host drains, closes its Subs and flushes the last save (`../../host/actor.ts`).
  *
- * Between turns, not during one. A stop taken while a Pi turn is in flight never returns (#7896),
- * and mid-turn state is unobservable from here anyway, because a Cmd handler runs inside the
- * actor's serial step (`host/actor.ts`'s `runInterpret`) so nothing folds until `prompt` resolves
- * (#7852). The interrupted marker is therefore proven on a checkpoint, in `interrupted.unit.test.ts`
- * beside this file, rather than by cutting a live Pi turn.
+ * Between turns, not during one. Mid-turn state is unobservable from here: a Cmd handler runs
+ * inside the actor's serial step (`host/actor.ts`'s `runInterpret`), so nothing folds until
+ * `prompt` resolves (#7852). The interrupted marker is therefore proven on a checkpoint, in
+ * `interrupted.unit.test.ts` beside this file, rather than by cutting a live Pi turn. The stop
+ * itself is no longer the obstacle it was — a mid-turn close returns, and
+ * `../ai-agent/teardown.unit.test.ts` pins that (#7896).
  */
 const runFirstBoot = (project: string): Effect.Effect<FirstRun, unknown, FileSystem.FileSystem> =>
 	Effect.gen(function* () {

--- a/apps/tuval/src/pi/server/PiServerService.ts
+++ b/apps/tuval/src/pi/server/PiServerService.ts
@@ -8,7 +8,8 @@
  *
  * The service is acquire/release scoped. Closing its scope closes every socket, ends every
  * connection's fibers and disposes every session exactly once — the table is drained before the
- * handles are disposed, so nothing can be disposed twice.
+ * handles are disposed, so nothing can be disposed twice. It returns whether or not a turn is in
+ * flight: the one wait on something outside Effect runs under `../teardown.ts`'s ceiling.
  */
 
 import {randomUUID} from "node:crypto";
@@ -24,6 +25,7 @@ import {
 } from "@earendil-works/pi-protocol";
 import {Context, Effect, FiberSet, Layer, Queue, Redacted, type Scope} from "effect";
 import {type WebSocket, WebSocketServer} from "ws";
+import {boundedTeardown} from "../teardown.ts";
 import {dispatch} from "./dispatch.ts";
 import {FrameRefused, MessageNotEncodable, ServerBindFailed} from "./errors.ts";
 import {
@@ -102,9 +104,9 @@ const refuseUpgrade = (socket: Duplex, refusal: HandshakeRefused): void => {
 };
 
 const closeServer = (server: HttpServer): Effect.Effect<void> =>
-	Effect.callback<void>((resume) => {
+	boundedTeardown("the loopback server's close", (settled) => {
 		server.closeAllConnections();
-		server.close(() => resume(Effect.void));
+		server.close(() => settled());
 	});
 
 const make = (

--- a/apps/tuval/src/pi/teardown.ts
+++ b/apps/tuval/src/pi/teardown.ts
@@ -1,0 +1,43 @@
+/**
+ * The ceiling every Pi finalizer that waits on something outside Effect runs under.
+ *
+ * A scope finalizer is uninterruptible, so a wait inside one that never settles hangs the close for
+ * good — there is no interrupt left to cut it and the operator's stop never returns (#7896). The
+ * ceiling is a timer beside the wait rather than `Effect.timeout` over it: timing out needs the
+ * region to be interruptible, and an interruptible finalizer is skipped outright when the stop
+ * itself arrived as an interrupt, which trades a hang for a leak. Neither `http.Server.close` nor
+ * `PiClient.dispose` takes an `AbortSignal`, so a bound is the only shape available to them.
+ */
+
+import {Duration, Effect} from "effect";
+
+export const TEARDOWN_CEILING = Duration.seconds(5);
+
+/**
+ * Wait for `register` to report settled, or give the wait up at `ceiling`.
+ *
+ * Expiry logs and returns rather than failing: a socket the runtime never reported closed is a
+ * worse outcome than nothing, and a far better one than a stop that never returns.
+ */
+export const boundedTeardown = (
+	what: string,
+	register: (settled: () => void) => void,
+	ceiling: Duration.Duration = TEARDOWN_CEILING,
+): Effect.Effect<void> =>
+	Effect.callback<void>((resume) => {
+		let done = false;
+		const finish = (expired: boolean): void => {
+			if (done) return;
+			done = true;
+			clearTimeout(timer);
+			resume(
+				expired
+					? Effect.logWarning(
+							`teardown gave up waiting on ${what} after ${Duration.toMillis(ceiling)}ms`,
+						)
+					: Effect.void,
+			);
+		};
+		const timer = setTimeout(() => finish(true), Duration.toMillis(ceiling));
+		register(() => finish(false));
+	});

--- a/apps/tuval/src/pi/teardown.unit.test.ts
+++ b/apps/tuval/src/pi/teardown.unit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The ceiling itself, over a wait that settles and one that never does. Both run inside an
+ * `acquireRelease` finalizer, because uninterruptibility is the whole reason the ceiling is a timer
+ * rather than `Effect.timeout` — a bound proven on an ordinary effect would not be the bound this
+ * module claims.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Duration, Effect, Fiber} from "effect";
+import {boundedTeardown} from "./teardown.ts";
+
+const CEILING = Duration.millis(60);
+
+const closing = (release: Effect.Effect<void>) =>
+	Effect.acquireRelease(Effect.void, () => release).pipe(Effect.scoped);
+
+describe("a bounded teardown wait", () => {
+	it.live("returns as soon as the wait settles", () =>
+		Effect.gen(function* () {
+			const started = Date.now();
+			yield* closing(boundedTeardown("a wait that settles", (settled) => settled(), CEILING));
+			assert.isBelow(
+				Date.now() - started,
+				Duration.toMillis(CEILING),
+				"a settled wait paid the ceiling instead of returning on the callback",
+			);
+		}),
+	);
+
+	it.live("gives a wait that never settles up at the ceiling", () =>
+		Effect.gen(function* () {
+			const started = Date.now();
+			yield* closing(boundedTeardown("a wait that never settles", () => {}, CEILING));
+			const elapsed = Date.now() - started;
+			assert.isAtLeast(elapsed, Duration.toMillis(CEILING) - 5, "the ceiling was not waited out");
+			assert.isBelow(
+				elapsed,
+				Duration.toMillis(CEILING) * 10,
+				"the finalizer did not return at its ceiling",
+			);
+		}),
+	);
+
+	it.live("still runs the wait when the stop arrived as an interrupt", () =>
+		Effect.gen(function* () {
+			let waited = false;
+			const fiber = yield* Effect.forkChild(
+				Effect.acquireRelease(Effect.void, () =>
+					boundedTeardown(
+						"a wait under an interrupt",
+						(settled) => {
+							waited = true;
+							settled();
+						},
+						CEILING,
+					),
+				).pipe(Effect.andThen(Effect.never), Effect.scoped),
+			);
+			yield* Effect.sleep(Duration.millis(20));
+			yield* Fiber.interrupt(fiber);
+			assert.isTrue(waited, "the interrupted stop skipped the finalizer's wait");
+		}),
+	);
+});


### PR DESCRIPTION
Part of #7896.

## What I found

**The hang does not reproduce at `origin/main`.** I ran the issue's own reproduction three ways and
every one of them returned:

| Shape | Turn state at the close | Time the close took |
|---|---|---|
| `aiAgentOverHost` over Pi's faux provider, reply 3s out | provider called, not resolved | 3ms |
| Same, two turns, second one 3s out | provider called, not resolved | 10ms |
| Full app — `boot` on a `pi-session` row, prompt through the window's port, reply 5s out | agent state `phase: "prompting"` | 16ms |

The scripted-host version in this PR agrees: the close returns in ~530ms of a 4s turn, and the
session is still disposed exactly once.

So **no finalizer failed to return**, and criterion 3 has no subject to name. The likely reason it
is gone is #8018's `32837680a4`, which made `prompt` fork `pi.prompt` into the layer's scope and
return at the send. Before it, a caller's `Effect.forkScoped(agent.prompt(...))` held a fiber
awaiting the server's end-of-turn response frame across the same close.

The triage note's stronger candidate does not hold either: `Effect.tryPromise` without an
`AbortSignal` **is** fiber-interruptible — interrupting abandons the awaited promise rather than
waiting on it. That is what the 3ms close is showing.

## What this changes

Two finalizers could still have hung, for a different reason than the one filed, and criterion 5
names exactly that shape. A scope finalizer is uninterruptible, so a wait inside one that never
settles has no interrupt left to cut it:

- `apps/tuval/src/pi/server/PiServerService.ts` — `closeServer`'s `Effect.callback` over
  `server.close(cb)`. If the callback never fires, the stop never returns.
- `apps/tuval/src/pi/client/PiClientService.ts` — the client release's wait on `PiClient.dispose()`.

Neither `http.Server.close` nor `PiClient.dispose` takes an `AbortSignal`, so both now run under a
ceiling: `apps/tuval/src/pi/teardown.ts`'s `boundedTeardown`, five seconds, expiry logs and gives
the wait up. The ceiling is a timer beside the wait rather than `Effect.timeout` over it —
`Effect.timeout` interrupts its source and waits for it, and making a finalizer interruptible to
let it cut means an interrupted stop skips the finalizer outright, trading a hang for a leak. There
is a test for that case.

Every other finalizer under `apps/tuval/src/pi/` is `Effect.sync` or `Queue.shutdown`, including the
session handle's `dispose` — Pi's `AgentSession.dispose()` is synchronous at the 0.84.3 pin.

## Where to look first

`apps/tuval/src/pi/teardown.ts` and its test, then the mid-turn case appended to
`apps/tuval/src/pi/ai-agent/teardown.unit.test.ts`. That test forks the run and *awaits* the fiber
under a bound instead of wrapping it in `Effect.timeout`, for the same reason as above: wrapping a
hung uninterruptible finalizer would hang the wrapper.

Three docblocks that asserted "a stop taken while a Pi turn is in flight never returns (#7896)"
were true when written and are not now, so they are narrowed to the reason that is still live —
#7852, mid-turn state being unobservable through the actor's serial step.

`pnpm typecheck`, `pnpm lint` and the full `apps/tuval` suite (1583 tests, unit + integration) are
green.

## Deviations

- **Known defect left unfixed** — **Said:** criterion 2 asks the new test to fail against the
  current teardown path and pass after the fix. **Did:** it passes on both sides. **Why:** the
  reported hang does not reproduce at `origin/main`, as the three runs above show, so there is no
  red for it to turn green; the test lands as a pin against the regression coming back.
  **Disposition:** stated here, with the evidence in the section above.
- **Scope narrowing** — **Said:** criterion 3 asks for the finalizer that did not return, named
  with the evidence that identified it. **Did:** named that none of them does, and named instead
  the two that could not have returned under a callback that never fires. **Why:** there is no
  hanging finalizer at this head to identify. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #7896 names the teardown path and its test. **Did:** also
  narrowed three docblocks in `apps/tuval/src/pi/restore/` that cite #7896 as the reason a proof
  stops between turns. **Why:** this PR makes those sentences false, and a stale reason left
  standing sends the next reader to the wrong constraint. **Disposition:** stated here; the proof
  shape itself is untouched, since reopening it is explicitly not in this ticket.
