### PR TITLE
feat: portability guard: fabrika guard portability-guard check, its CI job and the review-skill wiring

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -17,6 +17,14 @@
 
 	"capClearAuthors": ["@usirin", "@notusirin", "@cansirin"],
 
+	// The names that resolve only in this repository, which fabrika's own shipped text may not
+	// carry (`fabrika guard portability-guard check`). The shipped default is the empty list and
+	// turns nothing off — the guard's four other rules never read this key. phoenix names its org,
+	// its repo, its products and the one app directory its skills used to point at.
+	"portability": {
+		"repoNames": ["phoenix", "kamp-us", "Tuval", "sözlük", "apps/web"]
+	},
+
 	// Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `campaign
 	// state`). It narrows the repo's collaborator ACL and never replaces it: an entry here still
 	// needs `write` or above on the repo (ADR 0294). Founder-declared 2026-08-20 on #6811 — the

--- a/.fabrika.schema.json
+++ b/.fabrika.schema.json
@@ -221,6 +221,21 @@
 			},
 			"minItems": 1
 		},
+		"portability": {
+			"type": "object",
+			"description": "What `fabrika guard portability-guard check` treats as this repository's own. `repoNames` are the product, org and directory names fabrika's shipped text may not carry; they are matched whole and case-insensitively. Absent or empty means this repo keeps no names of its own out — the guard's four other rules are unaffected.",
+			"properties": {
+				"repoNames": {
+					"type": "array",
+					"description": "Names that resolve only in this repository.",
+					"items": {
+						"type": "string",
+						"minLength": 1
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"roadmapFile": {
 			"type": "string",
 			"description": "The roadmap file carrying the `## Campaigns` focus table, repo-relative.",

--- a/.github/workflows/portability-guard.yml
+++ b/.github/workflows/portability-guard.yml
@@ -1,0 +1,45 @@
+name: portability-guard
+
+# CI gate: nothing under claude-plugins/fabrika/ or packages/fabrika-cli/src/ may carry a
+# reference that only resolves in this repository. fabrika installs into repositories that
+# are not phoenix, and every issue number, ADR number, .decisions/ link or product name
+# left in a skill or a docblock is a pointer an adopter cannot follow. Nothing else catches
+# one, and every lane that edits a skill adds more — which is how it reached two thousand
+# lines unnoticed (#8281). Whole-tree, so it runs on `push: main` too
+# (.patterns/repo-wide-gates-run-on-main.md), and it fails closed if it scans zero files
+# (ADR 0092).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: check fabrika's shipped text carries no repo-bound reference
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Non-zero on three distinct seats, so a red says which thing happened: 12 a reference
+      # was found, a ceiling was exceeded or a floor row sits above its count; 7 zero scope
+      # or an unusable allow-list (fail-closed, ADR 0092); 11 a read failed so the verdict is
+      # UNKNOWN. The report is on stderr, with ::error annotations beside it. The allow-list
+      # is portability-guard.config.json — `unmigrated` is the sweep floor and only shrinks.
+      - name: Check fabrika's shipped text carries no repo-bound reference
+        run: node packages/fabrika-cli/src/bin.ts guard portability-guard check

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -116,6 +116,20 @@ to each class's slice: code → [rubrics/code.md](rubrics/code.md) · doc →
 any prose surface: apply **fabrika's** shared writing rubric skill verbatim, never v1's copy; the
 doc rubric's prose-craft line is the fallback until it lands.
 
+**A diff touching fabrika's own two trees owes the portability check, in the doc class and the skill
+class alike.** When any changed file sits under `claude-plugins/fabrika/` or
+`packages/fabrika-cli/src/`, run it and read the verdict into those classes:
+
+```bash
+fabrika guard portability-guard check
+```
+
+A red is a FAIL finding, never a note. The text fabrika ships installs into repositories that are
+not this one, so a ticket number, a decision-record number, a decision-corpus path, a hosted issue
+or pull-request URL, or a name this repo declared as its own is a pointer the reader there cannot
+follow. The guard's allow-list is a floor that only shrinks: a diff that raises a ceiling to make
+room for a new reference **is** the finding, whatever the sentence around it says.
+
 <!-- anchor: STAGE-ONLY-UNDER-THE-ALLOCATED-PATH --> **A diff too large for one read is staged under
 the path this verb allocates, and never under a name you chose.** The session scratchpad is shared
 by every lane in the session, so a generic `diff.txt` there is a name a concurrent lane writes too:

--- a/claude-plugins/fabrika/skills/review/rubrics/doc.md
+++ b/claude-plugins/fabrika/skills/review/rubrics/doc.md
@@ -25,6 +25,13 @@ Read the CI-at-head result; do not re-derive them.
   still speaks in the present tense; an `accepted` ADR whose body says "proposal").
 - **Claims trace.** Falsifiable claims about platform/runtime/dependency behavior cite source or
   a real measurement (CLAUDE.md's grounding rule); an intuition stated as fact is a finding.
+- **No reference only this repo can resolve, in fabrika's own text.** On a diff under
+  `claude-plugins/fabrika/` or `packages/fabrika-cli/src/`, run
+  `fabrika guard portability-guard check` and take a red as a finding: a ticket number, a
+  decision-record number in either spelling, a decision-corpus path, a hosted issue URL and a name
+  the repo declared as its own all resolve nowhere else, and the docs fabrika ships are read
+  elsewhere. Raising an allow-list ceiling to fit a new one is itself the finding — that floor only
+  shrinks.
 - **Prose craft.** Plain words, short sentences, nothing a reader must re-read to parse; once
   fabrika's shared writing rubric skill lands, apply it verbatim instead of this line.
 

--- a/claude-plugins/fabrika/skills/review/rubrics/skill.md
+++ b/claude-plugins/fabrika/skills/review/rubrics/skill.md
@@ -43,6 +43,13 @@ and capability set — and its contract to `cli-interface-convention.md` Part 2'
 test. A restated sibling behavior (rather than an imported module or a cited section) is drift
 waiting to happen; name it.
 
+**No step, rationale or exit-code note may point at something only this repo can resolve.** Run
+`fabrika guard portability-guard check` on any diff under `claude-plugins/fabrika/` or
+`packages/fabrika-cli/src/` and take a red as a finding: a skill installed elsewhere whose refusal
+rationale names a ticket the reader cannot open teaches nothing, and the fix is a self-contained
+sentence, not a shorter pointer. The guard's floor only shrinks, so a diff that lifts a ceiling to
+admit a new reference is the finding rather than the remedy.
+
 **Every contract read the diff instructs is a section read** (ADR
 [0296](../../../../../.decisions/0296-contracts-are-read-by-section.md)). Skill text and any
 spawn prompt in the diff point at

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -38,6 +38,17 @@ login before any request. A credential that resolves nowhere is a refusal naming
 never an anonymous call. There is no `gh` prerequisite: the package reaches api.github.com over HTTP
 ([`src/io/gh-api.ts`](./src/io/gh-api.ts)), and `guard no-gh check` keeps it that way on every push.
 
+This package installs into repositories that are not the one it is developed in, so neither its
+source nor the plugin's skills may carry a reference that only resolves here. `guard
+portability-guard check` holds that on every push: it walks `claude-plugins/fabrika/` and
+`packages/fabrika-cli/src/` and reds a ticket number, a decision-record number in either spelling, a
+`.decisions/` path, a hosted issue or pull-request URL, and any name the repo declares under the
+`portability` key of `.fabrika.jsonc`. A markdown heading, a hex colour and a ticket number that is
+test data are not references. The bounded allow-list in `portability-guard.config.json` has two
+buckets, each entry carrying a mandatory `why`: `exempt` is a permanent per-file cap for text that
+is not a portability defect, and `unmigrated` is the sweep floor — one row per sweep unit, and it
+only shrinks, so a ceiling left above the count reds exactly as loudly as a new reference does.
+
 Ordered recipes — installing, credentialing, finding a group and a verb, reading a refusal, running
 from a consumer repo — are in
 [`docs/running-fabrika-in-a-repo.md`](./docs/running-fabrika-in-a-repo.md).

--- a/packages/fabrika-cli/src/config/keys/portability.ts
+++ b/packages/fabrika-cli/src/config/keys/portability.ts
@@ -1,0 +1,62 @@
+/**
+ * `portability` — the names this repository owns, which fabrika's own shipped text may not carry.
+ *
+ * `guard portability-guard check` reds a reference in `claude-plugins/fabrika/**` or
+ * `packages/fabrika-cli/src/**` that only resolves here. Four of its five rules are universal — a
+ * ticket number, a decision-record number, a decision-corpus path, a hosted issue URL — and the
+ * fifth is this list: the product, org and directory names that mean something in this repository
+ * and nothing in the next one.
+ *
+ * The shipped default is the empty list, and that turns nothing off: the other four rules do not
+ * read this key, so a repo that declared no names still gets the guard at full strength. Empty means
+ * "this repo has no names of its own to keep out", which is the honest answer for a fresh adopter
+ * and the wrong one for a repo with products — so a repo with products declares them.
+ */
+
+import {trimmedStrings} from "../entries.ts";
+import type {Decoded, KeyGroup} from "../key-group.ts";
+
+export const PORTABILITY = "portability";
+
+export interface Portability {
+	/** Names matched whole and case-insensitively, wherever they are not part of a longer word. */
+	readonly repoNames: ReadonlyArray<string>;
+}
+
+const decode = (raw: unknown): Decoded<Portability> => {
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+		return {_tag: "Malformed", reason: `\`${PORTABILITY}\` is not an object`};
+	}
+	const {repoNames} = raw as {repoNames?: unknown};
+	if (repoNames === undefined) return {_tag: "Value", value: {repoNames: []}};
+	if (!Array.isArray(repoNames)) {
+		return {_tag: "Malformed", reason: `\`${PORTABILITY}.repoNames\` is not an array`};
+	}
+	const names = trimmedStrings(repoNames);
+	return names === null
+		? {
+				_tag: "Malformed",
+				reason: `\`${PORTABILITY}.repoNames\` holds an entry that is not a non-empty string — expected a product, org or directory name`,
+			}
+		: {_tag: "Value", value: {repoNames: names}};
+};
+
+export const portabilityKey: KeyGroup<Portability> = {
+	key: PORTABILITY,
+	shippedDefault: {repoNames: []},
+	decode,
+	render: (value) => value.repoNames,
+	jsonSchema: {
+		type: "object",
+		description:
+			"What `fabrika guard portability-guard check` treats as this repository's own. `repoNames` are the product, org and directory names fabrika's shipped text may not carry; they are matched whole and case-insensitively. Absent or empty means this repo keeps no names of its own out — the guard's four other rules are unaffected.",
+		properties: {
+			repoNames: {
+				type: "array",
+				description: "Names that resolve only in this repository.",
+				items: {type: "string", minLength: 1},
+			},
+		},
+		additionalProperties: false,
+	},
+};

--- a/packages/fabrika-cli/src/config/registry.ts
+++ b/packages/fabrika-cli/src/config/registry.ts
@@ -18,6 +18,7 @@ import {dependencyReconcilerKey} from "./keys/dependency-reconciler.ts";
 import {docLeakExemptKey} from "./keys/doc-leak-exempt.ts";
 import {governedRootsKey} from "./keys/governed-roots.ts";
 import {cycleDocKey, decisionsDirKey, designHarnessKey, roadmapFileKey} from "./keys/paths.ts";
+import {portabilityKey} from "./keys/portability.ts";
 import {surfaceDispositionsKey} from "./keys/surface-dispositions.ts";
 import {triageFacetsKey} from "./keys/triage-facets.ts";
 import {workflowValidatorsKey} from "./keys/workflow-validators.ts";
@@ -35,6 +36,7 @@ export const KEY_GROUPS: ReadonlyArray<Registration> = [
 	register(designHarnessKey),
 	register(docLeakExemptKey),
 	register(governedRootsKey),
+	register(portabilityKey),
 	register(roadmapFileKey),
 	register(surfaceDispositionsKey),
 	register(triageFacetsKey),

--- a/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/config/schema-verb.unit.test.ts
@@ -49,7 +49,7 @@ describe("reconcile", () => {
 	it("agrees when the committed file matches the assembled schema", () => {
 		const {outcome} = run({write: false, read: {_tag: "Text", text: committed}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\tagrees\t17");
+		expect(outcome.stdout).toContain("schema\tagrees\t18");
 	});
 
 	it("agrees whatever the committed file's whitespace, comparing content not bytes", () => {
@@ -87,7 +87,7 @@ describe("write", () => {
 	it("renders the file from the registry and reports written", () => {
 		const {outcome, saves} = run({write: true, read: {_tag: "Absent"}});
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toContain("schema\twritten\t17");
+		expect(outcome.stdout).toContain("schema\twritten\t18");
 		expect(saves).toHaveLength(1);
 		expect(saves[0]).toBe(committed);
 	});

--- a/packages/fabrika-cli/src/guard/__fixtures__/portability-self-exempt.golden.json
+++ b/packages/fabrika-cli/src/guard/__fixtures__/portability-self-exempt.golden.json
@@ -1,0 +1,10 @@
+{
+	"pins": "The files guard portability-guard check may not scan, as path suffixes in list order. A guard has to spell out what it forbids, so its own source and tests are literal examples of the thing — and the exemption is per file, never a directory, because a guard-directory-wide carve-out would silently drop every other guard from the scan. A file added here is one nothing checks, so the list is pinned rather than merely written.",
+	"suffixes": [
+		"/src/guard/portability.ts",
+		"/src/guard/portability-verb.ts",
+		"/src/guard/portability.unit.test.ts",
+		"/src/guard/portability-verb.unit.test.ts",
+		"/src/guard/portability.golden.test.ts"
+	]
+}

--- a/packages/fabrika-cli/src/guard/command.ts
+++ b/packages/fabrika-cli/src/guard/command.ts
@@ -31,6 +31,7 @@ import {runPatchGuard} from "./patch-verb.ts";
 import {runPathFilterGuard} from "./path-filter-verb.ts";
 import {runPitchGuard} from "./pitch-verb.ts";
 import {runPointerGuard} from "./pointer-verb.ts";
+import {runPortabilityGuard} from "./portability-verb.ts";
 import {runPublishIsolationGuard} from "./publish-isolation-verb.ts";
 import {runReadmeGuard} from "./readme-verb.ts";
 import {runRoadmapGuard} from "./roadmap-verb.ts";
@@ -129,6 +130,33 @@ const noGhGuard = Command.make("no-gh").pipe(
 	Command.withShortDescription("fabrika-cli's source holds no `gh` invocation."),
 	Command.withDescription(
 		"packages/fabrika-cli/src/ must reach GitHub over HTTP and never through the `gh` binary, so that every verb runs from a token alone (ADR 0315).",
+	),
+);
+
+const portabilityCheck = leafCommand(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root}) {
+		yield* emit(
+			yield* runPortabilityGuard({
+				root: Option.getOrNull(root),
+				cwd: process.cwd(),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Red on a reference in fabrika's text that only resolves here."),
+	Command.withDescription(
+		"Walk claude-plugins/fabrika/ and packages/fabrika-cli/src/ and red on any reference that resolves only in the repository fabrika is developed in: a ticket number, a decision-record number in either spelling, a decision-corpus path, a hosted issue or pull-request URL, and any name declared under the `portability` key of the repo config. A markdown heading, a hex colour and a ticket number that is test data (a string literal in a *.test.ts file, or anything under a fixtures directory) are not references. The allow-list at portability-guard.config.json carries two buckets, each entry with a mandatory `why`: `exempt` is a permanent per-file cap, `unmigrated` is the sweep floor and only shrinks, so a ceiling left above the count reds too. Prints the one-line all-clear on stdout; a red puts the report on stderr, with GitHub ::error annotations beside it under Actions. Exits 7 (zero scope: a root walked to nothing, a directory contributed no file, or the allow-list is unusable — fail-closed), 11 (a read failed, so the verdict is UNKNOWN), 12 (a reference was found, a ceiling was exceeded, or a floor row sits above its count). Example: fabrika guard portability-guard check",
+	),
+);
+
+const portabilityGuard = Command.make("portability-guard").pipe(
+	Command.withSubcommands([portabilityCheck]),
+	Command.withShortDescription("fabrika's shipped text carries no reference to one repository."),
+	Command.withDescription(
+		"claude-plugins/fabrika/ and packages/fabrika-cli/src/ install into repositories that are not this one, so every rationale in them must read without a link only this repository can resolve.",
 	),
 );
 
@@ -691,6 +719,7 @@ const guards = [
 	designInventoryGuard,
 	i18nGuard,
 	noGhGuard,
+	portabilityGuard,
 ];
 
 export const guardCommand = Command.make("guard").pipe(

--- a/packages/fabrika-cli/src/guard/portability-verb.ts
+++ b/packages/fabrika-cli/src/guard/portability-verb.ts
@@ -1,0 +1,253 @@
+/**
+ * `guard portability-guard check` — fabrika's own shipped text carries no reference that resolves
+ * only in the repository it is being developed in.
+ *
+ * The verb owns the scope walk, the allow-list read and the fail-closed floors, the way
+ * `./no-gh-verb.ts` does: a scan whose root resolved elsewhere, matched no file, or skipped a whole
+ * group directory is a ZERO_SCOPE red rather than a green over nothing. The matchers and the
+ * ceiling arithmetic stay pure in `./portability.ts`.
+ *
+ * Two configs, and they answer two different questions. `.fabrika.jsonc`'s `portability` key says
+ * which *names* belong to this repository — policy an adopter rewrites. The allow-list at
+ * {@link CONFIG_PATH} is this repository's own ledger of what has not been swept yet, so it lives
+ * outside the two trees the guard scans and never ships with the plugin.
+ */
+
+import {Effect, FileSystem, Option, Path} from "effect";
+import {portabilityKey} from "../config/keys/portability.ts";
+import {readKey} from "../config/read-key.ts";
+import {discoverRepoRoot} from "../delegate/root.ts";
+import {type ReadFailed, readDir, readFile, realPath} from "../io/fs.ts";
+import {parseJson} from "../io/json.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {
+	type Allowance,
+	annotationsFor,
+	type FileScan,
+	isInScope,
+	judge,
+	type PortabilityConfig,
+	renderReport,
+	SCAN_ROOTS,
+	scanFile,
+	type Unit,
+} from "./portability.ts";
+import {
+	annotationsOrNone,
+	clean,
+	emitVerdict,
+	type GuardVerdict,
+	unknown,
+	violation,
+	zeroScope,
+} from "./verdict.ts";
+
+const VERB = "guard portability-guard check";
+
+/** The floor and the carve-outs, at the repo root — outside both scanned trees, on purpose. */
+export const CONFIG_PATH = "portability-guard.config.json";
+
+/**
+ * The directories each scanned root must contribute a file from.
+ *
+ * A walk narrowed to one corner still reports green over the corners it never entered, and a green
+ * from an empty corner reads exactly like a green from swept text.
+ */
+const GROUP_ROOTS = ["claude-plugins/fabrika/skills", "packages/fabrika-cli/src"] as const;
+
+const walk = (
+	fs: FileSystem.FileSystem,
+	path: Path.Path,
+	root: string,
+	dir: string,
+): Effect.Effect<ReadonlyArray<string>, ReadFailed, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const found: Array<string> = [];
+		for (const name of yield* readDir(path.join(root, dir))) {
+			const relative = `${dir}/${name}`;
+			const abs = path.join(root, relative);
+			const stat = yield* Effect.option(fs.stat(abs));
+			if (Option.isNone(stat)) continue;
+			if (stat.value.type === "Directory") {
+				if (name === "node_modules" || name === "dist") continue;
+				found.push(...(yield* walk(fs, path, root, relative)));
+				continue;
+			}
+			if (isInScope(relative)) found.push(relative);
+		}
+		return found.sort();
+	});
+
+const subdirectories = (
+	fs: FileSystem.FileSystem,
+	path: Path.Path,
+	root: string,
+	dir: string,
+): Effect.Effect<ReadonlyArray<string>, ReadFailed, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const dirs: Array<string> = [];
+		for (const name of yield* readDir(path.join(root, dir))) {
+			const stat = yield* Effect.option(fs.stat(path.join(root, dir, name)));
+			if (Option.isNone(stat) || stat.value.type !== "Directory") continue;
+			dirs.push(`${dir}/${name}`);
+		}
+		return dirs.sort();
+	});
+
+/** The parsed allow-list, or the named reason it is unusable. */
+type ConfigRead =
+	| {readonly _tag: "Config"; readonly config: PortabilityConfig}
+	| {readonly _tag: "Malformed"; readonly report: string};
+
+const isAllowance = (entry: unknown): entry is Allowance =>
+	entry !== null &&
+	typeof entry === "object" &&
+	typeof (entry as Allowance).ceiling === "number" &&
+	typeof (entry as Allowance).why === "string" &&
+	(entry as Allowance).why.trim().length > 0;
+
+const isAllowanceMap = (value: unknown): value is Readonly<Record<string, Allowance>> =>
+	value !== null &&
+	typeof value === "object" &&
+	!Array.isArray(value) &&
+	Object.values(value as Record<string, unknown>).every(isAllowance);
+
+const isUnitMap = (value: unknown): value is Readonly<Record<string, Unit>> =>
+	value !== null &&
+	typeof value === "object" &&
+	!Array.isArray(value) &&
+	Object.values(value as Record<string, unknown>).every(
+		(entry) =>
+			isAllowance(entry) &&
+			Array.isArray((entry as Unit).paths) &&
+			(entry as Unit).paths.length > 0 &&
+			(entry as Unit).paths.every((p) => typeof p === "string" && p.trim().length > 0),
+	);
+
+const readConfig = (
+	root: string,
+): Effect.Effect<ConfigRead, ReadFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const parsed = parseJson(yield* readFile(path.join(root, CONFIG_PATH))) as Partial<
+			Record<"exempt" | "unmigrated", unknown>
+		> | null;
+		if (parsed === null || !isAllowanceMap(parsed.exempt) || !isUnitMap(parsed.unmigrated)) {
+			return {
+				_tag: "Malformed",
+				report: `${VERB}: ${CONFIG_PATH} does not parse, or an entry is missing a numeric \`ceiling\`, a non-empty \`why\`, or (under \`unmigrated\`) a non-empty \`paths\` list — the allow-list the floor is judged against is broken, so the verdict is fail-closed.\n`,
+			};
+		}
+		return {_tag: "Config", config: {exempt: parsed.exempt, unmigrated: parsed.unmigrated}};
+	});
+
+const gather = (
+	root: string,
+	repoNames: ReadonlyArray<string>,
+): Effect.Effect<
+	{readonly files: ReadonlyArray<FileScan>; readonly refusal: string | null},
+	ReadFailed,
+	FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const expectedRoot = yield* realPath(root);
+		const paths: Array<string> = [];
+		for (const tree of SCAN_ROOTS) {
+			const resolved = yield* realPath(path.join(root, tree));
+			if (resolved !== path.join(expectedRoot, tree)) {
+				return {
+					files: [],
+					refusal: `the scan root ${tree}/ resolves to ${resolved}, not ${path.join(expectedRoot, tree)} — the walk would scan another tree, or nothing`,
+				};
+			}
+			const found = yield* walk(fs, path, root, tree);
+			if (found.length === 0) {
+				return {files: [], refusal: `the walk of ${tree}/ matched ZERO readable text files`};
+			}
+			paths.push(...found);
+		}
+		for (const group of GROUP_ROOTS) {
+			const missing: Array<string> = [];
+			for (const dir of yield* subdirectories(fs, path, root, group)) {
+				if (!paths.some((p) => p.startsWith(`${dir}/`))) missing.push(dir);
+			}
+			if (missing.length > 0) {
+				return {
+					files: [],
+					refusal: `these directories contributed ZERO scanned files, so the walk does not cover them: ${missing.join(", ")}`,
+				};
+			}
+		}
+		const scans: Array<FileScan> = [];
+		for (const relative of paths) {
+			scans.push({
+				path: relative,
+				hits: scanFile(relative, yield* readFile(path.join(root, relative)), repoNames),
+			});
+		}
+		return {files: scans, refusal: null};
+	});
+
+const judgeTree = (
+	root: string,
+	cwd: string,
+): Effect.Effect<GuardVerdict, ReadFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const names = yield* readKey(cwd, portabilityKey);
+		if (names._tag === "Refused") {
+			return zeroScope(
+				`${VERB}: ${names.reason} — the guard cannot judge a name it never read, so the verdict is fail-closed.\n`,
+			);
+		}
+		const config = yield* readConfig(root);
+		if (config._tag === "Malformed") return zeroScope(config.report);
+		const gathered = yield* gather(root, names.value.repoNames);
+		if (gathered.refusal !== null) {
+			return zeroScope(`${VERB}: ${gathered.refusal}. Fail-closed.\n`);
+		}
+		const verdict = judge({files: gathered.files, config: config.config});
+		const report = renderReport(VERB, verdict);
+		if (verdict._tag === "Clean") return clean(report.trimEnd(), verdict.filesScanned);
+		if (verdict._tag === "ZeroScope") return zeroScope(report);
+		return violation(
+			report,
+			annotationsOrNone(() => annotationsFor(verdict)),
+		);
+	});
+
+export interface PortabilityGuardOptions {
+	/** An explicit repo root, or `null` to walk up from `cwd` for one. */
+	readonly root: string | null;
+	readonly cwd: string;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runPortabilityGuard = (
+	options: PortabilityGuardOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const root =
+			options.root ?? (yield* discoverRepoRoot(options.cwd).pipe(Effect.map((r) => r ?? null)));
+		if (root === null) {
+			return emitVerdict(
+				unknown(
+					`${VERB}: no repo root at or above ${options.cwd} — nothing to scope the scan to, so the verdict is UNKNOWN.\n`,
+				),
+				options.env,
+			);
+		}
+		return emitVerdict(yield* judgeTree(root, options.root ?? options.cwd), options.env);
+	}).pipe(
+		Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+			Effect.succeed(
+				emitVerdict(
+					unknown(
+						`${VERB}: cannot read ${failure.path}: ${failure.reason} — the scan could not be completed, so the verdict is UNKNOWN, never clean.\n`,
+					),
+					options.env,
+				),
+			),
+		),
+	);

--- a/packages/fabrika-cli/src/guard/portability-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/portability-verb.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `guard portability-guard check` — the two-root scope walk, its fail-closed floors and the exit
+ * taxonomy, over a scripted filesystem.
+ *
+ * Each floor is asserted rather than trusted, because each one is a way this guard could go green
+ * having judged nothing: a root that resolves elsewhere, an empty walk, a directory the walk never
+ * entered, and an allow-list nobody could parse.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
+import {VIOLATION, ZERO_SCOPE} from "./codes.ts";
+import {CONFIG_PATH, runPortabilityGuard} from "./portability-verb.ts";
+
+const ROOT = "/repo";
+const PLUGIN = `${ROOT}/claude-plugins/fabrika`;
+const SOURCE = `${ROOT}/packages/fabrika-cli/src`;
+
+const run = (options: FakeFsOptions, env: Record<string, string | undefined> = {}) =>
+	Effect.runPromise(
+		Effect.provide(runPortabilityGuard({root: ROOT, cwd: ROOT, env}), fakeFs(options).layer),
+	);
+
+interface Tree {
+	/** Skill name → file name → contents, under the plugin's `skills/` directory. */
+	readonly skills?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+	/** Verb group → file name → contents, under the package's `src/`. */
+	readonly groups?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+	readonly allowList?: string;
+	readonly repoNames?: ReadonlyArray<string>;
+}
+
+const scriptTree = ({skills = {}, groups = {}, allowList, repoNames}: Tree): FakeFsOptions => {
+	const dirs: Record<string, ReadonlyArray<string>> = {
+		[PLUGIN]: ["skills"],
+		[`${PLUGIN}/skills`]: Object.keys(skills),
+		[SOURCE]: Object.keys(groups),
+	};
+	const directories = [ROOT, PLUGIN, `${PLUGIN}/skills`, SOURCE];
+	const files: Record<string, string> = {
+		[`${ROOT}/${CONFIG_PATH}`]: allowList ?? JSON.stringify({exempt: {}, unmigrated: {}}),
+	};
+	if (repoNames !== undefined) {
+		files[`${ROOT}/.fabrika.jsonc`] = JSON.stringify({portability: {repoNames}});
+	}
+	for (const [group, held] of Object.entries(skills)) {
+		const dir = `${PLUGIN}/skills/${group}`;
+		directories.push(dir);
+		dirs[dir] = Object.keys(held);
+		for (const [name, content] of Object.entries(held)) files[`${dir}/${name}`] = content;
+	}
+	for (const [group, held] of Object.entries(groups)) {
+		const dir = `${SOURCE}/${group}`;
+		directories.push(dir);
+		dirs[dir] = Object.keys(held);
+		for (const [name, content] of Object.entries(held)) files[`${dir}/${name}`] = content;
+	}
+	return {dirs, files, directories};
+};
+
+const swept: Tree = {
+	skills: {build: {"SKILL.md": "Prove the ground, then pick.\n"}},
+	groups: {lane: {"report.ts": "export const report = () => 0;\n"}},
+};
+
+describe("runPortabilityGuard", () => {
+	it("passes a corpus that reads the same in any repository, naming what it walked", async () => {
+		const outcome = await run(scriptTree(swept));
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toContain("clean — 2 file(s)");
+		expect(outcome.stderr).toEqual([]);
+	});
+
+	it("reds a reference no allow-list row covers, with nothing on stdout", async () => {
+		const outcome = await run(
+			scriptTree({...swept, skills: {build: {"SKILL.md": "The lane parked twice (#6037).\n"}}}),
+		);
+		expect(outcome.code).toBe(VIOLATION);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain(
+			"claude-plugins/fabrika/skills/build/SKILL.md:1: #6037",
+		);
+	});
+
+	it("reds a name the repo declared as its own", async () => {
+		const outcome = await run(
+			scriptTree({
+				...swept,
+				skills: {build: {"SKILL.md": "In phoenix the gate runs on push.\n"}},
+				repoNames: ["phoenix"],
+			}),
+		);
+		expect(outcome.code).toBe(VIOLATION);
+		expect(outcome.stderr.join("\n")).toContain("phoenix");
+	});
+
+	it("emits one ::error per finding under Actions, and none outside it", async () => {
+		const dirty = scriptTree({...swept, skills: {build: {"SKILL.md": "per ADR 0092.\n"}}});
+		const annotated = await run(dirty, {GITHUB_ACTIONS: "true"});
+		expect(annotated.stderr.some((line) => line.startsWith("::error file="))).toBe(true);
+		const plain = await run(dirty, {GITHUB_ACTIONS: "false"});
+		expect(plain.stderr.some((line) => line.startsWith("::error"))).toBe(false);
+	});
+
+	it("reds a walk of either root that matched no file rather than passing it", async () => {
+		const noPlugin = await run(
+			scriptTree({groups: {lane: {"report.ts": "export const a = 0;\n"}}}),
+		);
+		expect(noPlugin.code).toBe(ZERO_SCOPE);
+		expect(noPlugin.stderr.join("\n")).toContain("claude-plugins/fabrika/ matched ZERO");
+		const noSource = await run(scriptTree({skills: {build: {"SKILL.md": "clean\n"}}}));
+		expect(noSource.code).toBe(ZERO_SCOPE);
+		expect(noSource.stderr.join("\n")).toContain("packages/fabrika-cli/src/ matched ZERO");
+	});
+
+	it("reds a directory the walk never entered, so a green cannot come from an empty corner", async () => {
+		const outcome = await run(scriptTree({...swept, skills: {...swept.skills, ship: {}}}));
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain("claude-plugins/fabrika/skills/ship");
+	});
+
+	it("reds a root that resolves to another tree", async () => {
+		const outcome = await run({
+			...scriptTree(swept),
+			real: {[SOURCE]: "/elsewhere/src"},
+		});
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain("resolves to /elsewhere/src");
+	});
+
+	it("reds an allow-list entry with no `why`, rather than reading it as a carve-out", async () => {
+		const outcome = await run(
+			scriptTree({
+				...swept,
+				allowList: JSON.stringify({exempt: {"a.md": {ceiling: 1}}, unmigrated: {}}),
+			}),
+		);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain(CONFIG_PATH);
+	});
+
+	it("reds a floor row whose ceiling sits above what the tree carries", async () => {
+		const outcome = await run(
+			scriptTree({
+				...swept,
+				allowList: JSON.stringify({
+					exempt: {},
+					unmigrated: {
+						"plugin-build": {
+							ceiling: 3,
+							why: "cleared by the build sweep child",
+							paths: ["claude-plugins/fabrika/skills/build"],
+						},
+					},
+				}),
+			}),
+		);
+		expect(outcome.code).toBe(VIOLATION);
+		expect(outcome.stderr.join("\n")).toContain("lower the ceiling to 0 or delete the row");
+	});
+});

--- a/packages/fabrika-cli/src/guard/portability.golden.test.ts
+++ b/packages/fabrika-cli/src/guard/portability.golden.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The pin on what `portability-guard` may not scan.
+ *
+ * The self-exempt list is the one place this guard can be widened without any test noticing: a file
+ * added to it is a file nothing checks, and it would read in a diff as a two-line edit. So the list
+ * is committed as a fixture and compared here, and every entry stays a file suffix — a directory
+ * entry would drop every other guard in the group from the scan at once.
+ */
+import {describe, expect, it} from "vitest";
+import {loadGoldenPayload} from "../golden-fixture.ts";
+import {isSelfExempt, selfExemptSuffixes} from "./portability.ts";
+
+const FIXTURE = "./__fixtures__/portability-self-exempt.golden.json";
+
+const pinned = (): ReadonlyArray<string> =>
+	loadGoldenPayload(import.meta.url, FIXTURE).suffixes as ReadonlyArray<string>;
+
+describe("self-exempt list", () => {
+	it("carries exactly the pinned suffixes, in order", () => {
+		expect(selfExemptSuffixes()).toEqual(pinned());
+	});
+
+	it("names a file every time, never a directory", () => {
+		for (const suffix of selfExemptSuffixes()) expect(suffix).toMatch(/\.ts$/);
+	});
+
+	it("exempts the pinned files and nothing beside them in the same directory", () => {
+		for (const suffix of pinned()) expect(isSelfExempt(`packages/fabrika-cli${suffix}`)).toBe(true);
+		expect(isSelfExempt("packages/fabrika-cli/src/guard/no-gh.ts")).toBe(false);
+		expect(isSelfExempt("packages/fabrika-cli/src/guard/portability-config.ts")).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/guard/portability.ts
+++ b/packages/fabrika-cli/src/guard/portability.ts
@@ -1,0 +1,383 @@
+/**
+ * `portability-guard`'s pure half — is there a reference in fabrika's own text that resolves only in
+ * the repository fabrika grew up in?
+ *
+ * fabrika installs into repositories that are not its home. Every issue number, decision-record
+ * number, decision-corpus link and product name left in a skill, a contract or a docblock is a
+ * pointer an adopter cannot follow: the exit-code rationale names a ticket they cannot open and the
+ * step names a product they do not have. Nothing else in the corpus catches one, and every lane that
+ * edits a skill adds more.
+ *
+ * The five matchers below are the whole rule. Three things are deliberately not hits: a markdown
+ * heading (`#` with no digits behind it), a hex colour (`#fff`, `#1a1a1a` — a colour carries letters
+ * or too few digits to be a ticket), and a ticket number that is test *data* — the subject under
+ * test in a `*.test.ts` string literal, or anything under a fixtures directory, where the number is
+ * the input rather than a claim about the world.
+ *
+ * Scope, the fail-closed floor and the allow-list live at the IO boundary in `./portability-verb.ts`;
+ * this module never touches disk and never decides what a scan covered.
+ */
+
+import {type Annotation, atLine} from "./annotate.ts";
+
+/** Which of the five rules a hit broke — the report groups on it and a test names it. */
+export type PatternId = "issue" | "decision-number" | "decision-link" | "url" | "repo-name";
+
+export interface Hit {
+	/** 1-based, so it addresses an editor and a CI annotation directly. */
+	readonly line: number;
+	readonly pattern: PatternId;
+	/** The exact text that matched — what the report shows. */
+	readonly matched: string;
+}
+
+export interface FileScan {
+	readonly path: string;
+	readonly hits: ReadonlyArray<Hit>;
+}
+
+/** A per-file permanent carve-out. `ceiling` is a count, so one more hit in the file still reds. */
+export interface Allowance {
+	readonly ceiling: number;
+	readonly why: string;
+}
+
+/**
+ * One sweep unit's floor: the hit count under `paths` at the guard's landing, plus the reason.
+ *
+ * Keyed per unit rather than per file so that parallel sweeps each edit their own row instead of one
+ * file's neighbouring lines.
+ */
+export interface Unit extends Allowance {
+	/** Repo-relative path prefixes this unit owns. Longest prefix wins, so a catch-all may be a root. */
+	readonly paths: ReadonlyArray<string>;
+}
+
+export interface PortabilityConfig {
+	readonly exempt: Readonly<Record<string, Allowance>>;
+	readonly unmigrated: Readonly<Record<string, Unit>>;
+}
+
+/** The two trees fabrika ships. Everything under them has to read the same in any repository. */
+export const SCAN_ROOTS = ["claude-plugins/fabrika", "packages/fabrika-cli/src"] as const;
+
+/** Text this guard can read. Anything else in the trees is bytes it would only guess at. */
+const TEXT_EXTENSIONS = [
+	".md",
+	".ts",
+	".tsx",
+	".js",
+	".mjs",
+	".json",
+	".jsonc",
+	".yml",
+	".yaml",
+	".txt",
+	".sh",
+] as const;
+
+export const isTextFile = (path: string): boolean =>
+	TEXT_EXTENSIONS.some((extension) => path.endsWith(extension));
+
+/**
+ * The guard's own files, which cannot be scanned by it: a guard must spell out what it forbids, so
+ * every pattern below is a literal example of the thing.
+ *
+ * Per-file by suffix, never a directory — a `src/guard/`-wide exemption would silently drop every
+ * other guard from the scan.
+ */
+const SELF_EXEMPT_SUFFIXES = [
+	"/src/guard/portability.ts",
+	"/src/guard/portability-verb.ts",
+	"/src/guard/portability.unit.test.ts",
+	"/src/guard/portability-verb.unit.test.ts",
+	"/src/guard/portability.golden.test.ts",
+] as const;
+
+export const selfExemptSuffixes = (): ReadonlyArray<string> => SELF_EXEMPT_SUFFIXES;
+
+const normalize = (path: string): string => `/${path.replace(/\\/g, "/").replace(/^\/+/, "")}`;
+
+export const isSelfExempt = (path: string): boolean => {
+	const p = normalize(path);
+	return SELF_EXEMPT_SUFFIXES.some((suffix) => p.endsWith(suffix));
+};
+
+export const isInScope = (path: string): boolean => {
+	const p = path.replace(/\\/g, "/");
+	if (isSelfExempt(p)) return false;
+	if (!isTextFile(p)) return false;
+	return SCAN_ROOTS.some((root) => p === root || p.startsWith(`${root}/`));
+};
+
+/**
+ * A ticket number: `#` and two to six digits, ending on a non-word character.
+ *
+ * Two digits minimum keeps `#1` in a sentence out; the trailing word boundary is what leaves a hex
+ * colour alone, because `#1a1a1a` puts a letter where the boundary has to be. A markdown heading
+ * needs no rule at all — `## What` carries no digits.
+ */
+const ISSUE = /#\d{2,6}\b/g;
+
+/** A decision record by number, in the bare and the linked spelling alike. */
+const DECISION_NUMBER = /\bADRs?[\s-]+\[?\d{3,4}\b/g;
+
+/** A path into a decision corpus — a directory only the repository that keeps it can resolve. */
+const DECISION_LINK = /\.decisions\//g;
+
+/** A hosted issue or pull-request URL, whoever owns the repository it names. */
+const URL_REF = /github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\//g;
+
+const REASONS: Readonly<Record<PatternId, string>> = {
+	issue: "an issue or pull-request number — it resolves only in the repository it was filed in",
+	"decision-number":
+		"a decision-record number — the record sits in one repository's own corpus, and the number means something else in the next one",
+	"decision-link": "a path into one repository's decision corpus",
+	url: "a URL into one repository's issues or pull requests",
+	"repo-name": "a name this repository declared as its own under `portability.repoNames`",
+};
+
+export const reasonFor = (pattern: PatternId): string => REASONS[pattern];
+
+/** A declared repo name, matched whole and case-insensitively wherever it is not part of a word. */
+const repoNamePattern = (name: string): RegExp =>
+	new RegExp(
+		`(?<![\\p{L}\\p{N}_])${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![\\p{L}\\p{N}_])`,
+		"giu",
+	);
+
+const isFixtureFile = (path: string): boolean =>
+	/(?:^|\/)(?:__fixtures__|fixtures)\//.test(path.replace(/\\/g, "/"));
+
+const isTestFile = (path: string): boolean => path.replace(/\\/g, "/").endsWith(".test.ts");
+
+/**
+ * The `[start, end)` ranges of one line that sit inside a quoted or templated string.
+ *
+ * Same-line only: a quote that never closes on its line opens nothing, so an apostrophe in prose
+ * cannot swallow the rest of the file — which on a fail-closed gate would be fail-open.
+ */
+const stringSpans = (line: string): ReadonlyArray<readonly [number, number]> => {
+	const spans: Array<readonly [number, number]> = [];
+	for (let i = 0; i < line.length; i++) {
+		const quote = line[i];
+		if (quote !== '"' && quote !== "'" && quote !== "`") continue;
+		let end = -1;
+		for (let j = i + 1; j < line.length; j++) {
+			if (line[j] === "\\") {
+				j++;
+				continue;
+			}
+			if (line[j] === quote) {
+				end = j;
+				break;
+			}
+		}
+		if (end === -1) continue;
+		spans.push([i + 1, end]);
+		i = end;
+	}
+	return spans;
+};
+
+const within = (
+	spans: ReadonlyArray<readonly [number, number]>,
+	index: number,
+	length: number,
+): boolean => spans.some(([start, end]) => index >= start && index + length <= end);
+
+/**
+ * Is this ticket number data rather than a claim? A fixtures directory holds nothing but data, and
+ * inside a test a quoted number is the input the assertion is written against.
+ */
+const isTicketData = (path: string, line: string, index: number, length: number): boolean => {
+	if (isFixtureFile(path)) return true;
+	if (!isTestFile(path)) return false;
+	return within(stringSpans(line), index, length);
+};
+
+/** Every repo-bound reference in one file's text. */
+export const scanFile = (
+	path: string,
+	content: string,
+	repoNames: ReadonlyArray<string>,
+): ReadonlyArray<Hit> => {
+	if (isSelfExempt(path)) return [];
+	const matchers: Array<readonly [PatternId, RegExp]> = [
+		["issue", ISSUE],
+		["decision-number", DECISION_NUMBER],
+		["decision-link", DECISION_LINK],
+		["url", URL_REF],
+		...repoNames.map((name) => ["repo-name", repoNamePattern(name)] as const),
+	];
+	const hits: Array<Hit> = [];
+	const lines = content.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const text = lines[i] ?? "";
+		for (const [pattern, regex] of matchers) {
+			regex.lastIndex = 0;
+			for (const match of text.matchAll(regex)) {
+				const index = match.index ?? 0;
+				if (pattern === "issue" && isTicketData(path, text, index, match[0].length)) continue;
+				hits.push({line: i + 1, pattern, matched: match[0]});
+			}
+		}
+	}
+	return hits.sort((a, b) => a.line - b.line);
+};
+
+/** A row of the allow-list judged against what the scan actually found under it. */
+export interface RowVerdict {
+	readonly key: string;
+	readonly bucket: "exempt" | "unmigrated";
+	readonly ceiling: number;
+	readonly count: number;
+	readonly files: ReadonlyArray<FileScan>;
+}
+
+export type Verdict =
+	| {readonly _tag: "Clean"; readonly filesScanned: number; readonly allowed: number}
+	| {readonly _tag: "ZeroScope"; readonly reason: string}
+	| {
+			readonly _tag: "Violation";
+			readonly filesScanned: number;
+			/** Files carrying a reference that no row of the allow-list covers. */
+			readonly unlisted: ReadonlyArray<FileScan>;
+			/** Rows the scan found more references under than their ceiling allows. */
+			readonly over: ReadonlyArray<RowVerdict>;
+			/** Floor rows whose ceiling now sits above the count — the floor only shrinks. */
+			readonly stale: ReadonlyArray<RowVerdict>;
+	  };
+
+/** The unit owning a path: the longest declared prefix, so a catch-all row may name a whole root. */
+const unitFor = (config: PortabilityConfig, path: string): string | null => {
+	let owner: string | null = null;
+	let length = -1;
+	for (const [key, unit] of Object.entries(config.unmigrated)) {
+		for (const prefix of unit.paths) {
+			const covers = path === prefix || path.startsWith(`${prefix.replace(/\/$/, "")}/`);
+			if (covers && prefix.length > length) {
+				owner = key;
+				length = prefix.length;
+			}
+		}
+	}
+	return owner;
+};
+
+export interface JudgeInput {
+	readonly files: ReadonlyArray<FileScan>;
+	readonly config: PortabilityConfig;
+}
+
+/**
+ * The scan against the allow-list.
+ *
+ * The two buckets differ in one way and it is the point. `exempt` is permanent, so its ceiling is a
+ * cap: fewer references than declared is fine. `unmigrated` is the floor a sweep pays down, so its
+ * ceiling has to *equal* the count — a ceiling left above what the tree carries is a tolerance the
+ * next lane could spend, which is how a ratchet stops ratcheting.
+ */
+export const judge = ({files, config}: JudgeInput): Verdict => {
+	if (files.length === 0) {
+		return {
+			_tag: "ZeroScope",
+			reason: "the scan covered zero files, so a clean verdict would rest on nothing",
+		};
+	}
+	const rows = new Map<string, RowVerdict>();
+	const row = (key: string, bucket: "exempt" | "unmigrated", ceiling: number): RowVerdict => {
+		const existing = rows.get(key);
+		if (existing !== undefined) return existing;
+		const fresh: RowVerdict = {key, bucket, ceiling, count: 0, files: []};
+		rows.set(key, fresh);
+		return fresh;
+	};
+	for (const [key, allowance] of Object.entries(config.exempt))
+		row(key, "exempt", allowance.ceiling);
+	for (const [key, unit] of Object.entries(config.unmigrated)) row(key, "unmigrated", unit.ceiling);
+
+	const unlisted: Array<FileScan> = [];
+	for (const file of files) {
+		if (file.hits.length === 0) continue;
+		const exempt = config.exempt[file.path];
+		const key = exempt !== undefined ? file.path : unitFor(config, file.path);
+		if (key === null) {
+			unlisted.push(file);
+			continue;
+		}
+		const current = rows.get(key);
+		if (current === undefined) {
+			unlisted.push(file);
+			continue;
+		}
+		rows.set(key, {
+			...current,
+			count: current.count + file.hits.length,
+			files: [...current.files, file],
+		});
+	}
+	const judged = [...rows.values()];
+	const over = judged.filter((r) => r.count > r.ceiling);
+	const stale = judged.filter((r) => r.bucket === "unmigrated" && r.count < r.ceiling);
+	if (unlisted.length === 0 && over.length === 0 && stale.length === 0) {
+		return {
+			_tag: "Clean",
+			filesScanned: files.length,
+			allowed: judged.reduce((sum, r) => sum + r.count, 0),
+		};
+	}
+	return {_tag: "Violation", filesScanned: files.length, unlisted, over, stale};
+};
+
+const HIT_CAP = 20;
+
+const hitLines = (file: FileScan): ReadonlyArray<string> =>
+	file.hits
+		.slice(0, HIT_CAP)
+		.map((hit) => `    ${file.path}:${hit.line}: ${hit.matched} — ${reasonFor(hit.pattern)}`)
+		.concat(
+			file.hits.length > HIT_CAP
+				? [`    … and ${file.hits.length - HIT_CAP} more in this file`]
+				: [],
+		);
+
+export const renderReport = (verb: string, verdict: Verdict): string => {
+	if (verdict._tag === "Clean") {
+		return `${verb}: clean — ${verdict.filesScanned} file(s) scanned, ${verdict.allowed} reference(s) under a declared ceiling and none above it.\n`;
+	}
+	if (verdict._tag === "ZeroScope") {
+		return `${verb}: ${verdict.reason}. Fail-closed.\n`;
+	}
+	const lines: Array<string> = [
+		`${verb}: ${verdict.filesScanned} file(s) scanned; the corpus fabrika ships must read the same in any repository, and it does not here:`,
+	];
+	if (verdict.unlisted.length > 0) {
+		lines.push(
+			`  ${verdict.unlisted.length} file(s) carry a reference no allow-list row covers — rewrite the sentence so it stands alone, move the fact into the repository's own config or docs, or drop it:`,
+		);
+		for (const file of verdict.unlisted) lines.push(...hitLines(file));
+	}
+	for (const entry of verdict.over) {
+		lines.push(
+			`  ${entry.bucket} row \`${entry.key}\` carries ${entry.count} reference(s) over a ceiling of ${entry.ceiling} — a ceiling is a count, so a new reference under a listed row still reds:`,
+		);
+		for (const file of entry.files) lines.push(...hitLines(file));
+	}
+	for (const entry of verdict.stale) {
+		lines.push(
+			`  unmigrated row \`${entry.key}\` declares a ceiling of ${entry.ceiling} over ${entry.count} reference(s) — the floor only shrinks, so lower the ceiling to ${entry.count}${entry.count === 0 ? " or delete the row" : ""}.`,
+		);
+	}
+	return `${lines.join("\n")}\n`;
+};
+
+export const annotationsFor = (verdict: Verdict): ReadonlyArray<Annotation> => {
+	if (verdict._tag !== "Violation") return [];
+	const files = [...verdict.unlisted, ...verdict.over.flatMap((entry) => entry.files)];
+	return files.flatMap((file) =>
+		file.hits
+			.slice(0, HIT_CAP)
+			.map((hit) => atLine("error", file.path, hit.line, reasonFor(hit.pattern))),
+	);
+};

--- a/packages/fabrika-cli/src/guard/portability.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/portability.unit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `portability-guard`'s matchers and its ceiling arithmetic.
+ *
+ * Both halves of every rule are pinned: the reference it must catch, and the lookalike it must not.
+ * A guard that reds a markdown heading or a hex colour is one somebody turns off, and a guard that
+ * reds the synthetic ticket number a test asserts against would force the test to stop naming it.
+ */
+import {describe, expect, it} from "vitest";
+import {judge, type PortabilityConfig, renderReport, scanFile} from "./portability.ts";
+
+const PLUGIN = "claude-plugins/fabrika/skills/build/SKILL.md";
+
+const kinds = (path: string, text: string, names: ReadonlyArray<string> = []) =>
+	scanFile(path, text, names).map((hit) => hit.pattern);
+
+describe("scanFile", () => {
+	it("catches a ticket number, in prose and in a code docblock alike", () => {
+		expect(kinds(PLUGIN, "The lane parked twice on this shape (#6037).")).toEqual(["issue"]);
+		expect(
+			kinds("packages/fabrika-cli/src/lane/report.ts", " * See #4312 for the incident."),
+		).toEqual(["issue"]);
+	});
+
+	it("catches a decision-record number in the bare and the linked spelling", () => {
+		expect(kinds(PLUGIN, "Fail-closed per ADR 0092.")).toEqual(["decision-number"]);
+		expect(kinds(PLUGIN, "per ADR [0092](../../../../.decisions/0092-guards.md)")).toEqual([
+			"decision-number",
+			"decision-link",
+		]);
+	});
+
+	it("catches a hosted issue or pull-request URL whoever owns the repository", () => {
+		expect(kinds(PLUGIN, "see https://github.com/some-org/some-repo/issues/12")).toEqual(["url"]);
+		expect(kinds(PLUGIN, "see https://github.com/some-org/some-repo/pull/9")).toEqual(["url"]);
+	});
+
+	it("catches a declared repo name, case-insensitively and only as a whole word", () => {
+		expect(kinds(PLUGIN, "In Phoenix the gate runs on push.", ["phoenix"])).toEqual(["repo-name"]);
+		expect(kinds(PLUGIN, "the phoenixlike shape", ["phoenix"])).toEqual([]);
+		expect(kinds(PLUGIN, "copy lives under apps/web/src", ["apps/web"])).toEqual(["repo-name"]);
+		expect(kinds(PLUGIN, "the sözlük alphabet", ["sözlük"])).toEqual(["repo-name"]);
+	});
+
+	it("leaves a markdown heading and a hex colour alone", () => {
+		expect(kinds(PLUGIN, "## 3 — Read the contract")).toEqual([]);
+		expect(kinds(PLUGIN, "background: #fff; border: #1a1a1a;")).toEqual([]);
+	});
+
+	it("leaves a ticket number that is test data, and still reads the narration around it", () => {
+		const test = "packages/fabrika-cli/src/lane/report.unit.test.ts";
+		expect(kinds(test, '\t\texpect(refsIn("closes #4789")).toEqual([4789]);')).toEqual([]);
+		expect(kinds(test, "\t// the two-marker shape #6691 left behind")).toEqual(["issue"]);
+		expect(
+			kinds("packages/fabrika-cli/src/build/__fixtures__/epic.body.txt", "Part of #4300"),
+		).toEqual([]);
+	});
+
+	it("scans none of its own files, so the guard may spell out what it forbids", () => {
+		expect(kinds("packages/fabrika-cli/src/guard/portability.ts", "ADR 0092 and #6037")).toEqual(
+			[],
+		);
+	});
+
+	it("reports the line a reference sits on", () => {
+		expect(scanFile(PLUGIN, "clean\nclean\ncarrying #4312\n", [])).toEqual([
+			{line: 3, pattern: "issue", matched: "#4312"},
+		]);
+	});
+});
+
+const config = (over: Partial<PortabilityConfig> = {}): PortabilityConfig => ({
+	exempt: {},
+	unmigrated: {},
+	...over,
+});
+
+const file = (path: string, hits: number) => ({
+	path,
+	hits: Array.from({length: hits}, (_, i) => ({
+		line: i + 1,
+		pattern: "issue" as const,
+		matched: "#4312",
+	})),
+});
+
+describe("judge", () => {
+	it("reds a scan that covered nothing rather than calling it clean", () => {
+		expect(judge({files: [], config: config()})._tag).toBe("ZeroScope");
+	});
+
+	it("reds a reference no row covers, naming the file", () => {
+		const verdict = judge({files: [file(PLUGIN, 1)], config: config()});
+		expect(verdict._tag).toBe("Violation");
+		if (verdict._tag !== "Violation") return;
+		expect(verdict.unlisted.map((f) => f.path)).toEqual([PLUGIN]);
+	});
+
+	it("passes a floor row whose count equals its ceiling, and reds one over it", () => {
+		const unmigrated = {
+			"plugin-build": {
+				ceiling: 2,
+				why: "swept later",
+				paths: ["claude-plugins/fabrika/skills/build"],
+			},
+		};
+		expect(judge({files: [file(PLUGIN, 2)], config: config({unmigrated})})._tag).toBe("Clean");
+		expect(judge({files: [file(PLUGIN, 3)], config: config({unmigrated})})._tag).toBe("Violation");
+	});
+
+	it("reds a floor row whose ceiling now sits above the count — the floor only shrinks", () => {
+		const verdict = judge({
+			files: [file(PLUGIN, 1)],
+			config: config({
+				unmigrated: {
+					"plugin-build": {
+						ceiling: 4,
+						why: "swept later",
+						paths: ["claude-plugins/fabrika/skills/build"],
+					},
+				},
+			}),
+		});
+		expect(verdict._tag).toBe("Violation");
+		if (verdict._tag !== "Violation") return;
+		expect(verdict.stale.map((row) => row.key)).toEqual(["plugin-build"]);
+		expect(renderReport("guard portability-guard check", verdict)).toContain(
+			"lower the ceiling to 1",
+		);
+	});
+
+	it("gives a file to the longest matching prefix, so a catch-all row cannot swallow a unit", () => {
+		const verdict = judge({
+			files: [file(PLUGIN, 1)],
+			config: config({
+				unmigrated: {
+					"plugin-build": {
+						ceiling: 1,
+						why: "swept later",
+						paths: ["claude-plugins/fabrika/skills/build"],
+					},
+					"plugin-tail": {ceiling: 1, why: "swept later", paths: ["claude-plugins/fabrika"]},
+				},
+			}),
+		});
+		expect(verdict._tag).toBe("Violation");
+		if (verdict._tag !== "Violation") return;
+		expect(verdict.stale.map((row) => row.key)).toEqual(["plugin-tail"]);
+	});
+
+	it("caps an exempt file rather than ratcheting it, so a permanent row may hold fewer", () => {
+		const exempt = {[PLUGIN]: {ceiling: 3, why: "the manifest says where it is published"}};
+		expect(judge({files: [file(PLUGIN, 1)], config: config({exempt})})._tag).toBe("Clean");
+		expect(judge({files: [file(PLUGIN, 4)], config: config({exempt})})._tag).toBe("Violation");
+	});
+});

--- a/portability-guard.config.json
+++ b/portability-guard.config.json
@@ -1,0 +1,161 @@
+{
+	"$comment": "The bounded allow-list `fabrika guard portability-guard check` judges claude-plugins/fabrika/ and packages/fabrika-cli/src/ against. `exempt` is a permanent per-file cap for text that is not a portability defect. `unmigrated` is the sweep floor: one row per sweep unit, ceiling equal to that unit's reference count when the guard landed, each `why` naming the child that clears it. The floor only shrinks — a ceiling above the count reds as loudly as a count above the ceiling.",
+	"exempt": {
+		"claude-plugins/fabrika/.claude-plugin/plugin.json": {
+			"ceiling": 6,
+			"why": "The plugin manifest's `homepage`/`repository` name where this plugin is published; a published package has to say where it lives."
+		},
+		"packages/fabrika-cli/src/guard/i18n-literal-verb.ts": {
+			"ceiling": 5,
+			"why": "This guard's scan root and config path are this repo's own directories, and they are behaviour rather than prose — moving them onto config is a separate ticket of its own class."
+		},
+		"packages/fabrika-cli/src/guard/fanout.ts": {
+			"ceiling": 16,
+			"why": "The fanned-mutation manifest path is this repo's own directory, read as behaviour rather than written as prose — same class as the workflow literals, moved by its own ticket."
+		},
+		"packages/fabrika-cli/src/config/keys/governed-roots.ts": {
+			"ceiling": 4,
+			"why": "The shipped default governed-root set is this repo's shape, kept as the value a repo overrides rather than as a sentence a reader follows."
+		},
+		"packages/fabrika-cli/src/config/keys/doc-leak-exempt.ts": {
+			"ceiling": 2,
+			"why": "The key's own docblock names the repo whose docs the shipped default was drawn from, as the value's provenance rather than a pointer."
+		}
+	},
+	"unmigrated": {
+		"plugin-build": {
+			"ceiling": 457,
+			"why": "The build skill's text, cleared by #8291, the build sweep child.",
+			"paths": ["claude-plugins/fabrika/skills/build"]
+		},
+		"plugin-ship": {
+			"ceiling": 368,
+			"why": "The ship skill's text, cleared by #8292, the ship sweep child.",
+			"paths": ["claude-plugins/fabrika/skills/ship"]
+		},
+		"plugin-docs": {
+			"ceiling": 801,
+			"why": "The plugin's docs directory, cleared by #8293, the docs sweep child.",
+			"paths": ["claude-plugins/fabrika/docs"]
+		},
+		"plugin-review": {
+			"ceiling": 330,
+			"why": "The two review skills' text, cleared by #8294, the review sweep child.",
+			"paths": ["claude-plugins/fabrika/skills/review", "claude-plugins/fabrika/skills/review-ui"]
+		},
+		"plugin-triage": {
+			"ceiling": 308,
+			"why": "The triage skill's text, cleared by #8295, the triage sweep child.",
+			"paths": ["claude-plugins/fabrika/skills/triage"]
+		},
+		"plugin-governance": {
+			"ceiling": 363,
+			"why": "The governance and front-door skills' text, cleared by #8296, the governance sweep child.",
+			"paths": [
+				"claude-plugins/fabrika/skills/governance",
+				"claude-plugins/fabrika/skills/front-door"
+			]
+		},
+		"plugin-planning": {
+			"ceiling": 269,
+			"why": "The epic planning and plan-gate skills' text, cleared by #8297, the planning sweep child.",
+			"paths": [
+				"claude-plugins/fabrika/skills/plan-epic",
+				"claude-plugins/fabrika/skills/check-epic-plan"
+			]
+		},
+		"plugin-discovery": {
+			"ceiling": 300,
+			"why": "The grilling, wayfinding, graduate and prototyping skills' text, cleared by #8298, the discovery sweep child.",
+			"paths": [
+				"claude-plugins/fabrika/skills/grilling",
+				"claude-plugins/fabrika/skills/wayfinding",
+				"claude-plugins/fabrika/skills/graduate",
+				"claude-plugins/fabrika/skills/prototyping"
+			]
+		},
+		"plugin-operate": {
+			"ceiling": 288,
+			"why": "The operate and heal-ci skills' text, cleared by #8299, the operate sweep child.",
+			"paths": ["claude-plugins/fabrika/skills/operate", "claude-plugins/fabrika/skills/heal-ci"]
+		},
+		"plugin-authoring": {
+			"ceiling": 302,
+			"why": "The build-ui, campaign, adr, glossary and taste-color skills' text, cleared by #8300, the authoring sweep child.",
+			"paths": [
+				"claude-plugins/fabrika/skills/build-ui",
+				"claude-plugins/fabrika/skills/campaign",
+				"claude-plugins/fabrika/skills/adr",
+				"claude-plugins/fabrika/skills/glossary",
+				"claude-plugins/fabrika/skills/taste-color"
+			]
+		},
+		"plugin-tail": {
+			"ceiling": 288,
+			"why": "Everything else the plugin ships — the guide, the README, the agents, the hook manifest and the remaining skills — cleared by #8301, the plugin tail sweep child.",
+			"paths": ["claude-plugins/fabrika"]
+		},
+		"cli-lane": {
+			"ceiling": 586,
+			"why": "The lane group's source, cleared by #8302, the lane sweep child.",
+			"paths": ["packages/fabrika-cli/src/lane"]
+		},
+		"cli-guard": {
+			"ceiling": 649,
+			"why": "The guard group's source, cleared by #8303, the guard sweep child.",
+			"paths": ["packages/fabrika-cli/src/guard"]
+		},
+		"cli-build": {
+			"ceiling": 622,
+			"why": "The build group's source, cleared by #8304, the CLI build sweep child.",
+			"paths": ["packages/fabrika-cli/src/build"]
+		},
+		"cli-review": {
+			"ceiling": 369,
+			"why": "The two review groups' source, cleared by #8305, the CLI review sweep child.",
+			"paths": ["packages/fabrika-cli/src/review", "packages/fabrika-cli/src/review-ui"]
+		},
+		"cli-ship": {
+			"ceiling": 310,
+			"why": "The ship and heal-ci groups' source, cleared by #8306, the CLI ship sweep child.",
+			"paths": ["packages/fabrika-cli/src/ship", "packages/fabrika-cli/src/heal-ci"]
+		},
+		"cli-wire": {
+			"ceiling": 771,
+			"why": "The wire, io, ci and config groups' source, cleared by #8307, the wire sweep child.",
+			"paths": [
+				"packages/fabrika-cli/src/wire",
+				"packages/fabrika-cli/src/io",
+				"packages/fabrika-cli/src/ci",
+				"packages/fabrika-cli/src/config"
+			]
+		},
+		"cli-triage": {
+			"ceiling": 367,
+			"why": "The triage, report, graduate, grill and campaign groups' source, cleared by #8308, the CLI triage sweep child.",
+			"paths": [
+				"packages/fabrika-cli/src/triage",
+				"packages/fabrika-cli/src/report",
+				"packages/fabrika-cli/src/graduate",
+				"packages/fabrika-cli/src/grill",
+				"packages/fabrika-cli/src/campaign"
+			]
+		},
+		"cli-capture": {
+			"ceiling": 647,
+			"why": "The capture, governance, recipe, status and hook groups' source, cleared by #8309, the capture sweep child.",
+			"paths": [
+				"packages/fabrika-cli/src/capture",
+				"packages/fabrika-cli/src/governance",
+				"packages/fabrika-cli/src/recipe",
+				"packages/fabrika-cli/src/status",
+				"packages/fabrika-cli/src/hook"
+			]
+		},
+		"cli-tail": {
+			"ceiling": 664,
+			"why": "The remaining small groups and the top-level modules under src/, cleared by #8310, the CLI tail sweep child.",
+			"paths": ["packages/fabrika-cli/src"]
+		}
+	}
+}


### PR DESCRIPTION
Adds `fabrika guard portability-guard check`, a CI job, and the review-skill wiring, so
nothing under `claude-plugins/fabrika/**` or `packages/fabrika-cli/src/**` may carry a
reference that only resolves in this repository.

The guard walks both trees and reds five things: a ticket number (`#4312`), a
decision-record number in either spelling (`ADR 0092`, `ADR [0092](…)`), a `.decisions/`
path, a hosted issue or pull-request URL, and any name declared under the new
`portability` key of `.fabrika.jsonc` (phoenix declares `phoenix`, `kamp-us`, `Tuval`,
`sözlük`, `apps/web`; the shipped default is an empty list). A markdown heading, a hex
colour, and a ticket number that is test data — a string literal in a `*.test.ts` file, or
anything under a `__fixtures__`/`fixtures` directory — are not references.

Shape follows `guard no-gh`: matchers and ceiling arithmetic pure in
`src/guard/portability.ts`, the scope walk and the fail-closed floors in
`src/guard/portability-verb.ts`, self-exemption by file suffix and never by directory.
Zero scope in either root, a group directory that contributed no file, a root resolving
elsewhere, and an unusable allow-list are all `7`.

The allow-list is `portability-guard.config.json` at the repo root, outside both scanned
trees so it never ships with the plugin. Two buckets, each entry carrying a mandatory
`why`: `exempt` is a permanent per-file cap (the plugin manifest's `homepage`/`repository`
and the four behaviour literals), and `unmigrated` is the sweep floor — one row per sweep
unit of the epic's plan, keyed per unit rather than per file so twenty parallel sweeps do
not edit one file's neighbouring rows, each row naming the child that clears it. The floor
only shrinks: a ceiling left above the count reds exactly as loudly as a new reference.

Today's tree is green at 1,260 files scanned and 9,092 references under a declared
ceiling.

Reviewer's first look: the allow-list ceilings (they are the whole reason CI is green
today), and the `unmigrated` exact-equality rule in `judge` — that is what makes the floor
a ratchet rather than a tolerance.

Fixes #8290

## Deviations

- **Scope narrowing** — **Said:** the criteria name `packages/fabrika-cli/README.md` **or**
  the guard's docblock as the place the rule is written down. **Did:** wrote it in the
  README and left the docblocks to state the module's own shape. **Why:** the criterion is
  an either/or and the README is the surface a consumer reads. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names the guard, its CI job and the review
  wiring. **Did:** also bumped the two pinned key counts in
  `src/config/schema-verb.unit.test.ts` from 17 to 18. **Why:** registering the
  `portability` key group makes the registry eighteen keys, and those two assertions pin
  the count. **Disposition:** stated here.
- **Declined guidance** — **Said:** the epic's resolved question suggests the test-data
  carve-out covers "string literals and fixtures directories in test files". **Did:**
  applied it to the ticket-number rule only, not to the URL rule, so a placeholder
  `github.com/o/r/pull/` in a test still counts against its unit's floor. **Why:** the
  acceptance criterion names `#NNNN` alone, and the sweep children can rewrite such a URL
  to `<owner>/<repo>`, which the matcher does not read. **Disposition:** stated here; the
  affected lines sit inside the landing floor, so nothing reds today.
