### PR TITLE
feat(tuval): the agy presentation leaf — renderer-ref plus a thin AgyChatWindow

### DIFF
--- a/apps/tuval/src/agy/renderer-ref.ts
+++ b/apps/tuval/src/agy/renderer-ref.ts
@@ -1,0 +1,28 @@
+/**
+ * The `agy-session` row's two names — its program id and its renderer reference — as a leaf both
+ * ends can import.
+ *
+ * Same split as `../pi/renderer-ref.ts`, for the same reason: the row is kernel-side and drives the
+ * `agy` CLI over a subprocess, the renderer is browser-side and must reach none of that, so the two
+ * names they share live alone in a file that imports one type.
+ *
+ * It sits beside the row rather than inside `./window/`, because the strict lens is `composite` and
+ * must list every file it compiles: `./window/` is excluded from it whole (it imports
+ * `@kampus/design`, which needs the relaxed lens of `tsconfig.design.json`), and a file the row
+ * imports out of an excluded directory is a `TS6307` on every build.
+ */
+
+import type {RendererRef} from "../registry/program.ts";
+
+/**
+ * The row's program id. It is declared here rather than on the row for the reason `../pi`'s twin
+ * documents: importing it from the row would pull the agy subprocess and the whole kernel-side row
+ * into the browser bundle, which is the failure #7836 closed. The row re-exports it, so there is
+ * one declaration and nothing can name two different programs.
+ */
+export const AGY_SESSION_PROGRAM = "agy-session";
+
+export const AGY_CHAT_WINDOW_REF: RendererRef = {
+	kind: "host-native",
+	ref: "tuval/agy-chat-window",
+};

--- a/apps/tuval/src/agy/window/AgyChatWindow.tsx
+++ b/apps/tuval/src/agy/window/AgyChatWindow.tsx
@@ -1,0 +1,75 @@
+/**
+ * `AgyChatWindow` — what the `agy-session` row renders: the shared `ChatWindow` plus agy's one
+ * extra.
+ *
+ * Shaped on `../../pi/window/PiChatWindow.tsx`, which is epic #8162's scope call: agy follows
+ * `src/pi/` and not `src/claude/`. Nothing here re-derives a transcript, a composer or a control —
+ * the window is `../../shell/chat/`'s, and this module supplies its `extras` slot with a usage line
+ * read straight off the session state.
+ *
+ * Two things are deliberate and not obvious.
+ *
+ * **The line reads state, it does not accumulate.** `usage` is the core's own running total
+ * (`../../ai-agent/core/state.ts`), checkpointed with the rest of the session, so two windows over
+ * one process show one figure and a restart shows the figure it left on. There is no counter here,
+ * and this file never sees an agy wire event: what fills `UsageTotals` is the mapper's business.
+ *
+ * **It is not a live region.** Cost and token counts move on every usage event of a running turn,
+ * and a `role="status"` here would narrate the whole turn to a screen-reader user. It is a named
+ * `group` of plain text instead: reachable on demand, silent while it changes.
+ */
+
+import {MetaRow} from "@kampus/design";
+import type {ReactElement} from "react";
+import type {UsageTotals} from "../../ai-agent/core/index.ts";
+import type {ChatWindowOptions, ChatWindowRenderer} from "../../shell/chat/index.ts";
+import {chatWindow} from "../../shell/chat/index.ts";
+import "./agy-window.css";
+
+/**
+ * `UsageTotals.cost` is a currency amount by the field's own contract — whoever fills it does the
+ * scaling, as Pi's adapter does. Four fraction digits for Pi's reason: a single turn routinely costs
+ * well under a cent, and a session that reads `$0.00` after ten turns says nothing.
+ */
+const money = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	minimumFractionDigits: 2,
+	maximumFractionDigits: 4,
+});
+
+const tokens = new Intl.NumberFormat("en-US");
+
+/** Before the first usage event the session has no model to name, and says so rather than blanking. */
+const NO_MODEL_YET = "no model yet";
+
+/**
+ * The model, the cumulative cost and the token counts of this session.
+ *
+ * Every number carries visible text beside it, because a bare number names nothing to a screen
+ * reader (`.patterns/manti-accessibility.md`); the group's own label is what a reader jumps to.
+ */
+export function UsageLine({usage}: {readonly usage: UsageTotals}): ReactElement {
+	return (
+		<MetaRow className="tuval-agy-usage" role="group" aria-label="Session usage">
+			<span className="tuval-agy-usage-model">{usage.model ?? NO_MODEL_YET}</span>
+			<MetaRow.Dot />
+			<span>{money.format(usage.cost)}</span>
+			<MetaRow.Dot />
+			<span>{tokens.format(usage.inputTokens)} in</span>
+			<MetaRow.Dot />
+			<span>{tokens.format(usage.outputTokens)} out</span>
+		</MetaRow>
+	);
+}
+
+/**
+ * The agy renderer at whatever window options a caller needs. `extras` is fixed rather than merged:
+ * it is the one thing this binding exists to add, and a caller overriding it would be asking for
+ * the shared window under agy's name.
+ */
+export const agyChatWindow = (options: ChatWindowOptions = {}): ChatWindowRenderer =>
+	chatWindow({...options, extras: (state) => <UsageLine usage={state.usage} />});
+
+/** The renderer `AGY_CHAT_WINDOW_REF` names, at its defaults: what a page's renderer table binds. */
+export const AgyChatWindow: ChatWindowRenderer = agyChatWindow();

