### PR TITLE
feat(tuval): a program's window renderer may be a module specifier the page loads (#8252)

### DIFF
--- a/.decisions/0359-tuval-window-renderer-is-a-module-specifier.md
+++ b/.decisions/0359-tuval-window-renderer-is-a-module-specifier.md
@@ -1,0 +1,119 @@
+---
+id: 0359
+title: A Tuval program's window renderer may be a module specifier the page loads, keyed by the row's own ref
+status: accepted
+date: 2026-09-06
+tags: [tuval, shell, window, renderer, config, extensibility]
+---
+
+# 0359 — A Tuval program's window renderer may be a module specifier the page loads, keyed by the row's own ref
+
+**What this decides:** a program row may declare `renderer: {kind: "module", ref: "<specifier>"}`,
+where `ref` is a module specifier and the module's `default` export is the renderer. The page loads
+every such module at boot and seats it in its renderer table under the same `ref`, so a program
+installed with `pnpm add` and registered in one `tuval.config.ts` row is whole — kernel half and
+window half — with no edit to the app. A specifier that does not resolve refuses the page at boot;
+a module that loads into something that is not a renderer is a placeholder in the window, as a
+value, never a throw.
+
+## Context
+
+A row (`apps/tuval/src/registry/program.ts`) names its window renderer by `RendererRef = {kind, ref}`,
+and the page answers the name from a table compiled into it (`src/page/renderers.tsx`, resolved by
+`resolverFromTable` in `src/shell/window/renderer.ts`). A miss is the value
+`{_tag: "RendererUnresolved", reason: "unknown-ref" | "kind-mismatch"}` and renders a placeholder.
+That was the right shape for the programs in the box, whose rows and renderers ship together.
+
+It has no answer for a third-party program. The kernel half already works: config rows are opaque
+beyond their id (`Schema.Unknown.check(hasStringId)`, `src/config.ts`), so a row from any package
+registers and runs. The window half cannot: the page's table is compiled, and the only way to add a
+name to it is to edit `renderers.tsx` — which is what the demo of `@csirin/tuval-calc` (csirin/monorepo,
+unpublished) had to do to show its window at all. A program whose window needs a patch to the app
+is not an installed program.
+
+Two constraints shape the answer. The config module is evaluated by **Node** (`src/config.ts`, from
+`src/bin.ts`); the renderer is a React component that cannot cross the kernel→browser wire, and
+kernel-side code must never enter the browser bundle (#7836, `src/pi/renderer-ref.ts`). So whatever
+the row carries must be a string. And the page is served by **Vite** in dev (`src/page/dev-server.ts`),
+which rewrites only the imports it can read statically: a bare specifier handed to `import()` at
+runtime in the browser does not resolve.
+
+## Options
+
+**A. A second, browser-side config file** — `~/.tuval/renderers.ts`, a module the page imports that
+maps `ref` strings to renderers. Rejected: it splits one program across two files, and the author
+writes the ref string twice, once on the row and once in the map, with nothing holding the two
+together. The failure of a mismatch is the quiet one — an unresolved reference is a value, so the
+window simply comes up on its placeholder.
+
+**B. A new renderer kind, `module`, whose `ref` is the specifier** — chosen. One file, one row, one
+string. The row is self-describing: everything a page needs to find the window is on the row the
+kernel already sends over the registry frame (`src/shell/transport/wire.ts`, #7788).
+
+## Decision
+
+**1. `kind: "module"` is a `RendererKind`.** Its `ref` is a module specifier resolved from the app
+root the way any import there is — a bare package entry, `@csirin/tuval-calc/window`, or a
+root-relative path for a module in the tree, `/src/demo/module-window.tsx`. The wire admits the kind
+(`isRendererRef`), so a module row crosses to the page like any other windowed row.
+
+**2. The module exports two things.** `default` is the renderer, minted with
+`windowRenderer("module", …)` so the resolver's kind check still holds — a `host-native` export
+behind a `module` reference is a `kind-mismatch`, not a quiet acceptance. `admits` is the predicate
+over the state the renderer reads. The page seats the loaded renderer through `readsState(admits,
+default)`, so an external window gets the same admission test every in-tree one has
+([0358](0358-window-renderer-admission-and-per-window-boundary.md)); the rule does not bend for a
+renderer that arrived by `pnpm add`, and the predicate still belongs to the program whose state it is.
+
+**3. Resolution goes through a generated module, not a runtime `import()` of the string.** Node holds
+every row at boot, so `src/bin.ts` collects the module references (`moduleRendererRefs`) and hands
+them to `servePage`, which registers a Vite plugin serving `virtual:tuval/module-renderers`: one
+static `() => import("<ref>")` per reference, keyed by the reference (`moduleRenderersSource`). Vite
+then resolves, prebundles and serves each specifier exactly as it does the app's own imports —
+including prebundling a package against the page's one React, which is what keeps a module
+renderer's hooks working at first paint. `src/page/boot.tsx` imports the virtual module, runs
+`loadModuleRenderers` over it, and merges the result over `pageRenderers`; the desk waits for the
+table as it waits for the socket, so a module window never resolves against a table its seat has not
+reached.
+
+**4. Two failure points, two shapes.** A specifier that does not resolve refuses the page at boot:
+`servePage` resolves every reference through Vite's own resolver after binding and fails with
+`PageServerFailed` naming the specifier and the root — the graph compiler's stance, refuse before
+anything is shown. A module that resolves but does not load, or loads into something that is not the
+contract above, is a `RendererLoadFailure` in that reference's seat of the table; `resolverFromTable`
+reports it as `RendererUnresolved` with the new reason `module-load-failed` and the load's sentence
+as `detail`, and the window's placeholder says it. The desk, every other window and the process keep
+running.
+
+**5. Trust model: unchanged.** A module renderer is local code the founder installed and named in a
+config module they own. It runs in the page with every capability the page has, exactly as the
+in-tree renderers do. Tuval's row already says this of the identity, capability and placement records
+— they are "INERT DATA, ENFORCED BY NOTHING … local program code is fully trusted, there is no
+sandbox, ever" (#7484 R1.1, the Neovim model) — and this decision extends the same sentence to the
+window half. `module` is a resolution strategy, not an isolation tier; the tier a remote process
+would need is `isolated-frame`, still reserved.
+
+## Consequences
+
+- The config a third party writes is one row and nothing else:
+  ```ts
+  calcProgram({packs: [basePack]})  // its row declares renderer: {kind: "module", ref: "@csirin/tuval-calc/window"}
+  ```
+  with `@csirin/tuval-calc` installed in the app's `node_modules`, and `@csirin/tuval-calc/window`
+  exporting `default` and `admits`. `@csirin/tuval-calc` is the demo of this seam, not a test
+  dependency of it; the in-tree proof is `apps/tuval/src/demo/module-window.tsx` through the same
+  loader and the same served module.
+- The renderer table is no longer only compiled code: its type is now `RendererTable`, a renderer or
+  a load failure per reference, and `AttachedDesk` reads the failure's sentence into the placeholder.
+- The loader module is generated once, at boot, from the rows booted. A reload
+  (`Booted.reload`) that adds a module row does not regenerate it: that row's window is
+  `unknown-ref` until the next boot. Follow-up, not decided here.
+- Only the window renderer is loadable this way. The desk-level `inspector` and `status` references
+  (`src/shell/desk/`, #7500) still resolve from compiled tables; the `module-load-failed` sentence exists for them so their reason
+  record stays total, but no loader feeds them yet. Follow-up.
+- A package authoring a renderer needs the types — `Program`, `WindowHost`, `windowRenderer`,
+  `defineSpell` — and `@kampus/tuval` is private with no entry point to import them from
+  ([0345](0345-tuval-lives-under-apps.md) keeps Tuval an app, not a package). Whether and how an
+  authoring surface is published is a separate decision; today the demo compiles against a copy.
+- Brushes [0348](0348-tuval-command-framework-spell-registry-versioned-protocol.md): a module
+  program's spells register through the same row, so nothing there moves.

--- a/.patterns/window-renderer-admission.md
+++ b/.patterns/window-renderer-admission.md
@@ -59,6 +59,11 @@ The predicate belongs to the program whose state it is — `isCounterState` in `
 `isAiAgentSessionState` in `ai-agent/core/snapshot.ts` — never to the page. The page only pairs it
 with the renderer.
 
+A renderer the page loads from a module (`kind: "module"`, ADR 0359) is seated the same way: the
+module exports `admits` beside its `default` renderer, and `loadModuleRenderers`
+(`apps/tuval/src/page/module-renderers.ts`) passes the pair through `readsState`. A module with no
+`admits` is a load failure in the table, not an unguarded entry.
+
 ## The boundary's reset keys
 
 `resetKeys={[mount.host.processId]}`, and nothing that moves per render. The boundary compares keys

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -551,9 +551,14 @@ exactly one effect per new key; and a dropped socket whose re-attach shows the s
 a key that reaches its process. The shape and its two rules are
 [`.patterns/tuval-shell-assembly.md`](../../.patterns/tuval-shell-assembly.md).
 
-Two things the page cannot do yet, both because the wire carries rows and no registry listing: its
-picker offers running processes only (open by name through `prefix : window:open <program>`), and its
-renderer table is keyed by program id rather than by the `renderer` reference a row declares.
+The renderer table is keyed by the `renderer` reference a row declares, and a row may point that
+reference outside the tree: `renderer: {kind: "module", ref: "@csirin/tuval-calc/window"}` names a
+module the page loads at boot, whose `default` export is a `windowRenderer("module", …)` and whose
+`admits` export is the predicate over the state it reads. A program installed with `pnpm add` and
+registered as one row is then whole — its kernel half runs from the row and its window is found by
+the same string; a specifier that does not resolve refuses the page at boot, and a module that loads
+into something else is the placeholder's sentence. The why and the failure shapes are
+[ADR 0359](../../.decisions/0359-tuval-window-renderer-is-a-module-specifier.md).
 
 ## The two entry points
 

--- a/apps/tuval/src/bin.ts
+++ b/apps/tuval/src/bin.ts
@@ -18,8 +18,10 @@ import {Command, Flag} from "effect/unstable/cli";
 import {boot, defaultGlobalConfig} from "./boot.ts";
 import {renderBindingErrors} from "./commands/bindings/index.ts";
 import {servePage} from "./page/dev-server.ts";
+import {Registry} from "./registry/Registry.ts";
 import {serveDesk} from "./shell/host/index.ts";
 import {defaultPrefixTable} from "./shell/keys/index.ts";
+import {moduleRendererRefs} from "./shell/window/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 import type {TableRow} from "./table/row.ts";
 
@@ -102,7 +104,13 @@ const tuval = Command.make(
 			// and checkpointing, and a second `pnpm dev` can attach to the same socket.
 			// `servePage` admits its own port with the transport's fence before returning, so the URL
 			// printed here is one a browser can actually attach from (#7560).
-			yield* servePage({root: appRoot, transport, port: pagePort}).pipe(
+			// The rows are the page's loader list too: every `kind: "module"` renderer they name is
+			// handed to the page server, which refuses a specifier that does not resolve (ADR 0359).
+			const programs = yield* Registry.use((registry) => registry.list).pipe(
+				Effect.provideContext(kernel),
+			);
+			const moduleRenderers = moduleRendererRefs(programs);
+			yield* servePage({root: appRoot, transport, port: pagePort, moduleRenderers}).pipe(
 				Effect.flatMap((page) => Console.log(`tuval: desk at ${page.url}`)),
 				Effect.catch((error) => Console.error(`tuval: ${error.message}`)),
 			);

--- a/apps/tuval/src/demo/module-window.tsx
+++ b/apps/tuval/src/demo/module-window.tsx
@@ -1,0 +1,28 @@
+/**
+ * The in-tree stand-in for a renderer module a package would ship (ADR 0359): a module whose
+ * `default` export is a `windowRenderer("module", …)` and whose `admits` export is the predicate over
+ * the state it reads. It shows the demo counter, so the state it reads is one the box already has.
+ *
+ * A row reaches it with `renderer: {kind: "module", ref: "/src/demo/module-window.tsx"}` — a
+ * root-relative specifier, since nothing in the tree is a package. A published package writes a
+ * bare one instead, `@csirin/tuval-calc/window`, and the page treats the two the same way.
+ */
+
+import type {ReactElement} from "react";
+import type {WindowHost} from "../shell/window/index.ts";
+import {windowRenderer} from "../shell/window/index.ts";
+import {type CounterState, isCounterState} from "./counter.ts";
+
+export const admits = isCounterState;
+
+function ModuleCounter({host}: {readonly host: WindowHost<CounterState>}): ReactElement {
+	return (
+		<p className="tuval-demo-hint" data-testid="module-window">
+			process {host.processId}, shown by a module-loaded window
+		</p>
+	);
+}
+
+export default windowRenderer("module", (host: WindowHost<CounterState>) => (
+	<ModuleCounter host={host} />
+));

--- a/apps/tuval/src/page/AttachedDesk.tsx
+++ b/apps/tuval/src/page/AttachedDesk.tsx
@@ -39,15 +39,18 @@ import type {
 	MountResolver,
 } from "../shell/ui/index.ts";
 import {boundMount, Desk, noRenderer, useDeskAttachment} from "../shell/ui/index.ts";
-import type {AnyWindowRenderer} from "../shell/window/index.ts";
+import type {RendererTable} from "../shell/window/index.ts";
 import {empty, processGone, resolverFromTable, type ViewState} from "../shell/window/index.ts";
 import type {TableRow} from "../table/row.ts";
 
 export interface AttachedDeskProps {
 	readonly page: PageAttachment;
 	readonly shell: AttachedProcess<unknown, ShellMsg>;
-	/** One renderer per `RendererRef.ref` — `./renderers.tsx` says why the key is the reference. */
-	readonly renderers: Readonly<Record<string, AnyWindowRenderer>>;
+	/**
+	 * One renderer per `RendererRef.ref` — `./renderers.tsx` says why the key is the reference — or,
+	 * for a module reference the page could not load, the failure in its seat (`./module-renderers.ts`).
+	 */
+	readonly renderers: RendererTable;
 	/**
 	 * The two desk-level renderer tables, keyed the same way. Both default to empty: a page that
 	 * mounts no program's inspector still gets the region, showing why it is empty.
@@ -254,6 +257,9 @@ export function AttachedDesk({
 				return noRenderer(id, `no catalog entry on this page for program ${row.programId}`);
 			}
 			const resolved = resolveRenderer(program.renderer);
+			if (resolved._tag === "RendererUnresolved" && resolved.reason === "module-load-failed") {
+				return noRenderer(id, `this page could not load a renderer module: ${resolved.detail}`);
+			}
 			if (resolved._tag !== "Resolved") {
 				return noRenderer(id, `this page answers to no renderer named ${program.renderer.ref}`);
 			}

--- a/apps/tuval/src/page/assets.d.ts
+++ b/apps/tuval/src/page/assets.d.ts
@@ -7,3 +7,13 @@ declare module "*.css" {
 	const url: string;
 	export default url;
 }
+
+/**
+ * The page server's generated loader module (`./dev-server.ts`, ADR 0359): one `import()` thunk per
+ * `kind: "module"` renderer reference the booted rows declared, keyed by the reference. Declared
+ * here for the same reason `*.css` is — Vite knows the module, TypeScript does not.
+ */
+declare module "virtual:tuval/module-renderers" {
+	const loaders: Readonly<Record<string, () => Promise<unknown>>>;
+	export default loaders;
+}

--- a/apps/tuval/src/page/boot.tsx
+++ b/apps/tuval/src/page/boot.tsx
@@ -16,11 +16,15 @@
  * (`./proof/no-recovery.tsx`).
  */
 
-import {StrictMode} from "react";
+import moduleLoaders from "virtual:tuval/module-renderers";
+import {Effect} from "effect";
+import {StrictMode, useEffect, useState} from "react";
 import {createRoot} from "react-dom/client";
 import {ErrorBoundary} from "../shell/ui/index.ts";
+import type {RendererTable} from "../shell/window/index.ts";
 import {AttachedDesk} from "./AttachedDesk.tsx";
 import {defaultRecovery, type Recovery, usePageConnection} from "./connection.ts";
+import {loadModuleRenderers} from "./module-renderers.ts";
 import {pageRenderers} from "./renderers.tsx";
 
 /** Shown while the first socket is opening, and replaced by the desk or by the reason it never opened. */
@@ -42,11 +46,33 @@ const AttachFailed = ({reason}: {readonly reason: string}) => (
 	</div>
 );
 
+/**
+ * The compiled table plus every module the rows asked the page to load, once loaded; `null` until
+ * then. The desk waits for it exactly as it waits for the socket, so a module-referenced window is
+ * never resolved against a table its entry has not reached yet — that would render the placeholder
+ * for one frame and the window the next, which reads as a flicker and lies about the row.
+ * A module that did not load is in the table too, as the failure the resolver reports (ADR 0359).
+ */
+const useRendererTable = (): RendererTable | null => {
+	const [table, setTable] = useState<RendererTable | null>(null);
+	useEffect(() => {
+		let current = true;
+		Effect.runPromise(loadModuleRenderers(moduleLoaders)).then((loaded) => {
+			if (current) setTable({...pageRenderers, ...loaded});
+		});
+		return () => {
+			current = false;
+		};
+	}, []);
+	return table;
+};
+
 const PageDesk = ({recovery}: {readonly recovery: Recovery}) => {
 	const connection = usePageConnection(recovery);
+	const renderers = useRendererTable();
 	const reducedMotion = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? true;
 
-	if (connection.link === null) {
+	if (connection.link === null || renderers === null) {
 		return connection.refusal === null ? (
 			<Attaching />
 		) : (
@@ -58,7 +84,7 @@ const PageDesk = ({recovery}: {readonly recovery: Recovery}) => {
 			page={connection.link.page}
 			shell={connection.link.shell}
 			refusal={connection.refusal}
-			renderers={pageRenderers}
+			renderers={renderers}
 			reducedMotion={reducedMotion}
 		/>
 	);

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -43,6 +43,12 @@ export interface PageServerOptions {
 	readonly transport: TransportServer;
 	/** `0` picks a free port, which is what a second `pnpm dev` on one machine needs. */
 	readonly port: number;
+	/**
+	 * The `kind: "module"` renderer specifiers the booted rows declared (`moduleRendererRefs`,
+	 * `../shell/window/renderer.ts`), each one the page has to load (ADR 0359). Absent means none:
+	 * a proof that serves the page over its own rows names none and the page loads nothing.
+	 */
+	readonly moduleRenderers?: ReadonlyArray<string>;
 }
 
 export interface PageServer {
@@ -53,6 +59,46 @@ export interface PageServer {
 }
 
 export const LAUNCH_ENDPOINT = "/__tuval/launch";
+
+/**
+ * The page's loader module, generated here from the rows and imported by `./boot.tsx` under this
+ * one id; `./assets.d.ts` declares its shape. A bare specifier cannot be `import()`ed from the
+ * browser by value — Vite rewrites only the imports it can read statically — so the specifiers are
+ * written into a module Vite reads like any other, and are resolved, prebundled and served the way
+ * the app's own imports are. The `\0` prefix on the resolved id is Rollup's convention for a module
+ * with no file behind it, and keeps every other plugin from trying to find one.
+ */
+export const MODULE_RENDERERS_ID = "virtual:tuval/module-renderers";
+const RESOLVED_MODULE_RENDERERS_ID = `\0${MODULE_RENDERERS_ID}`;
+
+/**
+ * The source of the loader module: one `import()` per reference, keyed by the reference string the
+ * row wrote. Both are written through `JSON.stringify`, so a specifier is a string literal in the
+ * output whatever characters it holds — this is generated code, and a row's string is data to it.
+ */
+export const moduleRenderersSource = (refs: ReadonlyArray<string>): string => {
+	const entries = refs.map(
+		(ref) => `\t${JSON.stringify(ref)}: () => import(${JSON.stringify(ref)}),`,
+	);
+	return `export default {\n${entries.join("\n")}\n};\n`;
+};
+
+/**
+ * A specifier naming a package, as opposed to a path: the only kind the dependency optimiser takes.
+ * A root-relative or relative path — the in-tree fixture's spelling — is source, and Vite serves it
+ * transformed like any other file of the app.
+ */
+const isBareSpecifier = (ref: string): boolean => !ref.startsWith("/") && !ref.startsWith(".");
+
+const moduleRenderersPlugin = (refs: ReadonlyArray<string>) => ({
+	name: "tuval-module-renderers",
+	resolveId(id: string) {
+		return id === MODULE_RENDERERS_ID ? RESOLVED_MODULE_RENDERERS_ID : null;
+	},
+	load(id: string) {
+		return id === RESOLVED_MODULE_RENDERERS_ID ? moduleRenderersSource(refs) : null;
+	},
+});
 
 interface LaunchResponse {
 	setHeader: (name: string, value: string) => void;
@@ -74,19 +120,40 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 			}) as never);
 		},
 	};
+	const moduleRenderers = options.moduleRenderers ?? [];
 	const server = yield* Effect.acquireRelease(
 		attempt(() =>
 			createServer({
 				root: options.root,
 				configFile: false,
 				appType: "spa",
-				plugins: [launchEndpoint, react.default()],
+				plugins: [launchEndpoint, moduleRenderersPlugin(moduleRenderers), react.default()],
 				server: {port: options.port, strictPort: false, host: "127.0.0.1"},
+				// Named up front so a renderer package is prebundled with the page's own React rather
+				// than discovered on first open, which would serve it a second React copy until the
+				// re-optimise reload — the one way a module renderer's hooks can break at first paint.
+				optimizeDeps: {include: moduleRenderers.filter(isBareSpecifier)},
 			}),
 		),
 		(dev) => Effect.ignore(attempt(() => dev.close())),
 	);
 	yield* attempt(() => server.listen());
+	// Every specifier the rows named is resolved now, from the same root the loader module's own
+	// `import()` resolves from. One that does not resolve refuses the page here, naming itself, rather
+	// than surfacing as a failed import in a browser tab (the graph compiler's stance: refuse at boot).
+	for (const ref of moduleRenderers) {
+		const resolved = yield* attempt(() =>
+			server.environments.client.pluginContainer.resolveId(ref, RESOLVED_MODULE_RENDERERS_ID),
+		);
+		if (resolved === null) {
+			yield* Effect.ignore(attempt(() => server.close()));
+			return yield* new PageServerFailed({
+				cause: new Error(
+					`renderer module ${JSON.stringify(ref)} does not resolve from ${options.root}; is the package installed here?`,
+				),
+			});
+		}
+	}
 	const url = server.resolvedUrls?.local[0];
 	if (url === undefined) {
 		return yield* new PageServerFailed({cause: new Error("it bound no local address")});

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -72,14 +72,25 @@ export const MODULE_RENDERERS_ID = "virtual:tuval/module-renderers";
 const RESOLVED_MODULE_RENDERERS_ID = `\0${MODULE_RENDERERS_ID}`;
 
 /**
+ * A string as a JavaScript string literal. `JSON.stringify` is the escape, plus the two characters
+ * it leaves raw that JavaScript source treats as line terminators (U+2028, U+2029): inside a JSON
+ * string they are legal, inside a JS literal they end the line, and this string becomes code.
+ */
+const sourceLiteral = (value: string): string =>
+	JSON.stringify(value)
+		.replace(/\u2028/g, "\\u2028")
+		.replace(/\u2029/g, "\\u2029");
+
+/**
  * The source of the loader module: one `import()` per reference, keyed by the reference string the
- * row wrote. Both are written through `JSON.stringify`, so a specifier is a string literal in the
+ * row wrote. Both are written through `sourceLiteral`, so a specifier is a string literal in the
  * output whatever characters it holds — this is generated code, and a row's string is data to it.
  */
 export const moduleRenderersSource = (refs: ReadonlyArray<string>): string => {
-	const entries = refs.map(
-		(ref) => `\t${JSON.stringify(ref)}: () => import(${JSON.stringify(ref)}),`,
-	);
+	const entries = refs.map((ref) => {
+		const literal = sourceLiteral(ref);
+		return `\t${literal}: () => import(${literal}),`;
+	});
 	return `export default {\n${entries.join("\n")}\n};\n`;
 };
 

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -133,6 +133,11 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 				// than discovered on first open, which would serve it a second React copy until the
 				// re-optimise reload — the one way a module renderer's hooks can break at first paint.
 				optimizeDeps: {include: moduleRenderers.filter(isBareSpecifier)},
+				// A renderer package names React and Effect as peers, and a peer means "the page's copy".
+				// A package linked from another checkout (`link:`, `pnpm link`) carries its own
+				// `node_modules`, and without this the browser gets a second React whose hooks throw
+				// `Cannot read properties of null (reading 'useState')` on the module window's first paint.
+				resolve: {dedupe: ["react", "react-dom", "effect"]},
 			}),
 		),
 		(dev) => Effect.ignore(attempt(() => dev.close())),

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The generated loader module (ADR 0359), as text: the page server writes it from the rows'
+ * `kind: "module"` references, and this is the one place its shape is pinned. The served module and
+ * the boot-time refusal of a specifier that does not resolve are `module-renderers.integration.test.ts`.
+ */
+
+import {describe, expect, it} from "vitest";
+import {counterRow, noRendererRow} from "../shell/window/fixtures.ts";
+import {moduleRendererRefs} from "../shell/window/index.ts";
+import {moduleRenderersSource} from "./dev-server.ts";
+
+describe("the module renderers loader module", () => {
+	it("holds one static import() per reference, keyed by the reference the row wrote", () => {
+		expect(
+			moduleRenderersSource(["@csirin/tuval-calc/window", "/src/demo/module-window.tsx"]),
+		).toBe(`export default {
+\t"@csirin/tuval-calc/window": () => import("@csirin/tuval-calc/window"),
+\t"/src/demo/module-window.tsx": () => import("/src/demo/module-window.tsx"),
+};
+`);
+	});
+
+	it("is an empty record when no row names a module, so the page loads nothing", () => {
+		expect(moduleRenderersSource([])).toBe("export default {\n\n};\n");
+	});
+
+	it("writes a specifier as a string literal, whatever it holds", () => {
+		expect(moduleRenderersSource(['a"b'])).toContain('import("a\\"b")');
+	});
+});
+
+describe("moduleRendererRefs", () => {
+	it("lists the module references only, each once, in row order", () => {
+		const module = {...counterRow, renderer: {kind: "module", ref: "@x/one/window"}} as const;
+		const again = {...counterRow, renderer: {kind: "module", ref: "@x/one/window"}} as const;
+		const other = {...counterRow, renderer: {kind: "module", ref: "@x/two/window"}} as const;
+		expect(moduleRendererRefs([counterRow, noRendererRow, other, module, again])).toEqual([
+			"@x/two/window",
+			"@x/one/window",
+		]);
+	});
+});

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -27,6 +27,12 @@ describe("the module renderers loader module", () => {
 	it("writes a specifier as a string literal, whatever it holds", () => {
 		expect(moduleRenderersSource(['a"b'])).toContain('import("a\\"b")');
 	});
+
+	it("escapes the two line terminators JSON leaves raw, so a specifier cannot end a line of code", () => {
+		const source = moduleRenderersSource(["a\u2028b\u2029c"]);
+		expect(source).not.toMatch(/[\u2028\u2029]/);
+		expect(source).toContain('import("a\\u2028b\\u2029c")');
+	});
 });
 
 describe("moduleRendererRefs", () => {

--- a/apps/tuval/src/page/module-renderers.integration.test.ts
+++ b/apps/tuval/src/page/module-renderers.integration.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The page server's half of a module renderer reference (ADR 0359), against a real Vite: the loader
+ * module it generates is served under its virtual id with the fixture's `import()` inside, and a
+ * specifier nothing installed here answers to refuses the page at boot with the specifier in the
+ * sentence — the terminal, not a blank tab, is where a founder learns the package is not there.
+ *
+ * The fixture behind the `import()` is not fetched here on purpose. Transforming a `.tsx` starts
+ * Vite's dependency discovery, and a `close()` that lands while that scan is in flight never settles
+ * (Vite 8.1.5; `waitForRequestsIdle()` before the close is the cure, and `servePage` hands out no
+ * server to wait on). The fixture's own load path is `module-renderers.unit.test.ts`, through the
+ * same `import()` the served module carries.
+ */
+
+import {dirname} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit, Schema} from "effect";
+import type {TransportServer} from "../shell/transport/server.ts";
+import {PageServerFailed, servePage} from "./dev-server.ts";
+
+const appRoot = dirname(dirname(import.meta.dirname));
+const FIXTURE_REF = "/src/demo/module-window.tsx";
+/** How Vite spells a `\0`-prefixed virtual id in a URL. */
+const VIRTUAL_URL = "/@id/__x00__virtual:tuval/module-renderers";
+const TIMEOUT = 30_000;
+
+/** The page server needs a launch URL to answer and a fence to tell; nothing here attaches. */
+const transport: TransportServer = {
+	port: 1,
+	publishRegistry: Effect.void,
+	launchUrl: "ws://127.0.0.1:1/?token=none",
+	admitLoopbackPort: () => {},
+};
+
+class FetchFailed extends Schema.TaggedError<FetchFailed>()("FetchFailed", {
+	cause: Schema.Defect(),
+}) {}
+
+const text = (url: URL) =>
+	Effect.tryPromise({
+		try: () => fetch(url).then((response) => response.text()),
+		catch: (cause) => new FetchFailed({cause}),
+	});
+
+describe("the served module renderers", () => {
+	it.live(
+		"the virtual module carries one import() per reference, keyed by the reference",
+		() =>
+			Effect.gen(function* () {
+				const page = yield* servePage({
+					root: appRoot,
+					transport,
+					port: 0,
+					moduleRenderers: [FIXTURE_REF],
+				});
+				const loader = yield* text(new URL(VIRTUAL_URL, page.url));
+				assert.include(loader, `"${FIXTURE_REF}"`);
+				assert.include(loader, "import(");
+				assert.include(loader, "module-window.tsx");
+			}).pipe(Effect.scoped),
+		TIMEOUT,
+	);
+
+	it.live(
+		"a specifier that does not resolve from the app root refuses the page at boot, by name",
+		() =>
+			Effect.gen(function* () {
+				const exit = yield* servePage({
+					root: appRoot,
+					transport,
+					port: 0,
+					moduleRenderers: ["@tuval-nobody/not-installed/window"],
+				}).pipe(Effect.scoped, Effect.exit);
+				assert.ok(Exit.isFailure(exit), "the page refused to serve");
+				if (!Exit.isFailure(exit)) return;
+				const failure = Exit.isFailure(exit) ? exit.cause : null;
+				const message = String(failure);
+				assert.include(message, "@tuval-nobody/not-installed/window");
+				assert.include(message, "does not resolve");
+				assert.include(message, PageServerFailed.name);
+			}),
+		TIMEOUT,
+	);
+});

--- a/apps/tuval/src/page/module-renderers.ts
+++ b/apps/tuval/src/page/module-renderers.ts
@@ -1,0 +1,90 @@
+/**
+ * The page's half of a `kind: "module"` renderer reference (ADR 0359): given the loaders the page
+ * server generated — one `import()` per specifier the rows named — load each, admit what came back,
+ * and answer a table the resolver reads beside `./renderers.tsx`.
+ *
+ * Nothing here throws. A specifier that would not load, or loaded into something that is not a
+ * renderer, becomes a `RendererLoadFailure` in that reference's seat, and `resolverFromTable` turns
+ * it into `RendererUnresolved` with `module-load-failed` and the sentence — the placeholder in the
+ * window then says what happened, which is the whole difference from a blank pane.
+ *
+ * The loaded renderer goes through `readsState` with the module's own `admits`, so an external
+ * window gets the same admission test every in-tree one has (ADR 0358): the rule does not bend for
+ * a renderer that arrived by `pnpm add`, and the predicate still belongs to the program whose state
+ * it is — the module exports it beside the renderer.
+ */
+
+import {Effect, Predicate} from "effect";
+import type {ReactNode} from "react";
+import type {
+	AnyWindowRenderer,
+	RendererLoadFailure,
+	WindowRenderer,
+} from "../shell/window/index.ts";
+import {rendererLoadFailure} from "../shell/window/index.ts";
+import {type ReadableRenderer, readsState} from "./readable-state.tsx";
+
+/** One thunk per specifier, keyed by the reference string the row wrote: what the virtual module exports. */
+export type ModuleLoaders = Readonly<Record<string, () => Promise<unknown>>>;
+
+/** What a renderer module has to export. Checked at load, so a wrong export is a named failure and not a throw in React. */
+export interface ModuleRendererExports {
+	readonly default: AnyWindowRenderer;
+	readonly admits: (state: unknown) => boolean;
+}
+
+export type LoadedModuleRenderers = Readonly<
+	Record<string, ReadableRenderer | RendererLoadFailure>
+>;
+
+const isWindowRenderer = (value: unknown): value is AnyWindowRenderer =>
+	Predicate.isObject(value) && typeof value.kind === "string" && typeof value.render === "function";
+
+/** Which of the contract's two exports is missing or malformed, or `null` when both are right. */
+const exportsFault = (loaded: unknown): string | null => {
+	if (!Predicate.isObject(loaded)) return "the module is not an object";
+	if (!isWindowRenderer(loaded.default)) {
+		return 'no default export that is a window renderer; export default windowRenderer("module", …)';
+	}
+	if (loaded.default.kind !== "module") {
+		return `the default export is a ${loaded.default.kind} renderer, and a module reference needs one minted with windowRenderer("module", …)`;
+	}
+	if (typeof loaded.admits !== "function") {
+		return "no admits export; export the predicate over the state this renderer reads";
+	}
+	return null;
+};
+
+const thrownMessage = (cause: unknown): string =>
+	cause instanceof Error ? cause.message : String(cause);
+
+const loadOne = (
+	ref: string,
+	load: () => Promise<unknown>,
+): Effect.Effect<ReadableRenderer | RendererLoadFailure> =>
+	Effect.tryPromise({try: load, catch: (cause) => thrownMessage(cause)}).pipe(
+		Effect.map((loaded): ReadableRenderer | RendererLoadFailure => {
+			const fault = exportsFault(loaded);
+			if (fault !== null) return rendererLoadFailure(`${ref}: ${fault}`);
+			const {default: renderer, admits} = loaded as ModuleRendererExports;
+			// The one widening: the module's predicate is `(state: unknown) => boolean` because the
+			// module is outside the checker's reach, and `readsState` wants a guard. `S` is `unknown`
+			// on this side either way — the renderer's own types stayed in its package.
+			return readsState(
+				admits as (state: unknown) => state is unknown,
+				renderer as WindowRenderer<ReactNode, unknown>,
+			);
+		}),
+		Effect.catch((message) =>
+			Effect.succeed(rendererLoadFailure(`${ref}: the module threw while loading: ${message}`)),
+		),
+	);
+
+/** Every loader run, every outcome kept: the table has one seat per reference, resolved or refused. */
+export const loadModuleRenderers = (loaders: ModuleLoaders): Effect.Effect<LoadedModuleRenderers> =>
+	Effect.forEach(
+		Object.entries(loaders),
+		([ref, load]) => Effect.map(loadOne(ref, load), (entry) => [ref, entry] as const),
+		// Each load is its own import and none reads another's outcome, so they run together.
+		{concurrency: "unbounded"},
+	).pipe(Effect.map((entries) => Object.fromEntries(entries)));

--- a/apps/tuval/src/page/module-renderers.unit.test.ts
+++ b/apps/tuval/src/page/module-renderers.unit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * A `kind: "module"` renderer reference, through the real seam (ADR 0359): the loader the page runs
+ * over the generated loaders, feeding the table the resolver reads. The module under test is the
+ * in-tree fixture `../demo/module-window.tsx`, loaded by the same `import()` the generated module
+ * would carry. Every failure below is a value the resolver reports, never a throw.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import * as fixture from "../demo/module-window.tsx";
+import type {RendererRef} from "../registry/program.ts";
+import {counterRow} from "../shell/window/fixtures.ts";
+import {rendererFor, resolverFromTable, windowRenderer} from "../shell/window/index.ts";
+import {loadModuleRenderers} from "./module-renderers.ts";
+
+const MODULE_REF = "/src/demo/module-window.tsx";
+const moduleRef: RendererRef = {kind: "module", ref: MODULE_REF};
+const loadFixture = () => import("../demo/module-window.tsx");
+
+const rowWith = (renderer: RendererRef) => ({...counterRow, renderer});
+
+describe("a module renderer reference", () => {
+	it.effect("resolves to the module's default export, admitted by the module's own predicate", () =>
+		Effect.gen(function* () {
+			const loaded = yield* loadModuleRenderers({[MODULE_REF]: loadFixture});
+			const resolution = rendererFor(rowWith(moduleRef), resolverFromTable(loaded));
+			assert.strictEqual(resolution._tag, "Resolved");
+			if (resolution._tag !== "Resolved") return;
+			assert.strictEqual(resolution.renderer.kind, "module");
+			// The seat holds a `ReadableRenderer` over the module's export: the guard `readsState`
+			// mints, carrying the module's predicate, and the module's renderer inside it.
+			const entry = loaded[MODULE_REF];
+			assert.ok(entry !== undefined && "renderer" in entry);
+			if (entry === undefined || !("renderer" in entry)) return;
+			assert.strictEqual(entry.renderer, fixture.default);
+			assert.strictEqual(entry.admits, fixture.admits);
+			assert.strictEqual(entry.admits({count: 3}), true);
+			assert.strictEqual(entry.admits({lines: []}), false);
+		}),
+	);
+
+	it.effect(
+		"an unknown reference is still unknown-ref: loading modules adds seats, it does not widen them",
+		() =>
+			Effect.gen(function* () {
+				const loaded = yield* loadModuleRenderers({[MODULE_REF]: loadFixture});
+				const other: RendererRef = {kind: "module", ref: "@nobody/nothing/window"};
+				assert.deepStrictEqual(rendererFor(rowWith(other), resolverFromTable(loaded)), {
+					_tag: "RendererUnresolved",
+					ref: other,
+					reason: "unknown-ref",
+				});
+			}),
+	);
+
+	it.effect(
+		"a host-native reference to a loaded module is a kind mismatch, and so is the reverse",
+		() =>
+			Effect.gen(function* () {
+				const loaded = yield* loadModuleRenderers({[MODULE_REF]: loadFixture});
+				const asNative: RendererRef = {kind: "host-native", ref: MODULE_REF};
+				assert.deepStrictEqual(rendererFor(rowWith(asNative), resolverFromTable(loaded)), {
+					_tag: "RendererUnresolved",
+					ref: asNative,
+					reason: "kind-mismatch",
+				});
+				const table = {[MODULE_REF]: windowRenderer("host-native", () => "native")};
+				assert.deepStrictEqual(rendererFor(rowWith(moduleRef), resolverFromTable(table)), {
+					_tag: "RendererUnresolved",
+					ref: moduleRef,
+					reason: "kind-mismatch",
+				});
+			}),
+	);
+
+	it.effect(
+		"a module that throws while loading is a module-load-failed value naming the throw",
+		() =>
+			Effect.gen(function* () {
+				const loaded = yield* loadModuleRenderers({
+					[MODULE_REF]: () => Promise.reject(new Error("Cannot find module")),
+				});
+				assert.deepStrictEqual(rendererFor(rowWith(moduleRef), resolverFromTable(loaded)), {
+					_tag: "RendererUnresolved",
+					ref: moduleRef,
+					reason: "module-load-failed",
+					detail: `${MODULE_REF}: the module threw while loading: Cannot find module`,
+				});
+			}),
+	);
+
+	it.effect("a module missing either export, or exporting the wrong kind, is refused by name", () =>
+		Effect.gen(function* () {
+			const native = windowRenderer("host-native", () => "native");
+			const loaded = yield* loadModuleRenderers({
+				"no-default": () => Promise.resolve({admits: () => true}),
+				"no-admits": () => Promise.resolve({default: windowRenderer("module", () => null)}),
+				"wrong-kind": () => Promise.resolve({default: native, admits: () => true}),
+				"not-an-object": () => Promise.resolve(null),
+			});
+			const detailOf = (ref: string): string | undefined => {
+				const resolution = resolverFromTable(loaded)({kind: "module", ref});
+				return resolution._tag === "RendererUnresolved" ? resolution.detail : undefined;
+			};
+			assert.match(detailOf("no-default") ?? "", /no default export that is a window renderer/);
+			assert.match(detailOf("no-admits") ?? "", /no admits export/);
+			assert.match(detailOf("wrong-kind") ?? "", /is a host-native renderer/);
+			assert.match(detailOf("not-an-object") ?? "", /not an object/);
+		}),
+	);
+
+	it.effect("no loaders is an empty table, so a page with no module rows resolves as before", () =>
+		Effect.gen(function* () {
+			assert.deepStrictEqual(yield* loadModuleRenderers({}), {});
+		}),
+	);
+});

--- a/apps/tuval/src/registry/program.ts
+++ b/apps/tuval/src/registry/program.ts
@@ -75,9 +75,19 @@ export type HostSubs<M, U extends Sub, E, R> = {
  */
 export type Receiver<M> = (payload: never) => M;
 
-export type RendererKind = "host-native" | "host-declarative" | "isolated-frame";
+export type RendererKind = "host-native" | "host-declarative" | "isolated-frame" | "module";
 
-/** A reference only. Rendering is not this epic's; the kernel stores the reference and reports it. */
+/**
+ * A reference only. Rendering is not this epic's; the kernel stores the reference and reports it.
+ *
+ * For every kind but one, `ref` is a name the page's own table answers to. For `kind: "module"`,
+ * `ref` is a module specifier the page loads (ADR 0359): a bare package entry such as
+ * `@csirin/tuval-calc/window`, resolved from the app root the way any import there is. The module's
+ * `default` export is the renderer, minted with `windowRenderer("module", …)`, and its `admits`
+ * export is the predicate over the state that renderer reads (ADR 0358). A row written by a package
+ * installed with `pnpm add` is then whole on its own: the kernel half runs from this row, and the
+ * page finds the window half by the same string, with no table edit in the app.
+ */
 export interface RendererRef {
 	readonly kind: RendererKind;
 	readonly ref: string;

--- a/apps/tuval/src/shell/transport/wire.ts
+++ b/apps/tuval/src/shell/transport/wire.ts
@@ -196,6 +196,7 @@ const rendererKinds: ReadonlySet<string> = new Set<RendererKind>([
 	"host-native",
 	"host-declarative",
 	"isolated-frame",
+	"module",
 ]);
 
 const isRendererRef = (value: unknown): value is RendererRef =>

--- a/apps/tuval/src/shell/ui/DeskInspector.tsx
+++ b/apps/tuval/src/shell/ui/DeskInspector.tsx
@@ -30,6 +30,7 @@ const emptyReason: Readonly<Record<DeskEmptyReason, string>> = {
 	"not-declared": "This program declares no inspector.",
 	"unknown-ref": "This page answers to no inspector by the name that program declares.",
 	"kind-mismatch": "That program's inspector is declared at a kind this page does not mount.",
+	"module-load-failed": "This page could not load the module that program's inspector names.",
 };
 
 /**

--- a/apps/tuval/src/shell/window/index.ts
+++ b/apps/tuval/src/shell/window/index.ts
@@ -20,10 +20,14 @@ export {
 } from "./host.ts";
 export {
 	type AnyWindowRenderer,
+	moduleRendererRefs,
+	type RendererLoadFailure,
 	type RendererRefusal,
 	type RendererResolution,
 	type RendererResolver,
+	type RendererTable,
 	rendererFor,
+	rendererLoadFailure,
 	resolverFromTable,
 	type WindowRenderer,
 	windowRenderer,

--- a/apps/tuval/src/shell/window/renderer.ts
+++ b/apps/tuval/src/shell/window/renderer.ts
@@ -38,8 +38,12 @@ export const windowRenderer = <Out, S, M extends Message, V extends ViewState>(
 	render: (host: WindowHost<S, M, V>) => Out,
 ): WindowRenderer<Out, S, M, V> => ({kind, render});
 
-/** Why a reference did not resolve. Both arms are the shell's own answer, never a throw. */
-export type RendererRefusal = "unknown-ref" | "kind-mismatch";
+/**
+ * Why a reference did not resolve. Every arm is the shell's own answer, never a throw.
+ * `module-load-failed` is the arm a `kind: "module"` reference lands on when the page loaded its
+ * specifier and got no renderer back (ADR 0359); `detail` on the resolution says what it got.
+ */
+export type RendererRefusal = "unknown-ref" | "kind-mismatch" | "module-load-failed";
 
 export type RendererResolution =
 	| {readonly _tag: "Resolved"; readonly renderer: AnyWindowRenderer}
@@ -49,25 +53,66 @@ export type RendererResolution =
 			readonly _tag: "RendererUnresolved";
 			readonly ref: RendererRef;
 			readonly reason: RendererRefusal;
+			/** For `module-load-failed`: the load's own sentence, so the placeholder can name it. */
+			readonly detail?: string;
 	  };
 
 /** How a shell turns a row's reference into the renderer it names. The transport picks the implementation. */
 export type RendererResolver = (ref: RendererRef) => RendererResolution;
 
 /**
+ * What a table holds for a reference whose module the page tried to load and could not: the failure
+ * itself, as a value in the renderer's seat. It stays in the table rather than being dropped so the
+ * resolver can tell "no module was ever named for this" from "it was named and did not load" — the
+ * second is the one a founder can act on, and it must not read as the first.
+ */
+export interface RendererLoadFailure {
+	readonly _tag: "RendererLoadFailure";
+	readonly detail: string;
+}
+
+export const rendererLoadFailure = (detail: string): RendererLoadFailure => ({
+	_tag: "RendererLoadFailure",
+	detail,
+});
+
+const isLoadFailure = (
+	entry: AnyWindowRenderer | RendererLoadFailure,
+): entry is RendererLoadFailure => "_tag" in entry && entry._tag === "RendererLoadFailure";
+
+/** A shell-wide renderer table, keyed by `RendererRef.ref`. */
+export type RendererTable = Readonly<Record<string, AnyWindowRenderer | RendererLoadFailure>>;
+
+/**
  * The resolver over a table keyed by `RendererRef.ref`. `kind` is checked too: a reference asking
  * for an `isolated-frame` renderer must not be answered with the `host-native` one of the same name.
  */
 export const resolverFromTable =
-	(table: Readonly<Record<string, AnyWindowRenderer>>): RendererResolver =>
+	(table: RendererTable): RendererResolver =>
 	(ref) => {
-		const renderer = table[ref.ref];
-		if (renderer === undefined) return {_tag: "RendererUnresolved", ref, reason: "unknown-ref"};
-		if (renderer.kind !== ref.kind) {
+		const entry = table[ref.ref];
+		if (entry === undefined) return {_tag: "RendererUnresolved", ref, reason: "unknown-ref"};
+		if (isLoadFailure(entry)) {
+			return {_tag: "RendererUnresolved", ref, reason: "module-load-failed", detail: entry.detail};
+		}
+		if (entry.kind !== ref.kind) {
 			return {_tag: "RendererUnresolved", ref, reason: "kind-mismatch"};
 		}
-		return {_tag: "Resolved", renderer};
+		return {_tag: "Resolved", renderer: entry};
 	};
+
+/**
+ * The module specifiers a set of rows asks the page to load: one per `kind: "module"` window
+ * reference, in row order, each once. The page server generates its loader module from exactly this
+ * list, which is why it is computed here from the rows and not typed twice.
+ */
+export const moduleRendererRefs = (rows: ReadonlyArray<AnyProgram>): ReadonlyArray<string> => [
+	...new Set(
+		rows.flatMap((row) =>
+			row.renderer?.kind === "module" ? [row.renderer.ref] : ([] as ReadonlyArray<string>),
+		),
+	),
+];
 
 /** The row's renderer, or the reason there is none. This is the only route from a program to its window renderer. */
 export const rendererFor = (row: AnyProgram, resolve: RendererResolver): RendererResolution =>


### PR DESCRIPTION
A program row could register from any package, and its window could not follow it: `renderer.ref` was a name answered only by a table compiled into the page. This adds `kind: "module"`, where `ref` is a module specifier the page loads at boot and seats under the row's own ref. One config row is now the whole install of an external program, kernel half and window half.

Fixes #8252

**The decision.** ADR 0359 weighs a second browser-side config file against a module-specifier kind and chooses the kind: one file, one row, one string, and the row stays self-describing over the registry frame. It also records the trust model (a module renderer is local code and runs with the user's authority, as every row does) and names the follow-ups: `Booted.reload` not regenerating the loader until next boot, `inspector`/`status` refs staying host-native, and publishing an authoring entry point for the row types as its own decision.

**The mechanism.** `bin.ts` reads the module refs off the registry; `servePage` registers a Vite plugin serving `virtual:tuval/module-renderers`, one static `() => import("<ref>")` per ref, and after listen resolves every ref through the client environment — a miss is `PageServerFailed` naming the ref and the root, so a bad specifier refuses at boot and never reaches a tab. `boot.tsx` imports the virtual module, runs each loader, checks the module's `default` is a `windowRenderer("module", …)` and that it exports `admits`, threads the pair through `readsState` so ADR 0358's admission holds for external windows, and merges the table over `pageRenderers`. A module that loads wrong becomes `RendererUnresolved` with a new reason, `module-load-failed`, and a placeholder. Bare refs go in `optimizeDeps.include`, and `react`, `react-dom` and `effect` are deduped: a renderer package names them as peers, and a `link:`-installed package otherwise carries its own React, whose hooks throw on the window's first paint.

**Proof in-tree.** `src/demo/module-window.tsx` is a fixture module resolved through the real seam. Unit tests cover the loader's refusals, the dev server's boot-time resolution, and an integration test boots a real page server against the fixture. The page's Node-free boundary test still passes.

**Proof against the real consumer.** `@csirin/tuval-calc` (csirin/monorepo, unpublished) with `renderer: {kind: "module", ref: "@csirin/tuval-calc/window"}` on its row, linked into `apps/tuval`, one row in `.tuval/tuval.config.ts` and no edit to `renderers.tsx`:

```
tuval: booted — 6 program(s), 28 spell(s) registered …
```

The calc window paints, restored from its checkpoint, and evaluates. The second commit is the dedupe that booting it found.

**Checks.** `pnpm --filter @kampus/tuval test`: 196 files, 1656 tests passed. Typecheck (tsc + effect-tsgo, three lenses): 0 errors. Biome clean on every touched file. Governance read by hand against 0358, 0345, 0348, 0353: no contradiction, no weakened guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Deviations

None.
