### PR TITLE
fix: Resuming a Tuval pi session replays the whole transcript as live events and trims the operator's new message out of the window

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -25,7 +25,7 @@ import {
 } from "../ports/index.ts";
 import {START_ERROR} from "./failures.ts";
 import {markTurnRunning, settleAccepted, settlePending} from "./sends.ts";
-import {type AiAgentSessionState, settleTurn, type UsageTotals} from "./state.ts";
+import {type AiAgentSessionState, settleTurn, type UsageLedger} from "./state.ts";
 
 /** How much tail one session keeps. Absent, the window module's own defaults apply. */
 export interface WindowLimits {
@@ -94,14 +94,30 @@ export const foldItem = (
 		: {items: planned.items, omitted: addOmission(transcript.omitted, planned.omitted)};
 };
 
+/**
+ * One turn's cost, folded under that turn's own id.
+ *
+ * A turn already in the ledger keeps the entry it has: the event is the backend restating what
+ * that turn cost, which a resume does routinely, and adding it a second time is the double-count
+ * #8369 closed. The model is not keyed — it is whatever the newest report named, which is what the
+ * inspector's model line has always shown.
+ */
 export const addUsage = (
-	usage: UsageTotals,
+	usage: UsageLedger,
 	event: Extract<AgentEvent, {kind: "usage"}>,
-): UsageTotals => ({
+): UsageLedger => ({
 	model: event.model,
-	inputTokens: usage.inputTokens + event.inputTokens,
-	outputTokens: usage.outputTokens + event.outputTokens,
-	cost: usage.cost + event.cost,
+	turns:
+		usage.turns[event.turn] === undefined
+			? {
+					...usage.turns,
+					[event.turn]: {
+						inputTokens: event.inputTokens,
+						outputTokens: event.outputTokens,
+						cost: event.cost,
+					},
+				}
+			: usage.turns,
 });
 
 const without = <A>(

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -66,7 +66,9 @@ export {
 	loadCheckpoint,
 	parseSessionState,
 	readCheckpoint,
+	SPENT_BEFORE_LEDGER,
 	withCheckpointDefaults,
+	withUsageLedger,
 } from "./snapshot.ts";
 export {
 	type AgentFailure,
@@ -88,5 +90,8 @@ export {
 	settleRunningSubagents,
 	settleTurn,
 	type ThinkingState,
+	type TurnUsage,
+	type UsageLedger,
 	type UsageTotals,
+	usageTotals,
 } from "./state.ts";

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -17,7 +17,7 @@ import {aiAgentSessionMachine} from "./machine.ts";
 import type {AiAgentSessionCmd, AiAgentSessionMsg} from "./messages.ts";
 import {queueLimit} from "./queue.ts";
 import {isAiAgentSessionState, loadCheckpoint} from "./snapshot.ts";
-import {type AiAgentSessionState, checkpointFields, initialState} from "./state.ts";
+import {type AiAgentSessionState, checkpointFields, initialState, usageTotals} from "./state.ts";
 
 const machine = aiAgentSessionMachine({cwd: "/repo"});
 
@@ -486,22 +486,51 @@ describe("event", () => {
 		expect(state.modes).toEqual({current: "plan", available: ["plan"]});
 	});
 
-	it("accumulates cost and tokens across usage events", () => {
-		const usage = (cost: number): AgentEvent => ({
+	it("accumulates cost and tokens across turns", () => {
+		const usage = (turn: string, cost: number): AgentEvent => ({
 			kind: "usage",
+			turn,
 			model: "claude-opus-5",
 			inputTokens: 10,
 			outputTokens: 5,
 			cost,
 		});
-		const [once] = apply(started(), {type: "event", sessionId: "session-1", event: usage(0.01)});
-		const [twice] = apply(once, {type: "event", sessionId: "session-1", event: usage(0.02)});
-		expect(twice.usage).toEqual({
+		const [once] = apply(started(), {
+			type: "event",
+			sessionId: "session-1",
+			event: usage("turn-1", 0.01),
+		});
+		const [twice] = apply(once, {
+			type: "event",
+			sessionId: "session-1",
+			event: usage("turn-2", 0.02),
+		});
+		expect(usageTotals(twice.usage)).toEqual({
 			model: "claude-opus-5",
 			inputTokens: 20,
 			outputTokens: 10,
 			cost: 0.03,
 		});
+	});
+
+	/**
+	 * A layer reports a turn's cost as a fact about that turn, and reports it again whenever a
+	 * resume walks a transcript this process has already folded (#8369). The second report is the
+	 * same turn, not a second one.
+	 */
+	it("counts one turn's cost once however often the backend reports it", () => {
+		const usage: AgentEvent = {
+			kind: "usage",
+			turn: "turn-1",
+			model: "claude-opus-5",
+			inputTokens: 10,
+			outputTokens: 5,
+			cost: 0.01,
+		};
+		const [once] = apply(started(), {type: "event", sessionId: "session-1", event: usage});
+		const [twice] = apply(once, {type: "event", sessionId: "session-1", event: usage});
+		expect(usageTotals(twice.usage)).toEqual(usageTotals(once.usage));
+		expect(usageTotals(twice.usage).cost).toBe(0.01);
 	});
 
 	it("adds a permission card and drops it when the backend settles it itself", () => {

--- a/apps/tuval/src/ai-agent/core/properties.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/properties.unit.test.ts
@@ -112,6 +112,7 @@ const randomMsg = (
 					sessionId: "session-1",
 					event: {
 						kind: "usage",
+						turn: `turn-${random.int(1_000)}`,
 						model: "claude-opus-5",
 						inputTokens: random.int(500),
 						outputTokens: random.int(500),

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -28,6 +28,8 @@ import {
 	initialState,
 	phases,
 	restore,
+	type TurnUsage,
+	type UsageLedger,
 	type UsageTotals,
 } from "./state.ts";
 
@@ -37,12 +39,25 @@ const isNullOrString = (value: unknown): value is string | null =>
 const isFiniteNumber = (value: unknown): value is number =>
 	typeof value === "number" && Number.isFinite(value);
 
-const isUsage = (value: unknown): value is UsageTotals =>
+/** The flat totals a checkpoint written before usage was keyed by turn carries; see `withUsageLedger`. */
+const isFlatUsage = (value: unknown): value is UsageTotals =>
 	Predicate.isObject(value) &&
 	isNullOrString(value.model) &&
 	isFiniteNumber(value.inputTokens) &&
 	isFiniteNumber(value.outputTokens) &&
 	isFiniteNumber(value.cost);
+
+const isTurnUsage = (value: unknown): value is TurnUsage =>
+	Predicate.isObject(value) &&
+	isFiniteNumber(value.inputTokens) &&
+	isFiniteNumber(value.outputTokens) &&
+	isFiniteNumber(value.cost);
+
+const isUsage = (value: unknown): value is UsageLedger =>
+	Predicate.isObject(value) &&
+	isNullOrString(value.model) &&
+	Predicate.isObject(value.turns) &&
+	Object.values(value.turns).every(isTurnUsage);
 
 const isPermissions = (value: unknown): value is Readonly<Record<string, PendingPermission>> =>
 	Predicate.isObject(value) && Object.values(value).every(isPendingPermission);
@@ -167,6 +182,39 @@ export const withCheckpointDefaults = (raw: unknown, cwd: string): unknown => {
 };
 
 /**
+ * The one entry a pre-ledger checkpoint's totals come back as. Reserved: no backend mints it.
+ */
+export const SPENT_BEFORE_LEDGER = "spent-before-ledger";
+
+/**
+ * A checkpoint written before usage was keyed by turn, read as a ledger (#8369).
+ *
+ * It carries one flat sum and no ids to attribute it to, so the sum becomes a single entry and the
+ * totals the window renders are unchanged. This is a repair rather than a default, which is why it
+ * is not `withCheckpointDefaults`' walk: the field is present and well-formed, it is the shape the
+ * ledger replaced. A turn that was in flight when that checkpoint was written is not in the ledger
+ * and can still be reported once more — this migrates the totals, it cannot recover ids the old
+ * shape never held.
+ */
+export const withUsageLedger = (raw: unknown): unknown => {
+	if (!Predicate.isObject(raw) || !isFlatUsage(raw.usage)) return raw;
+	const flat = raw.usage;
+	return {
+		...raw,
+		usage: {
+			model: flat.model,
+			turns: {
+				[SPENT_BEFORE_LEDGER]: {
+					inputTokens: flat.inputTokens,
+					outputTokens: flat.outputTokens,
+					cost: flat.cost,
+				},
+			},
+		},
+	};
+};
+
+/**
  * The checkpoint read, as the defaulting and the predicate composed once: the session, or `null`.
  *
  * One function rather than two call sites of the same pair, because `loadCheckpoint` wants the
@@ -174,7 +222,7 @@ export const withCheckpointDefaults = (raw: unknown, cwd: string): unknown => {
  * different verdict than the one the window renders would hold the wrong bytes (#8112).
  */
 export const readCheckpoint = (loaded: unknown, cwd: string): AiAgentSessionState | null =>
-	parseSessionState(withCheckpointDefaults(loaded, cwd));
+	parseSessionState(withUsageLedger(withCheckpointDefaults(loaded, cwd)));
 
 /**
  * What the store loaded, read as a session — or the refusal, when it is not one. The machine's

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -27,14 +27,50 @@ import {promptUnqueued} from "./failures.ts";
 import {type QueuedPrompt, releaseQueued} from "./queue.ts";
 import type {SendOutcome} from "./sends.ts";
 
-/** Cumulative for the session: the core owns the running totals, the layer reports the deltas. */
-export interface UsageTotals {
+/** What one turn spent. No model of its own: the ledger holds the last one named. */
+export interface TurnUsage {
+	readonly inputTokens: number;
+	readonly outputTokens: number;
+	readonly cost: number;
+}
+
+/**
+ * What the session has spent, under each turn's own id.
+ *
+ * Keyed rather than summed, and that is the whole point: a layer reports a turn's cost as a fact
+ * about that turn, not as an increment, and it reports it again whenever a resume walks a
+ * transcript this process has already folded (#8369). A running sum cannot tell that second report
+ * from a second turn, so every path that resumes has to carry "already counted" correctly and
+ * exactly one of them getting it wrong is a wrong number on the operator's screen. Under a key
+ * there is nothing to carry: folding a turn already here is a no-op.
+ *
+ * The totals are derived (`usageTotals`) rather than stored beside this, so no total can disagree
+ * with the turns it is a sum of.
+ */
+export interface UsageLedger {
 	/** The model the last usage event named, or `null` before any has arrived. */
+	readonly model: string | null;
+	readonly turns: Readonly<Record<string, TurnUsage>>;
+}
+
+/** Cumulative for the session, as a window renders it: the ledger summed. */
+export interface UsageTotals {
 	readonly model: string | null;
 	readonly inputTokens: number;
 	readonly outputTokens: number;
 	readonly cost: number;
 }
+
+export const usageTotals = (usage: UsageLedger): UsageTotals =>
+	Object.values(usage.turns).reduce<UsageTotals>(
+		(totals, turn) => ({
+			model: totals.model,
+			inputTokens: totals.inputTokens + turn.inputTokens,
+			outputTokens: totals.outputTokens + turn.outputTokens,
+			cost: totals.cost + turn.cost,
+		}),
+		{model: usage.model, inputTokens: 0, outputTokens: 0, cost: 0},
+	);
 
 export interface ModeState {
 	readonly current: Mode | null;
@@ -104,7 +140,7 @@ export interface AiAgentSessionState {
 	readonly interrupted: ItemId | null;
 	/** An interruption asked for and not yet confirmed by an event; `null` when none is in flight. */
 	readonly interruption: Interruption | null;
-	readonly usage: UsageTotals;
+	readonly usage: UsageLedger;
 	/**
 	 * Pending permission cards by request id: one arrives with an event, and one leaves on the
 	 * confirmation of its answer rather than on the click that answered it (#8006).
@@ -207,7 +243,7 @@ export type CheckpointField = (typeof checkpointFields)[number];
 
 export const emptyOmission: WindowOmission = {items: 0, bytes: 0, reason: "none"};
 
-export const emptyUsage: UsageTotals = {model: null, inputTokens: 0, outputTokens: 0, cost: 0};
+export const emptyUsage: UsageLedger = {model: null, turns: {}};
 
 export const initialState = (cwd: string): AiAgentSessionState => ({
 	phase: "idle",

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -51,7 +51,10 @@ const saved: AiAgentSessionState = {
 		items: [userItem("i0"), assistantItem("i1"), toolItem("i2")],
 		omitted: {items: 3, bytes: 120, reason: "item-limit"},
 	},
-	usage: {model: "claude-opus-5", inputTokens: 1_200, outputTokens: 340, cost: 0.031},
+	usage: {
+		model: "claude-opus-5",
+		turns: {i1: {inputTokens: 1_200, outputTokens: 340, cost: 0.031}},
+	},
 	permissions: {"req-1": pendingPermission({request: card, seq: 3})},
 	permissionsRaised: 3,
 	modes: {current: Mode.make("plan"), available: [Mode.make("plan"), Mode.make("build")]},

--- a/apps/tuval/src/ai-agent/events.ts
+++ b/apps/tuval/src/ai-agent/events.ts
@@ -150,6 +150,15 @@ export interface SubagentEvent {
 /** Plain numbers and a plain model name: no backend's usage type reaches the core. */
 export interface UsageEvent {
 	readonly kind: "usage";
+	/**
+	 * Which turn this cost belongs to, under the reporting backend's own id for it.
+	 *
+	 * A report is not an increment. A resume re-reports turns the process has already folded — the
+	 * reconnect hands its own tail through as the fold's seed, and a row the restore marked
+	 * `interrupted` differs from the backend's copy by that marker alone (#8369) — so the core keys
+	 * the cost on this and the second report of one turn adds nothing.
+	 */
+	readonly turn: string;
 	readonly model: string;
 	readonly inputTokens: number;
 	readonly outputTokens: number;

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -145,12 +145,13 @@ export const aiAgentHandlers = <RIn = never>(
 		cwd: string,
 		resume: string | null,
 		mode: Mode | null,
+		holdsTranscript = false,
 	): Effect.Effect<Follow, never, ProcessSelf | RIn> =>
 		Effect.gen(function* () {
 			const agent = yield* slot.rebuild;
 			const options: StartOptions = {
 				cwd,
-				...(resume === null ? {} : {resume}),
+				...(resume === null ? {} : {resume, holdsTranscript}),
 				...(mode === null ? {} : {mode}),
 			};
 			const started = yield* Effect.result(underPolicy(agent.start(options), policy));
@@ -198,7 +199,11 @@ export const aiAgentHandlers = <RIn = never>(
 
 		"aiAgent.start": (cmd) => open(cmd.cwd, cmd.resume, cmd.mode),
 
-		"aiAgent.reconnect": (cmd) => open(cmd.cwd, cmd.sessionId, cmd.mode),
+		// The one resume whose window already holds the transcript: a reconnect stands a new
+		// transport under the state this process came back with, so the layer owes it no replay
+		// (#8369). A `start` carrying a resume is the picker opening a session on a fresh process,
+		// which holds nothing and needs one.
+		"aiAgent.reconnect": (cmd) => open(cmd.cwd, cmd.sessionId, cmd.mode, true),
 
 		// The one handler that reads the committed state rather than folding forward from it: there
 		// is no event to fold, which is the whole point — a restored session's tail and its pending

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -29,7 +29,6 @@ import {
 	type AiAgentEventsSub,
 	type AiAgentSessionCmd,
 	type AiAgentSessionMsg,
-	type AiAgentSessionState,
 	type AiAgentSessionSub,
 	foldEvent,
 	initialState,
@@ -105,22 +104,6 @@ const noSession: AgentFailure = {
 	tag: START_ERROR,
 	reason: "session-not-found",
 	detail: "no agent has been started in this process",
-};
-
-/**
- * The newest item in a restored tail that a backend minted, or `null`.
- *
- * The operator's own turn is recorded locally on send under an id no layer has ever seen
- * (`../core/fold.ts`'s `promptItem`), so it cannot be the boundary a layer suppresses at — it walks
- * back past every still-unechoed local turn to the last item the session itself produced.
- */
-const newestBackendItemId = (state: AiAgentSessionState | null): string | null => {
-	const items = state?.transcript.items ?? [];
-	for (let index = items.length - 1; index >= 0; index -= 1) {
-		const item = items[index];
-		if (item !== undefined && !(item.kind === "user" && item.local === true)) return item.id;
-	}
-	return null;
 };
 
 export const aiAgentHandlers = <RIn = never>(
@@ -227,9 +210,9 @@ export const aiAgentHandlers = <RIn = never>(
 		// which holds nothing and needs one.
 		//
 		// What it does owe is everything the session finished while the socket was down, so the
-		// boundary rides with the flag: the newest item the *backend* minted in the restored tail.
-		// A locally-recorded turn is skipped because no layer knows its id — a boundary the layer
-		// cannot find in its snapshot suppresses nothing, which would replay the session (#8374).
+		// restored tail itself rides with the flag. The layer reads both facts off it: where
+		// "already on screen" stops, and what each of those rows looked like when this process last
+		// saw it — a row that moved while the transport was gone is not one the operator has read.
 		"aiAgent.reconnect": (cmd) =>
 			Effect.flatMap(readSession, (state) =>
 				open(
@@ -237,7 +220,7 @@ export const aiAgentHandlers = <RIn = never>(
 					{
 						sessionId: cmd.sessionId,
 						holdsTranscript: true,
-						newestItemId: newestBackendItemId(state),
+						held: state?.transcript.items ?? [],
 					},
 					cmd.mode,
 				),

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -29,6 +29,7 @@ import {
 	type AiAgentEventsSub,
 	type AiAgentSessionCmd,
 	type AiAgentSessionMsg,
+	type AiAgentSessionState,
 	type AiAgentSessionSub,
 	foldEvent,
 	initialState,
@@ -39,6 +40,7 @@ import {isRefusal, planTranscriptPage, withoutLocalEchoes} from "../history/inde
 import {SessionOpening} from "../opening.ts";
 import type {Mode, TranscriptPagePayload} from "../ports/index.ts";
 import {
+	type ResumeTarget,
 	type StartOptions,
 	type TranscriptPage,
 	TransportError,
@@ -105,6 +107,22 @@ const noSession: AgentFailure = {
 	detail: "no agent has been started in this process",
 };
 
+/**
+ * The newest item in a restored tail that a backend minted, or `null`.
+ *
+ * The operator's own turn is recorded locally on send under an id no layer has ever seen
+ * (`../core/fold.ts`'s `promptItem`), so it cannot be the boundary a layer suppresses at — it walks
+ * back past every still-unechoed local turn to the last item the session itself produced.
+ */
+const newestBackendItemId = (state: AiAgentSessionState | null): string | null => {
+	const items = state?.transcript.items ?? [];
+	for (let index = items.length - 1; index >= 0; index -= 1) {
+		const item = items[index];
+		if (item !== undefined && !(item.kind === "user" && item.local === true)) return item.id;
+	}
+	return null;
+};
+
 export const aiAgentHandlers = <RIn = never>(
 	options: AiAgentHandlerOptions<RIn>,
 ): AiAgentHandlerSet<RIn> => {
@@ -143,15 +161,14 @@ export const aiAgentHandlers = <RIn = never>(
 	 */
 	const open = (
 		cwd: string,
-		resume: string | null,
+		resume: ResumeTarget | null,
 		mode: Mode | null,
-		holdsTranscript = false,
 	): Effect.Effect<Follow, never, ProcessSelf | RIn> =>
 		Effect.gen(function* () {
 			const agent = yield* slot.rebuild;
 			const options: StartOptions = {
 				cwd,
-				...(resume === null ? {} : {resume, holdsTranscript}),
+				...(resume === null ? {} : {resume}),
 				...(mode === null ? {} : {mode}),
 			};
 			const started = yield* Effect.result(underPolicy(agent.start(options), policy));
@@ -197,13 +214,34 @@ export const aiAgentHandlers = <RIn = never>(
 					: [{type: "start", cwd: opening.value.cwd, resume: opening.value.resume} as const],
 			),
 
-		"aiAgent.start": (cmd) => open(cmd.cwd, cmd.resume, cmd.mode),
+		"aiAgent.start": (cmd) =>
+			open(
+				cmd.cwd,
+				cmd.resume === null ? null : {sessionId: cmd.resume, holdsTranscript: false},
+				cmd.mode,
+			),
 
 		// The one resume whose window already holds the transcript: a reconnect stands a new
 		// transport under the state this process came back with, so the layer owes it no replay
 		// (#8369). A `start` carrying a resume is the picker opening a session on a fresh process,
 		// which holds nothing and needs one.
-		"aiAgent.reconnect": (cmd) => open(cmd.cwd, cmd.sessionId, cmd.mode, true),
+		//
+		// What it does owe is everything the session finished while the socket was down, so the
+		// boundary rides with the flag: the newest item the *backend* minted in the restored tail.
+		// A locally-recorded turn is skipped because no layer knows its id — a boundary the layer
+		// cannot find in its snapshot suppresses nothing, which would replay the session (#8374).
+		"aiAgent.reconnect": (cmd) =>
+			Effect.flatMap(readSession, (state) =>
+				open(
+					cmd.cwd,
+					{
+						sessionId: cmd.sessionId,
+						holdsTranscript: true,
+						newestItemId: newestBackendItemId(state),
+					},
+					cmd.mode,
+				),
+			),
 
 		// The one handler that reads the committed state rather than folding forward from it: there
 		// is no event to fold, which is the whole point — a restored session's tail and its pending

--- a/apps/tuval/src/ai-agent/ports/index.ts
+++ b/apps/tuval/src/ai-agent/ports/index.ts
@@ -59,6 +59,7 @@ export {
 	isTranscriptItem,
 	isTranscriptItems,
 	type JsonValue,
+	newestBackendItemId,
 	type ResultOmission,
 	type SystemItem,
 	type ThinkingItem,

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -128,6 +128,21 @@ export type TranscriptItem =
 	| ThinkingItem
 	| CompactionItem;
 
+/**
+ * The newest row in a tail that a backend minted, or `null` when the tail holds none.
+ *
+ * The operator's own turn is recorded locally on send under an id no layer has ever seen
+ * (`../core/fold.ts`'s `promptItem`), so it cannot be a boundary a layer suppresses at: this walks
+ * back past every still-unechoed local turn to the last row the session itself produced.
+ */
+export const newestBackendItemId = (items: ReadonlyArray<TranscriptItem>): ItemId | null => {
+	for (let index = items.length - 1; index >= 0; index -= 1) {
+		const item = items[index];
+		if (item !== undefined && !(item.kind === "user" && item.local === true)) return item.id;
+	}
+	return null;
+};
+
 /** One tool result may spend this many bytes of the window; the rest is omission metadata. */
 export const TOOL_RESULT_BYTE_LIMIT = 8_000;
 

--- a/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
@@ -14,7 +14,9 @@ import {
 	initialState,
 	parseSessionState,
 	promptItemId,
+	readCheckpoint,
 	restore,
+	usageTotals,
 } from "../core/index.ts";
 import {Mode, type PermissionRequest} from "../ports/index.ts";
 import {checkpointFields, resumeMessages} from "./checkpoint.ts";
@@ -45,7 +47,10 @@ const saved: AiAgentSessionState = {
 		items: [userItem("i0"), assistantItem("i1"), toolItem("i2")],
 		omitted: {items: 3, bytes: 120, reason: "item-limit"},
 	},
-	usage: {model: "claude-opus-5", inputTokens: 1_200, outputTokens: 340, cost: 0.031},
+	usage: {
+		model: "claude-opus-5",
+		turns: {i1: {inputTokens: 1_200, outputTokens: 340, cost: 0.031}},
+	},
 	permissions: {"req-1": pendingPermission({request: card, seq: 2})},
 	permissionsRaised: 2,
 	modes: {current: Mode.make("plan"), available: [Mode.make("plan"), Mode.make("build")]},
@@ -100,6 +105,25 @@ describe("what a checkpoint carries", () => {
 
 	it("carries nothing a JSON round trip would lose", () => {
 		expect(JSON.parse(JSON.stringify(saved))).toEqual(saved);
+	});
+
+	/**
+	 * A desk that saved before usage was keyed by turn holds one flat sum, and refusing it would
+	 * open that session `gone` over a shape change (#8369). The sum it renders is unchanged.
+	 */
+	it("reads a checkpoint written before usage was keyed by turn", () => {
+		const before = {
+			...JSON.parse(JSON.stringify(saved)),
+			usage: {model: "claude-opus-5", inputTokens: 1_200, outputTokens: 340, cost: 0.031},
+		};
+		const read = readCheckpoint(before, "/repo");
+		expect(read).not.toBeNull();
+		expect(read === null ? null : usageTotals(read.usage)).toEqual({
+			model: "claude-opus-5",
+			inputTokens: 1_200,
+			outputTokens: 340,
+			cost: 0.031,
+		});
 	});
 });
 

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -247,7 +247,9 @@ describe("a restored agent session", () => {
 					const after = yield* settled;
 					assert.deepStrictEqual(
 						starts[1],
-						{cwd: CWD, resume: SESSION_ID, mode: modes.current},
+						// `holdsTranscript` is the reconnect's own half of #8369: this process came back
+						// with its committed tail, so the layer owes it no replay of the history.
+						{cwd: CWD, resume: SESSION_ID, holdsTranscript: true, mode: modes.current},
 						"the reconnect did not resume the checkpointed session id on its saved mode",
 					);
 					assert.strictEqual(starts.length, 2, "the resume opened more than one session");

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -242,19 +242,25 @@ describe("a restored agent session", () => {
 			yield* runToTheCut(stores, starts);
 			assert.deepStrictEqual(starts, [{cwd: CWD}], "the first run did not open a fresh session");
 
-			yield* resume(stores, script(), starts, (_restored, _log, settled) =>
+			yield* resume(stores, script(), starts, (restored, _log, settled) =>
 				Effect.gen(function* () {
 					const after = yield* settled;
 					assert.deepStrictEqual(
 						starts[1],
 						// `holdsTranscript` is the reconnect's own half of #8369: this process came back
-						// with its committed tail, so the layer owes it no replay of the history.
-						// `newestItemId` is where that tail stops — the boundary the layer suppresses
-						// at, so a turn the session finished while the socket was down still emits
-						// (#8374). `a1` is the last item the checkpoint carried.
+						// with its committed tail, so the layer owes it no replay of the history. The
+						// tail itself rides with it — where it stops is the boundary the layer
+						// suppresses at, so a turn the session finished while the socket was down still
+						// emits, and each row is the copy this process holds, so one that moved under
+						// the boundary emits too (#8374). Here `a1` is the reply the cut caught
+						// mid-write, carried back marked `interrupted`.
 						{
 							cwd: CWD,
-							resume: {sessionId: SESSION_ID, holdsTranscript: true, newestItemId: "a1"},
+							resume: {
+								sessionId: SESSION_ID,
+								holdsTranscript: true,
+								held: restored.transcript.items,
+							},
 							mode: modes.current,
 						},
 						"the reconnect did not resume the checkpointed session id on its saved mode",

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -249,7 +249,14 @@ describe("a restored agent session", () => {
 						starts[1],
 						// `holdsTranscript` is the reconnect's own half of #8369: this process came back
 						// with its committed tail, so the layer owes it no replay of the history.
-						{cwd: CWD, resume: SESSION_ID, holdsTranscript: true, mode: modes.current},
+						// `newestItemId` is where that tail stops — the boundary the layer suppresses
+						// at, so a turn the session finished while the socket was down still emits
+						// (#8374). `a1` is the last item the checkpoint carried.
+						{
+							cwd: CWD,
+							resume: {sessionId: SESSION_ID, holdsTranscript: true, newestItemId: "a1"},
+							mode: modes.current,
+						},
 						"the reconnect did not resume the checkpointed session id on its saved mode",
 					);
 					assert.strictEqual(starts.length, 2, "the resume opened more than one session");
@@ -340,7 +347,7 @@ describe("a restored agent session", () => {
 					// policy retries a start, so the count is the policy's; what matters is that not one
 					// of those tries was a bare `{cwd}`, which is the fresh session #7514 refuses.
 					assert.deepStrictEqual(
-						starts.slice(1).map((options) => options.resume),
+						starts.slice(1).map((options) => options.resume?.sessionId),
 						starts.slice(1).map(() => SESSION_ID),
 						"an open after the restore asked for a fresh session instead of the saved one",
 					);

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
@@ -48,7 +48,7 @@ import {
 } from "./errors.ts";
 import type {AgentScript, ScriptedAnswer, ScriptedPlan} from "./script.ts";
 import {newestFirst} from "./sessions.ts";
-import {TuvalAiAgent, type TuvalAiAgentApi} from "./TuvalAiAgent.ts";
+import {type StartOptions, TuvalAiAgent, type TuvalAiAgentApi} from "./TuvalAiAgent.ts";
 
 interface ScriptState {
 	readonly started: boolean;
@@ -159,11 +159,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 			}
 		});
 
-		const start = Effect.fn("TuvalAiAgent.start")(function* (options: {
-			readonly cwd: string;
-			readonly resume?: string;
-			readonly mode?: Mode;
-		}) {
+		const start = Effect.fn("TuvalAiAgent.start")(function* (options: StartOptions) {
 			const current = yield* Ref.get(state);
 			if (!current.live) {
 				return yield* new StartError({
@@ -172,15 +168,16 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 					detail: "the scripted transport is down and nothing reconnects it",
 				});
 			}
-			if (options.resume !== undefined && options.resume !== script.sessionId) {
+			const resuming = options.resume?.sessionId;
+			if (resuming !== undefined && resuming !== script.sessionId) {
 				return yield* new StartError({
 					reason: "session-not-found",
 					cwd: options.cwd,
-					detail: `the script holds session ${script.sessionId}, not ${options.resume}`,
+					detail: `the script holds session ${script.sessionId}, not ${resuming}`,
 				});
 			}
 			yield* emit([{kind: "phase", phase: "starting"}]);
-			if (options.resume !== undefined) {
+			if (resuming !== undefined) {
 				yield* emit(script.history.map((item) => ({kind: "item", item}) as const));
 				const resumed = script.resumed ?? [];
 				yield* emit(resumed);
@@ -208,7 +205,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 				...previous,
 				started: true,
 				mode: openedOn,
-				...(options.resume === undefined ? {} : {turn: script.resumeAtTurn ?? previous.turn}),
+				...(resuming === undefined ? {} : {turn: script.resumeAtTurn ?? previous.turn}),
 			}));
 			return {sessionId: script.sessionId};
 		});

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.unit.test.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.unit.test.ts
@@ -101,7 +101,7 @@ describe("start", () => {
 	it.effect("replays the prior items when it resumes the session", () =>
 		on(plainReply, (agent) =>
 			Effect.gen(function* () {
-				yield* agent.start({cwd: CWD, resume: SESSION_ID});
+				yield* agent.start({cwd: CWD, resume: {sessionId: SESSION_ID, holdsTranscript: false}});
 				const events = yield* take(agent, START_EVENTS + history.length);
 				const replayed = events.filter((event) => event.kind === "item").map(({item}) => item);
 				assert.deepStrictEqual(replayed, [...history]);
@@ -112,7 +112,12 @@ describe("start", () => {
 	it.effect("fails session-not-found when the resumed id is not this session's", () =>
 		on(plainReply, (agent) =>
 			Effect.gen(function* () {
-				const exit = yield* Effect.exit(agent.start({cwd: CWD, resume: "session-someone-else"}));
+				const exit = yield* Effect.exit(
+					agent.start({
+						cwd: CWD,
+						resume: {sessionId: "session-someone-else", holdsTranscript: false},
+					}),
+				);
 				const error = causeError(exit);
 				assert.strictEqual(error._tag, "tuval/ai-agent/StartError");
 				assert.strictEqual(error.reason, "session-not-found");
@@ -126,7 +131,10 @@ describe("start", () => {
 	it.effect("resumes a session that is genuinely empty, replaying nothing", () =>
 		on(emptySession, (agent) =>
 			Effect.gen(function* () {
-				const session = yield* agent.start({cwd: CWD, resume: SESSION_ID});
+				const session = yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION_ID, holdsTranscript: false},
+				});
 				assert.strictEqual(session.sessionId, SESSION_ID);
 				const events = yield* take(agent, START_EVENTS);
 				assert.deepStrictEqual(
@@ -311,7 +319,7 @@ describe("models", () => {
 				yield* take(agent, START_EVENTS + 1);
 				// A resumed start re-announces what the session is on, which is the picked model and
 				// not the script's opening one — the switch outlives the turn it was made between.
-				yield* agent.start({cwd: CWD, resume: SESSION_ID});
+				yield* agent.start({cwd: CWD, resume: {sessionId: SESSION_ID, holdsTranscript: false}});
 				const resumed = yield* take(agent, START_EVENTS + history.length);
 				assert.deepStrictEqual(resumed.at(-4), {
 					kind: "model",
@@ -380,7 +388,7 @@ describe("thinking levels", () => {
 				yield* agent.start({cwd: CWD});
 				yield* agent.setThinkingLevel("max");
 				yield* take(agent, START_EVENTS + 1);
-				yield* agent.start({cwd: CWD, resume: SESSION_ID});
+				yield* agent.start({cwd: CWD, resume: {sessionId: SESSION_ID, holdsTranscript: false}});
 				const resumed = yield* take(agent, START_EVENTS + history.length);
 				assert.deepStrictEqual(resumed.at(-2), {
 					kind: "thinking",

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -51,6 +51,15 @@ export interface StartOptions {
 	 */
 	readonly resume?: string;
 	/**
+	 * Whether the caller already holds the resumed session's transcript, and so must not be sent it
+	 * again. A restored process comes back with its committed tail already on screen
+	 * (`../restore/checkpoint.ts`), so a layer that replays the history it can see floods the window
+	 * on top of the operator's own turn and pushes it out of the 40-item cut (#8369). A window
+	 * opened on a session out of the picker holds nothing, and the replay is the only way its
+	 * history paints. Read only alongside `resume`; absent means the caller holds nothing.
+	 */
+	readonly holdsTranscript?: boolean;
+	/**
 	 * The mode to open on, which is how a restored session keeps the operator's switch (#7953). A
 	 * layer holds its mode in its own build, so a rebuilt one holds none and would otherwise open on
 	 * the row's configured mode and announce that. Re-applying the mode after `started` landed would

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -43,7 +43,7 @@ import type {SessionSummary} from "./sessions.ts";
  *
  * The two facts are one value because neither is legal without the other: `holdsTranscript` is a
  * property of the resume, not a sibling of it, and a caller that holds the transcript owes the
- * boundary it holds it through (#8369, #8374).
+ * tail it holds (#8369, #8374).
  *
  * Any id `listSessions` offered is legal, not only one this desk started: continuing a session the
  * operator began in his terminal is what the session list is for (epic #8070, ruling 3). A miss is
@@ -62,15 +62,18 @@ export type ResumeTarget =
 	 * (`../restore/checkpoint.ts`). Replaying what it can already see floods the window on top of
 	 * the operator's own turn and pushes it out of the 40-item cut (#8369).
 	 *
-	 * `newestItemId` is where "already on screen" stops. Everything at or older than it is
-	 * suppressed; anything after it is work this process has never seen — a turn the session
-	 * finished while the socket was down — and is emitted (#8374). `null` says the restored tail is
-	 * empty, so nothing is suppressed.
+	 * `held` is that tail itself, oldest first — not a boundary id, because a layer needs both
+	 * facts and they are one value. Its newest backend-minted row is where "already on screen"
+	 * stops: anything after that is work this process has never seen and is emitted (#8374). And
+	 * each row is the caller's *own copy*, which is what a layer compares against to tell an item
+	 * it has already rendered from one that moved while the socket was down — a reply still
+	 * streaming when the transport died and complete by the time it came back. An empty tail says
+	 * there is nothing to suppress.
 	 */
 	| {
 			readonly sessionId: string;
 			readonly holdsTranscript: true;
-			readonly newestItemId: string | null;
+			readonly held: ReadonlyArray<TranscriptItem>;
 	  };
 
 export interface StartOptions {

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -38,27 +38,44 @@ import type {
 } from "./errors.ts";
 import type {SessionSummary} from "./sessions.ts";
 
+/**
+ * A session to pick back up, and what the caller already has on screen for it.
+ *
+ * The two facts are one value because neither is legal without the other: `holdsTranscript` is a
+ * property of the resume, not a sibling of it, and a caller that holds the transcript owes the
+ * boundary it holds it through (#8369, #8374).
+ *
+ * Any id `listSessions` offered is legal, not only one this desk started: continuing a session the
+ * operator began in his terminal is what the session list is for (epic #8070, ruling 3). A miss is
+ * `StartError({reason: "session-not-found"})`, never a start that succeeds and replays nothing. A
+ * row that opens onto silence has to be saying the session is empty; if it could also mean the
+ * session is gone, neither reading is worth anything.
+ */
+export type ResumeTarget =
+	/**
+	 * The picker opening a session on a fresh window. It holds nothing, so the layer's replay of
+	 * the whole transcript is the only way that history paints.
+	 */
+	| {readonly sessionId: string; readonly holdsTranscript: false}
+	/**
+	 * A restored process standing a new transport under the tail it came back with
+	 * (`../restore/checkpoint.ts`). Replaying what it can already see floods the window on top of
+	 * the operator's own turn and pushes it out of the 40-item cut (#8369).
+	 *
+	 * `newestItemId` is where "already on screen" stops. Everything at or older than it is
+	 * suppressed; anything after it is work this process has never seen — a turn the session
+	 * finished while the socket was down — and is emitted (#8374). `null` says the restored tail is
+	 * empty, so nothing is suppressed.
+	 */
+	| {
+			readonly sessionId: string;
+			readonly holdsTranscript: true;
+			readonly newestItemId: string | null;
+	  };
+
 export interface StartOptions {
 	readonly cwd: string;
-	/**
-	 * A session id to pick back up, or absent to start a new one. Any id `listSessions` offered is
-	 * legal, not only one this desk started: continuing a session the operator began in his terminal
-	 * is what the session list is for (epic #8070, ruling 3).
-	 *
-	 * A miss is `StartError({reason: "session-not-found"})`, never a start that succeeds and replays
-	 * nothing. A row that opens onto silence has to be saying the session is empty; if it could also
-	 * mean the session is gone, neither reading is worth anything.
-	 */
-	readonly resume?: string;
-	/**
-	 * Whether the caller already holds the resumed session's transcript, and so must not be sent it
-	 * again. A restored process comes back with its committed tail already on screen
-	 * (`../restore/checkpoint.ts`), so a layer that replays the history it can see floods the window
-	 * on top of the operator's own turn and pushes it out of the 40-item cut (#8369). A window
-	 * opened on a session out of the picker holds nothing, and the replay is the only way its
-	 * history paints. Read only alongside `resume`; absent means the caller holds nothing.
-	 */
-	readonly holdsTranscript?: boolean;
+	readonly resume?: ResumeTarget;
 	/**
 	 * The mode to open on, which is how a restored session keeps the operator's switch (#7953). A
 	 * layer holds its mode in its own build, so a rebuilt one holds none and would otherwise open on

--- a/apps/tuval/src/ai-agent/service/fixtures/scripts.ts
+++ b/apps/tuval/src/ai-agent/service/fixtures/scripts.ts
@@ -173,6 +173,7 @@ export const permissionTurn: AgentScript = {...empty, turns: [{events: permissio
 /** A usage report rides the same stream as everything else, and no port ever carries it. */
 export const usageEvent = {
 	kind: "usage",
+	turn: "a2",
 	model: "claude-opus-5",
 	inputTokens: 1_200,
 	outputTokens: 340,

--- a/apps/tuval/src/ai-agent/service/index.ts
+++ b/apps/tuval/src/ai-agent/service/index.ts
@@ -50,6 +50,7 @@ export {
 	sessionSummary,
 } from "./sessions.ts";
 export {
+	type ResumeTarget,
 	type StartedSession,
 	type StartOptions,
 	type TranscriptPage,

--- a/apps/tuval/src/ai-agent/transcripts.ts
+++ b/apps/tuval/src/ai-agent/transcripts.ts
@@ -64,7 +64,10 @@ const readFrom = (
 		Effect.gen(function* () {
 			const built = yield* Layer.build(row.aiAgent.layer as Layer.Layer<TuvalAiAgent>);
 			const agent = Context.get(built, TuvalAiAgent);
-			yield* agent.start({cwd: request.cwd, resume: request.sessionId});
+			yield* agent.start({
+				cwd: request.cwd,
+				resume: {sessionId: request.sessionId, holdsTranscript: false},
+			});
 			const page = yield* agent.page(request.before, request.limit);
 			// The port answers `hasMore`; the cursor it implies is this page's oldest item, which is
 			// what a caller hands back as `before` to walk one page further into history.

--- a/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
+++ b/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
@@ -25,7 +25,7 @@ import {useEffect, useState} from "react";
 import type {AnyInspectorRenderer} from "../../shell/desk/index.ts";
 import {inspectorRenderer} from "../../shell/desk/index.ts";
 import type {AnyWindowHost} from "../../shell/window/index.ts";
-import type {AiAgentSessionState} from "../core/index.ts";
+import {type AiAgentSessionState, usageTotals} from "../core/index.ts";
 import {isAiAgentSessionState} from "../core/snapshot.ts";
 import "./ai-agent-inspector.css";
 
@@ -49,13 +49,16 @@ const NO_SESSION_YET = "no session yet";
 /** The rows this panel shows, in the order it shows them. */
 const inspectorRows = (
 	state: AiAgentSessionState,
-): ReadonlyArray<readonly [label: string, value: string, className?: string]> => [
-	["Cost", money.format(state.usage.cost)],
-	["Input tokens", tokens.format(state.usage.inputTokens)],
-	["Output tokens", tokens.format(state.usage.outputTokens)],
-	["Session", state.sessionId ?? NO_SESSION_YET, "tuval-agent-inspector-wrap"],
-	["Directory", state.cwd, "tuval-agent-inspector-wrap"],
-];
+): ReadonlyArray<readonly [label: string, value: string, className?: string]> => {
+	const usage = usageTotals(state.usage);
+	return [
+		["Cost", money.format(usage.cost)],
+		["Input tokens", tokens.format(usage.inputTokens)],
+		["Output tokens", tokens.format(usage.outputTokens)],
+		["Session", state.sessionId ?? NO_SESSION_YET, "tuval-agent-inspector-wrap"],
+		["Directory", state.cwd, "tuval-agent-inspector-wrap"],
+	];
+};
 
 function AiAgentInspectorPanel({state}: {readonly state: AiAgentSessionState}): ReactElement {
 	return (

--- a/apps/tuval/src/ai-agent/window/inspector.testing.ts
+++ b/apps/tuval/src/ai-agent/window/inspector.testing.ts
@@ -8,7 +8,7 @@
  * fixture serves both backends' tests exactly as one renderer serves both rows.
  */
 
-import type {AiAgentSessionState, UsageTotals} from "../core/index.ts";
+import type {AiAgentSessionState, UsageLedger} from "../core/index.ts";
 import {initialState} from "../core/state.ts";
 
 export const CWD = "/tmp/project";
@@ -20,11 +20,9 @@ export const usageOf = (usage: {
 	readonly cost: number;
 	readonly input: number;
 	readonly output: number;
-}): UsageTotals => ({
+}): UsageLedger => ({
 	model: usage.model,
-	cost: usage.cost,
-	inputTokens: usage.input,
-	outputTokens: usage.output,
+	turns: {"turn-1": {cost: usage.cost, inputTokens: usage.input, outputTokens: usage.output}},
 });
 
 export const agentSessionState = (

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -52,6 +52,7 @@ import {
 	ModelUnsupported,
 	ModeUnsupported,
 	type StartError,
+	type StartOptions,
 	ThinkingUnsupported,
 	type TransportError,
 	TuvalAiAgent,
@@ -525,11 +526,7 @@ const make = (
 			};
 		});
 
-		const start = Effect.fn("TuvalAiAgent.start")(function* (startOptions: {
-			readonly cwd: string;
-			readonly resume?: string;
-			readonly mode?: Mode;
-		}) {
+		const start = Effect.fn("TuvalAiAgent.start")(function* (startOptions: StartOptions) {
 			const previous = yield* Ref.get(session);
 			// A second `start` is a reconnect, and it replaces the session whole: the previous
 			// subprocess is closed, its pump ended with it, and the old queue is shut so a
@@ -547,7 +544,8 @@ const make = (
 			const held = (yield* Ref.get(mode)) ?? startOptions.mode ?? null;
 			// One stream carries everything (ruling 1, #7570), so a failed start owes it a terminal
 			// phase: without this every subscriber sits on `starting` for the life of the layer.
-			const opened = yield* open(startOptions.cwd, startOptions.resume, held).pipe(
+			const resuming = startOptions.resume?.sessionId;
+			const opened = yield* open(startOptions.cwd, resuming, held).pipe(
 				Effect.tapError((_error: StartError) => emit(out, [{kind: "phase", phase: "gone"}])),
 			);
 
@@ -555,7 +553,7 @@ const make = (
 			// The keys belong to a session, not to the layer: a key is dropped when this *session* has
 			// seen it, so a new session admits one the previous session spent. Resuming the session the
 			// keys were recorded under is the one case that keeps them.
-			const continuing = previous !== null && startOptions.resume === previous.id;
+			const continuing = previous !== null && resuming === previous.id;
 			if (!continuing) yield* Ref.set(keys, new Set<string>());
 
 			// The layer's own narration of the open, which the handshake is: the core is already

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -203,6 +203,7 @@ describe("start against a CLI that says nothing until the first prompt", () => {
 							{kind: "phase", phase: "prompting"},
 							{
 								kind: "usage",
+								turn: "claude:model-announcement",
 								model: "claude-fable-5-1",
 								inputTokens: 0,
 								outputTokens: 0,

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -233,7 +233,10 @@ describe("start on a resume", () => {
 	it.effect("passes the session id through and reads that session's store", () =>
 		on({rows: rows()}, (agent, scripted) =>
 			Effect.gen(function* () {
-				yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+				});
 				assert.deepStrictEqual(scripted.reads, [{sessionId: TOOL_SESSION_ID, dir: CWD}]);
 				assert.strictEqual(scripted.opened[0]?.record.options.resume, TOOL_SESSION_ID);
 			}),
@@ -243,7 +246,12 @@ describe("start on a resume", () => {
 	it.effect("refuses a session the store does not hold as SessionNotFound", () =>
 		Effect.gen(function* () {
 			const exit = yield* Effect.exit(
-				on({}, (agent) => agent.start({cwd: CWD, resume: "00000000-0000-4000-8000-00000000dead"})),
+				on({}, (agent) =>
+					agent.start({
+						cwd: CWD,
+						resume: {sessionId: "00000000-0000-4000-8000-00000000dead", holdsTranscript: false},
+					}),
+				),
 			);
 			assert.strictEqual(failure(exit)._tag, "tuval/ai-agent/StartError");
 			assert.strictEqual(failure(exit).reason, "session-not-found");
@@ -253,7 +261,12 @@ describe("start on a resume", () => {
 	it.effect("takes the session down rather than leaving it on starting", () =>
 		on({}, (agent) =>
 			Effect.gen(function* () {
-				yield* Effect.exit(agent.start({cwd: CWD, resume: "00000000-0000-4000-8000-00000000dead"}));
+				yield* Effect.exit(
+					agent.start({
+						cwd: CWD,
+						resume: {sessionId: "00000000-0000-4000-8000-00000000dead", holdsTranscript: false},
+					}),
+				);
 				assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, 2)), [
 					{kind: "phase", phase: "starting"},
 					{kind: "phase", phase: "gone"},
@@ -269,7 +282,10 @@ describe("start on a resume", () => {
 			{rows: rows().slice(0, 2)},
 			(agent) =>
 				Effect.gen(function* () {
-					yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+					yield* agent.start({
+						cwd: CWD,
+						resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+					});
 					const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS + 1));
 					assert.deepStrictEqual(events[START_EVENTS], {
 						kind: "permission-resolved",
@@ -283,7 +299,10 @@ describe("start on a resume", () => {
 	it.effect("emits no resolution when every stored call already settled", () =>
 		on({rows: rows(), opening: messages("tool-turn")}, (agent) =>
 			Effect.gen(function* () {
-				yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+				});
 				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS + 1));
 				assert.notStrictEqual(events[START_EVENTS]?.kind, "permission-resolved");
 			}),

--- a/apps/tuval/src/claude/agent/turns.unit.test.ts
+++ b/apps/tuval/src/claude/agent/turns.unit.test.ts
@@ -121,7 +121,10 @@ describe("page", () => {
 	it.effect("reads the session's own store and returns the page oldest-first", () =>
 		on({rows: rows()}, (agent) =>
 			Effect.gen(function* () {
-				yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+				});
 				const page = yield* agent.page(null, 10);
 				assert.deepStrictEqual(
 					page.items.map((one) => one.kind),
@@ -135,7 +138,7 @@ describe("page", () => {
 	it.effect("reads through the id it resumed, which is the id the CLI hands back", () =>
 		on({rows: rows(), opening: [message("resumed-init")]}, (agent, scripted) =>
 			Effect.gen(function* () {
-				yield* agent.start({cwd: CWD, resume: SESSION_ID});
+				yield* agent.start({cwd: CWD, resume: {sessionId: SESSION_ID, holdsTranscript: false}});
 				yield* agent.page(null, 10);
 				// A plain `resume` keeps the session's id — `resumed-init.json` is a real second
 				// `query()` over the same id (`../history/fixtures/PROVENANCE.md`) — so the existence
@@ -157,7 +160,10 @@ describe("page", () => {
 					// `resumed-init` names SESSION_ID, so resuming TOOL_SESSION_ID is a CLI that opened
 					// a session other than the one the layer is keyed on — silent, and it would break
 					// every later read.
-					yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+					yield* agent.start({
+						cwd: CWD,
+						resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+					});
 					yield* Stream.runCollect(Stream.take(agent.events, OPENED_EVENTS));
 				}),
 			).pipe(
@@ -181,7 +187,10 @@ describe("page", () => {
 			const exit = yield* Effect.exit(
 				on({rows: rows()}, (agent) =>
 					Effect.gen(function* () {
-						yield* agent.start({cwd: CWD, resume: TOOL_SESSION_ID});
+						yield* agent.start({
+							cwd: CWD,
+							resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+						});
 						return yield* agent.page("no-such-item", 10);
 					}),
 				),

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -56,7 +56,14 @@ describe("toAgentEvents over a captured init", () => {
 	it("reports the model the session named, and no phase", () => {
 		const {events, mapping} = run([message("init")]);
 		expect(events).toEqual([
-			{kind: "usage", model: "claude-fable-5-1", inputTokens: 0, outputTokens: 0, cost: 0},
+			{
+				kind: "usage",
+				turn: "claude:model-announcement",
+				model: "claude-fable-5-1",
+				inputTokens: 0,
+				outputTokens: 0,
+				cost: 0,
+			},
 		]);
 		expect(mapping.model).toBe("claude-fable-5-1");
 	});
@@ -64,7 +71,14 @@ describe("toAgentEvents over a captured init", () => {
 	it("reads a resumed session's init the same way", () => {
 		const {events} = run([message("resumed-init")]);
 		expect(events).toEqual([
-			{kind: "usage", model: "claude-fable-5-1", inputTokens: 0, outputTokens: 0, cost: 0},
+			{
+				kind: "usage",
+				turn: "claude:model-announcement",
+				model: "claude-fable-5-1",
+				inputTokens: 0,
+				outputTokens: 0,
+				cost: 0,
+			},
 		]);
 	});
 });
@@ -101,6 +115,7 @@ describe("toAgentEvents over a captured plain turn", () => {
 		expect(usage).toHaveLength(2);
 		expect(usage[1]).toEqual({
 			kind: "usage",
+			turn: "00000000-0000-4000-8000-000000000006",
 			model: "claude-fable-5-1",
 			inputTokens: 2,
 			outputTokens: 4,

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -429,9 +429,9 @@ export const resultEvents = (
 ): MappingStep => {
 	if (!isRecord(message)) return skipMessage(mapping);
 	const at = timestampOf(message, options.at);
+	const id = typeof message.uuid === "string" ? message.uuid : `result-${at}`;
 	const failed = message.is_error === true || message.subtype !== "success";
 	if (failed) {
-		const id = typeof message.uuid === "string" ? message.uuid : `result-${at}`;
 		const subtype = typeof message.subtype === "string" ? message.subtype : "error";
 		return {
 			mapping,
@@ -451,6 +451,7 @@ export const resultEvents = (
 		events: [
 			{
 				kind: "usage",
+				turn: id,
 				model: mapping.model,
 				inputTokens: tokensOf(message.usage, "input_tokens"),
 				outputTokens: tokensOf(message.usage, "output_tokens"),
@@ -459,6 +460,13 @@ export const resultEvents = (
 		],
 	};
 };
+
+/**
+ * The turn id `init`'s announcement rides under. It is not a turn: `init` fires at the start of
+ * every turn and carries no spend, so one reserved key keeps the session's ledger from growing an
+ * empty entry per turn while the model it names still lands (`core/fold.ts`, `addUsage`).
+ */
+const MODEL_ANNOUNCEMENT = "claude:model-announcement";
 
 /**
  * `init` is where a session says which model it is, and the only place it ever says so.
@@ -473,7 +481,9 @@ export const initEvents = (message: unknown, mapping: Mapping): MappingStep => {
 	const model = typeof message.model === "string" ? message.model : mapping.model;
 	return {
 		mapping: {...mapping, model},
-		events: [{kind: "usage", model, inputTokens: 0, outputTokens: 0, cost: 0}],
+		events: [
+			{kind: "usage", turn: MODEL_ANNOUNCEMENT, model, inputTokens: 0, outputTokens: 0, cost: 0},
+		],
 	};
 };
 

--- a/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
@@ -201,7 +201,9 @@ describe("the reconnect handler", () => {
 
 				yield* handle.dispatch({type: "reconnect"});
 				yield* eventually(() => probe.starts.length === 2);
-				assert.deepStrictEqual(probe.starts[1], {cwd: CWD, resume: SESSION});
+				// `holdsTranscript` rides every reconnect since #8369: the process came back with its
+				// committed tail, so a layer that can replay history is told not to.
+				assert.deepStrictEqual(probe.starts[1], {cwd: CWD, resume: SESSION, holdsTranscript: true});
 				assert.strictEqual(probe.builds, 2, "the reconnect reused the handle the stop killed");
 			}),
 		);

--- a/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
@@ -202,10 +202,11 @@ describe("the reconnect handler", () => {
 				yield* handle.dispatch({type: "reconnect"});
 				yield* eventually(() => probe.starts.length === 2);
 				// `holdsTranscript` rides every reconnect since #8369: the process came back with its
-				// committed tail, so a layer that can replay history is told not to.
+				// committed tail, so a layer that can replay history is told not to. The tail itself
+				// rides with it, and this session was checkpointed with none.
 				assert.deepStrictEqual(probe.starts[1], {
 					cwd: CWD,
-					resume: {sessionId: SESSION, holdsTranscript: true, newestItemId: null},
+					resume: {sessionId: SESSION, holdsTranscript: true, held: []},
 				});
 				assert.strictEqual(probe.builds, 2, "the reconnect reused the handle the stop killed");
 			}),

--- a/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore.unit.test.ts
@@ -203,7 +203,10 @@ describe("the reconnect handler", () => {
 				yield* eventually(() => probe.starts.length === 2);
 				// `holdsTranscript` rides every reconnect since #8369: the process came back with its
 				// committed tail, so a layer that can replay history is told not to.
-				assert.deepStrictEqual(probe.starts[1], {cwd: CWD, resume: SESSION, holdsTranscript: true});
+				assert.deepStrictEqual(probe.starts[1], {
+					cwd: CWD,
+					resume: {sessionId: SESSION, holdsTranscript: true, newestItemId: null},
+				});
 				assert.strictEqual(probe.builds, 2, "the reconnect reused the handle the stop killed");
 			}),
 		);

--- a/apps/tuval/src/claude/window/claude-window.testing.ts
+++ b/apps/tuval/src/claude/window/claude-window.testing.ts
@@ -11,7 +11,7 @@
  * switch — which is the shared window's control, not one this binding adds.
  */
 
-import type {AiAgentSessionState, UsageTotals} from "../../ai-agent/core/index.ts";
+import type {AiAgentSessionState, UsageLedger} from "../../ai-agent/core/index.ts";
 import {initialState} from "../../ai-agent/core/state.ts";
 import {Mode} from "../../ai-agent/ports/index.ts";
 import {assistantItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
@@ -27,11 +27,9 @@ export const usageOf = (usage: {
 	readonly cost: number;
 	readonly input: number;
 	readonly output: number;
-}): UsageTotals => ({
+}): UsageLedger => ({
 	model: usage.model,
-	cost: usage.cost,
-	inputTokens: usage.input,
-	outputTokens: usage.output,
+	turns: {"turn-1": {cost: usage.cost, inputTokens: usage.input, outputTokens: usage.output}},
 });
 
 export const claudeSessionState = (

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -69,7 +69,7 @@ import {
 	type ServerBindFailed,
 } from "../server/index.ts";
 import {pageItems} from "./entries.ts";
-import {emptyProjection, eventsOf} from "./items.ts";
+import {emptyProjection, eventsOf, projectionOf, type SnapshotProjection} from "./items.ts";
 import {
 	promptDropOf,
 	promptErrorOf,
@@ -227,9 +227,10 @@ const make = (
 			sessionId: string,
 			open: EventQueue,
 			feed: Queue.Queue<FoldInput>,
+			seed: SnapshotProjection,
 		): Effect.Effect<void> =>
 			Effect.gen(function* () {
-				const projection = yield* Ref.make(emptyProjection);
+				const projection = yield* Ref.make(seed);
 				const pushes = pi
 					.snapshots(sessionId)
 					.pipe(Stream.runForEach((snapshot) => Queue.offer(feed, {_tag: "snapshot", snapshot})));
@@ -329,6 +330,7 @@ const make = (
 		const start = Effect.fn("TuvalAiAgent.start")(function* (options_: {
 			readonly cwd: string;
 			readonly resume?: string;
+			readonly holdsTranscript?: boolean;
 		}) {
 			const previous = yield* Ref.get(pump);
 			if (previous !== null) yield* Fiber.interrupt(previous);
@@ -345,14 +347,27 @@ const make = (
 				// A held pick outranks the layer's static option: it is the later choice, and this
 				// open is the one it was made for.
 				const opening = (yield* Ref.get(pendingModel)) ?? options.model;
-				return options_.resume === undefined
-					? yield* pi.createSession(options_.cwd, opening === undefined ? {} : {model: opening})
-					: yield* pi.attachSession(options_.resume);
+				if (options_.resume === undefined) {
+					const opened = yield* pi.createSession(
+						options_.cwd,
+						opening === undefined ? {} : {model: opening},
+					);
+					return {ref: opened, seed: emptyProjection};
+				}
+				const resumed = yield* pi.attachSession(options_.resume);
+				// A caller that already holds the transcript is looking at it: seeding the fold with
+				// the lease's own snapshot is what keeps Pi's next whole-transcript push from
+				// replaying the session as live items on top of the operator's turn (#8369). A
+				// caller that holds none — the picker opening a session on a fresh window — still
+				// gets the replay, because it is the only way that history paints.
+				if (options_.holdsTranscript !== true) return {ref: resumed, seed: emptyProjection};
+				const held = yield* pi.heldSnapshot(resumed.id);
+				return {ref: resumed, seed: projectionOf(held)};
 			}).pipe(Effect.mapError((refusal) => startErrorOf(options_.cwd, refusal)));
 
 			// One stream carries everything (ruling 1, #7570), so a failed start owes it a terminal
 			// phase: without this every subscriber sits on `starting` for the life of the layer.
-			const ref = yield* acquire.pipe(
+			const {ref, seed} = yield* acquire.pipe(
 				Effect.tapError(() => emit(open, [{kind: "phase", phase: "gone"}])),
 			);
 
@@ -383,7 +398,7 @@ const make = (
 			yield* Ref.set(inbox, feed);
 			// Forked into the layer's own scope, not the caller's, so the fan lives exactly as long
 			// as the transport it reads and dies with it.
-			yield* Ref.set(pump, yield* Effect.forkIn(follow(ref.id, open, feed), scope));
+			yield* Ref.set(pump, yield* Effect.forkIn(follow(ref.id, open, feed, seed), scope));
 			const offered = catalog.map(refOf);
 			yield* emit(open, [
 				// `StartOptions.mode` is ignored here, and this is the one layer where that is right:

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -363,16 +363,16 @@ const make = (
 				// opened on `emptyProjection` replays the session as live items on the first push
 				// after the attach (#8369). What differs is what the caller can already see.
 				const resumed = yield* pi.attachSession(resume.sessionId);
-				const held = yield* pi.heldSnapshot(resumed.id);
+				const lease = yield* pi.heldSnapshot(resumed.id);
 				// A restored process is looking at its own committed tail, so the seed suppresses
-				// everything through the boundary it holds and emits whatever the session finished
-				// past it (#8374).
+				// everything through the boundary that tail reaches and emits whatever the session
+				// finished past it — or changed under it — while the socket was down (#8374).
 				if (resume.holdsTranscript) {
-					return {ref: resumed, seed: projectionOf(held, resume.newestItemId), paint: []};
+					return {ref: resumed, seed: projectionOf(lease, resume.held), paint: []};
 				}
 				// A window opened out of the picker holds nothing, so the history is painted here,
 				// at the attach, while its tail is still empty.
-				const painted = paintOf(held);
+				const painted = paintOf(lease);
 				return {ref: resumed, seed: painted.projection, paint: painted.events};
 			}).pipe(Effect.mapError((refusal) => startErrorOf(options_.cwd, refusal)));
 

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -52,6 +52,7 @@ import {
 	ModeUnsupported,
 	PageError,
 	PromptError,
+	type StartOptions,
 	ThinkingUnsupported,
 	type TransportError,
 	TuvalAiAgent,
@@ -69,7 +70,13 @@ import {
 	type ServerBindFailed,
 } from "../server/index.ts";
 import {pageItems} from "./entries.ts";
-import {emptyProjection, eventsOf, projectionOf, type SnapshotProjection} from "./items.ts";
+import {
+	emptyProjection,
+	eventsOf,
+	paintOf,
+	projectionOf,
+	type SnapshotProjection,
+} from "./items.ts";
 import {
 	promptDropOf,
 	promptErrorOf,
@@ -327,11 +334,7 @@ const make = (
 			yield* Ref.set(dialled, true);
 		});
 
-		const start = Effect.fn("TuvalAiAgent.start")(function* (options_: {
-			readonly cwd: string;
-			readonly resume?: string;
-			readonly holdsTranscript?: boolean;
-		}) {
+		const start = Effect.fn("TuvalAiAgent.start")(function* (options_: StartOptions) {
 			const previous = yield* Ref.get(pump);
 			if (previous !== null) yield* Fiber.interrupt(previous);
 			yield* Effect.flatMap(Ref.get(queue), Queue.shutdown);
@@ -347,29 +350,38 @@ const make = (
 				// A held pick outranks the layer's static option: it is the later choice, and this
 				// open is the one it was made for.
 				const opening = (yield* Ref.get(pendingModel)) ?? options.model;
-				if (options_.resume === undefined) {
+				const resume = options_.resume;
+				if (resume === undefined) {
 					const opened = yield* pi.createSession(
 						options_.cwd,
 						opening === undefined ? {} : {model: opening},
 					);
-					return {ref: opened, seed: emptyProjection};
+					return {ref: opened, seed: emptyProjection, paint: []};
 				}
-				const resumed = yield* pi.attachSession(options_.resume);
-				// A caller that already holds the transcript is looking at it: seeding the fold with
-				// the lease's own snapshot is what keeps Pi's next whole-transcript push from
-				// replaying the session as live items on top of the operator's turn (#8369). A
-				// caller that holds none — the picker opening a session on a fresh window — still
-				// gets the replay, because it is the only way that history paints.
-				if (options_.holdsTranscript !== true) return {ref: resumed, seed: emptyProjection};
+				// Either way the lease's own snapshot is the seed, and neither reading of it costs a
+				// round trip: Pi re-sends the whole transcript on every revision, so a fold that
+				// opened on `emptyProjection` replays the session as live items on the first push
+				// after the attach (#8369). What differs is what the caller can already see.
+				const resumed = yield* pi.attachSession(resume.sessionId);
 				const held = yield* pi.heldSnapshot(resumed.id);
-				return {ref: resumed, seed: projectionOf(held)};
+				// A restored process is looking at its own committed tail, so the seed suppresses
+				// everything through the boundary it holds and emits whatever the session finished
+				// past it (#8374).
+				if (resume.holdsTranscript) {
+					return {ref: resumed, seed: projectionOf(held, resume.newestItemId), paint: []};
+				}
+				// A window opened out of the picker holds nothing, so the history is painted here,
+				// at the attach, while its tail is still empty.
+				const painted = paintOf(held);
+				return {ref: resumed, seed: painted.projection, paint: painted.events};
 			}).pipe(Effect.mapError((refusal) => startErrorOf(options_.cwd, refusal)));
 
 			// One stream carries everything (ruling 1, #7570), so a failed start owes it a terminal
 			// phase: without this every subscriber sits on `starting` for the life of the layer.
-			const {ref, seed} = yield* acquire.pipe(
+			const {ref, seed, paint} = yield* acquire.pipe(
 				Effect.tapError(() => emit(open, [{kind: "phase", phase: "gone"}])),
 			);
+			yield* emit(open, paint);
 
 			// A `start({resume})` reattaches to a session already on its own stored model, and a
 			// create can answer on another, so a held pick is applied here rather than assumed to

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -232,15 +232,15 @@ export const projectionOf = (
 	for (const source of snapshot.transcript) {
 		if (reached) break;
 		const rows = itemsOf(source);
-		for (const item of rows) {
-			if (reached) break;
-			items.set(item.id, fingerprint(item));
-			reached = item.id === through;
-		}
-		// A turn's cost is seeded only when the whole turn is behind the boundary. A boundary
-		// falling between a turn's reasoning row and its reply — the window cut there — leaves the
-		// reply to emit, and its `usage` is that reply's annotation.
-		const event = reached && items.size < rows.length ? null : usageEventOf(source);
+		const cut = rows.findIndex((item) => item.id === through);
+		reached = cut !== -1;
+		const seeded = reached ? rows.slice(0, cut + 1) : rows;
+		for (const item of seeded) items.set(item.id, fingerprint(item));
+		// A turn's cost is seeded only when the whole turn is behind the boundary, which is a count
+		// within this turn's own rows — `items` spans every turn walked so far and would always be
+		// the larger number. A boundary falling between a turn's reasoning row and its reply — the
+		// window cut there — leaves the reply to emit, and its `usage` is that reply's annotation.
+		const event = seeded.length === rows.length ? usageEventOf(source) : null;
 		if (event !== null) usage.set(source.id, fingerprint(event));
 	}
 	return reached ? {items, usage, phase: null} : emptyProjection;

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -27,6 +27,7 @@ import {
 	boundToolResult,
 	type ItemId,
 	type JsonValue,
+	newestBackendItemId,
 	type ThinkingItem,
 	type ToolStatus,
 	type TranscriptItem,
@@ -210,22 +211,42 @@ export const eventsOf = (
  * own newly typed turn and pushing it out of the window's 40-item cut (#8369). The attach lease
  * already carries the session's snapshot, and this is that snapshot read as "already rendered".
  *
- * `through` is where "already read" stops: the newest item the caller's window holds. Everything
- * at or older than it is seeded, and anything after it is left unseeded so it emits — a turn the
- * session finished while the socket was down is work the operator has never seen, and seeding the
- * whole snapshot would bury it for the life of the session with no gap marker and no way to page
- * to it (#8374). `null` seeds nothing. An id this snapshot does not carry — a compaction
- * renumbered the transcript out from under the caller — also seeds nothing, which replays: a
- * visibly wrong transcript is recoverable and a silently missing reply is not.
+ * `held` is the caller's own tail, oldest first, and it answers both halves. Its newest
+ * backend-minted row is where "already read" stops: everything at or older than that is seeded,
+ * and anything after it is left unseeded so it emits — a turn the session finished while the
+ * socket was down is work the operator has never seen, and seeding the whole snapshot would bury
+ * it for the life of the session with no gap marker and no way to page to it (#8374). An empty
+ * tail seeds nothing. A boundary this snapshot does not carry — a compaction renumbered the
+ * transcript out from under the caller — also seeds nothing, which replays: a visibly wrong
+ * transcript is recoverable and a silently missing reply is not.
+ *
+ * A seeded row is fingerprinted off the **caller's** copy, never off the snapshot's. Being at or
+ * older than the boundary means "already read" only if an item's content cannot move, and on this
+ * wire it can: `@earendil-works/pi-protocol` 0.84.3 `dist/schemas.d.ts` gives the assistant item a
+ * `status: "streaming"` variant with `usage` optional, so a reply the socket died in the middle of
+ * settles server-side while this process is away. Seeded off the snapshot, that row would be
+ * compared against itself, match, and never emit again — the operator keeps the half-written reply
+ * for the life of the session and its cost never joins the totals. Seeded off what the caller
+ * holds, it differs and emits. A seeded row the caller holds no copy of is one the window's own
+ * bound already dropped, so the snapshot's copy stands and it stays suppressed: re-emitting it is
+ * the replay #8369 closed.
+ *
+ * A turn's cost is seeded only when the whole turn is behind the boundary — a count within that
+ * turn's own rows, since `items` spans every turn walked so far and would always be larger — and
+ * only when every seeded row of it still matches what the caller holds. A boundary falling between
+ * a turn's reasoning row and its reply leaves the reply to emit, and a turn that moved leaves its
+ * reply to emit; either way the `usage` is that reply's annotation and travels with it.
  *
  * The phase is deliberately left unseeded: a session still working when it was reattached has to
  * restate `prompting` on its first push, or the window sits on the `ready` that `start` emitted.
  */
 export const projectionOf = (
 	snapshot: SessionSnapshot,
-	through: string | null,
+	held: ReadonlyArray<TranscriptItem>,
 ): SnapshotProjection => {
+	const through = newestBackendItemId(held);
 	if (through === null) return emptyProjection;
+	const carried = new Map(held.map((item) => [item.id as string, fingerprint(item)]));
 	const items = new Map<string, string>();
 	const usage = new Map<string, string>();
 	let reached = false;
@@ -235,12 +256,14 @@ export const projectionOf = (
 		const cut = rows.findIndex((item) => item.id === through);
 		reached = cut !== -1;
 		const seeded = reached ? rows.slice(0, cut + 1) : rows;
-		for (const item of seeded) items.set(item.id, fingerprint(item));
-		// A turn's cost is seeded only when the whole turn is behind the boundary, which is a count
-		// within this turn's own rows — `items` spans every turn walked so far and would always be
-		// the larger number. A boundary falling between a turn's reasoning row and its reply — the
-		// window cut there — leaves the reply to emit, and its `usage` is that reply's annotation.
-		const event = seeded.length === rows.length ? usageEventOf(source) : null;
+		let moved = false;
+		for (const item of seeded) {
+			const mark = fingerprint(item);
+			const mine = carried.get(item.id);
+			items.set(item.id, mine ?? mark);
+			if (mine !== undefined && mine !== mark) moved = true;
+		}
+		const event = !moved && seeded.length === rows.length ? usageEventOf(source) : null;
 		if (event !== null) usage.set(source.id, fingerprint(event));
 	}
 	return reached ? {items, usage, phase: null} : emptyProjection;

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -210,10 +210,62 @@ export const eventsOf = (
  * own newly typed turn and pushing it out of the window's 40-item cut (#8369). The attach lease
  * already carries the session's snapshot, and this is that snapshot read as "already rendered".
  *
+ * `through` is where "already read" stops: the newest item the caller's window holds. Everything
+ * at or older than it is seeded, and anything after it is left unseeded so it emits — a turn the
+ * session finished while the socket was down is work the operator has never seen, and seeding the
+ * whole snapshot would bury it for the life of the session with no gap marker and no way to page
+ * to it (#8374). `null` seeds nothing. An id this snapshot does not carry — a compaction
+ * renumbered the transcript out from under the caller — also seeds nothing, which replays: a
+ * visibly wrong transcript is recoverable and a silently missing reply is not.
+ *
  * The phase is deliberately left unseeded: a session still working when it was reattached has to
  * restate `prompting` on its first push, or the window sits on the `ready` that `start` emitted.
  */
-export const projectionOf = (snapshot: SessionSnapshot): SnapshotProjection => ({
-	...eventsOf(emptyProjection, snapshot).next,
-	phase: null,
-});
+export const projectionOf = (
+	snapshot: SessionSnapshot,
+	through: string | null,
+): SnapshotProjection => {
+	if (through === null) return emptyProjection;
+	const items = new Map<string, string>();
+	const usage = new Map<string, string>();
+	let reached = false;
+	for (const source of snapshot.transcript) {
+		if (reached) break;
+		const rows = itemsOf(source);
+		for (const item of rows) {
+			if (reached) break;
+			items.set(item.id, fingerprint(item));
+			reached = item.id === through;
+		}
+		// A turn's cost is seeded only when the whole turn is behind the boundary. A boundary
+		// falling between a turn's reasoning row and its reply — the window cut there — leaves the
+		// reply to emit, and its `usage` is that reply's annotation.
+		const event = reached && items.size < rows.length ? null : usageEventOf(source);
+		if (event !== null) usage.set(source.id, fingerprint(event));
+	}
+	return reached ? {items, usage, phase: null} : emptyProjection;
+};
+
+/**
+ * The history a window holding nothing has to be shown, and the projection that leaves behind.
+ *
+ * The picker opens a past session on a fresh window, so its history has to paint — but Pi only
+ * pushes on a session event, and nothing changes the session until the operator types. That defers
+ * the whole transcript to the same push that carries their turn, and `../../ai-agent/core/fold.ts`
+ * appends every unknown item after the turn the core recorded on send, so their message ends up
+ * above the session it belongs under (#8369). Painting at the attach instead puts the history on
+ * screen while the tail is still empty, where appending is the right order and there is nothing to
+ * land on top of.
+ *
+ * The phase is left to the first push for the same reason `projectionOf` leaves it: `start` emits
+ * its own `ready` after this, which would overwrite a `prompting` stated here.
+ */
+export const paintOf = (
+	snapshot: SessionSnapshot,
+): {readonly events: ReadonlyArray<AgentEvent>; readonly projection: SnapshotProjection} => {
+	const folded = eventsOf(emptyProjection, snapshot);
+	return {
+		events: folded.events.filter((event) => event.kind !== "phase"),
+		projection: {...folded.next, phase: null},
+	};
+};

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -128,11 +128,18 @@ export const itemsOf = (item: PiTranscriptItem): ReadonlyArray<TranscriptItem> =
  */
 export const phaseOf = (phase: SessionPhase): Phase => (phase === "idle" ? "ready" : "prompting");
 
-/** What one assistant turn cost, as plain numbers. No Pi `Usage` value crosses. */
+/**
+ * What one assistant turn cost, as plain numbers. No Pi `Usage` value crosses.
+ *
+ * `turn` is the wire item's own id, which is also what the projections below key a turn's cost by:
+ * the fold and the seed then name one turn the same way, so a cost the seed misses is folded once
+ * rather than twice (#8369).
+ */
 const usageEventOf = (item: PiTranscriptItem): Extract<AgentEvent, {kind: "usage"}> | null => {
 	if (item.role !== "assistant" || item.usage === undefined) return null;
 	return {
 		kind: "usage",
+		turn: item.id,
 		model: `${item.model.provider}/${item.model.id}`,
 		inputTokens: item.usage.input,
 		outputTokens: item.usage.output,
@@ -236,6 +243,11 @@ export const eventsOf = (
  * only when every seeded row of it still matches what the caller holds. A boundary falling between
  * a turn's reasoning row and its reply leaves the reply to emit, and a turn that moved leaves its
  * reply to emit; either way the `usage` is that reply's annotation and travels with it.
+ *
+ * That seed decides what the window is *shown*, not what it is *charged*. A turn's cost is folded
+ * under the turn's own id (`core/fold.ts`, `addUsage`), so a cost this seed leaves out and the
+ * caller has already counted costs them nothing the second time — which is what lets the rule above
+ * be about the reply the operator reads rather than about arithmetic (#8369).
  *
  * The phase is deliberately left unseeded: a session still working when it was reattached has to
  * restate `prompting` on its first push, or the window sits on the `ready` that `start` emitted.

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -201,3 +201,19 @@ export const eventsOf = (
 
 	return {events, next: {items, usage, phase}};
 };
+
+/**
+ * What a snapshot the operator has already read leaves behind, so a resume folds it to nothing.
+ *
+ * Pi re-sends the whole transcript every revision, so a `follow` that opened on `emptyProjection`
+ * after a reattach re-emits the entire history as live items — landing on top of the operator's
+ * own newly typed turn and pushing it out of the window's 40-item cut (#8369). The attach lease
+ * already carries the session's snapshot, and this is that snapshot read as "already rendered".
+ *
+ * The phase is deliberately left unseeded: a session still working when it was reattached has to
+ * restate `prompting` on its first push, or the window sits on the `ready` that `start` emitted.
+ */
+export const projectionOf = (snapshot: SessionSnapshot): SnapshotProjection => ({
+	...eventsOf(emptyProjection, snapshot).next,
+	phase: null,
+});

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -262,6 +262,7 @@ describe("one revision folded into events", () => {
 		]);
 		expect(folded.events.at(-2)).toEqual({
 			kind: "usage",
+			turn: "item-1",
 			model: "faux/faux-1",
 			inputTokens: 11,
 			outputTokens: 22,
@@ -322,6 +323,7 @@ describe("one revision folded into events", () => {
 			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
 			{
 				kind: "usage",
+				turn: "item-1",
 				model: "faux/faux-1",
 				inputTokens: 11,
 				outputTokens: 22,
@@ -347,6 +349,7 @@ describe("one revision folded into events", () => {
 			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
 			{
 				kind: "usage",
+				turn: "item-1",
 				model: "faux/faux-1",
 				inputTokens: 11,
 				outputTokens: 22,
@@ -385,6 +388,7 @@ describe("one revision folded into events", () => {
 			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
 			{
 				kind: "usage",
+				turn: "item-1",
 				model: "faux/faux-1",
 				inputTokens: 11,
 				outputTokens: 22,

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../../ai-agent/core/index.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {TOOL_RESULT_BYTE_LIMIT} from "../../ai-agent/ports/index.ts";
-import {emptyProjection, eventsOf, itemOf, itemsOf, phaseOf} from "./items.ts";
+import {emptyProjection, eventsOf, itemOf, itemsOf, phaseOf, projectionOf} from "./items.ts";
 
 const usage = (total: number) => ({
 	input: 11,
@@ -250,6 +250,47 @@ describe("one revision folded into events", () => {
 		const first = eventsOf(emptyProjection, snapshot([user, assistant("hi back")]));
 		const second = eventsOf(first.next, snapshot([user, assistant("hi back")], "idle", 2));
 		expect(second.events).toEqual([]);
+	});
+
+	/**
+	 * A resume opens a fresh fold over a transcript the operator is already reading, so the seed
+	 * off the attach lease's snapshot has to make Pi's next whole-transcript push a no-op: no
+	 * `item`, so nothing is appended after the operator's own turn and pushed out of the window's
+	 * 40-item cut, and no `usage`, so the session's totals are not re-added (#8369).
+	 */
+	it("emits no item and no usage when a resume's seed already holds the whole transcript", () => {
+		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
+		const folded = eventsOf(projectionOf(restored), restored);
+		expect(folded.events).toEqual([{kind: "phase", phase: "ready"}]);
+	});
+
+	it("emits only the operator's own turn on the first push after a resume", () => {
+		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
+		const sent: PiTranscriptItem = {
+			id: "item-3",
+			role: "user",
+			content: [{type: "text", text: "and again"}],
+			timestamp: 13,
+		};
+		const folded = eventsOf(
+			projectionOf(restored),
+			snapshot([user, assistant("hi back", 0.42), sent], "turn", 8),
+		);
+		expect(folded.events).toEqual([
+			{kind: "item", item: itemOf(sent)},
+			{kind: "phase", phase: "prompting"},
+		]);
+	});
+
+	/**
+	 * The phase is the one thing the seed leaves out: `start` emits its own `ready` after the
+	 * attach, so a session still working when it was reattached has to restate `prompting`.
+	 */
+	it("restates the phase of a session that was still working when it was reattached", () => {
+		const working = snapshot([user], "turn", 7);
+		expect(eventsOf(projectionOf(working), working).events).toEqual([
+			{kind: "phase", phase: "prompting"},
+		]);
 	});
 
 	/**

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -260,7 +260,7 @@ describe("one revision folded into events", () => {
 	 */
 	it("emits no item and no usage when a resume's seed already holds the whole transcript", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored), restored);
+		const folded = eventsOf(projectionOf(restored, "item-1"), restored);
 		expect(folded.events).toEqual([{kind: "phase", phase: "ready"}]);
 	});
 
@@ -273,7 +273,7 @@ describe("one revision folded into events", () => {
 			timestamp: 13,
 		};
 		const folded = eventsOf(
-			projectionOf(restored),
+			projectionOf(restored, "item-1"),
 			snapshot([user, assistant("hi back", 0.42), sent], "turn", 8),
 		);
 		expect(folded.events).toEqual([
@@ -283,12 +283,48 @@ describe("one revision folded into events", () => {
 	});
 
 	/**
+	 * Everything after the boundary is work the caller has never seen — a turn the session finished
+	 * while the socket was down — and burying it would leave no gap marker and no way to page to it
+	 * (#8374).
+	 */
+	it("emits what the session finished past the boundary the caller holds", () => {
+		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
+		const folded = eventsOf(projectionOf(restored, user.id), restored);
+		expect(folded.events).toEqual([
+			{
+				kind: "item",
+				item: {kind: "thinking", id: "item-1:thinking", timestamp: 11, text: "not for the window"},
+			},
+			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
+			{
+				kind: "usage",
+				model: "faux/faux-1",
+				inputTokens: 11,
+				outputTokens: 22,
+				cost: 0.42,
+			},
+			{kind: "phase", phase: "ready"},
+		]);
+	});
+
+	/**
+	 * A boundary this snapshot does not carry — a compaction renumbered the transcript out from
+	 * under the caller — seeds nothing and replays. A visibly wrong transcript is recoverable; a
+	 * silently missing reply is not.
+	 */
+	it("replays rather than guesses when the boundary is not in the snapshot", () => {
+		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
+		const folded = eventsOf(projectionOf(restored, "item-gone"), restored);
+		expect(folded.events.filter((event) => event.kind === "item")).toHaveLength(3);
+	});
+
+	/**
 	 * The phase is the one thing the seed leaves out: `start` emits its own `ready` after the
 	 * attach, so a session still working when it was reattached has to restate `prompting`.
 	 */
 	it("restates the phase of a session that was still working when it was reattached", () => {
 		const working = snapshot([user], "turn", 7);
-		expect(eventsOf(projectionOf(working), working).events).toEqual([
+		expect(eventsOf(projectionOf(working, "item-0"), working).events).toEqual([
 			{kind: "phase", phase: "prompting"},
 		]);
 	});

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -308,6 +308,28 @@ describe("one revision folded into events", () => {
 	});
 
 	/**
+	 * The socket can drop between a turn's reasoning row and its reply, so the boundary lands
+	 * inside the turn rather than after it. The reply is then unseen work that has to emit — and
+	 * its cost is that reply's annotation, so the turn's `usage` has to emit with it or the tokens
+	 * and the cost never join the session totals, silently, for the life of the session (#8374).
+	 */
+	it("emits the cost of a turn the boundary fell inside, not just its reply", () => {
+		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
+		const folded = eventsOf(projectionOf(restored, "item-1:thinking"), restored);
+		expect(folded.events).toEqual([
+			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
+			{
+				kind: "usage",
+				model: "faux/faux-1",
+				inputTokens: 11,
+				outputTokens: 22,
+				cost: 0.42,
+			},
+			{kind: "phase", phase: "ready"},
+		]);
+	});
+
+	/**
 	 * A boundary this snapshot does not carry — a compaction renumbered the transcript out from
 	 * under the caller — seeds nothing and replays. A visibly wrong transcript is recoverable; a
 	 * silently missing reply is not.

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -19,8 +19,32 @@ import {
 	initialState,
 } from "../../ai-agent/core/index.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
-import {TOOL_RESULT_BYTE_LIMIT} from "../../ai-agent/ports/index.ts";
-import {emptyProjection, eventsOf, itemOf, itemsOf, phaseOf, projectionOf} from "./items.ts";
+import {TOOL_RESULT_BYTE_LIMIT, type TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {
+	emptyProjection,
+	eventsOf,
+	itemId,
+	itemOf,
+	itemsOf,
+	phaseOf,
+	projectionOf,
+} from "./items.ts";
+
+/**
+ * The tail an operator holds who read this snapshot as far as `through`: the rows the fold would
+ * have emitted, in that order. `projectionOf` takes the tail rather than a boundary id, because
+ * "already read" is measured against the copies in it.
+ */
+const heldThrough = (source: SessionSnapshot, through: string): ReadonlyArray<TranscriptItem> => {
+	const rows: Array<TranscriptItem> = [];
+	for (const item of source.transcript) {
+		for (const row of itemsOf(item)) {
+			rows.push(row);
+			if (row.id === through) return rows;
+		}
+	}
+	return rows;
+};
 
 const usage = (total: number) => ({
 	input: 11,
@@ -260,7 +284,7 @@ describe("one revision folded into events", () => {
 	 */
 	it("emits no item and no usage when a resume's seed already holds the whole transcript", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored, "item-1"), restored);
+		const folded = eventsOf(projectionOf(restored, heldThrough(restored, "item-1")), restored);
 		expect(folded.events).toEqual([{kind: "phase", phase: "ready"}]);
 	});
 
@@ -273,7 +297,7 @@ describe("one revision folded into events", () => {
 			timestamp: 13,
 		};
 		const folded = eventsOf(
-			projectionOf(restored, "item-1"),
+			projectionOf(restored, heldThrough(restored, "item-1")),
 			snapshot([user, assistant("hi back", 0.42), sent], "turn", 8),
 		);
 		expect(folded.events).toEqual([
@@ -289,7 +313,7 @@ describe("one revision folded into events", () => {
 	 */
 	it("emits what the session finished past the boundary the caller holds", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored, user.id), restored);
+		const folded = eventsOf(projectionOf(restored, heldThrough(restored, user.id)), restored);
 		expect(folded.events).toEqual([
 			{
 				kind: "item",
@@ -315,7 +339,48 @@ describe("one revision folded into events", () => {
 	 */
 	it("emits the cost of a turn the boundary fell inside, not just its reply", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored, "item-1:thinking"), restored);
+		const folded = eventsOf(
+			projectionOf(restored, heldThrough(restored, "item-1:thinking")),
+			restored,
+		);
+		expect(folded.events).toEqual([
+			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
+			{
+				kind: "usage",
+				model: "faux/faux-1",
+				inputTokens: 11,
+				outputTokens: 22,
+				cost: 0.42,
+			},
+			{kind: "phase", phase: "ready"},
+		]);
+	});
+
+	/**
+	 * The boundary can land *on* a row whose content moved while the socket was down. Pi's
+	 * assistant item has a `status: "streaming"` variant with `usage` optional
+	 * (`@earendil-works/pi-protocol` 0.84.3 `dist/schemas.d.ts`), so a reply the drop caught
+	 * mid-write settles server-side while this process is away. Being at the boundary does not
+	 * make it read: the operator holds the half-written copy, so the settled one has to emit, and
+	 * the turn's cost with it.
+	 */
+	it("emits a row that settled under the boundary while the caller was away", () => {
+		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
+		const streaming: PiTranscriptItem = {
+			id: "item-1",
+			role: "assistant",
+			content: [
+				{type: "thinking", thinking: "not for the window"},
+				{type: "text", text: "hi b"},
+			],
+			model: {provider: "faux", id: "faux-1"},
+			timestamp: 11,
+			status: "streaming",
+		};
+		const folded = eventsOf(
+			projectionOf(restored, [itemOf(user), ...itemsOf(streaming)]),
+			restored,
+		);
 		expect(folded.events).toEqual([
 			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
 			{
@@ -336,7 +401,12 @@ describe("one revision folded into events", () => {
 	 */
 	it("replays rather than guesses when the boundary is not in the snapshot", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored, "item-gone"), restored);
+		const folded = eventsOf(
+			projectionOf(restored, [
+				{kind: "assistant", id: itemId("item-gone"), timestamp: 9, text: "gone"},
+			]),
+			restored,
+		);
 		expect(folded.events.filter((event) => event.kind === "item")).toHaveLength(3);
 	});
 
@@ -346,9 +416,9 @@ describe("one revision folded into events", () => {
 	 */
 	it("restates the phase of a session that was still working when it was reattached", () => {
 		const working = snapshot([user], "turn", 7);
-		expect(eventsOf(projectionOf(working, "item-0"), working).events).toEqual([
-			{kind: "phase", phase: "prompting"},
-		]);
+		expect(eventsOf(projectionOf(working, heldThrough(working, "item-0")), working).events).toEqual(
+			[{kind: "phase", phase: "prompting"}],
+		);
 	});
 
 	/**

--- a/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
@@ -36,6 +36,7 @@ const idle: PiClientApi = {
 	connected: Effect.succeed(false),
 	createSession: () => Effect.die("listing must not open a session"),
 	attachSession: () => Effect.die("listing must not open a session"),
+	heldSnapshot: () => Effect.die("listing must not read a session's snapshot"),
 	prompt: () => Effect.die("listing must not prompt"),
 	abort: () => Effect.never,
 	setModel: () => Effect.die("listing must not switch models"),

--- a/apps/tuval/src/pi/ai-agent/pi-ai-agent.integration.test.ts
+++ b/apps/tuval/src/pi/ai-agent/pi-ai-agent.integration.test.ts
@@ -303,11 +303,15 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 
 					yield* Effect.gen(function* () {
 						const intruder = yield* TuvalAiAgent;
-						const locked = yield* Effect.flip(intruder.start({cwd, resume: started.sessionId}));
+						const locked = yield* Effect.flip(
+							intruder.start({cwd, resume: {sessionId: started.sessionId, holdsTranscript: false}}),
+						);
 						assert.instanceOf(locked, StartError);
 						assert.strictEqual(locked.reason, "session-locked");
 
-						const missing = yield* Effect.flip(intruder.start({cwd, resume: "no-such-session"}));
+						const missing = yield* Effect.flip(
+							intruder.start({cwd, resume: {sessionId: "no-such-session", holdsTranscript: false}}),
+						);
 						assert.strictEqual(missing.reason, "session-not-found");
 					}).pipe(
 						Effect.provide(
@@ -342,7 +346,10 @@ describe("the Pi AI agent layer over a real AgentSession", () => {
 					);
 
 					// The way back in re-dials and reacquires the same session by id.
-					const resumed = yield* owner.start({cwd, resume: started.sessionId});
+					const resumed = yield* owner.start({
+						cwd,
+						resume: {sessionId: started.sessionId, holdsTranscript: false},
+					});
 					assert.strictEqual(resumed.sessionId, started.sessionId);
 					yield* owner.prompt("second question");
 					yield* turnsRan(faux, 2);

--- a/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
@@ -119,6 +119,7 @@ const pin = (options: {readonly refusals?: number} = {}): Effect.Effect<Pin> =>
 			connected: Effect.succeed(true),
 			createSession: () => Effect.succeed(SESSION),
 			attachSession: () => Effect.succeed(SESSION),
+			heldSnapshot: () => Effect.succeed(snapshotOf([], "idle", 0)),
 			prompt: (_sessionId, text) =>
 				Effect.gen(function* () {
 					sends.push(text);

--- a/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
@@ -14,6 +14,10 @@
  * the whole snapshot would bury it for the life of the session, which is why the seed cuts at that
  * tail rather than at the snapshot — and why it suppresses against the caller's own copy of each
  * row, so one that settled under the cut while the transport was gone still emits (#8374).
+ *
+ * What the operator is shown and what they are charged come apart here, and both are pinned. A cost
+ * is folded under its turn's id, so a resume may restate a turn the process already counted without
+ * moving the totals — the last two cases walk that in both directions.
  */
 
 import type {
@@ -22,7 +26,15 @@ import type {
 } from "@earendil-works/pi-protocol";
 import {assert, describe, it} from "@effect/vitest";
 import {type Cause, Effect, Layer, Option, Queue, Stream} from "effect";
-import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
+import {
+	type AiAgentSessionState,
+	foldEvent,
+	initialState,
+	restore,
+	usageTotals,
+} from "../../ai-agent/core/index.ts";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import type {AgentEvent, Phase, TransportError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
 import {itemsOf} from "./items.ts";
@@ -135,6 +147,34 @@ const itemIds = (events: ReadonlyArray<AgentEvent>): ReadonlyArray<string> =>
 
 const usages = (events: ReadonlyArray<AgentEvent>): number =>
 	events.filter((event) => event.kind === "usage").length;
+
+/** The tool row the agent was still running when the process went away. */
+const running: PiTranscriptItem = {
+	id: "item-2",
+	role: "tool",
+	toolCallId: "call-1",
+	toolName: "read_file",
+	input: {path: "README.md"},
+	content: [],
+	timestamp: 12,
+	status: "running",
+	isError: false,
+};
+
+/** A session whose ledger already holds what `reply` cost, as a checkpoint would carry it. */
+const counted = (items: ReadonlyArray<TranscriptItem>, phase: Phase): AiAgentSessionState => ({
+	...initialState(CWD),
+	phase,
+	transcript: {items: [...items], omitted: {items: 0, bytes: 0, reason: "none"}},
+	usage: {
+		model: `${SESSION.model.provider}/${SESSION.model.id}`,
+		turns: {[reply.id]: {inputTokens: 11, outputTokens: 22, cost: 0.42}},
+	},
+});
+
+/** What the session has spent once every event of this push has been folded into it. */
+const spent = (state: AiAgentSessionState, events: ReadonlyArray<AgentEvent>) =>
+	usageTotals(events.reduce((carried, event) => foldEvent(carried, event, {}), state).usage);
 
 describe("a Pi session resumed by a caller that already holds its transcript", () => {
 	it.live(
@@ -309,6 +349,72 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 					Effect.scoped,
 				);
 			}),
+	);
+
+	/**
+	 * Criterion 5, the direction a seed can lose: a resume that shows the operator nothing new must
+	 * cost them nothing new either.
+	 */
+	it.live("leaves the totals where they were when the resume adds no item", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				const tail = held(user, reply);
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION.id, holdsTranscript: true, held: tail},
+				});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* drain(events);
+
+				yield* client.push(HELD);
+				const folded = yield* drain(events);
+				assert.strictEqual(
+					spent(counted(tail, "ready"), folded).cost,
+					0.42,
+					"the resume charged the session again for a turn it had already counted",
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	/**
+	 * Criterion 5, the other direction, and the ordinary shape of an agent parked mid-work: a
+	 * multi-step turn checkpointed on a running tool row at phase `prompting`.
+	 *
+	 * `restore` marks the tail's newest assistant row `interrupted`, walking back past the tool row
+	 * to reach it (`core/state.ts`) — so the reply this process already paid for comes back
+	 * carrying a marker the backend's copy does not have, and the reconnect hands that marked tail
+	 * through as the fold's seed. The turn is behind the seed's boundary and still differs from the
+	 * snapshot, so its cost is re-reported; keying the cost on the turn is what makes the second
+	 * report cost nothing (#8369).
+	 */
+	it.live("counts a turn parked under an interrupted marker exactly once", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				const parked = counted(held(user, reply, running), "prompting");
+				const marked = restore(parked).transcript.items;
+				assert.ok(
+					marked.some((item) => item.kind === "assistant" && item.interrupted === true),
+					"the restore left the parked reply unmarked, so this pins nothing",
+				);
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION.id, holdsTranscript: true, held: marked},
+				});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* drain(events);
+
+				yield* client.push(snapshot([user, reply, running], "turn", 8));
+				const folded = yield* drain(events);
+				assert.strictEqual(spent(parked, folded).cost, 0.42, "the parked turn's cost landed twice");
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
 	);
 
 	it.live("opens a fresh session on an empty projection, so its first snapshot paints", () =>

--- a/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
@@ -12,7 +12,8 @@
  * What the restored process holds stops at the tail it was checkpointed with, so a turn the session
  * finished while the socket was down sits in the lease snapshot and on nobody's screen. Suppressing
  * the whole snapshot would bury it for the life of the session, which is why the seed cuts at that
- * boundary rather than at the snapshot (#8374).
+ * tail rather than at the snapshot — and why it suppresses against the caller's own copy of each
+ * row, so one that settled under the cut while the transport was gone still emits (#8374).
  */
 
 import type {
@@ -24,6 +25,7 @@ import {type Cause, Effect, Layer, Option, Queue, Stream} from "effect";
 import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {itemsOf} from "./items.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
 
 const CWD = "/tuval/resume";
@@ -89,6 +91,9 @@ const snapshot = (
 /** The transcript the session already had when this client attached to it. */
 const HELD = snapshot([user, reply], "idle", 7);
 
+/** The tail a restored process comes back with: the rows the fold emitted it for these turns. */
+const held = (...sources: ReadonlyArray<PiTranscriptItem>) => sources.flatMap(itemsOf);
+
 const stub = Effect.gen(function* () {
 	const pushes = yield* Queue.unbounded<SessionSnapshot>();
 	const api: PiClientApi = {
@@ -142,7 +147,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 					const agent = yield* TuvalAiAgent;
 					yield* agent.start({
 						cwd: CWD,
-						resume: {sessionId: SESSION.id, holdsTranscript: true, newestItemId: reply.id},
+						resume: {sessionId: SESSION.id, holdsTranscript: true, held: held(user, reply)},
 					});
 					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 					yield* drain(events);
@@ -166,7 +171,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 				const agent = yield* TuvalAiAgent;
 				yield* agent.start({
 					cwd: CWD,
-					resume: {sessionId: SESSION.id, holdsTranscript: true, newestItemId: reply.id},
+					resume: {sessionId: SESSION.id, holdsTranscript: true, held: held(user, reply)},
 				});
 				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 				yield* drain(events);
@@ -243,7 +248,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 				// socket dropped, so this process has never seen it and nothing else will show it.
 				yield* agent.start({
 					cwd: CWD,
-					resume: {sessionId: SESSION.id, holdsTranscript: true, newestItemId: user.id},
+					resume: {sessionId: SESSION.id, holdsTranscript: true, held: held(user)},
 				});
 				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 				yield* drain(events);
@@ -258,6 +263,52 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 				assert.strictEqual(usages(folded), 1, "the reply arrived without its own cost");
 			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
 		}),
+	);
+
+	/**
+	 * The drop can catch the agent mid-sentence. Pi's assistant item carries a `status: "streaming"`
+	 * variant whose `usage` is optional (`@earendil-works/pi-protocol` 0.84.3 `dist/schemas.d.ts`),
+	 * so the tail this process comes back with holds a half-written reply under the same id the
+	 * finished one now has. That id being the newest thing it holds does not make the finished reply
+	 * read: suppressing it leaves the operator on the half-written text for the life of the session
+	 * and drops the turn's cost out of the totals, with nothing to show either happened.
+	 */
+	it.live(
+		"emits a reply that settled under the caller's own boundary while the socket was down",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* stub;
+
+				yield* Effect.gen(function* () {
+					const agent = yield* TuvalAiAgent;
+					const streaming: PiTranscriptItem = {
+						id: reply.id,
+						role: "assistant",
+						content: [{type: "text", text: "hel"}],
+						model: SESSION.model,
+						timestamp: 11,
+						status: "streaming",
+					};
+					yield* agent.start({
+						cwd: CWD,
+						resume: {sessionId: SESSION.id, holdsTranscript: true, held: held(user, streaming)},
+					});
+					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+					yield* drain(events);
+
+					yield* client.push(HELD);
+					const folded = yield* drain(events);
+					assert.deepStrictEqual(
+						itemIds(folded),
+						[reply.id],
+						"the operator is still looking at the half-written reply",
+					);
+					assert.strictEqual(usages(folded), 1, "the settled turn's cost never joined the totals");
+				}).pipe(
+					Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))),
+					Effect.scoped,
+				);
+			}),
 	);
 
 	it.live("opens a fresh session on an empty projection, so its first snapshot paints", () =>

--- a/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
@@ -1,0 +1,220 @@
+/**
+ * What a resume owes the window, over a stub `PiClientService` whose snapshot stream is a queue the
+ * test pushes.
+ *
+ * Pi re-sends the whole transcript every revision, so the fold's projection is the only thing
+ * standing between a reattach and a full replay of the session as live items. A restored process
+ * comes back with that transcript already on screen, and the replay lands on top of the operator's
+ * own newly typed turn, pushing it out of the 40-item window (#8369). A window opened on a session
+ * out of the picker holds nothing, and the same replay is the only way its history paints — so both
+ * halves are pinned here.
+ */
+
+import type {
+	TranscriptItem as PiTranscriptItem,
+	SessionSnapshot,
+} from "@earendil-works/pi-protocol";
+import {assert, describe, it} from "@effect/vitest";
+import {type Cause, Effect, Layer, Option, Queue, Stream} from "effect";
+import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
+import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {aiAgentOverClient} from "./PiAiAgent.ts";
+
+const CWD = "/tuval/resume";
+const SESSION: PiSessionRef = {
+	id: "session-8369",
+	cwd: CWD,
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+};
+
+const user: PiTranscriptItem = {
+	id: "item-0",
+	role: "user",
+	content: [{type: "text", text: "say hello"}],
+	timestamp: 10,
+};
+
+const reply: PiTranscriptItem = {
+	id: "item-1",
+	role: "assistant",
+	content: [{type: "text", text: "hello"}],
+	model: SESSION.model,
+	timestamp: 11,
+	status: "complete",
+	stopReason: "stop",
+	usage: {
+		input: 11,
+		output: 22,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 33,
+		cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.42},
+	},
+};
+
+const sent: PiTranscriptItem = {
+	id: "item-2",
+	role: "user",
+	content: [{type: "text", text: "and again"}],
+	timestamp: 12,
+};
+
+const snapshot = (
+	transcript: ReadonlyArray<PiTranscriptItem>,
+	phase: SessionSnapshot["phase"],
+	revision: number,
+): SessionSnapshot => ({
+	id: SESSION.id,
+	cwd: CWD,
+	createdAt: 0,
+	updatedAt: 0,
+	phase,
+	model: SESSION.model,
+	thinkingLevel: "off",
+	attached: true,
+	locked: false,
+	revision,
+	transcript: [...transcript],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+/** The transcript the session already had when this client attached to it. */
+const HELD = snapshot([user, reply], "idle", 7);
+
+const stub = Effect.gen(function* () {
+	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const api: PiClientApi = {
+		connect: Effect.void,
+		reconnect: Effect.void,
+		connected: Effect.succeed(true),
+		createSession: () => Effect.succeed(SESSION),
+		attachSession: () => Effect.succeed(SESSION),
+		heldSnapshot: () => Effect.succeed(HELD),
+		prompt: () => Effect.never,
+		abort: () => Effect.never,
+		setModel: () => Effect.never,
+		setThinkingLevel: () => Effect.never,
+		models: Effect.succeed([]),
+		snapshots: () => Stream.fromQueue(pushes),
+		disconnections: Stream.never,
+	};
+	return {
+		layer: Layer.succeed(PiClientService, api),
+		push: (value: SessionSnapshot) => Queue.offer(pushes, value),
+	};
+});
+
+type Events = Queue.Dequeue<AgentEvent, TransportError | Cause.Done>;
+
+/** Every event the stream holds now, drained until it goes quiet. */
+const drain = (events: Events) =>
+	Effect.gen(function* () {
+		const seen: Array<AgentEvent> = [];
+		while (true) {
+			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("250 millis"));
+			if (Option.isNone(next)) return seen;
+			seen.push(next.value);
+		}
+	});
+
+const itemIds = (events: ReadonlyArray<AgentEvent>): ReadonlyArray<string> =>
+	events.flatMap((event) => (event.kind === "item" ? [event.item.id] : []));
+
+const usages = (events: ReadonlyArray<AgentEvent>): number =>
+	events.filter((event) => event.kind === "usage").length;
+
+describe("a Pi session resumed by a caller that already holds its transcript", () => {
+	it.live(
+		"emits no item and no usage when the first push carries the transcript it opened on",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* stub;
+
+				yield* Effect.gen(function* () {
+					const agent = yield* TuvalAiAgent;
+					yield* agent.start({cwd: CWD, resume: SESSION.id, holdsTranscript: true});
+					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+					yield* drain(events);
+
+					yield* client.push(HELD);
+					const folded = yield* drain(events);
+					assert.deepStrictEqual(itemIds(folded), [], "the resume replayed the transcript");
+					assert.strictEqual(usages(folded), 0, "the resume re-added the session's usage");
+				}).pipe(
+					Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))),
+					Effect.scoped,
+				);
+			}),
+	);
+
+	it.live("emits the operator's own turn, and nothing under it, on the push that carries it", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD, resume: SESSION.id, holdsTranscript: true});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* drain(events);
+
+				yield* client.push(snapshot([user, reply, sent], "turn", 8));
+				const folded = yield* drain(events);
+				assert.deepStrictEqual(
+					itemIds(folded),
+					[sent.id],
+					"the send arrived under a replay of the history above it",
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	it.live(
+		"still replays the history for a caller that holds none, which is how the picker paints",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* stub;
+
+				yield* Effect.gen(function* () {
+					const agent = yield* TuvalAiAgent;
+					yield* agent.start({cwd: CWD, resume: SESSION.id});
+					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+					yield* drain(events);
+
+					yield* client.push(HELD);
+					const folded = yield* drain(events);
+					assert.deepStrictEqual(
+						itemIds(folded),
+						[user.id, reply.id],
+						"a window opened on a past session came up empty",
+					);
+				}).pipe(
+					Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))),
+					Effect.scoped,
+				);
+			}),
+	);
+
+	it.live("opens a fresh session on an empty projection, so its first snapshot paints", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* drain(events);
+
+				yield* client.push(snapshot([user], "turn", 1));
+				const folded = yield* drain(events);
+				assert.deepStrictEqual(
+					itemIds(folded),
+					[user.id],
+					"a fresh session's first item was eaten",
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+});

--- a/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
@@ -8,6 +8,11 @@
  * own newly typed turn, pushing it out of the 40-item window (#8369). A window opened on a session
  * out of the picker holds nothing, and the same replay is the only way its history paints — so both
  * halves are pinned here.
+ *
+ * What the restored process holds stops at the tail it was checkpointed with, so a turn the session
+ * finished while the socket was down sits in the lease snapshot and on nobody's screen. Suppressing
+ * the whole snapshot would bury it for the life of the session, which is why the seed cuts at that
+ * boundary rather than at the snapshot (#8374).
  */
 
 import type {
@@ -135,7 +140,10 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 
 				yield* Effect.gen(function* () {
 					const agent = yield* TuvalAiAgent;
-					yield* agent.start({cwd: CWD, resume: SESSION.id, holdsTranscript: true});
+					yield* agent.start({
+						cwd: CWD,
+						resume: {sessionId: SESSION.id, holdsTranscript: true, newestItemId: reply.id},
+					});
 					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 					yield* drain(events);
 
@@ -156,7 +164,10 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 
 			yield* Effect.gen(function* () {
 				const agent = yield* TuvalAiAgent;
-				yield* agent.start({cwd: CWD, resume: SESSION.id, holdsTranscript: true});
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION.id, holdsTranscript: true, newestItemId: reply.id},
+				});
 				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 				yield* drain(events);
 
@@ -171,30 +182,82 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 		}),
 	);
 
-	it.live(
-		"still replays the history for a caller that holds none, which is how the picker paints",
-		() =>
-			Effect.gen(function* () {
-				const client = yield* stub;
+	it.live("paints the history at the attach for a caller that holds none", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
 
-				yield* Effect.gen(function* () {
-					const agent = yield* TuvalAiAgent;
-					yield* agent.start({cwd: CWD, resume: SESSION.id});
-					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
-					yield* drain(events);
-
-					yield* client.push(HELD);
-					const folded = yield* drain(events);
-					assert.deepStrictEqual(
-						itemIds(folded),
-						[user.id, reply.id],
-						"a window opened on a past session came up empty",
-					);
-				}).pipe(
-					Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))),
-					Effect.scoped,
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION.id, holdsTranscript: false},
+				});
+				const opened = yield* drain(events);
+				assert.deepStrictEqual(
+					itemIds(opened),
+					[user.id, reply.id],
+					"a window opened on a past session came up empty",
 				);
-			}),
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	/**
+	 * Criterion 7's own case. The picker's window is empty, so the history paints — but at the
+	 * attach, before the operator can have typed anything. By the time their turn provokes Pi's
+	 * first push, the fold already holds that history and emits their turn alone, so it stays the
+	 * newest item in the tail instead of sitting above the session it belongs under (#8369).
+	 */
+	it.live("emits only the operator's turn on the first push after a picker open", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION.id, holdsTranscript: false},
+				});
+				yield* drain(events);
+
+				yield* client.push(snapshot([user, reply, sent], "turn", 8));
+				const folded = yield* drain(events);
+				assert.deepStrictEqual(
+					itemIds(folded),
+					[sent.id],
+					"the picker's first send arrived under a replay of the history above it",
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	it.live("emits the turn the session finished while the socket was down", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				// The checkpointed tail stops at the operator's turn: the reply landed after the
+				// socket dropped, so this process has never seen it and nothing else will show it.
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: SESSION.id, holdsTranscript: true, newestItemId: user.id},
+				});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* drain(events);
+
+				yield* client.push(HELD);
+				const folded = yield* drain(events);
+				assert.deepStrictEqual(
+					itemIds(folded),
+					[reply.id],
+					"the reply that landed during the drop was suppressed and never paints",
+				);
+				assert.strictEqual(usages(folded), 1, "the reply arrived without its own cost");
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
 	);
 
 	it.live("opens a fresh session on an empty projection, so its first snapshot paints", () =>

--- a/apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts
@@ -79,6 +79,7 @@ const stub = Effect.gen(function* () {
 		connected: Effect.succeed(true),
 		createSession: () => Effect.succeed(SESSION),
 		attachSession: () => Effect.succeed(SESSION),
+		heldSnapshot: () => Effect.succeed(snapshot([], "idle", 0)),
 		prompt: () => Deferred.await(ended),
 		abort: () => Effect.never,
 		setModel: () => Effect.never,

--- a/apps/tuval/src/pi/ai-agent/turn.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/turn.unit.test.ts
@@ -394,7 +394,9 @@ describe("a failed start", () => {
 
 			yield* Effect.gen(function* () {
 				const agent = yield* TuvalAiAgent;
-				const refused = yield* Effect.flip(agent.start({cwd: CWD, resume: SESSION.id}));
+				const refused = yield* Effect.flip(
+					agent.start({cwd: CWD, resume: {sessionId: SESSION.id, holdsTranscript: false}}),
+				);
 				assert.strictEqual(refused.reason, "session-locked");
 
 				assert.deepStrictEqual(

--- a/apps/tuval/src/pi/ai-agent/turn.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/turn.unit.test.ts
@@ -108,6 +108,7 @@ const stub = (options: StubOptions) =>
 				options.lockAttach === true
 					? Effect.fail(new SessionLocked({sessionId, detail: "another connection holds it"}))
 					: Effect.succeed(SESSION),
+			heldSnapshot: () => Effect.succeed(SNAPSHOT),
 			prompt: (_sessionId, text) =>
 				Effect.gen(function* () {
 					yield* Ref.update(sends, (seen) => [...seen, text]);

--- a/apps/tuval/src/pi/client/PiClientService.ts
+++ b/apps/tuval/src/pi/client/PiClientService.ts
@@ -74,6 +74,13 @@ export interface PiClientApi {
 		options?: OpenSessionOptions,
 	) => Effect.Effect<PiSessionRef, ConnectionRefusal>;
 	readonly attachSession: (sessionId: string) => Effect.Effect<PiSessionRef, SessionRefusal>;
+	/**
+	 * The snapshot the lease on this session landed with — the transcript Pi had already sent by
+	 * the time `createSession` or `attachSession` answered. `PiSessionRef` keeps only the three
+	 * fields a caller needs to run the session; a resume needs the transcript itself, to seed its
+	 * snapshot diff so the first push after reattaching folds to zero events (#8369).
+	 */
+	readonly heldSnapshot: (sessionId: string) => Effect.Effect<SessionSnapshot, SessionRefusal>;
 	/** Needs a lease this client took through `createSession` or `attachSession`. */
 	readonly prompt: (
 		sessionId: string,
@@ -263,6 +270,16 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 				: Effect.succeed(lease);
 		};
 
+		const heldSnapshot = Effect.fn("PiClientService.heldSnapshot")(function* (sessionId: string) {
+			const lease = yield* leased(sessionId);
+			return lease.snapshot === undefined
+				? yield* new ProtocolRefused({
+						code: "internal_error",
+						detail: `no snapshot arrived for session ${lease.id}`,
+					})
+				: lease.snapshot;
+		});
+
 		const prompt = Effect.fn("PiClientService.prompt")(function* (sessionId: string, text: string) {
 			const lease = yield* leased(sessionId);
 			return yield* Effect.tryPromise({
@@ -336,6 +353,7 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 			connected: Effect.sync(() => client.connected),
 			createSession,
 			attachSession,
+			heldSnapshot,
 			prompt,
 			abort,
 			setModel,

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -42,7 +42,7 @@ const cutMidReply: AiAgentSessionState = {
 	},
 	interrupted: null,
 	interruption: null,
-	usage: {model: "faux/faux-1", inputTokens: 10, outputTokens: 4, cost: 0},
+	usage: {model: "faux/faux-1", turns: {"item-1": {inputTokens: 10, outputTokens: 4, cost: 0}}},
 	permissions: {},
 	permissionsRaised: 0,
 	modes: {current: null, available: []},

--- a/apps/tuval/src/pi/window/pi-window.testing.ts
+++ b/apps/tuval/src/pi/window/pi-window.testing.ts
@@ -11,7 +11,7 @@
  * would be testing a session Pi cannot produce.
  */
 
-import type {AiAgentSessionState, UsageTotals} from "../../ai-agent/core/index.ts";
+import type {AiAgentSessionState, UsageLedger} from "../../ai-agent/core/index.ts";
 import {initialState} from "../../ai-agent/core/state.ts";
 import {assistantItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 
@@ -22,11 +22,9 @@ export const usageOf = (usage: {
 	readonly cost: number;
 	readonly input: number;
 	readonly output: number;
-}): UsageTotals => ({
+}): UsageLedger => ({
 	model: usage.model,
-	cost: usage.cost,
-	inputTokens: usage.input,
-	outputTokens: usage.output,
+	turns: {"turn-1": {cost: usage.cost, inputTokens: usage.input, outputTokens: usage.output}},
 });
 
 export const piSession = (overrides: Partial<AiAgentSessionState> = {}): AiAgentSessionState => ({


### PR DESCRIPTION
Fixes #8369

Resuming a Tuval pi session used to dump the whole transcript back onto the live stream. The flood
landed in the same snapshot as the operator's newly typed message, `upsertItem` appended the
replayed history *after* that message, and `planTranscriptWindow`'s newest-40-by-position cut then
trimmed the operator's own turn out of the window — so the send looked lost.

Two resume paths reach that symptom and they want different remedies, so round 2 fixes both.

**Reconnect — seed, and cut the seed at the tail the process holds.** A restored process comes back
with its committed tail on screen, so `follow()` seeds its snapshot-diff projection from the attach
lease's own snapshot and the first push after reattaching folds to zero events. Round 1 seeded the
*whole* snapshot, which buried anything the session finished while the socket was down. The seed now
stops at the newest item the process actually holds: `projectionOf(snapshot, held)` marks everything
at or older than that boundary as already rendered and leaves the rest to emit. A boundary the
snapshot does not carry (a compaction renumbered it) seeds nothing and replays: a visibly wrong
transcript is recoverable, a silently missing reply is not.

**Picker — paint the history earlier, not lower.** A window opened out of the picker is genuinely
empty, so painting its history there is correct; the defect is only *when* it paints. Pi pushes only
on a session event, so nothing paints until the operator's first prompt — and that snapshot carries
the whole history *and* their turn, which is how their message ends up above the session it belongs
under. `paintOf(snapshot)` emits that history at the attach instead, while the tail is still empty
and appending is the right order, and seeds the projection with it so the first real push emits the
operator's turn alone. Nothing in the core changes.

**`resume` carries its own facts.** `StartOptions.resume` is a `ResumeTarget` — `{sessionId,
holdsTranscript: false}` or `{sessionId, holdsTranscript: true, held}` — so `holdsTranscript`
without a resume, and a tail without `holdsTranscript`, are both unrepresentable. That retires the
trailing positional boolean on `open()` in `ai-agent/handlers/index.ts` and its
`open(cmd.cwd, cmd.sessionId, cmd.mode, true)` call site.

**Round 4 — suppress against the operator's copy, not the lease's.** Round 3's review found that the
seed fingerprinted each already-read row off the *lease* snapshot, so `eventsOf` compared that
snapshot against itself. A reply the socket died in the middle of and that settled server-side while
the process was away matched its own fingerprint and never emitted: the operator kept the
half-written text and the turn's cost never joined the totals. Suppressing by id assumes item
content is immutable, and on this wire it is not —
`@earendil-works/pi-protocol@0.84.3` `dist/schemas.d.ts` declares the assistant item as a
`streaming` / `complete` / `aborted` union with `usage` `TOptional` on every arm. The resume now
carries the caller's tail itself rather than a boundary id, and both facts come off that one value:
its newest backend-minted row is the same boundary as before, and each row is the copy a seeded row
is measured against, so a row that moved under the boundary emits and its turn's cost travels with
it. `newestBackendItemId` moved from `ai-agent/handlers/index.ts` to `ai-agent/ports/transcript-item.ts`,
which is where that knowledge belongs. The finding landed as an escalation comment rather than as
criterion 11 because round 3 is ADR 0079's freeze; the founder read it and ruled fix-here
(https://github.com/kamp-us/phoenix/issues/8369#issuecomment-5563165817).

**Round 5 — a turn's cost is keyed by the turn, so folding it twice is a no-op.** Round 4's review
found the seed's other direction: `restore` marks the tail's newest assistant row `interrupted`
whenever the saved phase was `prompting`, the reconnect hands that marked tail through as the seed,
and a row that differs from the snapshot by the local marker alone trips `moved` — so the turn's
cost is re-reported and `addUsage`, a plain running sum, charged it twice. Stripping the marker
before fingerprinting trades that for the symmetric under-count, because a `streaming` reply with
its text fully written projects to the identical value as the settled one and there the re-emit is
correct. Three rounds have now failed on that same axis, because "already counted" is not a fact the
code can check — it is one the resume payload has to carry correctly on every path. The founder
ruled the defect class out instead
(https://github.com/kamp-us/phoenix/issues/8369#issuecomment-5563706105): a `UsageEvent` now names
the turn it belongs to, and the session's spend is a ledger keyed by that id
(`ai-agent/core/state.ts`'s `UsageLedger`) whose totals are summed on read (`usageTotals`) rather
than stored beside it. `addUsage` leaves a turn already in the ledger exactly as it stands, so a
seed that misses a cost the caller has already counted costs nothing the second time. No total can
disagree with the turns it is a sum of, and nothing in `projectionOf` became dead — both of its
guards still hold the under-count direction, which the revert proofs below check one at a time.

**On the general ordering rule, and #8366.** The reviewer's root reading is right: nothing in the
tail sorts, `upsertItem` appends unknown ids at the end and `rows.ts` renders raw array order. I
tried the general cut — a timestamp-ordered insert — and it is not merely broad, it is unsound as
written. A locally-recorded turn's timestamp is the desk's `Date.now()` and every other item's is
the backend's, so the two are not comparable, and ordering across that boundary breaks two invariants
this repo already pins: `core/machine.unit.test.ts`'s "keeps its position rather than moving to the
end of the tail" and `restore/restore-proof.unit.test.ts`'s resend ordering. A clock-free variant
(the echo moves to the tail) breaks the first of those too. So the ordering rule needs a real
ordering key and a decision about which clock owns it, which is its own piece of work — filed as
#8382. This PR's picker fix does not touch `upsertItem`, so it does not overlap #8366's
arrival-ordering lane at all.

Tests: `items.unit.test.ts` pins the boundary seed every way — nothing emitted through it, the turn
past it emitted with its usage, a replay when the boundary is missing, and a row that settled *under*
the boundary while the caller was away emitted with its cost.
`resumes-without-replay.unit.test.ts` covers eight arms: the six from round 4, plus criterion 5 in
both directions — a resume that adds no item leaves the totals where they were, and the worked
interrupted-restore case (tail `[user, assistant(complete, usage), tool(running)]` at phase
`prompting`, run through the real `restore` so the marker is the code's and not the test's) counts
that parked turn exactly once. `machine.unit.test.ts` pins the fold itself both ways, and
`restore/checkpoint.unit.test.ts` pins that a checkpoint written before the ledger still reads and
renders the same totals. Revert proofs: with `addUsage` summing again, the parked-turn pin reads
0.84 against 0.42 and the fold pin reds; with `projectionOf`'s usage seed removed, criterion 3's
"no usage" pin reds; the totals-unchanged pin reds when both go, which is the point — under either
guard alone the number stays right. The tuval unit subset over `src/ai-agent`, `src/pi` and
`src/claude` passes (805 tests), and `build check --surface code` is green.

## Deviations

- **Scope narrowing** — **Said:** criterion 8 names the seed cut. **Did:** took it, and left the
  `heldSnapshot` refusal arm untested. **Why:** the reviewer's own note — on the one live call path
  `attachSession` has already proved the snapshot defined, so the branch is unreachable and a test
  would pin a state the code cannot enter. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about existing tests. **Did:**
  rewrote every `agent.start({resume})` call site across nine test files to the `ResumeTarget` shape,
  and widened the two reconnect assertions in `ai-agent/restore/restore.unit.test.ts` and
  `claude/restore/claude-restore.unit.test.ts` to carry the held tail. Round 5 adds the same kind of
  widening for the ledger: the three `usageOf` window fixtures and the two checkpoint fixtures now
  build a keyed ledger, and every expected `usage` event carries its `turn`. **Why:** criterion 9
  changes the type every one of them constructs, and rounds 4 and 5 change what that type carries.
  **Disposition:** stated here — the assertions were widened to the new value, not loosened, and no
  assertion was removed.
- **Out-of-scope change** — **Said:** the round-4 finding names `projectionOf`'s seed in
  `pi/ai-agent/items.ts`. **Did:** also changed `ResumeTarget` in `ai-agent/service/TuvalAiAgent.ts`,
  the reconnect handler in `ai-agent/handlers/index.ts`, and moved `newestBackendItemId` into
  `ai-agent/ports/transcript-item.ts`. **Why:** the invariant is that a row may be suppressed only
  when the caller's copy matches the snapshot's, and the resume carried no copy for the layer to
  compare against — only an id. Carrying the tail is what makes the fix possible, and carrying it
  alongside the id would be two facts that can disagree. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the round-5 finding is a double-count on the pi resume path.
  **Did:** changed how cost accounting works for both backends — `UsageEvent` carries a `turn`, the
  state's `usage` field is a keyed ledger instead of a running sum, `AiAgentInspector` sums it on
  read, the checkpoint predicate reads the new shape, and Claude's two emit sites in
  `claude/history/map.ts` supply a turn id (the `result` message's uuid, and one reserved key for
  `init`'s zero-cost model announcement, which fires once per turn and would otherwise grow the
  ledger an empty entry per turn). **Why:** the founder ruled this shape over a fourth guard
  (https://github.com/kamp-us/phoenix/issues/8369#issuecomment-5563706105), and the fold is shared,
  so keying it means every layer names the turn its report is about. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the checkpoint. **Did:** added
  `withUsageLedger` to `ai-agent/core/snapshot.ts`, which reads a pre-ledger checkpoint's flat totals
  as a single reserved entry. **Why:** the ledger has to survive a checkpoint round trip or the
  interrupted-restore path cannot know the parked turn was counted, and without the migration an
  existing desk's saved session would fail the predicate and come back `gone` over a shape change.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left the tail unordered, so an item
  arriving out of order still lands at the end. **Why:** the two clocks are not comparable, so the
  rule needs a decision this PR should not make on its own. **Disposition:** filed as #8382.
- **Known defect left unfixed** — **Said:** the parked turn is counted once. **Did:** left one
  case where it is not — a session resuming from a checkpoint written *before* this change, whose
  flat total names no turn ids. That turn is absent from the migrated ledger, so its next report
  adds once more. **Why:** the old shape never held the ids, so no migration can recover them; it is
  one turn, once, on the first resume after this lands, and every turn after it keys normally.
  **Disposition:** stated here.

---

## Amendment — 2026-09-06

## Hand-verification (round 6 — evidence only, no behaviour changed)

Appended 2026-09-06. Nothing above this line was edited, and this round changed no code: it exists
because `review-ui` terminated CANT-SEE (`no-preview-render`) at head `2a82183`
(https://github.com/kamp-us/phoenix/pull/8375#issuecomment-5564129658) and the founder's interim
exception on #7306 wants a builder hand-verification the PR body did not carry. Every capture below
is a real browser load of this branch's code.

**How it was run.** The desk is `apps/tuval`'s own Pi vertical proof — the shipped shell, the
shipped `pi-session` row, over Pi's faux provider (`src/pi/proof/desk.ts`; no key, no model API). It
booted in this lane's worktree on its own port; the founder's desk on 5173 and its `.tuval` state
were not touched. Viewport 1280×900, headless chromium, dark by default.

### 1 — Fresh session: the totals accumulate from zero

Two turns complete, and the inspector reads what the keyed ledger sums to.

![Fresh Pi session, inspector open](https://github.com/user-attachments/assets/de6ff354-2d2b-441b-b72d-3f00f15f9707)

| Row | On screen | The ledger on disk |
|---|---|---|
| Cost | `$0.00` | two turns at `cost: 0` |
| Input tokens | `1,146` | `item-1: 1128` + `item-3: 18` |
| Output tokens | `18` | `item-1: 8` + `item-3: 10` |

The panel's numbers are exactly `usageTotals` over the two keyed turns the checkpoint holds. **The
`$0.00` is the faux provider, not a dropped cost** — it reports zero cost by design, so this capture
proves the token fold and says nothing about the money format. Capture 2 exercises that.

### 2 — A session restored from a pre-ledger checkpoint (the case the gate could not sign)

The checkpoint was written by hand in the old flat-`usage` shape, in this lane's own state dir, with
numbers chosen to be unmistakable and to exercise both formatters:

```json
"usage": {"model": "faux/faux-1", "inputTokens": 1234567, "outputTokens": 89012, "cost": 12.3456}
```

`withUsageLedger` folds that into one `spent-before-ledger` turn on load. What the desk renders:

![Restored from a pre-ledger checkpoint, PR head](https://github.com/user-attachments/assets/87f14dab-a6fd-40bf-ad62-f48dcfb900a5)

| Row | Rendered | Expected |
|---|---|---|
| Cost | `$12.3456` | `$12.3456` |
| Input tokens | `1,234,567` | `1,234,567` |
| Output tokens | `89,012` | `89,012` |

**All three match exactly.** The thousands separators are right, and the four-fraction-digit cost
survives the fold — a running sum would have shown the same number here, which is the point.

The checkpoint written back after that boot carries the migration verbatim:

```json
"usage": {"model": "faux/faux-1", "turns": {"spent-before-ledger": {"inputTokens": 1234567, "outputTokens": 89012, "cost": 12.3456}}}
```

### 3 — No pixels moved: the same checkpoint on `main` and on this head

Because capture 2's checkpoint is in the *old* shape, `main` reads it directly and this branch reads
it through the migration — so the same seeded bytes give a true before/after pair. `main` at
`e900eec`, same harness, same port, same viewport:

![Same checkpoint on main](https://github.com/user-attachments/assets/feaae23d-80c3-4429-be7c-b71b4075baf0)

The two PNGs are **byte-identical** — one sha256,
`4683aba37990b1c141073250d39a3f32d3bd000cf876bcced4e213e969a6f140`, 77,194 bytes each. Same five
rows, same order, same wrap, same values. That is the "no pixels moved" claim, measured rather than
argued.

### What I judged, including what I did not prove

- Zero uncaught page errors and zero console errors on all three loads.
- Composition is unchanged and reads correctly: five rows, label above value, muted label token over
  primary value token, the session id and path wrapping instead of truncating.
- **Not proven here:** the known defect this PR already states — a turn in flight when a pre-ledger
  checkpoint was written is absent from the migrated ledger and can be reported once more. A
  hand-written pre-ledger checkpoint names no turn ids by definition, so no seeded state can stage
  it; it stays a stated known defect, unchanged by this round.
- **Observation, pre-existing and not from this diff:** the value rows carry no
  `font-variant-numeric: tabular-nums`, and cost and token counts move on every usage event of a
  running turn, so the digits reflow while a turn streams. Identical on `main` — filed as
  https://github.com/kamp-us/phoenix/issues/8424 rather than fixed in an evidence-only round.
- **Observation, pre-existing and not from this diff:** the composer's thinking-level control reads
  `loading` in every capture, on `main` and on this head alike, under the faux provider. Filed as
  https://github.com/kamp-us/phoenix/issues/8425.
