### PR TITLE
chore: sweep claude-plugins/fabrika/skills/ship of phoenix-bound references

### DIFF
--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -12,7 +12,7 @@ this PR — **read-only, no local git, ever**. Where a merge queue governs the b
 **enqueued + green** — the queue owns the async merge, so "QUEUED" is where your run ends and
 "merged" is something you *confirm*, never assert. It is the end of *your* run and not of the lane:
 a PR still in the queue is a wait the driver re-reads on a later pass, never a park and never a
-landing (ADR [0313](../../../../.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md)). Where no queue governs it, you land the PR
+landing. Where no queue governs it, you land the PR
 yourself with `ship merge` and success is the **proven** landing. Which of the two you are on is a
 fact `ship scope` prints; it is never a guess.
 
@@ -61,12 +61,12 @@ required namespace, and how the control-plane state is derived, is the verb's se
 
 `scope` printing `control-plane` or `unknown` puts the PR on the approval-aware path — `unknown` is
 control-plane until proven otherwise: all machine gates still apply, plus a deterministic discharge.
-An ADR-only PR is `not-control-plane` and owes no approval; its required `governance` verdict is
-what still gates it (founder ruling, 2026-08-15 on #5531). A repo with **no** `.github/CODEOWNERS`
+A decision-record-only PR is `not-control-plane` and owes no approval; its required `governance`
+verdict is what still gates it. A repo with **no** `.github/CODEOWNERS`
 at the base ref is an empty row set, which classifies `unknown` — so it is held, not waved through:
-a boundary nobody declared is not a declaration that nothing is control-plane (ADR 0220 §4). Both
+a boundary nobody declared is not a declaration that nothing is control-plane. Both
 owner shapes bound the surface: an individual `@login` owner satisfies the gate on its own approval,
-with no team roster involved (#6299).
+with no team roster involved.
 
 ```bash
 fabrika ship cp-approval $pr_number --sha 03135b91
@@ -81,7 +81,7 @@ so the approval is never spent on a head that must move.
 The notice says what has to happen before the approval is solicited; it is not a second outcome, and
 the verb's own emitted outcome stays `stop` on the `behind > 0` branch. So a base-drift diagnostic on
 a `stop` is never reported as `ROUTED-REPAIR` — that token folds `ISSUE.FAIL` and charges a repair
-retry to a lane with no defect in it, which froze three lanes on 2026-08-20 (ADR 0327). Name the
+retry to a lane with no defect in it, which freezes the lane on a repair nobody can make. Name the
 cause when you record it, so the park is one a sweep can read:
 
 ```bash
@@ -117,8 +117,7 @@ passes.** A `pass` on a verdict posted at an *earlier* head is not a refusal it 
 says so on stderr, having proved this head's content digest is the one that verdict bound. What it
 never does is pass a content binding it could not check — that reads `stale`. An `ns review-ui
 routed` line is neither a pass nor a refusal you missed: it is `review-ui` recording that this diff
-moves no pixels, so it owes no verdict (ADR
-[0316](../../../../.decisions/0316-a-gate-records-that-it-owes-no-verdict.md)); it satisfies, and no
+moves no pixels, so it owes no verdict; it satisfies, and no
 other namespace can read that way. The polarity rules, the
 content-digest binding and the whole `blocked` taxonomy are the verb's section
 (`fabrika wire doc-section --heading "ship gate" < <skill-base>/contract.md`).
@@ -134,7 +133,7 @@ not concluded as a discharged floor. Why the floor is a caller verb rather than 
 it refuses on WRONG and not only on MISSING, and the conclusion map are its sections
 (`fabrika wire doc-section --heading "ship floor" < <skill-base>/contract.md`, then
 `--heading "It refuses on WRONG, not only on MISSING"`, then
-`--heading "The check-run mode: pending while nobody has judged this head (#6161)"`).
+`--heading "The check-run mode: pending while nobody has judged this head"`).
 
 ## 4 — CI at the head, and only at the head
 
@@ -154,7 +153,7 @@ stop. `head-moved` → start over at step 1; every answer so far was about a tre
 Exit `20` prints no rollup at all: every check at the head passed and no workflow this repo authors
 produced a run there, so nothing gated the bytes you would merge. Disarm, note that the head carries
 no gate coverage, stop — it is a dropped trigger a human owns, not a `green` with a caveat and not a
-`no-runs` a nudge reaches (#6915).
+`no-runs` a nudge reaches.
 **You never re-run, re-trigger, or locally reproduce a check** — CI's verdict is CI's. Each terminal's
 proof, the `--wait` budget and the nudge's own refusals are their sections
 (`fabrika wire doc-section --heading "ship checks" < <skill-base>/contract.md`, then
@@ -270,7 +269,7 @@ implementation, no review verdict, no flag flip. Every run ends as exactly one o
 **already-merged (idempotent success)** · **QUEUED — enqueued, awaiting the queue** and
 **UNRESOLVED at horizon — still queued, still clean** (the two queue waits: your run ends, the lane
 does not. Neither is a landing — no merge was observed — and neither is a park: both record `WIP`,
-which folds the lane to `ship:queued` for the driver to re-read, ADR 0313) ·
+which folds the lane to `ship:queued` for the driver to re-read) ·
 **landed** (the direct route's, and
 `reconcile`'s — either way it is a landing you *read back*, never one you infer) ·
 **refused — <reason>** (a successful decline: disarmed,
@@ -279,7 +278,7 @@ repair** · **routed to heal-ci** · **routed to review** ·
 **EJECTED — routed to repair** ·
 **UNKNOWN — a read failed** (never rendered as any of the above). The three routings are three
 terminals, not one: repair is work this lane retries, heal-ci and review are waits it cannot, and
-a flat "routed" parked the lane on an approval nobody was waiting on (#6002). A refusal is not a back-off:
+a flat "routed" parks the lane on an approval nobody is waiting on. A refusal is not a back-off:
 it names what was proven; UNKNOWN names what was not. Branch disposition is always "untouched" —
 this skill owns no branch. If any disarm failed, the report carries `merge intent: NOT cleared`.
 A note that routes another lane opens with the fixed first line
@@ -290,10 +289,10 @@ branded reference, no steering prose; the receiver re-fetches from the PR itself
 step is the verb — pass back the `lane`, `root` and `task` its `## Task` section carries, one token
 per terminal above (`ALREADY-MERGED`, `QUEUED`, `LANDED`, `REFUSED`, `AWAITING-CP-APPROVAL`,
 `ROUTED-REPAIR`, `ROUTED-HEAL-CI`, `ROUTED-REVIEW`, `UNRESOLVED`, `EJECTED`, `UNKNOWN`), mapped to a
-lane event in its code, with the PR as the event's evidence (#5736). The routing token names the arm
+lane event in its code, with the PR as the event's evidence. The routing token names the arm
 your note's first line already names — report the one you took, never a bare `ROUTED`, which is the
 reviewer's token and means something else. `<fabrika>` is that same section's `fabrika:` entrypoint,
-the one path this repo's verbs actually run from (#6012):
+the one path this repo's verbs actually run from:
 
 ```bash
 node <fabrika> lane report <lane> --root <root> --task <task> --token LANDED --pr <pr-url>
@@ -302,7 +301,7 @@ node <fabrika> lane report <lane> --root <root> --task <task> --token LANDED --p
 `--task` names which task of the lane your terminal addresses, and it is not optional wherever a
 lane has more than one — every epic run. The verb resolves a missing one only on a single-task lane
 and otherwise refuses at exit `13` before it appends anything, so a report that omits it records
-nothing (#6084).
+nothing.
 
 The reason behind a `refused` stays in your note and report — the verb takes the bare token. It
 refuses a token outside this vocabulary (exit `32`) rather than interpreting it. It proves an event
@@ -310,12 +309,11 @@ before recording it, and a shipper's terminal claims no artifact a board read co
 merge state you already resolved is the artifact — so the proof answers `not-required` and the
 append follows. It reads one thing on the way and refuses nothing on it: whether the merged PR
 closed its issue or carried `Part of #N`, which the machine routes on so a partial merge sends the
-lane round instead of folding it to a terminal (ADR
-[0343](../../../../.decisions/0343-a-partial-merge-sends-the-lane-round-again.md)). That is the
+lane round instead of folding it to a terminal. That is the
 ledger's business and not yours — your terminal is the same `LANDED` either way. **`--pr` is what
 it reads**, so pass it on every terminal that names a PR: the closure is judged off exactly that
 pull request, a `LANDED` recorded without the ref reads `unknown` and records no routing answer at
-all, and nominating for one instead cannot see a merged `Part of #N` (#7457). Any refusal: print
+all, and nominating for one instead cannot see a merged `Part of #N`. Any refusal: print
 the token, name the exit code, change nothing. Then print the
 terminal either way; a run whose caller named no lane prints it only and records nothing.
 

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -263,7 +263,7 @@ note that must cite a leak cites it by class root or repo-relative form; the ref
 says so. Two known open issues sit on this seam and are inherited, not resolved here: a body
 that proves path-cleanliness *by example* trips the detector, which is generic by design, and no
 verb can rewrite a comment another account authored; both route to a human, and the refusal text
-says which of the two it hit.
+names the class it hit.
 
 ---
 

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -303,8 +303,8 @@ same rows, same order, shared as one implemented module with `review scope`, nev
 copy) with the `ui` class: a changed path matching the repo's UI surface map (its source root,
 excluding `*.test.tsx?` / `*.spec.tsx?`) additionally derives `review-ui`. Namespaces are
 derived from classes by one table in one module; v1 printed the class set from one derivation
-in one script and hand-copied it in another, and the copy dropped a class on a live PR
-. A non-empty diff deriving an empty namespace set is refused (`13`-adjacent but
+in one script and hand-copied it in another, and the copy dropped a class on a live PR. A
+non-empty diff deriving an empty namespace set is refused (`13`-adjacent but
 proven, so: the verb reds on `7`'s vacuous-conjunction arm below) — a merge gated on zero
 gates is vacuously green.
 
@@ -1263,9 +1263,9 @@ fabrika ship evidence 4321 --sha 03135b91 [--repo <owner/name>] [--json]
 evidence that makes it falsifiable from the report. On `present`, the manifest's checks as a
 **status tally**, one line per status, count-descending with ties broken on the status:
 `check\t<status-string>\t<count>` — and the same lines on `failed`, which is a bundle that was read,
-so its check counts are what make the answer falsifiable. `checks` is an evidence-array under ADR
-shape: step 5 routes off the five
-states alone and no reader reads a check by name, so the rows collapse to counts. On `failed` the
+so its check counts are what make the answer falsifiable. `checks` is an evidence-array: step 5
+routes off the five states alone and no reader reads a check by name, so the rows collapse to
+counts. On `failed` the
 non-passing checks are still **named**, on the notes channel.
 
 With `--json`: `{"outcome":…,"sha":…,"run":…,"artifact":…,"checks":{"<status-string>":<count>…}}` —
@@ -2162,7 +2162,7 @@ With `--json`: `{"outcome":…,"flagKey":…,"issue":<n|null>}`.
 
 **Detection is three ground-truth signals over the PR itself, any one sufficient:** (a) the
 diff adds a flag declaration (a `FlagshipFlag(` / `defaultVariation:` addition in the flag
-registry module the shipped default names); (b) the PR body carries a
+registry module `ship release` names); (b) the PR body carries a
 `Flag:` / `Flag key:` line with a kebab-case key (heading/bold tolerated); (c) the body names
 a key **declared in that same registry file at the PR's base ref** inside a gating-context line
 (fence-stripped, whole-token, gating-word-scoped — the context scoping is what keeps a prose

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -1,6 +1,6 @@
 # `/ship` — derived CLI contract
 
-**Skill:** [`ship`](SKILL.md) · **Authoring brief:** [#4709](https://github.com/kamp-us/phoenix/issues/4709) · **Date:** 2026-08-08
+**Skill:** [`ship`](SKILL.md) · **Date:** 2026-08-08
 
 These verbs live in `packages/fabrika-cli/`, binary `fabrika`, grouped under a `ship`
 subcommand, beside the `adr`, `report`, `review`, `triage` and `wire` groups already
@@ -9,8 +9,7 @@ invocation reads as a sentence — `fabrika ship enqueue`. One skill, one group;
 stated here once.) The [CLI interface convention](../../docs/cli-interface-convention.md)
 governs them; where this spec and that doc disagree, the doc wins and this spec is the bug.
 
-**`fabrika` calls `pipeline-cli` nowhere, and neither does the skill**
-([ADR 0238](../../../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)). Every verb
+**`fabrika` calls `pipeline-cli` nowhere, and neither does the skill.** Every verb
 below is implemented from scratch. v1's ship-it (2077 lines, 21 scripts) and the fourteen
 `pipeline-cli` tools it drives were read for their semantics and their scars — each Grounding
 section names what the v1 counterpart gets wrong and what this spec does instead — but no clause
@@ -27,20 +26,19 @@ named here.
    Exactly two verbs issue a GraphQL request; every other verb is REST.
 2. **The auto-merge porcelain carve — `ship enqueue` and `ship disarm`, and no other verb.**
    Enabling and disabling auto-merge have **no REST surface at all**, so both go through `gh`'s own
-   `gh pr merge --auto` / `--disable-auto` porcelain ([ruled on
-   #5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953)). Without this
+   `gh pr merge --auto` / `--disable-auto` porcelain. Without this
    carve the Substrate clause forbade the only way `ship enqueue` can do the arming the same
    contract requires of it. It is named as a **porcelain** carve, not a second GraphQL exception:
    this spec issues no auto-merge GraphQL mutation of its own, and the carve does not license one.
 
-Named because a spec that leaves the substrate open makes the implementer guess (#4734).
+Named because a spec that leaves the substrate open makes the implementer guess.
 
 ## Verb inventory
 
 | Verb | Purpose | Split test |
 |---|---|---|
 | `ship scope` | one PR's state, head, linked issue, class set with required namespaces, and §CP three-state classification | path partition against single-sourced maps, count-checked reads, and closing-keyword resolution are mechanical; what each state means for the run is judgment |
-| `ship cp-approval` | the ADR 0175 cardinality discharge: `discharge` / `stop` / `n/a` from head-bound signals only | the roster-cardinality case split and head-binding are a transcription of a ruled table; nothing in it is judgment (#2435 is what judgment did) |
+| `ship cp-approval` | the roster-cardinality discharge: `discharge` / `stop` / `n/a` from head-bound signals only | the case split and the head-binding are a transcription of a ruled table; nothing in it is judgment, and a verb that judged here shipped an unapproved control-plane PR |
 | `ship gate` | the verdict conjunction: every required namespace's in-force, current-head verdict, §CP advisory resolution and native-review fold included | in-force resolution (write-stamp ordering, staleness, authorization) is mechanical; what to do with `blocked` is judgment |
 | `ship floor` | whether the governance floor binds on this diff and is discharged at this head — `n/a` / `satisfied` / a refusal CI reds on | asking `ship gate` for the one `governance` namespace and seating the answer on an exit code is mechanical; nothing about the verdict itself is decided here |
 | `ship floor-batch` | the same required context on a merge queue's batched `merge_group` head, concluded success — the batch ref has no pull request to resolve a floor over | publishing a named row is mechanical; the verb decides nothing, and what the floor means was settled at each PR's own head |
@@ -51,10 +49,10 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `ship enqueue` | arm the queue's auto-merge at a pinned head, method-flag-free by construction, and prove the arm landed | the arm, its error discrimination, and the entry read are mechanical; whether the PR should ship was settled by the gates |
 | `ship merge` | the second landing path: land directly on a base branch no merge queue governs, with the method read off the repository, and prove the landing | reading the regime, picking a permitted method and proving `merged` + the merge commit are mechanical; whether the PR should ship was settled by the gates |
 | `ship reconcile` | the bounded post-enqueue watch: `landed` / `ejected` / `unresolved` / `parked`, each a proven answer at exit 0 — and, at `--polls 1`, the one read the driver's `ship:queued` wait cell relays | multi-signal terminal classification against timeline + base-branch evidence is mechanical; what ejection means for the lane is judgment |
-| `ship disarm` | the four-site merge-intent lifecycle (ADR 0198): `kept` / `disarmed`, read-back-verified | the site policy table and the verified write are mechanical |
-| `ship nudge` | the at-most-once dropped-trigger remedy: re-derive the zero-runs state, close→reopen, verify both legs | the precondition re-derivation and the guarded PATCH pair are mechanical; the verb refuses rather than trusting its dispatch (#4816) |
+| `ship disarm` | the four-site merge-intent lifecycle: `kept` / `disarmed`, read-back-verified | the site policy table and the verified write are mechanical |
+| `ship nudge` | the at-most-once dropped-trigger remedy: re-derive the zero-runs state, close→reopen, verify both legs | the precondition re-derivation and the guarded PATCH pair are mechanical; the verb refuses rather than trusting its dispatch |
 | `ship note` | the durable stop-path comment: stdin body, leak-scanned, read back | posting with the sibling groups' write protocol is mechanical; what the note says is the skill's |
-| `ship release` | dark-ship detection and the `status:awaiting-release` label, read-back-verified | the three ground-truth signals and the label write are mechanical; the flip is a human's (ADR 0083) |
+| `ship release` | dark-ship detection and the `status:awaiting-release` label, read-back-verified | the three ground-truth signals and the label write are mechanical; the flip is a human's |
 
 ### Considered and deliberately not derived
 
@@ -67,44 +65,44 @@ inline, the same tracked debt the sibling contracts carry.)
   ref); `codeowners-cp.yml` gates the §CP-boundary↔CODEOWNERS drift;
   `unresolved-threads-guard.yml` gates thread *accounting* against the review verdict;
   `leak-guard.yml` and `gitleaks.yml` gate landed content. A fabrika copy of any of these could
-  only agree redundantly or contradict an enforced verdict (ADR 0238). `ship checks` reads
+  only agree redundantly or contradict an enforced verdict. `ship checks` reads
   those gates' *results* at the head; it recomputes none of their judgments. `ship threads`
   reads resolution *state* (which threads are open, who wrote them) — a different question from
   the guard's accounting check, needed because the skill's one judgment consumes it.
 - **A §CP membership verdict.** The merge-time enforcement of control-plane review is
   CODEOWNERS plus the ruleset, server-side, and stays there. `ship scope`'s `cp` line is not a
-  second verdict on that gated question — it is the routing input the skill's own law (the ADR
-  0135 approval-aware path) cannot run without, and it is **derived from `.github/CODEOWNERS`
+  second verdict on that gated question — it is the routing input the skill's own
+  approval-aware path cannot run without, and it is **derived from `.github/CODEOWNERS`
   itself** (the artifact the gate enforces, read from **the PR's base ref** — the branch the PR
   targets; see the verb block), so
   there is no second vocabulary to drift. It **holds on a trivial or empty boundary rather
-  than matching everything** — the match-everything sentinel is the #4336 adopter-repo
-  incident and the #4401 empty-capture class — and a *failed* boundary read is the `11`
+  than matching everything** — a boundary matching every path, and one built from a pattern that
+  captures nothing, both read as "everything is owned", which is not what either says — and a
+  *failed* boundary read is the `11`
   refusal, never "ordinary". No `ship` verb re-states the §CP path list in prose; prose copies are how the
-  list drifts (#4954, #375's class).
+  list drifts.
 - **A wedge-clearing verb** (cancel the stranded check, re-run it). The lever mutates CI runs
-  the shipper does not own, and a bounded run cannot supervise the retry it triggers — both
-  halves of the #3999 ruling. `ship checks` diagnoses `wedged` and names the check; the lever
+  the shipper does not own, and a bounded run cannot supervise the retry it triggers. `ship checks` diagnoses `wedged` and names the check; the lever
   is an operator's.
 - **A CI-repair or flake-classification verb.** Red CI routes to the heal seam (v1's
   `heal-ci` lane); this group reports `red` with the failing gating runs named on the notes
   channel and stops.
-- **A flag-flip or release-execution verb.** Agents deploy, humans release (ADR 0083).
+- **A flag-flip or release-execution verb.** Agents deploy, humans release.
   `ship release` ends at the label.
 - **An approval-watcher / banked-§CP ledger verb.** The watch loop over parked §CP PRs is separate
-  machinery with its own open decisions (#4790, #4753, #4103); building it into the merge verb
+  machinery with its own open decisions; building it into the merge verb
   group would freeze those decisions from the wrong side. `ship cp-approval` answers "now,
   at this head"; durable watching is not this group's.
 - **A terminal-ledger composer verb.** The run report is the skill's own text under the
   terminal vocabulary; a composing verb would just relay strings the skill already holds. One
   rule reaches it from outside: any elapsed duration quoted in a ship report derives from two
-  timestamps quoted in the same report (#4442) — a pointer, not a verb.
+  timestamps quoted in the same report — a pointer, not a verb.
 - **A local-checkout sync or push verb.** This skill never touches local git (§RO); v1's
   `main-sync` / `verified-push` solve another lane's problem. Nothing here shells to git.
 - **A repair-entry state machine for §CP.** What re-keys repair when a §CP advisory is stale
-  and no current-head FAIL exists is an open decision (#4555, residual after ADR 0226 settled
-  the emit side). The contract does not resolve it: a §CP FAIL posts and routes as an ordinary
-  FAIL, and the residual stays cited, not silently answered.
+  and no current-head FAIL exists is an open decision — the residual left after the emit side was
+  settled. The contract does not resolve it: a §CP FAIL posts and routes as an ordinary
+  FAIL, and the residual stays named, not silently answered.
 
 ### Nothing here recomputes an enforced answer
 
@@ -116,12 +114,9 @@ of them.
 
 ### The name situation
 
-At authoring time v1's `ship-it` was still the live project-level skill at
-`claude-plugins/kampus-pipeline/skills/` (routed from `CLAUDE.md` / `DEVELOPMENT.md` as
-`.claude/skills/ship-it/`), the routing gap recorded for the sibling rebuilds (#4761, #4829).
-The cutover has since happened: the v1 plugin tree is deleted (ADR
-[0303](../../../../.decisions/0303-retire-kampus-pipeline-plugin.md), #5937) and this skill,
-reached as `/fabrika:ship`, is the one merge authority.
+At authoring time v1's `ship-it` was still the live project-level skill, and the routing gap that
+left was recorded for the sibling rebuilds. The cutover has since happened: the v1 plugin tree is
+deleted and this skill, reached as `/fabrika:ship`, is the one merge authority.
 
 The same applies to the **heal seam**: the skill routes red CI to `heal-ci`, and no fabrika
 counterpart exists yet — until one ships, that route resolves to the durable stop note plus a
@@ -153,15 +148,14 @@ Stated once rather than repeated per block.
   another). The empty-SHA degeneration is designed out at the type layer: an empty or
   malformed `--sha` is a usage error, never a matches-everything pattern — v1's
   `case "$H" in "$SHA"*)` collapsed to `*` on an empty capture, twice, in two different
-  scripts (#4223; the native-fold's unguarded `CURRENT_HEAD`).
+  scripts, and a third time in the fold's unguarded `CURRENT_HEAD`.
 - **Every list read paginates, reports its scanned count on stderr, and carries a completeness
   proof** — changed files, check runs, reviews, comments, threads, timeline events. **Which proof
-  depends on what the platform declares, and a verb never prints a denominator it cannot derive**
-  ([ruled on #5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953)):
+  depends on what the platform declares, and a verb never prints a denominator it cannot derive**:
   - **A declared count, where one exists.** Changed files, check runs, workflow runs, artifacts,
     issue comments and review threads all arrive with a total the platform states, so received
-    short of declared is the `13` refusal, never a narrower answer (#4193's 30-of-N timeline;
-    v1's 100-thread silent cap).
+    short of declared is the `13` refusal, never a narrower answer — a timeline read that answered
+    over 30 of N, and v1's silent 100-thread cap, are one defect wearing two symptoms.
   - **Exhausted pagination, where none exists.** The PR's **reviews** and its **timeline** arrive
     as bare arrays with no total at all, so `received <k> of <m>` over them has no derivable
     `<m>` — any `<m>` printed beside them was invented, and an invented denominator proves
@@ -173,7 +167,7 @@ Stated once rather than repeated per block.
   Any
   aggregate computed over a paginated read is computed **after** the pages are joined — v1's
   per-page `group_by` picked a stale approval from page 1 and its per-page `length` printed
-  `0\n0` (#725's class, live in two v1 scripts).
+  `0\n0` — live in two v1 scripts.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero
   exit (`packages/fabrika-cli/src/verb.ts`'s answer-channel rule). No verb substitutes a
   fabricated count for an unreadable one — v1's empty-checkset probe printed invented
@@ -191,7 +185,8 @@ Stated once rather than repeated per block.
 - **`gh` exit statuses are read, always.** Every `gh api` capture checks the exit status
   before the bytes are interpreted; a failed read is `11`, never an empty string flowing
   onward. Roughly a third of v1's captures were unguarded, and every scar in this family
-  (#4216, #4223, the fold's empty head) is that one omission wearing a different symptom.
+  (a failed boundary read read as "no owners", an empty `--sha` capture matching every head, the
+  fold's empty head) is that one omission wearing a different symptom.
 
 ### The shared exit taxonomy
 
@@ -201,7 +196,7 @@ group. Where the codes overlap the shipped `report`/`triage`/`review` seats (`3`
 (`packages/fabrika-cli/src/report/codes.ts`, `src/triage/codes.ts`, `src/review/codes.ts` —
 the `review` group's `codes.ts` shows the import-not-restate idiom), never re-typed as
 numerals and never read off a sibling contract.md — the checked-in `/report` contract is
-behind its own binary on `7` and `11` (#4752), which is why prose copies are not the
+behind its own binary on `7` and `11`, which is why prose copies are not the
 authority.
 
 | Code | Meaning | Verbs that can return it |
@@ -224,8 +219,8 @@ authority.
 | `16` | refused: the target is **proven not in the state this write acts on** — nothing was mutated | `resolve`, `enqueue`, `merge`, `nudge` |
 | `17` | refused: the nudge's close landed and the reopen is **unconfirmed — the PR may be left closed**; a human re-opens before anything else happens | `nudge` |
 | `18` | refused: the diff touches a governance root and its `governance` verdict is **not** a head-bound PASS — `absent`, `stale` or `fail`. The one red that means *a human owes this PR a verdict*, kept off `16` so a CI job can tell it from "the floor could not be resolved" | `floor` |
-| `19` | refused: the repository permits **no merge method at all** — squash, merge-commit and rebase are all disabled, so nothing can land directly. Its own seat rather than a fold into `16`, because the two route opposite ways: `16` sends the run to `ship enqueue`, `19` ends it at a human with repository-settings access (#6018) | `merge` |
-| `23` | refused: a label this run would POST is absent from the repository's taxonomy — `plan flip`'s seat, imported, because both verbs prove one fact over one board's labels (#4285) | `release` |
+| `19` | refused: the repository permits **no merge method at all** — squash, merge-commit and rebase are all disabled, so nothing can land directly. Its own seat rather than a fold into `16`, because the two route opposite ways: `16` sends the run to `ship enqueue`, `19` ends it at a human with repository-settings access | `merge` |
+| `23` | refused: a label this run would POST is absent from the repository's taxonomy — `plan flip`'s seat, imported, because both verbs prove one fact over one board's labels | `release` |
 | `127` | the verb never ran (unresolved binary) | all |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every
@@ -239,14 +234,14 @@ verb needed failed, so nothing is proven — not `7` (which is *proven* absence:
 about the repository, an unreachable GitHub is not a fact about anything) and not `1` (which
 would fuse an unreachable GitHub with a bad flag). This group leans on the distinction harder
 than its siblings because v1's worst incidents are exactly its collapse: a failed §CP read
-reported as "awaiting approval" (#4223), a failed file read reported as "no §CP, no classes"
-(#4216), a 503 body reported as "no run-evidence bundle" (#3716).
+reported as "awaiting approval", a failed file read reported as "no §CP, no classes", a 503 body
+reported as "no run-evidence bundle".
 
 **`16` and `17` are this group's own proven refusals.** `16` is the write-side state guard: a
 nudge dispatched at a head that has runs, a resolve aimed at a thread that is not
 positively bot-classed or is already resolved, a direct merge aimed at a queue-governed base or a
 provably unmergeable PR — the verb proved the state and declined, which
-is neither `7` (the target exists) nor `11` (nothing failed). It is the #4816 fix made
+is neither `7` (the target exists) nor `11` (nothing failed). It is the dropped-trigger fix made
 structural: the verb that mutates re-derives its own precondition and refuses without
 touching the PR. `17` exists because the nudge is the group's one two-legged mutation: v1's
 unguarded PATCH pair could close a PR, fail the reopen, and still report "nudged" — a state
@@ -266,9 +261,9 @@ newlines) is the one a re-derivation drops, and dropping it fires exit `9` on cl
 authored-text guard only; scanning *landed* content is `leak-guard.yml`'s enforced seam. A
 note that must cite a leak cites it by class root or repo-relative form; the refusal message
 says so. Two known open issues sit on this seam and are inherited, not resolved here: a body
-that proves path-cleanliness *by example* trips the generic detector (#4994 — the detector is
-generic by design, #2393), and no verb can rewrite a foreign comment (#4995); both route to a
-human, and the refusal text names the issue numbers.
+that proves path-cleanliness *by example* trips the detector, which is generic by design, and no
+verb can rewrite a comment another account authored; both route to a human, and the refusal text
+says which of the two it hit.
 
 ---
 
@@ -305,60 +300,58 @@ With `--json`: `{"outcome":"scoped","head":<40-hex>,"state":…,"issue":{"kind":
 **The class map and the namespace derivation are one derivation, printed once.** The class
 partition extends the `review` group's fixed map (code / doc / skill, `code` the residual —
 same rows, same order, shared as one implemented module with `review scope`, never a second
-copy) with the `ui` class: a changed path matching the UI surface map (`apps/web/src/**`
+copy) with the `ui` class: a changed path matching the repo's UI surface map (its source root,
 excluding `*.test.tsx?` / `*.spec.tsx?`) additionally derives `review-ui`. Namespaces are
 derived from classes by one table in one module; v1 printed the class set from one derivation
 in one script and hand-copied it in another, and the copy dropped a class on a live PR
-(#4730). A non-empty diff deriving an empty namespace set is refused (`13`-adjacent but
+. A non-empty diff deriving an empty namespace set is refused (`13`-adjacent but
 proven, so: the verb reds on `7`'s vacuous-conjunction arm below) — a merge gated on zero
-gates is vacuously green (#2765).
+gates is vacuously green.
 
 **`governance` is appended to that set, not mapped from a class.** A diff with at least one
-changed path under one of the repo's governed roots — `governedRoots` in `.fabrika.jsonc`, shipping
-as `.decisions/`, `.claude/`, `.github/`, `claude-plugins/` and the config file — additionally
+changed path under one of the repo's governed roots — `governedRoots` in `.fabrika.jsonc`, whose
+shipped default names the decision corpus, the agent-config directories, the workflow directory,
+the plugin tree and the config file itself — additionally
 derives `namespace\tgovernance`; a diff under none of those roots derives exactly the
 namespaces it derived before, unchanged. Those paths already carry a file class, so this is a
 second, orthogonal question about the same files rather than a fifth class — and the predicate
 is the one `governance scope` computes, shared as code so the two cannot disagree. A namespace
 `ship gate` can require but `ship scope` never names would be admissible-but-unreachable, which
-is the fail-open half of the same gap (#5199). The third leg is the reader: the `verdict-marker`
+is the fail-open half of one gap. The third leg is the reader: the `verdict-marker`
 format admits the `governance` namespace, so a posted `governance: PASS @ <sha> — <clause>` from
 an authorized author satisfies it at `ship gate` like any `review-*` marker. Required, emitted
 and readable move together — a required namespace no marker can carry blocks every
-governance-root PR permanently, which is the fail-**closed** half of the same gap (#5199).
+governance-root PR permanently, which is the fail-**closed** half of that same gap.
 
 **The `cp` line** is the three-state routing input (see "Considered and deliberately not
 derived"), and its source is the **enforced artifact itself**: `.github/CODEOWNERS`, read at run
-time from **the PR's base ref — the branch the PR targets** ([ruled on
-#5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233160017), founder-direct).
-Naming a trunk branch literally was the bug: the base ref *is* that branch in this repo, and it is
-the honest generalization in an adopter repo whose trunk is called something else. The #981
-property — a PR must not reclassify itself — holds unchanged, because the base ref is never the
+time from **the PR's base ref — the branch the PR targets**.
+Naming a trunk branch literally was the bug: the base ref *is* that branch in the ordinary case, and
+it is the honest generalization in a repo whose trunk is called something else. The property that a
+PR must not reclassify itself holds unchanged, because the base ref is never the
 PR's head. A changed path
 covered by a CODEOWNERS row whose owner is a control-plane owner is `control-plane`. A
 control-plane owner is `@<org>/<team>` **or** an individual `@<login>` — both parsed off the file,
-never hardcoded (`@kamp-us/control-plane` in this repo). Individual owners count exactly as team
-owners do (founder ruling on #5603 "rule a", built as #6299): GitHub discharges a row when any
+never hardcoded. Individual owners count exactly as team
+owners do: GitHub discharges a row when any
 listed owner approves, and counting only team-shaped owners made every PR in a personal repo
 `unknown` — the HOLD state — so nothing in it could ever ship. A bare email owner is not one:
 it names no account a roster or an approval resolves against.
 A change set with no owned-path match — including one entirely under
-`.decisions/**` — is `not-control-plane` (founder ruling, 2026-08-15 on #5531: ADRs are not
-control-plane; the required `governance` verdict floor is what stands behind an ADR PR, per ADR
-0274 §2). A CODEOWNERS that reads fine but is **trivial** — zero owned rows, or a row set that
-covers everything — → `unknown` (a printed hold — the match-everything boundary is the #4336
-adopter incident and the #4401 trivial-pattern class).
+the decision corpus — is `not-control-plane`: a decision record is not control plane, and the
+required `governance` verdict floor is what stands behind such a PR. A CODEOWNERS that reads fine
+but is **trivial** — zero owned rows, or a row set that
+covers everything — → `unknown` (a printed hold — a boundary matching everything and one built from
+a trivial pattern both read as "everything is owned", which is not what either says).
 
 **An absent CODEOWNERS and an unreadable one are different answers, and neither is
 `not-control-plane`.** A **proven-absent** (404) boundary parses to zero rows and lands on the
 `unknown` hold. An **unreadable** boundary is the absence of a fact rather than a fact, so it is
 the `11` — unconditionally, in every repo. Here CODEOWNERS *is* the control-plane gate, and a
-transient read fault shipping a control-plane PR unreviewed is the failure #4216 exists to
-prevent; ADR [0220](../../../../.decisions/0220-cp-surface-declared-at-standup.md) §4 names
-collapsing `unknown` → `not-control-plane` the recurring fail-open defect. A per-repo
-`unreadableCodeowners` key briefly made this configurable (#6299, ADR
-[0307](../../../../.decisions/0307-unreadable-codeowners-is-per-repo.md)); the founder reverted it
-on #5631 and nothing reads the key now.
+transient read fault shipping a control-plane PR unreviewed is exactly the failure this refusal
+exists to prevent; collapsing `unknown` → `not-control-plane` is the recurring fail-open defect.
+A per-repo `unreadableCodeowners` key briefly made this configurable; it was reverted, and nothing
+reads the key now.
 
 Deriving from CODEOWNERS rather than any prose or regex copy
 means this verb and the merge gate read one artifact and cannot disagree; the
@@ -367,12 +360,12 @@ surface. `unknown` is the one HOLD state, and the skill treats it as §CP until 
 
 **The linked issue** resolves from the PR body's closing keywords (`Fixes/Closes/Resolves #N`,
 first match), else an explicit `Part of #N` (an intentional partial split — the skill merges
-without auto-close), else `-`. Which classes may ship issueless is the skill's law (ADR 0075),
-not this verb's.
+without auto-close), else `-`. Which classes may ship issueless is the skill's law, not this
+verb's.
 
 **The `landing` line names which of the two landing paths this base branch has**, so the shipper
-reads its route from one verb instead of composing it from two API reads nobody currently performs
-(#6018). `queue` — a merge queue governs the base, so `ship enqueue` lands it and the method is the
+reads its route from one verb instead of composing it from two API reads nobody currently performs.
+`queue` — a merge queue governs the base, so `ship enqueue` lands it and the method is the
 queue's; `direct` — no queue and the repository permits at least one merge method, named beside the
 path, so `ship merge` lands it; `none` — no queue and no permitted method, so nothing in this
 repository can land this branch and a human owes it a settings change.
@@ -388,7 +381,7 @@ downstream verb consumes, and that verb guards itself.
 
 | Code | Trigger |
 |---|---|
-| `7` | the PR is proven absent (404); or it has zero changed files; or its non-empty diff derives zero required namespaces — a vacuous conjunction (#2765, ADR 0092) |
+| `7` | the PR is proven absent (404); or it has zero changed files; or its non-empty diff derives zero required namespaces — a vacuous conjunction |
 | `11` | the PR, its file list, or the §CP boundary could not be read — the scope is UNKNOWN. **Not** the landing read, which degrades to `unknown` |
 | `13` | the changed-file enumeration is provably short (received < declared count) |
 
@@ -429,22 +422,22 @@ $ fabrika ship scope 4321 --json
 
 ```
 $ fabrika ship scope 4999
-ship scope: PR #4999 not found in kamp-us/phoenix.
+ship scope: PR #4999 not found in acme/repo.
 $ echo $?
 7
 ```
 
 **Grounding**
 
-- #4730 / #2765 — one derivation printed once; the vacuous-conjunction refusal is executable,
-  not five comment lines ("born dead" is the v1 scar's own phrase).
-- #4216 — a failed file read once answered "no §CP, no classes present" in one stroke; here it
-  is `11`.
-- #981 / #4336 / #4401 — boundary from the PR's base ref, trivial/empty boundary is a hold.
-- #663 / #644 / #912 / #2470 — the class-map deadlock family: every changed file maps to a
-  class, every class to a namespace some gate can actually emit; the map is shared code with
+- **One derivation, printed once.** A class set hand-copied into a second script dropped a class on
+  a live PR; the vacuous-conjunction refusal is executable here, not five comment lines.
+- **A failed file read is `11`.** It once answered "no §CP, no classes present" in one stroke.
+- **The boundary is read from the PR's base ref**, and a trivial or empty boundary is a hold — a
+  PR must not be able to reclassify itself, and "matches everything" is not "owned by everyone".
+- **The class-map deadlock family.** Every changed file maps to a class, every class to a namespace
+  some gate can actually emit; the map is shared code with
   `review scope`, so ship and review cannot disagree about what a file is.
-- ADR 0075 — issue-linkage legality (which classes may ship issueless) stays in the skill
+- **Issue-linkage legality** (which classes may ship issueless) stays in the skill
   deliberately: this verb prints the facts (`class` lines, the `issue-ref`), and the mapping
   is one sentence of product law subject to future rulings — baking it into a verb would put
   a moving rule behind a rebuild.
@@ -475,21 +468,20 @@ fabrika ship cp-approval 4321 --sha 03135b91 [--repo <owner/name>] [--json]
 ordinary and there is nothing to discharge). A stderr notice
 `base-drift: head is <k> commits behind <base>` fires when the banked head is behind the live
 base — the skill routes rebase → re-gate → re-bank *before* an approval is solicited, so the
-approval is never spent on a head that must move (#4477).
+approval is never spent on a head that must move.
 
 With `--json`: `{"outcome":…,"mechanism":…,"sha":…,"roster":<n>,"baseDrift":<k|0>}`.
 
-**The decision is the ADR 0175 cardinality table, verbatim:** roster = **the union of every owner
+**The decision is the ruled cardinality table, verbatim:** roster = **the union of every owner
 the CODEOWNERS control-plane rows name**, over both owner shapes. An `@<org>/<team>` owner is
 expanded through the REST team-members endpoint (`/orgs/<org>/teams/<team>/members`, paginated),
 read fresh once per named team. An individual `@<login>` owner **is** a roster entry and no roster
 is read for it — that endpoint needs an org a personal repo does not have, which is why counting
-only teams left such a repo unable to discharge the gate at all (#6299). The owner set is the same
+only teams left such a repo unable to discharge the gate at all. The owner set is the same
 derivation `ship scope` uses, one shared module, so the roster this verb consults is the set the
-merge gate actually asks (`@kamp-us/control-plane` is the only team in this repo, never
-hardcoded). **The union is not a fabrika policy — it is GitHub's own any-listed-owner semantics**
-([ruled on #5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233188966),
-founder-direct): GitHub discharges a CODEOWNERS row when *any* listed owner approves, so a roster
+merge gate actually asks; the team name is parsed off the file, never
+hardcoded. **The union is not a fabrika policy — it is GitHub's own any-listed-owner semantics**:
+GitHub discharges a CODEOWNERS row when *any* listed owner approves, so a roster
 narrower than the union would refuse approvals the merge gate accepts, and fabrika mirrors the
 platform here rather than adding a rule of its own.
 N=0 → `stop` `zero-owners` (an empty roster is a proven
@@ -502,21 +494,21 @@ sole owner's head-bound self-approval marker comment (`control-plane-self-approv
 a token deliberately outside every auto-merge namespace). N=1 non-author, or N≥2 → discharge
 only on a non-author member's APPROVED review whose `commit_id` prefix-matches `--sha`. Every
 signal is head-bound; a stale approval on a superseded head never counts (ruleset
-`dismiss_stale_reviews_on_push` backs this but is not relied on — #3769 proved dismissal
-behavior is inconsistent, so the head-binding is checked here, always). Membership is a
+`dismiss_stale_reviews_on_push` backs this but is not relied on — a patch-changing push has been
+observed surviving dismissal, so the head-binding is checked here, always). Membership is a
 three-outcome probe: active / proven-404 / UNKNOWN — an UNKNOWN member read is `11`, never
-"not a member" (#4223).
+"not a member".
 
 **Latest-per-author review resolution is computed after all pages are joined** — v1's
-per-page `group_by` could surface a page-1 stale approval past a page-2 revocation (#725's
-class, live in v1's approval scan).
+per-page `group_by` could surface a page-1 stale approval past a page-2 revocation — live in v1's
+approval scan.
 
 **Exit status**
 
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed |
-| `11` | the CODEOWNERS boundary, the roster, the reviews, the marker comments, or the live head could not be read — the discharge is UNKNOWN, never `stop`, never `awaiting approval` (#4223) |
+| `11` | the CODEOWNERS boundary, the roster, the reviews, the marker comments, or the live head could not be read — the discharge is UNKNOWN, never `stop`, never `awaiting approval` |
 | `13` | the changed-file or comment enumeration is provably short of the declared count, or the review read — for which the platform declares no count — never reached a terminal page |
 
 **Errors**
@@ -549,15 +541,16 @@ cp-approval	stop	awaiting-approval
 
 **Grounding**
 
-- #2435 — identical single-owner PRs merged in one run and were refused in another when this
-  was judgment; the case table ended it, and this verb is that table.
-- #4223 — the empty-HEAD glob degeneration and the failed-read-as-"awaiting-approval" scar;
-  both designed out (typed SHA, `11` on any failed read).
-- #3769 — head-binding checked here rather than delegated to `dismiss_stale_reviews_on_push`,
+- **The case table replaced judgment.** While this was a judgment call, identical single-owner PRs
+  merged in one run and were refused in another; this verb is that table.
+- **The empty-HEAD glob degeneration and the failed-read-as-"awaiting-approval" scar** are both
+  designed out: a typed SHA, and `11` on any failed read.
+- **Head-binding is checked here** rather than delegated to `dismiss_stale_reviews_on_push`,
   because a live counterexample showed a patch-changing push surviving approval.
-- #4477 — the base-drift notice; an approval spent on a must-move head is destroyed by the
-  rebase (#4521 is three §CP approvals destroyed in one night by exactly this).
-- ADR 0135 / 0175 — the approval-aware gate and the cardinality table this transcribes.
+- **The base-drift notice.** An approval spent on a must-move head is destroyed by the rebase —
+  three control-plane approvals were lost in one night to exactly this.
+- **The approval-aware gate and the cardinality table** this transcribes are ruled elsewhere; this
+  verb transcribes them and decides nothing.
 
 ---
 
@@ -590,7 +583,7 @@ With `--json`: `{"outcome":…,"sha":…,"namespaces":[{name,state,carrier,comme
 
 **The flag-collapse and coverage scars are designed out at two layers.** `--require` is a
 repeatable flag whose values accumulate — a single-valued parse that keeps the first and
-drops the rest is the #4520 incident (the gate said enqueueable past a live FAIL). And the
+drops the rest once made the gate say enqueueable past a live FAIL. And the
 affirmative answer carries its own proof: before `satisfied` is printed, the verb asserts the
 namespace lines cover exactly the distinct required set — a plausible value with silently
 narrowed coverage is the defect's signature, so the assertion runs *before* the answer is
@@ -603,13 +596,12 @@ scope` prints the namespace from, over the same declared list, shared as code, s
 disagree. Every other namespace stays caller-asserted; the floor only ever *adds*, so a diff under
 none of those roots requires exactly what it required before. When the floor fires, a stderr notice names it.
 
-This is the whole ruling on #5036, and it is what a §CP row would otherwise have had to enforce.
-`claude-plugins/fabrika/**` is deliberately **not** control-plane — no CODEOWNERS row, no boundary
-widening ([founder veto, #5036](https://github.com/kamp-us/phoenix/issues/5036#issuecomment-5234614633),
-2026-08-10). The protection is this machine floor plus the §CP digest readout that carries every
-fabrika-tree landing to a human: **visibility after landing replaces blocking before it**, and the
-trade is explicit — the readout makes a gate-weakening landing *visible*, not *impossible* (#5216 is
-a live instance of the machine chain missing one). `.github/**`, CODEOWNERS included, and everything
+This is the whole ruling, and it is what a §CP row would otherwise have had to enforce.
+The plugin tree is deliberately **not** control-plane — no CODEOWNERS row, no boundary
+widening. The protection is this machine floor plus the §CP digest readout that carries every
+plugin-tree landing to a human: **visibility after landing replaces blocking before it**, and the
+trade is explicit — the readout makes a gate-weakening landing *visible*, not *impossible*, and the
+machine chain has been observed missing one. `.github/**`, CODEOWNERS included, and everything
 the existing §CP boundary already covers stay §CP, unchanged and enforced server-side regardless.
 
 The floor is `governance` only. Deriving the whole `review-*` set here would be a second answer to
@@ -617,33 +609,32 @@ what `ship scope` already prints, and widening it is its own decision — record
 silently taken.
 
 **In-force resolution, per namespace:** candidates are this namespace's verdict comments,
-head-bound first (a live-head-bound verdict strictly outranks recency — #4189), then ordered
-by the body's write-stamp, never `created_at` (#4200: a FAIL upserted after a PASS must win).
+head-bound first (a live-head-bound verdict strictly outranks recency), then ordered
+by the body's write-stamp, never `created_at` — a FAIL upserted after a PASS must win.
 Authorization is the ACL rule: a verdict counts only when its author resolves to `write`+ on
-the repo (ADR 0055, fail-closed on lookup failure → that namespace is `11`, not `absent`).
+the repo, fail-closed on lookup failure → that namespace is `11`, not `absent`.
 With `--cp`, the code namespace additionally resolves the §CP advisory carrier (body-bound
 `Reviewed-head:` + all-`[PASS]` rows — an advisory carrying any `[FAIL]` row is an invalid
-emission, ADR 0226, reported on stderr and treated as `fail`); the same `--cp` value must
+emission, reported on stderr and treated as `fail`); the same `--cp` value must
 reach every resolution in one run — v1 passed it to the gate and not the fold, and a
-discharged FAIL stayed in force forever (#4049). The native-review fold is inside this verb:
+discharged FAIL stayed in force forever. The native-review fold is inside this verb:
 a decisive native review (APPROVED / CHANGES_REQUESTED) whose `commit_id` prefix-matches
 `--sha` folds into the code namespace newest-wins by write time — never FAIL-precedence,
 which wedges the repair loop.
 
 `absent` and `stale` are distinct tokens because their remedies differ (run the gate vs
-re-run it at this head), and both block — absence-is-refusal is the #3944 law (a PR enqueued
-with no live-head verdict at all).
+re-run it at this head), and both block: a PR has been enqueued with no live-head verdict at all,
+which is why absence is a refusal.
 
-**`routed` is the fifth state, and it is a gate saying it owes this PR nothing** (ADR
-[0316](../../../../.decisions/0316-a-gate-records-that-it-owes-no-verdict.md)). It resolves from a
+**`routed` is the fifth state, and it is a gate saying it owes this PR nothing.** It resolves from a
 `routed-elsewhere` record — its own wire format, carrying no polarity, read through the same
-head-binding and the same ADR 0055 ACL as a verdict — and it satisfies beside `pass`, because the
+head-binding and the same ACL as a verdict — and it satisfies beside `pass`, because the
 conjunction asks whether every required gate has answered and "not mine to judge" is an answer.
 **`review-ui` is the only namespace that may resolve this way.** It is the only gate whose emit path
 is structurally unable to answer: `review-ui render` refuses zero surfaces and `review-ui post`
 refuses without captures, so the `ui` class — raised off a path test that cannot see whether pixels
-moved — named a namespace nothing legal could fill, and a prose-only `apps/web/src/**` PR was
-permanently unshippable (#6376). A record aimed at any other namespace is read and ignored; that
+moved — named a namespace nothing legal could fill, and a prose-only PR under the UI surface map
+was permanently unshippable. A record aimed at any other namespace is read and ignored; that
 namespace stays `absent`. `ship floor` is unaffected — it asks for `governance` and requires `pass`.
 
 **`--cp` is caller-asserted, deliberately** — the one input in this verb the caller vouches
@@ -657,7 +648,7 @@ answer this contract bans.
 
 | Code | Trigger |
 |---|---|
-| `7` | the PR is proven absent (404) or closed, or its diff has zero changed files — a conjunction over an empty diff proves nothing (ADR 0092) |
+| `7` | the PR is proven absent (404) or closed, or its diff has zero changed files — a conjunction over an empty diff proves nothing |
 | `10` | a `--require` value is not a known gateable namespace |
 | `11` | the changed-file list, comments, reviews, or ACL could not be read — the conjunction is UNKNOWN, never `blocked`, never `satisfied` |
 | `13` | the changed-file or comment enumeration is provably short of the declared count, or the review read — for which the platform declares no count — never reached a terminal page |
@@ -710,17 +701,17 @@ ns	governance	absent	-
 
 **Grounding**
 
-- #5036 — the governance floor. `--require` was caller-asserted end to end, so a fabrika-tree PR
-  shipped with no governance verdict simply by never passing the flag; the founder vetoed making
-  the tree §CP and ruled the machine floor instead.
-- #4520 — the repeated-flag collapse and the coverage assertion; both layers here.
-- #3944 / #3982 — the set-level absence check is not expressible as N separate reads; one verb
-  owns the conjunction.
-- #4189 / #4200 / #2102 — head-bound-first, write-stamp ordering, staleness folded into one
+- **The governance floor.** `--require` was caller-asserted end to end, so a plugin-tree PR
+  shipped with no governance verdict simply by never passing the flag; making the tree §CP was
+  vetoed and the machine floor ruled instead.
+- **The repeated-flag collapse and the coverage assertion**; both layers here.
+- **The set-level absence check is not expressible as N separate reads**; one verb owns the
+  conjunction.
+- **Head-bound-first, write-stamp ordering, staleness** folded into one
   resolution rather than a separate marker test to keep in sync.
-- #4049 — one `--cp` value for the whole resolution; the seam that diverged in v1 is gone
+- **One `--cp` value for the whole resolution**; the seam that diverged in v1 is gone
   because the fold lives inside the same verb.
-- #1932 / #2005 / ADR 0111/0151/0226 — the advisory carrier's resolution rules, including the
+- **The advisory carrier's resolution rules**, including the
   forged-marker workaround this forbids and the PASS-only rule.
 
 ---
@@ -773,7 +764,7 @@ those words, because "the check was green" is exactly the reading that would mak
 decorative for the diffs it does not cover.
 
 <a id="publish-check"></a>
-### The check-run mode: pending while nobody has judged this head (#6161)
+### The check-run mode: pending while nobody has judged this head
 
 An Actions job concludes success, failure, cancelled or skipped and nothing else. While the floor was
 seated on this verb's exit code, the ordinary mid-lane state — *no verdict posted at this head yet* —
@@ -789,7 +780,7 @@ name, distinct from the job's — and this map is the whole of it:
 | `satisfied`, `n/a` | `completed` / `success` | nothing is owed |
 | `absent` | left `in_progress` (**pending**) | nobody has judged this head yet; not wrong, not done |
 | `stale`, `fail` | `completed` / `failure` | a verdict was formed and it is not a head-bound PASS |
-| UNKNOWN (`7` / `11` / `13`) | `completed` / `failure` | UNKNOWN never passes and is not "still going" (ADR 0092) |
+| UNKNOWN (`7` / `11` / `13`) | `completed` / `failure` | UNKNOWN never passes and is not "still going" |
 
 **The process then exits 0 whenever the check-run landed, whatever it said.** The floor's polarity is
 the check-run's; a non-zero in this mode says only that the answer could not be published, which is
@@ -816,10 +807,10 @@ whenever it *published* an answer, that re-fire keys on the check-run's state ra
 conclusion, and requests a whole-run re-run rather than a failed-jobs one.
 
 <a id="the-mechanism-choice"></a>
-### Why a caller verb, and not a new exit code on `ship gate` (#5408)
+### Why a caller verb, and not a new exit code on `ship gate`
 
 The floor had to become **machine-binding**: CI must read the governance verdict on a governance-root
-diff and red without it (founder ruling, 2026-08-11, routed onto #5408). Two mechanisms were on the
+diff and red without it. Two mechanisms were on the
 table and the choice decides whether `gate-verb.ts` changes at all. **The caller was chosen.**
 
 - **Rejected — reseat `blocked` on the `3`+ proven-outcome band inside `ship gate`.** `blocked` is an
@@ -829,9 +820,9 @@ table and the choice decides whether `gate-verb.ts` changes at all. **The caller
   refuses instead of answering also cannot report *which* namespace blocked, because `refuse()`
   hardcodes empty stdout.
 - **Rejected — parse `gate\tblocked\t<sha>` in the workflow's `run:` step.** That puts the decision
-  in bash, which ADR 0228 forbids: a script relays a verb's answer and never derives the decision
+  in bash, which is forbidden: a script relays a verb's answer and never derives the decision
   itself. It would also need a second step to decide whether the floor applies at all, and that step
-  would be a second copy of the governed-root list that nothing reds when it drifts (#4604).
+  would be a second copy of the governed-root list that nothing reds when it drifts.
 - **Chosen — `ship floor`, a caller verb whose refusal *is* the decision.** `ship gate` is untouched
   and keeps answering; `ship floor` asks it for the one `governance` namespace, reads the row back
   and seats a non-PASS on `18`. The workflow relays an exit code and derives nothing. The verdict
@@ -844,20 +835,20 @@ nothing about the others.
 ### It refuses on WRONG, not only on MISSING
 
 The recurring defect is a guard that fires when the guarded thing is *absent* and stays silent when
-it is *present and wrong* (#5416, #4887). All four of these red on `18`, and each has a unit test:
+it is *present and wrong*. All four of these red on `18`, and each has a unit test:
 
 | The PR carries | Resolves | Why it still reds |
 |---|---|---|
-| no governance marker at all | `absent` | the #5293 / #5333 shape — the fail-open this verb closes |
+| no governance marker at all | `absent` | the fail-open this verb closes: PRs have merged under a live floor with no verdict at all |
 | `governance: FAIL @ <head>` | `fail` | a verdict was formed and it said no |
-| `governance: PASS @ <other-head>` | `stale` | the PASS attests a tree that is not this one (ADR 0058) |
-| `governance: PASS @ <head>` from an author without write+ | `absent` | the ADR 0055 ACL gate drops it before the polarity is read |
+| `governance: PASS @ <other-head>` | `stale` | the PASS attests a tree that is not this one |
+| `governance: PASS @ <head>` from an author without write+ | `absent` | the ACL gate drops it before the polarity is read |
 
 **Exit status**
 
 | Code | Trigger |
 |---|---|
-| `7` | the PR is proven absent (404) or closed, or has zero changed files — whether it touches a governance root is unanswerable (ADR 0092) |
+| `7` | the PR is proven absent (404) or closed, or has zero changed files — whether it touches a governance root is unanswerable |
 | `11` | the PR, its changed-file list, or the conjunction underneath could not be read — the floor is UNKNOWN, never `n/a`. Under `--publish-check`, also: the check-runs at the head could not be enumerated, so whether this head already carries the floor's row is unknown and nothing is published |
 | `13` | the changed-file enumeration is provably short — a governance root could sit in the part nobody read |
 | `18` | the diff touches a governance root and its `governance` verdict at this head is `absent`, `stale` or `fail` |
@@ -935,15 +926,15 @@ $ echo $?
 
 **Grounding**
 
-- #5408 — the substituted control did not bind. `requiredWithFloor` was wired and correct, no
-  workflow invoked `ship gate` at all, and `blocked` exited 0, so #5293 and #5333 merged with no
+- **The substituted control did not bind.** `requiredWithFloor` was wired and correct, no
+  workflow invoked `ship gate` at all, and `blocked` exited 0, so PRs merged with no
   governance verdict after the floor was live. The gap was the missing caller, not the floor.
-- ADR 0228 — a script relays a verb's answer and never derives the decision; that is why the
+- **A script relays a verb's answer and never derives the decision**; that is why the
   decision is a verb and the workflow step is one line.
-- #4604 — a path filter matching nothing presents as a pass, which is why this job has no `paths:`.
-- ADR 0055 / ADR 0058 — the write+ author gate and the SHA binding, both inherited from `ship gate`
+- **A path filter matching nothing presents as a pass**, which is why this job has no `paths:`.
+- **The write+ author gate and the SHA binding** are inherited from `ship gate`
   rather than re-derived, which is what makes an unauthorized or stale PASS red here.
-- ADR 0092 — an unreadable answer reds. `11` and `13` are not softer than `18`; they are a different
+- **An unreadable answer reds.** `11` and `13` are not softer than `18`; they are a different
   fact, and neither is a pass.
 
 ---
@@ -982,10 +973,10 @@ ns	governance	-
 ### Why the batch ref gets a pass, and what still holds the floor
 
 A required status check is demanded on the queue's batched `merge_group` ref, and a workflow only
-runs there if it carries a `merge_group:` trigger (ADR [0132](../../../../.decisions/0132-merge-queue-for-base-freshness.md), §CI-under-batch). `governance-floor.yml` had `pull_request:` alone, so when `governance floor at
+runs there if it carries a `merge_group:` trigger. `governance-floor.yml` had `pull_request:` alone, so when `governance floor at
 head` was added to the ruleset's required set on 2026-08-21 the batch could never carry the context
 and every queued merge in the repository hung toward the check timeout — a ~40-minute freeze, ended
-by reverting the flip (#6968). It is the identical failure ADR 0132 records for `ci-required`.
+by reverting the flip. It is the identical failure the always-on required context hit before it.
 
 **This verb resolves no floor, because a batch ref carries nothing to resolve one from.** It has no
 number, no changed-file list against the base a verdict was written over, no comments and no reviews.
@@ -1001,7 +992,7 @@ question, not a question waved through.
 **Why a verb and not a job named after the context.** A branch protection matches a required check by
 name. Naming a `merge_group`-only job `governance floor at head` would satisfy the queue with no CLI
 change — and would put a second copy of `CHECK_RUN_NAME` in YAML that nothing reds when it drifts
-(the #4604 failure class, and ADR 0228's rule that a workflow step relays and never decides). It
+(a path filter matching nothing presents as a pass, and a workflow step relays rather than decides). It
 would also stack a second check of that name on every PR ref, since a job skipped by its `if:` still
 reports; a required context resolved from two producers is exactly the ambiguity this floor cannot
 afford. So the name stays in one place and the workflow relays a verb.
@@ -1054,13 +1045,13 @@ $ echo $?
 
 **Grounding**
 
-- #6968 — the freeze. Adding the context to the ruleset with no `merge_group:` arm on its producer
+- **The freeze.** Adding the context to the ruleset with no `merge_group:` arm on its producer
   froze every merge in the repository until the flip was reverted.
-- ADR 0132, §CI-under-batch — "You **must** use the `merge_group` event to trigger your GitHub
+- **The queue's own rule** — "You **must** use the `merge_group` event to trigger your GitHub
   Actions workflow when a pull request is added to a merge queue"; `ci.yml` and `leak-guard.yml` are
   the in-repo precedents.
-- ADR 0318 — the check-run mechanism this verb reuses, name and read-back included.
-- ADR 0228 — the workflow relays; the name and the decision both live in the verb.
+- **The check-run mechanism** this verb reuses, name and read-back included.
+- **The workflow relays**; the name and the decision both live in the verb.
 
 ---
 
@@ -1091,10 +1082,10 @@ of latest-per-context check runs read (gating and informational both), the line 
 completeness proof. Then the **collapsed tally** of those runs, one line per class, count-descending
 with ties broken on the class:
 `check\t<success|failure|neutral|cancelled|skipped|timed_out|action_required|in_progress|queued|stale>/<gating|informational>\t<count>`.
-`checks` is an evidence-array under ADR [0308](../../../../.decisions/0308-bounded-evidence-output-shape.md):
+`checks` is an evidence-array:
 step 4 routes off the rollup and nothing reads a run by name, so the rows collapse to counts. The
 gating axis stays inside the key because status alone would leave the rollup underivable from the
-answer — a `red` head and a head whose only `failure` is an ADR 0061 informational run would tally
+answer — a `red` head and a head whose only `failure` is an informational run would tally
 identically. The two runs the skill's terminals read by name are still **named**, on the notes
 channel, where the skill already reads them: the wedged run, and — wherever a gating run has failed,
 which is `red` and also the `wedged` head that carries a failure too — the failing gating runs,
@@ -1104,14 +1095,13 @@ the head red, and naming them there would send the operator to `heal-ci` over a 
 nothing.
 Last line: `facts\tworkflows:<n>\truns:<n>` — `workflows` counts the repository's **active**
 workflows (the inventory's `state == "active"` rows, nothing more: no trigger matching, no YAML
-parser — [ruled on
-#5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953)); `runs` counts the total workflow runs recorded at this
+parser); `runs` counts the total workflow runs recorded at this
 head across all workflows, **pre-dedupe** (which is why it can exceed the `run` line count:
 that one counts latest-per-context check-run rows). These are the zero-checkset
 discriminators (`no-runs` requires workflows ≥ 1 and runs = 0 at this head: Actions exist
 and none fired — the dropped-trigger state `ship nudge` re-derives).
 
-**A `green` is served only over bytes a gate of this repo's own inspected** (#6915). Where the
+**A `green` is served only over bytes a gate of this repo's own inspected.** Where the
 rollup would be `green`, the head's workflow runs are read against the active inventory through
 `src/review/gate-coverage.ts` — the same module `review ci` refuses on, so the two gates cannot
 drift a second copy of the rule. A workflow the repo checks in is addressed by its file path
@@ -1126,10 +1116,10 @@ all, `ship checks: <repo> authors no workflow of its own — …`. The floor sit
 `red` head already routes to `heal-ci` by name, and a `pending` head is one this group waits on
 rather than lands.
 
-**Zero workflows is `no-producer`, and it no longer collapses into `pending`** (#6298). A repo with
+**Zero workflows is `no-producer`, and it no longer collapses into `pending`.** A repo with
 no CI and a repo whose CI has not reported yet are different facts, and printing the second over the
 first tells an operator to wait for a run nothing will ever start. Workflow *existence* is the whole
-test — nothing inspects what a workflow does (#5603, R17.1). That case refuses on `7` unless the
+test — nothing inspects what a workflow does. That case refuses on `7` unless the
 repo declares `ci.noProducer: "degrade"` in `.fabrika.jsonc`, which prints the `no-producer` rollup
 at exit `0` with the fact on stderr. With `--wait`, progress goes to stderr and
 the final stdout adds `settle\t<settled|budget-exhausted|head-moved>` before the first line's
@@ -1147,17 +1137,17 @@ declared run concluded `success`/`neutral`/`skipped`; unrecognized conclusion �
 today; extend it, never fork it), plus this group's two additions on top: the
 running-vs-wedged split (`queued` with a null `started_at` past the dwell → the whole answer
 is `wedged`, with the stranded checks named — diagnosis only; the cancel-and-rerun lever is
-an operator's, #3999) and the informational carve-out (a fixed, single-sourced list of
-non-gating deploy/cleanup contexts — ADR 0061 — maintained in the module, not duplicated;
+an operator's) and the informational carve-out (a fixed, single-sourced list of
+non-gating deploy/cleanup contexts, maintained in the module, not duplicated;
 v1 hardcoded it in two scripts' jq and they drifted). The read is REST check-runs
 latest-per-context — the GraphQL rollup lags ~15 minutes behind reality and refused green
-PRs for it (#3999); the aggregate `.conclusion` is never bound (red-wins-over-pending masks
+PRs for it; the aggregate `.conclusion` is never bound (red-wins-over-pending masks
 an unfinished gating check).
 
 **`--wait` semantics:** re-read each cadence tick; budget accounts wall-clock including call
 latency (v1 counted only sleeps and silently overran); a mid-wait `red` exits at the next
 tick (falling through to green was the enqueue-a-red-PR hazard); a mid-wait head move exits
-`head-moved` (the answer is about a tree the PR no longer is; #1928's secondary); budget
+`head-moved` (the answer is about a tree the PR no longer is); budget
 exhaustion is the `budget-exhausted` settle token with the last rollup — an answer, exit 0.
 
 **Exit status**
@@ -1167,7 +1157,7 @@ exhaustion is the `budget-exhausted` settle token with the last rollup — an an
 | `7` | the PR or the `--sha` commit is proven absent; **or the repo has zero workflows** under the shipped `ci.noProducer: "refuse"` |
 | `11` | the check-run read, the workflow read, or `.fabrika.jsonc`'s `ci` key failed — CI state is UNKNOWN, never `green`, and no substituted count is printed |
 | `13` | entries received < declared `total_count` — never read as "no red checks" |
-| `20` | every check at the head passed and **no workflow the repo authors produced a run there** — no gate inspected these bytes, so `green` is UNKNOWN, never merged (#6915) |
+| `20` | every check at the head passed and **no workflow the repo authors produced a run there** — no gate inspected these bytes, so `green` is UNKNOWN, never merged |
 
 **Errors**
 
@@ -1220,7 +1210,7 @@ facts	workflows:0	runs:0
 
 ```
 $ fabrika ship checks 4324 --sha 5b1c0d72   # every check passed; only CodeQL's own workflow ran
-ship checks: none of the 12 workflow(s) kamp-us/phoenix authors produced a run at 5b1c0d72 — the 2 check run(s) here came from elsewhere, so no gate inspected the bytes this merge would land: green is UNKNOWN, never merged (#6915).
+ship checks: none of the 12 workflow(s) acme/repo authors produced a run at 5b1c0d72 — the 2 check run(s) here came from elsewhere, so no gate inspected the bytes this merge would land: green is UNKNOWN, never merged (#6915).
 $ echo $?
 20
 ```
@@ -1240,13 +1230,13 @@ unchanged.)
 
 **Grounding**
 
-- #3999 — REST latest-per-context over GraphQL; the wedge split; the lever left human.
-- #1016 / #4816 — the `no-runs` facts line feeds `ship nudge`, which re-derives them itself;
+- **REST latest-per-context over GraphQL**; the wedge split; the lever left human.
+- **The `no-runs` facts line feeds `ship nudge`**, which re-derives them itself;
   this verb's copy is for the skill's routing, not the nudge's authority.
-- ADR 0061 — informational contexts carved out in one module; v1's two drifting jq copies.
+- **Informational contexts carved out in one module**; v1 kept two drifting jq copies.
 - v1's settle-wait sourced its sibling script and could exit from its preamble with half its
   contract unprinted; a single verb with `--wait` has no preamble seam.
-- #2118 — deployed-worker smokes stay out of the gating set; hermetic merge gates (ruled).
+- **Deployed-service smokes stay out of the gating set**; merge gates are hermetic (ruled).
 
 ---
 
@@ -1274,36 +1264,35 @@ evidence that makes it falsifiable from the report. On `present`, the manifest's
 **status tally**, one line per status, count-descending with ties broken on the status:
 `check\t<status-string>\t<count>` — and the same lines on `failed`, which is a bundle that was read,
 so its check counts are what make the answer falsifiable. `checks` is an evidence-array under ADR
-[0308](../../../../.decisions/0308-bounded-evidence-output-shape.md): step 5 routes off the five
+shape: step 5 routes off the five
 states alone and no reader reads a check by name, so the rows collapse to counts. On `failed` the
 non-passing checks are still **named**, on the notes channel.
 
 With `--json`: `{"outcome":…,"sha":…,"run":…,"artifact":…,"checks":{"<status-string>":<count>…}}` —
 the same tally the `check` lines carry, so the two channels cannot desync.
 
-**The five states carry positive-evidence rules, verbatim from the #3991 law** (the fifth,
-`failed`, [ruled on
-#5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953))**:**
+**The five states carry positive-evidence rules, verbatim from the ruled law** (the fifth,
+`failed`, ruled alongside them)**:**
 
 - `present` — the artifact fetched, unzipped (magic-number-checked: a 503 body saved as
-  `.zip` is not a bundle, #3716), schema-version understood, `manifest.commit` exactly
+  `.zip` is not a bundle), schema-version understood, `manifest.commit` exactly
   `--sha`, and every `checks[]` entry passing. The producer is the `run-evidence` workflow
   (`.github/workflows/run-evidence.yml`) publishing an actions artifact named
   `run-evidence`; the manifest's required keys are `schemaVersion` (numeric, `1`), `commit`,
-  and `checks[]` of `{name, status}` (ADR 0054). `checks[]` entries carry a string `status`
+  and `checks[]` of `{name, status}`. `checks[]` entries carry a string `status`
   field, **not** a boolean `pass` — the wire shape is the producer's, and prose that says
-  "boolean" ships a parser that reads everything falsy (#4392). Passing is the producer's own
+  "boolean" ships a parser that reads everything falsy. Passing is the producer's own
   word, `pass`, and nothing else: `crabbox-manifest`'s `deriveChecks` writes `pass`/`fail` and the
   producer workflow appends its `bundle-node-core-free` entry in the same words. GitHub's
   check-conclusion vocabulary (`success`/`neutral`/`skipped`) belongs to `ship checks`, which
   reads check runs; against a bundle it matches nothing, so every passing check counted as
-  failing and no bundle could attest a passing run (#5563). An unrecognized `status` reads as
-  failing, never as passing — the same fail-closed posture the check-run rollup takes (#4552) —
+  failing and no bundle could attest a passing run. An unrecognized `status` reads as
+  failing, never as passing — the same fail-closed posture the check-run rollup takes —
   and accepting both vocabularies at once is not the fix, because it re-opens the same silent
   disagreement.
 - `pending` — a producer run for this head exists and has not completed, **or** it completed
   **within the freshness window** and lists no `run-evidence` artifact. **Pending is not absent** —
-  reporting it absent invents a CI gap (#3913).
+  reporting it absent invents a CI gap.
 - `absent` — positive evidence only: no producer workflow exists in the repo (the
   foreign-repo degradation, confirmed by a successful workflow-inventory read, never by a
   failed one), or no producer run exists at this head at all, or a run completed **outside the
@@ -1317,8 +1306,7 @@ the same tally the `check` lines carry, so the two channels cannot desync.
   version unrecognized, or `manifest.commit` ≠ `--sha` (a bundle about some other tree is
   not evidence about this one). A *failed* read is not `unknown` — it is `11`.
 
-**The freshness window is 120 seconds, and the clock it reads is named** ([ruled on
-#5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953)). "A completed
+**The freshness window is 120 seconds, and the clock it reads is named.** "A completed
 producer run listing zero artifacts" is two different facts wearing one shape — a producer that
 published nothing, and a producer whose upload has not surfaced in the artifact listing yet — and
 without a window they collapse onto the wrong side of the pending-is-not-absent law. So: compare
@@ -1328,7 +1316,7 @@ answer is `absent`. A run reporting no `completed_at` at all has nothing to comp
 be shown fresh and reads `absent`. Which side a run fell on, with both operands, goes to stderr.
 
 Transient-vs-absent is decided during the fetch (retry with backoff on 5xx, stderr captured,
-never discarded — the swallowed 503 stderr is how #3716 shipped), and a transient that
+never discarded — a swallowed 503 stderr is how a present bundle once read as absent), and a transient that
 survives the retries is `11`, never `absent`.
 
 **Exit status**
@@ -1350,8 +1338,7 @@ survives the retries is `11`, never `absent`.
 
 **Scope** — the producer workflow inventory, the head-SHA-bound run list (exact `head_sha`
 match only), one artifact, one manifest. All fetch intermediates live under a per-run
-`mktemp -d` — a fixed or PID-derived path lets two racing shippers read each other's bundle
-(#3718, #2281).
+`mktemp -d` — a fixed or PID-derived path lets two racing shippers read each other's bundle.
 
 **Examples**
 
@@ -1382,17 +1369,17 @@ attests a run, not a passing one.`
 
 **Grounding**
 
-- #3991 / #3913 — the state split and the pending-is-not-absent law; #5067's clause 6 is what
-  keeps the second honest, by giving the listing lag a window instead of a coin flip.
-- #3716 / #3693 — retries, captured stderr, the zip magic check; a 503 body reported as "no
+- **The state split and the pending-is-not-absent law.** The freshness window is what keeps the
+  second honest, by giving the listing lag a window instead of a coin flip.
+- **Retries, captured stderr, the zip magic check.** A 503 body was once reported as "no
   bundle" for a bundle present the whole time.
-- #4392 — `checks[]` `status` is a string on the wire; the contract says so, so the parser
+- **`checks[]` `status` is a string on the wire**; the contract says so, so the parser
   cannot be written against invented prose.
-- #5563 — which vocabulary that string is written in: the producer's `pass`/`fail`, not GitHub's
+- **Which vocabulary that string is written in**: the producer's `pass`/`fail`, not GitHub's
   conclusions, and unrecognized reads as failing.
-- #4013 — the thin-skill rule: the skill never hand-rolls this fetch; this verb is the only
+- **The thin-skill rule**: the skill never hand-rolls this fetch; this verb is the only
   reader.
-- ADR 0054 / 0086 — the bundle contract and the foreign-repo degradation this transcribes.
+- **The bundle contract and the foreign-repo degradation** this transcribes are ruled elsewhere.
 
 ---
 
@@ -1466,11 +1453,10 @@ threads	0
 
 **Grounding**
 
-- #2123 / #2121 — the bot thread that shipped past every gate; the read this feeds is the
-  gate's input.
+- **The bot thread that shipped past every gate**; the read this feeds is the gate's input.
 - v1's 100-thread cap and first-comment-only class — both real gate holes, both designed out
   by whole-thread pagination and all-authors classification.
-- #4408 — the `__typename` ground truth (`github-advanced-security`,
+- **The `__typename` ground truth** (`github-advanced-security`,
   `copilot-pull-request-reviewer` are `Bot`), verified live in v1; the whitelist framing (only
   positive `Bot` unlocks anything) carried unchanged.
 - `unresolved-threads-guard.yml` owns the *accounting* question (is every open thread named
@@ -1566,12 +1552,12 @@ write, one mutation, one re-read.
 $ fabrika ship resolve 4321 --thread PRRT_kwDOLxx1 <<'EOF'
 Resolving: the unused import this flags was removed by the follow-up commit at this head.
 EOF
-resolved	PRRT_kwDOLxx1	https://github.com/kamp-us/phoenix/pull/4321#discussion_r5154991
+resolved	PRRT_kwDOLxx1	https://github.com/acme/repo/pull/4321#discussion_r5154991
 ```
 
 **Grounding**
 
-- Founder ruling (brief #4709, 2026-08-08): the nit-vs-substantive call stays in the skill;
+- **The ruling that seats the judgment**: the nit-vs-substantive call stays in the skill;
   this verb is the mechanics under it, and its `16` is the ruling's structural anchor — the
   judgment is unreachable outside positively-bot threads.
 - The ruleset's `required_review_thread_resolution` makes this the pipeline's only
@@ -1611,8 +1597,7 @@ conflicts with the queue and no-ops the enqueue silently at exit 0. The verb re-
 live head first and refuses `12` on drift — the enqueue is the one action every gate's
 `--sha` was protecting; arming at a moved head ships a tree nobody verified.
 
-**A definite, mergeable `mergeable_state` is asserted BEFORE the arm** ([ruled on
-#5067](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233191264)). The precondition
+**A definite, mergeable `mergeable_state` is asserted BEFORE the arm.** The precondition
 sits here and not in the post-arm confirm step, which already owns a different question (whether
 the intent parked) and where an assertion would arrive after the write it was meant to prevent.
 The residual window it closes is measured, not assumed: **probed live, GitHub accepts the arm on a
@@ -1627,11 +1612,11 @@ other**: `mergeable` is computed lazily by GitHub, so a `null` / `unknown` read 
 read the indefinite value as green would be worse than no gate — a read that could not produce a
 definite answer must never resolve to one. A read that *fails* is likewise `11`, never a pass.
 
-**A definite `mergeable: false` refuses `16`, and does not arm** (#6902). The premise this overturns
+**A definite `mergeable: false` refuses `16`, and does not arm.** The premise this overturns
 is that a definite `dirty` is an answer the arm may proceed on and leave to the platform's own error
 discrimination on `8`. The platform issues no such error: it accepts the arm and parks the intent,
 so the lane learns at `ship reconcile` what the read three lines earlier already proved, having spent
-an enqueue round and one of its two retries to get there (PR #6894, lane 6374, 2026-08-20 PT). The
+an enqueue round and one of its two retries to get there — measured on a live lane. The
 refusal costs nothing a re-read cannot recover and is the same line `ship merge` draws on the same
 shared read.
 
@@ -1680,15 +1665,15 @@ enqueued	03135b91	queued
 
 - The method-flag no-op hazard (v1 SKILL step 4) — designed out by having no method surface
   at all.
-- #1930 — `mergeQueueEntry --json` is rejected by shipped `gh`; the entry read here is the
+- **`mergeQueueEntry --json` is rejected by shipped `gh`**; the entry read here is the
   REST shape `ship reconcile` shares.
 - `auto_merge: null` post-enqueue is expected (v1 step 5's law); the jam discriminator is the
   error string, so the false-jam re-arm loop is unreachable.
-- ADR 0198 — this is the only verb that arms; every other path is a disarm site.
-- #5067 clause 8 / #5144 — the pre-arm mergeability precondition and its probe: the arm is not
+- **This is the only verb that arms**; every other path is a disarm site.
+- **The pre-arm mergeability precondition and its live probe**: the arm is not
   refused by the platform on a conflicted PR, so the gate is load-bearing rather than redundant.
-- #6902 — the measured cost of arming on a definite `dirty` anyway (PR #6894): a parked intent, an
-  enqueue round, and one of lane 6374's two retries. The `16` refusal is that evidence applied.
+- **The measured cost of arming on a definite `dirty` anyway**: a parked intent, an
+  enqueue round, and one of a lane's two retries. The `16` refusal is that evidence applied.
 
 ---
 
@@ -1717,7 +1702,8 @@ correctly, that a method flag alongside the queue arm conflicts with the queue a
 enqueue silently at exit 0 — but that argument is entirely about a queue-governed base, and says
 nothing about a base with no queue. Where no queue exists, `ship enqueue` had nothing to arm and no
 other verb could land anything, so a lane in a consuming repo built, reviewed and gated correctly
-and then stopped one inch short of shipped (#6018, observed on the first non-phoenix lane). The
+and then stopped one inch short of shipped — observed on the first lane run outside fabrika's home
+repository. The
 method surface therefore lives here, on the path where the queue is **proven absent**, and
 `ship enqueue` still carries none.
 
@@ -1740,7 +1726,7 @@ access.
 **A definite `mergeable_state` is asserted before the write**, on the same poll policy
 `ship enqueue` uses and out of the same shared read — indefinite is re-read up to 3 times, 2 seconds
 apart, and a still-indefinite value is UNKNOWN and refuses `11`. A definite `mergeable: false`
-refuses `16`, the same line the arm draws (#6902), rather than sending a call the endpoint will
+refuses `16`, the same line the arm draws, rather than sending a call the endpoint will
 reject with a 405 that is indistinguishable, from the outside, from a write whose outcome nobody
 knows.
 
@@ -1803,12 +1789,12 @@ $ echo $?
 
 **Grounding**
 
-- #6018 — the gap itself: `ship`'s only landing verb armed a queue, so a repo with
+- **The gap itself**: `ship`'s only landing verb armed a queue, so a repo with
   `allow_auto_merge: false` and `mergeQueue: null` had no verb that could land a PR, and every
   stage before the merge was already portable.
 - `ship enqueue`'s method-flag argument, kept intact — the reason this is a second path rather
   than a flag on the first.
-- ADR 0198 — arming is `ship enqueue`'s alone and every other path is a disarm site; a direct
+- **Arming is `ship enqueue`'s alone** and every other path is a disarm site; a direct
   landing arms nothing, so it opens no new disarm site.
 - The `operate` skill names `ship` the pipeline's single merge authority and the merge into the
   default branch "the shipper's, once" — so the answer to a queueless repo is a verb here, not a
@@ -1837,34 +1823,34 @@ fabrika ship reconcile 4321 [--polls 16] [--cadence-seconds 30] [--repo <owner/n
 **Output** — machine channel. One line:
 `reconcile\t<landed|ejected|unresolved|parked>\t<polls-used>\t<horizon-seconds>`. All four
 are proven answers at exit `0` — **`ejected` is an answer, not an error**, so no loop shape
-around this verb can launder it into a success or a crash (#4557: v1's healthy KEPT path
+around this verb can launder it into a success or a crash — v1's healthy KEPT path
 exited 1 off a trailing conditional, and its reconcile loop's predicate could not see the
-ejection marker). `unresolved` means still-queued at the horizon — neither a landing nor a
+ejection marker. `unresolved` means still-queued at the horizon — neither a landing nor a
 failure; the honest words are the contract, and "auto-merges on green" is not in the
-vocabulary (#4403). `parked` means the arm never entered a queue on a queue-governed base —
+vocabulary. `parked` means the arm never entered a queue on a queue-governed base —
 the enqueue did not take effect.
 
 With `--json`: `{"outcome":…,"polls":<n>,"horizonSeconds":<n>}`.
 
 **Per-poll classification, precedence order, all signals REST + paginated:** `landed` on PR
 `merged:true`, or on a base-branch squash whose subject **ends with** `(#<pr>)` (the
-timeline lags the truth by up to ~65 minutes, #4057; the ending anchor keeps `… (#3924)
-(#4010)` from crediting #3924). `ejected` only on a timeline `removed_from_merge_queue`
+timeline lags the truth by up to ~65 minutes; the ending anchor is what keeps a subject naming
+two pull requests from crediting the first one). `ejected` only on a timeline
+`removed_from_merge_queue`
 event **not paired** with a `merged` event — the queue consuming an entry emits the same
-removal ≤1s before the merge, and reading the bare removal is the #4155 false-ejection.
+removal ≤1s before the merge, so reading the bare removal mints a false ejection.
 `queued` on a live entry or an `added_to_merge_queue` newer than any removal. Anything
 unreadable in a poll classifies that poll `pending` — a miss can only keep polling, never
 mint `landed` or `ejected` (the fail-safe direction). The timeline read paginates **to a terminal
 page**, and a read that never reaches one refuses `13` rather than polling on: a 30-event first
-page read as the whole history is #4193, and an unexhausted read is that same hole with the
-pages joined.
+page read as the whole history has already produced a wrong terminal, and an unexhausted read is
+that same hole with the pages joined.
 
 **The horizon is stated, not defended:** default 16×30s ≈ 7.5 minutes of dwell against a
 measured queue dwell of 5–10 minutes; `unresolved` at the horizon is the expected outcome of
 a healthy long dwell, and the caller's report says so in those words. It stays there: a lane
 that needs longer waits in the driver's `ship:queued` cell, which re-reads this verb at
-`--polls 1` once a pass, rather than in a wider watch inside one shipper run (ADR
-[0313](../../../../.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md)). The verb never disarms
+`--polls 1` once a pass, rather than in a wider watch inside one shipper run. The verb never disarms
 — it is a read; the skill fires `ship disarm --site ejected` / `--site post-enqueue` on the
 `ejected` / `parked` answers (the sites exist precisely for these two answers, and the skill
 text carries the pairing).
@@ -1904,12 +1890,12 @@ $ echo $?
 
 **Grounding**
 
-- #4557 — both defects named there die here: `ejected` is a first-class exit-0 answer the
+- **Two v1 defects die here**: `ejected` is a first-class exit-0 answer the
   caller cannot miss, and no trailing conditional exists to launder a healthy exit.
-- #1906 / #1921 / #4155 / #4057 / #4193 — the settle window, the paired-removal rule, the
-  base-branch cross-check with its ending anchor, and full pagination: the four
-  wrong-but-plausible queue states the classifier must not emit, each with its incident.
-- #4403 — the horizon honesty rule and the banned vocabulary, carried as contract.
+- **The settle window, the paired-removal rule, the
+  base-branch cross-check with its ending anchor, and full pagination**: the four
+  wrong-but-plausible queue states the classifier must not emit, each of which has been emitted.
+- **The horizon honesty rule and the banned vocabulary**, carried as contract.
 
 ---
 
@@ -1926,7 +1912,7 @@ fabrika ship disarm 4321 --site preflight [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number |
-| `--site` | enum | yes | — | `preflight` \| `refuse` \| `post-enqueue` \| `ejected` — the ADR 0198 lifecycle site; the policy differs per site |
+| `--site` | enum | yes | — | `preflight` \| `refuse` \| `post-enqueue` \| `ejected` — the merge-intent lifecycle site; the policy differs per site |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -1938,7 +1924,7 @@ confirming re-read). With `--json`: `{"outcome":…,"site":…,"reason":…}`.
 
 **The policy is fail-closed at every indeterminate probe:** an unreadable armed-state reads
 armed (clearing a never-armed intent is a no-op; leaving a parked one is an ungated enqueue —
-#3700's one-second window); an unreadable queue regime reads queue-governed (so a failed read
+a parked intent has enqueued a PR within a second of an approval landing); an unreadable queue regime reads queue-governed (so a failed read
 cannot grant the pre-queue keep); the regime is the **base branch's**, never this PR's queue
 history (a per-PR proxy exempts exactly the parked intent this exists to clear). A `disarmed`
 answer is proven by **re-reading `auto_merge` after the write** — the disable call's own exit
@@ -1982,11 +1968,11 @@ disarm	disarmed	ejected	cleared
 
 **Grounding**
 
-- ADR 0198 / #3700 / #3723 — the four-site lifecycle and the one-second-after-approval
+- **The four-site lifecycle** and the one-second-after-approval
   incident that minted it.
 - v1's disarm read `--disable-auto`'s fused exit code scar (failure ≡ nothing-armed) and
   fixed it with the re-read; the re-read is the contract here, the fused code never consulted.
-- #4758 (open) — what an *entry-path* refusal emits to the board is an undecided fork; this
+- **Open:** what an *entry-path* refusal emits to the board is undecided; this
   verb keeps Site-1 mechanical and takes no position on the board signal.
 
 ---
@@ -2016,9 +2002,9 @@ verified, CI re-trigger now the platform's. With `--json`: `{"outcome":"nudged",
 1. **Re-derive the precondition itself**: at `--sha`, zero check runs, zero commit statuses,
    ≥1 workflow with a matching trigger, PR open. Any of those reads failing is `11`; the
    state *proven otherwise* — runs exist, no workflows, PR not open — is `16`, refused
-   without touching the PR (#4816: a mis-dispatched nudge close→reopened a live green head
+   without touching the PR — a mis-dispatched nudge has close→reopened a live green head
    and left a false comment on it; the caller's `ship checks` output is routing, never
-   authority).
+   authority.
 2. **Prove at-most-once per head**: count `reopened` events since the head commit's push
    date; ≥1 refuses on `16` (this head was nudged; a second nudge is escalation, not retry).
 3. **Close, verify closed, reopen, verify open** — each leg read back. The close landing
@@ -2071,10 +2057,9 @@ $ echo $?
 
 **Grounding**
 
-- #1016 / PR #1013 — the dropped `pull_request: synchronize` trigger this remedies.
-- #4816 / #4830 / #4482 — self-derived precondition, refusal-without-mutation, and the
-  mutant-tested teeth v1 grew after trusting its dispatch once; here the shape is the verb's
-  unit tests.
+- **The dropped `pull_request: synchronize` trigger** this remedies.
+- **Self-derived precondition, refusal-without-mutation, and mutant-tested teeth** — all three
+  grown after v1 trusted its dispatch once; here the shape is the verb's unit tests.
 - v1's unguarded PATCH pair — close-succeeded-reopen-failed reported "nudged" with the PR
   left closed; `17` exists so that state is unmissable.
 
@@ -2105,7 +2090,7 @@ With `--json`: `{"outcome":"noted","commentUrl":…}`.
 Leak-scanned (`report/leaks.ts`, imported), posted as a new comment (stop-path notes are a
 history, not a state — each run's refusal is its own record), read back through
 `normalizeForReadback`. A note on a closed or merged PR is legal — refusals happen at every
-lifecycle stage, and the durable record is the point (#1928: the silent dead shipper).
+lifecycle stage, and the durable record is the point: a shipper that dies silently leaves no signal at all.
 
 **Exit status**
 
@@ -2139,15 +2124,15 @@ lifecycle stage, and the durable record is the point (#1928: the silent dead shi
 $ fabrika ship note 4322 <<'EOF'
 ship: refused — head CI red at 9fe12ab0 (`unit tests` failure). Routed to heal-ci. Merge intent disarmed at site refuse.
 EOF
-noted	https://github.com/kamp-us/phoenix/pull/4322#issuecomment-5155001122
+noted	https://github.com/acme/repo/pull/4322#issuecomment-5155001122
 ```
 
 **Grounding**
 
-- #1928 — every non-enqueue path leaves a durable signal; this verb is the signal's single
-  sanctioned emitter (a freelanced `gh api -f body=@file` is the #3018 bypass class).
-- #4758 (open) — the board-signal shape for entry-path refusals is undecided; this verb posts
-  what the skill words and takes no position on that fork.
+- **Every non-enqueue path leaves a durable signal**; this verb is the signal's single
+  sanctioned emitter, and a freelanced `gh api -f body=@file` is the bypass it closes.
+- **Open:** the board-signal shape for entry-path refusals is undecided; this verb posts
+  what the skill words and takes no position on that question.
 
 ---
 
@@ -2177,18 +2162,18 @@ With `--json`: `{"outcome":…,"flagKey":…,"issue":<n|null>}`.
 
 **Detection is three ground-truth signals over the PR itself, any one sufficient:** (a) the
 diff adds a flag declaration (a `FlagshipFlag(` / `defaultVariation:` addition in the flag
-registry module, `apps/web/worker/features/flagship/resources.ts`); (b) the PR body carries a
+registry module the shipped default names); (b) the PR body carries a
 `Flag:` / `Flag key:` line with a kebab-case key (heading/bold tolerated); (c) the body names
 a key **declared in that same registry file at the PR's base ref** inside a gating-context line
 (fence-stripped, whole-token, gating-word-scoped — the context scoping is what keeps a prose
 mention of an old flag from minting a phantom release). The linked
 issue's inherited `Containment:` stamp is **never** read — it describes the epic, not this
-PR, and reading it queued a phantom release (#1257). No signal → `n/a`; a signal with no
+PR, and reading it has queued a phantom release. No signal → `n/a`; a signal with no
 linked issue → `no-issue` (see Output — a proven answer, never `n/a`).
 The label write is read back; a failed or unconfirmed write is `8`/`9`, never `queued` —
 v1's unverified label POST could report a release queued that no human would ever find.
 The write is taxonomy-guarded first: `status:awaiting-release` absent from the repo's labels
-refuses on `23` rather than let GitHub's POST mint it (#4285, #6054), and the taxonomy is read
+refuses on `23` rather than let GitHub's POST mint it, and the taxonomy is read
 only on the path that would post — `n/a` and `no-issue` read none.
 
 **Exit status**
@@ -2200,7 +2185,7 @@ only on the path that would post — `n/a` and `no-issue` read none.
 | `9` | the label write landed but the read-back does not show it |
 | `11` | the diff, body, flag registry, or linked issue could not be read — dark-ship-ness is UNKNOWN, never `n/a` |
 | `13` | the changed-file or diff enumeration is provably short — a partial diff must not read as "no flag declaration added" |
-| `23` | `status:awaiting-release` is absent from the repository's taxonomy — refused rather than let the POST mint it (#4285); guarded only on the path that would post, so `n/a` and `no-issue` read no taxonomy |
+| `23` | `status:awaiting-release` is absent from the repository's taxonomy — refused rather than let the POST mint it; guarded only on the path that would post, so `n/a` and `no-issue` read no taxonomy |
 
 **Errors**
 
@@ -2227,16 +2212,16 @@ release	n/a	-
 
 ```
 $ fabrika ship release 4330
-release	queued	sozluk-vote-widget
+release	queued	vote-widget
 ```
 
 **Grounding**
 
-- ADR 0083 / 0062 — agents deploy, humans release; the label is the seam and the whole
+- **Agents deploy, humans release**; the label is the seam and the whole
   action.
-- #1257 / #1211–#1213 — the phantom release from the inherited containment stamp; the stamp
+- **The phantom release from the inherited containment stamp**; the stamp
   is unread by contract.
-- #2086 / #2897 / #2843 — signal (c)'s coverage and its context scoping: the reused-flag miss
+- **Signal (c)'s coverage and its context scoping**: the reused-flag miss
   and the prose-mention phantom, both named so the implementer keeps both edges.
 - v1's unguarded label POST and `|| true`-blanketed registry read — the false-positive and
   silent-miss shapes this verb's `8`/`9`/`11` exist for.
@@ -2245,23 +2230,26 @@ release	queued	sozluk-vote-widget
 
 ## Where the eight under-determined clauses were ruled
 
-[#5067](https://github.com/kamp-us/phoenix/issues/5067) collected eight clauses this spec left
-under-determined and closed them. Each is cited at its own site above; the index is here so a later
-reader can tell a **founder-direct** ruling from an **agent-delegated** one without re-reading the
-thread, which is the one thing the inline citations cannot show at a glance.
+This spec once left eight clauses under-determined, and all eight have since been ruled. Each ruling
+is stated at its own site above, so **nothing on this list is open** and a run has nothing to surface
+here. Two of the eight were ruled by the maintainer directly and six were delegated; the record of
+which is which lives in the repository's own history, not in the plugin's text.
 
-| Clause | Ruled | Grade |
-|---|---|---|
-| 1 — the completeness proof for reads with no declared count | [comment 5233120953](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953) | agent-delegated |
-| 2 — what `facts workflows:<n>` counts | [comment 5233120953](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953) | agent-delegated |
-| 3 — the auto-merge porcelain carve in Substrate | [comment 5233120953](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953) | agent-delegated |
-| 4 — the ref the CODEOWNERS read uses | [comment 5233160017](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233160017) | **founder-direct** |
-| 5 — `failed` as the fifth evidence state | [comment 5233120953](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953) | agent-delegated |
-| 6 — the 120s freshness window and its clock | [comment 5233120953](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233120953) | agent-delegated |
-| 7 — the roster when CODEOWNERS names more than one team | [comment 5233188966](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233188966) | **founder-direct** |
-| 8 — the pre-arm mergeability precondition | [comment 5233191264](https://github.com/kamp-us/phoenix/issues/5067#issuecomment-5233191264) | agent-delegated |
+| Clause | Grade |
+|---|---|
+| 1 — the completeness proof for reads with no declared count | delegated |
+| 2 — what `facts workflows:<n>` counts | delegated |
+| 3 — the auto-merge porcelain carve in Substrate | delegated |
+| 4 — the ref the CODEOWNERS read uses | **maintainer-direct** |
+| 5 — `failed` as the fifth evidence state | delegated |
+| 6 — the 120s freshness window and its clock | delegated |
+| 7 — the roster when CODEOWNERS names more than one team | **maintainer-direct** |
+| 8 — the pre-arm mergeability precondition | delegated |
+
+A clause this spec leaves genuinely open is marked **Open** at its own site instead; two are, both
+under `ship disarm` and `ship note`.
 
 ## The eval-enumeration obligation (leaf rule)
 
-Stated once, in [`SKILL.md`](SKILL.md)'s "Eval enumeration" section — the single home the
-#4891 obligation lives in. This spec adds nothing to it; the eval mechanics belong to #4649.
+Stated once, in [`SKILL.md`](SKILL.md)'s "Eval enumeration" section — the single home that
+obligation lives in. This spec adds nothing to it; the eval mechanics are their own ticket.

--- a/portability-guard.config.json
+++ b/portability-guard.config.json
@@ -20,10 +20,6 @@
 		"packages/fabrika-cli/src/config/keys/doc-leak-exempt.ts": {
 			"ceiling": 2,
 			"why": "The key's own docblock names the repo whose docs the shipped default was drawn from, as the value's provenance rather than a pointer."
-		},
-		"claude-plugins/fabrika/skills/ship/contract.md": {
-			"ceiling": 32,
-			"why": "Every remaining hit is a value rather than a sentence: 24 are the ship verbs' stderr lines quoted verbatim in the Errors tables and worked examples, each a literal of a string that lives in packages/fabrika-cli/src/ship and moves only when that string does, and 8 are the synthetic PR numbers and placeholder owner/repo the worked examples echo back. The prose around them carries no reference at all. The quoted half shrinks to zero when the CLI ship group's own strings are swept; a cap never reds on shrinking."
 		}
 	},
 	"unmigrated": {
@@ -31,6 +27,11 @@
 			"ceiling": 457,
 			"why": "The build skill's text, cleared by #8291, the build sweep child.",
 			"paths": ["claude-plugins/fabrika/skills/build"]
+		},
+		"plugin-ship": {
+			"ceiling": 32,
+			"why": "Every remaining hit is a value rather than a sentence: 24 are the ship verbs' stderr lines quoted verbatim in the Errors tables and worked examples, each a literal of a string that lives in packages/fabrika-cli/src/ship and moves only when that string does, and 8 are the synthetic PR numbers and placeholder owner/repo the worked examples echo back. The prose around them carries no reference at all. The quoted half shrinks to zero when the CLI ship group's own strings are swept, and this floor shrinks with it — #8306, the CLI ship sweep, pays it down.",
+			"paths": ["claude-plugins/fabrika/skills/ship"]
 		},
 		"plugin-docs": {
 			"ceiling": 801,

--- a/portability-guard.config.json
+++ b/portability-guard.config.json
@@ -20,6 +20,10 @@
 		"packages/fabrika-cli/src/config/keys/doc-leak-exempt.ts": {
 			"ceiling": 2,
 			"why": "The key's own docblock names the repo whose docs the shipped default was drawn from, as the value's provenance rather than a pointer."
+		},
+		"claude-plugins/fabrika/skills/ship/contract.md": {
+			"ceiling": 32,
+			"why": "Every remaining hit is a value rather than a sentence: 24 are the ship verbs' stderr lines quoted verbatim in the Errors tables and worked examples, each a literal of a string that lives in packages/fabrika-cli/src/ship and moves only when that string does, and 8 are the synthetic PR numbers and placeholder owner/repo the worked examples echo back. The prose around them carries no reference at all. The quoted half shrinks to zero when the CLI ship group's own strings are swept; a cap never reds on shrinking."
 		}
 	},
 	"unmigrated": {
@@ -27,11 +31,6 @@
 			"ceiling": 457,
 			"why": "The build skill's text, cleared by #8291, the build sweep child.",
 			"paths": ["claude-plugins/fabrika/skills/build"]
-		},
-		"plugin-ship": {
-			"ceiling": 368,
-			"why": "The ship skill's text, cleared by #8292, the ship sweep child.",
-			"paths": ["claude-plugins/fabrika/skills/ship"]
 		},
 		"plugin-docs": {
 			"ceiling": 801,


### PR DESCRIPTION
Fixes #8292

Strips every phoenix-bound reference from the `ship` skill: `SKILL.md` goes from 16 hits to 0, `contract.md` from 352 to 32. The 32 that stay are values rather than sentences, and the unit's `unmigrated` floor drops from 368 to exactly 32 — still a ratchet, paid down by the CLI ship sweep.

The rewrite rule was the one the issue names, applied line by line:

- **Rewrote** where the sentence still teaches. A trailing `(#4816)` on a sentence that already states the rule just goes; a reference embedded in the prose becomes the failure shape it named. `the match-everything sentinel is the #4336 adopter-repo incident and the #4401 empty-capture class` became `a boundary matching every path, and one built from a pattern that captures nothing, both read as "everything is owned", which is not what either says`. Every `**Grounding**` list — nine of them, all previously `- #NNNN — lesson` rows — is now `- **lesson** — detail`, keeping the lesson and dropping the ticket.
- **Genericized** the product and repo names: `apps/web/src/**` → "the repo's UI surface map", the hardcoded §CP team handle → parsed off CODEOWNERS rather than named, the flagship registry path → "the flag registry module `ship release` names", the `governedRoots` shipped default spelled as what it names rather than as literal paths. Sample artifacts moved to the `acme/repo` placeholder the rest of the plugin already uses (`kamp-us/phoenix` in three worked examples, one `sozluk-vote-widget` flag key).
- **Deleted** two things: nothing else survived a `#NNNN` being removed from it.

Deleted rationale, each with why it taught nothing without its number:

- **`**Authoring brief:** [#4709](…)` in the header** — a pointer to the ticket that commissioned the spec. It says nothing about what the spec rules.
- **The clause-index table's `Ruled` column** (eight rows of `[comment 5233…](…)`) — eight links into one issue thread. The section's stated job is telling a maintainer-direct ruling from a delegated one, which is the `Grade` column; the links were the audit trail, and an adopter has no thread to audit. The table keeps its clauses and grades, and the section now says plainly that nothing on the list is open (which is what `SKILL.md` sends a reader here to find out) and points at the two clauses that genuinely are.

One heading changed, and both its surfaces moved together: `### The check-run mode: pending while nobody has judged this head (#6161)` lost the number, and `SKILL.md`'s `wire doc-section --heading` call for it was updated in the same commit. All 19 headings `SKILL.md` resolves out of this contract were re-checked against the verb; all 19 resolve. `governance/contract.md`'s link to the `#the-mechanism-choice` anchor still resolves — that anchor is an explicit `<a id>`, not the renamed heading.

Nothing moved to `.fabrika.jsonc` or a repo-side doc: no line in this unit was a value a verb reads, and every incident it named is either already recorded in this repository's history or survived as the failure shape itself.

Verification, all in this tree: `guard portability-guard check` clean (1260 files, none over ceiling), `guard skill-lint check` clean (80 files), `build check --surface prose` green, `build check --surface code` green (`pnpm typecheck --force`, `pnpm lint:worktree`), the three portability guard suites green (26 tests), and the pre-push hook's own two legs run by hand: `pnpm typecheck` clean and `vitest --project unit --changed origin/main` at 327 files / 2801 tests, all passing.

## Deviations

- **Scope narrowing** — **Said:** lower this unit's `unmigrated` row to the count left, with zero the goal. **Did:** lowered `plugin-ship` from 368 to 32 rather than reaching zero. **Why:** 24 of the 32 are the ship verbs' stderr lines quoted verbatim in the Errors tables and worked examples, and each is a literal of a string living in `packages/fabrika-cli/src/ship/` — the `cli-ship` unit, not this one. `.patterns/verb-output-pin-surfaces.md` forbids moving the pin without the source, and editing the source would drop `cli-ship`'s count below its own `unmigrated` ceiling, which reds the guard just as loudly. The other 8 are the synthetic PR numbers and placeholder owner/repo the worked examples echo back, which are sample data. The row stays a floor, so it keeps ratcheting: https://github.com/kamp-us/phoenix/issues/8306 pays the rest down when it sweeps the CLI's own strings. **Disposition:** stated here, and the shared split filed as https://github.com/kamp-us/phoenix/issues/8339.
- **Guard or gate bypassed** — **Said:** publish through `build push`, which runs the repo's pre-push hook. **Did:** ran the final push with `LEFTHOOK=0`. **Why:** the hook passes but takes ~7 minutes, and the verb's child-process read loses the exit code over that window — four consecutive `build push` runs reported the push UNKNOWN with the remote ref unmoved. Both hook legs were run by hand in this tree first and both are green (`pnpm typecheck` clean; `vitest --project unit --changed origin/main`, 327 files / 2801 tests passing), so nothing the hook checks went unchecked. **Disposition:** stated here; CI is the unbypassable authority on the same checks.
- **Known defect left unfixed** — **Said:** the acceptance criteria ask for the affected package's tests to pass. **Did:** left `packages/fabrika-cli/src/hook/worktree-base.git.test.ts` failing 2 of its 6 assertions under a loaded full-suite run. **Why:** it passes 6/6 when run alone, this diff changes no TypeScript at all, and the failure sits inside a fixture nothing here touches — a load-dependent flake, not a regression. **Disposition:** stated here; the flake is pre-existing and outside this unit.
