### PR TITLE
feat: TuvalAiAgent port: every transcript item kind carries the parent tag, not ToolItem alone

### DIFF
--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -38,6 +38,16 @@ interface ItemBase {
 	readonly id: ItemId;
 	/** Epoch milliseconds. A wall-clock number, so no backend clock type reaches the window. */
 	readonly timestamp: number;
+	/**
+	 * The id of the tool call this item ran *inside*, when a backend nests calls — an agent-spawning
+	 * tool whose worker prompts, reasons and calls tools of its own. Absent means the item is the
+	 * agent's own, which is every item a backend with no nesting concept ever emits.
+	 *
+	 * On the base rather than on the tool kind alone: a nested worker's prose is as much the worker's
+	 * as its calls are, and a window handed the tag on calls only cannot tell a worker's reply or
+	 * reasoning from the agent's own.
+	 */
+	readonly parentId?: ItemId;
 }
 
 /**
@@ -65,18 +75,12 @@ export interface AssistantItem extends ItemBase {
 	readonly partial?: boolean;
 }
 
-/**
- * `parentId` is the id of the tool call this one ran *inside*, when a backend nests calls — an
- * agent-spawning tool whose worker makes calls of its own. Absent means the call is the agent's
- * own, which is every call a backend with no nesting concept ever emits.
- */
 export interface ToolItem extends ItemBase {
 	readonly kind: "tool";
 	readonly name: string;
 	readonly input: JsonValue;
 	readonly result: ToolResult;
 	readonly status: ToolStatus;
-	readonly parentId?: ItemId;
 }
 
 /**
@@ -166,6 +170,8 @@ const isId = (value: unknown): value is ItemId => typeof value === "string" && v
 const isOptionalFlag = (value: unknown): boolean =>
 	value === undefined || typeof value === "boolean";
 
+const isOptionalId = (value: unknown): boolean => value === undefined || isId(value);
+
 export const isNonNegativeInteger = (value: unknown): boolean =>
 	typeof value === "number" && Number.isInteger(value) && value >= 0;
 
@@ -178,9 +184,17 @@ const isToolResult = (value: unknown): value is ToolResult =>
 
 const statuses: ReadonlySet<string> = new Set<ToolStatus>(["running", "ok", "error"]);
 
-/** The port predicate for one item: identity, clock, kind, and the tool result's own bound. */
+/**
+ * The port predicate for one item: identity, clock, parent tag, kind, and the tool result's own
+ * bound. The parent tag is read once ahead of the switch, because every kind may carry one.
+ */
 export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
-	if (!Predicate.isObject(value) || !isId(value.id) || !Number.isFinite(value.timestamp))
+	if (
+		!Predicate.isObject(value) ||
+		!isId(value.id) ||
+		!Number.isFinite(value.timestamp) ||
+		!isOptionalId(value.parentId)
+	)
 		return false;
 	switch (value.kind) {
 		case "user":
@@ -205,8 +219,7 @@ export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 				isJsonValue(value.input) &&
 				isToolResult(value.result) &&
 				typeof value.status === "string" &&
-				statuses.has(value.status) &&
-				(value.parentId === undefined || isId(value.parentId))
+				statuses.has(value.status)
 			);
 		default:
 			return false;

--- a/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
@@ -31,16 +31,11 @@ const tool: TranscriptItem = {
 	status: "running",
 };
 
