### PR TITLE
fix: A re-read Tuval config reaches no running process, so a changed permissionMode never applies live

### DIFF
--- a/.patterns/tuval-program-row-effects.md
+++ b/.patterns/tuval-program-row-effects.md
@@ -213,3 +213,39 @@ backend is still waiting on wedges, because the event that would clear it only a
 answered. The fix is a Cmd whose handler reads the committed state and emits the projections again,
 scheduled by the same Msg that resumes. It is the one handler that reads `ProcessSelf.state()`
 rather than folding forward, and the reason is that there is no event to fold.
+
+## A re-read config: what applies to a process that is already running
+
+A reload is not a restart. `Booted.reload` re-reads the layered config, swaps the spell registry and
+the key table, and then hands every live process what its own row says the new config means for it
+(#7509 ruling 3). Nothing respawns, and a process keeps running under the row it was spawned from.
+
+**The row declares what applies live, under `configChanged`, or the reload reaches it with nothing.**
+The field is `(next: AnyProgram) => ReadonlyArray<Msg>`
+([`registry/program.ts`](../apps/tuval/src/registry/program.ts)), read off the row a process is
+*running under* and handed the reloaded row of the same id. `claude-session` is the worked example:
+`configChanged(previous, next)` in [`claude/program.ts`](../apps/tuval/src/claude/program.ts) maps a
+changed `permissionMode` to one `setMode` and every other field to nothing, because
+`Query.setPermissionMode` is the one thing the SDK lets a running session change — the model and the
+tool list are `Options` of a query that is already open, and `cwd` never changes live at all.
+
+**A row that wants to diff its own settings has to publish them on itself.** The two generations meet
+in one call and a closure only holds one of them, so the other side has to be data: `claudeSession`
+returns a `ClaudeSessionProgram`, which is the generic row plus the decoded `settings` it runs on,
+and its `configChanged` narrows the row it is handed before reading them. Keep that field the user's
+own decoded config and nothing more — the kernel never reads it, and a row of another program that
+happens to share an id is refused by the narrowing rather than mis-diffed.
+
+**The kernel's half is one shared step, and it walks the process table.**
+[`reload.ts`](../apps/tuval/src/reload.ts)'s `dispatchConfigChanged` takes the generation the live
+processes were spawned from and the generation just read, and for each live process asks its row.
+Three cases dispatch nothing: a row with no `configChanged`, a row whose settings did not move, and a
+row the reloaded config no longer carries — that last process keeps running and is never told. The
+answer is a count, which rides out on `ReloadReport.notified`, and a dispatch that fails is logged
+rather than failing the reload: a reload is a read of the config, and one process refusing a Msg must
+not turn the whole re-read into a refusal.
+
+**The running generation is `boot`'s own, never the `Registry`.** The registry is built once at boot
+and a reload never rewrites it, so after the first reload it names rows no running process has seen a
+change against — the second reload would then re-send the first one's change. `boot` carries the
+generation in a `Ref` and swaps it as it dispatches, so each reload diffs against the one before it.

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -1,6 +1,6 @@
 import {homedir} from "node:os";
 import {join} from "node:path";
-import {type Context, Effect, type FileSystem, Layer} from "effect";
+import {type Context, Effect, type FileSystem, Layer, Ref} from "effect";
 import type {BindingError, BindingSource} from "./commands/bindings/index.ts";
 import {everyRegistered, SpellBridge} from "./commands/bridge/index.ts";
 import {helpSpells} from "./commands/core/index.ts";
@@ -24,6 +24,7 @@ import {ProcessTable} from "./process/ProcessTable.ts";
 import type {ProcessHandle} from "./process/process.ts";
 import type {AnyProgram} from "./registry/program.ts";
 import {Registry} from "./registry/Registry.ts";
+import {dispatchConfigChanged} from "./reload.ts";
 import type {ShellDispatch} from "./shell/commands/dispatch.ts";
 import {shellDispatchKernel, shellWindowIndexKernel} from "./shell/commands/kernel.ts";
 import {shellId} from "./shell/program.ts";
@@ -153,12 +154,18 @@ export interface BootReport {
 	readonly restoredCount: number;
 }
 
-/** What a reload replaced. The running processes are not among them; see `Booted.reload`. */
+/** What a reload replaced, and how many running processes it told. See `Booted.reload`. */
 export interface ReloadReport {
 	readonly sources: ReadonlyArray<string>;
 	readonly spellCount: number;
 	readonly bindingCount: number;
 	readonly bindingErrors: ReadonlyArray<BindingError>;
+	/**
+	 * Live processes handed a config change by their own row's `configChanged`. A row whose
+	 * settings did not move, one that applies nothing live, and one the reloaded config dropped
+	 * all leave their processes uncounted and untouched.
+	 */
+	readonly notified: number;
 }
 
 export interface Booted {
@@ -166,8 +173,9 @@ export interface Booted {
 	readonly kernel: Context.Context<Kernel>;
 	/**
 	 * The config read again, its spells registered and its bindings compiled against them in one
-	 * write. It replaces the spell registry and the binding table and nothing else: the processes
-	 * the first boot launched keep running under the program rows they were spawned from.
+	 * write, and then every live process handed what its own row says the new config means for it
+	 * (`reload.ts`). Nothing restarts and nothing respawns: a process keeps running under the row
+	 * it was spawned from, and what applies live is the row's own call (#7509 ruling 3).
 	 */
 	readonly reload: Effect.Effect<
 		ReloadReport,
@@ -200,20 +208,24 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 			started.launched.filter((process) => process.restored).length + started.restored.length,
 	};
 
+	// The generation the live processes are running under. `Registry` cannot answer this: it is
+	// built once at boot and a reload never rewrites it, so after the first reload it names rows
+	// no running process has seen a change against.
+	const generation = yield* Ref.make(programs);
+
 	const reload = Effect.fn("Tuval.reload")(function* () {
 		const next = yield* loadLayeredConfig(layers);
+		const rows = next.programs as ReadonlyArray<AnyProgram>;
 		const set = yield* SpellSet;
-		yield* set.reload({
-			core: coreSpells,
-			programs: next.programs as ReadonlyArray<AnyProgram>,
-			keys: next.keys,
-		});
+		yield* set.reload({core: coreSpells, programs: rows, keys: next.keys});
+		const notified = yield* dispatchConfigChanged(yield* Ref.getAndSet(generation, rows), rows);
 		const current = yield* set.read;
 		return {
 			sources: next.sources,
 			spellCount: current.table.rows.length,
 			bindingCount: current.bindings.bindings.length,
 			bindingErrors: current.bindings.errors,
+			notified,
 		} satisfies ReloadReport;
 	});
 

--- a/apps/tuval/src/claude/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/boundary.unit.test.ts
@@ -22,7 +22,8 @@ import type {AiAgentProgram} from "../ai-agent/program.ts";
 import type {TuvalAiAgent} from "../ai-agent/service/index.ts";
 import type {SpellBridge} from "../commands/bridge/index.ts";
 import type {PortSchema, Program} from "../registry/program.ts";
-import {claudeSession, claudeSessionLayer} from "./program.ts";
+import type {ClaudeSessionSettings} from "./config.ts";
+import {type ClaudeSessionProgram, claudeSession, claudeSessionLayer} from "./program.ts";
 
 /**
  * The row's four private types, read back off the program type it actually returns. Reading them
@@ -59,7 +60,15 @@ describe("what the row hands the factory", () => {
 
 describe("the row's own type", () => {
 	it("is the generic program type over SpellBridge, so no SDK type is reachable through it", () => {
-		expectTypeOf(claudeSession).returns.toEqualTypeOf<AiAgentProgram<SpellBridge>>();
+		expectTypeOf(claudeSession).returns.toEqualTypeOf<ClaudeSessionProgram>();
+		expectTypeOf<ClaudeSessionProgram>().toMatchTypeOf<AiAgentProgram<SpellBridge>>();
+	});
+
+	// The one field the row adds over the generic program (#7952). Pinned exactly, because it is
+	// what a reloaded row of the same id is diffed against: a Claude-shaped type reaching the row
+	// would reach it here first.
+	it("adds the decoded config and nothing else", () => {
+		expectTypeOf<ClaudeSessionProgram["settings"]>().toEqualTypeOf<ClaudeSessionSettings>();
 	});
 
 	it("carries the generic state, Msg, Cmd and Sub, which name nothing Claude-shaped", () => {

--- a/apps/tuval/src/claude/program.ts
+++ b/apps/tuval/src/claude/program.ts
@@ -26,7 +26,7 @@ import {type AiAgentProgram, aiAgentProgram} from "../ai-agent/program.ts";
 import type {TuvalAiAgent} from "../ai-agent/service/index.ts";
 import type {SpellBridge} from "../commands/bridge/index.ts";
 import type {Scope as SpellScope} from "../commands/spell.ts";
-import type {CapabilityRequest} from "../registry/program.ts";
+import type {AnyProgram, CapabilityRequest} from "../registry/program.ts";
 import {ClaudeAiAgent} from "./agent/index.ts";
 import {
 	type ClaudeSessionConfigInput,
@@ -89,22 +89,40 @@ export const claudeSessionLayer = (
 ): Layer.Layer<TuvalAiAgent, never, SpellBridge> =>
 	ClaudeAiAgent.layer(settings).pipe(Layer.provide(KernelBridge.live(scope)));
 
-export const claudeSession = (
-	options: ClaudeSessionProgramOptions,
-): AiAgentProgram<SpellBridge> => {
+/**
+ * The row, plus the decoded settings it runs on.
+ *
+ * `configChanged` is read off the row a process is *running under* and handed the reloaded row of
+ * the same id (`../registry/program.ts`), so the two generations' settings have to meet somewhere:
+ * one side is the closure below, and this field is the other. It is the user's own config as the
+ * row decoded it — the same data a config module wrote — and nothing in the kernel reads it.
+ */
+export interface ClaudeSessionProgram extends AiAgentProgram<SpellBridge> {
+	readonly settings: ClaudeSessionSettings;
+}
+
+const isClaudeSessionRow = (row: AnyProgram): row is ClaudeSessionProgram =>
+	row.id === CLAUDE_SESSION_PROGRAM && "settings" in row;
+
+export const claudeSession = (options: ClaudeSessionProgramOptions): ClaudeSessionProgram => {
 	const settings = claudeSessionSettings(options.claude ?? {});
-	return aiAgentProgram<SpellBridge>({
-		id: CLAUDE_SESSION_PROGRAM,
-		layer:
-			options.layer === undefined ? claudeSessionLayer(settings, options.scope) : options.layer,
-		config: {
-			cwd: options.cwd,
-			...(options.itemLimit === undefined ? {} : {itemLimit: options.itemLimit}),
-			...(options.byteLimit === undefined ? {} : {byteLimit: options.byteLimit}),
-		},
-		renderer: CLAUDE_CHAT_WINDOW_REF,
-		capabilities: CLAUDE_SESSION_CAPABILITIES,
-	});
+	return {
+		...aiAgentProgram<SpellBridge>({
+			id: CLAUDE_SESSION_PROGRAM,
+			layer:
+				options.layer === undefined ? claudeSessionLayer(settings, options.scope) : options.layer,
+			config: {
+				cwd: options.cwd,
+				...(options.itemLimit === undefined ? {} : {itemLimit: options.itemLimit}),
+				...(options.byteLimit === undefined ? {} : {byteLimit: options.byteLimit}),
+			},
+			renderer: CLAUDE_CHAT_WINDOW_REF,
+			capabilities: CLAUDE_SESSION_CAPABILITIES,
+		}),
+		settings,
+		configChanged: (next) =>
+			isClaudeSessionRow(next) ? configChanged(settings, next.settings) : [],
+	};
 };
 
 /**
@@ -116,10 +134,10 @@ export const claudeSession = (
  * spawn; `cwd` never changes live at all.
  *
  * `config-changed` is in no Msg list on the generic core (#7601) and `aiAgentProgram` offers no
- * seam for a row-level Msg, so this is the mapping as a pure function the reload path calls: it
- * writes nothing under `src/ai-agent/` and nothing here has to know how the reload is delivered.
- * The kernel does not deliver one yet
- * ([#7952](https://github.com/kamp-us/phoenix/issues/7952)), so this has no caller.
+ * seam for a row-level Msg, so this stays the mapping as a pure function: it writes nothing under
+ * `src/ai-agent/` and nothing here has to know how the reload is delivered. The row's
+ * `configChanged` field is what calls it, and `Booted.reload` is what dispatches its answer
+ * (`../reload.ts`, #7952).
  */
 export const configChanged = (
 	previous: ClaudeSessionSettings,

--- a/apps/tuval/src/config-fixtures/reloadable-claude.ts
+++ b/apps/tuval/src/config-fixtures/reloadable-claude.ts
@@ -1,0 +1,94 @@
+/**
+ * The config-change dispatch proof's config layer: one `claude-session` row over
+ * `ScriptedAiAgent`, plus a second row that declares no `configChanged` at all.
+ *
+ * What each generation holds is read at import out of the JSON file
+ * `TUVAL_CLAUDE_RELOAD_FIXTURE` names, exactly as `./reloadable.ts` reads its own — so rewriting
+ * that file and loading the config again is a genuine config change, and the module itself stays
+ * put. `other` is here so a reload can be watched *not* reaching a process, and `drop` leaves the
+ * claude row out entirely, which is the generation a running process has no replacement row in.
+ */
+
+import {readFileSync} from "node:fs";
+import {defineMachine} from "@demlik/tea";
+import {Effect} from "effect";
+import {Mode} from "../ai-agent/ports/index.ts";
+import {ScriptedAiAgent} from "../ai-agent/service/index.ts";
+import type {AgentScript} from "../ai-agent/service/script.ts";
+import type {ClaudeSessionConfigInput} from "../claude/config.ts";
+import {CLAUDE_SESSION_PROGRAM, claudeSession} from "../claude/program.ts";
+import type {TuvalConfigInput} from "../config.ts";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
+
+/** One generation of the fixture: the `claude` block, or the row's absence. */
+export interface DeclaredClaudeConfig {
+	readonly claude: ClaudeSessionConfigInput;
+	readonly drop?: boolean;
+}
+
+export const CWD = "/repo";
+export const AGENT_NODE = "agent";
+export const OTHER_NODE = "other";
+export const OTHER_PROGRAM = "other-session";
+
+/** The four modes the `claude-session` row advertises, so any of them is an admissible `setMode`. */
+const script: AgentScript = {
+	sessionId: "session-7952",
+	history: [],
+	modes: {
+		current: Mode.make("default"),
+		available: ["default", "acceptEdits", "plan", "auto"].map((value) => Mode.make(value)),
+	},
+	models: {current: null, available: []},
+	thinking: {current: null, available: []},
+	interrupt: [],
+	turns: [],
+};
+
+type State = {readonly seen: number};
+type Msg = {readonly type: "tick"};
+type Notify = {readonly type: "notify"};
+
+/** A row with no `configChanged`: the reload walks past it whatever the config did. */
+const other: AnyProgram = {
+	id: ProgramId.make(OTHER_PROGRAM),
+	core: defineMachine<State, Msg, Notify, never, unknown>({
+		init: (loaded) => [loaded ?? {seen: 0}, []],
+		update: {tick: (state) => [{seen: state.seen + 1}, []]},
+		interpret: {notify: () => Promise.resolve()},
+	}),
+	ports: {},
+	handlers: {notify: () => Effect.succeed([] as ReadonlyArray<Msg>)},
+	capabilities: [],
+	identity: {
+		package: "@kampus/tuval",
+		program: OTHER_PROGRAM,
+		version: "1.0.0",
+		digest: `sha256:${OTHER_PROGRAM}`,
+	},
+	placement: {host: "local"},
+} satisfies Program<State, Msg, Notify, never, unknown, never, never>;
+
+const declared = JSON.parse(
+	readFileSync(process.env.TUVAL_CLAUDE_RELOAD_FIXTURE ?? "", "utf8"),
+) as DeclaredClaudeConfig;
+
+const claudeRow = claudeSession({
+	cwd: CWD,
+	claude: declared.claude,
+	layer: ScriptedAiAgent.layer(script),
+});
+
+export default {
+	version: 1,
+	programs: declared.drop === true ? [other] : [claudeRow, other],
+	graph: {
+		nodes:
+			declared.drop === true
+				? [{id: OTHER_NODE, program: OTHER_PROGRAM, on: []}]
+				: [
+						{id: AGENT_NODE, program: CLAUDE_SESSION_PROGRAM, on: []},
+						{id: OTHER_NODE, program: OTHER_PROGRAM, on: []},
+					],
+	},
+} satisfies TuvalConfigInput;

--- a/apps/tuval/src/registry/program.ts
+++ b/apps/tuval/src/registry/program.ts
@@ -179,6 +179,18 @@ export interface Program<
 	 */
 	readonly resume?: (state: S) => ReadonlyArray<M>;
 	/**
+	 * What the kernel dispatches into every live process of this program when the config is re-read
+	 * and this row's replacement carries different settings (#7509 ruling 3).
+	 *
+	 * Read off the row a process is *running under*, and handed the reloaded row of the same id —
+	 * so a row that wants to diff its own settings has to publish them on itself, as
+	 * `claudeSession` publishes `settings` (`../claude/program.ts`). Pure and total: a row that
+	 * applies nothing live answers with an empty list, and the kernel never reads what the Msgs
+	 * mean. A row the reloaded config dropped is never asked, so its processes keep running under
+	 * the row they were spawned from.
+	 */
+	readonly configChanged?: (next: AnyProgram) => ReadonlyArray<M>;
+	/**
 	 * Whether this program could restore the raw checkpoint durability loaded for it — the same
 	 * verdict its `init` reaches, asked before `init` runs.
 	 *

--- a/apps/tuval/src/reload-dispatch.unit.test.ts
+++ b/apps/tuval/src/reload-dispatch.unit.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The delivery half of a config reload (#7952, #7509 ruling 3): a re-read config reaches the
+ * processes that are already running, through the row's own `configChanged`.
+ *
+ * The whole proof drives the real `Booted.reload`, in the shape `./reload-proof.unit.test.ts` uses
+ * — the config layer is `config-fixtures/reloadable-claude.ts`, whose generation is read out of a
+ * JSON file this test rewrites between loads, so a second load is a genuinely different config.
+ * Nothing here reaches into the dispatch: it reads the mode the live session ended up in.
+ */
+
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, type FileSystem, type Scope} from "effect";
+import {afterEach} from "vitest";
+import {type AiAgentSessionState, isAiAgentSessionState} from "./ai-agent/core/index.ts";
+import {Mode} from "./ai-agent/ports/index.ts";
+import {type Booted, boot, projectDir} from "./boot.ts";
+import type {DeclaredClaudeConfig} from "./config-fixtures/reloadable-claude.ts";
+import {ProcessTable} from "./process/ProcessTable.ts";
+import {ProcessId} from "./process/process.ts";
+
+const layer = fileURLToPath(new URL("./config-fixtures/reloadable-claude.ts", import.meta.url));
+
+const AGENT = ProcessId.make("agent");
+
+const tempDirs: string[] = [];
+const freshDir = (prefix: string) => {
+	const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+	tempDirs.push(dir);
+	return dir;
+};
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, {recursive: true, force: true});
+	delete process.env.TUVAL_CLAUDE_RELOAD_FIXTURE;
+});
+
+const declare = (path: string, config: DeclaredClaudeConfig) =>
+	writeFileSync(path, JSON.stringify(config));
+
+/** A booted app over the claude layer, its fixture file already holding `first`. */
+const bootClaude = Effect.fnUntraced(function* (first: DeclaredClaudeConfig) {
+	const project = freshDir("tuval-claude-reload-");
+	mkdirSync(join(projectDir(project), "processes"), {recursive: true});
+	const declaration = join(freshDir("tuval-claude-declared-"), "config.json");
+	declare(declaration, first);
+	process.env.TUVAL_CLAUDE_RELOAD_FIXTURE = declaration;
+	const booted = yield* boot({global: layer, project});
+	return {booted, declaration};
+});
+
+const sessionOf = (booted: Booted) =>
+	ProcessTable.use((table) => table.get(AGENT)).pipe(
+		Effect.map((row) => {
+			const state = row.stateSummary().state;
+			assert.isTrue(isAiAgentSessionState(state), "the agent process holds no session state");
+			return state as AiAgentSessionState;
+		}),
+		Effect.provideContext(booted.kernel),
+	);
+
+/** A spent budget asserts rather than falling through, so a timeout names itself. */
+const until = (
+	booted: Booted,
+	what: string,
+	check: (session: AiAgentSessionState) => boolean,
+): Effect.Effect<AiAgentSessionState, never, never> =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 400; attempt += 1) {
+			const session = yield* sessionOf(booted);
+			if (check(session)) return session;
+			yield* Effect.sleep("5 millis");
+		}
+		return assert.fail(`timed out after 2s waiting for ${what}`);
+	}).pipe(Effect.orDie);
+
+/**
+ * The session has to be live before a `setMode` is admissible, and it has to have folded the mode
+ * its layer advertises — `ready` commits before that event lands, so a mode read at `ready` alone
+ * is still `null` and no later mode could be told apart from it.
+ */
+const readySession = (booted: Booted) =>
+	until(
+		booted,
+		"the spawned claude session to reach ready and fold its mode",
+		(session) => session.phase === "ready" && session.modes.current !== null,
+	);
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Scope.Scope>) =>
+	effect.pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
+
+describe("a config reload over live processes", () => {
+	it.live("hands a running claude session the new permissionMode, as one setMode", () =>
+		run(
+			Effect.gen(function* () {
+				const {booted, declaration} = yield* bootClaude({claude: {permissionMode: "default"}});
+				const before = yield* readySession(booted);
+				assert.strictEqual(
+					before.modes.current,
+					Mode.make("default"),
+					"the scripted session did not open in the mode its script names",
+				);
+
+				declare(declaration, {claude: {permissionMode: "plan"}});
+				const report = yield* booted.reload;
+
+				assert.strictEqual(report.notified, 1, "the reload told the wrong number of processes");
+				const after = yield* until(
+					booted,
+					"the reload's setMode to reach the session",
+					(session) => session.modes.current === Mode.make("plan"),
+				);
+				assert.isNull(after.failure, "the session refused the mode the reload sent it");
+			}),
+		),
+	);
+
+	it.live("tells nobody when no row moved, and nobody when only a next-spawn field moved", () =>
+		run(
+			Effect.gen(function* () {
+				const {booted, declaration} = yield* bootClaude({claude: {permissionMode: "acceptEdits"}});
+				const opened = yield* readySession(booted);
+
+				const unchanged = yield* booted.reload;
+				assert.strictEqual(unchanged.notified, 0, "an unchanged config still told a process");
+
+				declare(declaration, {
+					claude: {
+						permissionMode: "acceptEdits",
+						model: "claude-opus-5",
+						allowedTools: ["mcp__tuval__read"],
+					},
+				});
+				const nextSpawnOnly = yield* booted.reload;
+				assert.strictEqual(nextSpawnOnly.notified, 0, "a model or tool change was sent live");
+
+				const session = yield* sessionOf(booted);
+				assert.strictEqual(
+					session.modes.current,
+					opened.modes.current,
+					"the live mode moved with no setMode behind it",
+				);
+			}),
+		),
+	);
+
+	it.live("leaves a process whose row the reloaded config dropped running and untold", () =>
+		run(
+			Effect.gen(function* () {
+				const {booted, declaration} = yield* bootClaude({claude: {permissionMode: "default"}});
+				const opened = yield* readySession(booted);
+
+				declare(declaration, {claude: {permissionMode: "plan"}, drop: true});
+				const report = yield* booted.reload;
+
+				assert.strictEqual(report.notified, 0, "a dropped row's process was still told");
+				const session = yield* sessionOf(booted);
+				assert.strictEqual(session.phase, "ready", "the process did not survive the reload");
+				assert.strictEqual(
+					session.modes.current,
+					opened.modes.current,
+					"a dropped row still applied live",
+				);
+			}),
+		),
+	);
+});

