### PR TITLE
feat: Chat window: swap the view slot to a subagent in place, with the list as navigator and a finished state

### DIFF
--- a/apps/tuval/src/claude/agent/refusals.ts
+++ b/apps/tuval/src/claude/agent/refusals.ts
@@ -71,6 +71,7 @@ export const unknownCursor = (reason: string): PageError =>
  * parse are three different things to have to tell an operator, and "this subagent said nothing"
  * is none of them.
  */
+/** The id is appended here and named nowhere else — a caller that spells it again says it twice. */
 export const subagentNotFound = (agentId: string, detail: string): PageError =>
 	new PageError({reason: "subagent-not-found", detail: `${detail} (${agentId})`});
 

--- a/apps/tuval/src/claude/agent/refusals.ts
+++ b/apps/tuval/src/claude/agent/refusals.ts
@@ -70,8 +70,10 @@ export const unknownCursor = (reason: string): PageError =>
  * transcript: a sidechain file nobody wrote, a store that would not open and a line that will not
  * parse are three different things to have to tell an operator, and "this subagent said nothing"
  * is none of them.
+ *
+ * `subagentNotFound` appends the id itself and is the only place that names it — a caller that
+ * spells it in its own `detail` says it twice.
  */
-/** The id is appended here and named nowhere else — a caller that spells it again says it twice. */
 export const subagentNotFound = (agentId: string, detail: string): PageError =>
 	new PageError({reason: "subagent-not-found", detail: `${detail} (${agentId})`});
 

