### PR TITLE
feat: Chat window: c-b a and the mouse both reach every action on the running-subagent list

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -45,6 +45,8 @@ import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
 import {isAiAgentSessionState} from "../../ai-agent/core/snapshot.ts";
 import type {Mode, TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {FOCUS_LIST_KEY} from "../keys/syntax.ts";
+import {useForwardedKey} from "../ui/forwarded-key.tsx";
 import type {ProcessView, WindowHost, WindowRenderer} from "../window/index.ts";
 import {prefixArmedAround, windowRenderer} from "../window/index.ts";
 import {CompactionMarker} from "./CompactionMarker.tsx";
@@ -67,7 +69,7 @@ import {
 	subagentRows,
 } from "./rows.ts";
 import {SessionRow} from "./SessionRow.tsx";
-import {SubagentList} from "./SubagentList.tsx";
+import {SubagentList, type SubagentListHandle} from "./SubagentList.tsx";
 import {ThinkingRow} from "./ThinkingRow.tsx";
 import {type ToolFold, ToolRow} from "./ToolRow.tsx";
 import {UnsentMessages} from "./UnsentMessages.tsx";
@@ -536,6 +538,18 @@ function ChatWindow({
 		commit(viewMain);
 	}, [commit, settleScroll]);
 
+	/**
+	 * `<c-b> a`, arriving as the key that chord's command row mints (`../commands/table.ts`). The
+	 * shell cannot address a renderer by name, so the binding forwards a key instead and this is the
+	 * window's whole share of it: hand the list its focus, or — with the flag off, where no list is
+	 * rendered and this ref is null — do nothing at all.
+	 */
+	const navigatorRef = useRef<SubagentListHandle>(null);
+	useForwardedKey(host.windowId, (key) => {
+		if (key !== FOCUS_LIST_KEY) return;
+		navigatorRef.current?.focus();
+	});
+
 	const mainRows = useMemo(
 		() =>
 			chatRows({
@@ -947,6 +961,7 @@ function ChatWindow({
 				{options.subagentList ? (
 					<>
 						<SubagentList
+							ref={navigatorRef}
 							slots={process.state.subagents}
 							now={options.now}
 							viewing={viewing?.id ?? null}

--- a/apps/tuval/src/shell/chat/SubagentList.tsx
+++ b/apps/tuval/src/shell/chat/SubagentList.tsx
@@ -1,5 +1,5 @@
 /**
- * The subagent navigator at the top of the agent window (#8405, #8406).
+ * The subagent navigator at the top of the agent window (#8405, #8406, #8407).
  *
  * Rendered off the port's subagent slot alone, so every agent program gets it the moment its
  * mapper fills the slot — nothing here names a backend. Absent rather than empty when nothing is
@@ -8,7 +8,14 @@
  *
  * It is a navigator and not a readout (Q8): each row is a real button that swaps the window's one
  * view slot onto that worker's transcript, and inside a subagent view a leading row swaps back to
- * the agent's own. Both reach with mouse and keyboard alike, which was Q4's other half.
+ * the agent's own. Both reach with mouse and keyboard alike, which was Q4's other half — and the
+ * keyboard reaches them through *these* handlers, the ones the mouse calls, never through a second
+ * copy that could drift.
+ *
+ * The list holds one tab stop, not one per row: `<c-b> a` puts focus on the row the window is
+ * showing (`focus()` below, driven by the shell's forwarded key), and the arrows walk from there.
+ * Which row holds the stop is component state and never the view slot — where DOM focus sits is not
+ * a fact a checkpoint should restore.
  *
  * Elapsed is the one thing the list computes rather than reads. It ticks on a timer that moves a
  * render counter and nothing else: a per-second `Msg` would checkpoint the whole session once a
@@ -16,65 +23,119 @@
  */
 
 import {MetaRow} from "@kampus/design";
-import type {ReactElement} from "react";
-import {useEffect, useMemo, useState} from "react";
+import type {ReactElement, KeyboardEvent as ReactKeyboardEvent, ReactNode, Ref} from "react";
+import {
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import type {SubagentSlot} from "../../ai-agent/ports/index.ts";
-import {elapsedLabel, runningSubagents, type SubagentRow, tokenLabel} from "./subagents.ts";
+import {prefixArmedAround} from "../window/index.ts";
+import {
+	elapsedLabel,
+	runningSubagents,
+	SUBAGENT_ROW_CAP,
+	type SubagentRow,
+	tokenLabel,
+} from "./subagents.ts";
 
 /** How often the elapsed readouts are re-rendered. One second: the coarsest unit the label shows. */
 const TICK_MS = 1_000;
 
-function NavigatorRow({
-	row,
-	at,
-	onView,
+/** How the window drives the list from outside it — the chord's landing point, and nothing else. */
+export interface SubagentListHandle {
+	/** Put DOM focus on the row holding the tab stop. `false` when there is no list to focus. */
+	readonly focus: () => boolean;
+}
+
+/**
+ * One focusable line, in the order they are drawn. The key is prefixed rather than the bare id
+ * because a worker's id is a transcript item id and could spell either of the other two.
+ */
+type Entry =
+	| {readonly kind: "main"; readonly key: string}
+	| {readonly kind: "row"; readonly key: string; readonly row: SubagentRow}
+	| {readonly kind: "more"; readonly key: string; readonly count: number};
+
+/** Which line to put focus on once the entries have changed under an activation. */
+type FocusRequest = {readonly kind: "first"} | {readonly kind: "key"; readonly key: string};
+
+const rowKey = (id: string): string => `row:${id}`;
+
+function Line({
+	entryKey,
+	current,
+	stop,
+	register,
+	onPick,
+	className,
+	children,
 }: {
-	readonly row: SubagentRow;
-	readonly at: number;
-	readonly onView: (id: string) => void;
+	readonly entryKey: string;
+	readonly current?: boolean;
+	/** This line holds the list's one tab stop. Every other line is reachable by arrow alone. */
+	readonly stop: boolean;
+	readonly register: (key: string, node: HTMLButtonElement | null) => void;
+	readonly onPick: () => void;
+	readonly className?: string;
+	readonly children: ReactNode;
 }): ReactElement {
 	return (
 		<li className="tuval-chat-subagent-item">
 			<button
 				type="button"
-				className="tuval-chat-subagent-pick"
+				className={className ?? "tuval-chat-subagent-pick"}
+				ref={(node) => {
+					register(entryKey, node);
+				}}
 				// The row that is showing is marked rather than disabled: a disabled control drops out
 				// of the tab order, so the operator's place in the navigator would vanish under them.
-				aria-current={row.current ? "true" : undefined}
-				onClick={() => onView(row.id)}
+				aria-current={current === true ? "true" : undefined}
+				tabIndex={stop ? 0 : -1}
+				onClick={onPick}
 			>
-				<MetaRow as="span" className="tuval-chat-subagent">
-					<span className="tuval-chat-subagent-type" data-field="type">
-						{row.type}
-					</span>
-					<MetaRow.Dot />
-					<span className="tuval-chat-subagent-line" data-field="line">
-						{row.lastLine}
-					</span>
-					{row.status === "finished" ? (
-						<>
-							<MetaRow.Dot />
-							{/* Q2: no elapsed and no token readout once a worker stops. */}
-							<span data-field="status">finished</span>
-						</>
-					) : (
-						<>
-							<MetaRow.Dot />
-							<span data-field="elapsed">
-								{/* The unit is what the number means, and the layout is the only thing saying it. */}
-								<span className="kp-visually-hidden">elapsed </span>
-								{elapsedLabel(at - row.startedAt)}
-							</span>
-							<MetaRow.Dot />
-							<span data-field="tokens">
-								{tokenLabel(row.tokens)}
-								<span className="kp-visually-hidden"> tokens</span>
-							</span>
-						</>
-					)}
-				</MetaRow>
+				{children}
 			</button>
 		</li>
+	);
+}
+
+function RowFields({row, at}: {readonly row: SubagentRow; readonly at: number}): ReactElement {
+	return (
+		<MetaRow as="span" className="tuval-chat-subagent">
+			<span className="tuval-chat-subagent-type" data-field="type">
+				{row.type}
+			</span>
+			<MetaRow.Dot />
+			<span className="tuval-chat-subagent-line" data-field="line">
+				{row.lastLine}
+			</span>
+			{row.status === "finished" ? (
+				<>
+					<MetaRow.Dot />
+					{/* Q2: no elapsed and no token readout once a worker stops. */}
+					<span data-field="status">finished</span>
+				</>
+			) : (
+				<>
+					<MetaRow.Dot />
+					<span data-field="elapsed">
+						{/* The unit is what the number means, and the layout is the only thing saying it. */}
+						<span className="kp-visually-hidden">elapsed </span>
+						{elapsedLabel(at - row.startedAt)}
+					</span>
+					<MetaRow.Dot />
+					<span data-field="tokens">
+						{tokenLabel(row.tokens)}
+						<span className="kp-visually-hidden"> tokens</span>
+					</span>
+				</>
+			)}
+		</MetaRow>
 	);
 }
 
@@ -84,6 +145,7 @@ export function SubagentList({
 	viewing,
 	onView,
 	onMain,
+	ref,
 }: {
 	readonly slots: Readonly<Record<string, SubagentSlot>>;
 	readonly now: () => number;
@@ -91,9 +153,50 @@ export function SubagentList({
 	readonly viewing: string | null;
 	readonly onView: (id: string) => void;
 	readonly onMain: () => void;
+	readonly ref?: Ref<SubagentListHandle>;
 }): ReactElement | null {
-	const model = useMemo(() => runningSubagents(slots, viewing), [slots, viewing]);
+	const [showAll, setShowAll] = useState(false);
+	const [held, setHeld] = useState<string | null>(null);
+	const [request, setRequest] = useState<FocusRequest | null>(null);
+	const nodes = useRef(new Map<string, HTMLButtonElement>());
+
+	const model = useMemo(
+		() => runningSubagents(slots, viewing, showAll ? Number.POSITIVE_INFINITY : SUBAGENT_ROW_CAP),
+		[slots, viewing, showAll],
+	);
 	const running = model.rows.filter((row) => row.status === "running").length;
+
+	const entries = useMemo((): ReadonlyArray<Entry> => {
+		const rows = model.rows.map((row): Entry => ({kind: "row", key: rowKey(row.id), row}));
+		return [
+			...(viewing === null ? [] : [{kind: "main", key: "main"} as const]),
+			...rows,
+			...(model.more <= 0 ? [] : [{kind: "more", key: "more", count: model.more} as const]),
+		];
+	}, [model, viewing]);
+	const keys = useMemo(() => entries.map((entry) => entry.key), [entries]);
+
+	// Where the stop rests by default: the row the window is showing, so the chord lands on the
+	// operator's own place in the navigator rather than at the top of a list they have walked past.
+	const fallback =
+		entries.find((entry) => entry.kind === "row" && entry.row.current)?.key ?? keys[0];
+	const stop = held !== null && keys.includes(held) ? held : fallback;
+
+	const register = useCallback((key: string, node: HTMLButtonElement | null) => {
+		if (node === null) nodes.current.delete(key);
+		else nodes.current.set(key, node);
+	}, []);
+
+	const moveTo = useCallback((key: string | undefined) => {
+		if (key === undefined) return false;
+		setHeld(key);
+		const node = nodes.current.get(key);
+		if (node === undefined) return false;
+		node.focus();
+		return true;
+	}, []);
+
+	useImperativeHandle(ref, () => ({focus: () => moveTo(stop)}), [moveTo, stop]);
 
 	// The counter's value is never read: setting it is the re-render, and the re-render is the tick.
 	const [, tick] = useState(0);
@@ -102,6 +205,76 @@ export function SubagentList({
 		const timer = setInterval(() => tick((count) => count + 1), TICK_MS);
 		return () => clearInterval(timer);
 	}, [running]);
+
+	/**
+	 * A line that took the focus and then removed itself — the way back, the "more" row — would drop
+	 * focus onto the body, which is where a keyboard operator loses the list entirely. So an
+	 * activation that changes the entries names where focus goes next, and this places it once the
+	 * new entries are drawn.
+	 */
+	useLayoutEffect(() => {
+		if (request === null) return;
+		setRequest(null);
+		moveTo(request.kind === "key" && keys.includes(request.key) ? request.key : keys[0]);
+	}, [request, keys, moveTo]);
+
+	const pickRow = useCallback(
+		(id: string) => {
+			setHeld(rowKey(id));
+			onView(id);
+		},
+		[onView],
+	);
+
+	const pickMain = useCallback(() => {
+		setRequest({kind: "first"});
+		onMain();
+	}, [onMain]);
+
+	const expand = useCallback(() => {
+		const first = runningSubagents(slots, viewing, Number.POSITIVE_INFINITY).rows[SUBAGENT_ROW_CAP];
+		setShowAll(true);
+		setRequest(first === undefined ? {kind: "first"} : {kind: "key", key: rowKey(first.id)});
+	}, [slots, viewing]);
+
+	const onKeyDown = useCallback(
+		(event: ReactKeyboardEvent<HTMLUListElement>) => {
+			if (event.defaultPrevented) return;
+			// An armed prefix owns the next key from any focus, so the list stands down for it:
+			// `<prefix> <arrowdown>` is the shell walking windows, not this list walking rows (#8270).
+			if (prefixArmedAround(event.target)) return;
+			const step = (to: number): void => {
+				const key = keys[Math.min(Math.max(to, 0), keys.length - 1)];
+				if (key === undefined) return;
+				event.preventDefault();
+				// Swallowed here, so the desk's one listener never routes it and no second copy of this
+				// key comes back forwarded — which would walk the list twice per press.
+				event.stopPropagation();
+				moveTo(key);
+			};
+			const at = stop === undefined ? -1 : keys.indexOf(stop);
+			switch (event.key) {
+				case "ArrowDown":
+					return step(at + 1);
+				case "ArrowUp":
+					return step(at - 1);
+				case "Home":
+					return step(0);
+				case "End":
+					return step(keys.length - 1);
+				case "Escape":
+					// Only while there is somewhere to come back from. On main, Escape is the window's —
+					// it interrupts a running turn — and taking it here would swallow that.
+					if (viewing === null) return;
+					event.preventDefault();
+					event.stopPropagation();
+					return pickMain();
+				default:
+					return;
+			}
+		},
+		[keys, moveTo, pickMain, stop, viewing],
+	);
 
 	// A subagent view always draws the region, even with nothing to list: the way back is in it, and
 	// a slot that has gone from state must not take the operator's exit with it.
@@ -114,22 +287,53 @@ export function SubagentList({
 			// also carries the way back and, under Q9, a worker that has stopped — so it is named for
 			// what it is there instead.
 			aria-label={viewing === null ? "Running subagents" : "Subagents"}
+			onKeyDown={onKeyDown}
 		>
-			{viewing === null ? null : (
-				<li className="tuval-chat-subagent-item">
-					<button type="button" className="tuval-chat-subagent-pick" onClick={onMain}>
-						<MetaRow as="span" className="tuval-chat-subagent">
-							Back to the agent transcript
-						</MetaRow>
-					</button>
-				</li>
-			)}
-			{model.rows.map((row) => (
-				<NavigatorRow key={row.id} row={row} at={at} onView={onView} />
-			))}
-			{model.more <= 0 ? null : (
-				<li className="tuval-chat-subagent-more">{model.more} more running</li>
-			)}
+			{entries.map((entry) => {
+				if (entry.kind === "main") {
+					return (
+						<Line
+							key={entry.key}
+							entryKey={entry.key}
+							stop={stop === entry.key}
+							register={register}
+							onPick={pickMain}
+						>
+							<MetaRow as="span" className="tuval-chat-subagent">
+								Back to the agent transcript
+							</MetaRow>
+						</Line>
+					);
+				}
+				if (entry.kind === "row") {
+					return (
+						<Line
+							key={entry.key}
+							entryKey={entry.key}
+							current={entry.row.current}
+							stop={stop === entry.key}
+							register={register}
+							onPick={() => pickRow(entry.row.id)}
+						>
+							<RowFields row={entry.row} at={at} />
+						</Line>
+					);
+				}
+				return (
+					<Line
+						key={entry.key}
+						entryKey={entry.key}
+						stop={stop === entry.key}
+						register={register}
+						onPick={expand}
+						className="tuval-chat-subagent-pick tuval-chat-subagent-more"
+					>
+						{/* The name says what the control does and still contains its visible text. */}
+						<span className="kp-visually-hidden">Show </span>
+						{entry.count} more running
+					</Line>
+				);
+			})}
 		</ul>
 	);
 }

--- a/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
@@ -452,6 +452,35 @@ describe("the running-subagent list", () => {
 		rendered.unmount();
 	});
 
+	/**
+	 * The focus model the chord lands in (#8407). One tab stop and arrows to walk, so the list is a
+	 * composite the operator enters once — and every row still reachable and still visibly focused
+	 * wherever the walk leaves it, which is what `probeFocus` reads.
+	 */
+	it("carries one tab stop, moves it with the arrows, and shows focus wherever it lands", async () => {
+		const rendered = await mountList();
+		const root = rendered.container.firstElementChild as HTMLElement;
+		const picks = Array.from(root.querySelectorAll<HTMLButtonElement>(".tuval-chat-subagent-pick"));
+
+		expect(picks.map((pick) => pick.tabIndex)).toEqual([0, -1]);
+		for (const pick of picks) {
+			expect(await probeFocus(root, pick)).toEqual([]);
+		}
+
+		await act(async () => {
+			(picks[0] as HTMLButtonElement).focus();
+			fireEvent.keyDown(picks[0] as HTMLButtonElement, {key: "ArrowDown", bubbles: true});
+		});
+
+		// Focus moved onto a control with a name of its own, which is the whole announcement a moved
+		// focus owes: the row is read out where it lands.
+		expect(document.activeElement).toBe(picks[1]);
+		expect(picks[1]?.textContent).toContain("builder");
+		expect(picks.map((pick) => pick.tabIndex)).toEqual([-1, 0]);
+
+		rendered.unmount();
+	});
+
 	it(
 		"holds the enforced pillar-4 invariants with workers running",
 		async () => {

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -180,6 +180,7 @@
 	white-space: nowrap;
 }
 
+/* The tail's own door (#8407): a control, so it carries the row reset above plus its muted type. */
 .tuval-chat-subagent-more {
 	font: var(--t-meta);
 	color: var(--text-muted);

--- a/apps/tuval/src/shell/chat/subagent-navigator.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-navigator.unit.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The navigator under a hand (#8407): `<c-b> a` arriving as the forwarded key, the arrows walking
+ * the rows, the way back, the tail's door — and the mouse doing all of it through the same handlers.
+ *
+ * The chord's route through the key router and the command table is proven without a DOM in
+ * `../core/machine.unit.test.ts`; what is proven here is the other end of it, where the key lands.
+ *
+ * **Enter and Space are the platform's, not this window's.** jsdom implements no activation
+ * behaviour, so a `keyDown` on a button fires no click there and asserting one would test the test.
+ * What the keyboard needs is a real `button` it can reach, and that is what these cases read: the
+ * element focus lands on is a `button`, and clicking it runs the same handler the mouse runs. The
+ * shipped a11y pass makes the same call for the same reason.
+ */
+
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {act, fireEvent, render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {SubagentSlot} from "../../ai-agent/ports/index.ts";
+import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
+import {ProcessId} from "../../process/process.ts";
+import {FOCUS_LIST_KEY} from "../keys/index.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {ForwardedKeyProvider} from "../ui/forwarded-key.tsx";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {type ChatWindowOptions, chatWindow} from "./ChatWindow.tsx";
+import {call, userItem, withTranscript} from "./chat.testing.ts";
+import {SUBAGENT_ROW_CAP} from "./subagents.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+const WINDOW = WindowId.make("w1");
+
+const slots = (...entries: ReadonlyArray<SubagentSlot>): Record<string, SubagentSlot> =>
+	Object.fromEntries(entries.map((slot) => [slot.id, slot]));
+
+/** Two running workers and the call that spawned one of them — the ordinary shape of the list. */
+const twoRunning = (): AiAgentSessionState =>
+	withTranscript([userItem("u1", "go"), call("agent", {name: "Agent"})], {
+		subagents: slots(
+			subagentSlot("agent", {type: "reviewer", lastLine: "reading rows.ts"}),
+			subagentSlot("other", {type: "builder", lastLine: "writing the test"}),
+		),
+	});
+
+/**
+ * A window mounted under a forwarded-key provider, so a test can press the chord the way the desk
+ * delivers it: one bump of `seq`, which is the only thing that makes two presses two events.
+ */
+const openWindow = async (
+	state: AiAgentSessionState,
+	options: ChatWindowOptions = {},
+	view: ChatView = initialChatView,
+) => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
+	);
+	const host = await Effect.runPromise(process.window(WINDOW, view));
+	const renderer = chatWindow({scrollCommitMs: 0, scrollToFn: () => undefined, ...options});
+	const stage = (key: string | null, seq: number): ReactElement => (
+		<ForwardedKeyProvider value={key === null ? null : {windowId: WINDOW, key, seq}}>
+			{renderer.render(host) as ReactElement}
+		</ForwardedKeyProvider>
+	);
+	const rendered = render(stage(null, 0));
+	await screen.findByRole("log", {name: /^Transcript/});
+	let seq = 0;
+	const forward = async (key: string) => {
+		seq += 1;
+		await act(async () => {
+			rendered.rerender(stage(key, seq));
+		});
+	};
+	return {rendered, process, chord: () => forward(FOCUS_LIST_KEY), forward};
+};
+
+const active = (): HTMLElement => document.activeElement as HTMLElement;
+const rows = (): ReadonlyArray<HTMLButtonElement> =>
+	Array.from(
+		document.querySelectorAll<HTMLButtonElement>(
+			".tuval-chat-subagent-pick:not(.tuval-chat-subagent-more)",
+		),
+	);
+
+const press = async (key: string) => {
+	await act(async () => {
+		fireEvent.keyDown(active(), {key, bubbles: true});
+	});
+};
+
+const click = async (node: HTMLElement) => {
+	await act(async () => {
+		node.click();
+	});
+};
+
+describe("<c-b> a and the list it lands in", () => {
+	it("puts focus on a row of the list, and the arrows walk it", async () => {
+		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
+		expect(active().className).not.toContain("tuval-chat-subagent-pick");
+
+		await chord();
+		expect(active()).toBe(rows()[0]);
+		expect(active().tagName).toBe("BUTTON");
+
+		await press("ArrowDown");
+		expect(active()).toBe(rows()[1]);
+		// Clamped at the end rather than wrapped: the walk stops where the list does.
+		await press("ArrowDown");
+		expect(active()).toBe(rows()[1]);
+		await press("ArrowUp");
+		expect(active()).toBe(rows()[0]);
+		await press("End");
+		expect(active()).toBe(rows()[1]);
+		await press("Home");
+		expect(active()).toBe(rows()[0]);
+
+		rendered.unmount();
+	});
+
+	it("holds one tab stop, and it is the row the window is showing", async () => {
+		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
+		expect(rows().map((row) => row.tabIndex)).toEqual([0, -1]);
+
+		await chord();
+		await press("ArrowDown");
+		expect(rows().map((row) => row.tabIndex)).toEqual([-1, 0]);
+
+		// Opening the second row keeps the stop on it, so the chord comes back to where they were.
+		await click(rows()[1] as HTMLElement);
+		const [back, ...opened] = rows();
+		expect(back?.textContent).toBe("Back to the agent transcript");
+		expect(opened.map((row) => row.tabIndex)).toEqual([-1, 0]);
+		expect(opened[1]?.getAttribute("aria-current")).toBe("true");
+
+		rendered.unmount();
+	});
+
+	it("opens the focused row in place, through the button the mouse clicks", async () => {
+		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
+		await chord();
+		await click(active());
+
+		expect(screen.getByRole("log", {name: "Transcript: reviewer subagent"})).toBeTruthy();
+		rendered.unmount();
+	});
+
+	it("comes back to main from the way-back row, and leaves focus in the list", async () => {
+		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
+		await chord();
+		await click(active());
+
+		const back = rows()[0] as HTMLButtonElement;
+		expect(back.textContent).toBe("Back to the agent transcript");
+		await click(back);
+
+		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
+		// The row that took the click is gone with the view it left, so focus would have fallen to
+		// the body — where a keyboard operator loses the list altogether.
+		expect(active()).toBe(rows()[0]);
+		rendered.unmount();
+	});
+
+	it("comes back to main on Escape from inside a subagent view", async () => {
+		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
+		await chord();
+		await click(active());
+		expect(screen.getByRole("log", {name: "Transcript: reviewer subagent"})).toBeTruthy();
+
+		await press("Escape");
+		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
+		rendered.unmount();
+	});
+
+	it("leaves Escape to the window while it is already on main, so a turn can still be cut", async () => {
+		const state = withTranscript([userItem("u1", "go")], {
+			phase: "prompting",
+			subagents: slots(subagentSlot("agent", {type: "reviewer"})),
+		});
+		const {rendered, process, chord} = await openWindow(state, {subagentList: true});
+		await chord();
+		await press("Escape");
+
+		expect(process.inbox().map((msg) => msg.type)).toContain("interrupt");
+		rendered.unmount();
+	});
+
+	it("expands the tail from the more row and lands focus on the first row it revealed", async () => {
+		const running = Array.from({length: 8}, (_, index) =>
+			subagentSlot(`s${index}`, {type: `worker-${index}`, startedAt: 1_756_000_000_000 + index}),
+		);
+		const {rendered, chord} = await openWindow(
+			withTranscript([userItem("u1", "go")], {subagents: slots(...running)}),
+			{subagentList: true},
+		);
+		expect(rows()).toHaveLength(SUBAGENT_ROW_CAP);
+		const more = screen.getByRole("button", {name: "Show 3 more running"});
+
+		await chord();
+		await press("End");
+		expect(active()).toBe(more);
+		await click(more);
+
+		expect(rows()).toHaveLength(8);
+		expect(screen.queryByRole("button", {name: /more running$/})).toBeNull();
+		expect(active()).toBe(rows()[SUBAGENT_ROW_CAP]);
+		rendered.unmount();
+	});
+});
+
+describe("the chord where there is no list", () => {
+	it("does nothing and takes nothing down when the window is showing none", async () => {
+		const {rendered, chord} = await openWindow(withTranscript([userItem("u1", "go")]), {
+			subagentList: true,
+		});
+		const before = active();
+
+		await chord();
+
+		expect(document.querySelector(".tuval-chat-subagents")).toBeNull();
+		expect(active()).toBe(before);
+		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
+		rendered.unmount();
+	});
+
+	it("does nothing with the flag off, where no row is focusable at all", async () => {
+		const {rendered, chord} = await openWindow(twoRunning(), {});
+		const before = active();
+
+		await chord();
+
+		expect(document.querySelector(".tuval-chat-subagents")).toBeNull();
+		expect(rows()).toEqual([]);
+		expect(active()).toBe(before);
+		rendered.unmount();
+	});
+});
+
+/**
+ * #7559's own invariant, re-read because this ticket is the one that could have broken it: the
+ * chord reaches the window as a forwarded key, so the list needs no listener of its own and the
+ * page keeps the one the desk owns.
+ */
+describe("the page's keyboard listeners", () => {
+	const modules = (dir: string): ReadonlyArray<readonly [string, string]> =>
+		readdirSync(dir, {recursive: true, withFileTypes: true})
+			.filter((entry) => entry.isFile() && /\.tsx?$/.test(entry.name))
+			.filter((entry) => !entry.name.includes(".test.") && !entry.name.endsWith(".testing.ts"))
+			.map((entry) => {
+				const path = join(entry.parentPath, entry.name);
+				return [path, readFileSync(path, "utf8")] as const;
+			});
+
+	it("registers a keydown on a shared target in exactly one module, and it is the desk's", () => {
+		const shell = join(import.meta.dirname, "..");
+		const offenders = modules(shell)
+			.filter(([, source]) => /addEventListener\(\s*"keydown"/.test(source))
+			.map(([path]) => path.slice(shell.length + 1));
+		expect(offenders).toEqual(["ui/Desk.tsx"]);
+	});
+});

--- a/apps/tuval/src/shell/chat/subagents.ts
+++ b/apps/tuval/src/shell/chat/subagents.ts
@@ -64,6 +64,8 @@ const rowOf = (slot: SubagentSlot, current: boolean): SubagentRow => ({
 export const runningSubagents = (
 	slots: Readonly<Record<string, SubagentSlot>>,
 	viewing: string | null = null,
+	/** How many running workers the list shows. The "more" row raises it to all of them (#8407). */
+	cap: number = SUBAGENT_ROW_CAP,
 ): SubagentListModel => {
 	const running = Object.values(slots)
 		.filter((slot) => slot.status === "running")
@@ -72,7 +74,7 @@ export const runningSubagents = (
 				? left.id.localeCompare(right.id)
 				: left.startedAt - right.startedAt,
 		);
-	const shown = running.slice(0, SUBAGENT_ROW_CAP);
+	const shown = running.slice(0, cap);
 	const held = new Set<string>(shown.map((slot) => slot.id));
 	const viewed = viewing === null || held.has(viewing) ? undefined : slots[viewing];
 	return {

--- a/apps/tuval/src/shell/commands/table.ts
+++ b/apps/tuval/src/shell/commands/table.ts
@@ -18,6 +18,7 @@
 
 import {Schema} from "effect";
 import type {ShellMsg} from "../core/machine.ts";
+import {FOCUS_LIST_KEY} from "../keys/syntax.ts";
 import type {CommandName} from "../keys/table.ts";
 import type {Direction} from "../layout/index.ts";
 import {type PickerCommand, pickerCommands} from "../picker/intent.ts";
@@ -127,6 +128,15 @@ export const shellCommands: ReadonlyArray<AnyShellCommand> = [
 			"Return the focused window to the picker. The process it was showing keeps running, and the picker offers it back.",
 		params: noParams,
 		toMsg: () => ({type: "window.unbind"}),
+	}),
+	// The one row whose Msg carries a key rather than a decision. A binding names a command and a
+	// command names a Msg, so nothing bound can address a window's *renderer* — where a list's focus
+	// lives — and this row closes that gap by forwarding a key no keyboard can produce (#8407).
+	defineCommand({
+		path: ["window", "focus-list"],
+		describe: "Move focus into the focused window's own list, when it draws one.",
+		params: noParams,
+		toMsg: () => ({type: "window.forwardKey", key: FOCUS_LIST_KEY}),
 	}),
 	...pickerCommands.map(pickerRow),
 	defineCommand({

--- a/apps/tuval/src/shell/commands/table.unit.test.ts
+++ b/apps/tuval/src/shell/commands/table.unit.test.ts
@@ -5,6 +5,7 @@
 
 import {describe, expect, it} from "vitest";
 import type {ShellMsg} from "../core/machine.ts";
+import {CommandName, FOCUS_LIST_KEY} from "../keys/index.ts";
 import {pickerCommands} from "../picker/intent.ts";
 import {commandName, isOptionalParameter, parameterNames} from "./row.ts";
 import {commandFor, commandNames, msgForCommandName, resolveVerb, shellCommands} from "./table.ts";
@@ -29,6 +30,7 @@ describe("the command table", () => {
 			"window:focus-down",
 			"window:focus",
 			"window:pick",
+			"window:focus-list",
 			"window:open",
 			"window:attach",
 			"workspace:create",
@@ -41,6 +43,18 @@ describe("the command table", () => {
 			"config:reload",
 		]);
 		expect(new Set(commandNames.map(String)).size).toBe(commandNames.length);
+	});
+
+	it("gives the focus-list row a key to mint, since no command name can address a renderer", () => {
+		expect(msgOf("window:focus-list")).toEqual({
+			type: "window.forwardKey",
+			key: FOCUS_LIST_KEY,
+		});
+		// A bound key sequence has nowhere to carry an argument, so the chord's row must take none.
+		expect(msgForCommandName(CommandName.make("window:focus-list"))).toEqual({
+			type: "window.forwardKey",
+			key: FOCUS_LIST_KEY,
+		});
 	});
 
 	it("names every row from its own path, and every row carries a sentence", () => {

--- a/apps/tuval/src/shell/core/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/core/boundary.unit.test.ts
@@ -100,6 +100,7 @@ describe("shell core boundary", () => {
 			| "window.focusDirection"
 			| "window.bind"
 			| "window.unbind"
+			| "window.forwardKey"
 			| "window.setView"
 			| "layout.resize"
 			| "layout.zoom"

--- a/apps/tuval/src/shell/core/machine.ts
+++ b/apps/tuval/src/shell/core/machine.ts
@@ -144,6 +144,15 @@ export type ShellMsg =
 			readonly takesKeys?: boolean;
 	  }
 	| {readonly type: "window.unbind"; readonly windowId?: WindowId}
+	| {
+			/**
+			 * Hand this key to the focused window as if it had been pressed there. The Msg knows
+			 * nothing about what any window does with it: a window that draws no list for
+			 * `FOCUS_LIST_KEY` ignores it, exactly as a process with no `key` cell does (#8407).
+			 */
+			readonly type: "window.forwardKey";
+			readonly key: string;
+	  }
 	| {readonly type: "window.setView"; readonly view: ViewState; readonly windowId?: WindowId}
 	| {
 			readonly type: "layout.resize";
@@ -504,6 +513,34 @@ const viewOf = (state: ShellState, windowId: WindowId): {readonly view?: ViewSta
 export const cellsFor = (table: PrefixTable): ShellCells => {
 	const apply = (state: ShellState, msg: ShellMsg): Step => runCell(cells, state, msg);
 
+	/**
+	 * Hand one key to the focused window, both halves of what that means: the Cmd that delivers it
+	 * into the window's *process*, and the `ToWindow` answer the page reads to deliver it into the
+	 * window's *renderer* (`../ui/press.ts`). They reach two different places, and the renderer is
+	 * the one where a list's focus lives — which is why an empty window, whose program has no
+	 * process to forward to, still forwards to whatever is drawn in it (the picker).
+	 *
+	 * `window.forwardKey` runs this too, and that is what lets a bound chord reach a renderer no
+	 * command name can address: the binding names a command, the command mints a key, and this
+	 * writes the same answer an unbound press of that key would have written (#8407).
+	 */
+	const toFocusedWindow = (state: ShellState, key: string): Step => {
+		const workspace = activeWorkspace(state);
+		const next: ShellState =
+			state.lastPress === undefined
+				? state
+				: {...state, lastPress: {...state.lastPress, outcome: {_tag: "ToWindow", key}}};
+		// An empty window has no process to forward to, and a window whose program never declared
+		// `takesKeys` has no cell for one, so the key is dropped rather than queued (#7973).
+		const processId = workspace === undefined ? null : keyTargetOf(workspace, workspace.focused);
+		return [
+			next,
+			processId === null || workspace === undefined
+				? NO_CMDS
+				: [{type: "forwardKey", processId, windowId: workspace.focused, key}],
+		];
+	};
+
 	const pressKey = (state: ShellState, msg: Extract<ShellMsg, {type: "keys.press"}>): Step => {
 		const answer = route(table, toRouter(state.prefix), msg.key);
 		const prefix = fromRouter(answer.next);
@@ -514,24 +551,8 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 		const routed: ShellState = {...state, prefix, lastPress: recorded(msg, answer)};
 
 		if (answer._tag === "ToWindow") {
-			const workspace = activeWorkspace(routed);
-			const processId = workspace === undefined ? null : keyTargetOf(workspace, workspace.focused);
-			// An empty window has no process to forward to, and a window whose program never declared
-			// `takesKeys` has no cell for one, so the key is dropped rather than queued (#7973).
-			return [
-				routed,
-				processId === null || workspace === undefined
-					? timer
-					: [
-							...timer,
-							{
-								type: "forwardKey",
-								processId,
-								windowId: workspace.focused,
-								key: answer.key,
-							},
-						],
-			];
+			const [next, cmds] = toFocusedWindow(routed, answer.key);
+			return [next, [...timer, ...cmds]];
 		}
 
 		if (answer._tag !== "Command") return [routed, timer];
@@ -552,6 +573,7 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 		"window.focusDirection": (state, msg) => focusDirection(state, msg.direction),
 		"window.bind": (state, msg) => bindWindow(state, msg.windowId, msg.processId, msg.takesKeys),
 		"window.unbind": (state, msg) => unbindWindow(state, msg.windowId),
+		"window.forwardKey": (state, msg) => toFocusedWindow(state, msg.key),
 		"window.setView": setView,
 		"layout.resize": resizeStack,
 		"layout.zoom": zoomWindow,

--- a/apps/tuval/src/shell/core/machine.unit.test.ts
+++ b/apps/tuval/src/shell/core/machine.unit.test.ts
@@ -4,7 +4,13 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {CommandName, defaultPrefixTable, type Key, type PrefixTable} from "../keys/index.ts";
+import {
+	CommandName,
+	defaultPrefixTable,
+	FOCUS_LIST_KEY,
+	type Key,
+	type PrefixTable,
+} from "../keys/index.ts";
 import {findWindow, windows} from "../layout/index.ts";
 import {mountPicker} from "../picker/view.ts";
 import {applyMsg, cellsFor, initialState, type ShellCmd, type ShellMsg} from "./machine.ts";
@@ -52,6 +58,7 @@ describe("shell core: the reducer's cells", () => {
 			"window.close",
 			"window.focus",
 			"window.focusDirection",
+			"window.forwardKey",
 			"window.open",
 			"window.setView",
 			"window.split",
@@ -319,6 +326,61 @@ describe("shell core: keys", () => {
 			},
 		]);
 		expect(after.prefix).toEqual({armed: false});
+	});
+
+	/**
+	 * The whole route the chord takes (#8407): the router resolves `<c-b> a` to a command name, the
+	 * command table turns that name into `window.forwardKey`, and its cell hands the focused window a
+	 * key no keyboard can produce. Read here rather than at the window, because the claim is that the
+	 * three tables agree — a component test could pass with the binding missing entirely.
+	 */
+	it("<c-b> a mints the focus-list key and hands it to the focused window", () => {
+		const bound = fold(initialState(), {
+			type: "window.bind",
+			processId: "process-agent",
+			takesKeys: true,
+		});
+		const [after, cmds] = apply(fold(bound, prefix), press("a"));
+
+		expect(cmds).toEqual([
+			{
+				type: "forwardKey",
+				processId: "process-agent",
+				windowId: active(bound).focused,
+				key: FOCUS_LIST_KEY,
+			},
+		]);
+		// The answer the page reads, and the half that reaches the *renderer* — where a list's focus
+		// lives. Without it the chord would end at the process and never move anything on screen.
+		expect(after.lastPress?.outcome).toEqual({_tag: "ToWindow", key: FOCUS_LIST_KEY});
+		expect(after.prefix).toEqual({armed: false});
+	});
+
+	it("answers the page the same key even where there is no process to forward it to", () => {
+		const bound = fold(initialState(), {type: "window.bind", processId: "process-agent"});
+		const [after, cmds] = apply(fold(bound, prefix), press("a"));
+
+		expect(cmds).toEqual([]);
+		expect(after.lastPress?.outcome).toEqual({_tag: "ToWindow", key: FOCUS_LIST_KEY});
+	});
+
+	it("a bare `a` is the window's own key and mints nothing", () => {
+		const bound = fold(initialState(), {
+			type: "window.bind",
+			processId: "process-agent",
+			takesKeys: true,
+		});
+		const [after, cmds] = apply(bound, press("a"));
+
+		expect(cmds).toEqual([
+			{
+				type: "forwardKey",
+				processId: "process-agent",
+				windowId: active(bound).focused,
+				key: "a",
+			},
+		]);
+		expect(after.lastPress?.outcome).toEqual({_tag: "ToWindow", key: "a"});
 	});
 
 	it("a window whose program never declared keys is forwarded none (#7973)", () => {

--- a/apps/tuval/src/shell/keys/index.ts
+++ b/apps/tuval/src/shell/keys/index.ts
@@ -16,6 +16,7 @@ export {
 export {
 	type DisallowedModifierError,
 	type DuplicateModifierError,
+	FOCUS_LIST_KEY,
 	type InvalidKeyError,
 	type Key,
 	type KeyParseError,

--- a/apps/tuval/src/shell/keys/syntax.ts
+++ b/apps/tuval/src/shell/keys/syntax.ts
@@ -267,3 +267,14 @@ export const normalize = (keyString: string): Result.Result<string, KeyParseErro
  */
 export const parseSequence = (keySequence: string): ReadonlyArray<string> | null =>
 	keySequence.match(/<[^<>\s]+>|[\s\S]|^$/g);
+
+/**
+ * The key `window:focus-list` mints (#8407). A binding names a command and a command names a Msg, so
+ * a chord cannot address a renderer directly; the command forwards this string to the focused window
+ * instead, and a window that draws a list moves focus into it.
+ *
+ * It is deliberately a spelling `parse` refuses — no chord may hold a `-` in its key — so neither a
+ * press nor a config binding can ever mint it, and a renderer comparing against it cannot be fooled
+ * by something the operator typed. `syntax.unit.test.ts` pins that refusal.
+ */
+export const FOCUS_LIST_KEY = "<focus-list>";

--- a/apps/tuval/src/shell/keys/syntax.unit.test.ts
+++ b/apps/tuval/src/shell/keys/syntax.unit.test.ts
@@ -6,7 +6,7 @@
 
 import {Result} from "effect";
 import {describe, expect, it} from "vitest";
-import {normalize, parse, parseSequence, stringify} from "./syntax.ts";
+import {FOCUS_LIST_KEY, normalize, parse, parseSequence, stringify} from "./syntax.ts";
 
 const value = <A, E>(result: Result.Result<A, E>): A | E => Result.merge(result);
 
@@ -465,5 +465,25 @@ describe("parse()", () => {
 				message: "<S-greater>: Unusable modifier with single-character keys: S",
 			});
 		});
+	});
+});
+
+/**
+ * The key a command mints (#8407). Its whole guarantee is that the grammar refuses it, so no press
+ * and no config binding can produce it and a renderer reading it knows where it came from.
+ */
+describe("FOCUS_LIST_KEY", () => {
+	it("is a spelling the grammar refuses, so nothing a keyboard does can mint it", () => {
+		expect(value(parse(FOCUS_LIST_KEY))).toEqual({
+			_tag: "InvalidKeyError",
+			key: FOCUS_LIST_KEY,
+			message: `Invalid key: ${FOCUS_LIST_KEY}`,
+		});
+		expect(Result.isFailure(normalize(FOCUS_LIST_KEY))).toBe(true);
+	});
+
+	it("is not what any key event stringifies to", () => {
+		expect(stringify({key: FOCUS_LIST_KEY})).not.toBe(FOCUS_LIST_KEY);
+		expect(stringify({key: "a"})).not.toBe(FOCUS_LIST_KEY);
 	});
 });

--- a/apps/tuval/src/shell/keys/table.ts
+++ b/apps/tuval/src/shell/keys/table.ts
@@ -62,6 +62,9 @@ export const defaultPrefixTable: PrefixTable = {
 		{sequence: "x", command: command("window:close"), repeatable: false},
 		// tmux binds `w` to `choose-window`, and the founder's config leaves it free (#8083).
 		{sequence: "w", command: command("window:pick"), repeatable: false},
+		// `a` is tmux's `last-pane` and the founder's config leaves it free, so it is the chord that
+		// puts focus on the focused window's own list (#8407).
+		{sequence: "a", command: command("window:focus-list"), repeatable: false},
 		{sequence: "N", command: command("workspace:create"), repeatable: false},
 		{sequence: "<c-h>", command: command("workspace:previous"), repeatable: true},
 		{sequence: "<c-l>", command: command("workspace:next"), repeatable: true},

--- a/apps/tuval/src/shell/keys/table.unit.test.ts
+++ b/apps/tuval/src/shell/keys/table.unit.test.ts
@@ -33,6 +33,7 @@ describe("defaultPrefixTable", () => {
 			["z", "window:zoom", false],
 			["x", "window:close", false],
 			["w", "window:pick", false],
+			["a", "window:focus-list", false],
 			["N", "workspace:create", false],
 			["<c-h>", "workspace:previous", true],
 			["<c-l>", "workspace:next", true],

--- a/apps/tuval/src/shell/ui/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/ui/boundary.unit.test.ts
@@ -38,6 +38,15 @@ const specifiersOf = (source: string): ReadonlyArray<string> =>
 /** The two slices under `src/shell/` that render. A third one is a decision, not a drift. */
 const rendering: ReadonlySet<string> = new Set(["ui", "chat"]);
 
+/**
+ * The one module of `ui/` the other rendering slice may reach for (#8407). `useForwardedKey` is the
+ * renderer's half of the desk's key channel, and the desk is where the channel has to live — the
+ * page owns exactly one keyboard listener (#7559) and `WindowHost` stays free of the DOM. So a
+ * window renderer outside `ui/` that must hear a key has this door and no other; the desk's own
+ * chrome stays as unreachable from `chat/` as it is from every logic slice.
+ */
+const allowed: ReadonlySet<string> = new Set(["../ui/forwarded-key.tsx"]);
+
 describe("ui boundary", () => {
 	it("stores nothing in a window's slot that the slot cannot hold", () => {
 		expect(pickerViewFits).toBe(true);
@@ -62,7 +71,7 @@ describe("ui boundary", () => {
 		expect(offenders).toEqual([]);
 	});
 
-	it("is depended on by nothing outside itself", () => {
+	it("is depended on by nothing outside itself, bar the one key channel a renderer needs", () => {
 		const shell = dirname(import.meta.dirname);
 		const offenders = readdirSync(shell, {withFileTypes: true})
 			.filter((entry) => entry.isDirectory() && entry.name !== "ui")
@@ -70,10 +79,16 @@ describe("ui boundary", () => {
 				sourcesIn(join(shell, entry.name)).flatMap(([name, source]) =>
 					specifiersOf(source)
 						.filter((specifier) => specifier.includes("/ui/") || specifier.startsWith("../ui/"))
+						.filter((specifier) => !allowed.has(specifier))
 						.map((specifier) => `${entry.name}/${name}: ${specifier}`),
 				),
 			);
 		expect(offenders).toEqual([]);
+		// The teeth: the edge below is one named module, not the slice. Anything else in `ui/` is
+		// still refused, including from `chat/`.
+		expect([...allowed].filter((specifier) => !specifier.endsWith("/forwarded-key.tsx"))).toEqual(
+			[],
+		);
 	});
 
 	it("registers the application-level keyboard listener in exactly one file", () => {

--- a/apps/tuval/src/shell/ui/key-agreement.unit.test.ts
+++ b/apps/tuval/src/shell/ui/key-agreement.unit.test.ts
@@ -24,7 +24,13 @@ import {Result} from "effect";
 import {describe, expect, it} from "vitest";
 import {applyMsg, type ShellCmd, type ShellState} from "../core/index.ts";
 import type {Binding, Key, PrefixTable} from "../keys/index.ts";
-import {applyKeysConfig, defaultPrefixTable, normalizeSequence, parse} from "../keys/index.ts";
+import {
+	applyKeysConfig,
+	defaultPrefixTable,
+	normalizeSequence,
+	parse,
+	stringify,
+} from "../keys/index.ts";
 import {threeWindowDesk} from "./fixtures.ts";
 import {COMMAND_LINE_COMMAND, routerPrefix, shellOwnsKey} from "./frame.ts";
 import {replyIn} from "./press.ts";
@@ -69,8 +75,14 @@ const disagreements = (core: PrefixTable, page: PrefixTable): ReadonlyArray<stri
 	for (const binding of core.bindings) {
 		// The prefix first, then the sequence — the whole gesture a user types for this entry.
 		const gesture = [...keysOf(core.prefix), ...keysOf(binding.sequence)];
-		// The focused window holds a process, so `forwardKey` is emitted where the surface forwards.
-		let state = threeWindowDesk();
+		// The focused window holds a process *and declares it takes keys*, which is what the first
+		// claim above rests on: a window whose program declared none is answered on `lastPress` and
+		// sent no Cmd (#7973), so the two statements part company for a reason that is not drift.
+		let state = applyMsg(core, threeWindowDesk(), {
+			type: "window.bind",
+			processId: "process-1",
+			takesKeys: true,
+		})[0];
 		let press = 0;
 		for (const key of gesture) {
 			press += 1;
@@ -80,8 +92,11 @@ const disagreements = (core: PrefixTable, page: PrefixTable): ReadonlyArray<stri
 			const [next, cmds] = applyMsg(core, state, {type: "keys.press", key, pressId});
 			const [asked, repeatTimer] = asCmds(cmds);
 			const derived = asAnswer(next, pressId);
-			// The kernel took the key whenever it did not hand it to the window.
-			const coreOwns = !asked.some((one) => one._tag === "ToWindow");
+			// The kernel took the key whenever it did not hand *this* key to the window. Not "forwarded
+			// nothing": a bound row may mint a key of its own and forward that (`window:focus-list`,
+			// #8407), and the press it ran on is still the shell's — which is the question the page
+			// answers at the press when it decides whether to swallow the default action.
+			const coreOwns = !asked.some((one) => one._tag === "ToWindow" && one.key === stringify(key));
 			if (pageOwns !== coreOwns) {
 				found.push(
 					`${binding.sequence}: core owns ${String(coreOwns)} vs page owns ${String(pageOwns)}`,


### PR DESCRIPTION
`<c-b> a` puts focus on the running-subagent list, and from there the arrows walk it, Enter opens a
row's transcript in place, Escape comes back, and the "more" row expands the tail. The mouse does all
of it by clicking the same buttons — the keyboard runs no handler of its own.

## The route

A binding names a `CommandName` and a command row turns that name into one `ShellMsg`, so nothing
bound can address a window's *renderer* — which is where DOM focus lives. The gap is closed with one
key the keyboard cannot produce:

- `a` in `defaultPrefixTable` names `window:focus-list`.
- That row's Msg is `window.forwardKey`, carrying `FOCUS_LIST_KEY` (`<focus-list>`). The Msg knows
  nothing about chat; a window with no list ignores it.
- Its cell is the same arm the key router's `ToWindow` already ran, lifted into one helper: the
  `forwardKey` Cmd into the window's process, and the `ToWindow` answer on `lastPress` the page reads
  to deliver the key to the renderer (`shell/ui/press.ts`). Those are two different places, and the
  renderer is the one that matters here — a chat window's program declares no `takesKeys`, so it gets
  the answer and no Cmd, exactly as the picker does.
- `ChatWindow` consumes it through the shipped `useForwardedKey`; no second keyboard listener.

`<focus-list>` is deliberately a spelling `parse` refuses — no chord may hold a `-` in its key — so no
press and no config binding can mint it. `keys/syntax.unit.test.ts` pins that refusal, which is what
makes the renderer's comparison against it safe.

## The list

One tab stop, moved with the arrows and Home/End, defaulting to the row the window is showing so the
chord lands where the operator left off. Rows stay `li > button` with `aria-current` on the one
showing — the shipped a11y pass reads this region as a named list of list items, and that stayed.
Escape returns only while there is somewhere to return from; on main it is left to the window, which
interrupts a running turn with it. The keys the list takes are swallowed so the desk's one listener
never routes them and no second copy arrives forwarded.

The "more" row became a real button ("Show N more running" — the visible text plus a hidden verb, so
the name contains the label). Activating it shows the whole tail and moves focus onto the first row it
revealed, because the control that took the focus removes itself. The way-back row does the same:
after it swaps, focus lands on the first remaining row instead of falling to the body.

## What the scratch desk showed

Run on port 5288 with `features.subagentList` on in a scratch project layer, against
`proof:claude-real` — the real Claude CLI — with one real Explore subagent running:

- `<c-b> a` moved focus onto the running row (`BUTTON.tuval-chat-subagent-pick`, `tabIndex 0`).
- Enter opened it in place: the transcript's name became `Transcript: Explore subagent`, the row took
  `aria-current="true"`, the way-back row appeared holding `tabIndex -1`, and the live region read
  "Showing the Explore subagent's transcript. Still running."
- Escape came back: `Transcript`, "Showing the agent's own transcript.", focus still in the list.
- Clicking the row and then the way-back row did the same two things, through the same buttons.

The arrows had one row to walk on that run, and the "more" row never appeared — a second paid turn
asking for seven parallel subagents spent itself on permission cards and launched none. Both are
proven instead in `subagent-navigator.unit.test.tsx`, which walks a two-row list with
ArrowDown/ArrowUp/Home/End and expands an eight-worker tail off the more row.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8407 names the key, command, core and chat
  tests. **Did:** also changed `shell/ui/key-agreement.unit.test.ts`. **Why:** it derived "the kernel
  took this key" from "it forwarded nothing", which a row that mints a key of its own breaks; and its
  walk ran on a desk whose focused window declares no `takesKeys`, so the premise its first claim
  states was not armed. Both are corrected in place. **Disposition:** stated here.
- **Guard or gate bypassed** — **Said:** `shell/ui/boundary.unit.test.ts` refuses every import of
  `ui/` from outside `ui/`. **Did:** narrowed it to allow exactly `../ui/forwarded-key.tsx`, with a
  second assertion that the allow-list holds nothing else. **Why:** `useForwardedKey` is the
  renderer's half of the desk's key channel and the channel must live where the one keyboard listener
  is (#7559), while `WindowHost` stays free of the DOM. Moving it would need a third rendering slice,
  which the same file calls a decision rather than a drift. Every other module of `ui/` is still
  refused, from `chat/` as from every logic slice. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the ticket lists the chat and shell files. **Did:** also added a
  `cap` parameter to `runningSubagents` and updated the `ShellMsg` union pin in
  `shell/core/boundary.unit.test.ts`. **Why:** the "more" row needs the uncapped list to expand into,
  and the union pin reds on any new Msg by design. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** `build check --surface code` should read every changed
  file. **Did:** left `apps/tuval/src/shell/chat/chat.css` unvalidated. **Why:** no declared surface
  validates CSS in this repo. **Disposition:** stated here.

Fixes #8407