--- a/apps/tuval/src/reload.ts
+++ b/apps/tuval/src/reload.ts
@@ -1,0 +1,55 @@
+/**
+ * The delivery half of a config reload: hand every live process the Msgs its own row says a
+ * re-read config means for it (`registry/program.ts`'s `configChanged`, #7509 ruling 3).
+ *
+ * It sits beside `boot.ts` rather than in either slice because it is the one place the two
+ * generations of program rows meet: `Booted.reload` holds the config it just read, and the
+ * processes it walks were spawned from the one before it. The `Registry` is not that pair — it
+ * still holds the boot generation after any number of reloads, which is exactly why the running
+ * generation is carried through `boot`'s own closure instead.
+ *
+ * A dispatch that fails is logged and the walk goes on: a reload is a read of the config, and one
+ * process refusing a Msg must not turn it into a refusal of the whole re-read.
+ */
+
+import {Effect, Option} from "effect";
+import {Processes} from "./process/Processes.ts";
+import {ProcessTable} from "./process/ProcessTable.ts";
+import type {Message} from "./process/process.ts";
+import type {AnyProgram, ProgramId} from "./registry/program.ts";
+
+const byId = (rows: ReadonlyArray<AnyProgram>): ReadonlyMap<ProgramId, AnyProgram> =>
+	new Map(rows.map((row) => [row.id, row]));
+
+/**
+ * Answers how many live processes were handed a change, which is what `ReloadReport` carries: a
+ * reload that moved no row a process is running under answers zero.
+ */
+export const dispatchConfigChanged = (
+	previous: ReadonlyArray<AnyProgram>,
+	next: ReadonlyArray<AnyProgram>,
+): Effect.Effect<number, never, ProcessTable | Processes> =>
+	Effect.gen(function* () {
+		const table = yield* ProcessTable;
+		const processes = yield* Processes;
+		const running = byId(previous);
+		const reloaded = byId(next);
+		let notified = 0;
+		for (const row of yield* table.list) {
+			const spawnedFrom = running.get(row.programId);
+			const replacement = reloaded.get(row.programId);
+			if (spawnedFrom?.configChanged === undefined || replacement === undefined) continue;
+			const messages = spawnedFrom.configChanged(replacement) as ReadonlyArray<Message>;
+			if (messages.length === 0) continue;
+			const handle = yield* processes.handle(row.id);
+			if (Option.isNone(handle)) continue;
+			// Serial: a row's answer is an ordered list, and dispatching it in parallel would apply
+			// two of one process's Msgs in whichever order the fibers happened to win.
+			yield* Effect.forEach(messages, handle.value.dispatch, {
+				concurrency: 1,
+				discard: true,
+			}).pipe(Effect.catch((error) => Effect.logError(error)));
+			notified += 1;
+		}
+		return notified;
+	}).pipe(Effect.withSpan("Tuval.reload.dispatchConfigChanged"));


