### PR TITLE
fix: ui evidence's read-back probe is unauthenticated, so every build-ui lane refuses to attach its captures (the #6520 defect, un-fixed on the ui group)

### DIFF
--- a/packages/fabrika-cli/src/ui/http.ts
+++ b/packages/fabrika-cli/src/ui/http.ts
@@ -102,11 +102,11 @@ const verifyAttachment = async (
 	) {
 		return {_tag: "Failed", reason: "the upload returned no trusted GitHub attachment URL"};
 	}
-	let url = attachment;
+	let url: URL = attachment;
 	let authenticated = true;
 	for (let redirects = 0; redirects <= 20; redirects++) {
 		// Signed asset requests can be GET-only; never forward the GitHub token across origins.
-		const probe = await attempt(
+		const probe: Response | Error = await attempt(
 			fetch(url.href, {
 				method: "GET",
 				redirect: "manual",
@@ -117,9 +117,9 @@ const verifyAttachment = async (
 			return {_tag: "Failed", reason: "the hosted attachment GET failed"};
 		}
 		if ([301, 302, 303, 307, 308].includes(probe.status)) {
-			const location = probe.headers.get("location");
+			const location: string | null = probe.headers.get("location");
 			await attempt(probe.body?.cancel() ?? Promise.resolve());
-			const next = location === null ? null : URL.parse(location, url);
+			const next: URL | null = location === null ? null : URL.parse(location, url);
 			if (
 				next === null ||
 				next.protocol !== "https:" ||

--- a/packages/fabrika-cli/src/ui/http.ts
+++ b/packages/fabrika-cli/src/ui/http.ts
@@ -4,7 +4,7 @@
  * Every one of them **verifies its own effect** rather than trusting a status line: the golden fetch
  * hands the bytes back for the caller to hash against the pointer, the store tier PUTs then GETs the
  * same content-addressed URL and hash-compares, and the attachment tier probes every returned URL
- * with a HEAD. That is the whole difference from the upstream capture-side upload, whose failures are
+ * with a GET and compares the PNG bytes. That is the whole difference from the upstream capture-side upload, whose failures are
  * projected away by an error channel typed `never` (#3925): here a failed verification is a value the
  * verb refuses on.
  */
@@ -23,7 +23,7 @@ import {isRecord} from "../io/json.ts";
 import type {Upload, UploadLeg, UploadTarget} from "./evidence-verb.ts";
 import type {FetchLeg} from "./golden-verb.ts";
 import {legFailed} from "./leg-failed.ts";
-import {sha256Of} from "./png.ts";
+import {decodePng, sha256Of} from "./png.ts";
 import {goldenUrl} from "./pointer.ts";
 
 /** Settle a promise into its value or its failure, so no path here needs a `try`. */
@@ -83,8 +83,81 @@ export const storeUpload = (store: string, target: UploadTarget): Effect.Effect<
 		catch: legFailed,
 	}).pipe(Effect.catch((cause) => Effect.succeed<Upload>({_tag: "Failed", reason: cause.reason})));
 
+const verifyAttachment = async (
+	hostedUrl: string,
+	token: string,
+	target: UploadTarget,
+): Promise<Upload> => {
+	const attachment = URL.parse(hostedUrl);
+	if (
+		attachment === null ||
+		attachment.origin !== "https://github.com" ||
+		attachment.username !== "" ||
+		attachment.password !== "" ||
+		attachment.search !== "" ||
+		attachment.hash !== "" ||
+		!/^\/user-attachments\/assets\/[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}$/i.test(
+			attachment.pathname,
+		)
+	) {
+		return {_tag: "Failed", reason: "the upload returned no trusted GitHub attachment URL"};
+	}
+	let url = attachment;
+	let authenticated = true;
+	for (let redirects = 0; redirects <= 20; redirects++) {
+		// Signed asset requests can be GET-only; never forward the GitHub token across origins.
+		const probe = await attempt(
+			fetch(url.href, {
+				method: "GET",
+				redirect: "manual",
+				headers: authenticated ? {authorization: `token ${token}`} : {},
+			}),
+		);
+		if (probe instanceof Error) {
+			return {_tag: "Failed", reason: "the hosted attachment GET failed"};
+		}
+		if ([301, 302, 303, 307, 308].includes(probe.status)) {
+			const location = probe.headers.get("location");
+			await attempt(probe.body?.cancel() ?? Promise.resolve());
+			const next = location === null ? null : URL.parse(location, url);
+			if (
+				next === null ||
+				next.protocol !== "https:" ||
+				next.username !== "" ||
+				next.password !== "" ||
+				redirects === 20
+			) {
+				return {_tag: "Failed", reason: "the hosted attachment GET returned an invalid redirect"};
+			}
+			authenticated = authenticated && next.origin === attachment.origin;
+			url = next;
+			continue;
+		}
+		if (probe.status !== 200) {
+			await attempt(probe.body?.cancel() ?? Promise.resolve());
+			return {_tag: "Failed", reason: `the hosted attachment GET returned HTTP ${probe.status}`};
+		}
+		if (
+			probe.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() !== PNG_CONTENT_TYPE
+		) {
+			await attempt(probe.body?.cancel() ?? Promise.resolve());
+			return {_tag: "Failed", reason: "the hosted attachment GET did not serve image/png"};
+		}
+		const body = await attempt(probe.arrayBuffer());
+		if (body instanceof Error) {
+			return {_tag: "Failed", reason: "the hosted attachment GET body could not be read"};
+		}
+		const bytes = new Uint8Array(body);
+		if (sha256Of(bytes) !== target.sha256 || decodePng(bytes)._tag !== "Image") {
+			return {_tag: "Failed", reason: "the hosted attachment GET did not match the captured PNG"};
+		}
+		return {_tag: "Ok", url: hostedUrl};
+	}
+	return {_tag: "Failed", reason: "the hosted attachment GET exceeded the redirect limit"};
+};
+
 /**
- * Attachment tier: GitHub's user-attachment endpoint, then a HEAD probe of the returned URL.
+ * Attachment tier: GitHub's user-attachment endpoint, then a verified GET of the returned URL.
  *
  * Two facts stated rather than hidden. The endpoint is **undocumented** (ADR 0165's durability
  * caveat rides along — hosted copies are display-grade, the set manifest in the lane scratch is the
@@ -117,27 +190,24 @@ export const attachmentUpload =
 				if (response instanceof Error) {
 					return {
 						_tag: "Failed",
-						reason: `the user-attachments upload failed: ${response.message}`,
+						reason: "the user-attachments upload failed",
 					};
 				}
 				const body = await attempt(response.text());
-				const outcome: UploadOutcome = parseUploadResponse({
-					status: response.status,
-					body: body instanceof Error ? body.message : body,
-				});
+				if (body instanceof Error) {
+					return {_tag: "Failed", reason: "the user-attachments upload response could not be read"};
+				}
+				const outcome: UploadOutcome = parseUploadResponse({status: response.status, body});
 				const hostedUrl = outcome.hostedUrl;
 				if (hostedUrl === null) {
-					return {_tag: "Failed", reason: outcome.uploadError ?? "the upload returned no URL"};
+					return {
+						_tag: "Failed",
+						reason: `the user-attachments upload returned no trusted URL (HTTP ${response.status})`,
+					};
 				}
-				const probe = await attempt(fetch(hostedUrl, {method: "HEAD"}));
-				if (probe instanceof Error) {
-					return {_tag: "Failed", reason: `${hostedUrl}: HEAD failed: ${probe.message}`};
-				}
-				return probe.status === 200
-					? {_tag: "Ok", url: hostedUrl}
-					: {_tag: "Failed", reason: `${hostedUrl}: HEAD returned HTTP ${probe.status}`};
+				return verifyAttachment(hostedUrl, params.token, target);
 			},
-			catch: legFailed,
+			catch: () => legFailed("the attachment upload or verification failed"),
 		}).pipe(
 			Effect.catch((cause) => Effect.succeed<Upload>({_tag: "Failed", reason: cause.reason})),
 		);

--- a/packages/fabrika-cli/src/ui/http.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/http.unit.test.ts
@@ -7,11 +7,13 @@
  * here is a credential path that never needed the binary.
  */
 import {Effect, Layer} from "effect";
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 import {fakeHttp, fakeShell} from "../fakes.test-support.ts";
 import {NO_TOKEN} from "../io/gh-api.ts";
 import type {UploadTarget} from "./evidence-verb.ts";
-import {forgetCredentials, ghAttachmentUpload} from "./http.ts";
+import {encodePng, solid} from "./fakes.test-support.ts";
+import {attachmentUpload, forgetCredentials, ghAttachmentUpload} from "./http.ts";
+import {sha256Of} from "./png.ts";
 
 const target = (surface: string): UploadTarget => ({
 	surface,
@@ -36,6 +38,220 @@ const run = (
 			Layer.merge(shell.layer, http.layer),
 		),
 	);
+
+const HOSTED = "https://github.com/user-attachments/assets/d8c7f5c8-a9de-4575-b418-8837ec743c5e";
+const SIGNED = "https://asset.example/screenshot.png?signature=private-fixture";
+const TOKEN = "scripted-upload-credential";
+const PNG = encodePng(2, 2, solid(2, 2, [0, 0, 0, 255]));
+const capture: UploadTarget = {
+	...target("surface"),
+	bytes: PNG,
+	sha256: sha256Of(PNG),
+};
+const uploaded = (url = HOSTED) => Response.json({href: url}, {status: 201});
+const image = (bytes: Uint8Array = PNG) =>
+	new Response(bytes, {
+		headers: {
+			"content-type": "image/png",
+		},
+	});
+const redirect = (location = SIGNED) =>
+	new Response(null, {
+		status: 302,
+		headers: {
+			location,
+		},
+	});
+const upload = (input = capture) =>
+	Effect.runPromise(attachmentUpload({repositoryId: 918, token: TOKEN})(input));
+
+const scriptedFetch = (...responses: Array<Response | Error>) => {
+	const mock = vi.spyOn(globalThis, "fetch");
+	for (const response of responses) {
+		if (response instanceof Error) mock.mockRejectedValueOnce(response);
+		else mock.mockResolvedValueOnce(response);
+	}
+	mock.mockRejectedValue(new Error("unexpected fetch"));
+	return mock;
+};
+
+const expectPrivateFailure = (result: unknown) => {
+	expect(result).toMatchObject({_tag: "Failed"});
+	expect(JSON.stringify(result)).not.toContain(TOKEN);
+	expect(JSON.stringify(result)).not.toContain(SIGNED);
+	expect(JSON.stringify(result)).not.toContain("private-fixture");
+};
+
+describe("attachmentUpload's served-image verification", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("uploads PNG with auth, follows a GET-only signed asset, and returns only the stable URL", async () => {
+		const mock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+			if (init?.method === "POST") return uploaded();
+			if (String(input) === HOSTED) return redirect();
+			if (String(input) === SIGNED) {
+				return init?.method === "GET" ? image() : new Response(null, {status: 403});
+			}
+			throw new Error("unexpected fetch");
+		});
+		expect(await upload()).toEqual({_tag: "Ok", url: HOSTED});
+		expect(mock).toHaveBeenCalledTimes(3);
+		const [endpoint, request] = mock.mock.calls[0] ?? [];
+		expect(String(endpoint)).toContain("https://uploads.github.com/user-attachments/assets?");
+		expect(String(endpoint)).toContain("repository_id=918");
+		expect(request).toMatchObject({
+			method: "POST",
+			body: PNG,
+			headers: {
+				authorization: `token ${TOKEN}`,
+				"content-type": "image/png",
+			},
+		});
+		expect(mock.mock.calls[1]).toEqual([
+			HOSTED,
+			{
+				method: "GET",
+				redirect: "manual",
+				headers: {
+					authorization: `token ${TOKEN}`,
+				},
+			},
+		]);
+		expect(mock.mock.calls[2]).toEqual([
+			SIGNED,
+			{
+				method: "GET",
+				redirect: "manual",
+				headers: {},
+			},
+		]);
+	});
+
+	it("also accepts a directly served verified PNG", async () => {
+		scriptedFetch(uploaded(), image());
+		expect(await upload()).toEqual({_tag: "Ok", url: HOSTED});
+	});
+
+	it("keeps auth on a same-origin redirect but never restores it after crossing origins", async () => {
+		const sameOrigin = `${HOSTED}?download=1`;
+		const mock = scriptedFetch(
+			uploaded(),
+			redirect("?download=1"),
+			redirect("https://assets.github.com/signed"),
+			redirect(HOSTED),
+			image(),
+		);
+		expect(await upload()).toEqual({_tag: "Ok", url: HOSTED});
+		expect(mock.mock.calls[2]?.[0]).toBe(sameOrigin);
+		expect(
+			mock.mock.calls.slice(1).map(([, init]) => new Headers(init?.headers).get("authorization")),
+		).toEqual([`token ${TOKEN}`, `token ${TOKEN}`, null, null]);
+	});
+
+	it.each([
+		SIGNED,
+		"https://github.com.evil.example/user-attachments/assets/a",
+		"https://github.com@evil.example/user-attachments/assets/a",
+		HOSTED.replace("https:", "http:"),
+		`${HOSTED}?signature=private-fixture`,
+		`${HOSTED}#private-fixture`,
+		"https://github.com/user-attachments/assets/../../private-fixture",
+		"https://github.com/user-attachments/assets/not-an-asset",
+	])("rejects an untrusted uploaded destination without requesting it: %s", async (url) => {
+		const mock = scriptedFetch(uploaded(url));
+		expectPrivateFailure(await upload());
+		expect(mock).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		"http://asset.example/image",
+		"https://user:password@asset.example/image",
+		"https://[",
+	])("rejects an unsafe redirect without requesting it: %s", async (location) => {
+		const mock = scriptedFetch(uploaded(), redirect(location));
+		expectPrivateFailure(await upload());
+		expect(mock).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects a redirect without a destination", async () => {
+		scriptedFetch(uploaded(), new Response(null, {status: 302}));
+		expectPrivateFailure(await upload());
+	});
+
+	it("bounds a redirect loop rather than calling a redirect evidence", async () => {
+		const mock = scriptedFetch(uploaded(), ...Array.from({length: 21}, () => redirect(HOSTED)));
+		expectPrivateFailure(await upload());
+		expect(mock).toHaveBeenCalledTimes(22);
+	});
+
+	it.each([204, 206, 304, 403, 404, 500])("rejects final HTTP %s", async (status) => {
+		scriptedFetch(uploaded(), redirect(), new Response(null, {status}));
+		expectPrivateFailure(await upload());
+	});
+
+	it.each([
+		"text/html",
+		"image/jpeg",
+		"application/octet-stream",
+		"",
+	])("rejects a non-PNG content type: %s", async (contentType) => {
+		scriptedFetch(
+			uploaded(),
+			new Response(PNG, {
+				headers: {
+					"content-type": contentType,
+				},
+			}),
+		);
+		expectPrivateFailure(await upload());
+	});
+
+	it.each([
+		new Uint8Array(),
+		new TextEncoder().encode("<html>not an image</html>"),
+		PNG.slice(0, 40),
+		encodePng(2, 2, solid(2, 2, [255, 0, 0, 255])),
+	])("rejects empty, non-image, truncated, or different served bytes", async (bytes) => {
+		scriptedFetch(uploaded(), image(bytes));
+		expectPrivateFailure(await upload());
+	});
+
+	it("decodes the PNG rather than trusting even a matching digest", async () => {
+		const bytes = new TextEncoder().encode("not a PNG");
+		scriptedFetch(uploaded(), image(bytes));
+		expectPrivateFailure(await upload({...capture, bytes, sha256: sha256Of(bytes)}));
+	});
+
+	it.each([
+		"upload",
+		"initial GET",
+		"redirected GET",
+	])("absorbs a %s transport failure without leaking secrets", async (stage) => {
+		const error = new Error(`${TOKEN} ${SIGNED}`);
+		const responses =
+			stage === "upload" ? [] : stage === "initial GET" ? [uploaded()] : [uploaded(), redirect()];
+		scriptedFetch(...responses, error);
+		expectPrivateFailure(await upload());
+	});
+
+	it.each([
+		"upload",
+		"GET",
+	])("absorbs an unreadable %s body without leaking secrets", async (stage) => {
+		const response = stage === "upload" ? uploaded() : image();
+		vi.spyOn(response, stage === "upload" ? "text" : "arrayBuffer").mockRejectedValue(
+			new Error(`${TOKEN} ${SIGNED}`),
+		);
+		scriptedFetch(...(stage === "upload" ? [response] : [uploaded(), redirect(), response]));
+		expectPrivateFailure(await upload());
+	});
+
+	it.each([201, 403])("does not echo an invalid upload response body (HTTP %s)", async (status) => {
+		const mock = scriptedFetch(new Response(`${TOKEN} ${SIGNED}`, {status}));
+		expectPrivateFailure(await upload());
+		expect(mock).toHaveBeenCalledTimes(1);
+	});
+});
 
 describe("ghAttachmentUpload's credentials", () => {
 	it("resolves nothing until an upload asks for them", () => {


### PR DESCRIPTION
Verify construction screenshots with an authenticated GET to the intended GitHub attachment, following bounded HTTPS redirects without forwarding credentials across origins. Require a served PNG whose bytes match the captured digest and decode successfully; return only the stable attachment URL and keep secrets out of failures.

The [measured correction](https://github.com/kamp-us/phoenix/issues/7575#issuecomment-5563707853) found HEAD-through-redirect returning 403 while GET returned 200 image/png. Original construction runs reported HEAD 404; missing authentication alone is not demonstrated sufficient.

Fixes #7575

Focused verification: `pnpm --filter @kampus/tuval exec vitest run --root ../../packages/fabrika-cli --config "$PWD/packages/fabrika-cli/vitest.config.ts" src/ui/http.unit.test.ts src/ui/evidence-verb.unit.test.ts` — 62 tests passed across both files, including the unchanged mixed-success/no-partial-comment and capture-integrity regressions. Staged-file Biome checks and the commit hook passed after formatting corrections. No live upload was created.

Effect grounding: [main LLMS.md, Writing Effect code and Error handling](https://github.com/Effect-TS/effect/blob/main/LLMS.md), checked against installed `effect@4.0.0-beta.92` `src/Effect.ts`'s object-form `tryPromise` contract. The existing tagged-error conversion is retained with a redacted fallback.

## Deviations

- **Guard or gate bypassed** — **Said:** The build skill normally runs the repository-wide code check. **Did:** Ran only the owner-approved two-file regression command and staged-file checks; no broad build, suite, or typecheck. **Why:** The owner explicitly restricted this infrastructure repair to bounded verification. **Disposition:** CI and all required review, ACL, merge, and human gates remain required; no unrun validation is claimed. pnpm warned that its Node 22.22.3 runner is below the package's declared Node 24 floor, although both test files passed.
- **Guard or gate bypassed** — **Said:** The local pre-push hook normally runs affected typechecks. **Did:** Pushed with `LEFTHOOK=0`, retaining the pre-commit hook. **Why:** The owner explicitly authorized this push-only exception under #8361. **Disposition:** Remote ref was read back as moved; the standard CI and merge gates remain intact.
