### PR TITLE
feat: Escape on the picker after ctrl-b w should return the window to the process it was showing

### DIFF
--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -264,7 +264,7 @@ const openFromThePicker = Effect.fn("claudeVertical.openFromThePicker")(function
 	for (let step = 0; step < at; step += 1) {
 		const moved = pickerPress(windowId, entries, view, "j");
 		assert.isNotNull(moved, "the picker moved its highlight");
-		view = {cursor: view.cursor + 1, refusal: null};
+		view = {...view, cursor: step + 1, refusal: null};
 		yield* desk.send(moved as ShellMsg);
 	}
 	const chosen = pickerPress(windowId, entries, view, "<enter>");

--- a/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
+++ b/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
@@ -227,7 +227,7 @@ const openPiFromThePicker = Effect.fn("piVertical.openPiFromThePicker")(function
 	for (let step = 0; step < at; step += 1) {
 		const moved = pickerPress(windowId, entries, view, "j");
 		assert.isNotNull(moved, "the picker moved its highlight");
-		view = {cursor: view.cursor + 1, refusal: null};
+		view = {...view, cursor: step + 1, refusal: null};
 		yield* desk.send(moved as ShellMsg);
 	}
 	const chosen = pickerPress(windowId, entries, view, "<enter>");

--- a/apps/tuval/src/shell/commands/window-pick.unit.test.ts
+++ b/apps/tuval/src/shell/commands/window-pick.unit.test.ts
@@ -10,23 +10,50 @@ import {Effect} from "effect";
 import {ProcessId} from "../../process/process.ts";
 import {applyMsg, initialState, type ShellMsg} from "../core/machine.ts";
 import {activeWorkspace, keyTargetOf, type ShellState} from "../core/state.ts";
+import {wiredShellEffects} from "../host/effects.ts";
 import {defaultPrefixTable} from "../keys/index.ts";
 import {findWindow, windows} from "../layout/index.ts";
-import {readEntries} from "../picker/entries.ts";
+import {type PickerEntries, readEntries} from "../picker/entries.ts";
 import {pickerHarness, programRow, shellProcessId} from "../picker/fixtures.ts";
 import type {PickerIntent} from "../picker/intent.ts";
 import {attachProcess, openProgram} from "../picker/intent.ts";
 import {runPickerIntent} from "../picker/open.ts";
-import {highlighted, mountPicker, type PickerKeyAnswer, pickerKey} from "../picker/view.ts";
-import {asPickerView} from "../ui/PickerView.tsx";
+import {
+	asPickerView,
+	highlighted,
+	mountPicker,
+	type PickerKeyAnswer,
+	type PickerView,
+	pickerKey,
+} from "../picker/view.ts";
 import {WindowId} from "../window/index.ts";
 import {commandFor} from "./table.ts";
 
 const counter = programRow("counter", {label: "Counter"});
 const keyed = programRow("keyed", {label: "Keyed", takesKeys: true});
+const faulty = programRow("faulty", {label: "Faulty"});
 
 const apply = (state: ShellState, msg: ShellMsg): ShellState =>
 	applyMsg(defaultPrefixTable, state, msg)[0];
+
+/**
+ * One Msg down the path the desk actually runs: the core answers it with Cmds, the shell's own
+ * wired handlers answer those, and their Msgs go back through the core. A test that calls
+ * `runPickerIntent` itself skips the seam where a Cmd carries the window's view slot, which is the
+ * seam a refusal's `previous` survives on (#8265).
+ */
+const dispatch = (state: ShellState, msg: ShellMsg) =>
+	Effect.gen(function* () {
+		const effects = wiredShellEffects({shellProcessId});
+		const [next, cmds] = applyMsg(defaultPrefixTable, state, msg);
+		let out = next;
+		for (const cmd of cmds) {
+			if (cmd.type === "openProgram") out = (yield* effects.openProgram(cmd)).reduce(apply, out);
+			if (cmd.type === "attachProcess")
+				out = (yield* effects.attachProcess(cmd)).reduce(apply, out);
+		}
+		return out;
+	});
 
 const workspaceOf = (state: ShellState) => {
 	const workspace = activeWorkspace(state);
@@ -45,6 +72,29 @@ const boundProcess = (state: ShellState, windowId: WindowId): string => {
 	if (id === null) throw new Error("test setup: nothing is bound to the window");
 	return id;
 };
+
+const viewIn = (state: ShellState, windowId: WindowId): PickerView =>
+	asPickerView(state.views[windowId]);
+
+/** One key, answered the way `PickerView.tsx` answers it: store the view, or dispatch the choice. */
+const press = (state: ShellState, entries: PickerEntries, windowId: WindowId, key: string) =>
+	Effect.gen(function* () {
+		const answer = pickerKey(windowId, entries, viewIn(state, windowId), key);
+		switch (answer._tag) {
+			case "Moved":
+			case "Cleared":
+				return apply(state, {type: "window.setView", windowId, view: answer.view});
+			case "Chose":
+				return yield* dispatch(
+					state,
+					answer.intent._tag === "OpenProgram"
+						? {type: "window.open", windowId, programId: answer.intent.programId}
+						: {type: "window.attach", windowId, processId: answer.intent.processId},
+				);
+			case "Ignored":
+				return yield* Effect.die(new Error(`test setup: the picker ignored "${key}"`));
+		}
+	});
 
 const chosen = (answer: PickerKeyAnswer): PickerIntent => {
 	if (answer._tag !== "Chose") throw new Error(`test setup: the key answered ${answer._tag}`);
@@ -148,6 +198,58 @@ describe("window:pick returns a filled window to the picker", () => {
 					returned.map((msg) => msg.type),
 					["window.bind"],
 				);
+			}),
+		),
+	);
+
+	it.effect("a refusal the host raised leaves the way back intact (#8265)", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const harness = yield* pickerHarness([keyed, faulty], {spawnFails: faulty.id});
+				const empty = initialState();
+				const window = WindowId.make(workspaceOf(empty).focused);
+
+				const bound = yield* dispatch(empty, {
+					type: "window.open",
+					windowId: window,
+					programId: keyed.id,
+				}).pipe(Effect.provide(harness.layer));
+				const spawned = boundProcess(bound, window);
+
+				const unbound = apply(bound, pickMsg());
+				const entries = yield* readEntries.pipe(Effect.provide(harness.layer));
+
+				// One row up from the mounted highlight is the program whose spawn fails — the refusal a
+				// `<c-b> w` picker can actually raise, and the one that used to eat `previous`.
+				const onFaulty = yield* press(unbound, entries, window, "<arrowup>").pipe(
+					Effect.provide(harness.layer),
+				);
+				assert.deepStrictEqual(highlighted(entries, viewIn(onFaulty, window)), {
+					_tag: "Program",
+					programId: faulty.id,
+					label: "Faulty",
+				});
+
+				const refused = yield* press(onFaulty, entries, window, "<enter>").pipe(
+					Effect.provide(harness.layer),
+				);
+				assert.isNotNull(viewIn(refused, window).refusal);
+				assert.strictEqual(viewIn(refused, window).previous, spawned);
+				assert.isNull(processIn(refused, window));
+
+				const cleared = yield* press(refused, entries, window, "<escape>").pipe(
+					Effect.provide(harness.layer),
+				);
+				assert.isNull(viewIn(cleared, window).refusal);
+				assert.strictEqual(viewIn(cleared, window).previous, spawned);
+
+				const returned = yield* press(cleared, entries, window, "<escape>").pipe(
+					Effect.provide(harness.layer),
+				);
+				assert.strictEqual(processIn(returned, window), spawned);
+				assert.strictEqual(keyTargetOf(workspaceOf(returned), window), spawned);
+				// The refused spawn minted nothing, and Escape attached rather than opening a second one.
+				assert.strictEqual(harness.spawns().length, 1);
 			}),
 		),
 	);

