### PR TITLE
fix: Tuval's Claude composer effort picker is blank: the model ref stays null

### DIFF
--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -40,6 +40,15 @@ tier uses, with a tool call of each shape, a pending permission card and three m
 kernel, opens no socket and imports no agent code, so what it proves is paint and keyboard and
 nothing else. Pass `--port <n>` when the default is taken.
 
+The same server's `/effort.html` is the fresh-Claude effort proof: its Node endpoint runs the
+real `ClaudeAiAgent` and core fold against the scripted SDK catalog/context response, then hands
+the emitted initial-open state to the actual `ChatWindow` through an in-memory window host.
+No model is configured, the active row is not first, and no prompt or selection precedes the
+render. `/effort-offered.html` also opens the actual effort menu without selecting an item.
+`/initial-effort.json` exposes the run timestamp, duration, events and recorded control calls.
+This proves the layer-to-component state and paint, **not** the real CLI, login, kernel transport
+or model execution; the in-memory host records UI dispatches without executing them.
+
 `pnpm dev` runs `node src/bin.ts`, an Effect CLI (`effect/unstable/cli`) over the pure `boot`.
 Node strips the TypeScript itself, so the kernel has no build step. Boot loads your config layers
 (see "Your config"), registers their programs, launches the processes the graph plans, restores any

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -200,9 +200,9 @@ const make = (
 		const session = yield* Ref.make<Session | null>(null);
 		const keys = yield* Ref.make<ReadonlySet<string>>(new Set());
 		const mode = yield* Ref.make<Mode | null>(null);
-		// Two Refs for the same reason `mode` is one: a switch made before a session exists, or
-		// between sessions, has to survive to the next `start` and be re-announced there.
 		const model = yield* Ref.make<ModelRef | null>(null);
+		// Only an operator pick survives as an override; a discovered default is read afresh.
+		const pickedModel = yield* Ref.make<ModelRef | null>(null);
 		const models = yield* Ref.make<ReadonlyArray<ModelRef>>([]);
 		const commands = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
 		// The effort axis is per model — `ModelInfo` carries `supportedEffortLevels` per row — so the
@@ -256,6 +256,20 @@ const make = (
 			);
 
 		const refOf = (row: ModelInfo): ModelRef => ({id: row.value, name: row.displayName});
+
+		const readRunningModel = (current: Session): Effect.Effect<string | undefined> =>
+			Effect.tryPromise({
+				try: () => current.handle.getContextUsage({detail: "summary"}),
+				catch: controlRefused,
+			}).pipe(
+				Effect.map((usage) => usage.model),
+				Effect.catch((refusal) =>
+					Effect.as(
+						Effect.logWarning(`the running model could not be read: ${refusal.detail}`),
+						undefined,
+					),
+				),
+			);
 
 		/**
 		 * The levels one row offers, and the founder's ruling in one line (#8062): Claude's effort
@@ -579,11 +593,16 @@ const make = (
 			yield* Ref.set(models, offered);
 			const table = effortsOf(rows);
 			yield* Ref.set(efforts, table);
-			const spawned =
-				options.model === undefined
-					? null
-					: (offered.find((candidate) => candidate.id === options.model) ?? null);
-			const picked = yield* Ref.get(model);
+			const runningId = (yield* readRunningModel(opened.session)) ?? options.model;
+			// `resolvedModel` matches a canonical running id to its selectable alias (sdk.d.ts).
+			// Catalog order is not evidence that a row is active, even when it is named Default.
+			const runningRow =
+				runningId === undefined
+					? undefined
+					: (rows.find((row) => row.value === runningId) ??
+						rows.find((row) => row.resolvedModel === runningId));
+			const spawned = runningRow === undefined ? null : refOf(runningRow);
+			const picked = yield* Ref.get(pickedModel);
 			const opening =
 				picked === null || !offered.some((candidate) => sameModel(candidate, picked))
 					? spawned
@@ -723,7 +742,10 @@ const make = (
 			// No session yet is not a refusal: the pick is held and applied by the next open, exactly
 			// as a mode set before the first session is.
 			const changed = current === null ? true : yield* applyModel(current, picked);
-			if (changed) yield* Ref.set(model, picked);
+			if (changed) {
+				yield* Ref.set(model, picked);
+				yield* Ref.set(pickedModel, picked);
+			}
 			const held = yield* Ref.get(model);
 			yield* publish([{kind: "model", current: held, available: offered}]);
 			// The offered levels are the model's, so a switch moves the picker's rows. A level the

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -114,6 +114,8 @@ export const on = <A, E>(
 			...(harness.deferOpening === undefined ? {} : {deferOpening: harness.deferOpening}),
 			...(harness.endsAtOnce === undefined ? {} : {endsAtOnce: harness.endsAtOnce}),
 			...(harness.models === undefined ? {} : {models: harness.models}),
+			...(harness.runningModel === undefined ? {} : {runningModel: harness.runningModel}),
+			...(harness.contextFails === undefined ? {} : {contextFails: harness.contextFails}),
 			...(harness.modelSwitchFails === undefined
 				? {}
 				: {modelSwitchFails: harness.modelSwitchFails}),

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -45,6 +45,7 @@ export interface QueryRecord {
 	readonly models: Array<string | undefined>;
 	/** Every effort level the layer applied, in order, for the same reason (#8062). */
 	readonly efforts: Array<EffortLevel | null>;
+	readonly contextReads: Array<{detail: "summary"}>;
 	closes: number;
 	interrupts: number;
 	readonly child: SpawnedProcess | null;
@@ -65,6 +66,8 @@ export interface ScriptedBehaviour {
 	readonly endsAtOnce?: boolean;
 	/** What `supportedModels()` answers. Absent is a CLI that offers none, which is the old shape. */
 	readonly models?: ReadonlyArray<ModelInfo>;
+	readonly runningModel?: string;
+	readonly contextFails?: Error;
 	/** A `setModel` the CLI refuses. The call is still recorded, so a test sees it was attempted. */
 	readonly modelSwitchFails?: Error;
 	/** An `applyFlagSettings` the CLI refuses, recorded the same way. */
@@ -102,6 +105,7 @@ export const scriptedQuery = (
 		modes: [],
 		models: [],
 		efforts: [],
+		contextReads: [],
 		closes: 0,
 		interrupts: 0,
 		child,
@@ -177,6 +181,11 @@ export const scriptedQuery = (
 		applyFlagSettings: async (settings: {effortLevel: EffortLevel | null}) => {
 			record.efforts.push(settings.effortLevel);
 			if (behaviour.effortSwitchFails !== undefined) throw behaviour.effortSwitchFails;
+		},
+		getContextUsage: async (options: {detail: "summary"}) => {
+			record.contextReads.push(options);
+			if (behaviour.contextFails !== undefined) throw behaviour.contextFails;
+			return {model: behaviour.runningModel ?? params.options.model ?? ""};
 		},
 		supportedModels: async () => {
 			if (behaviour.catalogFails !== undefined) throw behaviour.catalogFails;

--- a/apps/tuval/src/claude/agent/sdk.ts
+++ b/apps/tuval/src/claude/agent/sdk.ts
@@ -17,6 +17,7 @@ import type {
 	ModelInfo,
 	Options,
 	PermissionMode,
+	SDKControlGetContextUsageResponse,
 	SDKMessage,
 	SDKSessionInfo,
 	SDKUserMessage,
@@ -67,6 +68,13 @@ export interface AgentSession extends AsyncGenerator<SDKMessage, void> {
 	 */
 	applyFlagSettings(settings: {effortLevel: EffortLevel | null}): Promise<void>;
 	supportedModels(): Promise<ReadonlyArray<ModelInfo>>;
+	/**
+	 * `sdk.d.ts` at 0.3.259: summary uses local estimates, not token-count API calls. Its
+	 * `model` is the main-loop model, available before the first turn (unlike `system/init`).
+	 */
+	getContextUsage(options: {
+		detail: "summary";
+	}): Promise<Pick<SDKControlGetContextUsageResponse, "model">>;
 	/**
 	 * The session's slash commands, declared beside `supportedModels` and read the same way — once
 	 * per open. The pin's `sdk.d.ts` documents it as tracking the latest `commands_changed` push, so

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -515,6 +515,7 @@ describe("setThinkingLevel", () => {
 	const EFFORT: ReadonlyArray<ModelInfo> = [
 		{
 			value: "opus",
+			resolvedModel: "claude-opus-5",
 			displayName: "Opus 5",
 			description: "the deep one",
 			supportsEffort: true,
@@ -522,6 +523,137 @@ describe("setThinkingLevel", () => {
 		},
 		{value: "haiku", displayName: "Haiku", description: "no effort axis"},
 	];
+
+	it.effect("discovers the running model without config or a first prompt (#8212)", () =>
+		on(
+			{
+				models: [...EFFORT].reverse(),
+				runningModel: "claude-opus-5",
+				opening: [message("init")],
+				deferOpening: true,
+			},
+			(agent, scripted) =>
+				Effect.gen(function* () {
+					yield* agent.start({cwd: CWD});
+					const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+					assert.isUndefined(scripted.opened[0]?.record.options.model);
+					assert.deepStrictEqual(scripted.opened[0]?.record.prompts, []);
+					assert.deepStrictEqual(scripted.opened[0]?.record.contextReads, [{detail: "summary"}]);
+					assert.deepStrictEqual(scripted.opened[0]?.record.models, []);
+					assert.deepStrictEqual(events.find((event) => event.kind === "model")?.current, {
+						id: "opus",
+						name: "Opus 5",
+					});
+					assert.deepStrictEqual(
+						events.find((event) => event.kind === "thinking"),
+						{
+							kind: "thinking",
+							current: null,
+							available: ["low", "medium", "high", "xhigh", "max"],
+						},
+					);
+					yield* agent.setThinkingLevel("xhigh");
+					assert.deepStrictEqual(scripted.opened[0]?.record.efforts, ["xhigh"]);
+				}),
+		),
+	);
+
+	it.effect("updates offered levels after setModel from a null-model start (#8212)", () =>
+		on({models: EFFORT, runningModel: "unlisted-model"}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const opening = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.strictEqual(opening.find((event) => event.kind === "model")?.current, null);
+				assert.deepStrictEqual(
+					opening.find((event) => event.kind === "thinking"),
+					{
+						kind: "thinking",
+						current: null,
+						available: [],
+					},
+				);
+				yield* agent.setModel({id: "opus", name: "Opus 5"});
+				const changed = yield* Stream.runCollect(Stream.take(agent.events, 2));
+				assert.deepStrictEqual(changed.at(-1), {
+					kind: "thinking",
+					current: null,
+					available: ["low", "medium", "high", "xhigh", "max"],
+				});
+				assert.deepStrictEqual(scripted.opened[0]?.record.models, ["opus"]);
+			}),
+		),
+	);
+
+	it.effect("reads the runtime rather than assuming the configured model is active", () =>
+		on({models: EFFORT, model: "haiku", runningModel: "claude-opus-5"}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(events.find((event) => event.kind === "thinking")?.available, [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				]);
+			}),
+		),
+	);
+
+	it.effect("does not turn a discovered default into an operator override on restart", () =>
+		on({models: EFFORT, runningModel: "claude-opus-5"}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				yield* agent.start({cwd: CWD});
+				assert.deepStrictEqual(scripted.opened[1]?.record.models, []);
+				assert.deepStrictEqual(scripted.opened[1]?.record.contextReads, [{detail: "summary"}]);
+				yield* agent.setModel({id: "haiku", name: "Haiku"});
+				yield* agent.start({cwd: CWD});
+				assert.deepStrictEqual(scripted.opened[2]?.record.models, ["haiku"]);
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(
+					events.find((event) => event.kind === "thinking"),
+					{
+						kind: "thinking",
+						current: null,
+						available: [],
+					},
+				);
+			}),
+		),
+	);
+
+	it.effect("keeps start usable without guessing a default when discovery fails", () =>
+		on({models: EFFORT, contextFails: new Error("context unavailable")}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(
+					events.find((event) => event.kind === "thinking"),
+					{
+						kind: "thinking",
+						current: null,
+						available: [],
+					},
+				);
+			}),
+		),
+	);
+
+	it.effect("matches a configured canonical id when runtime discovery is unavailable", () =>
+		on(
+			{models: EFFORT, model: "claude-opus-5", contextFails: new Error("context unavailable")},
+			(agent) =>
+				Effect.gen(function* () {
+					yield* agent.start({cwd: CWD});
+					const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+					assert.deepStrictEqual(events.find((event) => event.kind === "model")?.current, {
+						id: "opus",
+						name: "Opus 5",
+					});
+				}),
+		),
+	);
 
 	it.effect("announces the model row's own offered set on the open", () =>
 		on({models: EFFORT, model: "opus"}, (agent) =>

--- a/apps/tuval/src/claude/proof/initial-effort.ts
+++ b/apps/tuval/src/claude/proof/initial-effort.ts
@@ -1,0 +1,52 @@
+import type {ModelInfo} from "@anthropic-ai/claude-agent-sdk";
+import {Effect, Stream} from "effect";
+import {foldEvent, initialState} from "../../ai-agent/core/index.ts";
+import {CWD, message, on, START_EVENTS} from "../agent/fixtures/harness.ts";
+
+const models: ReadonlyArray<ModelInfo> = [
+	{value: "haiku", displayName: "Haiku", description: "No effort axis"},
+	{
+		value: "opus",
+		resolvedModel: "claude-opus-5",
+		displayName: "Opus 5",
+		description: "Scripted catalog row, not a live model claim",
+		supportsEffort: true,
+		supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+	},
+];
+
+/** Real layer and core, scripted SDK/KernelBridge; never opens the real CLI or sends a prompt. */
+export const initialEffortProof = () =>
+	on(
+		{
+			models,
+			runningModel: "claude-opus-5",
+			opening: [message("init")],
+			deferOpening: true,
+		},
+		(agent, scripted) =>
+			Effect.gen(function* () {
+				const startedAt = new Date().toISOString();
+				const start = performance.now();
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				const record = scripted.opened[0]?.record;
+				return {
+					boundary:
+						"Real ClaudeAiAgent and core; scripted SDK and KernelBridge; no CLI, kernel transport or model spend",
+					startedAt,
+					elapsedMs: performance.now() - start,
+					events,
+					state: events.reduce((state, event) => foldEvent(state, event, {}), initialState(CWD)),
+					record: {
+						configuredModel: record?.options.model ?? null,
+						prompts: record?.prompts.length ?? -1,
+						modelSelections: record?.models ?? [],
+						effortSelections: record?.efforts ?? [],
+						contextReads: record?.contextReads ?? [],
+					},
+				};
+			}),
+	);
+
+export type InitialEffortProof = Effect.Success<ReturnType<typeof initialEffortProof>>;

--- a/apps/tuval/src/claude/proof/initial-effort.unit.test.ts
+++ b/apps/tuval/src/claude/proof/initial-effort.unit.test.ts
@@ -1,0 +1,24 @@
+import {assert, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {initialEffortProof} from "./initial-effort.ts";
+
+it.effect("hands the paint proof actual initial-open state before a prompt or selection", () =>
+	Effect.gen(function* () {
+		const proof = yield* initialEffortProof();
+		assert.strictEqual(proof.state.phase, "ready");
+		assert.deepStrictEqual(proof.state.models.current, {id: "opus", name: "Opus 5"});
+		assert.deepStrictEqual(proof.state.thinking, {
+			current: null,
+			available: ["low", "medium", "high", "xhigh", "max"],
+		});
+		assert.deepStrictEqual(proof.record, {
+			configuredModel: null,
+			prompts: 0,
+			modelSelections: [],
+			effortSelections: [],
+			contextReads: [{detail: "summary"}],
+		});
+		assert.lengthOf(proof.state.transcript.items, 0);
+		assert.isAtLeast(proof.elapsedMs, 0);
+	}),
+);

--- a/apps/tuval/src/shell/chat/proof/effort-offered.html
+++ b/apps/tuval/src/shell/chat/proof/effort-offered.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="color-scheme" content="dark" />
+		<title>Offered effort proof — scripted SDK, actual ChatWindow</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./effort.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/shell/chat/proof/effort.html
+++ b/apps/tuval/src/shell/chat/proof/effort.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="color-scheme" content="dark" />
+		<title>Initial effort proof — scripted SDK, actual ChatWindow</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./effort.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/shell/chat/proof/effort.tsx
+++ b/apps/tuval/src/shell/chat/proof/effort.tsx
@@ -1,0 +1,55 @@
+import {Effect} from "effect";
+import {createRoot} from "react-dom/client";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../../ai-agent/core/index.ts";
+import type {InitialEffortProof} from "../../../claude/proof/initial-effort.ts";
+import {ProcessId} from "../../../process/process.ts";
+import {testProcess} from "../../window/fixtures.ts";
+import {WindowId} from "../../window/index.ts";
+import {chatWindow} from "../ChatWindow.tsx";
+import {initialChatView} from "../view.ts";
+import "../../../page/styles.ts";
+import "./proof.css";
+
+const response = await fetch("/initial-effort.json");
+if (!response.ok) throw new Error(`Initial effort proof failed: ${response.status}`);
+const proof: InitialEffortProof = await response.json();
+const host = document.getElementById("proof");
+if (host === null) throw new Error("Missing proof host");
+
+await Effect.runPromise(
+	Effect.gen(function* () {
+		const process = yield* testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+			ProcessId.make("initial-effort-proof"),
+			proof.state,
+		);
+		const window = yield* process.window(WindowId.make("initial-effort"), initialChatView);
+		createRoot(host).render(
+			<div className="tuval-surface proof-desk" data-scheme="dark">
+				<div className="proof-pane">{chatWindow().render(window)}</div>
+			</div>,
+		);
+		// The transport double records UI dispatches but does not run a kernel command handler.
+		Object.assign(globalThis, {initialEffortProof: proof, initialEffortInbox: process.inbox});
+	}),
+);
+
+// The capture-only route opens the actual picker, never selects a model or an effort.
+if (location.pathname.endsWith("/effort-offered.html")) {
+	const button = await new Promise<HTMLButtonElement>((resolve, reject) => {
+		const observer = new MutationObserver(() => {
+			const picker = document.querySelector<HTMLButtonElement>(
+				'button[aria-label="thinking effort: none selected"]',
+			);
+			if (picker === null || picker.disabled) return;
+			observer.disconnect();
+			clearTimeout(timeout);
+			resolve(picker);
+		});
+		const timeout = setTimeout(() => {
+			observer.disconnect();
+			reject(new Error("Initial effort picker did not become enabled"));
+		}, 5000);
+		observer.observe(host, {subtree: true, childList: true, attributes: true});
+	});
+	button.click();
+}

--- a/apps/tuval/src/shell/chat/proof/vite.config.ts
+++ b/apps/tuval/src/shell/chat/proof/vite.config.ts
@@ -1,13 +1,35 @@
 import {dirname, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
 import react from "@vitejs/plugin-react";
+import {Effect} from "effect";
 import {defineConfig} from "vite";
+import {initialEffortProof} from "../../../claude/proof/initial-effort.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
 	root: here,
-	plugins: [react()],
+	plugins: [
+		react(),
+		{
+			name: "initial-effort-proof",
+			configureServer(server) {
+				server.middlewares.use("/initial-effort.json", (_request, response) => {
+					Effect.runPromise(initialEffortProof()).then(
+						(proof) => {
+							response.setHeader("Content-Type", "application/json");
+							response.setHeader("Cache-Control", "no-store");
+							response.end(JSON.stringify(proof));
+						},
+						(error: unknown) => {
+							response.statusCode = 500;
+							response.end(String(error));
+						},
+					);
+				});
+			},
+		},
+	],
 	// `@kampus/design` and the design tokens are source-consumed out of the workspace, so the dev
 	// server has to be allowed to read above this app's root.
 	server: {fs: {allow: [resolve(here, "../../../../../..")]}},


### PR DESCRIPTION
Discover Claude's running model before the first prompt and use its catalog row's supported effort levels. Keep the effort selection unset until the operator picks one, and keep discovered defaults separate from operator model overrides across restarts. Pi and production rendered components are unchanged.

The pinned SDK's `Query.getContextUsage({detail: "summary"})` supplies the runtime model without token-count API calls; `ModelInfo.resolvedModel` connects canonical IDs to selectable aliases ([SDK 0.3.259 declarations](https://unpkg.com/@anthropic-ai/claude-agent-sdk@0.3.259/sdk.d.ts)). Regression coverage includes no-model startup, switching from an unknown model, runtime/config disagreement, restarts, and discovery failure.

### Builder hand-verification

Head: `7d1854ad614ae93abb497d69b76bf27fd718d868`. [Validated initial-open and offered-menu screenshots](https://github.com/kamp-us/phoenix/pull/8432#issuecomment-5565203021), both 1280×900, published through `ui render` → `ui evidence`.

At `2026-09-07T04:50:33.589Z`, the **real ClaudeAiAgent and core fold on a scripted SDK/KernelBridge** opened in 1.677 ms; agent-browser observed the actual ChatWindow ready 380.6 ms after navigation (an observation timestamp, not a benchmark). No configured model, prompt, model selection or effort selection preceded inspection. The script puts Haiku first and reports canonical `claude-opus-5` as the running model. The layer made one summary-context read, emitted five offered levels and retained `current: null`. The actual composer displayed `Opus 5`, an enabled `none selected` effort button, and an empty transcript. Opening only that button showed `low`, `medium`, `high`, `very high`, `maximum`, all unchecked; no page errors were recorded. The menu was visually inspected for legibility and placement.

Reproduce from this head: `pnpm --filter @kampus/tuval proof:chat`, navigate to its printed origin's `/effort.html`, then open the effort button without touching the model or prompt. `/effort-offered.html` performs only that menu-opening interaction for deterministic capture. `/initial-effort.json` returns each fresh run's events, timings and recorded control calls. The in-memory window host records dispatches but does not execute kernel commands. This is **not** a real CLI/login/backend transport run; the model/catalog identity is scripted, not observed from an installed running model. No real CLI or model spend was used.

Validation: 141 focused unit regressions passed across 13 files; direct Tuval typechecks passed with zero errors/warnings; normal code and prose validators green. The two new HTML entries were loaded and captured by the normal renderer (the text validator explicitly leaves HTML unvalidated). The new head still requires fresh independent text/UI namespaces and CI; the earlier text PASS is stale. LAW-SOURCE: manifest-prose.

Fixes #8212

## Deviations

- **Declined guidance** — **Said:** The issue's non-binding suggestion allows falling back to the first catalog row. **Did:** Read the runtime model and match it by ID or resolved alias; leave it unknown if discovery fails without configured-model evidence. **Why:** Catalog rows have no active marker, and list order does not prove which model is running. **Disposition:** Stated here; discovery failures warn and preserve a usable session rather than inventing model or effort state.
- **Guard or gate bypassed** — **Said:** Build-ui normally captures a before state and a rendered product, while review-ui requires admissible independent evidence. **Did:** Added first-render proof routes and published builder captures over the real layer/component with the SDK, KernelBridge and window transport scripted; no pre-change capture or real backend run is claimed. **Why:** The original builder omitted hand-verification, and the existing WEB preview is not Tuval; the real-CLI proof remains founder-only. **Disposition:** The missing builder proof is now published with its boundary. The live #7306 interim exception remains the independent reviewer's routing decision after current-head text PASS, not a visual PASS from this builder; if used, this PR must be listed in #7306 for the post-merge sweep.
- **Guard or gate bypassed** — **Said:** Push normally runs its hooks. **Did:** Used the owner's authorized push-only `LEFTHOOK=0` for #8361; normal commit hooks and guarded commit remained enabled. **Why:** The named push-hook recovery is authorized for this batch. **Disposition:** Normal validators and direct focused checks passed; guarded push verified the remote SHA. Current-head CI remains authoritative.
