### PR TITLE
fix: A prompt payload the ai-agent receiver refuses is still reported as delivered

### DIFF
--- a/apps/tuval/src/ai-agent/ports/payloads.ts
+++ b/apps/tuval/src/ai-agent/ports/payloads.ts
@@ -81,22 +81,26 @@ export const isTranscriptPagePayload = (value: unknown): value is TranscriptPage
  * key the session already saw is dropped rather than re-sent, so a transport retry is free while
  * a deliberate resend mints a new key.
  *
- * Both `key` and `timestamp` are optional on the wire and refused by the receiver when absent
- * (`program.ts`), because the payload predicate is the port's compatibility contract and a field
- * required there is a sender this end can no longer read at all.
+ * Both fields are required here, and that is a reversal (#7991). They used to be optional so an
+ * older sender stayed readable, but the receiver refused an unstamped prompt anyway (`program.ts`)
+ * — into a `failed` Msg only a rendering window can see. So the optionality bought no sender
+ * anything: their turn never ran either way, and the caller read `delivered: true`. Required, the
+ * kernel's own `accepts` check refuses at the send, which is the error the Claude `send` tool
+ * already promises. The kind stays `@1` because the set of payloads that ever produced a turn is
+ * unchanged; only the moment of refusal moved.
  */
 export interface PromptPayload {
 	readonly text: string;
-	readonly key?: string;
+	readonly key: string;
 	/** Epoch milliseconds, stamped by the sender: the turn's clock, since the core reads none. */
-	readonly timestamp?: number;
+	readonly timestamp: number;
 }
 
 export const isPromptPayload = (value: unknown): value is PromptPayload =>
 	Predicate.isObject(value) &&
 	typeof value.text === "string" &&
-	(value.key === undefined || typeof value.key === "string") &&
-	(value.timestamp === undefined || Number.isFinite(value.timestamp));
+	typeof value.key === "string" &&
+	Number.isFinite(value.timestamp);
 
 /** One card the window renders while the program waits for an answer. */
 export interface PermissionRequest {

--- a/apps/tuval/src/ai-agent/ports/payloads.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/payloads.unit.test.ts
@@ -61,14 +61,21 @@ describe("transcript-page payload", () => {
 });
 
 describe("prompt payload", () => {
-	it("admits text with and without an idempotency key", () => {
-		expect(isPromptPayload({text: "go"})).toBe(true);
-		expect(isPromptPayload({text: "go", key: "turn-4"})).toBe(true);
+	it("admits text carrying both an idempotency key and a timestamp", () => {
+		expect(isPromptPayload({text: "go", key: "turn-4", timestamp: 1_700_000_000_000})).toBe(true);
 	});
 
 	it("refuses a payload with no text or a non-string key", () => {
-		expect(isPromptPayload({key: "turn-4"})).toBe(false);
-		expect(isPromptPayload({text: "go", key: 4})).toBe(false);
+		expect(isPromptPayload({key: "turn-4", timestamp: 1})).toBe(false);
+		expect(isPromptPayload({text: "go", key: 4, timestamp: 1})).toBe(false);
+	});
+
+	// The port refuses these rather than the receiver, so the sender reads the refusal (#7991).
+	it("refuses a payload missing the key or the timestamp", () => {
+		expect(isPromptPayload({text: "go"})).toBe(false);
+		expect(isPromptPayload({text: "go", key: "turn-4"})).toBe(false);
+		expect(isPromptPayload({text: "go", timestamp: 1})).toBe(false);
+		expect(isPromptPayload({text: "go", key: "turn-4", timestamp: Number.NaN})).toBe(false);
 	});
 });
 

--- a/apps/tuval/src/ai-agent/ports/ports.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/ports.unit.test.ts
@@ -58,7 +58,7 @@ describe("the five AI agent ports", () => {
 		expect(
 			transcript.outbound().accepts({items: [], omitted: {items: 0, bytes: 0, reason: "none"}}),
 		).toBe(true);
-		expect(prompt.inbound().accepts({text: "go"})).toBe(true);
+		expect(prompt.inbound().accepts({text: "go", key: "k1", timestamp: 1})).toBe(true);
 		expect(prompt.inbound().accepts({items: []})).toBe(false);
 	});
 });

--- a/apps/tuval/src/ai-agent/program.ts
+++ b/apps/tuval/src/ai-agent/program.ts
@@ -28,7 +28,6 @@ import {
 	aiAgentSessionMachine,
 	MODE_UNSUPPORTED,
 	PAGE_ERROR,
-	PROMPT_ERROR,
 	portRefused,
 	readCheckpoint,
 	UNKNOWN_REQUEST,
@@ -137,25 +136,15 @@ export const aiAgentProgram = <RIn = never>(
 		}),
 		ports: portsOf(),
 		receive: {
-			[aiAgentPortNames.prompt]: (payload: PromptPayload) => {
-				if (payload.key === undefined) {
-					return refuse(
-						PROMPT_ERROR,
-						`a prompt arrived with no idempotency key: "${payload.text}"`,
-					);
-				}
-				// Refused rather than stamped here: a receiver is a pure translation, and the turn the
-				// core records off this Msg needs a clock only its sender holds (#7978).
-				if (payload.timestamp === undefined) {
-					return refuse(PROMPT_ERROR, `a prompt arrived with no timestamp: "${payload.text}"`);
-				}
-				return {
-					type: "prompt",
-					text: payload.text,
-					key: payload.key,
-					timestamp: payload.timestamp,
-				};
-			},
+			// A pure translation with nothing to refuse: the port's predicate requires the key and the
+			// timestamp, so the kernel's `accepts` check turns an unstamped prompt away at the send
+			// and the caller reads that refusal (#7991).
+			[aiAgentPortNames.prompt]: (payload: PromptPayload) => ({
+				type: "prompt",
+				text: payload.text,
+				key: payload.key,
+				timestamp: payload.timestamp,
+			}),
 			[aiAgentPortNames.pageRequest]: (payload: TranscriptPagePayload) =>
 				payload.kind === "request"
 					? {type: "page", before: payload.before, limit: payload.limit}

--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -969,6 +969,22 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 								(entry: TableRow) => entry.id === spawned.process,
 							) as TableRow;
 
+							// An unstamped prompt is refused at the send (#7991). Asserted here because the
+							// alternative is the failure this case used to have: a delivered nobody could
+							// act on, and a poll below that runs to the test's own timeout.
+							const unstamped = yield* callTool("send", () =>
+								tools.handlers.send({
+									process: spawned.process,
+									port: "prompt",
+									payload: {text: CHILD_PROMPT, key: "child-unstamped"},
+								}),
+							);
+							assert.strictEqual(
+								unstamped.isError,
+								true,
+								"the child's prompt port took a payload carrying no timestamp",
+							);
+
 							const sent = answered(
 								yield* callTool("send", () =>
 									tools.handlers.send({

--- a/apps/tuval/src/claude/tools/server.ts
+++ b/apps/tuval/src/claude/tools/server.ts
@@ -72,7 +72,7 @@ const KERNEL =
 	"Tuval's kernel is a registry of programs and a table of running processes; a process has typed ports, an in-port you write to and an out-port you read from.";
 
 const SPAWN_DESCRIPTION = `Start a new process of a program the registry knows, as a child of your own process. ${KERNEL} Answers with the new process's id.`;
-const SEND_DESCRIPTION = `Write one payload to a named in-port of a process you spawned. ${KERNEL} The port decides what it takes, and a payload it refuses is an error naming what the port takes.`;
+const SEND_DESCRIPTION = `Write one payload to a named in-port of a process you spawned. ${KERNEL} The port decides what it takes, and a payload it refuses is an error naming what the port takes. One exception: a port whose protocol runs both ways takes either direction's payload, so a reply written to the end that takes requests is delivered here and refused inside the process, where nothing this tool answers reports it.`;
 const READ_DESCRIPTION = `Read the current value of a named out-port of a process you spawned. ${KERNEL} A port that has said nothing yet answers empty rather than making you wait.`;
 
 const text = (value: unknown): CallToolResult => ({

--- a/apps/tuval/src/claude/tools/server.unit.test.ts
+++ b/apps/tuval/src/claude/tools/server.unit.test.ts
@@ -11,6 +11,8 @@
 import {assert, describe, it} from "@effect/vitest";
 import type {CallToolResult} from "@modelcontextprotocol/sdk/types.js";
 import {type Context, Effect, Schema} from "effect";
+import {aiAgentPortNames} from "../../ai-agent/handlers/index.ts";
+import {prompt} from "../../ai-agent/ports/index.ts";
 import {ProcessId} from "../../process/process.ts";
 import {ProgramId} from "../../registry/program.ts";
 import {KernelBridge, type ScriptedKernel} from "./KernelBridge.ts";
@@ -55,12 +57,12 @@ class TestIo extends Schema.TaggedError<TestIo>()("TestIo", {cause: Schema.Defec
 const answered = <A>(call: () => Promise<A>): Effect.Effect<A> =>
 	Effect.tryPromise({try: call, catch: (cause) => new TestIo({cause})}).pipe(Effect.orDie);
 
-const server = () =>
+const server = (rows: ScriptedKernel = table) =>
 	Effect.gen(function* () {
 		const bridge = yield* KernelBridge;
 		const run = countingRuntime(yield* Effect.context<never>());
 		return {tools: tuvalToolServer(bridge, run), run};
-	}).pipe(Effect.provide(KernelBridge.scripted(table)));
+	}).pipe(Effect.provide(KernelBridge.scripted(rows)));
 
 const textOf = (result: CallToolResult): string => {
 	const first = result.content[0];
@@ -181,6 +183,52 @@ describe("the tuval tool server", () => {
 				return yield* bridge.spawn(ProgramId.make(scriptedProgram));
 			}).pipe(Effect.provide(KernelBridge.scripted(table)));
 			assert.strictEqual(spawned, scriptedProcess);
+		}),
+	);
+});
+
+/**
+ * The AI agent's own `prompt` port behind the scripted kernel, so what a model reads back from
+ * `send` is judged against the predicate production ships rather than a stand-in (#7991).
+ */
+const agentProcess = ProcessId.make("p-agent");
+const agentTable: ScriptedKernel = {
+	[agentProcess]: {
+		program: "ai-agent",
+		inPorts: {[aiAgentPortNames.prompt]: {kind: prompt.kind, accepts: prompt.is}},
+		outPorts: {},
+	},
+};
+
+describe("send, on the AI agent's prompt port", () => {
+	it.effect("refuses an unstamped prompt at the send instead of answering delivered", () =>
+		Effect.gen(function* () {
+			const {tools} = yield* server(agentTable);
+			const refused = yield* answered(() =>
+				tools.handlers.send({
+					process: agentProcess,
+					port: aiAgentPortNames.prompt,
+					payload: {text: "hi", key: "child-1"},
+				}),
+			);
+			assert.isTrue(refused.isError, "an unstamped prompt was reported as delivered");
+			assert.include(textOf(refused), "tuval/claude/PortRefused");
+			assert.include(textOf(refused), prompt.kind);
+		}),
+	);
+
+	it.effect("takes a prompt carrying both the key and the timestamp", () =>
+		Effect.gen(function* () {
+			const {tools} = yield* server(agentTable);
+			const sent = yield* answered(() =>
+				tools.handlers.send({
+					process: agentProcess,
+					port: aiAgentPortNames.prompt,
+					payload: {text: "hi", key: "child-1", timestamp: 1_700_000_000_000},
+				}),
+			);
+			assert.isNotTrue(sent.isError);
+			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true});
 		}),
 	);
 });


### PR DESCRIPTION
The ai-agent `prompt` port now requires both `key` and `timestamp` in its own predicate, so an unstamped payload is refused at the send instead of being taken and dropped one step later.

## The route, and why this one

Of the three routes the issue names — a new out-port projecting `state.failure`, a refusal on the send reply, or tightening the port predicate — this takes the third, which is also the second: the kernel's `send` already answers `PortRefused` when a port's `accepts` says no (`apps/tuval/src/commands/core/process.ts`), and the Claude `send` tool already renders that as an error naming the port's kind. Tightening the predicate is what puts the prompt port on that path. A new out-port would have left `delivered: true` standing and asked the caller to poll a second port to find out it was a lie.

## Why the docblock's reason no longer holds

`PromptPayload`'s docblock said both fields were optional because "the payload predicate is the port's compatibility contract and a field required there is a sender this end can no longer read at all". That reads as a real cost, but there was none to pay: the receiver refused the unstamped payload anyway, so the sender it was protecting never got a turn either way. What optionality bought was not compatibility but silence — the refusal landed on `state.failure`, which `apps/tuval/src/ai-agent/handlers/publish.ts` projects nowhere, so only a rendering window could see it. The docblock is rewritten to say that, and to say what replaced it.

The kind stays `tuval/ai-agent/prompt@1`. A version bump would say these two ends can no longer talk, and that is false: every payload that ever produced a turn still produces one. Only the moment of refusal moved.

## What changed

- `apps/tuval/src/ai-agent/ports/payloads.ts` — `key` and `timestamp` required on the type and in `isPromptPayload`, docblock rewritten.
- `apps/tuval/src/ai-agent/program.ts` — the `prompt` receiver is now a pure translation; its two `refuse(PROMPT_ERROR, …)` branches were unreachable once the port refuses first. The other three receivers keep theirs: a two-way port kind admits both directions, so those refusals are still real.
- `apps/tuval/src/claude/tools/server.ts` — `SEND_DESCRIPTION` says the two-way-port exception out loud, since a reply written to a request end is still taken here and refused inside the process.
- Proofs: the tool-path case in `server.unit.test.ts` runs the real `prompt` port behind the scripted kernel and asserts an unstamped send is `isError` naming the kind, with a stamped one delivered; the claude-vertical spawn-child case asserts the same refusal before its good send, so a regression fails there on a cause rather than sitting in the poll loop to the 180s timeout.

`pnpm typecheck`, `pnpm lint`, and the apps/tuval unit (1559) and integration (41) suites pass.

Fixes #7991

## Deviations

- **Out-of-scope change** — **Said:** #7991 names the `prompt` port's predicate and the `send` tool description. **Did:** also added the refusal assertion to the claude-vertical spawn-child case in `apps/tuval/src/claude/proof/claude-vertical.integration.test.ts`. **Why:** the fifth acceptance criterion asks that this proof fail with a named cause rather than hang, and that case is where the hang was observed. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about test stability. **Did:** left four apps/tuval unit cases that time out under parallel-lane machine load (`chat-a11y`, `agent-controls`, `handlers`, and `chat-window`'s scroll-offset case). **Why:** they pass alone and on a quiet box, they are unrelated to this diff, and #8119 already owns the cause. **Disposition:** noted on #8119 with the four names.
