### PR TITLE
feat: The Tuval session picker's reading state has no live feedback, elapsed readout or timed-out state

### DIFF
--- a/apps/tuval/src/ai-agent/session-list.ts
+++ b/apps/tuval/src/ai-agent/session-list.ts
@@ -26,7 +26,12 @@
 import {type Cmd, defineMachine} from "@demlik/tea";
 import {Cause, Context, Effect, Option, Schema} from "effect";
 import {defineSpell} from "../commands/spell.ts";
-import {SESSION_LIST_PATH, SessionList} from "../protocol/session-list.ts";
+import {
+	SESSION_LIST_DEADLINE_MILLIS,
+	SESSION_LIST_PATH,
+	SESSION_LIST_TIMED_OUT_TAG,
+	SessionList,
+} from "../protocol/session-list.ts";
 import type {AnyProgram, Program} from "../registry/program.ts";
 import {ProgramId} from "../registry/program.ts";
 import type {Registry} from "../registry/Registry.ts";
@@ -64,11 +69,8 @@ export const aiAgentSessionListKernel = (
 	read: listAiAgentSessions(services).pipe(Effect.provideContext(services)),
 });
 
-/** How long the whole union may take before the call answers with a refusal instead of waiting. */
-export const SESSION_LIST_DEADLINE_MILLIS = 10_000;
-
 export class SessionListTimedOut extends Schema.TaggedError<SessionListTimedOut>()(
-	"tuval/SessionListTimedOut",
+	SESSION_LIST_TIMED_OUT_TAG,
 	{millis: Schema.Number},
 ) {
 	override get message(): string {

--- a/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
@@ -9,23 +9,30 @@
  * presentation rather than forking it: a window is not an overlay, and a modal inside one traps the
  * whole desk behind a list.
  *
- * **The list is handed in.** `useAnswer` is the seam: the renderer asks for the current answer and
- * renders it, so this module knows nothing about how a page gets one — the page binds a source that
- * calls `session.list` over its socket (`../../page/renderers.tsx`, #8161). It is handed this
- * window's id, because the call carries the window it came from and the kernel resolves the rest.
- * At its default it hands `null`, "nothing has been read yet", which is what a fixture or a surface
- * with no socket behind it renders.
+ * **The list is handed in.** `useAnswer` is the seam: the renderer asks where the read has got to
+ * and renders that, so this module knows nothing about how a page gets an answer — the page binds a
+ * source that calls `session.list` over its socket (`../../page/renderers.tsx`, #8161). It is handed
+ * this window's id, because the call carries the window it came from and the kernel resolves the
+ * rest. At its default it hands a read nobody sent, which is what a fixture or a surface with no
+ * socket behind it renders.
  *
- * **Four states, none of them a blank window.** No answer yet, a refused call, an empty store, and a
- * store whose backends could not be read are four different sentences — the last two are the pair
- * that matters, because a failed read rendered as an empty list tells an operator they have no
- * sessions.
+ * **Five states, none of them a blank window.** Reading, a fired deadline, a refused call, an empty
+ * store, and a store whose backends could not be read are five different sentences — the last two
+ * are the pair that matters, because a failed read rendered as an empty list tells an operator they
+ * have no sessions.
+ *
+ * **The waiting state is a state, not the absence of one** (#8280). The seam hands a `Reading` that
+ * carries when the call left and the bound it runs against, this window ticks a clock against it,
+ * and a deadline that passes with no reply ends the wait rather than spinning forever. The readout
+ * measures *time*, never work: one reply answers the whole union, so no per-backend progress exists
+ * to show and none is invented.
  */
 
-import {CommandPalette, type CommandPaletteItem} from "@kampus/design";
+import {Button, CommandPalette, type CommandPaletteItem} from "@kampus/design";
 import type {ReactElement, KeyboardEvent as ReactKeyboardEvent, ReactNode} from "react";
-import {useCallback, useMemo, useState} from "react";
-import type {SessionListAnswer} from "../../page/session-list.ts";
+import {useCallback, useEffect, useMemo, useState} from "react";
+import type {ReadingSessions, SessionListStatus} from "../../page/session-list.ts";
+import {atClock, elapsedMillis, reading} from "../../page/session-list.ts";
 import {failureLine} from "../../palette/call.ts";
 import type {WindowId} from "../../protocol/ids.ts";
 import type {SessionRow, UnreadableBackend} from "../../protocol/session-list.ts";
@@ -56,7 +63,84 @@ const COPY = {
 	allRefused: "No sessions: every backend that could have answered refused the read.",
 	noMatch: "No session matches this filter.",
 	refused: "The kernel refused the session list.",
+	elapsed: "Time the read has been out, against its deadline",
+	timedOut: "The read ran past its deadline before any backend answered.",
+	timedOutNote:
+		"Nothing was read, so this says nothing about what is on this machine — the sessions may all still be there.",
+	retry: "Read the sessions again",
 } as const;
+
+/** Whole seconds, because a readout that ticks in milliseconds is a number nobody can read. */
+const seconds = (millis: number): number => Math.floor(millis / 1000);
+
+/**
+ * How often the elapsed readout re-renders while a read is out. Finer than the second it prints, so
+ * the wait ends near its deadline rather than up to a second after it.
+ */
+const TICK_MILLIS = 250;
+
+/**
+ * The clock the waiting readout is measured against: the caller's when it pinned one, otherwise
+ * this window's own, ticking only while a read is actually out. A pinned clock never ticks, which
+ * is what lets a test render one exact moment of the wait.
+ */
+const useClock = (pinned: number | undefined, ticking: boolean): number => {
+	const [now, setNow] = useState(() => pinned ?? Date.now());
+	useEffect(() => {
+		if (pinned !== undefined || !ticking) return;
+		const timer = setInterval(() => setNow(Date.now()), TICK_MILLIS);
+		return () => clearInterval(timer);
+	}, [pinned, ticking]);
+	return pinned ?? now;
+};
+
+/**
+ * How long the read has been out, said in time and nothing else. `role="progressbar"` rather than a
+ * live region on purpose: a reader can query it whenever it wants, and a value that changes four
+ * times a second announces nothing (Pillar 4 — the state *change* is announced, the ticks are not).
+ */
+const ReadingProgress = ({
+	status,
+	now,
+}: {
+	readonly status: ReadingSessions;
+	readonly now: number;
+}): ReactElement => {
+	const elapsed = seconds(elapsedMillis(status, now));
+	const deadline = seconds(status.deadlineMillis);
+	const fraction = elapsedMillis(status, now) / status.deadlineMillis;
+	return (
+		<div className="tuval-session-list-reading" aria-busy="true">
+			<div
+				className="tuval-session-list-progress"
+				role="progressbar"
+				aria-label={COPY.elapsed}
+				aria-valuemin={0}
+				aria-valuemax={deadline}
+				aria-valuenow={elapsed}
+				aria-valuetext={`${elapsed} of ${deadline} seconds elapsed`}
+				style={{"--tuval-elapsed": `${Math.round(fraction * 100)}%`} as Record<string, string>}
+			>
+				<div className="tuval-session-list-progress-fill" />
+			</div>
+			<p className="tuval-session-list-elapsed">{`${elapsed}s elapsed of a ${deadline}s deadline`}</p>
+		</div>
+	);
+};
+
+/**
+ * The sentence a reader is told when the state changes, and nothing while a read is merely running:
+ * it is derived from the tag alone, so the four ticks a second write the same string and the live
+ * region stays silent until the state itself moves.
+ */
+const stateAnnouncement = (status: SessionListStatus): string | null => {
+	if (status._tag === "Reading") return null;
+	if (status._tag === "TimedOut") return COPY.timedOut;
+	if (status._tag === "Refused") return COPY.refused;
+	return status.sessions.length === 1
+		? "1 session read."
+		: `${status.sessions.length} sessions read.`;
+};
 
 /** One backend that could not answer, named with the store's own words rather than a paraphrase. */
 const UnreadableBackends = ({
@@ -81,8 +165,10 @@ const UnreadableBackends = ({
 );
 
 export interface SessionListProps {
-	/** The answer to render. `null` is "nothing has been read yet", never "there are no sessions". */
-	readonly answer: SessionListAnswer | null;
+	/** The read to render, waiting state included — there is no "no state yet" to infer one from. */
+	readonly status: SessionListStatus;
+	/** Ask for the read again. Offered on both terminal failures; absent, neither shows the button. */
+	readonly onRetry?: () => void;
 	/**
 	 * A row was picked, and where it should land: `inline` for plain activation, `new-window` for
 	 * Cmd+Enter. Reported for both targets, because the inline open is this component's own act and
@@ -99,12 +185,13 @@ export interface SessionListProps {
  * it owns — the filter term, the active row, the announcement — is the palette's or this render's,
  * and none of it outlives the window.
  */
-export function SessionList({answer, onActivate, now}: SessionListProps): ReactElement {
+export function SessionList({status, onActivate, onRetry, now}: SessionListProps): ReactElement {
 	const [chosen, setChosen] = useState<string | null>(null);
-	const clock = now ?? Date.now();
+	const clock = useClock(now, status._tag === "Reading");
+	const shown = atClock(status, clock);
 
-	const sessions = answer?._tag === "Listed" ? answer.sessions : [];
-	const unreadable = answer?._tag === "Listed" ? answer.unreadable : [];
+	const sessions = shown._tag === "Listed" ? shown.sessions : [];
+	const unreadable = shown._tag === "Listed" ? shown.unreadable : [];
 
 	const byValue = useMemo(
 		() => new Map(sessions.map((session) => [rowValue(session), session])),
@@ -148,19 +235,21 @@ export function SessionList({answer, onActivate, now}: SessionListProps): ReactE
 		[byValue, onActivate],
 	);
 
-	// Only reached once an answer has landed: before that the palette is `loading` and shows
-	// `loadingLabel` instead, which is the "nothing has been read yet" state.
+	// Only reached once the read has settled: while it is out the palette is `loading` and shows
+	// `loadingLabel` instead, with the elapsed readout beside it.
 	const emptyLabel =
-		answer?._tag === "Refused"
-			? COPY.refused
-			: sessions.length === 0
-				? unreadable.length === 0
-					? COPY.emptyStore
-					: COPY.allRefused
-				: COPY.noMatch;
+		shown._tag === "TimedOut"
+			? COPY.timedOut
+			: shown._tag === "Refused"
+				? COPY.refused
+				: sessions.length === 0
+					? unreadable.length === 0
+						? COPY.emptyStore
+						: COPY.allRefused
+					: COPY.noMatch;
 
-	const error: ReactNode =
-		answer !== null && answer._tag === "Refused" ? failureLine(answer.failure) : undefined;
+	const error: ReactNode = shown._tag === "Refused" ? failureLine(shown.failure) : undefined;
+	const failed = shown._tag === "TimedOut" || shown._tag === "Refused";
 
 	return (
 		<div className="tuval-session-list">
@@ -170,28 +259,54 @@ export function SessionList({answer, onActivate, now}: SessionListProps): ReactE
 				title={TITLE}
 				placeholder={COPY.placeholder}
 				emptyLabel={emptyLabel}
-				loading={answer === null}
+				loading={shown._tag === "Reading"}
 				loadingLabel={COPY.reading}
 				filter={filter}
 				onSelect={select}
 				onKeyDown={keyDown}
 				shortcut={false}
-				announcement={chosen === null ? null : `Chose ${chosen}.`}
+				announcement={chosen === null ? stateAnnouncement(shown) : `Chose ${chosen}.`}
 				{...(error === undefined ? {} : {error})}
 			/>
+			{shown._tag === "Reading" ? <ReadingProgress status={shown} now={clock} /> : null}
+			{shown._tag === "TimedOut" ? (
+				<p className="tuval-session-list-note">{COPY.timedOutNote}</p>
+			) : null}
+			{failed && onRetry !== undefined ? (
+				<div className="tuval-session-list-retry">
+					<Button type="button" variant="tertiary" size="sm" onClick={onRetry}>
+						{COPY.retry}
+					</Button>
+				</div>
+			) : null}
 			{unreadable.length === 0 ? null : <UnreadableBackends backends={unreadable} />}
 		</div>
 	);
 }
 
-/**
- * How the renderer gets the answer to render. The page owns it; the default hands nothing. It is a
- * hook the window calls on every render, so a source that reads state re-renders the window when the
- * answer lands. The window id rides along because a call names the window it came from.
- */
-export type SessionListSource = (window: WindowId) => SessionListAnswer | null;
+/** What the page hands the window: where the read has got to, and how to ask for it again. */
+export interface SessionListRead {
+	readonly status: SessionListStatus;
+	/** Absent when the page cannot re-issue the call — then no retry is offered rather than a dead one. */
+	readonly retry?: () => void;
+}
 
-const nothingRead: SessionListSource = () => null;
+/**
+ * How the renderer gets the read to render. The page owns it; the default asks nobody. It is a hook
+ * the window calls on every render, so a source that reads state re-renders the window when the
+ * reply lands. The window id rides along because a call names the window it came from.
+ */
+export type SessionListSource = (window: WindowId) => SessionListRead;
+
+/**
+ * The default: a read that was never sent. It still starts a clock, so a surface with no socket
+ * behind it walks the same reading-then-timed-out path a real one does rather than claiming a
+ * store it never asked about.
+ */
+const nothingRead: SessionListSource = () => {
+	const [startedAt] = useState(() => Date.now());
+	return {status: reading(startedAt)};
+};
 
 /** How the renderer gets one session's transcript. The default reads none, so a window says so. */
 export type TranscriptSource = (read: TranscriptRead) => TranscriptAnswer | null;
@@ -235,7 +350,7 @@ function SessionListHost({
 	onOpenInNewWindow,
 	onSend,
 }: SessionListWindowOptions & {readonly window: WindowId}): ReactElement {
-	const answer = (useAnswer ?? nothingRead)(window);
+	const read = (useAnswer ?? nothingRead)(window);
 	const [view, setView] = useState<SessionListView>(listView);
 	const [phase, setPhase] = useState<OpenPhase>("reading");
 
@@ -255,7 +370,13 @@ function SessionListHost({
 	const back = useCallback(() => setView(listView), []);
 
 	if (view.kind === "list") {
-		return <SessionList answer={answer} onActivate={activate} />;
+		return (
+			<SessionList
+				status={read.status}
+				onActivate={activate}
+				{...(read.retry === undefined ? {} : {onRetry: read.retry})}
+			/>
+		);
 	}
 
 	const request = openRead(view.session);

--- a/apps/tuval/src/ai-agent/window/index.ts
+++ b/apps/tuval/src/ai-agent/window/index.ts
@@ -36,6 +36,7 @@ export {
 export {
 	SessionList,
 	type SessionListProps,
+	type SessionListRead,
 	type SessionListSource,
 	SessionListWindow,
 	type SessionListWindowOptions,

--- a/apps/tuval/src/ai-agent/window/session-list-window.css
+++ b/apps/tuval/src/ai-agent/window/session-list-window.css
@@ -11,6 +11,46 @@
 	flex: 1;
 }
 
+.tuval-session-list-reading {
+	flex: none;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+
+.tuval-session-list-progress {
+	block-size: 4px;
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+	overflow: hidden;
+}
+
+.tuval-session-list-progress-fill {
+	block-size: 100%;
+	inline-size: var(--tuval-elapsed, 0%);
+	background: var(--accent);
+	transition: inline-size 250ms linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.tuval-session-list-progress-fill {
+		transition: none;
+	}
+}
+
+.tuval-session-list-elapsed,
+.tuval-session-list-note {
+	flex: none;
+	margin: 0;
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.tuval-session-list-retry {
+	flex: none;
+	display: flex;
+}
+
 .tuval-session-list-unreadable {
 	flex: none;
 	padding: var(--s-3);

--- a/apps/tuval/src/ai-agent/window/session-list-window.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/session-list-window.unit.test.tsx
@@ -9,8 +9,10 @@
 import {fireEvent, render, screen} from "@testing-library/react";
 import type {ReactElement} from "react";
 import {describe, expect, it, vi} from "vitest";
-import type {SessionListAnswer} from "../../page/session-list.ts";
+import type {SessionListStatus} from "../../page/session-list.ts";
+import {reading, settled} from "../../page/session-list.ts";
 import type {SessionRow, UnreadableBackend} from "../../protocol/session-list.ts";
+import {SESSION_LIST_DEADLINE_MILLIS} from "../../protocol/session-list.ts";
 import {installDomShims} from "../../shell/ui/dom.testing.ts";
 import {bareSession, claudeSession, NOW, piSession, scrambled} from "./fixtures.ts";
 import type {OpenTarget} from "./opening.ts";
@@ -22,13 +24,22 @@ installDomShims();
 const listed = (
 	sessions: ReadonlyArray<SessionRow>,
 	unreadable: ReadonlyArray<UnreadableBackend> = [],
-): SessionListAnswer => ({_tag: "Listed", sessions, unreadable});
+): SessionListStatus => ({_tag: "Listed", sessions, unreadable});
 
 const open = (
-	answer: SessionListAnswer | null,
+	status: SessionListStatus,
 	onActivate?: (session: SessionRow, target: OpenTarget) => void,
 ): ReactElement => (
-	<SessionList answer={answer} now={NOW} {...(onActivate === undefined ? {} : {onActivate})} />
+	<SessionList status={status} now={NOW} {...(onActivate === undefined ? {} : {onActivate})} />
+);
+
+/** The wait as a window renders it: the call left at `NOW`, and this many milliseconds have passed. */
+const waiting = (elapsed: number, onRetry?: () => void): ReactElement => (
+	<SessionList
+		status={reading(NOW, SESSION_LIST_DEADLINE_MILLIS)}
+		now={NOW + elapsed}
+		{...(onRetry === undefined ? {} : {onRetry})}
+	/>
 );
 
 const rows = (): ReadonlyArray<string> =>
@@ -133,8 +144,8 @@ describe("the keyboard", () => {
 });
 
 describe("the states that are not a list", () => {
-	it("says nothing has been read yet before an answer arrives", () => {
-		render(open(null));
+	it("says it is reading before an answer arrives", () => {
+		render(waiting(0));
 		expect(screen.getByRole("status").textContent).toContain(
 			"Reading every registered backend's sessions",
 		);
@@ -189,13 +200,112 @@ describe("the states that are not a list", () => {
 			open({
 				_tag: "Refused",
 				failure: {
-					tag: "tuval/SessionListTimedOut",
-					message: "the session list did not answer within 10000ms",
+					tag: "tuval/UnknownSpell",
+					message: "no spell is registered at session list",
 					path: ["session", "list"],
 				},
 			}),
 		);
-		expect(document.body.textContent).toContain("did not answer within 10000ms");
+		expect(document.body.textContent).toContain("no spell is registered at session list");
 		expect(rows()).toHaveLength(0);
+	});
+});
+
+describe("the wait", () => {
+	it("counts the elapsed time against the deadline instead of one unchanging sentence", () => {
+		render(waiting(6_000));
+
+		const bar = screen.getByRole("progressbar");
+		expect(bar.getAttribute("aria-valuenow")).toBe("6");
+		expect(bar.getAttribute("aria-valuemax")).toBe("10");
+		expect(bar.getAttribute("aria-valuetext")).toBe("6 of 10 seconds elapsed");
+		expect(document.body.textContent).toContain("6s elapsed of a 10s deadline");
+	});
+
+	it("marks the waiting region busy and leaves the ticking readout out of the live region", () => {
+		const {rerender} = render(waiting(3_000));
+		const region = document.querySelector(".tuval-session-list-reading");
+		expect(region?.getAttribute("aria-busy")).toBe("true");
+		const announce = document.querySelector(".kp-command-palette__announce");
+		expect(announce?.textContent).toBe("");
+
+		rerender(waiting(4_000));
+		expect(document.body.textContent).toContain("4s elapsed of a 10s deadline");
+		expect(document.querySelector(".kp-command-palette__announce")?.textContent).toBe("");
+	});
+
+	it("names no backend while it waits: one reply answers the whole union", () => {
+		render(waiting(6_000));
+		expect(document.body.textContent).not.toContain("claude");
+		expect(document.body.textContent).not.toContain("pi");
+		expect(screen.queryByRole("alert")).toBeNull();
+	});
+
+	it("ends the wait at the deadline rather than reading forever", () => {
+		render(waiting(SESSION_LIST_DEADLINE_MILLIS));
+
+		expect(screen.queryByRole("progressbar")).toBeNull();
+		expect(screen.getByRole("status").textContent).toContain(
+			"ran past its deadline before any backend answered",
+		);
+		expect(document.querySelector(".kp-command-palette__announce")?.textContent).toContain(
+			"ran past its deadline",
+		);
+	});
+
+	it("says a timed-out read is not an empty store", () => {
+		render(waiting(SESSION_LIST_DEADLINE_MILLIS));
+
+		expect(document.body.textContent).not.toContain("No sessions on this machine yet.");
+		expect(document.body.textContent).toContain("says nothing about what is on this machine");
+	});
+
+	it("renders the kernel's own timeout as the timed-out state, not as a generic refusal", () => {
+		render(
+			open(
+				settled({
+					_tag: "Refused",
+					failure: {
+						tag: "tuval/SessionListTimedOut",
+						message: "the session list did not answer within 10000ms",
+						path: ["session", "list"],
+					},
+				}),
+			),
+		);
+
+		expect(screen.getByRole("status").textContent).toContain(
+			"ran past its deadline before any backend answered",
+		);
+		expect(document.body.textContent).not.toContain("The kernel refused the session list.");
+		expect(document.body.textContent).not.toContain("No sessions on this machine yet.");
+	});
+
+	it("offers a retry on the timed-out state and re-issues the read", () => {
+		const again = vi.fn();
+		render(waiting(SESSION_LIST_DEADLINE_MILLIS, again));
+
+		fireEvent.click(screen.getByRole("button", {name: "Read the sessions again"}));
+		expect(again).toHaveBeenCalledTimes(1);
+	});
+
+	it("offers the same retry on a refusal, and none while the read is still out", () => {
+		const again = vi.fn();
+		const {unmount} = render(
+			<SessionList
+				status={{
+					_tag: "Refused",
+					failure: {tag: "tuval/UnknownSpell", message: "no spell there"},
+				}}
+				now={NOW}
+				onRetry={again}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", {name: "Read the sessions again"}));
+		expect(again).toHaveBeenCalledTimes(1);
+		unmount();
+
+		render(waiting(2_000, again));
+		expect(screen.queryByRole("button", {name: "Read the sessions again"})).toBeNull();
 	});
 });

--- a/apps/tuval/src/ai-agent/window/session-open.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/session-open.unit.test.tsx
@@ -56,7 +56,7 @@ const host = {windowId: WindowId.make("w-1")} as WindowHost;
 /** The window as a page mounts it, at whatever seams a test needs. */
 const mount = (options: SessionListWindowOptions = {}): ReactElement => {
 	const renderer = sessionListWindow({
-		useAnswer: () => listed(scrambled),
+		useAnswer: () => ({status: listed(scrambled)}),
 		...options,
 	});
 	return renderer.render(host) as ReactElement;
@@ -103,7 +103,7 @@ describe("activating a row inline", () => {
 	it("says a session it cannot open is unopenable rather than rendering it empty", () => {
 		// The oldest row is the one whose store reported no folder, so it is the one Enter lands on
 		// when it is the only row on offer.
-		const renderer = sessionListWindow({useAnswer: () => listed([bareSession])});
+		const renderer = sessionListWindow({useAnswer: () => ({status: listed([bareSession])})});
 		render(renderer.render(host) as ReactElement);
 		fireEvent.keyDown(field(), {key: "Enter"});
 

--- a/apps/tuval/src/page/renderers.tsx
+++ b/apps/tuval/src/page/renderers.tsx
@@ -28,7 +28,7 @@
 import features from "virtual:tuval/features";
 import {Effect, Fiber, Stream} from "effect";
 import type {ReactElement} from "react";
-import {useEffect, useState} from "react";
+import {useCallback, useEffect, useState} from "react";
 import {isAiAgentSessionState} from "../ai-agent/core/snapshot.ts";
 import {isSessionListState} from "../ai-agent/renderer-ref.ts";
 import {
@@ -48,7 +48,13 @@ import type {PageAttachment} from "../shell/transport/browser.ts";
 import type {WindowHost} from "../shell/window/index.ts";
 import {windowRenderer} from "../shell/window/index.ts";
 import {Pending, type ReadableRenderer, readsState} from "./readable-state.tsx";
-import {readSessionList, type SessionListAnswer, sessionListCall} from "./session-list.ts";
+import {
+	reading,
+	readSessionList,
+	type SessionListAnswer,
+	sessionListCall,
+	settled,
+} from "./session-list.ts";
 
 /**
  * One process's public state, live. The stream never fails and ends on `ProcessGone`, so the hook
@@ -114,14 +120,24 @@ function LogRenderer({host}: {readonly host: WindowHost<LogState>}): ReactElemen
 export type SpellCaller = PageAttachment["call"];
 
 /**
- * The session list, read from the kernel. One call per window, sent when the window mounts and
+ * The session list, read from the kernel. One call per attempt, sent when the window mounts and
  * matched to its reply by the `CallId` it minted, so two open pickers never read each other's answer
- * (`./session-list.ts`). A socket that goes away is no answer at all: the window stays on its
- * reading state, and the desk's own connection banner is what says the link is gone.
+ * (`./session-list.ts`). A socket that goes away is no answer at all: the read stays out until its
+ * deadline passes, and the desk's own connection banner is what says the link is gone.
+ *
+ * Retry is the second correlation, and the attempt number is what carries it: a superseded call's
+ * reply still passes the `CallId` check for the call *it* answered, so the landing is refused unless
+ * the attempt it was sent for is still the current one (#8280).
  */
 const sessionListSource = (call: SpellCaller): SessionListSource => {
 	const useSessionListAnswer: SessionListSource = (window) => {
-		const [answer, setAnswer] = useState<SessionListAnswer | null>(null);
+		const [attempt, setAttempt] = useState(0);
+		const [startedAt, setStartedAt] = useState(() => Date.now());
+		const [landed, setLanded] = useState<{
+			readonly attempt: number;
+			readonly answer: SessionListAnswer;
+		} | null>(null);
+
 		useEffect(() => {
 			const spell = sessionListCall(window);
 			const fiber = Effect.runFork(
@@ -129,15 +145,26 @@ const sessionListSource = (call: SpellCaller): SessionListSource => {
 					Effect.flatMap((reply) =>
 						Effect.sync(() => {
 							const read = readSessionList(spell, reply);
-							if (read !== null) setAnswer(read);
+							if (read !== null) setLanded({attempt, answer: read});
 						}),
 					),
 					Effect.catchCause(() => Effect.void),
 				),
 			);
 			return () => void Effect.runFork(Fiber.interrupt(fiber));
-		}, [window]);
-		return answer;
+		}, [call, window, attempt]);
+
+		const retry = useCallback(() => {
+			setLanded(null);
+			setStartedAt(Date.now());
+			setAttempt((current) => current + 1);
+		}, []);
+
+		const answer = landed !== null && landed.attempt === attempt ? landed.answer : null;
+		return {
+			status: answer === null ? reading(startedAt) : settled(answer),
+			retry,
+		};
 	};
 	return useSessionListAnswer;
 };

--- a/apps/tuval/src/page/session-list.ts
+++ b/apps/tuval/src/page/session-list.ts
@@ -22,7 +22,12 @@ import {CallId} from "../protocol/ids.ts";
 import type {SpellFailure, SpellReply} from "../protocol/messages.ts";
 import {PROTOCOL_VERSION, SpellCall} from "../protocol/messages.ts";
 import type {SessionRow, UnreadableBackend} from "../protocol/session-list.ts";
-import {SESSION_LIST_CALL_PATH, SessionList} from "../protocol/session-list.ts";
+import {
+	SESSION_LIST_CALL_PATH,
+	SESSION_LIST_DEADLINE_MILLIS,
+	SESSION_LIST_TIMED_OUT_TAG,
+	SessionList,
+} from "../protocol/session-list.ts";
 
 /** The rows a window is handed, and the backends that could not be read beside them. */
 export interface ListedSessions {
@@ -37,7 +42,66 @@ export interface RefusedSessions {
 	readonly failure: SpellFailure;
 }
 
+/**
+ * The call is out and no reply has landed. It carries the clock a window renders against — when the
+ * call left and the bound it runs against — because "still reading" with nothing beside it is the
+ * one unchanging sentence #8280 exists to remove.
+ */
+export interface ReadingSessions {
+	readonly _tag: "Reading";
+	readonly startedAt: number;
+	readonly deadlineMillis: number;
+}
+
+/**
+ * The deadline won. Its own state rather than a refusal with a tag to read, because a timed-out
+ * read is neither an empty store nor an unreadable backend, and a surface that folds it into either
+ * of those says something about the store that nobody measured.
+ */
+export interface TimedOutSessions {
+	readonly _tag: "TimedOut";
+	readonly deadlineMillis: number;
+}
+
 export type SessionListAnswer = ListedSessions | RefusedSessions;
+
+/** Every state the read can end in. `Reading` is not among them, which is the point of the split. */
+export type SettledSessions = ListedSessions | RefusedSessions | TimedOutSessions;
+
+/** What a window renders: the read, at whatever point it has reached. */
+export type SessionListStatus = ReadingSessions | SettledSessions;
+
+export const reading = (
+	startedAt: number,
+	deadlineMillis: number = SESSION_LIST_DEADLINE_MILLIS,
+): ReadingSessions => ({_tag: "Reading", startedAt, deadlineMillis});
+
+/**
+ * One landed answer as the state it really is. A refusal carrying the kernel's own timeout tag is
+ * the deadline having fired, so it becomes `TimedOut` here rather than at every surface that
+ * renders a refusal — one reading of that tag, in the module that already owns the wire.
+ */
+export const settled = (
+	answer: SessionListAnswer,
+	deadlineMillis: number = SESSION_LIST_DEADLINE_MILLIS,
+): SettledSessions =>
+	answer._tag === "Refused" && answer.failure.tag === SESSION_LIST_TIMED_OUT_TAG
+		? {_tag: "TimedOut", deadlineMillis}
+		: answer;
+
+/**
+ * The status at a clock. A read whose deadline has passed with no reply is timed out whatever the
+ * transport does next: the kernel bounds the walk at the same number, so a surface still saying
+ * "reading" past it is waiting on an answer that is not coming.
+ */
+export const atClock = (status: SessionListStatus, now: number): SessionListStatus =>
+	status._tag === "Reading" && now - status.startedAt >= status.deadlineMillis
+		? {_tag: "TimedOut", deadlineMillis: status.deadlineMillis}
+		: status;
+
+/** How long the read has been out, never past its own bound and never negative. */
+export const elapsedMillis = (status: ReadingSessions, now: number): number =>
+	Math.min(Math.max(now - status.startedAt, 0), status.deadlineMillis);
 
 /**
  * One call for the whole list. The id is minted here — the caller keeps it and hands it back to

--- a/apps/tuval/src/page/session-list.unit.test.ts
+++ b/apps/tuval/src/page/session-list.unit.test.ts
@@ -7,8 +7,19 @@
 import {assert, describe, it} from "vitest";
 import {CallId} from "../protocol/ids.ts";
 import {PROTOCOL_VERSION, SpellReplyError, SpellReplyOk} from "../protocol/messages.ts";
-import {SESSION_LIST_CALL_PATH, SESSION_LIST_PATH} from "../protocol/session-list.ts";
-import {readSessionList, sessionListCall} from "./session-list.ts";
+import {
+	SESSION_LIST_CALL_PATH,
+	SESSION_LIST_DEADLINE_MILLIS,
+	SESSION_LIST_PATH,
+} from "../protocol/session-list.ts";
+import {
+	atClock,
+	elapsedMillis,
+	reading,
+	readSessionList,
+	sessionListCall,
+	settled,
+} from "./session-list.ts";
 
 const okReply = (id: CallId, result: unknown) =>
 	new SpellReplyOk({type: "spell.reply", version: PROTOCOL_VERSION, id, ok: true, result});
@@ -103,6 +114,58 @@ describe("the page's session list", () => {
 		assert.strictEqual(
 			answer?._tag === "Refused" ? answer.failure.tag : undefined,
 			"tuval/BadSessionList",
+		);
+	});
+});
+
+describe("where the read has got to", () => {
+	const started = 1_000_000;
+	const outstanding = reading(started, SESSION_LIST_DEADLINE_MILLIS);
+
+	it("counts elapsed time from when the call left, clamped to its own bound", () => {
+		assert.strictEqual(elapsedMillis(outstanding, started + 6_000), 6_000);
+		assert.strictEqual(elapsedMillis(outstanding, started - 5), 0);
+		assert.strictEqual(
+			elapsedMillis(outstanding, started + SESSION_LIST_DEADLINE_MILLIS + 9_000),
+			SESSION_LIST_DEADLINE_MILLIS,
+		);
+	});
+
+	it("stays reading until the deadline, and is timed out from the moment it passes", () => {
+		assert.strictEqual(atClock(outstanding, started + 9_999)._tag, "Reading");
+
+		const past = atClock(outstanding, started + SESSION_LIST_DEADLINE_MILLIS);
+		assert.strictEqual(past._tag, "TimedOut");
+		assert.strictEqual(
+			past._tag === "TimedOut" ? past.deadlineMillis : 0,
+			SESSION_LIST_DEADLINE_MILLIS,
+		);
+	});
+
+	it("leaves a landed answer where it is, whatever the clock says", () => {
+		const landed = settled({_tag: "Listed", sessions: [], unreadable: []});
+		assert.strictEqual(atClock(landed, started + 60_000)._tag, "Listed");
+	});
+
+	it("reads the kernel's own timeout tag as the timed-out state, not as a refusal", () => {
+		const status = settled({
+			_tag: "Refused",
+			failure: {tag: "tuval/SessionListTimedOut", message: "did not answer within 10000ms"},
+		});
+
+		assert.strictEqual(status._tag, "TimedOut");
+	});
+
+	it("leaves every other refusal a refusal, so the kernel's own sentence still reaches a reader", () => {
+		const status = settled({
+			_tag: "Refused",
+			failure: {tag: "tuval/UnknownSpell", message: "no spell is registered there"},
+		});
+
+		assert.strictEqual(status._tag, "Refused");
+		assert.strictEqual(
+			status._tag === "Refused" ? status.failure.message : "",
+			"no spell is registered there",
 		);
 	});
 });

--- a/apps/tuval/src/protocol/session-list.ts
+++ b/apps/tuval/src/protocol/session-list.ts
@@ -33,6 +33,18 @@ export const SESSION_LIST_PROGRAM = "ai-agent-sessions";
 export const SESSION_LIST_CALL_PATH = [SESSION_LIST_PROGRAM, ...SESSION_LIST_PATH] as const;
 
 /**
+ * How long the whole union may take before the call answers with a refusal instead of waiting. It
+ * lives here beside the call's address because both ends need it: the kernel bounds the walk with
+ * it (`../ai-agent/session-list.ts`) and a page counts elapsed time against it while the reply is
+ * out (`../page/session-list.ts`). Two spellings of one bound would let a window promise a deadline
+ * the kernel does not keep.
+ */
+export const SESSION_LIST_DEADLINE_MILLIS = 10_000;
+
+/** The failure tag a fired deadline arrives under, so a page can tell a timeout from a refusal. */
+export const SESSION_LIST_TIMED_OUT_TAG = "tuval/SessionListTimedOut";
+
+/**
  * One session. The four optional fields are optional because a real store leaves them out, and an
  * absent key stays absent across the wire — a row renders an absence as an absence rather than as a
  * plausible-looking zero or empty string.


### PR DESCRIPTION
The session picker stopped saying one unchanging sentence while it waits.

The founder's ruling on #8280 (2026-09-07) is the shape: elapsed time against the known deadline
plus honest terminal states, and no per-backend progress. That is what this builds, page-side only —
no new progress channel, no kernel deadline redesign, #8165 and #8245 untouched.

What changed:

- `SESSION_LIST_DEADLINE_MILLIS` and the `tuval/SessionListTimedOut` tag moved to
  `apps/tuval/src/protocol/session-list.ts`, so the kernel's bound and the page's clock are one
  number instead of two spellings.
- `apps/tuval/src/page/session-list.ts` gained the read's state machine: `Reading` (carrying when
  the call left and its deadline) and `TimedOut` beside `Listed` / `Refused`, with `settled` folding
  the kernel's own timeout tag into `TimedOut`, `atClock` ending a wait whose deadline has passed,
  and `elapsedMillis` clamped to that bound.
- The window's seam is now that state plus a `retry`, not `answer === null`. It ticks a clock while
  a read is out, shows `Ns elapsed of a 10s deadline` on an `aria-busy` region whose bar is a
  `role="progressbar"` measuring *time*, and offers a retry on both terminal failures.
- A timed-out read gets its own sentence and says outright that it read nothing, so it never reads
  as an empty store or as an unreadable backend.
- Retry keeps the correlation twice over: the outstanding fiber is interrupted and a landed reply is
  dropped unless the attempt it was sent for is still current.

Accessibility: the live region carries the state *change* only — the announcement string is derived
from the state's tag, so the four ticks a second write the same text and announce nothing. The
elapsed numbers live on the progressbar, which a reader queries rather than being read at.

Fixes #8280

## Deviations

- **Out-of-scope change** — **Said:** #8280 names the window, `session-list.ts` and the page.
  **Did:** also moved the deadline constant and the timeout tag out of the kernel module into
  `protocol/session-list.ts`. **Why:** the window has to count against the same bound the kernel
  enforces, and the page cannot import the kernel module (it pulls `node:*` and the backends);
  two literals would let the window promise a deadline the kernel does not keep.
  **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** add coverage for the new states.
  **Did:** also rewrote the existing "shows a refused call as the kernel's own sentence" case to use
  a non-timeout failure. **Why:** it used the timeout tag as its example refusal, and that tag now
  renders as the timed-out state by design, so the case no longer tested what it names.
  **Disposition:** stated here; a timed-out reply has its own case beside it.
- **Known defect left unfixed** — **Said:** nothing about the CSS. **Did:** `build check` reports
  `apps/tuval/src/ai-agent/window/session-list-window.css` as unvalidated. **Why:** no surface in
  this repo validates CSS. **Disposition:** stated here, nothing to run.
