### PR TITLE
fix: Tuval: a module renderer resolves from the app root, not from the config that declared its row, so a program cannot live beside the user's config

### DIFF
--- a/.decisions/0359-tuval-window-renderer-is-a-module-specifier.md
+++ b/.decisions/0359-tuval-window-renderer-is-a-module-specifier.md
@@ -117,3 +117,13 @@ would need is `isolated-frame`, still reserved.
   authoring surface is published is a separate decision; today the demo compiles against a copy.
 - Brushes [0348](0348-tuval-command-framework-spell-registry-versioned-protocol.md): a module
   program's spells register through the same row, so nothing there moves.
+
+> Amendment 2026-09-06: a `kind: "module"` `ref` is **not** resolved from the app root. Decision 1's
+> sentence at line 55 and decision 4's "naming the specifier and the root" were true only while the
+> app root was the sole place a program could be installed. Each ref now resolves from the config
+> module that declared its row — the same base Node already used for the row's kernel half — so a
+> program lives beside the user's config (`~/.tuval`, `<project>/.tuval`) and is never a dependency
+> of the app. The root-relative spelling an in-tree module uses (`/src/demo/module-window.tsx`) is
+> unchanged and still reads against the page root. A specifier that resolves from neither refuses the
+> page at boot naming that config module rather than the root, and the page's file server is allowed
+> the config's directory so the resolved module can be served from outside the workspace. See #8262.

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -556,8 +556,11 @@ reference outside the tree: `renderer: {kind: "module", ref: "@csirin/tuval-calc
 module the page loads at boot, whose `default` export is a `windowRenderer("module", …)` and whose
 `admits` export is the predicate over the state it reads. A program installed with `pnpm add` and
 registered as one row is then whole — its kernel half runs from the row and its window is found by
-the same string; a specifier that does not resolve refuses the page at boot, and a module that loads
-into something else is the placeholder's sentence. The why and the failure shapes are
+the same string. The specifier resolves from the config module that declared the row, the same base
+Node used for the row itself, so the package lives beside your own `tuval.config.ts` and is never a
+dependency of Tuval; a specifier that resolves from neither that config nor the page root refuses the
+page at boot naming that config, and a module that loads into something else is the placeholder's
+sentence. The why and the failure shapes are
 [ADR 0359](../../.decisions/0359-tuval-window-renderer-is-a-module-specifier.md).
 
 ## The two entry points

--- a/apps/tuval/src/bin.ts
+++ b/apps/tuval/src/bin.ts
@@ -18,10 +18,8 @@ import {Command, Flag} from "effect/unstable/cli";
 import {boot, defaultGlobalConfig} from "./boot.ts";
 import {renderBindingErrors} from "./commands/bindings/index.ts";
 import {servePage} from "./page/dev-server.ts";
-import {Registry} from "./registry/Registry.ts";
 import {serveDesk} from "./shell/host/index.ts";
 import {defaultPrefixTable} from "./shell/keys/index.ts";
-import {moduleRendererRefs} from "./shell/window/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 import type {TableRow} from "./table/row.ts";
 
@@ -66,7 +64,7 @@ const tuval = Command.make(
 		),
 	},
 	Effect.fn(function* ({config, project, noPage, pagePort}) {
-		const {report, kernel} = yield* boot({
+		const {report, kernel, moduleRenderers} = yield* boot({
 			global: Option.getOrElse(config, defaultGlobalConfig),
 			project: Option.getOrElse(project, () => process.cwd()),
 		}).pipe(
@@ -104,12 +102,9 @@ const tuval = Command.make(
 			// and checkpointing, and a second `pnpm dev` can attach to the same socket.
 			// `servePage` admits its own port with the transport's fence before returning, so the URL
 			// printed here is one a browser can actually attach from (#7560).
-			// The rows are the page's loader list too: every `kind: "module"` renderer they name is
-			// handed to the page server, which refuses a specifier that does not resolve (ADR 0359).
-			const programs = yield* Registry.use((registry) => registry.list).pipe(
-				Effect.provideContext(kernel),
-			);
-			const moduleRenderers = moduleRendererRefs(programs);
+			// The config's rows are the page's loader list too: every `kind: "module"` renderer they name
+			// is handed to the page server beside the config module that declared it, and the page refuses
+			// a specifier that resolves from neither (ADR 0359, amended by #8262).
 			yield* servePage({root: appRoot, transport, port: pagePort, moduleRenderers}).pipe(
 				Effect.flatMap((page) => Console.log(`tuval: desk at ${page.url}`)),
 				Effect.catch((error) => Console.error(`tuval: ${error.message}`)),

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -30,6 +30,7 @@ import {dispatchConfigChanged} from "./reload.ts";
 import type {ShellDispatch} from "./shell/commands/dispatch.ts";
 import {shellDispatchKernel, shellWindowIndexKernel} from "./shell/commands/kernel.ts";
 import {shellId} from "./shell/program.ts";
+import type {ModuleRendererRef} from "./shell/window/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 
 /** The global config module, `~/.tuval/tuval.config.ts`; the home dir is a parameter so a test can point it elsewhere. */
@@ -185,6 +186,12 @@ export interface Booted {
 	readonly report: BootReport;
 	readonly kernel: Context.Context<Kernel>;
 	/**
+	 * The `kind: "module"` window specifiers the booted rows declared, each beside the config module
+	 * that declared it. The page server resolves every one from its own origin, so it is carried out
+	 * of the config load rather than recomputed from the registry, whose rows have lost their layer.
+	 */
+	readonly moduleRenderers: ReadonlyArray<ModuleRendererRef>;
+	/**
 	 * The config read again, its spells registered and its bindings compiled against them in one
 	 * write, and then every live process handed what its own row says the new config means for it
 	 * (`reload.ts`). Nothing restarts and nothing respawns: a process keeps running under the row
@@ -245,6 +252,7 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 	return {
 		report,
 		kernel: started.kernel,
+		moduleRenderers: config.moduleRenderers,
 		reload: reload().pipe(Effect.provideContext(started.kernel)),
 	} satisfies Booted;
 });

--- a/apps/tuval/src/config-fixtures/module-renderer-global.ts
+++ b/apps/tuval/src/config-fixtures/module-renderer-global.ts
@@ -1,0 +1,7 @@
+export default {
+	version: 1,
+	programs: [
+		{id: "a", renderer: {kind: "module", ref: "@global/win/window"}},
+		{id: "b", renderer: {kind: "module", ref: "@shared/win/window"}},
+	],
+};

--- a/apps/tuval/src/config-fixtures/module-renderer-project.ts
+++ b/apps/tuval/src/config-fixtures/module-renderer-project.ts
@@ -1,0 +1,8 @@
+export default {
+	version: 1,
+	programs: [
+		{id: "b", renderer: {kind: "module", ref: "@shared/win/window"}},
+		{id: "c", renderer: {kind: "module", ref: "@project/win/window"}},
+		{id: "d", renderer: {kind: "host-native", ref: "not-a-module"}},
+	],
+};

--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -25,7 +25,12 @@ import {
 	KeyBindings,
 } from "./commands/bindings/index.ts";
 import {type Graph, NodeId} from "./ports/graph.ts";
-import {ProgramId} from "./registry/program.ts";
+import {type AnyProgram, ProgramId} from "./registry/program.ts";
+import {
+	type DeclaredProgram,
+	type ModuleRendererRef,
+	moduleRendererRefs,
+} from "./shell/window/renderer.ts";
 
 const hasStringId = (row: unknown): row is {readonly id: string} =>
 	Predicate.isObject(row) && Predicate.isString((row as {readonly id?: unknown}).id);
@@ -137,6 +142,12 @@ export interface ConfigLayers {
 
 export interface LoadedConfig {
 	readonly programs: ReadonlyArray<unknown>;
+	/**
+	 * The `kind: "module"` window specifiers the merged rows declared, each beside the layer module
+	 * that declared it. Carried from here rather than recomputed from `programs`, because the origin
+	 * is only knowable while the layers are still apart — a flat merged row has lost its layer (#8262).
+	 */
+	readonly moduleRenderers: ReadonlyArray<ModuleRendererRef>;
 	readonly graph: Graph;
 	/**
 	 * One binding source per layer that existed, global first. They stay apart rather than merging
@@ -160,6 +171,13 @@ const bindingSource = (layer: ConfigLayer, path: string, keys: KeyBindings): Bin
 });
 
 const rowId = (row: unknown): string => (row as {readonly id: string}).id;
+
+/**
+ * A layer's rows, each stamped with the module they were written in. Config rows are trusted local
+ * code and opaque past their id (#7484 R1.1), so the cast here is the same one `boot` makes.
+ */
+const declaredIn = (config: TuvalConfig, module: string): ReadonlyArray<DeclaredProgram> =>
+	config.programs.map((row) => ({row: row as AnyProgram, origin: module}));
 
 /** `over` replaces a `base` entry with the same key in place; the rest append in `over`'s order. */
 const mergeById = <T>(base: ReadonlyArray<T>, over: ReadonlyArray<T>, key: (item: T) => string) => {
@@ -187,8 +205,19 @@ export const loadLayeredConfig = Effect.fn("Tuval.loadLayeredConfig")(function* 
 	const empty: TuvalConfig = {version: 1, programs: [], graph: {nodes: []}, keys: {}};
 	const base = Option.getOrElse(global, () => empty);
 	const over = Option.getOrElse(project, () => empty);
+	// Merged as declared rows rather than as bare rows: the merge is the last place a row and its
+	// layer module are still together, and a project row that replaces a global one by id has to come
+	// out carrying the project module as its origin.
+	const declared = mergeById(
+		declaredIn(base, layers.global),
+		declaredIn(over, layers.project),
+		(program) => rowId(program.row),
+	);
 	return {
-		programs: mergeById(base.programs, over.programs, rowId),
+		// Widened back: the loader checked each row's id and nothing else, and that is all a caller
+		// may assume of one.
+		programs: declared.map((program): unknown => program.row),
+		moduleRenderers: moduleRendererRefs(declared),
 		graph: {nodes: mergeById(base.graph.nodes, over.graph.nodes, (node) => node.id)},
 		keys: [
 			...(Option.isSome(global) ? [bindingSource("global", layers.global, base.keys)] : []),

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -102,6 +102,7 @@ describe("loadLayeredConfig", () => {
 				const config = yield* layered(fixture("global-layer"), fixture("project-layer"));
 				assert.deepStrictEqual(config, {
 					programs: [{id: "a"}, {id: "b", core: "project"}],
+					moduleRenderers: [],
 					graph: {
 						nodes: [
 							{id: NodeId.make("n"), program: ProgramId.make("b"), on: []},
@@ -122,18 +123,21 @@ describe("loadLayeredConfig", () => {
 			const missing = fixture("does-not-exist");
 			assert.deepStrictEqual(yield* layered(missing, fixture("with-graph")), {
 				programs: [{id: "a"}],
+				moduleRenderers: [],
 				graph: {nodes: [{id: NodeId.make("n"), program: ProgramId.make("a"), on: []}]},
 				keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
 				sources: [fixture("with-graph")],
 			});
 			assert.deepStrictEqual(yield* layered(fixture("two-rows"), missing), {
 				programs: [{id: "a"}, {id: "b"}],
+				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
 				sources: [fixture("two-rows")],
 			});
 			assert.deepStrictEqual(yield* layered(missing, missing), {
 				programs: [],
+				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [],
 				sources: [],
@@ -151,6 +155,23 @@ describe("loadLayeredConfig", () => {
 				},
 			]);
 		}),
+	);
+
+	it.effect(
+		"names each module renderer beside the layer module that declared it, project origin winning",
+		() =>
+			Effect.gen(function* () {
+				const global = fixture("module-renderer-global");
+				const project = fixture("module-renderer-project");
+				const config = yield* layered(global, project);
+				assert.deepStrictEqual(config.moduleRenderers, [
+					{ref: "@global/win/window", origin: global},
+					// Row `b` is declared in both layers; the project row replaced the global one in
+					// place, so the specifier resolves from the project config, not the global one.
+					{ref: "@shared/win/window", origin: project},
+					{ref: "@project/win/window", origin: project},
+				]);
+			}),
 	);
 
 	it.effect("still refuses a layer that exists and is broken", () =>

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -16,8 +16,10 @@
  * to be told this one, and that is why this module takes the transport rather than its URL (#7560).
  */
 
+import {dirname} from "node:path";
 import {Effect, Schema} from "effect";
 import type {TransportServer} from "../shell/transport/server.ts";
+import type {ModuleRendererRef} from "../shell/window/index.ts";
 
 /** The page did not start. The kernel is unaffected — the bin reports this and keeps running. */
 export class PageServerFailed extends Schema.TaggedError<PageServerFailed>()(
@@ -45,10 +47,11 @@ export interface PageServerOptions {
 	readonly port: number;
 	/**
 	 * The `kind: "module"` renderer specifiers the booted rows declared (`moduleRendererRefs`,
-	 * `../shell/window/renderer.ts`), each one the page has to load (ADR 0359). Absent means none:
-	 * a proof that serves the page over its own rows names none and the page loads nothing.
+	 * `../shell/window/renderer.ts`), each beside the config module that declared it (ADR 0359, as
+	 * amended by #8262). Absent means none: a proof that serves the page over its own rows names none
+	 * and the page loads nothing.
 	 */
-	readonly moduleRenderers?: ReadonlyArray<string>;
+	readonly moduleRenderers?: ReadonlyArray<ModuleRendererRef>;
 }
 
 export interface PageServer {
@@ -101,14 +104,135 @@ export const moduleRenderersSource = (refs: ReadonlyArray<string>): string => {
  */
 const isBareSpecifier = (ref: string): boolean => !ref.startsWith("/") && !ref.startsWith(".");
 
-const moduleRenderersPlugin = (refs: ReadonlyArray<string>) => ({
-	name: "tuval-module-renderers",
-	resolveId(id: string) {
-		return id === MODULE_RENDERERS_ID ? RESOLVED_MODULE_RENDERERS_ID : null;
-	},
-	load(id: string) {
-		return id === RESOLVED_MODULE_RENDERERS_ID ? moduleRenderersSource(refs) : null;
-	},
+/**
+ * A specifier written against the page's own root, the spelling an in-tree module uses
+ * (`/src/demo/module-window.tsx`). It names a file of the app rather than a module the founder
+ * installed, so its base is the root and stays the root: Vite resolves it exactly as it resolves
+ * every other import the app writes, and the plugin below leaves it alone.
+ */
+const isRootRelative = (ref: string): boolean => ref.startsWith("/");
+
+/**
+ * A module reference after resolution. `file` is the module the specifier actually names; `origin`
+ * is the config module that declared the row, kept so a later sentence can name it.
+ */
+export interface ResolvedModuleRenderer {
+	/** The specifier as the row wrote it: the key the loader module and the renderer table share. */
+	readonly ref: string;
+	readonly origin: string;
+	/** Absolute path of the module `ref` resolved to. */
+	readonly file: string;
+}
+
+/**
+ * The dependency-optimiser entries a set of resolved references asks for: the absolute file behind
+ * every bare specifier. Naming them up front is what prebundles a renderer package with the page's
+ * own React and Effect rather than discovering it on first open — the one way a module renderer's
+ * hooks can break at first paint — and it is the absolute path, not the bare specifier, because a
+ * package installed beside the user's config does not resolve from the app root at all (#8262).
+ */
+export const optimizedDepEntries = (
+	resolved: ReadonlyArray<ResolvedModuleRenderer>,
+): ReadonlyArray<string> =>
+	resolved.filter((entry) => isBareSpecifier(entry.ref)).map((entry) => entry.file);
+
+/**
+ * The directories the file server has to be allowed to read from, beside the workspace Vite already
+ * allows: each config module's own directory and each resolved module's, because a program installed
+ * beside `<home>/.tuval/tuval.config.ts` is served from outside the app's workspace entirely.
+ */
+export const servedDirectories = (
+	resolved: ReadonlyArray<ResolvedModuleRenderer>,
+): ReadonlyArray<string> => [
+	...new Set(
+		resolved.flatMap((entry) =>
+			isRootRelative(entry.ref) ? [] : [dirname(entry.origin), dirname(entry.file)],
+		),
+	),
+];
+
+/**
+ * The page's own resolver, told the one thing it cannot work out: which file each specifier the
+ * loader module imports actually names. Only the loader module's imports are answered — the same
+ * specifier written anywhere else in the app is nobody's business but Vite's.
+ */
+const moduleRenderersPlugin = (resolved: ReadonlyArray<ResolvedModuleRenderer>) => {
+	const files = new Map(
+		resolved.filter((entry) => !isRootRelative(entry.ref)).map((entry) => [entry.ref, entry.file]),
+	);
+	return {
+		name: "tuval-module-renderers",
+		resolveId(id: string, importer: string | undefined) {
+			if (id === MODULE_RENDERERS_ID) return RESOLVED_MODULE_RENDERERS_ID;
+			if (importer !== RESOLVED_MODULE_RENDERERS_ID) return null;
+			return files.get(id) ?? null;
+		},
+		load(id: string) {
+			return id === RESOLVED_MODULE_RENDERERS_ID
+				? moduleRenderersSource(resolved.map((entry) => entry.ref))
+				: null;
+		},
+	};
+};
+
+/**
+ * Why a specifier refused the page, in the terms of whoever has to act on it: a package the founder
+ * installed is named against the config module they wrote the row in, and an in-tree path against
+ * the page root it was written for. Neither sentence blames a base the author never named.
+ */
+const unresolvedSentence = (ref: ModuleRendererRef, root: string): string =>
+	isRootRelative(ref.ref)
+		? `renderer module ${JSON.stringify(ref.ref)}, declared by ${ref.origin}, does not resolve from the page root ${root}`
+		: `renderer module ${JSON.stringify(ref.ref)} does not resolve from ${ref.origin}, the config that declared it; is the package installed beside that config?`;
+
+/**
+ * Every reference resolved from the base its own row was declared against, before the page binds
+ * anything. Node resolved the row's kernel half from the config module that declared it, and this is
+ * the same lookup for the row's window half (#8262) — so a program lives beside the user's config
+ * rather than having to be a dependency of the app. A specifier that resolves from neither that
+ * config nor the page root refuses here, naming itself and that config, rather than surfacing as a
+ * failed import in a browser tab: the graph compiler's stance, refuse before anything is shown.
+ *
+ * The resolver is a Vite of its own, in middleware mode — it binds no port and serves nothing. It
+ * has to be a second one because its answers are what the real server's `optimizeDeps.include` and
+ * `server.fs.allow` are built from, and a server reads both once, when it is created.
+ */
+const resolveModuleRenderers = Effect.fn("Tuval.page.resolveModuleRenderers")(function* (
+	createServer: typeof import("vite").createServer,
+	root: string,
+	refs: ReadonlyArray<ModuleRendererRef>,
+) {
+	if (refs.length === 0) return [] as ReadonlyArray<ResolvedModuleRenderer>;
+	const resolver = yield* attempt(() =>
+		createServer({
+			root,
+			configFile: false,
+			appType: "custom",
+			server: {middlewareMode: true, hmr: false, ws: false},
+			// Nothing is served from this one, so nothing needs prebundling; discovery here would
+			// optimise into a cache the real server is about to rebuild anyway.
+			optimizeDeps: {noDiscovery: true, include: []},
+		}),
+	);
+	return yield* Effect.forEach(
+		refs,
+		(ref) =>
+			Effect.gen(function* () {
+				// The importer is the base: the config module for a package or a relative path, and none at
+				// all for the root-relative spelling, which Vite reads against the root it was given.
+				const importer = isRootRelative(ref.ref) ? undefined : ref.origin;
+				const hit = yield* attempt(() =>
+					resolver.environments.ssr.pluginContainer.resolveId(ref.ref, importer),
+				);
+				if (hit === null) {
+					return yield* new PageServerFailed({cause: new Error(unresolvedSentence(ref, root))});
+				}
+				return {ref: ref.ref, origin: ref.origin, file: hit.id} satisfies ResolvedModuleRenderer;
+			}),
+		// Serial on purpose: the first specifier that does not resolve is the one the founder is
+		// told about, and row order is the order they wrote.
+		{concurrency: 1},
+	).pipe(Effect.ensuring(Effect.ignore(attempt(() => resolver.close()))));
 });
 
 interface LaunchResponse {
@@ -118,7 +242,7 @@ interface LaunchResponse {
 
 /** Start the dev server, and close it with the caller's Scope. */
 export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageServerOptions) {
-	const {createServer} = yield* attempt(() => import("vite"));
+	const {createServer, searchForWorkspaceRoot} = yield* attempt(() => import("vite"));
 	// Configured here rather than in a `vite.config.ts` so the one config lives in code the
 	// typechecker reads. React Fast Refresh is what makes editing a renderer bearable.
 	const react = yield* attempt(() => import("@vitejs/plugin-react"));
@@ -131,7 +255,14 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 			}) as never);
 		},
 	};
-	const moduleRenderers = options.moduleRenderers ?? [];
+	// Resolved before the server exists, because the answers are what its optimiser entries and its
+	// file-serving allowance are built from — and because a specifier that resolves from nowhere then
+	// refuses with no port bound and nothing to close.
+	const moduleRenderers = yield* resolveModuleRenderers(
+		createServer,
+		options.root,
+		options.moduleRenderers ?? [],
+	);
 	const server = yield* Effect.acquireRelease(
 		attempt(() =>
 			createServer({
@@ -139,11 +270,22 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 				configFile: false,
 				appType: "spa",
 				plugins: [launchEndpoint, moduleRenderersPlugin(moduleRenderers), react.default()],
-				server: {port: options.port, strictPort: false, host: "127.0.0.1"},
+				server: {
+					port: options.port,
+					strictPort: false,
+					host: "127.0.0.1",
+					// A program installed beside the user's config is outside the app's workspace, and
+					// Vite's default allowance is that workspace alone — so the page would resolve the
+					// module and then refuse to serve it. The workspace stays in the list: the app's own
+					// linked packages are served from it.
+					fs: {
+						allow: [searchForWorkspaceRoot(options.root), ...servedDirectories(moduleRenderers)],
+					},
+				},
 				// Named up front so a renderer package is prebundled with the page's own React rather
 				// than discovered on first open, which would serve it a second React copy until the
 				// re-optimise reload — the one way a module renderer's hooks can break at first paint.
-				optimizeDeps: {include: moduleRenderers.filter(isBareSpecifier)},
+				optimizeDeps: {include: [...optimizedDepEntries(moduleRenderers)]},
 				// A renderer package names React and Effect as peers, and a peer means "the page's copy".
 				// A package linked from another checkout (`link:`, `pnpm link`) carries its own
 				// `node_modules`, and without this the browser gets a second React whose hooks throw
@@ -154,22 +296,6 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 		(dev) => Effect.ignore(attempt(() => dev.close())),
 	);
 	yield* attempt(() => server.listen());
-	// Every specifier the rows named is resolved now, from the same root the loader module's own
-	// `import()` resolves from. One that does not resolve refuses the page here, naming itself, rather
-	// than surfacing as a failed import in a browser tab (the graph compiler's stance: refuse at boot).
-	for (const ref of moduleRenderers) {
-		const resolved = yield* attempt(() =>
-			server.environments.client.pluginContainer.resolveId(ref, RESOLVED_MODULE_RENDERERS_ID),
-		);
-		if (resolved === null) {
-			yield* Effect.ignore(attempt(() => server.close()));
-			return yield* new PageServerFailed({
-				cause: new Error(
-					`renderer module ${JSON.stringify(ref)} does not resolve from ${options.root}; is the package installed here?`,
-				),
-			});
-		}
-	}
 	const url = server.resolvedUrls?.local[0];
 	if (url === undefined) {
 		return yield* new PageServerFailed({cause: new Error("it bound no local address")});

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -5,9 +5,13 @@
  */
 
 import {describe, expect, it} from "vitest";
+import type {AnyProgram} from "../registry/program.ts";
 import {counterRow, noRendererRow} from "../shell/window/fixtures.ts";
-import {moduleRendererRefs} from "../shell/window/index.ts";
-import {moduleRenderersSource} from "./dev-server.ts";
+import {type DeclaredProgram, moduleRendererRefs} from "../shell/window/index.ts";
+import {moduleRenderersSource, optimizedDepEntries, servedDirectories} from "./dev-server.ts";
+
+const GLOBAL_CONFIG = "/home/founder/.tuval/tuval.config.ts";
+const PROJECT_CONFIG = "/work/app/.tuval/tuval.config.ts";
 
 describe("the module renderers loader module", () => {
 	it("holds one static import() per reference, keyed by the reference the row wrote", () => {
@@ -36,13 +40,59 @@ describe("the module renderers loader module", () => {
 });
 
 describe("moduleRendererRefs", () => {
-	it("lists the module references only, each once, in row order", () => {
+	const declared = (row: AnyProgram, origin: string): DeclaredProgram => ({row, origin});
+
+	it("lists the module references only, each once, in row order, each with its own config", () => {
 		const module = {...counterRow, renderer: {kind: "module", ref: "@x/one/window"}} as const;
 		const again = {...counterRow, renderer: {kind: "module", ref: "@x/one/window"}} as const;
 		const other = {...counterRow, renderer: {kind: "module", ref: "@x/two/window"}} as const;
-		expect(moduleRendererRefs([counterRow, noRendererRow, other, module, again])).toEqual([
-			"@x/two/window",
-			"@x/one/window",
+		expect(
+			moduleRendererRefs([
+				declared(counterRow, GLOBAL_CONFIG),
+				declared(noRendererRow, GLOBAL_CONFIG),
+				declared(other, GLOBAL_CONFIG),
+				declared(module, PROJECT_CONFIG),
+				declared(again, PROJECT_CONFIG),
+			]),
+		).toEqual([
+			{ref: "@x/two/window", origin: GLOBAL_CONFIG},
+			{ref: "@x/one/window", origin: PROJECT_CONFIG},
+		]);
+	});
+
+	it("keeps the first row's config when two rows write one specifier, as the table has one seat", () => {
+		const first = {...counterRow, renderer: {kind: "module", ref: "@x/one/window"}} as const;
+		const second = {...counterRow, renderer: {kind: "module", ref: "@x/one/window"}} as const;
+		expect(
+			moduleRendererRefs([declared(first, GLOBAL_CONFIG), declared(second, PROJECT_CONFIG)]),
+		).toEqual([{ref: "@x/one/window", origin: GLOBAL_CONFIG}]);
+	});
+});
+
+describe("what a resolved reference tells the page server", () => {
+	const installed = {
+		ref: "@acme/win/window",
+		origin: GLOBAL_CONFIG,
+		file: "/home/founder/.tuval/node_modules/@acme/win/window.js",
+	};
+	const inTree = {
+		ref: "/src/demo/module-window.tsx",
+		origin: PROJECT_CONFIG,
+		file: "/work/app/apps/tuval/src/demo/module-window.tsx",
+	};
+
+	it("optimises the file behind a bare specifier, not the specifier the app root cannot resolve", () => {
+		expect(optimizedDepEntries([installed, inTree])).toEqual([installed.file]);
+	});
+
+	it("leaves an in-tree path to the optimiser's source handling, as it always was", () => {
+		expect(optimizedDepEntries([inTree])).toEqual([]);
+	});
+
+	it("asks the file server for the config's directory and the module's, and each once", () => {
+		expect(servedDirectories([installed, installed, inTree])).toEqual([
+			"/home/founder/.tuval",
+			"/home/founder/.tuval/node_modules/@acme/win",
 		]);
 	});
 });

--- a/apps/tuval/src/page/module-renderers.integration.test.ts
+++ b/apps/tuval/src/page/module-renderers.integration.test.ts
@@ -1,24 +1,34 @@
 /**
  * The page server's half of a module renderer reference (ADR 0359), against a real Vite: the loader
  * module it generates is served under its virtual id with the fixture's `import()` inside, and a
- * specifier nothing installed here answers to refuses the page at boot with the specifier in the
+ * specifier nothing installed answers to refuses the page at boot with the specifier in the
  * sentence — the terminal, not a blank tab, is where a founder learns the package is not there.
  *
- * The fixture behind the `import()` is not fetched here on purpose. Transforming a `.tsx` starts
- * Vite's dependency discovery, and a `close()` that lands while that scan is in flight never settles
- * (Vite 8.1.5; `waitForRequestsIdle()` before the close is the cure, and `servePage` hands out no
- * server to wait on). The fixture's own load path is `module-renderers.unit.test.ts`, through the
- * same `import()` the served module carries.
+ * The base each specifier resolves from is the config module that declared its row, not the app root
+ * (#8262), so the third case here is the install the app root has no answer for at all: a package
+ * under a config directory outside the tree. It is built on disk rather than described, because what
+ * is under test is Node package resolution and Vite's file serving, and a fake of either would agree
+ * with whatever this file believed.
+ *
+ * The in-tree fixture behind the root-relative `import()` is not fetched here on purpose.
+ * Transforming a `.tsx` starts Vite's dependency discovery, and a `close()` that lands while that
+ * scan is in flight never settles (Vite 8.1.5; `waitForRequestsIdle()` before the close is the cure,
+ * and `servePage` hands out no server to wait on). The fixture's own load path is
+ * `module-renderers.unit.test.ts`, through the same `import()` the served module carries. The
+ * out-of-tree package below imports nothing for the same reason.
  */
 
-import {dirname} from "node:path";
-import {assert, describe, it} from "@effect/vitest";
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {afterAll, assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Schema} from "effect";
 import type {TransportServer} from "../shell/transport/server.ts";
 import {PageServerFailed, servePage} from "./dev-server.ts";
 
 const appRoot = dirname(dirname(import.meta.dirname));
 const FIXTURE_REF = "/src/demo/module-window.tsx";
+const IN_TREE_CONFIG = join(appRoot, ".tuval", "tuval.config.ts");
 /** How Vite spells a `\0`-prefixed virtual id in a URL. */
 const VIRTUAL_URL = "/@id/__x00__virtual:tuval/module-renderers";
 const TIMEOUT = 30_000;
@@ -41,6 +51,39 @@ const text = (url: URL) =>
 		catch: (cause) => new FetchFailed({cause}),
 	});
 
+const tempDirs: string[] = [];
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, {recursive: true, force: true});
+});
+
+/**
+ * A config directory nowhere near the app root, holding one installed renderer package: the shape
+ * `~/.tuval` has once a founder runs `pnpm add` beside their own config. The package's window module
+ * is plain JavaScript and imports nothing, so serving it starts no dependency scan.
+ */
+const configWithInstalledRenderer = (): {readonly config: string; readonly file: string} => {
+	// realpath: macOS resolves /var to /private/var, and Vite answers with the real path.
+	const dir = realpathSync(mkdtempSync(join(tmpdir(), "tuval-config-")));
+	tempDirs.push(dir);
+	const pkg = join(dir, "node_modules", "@tuval-fixture", "win");
+	mkdirSync(pkg, {recursive: true});
+	writeFileSync(
+		join(pkg, "package.json"),
+		JSON.stringify({
+			name: "@tuval-fixture/win",
+			version: "1.0.0",
+			type: "module",
+			exports: {"./window": "./window.js"},
+		}),
+	);
+	writeFileSync(
+		join(pkg, "window.js"),
+		'export const admits = () => true;\nexport default {kind: "module", render: () => "installed-beside-the-config"};\n',
+	);
+	writeFileSync(join(dir, "tuval.config.ts"), "export default {version: 1, programs: []};\n");
+	return {config: join(dir, "tuval.config.ts"), file: join(pkg, "window.js")};
+};
+
 describe("the served module renderers", () => {
 	it.live(
 		"the virtual module carries one import() per reference, keyed by the reference",
@@ -50,7 +93,7 @@ describe("the served module renderers", () => {
 					root: appRoot,
 					transport,
 					port: 0,
-					moduleRenderers: [FIXTURE_REF],
+					moduleRenderers: [{ref: FIXTURE_REF, origin: IN_TREE_CONFIG}],
 				});
 				const loader = yield* text(new URL(VIRTUAL_URL, page.url));
 				assert.include(loader, `"${FIXTURE_REF}"`);
@@ -61,23 +104,47 @@ describe("the served module renderers", () => {
 	);
 
 	it.live(
-		"a specifier that does not resolve from the app root refuses the page at boot, by name",
+		"a specifier that resolves from neither refuses the page at boot, naming its config",
 		() =>
 			Effect.gen(function* () {
+				const {config} = configWithInstalledRenderer();
 				const exit = yield* servePage({
 					root: appRoot,
 					transport,
 					port: 0,
-					moduleRenderers: ["@tuval-nobody/not-installed/window"],
+					moduleRenderers: [{ref: "@tuval-nobody/not-installed/window", origin: config}],
 				}).pipe(Effect.scoped, Effect.exit);
 				assert.ok(Exit.isFailure(exit), "the page refused to serve");
 				if (!Exit.isFailure(exit)) return;
-				const failure = Exit.isFailure(exit) ? exit.cause : null;
-				const message = String(failure);
+				const message = String(exit.cause);
 				assert.include(message, "@tuval-nobody/not-installed/window");
 				assert.include(message, "does not resolve");
+				assert.include(message, config);
+				assert.notInclude(message, `does not resolve from ${appRoot}`);
 				assert.include(message, PageServerFailed.name);
 			}),
+		TIMEOUT,
+	);
+
+	it.live(
+		"a package installed beside a config outside the app root resolves, and the page serves it",
+		() =>
+			Effect.gen(function* () {
+				const {config, file} = configWithInstalledRenderer();
+				const page = yield* servePage({
+					root: appRoot,
+					transport,
+					port: 0,
+					moduleRenderers: [{ref: "@tuval-fixture/win/window", origin: config}],
+				});
+				const loader = yield* text(new URL(VIRTUAL_URL, page.url));
+				assert.include(loader, '"@tuval-fixture/win/window"');
+				// The import Vite rewrote is the file itself, reached from the config that declared
+				// the row — the app root holds no such package and never resolved it.
+				assert.include(loader, file);
+				const served = yield* text(new URL(`/@fs${file}`, page.url));
+				assert.include(served, "installed-beside-the-config");
+			}).pipe(Effect.scoped),
 		TIMEOUT,
 	);
 });

--- a/apps/tuval/src/shell/window/index.ts
+++ b/apps/tuval/src/shell/window/index.ts
@@ -20,6 +20,8 @@ export {
 } from "./host.ts";
 export {
 	type AnyWindowRenderer,
+	type DeclaredProgram,
+	type ModuleRendererRef,
 	moduleRendererRefs,
 	type RendererLoadFailure,
 	type RendererRefusal,

--- a/apps/tuval/src/shell/window/renderer.ts
+++ b/apps/tuval/src/shell/window/renderer.ts
@@ -102,17 +102,46 @@ export const resolverFromTable =
 	};
 
 /**
- * The module specifiers a set of rows asks the page to load: one per `kind: "module"` window
- * reference, in row order, each once. The page server generates its loader module from exactly this
- * list, which is why it is computed here from the rows and not typed twice.
+ * A program row beside the config module that declared it. Node resolved the row's own imports from
+ * that module, and a `kind: "module"` renderer on the row is the other half of the same program, so
+ * that module is the base its specifier resolves from too — a program installed beside the user's
+ * config is whole there, and never has to be a dependency of the app (#8262).
  */
-export const moduleRendererRefs = (rows: ReadonlyArray<AnyProgram>): ReadonlyArray<string> => [
-	...new Set(
-		rows.flatMap((row) =>
-			row.renderer?.kind === "module" ? [row.renderer.ref] : ([] as ReadonlyArray<string>),
-		),
-	),
-];
+export interface DeclaredProgram {
+	readonly row: AnyProgram;
+	/** Absolute path of the config module whose `programs` array holds this row. */
+	readonly origin: string;
+}
+
+/** One `kind: "module"` window specifier, carrying the config module that declared its row. */
+export interface ModuleRendererRef {
+	/** The specifier as the row wrote it: the key the page seats the loaded renderer under. */
+	readonly ref: string;
+	/** Absolute path of the config module that declared the row — what `ref` resolves from. */
+	readonly origin: string;
+}
+
+/**
+ * The module specifiers a set of declared rows asks the page to load: one per `kind: "module"`
+ * window reference, in row order, each once. The page server generates its loader module from
+ * exactly this list, which is why it is computed here from the rows and not typed twice.
+ *
+ * The dedupe key is `ref` alone, because that string is the renderer table's key and two seats
+ * cannot share one. Where two rows wrote the same specifier, the first keeps its origin: a merged
+ * row sits in the layer position it overrode, so a project row replacing a global one by id already
+ * arrives here carrying the project config as its origin.
+ */
+export const moduleRendererRefs = (
+	declared: ReadonlyArray<DeclaredProgram>,
+): ReadonlyArray<ModuleRendererRef> => {
+	const seen = new Map<string, ModuleRendererRef>();
+	for (const {row, origin} of declared) {
+		if (row.renderer?.kind !== "module") continue;
+		if (seen.has(row.renderer.ref)) continue;
+		seen.set(row.renderer.ref, {ref: row.renderer.ref, origin});
+	}
+	return [...seen.values()];
+};
 
 /** The row's renderer, or the reason there is none. This is the only route from a program to its window renderer. */
 export const rendererFor = (row: AnyProgram, resolve: RendererResolver): RendererResolution =>


### PR DESCRIPTION
A `kind: "module"` renderer's two halves resolved from two different bases. Node resolved the row's
kernel half from the config module that declared it; Vite resolved the same row's window half from
the app root. They agreed only because the app root is the sole place a program is installed today,
and they part the moment a config lives anywhere else — which is the install the Neovim model wants.

Each specifier now resolves from the config module that declared its row. The origin is kept at the
config merge, which is the last point a row and its layer module are still together, carried beside
the specifier by `moduleRendererRefs`, and used by `servePage` to resolve every reference before the
page binds a port. The root-relative spelling an in-tree module uses (`/src/demo/module-window.tsx`)
still reads against the page root and is untouched.

Three things move with it: the boot refusal names the config that declared the specifier instead of
the app root; `server.fs.allow` gains each config's directory and each resolved module's, so a
package outside the app's workspace can actually be served; and `optimizeDeps.include` names the
resolved absolute path rather than the bare specifier, which the app root cannot resolve at all —
`resolve.dedupe` is unchanged, and the served module's `react` and `effect` still come from the
page's own prebundled deps.

Verified by booting `node src/bin.ts` against a config directory outside the app root holding
`node_modules/@tuval-demo/win/window.js`: the page serves, the loader module's `import()` points at
that file, and its `react`/`effect` imports resolve to `/node_modules/.vite/deps/react.js` and
`effect.js` at the page's own build hash. The same run with the row moved to the project config
resolved from `<project>/.tuval`, and with the specifier misspelled printed
`renderer module "@tuval-proj/not-installed/window" does not resolve from <project>/.tuval/tuval.config.ts,
the config that declared it`.

ADR 0359's "resolved from the app root" sentence is amended in place with a dated `> Amendment`
blockquote, per the house form.

A reviewer should look first at `resolveModuleRenderers` in `apps/tuval/src/page/dev-server.ts` —
the resolution pass runs on a second Vite in middleware mode, because its answers are what the real
server's `optimizeDeps.include` and `server.fs.allow` are built from and a server reads both once,
at creation.

Fixes #8262

## Deviations

- **Out-of-scope change** — **Said:** the five criteria name the engine, the tests and ADR 0359.
  **Did:** also corrected the module-renderer paragraph in `apps/tuval/README.md`. **Why:** it told a
  founder the same thing the amended ADR sentence did, and leaving it would have left a second copy
  of the wrong rule on the surface a founder actually reads. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about the chat window's follow-the-newest-turn
  test. **Did:** left `src/shell/chat/chat-window.unit.test.tsx > leaves the offset alone when a turn
  lands after the reader scrolled up` alone. **Why:** it failed once here and once on a clean
  `origin/main` checkout, then passed on a full re-run of both — it is flaky, not broken by this
  change, and chasing it would widen the PR. **Disposition:** filed as a follow-up.
