### PR TITLE
chore: Prove the running-subagent list and the subagent view end to end on the real Claude row

### DIFF
--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -77,6 +77,7 @@ describe("the Claude history mapping is pure", () => {
 			"subagent-turn",
 			"thinking-turn",
 			"tool-turn",
+			"two-subagent-turn",
 			"unknown-message",
 		]);
 	});

--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -16,6 +16,26 @@ const sources = () =>
 
 const shipped = () => sources().filter(({name}) => !name.endsWith(".unit.test.ts"));
 
+/**
+ * Just enough of a captured frame to walk one. Structural rather than `SDKMessage`, because this
+ * file's subject is the bytes on disk: a fixture that stopped matching the SDK's union is exactly
+ * what a check written against that union could no longer read.
+ */
+interface AnyFrame {
+	readonly event?: {
+		readonly type?: string;
+		readonly content_block?: {readonly type?: string; readonly id?: unknown};
+		readonly delta?: {readonly type?: string; readonly partial_json?: unknown};
+	};
+	readonly message?: {
+		readonly content?: ReadonlyArray<{
+			readonly type?: string;
+			readonly id?: unknown;
+			readonly input?: unknown;
+		}>;
+	};
+}
+
 const importsOf = (text: string) =>
 	[...text.matchAll(/(^|\n)import\s+(type\s+)?[^;]*?from\s+"([^"]+)"/g)].map((match) => ({
 		specifier: match[3] ?? "",
@@ -82,11 +102,82 @@ describe("the Claude history mapping is pure", () => {
 		]);
 	});
 
