### PR TITLE
chore(fabrika): raise laneConcurrencyCap to 8

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -28,7 +28,7 @@
 	// How many issue lanes may stand open at once — the number the founder drove this weekend, now
 	// enforced at the boot instead of remembered (#8264). `lane open` and `lane emit` refuse past it
 	// with nothing written; there is no override flag, so raising this line is the only way past.
-	"laneConcurrencyCap": 2,
+	"laneConcurrencyCap": 8,
 
 	// Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `campaign
 	// state`). It narrows the repo's collaborator ACL and never replaces it: an entry here still


### PR DESCRIPTION
## Why

Every `fabrika lane open` refuses on exit 51: the repo caps lanes at 2 and 71 seats read as active. They are lanes whose issues were shipped by hand, so the ledger never heard a terminal event, and no verb folds such a lane today. That is #7310, agent-ready as of 2026-09-07.

## What

One line in `.fabrika.jsonc`: `laneConcurrencyCap` 2 to 8. The counter already ignores finished lanes (it counts only active or unreadable logs), so old lane logs stay on disk for the record at no cost. 8 matches the ~6 concurrent agents the laptop tolerates.

## Ruling

Founder, 2026-09-07 PT: "yes 8 sounds good, but it should not blindly count the lane folders, right? we wanna have the old lane logs stay there for observability type of thing."

Refs #8484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8484
