### PR TITLE
chore: Root package.json's devDependency on @kampus/fabrika-cli puts fabrika-cli source in turbo's global hash, so every fabrika-cli change re-typechecks all 24 packages

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,16 @@
+// Re-adds the root's `fabrika` binstub edge at install time so it never appears in the root
+// package.json on disk: turbo reads that file to build its graph, and a root->internal edge puts
+// every file of that package in the global hash, so one fabrika-cli change misses the cache for
+// all 24 packages (#8277).
+"use strict";
+
+const ROOT_PACKAGE_NAME = "phoenix";
+const FABRIKA_CLI = "@kampus/fabrika-cli";
+
+function readPackage(pkg) {
+	if (pkg.name !== ROOT_PACKAGE_NAME) return pkg;
+	pkg.devDependencies = {...pkg.devDependencies, [FABRIKA_CLI]: "workspace:*"};
+	return pkg;
+}
+
+module.exports = {hooks: {readPackage}};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",
-		"@kampus/fabrika-cli": "workspace:*",
 		"@effect/language-service": "catalog:",
 		"@effect/tsgo": "catalog:",
 		"lefthook": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,8 @@ overrides:
   '@earendil-works/pi-telemetry': 0.84.3
   '@earendil-works/pi-tui': 0.84.3
 
+pnpmfileChecksum: sha256-ENBbpnCM6iEJZwql5y+XIdMMnEPnYSp47O6FmPjp4UI=
+
 patchedDependencies:
   '@nkzw/fate@1.3.1':
     hash: e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c


### PR DESCRIPTION
Fixes #8277

Root `package.json` declared `"@kampus/fabrika-cli": "workspace:*"` to get the `fabrika` binstub into the root `node_modules/.bin`. That edge made every tracked file of `packages/fabrika-cli` a turbo global-hash input, so one fabrika-cli change invalidated the cache for all 24 packages.

The fix follows the founder ruling (https://github.com/kamp-us/phoenix/issues/8277#issuecomment-5561284187) on the research in https://github.com/kamp-us/phoenix/issues/8264#issuecomment-5561242790: drop the root devDependency and re-add it at install time with a `.pnpmfile.cjs` `readPackage` hook scoped to the root manifest. Turbo builds its graph from `package.json` on disk, so it sees no root edge; pnpm still links the binstub, so nothing that calls `fabrika <group> <verb>` changes.

`readPackage(pkg, context)` is pnpm's documented per-manifest hook (https://pnpm.io/pnpmfile#readpackagepkg-context-promisepkg). The docs word its argument as "a dependency's package.json", but on pnpm 10.27.0 it also runs on the workspace root manifest — which is what this change relies on, and what the `+ @kampus/fabrika-cli workspace:*` line in every install's output confirms.

## Probe — `turbo run typecheck --filter='...<base>' --dry=json` with a one-file change under `packages/fabrika-cli/src`

Before (on `epic/8264`, `--filter='...[origin/main]'`) — 24 packages, `hashOfInternalDependencies: 914c3ead6981ce28`:

```
//, @kampus/admin-grant, @kampus/anka-ops, @kampus/authz, @kampus/cf-credentials,
@kampus/composer, @kampus/d1-rest, @kampus/db-schema, @kampus/depo, @kampus/depo-infra,
@kampus/design, @kampus/fabrika-cli, @kampus/fabrika-opencode, @kampus/fabrika-pi,
@kampus/fate-effect, @kampus/founder-seed, @kampus/fts-backfill, @kampus/infra,
@kampus/migrations-guard, @kampus/orphan-sweep, @kampus/preview-seed, @kampus/tuval,
@kampus/web, @kampus/worker-relevance
```

After (this branch, `--filter='...[HEAD]'` so only the probe is in the diff) — 1 package, `hashOfInternalDependencies: ""`:

```
@kampus/fabrika-cli
```

Run against `origin/main` while this change is still in flight, the after-list is `//, @kampus/fabrika-cli`: `//` is selected because the root `package.json` and lockfile edits are themselves in that diff. Once this lands, a fabrika-cli-only diff selects fabrika-cli and its dependents alone.

## Timing and cache hits

Same tree, same machine, warm cache, one appended comment line in `packages/fabrika-cli/src/bin.ts` as the change.

| | selected | cached | wall clock | `uptime` load at start |
|---|---|---|---|---|
| before — `turbo run typecheck --filter='...[origin/main]'` | 23 | 0 / 23 | 36.2s | `11:52 up 22 days, 8:22, load averages: 49.70 38.07 30.44` |
| after — `pnpm typecheck` (all 23) | 23 | 22 / 23 | 5.45s | `11:55 up 22 days, 8:25, load averages: 16.91 30.21 28.82` |
| after — `turbo run typecheck --filter='...[HEAD]'` | 1 | 0 / 1 | 5.50s | `11:55 up 22 days, 8:25, load averages: 20.32 31.72 29.30` |

`fabrika build check --surface code` is not a useful before/after here and the criterion asking for it cannot be met as written: the verb runs `pnpm typecheck --force`, which bypasses the cache by design, so it runs all 23 tasks either way (42.0s before at load 76.40, 26.0s after at load 20.32 — the gap is machine load, not this change). The numbers above are the measurement that criterion was reaching for.

## Verification

- `pnpm install --frozen-lockfile` passes; the lockfile diff is 2 lines (a `pnpmfileChecksum` entry).
- `pnpm exec fabrika --help` and `pnpm exec fabrika status settings` run from this checkout's root and from a fresh linked worktree after its post-checkout `pnpm install`, with no PATH or path edits. That install prints `+ @kampus/fabrika-cli 0.5.0 <- packages/fabrika-cli` with no root manifest entry.
- `fabrika build check --surface code` green (`pnpm typecheck --force`, `pnpm lint:worktree`); `fabrika guard catalog-guard check` and `fabrika guard readme-guard check` green.
- No `--ignore-pnpmfile` anywhere in `.github/`, `scripts/` or the root scripts, so CI installs run the hook.

`.pnpmfile.cjs` is new at the repo root. It carries one comment at its top saying why it exists, because a root file whose whole job is to hide an edge from another tool is unreadable without that note.

## Deviations

- **Scope narrowing** — **Said:** the issue's fifth acceptance criterion asks for before/after wall-clock of `fabrika build check --surface code` with a warm cache. **Did:** recorded that pair but reported the filtered/full `turbo run typecheck` numbers as the real measurement. **Why:** `build check` passes `--force`, so it never reads the cache and cannot show a cache effect. **Disposition:** stated here, with both numbers in the table's note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvmPoYyaLWnukLLHkQeXXo
