### PR TITLE
feat: A laneConcurrencyCap key in .fabrika.jsonc that fabrika lane open refuses past

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -17,6 +17,11 @@
 
 	"capClearAuthors": ["@usirin", "@notusirin", "@cansirin"],
 
+	// How many issue lanes may stand open at once — the number the founder drove this weekend, now
+	// enforced at the boot instead of remembered (#8264). `lane open` and `lane emit` refuse past it
+	// with nothing written; there is no override flag, so raising this line is the only way past.
+	"laneConcurrencyCap": 2,
+
 	// Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `campaign
 	// state`). It narrows the repo's collaborator ACL and never replaces it: an entry here still
 	// needs `write` or above on the repo (ADR 0294). Founder-declared 2026-08-20 on #6811 — the

--- a/.fabrika.schema.json
+++ b/.fabrika.schema.json
@@ -221,6 +221,14 @@
 			},
 			"minItems": 1
 		},
+		"laneConcurrencyCap": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "How many issue lanes may stand open at once — `lane open` and `lane emit` refuse past it, with no override. Write null (or leave it out) for no cap.",
+			"minimum": 1
+		},
 		"roadmapFile": {
 			"type": "string",
 			"description": "The roadmap file carrying the `## Campaigns` focus table, repo-relative.",

--- a/packages/fabrika-cli/src/config/json-schema.ts
+++ b/packages/fabrika-cli/src/config/json-schema.ts
@@ -2,7 +2,7 @@
  * The document-level JSON Schema for `.fabrika.jsonc`, assembled from the per-key fragments.
  *
  * Each key group carries its own `jsonSchema` fragment beside its `decode`, so the shape a repo
- * hand-edits is described in the one place its decoder already lives. This module joins the fifteen
+ * hand-edits is described in the one place its decoder already lives. This module joins the registry's
  * fragments into one draft-07 document an editor validates the file against — a red squiggle on a
  * misspelled key or a wrong-typed value, where the only feedback used to be a decode failure at
  * runtime (#6488).
@@ -30,6 +30,7 @@ export interface JsonSchema {
 	readonly enum?: ReadonlyArray<string>;
 	readonly pattern?: string;
 	readonly minLength?: number;
+	readonly minimum?: number;
 	readonly properties?: Readonly<Record<string, JsonSchema>>;
 	readonly required?: ReadonlyArray<string>;
 	readonly additionalProperties?: boolean | JsonSchema;

--- a/packages/fabrika-cli/src/config/keys/lane-concurrency-cap.ts
+++ b/packages/fabrika-cli/src/config/keys/lane-concurrency-cap.ts
@@ -1,0 +1,46 @@
+/**
+ * `laneConcurrencyCap` — how many issue lanes this repo lets stand open at once.
+ *
+ * "Cap at 2 for the rest of the night" was a spoken instruction, so it bound only the operator who
+ * heard it and only for as long as they remembered it. Declared here it binds the boot itself:
+ * `lane open` and `lane emit` count the seats before they write, and refuse past the number.
+ *
+ * **The shipped default is `null` — no cap.** A repo that declares nothing is not capped, matching
+ * every other shipped default on this surface, which declines rather than guessing a number that
+ * fits somebody else's machine. `null` is also writable, and means the same thing said out loud.
+ *
+ * A declared value is a **positive integer**: `0` would be a cap no boot could ever clear, and a
+ * fraction or a numeric string is a value the writer did not mean. All of them refuse at load rather
+ * than round, because a cap silently repaired to a different number is one the operator believes
+ * they set and did not.
+ */
+
+import type {Decoded, KeyGroup} from "../key-group.ts";
+
+export const LANE_CONCURRENCY_CAP = "laneConcurrencyCap";
+
+/** A repo declaring nothing has no cap — the decline, not a number guessed for it. */
+export const SHIPPED_LANE_CONCURRENCY_CAP: number | null = null;
+
+const decode = (raw: unknown): Decoded<number | null> => {
+	if (raw === null) return {_tag: "Value", value: null};
+	if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1) {
+		return {
+			_tag: "Malformed",
+			reason: `\`${LANE_CONCURRENCY_CAP}\` is not a positive integer — write the number of issue lanes that may stand open at once, or null for no cap`,
+		};
+	}
+	return {_tag: "Value", value: raw};
+};
+
+export const laneConcurrencyCapKey: KeyGroup<number | null> = {
+	key: LANE_CONCURRENCY_CAP,
+	shippedDefault: SHIPPED_LANE_CONCURRENCY_CAP,
+	decode,
+	jsonSchema: {
+		type: ["integer", "null"],
+		description:
+			"How many issue lanes may stand open at once — `lane open` and `lane emit` refuse past it, with no override. Write null (or leave it out) for no cap.",
+		minimum: 1,
+	},
+};

--- a/packages/fabrika-cli/src/config/keys/lane-concurrency-cap.unit.test.ts
+++ b/packages/fabrika-cli/src/config/keys/lane-concurrency-cap.unit.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from "vitest";
+import {loadConfig, resolve} from "../load.ts";
+import {LANE_CONCURRENCY_CAP, laneConcurrencyCapKey} from "./lane-concurrency-cap.ts";
+
+const declared = (value: unknown) =>
+	resolve(
+		loadConfig({_tag: "Text", text: JSON.stringify({[LANE_CONCURRENCY_CAP]: value})}),
+		laneConcurrencyCapKey,
+	);
+
+describe("a repo that declares nothing is not capped", () => {
+	it("resolves null for a repo with no config at all", () => {
+		const resolved = resolve(loadConfig({_tag: "Absent"}), laneConcurrencyCapKey);
+		expect(resolved._tag).toBe("Default");
+		if (resolved._tag !== "Default") return;
+		expect(resolved.value).toBeNull();
+	});
+
+	it("resolves null for a config that declares other keys and not this one", () => {
+		const resolved = resolve(
+			loadConfig({_tag: "Text", text: JSON.stringify({capClearAuthors: ["@someone"]})}),
+			laneConcurrencyCapKey,
+		);
+		expect(resolved._tag).toBe("Default");
+		if (resolved._tag !== "Default") return;
+		expect(resolved.value).toBeNull();
+	});
+});
+
+describe("a declared value is a positive integer, or null for no cap", () => {
+	it("takes the number the repo wrote", () => {
+		const resolved = declared(2);
+		expect(resolved._tag).toBe("Declared");
+		if (resolved._tag !== "Declared") return;
+		expect(resolved.value).toBe(2);
+	});
+
+	it("takes an explicit null as the declared decline", () => {
+		const resolved = declared(null);
+		expect(resolved._tag).toBe("Declared");
+		if (resolved._tag !== "Declared") return;
+		expect(resolved.value).toBeNull();
+	});
+
+	// 0 is a cap no boot could ever clear, and every other value here is one the writer did not mean:
+	// a silently-repaired cap is one the operator believes they set and did not.
+	it.each([0, -1, "2", 1.5, true, [2], {cap: 2}])("refuses %p, naming the key", (value) => {
+		const resolved = declared(value);
+		expect(resolved._tag).toBe("Malformed");
+		if (resolved._tag !== "Malformed") return;
+		expect(resolved.reason).toContain(LANE_CONCURRENCY_CAP);
+		expect(resolved.reason).toContain("positive integer");
+	});
+});

--- a/packages/fabrika-cli/src/config/registry.ts
+++ b/packages/fabrika-cli/src/config/registry.ts
@@ -17,6 +17,7 @@ import {unreadableCodeownersKey} from "./keys/control-plane.ts";
 import {dependencyReconcilerKey} from "./keys/dependency-reconciler.ts";
 import {docLeakExemptKey} from "./keys/doc-leak-exempt.ts";
 import {governedRootsKey} from "./keys/governed-roots.ts";
+import {laneConcurrencyCapKey} from "./keys/lane-concurrency-cap.ts";
 import {cycleDocKey, decisionsDirKey, designHarnessKey, roadmapFileKey} from "./keys/paths.ts";
 import {surfaceDispositionsKey} from "./keys/surface-dispositions.ts";
 import {triageFacetsKey} from "./keys/triage-facets.ts";
@@ -35,6 +36,7 @@ export const KEY_GROUPS: ReadonlyArray<Registration> = [
 	register(designHarnessKey),
 	register(docLeakExemptKey),
 	register(governedRootsKey),
+	register(laneConcurrencyCapKey),
 	register(roadmapFileKey),
 	register(surfaceDispositionsKey),
 	register(triageFacetsKey),

--- a/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
@@ -49,7 +49,7 @@ describe("reconcile", () => {
 	it("agrees when the committed file matches the assembled schema", () => {
 		const {outcome} = run({write: false, read: {_tag: "Text", text: committed}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\tagrees\t17");
+		expect(outcome.stdout).toContain("schema\tagrees\t18");
 	});
 
 	it("agrees whatever the committed file's whitespace, comparing content not bytes", () => {
@@ -87,7 +87,7 @@ describe("write", () => {
 	it("renders the file from the registry and reports written", () => {
 		const {outcome, saves} = run({write: true, read: {_tag: "Absent"}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\twritten\t17");
+		expect(outcome.stdout).toContain("schema\twritten\t18");
 		expect(saves).toHaveLength(1);
 		expect(saves[0]).toBe(committed);
 	});

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -405,3 +405,14 @@ export const ISSUE_LIVE = 49;
  * remedy is to leave it where it is (ADR 0352).
  */
 export const LOG_REPLAYS = 50;
+
+/**
+ * The lanes root already holds as many lanes as `.fabrika.jsonc`'s `laneConcurrencyCap` allows, so
+ * the boot is refused with nothing written.
+ *
+ * Its own seat rather than {@link LANE_EXISTS}'s: that one says this lane is already there and the
+ * remedy is to drive it, while this one says every seat is taken by *other* lanes and the remedy is
+ * to free one — `lane archive` on a lane that is done, or a raised number in the config. No flag
+ * opens it, because a cap with an override is the spoken instruction it replaced.
+ */
+export const CONCURRENCY_CAPPED = 51;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -11,6 +11,8 @@ import {fileURLToPath} from "node:url";
 import {Effect, type FileSystem, Option, Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {claimReader} from "../build/claimants-verb.ts";
+import {laneConcurrencyCapKey} from "../config/keys/lane-concurrency-cap.ts";
+import {readKey} from "../config/read-key.ts";
 import {resolveEntrypoint} from "../delegate/entrypoint.ts";
 import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
@@ -347,6 +349,7 @@ const open = leafCommand(
 		),
 	},
 	Effect.fn(function* ({lane, root, repo}) {
+		const cap = yield* readKey(process.cwd(), laneConcurrencyCapKey);
 		yield* emit(
 			yield* onKey("open", lane, root, (key, ref) =>
 				runOpen({
@@ -354,6 +357,7 @@ const open = leafCommand(
 					templatePath: templatePath(key._tag),
 					issue: key._tag === "Issue" ? Number(key.lane) : null,
 					expectation: expectationReader(Option.getOrNull(repo), process.env),
+					cap,
 				}),
 			),
 		);
@@ -361,7 +365,7 @@ const open = leafCommand(
 ).pipe(
 	Command.withShortDescription("Boot a lane from the committed template its key selects."),
 	Command.withDescription(
-		"Boot one lane: create `<root>/<key>/` and place a byte-identical copy of the committed template the key selects as its workflow.json — the coder template for an issue number, the chore template for a `chore:<name>` key. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. An ISSUE key first reads that issue's type, its native sub-issue links and its parent edge: the coder template has one task, so an epic has no machine here and is refused at 46 before anything is written (#7024). Both halves of \"epic\" are asked for, because they answer for different moments — a planned epic carries children, and an epic nobody has planned yet carries none and is known only by its `type:epic` label, which is the window the wrong-template lane was booted in. The refusal names which case it is: an unplanned epic goes to `plan-epic` first, and a planned one is booted with `fabrika lane emit <n>`. An epic's CHILD carries neither fact, and is refused at 48 instead, naming the parent whose lane already carries it as a task — a child gets no lane of its own (#7381). Epic wins the precedence, so a sub-epic still routes to `lane emit`. The parent edge rides the issue read already made, so those two reads stay the only network calls; a `chore:<name>` key drives no issue and is never asked. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template, the lane dir's existence, or the issue's child list could not be read — UNKNOWN, never a boot), 14 (the lane already exists), 21 (the key is not a lane key), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default lanes root; an unreadable repository identity is UNKNOWN at 11; NOT \"no lane here\", so never a boot), 46 (the issue is an epic — typed `type:epic`, or carrying sub-issue links — so this template is the wrong machine for it), 48 (the issue hangs under a parent, whose lane is the one to drive). Examples: fabrika lane open 5673 · fabrika lane open chore:park-sweep",
+		"Boot one lane: create `<root>/<key>/` and place a byte-identical copy of the committed template the key selects as its workflow.json — the coder template for an issue number, the chore template for a `chore:<name>` key. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. An ISSUE key first reads that issue's type, its native sub-issue links and its parent edge: the coder template has one task, so an epic has no machine here and is refused at 46 before anything is written (#7024). Both halves of \"epic\" are asked for, because they answer for different moments — a planned epic carries children, and an epic nobody has planned yet carries none and is known only by its `type:epic` label, which is the window the wrong-template lane was booted in. The refusal names which case it is: an unplanned epic goes to `plan-epic` first, and a planned one is booted with `fabrika lane emit <n>`. An epic's CHILD carries neither fact, and is refused at 48 instead, naming the parent whose lane already carries it as a task — a child gets no lane of its own (#7381). Epic wins the precedence, so a sub-epic still routes to `lane emit`. The parent edge rides the issue read already made, so those two reads stay the only network calls; a `chore:<name>` key drives no issue and is never asked. Last before the write, an issue key is counted against `.fabrika.jsonc`'s `laneConcurrencyCap`: the issue lanes under this root that have not folded to done hold its seats, an archived one is already out of the count, and there is no override flag — raising the number in the config is how it changes. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template, the lane dir's existence, or the issue's child list could not be read — UNKNOWN, never a boot), 14 (the lane already exists), 21 (the key is not a lane key), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default lanes root; an unreadable repository identity is UNKNOWN at 11; NOT \"no lane here\", so never a boot), 46 (the issue is an epic — typed `type:epic`, or carrying sub-issue links — so this template is the wrong machine for it), 48 (the issue hangs under a parent, whose lane is the one to drive), 51 (the lanes root already holds as many lanes as `.fabrika.jsonc`'s `laneConcurrencyCap` allows — the cap, the count and every lane holding a seat are named, and nothing was written). Examples: fabrika lane open 5673 · fabrika lane open chore:park-sweep",
 	),
 );
 
@@ -380,6 +384,7 @@ const emitLane = leafCommand(
 		),
 	},
 	Effect.fn(function* ({epic, root, repo}) {
+		const cap = yield* readKey(process.cwd(), laneConcurrencyCapKey);
 		const resolvedRoot = yield* resolveRootOrRefuse(
 			"fabrika lane emit",
 			root,
@@ -397,6 +402,7 @@ const emitLane = leafCommand(
 					root: resolvedRoot,
 					repo: Option.getOrNull(repo),
 					env: process.env,
+					cap,
 				}),
 			),
 		);
@@ -404,7 +410,7 @@ const emitLane = leafCommand(
 ).pipe(
 	Command.withShortDescription("Generate an epic's lane machine from its board topology."),
 	Command.withDescription(
-		"Generate a lane machine from the epic's board state: read the epic body's `## Dependencies` topology (the shape `ledger topology` stages) and emit `<root>/<epic>/workflow.json` — one region per child in the coder template's exact shape, phase-sequenced, parallel within a phase. A closed child boots its region in a final state (`completed` → `shipped`, any other close → `frozen`), so a partly-built epic's machine can still terminate. Deterministic: the same epic body bytes and the same child links (number, state and close reason per child) emit the same machine bytes. stdout is {answer:\"emitted\", epic, workflow, phases, children, bytes}. An existing lane is refused at 14 with no exception — a lane on disk is never re-emitted over (ADR 0313, amendment 2026-08-20) — and the refusal names the whole remedy: retire the lane directory, then re-run this verb. `fabrika lane migrate --check` is what says a lane on disk runs the wrong machine (#7024). Exits 4 (the topology was read in full and does not parse — the defective line, duplicate placement or unplaced requires subject is named), 7 (the epic is proven absent or closed), 8 (the write did not land), 11 (the epic, its child list or the lane dir could not be read — UNKNOWN), 14 (the lane already exists — retire its directory and re-run to rebuild it), 15 (no `## Dependencies` topology — plan the epic first), 16 (the topology references a non-child, named), 17 (the topology holds a cycle, path named), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default lanes root; an unreadable repository identity is UNKNOWN at 11; NOT \"no lane here\", so never a boot). Example: fabrika lane emit 5680",
+		"Generate a lane machine from the epic's board state: read the epic body's `## Dependencies` topology (the shape `ledger topology` stages) and emit `<root>/<epic>/workflow.json` — one region per child in the coder template's exact shape, phase-sequenced, parallel within a phase. A closed child boots its region in a final state (`completed` → `shipped`, any other close → `frozen`), so a partly-built epic's machine can still terminate. Deterministic: the same epic body bytes and the same child links (number, state and close reason per child) emit the same machine bytes. stdout is {answer:\"emitted\", epic, workflow, phases, children, bytes}. An existing lane is refused at 14 with no exception — a lane on disk is never re-emitted over (ADR 0313, amendment 2026-08-20) — and the refusal names the whole remedy: retire the lane directory, then re-run this verb. `fabrika lane migrate --check` is what says a lane on disk runs the wrong machine (#7024). Exits 4 (the topology was read in full and does not parse — the defective line, duplicate placement or unplaced requires subject is named), 7 (the epic is proven absent or closed), 8 (the write did not land), 11 (the epic, its child list or the lane dir could not be read — UNKNOWN), 14 (the lane already exists — retire its directory and re-run to rebuild it), 15 (no `## Dependencies` topology — plan the epic first), 16 (the topology references a non-child, named), 17 (the topology holds a cycle, path named), 39 (no .git entry exists at or above the cwd, so there is no owning repository from which to derive the default lanes root; an unreadable repository identity is UNKNOWN at 11; NOT \"no lane here\", so never a boot), 51 (the lanes root already holds as many lanes as `.fabrika.jsonc`'s `laneConcurrencyCap` allows — an epic's lane holds a seat like any other). Example: fabrika lane emit 5680",
 	),
 );
 

--- a/packages/fabrika-cli/src/lane/concurrency.ts
+++ b/packages/fabrika-cli/src/lane/concurrency.ts
@@ -1,0 +1,115 @@
+/**
+ * How many seats the lanes root is holding, and the refusal a boot takes when the repo's declared
+ * `laneConcurrencyCap` is full.
+ *
+ * The count is over the boot's own root and nothing beside it, which is what keeps
+ * `.fabrika/lanes-archived` and `.fabrika/chores` out of it without either name appearing here: both
+ * are sibling roots, so a lane archived is a lane already gone from this read (ADR 0352), and a
+ * chore lane is counted by nobody.
+ *
+ * **Only a lane proven done frees its seat.** A lane whose record will not load or whose log will not
+ * replay is not finished — it is a seat nobody can account for — so it counts, and the refusal names
+ * it as such. Reading it the other way is the permissive arm: a stale directory would silently raise
+ * the cap the operator set, which is the spoken-instruction failure all over again. The remedy for a
+ * dead seat is `lane archive` or `lane reconcile`, and the refusal says so.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import {CONFIG_PATH} from "../config/document.ts";
+import {LANE_CONCURRENCY_CAP} from "../config/keys/lane-concurrency-cap.ts";
+import type {Read} from "../config/read-key.ts";
+import {exists, readDir} from "../io/fs.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {CONCURRENCY_CAPPED, LANE_UNREADABLE} from "./codes.ts";
+import {deriveStatus, foldLog, standingCauses} from "./fold.ts";
+import {loadLane} from "./store.ts";
+
+/** One lane holding a seat, and why it is not free. */
+export interface Seat {
+	readonly lane: string;
+	/** `active` folded from its log; `unaccountable` where the record would not load or replay. */
+	readonly held: "active" | "unaccountable";
+}
+
+export type Seats =
+	| {readonly _tag: "Counted"; readonly seats: ReadonlyArray<Seat>}
+	/** The root itself could not be listed — how full it is is UNKNOWN, never zero. */
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/** Numeric lane ids in numeric order, so a refusal reads the same twice over one root. */
+const ordered = (seats: ReadonlyArray<Seat>): ReadonlyArray<Seat> =>
+	[...seats].sort((a, b) => Number(a.lane) - Number(b.lane) || a.lane.localeCompare(b.lane));
+
+export const seatsIn = (
+	root: string,
+): Effect.Effect<Seats, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const there = yield* Effect.result(exists(root));
+		if (there._tag === "Failure") {
+			return {_tag: "Unreadable", reason: there.failure.reason} as const;
+		}
+		if (!there.success) return {_tag: "Counted", seats: []} as const;
+		const listed = yield* Effect.result(readDir(root));
+		if (listed._tag === "Failure") {
+			return {_tag: "Unreadable", reason: listed.failure.reason} as const;
+		}
+		const seats: Seat[] = [];
+		for (const lane of listed.success) {
+			const loaded = yield* loadLane({root, lane});
+			// A directory with no workflow.json is not a lane, so it is not a seat — the same read
+			// `lane reconcile` makes of a scratch directory under the root.
+			if (loaded._tag === "Absent") continue;
+			if (loaded._tag !== "Loaded") {
+				seats.push({lane, held: "unaccountable"});
+				continue;
+			}
+			const folded = foldLog(loaded.lane, loaded.entries);
+			if (folded._tag !== "Folded") {
+				seats.push({lane, held: "unaccountable"});
+				continue;
+			}
+			const status = deriveStatus(loaded.lane, folded.states, standingCauses(loaded.entries));
+			if (status.status === "active") seats.push({lane, held: "active"});
+		}
+		return {_tag: "Counted", seats: ordered(seats)} as const;
+	});
+
+const seatList = (seats: ReadonlyArray<Seat>): string =>
+	seats
+		.map((seat) => (seat.held === "active" ? `#${seat.lane}` : `#${seat.lane} (unaccountable)`))
+		.join(", ");
+
+/**
+ * The refusal a boot owes the declared cap, or `null` where it may proceed.
+ *
+ * There is no `--override` and no environment escape, by design: a cap you can step around on the
+ * machine it protects is the spoken instruction again. Raising the number in {@link CONFIG_PATH} is
+ * the override, and it is the only one.
+ */
+export const capRefusal = (
+	verb: string,
+	cap: Read<number | null>,
+	root: string,
+): Effect.Effect<VerbOutcome | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		if (cap._tag === "Refused") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${verb}: cannot read \`${LANE_CONCURRENCY_CAP}\` from ${CONFIG_PATH} (${cap.reason}) — how many lanes this repo allows is UNKNOWN, and nothing was booted.`,
+			);
+		}
+		const limit = cap.value;
+		if (limit === null) return null;
+		const counted = yield* seatsIn(root);
+		if (counted._tag === "Unreadable") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${verb}: cannot list ${root} to count the lanes standing against \`${LANE_CONCURRENCY_CAP}\` (${counted.reason}) — nothing was booted.`,
+			);
+		}
+		const {seats} = counted;
+		if (seats.length < limit) return null;
+		return refuse(
+			CONCURRENCY_CAPPED,
+			`${verb}: ${CONFIG_PATH} caps this repo at ${limit} lane(s) and ${root} already holds ${seats.length} — ${seatList(seats)}. Nothing was booted. Drive one of them to done and \`fabrika lane archive <n>\` it (\`fabrika lane reconcile\` first if its ledger is behind the board); an unaccountable seat is freed the same way, never by a cap that ignores it. There is no override flag: raising \`${LANE_CONCURRENCY_CAP}\` in ${CONFIG_PATH} is how the number changes.`,
+		);
+	});

--- a/packages/fabrika-cli/src/lane/concurrency.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/concurrency.unit.test.ts
@@ -1,0 +1,221 @@
+/** The cap `lane open` refuses past — what holds a seat, what frees one, and what is never counted. */
+import {Effect, type FileSystem, type Path} from "effect";
+import {describe, expect, it} from "vitest";
+import type {Read} from "../config/read-key.ts";
+import {fakeFs} from "../fakes.test-support.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {CONCURRENCY_CAPPED, LANE_UNREADABLE} from "./codes.ts";
+import {choreTemplateText, coderTemplateText} from "./fixtures.test-support.ts";
+import {runOpen} from "./open-verb.ts";
+import {
+	DEFAULT_ARCHIVED_LANES_ROOT,
+	DEFAULT_CHORES_ROOT,
+	DEFAULT_LANES_ROOT as ROOT,
+} from "./store.ts";
+
+const TEMPLATE = "/pkg/src/lane/templates/coder.workflow.json";
+const CHORE_TEMPLATE = "/pkg/src/lane/templates/chore.workflow.json";
+
+const capped = (value: number | null): Read<number | null> => ({
+	_tag: "Value",
+	value,
+	note: "test",
+});
+
+/** The events that walk the coder template all the way to `complete` — a lane whose seat is free. */
+const SHIPPED_LOG = ["ISSUE.WIP", "ISSUE.DONE", "ISSUE.PASS", "ISSUE.DONE"]
+	.map((event, index) =>
+		JSON.stringify({task: "issue", event, at: `2026-09-0${index + 1}T00:00:00Z`}),
+	)
+	.join("\n");
+
+/** A lane directory holding a freshly booted machine — folds to `active`. */
+const lane = (root: string, id: string, log?: string) => ({
+	[`${root}/${id}/workflow.json`]: coderTemplateText(),
+	...(log === undefined ? {} : {[`${root}/${id}/events.jsonl`]: log}),
+});
+
+const options = (cap: Read<number | null>) => ({
+	root: ROOT,
+	lane: "42",
+	templatePath: TEMPLATE,
+	issue: 42,
+	expectation: null,
+	cap,
+});
+
+const run = (
+	fs: ReturnType<typeof fakeFs>,
+	eff: Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path>,
+) => Effect.runPromise(Effect.provide(eff, fs.layer));
+
+describe("a repo with no cap declared boots whatever it likes", () => {
+	it("boots over two standing lanes when the cap is null", async () => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText(), ...lane(ROOT, "1"), ...lane(ROOT, "2")},
+			dirs: {[ROOT]: ["1", "2"]},
+			directories: [ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(null))));
+
+		expect(out.code).toBe(0);
+		expect(fs.written.get(`${ROOT}/42/workflow.json`)).toBe(coderTemplateText());
+	});
+
+	it("boots against an unreadable lanes root, because nothing needs counting", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}});
+		expect((await run(fs, runOpen(options(capped(null))))).code).toBe(0);
+	});
+});
+
+describe("a declared cap refuses the boot that would exceed it", () => {
+	it("refuses at the cap, naming the cap, the count and every lane holding a seat", async () => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText(), ...lane(ROOT, "7000"), ...lane(ROOT, "7001")},
+			dirs: {[ROOT]: ["7001", "7000"]},
+			directories: [ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(2))));
+
+		expect(out.code).toBe(CONCURRENCY_CAPPED);
+		expect(out.stderr.join("\n")).toContain("caps this repo at 2");
+		expect(out.stderr.join("\n")).toContain("already holds 2");
+		expect(out.stderr.join("\n")).toContain("#7000, #7001");
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("boots below the cap", async () => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText(), ...lane(ROOT, "7000")},
+			dirs: {[ROOT]: ["7000"]},
+			directories: [ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(2))));
+
+		expect(out.code).toBe(0);
+		expect(fs.written.get(`${ROOT}/42/workflow.json`)).toBe(coderTemplateText());
+	});
+
+	it("names no override flag — raising the config value is the only way past", async () => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText(), ...lane(ROOT, "7000")},
+			dirs: {[ROOT]: ["7000"]},
+			directories: [ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(1))));
+
+		expect(out.code).toBe(CONCURRENCY_CAPPED);
+		expect(out.stderr.join("\n")).toContain("There is no override flag");
+		expect(out.stderr.join("\n")).toContain("laneConcurrencyCap");
+	});
+});
+
+describe("what frees a seat, and what never held one", () => {
+	it("does not count a lane whose log folded it to done", async () => {
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				...lane(ROOT, "7000"),
+				...lane(ROOT, "7001", SHIPPED_LOG),
+			},
+			dirs: {[ROOT]: ["7000", "7001"]},
+			directories: [ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(2))));
+
+		expect(out.code).toBe(0);
+	});
+
+	it("does not count an archived lane — it sits under a sibling root", async () => {
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				...lane(ROOT, "7000"),
+				...lane(DEFAULT_ARCHIVED_LANES_ROOT, "7001"),
+			},
+			dirs: {[ROOT]: ["7000"], [DEFAULT_ARCHIVED_LANES_ROOT]: ["7001"]},
+			directories: [ROOT, DEFAULT_ARCHIVED_LANES_ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(2))));
+
+		expect(out.code).toBe(0);
+	});
+
+	it("does not count a chore lane, and never caps a chore boot", async () => {
+		const fs = fakeFs({
+			files: {
+				[CHORE_TEMPLATE]: choreTemplateText(),
+				...lane(ROOT, "7000"),
+				...lane(ROOT, "7001"),
+				[`${DEFAULT_CHORES_ROOT}/park-sweep/workflow.json`]: choreTemplateText(),
+			},
+			dirs: {[ROOT]: ["7000", "7001"], [DEFAULT_CHORES_ROOT]: ["park-sweep"]},
+			directories: [ROOT, DEFAULT_CHORES_ROOT],
+		});
+		const out = await run(
+			fs,
+			runOpen({
+				root: DEFAULT_CHORES_ROOT,
+				lane: "leak-sweep",
+				templatePath: CHORE_TEMPLATE,
+				issue: null,
+				expectation: null,
+				cap: capped(2),
+			}),
+		);
+
+		expect(out.code).toBe(0);
+		expect(fs.written.get(`${DEFAULT_CHORES_ROOT}/leak-sweep/workflow.json`)).toBe(
+			choreTemplateText(),
+		);
+	});
+
+	// A directory under the root with no workflow.json is not a lane, so it is not a seat — the same
+	// read `lane reconcile` makes of a scratch directory.
+	it("does not count a directory that holds no machine", async () => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText(), ...lane(ROOT, "7000")},
+			dirs: {[ROOT]: ["7000", "scratch"]},
+			directories: [ROOT],
+		});
+		expect((await run(fs, runOpen(options(capped(2))))).code).toBe(0);
+	});
+
+	it("counts a lane whose machine will not compile — a seat nobody can account for", async () => {
+		const fs = fakeFs({
+			files: {
+				[TEMPLATE]: coderTemplateText(),
+				...lane(ROOT, "7000"),
+				[`${ROOT}/7001/workflow.json`]: "{not json",
+			},
+			dirs: {[ROOT]: ["7000", "7001"]},
+			directories: [ROOT],
+		});
+		const out = await run(fs, runOpen(options(capped(2))));
+
+		expect(out.code).toBe(CONCURRENCY_CAPPED);
+		expect(out.stderr.join("\n")).toContain("#7001 (unaccountable)");
+	});
+});
+
+describe("a cap that could not be read is UNKNOWN, never absent", () => {
+	it("refuses when the config key did not resolve", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}});
+		const out = await run(
+			fs,
+			runOpen(options({_tag: "Refused", reason: "`laneConcurrencyCap` is not a positive integer"})),
+		);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses when the lanes root exists and cannot be listed", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}, directories: [ROOT]});
+		const out = await run(fs, runOpen(options(capped(2))));
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stderr.join("\n")).toContain("to count the lanes standing against");
+		expect(fs.written.size).toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/lane/emit-verb.ts
+++ b/packages/fabrika-cli/src/lane/emit-verb.ts
@@ -16,6 +16,7 @@ import {Effect, type FileSystem, type Path} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {badNumber, openIssue, resolveTargetRepo} from "../build/target.ts";
+import type {Read} from "../config/read-key.ts";
 import {listSubIssues} from "../plan/github.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