--- a/apps/tuval/src/shell/commands/window-pick.unit.test.ts
+++ b/apps/tuval/src/shell/commands/window-pick.unit.test.ts
@@ -9,19 +9,21 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {ProcessId} from "../../process/process.ts";
 import {applyMsg, initialState, type ShellMsg} from "../core/machine.ts";
-import {activeWorkspace, type ShellState} from "../core/state.ts";
+import {activeWorkspace, keyTargetOf, type ShellState} from "../core/state.ts";
 import {defaultPrefixTable} from "../keys/index.ts";
 import {findWindow, windows} from "../layout/index.ts";
 import {readEntries} from "../picker/entries.ts";
 import {pickerHarness, programRow, shellProcessId} from "../picker/fixtures.ts";
+import type {PickerIntent} from "../picker/intent.ts";
 import {attachProcess, openProgram} from "../picker/intent.ts";
 import {runPickerIntent} from "../picker/open.ts";
-import {mountPicker} from "../picker/view.ts";
+import {highlighted, mountPicker, type PickerKeyAnswer, pickerKey} from "../picker/view.ts";
 import {asPickerView} from "../ui/PickerView.tsx";
 import {WindowId} from "../window/index.ts";
 import {commandFor} from "./table.ts";
 
 const counter = programRow("counter", {label: "Counter"});
+const keyed = programRow("keyed", {label: "Keyed", takesKeys: true});
 
 const apply = (state: ShellState, msg: ShellMsg): ShellState =>
 	applyMsg(defaultPrefixTable, state, msg)[0];
@@ -37,6 +39,17 @@ const processIn = (state: ShellState, windowId: WindowId): string | null =>
 
 const slots = (state: ShellState): ReadonlyArray<string> =>
 	[...windows(workspaceOf(state).layout.root)].map((node) => node.id);
+
+const boundProcess = (state: ShellState, windowId: WindowId): string => {
+	const id = processIn(state, windowId);
+	if (id === null) throw new Error("test setup: nothing is bound to the window");
+	return id;
+};
+
+const chosen = (answer: PickerKeyAnswer): PickerIntent => {
+	if (answer._tag !== "Chose") throw new Error(`test setup: the key answered ${answer._tag}`);
+	return answer.intent;
+};
 
 /** The Msg the key `<c-b> w` runs, read off the row rather than written out here. */
 const pickMsg = (): ShellMsg => {
@@ -67,7 +80,9 @@ describe("window:pick returns a filled window to the picker", () => {
 				const unbound = apply(used, pickMsg());
 				assert.isNull(processIn(unbound, window));
 				assert.deepStrictEqual(slots(unbound), slots(used));
-				assert.deepStrictEqual(asPickerView(unbound.views[window]), mountPicker());
+				// Fresh but for `previous`: #8083's "cursor 0" was about not leaking a stale cursor or
+				// refusal, and #8265 refines it — the mount names the process Escape returns to.
+				assert.deepStrictEqual(asPickerView(unbound.views[window]), mountPicker(spawned));
 
 				const entries = yield* readEntries.pipe(Effect.provide(harness.layer));
 				const offered = entries.processes.map((entry) => String(entry.processId));
@@ -90,6 +105,63 @@ describe("window:pick returns a filled window to the picker", () => {
 		),
 	);
 
+	it.effect("Escape on the picker it mounted puts the same process back (#8265)", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const harness = yield* pickerHarness([keyed]);
+				const empty = initialState();
+				const window = WindowId.make(workspaceOf(empty).focused);
+
+				const opened = yield* runPickerIntent(openProgram(window, keyed.id), {
+					shellProcessId,
+				}).pipe(Effect.provide(harness.layer));
+				const bound = opened.reduce(apply, empty);
+				const spawned = boundProcess(bound, window);
+				assert.strictEqual(keyTargetOf(workspaceOf(bound), window), spawned);
+
+				const unbound = apply(bound, pickMsg());
+				const entries = yield* readEntries.pipe(Effect.provide(harness.layer));
+				const view = asPickerView(unbound.views[window]);
+
+				// The picker mounts pointing at the row Escape returns to, so the operator can see it.
+				assert.deepStrictEqual(highlighted(entries, view), {
+					_tag: "Process",
+					processId: ProcessId.make(spawned),
+					programId: keyed.id,
+					label: "Keyed",
+					parentId: shellProcessId,
+				});
+
+				const intent = chosen(pickerKey(window, entries, view, "<escape>"));
+				const returned = yield* runPickerIntent(intent, {shellProcessId}).pipe(
+					Effect.provide(harness.layer),
+				);
+				const refilled = returned.reduce(apply, unbound);
+				assert.strictEqual(processIn(refilled, window), spawned);
+				// `takesKeys` came back with the binding, so the returned window is sent keys again.
+				assert.strictEqual(keyTargetOf(workspaceOf(refilled), window), spawned);
+
+				// One spawn on the whole trip: Escape attached, it never re-opened the program, and
+				// nothing on the path could have stopped the process — the core has no arm for it.
+				assert.strictEqual(harness.spawns().length, 1);
+				assert.deepStrictEqual(
+					returned.map((msg) => msg.type),
+					["window.bind"],
+				);
+			}),
+		),
+	);
+
+	it("Escape on a picker no `window:pick` mounted stays the dismiss key (#8265)", () => {
+		const empty = initialState();
+		const window = WindowId.make(workspaceOf(empty).focused);
+		const view = asPickerView(empty.views[window]);
+		assert.strictEqual(view.previous, null);
+		assert.deepStrictEqual(pickerKey(window, {programs: [], processes: []}, view, "<escape>"), {
+			_tag: "Ignored",
+		});
+	});
+
 	it("does nothing to a window that is already on the picker", () => {
 		const empty = initialState();
 		const window = WindowId.make(workspaceOf(empty).focused);
@@ -97,6 +169,10 @@ describe("window:pick returns a filled window to the picker", () => {
 
 		const after = apply(moved, pickMsg());
 		assert.strictEqual(after, moved);
-		assert.deepStrictEqual(asPickerView(after.views[window]), {cursor: 1, refusal: null});
+		assert.deepStrictEqual(asPickerView(after.views[window]), {
+			cursor: 1,
+			refusal: null,
+			previous: null,
+		});
 	});
 });

