### PR TITLE
fix: Claude backend: thinking_delta stream frames never grow the thinking row

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -517,7 +517,10 @@ shapes are [`.patterns/tuval-spells.md`](../.patterns/tuval-spells.md).
   not an event kind, and it names no backend: the window learns "still growing" once and every
   agent program streams the same way ([#8142's
   ruling](https://github.com/kamp-us/phoenix/issues/8142), epic
-  [#8160](https://github.com/kamp-us/phoenix/issues/8160)). Source:
+  [#8160](https://github.com/kamp-us/phoenix/issues/8160)). Two kinds grow one — the assistant reply
+  and the thinking row, since a turn's reasoning streams before its answer does
+  ([#8288](https://github.com/kamp-us/phoenix/issues/8288)) — and every predicate that reads the
+  marker reads it through `in`, so a third costs no arm. Source:
   [`apps/tuval/src/ai-agent/ports/transcript-item.ts`](../apps/tuval/src/ai-agent/ports/transcript-item.ts).
 
 ### Tuval: thinking row, compaction marker, session row

--- a/.patterns/snapshot-authoritative-to-delta-events.md
+++ b/.patterns/snapshot-authoritative-to-delta-events.md
@@ -45,7 +45,7 @@ phase above a reply that has not landed yet, and usage annotates a turn that is 
 
 An item id used for live upserts is not necessarily a stored paging cursor. Keep the visual anchor
 and the cursor separate: [`history/cursor.ts`](../apps/tuval/src/ai-agent/history/cursor.ts) skips
-local echoes and partial assistant rows once for the handler and window, returning an explicit
+local echoes and every partial row once for the handler and window, returning an explicit
 unavailable result rather than turning absence into `before: null` (the newest end). A partial row
 can arrive before its first completed block exists in storage; a live id alone does not prove that
 an alias has a target. Completion makes that row eligible on the next request; the local visual

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -8,6 +8,7 @@ import {pendingPermission} from "../../ai-agent-fixtures/permissions.ts";
 import {
 	assistantItem,
 	subagentSlot,
+	thinkingItem,
 	toolItem,
 	userItem,
 } from "../../ai-agent-fixtures/transcripts.ts";
@@ -171,6 +172,16 @@ describe("what is worth a checkpoint write", () => {
 		};
 		expect(checkpointWorthy(partial)).toBe(false);
 		expect(checkpointWorthy(base)).toBe(true);
+	});
+
+	// The gate reads the marker through `in`, so reasoning growing one costs it no arm (#8288).
+	it("refuses a state whose reasoning is still being written", () => {
+		const reasoning = {
+			...base,
+			transcript: {...base.transcript, items: [{...thinkingItem("k1"), partial: true}]},
+		};
+		expect(checkpointWorthy(reasoning)).toBe(false);
+		expect(checkpointWorthy({...reasoning, transcript: {...base.transcript}})).toBe(true);
 	});
 });
 

--- a/apps/tuval/src/ai-agent/history/cursor.ts
+++ b/apps/tuval/src/ai-agent/history/cursor.ts
@@ -4,10 +4,13 @@ export type PageCursor =
 	| {readonly kind: "page"; readonly before: string | null}
 	| {readonly kind: "unavailable"};
 
+// The partial arm is read through `in` rather than off the assistant kind, for the reason
+// `../core/state.ts`'s `holdsPartialItem` is: reasoning grows a partial row of its own now (#8288),
+// and a third kind that grows one must not need this predicate edited to stay off the cursor.
 const isUnavailable = (item: TranscriptItem): boolean =>
 	(item.kind === "user" && item.local === true) ||
 	item.id.startsWith("local:") ||
-	(item.kind === "assistant" && item.partial === true);
+	("partial" in item && item.partial === true);
 
 /** Live partial text need not have a stored frame yet; aliases only join completed rows. */
 export const pageCursor = (

--- a/apps/tuval/src/ai-agent/history/page.unit.test.ts
+++ b/apps/tuval/src/ai-agent/history/page.unit.test.ts
@@ -3,6 +3,7 @@ import {
 	assistantItem,
 	randomStream,
 	randomTranscript,
+	thinkingItem,
 	toolItem,
 	userItem,
 } from "../../ai-agent-fixtures/transcripts.ts";
@@ -197,6 +198,21 @@ describe("a local echo is not a stored page cursor", () => {
 		expect(pageCursor([local, {...reply, partial: false}], local.id)).toEqual({
 			kind: "page",
 			before: reply.id,
+		});
+	});
+
+	// Reasoning grows a partial row of its own (#8288), and it need not have a stored frame either.
+	it("never selects reasoning that is still being written", () => {
+		const growing = {...thinkingItem("stored-thinking"), partial: true};
+		expect(pageCursor([local, growing], local.id)).toEqual({kind: "unavailable"});
+		expect(pageCursor([local, growing], growing.id)).toEqual({kind: "unavailable"});
+		expect(pageCursor([local, growing, ...older], local.id)).toEqual({
+			kind: "page",
+			before: older[0]?.id,
+		});
+		expect(pageCursor([local, thinkingItem("stored-thinking")], local.id)).toEqual({
+			kind: "page",
+			before: "stored-thinking",
 		});
 	});
 

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -88,10 +88,15 @@ export interface ToolItem extends ItemBase {
  *
  * Model-blind like every other item: no provider signature, no redaction flag, no effort level.
  * `ports/thinking.ts` is the effort-level *control* and has nothing to do with this row.
+ *
+ * `partial` is `AssistantItem`'s marker and carries exactly its contract: absent means final, and a
+ * backend re-upserts this same id as the reasoning grows. Reasoning streams before the answer does,
+ * so a window that reads the marker on one kind reads it on both without learning a second field.
  */
 export interface ThinkingItem extends ItemBase {
 	readonly kind: "thinking";
 	readonly text: string;
+	readonly partial?: boolean;
 }
 
 /**
@@ -219,9 +224,10 @@ export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 				typeof value.text === "string" &&
 				(value.detail === undefined || typeof value.detail === "string")
 			);
-		case "thinking":
 		case "compaction":
 			return typeof value.text === "string";
+		case "thinking":
+			return typeof value.text === "string" && isOptionalFlag(value.partial);
 		case "assistant":
 			return (
 				typeof value.text === "string" &&

--- a/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.unit.test.ts
@@ -2,11 +2,19 @@ import {describe, expect, it} from "vitest";
 import {
 	boundToolResult,
 	byteLength,
+	type CompactionItem,
 	ItemId,
 	isTranscriptItem,
 	TOOL_RESULT_BYTE_LIMIT,
 	type TranscriptItem,
 } from "./transcript-item.ts";
+
+/**
+ * The streaming marker is the growing kinds' alone. A compaction boundary is written once and never
+ * rewritten, so it declares nothing a reader could watch — giving it the field reds here with
+ * TS2322, at the line that says why.
+ */
+const compactionStreamsNothing: "partial" extends keyof CompactionItem ? false : true = true;
 
 const at = 1_756_000_000_000;
 const id = (value: string) => ItemId.make(value);
@@ -52,6 +60,19 @@ describe("transcript item union", () => {
 		expect(isTranscriptItem({...assistant, partial: "true"})).toBe(false);
 		expect(isTranscriptItem({...assistant, partial: 1})).toBe(false);
 		expect(isTranscriptItem({...assistant, partial: null})).toBe(false);
+	});
+
+	it("admits reasoning still being written, and reasoning that has finished", () => {
+		expect(isTranscriptItem({...thinking, partial: true})).toBe(true);
+		expect(isTranscriptItem({...thinking, partial: false})).toBe(true);
+		expect(isTranscriptItem({...thinking, partial: undefined})).toBe(true);
+	});
+
+	it("refuses a reasoning partial marker that is not a flag", () => {
+		expect(isTranscriptItem({...thinking, partial: "true"})).toBe(false);
+		expect(isTranscriptItem({...thinking, partial: 1})).toBe(false);
+		expect(isTranscriptItem({...thinking, partial: null})).toBe(false);
+		expect(compactionStreamsNothing).toBe(true);
 	});
 
 	it("refuses an item of an unknown kind", () => {

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -465,10 +465,10 @@ describe("toAgentEvents over a captured streaming turn", () => {
 
 describe("toAgentEvents over a thinking delta", () => {
 	/**
-	 * No committed capture holds one: whether a turn reasons is the provider's call, not a run's
-	 * (`fixtures/PROVENANCE.md`). So this stamps the delta the SDK declares — a `thinking_delta`
-	 * carrying `thinking` — over the golden streaming turn's own first delta, and every other frame
-	 * stays the captured shape.
+	 * `streaming-turn` holds no reasoning of its own — whether a turn reasons is the provider's call,
+	 * not a run's (`fixtures/PROVENANCE.md`). So this stamps the delta the SDK declares — a
+	 * `thinking_delta` carrying `thinking` — over that capture's own deltas, and every other frame
+	 * stays the captured shape. The reasoning stream `subagent-turn` did capture is below.
 	 */
 	const reasoning = (stream: ReadonlyArray<SDKMessage>): ReadonlyArray<SDKMessage> =>
 		stream.map((one) =>
@@ -807,5 +807,183 @@ describe("toAgentEvents over a subagent's streamed reply", () => {
 			(one) => one.kind === "assistant",
 		);
 		expect(replies.map((one) => "parentId" in one)).toEqual(replies.map(() => false));
+	});
+});
+
+describe("toAgentEvents over the one captured stream that reasons", () => {
+	/**
+	 * `subagent-turn.json` is it: `content_block_start` on a `thinking` block, two `thinking_delta`
+	 * frames, a `signature_delta`, then that block's own `assistant` frame. Every one of those deltas
+	 * carries an empty `thinking` — the provider ships this pin's reasoning encrypted, in both wire
+	 * forms and in every capture (`fixtures/PROVENANCE.md`) — so what the capture proves is the
+	 * withheld half. The plaintext half is stamped over these same frames in the case below.
+	 */
+	const MSG = "msg_000000000000000000000001";
+	const {events, mapping} = run(messages("subagent-turn"));
+	const reasoning = tail(events).filter(
+		(one) => one.kind === "thinking" && one.parentId === undefined,
+	);
+
+	it("draws no growing row for withheld reasoning, and settles the row that says it was", () => {
+		expect(reasoning).toEqual([
+			{
+				kind: "thinking",
+				id: `${MSG}:thinking`,
+				timestamp: AT,
+				text: "(the provider withheld this reasoning)",
+			},
+		]);
+	});
+
+	it("keeps the block's signature out of every row, reasoning or reply", () => {
+		expect(JSON.stringify(items(events))).not.toContain("SIGNATURE-PLACEHOLDER");
+		expect(mapping.thinking).toBe("");
+	});
+});
+
+/**
+ * The captured reasoning stream with plaintext where the encrypted reasoning was: the two
+ * `thinking_delta` frames of `subagent-turn.json` and the `thinking` block of the `assistant` frame
+ * that settles them. Nothing else is touched — the envelopes, the block boundaries and the arrival
+ * order are the capture's — and no run can force the plaintext (`fixtures/PROVENANCE.md`).
+ */
+const REASONED = ["let me ", "weigh it"];
+
+const carriesThinking = (one: SDKMessage): boolean =>
+	one.type === "assistant" &&
+	Array.isArray(one.message.content) &&
+	one.message.content.some((block) => block.type === "thinking");
+
+const spokenAloud = (stream: ReadonlyArray<SDKMessage>): ReadonlyArray<SDKMessage> => {
+	let next = 0;
+	return stream.map((one) => {
+		if (
+			one.type === "stream_event" &&
+			one.event.type === "content_block_delta" &&
+			one.event.delta.type === "thinking_delta"
+		) {
+			const thinking = REASONED[next] ?? "";
+			next += 1;
+			return {...one, event: {...one.event, delta: {...one.event.delta, thinking}}} as SDKMessage;
+		}
+		if (one.type !== "assistant" || !carriesThinking(one)) return one;
+		return {
+			...one,
+			message: {
+				...one.message,
+				content: one.message.content.map((block) =>
+					block.type === "thinking" ? {...block, thinking: REASONED.join("")} : block,
+				),
+			},
+		} as SDKMessage;
+	});
+};
+
+describe("toAgentEvents over a streamed reasoning block that is not withheld", () => {
+	const MSG = "msg_000000000000000000000001";
+	const ANSWER = "msg_000000000000000000000004";
+	const {events, mapping} = run(spokenAloud(messages("subagent-turn")));
+	const reasoning = items(events).filter(
+		(one) => one.kind === "thinking" && one.parentId === undefined,
+	);
+
+	it("grows one reasoning row across the deltas instead of a row apiece", () => {
+		expect(new Set(reasoning.map((one) => one.id))).toEqual(new Set([`${MSG}:thinking`]));
+		expect(reasoning.map((one) => one.kind === "thinking" && one.text)).toEqual([
+			"let me ",
+			"let me weigh it",
+			"let me weigh it",
+		]);
+	});
+
+	it("holds the row's clock and its parent through the growth and the settle", () => {
+		expect(reasoning.map((one) => one.timestamp)).toEqual(reasoning.map(() => AT));
+		expect(reasoning.map((one) => "parentId" in one)).toEqual(reasoning.map(() => false));
+	});
+
+	it("marks every row but the settled one as still being written", () => {
+		expect(reasoning.map((one) => one.kind === "thinking" && one.partial)).toEqual([
+			true,
+			true,
+			undefined,
+		]);
+	});
+
+	it("keeps the reasoning out of the reply, and still streams the answer that follows it", () => {
+		const replies = items(events).filter(
+			(one) => one.kind === "assistant" && one.parentId === undefined,
+		);
+		expect(replies.every((one) => one.kind === "assistant" && !one.text.includes("weigh it"))).toBe(
+			true,
+		);
+		const answer = tail(events).find((one) => one.id === ANSWER);
+		expect(answer?.kind === "assistant" && answer.text.startsWith("Subagent's answer:")).toBe(true);
+		expect(answer !== undefined && !("partial" in answer)).toBe(true);
+	});
+
+	it("leaves nothing partial once the stream has ended", () => {
+		expect(tail(events).filter((one) => "partial" in one && one.partial === true)).toEqual([]);
+		expect(mapping.thinking).toBe("");
+		expect(mapping.partial).toBeNull();
+	});
+});
+
+describe("toAgentEvents over reasoning no assistant frame ever settles", () => {
+	/**
+	 * The stamped stream with the frame that carries the reasoning block dropped, which is what a
+	 * turn cut inside the block leaves: nothing downstream settles the row the deltas drew, and a row
+	 * left marked partial is one nothing checkpoints past for the rest of the session (#8170).
+	 * Dropping that frame is this case's only variable.
+	 */
+	const MSG = "msg_000000000000000000000001";
+	const stream = spokenAloud(messages("subagent-turn")).filter((one) => !carriesThinking(one));
+	const ownReasoning = (events: ReadonlyArray<AgentEvent>) =>
+		tail(events).filter((one) => one.kind === "thinking" && one.parentId === undefined);
+
+	it("settles the row at the text the deltas wrote when the stream ends", () => {
+		const {events, mapping} = run(stream);
+		expect(ownReasoning(events)).toEqual([
+			{kind: "thinking", id: `${MSG}:thinking`, timestamp: AT, text: "let me weigh it"},
+		]);
+		expect(mapping.thinking).toBe("");
+	});
+
+	it("settles it on the frame that cut the turn instead, when one arrives first", () => {
+		// `aborted` is the SDK's mark for a message the stream cut mid-word. The frame is the
+		// capture's own, of this same turn; only the mark is stamped.
+		const cut = stream.map((one) =>
+			one.type === "assistant" && one.message.id === MSG
+				? ({...one, aborted: true} as SDKMessage)
+				: one,
+		);
+		const {events, mapping} = run(cut);
+		expect(ownReasoning(events)).toEqual([
+			{kind: "thinking", id: `${MSG}:thinking`, timestamp: AT, text: "let me weigh it"},
+		]);
+		expect(mapping.thinking).toBe("");
+	});
+});
+
+describe("toAgentEvents over a subagent's streamed reasoning", () => {
+	/**
+	 * A worker's reply is forwarded whole and never streamed, so no run can force a nested
+	 * `stream_event` (`fixtures/PROVENANCE.md`). `SDKPartialAssistantMessage` declares
+	 * `parent_tool_use_id: string | null` exactly as an assistant frame does (`sdk.d.ts`, 0.3.259),
+	 * so this is the stamped reasoning stream with that one field stamped over it as well.
+	 */
+	const PARENT = "toolu_01SubagentParent";
+	const nested = spokenAloud(messages("subagent-turn")).map((one) =>
+		one.type === "stream_event" || one.type === "assistant"
+			? ({...one, parent_tool_use_id: PARENT} as SDKMessage)
+			: one,
+	);
+
+	it("tags every upsert of the growing reasoning, and the settled row that replaces them", () => {
+		const reasoning = items(run(nested).events).filter((one) => one.kind === "thinking");
+		expect(reasoning.length).toBeGreaterThan(1);
+		expect(reasoning.map((one) => one.parentId)).toEqual(reasoning.map(() => PARENT));
+		expect(
+			reasoning.filter((one) => one.kind === "thinking" && one.partial !== true).length,
+		).toBeGreaterThan(0);
 	});
 });

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -206,12 +206,19 @@ so a worker's reply is forwarded whole rather than delta by delta and no run can
 case. `events.unit.test.ts` covers it by stamping that one field over the golden `streaming-turn`
 stream, and says so at the case.
 
-**A worker's reasoning in plain text.** Both captures agree and neither has one: `subagent-turn.json`
-carries two `thinking` blocks and the sidechain pair two more, every one with a real `signature` and
-an empty `thinking` string — the provider ships a worker's reasoning encrypted. Four `query()` runs
-at this pin (two models, two thinking budgets) produced no plaintext one, so `thinking-turn.json`'s
-shape is not what a live worker yields today. `blocks.ts` reads the empty-with-signature shape as
-withheld, which is what the captures forced.
+**Reasoning in plain text off a stream.** Both captures agree and neither has one:
+`subagent-turn.json` carries two `thinking` blocks and the sidechain pair two more, every one with a
+real `signature` and an empty `thinking` string — the provider ships reasoning encrypted, and its
+two `thinking_delta` frames carry the empty string for the same reason. Four `query()` runs at this
+pin (two models, two thinking budgets) produced no plaintext one, so `thinking-turn.json`'s shape is
+not what a live stream yields today. `blocks.ts` reads the empty-with-signature shape as withheld,
+which is what the captures forced.
+
+`subagent-turn.json` is still the only capture whose *stream* reasons, and it is what
+`events.unit.test.ts` folds for the withheld case. For the growing row (#8288) that file stamps
+plaintext over those two `thinking_delta` frames and the `thinking` block of the `assistant` frame
+that settles them, leaving every envelope, block boundary and arrival order the capture's — and says
+so at the case.
 
 **Two workers under one *parent* tool call.** Both captures spawn workers as siblings of each other.
 A `Task` call made *by* a worker — `spawn_depth` above 1 — is uncaptured, and nothing a prompt

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -39,6 +39,13 @@ import {
 const itemId = (value: string): ItemId => value as ItemId;
 
 /**
+ * The reasoning row of a turn, keyed off the turn's own row and suffixed. One frame carrying both a
+ * thinking block and text is two rows, and two rows sharing an id would fold into one — and the
+ * deltas that grow this row take the same key, so growing and settled are one row.
+ */
+const thinkingId = (turnId: string): ItemId => itemId(`${turnId}:thinking`);
+
+/**
  * One tool call the transcript has opened and not yet settled. `at` is the call's own clock, kept
  * so the settled row lands at the time of the call rather than of its answer — a transcript read
  * oldest-first has to stay monotonic, and a row that jumped forward when it settled would not.
@@ -91,6 +98,16 @@ export interface Mapping {
 	 * on the frame's own uuid and appended below whatever arrived in between (#8366).
 	 */
 	readonly settled: PartialReply | null;
+	/**
+	 * The reasoning block the deltas are growing, as they have written it so far; empty when none is
+	 * open. It needs no id, clock or parent of its own: a reasoning block belongs to the turn the
+	 * open reply already names, and its row is that reply's id suffixed `:thinking` — the same key
+	 * `assistantEvents` settles on, so the growing row and the settled one are one row (#8288).
+	 *
+	 * Reset at each reasoning block rather than joined across them, because the frame that settles
+	 * one carries that block alone: joining would grow a row the settle then shrinks.
+	 */
+	readonly thinking: string;
 	/** Every subagent slot this stream has opened, by the spawning call's id. */
 	readonly subagents: ReadonlyMap<string, SubagentSlot>;
 	/** How many messages this mapping had nothing to say about. */
@@ -102,6 +119,7 @@ export const emptyMapping: Mapping = {
 	toolCalls: new Map(),
 	partial: null,
 	settled: null,
+	thinking: "",
 	subagents: new Map(),
 	skipped: 0,
 };
@@ -339,14 +357,20 @@ export const assistantEvents = (
 	const tagged = parentId === null ? {} : {parentId: itemId(parentId)};
 	const emitted: Array<TranscriptItem> = [];
 	const thinking = thinkingOf(body);
-	if (thinking.length > 0) {
-		// Suffixed rather than the frame's own uuid, because one frame carrying both a thinking block
-		// and text is two rows, and two rows sharing an id would fold into one.
+	// Only a frame of the open reply's own turn ends it, for the same reason it alone closes the
+	// reply below: a subagent's frame arrives mid-stream and carries a stop reason of its own.
+	const endsOpen = open !== null && ends;
+	// What the deltas of this turn's open reasoning block wrote, when the run streamed them. A frame
+	// carrying the block settles the row they drew; an *ending* frame that carries no block settles
+	// it at the text they wrote, because a cut turn must not leave that row partial forever (#8288).
+	const reasoning =
+		thinking.length > 0 ? thinkingTextOf(thinking) : endsOpen ? mapping.thinking : "";
+	if (reasoning.length > 0) {
 		emitted.push({
 			kind: "thinking",
-			id: itemId(`${id}:thinking`),
+			id: thinkingId(id),
 			timestamp: at,
-			text: thinkingTextOf(thinking),
+			text: reasoning,
 			...tagged,
 		});
 	}
@@ -405,6 +429,7 @@ export const assistantEvents = (
 			// A row this frame leaves settled stays reachable, so a further frame of the same turn —
 			// a trailing content block — still lands on it rather than beside it.
 			settled: reply === null || (open !== null && !ends) ? mapping.settled : reply,
+			thinking: thinking.length > 0 || endsOpen ? "" : mapping.thinking,
 		},
 		events,
 	};
@@ -443,6 +468,21 @@ const textDeltaOf = (event: Record<string, unknown>): string => {
 	return typeof delta.text === "string" ? delta.text : "";
 };
 
+/**
+ * The reasoning one frame adds: "concatenate the `thinking` values of successive `thinking_delta`
+ * events to assemble the block's full `thinking` value" (`@anthropic-ai/sdk`, `BetaThinkingDelta`).
+ *
+ * A `signature_delta` carries a `signature` and no reasoning at all — an opaque value the API reads
+ * back, not text (`BetaSignatureDelta`) — so it adds nothing here and reaches no row. The captured
+ * `thinking_delta` frames add nothing either: the provider ships this pin's reasoning encrypted, so
+ * their `thinking` is empty and the settled block is what says a block was there.
+ */
+const thinkingDeltaOf = (event: Record<string, unknown>): string => {
+	const delta = event.delta;
+	if (!isRecord(delta) || delta.type !== "thinking_delta") return "";
+	return typeof delta.thinking === "string" ? delta.thinking : "";
+};
+
 /** The `message_delta` that announces the turn's stop reason, which ends the stream with it. */
 const stopsStream = (event: Record<string, unknown>): boolean =>
 	event.type === "message_delta" && stopReasonOf(event.delta) !== null;
@@ -460,8 +500,9 @@ const grown = (open: PartialReply, text: string): PartialReply => ({
  * counted rather than given an id of its own — that happens to a reader that joined the stream
  * mid-turn, and inventing a key for it would put a second row on screen for one answer.
  *
- * A `thinking_delta` is not assistant text. The reasoning a turn streams is the `thinking` item
- * kind's, never folded into the reply, so it leaves this row where it was.
+ * A `thinking_delta` is not assistant text. The reasoning a turn streams grows a `thinking` row of
+ * its own, keyed off this reply's id and settled by the same frame that settles the block — so the
+ * row the operator watches open is the row that stays (#8288). It never touches the reply.
  *
  * The end of the stream is what settles the row: `message_stop`, or the `message_delta` carrying
  * the turn's `stop_reason`. Nothing earlier can, because the turn emits one `assistant` frame per
@@ -481,30 +522,59 @@ export const partialReplyEvents = (
 		if (id.length === 0) return skipMessage(mapping);
 		const at = timestampOf(message, options.at);
 		const parentId = parentToolUseIdOf(message);
-		return {mapping: {...mapping, partial: {id, text: "", at, parentId}}, events: []};
+		return {mapping: {...mapping, partial: {id, text: "", at, parentId}, thinking: ""}, events: []};
 	}
 	const open = mapping.partial;
 	if (open === null) return skipMessage(mapping);
 	const tagged = open.parentId === null ? {} : {parentId: itemId(open.parentId)};
 	if (event.type === "message_stop" || stopsStream(event)) {
-		if (open.text.length === 0)
-			return {mapping: {...mapping, partial: null, settled: open}, events: []};
-		const settledRow: TranscriptItem = {
-			kind: "assistant",
-			id: itemId(open.id),
-			timestamp: open.at,
-			text: open.text,
-			...tagged,
-		};
-		const folded = foldSlots(mapping, [settledRow], open.parentId, 0);
+		const settledRows: Array<TranscriptItem> = [];
+		// Reasoning the deltas drew that no `assistant` frame ever carried — a turn cut mid-block is
+		// the case. The end of the stream is the last moment it can settle, and a row left marked
+		// partial is a row nothing checkpoints past for the rest of the session (#8170).
+		if (mapping.thinking.length > 0) {
+			settledRows.push({
+				kind: "thinking",
+				id: thinkingId(open.id),
+				timestamp: open.at,
+				text: mapping.thinking,
+				...tagged,
+			});
+		}
+		if (open.text.length > 0) {
+			settledRows.push({
+				kind: "assistant",
+				id: itemId(open.id),
+				timestamp: open.at,
+				text: open.text,
+				...tagged,
+			});
+		}
+		const folded = foldSlots(mapping, settledRows, open.parentId, 0);
 		return {
-			mapping: {...mapping, partial: null, settled: open, subagents: folded.subagents},
-			events: [item(settledRow), ...folded.events],
+			mapping: {
+				...mapping,
+				partial: null,
+				settled: open,
+				thinking: "",
+				subagents: folded.subagents,
+			},
+			events: [...settledRows.map(item), ...folded.events],
 		};
 	}
 	if (event.type === "content_block_start") {
 		const block = event.content_block;
-		if (!isRecord(block) || block.type !== "text") return skipMessage(mapping);
+		if (!isRecord(block)) return skipMessage(mapping);
+		if (block.type === "thinking") {
+			// The block's own opening text, replacing whatever the last reasoning block wrote: the
+			// `assistant` frame that settles a block carries that block alone. A block opens empty and
+			// its `signature` is not reasoning, so nothing is drawn until a delta arrives.
+			return {
+				mapping: {...mapping, thinking: typeof block.thinking === "string" ? block.thinking : ""},
+				events: [],
+			};
+		}
+		if (block.type !== "text") return skipMessage(mapping);
 		// `textOf` joins a body's text blocks on a newline, so the growing row joins them the same
 		// way: without this the last upsert would reflow text the operator was already reading.
 		const lead = open.text.length === 0 ? "" : "\n";
@@ -512,6 +582,23 @@ export const partialReplyEvents = (
 		return {mapping: {...mapping, partial: grown(open, lead + opening)}, events: []};
 	}
 	if (event.type !== "content_block_delta") return skipMessage(mapping);
+	const reasoning = thinkingDeltaOf(event);
+	if (reasoning.length > 0) {
+		const thinking = mapping.thinking + reasoning;
+		const upsert: TranscriptItem = {
+			kind: "thinking",
+			id: thinkingId(open.id),
+			timestamp: open.at,
+			text: thinking,
+			partial: true,
+			...tagged,
+		};
+		const line = slotLine(mapping, open.parentId, lineOf(upsert));
+		return {
+			mapping: {...mapping, thinking, subagents: line.subagents},
+			events: [item(upsert), ...line.events],
+		};
+	}
 	const text = textDeltaOf(event);
 	if (text.length === 0) return skipMessage(mapping);
 	const partial = grown(open, text);


### PR DESCRIPTION
Reasoning streamed by the Claude backend now grows a thinking row of its own instead of arriving whole on the block's `assistant` frame. `thinking_delta` frames upsert `<msg id>:thinking` with `partial: true` under the turn's stable id, and the frame that carries the block settles that same row with the marker gone.

What changed:

- `ThinkingItem` takes `AssistantItem`'s optional `partial` marker, and the port predicate reads it as a flag on the thinking kind only. Compaction keeps no streaming contract — a type-level assertion in the port test reds if it ever grows one.
- `map.ts` holds the open block's text on `Mapping.thinking`, reset per block because the `assistant` frame that settles a block carries that block alone. The row is keyed off the reply's `msg_*` suffixed `:thinking`, so the growing row and the settled row are one row at one clock with one parent tag. A `signature_delta` carries a signature and no reasoning, so it reaches no row.
- Terminal handling: the end of the stream settles a block no `assistant` frame carried, and an ending or aborted frame of the same turn does the same — nothing can strand a forever-partial row. `holdsPartialItem` / `settlePartialItems` already read the marker through `in` and needed no arm; `history/cursor.ts` did, and now reads it the same way.

Grounded in the pinned SDK's own source: `BetaThinkingDelta.thinking` is the increment to concatenate and `BetaSignatureDelta` carries only an opaque signature (`@anthropic-ai/sdk`, `resources/beta/messages/messages.d.ts`); `SDKPartialAssistantMessage.event` is one Messages-API stream event and its `uuid` is the frame's, not the turn's (`@anthropic-ai/claude-agent-sdk@0.3.259`, `sdk.d.ts`).

Tests ride the change. `subagent-turn.json` turns out to be a real captured reasoning stream — `content_block_start` on a thinking block, two `thinking_delta` frames, a `signature_delta`, then the block's `assistant` frame — so the withheld case folds the capture as-is. Its deltas carry an empty `thinking` because the provider ships this pin's reasoning encrypted, so the growing case stamps plaintext over those two frames and the block the settling frame carries, leaving every envelope and the arrival order the capture's. The stamp is disclosed at each case and in `fixtures/PROVENANCE.md`.

Ran: `vitest run src/claude/history src/ai-agent` (544 passed) and `src/pi src/protocol src/shell/chat` (580 passed); `build check` green on both the code and prose surfaces.

Fixes #8288

## Deviations

- **Out-of-scope change** — **Said:** #8288 names the port, the Claude mapper and the shared settlement predicates. **Did:** also corrected one line of `.patterns/snapshot-authoritative-to-delta-events.md` and extended the `.glossary/LANGUAGE.md` `partial` entry. **Why:** the pattern doc said the cursor skips "partial assistant rows", which this change makes false, and the glossary entry is the marker's definition. **Disposition:** stated here.