### PR DESCRIPTION
Fixes #7952

`Booted.reload` re-read the config, swapped the spell registry and the key table, and told no
running process anything. So `configChanged` in `apps/tuval/src/claude/program.ts` — the mapping
that turns a changed `permissionMode` into a live `setMode` — had no caller, and a founder editing
`permissionMode` while a Claude session was open saw nothing change.

This builds the delivery seam #7509 ruling 3 names, in two halves that meet in the middle.

**The row half.** `Program` grows an optional `configChanged: (next: AnyProgram) => ReadonlyArray<Msg>`,
read off the row a process is *running under* and handed the reloaded row of the same id — the same
shape `resume` already has. `claudeSession` now returns a `ClaudeSessionProgram`: the generic row plus
the decoded `settings` it runs on, so the two generations' settings have somewhere to meet (a closure
only holds one of them). Its `configChanged` narrows the row it is handed and calls the existing pure
mapping, which is unchanged. Nothing was written under `apps/tuval/src/ai-agent/`.

**The kernel half.** `apps/tuval/src/reload.ts` walks the process table and asks each live process's
row. Three cases dispatch nothing: a row with no `configChanged`, a row whose settings did not move,
and a row the reloaded config no longer carries — that last process keeps running and is never told.
The count rides out on `ReloadReport.notified`. `boot` carries the running generation in a `Ref` and
swaps it as it dispatches, because the `Registry` is built once at boot and never rewritten, so after
one reload it would name rows no running process has seen a change against.

