### PR TITLE
chore: Scope the pre-push typecheck leg to changed packages with turbo --filter='...[origin/main]'

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -52,22 +52,29 @@
 	"unreadableCodeowners": "refuse",
 
 	// The repo's own commands that compile and lint its code. `fabrika build check --surface code`
-	// runs each one in the lane's tree, and what stands here is phoenix's own: `turbo run typecheck`
-	// is what the `pnpm typecheck` script wraps (a bare `tsc` takes none of this), and
-	// `lint:worktree` is a phoenix script name. Nothing is compiled into the CLI, so a repo
+	// runs each one in the lane's tree, and both script names here are phoenix's own —
+	// `typecheck:affected` and `lint:worktree`. Nothing is compiled into the CLI, so a repo
 	// declaring nothing gets a named refusal rather than these two commands (#6015).
 	//
-	// `--filter=...[origin/main]` scopes the typecheck to the packages this branch changed plus
-	// their dependents; the cache carries the rest, and turbo shares one `.turbo/cache` across every
-	// linked worktree of this clone, so a lane that touched one package pays for one package. There
-	// is deliberately no cache-bypass flag here: turbo 2.10.3's `run` reference defines that flag as
-	// ignoring existing cached artifacts and re-executing all tasks, so it recompiled all 23
-	// packages on every check, every `lane integrate` and every repair round — for a cache-poisoning
-	// risk nothing here ever recorded, and which `ci.yml`'s own bare `pnpm typecheck` never took
-	// (#8275). A checkout too shallow to resolve the ref degrades to every package, the fail-safe
-	// direction.
+	// `typecheck:affected` is `TURBO_SCM_BASE=origin/main turbo run typecheck --affected`: the
+	// packages this branch changed plus their dependents, measured from the MERGE-BASE of
+	// `origin/main` and HEAD. The cache carries the rest, and turbo shares one `.turbo/cache` across
+	// every linked worktree of this clone, so a lane that touched one package pays for one package.
+	// The base lives in the script rather than here because a validator is argv with no environment,
+	// and `--affected` takes its base from `TURBO_SCM_BASE` (defaulting to a LOCAL `main`, which in a
+	// lane worktree lags the remote) — the same script backs the pre-push hook, so one base serves
+	// both.
+	//
+	// Two things this deliberately does not do. There is no cache-bypass flag: turbo 2.10.3's `run`
+	// reference defines it as ignoring cached artifacts and re-executing all tasks, so it recompiled
+	// every package on every check, every `lane integrate` and every repair round — for a
+	// cache-poisoning risk nothing here ever recorded, and which `ci.yml`'s own bare `pnpm typecheck`
+	// never took (#8275). And it does not use `--filter=...[origin/main]`, which diffs against the
+	// ref itself rather than the merge-base and so selects every package on any branch behind main
+	// (#8273 review round 1). A checkout too shallow to hold a merge base degrades to every package,
+	// the fail-safe direction.
 	"codeValidators": [
-		{ "command": ["pnpm", "exec", "turbo", "run", "typecheck", "--filter=...[origin/main]"] },
+		{ "command": ["pnpm", "typecheck:affected"] },
 		{ "command": ["pnpm", "lint:worktree"] }
 	],
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1899,9 +1899,9 @@ Per surface:
   another tree's answer three times in one session (#4106) and recurred on the review side (#4887)
   — but what a validator does about a build cache is the repo's own declaration, since turbo's flags
   are a hard error to a bare `tsc` (#6015). Nothing is compiled in for a repo to inherit: phoenix
-  declares `pnpm exec turbo run typecheck --filter=...[origin/main]` and `pnpm lint:worktree` in its
-  own `.fabrika.jsonc` like anyone else, and reads the content-addressed cache rather than
-  re-deriving what its key already holds (#8275). A
+  declares `pnpm typecheck:affected` and `pnpm lint:worktree` in its own `.fabrika.jsonc` like
+  anyone else, and reads the content-addressed cache rather than re-deriving what its key already
+  holds (#8275). A
   repo with no list — declared empty, or never declared at all — has nothing to run, which refuses
   `11`, UNKNOWN naming which of the two it was — never green, and never the `VALIDATION_RED` that
   says the code failed.
@@ -2089,7 +2089,7 @@ surface that ran, so a file another surface would have read counts as uncovered 
 
 ```
 $ fabrika build check --surface code
-{"verdict":"green","surface":"code","tree":"/private/var/<redacted>/build-4312","ran":["pnpm exec turbo run typecheck --filter=...[origin/main]","pnpm lint:worktree"],"unvalidated":["README.md","scripts/deploy.sh"]}
+{"verdict":"green","surface":"code","tree":"/private/var/<redacted>/build-4312","ran":["pnpm typecheck:affected","pnpm lint:worktree"],"unvalidated":["README.md","scripts/deploy.sh"]}
 ```
 
 `ran` echoes whatever `codeValidators` resolved to, one `argv.join(" ")` per validator; the two

--- a/claude-plugins/fabrika/skills/build/references/code.md
+++ b/claude-plugins/fabrika/skills/build/references/code.md
@@ -2,8 +2,8 @@
 
 Compiled, tested text. `fabrika build check` runs the commands this repo declares under
 `.fabrika.jsonc`'s `codeValidators` in this tree — in phoenix, the pair it declares there,
-`pnpm exec turbo run typecheck --filter=...[origin/main]` and `pnpm lint:worktree`. A repo that
-declares none refuses UNKNOWN rather than running someone else's script names.
+`pnpm typecheck:affected` and `pnpm lint:worktree`. A repo that declares none refuses UNKNOWN
+rather than running someone else's script names.
 
 - **Match the surrounding code's idiom** — comment density, naming, bracket style. A diff that
   reads as a different author is a defect before it is a style choice.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -113,16 +113,25 @@ pre-push:
   parallel: false
   commands:
     typecheck:
-      # tsc over the packages this push changed vs origin/main plus their dependents, via
-      # turbo's `...[<commit>]` filter microsyntax. A push touching no package selects
-      # nothing and exits 0 — that subsumes the hand-rolled docs-only fast path this leg
-      # used to carry (#3130), so it is gone. Cache hits replay out of the shared
-      # `.turbo/cache` (turbo redirects a linked worktree to the main worktree's cache), so
-      # a package another lane already typechecked costs nothing here.
+      # tsc over the packages this push changed plus their dependents, via the root
+      # `typecheck:affected` script — turbo's `--affected`, anchored to the MERGE-BASE of
+      # `origin/main` and HEAD. A push touching no package selects nothing and exits 0, which
+      # subsumes the hand-rolled docs-only fast path this leg used to carry (#3130), so it is
+      # gone. Cache hits replay out of the shared `.turbo/cache` (turbo redirects a linked
+      # worktree to the main worktree's cache), so a package another lane already typechecked
+      # costs nothing here.
       #
-      # Fail-SAFE on an unusable base: turbo needs everything between base and head present
-      # in the checkout, and on a too-shallow one considers ALL packages changed — so a
-      # missing `origin/main` degrades to the whole-repo run, never to a skip.
+      # The merge-base is the whole point, and a plain `--filter=...[origin/main]` does NOT get
+      # it: that microsyntax diffs against the ref itself, so once main moves ahead — the
+      # ordinary shape here — everything main landed reads as this branch's change. Measured on
+      # a markdown-only branch 40 commits behind: 24 packages / 33 typecheck tasks, against 1
+      # package / 0 tasks from the merge-base (#8273 review round 1).
+      #
+      # Fail-SAFE on an unusable base: `--affected` sets turbo's `allow_unknown_objects`
+      # (turborepo v2.10.3 `crates/turborepo-scope/src/filter.rs`), so a checkout too shallow to
+      # hold a merge base degrades to the whole-repo run, never to a skip — measured at 24
+      # packages / 33 tasks against a base with no merge base. An `origin/main` that does not
+      # resolve at all is a turbo error, which blocks the push rather than passing it.
       use_stdin: true
       run: |
         [ -t 0 ] || cat >/dev/null   # git's pushed-ref list — see the pre-push note (#6172)
@@ -130,7 +139,7 @@ pre-push:
           echo "typecheck: no pnpm on PATH (stripped-PATH/lean worktree); skipping local pre-push typecheck — CI is the authority" >&2
           exit 0
         }
-        pnpm exec turbo run typecheck --filter='...[origin/main]'
+        pnpm typecheck:affected
 
 # `git worktree add` fires post-checkout, so this provisions a fresh worktree's deps —
 # node_modules is gitignored and per-checkout, so a worktree is otherwise dead-on-arrival

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -106,19 +106,23 @@ pre-commit:
 # the pre-push hook's stdin; without `use_stdin` lefthook hands the leg a fresh already-closed
 # pipe and leaves git's own pipe open-but-unread for the hook's whole run, so nothing under this
 # hook ever consumes what git wrote. The drain leads the body — ahead of the toolchain-absent
-# and docs-only skips — so no exit path can leave those bytes unread. It is `[ -t 0 ]`-guarded
+# skip — so no exit path can leave those bytes unread. It is `[ -t 0 ]`-guarded
 # because `lefthook run pre-push` by hand hands the leg a terminal, and an unguarded `cat` would
 # sit there waiting for a human to type EOF.
 pre-push:
   parallel: false
   commands:
     typecheck:
-      # tsc across the workspace (the same `pnpm typecheck` CI runs); a type error fails
-      # closed and blocks the push. Docs-only fast-path (#3130): a push whose diff vs
-      # origin/main touches ONLY non-code paths (markdown/docs) has nothing tsc checks, so
-      # it skips the whole-repo run. Fail-SAFE: any changed path not recognized as docs — or
-      # a diff that can't be computed (origin/main unfetched) — runs the full typecheck, so a
-      # code change is NEVER skipped. Toolchain-absence still fails open.
+      # tsc over the packages this push changed vs origin/main plus their dependents, via
+      # turbo's `...[<commit>]` filter microsyntax. A push touching no package selects
+      # nothing and exits 0 — that subsumes the hand-rolled docs-only fast path this leg
+      # used to carry (#3130), so it is gone. Cache hits replay out of the shared
+      # `.turbo/cache` (turbo redirects a linked worktree to the main worktree's cache), so
+      # a package another lane already typechecked costs nothing here.
+      #
+      # Fail-SAFE on an unusable base: turbo needs everything between base and head present
+      # in the checkout, and on a too-shallow one considers ALL packages changed — so a
+      # missing `origin/main` degrades to the whole-repo run, never to a skip.
       use_stdin: true
       run: |
         [ -t 0 ] || cat >/dev/null   # git's pushed-ref list — see the pre-push note (#6172)
@@ -126,18 +130,7 @@ pre-push:
           echo "typecheck: no pnpm on PATH (stripped-PATH/lean worktree); skipping local pre-push typecheck — CI is the authority" >&2
           exit 0
         }
-        CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null) || CHANGED=""
-        # NON-DOC = changed paths that are NOT markdown/docs. Empty NON-DOC (with a non-empty
-        # diff) ⇒ docs-only ⇒ skip. Tested via empty-output, not `grep -qv`: the `-q`+`-v`
-        # combo misbehaves under some grep variants (ugrep returns non-zero even with
-        # non-matching lines), which the empty-output form sidesteps portably.
-        NONDOC=""
-        [ -n "$CHANGED" ] && NONDOC=$(printf '%s\n' "$CHANGED" | grep -vE '\.(md|mdx|txt)$')
-        if [ -n "$CHANGED" ] && [ -z "$NONDOC" ]; then
-          echo "typecheck: docs-only push (every path changed vs origin/main is markdown/docs); skipping whole-repo typecheck — CI is the authority" >&2
-          exit 0
-        fi
-        pnpm typecheck
+        pnpm exec turbo run typecheck --filter='...[origin/main]'
 
 # `git worktree add` fires post-checkout, so this provisions a fresh worktree's deps —
 # node_modules is gitignored and per-checkout, so a worktree is otherwise dead-on-arrival

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"build": "turbo run build",
 		"deploy": "turbo run deploy",
 		"typecheck": "turbo run typecheck",
