### PR TITLE
feat(tuval): the agy wire mapper — NDJSON to AgentEvent, open enums failing closed

### DIFF
--- a/apps/tuval/src/agy/ai-agent/fixtures.ts
+++ b/apps/tuval/src/agy/ai-agent/fixtures.ts
@@ -1,0 +1,53 @@
+/**
+ * Captured agy v1.1.27 stream lines, verbatim apart from one substitution: the invoking user's
+ * home directory reads `/Users/founder`, so no real home path lands in the repo.
+ *
+ * Every line below came off a live run of
+ * `agy --input-format=stream-json --output-format=stream-json --print='' --model=gemini-3.8-flash-low
+ * --sandbox --add-dir=<dir>` — which is what makes them evidence rather than a guess about a wire
+ * that ships no schema and no version field.
+ */
+
+/** `init`, with `--model` given. `model` is absent when the run took the CLI's default. */
+export const init =
+	'{"event":"init","conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","init":{"model":"gemini-3.8-flash-low","cwd":"/tmp/agyprobe","tools":["ask_custom_permission","ask_permission","ask_question","browser_click_element","browser_drag_pixel_to_pixel","browser_get_dom","browser_get_network_request","browser_input","browser_list_network_requests","browser_mouse_down","browser_mouse_up","browser_move_mouse","browser_press_key","browser_refresh_page","browser_resize_window","browser_scroll","browser_scroll_dom","browser_select_option","browser_subagent","call_mcp_tool","capture_browser_console_logs","capture_browser_screenshot","click_browser_pixel","command_status","define_subagent","delete_knowledge","execute_browser_javascript","find_by_name","finish","generate_image","grep_search","invoke_subagent","list_browser_pages","list_dir","list_permissions","list_resources","manage_inbox","manage_subagents","manage_task","multi_replace_file_content","notebook_edit","notebook_execution","open_browser_url","read_browser_page","read_resource","read_url_content","replace_file_content","run_command","schedule","search_web","sed_file","send_command_input","send_message","view_file","wait","wait_5_seconds","write_to_file"],"permission_mode":"request-review"}}';
+
+/** The `user_input` step. v1.1.27 puts no text on it — the prompt is not echoed back. */
+export const userInput =
+	'{"event":"step_update","step_update":{"conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","step_index":0,"state":"DONE","step_type":"user_input"}}';
+
+/** The turn's first reply chunk. */
+export const responseActive =
+	'{"event":"step_update","step_update":{"conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","step_index":3,"state":"ACTIVE","step_type":"agent_response","text_delta":"The current directory contains **5** files:\\n\\n- [err.txt](file:///tmp/agyprobe/err.txt)\\n- [out.ndjson](file:///tmp/agyprobe/out.ndjson)\\n- [sample.txt](file:///t"}}';
+
+/** The last chunk, and it is a chunk: `"mp/agyprobe/sample.txt)…"` continues the line above rather than repeating it. */
+export const responseDone =
+	'{"event":"step_update","step_update":{"conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","step_index":3,"state":"DONE","step_type":"agent_response","text_delta":"mp/agyprobe/sample.txt)\\n- [tool.err](file:///tmp/agyprobe/tool.err)\\n- [tool.ndjson](file:///tmp/agyprobe/tool.ndjson)\\n\\nTotal count: **5**\\n","duration_seconds":3.425466,"usage":{"input_tokens":4481,"output_tokens":110,"thinking_tokens":0,"cache_read_tokens":12195,"total_tokens":4591}}}';
+
+/** A tool call, before its outcome: `tool_info` carries `parameters` and no `output`. */
+export const toolActive =
+	'{"event":"step_update","step_update":{"conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","step_index":2,"state":"ACTIVE","step_type":"tool","tool_name":"list_dir","tool_info":{"name":"list_dir","parameters":{"DirectoryPath":"/tmp/agyprobe"}}}}';
+
+/** The same `step_index`, now with `tool_info.output`. */
+export const toolDone =
+	'{"event":"step_update","step_update":{"conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","step_index":2,"state":"DONE","step_type":"tool","tool_name":"list_dir","duration_seconds":0.03474,"tool_info":{"name":"list_dir","parameters":{"DirectoryPath":"/tmp/agyprobe"},"output":"err.txt\\nout.ndjson\\nsample.txt\\ntool.err\\ntool.ndjson"}}}';
+
+/** The other outcome: `tool_info.error {type, message}`, from a `view_file` on a missing path. */
+export const toolError =
+	'{"event":"step_update","step_update":{"conversation_id":"efa24031-a6f7-483e-81af-1fad5fae1887","step_index":2,"state":"ERROR","step_type":"tool","tool_name":"view_file","duration_seconds":0.033857,"tool_info":{"name":"view_file","parameters":{"AbsolutePath":"/tmp/agyprobe/definitely-missing.txt"},"error":{"type":"TOOL_ERROR","message":"declaring permissions: cortex tool view_file: convert tool call for permissions: model output error: invalid tool call error (invalid_args) failed to read file: open /tmp/agyprobe/definitely-missing.txt: no such file or directory"}}}}';
+
+/** An `invoke_subagent` call. `subagent_info.subagents[]` is the whole payload. */
+export const subagentActive =
+	'{"event":"step_update","step_update":{"conversation_id":"e9e99659-bc69-44f8-8b42-3dea5c1a5008","step_index":2,"state":"ACTIVE","step_type":"subagent","tool_name":"invoke_subagent","subagent_info":{"subagents":[{"type_name":"research","role":"Robotics Historian","initial_prompt":"Please briefly answer: What are the three laws of robotics introduced by Isaac Asimov? Keep the answer concise.","conversation_id":"4ce4cca7-2b7f-4728-b171-1a84d3ff70f6","log_uri":"file:///Users/founder/.gemini/antigravity-cli/brain/4ce4cca7-2b7f-4728-b171-1a84d3ff70f6/.system_generated/logs/transcript.jsonl","workspace_uris":["file:///tmp/agyprobe2"]}]}}}';
+
+/** The same step, done — the `subagent_info` payload is identical and carries no result. */
+export const subagentDone =
+	'{"event":"step_update","step_update":{"conversation_id":"e9e99659-bc69-44f8-8b42-3dea5c1a5008","step_index":2,"state":"DONE","step_type":"subagent","tool_name":"invoke_subagent","duration_seconds":0.237139,"subagent_info":{"subagents":[{"type_name":"research","role":"Robotics Historian","initial_prompt":"Please briefly answer: What are the three laws of robotics introduced by Isaac Asimov? Keep the answer concise.","conversation_id":"4ce4cca7-2b7f-4728-b171-1a84d3ff70f6","log_uri":"file:///Users/founder/.gemini/antigravity-cli/brain/4ce4cca7-2b7f-4728-b171-1a84d3ff70f6/.system_generated/logs/transcript.jsonl","workspace_uris":["file:///tmp/agyprobe2"]}]}}}';
+
+/** A `system_message` step, and it carries no text at all. */
+export const systemMessage =
+	'{"event":"step_update","step_update":{"conversation_id":"e9e99659-bc69-44f8-8b42-3dea5c1a5008","step_index":4,"state":"DONE","step_type":"system_message","duration_seconds":0.000191}}';
+
+/** The terminal `result`. `response` holds text no step delta carried (`"I have delegated…"`). */
+export const resultSuccess =
+	'{"event":"result","result":{"conversation_id":"9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf","status":"SUCCESS","response":"The current directory contains **5** files:\\n\\n- [err.txt](file:///tmp/agyprobe/err.txt)\\n- [out.ndjson](file:///tmp/agyprobe/out.ndjson)\\n- [sample.txt](file:///tmp/agyprobe/sample.txt)\\n- [tool.err](file:///tmp/agyprobe/tool.err)\\n- [tool.ndjson](file:///tmp/agyprobe/tool.ndjson)\\n\\nTotal count: **5**\\n","duration_seconds":4.7196169999999995,"num_turns":1,"usage":{"input_tokens":20963,"output_tokens":151,"thinking_tokens":0,"cache_read_tokens":12195,"total_tokens":21114}}}';