`apps/tuval/src/reload-dispatch.unit.test.ts` drives the real `Booted.reload` over a config layer
whose generation is read out of a JSON file the test rewrites between loads, in the shape
`reload-proof.unit.test.ts` uses. It watches a live `claude-session` process reach the new mode, and
watches the three no-op cases stay at zero.

Reviewer's first stop: `apps/tuval/src/reload.ts` — whether the previous/next pair it diffs is the
right pair, and whether logging a failed dispatch rather than failing the reload is the right call.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #7952 names `claude/program.ts`, the reload
  path, and the pattern doc. **Did:** also updated the exact type pin in
  `apps/tuval/src/claude/boundary.unit.test.ts`, which asserted `claudeSession` returns exactly
  `AiAgentProgram<SpellBridge>`. **Why:** the row now returns that type plus one `settings` field, so
  the old pin is false by construction. **Disposition:** the pin is kept exact on the new type, and a
  second exact pin was added on `ClaudeSessionProgram["settings"]` so the one added field is named
  rather than waved through; the assignability pin to `AiAgentProgram<SpellBridge>` still holds the
  "no SDK type reachable" line.
- **Out-of-scope change** — **Said:** the ticket scopes the reload dispatch. **Did:** `ReloadReport`
  grew a `notified` count. **Why:** the acceptance criteria include three cases that dispatch
  *nothing*, and proving a negative off process state alone is weak; a count the reload itself
  reports is the direct observation. **Disposition:** stated here.
