### PR TITLE
fix: A long setting picker opens at the top, not at the model currently selected

### DIFF
--- a/.decisions/0361-manti-menu-highlighted-value-patch.md
+++ b/.decisions/0361-manti-menu-highlighted-value-patch.md
@@ -62,9 +62,19 @@ when the menu opens and mirrors the machine afterwards. Seeding is required rath
 Zag clears the highlight on the machine's `closed` entry, so `defaultHighlightedValue` alone would
 work for the first open and no other.
 
+The patch is held the way every maintained patch here is held, in the two layers
+[`.patterns/dependency-patch-behavior-pins.md`](../.patterns/dependency-patch-behavior-pins.md)
+defines and `fabrika guard patch-guard check` fails closed on: the version-keyed
+`patchedDependencies` entry, which is pnpm's own loud-fail on version drift, and a behavior pin —
+a test that reds if the patched behaviour regresses, self-registering with a
+`// @patch-pin: @manti-ui/react@0.9.0` marker. `chat-picker-opens-on-checked-row.unit.test.tsx`
+carries that marker and is that pin.
+
 **Binding constraints.**
 
-- Re-key this patch on the next `@manti-ui/react` bump, and drop it once a release ships the props.
+- Re-key this patch on the next `@manti-ui/react` bump — both layers, the
+  `patchedDependencies` key and the `@patch-pin` marker — and drop it once a release ships the
+  props.
 - The rejected DOM route stays rejected: `SettingMenu` never reaches into the portaled panel by
   Zag's private id template, and never scrolls a row the machine does not also have highlighted.
 - Manti's surface coming up short a third time is when driving `@zag-js/menu` directly from
@@ -77,15 +87,15 @@ The picker opens where the user is, and the first arrow key moves from there —
 the panel and the screen reader cannot disagree. Every Manti `Menu` in the repo gains the props,
 not just this one.
 
-The cost is a fourth patched dependency and one more thing a pin bump re-litigates. It is bounded:
+The cost is a fifth patched dependency and one more thing a pin bump re-litigates. It is bounded:
 the patch adds a passthrough and changes no default, so an upstream release that ships the same
 props retires it with no consumer change. Until then `packages/design` resolves a patched copy of
 `@manti-ui/react`, which is visible in the lockfile and in the diff.
 
-Nothing pins the patch by machine beyond
-`apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx`, which fails on all three
-assertions with the props unwired — an unpatched or badly re-keyed copy reds there rather than
-shipping a picker that silently reverted to row 1.
+What pins it is `apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx`, which
+fails on all three assertions with the props unwired — an unpatched or badly re-keyed copy reds
+there rather than shipping a picker that silently reverted to row 1. The next person to bump the pin
+finds it through the marker rather than by accident.
 
 ## Records
 