@@ -26,6 +27,7 @@ import {
 	TOPOLOGY_CYCLE,
 	TOPOLOGY_FOREIGN,
 } from "./codes.ts";
+import {capRefusal} from "./concurrency.ts";
 import {type EmitResult, emitMachine} from "./emit.ts";
 import {placementRefusal} from "./refusals.ts";
 import {type LaneRef, placeMachine} from "./store.ts";
@@ -37,6 +39,8 @@ export interface EmitOptions {
 	readonly root: string;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The repo's declared `laneConcurrencyCap` — an epic's lane holds a seat like any other. */
+	readonly cap: Read<number | null>;
 }
 
 const emitRefusal = (epic: number, result: Exclude<EmitResult, {_tag: "Emitted"}>): VerbOutcome => {
@@ -106,6 +110,8 @@ export const runEmit = (
 		const emitted = emitMachine(options.epic, target.issue.body, listed.value);
 		if (emitted._tag !== "Emitted") return emitRefusal(options.epic, emitted);
 		const ref: LaneRef = {root: options.root, lane: String(options.epic)};
+		const capped = yield* capRefusal(VERB, options.cap, options.root);
+		if (capped !== null) return capped;
 		const placed = yield* placeMachine(ref, emitted.text);
 		if (placed._tag === "Exists") {
 			return refuse(

--- a/packages/fabrika-cli/src/lane/emit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit-verb.unit.test.ts
@@ -46,6 +46,8 @@ const OPTIONS = {
 		string,
 		string | undefined
 	>,
+	// No cap declared — the cap's own arms live in [`concurrency.unit.test.ts`](concurrency.unit.test.ts).
+	cap: {_tag: "Value", value: null, note: "test"} as const,
 };
 
 const run = (script: ReadonlyArray<readonly [RegExp, HttpReply]> = [], fs = fakeFs({files: {}})) =>

--- a/packages/fabrika-cli/src/lane/open-verb.ts
+++ b/packages/fabrika-cli/src/lane/open-verb.ts
@@ -21,11 +21,16 @@
  * lane already held the same number as a task — two ledgers over one piece of work, reconciled by
  * nothing (#7381). That refusal is {@link LANE_IS_CHILD} and names the parent's lane as the one to
  * drive. Epic wins the precedence, so a sub-epic still routes to `lane emit`.
+ *
+ * The repo's declared `laneConcurrencyCap` is the last gate before the write, and an issue lane's
+ * alone — see [`concurrency.ts`](concurrency.ts) for what counts as a held seat.
  */
 import {Effect, type FileSystem, type Path, Result} from "effect";
+import type {Read} from "../config/read-key.ts";
 import {readFile} from "../io/fs.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {LANE_IS_CHILD, LANE_UNREADABLE, SHAPE_MISMATCH} from "./codes.ts";
+import {capRefusal} from "./concurrency.ts";
 import type {ExpectationReader} from "./expectation.ts";
 import {placementRefusal} from "./refusals.ts";
 import {type LaneRef, placeMachine} from "./store.ts";
@@ -39,6 +44,13 @@ export interface OpenOptions<R = never> extends LaneRef {
 	readonly issue: number | null;
 	/** The board reader, or `null` for the offline boot a caller gets by passing none. */
 	readonly expectation: ExpectationReader<R> | null;
+	/**
+	 * The repo's declared `laneConcurrencyCap`, read off `.fabrika.jsonc` by the adapter.
+	 *
+	 * Read for every boot and applied to an issue lane only: the cap counts the issue lanes under
+	 * this root, and a chore lane lives under a root of its own that nothing here counts.
+	 */
+	readonly cap: Read<number | null>;
 }
 
 export const runOpen = <R = never>(
@@ -82,6 +94,12 @@ export const runOpen = <R = never>(
 						: `${VERB}: #${issue} hangs under #${parent}, whose lane already carries it as a task — drive that lane (\`fabrika lane status ${parent}\`), never a second ledger for the child. Nothing was written.`,
 				);
 			}
+		}
+		// Last, so a permanent defect — the wrong template for this issue, a child that gets no lane —
+		// is named ahead of a cap that will clear on its own the moment a seat frees.
+		if (issue !== null) {
+			const capped = yield* capRefusal(VERB, options.cap, options.root);
+			if (capped !== null) return capped;
 		}
 		const placed = yield* placeMachine(options, template.success);
 		if (placed._tag !== "Placed") return placementRefusal(VERB, placed);

--- a/packages/fabrika-cli/src/lane/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/open-verb.unit.test.ts
@@ -24,12 +24,16 @@ const TEMPLATE = "/pkg/src/lane/templates/coder.workflow.json";
 const reads = (read: ExpectationRead) => () => Effect.succeed(read);
 const childless = reads({_tag: "Read", expectation: {_tag: "Single"}});
 
+/** No cap declared — the cap's own arms live in [`concurrency.unit.test.ts`](concurrency.unit.test.ts). */
+const UNCAPPED = {_tag: "Value", value: null, note: "test"} as const;
+
 const OPTIONS = {
 	root: ROOT,
 	lane: "42",
 	templatePath: TEMPLATE,
 	issue: 42,
 	expectation: childless,
+	cap: UNCAPPED,
 };
 
 const run = (
@@ -66,6 +70,7 @@ describe("lane open", () => {
 			templatePath: "/pkg/src/lane/templates/chore.workflow.json",
 			issue: null,
 			expectation: null,
+			cap: UNCAPPED,
 		};
 		const fs = fakeFs({files: {[chore.templatePath]: choreTemplateText()}});
 		const opened = await run(fs, runOpen(chore));


### PR DESCRIPTION
Fixes #8276

A repo now declares how many issue lanes may stand open at once, and the boot enforces it — "cap at 2 for the rest of the night" stops being a spoken instruction.

- `laneConcurrencyCap` is a new key fragment beside its siblings under `config/keys/`: shipped default `null` (no cap), a positive integer when declared, and `0` / negative / fractional / string refused as `Malformed` at load with a reason naming the key. `.fabrika.schema.json` is regenerated by `fabrika config schema --write`.
- `lane/concurrency.ts` counts the seats under the boot's own root and returns the refusal. Sibling roots are out of the count by construction, so an archived lane and a chore lane are never counted, and only a lane whose fold reads done frees its seat. A lane whose record will not load or replay counts as `unaccountable` rather than being skipped — reading it the other way silently raises the cap.
- `lane open` (issue keys only) and `lane emit` refuse past the cap on the new exit `51`, naming the cap, the count and every lane holding a seat, with nothing written. There is no `--override` and no env escape; raising the number in `.fabrika.jsonc` is the only way past.
- phoenix declares `"laneConcurrencyCap": 2` with a comment citing the epic.

Verified live: at the cap `lane open` exits `51` and creates no directory; with one lane moved to the archived root the same boot succeeds; a `0` in the config makes `status settings` print the key `unknown` with its reason; `lane open --help` lists `51`.

## Deviations

- **Out-of-scope change** — **Said:** the issue body enforces the cap at `fabrika lane open`. **Did:** enforced it at `lane emit` too. **Why:** the lane brief for this child names both verbs, and an epic's lane holds a seat exactly like an issue lane's. **Disposition:** stated here; `lane emit`'s `--help` exit list carries `51` as well.
- **Declined guidance** — **Said:** criterion 6 runs `pnpm --filter @kampus/fabrika-cli test:unit`. **Did:** ran `pnpm exec vitest run` (the package's `test` script). **Why:** the package declares no `test:unit` script. **Disposition:** whole suite green — 502 files, 8831 tests.
- **Scope narrowing** — **Said:** criterion 7 asks the README to name the key in its `.fabrika.jsonc` key list, if that list exists. **Did:** nothing. **Why:** neither `packages/fabrika-cli/README.md` nor `docs/running-fabrika-in-a-repo.md` carries a key list; the readout for every key is `fabrika status settings`. **Disposition:** the criterion's own condition is unmet, so nothing was added.
- **Pre-existing test or fixture changed** — **Said:** nothing about existing tests. **Did:** bumped the assembled-key count 17 to 18 in `config/schema-verb.unit.test.ts`, and added the new required `cap` option to the `lane open` / `lane emit` verb fixtures. **Why:** registering an eighteenth key moves the count the schema verb prints, and the option is not optional on the verb. **Disposition:** each is a mechanical consequence of the new key; no assertion was weakened.
- **Out-of-scope change** — **Said:** build the key fragment the way the siblings are built. **Did:** also added `minimum` to the `JsonSchema` keyword type, and fixed a stale "fifteen fragments" line in the same docblock. **Why:** an integer fragment with a floor cannot be expressed without the keyword, and the count in that sentence was already wrong before this change. **Disposition:** stated here.
- **Guard or gate bypassed** — **Said:** nothing. **Did:** opened this PR against `main` and retargeted it to `epic/8264` with `gh api -X PATCH .../pulls/N -f base=epic/8264`. **Why:** `build pr` carries no base flag; the lane brief prescribes exactly this two-step. **Disposition:** disclosed as the brief requires.
