### PR TITLE
fix: Tuval chat tail is arrival-ordered; a streamed reply can land twice, the second copy below newer rows

### DIFF
--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -10,8 +10,14 @@
 
 import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
 import {describe, expect, it} from "vitest";
+import {upsertItem} from "../../ai-agent/core/fold.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
-import {byteLength, type ItemId, TOOL_RESULT_BYTE_LIMIT} from "../../ai-agent/ports/index.ts";
+import {
+	byteLength,
+	type ItemId,
+	TOOL_RESULT_BYTE_LIMIT,
+	type TranscriptItem,
+} from "../../ai-agent/ports/index.ts";
 import {toAgentEvents} from "./events.ts";
 import {loadFixture} from "./fixtures/load.ts";
 import {emptyMapping, type Mapping, type MappingStep} from "./map.ts";
@@ -38,6 +44,13 @@ const run = (stream: ReadonlyArray<SDKMessage>, mapping: Mapping = emptyMapping)
 
 const items = (events: ReadonlyArray<AgentEvent>) =>
 	events.flatMap((event) => (event.kind === "item" ? [event.item] : []));
+
+/** The transcript these events fold to, in the arrival order `upsertItem` gives it. */
+const tail = (events: ReadonlyArray<AgentEvent>): ReadonlyArray<TranscriptItem> =>
+	items(events).reduce<ReadonlyArray<TranscriptItem>>(
+		(carried, one) => upsertItem(carried, one),
+		[],
+	);
 
 describe("toAgentEvents over a captured init", () => {
 	it("reports the model the session named, and no phase", () => {
@@ -567,6 +580,88 @@ describe("toAgentEvents over a streamed turn that reasons before it answers", ()
 				.map(() => true),
 			undefined,
 		]);
+	});
+});
+
+describe("toAgentEvents over a streamed turn whose assistant frame lands after the close", () => {
+	/**
+	 * Arrival order is the only variable here. Every envelope is the committed streaming turn's own,
+	 * and the turn's `assistant` frame is lifted out of its captured slot — mid-stream, where it
+	 * folds into the open reply — to after `message_stop`, where the reply has already settled. No
+	 * capture exhibits that ordering: the founder's sighting of the doubled row was not captured,
+	 * and nothing proves the SDK ever delivers the frame that late. The mapping holds on either
+	 * order because a frame naming a settled `msg_*` belongs on that row whatever the SDK does
+	 * (#8366).
+	 */
+	const MSG = "msg_00000000000000000006";
+	const stream = messages("streaming-turn");
+	const captured = <T extends SDKMessage>(rows: ReadonlyArray<T>, what: string): T => {
+		const first = rows[0];
+		if (first === undefined) throw new Error(`the capture holds no ${what} frame`);
+		return first;
+	};
+	const finished = captured(
+		stream.flatMap((one) => (one.type === "assistant" ? [one] : [])),
+		"assistant",
+	);
+	/** The capture with its `assistant` frame moved past `message_stop`, `between` in the gap. */
+	const late = (
+		frame: SDKMessage = finished,
+		between: ReadonlyArray<SDKMessage> = [],
+	): ReadonlyArray<SDKMessage> =>
+		stream.flatMap((one) =>
+			one.type === "assistant"
+				? []
+				: one.type === "stream_event" && one.event.type === "message_stop"
+					? [one, ...between, frame]
+					: [one],
+		);
+
+	it("lands the frame on the settled row instead of a second copy of the answer", () => {
+		const {events} = run(late());
+		const replies = tail(events).filter((one) => one.kind === "assistant");
+		expect(replies).toEqual([
+			{kind: "assistant", id: MSG, timestamp: AT, text: "hello from tuval streaming capture"},
+		]);
+	});
+
+	it("keeps the reply above a tool row that landed while the frame was in flight", () => {
+		// The tool row is the `tool-turn` capture's own `tool_use` frame, so the gap is filled by a
+		// real envelope rather than an invented one; only where it sits is this case's doing.
+		const tool = captured(
+			messages("tool-turn").flatMap((one) => (one.type === "assistant" ? [one] : [])),
+			"tool_use",
+		);
+		const {events} = run(late(finished, [tool]));
+		const rows = tail(events).filter((one) => one.kind === "assistant" || one.kind === "tool");
+		expect(rows.map((one) => one.kind)).toEqual(["assistant", "tool"]);
+		expect(rows[0]).toEqual({
+			kind: "assistant",
+			id: MSG,
+			timestamp: AT,
+			text: "hello from tuval streaming capture",
+		});
+	});
+
+	/**
+	 * The frame carries `thinking-turn`'s captured reasoning block in place of the streaming turn's
+	 * text block — two captures crossed, because whether a turn reasons is the provider's call and
+	 * no single capture holds both shapes (`fixtures/PROVENANCE.md`). Nothing here is invented: the
+	 * envelope and the block are both captured bytes, and the ordering stays this case's variable.
+	 */
+	it("hangs a late reasoning block off the settled row's id", () => {
+		const reasoned = captured(
+			messages("thinking-turn").flatMap((one) => (one.type === "assistant" ? [one] : [])),
+			"thinking",
+		);
+		const frame: unknown = {
+			...finished,
+			message: {...finished.message, content: reasoned.message.content},
+		};
+		const {events} = run(late(frame as SDKMessage));
+		const thinking = tail(events).filter((one) => one.kind === "thinking");
+		expect(thinking.map((one) => one.id)).toEqual([`${MSG}:thinking`]);
+		expect(thinking[0]?.timestamp).toBe(AT);
 	});
 });
 

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -72,6 +72,12 @@ export interface Mapping {
 	readonly toolCalls: ReadonlyMap<string, ToolCall>;
 	/** The reply the deltas are growing, or `null` when no turn is streaming. */
 	readonly partial: PartialReply | null;
+	/**
+	 * The reply whose stream has closed, kept so a frame still naming that `msg_*` finds its row.
+	 * Dropping the id at the close is what let a late frame mint a second copy of one answer, keyed
+	 * on the frame's own uuid and appended below whatever arrived in between (#8366).
+	 */
+	readonly settled: PartialReply | null;
 	/** How many messages this mapping had nothing to say about. */
 	readonly skipped: number;
 }
