### PR TITLE
fix: Tuval's config feature flags never reach the browser, so no operator can turn one on

### DIFF
--- a/apps/tuval/src/bin.ts
+++ b/apps/tuval/src/bin.ts
@@ -64,7 +64,7 @@ const tuval = Command.make(
 		),
 	},
 	Effect.fn(function* ({config, project, noPage, pagePort}) {
-		const {report, kernel, moduleRenderers} = yield* boot({
+		const {report, kernel, moduleRenderers, features} = yield* boot({
 			global: Option.getOrElse(config, defaultGlobalConfig),
 			project: Option.getOrElse(project, () => process.cwd()),
 		}).pipe(
@@ -105,7 +105,10 @@ const tuval = Command.make(
 			// The config's rows are the page's loader list too: every `kind: "module"` renderer they name
 			// is handed to the page server beside the config module that declared it, and the page refuses
 			// a specifier that resolves from neither (ADR 0359, amended by #8262).
-			yield* servePage({root: appRoot, transport, port: pagePort, moduleRenderers}).pipe(
+			// The merged flags ride along for the same reason the rows do: the page generates them into
+			// a module its renderer table imports, and that is the only way a flag an operator turned
+			// on in their config reaches the browser (#8439).
+			yield* servePage({root: appRoot, transport, port: pagePort, moduleRenderers, features}).pipe(
 				Effect.flatMap((page) => Console.log(`tuval: desk at ${page.url}`)),
 				Effect.catch((error) => Console.error(`tuval: ${error.message}`)),
 			);

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -13,7 +13,7 @@ import type {SpellRegistry} from "./commands/registry.ts";
 import type {WindowIndex} from "./commands/scope.ts";
 import type {AnySpell} from "./commands/spell.ts";
 import {SpellSet} from "./commands/spell-set.ts";
-import {type ConfigLoadError, loadLayeredConfig} from "./config.ts";
+import {type ConfigLoadError, loadLayeredConfig, type TuvalFeatures} from "./config.ts";
 import {Checkpoints} from "./durability/Checkpoints.ts";
 import {restore} from "./durability/restore.ts";
 import {fileStores} from "./durability/stores.ts";
@@ -192,6 +192,12 @@ export interface Booted {
 	 */
 	readonly moduleRenderers: ReadonlyArray<ModuleRendererRef>;
 	/**
+	 * The merged feature flags, every one resolved to a boolean. Carried out of the boot because the
+	 * page server generates them into a module the browser imports — without that they stay on this
+	 * side and an operator who turns one on sees nothing (#8439).
+	 */
+	readonly features: TuvalFeatures;
+	/**
 	 * The config read again, its spells registered and its bindings compiled against them in one
 	 * write, and then every live process handed what its own row says the new config means for it
 	 * (`reload.ts`). Nothing restarts and nothing respawns: a process keeps running under the row
@@ -253,6 +259,7 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 		report,
 		kernel: started.kernel,
 		moduleRenderers: config.moduleRenderers,
+		features: config.features,
 		reload: reload().pipe(Effect.provideContext(started.kernel)),
 	} satisfies Booted;
 });

--- a/apps/tuval/src/claude/proof/serve.ts
+++ b/apps/tuval/src/claude/proof/serve.ts
@@ -60,7 +60,15 @@ const proof = Command.make(
 
 		const booted = yield* boot({global: configModule, project});
 		const transport = yield* serveDesk({kernel: booted.kernel, port: 0, table: defaultPrefixTable});
-		const page = yield* servePage({root: appRoot, transport, port: pagePort}).pipe(Effect.orDie);
+		// The booted flags ride to the page for the same reason they do in `src/bin.ts`: this harness
+		// is the one desk a founder can turn a flag on in and look at, so a run that dropped them
+		// would render the flags-off window whatever their config says (#8439).
+		const page = yield* servePage({
+			root: appRoot,
+			transport,
+			port: pagePort,
+			features: booted.features,
+		}).pipe(Effect.orDie);
 		yield* Console.log(`claude-real proof: project ${project}`);
 		yield* Console.log(`claude-real proof: desk at ${page.url}`);
 		yield* Console.log(

--- a/apps/tuval/src/claude/window/ClaudeChatWindow.tsx
+++ b/apps/tuval/src/claude/window/ClaudeChatWindow.tsx
@@ -21,5 +21,9 @@ import {chatWindow} from "../../shell/chat/index.ts";
 export const claudeChatWindow = (options: ChatWindowOptions = {}): ChatWindowRenderer =>
 	chatWindow(options);
 
-/** The renderer `CLAUDE_CHAT_WINDOW_REF` names, at its defaults: what a page's table binds. */
+/**
+ * The renderer `CLAUDE_CHAT_WINDOW_REF` names, at its defaults — every feature flag off. The page's
+ * table no longer binds it: that table builds its own at the operator's flags (#8439). This stays as
+ * the defaults themselves, which is what a test mounting the window without options wants.
+ */
 export const ClaudeChatWindow: ChatWindowRenderer = claudeChatWindow();

--- a/apps/tuval/src/claude/window/claude-chat-window.unit.test.tsx
+++ b/apps/tuval/src/claude/window/claude-chat-window.unit.test.tsx
@@ -135,9 +135,14 @@ describe("the window's scheme", () => {
 });
 
 describe("the row's renderer reference", () => {
-	it("resolves to this renderer in the page's table", () => {
+	// Not an identity check against `ClaudeChatWindow` any more: the page builds its own renderer at
+	// the operator's feature flags, so the table holds an equivalent renderer rather than this
+	// module's default constant (#8439). What is still checked is that the reference has a seat, that
+	// the seat holds a renderer of the kind the reference declares, and its guard.
+	it("resolves to a renderer of this kind in the page's table", () => {
 		const entry = renderers[CLAUDE_CHAT_WINDOW_REF.ref];
-		expect(entry?.renderer).toBe(ClaudeChatWindow);
+		expect(entry?.renderer.kind).toBe(CLAUDE_CHAT_WINDOW_REF.kind);
+		expect(entry?.renderer.kind).toBe(ClaudeChatWindow.kind);
 		// Guarded by the session state's own predicate, so a kernel sending an older shape refuses in
 		// this window instead of throwing through it (#8157).
 		expect(entry?.admits(claudeSessionState())).toBe(true);

--- a/apps/tuval/src/config-fixtures/features-off.ts
+++ b/apps/tuval/src/config-fixtures/features-off.ts
@@ -1,0 +1,1 @@
+export default {version: 1, programs: [{id: "a"}], features: {subagentList: false}};

--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -24,6 +24,9 @@ import {
 	describeFile,
 	KeyBindings,
 } from "./commands/bindings/index.ts";
+// Re-exported below rather than declared here: both ends of the node/browser wire need the resolved
+// flag record, and this module reaches `node:*` (#8439).
+import {featuresOff, type TuvalFeatures} from "./features.ts";
 import {type Graph, NodeId} from "./ports/graph.ts";
 import {type AnyProgram, ProgramId} from "./registry/program.ts";
 import {
@@ -63,16 +66,7 @@ const DeclaredFeatures = Schema.Struct({
 	subagentList: Schema.optionalKey(Schema.Boolean),
 });
 
-/** The flags as everything downstream reads them: every one resolved to a boolean. */
-export interface TuvalFeatures {
-	readonly subagentList: boolean;
-}
-
-/**
- * Every flag off. A user-facing change ships dark behind a default-off flag
- * (`product-development-cycle.md`), so this is what a config that declares no `features` means.
- */
-export const featuresOff: TuvalFeatures = {subagentList: false};
+export {featuresOff, type TuvalFeatures} from "./features.ts";
 
 /** Version 1 of the config shape. A config module default-exports its `Encoded` form. */
 export const TuvalConfig = Schema.Struct({

--- a/apps/tuval/src/features.ts
+++ b/apps/tuval/src/features.ts
@@ -1,0 +1,25 @@
+/**
+ * The feature flags as everything downstream reads them, and the record a config that states none
+ * means. Its own module, node-free on purpose: the flags are merged on the node side (`./config.ts`)
+ * and read on the browser side, so both ends need this type and only one end may reach `node:*`.
+ * `page/assets.d.ts` types the generated `virtual:tuval/features` module from here, and
+ * `tsconfig.browser.json` — which compiles with `types: []` — is what would red if this file grew a
+ * Node import (#8439).
+ *
+ * A flag added here crosses to the page with no other edit: the generated module is written by
+ * walking this record (`page/dev-server.ts`).
+ */
+
+export interface TuvalFeatures {
+	/**
+	 * The running-subagent list at the top of the agent window, and — the same flag, because they are
+	 * one change — a subagent's rows leaving the agent window's transcript (#8405).
+	 */
+	readonly subagentList: boolean;
+}
+
+/**
+ * Every flag off. A user-facing change ships dark behind a default-off flag
+ * (`product-development-cycle.md`), so this is what a config that declares no `features` means.
+ */
+export const featuresOff: TuvalFeatures = {subagentList: false};

--- a/apps/tuval/src/page/assets.d.ts
+++ b/apps/tuval/src/page/assets.d.ts
@@ -17,3 +17,23 @@ declare module "virtual:tuval/module-renderers" {
 	const loaders: Readonly<Record<string, () => Promise<unknown>>>;
 	export default loaders;
 }
+
+/**
+ * The page server's generated feature-flag module (`./dev-server.ts`, #8439): the booted config's
+ * flags, every one resolved to a boolean, so `./renderers.tsx` builds each chat renderer at the
+ * operator's flags with no async step.
+ *
+ * The shape is `TuvalFeatures` itself, read from `../features.ts` — the node-free module that owns
+ * it — and never from `../config.ts`, which merges the layers and imports `node:*`: this file is in
+ * `tsconfig.browser.json`'s two-file `include`, so naming `config.ts` here drags it into a project
+ * compiled with `types: []` and reds on the `node:` specifiers.
+ *
+ * It is an `import(…)` type rather than a top-level import because a `.d.ts` carrying one of those
+ * stops being ambient, and every `declare module` in it turns into an augmentation of a module that
+ * does not exist. Being a type position, it is also no runtime edge — `./boundary.unit.test.ts`
+ * still walks a page that reaches nothing Node-only.
+ */
+declare module "virtual:tuval/features" {
+	const features: import("../features.ts").TuvalFeatures;
+	export default features;
+}

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -18,6 +18,7 @@
 
 import {dirname} from "node:path";
 import {Effect, Schema} from "effect";
+import {featuresOff, type TuvalFeatures} from "../features.ts";
 import type {TransportServer} from "../shell/transport/server.ts";
 import type {ModuleRendererRef} from "../shell/window/index.ts";
 
@@ -60,6 +61,12 @@ export interface PageServerOptions {
 	 * and the page loads nothing.
 	 */
 	readonly moduleRenderers?: ReadonlyArray<ModuleRendererRef>;
+	/**
+	 * The booted config's feature flags (`../config.ts`), merged and every one resolved to a boolean.
+	 * Absent means `featuresOff` — what a caller serving the page over its own rows rather than a
+	 * founder's config wants.
+	 */
+	readonly features?: TuvalFeatures;
 }
 
 export interface PageServer {
@@ -103,6 +110,49 @@ export const moduleRenderersSource = (refs: ReadonlyArray<string>): string => {
 		return `\t${literal}: () => import(${literal}),`;
 	});
 	return `export default {\n${entries.join("\n")}\n};\n`;
+};
+
+/**
+ * The page's feature-flag module, generated here from the booted config and imported by
+ * `./renderers.tsx` under this one id; `./assets.d.ts` declares its shape. It exists for the reason
+ * `MODULE_RENDERERS_ID` does: the flags are merged on the node side, the renderer table is built on
+ * the browser side, and a generated module is the wire between them that costs the table no async
+ * step — so a chat renderer is built at the operator's flags before the first paint rather than
+ * rebuilt after a fetch (#8439).
+ */
+export const FEATURES_ID = "virtual:tuval/features";
+const RESOLVED_FEATURES_ID = `\0${FEATURES_ID}`;
+
+/**
+ * The source of the feature-flag module: one boolean per flag, keyed by the flag's name. It walks
+ * the resolved flags rather than naming any one of them, so a flag added to `TuvalFeatures` reaches
+ * the page with no edit here. Every value is written through `=== true` because this is the
+ * *resolved* record: a `false` has to reach the page as `false`, never as an absent key.
+ */
+export const featuresSource = (features: TuvalFeatures): string => {
+	const entries = Object.entries(features).map(
+		([flag, on]) => `\t${sourceLiteral(flag)}: ${on === true},`,
+	);
+	return `export default {\n${entries.join("\n")}\n};\n`;
+};
+
+/**
+ * The plugin serving that module. Exported because the renderer table imports the specifier
+ * unconditionally, so every environment loading the table has to answer it: the dev server below
+ * with the founder's flags, and `vitest.config.ts` with `featuresOff` — the flags-off desk a unit
+ * test means to render.
+ */
+export const featuresPlugin = (features: TuvalFeatures = featuresOff) => {
+	const source = featuresSource(features);
+	return {
+		name: "tuval-features",
+		resolveId(id: string) {
+			return id === FEATURES_ID ? RESOLVED_FEATURES_ID : null;
+		},
+		load(id: string) {
+			return id === RESOLVED_FEATURES_ID ? source : null;
+		},
+	};
 };
 
 /**
@@ -277,7 +327,12 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 				root: options.root,
 				configFile: false,
 				appType: "spa",
-				plugins: [launchEndpoint, moduleRenderersPlugin(moduleRenderers), react.default()],
+				plugins: [
+					launchEndpoint,
+					moduleRenderersPlugin(moduleRenderers),
+					featuresPlugin(options.features),
+					react.default(),
+				],
 				server: {
 					port: options.port,
 					strictPort: options.strictPort ?? false,

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -1,14 +1,24 @@
 /**
- * The generated loader module (ADR 0359), as text: the page server writes it from the rows'
- * `kind: "module"` references, and this is the one place its shape is pinned. The served module and
- * the boot-time refusal of a specifier that does not resolve are `module-renderers.integration.test.ts`.
+ * The two generated modules, as text: the page server writes the loader module from the rows'
+ * `kind: "module"` references (ADR 0359) and the feature-flag module from the booted config (#8439),
+ * and this is the one place either shape is pinned. The served loader module and the boot-time
+ * refusal of a specifier that does not resolve are `module-renderers.integration.test.ts`.
  */
 
+import {fileURLToPath} from "node:url";
+import {NodeFileSystem} from "@effect/platform-node";
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
+import {loadLayeredConfig} from "../config.ts";
 import type {AnyProgram} from "../registry/program.ts";
 import {counterRow, noRendererRow} from "../shell/window/fixtures.ts";
 import {type DeclaredProgram, moduleRendererRefs} from "../shell/window/index.ts";
-import {moduleRenderersSource, optimizedDepEntries, servedDirectories} from "./dev-server.ts";
+import {
+	featuresSource,
+	moduleRenderersSource,
+	optimizedDepEntries,
+	servedDirectories,
+} from "./dev-server.ts";
 
 const GLOBAL_CONFIG = "/home/founder/.tuval/tuval.config.ts";
 const PROJECT_CONFIG = "/work/app/.tuval/tuval.config.ts";
@@ -36,6 +46,51 @@ describe("the module renderers loader module", () => {
 		const source = moduleRenderersSource(["a\u2028b\u2029c"]);
 		expect(source).not.toMatch(/[\u2028\u2029]/);
 		expect(source).toContain('import("a\\u2028b\\u2029c")');
+	});
+});
+
+/**
+ * Driven from real merged configs rather than a hand-written flag record, because the wire this
+ * pins is the whole one: what a founder writes in a layer is what the browser reads. A merge that
+ * resolved a flag differently would show up here as generated source, which is the failure #8439
+ * was — the flag merged correctly and reached nobody.
+ */
+describe("the feature-flag module", () => {
+	const fixture = (name: string) =>
+		fileURLToPath(new URL(`../config-fixtures/${name}.ts`, import.meta.url));
+
+	const generated = (global: string, project: string) =>
+		Effect.runPromise(
+			loadLayeredConfig({global: fixture(global), project: fixture(project)}).pipe(
+				Effect.map((config) => featuresSource(config.features)),
+				Effect.provide(NodeFileSystem.layer),
+			),
+		);
+
+	it("carries a flag a layer turned on", async () => {
+		expect(await generated("features-on", "two-rows")).toBe(
+			'export default {\n\t"subagentList": true,\n};\n',
+		);
+	});
+
+	it("carries a flag a layer turned off", async () => {
+		expect(await generated("features-off", "two-rows")).toBe(
+			'export default {\n\t"subagentList": false,\n};\n',
+		);
+	});
+
+	// The page reads `features.subagentList` and gets a boolean either way: an absent key would read
+	// `undefined`, which is falsy and so passes by luck until a flag defaults on.
+	it("carries every flag as false when no layer declares a features block", async () => {
+		expect(await generated("two-rows", "one-counter")).toBe(
+			'export default {\n\t"subagentList": false,\n};\n',
+		);
+	});
+
+	it("names no flag itself, so a flag added to TuvalFeatures crosses with no edit here", () => {
+		expect(featuresSource({subagentList: true, somethingLater: false} as never)).toBe(
+			'export default {\n\t"subagentList": true,\n\t"somethingLater": false,\n};\n',
+		);
 	});
 });
 

--- a/apps/tuval/src/page/renderers.tsx
+++ b/apps/tuval/src/page/renderers.tsx
@@ -11,8 +11,10 @@
  * The two demo renderers below are the demo programs' (#7517). Each reads its process through the
  * window contract's `readProcess` and nothing else: no store, no fetch, no socket.
  *
- * The Pi entry is `PiChatWindow` (#7611), the Claude entry is `ClaudeChatWindow` (#7624) and the
- * session-list entry is `SessionListWindow` (#8102). They are why this module is out of the
+ * The Pi entry is `piChatWindow` (#7611), the Claude entry is `claudeChatWindow` (#7624) and the
+ * session-list entry is `SessionListWindow` (#8102). Both chat entries are *built* here rather than
+ * imported as their modules' default constants, because each is built at the operator's feature
+ * flags (`chatOptions` below, #8439). They are why this module is out of the
  * kernel's strict lens and inside `tsconfig.design.json`'s: each is built on `@kampus/design`,
  * which is source-consumed and authored with
  * `exactOptionalPropertyTypes: false`. Each key is the reference that program's own row declares,
@@ -23,6 +25,7 @@
  * it renders came over the socket the desk is attached to and dies with it (#8161).
  */
 
+import features from "virtual:tuval/features";
 import {Effect, Fiber, Stream} from "effect";
 import type {ReactElement} from "react";
 import {useEffect, useState} from "react";
@@ -35,10 +38,11 @@ import {
 	type SessionListSource,
 	sessionListWindow,
 } from "../ai-agent/window/index.ts";
-import {CLAUDE_CHAT_WINDOW_REF, ClaudeChatWindow} from "../claude/window/index.ts";
+import {CLAUDE_CHAT_WINDOW_REF, claudeChatWindow} from "../claude/window/index.ts";
 import {type CounterState, isCounterState} from "../demo/counter.ts";
 import {isLogState, type LogState} from "../demo/log.ts";
-import {PI_CHAT_WINDOW_REF, PiChatWindow} from "../pi/window/index.ts";
+import {PI_CHAT_WINDOW_REF, piChatWindow} from "../pi/window/index.ts";
+import type {ChatWindowOptions} from "../shell/chat/index.ts";
 import type {AnyInspectorRenderer} from "../shell/desk/index.ts";
 import type {PageAttachment} from "../shell/transport/browser.ts";
 import type {WindowHost} from "../shell/window/index.ts";
@@ -139,6 +143,20 @@ const sessionListSource = (call: SpellCaller): SessionListSource => {
 };
 
 /**
+ * What the two chat renderers are built at: the operator's own flags, read straight out of the
+ * module the page server generated from the booted config (`./dev-server.ts`, #8439). It is a plain
+ * import rather than a fetch or a prop, which is the whole point — the table below is built
+ * synchronously, so a flagged window is the first thing painted rather than the second.
+ *
+ * Nothing here reaches `../config.ts` at runtime: the flags arrive as generated source and the
+ * shape arrives as a type (`./assets.d.ts`), so the page's Node-free walk is unaffected.
+ */
+const chatOptions: ChatWindowOptions = {subagentList: features.subagentList};
+
+const claudeWindow = claudeChatWindow(chatOptions);
+const piWindow = piChatWindow(chatOptions);
+
+/**
  * Every renderer the page knows, by the reference a program row names it with — each bound to the
  * predicate over the state it reads, which is what the `ReadableRenderer` type asks for. A renderer
  * put here unguarded does not typecheck, so the rule holds at the table and not by review (#8157).
@@ -154,8 +172,8 @@ export const pageRenderers = (call: SpellCaller): Readonly<Record<string, Readab
 		isLogState,
 		windowRenderer("host-native", (host: WindowHost<LogState>) => <LogRenderer host={host} />),
 	),
-	[PI_CHAT_WINDOW_REF.ref]: readsState(isAiAgentSessionState, PiChatWindow),
-	[CLAUDE_CHAT_WINDOW_REF.ref]: readsState(isAiAgentSessionState, ClaudeChatWindow),
+	[PI_CHAT_WINDOW_REF.ref]: readsState(isAiAgentSessionState, piWindow),
+	[CLAUDE_CHAT_WINDOW_REF.ref]: readsState(isAiAgentSessionState, claudeWindow),
 	[SESSION_LIST_WINDOW_REF.ref]: readsState(
 		isSessionListState,
 		sessionListWindow({useAnswer: sessionListSource(call)}),

--- a/apps/tuval/src/pi/window/PiChatWindow.tsx
+++ b/apps/tuval/src/pi/window/PiChatWindow.tsx
@@ -20,5 +20,9 @@ import {chatWindow} from "../../shell/chat/index.ts";
 export const piChatWindow = (options: ChatWindowOptions = {}): ChatWindowRenderer =>
 	chatWindow(options);
 
-/** The renderer `PI_CHAT_WINDOW_REF` names, at its defaults: what a page's renderer table binds. */
+/**
+ * The renderer `PI_CHAT_WINDOW_REF` names, at its defaults — every feature flag off. The page's
+ * table no longer binds it: that table builds its own at the operator's flags (#8439). This stays as
+ * the defaults themselves, which is what a test mounting the window without options wants.
+ */
 export const PiChatWindow: ChatWindowRenderer = piChatWindow();

--- a/apps/tuval/vitest.config.ts
+++ b/apps/tuval/vitest.config.ts
@@ -1,4 +1,5 @@
 import {defineConfig} from "vitest/config";
+import {featuresPlugin} from "./src/page/dev-server.ts";
 
 // A `unit` project so `vitest --project unit` (the pre-push `unit-changed` leg over `apps/**`)
 // resolves here, and an `integration` project beside it now that the app has one. Tuval's
@@ -30,10 +31,20 @@ const execArgv = ["--max-old-space-size=512", "--no-experimental-webstorage"];
 // reached 74-87 workers and load average 218. `undefined` on CI falls through to that default.
 const maxWorkers = process.env.CI ? undefined : 2;
 
+// `src/page/renderers.tsx` imports `virtual:tuval/features` — the module the page server generates
+// from the booted config (#8439) — so any test that reaches the renderer table has to be able to
+// resolve it. Served here at `featuresOff`, its default: a unit test renders the desk an operator
+// who turned nothing on gets. A test wanting a flag on passes `ChatWindowOptions` to `chatWindow()`
+// directly, which is what `src/shell/chat/subagent-list.unit.test.tsx` does.
+// Declared per project rather than at the root: Vitest 4 builds each project's own Vite server and
+// a root `plugins` entry does not reach one.
+const plugins = [featuresPlugin()];
+
 export default defineConfig({
 	test: {
 		projects: [
 			{
+				plugins,
 				test: {
 					name: "unit",
 					include: ["src/**/*.unit.test.ts", "src/**/*.unit.test.tsx"],
@@ -44,6 +55,7 @@ export default defineConfig({
 				},
 			},
 			{
+				plugins,
 				test: {
 					name: "integration",
 					include: ["src/**/*.integration.test.ts"],


### PR DESCRIPTION
Tuval's config grew a `features` block in #8405, but nothing carried it from the node boot to the browser. The chat renderers were module-scope constants built at their defaults, so an operator who wrote `features: {subagentList: true}` in their config saw no change at all — the gate shipped dark and stayed dark.

This is the wire. `virtual:tuval/features` is generated by the page server from the booted config, the same idiom `virtual:tuval/module-renderers` already uses, and `renderers.tsx` imports it to build both `chatWindow()` renderers at the operator's flags. No async step, so a flagged window is the first thing painted rather than the second.

## What moved

- `page/dev-server.ts` — `FEATURES_ID`, `featuresSource` and `featuresPlugin`, plus a `features` option on `PageServerOptions` defaulting to `featuresOff`. `featuresSource` walks the resolved flag record rather than naming any flag, so a flag added to `TuvalFeatures` crosses with no edit here.
- `page/assets.d.ts` — the module's shape, typed as `TuvalFeatures` itself through an `import(…)` type.
- `page/renderers.tsx` — reads the module and binds `claudeChatWindow(chatOptions)` / `piChatWindow(chatOptions)`.
- `boot.ts` / `bin.ts` — `Booted.features`, passed to `servePage`.
- `features.ts` (new) — `TuvalFeatures` and `featuresOff` moved out of `config.ts` into a Node-free module, re-exported from `config.ts` so every existing importer is unaffected.

`config.ts` imports `node:path` and `node:url`, and `tsconfig.browser.json` compiles the page entry plus `assets.d.ts` with `types: []`. Typing the virtual module off `config.ts` therefore dragged a Node-importing module into that project and reduced to three `TS2591` errors. The guard was right and the fix is the split above, not a suppression. Nothing browser-side reaches `config.ts` or `boot.ts` at runtime; `page/boundary.unit.test.ts` still walks a Node-free graph.

## Hand-verified on a scratch desk

Port `127.0.0.1:5318`, never 5173 (the founder's desk stayed up and untouched throughout). Real Claude session on the real CLI, `claude` 2.1.263, driven with Playwright through `src/claude/proof/serve.ts`. Desk stopped and the port released afterwards.

The only thing that changed between arms is one line of the project config layer.

**The generated module, read straight off the running dev server:**

| Project layer | `GET /@id/__x00__virtual:tuval/features` |
|---|---|
| `{version: 1, programs: [], features: {subagentList: true}}` | `export default {\n\t"subagentList": true,\n};` |
| `{version: 1, programs: []}` | `export default {\n\t"subagentList": false,\n};` |

**Flag on — the list is there, live.** Prompt: *"Launch exactly one Explore subagent and ask it to list what files exist in the current working directory, then tell me in one sentence what it reported. Use no other tools yourself."*

| Probe | Result |
|---|---|
| `role=list, name="Running subagents"` | **1** |
| `.tuval-chat-subagents` nodes | **1** |
| Rows | one — `type: "Explore"` |
| Row's `lastLine`, live | `"List what files and directories exist in the current working directory"` → `"Bash"` |
| Row's elapsed, live | ticked `0s` → `3m 14s` |
| Rendered row | `Explore · Bash · 3m 14s · 17.9k` |
| Agent row's disclosure | **none** — the subagent's rows are out of the transcript |
| Browser page errors | none |

**Flag off — no list, on a live subagent.** Same desk, same prompt, layer with no `features` block.

| Probe | Result |
|---|---|
| `role=list, name="Running subagents"` | **0**, at every poll |
| `.tuval-chat-subagents` nodes | **0**, at every poll |
| Agent row's disclosure, live | `Show 1 nested call` → `Show 2` → `3` → `4` → `Show 5 nested calls` |
| Turn outcome | `Agent ok`, fold of 5 nested calls, agent's reply rendered |
| Browser page errors | none |

The climbing fold count is what makes this arm falsifiable: a real Explore worker was streaming frames the whole time, and no list appeared.

**One thing I got wrong and caught.** My first flag-off arm reused the flag-on run's checkpoint, to spend a single turn. It read zero list regions — and that reading was worthless. I re-ran the same restored session with the flag back **on** as a falsifiability check, and it also showed zero: the port's subagent slots are filled by the live mapper from streamed frames and are not rebuilt from history, so a restored session shows no list whatever the flag says. The flag-off arm above is therefore a second live turn, not a checkpoint replay. That is one real Claude turn more than the ticket budgeted, and it is the reason the arm means anything.

Also observed, already filed as #8446 and not touched here: the restored desk showed a `Could not load earlier messages: … cursor-not-found` head row.

## Tests

Tuval unit subset: **2047 tests across 214 files, all passing**. `pnpm typecheck` clean on all three projects (`tsconfig.json`, `tsconfig.design.json`, `tsconfig.browser.json`); `build check --surface code` green with an empty `unvalidated`.

New coverage in `page/dev-server.unit.test.ts` drives `featuresSource` from real merged configs through `loadLayeredConfig` rather than a hand-written flag record — flag on, flag off, and no `features` block at all — plus one case pinning that the generator names no flag itself.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8439 names the transport, not the Claude window's tests. **Did:** rewrote one assertion in `claude/window/claude-chat-window.unit.test.tsx` ("the row's renderer reference"), which checked `entry?.renderer` was identically the `ClaudeChatWindow` constant; it now checks the entry's renderer kind and keeps both `admits` assertions. **Why:** the page's table no longer binds that constant — it builds its own renderer at the operator's flags, which is the change — so object identity could not hold. Behaviour is unchanged: `chatWindow({subagentList: false})` and `chatWindow()` resolve identically. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the pointers name `config.ts`, `boot.ts`, `renderers.tsx`, `dev-server.ts` and `assets.d.ts`. **Did:** also added `apps/tuval/src/features.ts` and moved `TuvalFeatures` / `featuresOff` into it, re-exporting both from `config.ts`. **Why:** `tsconfig.browser.json`'s `types: []` guard reds when `assets.d.ts` types the virtual module off `config.ts`, which imports `node:*`; both ends of the wire need the record and only one may reach Node. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the wire from the boot to the page. **Did:** also passed `features: booted.features` in `claude/proof/serve.ts`. **Why:** that harness is the desk this change was hand-verified on, and without it the proof run renders the flags-off window whatever the config says. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the test runner. **Did:** registered `featuresPlugin()` on both projects in `apps/tuval/vitest.config.ts`. **Why:** `renderers.tsx` now imports the virtual specifier unconditionally, and several unit tests reach that table; without a resolver they fail to import. It serves `featuresOff`, which is the flags-off desk a unit test means to render. **Disposition:** stated here.

Fixes #8439
