### PR TITLE
fix: A restored AI agent session drops the operator's mode switch: the rebuilt layer's first mode event overwrites it

### DIFF
--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -117,7 +117,14 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 								interruption: null,
 								failure: null,
 							},
-							[{type: "aiAgent.start", cwd: msg.cwd, resume: msg.resume}],
+							[
+								{
+									type: "aiAgent.start",
+									cwd: msg.cwd,
+									resume: msg.resume,
+									mode: state.modes.current,
+								},
+							],
 						],
 
 			// The connection bump is what re-opens the events Sub: a reconnect stands a new transport
@@ -331,11 +338,20 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 				if (opening(state)) return [{...state, failure: startRefused(state.phase)}, noCmds];
 				// The republish goes first so a window attached to a restored session paints the saved
 				// tail and its pending cards before the transport is back, rather than after it.
+				//
+				// The checkpointed mode rides the reconnect for the same reason it cannot ride a
+				// `setMode` after `started`: a rebuilt layer holds no mode, so one told after the open
+				// would run a stretch of session on the row's configured mode and say so (#7953).
 				return [
 					{...state, phase: "reconnecting", interruption: null},
 					[
 						{type: "aiAgent.republish"},
-						{type: "aiAgent.reconnect", cwd: state.cwd, sessionId: state.sessionId},
+						{
+							type: "aiAgent.reconnect",
+							cwd: state.cwd,
+							sessionId: state.sessionId,
+							mode: state.modes.current,
+						},
 					],
 				];
 			},

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -166,7 +166,7 @@ describe("start", () => {
 		});
 		expect(state.phase).toBe("starting");
 		expect(state.cwd).toBe("/other");
