### PR TITLE
fix: A line break the operator typed in Tuval chat disappears once his row renders as markdown

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -210,9 +210,10 @@ function ItemBody({
 		return <p className="tuval-chat-text">{item.text}</p>;
 	}
 	// The transcript is a region inside the desk, so a `#` heading in a message is a subsection of
-	// it rather than a page title.
+	// it rather than a page title; and a transcript row is read as the lines it was typed on, so a
+	// lone newline is a break here where a document-shaped surface would fold it (#8244).
 	return (
-		<Markdown className="tuval-chat-markdown" headingBase={3}>
+		<Markdown className="tuval-chat-markdown" headingBase={3} breaks>
 			{item.text}
 		</Markdown>
 	);

--- a/apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx
@@ -150,6 +150,19 @@ describe("a typed message renders as markdown too (#8226)", () => {
 		expect(within(row).queryByText(typed)).toBeNull();
 	});
 
+	it("keeps a line the operator typed on its own line, for a reply as much as a message", async () => {
+		await openWindow(
+			withTranscript([userItem("u1", "one\ntwo"), assistantItem("a1", "three\nfour")]),
+		);
+
+		const row = screen.getByRole("log", {name: "Transcript"});
+		const paragraphs = row.querySelectorAll(".tuval-chat-markdown p");
+		expect(paragraphs).toHaveLength(2);
+		for (const paragraph of paragraphs) {
+			expect(paragraph.querySelectorAll("br")).toHaveLength(1);
+		}
+	});
+
 	it("renders through the same block, class and headingBase as an agent reply", async () => {
 		await openWindow(withTranscript([userItem("u1", "# ask"), assistantItem("a1", "# answer")]));
 

--- a/apps/web/src/lab/atolye/exhibits/Markdown.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Markdown.exhibit.tsx
@@ -37,6 +37,7 @@ export const markdownExhibit = defineExhibit<React.ComponentProps<typeof Markdow
 	component: Markdown,
 	knobs: {
 		headingBase: {kind: "number", label: "Heading base", default: 2, min: 1, max: 6, step: 1},
+		breaks: {kind: "boolean", label: "Breaks", default: false},
 	},
 	fixedProps: {children: SAMPLE},
 });

--- a/packages/design/src/Markdown.test.tsx
+++ b/packages/design/src/Markdown.test.tsx
@@ -159,6 +159,30 @@ describe("Markdown", () => {
 		expect(screen.getByRole("heading", {level: 6, name: "five"})).toBeDefined();
 	});
 
+	it("folds a lone newline into a space by default, the way markdown reads it", () => {
+		const {container} = render(<Markdown>{"one\ntwo"}</Markdown>);
+
+		expect(container.querySelector("br")).toBeNull();
+		expect(container.querySelector("p")?.textContent).toBe("one\ntwo");
+	});
+
+	it("renders a lone newline as a break under breaks", () => {
+		const {container} = render(<Markdown breaks>{"one\ntwo"}</Markdown>);
+
+		const paragraph = container.querySelector("p");
+		expect(paragraph?.querySelectorAll("br")).toHaveLength(1);
+		expect(paragraph?.textContent).toBe("onetwo");
+	});
+
+	// `breaks` is read only under marked's `gfm`, and an options object replaces the defaults rather
+	// than merging into them — so passing it alone would take GFM's own syntax down with it.
+	it("keeps GFM syntax under breaks", () => {
+		render(<Markdown breaks>{"| a | b |\n|---|---|\n| 1 | 2 |\n\n~~gone~~"}</Markdown>);
+
+		expect(screen.getByRole("table")).toBeDefined();
+		expect(screen.getByText("gone").tagName).toBe("DEL");
+	});
+
 	it("renders nothing but an empty block for empty source", () => {
 		const {container} = render(<Markdown>{""}</Markdown>);
 

--- a/packages/design/src/Markdown.tsx
+++ b/packages/design/src/Markdown.tsx
@@ -214,6 +214,7 @@ export function Markdown({
 	children,
 	className = "",
 	headingBase = 1,
+	breaks = false,
 }: {
 	readonly children: string;
 	readonly className?: string;
@@ -222,7 +223,16 @@ export function Markdown({
 	 * outline does not emit an `<h1>` under it. Deeper headings step down from here and clamp at 6.
 	 */
 	readonly headingBase?: number;
+	/**
+	 * Whether a lone newline inside a paragraph is a line break. Off by default, which is markdown's
+	 * own reading and the one a document-shaped surface wants; a chat transcript turns it on,
+	 * because a message is read as the lines it was typed on (#8244).
+	 */
+	readonly breaks?: boolean;
 }): ReactElement {
-	const tokens = useMemo(() => lexer(children), [children]);
+	// `gfm` is restated because an options object replaces marked's defaults wholesale rather than
+	// merging into them (`Lexer`'s `this.options = e || _defaults`), and `breaks` is read only under
+	// `gfm` — passing `{breaks}` alone would silently drop tables and strikethrough.
+	const tokens = useMemo(() => lexer(children, {gfm: true, breaks}), [children, breaks]);
 	return <div className={`kp-markdown ${className}`.trim()}>{blocks(tokens, headingBase)}</div>;
 }


### PR DESCRIPTION
A single newline the operator types in a Tuval chat message now survives into his transcript row,
for an agent reply as much as for his own message.

## The route taken, and why

A `breaks` prop on `Markdown`, defaulted to `false`, which `ChatWindow` passes — not `breaks: true`
on the shared component.

The component's docblock frames it as the general read-only block for model output, and its default
is the one a document-shaped surface wants: markdown's own reading, where a lone newline is a space.
Chat semantics belong to the chat surface that asked for them, so the one caller that wants a break
per typed line says so at its own call site. It costs one optional prop and it sits beside
`headingBase`, which is already a per-consumer rendering-contract prop on this component. The other
two consumers today — the a11y registry and the atölye exhibit — keep exactly the behaviour they had.

## The one thing that is not obvious

`{breaks: true}` alone does nothing, and would have quietly broken tables.

marked's `Lexer` constructor is `this.options = e || _defaults` — an options object **replaces** the
defaults rather than merging into them — and the breaks rule set is reached only under
`this.options.gfm` (`marked/lib/marked.esm.js`, `_Lexer`'s constructor; `breaks` is documented in
`marked/lib/marked.d.ts:450` as "requires the gfm option to be true"). Since `_defaults` carries
`gfm: true`, `lexer(children, {breaks})` would have turned GFM off and taken tables and
strikethrough with it, while emitting no `br` either. So the call is
`lexer(children, {gfm: true, breaks})`, and a test holds that: `keeps GFM syntax under breaks`
renders a table and a `~~del~~` with the prop on.

Verified against the pinned copy (`marked@18.0.5`) rather than intuition: `lexer("one\ntwo",
{gfm: true, breaks: true})` yields `text, br, text`; `{breaks: true}` alone yields a single `text`.

## What landed

- `packages/design/src/Markdown.tsx` — the `breaks` prop, and the lexer call with `gfm` restated.
- `apps/tuval/src/shell/chat/ChatWindow.tsx` — `ItemBody` passes `breaks`; that one branch already
  serves both `user` and `assistant` rows, so the two kinds cannot diverge.
- `packages/design/src/Markdown.test.tsx` — three cases: the default still folds a lone newline, the
  prop renders a `<br>`, and GFM survives the prop.
- `apps/tuval/src/shell/chat/transcript-markdown.unit.test.tsx` — a transcript with a two-line user
  message and a two-line assistant reply, asserting one `<br>` in each row's paragraph.
- `apps/web/src/lab/atolye/exhibits/Markdown.exhibit.tsx` — a `Breaks` knob.

`pnpm typecheck --force` and `pnpm lint:worktree` are green in this tree. The design suite (146),
the Tuval unit suite (1604) and the atölye client tests (14) all pass.

## Deviations

- **Out-of-scope change** — **Said:** #8244 names the component, the chat call site and the two test
  files. **Did:** also added a `Breaks` knob to the atölye Markdown exhibit. **Why:** that exhibit's
  own docblock says the stage is the only place this component is judged rendered rather than
  through jsdom, so a new rendering prop with no knob is a hole in that surface.
  **Disposition:** stated here.

Fixes #8244
