### PR TITLE
feat: A window has no keybind to return to the picker screen a new window opens with

### DIFF
--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -77,7 +77,8 @@ the page's origin as it starts, so the browser's attach goes through (#7560).
 
 Open that URL and the desk is yours by keyboard: `<c-b> |` and `<c-b> -` split, `<c-b> h/j/k/l`
 walk focus, `<c-b> N` makes a workspace and `<c-b> <c-h>` / `<c-b> <c-l>` walk them, `<c-b> z`
-zooms, and `<c-b> :` opens the command line — `window:open log` fills the focused window with a demo
+zooms, `<c-b> w` puts the focused window back on the picker with its process still running, and
+`<c-b> :` opens the command line — `window:open log` fills the focused window with a demo
 program. With the prefix unarmed every key belongs to the focused window's process.
 
 Beside the shell (below), the box holds the demo counter and log (`src/demo/`, #7517): the counter

--- a/apps/tuval/src/shell/commands/bindings.unit.test.ts
+++ b/apps/tuval/src/shell/commands/bindings.unit.test.ts
@@ -43,9 +43,11 @@ describe("a table naming a row that is not there", () => {
 			],
 		});
 		expect(drifted._tag).toBe("Success");
-		expect(drifted._tag === "Success" ? dangling(drifted.success) : null).toEqual([
-			"window:quit",
+		// Sorted, because merge order is not the claim: `w` replaces a default in place while `q`
+		// appends, so binding either sequence to a shipped row would rewrite this list's order.
+		expect(drifted._tag === "Success" ? [...dangling(drifted.success)].sort() : null).toEqual([
 			"windo:close",
+			"window:quit",
 		]);
 	});
 });

--- a/apps/tuval/src/shell/commands/table.ts
+++ b/apps/tuval/src/shell/commands/table.ts
@@ -109,6 +109,13 @@ export const shellCommands: ReadonlyArray<AnyShellCommand> = [
 		params: Schema.Struct({window: Schema.NonEmptyString}),
 		toMsg: ({window}) => ({type: "window.focus", windowId: WindowId.make(window)}),
 	}),