--- a/apps/tuval/src/agy/ai-agent/mapper.ts
+++ b/apps/tuval/src/agy/ai-agent/mapper.ts
@@ -1,0 +1,272 @@
+/**
+ * agy's NDJSON stream → the `AgentEvent`s the core folds. Pure, total, and the far side of this
+ * module is `ai-agent/events.ts` + `ai-agent/ports/` only: no agy wire type crosses.
+ *
+ * A line is folded against a small carry (`AgyTurn`) rather than read alone, because three facts
+ * about the wire need memory:
+ *
+ * - **`text_delta` is incremental**, and the `DONE` step carries the last chunk, not the
+ *   accumulation. So the turn's reply is streamed into one assistant item whose text grows, and
+ *   the terminal `result` re-sends *that same `ItemId`* with `result.response`, which is the only
+ *   place the whole reply lives. The deltas are lossy against it: a captured turn's steps read
+ *   `" delegated the research task…"` where the response reads `"I have delegated…"`.
+ * - **`init.model` names the model** and only `init` carries it, while every usage payload that
+ *   needs the name arrives later.
+ * - A row with no natural wire key (an unreadable line, a denied-action report) needs an id that
+ *   does not collide with the next one.
+ *
+ * A tool call and its outcome both ride inside `step_update` — `DONE` carries `tool_info.output`,
+ * `ERROR` carries `tool_info.error` — so both project onto one `ToolItem` keyed by
+ * `<conversation_id>:<step_index>`, and the running row is superseded rather than duplicated.
+ * A subagent invocation projects onto the same shape, and its `DONE` payload is byte-identical to
+ * its `ACTIVE` one, so `state` alone drives the transition.
+ *
+ * **An unrecognised `step_type` renders a `SystemItem` and is never dropped and never thrown on.**
+ * That is the whole reason this file has a default arm: the enum is provably open and the stream
+ * carries no version to branch on (see `wire.ts`).
+ */
+
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {
+	boundToolResult,
+	type ItemId,
+	type JsonValue,
+	type ToolStatus,
+} from "../../ai-agent/ports/index.ts";
+import {
+	type AgyResult,
+	type AgyStepUpdate,
+	type AgySubagentInfo,
+	type AgyUsage,
+	decodeLine,
+} from "./wire.ts";
+
+/** `ItemId` is an opaque brand, minted here so no call site writes its own cast. */
+export const itemId = (value: string): ItemId => value as ItemId;
+
+/** How much of an unreadable line reaches the transcript before it is cut. */
+export const UNREADABLE_LINE_LIMIT = 500;
+
+export interface AgyTurn {
+	/** `agy/<model>` once `init` names one, else the bare binary — agy omits `init.model` on a default run. */
+	readonly model: string;
+	/** The item this turn's reply streams into, minted at its first `agent_response` delta. */
+	readonly responseId: ItemId | null;
+	readonly responseText: string;
+	/** Monotonic, so two keyless rows never share an id. */
+	readonly minted: number;
+}
+
+export const idleTurn: AgyTurn = {model: "agy", responseId: null, responseText: "", minted: 0};
+
+interface Folded {
+	readonly events: ReadonlyArray<AgentEvent>;
+	readonly next: AgyTurn;
+}
+
+const systemEvent = (id: string, timestamp: number, text: string): AgentEvent => ({
+	kind: "item",
+	item: {kind: "system", id: itemId(id), timestamp, text},
+});
+
+/**
+ * agy reports no cost anywhere on the stream, so `cost` is `0` rather than a guess, and
+ * `thinking_tokens` / `cache_read_tokens` have no port field and are left on the wire.
+ */
+const usageEvent = (model: string, usage: AgyUsage | undefined): AgentEvent | null =>
+	usage === undefined
+		? null
+		: {
+				kind: "usage",
+				model,
+				inputTokens: usage.input_tokens,
+				outputTokens: usage.output_tokens,
+				cost: 0,
+			};
+
+const subagentInput = (info: AgySubagentInfo): JsonValue => ({
+	subagents: info.subagents.map((subagent) => ({
+		type_name: subagent.type_name ?? null,
+		role: subagent.role ?? null,
+		initial_prompt: subagent.initial_prompt ?? null,
+		conversation_id: subagent.conversation_id ?? null,
+		log_uri: subagent.log_uri ?? null,
+		workspace_uris: subagent.workspace_uris === undefined ? null : [...subagent.workspace_uris],
+	})),
+});
+
+const toolStatusOf = (state: string): ToolStatus => {
+	if (state === "ERROR") return "error";
+	return state === "DONE" ? "ok" : "running";
+};
+
+const toolResultText = (step: AgyStepUpdate, status: ToolStatus): string => {
+	if (status === "error") {
+		const error = step.tool_info?.error;
+		if (error === undefined) return "agy reported a tool error with no detail";
+		return error.type.length === 0 ? error.message : `${error.type}: ${error.message}`;
+	}
+	return status === "ok" ? (step.tool_info?.output ?? "") : "";
+};
+
+const unrecognisedText = (step: AgyStepUpdate): string => {
+	const delta = step.text_delta;
+	const head = `agy step ${step.step_index} of an unrecognised type ${JSON.stringify(step.step_type)} (${step.state})`;
+	return delta === undefined || delta.length === 0 ? head : `${head}: ${delta}`;
+};
+
+const stepEvents = (previous: AgyTurn, step: AgyStepUpdate, timestamp: number): Folded => {
+	const events: Array<AgentEvent> = [];
+	const key = `${step.conversation_id}:${step.step_index}`;
+	const delta = step.text_delta ?? "";
+	let next = previous;
+
+	switch (step.step_type) {
+		case "user_input":
+			// v1.1.27 carries no text on this step; the core already holds the operator's own turn,
+			// so an empty row here would be a blank bubble beside it rather than an echo of it.
+			if (delta.length > 0)
+				events.push({kind: "item", item: {kind: "user", id: itemId(key), timestamp, text: delta}});
+			break;
+
+		case "agent_response":
+			if (delta.length > 0) {
+				const id = previous.responseId ?? itemId(key);
+				const text = previous.responseText + delta;
+				next = {...next, responseId: id, responseText: text};
+				events.push({kind: "item", item: {kind: "assistant", id, timestamp, text}});
+			}
+			break;
+
+		case "tool":
+		case "subagent": {
+			const name = step.tool_name ?? step.tool_info?.name;
+			if (name === undefined) {
+				events.push(
+					systemEvent(
+						key,
+						timestamp,
+						`agy ${step.step_type} step ${step.step_index} names no tool (${step.state})`,
+					),
+				);
+				break;
+			}
+			const status = toolStatusOf(step.state);
+			const input =
+				step.subagent_info === undefined
+					? (step.tool_info?.parameters ?? null)
+					: subagentInput(step.subagent_info);
+			events.push({
+				kind: "item",
+				item: {
+					kind: "tool",
+					id: itemId(key),
+					timestamp,
+					name,
+					input,
+					result: boundToolResult(toolResultText(step, status)),
+					status,
+				},
+			});
+			break;
+		}
+
+		case "system_message":
+			if (delta.length > 0) events.push(systemEvent(key, timestamp, delta));
+			break;
+
+		default:
+			events.push(systemEvent(key, timestamp, unrecognisedText(step)));
+	}
+
+	const usage = usageEvent(next.model, step.usage);
+	if (usage !== null) events.push(usage);
+	return {events, next};
+};
+
+const resultEvents = (previous: AgyTurn, result: AgyResult, timestamp: number): Folded => {
+	const events: Array<AgentEvent> = [];
+	let minted = previous.minted;
+
+	if (result.response.length > 0) {
+		const id = previous.responseId ?? itemId(`${result.conversation_id}:response`);
+		events.push({kind: "item", item: {kind: "assistant", id, timestamp, text: result.response}});
+	}
+
+	const denied = result.denied_actions;
+	if (denied !== undefined && denied.length > 0) {
+		events.push(
+			systemEvent(
+				`agy:denied:${minted}`,
+				timestamp,
+				`agy denied ${denied.length} action(s): ${JSON.stringify(denied)}`,
+			),
+		);
+		minted += 1;
+	}
+
+	const usage = usageEvent(previous.model, result.usage);
+	if (usage !== null) events.push(usage);
+
+	// Fail closed: only `SUCCESS` is a success, so a status this pin has not seen surfaces as a
+	// failure instead of being silently folded into a completed turn.
+	if (result.status !== "SUCCESS")
+		events.push({
+			kind: "failure",
+			failure: {
+				tag: "AgyTurnFailed",
+				reason: result.status,
+				detail: result.error ?? "agy ended the turn with no error detail",
+			},
+		});
+
+	return {events, next: {...previous, responseId: null, responseText: "", minted}};
+};
+
+/**
+ * One NDJSON line → zero or more `AgentEvent`s, plus the carry the next line folds against.
+ *
+ * `timestamp` is the caller's wall clock in epoch milliseconds: agy stamps nothing, and the port's
+ * items all carry one.
+ */
+export const eventsOf = (previous: AgyTurn, line: string, timestamp: number): Folded => {
+	const read = decodeLine(line);
+	switch (read.kind) {
+		case "blank":
+			return {events: [], next: previous};
+
+		case "unreadable": {
+			const raw =
+				read.raw.length <= UNREADABLE_LINE_LIMIT
+					? read.raw
+					: `${read.raw.slice(0, UNREADABLE_LINE_LIMIT)}…`;
+			return {
+				events: [
+					systemEvent(
+						`agy:unreadable:${previous.minted}`,
+						timestamp,
+						`agy emitted a line this reader cannot use (${read.reason}): ${raw}`,
+					),
+				],
+				next: {...previous, minted: previous.minted + 1},
+			};
+		}
+
+		case "event":
+			switch (read.event.event) {
+				// `init` names the model and nothing the transcript renders; the layer reads the rest
+				// of it directly for `StartedSession`, and the model catalog is its own invocation.
+				case "init": {
+					const model = read.event.init.model;
+					return {
+						events: [],
+						next: {...previous, model: model === undefined ? "agy" : `agy/${model}`},
+					};
+				}
+				case "step_update":
+					return stepEvents(previous, read.event.step_update, timestamp);
+				case "result":
+					return resultEvents(previous, read.event.result, timestamp);
+			}
+	}
+};