--- a/.decisions/0361-manti-menu-highlighted-value-patch.md
+++ b/.decisions/0361-manti-menu-highlighted-value-patch.md
@@ -1,0 +1,92 @@
+---
+id: 0361
+title: "`@manti-ui/react`'s `Menu` forwards Zag's highlight props, carried as a local patch until upstream takes it"
+status: accepted
+date: 2026-09-07
+tags: [design-system, dependencies, accessibility, tuval]
+---
+
+# 0361 — `@manti-ui/react`'s `Menu` forwards Zag's highlight props, carried as a local patch until upstream takes it
+
+**What this decides:** phoenix patches its pinned `@manti-ui/react` so the composer's model picker
+can open on the model you are actually using, and offers the same change upstream rather than
+working around the gap in our own code.
+
+## Context
+
+Tuval's composer renders its model and thinking-level pickers through `SettingMenu`
+(`packages/design/src/AgentChatInput.tsx`), which is a Manti `Menu` holding one radio group. With
+Pi's ~30-model catalogue the picker opened at row 1 every time, so the row you were on sat below
+the fold and you had to hunt for yourself before you could move
+([#8078](https://github.com/kamp-us/phoenix/issues/8078)). An option list that opens away from its
+checked option is an accessibility defect, not a polish item.
+
+The behaviour already exists in the machine. `@zag-js/menu@1.43.0` runs `scrollToHighlightedItem`
+as an effect of its open state and resolves the element to scroll from the machine's
+`highlightedValue` (`dist/menu.machine.mjs`, the `scrollToHighlightedItem` effect and the
+`highlightedId` computed). The machine's public props already include `highlightedValue`,
+`defaultHighlightedValue` and `onHighlightChange` (`dist/menu.props.mjs`).
+
+What was missing was a route to them. `@manti-ui/react@0.9.0`'s `MenuProps` exposes
+`open`/`defaultOpen`/`onOpenChange`/`onSelect`/`contentProps`/`getItemProps` and forwards none of
+the three; `contentProps` and `getItemProps` are plain attribute bags carrying no `ref`, so there is
+no handle on the panel or a row either.
+
+The founder ruled the route on the issue
+([comment](https://github.com/kamp-us/phoenix/issues/8078#issuecomment-5555642577)): patch the pin
+and offer the same diff upstream. The rejected alternative was a `useEffect` in `SettingMenu` that
+queries the portaled row and calls native `Element.scrollIntoView`. It scrolls the panel while
+leaving the machine's highlight on row 1, so the visible panel and the next arrow key disagree —
+worse for a screen-reader or keyboard user than an honest top-of-list.
+
+ADR [0038](0038-dependency-patches-local-only.md) already governs this shape: a local `pnpm patch`
+committed to the repo, never an external patch source, with upstreaming encouraged and the merged
+release — not the in-flight PR — as the thing phoenix eventually depends on. ADR
+[0170](0170-workers-cache-via-alchemy-effect-pnpm-patch.md) is the same move on alchemy.
+
+## Decision
+
+**`@manti-ui/react@0.9.0` is patched in-repo so `Menu` forwards `highlightedValue`,
+`defaultHighlightedValue` and `onHighlightChange` into the Zag machine it already owns, and the same
+change is offered upstream to `manti-ui/ui`.**
+
+The patch lives at `patches/@manti-ui__react@0.9.0.patch`, wired through `patchedDependencies` in
+`pnpm-workspace.yaml`. It touches two files and adds no behaviour of its own: three destructured
+props threaded into the existing `useMachine` options in `dist/index.js`, and the matching entries
+on `MenuProps` in `dist/components/Menu/Menu.d.ts`. `onHighlightChange` is unwrapped to
+`(value: string | null) => void`, matching how the adapter already unwraps `onOpenChange` and
+`onSelect`.
+
+`SettingMenu` drives the highlight as controlled state: it seeds the highlight to the checked row
+when the menu opens and mirrors the machine afterwards. Seeding is required rather than optional —
+Zag clears the highlight on the machine's `closed` entry, so `defaultHighlightedValue` alone would
+work for the first open and no other.
+
+**Binding constraints.**
+
+- Re-key this patch on the next `@manti-ui/react` bump, and drop it once a release ships the props.
+- The rejected DOM route stays rejected: `SettingMenu` never reaches into the portaled panel by
+  Zag's private id template, and never scrolls a row the machine does not also have highlighted.
+- Manti's surface coming up short a third time is when driving `@zag-js/menu` directly from
+  `@kampus/design` becomes the answer. [#6776](https://github.com/kamp-us/phoenix/issues/6776) was
+  the first, this is the second.
+
+## Consequences
+
+The picker opens where the user is, and the first arrow key moves from there — one behaviour, so
+the panel and the screen reader cannot disagree. Every Manti `Menu` in the repo gains the props,
+not just this one.
+
+The cost is a fourth patched dependency and one more thing a pin bump re-litigates. It is bounded:
+the patch adds a passthrough and changes no default, so an upstream release that ships the same
+props retires it with no consumer change. Until then `packages/design` resolves a patched copy of
+`@manti-ui/react`, which is visible in the lockfile and in the diff.
+
+Nothing pins the patch by machine beyond
+`apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx`, which fails on all three
+assertions with the props unwired — an unpatched or badly re-keyed copy reds there rather than
+shipping a picker that silently reverted to row 1.
+
+## Records
+
+no vocabulary impact

--- a/apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx
@@ -16,7 +16,12 @@
  * publishing it as the panel's `aria-activedescendant` and the row's `data-highlighted`. So the
  * assertions are over the highlight, which is also what the second one is about on its own terms:
  * the arrow key has to move from the row the user is on.
+ *
+ * It doubles as the behavior pin for the `@manti-ui/react` patch, which is what forwards
+ * `highlightedValue` into the machine at all: unpatched, the highlight stays null and every
+ * assertion below reds (`.patterns/dependency-patch-behavior-pins.md`, ADR 0361).
  */
+// @patch-pin: @manti-ui/react@0.9.0
 
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";

--- a/apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer's setting pickers open on the model you are actually using (#8078).
+ *
+ * The rule under test is `@kampus/design`'s, not Tuval's, so this file reads the shipped
+ * stylesheets off disk the way `chat-composer-width.unit.test.tsx` does — under Vitest's default
+ * `css: false` the component's own `import "./AgentChatInput.css"` resolves to an empty module.
+ * They are here so the panel's cap is a fact this file reads rather than an assumption: a
+ * catalogue only has a fold because `.kp-agent-chat__picker-menu` caps and scrolls (#8064).
+ *
+ * jsdom runs no layout engine, so the scroll itself cannot be observed. What can be is the thing
+ * that drives it: `@zag-js/menu`'s `scrollToHighlightedItem` is an effect of the open state and
+ * resolves the element it scrolls to from the machine's `highlightedValue`
+ * (`dist/menu.machine.mjs`, the `scrollToHighlightedItem` effect and the `highlightedId` computed),
+ * publishing it as the panel's `aria-activedescendant` and the row's `data-highlighted`. So the
+ * assertions are over the highlight, which is also what the second one is about on its own terms:
+ * the arrow key has to move from the row the user is on.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {AgentSettingMenu} from "@kampus/design";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {afterAll, beforeAll, expect, it} from "vitest";
+import {installDomShims} from "../ui/dom.testing.ts";
+
+installDomShims();
+
+const designCss = (name: string): string => {
+	const entry = fileURLToPath(import.meta.resolve("@kampus/design"));
+	return readFileSync(entry.replace(/index\.ts$/, name), "utf8");
+};
+
+const styles = ["Menu.css", "AgentChatInput.css"].map((name) => {
+	const style = document.createElement("style");
+	style.textContent = designCss(name);
+	return style;
+});
+
+beforeAll(() => {
+	for (const style of styles) document.head.appendChild(style);
+});
+afterAll(() => {
+	for (const style of styles) style.remove();
+});
+
+const model = (index: number) => ({value: `model-${index}`, label: `Model ${index}`});
+
+/** Pi's catalogue is this long; the row under test sits far enough down to be past any cap. */
+const MODELS = Array.from({length: 30}, (_, index) => model(index));
+const BELOW_THE_FOLD = model(24);
+const NEXT_ROW = model(25);
+
+const openPicker = async (): Promise<HTMLElement> => {
+	render(
+		<AgentSettingMenu
+			label="Model"
+			items={MODELS}
+			value={BELOW_THE_FOLD.value}
+			onValueChange={() => {}}
+		/>,
+	);
+	fireEvent.click(screen.getByRole("button", {name: `Model: ${BELOW_THE_FOLD.label}`}));
+	return await screen.findByRole("menu", {name: `Model: ${BELOW_THE_FOLD.label}`});
+};
+
+const highlightedRow = (menu: HTMLElement): HTMLElement | null => {
+	const id = menu.getAttribute("aria-activedescendant");
+	const row = menu.querySelector<HTMLElement>("[data-highlighted]");
+	// One highlight, published two ways. A row carrying `data-highlighted` that the panel does not
+	// point at would leave the screen reader and the scroll effect on different rows.
+	return id !== null && row?.id === id ? row : null;
+};
+
+it("opens the model picker on the checked row rather than the top of the catalogue", async () => {
+	const menu = await openPicker();
+
+	expect(getComputedStyle(menu).getPropertyValue("overflow-y")).toBe("auto");
+	await waitFor(() => {
+		expect(highlightedRow(menu)?.textContent).toBe(BELOW_THE_FOLD.label);
+	});
+});
+
+it("moves the first arrow key from the checked row, not from row 1", async () => {
+	const menu = await openPicker();
+	await waitFor(() => {
+		expect(highlightedRow(menu)?.textContent).toBe(BELOW_THE_FOLD.label);
+	});
+
+	fireEvent.keyDown(menu, {key: "ArrowDown"});
+
+	await waitFor(() => {
+		expect(highlightedRow(menu)?.textContent).toBe(NEXT_ROW.label);
+	});
+});
+
+it("still opens the thinking picker's short list on its checked row", async () => {
+	const levels = ["off", "low", "medium", "high", "max"].map((value) => ({
+		value,
+		label: value,
+	}));
+	render(
+		<AgentSettingMenu label="Thinking" items={levels} value="high" onValueChange={() => {}} />,
+	);
+	fireEvent.click(screen.getByRole("button", {name: "Thinking: high"}));
+	const menu = await screen.findByRole("menu", {name: "Thinking: high"});
+
+	await waitFor(() => {
+		expect(highlightedRow(menu)?.textContent).toBe("high");
+	});
+});

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -1332,6 +1332,11 @@ export interface SettingMenuProps {
 export function SettingMenu({label, items, value, onValueChange, disabled}: SettingMenuProps) {
 	const t = useDesignT();
 	const [open, setOpen] = useState(false);
+	// The highlight is ours to drive, not the machine's: Zag clears it on close and re-seeds it to
+	// row 1 on the next open, so a catalogue taller than the popover always opens away from the
+	// checked row. Seeding it to `value` at the open makes the machine's own scroll-into-view land
+	// there and the first arrow key move from there. See ADR 0361.
+	const [highlighted, setHighlighted] = useState<string | null>(null);
 	const selected = items.find((item) => item.value === value);
 	// Two different unselected states, and only one of them is loading: an empty `items` is a host
 	// that has not resolved what it can offer, while a populated `items` with no `value` is a
@@ -1347,7 +1352,12 @@ export function SettingMenu({label, items, value, onValueChange, disabled}: Sett
 	return (
 		<Menu
 			open={open}
-			onOpenChange={setOpen}
+			onOpenChange={(next) => {
+				if (next) setHighlighted(value ?? null);
+				setOpen(next);
+			}}
+			highlightedValue={highlighted}
+			onHighlightChange={setHighlighted}
 			placement="top-start"
 			ariaLabel={label}
 			className="kp-agent-chat__picker-menu"

--- a/patches/@manti-ui__react@0.9.0.patch
+++ b/patches/@manti-ui__react@0.9.0.patch
@@ -1,0 +1,49 @@
+diff --git a/dist/components/Menu/Menu.d.ts b/dist/components/Menu/Menu.d.ts
+index 0dc3d5bac2ad789ac28f6059296977f0fa73ba8f..fc31ea63e5b0dc61ad2c4fd2b24bfc39eb4cfa50 100644
+--- a/dist/components/Menu/Menu.d.ts
++++ b/dist/components/Menu/Menu.d.ts
+@@ -22,6 +22,12 @@ export interface MenuProps {
+     defaultOpen?: boolean;
+     /** Called whenever the open state changes. */
+     onOpenChange?: (open: boolean) => void;
++    /** Controlled value of the highlighted command. Drives the machine's scroll-into-view on open. */
++    highlightedValue?: string | null;
++    /** Initial highlighted command for uncontrolled usage. */
++    defaultHighlightedValue?: string | null;
++    /** Called with the value of the newly highlighted command, or null when nothing is highlighted. */
++    onHighlightChange?: (value: string | null) => void;
+     /** Accessible name for the menu panel. */
+     ariaLabel?: string;
+     id?: string;
+@@ -47,5 +53,5 @@ export interface MenuProps {
+  * />
+  * ```
+  */
+-export declare function Menu({ trigger, items, placement, size, onSelect, open, defaultOpen, onOpenChange, ariaLabel, id, className, contentProps, getItemProps, }: MenuProps): import("react").JSX.Element;
++export declare function Menu({ trigger, items, placement, size, onSelect, open, defaultOpen, onOpenChange, ariaLabel, id, className, contentProps, getItemProps, highlightedValue, defaultHighlightedValue, onHighlightChange, }: MenuProps): import("react").JSX.Element;
+ //# sourceMappingURL=Menu.d.ts.map
+\ No newline at end of file
+diff --git a/dist/index.js b/dist/index.js
+index e769e146e2a2fb30d9ab32843d8bf1f640ee246d..16be03af85c01ba512f8c2d42a24657df6736b86 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2617,14 +2617,17 @@ function Sn({ children: e, direction: t = "left", speed: n = 20, pauseOnHover: r
+ }
+ //#endregion
+ //#region src/components/Menu/Menu.tsx
+-function Cn({ trigger: e, items: t, placement: n = "bottom-start", size: r = "md", onSelect: i, open: a, defaultOpen: o, onOpenChange: s, ariaLabel: c, id: l, className: d, contentProps: f, getItemProps: p }) {
++function Cn({ trigger: e, items: t, placement: n = "bottom-start", size: r = "md", onSelect: i, open: a, defaultOpen: o, onOpenChange: s, ariaLabel: c, id: l, className: d, contentProps: f, getItemProps: p, highlightedValue: $hv, defaultHighlightedValue: $dhv, onHighlightChange: $ohc }) {
+ 	let m = u(), h = l ?? m, g = n === "bottom-center" ? "bottom" : n, _ = Ot(), v = U(M.machine, {
+ 		id: h,
+ 		positioning: { placement: g },
+ 		"aria-label": c,
+ 		open: a,
+ 		defaultOpen: o,
+-		onOpenChange: s ? (e) => s(e.open) : void 0
++		onOpenChange: s ? (e) => s(e.open) : void 0,
++		highlightedValue: $hv,
++		defaultHighlightedValue: $dhv,
++		onHighlightChange: $ohc ? (e) => $ohc(e.highlightedValue) : void 0
+ 	}), y = M.connect(v, H);
+ 	return /* @__PURE__ */ K(Dt, {
+ 		value: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ overrides:
 pnpmfileChecksum: sha256-ENBbpnCM6iEJZwql5y+XIdMMnEPnYSp47O6FmPjp4UI=
 
 patchedDependencies:
+  '@manti-ui/react@0.9.0':
+    hash: 72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484
+    path: patches/@manti-ui__react@0.9.0.patch
   '@nkzw/fate@1.3.1':
     hash: e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c
     path: patches/@nkzw__fate@1.3.1.patch
@@ -425,7 +428,7 @@ importers:
         version: link:../../packages/fate-effect
       '@manti-ui/react':
         specifier: 'catalog:'
-        version: 0.9.0(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.9.0(patch_hash=72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484)(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@manti-ui/styles':
         specifier: 'catalog:'
         version: 0.9.0
@@ -868,7 +871,7 @@ importers:
         version: 5.2.8
       '@manti-ui/react':
         specifier: 'catalog:'
-        version: 0.9.0(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.9.0(patch_hash=72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484)(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -7322,7 +7325,7 @@ snapshots:
     transitivePeerDependencies:
       - '@internationalized/date'
 
-  '@manti-ui/react@0.9.0(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@manti-ui/react@0.9.0(patch_hash=72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484)(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@manti-ui/folds': 0.9.0(@internationalized/date@3.12.3)
       '@manti-ui/styles': 0.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -230,6 +230,7 @@ onlyBuiltDependencies:
 #    which nothing else in the repo declares any. Behavior-pinned by
 #    packages/fabrika-cli/src/excess-operand.cli.test.ts. Retire when effect honours it.
 patchedDependencies:
+  '@manti-ui/react@0.9.0': patches/@manti-ui__react@0.9.0.patch
   '@nkzw/fate@1.3.1': patches/@nkzw__fate@1.3.1.patch
   alchemy@2.0.0-beta.59: patches/alchemy@2.0.0-beta.59.patch
   effect@4.0.0-beta.92: patches/effect@4.0.0-beta.92.patch


### PR DESCRIPTION
Fixes #8078.

The composer's setting pickers now open on the model you are actually using.

`SettingMenu` (`packages/design/src/AgentChatInput.tsx`) renders a Manti `Menu` holding one radio
group. With Pi's ~30-model catalogue the panel opened at row 1 every time, so the row you were on
sat below the fold and you had to hunt for yourself before you could move.

Zag's menu machine already owns the behaviour — `scrollToHighlightedItem` is an effect of its open
state and resolves the element to scroll from `highlightedValue` (`@zag-js/menu@1.43.0`,
`dist/menu.machine.mjs`; the props are public in `dist/menu.props.mjs`). What was missing was a
route to it: `@manti-ui/react@0.9.0`'s `MenuProps` forwards `open`/`defaultOpen`/`onOpenChange` and
none of the three highlight props, and `contentProps`/`getItemProps` are plain attribute bags with
no `ref`, so there is no handle from outside either.

Per the founder's ruling on the issue
(https://github.com/kamp-us/phoenix/issues/8078#issuecomment-5555642577) this takes routes 2 + 1:

- **`patches/@manti-ui__react@0.9.0.patch`** — `Menu` forwards `highlightedValue`,
  `defaultHighlightedValue` and `onHighlightChange` into the machine it already owns, plus the
  matching `MenuProps` entries. Wired through `patchedDependencies` in `pnpm-workspace.yaml`. It
  adds no behaviour and changes no default; a caller passing none of the three gets today's
  behaviour exactly.
- **`SettingMenu`** drives the highlight as controlled state: seeded to the checked row at the open,
  mirroring the machine after. Seeding is required rather than optional — Zag clears the highlight
  on the machine's `closed` entry, so `defaultHighlightedValue` alone would work for the first open
  and no other.
- **ADR 0361** records why the repo carries the patch, under ADR 0038's local-patch policy, and
  cites the ruling comment.
- **`apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx`** covers
  open-with-a-selection-below-the-fold, following `chat-composer-width.unit.test.tsx`'s harness. All
  three assertions fail with the props unwired, which is what makes it the patch's behavior pin: it
  carries the `// @patch-pin: @manti-ui/react@0.9.0` marker `patch-guard` requires
  (`.patterns/dependency-patch-behavior-pins.md`), and `fabrika guard patch-guard check` is green.

Route 3 (a `useEffect` calling native `scrollIntoView`) stays rejected: it scrolls the panel while
leaving the machine's highlight on row 1, so the visible panel and the next arrow key disagree.

## What I observed

Checked on a scratch Tuval desk — the real `ChatWindow` composer, 30-model catalogue, `model-24`
selected, on a free port (not 5173), driven headless so the numbers come from a real layout engine.
Panel 420px tall over 558px of rows, so `model-24` is genuinely past the fold.

| | before | after |
| --- | --- | --- |
| panel `scrollTop` on open | 0 | 48 |
| checked row in view | no | yes |
| highlighted row on open | none | `model-24` |
| highlighted row after ArrowDown | `model-00` | `model-25` |
| `aria-activedescendant` agrees with `[data-highlighted]` | — | yes |

The thinking picker (5 rows, under the cap) opens on its checked row too, covered by the third case
in the unit test. `pnpm typecheck` and `pnpm lint` are green via `fabrika build check --surface
code`; `patch-guard` and `catalog-guard` are green; `packages/design`'s own suite and its a11y suite
both pass.

## Upstream

The same change is prepared as a commit against `manti-ui/ui` — branch
`umut/menu-forward-highlight-props`, one commit on top of `main` (`20d98a8`), touching
`packages/react/src/components/Menu/Menu.tsx` (+18) and `Menu.test.tsx` (+49, two cases). Prettier
clean, and the suite goes 12 passed with the change and 2 failed without it. **Not opened** — the
upstream PR is a separate step for a human to take, and the ADR's binding constraint is to drop the
patch once a release ships the props.

## Deviations

- **Scope narrowing** — **Said:** the patch makes `Menu` forward Zag's highlight props. **Did:**
  patched `Menu` only, not `ContextMenu`, which drives the same machine through the same adapter.
  **Why:** nothing in the repo needs a highlighted `ContextMenu`, and the upstream PR is the right
  place to decide whether the two surfaces stay symmetric. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8078 names `SettingMenu` and the patch. **Did:** `pnpm
  patch-commit` also rewrote `pnpm-workspace.yaml`, stripping every comment and reordering every
  catalog entry; I restored the file from `origin/main` and hand-added the one
  `patchedDependencies` line, so the diff there is one line. **Why:** the stripped comments carry
  load-bearing pin rationale (the better-auth/drizzle coupling, the `@effect/platform-node-shared`
  override) that no reader could reconstruct. **Disposition:** stated here.
- **Declined guidance** — **Said:** the first acceptance criterion asks that the chosen route be
  recorded on the issue and named in the issue body before any code is written. **Did:** the route
  is recorded on the issue as the founder's ruling comment and cited in ADR 0361, but I did not edit
  the issue body. **Why:** a build lane writes branches, not issue bodies, and appending to a filed
  body is a separate act. **Disposition:** stated here; the body edit is a human's if it is still
  wanted.
- **Known defect left unfixed** — **Said:** the second acceptance criterion asks that the checked
  row be in view in the panel's scroll box. **Did:** the unit test cannot assert that — jsdom runs
  no layout engine, so it asserts the highlight that drives the scroll, not the scroll. **Why:** the
  scroll is `@zag-js/menu`'s, keyed off `highlightedValue`; the criterion's own evidence is the
  real-layout measurement in "What I observed" above, which lives outside the test suite and so is
  not re-run by CI. **Disposition:** stated here.
