### PR TITLE
fix: The shell prefix is dead while the chat composer or the transcript has focus

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -43,7 +43,7 @@ import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
 import type {Mode, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import type {ProcessView, WindowHost, WindowRenderer} from "../window/index.ts";
-import {windowRenderer} from "../window/index.ts";
+import {prefixArmedAround, windowRenderer} from "../window/index.ts";
 import {CompactionMarker} from "./CompactionMarker.tsx";
 import {composerBridge} from "./composer-bridge.ts";
 import {tuvalDesignTranslate} from "./copy.ts";
@@ -156,10 +156,14 @@ const useProcessView = (host: ChatWindowHost): ProcessView<AiAgentSessionState> 
  * text to take it, and letting it reach the desk's one keyboard listener either arms the prefix or
  * forwards it into the window's process (#7973). Modified keys are somebody else's — the desk
  * prefix is Ctrl-keyed and Alt+R is the window's — and so is every named key the region scrolls on.
+ *
+ * Unless the shell's prefix is armed, and then the bare key *is* the shell's: it is the second key
+ * of a sequence the operator already started, and swallowing it here is what left `<prefix> w`
+ * dead from the transcript all day (#8270).
  */
 const swallowBareCharacter = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
 	const bare = !event.ctrlKey && !event.metaKey && !event.altKey && [...event.key].length === 1;
-	if (bare) event.stopPropagation();
+	if (bare && !prefixArmedAround(event.target)) event.stopPropagation();
 };
 
 /**
@@ -705,6 +709,9 @@ function ChatWindow({
 	const onKeyDown = useCallback(
 		(event: ReactKeyboardEvent<HTMLDivElement>) => {
 			if (event.defaultPrevented) return;
+			// An armed prefix owns the next key from any focus, so the window's own two keys stand
+			// down for it: `<prefix> r` is a shell reload, not a resend (#8270).
+			if (prefixArmedAround(event.target)) return;
 			if (event.key === "Escape" && isWorking(phase)) {
 				event.preventDefault();
 				dispatch({type: "interrupt", at: options.now()});

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -25,7 +25,7 @@ import {ItemId} from "../../ai-agent/ports/index.ts";
 import {ProcessId} from "../../process/process.ts";
 import {installDomShims, TEST_VIEWPORT} from "../ui/dom.testing.ts";
 import {type TestProcess, testProcess} from "../window/fixtures.ts";
-import {WindowId} from "../window/index.ts";
+import {PREFIX_ARMED_ATTRIBUTE, WindowId} from "../window/index.ts";
 import {type ChatWindowHost, type ChatWindowOptions, chatWindow} from "./ChatWindow.tsx";
 import {
 	assistantItem,
@@ -625,8 +625,16 @@ describe("keys typed on the transcript", () => {
 
 	afterEach(() => {
 		globalThis.document.removeEventListener("keydown", listener);
+		globalThis.document.body.removeAttribute(PREFIX_ARMED_ATTRIBUTE);
 		seen.length = 0;
 	});
+
+	/**
+	 * The desk's mark, put on an ancestor of the window exactly as the desk puts it on its own root
+	 * (`../ui/Desk.tsx`) — the window is mounted under `body` here, and there is no desk above it.
+	 */
+	const armTheDesk = (): void =>
+		globalThis.document.body.setAttribute(PREFIX_ARMED_ATTRIBUTE, "true");
 
 	/** Every keydown the desk's one document listener would have seen (`../ui/Desk.tsx`). */
 	const watchDesk = (): ReadonlyArray<string> => {
@@ -647,6 +655,25 @@ describe("keys typed on the transcript", () => {
 		});
 
 		expect(reached).toEqual(["b", "Escape", "r"]);
+	});
+
+	it("stands down for every key of an armed sequence, transcript and composer alike (#8270)", async () => {
+		const {process} = await openWindow(
+			withTranscript(transcriptOf(2), {phase: "prompting", interrupted: ItemId.make("b")}),
+		);
+		const reached = watchDesk();
+		armTheDesk();
+
+		await act(async () => {
+			fireEvent.keyDown(screen.getByRole("log", {name: "Transcript"}), {key: "w"});
+			fireEvent.keyDown(composer(), {key: "Escape"});
+			fireEvent.keyDown(composer(), {key: "r", altKey: true});
+		});
+
+		// The bare `w` is the second key of `<prefix> w`, and the window's own two keys are the
+		// shell's while it is armed: nothing here is the window's to act on.
+		expect(reached).toEqual(["w", "Escape", "r"]);
+		expect(process.inbox()).toEqual([]);
 	});
 
 	it("still interrupts on Escape typed on the transcript", async () => {

--- a/apps/tuval/src/shell/ui/Desk.tsx
+++ b/apps/tuval/src/shell/ui/Desk.tsx
@@ -32,14 +32,14 @@ import type {Key, PrefixTable} from "../keys/index.ts";
 import {layoutSignature} from "../layout/index.ts";
 import type {PickerEntries} from "../picker/browser.ts";
 import {noEntries} from "../picker/browser.ts";
-import {WindowId} from "../window/index.ts";
+import {PREFIX_ARMED_ATTRIBUTE, WindowId} from "../window/index.ts";
 import {CommandLine} from "./CommandLine.tsx";
 import {DeskInspector} from "./DeskInspector.tsx";
 import type {DeskTables} from "./desk-snapshot.ts";
 import {deskSnapshotOf, noDeskTables} from "./desk-snapshot.ts";
 import {ErrorBoundary} from "./ErrorBoundary.tsx";
 import {type ForwardedKey, ForwardedKeyProvider} from "./forwarded-key.tsx";
-import {routerPrefix, statusFrame, surfaceKey, zoomedWindow} from "./frame.ts";
+import {routerPrefix, shellOwnsKey, statusFrame, surfaceKey, zoomedWindow} from "./frame.ts";
 import {LayoutView} from "./LayoutView.tsx";
 import type {MountResolver} from "./mount.ts";
 import {focusedWindowOf, PaletteHost} from "./PaletteHost.tsx";
@@ -96,13 +96,15 @@ export function Desk({
 	const onKeyDown = useCallback((event: KeyboardEvent): void => {
 		const {state: current, table: grammar, focused: window, commandLineOpen: open} = latest.current;
 		const overlay = latest.current.palette;
-		if (open || overlay.open || isTextEntry(event.target)) return;
+		if (open || overlay.open) return;
 
 		// The palette's own door, beside the `<prefix> :` line rather than instead of it: one is the
-		// address you already know, the other is the one you go looking through (#7643).
+		// address you already know, the other is the one you go looking through (#7643). It opens
+		// from a text entry too — the door you go looking through must not be shut by where the
+		// caret happens to be, which is most of the day the composer (#8270).
 		if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
 			event.preventDefault();
-			overlay.openPalette(focusedWindowOf(latest.current.state));
+			overlay.openPalette(focusedWindowOf(current));
 			return;
 		}
 
@@ -114,13 +116,20 @@ export function Desk({
 			altKey: event.altKey,
 			metaKey: event.metaKey,
 		};
-		const answer = surfaceKey(grammar, routerPrefix(current), key);
+		const prefix = routerPrefix(current);
+		const shellOwns = shellOwnsKey(grammar, prefix, key);
+		if (!shellOwns && isTextEntry(event.target)) return;
+
+		const answer = surfaceKey(grammar, prefix, key);
 		// The kernel owns the desk, so every press goes to it whatever the surface also does with it.
 		latest.current.dispatch({type: "keys.press", key});
+		// Swallowed once, where ownership is decided rather than per arm: the prefix and every key
+		// after it are the shell's, so none of them may also insert a character into the text entry
+		// underneath — that is what stops `prefix |` typing a pipe into whatever had focus.
+		if (shellOwns) event.preventDefault();
 
 		switch (answer._tag) {
 			case "OpenCommandLine":
-				event.preventDefault();
 				setCommandLineOpen(true);
 				return;
 			case "ToWindow":
@@ -129,9 +138,6 @@ export function Desk({
 				setForwarded({windowId: WindowId.make(window), key: answer.key, seq: seq.current});
 				return;
 			case "Shell":
-				// A bound sequence is the shell's; swallowing it is what stops `prefix |` from typing
-				// a pipe into whatever had focus.
-				if (answer.command !== null) event.preventDefault();
 				return;
 		}
 	}, []);
@@ -218,7 +224,16 @@ export function Desk({
 	);
 
 	return (
-		<div className="tuval-surface" ref={desk} tabIndex={-1} data-scheme="dark">
+		<div
+			className="tuval-surface"
+			ref={desk}
+			tabIndex={-1}
+			data-scheme="dark"
+			// The one desk-level key fact a window renderer cannot be handed
+			// (`../window/prefix-signal.ts`): while this mark is here the next key is the shell's, and
+			// a region inside stands down rather than taking it (#8270).
+			{...(state.prefix.armed ? {[PREFIX_ARMED_ATTRIBUTE]: "true"} : {})}
+		>
 			<div className="tuval-desk-body">
 				<ForwardedKeyProvider value={forwarded}>
 					{/* The tiling area alone, so a throw costs the founder the windows and not the status

--- a/apps/tuval/src/shell/ui/desk.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/desk.unit.test.tsx
@@ -19,11 +19,11 @@ import type {ShellMsg, ShellState} from "../core/index.ts";
 import {applyMsg} from "../core/index.ts";
 import {defaultPrefixTable} from "../keys/index.ts";
 import type {PickerEntries} from "../picker/index.ts";
-import {empty, processGone} from "../window/index.ts";
+import {empty, prefixArmedAround, processGone} from "../window/index.ts";
 import {Desk} from "./Desk.tsx";
 import {installDomShims} from "./dom.testing.ts";
 import {threeWindowDesk} from "./fixtures.ts";
-import {type MountResolver, noRenderer} from "./mount.ts";
+import {boundMount, type MountResolver, noRenderer, type ReactWindowRenderer} from "./mount.ts";
 
 installDomShims();
 
@@ -32,22 +32,51 @@ const entries: PickerEntries = {
 	processes: [],
 };
 
+/** Every window bound, rendering whatever the caller wants inside it. */
+const boundTo =
+	(render: ReactWindowRenderer): MountResolver =>
+	(windowId, processId) =>
+		processId === null
+			? empty
+			: boundMount(
+					{
+						windowId,
+						processId: ProcessId.make(processId),
+						readProcess: undefined as never,
+						dispatch: undefined as never,
+						view: () => null,
+						setView: undefined as never,
+					},
+					render,
+				);
+
 /** Every window bound, every renderer a paragraph naming its process. */
-const boundEverywhere: MountResolver = (windowId, processId) =>
-	processId === null
-		? empty
-		: {
-				_tag: "Bound",
-				host: {
-					windowId,
-					processId: ProcessId.make(processId),
-					readProcess: undefined as never,
-					dispatch: undefined as never,
-					view: () => null,
-					setView: undefined as never,
-				},
-				render: (host) => <p>renderer for {String(host.processId)}</p>,
-			};
+const boundEverywhere: MountResolver = boundTo((host) => (
+	<p>renderer for {String(host.processId)}</p>
+));
+
+/**
+ * A window shaped like the chat one: the two places an operator's focus actually sits — a composer
+ * that reads its own keys, and a scroll region that swallows a bare character exactly as
+ * `../chat/ChatWindow.tsx` does. The rule is the shipped helper, not a paraphrase of it, so a desk
+ * that stopped honouring the armed mark fails here.
+ */
+const chatShapedWindow: MountResolver = boundTo((host) => (
+	<>
+		<div
+			role="log"
+			aria-label={`Transcript ${host.windowId}`}
+			// biome-ignore lint/a11y/noNoninteractiveTabindex: a scroll region must take keyboard focus
+			tabIndex={0}
+			onKeyDown={(event) => {
+				const bare =
+					!event.ctrlKey && !event.metaKey && !event.altKey && [...event.key].length === 1;
+				if (bare && !prefixArmedAround(event.target)) event.stopPropagation();
+			}}
+		/>
+		<textarea aria-label={`Compose ${host.windowId}`} defaultValue="" />
+	</>
+));
 
 interface HarnessProps {
 	readonly initial: ShellState;
@@ -360,6 +389,110 @@ describe("the command line", () => {
 
 		fireEvent.keyDown(screen.getByLabelText("Type a command"), {key: "x"});
 		expect(sent).toHaveLength(before);
+	});
+});
+
+/**
+ * tmux's rule, from the two places the operator actually sits (#8270). The composer holds the caret
+ * most of the day and the transcript the rest of it, and before this the whole key grammar was
+ * unreachable from both.
+ *
+ * `fireEvent` returns the `dispatchEvent` answer, so `false` is "the default was prevented" — which
+ * is the browser-side proof that no character was inserted. jsdom performs no default text entry of
+ * its own, so that return, and not the textarea's value, is what carries the claim.
+ */
+describe("the shell's own keys from a focused text entry or transcript", () => {
+	const openDesk = (sent: Array<ShellMsg>): void => {
+		render(
+			<Harness initial={threeWindowDesk("window-1")} sent={sent} resolveMount={chatShapedWindow} />,
+		);
+	};
+	const composer = (): HTMLTextAreaElement =>
+		screen.getByLabelText("Compose window-1") as HTMLTextAreaElement;
+	const transcript = (): HTMLElement => screen.getByRole("log", {name: "Transcript window-1"});
+	const armed = (): boolean =>
+		document.querySelector(".tuval-surface")?.hasAttribute("data-prefix-armed") === true;
+
+	/** The `dispatchEvent` answer for one press, with the render it caused already flushed. */
+	const press = (element: Element, init: Record<string, unknown>): boolean => {
+		let answer = true;
+		act(() => {
+			answer = fireEvent.keyDown(element, init);
+		});
+		return answer;
+	};
+
+	it("arms the prefix on `<c-b>` typed into a focused textarea", () => {
+		const sent: Array<ShellMsg> = [];
+		openDesk(sent);
+		composer().focus();
+
+		const notPrevented = press(composer(), {key: "b", ctrlKey: true, code: "KeyB"});
+
+		expect(sent).toEqual([
+			{type: "keys.press", key: expect.objectContaining({key: "b", ctrlKey: true})},
+		]);
+		expect(armed()).toBe(true);
+		expect(notPrevented).toBe(false);
+	});
+
+	it("completes `<c-b> w` from the focused transcript, putting the window back on the picker", () => {
+		openDesk([]);
+		transcript().focus();
+
+		const scroller = transcript();
+		press(scroller, {key: "b", ctrlKey: true, code: "KeyB"});
+		expect(armed()).toBe(true);
+		press(scroller, {key: "w", code: "KeyW"});
+
+		expect(armed()).toBe(false);
+		// `window:pick` unbound the focused window, so its mount is the picker (#8083) — window-2 is
+		// empty from the start, so the claim is scoped to the one the sequence acted on.
+		const window1 = within(screen.getByLabelText("Window window-1"));
+		expect(window1.getByRole("listbox", {name: /Open a program/})).toBeTruthy();
+		expect(window1.queryByRole("log")).toBeNull();
+	});
+
+	it("leaves a plain `w` to the composer while the prefix is idle", () => {
+		const sent: Array<ShellMsg> = [];
+		openDesk(sent);
+		composer().focus();
+
+		const notPrevented = press(composer(), {key: "w", code: "KeyW"});
+
+		expect(notPrevented).toBe(true);
+		expect(sent).toEqual([]);
+		expect(armed()).toBe(false);
+	});
+
+	it("opens the palette on Cmd+K and on Ctrl+K from inside a textarea", () => {
+		openDesk([]);
+		const palette = (): HTMLElement | null => screen.queryByRole("combobox", {name: "Run a spell"});
+
+		composer().focus();
+		press(composer(), {key: "k", metaKey: true, code: "KeyK"});
+		expect(palette()).toBeTruthy();
+
+		press(palette() as HTMLElement, {key: "Escape"});
+		expect(palette()).toBeNull();
+
+		composer().focus();
+		press(composer(), {key: "k", ctrlKey: true, code: "KeyK"});
+		expect(palette()).toBeTruthy();
+	});
+
+	it("keeps every key of an armed sequence out of the composer", () => {
+		openDesk([]);
+		// Held across the sequence: `<c-b> w` unbinds this window, so the element is the composer's
+		// only surviving witness once the picker has taken its place.
+		const box = composer();
+		box.focus();
+
+		const prefixPrevented = press(box, {key: "b", ctrlKey: true, code: "KeyB"});
+		const sequencePrevented = press(box, {key: "w", code: "KeyW"});
+
+		expect([prefixPrevented, sequencePrevented]).toEqual([false, false]);
+		expect(box.value).toBe("");
 	});
 });
 

--- a/apps/tuval/src/shell/ui/frame.ts
+++ b/apps/tuval/src/shell/ui/frame.ts
@@ -49,6 +49,17 @@ export type SurfaceKeyAnswer =
 	/** A named command the page does not implement, or an armed/pending/unbound prefix. */
 	| {readonly _tag: "Shell"; readonly command: CommandName | null};
 
+/**
+ * Is this key the shell's, whatever holds DOM focus? tmux's rule, and the whole of #8270: the
+ * prefix is the one key a pane never gets, and once it is armed every key of the sequence is the
+ * shell's too. Everything else typed into a text entry belongs to the text entry.
+ *
+ * Asked of the same `route` the surface routes with, so the two can never disagree about which key
+ * arms the prefix — a second reading of `table.prefix` here is how that drift starts.
+ */
+export const shellOwnsKey = (table: PrefixTable, prefix: PrefixState, event: Key): boolean =>
+	prefix._tag === "Armed" || route(table, prefix, event)._tag === "Arm";
+
 export const surfaceKey = (
 	table: PrefixTable,
 	prefix: PrefixState,

--- a/apps/tuval/src/shell/ui/index.ts
+++ b/apps/tuval/src/shell/ui/index.ts
@@ -28,6 +28,7 @@ export {
 	type StatusFrame,
 	type SurfaceKeyAnswer,
 	sameLayout,
+	shellOwnsKey,
 	statusFrame,
 	surfaceKey,
 	zoomedWindow,

--- a/apps/tuval/src/shell/ui/text-entry.ts
+++ b/apps/tuval/src/shell/ui/text-entry.ts
@@ -1,7 +1,7 @@
 /**
  * Does this element read its own keys? Two surfaces need the same answer and must not drift: the
- * desk skips a press typed into one (`./Desk.tsx`), and the picker declines to pull DOM focus off
- * one (`./PickerView.tsx`).
+ * desk leaves it the presses the shell does not own (`./Desk.tsx`, `shellOwnsKey` in `./frame.ts`),
+ * and the picker declines to pull DOM focus off one (`./PickerView.tsx`).
  */
 export const isTextEntry = (target: EventTarget | null | undefined): boolean => {
 	if (

--- a/apps/tuval/src/shell/window/index.ts
+++ b/apps/tuval/src/shell/window/index.ts
@@ -18,6 +18,7 @@ export {
 	WindowId,
 	type WindowSlot,
 } from "./host.ts";
+export {PREFIX_ARMED_ATTRIBUTE, prefixArmedAround} from "./prefix-signal.ts";
 export {
 	type AnyWindowRenderer,
 	type DeclaredProgram,

--- a/apps/tuval/src/shell/window/prefix-signal.ts
+++ b/apps/tuval/src/shell/window/prefix-signal.ts
@@ -1,0 +1,24 @@
+/**
+ * The one desk-level key fact a window renderer needs, published on the DOM instead of passed.
+ *
+ * It cannot be passed: `./host.ts` carries a dispatch and a view slot and no key channel, and the
+ * two rendering slices may not import each other (`../ui/boundary.unit.test.ts`). So the desk marks
+ * its own root while the shell's prefix is armed and a region that would otherwise take a key reads
+ * that mark off the key's own target.
+ *
+ * Armed means tmux's rule is in force: the next key is the shell's from any focus (#8270), so every
+ * region inside the desk stands down until the sequence resolves.
+ */
+
+export const PREFIX_ARMED_ATTRIBUTE = "data-prefix-armed";
+
+/** Present only while armed, so presence is the whole answer and no value has to be compared. */
+const PREFIX_ARMED_SELECTOR = `[${PREFIX_ARMED_ATTRIBUTE}]`;
+
+/** Is the desk this event landed in holding an armed prefix? `false` outside a desk entirely. */
+export const prefixArmedAround = (target: EventTarget | null | undefined): boolean => {
+	if (target === null || target === undefined || typeof target !== "object") return false;
+	const element = target as {closest?: unknown};
+	if (typeof element.closest !== "function") return false;
+	return (element as Element).closest(PREFIX_ARMED_SELECTOR) !== null;
+};


### PR DESCRIPTION
The shell's key grammar was unreachable from the two places an operator actually sits: the chat composer and the transcript scroller. `<c-b>` never armed from a `textarea`, `cmd-k` never opened the palette from one, and a sequence armed elsewhere lost its second key to the transcript.

Three changes:

- **`Desk.tsx` decides ownership before it decides focus.** `shellOwnsKey` (new, in `frame.ts`) asks the same pure `route` the surface routes with: the prefix key, and every key while the prefix is armed, is the shell's whatever holds DOM focus. Only a key the shell does not own is left to a text entry. A key the shell takes gets one `preventDefault`, so no character reaches the composer — that swallow moved from the per-arm `switch` to the one place ownership is decided.
- **`cmd-k` / `ctrl-k` moved above the text-entry check.** The door you go looking through should not be shut by where the caret happens to be.
- **The chat window stands down while the prefix is armed.** `swallowBareCharacter` stops swallowing, and the composer's Escape / Alt+R handler bails. It learns the armed state from a `data-prefix-armed` mark the desk puts on its own root (`shell/window/prefix-signal.ts`): `ui/` and `chat/` may not import each other (`ui/boundary.unit.test.ts`) and `WindowHost` carries no key channel, so the DOM is the only seam there is.

Five new desk tests cover the criteria — arming from a focused `textarea`, `<c-b> w` completing from a focused `role="log"` scroller, a plain `w` staying with the composer while idle, both palette keys from a `textarea`, and every key of an armed sequence prevented. One new chat-window test proves the real transcript and composer stand down under the mark. All three were flip-verified against the pre-fix code. `isTextEntry` is unchanged, and #7973's swallow still holds while the prefix is idle.

Read first: `shellOwnsKey` in `apps/tuval/src/shell/ui/frame.ts` and the reworked `onKeyDown` in `apps/tuval/src/shell/ui/Desk.tsx`.

## Deviations

- **Out-of-scope change** — **Said:** #8270 names the desk handler, `text-entry.ts` and the transcript's `swallowBareCharacter`. **Did:** also made the composer's own `Escape` / `Alt+R` handler bail while the prefix is armed. **Why:** it is the same rule — an armed prefix owns the next key from any focus — and leaving it out would have let `<prefix> r` resend a turn instead of reloading the config. **Disposition:** stated here; criterion 7 (both keys keep working with the prefix idle) is covered by the existing tests, which stay green.

Fixes #8270