--- a/apps/tuval/src/claude/agent/sidechain-store.ts
+++ b/apps/tuval/src/claude/agent/sidechain-store.ts
@@ -74,7 +74,7 @@ const locateSessionDir = Effect.fn("Claude.locateSessionDir")(function* (
 	for (const entry of yield* fs.readDirectory(projects).pipe(unreadable)) {
 		if (yield* fs.exists(at(entry)).pipe(unreadable)) return at(entry);
 	}
-	return yield* subagentNotFound(session.id, `no stored session directory for "${session.id}"`);
+	return yield* subagentNotFound(session.id, "no stored session directory for this session");
 });
 
 /**
@@ -95,7 +95,7 @@ export const readSubagentTranscript = Effect.fn("Claude.readSubagentTranscript")
 
 	const file = path.join(dir, sidechainFileName(agentId));
 	if (!(yield* fs.exists(file).pipe(unreadable))) {
-		return yield* subagentNotFound(agentId, `no transcript file for subagent "${agentId}"`);
+		return yield* subagentNotFound(agentId, "no transcript file for this subagent");
 	}
 	const jsonl = yield* fs.readFileString(file).pipe(unreadable);
 	const meta = yield* fs

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -64,13 +64,14 @@ import {
 	rowIndexOfItem,
 	rowKey,
 	subagentHeads,
+	subagentRows,
 } from "./rows.ts";
 import {SessionRow} from "./SessionRow.tsx";
 import {SubagentList} from "./SubagentList.tsx";
 import {ThinkingRow} from "./ThinkingRow.tsx";
 import {type ToolFold, ToolRow} from "./ToolRow.tsx";
 import {UnsentMessages} from "./UnsentMessages.tsx";
-import {asChatView, type ChatView} from "./view.ts";
+import {asChatView, type ChatView, viewMain, viewSubagent} from "./view.ts";
 import "./chat.css";
 
 export type ChatWindowHost = WindowHost<AiAgentSessionState, AiAgentSessionMsg, ChatView>;
@@ -487,7 +488,21 @@ function ChatWindow({
 		[options.subagentList, subagentSlots],
 	);
 
-	const rows = useMemo(
+	/**
+	 * Which transcript the one view slot is showing (founder ruling Q7 on #8384), or `null` for the
+	 * agent's own. Gated on the flag rather than trusted from the slot: a slot written while the flag
+	 * was on must not keep a window swapped away once it is off (#8405's containment).
+	 */
+	const viewing = options.subagentList ? view.viewing : null;
+	const viewedSlot = viewing === null ? undefined : state?.subagents[viewing.id];
+
+	const showSubagent = useCallback(
+		(id: string) => commit((current) => viewSubagent(current, id)),
+		[commit],
+	);
+	const showMain = useCallback(() => commit(viewMain), [commit]);
+
+	const mainRows = useMemo(
 		() =>
 			chatRows({
 				older,
@@ -500,6 +515,13 @@ function ChatWindow({
 				subagents,
 			}),
 		[older, state, loading, pageError, view.atOldest, unfolded, subagents],
+	);
+
+	// The swap is a swap of *this* list and nothing else: main's own rows, pages and cursor are left
+	// exactly as they were, which is what lets the back action put the window back where it was.
+	const rows = useMemo(
+		() => (viewedSlot === undefined ? mainRows : subagentRows(viewedSlot, unfolded)),
+		[viewedSlot, mainRows, unfolded],
 	);
 
 	/** The row the viewport was resting on when the current page was asked for. */
@@ -565,6 +587,9 @@ function ChatWindow({
 	const totalSize = virtualizer.getTotalSize();
 
 	const requestOlder = useCallback(() => {
+		// A subagent's rows arrive whole with its slot, so there is no page behind them to ask for —
+		// and the ids in this list are the worker's, which the agent's own cursor knows nothing about.
+		if (viewing !== null) return;
 		if (pageRequestRef.current !== null || view.atOldest || rows.length === 0) return;
 		const request = olderPageRequest(rows);
 		if (request === null) return;
@@ -615,6 +640,7 @@ function ChatWindow({
 			}),
 		);
 	}, [
+		viewing,
 		view.atOldest,
 		rows,
 		session,
@@ -650,12 +676,22 @@ function ChatWindow({
 	// A window left following its newest turn is restored onto the newest row and not onto its saved
 	// offset: that offset was the bottom when it was written, and the transcript has grown since.
 	const placedRef = useRef(false);
+	// …and once per swap after that. A swapped-in view is a different transcript, so the offset the
+	// viewport holds means nothing in it: the placement below runs again, onto the newest row of the
+	// subagent, or back onto the row and offset `viewMain` restored for the agent's own.
+	const placedViewRef = useRef<string | null>(viewing?.id ?? null);
+	useLayoutEffect(() => {
+		const id = viewing?.id ?? null;
+		if (placedViewRef.current === id) return;
+		placedViewRef.current = id;
+		placedRef.current = false;
+	}, [viewing]);
 	useLayoutEffect(() => {
 		if (placedRef.current || rows.length === 0) return;
 		placedRef.current = true;
 		if (!view.pinned && view.scroll > 0) virtualizer.scrollToOffset(view.scroll);
 		else virtualizer.scrollToIndex(rows.length - 1, {align: "end"});
-	}, [rows.length, view.pinned, view.scroll, virtualizer]);
+	}, [rows.length, view.pinned, view.scroll, viewing, virtualizer]);
 
 	// …and after that, the transcript follows the newest turn only while it is already resting on
 	// it. `totalSize` carries both cases the follow owes: a row appended, and the last row measuring
@@ -879,7 +915,28 @@ function ChatWindow({
 					</div>
 				</div>
 				{options.subagentList ? (
-					<SubagentList slots={process.state.subagents} now={options.now} />
+					<>
+						<SubagentList
+							slots={process.state.subagents}
+							now={options.now}
+							viewing={viewing?.id ?? null}
+							onView={showSubagent}
+							onMain={showMain}
+						/>
+						{/* The one live region for the view slot, and the reason the visible notice below is
+						    not a second one. A `log` announces what is appended to it, so a swap — which
+						    replaces the whole transcript under the reader — and a worker finishing under an
+						    open view are both announced here or nowhere. */}
+						<p className="kp-visually-hidden" role="status">
+							{viewedSlot === undefined
+								? viewing === null
+									? "Showing the agent's own transcript."
+									: "Showing a subagent whose transcript is not in this session's state."
+								: viewedSlot.status === "finished"
+									? `Showing the ${viewedSlot.type} subagent's transcript. Finished: ${viewedSlot.lastLine}`
+									: `Showing the ${viewedSlot.type} subagent's transcript. Still running.`}
+						</p>
+					</>
 				) : null}
 				<div
 					ref={scrollRef}
@@ -887,7 +944,10 @@ function ChatWindow({
 					onScroll={onScroll}
 					onKeyDown={swallowBareCharacter}
 					role="log"
-					aria-label="Transcript"
+					data-view={viewing === null ? undefined : viewing.id}
+					aria-label={
+						viewedSlot === undefined ? "Transcript" : `Transcript: ${viewedSlot.type} subagent`
+					}
 					// The scroll container is the only way to older turns on a plain transcript, so a
 					// keyboard user must be able to focus it (axe scrollable-region-focusable).
 					// biome-ignore lint/a11y/noNoninteractiveTabindex: a scroll region must take keyboard focus
@@ -927,6 +987,24 @@ function ChatWindow({
 						})}
 					</div>
 				</div>
+				{viewing === null ? null : (
+					// Q9, verbatim: "we should show something to user if they are actually inside a
+					// subagent that's already finished." The view stays open on the rows it had and says
+					// so at the end of them; the way back is the navigator's first row, above. Not a live
+					// region — the hidden one above carries this same sentence and announces it once.
+					<p className="tuval-chat-subagent-end" data-status={viewedSlot?.status}>
+						{viewedSlot === undefined ? (
+							"This subagent's transcript is not in this session's state."
+						) : viewedSlot.status === "finished" ? (
+							<>
+								<span className="tuval-chat-subagent-end-mark">finished</span>
+								{viewedSlot.lastLine}
+							</>
+						) : (
+							`The ${viewedSlot.type} subagent is still running.`
+						)}
+					</p>
+				)}
 				{isWorking(phase) ? (
 					// Visual only. The phase line above is the announced surface for the running turn, so a
 					// live region here would narrate that same turn twice; what this adds is the tell at

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -496,11 +496,45 @@ function ChatWindow({
 	const viewing = options.subagentList ? view.viewing : null;
 	const viewedSlot = viewing === null ? undefined : state?.subagents[viewing.id];
 
-	const showSubagent = useCallback(
-		(id: string) => commit((current) => viewSubagent(current, id)),
-		[commit],
+	/** The scroll offset `onScroll` is holding for its settle window, and the timer holding it. */
+	const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const restingAt = useRef<number | null>(null);
+	useEffect(
+		() => () => {
+			if (commitTimer.current !== null) clearTimeout(commitTimer.current);
+		},
+		[],
 	);
-	const showMain = useCallback(() => commit(viewMain), [commit]);
+
+	/**
+	 * Write the held offset now, so `scroll` describes where the *current* view rests before another
+	 * one takes its place.
+	 *
+	 * A swap that skipped this would be wrong twice over one debounce: `viewSubagent` would park an
+	 * offset up to `scrollCommitMs` behind where the reader actually is, and the timer would then fire
+	 * past the swap and write main's offset onto the subagent's `scroll` — a field that means a
+	 * different transcript now (review round 1 on #8467).
+	 */
+	const settleScroll = useCallback(() => {
+		if (commitTimer.current !== null) clearTimeout(commitTimer.current);
+		commitTimer.current = null;
+		const offset = restingAt.current;
+		restingAt.current = null;
+		if (offset === null) return;
+		commit((current) => (current.scroll === offset ? current : {...current, scroll: offset}));
+	}, [commit]);
+
+	const showSubagent = useCallback(
+		(id: string) => {
+			settleScroll();
+			commit((current) => viewSubagent(current, id));
+		},
+		[commit, settleScroll],
+	);
+	const showMain = useCallback(() => {
+		settleScroll();
+		commit(viewMain);
+	}, [commit, settleScroll]);
 
 	const mainRows = useMemo(
 		() =>
@@ -702,14 +736,6 @@ function ChatWindow({
 		virtualizer.scrollToIndex(rows.length - 1, {align: "end"});
 	}, [view.pinned, rows.length, totalSize, virtualizer]);
 
-	const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-	useEffect(
-		() => () => {
-			if (commitTimer.current !== null) clearTimeout(commitTimer.current);
-		},
-		[],
-	);
-
 	const onScroll = useCallback(
 		(event: UIEvent<HTMLDivElement>) => {
 			const offset = event.currentTarget.scrollTop;
@@ -728,9 +754,13 @@ function ChatWindow({
 				commit((current) => (current.pinned === pinned ? current : {...current, pinned}));
 			}
 			// The offset is where the transcript rests whoever moved it, so it is committed either way.
+			// It is held on a ref as well as in this closure, because a swap has to be able to settle it
+			// early — `settleScroll` above.
+			restingAt.current = offset;
 			if (commitTimer.current !== null) clearTimeout(commitTimer.current);
 			commitTimer.current = setTimeout(() => {
 				commitTimer.current = null;
+				restingAt.current = null;
 				commit((current) => (current.scroll === offset ? current : {...current, scroll: offset}));
 			}, options.scrollCommitMs);
 			if (byReader && offset <= options.topThreshold) requestOlder();

--- a/apps/tuval/src/shell/chat/SubagentList.tsx
+++ b/apps/tuval/src/shell/chat/SubagentList.tsx
@@ -1,10 +1,14 @@
 /**
- * The running-subagent list at the top of the agent window (#8405).
+ * The subagent navigator at the top of the agent window (#8405, #8406).
  *
- * Rendered off the port's subagent slot alone, so every agent program gets this list the moment its
+ * Rendered off the port's subagent slot alone, so every agent program gets it the moment its
  * mapper fills the slot — nothing here names a backend. Absent rather than empty when nothing is
- * running (Q4, the founder: "my screen should only show me enough info, not more"), which is why
- * this returns `null` instead of an empty region.
+ * running and the window is on main (Q4, the founder: "my screen should only show me enough info,
+ * not more"), which is why this returns `null` instead of an empty region.
+ *
+ * It is a navigator and not a readout (Q8): each row is a real button that swaps the window's one
+ * view slot onto that worker's transcript, and inside a subagent view a leading row swaps back to
+ * the agent's own. Both reach with mouse and keyboard alike, which was Q4's other half.
  *
  * Elapsed is the one thing the list computes rather than reads. It ticks on a timer that moves a
  * render counter and nothing else: a per-second `Msg` would checkpoint the whole session once a
@@ -15,20 +19,81 @@ import {MetaRow} from "@kampus/design";
 import type {ReactElement} from "react";
 import {useEffect, useMemo, useState} from "react";
 import type {SubagentSlot} from "../../ai-agent/ports/index.ts";
-import {elapsedLabel, runningSubagents, tokenLabel} from "./subagents.ts";
+import {elapsedLabel, runningSubagents, type SubagentRow, tokenLabel} from "./subagents.ts";
 
 /** How often the elapsed readouts are re-rendered. One second: the coarsest unit the label shows. */
 const TICK_MS = 1_000;
 
+function NavigatorRow({
+	row,
+	at,
+	onView,
+}: {
+	readonly row: SubagentRow;
+	readonly at: number;
+	readonly onView: (id: string) => void;
+}): ReactElement {
+	return (
+		<li className="tuval-chat-subagent-item">
+			<button
+				type="button"
+				className="tuval-chat-subagent-pick"
+				// The row that is showing is marked rather than disabled: a disabled control drops out
+				// of the tab order, so the operator's place in the navigator would vanish under them.
+				aria-current={row.current ? "true" : undefined}
+				onClick={() => onView(row.id)}
+			>
+				<MetaRow as="span" className="tuval-chat-subagent">
+					<span className="tuval-chat-subagent-type" data-field="type">
+						{row.type}
+					</span>
+					<MetaRow.Dot />
+					<span className="tuval-chat-subagent-line" data-field="line">
+						{row.lastLine}
+					</span>
+					{row.status === "finished" ? (
+						<>
+							<MetaRow.Dot />
+							{/* Q2: no elapsed and no token readout once a worker stops. */}
+							<span data-field="status">finished</span>
+						</>
+					) : (
+						<>
+							<MetaRow.Dot />
+							<span data-field="elapsed">
+								{/* The unit is what the number means, and the layout is the only thing saying it. */}
+								<span className="kp-visually-hidden">elapsed </span>
+								{elapsedLabel(at - row.startedAt)}
+							</span>
+							<MetaRow.Dot />
+							<span data-field="tokens">
+								{tokenLabel(row.tokens)}
+								<span className="kp-visually-hidden"> tokens</span>
+							</span>
+						</>
+					)}
+				</MetaRow>
+			</button>
+		</li>
+	);
+}
+
 export function SubagentList({
 	slots,
 	now,
+	viewing,
+	onView,
+	onMain,
 }: {
 	readonly slots: Readonly<Record<string, SubagentSlot>>;
 	readonly now: () => number;
+	/** The subagent whose transcript the window is showing, or `null` for the agent's own. */
+	readonly viewing: string | null;
+	readonly onView: (id: string) => void;
+	readonly onMain: () => void;
 }): ReactElement | null {
-	const model = useMemo(() => runningSubagents(slots), [slots]);
-	const running = model.rows.length;
+	const model = useMemo(() => runningSubagents(slots, viewing), [slots, viewing]);
+	const running = model.rows.filter((row) => row.status === "running").length;
 
 	// The counter's value is never read: setting it is the re-render, and the re-render is the tick.
 	const [, tick] = useState(0);
@@ -38,36 +103,32 @@ export function SubagentList({
 		return () => clearInterval(timer);
 	}, [running]);
 
-	if (running === 0) return null;
+	// A subagent view always draws the region, even with nothing to list: the way back is in it, and
+	// a slot that has gone from state must not take the operator's exit with it.
+	if (model.rows.length === 0 && viewing === null) return null;
 	const at = now();
 	return (
-		<ul className="tuval-chat-subagents" aria-label="Running subagents">
+		<ul
+			className="tuval-chat-subagents"
+			// On main the region is what it says: the workers running right now. In a subagent view it
+			// also carries the way back and, under Q9, a worker that has stopped — so it is named for
+			// what it is there instead.
+			aria-label={viewing === null ? "Running subagents" : "Subagents"}
+		>
+			{viewing === null ? null : (
+				<li className="tuval-chat-subagent-item">
+					<button type="button" className="tuval-chat-subagent-pick" onClick={onMain}>
+						<MetaRow as="span" className="tuval-chat-subagent">
+							Back to the agent transcript
+						</MetaRow>
+					</button>
+				</li>
+			)}
 			{model.rows.map((row) => (
-				<MetaRow as="li" className="tuval-chat-subagent" key={row.id}>
-					<span className="tuval-chat-subagent-type" data-field="type">
-						{row.type}
-					</span>
-					<MetaRow.Dot />
-					<span className="tuval-chat-subagent-line" data-field="line">
-						{row.lastLine}
-					</span>
-					<MetaRow.Dot />
-					<span data-field="elapsed">
-						{/* The unit is what the number means, and the layout is the only thing saying it. */}
-						<span className="kp-visually-hidden">elapsed </span>
-						{elapsedLabel(at - row.startedAt)}
-					</span>
-					<MetaRow.Dot />
-					<span data-field="tokens">
-						{tokenLabel(row.tokens)}
-						<span className="kp-visually-hidden"> tokens</span>
-					</span>
-				</MetaRow>
+				<NavigatorRow key={row.id} row={row} at={at} onView={onView} />
 			))}
-			{model.more === 0 ? null : (
-				<MetaRow as="li" className="tuval-chat-subagent-more">
-					{model.more} more running
-				</MetaRow>
+			{model.more <= 0 ? null : (
+				<li className="tuval-chat-subagent-more">{model.more} more running</li>
 			)}
 		</ul>
 	);

--- a/apps/tuval/src/shell/chat/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/chat/boundary.unit.test.ts
@@ -33,6 +33,7 @@ const chatViewFitsTheSlot: ViewState = {
 	atOldest: false,
 	expanded: [],
 	unfolded: [],
+	viewing: null,
 } satisfies ChatView;
 
 /**
@@ -112,6 +113,7 @@ describe("chat window boundary", () => {
 			atOldest: false,
 			expanded: [],
 			unfolded: [],
+			viewing: null,
 		});
 		expect(interfaceMisfitsTheSlot).toBe(asInterface);
 		expect(isWindowRenderer).toBe(true);

--- a/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
@@ -462,4 +462,63 @@ describe("the running-subagent list", () => {
 		},
 		SLOW,
 	);
+
+	/**
+	 * The swap (#8406). A `log` announces what is *appended* to it, so replacing the whole transcript
+	 * under a reader announces nothing at all — the window owes a live region of its own, and it owes
+	 * the picking control to the keyboard as much as to the mouse.
+	 */
+	it("reaches every navigator row from the keyboard and announces the swap", async () => {
+		const rendered = await mountList();
+		const root = rendered.container.firstElementChild as HTMLElement;
+		const status = () =>
+			Array.from(root.querySelectorAll<HTMLElement>('[role="status"]'))
+				.map((region) => region.textContent ?? "")
+				.join(" ");
+
+		const picks = Array.from(root.querySelectorAll<HTMLButtonElement>(".tuval-chat-subagent-pick"));
+		expect(picks).toHaveLength(2);
+		expect(status()).toContain("Showing the agent's own transcript.");
+		for (const control of picks) {
+			expect(await probeFocus(root, control)).toEqual([]);
+			expect(control.getAttribute("aria-current")).toBeNull();
+		}
+
+		// A button is activated by Enter and Space, so pressing it *is* the keyboard path — what a
+		// keyboard user needs beyond that is to reach it, which the focus probe above just proved.
+		const reviewer = picks[0] as HTMLButtonElement;
+		await act(async () => {
+			reviewer.focus();
+			reviewer.click();
+		});
+
+		expect(document.activeElement).toBe(reviewer);
+		expect(reviewer.getAttribute("aria-current")).toBe("true");
+		expect(status()).toContain("Showing the reviewer subagent's transcript.");
+		expect(screen.getByRole("log", {name: "Transcript: reviewer subagent"})).toBeTruthy();
+
+		const back = root.querySelector<HTMLButtonElement>(".tuval-chat-subagent-pick");
+		expect(back?.textContent).toBe("Back to the agent transcript");
+		expect(await probeFocus(root, back as HTMLElement)).toEqual([]);
+		await act(async () => {
+			(back as HTMLButtonElement).click();
+		});
+		expect(status()).toContain("Showing the agent's own transcript.");
+
+		rendered.unmount();
+	});
+
+	it(
+		"holds the enforced pillar-4 invariants inside a subagent's own view",
+		async () => {
+			const rendered = await mountList();
+			const root = rendered.container.firstElementChild as HTMLElement;
+			await act(async () => {
+				root.querySelector<HTMLButtonElement>(".tuval-chat-subagent-pick")?.click();
+			});
+			expect(await scanRegions(root)).toEqual([]);
+			rendered.unmount();
+		},
+		SLOW,
+	);
 });

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -116,6 +116,46 @@
 	background: var(--surface-sunken);
 }
 
+.tuval-chat-subagent-item {
+	display: flex;
+	min-inline-size: 0;
+}
+
+/*
+ * Each row is a button, because picking one swaps the window's view slot (#8406). It is styled as
+ * the row rather than as a control: the affordance is the hover and the focus ring, and a row of
+ * buttons drawn as buttons would read as a toolbar rather than as a list to walk.
+ */
+.tuval-chat-subagent-pick {
+	flex: 1 1 auto;
+	min-inline-size: 0;
+	padding: var(--s-1) var(--s-2);
+	border: 0;
+	border-radius: var(--r-sm);
+	background: none;
+	color: inherit;
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
+	/* The list is dense, so the row's own height is the target rather than a taller padded box. */
+	min-block-size: var(--tap-min, 36px);
+}
+
+.tuval-chat-subagent-pick:hover {
+	background: var(--surface-raised);
+}
+
+.tuval-chat-subagent-pick:focus-visible {
+	outline: 2px solid var(--focus-ring, var(--text-primary));
+	outline-offset: 1px;
+}
+
+/* The one showing. The mark is the left rule plus the stronger text, never colour alone. */
+.tuval-chat-subagent-pick[aria-current="true"] {
+	background: var(--surface-raised);
+	box-shadow: inset 2px 0 0 var(--text-primary);
+}
+
 .tuval-chat-subagent {
 	flex-wrap: nowrap;
 	min-inline-size: 0;
@@ -125,6 +165,10 @@
 .tuval-chat-subagent-type {
 	color: var(--text-secondary);
 	font-weight: 600;
+}
+
+.tuval-chat-subagent-pick[aria-current="true"] .tuval-chat-subagent-type {
+	color: var(--text-primary);
 }
 
 /* The one field that may be any length, so it is the one that truncates. */
@@ -139,6 +183,28 @@
 .tuval-chat-subagent-more {
 	font: var(--t-meta);
 	color: var(--text-muted);
+}
+
+/*
+ * The line at the end of a subagent's own view (Q9): what became of the worker, under its rows,
+ * where the eye already is when the transcript stops moving.
+ */
+.tuval-chat-subagent-end {
+	display: flex;
+	gap: var(--s-2);
+	align-items: baseline;
+	margin: 0;
+	padding: var(--s-2) var(--s-3);
+	font: var(--t-meta);
+	color: var(--text-muted);
+	border-block-start: 1px solid var(--border-faint);
+}
+
+.tuval-chat-subagent-end-mark {
+	color: var(--text-secondary);
+	font: var(--t-micro);
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
 }
 
 /*

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -77,6 +77,12 @@ export interface ChatRowsInput {
 	 * this be one boolean and no second code path.
 	 */
 	readonly subagents?: ReadonlySet<string>;
+	/**
+	 * The call this whole list ran inside, set only when the list is one subagent's own transcript
+	 * (#8406). Its children are this list's top level, so they read at depth zero instead of as rows
+	 * nested under a head the list does not contain.
+	 */
+	readonly head?: string;
 }
 
 /**
@@ -303,12 +309,35 @@ export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 		if (!unfolded.has(item.id)) return;
 		for (const child of group) emit(child, depth + 1);
 	};
-	for (const item of roots) emit(item, item.parentId === undefined ? 0 : 1);
+	for (const item of roots) {
+		emit(item, item.parentId === undefined || item.parentId === input.head ? 0 : 1);
+	}
 	for (const item of items) {
 		if (!reachable.has(item.id)) emit(item, 1);
 	}
 	return rows;
 };
+
+/**
+ * One subagent's own transcript, as the swapped-in view renders it (#8406, founder ruling Q7).
+ *
+ * The slot carries every item the worker produced, so this needs no page walk and no live tail, and
+ * `atOldest` is true: a subagent's rows arrive with its slot or not at all, and there is nothing
+ * older to ask the backend for.
+ */
+export const subagentRows = (
+	slot: SubagentSlot,
+	unfolded?: ReadonlySet<string>,
+): ReadonlyArray<ChatRow> =>
+	chatRows({
+		older: [],
+		tail: slot.items,
+		omitted: 0,
+		loading: false,
+		atOldest: true,
+		head: slot.id,
+		...(unfolded === undefined ? {} : {unfolded}),
+	});
 
 /** The prepend anchor: the visually oldest item, including a local echo. */
 export const oldestLoadedId = (rows: ReadonlyArray<ChatRow>): string | null => {

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -28,6 +28,7 @@ import {
 	rowIndexOfItem,
 	rowKey,
 	subagentHeads,
+	subagentRows,
 } from "./rows.ts";
 
 const base = {older: [], tail: [], omitted: 0, loading: false, atOldest: false};
@@ -595,5 +596,58 @@ describe("subagentHeads", () => {
 	// silently hide rows in every window of the process.
 	it("hands out a set nothing can add to", () => {
 		expect(Object.isFrozen(NO_SUBAGENTS)).toBe(true);
+	});
+});
+
+/**
+ * The swapped-in view's own list (#8406, founder ruling Q7). The slot carries everything the worker
+ * produced, so this is a build over one array with no page walk and no live-tail stitch. What it has
+ * to get right is the depth: every row in the slot names the spawning call as its parent, and that
+ * call is the agent's row rather than one of these.
+ */
+describe("subagentRows", () => {
+	const under = (head: string) => ({parentId: ItemId.make(head)});
+
+	it("reads the worker's own rows at depth zero, not as rows nested under a head it lacks", () => {
+		const rows = subagentRows(
+			subagentSlot("agent", {
+				items: [
+					{...userItem("u1", "go and look"), ...under("agent")},
+					{...assistantItem("a1", "looking"), ...under("agent")},
+					call("t1", {parentId: "agent"}),
+				],
+			}),
+		);
+		expect(itemIds(rows)).toEqual(["u1", "a1", "t1"]);
+		expect(rows.every((row) => row.kind === "item" && !row.nested && row.depth === 0)).toBe(true);
+	});
+
+	it("has no head row: a subagent's rows arrive with its slot, and nothing older can be asked for", () => {
+		const rows = subagentRows(
+			subagentSlot("agent", {items: [{...userItem("u1", "go"), ...under("agent")}]}),
+		);
+		expect(rows.map((row) => row.kind)).toEqual(["item"]);
+	});
+
+	it("is empty for a worker that has written nothing yet", () => {
+		expect(subagentRows(subagentSlot("agent"))).toEqual([]);
+	});
+
+	// A call the worker made itself heads a fold inside this view exactly as it does in the agent's,
+	// so #8027's disclosure still holds one level in.
+	it("still folds the calls the worker nested under its own", () => {
+		const slot = subagentSlot("agent", {
+			items: [
+				call("t1", {parentId: "agent"}),
+				{...assistantItem("nested", "reading"), ...under("t1")},
+			],
+		});
+		const folded = subagentRows(slot);
+		expect(itemIds(folded)).toEqual(["t1"]);
+		expect(folded[0]?.kind === "item" && folded[0].nestedIds).toEqual(["nested"]);
+
+		const open = subagentRows(slot, new Set(["t1"]));
+		expect(itemIds(open)).toEqual(["t1", "nested"]);
+		expect(open[1]?.kind === "item" && open[1].depth).toBe(1);
 	});
 });

--- a/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The window's one view slot, swapped in place (#8406, founder ruling Q7).
+ *
+ * Everything here mounts the whole `ChatWindow`, because the criteria are about what the operator
+ * gets: which transcript is on screen, what the navigator says while they are inside a worker, and
+ * where the viewport lands when they come back. What the slot itself holds is proven without a DOM
+ * in `./view.unit.test.ts`, the row build in `./rows.unit.test.ts`, and the navigator's model in
+ * `./subagents.unit.test.ts`.
+ */
+
+import {act, render, within} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {SubagentSlot, TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {ItemId} from "../../ai-agent/ports/index.ts";
+import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {type ChatWindowOptions, chatWindow} from "./ChatWindow.tsx";
+import {assistantItem, call, userItem, withTranscript} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+/**
+ * jsdom lays nothing out, so every element reports `scrollHeight === clientHeight === 0` and the
+ * virtualizer clamps every scroll to `scrollHeight - clientHeight` (`@tanstack/virtual-core@3.17.8`,
+ * `getMaxScrollOffset`) — without a box, the answer to every scroll is 0 and a scroll assertion
+ * proves nothing. On the prototype and before the first render, because a box stubbed after mount
+ * is stubbed after the opening layout effect has already resolved against a max scroll of 0
+ * (`./chat-window.unit.test.tsx` carries the same shim and the #8174 case behind it).
+ */
+const SCROLL_BOX = 100_000;
+const VIEWPORT = 600;
+
+Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+	configurable: true,
+	get(this: HTMLElement): number {
+		return this.classList.contains("tuval-chat-transcript") ? SCROLL_BOX : 0;
+	},
+});
+Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+	configurable: true,
+	get(this: HTMLElement): number {
+		return this.classList.contains("tuval-chat-transcript") ? VIEWPORT : 0;
+	},
+});
+
+const slots = (...entries: ReadonlyArray<SubagentSlot>): Record<string, SubagentSlot> =>
+	Object.fromEntries(entries.map((slot) => [slot.id, slot]));
+
+const under = (head: string) => ({parentId: ItemId.make(head)});
+
+/** What the `reviewer` worker wrote, as its slot carries it: parent-tagged, every kind. */
+const reviewerItems: ReadonlyArray<TranscriptItem> = [
+	{...userItem("r-in", "review the diff"), ...under("agent")},
+	{...assistantItem("r-out", "the fold looks right"), ...under("agent")},
+];
+
+const builderItems: ReadonlyArray<TranscriptItem> = [
+	{...assistantItem("b-out", "writing the test"), ...under("other")},
+];
+
+const reviewer = (status: SubagentSlot["status"] = "running") =>
+	subagentSlot("agent", {type: "reviewer", items: reviewerItems, status, lastLine: "wrote 4 rows"});
+
+const builder = () => subagentSlot("other", {type: "builder", items: builderItems});
+
+/** The agent's own transcript, with the two spawning calls and one call of the agent's own. */
+const agentSession = (...held: ReadonlyArray<SubagentSlot>) =>
+	withTranscript(
+		[
+			userItem("u1", "go"),
+			call("agent", {name: "Agent"}),
+			call("other", {name: "Agent"}),
+			call("own", {name: "Bash", output: "the agent's own call"}),
+			...reviewerItems,
+			...builderItems,
+		],
+		{subagents: slots(...held)},
+	);
+
+const openProcess = (state: AiAgentSessionState) =>
+	Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
+	);
+
+type Process = Awaited<ReturnType<typeof openProcess>>;
+
+/** One window onto an already-open process, so a case can mount two of them. */
+const openWindow = async (
+	process: Process,
+	windowId: string,
+	options: ChatWindowOptions = {},
+	view: ChatView = initialChatView,
+) => {
+	const bound = await Effect.runPromise(process.window(WindowId.make(windowId), view));
+	const scrolls: Array<number> = [];
+	const rendered = render(
+		chatWindow({
+			scrollCommitMs: 0,
+			scrollToFn: (offset) => void scrolls.push(offset),
+			subagentList: true,
+			...options,
+		}).render(bound) as ReactElement,
+	);
+	// Scoped to this render, because a case that mounts two windows has two of every region.
+	await within(rendered.container).findByRole("log", {name: /^Transcript/});
+	return {rendered, scrolls, view: () => bound.view()};
+};
+
+/** A window over its own process, the shape most cases need. */
+const openOne = async (
+	state: AiAgentSessionState,
+	options: ChatWindowOptions = {},
+	view: ChatView = initialChatView,
+) => {
+	const process = await openProcess(state);
+	return {process, ...(await openWindow(process, "w1", options, view))};
+};
+
+const dom = (root: ParentNode) => ({
+	rowKinds: () =>
+		Array.from(root.querySelectorAll<HTMLElement>(".tuval-chat-row")).map(
+			(row) => row.dataset.kind ?? "",
+		),
+	text: () => root.querySelector<HTMLElement>(".tuval-chat-spacer")?.textContent ?? "",
+	picks: () => Array.from(root.querySelectorAll<HTMLButtonElement>(".tuval-chat-subagent-pick")),
+	current: () =>
+		root.querySelector<HTMLElement>('.tuval-chat-subagent-pick[aria-current="true"]')
+			?.textContent ?? null,
+	end: () => root.querySelector<HTMLElement>(".tuval-chat-subagent-end")?.textContent ?? null,
+	list: () => root.querySelector<HTMLElement>(".tuval-chat-subagents"),
+});
+
+/** Click the navigator row whose visible text starts with `type`. */
+const pick = async (root: ParentNode, label: string) => {
+	const button = dom(root)
+		.picks()
+		.find((candidate) => (candidate.textContent ?? "").startsWith(label));
+	expect(button, `no navigator row for "${label}"`).toBeTruthy();
+	await act(async () => {
+		(button as HTMLButtonElement).click();
+	});
+};
+
+const atOldest = (over: Partial<ChatView> = {}): ChatView => ({
+	...initialChatView,
+	atOldest: true,
+	...over,
+});
+
+describe("swapping the view slot to a subagent", () => {
+	it("swaps the transcript in place, opening no window and minting no picker entry (Q7)", async () => {
+		const {rendered, process} = await openOne(agentSession(reviewer(), builder()), {}, atOldest());
+		const root = rendered.container;
+		expect(dom(root).text()).toContain("the agent's own call");
+
+		await pick(root, "reviewer");
+
+		expect(dom(root).text()).toContain("the fold looks right");
+		expect(dom(root).text()).not.toContain("the agent's own call");
+		// The swap is a write to this window's own slot and nothing else: no Msg reaches the process,
+		// so nothing downstream of it could open a window or mint a picker entry.
+		expect(process.inbox()).toEqual([]);
+		expect(root.querySelectorAll(".tuval-chat").length).toBe(1);
+		rendered.unmount();
+	});
+
+	it("keeps the list as the navigator, marking the row that is showing (Q8)", async () => {
+		const {rendered} = await openOne(agentSession(reviewer(), builder()), {}, atOldest());
+		const root = rendered.container;
+		expect(dom(root).current()).toBeNull();
+
+		await pick(root, "reviewer");
+
+		expect(dom(root).list()).not.toBeNull();
+		expect(dom(root).current()).toContain("reviewer");
+		expect(
+			dom(root)
+				.picks()
+				.map((button) => (button.textContent ?? "").split("·")[0]?.trim()),
+		).toEqual(["Back to the agent transcript", "reviewer", "builder"]);
+
+		// Hopping straight to the other worker is one pick, with no stop at main.
+		await pick(root, "builder");
+		expect(dom(root).current()).toContain("builder");
+		expect(dom(root).text()).toContain("writing the test");
+		rendered.unmount();
+	});
+
+	it("names the region a screen reader lands in after the swap", async () => {
+		const {rendered} = await openOne(agentSession(reviewer()), {}, atOldest());
+		expect(within(rendered.container).getByRole("log", {name: "Transcript"})).toBeTruthy();
+
+		await pick(rendered.container, "reviewer");
+
+		expect(
+			within(rendered.container).getByRole("log", {name: "Transcript: reviewer subagent"}),
+		).toBeTruthy();
+		rendered.unmount();
+	});
+
+	it("reads the worker's rows at depth zero rather than as rows nested under a head", async () => {
+		const {rendered} = await openOne(agentSession(reviewer()), {}, atOldest());
+		await pick(rendered.container, "reviewer");
+		expect(dom(rendered.container).rowKinds()).toEqual(["user", "assistant"]);
+		expect(rendered.container.querySelector('[data-nested="true"]')).toBeNull();
+		rendered.unmount();
+	});
+});
+
+describe("the way back to the agent's own transcript", () => {
+	it("returns to main and leaves main where it was, offset and all", async () => {
+		const {rendered, scrolls} = await openOne(
+			agentSession(reviewer()),
+			{},
+			atOldest({pinned: false, scroll: 640}),
+		);
+		const root = rendered.container;
+		// First paint puts main back on its saved offset, which is the position the back action owes.
+		expect(scrolls).toContain(640);
+
+		await pick(root, "reviewer");
+		scrolls.length = 0;
+		await pick(root, "Back to the agent transcript");
+
+		expect(dom(root).text()).toContain("the agent's own call");
+		expect(dom(root).current()).toBeNull();
+		expect(scrolls).toContain(640);
+		rendered.unmount();
+	});
+
+	it("writes the parked position into the slot, so a re-mount restores it too", async () => {
+		const {rendered, view} = await openOne(
+			agentSession(reviewer()),
+			{},
+			atOldest({pinned: false, scroll: 640}),
+		);
+		await pick(rendered.container, "reviewer");
+
+		expect(view().viewing).toEqual({id: "agent", from: {pinned: false, scroll: 640}});
+		expect([view().pinned, view().scroll]).toEqual([true, 0]);
+		rendered.unmount();
+	});
+});
+
+describe("a subagent that finishes while its view is open (Q9)", () => {
+	const finish = async (process: Process) => {
+		await act(async () => {
+			await Effect.runPromise(process.commit(agentSession(reviewer("finished"))));
+		});
+	};
+
+	it("keeps the view open on its rows, and neither blanks nor snaps to main", async () => {
+		const {rendered, process} = await openOne(agentSession(reviewer()), {}, atOldest());
+		const root = rendered.container;
+		await pick(root, "reviewer");
+
+		await finish(process);
+
+		expect(dom(root).text()).toContain("the fold looks right");
+		expect(dom(root).current()).toContain("reviewer");
+		expect(
+			within(rendered.container).getByRole("log", {name: "Transcript: reviewer subagent"}),
+		).toBeTruthy();
+		rendered.unmount();
+	});
+
+	it("shows the terminal result and the way back", async () => {
+		const {rendered, process} = await openOne(agentSession(reviewer()), {}, atOldest());
+		const root = rendered.container;
+		await pick(root, "reviewer");
+		expect(dom(root).end()).toContain("still running");
+
+		await finish(process);
+
+		expect(dom(root).end()).toContain("finished");
+		expect(dom(root).end()).toContain("wrote 4 rows");
+		expect(dom(root).picks()[0]?.textContent).toBe("Back to the agent transcript");
+		rendered.unmount();
+	});
+
+	it("drops the row from the running list at that same moment, and marks the one being read", async () => {
+		const process = await openProcess(agentSession(reviewer(), builder()));
+		const inside = await openWindow(process, "w1", {}, atOldest());
+		const onMain = await openWindow(process, "w2", {}, atOldest());
+		await pick(inside.rendered.container, "reviewer");
+
+		await finish(process);
+
+		// The window on main sees a two-row list become one: a finished worker left it (Q2).
+		expect(
+			dom(onMain.rendered.container)
+				.picks()
+				.map((button) => button.textContent),
+		).toEqual([]);
+		// …and the window reading it keeps the row, marked and without the elapsed or token readout.
+		const held = dom(inside.rendered.container).picks();
+		expect(held[1]?.textContent).toContain("finished");
+		expect(held[1]?.textContent).not.toContain("elapsed");
+		expect(held[1]?.getAttribute("aria-current")).toBe("true");
+		inside.rendered.unmount();
+		onMain.rendered.unmount();
+	});
+});
+
+describe("two windows over one process", () => {
+	it("sit on two different subagents at once, and closing one does not move the other", async () => {
+		const process = await openProcess(agentSession(reviewer(), builder()));
+		const first = await openWindow(process, "w1", {}, atOldest());
+		const second = await openWindow(process, "w2", {}, atOldest());
+
+		await pick(first.rendered.container, "reviewer");
+		await pick(second.rendered.container, "builder");
+
+		expect(dom(first.rendered.container).text()).toContain("the fold looks right");
+		expect(dom(second.rendered.container).text()).toContain("writing the test");
+		expect(first.view().viewing?.id).toBe("agent");
+		expect(second.view().viewing?.id).toBe("other");
+
+		second.rendered.unmount();
+
+		expect(dom(first.rendered.container).current()).toContain("reviewer");
+		expect(dom(first.rendered.container).text()).toContain("the fold looks right");
+		expect(first.view().viewing?.id).toBe("agent");
+		first.rendered.unmount();
+	});
+});
+
+describe("with the flag off", () => {
+	it("draws today's window, whatever the slot says the view is", async () => {
+		const {rendered} = await openOne(
+			agentSession(reviewer()),
+			{subagentList: false},
+			atOldest({
+				viewing: {id: "agent", from: {pinned: true, scroll: 0}},
+				unfolded: ["agent"],
+			}),
+		);
+		const root = rendered.container;
+
+		expect(dom(root).list()).toBeNull();
+		expect(dom(root).end()).toBeNull();
+		expect(within(rendered.container).getByRole("log", {name: "Transcript"})).toBeTruthy();
+		// The agent's own rows are all there, and the subagent's still fold under the spawning call —
+		// today's window, exactly as it was before #8405.
+		expect(dom(root).text()).toContain("the agent's own call");
+		expect(dom(root).text()).toContain("the fold looks right");
+		expect(root.querySelectorAll('[data-nested="true"]').length).toBeGreaterThan(0);
+		rendered.unmount();
+	});
+});

--- a/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
@@ -10,10 +10,10 @@
  * `./subagents.unit.test.ts`.
  */
 
-import {act, render, within} from "@testing-library/react";
+import {act, fireEvent, render, within} from "@testing-library/react";
 import {Effect} from "effect";
 import type {ReactElement} from "react";
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
 import type {SubagentSlot, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {ItemId} from "../../ai-agent/ports/index.ts";
@@ -150,10 +150,22 @@ const pick = async (root: ParentNode, label: string) => {
 	});
 };
 
+/** jsdom never moves a scroller, so the offset a scroll event reports is set on the element. */
+const scrollTo = async (scroller: HTMLElement, offset: number) => {
+	Object.defineProperty(scroller, "scrollTop", {configurable: true, value: offset});
+	await act(async () => {
+		fireEvent.scroll(scroller);
+	});
+};
+
 const atOldest = (over: Partial<ChatView> = {}): ChatView => ({
 	...initialChatView,
 	atOldest: true,
 	...over,
+});
+
+afterEach(() => {
+	vi.useRealTimers();
 });
 
 describe("swapping the view slot to a subagent", () => {
@@ -247,6 +259,41 @@ describe("the way back to the agent's own transcript", () => {
 
 		expect(view().viewing).toEqual({id: "agent", from: {pinned: false, scroll: 640}});
 		expect([view().pinned, view().scroll]).toEqual([true, 0]);
+		rendered.unmount();
+	});
+
+	/**
+	 * The offset is committed on a settle timer, so a swap taken inside that window has two ways to
+	 * get the park wrong: it can park an offset one debounce behind the reader, and the pending timer
+	 * can then land main's offset on the `scroll` field the subagent view now owns (review round 1 on
+	 * #8467). Both are closed by settling the offset before the swap, and both are asserted here —
+	 * dropping the `settleScroll()` call from `showSubagent` reds each of them.
+	 */
+	it("settles the pending scroll commit before it parks, and lands nothing on the subagent", async () => {
+		vi.useFakeTimers({shouldAdvanceTime: true});
+		const {rendered, view} = await openOne(
+			agentSession(reviewer()),
+			{scrollCommitMs: 150},
+			atOldest({pinned: false, scroll: 10}),
+		);
+		const scroller = rendered.container.querySelector(".tuval-chat-transcript") as HTMLElement;
+		// The first event is the window hearing the scroll its own first paint asked for; the second is
+		// the reader, which is the one whose offset the settle window is holding.
+		await scrollTo(scroller, 10);
+		await scrollTo(scroller, 640);
+		expect(view().scroll, "still inside the settle window").toBe(10);
+
+		await pick(rendered.container, "reviewer");
+
+		expect(view().viewing).toEqual({id: "agent", from: {pinned: false, scroll: 640}});
+		expect(view().scroll).toBe(0);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(400);
+		});
+
+		expect(view().viewing?.from.scroll).toBe(640);
+		expect(view().scroll, "main's offset must not land on the subagent's view").toBe(0);
 		rendered.unmount();
 	});
 });

--- a/apps/tuval/src/shell/chat/subagents.ts
+++ b/apps/tuval/src/shell/chat/subagents.ts
@@ -5,13 +5,14 @@
  * (`../../ai-agent/ports/subagent.ts`), so the list a window draws is the same list for every agent
  * program the moment that program's mapper fills the slot (founder ruling Q11 on #8384).
  *
- * A row carries the four fields Q1 names and nothing else — no count of the rows the slot holds,
- * which was a verbatim "no". `startedAt` rather than an elapsed number: elapsed is what a clock the
+ * A row draws the four fields Q1 names and nothing else — no count of the rows the slot holds, which
+ * was a verbatim "no". `startedAt` rather than an elapsed number: elapsed is what a clock the
  * component reads makes of it, and computing it here would freeze it at the render that built the
- * model.
+ * model. `status` and `current` are not a fifth and sixth field but the row's own state: which
+ * navigator entry is the one showing, and whether its worker still runs (#8406).
  */
 
-import type {ItemId, SubagentSlot} from "../../ai-agent/ports/index.ts";
+import type {ItemId, SubagentSlot, SubagentStatus} from "../../ai-agent/ports/index.ts";
 
 /** How many rows the list shows before the tail collapses into one "more" row (Q3). */
 export const SUBAGENT_ROW_CAP = 5;
@@ -23,6 +24,13 @@ export interface SubagentRow {
 	/** Epoch milliseconds, so the row's elapsed is the reader's own clock minus this. */
 	readonly startedAt: number;
 	readonly tokens: number;
+	/**
+	 * A `finished` row is only ever here because it is the one being viewed (Q9). It draws neither
+	 * elapsed nor tokens — Q2 answered "no" to both once a worker stops.
+	 */
+	readonly status: SubagentStatus;
+	/** This row's transcript is the one the window is showing.  */
+	readonly current: boolean;
 }
 
 export interface SubagentListModel {
@@ -31,16 +39,31 @@ export interface SubagentListModel {
 	readonly more: number;
 }
 
+const rowOf = (slot: SubagentSlot, current: boolean): SubagentRow => ({
+	id: slot.id,
+	type: slot.type,
+	lastLine: slot.lastLine,
+	startedAt: slot.startedAt,
+	tokens: slot.tokens,
+	status: slot.status,
+	current,
+});
+
 /**
- * The running workers, oldest-first and capped.
+ * The list the window draws, oldest-first and capped, plus the viewed worker wherever it is.
  *
  * Oldest-first, tie-broken on the id, because the order has to hold still: a list sorted by
  * anything that moves — the last line, the token count — would re-order itself under a reader's
- * eyes on every frame the workers write. A finished slot is not here at all: it left the list the
- * moment its worker stopped (Q2), and its spawning call is a plain tool row again.
+ * eyes on every frame the workers write.
+ *
+ * A finished slot left the list the moment its worker stopped (Q2) — *unless* it is the one being
+ * viewed, and then it is appended. That is what keeps the navigator honest under Q9: the operator
+ * inside a subagent that finishes still sees which transcript they are reading and can pick another,
+ * where a list that simply dropped the row would leave the view with no name on it.
  */
 export const runningSubagents = (
 	slots: Readonly<Record<string, SubagentSlot>>,
+	viewing: string | null = null,
 ): SubagentListModel => {
 	const running = Object.values(slots)
 		.filter((slot) => slot.status === "running")
@@ -49,15 +72,15 @@ export const runningSubagents = (
 				? left.id.localeCompare(right.id)
 				: left.startedAt - right.startedAt,
 		);
+	const shown = running.slice(0, SUBAGENT_ROW_CAP);
+	const held = new Set<string>(shown.map((slot) => slot.id));
+	const viewed = viewing === null || held.has(viewing) ? undefined : slots[viewing];
 	return {
-		rows: running.slice(0, SUBAGENT_ROW_CAP).map((slot) => ({
-			id: slot.id,
-			type: slot.type,
-			lastLine: slot.lastLine,
-			startedAt: slot.startedAt,
-			tokens: slot.tokens,
-		})),
-		more: Math.max(0, running.length - SUBAGENT_ROW_CAP),
+		rows: [
+			...shown.map((slot) => rowOf(slot, slot.id === viewing)),
+			...(viewed === undefined ? [] : [rowOf(viewed, true)]),
+		],
+		more: running.length - shown.length - (viewed?.status === "running" ? 1 : 0),
 	};
 };
 

--- a/apps/tuval/src/shell/chat/subagents.unit.test.ts
+++ b/apps/tuval/src/shell/chat/subagents.unit.test.ts
@@ -27,6 +27,8 @@ describe("runningSubagents", () => {
 					lastLine: "reading rows.ts",
 					startedAt: 1_756_000_000_000,
 					tokens: 2_400,
+					status: "running",
+					current: false,
 				},
 			],
 			more: 0,
@@ -81,6 +83,47 @@ describe("runningSubagents", () => {
 			subagentSlot(`s${index}`, {startedAt: index, status: index < 7 ? "running" : "finished"}),
 		);
 		expect(runningSubagents(slots(...running)).more).toBe(2);
+	});
+});
+
+/**
+ * The navigator's half (#8406). Which row is marked, and the one case the running set alone cannot
+ * answer: the worker being read has stopped, and its row must still be in the list under Q9.
+ */
+describe("runningSubagents as the navigator", () => {
+	it("marks the viewed worker and nothing else", () => {
+		const model = runningSubagents(slots(subagentSlot("a"), subagentSlot("b")), "b");
+		expect(model.rows.map((row) => [row.id, row.current])).toEqual([
+			["a", false],
+			["b", true],
+		]);
+	});
+
+	it("keeps a finished worker in the list while it is the one being read (Q9)", () => {
+		const model = runningSubagents(
+			slots(subagentSlot("a"), subagentSlot("b", {status: "finished"})),
+			"b",
+		);
+		expect(model.rows.map((row) => [row.id, row.status, row.current])).toEqual([
+			["a", "running", false],
+			["b", "finished", true],
+		]);
+		expect(model.more).toBe(0);
+	});
+
+	it("pulls a viewed worker in past the cap, and stops counting it as left off", () => {
+		const running = Array.from({length: 10}, (_, index) =>
+			subagentSlot(`s${index}`, {startedAt: index}),
+		);
+		const model = runningSubagents(slots(...running), "s9");
+		expect(model.rows.map((row) => row.id)).toEqual(["s0", "s1", "s2", "s3", "s4", "s9"]);
+		expect(model.rows.at(-1)?.current).toBe(true);
+		expect(model.more).toBe(4);
+	});
+
+	it("marks nothing when the viewed id names no slot this session holds", () => {
+		const model = runningSubagents(slots(subagentSlot("a")), "gone");
+		expect(model.rows.map((row) => [row.id, row.current])).toEqual([["a", false]]);
 	});
 });
 

--- a/apps/tuval/src/shell/chat/view.ts
+++ b/apps/tuval/src/shell/chat/view.ts
@@ -1,12 +1,13 @@
 /**
  * What one chat window keeps in its own `view` slot, and how a slot of unknown shape is read back.
  *
- * Six facts live here and nothing else: whether the transcript is following its newest turn, where
+ * Seven facts live here and nothing else: whether the transcript is following its newest turn, where
  * it was scrolled to otherwise, what was typed and not yet sent, how far back into history this
- * window has walked, which rows it has disclosed, and which group heads have their folded rows
- * showing. Two windows over one process share the transcript and own one of these each (#7484
- * R1.1), so everything here is per-window — including `expanded`, which is why the same tool call
- * can be open in one window and closed in the other.
+ * window has walked, which rows it has disclosed, which group heads have their folded rows showing,
+ * and which transcript the window's one view slot is showing. Two windows over one process share
+ * the transcript and own one of these each (#7484 R1.1), so everything here is per-window —
+ * including `expanded`, which is why the same tool call can be open in one window and closed in the
+ * other, and including `viewing`, which is what lets two windows sit on two different subagents.
  *
  * `expanded` and `unfolded` are two facts, not one: opening a call's input panel and revealing the
  * subagent rows it heads are different asks, and one control doing both is what left the revealed
@@ -20,6 +21,21 @@
 
 import type {ViewState} from "../window/index.ts";
 import {asOutgoing, type OutgoingSend} from "./outgoing.ts";
+
+/**
+ * The subagent this window's one view slot is showing, and where main was left when it swapped.
+ *
+ * One field rather than two, because "which transcript is showing" and "where main was parked" are
+ * the same fact: a window on main has no parked position to restore, and a window on a subagent
+ * always has one. Split, a slot could say it is on main while parking an offset — a state the back
+ * action could not read.
+ */
+export type ChatSubagentView = {
+	/** The spawning call's item id — the key of the slot whose transcript is showing. */
+	readonly id: string;
+	/** Where main was resting when this window swapped away from it. The back action restores it. */
+	readonly from: {readonly pinned: boolean; readonly scroll: number};
+};
 
 export type ChatView = {
 	/**
@@ -46,6 +62,13 @@ export type ChatView = {
 	readonly expanded: ReadonlyArray<string>;
 	/** The ids of the group heads whose folded rows this window is showing. Absent means folded. */
 	readonly unfolded: ReadonlyArray<string>;
+	/**
+	 * Which transcript the one view slot shows: `null` is the agent's own, a record is the subagent
+	 * swapped in over it (founder ruling Q7 on #8384 — one window, one slot, swapped in place).
+	 * `pinned` and `scroll` above always describe the *current* view, which is why the place main was
+	 * left is parked in here rather than overwritten.
+	 */
+	readonly viewing: ChatSubagentView | null;
 };
 
 export const initialChatView: ChatView = {
@@ -57,6 +80,7 @@ export const initialChatView: ChatView = {
 	atOldest: false,
 	expanded: [],
 	unfolded: [],
+	viewing: null,
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -67,6 +91,23 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  * holds `null`, and a slot written by another program holds something else entirely — neither is an
  * error the surface may throw on, because the contract's own fallbacks are values.
  */
+/**
+ * Read the view slot back. Total like everything beside it: a slot from a build that had no such
+ * field, and one whose record is any other shape, are both a window on main.
+ */
+const asSubagentView = (value: unknown): ChatSubagentView | null => {
+	if (!isRecord(value)) return null;
+	if (typeof value.id !== "string" || value.id.length === 0) return null;
+	const from = isRecord(value.from) ? value.from : {};
+	return {
+		id: value.id,
+		from: {
+			pinned: from.pinned !== false,
+			scroll: typeof from.scroll === "number" && Number.isFinite(from.scroll) ? from.scroll : 0,
+		},
+	};
+};
+
 export const asChatView = (value: ViewState | undefined): ChatView => {
 	if (!isRecord(value)) return initialChatView;
 	return {
@@ -84,5 +125,26 @@ export const asChatView = (value: ViewState | undefined): ChatView => {
 		unfolded: Array.isArray(value.unfolded)
 			? value.unfolded.filter((id): id is string => typeof id === "string")
 			: [],
+		viewing: asSubagentView(value.viewing),
 	};
+};
+
+/**
+ * Swap the slot onto a subagent, parking where main was left. Already there is a no-op, and a swap
+ * straight from one subagent to another keeps the *original* park: main was left once.
+ *
+ * The swapped-in view starts on its own newest row rather than on main's offset, which is an offset
+ * into a transcript this one is not.
+ */
+export const viewSubagent = (view: ChatView, id: string): ChatView => {
+	if (view.viewing?.id === id) return view;
+	const from = view.viewing?.from ?? {pinned: view.pinned, scroll: view.scroll};
+	return {...view, pinned: true, scroll: 0, viewing: {id, from}};
+};
+
+/** Swap back to main, onto the row and offset it was left on. Already there is a no-op. */
+export const viewMain = (view: ChatView): ChatView => {
+	if (view.viewing === null) return view;
+	const {from} = view.viewing;
+	return {...view, pinned: from.pinned, scroll: from.scroll, viewing: null};
 };

--- a/apps/tuval/src/shell/chat/view.ts
+++ b/apps/tuval/src/shell/chat/view.ts
@@ -87,13 +87,8 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
- * Read a slot back. Total by construction: a window opened onto this program for the first time
- * holds `null`, and a slot written by another program holds something else entirely — neither is an
- * error the surface may throw on, because the contract's own fallbacks are values.
- */
-/**
- * Read the view slot back. Total like everything beside it: a slot from a build that had no such
- * field, and one whose record is any other shape, are both a window on main.
+ * Read the view slot's own field back. Total like everything beside it: a slot from a build that had
+ * no such field, and one whose record is any other shape, are both a window on main.
  */
 const asSubagentView = (value: unknown): ChatSubagentView | null => {
 	if (!isRecord(value)) return null;
@@ -108,6 +103,11 @@ const asSubagentView = (value: unknown): ChatSubagentView | null => {
 	};
 };
 
+/**
+ * Read a slot back. Total by construction: a window opened onto this program for the first time
+ * holds `null`, and a slot written by another program holds something else entirely — neither is an
+ * error the surface may throw on, because the contract's own fallbacks are values.
+ */
 export const asChatView = (value: ViewState | undefined): ChatView => {
 	if (!isRecord(value)) return initialChatView;
 	return {

--- a/apps/tuval/src/shell/chat/view.unit.test.ts
+++ b/apps/tuval/src/shell/chat/view.unit.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {asChatView, initialChatView} from "./view.ts";
+import {asChatView, type ChatView, initialChatView, viewMain, viewSubagent} from "./view.ts";
 
 describe("asChatView", () => {
 	it("reads a slot this window wrote", () => {
@@ -30,6 +30,7 @@ describe("asChatView", () => {
 			atOldest: true,
 			expanded: ["t1", "t2"],
 			unfolded: ["t3"],
+			viewing: null,
 		});
 	});
 
@@ -64,6 +65,7 @@ describe("asChatView", () => {
 			atOldest: false,
 			expanded: [],
 			unfolded: [],
+			viewing: null,
 		});
 	});
 
@@ -84,5 +86,75 @@ describe("asChatView", () => {
 	it("refuses a non-finite scroll offset, which would take the virtualizer with it", () => {
 		expect(asChatView({scroll: Number.NaN}).scroll).toBe(0);
 		expect(asChatView({scroll: Number.POSITIVE_INFINITY}).scroll).toBe(0);
+	});
+
+	// The criterion #8406 states as "a slot written by an older build reads back as main rather than
+	// throwing": every one of these is a slot no build of this window ever wrote.
+	it("reads a slot with no view field, and every unreadable one, as a window on main", () => {
+		expect(asChatView({scroll: 12}).viewing).toBeNull();
+		expect(asChatView({viewing: "call-1"}).viewing).toBeNull();
+		expect(asChatView({viewing: {}}).viewing).toBeNull();
+		expect(asChatView({viewing: {id: ""}}).viewing).toBeNull();
+		expect(asChatView({viewing: {id: 7}}).viewing).toBeNull();
+		expect(asChatView({viewing: [{id: "call-1"}]}).viewing).toBeNull();
+	});
+
+	it("defaults the parked position of a view slot whose park is missing or unreadable", () => {
+		expect(asChatView({viewing: {id: "call-1"}}).viewing).toEqual({
+			id: "call-1",
+			from: {pinned: true, scroll: 0},
+		});
+		expect(asChatView({viewing: {id: "call-1", from: {scroll: "far", pinned: 3}}}).viewing).toEqual(
+			{
+				id: "call-1",
+				from: {pinned: true, scroll: 0},
+			},
+		);
+		expect(
+			asChatView({viewing: {id: "call-1", from: {pinned: false, scroll: 420}}}).viewing,
+		).toEqual({id: "call-1", from: {pinned: false, scroll: 420}});
+	});
+});
+
+describe("swapping the one view slot", () => {
+	const main: ChatView = {...initialChatView, pinned: false, scroll: 420};
+
+	it("parks where main was left and starts the subagent on its own newest row", () => {
+		const swapped = viewSubagent(main, "call-1");
+		expect(swapped.viewing).toEqual({id: "call-1", from: {pinned: false, scroll: 420}});
+		expect([swapped.pinned, swapped.scroll]).toEqual([true, 0]);
+	});
+
+	it("puts main back exactly where it was left", () => {
+		const back = viewMain(viewSubagent(main, "call-1"));
+		expect(back.viewing).toBeNull();
+		expect([back.pinned, back.scroll]).toEqual([false, 420]);
+	});
+
+	// Main was left once. A hop from one worker to another must not re-park the *subagent's* offset
+	// as main's, or the back action would land on a position that was never main's.
+	it("keeps the original park when the slot hops straight to another subagent", () => {
+		const first = viewSubagent(main, "call-1");
+		const scrolled = {...first, pinned: false, scroll: 90};
+		const second = viewSubagent(scrolled, "call-2");
+		expect(second.viewing).toEqual({id: "call-2", from: {pinned: false, scroll: 420}});
+		expect(viewMain(second).scroll).toBe(420);
+	});
+
+	it("is identity when the slot is already where it is being sent", () => {
+		const swapped = viewSubagent(main, "call-1");
+		expect(viewSubagent(swapped, "call-1")).toBe(swapped);
+		expect(viewMain(main)).toBe(main);
+	});
+
+	it("leaves every other field of the slot alone", () => {
+		const held: ChatView = {...main, draft: "half a prompt", expanded: ["t1"], cursor: "i7"};
+		const swapped = viewSubagent(held, "call-1");
+		expect([swapped.draft, swapped.expanded, swapped.cursor]).toEqual([
+			"half a prompt",
+			["t1"],
+			"i7",
+		]);
+		expect(viewMain(swapped).cursor).toBe("i7");
 	});
 });


### PR DESCRIPTION
The chat window now carries **one view slot**, swapped in place between the agent's own transcript
and one subagent's (founder ruling Q7 on #8384). The running list becomes the navigator (Q8), and a
worker that stops while its view is open keeps that view and says what became of it (Q9). All of it
sits behind `features.subagentList`, the flag #8405 declared — no second flag.

Fixes #8406

## What changed

- `view.ts` gains one field, `viewing`. It is a record or `null`, and it holds main's parked
  position inside itself, so "the slot is on a subagent" and "main was left at offset X" cannot
  disagree. `asChatView` stays total: a slot from an older build, or one whose record is any other
  shape, reads back as main.
- `rows.ts` gains `subagentRows(slot, unfolded)` — one subagent's own transcript off its slot, with
  no page walk and no live-tail stitch. The one thing it has to get right is depth: every row in a
  slot names the spawning call as its parent, and that call is the agent's row, so `chatRows` takes a
  `head` and reads the worker's own rows at depth zero. Calls the worker nested under its *own* calls
  still fold exactly as they do at main.
- `SubagentList.tsx` becomes the navigator: each row is a real button, marked `aria-current` when it
  is the one showing, and a subagent view puts a "Back to the agent transcript" row at the top. A
  finished worker keeps its row only while it is the one being read, and draws no elapsed and no
  token readout there (Q2).
- `ChatWindow.tsx` picks the row list off the slot, resets its one first-paint placement per swap,
  makes `requestOlder` inert inside a subagent view, names the transcript region after the worker,
  and carries one visually-hidden live region for both the swap and the finish — a `log` announces
  only what is appended to it, so replacing the whole transcript under a reader announces nothing.

The `subagent-not-found` refusal named its id twice (`… for subagent "x" (x)`); the two call sites
now leave the id to the helper, which is the only place that spells it.

## What the scratch desk showed

Hand-verified on a scratch desk (port 5199, never 5173) booted from this worktree with
`features: {subagentList: true}` in the project layer, driving a real Claude session that dispatched
a real `Explore` subagent through the Task tool. Four checkpoints, each read off the live DOM and
screenshotted:

- **Running.** The list appeared as soon as the worker's first parent-tagged frame landed —
  `Explore · Search breadth: medium… · 0s · 0` — while the agent's transcript showed the spawning
  `Agent running` row and none of the worker's output.
- **Picked.** Clicking the row swapped the transcript in place. The log's accessible name became
  `Transcript: Explore subagent`, the live region read `Showing the Explore subagent's transcript.
  Still running.`, and the window / chat / picker element counts were unchanged — one window, no new
  picker entry. Only the worker's own rows were on screen.
- **Finished under an open view.** Staying inside it, the row flipped to `Explore · Definition found
  (single): · finished` (no elapsed, no tokens), the end line read `FINISHED Definition found
  (single):`, and the view kept every row the worker had written — its three `Bash` calls, its
  thinking row and its answer. It neither blanked nor snapped to main.
- **Back.** The first navigator row returned to the agent's transcript: label back to `Transcript`,
  `data-view` cleared, live region back to `Showing the agent's own transcript.`, and the agent's own
  rows — the `Agent` tool call and the session notices — back in place.

Unit tier: 2078 tests pass across `apps/tuval`'s unit project; the touched slices
(`src/shell/chat`, `src/claude/agent`) are 436 of them.

Part of #8384

## Deviations

- **Out-of-scope change** — **Said:** #8406's files list names `view.ts`, `ChatWindow.tsx`,
  `rows.ts` and three test files. **Did:** also changed `subagents.ts` / `subagents.unit.test.ts`
  (the navigator's model) and `SubagentList.tsx` (the rows became buttons), plus
  `boundary.unit.test.ts` for the new slot field. **Why:** the criteria "the list stays visible with
  that subagent's row marked" and "a finished subagent keeps its view" are decisions about which
  rows the list holds and how one is marked, which is that model's job rather than the window's.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the spawn brief authorised fixing the `subagent-not-found`
  detail's doubled id "in passing if you touch it". **Did:** fixed it in
  `apps/tuval/src/claude/agent/refusals.ts` and its two call sites in `sidechain-store.ts`.
  **Why:** the brief named it. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the issue body says a subagent's rows come "from child #8404's
  sidechain reader once it has finished or once its rows are no longer in the live tail". **Did:**
  the view reads the slot alone. **Why:** `SubagentSlot.items` carries every item the worker produced
  and the slot is kept — not dropped — when it finishes (`ports/subagent.ts`; `core/state.ts`
  checkpoints `subagents`), so the slot answers both cases the reader was named for, and no
  acceptance criterion names it. The reader is Node-side and this directory's
  `boundary.unit.test.ts` forbids a `node:` or `/claude/` import, so wiring it needs a port
  round-trip that does not exist. **Disposition:** filed as #8465.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left the composer sending to the
  parent agent while a subagent view is open, unlabelled. **Why:** the behaviour is right — Q6 on
  #8384 grounded that a subagent is driven through its parent session — and whether the surface
  should *say* so is an unruled design question no criterion covers. **Disposition:** filed as
  #8466.
- **Pre-existing test or fixture changed** — **Said:** nothing. **Did:** added `viewing: null` to
  three existing expectations in `view.unit.test.ts` and `boundary.unit.test.ts`, and `status` /
  `current` to one in `subagents.unit.test.ts`. **Why:** each asserts a whole record that gained a
  field. **Disposition:** stated here; no assertion was weakened.