-	it("carries no operator path in a fixture", () => {
+	/**
+	 * The two operator roots in every form a sanitizer can leave one in: absolute, with the leading
+	 * slash gone, and slug-encoded the way the CLI keys a project directory. The bare-prefix form is
+	 * what `two-subagent-turn.json` needed — its `input_json_delta` run splits a path across frames,
+	 * so the substitution reached the delta holding the absolute prefix and not the one holding what
+	 * followed it (#8474 review round 1).
+	 *
+	 * **This is a scan for two known roots, not a proof that no operator path is left.** A tail cut
+	 * past both root names matches nothing here and never will; the reassembly check below is what
+	 * caught that one, and it catches it only where a delta run has a settled block to disagree with.
+	 */
+	const operatorRoots = /\/?Users\/|\/?(private\/)?var\/folders\/|-Users-|-private-var-folders-/;
+
+	it("carries no operator path in a fixture, in any of the forms a root is left in", () => {
 		const dir = join(import.meta.dirname, "fixtures");
 		const offenders = readdirSync(dir)
 			.filter((name) => name.endsWith(".json") || name.endsWith(".jsonl"))
-			.filter((name) => /\/Users\/|\/var\/folders\//.test(readFileSync(join(dir, name), "utf8")));
+			.filter((name) => operatorRoots.test(readFileSync(join(dir, name), "utf8")));
 		expect(offenders).toEqual([]);
+	});
+
+	/**
+	 * A streamed tool call is written twice — delta by delta, and again whole on the frame that
+	 * settles it — so the two copies are each other's check. A sanitizer that rewrites one delta of a
+	 * split path and leaves its neighbour leaves a fixture whose halves disagree, which is a leak in
+	 * the half nothing reads today and a lie in the golden property the corpus rests on.
+	 */
+	const deltaRuns = (frames: ReadonlyArray<AnyFrame>) => {
+		const runs: Array<{id: string; parts: Array<string>}> = [];
+		let open: {id: string; parts: Array<string>} | null = null;
+		for (const frame of frames) {
+			const event = frame.event;
+			if (event === undefined) continue;
+			if (event.type === "content_block_start" && event.content_block?.type === "tool_use") {
+				open = {id: String(event.content_block.id), parts: []};
+				runs.push(open);
+			} else if (event.delta?.type === "input_json_delta") {
+				open?.parts.push(String(event.delta.partial_json ?? ""));
+			} else if (event.type === "content_block_stop") {
+				open = null;
+			}
+		}
+		return runs;
+	};
+
+	const settledInputs = (frames: ReadonlyArray<AnyFrame>) => {
+		const inputs = new Map<string, unknown>();
+		for (const frame of frames) {
+			for (const block of frame.message?.content ?? []) {
+				if (block.type === "tool_use") inputs.set(String(block.id), block.input);
+			}
+		}
+		return inputs;
+	};
+
+	it("reassembles every streamed tool call to the input its settled block carries", () => {
+		const dir = join(import.meta.dirname, "fixtures");
+		let checked = 0;
+		const offenders: Array<string> = [];
+		for (const name of readdirSync(dir).filter((one) => one.endsWith(".json"))) {
+			const parsed: unknown = JSON.parse(readFileSync(join(dir, name), "utf8"));
+			if (!Array.isArray(parsed)) continue;
+			const frames = parsed as ReadonlyArray<AnyFrame>;
+			const settled = settledInputs(frames);
+			for (const run of deltaRuns(frames)) {
+				const whole = settled.get(run.id);
+				if (whole === undefined || run.parts.length === 0) continue;
+				checked += 1;
+				if (JSON.stringify(JSON.parse(run.parts.join(""))) !== JSON.stringify(whole)) {
+					offenders.push(`${name}: ${run.id}`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+		// Fail closed: a corpus whose streamed captures stopped carrying tool calls would otherwise
+		// pass this by checking nothing.
+		expect(checked).toBeGreaterThan(0);
 	});
 });

--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -103,17 +103,22 @@ describe("the Claude history mapping is pure", () => {
 	});
 
 	/**
-	 * The two operator roots in every form a sanitizer can leave one in: absolute, with the leading
-	 * slash gone, and slug-encoded the way the CLI keys a project directory. The bare-prefix form is
-	 * what `two-subagent-turn.json` needed — its `input_json_delta` run splits a path across frames,
-	 * so the substitution reached the delta holding the absolute prefix and not the one holding what
-	 * followed it (#8474 review round 1).
+	 * The two operator roots, in every form a sanitizer can leave one in.
 	 *
-	 * **This is a scan for two known roots, not a proof that no operator path is left.** A tail cut
-	 * past both root names matches nothing here and never will; the reassembly check below is what
-	 * caught that one, and it catches it only where a delta run has a settled block to disagree with.
+	 * The separator is a class rather than a slash, because the CLI keys a project directory by
+	 * rewriting every separator to `-`; the leading one is optional, because a path cut across
+	 * streamed deltas leaves the second half without it. That is three axes over two roots, and
+	 * `private` optional on the second gives the eight forms the case below enumerates — one of which
+	 * (`-var-folders-…`, the second root slug-encoded without its `private` segment) fell through the
+	 * first widening (#8474 review round 2).
+	 *
+	 * **This is a scan for two known roots, not a proof that no operator path is left.** A fragment
+	 * cut past both root names matches nothing here, and no widening of this pattern will change
+	 * that: there is no root name left in it to match. The reassembly check below is the one that
+	 * catches that shape, and only where the fragment sits in a delta run with a settled block to
+	 * disagree with (#8474 review round 1).
 	 */
-	const operatorRoots = /\/?Users\/|\/?(private\/)?var\/folders\/|-Users-|-private-var-folders-/;
+	const operatorRoots = /[/-]?(private[/-])?var[/-]folders[/-]|[/-]?Users[/-]/;
 
 	it("carries no operator path in a fixture, in any of the forms a root is left in", () => {
 		const dir = join(import.meta.dirname, "fixtures");
@@ -121,6 +126,28 @@ describe("the Claude history mapping is pure", () => {
 			.filter((name) => name.endsWith(".json") || name.endsWith(".jsonl"))
 			.filter((name) => operatorRoots.test(readFileSync(join(dir, name), "utf8")));
 		expect(offenders).toEqual([]);
+	});
+
+	/**
+	 * The scan's own coverage, as a case rather than as a sentence in a docblock — `PROVENANCE.md`
+	 * tells a capture author which forms are covered, and an enumeration nothing checks is how that
+	 * claim came to be true of one root and half-true of the other.
+	 */
+	it("matches both operator roots in all eight forms", () => {
+		const forms = [
+			"/Users/someone/notes",
+			"Users/someone/notes",
+			"/private/var/folders/ab/cd/T/run",
+			"private/var/folders/ab/cd/T/run",
+			"-Users-someone-notes",
+			"Users-someone-notes",
+			"-private-var-folders-ab-cd-T-run",
+			"-var-folders-ab-cd-T-run",
+		];
+		expect(forms.filter((form) => !operatorRoots.test(form))).toEqual([]);
+		// The flip side: a fragment with no root name in it is what the scan cannot see, and the
+		// reassembly check below is why that gap is survivable.
+		expect(operatorRoots.test("xvxk83q4c0000gn/T/tu")).toBe(false);
 	});
 
 	/**

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -66,9 +66,21 @@ its view (founder ruling Q9 on #8384).
 
 The run was driven exactly as the first table's rows were — `query()` from a throwaway cwd holding
 two one-line files, every message the iterator yielded written in order — and sanitized the same
-way. Two shapes of the operator's machine needed substituting beyond the usual list, because this
-capture carries them where the others do not: the CLI's slug-encoded project key (a temp path with
-the separators rewritten) and a path cut mid-token inside a streamed `input_json_delta`.
+way, plus two shapes the other captures do not carry: the CLI's slug-encoded project key (a temp
+path with the separators rewritten), and a path split across four `input_json_delta` frames.
+
+**The split path is the one that went wrong, and it is worth reading before taking another
+capture.** The first pass substituted the delta holding the absolute prefix and left the neighbour
+holding the rest of it, so the fixture kept a bare tail of the operator's temp namespace — matching
+no root name, invisible to a scan for absolute prefixes, and outside `leak-guard`'s surface, which
+does not read `.json`. It was caught in review of #8474 and the frames were rewritten so the run
+reassembles to the same path the settled block carries. The split itself is kept, cut mid-token
+where the capture cut it: it is the shape a sanitizer has to survive, and the corpus should hold one.
+
+The check that now stands behind that is in `../boundary.unit.test.ts`: it reassembles every
+`input_json_delta` run in every fixture and compares it to the `tool_use` block that settles it, so
+a capture whose two halves disagree reds. That is a narrow guarantee and the section below says how
+narrow.
 
 ## The three excerpted from a CLI session transcript
 
@@ -153,15 +165,29 @@ groups:
 
 - every uuid, `toolu_*`, `msg_*` and `req_*` id, consistently, so a cross-reference that was real
   in the capture is still real in the fixture (a `tool_result` still names its `tool_use`);
-- absolute paths, to `/tmp/tuval-capture` and `/home/user` — no operator path lands in the repo;
+- absolute paths, to `/tmp/tuval-capture` and `/home/user`, in every form the path appears in —
+  including the CLI's slug-encoded project keys and a path split across streamed deltas;
 - `thinking` block signatures, to a short placeholder;
 - the open-ended discovery lists on `init` (`tools`, `slash_commands`, `skills`, `plugins`,
   `agents`, `mcp_servers`, `capabilities`) trimmed to their first three entries. They are a
   machine's local configuration, not part of any shape this mapping reads.
 
 Everything else — `stop_reason`, the `usage` and `modelUsage` blocks, `total_cost_usd`,
-`is_error`, `subtype`, `aborted`, `tool_use_result` — is verbatim. `boundary.unit.test.ts` reds if
-any operator path returns and if the fixture set loses a member.
+`is_error`, `subtype`, `aborted`, `tool_use_result` — is verbatim.
+
+`subagent-turn.json` was re-sanitized in the same round: its `init` frame's `memory_paths.auto`
+still carried the operator's temp namespace slug-encoded, which is the second of the two shapes the
+widened scan below now names. Nothing else about that capture changed.
+
+**What `../boundary.unit.test.ts` actually checks, which is less than "no operator path returns".**
+Three things: that the fixture set has not lost a member; that no file carries either operator root
+— `Users/` or `var/folders/` — absolute, with the leading slash gone, or slug-encoded; and that
+every streamed tool call reassembles to the input its settled block carries. A path fragment cut
+past both root names matches the second check and never will, which is exactly what the
+`two-subagent-turn.json` split delta was; the third check is what catches that shape, and only
+where the fragment sits in a delta run with a settled block to disagree with. So the scan is a net
+with a known mesh, not a proof — **read a new capture yourself before committing it**, and treat
+these checks as what stops a shape that has already happened from happening twice.
 
 ## What is not captured
 

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -181,13 +181,19 @@ widened scan below now names. Nothing else about that capture changed.
 
 **What `../boundary.unit.test.ts` actually checks, which is less than "no operator path returns".**
 Three things: that the fixture set has not lost a member; that no file carries either operator root
-— `Users/` or `var/folders/` — absolute, with the leading slash gone, or slug-encoded; and that
-every streamed tool call reassembles to the input its settled block carries. A path fragment cut
-past both root names matches the second check and never will, which is exactly what the
-`two-subagent-turn.json` split delta was; the third check is what catches that shape, and only
-where the fragment sits in a delta run with a settled block to disagree with. So the scan is a net
-with a known mesh, not a proof — **read a new capture yourself before committing it**, and treat
-these checks as what stops a shape that has already happened from happening twice.
+— `Users` or `var/folders` — in any of eight forms, being each root with its leading separator or
+without it, spelled with slashes or slug-encoded the way the CLI keys a project directory, and with
+`private` present or absent on the second; and that every streamed tool call reassembles to the
+input its settled block carries. The eight forms are enumerated as their own case in that file, so
+this list and the pattern cannot drift apart.
+
+**A path fragment cut past both root names matches neither root check.** It carries no root name, so
+there is nothing for that scan to match and no widening of it would help. That is exactly what the
+`two-subagent-turn.json` split delta was, and the reassembly check is the only one that catches the
+shape — and only where the fragment sits in a delta run with a settled block to disagree with. So
+these checks are a net with a known mesh, not a proof: **read a new capture yourself before
+committing it**, and treat them as what stops a shape that has already happened from happening
+twice.
 
 ## What is not captured
 

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -16,7 +16,7 @@ The rows below describe the `query()` captures; the last three fixtures have the
 
 | | |
 |---|---|
-| Captured | 2026-09-04; `streaming-turn.json` on 2026-09-06; `subagent-turn.json` on 2026-09-07 |
+| Captured | 2026-09-04; `streaming-turn.json` on 2026-09-06; `subagent-turn.json` and `two-subagent-turn.json` on 2026-09-07 |
 | SDK | `@anthropic-ai/claude-agent-sdk` **0.3.259** (the `pnpm-workspace.yaml` catalog pin) |
 | CLI | `claude_code_version` **2.1.259**, as reported by the `init` frame itself |
 | Models | `claude-fable-5-1` on every capture but `interrupted-assistant.json` and `subagent-turn.json`, which are `claude-opus-5` |
@@ -46,9 +46,29 @@ in order.
 | `unknown-message.json` | a `rate_limit_event` frame from the plain run — a real member of `SDKMessage` |
 | `streaming-turn.json` | one prompt with `includePartialMessages: true`, captured 2026-09-06 — the whole `stream_event` run of one turn, `message_start` through `message_stop` (#8172) |
 | `subagent-turn.json` | one prompt asking for a single `Task` spawn, run with `forwardSubagentText: true` and `includePartialMessages: true` on `claude-opus-5` with `thinking: {type: "enabled", budgetTokens: 8000}`, captured 2026-09-07 — the whole 74-frame run of a turn that spawns one worker (#8403) |
+| `two-subagent-turn.json` | the same options on `claude-fable-5-1`, with a prompt asking for **two** `Explore` workers in parallel over two files in the throwaway cwd, captured 2026-09-07 — the whole 59-frame run, and the one capture where two workers overlap (#8408) |
 | `thinking-turn.json` | excerpted from an operator's own CLI session transcript, not from a `query()` run — see below |
 | `compact-boundary.json` | the same, from a session that compacted |
 | `informational-notice.json` | the same, from a session that hit a usage limit |
+
+### The two-worker capture
+
+`two-subagent-turn.json` is the capture `subagent-turn.json` could not be: **two workers running at
+once**, which is the whole subject of the running list. The frames say so on their own — both
+`Agent` calls are made and both raise `system`/`task_started` before either worker's
+`tool_result` arrives, and the two results land four frames apart, so there is a stretch where one
+worker finishes while the other is still writing. The run's own `result` frame agrees:
+`subagent_stats` reads `{"spawned": 2, "completed": 2, "by_type": {"Explore": 2}}`.
+
+That gap between the two endings is what `../../proof/subagent-vertical.integration.test.ts` replays
+a frame at a time: it is the only moment at which a worker can finish while an operator is inside
+its view (founder ruling Q9 on #8384).
+
+The run was driven exactly as the first table's rows were — `query()` from a throwaway cwd holding
+two one-line files, every message the iterator yielded written in order — and sanitized the same
+way. Two shapes of the operator's machine needed substituting beyond the usual list, because this
+capture carries them where the others do not: the CLI's slug-encoded project key (a temp path with
+the separators rewritten) and a path cut mid-token inside a streamed `input_json_delta`.
 
 ## The three excerpted from a CLI session transcript
 
@@ -160,6 +180,10 @@ an empty `thinking` string — the provider ships a worker's reasoning encrypted
 at this pin (two models, two thinking budgets) produced no plaintext one, so `thinking-turn.json`'s
 shape is not what a live worker yields today. `blocks.ts` reads the empty-with-signature shape as
 withheld, which is what the captures forced.
+
+**Two workers under one *parent* tool call.** Both captures spawn workers as siblings of each other.
+A `Task` call made *by* a worker — `spawn_depth` above 1 — is uncaptured, and nothing a prompt
+controls decides whether a worker delegates further.
 
 **A run with `forwardSubagentText` off.** `subagent-turn.json` sets it, because the SDK forwards only
 a worker's `tool_use`/`tool_result` blocks by default — "enough for a heartbeat counter"

--- a/apps/tuval/src/claude/history/fixtures/load.ts
+++ b/apps/tuval/src/claude/history/fixtures/load.ts
@@ -24,6 +24,7 @@ export type FixtureName =
 	| "subagent-turn"
 	| "thinking-turn"
 	| "tool-turn"
+	| "two-subagent-turn"
 	| "unknown-message";
 
 export const loadFixture = (name: FixtureName): unknown =>

--- a/apps/tuval/src/claude/history/fixtures/subagent-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/subagent-turn.json
@@ -74,7 +74,7 @@
 		"product_feedback_disabled": false,
 		"uuid": "00000000-0000-4000-8000-000000000003",
 		"memory_paths": {
-			"auto": "/home/user/.claude/projects/-private-var-folders-8f-r3k3t6817cgbsxsxvxk83q4c0000gn-T-fabrika-build-00000000-0000-4000-8000-000000000004-8403-64d5387e-capture-cwd/memory/"
+			"auto": "/home/user/.claude/projects/-tmp-tuval-capture/memory/"
 		},
 		"messaging_socket_path": "/tmp/cc-socks/27275.sock",
 		"fast_mode_state": "off",

--- a/apps/tuval/src/claude/history/fixtures/two-subagent-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/two-subagent-turn.json
@@ -1,0 +1,1432 @@
+[
+	{
+		"type": "system",
+		"subtype": "init",
+		"cwd": "/tmp/tuval-capture",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"tools": ["Task", "Bash", "CronCreate"],
+		"mcp_servers": [
+			{
+				"name": "plugin:playwright:playwright",
+				"status": "connected"
+			},
+			{
+				"name": "plugin:accessibility:binclusive",
+				"status": "needs-auth"
+			},
+			{
+				"name": "effect-docs",
+				"status": "connected"
+			}
+		],
+		"model": "claude-fable-5-1",
+		"permissionMode": "bypassPermissions",
+		"slash_commands": ["find-skills", "pr-review-canvas", "sound"],
+		"terminal_slash_commands": ["doctor", "color"],
+		"apiKeySource": "none",
+		"claude_code_version": "2.1.259",
+		"output_style": "default",
+		"agents": ["claude", "Explore", "fabrika:builder"],
+		"skills": ["find-skills", "pr-review-canvas", "sound"],
+		"plugins": [
+			{
+				"name": "frontend-design",
+				"path": "/home/user/.claude/plugins/cache/claude-plugins-official/frontend-design/85cce0381e78",
+				"source": "frontend-design@claude-plugins-official"
+			},
+			{
+				"name": "typescript-lsp",
+				"path": "/home/user/.claude/plugins/cache/claude-plugins-official/typescript-lsp/1.0.0",
+				"source": "typescript-lsp@claude-plugins-official",
+				"version": "1.0.0"
+			},
+			{
+				"name": "feature-dev",
+				"path": "/home/user/.claude/plugins/cache/claude-plugins-official/feature-dev/85cce0381e78",
+				"source": "feature-dev@claude-plugins-official"
+			}
+		],
+		"capabilities": [
+			"interrupt_receipt_v1",
+			"interrupt_cancel_queued_v1",
+			"msg_000000000000000000000001_v1"
+		],
+		"analytics_disabled": false,
+		"product_feedback_disabled": false,
+		"uuid": "00000000-0000-4000-8000-000000000002",
+		"memory_paths": {
+			"auto": "/home/user/.claude/projects/-tmp-tuval-capture/memory/"
+		},
+		"messaging_socket_path": "/tmp/cc-socks/30102.sock",
+		"fast_mode_state": "off",
+		"fast_mode_disabled_reason": "sdk_opt_in_required"
+	},
+	{
+		"type": "system",
+		"subtype": "status",
+		"status": "requesting",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000003"
+	},
+	{
+		"type": "rate_limit_event",
+		"rate_limit_info": {
+			"status": "allowed",
+			"resetsAt": 1788775800,
+			"rateLimitType": "five_hour",
+			"overageStatus": "rejected",
+			"overageDisabledReason": "org_level_disabled",
+			"isUsingOverage": false,
+			"unifiedWindows": {
+				"five_hour": {
+					"utilization": 0.33,
+					"resetsAt": 1788775800
+				},
+				"seven_day": {
+					"utilization": 0.52,
+					"resetsAt": 1788976800
+				}
+			}
+		},
+		"uuid": "00000000-0000-4000-8000-000000000004",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_start",
+			"message": {
+				"model": "claude-fable-5-1",
+				"id": "msg_000000000000000000000002",
+				"type": "message",
+				"role": "assistant",
+				"content": [],
+				"stop_reason": null,
+				"stop_sequence": null,
+				"stop_details": null,
+				"usage": {
+					"input_tokens": 2,
+					"cache_creation_input_tokens": 28286,
+					"cache_read_input_tokens": 0,
+					"cache_creation": {
+						"ephemeral_5m_input_tokens": 0,
+						"ephemeral_1h_input_tokens": 28286
+					},
+					"output_tokens": 15,
+					"service_tier": "standard",
+					"inference_geo": "not_available"
+				},
+				"diagnostics": null
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000005",
+		"ttft_ms": 1545
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_start",
+			"index": 0,
+			"content_block": {
+				"type": "tool_use",
+				"id": "toolu_000000000000000000000001",
+				"name": "Agent",
+				"input": {},
+				"caller": {
+					"type": "direct"
+				}
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000006"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": ""
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000007"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "{\"subagent_type\": \"Explore"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000008"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "\", \"description\": \"Read alpha.txt contents"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000009"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "\", \"prompt\": \"Read the file alpha.txt in the working directory (/"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000010"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "/tmp/tuval-capture"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000011"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "xvxk83q4c0000gn/T/tu"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000012"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "val-capture/alpha.txt) and report its exact contents verbatim."
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000013"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "\", \"run_in_background\": false"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000014"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "}"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000015"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-fable-5-1",
+			"id": "msg_000000000000000000000002",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "tool_use",
+					"id": "toolu_000000000000000000000001",
+					"name": "Agent",
+					"input": {
+						"subagent_type": "Explore",
+						"description": "Read alpha.txt contents",
+						"prompt": "Read the file alpha.txt in the working directory (/tmp/tuval-capture/alpha.txt) and report its exact contents verbatim.",
+						"run_in_background": false
+					},
+					"caller": {
+						"type": "direct"
+					}
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 28286,
+				"cache_read_input_tokens": 0,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 0,
+					"ephemeral_1h_input_tokens": 28286
+				},
+				"output_tokens": 15,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": null,
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000016",
+		"timestamp": "2026-09-07T09:37:30.282Z",
+		"request_id": "req_000000000000000000000001"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_stop",
+			"index": 0
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000017"
+	},
+	{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "a0ebe532c2169f999",
+		"tool_use_id": "toolu_000000000000000000000001",
+		"description": "Read alpha.txt contents",
+		"subagent_type": "Explore",
+		"is_backgrounded": false,
+		"spawn_depth": 1,
+		"task_type": "local_agent",
+		"prompt": "Read the file alpha.txt in the working directory (/tmp/tuval-capture/alpha.txt) and report its exact contents verbatim.",
+		"uuid": "00000000-0000-4000-8000-000000000018",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "user",
+		"message": {
+			"role": "user",
+			"content": [
+				{
+					"type": "text",
+					"text": "Read the file alpha.txt in the working directory (/tmp/tuval-capture/alpha.txt) and report its exact contents verbatim."
+				}
+			]
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000001",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000019",
+		"timestamp": "2026-09-07T09:37:30.296Z",
+		"subagent_type": "Explore",
+		"task_description": "Read alpha.txt contents"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_start",
+			"index": 1,
+			"content_block": {
+				"type": "tool_use",
+				"id": "toolu_000000000000000000000002",
+				"name": "Agent",
+				"input": {},
+				"caller": {
+					"type": "direct"
+				}
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000020"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": ""
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000021"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "{\"subagent_type\": \"Explore"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000022"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "\", \"description\": \"Read beta.txt contents"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000023"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "\", \"prompt\": \"Read the file beta.txt in the working directory ("
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000024"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "/tmp/tuval-capture/beta.txt) and report its exact contents verbatim."
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000025"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "\", \"run_in_background\": false"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000026"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 1,
+			"delta": {
+				"type": "input_json_delta",
+				"partial_json": "}"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000027"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-fable-5-1",
+			"id": "msg_000000000000000000000002",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "tool_use",
+					"id": "toolu_000000000000000000000002",
+					"name": "Agent",
+					"input": {
+						"subagent_type": "Explore",
+						"description": "Read beta.txt contents",
+						"prompt": "Read the file beta.txt in the working directory (/tmp/tuval-capture/beta.txt) and report its exact contents verbatim.",
+						"run_in_background": false
+					},
+					"caller": {
+						"type": "direct"
+					}
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 28286,
+				"cache_read_input_tokens": 0,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 0,
+					"ephemeral_1h_input_tokens": 28286
+				},
+				"output_tokens": 15,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": null,
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000028",
+		"timestamp": "2026-09-07T09:37:31.309Z",
+		"request_id": "req_000000000000000000000001"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_stop",
+			"index": 1
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000029"
+	},
+	{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "a8fee33eabf7667df",
+		"tool_use_id": "toolu_000000000000000000000002",
+		"description": "Read beta.txt contents",
+		"subagent_type": "Explore",
+		"is_backgrounded": false,
+		"spawn_depth": 1,
+		"task_type": "local_agent",
+		"prompt": "Read the file beta.txt in the working directory (/tmp/tuval-capture/beta.txt) and report its exact contents verbatim.",
+		"uuid": "00000000-0000-4000-8000-000000000030",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "user",
+		"message": {
+			"role": "user",
+			"content": [
+				{
+					"type": "text",
+					"text": "Read the file beta.txt in the working directory (/tmp/tuval-capture/beta.txt) and report its exact contents verbatim."
+				}
+			]
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000002",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000031",
+		"timestamp": "2026-09-07T09:37:31.315Z",
+		"subagent_type": "Explore",
+		"task_description": "Read beta.txt contents"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_delta",
+			"delta": {
+				"stop_reason": "tool_use",
+				"stop_sequence": null,
+				"stop_details": null
+			},
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 28286,
+				"cache_read_input_tokens": 0,
+				"output_tokens": 428,
+				"output_tokens_details": {
+					"thinking_tokens": 0
+				},
+				"iterations": [
+					{
+						"input_tokens": 2,
+						"output_tokens": 428,
+						"cache_read_input_tokens": 0,
+						"cache_creation_input_tokens": 28286,
+						"cache_creation": {
+							"ephemeral_5m_input_tokens": 0,
+							"ephemeral_1h_input_tokens": 28286
+						},
+						"type": "message"
+					}
+				]
+			},
+			"context_management": {
+				"applied_edits": []
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000032"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_stop"
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000033"
+	},
+	{
+		"type": "rate_limit_event",
+		"rate_limit_info": {
+			"status": "allowed",
+			"resetsAt": 1788775800,
+			"rateLimitType": "five_hour",
+			"overageStatus": "rejected",
+			"overageDisabledReason": "org_level_disabled",
+			"isUsingOverage": false,
+			"unifiedWindows": {
+				"five_hour": {
+					"utilization": 0.33,
+					"resetsAt": 1788775800
+				},
+				"seven_day": {
+					"utilization": 0.52,
+					"resetsAt": 1788976800
+				},
+				"seven_day_overage_included": {
+					"utilization": 0.44,
+					"resetsAt": 1788976800
+				}
+			}
+		},
+		"uuid": "00000000-0000-4000-8000-000000000034",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "system",
+		"subtype": "task_progress",
+		"task_id": "a0ebe532c2169f999",
+		"tool_use_id": "toolu_000000000000000000000001",
+		"description": "Reading alpha.txt",
+		"subagent_type": "Explore",
+		"usage": {
+			"total_tokens": 17138,
+			"tool_uses": 1,
+			"duration_ms": 2893
+		},
+		"last_tool_name": "Read",
+		"uuid": "00000000-0000-4000-8000-000000000035",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-opus-5",
+			"id": "msg_000000000000000000000003",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "tool_use",
+					"id": "toolu_000000000000000000000003",
+					"name": "Read",
+					"input": {
+						"file_path": "/tmp/tuval-capture/alpha.txt"
+					},
+					"caller": {
+						"type": "direct"
+					}
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 17094,
+				"cache_read_input_tokens": 0,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 17094,
+					"ephemeral_1h_input_tokens": 0
+				},
+				"output_tokens": 17,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000001",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000036",
+		"timestamp": "2026-09-07T09:37:33.183Z",
+		"request_id": "req_000000000000000000000002",
+		"subagent_type": "Explore",
+		"task_description": "Read alpha.txt contents"
+	},
+	{
+		"type": "user",
+		"message": {
+			"role": "user",
+			"content": [
+				{
+					"tool_use_id": "toolu_000000000000000000000003",
+					"type": "tool_result",
+					"content": "1\talpha\n2\t"
+				}
+			]
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000001",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000037",
+		"timestamp": "2026-09-07T09:37:33.210Z",
+		"subagent_type": "Explore",
+		"task_description": "Read alpha.txt contents"
+	},
+	{
+		"type": "system",
+		"subtype": "task_progress",
+		"task_id": "a8fee33eabf7667df",
+		"tool_use_id": "toolu_000000000000000000000002",
+		"description": "Reading beta.txt",
+		"subagent_type": "Explore",
+		"usage": {
+			"total_tokens": 17130,
+			"tool_uses": 1,
+			"duration_ms": 2914
+		},
+		"last_tool_name": "Read",
+		"uuid": "00000000-0000-4000-8000-000000000038",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-opus-5",
+			"id": "msg_000000000000000000000004",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "tool_use",
+					"id": "toolu_000000000000000000000004",
+					"name": "Read",
+					"input": {
+						"file_path": "/tmp/tuval-capture/beta.txt"
+					},
+					"caller": {
+						"type": "direct"
+					}
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 11542,
+				"cache_read_input_tokens": 5550,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 11542,
+					"ephemeral_1h_input_tokens": 0
+				},
+				"output_tokens": 17,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000002",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000039",
+		"timestamp": "2026-09-07T09:37:34.225Z",
+		"request_id": "req_000000000000000000000003",
+		"subagent_type": "Explore",
+		"task_description": "Read beta.txt contents"
+	},
+	{
+		"type": "user",
+		"message": {
+			"role": "user",
+			"content": [
+				{
+					"tool_use_id": "toolu_000000000000000000000004",
+					"type": "tool_result",
+					"content": "1\tbeta\n2\t"
+				}
+			]
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000002",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000040",
+		"timestamp": "2026-09-07T09:37:34.248Z",
+		"subagent_type": "Explore",
+		"task_description": "Read beta.txt contents"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-opus-5",
+			"id": "msg_000000000000000000000005",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "text",
+					"text": "File: /tmp/tuval-capture/alpha.txt\n\nContents verbatim (single line, followed by a trailing newline):\n\n```\nalpha\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and this session is non-interactive, so its tools are unavailable until it is authorized via `claude mcp` or /mcp in an interactive session. This did not affect the task above."
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 305,
+				"cache_read_input_tokens": 17094,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 305,
+					"ephemeral_1h_input_tokens": 0
+				},
+				"output_tokens": 1,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000001",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000041",
+		"timestamp": "2026-09-07T09:37:35.546Z",
+		"request_id": "req_000000000000000000000004",
+		"subagent_type": "Explore",
+		"task_description": "Read alpha.txt contents"
+	},
+	{
+		"type": "system",
+		"subtype": "task_updated",
+		"task_id": "a0ebe532c2169f999",
+		"patch": {
+			"status": "completed",
+			"end_time": 1788773855675
+		},
+		"uuid": "00000000-0000-4000-8000-000000000042",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "system",
+		"subtype": "task_notification",
+		"task_id": "a0ebe532c2169f999",
+		"tool_use_id": "toolu_000000000000000000000001",
+		"status": "completed",
+		"output_file": "/tmp/tuval-capture/state/-tmp-tuval-capture/00000000-0000-4000-8000-000000000001/tasks/a0ebe532c2169f999.output",
+		"summary": "File: /tmp/tuval-capture/alpha.txt\n\nContents verbatim (single line, followed by a trailing newline):\n\n```\nalpha\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and this session is non-interactive, so its tools are unavailable until it is authorized via `claude mcp` or /mcp in an interactive session. This did not affect the task above.",
+		"usage": {
+			"total_tokens": 17526,
+			"tool_uses": 1,
+			"duration_ms": 5382
+		},
+		"uuid": "00000000-0000-4000-8000-000000000043",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "user",
+		"message": {
+			"role": "user",
+			"content": [
+				{
+					"tool_use_id": "toolu_000000000000000000000001",
+					"type": "tool_result",
+					"content": [
+						{
+							"type": "text",
+							"text": "File: /tmp/tuval-capture/alpha.txt\n\nContents verbatim (single line, followed by a trailing newline):\n\n```\nalpha\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and this session is non-interactive, so its tools are unavailable until it is authorized via `claude mcp` or /mcp in an interactive session. This did not affect the task above."
+						}
+					]
+				}
+			]
+		},
+		"parent_tool_use_id": null,
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000044",
+		"timestamp": "2026-09-07T09:37:35.678Z",
+		"tool_use_result": {
+			"status": "completed",
+			"prompt": "Read the file alpha.txt in the working directory (/tmp/tuval-capture/alpha.txt) and report its exact contents verbatim.",
+			"agentId": "a0ebe532c2169f999",
+			"agentType": "Explore",
+			"harnessNoteCount": 0,
+			"harnessTailCount": 0,
+			"harnessSectionHash": "a4f3e76a9bacc9d0",
+			"content": [
+				{
+					"type": "text",
+					"text": "File: /tmp/tuval-capture/alpha.txt\n\nContents verbatim (single line, followed by a trailing newline):\n\n```\nalpha\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and this session is non-interactive, so its tools are unavailable until it is authorized via `claude mcp` or /mcp in an interactive session. This did not affect the task above."
+				}
+			],
+			"resolvedModel": "claude-opus-5[1m]",
+			"totalDurationMs": 5384,
+			"totalTokens": 17576,
+			"totalToolUseCount": 1,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 305,
+				"cache_read_input_tokens": 17094,
+				"output_tokens": 175,
+				"output_tokens_details": {
+					"thinking_tokens": 0
+				},
+				"server_tool_use": {
+					"web_search_requests": 0,
+					"web_fetch_requests": 0
+				},
+				"service_tier": "standard",
+				"cache_creation": {
+					"ephemeral_1h_input_tokens": 0,
+					"ephemeral_5m_input_tokens": 305
+				},
+				"inference_geo": "not_available",
+				"iterations": [
+					{
+						"input_tokens": 2,
+						"output_tokens": 175,
+						"cache_read_input_tokens": 17094,
+						"cache_creation_input_tokens": 305,
+						"cache_creation": {
+							"ephemeral_5m_input_tokens": 305,
+							"ephemeral_1h_input_tokens": 0
+						},
+						"type": "message"
+					}
+				],
+				"speed": "standard"
+			},
+			"toolStats": {
+				"readCount": 1,
+				"searchCount": 0,
+				"bashCount": 0,
+				"editFileCount": 0,
+				"linesAdded": 0,
+				"linesRemoved": 0,
+				"otherToolCount": 0
+			}
+		}
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-opus-5",
+			"id": "msg_000000000000000000000006",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "text",
+					"text": "/tmp/tuval-capture/beta.txt contains exactly one line:\n\n```\nbeta\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and could not be authorized in this non-interactive session. It needs to be authorized via `claude mcp` or `/mcp` in an interactive session (or claude.ai connector settings) before its tools are available. It was not needed for this task."
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 303,
+				"cache_read_input_tokens": 17092,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 303,
+					"ephemeral_1h_input_tokens": 0
+				},
+				"output_tokens": 1,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": "toolu_000000000000000000000002",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000045",
+		"timestamp": "2026-09-07T09:37:36.842Z",
+		"request_id": "req_000000000000000000000005",
+		"subagent_type": "Explore",
+		"task_description": "Read beta.txt contents"
+	},
+	{
+		"type": "system",
+		"subtype": "task_updated",
+		"task_id": "a8fee33eabf7667df",
+		"patch": {
+			"status": "completed",
+			"end_time": 1788773856863
+		},
+		"uuid": "00000000-0000-4000-8000-000000000046",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "system",
+		"subtype": "task_notification",
+		"task_id": "a8fee33eabf7667df",
+		"tool_use_id": "toolu_000000000000000000000002",
+		"status": "completed",
+		"output_file": "/tmp/tuval-capture/state/-tmp-tuval-capture/00000000-0000-4000-8000-000000000001/tasks/a8fee33eabf7667df.output",
+		"summary": "/tmp/tuval-capture/beta.txt contains exactly one line:\n\n```\nbeta\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and could not be authorized in this non-interactive session. It needs to be authorized via `claude mcp` or `/mcp` in an interactive session (or claude.ai connector settings) before its tools are available. It was not needed for this task.",
+		"usage": {
+			"total_tokens": 17526,
+			"tool_uses": 1,
+			"duration_ms": 5550
+		},
+		"uuid": "00000000-0000-4000-8000-000000000047",
+		"session_id": "00000000-0000-4000-8000-000000000001"
+	},
+	{
+		"type": "user",
+		"message": {
+			"role": "user",
+			"content": [
+				{
+					"tool_use_id": "toolu_000000000000000000000002",
+					"type": "tool_result",
+					"content": [
+						{
+							"type": "text",
+							"text": "/tmp/tuval-capture/beta.txt contains exactly one line:\n\n```\nbeta\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and could not be authorized in this non-interactive session. It needs to be authorized via `claude mcp` or `/mcp` in an interactive session (or claude.ai connector settings) before its tools are available. It was not needed for this task."
+						}
+					]
+				}
+			]
+		},
+		"parent_tool_use_id": null,
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000048",
+		"timestamp": "2026-09-07T09:37:36.868Z",
+		"tool_use_result": {
+			"status": "completed",
+			"prompt": "Read the file beta.txt in the working directory (/tmp/tuval-capture/beta.txt) and report its exact contents verbatim.",
+			"agentId": "a8fee33eabf7667df",
+			"agentType": "Explore",
+			"harnessNoteCount": 0,
+			"harnessTailCount": 0,
+			"harnessSectionHash": "e52194ce07b0cacf",
+			"content": [
+				{
+					"type": "text",
+					"text": "/tmp/tuval-capture/beta.txt contains exactly one line:\n\n```\nbeta\n```\n\nNote: the MCP server `plugin:accessibility:binclusive` requires authentication and could not be authorized in this non-interactive session. It needs to be authorized via `claude mcp` or `/mcp` in an interactive session (or claude.ai connector settings) before its tools are available. It was not needed for this task."
+				}
+			],
+			"resolvedModel": "claude-opus-5[1m]",
+			"totalDurationMs": 5551,
+			"totalTokens": 17573,
+			"totalToolUseCount": 1,
+			"usage": {
+				"input_tokens": 2,
+				"cache_creation_input_tokens": 303,
+				"cache_read_input_tokens": 17092,
+				"output_tokens": 176,
+				"output_tokens_details": {
+					"thinking_tokens": 0
+				},
+				"server_tool_use": {
+					"web_search_requests": 0,
+					"web_fetch_requests": 0
+				},
+				"service_tier": "standard",
+				"cache_creation": {
+					"ephemeral_1h_input_tokens": 0,
+					"ephemeral_5m_input_tokens": 303
+				},
+				"inference_geo": "not_available",
+				"iterations": [
+					{
+						"input_tokens": 2,
+						"output_tokens": 176,
+						"cache_read_input_tokens": 17092,
+						"cache_creation_input_tokens": 303,
+						"cache_creation": {
+							"ephemeral_5m_input_tokens": 303,
+							"ephemeral_1h_input_tokens": 0
+						},
+						"type": "message"
+					}
+				],
+				"speed": "standard"
+			},
+			"toolStats": {
+				"readCount": 1,
+				"searchCount": 0,
+				"bashCount": 0,
+				"editFileCount": 0,
+				"linesAdded": 0,
+				"linesRemoved": 0,
+				"otherToolCount": 0
+			}
+		}
+	},
+	{
+		"type": "system",
+		"subtype": "status",
+		"status": "requesting",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000049"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_start",
+			"message": {
+				"model": "claude-fable-5-1",
+				"id": "msg_000000000000000000000007",
+				"type": "message",
+				"role": "assistant",
+				"content": [],
+				"stop_reason": null,
+				"stop_sequence": null,
+				"stop_details": null,
+				"usage": {
+					"input_tokens": 56,
+					"cache_creation_input_tokens": 831,
+					"cache_read_input_tokens": 28286,
+					"cache_creation": {
+						"ephemeral_5m_input_tokens": 0,
+						"ephemeral_1h_input_tokens": 831
+					},
+					"output_tokens": 1,
+					"service_tier": "standard",
+					"inference_geo": "not_available"
+				},
+				"diagnostics": null
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000050",
+		"ttft_ms": 1564
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_start",
+			"index": 0,
+			"content_block": {
+				"type": "text",
+				"text": ""
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000051"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "text_delta",
+				"text": "al"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000052"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "text_delta",
+				"text": "pha.txt:"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000053"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "text_delta",
+				"text": " alpha\nbeta.tx"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000054"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_delta",
+			"index": 0,
+			"delta": {
+				"type": "text_delta",
+				"text": "t: beta"
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000055"
+	},
+	{
+		"type": "assistant",
+		"message": {
+			"model": "claude-fable-5-1",
+			"id": "msg_000000000000000000000007",
+			"type": "message",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "text",
+					"text": "alpha.txt: alpha\nbeta.txt: beta"
+				}
+			],
+			"stop_reason": null,
+			"stop_sequence": null,
+			"stop_details": null,
+			"usage": {
+				"input_tokens": 56,
+				"cache_creation_input_tokens": 831,
+				"cache_read_input_tokens": 28286,
+				"cache_creation": {
+					"ephemeral_5m_input_tokens": 0,
+					"ephemeral_1h_input_tokens": 831
+				},
+				"output_tokens": 1,
+				"service_tier": "standard",
+				"inference_geo": "not_available"
+			},
+			"diagnostics": null,
+			"context_management": null
+		},
+		"parent_tool_use_id": null,
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"uuid": "00000000-0000-4000-8000-000000000056",
+		"timestamp": "2026-09-07T09:37:38.498Z",
+		"request_id": "req_000000000000000000000006"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "content_block_stop",
+			"index": 0
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000057"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_delta",
+			"delta": {
+				"stop_reason": "end_turn",
+				"stop_sequence": null,
+				"stop_details": null
+			},
+			"usage": {
+				"input_tokens": 56,
+				"cache_creation_input_tokens": 831,
+				"cache_read_input_tokens": 28286,
+				"output_tokens": 21,
+				"output_tokens_details": {
+					"thinking_tokens": 0
+				},
+				"iterations": [
+					{
+						"input_tokens": 56,
+						"output_tokens": 21,
+						"cache_read_input_tokens": 28286,
+						"cache_creation_input_tokens": 831,
+						"cache_creation": {
+							"ephemeral_5m_input_tokens": 0,
+							"ephemeral_1h_input_tokens": 831
+						},
+						"type": "message"
+					}
+				]
+			},
+			"context_management": {
+				"applied_edits": []
+			}
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000058"
+	},
+	{
+		"type": "stream_event",
+		"event": {
+			"type": "message_stop"
+		},
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"parent_tool_use_id": null,
+		"uuid": "00000000-0000-4000-8000-000000000059"
+	},
+	{
+		"duration_api_ms": 19640,
+		"stop_reason": "end_turn",
+		"session_id": "00000000-0000-4000-8000-000000000001",
+		"total_cost_usd": 0.8301875000000001,
+		"usage": {
+			"input_tokens": 58,
+			"cache_creation_input_tokens": 29117,
+			"cache_read_input_tokens": 28286,
+			"output_tokens": 449,
+			"output_tokens_details": {
+				"thinking_tokens": 0
+			},
+			"server_tool_use": {
+				"web_search_requests": 0,
+				"web_fetch_requests": 0
+			},
+			"service_tier": "standard",
+			"cache_creation": {
+				"ephemeral_1h_input_tokens": 29117,
+				"ephemeral_5m_input_tokens": 0
+			},
+			"inference_geo": "not_available",
+			"iterations": [
+				{
+					"input_tokens": 56,
+					"output_tokens": 21,
+					"cache_read_input_tokens": 28286,
+					"cache_creation_input_tokens": 831,
+					"cache_creation": {
+						"ephemeral_5m_input_tokens": 0,
+						"ephemeral_1h_input_tokens": 831
+					},
+					"type": "message"
+				}
+			],
+			"speed": "standard"
+		},
+		"modelUsage": {
+			"claude-haiku-4-5-20251001": {
+				"inputTokens": 973,
+				"outputTokens": 18,
+				"cacheReadInputTokens": 0,
+				"cacheCreationInputTokens": 0,
+				"webSearchRequests": 0,
+				"costUSD": 0.001063,
+				"contextWindow": 200000,
+				"maxOutputTokens": 32000,
+				"thinkingTokens": 0,
+				"canonicalModel": "claude-haiku-4-5",
+				"provider": "firstParty",
+				"costBasis": "list"
+			},
+			"claude-fable-5-1": {
+				"inputTokens": 58,
+				"outputTokens": 449,
+				"cacheReadInputTokens": 28286,
+				"cacheCreationInputTokens": 29117,
+				"webSearchRequests": 0,
+				"costUSD": 0.6124415,
+				"contextWindow": 1000000,
+				"maxOutputTokens": 64000,
+				"thinkingTokens": 0,
+				"canonicalModel": "claude-fable-5-1",
+				"provider": "firstParty",
+				"costBasis": "list"
+			},
+			"claude-opus-5[1m]": {
+				"inputTokens": 8,
+				"outputTokens": 560,
+				"cacheReadInputTokens": 39736,
+				"cacheCreationInputTokens": 29244,
+				"webSearchRequests": 0,
+				"costUSD": 0.21668300000000001,
+				"contextWindow": 1000000,
+				"maxOutputTokens": 64000,
+				"thinkingTokens": 0,
+				"canonicalModel": "claude-opus-5",
+				"provider": "firstParty",
+				"costBasis": "list"
+			}
+		},
+		"permission_denials": [],
+		"terminal_reason": "completed",
+		"fast_mode_state": "off",
+		"fast_mode_disabled_reason": "sdk_opt_in_required",
+		"subagent_stats": {
+			"spawned": 2,
+			"requested": {
+				"background": 0,
+				"foreground": 2,
+				"unset": 0
+			},
+			"started_in_background": 0,
+			"max_depth": 1,
+			"spawned_by_subagents": 0,
+			"completed": 2,
+			"failed": 0,
+			"killed": {
+				"parent": 0,
+				"user": 0,
+				"system": 0
+			},
+			"refused": {
+				"depth_limit": 0,
+				"concurrency_limit": 0,
+				"budget": 0
+			},
+			"by_type": {
+				"Explore": 2
+			}
+		},
+		"is_error": false,
+		"num_turns": 3,
+		"subtype": "success",
+		"api_error_status": null,
+		"result": "alpha.txt: alpha\nbeta.txt: beta",
+		"ttft_ms": 5310,
+		"type": "result",
+		"duration_ms": 13588,
+		"uuid": "00000000-0000-4000-8000-000000000060",
+		"ttft_stream_ms": 1571,
+		"time_to_request_ms": 26,
+		"queued_turn_count": 0
+	}
+]

--- a/apps/tuval/src/claude/history/fixtures/two-subagent-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/two-subagent-turn.json
@@ -206,7 +206,7 @@
 			"index": 0,
 			"delta": {
 				"type": "input_json_delta",
-				"partial_json": "/tmp/tuval-capture"
+				"partial_json": "tmp/"
 			}
 		},
 		"session_id": "00000000-0000-4000-8000-000000000001",
@@ -220,7 +220,7 @@
 			"index": 0,
 			"delta": {
 				"type": "input_json_delta",
-				"partial_json": "xvxk83q4c0000gn/T/tu"
+				"partial_json": "tu"
 			}
 		},
 		"session_id": "00000000-0000-4000-8000-000000000001",

--- a/apps/tuval/src/claude/proof/subagent-desk.ts
+++ b/apps/tuval/src/claude/proof/subagent-desk.ts
@@ -1,0 +1,54 @@
+/**
+ * The user config the subagent proof boots: the real shell row and the real `claude-session` row on
+ * the **real** `ClaudeAiAgent.layer`.
+ *
+ * The one substitution is the SDK seam (`../agent/sdk.ts`), which hands the layer a scripted `Query`
+ * replaying `two-subagent-turn.json` instead of spawning the `claude` CLI. Everything downstream of
+ * that seam is the shipped vertical: the layer's own fold, the mapping that opens and closes a
+ * subagent slot, the core, the transport and the window. `./desk.ts` beside this one substitutes the
+ * whole *layer* instead, which is why it cannot prove a mapping (#8408).
+ *
+ * No Pi row and no child row: neither is on the path from a spawning call to the running list, and a
+ * process the proof never opens is a process whose failure it would have to explain.
+ */
+
+import {Layer} from "effect";
+import type {TuvalConfigInput} from "../../config.ts";
+import {ProcessId} from "../../process/process.ts";
+import {wiredShellEffects} from "../../shell/host/index.ts";
+import {shellGraphNode, shellNode, shellProgram} from "../../shell/program.ts";
+import {ClaudeAiAgent} from "../agent/index.ts";
+import {claudeSessionSettings} from "../config.ts";
+import {claudeSession} from "../program.ts";
+import {KernelBridge} from "../tools/index.ts";
+import {PROJECT_ROOT_VAR} from "./names.ts";
+import {CAPTURE_SESSION_ID, captureHandle} from "./two-subagents.ts";
+
+const projectRoot = (): string => {
+	const root = process.env[PROJECT_ROOT_VAR];
+	if (root === undefined) throw new Error(`${PROJECT_ROOT_VAR} is not set`);
+	return root;
+};
+
+const root = projectRoot();
+
+// The capture was taken with `includePartialMessages` on, so the row asks for the same frames the
+// fixture holds; `KernelBridge.scripted` closes the tool bridge, which no claim here reaches.
+const settings = claudeSessionSettings({streamPartialReplies: true});
+
+export default {
+	version: 1,
+	programs: [
+		shellProgram({effects: wiredShellEffects({shellProcessId: ProcessId.make(shellNode)})}),
+		claudeSession({
+			cwd: root,
+			claude: {streamPartialReplies: true},
+			layer: ClaudeAiAgent.layer({
+				...settings,
+				sdk: captureHandle().sdk.sdk,
+				newSessionId: () => CAPTURE_SESSION_ID,
+			}).pipe(Layer.provide(KernelBridge.scripted({}))),
+		}),
+	],
+	graph: {nodes: [shellGraphNode]},
+} satisfies TuvalConfigInput;

--- a/apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts
@@ -1,0 +1,591 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The running-subagent list on the real Claude row, end to end (#8408).
+ *
+ * One run drives the whole arc: a Claude session opened from the real picker, prompted, and fed the
+ * captured frames of a real turn that spawned two overlapping workers
+ * (`../history/fixtures/two-subagent-turn.json`). The substitution is the SDK seam and nothing else
+ * — `ClaudeAiAgent` does the mapping, the core folds the slots, the transport carries them and the
+ * shipped `ChatWindow` draws them — so what this proves is the vertical, not a stand-in for it
+ * (`./subagent-desk.ts` says why `./desk.ts`'s scripted *layer* could not).
+ *
+ * Five claims, in the order an operator meets them:
+ *
+ * 1. the list is there with both workers on it while they run;
+ * 2. no row of either worker reaches the agent's own window;
+ * 3. picking one swaps that worker's transcript in, with the list still above it;
+ * 4. coming back restores main;
+ * 5. a worker that finishes while its view is open leaves the view up, saying finished.
+ *
+ * The state claims read the transport; the window claims read the DOM, because "what is on screen"
+ * is what the flag was built to change and no process state can answer it. Both halves are the same
+ * run: the rendered window is bound to the same live process the state assertions read.
+ */
+
+import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {act, fireEvent, render} from "@testing-library/react";
+import {Effect, type FileSystem, Queue, Schema, type Scope, Stream} from "effect";
+import {Socket} from "effect/unstable/socket";
+import type {ReactElement} from "react";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {boot, projectDir} from "../../boot.ts";
+import {ProcessId} from "../../process/process.ts";
+import {type ChatView, initialChatView} from "../../shell/chat/index.ts";
+import {
+	activeWorkspace,
+	type ShellMsg,
+	type ShellState,
+	windowIds,
+} from "../../shell/core/index.ts";
+import {serveDesk} from "../../shell/host/index.ts";
+import {defaultPrefixTable} from "../../shell/keys/index.ts";
+import {windows} from "../../shell/layout/index.ts";
+import {
+	mountPicker,
+	type PickerEntries,
+	type PickerView,
+	pickerKey,
+	readEntries,
+} from "../../shell/picker/index.ts";
+import {shellNode} from "../../shell/program.ts";
+import {attach} from "../../shell/transport/client.ts";
+import {installDomShims} from "../../shell/ui/dom.testing.ts";
+import type {ProcessView, WindowHost} from "../../shell/window/index.ts";
+import {WindowId} from "../../shell/window/index.ts";
+import {CLAUDE_SESSION_PROGRAM} from "../renderer-ref.ts";
+import {claudeChatWindow} from "../window/index.ts";
+import {PROJECT_ROOT_VAR} from "./names.ts";
+import {
+	CAPTURE_SESSION_ID,
+	captureFrames,
+	captureHandle,
+	finishFrameOf,
+	spawnCallIds,
+} from "./two-subagents.ts";
+
+installDomShims();
+
+/**
+ * jsdom lays nothing out, so without a box the virtualizer clamps every offset to zero and renders
+ * one row — the same shim `../../shell/chat/subagent-view.unit.test.tsx` carries, and for the same
+ * reason. On the prototype and before the first render, because a box stubbed after mount is stubbed
+ * after the opening layout effect has already resolved against a max scroll of 0.
+ */
+Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+	configurable: true,
+	get(this: HTMLElement): number {
+		return this.classList.contains("tuval-chat-transcript") ? 100_000 : 0;
+	},
+});
+Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+	configurable: true,
+	get(this: HTMLElement): number {
+		return this.classList.contains("tuval-chat-transcript") ? 600 : 0;
+	},
+});
+
+/**
+ * The port jsdom's document is served on, which is the `Origin` its `WebSocket` puts on the upgrade.
+ *
+ * The desk admits only the loopback origins of the ports it knows about, so a page-realm socket is
+ * refused until its port is admitted — the same fence a real browser meets, and the same seam the
+ * launch uses once Vite has listened (`admitLoopbackPort`, #7560). Reading it off `location` rather
+ * than writing 3000 down: the number is Vitest's environment option, not this proof's.
+ */
+const pageOrigin = (): number => {
+	const port = Number.parseInt(globalThis.location.port, 10);
+	return Number.isNaN(port) ? 80 : port;
+};
+
+const TIMEOUT = 180_000;
+const PROMPT = "read both files through two workers";
+const PROMPT_KEY = "k1";
+
+// `import.meta.dirname` rather than `fileURLToPath(new URL(…))`: under jsdom the global `URL` is
+// whatwg-url's, and `node:url` refuses an instance that is not its own ("The URL must be of scheme
+// file", however plainly the href says `file:`).
+const configModule = join(import.meta.dirname, "subagent-desk.ts");
+const shellProcessId = ProcessId.make(shellNode);
+
+const tempDirs: string[] = [];
+
+const freshProject = (): string => {
+	const dir = realpathSync(mkdtempSync(join(tmpdir(), "tuval-subagent-vertical-")));
+	tempDirs.push(dir);
+	mkdirSync(projectDir(dir));
+	process.env[PROJECT_ROOT_VAR] = dir;
+	return dir;
+};
+
+const bootDesk = Effect.fn("subagentVertical.bootDesk")(function* (project: string) {
+	const booted = yield* boot({global: configModule, project});
+	const server = yield* serveDesk({kernel: booted.kernel, port: 0, table: defaultPrefixTable});
+	const entries = yield* readEntries.pipe(Effect.provideContext(booted.kernel));
+	return {booted, server, entries};
+});
+
+const watch = Effect.fn("subagentVertical.watch")(function* <A>(stream: Stream.Stream<A>) {
+	const seen = yield* Queue.unbounded<A>();
+	yield* Effect.forkScoped(
+		Stream.runForEach(stream, (value) => Effect.asVoid(Queue.offer(seen, value))),
+	);
+	return seen;
+});
+
+/** The next published value satisfying `predicate`; the last one that did arrive names the failure. */
+const where = <A>(seen: Queue.Queue<A>, what: string, predicate: (value: A) => boolean) => {
+	let last: A | null = null;
+	return Effect.gen(function* () {
+		while (true) {
+			const value = yield* Queue.take(seen);
+			last = value;
+			if (predicate(value)) return value;
+		}
+	}).pipe(
+		Effect.timeout("60 seconds"),
+		Effect.catchTag("TimeoutError", () =>
+			Effect.die(new Error(`nothing where ${what}; last seen: ${JSON.stringify(last)}`)),
+		),
+	);
+};
+
+const liveWhere = <S>(
+	seen: Queue.Queue<ProcessView<S>>,
+	what: string,
+	predicate: (state: S) => boolean,
+): Effect.Effect<S> =>
+	where(seen, what, (view) => view._tag === "Live" && predicate(view.state)).pipe(
+		Effect.map((view) => (view as {readonly state: S}).state),
+	);
+
+const workspaceOf = (state: ShellState) => {
+	const workspace = activeWorkspace(state);
+	assert.isDefined(workspace, "the desk has an active workspace");
+	return workspace;
+};
+
+const boundProcess = (state: ShellState, windowId: string): string | null => {
+	for (const window of windows(workspaceOf(state).layout.root)) {
+		if (window.id === windowId) return window.processId;
+	}
+	return null;
+};
+
+interface Desk {
+	readonly send: (msg: ShellMsg) => Effect.Effect<void>;
+	readonly seen: Queue.Queue<ProcessView<ShellState>>;
+}
+
+const attachDesk = Effect.fn("subagentVertical.attachDesk")(function* (url: string) {
+	const page = yield* attach(url).pipe(Effect.provide(Socket.layerWebSocketConstructorGlobal));
+	const shell = yield* page.attachProcess<ShellState, ShellMsg>(shellProcessId);
+	const seen = yield* watch(shell.readProcess);
+	const desk: Desk = {send: (msg) => Effect.asVoid(shell.dispatch(msg)), seen};
+	return {page, desk};
+});
+
+/** The picker's own answer to a key, as the browser surface dispatches it. */
+const pickerPress = (
+	windowId: string,
+	entries: PickerEntries,
+	view: PickerView,
+	spelling: string,
+): ShellMsg | null => {
+	const answer = pickerKey(windowId as never, entries, view, spelling);
+	switch (answer._tag) {
+		case "Moved":
+		case "Cleared":
+			return {type: "window.setView", windowId: windowId as never, view: answer.view};
+		case "Chose":
+			return answer.intent._tag === "OpenProgram"
+				? {type: "window.open", windowId: windowId as never, programId: answer.intent.programId}
+				: {type: "window.attach", windowId: windowId as never, processId: answer.intent.processId};
+		case "Ignored":
+			return null;
+	}
+};
+
+const openFromThePicker = Effect.fn("subagentVertical.openFromThePicker")(function* (
+	desk: Desk,
+	entries: PickerEntries,
+	windowId: string,
+	programId: string,
+) {
+	const at = entries.programs.findIndex((entry) => entry.programId === programId);
+	assert.isAtLeast(at, 0, `the picker offers the ${programId} program`);
+	let view = mountPicker();
+	for (let step = 0; step < at; step += 1) {
+		const moved = pickerPress(windowId, entries, view, "j");
+		assert.isNotNull(moved, "the picker moved its highlight");
+		view = {...view, cursor: step + 1, refusal: null};
+		yield* desk.send(moved as ShellMsg);
+	}
+	const chosen = pickerPress(windowId, entries, view, "<enter>");
+	assert.isNotNull(chosen, "the picker chose the highlighted row");
+	yield* desk.send(chosen as ShellMsg);
+	const opened = yield* liveWhere(
+		desk.seen,
+		`the window bound to a ${programId} process`,
+		(state) => boundProcess(state, windowId) !== null,
+	);
+	return boundProcess(opened, windowId) as string;
+});
+
+const runningSlots = (state: AiAgentSessionState): ReadonlyArray<string> =>
+	Object.values(state.subagents)
+		.filter((slot) => slot.status === "running")
+		.map((slot) => slot.id as string);
+
+/** Hand the layer's query the next frames of the capture, so the run advances to one moment. */
+const deliver = (frames: ReadonlyArray<SDKMessage>, upTo: number): void => {
+	const handle = captureHandle();
+	const query = handle.sdk.opened[0];
+	assert.isDefined(query, "the layer never opened a query; nothing can be replayed into it");
+	for (let at = handle.delivered; at < upTo; at += 1) {
+		query.say(frames[at] as SDKMessage);
+	}
+	handle.delivered = upTo;
+};
+
+/**
+ * The opening line of every reply in one worker's slot — the discriminator two of the claims read.
+ *
+ * The worker's *replies* rather than its whole slot, because a worker's inbound turn is also the
+ * spawning call's `prompt` input, which the agent's own tool row legitimately carries. One line
+ * rather than a whole reply, because a reply renders as markdown: the fences and blank lines the
+ * slot holds are not in the DOM the operator reads.
+ */
+const repliesOf = (state: AiAgentSessionState, id: string): ReadonlyArray<string> =>
+	(state.subagents[id]?.items ?? []).flatMap((item) => {
+		if (item.kind !== "assistant") return [];
+		const line = item.text.split("\n").find((one) => one.trim().length > 0);
+		return line === undefined ? [] : [line.trim()];
+	});
+
+interface Screen {
+	readonly rows: () => ReadonlyArray<HTMLElement>;
+	readonly text: () => string;
+	/** The subagent whose transcript the swapped-in view is showing, or `null` on main. */
+	readonly showing: () => string | null;
+	readonly list: () => HTMLElement | null;
+	/** Every line of the list, including the way back and the "more" row. */
+	readonly picks: () => ReadonlyArray<HTMLButtonElement>;
+	/** The worker lines alone: a line with a type field on it is a row and nothing else is. */
+	readonly workers: () => ReadonlyArray<HTMLButtonElement>;
+	readonly more: () => HTMLElement | null;
+	/** Every spawning call offering to reveal the rows under it. On the agent window there are none. */
+	readonly folds: () => ReadonlyArray<HTMLElement>;
+	readonly current: () => string | null;
+	readonly end: () => HTMLElement | null;
+}
+
+const screenOf = (root: ParentNode): Screen => ({
+	rows: () => Array.from(root.querySelectorAll<HTMLElement>(".tuval-chat-row")),
+	showing: () => root.querySelector<HTMLElement>(".tuval-chat-transcript")?.dataset.view ?? null,
+	text: () => root.querySelector<HTMLElement>(".tuval-chat-spacer")?.textContent ?? "",
+	list: () => root.querySelector<HTMLElement>(".tuval-chat-subagents"),
+	picks: () => Array.from(root.querySelectorAll<HTMLButtonElement>(".tuval-chat-subagent-pick")),
+	workers: () =>
+		Array.from(
+			root.querySelectorAll<HTMLButtonElement>(
+				'.tuval-chat-subagent-pick:has([data-field="type"])',
+			),
+		),
+	more: () => root.querySelector<HTMLElement>(".tuval-chat-subagent-more"),
+	folds: () => Array.from(root.querySelectorAll<HTMLElement>(".tuval-chat-tool-fold")),
+	current: () =>
+		root.querySelector<HTMLElement>('.tuval-chat-subagent-pick[aria-current="true"]')
+			?.textContent ?? null,
+	end: () => root.querySelector<HTMLElement>(".tuval-chat-subagent-end"),
+});
+
+/** A rendered claim that never arrived, or a React act that threw — both are this proof failing. */
+class WindowNeverShowed extends Schema.TaggedError<WindowNeverShowed>()(
+	"tuval/subagent-vertical-proof/WindowNeverShowed",
+	{detail: Schema.String},
+) {
+	override get message(): string {
+		return this.detail;
+	}
+}
+
+const acted = (detail: string, body: () => Promise<void>): Effect.Effect<void> =>
+	Effect.tryPromise({
+		try: body,
+		catch: (cause) => new WindowNeverShowed({detail: `${detail}: ${String(cause)}`}),
+	}).pipe(Effect.orDie);
+
+/**
+ * Let React catch up with the transport. The window's state arrives on a stream the renderer reads
+ * on its own fiber, so there is no promise to await — the settle is a bounded poll on what is drawn,
+ * and its failure names the claim that never landed.
+ */
+const settle = (what: string, until: () => boolean): Effect.Effect<void> =>
+	acted(`waiting for ${what}`, async () => {
+		for (let attempt = 0; attempt < 200; attempt += 1) {
+			await act(async () => {
+				await new Promise((resume) => setTimeout(resume, 25));
+			});
+			if (until()) return;
+		}
+		throw new WindowNeverShowed({detail: `the window never showed ${what}`});
+	});
+
+const click = (button: HTMLButtonElement): Effect.Effect<void> =>
+	acted("clicking a list row", async () => {
+		await act(async () => {
+			button.click();
+		});
+	});
+
+const pressEscape = (list: HTMLElement): Effect.Effect<void> =>
+	acted("pressing Escape on the list", async () => {
+		await act(async () => {
+			fireEvent.keyDown(list, {key: "Escape"});
+		});
+	});
+
+const run = <A, E>(effect: Effect.Effect<A, E, Scope.Scope | FileSystem.FileSystem>) =>
+	effect.pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
+
+describe("the running-subagent list on a real Claude row", () => {
+	it.live(
+		"lists both workers while they run, keeps their rows out of the agent window, swaps one in and back, and holds an open view when its worker finishes",
+		() =>
+			run(
+				Effect.gen(function* () {
+					const frames = captureFrames();
+					const spawns = spawnCallIds(frames);
+					assert.lengthOf(spawns, 2, "the capture does not spawn exactly two workers");
+					const [first, second] = spawns as readonly [string, string];
+					const firstEnds = finishFrameOf(frames, first);
+					const secondEnds = finishFrameOf(frames, second);
+					assert.isAtLeast(firstEnds, 0, "the capture never finishes the first worker");
+					assert.isAtLeast(secondEnds, 0, "the capture never finishes the second worker");
+					assert.isBelow(
+						firstEnds,
+						secondEnds,
+						"the two workers finish on one frame; nothing can finish under an open view",
+					);
+
+					const project = freshProject();
+					const app = yield* bootDesk(project);
+					app.server.admitLoopbackPort(pageOrigin());
+					const {page, desk} = yield* attachDesk(app.server.launchUrl);
+
+					const fresh = yield* liveWhere(desk.seen, "the first snapshot", () => true);
+					const only = windowIds(workspaceOf(fresh))[0] as string;
+					assert.isDefined(only);
+
+					const agentId = yield* openFromThePicker(desk, app.entries, only, CLAUDE_SESSION_PROGRAM);
+					const process = yield* page.attachProcess<AiAgentSessionState, AiAgentSessionMsg>(
+						ProcessId.make(agentId),
+					);
+					const session = yield* watch(process.readProcess);
+					const ready = yield* liveWhere(
+						session,
+						"the session to open",
+						(state) => state.phase === "ready" && state.sessionId !== null,
+					);
+					assert.strictEqual(
+						ready.sessionId,
+						CAPTURE_SESSION_ID,
+						"the layer opened a session other than the one the capture is of",
+					);
+
+					// The window is bound to this live process and writes its view slot through the real
+					// shell, which is the path a swap takes on the desk.
+					let slot: ChatView = initialChatView;
+					const host: WindowHost<AiAgentSessionState, AiAgentSessionMsg, ChatView> = {
+						windowId: WindowId.make(only),
+						processId: ProcessId.make(agentId),
+						readProcess: process.readProcess,
+						dispatch: process.dispatch,
+						view: () => slot,
+						setView: (next) =>
+							Effect.flatMap(
+								Effect.sync(() => {
+									slot = next;
+								}),
+								() =>
+									desk.send({
+										type: "window.setView",
+										windowId: only as never,
+										view: next,
+									}),
+							),
+					};
+					const rendered = render(
+						claudeChatWindow({subagentList: true, scrollCommitMs: 0}).render(host) as ReactElement,
+					);
+					const screen = screenOf(rendered.container);
+
+					yield* Effect.addFinalizer(() => Effect.sync(() => rendered.unmount()));
+
+					yield* Effect.asVoid(
+						process.dispatch({
+							type: "prompt",
+							text: PROMPT,
+							key: PROMPT_KEY,
+							timestamp: Date.now(),
+						}),
+					);
+
+					// Claim 1: both workers on the list while they run. The frames stop one short of the
+					// first worker's own `tool_result`, which is the moment both are still writing.
+					deliver(frames, firstEnds);
+					// Both slots open *and* the first one already writing: the assertion below needs a
+					// line only the worker's slot can hold, and the first state with two slots in it is
+					// the one where neither has written yet.
+					const both = yield* liveWhere(
+						session,
+						"both workers to be running with the first one writing",
+						(state) => runningSlots(state).length === 2 && repliesOf(state, first).length > 0,
+					);
+					assert.deepStrictEqual(
+						runningSlots(both).toSorted(),
+						[first, second].toSorted(),
+						"the two slots are not the two spawning calls the capture made",
+					);
+					yield* settle("two rows on the list", () => screen.workers().length === 2);
+					assert.isNotNull(screen.list(), "the list is not on screen while two workers run");
+					assert.isNull(
+						screen.more(),
+						"the list collapsed a worker into the “more” row with only two running",
+					);
+					assert.deepStrictEqual(
+						screen
+							.workers()
+							.map((row) => row.querySelector('[data-field="type"]')?.textContent ?? ""),
+						["Explore", "Explore"],
+						"the two rows do not name the worker type the capture spawned",
+					);
+
+					// Claim 2: no row of either worker in the agent's own window. Counted by kind rather
+					// than matched by text, because the CLI's own `task_notification` notice quotes a
+					// worker's summary and that notice is the agent's row, not the worker's.
+					const spoken = repliesOf(both, first);
+					assert.isNotEmpty(spoken, "the first worker has written nothing yet to look for");
+					const kindsIn = (state: AiAgentSessionState, kind: string): number =>
+						state.transcript.items.filter((item) => item.kind === kind).length;
+					assert.isAtLeast(
+						kindsIn(both, "user"),
+						3,
+						"the tail holds no worker turns, so dropping them from the window proves nothing",
+					);
+					assert.isAtLeast(kindsIn(both, "assistant"), 1, "the tail holds no worker reply");
+					const drawn = (of: string): number =>
+						screen.rows().filter((row) => row.dataset.kind === of).length;
+					assert.strictEqual(
+						drawn("user"),
+						1,
+						"a worker's own turn reached the agent window; only the operator's prompt belongs there",
+					);
+					assert.strictEqual(
+						drawn("assistant"),
+						0,
+						"a worker's own reply reached the agent window",
+					);
+					// Dropped, not folded: a spawning call offering to reveal its rows is a window that
+					// still holds them, one click away (#8405's containment).
+					assert.lengthOf(
+						screen.folds(),
+						0,
+						"a spawning call still offers to unfold the worker's rows into the agent window",
+					);
+					assert.isNull(screen.showing(), "the window opened on a subagent rather than on main");
+					const mainText = screen.text();
+
+					// Claim 3: picking the first worker swaps its transcript in, list still above.
+					yield* click(screen.picks()[0] as HTMLButtonElement);
+					yield* settle("the first worker's transcript", () => screen.showing() === first);
+					const insideText = screen.text();
+					for (const line of spoken) {
+						assert.include(
+							insideText,
+							line,
+							"the swapped-in view is missing a row the worker wrote",
+						);
+					}
+					assert.isNotNull(
+						screen.list(),
+						"the list left the screen inside a subagent's view; there is no way back",
+					);
+					assert.include(
+						screen.current() ?? "",
+						"Explore",
+						"the list does not mark the worker whose transcript is showing",
+					);
+
+					// Claim 4: back to main, on the transcript it was left on.
+					yield* pressEscape(screen.list() as HTMLElement);
+					yield* settle("main again", () => screen.showing() === null);
+					assert.strictEqual(
+						screen.text(),
+						mainText,
+						"coming back from a worker did not restore the agent's own transcript",
+					);
+
+					// Claim 5: the first worker finishes while its view is open. The view stays up and
+					// says so; the second worker is still running, so the list is still a list.
+					yield* click(screen.picks()[0] as HTMLButtonElement);
+					yield* settle("the worker's view again", () => screen.showing() === first);
+					deliver(frames, firstEnds + 1);
+					const finished = yield* liveWhere(
+						session,
+						"the first worker to finish",
+						(state) => state.subagents[first]?.status === "finished",
+					);
+					assert.deepStrictEqual(
+						runningSlots(finished),
+						[second],
+						"finishing one worker moved the other",
+					);
+					yield* settle(
+						"the finished mark under the open view",
+						() => screen.end()?.dataset.status === "finished",
+					);
+					assert.strictEqual(
+						screen.showing(),
+						first,
+						"the view closed itself when its worker finished",
+					);
+					for (const line of spoken) {
+						assert.include(
+							screen.text(),
+							line,
+							"the finished worker's rows went out from under the operator reading them",
+						);
+					}
+					assert.include(
+						screen.end()?.textContent ?? "",
+						"finished",
+						"the open view does not say its worker has stopped",
+					);
+					assert.isNotNull(screen.list(), "the way back left with the worker that finished");
+
+					// The slot the window wrote is the slot the shell holds: the swap went through the
+					// real view-slot path and not through a value this test kept to itself.
+					const held = yield* liveWhere(
+						desk.seen,
+						"the shell to hold this window's view slot",
+						(state) =>
+							(state.views as Record<string, {viewing?: {id?: string}} | undefined>)[only]?.viewing
+								?.id === first,
+					);
+					assert.isDefined(held);
+				}),
+			),
+		TIMEOUT,
+	);
+});
+
+process.on("exit", () => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, {recursive: true, force: true});
+});

--- a/apps/tuval/src/claude/proof/two-subagents.ts
+++ b/apps/tuval/src/claude/proof/two-subagents.ts
@@ -1,0 +1,85 @@
+/**
+ * The captured two-worker turn the subagent proof replays, and the handle that paces it.
+ *
+ * `two-subagent-turn.json` is a real `query()` run whose one prompt spawned two `Explore` workers
+ * that overlapped (`../history/fixtures/PROVENANCE.md`). Replaying it through the scripted `AgentSdk`
+ * seam is what makes the proof a claim about the *real* Claude layer: `ClaudeAiAgent` does the whole
+ * mapping — the slot opens, the nested rows fold into it, the parent's `tool_result` finishes it —
+ * and nothing here hands the core an `AgentEvent` of its own.
+ *
+ * The handle is paced rather than played whole, because three of the five claims are about a moment:
+ * both workers on the list *while they run*, one of them finishing *under an open view*, and main
+ * restored after that. A run that delivered all 59 frames at once would only ever show the end.
+ *
+ * It hangs off `globalThis` because two importers have to reach one object: the test imports this
+ * module by path, and `boot` imports `./subagent-desk.ts` beside it as a `file://` URL
+ * (`../../config.ts`). Two module instances would leave the test pacing a query the desk never
+ * opened, and the failure would read as a layer that never started.
+ */
+
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {type ScriptedSdk, scriptedSdk} from "../agent/fixtures/scripted-query.ts";
+import {loadFixture} from "../history/fixtures/load.ts";
+
+/** The id the capture's own `init` frame names, so the layer opens the session the capture is of. */
+export const CAPTURE_SESSION_ID = "00000000-0000-4000-8000-000000000001";
+
+export const captureFrames = (): ReadonlyArray<SDKMessage> =>
+	loadFixture("two-subagent-turn") as ReadonlyArray<SDKMessage>;
+
+const HANDLE = Symbol.for("tuval/claude/proof/two-subagents");
+
+interface Handle {
+	readonly sdk: ScriptedSdk;
+	delivered: number;
+}
+
+export const captureHandle = (): Handle => {
+	const held = (globalThis as Record<symbol, unknown>)[HANDLE];
+	if (held !== undefined) return held as Handle;
+	const made: Handle = {sdk: scriptedSdk({opening: []}), delivered: 0};
+	(globalThis as Record<symbol, unknown>)[HANDLE] = made;
+	return made;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+/**
+ * A frame's content blocks. Read off the value rather than off `SDKMessage`'s union, because only
+ * some members declare `message` at all and this walks every frame the capture holds.
+ */
+const blocksOf = (frame: SDKMessage): ReadonlyArray<Record<string, unknown>> => {
+	const held = frame as Record<string, unknown>;
+	const message = isRecord(held.message) ? held.message : undefined;
+	const content = message === undefined ? undefined : message.content;
+	return Array.isArray(content) ? content.filter(isRecord) : [];
+};
+
+/**
+ * The two spawning calls, in the order the capture made them. Read off the frames rather than
+ * written down: a re-capture moves the ids, and a proof carrying its own copy of them would assert
+ * against the old run.
+ */
+export const spawnCallIds = (frames: ReadonlyArray<SDKMessage>): ReadonlyArray<string> =>
+	frames.flatMap((frame) =>
+		blocksOf(frame).flatMap((block) =>
+			block.type === "tool_use" &&
+			isRecord(block.input) &&
+			typeof block.input.subagent_type === "string" &&
+			typeof block.id === "string"
+				? [block.id]
+				: [],
+		),
+	);
+
+/**
+ * Where the parent's own `tool_result` for one spawning call arrives — the frame that ends that
+ * worker. `parent_tool_use_id: null` is what makes it the parent's frame and not a nested one.
+ */
+export const finishFrameOf = (frames: ReadonlyArray<SDKMessage>, callId: string): number =>
+	frames.findIndex(
+		(frame) =>
+			(frame as Record<string, unknown>).parent_tool_use_id === null &&
+			blocksOf(frame).some((block) => block.type === "tool_result" && block.tool_use_id === callId),
+	);

--- a/apps/tuval/tsconfig.design.json
+++ b/apps/tuval/tsconfig.design.json
@@ -27,6 +27,7 @@
 		"src/page/proof/no-recovery.tsx",
 		"src/page/attached-desk.unit.test.tsx",
 		"src/page/readable-state.unit.test.tsx",
+		"src/claude/proof/subagent-vertical.integration.test.ts",
 		"src/page/assets.d.ts"
 	],
 	// `exclude` is inherited, and the base excludes exactly this directory.

--- a/apps/tuval/tsconfig.json
+++ b/apps/tuval/tsconfig.json
@@ -31,6 +31,10 @@
 	// `src/page/` is split rather than excluded whole: the three React modules reach the chat window
 	// through the page's renderer table (#7573) and go to the other lens, while `dev-server.ts` is
 	// Node-side, is imported by `src/bin.ts`, and stays here.
+	// `src/claude/proof/subagent-vertical.integration.test.ts` is split the same way and for the same
+	// reason: it mounts the shipped chat window over a live process, so it reaches `@kampus/design`
+	// through it. Its two neighbours — the config module and the capture handle — reach no React and
+	// stay here.
 	// `src/pi/renderer-ref.ts`, `src/claude/renderer-ref.ts` and `src/ai-agent/renderer-ref.ts` still
 	// enter this project by import from their rows, which is the point of those leaves: a row names
 	// its renderer without reaching any of it.
@@ -46,6 +50,7 @@
 		"src/page/renderers.tsx",
 		"src/page/proof/no-recovery.tsx",
 		"src/page/attached-desk.unit.test.tsx",
-		"src/page/readable-state.unit.test.tsx"
+		"src/page/readable-state.unit.test.tsx",
+		"src/claude/proof/subagent-vertical.integration.test.ts"
 	]
 }


### PR DESCRIPTION
The last child of #8384: prove the running-subagent list on the real Claude row, end to end, and
hand the founder the steps to see it on his own desk.

## The automated half

`apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts` opens a `claude-session` from the
real picker, prompts it, and feeds it a captured turn one frame at a time. The one substitution is
the SDK seam (`AgentSdk`) — the layer, the mapping that opens and closes a subagent slot, the core,
the transport and the shipped `ChatWindow` are all the real ones. `proof/desk.ts` beside it
substitutes the whole *layer*, which is why it could not carry this claim.

Five things in one run:

1. the list is on screen with both workers on it while they run, and no "more" row;
2. no row of either worker reaches the agent's own window — dropped, not folded, so the spawning call
   offers nothing to unfold;
3. picking one swaps that worker's transcript in, with the list still above it and the row marked;
4. Escape puts main back on the transcript it was left on;
5. a worker that finishes while its view is open leaves the view up, marked finished, with its rows
   still there.

Each of the five was checked by breaking it and watching the test red, not by reading it:

| Removed | What went red |
|---|---|
| `SUBAGENT_ROW_CAP` 5 → 1 | "the window never showed two rows on the list" |
| `subagentHeads(slots, false)` — stop dropping worker rows | two spawning calls offer to unfold them |
| `viewSubagent` returns its input | "never showed the first worker's transcript" |
| `viewMain` returns its input | "never showed main again" |
| the core drops a finished slot instead of keeping it | "nothing where the first worker to finish" |

## The capture

No existing fixture had two workers running at once, so one was taken:
`apps/tuval/src/claude/history/fixtures/two-subagent-turn.json`, a real `query()` run whose prompt
asked for two parallel `Explore` workers over two files in a throwaway cwd. 59 frames; both `Agent`
calls and both `task_started` frames land before either worker's result, and the two results land
four frames apart — which is the only moment at which a worker can finish under an open view.

## Round 2 — the split-path leak

Review round 1 found the capture's first sanitization pass wrong on one path. That path is split
across four `input_json_delta` frames; the pass rewrote the frame holding its absolute prefix and
left the neighbour holding the tail, so the fixture kept a bare fragment of the operator's temp
namespace and the streamed half of that tool call no longer reassembled to its settled half.

Fixed here, and the class closed rather than the instance:

- both frames rewritten so the alpha `Agent` call's delta run reassembles to exactly the input its
  settled `tool_use` block carries. The split itself is kept, cut mid-token where the capture cut
  it — that is the shape a sanitizer has to survive and the corpus should hold one.
- `boundary.unit.test.ts` gains a check that reassembles **every** delta run in every fixture and
  compares it to the settled input, failing closed on a corpus that carries none. Verified by
  restoring the bad tail and watching that check — and only that check — red.
- its operator-root scan now reads the leading-slash-stripped and slug-encoded forms of both roots,
  not two absolute prefixes. That immediately caught the same slug still sitting in
  `subagent-turn.json`'s `init` frame, which is fixed here too.
- `PROVENANCE.md` describes the split-delta shape as one that went wrong and was repaired, and the
  standing "reds if any operator path returns" sentence is replaced by what the three checks
  actually cover — including that a fragment cut past both root names matches none of them, which is
  exactly what this one was.

## The hand-verification half

The founder's numbered runbook is appended to #8408's body, before he is asked to run it:
https://github.com/kamp-us/phoenix/issues/8408

The flag stays default-off in the repo. Nothing here flips it; his pass is the release.

## Deviations

- **Scope narrowing** — **Said:** the issue's plan names `pnpm --filter @kampus/tuval proof:chat
  --port <scratch port>` as the founder's step 2. **Did:** the runbook names his own desk (or
  `dev --project <dir> --page-port <scratch>`) instead. **Why:** `proof:chat` is a static component
  harness with no kernel, socket or agent — it cannot spawn a subagent, so it cannot show the list
  filling. **Disposition:** the runbook says the working command; the issue's plan text is left as it
  was written.
- **Known defect left unfixed** — **Said:** nothing of a subagent reaches the agent window.
  **Did:** the assertion counts rendered rows by kind and checks no spawning call offers a fold,
  rather than matching the worker's text. **Why:** the CLI's own `system`/`task_notification` notice
  quotes the worker's whole summary, and that notice is the agent's row, not the worker's — a
  text match would fail on a row that legitimately belongs there. Whether that notice should be
  showing a worker's full output in the agent transcript is a separate question, filed rather than
  fixed here. **Disposition:** stated here and filed as #8475.
- **Out-of-scope change** — **Said:** #8408 names the new test and the runbook. **Did:** also split
  `subagent-vertical.integration.test.ts` into `tsconfig.design.json` and out of `tsconfig.json`.
  **Why:** it mounts the shipped chat window, so it reaches `@kampus/design`, and the kernel lens
  excludes every slice that does. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the same. **Did:** also registered the new fixture in
  `fixtures/load.ts` and in `boundary.unit.test.ts`'s member list. **Why:** that list is fail-closed
  — a fixture nobody named would red the boundary test. **Disposition:** stated here.
- **Declined guidance** — **Said:** the ordinary construction path ends with the builder having seen
  the change rendered. **Did:** ran no visual pass. **Why:** this seat has no browser, so the only
  pass I could make was mechanical — a desk booted on scratch port 5289 with
  `features: {subagentList: true}` serves `virtual:tuval/features` as `{"subagentList": true}` and
  registers the Claude row. What the strip looks like is unchecked by me. **Disposition:** stated
  here; the rendered-surface verdict is `review-ui`'s, and the founder's own pass is what releases
  the flag.
- **Pre-existing test or fixture changed** — **Said:** this PR adds a capture; it does not touch the
  ones already landed. **Did:** rewrote one string in `subagent-turn.json` — its `init` frame's
  `memory_paths.auto`, which carried the operator's temp namespace slug-encoded. **Why:** the
  widened operator-root scan reds on it, and a guard that tolerated a known leak to avoid touching a
  neighbour would be worth nothing. Nothing else about that capture changed, and `PROVENANCE.md`
  records it. **Disposition:** stated here.

Fixes #8408
