### PR TITLE
fix: Stopping a Tuval Pi agent while a turn is in flight never returns

### DIFF
--- a/apps/tuval/src/pi/ai-agent/teardown.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/teardown.unit.test.ts
@@ -95,10 +95,21 @@ describe("closing the process's scope", () => {
  * interrupts its source and waits for it, and a scope finalizer is uninterruptible, so wrapping the
  * hang would hang the wrapper too. Awaiting the fiber instead leaves the failure line as the
  * diagnosis (`.patterns/ci-legible-integration-tests.md`).
+ *
+ * The outer bound only tells a hang from a return; what pins the *correct* return is
+ * `CLOSE_BOUND_MS` over the close alone, measured from the run's last statement. It sits under
+ * every degraded shape this close could take — one `boundedTeardown` ceiling (5s), two of them in
+ * series, and a close that merely waits the scripted turn's remaining 3.75s out — so none of them
+ * can pass as the correct return, which measures in tens of milliseconds.
  */
+const TURN_MS = 4_000;
+const REACHED_MS = 250;
+const CLOSE_BOUND_MS = 1_000;
+
 describe("closing the process's scope with a turn in flight", () => {
 	it.live("returns, and still disposes the session exactly once", () => {
-		const host = makeScriptedHost({promptDelayMs: 4_000});
+		const host = makeScriptedHost({promptDelayMs: TURN_MS});
+		let leftAt = 0;
 		return Effect.gen(function* () {
 			const baseline = sockets();
 			const run = Effect.gen(function* () {
@@ -107,7 +118,10 @@ describe("closing the process's scope with a turn in flight", () => {
 				// `prompt` returns at the send (#8018), so the turn is running when this returns and
 				// the sleep is only there to let the host reach it before the scope closes.
 				yield* agent.prompt("mid-turn");
-				yield* Effect.sleep("250 millis");
+				yield* Effect.sleep(`${REACHED_MS} millis`);
+				yield* Effect.sync(() => {
+					leftAt = Date.now();
+				});
 				return started.sessionId;
 			}).pipe(Effect.provide(aiAgentOverHost().pipe(Layer.provide(host.layer))), Effect.scoped);
 
@@ -118,6 +132,11 @@ describe("closing the process's scope with a turn in flight", () => {
 				"closing the scope with a turn in flight never returned",
 			);
 			const sessionId = yield* Fiber.join(fiber);
+			assert.isBelow(
+				Date.now() - leftAt,
+				CLOSE_BOUND_MS,
+				`the close returned, but took long enough to be a ceiling expiring or the ${TURN_MS}ms turn being waited out rather than a stop taken mid-turn`,
+			);
 
 			assert.deepStrictEqual(
 				[...host.disposals.entries()],

--- a/apps/tuval/src/pi/client/PiClientService.ts
+++ b/apps/tuval/src/pi/client/PiClientService.ts
@@ -176,7 +176,9 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 			// A release has no error channel to model into, so the settle is one arm either way: a
 			// rejection is nothing this scope can act on. The wait is the one thing that matters
 			// here and it runs under `../teardown.ts`'s ceiling, because a `dispose` that never
-			// resolves would hang the close for good.
+			// resolves would hang the close for good. `dispose()` is not `async` at the 0.84.3 pin,
+			// so it can throw before returning its promise; the ceiling folds that throw rather
+			// than letting it escape this uninterruptible finalizer.
 			(open) =>
 				boundedTeardown("the Pi client's dispose", (settled) => {
 					open.dispose().then(settled, settled);

--- a/apps/tuval/src/pi/client/client.unit.test.ts
+++ b/apps/tuval/src/pi/client/client.unit.test.ts
@@ -1,3 +1,4 @@
+import type {ByteTransportFactory} from "@earendil-works/pi-client";
 import {
 	PiClientDisposedError,
 	PiDisconnectedError,
@@ -7,11 +8,13 @@ import {
 } from "@earendil-works/pi-client";
 import type {ClientMessage, ServerMessage, SessionSnapshot} from "@earendil-works/pi-protocol";
 import {assert, describe, it} from "@effect/vitest";
-import {Cause, Effect, type Exit, Option, Queue, Stream} from "effect";
+import {Cause, Duration, Effect, type Exit, Option, Queue, Stream} from "effect";
+import {TEARDOWN_CEILING} from "../teardown.ts";
 import {Disconnected, SessionLocked, SessionNotFound} from "./errors.ts";
 import {defaultAnswer, startProtocolServer} from "./fixtures.ts";
 import {PiClientService} from "./PiClientService.ts";
 import {connectionRefusalOf, sessionRefusalOf} from "./refusals.ts";
+import {webSocketTransportFactory} from "./transport.ts";
 
 /** Long enough for a hidden retry to have redialled, if the client held one. */
 const SETTLE_MS = 200;
@@ -198,6 +201,51 @@ describe("the PiClient lease service", () => {
 				const exit = yield* Effect.exit(pi.prompt("s-unknown", "hello"));
 				assert.instanceOf(failureOf(exit), SessionNotFound);
 			}).pipe(Effect.provide(PiClientService.layerWebSocket({url: server.url})));
+		}).pipe(Effect.scoped),
+	);
+});
+
+/**
+ * `PiClient.dispose()` is not `async` at the 0.84.3 pin: its body rejects the pending requests,
+ * calls `#connection.disconnect(error)` and disposes the state before the promise is returned
+ * (`dist/client.js` line 292), and `disconnect` reaches `transport?.close()` with no try/catch
+ * (`dist/connection.js` line 190). A transport whose `close()` throws therefore makes `dispose()`
+ * throw synchronously — into an uninterruptible release, where an escaping throw would leave the
+ * ceiling's timer armed and the stop never resumed.
+ */
+const closeThrows = (url: string): ByteTransportFactory => {
+	const open = webSocketTransportFactory({url});
+	return async (handlers) => {
+		const transport = await open(handlers);
+		return {
+			send: (chunk) => transport.send(chunk),
+			close: () => {
+				transport.close();
+				// biome-ignore lint/plugin: the throw is the subject under test — the pin's own `transport?.close()` call site has no try/catch, so this is how a real one lands.
+				throw new Error("the transport refused to close");
+			},
+		};
+	};
+};
+
+describe("the lease service's release", () => {
+	it.live("returns when the client's dispose throws synchronously", () =>
+		Effect.gen(function* () {
+			const server = yield* startProtocolServer();
+			const started = Date.now();
+			yield* Effect.gen(function* () {
+				const pi = yield* PiClientService;
+				yield* pi.connect;
+				assert.isTrue(yield* pi.connected);
+			}).pipe(
+				Effect.provide(PiClientService.layer({transportFactory: closeThrows(server.url)})),
+				Effect.scoped,
+			);
+			assert.isBelow(
+				Date.now() - started,
+				Duration.toMillis(TEARDOWN_CEILING),
+				"a throwing dispose left the release waiting out the ceiling instead of returning on it",
+			);
 		}).pipe(Effect.scoped),
 	);
 });

--- a/apps/tuval/src/pi/teardown.ts
+++ b/apps/tuval/src/pi/teardown.ts
@@ -17,7 +17,13 @@ export const TEARDOWN_CEILING = Duration.seconds(5);
  * Wait for `register` to report settled, or give the wait up at `ceiling`.
  *
  * Expiry logs and returns rather than failing: a socket the runtime never reported closed is a
- * worse outcome than nothing, and a far better one than a stop that never returns.
+ * worse outcome than nothing, and a far better one than a stop that never returns. A `register`
+ * that throws synchronously ends the wait the same way, because `Effect.callback` calls it with no
+ * try/catch of its own (`internal/effect.js`'s `callbackOptions`, `const onCancel = register(…)`,
+ * at the rc.112 pin): an escaping throw would leave this uninterruptible finalizer with the ceiling
+ * timer still armed and no `resume` ever taken. `PiClient.dispose()` is the live case — it is not
+ * `async`, and its body rejects pending requests, disconnects the transport and disposes the state
+ * synchronously before the promise is returned (`pi-client@0.84.3`, `dist/client.js` line 292).
  */
 export const boundedTeardown = (
 	what: string,
@@ -26,18 +32,25 @@ export const boundedTeardown = (
 ): Effect.Effect<void> =>
 	Effect.callback<void>((resume) => {
 		let done = false;
-		const finish = (expired: boolean): void => {
+		const finish = (outcome: Effect.Effect<void>): void => {
 			if (done) return;
 			done = true;
 			clearTimeout(timer);
-			resume(
-				expired
-					? Effect.logWarning(
-							`teardown gave up waiting on ${what} after ${Duration.toMillis(ceiling)}ms`,
-						)
-					: Effect.void,
-			);
+			resume(outcome);
 		};
-		const timer = setTimeout(() => finish(true), Duration.toMillis(ceiling));
-		register(() => finish(false));
+		const timer = setTimeout(
+			() =>
+				finish(
+					Effect.logWarning(
+						`teardown gave up waiting on ${what} after ${Duration.toMillis(ceiling)}ms`,
+					),
+				),
+			Duration.toMillis(ceiling),
+		);
+		// biome-ignore lint/plugin: `register` is a foreign callback rather than an effect, so `Effect.try` cannot wrap it without giving up the `resume` this whole callback is built around; the throw is folded into the ceiling's own outcome instead of modelled as a failure.
+		try {
+			register(() => finish(Effect.void));
+		} catch (cause) {
+			finish(Effect.logWarning(`teardown's wait on ${what} threw`, cause));
+		}
 	});

--- a/apps/tuval/src/pi/teardown.unit.test.ts
+++ b/apps/tuval/src/pi/teardown.unit.test.ts
@@ -9,7 +9,12 @@ import {assert, describe, it} from "@effect/vitest";
 import {Duration, Effect, Fiber} from "effect";
 import {boundedTeardown} from "./teardown.ts";
 
-const CEILING = Duration.millis(60);
+/**
+ * Wide enough that a saturated machine cannot beat a settle to it: at 60ms a parallel run's
+ * scheduler delay alone expired the ceiling and reddened the settled case (#8119). The give-up case
+ * pays it in full, so it is the only cost of the width.
+ */
+const CEILING = Duration.millis(500);
 
 const closing = (release: Effect.Effect<void>) =>
 	Effect.acquireRelease(Effect.void, () => release).pipe(Effect.scoped);

--- a/apps/tuval/src/pi/teardown.unit.test.ts
+++ b/apps/tuval/src/pi/teardown.unit.test.ts
@@ -41,6 +41,31 @@ describe("a bounded teardown wait", () => {
 		}),
 	);
 
+	// `Effect.callback` calls `register` with no try/catch of its own, so an escaping throw would
+	// leave the finalizer with the timer armed and no resume ever taken. Returning below the
+	// ceiling is what proves the throw was folded rather than swallowed: a swallow with no resume
+	// reads as a wait that never settles, and pays the ceiling.
+	it.live("returns below the ceiling when the wait throws synchronously", () =>
+		Effect.gen(function* () {
+			const started = Date.now();
+			yield* closing(
+				boundedTeardown(
+					"a wait that throws",
+					() => {
+						// biome-ignore lint/plugin: the throw is the subject under test — a foreign callback failing the way `PiClient.dispose()` can, not a failure this code models.
+						throw new Error("the wait refused to register");
+					},
+					CEILING,
+				),
+			);
+			assert.isBelow(
+				Date.now() - started,
+				Duration.toMillis(CEILING),
+				"a throwing wait paid the ceiling instead of returning on the throw",
+			);
+		}),
+	);
+
 	it.live("still runs the wait when the stop arrived as an interrupt", () =>
 		Effect.gen(function* () {
 			let waited = false;


### PR DESCRIPTION
Fixes #7896.

The two criteria the review appended to #7896 after PR #8175 landed. #8175 carries the rest.

## Criterion 7 — the mid-turn close is now bounded by the close, not by the run

The old assertion was a 20-second `timeoutOption` over the whole forked run, which admitted every
shape it was supposed to refuse: two `boundedTeardown` ceilings expiring in series (10s), one
expiring (5s), and a close that just waits the scripted turn's remaining 3.75s out.

`apps/tuval/src/pi/ai-agent/teardown.unit.test.ts` now times the close alone — the run stamps
`leftAt` as its last statement, so the measurement starts where `Effect.scoped` begins closing — and
asserts it under `CLOSE_BOUND_MS`, 1 second. The correct close measures 10ms on this machine, so the
bound sits ~100x above the real answer and below every degraded shape above. The 20s outer bound
stays, doing the one job it can do: telling a hang from a return, with its own failure line.

I checked the assertion is live rather than vacuous by setting the bound to 1ms and reading the
failure back: `expected 10 to be below 1`.

## Criterion 8 — a synchronous throw out of `dispose()` no longer escapes the finalizer

Grounded in both pins rather than assumed:

- `PiClient.dispose()` is not `async` (`pi-client@0.84.3`, `dist/client.js` line 292). Its body
  rejects the pending requests, calls `#connection.disconnect(error)` and disposes the state before
  the promise is returned, and `disconnect` reaches `transport?.close()` with no try/catch
  (`dist/connection.js` line 190). A transport whose `close()` throws makes `dispose()` throw
  synchronously.
- `Effect.callback` calls its register with no try/catch: `internal/effect.js`'s `callbackOptions`
  is `const onCancel = register(…)`, bare, at the rc.112 pin.

So the throw escaped an uninterruptible finalizer with the ceiling's `setTimeout` still armed and no
`resume` ever taken. The fix is in `apps/tuval/src/pi/teardown.ts`, not at the one call site: every
`boundedTeardown` caller hands it a foreign callback, and the server's `server.close(cb)` has the
same exposure. `register` now runs under a guard whose catch routes into the same `finish` the
settle and the expiry use, so the timer is cleared on one path for all three outcomes. The throw is
logged and the close returns, matching what expiry already does — a release has no error channel to
model into.

The guard is a raw `try/catch` with a `biome-ignore` and a reason: `Effect.try` cannot wrap
`register` without giving up the `resume` the callback is built around.

## Two tests, both red before the fix

Both were run against the unfixed `boundedTeardown` and both failed there:

- `apps/tuval/src/pi/teardown.unit.test.ts` — a register that throws must return below the ceiling.
  A swallowed throw with no resume reads as a wait that never settles and pays the ceiling, so the
  bound is what separates folded from swallowed.
- `apps/tuval/src/pi/client/client.unit.test.ts` — the real client site, over the folder's own
  loopback protocol server, with the transport wrapped so its `close()` throws after closing. The
  red run's stack was the whole path: `PiClient.dispose` → `Connection.disconnect` →
  `#failAndClose` → the throwing `close`, out through `PiClientService.ts` into `teardown.ts`.

`pnpm typecheck`, `pnpm lint` and the full `apps/tuval` suite (1599 tests, unit + integration) are
green.

## Deviations

- **Out-of-scope change** — **Said:** #7896's criteria 7 and 8 name the mid-turn bound and the Pi
  client's release. **Did:** also widened `CEILING` in `apps/tuval/src/pi/teardown.unit.test.ts`
  from 60ms to 500ms. **Why:** at 60ms the settled case is red under a saturated parallel run — the
  scheduler's own delay expires the ceiling before the callback lands, which I hit on the pre-push
  leg (#8119). The give-up case pays the extra 440ms; nothing else does. **Disposition:** stated
  here.
- **Known defect left unfixed** — **Said:** nothing about the pre-push hook. **Did:** left it
  alone after eight refused pushes. **Why:** `apps/tuval/src/boot.unit.test.ts` and
  `src/shell/program.unit.test.ts` time out under the load the hook creates, and the hook pulls them
  in because `--changed` does not scope inside it. Both are filed and neither is mine: #8209, #7995,
  #8198, #8119. The ninth attempt went through unchanged. **Disposition:** stated here.
