### PR TITLE
feat(tuval): the running-subagent list is on by default

### DIFF
--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -26,7 +26,7 @@ import {
 } from "./commands/bindings/index.ts";
 // Re-exported below rather than declared here: both ends of the node/browser wire need the resolved
 // flag record, and this module reaches `node:*` (#8439).
-import {featuresOff, type TuvalFeatures} from "./features.ts";
+import {featuresDefault, type TuvalFeatures} from "./features.ts";
 import {type Graph, NodeId} from "./ports/graph.ts";
 import {type AnyProgram, ProgramId} from "./registry/program.ts";
 import {
@@ -56,7 +56,8 @@ const GraphSchema = Schema.Struct({nodes: Schema.Array(GraphNode)});
 /**
  * The feature flags a layer *states*. Every key is optional, and that is the whole point: absent
  * means "this layer says nothing", not "off", so a project layer naming one flag cannot put back to
- * its default a flag the global layer turned on. `featuresOff` is where a flag nobody stated lands.
+ * its default a flag the global layer turned on. `featuresDefault` is where a flag nobody stated
+ * lands.
  */
 const DeclaredFeatures = Schema.Struct({
 	/**
@@ -66,7 +67,7 @@ const DeclaredFeatures = Schema.Struct({
 	subagentList: Schema.optionalKey(Schema.Boolean),
 });
 
-export {featuresOff, type TuvalFeatures} from "./features.ts";
+export {featuresDefault, type TuvalFeatures} from "./features.ts";
 
 /** Version 1 of the config shape. A config module default-exports its `Encoded` form. */
 export const TuvalConfig = Schema.Struct({
@@ -244,7 +245,7 @@ export const loadLayeredConfig = Effect.fn("Tuval.loadLayeredConfig")(function* 
 		// Widened back: the loader checked each row's id and nothing else, and that is all a caller
 		// may assume of one.
 		programs: declared.map((program): unknown => program.row),
-		features: {...featuresOff, ...base.features, ...over.features},
+		features: {...featuresDefault, ...base.features, ...over.features},
 		moduleRenderers: moduleRendererRefs(declared),
 		graph: {nodes: mergeById(base.graph.nodes, over.graph.nodes, (node) => node.id)},
 		keys: [

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -119,6 +119,20 @@ describe("the feature flags", () => {
 			assert.deepStrictEqual(merged.features, {subagentList: true});
 		}),
 	);
+
+	// The direction that costs something: `subagentList` defaults on, so an operator turning it off
+	// is a layer stating `false` over a `true` default, and a merge folding the layers the other way
+	// round would silently ignore them.
+	it.effect("let a layer that states a flag off win over the on default", () =>
+		Effect.gen(function* () {
+			const global = yield* layered(fixture("features-off"), fixture("two-rows"));
+			assert.deepStrictEqual(global.features, {subagentList: false});
+			const project = yield* layered(fixture("two-rows"), fixture("features-off"));
+			assert.deepStrictEqual(project.features, {subagentList: false});
+			const overGlobalOn = yield* layered(fixture("features-on"), fixture("features-off"));
+			assert.deepStrictEqual(overGlobalOn.features, {subagentList: false});
+		}),
+	);
 });
 
 describe("loadLayeredConfig", () => {
@@ -129,7 +143,7 @@ describe("loadLayeredConfig", () => {
 				const config = yield* layered(fixture("global-layer"), fixture("project-layer"));
 				assert.deepStrictEqual(config, {
 					programs: [{id: "a"}, {id: "b", core: "project"}],
-					features: {subagentList: false},
+					features: {subagentList: true},
 					moduleRenderers: [],
 					graph: {
 						nodes: [
@@ -151,7 +165,7 @@ describe("loadLayeredConfig", () => {
 			const missing = fixture("does-not-exist");
 			assert.deepStrictEqual(yield* layered(missing, fixture("with-graph")), {
 				programs: [{id: "a"}],
-				features: {subagentList: false},
+				features: {subagentList: true},
 				moduleRenderers: [],
 				graph: {nodes: [{id: NodeId.make("n"), program: ProgramId.make("a"), on: []}]},
 				keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
@@ -159,7 +173,7 @@ describe("loadLayeredConfig", () => {
 			});
 			assert.deepStrictEqual(yield* layered(fixture("two-rows"), missing), {
 				programs: [{id: "a"}, {id: "b"}],
-				features: {subagentList: false},
+				features: {subagentList: true},
 				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
@@ -167,7 +181,7 @@ describe("loadLayeredConfig", () => {
 			});
 			assert.deepStrictEqual(yield* layered(missing, missing), {
 				programs: [],
-				features: {subagentList: false},
+				features: {subagentList: true},
 				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [],

--- a/apps/tuval/src/features.ts
+++ b/apps/tuval/src/features.ts
@@ -19,7 +19,9 @@ export interface TuvalFeatures {
 }
 
 /**
- * Every flag off. A user-facing change ships dark behind a default-off flag
- * (`product-development-cycle.md`), so this is what a config that declares no `features` means.
+ * What a config that declares no `features` block means. A user-facing change ships dark behind a
+ * default-off flag (`product-development-cycle.md`) and is flipped on here once it has had its
+ * runbook pass, so a flag's entry moves from `false` to `true` in this record and nowhere else. A
+ * layer that states a flag still wins over it, in either direction (`./config.ts`'s merge).
  */
-export const featuresOff: TuvalFeatures = {subagentList: false};
+export const featuresDefault: TuvalFeatures = {subagentList: true};

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -18,7 +18,7 @@
 
 import {dirname} from "node:path";
 import {Effect, Schema} from "effect";
-import {featuresOff, type TuvalFeatures} from "../features.ts";
+import {featuresDefault, type TuvalFeatures} from "../features.ts";
 import type {TransportServer} from "../shell/transport/server.ts";
 import type {ModuleRendererRef} from "../shell/window/index.ts";
 
@@ -63,7 +63,7 @@ export interface PageServerOptions {
 	readonly moduleRenderers?: ReadonlyArray<ModuleRendererRef>;
 	/**
 	 * The booted config's feature flags (`../config.ts`), merged and every one resolved to a boolean.
-	 * Absent means `featuresOff` — what a caller serving the page over its own rows rather than a
+	 * Absent means `featuresDefault` — what a caller serving the page over its own rows rather than a
 	 * founder's config wants.
 	 */
 	readonly features?: TuvalFeatures;
@@ -139,10 +139,10 @@ export const featuresSource = (features: TuvalFeatures): string => {
 /**
  * The plugin serving that module. Exported because the renderer table imports the specifier
  * unconditionally, so every environment loading the table has to answer it: the dev server below
- * with the founder's flags, and `vitest.config.ts` with `featuresOff` — the flags-off desk a unit
- * test means to render.
+ * with the founder's flags, and `vitest.config.ts` with `featuresDefault` — the desk a unit test
+ * means to render.
  */
-export const featuresPlugin = (features: TuvalFeatures = featuresOff) => {
+export const featuresPlugin = (features: TuvalFeatures = featuresDefault) => {
 	const source = featuresSource(features);
 	return {
 		name: "tuval-features",

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -79,11 +79,12 @@ describe("the feature-flag module", () => {
 		);
 	});
 
-	// The page reads `features.subagentList` and gets a boolean either way: an absent key would read
-	// `undefined`, which is falsy and so passes by luck until a flag defaults on.
-	it("carries every flag as false when no layer declares a features block", async () => {
+	// The page reads `features.subagentList` and gets a boolean either way. `subagentList` defaults
+	// on, so an absent key reading `undefined` would now be wrong in the direction that shows: the
+	// operator who stated nothing would get the flag off.
+	it("carries every flag at its default when no layer declares a features block", async () => {
 		expect(await generated("two-rows", "one-counter")).toBe(
-			'export default {\n\t"subagentList": false,\n};\n',
+			'export default {\n\t"subagentList": true,\n};\n',
 		);
 	});
 

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -101,9 +101,10 @@ export interface ChatWindowOptions {
 	/** The clock a send stamps its turn with, so no update cell has to read one (#7978). */
 	readonly now?: () => number;
 	/**
-	 * The window's half of the config's `features.subagentList` flag (`../../config.ts`), off by
-	 * default. It gates the running list and the removal of a subagent's rows from the transcript
-	 * together, so an operator with it off sees exactly today's window (#8405).
+	 * The window's half of the config's `features.subagentList` flag (`../../config.ts`), on by
+	 * default since the flag's flip. It gates the running list and the removal of a subagent's rows
+	 * from the transcript together, so a caller passing `false` gets exactly the pre-flag window
+	 * (#8405).
 	 */
 	readonly subagentList?: boolean;
 	readonly pageLimit?: number;
@@ -141,7 +142,7 @@ const resolve = (options: ChatWindowOptions): ResolvedOptions => ({
 	extras: options.extras ?? null,
 	newKey: options.newKey ?? (() => crypto.randomUUID()),
 	now: options.now ?? (() => Date.now()),
-	subagentList: options.subagentList === true,
+	subagentList: options.subagentList !== false,
 	pageLimit: options.pageLimit ?? 50,
 	overscan: options.overscan ?? 6,
 	estimateRowHeight: options.estimateRowHeight ?? 72,

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -239,6 +239,16 @@ const scrollElementTo = async (scroller: HTMLElement, offset: number): Promise<v
 
 const transcript = (): HTMLElement => screen.getByRole("log", {name: "Transcript"});
 
+// The window carries more than one `role="status"` — the phase line, and the subagent view slot's
+// notice that `features.subagentList` brings with it — so a bare `getByRole("status")` is ambiguous.
+const phaseLine = (): HTMLElement => {
+	const line = document.querySelector<HTMLElement>(".tuval-chat-phase");
+	if (line === null) throw new Error("no phase line");
+	return line;
+};
+
+const liveRegions = (): number => screen.getAllByRole("status").length;
+
 const scrollTo = (offset: number): Promise<void> => scrollElementTo(transcript(), offset);
 
 /**
@@ -943,8 +953,9 @@ describe("the composer", () => {
 				),
 			);
 		});
-		await waitFor(() => expect(screen.getByRole("status").textContent).toContain("Interrupting"));
-		expect(screen.getByRole("status").textContent).not.toContain("Ready");
+		expect(phaseLine().getAttribute("role")).toBe("status");
+		await waitFor(() => expect(phaseLine().textContent).toContain("Interrupting"));
+		expect(phaseLine().textContent).not.toContain("Ready");
 	});
 
 	it("restores the draft the window was left with", async () => {
@@ -1346,6 +1357,7 @@ describe("the phase line and the contract's two placeholders", () => {
 		const {process} = await openWindow(withTranscript(transcriptOf(2), {phase: "ready"}));
 		const working = () => document.querySelector(".tuval-chat-working");
 		expect(working()).toBeNull();
+		const regionsWhileReady = liveRegions();
 
 		await act(async () => {
 			await Effect.runPromise(
@@ -1353,9 +1365,11 @@ describe("the phase line and the contract's two placeholders", () => {
 			);
 		});
 		await waitFor(() => expect(working()).not.toBeNull());
-		// The phase line is the announced one; a second `status` would narrate the same turn twice.
+		// The phase line is the announced one; a `status` the tell brought with it would narrate the
+		// same turn twice. Counted against the ready window rather than against a literal, because not
+		// every live region the window carries is the tell's business.
 		expect(working()?.getAttribute("aria-hidden")).toBe("true");
-		expect(screen.getAllByRole("status").length).toBe(1);
+		expect(liveRegions()).toBe(regionsWhileReady);
 
 		await act(async () => {
 			await Effect.runPromise(process.commit(withTranscript(transcriptOf(2), {phase: "ready"})));

--- a/apps/tuval/src/shell/chat/subagent-list.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-list.unit.test.tsx
@@ -227,7 +227,7 @@ describe("a subagent's rows in the agent window", () => {
 	it("fold exactly as they do at main with the flag off, and no list is drawn", async () => {
 		const {rendered} = await openWindow(
 			state(),
-			{},
+			{subagentList: false},
 			{
 				...initialChatView,
 				atOldest: true,

--- a/apps/tuval/src/shell/chat/subagent-navigator.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-navigator.unit.test.tsx
@@ -231,7 +231,7 @@ describe("the chord where there is no list", () => {
 	});
 
 	it("does nothing with the flag off, where no row is focusable at all", async () => {
-		const {rendered, chord} = await openWindow(twoRunning(), {});
+		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: false});
 		const before = active();
 
 		await chord();

--- a/apps/tuval/vitest.config.ts
+++ b/apps/tuval/vitest.config.ts
@@ -33,9 +33,9 @@ const maxWorkers = process.env.CI ? undefined : 2;
 
 // `src/page/renderers.tsx` imports `virtual:tuval/features` — the module the page server generates
 // from the booted config (#8439) — so any test that reaches the renderer table has to be able to
-// resolve it. Served here at `featuresOff`, its default: a unit test renders the desk an operator
-// who turned nothing on gets. A test wanting a flag on passes `ChatWindowOptions` to `chatWindow()`
-// directly, which is what `src/shell/chat/subagent-list.unit.test.tsx` does.
+// resolve it. Served here at `featuresDefault`: a unit test renders the desk an operator who stated
+// no flags gets. A test wanting a flag at some other value passes `ChatWindowOptions` to
+// `chatWindow()` directly, which is what `src/shell/chat/subagent-list.unit.test.tsx` does.
 // Declared per project rather than at the root: Vitest 4 builds each project's own Vite server and
 // a root `plugins` entry does not reach one.
 const plugins = [featuresPlugin()];


### PR DESCRIPTION
Tuval's `features.subagentList` shipped dark and has now had its runbook pass on the real Claude vertical (#8408, "alright it worked now"), so the default record flips: `featuresOff` becomes `featuresDefault` and `subagentList` is `true` in it. Epic #8384. ADR 0363 (#8478) is the ruling record for how flags are shaped — a `features` block in the config file merged at boot — and nothing in `.decisions/` is touched here.

The merge stays `{...featuresDefault, ...base.features, ...over.features}`, so a config layer still wins in either direction; a new config case proves an explicit `false` beats the on default from the global layer, from the project layer, and over a global `true`. `ChatWindowOptions.subagentList` follows the config rather than contradicting it — absent now resolves on — and the tests that read the pre-flag window pass `false` explicitly instead of leaning on the old default. The two that counted `role="status"` regions now name the phase line, because the flag brings the view slot's own live region with it. Tuval unit subset: 217 files, 2099 tests, all green; `pnpm turbo run typecheck --force` and `pnpm lint` clean.

## Deviations

None.

Fixes #8481
