### PR TITLE
fix: Nothing renders the Tuval desk inspector region or the composed status bar

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -256,25 +256,43 @@ The row carries three optional references (`src/registry/program.ts`): `renderer
   command row like any other.
 - `src/shell/desk/` imports no socket, no React and nothing from `src/shell/ui/` — its own boundary
   test is the gate, as `src/shell/window/`'s is.
+- **The snapshot is assembled on the surface**, in `src/shell/ui/desk-snapshot.ts`, because half of
+  it only exists there: the live `WindowHost` a renderer mounts into, and the two renderer tables a
+  page assembles from its own imports. `Desk.tsx` takes the rest as one `DeskTables` prop — kernel
+  facts, process rows, program rows, both renderer tables — and the page fills it from the frames it
+  already reads for the windows' sake (`src/page/AttachedDesk.tsx`). The host comes back through the
+  one `MountResolver` the tiling area already asks per window, so the inspector cannot mount a host
+  the windows do not also hold.
+- **The region is mounted or not mounted**, never a collapsed shell with its own disclosure: the
+  open/closed bit is desk state the kernel holds, so a `Collapsible` beside it would be a second
+  authority over one bit. Both regions read one snapshot, so they cannot disagree about which window
+  is focused.
 
-## Two error boundaries, and what each one is allowed to cost
+## Three error boundaries, and what each one is allowed to cost
 
 A render throw with nothing above it unmounts React's whole tree, and on this surface that is a
 black tab with the reason only in a console nobody is reading. It has cost the project twice —
 #7560, then a `<c-b> |` that took the desk down on its own headline key
 ([#7839](https://github.com/kamp-us/phoenix/issues/7839)). `ErrorBoundary` in
-`src/shell/ui/ErrorBoundary.tsx` is the answer, and it is mounted in exactly two places, each sized
+`src/shell/ui/ErrorBoundary.tsx` is the answer, and it is mounted in exactly three places, each sized
 to what a throw there may cost:
 
 | Where | Wraps | What survives |
 |---|---|---|
-| `Desk.tsx` | the tiling area alone | the status line, the command line, the desk's keyboard |
+| `Desk.tsx` | the tiling area alone | the inspector, the status line, the command line, the desk's keyboard |
+| `DeskInspector.tsx` | the program's inspector alone | the windows, and the rest of the desk |
 | `main.tsx` | everything the page renders | the tab, with the reason on it |
+
+The inspector's boundary is why `DeskInspector.tsx` runs the program's renderer inside its own
+component rather than in the panel's body: called in the parent it throws during the *parent's*
+render, above the boundary and past it.
 
 **Recovery is not a button that re-throws.** The boundary takes `resetKeys`, and the desk hands it
 `layoutSignature(workspace.layout)` — the layout tree serialized to one string
 (`src/shell/layout/tree.ts`) — so the next kernel snapshot that changes the layout clears the panel
-with no gesture at all. The button is the fallback for the case where nothing new arrives.
+with no gesture at all. The button is the fallback for the case where nothing new arrives. The
+inspector's key is the same shape at its own scale: the focused window and its process, spelled as
+one string, so moving focus clears a caught throw and unrelated kernel traffic does not.
 
 **The key is a signature and never the layout object**, and that is the whole rule for anything else
 mounting this boundary: `resetKeys` are compared with `Object.is`, and every snapshot the page

--- a/apps/tuval/src/page/AttachedDesk.tsx
+++ b/apps/tuval/src/page/AttachedDesk.tsx
@@ -22,10 +22,22 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import type {ProcessId} from "../process/process.ts";
 import type {ProgramId} from "../registry/program.ts";
 import type {ShellMsg, ShellState} from "../shell/core/index.ts";
+import type {
+	AnyInspectorRenderer,
+	AnyStatusRenderer,
+	DeclaredRenderers,
+	SnapshotProcess,
+} from "../shell/desk/index.ts";
 import {windows} from "../shell/layout/index.ts";
 import type {PickerEntries} from "../shell/picker/browser.ts";
 import type {AttachedProcess, PageAttachment, WireProgram} from "../shell/transport/browser.ts";
-import type {AttachEvent, AttachStatus, DeskSource, MountResolver} from "../shell/ui/index.ts";
+import type {
+	AttachEvent,
+	AttachStatus,
+	DeskSource,
+	DeskTables,
+	MountResolver,
+} from "../shell/ui/index.ts";
 import {boundMount, Desk, noRenderer, useDeskAttachment} from "../shell/ui/index.ts";
 import type {AnyWindowRenderer} from "../shell/window/index.ts";
 import {empty, processGone, resolverFromTable, type ViewState} from "../shell/window/index.ts";
@@ -36,6 +48,12 @@ export interface AttachedDeskProps {
 	readonly shell: AttachedProcess<unknown, ShellMsg>;
 	/** One renderer per `RendererRef.ref` — `./renderers.tsx` says why the key is the reference. */
 	readonly renderers: Readonly<Record<string, AnyWindowRenderer>>;
+	/**
+	 * The two desk-level renderer tables, keyed the same way. Both default to empty: a page that
+	 * mounts no program's inspector still gets the region, showing why it is empty.
+	 */
+	readonly inspectors?: Readonly<Record<string, AnyInspectorRenderer>>;
+	readonly statuses?: Readonly<Record<string, AnyStatusRenderer>>;
 	readonly reducedMotion: boolean;
 	/**
 	 * Why the page stopped re-attaching, if it has. Set means the desk below is frozen for good and
@@ -111,16 +129,22 @@ const entriesFrom = (
 	})),
 });
 
+const EMPTY_RENDERERS: Readonly<Record<string, never>> = {};
+
 export function AttachedDesk({
 	page,
 	shell,
 	renderers,
+	inspectors = EMPTY_RENDERERS,
+	statuses = EMPTY_RENDERERS,
 	reducedMotion,
 	refusal,
 }: AttachedDeskProps): ReactElement {
 	const [rows, setRows] = useState<ReadonlyMap<ProcessId, TableRow>>(new Map());
 	const [catalog, setCatalog] = useState<ReadonlyMap<ProgramId, WireProgram>>(new Map());
 	const [attached, setAttached] = useState<ReadonlyMap<string, AttachedProcess>>(new Map());
+	/** The shell process's own revision — the bar's `rev`, read off the same view the snapshot is. */
+	const [revision, setRevision] = useState(0);
 	/** Ids an attach has already been started for; a second window must not open a second socket read. */
 	const asked = useRef(new Set<string>());
 
@@ -129,13 +153,14 @@ export function AttachedDesk({
 			emit({_tag: "Attached"} satisfies AttachEvent);
 			const snapshots = Effect.runFork(
 				Stream.runForEach(shell.readProcess, (view) =>
-					Effect.sync(() =>
+					Effect.sync(() => {
+						if (view._tag === "Live") setRevision(view.revision);
 						emit(
 							view._tag === "Live"
 								? {_tag: "Snapshot", state: view.state}
 								: {_tag: "Dropped", reason: "the shell process is gone"},
-						),
-					),
+						);
+					}),
 				),
 			);
 			// The grammar rides the same machine as the snapshot, so a drop keeps both (ADR 0353).
@@ -250,6 +275,21 @@ export function AttachedDesk({
 
 	const entries = useMemo(() => entriesFrom(rows, catalog), [rows, catalog]);
 
+	// The half of a `DeskSnapshot` the shell state does not carry. Everything here is already on the
+	// page for the windows' sake; this is the same two frames read for the desk's own regions.
+	const deskTables = useMemo<DeskTables>(() => {
+		const processes: Record<string, SnapshotProcess> = {};
+		for (const row of rows.values()) processes[row.id] = {programId: row.programId};
+		const programs: Record<string, DeclaredRenderers> = {};
+		for (const program of catalog.values()) {
+			programs[program.programId] = {
+				...(program.inspector === undefined ? {} : {inspector: program.inspector}),
+				...(program.status === undefined ? {} : {status: program.status}),
+			};
+		}
+		return {kernel: {processes: rows.size, revision}, processes, programs, inspectors, statuses};
+	}, [rows, catalog, revision, inspectors, statuses]);
+
 	// The grammar gates the desk beside the snapshot: a surface routing keys over a table nobody sent
 	// it is the thing ADR 0353 took away, so it waits for one exactly as it waits for a desk.
 	if (desk === null || attachment.table === null) {
@@ -274,6 +314,7 @@ export function AttachedDesk({
 				resolveMount={resolveMount}
 				entries={entries}
 				table={attachment.table}
+				deskTables={deskTables}
 				reducedMotion={reducedMotion}
 			/>
 		</>

--- a/apps/tuval/src/shell/transport/server.ts
+++ b/apps/tuval/src/shell/transport/server.ts
@@ -118,6 +118,10 @@ export const registryFrame = (rows: ReadonlyArray<AnyProgram>): RegistryFrame =>
 		programId: row.id,
 		label: programLabel(row),
 		renderer: row.renderer,
+		// Spread rather than assigned, so a row declaring neither sends no key at all: an explicit
+		// `inspector: undefined` is a different frame once it has been through `JSON.stringify`.
+		...(row.inspector === undefined ? {} : {inspector: row.inspector}),
+		...(row.status === undefined ? {} : {status: row.status}),
 	})),
 });
 

--- a/apps/tuval/src/shell/transport/wire.ts
+++ b/apps/tuval/src/shell/transport/wire.ts
@@ -124,6 +124,14 @@ export interface WireProgram {
 	readonly programId: ProgramId;
 	readonly label: string;
 	readonly renderer: RendererRef;
+	/**
+	 * The two desk-level references the row declares beside its window renderer
+	 * (`../../registry/program.ts`). Optional on the row and therefore optional here: a program that
+	 * declares neither sends neither, and the page's inspector region answers `not-declared` rather
+	 * than going looking for a reference nobody made.
+	 */
+	readonly inspector?: RendererRef;
+	readonly status?: RendererRef;
 }
 
 /**
@@ -264,7 +272,11 @@ export const isWireProgram = (value: unknown): value is WireProgram =>
 	Predicate.isObject(value) &&
 	typeof value.programId === "string" &&
 	typeof value.label === "string" &&
-	isRendererRef(value.renderer);
+	isRendererRef(value.renderer) &&
+	// Absent is legal, present must be a reference: an `inspector` key carrying junk is a malformed
+	// frame, not a program that declares no inspector.
+	(value.inspector === undefined || isRendererRef(value.inspector)) &&
+	(value.status === undefined || isRendererRef(value.status));
 
 export const isRegistryFrame = (value: unknown): value is RegistryFrame =>
 	Predicate.isObject(value) &&

--- a/apps/tuval/src/shell/ui/Desk.tsx
+++ b/apps/tuval/src/shell/ui/Desk.tsx
@@ -1,7 +1,11 @@
 /**
  * The desk: the whole browser surface for one shell process. It renders the active workspace's
- * layout, the status line and — when a key asked for it — the command line, and it owns the page's
- * one application-level keyboard listener.
+ * layout, the inspector region beside it, the status line and — when a key asked for it — the
+ * command line, and it owns the page's one application-level keyboard listener.
+ *
+ * The two desk-level regions are *composed*, never pushed into: `./desk-snapshot.ts` assembles one
+ * `DeskSnapshot` and `../desk/compose.ts` answers what each region shows. Both read that one
+ * snapshot, so they cannot disagree about which window is focused.
  *
  * "One listener" is the invariant, and it has exactly two sanctioned exceptions, both of them
  * elements that would be broken without their own keys: the command line's `input`, and each
@@ -19,16 +23,20 @@
  */
 
 import type {ReactElement, ReactNode} from "react";
-import {useCallback, useEffect, useRef, useState} from "react";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {usePalette} from "../../palette/index.ts";
 import type {ShellMsg, ShellState} from "../core/index.ts";
 import {activeWorkspace, processOf} from "../core/index.ts";
+import {inspectorFor, statusFor} from "../desk/index.ts";
 import type {Key, PrefixTable} from "../keys/index.ts";
 import {layoutSignature} from "../layout/index.ts";
 import type {PickerEntries} from "../picker/browser.ts";
 import {noEntries} from "../picker/browser.ts";
 import {WindowId} from "../window/index.ts";
 import {CommandLine} from "./CommandLine.tsx";
+import {DeskInspector} from "./DeskInspector.tsx";
+import type {DeskTables} from "./desk-snapshot.ts";
+import {deskSnapshotOf, noDeskTables} from "./desk-snapshot.ts";
 import {ErrorBoundary} from "./ErrorBoundary.tsx";
 import {type ForwardedKey, ForwardedKeyProvider} from "./forwarded-key.tsx";
 import {routerPrefix, statusFrame, surfaceKey, zoomedWindow} from "./frame.ts";
@@ -49,6 +57,12 @@ export interface DeskProps {
 	 * other. Required: a default here is a page inventing a grammar nobody gave it (ADR 0353).
 	 */
 	readonly table: PrefixTable;
+	/**
+	 * The half of a `DeskSnapshot` only the page knows (`./desk-snapshot.ts`): the kernel facts, the
+	 * process and program rows, and the two desk renderer tables. Defaulted rather than required, so
+	 * a caller that composes no desk regions still renders a desk.
+	 */
+	readonly deskTables?: DeskTables;
 	/** The listener's home. `document` in a page; a container in a test that wants two desks. */
 	readonly keyTarget?: Pick<EventTarget, "addEventListener" | "removeEventListener"> | null;
 	readonly reducedMotion?: boolean;
@@ -60,6 +74,7 @@ export function Desk({
 	resolveMount,
 	entries = noEntries,
 	table,
+	deskTables = noDeskTables,
 	keyTarget,
 	reducedMotion = false,
 }: DeskProps): ReactElement {
@@ -169,6 +184,23 @@ export function Desk({
 		});
 	}, [palette]);
 
+	// Both desk regions are composed from one snapshot, so the inspector and the bar's middle can
+	// never disagree about which window is focused or which program it is showing.
+	const snapshot = useMemo(
+		() => deskSnapshotOf(state, deskTables, resolveMount),
+		[state, deskTables, resolveMount],
+	);
+	const bar = statusFor(snapshot);
+	// Composed only while the region is open: `inspectorFor` runs no program code, but the renderer
+	// it hands back does, and a closed region must not be paying for one.
+	const inspector = state.desk.inspectorOpen ? inspectorFor(snapshot) : null;
+	// The boundary's reset key, as values: which window and which process the panel is showing. A
+	// snapshot that moves focus clears a caught throw; unrelated kernel traffic leaves it alone.
+	const inspecting =
+		snapshot.focused === null
+			? null
+			: `${snapshot.focused.windowId}:${snapshot.focused.processId ?? ""}`;
+
 	const renderWindow = (windowId: WindowId): ReactNode => (
 		<WindowView
 			key={windowId}
@@ -187,32 +219,35 @@ export function Desk({
 
 	return (
 		<div className="tuval-surface" ref={desk} tabIndex={-1} data-scheme="dark">
-			<ForwardedKeyProvider value={forwarded}>
-				{/* The tiling area alone, so a throw costs the founder the windows and not the status
+			<div className="tuval-desk-body">
+				<ForwardedKeyProvider value={forwarded}>
+					{/* The tiling area alone, so a throw costs the founder the windows and not the status
 				    line, the command line or the keyboard. The reset key is the layout's *signature*
 				    and never the layout object, for the same reason the countdown above is keyed on
 				    values: the boundary compares its keys with `Object.is`, and a decoded object is
 				    new on every snapshot, so the panel would be torn down and rebuilt on unrelated
 				    kernel traffic — losing focus on its button and the stack a founder came to read
 				    (#7839). */}
-				<ErrorBoundary
-					label="The desk layout"
-					resetKeys={[workspace === undefined ? null : layoutSignature(workspace.layout)]}
-				>
-					{workspace === undefined ? (
-						<div className="tuval-tiling tuval-placeholder" role="status">
-							<p>This desk has no active workspace. Open one with the command line.</p>
-						</div>
-					) : (
-						<LayoutView
-							root={workspace.layout.root}
-							zoomed={zoomedWindow(workspace)}
-							renderWindow={renderWindow}
-							dispatch={dispatch}
-						/>
-					)}
-				</ErrorBoundary>
-			</ForwardedKeyProvider>
+					<ErrorBoundary
+						label="The desk layout"
+						resetKeys={[workspace === undefined ? null : layoutSignature(workspace.layout)]}
+					>
+						{workspace === undefined ? (
+							<div className="tuval-tiling tuval-placeholder" role="status">
+								<p>This desk has no active workspace. Open one with the command line.</p>
+							</div>
+						) : (
+							<LayoutView
+								root={workspace.layout.root}
+								zoomed={zoomedWindow(workspace)}
+								renderWindow={renderWindow}
+								dispatch={dispatch}
+							/>
+						)}
+					</ErrorBoundary>
+				</ForwardedKeyProvider>
+				{inspector === null ? null : <DeskInspector region={inspector} resetKeys={[inspecting]} />}
+			</div>
 			{commandLineOpen ? <CommandLine dispatch={dispatch} onClose={closeCommandLine} /> : null}
 			{palette.open ? (
 				<PaletteHost
@@ -222,7 +257,7 @@ export function Desk({
 					onClose={closePalette}
 				/>
 			) : null}
-			<StatusLine frame={statusFrame(state)} prefixKey={table.prefix} />
+			<StatusLine frame={statusFrame(state)} bar={bar} prefixKey={table.prefix} />
 		</div>
 	);
 }

--- a/apps/tuval/src/shell/ui/DeskInspector.tsx
+++ b/apps/tuval/src/shell/ui/DeskInspector.tsx
@@ -1,0 +1,85 @@
+/**
+ * The desk inspector: one region beside the tiling area, filled by the focused window's program.
+ *
+ * It is mounted or not mounted — never a collapsed shell with its own disclosure — because the
+ * open/closed flag is desk state the kernel holds (`../desk/state.ts`) and `desk:inspector-toggle`
+ * is the one thing that writes it. A `Collapsible` here would be a second authority over the same
+ * bit, and its trigger would still be on screen with the region closed.
+ *
+ * Every `NoInspector` reason gets a sentence rather than a hole (#7500 rulings 4 and 5): the walk
+ * that ends in one is a value, and the reader is told which step ended. A renderer that *throws* is
+ * a different failure and gets the boundary — sized to this region alone, so a program's bad
+ * inspector costs the founder the panel and not the windows.
+ */
+
+import {Card, EmptyState} from "@kampus/design";
+import type {ReactElement, ReactNode} from "react";
+import type {DeskEmptyReason, InspectorRegion} from "../desk/index.ts";
+import "./desk.css";
+import {ErrorBoundary} from "./ErrorBoundary.tsx";
+
+/**
+ * Why the region is empty, in the reader's words. Every arm of `DeskEmptyReason` is here and the
+ * record is total, so a new arm is a compile error rather than a blank panel.
+ */
+const emptyReason: Readonly<Record<DeskEmptyReason, string>> = {
+	"no-focused-window": "No window has focus. Focus one and its program fills this region.",
+	"window-unbound": "The focused window is showing no process.",
+	"process-unknown": "The focused window's process has left the table.",
+	"program-unknown": "This page holds no program row for that process.",
+	"not-declared": "This program declares no inspector.",
+	"unknown-ref": "This page answers to no inspector by the name that program declares.",
+	"kind-mismatch": "That program's inspector is declared at a kind this page does not mount.",
+};
+
+/**
+ * The program's renderer, run inside its own component. Called in the parent's body it would throw
+ * during the *parent's* render, above the boundary and past it — the panel has to be the thing that
+ * throws for the boundary to be the thing that catches.
+ */
+const Mounted = ({
+	region,
+}: {
+	readonly region: Extract<InspectorRegion, {readonly _tag: "Inspector"}>;
+}): ReactElement => <>{region.renderer.render(region.host) as ReactNode}</>;
+
+export interface DeskInspectorProps {
+	readonly region: InspectorRegion;
+	/**
+	 * What a caught throw is cleared by. Values, never objects: the boundary compares its keys with
+	 * `Object.is` and every snapshot arrives decoded afresh (`./ErrorBoundary.tsx`).
+	 */
+	readonly resetKeys?: ReadonlyArray<unknown>;
+}
+
+export function DeskInspector({region, resetKeys = []}: DeskInspectorProps): ReactElement {
+	return (
+		<Card
+			as="section"
+			className="tuval-inspector"
+			aria-label="Desk inspector"
+			// The panel is its own scroll container, and a scroll container a keyboard user cannot
+			// reach is content they cannot read. It sits after the tiling area in the DOM, so Tab
+			// lands here on the way out of the windows.
+			tabIndex={0}
+		>
+			<h2 className="tuval-inspector-title">Inspector</h2>
+			{region._tag === "NoInspector" ? (
+				// Centred in what is left of a full-height column rather than sitting under the title:
+				// a sparse region reads as composed, never as a void with its content jammed at the top
+				// (`design-system-manifest.md`, Pillar 3).
+				<div className="tuval-inspector-empty">
+					<EmptyState title="Nothing to inspect" description={emptyReason[region.reason]} />
+				</div>
+			) : (
+				<ErrorBoundary
+					label="The desk inspector"
+					className="tuval-inspector-panel"
+					resetKeys={resetKeys}
+				>
+					<Mounted region={region} />
+				</ErrorBoundary>
+			)}
+		</Card>
+	);
+}

--- a/apps/tuval/src/shell/ui/StatusLine.tsx
+++ b/apps/tuval/src/shell/ui/StatusLine.tsx
@@ -1,40 +1,76 @@
 /**
- * The status line: active workspace, whether the prefix is armed, and the sequence typed since it
- * armed. Every field comes off `statusFrame` (`./frame.ts`), so the page stores none of it.
+ * The status line: three groups, and which of them a program can reach is the whole point.
  *
- * The armed prefix is announced as text in a polite live region as well as shown, because a state
+ * `statusFor` (`../desk/compose.ts`) hands over a composed `StatusBar` whose `left` and `right` it
+ * derived itself and whose `middle` is whatever the focused window's program returned. This binds
+ * that answer verbatim — a program's segments go into the middle group and nowhere else, because
+ * that is the only place this component reads them from (#7500 ruling 5). An empty middle is an
+ * empty group, never an error: `middleEmpty` names a step of a walk that did not resolve, and the
+ * bar carries no room for that sentence.
+ *
+ * The shell's own prefix and pending sequence ride the right group beside the kernel facts, and the
+ * armed prefix is announced as text in a polite live region as well as shown, because a state
  * carried only by a highlight is a state a screen-reader user never learns (Pillar 4, "never signal
  * state by colour alone").
  *
  * A `section` rather than a `footer`: an accessible name needs a role that takes one, and a `footer`
- * nested inside the desk is generic. `region` also makes the line a landmark of its own.
+ * nested inside the desk is generic. `region` also makes the line a landmark of its own; each group
+ * inside it is a `group`, which is the role that takes the name each one owes.
  */
 
+import {Kbd} from "@kampus/design";
 import type {ReactElement} from "react";
+import type {StatusBar, StatusSegment} from "../desk/index.ts";
+import "./desk.css";
 import type {StatusFrame} from "./frame.ts";
 
 export interface StatusLineProps {
 	readonly frame: StatusFrame;
+	readonly bar: StatusBar;
 	readonly prefixKey: string;
 }
 
-export function StatusLine({frame, prefixKey}: StatusLineProps): ReactElement {
+const Segments = ({segments}: {readonly segments: ReadonlyArray<StatusSegment>}): ReactElement => (
+	<>
+		{segments.map((segment) => (
+			// `tone` is a name, never a colour: the segment says "attention" and this surface decides
+			// what that looks like (`../desk/renderer.ts`).
+			<span key={segment.id} className="tuval-status-segment" data-tone={segment.tone ?? "normal"}>
+				{segment.text}
+			</span>
+		))}
+	</>
+);
+
+export function StatusLine({frame, bar, prefixKey}: StatusLineProps): ReactElement {
 	return (
 		<section className="tuval-status" aria-label="Shell status">
-			<span>
-				workspace <strong>{frame.workspace}</strong> ({frame.position.at}/{frame.position.of})
-			</span>
-			<span>
-				{frame.windowCount} window{frame.windowCount === 1 ? "" : "s"}
-				{frame.zoomed ? " · zoomed" : ""}
-			</span>
-			<span>
-				prefix <kbd className="tuval-kbd">{prefixKey}</kbd>{" "}
-				<strong>{frame.prefixArmed ? "armed" : "idle"}</strong>
-			</span>
-			<span>
-				pending <strong>{frame.pending.length === 0 ? "—" : frame.pending.join("")}</strong>
-			</span>
+			{/* biome-ignore lint/a11y/useSemanticElements: the rule's `fieldset` groups form controls;
+			    these three group read-only status text, and `group` is the only role that names one */}
+			<div className="tuval-status-group" role="group" aria-label="Workspace">
+				<Segments segments={bar.left} />
+				<span>
+					({frame.position.at}/{frame.position.of})
+				</span>
+				<span>
+					{frame.windowCount} window{frame.windowCount === 1 ? "" : "s"}
+					{frame.zoomed ? " · zoomed" : ""}
+				</span>
+			</div>
+			{/* biome-ignore lint/a11y/useSemanticElements: see the group above */}
+			<div className="tuval-status-group tuval-status-middle" role="group" aria-label="Program">
+				<Segments segments={bar.middle} />
+			</div>
+			{/* biome-ignore lint/a11y/useSemanticElements: see the group above */}
+			<div className="tuval-status-group" role="group" aria-label="Shell">
+				<span>
+					prefix <Kbd>{prefixKey}</Kbd> <strong>{frame.prefixArmed ? "armed" : "idle"}</strong>
+				</span>
+				<span>
+					pending <strong>{frame.pending.length === 0 ? "—" : frame.pending.join("")}</strong>
+				</span>
+				<Segments segments={bar.right} />
+			</div>
 			<span className="tuval-refusal" role="status" aria-live="polite">
 				{frame.announcement}
 			</span>

--- a/apps/tuval/src/shell/ui/desk-regions.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/desk-regions.unit.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The two desk-level regions, rendered: the inspector beside the tiling area and the composed
+ * status bar under it. The tier is `unit` — every assertion here could be wrong with a perfectly
+ * behaved socket, which is the litmus (`.patterns/effect-testing.md`).
+ *
+ * The harness runs the real reducer, so the toggle is proven the way a founder reaches it: the Msg
+ * through the core, and a key bound to `desk:inspector-toggle` in the grammar the kernel sent. A
+ * stubbed reducer would prove the surface agrees with a fake.
+ */
+
+import {act, fireEvent, render, screen, within} from "@testing-library/react";
+import axe from "axe-core";
+import {Duration} from "effect";
+import type {ReactElement} from "react";
+import {useState} from "react";
+import {describe, expect, it} from "vitest";
+import {ProcessId} from "../../process/process.ts";
+import {ProgramId, type RendererRef} from "../../registry/program.ts";
+import type {ShellMsg, ShellState} from "../core/index.ts";
+import {applyMsg} from "../core/index.ts";
+import type {DeskEmptyReason} from "../desk/index.ts";
+import {inspectorRenderer, statusRenderer} from "../desk/index.ts";
+import type {PrefixTable} from "../keys/index.ts";
+import {CommandName, defaultPrefixTable} from "../keys/index.ts";
+import type {AnyWindowHost, WindowId} from "../window/index.ts";
+import {empty} from "../window/index.ts";
+import {Desk} from "./Desk.tsx";
+import type {DeskTables} from "./desk-snapshot.ts";
+import {noDeskTables} from "./desk-snapshot.ts";
+import {installDomShims} from "./dom.testing.ts";
+import {threeWindowDesk} from "./fixtures.ts";
+import type {MountResolver} from "./mount.ts";
+
+installDomShims();
+
+const COUNTER = ProgramId.make("counter");
+const INSPECTOR_REF: RendererRef = {kind: "host-native", ref: "test/inspector"};
+const STATUS_REF: RendererRef = {kind: "host-native", ref: "test/status"};
+
+/**
+ * A host over the one field these renderers read. The window contract's streams are never touched
+ * here, so standing them up would be a socket this tier does not have.
+ */
+const hostFor = (windowId: WindowId, processId: string): AnyWindowHost => ({
+	windowId,
+	processId: ProcessId.make(processId),
+	readProcess: undefined as never,
+	dispatch: undefined as never,
+	view: () => null,
+	setView: undefined as never,
+});
+
+const boundEverywhere: MountResolver = (windowId, processId) =>
+	processId === null
+		? empty
+		: {
+				_tag: "Bound",
+				host: hostFor(windowId, processId),
+				render: (host) => <p>renderer for {String(host.processId)}</p>,
+			};
+
+const inspector = (
+	render_: (host: AnyWindowHost) => ReactElement,
+	kind: RendererRef["kind"] = "host-native",
+) => inspectorRenderer(kind, render_);
+
+/** Every window bound, `process-1` running `counter`, and `counter` declaring both desk renderers. */
+const tables = (overrides: Partial<DeskTables> = {}): DeskTables => ({
+	kernel: {processes: 2, revision: 7},
+	processes: {"process-1": {programId: COUNTER}, "process-3": {programId: COUNTER}},
+	programs: {[COUNTER]: {inspector: INSPECTOR_REF, status: STATUS_REF}},
+	inspectors: {
+		[INSPECTOR_REF.ref]: inspector((host) => <p>inspecting {String(host.processId)}</p>),
+	},
+	statuses: {
+		[STATUS_REF.ref]: statusRenderer("host-native", () => [{id: "lines", text: "12 lines"}]),
+	},
+	...overrides,
+});
+
+/** The grammar a kernel could send: the founder's table with `<c-b> i` bound to the toggle. */
+const withInspectorKey: PrefixTable = {
+	prefix: defaultPrefixTable.prefix,
+	repeatTimeout: Duration.millis(500),
+	bindings: [
+		...defaultPrefixTable.bindings,
+		{sequence: "i", command: CommandName.make("desk:inspector-toggle"), repeatable: false},
+	],
+};
+
+interface HarnessProps {
+	readonly initial: ShellState;
+	readonly deskTables?: DeskTables;
+	readonly table?: PrefixTable;
+	readonly resolveMount?: MountResolver;
+	/** Handed the live `dispatch`, so a test can send the Msg a command row names. */
+	readonly onReady?: (dispatch: (msg: ShellMsg) => void) => void;
+}
+
+function Harness({
+	initial,
+	deskTables = tables(),
+	table = defaultPrefixTable,
+	resolveMount = boundEverywhere,
+	onReady,
+}: HarnessProps): ReactElement {
+	const [state, setState] = useState(initial);
+	const dispatch = (msg: ShellMsg): void => setState((current) => applyMsg(table, current, msg)[0]);
+	onReady?.(dispatch);
+	return (
+		<Desk
+			state={state}
+			dispatch={dispatch}
+			resolveMount={resolveMount}
+			table={table}
+			deskTables={deskTables}
+		/>
+	);
+}
+
+const opened = (state: ShellState): ShellState => ({
+	...state,
+	desk: {...state.desk, inspectorOpen: true},
+});
+
+const region = (): HTMLElement | null => screen.queryByRole("region", {name: "Desk inspector"});
+const group = (name: string): HTMLElement => screen.getByRole("group", {name});
+
+describe("the desk inspector region", () => {
+	it("is not rendered at all while the desk holds it closed", () => {
+		render(<Harness initial={threeWindowDesk()} />);
+		expect(region()).toBeNull();
+	});
+
+	it("opens and closes on desk.inspector.toggle", () => {
+		let dispatch: (msg: ShellMsg) => void = () => undefined;
+		render(<Harness initial={threeWindowDesk()} onReady={(next) => (dispatch = next)} />);
+		expect(region()).toBeNull();
+
+		act(() => dispatch({type: "desk.inspector.toggle"}));
+		expect(within(region() as HTMLElement).getByText("inspecting process-1")).toBeTruthy();
+
+		act(() => dispatch({type: "desk.inspector.toggle"}));
+		expect(region()).toBeNull();
+	});
+
+	it("opens on the key a grammar binds to desk:inspector-toggle", () => {
+		render(<Harness initial={threeWindowDesk()} table={withInspectorKey} />);
+		expect(region()).toBeNull();
+
+		act(() => {
+			fireEvent.keyDown(document, {key: "b", ctrlKey: true, code: "KeyB"});
+			fireEvent.keyDown(document, {key: "i", code: "KeyI"});
+		});
+		expect(region()).not.toBeNull();
+	});
+
+	it("survives a workspace switch with its state exactly as it was (#7500 ruling 4)", () => {
+		let dispatch: (msg: ShellMsg) => void = () => undefined;
+		render(<Harness initial={opened(threeWindowDesk())} onReady={(next) => (dispatch = next)} />);
+		expect(region()).not.toBeNull();
+
+		act(() => dispatch({type: "workspace.create"}));
+		act(() => dispatch({type: "workspace.step", direction: "next"}));
+		expect(region()).not.toBeNull();
+	});
+
+	it("keeps the tiling area when an inspector throws", () => {
+		const throwing = tables({
+			inspectors: {
+				[INSPECTOR_REF.ref]: inspector(() => {
+					throw new Error("the inspector fell over");
+				}),
+			},
+		});
+		render(<Harness initial={opened(threeWindowDesk())} deskTables={throwing} />);
+
+		expect(screen.getByRole("alert").textContent).toContain("The desk inspector stopped rendering");
+		expect(screen.getByRole("alert").textContent).toContain("the inspector fell over");
+		// The windows are the point: a program's bad inspector costs the panel and nothing else.
+		expect(screen.getAllByRole("region", {name: /^Window /})).toHaveLength(3);
+	});
+});
+
+/**
+ * Each arm of `DeskEmptyReason`, driven to the surface. The list is the type's, so an arm added
+ * without a placeholder is a compile error here before it is a hole in the browser.
+ */
+const emptyCases: ReadonlyArray<readonly [DeskEmptyReason, HarnessProps]> = [
+	[
+		"no-focused-window",
+		{initial: opened({...threeWindowDesk(), activeWorkspace: "workspace-gone"})},
+	],
+	["window-unbound", {initial: opened(threeWindowDesk("window-2"))}],
+	["process-unknown", {initial: opened(threeWindowDesk()), deskTables: tables({processes: {}})}],
+	["program-unknown", {initial: opened(threeWindowDesk()), deskTables: tables({programs: {}})}],
+	[
+		"not-declared",
+		{initial: opened(threeWindowDesk()), deskTables: tables({programs: {[COUNTER]: {}}})},
+	],
+	["unknown-ref", {initial: opened(threeWindowDesk()), deskTables: tables({inspectors: {}})}],
+	[
+		"kind-mismatch",
+		{
+			initial: opened(threeWindowDesk()),
+			deskTables: tables({
+				inspectors: {
+					[INSPECTOR_REF.ref]: inspector(() => <p>wrong kind</p>, "isolated-frame"),
+				},
+			}),
+		},
+	],
+];
+
+describe("every reason the inspector has nothing to show", () => {
+	for (const [reason, props] of emptyCases) {
+		it(`renders a placeholder for ${reason}`, () => {
+			render(<Harness {...props} />);
+			const panel = region();
+			expect(panel).not.toBeNull();
+			expect(within(panel as HTMLElement).getByText("Nothing to inspect")).toBeTruthy();
+			// A placeholder, not a hole: the reason is spelled out for the reader.
+			expect((panel as HTMLElement).textContent?.length ?? 0).toBeGreaterThan(
+				"Nothing to inspect".length,
+			);
+		});
+	}
+});
+
+describe("the composed status bar", () => {
+	it("puts the shell's own facts left and right and the program's segments in the middle", () => {
+		render(<Harness initial={threeWindowDesk()} />);
+		expect(group("Workspace").textContent).toContain("workspace-0");
+		expect(group("Shell").textContent).toContain("2 processes");
+		expect(group("Shell").textContent).toContain("rev 7");
+		expect(group("Program").textContent).toBe("12 lines");
+		// The program reached the middle and nothing else on the bar.
+		expect(group("Workspace").textContent).not.toContain("12 lines");
+		expect(group("Shell").textContent).not.toContain("12 lines");
+	});
+
+	it("renders an empty middle rather than an error when no program filled it", () => {
+		render(<Harness initial={threeWindowDesk()} deskTables={noDeskTables} />);
+		expect(group("Program").textContent).toBe("");
+		expect(group("Workspace").textContent).toContain("workspace-0");
+	});
+
+	it("keeps the announcements the line carried before it was composed", () => {
+		render(<Harness initial={threeWindowDesk()} />);
+		const bar = screen.getByRole("region", {name: "Shell status"});
+		expect(bar.textContent).toContain("idle");
+		expect(bar.textContent).toContain("Prefix idle.");
+		expect(within(bar).getByText(defaultPrefixTable.prefix).tagName).toBe("KBD");
+
+		act(() => {
+			fireEvent.keyDown(document, {key: "b", ctrlKey: true, code: "KeyB"});
+		});
+		expect(bar.textContent).toContain("armed");
+		expect(bar.textContent).toContain("Prefix armed, waiting for a sequence.");
+	});
+});
+
+/**
+ * The axe pass runs over the desk with the inspector open, scoped to the two regions this diff
+ * builds. Widening it to the whole desk would red this gate on two defects it does not own and
+ * cannot fix here — the empty window's picker `listbox` renders no `option` until a program is
+ * typed (`aria-required-children`), and `react-resizable-panels` renders its separators outside any
+ * landmark (`region`). Both are filed; scoping is the same call `../../claude/window/claude-a11y.unit.test.tsx`
+ * makes for the same reason.
+ */
+describe("axe over the desk with the inspector open", () => {
+	it("reports no violations over the inspector region or the status bar", async () => {
+		render(<Harness initial={opened(threeWindowDesk())} />);
+		const results = await axe.run(
+			{include: [[".tuval-inspector"], [".tuval-status"]]},
+			{
+				// jsdom paints nothing, so axe cannot measure a ratio; the contrast floor is the design
+				// layer's, enforced by `@kampus/design`'s own a11y tier.
+				rules: {"color-contrast": {enabled: false}},
+			},
+		);
+		expect(results.violations.map((violation) => violation.id)).toEqual([]);
+	});
+});

--- a/apps/tuval/src/shell/ui/desk-snapshot.ts
+++ b/apps/tuval/src/shell/ui/desk-snapshot.ts
@@ -1,0 +1,83 @@
+/**
+ * The `DeskSnapshot` the desk regions are composed from, assembled where the live half of it lives.
+ *
+ * `../desk/` is pure and imports no React and nothing from here
+ * ([`.patterns/tuval-shell-assembly.md`](../../../../../.patterns/tuval-shell-assembly.md)), so it
+ * states what a snapshot *is* and never builds one: half of it — the `WindowHost` a renderer mounts
+ * into, and the two renderer tables a page assembles from its own imports — exists only on the
+ * surface. This module is that assembly and nothing else.
+ *
+ * The host comes back through the same `MountResolver` the tiling area already asks per window, so
+ * the inspector cannot mount a host the windows do not also hold; a second lookup here would be a
+ * second answer to "what is this window showing".
+ */
+
+import {ProcessId} from "../../process/process.ts";
+import type {ShellState} from "../core/index.ts";
+import {activeWorkspace, processOf} from "../core/index.ts";
+import type {
+	AnyInspectorRenderer,
+	AnyStatusRenderer,
+	DeclaredRenderers,
+	DeskSnapshot,
+	KernelFacts,
+	SnapshotProcess,
+} from "../desk/index.ts";
+import {WindowId} from "../window/index.ts";
+import type {MountResolver} from "./mount.ts";
+
+/**
+ * The half of a snapshot the shell state does not carry: what the socket said about the kernel and
+ * its processes, and the renderers this page answers a program's references with.
+ */
+export interface DeskTables {
+	readonly kernel: KernelFacts;
+	/** Keyed by process id, as the snapshot reads it. */
+	readonly processes: Readonly<Record<string, SnapshotProcess>>;
+	/** Keyed by `ProgramId`: the two desk references each program row declares. */
+	readonly programs: Readonly<Record<string, DeclaredRenderers>>;
+	/** Both keyed by `RendererRef.ref`, as the window renderer table is. */
+	readonly inspectors: Readonly<Record<string, AnyInspectorRenderer>>;
+	readonly statuses: Readonly<Record<string, AnyStatusRenderer>>;
+}
+
+/**
+ * A page that has attached to nothing yet, and what a caller supplying no tables gets. A whole
+ * snapshot's worth of empty rather than an absence, so every region still composes: the inspector
+ * answers with a reason and the bar still carries its shell-owned left and right.
+ */
+export const noDeskTables: DeskTables = {
+	kernel: {processes: 0, revision: 0},
+	processes: {},
+	programs: {},
+	inspectors: {},
+	statuses: {},
+};
+
+export const deskSnapshotOf = (
+	state: ShellState,
+	tables: DeskTables,
+	resolveMount: MountResolver,
+): DeskSnapshot => {
+	const workspace = activeWorkspace(state);
+	const focused = workspace?.focused ?? null;
+	const processId =
+		workspace === undefined || focused === null ? null : processOf(workspace, focused);
+	const mount = focused === null ? null : resolveMount(WindowId.make(focused), processId);
+	return {
+		workspace: state.activeWorkspace,
+		kernel: tables.kernel,
+		focused:
+			focused === null
+				? null
+				: {
+						windowId: WindowId.make(focused),
+						processId: processId === null ? null : ProcessId.make(processId),
+						host: mount !== null && mount._tag === "Bound" ? mount.host : null,
+					},
+		processes: tables.processes,
+		programs: tables.programs,
+		inspectors: tables.inspectors,
+		statuses: tables.statuses,
+	};
+};

--- a/apps/tuval/src/shell/ui/desk.css
+++ b/apps/tuval/src/shell/ui/desk.css
@@ -1,0 +1,83 @@
+/*
+ * Layout for the two desk-level regions — where they sit, not what they look like.
+ *
+ * Everything painted here comes from a `@kampus/design` primitive (`Card` for the inspector panel,
+ * `Kbd` for the prefix chip) or from a role token already declared in `./tokens.css`. There is no
+ * new token in this file and no literal colour, radius or shadow: a rule that wanted one is a rule
+ * that should have reached for a primitive instead.
+ */
+
+/* The tiling area and the inspector share one row; the status line stays below both. */
+.tuval-desk-body {
+	display: flex;
+	flex: 1 1 auto;
+	min-block-size: 0;
+	min-inline-size: 0;
+}
+
+.tuval-inspector {
+	flex: 0 0 auto;
+	inline-size: 320px;
+	max-inline-size: 40%;
+	margin-inline-start: var(--s-2);
+	display: flex;
+	flex-direction: column;
+	/* Its own scroll container, which is what the `tabindex` on it is for: a program's inspector is
+	   as tall as it likes and the desk does not grow to fit it. */
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
+.tuval-inspector-empty {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
+.tuval-inspector-title {
+	margin: 0 0 var(--s-2);
+	font:
+		var(--t-meta) system-ui,
+		sans-serif;
+	color: var(--text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+/* The boundary panel where an inspector threw: the region's box, so the throw costs this column. */
+.tuval-inspector-panel {
+	min-block-size: 0;
+}
+
+/*
+ * The bar's three groups. `left` and `right` hug their ends and the program's middle takes the room
+ * between them, so a program that returns nothing leaves a gap rather than shifting the shell's own
+ * segments around.
+ */
+.tuval-status-group {
+	display: flex;
+	gap: var(--s-4);
+	align-items: center;
+	min-inline-size: 0;
+}
+
+.tuval-status-middle {
+	flex: 1 1 auto;
+	justify-content: center;
+	/* A long segment truncates rather than pushing the kernel facts off the end of the bar. */
+	overflow: hidden;
+}
+
+.tuval-status-segment {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* `attention` is the segment's own word for "read this one"; it is spelled twice, weight and rung,
+   because Pillar 4 forbids carrying meaning on colour alone. */
+.tuval-status-segment[data-tone="attention"] {
+	color: var(--text-primary);
+	font-weight: 600;
+}

--- a/apps/tuval/src/shell/ui/index.ts
+++ b/apps/tuval/src/shell/ui/index.ts
@@ -11,6 +11,8 @@ export {
 } from "./attach.ts";
 export {CommandLine, type CommandLineProps} from "./CommandLine.tsx";
 export {Desk, type DeskProps} from "./Desk.tsx";
+export {DeskInspector, type DeskInspectorProps} from "./DeskInspector.tsx";
+export {type DeskTables, deskSnapshotOf, noDeskTables} from "./desk-snapshot.ts";
 export {ErrorBoundary, type ErrorBoundaryProps} from "./ErrorBoundary.tsx";
 export {
 	type ForwardedKey,


### PR DESCRIPTION
Mounts the two desk-level regions the shell already composed as data. Before this, `desk:inspector-toggle` flipped a flag no surface read, and a program declaring an `inspector` or a `status` renderer saw it run nowhere.

LAW-SOURCE: manifest-prose (the repo ships `design-system-manifest.md` and no typed `design-prohibitions.json`; `fabrika ui law` exit 13).

## What changed

- **`apps/tuval/src/shell/ui/desk-snapshot.ts`** (new) assembles the `DeskSnapshot` on the surface, where the live half of it exists: the `WindowHost` a renderer mounts into, and the two renderer tables a page builds from its own imports. The host comes back through the one `MountResolver` the tiling area already asks per window, so the inspector cannot mount a host the windows do not also hold. The rest arrives as one `DeskTables` prop.
- **`apps/tuval/src/shell/ui/DeskInspector.tsx`** (new) is the region beside the tiling area. Mounted only while the desk holds it open — not a collapsed shell with its own disclosure, because the open bit is desk state the kernel holds and a `Collapsible` would be a second authority over it. Every arm of `DeskEmptyReason` gets a sentence; a renderer that throws is caught by a boundary sized to this column alone.
- **`apps/tuval/src/shell/ui/StatusLine.tsx`** now binds `statusFor`'s composed bar: shell-owned `left`, program-owned `middle`, shell-owned `right`, each a named `group`. `middleEmpty` renders an empty middle. The armed-prefix, pending sequence and polite live region survive unchanged.
- **`apps/tuval/src/shell/transport/{wire,server}.ts`**: `WireProgram` carries the two desk references, both optional. Without them the page can never fill `programs` and the mount is vacuous — every inspector would answer `program-unknown` forever.
- **`.patterns/tuval-shell-assembly.md`**: the surface-side assembly, and the boundary table, which said "two" and is now three.

`apps/tuval/src/shell/desk/` gains no React and no `shell/ui/` import; its boundary test is untouched.

## Built from `@kampus/design`

`Card` for the panel, `EmptyState` for each empty reason, `Kbd` for the prefix chip. `apps/tuval/src/shell/ui/desk.css` (new) carries layout only — flex, sizing, overflow, text truncation — and declares no custom property and no literal colour, radius or shadow. `apps/tuval/src/shell/ui/tokens.css` is untouched.

## What was proven

- 16 new tests in `apps/tuval/src/shell/ui/desk-regions.unit.test.tsx`, over the real reducer: the region absent when closed; open and close on `desk.inspector.toggle`; open on a key a grammar binds to `desk:inspector-toggle`; the open state surviving a workspace create + switch; the tiling area surviving an inspector throw; a placeholder for each of the seven `DeskEmptyReason` arms; the three groups with the program's segments reaching only the middle; an empty middle; the announcements after the rewrite.
- `pnpm typecheck` (all three Tuval lenses), `pnpm lint`, and the whole `src/shell` + `src/page` unit tier (593 tests) pass.
- Looked at in a real browser, twice, against the reconnect proof harness (`src/page/proof/serve.ts`) on a free port: the region renders beside the tiling area with the bar's three groups under both, no page errors, no console errors. The first look showed the empty state sitting near the top of a full-height column, which the second fixed by centring it in what is left of the column (Pillar 3).

## Deviations

- **Evidence not attached** — **Said:** attach `fabrika ui render` captures of the changed surfaces to the PR. **Did:** attached none; `fabrika ui evidence` ran on nothing. **Why:** the repo's `design-harness.json` boots `pnpm dev` and serves `apps/web` at `http://localhost:3000`. Tuval is a local app with its own kernel and page server and has no surface on that harness at all, so no route it can name renders this diff. Run here it also failed to become ready (`@kampus/web:dev` exited 1 in this worktree) — every surface UNKNOWN, exit 11. It was not re-run, because `pnpm dev` at the repo root starts Tuval too and a second run risks the port and state folder a founder's desk is using. **Disposition:** the browser look described above stands in for the capture and is not a capture; the design gate owns whether that is acceptable. Extending the harness to a second app is its own ticket.
- **Narrowed a11y scope** — **Said:** an axe pass over the desk with the inspector open reports no violations. **Did:** scoped the pass to the inspector region and the status bar. **Why:** widened to the whole desk it reds on two defects this lane does not own and cannot fix here — the empty window's picker `listbox` renders no `option` until a program is typed (`aria-required-children`), and `react-resizable-panels` renders its separators outside any landmark (`region`). **Disposition:** both filed; the scoping is the same call `apps/tuval/src/claude/window/claude-a11y.unit.test.tsx` already makes for the same reason.
- **No default key binding added** — **Said:** the `desk:inspector-toggle` command and its bound key visibly open and close the region. **Did:** proved the command and a bound key, without adding a default binding. **Why:** `defaultPrefixTable` binds no key to that row today, and minting one is a grammar decision this ticket does not carry. The command reaches the region through the command line and the palette; the test drives the key path over a table that binds it, which is the shape a config gives a founder. **Disposition:** filed, so the default binding is decided rather than assumed.
- **ARIA role over a semantic element** — **Said:** the status bar's three groups each carry an accessible name. **Did:** named them with `role="group"` on a `div`, under a `biome-ignore` for `useSemanticElements`. **Why:** the rule's suggested `fieldset` groups form controls; these group read-only status text, and `group` is the only role that takes a name here. **Disposition:** `apps/tuval/src/shell/ui/PickerView.tsx` already carries the same ignore for the same reason.
- **Extra shell facts in the left group** — **Said:** the line renders `statusFor`'s three groups. **Did:** the `left` group also carries the workspace position and window count. **Why:** both are shell-owned facts the line showed before this change, and dropping them would be a regression the rewrite smuggled in. **Disposition:** a program's segments still reach only `middle`, which the tests assert from both sides.

Fixes #7873