--- a/apps/tuval/src/agy/ai-agent/mapper.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/mapper.unit.test.ts
@@ -1,0 +1,339 @@
+/**
+ * The agy fold, over captured v1.1.27 stream lines rather than a live CLI.
+ *
+ * **Nothing here enumerates the observed `step_type`s as exhaustive.** The cases below name the
+ * five that were observed and the eleven that were not, and every one of them is a claim about
+ * that value alone — an assertion that the observed set is closed would rebuild the exact defect
+ * the default arm exists to prevent, on a wire that ships no version field to warn anyone.
+ */
+
+import {describe, expect, it} from "vitest";
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {
+	boundToolResult,
+	isTranscriptItem,
+	TOOL_RESULT_BYTE_LIMIT,
+	type ToolItem,
+	type TranscriptItem,
+} from "../../ai-agent/ports/index.ts";
+import * as fixtures from "./fixtures.ts";
+import {type AgyTurn, eventsOf, idleTurn} from "./mapper.ts";
+
+const AT = 1_700_000_000_000;
+
+const fold = (
+	lines: ReadonlyArray<string>,
+	start: AgyTurn = idleTurn,
+): {readonly events: ReadonlyArray<AgentEvent>; readonly turn: AgyTurn} => {
+	let turn = start;
+	const events: Array<AgentEvent> = [];
+	for (const line of lines) {
+		const folded = eventsOf(turn, line, AT);
+		turn = folded.next;
+		events.push(...folded.events);
+	}
+	expect(
+		events.filter((event) => event.kind === "item").every((event) => isTranscriptItem(event.item)),
+	).toBe(true);
+	return {events, turn};
+};
+
+const items = (events: ReadonlyArray<AgentEvent>): ReadonlyArray<TranscriptItem> =>
+	events.flatMap((event) => (event.kind === "item" ? [event.item] : []));
+
+/** A captured line with its `step_update` patched — so even a synthetic case rides a real envelope. */
+const patchStep = (line: string, patch: Record<string, unknown>): string => {
+	const parsed = JSON.parse(line) as {step_update: Record<string, unknown>};
+	return JSON.stringify({...parsed, step_update: {...parsed.step_update, ...patch}});
+};
+
+const patchResult = (line: string, patch: Record<string, unknown>): string => {
+	const parsed = JSON.parse(line) as {result: Record<string, unknown>};
+	return JSON.stringify({...parsed, result: {...parsed.result, ...patch}});
+};
+
+describe("an unrecognised step_type", () => {
+	// The six that exist as strings in the agy binary and have never been emitted.
+	const neverEmitted = ["thinking", "plan", "error", "command", "memory", "checkpoint"];
+
+	for (const stepType of neverEmitted) {
+		it(`renders "${stepType}" as a system row rather than dropping or throwing it`, () => {
+			const {events} = fold([patchStep(fixtures.userInput, {step_type: stepType})]);
+			const rendered = items(events);
+			expect(rendered).toHaveLength(1);
+			expect(rendered[0]?.kind).toBe("system");
+			expect(rendered[0]?.kind === "system" && rendered[0].text).toContain(stepType);
+		});
+	}
+
+	it("renders a step type nobody has ever seen as a system row too", () => {
+		const invented = "a_step_type_agy_has_never_shipped";
+		const {events} = fold([
+			patchStep(fixtures.userInput, {step_type: invented, text_delta: "payload"}),
+		]);
+		const rendered = items(events);
+		expect(rendered).toHaveLength(1);
+		expect(rendered[0]?.kind).toBe("system");
+		expect(rendered[0]?.kind === "system" && rendered[0].text).toContain(invented);
+		expect(rendered[0]?.kind === "system" && rendered[0].text).toContain("payload");
+	});
+
+	it("keeps its usage even though its content is unrecognised", () => {
+		const {events} = fold([
+			patchStep(fixtures.responseDone, {step_type: "checkpoint", text_delta: "x"}),
+		]);
+		expect(events.filter((event) => event.kind === "usage")).toHaveLength(1);
+	});
+});
+
+describe("a line the reader cannot use", () => {
+	it("degrades a non-JSON line to a system row and keeps the stream alive", () => {
+		const {events} = fold([`{"event":"step_update"`, fixtures.responseActive]);
+		const rendered = items(events);
+		expect(rendered).toHaveLength(2);
+		expect(rendered[0]?.kind).toBe("system");
+		expect(rendered[1]?.kind).toBe("assistant");
+	});
+
+	it("degrades a step_update missing the fields that route it", () => {
+		const {events} = fold([JSON.stringify({event: "step_update", step_update: {state: "DONE"}})]);
+		expect(items(events)[0]?.kind).toBe("system");
+	});
+
+	it("degrades a tool step whose optional payload is missing altogether", () => {
+		const line = JSON.stringify({
+			event: "step_update",
+			step_update: {
+				conversation_id: "c",
+				step_index: 4,
+				state: "DONE",
+				step_type: "tool",
+			},
+		});
+		const rendered = items(fold([line]).events);
+		expect(rendered).toHaveLength(1);
+		expect(rendered[0]?.kind).toBe("system");
+	});
+
+	it("gives two unreadable lines two ids, so neither supersedes the other", () => {
+		const {events} = fold(["not json at all", "also not json"]);
+		const rendered = items(events);
+		expect(rendered).toHaveLength(2);
+		expect(rendered[0]?.id).not.toBe(rendered[1]?.id);
+	});
+
+	it("emits nothing for a blank separator line", () => {
+		expect(fold(["", "   "]).events).toEqual([]);
+	});
+});
+
+describe("the five observed step types", () => {
+	it("takes no transcript row from a user_input step, which carries no text at v1.1.27", () => {
+		expect(items(fold([fixtures.userInput]).events)).toEqual([]);
+	});
+
+	it("renders a user_input step that does carry text as a user row", () => {
+		const rendered = items(fold([patchStep(fixtures.userInput, {text_delta: "say hello"})]).events);
+		expect(rendered[0]).toMatchObject({kind: "user", text: "say hello", timestamp: AT});
+	});
+
+	it("renders an agent_response delta as an assistant row", () => {
+		const rendered = items(fold([fixtures.responseActive]).events);
+		expect(rendered[0]).toMatchObject({kind: "assistant", timestamp: AT});
+		expect(rendered[0]?.kind === "assistant" && rendered[0].text).toContain("**5** files");
+	});
+
+	it("renders a tool step as a tool row carrying the call's own parameters", () => {
+		const rendered = items(fold([fixtures.toolActive]).events);
+		expect(rendered[0]).toMatchObject({
+			kind: "tool",
+			name: "list_dir",
+			status: "running",
+			input: {DirectoryPath: "/tmp/agyprobe"},
+			result: {text: "", omitted: {bytes: 0}},
+		});
+	});
+
+	it("renders a subagent step as a tool row over the same running/done shape", () => {
+		const rendered = items(fold([fixtures.subagentActive]).events);
+		expect(rendered[0]).toMatchObject({kind: "tool", name: "invoke_subagent", status: "running"});
+		const input = (rendered[0] as ToolItem).input as {subagents: ReadonlyArray<{role: string}>};
+		expect(input.subagents[0]?.role).toBe("Robotics Historian");
+	});
+
+	it("takes no row from a system_message step with no text, and one from a system_message with text", () => {
+		expect(items(fold([fixtures.systemMessage]).events)).toEqual([]);
+		const rendered = items(
+			fold([patchStep(fixtures.systemMessage, {text_delta: "context compacted"})]).events,
+		);
+		expect(rendered[0]).toMatchObject({kind: "system", text: "context compacted"});
+	});
+});
+
+describe("the tool arm", () => {
+	it("re-sends the running row's id on DONE, with tool_info.output as the result", () => {
+		const rendered = items(fold([fixtures.toolActive, fixtures.toolDone]).events);
+		expect(rendered).toHaveLength(2);
+		expect(rendered[0]?.id).toBe(rendered[1]?.id);
+		expect(rendered[0]).toMatchObject({status: "running"});
+		expect(rendered[1]).toMatchObject({
+			status: "ok",
+			result: boundToolResult("err.txt\nout.ndjson\nsample.txt\ntool.err\ntool.ndjson"),
+		});
+	});
+
+	it("maps ERROR off tool_info.error", () => {
+		const rendered = items(fold([fixtures.toolError]).events);
+		expect(rendered[0]).toMatchObject({kind: "tool", name: "view_file", status: "error"});
+		const result = (rendered[0] as ToolItem).result;
+		expect(result.text).toContain("TOOL_ERROR");
+		expect(result.text).toContain("no such file or directory");
+	});
+
+	it("passes the result text through boundToolResult", () => {
+		const output = "x".repeat(TOOL_RESULT_BYTE_LIMIT + 500);
+		const rendered = items(
+			fold([patchStep(fixtures.toolDone, {tool_info: {name: "list_dir", output}})]).events,
+		);
+		expect((rendered[0] as ToolItem).result).toEqual(boundToolResult(output));
+		expect((rendered[0] as ToolItem).result.omitted.bytes).toBe(500);
+	});
+});
+
+describe("the subagent arm", () => {
+	it("drives ACTIVE→DONE off state alone, on two payloads identical apart from it", () => {
+		const active = fixtures.subagentActive;
+		const done = active.replace('"state":"ACTIVE"', '"state":"DONE"');
+		expect(done).not.toBe(active);
+		expect(done.replace('"state":"DONE"', '"state":"ACTIVE"')).toBe(active);
+
+		const rendered = items(fold([active, done]).events);
+		expect(rendered[0]?.id).toBe(rendered[1]?.id);
+		expect(rendered[0]).toMatchObject({status: "running"});
+		expect(rendered[1]).toMatchObject({status: "ok"});
+		expect({...(rendered[0] as ToolItem), status: "x"}).toEqual({
+			...(rendered[1] as ToolItem),
+			status: "x",
+		});
+	});
+
+	it("carries no result summary on the captured DONE either, so state is all there is to read", () => {
+		const rendered = items(fold([fixtures.subagentActive, fixtures.subagentDone]).events);
+		expect((rendered[1] as ToolItem).result.text).toBe("");
+		expect((rendered[0] as ToolItem).input).toEqual((rendered[1] as ToolItem).input);
+	});
+});
+
+describe("the turn's text", () => {
+	it("streams deltas incrementally: the DONE step carries the last chunk, not the accumulation", () => {
+		const first = (JSON.parse(fixtures.responseActive) as {step_update: {text_delta: string}})
+			.step_update.text_delta;
+		const last = (JSON.parse(fixtures.responseDone) as {step_update: {text_delta: string}})
+			.step_update.text_delta;
+		expect(last.startsWith(first)).toBe(false);
+		expect(last).not.toContain("The current directory contains");
+
+		const rendered = items(fold([fixtures.responseActive, fixtures.responseDone]).events);
+		expect(rendered[0]?.id).toBe(rendered[1]?.id);
+		expect(rendered[0]?.kind === "assistant" && rendered[0].text).toBe(first);
+		expect(rendered[1]?.kind === "assistant" && rendered[1].text).toBe(first + last);
+	});
+
+	it("takes the whole reply from result.response, superseding the streamed accumulation", () => {
+		const response = (JSON.parse(fixtures.resultSuccess) as {result: {response: string}}).result
+			.response;
+		const rendered = items(
+			fold([fixtures.responseActive, fixtures.responseDone, fixtures.resultSuccess]).events,
+		);
+		expect(rendered).toHaveLength(3);
+		expect(rendered[2]?.id).toBe(rendered[0]?.id);
+		expect(rendered[2]?.kind === "assistant" && rendered[2].text).toBe(response);
+	});
+
+	it("mints a response row even when no delta ever arrived", () => {
+		const rendered = items(fold([fixtures.resultSuccess]).events);
+		expect(rendered[0]?.kind).toBe("assistant");
+	});
+});
+
+describe("usage", () => {
+	it("reaches a UsageEvent from step_update.usage, named by the model init announced", () => {
+		const {events} = fold([fixtures.init, fixtures.responseDone]);
+		expect(events.filter((event) => event.kind === "usage")).toEqual([
+			{
+				kind: "usage",
+				model: "agy/gemini-3.8-flash-low",
+				inputTokens: 4481,
+				outputTokens: 110,
+				cost: 0,
+			},
+		]);
+	});
+
+	it("reaches a UsageEvent from result.usage too", () => {
+		const {events} = fold([fixtures.init, fixtures.resultSuccess]);
+		expect(events.filter((event) => event.kind === "usage")).toEqual([
+			{
+				kind: "usage",
+				model: "agy/gemini-3.8-flash-low",
+				inputTokens: 20963,
+				outputTokens: 151,
+				cost: 0,
+			},
+		]);
+	});
+
+	it("falls back to the bare binary name when init announced no model", () => {
+		const initWithoutModel = JSON.stringify({
+			event: "init",
+			conversation_id: "c",
+			init: {cwd: "/tmp", permission_mode: "request-review"},
+		});
+		const {events} = fold([initWithoutModel, fixtures.responseDone]);
+		expect(events.find((event) => event.kind === "usage")?.model).toBe("agy");
+	});
+
+	it("emits nothing at all for init itself", () => {
+		expect(fold([fixtures.init]).events).toEqual([]);
+	});
+});
+
+describe("the terminal result", () => {
+	it("reports a non-SUCCESS status as a failure, keeping the session alive", () => {
+		const {events} = fold([
+			patchResult(fixtures.resultSuccess, {
+				status: "ERROR",
+				error: "timeout waiting for response",
+			}),
+		]);
+		expect(events.at(-1)).toEqual({
+			kind: "failure",
+			failure: {
+				tag: "AgyTurnFailed",
+				reason: "ERROR",
+				detail: "timeout waiting for response",
+			},
+		});
+	});
+
+	it("reads a status this pin has never seen as a failure rather than a success", () => {
+		const {events} = fold([patchResult(fixtures.resultSuccess, {status: "INTERRUPTED"})]);
+		expect(events.at(-1)).toMatchObject({kind: "failure", failure: {reason: "INTERRUPTED"}});
+	});
+
+	it("surfaces denied_actions as a system row instead of swallowing them", () => {
+		const {events} = fold([
+			patchResult(fixtures.resultSuccess, {denied_actions: [{tool: "run_command"}]}),
+		]);
+		const denied = items(events).find(
+			(item) => item.kind === "system" && item.text.includes("denied"),
+		);
+		expect(denied?.kind === "system" && denied.text).toContain("run_command");
+	});
+
+	it("clears the turn's response row, so the next turn opens its own", () => {
+		const {turn} = fold([fixtures.responseActive, fixtures.resultSuccess]);
+		expect(turn.responseId).toBeNull();
+		expect(turn.responseText).toBe("");
+	});
+});