--- a/apps/tuval/src/shell/core/machine.ts
+++ b/apps/tuval/src/shell/core/machine.ts
@@ -43,6 +43,7 @@ import {
 	zoom,
 } from "../layout/index.ts";
 import type {OpenSession} from "../picker/intent.ts";
+import {mountPicker} from "../picker/view.ts";
 import type {ViewState} from "../window/host.ts";
 import {
 	activeWorkspace,
@@ -226,6 +227,10 @@ const timerCmds = (before: PrefixSnapshot, after: PrefixSnapshot): readonly Shel
 /**
  * Attach or detach the process a window shows. Detaching is `null` and stops nothing: the process
  * runs on with no view, which is what makes a window a view rather than a container.
+ *
+ * The view slot goes with the binding either way. A slot belongs to whatever the window is showing,
+ * and the newly bound program did not write the one that is there — which is also what keeps a
+ * `previous` from outliving the picker that recorded it (#8265).
  */
 const bindWindow = (
 	state: ShellState,
@@ -238,18 +243,22 @@ const bindWindow = (
 	const target = windowId ?? workspace.focused;
 	if (!hasWindow(workspace, target)) return [state, NO_CMDS];
 	return [
-		withActive(state, {
-			...workspace,
-			layout: setProcess(workspace.layout, target, processId, takesKeys),
-		}),
+		{
+			...withActive(state, {
+				...workspace,
+				layout: setProcess(workspace.layout, target, processId, takesKeys),
+			}),
+			views: withoutViews(state.views, [target]),
+		},
 		NO_CMDS,
 	];
 };
 
 /**
- * Put a window back on the picker: detach its process, which stops nothing, and drop the view slot
- * so the picker mounts fresh rather than on the cursor and refusal the last mount left behind
- * (`../ui/PickerView.tsx` rebuilds the picker's view from that slot).
+ * Put a window back on the picker: detach its process, which stops nothing, and mount a fresh
+ * picker view naming the process it was showing, so Escape has somewhere to return to and the
+ * highlight starts on that row (`../picker/view.ts`). The mount is fresh rather than the cursor and
+ * refusal the last one left behind (`../ui/PickerView.tsx` rebuilds the picker's view from it).
  *
  * A window holding no process is left untouched rather than cleared. It is already showing the
  * picker, and dropping the slot there would move the user's highlight back to the first row under
@@ -259,11 +268,11 @@ const unbindWindow = (state: ShellState, windowId: WindowId | undefined): Step =
 	const workspace = activeWorkspace(state);
 	if (workspace === undefined) return [state, NO_CMDS];
 	const target = windowId ?? workspace.focused;
-	if (!hasWindow(workspace, target) || processOf(workspace, target) === null) {
-		return [state, NO_CMDS];
-	}
+	if (!hasWindow(workspace, target)) return [state, NO_CMDS];
+	const showing = processOf(workspace, target);
+	if (showing === null) return [state, NO_CMDS];
 	const [detached] = bindWindow(state, target, null);
-	return [{...detached, views: withoutViews(detached.views, [target])}, NO_CMDS];
+	return [{...detached, views: {...detached.views, [target]: mountPicker(showing)}}, NO_CMDS];
 };
 
 /**

--- a/apps/tuval/src/shell/core/machine.ts
+++ b/apps/tuval/src/shell/core/machine.ts
@@ -65,7 +65,10 @@ import {
  * The arms the kernel's own `HostHandlers` answer (`../host/effects.ts`). `openProgram` and
  * `attachProcess` are the picker's (`../picker/open.ts` runs both): spawning needs the registry and
  * the process table, which a pure reducer cannot reach, so the core names the window and the thing
- * to show in it and stops there. `forwardKey` is here too — a key belongs to the focused window's
+ * to show in it and stops there. Each carries the window's view slot as well, because a refusal
+ * leaves that handler as a `window.setView` written back over it, and the slot is state only the
+ * core can read — a refusal handed no slot is the one that throws away the picker's `previous`
+ * (#8265). `forwardKey` is here too — a key belongs to the focused window's
  * *process*, and delivering it is a dispatch into that process. `runCommand` and `reloadConfig`
  * have no runner yet and are still the kernel's: resolving a name the command table does not hold
  * needs the spell registry, and `Booted.reload` sits above the kernel (#7743).
@@ -83,8 +86,14 @@ export type KernelCmd =
 			readonly windowId: WindowId;
 			readonly programId: string;
 			readonly session?: OpenSession;
+			readonly view?: ViewState;
 	  }
-	| {readonly type: "attachProcess"; readonly windowId: WindowId; readonly processId: string}
+	| {
+			readonly type: "attachProcess";
+			readonly windowId: WindowId;
+			readonly processId: string;
+			readonly view?: ViewState;
+	  }
 	| {readonly type: "reloadConfig"};
 
 /**
@@ -453,6 +462,16 @@ const targetWindow = (state: ShellState, windowId: WindowId | undefined): Window
 };
 
 /**
+ * One window's view slot as a Cmd field, spread rather than assigned so a window holding no slot
+ * sends no `view` key at all — the field is optional and `exactOptionalPropertyTypes` reads an
+ * explicit `undefined` as a different thing from an absent one.
+ */
+const viewOf = (state: ShellState, windowId: WindowId): {readonly view?: ViewState} => {
+	const view = state.views[windowId];
+	return view === undefined ? {} : {view};
+};
+
+/**
  * The cells, closed over the table the key router reads. A table is configuration, not state: it
  * holds `Duration.Duration` values, and the shell's state is checkpointed JSON.
  */
@@ -526,6 +545,7 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 								windowId: target,
 								programId: msg.programId,
 								...(msg.session === undefined ? {} : {session: msg.session}),
+								...viewOf(state, target),
 							},
 						],
 					];
@@ -534,7 +554,17 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 			const target = targetWindow(state, msg.windowId);
 			return target === null
 				? [state, NO_CMDS]
-				: [state, [{type: "attachProcess", windowId: target, processId: msg.processId}]];
+				: [
+						state,
+						[
+							{
+								type: "attachProcess",
+								windowId: target,
+								processId: msg.processId,
+								...viewOf(state, target),
+							},
+						],
+					];
 		},
 		// Neither touches the desk, and neither leaves as `runCommand`: a host answering that Cmd
 		// resolves the name through the command table, so routing a row's own Msg back through it

