### PR TITLE
fix: Tuval Pi chat cannot page history: live items are item-index but the page reads entry ids

### DIFF
--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -37,7 +37,7 @@ import {dirname, join} from "node:path";
 import {getAgentDir, ModelRuntime, SessionManager} from "@earendil-works/pi-coding-agent";
 import type {SessionSnapshot} from "@earendil-works/pi-protocol";
 import {type Cause, Effect, Fiber, Layer, Queue, Redacted, Ref, type Scope, Stream} from "effect";
-import {isRefusal, planTranscriptPage} from "../../ai-agent/history/index.ts";
+import {isRefusal} from "../../ai-agent/history/index.ts";
 import type {
 	Mode,
 	ModelRef,
@@ -70,7 +70,7 @@ import {
 	type PiSessionHost,
 	type ServerBindFailed,
 } from "../server/index.ts";
-import {pageCursorAliases, pageItems} from "./entries.ts";
+import {planPageOverEntries} from "./entries.ts";
 import {
 	emptyProjection,
 	eventsOf,
@@ -582,12 +582,7 @@ const make = (
 				});
 			}
 			const entries = yield* readBranch(sessionDir(current.cwd), current.id, current.cwd);
-			const planned = planTranscriptPage(pageItems(entries), {
-				before,
-				cursorAliases: pageCursorAliases(entries),
-				limit,
-				cursorBoundary: "containing-group",
-			});
+			const planned = planPageOverEntries(entries, {before, limit});
 			if (isRefusal(planned)) {
 				if (planned.reason === "limit-not-positive") {
 					// The port declares `limit > 0`; a caller that broke it has a bug this
@@ -631,11 +626,9 @@ const make = (
 				try: () => SessionManager.open(file, dirname(file), query.cwd).getBranch(),
 				catch: (cause) => transcriptUnreadable(query.sessionId, cause),
 			});
-			const planned = planTranscriptPage(pageItems(entries), {
+			const planned = planPageOverEntries(entries, {
 				before: query.before,
-				cursorAliases: pageCursorAliases(entries),
 				limit: query.limit,
-				cursorBoundary: "containing-group",
 			});
 			if (isRefusal(planned)) {
 				if (planned.reason === "limit-not-positive") {

--- a/apps/tuval/src/pi/ai-agent/entries.ts
+++ b/apps/tuval/src/pi/ai-agent/entries.ts
@@ -30,6 +30,7 @@ import {
 	sessionEntryToContextMessages,
 } from "@earendil-works/pi-coding-agent";
 import type {TranscriptItem as PiTranscriptItem} from "@earendil-works/pi-protocol";
+import {planTranscriptPage, type TranscriptPageResult} from "../../ai-agent/history/index.ts";
 import type {SystemItem, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {projectTranscript, type SourceMessage} from "../server/index.ts";
 import {itemId, itemsOf, thinkingId} from "./items.ts";
@@ -155,3 +156,22 @@ export const pageItems = (entries: ReadonlyArray<SessionEntry>): ReadonlyArray<T
 	}
 	return items;
 };
+
+/**
+ * One page of this branch, planned the one way every caller must plan it.
+ *
+ * `cursorAliases` is what joins the window's live `item-<index>` cursor to the stored ids
+ * `pageItems` keys by, and it is the whole of #8204's fix — so it lives here, where a test can
+ * exercise the same construction the callers do, rather than being re-typed at each call site,
+ * where dropping it reds nothing.
+ */
+export const planPageOverEntries = (
+	entries: ReadonlyArray<SessionEntry>,
+	bound: {readonly before: string | null; readonly limit: number},
+): TranscriptPageResult =>
+	planTranscriptPage(pageItems(entries), {
+		before: bound.before,
+		cursorAliases: pageCursorAliases(entries),
+		limit: bound.limit,
+		cursorBoundary: "containing-group",
+	});

--- a/apps/tuval/src/pi/ai-agent/paging-from-live.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/paging-from-live.unit.test.ts
@@ -15,10 +15,10 @@
 import type {CompactionEntry, SessionEntry} from "@earendil-works/pi-coding-agent";
 import {buildContextEntries, sessionEntryToContextMessages} from "@earendil-works/pi-coding-agent";
 import {describe, expect, it} from "vitest";
-import {isRefusal, planTranscriptPage} from "../../ai-agent/history/index.ts";
+import {isRefusal} from "../../ai-agent/history/index.ts";
 import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {projectTranscript, type SourceMessage} from "../server/index.ts";
-import {pageCursorAliases, pageItems} from "./entries.ts";
+import {pageItems, planPageOverEntries} from "./entries.ts";
 import {itemsOf} from "./items.ts";
 
 const at = (seconds: number): string => new Date(1_760_000_000_000 + seconds * 1_000).toISOString();
@@ -67,14 +67,13 @@ const liveTail = (entries: ReadonlyArray<SessionEntry>): ReadonlyArray<Transcrip
 	return projectTranscript(messages).flatMap((item) => [...itemsOf(item)]);
 };
 
-/** The `page` request `PiAiAgent` plans, minus the disk read. */
+/**
+ * The `page` request, minus the disk read. It goes through `planPageOverEntries` — the same
+ * function `PiAiAgent`'s `page` and `sessionTranscript` call — rather than re-typing the planner
+ * options here, so removing the cursor alias from the shipped path reds this file (#8502 review).
+ */
 const pageBefore = (entries: ReadonlyArray<SessionEntry>, before: string | null, limit = 10) =>
-	planTranscriptPage(pageItems(entries), {
-		before,
-		cursorAliases: pageCursorAliases(entries),
-		limit,
-		cursorBoundary: "containing-group",
-	});
+	planPageOverEntries(entries, {before, limit});
 
 const texts = (items: ReadonlyArray<TranscriptItem>): ReadonlyArray<string> =>
 	items.map((item) => {

--- a/apps/tuval/src/pi/ai-agent/paging-from-live.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/paging-from-live.unit.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The seam #8204 reported broken: a Pi window's live rows and its history page are built by two
+ * different modules, and the window pages by sending a live row's own id back as the cursor.
+ *
+ * The two paths are joined here rather than in either module's own test, because neither of them
+ * can see the mismatch alone. `items.ts` keys a live row `item-<index>` over the context messages
+ * Pi's host projected; `entries.ts` keys the same message by its stored entry id, which is what
+ * survives the renumbering a compaction causes. The join is `pageCursorAliases`, and it is
+ * position-for-position with Pi's own context build — so the live tail here is projected the way
+ * `../server/AgentSessionHost.ts` projects it (`buildContextEntries` → `sessionEntryToContextMessages`
+ * → `projectTranscript`), never hand-numbered. Hand-numbering would pass while the real thing
+ * failed, which is the whole bug.
+ */
+
+import type {CompactionEntry, SessionEntry} from "@earendil-works/pi-coding-agent";
+import {buildContextEntries, sessionEntryToContextMessages} from "@earendil-works/pi-coding-agent";
+import {describe, expect, it} from "vitest";
+import {isRefusal, planTranscriptPage} from "../../ai-agent/history/index.ts";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {projectTranscript, type SourceMessage} from "../server/index.ts";
+import {pageCursorAliases, pageItems} from "./entries.ts";
+import {itemsOf} from "./items.ts";
+
+const at = (seconds: number): string => new Date(1_760_000_000_000 + seconds * 1_000).toISOString();
+
+const message = (id: string, parent: string | null, seconds: number, body: unknown): SessionEntry =>
+	({type: "message", id, parentId: parent, timestamp: at(seconds), message: body}) as SessionEntry;
+
+const said = (text: string) => ({
+	role: "user" as const,
+	content: [{type: "text" as const, text}],
+	timestamp: 0,
+});
+
+const replied = (text: string) => ({
+	role: "assistant" as const,
+	content: [{type: "text" as const, text}],
+	provider: "faux",
+	model: "faux-1",
+	stopReason: "stop",
+	timestamp: 0,
+});
+
+const called = (callId: string, name: string) => ({
+	role: "assistant" as const,
+	content: [{type: "toolCall" as const, id: callId, name, arguments: {path: "notes.md"}}],
+	provider: "faux",
+	model: "faux-1",
+	stopReason: "toolUse",
+	timestamp: 0,
+});
+
+const resulted = (callId: string, name: string, text: string) => ({
+	role: "toolResult" as const,
+	toolCallId: callId,
+	toolName: name,
+	content: [{type: "text" as const, text}],
+	isError: false,
+	timestamp: 0,
+});
+
+/** The rows the window's live tail holds, projected the way the real host projects them. */
+const liveTail = (entries: ReadonlyArray<SessionEntry>): ReadonlyArray<TranscriptItem> => {
+	const messages = buildContextEntries([...entries]).flatMap(
+		sessionEntryToContextMessages,
+	) as ReadonlyArray<SourceMessage>;
+	return projectTranscript(messages).flatMap((item) => [...itemsOf(item)]);
+};
+
+/** The `page` request `PiAiAgent` plans, minus the disk read. */
+const pageBefore = (entries: ReadonlyArray<SessionEntry>, before: string | null, limit = 10) =>
+	planTranscriptPage(pageItems(entries), {
+		before,
+		cursorAliases: pageCursorAliases(entries),
+		limit,
+		cursorBoundary: "containing-group",
+	});
+
+const texts = (items: ReadonlyArray<TranscriptItem>): ReadonlyArray<string> =>
+	items.map((item) => {
+		if (item.kind === "user" || item.kind === "assistant") return item.text;
+		if (item.kind === "tool") return `${item.name}()`;
+		return item.kind;
+	});
+
+const plain: ReadonlyArray<SessionEntry> = [
+	message("e1", null, 1, said("first question")),
+	message("e2", "e1", 2, replied("first answer")),
+	message("e3", "e2", 3, said("second question")),
+	message("e4", "e3", 4, replied("second answer")),
+	message("e5", "e4", 5, said("third question")),
+	message("e6", "e5", 6, replied("third answer")),
+];
+
+describe("paging a Pi window back from its own live tail", () => {
+	it("takes a live row's id as the cursor and answers with the exchange behind it", () => {
+		const tail = liveTail(plain);
+		expect(tail.map((item) => item.id)).toEqual([
+			"item-0",
+			"item-1",
+			"item-2",
+			"item-3",
+			"item-4",
+			"item-5",
+		]);
+
+		const planned = pageBefore(plain, tail[4]?.id ?? null);
+		expect(isRefusal(planned)).toBe(false);
+		if (isRefusal(planned)) return;
+		expect(texts(planned.items)).toEqual([
+			"first question",
+			"first answer",
+			"second question",
+			"second answer",
+		]);
+	});
+
+	it("hands back stored ids, so a second page walks off the first page's own oldest row", () => {
+		const first = pageBefore(plain, liveTail(plain)[4]?.id ?? null, 2);
+		expect(isRefusal(first)).toBe(false);
+		if (isRefusal(first)) return;
+		expect(texts(first.items)).toEqual(["second question", "second answer"]);
+
+		const second = pageBefore(plain, first.items[0]?.id ?? null, 2);
+		expect(isRefusal(second)).toBe(false);
+		if (isRefusal(second)) return;
+		expect(texts(second.items)).toEqual(["first question", "first answer"]);
+	});
+
+	// `mergeOlder`'s own join is `rows.unit.test.ts`'s; what it needs from this seam is that the
+	// page and the tail never carry one turn twice — which they cannot be asked here by id, since
+	// the two spaces are deliberately different. The turns themselves are the check.
+	it("answers a page the live tail does not already hold, so a prepend doubles no turn", () => {
+		const tail = liveTail(plain).slice(4);
+		const planned = pageBefore(plain, tail[0]?.id ?? null);
+		expect(isRefusal(planned)).toBe(false);
+		if (isRefusal(planned)) return;
+		expect([...texts(planned.items), ...texts(tail)]).toEqual([
+			"first question",
+			"first answer",
+			"second question",
+			"second answer",
+			"third question",
+			"third answer",
+		]);
+	});
+
+	it("keys a tool row by its call on both paths, so a page joins the running row it replaced", () => {
+		const withTool: ReadonlyArray<SessionEntry> = [
+			...plain,
+			message("e7", "e6", 7, said("fourth question")),
+			message("e8", "e7", 8, called("call_notes", "read")),
+			message("e9", "e8", 9, resulted("call_notes", "read", "the file body")),
+			message("e10", "e9", 10, replied("fourth answer")),
+		];
+		const tail = liveTail(withTool);
+		const tool = tail.find((item) => item.kind === "tool");
+		expect(tool?.id).toBe("call_notes");
+		expect(pageItems(withTool).find((item) => item.kind === "tool")?.id).toBe("call_notes");
+
+		const planned = pageBefore(withTool, tool?.id ?? null, 2);
+		expect(isRefusal(planned)).toBe(false);
+		if (isRefusal(planned)) return;
+		expect(texts(planned.items)).toEqual(["third question", "third answer"]);
+	});
+
+	it("keeps a loaded row's id still when a compaction renumbers the live tail under it", () => {
+		const compaction: CompactionEntry = {
+			type: "compaction",
+			id: "compact",
+			parentId: "e6",
+			timestamp: at(7),
+			summary: "the first two exchanges, summarized",
+			firstKeptEntryId: "e5",
+			tokensBefore: 4_000,
+		};
+		const compacted: ReadonlyArray<SessionEntry> = [
+			...plain,
+			compaction,
+			message("e7", "compact", 8, said("fourth question")),
+			message("e8", "e7", 9, replied("fourth answer")),
+		];
+
+		// The live space moved: the third exchange was `item-4`/`item-5` and is now `item-1`/`item-2`.
+		expect(liveTail(compacted).map((item) => item.id)).toEqual([
+			"item-1",
+			"item-2",
+			"item-3",
+			"item-4",
+		]);
+		// The stored space did not, so a page a window already holds still names the same rows.
+		expect(pageItems(compacted).map((item) => item.id)).toEqual([
+			"e1",
+			"e2",
+			"e3",
+			"e4",
+			"e5",
+			"e6",
+			"compact",
+			"e7",
+			"e8",
+		]);
+
+		const planned = pageBefore(compacted, liveTail(compacted)[0]?.id ?? null);
+		expect(isRefusal(planned)).toBe(false);
+		if (isRefusal(planned)) return;
+		expect(texts(planned.items)).toEqual([
+			"first question",
+			"first answer",
+			"second question",
+			"second answer",
+		]);
+	});
+});


### PR DESCRIPTION
A Pi window pages back by sending its oldest live row's own id as the cursor, and that id is
`item-<index>` over the transcript Pi pushed. The page path keys the same message by its stored
entry id. #8204 reported every page back failing with `unknown-cursor: cursor-not-found`.

The translation the issue's triage note called the cheapest route has since landed: PR #8433,
fixing the sibling #8202, added `pageCursorAliases` to `apps/tuval/src/pi/ai-agent/entries.ts` and
passed it into `planTranscriptPage`. Nothing pinned it, though — the existing unit test asserts the
alias map's contents, and the only test that pages from a real live id is `it.live`, so it does not
run in the ordinary suite.

Two changes here. First, `entries.ts` gains `planPageOverEntries`, the one construction of the
planner call — cursor aliases, limit and the `containing-group` boundary — and both call sites in
`PiAiAgent.ts` (`page` and `sessionTranscript`) now use it instead of re-typing those four options.
Second, `paging-from-live.unit.test.ts` calls that same function, so the test and the shipped path
share one construction rather than two copies that can drift apart.

The test builds the live tail the way the host builds it — `buildContextEntries` →
`sessionEntryToContextMessages` → `projectTranscript` → `itemsOf` — rather than hand-numbering
`item-<n>`, because a hand-numbered fixture would pass while the real projection failed, which is
exactly the bug. It then pages from that tail's oldest id and asserts the slice, walks a second page
off the first page's stored id, checks the page and the tail carry no turn twice, checks a tool row
keys on `toolCallId` on both paths, and checks a compaction moves the live ids while leaving the
stored ids of already-loaded rows still.

Proof it pins production: deleting `cursorAliases: pageCursorAliases(entries)` from
`planPageOverEntries` reds 4 of the 5 unit cases plus the `it.live` integration case — 5 failed, 82
passed across the `src/pi/ai-agent` subset. At the previous head the same deletion left that subset
fully green, which is the review finding this round answers.

Fixes #8204

## Deviations

- **Scope narrowing** — **Said:** criterion 2 asks that an item arriving live and later arriving in
  a page carry the same id in both paths. **Did:** asserted instead that the two never carry one
  turn twice, which is the criterion's own stated consequence. **Why:** literal id equality is not
  reachable without giving up criterion 3 — the live path folds a `SessionSnapshot` that holds no
  entry ids, and keying the page path positionally would move a loaded row's id under a compaction.
  The alias is the join, and the window's cursor is always its oldest backend row, so a page can
  only answer with groups strictly older than anything the tail holds.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8204 asks for a test. **Did:** also refactored the planner
  call out of `PiAiAgent.ts`'s two page paths into `planPageOverEntries` in `entries.ts`. **Why:**
  a test that re-types the options pins nothing about the shipped call site, which the review
  verified by mutation; sharing one construction is what makes the deletion red. No behaviour
  changes — the options are identical at both call sites. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** #8204 is the id-space mismatch. **Did:** left a
  neighbouring hole alone — under `cursorBoundary: "containing-group"`, the whole group containing
  the cursor is excluded, so when the live-tail bound has trimmed a group's user prompt but kept
  its reply, that prompt is returned by no page and shown by no tail. **Why:** it is a consequence
  of #8202's boundary choice, not of the two id spaces, and fixing it here would be an unrelated
  change to a shared planner. Filed separately. **Disposition:** stated here.
