### PR TITLE
fix: Pi streaming projection landed behind streamPartialText, but no config path reaches the flag

### DIFF
--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -106,6 +106,11 @@ export interface PiAiAgentOptions {
 	 * Pi's own (`$PI_AGENT_DIR`, else `~/.pi/agent`).
 	 */
 	readonly agentDir?: string;
+	/**
+	 * Project the reply still being written, so the window shows text as the model writes it rather
+	 * than when the turn ends. Absent is off, which is the shape every caller had before this key.
+	 */
+	readonly streamPartialText?: boolean;
 }
 
 type EventQueue = Queue.Queue<AgentEvent, TransportError | Cause.Done>;
@@ -663,6 +668,9 @@ const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost> =>
 				agentDir,
 				...(options.sessionDir === undefined ? {} : {sessionDir: options.sessionDir}),
 				...(options.projectRoot === undefined ? {} : {projectRoot: options.projectRoot}),
+				...(options.streamPartialText === undefined
+					? {}
+					: {streamPartialText: options.streamPartialText}),
 			});
 		}),
 	);

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -73,16 +73,17 @@ export const itemOf = (item: PiTranscriptItem): TranscriptItem => {
 				text: textOf(item.content),
 			};
 		case "assistant": {
-			const text = textOf(item.content);
-			return item.status === "aborted"
-				? {
-						kind: "assistant",
-						id: itemId(item.id),
-						timestamp: item.timestamp,
-						text,
-						interrupted: true,
-					}
-				: {kind: "assistant", id: itemId(item.id), timestamp: item.timestamp, text};
+			const row = {
+				kind: "assistant" as const,
+				id: itemId(item.id),
+				timestamp: item.timestamp,
+				text: textOf(item.content),
+			};
+			if (item.status === "aborted") return {...row, interrupted: true};
+			// `streaming` is the reply mid-flight (`../server/transcript.ts`). The marker is what
+			// keeps it out of the store and tells the window the text is still growing; the settled
+			// revision arrives under this same id and carries none, which is what drops it.
+			return item.status === "streaming" ? {...row, partial: true} : row;
 		}
 		case "tool":
 			return {

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -15,6 +15,7 @@ import {
 	type AiAgentSessionMsg,
 	type AiAgentSessionState,
 	aiAgentSessionMachine,
+	holdsPartialItem,
 	initialState,
 } from "../../ai-agent/core/index.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
@@ -66,6 +67,30 @@ const assistant = (text: string, total = 0): PiTranscriptItem => ({
 	],
 	model: {provider: "faux", id: "faux-1"},
 	usage: usage(total),
+	timestamp: 11,
+	status: "complete",
+	stopReason: "stop",
+});
+
+/**
+ * The same turn twice: mid-flight, then settled. Pi ids items positionally over
+ * `[...messages, streaming]` (`../server/transcript.ts`), and the in-flight message lands on
+ * `messages` under the index it already occupied — so the pair shares one id by construction.
+ */
+const streamingAssistant = (text: string): PiTranscriptItem => ({
+	id: "item-1",
+	role: "assistant",
+	content: [{type: "text", text}],
+	model: {provider: "faux", id: "faux-1"},
+	timestamp: 11,
+	status: "streaming",
+});
+
+const settledAssistant = (text: string): PiTranscriptItem => ({
+	id: "item-1",
+	role: "assistant",
+	content: [{type: "text", text}],
+	model: {provider: "faux", id: "faux-1"},
 	timestamp: 11,
 	status: "complete",
 	stopReason: "stop",
@@ -138,6 +163,28 @@ describe("one wire item as a port item", () => {
 			text: "half a th",
 			interrupted: true,
 		});
+	});
+
+	it("marks a reply still being written, and drops the marker when it settles", () => {
+		const inFlight = itemOf(streamingAssistant("hi"));
+		const settled = itemOf(settledAssistant("hi back"));
+		expect(inFlight).toEqual({
+			kind: "assistant",
+			id: "item-1",
+			timestamp: 11,
+			text: "hi",
+			partial: true,
+		});
+		expect(settled).toEqual({kind: "assistant", id: "item-1", timestamp: 11, text: "hi back"});
+		expect(settled.id, "the settled turn lands under a second id and the window keeps both").toBe(
+			inFlight.id,
+		);
+		expect("partial" in settled).toBe(false);
+	});
+
+	it("leaves no partial on a transcript nothing is in flight in", () => {
+		const items = [user, settledAssistant("hi back"), settledTool].flatMap(itemsOf);
+		expect(items.some((item) => "partial" in item)).toBe(false);
 	});
 
 	it("keys a tool row by its call id and folds the three wire statuses", () => {
@@ -241,6 +288,58 @@ describe("one revision folded into events", () => {
 			{kind: "item", item: itemOf(settledTool)},
 			{kind: "phase", phase: "ready"},
 		]);
+	});
+});
+
+/**
+ * What the streaming marker buys once it reaches the core: the in-flight row supersedes itself
+ * under one id, and the tail holding it is a state `checkpointWorthy` refuses to write (#8170).
+ * `holdsPartialItem` is the generic rule and needs no Pi arm — this pins that Pi now trips it.
+ */
+describe("a Pi reply arriving as it is written", () => {
+	const machine = aiAgentSessionMachine({cwd: "/workspace"});
+
+	const fold = (
+		state: AiAgentSessionState,
+		events: ReadonlyArray<AgentEvent>,
+	): AiAgentSessionState =>
+		events.reduce(
+			(carried, event) =>
+				applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(
+					machine,
+					carried,
+					{type: "event", sessionId: "session-7602", event},
+				)[0],
+			state,
+		);
+
+	const opened: AiAgentSessionState = {
+		...initialState("/workspace"),
+		phase: "ready",
+		sessionId: "session-7602",
+	};
+
+	const rows = (folded: ReturnType<typeof eventsOf>) =>
+		folded.events.flatMap((event) => (event.kind === "item" ? [event.item] : []));
+
+	it("supersedes the partial row rather than appending the settled one beside it", () => {
+		const first = eventsOf(emptyProjection, snapshot([user, streamingAssistant("hi")], "turn"));
+		const second = eventsOf(first.next, snapshot([user, settledAssistant("hi back")], "idle", 2));
+		expect(rows(first).map((item) => item.id)).toEqual(["item-0", "item-1"]);
+		expect(rows(first).at(-1)).toMatchObject({partial: true});
+		expect(rows(second).map((item) => item.id)).toEqual(["item-1"]);
+		expect(rows(second).some((item) => "partial" in item)).toBe(false);
+		expect(
+			fold(fold(opened, first.events), second.events).transcript.items.map((i) => i.id),
+		).toEqual(["item-0", "item-1"]);
+	});
+
+	it("keeps the tail out of the store while the reply grows, and lets it in once it settles", () => {
+		const first = eventsOf(emptyProjection, snapshot([user, streamingAssistant("hi")], "turn"));
+		const second = eventsOf(first.next, snapshot([user, settledAssistant("hi back")], "idle", 2));
+		const growing = fold(opened, first.events);
+		expect(holdsPartialItem(growing)).toBe(true);
+		expect(holdsPartialItem(fold(growing, second.events))).toBe(false);
 	});
 });
 