--- a/apps/tuval/src/shell/core/machine.unit.test.ts
+++ b/apps/tuval/src/shell/core/machine.unit.test.ts
@@ -6,6 +6,7 @@
 import {describe, expect, it} from "vitest";
 import {CommandName, defaultPrefixTable, type Key, type PrefixTable} from "../keys/index.ts";
 import {findWindow, windows} from "../layout/index.ts";
+import {mountPicker} from "../picker/view.ts";
 import {applyMsg, cellsFor, initialState, type ShellCmd, type ShellMsg} from "./machine.ts";
 import {activeWorkspace, type ShellState, windowIds} from "./state.ts";
 
@@ -203,19 +204,25 @@ describe("shell core: windows", () => {
 		expect(cmds).toEqual([]);
 	});
 
-	it("window.unbind drops the view slot, so the picker it returns to mounts fresh (#8083)", () => {
+	it("window.bind drops the view slot the last thing in the window left (#8083, #8265)", () => {
 		const state = initialState();
 		const window = active(state).focused;
 		const filled = fold(
 			state,
-			{type: "window.setView", view: {cursor: 3, refusal: null}},
+			{type: "window.setView", view: {cursor: 3, refusal: null, previous: null}},
 			{type: "window.bind", processId: "process-pi"},
 		);
-		expect(filled.views[window]).toEqual({cursor: 3, refusal: null});
+		expect(filled.views[window]).toBeUndefined();
+	});
+
+	it("window.unbind mounts a fresh picker naming the process it detached (#8083, #8265)", () => {
+		const state = initialState();
+		const window = active(state).focused;
+		const filled = fold(state, {type: "window.bind", processId: "process-pi"});
 
 		const [unbound] = apply(filled, {type: "window.unbind"});
 		expect(focusedProcess(unbound)).toBeNull();
-		expect(unbound.views[window]).toBeUndefined();
+		expect(unbound.views[window]).toEqual(mountPicker("process-pi"));
 		expect(windowIds(active(unbound))).toEqual(windowIds(active(filled)));
 	});
 

--- a/apps/tuval/src/shell/host/effects.ts
+++ b/apps/tuval/src/shell/host/effects.ts
@@ -81,10 +81,11 @@ export const wiredShellEffects = ({
 	openProgram: (cmd) =>
 		runPickerIntent(
 			openProgram(WindowId.make(cmd.windowId), ProgramId.make(cmd.programId), cmd.session),
-			{shellProcessId},
+			{shellProcessId, ...(cmd.view === undefined ? {} : {view: cmd.view})},
 		),
 	attachProcess: (cmd) =>
 		runPickerIntent(attachProcess(WindowId.make(cmd.windowId), ProcessId.make(cmd.processId)), {
 			shellProcessId,
+			...(cmd.view === undefined ? {} : {view: cmd.view}),
 		}),
 });

--- a/apps/tuval/src/shell/picker/browser.ts
+++ b/apps/tuval/src/shell/picker/browser.ts
@@ -49,6 +49,7 @@ export {
 	unreadableCommand,
 } from "./refusal.ts";
 export {
+	asPickerView,
 	cursorOf,
 	highlighted,
 	mountPicker,

--- a/apps/tuval/src/shell/picker/fixtures.ts
+++ b/apps/tuval/src/shell/picker/fixtures.ts
@@ -33,7 +33,11 @@ const core = defineMachine<CountState, CountMsg, Cmd<never>, never, unknown>({
 
 export const programRow = (
 	id: string,
-	options?: {readonly label?: string; readonly renderer?: boolean},
+	options?: {
+		readonly label?: string;
+		readonly renderer?: boolean;
+		readonly takesKeys?: boolean;
+	},
 ): AnyProgram =>
 	({
 		id: ProgramId.make(id),
@@ -42,6 +46,7 @@ export const programRow = (
 		handlers: {},
 		capabilities: [],
 		...(options?.label === undefined ? {} : {label: options.label}),
+		...(options?.takesKeys === true ? {takesKeys: true} : {}),
 		...(options?.renderer === false
 			? {}
 			: {renderer: {kind: "host-native" as const, ref: `tuval/${id}`}}),

--- a/apps/tuval/src/shell/picker/frame.ts
+++ b/apps/tuval/src/shell/picker/frame.ts
@@ -117,8 +117,16 @@ const KEY_HELP = [
 	{keys: "↑ ↓ / k j", action: "Move between rows"},
 	{keys: "Home / End", action: "Jump to the first or last row"},
 	{keys: "Enter", action: "Open or attach the highlighted row"},
-	{keys: "Escape", action: "Dismiss the message"},
 ] as const;
+
+/** Escape's help is the one row that reads off the view: it says what the key will actually do. */
+const escapeHelp = (view: PickerView) => ({
+	keys: "Escape",
+	action:
+		view.previous === null
+			? "Dismiss the message"
+			: "Return to the process this window was showing",
+});
 
 /**
  * The frame for one mount. Pure over `entries` and `view`: the same pair always renders the same
@@ -187,6 +195,6 @@ export const pickerFrame = (
 		groups,
 		announcement,
 		theme: themeFor(options),
-		keyHelp: [...KEY_HELP],
+		keyHelp: [...KEY_HELP, escapeHelp(view)],
 	};
 };

--- a/apps/tuval/src/shell/picker/frame.unit.test.ts
+++ b/apps/tuval/src/shell/picker/frame.unit.test.ts
@@ -45,7 +45,7 @@ describe("picker frame", () => {
 	});
 
 	it("names the active option by id, and marks exactly one option selected", () => {
-		const frame = pickerFrame(window, entries, {cursor: 2, refusal: null});
+		const frame = pickerFrame(window, entries, {cursor: 2, refusal: null, previous: null});
 		const options = frame.groups.flatMap((group) => group.options);
 		expect(frame.activeDescendant).toBe("picker-window-1-option-2");
 		expect(options.filter((option) => option.selected).map((option) => option.id)).toEqual([
@@ -123,5 +123,28 @@ describe("picker frame", () => {
 			"Open or attach the highlighted row",
 			"Dismiss the message",
 		]);
+	});
+
+	it("mounted with a `previous`, highlights that row and offers Escape as the way back (#8265)", () => {
+		const frame = pickerFrame(window, entries, mountPicker("p-2"));
+		const options = frame.groups.flatMap((group) => group.options);
+
+		// `p-2` is the fourth row of the flattened list — two programs, then two processes.
+		expect(frame.activeDescendant).toBe("picker-window-1-option-3");
+		expect(options.filter((option) => option.selected).map((option) => option.id)).toEqual([
+			"picker-window-1-option-3",
+		]);
+		expect(frame.keyHelp.map((row) => row.action)).toContain(
+			"Return to the process this window was showing",
+		);
+	});
+
+	it("a `previous` whose process is gone falls back to the first row (#8265)", () => {
+		const frame = pickerFrame(window, entries, mountPicker("p-gone"));
+		expect(frame.activeDescendant).toBe("picker-window-1-option-0");
+		// The help still offers the return: the attach handler is where a dead id becomes a refusal.
+		expect(frame.keyHelp.map((row) => row.action)).toContain(
+			"Return to the process this window was showing",
+		);
 	});
 });

--- a/apps/tuval/src/shell/picker/mount.unit.test.ts
+++ b/apps/tuval/src/shell/picker/mount.unit.test.ts
@@ -54,8 +54,9 @@ describe("a mount reads the world fresh", () => {
 		}),
 	);
 
-	it("a fresh mount starts at the top with no refusal, whatever the last one ended on", () => {
-		expect(mountPicker()).toEqual({cursor: 0, refusal: null});
+	it("a fresh mount starts unplaced with no refusal, whatever the last one ended on", () => {
+		expect(mountPicker()).toEqual({cursor: null, refusal: null, previous: null});
+		expect(mountPicker("p-1")).toEqual({cursor: null, refusal: null, previous: "p-1"});
 		expect(mountPicker()).not.toBe(mountPicker());
 	});
 });

--- a/apps/tuval/src/shell/picker/open.ts
+++ b/apps/tuval/src/shell/picker/open.ts
@@ -18,7 +18,7 @@ import type {ProcessId} from "../../process/process.ts";
 import {type AnyProgram, type ProgramId, takesForwardedKeys} from "../../registry/program.ts";
 import {Registry} from "../../registry/Registry.ts";
 import type {ShellMsg} from "../core/machine.ts";
-import type {WindowId} from "../window/host.ts";
+import type {ViewState, WindowId} from "../window/host.ts";
 import {showsInAWindow} from "./entries.ts";
 import type {OpenSession, PickerIntent} from "./intent.ts";
 import {
@@ -28,16 +28,18 @@ import {
 	spawnFailed,
 	unknownProgram,
 } from "./refusal.ts";
-import {mountPicker, type PickerView, withRefusal} from "./view.ts";
+import {asPickerView, withRefusal} from "./view.ts";
 
 export interface PickerOptions {
 	/** The process every program the picker opens is spawned under — the shell's own. */
 	readonly shellProcessId: ProcessId;
 	/**
-	 * The view a refusal is written back over. The picker route passes its live view so a refused
-	 * choice leaves the highlight where the user put it; the command line has none and omits it.
+	 * The window's own view slot, unnarrowed, as the state the Cmd left carries it (`../core/machine.ts`).
+	 * A refusal is written back over it, so a refused choice keeps the highlight where the user put it
+	 * and keeps the process `<c-b> w` left behind — otherwise the first refusal on a picker is what
+	 * throws away the way back (#8265). The command line has no slot and omits it.
 	 */
-	readonly view?: PickerView;
+	readonly view?: ViewState;
 }
 
 /** A refusal reaches the user as the window's view: the picker is still mounted and re-renders. */
@@ -46,7 +48,7 @@ const refuse = (
 	options: PickerOptions,
 	refusal: PickerRefusal,
 ): ReadonlyArray<ShellMsg> => [
-	{type: "window.setView", windowId, view: withRefusal(options.view ?? mountPicker(), refusal)},
+	{type: "window.setView", windowId, view: withRefusal(asPickerView(options.view), refusal)},
 ];
 
 /**

--- a/apps/tuval/src/shell/picker/open.unit.test.ts
+++ b/apps/tuval/src/shell/picker/open.unit.test.ts
@@ -22,7 +22,7 @@ import {
 import type {PickerIntent} from "./intent.ts";
 import {attachProcess, openProgram} from "./intent.ts";
 import {runPickerIntent} from "./open.ts";
-import {mountPicker, pickerKey} from "./view.ts";
+import {mountPicker, pickerKey, withRefusal} from "./view.ts";
 
 const window = windowId("window-1");
 const rows: ReadonlyArray<AnyProgram> = [
@@ -86,7 +86,7 @@ describe("choosing a program", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "UnknownProgram", programId: "ghost"}},
+					view: withRefusal(mountPicker(), {_tag: "UnknownProgram", programId: "ghost"}),
 				},
 			]);
 		}),
@@ -100,7 +100,7 @@ describe("choosing a program", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "indexer"}},
+					view: withRefusal(mountPicker(), {_tag: "ProgramHeadless", programId: "indexer"}),
 				},
 			]);
 		}),
@@ -114,7 +114,7 @@ describe("choosing a program", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "shell"}},
+					view: withRefusal(mountPicker(), {_tag: "ProgramHeadless", programId: "shell"}),
 				},
 			]);
 		}),
@@ -129,14 +129,11 @@ describe("choosing a program", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {
-						cursor: 0,
-						refusal: {
-							_tag: "SpawnFailed",
-							programId: "counter",
-							reason: 'no live process has id "counter"',
-						},
-					},
+					view: withRefusal(mountPicker(), {
+						_tag: "SpawnFailed",
+						programId: "counter",
+						reason: 'no live process has id "counter"',
+					}),
 				},
 			]);
 		}),
@@ -163,7 +160,7 @@ describe("attaching to a running process", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "ProcessGone", processId: "p-gone"}},
+					view: withRefusal(mountPicker(), {_tag: "ProcessGone", processId: "p-gone"}),
 				},
 			]);
 		}),
@@ -179,7 +176,7 @@ describe("attaching to a running process", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "shell"}},
+					view: withRefusal(mountPicker(), {_tag: "ProgramHeadless", programId: "shell"}),
 				},
 			]);
 		}),
@@ -194,7 +191,7 @@ describe("attaching to a running process", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "indexer"}},
+					view: withRefusal(mountPicker(), {_tag: "ProgramHeadless", programId: "indexer"}),
 				},
 			]);
 		}),
@@ -250,7 +247,7 @@ describe("the picker row and the command line are one handler", () => {
 				{
 					type: "window.setView",
 					windowId: window,
-					view: {cursor: 0, refusal: {_tag: "ProgramHeadless", programId: "shell"}},
+					view: withRefusal(mountPicker(), {_tag: "ProgramHeadless", programId: "shell"}),
 				},
 			]);
 		}),

--- a/apps/tuval/src/shell/picker/view.ts
+++ b/apps/tuval/src/shell/picker/view.ts
@@ -18,7 +18,7 @@ import {normalize} from "../keys/syntax.ts";
 import type {WindowId} from "../window/host.ts";
 import {flatten, type PickerEntries, type PickerEntry} from "./entries.ts";
 import {attachProcess, intentOf, type PickerIntent} from "./intent.ts";
-import type {PickerRefusal} from "./refusal.ts";
+import {isPickerRefusal, type PickerRefusal} from "./refusal.ts";
 
 /**
  * The window's view slot while it shows the picker. A type alias rather than an interface because
@@ -51,6 +51,27 @@ export const withRefusal = (view: PickerView, refusal: PickerRefusal): PickerVie
 	...view,
 	refusal,
 });
+
+/**
+ * Read one window's view slot as the picker's. The slot is `Schema.Json` and any program may have
+ * written it, so a fresh view is rebuilt field by field from what is actually there — never
+ * narrowed by assertion, which would hand a foreign record to `pickerKey` typed as if it were
+ * sound. A slot the picker did not write reads as `mountPicker()`, which is also what a first mount
+ * starts from, and that is what an absent slot reads as too.
+ */
+export const asPickerView = (slot: unknown): PickerView => {
+	if (typeof slot !== "object" || slot === null || Array.isArray(slot)) return mountPicker();
+	const record: Record<string, unknown> = {...slot};
+	const cursor = record.cursor;
+	if (cursor !== null && typeof cursor !== "number") return mountPicker();
+	const refusal = record.refusal;
+	const previous = record.previous;
+	return {
+		cursor,
+		refusal: isPickerRefusal(refusal) ? refusal : null,
+		previous: typeof previous === "string" ? previous : null,
+	};
+};
 
 const clamp = (cursor: number, length: number): number => {
 	if (length === 0) return 0;

--- a/apps/tuval/src/shell/picker/view.ts
+++ b/apps/tuval/src/shell/picker/view.ts
@@ -1,36 +1,51 @@
 /**
  * The picker's keyboard model. Everything the picker "remembers" is the window's own view slot — a
- * cursor and at most one refusal — so the picker itself holds nothing: `mountPicker` derives a
- * fresh view from nothing at all, which is why a second mount after a registry change cannot show
- * yesterday's list or yesterday's highlight.
+ * cursor, at most one refusal, and the process the window was showing before it came back here — so
+ * the picker itself holds nothing: `mountPicker` derives a fresh view from its one argument, which
+ * is why a second mount after a registry change cannot show yesterday's list or yesterday's
+ * highlight.
  *
- * The cursor indexes `flatten(entries)`, and it is clamped on every read rather than on write: the
- * list is re-read each mount and can shrink under a stored cursor (a process stops), and a clamp at
- * the read is the only place that sees both the cursor and the list it must be valid against.
+ * The cursor indexes `flatten(entries)`, and it is resolved on every read rather than on write: the
+ * list is re-read each mount and can shrink under a stored cursor (a process stops), and the read is
+ * the only place that sees both the cursor and the list it must be valid against. `null` is the
+ * cursor nobody has placed yet, which is why a mount can start on `previous`'s row without the
+ * unbinding reducer — which cannot see the registry or the process table — knowing its index.
  */
 
 import {Result} from "effect";
+import {ProcessId} from "../../process/process.ts";
 import {normalize} from "../keys/syntax.ts";
 import type {WindowId} from "../window/host.ts";
 import {flatten, type PickerEntries, type PickerEntry} from "./entries.ts";
-import {intentOf, type PickerIntent} from "./intent.ts";
+import {attachProcess, intentOf, type PickerIntent} from "./intent.ts";
 import type {PickerRefusal} from "./refusal.ts";
 
 /**
  * The window's view slot while it shows the picker. A type alias rather than an interface because
  * the slot is `Schema.Json`, and only an alias gets the implicit index signature that assignment
  * needs (TypeScript, "index signature inference").
+ *
+ * `previous` is typed `string` rather than `ProcessId` because the shell core writes it and types
+ * every process id as a plain string for the same reason the layout tree does — the branded type
+ * lives behind an Effect import neither module takes.
  */
 export type PickerView = {
-	readonly cursor: number;
+	/** `null` until something places it: the read resolves that to `previous`'s row, else the first. */
+	readonly cursor: number | null;
 	readonly refusal: PickerRefusal | null;
+	/** The process this window was showing when `window:pick` put it back on the picker (#8265). */
+	readonly previous: string | null;
 };
 
 /**
  * What a mount starts from. A function rather than a constant so no caller can hold a reference to
  * one shared object and mutate the next mount's starting point.
  */
-export const mountPicker = (): PickerView => ({cursor: 0, refusal: null});
+export const mountPicker = (previous: string | null = null): PickerView => ({
+	cursor: null,
+	refusal: null,
+	previous,
+});
 
 export const withRefusal = (view: PickerView, refusal: PickerRefusal): PickerView => ({
 	...view,
@@ -43,14 +58,25 @@ const clamp = (cursor: number, length: number): number => {
 	return cursor > length - 1 ? length - 1 : cursor;
 };
 
-/** The row the cursor names, or `null` when there is nothing to name. */
-export const highlighted = (entries: PickerEntries, view: PickerView): PickerEntry | null => {
+/**
+ * Where the highlight actually sits. An unplaced cursor lands on the row of the process this window
+ * was showing, so `<c-b> w` mounts the picker pointing at where Escape would take the operator
+ * back; a `previous` no row offers — the process exited while the picker was up — falls back to the
+ * first row rather than to nothing.
+ */
+export const cursorOf = (entries: PickerEntries, view: PickerView): number => {
 	const rows = flatten(entries);
-	return rows[clamp(view.cursor, rows.length)] ?? null;
+	if (view.cursor !== null) return clamp(view.cursor, rows.length);
+	if (view.previous === null) return 0;
+	const at = rows.findIndex(
+		(row) => row._tag === "Process" && String(row.processId) === view.previous,
+	);
+	return at === -1 ? 0 : at;
 };
 
-export const cursorOf = (entries: PickerEntries, view: PickerView): number =>
-	clamp(view.cursor, flatten(entries).length);
+/** The row the cursor names, or `null` when there is nothing to name. */
+export const highlighted = (entries: PickerEntries, view: PickerView): PickerEntry | null =>
+	flatten(entries)[cursorOf(entries, view)] ?? null;
 
 /**
  * What one key did. `Moved` and `Cleared` carry the view to store; `Chose` carries the intent to
@@ -78,6 +104,12 @@ const DISMISS = ["<escape>"];
  *
  * Movement clamps at both ends instead of wrapping, which is the APG listbox default: a wrap makes
  * "am I at the end" unanswerable to someone reading one option at a time.
+ *
+ * Escape is two keys in one, and the order is what makes both reachable: a refusal showing is
+ * cleared first, and only a picker with nothing to dismiss goes back to `previous`. A `previous`
+ * whose process has since stopped still chooses — `runPickerIntent`'s attach arm (`./open.ts`)
+ * answers a missing row with a `ProcessGone` refusal shown in the window, which is the one place
+ * the process table can be read.
  */
 export const pickerKey = (
 	windowId: WindowId,
@@ -89,19 +121,24 @@ export const pickerKey = (
 	if (Result.isFailure(spelled)) return ignored;
 	const pressed = spelled.success;
 	const rows = flatten(entries);
-	const at = clamp(view.cursor, rows.length);
+	const at = cursorOf(entries, view);
 
 	const moveTo = (next: number): PickerKeyAnswer =>
 		rows.length === 0 || next === at
 			? {_tag: "Moved", view: {...view, cursor: at}}
-			: {_tag: "Moved", view: {cursor: next, refusal: null}};
+			: {_tag: "Moved", view: {...view, cursor: next, refusal: null}};
 
 	if (DOWN.includes(pressed)) return moveTo(clamp(at + 1, rows.length));
 	if (UP.includes(pressed)) return moveTo(clamp(at - 1, rows.length));
 	if (FIRST.includes(pressed)) return moveTo(0);
 	if (LAST.includes(pressed)) return moveTo(clamp(rows.length - 1, rows.length));
 	if (DISMISS.includes(pressed)) {
-		return view.refusal === null ? ignored : {_tag: "Cleared", view: {cursor: at, refusal: null}};
+		if (view.refusal !== null) {
+			return {_tag: "Cleared", view: {...view, cursor: at, refusal: null}};
+		}
+		return view.previous === null
+			? ignored
+			: {_tag: "Chose", intent: attachProcess(windowId, ProcessId.make(view.previous))};
 	}
 	if (CHOOSE.includes(pressed)) {
 		const entry = rows[at];

--- a/apps/tuval/src/shell/picker/view.unit.test.ts
+++ b/apps/tuval/src/shell/picker/view.unit.test.ts
@@ -70,16 +70,55 @@ describe("picker keyboard", () => {
 		const refused = withRefusal(mountPicker(), unknownProgram("nope"));
 		expect(pickerKey(window, entries, refused, "<escape>")).toEqual({
 			_tag: "Cleared",
-			view: {cursor: 0, refusal: null},
+			view: {cursor: 0, refusal: null, previous: null},
 		});
 		expect(pickerKey(window, entries, mountPicker(), "<escape>")).toEqual({_tag: "Ignored"});
+	});
+
+	it("Escape on a picker with a `previous` attaches that process back (#8265)", () => {
+		expect(pickerKey(window, entries, mountPicker("p-1"), "<escape>")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "AttachProcess", windowId: window, processId: "p-1"},
+		});
+	});
+
+	it("a refusal is dismissed first, and the Escape after it returns (#8265)", () => {
+		const refused = withRefusal(mountPicker("p-1"), unknownProgram("nope"));
+		const cleared = pickerKey(window, entries, refused, "<escape>");
+		expect(cleared).toEqual({
+			_tag: "Cleared",
+			view: {cursor: 2, refusal: null, previous: "p-1"},
+		});
+		if (cleared._tag !== "Cleared") throw new Error("test setup: Escape cleared nothing");
+		expect(pickerKey(window, entries, cleared.view, "<escape>")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "AttachProcess", windowId: window, processId: "p-1"},
+		});
+	});
+
+	it("a `previous` no row offers still chooses — liveness is the attach handler's (#8265)", () => {
+		expect(highlighted(entries, mountPicker("p-gone"))).toEqual(entries.programs[0]);
+		expect(pickerKey(window, entries, mountPicker("p-gone"), "<escape>")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "AttachProcess", windowId: window, processId: "p-gone"},
+		});
+	});
+
+	it("an unplaced cursor starts on the `previous` row rather than the first (#8265)", () => {
+		expect(highlighted(entries, mountPicker("p-1"))).toEqual(entries.processes[0]);
+		// Once the operator moves, the cursor is theirs and `previous` only names Escape's target.
+		expect(press(mountPicker("p-1"), "<home>")).toEqual({
+			cursor: 0,
+			refusal: null,
+			previous: "p-1",
+		});
 	});
 
 	it("a move clears the refusal, because the user has moved on from it", () => {
 		const refused = withRefusal(mountPicker(), unknownProgram("nope"));
 		expect(pickerKey(window, entries, refused, "j")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 1, refusal: null},
+			view: {cursor: 1, refusal: null, previous: null},
 		});
 	});
 
@@ -94,16 +133,16 @@ describe("picker keyboard", () => {
 		expect(pickerKey(window, noEntries, mountPicker(), "<enter>")).toEqual({_tag: "Ignored"});
 		expect(pickerKey(window, noEntries, mountPicker(), "j")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 0, refusal: null},
+			view: {cursor: 0, refusal: null, previous: null},
 		});
 	});
 
 	it("a cursor left past the end of a shrunken list reads as the last row", () => {
-		const stale = {cursor: 9, refusal: null};
+		const stale = {cursor: 9, refusal: null, previous: null};
 		expect(highlighted(entries, stale)).toEqual(entries.processes[0]);
 		expect(pickerKey(window, entries, stale, "<arrowup>")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 1, refusal: null},
+			view: {cursor: 1, refusal: null, previous: null},
 		});
 	});
 });