+const kinds: ReadonlyArray<TranscriptItem> = [user, assistant, system, tool, thinking, compaction];
+
 describe("transcript item union", () => {
 	it("admits all six kinds", () => {
-		expect([user, assistant, system, tool, thinking, compaction].map(isTranscriptItem)).toEqual([
-			true,
-			true,
-			true,
-			true,
-			true,
-			true,
-		]);
+		expect(kinds.map(isTranscriptItem)).toEqual(kinds.map(() => true));
 	});
 
 	it("admits an assistant turn the operator cut short", () => {
@@ -94,12 +89,22 @@ describe("transcript item union", () => {
 		expect(isTranscriptItem({...tool, status: "pending"})).toBe(false);
 	});
 
-	it("takes a tool item with or without a parent, and refuses an empty parent id", () => {
-		expect(isTranscriptItem({...tool, parentId: "toolu_agent"})).toBe(true);
-		expect(isTranscriptItem({...tool, parentId: undefined})).toBe(true);
-		expect(isTranscriptItem({...tool, parentId: ""})).toBe(false);
-		expect(isTranscriptItem({...tool, parentId: 7})).toBe(false);
-		expect(isTranscriptItem({...tool, parentId: null})).toBe(false);
+	it("takes an item of any kind with or without a parent", () => {
+		expect(kinds.map((item) => isTranscriptItem({...item, parentId: "toolu_agent"}))).toEqual(
+			kinds.map(() => true),
+		);
+		expect(kinds.map((item) => isTranscriptItem({...item, parentId: undefined}))).toEqual(
+			kinds.map(() => true),
+		);
+	});
+
+	it("refuses a parent tag that is not an id, in every kind's arm", () => {
+		for (const parentId of ["", 7, null]) {
+			expect(
+				kinds.map((item) => isTranscriptItem({...item, parentId})),
+				String(parentId),
+			).toEqual(kinds.map(() => false));
+		}
 	});
 
 	it("refuses a tool result past the per-item byte bound, however it was built", () => {

--- a/apps/tuval/src/protocol/session-transcript.ts
+++ b/apps/tuval/src/protocol/session-transcript.ts
@@ -64,6 +64,7 @@ export const UserItem = Schema.Struct({
 	timestamp: Timestamp,
 	text: Schema.String,
 	local: Schema.optionalKey(Schema.Boolean),
+	parentId: Schema.optionalKey(ItemId),
 });
 
 export const AssistantItem = Schema.Struct({
@@ -72,6 +73,7 @@ export const AssistantItem = Schema.Struct({
 	timestamp: Timestamp,
 	text: Schema.String,
 	interrupted: Schema.optionalKey(Schema.Boolean),
+	parentId: Schema.optionalKey(ItemId),
 });
 
 export const ToolItem = Schema.Struct({
@@ -90,6 +92,7 @@ export const ThinkingItem = Schema.Struct({
 	id: ItemId,
 	timestamp: Timestamp,
 	text: Schema.String,
+	parentId: Schema.optionalKey(ItemId),
 });
 
 export const CompactionItem = Schema.Struct({
@@ -97,6 +100,7 @@ export const CompactionItem = Schema.Struct({
 	id: ItemId,
 	timestamp: Timestamp,
 	text: Schema.String,
+	parentId: Schema.optionalKey(ItemId),
 });
 
 export const SystemItem = Schema.Struct({
@@ -105,6 +109,7 @@ export const SystemItem = Schema.Struct({
 	timestamp: Timestamp,
 	text: Schema.String,
 	detail: Schema.optionalKey(Schema.String),
+	parentId: Schema.optionalKey(ItemId),
 });
 
 export const TranscriptItem = Schema.Union([

--- a/apps/tuval/src/protocol/session-transcript.unit.test.ts
+++ b/apps/tuval/src/protocol/session-transcript.unit.test.ts
@@ -32,12 +32,32 @@ const admitted: ReadonlyArray<readonly [string, TranscriptItem]> = [
 		"an interrupted assistant turn",
 		{kind: "assistant", id: ItemId.make("a2"), timestamp: AT, text: "hi", interrupted: true},
 	],
+	[
+		"an assistant turn a subagent wrote",
+		{
+			kind: "assistant",
+			id: ItemId.make("a3"),
+			timestamp: AT,
+			text: "hi",
+			parentId: ItemId.make("t1"),
+		},
+	],
 	["a system line", {kind: "system", id: ItemId.make("s1"), timestamp: AT, text: "resumed"}],
 	[
 		"a system line with a folded detail",
 		{kind: "system", id: ItemId.make("s2"), timestamp: AT, text: "hook ran", detail: "exit 0"},
 	],
 	["a thinking row", {kind: "thinking", id: ItemId.make("th1"), timestamp: AT, text: "weighing"}],
+	[
+		"a thinking row a subagent reasoned out",
+		{
+			kind: "thinking",
+			id: ItemId.make("th2"),
+			timestamp: AT,
+			text: "weighing",
+			parentId: ItemId.make("t1"),
+		},
+	],
 	[
 		"a compaction marker",
 		{kind: "compaction", id: ItemId.make("c1"), timestamp: AT, text: "context compacted"},

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -140,16 +140,24 @@ export const mergeOlder = (
 	return fresh.length === 0 ? held : [...fresh, ...held];
 };
 
-/** The call a tool row ran inside, when the backend marked one. Nothing else nests. */
-const parentOf = (item: TranscriptItem): ItemId | undefined =>
-	item.kind === "tool" ? item.parentId : undefined;
+/**
+ * The ids a fold may hang under. A session notice is not one: it renders as part of a run, with no
+ * disclosure and no depth of its own, so a row naming one as its parent is an orphan rather than a
+ * row hidden behind a head that can never open.
+ */
+const foldHeads = (items: ReadonlyArray<TranscriptItem>): ReadonlySet<string> =>
+	new Set(items.flatMap((item) => (item.kind === "system" ? [] : [item.id])));
+
+/** The head this row hangs under: the call it ran inside, when that call is in this list too. */
+const headOf = (item: TranscriptItem, heads: ReadonlySet<string>): ItemId | undefined =>
+	item.parentId !== undefined && heads.has(item.parentId) ? item.parentId : undefined;
 
 /**
  * Append a session notice, joining the run already at the end of the list when there is one.
  *
- * Only `parentOf` decides nesting and only a tool row answers it, so a session notice is always a
- * root at depth zero heading no fold — which is what makes a plain "is the last row a run" test the
- * whole of adjacency, and what makes the dropped `depth`/`nestedIds` fields nothing lost.
+ * A notice heads no fold — `foldHeads` refuses it one — and its own depth is never drawn, which is
+ * what makes a plain "is the last row a run" test the whole of adjacency, and what makes the
+ * dropped `depth`/`nestedIds` fields nothing lost.
  */
 const pushSession = (rows: Array<ChatRow>, item: SystemItem): void => {
 	const last = rows[rows.length - 1];
@@ -167,7 +175,7 @@ const pushSession = (rows: Array<ChatRow>, item: SystemItem): void => {
  * collision is `unheld`'s — id, then text against a turn the tail still holds as `local` — so the
  * surviving row keeps the `local:` id it has had since the send and its `rowKey` does not move.
  *
- * A tool row naming a parent that is also in this list is **folded under it** (founder ruling,
+ * A row naming a parent that is also in this list is **folded under it** (founder ruling,
  * 2026-09-05): the group head carries the count and the folded rows appear only while it is
  * unfolded, which is what keeps a fifty-call subagent from flooding the window. A row whose parent
  * is not in the list — its group head is older than the pages walked back to — stays where it is,
@@ -185,11 +193,11 @@ const pushSession = (rows: Array<ChatRow>, item: SystemItem): void => {
 export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	const items = [...unheld(input.tail, input.older), ...input.tail];
 	const unfolded = input.unfolded ?? new Set<string>();
-	const present = new Set(items.map((item) => item.id));
+	const heads = foldHeads(items);
 	const folded = new Map<string, Array<TranscriptItem>>();
 	for (const item of items) {
-		const parent = parentOf(item);
-		if (parent === undefined || !present.has(parent)) continue;
+		const parent = headOf(item, heads);
+		if (parent === undefined) continue;
 		const group = folded.get(parent);
 		if (group === undefined) folded.set(parent, [item]);
 		else group.push(item);
@@ -198,10 +206,7 @@ export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	if (!input.atOldest && items.length > 0) {
 		rows.push(input.loading ? {kind: "loading"} : {kind: "older", items: input.omitted});
 	}
-	const roots = items.filter((item) => {
-		const parent = parentOf(item);
-		return parent === undefined || !present.has(parent);
-	});
+	const roots = items.filter((item) => headOf(item, heads) === undefined);
 	const reachable = new Set<string>();
 	const mark = (item: TranscriptItem): void => {
 		if (reachable.has(item.id)) return;
@@ -228,7 +233,7 @@ export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 		if (!unfolded.has(item.id)) return;
 		for (const child of group) emit(child, depth + 1);
 	};
-	for (const item of roots) emit(item, parentOf(item) === undefined ? 0 : 1);
+	for (const item of roots) emit(item, item.parentId === undefined ? 0 : 1);
 	for (const item of items) {
 		if (!reachable.has(item.id)) emit(item, 1);
 	}

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -7,7 +7,16 @@
 import {describe, expect, it} from "vitest";
 import {promptItem} from "../../ai-agent/core/fold.ts";
 import {planTranscriptPage, planTranscriptWindow} from "../../ai-agent/history/index.ts";
-import {assistantItem, call, systemItem, toolItem, transcriptOf, userItem} from "./chat.testing.ts";
+import {ItemId} from "../../ai-agent/ports/index.ts";
+import {
+	assistantItem,
+	call,
+	systemItem,
+	thinkingItem,
+	toolItem,
+	transcriptOf,
+	userItem,
+} from "./chat.testing.ts";
 import type {ChatRow} from "./rows.ts";
 import {chatRows, mergeOlder, oldestLoadedId, rowIndexOfItem, rowKey} from "./rows.ts";
 
@@ -135,6 +144,41 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 			"free",
 			"a",
 			"b",
+		]);
+	});
+
+	it("folds a subagent's own reply and reasoning under its head, not just its calls", () => {
+		const inside = ItemId.make("agent");
+		const prose = [
+			call("agent", {name: "Agent"}),
+			{...assistantItem("reply"), parentId: inside},
+			{...thinkingItem("weighing"), parentId: inside},
+			call("child", {parentId: "agent"}),
+		];
+		const collapsed = chatRows({...base, tail: prose, atOldest: true});
+		expect(itemIds(collapsed)).toEqual(["agent"]);
+		expect(collapsed[0]?.kind === "item" && collapsed[0].nestedIds).toEqual([
+			"reply",
+			"weighing",
+			"child",
+		]);
+
+		const open = chatRows({...base, tail: prose, atOldest: true, unfolded: new Set(["agent"])});
+		expect(open.flatMap((row) => (row.kind === "item" ? [[row.item.id, row.depth]] : []))).toEqual([
+			["agent", 0],
+			["reply", 1],
+			["weighing", 1],
+			["child", 1],
+		]);
+	});
+
+	it("leaves a row whose parent is a session notice in place rather than behind it", () => {
+		const notice = systemItem("note");
+		const child = call("child", {parentId: "note"});
+		const rows = chatRows({...base, tail: [notice, child], atOldest: true});
+		expect(rows).toEqual([
+			{kind: "session", items: [notice]},
+			{kind: "item", item: child, nestedIds: [], nested: true, depth: 1},
 		]);
 	});
 


### PR DESCRIPTION
Only `ToolItem` carried `parentId`, so a subagent's prose — its reply, its reasoning — could not be told from the agent's own at the port. `chatRows` read that limit directly: `parentOf` answered for a `tool` row and `undefined` for everything else.

`parentId` moves onto `ItemBase`, so every item kind carries it, documented once. Its meaning is unchanged: the id of the tool call this item ran *inside*, absent means the item is the agent's own. `isTranscriptItem` reads the tag once ahead of the switch, so every arm admits a valid one and refuses an empty string, a number or `null`.

In `rows.ts`, `parentOf` is replaced by `headOf`, which reads the tag off any item and only resolves to a head that is in the list. A nested assistant or thinking row now folds under the call that spawned it at the same depth a nested tool row gets. Nothing else about the fold moves: the depth walk, the cycle sweep and #8027's disclosure behave exactly as before, and the existing `rows.unit.test.ts` cases are unchanged.

This is the port half only. The Claude mapper that fills the tag on assistant and thinking items is #8403; `map.ts` is untouched.

Reviewer should look first at `foldHeads` in `rows.ts` and at the two new rows in the wire mirror's `admitted` table.

Fixes #8400

## Deviations

- **Out-of-scope change** — **Said:** #8400 names four files: the port, its test, `rows.ts` and its test. **Did:** also widened `apps/tuval/src/protocol/session-transcript.ts` (the wire codec for the union) with `parentId` on the five other item structs, and added two rows to its `admitted` table in `session-transcript.unit.test.ts`. **Why:** that file's own docblock states it is `TranscriptItem` written as a schema, and its test is the declared anti-drift guard between the two. Widening the port without it leaves a nested assistant or thinking item that the port predicate admits but the wire silently strips — exactly the silent drift that test exists to catch. **Disposition:** landed here, six lines plus two table rows.

- **Out-of-scope change** — **Said:** the fold behaviour does not change in this PR. **Did:** a `SystemItem` can no longer be a fold head (`foldHeads` excludes it), so a row naming a notice as its parent stays at the top level marked nested instead of being folded under it. **Why:** the port change makes a system item nameable as a parent, and `emit` returns early on a notice without emitting its group — so such a child would be marked reachable and then rendered nowhere, dropped from the window silently. The type already says a notice is not a row (`RowItem = Exclude<TranscriptItem, SystemItem>`); this makes the fold agree. The latent case existed before (a tool row could always name a notice's id) but nothing could produce it. **Disposition:** landed here with a test.

- **Known defect left unfixed** — **Said:** nothing. **Did:** left `apps/tuval/src/claude/history/map.ts` alone, so nothing yet writes `parentId` onto an assistant or thinking item. **Why:** that is #8403's whole subject, and the brief scopes this child to the port. **Disposition:** stated here; the widening is inert until #8403 lands.