--- a/apps/tuval/src/pi/program.unit.test.ts
+++ b/apps/tuval/src/pi/program.unit.test.ts
@@ -15,7 +15,12 @@ import {pathToFileURL} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
 import {Context, Effect, Layer, Redacted} from "effect";
 import {afterAll, expect} from "vitest";
-import {type AiAgentSessionState, isAiAgentSessionState} from "../ai-agent/core/index.ts";
+import {
+	type AiAgentSessionState,
+	initialState,
+	isAiAgentSessionState,
+} from "../ai-agent/core/index.ts";
+import {ItemId, type TranscriptItem} from "../ai-agent/ports/index.ts";
 import {checkpointFields} from "../ai-agent/restore/index.ts";
 import {ScriptedAiAgent} from "../ai-agent/service/index.ts";
 import {projectConfig} from "../boot.ts";
@@ -26,10 +31,15 @@ import {ProcessId} from "../process/process.ts";
 import {ProgramId} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
 import {programEntries, showsInAWindow} from "../shell/picker/entries.ts";
-import {PI_SESSION_PROGRAM, piSessionProgram, projectRootOf} from "./program.ts";
+import {
+	PI_SESSION_PROGRAM,
+	type PiSessionProgramOptions,
+	piSessionProgram,
+	projectRootOf,
+} from "./program.ts";
 import {PI_CHAT_WINDOW_REF} from "./renderer-ref.ts";
 import {makeScriptedHost} from "./server/fixtures.ts";
-import {PiServerService} from "./server/index.ts";
+import {type AgentSessionHostOptions, PiServerService} from "./server/index.ts";
 
 const tempDirs: string[] = [];
 