--- a/apps/tuval/src/shell/proof/end-to-end.integration.test.ts
+++ b/apps/tuval/src/shell/proof/end-to-end.integration.test.ts
@@ -333,7 +333,7 @@ describe("the Tuval shell, end to end", () => {
 				for (let step = 0; step < logAt; step++) {
 					const msg = pickerPress(left, app.entries, view, "j");
 					assert.isNotNull(msg);
-					view = {cursor: view.cursor + 1, refusal: null};
+					view = {...view, cursor: step + 1, refusal: null};
 					yield* desk.send(msg as ShellMsg);
 				}
 				const chosen = pickerPress(left, app.entries, view, "<enter>");

--- a/apps/tuval/src/shell/ui/PickerView.tsx
+++ b/apps/tuval/src/shell/ui/PickerView.tsx
@@ -16,8 +16,6 @@ import type {ReactElement} from "react";
 import {useCallback, useEffect, useRef} from "react";
 import type {ShellMsg} from "../core/index.ts";
 import {
-	isPickerRefusal,
-	mountPicker,
 	type PickerEntries,
 	type PickerView as PickerViewState,
 	pickerFrame,
@@ -37,26 +35,6 @@ export interface PickerViewProps {
 	/** Whether this window is the desk's focused one — the picker holds DOM focus only then. */
 	readonly focused: boolean;
 }
-
-/**
- * Is this view slot the picker's? The slot is `Schema.Json` and any program may have written it, so
- * a fresh view is rebuilt field by field from what is actually there — never narrowed by assertion,
- * which would hand a foreign record to `pickerKey` typed as if it were sound. A slot the picker did
- * not write reads as `mountPicker()`, which is also what a first mount starts from.
- */
-export const asPickerView = (slot: unknown): PickerViewState => {
-	if (typeof slot !== "object" || slot === null || Array.isArray(slot)) return mountPicker();
-	const record: Record<string, unknown> = {...slot};
-	const cursor = record.cursor;
-	if (cursor !== null && typeof cursor !== "number") return mountPicker();
-	const refusal = record.refusal;
-	const previous = record.previous;
-	return {
-		cursor,
-		refusal: isPickerRefusal(refusal) ? refusal : null,
-		previous: typeof previous === "string" ? previous : null,
-	};
-};
 
 export function PickerView({
 	windowId,

--- a/apps/tuval/src/shell/ui/PickerView.tsx
+++ b/apps/tuval/src/shell/ui/PickerView.tsx
@@ -47,9 +47,15 @@ export interface PickerViewProps {
 export const asPickerView = (slot: unknown): PickerViewState => {
 	if (typeof slot !== "object" || slot === null || Array.isArray(slot)) return mountPicker();
 	const record: Record<string, unknown> = {...slot};
-	if (typeof record.cursor !== "number") return mountPicker();
+	const cursor = record.cursor;
+	if (cursor !== null && typeof cursor !== "number") return mountPicker();
 	const refusal = record.refusal;
-	return {cursor: record.cursor, refusal: isPickerRefusal(refusal) ? refusal : null};
+	const previous = record.previous;
+	return {
+		cursor,
+		refusal: isPickerRefusal(refusal) ? refusal : null,
+		previous: typeof previous === "string" ? previous : null,
+	};
 };
 
 export function PickerView({

--- a/apps/tuval/src/shell/ui/WindowView.tsx
+++ b/apps/tuval/src/shell/ui/WindowView.tsx
@@ -17,11 +17,11 @@
 
 import type {ReactElement} from "react";
 import type {ShellMsg} from "../core/index.ts";
-import type {PickerEntries} from "../picker/browser.ts";
+import {asPickerView, type PickerEntries} from "../picker/browser.ts";
 import type {ViewState, WindowId} from "../window/index.ts";
 import {ErrorBoundary} from "./ErrorBoundary.tsx";
 import type {WindowMount} from "./mount.ts";
-import {asPickerView, PickerView} from "./PickerView.tsx";
+import {PickerView} from "./PickerView.tsx";
 
 export interface WindowViewProps {
 	readonly windowId: WindowId;

--- a/apps/tuval/src/shell/ui/index.ts
+++ b/apps/tuval/src/shell/ui/index.ts
@@ -40,6 +40,6 @@ export {
 	type ReactWindowRenderer,
 	type WindowMount,
 } from "./mount.ts";
-export {asPickerView, PickerView, type PickerViewProps} from "./PickerView.tsx";
+export {PickerView, type PickerViewProps} from "./PickerView.tsx";
 export {StatusLine, type StatusLineProps} from "./StatusLine.tsx";
 export {WindowView, type WindowViewProps} from "./WindowView.tsx";


### PR DESCRIPTION
Fixes #8265

`<c-b> w` used to be a one-way door: it detached the window's process and dropped
the view slot, so the picker that mounted had no idea where it came from and
Escape did nothing. The founder asked for the way back on 2026-09-06.

The window's picker view slot now carries a `previous` — the process id the
window was showing. `window.unbind` writes it; `window.bind` drops the whole slot,
so a window that picked a new row never carries a stale one. `pickerKey` answers
Escape with the same `AttachProcess` intent Enter on a `Process` row produces, and
`PickerView.tsx` already dispatches a `Chose` as `{type: "window.attach", …}`, so
there is no new bind path. A refusal showing is still cleared first; a picker with
no `previous` still answers `Ignored`.

The picker's cursor is now `number | null` — `null` is "nobody placed it yet",
resolved at read onto `previous`'s row. That keeps the placement out of the
reducer, which cannot see the registry or the process table and so cannot know a
row's index. `KEY_HELP`'s Escape row reads off `previous` too, so the help says
what the key will actually do.

A `previous` whose process has since exited still chooses, and
`runPickerIntent`'s attach arm answers it with the existing `ProcessGone` refusal
shown in the window — never a bind to a dead id, and no second liveness check in
a module that cannot read the table.

Round 1 found the half that only shows on the real path: every refusal the host
raises goes through `refuse` in `picker/open.ts`, which built on
`options.view ?? mountPicker()` — and `host/effects.ts` passed no view, so the
first refusal on a `<c-b> w` picker rewrote the slot with `previous: null` and the
second Escape was `Ignored`. The `openProgram` and `attachProcess` Cmds now carry
the window's view slot, which is state only the core can read, and the refusal is
written back over it, so the highlight survives a refusal too. `asPickerView` moved
into `picker/view.ts` so the kernel-side handler can read a slot without importing
the React layer.

Reviewer, start at `apps/tuval/src/shell/picker/view.ts`: the cursor's null arm
and the Escape branch are the whole behaviour change. Then
`apps/tuval/src/shell/core/machine.ts` for the reducer edits and the Cmd's new
`view` field. The round-1 sequence is proven in
`apps/tuval/src/shell/commands/window-pick.unit.test.ts`, which drives Enter,
Escape, Escape through `applyMsg` and `wiredShellEffects` rather than calling
`runPickerIntent` directly.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8265 names `unbindWindow`,
  `pickerKey`, `PickerView.tsx` and `KEY_HELP`. **Did:** also rewrote #8083's
  `window:pick` round-trip assertion (`mountPicker()` → `mountPicker(spawned)`),
  split the `window.unbind drops the view slot` core test into a bind case and an
  unbind case, and widened the picker's `programRow` fixture with a `takesKeys`
  option. **Why:** the issue's fourth criterion deliberately refines #8083's
  "mounts fresh — cursor 0" wording, so that assertion had to move with it; the
  core test asserted the slot survived a bind, which is the behaviour criterion 1
  reverses; and the sixth criterion asks for `takesKeys` intact, which no existing
  fixture row declared. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** record a `previous` at unbind. **Did:** also
  made `window.bind` drop the target's view slot. **Why:** criterion 1 requires the
  `previous` cleared the moment the window binds to anything, and keeping the slot
  across an unbind (which the `previous` needs) would otherwise hand the newly
  bound program a picker-shaped slot as its own view — a regression on today's
  behaviour, where the unbind dropped it. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** criterion 8 asks that a refusal raised through
  `runPickerIntent` keep the picker's `previous`. **Did:** moved `asPickerView` from
  `ui/PickerView.tsx` into `picker/view.ts` (re-exported through `picker/browser.ts`,
  so `ui/index.ts` and `WindowView.tsx` now source it there), and gave the two picker
  Cmds an optional `view` field. **Why:** `refuse` runs kernel-side and had to read
  the window's slot; leaving the coercion in a `.tsx` module would have pointed the
  picker handler at the React layer. The `view` field is the only carrier from state
  to a host handler, which is why the fix could not sit inside `open.ts` alone.
  **Disposition:** stated here.
