### PR TITLE
feat(tuval): a reply streams into the window as it is written

### DIFF
--- a/.decisions/0359-tuval-streams-the-reply-as-one-growing-row.md
+++ b/.decisions/0359-tuval-streams-the-reply-as-one-growing-row.md
@@ -1,0 +1,105 @@
+---
+id: 0359
+title: A reply streams into one growing transcript row, and the marker on it expires with the turn
+status: accepted
+date: 2026-09-05
+tags: [tuval, ai-agent, ux]
+---
+
+# 0359 — A reply streams into one growing transcript row, and the marker on it expires with the turn
+
+**What this decides:** An agent's reply reaches the Tuval chat window as it is written, as one row
+re-sent under one id with more text each time, marked `streaming` on the shared transcript item —
+and the moment the turn ends, whichever way it ends, that marker is gone.
+
+## Context
+
+Every reply landed as one block at the turn's end. A two-minute turn was two minutes of a window
+with nothing in it but the "Working…" line, which is the single thing that made a Tuval window worse
+than the terminal it replaces; every comparable surface streams (#8160).
+
+Neither backend was streaming, and for different reasons.
+
+Claude *has* the stream and threw it away. `SDKPartialAssistantMessage` frames are emitted only
+under `includePartialMessages` (`sdk.d.ts` at `@anthropic-ai/claude-agent-sdk@0.3.259`), the option
+was never set, and `history/events.ts` fell `stream_event` through to `skipMessage` anyway. The flag
+is one line; the mapping is not, because the frame's own `uuid` is fresh per delta, so a row keyed
+on it is a row per token.
+
+Pi does not have the stream at the seam at all. The in-flight reply is held aside in
+`AgentState.streamingMessage` and only pushed into `messages` on `message_end` (`pi-agent-core`
+`dist/agent.js`, `processEvents`) — and the loop's own partial goes into a *copy* of the message
+array (`dist/agent-loop.js`, over `createContextSnapshot`), so `session.messages` never holds it.
+The server projected `session.messages` alone, so a mid-turn snapshot differed from the one before
+it in `phase` and `revision` and nothing else.
+
+## Decision
+
+**One marker on the shared item, and the turn's end is what expires it.**
+
+`AssistantItem` becomes a two-member union in `ports/transcript-item.ts`: a `StreamingAssistantItem`
+carrying `streaming: true` and no `interrupted`, and a `SettledAssistantItem` carrying `interrupted`
+and no `streaming`. They are two answers to the one question a reader asks of a reply — has this
+turn finished? — so an interrupt *settles* a stream rather than annotating one, and
+`{streaming: true, interrupted: true}` is a sentence no producer can write. The port predicate is
+the runtime half of that and refuses it.
+
+No new event kind and no new port. A delta is an ordinary `item` event, and the fold's existing
+`upsertItem` supersedes by id, so a growing reply is the send-echo join (#7978) used again.
+
+**The join key is the backend's, and each backend already has one.**
+
+- Claude: the *API* message id off the wrapped `BetaRawMessageStartEvent`, held in `Mapping` across
+  the turn, with the row id `stream:<message id>:<block index>`. The complete `SDKAssistantMessage`
+  for a block repeats that id, claims the row, and lands under it — so the finished reply replaces
+  the growing one instead of landing beside it, and a turn with the flag off produces exactly what
+  it produced before. Claiming is ordered per message id, because one message can stream several
+  text blocks.
+- Pi: the wire's own positional id. The server appends `streamingMessage` to the projection
+  (`pi/server/transcript.ts`), which is the index `message_end` pushes the finished message at — so
+  the partial and the reply that replaces it are one row with no join invented for them. Its
+  `stopReason` is `"pending"` while it streams, which is what the projection's already-present
+  `streaming` arm answers to.
+
+**The marker is a claim about a turn that is running, so `foldEvent` clears it on every way out of
+`prompting`** — ready, gone, failed. A row still `streaming` past the turn's end is a reply nobody
+will finish, and it settles as `interrupted`. A backend that reports the cut itself wins, because
+its item carries the streamed row's id and lands first.
+
+**A partial never comes back from a checkpoint as a whole reply.** The store is written per fold, so
+a checkpoint taken between two deltas holds a `streaming` row; `restore` settles it as `interrupted`
+and points the resend affordance at it — a sharper cut test than the saved phase, which is folded by
+a different event and can say anything.
+
+**Claude's deltas are coalesced in the mapping, on the clock the layer already stamps.** Deltas
+arrive per token and every fold writes the whole session state to the checkpoint store
+(`host/actor.ts`), so an unthrottled stream would rewrite the transcript to disk per token. A pure
+interval read off `MappingOptions.at` (`STREAM_EMIT_INTERVAL_MS`) is the coalescing; each emission
+carries the whole accumulated block, so it costs latency and never text. Pi needs none of its own:
+the session host already collapses a burst of events into one pending change, and the revision diff
+suppresses a repaint of an unchanged projection.
+
+## Consequences
+
+Both windows show a reply as it is written. `#8148`'s thinking row is now free to stream on the same
+marker, which was the sequencing reason it shipped collapsed-only.
+
+A partial does still reach the checkpoint store — the debounce the epic names lives in `durability/`
+and `host/`, which every Tuval program sits on, and it is its own child (#8160). What this record
+buys against that is the *correctness* half: a partial that lands in a checkpoint can never come
+back looking final.
+
+The cost of the union over a second boolean is that `AssistantItem` is no longer one interface, so a
+construction that widened `kind` across a ternary now has to build each arm (`service/fixtures/`).
+`interrupted` keeps its shape and its meaning, so no `.tuval/` checkpoint a running desk wrote has
+become unreadable.
+
+**Grounded, not assumed.** The one fact that decided the Claude mapping is not readable off
+`sdk.d.ts` and came out of a fresh golden capture
+(`claude/history/fixtures/partial-assistant-turn.json`, `PROVENANCE.md`): the complete `assistant`
+frame for a text block arrives **before** that block's `content_block_stop`. A mapping that settled
+the row on the stop would re-open a finished reply as a partial one.
+
+## Records
+
+no vocabulary impact

--- a/apps/tuval/src/ai-agent-fixtures/transcripts.ts
+++ b/apps/tuval/src/ai-agent-fixtures/transcripts.ts
@@ -40,6 +40,15 @@ export const assistantItem = (
 	...(interrupted === undefined ? {} : {interrupted}),
 });
 
+/** A reply that is still arriving: the marker the layers set while they stream (#8160). */
+export const streamingItem = (id: string, text = "answ", timestamp = AT): AssistantItem => ({
+	kind: "assistant",
+	id: ItemId.make(id),
+	timestamp,
+	text,
+	streaming: true,
+});
+
 export const toolItem = (id: string, output = "ok", timestamp = AT): ToolItem => ({
 	kind: "tool",
 	id: ItemId.make(id),

--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -25,7 +25,7 @@ import {
 } from "../ports/index.ts";
 import {START_ERROR} from "./failures.ts";
 import {settleAccepted, settlePending} from "./sends.ts";
-import type {AiAgentSessionState, UsageTotals} from "./state.ts";
+import {type AiAgentSessionState, settleStreaming, type UsageTotals} from "./state.ts";
 
 /** How much tail one session keeps. Absent, the window module's own defaults apply. */
 export interface WindowLimits {
@@ -168,6 +168,24 @@ const sessionGone = (failure: AgentFailure): boolean =>
 	failure.tag === START_ERROR && failure.reason === "session-not-found";
 
 /**
+ * The tail as it stands once the session lands on `phase`.
+ *
+ * Streaming is a claim about a turn that is running, so the turn's end is where the claim expires.
+ * Whichever way the session leaves `prompting` — the reply landed, the turn failed, the transport
+ * went away — a row still marked `streaming` is one no layer will add to again, and it settles as
+ * the cut reply it is (`settleStreaming`). A reply the layer finished is not among them: its final
+ * item carries the streamed row's own id, so it superseded the row before this line ran.
+ */
+export const transcriptAfter = (
+	state: AiAgentSessionState,
+	phase: AiAgentSessionState["phase"],
+): AiAgentSessionState["transcript"] => {
+	if (phase === "prompting") return state.transcript;
+	const items = settleStreaming(state.transcript.items);
+	return items === state.transcript.items ? state.transcript : {...state.transcript, items};
+};
+
+/**
  * What is left of an outstanding interruption once the session lands on `phase`.
  *
  * The request is a question — "has the turn stopped?" — and the session leaving `prompting` is the
@@ -226,6 +244,7 @@ export const foldEvent = (
 				return {
 					...state,
 					phase: event.phase,
+					transcript: transcriptAfter(state, event.phase),
 					interruption: interruptionAfter(state, event.phase),
 					sends: settlePending(state.sends, null),
 				};
@@ -233,6 +252,7 @@ export const foldEvent = (
 			return {
 				...state,
 				phase: event.phase,
+				transcript: transcriptAfter(state, event.phase),
 				interruption: interruptionAfter(state, event.phase),
 				sends: event.phase === "prompting" ? state.sends : settleAccepted(state.sends),
 			};
@@ -273,6 +293,7 @@ export const foldEvent = (
 			return {
 				...state,
 				phase,
+				transcript: transcriptAfter(state, phase),
 				interruption: interruptionAfter(state, phase),
 				failure: event.failure,
 				sends: settlePending(state.sends, event.failure),

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -225,6 +225,43 @@ export const lastAssistantId = (items: ReadonlyArray<TranscriptItem>): ItemId | 
 	return null;
 };
 
+/**
+ * Every streamed item in the tail, settled as the cut reply it turned out to be.
+ *
+ * A `streaming` item is a promise that more of this reply is coming, and only the layer that opened
+ * it can keep that promise. So the moment the turn it belongs to is over — the phase leaves
+ * `prompting` (`fold.ts`), or the process it was streaming into went away (`restore` below) — a row
+ * still marked `streaming` is a reply nobody will finish, and it settles to `interrupted`.
+ *
+ * A reply the backend *did* finish never reaches this: the layer's own final item carries the same
+ * id, so `upsertItem` has already replaced the streamed row with the whole of it.
+ */
+export const settleStreaming = (
+	items: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> =>
+	items.some((item) => item.kind === "assistant" && item.streaming === true)
+		? items.map((item) =>
+				item.kind === "assistant" && item.streaming === true
+					? {
+							kind: "assistant",
+							id: item.id,
+							timestamp: item.timestamp,
+							text: item.text,
+							interrupted: true,
+						}
+					: item,
+			)
+		: items;
+
+/** The newest streamed assistant turn in the tail, which is the one a restart cut mid-reply. */
+export const lastStreamingId = (items: ReadonlyArray<TranscriptItem>): ItemId | null => {
+	for (let index = items.length - 1; index >= 0; index -= 1) {
+		const item = items[index];
+		if (item?.kind === "assistant" && item.streaming === true) return item.id;
+	}
+	return null;
+};
+
 /** The cut-short turn, marked in the tail so a window renders the break off the transcript alone. */
 const markInterrupted = (
 	items: ReadonlyArray<TranscriptItem>,
@@ -233,7 +270,15 @@ const markInterrupted = (
 	cut === null
 		? items
 		: items.map((item) =>
-				item.id === cut && item.kind === "assistant" ? {...item, interrupted: true} : item,
+				item.id === cut && item.kind === "assistant"
+					? {
+							kind: "assistant",
+							id: item.id,
+							timestamp: item.timestamp,
+							text: item.text,
+							interrupted: true,
+						}
+					: item,
 			);
 
 /**
@@ -244,7 +289,12 @@ const markInterrupted = (
  * `reconnect` is admissible from. `gone` stays `gone`: that session is over, and resuming it
  * anyway is the silent fresh session #7514 refuses.
  *
- * The saved phase is the whole interruption test. `prompting` means the layer never reported the
+ * A half-streamed reply comes back cut, whatever the saved phase says. `settleStreaming` clears the
+ * `streaming` marker — nothing is left to finish that row — and the row is also the cut turn the
+ * resend is offered against, which is a sharper answer than the saved phase can give: a checkpoint
+ * written between the deltas and the turn's end names its own unfinished reply.
+ *
+ * The saved phase is the rest of the interruption test. `prompting` means the layer never reported the
  * turn's `ready`, so the reply was still running when the process went away — whatever the tail
  * ends on, which is why a "does the tail end on an assistant item" predicate is the wrong reader:
  * a half-written assistant item reads as a completed reply to it.
@@ -271,11 +321,16 @@ const markInterrupted = (
  * reconnect is a Msg the spawner dispatches (`../restore/checkpoint.ts`), never one scheduled here.
  */
 export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
-	const cut = loaded.phase === "prompting" ? lastAssistantId(loaded.transcript.items) : null;
+	const streamed = lastStreamingId(loaded.transcript.items);
+	const cut =
+		streamed ?? (loaded.phase === "prompting" ? lastAssistantId(loaded.transcript.items) : null);
 	return {
 		...loaded,
 		phase: loaded.phase === "gone" ? "gone" : "idle",
-		transcript: {...loaded.transcript, items: markInterrupted(loaded.transcript.items, cut)},
+		transcript: {
+			...loaded.transcript,
+			items: markInterrupted(settleStreaming(loaded.transcript.items), cut),
+		},
 		interrupted: cut ?? loaded.interrupted,
 		interruption: null,
 		queued: [],

--- a/apps/tuval/src/ai-agent/core/streaming.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/streaming.unit.test.ts
@@ -1,0 +1,249 @@
+/**
+ * What the core does with a reply that is still arriving (#8160): it grows one row, and it never
+ * lets a `streaming` marker outlive the turn that justifies it.
+ *
+ * Both halves are the core's alone. The layers decide what a delta *is* — that is proved against
+ * their own captures (`claude/history/partials.unit.test.ts`, `pi/ai-agent/items.unit.test.ts`) —
+ * and the core decides what a session made of them looks like at rest, which is the question every
+ * case here asks.
+ */
+
+import {applyCellChecked} from "@demlik/tea";
+import {describe, expect, it} from "vitest";
+import {assistantItem, streamingItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
+import type {AgentEvent} from "../events.ts";
+import type {TranscriptItem} from "../ports/index.ts";
+import {foldEvent} from "./fold.ts";
+import {aiAgentSessionMachine} from "./machine.ts";
+import type {AiAgentSessionCmd, AiAgentSessionMsg} from "./messages.ts";
+import {type AiAgentSessionState, initialState, restore} from "./state.ts";
+
+const AT = 1_756_000_000_000;
+const SENT_AT = 1_700_000_000_000;
+
+const machine = aiAgentSessionMachine({cwd: "/repo"});
+
+const apply = (
+	state: AiAgentSessionState,
+	msg: AiAgentSessionMsg,
+): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
+
+const session = (over: Partial<AiAgentSessionState> = {}): AiAgentSessionState => ({
+	...initialState("/repo"),
+	phase: "prompting",
+	sessionId: "session-1",
+	...over,
+});
+
+const fold = (
+	state: AiAgentSessionState,
+	...events: ReadonlyArray<AgentEvent>
+): AiAgentSessionState => events.reduce((one, event) => foldEvent(one, event, {}), state);
+
+const item = (one: TranscriptItem): AgentEvent => ({kind: "item", item: one});
+
+/** The deltas of one reply, as a layer emits them: the same id, more text each time. */
+const deltas = (id: string, ...texts: ReadonlyArray<string>): ReadonlyArray<AgentEvent> =>
+	texts.map((text) => item(streamingItem(id, text, AT)));
+
+const tail = (state: AiAgentSessionState): ReadonlyArray<TranscriptItem> => state.transcript.items;
+
+describe("a stream of deltas", () => {
+	it("folds into one growing row rather than a row apiece", () => {
+		const state = fold(session(), ...deltas("a1", "The", "The quick", "The quick brown fox"));
+		expect(tail(state)).toEqual([streamingItem("a1", "The quick brown fox", AT)]);
+	});
+
+	it("is superseded whole by the finished reply under the same id", () => {
+		const streamed = fold(session(), ...deltas("a1", "The", "The quick"));
+		const settled = fold(streamed, item(assistantItem("a1", "The quick brown fox.", AT)));
+		expect(tail(settled)).toEqual([assistantItem("a1", "The quick brown fox.", AT)]);
+		expect(tail(settled).some((one) => one.kind === "assistant" && one.streaming === true)).toBe(
+			false,
+		);
+	});
+
+	it("grows the newest row without disturbing the turns above it", () => {
+		const seeded = fold(session(), item(userItem("u1")), item(assistantItem("a0")));
+		const state = fold(seeded, ...deltas("a1", "one", "one two"));
+		expect(tail(state).map((one) => one.id)).toEqual(["u1", "a0", "a1"]);
+	});
+});
+
+/**
+ * The marker is a claim about a turn that is running, so every way out of `prompting` settles it.
+ * A row left `streaming` past the turn's end is a window promising text that will never come.
+ */
+describe("a turn that ends mid-stream", () => {
+	const streaming = (): AiAgentSessionState => fold(session(), ...deltas("a1", "half a rep"));
+
+	it("settles the half-written row as cut when the turn reports ready", () => {
+		const state = fold(streaming(), {kind: "phase", phase: "ready"});
+		expect(tail(state)).toEqual([assistantItem("a1", "half a rep", AT, true)]);
+		expect(state.phase).toBe("ready");
+	});
+
+	it("settles it when the transport goes away instead", () => {
+		const state = fold(streaming(), {kind: "phase", phase: "gone"});
+		expect(tail(state)).toEqual([assistantItem("a1", "half a rep", AT, true)]);
+	});
+
+	it("settles it when the turn fails", () => {
+		const state = fold(streaming(), {
+			kind: "failure",
+			failure: {tag: "TurnFailed", reason: null, detail: "the model refused"},
+		});
+		expect(tail(state)).toEqual([assistantItem("a1", "half a rep", AT, true)]);
+		expect(state.phase).toBe("ready");
+	});
+
+	// The other side of the same rule: while the turn is still running the marker must stand, or the
+	// window loses the one thing that says the reply is still coming.
+	it("leaves the marker alone while the session is still on the turn", () => {
+		const state = fold(streaming(), {kind: "phase", phase: "prompting"});
+		expect(tail(state)).toEqual([streamingItem("a1", "half a rep", AT)]);
+	});
+
+	it("leaves a settled tail untouched, so the fold costs a turn that streamed nothing nothing", () => {
+		const before = fold(session(), item(assistantItem("a1")));
+		const after = fold(before, {kind: "phase", phase: "ready"});
+		expect(after.transcript).toBe(before.transcript);
+	});
+});
+
+/**
+ * Asking for an interrupt is not the turn stopping (ADR 0356 / #8007), so the request alone leaves
+ * the marker where it is; the backend's own answer is what settles it.
+ */
+describe("an interrupt mid-stream", () => {
+	const streaming = (): AiAgentSessionState => fold(session(), ...deltas("a1", "as far as it g"));
+
+	it("keeps the row growing while the abort is still outstanding", () => {
+		const [asked] = apply(streaming(), {type: "interrupt", at: SENT_AT});
+		expect(asked.phase).toBe("prompting");
+		expect(asked.interruption).toEqual({requestedAt: SENT_AT});
+		expect(tail(asked)).toEqual([streamingItem("a1", "as far as it g", AT)]);
+	});
+
+	it("settles the row as cut once the backend answers the abort", () => {
+		const [asked] = apply(streaming(), {type: "interrupt", at: SENT_AT});
+		const [stopped] = apply(asked, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "ready"},
+		});
+		expect(stopped.interruption).toBeNull();
+		expect(tail(stopped)).toEqual([assistantItem("a1", "as far as it g", AT, true)]);
+	});
+
+	// A backend that reports the cut itself wins, because it knows what it actually wrote: its own
+	// item carries the streamed row's id, so it replaces the row before the phase line settles it.
+	it("prefers the backend's own cut reply over the core's settlement", () => {
+		const [asked] = apply(streaming(), {type: "interrupt", at: SENT_AT});
+		const [reported] = apply(asked, {
+			type: "event",
+			sessionId: "session-1",
+			event: item(assistantItem("a1", "as far as it got before the abort", AT, true)),
+		});
+		const [stopped] = apply(reported, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "ready"},
+		});
+		expect(tail(stopped)).toEqual([
+			assistantItem("a1", "as far as it got before the abort", AT, true),
+		]);
+	});
+});
+
+/**
+ * #8160 no-go: no partial item reaches a checkpoint as if it were final. The store is written per
+ * fold, so a checkpoint taken between two deltas holds a `streaming` row — and this is where that
+ * row stops being a half-written reply presented as a whole one.
+ */
+describe("a restore over a half-streamed tail", () => {
+	const saved = (over: Partial<AiAgentSessionState> = {}): AiAgentSessionState =>
+		session({
+			transcript: {
+				items: [userItem("u1"), streamingItem("a1", "half a rep", AT)],
+				omitted: initialState("/repo").transcript.omitted,
+			},
+			...over,
+		});
+
+	it("brings the row back cut, never as the whole reply", () => {
+		const state = restore(saved());
+		expect(tail(state)).toEqual([userItem("u1"), assistantItem("a1", "half a rep", AT, true)]);
+	});
+
+	it("offers the resend against the row that was streaming", () => {
+		expect(restore(saved()).interrupted).toBe("a1");
+	});
+
+	// A checkpoint written mid-stream can name any phase — `phase` and the tail are folded by
+	// separate events — so the streamed row is a sharper cut test than the saved phase is.
+	it("cuts the streamed row even when the saved phase says the turn was over", () => {
+		const state = restore(saved({phase: "ready"}));
+		expect(state.interrupted).toBe("a1");
+		expect(tail(state).at(-1)).toEqual(assistantItem("a1", "half a rep", AT, true));
+	});
+
+	it("round-trips through JSON the way every other checkpoint field does", () => {
+		const loaded = JSON.parse(JSON.stringify(saved())) as AiAgentSessionState;
+		expect(restore(loaded)).toEqual(restore(saved()));
+	});
+});
+
+/**
+ * ADR 0357's queue and this stream meet at exactly one point: the turn's end, which both the
+ * settlement and the admission hang off. Neither may cost the other.
+ */
+describe("the prompt queue under a streamed turn", () => {
+	const prompt = (text: string, key: string): AiAgentSessionMsg => ({
+		type: "prompt",
+		text,
+		key,
+		timestamp: SENT_AT,
+	});
+
+	it("drains the head once a streamed turn completes, with the reply settled beside it", () => {
+		const [running] = apply(
+			session({phase: "ready", transcript: initialState("/repo").transcript}),
+			prompt("make the README", "k1"),
+		);
+		const streaming = fold(running, ...deltas("a1", "writing the RE"));
+		const [queued] = apply(streaming, prompt("then the CHANGELOG", "k2"));
+		expect(queued.queued).toHaveLength(1);
+		expect(tail(queued).at(-1)).toEqual(streamingItem("a1", "writing the RE", AT));
+
+		const [sent, cmds] = apply(queued, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "ready"},
+		});
+		expect(sent.queued).toEqual([]);
+		expect(sent.phase).toBe("prompting");
+		expect(cmds).toEqual([{type: "aiAgent.prompt", text: "then the CHANGELOG", key: "k2"}]);
+		// The settlement and the admission are one transition, and both landed: the cut reply is on
+		// the tail and the queued turn is recorded under it.
+		expect(tail(sent).map((one) => one.id)).toEqual(["local:k1", "a1", "local:k2"]);
+		expect(tail(sent)[1]).toEqual(assistantItem("a1", "writing the RE", AT, true));
+	});
+
+	it("releases a queue whose turn was streaming when the session went away", () => {
+		const [running] = apply(
+			session({phase: "ready", transcript: initialState("/repo").transcript}),
+			prompt("make the README", "k1"),
+		);
+		const [queued] = apply(fold(running, ...deltas("a1", "writ")), prompt("and then", "k2"));
+		const [gone] = apply(queued, {
+			type: "event",
+			sessionId: "session-1",
+			event: {kind: "phase", phase: "gone"},
+		});
+		expect(gone.queued).toEqual([]);
+		expect(gone.sends.find((one) => one.key === "k2")?.state).toBe("refused");
+		expect(tail(gone)[1]).toEqual(assistantItem("a1", "writ", AT, true));
+	});
+});

--- a/apps/tuval/src/ai-agent/ports/index.ts
+++ b/apps/tuval/src/ai-agent/ports/index.ts
@@ -53,6 +53,8 @@ export {
 	isTranscriptItems,
 	type JsonValue,
 	type ResultOmission,
+	type SettledAssistantItem,
+	type StreamingAssistantItem,
 	type SystemItem,
 	TOOL_RESULT_BYTE_LIMIT,
 	type ToolItem,

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -50,12 +50,35 @@ export interface UserItem extends ItemBase {
 	readonly local?: boolean;
 }
 
-/** `interrupted` marks a turn the operator cut short; the resend is a fresh prompt, not a retry. */
-export interface AssistantItem extends ItemBase {
+interface AssistantBase extends ItemBase {
 	readonly kind: "assistant";
 	readonly text: string;
+}
+
+/**
+ * A reply the backend is still writing. `text` is everything of it that has arrived, and the next
+ * item under this id carries more — the same id, so the fold's `upsertItem` grows one row.
+ *
+ * It carries no `interrupted`, and that is the point of the union rather than a second flag beside
+ * one: `streaming` and `interrupted` are two answers to the one question a reader asks of an
+ * assistant row — has this turn finished? — so an interrupt *settles* a stream instead of
+ * annotating it, and `{streaming: true, interrupted: true}` is a sentence no producer can write.
+ */
+export interface StreamingAssistantItem extends AssistantBase {
+	readonly streaming: true;
+	readonly interrupted?: never;
+}
+
+/**
+ * A reply that is the whole of what the backend produced. `interrupted` marks a turn the operator
+ * cut short; the resend is a fresh prompt, not a retry.
+ */
+export interface SettledAssistantItem extends AssistantBase {
+	readonly streaming?: never;
 	readonly interrupted?: boolean;
 }
+
+export type AssistantItem = StreamingAssistantItem | SettledAssistantItem;
 
 /**
  * `parentId` is the id of the tool call this one ran *inside*, when a backend nests calls — an
@@ -140,11 +163,14 @@ export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 			);
 		case "system":
 			return typeof value.text === "string";
+		// The union's admission test, and the one place it is enforced at runtime: a streaming item
+		// may carry no `interrupted`, so a producer that marks a row both ways is refused here
+		// rather than rendered as a contradiction.
 		case "assistant":
-			return (
-				typeof value.text === "string" &&
-				(value.interrupted === undefined || typeof value.interrupted === "boolean")
-			);
+			if (typeof value.text !== "string") return false;
+			return value.streaming === undefined
+				? value.interrupted === undefined || typeof value.interrupted === "boolean"
+				: value.streaming === true && value.interrupted === undefined;
 		case "tool":
 			return (
 				typeof value.name === "string" &&

--- a/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
@@ -33,6 +33,21 @@ describe("transcript item union", () => {
 		expect(isTranscriptItem({...assistant, interrupted: true})).toBe(true);
 	});
 
+	it("admits a reply that is still arriving", () => {
+		expect(isTranscriptItem({...assistant, streaming: true})).toBe(true);
+	});
+
+	// The union's whole point: `streaming` and `interrupted` are two answers to one question, so an
+	// item claiming both is a contradiction the port refuses rather than a row the window renders.
+	it("refuses a reply marked both still arriving and cut short", () => {
+		expect(isTranscriptItem({...assistant, streaming: true, interrupted: true})).toBe(false);
+	});
+
+	it("refuses a streaming marker that is anything but true", () => {
+		expect(isTranscriptItem({...assistant, streaming: false})).toBe(false);
+		expect(isTranscriptItem({...assistant, streaming: "yes"})).toBe(false);
+	});
+
 	it("refuses an item of an unknown kind", () => {
 		expect(isTranscriptItem({...user, kind: "thinking"})).toBe(false);
 	});

--- a/apps/tuval/src/ai-agent/service/fixtures/scripts.ts
+++ b/apps/tuval/src/ai-agent/service/fixtures/scripts.ts
@@ -50,12 +50,16 @@ const at = (offset: number): number => 1_760_000_000_000 + offset;
 
 /** Nine older items, oldest first — enough for `page` to walk in threes and stop at the beginning. */
 export const history: ReadonlyArray<TranscriptItem> = Array.from({length: 9}, (_, index) =>
-	item({
-		kind: index % 2 === 0 ? "user" : "assistant",
-		id: id(`history-${index}`),
-		timestamp: at(index),
-		text: `turn ${index}`,
-	}),
+	item(
+		index % 2 === 0
+			? {kind: "user", id: id(`history-${index}`), timestamp: at(index), text: `turn ${index}`}
+			: {
+					kind: "assistant",
+					id: id(`history-${index}`),
+					timestamp: at(index),
+					text: `turn ${index}`,
+				},
+	),
 );
 
 const empty = {

--- a/apps/tuval/src/claude/agent/options.ts
+++ b/apps/tuval/src/claude/agent/options.ts
@@ -115,6 +115,11 @@ export const queryOptionsOf = (
 	const servers: Record<string, McpServerConfig> = {[TUVAL_SERVER_NAME]: input.server.server};
 	return {
 		cwd: input.cwd,
+		// The reply as it is written, not only when it lands (#8160). `SDKPartialAssistantMessage`
+		// events "will be emitted during streaming" only when this is true (`sdk.d.ts`, `0.3.259`),
+		// and the complete assistant message still follows every one of them, so nothing a
+		// non-streaming turn produced has gone away.
+		includePartialMessages: true,
 		permissionMode: openingMode(options, input.held ?? null),
 		allowedTools: [...new Set([...input.server.wireNames, ...options.allowedTools])],
 		mcpServers: servers,

--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -66,6 +66,7 @@ describe("the Claude history mapping is pure", () => {
 			"init",
 			"interrupted-assistant",
 			"oversized-tool-turn",
+			"partial-assistant-turn",
 			"permission-denied",
 			"resumed-init",
 			"session-messages",

--- a/apps/tuval/src/claude/history/events.ts
+++ b/apps/tuval/src/claude/history/events.ts
@@ -9,8 +9,9 @@
  * six this transcript has a shape for, and everything else is counted rather than refused. A new
  * message kind must never take a session down.
  *
- * Partial assistant frames are among the counted: streaming granularity here is one whole
- * assistant message, so a run with `includePartialMessages` costs nothing and shows nothing extra.
+ * `stream_event` is the reply as it is written. It is mapped rather than counted because a turn
+ * that shows nothing until it ends reads as a hang (#8160), and the row it grows is claimed by the
+ * complete assistant frame that follows — see `partialEvents` and `assistantEvents` in `map.ts`.
  */
 
 import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
@@ -21,6 +22,7 @@ import {
 	type Mapping,
 	type MappingOptions,
 	type MappingStep,
+	partialEvents,
 	permissionDeniedEvents,
 	resultEvents,
 	skipMessage,
@@ -37,6 +39,8 @@ export const toAgentEvents = (
 			return assistantEvents(message, mapping, options);
 		case "user":
 			return userEvents(message, mapping, options);
+		case "stream_event":
+			return partialEvents(message, mapping, options);
 		case "result":
 			return resultEvents(message, mapping, options);
 		case "system":

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -10,10 +10,10 @@ invented envelope would prove the mapping against a contract nobody emits.
 
 | | |
 |---|---|
-| Captured | 2026-09-04 |
+| Captured | 2026-09-04, plus `partial-assistant-turn.json` on 2026-09-05 |
 | SDK | `@anthropic-ai/claude-agent-sdk` **0.3.259** (the `pnpm-workspace.yaml` catalog pin) |
 | CLI | `claude_code_version` **2.1.259**, as reported by the `init` frame itself |
-| Models | `claude-fable-5-1` on every capture but `interrupted-assistant.json`, which is `claude-opus-5` |
+| Models | `claude-fable-5-1` on every capture but `interrupted-assistant.json` and `partial-assistant-turn.json`, which are `claude-opus-5` |
 
 Each run drove `query()` from a throwaway cwd and wrote every message the async iterator yielded,
 in order.
@@ -26,6 +26,7 @@ in order.
 | `oversized-tool-turn.json` | the same, running `seq 1 2000` — an 8,892-byte result, over the 8,000-byte per-item bound |
 | `error-result.json` | a three-command prompt under `maxTurns: 1`, which ends `error_max_turns` |
 | `permission-denied.json` | `permissionMode: "dontAsk"` with a project `permissions.deny` rule of `Bash(echo:*)` — the tool stays on the list and the *call* is refused, which is what emits the frame; denying `Bash` outright removes the tool instead and emits nothing |
+| `partial-assistant-turn.json` | one prompt, no tools, with `includePartialMessages: true` — the whole run from the `rate_limit_event` to the `result`, so the `stream_event` frames sit in the order the CLI emitted them |
 | `interrupted-assistant.json` | a streaming-input session asked for a long essay, then `query.interrupt()` mid-stream, which stamps `aborted: true` |
 | `session-messages.json` | `getSessionMessages(<the tool-turn session id>, {includeSystemMessages: true})` |
 | `unknown-message.json` | a `rate_limit_event` frame from the plain run — a real member of `SDKMessage` this mapping has no shape for |
@@ -45,6 +46,13 @@ The **key set and the field shapes are the golden part** and are untouched. Subs
 Everything else — `stop_reason`, the `usage` and `modelUsage` blocks, `total_cost_usd`,
 `is_error`, `subtype`, `aborted`, `tool_use_result` — is verbatim. `boundary.unit.test.ts` reds if
 any operator path returns and if the fixture set loses a member.
+
+**The one thing the streaming capture settles that no reading of `sdk.d.ts` does**: the complete
+`assistant` frame for a text block arrives **before** that block's `content_block_stop`, not after
+it. The captured order is `message_start`, `content_block_start`, two `content_block_delta`s,
+`assistant`, `content_block_stop`, `message_delta`, `message_stop`. A mapping that settled the row
+on `content_block_stop` would therefore re-open a finished reply as a partial one, which is why
+`map.ts` claims a streamed row on the complete frame and lets the stop find nothing.
 
 ## What is not captured
 

--- a/apps/tuval/src/claude/history/fixtures/load.ts
+++ b/apps/tuval/src/claude/history/fixtures/load.ts
@@ -15,6 +15,7 @@ export type FixtureName =
 	| "init"
 	| "interrupted-assistant"
 	| "oversized-tool-turn"
+	| "partial-assistant-turn"
 	| "permission-denied"
 	| "resumed-init"
 	| "session-messages"

--- a/apps/tuval/src/claude/history/fixtures/partial-assistant-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/partial-assistant-turn.json
@@ -1,0 +1,373 @@
+[
+	{
+		"type": "rate_limit_event",
+		"rate_limit_info": {
+			"status": "allowed",
+			"resetsAt": 1788676800,
+			"rateLimitType": "five_hour",
+			"overageStatus": "rejected",
+			"overageDisabledReason": "org_level_disabled",
+			"isUsingOverage": false,
+			"unifiedWindows": {
+				"five_hour": {
+					"utilization": 0.74,
+					"resetsAt": 1788676800
+				},
+				"seven_day": {
+					"utilization": 0.28,
+					"resetsAt": 1788807600
+				}
+			}
+		},
+		"uuid": "00000000-0000-4000-8000-000000000001",
+		"session_id": "00000000-0000-4000-8000-000000000002"
+	},
+	{
+		"type": "system",
+		"subtype": "init",
+		"cwd": "/tmp/tuval-capture",
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"tools": ["Task", "Bash", "CronCreate"],
+		"mcp_servers": [
+			{
+				"name": "posthog",
+				"status": "connected"
+			},
+			{
+				"name": "binclusive-local",
+				"status": "failed"
+			},
+			{
+				"name": "langfuse",
+				"status": "connected"
+			}
+		],
+		"model": "claude-opus-5[1m]",
+		"permissionMode": "default",
+		"slash_commands": ["audit-accessibility", "binclusive-report", "carousel"],
+		"terminal_slash_commands": ["doctor", "color"],
+		"apiKeySource": "none",
+		"claude_code_version": "2.1.259",
+		"output_style": "default",
+		"agents": ["claude", "Explore", "fabrika:builder"],
+		"skills": ["audit-accessibility", "binclusive-report", "carousel"],
+		"plugins": [
+			{
+				"name": "workflow",
+				"path": "/home/user/.claude/plugins/cache/usirin-skills/workflow/6fad1b84baee",
+				"source": "workflow@usirin-skills"
+			},
+			{
+				"name": "skill-creator",
+				"path": "/home/user/.claude/plugins/cache/claude-plugins-official/skill-creator/85cce0381e78",
+				"source": "skill-creator@claude-plugins-official"
+			},
+			{
+				"name": "roundtable",
+				"path": "/home/user/.claude/plugins/cache/agent-review-panel/roundtable/3.3.0",
+				"source": "roundtable@agent-review-panel",
+				"version": "3.3.0"
+			}
+		],
+		"capabilities": [
+			"interrupt_receipt_v1",
+			"interrupt_cancel_queued_v1",
+			"msg_000000000000000000000003_v1"
+		],
+		"analytics_disabled": false,
+		"product_feedback_disabled": false,
+		"uuid": "00000000-0000-4000-8000-000000000004",
+		"memory_paths": {
+			"auto": "/home/user/.claude/projects/-private-tmp-tuval-capture-stream/memory/"
+		},
+		"messaging_socket_path": "/tmp/cc-socks/0.sock",
+		"fast_mode_state": "off",
+		"fast_mode_disabled_reason": "sdk_opt_in_required"
+	},
+	{
+		"type": "system",
+		"subtype": "status",
+		"status": "requesting",
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"uuid": "00000000-0000-4000-8000-000000000005"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_start",
+			"message": {
+				"model": "claude-opus-5",
+				"id": "msg_000000000000000000000006",
+				"type": "message",
+				"role": "assistant",
+				"content": [],
+				"stop_reason": null,
+				"stop_sequence": null,
+				"stop_details": null,
+				"usage": {
+					"input_tokens": 2,
+					"cache_creation_input_tokens": 29738,
+					"cache_read_input_tokens": 0,
+					"cache_creation": {
+						"ephemeral_5m_input_tokens": 0,
+						"ephemeral_1h_input_tokens": 29738
+					},
+					"output_tokens": 1,
+					"service_tier": "standard",
+					"inference_geo": "not_available"
+				},
+				"diagnostics": null
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000007",
+		"ttft_ms": 788
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_start",
+			"index": 0,
+			"content_block": {
+				"type": "text",
+				"text": ""
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000008"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "text_delta",
+				"text": "The"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000009"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "text_delta",
+				"text": " quick brown fox jumps over the lazy dog."
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000010"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-opus-5",
+			"id": "msg_000000000000000000000006",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "text",
+					"text": "The quick brown fox jumps over the lazy dog."
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 29738,
+				"cache_read_input_tokens": 0,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 0,
+					"ephemeral_1h_input_tokens": 29738
+				},
+				"output_tokens": 1,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": null,
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"uuid": "00000000-0000-4000-8000-000000000011",
+		"timestamp": "2026-09-06T03:56:24.966Z",
+		"request_id": "req_000000000000000000000012"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_stop",
+			"index": 0
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000013"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_delta",
+			"delta": {
+				"stop_reason": "end_turn",
+				"stop_sequence": null,
+				"stop_details": null
+			},
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 29738,
+				"cache_read_input_tokens": 0,
+				"output_tokens": 20,
+				"output_tokens_details": {
+					"thinking_tokens": 0
+				},
+				"iterations": [
+					{
+						"input_tokens": 2,
+						"output_tokens": 20,
+						"cache_read_input_tokens": 0,
+						"cache_creation_input_tokens": 29738,
+						"cache_creation": {
+							"ephemeral_5m_input_tokens": 0,
+							"ephemeral_1h_input_tokens": 29738
+						},
+						"type": "message"
+					}
+				]
+			},
+			"context_management": {
+				"applied_edits": []
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000014"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_stop"
+		},
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000015"
+	},
+	{
+		"duration_api_ms": 2220,
+		"stop_reason": "end_turn",
+		"session_id": "00000000-0000-4000-8000-000000000002",
+		"total_cost_usd": 0.298852,
+		"usage": {
+			"input_tokens": 2,
+			"cache_creation_input_tokens": 29738,
+			"cache_read_input_tokens": 0,
+			"output_tokens": 20,
+			"output_tokens_details": {
+				"thinking_tokens": 0
+			},
+			"server_tool_use": {
+				"web_search_requests": 0,
+				"web_fetch_requests": 0
+			},
+			"service_tier": "standard",
+			"cache_creation": {
+				"ephemeral_1h_input_tokens": 29738,
+				"ephemeral_5m_input_tokens": 0
+			},
+			"inference_geo": "not_available",
+			"iterations": [
+				{
+					"input_tokens": 2,
+					"output_tokens": 20,
+					"cache_read_input_tokens": 0,
+					"cache_creation_input_tokens": 29738,
+					"cache_creation": {
+						"ephemeral_5m_input_tokens": 0,
+						"ephemeral_1h_input_tokens": 29738
+					},
+					"type": "message"
+				}
+			],
+			"speed": "standard"
+		},
+		"modelUsage": {
+			"claude-haiku-4-5-20251001": {
+				"inputTokens": 912,
+				"outputTokens": 10,
+				"cacheReadInputTokens": 0,
+				"cacheCreationInputTokens": 0,
+				"webSearchRequests": 0,
+				"costUSD": 0.0009620000000000001,
+				"contextWindow": 200000,
+				"maxOutputTokens": 32000,
+				"thinkingTokens": 0,
+				"canonicalModel": "claude-haiku-4-5",
+				"provider": "firstParty",
+				"costBasis": "list"
+			},
+			"claude-opus-5[1m]": {
+				"inputTokens": 2,
+				"outputTokens": 20,
+				"cacheReadInputTokens": 0,
+				"cacheCreationInputTokens": 29738,
+				"webSearchRequests": 0,
+				"costUSD": 0.29789,
+				"contextWindow": 1000000,
+				"maxOutputTokens": 64000,
+				"thinkingTokens": 0,
+				"canonicalModel": "claude-opus-5",
+				"provider": "firstParty",
+				"costBasis": "list"
+			}
+		},
+		"permission_denials": [],
+		"terminal_reason": "completed",
+		"fast_mode_state": "off",
+		"fast_mode_disabled_reason": "sdk_opt_in_required",
+		"subagent_stats": {
+			"spawned": 0,
+			"requested": {
+				"background": 0,
+				"foreground": 0,
+				"unset": 0
+			},
+			"started_in_background": 0,
+			"max_depth": 0,
+			"spawned_by_subagents": 0,
+			"completed": 0,
+			"failed": 0,
+			"killed": {
+				"parent": 0,
+				"user": 0,
+				"system": 0
+			},
+			"refused": {
+				"depth_limit": 0,
+				"concurrency_limit": 0,
+				"budget": 0
+			},
+			"by_type": {}
+		},
+		"is_error": false,
+		"num_turns": 1,
+		"subtype": "success",
+		"api_error_status": null,
+		"result": "The quick brown fox jumps over the lazy dog.",
+		"ttft_ms": 1361,
+		"type": "result",
+		"duration_ms": 1379,
+		"uuid": "00000000-0000-4000-8000-000000000016",
+		"ttft_stream_ms": 806,
+		"time_to_request_ms": 18,
+		"queued_turn_count": 0
+	}
+]

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -42,6 +42,36 @@ export interface ToolCall {
 	readonly parentId: string | null;
 }
 
+/**
+ * One text content block of the reply this turn is streaming, and the row it is being written into.
+ *
+ * `messageId` is the join key, and it is the *API* message id off the wrapped
+ * `BetaRawMessageStartEvent` (`@anthropic-ai/sdk` `BetaRawMessageStartEvent.message` is a
+ * `BetaMessage`, whose `id` the complete `SDKAssistantMessage.message` repeats). The frame's own
+ * `SDKPartialAssistantMessage.uuid` cannot be it: that uuid is fresh per delta (`sdk.d.ts` at
+ * `0.3.259`), so a row keyed on it would be a new row per token.
+ */
+export interface StreamedBlock {
+	readonly messageId: string;
+	readonly index: number;
+	readonly id: string;
+	readonly at: number;
+	readonly text: string;
+	/** The complete assistant frame for this block has landed and superseded the row. */
+	readonly claimed: boolean;
+}
+
+/**
+ * How often a growing reply earns an item event. Deltas arrive per token; every one of them folds
+ * into the session state and the whole state is written to the checkpoint store on each fold
+ * (`host/actor.ts`), so an unthrottled stream would rewrite the transcript to disk per token.
+ *
+ * A pure interval read off `MappingOptions.at` rather than a timer: the layer already stamps every
+ * message with `Date.now()`, so the coalescing is a fold over values and a test drives it by
+ * handing in clocks.
+ */
+export const STREAM_EMIT_INTERVAL_MS = 120;
+
 export interface Mapping {
 	/** The model `init` named, which is the only place a Claude session says it. */
 	readonly model: string;
@@ -49,9 +79,123 @@ export interface Mapping {
 	readonly toolCalls: ReadonlyMap<string, ToolCall>;
 	/** How many messages this mapping had nothing to say about. */
 	readonly skipped: number;
+	/** The API message id the last `message_start` opened; `null` outside a streamed message. */
+	readonly streamId: string | null;
+	/** The reply's text blocks as they stream, in the order the model opened them. */
+	readonly blocks: ReadonlyArray<StreamedBlock>;
+	/** When the last partial item event went out, so a burst of deltas costs one event. */
+	readonly emittedAt: number;
 }
 
-export const emptyMapping: Mapping = {model: "", toolCalls: new Map(), skipped: 0};
+export const emptyMapping: Mapping = {
+	model: "",
+	toolCalls: new Map(),
+	skipped: 0,
+	streamId: null,
+	blocks: [],
+	emittedAt: 0,
+};
+
+/** The row one streamed text block is written into. Stable for the life of the block. */
+const streamedItemId = (messageId: string, index: number): string => `stream:${messageId}:${index}`;
+
+const streamingItem = (block: StreamedBlock): TranscriptItem => ({
+	kind: "assistant",
+	id: itemId(block.id),
+	timestamp: block.at,
+	text: block.text,
+	streaming: true,
+});
+
+/**
+ * The streamed row one complete assistant frame supersedes, or `null`.
+ *
+ * The frame names its API message id and nothing finer, and one message can stream several text
+ * blocks — so the claim is the oldest unclaimed block of *that* message. A frame whose message
+ * streamed nothing claims nothing and keeps today's `uuid`-keyed row, which is what a run without
+ * `includePartialMessages` is made entirely of.
+ */
+const claimable = (blocks: ReadonlyArray<StreamedBlock>, messageId: string | null): number =>
+	messageId === null
+		? -1
+		: blocks.findIndex((block) => block.messageId === messageId && !block.claimed);
+
+const claim = (blocks: ReadonlyArray<StreamedBlock>, at: number): ReadonlyArray<StreamedBlock> =>
+	blocks.map((block, index) => (index === at ? {...block, claimed: true} : block));
+
+/**
+ * One `stream_event` frame — the deltas of the reply being written — as the growing row it changes.
+ *
+ * `SDKPartialAssistantMessage.event` is "one Anthropic Messages API streaming event" (`sdk.d.ts`,
+ * `0.3.259`), so the six members this reads are the Messages API's own: `message_start` opens a
+ * message and names its id, `content_block_start` opens a block, `content_block_delta` carries a
+ * `text_delta`, and `content_block_stop` closes one. Thinking, tool-input and signature deltas are
+ * not text and are held out on purpose — the port union is text-only, and a streamed thinking row
+ * is the `thinking` item kind, never folded into the reply.
+ *
+ * Read structurally rather than through the SDK's own event types, for the reason every other
+ * handler in this file is: this directory imports no runtime and must survive a delta kind the pin
+ * has never seen.
+ */
+export const partialEvents = (
+	message: unknown,
+	mapping: Mapping,
+	options: MappingOptions,
+): MappingStep => {
+	if (!isRecord(message) || !isRecord(message.event)) return skipMessage(mapping);
+	const frame = message.event;
+	const at = timestampOf(message, options.at);
+
+	if (frame.type === "message_start") {
+		const body = frame.message;
+		const id = isRecord(body) && typeof body.id === "string" ? body.id : null;
+		return {mapping: {...mapping, streamId: id}, events: []};
+	}
+
+	const streamId = mapping.streamId;
+	if (streamId === null || typeof frame.index !== "number") return skipMessage(mapping);
+	const index = frame.index;
+
+	if (frame.type === "content_block_start") {
+		if (!isRecord(frame.content_block) || frame.content_block.type !== "text") {
+			return skipMessage(mapping);
+		}
+		const block: StreamedBlock = {
+			messageId: streamId,
+			index,
+			id: streamedItemId(streamId, index),
+			at,
+			text: typeof frame.content_block.text === "string" ? frame.content_block.text : "",
+			claimed: false,
+		};
+		return {mapping: {...mapping, blocks: [...mapping.blocks, block]}, events: []};
+	}
+
+	const open = mapping.blocks.findIndex(
+		(block) => block.messageId === streamId && block.index === index && !block.claimed,
+	);
+	if (open < 0) return skipMessage(mapping);
+	const block = mapping.blocks[open] as StreamedBlock;
+
+	if (frame.type === "content_block_delta") {
+		if (!isRecord(frame.delta) || frame.delta.type !== "text_delta") return skipMessage(mapping);
+		const text = block.text + (typeof frame.delta.text === "string" ? frame.delta.text : "");
+		const grown = {...block, text};
+		const blocks = mapping.blocks.map((one, at) => (at === open ? grown : one));
+		// Under the interval the row still grows, it just does not repaint: the next event that does
+		// carries every delta accumulated since, so throttling costs latency and never text.
+		return at - mapping.emittedAt < STREAM_EMIT_INTERVAL_MS
+			? {mapping: {...mapping, blocks}, events: []}
+			: {mapping: {...mapping, blocks, emittedAt: at}, events: [item(streamingItem(grown))]};
+	}
+
+	// A closed block repaints whatever the interval last withheld, so the whole block is on screen
+	// before its complete frame arrives — and stays right even if that frame never does.
+	if (frame.type === "content_block_stop") {
+		return {mapping: {...mapping, emittedAt: at}, events: [item(streamingItem(block))]};
+	}
+	return skipMessage(mapping);
+};
 
 export interface MappingOptions {
 	/** Epoch milliseconds for any message carrying no timestamp of its own. */
@@ -103,14 +247,22 @@ export const assistantEvents = (
 	const body = message.message;
 	const text = textOf(body);
 	const interrupted = message.aborted === true;
-	const id = typeof message.uuid === "string" ? message.uuid : `assistant-${at}`;
 	const events: AgentEvent[] = [];
+	let blocks = mapping.blocks;
 	if (text.length > 0 || interrupted) {
+		const messageId = isRecord(body) && typeof body.id === "string" ? body.id : null;
+		const slot = claimable(blocks, messageId);
+		const streamed = slot < 0 ? undefined : blocks[slot];
+		if (slot >= 0) blocks = claim(blocks, slot);
+		// The streamed row's id, so the whole reply *replaces* the growing one rather than landing
+		// beside it. Absent a stream this is `message.uuid`, exactly as it was before partials.
+		const id =
+			streamed?.id ?? (typeof message.uuid === "string" ? message.uuid : `assistant-${at}`);
 		events.push(
 			item({
 				kind: "assistant",
 				id: itemId(id),
-				timestamp: at,
+				timestamp: streamed?.at ?? at,
 				text,
 				...(interrupted ? {interrupted: true} : {}),
 			}),
@@ -138,7 +290,7 @@ export const assistantEvents = (
 			),
 		);
 	}
-	return {mapping: {...mapping, toolCalls}, events};
+	return {mapping: {...mapping, toolCalls, blocks}, events};
 };
 
 /**
@@ -226,12 +378,16 @@ export const resultEvents = (
 ): MappingStep => {
 	if (!isRecord(message)) return skipMessage(mapping);
 	const at = timestampOf(message, options.at);
+	// The turn is over, so its stream is too. A block left unclaimed here streamed a reply whose
+	// complete frame never came; the core settles that row when the phase leaves `prompting`
+	// (`ai-agent/core/fold.ts`), and holding it any longer would let the next turn claim it.
+	const settled: Mapping = {...mapping, streamId: null, blocks: [], emittedAt: 0};
 	const failed = message.is_error === true || message.subtype !== "success";
 	if (failed) {
 		const id = typeof message.uuid === "string" ? message.uuid : `result-${at}`;
 		const subtype = typeof message.subtype === "string" ? message.subtype : "error";
 		return {
-			mapping,
+			mapping: settled,
 			events: [
 				item({
 					kind: "system",
@@ -244,7 +400,7 @@ export const resultEvents = (
 	}
 	const cost = typeof message.total_cost_usd === "number" ? message.total_cost_usd : 0;
 	return {
-		mapping,
+		mapping: settled,
 		events: [
 			{
 				kind: "usage",

--- a/apps/tuval/src/claude/history/partials.unit.test.ts
+++ b/apps/tuval/src/claude/history/partials.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The reply as it is written (#8160), driven by the golden `partial-assistant-turn` capture — a run
+ * of `query()` with `includePartialMessages: true`, kept whole and in the order the CLI emitted it
+ * (`fixtures/PROVENANCE.md`).
+ *
+ * The capture is what makes these cases worth anything. Two facts it settles are not readable off
+ * `sdk.d.ts` at all: the complete `assistant` frame lands **before** its block's
+ * `content_block_stop`, and the whole reply arrives over two `text_delta`s rather than one per
+ * token — so a mapping proved against a hand-written envelope would be proved against the wrong
+ * stream.
+ */
+
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {describe, expect, it} from "vitest";
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {type AssistantItem, isTranscriptItem} from "../../ai-agent/ports/index.ts";
+import {toAgentEvents} from "./events.ts";
+import {loadFixture} from "./fixtures/load.ts";
+import {emptyMapping, type Mapping, STREAM_EMIT_INTERVAL_MS} from "./map.ts";
+
+const AT = 1_700_000_000_000;
+
+const turn = (): ReadonlyArray<SDKMessage> =>
+	loadFixture("partial-assistant-turn") as ReadonlyArray<SDKMessage>;
+
+/**
+ * Fold the capture with a clock that advances `step` per frame, which is the axis the emit interval
+ * is read on. `step` of zero is one instant: every delta lands inside the interval.
+ */
+const run = (
+	stream: ReadonlyArray<SDKMessage>,
+	step: number,
+): {readonly events: ReadonlyArray<AgentEvent>; readonly mapping: Mapping} => {
+	const events: Array<AgentEvent> = [];
+	let mapping = emptyMapping;
+	stream.forEach((message, index) => {
+		const folded = toAgentEvents(message, mapping, {at: AT + index * step});
+		mapping = folded.mapping;
+		events.push(...folded.events);
+	});
+	return {events, mapping};
+};
+
+const assistants = (events: ReadonlyArray<AgentEvent>): ReadonlyArray<AssistantItem> =>
+	events.flatMap((event) =>
+		event.kind === "item" && event.item.kind === "assistant" ? [event.item] : [],
+	);
+
+const SENTENCE = "The quick brown fox jumps over the lazy dog.";
+
+describe("a streamed reply", () => {
+	it("grows one row rather than appending one per delta", () => {
+		const rows = assistants(run(turn(), STREAM_EMIT_INTERVAL_MS).events);
+		expect(rows.length).toBeGreaterThan(1);
+		expect(new Set(rows.map((row) => row.id)).size).toBe(1);
+		expect(rows.map((row) => row.text)).toEqual(["The", SENTENCE, SENTENCE]);
+	});
+
+	it("marks every row but the last as still arriving, and the last as the whole reply", () => {
+		const rows = assistants(run(turn(), STREAM_EMIT_INTERVAL_MS).events);
+		const marks = rows.map((row) => row.streaming);
+		expect(marks).toEqual([true, true, undefined]);
+		expect(rows.at(-1)).toEqual({
+			kind: "assistant",
+			id: rows[0]?.id,
+			timestamp: rows[0]?.timestamp,
+			text: SENTENCE,
+		});
+	});
+
+	it("emits every row through the port's own admission test", () => {
+		const rows = assistants(run(turn(), STREAM_EMIT_INTERVAL_MS).events);
+		expect(rows.every(isTranscriptItem)).toBe(true);
+	});
+
+	// The reason the last delta before the complete frame is not lost when the interval swallows it:
+	// each emission carries the whole accumulated block, so a throttle costs latency and never text.
+	it("still lands the whole reply when every delta falls inside one interval", () => {
+		const rows = assistants(run(turn(), 0).events);
+		expect(rows.at(-1)?.text).toBe(SENTENCE);
+		expect(rows.length).toBeLessThan(3);
+	});
+
+	it("holds nothing of the stream once the turn's result lands", () => {
+		const {mapping} = run(turn(), STREAM_EMIT_INTERVAL_MS);
+		expect(mapping.streamId).toBeNull();
+		expect(mapping.blocks).toEqual([]);
+	});
+
+	// A run without `includePartialMessages` is every frame of this capture minus the six
+	// `stream_event`s, and it must still produce exactly the reply it always did (#8160 no-go).
+	it("produces the same reply as the same run with the partial frames dropped", () => {
+		const whole = assistants(run(turn(), STREAM_EMIT_INTERVAL_MS).events).at(-1);
+		const without = assistants(
+			run(
+				turn().filter((message) => message.type !== "stream_event"),
+				STREAM_EMIT_INTERVAL_MS,
+			).events,
+		);
+		expect(without.length).toBe(1);
+		expect(without[0]?.text).toBe(whole?.text);
+		expect(without[0]?.streaming).toBeUndefined();
+	});
+});
+
+describe("the join between a streamed row and the reply that finishes it", () => {
+	// The frame's own uuid is fresh per delta (`sdk.d.ts`, `SDKPartialAssistantMessage`), so this is
+	// the case that reds if the row is ever keyed on it.
+	it("keys the row on the API message id, not on the partial frame's uuid", () => {
+		const stream = turn();
+		const start = stream.find(
+			(message) => message.type === "stream_event" && message.event.type === "message_start",
+		);
+		const messageId =
+			start !== undefined && start.type === "stream_event" && start.event.type === "message_start"
+				? start.event.message.id
+				: "";
+		expect(messageId.length).toBeGreaterThan(0);
+		const rows = assistants(run(stream, STREAM_EMIT_INTERVAL_MS).events);
+		expect(rows[0]?.id).toBe(`stream:${messageId}:0`);
+	});
+
+	// The capture's own ordering: the complete frame lands before `content_block_stop`, so the stop
+	// finds a claimed block and says nothing. A mapping that emitted there would re-open the reply.
+	it("says nothing on the block's stop, because the complete reply already claimed the row", () => {
+		const stream = turn();
+		const stopAt = stream.findIndex(
+			(message) => message.type === "stream_event" && message.event.type === "content_block_stop",
+		);
+		const completeAt = stream.findIndex((message) => message.type === "assistant");
+		expect(completeAt).toBeGreaterThan(-1);
+		expect(stopAt).toBeGreaterThan(completeAt);
+
+		let mapping = emptyMapping;
+		const events: Array<AgentEvent> = [];
+		stream.slice(0, stopAt).forEach((message, index) => {
+			const folded = toAgentEvents(message, mapping, {at: AT + index * STREAM_EMIT_INTERVAL_MS});
+			mapping = folded.mapping;
+			events.push(...folded.events);
+		});
+		const stop = toAgentEvents(stream[stopAt] as SDKMessage, mapping, {at: AT + 10_000});
+		expect(stop.events).toEqual([]);
+		expect(assistants(events).at(-1)?.streaming).toBeUndefined();
+	});
+});

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -66,17 +66,19 @@ export const itemOf = (item: PiTranscriptItem): TranscriptItem => {
 				timestamp: item.timestamp,
 				text: textOf(item.content),
 			};
+		// Three of the wire's four assistant statuses are settled and one is not: `streaming` is the
+		// reply Pi is still writing (`pi/server/transcript.ts` projects `AgentState.streamingMessage`
+		// under the id its finished form will take), so the row grows under one id and the finished
+		// reply supersedes it.
 		case "assistant": {
 			const text = textOf(item.content);
+			const id = itemId(item.id);
+			if (item.status === "streaming") {
+				return {kind: "assistant", id, timestamp: item.timestamp, text, streaming: true};
+			}
 			return item.status === "aborted"
-				? {
-						kind: "assistant",
-						id: itemId(item.id),
-						timestamp: item.timestamp,
-						text,
-						interrupted: true,
-					}
-				: {kind: "assistant", id: itemId(item.id), timestamp: item.timestamp, text};
+				? {kind: "assistant", id, timestamp: item.timestamp, text, interrupted: true}
+				: {kind: "assistant", id, timestamp: item.timestamp, text};
 		}
 		case "tool":
 			return {

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -123,6 +123,59 @@ describe("one wire item as a port item", () => {
 		});
 	});
 
+	// #8160: the fourth assistant status, and the only unsettled one. The server projects Pi's
+	// `streamingMessage` under it (`pi/server/transcript.ts`), so this is the row that grows.
+	it("marks a reply the session is still writing as streaming", () => {
+		const streaming: PiTranscriptItem = {
+			id: "item-1",
+			role: "assistant",
+			content: [{type: "text", text: "half a th"}],
+			model: {provider: "faux", id: "faux-1"},
+			timestamp: 11,
+			status: "streaming",
+		};
+		expect(itemOf(streaming)).toEqual({
+			kind: "assistant",
+			id: "item-1",
+			timestamp: 11,
+			text: "half a th",
+			streaming: true,
+		});
+	});
+
+	// The snapshot diff is what makes Pi stream at all: the partial and the finished reply carry the
+	// wire's same positional id, so a growing reply is one item event per revision under one id.
+	it("emits one growing row over the revisions of a streamed reply", () => {
+		const growing = (text: string, status: "streaming" | "complete"): PiTranscriptItem => ({
+			id: "item-1",
+			role: "assistant",
+			content: [{type: "text", text}],
+			model: {provider: "faux", id: "faux-1"},
+			timestamp: 11,
+			...(status === "streaming"
+				? {status: "streaming" as const}
+				: {status: "complete" as const, stopReason: "stop" as const}),
+		});
+		let projection = emptyProjection;
+		const rows: Array<unknown> = [];
+		for (const revision of [
+			growing("ha", "streaming"),
+			growing("half", "streaming"),
+			growing("half", "streaming"),
+			growing("half a thought", "complete"),
+		]) {
+			const folded = eventsOf(projection, snapshot([revision], "turn"));
+			projection = folded.next;
+			rows.push(...folded.events.filter((event) => event.kind === "item").map((one) => one.item));
+		}
+		// Three rows, not four: the repeated revision is the same projection and repaints nothing.
+		expect(rows).toEqual([
+			{kind: "assistant", id: "item-1", timestamp: 11, text: "ha", streaming: true},
+			{kind: "assistant", id: "item-1", timestamp: 11, text: "half", streaming: true},
+			{kind: "assistant", id: "item-1", timestamp: 11, text: "half a thought"},
+		]);
+	});
+
 	it("keys a tool row by its call id and folds the three wire statuses", () => {
 		expect(itemOf(runningTool)).toEqual({
 			kind: "tool",

--- a/apps/tuval/src/pi/ai-agent/pi-ai-agent.integration.test.ts
+++ b/apps/tuval/src/pi/ai-agent/pi-ai-agent.integration.test.ts
@@ -32,12 +32,20 @@ const MODEL = {provider: "faux", id: "faux-1"} as const;
 /** Long enough for a pushed snapshot to land, short enough to fail inside the suite budget. */
 const SETTLE = "500 millis";
 
-const setUp = (responses = [fauxAssistantMessage("hello from faux")]) => {
+/**
+ * `tokensPerSecond` paces the faux stream (`@earendil-works/pi-ai` `RegisterFauxProviderOptions`).
+ * Absent, a scripted reply arrives in one synchronous burst and the session host's own coalescing —
+ * one pending change, sliding, per burst (`server/AgentSessionHost.ts`) — collapses the whole turn
+ * into a single snapshot. A real model is slower than that tick, so a streaming case that wants to
+ * see what a real one produces has to be.
+ */
+const setUp = (responses = [fauxAssistantMessage("hello from faux")], tokensPerSecond?: number) => {
 	const cwd = mkdtempSync(join(tmpdir(), "tuval-pi-ai-agent-"));
 	const faux = fauxProvider({
 		provider: MODEL.provider,
 		api: "faux",
 		models: [{id: MODEL.id, cost: {input: 3, output: 15, cacheRead: 0, cacheWrite: 0}}],
+		...(tokensPerSecond === undefined ? {} : {tokensPerSecond}),
 	});
 	faux.setResponses([...responses]);
 	return {cwd, faux};
@@ -209,6 +217,66 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 				}
 
 				assert.strictEqual(faux.state.callCount, 2, "the tool loop ran two model turns");
+			}).pipe(
+				Effect.scoped,
+				Effect.provide(aiAgentOverHost({model: MODEL}).pipe(Layer.provide(hostLayer(cwd, faux)))),
+			);
+		},
+		{timeout: 60_000},
+	);
+
+	/**
+	 * #8160 over the real loop: Pi holds the reply it is writing in `AgentState.streamingMessage`
+	 * and pushes it into `messages` only on `message_end`, so this is the case that reds if the
+	 * server stops projecting it — the window would then see one item, at the end of the turn.
+	 *
+	 * The faux provider chunks a reply by token size and pushes a `text_delta` per chunk
+	 * (`@earendil-works/pi-ai` `dist/providers/faux.js`), so a long enough answer is a real stream
+	 * through the real session, the real snapshot push and the real revision diff.
+	 */
+	it.live(
+		"pushes a reply as it is written, growing one row that the finished reply supersedes",
+		() => {
+			const answer =
+				"One two three four five six seven eight nine ten eleven twelve thirteen fourteen " +
+				"fifteen sixteen seventeen eighteen nineteen twenty.";
+			const {cwd, faux} = setUp([fauxAssistantMessage(answer)], 40);
+			return Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd});
+				yield* agent.prompt("count to twenty", "key-1");
+				yield* turnsRan(faux, 1);
+				const events = yield* drain(agent);
+
+				const replies = items(events).filter((item) => item.kind === "assistant");
+				assert.isAbove(
+					replies.length,
+					1,
+					"the reply reached the window more than once — it streamed rather than landing whole",
+				);
+				assert.strictEqual(
+					new Set(replies.map((item) => item.id)).size,
+					1,
+					"every one of them is the same row, so the window grows one reply and not a list",
+				);
+
+				const growing = replies.slice(0, -1);
+				assert.isNotEmpty(growing);
+				assert.isTrue(
+					growing.every((item) => item.kind === "assistant" && item.streaming === true),
+					"every row before the last says the reply is still arriving",
+				);
+				// Monotonic, which is what makes it a stream and not a set of guesses: each row is a
+				// prefix of the next, and the last is the whole answer with the marker gone.
+				const lengths = replies.map((item) => (item.kind === "assistant" ? item.text.length : 0));
+				assert.deepStrictEqual(
+					[...lengths].sort((left, right) => left - right),
+					lengths,
+					"the row only ever grew",
+				);
+				const settled = replies.at(-1);
+				assert.strictEqual(settled?.kind === "assistant" ? settled.text : "", answer);
+				assert.isUndefined(settled?.kind === "assistant" ? settled.streaming : undefined);
 			}).pipe(
 				Effect.scoped,
 				Effect.provide(aiAgentOverHost({model: MODEL}).pipe(Layer.provide(hostLayer(cwd, faux)))),

--- a/apps/tuval/src/pi/server/AgentSessionHost.ts
+++ b/apps/tuval/src/pi/server/AgentSessionHost.ts
@@ -153,7 +153,10 @@ const handleOf = (
 						id: session.model?.id ?? "unknown",
 					},
 					thinkingLevel: session.thinkingLevel as ThinkingLevel,
-					transcript: projectTranscript(session.messages as ReadonlyArray<SourceMessage>),
+					transcript: projectTranscript(
+						session.messages as ReadonlyArray<SourceMessage>,
+						session.state.streamingMessage as SourceMessage | undefined,
+					),
 					name: session.sessionName,
 					queuedSteer: session.getSteeringMessages(),
 				}),

--- a/apps/tuval/src/pi/server/projections.unit.test.ts
+++ b/apps/tuval/src/pi/server/projections.unit.test.ts
@@ -118,6 +118,62 @@ describe("projectTranscript", () => {
 		});
 	});
 
+	/**
+	 * #8160: Pi holds the reply it is writing in `AgentState.streamingMessage` and pushes it into
+	 * `messages` only on `message_end` (`pi-agent-core` `dist/agent.js`), so a mid-turn snapshot
+	 * without this differs from the one before it in `phase` and `revision` and nothing else.
+	 */
+	describe("the reply still being written", () => {
+		const streaming: SourceMessage = {
+			role: "assistant",
+			content: [{type: "text", text: "on i"}],
+			provider: "faux",
+			model: "faux-1",
+			// `"pending"` is the stopReason a partial carries at this pin (`@earendil-works/pi-ai`
+			// `dist/types.d.ts`, `StopReason`), and the arm that answers `streaming` to it.
+			stopReason: "pending",
+			timestamp: 2,
+		};
+
+		it("is absent from the projection when the session is holding none", () => {
+			assert.strictEqual(projectTranscript(messages).length, messages.length);
+		});
+
+		it("lands as one more assistant item, marked streaming", () => {
+			const items = projectTranscript(messages, streaming);
+			assert.strictEqual(items.length, messages.length + 1);
+			assert.deepStrictEqual(items.at(-1), {
+				id: "item-3",
+				role: "assistant",
+				content: [{type: "text", text: "on i"}],
+				model: {provider: "faux", id: "faux-1"},
+				timestamp: 2,
+				status: "streaming",
+			});
+		});
+
+		// The whole reason it is appended rather than given an id of its own: `message_end` pushes
+		// the finished message at exactly this index, so the partial and the reply that replaces it
+		// are one row to every client, and no join has to be invented for them.
+		it("takes the id the finished reply will take", () => {
+			const partial = projectTranscript(messages, streaming).at(-1);
+			const settled = projectTranscript([
+				...messages,
+				{...streaming, content: [{type: "text", text: "on it"}], stopReason: "stop"},
+			]).at(-1);
+			assert.strictEqual(partial?.id, settled?.id);
+			assert.strictEqual(settled?.role === "assistant" ? settled.status : "", "complete");
+		});
+
+		it("still lets a tool result read its input off a call the partial made", () => {
+			const items = projectTranscript(messages, {
+				...streaming,
+				content: [{type: "toolCall", id: "call-2", name: "read", arguments: {path: "b.txt"}}],
+			});
+			assert.strictEqual(items.length, messages.length + 1);
+		});
+	});
+
 	it("produces items the wire accepts", () => {
 		encodeServerMessage({
 			type: "event",

--- a/apps/tuval/src/pi/server/transcript.ts
+++ b/apps/tuval/src/pi/server/transcript.ts
@@ -164,12 +164,23 @@ const assistantStatus = (stopReason: string, errorMessage: string | undefined): 
  * turn that made the call. An orphan result — the call was compacted away — gets a null input
  * rather than being dropped, because dropping it would leave the client a shorter transcript than
  * the session has.
+ *
+ * `streaming` is the reply the agent is writing right now, which Pi holds aside in
+ * `AgentState.streamingMessage` and pushes into `messages` only on `message_end` (`pi-agent-core`
+ * `dist/agent.js`, `processEvents`) — so without it a mid-turn snapshot differs from the one before
+ * it in `phase` and `revision` and nothing else, and the client has no reply to show until the turn
+ * ends (#8160). It is appended, because `message_end` pushes it at exactly that index: the item id
+ * is the position, so the partial and the reply that replaces it are one row and not two. Its
+ * `stopReason` is `"pending"` while it streams (`@earendil-works/pi-ai` `dist/types.d.ts`,
+ * `StopReason`), which is what `assistantStatus` answers `streaming` to.
  */
 export const projectTranscript = (
 	messages: ReadonlyArray<SourceMessage>,
+	streaming?: SourceMessage | undefined,
 ): ReadonlyArray<TranscriptItem> => {
 	const toolInputs = new Map<string, Record<string, unknown>>();
-	for (const message of messages) {
+	const all = streaming === undefined ? messages : [...messages, streaming];
+	for (const message of all) {
 		if (message.role !== "assistant") continue;
 		for (const content of message.content) {
 			if (content.type === "toolCall") toolInputs.set(content.id, content.arguments);
@@ -177,7 +188,7 @@ export const projectTranscript = (
 	}
 
 	const items: TranscriptItem[] = [];
-	messages.forEach((message, index) => {
+	all.forEach((message, index) => {
 		const id = `item-${index}`;
 		if (message.role === "user") {
 			const content: Array<UserContent> =

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -206,7 +206,19 @@ function ItemRow({
 					onToggle={(open) => onToggleTool(item.id, open)}
 				/>
 			) : (
-				<p className="tuval-chat-text">{item.text}</p>
+				<p
+					className="tuval-chat-text"
+					// A reply still arriving is announced as busy rather than as a new message per delta:
+					// `aria-busy` is what stops a live region re-reading the growing row on every repaint.
+					{...(item.kind === "assistant" && item.streaming === true
+						? {"aria-busy": true, "data-streaming": "true"}
+						: {})}
+				>
+					{item.text}
+					{item.kind === "assistant" && item.streaming === true ? (
+						<span className="tuval-chat-caret" aria-hidden="true" />
+					) : null}
+				</p>
 			)}
 			{interrupted ? (
 				<span className="tuval-chat-interrupted">

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -30,6 +30,7 @@ import {type ChatWindowHost, type ChatWindowOptions, chatWindow} from "./ChatWin
 import {
 	assistantItem,
 	call,
+	streamingItem,
 	toolItem,
 	transcriptOf,
 	userItem,
@@ -138,6 +139,37 @@ const composer = (): HTMLTextAreaElement =>
 
 const rows = (): ReadonlyArray<HTMLElement> =>
 	Array.from(document.querySelectorAll<HTMLElement>(".tuval-chat-row"));
+
+/**
+ * #8160: a reply that is still arriving renders as the text it has so far, marked busy. The marker
+ * is the shared item's own (`ports/transcript-item.ts`), so the window learns it once and every
+ * backend gets it — there is no Claude row and no Pi row.
+ */
+describe("a reply still arriving", () => {
+	const streamed = () =>
+		document.querySelector<HTMLElement>('.tuval-chat-text[data-streaming="true"]');
+
+	it("renders the text it has so far, marked busy for a screen reader", async () => {
+		await openWindow(withTranscript([userItem("u1"), streamingItem("a1", "half a rep")]));
+		const row = streamed();
+		expect(row).not.toBeNull();
+		expect(row?.textContent).toBe("half a rep");
+		expect(row?.getAttribute("aria-busy")).toBe("true");
+	});
+
+	it("carries no marker once the finished reply supersedes it", async () => {
+		const {process} = await openWindow(
+			withTranscript([userItem("u1"), streamingItem("a1", "half a rep")]),
+		);
+		await act(async () => {
+			await Effect.runPromise(
+				process.commit(withTranscript([userItem("u1"), assistantItem("a1", "half a reply.")])),
+			);
+		});
+		expect(streamed()).toBeNull();
+		expect(rows().at(-1)?.textContent).toContain("half a reply.");
+	});
+});
 
 describe("the transcript", () => {
 	it("renders only the rows the viewport can hold, over a thousand-item transcript", async () => {

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -559,6 +559,25 @@
 	}
 }
 
+/* Where a reply that is still arriving ends. The text is the signal and the blink only the
+   reassurance, so the reduced-motion block below cancels it. */
+.tuval-chat-caret {
+	display: inline-block;
+	width: 0.5ch;
+	height: 1em;
+	margin-inline-start: 0.15ch;
+	vertical-align: text-bottom;
+	background: currentColor;
+	opacity: 0.7;
+	animation: tuval-chat-caret-blink 1s steps(2, start) infinite;
+}
+
+@keyframes tuval-chat-caret-blink {
+	to {
+		visibility: hidden;
+	}
+}
+
 /* The override must tie or beat the rule it cancels: `@media` is a conditional group rule and
    contributes nothing to specificity, so a bare `.tuval-chat-phase-dot` (0,1,0) would silently lose
    to the pulse rule's (0,3,0) and keep animating for someone who asked for no motion. `[data-phase]`
@@ -568,5 +587,9 @@
 	.tuval-chat-working-dots span {
 		animation: none;
 		opacity: 1;
+	}
+
+	.tuval-chat-caret {
+		animation: none;
 	}
 }

--- a/apps/tuval/src/shell/chat/chat.testing.ts
+++ b/apps/tuval/src/shell/chat/chat.testing.ts
@@ -18,6 +18,7 @@ import {boundToolResult, ItemId, Mode} from "../../ai-agent/ports/index.ts";
 import {pendingPermission, permissionCard} from "../../ai-agent-fixtures/permissions.ts";
 import {
 	assistantItem,
+	streamingItem,
 	systemItem,
 	toolItem,
 	userItem,
@@ -27,6 +28,7 @@ export {
 	assistantItem,
 	pendingPermission,
 	permissionCard as permissionRequest,
+	streamingItem,
 	systemItem,
 	toolItem,
 	userItem,


### PR DESCRIPTION
Closes #8160

Was stacked on [#8163](https://github.com/kamp-us/phoenix/pull/8163) (the mid-turn prompt queue / ADR 0357); that landed as `bb86e4e1`, so this is **rebased onto `main` and standing alone** — one commit, no stack.

The rebase also picked up two Pi changes that were not under it when the work was written, and neither collides:

- **[#8168](https://github.com/kamp-us/phoenix/pull/8168)** (a Pi turn's end reaches the core even when its pushes coalesce) touches the same seam and is the one worth stating. It adds *phase* facts the snapshot diff could not supply — a `sent` mark at the send, and the snapshot the send's own answer carries — while this PR adds an *item* to what that diff sees. They cannot overlap in time: the answer snapshot is read after `session.prompt` resolves (`pi/server/dispatch.ts`, `withSession`: the call, then `snapshotOf`), and `AgentState.streamingMessage` is cleared on `message_end`/`agent_end` (`pi-agent-core` `dist/agent.js:389,410`) — so the re-folded answer never carries a partial and can never re-open a settled row. #8168 in fact *helps* this change: the `sent` mark is what makes the terminal `ready` a difference again, and that `ready` is the event the streaming settlement hangs off — without it, a Pi turn whose pushes coalesced would have stranded a row mid-stream.
- **[#8175](https://github.com/kamp-us/phoenix/pull/8175)** (mid-turn Pi teardown, finalizer ceilings) — zero file overlap, no projection change.

Verified rather than reasoned: the Pi integration suite (this PR's live-session streaming case plus #8168's own restore proof) ran five consecutive times clean with both changes together.

## Mechanism

A reply now reaches the window as one transcript row, re-sent under one id with more text each time. The shared `AssistantItem` becomes a two-member union — `StreamingAssistantItem` (`streaming: true`, no `interrupted`) and `SettledAssistantItem` (`interrupted`, no `streaming`) — because the two are answers to the one question a reader asks of a reply, *has this turn finished?*; an interrupt **settles** a stream rather than annotating one, and `{streaming: true, interrupted: true}` is a state no producer can write. `ports/transcript-item.ts` owns the runtime half of that and refuses it. There is no new event kind and no new port: a delta is an ordinary `item` event, and the fold's existing `upsertItem` supersedes by id, so a growing reply reuses the send-echo join from #7978. Each backend supplies a join key it already has, so the core stays backend-blind. The marker is a claim about a running turn, so `foldEvent` clears it on every way out of `prompting` — ready, gone, failed — and a row still marked `streaming` past its turn settles as `interrupted`; a backend that reports the cut itself wins, because its own item carries the streamed row's id and lands first.

## What each backend actually emits

**Claude** (`@anthropic-ai/claude-agent-sdk@0.3.259`). `SDKPartialAssistantMessage` frames are emitted only under `includePartialMessages` (`sdk.d.ts:1721-1725`), which was never set; `history/events.ts` skipped `stream_event` anyway. Each frame wraps "one Anthropic Messages API streaming event" (`sdk.d.ts:4759-4779`) and carries a `uuid` that is **fresh per delta** — so the row cannot be keyed on it. The key is the *API* message id off the wrapped `BetaRawMessageStartEvent.message.id` (`@anthropic-ai/sdk@0.91.1`, `messages.d.ts:1311-1314`), held in `Mapping` across the turn, with the row id `stream:<message id>:<block index>`; the complete `SDKAssistantMessage` repeats that id in `message.message.id` (`sdk.d.ts:3280-3285`) and claims the row, so the finished reply replaces the growing one instead of landing beside it.

One fact decided the mapping and is **not readable off `sdk.d.ts`** — it came out of a fresh golden capture (`fixtures/partial-assistant-turn.json` + its `PROVENANCE.md` row, per the #8160 no-go): the complete `assistant` frame for a text block arrives **before** that block's `content_block_stop`. Captured order: `message_start`, `content_block_start`, two `content_block_delta`s, `assistant`, `content_block_stop`, `message_delta`, `message_stop`. A mapping that settled the row on the stop would re-open a finished reply as a partial one.

**Pi** (`@earendil-works/pi-*@0.84.3`). Pi genuinely does not put the partial where the seam could see it: `processEvents` sets `AgentState.streamingMessage` on `message_start`/`message_update` and only pushes into `messages` on `message_end` (`pi-agent-core` `dist/agent.js:380-391`), and the loop's own partial goes into a *copy* of the array (`dist/agent-loop.js:199-206` over `createContextSnapshot`, `dist/agent.js:283`), so `session.messages` never holds it. `AgentSessionHost` now reads `session.state.streamingMessage` (`AgentState.streamingMessage`, `dist/types.d.ts:309`) and appends it to the projection — at exactly the index `message_end` pushes the finished message at, so the partial and the reply that replaces it are one row with no invented join. Its `stopReason` is `"pending"` while it streams (`pi-ai` `dist/types.d.ts:287`, `StopReason`), which is what `transcript.ts`'s already-present-but-unreachable `streaming` arm answers to. The snapshot diff in `pi/ai-agent/items.ts` then emits one item event per changed revision under one id.

## Per layer

- **ports** — `AssistantItem` split into the streaming/settled union; predicate refuses an item marked both ways, and refuses a `streaming` that is anything but `true`.
- **core** — `settleStreaming` / `transcriptAfter` in `fold.ts` + `state.ts`; `restore` settles a half-streamed tail and points the resend at it.
- **claude** — `includePartialMessages: true` in `options.ts`; `partialEvents` + the `Mapping` join in `history/map.ts`; `stream_event` routed in `history/events.ts`.
- **pi** — `projectTranscript(messages, streaming?)` in `server/transcript.ts`; `streamingMessage` read in `server/AgentSessionHost.ts`; the `streaming` status mapped in `ai-agent/items.ts`.
- **shell** — minimal and additive: the assistant `<p>` gets `aria-busy` + a caret while streaming, and the caret is cancelled in the sheet's existing reduced-motion block. Nothing in the virtualizer changed — the follow effect already depends on `totalSize`, which covers a last row that measures taller.

**Checkpoint churn.** Claude's deltas are per token and every fold writes the whole state to the store (`host/actor.ts`), so the mapping coalesces them on the clock the layer already stamps: `STREAM_EMIT_INTERVAL_MS` read off `MappingOptions.at`, pure and driven by a test's own clocks. Each emission carries the whole accumulated block, so throttling costs latency and never text. Pi needs none of its own — the session host already collapses a burst into one pending change and the revision diff suppresses an unchanged repaint. The `durability/` debounce the epic names is untouched and remains its own child; what this PR buys against it is the correctness half (below).

## Under interrupt and restore

- **Interrupt.** ADR 0356 / #8007 stands: asking is not stopping, so the request alone leaves the row growing and `interruption` outstanding. The backend's own answer settles it — Claude's `aborted: true` frame and Pi's `status: "aborted"` both carry the streamed row's id, so the cut reply lands as the row itself; failing that, the phase leaving `prompting` settles whatever is left.
- **Restore.** #8160's no-go — *no partial item reaches a checkpoint as if it were final*. A checkpoint written between two deltas does hold a `streaming` row; `restore` settles it as `interrupted` and makes it the `interrupted` id the resend is offered against. That is a sharper cut test than the saved phase, which is folded by a different event and can say anything.
- **The prompt queue (#8163 / ADR 0357).** Unchanged and tested against: the queue settle hangs off the same turn end the stream settlement does, and both land in one transition — `core/streaming.unit.test.ts` pins that a streamed turn's end settles the cut reply *and* admits the queue head, and that a session going `gone` mid-stream settles the row and releases the queue as `refused`.
- **#7998 / #8032.** `rows.ts` is untouched; the page/tail join and the operator-turn dedup are unchanged, and a streamed row keys on `rowKey` like any other.

## Verified

- **Real Claude, end to end.** Drove live `query()` with the flag through the real mapper and the real fold: one row, id `stream:msg_…:0`, three paints (`"One"` → 48 chars → settled), `rows=1` — the growing row and the finished reply are the same row, not two.
- **Real Pi session, end to end.** New `it.live` case in `pi-ai-agent.integration.test.ts` over a real `AgentSession`, real snapshot push, real revision diff, on Pi's own faux provider (no key, no spend, CI-safe) paced with `tokensPerSecond` — because an unpaced burst is faster than the host's own coalescing tick, which a real model is not. Asserts >1 reply item, all under one id, monotonically growing, the last one settled and whole. (A live Pi *model* was not driven: `~/.pi/agent/auth.json` has no configured provider on this machine.)
- **Unit** — `pnpm test:unit`: **179 files, 1586 tests, 0 failures** (was 177/1550; +36). New/extended: `claude/history/partials.unit.test.ts` (8, all against the golden capture — including that a run with the partial frames dropped produces exactly the reply it always did), `ai-agent/core/streaming.unit.test.ts` (17 — deltas folding into one row, a turn ending mid-stream, an interrupt mid-stream, a restore over a half-streamed tail, the queue draining after a streamed turn), plus cases in `ports/transcript-item`, `pi/ai-agent/items`, `pi/server/projections`, `shell/chat/chat-window`.
- **Integration** — `pnpm test:integration`: **9 files, 42 tests, 0 failures** (was 41).
- **`pnpm typecheck`** — 23/23 tasks, 0 errors, 0 warnings. **`pnpm lint`** — clean.
- `pnpm test` (both projects in one run) is flaky on this machine under load and is so on the base branch too — 21 failures at `51e22e72` vs 1 here, all timeouts in unrelated boot tests. The split scripts are green on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