@@ -80,6 +86,7 @@ export const emptyMapping: Mapping = {
 	model: "",
 	toolCalls: new Map(),
 	partial: null,
+	settled: null,
 	skipped: 0,
 };
 
@@ -147,11 +154,14 @@ export const assistantEvents = (
 	const interrupted = message.aborted === true;
 	// The deltas of this same reply, when the run streamed them: this frame's `message.id` is the
 	// `msg_*` the `message_start` announced, so the row lands on the partials rather than beside
-	// them, at the clock they were written under.
-	const open = openReplyOf(body, mapping);
-	const at = open === null ? timestampOf(message, options.at) : open.at;
-	const id = open?.id ?? (typeof message.uuid === "string" ? message.uuid : `assistant-${at}`);
-	const reply = open === null ? null : grown(open, addedTextOf(open.text, frameText));
+	// them, at the clock they were written under. The stream having already closed changes nothing
+	// about where the frame belongs, so a match against the settled reply routes it the same way.
+	const open = replyOf(body, mapping.partial);
+	const closed = open === null ? replyOf(body, mapping.settled) : null;
+	const row = open ?? closed;
+	const at = row === null ? timestampOf(message, options.at) : row.at;
+	const id = row?.id ?? (typeof message.uuid === "string" ? message.uuid : `assistant-${at}`);
+	const reply = row === null ? null : grown(row, addedTextOf(row.text, frameText));
 	const ends = interrupted || stopReasonOf(body) !== null;
 	const settles = open === null || ends;
 	const text = reply === null ? frameText : reply.text;
@@ -209,15 +219,18 @@ export const assistantEvents = (
 			...mapping,
 			toolCalls,
 			partial: open === null ? mapping.partial : ends ? null : reply,
+			// A row this frame leaves settled stays reachable, so a further frame of the same turn —
+			// a trailing content block — still lands on it rather than beside it.
+			settled: reply === null || (open !== null && !ends) ? mapping.settled : reply,
 		},
 		events,
 	};
 };
 
-/** The reply this frame belongs to, or `null` when it is not a frame of the streaming turn. */
-const openReplyOf = (body: unknown, mapping: Mapping): PartialReply | null => {
-	if (mapping.partial === null || !isRecord(body)) return null;
-	return body.id === mapping.partial.id ? mapping.partial : null;
+/** The reply this frame belongs to, or `null` when it is not a frame of that reply's turn. */
+const replyOf = (body: unknown, reply: PartialReply | null): PartialReply | null => {
+	if (reply === null || !isRecord(body)) return null;
+	return body.id === reply.id ? reply : null;
 };
 
 /**
@@ -290,7 +303,7 @@ export const partialReplyEvents = (
 	if (open === null) return skipMessage(mapping);
 	if (event.type === "message_stop" || stopsStream(event)) {
 		return {
-			mapping: {...mapping, partial: null},
+			mapping: {...mapping, partial: null, settled: open},
 			events:
 				open.text.length === 0
 					? []


### PR DESCRIPTION
A streamed reply could render twice, with the second copy below whatever landed in between.
`partialReplyEvents` dropped the turn's `msg_*` id when the stream closed, so the SDK's own
`assistant` frame for that same message — if it arrived after the close — looked like an unrelated
message: `assistantEvents` keyed it on `message.uuid` and `upsertItem` appended it at the tail.

`Mapping` now keeps the reply it just settled (`settled: PartialReply | null`), and `assistantEvents`
routes a frame naming that `msg_*` onto the same row: same `ItemId`, same `at`. Re-emitting under the
settled id is an in-place `upsertItem` replace, so it is idempotent — `fold.ts` is untouched and no
timestamp sort is introduced anywhere. A late thinking block rides the same id via the
`<msg_*>:thinking` suffix.

The fix holds on either arrival order, which is the point: no committed capture shows the SDK
delivering that frame late, and the founder's sighting was not captured. Three new cases in
`events.unit.test.ts` build their input by moving the committed `streaming-turn.json` capture's own
`assistant` frame past `message_stop` — every envelope stays captured-real and only the ordering
varies. All three fail on `main` and pass here. The existing fixture-order cases still fold to one
assistant row.

Ran: `vitest run src/claude/history/` (52 passed) and `pnpm --filter @kampus/tuval typecheck`.

Fixes #8366

## Deviations

- **Out-of-scope change** — **Said:** #8366 names `partialReplyEvents` and `assistantEvents`.
  **Did:** also inlined the one-line `openReplyOf` helper into a shared `replyOf(body, reply)` that
  both the open and the settled lookup call. **Why:** the two lookups are the same comparison, and
  keeping two spellings of it invites them to drift. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the ticket asks for two new tests, both off `streaming-turn.json`
  with the order varied. **Did:** added a third case for the late-thinking criterion, and it crosses
  two captures — `thinking-turn.json`'s real reasoning block on `streaming-turn.json`'s real
  `assistant` envelope. **Why:** whether a turn reasons is the provider's call, so no single capture
  holds both shapes; the existing "reasons before it answers" case sets the same precedent and the new
  case says so at the case. **Disposition:** stated here; both bytes are captured, nothing is invented.