+		"typecheck:affected": "TURBO_SCM_BASE=origin/main turbo run typecheck --affected",
 		"test": "turbo run test",
 		"lint": "case \"$PWD\" in */.claude/worktrees/*) pnpm run lint:worktree ;; *) biome check . ;; esac",
 		"lint:worktree": "node scripts/biome-worktree.mjs check",

--- a/packages/fabrika-cli/src/config/keys/code-validators.ts
+++ b/packages/fabrika-cli/src/config/keys/code-validators.ts
@@ -2,10 +2,10 @@
  * `codeValidators` — the repo's own commands that compile and lint its code.
  *
  * Declared rather than compiled in, because the script names and the flags they take are the repo's
- * own: `lint:worktree` is a phoenix script name, and turbo's flags — the cache-bypass one, the
- * `--filter` phoenix now scopes its typecheck with — are ones a bare `tsc` rejects outright (#6015).
- * An argv array rather than a command line, and the `command` key `workflowValidators` already uses,
- * so the file has one grammar for "a command fabrika spawns".
+ * own: `typecheck:affected` and `lint:worktree` are phoenix script names, and the turbo flags they
+ * wrap — a cache-bypass, a changed-package selection — are ones a bare `tsc` rejects outright
+ * (#6015). An argv array rather than a command line, and the `command` key `workflowValidators`
+ * already uses, so the file has one grammar for "a command fabrika spawns".
  *
  * No `reads`. On the workflow surface that field is what makes a green checkable per file, because
  * a declared guard opens a fixed set it names; a code validator is handed no paths and compiles the

--- a/turbo.json
+++ b/turbo.json
@@ -12,9 +12,10 @@
 	// web#dev:worker). A fourth persistent task in the repo has to raise this number with it.
 	"concurrency": "4",
 	// 25 package tsconfigs `extends` the root one, but turbo hashes it into no package and
-	// `--filter=...[origin/main]` — what `.fabrika.jsonc` declares for `build check --surface code`
-	// — then selects `//` alone and plans 0 typecheck tasks on a root-tsconfig-only change (#8275).
-	// Listing it here makes every package changed for that filter and part of every task's hash.
+	// the changed-package selection behind `pnpm typecheck:affected` — what `.fabrika.jsonc` declares
+	// for `build check --surface code`, and what the pre-push hook runs — then selects `//` alone and
+	// plans 0 typecheck tasks on a root-tsconfig-only change (#8275). Listing it here makes every
+	// package changed for that selection and part of every task's hash.
 	"globalDependencies": ["tsconfig.json"],
 	"tasks": {
 		"dev": {


### PR DESCRIPTION
The pre-push `typecheck` leg ran `pnpm typecheck` — every package in the workspace — behind a
hand-rolled docs-only fast path. Round 1 replaced that with `--filter='...[origin/main]'`, and the
review caught that this filter diffs against `origin/main` **itself**, not against the merge-base
with HEAD. On any branch behind main — the ordinary pre-push shape — everything main landed reads as
this branch's change, so the scoping delivered nothing.

Both callers now run one root script:

```
"typecheck:affected": "TURBO_SCM_BASE=origin/main turbo run typecheck --affected"
```

`--affected` is merge-base-anchored by construction: it builds its selector with `merge_base: true`
and `include_dependents: true`
([turborepo v2.10.3 `crates/turborepo-scope/src/filter.rs`](https://github.com/vercel/turborepo/blob/v2.10.3/crates/turborepo-scope/src/filter.rs)),
which reaches a `--merge-base` diff in
[`crates/turborepo-scm/src/git.rs`](https://github.com/vercel/turborepo/blob/v2.10.3/crates/turborepo-scm/src/git.rs).
The single-ref filter form does not: `...[<ref>]` parses to `merge_base: false`
([`crates/turborepo-scope/src/target_selector.rs`](https://github.com/vercel/turborepo/blob/v2.10.3/crates/turborepo-scope/src/target_selector.rs)),
which is the defect. `TURBO_SCM_BASE` names the base because `--affected`'s default resolution is a
**local** `main` branch (`default_base_ref` in that same `git.rs`), and a lane worktree's local
`main` lags the remote. The toolchain-absent skip and the stdin drain are unchanged.

### The stale-branch table

Every row is the same repo, turbo 2.10.3, from this linked worktree. "old" is
`--filter='...[origin/main]'`, "new" is the shipped `--affected`.

| tree | old: packages / tasks | new: packages / tasks |
| --- | --- | --- |
| clean tree, HEAD == `origin/main` | `[]` / 0 | `[]` / 0 |
| markdown-only commit, branch **level** with `origin/main` | `["//"]` / 0 | `["//"]` / 0 |
| markdown-only commit, branch **40 behind** `origin/main` | all 24 / 33 | `["//"]` / **0** |
| one `apps/tuval` file, branch **40 behind** `origin/main` | all 24 / 33 | `["//","@kampus/tuval"]` / **2** |
| markdown-only commit, branch **5 behind** `origin/main` | `["//","@kampus/tuval"]` / 2 | `["//"]` / 0 |

The level rows agree; every stale row is where the old shape over-selected. The 5-behind row shows
the size of the over-selection is just whatever main happened to land — it was 2 packages there and
all 24 forty commits back.

`pnpm exec lefthook run pre-push` on the 40-behind markdown-only branch: exit 0, `Packages in scope:
//`, `Tasks: 0 successful, 0 total`, no `tsc` started, turbo 86ms, hook 1.14s.

### Degrading when there is no merge base

Both merge-base shapes were tested against a tree with no merge base against `origin/main` (the
shallow-checkout class):

| shape | exit | selection |
| --- | --- | --- |
| `--filter='...[origin/main...HEAD]'` | 1, `Unable to query SCM … no merge base` | nothing runs |
| `--affected` | 0 | all 24 / 33 |

`--affected` sets `allow_unknown_objects: true`, which that `git.rs` reads as "treat everything as
changed" — the fail-safe direction the leg's comment promises. The range-filter form does not, which
is why it is not what shipped. An `origin/main` that does not resolve at all errors under both, and
that blocks the push rather than passing it.

### Package selection, worktree vs plain shell

Package lists from `--dry=json` at the repo root, plain shell:

| case | packages |
| --- | --- |
| (a) clean tree at `origin/main` | `[]` |
| (b) one file under `apps/tuval` | `["@kampus/tuval"]` |
| (c) one file under `packages/authz` | `["@kampus/admin-grant","@kampus/authz","@kampus/founder-seed","@kampus/fts-backfill","@kampus/preview-seed","@kampus/web"]` |

On this PR's own head, `pnpm exec lefthook run pre-push` printed a `Packages in scope` list
byte-identical to the plain-shell `--dry=json` list for the same tree (all 24 — this branch carries
`pnpm-lock.yaml`, `package.json` and `turbo.json` changes, so all-24 is the correct answer here, not
a fallback). The environment-variable half is disclosed below.

### Before / after, re-measured on a stale branch

Both runs are `pnpm exec lefthook run pre-push` on the same branch: one file changed under
`apps/tuval`, branch 40 commits behind `origin/main`. `uptime` at the start of each.
`TURBO_CACHE_DIR` pointed at a fresh directory per run so neither side replayed the other's work.

| | uptime at start | turbo tasks | wall clock |
| --- | --- | --- | --- |
| old (`--filter='...[origin/main]'`) | `13:15 up 22 days, 9:45, load averages: 22.85 15.26 26.28` | 23 planned, 0 cached, 32.696s | **33.76s** |
| new (`typecheck:affected`) | `13:15 up 22 days, 9:45, load averages: 5.87 11.84 25.44` | 1 planned, 0 cached, 8.738s | **9.55s** |

Round 1's headline (28.50s → 6.97s) was measured on a branch level with `origin/main`, where the old
shape happened to work. On a stale branch the old shape pays for the whole workspace, which is the
table above.

### Fail-closed, and the rest

- Deliberate `const probeBad: number = "not a number"` in `apps/tuval/src/config.ts`: exit 1, naming
  `src/config.ts(206,7): error TS2322: Type 'string' is not assignable to type 'number'.`
- `.github/workflows/ci.yml` is byte-identical to `main` — same blob sha,
  `b4b8d361c4fc2f9ca3dc27936b812a9ec810e09b`.
- `globalDependencies: ["tsconfig.json"]` still forces all 24 packages under `--affected`, so #8275's
  wiring is unaffected — verified with a root-`tsconfig.json`-only change.

### The same defect in `.fabrika.jsonc`

#8275 landed `--filter=...[origin/main]` in `codeValidators` on `epic/8264`, and it has the identical
over-selection. A validator is argv with no environment, so `--affected` alone there would silently
anchor to a stale local `main`; both callers therefore share the one `typecheck:affected` script,
which carries the base. `build check --surface code` is green on this tree running it.

Part of #8273

## Deviations

- **Out-of-scope change** — **Said:** #8273 names `lefthook.yml`. **Did:** also changed
  `.fabrika.jsonc`'s `codeValidators`, added the root `typecheck:affected` script, and updated the
  four surfaces that quote the old argv (`turbo.json`,
  `claude-plugins/fabrika/skills/build/contract.md`, `.../references/code.md`,
  `packages/fabrika-cli/src/config/keys/code-validators.ts`). **Why:** the review round named the
  `.fabrika.jsonc` copy as carrying the same defect and authorized fixing it here; the base has to
  live in a script because a validator takes no environment, and `build check --surface code` prints
  the validator argv in its `ran` field, so the docs quoting it are pinned output. **Disposition:**
  stated here. It brings `.fabrika.jsonc` and `claude-plugins/` into the diff, so this PR now touches
  governed roots where round 1 did not.
- **Governing-ADR departure** — **Said:** acceptance criterion 1 requires the leg to end in
  `pnpm exec turbo run typecheck --filter='...[origin/main]'`. **Did:** the leg ends in
  `pnpm typecheck:affected`. **Why:** criterion 7, appended by the round-1 review, requires a stale
  branch to select what a level branch selects, and criterion 1's literal command is exactly what
  cannot do that. **Disposition:** stated here; criterion 1's *intent* (one command, no docs-only
  filter — `grep -c "grep -vE" lefthook.yml` is `0`) is met.
- **Declined guidance** — **Said:** verify `--affected` in the turbo source at the pinned version
  under `node_modules`. **Did:** grounded against upstream `vercel/turborepo` at tag `v2.10.3`, cited
  by file above, cross-checked against strings in the installed binary (`TURBO_SCM_BASE`,
  `--merge-base`, `no merge base`, `task graph pruned for --affected`) and against live measurement
  at that version. **Why:** `node_modules/turbo` ships a stripped Rust binary and a JS launcher shim;
  there is no Rust source in the install to read. **Disposition:** stated here.
- **Declined guidance** — **Said:** criterion 2 asks for the `--dry=json` comparison run with the
  worktree gitdir environment variable set explicitly. **Did:** ran the plain-shell half, and
  compared the real hook's `Packages in scope` against the plain `--dry=json` list on this head.
  **Why:** this agent's sandbox refuses any command that sets that variable; the same refusal was
  disclosed and accepted in round 1. **Disposition:** stated here.
