### PR TITLE
chore: sweep claude-plugins/fabrika/skills/plan-epic and check-epic-plan of phoenix-bound references

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -52,10 +52,9 @@ lane's claim from yours.
 `--purpose gate` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
 should pick the issue up to **build**, and an epic earns that label only *after* it has been planned
 and gated — at step 3, from this very run — so fencing this gate on it is circular, and the fence
-binds build-purpose claims only.
-A `gate` claim is admitted without the label; the scope axis still binds, so an out-of-scope epic is still exit
-`20`. Never reach for `--override` to get past the audience axis — that is the fail-open convention
-the purpose exists to remove.
+binds build-purpose claims only. A `gate` claim is admitted without the label; the scope axis still
+binds, so an out-of-scope epic is still exit `20`. Never reach for `--override` to get past the
+audience axis — that is the fail-open convention the purpose exists to remove.
 
 Done when it answers `won`. Exit `15` is a proven loss with the winner named on stderr: end at
 `BACKED-OFF`. Exit `7` is a proven-absent or closed target: end at `PLAN-UNGATEABLE`. The verb takes
@@ -219,8 +218,8 @@ An unreleased claim is a lock nobody can reclaim, which a human then clears by h
   reading of this plan to relay. Say which of the two it was. Then release the claim with
   `fabrika build release $epic_number --token <claim-token>` before you end: this refusal lands ahead
   of everything, and an epic waiting on a founder must not also be waiting on a lock nobody can
-  reclaim. The epic goes back to the
-  founder — a re-plan is `plan-epic`'s, and a fresh approval is his.
+  reclaim. The epic goes back to the founder — a re-plan is `plan-epic`'s, and a fresh approval is
+  his.
 - `PLAN-MOVED` — `21`: the plan changed between the check and a writing verb. Nothing was written
   and no verdict is posted; re-check from step 2.
 - `FLIP-PARTIAL` — `22`: the floor was clean and something did not move — some children, or the

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -47,7 +47,7 @@ fabrika build claim $epic_number --purpose gate
 
 The token `claim` prints is `<claim-token>` below — this LANE's name, which every later verb takes as
 `--token`. A session runs several lanes, so a verb handed only the session id cannot tell a sibling
-lane's claim from yours (#6037).
+lane's claim from yours.
 
 `--purpose gate` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
 should pick the issue up to **build**, and an epic earns that label only *after* it has been planned
@@ -60,7 +60,7 @@ the purpose exists to remove.
 Done when it answers `won`. Exit `15` is a proven loss with the winner named on stderr: end at
 `BACKED-OFF`. Exit `7` is a proven-absent or closed target: end at `PLAN-UNGATEABLE`. The verb takes
 the session identity from the environment (`FABRIKA_SESSION_ID`, else `CLAUDE_CODE_SESSION_ID`, else
-`PI_SUBAGENT_PARENT_SESSION` — #6960), and an unset chain is exit `1` — a claim without
+`PI_SUBAGENT_PARENT_SESSION`), and an unset chain is exit `1` — a claim without
 an identity is not a claim. **Any other non-zero here (`1`, `8`, `9`, `10`, `11`, `20`) ends
 `STOPPED` with no note**: you hold no claim, and `build note` requires one, so there is nothing
 postable — report the code in the terminal line instead. `10` is an off-enum `--purpose`, and `20`
@@ -76,8 +76,7 @@ document a caller could hand it. Done when it prints the child set with each chi
 assignee slot, criteria token, stories and containment.
 
 **Then the approval precondition, ahead of the floor.** No plan reaches the gate without a founder
-approval bound to the scope it now derives (ADR
-[0289](../../../../.decisions/0289-founder-approves-every-epic-plan.md)):
+approval bound to the scope it now derives:
 
 ```bash
 fabrika plan approval $epic_number
@@ -220,7 +219,7 @@ An unreleased claim is a lock nobody can reclaim, which a human then clears by h
   reading of this plan to relay. Say which of the two it was. Then release the claim with
   `fabrika build release $epic_number --token <claim-token>` before you end: this refusal lands ahead
   of everything, and an epic waiting on a founder must not also be waiting on a lock nobody can
-  reclaim (ADR [0059](../../../../.decisions/0059-epic-plan-lock.md)). The epic goes back to the
+  reclaim. The epic goes back to the
   founder — a re-plan is `plan-epic`'s, and a fresh approval is his.
 - `PLAN-MOVED` — `21`: the plan changed between the check and a writing verb. Nothing was written
   and no verdict is posted; re-check from step 2.

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -9,20 +9,19 @@ excess-operand guard). The [CLI interface convention](../../docs/cli-interface-c
 governs every verb; where this spec and that doc disagree, the doc wins and this spec is the bug.
 
 **`fabrika` calls `pipeline-cli` nowhere, and neither does the skill** — a verb whose whole body
-relays another tool's answer is not a verb. The v1 machinery
-named below — under `packages/pipeline-cli/src/tools/`, `epic-ledger/`, `epic-lock/`,
-`scratchpad/`, and the `claude-plugins/kampus-pipeline/skills/review-plan/` scripts — is prior art
+relays another tool's answer is not a verb. The v1 machinery named below — under
+`packages/pipeline-cli/src/tools/`, `epic-ledger/`, `epic-lock/`, `scratchpad/`, and the
+`claude-plugins/kampus-pipeline/skills/review-plan/` scripts — is prior art
 **read** for semantics and scars; none is invoked, wrapped, or deferred to. Every v1 module name
 cited anywhere in this spec is **non-normative**: the behavior it informs is restated here in full,
 and an implementer needs none of those files to build these verbs.
 
 **The group name.** `plan` is this gate's, following the one-group-per-skill precedent (`build-ui`
-took `ui`, each reusing `build`'s verbs rather than sharing its group).
-The planner `plan-epic` takes
-its own group and may reuse these verbs the same way. **Nothing here allocates against the `epic`
-group.** (When this was written `epic` was an unimplemented spec; it later landed and was retired
-again with the epic conductor, so the conclusion outlived both — `plan` is this gate's, and nothing
-else answers its question.)
+took `ui`, each reusing `build`'s verbs rather than sharing its group). The planner `plan-epic`
+takes its own group and may reuse these verbs the same way. **Nothing here allocates against the
+`epic` group.** (When this was written `epic` was an unimplemented spec; it later landed and was
+retired again with the epic conductor, so the conclusion outlived both — `plan` is this gate's, and
+nothing else answers its question.)
 
 **What fabrika already ships, reused — never respecified.** The claim is the **`build` group's,
 reused as landed verbs** ([`build`'s contract](../build/contract.md)) — the cross-contract shape
@@ -81,13 +80,12 @@ as the sibling contracts do):
   exported `runConvergenceLoop` and registered it as no command at all — imported by nothing but
   its own unit test — so its stall test and its park were prose, not mechanism.
 - **A pickability predicate.** Whether child `#C` is *ready* (its dependency edges satisfied) is
-  `build`'s picker question, and still open there. This
-  gate makes children *eligible*; it computes no second answer to *pickable*. This is also why
-  `build`'s `16 BLOCKED` seat is unreachable here — blocked-ness reaches this gate only as the
-  dependency-shaped defects `DEP_CYCLE` / `DANGLING_DEP` / `UNENFORCED_DEP` / `ORPHAN_CHILD`, never
-  as a per-child readiness verdict. `UNENFORCED_DEP` reads the `blocked_by` graph and still is not
-  that verdict: it asks whether the graph *carries* the edge the plan states, never whether the
-  blocker behind it is closed.
+  `build`'s picker question, and still open there. This gate makes children *eligible*; it computes
+  no second answer to *pickable*. This is also why `build`'s `16 BLOCKED` seat is unreachable here —
+  blocked-ness reaches this gate only as the dependency-shaped defects `DEP_CYCLE` /
+  `DANGLING_DEP` / `UNENFORCED_DEP` / `ORPHAN_CHILD`, never as a per-child readiness verdict.
+  `UNENFORCED_DEP` reads the `blocked_by` graph and still is not that verdict: it asks whether the
+  graph *carries* the edge the plan states, never whether the blocker behind it is closed.
 - **An epic-body writer.** This gate never edits an issue body. The planner owns splicing, with its
   round-trip scars.
 - **A gate-was-never-run detector.** That question is lane-scoped; a verb here would answer for one
