### PR TITLE
fix: A per-turn refusal settles every other in-flight Tuval send as uncertain, including live ones

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -24,7 +24,7 @@ import {
 	type WindowOmission,
 } from "../ports/index.ts";
 import {START_ERROR} from "./failures.ts";
-import {markTurnRunning, settleAccepted, settlePending} from "./sends.ts";
+import {markTurnRunning, settleAccepted, settleEndedSession, settleFailedTurn} from "./sends.ts";
 import {type AiAgentSessionState, settleTurn, type UsageLedger} from "./state.ts";
 
 /** How much tail one session keeps. Absent, the window module's own defaults apply. */
@@ -244,10 +244,10 @@ export const foldEvent = (
 		// `settleAccepted` reaches that running send and no other. Neither reads "whichever send is
 		// pending", which is how a later turn accepted an older, never-started one (#8107).
 		//
-		// `gone` is the other half: a session that ended under a send in flight can never answer
-		// for it, so every send in flight becomes recoverable instead. Refusals reach the send by
-		// their own arms below, and they arrive before this line does — both rows push the turn's
-		// failure ahead of the phase that closes it.
+		// `gone` is the other half, and it is the terminal arm: a session that ended under a send in
+		// flight can never answer for it, so `settleEndedSession` makes every one of them
+		// recoverable. Refusals reach the send by their own arms below, and they arrive before this
+		// line does — both rows push the turn's failure ahead of the phase that closes it.
 		case "phase": {
 			if (coreOwned(event.phase)) return state;
 			// Any phase but `prompting` is the turn over, and nothing will supersede a partial the
@@ -259,7 +259,7 @@ export const foldEvent = (
 					...turn,
 					phase: event.phase,
 					interruption: interruptionAfter(turn, event.phase),
-					sends: settlePending(turn.sends, null),
+					sends: settleEndedSession(turn.sends, null),
 				};
 			}
 			return {
@@ -308,6 +308,10 @@ export const foldEvent = (
 		// same to the window whichever channel carried it. Routing it through `event` is what keeps
 		// the machine's identity filter over it: a late refusal from a session this process has
 		// already replaced is dropped rather than failing its successor (#8018).
+		//
+		// This is the per-turn arm, not the terminal one: `phaseAfterFailure` can walk the session
+		// back to `ready`, so `settleFailedTurn` settles the send this failure is about and leaves
+		// every other in flight `pending` for its own turn's end (#8236).
 		case "failure": {
 			const phase = phaseAfterFailure(state, event.failure);
 			const turn = settleTurn(state);
@@ -316,7 +320,7 @@ export const foldEvent = (
 				phase,
 				interruption: interruptionAfter(turn, phase),
 				failure: event.failure,
-				sends: settlePending(turn.sends, event.failure),
+				sends: settleFailedTurn(turn.sends, event.failure),
 			};
 		}
 	}

--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -17,8 +17,10 @@ import {
 	userItem,
 } from "../../ai-agent-fixtures/transcripts.ts";
 import type {TranscriptItem, TranscriptPayload} from "../ports/index.ts";
+import {PROMPT_ERROR} from "./failures.ts";
 import {foldEvent, foldItem, upsertItem, type WindowLimits} from "./fold.ts";
-import {initialState} from "./state.ts";
+import type {SendOutcome} from "./sends.ts";
+import {type AiAgentSessionState, initialState} from "./state.ts";
 
 const empty: TranscriptPayload = {items: [], omitted: {items: 0, bytes: 0, reason: "none"}};
 
@@ -179,5 +181,51 @@ describe("folding a subagent slot", () => {
 	it("leaves a worker running while the turn it belongs to is still going", () => {
 		const running = foldEvent(fold(), {kind: "phase", phase: "prompting"}, limits);
 		expect(running.subagents["call-1"]?.status).toBe("running");
+	});
+});
+
+/**
+ * #8236's ruling, at the arms rather than at the ledger: a per-turn failure leaves the session
+ * alive, so it settles only the send it is about, and `gone` is the terminal arm that settles every
+ * one of them.
+ */
+describe("folding a failure and a `gone` under two sends in flight", () => {
+	const limits: WindowLimits = {};
+	const refusal = {tag: PROMPT_ERROR, reason: "refused", detail: "the layer refused the handoff"};
+	const inFlight: ReadonlyArray<SendOutcome> = [
+		{key: "first", state: "pending", turn: "running"},
+		{key: "second", state: "pending", turn: "unstarted"},
+	];
+	const prompting: AiAgentSessionState = {
+		...initialState("/repo"),
+		phase: "prompting",
+		sends: inFlight,
+	};
+
+	it("settles only the failed send and keeps the other waiting for its own turn", () => {
+		const failed = foldEvent(prompting, {kind: "failure", failure: refusal}, limits);
+		expect(failed.phase).toBe("ready");
+		expect(failed.sends).toEqual([
+			{key: "first", state: "refused", failure: refusal},
+			{key: "second", state: "pending", turn: "unstarted"},
+		]);
+	});
+
+	it("accepts the send that outlived the refusal when its own turn ends", () => {
+		const failed = foldEvent(prompting, {kind: "failure", failure: refusal}, limits);
+		const running = foldEvent(failed, {kind: "phase", phase: "prompting"}, limits);
+		const ended = foldEvent(running, {kind: "phase", phase: "ready"}, limits);
+		expect(ended.sends).toEqual([
+			{key: "first", state: "refused", failure: refusal},
+			{key: "second", state: "accepted"},
+		]);
+	});
+
+	it("settles every send in flight when the session goes", () => {
+		const gone = foldEvent(prompting, {kind: "phase", phase: "gone"}, limits);
+		expect(gone.sends).toEqual([
+			{key: "first", state: "uncertain", failure: null},
+			{key: "second", state: "uncertain", failure: null},
+		]);
 	});
 });

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -58,7 +58,8 @@ export {
 	sendOutcome,
 	settleAccepted,
 	settledBy,
-	settlePending,
+	settleEndedSession,
+	settleFailedTurn,
 	type TurnProgress,
 } from "./sends.ts";
 export {

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -47,7 +47,7 @@ import {
 	eventsSub,
 } from "./messages.ts";
 import {enqueue, isQueueFull, type QueuedPrompt, queueLimit, releaseQueued} from "./queue.ts";
-import {noteSend, settledBy, settlePending} from "./sends.ts";
+import {noteSend, settledBy, settleFailedTurn} from "./sends.ts";
 import {loadCheckpoint} from "./snapshot.ts";
 import {
 	type AgentFailure,
@@ -142,7 +142,9 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 		const phase = phaseAfterFailure(state, failure);
 		// The turn is over however the failure reached the machine, so a partial the stream
 		// left in the tail — and any subagent under that turn — settles here too
-		// (`./state.ts`, `settleTurn`).
+		// (`./state.ts`, `settleTurn`). The *session* need not be: `phaseAfterFailure` can return
+		// it to `ready`, so this is the per-turn arm and only the failure's own send settles
+		// (#8236). The terminal arm is the `gone` phase in `./fold.ts`.
 		const turn = settleTurn(state);
 		return settleQueue([
 			{
@@ -150,7 +152,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 				phase,
 				interruption: interruptionAfter(turn, phase),
 				failure,
-				sends: settlePending(turn.sends, failure),
+				sends: settleFailedTurn(turn.sends, failure),
 			},
 			noCmds,
 		]);

--- a/apps/tuval/src/ai-agent/core/sends.ts
+++ b/apps/tuval/src/ai-agent/core/sends.ts
@@ -184,22 +184,31 @@ export const settleAccepted = (sends: ReadonlyArray<SendOutcome>): ReadonlyArray
 };
 
 /**
- * Settle every send in flight when something happened to the session as a whole — a transport
- * failure, a phase that went `gone`, a process that came back from a checkpoint.
- *
- * The failure names no key, so the send it is about is the one whose turn was running, or the
- * oldest in flight when none had begun; that one takes the arm its `reason` earns. Every other send
- * in flight is `uncertain` instead: the session ended under a turn the backend never began for it,
- * and nothing here can say whether the text crossed — which is the recoverable arm that never
- * resends on its own. Leaving them `pending` is the alternative, and it strands them for ever,
- * because a settled session narrates no more turns to accept them on (#8107).
+ * Which send a keyless outcome is about: the one whose turn was running, or the oldest in flight
+ * when none had begun. `null` when the failure names some other call, or nothing is in flight.
  */
-export const settlePending = (
+const namedByOrder = (
+	sends: ReadonlyArray<SendOutcome>,
+	failure: AgentFailure | null,
+): PendingSend | null => {
+	if (failure !== null && sendAfterFailure(failure) === null) return null;
+	return runningSend(sends) ?? pendingSend(sends);
+};
+
+/**
+ * The session is over — a phase that went `gone`, a process back from a checkpoint — so settle every
+ * send in flight.
+ *
+ * The failure names no key, so the send it is about takes the arm its `reason` earns and every
+ * other in flight is `uncertain`: nothing here can say whether their text crossed, and that is the
+ * recoverable arm that never resends on its own. Leaving them `pending` strands them for ever,
+ * because a dead session narrates no more turns to accept them on (#8107).
+ */
+export const settleEndedSession = (
 	sends: ReadonlyArray<SendOutcome>,
 	failure: AgentFailure | null,
 ): ReadonlyArray<SendOutcome> => {
-	if (failure !== null && sendAfterFailure(failure) === null) return sends;
-	const named = runningSend(sends) ?? pendingSend(sends);
+	const named = namedByOrder(sends, failure);
 	if (named === null) return sends;
 	return sends.map((held) => {
 		if (held.state !== "pending") return held;
@@ -207,4 +216,25 @@ export const settlePending = (
 			? settledBy(held.key, failure)
 			: {key: held.key, state: "uncertain", failure};
 	});
+};
+
+/**
+ * One turn failed and the session survived it, so settle only the send that failure is about.
+ *
+ * `phaseAfterFailure` walks a `prompting` session back to `ready`, and the design admits two sends
+ * in flight at once — so the other rows still have their own turns coming and stay `pending` with
+ * their `turn` progress intact, to be accepted under their own keys when those turns end.
+ * Rewriting them `uncertain` here left a send the ledger could never settle truthfully: once a row
+ * leaves `pending`, `runningSend` no longer reaches it and its turn's end accepts nothing, so the
+ * operator was told text might not have crossed when it did (#8236).
+ *
+ * The failure is never `null` on this arm: a session that survives failed at something, and the
+ * keyless session-wide settle is `settleEndedSession`'s.
+ */
+export const settleFailedTurn = (
+	sends: ReadonlyArray<SendOutcome>,
+	failure: AgentFailure,
+): ReadonlyArray<SendOutcome> => {
+	const named = namedByOrder(sends, failure);
+	return named === null ? sends : noteSend(sends, settledBy(named.key, failure));
 };

--- a/apps/tuval/src/ai-agent/core/sends.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/sends.unit.test.ts
@@ -27,7 +27,8 @@ import {
 	sendOutcome,
 	settleAccepted,
 	settledBy,
-	settlePending,
+	settleEndedSession,
+	settleFailedTurn,
 } from "./sends.ts";
 
 const failure = (tag: string, reason: string | null): AgentFailure => ({
@@ -82,20 +83,20 @@ describe("the ledger", () => {
 		const held = noteSend(noteSend([], {key: "old", state: "accepted"}), pending("live"));
 		expect(pendingSend(held)?.key).toBe("live");
 
-		const refused = settlePending(held, failure(PROMPT_ERROR, "refused"));
+		const refused = settleFailedTurn(held, failure(PROMPT_ERROR, "refused"));
 		expect(sendOutcome(refused, "live")).toMatchObject({state: "refused"});
 		expect(sendOutcome(refused, "old")).toEqual({key: "old", state: "accepted"});
 
 		// The failure names another call, so the send in flight is still in flight.
-		expect(settlePending(held, failure(MODE_UNSUPPORTED, null))).toEqual(held);
+		expect(settleFailedTurn(held, failure(MODE_UNSUPPORTED, null))).toEqual(held);
 		// Nothing in flight, nothing to settle.
 		expect(
-			settlePending([{key: "old", state: "accepted"}], failure(PROMPT_ERROR, "refused")),
+			settleFailedTurn([{key: "old", state: "accepted"}], failure(PROMPT_ERROR, "refused")),
 		).toEqual([{key: "old", state: "accepted"}]);
 	});
 
 	it("settles a send the session lost its footing under as uncertain, with no failure to name", () => {
-		expect(settlePending([pending("live")], null)).toEqual([
+		expect(settleEndedSession([pending("live")], null)).toEqual([
 			{key: "live", state: "uncertain", failure: null},
 		]);
 	});
@@ -163,13 +164,45 @@ describe("the ledger", () => {
 	it("settles every send in flight when the session ends under them", () => {
 		const refusal = failure(PROMPT_ERROR, "refused");
 		const running = markTurnRunning([pending("first"), pending("second")]);
-		expect(settlePending(running, refusal)).toEqual([
+		expect(settleEndedSession(running, refusal)).toEqual([
 			{key: "first", state: "refused", failure: refusal},
 			{key: "second", state: "uncertain", failure: refusal},
 		]);
-		expect(settlePending(running, null)).toEqual([
+		expect(settleEndedSession(running, null)).toEqual([
 			{key: "first", state: "uncertain", failure: null},
 			{key: "second", state: "uncertain", failure: null},
+		]);
+	});
+
+	/**
+	 * #8236's ruling: the session survives a per-turn refusal, so the sends it is not about keep
+	 * their own turns coming. Rewriting them `uncertain` here made a row `runningSend` could no
+	 * longer reach, and its turn's end then accepted nothing — the operator was told text might not
+	 * have crossed when it did.
+	 */
+	it("leaves the sends a per-turn failure is not about pending, with their turn progress", () => {
+		const refusal = failure(PROMPT_ERROR, "refused");
+		const running = markTurnRunning([pending("first"), pending("second")]);
+		expect(settleFailedTurn(running, refusal)).toEqual([
+			{key: "first", state: "refused", failure: refusal},
+			pending("second"),
+		]);
+
+		const bothRunning = markTurnRunning(running);
+		expect(settleFailedTurn(bothRunning, refusal)).toEqual([
+			{key: "first", state: "refused", failure: refusal},
+			{key: "second", state: "pending", turn: "running"},
+		]);
+	});
+
+	it("accepts a send that outlived a per-turn refusal when its own turn ends", () => {
+		const refusal = failure(PROMPT_ERROR, "refused");
+		const after = settleFailedTurn(markTurnRunning([pending("first"), pending("second")]), refusal);
+
+		const second = settleAccepted(markTurnRunning(after));
+		expect(second).toEqual([
+			{key: "first", state: "refused", failure: refusal},
+			{key: "second", state: "accepted"},
 		]);
 	});
 

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -399,10 +399,11 @@ const markInterrupted = (
  * there is nothing left to flush it, and it is released to its window as an unsent send the same way
  * an interrupted queue is — recoverable, never resent on the operator's behalf.
  *
- * A send still in flight comes back `uncertain` rather than dropped. The process went away between
- * handing the text to the layer and hearing what became of it, so nobody can say whether it landed
- * — and a window that reopens on this session offers its operator that text rather than resending
- * it.
+ * A send still in flight comes back `uncertain` rather than dropped — every one of them, because
+ * this is a terminal settle like `gone`'s and not a per-turn failure (#8236). The process went away
+ * between handing the text to the layer and hearing what became of it, so nobody can say whether it
+ * landed — and a window that reopens on this session offers its operator that text rather than
+ * resending it.
  *
  * No subagent comes back running. Nothing is pumping one any more — the layer that was reading its
  * frames went with the process — so a row still claiming to be live is a lie the operator cannot

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -132,6 +132,23 @@ describe("a restored session and its subagents", () => {
 	it("keeps the rows a worker collected, so a view open on it is not blanked", () => {
 		expect(restore(loaded).subagents["call-1"]?.items).toEqual(items);
 	});
+
+	// A restore is terminal like `gone` and not a per-turn failure: the process that was running
+	// these turns is gone, so a row left `pending` waits for a turn nobody will narrate (#8236).
+	it("brings every send that was in flight back uncertain, however far its turn had got", () => {
+		const back = restore({
+			...loaded,
+			phase: "prompting",
+			sends: [
+				{key: "first", state: "pending", turn: "running"},
+				{key: "second", state: "pending", turn: "unstarted"},
+			],
+		});
+		expect(back.sends).toEqual([
+			{key: "first", state: "uncertain", failure: null},
+			{key: "second", state: "uncertain", failure: null},
+		]);
+	});
 });
 
 // #8160's coalescing, extended rather than joined by a second throttle: the two fields that move


### PR DESCRIPTION
`settlePending` settled every send in flight on all three of its call sites. That is right when the
session is over, but two of the sites are per-turn failures the session survives: `phaseAfterFailure`
walks a `prompting` session back to `ready`, and the design admits two sends in flight at once. A
plain per-turn refusal therefore rewrote a second, still-live send to `uncertain` — and once a row
leaves `pending`, `runningSend` no longer reaches it, so its turn's end accepted nothing and the
operator was told text might not have crossed when it did.

Per the founder's ruling on the issue (amendment dated 2026-09-07): unrelated sends stay `pending`
after a per-turn refusal while the session is alive.

`settlePending` is now two named functions, so each call site says which arm it is:

- `settleFailedTurn(sends, failure)` — the session survives, so only the send the failure is about
  settles; every other keeps its row and its `turn` progress and waits for its own turn's end. Used
  by `fold.ts`'s `failure` arm and `machine.ts`'s `failed` handler. Its `failure` is not nullable —
  a session that survives failed at something.
- `settleEndedSession(sends, failure)` — the terminal arm, unchanged behaviour. Used by `fold.ts`'s
  `gone` phase arm. `state.ts`'s `restore` keeps its own settle-all mapping.

Tests cover two sends in flight through a keyless refusal with the second later accepted under its
own key, at the ledger (`sends.unit.test.ts`) and through the fold (`fold.unit.test.ts`), plus a
`gone` phase and a checkpoint restore under two in-flight sends asserting both settle.

Fixes #8236

## Deviations

None.