--- a/apps/tuval/src/agy/ai-agent/wire.ts
+++ b/apps/tuval/src/agy/ai-agent/wire.ts
@@ -1,0 +1,291 @@
+/**
+ * agy's `--output-format=stream-json` output, and the total read of one NDJSON line into it.
+ *
+ * Module-internal by construction: no type in this file appears on a public signature, which is
+ * what keeps agy's protocol inside `src/agy/` the way Pi's stays inside `src/pi/`.
+ *
+ * Everything here is captured from **agy v1.1.27** (`agy --input-format=stream-json
+ * --output-format=stream-json --print='' --sandbox --add-dir=<dir>`), and the stream carries no
+ * protocol or schema version field of any kind — so nothing downstream can branch on a version,
+ * and the two tolerances below are the only defence a later release leaves us:
+ *
+ * - **`step_type` is an open string, never a closed union.** Five values are observed —
+ *   `user_input`, `agent_response`, `tool`, `subagent`, `system_message` — and two of those were
+ *   found only after the first census. Six more (`thinking`, `plan`, `error`, `command`, `memory`,
+ *   `checkpoint`) exist as strings in the binary and have never been emitted. `state` and
+ *   `result.status` are typed open for the same reason.
+ * - **Only the fields that route a line are required.** Every other field is optional and
+ *   defaulted, because a line refused for a key this pin has not seen is content the operator
+ *   never gets.
+ *
+ * The envelope is nested and each payload is keyed by its own event name —
+ * `{"event":"step_update","step_update":{…}}` — and `conversation_id` sits at the top level on
+ * `init` but inside the payload on the other two.
+ */
+
+import {Predicate} from "effect";
+import {isJsonValue, type JsonValue} from "../../ai-agent/ports/index.ts";
+
+/** The release every shape below was captured from. There is no version field on the wire. */
+export const AGY_VERSION = "1.1.27";
+
+/**
+ * Token counts as v1.1.27 reports them. There is no cost field anywhere on the stream, and
+ * `thinking_tokens` / `cache_read_tokens` have no port counterpart.
+ */
+export interface AgyUsage {
+	readonly input_tokens: number;
+	readonly output_tokens: number;
+	readonly thinking_tokens: number;
+	readonly cache_read_tokens: number;
+	readonly total_tokens: number;
+}
+
+export interface AgyToolError {
+	readonly type: string;
+	readonly message: string;
+}
+
+/** A tool call and its outcome both ride here: `output` on `DONE`, `error` on `ERROR`. */
+export interface AgyToolInfo {
+	readonly name?: string;
+	readonly parameters?: JsonValue;
+	readonly output?: string;
+	readonly error?: AgyToolError;
+}
+
+export interface AgySubagent {
+	readonly type_name?: string;
+	readonly role?: string;
+	readonly initial_prompt?: string;
+	readonly conversation_id?: string;
+	readonly log_uri?: string;
+	readonly workspace_uris?: ReadonlyArray<string>;
+}
+
+export interface AgySubagentInfo {
+	readonly subagents: ReadonlyArray<AgySubagent>;
+}
+
+/** `model` is absent when the run took the CLI's own default rather than an explicit `--model`. */
+export interface AgyInit {
+	readonly model?: string;
+	readonly cwd?: string;
+	readonly tools?: ReadonlyArray<string>;
+	readonly permission_mode?: string;
+}
+
+export interface AgyStepUpdate {
+	readonly conversation_id: string;
+	readonly step_index: number;
+	/** `ACTIVE | DONE | ERROR` at v1.1.27, typed open for the reason `step_type` is. */
+	readonly state: string;
+	/** Open by ruling, never a union — see the module note. */
+	readonly step_type: string;
+	/** Incremental: the `DONE` step carries the last chunk, never the accumulation. */
+	readonly text_delta?: string;
+	readonly tool_name?: string;
+	readonly tool_info?: AgyToolInfo;
+	readonly subagent_info?: AgySubagentInfo;
+	readonly duration_seconds?: number;
+	readonly usage?: AgyUsage;
+}
+
+export interface AgyResult {
+	readonly conversation_id: string;
+	/** `SUCCESS | ERROR` at v1.1.27. Anything else reads as a failure — never as a success. */
+	readonly status: string;
+	/** The turn's whole reply. The step deltas are lossy against this; this one is authoritative. */
+	readonly response: string;
+	readonly error?: string;
+	readonly num_turns: number;
+	readonly usage?: AgyUsage;
+	/** Element shape unmeasured at this pin, so it stays `JsonValue` and is rendered, not parsed. */
+	readonly denied_actions?: ReadonlyArray<JsonValue>;
+}
+
+export type AgyEvent =
+	| {readonly event: "init"; readonly conversation_id: string; readonly init: AgyInit}
+	| {readonly event: "step_update"; readonly step_update: AgyStepUpdate}
+	| {readonly event: "result"; readonly result: AgyResult};
+
+/**
+ * One line, read. `blank` is a separator and means nothing; `unreadable` is content the mapper
+ * still has to show, because a line the reader cannot parse is not a line it may swallow.
+ */
+export type AgyLine =
+	| {readonly kind: "event"; readonly event: AgyEvent}
+	| {readonly kind: "blank"}
+	| {readonly kind: "unreadable"; readonly raw: string; readonly reason: string};
+
+type Fields = {readonly [key: string]: unknown};
+
+const fields = (value: unknown): Fields | undefined =>
+	Predicate.isObject(value) && !Array.isArray(value) ? (value as Fields) : undefined;
+
+const text = (value: unknown): string | undefined =>
+	typeof value === "string" ? value : undefined;
+
+const count = (value: unknown): number | undefined =>
+	typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const texts = (value: unknown): ReadonlyArray<string> | undefined =>
+	Array.isArray(value) && value.every((entry) => typeof entry === "string")
+		? (value as ReadonlyArray<string>)
+		: undefined;
+
+const json = (value: unknown): JsonValue | undefined => (isJsonValue(value) ? value : undefined);
+
+/** Present-or-absent, never `undefined`-valued: the tree is checked under `exactOptionalPropertyTypes`. */
+const optional = <K extends string, T>(key: K, value: T | undefined): {[P in K]?: T} =>
+	(value === undefined ? {} : {[key]: value}) as {[P in K]?: T};
+
+const readUsage = (value: unknown): AgyUsage | undefined => {
+	const source = fields(value);
+	if (source === undefined) return undefined;
+	return {
+		input_tokens: count(source.input_tokens) ?? 0,
+		output_tokens: count(source.output_tokens) ?? 0,
+		thinking_tokens: count(source.thinking_tokens) ?? 0,
+		cache_read_tokens: count(source.cache_read_tokens) ?? 0,
+		total_tokens: count(source.total_tokens) ?? 0,
+	};
+};
+
+const readToolError = (value: unknown): AgyToolError | undefined => {
+	const source = fields(value);
+	if (source === undefined) return undefined;
+	return {type: text(source.type) ?? "", message: text(source.message) ?? ""};
+};
+
+const readToolInfo = (value: unknown): AgyToolInfo | undefined => {
+	const source = fields(value);
+	if (source === undefined) return undefined;
+	return {
+		...optional("name", text(source.name)),
+		...optional("parameters", json(source.parameters)),
+		...optional("output", text(source.output)),
+		...optional("error", readToolError(source.error)),
+	};
+};
+
+const readSubagent = (value: unknown): AgySubagent => {
+	const source = fields(value) ?? {};
+	return {
+		...optional("type_name", text(source.type_name)),
+		...optional("role", text(source.role)),
+		...optional("initial_prompt", text(source.initial_prompt)),
+		...optional("conversation_id", text(source.conversation_id)),
+		...optional("log_uri", text(source.log_uri)),
+		...optional("workspace_uris", texts(source.workspace_uris)),
+	};
+};
+
+const readSubagentInfo = (value: unknown): AgySubagentInfo | undefined => {
+	const source = fields(value);
+	if (source === undefined) return undefined;
+	const subagents = Array.isArray(source.subagents) ? source.subagents : [];
+	return {subagents: subagents.map(readSubagent)};
+};
+
+const readInit = (value: unknown): AgyInit => {
+	const source = fields(value) ?? {};
+	return {
+		...optional("model", text(source.model)),
+		...optional("cwd", text(source.cwd)),
+		...optional("tools", texts(source.tools)),
+		...optional("permission_mode", text(source.permission_mode)),
+	};
+};
+
+/** `conversation_id`, `step_index`, `state` and `step_type` route the line; nothing else does. */
+const readStepUpdate = (value: unknown): AgyStepUpdate | undefined => {
+	const source = fields(value);
+	if (source === undefined) return undefined;
+	const conversationId = text(source.conversation_id);
+	const stepIndex = count(source.step_index);
+	const state = text(source.state);
+	const stepType = text(source.step_type);
+	if (
+		conversationId === undefined ||
+		stepIndex === undefined ||
+		state === undefined ||
+		stepType === undefined
+	)
+		return undefined;
+	return {
+		conversation_id: conversationId,
+		step_index: stepIndex,
+		state,
+		step_type: stepType,
+		...optional("text_delta", text(source.text_delta)),
+		...optional("tool_name", text(source.tool_name)),
+		...optional("tool_info", readToolInfo(source.tool_info)),
+		...optional("subagent_info", readSubagentInfo(source.subagent_info)),
+		...optional("duration_seconds", count(source.duration_seconds)),
+		...optional("usage", readUsage(source.usage)),
+	};
+};
+
+const readResult = (value: unknown): AgyResult | undefined => {
+	const source = fields(value);
+	if (source === undefined) return undefined;
+	const conversationId = text(source.conversation_id);
+	const status = text(source.status);
+	if (conversationId === undefined || status === undefined) return undefined;
+	const denied = Array.isArray(source.denied_actions)
+		? source.denied_actions.map((entry) => json(entry) ?? null)
+		: undefined;
+	return {
+		conversation_id: conversationId,
+		status,
+		response: text(source.response) ?? "",
+		num_turns: count(source.num_turns) ?? 0,
+		...optional("error", text(source.error)),
+		...optional("usage", readUsage(source.usage)),
+		...optional("denied_actions", denied),
+	};
+};
+
+/** Total: every string is an `AgyLine`, and nothing here throws on any input. */
+export const decodeLine = (line: string): AgyLine => {
+	if (line.trim().length === 0) return {kind: "blank"};
+	let parsed: unknown;
+	// biome-ignore lint/plugin: this reader is pure and total by contract — it hands the mapper a value, never an Effect — and `JSON.parse` is the one primitive here that throws, a failure `AgyLine`'s `unreadable` arm already models.
+	try {
+		parsed = JSON.parse(line);
+	} catch {
+		return {kind: "unreadable", raw: line, reason: "not JSON"};
+	}
+	const source = fields(parsed);
+	if (source === undefined) return {kind: "unreadable", raw: line, reason: "not a JSON object"};
+	switch (source.event) {
+		case "init": {
+			const conversationId = text(source.conversation_id);
+			if (conversationId === undefined)
+				return {kind: "unreadable", raw: line, reason: "init carries no conversation_id"};
+			return {
+				kind: "event",
+				event: {event: "init", conversation_id: conversationId, init: readInit(source.init)},
+			};
+		}
+		case "step_update": {
+			const step = readStepUpdate(source.step_update);
+			return step === undefined
+				? {kind: "unreadable", raw: line, reason: "step_update is missing a routing field"}
+				: {kind: "event", event: {event: "step_update", step_update: step}};
+		}
+		case "result": {
+			const result = readResult(source.result);
+			return result === undefined
+				? {kind: "unreadable", raw: line, reason: "result is missing a routing field"}
+				: {kind: "event", event: {event: "result", result}};
+		}
+		default:
+			return {
+				kind: "unreadable",
+				raw: line,
+				reason: `unrecognised event ${JSON.stringify(source.event) ?? "<absent>"}`,
+			};
+	}
+};