@@ -109,10 +107,10 @@ line takes nothing but the ability to comment on the epic, and the digest it mus
 check`'s stdout — so a read honouring the format alone would let any agent token approve a plan.
 Only a founder may approve a plan, so authority is sourced from the repository's own owner roster
 and never from the marker's format: `build clear`'s sibling read refuses the same shape for the same
-reason. A conforming marker from an
-off-roster account therefore reads `absent` and is counted in `unauthorized`, which keeps the state
-union closed at three. A roster nobody could read is `11`, never `absent` — an unread authority
-list is UNKNOWN, and collapsing it to "not approved" is the same fail-open shape in reverse.
+reason. A conforming marker from an off-roster account therefore reads `absent` and is counted in
+`unauthorized`, which keeps the state union closed at three. A roster nobody could read is `11`,
+never `absent` — an unread authority list is UNKNOWN, and collapsing it to "not approved" is the
+same fail-open shape in reverse.
 
 **The refusal is seated in the three verbs that re-derive the floor**, on `25` `PLAN_UNAPPROVED`.
 Each reads the epic's comments and resolves the roster itself, against the digest it has just
@@ -163,8 +161,8 @@ a story id no epic declared.
 
 **`**Containment:**` (child)** — the first such line outside a fence, with the same duplicate rule
 and the same `4`. Leading keyword only, from the set the repo's `containmentVocabulary` declares
-plus the reserved `none`. Anything unrecognised reads as unset,
-which `MISSING_CONTAINMENT` treats identically to `none`; only a declared value satisfies it.
+plus the reserved `none`. Anything unrecognised reads as unset, which `MISSING_CONTAINMENT` treats
+identically to `none`; only a declared value satisfies it.
 
 ## The floor — fourteen defect types
 
@@ -190,14 +188,11 @@ prose — the templates are the third column.
 | 13 | `UNVERIFIABLE_ASSIGNEE` | the child payload's `assignees` key was **not observed** — an unread field is UNKNOWN, never "unassigned is fine" | `the assignees field was not observed` |
 | 14 | `HELD_CHILD_UNASSIGNED` | a child carries `ready-for:human` and its observed assignee list is empty | `ready-for:human with an empty assignee slot` |
 
-**Grounded, and corrected against source.** The authoring brief
-named ten types; the live enum carries **fifteen names**, because the brief's list was copied from
-v1's `review-plan/SKILL.md` prose, which is stale (that file's own validator calls it "the closed
-7-type enum"). The five the brief omitted are `ZERO_SCOPE`, `UNENFORCED_DEP`,
-`MISSING_CONTAINMENT`, `UNVERIFIABLE_ASSIGNEE` and `HELD_CHILD_UNASSIGNED`. One of those five —
-`ZERO_SCOPE` — is seated here as exit `7` rather than a defect, so **fifteen names, fourteen
-defects**. Derive the enum
-from this table, never from a skill's prose.
+**Derive the enum from this table, never from a prose summary of it.** A summary drifts and this one
+has: v1's `review-plan/SKILL.md` still called this "the closed 7-type enum" after its own validator
+had outgrown the count. The live enum carries **fifteen names** and the table above lists
+**fourteen** — `ZERO_SCOPE` is the fifteenth, seated as exit `7` rather than as a defect, for the
+reason below.
 
 **Why `ZERO_SCOPE` is exit `7` and not defect zero.** v1 made a childless epic defect #1 and
 early-returned, so the ledger was never validated and the verdict reported exactly one thing wrong
@@ -336,19 +331,19 @@ read one meaning for it; `ship` importing `review`'s private band is the shipped
 obligation (interface convention rule 3), and the alignment this group opts into is checked
 **base-only, never pairwise** (`exit-code-alignment.ts`: `occupied = allocatedCodes(base)`).
 
-**The `20`/`21` overlap with `build` is settled.**
-This was written when `20`+ was free; the scope-admission fence has since taken `20` `OUT_OF_SCOPE`
-and `21` `AUDIENCE_NOT_AGENT`, both reachable from `fabrika build claim` — step 1 of this gate's
-skill. `21` is no longer among them: step 1 claims with `--purpose gate`, and the audience axis binds
-build-purpose claims only, so the only admission refusal this gate can meet is `20`. The
-overlap is therefore narrower than when it was settled, and it **stands**, on the same rule: *import
-a code when two groups prove the same fact; allocate freely when they do not.* `15` is imported because `plan flip` and
-`build claim` assert the identical fact (this session holds this issue's claim). `20`/`21` do not
-overlap in fact at all — lane admission is never something a `plan` verb proves, and a defective
-floor or a moved digest is never something a `build` verb proves — and an exit code is read off the
-command that produced it: [SKILL.md](SKILL.md) step 1 is total (`any other non-zero ends STOPPED`)
-and branches on `20`/`21` only off `plan flip` / `plan verdict`. Re-seating at `24`+ would also buy
-nothing, since `epic` already seats `20`–`24` over the same two `build` codes.
+**The `20`/`21` overlap with `build` is settled.** This was written when `20`+ was free; the
+scope-admission fence has since taken `20` `OUT_OF_SCOPE` and `21` `AUDIENCE_NOT_AGENT`, both
+reachable from `fabrika build claim` — step 1 of this gate's skill. `21` is no longer among them:
+step 1 claims with `--purpose gate`, and the audience axis binds build-purpose claims only, so the
+only admission refusal this gate can meet is `20`. The overlap is therefore narrower than when it
+was settled, and it **stands**, on the same rule: *import a code when two groups prove the same
+fact; allocate freely when they do not.* `15` is imported because `plan flip` and `build claim`
+assert the identical fact (this session holds this issue's claim). `20`/`21` do not overlap in fact
+at all — lane admission is never something a `plan` verb proves, and a defective floor or a moved
+digest is never something a `build` verb proves — and an exit code is read off the command that
+produced it: [SKILL.md](SKILL.md) step 1 is total (`any other non-zero ends STOPPED`) and branches
+on `20`/`21` only off `plan flip` / `plan verdict`. Re-seating at `24`+ would also buy nothing,
+since `epic` already seats `20`–`24` over the same two `build` codes.
 
 | Code | Meaning | `read` | `check` | `flip` | `verdict` | `approve` | `approval` |
 |---|---|---|---|---|---|---|---|
@@ -629,9 +624,8 @@ write, not an exemption.
 `children` covers **every** child of the epic, not only the planned ones, so the answer states the
 whole set the flip considered: `count` is that set's size, `results` tallies it by outcome. The rows
 themselves are gone — `children` is a bounded evidence array collapsed to a histogram, because this
-skill steers its
-reader to the counters and then bans any claim about what a child carries after the flip, so nothing
-ever read a row. `result` is closed and **total over that set**: `flipped` (the
+skill steers its reader to the counters and then bans any claim about what a child carries after the
+flip, so nothing ever read a row. `result` is closed and **total over that set**: `flipped` (the
 child carried `status:planned`, the labels moved, and the re-read proves it) · `already` (observed
 `status:triaged` with no `status:planned` — an idempotent no-op, outside the write scope) ·
 `unchanged` (the child carried `status:planned` and the write did not take) · `not-planned` (the
@@ -649,10 +643,10 @@ nothing on stdout, so the unchanged refs are named on **stderr** and the caller 
 There is deliberately no `unchanged` counter in the answer object: it could only ever be `0`.
 
 So `flipped-all` does **not** imply a child moved. Re-gating an epic planned before this verb owned
-the audience flip takes
-exactly that arm: every child already sits at `status:triaged`, only the epic's audience is owed, and
-the run prints `flipped-all` with `flipped: 0` and `audience.result: "flipped"`. A caller that wants
-to know whether any child became pickable reads `flipped`, never the token.
+the audience flip takes exactly that arm: every child already sits at `status:triaged`, only the
+epic's audience is owed, and the run prints `flipped-all` with `flipped: 0` and `audience.result:
+"flipped"`. A caller that wants to know whether any child became pickable reads `flipped`, never the
+token.
 
 **The flip is unconditional over every `status:planned` child** — ruled, with no per-child
 predicate and no opt-out hook. The barrier keeping a held child out of the build pool
@@ -661,13 +655,13 @@ is the assignee slot, which this verb never touches and `plan check` checks inst
 <a id="gate-owns-the-audience-flip"></a>
 **The epic's audience flip has exactly one owner, and it is this verb.** Under the single-PR
 model the operator picks the **epic** up, so the epic's own `ready-for:agent` decides whether the
-epic is pickable at all — and while nobody wrote it, planned-and-gated epics sat
-at `ready-for:human` and the operator could never pick one up. The other two candidates are both
-wrong for the same reason, that
-neither has proven a clean floor: the **planner** never flips, because an ungated plan would become
-pickable; the **operator** never flips, because it would be admitting itself. The gate re-derives the
-floor at the moment of writing, so the gate is the seat. It writes the epic **last**, after every
-child's re-read proves it moved, so an epic never becomes pickable over a half-flipped ledger.
+epic is pickable at all — and while nobody wrote it, planned-and-gated epics sat at
+`ready-for:human` and the operator could never pick one up. The other two candidates are both wrong
+for the same reason, that neither has proven a clean floor: the **planner** never flips, because an
+ungated plan would become pickable; the **operator** never flips, because it would be admitting
+itself. The gate re-derives the floor at the moment of writing, so the gate is the seat. It writes
+the epic **last**, after every child's re-read proves it moved, so an epic never becomes pickable
+over a half-flipped ledger.
 
 Order of operations, each guard designed against a named v1 failure:
 

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -1,6 +1,6 @@
 # `/check-epic-plan` — derived CLI contract
 
-**Skill:** [`check-epic-plan`](SKILL.md) · **Authoring brief:** [#4948](https://github.com/kamp-us/phoenix/issues/4948) · **Date:** 2026-08-09
+**Skill:** [`check-epic-plan`](SKILL.md) · **Date:** 2026-08-09
 
 The verbs land in `packages/fabrika-cli/` under the **`plan`** subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped groups, every leaf declared via
@@ -8,7 +8,8 @@ The verbs land in `packages/fabrika-cli/` under the **`plan`** subcommand group,
 excess-operand guard). The [CLI interface convention](../../docs/cli-interface-convention.md)
 governs every verb; where this spec and that doc disagree, the doc wins and this spec is the bug.
 
-**`fabrika` calls `pipeline-cli` nowhere, and neither does the skill** (ADR 0238). The v1 machinery
+**`fabrika` calls `pipeline-cli` nowhere, and neither does the skill** — a verb whose whole body
+relays another tool's answer is not a verb. The v1 machinery
 named below — under `packages/pipeline-cli/src/tools/`, `epic-ledger/`, `epic-lock/`,
 `scratchpad/`, and the `claude-plugins/kampus-pipeline/skills/review-plan/` scripts — is prior art
 **read** for semantics and scars; none is invoked, wrapped, or deferred to. Every v1 module name
@@ -17,12 +18,11 @@ and an implementer needs none of those files to build these verbs.
 
 **The group name.** `plan` is this gate's, following the one-group-per-skill precedent (`build-ui`
 took `ui`, each reusing `build`'s verbs rather than sharing its group).
-The planner `plan-epic` ([#4712](https://github.com/kamp-us/phoenix/issues/4712), unauthored) takes
+The planner `plan-epic` takes
 its own group and may reuse these verbs the same way. **Nothing here allocates against the `epic`
-group.** (When this was written `epic` was an unimplemented spec; it landed via
-[#5092](https://github.com/kamp-us/phoenix/issues/5092) and was retired again with the epic
-conductor, so the conclusion outlived both — `plan` is this gate's, and nothing else answers its
-question.)
+group.** (When this was written `epic` was an unimplemented spec; it later landed and was retired
+again with the epic conductor, so the conclusion outlived both — `plan` is this gate's, and nothing
+else answers its question.)
 
 **What fabrika already ships, reused — never respecified.** The claim is the **`build` group's,
 reused as landed verbs** ([`build`'s contract](../build/contract.md)) — the cross-contract shape
@@ -30,8 +30,7 @@ reused as landed verbs** ([`build`'s contract](../build/contract.md)) — the cr
 it with `fabrika build release`, and posts a successor note with `fabrika build note`. The purpose is
 part of the reuse, not a detail of it: `build claim`'s audience axis asks whether an agent should
 pick the issue up to *build*, and an epic earns `ready-for:agent` only after it has been planned and
-gated, so a `gate` claim is admitted without it (founder ruling,
-[#5175](https://github.com/kamp-us/phoenix/issues/5175)). The scope axis is unchanged by the purpose,
+gated, so a `gate` claim is admitted without it. The scope axis is unchanged by the purpose,
 and `--override` stays the exception it was — it now has to name its lane as well as its reason.
 **No second lock is
 derived**, and v1's `epic-lock` is why: its `acquire` short-circuits on a held label *before* any
@@ -76,13 +75,13 @@ A restatement of any of these would be a transcription, and a transcription drif
 convention rule 6; conventions §7 homes these in `.out-of-scope/`, unbootstrapped — tracked inline
 as the sibling contracts do):
 
-- **A planning lock.** The claim is `build claim` on the epic number. A second mutex would be the
-  wrapper-verb shape ADR 0238 bans.
+- **A planning lock.** The claim is `build claim` on the epic number. A second mutex would be a
+  wrapper verb whose whole body relays another verb's answer.
 - **A re-plan convergence loop.** The defective path is terminal and hands back to `plan-epic`. v1
   exported `runConvergenceLoop` and registered it as no command at all — imported by nothing but
   its own unit test — so its stall test and its park were prose, not mechanism.
 - **A pickability predicate.** Whether child `#C` is *ready* (its dependency edges satisfied) is
-  `build`'s picker question, open on [#4920](https://github.com/kamp-us/phoenix/issues/4920). This
+  `build`'s picker question, and still open there. This
   gate makes children *eligible*; it computes no second answer to *pickable*. This is also why
   `build`'s `16 BLOCKED` seat is unreachable here — blocked-ness reaches this gate only as the
   dependency-shaped defects `DEP_CYCLE` / `DANGLING_DEP` / `UNENFORCED_DEP` / `ORPHAN_CHILD`, never
@@ -90,10 +89,9 @@ as the sibling contracts do):
   that verdict: it asks whether the graph *carries* the edge the plan states, never whether the
   blocker behind it is closed.
 - **An epic-body writer.** This gate never edits an issue body. The planner owns splicing, with its