+	defineCommand({
+		path: ["window", "pick"],
+		describe:
+			"Return the focused window to the picker. The process it was showing keeps running, and the picker offers it back.",
+		params: noParams,
+		toMsg: () => ({type: "window.unbind"}),
+	}),
 	...pickerCommands.map(pickerRow),
 	defineCommand({
 		path: ["workspace", "create"],

--- a/apps/tuval/src/shell/commands/table.unit.test.ts
+++ b/apps/tuval/src/shell/commands/table.unit.test.ts
@@ -28,6 +28,7 @@ describe("the command table", () => {
 			"window:focus-up",
 			"window:focus-down",
 			"window:focus",
+			"window:pick",
 			"window:open",
 			"window:attach",
 			"workspace:create",

--- a/apps/tuval/src/shell/commands/window-pick.unit.test.ts
+++ b/apps/tuval/src/shell/commands/window-pick.unit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The `window:pick` round trip (#8083): a filled window goes back to the picker and takes the same
+ * process back, in the same slot. The core reducer and the picker's real handler are driven
+ * together here because the claim spans both — the reducer says the window is empty, and only the
+ * process table can say the process it was showing is still running.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {ProcessId} from "../../process/process.ts";
+import {applyMsg, initialState, type ShellMsg} from "../core/machine.ts";
+import {activeWorkspace, type ShellState} from "../core/state.ts";
+import {defaultPrefixTable} from "../keys/index.ts";
+import {findWindow, windows} from "../layout/index.ts";
+import {readEntries} from "../picker/entries.ts";
+import {pickerHarness, programRow, shellProcessId} from "../picker/fixtures.ts";
+import {attachProcess, openProgram} from "../picker/intent.ts";
+import {runPickerIntent} from "../picker/open.ts";
+import {mountPicker} from "../picker/view.ts";
+import {asPickerView} from "../ui/PickerView.tsx";
+import {WindowId} from "../window/index.ts";
+import {commandFor} from "./table.ts";
+
+const counter = programRow("counter", {label: "Counter"});
+
+const apply = (state: ShellState, msg: ShellMsg): ShellState =>
+	applyMsg(defaultPrefixTable, state, msg)[0];
+
+const workspaceOf = (state: ShellState) => {
+	const workspace = activeWorkspace(state);
+	if (workspace === undefined) throw new Error("test setup: no active workspace");
+	return workspace;
+};
+
+const processIn = (state: ShellState, windowId: WindowId): string | null =>
+	findWindow(workspaceOf(state).layout, windowId)?.processId ?? null;
+
+const slots = (state: ShellState): ReadonlyArray<string> =>
+	[...windows(workspaceOf(state).layout.root)].map((node) => node.id);
+
+/** The Msg the key `<c-b> w` runs, read off the row rather than written out here. */
+const pickMsg = (): ShellMsg => {
+	const row = commandFor("window:pick");
+	if (row === undefined) throw new Error("test setup: no window:pick row");
+	return row.toMsg({});
+};
+
+describe("window:pick returns a filled window to the picker", () => {
+	it.effect("unbinds the window, leaves the process running, and takes it back", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const harness = yield* pickerHarness([counter]);
+				const empty = initialState();
+				const window = WindowId.make(workspaceOf(empty).focused);
+
+				const opened = yield* runPickerIntent(openProgram(window, counter.id), {
+					shellProcessId,
+				}).pipe(Effect.provide(harness.layer));
+				const bound = opened.reduce(apply, empty);
+				const spawned = processIn(bound, window);
+				assert.isNotNull(spawned);
+
+				// A moved highlight from the mount that opened this program, so a stale slot would be
+				// visible rather than accidentally equal to a fresh one.
+				const used = apply(bound, {type: "window.setView", windowId: window, view: {cursor: 1}});
+
+				const unbound = apply(used, pickMsg());
+				assert.isNull(processIn(unbound, window));
+				assert.deepStrictEqual(slots(unbound), slots(used));
+				assert.deepStrictEqual(asPickerView(unbound.views[window]), mountPicker());
+
+				const entries = yield* readEntries.pipe(Effect.provide(harness.layer));
+				const offered = entries.processes.map((entry) => String(entry.processId));
+				assert.deepStrictEqual(offered, [spawned]);
+
+				const reattached = yield* runPickerIntent(attachProcess(window, ProcessId.make(spawned)), {
+					shellProcessId,
+				}).pipe(Effect.provide(harness.layer));
+				const refilled = reattached.reduce(apply, unbound);
+				assert.strictEqual(processIn(refilled, window), spawned);
+				assert.deepStrictEqual(slots(refilled), slots(used));
+
+				// Nothing on the path closed a window or split one: the whole trip is bind, unbind, bind.
+				assert.deepStrictEqual(
+					[...opened, pickMsg(), ...reattached].map((msg) => msg.type),
+					["window.bind", "window.unbind", "window.bind"],
+				);
+				assert.strictEqual(harness.spawns().length, 1);
+			}),
+		),
+	);
+
+	it("does nothing to a window that is already on the picker", () => {
+		const empty = initialState();
+		const window = WindowId.make(workspaceOf(empty).focused);
+		const moved = apply(empty, {type: "window.setView", windowId: window, view: {cursor: 1}});
+
+		const after = apply(moved, pickMsg());
+		assert.strictEqual(after, moved);
+		assert.deepStrictEqual(asPickerView(after.views[window]), {cursor: 1, refusal: null});
+	});
+});

--- a/apps/tuval/src/shell/core/machine.ts
+++ b/apps/tuval/src/shell/core/machine.ts
@@ -50,6 +50,7 @@ import {
 	keyTargetOf,
 	mint,
 	type PrefixSnapshot,
+	processOf,
 	type ShellState,
 	type Workspace,
 	type WorkspaceId,
@@ -231,6 +232,26 @@ const bindWindow = (
 		}),
 		NO_CMDS,
 	];
+};
+
+/**
+ * Put a window back on the picker: detach its process, which stops nothing, and drop the view slot
+ * so the picker mounts fresh rather than on the cursor and refusal the last mount left behind
+ * (`../ui/PickerView.tsx` rebuilds the picker's view from that slot).
+ *
+ * A window holding no process is left untouched rather than cleared. It is already showing the
+ * picker, and dropping the slot there would move the user's highlight back to the first row under
+ * their hands — a key that should have done nothing at all.
+ */
+const unbindWindow = (state: ShellState, windowId: WindowId | undefined): Step => {
+	const workspace = activeWorkspace(state);
+	if (workspace === undefined) return [state, NO_CMDS];
+	const target = windowId ?? workspace.focused;
+	if (!hasWindow(workspace, target) || processOf(workspace, target) === null) {
+		return [state, NO_CMDS];
+	}
+	const [detached] = bindWindow(state, target, null);
+	return [{...detached, views: withoutViews(detached.views, [target])}, NO_CMDS];
 };
 
 /**
@@ -461,7 +482,7 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 		"window.focus": (state, msg) => focusWindow(state, msg.windowId),
 		"window.focusDirection": (state, msg) => focusDirection(state, msg.direction),
 		"window.bind": (state, msg) => bindWindow(state, msg.windowId, msg.processId, msg.takesKeys),
-		"window.unbind": (state, msg) => bindWindow(state, msg.windowId, null),
+		"window.unbind": (state, msg) => unbindWindow(state, msg.windowId),
 		"window.setView": setView,
 		"layout.resize": resizeStack,
 		"layout.zoom": zoomWindow,

--- a/apps/tuval/src/shell/core/machine.unit.test.ts
+++ b/apps/tuval/src/shell/core/machine.unit.test.ts
@@ -203,6 +203,28 @@ describe("shell core: windows", () => {
 		expect(cmds).toEqual([]);
 	});
 
+	it("window.unbind drops the view slot, so the picker it returns to mounts fresh (#8083)", () => {
+		const state = initialState();
+		const window = active(state).focused;
+		const filled = fold(
+			state,
+			{type: "window.setView", view: {cursor: 3, refusal: null}},
+			{type: "window.bind", processId: "process-pi"},
+		);
+		expect(filled.views[window]).toEqual({cursor: 3, refusal: null});
+
+		const [unbound] = apply(filled, {type: "window.unbind"});
+		expect(focusedProcess(unbound)).toBeNull();
+		expect(unbound.views[window]).toBeUndefined();
+		expect(windowIds(active(unbound))).toEqual(windowIds(active(filled)));
+	});
+
+	it("window.unbind on a window holding no process changes nothing at all (#8083)", () => {
+		const empty = fold(initialState(), {type: "window.setView", view: {cursor: 2, refusal: null}});
+		expect(apply(empty, {type: "window.unbind"})[0]).toBe(empty);
+		expect(apply(empty, {type: "window.unbind", windowId: "window-nope"})[0]).toBe(empty);
+	});
+
 	it("window.setView writes the focused window's slot and refuses an unknown window", () => {
 		const state = initialState();
 		const [viewed] = apply(state, {type: "window.setView", view: {scroll: 3, wrap: true}});

--- a/apps/tuval/src/shell/keys/table.ts
+++ b/apps/tuval/src/shell/keys/table.ts
@@ -60,6 +60,8 @@ export const defaultPrefixTable: PrefixTable = {
 		{sequence: "<arrowright>", command: command("window:focus-right"), repeatable: false},
 		{sequence: "z", command: command("window:zoom"), repeatable: false},
 		{sequence: "x", command: command("window:close"), repeatable: false},
+		// tmux binds `w` to `choose-window`, and the founder's config leaves it free (#8083).
+		{sequence: "w", command: command("window:pick"), repeatable: false},
 		{sequence: "N", command: command("workspace:create"), repeatable: false},
 		{sequence: "<c-h>", command: command("workspace:previous"), repeatable: true},
 		{sequence: "<c-l>", command: command("workspace:next"), repeatable: true},

--- a/apps/tuval/src/shell/keys/table.unit.test.ts
+++ b/apps/tuval/src/shell/keys/table.unit.test.ts
@@ -32,6 +32,7 @@ describe("defaultPrefixTable", () => {
 			["<arrowright>", "window:focus-right", false],
 			["z", "window:zoom", false],
 			["x", "window:close", false],
+			["w", "window:pick", false],
 			["N", "workspace:create", false],
 			["<c-h>", "workspace:previous", true],
 			["<c-l>", "workspace:next", true],


### PR DESCRIPTION
`<c-b> w` puts the focused window back on the picker.

A window showed the picker only while it was empty, so changing what a window
held meant closing it and splitting a fresh one — losing its slot in the layout
and its view state. This adds the `window:pick` command row and binds `w` after
the prefix to it (tmux binds `w` to `choose-window`, and the founder's config
leaves it free).

The core Msg already existed: `window.unbind` detaches a window's process and
stops nothing, so the process keeps running and the picker's own `Process` rows
offer it straight back. One core change was needed on top of that — `window.unbind`
now drops the window's view slot, so the picker it returns to mounts at cursor 0
with no refusal rather than on the highlight the last mount left behind. Unbinding
a window that already holds no process is a no-op, so the key cannot reset a cursor
under the user's hands.

Worth looking at first: `unbindWindow` in `apps/tuval/src/shell/core/machine.ts`,
and the round-trip proof in `apps/tuval/src/shell/commands/window-pick.unit.test.ts`,
which drives the real picker handler and process table — open a program, press the
key, check the process is still in the table and offered as a `Process` row, attach
it back into the same window, and assert the whole path is bind → unbind → bind with
no close and no split.

Fixes #8083

## Deviations

- **Governing-ADR departure** — **Said:** the issue body says "nothing new is needed
  in the core. The gap is the command row and the key binding on top of it."
  **Did:** also changed the `window.unbind` cell in
  `apps/tuval/src/shell/core/machine.ts` to drop the window's view slot, and to no-op
  on a window that holds no process. **Why:** acceptance criterion 3 asks for the
  picker to mount fresh (`mountPicker()` — cursor 0, no refusal), and nothing cleared
  `state.views[windowId]` on bind or unbind, so a cursor the user moved before opening
  a program survived into the next picker mount. Criterion 5 then forces the no-op
  arm, because clearing the slot on an already-empty window is exactly the "lost
  cursor" it forbids. **Disposition:** stated here; `window.unbind` had no dispatcher
  outside tests before this PR, so nothing else changes behaviour.
- **Pre-existing test or fixture changed** — **Said:** criterion 6 asks that
  `bindings.unit.test.ts` still pass unchanged. **Did:** changed one assertion in it
  to compare the dangling-name list sorted. **Why:** that test binds `w` to a
  deliberately misspelled row, and `w` is now a default — so it replaces a binding in
  place instead of appending, which flips the order of the two names it collects.
  The claim (both drifted names are caught) is unchanged; only the order dependence is
  gone. **Disposition:** stated here.