--- a/apps/tuval/src/agy/window/agy-window.css
+++ b/apps/tuval/src/agy/window/agy-window.css
@@ -1,0 +1,20 @@
+/*
+ * The usage line's own tuning, and nothing else.
+ *
+ * `MetaRow` owns the row: its gap, its `--t-body-sm` type role and its `--text-muted` colour are the
+ * primitive's (`packages/design/src/MetaRow.css`), and re-declaring any of them here would be the
+ * hand-laid meta row `design-system-manifest.md` forbids. What is left is where the line sits in the
+ * chat bar, which is this surface's own divergence and belongs on this paired class.
+ *
+ * The line carries no colour, no size and no separator of its own. It renders dark because the
+ * window it mounts in is (`../../shell/chat/chat.css` sets `color-scheme: dark` on `.tuval-chat`),
+ * not because anything here says so.
+ */
+
+.tuval-agy-usage {
+	/* Shrink before the mode switch does, and wrap rather than push it off the end of the bar —
+	   `MetaRow` already wraps, so a narrow window gets a second line instead of a clipped model. */
+	flex: 0 1 auto;
+	min-inline-size: 0;
+	justify-content: flex-end;
+}

--- a/apps/tuval/src/agy/window/boundary.unit.test.ts
+++ b/apps/tuval/src/agy/window/boundary.unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The boundaries this slice keeps: what it may import, and what host it may be handed.
+ *
+ * Half the proof is `tsc` over this file — every `=` probe below is a claim on the right of an
+ * assignment, flip-verified per `.patterns/unconditional-test-assertions.md`, "the type-level
+ * sibling". The other half is the textual scan, which is the only thing that catches an import
+ * added later by a builder who never read this file.
+ *
+ * The scan matters more here than on `../../pi/window/`'s twin, because the rest of `../` does not
+ * exist yet: this leaf lands in epic #8162's first phase, and the wire decoder, the subprocess and
+ * the layer arrive in later slices. Naming them forbidden now is what keeps a later slice from
+ * reaching back into the window instead of into the mapper.
+ */
+
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {ChatView, ChatWindowRenderer} from "../../shell/chat/index.ts";
+import type {AnyWindowRenderer, WindowHost, WindowRenderer} from "../../shell/window/index.ts";
+import {AGY_CHAT_WINDOW_REF} from "../renderer-ref.ts";
+
+type CounterState = {readonly count: number};
+type CounterMsg = {readonly type: "tick"};
+
+const matching: ChatWindowRenderer = {
+	kind: "host-native",
+	render: (host: WindowHost<AiAgentSessionState, AiAgentSessionMsg, ChatView>) => host.windowId,
+};
+
+const anotherProgram: ChatWindowRenderer = {
+	kind: "host-native",
+	// @ts-expect-error — a host over another program's state cannot serve the agy window.
+	render: (host: WindowHost<CounterState, CounterMsg, ChatView>) => host.windowId,
+};
+
+/**
+ * `AgyChatWindow` is the window contract's own type at the shared session's parameters, not a
+ * lookalike. The probe reads `AnyWindowRenderer` because `WindowRenderer`'s defaults are the
+ * *erased* host and `render` is contravariant in it — a renderer over this program's host is
+ * deliberately not assignable to one over `WindowHost<unknown, …>`.
+ */
+const isWindowRenderer: ChatWindowRenderer extends AnyWindowRenderer ? true : false = true;
+const isTheSharedRenderer: ChatWindowRenderer extends WindowRenderer<
+	unknown,
+	AiAgentSessionState,
+	AiAgentSessionMsg,
+	ChatView
+>
+	? true
+	: false = true;
+
+const sourceFiles = (): ReadonlyArray<readonly [string, string]> => {
+	const dir = import.meta.dirname;
+	return readdirSync(dir)
+		.filter((name) => /\.tsx?$/.test(name))
+		.filter((name) => !name.includes(".test.") && !name.endsWith(".testing.ts"))
+		.map((name) => [name, readFileSync(join(dir, name), "utf8")] as const);
+};
+
+const specifiers = (source: string): ReadonlyArray<string> =>
+	[...source.matchAll(/from\s+"([^"]+)"/g), ...source.matchAll(/^import\s+"([^"]+)"/gm)].map(
+		(match) => match[1] ?? "",
+	);
+
+describe("the agy window boundary", () => {
+	it("resolves at the shared session's own host shape and nothing else", () => {
+		expect([matching.kind, anotherProgram.kind]).toEqual(["host-native", "host-native"]);
+		expect(isWindowRenderer).toBe(true);
+		expect(isTheSharedRenderer).toBe(true);
+	});
+
+	it("imports no subprocess, no agy wire, no agy client or server and no agent layer", () => {
+		const forbidden = [
+			/\/wire\//,
+			/\/server\//,
+			/\/client\//,
+			/\/process\//,
+			/agy\/ai-agent\//,
+			/^\.\.\/ai-agent\//,
+			/^\.\.\/program\.ts$/,
+			/^\.\.\/config\.ts$/,
+			/ai-agent\/service\//,
+			/ai-agent\/handlers\//,
+			/^ws$/,
+			/^node:/,
+			/^execa$/,
+			/@earendil-works/,
+			/@anthropic-ai/,
+			/@google\//,
+			/fate/,
+		];
+		const offenders = sourceFiles().flatMap(([name, source]) =>
+			specifiers(source)
+				.filter((specifier) => forbidden.some((pattern) => pattern.test(specifier)))
+				.map((specifier) => `${name}: ${specifier}`),
+		);
+		expect(offenders).toEqual([]);
+	});
+
+	it("keeps the row's renderer reference on a leaf that pulls in no window code", () => {
+		const leaf = readFileSync(join(import.meta.dirname, "..", "renderer-ref.ts"), "utf8");
+		expect(specifiers(leaf)).toEqual(["../registry/program.ts"]);
+		expect(AGY_CHAT_WINDOW_REF.kind).toBe("host-native");
+	});
+});

