### PR TITLE
fix: Tuval chat renders markdown for agent rows but not for the user's own rows

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -178,10 +178,12 @@ const who: Readonly<Record<TranscriptItem["kind"], string>> = {
 };
 
 /**
- * The three treatments an item's body gets. An agent reply is markdown by default and renders
- * through the shared block, which paints synchronously so the row's measurement still holds
- * (#8012); a `user` or `system` line is shown exactly as it arrived, so what the operator typed is
- * never reinterpreted as syntax.
+ * The three treatments an item's body gets. A `tool` call is its own row. Both sides of the
+ * exchange — an agent reply and what the operator typed — render through the shared markdown
+ * block, which paints synchronously so the row's measurement still holds (#8012/#8226): the
+ * transcript reads the same on either side, and a fence the operator sends is the fence the agent
+ * received. A `system` line is the session speaking rather than a person, so it stays exactly as it
+ * arrived.
  */
 function ItemBody({
 	item,
@@ -204,16 +206,16 @@ function ItemBody({
 			/>
 		);
 	}
-	if (item.kind === "assistant") {
-		// The transcript is a region inside the desk, so a `#` heading in a reply is a subsection of
-		// it rather than a page title.
-		return (
-			<Markdown className="tuval-chat-markdown" headingBase={3}>
-				{item.text}
-			</Markdown>
-		);
+	if (item.kind === "system") {
+		return <p className="tuval-chat-text">{item.text}</p>;
 	}
-	return <p className="tuval-chat-text">{item.text}</p>;
+	// The transcript is a region inside the desk, so a `#` heading in a message is a subsection of
+	// it rather than a page title.
+	return (
+		<Markdown className="tuval-chat-markdown" headingBase={3}>
+			{item.text}
+		</Markdown>
+	);
 }
 
 function ItemRow({

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -157,7 +157,9 @@
 	max-inline-size: 100%;
 }
 
-.tuval-chat-row[data-kind="user"] .tuval-chat-text {
+/* The operator's own row renders markdown too (#8226); this keeps the tint that told the two sides
+   apart, over `.kp-markdown`'s own `--text-primary`. */
+.tuval-chat-row[data-kind="user"] .tuval-chat-markdown {
 	color: var(--text-secondary);
 }
 

--- a/apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @vitest-environment jsdom
  *
- * What a transcript row does with the markdown an agent replies in (#8012), rendered through the
- * same window-contract double the rest of this slice uses (`../window/fixtures.ts`).
+ * What a transcript row does with markdown — an agent's reply and the operator's own message alike
+ * (#8012/#8226) — rendered through the same window-contract double the rest of this slice uses
+ * (`../window/fixtures.ts`).
  *
  * Every assertion here reads the DOM straight after `render`, with no `waitFor` and no `act` past
  * the mount. That is deliberate: the transcript is virtualized and each row is measured at the
@@ -127,18 +128,36 @@ describe("an agent reply renders as markdown", () => {
 		expect(row.textContent).toContain("click me");
 	});
 
-	it("leaves a typed message and a session line as plain text", async () => {
-		await openWindow(
-			withTranscript([
-				userItem("u1", "**not bold** | a | b |"),
-				systemItem("s1", "# not a heading"),
-			]),
-		);
+	it("leaves a session line as plain text", async () => {
+		await openWindow(withTranscript([systemItem("s1", "# not a heading")]));
 
 		const row = screen.getByRole("log", {name: "Transcript"});
-		expect(within(row).queryByRole("table")).toBeNull();
 		expect(within(row).queryByRole("heading")).toBeNull();
-		expect(within(row).getByText("**not bold** | a | b |").className).toBe("tuval-chat-text");
 		expect(within(row).getByText("# not a heading").className).toBe("tuval-chat-text");
+	});
+});
+
+describe("a typed message renders as markdown too (#8226)", () => {
+	it("renders a fenced block and a list the operator sent as markup, not as raw text", async () => {
+		const typed = ["- one", "- two", "", "```ts", "const x = 1;", "```"].join("\n");
+		await openWindow(withTranscript([userItem("u1", typed)]));
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		expect(within(row).getAllByRole("listitem")).toHaveLength(2);
+		const code = within(row).getByText("const x = 1;");
+		expect(code.tagName).toBe("CODE");
+		expect(code.parentElement?.tagName).toBe("PRE");
+		expect(within(row).queryByText(typed)).toBeNull();
+	});
+
+	it("renders through the same block, class and headingBase as an agent reply", async () => {
+		await openWindow(withTranscript([userItem("u1", "# ask"), assistantItem("a1", "# answer")]));
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		const headings = within(row).getAllByRole("heading");
+		expect(headings.map((heading) => heading.tagName)).toEqual(["H3", "H3"]);
+		for (const heading of headings) {
+			expect(heading.closest(".tuval-chat-markdown")).not.toBeNull();
+		}
 	});
 });


### PR DESCRIPTION
On the Tuval desk the two sides of the transcript rendered differently: `ItemBody` sent only
`assistant` items through `<Markdown className="tuval-chat-markdown" headingBase={3}>`, so a fence,
a list or a link the operator typed showed as raw text next to a reply that rendered. The founder
called it live on 2026-09-05 ("agent messages are md parsed, but my messages are not :/").

Both sides now render through the same block, the same class and the same `headingBase`. `tool`
still renders through `ToolRow`, untouched.

**The open call in the ticket — `system`.** I kept it plain. A session line is the app speaking
rather than a person, so there is nobody whose markdown it would be honouring, and the branch reads
cleanly as one early return for `system` above the shared markdown tail. The founder's complaint
names his own rows only, which is the ticket's stated default.

The `ItemBody` docblock claimed the plain-text treatment was deliberate ("what the operator typed is
never reinterpreted as syntax"); it now states the treatment per kind as it stands.

Tests: a `user` item carrying a list and a fenced block asserts it renders as `<li>` and
`<pre><code>` rather than raw text, and a second case asserts a `user` and an `assistant` heading
land on the same `H3` inside `.tuval-chat-markdown` — that is the "same component, class and
headingBase" criterion read off the DOM. The full `apps/tuval` suite passes (1643 tests).

Grounded in source, not intuition: `packages/design/src/Markdown.css` sets `color: var(--text-primary)`
on `.kp-markdown`, which is why the retargeted user-row rule is written at
`.tuval-chat-row[data-kind="user"] .tuval-chat-markdown` — a higher-specificity selector that still wins.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8226 names the docblock and a new test.
  **Did:** also rewrote the existing case "leaves a typed message and a session line as plain text"
  in `transcript-markdown.unit.test.tsx`, dropping its `user` half and keeping the `system` half.
  **Why:** that case asserted the exact behaviour this ticket reverses, so it could not survive the
  change; the `system` assertion it also carried is kept as its own case rather than deleted.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the ticket names `ChatWindow.tsx` only. **Did:** also
  retargeted one rule in `apps/tuval/src/shell/chat/chat.css` from
  `.tuval-chat-row[data-kind="user"] .tuval-chat-text` to the same row's `.tuval-chat-markdown`.
  **Why:** `ItemBody` was the only producer of `tuval-chat-text`, so after the change a `user` row
  no longer carries that class — leaving the rule would have made it dead and silently dropped the
  `--text-secondary` tint that tells the two sides apart. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about CSS validation. **Did:** left
  `chat.css` outside the green — `build check --surface code` names it in `unvalidated`, and no
  surface this skill offers validates a stylesheet. **Why:** the file class has no validator to run;
  the rule is a one-line selector swap and the rendered effect is unchanged by design.
  **Disposition:** stated here.

Fixes #8226