-  round-trip scars ([#4879](https://github.com/kamp-us/phoenix/issues/4879)).
-- **A gate-was-never-run detector.** [#4104](https://github.com/kamp-us/phoenix/issues/4104) is
-  open and lane-scoped; a verb here would answer for one epic the question the lane asks across
-  all of them.
+  round-trip scars.
+- **A gate-was-never-run detector.** That question is lane-scoped; a verb here would answer for one
+  epic the question the lane asks across all of them.
 
 ## Verb inventory
 
@@ -108,14 +106,13 @@ as the sibling contracts do):
 
 **The author gate is in the read, not only in `plan approve`'s write.** Posting a `plan-approved:`
 line takes nothing but the ability to comment on the epic, and the digest it must carry is on `plan
-check`'s stdout — so a read honouring the format alone would let any agent token approve a plan. ADR
-[0289](../../../../.decisions/0289-founder-approves-every-epic-plan.md) forbids that outright, and
-`build clear`'s sibling read refuses the same shape under ADR
-[0055](../../../../.decisions/0055-acl-sourced-review-authz.md) over
-[0051](../../../../.decisions/0051-author-bind-pass-marker.md). A conforming marker from an
+check`'s stdout — so a read honouring the format alone would let any agent token approve a plan.
+Only a founder may approve a plan, so authority is sourced from the repository's own owner roster
+and never from the marker's format: `build clear`'s sibling read refuses the same shape for the same
+reason. A conforming marker from an
 off-roster account therefore reads `absent` and is counted in `unauthorized`, which keeps the state
-union closed at three. A roster nobody could read is `11`, never `absent` — the #4223 collapse, on
-this side too.
+union closed at three. A roster nobody could read is `11`, never `absent` — an unread authority
+list is UNKNOWN, and collapsing it to "not approved" is the same fail-open shape in reverse.
 
 **The refusal is seated in the three verbs that re-derive the floor**, on `25` `PLAN_UNAPPROVED`.
 Each reads the epic's comments and resolves the roster itself, against the digest it has just
@@ -146,7 +143,7 @@ no fence awareness anywhere, so a documentation example inside a fence set a rea
 (`Found` / `Absent` / `Malformed`) are carried as tokens and never flattened.
 
 **`## Dependencies`** — read through the imported `readTopology`. An **edge is ordered
-`[dependent, prerequisite]`**: `["#4302","#4301"]` reads *#4302 requires #4301*.
+`[dependent, prerequisite]`**: `["#5","#4"]` reads *#5 requires #4*.
 
 **`### User stories` (epic)** — an ordered list; each item's leading integer is the story id. A
 list with at least one item must be **contiguous from 1 with no duplicates**; a gap or a repeat is
@@ -161,11 +158,12 @@ meaning. Its value must match `none` or a comma-separated list of bare integers
 (`^(none|\d+(\s*,\s*\d+)*)$` after trimming). `none` reads as the empty list; a conforming list
 reads as those ids; **no line at all reads as absent** (which is what `MISSING_STORY` tests); a
 **non-conforming value reads as absent and is reported in `detail`**. v1 harvested every bare
-integer anywhere in the value, so `**Stories:** 1, 3 (see #4021)` silently claimed story 4021.
+integer anywhere in the value, so a line carrying a parenthetical ticket reference silently claimed
+a story id no epic declared.
 
 **`**Containment:**` (child)** — the first such line outside a fence, with the same duplicate rule
 and the same `4`. Leading keyword only, from the set the repo's `containmentVocabulary` declares
-plus the reserved `none` (phoenix declares `flag` · `exempt`). Anything unrecognised reads as unset,
+plus the reserved `none`. Anything unrecognised reads as unset,
 which `MISSING_CONTAINMENT` treats identically to `none`; only a declared value satisfies it.
 
 ## The floor — fourteen defect types
@@ -192,10 +190,10 @@ prose — the templates are the third column.
 | 13 | `UNVERIFIABLE_ASSIGNEE` | the child payload's `assignees` key was **not observed** — an unread field is UNKNOWN, never "unassigned is fine" | `the assignees field was not observed` |
 | 14 | `HELD_CHILD_UNASSIGNED` | a child carries `ready-for:human` and its observed assignee list is empty | `ready-for:human with an empty assignee slot` |
 
-**Grounded, and corrected against source.** [Brief #4948](https://github.com/kamp-us/phoenix/issues/4948)
-names ten types; the live enum carries **fifteen names**, because the brief's list was copied from
+**Grounded, and corrected against source.** The authoring brief
+named ten types; the live enum carries **fifteen names**, because the brief's list was copied from
 v1's `review-plan/SKILL.md` prose, which is stale (that file's own validator calls it "the closed
-7-type enum"). The five the brief omits are `ZERO_SCOPE`, `UNENFORCED_DEP`,
+7-type enum"). The five the brief omitted are `ZERO_SCOPE`, `UNENFORCED_DEP`,
 `MISSING_CONTAINMENT`, `UNVERIFIABLE_ASSIGNEE` and `HELD_CHILD_UNASSIGNED`. One of those five —
 `ZERO_SCOPE` — is seated here as exit `7` rather than a defect, so **fifteen names, fourteen
 defects**. Derive the enum
@@ -204,19 +202,17 @@ from this table, never from a skill's prose.
 **Why `ZERO_SCOPE` is exit `7` and not defect zero.** v1 made a childless epic defect #1 and
 early-returned, so the ledger was never validated and the verdict reported exactly one thing wrong
 about a plan it had not read. A refused scope is not a defect list of length one: `plan check`
-refuses on `7`, derives nothing, and says so (ADR 0092).
+refuses on `7`, derives nothing, and says so — a guard over zero scope fails closed.
 
 **`p3` is not admitted.** The priority set is exactly `{p0, p1, p2}`; `p3` was ruled *retired*, not
-widened ([#4101](https://github.com/kamp-us/phoenix/issues/4101),
-[#2413](https://github.com/kamp-us/phoenix/issues/2413)).
+widened.
 
 **The two barrier defects are conservative by ruling, and their legacy cost is stated.** A
 pre-existing `ready-for:human` child with an empty assignee slot fails the floor, and one such
-child blocks the flip for every sibling. Back-fill versus grandfather is **unruled**
-([#5026](https://github.com/kamp-us/phoenix/issues/5026)); this contract takes the refusing arm
-because the permissive arm would flip a held child into the build pool, which is the exact outcome
-the barrier exists to prevent ([#4637-C](https://github.com/kamp-us/phoenix/issues/4637)). The seam
-a ruling lands at is this table's row 14.
+child blocks the flip for every sibling. Back-fill versus grandfather is **unruled**; this contract
+takes the refusing arm because the permissive arm would flip a held child into the build pool,
+which is the exact outcome the barrier exists to prevent. The seam a ruling lands at is this
+table's row 14.
 
 **When a class cannot be derived, it is named, never dropped.** `MISSING_CONTAINMENT` rests on a
 probe for the **declared** cycle doc (`cycleDoc`, whose shipped value here is
@@ -257,7 +253,7 @@ the gap between deciding and writing is closed by re-deciding against a value th
 not by trusting a cached decision. It is the same shape `build verdicts` uses when it re-reads a
 gate's marker against the PR's live head rather than against the head the marker claimed.
 
-**The two additive edits to `verdict-marker.ts` this gate needs landed in #5107**, recorded here
+**The two additive edits to `verdict-marker.ts` this gate needs are landed**, recorded here
 because the second one is easy to miss and stays load-bearing:
 
 1. `NAMESPACE` is `/^(review|check-epic-plan)(-[a-z0-9]+)*$/`, widened from the `review`-only class.
@@ -273,7 +269,7 @@ The module's two diagnostic strings widened with them and already speak the plan
 Both code edits were additive: no existing marker's reading changed, and the
 `Absent`-versus-`Malformed` discrimination the module exists to protect is untouched. The plan gate keeps its **own**
 namespace and **never** reuses `review` — a plan verdict wearing a review namespace is precisely the
-family confusion the partition ruling removed (#4891).
+family confusion the namespace partition removed.
 
 `Current` / `Stale` / `Unbindable` are what a **later reader** of the posted marker resolves
 through `bindToHead`; they are not this run's arms. This run's own drift check is the `--digest`
@@ -308,7 +304,7 @@ Every `plan` verb obeys these; stated once.
   `$CLAUDE_PIPELINE_REPO`, `$GITHUB_REPOSITORY`, then the `origin` remote) on every verb. That
   variable name is **inherited from the shipped `io/issues.ts`**, not minted here; renaming it to a
   `FABRIKA_*` name is a package-wide change tracked outside this contract. GitHub access per
-  [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql),
+  [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md),
   paginated in full.
 - **Bounded fan-out.** Child reads and child writes run at concurrency **8**, never `"unbounded"`.
   v1 issued one `gh api` per child unbounded, so a sixty-child epic spawned sixty concurrent
@@ -340,11 +336,11 @@ read one meaning for it; `ship` importing `review`'s private band is the shipped
 obligation (interface convention rule 3), and the alignment this group opts into is checked
 **base-only, never pairwise** (`exit-code-alignment.ts`: `occupied = allocatedCodes(base)`).
 
-**The `20`/`21` overlap with `build`, settled ([#5107](https://github.com/kamp-us/phoenix/issues/5107)).**
+**The `20`/`21` overlap with `build` is settled.**
 This was written when `20`+ was free; the scope-admission fence has since taken `20` `OUT_OF_SCOPE`
 and `21` `AUDIENCE_NOT_AGENT`, both reachable from `fabrika build claim` — step 1 of this gate's
 skill. `21` is no longer among them: step 1 claims with `--purpose gate`, and the audience axis binds
-build-purpose claims only (#5175), so the only admission refusal this gate can meet is `20`. The
+build-purpose claims only, so the only admission refusal this gate can meet is `20`. The
 overlap is therefore narrower than when it was settled, and it **stands**, on the same rule: *import
 a code when two groups prove the same fact; allocate freely when they do not.* `15` is imported because `plan flip` and
 `build claim` assert the identical fact (this session holds this issue's claim). `20`/`21` do not
@@ -373,7 +369,7 @@ nothing, since `epic` already seats `20`–`24` over the same two `build` codes.
 | `21` | proven: the plan moved — the recomputed digest differs from the `--digest` the caller carried | — | — | ✓ | ✓ | — | — |
 | `22` | proven: at least one child is `unchanged` — the flip did not fully apply; the observed set is on stderr | — | — | ✓ | — | — | — |
 | `23` | proven: a label the flip must write is absent from the repository's taxonomy | — | — | ✓ | — | — | — |
-| `24` | proven: the invoking account may not approve this epic's plan — it is outside the `@kamp-us/control-plane` roster resolved from CODEOWNERS at write time, or that roster names nobody | — | — | — | — | ✓ | — |
+| `24` | proven: the invoking account may not approve this epic's plan — it is outside the control-plane roster resolved from CODEOWNERS at write time, or that roster names nobody | — | — | — | — | ✓ | — |
 | `25` | proven: the plan is not approved as it now stands — the epic carries no standing approval marker, or the marker's digest names a plan the epic has since moved off | — | ✓ | ✓ | ✓ | — | — |
 | `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
@@ -399,7 +395,7 @@ happen).
 **Invocation**
 
 ```
-fabrika plan read 4300 [--repo <owner/name>]
+fabrika plan read 3 [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -412,13 +408,13 @@ fabrika plan read 4300 [--repo <owner/name>]
 **Output** — machine. One JSON object:
 
 ```
-{"answer": "read", "epic": 4300, "children": [
-   {"number": 4301, "labels": ["p1","status:planned","type:feature"], "assignees": ["rmoreno"], "assigneesObserved": true,
+{"answer": "read", "epic": 3, "children": [
+   {"number": 4, "labels": ["p1","status:planned","type:feature"], "assignees": ["rmoreno"], "assigneesObserved": true,
     "criteria": "found", "criteriaCount": 3, "stories": [1,2], "containment": "flag"},
-   {"number": 4302, "labels": ["p2","status:planned","type:chore"], "assignees": null, "assigneesObserved": false,
+   {"number": 5, "labels": ["p2","status:planned","type:chore"], "assignees": null, "assigneesObserved": false,
     "criteria": "malformed", "criteriaCount": 0, "stories": null, "containment": null}],
  "epicStories": [1,2], "cycleDoc": "present",
- "topology": {"phases": [["#4301"],["#4302"]], "edges": [["#4302","#4301"]]},
+ "topology": {"phases": [["#4"],["#5"]], "edges": [["#5","#4"]]},
  "digest": "4d90e1bb27ac"}
 ```
 
@@ -468,25 +464,25 @@ children is `7`, never an empty answer.
 **Examples**
 
 ```
-$ fabrika plan read 4300
-{"answer":"read","epic":4300,"children":[{"number":4301,"labels":["p1","status:planned","type:feature"],"assignees":["rmoreno"],"assigneesObserved":true,"criteria":"found","criteriaCount":3,"stories":[1,2],"containment":"flag"}],"epicStories":[1,2],"cycleDoc":"present","topology":{"phases":[["#4301"]],"edges":[]},"digest":"4d90e1bb27ac"}
+$ fabrika plan read 3
+{"answer":"read","epic":3,"children":[{"number":4,"labels":["p1","status:planned","type:feature"],"assignees":["rmoreno"],"assigneesObserved":true,"criteria":"found","criteriaCount":3,"stories":[1,2],"containment":"flag"}],"epicStories":[1,2],"cycleDoc":"present","topology":{"phases":[["#4"]],"edges":[]},"digest":"4d90e1bb27ac"}
 ```
 
 ```
-$ fabrika plan read 4300
-plan read: #4300 has zero sub-issue children — there is no ledger to read (ADR 0092).
+$ fabrika plan read 3
+plan read: #3 has zero sub-issue children — there is no ledger to read (ADR 0092).
 $ echo $?
 7
 ```
 
 **Grounding**
 
-- ADR 0092 — zero scope reds; an empty child set is a refusal, not a clean read.
+- Zero scope reds; an empty child set is a refusal, not a clean read.
 - v1 scar (`markdown.ts`): heading sections were first-match-wins with no fence awareness, story
   ids were list positions, and a `Stories:` value donated every bare integer it contained. §The
   ledger grammar refuses all three.
 - v1 scar (`github.ts`): `is404` matched `gh` stderr text; this verb branches on HTTP status.
-- The three-state assignee slot is #4693's landed shape — unread is UNKNOWN, never permissive.
+- The three-state assignee slot: unread is UNKNOWN, never permissive.
 
 ---
 
@@ -495,7 +491,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika plan check 4300 [--repo <owner/name>]
+fabrika plan check 3 [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -512,19 +508,19 @@ everything — a plan with defects is `defective` however many classes were skip
 Clean:
 
 ```
-{"answer": "clean", "epic": 4300, "scanned": [4301,4302], "digest": "4d90e1bb27ac", "skipped": [], "defects": []}
+{"answer": "clean", "epic": 3, "scanned": [4,5], "digest": "4d90e1bb27ac", "skipped": [], "defects": []}
 ```
 
 Clean with a class that could not be derived:
 
 ```
-{"answer": "clean", "epic": 4300, "scanned": [4301,4302], "digest": "7b2e09c4a18f", "skipped": ["MISSING_CONTAINMENT"], "defects": []}
+{"answer": "clean", "epic": 3, "scanned": [4,5], "digest": "7b2e09c4a18f", "skipped": ["MISSING_CONTAINMENT"], "defects": []}
 ```
 
 Defective:
 
 ```
-{"answer": "defective", "epic": 4300, "scanned": [4301,4302], "digest": "81c7a30f5e42", "skipped": [], "defects": [{"type":"ZERO_AC","refs":[4302],"detail":"acceptance criteria read as malformed"}]}
+{"answer": "defective", "epic": 3, "scanned": [4,5], "digest": "81c7a30f5e42", "skipped": [], "defects": [{"type":"ZERO_AC","refs":[5],"detail":"acceptance criteria read as malformed"}]}
 ```
 
 `skipped` names any defect class **not derived** and therefore not asked — today only
@@ -571,15 +567,15 @@ error, which is why it is not in the table above.
 **Examples**
 
 ```
-$ fabrika plan check 4300
-{"answer":"clean","epic":4300,"scanned":[4301,4302],"digest":"4d90e1bb27ac","skipped":[],"defects":[]}
+$ fabrika plan check 3
+{"answer":"clean","epic":3,"scanned":[4,5],"digest":"4d90e1bb27ac","skipped":[],"defects":[]}
 $ echo $?
 0
 ```
 
 ```
-$ fabrika plan check 4300
-{"answer":"defective","epic":4300,"scanned":[4301,4302],"digest":"81c7a30f5e42","skipped":[],"defects":[{"type":"HELD_CHILD_UNASSIGNED","refs":[4302],"detail":"ready-for:human with an empty assignee slot"}]}
+$ fabrika plan check 3
+{"answer":"defective","epic":3,"scanned":[4,5],"digest":"81c7a30f5e42","skipped":[],"defects":[{"type":"HELD_CHILD_UNASSIGNED","refs":[5],"detail":"ready-for:human with an empty assignee slot"}]}
 $ echo $?
 0
 ```
@@ -590,10 +586,9 @@ $ echo $?
   destructive verb re-derives the floor rather than reading an exit code.
 - v1's gate exited `0` on FAIL *and* printed only a `✓`/`✗` glyph, so a shell caller proceeded on a
   failure. The machine channel plus `plan flip`'s own `20` refusal is that hole closed.
-- ADR 0047 D2 / #4894 — this verb is the *whole* pass/fail decision; the advisory layer above it
-  cannot change the answer.
-- ADR 0092 — zero scope reds, and the scanned set is stated on both arms.
-- #4101 / #2413 — the priority set is `{p0,p1,p2}`; `p3` is retired, not admitted.
+- This verb is the *whole* pass/fail decision; the advisory layer above it cannot change the answer.
+- Zero scope reds, and the scanned set is stated on both arms.
+- The priority set is `{p0,p1,p2}`; `p3` is retired, not admitted.
 
 ---
 
@@ -602,7 +597,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
+fabrika plan flip 3 --digest 4d90e1bb27ac --token <claim-token>
 ```
 
 **Inputs**
@@ -611,14 +606,14 @@ fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose planned children are flipped, and whose own audience label is flipped with them |
 | `--digest` | string, 12 lowercase hex | yes | — | the scope digest `plan check` printed; the flip refuses if the plan has moved since |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose gate` printed — which lane is asking (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose gate` printed — which lane is asking |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
 **Output** — machine. The **observed** results over the children and for the epic, never the
 intended ones:
 
 ```
-{"answer": "flipped", "epic": 4300, "digest": "4d90e1bb27ac", "terminal": "flipped-all",
+{"answer": "flipped", "epic": 3, "digest": "4d90e1bb27ac", "terminal": "flipped-all",
  "children": {"count": 2, "results": {"already": 1, "flipped": 1}},
  "flipped": 1, "already": 1,
  "audience": {"result": "flipped", "observed": ["ready-for:agent","type:epic"]}}
@@ -633,8 +628,8 @@ write, not an exemption.
 
 `children` covers **every** child of the epic, not only the planned ones, so the answer states the
 whole set the flip considered: `count` is that set's size, `results` tallies it by outcome. The rows
-themselves are gone — `children` is an evidence-array collapsed to a histogram under ADR
-[0308](../../../../.decisions/0308-bounded-evidence-output-shape.md), because this skill steers its
+themselves are gone — `children` is a bounded evidence array collapsed to a histogram, because this
+skill steers its
 reader to the counters and then bans any claim about what a child carries after the flip, so nothing
 ever read a row. `result` is closed and **total over that set**: `flipped` (the
 child carried `status:planned`, the labels moved, and the re-read proves it) · `already` (observed
@@ -653,20 +648,22 @@ flip has no token here at all — any `unchanged` child forces exit `22`, and a 
 nothing on stdout, so the unchanged refs are named on **stderr** and the caller reads them there.
 There is deliberately no `unchanged` counter in the answer object: it could only ever be `0`.
 
-So `flipped-all` does **not** imply a child moved. Re-gating an epic planned before #5832 takes
+So `flipped-all` does **not** imply a child moved. Re-gating an epic planned before this verb owned
+the audience flip takes
 exactly that arm: every child already sits at `status:triaged`, only the epic's audience is owed, and
 the run prints `flipped-all` with `flipped: 0` and `audience.result: "flipped"`. A caller that wants
 to know whether any child became pickable reads `flipped`, never the token.
 
 **The flip is unconditional over every `status:planned` child** — ruled, with no per-child
-predicate and no opt-out hook (#4693 AC4). The barrier keeping a held child out of the build pool
+predicate and no opt-out hook. The barrier keeping a held child out of the build pool
 is the assignee slot, which this verb never touches and `plan check` checks instead.
 
 <a id="gate-owns-the-audience-flip"></a>
-**The epic's audience flip has exactly one owner, and it is this verb** (#5832). Under the single-PR
+**The epic's audience flip has exactly one owner, and it is this verb.** Under the single-PR
 model the operator picks the **epic** up, so the epic's own `ready-for:agent` decides whether the
-epic is pickable at all — and before #5832 nobody wrote it, leaving planned-and-gated epics sitting
-at `ready-for:human` (#5680). The other two candidates are both wrong for the same reason, that
+epic is pickable at all — and while nobody wrote it, planned-and-gated epics sat
+at `ready-for:human` and the operator could never pick one up. The other two candidates are both
+wrong for the same reason, that
 neither has proven a clean floor: the **planner** never flips, because an ungated plan would become
 pickable; the **operator** never flips, because it would be admitting itself. The gate re-derives the
 floor at the moment of writing, so the gate is the seat. It writes the epic **last**, after every
@@ -680,7 +677,7 @@ Order of operations, each guard designed against a named v1 failure:
 2. **Vocabulary precondition.** Confirm every label this run would **POST** exists in the
    repository's label list: `status:triaged` and `status:planned` when there is at least one
    `status:planned` child, and `ready-for:agent` when the epic is owed it. `POST .../labels`
-   **creates** an unknown label rather than rejecting it (#4285), so an absent label would be
+   **creates** an unknown label rather than rejecting it, so an absent label would be
    silently minted; refuse on `23` instead. Only posted labels are guarded — a `DELETE` of a label
    the repository never defined removes nothing and mints nothing. With nothing to write the check is
    skipped entirely — a `nothing-to-flip` success must not refuse over a label it was never going to
@@ -753,28 +750,28 @@ succeeded — and with the epic still owed its label, that one write is the whol
 **Examples**
 
 ```
-$ fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
-{"answer":"flipped","epic":4300,"digest":"4d90e1bb27ac","terminal":"flipped-all","children":{"count":1,"results":{"flipped":1}},"flipped":1,"already":0,"audience":{"result":"flipped","observed":["ready-for:agent","type:epic"]}}
+$ fabrika plan flip 3 --digest 4d90e1bb27ac --token <claim-token>
+{"answer":"flipped","epic":3,"digest":"4d90e1bb27ac","terminal":"flipped-all","children":{"count":1,"results":{"flipped":1}},"flipped":1,"already":0,"audience":{"result":"flipped","observed":["ready-for:agent","type:epic"]}}
 ```
 
 ```
-$ fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
-plan flip: 2 of 3 children flipped; 1 unchanged (#4303) — the epic is half-flipped and needs a human.
+$ fabrika plan flip 3 --digest 4d90e1bb27ac --token <claim-token>
+plan flip: 2 of 3 children flipped; 1 unchanged (#6) — the epic is half-flipped and needs a human.
 $ echo $?
 22
 ```
 
 **Grounding**
 
-- #4693 AC4 — the flip stays unconditional; a per-child exception hook is the escape hatch the gate
+- The flip stays unconditional; a per-child exception hook is the escape hatch the gate
   deliberately lacks.
 - v1 scars: unbounded `Effect.forEach` aborting on the first failure, a two-call flip leaving both
   labels, the PASS comment posted only after every write so a partial flip posted nothing, and
   `discard: true` erasing the per-child record. Steps 3 and 4 answer all four.
-- #4285 — `POST .../labels` creates unknown labels; the vocabulary check is a precondition.
-- #5832 / #5680 — the gate owns the epic's audience flip; before it, a planned-and-gated epic sat at
+- `POST .../labels` creates unknown labels; the vocabulary check is a precondition.
+- The gate owns the epic's audience flip; before it, a planned-and-gated epic sat at
   `ready-for:human` and the operator could never pick it up.
-- ADR 0058's shape — the re-gate is a relation checked at write time, not a cached decision.
+- The re-gate is a relation checked at write time, not a cached decision.
 
 ---
 
@@ -783,8 +780,8 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika plan verdict 4300 --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
-caveat: ac-not-checkable #4302 — "works well" states no observable outcome
+fabrika plan verdict 3 --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
+caveat: ac-not-checkable #5 — "works well" states no observable outcome
 EOF
 ```
 
@@ -795,12 +792,12 @@ EOF
 | `<number>` | positional integer | yes | — | the epic the verdict is posted on |
 | `--digest` | string, 12 lowercase hex | yes | — | the scope digest `plan check` printed; the verdict binds it and refuses if the plan has moved |
 | `--polarity` | enum: `PASS` \| `FAIL` | no | derived from the floor | an optional cross-check — when supplied and it disagrees with the floor this verb derives, the verb refuses on `10` rather than posting either. No step in [SKILL.md](SKILL.md) supplies it; it exists for an operator driving the verb by hand, and its absence from the skill is deliberate, not a missing step |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose gate` printed — which lane is asking (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose gate` printed — which lane is asking |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 | stdin | markdown | no | empty | advisory caveats, one per line, each `caveat: <kind> #<ref> — <text>`; empty is an ordinary answer |
 
 **Output** — machine.
-`{"answer": "posted", "epic": 4300, "polarity": "PASS", "digest": "4d90e1bb27ac", "skipped": [], "comment": 5230661234, "caveats": 1}`
+`{"answer": "posted", "epic": 3, "polarity": "PASS", "digest": "4d90e1bb27ac", "skipped": [], "comment": 5230661234, "caveats": 1}`
 
 **This verb derives its own polarity by re-running the floor**, for the same reason `plan check`
 re-fetches: a caller-supplied verdict would let the caller grade the document. `PASS` is the floor's
@@ -820,8 +817,8 @@ Below the marker the verb renders the scanned set, the derived defect list on a 
 
 **Caveat kinds are a closed set** — `ac-not-checkable` · `brief-fidelity` · `slice-too-broad` ·
 `dependency-implied-not-declared`. An off-set kind refuses on `10`. Caveats are **advisory**: they
-are recorded beside the verdict and the verb has no path by which a caveat changes the polarity
-(ADR 0047 D2). The caveat's trailing text is model-authored free prose, which is a deliberate,
+are recorded beside the verdict and the verb has no code path by which a caveat changes the
+polarity. The caveat's trailing text is model-authored free prose, which is a deliberate,
 bounded exception to the closed-vocabulary rule: the *kind* is closed, the tail is advisory, and
 **no verb reads a caveat back as input** — it is a note for a human, never a signal a lane consumes.
 
@@ -884,15 +881,15 @@ Zero children is `7`.
 **Examples**
 
 ```
-$ fabrika plan verdict 4300 --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
-caveat: ac-not-checkable #4302 — "works well" states no observable outcome
+$ fabrika plan verdict 3 --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
+caveat: ac-not-checkable #5 — "works well" states no observable outcome
 EOF
-{"answer":"posted","epic":4300,"polarity":"PASS","digest":"4d90e1bb27ac","skipped":[],"comment":5230661234,"caveats":1}
+{"answer":"posted","epic":3,"polarity":"PASS","digest":"4d90e1bb27ac","skipped":[],"comment":5230661234,"caveats":1}
 ```
 
 ```
-$ fabrika plan verdict 4300 --digest 81c7a30f5e42 --token <claim-token> <<'EOF'
-caveat: vibes #4302 — feels thin
+$ fabrika plan verdict 3 --digest 81c7a30f5e42 --token <claim-token> <<'EOF'
+caveat: vibes #5 — feels thin
 EOF
 plan verdict: caveat kind "vibes" is not in the closed set (ac-not-checkable, brief-fidelity, slice-too-broad, dependency-implied-not-declared).
 $ echo $?
@@ -901,11 +898,11 @@ $ echo $?
 
 **Grounding**
 
-- #5096 — an unmarked verdict is invisible to any drift check; the marker plus the scope digest is
+- An unmarked verdict is invisible to any drift check; the marker plus the scope digest is
   what makes gate state checkable by a later reader.
-- ADR 0058 via `bindToHead` — a later reader resolves `Current` / `Stale` / `Unbindable` against
+- `bindToHead` — a later reader resolves `Current` / `Stale` / `Unbindable` against
   the posted marker; `Unbindable` never renders as `Current`.
-- ADR 0047 D2 — caveats annotate, never block; there is no code path from a caveat to a polarity.
+- Caveats annotate, never block; there is no code path from a caveat to a polarity.
 - `report/leaks.ts` — the caveat text is model-authored prose reaching a public surface, which is
   the seat `5` / `6` exist for.
 - v1 hand-posted a gate verdict at least once and it read as genuine; the single emit path plus the

--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -266,10 +266,9 @@ that number is what you report. Do not re-mint it.
 `**Containment:**` is emitted only when the run's `cycleDoc` read is `present` — `ledger child`
 takes that from the run directory, so you neither pass it nor remember it. Which keywords are legal
 is the repo's `containmentVocabulary` (`fabrika status settings` prints the types it asks and the
-values it accepts), plus the reserved `none`, which declines. A
-trailing parenthetical is yours to write and is preserved. **On a child of an asked type only a
-legal value will do** — the gate reds `none` and unset alike, so `ledger child` refuses both rather
-than letting you author a defect.
+values it accepts), plus the reserved `none`, which declines. A trailing parenthetical is yours to
+write and is preserved. **On a child of an asked type only a legal value will do** — the gate reds
+`none` and unset alike, so `ledger child` refuses both rather than letting you author a defect.
 
 `**Stories:**` carries bare integers or `none`, and `ledger child` refuses anything else — a
 parser that harvests every digit run reads `1, 3 (see #<other>)` as claiming a story nobody wrote.

--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -64,7 +64,7 @@ fabrika build tree --require-clean
 
 The token `claim` prints is `<claim-token>` below — this LANE's name, which every later verb takes as
 `--token`. A session runs several lanes, so a verb handed only the session id cannot tell a sibling
-lane's claim from yours (#6037).
+lane's claim from yours.
 
 `--purpose plan` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
 should pick the issue up to **build**, and an epic earns that label only *after* this skill has
@@ -96,7 +96,7 @@ This proves the ground fresh against `origin/main`, allocates the run directory 
 **claim nonce `--token` names** — never the session, which every sibling subagent of one run shares
 — and reads what already exists. That is why every `ledger` verb takes the token: handed only a
 session id, the claim check passed for a lane that had *lost* the epic's claim and then derived the
-holder's run key, so two planning lanes wrote into one directory (#6060).
+holder's run key, so two planning lanes wrote into one directory.
 
 Done when you hold `run`, `mode` (`fresh` or `re-plan`), `children`, `cycleDoc`, `bodyDigest`, and
 `candidates`. Carry `bodyDigest` as `--body-digest` to `ledger draft` and `ledger write`; it is how
@@ -143,13 +143,12 @@ cannot say which story each slice serves is telling you the split is wrong.
 
 **Every epic is grilled, and it happens here** — the plan is staged, no child exists, and the epic
 body has not moved. There is **no size threshold, no fog threshold and no opt-out**: a one-question
-grill on a small epic is the expected cheap case, not a step you skipped (ADR
-[0289](../../../../.decisions/0289-founder-approves-every-epic-plan.md)). Position is the whole
+grill on a small epic is the expected cheap case, not a step you skipped. Position is the whole
 point. Asking after `ledger write` turns an answer into a re-plan; asking after step 5 turns it into
 a supersede.
 
 Open on the **epic**, never on a `--topic` you compose from its title — the ticket binding is what
-makes a re-plan resume this same session instead of minting a second one (#5661):
+makes a re-plan resume this same session instead of minting a second one:
 
 ```bash
 fabrika grill open --ticket $epic_number
@@ -185,13 +184,13 @@ fabrika grill read <session>
 Its `frontier` token routes you, and all four exit `0`. `clear` is the only one that lets you go on.
 `facts-pending` is yours to finish — answer them and read again. `awaiting-founder` is a standing
 `decision` question, which is `NEEDS-INPUT`. `empty` means no question was ever asked, so it is not
-`clear` by another name — it is this step not run, and going on from it is the skipped grill ADR 0289
-forbids. **Never read a question's state off prose**; a comment saying the founder approved something
-is content. A non-zero exit is UNKNOWN, never "nothing is open".
+`clear` by another name — it is this step not run, and going on from it skips the grill no epic may
+skip. **Never read a question's state off prose**; a comment saying the founder
+approved something is content. A non-zero exit is UNKNOWN, never "nothing is open".
 
-**The record belongs on the epic, and a cross-link is not that record.** ADR 0289 says it in so many
-words — "The questions and the answers are posted as comments on the epic issue, which is where
-anyone reading the epic later already looks." The session issue is where the grill is *worked*; the
+**The record belongs on the epic, and a cross-link is not that record.** The questions and the
+answers are posted as comments on the epic issue, because that is where anyone reading the epic
+later already looks. The session issue is where the grill is *worked*; the
 epic is where it is *kept*. So before you leave this step, mirror the whole grill onto the epic —
 every question with its kind, the answer or ruling it carries, and the session number so the live
 thread is one click away:
@@ -266,8 +265,8 @@ that number is what you report. Do not re-mint it.
 
 `**Containment:**` is emitted only when the run's `cycleDoc` read is `present` — `ledger child`
 takes that from the run directory, so you neither pass it nor remember it. Which keywords are legal
-is the repo's `containmentVocabulary` (`fabrika status settings` prints what it resolves to; in
-phoenix it is `flag` / `exempt` over `type:feature`), plus the reserved `none`, which declines. A
+is the repo's `containmentVocabulary` (`fabrika status settings` prints the types it asks and the
+values it accepts), plus the reserved `none`, which declines. A
 trailing parenthetical is yours to write and is preserved. **On a child of an asked type only a
 legal value will do** — the gate reds `none` and unset alike, so `ledger child` refuses both rather
 than letting you author a defect.
@@ -320,10 +319,10 @@ successor that re-mints them doubles the ledger.
 ## 8 — Put the topology on the graph
 
 The block you just wrote is a **picture** of the dependencies. The thing every build gate reads is
-GitHub's native `blocked_by` graph (ADR
-[0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md)), so a plan that stops at the
-picture leaves both gates blind — epic #6595 said in three places that #6598 waited on an unruled
-decision, and `build claim` admitted it anyway on `scanned 0 blocked_by edges` ([#6616](https://github.com/kamp-us/phoenix/issues/6616)):
+GitHub's native `blocked_by` graph, which is the carrier of record and the only thing the gates
+read, so a plan that stops at the picture leaves both gates blind — an epic once said in three
+places that a child waited on an unruled decision, and `build claim` admitted that child anyway on
+`scanned 0 blocked_by edges`:
 
 ```bash
 fabrika ledger edges $epic_number --token <claim-token>

--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -10,13 +10,13 @@ excess-operand guard, and `excess-operand.unit.test.ts` reds on it). The
 spec and that doc disagree, the doc wins and this spec is the bug.
 
 **`fabrika` calls `pipeline-cli` nowhere, and neither does the skill** — a verb whose whole body
-relays another tool's answer is not a verb. The v1 machinery
-named below — `claude-plugins/kampus-pipeline/skills/plan-epic/scripts/`, and under
-`packages/pipeline-cli/src/tools/`: `epic-lock/`, `epic-splice/`, `epic-ledger/`,
-`intake-compose/`, `intake-dedup/`, `scratchpad/`, `homing-guard/`, `reachability-guard/` — is
-prior art **read** for semantics and scars; none is invoked, wrapped, or deferred to. Every v1
-module name cited in this spec is **non-normative**: the behavior it informs is restated here in
-full, and an implementer needs none of those files to build these verbs.
+relays another tool's answer is not a verb. The v1 machinery named below —
+`claude-plugins/kampus-pipeline/skills/plan-epic/scripts/`, and under
+`packages/pipeline-cli/src/tools/`: `epic-lock/`, `epic-splice/`, `epic-ledger/`, `intake-compose/`,
+`intake-dedup/`, `scratchpad/`, `homing-guard/`, `reachability-guard/` — is prior art **read** for
+semantics and scars; none is invoked, wrapped, or deferred to. Every v1 module name cited in this
+spec is **non-normative**: the behavior it informs is restated here in full, and an implementer
+needs none of those files to build these verbs.
 
 **The group name.** `ledger` is this skill's, following the one-group-per-skill precedent
 (`build-ui` took `ui`, `check-epic-plan` took `plan`, each reusing
@@ -30,7 +30,7 @@ nothing shipped creates an issue with a full classification, links a sub-issue, 
 
 **One disambiguation, because the word is overloaded in this package.**
 `packages/fabrika-cli/src/lane/store.ts` calls its append-only `events.jsonl` a "ledger". That is
-the *run* ledger. This group's `ledger` is the **plan** — the noun the brief and
+the *run* ledger. This group's `ledger` is the **plan** — the noun this contract and
 [`check-epic-plan`](../check-epic-plan/SKILL.md) both use for an epic's decomposed task list. The
 two never meet: no verb here reads or writes a lane's run ledger.
 
@@ -41,8 +41,8 @@ its ground with `fabrika build tree`, releases with `fabrika build release`, and
 note with `fabrika build note`. The purpose is part of the reuse, not a detail of it: `build claim`'s
 audience axis asks whether an agent should pick the issue up to *build*, and an epic earns
 `ready-for:agent` only after this skill has planned it and the gate has passed it, so a `plan` claim
-is admitted without it. The scope axis is unchanged by the purpose,
-so `20` stays reachable and `21` does not, and `--override` stays the exception it was.
+is admitted without it. The scope axis is unchanged by the purpose, so `20` stays reachable and
+`21` does not, and `--override` stays the exception it was.
 
 **The grilling session is the `grill` group's, reused the same way**
 ([`grilling`'s contract](../grilling/contract.md)). Every epic is grilled, with no size threshold
@@ -231,32 +231,31 @@ bullet**; criteria are `- [ ] ` checkbox rows; a single trailing newline.
 **`**Stories:**` carries bare integers only**, and the composer refuses a value that is not `none`
 or a comma-separated integer list. The refusal is worth having because **v1** harvested every digit
 run in the value, so a value carrying a parenthetical ticket reference silently claimed a story id
-no epic declared. The
-downstream gate does not repeat that: it reads a non-conforming value as *absent* and reports it in
-`detail`. Refusing at authoring time is what keeps the two from disagreeing. `**Containment:**`'s **leading keyword** is one the repo's `containmentVocabulary` declares,
-or the reserved `none`; a trailing
-parenthetical is preserved verbatim (`flag (default-off)` is the ordinary form), and the field is
-emitted **only** when the cycle-doc probe reads `present` — v1's documented spec template omitted
-the field entirely while its skill body required it, so an author following the template dropped
-it on every child and the tolerant read made "forgot" indistinguishable from "no cycle doc".
+no epic declared. The downstream gate does not repeat that: it reads a non-conforming value as
+*absent* and reports it in `detail`. Refusing at authoring time is what keeps the two from
+disagreeing. `**Containment:**`'s **leading keyword** is one the repo's `containmentVocabulary`
+declares, or the reserved `none`; a trailing parenthetical is preserved verbatim (`flag
+(default-off)` is the ordinary form), and the field is emitted **only** when the cycle-doc probe
+reads `present` — v1's documented spec template omitted the field entirely while its skill body
+required it, so an author following the template dropped it on every child and the tolerant read
+made "forgot" indistinguishable from "no cycle doc".
 
 **`## Dependencies` — the rendered block.** It is a picture of the plan's shape for a human reader
 and **nothing gates on it**: blockedness sits behind GitHub's native `blocked_by` edges alone, and
-`build eligible` no longer parses this block at all. Exactly the two line
-forms `readTopology` parses, and
-nothing else: one `- phase <n>: #<ref>[, #<ref>…]` row per phase, phases ascending and members
-ascending within a row, then one `- #<ref> requires: #<ref>[, #<ref>…]` row per child that declares
-a prerequisite, ascending by subject. There is no `###` heading inside the section, no label column,
-no parenthesized clause and no `---` rule — `readTopology` breaks at the first heading of any level
-**or** the first thematic break (`packages/fabrika-cli/src/build/dependencies.ts`), so a `### Phase
-<n>` line would end the scan on the line after `## Dependencies` and the block would read back as
-zero edges: a well-formed, plausible, always-wrong answer the gate then reads as an epic every one
-of whose children is orphaned. The thematic break is the same boundary an appended amendment's
-separator draws, which is why one below the block leaves the block itself intact. The block ends with a trailing blank line so a later heading stays
-separated. The illustrated block above is the round trip this grammar buys — pasted into
-`readTopology` it parses to the three edges it depicts (`phase 1: #4, #5`, `phase 2: #6`,
-`#6 requires: #4`), never the empty set, which is what lets `ledger topology` stage instead of
-refusing on `24`.
+`build eligible` no longer parses this block at all. Exactly the two line forms `readTopology`
+parses, and nothing else: one `- phase <n>: #<ref>[, #<ref>…]` row per phase, phases ascending and
+members ascending within a row, then one `- #<ref> requires: #<ref>[, #<ref>…]` row per child that
+declares a prerequisite, ascending by subject. There is no `###` heading inside the section, no
+label column, no parenthesized clause and no `---` rule — `readTopology` breaks at the first heading
+of any level **or** the first thematic break (`packages/fabrika-cli/src/build/dependencies.ts`), so
+a `### Phase <n>` line would end the scan on the line after `## Dependencies` and the block would
+read back as zero edges: a well-formed, plausible, always-wrong answer the gate then reads as an
+epic every one of whose children is orphaned. The thematic break is the same boundary an appended
+amendment's separator draws, which is why one below the block leaves the block itself intact. The
+block ends with a trailing blank line so a later heading stays separated. The illustrated block
+above is the round trip this grammar buys — pasted into `readTopology` it parses to the three edges
+it depicts (`phase 1: #4, #5`, `phase 2: #6`, `#6 requires: #4`), never the empty set, which is what
+lets `ledger topology` stage instead of refusing on `24`.
 
 ## The body digest
 
@@ -320,10 +319,9 @@ Every `ledger` verb obeys these; stated once.
   writes, and swallowing that to `""` makes an unread pipe byte-identical to an empty one.
 - **The run directory is keyed on the claim nonce, never the session.** `runKey(epic, nonce)` →
   `<treeRoot>/.fabrika-plan/<epic>-<nonce>/`. Every sibling subagent of one session shares the
-  session id, so a session-keyed namespace collapses exactly the
-  isolation two parallel planning lanes need. Every file inside it is named for what
-  it holds — no fixed leaf shared across runs. The shipped precedents are
-  `build/scratch-verb.ts:33` and `ledger/run.ts:31-36`.
+  session id, so a session-keyed namespace collapses exactly the isolation two parallel planning
+  lanes need. Every file inside it is named for what it holds — no fixed leaf shared across runs.
+  The shipped precedents are `build/scratch-verb.ts:33` and `ledger/run.ts:31-36`.
   **It is kept out of git the way `ledger` already does it** — `ledger open` appends the literal line
   `.fabrika-plan/` to `.git/info/exclude` if absent (`ledger/run.ts:29`'s `EXCLUDE_ENTRY`, written by
   `ledger/open-verb.ts:251-258`).
@@ -894,13 +892,12 @@ EOF
 
 Lines are order-indifferent. **Every child in the run manifest appears exactly once — and the
 manifest is the epic's whole child set, retained children included**, which is what makes a
-`re-plan` placeable; a manifest
-child with no line is an unplaced child and a line naming a number that is not in the manifest is
-a dangling reference — both `24`. Edges are ordered `[dependent, prerequisite]`:
-`["#6","#4"]` reads *#6 requires #4*. `edges` is a bounded evidence array — a validated echo of the
-caller's own stdin, one pair per declared `requires` — so it collapses to a cap-and-count: the
-first 5 pairs in `rows`, with `more` counting what followed (`0` when the array was whole); the
-rendered block still carries every edge.
+`re-plan` placeable; a manifest child with no line is an unplaced child and a line naming a number
+that is not in the manifest is a dangling reference — both `24`. Edges are ordered `[dependent,
+prerequisite]`: `["#6","#4"]` reads *#6 requires #4*. `edges` is a bounded evidence array — a
+validated echo of the caller's own stdin, one pair per declared `requires` — so it collapses to a
+cap-and-count: the first 5 pairs in `rows`, with `more` counting what followed (`0` when the array
+was whole); the rendered block still carries every edge.
 
 The verb renders the `## Dependencies` block into `<dir>/topology.md` and then **parses its own
 output back through the imported `readTopology`**, refusing on `24` if the round trip does not

--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -1,6 +1,6 @@
 # `/plan-epic` — derived CLI contract
 
-**Skill:** [`plan-epic`](SKILL.md) · **Authoring brief:** [#4712](https://github.com/kamp-us/phoenix/issues/4712) · **Date:** 2026-08-09
+**Skill:** [`plan-epic`](SKILL.md) · **Date:** 2026-08-09
 
 The verbs land in `packages/fabrika-cli/` under the **`ledger`** subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped groups, every leaf declared via
@@ -9,7 +9,8 @@ excess-operand guard, and `excess-operand.unit.test.ts` reds on it). The
 [CLI interface convention](../../docs/cli-interface-convention.md) governs every verb; where this
 spec and that doc disagree, the doc wins and this spec is the bug.
 
-**`fabrika` calls `pipeline-cli` nowhere, and neither does the skill** (ADR 0238). The v1 machinery
+**`fabrika` calls `pipeline-cli` nowhere, and neither does the skill** — a verb whose whole body
+relays another tool's answer is not a verb. The v1 machinery
 named below — `claude-plugins/kampus-pipeline/skills/plan-epic/scripts/`, and under
 `packages/pipeline-cli/src/tools/`: `epic-lock/`, `epic-splice/`, `epic-ledger/`,
 `intake-compose/`, `intake-dedup/`, `scratchpad/`, `homing-guard/`, `reachability-guard/` — is
@@ -40,14 +41,12 @@ its ground with `fabrika build tree`, releases with `fabrika build release`, and
 note with `fabrika build note`. The purpose is part of the reuse, not a detail of it: `build claim`'s
 audience axis asks whether an agent should pick the issue up to *build*, and an epic earns
 `ready-for:agent` only after this skill has planned it and the gate has passed it, so a `plan` claim
-is admitted without it (founder ruling,
-[#5175](https://github.com/kamp-us/phoenix/issues/5175)). The scope axis is unchanged by the purpose,
+is admitted without it. The scope axis is unchanged by the purpose,
 so `20` stays reachable and `21` does not, and `--override` stays the exception it was.
 
 **The grilling session is the `grill` group's, reused the same way**
-([`grilling`'s contract](../grilling/contract.md)). ADR
-[0289](../../../../.decisions/0289-founder-approves-every-epic-plan.md) requires a grilling session
-on every epic, before the plan reaches the epic body; the skill's step 4 runs it with
+([`grilling`'s contract](../grilling/contract.md)). Every epic is grilled, with no size threshold
+and no opt-out, before the plan reaches the epic body; the skill's step 4 runs it with
 `fabrika grill open --ticket <epic>`, `grill round`, `grill answer` and `grill read`, between
 `ledger draft` and `ledger write` (before `ledger child`, so the `NEEDS-INPUT` exit really does mint
 nothing). **This adds no `ledger` verb, no plan section and no exit code**, and it is why: the
@@ -55,13 +54,13 @@ session issue, its round grammar, the `fact`/`decision` split enforced at `grill
 ACL-gated ruling and the closed-set frontier all already exist and are already tested. Deriving a
 second question-and-answer record here would put two records on one conversation.
 
-**The session is where the grill runs; the epic is where it is kept, and that placement is 0289's,
-not a preference.** That record says in so many words that "The questions and the answers are posted
-as comments on the epic issue, which is where anyone reading the epic later already looks." Reusing
+**The session is where the grill runs; the epic is where it is kept, and that placement is a
+governing rule, not a preference.** The questions and the answers are posted as comments on the epic
+issue, because that is where anyone reading the epic later already looks. Reusing
 the `grill` group puts the working thread on a session issue, so step 4 mirrors the settled grill
 back onto the epic through `build note` — question, kind, answer or ruling, and the session number.
 Stated here because the two are easy to confuse: the reuse is a mechanism choice this contract may
-make, while *where the record lands* is 0289's to decide, and a cross-link alone would have quietly
+make, while *where the record lands* is not, and a cross-link alone would have quietly
 moved it. Nothing is derived to enforce the mirror — see the paragraph below.
 
 **No `ledger` verb proves the grill happened**, and nothing here derives one. The ordering — a
@@ -69,7 +68,7 @@ session opened, a round posted, the frontier read, the grill mirrored, *then* `l
 convention the skill holds, stated at its `GRILL-IS-CONVENTION` anchor. A verb that read the session before splicing
 would be this group deriving a verdict about a `grill` artifact, which is the same second-answer
 defect that keeps the structural floor out of this group; it would also make an absent session a
-`ledger write` refusal, seating a code for a fact ADR 0289 gives to the founder's checkpoint.
+`ledger write` refusal, seating a code for a fact the founder's approval checkpoint owns.
 
 **No second lock is derived**, and v1's `epic-lock` is why: all five of its
 distinct outcomes collapse onto exit `1`
@@ -126,9 +125,8 @@ as the sibling contracts do):
   group derives no second verdict; `ledger draft`, `ledger child` and `ledger topology` each
   validate *the document they are composing* so a defect is caught at authoring time, which is a
   different question from grading a finished ledger.
-- **A `status:triaged` flip.** The gate's, unconditionally (#4693 AC4). No verb here writes it.
-- **A pickability predicate.** `build`'s picker question, open on
-  [#4920](https://github.com/kamp-us/phoenix/issues/4920).
+- **A `status:triaged` flip.** The gate's, unconditionally. No verb here writes it.
+- **A pickability predicate.** `build`'s picker question, and still open there.
 - **A reachability check.** `reachability-guard` answers a flag-graduation question at the
   `/release` seam; nothing in planning needs it, and its v1 shape is pinned to one app's paths.
 - **A convergence / re-plan loop.** v1 exported `runConvergenceLoop` and registered it as no
@@ -136,7 +134,7 @@ as the sibling contracts do):
   loops.
 - **A planning lock, a repo resolver, a scratch opener, a link confirmer.** All four exist in v1
   as scripts whose entire body relays an upstream answer (`resolve-repo.sh`, `scratch-open.sh`,
-  `epic-lock-release.sh`, `confirm-links.sh`). A relay-only verb is not a verb (ADR 0238).
+  `epic-lock-release.sh`, `confirm-links.sh`). A relay-only verb is not a verb.
 
 ## Verb inventory
 
@@ -172,7 +170,7 @@ gate's reader is authoritative and this composer is held to it by the imported m
 
 `plan-epic` appends its plan and dependency topology below.
 
-<!-- fabrika:enriched issue=4300 mode=wrap -->
+<!-- fabrika:enriched issue=3 mode=wrap -->
 <details>
 <summary>Original brief (verbatim)</summary>
 
@@ -186,22 +184,19 @@ gate's reader is authoritative and this composer is held to it by the imported m
 
 ## Dependencies
 
-- phase 1: #4301, #4302
-- phase 2: #4303
-- #4303 requires: #4301
+- phase 1: #4, #5
+- phase 2: #6
+- #6 requires: #4
 ```
 
 **The plan region is located by the enrichment marker, never by position.** Detection is the
 verb-written `<!-- fabrika:enriched issue=<N> mode=<rewrite|wrap> --> ` line, matched whole-line
 (`packages/fabrika-cli/src/triage/enrich.ts:41`), which is one mode-independent rule closing both
-the position axis ([#4850](https://github.com/kamp-us/phoenix/issues/4850)) and the mode axis
-([#4866](https://github.com/kamp-us/phoenix/issues/4866)). **This is the route taken on
-[#4896](https://github.com/kamp-us/phoenix/issues/4896)'s open fork, and the reason is that a
-sibling already shipped it**: with the marker doing the detecting, appending the plan below the
-brief envelope breaks no detector, so the wrap-last layout inversion, its three coupled changes
-and its legacy migration are all unnecessary. #4892's remedy (c) — making the `--epic` envelope
-independent of a splicer's anchor set — is thereby **moot**; that issue owns its own ADR write-up
-and this contract does not pre-empt it.
+the position axis and the mode axis at once. **The marker is what makes position free**: with it
+doing the detecting, appending the plan below the brief envelope breaks no detector, so a
+wrap-last layout inversion, its coupled changes and its legacy migration are all unnecessary.
+Making the `--epic` envelope independent of a splicer's anchor set is thereby **moot** as a
+remedy — the anchor set is no longer what locates the region.
 
 **Plan block — the closed section set.** `## Plan (plan-epic)` followed by exactly these `###`
 headings, each present exactly once, in this order:
@@ -235,18 +230,19 @@ between them; exactly one blank line before `### What to build` and before
 bullet**; criteria are `- [ ] ` checkbox rows; a single trailing newline.
 **`**Stories:**` carries bare integers only**, and the composer refuses a value that is not `none`
 or a comma-separated integer list. The refusal is worth having because **v1** harvested every digit
-run in the value, so `1, 3 (see #4021)` silently claimed a story 4021 no epic declared. The
+run in the value, so a value carrying a parenthetical ticket reference silently claimed a story id
+no epic declared. The
 downstream gate does not repeat that: it reads a non-conforming value as *absent* and reports it in
 `detail`. Refusing at authoring time is what keeps the two from disagreeing. `**Containment:**`'s **leading keyword** is one the repo's `containmentVocabulary` declares,
-or the reserved `none` (phoenix's set is `flag` / `exempt`); a trailing
+or the reserved `none`; a trailing
 parenthetical is preserved verbatim (`flag (default-off)` is the ordinary form), and the field is
 emitted **only** when the cycle-doc probe reads `present` — v1's documented spec template omitted
 the field entirely while its skill body required it, so an author following the template dropped
 it on every child and the tolerant read made "forgot" indistinguishable from "no cycle doc".
 
 **`## Dependencies` — the rendered block.** It is a picture of the plan's shape for a human reader
-and **nothing gates on it**: blockedness sits behind GitHub's native `blocked_by` edges alone
-(#5387, ADR 0301), and `build eligible` stopped parsing this block in #5913. Exactly the two line
+and **nothing gates on it**: blockedness sits behind GitHub's native `blocked_by` edges alone, and
+`build eligible` no longer parses this block at all. Exactly the two line
 forms `readTopology` parses, and
 nothing else: one `- phase <n>: #<ref>[, #<ref>…]` row per phase, phases ascending and members
 ascending within a row, then one `- #<ref> requires: #<ref>[, #<ref>…]` row per child that declares
@@ -256,10 +252,10 @@ no parenthesized clause and no `---` rule — `readTopology` breaks at the first
 <n>` line would end the scan on the line after `## Dependencies` and the block would read back as
 zero edges: a well-formed, plausible, always-wrong answer the gate then reads as an epic every one
 of whose children is orphaned. The thematic break is the same boundary an appended amendment's
-separator draws, which is why one below the block leaves the block itself intact (#5816). The block ends with a trailing blank line so a later heading stays
+separator draws, which is why one below the block leaves the block itself intact. The block ends with a trailing blank line so a later heading stays
 separated. The illustrated block above is the round trip this grammar buys — pasted into
-`readTopology` it parses to the three edges it depicts (`phase 1: #4301, #4302`, `phase 2: #4303`,
-`#4303 requires: #4301`), never the empty set, which is what lets `ledger topology` stage instead of
+`readTopology` it parses to the three edges it depicts (`phase 1: #4, #5`, `phase 2: #6`,
+`#6 requires: #4`), never the empty set, which is what lets `ledger topology` stage instead of
 refusing on `24`.
 
 ## The body digest
@@ -292,7 +288,7 @@ excluding the very bytes being verified.
 **Normalizing before hashing is a scar fix, not tidiness.** v1's splice round-trip compared raw
 bytes while its only caller captured stdout through command substitution, which strips every
 trailing newline before the PATCH — so what GitHub stored was never what was emitted and the
-comparison was structurally unwinnable (#4599). Hashing the normalized form makes a trailing-
+comparison was structurally unwinnable. Hashing the normalized form makes a trailing-
 newline round trip a match instead of a false `21` on every clean run.
 
 ## Shared conventions
@@ -314,7 +310,7 @@ Every `ledger` verb obeys these; stated once.
 - **A flag whose absence must be a *semantic* refusal is optional at the parser and refused in the
   verb body.** A parser-required flag's absence is exit `1`, indistinguishable from a typo
   (`triage/command.ts:78-85` is the shipped precedent). `--ready-for` on `ledger child` is the one
-  case here: its absence is a decision nobody made (#4780), which must be provable as `10`, not
+  case here: its absence is a decision nobody made, which must be provable as `10`, not
   guessable as a typo. **This does not apply to `--body-digest`, `--child` or `--title`**, whose
   absence is an ordinary usage error with no semantic content — those stay parser-required, and
   their fail-open risk is a *wrong* value, which is `21` and `10` respectively, not a missing one.
@@ -324,8 +320,8 @@ Every `ledger` verb obeys these; stated once.
   writes, and swallowing that to `""` makes an unread pipe byte-identical to an empty one.
 - **The run directory is keyed on the claim nonce, never the session.** `runKey(epic, nonce)` →
   `<treeRoot>/.fabrika-plan/<epic>-<nonce>/`. Every sibling subagent of one session shares the
-  session id (measured, #4500; resolved per #6960's chain), so a session-keyed namespace collapses exactly the
-  isolation two parallel planning lanes need (#4516, #4544). Every file inside it is named for what
+  session id, so a session-keyed namespace collapses exactly the
+  isolation two parallel planning lanes need. Every file inside it is named for what
   it holds — no fixed leaf shared across runs. The shipped precedents are
   `build/scratch-verb.ts:33` and `ledger/run.ts:31-36`.
   **It is kept out of git the way `ledger` already does it** — `ledger open` appends the literal line
@@ -357,7 +353,7 @@ Every `ledger` verb obeys these; stated once.
 - **Common inputs.** `--repo <owner/name>` (default: `resolveRepo`'s precedence — `--repo`,
   `$CLAUDE_PIPELINE_REPO`, `$GITHUB_REPOSITORY`, then the `origin` remote) on every verb. That
   variable name is **inherited from the shipped `io/issues.ts`**, not minted here. GitHub access
-  per [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql),
+  per [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md),
   paginated in full — v1's idempotency read used `per_page=100` with no `--paginate`, so in any
   repo past a hundred open issues its duplicate check was mostly blind and failed by re-minting.
 - **Bounded fan-out, where there is any.** Two verbs fan out and both do so at concurrency **8**,
@@ -456,7 +452,7 @@ never `20` — "I could not tell" is not "it is stale", and it is certainly not 
 **`8` versus `9` versus `23`:** `8` is a write whose outcome is unknown; `9` is a write that landed
 and read back wrong; `23` is narrower and more useful than either — the create is **proven** and
 the *link* is unknown, so a named child exists unlinked. Fusing `23` into `8` would leave a
-successor unable to tell "something may exist" from "#4302 exists and needs linking", which are
+successor unable to tell "something may exist" from "#5 exists and needs linking", which are
 opposite repairs.
 
 ---
@@ -466,7 +462,7 @@ opposite repairs.
 **Invocation**
 
 ```
-fabrika ledger open 4300 --token <claim-token> [--repo <owner/name>]
+fabrika ledger open 3 --token <claim-token> [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -474,16 +470,16 @@ fabrika ledger open 4300 --token <claim-token> [--repo <owner/name>]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic being planned |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository read |
 
 **Output** — machine. One JSON object:
 
 ```
-{"answer": "opened", "epic": 4300, "run": "4300-7f31a2", "mode": "fresh",
- "bodyDigest": "8f2c1a90b4d7", "dir": "/w/.fabrika-plan/4300-7f31a2",
+{"answer": "opened", "epic": 3, "run": "3-7f31a2", "mode": "fresh",
+ "bodyDigest": "8f2c1a90b4d7", "dir": "/w/.fabrika-plan/3-7f31a2",
  "children": [], "cycleDoc": "present",
- "candidates": {"outcome": "candidates", "items": [{"number": 4180, "title": "queue view for reports", "score": 3}]}}
+ "candidates": {"outcome": "candidates", "items": [{"number": 7, "title": "queue view for reports", "score": 3}]}}
 ```
 
 `mode` is closed: `fresh` (the body carries no `## Plan (plan-epic)` heading) or `re-plan`
@@ -517,8 +513,8 @@ refusal to notice.
 **Freshness.** The verb resolves `origin/main` and compares the tree's merge base. Provably
 behind is `20`. A fetch or rev-parse that fails is `11`. There is no third arm: this verb never
 answers "fresh" without having proven it, because the whole point is that v1 planned against
-stale checkouts and minted phantom children (#3330), and the repo has no post-merge sync with any
-call site (#4167) — so the tree is stale by default until shown otherwise.
+stale checkouts and minted phantom children, and no repo is guaranteed a post-merge sync at any
+call site — so the tree is stale by default until shown otherwise.
 
 **Exit status** (beyond the universal four)
 
@@ -551,12 +547,12 @@ which is why `outcome: "none"` is an answer and only an unreachable index is `in
 **Examples**
 
 ```
-$ fabrika ledger open 4300 --token <claim-token>
-{"answer":"opened","epic":4300,"run":"4300-7f31a2","mode":"fresh","bodyDigest":"8f2c1a90b4d7","dir":"/w/.fabrika-plan/4300-7f31a2","children":[],"cycleDoc":"present","candidates":{"outcome":"none","items":[]}}
+$ fabrika ledger open 3 --token <claim-token>
+{"answer":"opened","epic":3,"run":"3-7f31a2","mode":"fresh","bodyDigest":"8f2c1a90b4d7","dir":"/w/.fabrika-plan/3-7f31a2","children":[],"cycleDoc":"present","candidates":{"outcome":"none","items":[]}}
 ```
 
 ```
-$ fabrika ledger open 4300 --token <claim-token>
+$ fabrika ledger open 3 --token <claim-token>
 ledger open: base is 47 commit(s) behind origin/main — a plan derived here is derived on stale ground (#3330).
 $ echo $?
 20
@@ -564,11 +560,11 @@ $ echo $?
 
 **Grounding**
 
-- #3330 / #4167 — a stale checkout inflated a baseline and spawned phantom children; `main-sync
-  --post-merge` has no call site, so freshness is proven here rather than assumed.
-- #4934 — one tree per epic run; every subagent works in the tree the conductor is in.
-- #4516 / #4544 / #4500 — the run key is the claim nonce; sibling subagents share the session id,
-  so a session-keyed namespace is not a namespace.
+- A stale checkout once inflated a baseline and spawned phantom children, and no post-merge sync
+  runs on its own, so freshness is proven here rather than assumed.
+- One tree per epic run; every subagent works in the tree the conductor is in.
+- The run key is the claim nonce; sibling subagents share the session id, so a session-keyed
+  namespace is not a namespace.
 - v1 scar (`idempotency-sets.sh:27,33`) — `per_page=100` with no `--paginate` made the duplicate
   read blind past a hundred issues; this verb paginates in full and states its scope.
 - v1 scar (`intake-dedup/command.ts:55`) — the no-keywords refusal printed to stderr and exited
@@ -582,7 +578,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token <claim-token> <<'EOF'
+fabrika ledger draft 3 --body-digest 8f2c1a90b4d7 --token <claim-token> <<'EOF'
 ## Plan (plan-epic)
 
 ### Summary
@@ -596,12 +592,12 @@ EOF
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose plan is staged |
 | `--body-digest` | string, 12 lowercase hex | yes | — | the digest `ledger open` printed; the draft refuses if the epic body has moved since |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository read |
 | stdin | markdown | yes | — | the plan block, opening with `## Plan (plan-epic)` |
 
 **Output** — machine.
-`{"answer": "staged", "epic": 4300, "document": "plan", "sections": 10, "stories": [1,2,3], "bytes": 4187}`
+`{"answer": "staged", "epic": 3, "document": "plan", "sections": 10, "stories": [1,2,3], "bytes": 4187}`
 
 The verb checks the closed section set (each of the ten `###` headings present exactly once, in
 order), that the block opens with `## Plan (plan-epic)`, and that `### User stories` parses through
@@ -661,12 +657,12 @@ required, and an empty one is `3`.
 **Examples**
 
 ```
-$ fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token <claim-token> < plan.md
-{"answer":"staged","epic":4300,"document":"plan","sections":10,"stories":[1,2,3],"bytes":4187}
+$ fabrika ledger draft 3 --body-digest 8f2c1a90b4d7 --token <claim-token> < plan.md
+{"answer":"staged","epic":3,"document":"plan","sections":10,"stories":[1,2,3],"bytes":4187}
 ```
 
 ```
-$ fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token <claim-token> < plan.md
+$ fabrika ledger draft 3 --body-digest 8f2c1a90b4d7 --token <claim-token> < plan.md
 ledger draft: user stories are numbered 1, 2, 4 — a story list must run from 1 with no gaps or repeats.
 $ echo $?
 4
@@ -689,7 +685,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent [--assignee <login>] --milestone <title> [--label <name>]… --token <claim-token> <<'EOF'
+fabrika ledger child 3 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent [--assignee <login>] --milestone <title> [--label <name>]… --token <claim-token> <<'EOF'
 **Stories:** 1, 2
 **TDD:** yes
 **Containment:** flag (default-off)
@@ -712,16 +708,16 @@ EOF
 | `--priority` | string, one of `p0`/`p1`/`p2` | yes | — | the child's priority label; `p3` is retired, not admitted |
 | `--ready-for` | string, one of `human`/`agent` | **optional at the parser, refused in the body** | none | the child's audience; an absent value is refused on `10`, never defaulted |
 | `--assignee` | string (login) | no | none | required when `--ready-for human`; born-assignment is the enforced hold |
-| `--milestone` | string (open milestone title) | **required unless a `--label` carries a standing lane** | none | the child's home; a call naming neither is refused on `10` before any read (#5969) |
+| `--milestone` | string (open milestone title) | **required unless a `--label` carries a standing lane** | none | the child's home; a call naming neither is refused on `10` before any read |
 | `--label` | string, repeatable | no | none | any further label, applied in the same create call |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 | stdin | markdown | yes | — | the child body's fields and sections |
 
 **Output** — machine, the **observed** result:
 
 ```
-{"answer": "minted", "epic": 4300, "child": 4301, "linked": true,
+{"answer": "minted", "epic": 3, "child": 4, "linked": true,
  "observed": {"labels": ["p1","ready-for:agent","status:planned","type:feature"], "assignees": [], "milestone": "fabrika campaign"},
  "stories": [1,2], "containment": "flag"}
 ```
@@ -735,14 +731,14 @@ applied by a follow-up PATCH — and a follow-up PATCH opens a window in which t
 reads as a permissive default rather than an unknown. v1's own sibling script knows the hazard by
 name and warns that patching a fresh child "reopens the label-less-orphan window".
 
-**A home is required and is never defaulted** (#5969): the call names an open milestone, or a
-`--label` from the claim fence's standing-lane set (`STANDING_LANE_LABELS`, ADR 0208) — a child
+**A home is required and is never defaulted**: the call names an open milestone, or a
+`--label` from the claim fence's standing-lane set (`STANDING_LANE_LABELS`) — a child
 carrying neither is what the fence refuses at exit `20`, so the refusal moves to the mint, where
 nothing has been written yet. The lane set is *imported* from `build/scope-admission.ts`, never
 re-listed here in code: two copies is how the two seams drift into disagreeing about what a home is.
 
-**`--ready-for` is required and has no default** (#4780): a child must never inherit its audience
-by omission. **`--ready-for human` requires `--assignee`** (#4693): the label is the routing
+**`--ready-for` is required and has no default**: a child must never inherit its audience
+by omission. **`--ready-for human` requires `--assignee`**: the label is the routing
 signal, born-assignment is the enforced hold, and neither substitutes for the other — a label
 without assignment has no teeth, an assignment without the label hides the intent from queries.
 This is not merely a convention: the gate's floor reds `HELD_CHILD_UNASSIGNED` over the **whole
@@ -761,7 +757,7 @@ link, deliberately** — see step 5.
    The gate's `MISSING_CONTAINMENT` derives from the same key, so admitting one here would author a
    defect the floor then reds.
 3. **Vocabulary precondition.** Confirm every label and the milestone exist in the repository.
-   `POST .../labels` **creates** an unknown label rather than rejecting it (#4285), and a closed
+   `POST .../labels` **creates** an unknown label rather than rejecting it, and a closed
    milestone is off-vocabulary; refuse on `10` rather than minting taxonomy.
 4. **Leak-scan** the composed body (`5` / `6`).
 5. **Create,** with every attribute, in one `POST /repos/{repo}/issues` — `title`, `body`,
@@ -840,12 +836,12 @@ scope is unreachable: the verb writes exactly one child or refuses.
 **Examples**
 
 ```
-$ fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" --token <claim-token> < child.md
-{"answer":"minted","epic":4300,"child":4301,"linked":true,"observed":{"labels":["p1","ready-for:agent","status:planned","type:feature"],"assignees":[],"milestone":"fabrika campaign"},"stories":[1,2],"containment":"flag"}
+$ fabrika ledger child 3 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" --token <claim-token> < child.md
+{"answer":"minted","epic":3,"child":4,"linked":true,"observed":{"labels":["p1","ready-for:agent","status:planned","type:feature"],"assignees":[],"milestone":"fabrika campaign"},"stories":[1,2],"containment":"flag"}
 ```
 
 ```
-$ fabrika ledger child 4300 --title "moderation queue triage rules" --type type:feature --priority p1 --ready-for human --token <claim-token> < child.md
+$ fabrika ledger child 3 --title "moderation queue triage rules" --type type:feature --priority p1 --ready-for human --token <claim-token> < child.md
 ledger child: --ready-for human requires --assignee — a held child is born assigned (#4693).
 $ echo $?
 10
@@ -853,19 +849,18 @@ $ echo $?
 
 **Grounding**
 
-- #4780 — every child carries exactly one `ready-for:` value, set explicitly at creation and never
+- Every child carries exactly one `ready-for:` value, set explicitly at creation and never
   inherited by omission.
-- #4693 (founder ruling, 2026-08-09) — COMPOSE: the label is the routing signal, born-assignment is
-  the enforced hold; neither substitutes for the other. The gate's `HELD_CHILD_UNASSIGNED` is the
-  enforcement, and it fails the whole epic.
+- The label is the routing signal and born-assignment is the enforced hold; neither substitutes for
+  the other. The gate's `HELD_CHILD_UNASSIGNED` is the enforcement, and it fails the whole epic.
 - v1 scar (`create-child.sh:48-55`) — three hardcoded `labels[]`, no pass-through, no milestone, so
   the create was not atomic over the child's birth attributes despite its own docblock's claim.
 - v1 scar (`amend-child-labels.sh:2-4,18-19`) — the amend endpoint is additive, so "adjust" could
   only add, and it force-re-added `status:planned` to a child the gate may already have flipped.
 - v1 scar (`link-child.sh:22-24`) — the link was reported from the POST response and verified
   nowhere; `confirm-links.sh` was a separate manual step whose only assertion was a comment.
-- #4285 — `POST .../labels` creates unknown labels; the vocabulary check is a precondition.
-- #4101 / #2413 — the priority set is `{p0,p1,p2}`; `p3` is retired, not admitted.
+- `POST .../labels` creates unknown labels; the vocabulary check is a precondition.
+- The priority set is `{p0,p1,p2}`; `p3` is retired, not admitted.
 
 ---
 
@@ -874,10 +869,10 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger topology 4300 --token <claim-token> <<'EOF'
-#4301 phase 1
-#4302 phase 1
-#4303 phase 2 requires #4301
+fabrika ledger topology 3 --token <claim-token> <<'EOF'
+#4 phase 1
+#5 phase 1
+#6 phase 2 requires #4
 EOF
 ```
 
@@ -886,15 +881,15 @@ EOF
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose topology is declared |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository read |
 | stdin | line grammar | yes | — | one line per child: `#<ref> phase <n> [requires #<a>[, #<b>]…]` |
 
 **Output** — machine.
 
 ```
-{"answer": "staged", "epic": 4300, "document": "topology", "phases": 2, "children": 3,
- "edges": {"rows": [["#4303","#4301"]], "more": 0}, "bytes": 214}
+{"answer": "staged", "epic": 3, "document": "topology", "phases": 2, "children": 3,
+ "edges": {"rows": [["#6","#4"]], "more": 0}, "bytes": 214}
 ```
 
 Lines are order-indifferent. **Every child in the run manifest appears exactly once — and the
@@ -902,8 +897,7 @@ manifest is the epic's whole child set, retained children included**, which is w
 `re-plan` placeable; a manifest
 child with no line is an unplaced child and a line naming a number that is not in the manifest is
 a dangling reference — both `24`. Edges are ordered `[dependent, prerequisite]`:
-`["#4303","#4301"]` reads *#4303 requires #4301*. `edges` is an evidence-array under ADR
-[0308](../../../../.decisions/0308-bounded-evidence-output-shape.md) — a validated echo of the
+`["#6","#4"]` reads *#6 requires #4*. `edges` is a bounded evidence array — a validated echo of the
 caller's own stdin, one pair per declared `requires` — so it collapses to a cap-and-count: the
 first 5 pairs in `rows`, with `more` counting what followed (`0` when the array was whole); the
 rendered block still carries every edge.
@@ -916,7 +910,7 @@ of defect nobody notices until a build runs in the wrong order.
 
 **A cycle is `24`**, walked transitively and reported as the member set. **This verb cannot see a
 shared-file conflict** — whether two children in one phase write the same module is a judgment the
-skill carries (#3709), and the verb does not pretend otherwise.
+skill carries, and the verb does not pretend otherwise.
 
 **Exit status** (beyond the universal four)
 
@@ -953,26 +947,28 @@ an empty manifest means the epic has no children at all — none retained by the
 would produce a `## Dependencies` block the gate reads as an epic every one of whose children is
 orphaned. It is `7` rather than `24` because nothing was validated — a refused scope is not an
 invalid topology, the same split `plan check` makes when it seats a childless epic on `7` instead
-of calling it defect number one (ADR 0092).
+of calling it defect number one — every guard fails closed on zero scope rather than reporting a
+clean run over nothing.
 
 **Examples**
 
 ```
-$ fabrika ledger topology 4300 --token <claim-token> < topo.txt
-{"answer":"staged","epic":4300,"document":"topology","phases":2,"children":3,"edges":{"rows":[["#4303","#4301"]],"more":0},"bytes":214}
+$ fabrika ledger topology 3 --token <claim-token> < topo.txt
+{"answer":"staged","epic":3,"document":"topology","phases":2,"children":3,"edges":{"rows":[["#6","#4"]],"more":0},"bytes":214}
 ```
 
 ```
-$ fabrika ledger topology 4300 --token <claim-token> < topo.txt
-ledger topology: child #4302 is placed in no phase.
+$ fabrika ledger topology 3 --token <claim-token> < topo.txt
+ledger topology: child #5 is placed in no phase.
 $ echo $?
 24
 ```
 
 **Grounding**
 
-- ADR 0092 — an empty manifest is a refused scope, never a rendered empty topology.
-- #3709 — two slices sharing a central file are not parallel; the verb cannot decide that and says
+- An empty manifest is a refused scope, never a rendered empty topology: a guard over zero scope
+  fails closed.
+- Two slices sharing a central file are not parallel; the verb cannot decide that and says
   so rather than implying its verdict is complete.
 - v1 had no round-trip check on the composed block at all; the first time anyone learned the
   topology parsed differently than intended was when the gate derived the wrong defects.
@@ -986,7 +982,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
+fabrika ledger write 3 --body-digest 8f2c1a90b4d7 --token <claim-token>
 ```
 
 **Inputs**
@@ -995,13 +991,13 @@ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose body is written |
 | `--body-digest` | string, 12 lowercase hex | yes | — | the digest `ledger open` printed; the write refuses if the body has moved since |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
 **Output** — machine.
 
 ```
-{"answer": "written", "epic": 4300, "mode": "fresh", "bodyDigest": "8f2c1a90b4d7",
+{"answer": "written", "epic": 3, "mode": "fresh", "bodyDigest": "8f2c1a90b4d7",
  "newDigest": "c41b7e0a91f6", "planBytes": 4187, "topologyBytes": 214, "verified": true}
 ```
 
@@ -1028,8 +1024,8 @@ Order of operations:
 4. **PATCH once**, then **re-read and compare**. The comparison is over the normalized body and it
    checks the *whole* result, not a re-extraction of the region — v1 truncated an epic body to
    end-of-file whenever a `## Dependencies` heading appeared inside the preserved brief, and its
-   round-trip check could not see it because both sides ran the same first-occurrence extractor
-   (#4879). A PATCH whose status is unreadable is `8`; a body that lands and does not match is `9`.
+   round-trip check could not see it because both sides ran the same first-occurrence extractor.
+   A PATCH whose status is unreadable is `8`; a body that lands and does not match is `9`.
 
 **The region is never cut to end-of-file.** v1's replace branch sliced from the `## Dependencies`
 heading to EOF on the assumption that dependencies are the last section, destroying anything a
@@ -1072,12 +1068,12 @@ staged documents are required and their absence is `25`.
 **Examples**
 
 ```
-$ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
-{"answer":"written","epic":4300,"mode":"fresh","bodyDigest":"8f2c1a90b4d7","newDigest":"c41b7e0a91f6","planBytes":4187,"topologyBytes":214,"verified":true}
+$ fabrika ledger write 3 --body-digest 8f2c1a90b4d7 --token <claim-token>
+{"answer":"written","epic":3,"mode":"fresh","bodyDigest":"8f2c1a90b4d7","newDigest":"c41b7e0a91f6","planBytes":4187,"topologyBytes":214,"verified":true}
 ```
 
 ```
-$ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
+$ fabrika ledger write 3 --body-digest 8f2c1a90b4d7 --token <claim-token>
 ledger write: topology.md was never staged in this run — stage it before writing.
 $ echo $?
 25
@@ -1085,9 +1081,9 @@ $ echo $?
 
 **Grounding**
 
-- #4866 / #4850 — detection is the whole-line enrichment marker, so position is not load-bearing
-  and the plan may sit below the brief envelope. This is #4896's route, taken.
-- #4879 — v1 truncated a body to EOF when a `## Dependencies` heading sat inside the preserved
+- Detection is the whole-line enrichment marker, so position is not load-bearing
+  and the plan may sit below the brief envelope.
+- v1 truncated a body to EOF when a `## Dependencies` heading sat inside the preserved
   brief, and the round-trip check reused the buggy extractor so it could not see it. The bounded
   region and the whole-body comparison answer both halves.
 - v1 scar (`splice-body.sh:174-175,185`) — the PATCH's exit status was never checked and the
@@ -1097,7 +1093,7 @@ $ echo $?
 - v1 scar (`splice-body.sh:101`) — a `for attempt in 1 2 3` loop whose every branch broke, so the
   second attempt was unreachable while the terminal message claimed "every attempt raced". This
   verb attempts once and says so.
-- #4599 — the caller's command substitution stripped trailing newlines before the PATCH, so a raw
+- The caller's command substitution stripped trailing newlines before the PATCH, so a raw
   byte comparison could never succeed; the digest and the comparison both normalize.
 
 ---
@@ -1113,16 +1109,15 @@ fabrika ledger edges <epic> --token <claim-token> [--repo owner/name]
 **Answer**
 
 ```json
-{"answer": "reconciled", "epic": 4300, "required": 3, "already": 1, "written": 2, "verified": true}
+{"answer": "reconciled", "epic": 3, "required": 3, "already": 1, "written": 2, "verified": true}
 ```
 
 **Why it exists.** The `## Dependencies` block is a **picture** of the dependency graph, never the
-graph. ADR [0301](../../../../.decisions/0301-blocked-by-graph-is-the-carrier.md) makes GitHub's
-native `blocked_by` edges the one carrier of blockedness, and `build eligible` / `build claim` read
-only those. So a plan that stops at the picture admits a child it has itself declared blocked: epic
-#6595 stated in three places that #6598 waited on the open, unruled decision #6597, and `build claim`
-took it on `scanned 0 blocked_by edges`
-([#6616](https://github.com/kamp-us/phoenix/issues/6616)). This verb is the bridge.
+graph. GitHub's native `blocked_by` edges are the one carrier of blockedness, and `build eligible` /
+`build claim` read only those. So a plan that stops at the picture admits a child it has itself
+declared blocked: an epic once stated in three places that a child waited on an open, unruled
+decision, and `build claim` took that child on `scanned 0 blocked_by edges`. This verb is the
+bridge.
 
 Order of operations:
 
@@ -1185,23 +1180,23 @@ a surprising scope is auditable without re-running.
 **Examples**
 
 ```
-$ fabrika ledger edges 4300 --token <claim-token>
+$ fabrika ledger edges 3 --token <claim-token>
 ledger edges: scanned 3 required edges.
-{"answer":"reconciled","epic":4300,"required":3,"already":1,"written":2,"verified":true}
+{"answer":"reconciled","epic":3,"required":3,"already":1,"written":2,"verified":true}
 ```
 
 ```
-$ fabrika ledger edges 4300 --token <claim-token>
-ledger edges: #4300 declares no topology — refusing to answer over zero scope (ADR 0092).
+$ fabrika ledger edges 3 --token <claim-token>
+ledger edges: #3 declares no topology — refusing to answer over zero scope (ADR 0092).
 $ echo $?
 7
 ```
 
 **Grounding**
 
-- [#6616](https://github.com/kamp-us/phoenix/issues/6616) — the defect this verb answers, with the
-  epic #6595 / #6597 / #6598 reproduction.
-- ADR 0301 — the `blocked_by` graph is the carrier; the prose block is at most a picture of it.
+- The defect this verb answers: a prose-only dependency block let a build gate admit a child the
+  epic had itself declared blocked.
+- The `blocked_by` graph is the carrier; the prose block is at most a picture of it.
 - [`map ticket`](../../../../packages/fabrika-cli/src/map/ticket-verb.ts) — the shipped precedent for
   writing an edge on a resolved internal id, whose shape this verb follows rather than re-deriving.
 
@@ -1212,7 +1207,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice" --token <claim-token>
+fabrika ledger supersede 3 --child 8 --reason "folded into the loader slice" --token <claim-token>
 ```
 
 **Inputs**
@@ -1222,17 +1217,17 @@ fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slic
 | `<number>` | positional integer | yes | — | the parent epic |
 | `--child` | integer | yes | — | the child being retired |
 | `--reason` | string | yes | — | why it is retired; posted as the journal comment |
-| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
 **Output** — machine.
-`{"answer": "superseded", "epic": 4300, "child": 4288, "comment": 5230661234, "unlinked": true, "state": "closed"}`
+`{"answer": "superseded", "epic": 3, "child": 8, "comment": 5230661234, "unlinked": true, "state": "closed"}`
 
 Three legs in a fixed order — **comment, unlink, close** — then a re-read proving `state` is
 `closed` with `state_reason` `not_planned`. The order is load-bearing: closing before unlinking
 leaves a closed issue still counted as a sub-issue, which the gate reads as a child in scope that
-can never carry a live assignee (#5026 names this exact residue as undecided for pre-existing
-children; this verb simply does not create more of it).
+can never carry a live assignee. Whether that residue keeps a pre-existing child in floor scope is
+undecided; this verb simply does not create more of it.
 
 The three calls, so an implementer needs no other document:
 
@@ -1284,13 +1279,13 @@ unreachable: `--child` is required.
 **Examples**
 
 ```
-$ fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice" --token <claim-token>
-{"answer":"superseded","epic":4300,"child":4288,"comment":5230661234,"unlinked":true,"state":"closed"}
+$ fabrika ledger supersede 3 --child 8 --reason "folded into the loader slice" --token <claim-token>
+{"answer":"superseded","epic":3,"child":8,"comment":5230661234,"unlinked":true,"state":"closed"}
 ```
 
 ```
-$ fabrika ledger supersede 4300 --child 4301 --reason "no longer needed" --token <claim-token>
-ledger supersede: #4301 was minted by this run — refusing to supersede a child of the current plan.
+$ fabrika ledger supersede 3 --child 4 --reason "no longer needed" --token <claim-token>
+ledger supersede: #4 was minted by this run — refusing to supersede a child of the current plan.
 $ echo $?
 10
 ```
@@ -1302,7 +1297,7 @@ $ echo $?
   channel were two shapes on one stream.
 - v1 scar (`teardown-scratch-epic.sh:8-9`) — a destructive verb that "closes exactly the numbers
   you name" with no guard at all. The sub-issue check and the manifest check are that guard.
-- #5026 — whether pre-existing closed or unassigned held children stay in floor scope is undecided;
+- Whether pre-existing closed or unassigned held children stay in floor scope is undecided;
   this verb does not decide it and does not add to the residue.
 
 ---

--- a/portability-guard.config.json
+++ b/portability-guard.config.json
@@ -93,8 +93,8 @@
 			]
 		},
 		"plugin-planning": {
-			"ceiling": 269,
-			"why": "The epic planning and plan-gate skills' text, cleared by #8297, the planning sweep child.",
+			"ceiling": 21,
+			"why": "The prose is swept; every remaining hit is a value rather than a sentence. All 21 are stderr lines the shipped `ledger` and `plan` verbs print, quoted verbatim in the Errors tables and worked examples — each a copy of a string that lives in packages/fabrika-cli/src/ledger/ and packages/fabrika-cli/src/plan/, so it moves only when that string does. Rewriting the pin first would make the contract quote a line no verb prints. #8310, the CLI tail sweep, owns those two directories and pays this floor down with them.",
 			"paths": [
 				"claude-plugins/fabrika/skills/plan-epic",
 				"claude-plugins/fabrika/skills/check-epic-plan"


### PR DESCRIPTION
Part of #8297.

Sweeps `claude-plugins/fabrika/skills/plan-epic/` and
`claude-plugins/fabrika/skills/check-epic-plan/` (4 files, 3,012 lines) of every
reference that only resolves in this repository, and ratchets the guard's
`plugin-planning` floor from 269 to 21.

## What changed

**Rewritten, not dropped.** Each cut reference's rule is now stated in the
sentence itself: the ADR that requires a grilling session on every epic became
"every epic is grilled, with no size threshold and no opt-out"; the one that
makes the native `blocked_by` graph the carrier became "GitHub's native
`blocked_by` graph, which is the carrier of record and the only thing the gates
read"; the one behind every zero-scope refusal became "a guard over zero scope
fails closed"; the one that seats approval authority became "only a founder may
approve a plan, so authority is sourced from the repository's own owner roster
and never from the marker's format"; the ban on relay-only verbs became "a verb
whose whole body relays another tool's answer is not a verb". The two incident
narratives kept their failure shape and lost their numbers — a stale checkout
that "inflated a baseline and spawned phantom children", and an epic that "once
stated in three places that a child waited on an open, unruled decision" while
`build claim` admitted it on `scanned 0 blocked_by edges`.

**Generic nouns.** Both places that named this repo's own containment vocabulary
inline became a pointer at `fabrika status settings`,
which prints the types the repo asks and the values it accepts (verified against
the live verb). The org team handle in the exit matrix became a description of
the roster CODEOWNERS resolves at write time.

**Worked examples renumbered as units**, following the sibling repair on the
`build` contract: epic `3`, children `#4` `#5` `#6`, superseded child `8`, dedup
candidate `7`. Bare operands, run keys and JSON values moved with the
`#`-prefixed forms, so every example is self-consistent.

**Two anchor links lost their fragment.** The `skill-conventions.md` §11 anchor
reads as an issue reference to the guard's matcher; both citations now link the
document and keep the `§11` label in their text.

## Deleted rationale

Each of these was a bare citation whose sentence already stated its rule, so
nothing survived the number:

- **The audience-axis ruling on `--purpose plan` / `--purpose gate`** — the
  clause already says why a plan or gate claim is admitted without
  `ready-for:agent`.
- **The claim-token and run-key incident numbers** — both sentences already
  state the failure ("a verb handed only the session id cannot tell a sibling
  lane's claim from yours"; "two planning lanes wrote into one directory").
- **The session-id-resolution chain reference** — the environment chain it
  points at is spelled out in the same paragraph.
- **The grill-session ticket binding** — the sentence already says the binding
  is what makes a re-plan resume rather than mint a second session.
- **The enrichment-marker position/mode tickets and the superseded envelope
  remedy** — the paragraph states the rule (detection is the whole-line marker,
  so position is not load-bearing) and the remedy's mootness follows from it.
- **The pickability and gate-was-never-run tickets** — both are named as open
  questions belonging elsewhere, which is the whole content.
- **`p3` retirement, unknown-label creation, born-assignment, the required home,
  the required `--ready-for`, the three-state assignee slot, the unconditional
  flip, the audience-flip owner, the marker-namespace partition, the `20`/`21`
  overlap, the verdict-marker edits** — each grounding bullet restates its own
  rule in the same line.
- **The story-harvest example** — rewritten as "a value carrying a parenthetical
  ticket reference silently claimed a story id no epic declared", which is the
  defect without the digits.
- **Both contracts' `**Authoring brief:**` header entry** — a link to the ticket
  each contract was derived from, which resolves nowhere else. Removing it
  orphaned four sentences that still called that document "the brief", so those
  paragraphs were restated in the repair round: the defect-enum paragraph now
  stands on the table and the shipped enum (fourteen types plus `ZERO_SCOPE` as
  exit `7`), and `plan-epic`'s ledger disambiguation says "this contract" —
  "the brief" elsewhere in that file means the enrichment envelope, so the
  anaphor had started pointing at the wrong noun. The paragraph's reconciliation
  of a ten-name list against the live fifteen went with the brief, since the
  list it reconciled is no longer named anywhere.

## The config row

`plugin-planning` stays in `unmigrated`, ratcheted `269` → `21`, with a `why`
naming #8310. All 21 residual hits are stderr lines the shipped `ledger` and
`plan` verbs print, quoted verbatim in the Errors tables and worked examples.
Their source strings live in `packages/fabrika-cli/src/ledger/` and
`packages/fabrika-cli/src/plan/`, both of which #8310 owns; rewriting the pin
first would make the contract quote a line no verb prints. No other row moved,
and no `exempt` row was added.

## Checks

`fabrika guard portability-guard check` clean · `fabrika guard skill-lint check`
clean · `fabrika build check --surface prose` green.

## Deviations

- **Scope narrowing** — **Said:** #8297's criteria ask for the unit's
  `unmigrated` row lowered to zero and removed. **Did:** ratcheted it to 21
  instead. **Why:** the 21 remaining hits sit inside verbatim quotes of stderr
  lines the shipped verbs print, whose source strings are #8310's to rewrite;
  changing the pin here would make the contract quote a line no verb prints.
  **Disposition:** recorded as an `unmigrated` row at its exact count with a
  `why` naming #8310, per the driver's ruling on epic #8281.
- **Out-of-scope change** — **Said:** strip references from the two skills.
  **Did:** also renumbered the worked examples' bare operands, run keys and JSON
  values, which carry no reference the guard can see. **Why:** shrinking only the
  `#`-prefixed numbers leaves an example whose epic is a four-digit number and
  whose children are single digits; the sibling repair on the `build` contract
  set the renumber-as-a-unit precedent. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about doc anchors. **Did:**
  dropped the §11 fragment from two links rather than renaming the heading it
  points at. **Why:** the heading lives in `claude-plugins/fabrika/docs/`,
  outside this unit, and eight other files link the same anchor.
  **Disposition:** stated here; the links still resolve to the document and keep
  `§11` in their text.
- **Guard or gate bypassed** — **Said:** push through `fabrika build push`.
  **Did:** on the first push only, ran `git push` with the pre-push hook
  disabled, then `fabrika build push` for its verdict. **Why:** the hook killed
  `build push` on SIGPIPE. **Disposition:** the verb re-read the remote ref and
  answered `PUSH-VERDICT: MOVED`. The repair round's push ran through
  `fabrika build push --force-with-lease` with the hook on and needed no bypass.
- **Out-of-scope change** — **Said:** the repair round names one finding.
  **Did:** also reflowed roughly ten mid-paragraph lines the sweep left at 16–60
  columns. **Why:** the review named it as worth a pass while the finding was
  being repaired. **Disposition:** stated here; no wording changed, only wrap
  points, except the two restated paragraphs above.