### PR DESCRIPTION
Closes #8178

The agy wire mapper: internal wire types plus a total `decodeLine`, and `eventsOf(previous, line, timestamp) -> {events, next}` folding agy's NDJSON into `AgentEvent`. Four new files under `apps/tuval/src/agy/ai-agent/`; no shared port file touched.

## Built from live captures, not from the brief

`agy` v1.1.27 is on this machine, so the wire was captured from four live runs rather than taken off the epic body — **and the epic body's envelope was wrong.** It described flat payloads; the real wire nests each under a key named after the event:

```
{"event":"step_update","step_update":{"conversation_id":…,"step_index":…,"state":…,"step_type":…}}
```

`conversation_id` sits at the top level on `init` and inside the payload on the other two. Three more corrections fell out of the same captures: `init.model` is absent when no `--model` is passed; `usage` carries no cost field anywhere, so `UsageEvent.cost` is `0` rather than a guess; and `user_input` and `system_message` steps carry no text, mapping to zero events.

Filed as #8203 so #8181 and #8182 do not inherit the flat description — they would decode every line to nothing with green hand-written tests.

## Open enums fail closed

The unrecognised-`step_type` fallback is the issue's hard criterion, and `state` and `result.status` are typed open for the same reason: only `SUCCESS` reads as a success, so an unseen status fails closed rather than silently passing. No test treats the five observed values as exhaustive, and the test file's docblock says why.

## Gates

- `pnpm test:unit` — 1575/1575 (35 new)
- `pnpm typecheck` — 0 errors across all three lenses
- `biome check` clean; `build check --surface code` green, `unvalidated` empty

## Deviations

11 entries disclosed at https://github.com/kamp-us/phoenix/issues/8178#issuecomment-5556927959, including the one `biome-ignore lint/plugin` on the `JSON.parse` try/catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)