@@ -98,6 +108,40 @@ describe("the pi-session program row", () => {
 			assert.isNull((state as AiAgentSessionState).sessionId);
 		}).pipe(Effect.scoped, Effect.provide(kernel(CWD_UNDER_TEST))),
 	);
+
+	it("lets a desk config ask for the reply as it is written", () => {
+		const pi = {streamPartialText: true} satisfies NonNullable<PiSessionProgramOptions["pi"]>;
+		// The key a config writes is the host's own option, not a second flag beside it: this is the
+		// whole config path, since the row spreads `pi` straight onto `PiAiAgent.layer`'s options.
+		const forwarded: Pick<AgentSessionHostOptions, "streamPartialText"> = pi;
+		assert.strictEqual(forwarded.streamPartialText, true);
+		assert.strictEqual(
+			piSessionProgram({cwd: tempProject(), pi}).id,
+			ProgramId.make(PI_SESSION_PROGRAM),
+		);
+	});
+
+	/**
+	 * #8170's rule, inherited rather than restated: `aiAgentProgram` sets
+	 * `checkpointWorthy: (state) => !holdsPartialItem(state)`, so a Pi reply mid-flight is a state
+	 * the row refuses to write the moment `itemOf` marks it partial.
+	 */
+	it("writes no checkpoint while a reply is still being written", () => {
+		const declared = row(tempProject());
+		const base = initialState(CWD_UNDER_TEST);
+		const holding = (item: TranscriptItem): AiAgentSessionState => ({
+			...base,
+			transcript: {...base.transcript, items: [item]},
+		});
+		const settled = {
+			kind: "assistant",
+			id: ItemId.make("item-1"),
+			timestamp: 11,
+			text: "hi there",
+		} as const satisfies TranscriptItem;
+		assert.isFalse(declared.checkpointWorthy?.(holding({...settled, partial: true})));
+		assert.isTrue(declared.checkpointWorthy?.(holding(settled)));
+	});
 
 	it("reads the project root back off the config module's own location", () => {
 		const project = tempProject();

--- a/apps/tuval/src/pi/server/projections.unit.test.ts
+++ b/apps/tuval/src/pi/server/projections.unit.test.ts
@@ -195,6 +195,66 @@ describe("projectTranscript over a reply still being written", () => {
 		assert.strictEqual(final[1]?.id, "item-1");
 	});
 
+	/**
+	 * The turn #8390 recorded: an adapter that settles `stopReason` before the stream ends. The
+	 * OpenAI-Responses one assigns `"stop"` at a `message` item's `final_answer` phase and keeps
+	 * pushing deltas onto the same object, and Pi's own loop stops an assistant message on
+	 * `"toolUse"` and then opens another. Every revision here is one the host published while
+	 * `AgentState.streamingMessage` was still set, so every one of them has to be marked.
+	 */
+	it("marks every revision it is handed as in flight, whatever the stop reason says", () => {
+		const settling = (text: string, stopReason: string): SourceMessage => ({
+			role: "assistant",
+			content: [{type: "text", text}],
+			provider: "faux",
+			model: "faux-1",
+			stopReason,
+			timestamp: 2,
+		});
+		const toolCall: SourceMessage = {
+			role: "assistant",
+			content: [{type: "toolCall", id: "call-1", name: "read_file", arguments: {path: "a.md"}}],
+			provider: "faux",
+			model: "faux-1",
+			stopReason: "toolUse",
+			timestamp: 2,
+		};
+		const toolResult: SourceMessage = {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read_file",
+			content: [{type: "text", text: "the file"}],
+			isError: false,
+			timestamp: 3,
+		};
+
+		const midTurn: ReadonlyArray<readonly [ReadonlyArray<SourceMessage>, SourceMessage]> = [
+			[[asked], growing("hel")],
+			[[asked], settling("hello there", "stop")],
+			[[asked], settling("hello there, reading", "toolUse")],
+			[[asked, toolCall, toolResult], growing("the file")],
+			[[asked, toolCall, toolResult], settling("the file says hi", "stop")],
+		];
+
+		for (const [messages, streaming] of midTurn) {
+			const items = projectTranscript(messages, streaming);
+			const last = items.at(-1);
+			assert.deepInclude(
+				last,
+				{role: "assistant", status: "streaming"},
+				`a revision published mid-turn read as settled: ${JSON.stringify(last)}`,
+			);
+			assert.notProperty(last, "stopReason");
+		}
+
+		// The same message once `message_end` clears `streamingMessage`: settled, and no longer
+		// keyed as in flight, so its own stop reason is what speaks.
+		assert.deepInclude(projectTranscript([asked, landed]).at(-1), {
+			status: "complete",
+			stopReason: "stop",
+		});
+	});
+
 	it("leaves the transcript untouched when nothing is in flight", () => {
 		assert.deepStrictEqual(projectTranscript([asked, landed], undefined), [
 			...projectTranscript([asked, landed]),

--- a/apps/tuval/src/pi/server/projections.unit.test.ts
+++ b/apps/tuval/src/pi/server/projections.unit.test.ts
@@ -244,6 +244,23 @@ describe("streamingMessage", () => {
 		);
 	});
 
+	it("leaves the projected transcript the settled messages alone when it is off", () => {
+		const asked: SourceMessage = {
+			role: "user",
+			content: [{type: "text", text: "say hello"}],
+			timestamp: 1,
+		};
+		const items = projectTranscript(
+			[asked, {...inFlight, content: [{type: "text", text: "hello there"}], stopReason: "stop"}],
+			streamingMessage({}, {streamingMessage: inFlight}),
+		);
+		assert.deepStrictEqual(
+			items.map((item) => item.id),
+			["item-0", "item-1"],
+		);
+		assert.isFalse(items.some((item) => "status" in item && item.status === "streaming"));
+	});
+
 	it("is the in-flight message when the flag is on", () => {
 		assert.strictEqual(
 			streamingMessage({streamPartialText: true}, {streamingMessage: inFlight}),

--- a/apps/tuval/src/pi/server/transcript.ts
+++ b/apps/tuval/src/pi/server/transcript.ts
@@ -141,6 +141,21 @@ interface AssistantStatus {
 	readonly errorMessage?: string;
 }
 
+/**
+ * The status of a reply this host was handed as the one still being written.
+ *
+ * Not read off `stopReason`, because that field is the provider's and it settles before the stream
+ * does: the OpenAI-Responses adapter assigns `output.stopReason = "stop"` the moment a `message`
+ * item reports `phase: "final_answer"`, on the same live object every later delta mutates
+ * (`@earendil-works/pi-ai` `dist/api/openai-responses-shared.js:324-327`, and `output` is what each
+ * `partial` carries). Every delta after that point would project as a finished reply — unmarked,
+ * so `checkpointWorthy` saves a half-written answer once per delta (#8390, which is #8160's own
+ * no-go). Being handed the message at all is the stronger fact: `AgentState.streamingMessage` is
+ * set from `message_start` and cleared at `message_end` (`pi-agent-core` `dist/agent.js:382-390`),
+ * so a message reaching here is mid-flight whatever its `stopReason` says.
+ */
+const IN_FLIGHT: AssistantStatus = {status: "streaming"};
+
 const assistantStatus = (stopReason: string, errorMessage: string | undefined): AssistantStatus => {
 	switch (stopReason) {
 		case "stop":
@@ -170,15 +185,17 @@ const assistantStatus = (stopReason: string, errorMessage: string | undefined): 
  * rather than being dropped, because dropping it would leave the client a shorter transcript than
  * the session has.
  *
- * `streaming` is the reply still being written, projected as the last item. It carries Pi's
- * `pending` stop reason, which is the wire's `status: "streaming"` — the marker that tells a
- * client this text is not the whole reply.
+ * `streaming` is the reply still being written, projected as the last item under `status:
+ * "streaming"` — the marker that tells a client this text is not the whole reply, and the one that
+ * keeps it out of the store. That last slot is the only thing that decides the marker; see
+ * `IN_FLIGHT` for why the message's own stop reason cannot.
  */
 export const projectTranscript = (
 	messages: ReadonlyArray<SourceMessage>,
 	streaming?: SourceMessage | undefined,
 ): ReadonlyArray<TranscriptItem> => {
 	const all = streaming === undefined ? messages : [...messages, streaming];
+	const inFlight = streaming === undefined ? -1 : all.length - 1;
 	const toolInputs = new Map<string, Record<string, unknown>>();
 	for (const message of all) {
 		if (message.role !== "assistant") continue;
@@ -208,7 +225,9 @@ export const projectTranscript = (
 				...(message.responseModel === undefined ? {} : {responseModel: message.responseModel}),
 				...(message.usage === undefined ? {} : {usage: projectUsage(message.usage)}),
 				timestamp: message.timestamp,
-				...assistantStatus(message.stopReason, message.errorMessage),
+				...(index === inFlight
+					? IN_FLIGHT
+					: assistantStatus(message.stopReason, message.errorMessage)),
 			} as TranscriptItem);
 			return;
 		}


### PR DESCRIPTION
Pi's server could already project the reply as it is written, and nothing above it could turn that
on. This adds the one key that reaches the flag, repairs the mapper that dropped the streaming
status on the way up (#8251), and repairs the leak the hand-verification found once the flag was on
(#8390, folded in here — see the second deviation).

Three source changes:

- `PiAiAgentOptions` gains `readonly streamPartialText?: boolean` (absent is off) and spreads it
  conditionally onto `agentSessionHostLayer({modelRuntime, agentDir, …})`, beside `sessionDir` and
  `projectRoot`. Since `piSessionProgram` forwards `pi` straight onto `PiAiAgent.layer`, a desk
  config can now write `piSessionProgram({cwd, pi: {streamPartialText: true}})`. No committed
  config is flipped on.
- `itemOf` maps a wire assistant item with `status: "streaming"` to a port item carrying
  `partial: true`. The `aborted` → `interrupted: true` arm is unchanged.
- `projectTranscript` marks the message it was handed as the in-flight one `streaming` by its slot,
  rather than deriving that from the message's own `stopReason`.

That third one is #8390. `stopReason` is the provider's field and it settles before the stream
does: the OpenAI-Responses adapter assigns `output.stopReason = "stop"` as soon as a `message` item
reports `phase: "final_answer"`, on the same live object every later delta mutates
(`@earendil-works/pi-ai` `dist/api/openai-responses-shared.js:324-327`). Every delta after that
point projected as a finished reply, so `itemOf` set no `partial`, so `checkpointWorthy` saved a
half-written answer once per delta — 47 states in one 9 s turn on the scratch desk. Pi's own loop
does the same thing on a shorter fuse, stopping an assistant message on `toolUse` and opening
another. Being handed the message is the stronger fact: `AgentState.streamingMessage` is set at
`message_start` and cleared at `message_end` (`pi-agent-core` `dist/agent.js:382-390`), so anything
reaching that slot is mid-flight whatever its stop reason says.

No new checkpoint rule: `aiAgentProgram` already sets `checkpointWorthy: (state) =>
!holdsPartialItem(state)`, and `holdsPartialItem` is kind-blind, so the moment `itemOf` sets the
marker Pi is covered by #8170's rule. The tests prove that rather than restate it.

Tests, all hand-built typed wire values in each file's existing style:

- `items.unit.test.ts` — the streaming item yields `partial: true`; the settled item that follows
  carries the same id and no marker; the fold emits one row across both revisions rather than two;
  a Pi tail holding the partial makes `holdsPartialItem` true and false once it settles.
- `program.unit.test.ts` — the `pi` key a desk config writes is assignable to
  `AgentSessionHostOptions["streamPartialText"]`, and the `pi-session` row's own
  `checkpointWorthy` refuses a state holding a partial.
- `projections.unit.test.ts` — with the flag off, `streamingMessage` is `undefined` and the
  projected transcript is the settled messages alone; and the #8390 turn (deltas, a stop reason
  that settles mid-stream, a tool call, more deltas) has every mid-turn revision marked
  `streaming`, with the settled projection after `message_end` still reading `complete`.

Ran the three touched test files plus every unit test under `src/pi/server` and `src/pi/ai-agent`
(114 pass), and the tuval package typecheck.

Fixes #8380

## Deviations

- **Out-of-scope change** — **Said:** the criteria name `items.unit.test.ts` and the two source
  files. **Did:** also extended `apps/tuval/src/pi/program.unit.test.ts` and
  `apps/tuval/src/pi/server/projections.unit.test.ts`. **Why:** criteria 3, 6 and 7 are about the
  config path, the inherited checkpoint rule and the flag-off projection, and each is only
  observable in the file that owns that seam. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8380 names the config path and the mapper. **Did:** also
  changed `apps/tuval/src/pi/server/transcript.ts` so the in-flight message is marked by its slot
  rather than by `stopReason`. **Why:** hand-verifying this PR on a scratch desk found #8390 — with
  the flag on, the checkpoint was still rewritten mid-reply on unmarked revisions, which is the
  containment #8160 asked for being bypassed. The flag #8380 ships is not safe to turn on without
  it, so it lands here rather than beside it. **Disposition:** stated here.
- **Declined guidance** — **Said:** the repair brief asked for a second closing keyword aimed at
  #8390 in this body. **Did:** named that issue in prose instead. **Why:** `build pr-body` refuses
  a closing keyword aimed at any issue but the one this PR serves (exit 4), and this PR serves
  #8380. **Disposition:** stated here; the second issue's own state is triage's to settle once
  this lands.
