### PR TITLE
feat: Reading a Tuval session read-only still starts its backend transport

### DIFF
--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
@@ -43,12 +43,19 @@ import {
 	PromptError,
 	StartError,
 	ThinkingUnsupported,
+	TranscriptError,
 	type TransportError,
 	UnknownRequest,
 } from "./errors.ts";
 import type {AgentScript, ScriptedAnswer, ScriptedPlan} from "./script.ts";
 import {newestFirst} from "./sessions.ts";
-import {type StartOptions, TuvalAiAgent, type TuvalAiAgentApi} from "./TuvalAiAgent.ts";
+import {
+	type StartOptions,
+	type TranscriptPage,
+	type TranscriptQuery,
+	TuvalAiAgent,
+	type TuvalAiAgentApi,
+} from "./TuvalAiAgent.ts";
 
 interface ScriptState {
 	readonly started: boolean;
@@ -107,6 +114,28 @@ const toolItem = (id: string, answered: ScriptedAnswer): TranscriptItem => ({
 /** A plan that never ends is a fixture bug; the cap turns a hung run into a named failure. */
 const PLAN_CALL_LIMIT = 1_000;
 
+/**
+ * One page of a script's history, oldest-first, or `null` when `before` names no item in it.
+ *
+ * The two reads that serve it — `page` off the live session and `sessionTranscript` off the store —
+ * differ only in what refuses them, so the slicing is written once and each maps `null` onto its
+ * own unknown-cursor case.
+ */
+const historyPage = (
+	history: ReadonlyArray<TranscriptItem>,
+	before: string | null,
+	limit: number,
+): TranscriptPage | null => {
+	const end = before === null ? history.length : history.findIndex((item) => item.id === before);
+	if (end < 0) return null;
+	const from = Math.max(0, end - limit);
+	return {items: history.slice(from, end), hasMore: from > 0};
+};
+
+/** The port declares `limit > 0`; a caller that broke it has a bug this interface does not model. */
+const brokenLimit = (limit: number): Effect.Effect<never> =>
+	Effect.die(new Error(`a page was asked for ${limit} items; the port declares limit > 0`));
+
 const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.Scope> =>
 	Effect.gen(function* () {
 		// Acquired against the caller's Scope, so closing it shuts the queue: this layer's whole
@@ -160,6 +189,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 		});
 
 		const start = Effect.fn("TuvalAiAgent.start")(function* (options: StartOptions) {
+			if (script.startRefusal !== undefined) return yield* script.startRefusal;
 			const current = yield* Ref.get(state);
 			if (!current.live) {
 				return yield* new StartError({
@@ -304,23 +334,40 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 					detail: "the scripted transport is down and nothing reconnects it",
 				});
 			}
-			if (!Number.isInteger(limit) || limit < 1) {
-				return yield* Effect.die(
-					new Error(`page was asked for ${limit} items; the port declares limit > 0`),
-				);
-			}
-			const end =
-				before === null
-					? script.history.length
-					: script.history.findIndex((item) => item.id === before);
-			if (end < 0) {
-				return yield* new PageError({
-					reason: "unknown-cursor",
-					detail: `no item "${before}" is in this session's history`,
+			if (!Number.isInteger(limit) || limit < 1) return yield* brokenLimit(limit);
+			const planned = historyPage(script.history, before, limit);
+			return planned === null
+				? yield* new PageError({
+						reason: "unknown-cursor",
+						detail: `no item "${before}" is in this session's history`,
+					})
+				: planned;
+		});
+
+		// The store is the script's, so this answers before `start`, after a scripted disconnect and
+		// under a `startRefusal` — the same independence `listSessions` below has, and the whole
+		// point of the member (#8233).
+		const sessionTranscript = Effect.fn("TuvalAiAgent.sessionTranscript")(function* (
+			query: TranscriptQuery,
+		) {
+			if (query.sessionId !== script.sessionId) {
+				return yield* new TranscriptError({
+					reason: "session-not-found",
+					sessionId: query.sessionId,
+					detail: `the script holds session ${script.sessionId}`,
 				});
 			}
-			const from = Math.max(0, end - limit);
-			return {items: script.history.slice(from, end), hasMore: from > 0};
+			if (!Number.isInteger(query.limit) || query.limit < 1) {
+				return yield* brokenLimit(query.limit);
+			}
+			const planned = historyPage(script.history, query.before, query.limit);
+			return planned === null
+				? yield* new TranscriptError({
+						reason: "unknown-cursor",
+						sessionId: query.sessionId,
+						detail: `no item "${query.before}" is in this session's history`,
+					})
+				: planned;
 		});
 
 		// The store is the script's, not the session's: it answers before `start` and after a
@@ -340,6 +387,7 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 			commands: Effect.map(Ref.get(state), (current) => current.commands),
 			setThinkingLevel,
 			page,
+			sessionTranscript,
 			listSessions,
 			events: Stream.fromQueue(queue),
 		};

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -33,6 +33,7 @@ import type {
 	PromptError,
 	StartError,
 	ThinkingUnsupported,
+	TranscriptError,
 	TransportError,
 	UnknownRequest,
 } from "./errors.ts";
@@ -102,6 +103,18 @@ export interface TranscriptPage {
 	readonly hasMore: boolean;
 }
 
+/**
+ * Which stored session to read a page of, and how far back. `before` and `limit` are `page`'s own
+ * two arguments; `sessionId` and `cwd` stand where an open session would have carried them.
+ */
+export interface TranscriptQuery {
+	readonly sessionId: string;
+	readonly cwd: string;
+	/** The oldest item the caller already holds, or `null` for the newest end of the transcript. */
+	readonly before: string | null;
+	readonly limit: number;
+}
+
 export interface TuvalAiAgentApi {
 	readonly start: (options: StartOptions) => Effect.Effect<StartedSession, StartError>;
 	/**
@@ -150,8 +163,35 @@ export interface TuvalAiAgentApi {
 	/**
 	 * History is backend-owned (ruling 5): this reads the backend's own store through the
 	 * transport. Tuval keeps no second copy beyond the live tail the core holds.
+	 *
+	 * The live session's read, so it needs one open. `sessionTranscript` below is the same page off
+	 * the same store with no session open, and it is what a read-only surface calls.
 	 */
 	readonly page: (before: string | null, limit: number) => Effect.Effect<TranscriptPage, PageError>;
+	/**
+	 * One page of a *stored* session's history — `page`'s answer without `page`'s open session
+	 * (founder ruling, 2026-09-07,
+	 * https://github.com/kamp-us/phoenix/issues/8233#issuecomment-5567691729).
+	 *
+	 * A read of the store rather than of a session, exactly as `listSessions` is, so it answers
+	 * before `start` and on a layer that never starts one. That is the point: showing a session an
+	 * operator is only skimming used to go through `start({cwd, resume})`, which opens the
+	 * backend's own session and, on Pi, folds a whole replay into events nobody drains.
+	 *
+	 * **What the read-only promise covers.** Building the layer stays the layer's business — a
+	 * backend whose transport comes up with its build (`../../pi/ai-agent/PiAiAgent.ts`) still
+	 * stands it up here, exactly as it does for `listSessions`. What no longer happens is the
+	 * backend *session*: nothing attaches, nothing resumes, and no transcript is built for output
+	 * this read discards.
+	 *
+	 * A backend that could not look fails rather than answering an empty page, and a store that
+	 * does not hold the session fails differently again. Those are two of `TranscriptError`'s three
+	 * reasons; an empty `items` is the third answer — "this session is empty" — and none of the
+	 * three may be spelled as another.
+	 */
+	readonly sessionTranscript: (
+		query: TranscriptQuery,
+	) => Effect.Effect<TranscriptPage, TranscriptError>;
 	/**
 	 * Every session this backend's store holds, newest first — the tenth member (#8097).
 	 *

--- a/apps/tuval/src/ai-agent/service/boundary.unit.test.ts
+++ b/apps/tuval/src/ai-agent/service/boundary.unit.test.ts
@@ -27,6 +27,7 @@ import type {
 	PromptError,
 	StartError,
 	ThinkingUnsupported,
+	TranscriptError,
 	TransportError,
 	UnknownRequest,
 } from "./errors.ts";
@@ -35,20 +36,22 @@ import type {
 	StartedSession,
 	StartOptions,
 	TranscriptPage,
+	TranscriptQuery,
 	TuvalAiAgentApi,
 } from "./TuvalAiAgent.ts";
 
 /**
- * The founder's seven grew to eight on #7981, to nine on #8060, to ten on #8062 and to eleven on
- * #8097. The first three are one act: he wants the agent's model, its slash commands and its
- * thinking level reachable from the chat composer, and a picker over a generic window has to reach
- * them through the generic interface — so `setModel`, `commands` and `setThinkingLevel` are those
- * three members. #8097's eleventh is the other: every session on his machine listed from one
- * program whatever backend started it, which is `listSessions`. Both pins below count eleven, so
+ * The founder's seven grew to eight on #7981, to nine on #8060, to ten on #8062, to eleven on
+ * #8097 and to twelve on #8233. The first three are one act: he wants the agent's model, its slash
+ * commands and its thinking level reachable from the chat composer, and a picker over a generic
+ * window has to reach them through the generic interface — so `setModel`, `commands` and
+ * `setThinkingLevel` are those three members. The last two are the store's own pair: every session
+ * on his machine listed from one program whatever backend started it (`listSessions`), and one of
+ * those sessions read without opening it (`sessionTranscript`). Both pins below count twelve, so
  * each growth reads as the deliberate act it was rather than as drift.
  */
 describe("the TuvalAiAgent surface", () => {
-	it("carries the seven, #7981's, #8060's, #8062's and #8097's, at their declared types", () => {
+	it("carries the seven and the five that followed, at their declared types", () => {
 		expectTypeOf<TuvalAiAgentApi["start"]>().toEqualTypeOf<
 			(options: StartOptions) => Effect.Effect<StartedSession, StartError>
 		>();
@@ -74,6 +77,9 @@ describe("the TuvalAiAgent surface", () => {
 		expectTypeOf<TuvalAiAgentApi["page"]>().toEqualTypeOf<
 			(before: string | null, limit: number) => Effect.Effect<TranscriptPage, PageError>
 		>();
+		expectTypeOf<TuvalAiAgentApi["sessionTranscript"]>().toEqualTypeOf<
+			(query: TranscriptQuery) => Effect.Effect<TranscriptPage, TranscriptError>
+		>();
 		expectTypeOf<TuvalAiAgentApi["listSessions"]>().toEqualTypeOf<
 			Effect.Effect<ReadonlyArray<SessionSummary>, ListError>
 		>();
@@ -82,7 +88,7 @@ describe("the TuvalAiAgent surface", () => {
 		>();
 	});
 
-	it("has exactly those eleven members and no twelfth", () => {
+	it("has exactly those twelve members and no thirteenth", () => {
 		expectTypeOf<keyof TuvalAiAgentApi>().toEqualTypeOf<
 			| "start"
 			| "prompt"
@@ -93,6 +99,7 @@ describe("the TuvalAiAgent surface", () => {
 			| "commands"
 			| "setThinkingLevel"
 			| "page"
+			| "sessionTranscript"
 			| "listSessions"
 			| "events"
 		>();

--- a/apps/tuval/src/ai-agent/service/errors.ts
+++ b/apps/tuval/src/ai-agent/service/errors.ts
@@ -121,6 +121,31 @@ export class PageError extends Schema.TaggedError<PageError>()("tuval/ai-agent/P
 }
 
 /**
+ * Why a stored transcript did not come back. `sessionTranscript` reads the store off disk with no
+ * session open, so its cases are the store's and never the connection's — the same split
+ * `ListError` draws for `listSessions`.
+ *
+ * `session-not-found` is the whole reason this is not `PageError`: a store that does not hold the
+ * named session is a different answer from an empty page, and a read that could not tell them
+ * apart would render a lost session as a session that said nothing (epic #8070, ruling 2).
+ */
+export const TranscriptReason = Schema.Literals([
+	"session-not-found",
+	"store-unreadable",
+	"unknown-cursor",
+]);
+export type TranscriptReason = typeof TranscriptReason.Type;
+
+export class TranscriptError extends Schema.TaggedError<TranscriptError>()(
+	"tuval/ai-agent/TranscriptError",
+	{reason: TranscriptReason, sessionId: Schema.String, detail: Schema.String},
+) {
+	override get message(): string {
+		return `the stored transcript for "${this.sessionId}" could not be read (${this.reason}): ${this.detail}`;
+	}
+}
+
+/**
  * Why a session listing did not come back. Listing reads the backend's store off disk without the
  * session transport in it at all, so its cases are the store's, not the connection's.
  *

--- a/apps/tuval/src/ai-agent/service/index.ts
+++ b/apps/tuval/src/ai-agent/service/index.ts
@@ -27,6 +27,8 @@ export {
 	StartError,
 	type StartReason,
 	ThinkingUnsupported,
+	TranscriptError,
+	type TranscriptReason,
 	TransportError,
 	type TransportReason,
 	UnknownRequest,
@@ -54,6 +56,7 @@ export {
 	type StartedSession,
 	type StartOptions,
 	type TranscriptPage,
+	type TranscriptQuery,
 	TuvalAiAgent,
 	type TuvalAiAgentApi,
 } from "./TuvalAiAgent.ts";

--- a/apps/tuval/src/ai-agent/service/script.ts
+++ b/apps/tuval/src/ai-agent/service/script.ts
@@ -12,7 +12,7 @@ import type {SpellBridgeApi} from "../../commands/bridge/index.ts";
 import type {SpellPath, Scope as SpellScope} from "../../commands/spell.ts";
 import type {AgentEvent} from "../events.ts";
 import type {CommandRef, Mode, ModelRef, ThinkingLevel, TranscriptItem} from "../ports/index.ts";
-import type {ListError, TransportError} from "./errors.ts";
+import type {ListError, StartError, TransportError} from "./errors.ts";
 import type {SessionSummary} from "./sessions.ts";
 
 /** One spell a turn calls: the path and the args, exactly as they cross the wire. */
@@ -109,6 +109,15 @@ export interface AgentScript {
 	readonly thinking: ScriptedThinking;
 	/** One entry per prompt, consumed in order. */
 	readonly turns: ReadonlyArray<ScriptedTurn>;
+	/**
+	 * When set, `start` fails with this instead of opening the session, and it keeps failing for
+	 * the life of the layer.
+	 *
+	 * A script that refuses every open is how a test proves a call reached no session: the store
+	 * reads — `listSessions` and `sessionTranscript` — answer off this script either way, so one
+	 * that answers under a refusing `start` is one that never went near the transport (#8233).
+	 */
+	readonly startRefusal?: StartError;
 	/**
 	 * Which turn a *resumed* session's next prompt replays. A resumed session is one an earlier run
 	 * already spent turns on, and this layer's turn cursor lives in the build it hands back, so a

--- a/apps/tuval/src/ai-agent/session-transcript.ts
+++ b/apps/tuval/src/ai-agent/session-transcript.ts
@@ -11,10 +11,11 @@
  * forever. The overrun becomes `SessionTranscriptTimedOut`, which the executor turns into a
  * `SpellReplyError` a window can render.
  *
- * **It opens no process.** The read builds the backend's layer inside its own Scope
- * (`./transcripts.ts`), so `Processes`, `ProcessTable` and `Checkpoints` are untouched: reading a
- * session is read-only until the operator sends (epic #8070, ruling 2). Creating the live process
- * is the first send's act, and it happens through the picker's ordinary open with a session on it
+ * **It opens no process and no backend session.** The read builds the backend's layer inside its
+ * own Scope (`./transcripts.ts`), so `Processes`, `ProcessTable` and `Checkpoints` are untouched,
+ * and the one call it makes is the store-level `sessionTranscript` — reading a session is
+ * read-only until the operator sends (epic #8070, ruling 2; #8233). Creating the live process is
+ * the first send's act, and it happens through the picker's ordinary open with a session on it
  * (`../shell/picker/intent.ts`).
  */
 
@@ -27,7 +28,7 @@ import {
 } from "../protocol/session-transcript.ts";
 import {ProgramId} from "../registry/program.ts";
 import type {Registry} from "../registry/Registry.ts";
-import type {PageError, StartError} from "./service/index.ts";
+import type {TranscriptError} from "./service/index.ts";
 import {
 	type BackendTranscript,
 	type BackendUnknown,
@@ -35,8 +36,8 @@ import {
 	type TranscriptRequest,
 } from "./transcripts.ts";
 
-/** Why one transcript read could not answer: the three refusals `readAiAgentTranscript` raises. */
-export type TranscriptRefusal = BackendUnknown | StartError | PageError;
+/** Why one transcript read could not answer: the two refusals `readAiAgentTranscript` raises. */
+export type TranscriptRefusal = BackendUnknown | TranscriptError;
 
 /**
  * One session's history over the kernel's own context. A service for the same reason

--- a/apps/tuval/src/ai-agent/transcripts.ts
+++ b/apps/tuval/src/ai-agent/transcripts.ts
@@ -10,10 +10,12 @@
  * process behind and no restore state to bring one back, which is what
  * `transcripts.unit.test.ts` asserts directly.
  *
- * `start({cwd, resume})` is how a backend is pointed at a session this desk never opened — the
- * resume slot's whole purpose (`./service/TuvalAiAgent.ts`) — and it is also the call that reports
- * a session the store has since lost, as `StartError({reason: "session-not-found"})`. That refusal
- * is why a lost session cannot render as an empty transcript: the read never reaches `page`.
+ * The one call it makes is `sessionTranscript`, the store-level read (founder ruling, 2026-09-07,
+ * https://github.com/kamp-us/phoenix/issues/8233#issuecomment-5567691729). It opens no backend
+ * session: nothing attaches, nothing resumes, and none of the replay a resume would fold is built
+ * for a page this call would discard. A session the store has since lost comes back as
+ * `TranscriptError({reason: "session-not-found"})`, which is why a lost session cannot render as an
+ * empty transcript.
  */
 
 import {Context, Effect, Layer, Schema} from "effect";
@@ -21,7 +23,7 @@ import type {ProgramId} from "../registry/program.ts";
 import type {Registry} from "../registry/Registry.ts";
 import {type AiAgentBackendRow, readAiAgentBackends} from "./backends.ts";
 import type {TranscriptItem} from "./ports/index.ts";
-import {type PageError, type StartError, TuvalAiAgent} from "./service/index.ts";
+import {type TranscriptError, TuvalAiAgent} from "./service/index.ts";
 
 /** The request named a program row that is not a registered AI agent backend on this desk. */
 export class BackendUnknown extends Schema.TaggedError<BackendUnknown>()(
@@ -59,16 +61,17 @@ export interface BackendTranscript {
 const readFrom = (
 	row: AiAgentBackendRow,
 	request: TranscriptRequest,
-): Effect.Effect<BackendTranscript, StartError | PageError, never> =>
+): Effect.Effect<BackendTranscript, TranscriptError, never> =>
 	Effect.scoped(
 		Effect.gen(function* () {
 			const built = yield* Layer.build(row.aiAgent.layer as Layer.Layer<TuvalAiAgent>);
 			const agent = Context.get(built, TuvalAiAgent);
-			yield* agent.start({
+			const page = yield* agent.sessionTranscript({
+				sessionId: request.sessionId,
 				cwd: request.cwd,
-				resume: {sessionId: request.sessionId, holdsTranscript: false},
+				before: request.before,
+				limit: request.limit,
 			});
-			const page = yield* agent.page(request.before, request.limit);
 			// The port answers `hasMore`; the cursor it implies is this page's oldest item, which is
 			// what a caller hands back as `before` to walk one page further into history.
 			return {items: page.items, next: page.hasMore ? (page.items[0]?.id ?? null) : null};
@@ -78,7 +81,7 @@ const readFrom = (
 export const readAiAgentTranscript = (
 	services: Context.Context<never>,
 	request: TranscriptRequest,
-): Effect.Effect<BackendTranscript, BackendUnknown | StartError | PageError, Registry> =>
+): Effect.Effect<BackendTranscript, BackendUnknown | TranscriptError, Registry> =>
 	Effect.gen(function* () {
 		const rows = yield* readAiAgentBackends;
 		const row = rows.find((candidate) => candidate.id === request.programId);

--- a/apps/tuval/src/ai-agent/transcripts.unit.test.ts
+++ b/apps/tuval/src/ai-agent/transcripts.unit.test.ts
@@ -7,8 +7,13 @@
  * assertion is the whole guard.
  *
  * The other two are the pair a blank transcript would hide. History comes back one page at a time
- * off the port's own `page(before, limit)`, and a session the store has since lost is a refusal
- * rather than an empty page — a row that opens onto silence has to mean the session is empty.
+ * off the port's own paging, and a session the store has since lost is a refusal rather than an
+ * empty page — a row that opens onto silence has to mean the session is empty.
+ *
+ * The load-bearing assertion on the *backend* side is the sealed row (#8233): its script refuses
+ * every `start`, so a read that answers at all is a read that opened no backend session and stood
+ * no transport up for one. Its own `start` is asserted refusing right after, so the pass is the
+ * read staying away rather than the fixture having no teeth.
  *
  * **The fixture's program id and backend tag are deliberately different strings.** The row is
  * registered as `pi-session` and its sessions carry the tag `pi`, because an earlier fixture used
@@ -19,7 +24,7 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer} from "effect";
+import {Context, Effect, Layer} from "effect";
 import {Checkpoints} from "../durability/Checkpoints.ts";
 import {memoryStores} from "../durability/stores.ts";
 import {Processes} from "../process/Processes.ts";
@@ -30,7 +35,13 @@ import {listAiAgentSessions} from "./backends.ts";
 import {ItemId, type TranscriptItem} from "./ports/index.ts";
 import {aiAgentProgram} from "./program.ts";
 import {models, modes, thinking} from "./service/fixtures/scripts.ts";
-import {type AgentScript, ScriptedAiAgent, sessionSummary} from "./service/index.ts";
+import {
+	type AgentScript,
+	ScriptedAiAgent,
+	StartError,
+	sessionSummary,
+	TuvalAiAgent,
+} from "./service/index.ts";
 import {readAiAgentTranscript} from "./transcripts.ts";
 
 const at = (offset: number): number => 1_760_000_000_000 + offset;
@@ -42,37 +53,51 @@ const said = (id: string, text: string): TranscriptItem => ({
 	text,
 });
 
-/**
- * A backend row whose script holds one session with `history` behind it, listed under `tag`.
- *
- * `id` and `tag` are separate parameters because they are separate fields on the row a listing
- * answers: `id` is what a read has to name and `tag` is what the meta line prints.
- */
-const backendRow = (
-	id: string,
+/** One session's script, listed under `tag`, optionally refusing every open. */
+const scriptOf = (
 	tag: string,
 	sessionId: string,
-	history: ReadonlyArray<TranscriptItem>,
-): AnyProgram => {
-	const script: AgentScript = {
-		sessionId,
-		history,
-		modes,
-		models,
-		thinking,
-		turns: [],
-		interrupt: [],
-		sessions: [sessionSummary({sessionId, lastModified: at(0), backend: tag})],
-	};
-	return aiAgentProgram({id, layer: ScriptedAiAgent.layer(script), config: {cwd: "/workspace"}});
-};
+	items: ReadonlyArray<TranscriptItem>,
+	startRefusal?: StartError,
+): AgentScript => ({
+	sessionId,
+	history: items,
+	modes,
+	models,
+	thinking,
+	turns: [],
+	interrupt: [],
+	sessions: [sessionSummary({sessionId, lastModified: at(0), backend: tag})],
+	...(startRefusal === undefined ? {} : {startRefusal}),
+});
+
+/**
+ * A backend row over one script.
+ *
+ * `id` and the script's backend tag are separate strings because they are separate fields on the
+ * row a listing answers: `id` is what a read has to name and the tag is what the meta line prints.
+ */
+const programOf = (id: string, script: AgentScript): AnyProgram =>
+	aiAgentProgram({id, layer: ScriptedAiAgent.layer(script), config: {cwd: "/workspace"}});
 
 const history = [said("m-1", "one"), said("m-2", "two"), said("m-3", "three")];
 
 const PROGRAM_ID = "pi-session";
+const SEALED_ID = "pi-sealed";
 const BACKEND_TAG = "pi";
 
-const rows = [backendRow(PROGRAM_ID, BACKEND_TAG, "s-1", history)];
+const sealed = new StartError({
+	reason: "transport",
+	cwd: "/workspace",
+	detail: "this script refuses every open",
+});
+
+const sealedScript = scriptOf(BACKEND_TAG, "s-2", history, sealed);
+
+const rows = [
+	programOf(PROGRAM_ID, scriptOf(BACKEND_TAG, "s-1", history)),
+	programOf(SEALED_ID, sealedScript),
+];
 
 /** The real process machinery, so "nothing was spawned" is a claim about the thing that spawns. */
 const kernel = (): Layer.Layer<Processes | ProcessTable | Registry | Checkpoints> =>
@@ -142,12 +167,30 @@ describe("reading a session's transcript", () => {
 		Effect.gen(function* () {
 			const raised = yield* Effect.flip(read({programId: PROGRAM_ID, sessionId: "gone"}));
 
-			assert.strictEqual(raised._tag, "tuval/ai-agent/StartError");
+			assert.strictEqual(raised._tag, "tuval/ai-agent/TranscriptError");
 			assert.strictEqual(
-				raised._tag === "tuval/ai-agent/StartError" ? raised.reason : null,
+				raised._tag === "tuval/ai-agent/TranscriptError" ? raised.reason : null,
 				"session-not-found",
 			);
 		}).pipe(Effect.provide(kernel())),
+	);
+
+	it.effect("acquires no session: it answers on a backend that refuses every open", () =>
+		Effect.gen(function* () {
+			const page = yield* read({programId: SEALED_ID, sessionId: "s-2"});
+			assert.lengthOf(page.items, 3);
+		}).pipe(Effect.provide(kernel())),
+	);
+
+	it.effect("and that backend really does refuse, so the read above stayed away", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const built = yield* Layer.build(ScriptedAiAgent.layer(sealedScript));
+				const agent = Context.get(built, TuvalAiAgent);
+
+				assert.strictEqual(yield* Effect.flip(agent.start({cwd: "/workspace"})), sealed);
+			}),
+		),
 	);
 
 	it.effect("names the registered backends when the request names one that is not one", () =>

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -54,6 +54,7 @@ import {
 	type StartError,
 	type StartOptions,
 	ThinkingUnsupported,
+	type TranscriptQuery,
 	type TransportError,
 	TuvalAiAgent,
 	type TuvalAiAgentApi,
@@ -90,6 +91,9 @@ import {
 	storeUnreadable,
 	streamFailed,
 	subprocessGone,
+	transcriptSessionNotFound,
+	transcriptUnknownCursor,
+	transcriptUnreadable,
 	unknownCursor,
 } from "./refusals.ts";
 import {type AgentSession, realAgentSdk} from "./sdk.ts";
@@ -806,6 +810,56 @@ const make = (
 		});
 
 		/**
+		 * Whether the CLI's store holds a session at all, asked only where the transcript read came
+		 * back empty. `listSessions` with no options is the whole store, which is the same call
+		 * `listSessions` below makes and the same reason it makes it that way.
+		 */
+		const storeHolds = (sessionId: string) =>
+			Effect.map(
+				Effect.tryPromise({
+					try: () => sdk.listSessions(),
+					catch: (cause) => transcriptUnreadable(sessionId, cause),
+				}),
+				(stored) => stored.some((info) => info.sessionId === sessionId),
+			);
+
+		/**
+		 * `page`'s answer off the store, with no session open (#8233). `getSessionMessages` reads the
+		 * CLI's transcript files directly, so nothing here touches the `query()` this layer's `start`
+		 * owns and the read works on a layer that never opened one.
+		 */
+		const sessionTranscript = Effect.fn("TuvalAiAgent.sessionTranscript")(function* (
+			query: TranscriptQuery,
+		) {
+			const rows = yield* Effect.tryPromise({
+				try: () => sdk.getSessionMessages(query.sessionId, {dir: query.cwd}),
+				catch: (cause) => transcriptUnreadable(query.sessionId, cause),
+			});
+			// The pin answers an empty array for a session it does not hold as readily as for one
+			// that is genuinely empty (`refusals.ts`), so the listing settles which of the two this
+			// is rather than the caller reading silence as either.
+			if (rows.length === 0 && !(yield* storeHolds(query.sessionId))) {
+				return yield* transcriptSessionNotFound(query.sessionId);
+			}
+			const {items, cursorAliases} = toHistoryItems(rows, {at: Date.now()});
+			const planned = planTranscriptPage(items, {
+				before: query.before,
+				cursorAliases,
+				limit: query.limit,
+				cursorBoundary: "containing-group",
+			});
+			if (isRefusal(planned)) {
+				if (planned.reason === "limit-not-positive") {
+					return yield* Effect.die(
+						new Error(`page was asked for ${query.limit} items; the port declares limit > 0`),
+					);
+				}
+				return yield* transcriptUnknownCursor(query.sessionId, planned.reason);
+			}
+			return {items: planned.items, hasMore: planned.next !== null};
+		});
+
+		/**
 		 * One subagent this session spawned, as its own transcript and its type (#8404).
 		 *
 		 * `page`'s shape, on a different file: the live session names it, the store reads it, and
@@ -847,6 +901,7 @@ const make = (
 			commands: Ref.get(commands),
 			setThinkingLevel,
 			page,
+			sessionTranscript,
 			subagentTranscript,
 			listSessions,
 			events: Stream.unwrap(Effect.map(Ref.get(queue), (held) => Stream.fromQueue(held))),

--- a/apps/tuval/src/claude/agent/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/agent/boundary.unit.test.ts
@@ -57,7 +57,7 @@ describe("the layer's type", () => {
 		expectTypeOf(composed).toEqualTypeOf<Layer.Layer<TuvalAiAgent, never, SpellBridge>>();
 	});
 
-	it("implements exactly the ten generic members, and no eleventh", () => {
+	it("implements exactly the twelve generic members, and no thirteenth", () => {
 		expectTypeOf<keyof TuvalAiAgentApi>().toEqualTypeOf<
 			| "start"
 			| "prompt"
@@ -68,6 +68,7 @@ describe("the layer's type", () => {
 			| "commands"
 			| "setThinkingLevel"
 			| "page"
+			| "sessionTranscript"
 			| "listSessions"
 			| "events"
 		>();

--- a/apps/tuval/src/claude/agent/refusals.ts
+++ b/apps/tuval/src/claude/agent/refusals.ts
@@ -10,6 +10,7 @@ import {
 	PageError,
 	PromptError,
 	StartError,
+	TranscriptError,
 	TransportError,
 } from "../../ai-agent/service/index.ts";
 
@@ -85,6 +86,27 @@ export const subagentMalformed = (agentId: string, line: number, detail: string)
 		reason: "subagent-malformed",
 		detail: `subagent "${agentId}" line ${line}: ${detail}`,
 	});
+
+/**
+ * The three ways a *stored* session's transcript does not come back (#8233).
+ *
+ * `transcriptSessionNotFound` is the reading `sessionNotFound` above makes at `start`, moved onto
+ * the read that no longer starts anything: `getSessionMessages` "returns Array of messages, or
+ * empty array if session not found" (`sdk.d.ts`), so the empty read is two answers in one and the
+ * store's own listing is what tells them apart.
+ */
+export const transcriptSessionNotFound = (sessionId: string): TranscriptError =>
+	new TranscriptError({
+		reason: "session-not-found",
+		sessionId,
+		detail: "the Claude session store holds no session with this id",
+	});
+
+export const transcriptUnreadable = (sessionId: string, cause: unknown): TranscriptError =>
+	new TranscriptError({reason: "store-unreadable", sessionId, detail: detailOf(cause)});
+
+export const transcriptUnknownCursor = (sessionId: string, reason: string): TranscriptError =>
+	new TranscriptError({reason: "unknown-cursor", sessionId, detail: reason});
 
 /**
  * The session store could not be enumerated. Never `unsupported`: this backend does list, so a

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -33,7 +33,7 @@
  */
 
 import {readdirSync} from "node:fs";
-import {join} from "node:path";
+import {dirname, join} from "node:path";
 import {getAgentDir, ModelRuntime, SessionManager} from "@earendil-works/pi-coding-agent";
 import type {SessionSnapshot} from "@earendil-works/pi-protocol";
 import {type Cause, Effect, Fiber, Layer, Queue, Redacted, Ref, type Scope, Stream} from "effect";
@@ -54,6 +54,7 @@ import {
 	PromptError,
 	type StartOptions,
 	ThinkingUnsupported,
+	type TranscriptQuery,
 	type TransportError,
 	TuvalAiAgent,
 	type TuvalAiAgentApi,
@@ -83,9 +84,12 @@ import {
 	promptFailureOf,
 	startErrorOf,
 	storeUnreadable,
+	transcriptSessionMissing,
+	transcriptUnknownCursor,
+	transcriptUnreadable,
 	transportErrorOf,
 } from "./refusals.ts";
-import {readPiSessions} from "./sessions.ts";
+import {piSessionDirs, readPiSessions} from "./sessions.ts";
 
 /** A model this process may run, named the way Pi's catalog names one. */
 export interface ModelSelection {
@@ -155,6 +159,23 @@ const readBranch = (dir: string, sessionId: string, cwd: string) =>
 			return SessionManager.open(join(dir, file), dir, cwd).getBranch();
 		},
 		catch: storeUnreadable,
+	});
+
+/**
+ * Where one stored session's JSONL sits, across every directory either store keeps files in, or
+ * `null` when it is in none of them. A genuine miss, told apart from a directory that would not
+ * open by the `Effect.try` around the scan (#8233).
+ */
+const locateBranch = (dirs: ReadonlyArray<string>, sessionId: string) =>
+	Effect.try({
+		try: (): string | null => {
+			for (const dir of dirs) {
+				const file = readdirSync(dir).find((name) => name.endsWith(`_${sessionId}.jsonl`));
+				if (file !== undefined) return join(dir, file);
+			}
+			return null;
+		},
+		catch: (cause) => transcriptUnreadable(sessionId, cause),
 	});
 
 /**
@@ -581,6 +602,53 @@ const make = (
 		});
 
 		/**
+		 * `page`'s answer off disk, with no session open and no transport dialled (#8233).
+		 *
+		 * It walks both stores rather than `sessionDir(cwd)` alone, because the ids it is handed come
+		 * off `listSessions` below, which unions the two — a session the operator started with `pi`
+		 * in a terminal is in the CLI store and would otherwise read as gone.
+		 *
+		 * Nothing here reaches `paintOf`: that fold builds a whole transcript's worth of `item` and
+		 * `usage` events for the attach to emit, and on this path there is no attach and no
+		 * subscriber, so the events would be built and dropped.
+		 */
+		const sessionTranscript = Effect.fn("TuvalAiAgent.sessionTranscript")(function* (
+			query: TranscriptQuery,
+		) {
+			const stores = yield* piSessionDirs({agentDir, tuvalDir: sessionDir(query.cwd)});
+			const file = yield* locateBranch(stores.dirs, query.sessionId);
+			if (file === null) {
+				// A store that would not enumerate may be the one the file was in, so a miss across the
+				// rest is not the claim that the session is gone.
+				return yield* stores.failures.length === 0
+					? transcriptSessionMissing(query.sessionId)
+					: transcriptUnreadable(
+							query.sessionId,
+							stores.failures.map((failure) => `${failure.store}: ${failure.detail}`).join("; "),
+						);
+			}
+			const entries = yield* Effect.try({
+				try: () => SessionManager.open(file, dirname(file), query.cwd).getBranch(),
+				catch: (cause) => transcriptUnreadable(query.sessionId, cause),
+			});
+			const planned = planTranscriptPage(pageItems(entries), {
+				before: query.before,
+				cursorAliases: pageCursorAliases(entries),
+				limit: query.limit,
+				cursorBoundary: "containing-group",
+			});
+			if (isRefusal(planned)) {
+				if (planned.reason === "limit-not-positive") {
+					return yield* Effect.die(
+						new Error(`page was asked for ${query.limit} items; the port declares limit > 0`),
+					);
+				}
+				return yield* transcriptUnknownCursor(query.sessionId, planned.reason);
+			}
+			return {items: planned.items, hasMore: planned.next !== null};
+		});
+
+		/**
 		 * Both of Pi's stores, unioned (#8099). A read of disk rather than of the transport, so it
 		 * answers before `start` and after a drop.
 		 *
@@ -641,6 +709,7 @@ const make = (
 			commands: Effect.succeed([]),
 			setThinkingLevel,
 			page,
+			sessionTranscript,
 			listSessions,
 			events: Stream.unwrap(Effect.map(Ref.get(queue), (open) => Stream.fromQueue(open))),
 		};

--- a/apps/tuval/src/pi/ai-agent/refusals.ts
+++ b/apps/tuval/src/pi/ai-agent/refusals.ts
@@ -8,7 +8,13 @@
  */
 
 import type {AgentFailure} from "../../ai-agent/events.ts";
-import {PageError, PromptError, StartError, TransportError} from "../../ai-agent/service/index.ts";
+import {
+	PageError,
+	PromptError,
+	StartError,
+	TranscriptError,
+	TransportError,
+} from "../../ai-agent/service/index.ts";
 import type {ConnectionRefusal, Disconnected, SessionRefusal} from "../client/index.ts";
 
 export const startErrorOf = (
@@ -65,6 +71,31 @@ export const storeUnreadable = (cause: unknown): PageError =>
 		reason: "store-unreadable",
 		detail: cause instanceof Error ? cause.message : String(cause),
 	});
+
+/**
+ * The three ways a *stored* session's transcript does not come back (#8233).
+ *
+ * `transcriptSessionMissing` is the one `storeUnreadable` above cannot say. `page` reads the file
+ * of a session the layer already holds, so a missing file there is a broken store; the store read
+ * is handed an id off a listing and a file that is nowhere is the ordinary answer that the session
+ * is gone — which a caller must be able to tell from a store it could not enumerate.
+ */
+export const transcriptSessionMissing = (sessionId: string): TranscriptError =>
+	new TranscriptError({
+		reason: "session-not-found",
+		sessionId,
+		detail: "neither of Pi's session stores holds a file for this id",
+	});
+
+export const transcriptUnreadable = (sessionId: string, cause: unknown): TranscriptError =>
+	new TranscriptError({
+		reason: "store-unreadable",
+		sessionId,
+		detail: cause instanceof Error ? cause.message : String(cause),
+	});
+
+export const transcriptUnknownCursor = (sessionId: string, reason: string): TranscriptError =>
+	new TranscriptError({reason: "unknown-cursor", sessionId, detail: reason});
 
 /**
  * A send refused because the socket is gone, as the terminal failure that ends the event stream.

--- a/apps/tuval/src/pi/ai-agent/sessions.ts
+++ b/apps/tuval/src/pi/ai-agent/sessions.ts
@@ -96,6 +96,45 @@ const leavesOf = (
 		catch: (cause) => ({store, detail: detailOf(cause)}),
 	});
 
+/** Every directory the stores keep `.jsonl` files in, beside the stores that would not answer. */
+export interface StoreDirs {
+	readonly dirs: ReadonlyArray<string>;
+	readonly failures: ReadonlyArray<StoreFailure>;
+}
+
+const targetsOf = (stores: PiSessionStores): ReadonlyArray<readonly [PiSessionStore, string]> => [
+	["pi-cli", join(stores.agentDir, "sessions")],
+	...(stores.tuvalDir === undefined ? [] : [["tuval", stores.tuvalDir] as const]),
+];
+
+/**
+ * Where a stored session's file could be, across both stores.
+ *
+ * The transcript read (`./PiAiAgent.ts`) walks these to find one session's JSONL, so it reaches
+ * every row `readPiSessions` unions: a session the operator started with `pi` in a terminal lives
+ * in the CLI store and is unreachable off Tuval's own directory alone (#8233).
+ *
+ * A store that would not enumerate is named in `failures` rather than failing the call, for the
+ * reason `readPiSessions` gives — the other store's directories are still worth looking in, and it
+ * is the caller that knows whether a miss across what did answer is a miss at all.
+ */
+export const piSessionDirs = (stores: PiSessionStores): Effect.Effect<StoreDirs> =>
+	Effect.map(
+		Effect.forEach(
+			targetsOf(stores),
+			([store, root]) =>
+				leavesOf(store, root).pipe(
+					Effect.map((dirs) => ({dirs, failure: null as StoreFailure | null})),
+					Effect.catch((failure) => Effect.succeed({dirs: [] as ReadonlyArray<string>, failure})),
+				),
+			{concurrency: "unbounded"},
+		),
+		(answers) => ({
+			dirs: answers.flatMap((answer) => answer.dirs),
+			failures: answers.flatMap((answer) => (answer.failure === null ? [] : [answer.failure])),
+		}),
+	);
+
 interface StoreAnswer {
 	readonly store: PiSessionStore;
 	readonly sessions: ReadonlyArray<SessionSummary>;
@@ -132,13 +171,11 @@ const readStore = (store: PiSessionStore, root: string): Effect.Effect<StoreAnsw
  */
 export const readPiSessions = (stores: PiSessionStores): Effect.Effect<StoreRead> =>
 	Effect.gen(function* () {
-		const targets: ReadonlyArray<readonly [PiSessionStore, string]> = [
-			["pi-cli", join(stores.agentDir, "sessions")],
-			...(stores.tuvalDir === undefined ? [] : [["tuval", stores.tuvalDir] as const]),
-		];
-		const answers = yield* Effect.forEach(targets, ([store, root]) => readStore(store, root), {
-			concurrency: "unbounded",
-		});
+		const answers = yield* Effect.forEach(
+			targetsOf(stores),
+			([store, root]) => readStore(store, root),
+			{concurrency: "unbounded"},
+		);
 
 		const seen = new Set<string>();
 		const sessions: Array<SessionSummary> = [];


### PR DESCRIPTION
Fixes #8233.

Reading a session from the picker used to call `start({cwd, resume})` first, because `page` needs an
open session. On Pi that also folded `paintOf` over the whole transcript into `item`/`usage` events
nobody drained. The founder ruled on 2026-09-07 that read-only paging goes through a store-only API:
https://github.com/kamp-us/phoenix/issues/8233#issuecomment-5567691729

`TuvalAiAgentApi` gains a twelfth member, `sessionTranscript({sessionId, cwd, before, limit})`. It is
`listSessions`' sibling — a read of the backend's store, so it answers before `start` and on a layer
that never starts a session — and it answers `page`'s own `TranscriptPage`. Its failures are a new
`TranscriptError` whose three reasons keep apart the two things an empty page must never stand for:
`session-not-found` (the store holds no such session) and `store-unreadable` (it holds it and would
not open), plus `unknown-cursor`. An empty `items` is then the third answer and means the session is
empty.

All three backends implement it:

- **Claude** reads `sdk.getSessionMessages(id, {dir: cwd})`, which is a file read and touches no
  `query()`. That call "returns Array of messages, or empty array if session not found"
  (`sdk.d.ts` at the `0.3.259` pin), so on an empty read it asks `sdk.listSessions()` whether the
  store holds the id at all — that is the only way to tell the two apart on this SDK.
- **Pi** locates `<timestamp>_<sessionId>.jsonl` across *both* stores rather than
  `sessionDir(cwd)` alone, because the ids it is handed come off `listSessions`, which unions the
  CLI store and Tuval's own. A store that would not enumerate keeps a miss from reading as
  `session-not-found`.
- **Scripted** serves the script's `history` off the same slicing `page` uses.

`readFrom` in `transcripts.ts` now calls it and no longer calls `start`, so `paintOf` is not on this
path. The read-only promise is written down in the interface docblock next to `page` and
`listSessions`, including what it does *not* cover: building the layer still stands a backend's
transport up where that backend does so at build time, exactly as it does for `listSessions`. What
no longer happens is the backend session.

`transcripts.unit.test.ts` keeps its no-process / no-checkpoint assertions and gains a backend whose
script refuses every `start` (a new `AgentScript.startRefusal`). The read answers off that row, and
the next test asserts that row's `start` really does refuse — so the pass is the read staying away
from the transport, not a fixture with no teeth. The lost-session test now expects
`TranscriptError`.

#8238 still owns the page/window paging and its client wiring; this changes acquisition only.

## Deviations

- **Out-of-scope change** — **Said:** #8233 names the new member, the three backends, `readFrom` and
  the tests. **Did:** also added `piSessionDirs` to `apps/tuval/src/pi/ai-agent/sessions.ts` and
  pulled its store-target list out of `readPiSessions` into a shared `targetsOf`. **Why:** the Pi
  read has to look in both stores or a listed CLI-store session reads as gone, and duplicating the
  target list would have been two places to keep in step. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `AgentScript`. **Did:** added an optional
  `startRefusal` to it and honoured it in `ScriptedAiAgent.start`. **Why:** criterion 5 wants an
  assertion that no transport is acquired, and on the scripted layer the only observable act of
  acquisition is `start`; a script that refuses every open is what makes that assertion falsifiable.
  **Disposition:** stated here.
- **Declined guidance** — **Said:** the spawn brief asked for a branch name starting with `umut/`.
  **Did:** used `build/8233-store-only-transcript-read-ffebe58b`. **Why:** `fabrika build branch`
  composes the name from the claim nonce and the branch name is the lane record; it takes no prefix
  flag. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** keep the existing assertions. **Did:** the
  lost-session test's expected tag moved from `StartError` to `TranscriptError`, and both
  `boundary.unit.test.ts` member pins went from eleven members to twelve. **Why:** the refusal now
  comes from the member that replaced `start` on this path, and the interface really did grow one
  member — the pins exist to make that growth deliberate rather than silent. The claims themselves
  are unchanged. **Disposition:** stated here.