-		expect(cmds).toEqual([{type: "aiAgent.start", cwd: "/other", resume: null}]);
+		expect(cmds).toEqual([{type: "aiAgent.start", cwd: "/other", resume: null, mode: null}]);
 	});
 
 	it("carries the resume id for a session the backend already holds", () => {
@@ -175,7 +175,7 @@ describe("start", () => {
 			cwd: "/repo",
 			resume: "session-1",
 		});
-		expect(cmds).toEqual([{type: "aiAgent.start", cwd: "/repo", resume: "session-1"}]);
+		expect(cmds).toEqual([{type: "aiAgent.start", cwd: "/repo", resume: "session-1", mode: null}]);
 	});
 
 	it("refuses as data while a session is already live", () => {
@@ -778,12 +778,17 @@ describe("interrupt", () => {
 });
 
 describe("reconnect", () => {
-	it("republishes what it holds, then asks the layer to re-attach the session", () => {
-		const [state, cmds] = apply(started({phase: "gone"}), {type: "reconnect"});
+	it("republishes what it holds, then asks the layer to re-attach the session on its mode", () => {
+		const [state, cmds] = apply(
+			started({phase: "gone", modes: {current: Mode.make("plan"), available: [Mode.make("plan")]}}),
+			{type: "reconnect"},
+		);
 		expect(state.phase).toBe("reconnecting");
 		expect(cmds).toEqual([
 			{type: "aiAgent.republish"},
-			{type: "aiAgent.reconnect", cwd: "/repo", sessionId: "session-1"},
+			// The rebuilt layer holds no mode, so the one the session is on has to go out with the
+			// re-attach rather than as a `setMode` after it (#7953).
+			{type: "aiAgent.reconnect", cwd: "/repo", sessionId: "session-1", mode: Mode.make("plan")},
 		]);
 	});
 

--- a/apps/tuval/src/ai-agent/core/messages.ts
+++ b/apps/tuval/src/ai-agent/core/messages.ts
@@ -79,7 +79,13 @@ export type AiAgentSessionCmd =
 	 * the spawn has returned, rather than inside it.
 	 */
 	| {readonly type: "aiAgent.boot"; readonly cwd: string}
-	| {readonly type: "aiAgent.start"; readonly cwd: string; readonly resume: string | null}
+	| {
+			readonly type: "aiAgent.start";
+			readonly cwd: string;
+			readonly resume: string | null;
+			/** The mode the session is on, so the layer opens on it rather than on the row's (#7953). */
+			readonly mode: Mode | null;
+	  }
 	| {readonly type: "aiAgent.prompt"; readonly text: string; readonly key: string}
 	| {
 			readonly type: "aiAgent.answer";
@@ -93,7 +99,13 @@ export type AiAgentSessionCmd =
 	| {readonly type: "aiAgent.setThinkingLevel"; readonly level: ThinkingLevel}
 	| {readonly type: "aiAgent.page"; readonly before: string | null; readonly limit: number}
 	| {readonly type: "aiAgent.interrupt"}
-	| {readonly type: "aiAgent.reconnect"; readonly cwd: string; readonly sessionId: string}
+	| {
+			readonly type: "aiAgent.reconnect";
+			readonly cwd: string;
+			readonly sessionId: string;
+			/** The checkpointed mode, which is the whole reason a restore keeps the switch (#7953). */
+			readonly mode: Mode | null;
+	  }
 	/**
 	 * Publish the committed state's three outbound projections again, with no backend call.
 	 *

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -36,8 +36,9 @@ import {
 	type WindowLimits,
 } from "../core/index.ts";
 import {isRefusal, planTranscriptPage, withoutLocalEchoes} from "../history/index.ts";
-import type {TranscriptPagePayload} from "../ports/index.ts";
+import type {Mode, TranscriptPagePayload} from "../ports/index.ts";
 import {
+	type StartOptions,
 	type TranscriptPage,
 	TransportError,
 	type TuvalAiAgent,
@@ -142,12 +143,16 @@ export const aiAgentHandlers = <RIn = never>(
 	const open = (
 		cwd: string,
 		resume: string | null,
+		mode: Mode | null,
 	): Effect.Effect<Follow, never, ProcessSelf | RIn> =>
 		Effect.gen(function* () {
 			const agent = yield* slot.rebuild;
-			const started = yield* Effect.result(
-				underPolicy(agent.start(resume === null ? {cwd} : {cwd, resume}), policy),
-			);
+			const options: StartOptions = {
+				cwd,
+				...(resume === null ? {} : {resume}),
+				...(mode === null ? {} : {mode}),
+			};
+			const started = yield* Effect.result(underPolicy(agent.start(options), policy));
 			if (Result.isSuccess(started)) {
 				return [{type: "started", sessionId: started.success.sessionId}];
 			}
@@ -178,9 +183,9 @@ export const aiAgentHandlers = <RIn = never>(
 		// for as long as the backend takes to answer.
 		"aiAgent.boot": (cmd) => Effect.succeed([{type: "start", cwd: cmd.cwd, resume: null}]),
 
-		"aiAgent.start": (cmd) => open(cmd.cwd, cmd.resume),
+		"aiAgent.start": (cmd) => open(cmd.cwd, cmd.resume, cmd.mode),
 
-		"aiAgent.reconnect": (cmd) => open(cmd.cwd, cmd.sessionId),
+		"aiAgent.reconnect": (cmd) => open(cmd.cwd, cmd.sessionId, cmd.mode),
 
 		// The one handler that reads the committed state rather than folding forward from it: there
 		// is no event to fold, which is the whole point — a restored session's tail and its pending

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -159,7 +159,15 @@ const runToTheCut = (
 				id: PROCESS,
 				services: Context.make(ProcessPorts, recorder(log)),
 			});
-			yield* eventually(() => sessionOf(handle.getState()).sessionId !== null);
+			// `sessionId` lands with the `started` Msg the handler returns, but the layer's opening
+			// announcements ride the events Sub and fold after it. Waiting on the id alone lets
+			// `before` switch the mode into a state the opening `mode` event then overwrites, and the
+			// checkpoint keeps that overwrite. `available` is empty until that event folds, so it is
+			// the signal that the layer has finished announcing.
+			yield* eventually(() => {
+				const session = sessionOf(handle.getState());
+				return session.sessionId !== null && session.modes.available.length > 0;
+			});
 			yield* before(handle);
 			yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1", timestamp: Date.now()});
 			yield* eventually(() => Object.keys(sessionOf(handle.getState()).permissions).length === 2);
@@ -399,9 +407,21 @@ describe("the mode list", () => {
 						yield* eventually(() => sessionOf(handle.getState()).modes.current === mode("plan"));
 					}),
 				);
-				yield* resume(stores, script(), starts, (_restored, _log, settled) =>
+				yield* resume(stores, script(), starts, (restored, _log, settled) =>
 					Effect.gen(function* () {
+						// Three assertions rather than one, so a red says which side broke: the
+						// checkpoint, the reconnect that hands the layer its mode, or the fold.
+						assert.strictEqual(
+							restored.modes.current,
+							mode("plan"),
+							"the checkpoint did not carry the switch, so there was nothing to restore",
+						);
 						const after = yield* settled;
+						assert.strictEqual(
+							starts[1]?.mode,
+							mode("plan"),
+							"the reconnect opened the rebuilt layer without the operator's mode",
+						);
 						assert.strictEqual(
 							after.modes.current,
 							mode("plan"),

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -16,7 +16,7 @@ import {NodeId} from "../../ports/graph.ts";
 import {PortNotWired, ProcessPorts} from "../../ports/index.ts";
 import {Processes} from "../../process/Processes.ts";
 import {ProcessTable} from "../../process/ProcessTable.ts";
-import {ProcessId} from "../../process/process.ts";
+import {type ProcessHandle, ProcessId} from "../../process/process.ts";
 import {type AnyProgram, ProgramId} from "../../registry/program.ts";
 import {Registry} from "../../registry/Registry.ts";
 import {type AiAgentSessionState, isAiAgentSessionState, START_ERROR} from "../core/index.ts";
@@ -144,7 +144,12 @@ const pendingKeys = (log: ReadonlyArray<Emitted>): ReadonlyArray<ReadonlyArray<s
  * A session run up to the cut and checkpointed: spawn at a fixed id, start, prompt the turn that
  * never lands, then close the kernel's scope so the host flushes its last save.
  */
-const runToTheCut = (stores: CheckpointStores, starts: Array<StartOptions>) =>
+const runToTheCut = (
+	stores: CheckpointStores,
+	starts: Array<StartOptions>,
+	/** What the operator does on the open session before the turn that gets cut. */
+	before: (handle: ProcessHandle) => Effect.Effect<void, unknown> = () => Effect.void,
+) =>
 	Effect.gen(function* () {
 		const log: Array<Emitted> = [];
 		const rows = [row(script(), starts)];
@@ -155,6 +160,7 @@ const runToTheCut = (stores: CheckpointStores, starts: Array<StartOptions>) =>
 				services: Context.make(ProcessPorts, recorder(log)),
 			});
 			yield* eventually(() => sessionOf(handle.getState()).sessionId !== null);
+			yield* before(handle);
 			yield* handle.dispatch({type: "prompt", text: "delete it", key: "k1", timestamp: Date.now()});
 			yield* eventually(() => Object.keys(sessionOf(handle.getState()).permissions).length === 2);
 			assert.strictEqual(
@@ -233,8 +239,8 @@ describe("a restored agent session", () => {
 					const after = yield* settled;
 					assert.deepStrictEqual(
 						starts[1],
-						{cwd: CWD, resume: SESSION_ID},
-						"the reconnect did not resume the checkpointed session id",
+						{cwd: CWD, resume: SESSION_ID, mode: modes.current},
+						"the reconnect did not resume the checkpointed session id on its saved mode",
 					);
 					assert.strictEqual(starts.length, 2, "the resume opened more than one session");
 					assert.strictEqual(after.phase, "ready");
@@ -376,5 +382,33 @@ describe("the mode list", () => {
 				}),
 			);
 		}),
+	);
+
+	// The mode the operator switched to is the one fact of a session that used to be lost on the way
+	// back: the rebuilt layer announced the one it opened on, and that announcement superseded the
+	// republished checkpoint (#7953).
+	it.live(
+		"comes back on the mode the operator switched to, not the one the layer defaults to",
+		() =>
+			Effect.gen(function* () {
+				const stores = memoryStores();
+				const starts: Array<StartOptions> = [];
+				yield* runToTheCut(stores, starts, (handle) =>
+					Effect.gen(function* () {
+						yield* handle.dispatch({type: "setMode", mode: mode("plan")});
+						yield* eventually(() => sessionOf(handle.getState()).modes.current === mode("plan"));
+					}),
+				);
+				yield* resume(stores, script(), starts, (_restored, _log, settled) =>
+					Effect.gen(function* () {
+						const after = yield* settled;
+						assert.strictEqual(
+							after.modes.current,
+							mode("plan"),
+							"the restored session dropped the switch and came back on the script's mode",
+						);
+					}),
+				);
+			}),
 	);
 });

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
@@ -160,6 +160,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 		const start = Effect.fn("TuvalAiAgent.start")(function* (options: {
 			readonly cwd: string;
 			readonly resume?: string;
+			readonly mode?: Mode;
 		}) {
 			const current = yield* Ref.get(state);
 			if (!current.live) {
@@ -186,8 +187,16 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 					pending: foldPending(previous.pending, resumed),
 				}));
 			}
+			// `state` is per build and seeded from the script, so a rebuilt layer holds the script's
+			// mode rather than the operator's. The caller's mode is the session's, and announcing it
+			// here rather than re-applying it later is what keeps the announced mode and the mode the
+			// session runs on one fact (#7953).
+			const openedOn =
+				options.mode !== undefined && script.modes.available.includes(options.mode)
+					? options.mode
+					: current.mode;
 			yield* emit([
-				{kind: "mode", current: current.mode, available: script.modes.available},
+				{kind: "mode", current: openedOn, available: script.modes.available},
 				{kind: "model", current: current.model, available: script.models.available},
 				{kind: "commands", available: script.commands ?? []},
 				{kind: "thinking", current: current.thinking, available: script.thinking.available},
@@ -196,6 +205,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 			yield* Ref.update(state, (previous) => ({
 				...previous,
 				started: true,
+				mode: openedOn,
 				...(options.resume === undefined ? {} : {turn: script.resumeAtTurn ?? previous.turn}),
 			}));
 			return {sessionId: script.sessionId};

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -40,6 +40,17 @@ export interface StartOptions {
 	readonly cwd: string;
 	/** A session id an earlier run returned. Absent starts a new session. */
 	readonly resume?: string;
+	/**
+	 * The mode to open on, which is how a restored session keeps the operator's switch (#7953). A
+	 * layer holds its mode in its own build, so a rebuilt one holds none and would otherwise open on
+	 * the row's configured mode and announce that. Re-applying the mode after `started` landed would
+	 * leave a window in which the session runs on one mode and says another, which is the thing
+	 * #7828 closed — so it is handed over here, before the query exists.
+	 *
+	 * Absent means "whatever the layer would open on anyway". A layer that offers no modes ignores
+	 * it.
+	 */
+	readonly mode?: Mode;
 }
 
 export interface StartedSession {

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -526,6 +526,7 @@ const make = (
 		const start = Effect.fn("TuvalAiAgent.start")(function* (startOptions: {
 			readonly cwd: string;
 			readonly resume?: string;
+			readonly mode?: Mode;
 		}) {
 			const previous = yield* Ref.get(session);
 			// A second `start` is a reconnect, and it replaces the session whole: the previous
@@ -538,7 +539,10 @@ const make = (
 			yield* Ref.set(queue, out);
 			yield* emit(out, [{kind: "phase", phase: "starting"}]);
 
-			const held = yield* Ref.get(mode);
+			// The layer's own switch first, then the mode the caller says to open on. The Ref is per
+			// build, so on the rebuilt layer a reconnect stands up it is null and the caller's mode is
+			// the operator's — which is what carries a mode switch across a restart (#7953).
+			const held = (yield* Ref.get(mode)) ?? startOptions.mode ?? null;
 			// One stream carries everything (ruling 1, #7570), so a failed start owes it a terminal
 			// phase: without this every subscriber sits on `starting` for the life of the layer.
 			const opened = yield* open(startOptions.cwd, startOptions.resume, held).pipe(
@@ -560,8 +564,11 @@ const make = (
 			// raw `held`: `held` is null until an operator calls `setMode`, so a row carrying any
 			// non-default `permissionMode` would run on that mode and tell every subscriber it has
 			// none — a `current: null` beside a non-empty `available` is not a state `ModePayload`
-			// defines (#7828).
-			yield* emit(out, [{kind: "mode", current: openingMode(options, held) as Mode, available}]);
+			// defines (#7828). The Ref takes it too, so a later refused `setMode` re-announces the
+			// mode the session is really on rather than the null a rebuilt layer started from.
+			const openedOn = openingMode(options, held) as Mode;
+			yield* Ref.set(mode, openedOn);
+			yield* emit(out, [{kind: "mode", current: openedOn, available}]);
 			// The catalog is the session's, so it is read after the open. The announced model is the
 			// one the session is actually running: the query opened on the row's static `model`, so a
 			// model an operator picked before this open has to be re-applied here rather than merely

--- a/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
@@ -329,13 +329,14 @@ describe("the claude-session row, driven through ports and booted back over its 
 		).toEqual({current: SWITCHED_TO, available: OFFERED});
 	});
 
-	it("re-announces the mode the rebuilt layer opens on, which is not the operator's switch", () => {
-		// Stated rather than left unread: the checkpoint carries the switched mode, then the rebuilt
-		// layer's own `mode` event supersedes it, so the operator's live switch does not survive a
-		// restart. The layer resets its held mode on every build, which is true of `ClaudeAiAgent`
-		// too, and the fix is in the generic fold or the generic resume rule — out of this row's
-		// reach either way. https://github.com/kamp-us/phoenix/issues/7953
-		expect(outcome.second.modeAfterReconnect).toEqual({current: null, available: OFFERED});
+	it("brings the operator's mode switch back, announced by the layer the reconnect rebuilt", () => {
+		// The rebuilt layer holds no mode of its own, so this passes only because the reconnect hands
+		// it the checkpointed one to open on: its own `mode` event, which supersedes the republished
+		// checkpoint, already carries the switch (#7953).
+		expect(outcome.second.modeAfterReconnect).toEqual({
+			current: SWITCHED_TO,
+			available: OFFERED,
+		});
 	});
 
 	it("brings both processes back from the state directory, nothing fresh-booted", () => {

--- a/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
@@ -20,6 +20,7 @@ import {
 	initialState,
 	isAiAgentSessionState,
 } from "../../ai-agent/core/index.ts";
+import {Mode} from "../../ai-agent/ports/index.ts";
 import {checkpointFields, resumeMessages} from "../../ai-agent/restore/index.ts";
 import {
 	type AgentScript,
@@ -138,11 +139,15 @@ const apply = (
 ): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
 	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
 
+/** The mode the operator switched to before the app stopped, which the checkpoint carries. */
+const SWITCHED_TO = Mode.make("plan");
+
 /** A checkpoint as the store would hand one back: a session that was live when the app stopped. */
 const saved: AiAgentSessionState = {
 	...initialState(CWD),
 	phase: "prompting",
 	sessionId: SESSION,
+	modes: {current: SWITCHED_TO, available: [SWITCHED_TO]},
 };
 
 describe("what a claude-session checkpoint is made of", () => {
@@ -172,13 +177,15 @@ describe("a restored claude session before anything reconnects it", () => {
 		assert.deepStrictEqual(resumeMessages(state), [{type: "reconnect"}]);
 	});
 
-	it("enters reconnecting and asks for a republish and a resume by id", () => {
+	it("enters reconnecting and asks for a republish and a resume by id, on the saved mode", () => {
 		const [restored] = machine.init(saved, {});
 		const [state, cmds] = apply(restored, {type: "reconnect"});
 		assert.strictEqual(state.phase, "reconnecting");
 		assert.deepStrictEqual(cmds, [
 			{type: "aiAgent.republish"},
-			{type: "aiAgent.reconnect", cwd: CWD, sessionId: SESSION},
+			// The mode rides the Cmd rather than a later `setMode`: the rebuilt layer holds none, so
+			// it has to open on the operator's switch to announce it (#7953).
+			{type: "aiAgent.reconnect", cwd: CWD, sessionId: SESSION, mode: SWITCHED_TO},
 		]);
 	});
 });

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -345,6 +345,9 @@ const make = (
 			yield* Ref.set(pump, yield* Effect.forkIn(follow(ref.id, open), scope));
 			const offered = catalog.map(refOf);
 			yield* emit(open, [
+				// `StartOptions.mode` is ignored here, and this is the one layer where that is right:
+				// Pi offers no modes at this pin, so there is no operator switch for a rebuilt layer to
+				// lose and the checkpoint carries the same `null` back (#7953).
 				{kind: "mode", current: null, available: []},
 				{kind: "model", current: currentOf(offered, running), available: offered},
 				{kind: "thinking", current: thinking, available: levels},


### PR DESCRIPTION
A session the operator had switched to `plan` came back on the row's configured
`permissionMode` after a restart. The checkpoint carried the switch fine — the
reconnect then overwrote it, because a rebuilt layer holds no mode of its own and
announces the one it opened on, and that announcement lands after the republished
checkpoint.

The fix takes the issue's stated direction: hand the layer the mode to open on.
`StartOptions` grows an optional `mode`, both `aiAgent.start` and
`aiAgent.reconnect` carry `state.modes.current`, and the handler passes it into
`start`. So the layer's own `mode` event already says the operator's mode — there
is no window in which the session runs on one mode and reports another, which is
what #7828 closed for the first start.

Per layer:

- `ClaudeAiAgent` — its per-build `Ref<Mode | null>` falls back to
  `startOptions.mode`, and the resolved opening mode is written back to that Ref so
  a later refused `setMode` re-announces what the session is really on rather than
  the null a rebuilt layer started from.
- `ScriptedAiAgent` — its per-build state is seeded from the script, so a caller's
  mode that the script offers wins and is remembered.
- `PiAiAgent` — checked, and immune: Pi offers no modes at this pin, so its `mode`
  event is `{current: null, available: []}` and the checkpoint carries the same
  `null` back. A comment at the emit records the check.

The proof's assertion that pinned the old behaviour is flipped in place, not
duplicated, and `restore.unit.test.ts` gains the generic version of the same fact:
switch the mode, cut, restore, and the session comes back on the switch. Both fail
without the layer fix — I checked by reverting it.

## Repair round 1

The review's FAIL was real: the new generic test was intermittently red, roughly one
run in six. It was not the layer fix. The first boot of `runToTheCut` waited only for
`sessionId`, which lands with the `started` Msg the handler returns, while the layer's
opening `mode` event is still riding the events Sub. So the operator's `setMode` could
be overwritten by that late announcement, the checkpoint saved the overwrite, and the
resume had nothing to restore. Logged at a red run: the restored checkpoint read
`current: "normal"` and the reconnect faithfully carried `mode: "normal"` into `start`.

The wait now also requires `modes.available` to be non-empty, which is empty until that
opening event folds. The test also asserts the checkpoint and the reconnect's `start`
options alongside the restored mode, so a future red says which of the three sides broke.

`pnpm typecheck` is clean, and the whole `apps/tuval` unit project is green at this head
(180 files, 1564 tests) with `origin/main` merged in. The earlier body claimed 1582 tests
from a pre-merge run; that count was wrong.

Fixes #7953

## Deviations

- **Out-of-scope change** — **Said:** #7953 names the restore path. **Did:** also
  write the resolved opening mode back to `ClaudeAiAgent`'s mode `Ref`. **Why:**
  without it a `setMode` the CLI refuses after a resume would publish
  `current: null` beside a non-empty `available` — the exact state #7828 ruled out —
  because the Ref is still the null the rebuilt layer started from.
  **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** flip the one assertion in
  `claude-restore-proof.unit.test.ts`. **Did:** also changed the `saved` fixture in
  `claude-restore.unit.test.ts` and the `started(...)` state in the `reconnect` case
  of `machine.unit.test.ts` to carry a non-null mode. **Why:** both assert the
  reconnect Cmd exactly, and with the fixtures' `null` mode the new field would be
  asserted as `null` — true of the old behaviour too, so the assertion would prove
  nothing. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** add the new restore case.
  **Did:** in the repair round, also changed `runToTheCut`, the shared first-boot
  helper every case in `restore.unit.test.ts` runs through, to wait for the layer's
  opening announcement rather than for `sessionId` alone. **Why:** the old wait let a
  late `mode` event overwrite the operator's switch before the checkpoint was written,
  which made the new case flaky; the seven older cases are unaffected because they
  never touch the mode before the cut. **Disposition:** stated here.
- **Guard or gate bypassed** — **Said:** push through `fabrika build push`. **Did:**
  the verb reported `the remote ref did not move` three times, so I ran the same
  `git push --force-with-lease` by hand to read the hook's own output; that run passed
  its hooks and moved the ref, and `fabrika build push` then read the head back and
  reported `PUSH-VERDICT: MOVED`. **Why:** the verb swallows the pre-push hook's stderr,
  so nothing said which leg was failing. It was `apps/tuval/src/shell/program.unit.test.ts`
  timing out under CPU contention, a known flake (#8198, evidence added there) unrelated
  to this diff. **Disposition:** stated here; nothing was pushed with `--no-verify`.