--- a/apps/tuval/src/agy/window/index.ts
+++ b/apps/tuval/src/agy/window/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The agy window as a page's renderer table imports it. Importing this pulls React, the shared chat
+ * window and `@kampus/design` — and nothing of agy's own: no subprocess, no wire decoder, no
+ * `../ai-agent/`. `boundary.unit.test.ts` holds that.
+ *
+ * The name the row declares lives one directory up (`../renderer-ref.ts`) and is re-exported here,
+ * so a page's renderer table reads the reference and the renderer from one import while the
+ * kernel-side row still reaches none of the above.
+ */
+
+export {AGY_CHAT_WINDOW_REF} from "../renderer-ref.ts";
+export {AgyChatWindow, agyChatWindow, UsageLine} from "./AgyChatWindow.tsx";

--- a/apps/tuval/tsconfig.design.json
+++ b/apps/tuval/tsconfig.design.json
@@ -19,6 +19,7 @@
 		"src/shell/chat",
 		"src/pi/window",
 		"src/claude/window",
+		"src/agy/window",
 		"src/page/main.tsx",
 		"src/page/boot.tsx",
 		"src/page/AttachedDesk.tsx",

--- a/apps/tuval/tsconfig.json
+++ b/apps/tuval/tsconfig.json
@@ -31,14 +31,15 @@
 	// `src/page/` is split rather than excluded whole: the three React modules reach the chat window
 	// through the page's renderer table (#7573) and go to the other lens, while `dev-server.ts` is
 	// Node-side, is imported by `src/bin.ts`, and stays here.
-	// `src/pi/renderer-ref.ts` and `src/claude/renderer-ref.ts` still enter this project by import
-	// from their rows, which is the point of those leaves: a row names its renderer without reaching
-	// any of it.
+	// `src/pi/renderer-ref.ts`, `src/claude/renderer-ref.ts` and `src/agy/renderer-ref.ts` still
+	// enter this project by import from their rows, which is the point of those leaves: a row names
+	// its renderer without reaching any of it.
 	"exclude": [
 		"node_modules",
 		"src/shell/chat",
 		"src/pi/window",
 		"src/claude/window",
+		"src/agy/window",
 		"src/page/main.tsx",
 		"src/page/boot.tsx",
 		"src/page/AttachedDesk.tsx",


### PR DESCRIPTION
Closes #8180

The agy presentation leaf: `renderer-ref.ts` (`AGY_SESSION_PROGRAM` + `AGY_CHAT_WINDOW_REF`) and a thin `AgyChatWindow` over the shared `shell/chat`, following `src/pi/window/`.

Pi-shaped as the founder decision on #8162 requires — no `tools/`, no `KernelBridge`/`SpellBridge`, no `scope`. Nothing imports `agy/ai-agent/`; `src/page/renderers.tsx` is untouched (that wiring line is #8184's).

The usage line is a `MetaRow` with `role="group"` and `aria-label="Session usage"`, deliberately **not** a live region — token counts move on every usage event of a running turn, and a status role would narrate the whole turn to a screen-reader user. Same reasoning as the pi and claude windows.

## Verification

- `pnpm typecheck` — 0 errors across all three lenses; `tsc -p tsconfig.design.json --listFiles` confirms all four agy files enter the relaxed lens
- `pnpm test:unit` — 179 files / 1543 tests pass
- `pnpm lint` clean; `fabrika build check --surface code` green
- the window boundary scan is **flip-verified, not assumed**: appending `import "node:fs";` to `window/index.ts` reddened it with `['index.ts: node:fs']`, then the line was removed and it re-greened

## Deviations

Disclosed at https://github.com/kamp-us/phoenix/issues/8180#issuecomment-5556890655 — `agy-window.css` plus two tsconfig lens rows, neither named in the issue's file list. Both are load-bearing for the three-lens typecheck criterion the issue itself states: without the lens rows the design-lens `@kampus/design` import fails the strict composite lens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)