### PR TITLE
fix: Tuval's inline session transcript shows the newest 50 items with no route to older ones

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -709,6 +709,17 @@ a refusal when the result does not decode, and the value otherwise. The `null` i
 arm: a page holds several calls open on one socket, so "not my reply" has to stay distinguishable
 from "mine, and it is empty" — collapsing them shows one window another's answer.
 
+**The address is the program-prefixed one, and `protocol/` spells both.** The registry keys a row's
+spell under `[programId, ...path]` ([`commands/registry.ts`](../apps/tuval/src/commands/registry.ts)),
+so a call carrying the spell's bare path reaches nothing and the kernel answers `UnknownSpell`. Each
+protocol module therefore exports the row's own path *and* the whole call path
+(`SESSION_LIST_PATH` / `SESSION_LIST_CALL_PATH`,
+`SESSION_TRANSCRIPT_PATH` / `SESSION_TRANSCRIPT_CALL_PATH`), and the page sends the second. **A
+scripted socket in a test is a registry, not a router with a default arm**: it answers the addresses
+the kernel really registers and refuses everything else the way the kernel does. A fixture that parks
+any unrecognised path passes a mis-addressed call, which is how #8238's bare `session.transcript`
+cleared a whole rendered suite and failed on a real desk.
+
 **A hook the renderer calls, bound at the table.** The window declares a source type
 (`SessionListSource`, `TranscriptSource`) and takes it as an option; the default asks nobody, so a
 fixture or a socket-less surface renders the same waiting path a real one does.

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -694,3 +694,43 @@ the row's own schema refusing the argument and a run is the kernel's dispatch. T
 the host makes is the address: a shell row's spells are registered under `[shell, ...path]`, and a
 path the shell table does not hold is refused on the page because the kernel does not hold it
 either.
+
+## A window that calls a spell
+
+A spell answered on demand — the session list, one page of a session's transcript — reaches the
+surface through the page's socket rather than through a state frame, and the two live instances are
+[`page/session-list.ts`](../apps/tuval/src/page/session-list.ts) and
+[`page/session-transcript.ts`](../apps/tuval/src/page/session-transcript.ts). Both are the same three
+pieces, and the split is what keeps the surface provable.
+
+**A pure call/read pair per spell, under `page/`.** One function builds the `SpellCall` and mints its
+`CallId`; one takes that call and a reply and answers `null` when the reply's id is another call's,
+a refusal when the result does not decode, and the value otherwise. The `null` is the load-bearing
+arm: a page holds several calls open on one socket, so "not my reply" has to stay distinguishable
+from "mine, and it is empty" — collapsing them shows one window another's answer.
+
+**A hook the renderer calls, bound at the table.** The window declares a source type
+(`SessionListSource`, `TranscriptSource`) and takes it as an option; the default asks nobody, so a
+fixture or a socket-less surface renders the same waiting path a real one does.
+[`page/renderers.tsx`](../apps/tuval/src/page/renderers.tsx) binds the real one, closed over that
+page's `call`. **The binding is the step that gets forgotten**: a source left unbound is a window
+that reads forever while every unit around it passes, which is what #8238 repaired — so the test that
+covers a source mounts the renderer out of `pageRenderers` rather than passing a stub, and asserts on
+the calls the scripted socket received.
+
+**The hook is mounted per subject, never called conditionally.** A window showing one of several
+things calls the source from a child component whose whole life is that subject, keyed on it. That is
+two rules in one: hooks stay unconditional, which React requires, and picking a second subject
+unmounts the first read rather than folding its landed pages into the new one's history.
+
+**Retry and paging are attempts, not new inputs.** A read that can be asked for again — a retry, the
+next page — carries a counter beside its arguments, because two consecutive requests can legitimately
+carry the same ones: a retry asks for exactly the cursor that failed. Without the counter the effect's
+dependencies do not move and no call leaves. The landed answer is checked against the attempt it was
+sent for, so a superseded call's reply is dropped rather than folded (#8280, #8238).
+
+**The fold is pure and lives beside the codec.** Where an answer accumulates —
+`session-transcript.ts`'s `landedPage` — the state machine is a total function from the held state
+and one landing to the next, so every rule the surface owes (older items before held ones, an id
+already on screen never repeated, a failed page leaving the history and the cursor alone) is a unit
+test with no DOM in it. The hook holds that value and renders it; it decides nothing.

--- a/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
@@ -14,7 +14,8 @@
  * source that calls `session.list` over its socket (`../../page/renderers.tsx`, #8161). It is handed
  * this window's id, because the call carries the window it came from and the kernel resolves the
  * rest. At its default it hands a read nobody sent, which is what a fixture or a surface with no
- * socket behind it renders.
+ * socket behind it renders. `useTranscript` is the same seam for the session a row opens onto, bound
+ * to the `session.transcript` spell by the same table (#8238).
  *
  * **Five states, none of them a blank window.** Reading, a fired deadline, a refused call, an empty
  * store, and a store whose backends could not be read are five different sentences — the last two
@@ -33,6 +34,7 @@ import type {ReactElement, KeyboardEvent as ReactKeyboardEvent, ReactNode} from 
 import {useCallback, useEffect, useMemo, useState} from "react";
 import type {ReadingSessions, SessionListStatus} from "../../page/session-list.ts";
 import {atClock, elapsedMillis, reading} from "../../page/session-list.ts";
+import type {TranscriptAnswer} from "../../page/session-transcript.ts";
 import {failureLine} from "../../palette/call.ts";
 import type {WindowId} from "../../protocol/ids.ts";
 import type {SessionRow, UnreadableBackend} from "../../protocol/session-list.ts";
@@ -41,16 +43,16 @@ import {windowRenderer} from "../../shell/window/index.ts";
 import {
 	listView,
 	type OpenPhase,
+	type OpenRequest,
 	type OpenTarget,
 	openRead,
 	type SendPlan,
 	type SessionListView,
 	send,
 	sessionView,
-	type TranscriptRead,
 } from "./opening.ts";
 import {matchesQuery, rowValue, sessionItems} from "./rows.ts";
-import {SessionTranscriptView, type TranscriptAnswer} from "./SessionTranscript.tsx";
+import {SessionTranscriptView} from "./SessionTranscript.tsx";
 import "./session-list-window.css";
 
 const TITLE = "AI agent sessions";
@@ -308,10 +310,26 @@ const nothingRead: SessionListSource = () => {
 	return {status: reading(startedAt)};
 };
 
-/** How the renderer gets one session's transcript. The default reads none, so a window says so. */
-export type TranscriptSource = (read: TranscriptRead) => TranscriptAnswer | null;
+/** One session's transcript as the surface renders it, and the way to ask for the page before it. */
+export interface TranscriptPaged {
+	/** The history so far, waiting state included. `null` while the first read is out. */
+	readonly answer: TranscriptAnswer | null;
+	/** Absent when the caller cannot page — then the older affordance is not offered at all. */
+	readonly onOlder?: () => void;
+}
 
-const nothingPaged: TranscriptSource = () => null;
+/**
+ * How the renderer gets one session's transcript. Like `SessionListSource` it is a hook the window
+ * calls, so a source holding the landed pages re-renders the window when the next one arrives; it
+ * is handed `openRead`'s own answer and the window the call comes from. It takes the request rather
+ * than the read inside it because a row the store filed under no folder has no read to hand over,
+ * and a hook cannot be skipped for it — so the refusal is a case the source is given rather than a
+ * placeholder read invented to keep the call shape. The default reads none, so a surface with no
+ * socket behind it says the read is out rather than claiming an empty session.
+ */
+export type TranscriptSource = (request: OpenRequest, window: WindowId) => TranscriptPaged;
+
+const nothingPaged: TranscriptSource = () => ({answer: null});
 
 export interface SessionListWindowOptions {
 	readonly useAnswer?: SessionListSource;
@@ -379,13 +397,16 @@ function SessionListHost({
 		);
 	}
 
-	const request = openRead(view.session);
-	const page = request._tag === "Read" ? (useTranscript ?? nothingPaged)(request.read) : null;
+	// The transcript is a child rather than an arm of this render, because the source is a hook:
+	// called from here it would run on the session branch and not on the list branch, which is the
+	// conditional-hook fault React refuses. The key is the session, so picking a second row unmounts
+	// the first read's state instead of folding its pages into the new session's history.
 	return (
-		<SessionTranscriptView
+		<SessionTranscriptHost
+			key={`${view.session.programId}:${view.session.sessionId}`}
 			session={view.session}
-			answer={page}
-			unopenable={request._tag === "OpenRefused"}
+			window={window}
+			useTranscript={useTranscript ?? nothingPaged}
 			onBack={back}
 			onSend={(text) => {
 				// The phase is what makes the transition happen once: the first send hands back a spawn
@@ -394,6 +415,41 @@ function SessionListHost({
 				setPhase(plan.phase);
 				onSend?.(view.session, text, plan);
 			}}
+		/>
+	);
+}
+
+/**
+ * One session's transcript over whatever source the page bound. It exists so the source is called
+ * unconditionally from a component whose whole life is this one session: the read it sends is
+ * memoised on the row, so a re-render is not a second call, and unmounting is what discards a read
+ * whose session is no longer on screen.
+ */
+function SessionTranscriptHost({
+	session,
+	window,
+	useTranscript,
+	onBack,
+	onSend,
+}: {
+	readonly session: SessionRow;
+	readonly window: WindowId;
+	readonly useTranscript: TranscriptSource;
+	readonly onBack: () => void;
+	readonly onSend: (text: string) => void;
+}): ReactElement {
+	// Memoised on the row, so the source's own effect sees one request for the life of this mount: a
+	// fresh object every render would re-send the first page on every render.
+	const request = useMemo(() => openRead(session), [session]);
+	const paged = useTranscript(request, window);
+	return (
+		<SessionTranscriptView
+			session={session}
+			answer={paged.answer}
+			unopenable={request._tag === "OpenRefused"}
+			onBack={onBack}
+			onSend={onSend}
+			{...(paged.onOlder === undefined ? {} : {onOlder: paged.onOlder})}
 		/>
 	);
 }

--- a/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
@@ -14,14 +14,16 @@
  * cannot tell the two apart learns nothing from either.
  *
  * **Older history is asked for, not fetched whole.** `onOlder` walks the port's own cursor one page
- * at a time; the button is gone once the answer says there is nothing older.
+ * at a time; the button is gone once the answer says there is nothing older. An older page that
+ * fails is said beside the history rather than in place of it, and the button stays — the cursor
+ * did not move, so pressing it again asks for the same page rather than skipping past it.
  */
 
 import {AgentChatInput, Button, DesignTranslationProvider} from "@kampus/design";
 import type {ReactElement} from "react";
 import {useCallback, useMemo, useState} from "react";
+import type {OlderRead, TranscriptAnswer} from "../../page/session-transcript.ts";
 import {failureLine} from "../../palette/call.ts";
-import type {SpellFailure} from "../../protocol/messages.ts";
 import type {SessionRow} from "../../protocol/session-list.ts";
 import type {SessionTranscript} from "../../protocol/session-transcript.ts";
 import {composerBridge} from "../../shell/chat/composer-bridge.ts";
@@ -29,15 +31,13 @@ import {tuvalDesignTranslate} from "../../shell/chat/copy.ts";
 import {NO_FIRST_PROMPT} from "./rows.ts";
 import "./session-list-window.css";
 
-/** What a caller's read answered with. `null` is "the read is out", never "there is nothing". */
-export type TranscriptAnswer =
-	| {readonly _tag: "Read"; readonly page: SessionTranscript}
-	| {readonly _tag: "Refused"; readonly failure: SpellFailure};
-
 const COPY = {
 	reading: "Reading this session's transcript…",
 	empty: "This session holds no messages yet.",
 	older: "Load older messages",
+	olderReading: "Reading older messages…",
+	olderFailed: "The older messages could not be read, so this transcript stops here.",
+	olderRetry: "Try the older messages again",
 	back: "Back to the session list",
 	noFolder: "This session's store recorded no folder, so it cannot be opened.",
 } as const;
@@ -105,6 +105,8 @@ export function SessionTranscriptView({
 
 	const items = answer?._tag === "Read" ? answer.page.items : [];
 	const older = answer?._tag === "Read" ? answer.page.next : null;
+	const olderRead: OlderRead = answer?._tag === "Read" ? answer.older : {_tag: "Idle"};
+	const olderFailure = olderRead._tag === "Failed" ? olderRead.failure : null;
 	const refusal = answer !== null && answer._tag === "Refused" ? answer.failure : null;
 
 	const body: ReactElement =
@@ -137,9 +139,27 @@ export function SessionTranscriptView({
 				<h2>{session.firstPrompt ?? NO_FIRST_PROMPT}</h2>
 			</header>
 			{older === null || onOlder === undefined ? null : (
-				<Button type="button" variant="tertiary" size="sm" onClick={onOlder}>
-					{COPY.older}
-				</Button>
+				<div className="tuval-session-transcript-older">
+					<Button
+						type="button"
+						variant="tertiary"
+						size="sm"
+						disabled={olderRead._tag === "Reading"}
+						onClick={onOlder}
+					>
+						{olderFailure === null ? COPY.older : COPY.olderRetry}
+					</Button>
+					{olderRead._tag === "Reading" ? (
+						<p className="tuval-session-transcript-note" role="status">
+							{COPY.olderReading}
+						</p>
+					) : null}
+					{olderFailure === null ? null : (
+						<p className="tuval-session-transcript-refused" role="alert">
+							{`${COPY.olderFailed} ${failureLine(olderFailure)}`}
+						</p>
+					)}
+				</div>
 			)}
 			{body}
 			<DesignTranslationProvider translate={tuvalDesignTranslate}>

--- a/apps/tuval/src/ai-agent/window/index.ts
+++ b/apps/tuval/src/ai-agent/window/index.ts
@@ -41,10 +41,7 @@ export {
 	SessionListWindow,
 	type SessionListWindowOptions,
 	sessionListWindow,
+	type TranscriptPaged,
 	type TranscriptSource,
 } from "./SessionListWindow.tsx";
-export {
-	type SessionTranscriptProps,
-	SessionTranscriptView,
-	type TranscriptAnswer,
-} from "./SessionTranscript.tsx";
+export {type SessionTranscriptProps, SessionTranscriptView} from "./SessionTranscript.tsx";

--- a/apps/tuval/src/ai-agent/window/session-list-window.css
+++ b/apps/tuval/src/ai-agent/window/session-list-window.css
@@ -131,3 +131,11 @@
 .tuval-session-transcript-refused {
 	color: var(--text-danger);
 }
+
+.tuval-session-transcript-older {
+	flex: none;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--s-2);
+}

--- a/apps/tuval/src/ai-agent/window/session-open.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/session-open.unit.test.tsx
@@ -21,10 +21,10 @@ import type {WindowHost} from "../../shell/window/index.ts";
 import {WindowId} from "../../shell/window/index.ts";
 import {ItemId} from "../ports/index.ts";
 import {bareSession, claudeSession, NOW, scrambled} from "./fixtures.ts";
-import type {SendPlan, TranscriptRead} from "./opening.ts";
+import type {OpenRequest, SendPlan, TranscriptRead} from "./opening.ts";
 import {TRANSCRIPT_PAGE_SIZE} from "./opening.ts";
+import type {TranscriptPaged} from "./SessionListWindow.tsx";
 import {type SessionListWindowOptions, sessionListWindow} from "./SessionListWindow.tsx";
-import type {TranscriptAnswer} from "./SessionTranscript.tsx";
 
 installDomShims();
 
@@ -34,16 +34,19 @@ const listed = (sessions: ReadonlyArray<SessionRow>): SessionListAnswer => ({
 	unreadable: [],
 });
 
-const page = (texts: ReadonlyArray<string>): TranscriptAnswer => ({
-	_tag: "Read",
-	page: {
-		items: texts.map((text, index) => ({
-			kind: "user" as const,
-			id: ItemId.make(`m-${index}`),
-			timestamp: NOW,
-			text,
-		})),
-		next: null,
+const paged = (texts: ReadonlyArray<string>): TranscriptPaged => ({
+	answer: {
+		_tag: "Read",
+		older: {_tag: "Idle"},
+		page: {
+			items: texts.map((text, index) => ({
+				kind: "user" as const,
+				id: ItemId.make(`m-${index}`),
+				timestamp: NOW,
+				text,
+			})),
+			next: null,
+		},
 	},
 });
 
@@ -74,7 +77,7 @@ const activate = (
 
 describe("activating a row inline", () => {
 	it("replaces the list with that session's transcript in the same window", () => {
-		activate({useTranscript: () => page(["turn one", "turn two"])});
+		activate({useTranscript: () => paged(["turn one", "turn two"])});
 
 		expect(screen.queryByRole("combobox", {name: "AI agent sessions"})).toBeNull();
 		const transcript = screen.getByRole("region", {name: claudeSession.firstPrompt ?? ""});
@@ -85,9 +88,9 @@ describe("activating a row inline", () => {
 	it("asks for one page off the port's cursor rather than the whole transcript", () => {
 		const reads: Array<TranscriptRead> = [];
 		activate({
-			useTranscript: (read) => {
-				reads.push(read);
-				return page([]);
+			useTranscript: (request: OpenRequest) => {
+				if (request._tag === "Read") reads.push(request.read);
+				return paged([]);
 			},
 		});
 
@@ -112,7 +115,7 @@ describe("activating a row inline", () => {
 
 	it("opens no new window", () => {
 		const elsewhere = vi.fn();
-		activate({useTranscript: () => page([]), onOpenInNewWindow: elsewhere});
+		activate({useTranscript: () => paged([]), onOpenInNewWindow: elsewhere});
 		expect(elsewhere).not.toHaveBeenCalled();
 	});
 });
@@ -120,7 +123,7 @@ describe("activating a row inline", () => {
 describe("Cmd+Enter on a row", () => {
 	it("opens it in the other window and leaves this one on the list", () => {
 		const elsewhere = vi.fn();
-		activate({useTranscript: () => page([]), onOpenInNewWindow: elsewhere}, {metaKey: true});
+		activate({useTranscript: () => paged([]), onOpenInNewWindow: elsewhere}, {metaKey: true});
 
 		expect(elsewhere).toHaveBeenCalledWith(claudeSession);
 		expect(screen.getByRole("combobox", {name: "AI agent sessions"})).toBeTruthy();
@@ -143,7 +146,7 @@ describe("the first send on an opened session", () => {
 	it("creates exactly one process on that session id, and reuses it on the second", async () => {
 		const plans: Array<SendPlan> = [];
 		activate({
-			useTranscript: () => page([]),
+			useTranscript: () => paged([]),
 			onSend: (_session, _text, plan) => plans.push(plan),
 		});
 

--- a/apps/tuval/src/page/renderers.tsx
+++ b/apps/tuval/src/page/renderers.tsx
@@ -37,6 +37,7 @@ import {
 	SESSION_LIST_WINDOW_REF,
 	type SessionListSource,
 	sessionListWindow,
+	type TranscriptSource,
 } from "../ai-agent/window/index.ts";
 import {CLAUDE_CHAT_WINDOW_REF, claudeChatWindow} from "../claude/window/index.ts";
 import {type CounterState, isCounterState} from "../demo/counter.ts";
@@ -55,6 +56,14 @@ import {
 	sessionListCall,
 	settled,
 } from "./session-list.ts";
+import {
+	askedOlder,
+	landedPage,
+	noPages,
+	pagedAnswer,
+	readSessionTranscript,
+	sessionTranscriptCall,
+} from "./session-transcript.ts";
 
 /**
  * One process's public state, live. The stream never fails and ends on `ProcessGone`, so the hook
@@ -170,6 +179,69 @@ const sessionListSource = (call: SpellCaller): SessionListSource => {
 };
 
 /**
+ * One session's transcript, read from the kernel a page at a time. The first page leaves when the
+ * transcript mounts and every later one leaves when the operator asks for older history, each
+ * correlated on the `CallId` it minted (`./session-transcript.ts`) so a reply belonging to another
+ * call — the list's, the other window's, the page this one superseded — is never folded in.
+ *
+ * **The cursor is what a request is, and the attempt is what makes it a new one.** A page that
+ * lands moves the cursor; a page that fails does not, so asking again asks for the same page rather
+ * than skipping the history that did not arrive. Two consecutive requests can therefore carry the
+ * same cursor, which is why the attempt counter is in the dependencies: without it a retry would be
+ * an effect whose inputs did not change and no call would leave.
+ *
+ * **Nothing here outlives the session it was opened for.** The whole state is this hook's, the hook
+ * is mounted per selected session by the window (`../ai-agent/window/SessionListWindow.tsx`), and a
+ * reply that lands after the read it belongs to was superseded is dropped rather than folded.
+ */
+const sessionTranscriptSource = (call: SpellCaller): TranscriptSource => {
+	const useSessionTranscript: TranscriptSource = (request, window) => {
+		const [paging, setPaging] = useState(noPages);
+		const [cursor, setCursor] = useState<string | null>(null);
+		const [attempt, setAttempt] = useState(0);
+
+		useEffect(() => {
+			if (request._tag !== "Read") return;
+			let current = true;
+			const spell = sessionTranscriptCall({...request.read, before: cursor}, window);
+			const fiber = Effect.runFork(
+				call(spell).pipe(
+					Effect.flatMap((reply) =>
+						Effect.sync(() => {
+							if (!current) return;
+							const landing = readSessionTranscript(spell, reply);
+							if (landing !== null) setPaging((held) => landedPage(held, cursor, landing));
+						}),
+					),
+					Effect.catchCause(() => Effect.void),
+				),
+			);
+			return () => {
+				current = false;
+				void Effect.runFork(Fiber.interrupt(fiber));
+			};
+		}, [call, request, window, cursor, attempt]);
+
+		const next = paging.next;
+		const olderOut = paging.older._tag === "Reading";
+		const older = useCallback(() => {
+			if (next === null || olderOut) return;
+			setPaging(askedOlder);
+			setCursor(next);
+			setAttempt((current) => current + 1);
+		}, [next, olderOut]);
+
+		const answer = request._tag === "Read" ? pagedAnswer(paging) : null;
+		// The affordance is offered only where there is a page to ask for, so the surface's own rule
+		// ("gone once there is nothing older") and this one cannot disagree about the end of history.
+		return answer !== null && answer._tag === "Read" && answer.page.next !== null
+			? {answer, onOlder: older}
+			: {answer};
+	};
+	return useSessionTranscript;
+};
+
+/**
  * What the two chat renderers are built at: the operator's own flags, read straight out of the
  * module the page server generated from the booted config (`./dev-server.ts`, #8439). It is a plain
  * import rather than a fetch or a prop, which is the whole point — the table below is built
@@ -203,7 +275,10 @@ export const pageRenderers = (call: SpellCaller): Readonly<Record<string, Readab
 	[CLAUDE_CHAT_WINDOW_REF.ref]: readsState(isAiAgentSessionState, claudeWindow),
 	[SESSION_LIST_WINDOW_REF.ref]: readsState(
 		isSessionListState,
-		sessionListWindow({useAnswer: sessionListSource(call)}),
+		sessionListWindow({
+			useAnswer: sessionListSource(call),
+			useTranscript: sessionTranscriptSource(call),
+		}),
 	),
 });
 

--- a/apps/tuval/src/page/session-transcript-window.unit.test.tsx
+++ b/apps/tuval/src/page/session-transcript-window.unit.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The whole read-only transcript path, from the table a page really mounts to the calls that leave
+ * over its socket: `pageRenderers` builds the session-list renderer at a scripted `call`, a row is
+ * picked, and every assertion below is on what that socket was asked for and what the window
+ * rendered from the answer (#8238).
+ *
+ * It is mounted through `pageRenderers` rather than through `sessionListWindow` with a stub source,
+ * because the fault this file exists to keep out was exactly a window whose seam was never bound:
+ * the surface said "reading" forever and every unit around it passed (#8492's hand-verification).
+ * The pure half — one reply becoming a landing, a sequence of landings folding into one history —
+ * is `./session-transcript.unit.test.ts`.
+ */
+
+import {act, fireEvent, render, screen, within} from "@testing-library/react";
+import {Effect, Stream} from "effect";
+import type {Socket} from "effect/unstable/socket";
+import type {ReactElement} from "react";
+import {beforeEach, describe, expect, it} from "vitest";
+import type {SessionListState} from "../ai-agent/renderer-ref.ts";
+import {SESSION_LIST_STATE} from "../ai-agent/renderer-ref.ts";
+import {claudeSession} from "../ai-agent/window/fixtures.ts";
+import {SESSION_LIST_WINDOW_REF} from "../ai-agent/window/index.ts";
+import {ProcessId} from "../process/process.ts";
+import {CallId} from "../protocol/ids.ts";
+import type {SpellCall, SpellFailure, SpellReply} from "../protocol/messages.ts";
+import {PROTOCOL_VERSION, SpellReplyError, SpellReplyOk} from "../protocol/messages.ts";
+import {SESSION_LIST_CALL_PATH} from "../protocol/session-list.ts";
+import type {SessionTranscript, TranscriptItemWire} from "../protocol/session-transcript.ts";
+import {SESSION_TRANSCRIPT_PATH} from "../protocol/session-transcript.ts";
+import {installDomShims} from "../shell/ui/dom.testing.ts";
+import type {ProcessView, WindowHost} from "../shell/window/index.ts";
+import {delivered, WindowId} from "../shell/window/index.ts";
+import type {SpellCaller} from "./renderers.tsx";
+import {pageRenderers} from "./renderers.tsx";
+
+installDomShims();
+
+/**
+ * The scripted socket. `session.list` answers at once — this file is not about the list — and every
+ * `session.transcript` call is parked, so a test decides when a page lands and whether it lands at
+ * all. Parking is what makes the two cases that matter reachable: an older read that is still out,
+ * and a reply that arrives after the read it belongs to was left behind.
+ */
+interface Parked {
+	readonly spell: SpellCall;
+	readonly answer: (reply: SpellReply) => void;
+}
+
+let parked: Array<Parked> = [];
+
+const ok = (id: string, result: unknown): SpellReply =>
+	new SpellReplyOk({
+		type: "spell.reply",
+		version: PROTOCOL_VERSION,
+		id: CallId.make(id),
+		ok: true,
+		result,
+	});
+
+const refusal = (id: string, error: SpellFailure): SpellReply =>
+	new SpellReplyError({
+		type: "spell.reply",
+		version: PROTOCOL_VERSION,
+		id: CallId.make(id),
+		ok: false,
+		error,
+	});
+
+const NOT_FOUND: SpellFailure = {
+	tag: "tuval/TranscriptError",
+	message: 'no session "c-1" is stored for this working directory',
+	path: [...SESSION_TRANSCRIPT_PATH],
+};
+
+const call: SpellCaller = (spell) =>
+	Effect.callback<SpellReply, Socket.SocketError>((resume) => {
+		if (spell.path.join(".") === SESSION_LIST_CALL_PATH.join(".")) {
+			resume(Effect.succeed(ok(spell.id, {sessions: [claudeSession], unreadable: []})));
+			return;
+		}
+		parked.push({spell, answer: (reply) => resume(Effect.succeed(reply))});
+	});
+
+/**
+ * A whole host over the session-list row's own state, because that state is what the page's table
+ * admits a renderer over (`./readable-state.tsx`): a stub missing `readProcess` never gets past the
+ * admission test, so the surface under assertion would never mount.
+ */
+const hostFor = (window: string): WindowHost<SessionListState> => ({
+	windowId: WindowId.make(window),
+	processId: ProcessId.make("p-1"),
+	readProcess: Stream.succeed<ProcessView<SessionListState>>({
+		_tag: "Live",
+		processId: ProcessId.make("p-1"),
+		lifecycle: "running",
+		revision: 1,
+		state: SESSION_LIST_STATE,
+	}),
+	dispatch: () => Effect.succeed(delivered),
+	view: () => null,
+	setView: () => Effect.void,
+});
+
+const mount = (window = "w-1"): ReactElement => {
+	const entry = pageRenderers(call)[SESSION_LIST_WINDOW_REF.ref];
+	if (entry === undefined) throw new Error("the page's table has no session-list renderer");
+	return <>{entry.render(hostFor(window))}</>;
+};
+
+const settle = async (): Promise<void> => {
+	await act(async () => {
+		await Promise.resolve();
+	});
+};
+
+/** Mount the page's own window and pick the one row on offer. */
+const openSession = async (window = "w-1"): Promise<HTMLElement> => {
+	const {container} = render(mount(window));
+	await settle();
+	fireEvent.keyDown(
+		screen.getAllByRole("combobox", {name: "AI agent sessions"})[0] as HTMLElement,
+		{
+			key: "Enter",
+		},
+	);
+	await settle();
+	return container;
+};
+
+const item = (id: string): TranscriptItemWire => ({
+	kind: "user",
+	id,
+	timestamp: 1,
+	text: `turn ${id}`,
+});
+
+/** A page of `count` items ending at `next`, named so the assertions can read the order back. */
+const pageOf = (from: number, count: number, next: string | null): SessionTranscript => ({
+	items: Array.from({length: count}, (_, index) => item(`m-${from + index}`)),
+	next,
+});
+
+const answer = async (index: number, reply: (id: string) => SpellReply): Promise<void> => {
+	const call = parked[index];
+	if (call === undefined) throw new Error(`no call parked at ${index}`);
+	await act(async () => {
+		call.answer(reply(call.spell.id));
+	});
+};
+
+const older = (): HTMLElement | null => screen.queryByRole("button", {name: "Load older messages"});
+
+const texts = (container: HTMLElement): ReadonlyArray<string> =>
+	within(container)
+		.getAllByRole("listitem")
+		.map((row) => row.textContent ?? "");
+
+beforeEach(() => {
+	parked = [];
+});
+
+describe("picking a row", () => {
+	it("sends that row's whole address, the newest end of the transcript, and one bounded page", async () => {
+		await openSession();
+
+		expect(parked).toHaveLength(1);
+		expect(parked[0]?.spell.path).toEqual([...SESSION_TRANSCRIPT_PATH]);
+		expect(parked[0]?.spell.args).toEqual({
+			programId: claudeSession.programId,
+			sessionId: claudeSession.sessionId,
+			cwd: claudeSession.folder,
+			before: null,
+			limit: 50,
+		});
+		expect(parked[0]?.spell.window).toBe("w-1");
+	});
+
+	it("renders the decoded page in place of the reading sentence", async () => {
+		const container = await openSession();
+		await answer(0, (id) => ok(id, pageOf(1, 2, null)));
+
+		expect(texts(container)).toEqual(["userturn m-1", "userturn m-2"]);
+		expect(screen.queryByText("Reading this session's transcript…")).toBeNull();
+	});
+
+	it("keeps reading while a reply for another call arrives", async () => {
+		await openSession();
+		await answer(0, () => ok("another-call", pageOf(1, 2, null)));
+
+		expect(screen.getByText("Reading this session's transcript…")).toBeTruthy();
+	});
+
+	it("renders a refused first page as a refusal, never as an empty session", async () => {
+		await openSession();
+		await answer(0, (id) => refusal(id, NOT_FOUND));
+
+		expect(screen.getByRole("alert").textContent).toContain('no session "c-1" is stored');
+		expect(screen.queryByText("This session holds no messages yet.")).toBeNull();
+	});
+
+	it("renders a result it cannot decode as a refusal rather than an empty session", async () => {
+		await openSession();
+		await answer(0, (id) => ok(id, {items: [{kind: "nonsense"}], next: null}));
+
+		expect(screen.getByRole("alert").textContent).toContain("cannot read as a transcript page");
+		expect(screen.queryByText("This session holds no messages yet.")).toBeNull();
+	});
+
+	it("offers no older affordance on a session whose first page is the whole of it", async () => {
+		await openSession();
+		await answer(0, (id) => ok(id, pageOf(1, 2, null)));
+
+		expect(older()).toBeNull();
+	});
+});
+
+describe("paging past the newest fifty", () => {
+	it("asks for the reported cursor and keeps what is already on screen", async () => {
+		const container = await openSession();
+		await answer(0, (id) => ok(id, pageOf(51, 50, "m-51")));
+
+		expect(texts(container)).toHaveLength(50);
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+
+		expect(parked).toHaveLength(2);
+		expect(parked[1]?.spell.args).toMatchObject({before: "m-51", limit: 50});
+		expect(screen.getByText("Reading older messages…")).toBeTruthy();
+		expect(texts(container)).toHaveLength(50);
+	});
+
+	it("puts the older page before the held one, without repeating an overlapping item", async () => {
+		const container = await openSession();
+		await answer(0, (id) => ok(id, pageOf(51, 50, "m-51")));
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+		// The store re-reads the cursor's own row, so `m-51` arrives in both pages.
+		await answer(1, (id) =>
+			ok(id, {items: [...pageOf(1, 50, "m-1").items, item("m-51")], next: null}),
+		);
+
+		const rendered = texts(container);
+		expect(rendered).toHaveLength(100);
+		expect(rendered[0]).toBe("userturn m-1");
+		expect(rendered[49]).toBe("userturn m-50");
+		expect(rendered[50]).toBe("userturn m-51");
+		expect(new Set(rendered).size).toBe(100);
+	});
+
+	it("removes the affordance once a page reaches the beginning of history", async () => {
+		await openSession();
+		await answer(0, (id) => ok(id, pageOf(51, 50, "m-51")));
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+		await answer(1, (id) => ok(id, pageOf(1, 50, null)));
+
+		expect(older()).toBeNull();
+		expect(screen.queryByRole("button", {name: "Try the older messages again"})).toBeNull();
+	});
+
+	it("never asks for the whole store: three pages are three bounded calls", async () => {
+		await openSession();
+		await answer(0, (id) => ok(id, pageOf(101, 50, "m-101")));
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+		await answer(1, (id) => ok(id, pageOf(51, 50, "m-51")));
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+		await answer(2, (id) => ok(id, pageOf(1, 50, null)));
+
+		expect(parked.map((sent) => sent.spell.args)).toEqual([
+			expect.objectContaining({before: null, limit: 50}),
+			expect.objectContaining({before: "m-101", limit: 50}),
+			expect.objectContaining({before: "m-51", limit: 50}),
+		]);
+	});
+});
+
+describe("an older page that fails", () => {
+	const failFirstOlder = async (): Promise<HTMLElement> => {
+		const container = await openSession();
+		await answer(0, (id) => ok(id, pageOf(51, 50, "m-51")));
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+		await answer(1, (id) => refusal(id, NOT_FOUND));
+		return container;
+	};
+
+	it("leaves the history readable and says what failed", async () => {
+		const container = await failFirstOlder();
+
+		expect(texts(container)).toHaveLength(50);
+		expect(screen.getByRole("alert").textContent).toContain("could not be read");
+		expect(screen.getByRole("alert").textContent).toContain('no session "c-1" is stored');
+	});
+
+	it("retries the same cursor rather than advancing past the missing page", async () => {
+		const container = await failFirstOlder();
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", {name: "Try the older messages again"}));
+		});
+
+		expect(parked).toHaveLength(3);
+		expect(parked[2]?.spell.args).toMatchObject({before: "m-51"});
+		await answer(2, (id) => ok(id, pageOf(1, 50, null)));
+		expect(texts(container)).toHaveLength(100);
+		expect(screen.queryByRole("alert")).toBeNull();
+	});
+});
+
+describe("scoping", () => {
+	it("drops a reply for a read the operator has already left", async () => {
+		const container = await openSession();
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", {name: "Back to the session list"}));
+		});
+		fireEvent.keyDown(
+			screen.getAllByRole("combobox", {name: "AI agent sessions"})[0] as HTMLElement,
+			{
+				key: "Enter",
+			},
+		);
+		await settle();
+
+		expect(parked).toHaveLength(2);
+		await answer(0, (id) => ok(id, {items: [item("stale")], next: null}));
+		await answer(1, (id) => ok(id, {items: [item("fresh")], next: null}));
+
+		expect(texts(container)).toEqual(["userturn fresh"]);
+	});
+
+	it("keeps two windows' reads and histories apart", async () => {
+		const left = await openSession("w-1");
+		const right = await openSession("w-2");
+
+		expect(parked.map((sent) => sent.spell.window)).toEqual(["w-1", "w-2"]);
+		await answer(0, (id) => ok(id, {items: [item("left")], next: null}));
+		await answer(1, (id) => ok(id, {items: [item("right")], next: null}));
+
+		expect(texts(left)).toEqual(["userturn left"]);
+		expect(texts(right)).toEqual(["userturn right"]);
+	});
+});
+
+describe("the read-only contract", () => {
+	it("spends the whole read and both pagings on `session.transcript` and nothing else", async () => {
+		await openSession();
+		await answer(0, (id) => ok(id, pageOf(51, 50, "m-51")));
+		await act(async () => {
+			fireEvent.click(older() as HTMLElement);
+		});
+		await answer(1, (id) => ok(id, pageOf(1, 50, null)));
+
+		expect(new Set(parked.map((sent) => sent.spell.path.join(".")))).toEqual(
+			new Set(["session.transcript"]),
+		);
+	});
+});

--- a/apps/tuval/src/page/session-transcript-window.unit.test.tsx
+++ b/apps/tuval/src/page/session-transcript-window.unit.test.tsx
@@ -23,25 +23,36 @@ import {SESSION_LIST_STATE} from "../ai-agent/renderer-ref.ts";
 import {claudeSession} from "../ai-agent/window/fixtures.ts";
 import {SESSION_LIST_WINDOW_REF} from "../ai-agent/window/index.ts";
 import {ProcessId} from "../process/process.ts";
+import type {SpellPath} from "../protocol/ids.ts";
 import {CallId} from "../protocol/ids.ts";
-import type {SpellCall, SpellFailure, SpellReply} from "../protocol/messages.ts";
-import {PROTOCOL_VERSION, SpellReplyError, SpellReplyOk} from "../protocol/messages.ts";
+import type {SpellFailure, SpellReply} from "../protocol/messages.ts";
+import {PROTOCOL_VERSION, SpellCall, SpellReplyError, SpellReplyOk} from "../protocol/messages.ts";
 import {SESSION_LIST_CALL_PATH} from "../protocol/session-list.ts";
 import type {SessionTranscript, TranscriptItemWire} from "../protocol/session-transcript.ts";
-import {SESSION_TRANSCRIPT_PATH} from "../protocol/session-transcript.ts";
+import {
+	SESSION_TRANSCRIPT_CALL_PATH,
+	SESSION_TRANSCRIPT_PATH,
+} from "../protocol/session-transcript.ts";
 import {installDomShims} from "../shell/ui/dom.testing.ts";
 import type {ProcessView, WindowHost} from "../shell/window/index.ts";
 import {delivered, WindowId} from "../shell/window/index.ts";
 import type {SpellCaller} from "./renderers.tsx";
 import {pageRenderers} from "./renderers.tsx";
+import {sessionTranscriptCall} from "./session-transcript.ts";
 
 installDomShims();
 
 /**
- * The scripted socket. `session.list` answers at once — this file is not about the list — and every
- * `session.transcript` call is parked, so a test decides when a page lands and whether it lands at
- * all. Parking is what makes the two cases that matter reachable: an older read that is still out,
- * and a reply that arrives after the read it belongs to was left behind.
+ * The scripted socket, and it is a **registry** rather than a router with a default arm: it answers
+ * only the two addresses the kernel really registers, and refuses anything else the way the kernel
+ * does. That is what makes a mis-addressed call fail here — the first cut of this file parked every
+ * non-list path, so the page sending the bare `session.transcript` instead of the program-prefixed
+ * one passed every assertion below and failed on a real desk (#8238).
+ *
+ * `session.list` answers at once — this file is not about the list — and a transcript call is
+ * parked, so a test decides when a page lands and whether it lands at all. Parking is what makes the
+ * two cases that matter reachable: an older read that is still out, and a reply that arrives after
+ * the read it belongs to was left behind.
  */
 interface Parked {
 	readonly spell: SpellCall;
@@ -71,13 +82,25 @@ const refusal = (id: string, error: SpellFailure): SpellReply =>
 const NOT_FOUND: SpellFailure = {
 	tag: "tuval/TranscriptError",
 	message: 'no session "c-1" is stored for this working directory',
-	path: [...SESSION_TRANSCRIPT_PATH],
+	path: [...SESSION_TRANSCRIPT_CALL_PATH],
 };
+
+/** The kernel's own refusal for a path nothing is registered at (`../commands/errors.ts`). */
+const unknownSpell = (path: SpellPath): SpellFailure => ({
+	tag: "tuval/commands/UnknownSpell",
+	message: `no spell is registered at path "${path.join(" ")}"`,
+	path,
+});
 
 const call: SpellCaller = (spell) =>
 	Effect.callback<SpellReply, Socket.SocketError>((resume) => {
-		if (spell.path.join(".") === SESSION_LIST_CALL_PATH.join(".")) {
+		const address = spell.path.join(".");
+		if (address === SESSION_LIST_CALL_PATH.join(".")) {
 			resume(Effect.succeed(ok(spell.id, {sessions: [claudeSession], unreadable: []})));
+			return;
+		}
+		if (address !== SESSION_TRANSCRIPT_CALL_PATH.join(".")) {
+			resume(Effect.succeed(refusal(spell.id, unknownSpell(spell.path))));
 			return;
 		}
 		parked.push({spell, answer: (reply) => resume(Effect.succeed(reply))});
@@ -161,12 +184,34 @@ beforeEach(() => {
 	parked = [];
 });
 
+describe("the scripted socket", () => {
+	it("refuses an unregistered path instead of parking it, so a mis-addressed call cannot pass", async () => {
+		const bare = sessionTranscriptCall({
+			programId: claudeSession.programId,
+			sessionId: claudeSession.sessionId,
+			cwd: claudeSession.folder ?? "",
+			before: null,
+			limit: 50,
+		});
+		const misaddressed = new SpellCall({...bare, path: [...SESSION_TRANSCRIPT_PATH]});
+
+		const reply = await Effect.runPromise(call(misaddressed));
+
+		expect(parked).toHaveLength(0);
+		expect(reply.ok).toBe(false);
+		expect(reply.ok === false && reply.error.tag).toBe("tuval/commands/UnknownSpell");
+	});
+});
+
 describe("picking a row", () => {
 	it("sends that row's whole address, the newest end of the transcript, and one bounded page", async () => {
 		await openSession();
 
 		expect(parked).toHaveLength(1);
-		expect(parked[0]?.spell.path).toEqual([...SESSION_TRANSCRIPT_PATH]);
+		// The program-prefixed address, because that is where the registry holds the spell; the bare
+		// `session.transcript` is refused by the socket above and reaches nothing (#8238).
+		expect([...(parked[0]?.spell.path ?? [])]).toEqual([...SESSION_TRANSCRIPT_CALL_PATH]);
+		expect([...(parked[0]?.spell.path ?? [])].slice(1)).toEqual([...SESSION_TRANSCRIPT_PATH]);
 		expect(parked[0]?.spell.args).toEqual({
 			programId: claudeSession.programId,
 			sessionId: claudeSession.sessionId,
@@ -360,7 +405,7 @@ describe("the read-only contract", () => {
 		await answer(1, (id) => ok(id, pageOf(1, 50, null)));
 
 		expect(new Set(parked.map((sent) => sent.spell.path.join(".")))).toEqual(
-			new Set(["session.transcript"]),
+			new Set([SESSION_TRANSCRIPT_CALL_PATH.join(".")]),
 		);
 	});
 });

--- a/apps/tuval/src/page/session-transcript.ts
+++ b/apps/tuval/src/page/session-transcript.ts
@@ -24,7 +24,7 @@ import {CallId} from "../protocol/ids.ts";
 import type {SpellFailure, SpellReply} from "../protocol/messages.ts";
 import {PROTOCOL_VERSION, SpellCall} from "../protocol/messages.ts";
 import type {SessionTranscriptRequest, TranscriptItemWire} from "../protocol/session-transcript.ts";
-import {SESSION_TRANSCRIPT_PATH, SessionTranscript} from "../protocol/session-transcript.ts";
+import {SESSION_TRANSCRIPT_CALL_PATH, SessionTranscript} from "../protocol/session-transcript.ts";
 
 /** One page landed and decoded: the items it carried and the cursor for the page older than it. */
 export interface PagedTranscript {
@@ -41,9 +41,12 @@ export interface RefusedTranscript {
 export type TranscriptLanding = PagedTranscript | RefusedTranscript;
 
 /**
- * One page call. The id is minted here and the caller hands it back to `readSessionTranscript`,
- * which is the whole of the correlation. `window` rides along when the call came from one, exactly
- * as the list's does, so the kernel resolves the scope and the page names no process.
+ * One page call, addressed where the registry holds the spell: the row's program id followed by the
+ * spell's own path, which is `SESSION_TRANSCRIPT_CALL_PATH`. The bare `session.transcript` reaches
+ * nothing and the kernel answers `UnknownSpell` (#8238). The id is minted here and the caller hands
+ * it back to `readSessionTranscript`, which is the whole of the correlation. `window` rides along
+ * when the call came from one, exactly as the list's does, so the kernel resolves the scope and the
+ * page names no process.
  */
 export const sessionTranscriptCall = (
 	request: SessionTranscriptRequest,
@@ -53,7 +56,7 @@ export const sessionTranscriptCall = (
 		type: "spell.call",
 		version: PROTOCOL_VERSION,
 		id: CallId.make(crypto.randomUUID()),
-		path: [...SESSION_TRANSCRIPT_PATH],
+		path: [...SESSION_TRANSCRIPT_CALL_PATH],
 		args: {
 			programId: request.programId,
 			sessionId: request.sessionId,

--- a/apps/tuval/src/page/session-transcript.ts
+++ b/apps/tuval/src/page/session-transcript.ts
@@ -1,0 +1,179 @@
+/**
+ * The page's half of one session's transcript: build the page call, read the reply, fold the pages
+ * that land into the one history a window renders.
+ *
+ * It is the sibling of `./session-list.ts` and is shaped the same way, because it answers over the
+ * same carriage: a `SpellCall` correlated on its own `CallId` (`../protocol/messages.ts`, ADR 0348
+ * R1.3), decoded against the wire schema, refused rather than emptied when it cannot be read. The
+ * two rules that make a refusal legible are here rather than at the surface — a reply for another
+ * call is `null` and never an empty page, and a result the schema refuses is a refusal and never
+ * a session that holds nothing.
+ *
+ * **The fold is the other half, and it is why this module is more than a codec.** A transcript is
+ * read one page at a time from the newest end backwards, so the history on screen is every landed
+ * page in one list and the cursor is whatever the newest-landed page said. Keeping that fold pure
+ * is what lets the window's paging be proved without a socket: `landedPage` is a total function
+ * from the state and one answer to the next state, and every rule the surface owes — older pages
+ * go before the ones already held, an id already on screen is not repeated, a failed older page
+ * leaves the history alone and the cursor where it was — is a case of it.
+ */
+
+import {Result, Schema} from "effect";
+import type {WindowId} from "../protocol/ids.ts";
+import {CallId} from "../protocol/ids.ts";
+import type {SpellFailure, SpellReply} from "../protocol/messages.ts";
+import {PROTOCOL_VERSION, SpellCall} from "../protocol/messages.ts";
+import type {SessionTranscriptRequest, TranscriptItemWire} from "../protocol/session-transcript.ts";
+import {SESSION_TRANSCRIPT_PATH, SessionTranscript} from "../protocol/session-transcript.ts";
+
+/** One page landed and decoded: the items it carried and the cursor for the page older than it. */
+export interface PagedTranscript {
+	readonly _tag: "Paged";
+	readonly page: SessionTranscript;
+}
+
+/** The call was answered and the answer was a refusal — no such session, a timed-out store walk. */
+export interface RefusedTranscript {
+	readonly _tag: "Refused";
+	readonly failure: SpellFailure;
+}
+
+export type TranscriptLanding = PagedTranscript | RefusedTranscript;
+
+/**
+ * One page call. The id is minted here and the caller hands it back to `readSessionTranscript`,
+ * which is the whole of the correlation. `window` rides along when the call came from one, exactly
+ * as the list's does, so the kernel resolves the scope and the page names no process.
+ */
+export const sessionTranscriptCall = (
+	request: SessionTranscriptRequest,
+	window?: WindowId,
+): SpellCall =>
+	new SpellCall({
+		type: "spell.call",
+		version: PROTOCOL_VERSION,
+		id: CallId.make(crypto.randomUUID()),
+		path: [...SESSION_TRANSCRIPT_PATH],
+		args: {
+			programId: request.programId,
+			sessionId: request.sessionId,
+			cwd: request.cwd,
+			before: request.before,
+			limit: request.limit,
+		},
+		...(window === undefined ? {} : {window}),
+	});
+
+const refused = (failure: SpellFailure): RefusedTranscript => ({_tag: "Refused", failure});
+
+/**
+ * One reply as this call's answer, or `null` when it answers a different call. `null` is not an
+ * empty page: a window holding a first read and an older read open at once reads every reply, and
+ * "not mine" has to stay distinguishable from "mine, and there is nothing older".
+ */
+export const readSessionTranscript = (
+	call: SpellCall,
+	reply: SpellReply,
+): TranscriptLanding | null => {
+	if (reply.id !== call.id) return null;
+	if (!reply.ok) return refused(reply.error);
+	const decoded = Schema.decodeUnknownResult(SessionTranscript)(reply.result);
+	if (Result.isFailure(decoded)) {
+		return refused({
+			tag: "tuval/BadSessionTranscript",
+			message: "the kernel answered with a result this page cannot read as a transcript page",
+			path: call.path,
+		});
+	}
+	return {_tag: "Paged", page: decoded.success};
+};
+
+/**
+ * Where the walk into older history has got to, once a first page is on screen. It is beside the
+ * history rather than in place of it, because a failed older page must not take the transcript the
+ * operator is already reading off the screen.
+ */
+export type OlderRead =
+	| {readonly _tag: "Idle"}
+	| {readonly _tag: "Reading"}
+	| {readonly _tag: "Failed"; readonly failure: SpellFailure};
+
+/** What a caller's read answered with. `null` is "the first read is out", never "there is nothing". */
+export type TranscriptAnswer =
+	| {readonly _tag: "Read"; readonly page: SessionTranscript; readonly older: OlderRead}
+	| {readonly _tag: "Refused"; readonly failure: SpellFailure};
+
+/**
+ * Every landed page as one value. `landed` is its own field and not `items.length > 0`, because a
+ * session that really holds nothing is a page that landed and an empty transcript that never
+ * answered is not — folding them together is the one mistake this surface exists to refuse.
+ */
+export interface TranscriptPaging {
+	/** Oldest first, every landed page folded together. */
+	readonly items: ReadonlyArray<TranscriptItemWire>;
+	/** The cursor the next older request must carry, or `null` at the beginning of history. */
+	readonly next: string | null;
+	readonly landed: boolean;
+	/** The refusal that answered the *first* page, which is the whole view failing. */
+	readonly refusal: SpellFailure | null;
+	readonly older: OlderRead;
+}
+
+export const noPages: TranscriptPaging = {
+	items: [],
+	next: null,
+	landed: false,
+	refusal: null,
+	older: {_tag: "Idle"},
+};
+
+/** An older page was asked for. Nothing else moves: the cursor advances only when a page lands. */
+export const askedOlder = (paging: TranscriptPaging): TranscriptPaging => ({
+	...paging,
+	older: {_tag: "Reading"},
+});
+
+/**
+ * Older items before the ones already held, with anything already on screen dropped. Ids are the
+ * identity the store gives an item, so an overlapping page — a store that re-reads the cursor's own
+ * row, a retry that answered twice — folds to the same transcript rather than a doubled one.
+ */
+const fold = (
+	older: ReadonlyArray<TranscriptItemWire>,
+	held: ReadonlyArray<TranscriptItemWire>,
+): ReadonlyArray<TranscriptItemWire> => {
+	const seen = new Set(held.map((item) => item.id));
+	return [...older.filter((item) => !seen.has(item.id)), ...held];
+};
+
+/**
+ * The state after one answer to the request that carried `before`. `before === null` is the first
+ * page — the read that fills the window — and every other value is a walk further back, which is
+ * why the two refusal arms differ: the first page failing is the view failing, and an older page
+ * failing is a readable transcript that could not be extended.
+ */
+export const landedPage = (
+	paging: TranscriptPaging,
+	before: string | null,
+	landing: TranscriptLanding,
+): TranscriptPaging => {
+	if (landing._tag === "Refused") {
+		return before === null
+			? {...paging, refusal: landing.failure, older: {_tag: "Idle"}}
+			: {...paging, older: {_tag: "Failed", failure: landing.failure}};
+	}
+	return {
+		items: before === null ? landing.page.items : fold(landing.page.items, paging.items),
+		next: landing.page.next,
+		landed: true,
+		refusal: null,
+		older: {_tag: "Idle"},
+	};
+};
+
+/** The paging as the surface renders it: the first read out, refused, or a history with a cursor. */
+export const pagedAnswer = (paging: TranscriptPaging): TranscriptAnswer | null => {
+	if (paging.refusal !== null) return {_tag: "Refused", failure: paging.refusal};
+	if (!paging.landed) return null;
+	return {_tag: "Read", page: {items: paging.items, next: paging.next}, older: paging.older};
+};

--- a/apps/tuval/src/page/session-transcript.unit.test.ts
+++ b/apps/tuval/src/page/session-transcript.unit.test.ts
@@ -11,8 +11,12 @@ import {describe, expect, it} from "vitest";
 import {CallId} from "../protocol/ids.ts";
 import type {SpellFailure, SpellReply} from "../protocol/messages.ts";
 import {PROTOCOL_VERSION, SpellReplyError, SpellReplyOk} from "../protocol/messages.ts";
+import {SESSION_LIST_PROGRAM} from "../protocol/session-list.ts";
 import type {SessionTranscript, TranscriptItemWire} from "../protocol/session-transcript.ts";
-import {SESSION_TRANSCRIPT_PATH} from "../protocol/session-transcript.ts";
+import {
+	SESSION_TRANSCRIPT_CALL_PATH,
+	SESSION_TRANSCRIPT_PATH,
+} from "../protocol/session-transcript.ts";
 import type {TranscriptPaging} from "./session-transcript.ts";
 import {
 	askedOlder,
@@ -71,10 +75,19 @@ const ids = (paging: TranscriptPaging): ReadonlyArray<string> =>
 	paging.items.map((held) => held.id);
 
 describe("the call", () => {
+	it("addresses the call where the registry holds the spell", () => {
+		const call = sessionTranscriptCall(READ);
+
+		// The row's own path is `session.transcript`; the registry keys it under the program id, and
+		// a call carrying the bare path reaches no spell at all (#8238).
+		expect([...call.path]).toEqual([...SESSION_TRANSCRIPT_CALL_PATH]);
+		expect([...call.path].slice(1)).toEqual([...SESSION_TRANSCRIPT_PATH]);
+		expect(call.path[0]).toBe(SESSION_LIST_PROGRAM);
+	});
+
 	it("carries the session's whole address plus the cursor and the bound", () => {
 		const call = sessionTranscriptCall({...READ, before: "m-9", limit: 50});
 
-		expect(call.path).toEqual([...SESSION_TRANSCRIPT_PATH]);
 		expect(call.args).toEqual({
 			programId: "claude-session",
 			sessionId: "c-1",

--- a/apps/tuval/src/page/session-transcript.unit.test.ts
+++ b/apps/tuval/src/page/session-transcript.unit.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The page's transcript half without a socket: what one reply becomes, and what a sequence of
+ * landed pages folds into.
+ *
+ * The rendered half is `./session-transcript-window.unit.test.tsx`, which drives the same functions
+ * through the mounted window over a scripted `call`. This file is where the fold's rules are stated
+ * one at a time, because each of them is a case a rendered assertion would only reach indirectly.
+ */
+
+import {describe, expect, it} from "vitest";
+import {CallId} from "../protocol/ids.ts";
+import type {SpellFailure, SpellReply} from "../protocol/messages.ts";
+import {PROTOCOL_VERSION, SpellReplyError, SpellReplyOk} from "../protocol/messages.ts";
+import type {SessionTranscript, TranscriptItemWire} from "../protocol/session-transcript.ts";
+import {SESSION_TRANSCRIPT_PATH} from "../protocol/session-transcript.ts";
+import type {TranscriptPaging} from "./session-transcript.ts";
+import {
+	askedOlder,
+	landedPage,
+	noPages,
+	pagedAnswer,
+	readSessionTranscript,
+	sessionTranscriptCall,
+} from "./session-transcript.ts";
+
+const READ = {
+	programId: "claude-session",
+	sessionId: "c-1",
+	cwd: "/Users/founder/code/phoenix",
+	before: null,
+	limit: 50,
+};
+
+const item = (id: string): TranscriptItemWire => ({
+	kind: "user",
+	id,
+	timestamp: 1,
+	text: `turn ${id}`,
+});
+
+const page = (ids: ReadonlyArray<string>, next: string | null): SessionTranscript => ({
+	items: ids.map(item),
+	next,
+});
+
+const ok = (id: string, result: unknown): SpellReply =>
+	new SpellReplyOk({
+		type: "spell.reply",
+		version: PROTOCOL_VERSION,
+		id: CallId.make(id),
+		ok: true,
+		result,
+	});
+
+const failure: SpellFailure = {
+	tag: "tuval/TranscriptError",
+	message: 'no session "c-1" is stored for this working directory',
+	path: [...SESSION_TRANSCRIPT_PATH],
+};
+
+const refusal = (id: string, error: SpellFailure = failure): SpellReply =>
+	new SpellReplyError({
+		type: "spell.reply",
+		version: PROTOCOL_VERSION,
+		id: CallId.make(id),
+		ok: false,
+		error,
+	});
+
+const ids = (paging: TranscriptPaging): ReadonlyArray<string> =>
+	paging.items.map((held) => held.id);
+
+describe("the call", () => {
+	it("carries the session's whole address plus the cursor and the bound", () => {
+		const call = sessionTranscriptCall({...READ, before: "m-9", limit: 50});
+
+		expect(call.path).toEqual([...SESSION_TRANSCRIPT_PATH]);
+		expect(call.args).toEqual({
+			programId: "claude-session",
+			sessionId: "c-1",
+			cwd: "/Users/founder/code/phoenix",
+			before: "m-9",
+			limit: 50,
+		});
+	});
+
+	it("mints a fresh id per call, so two reads of one session are two answers", () => {
+		expect(sessionTranscriptCall(READ).id).not.toBe(sessionTranscriptCall(READ).id);
+	});
+});
+
+describe("reading a reply", () => {
+	it("ignores a reply that answers another call", () => {
+		const call = sessionTranscriptCall(READ);
+		expect(readSessionTranscript(call, ok("someone-else", page(["a"], null)))).toBeNull();
+	});
+
+	it("reads a well-formed page as the page it is", () => {
+		const call = sessionTranscriptCall(READ);
+		const landing = readSessionTranscript(call, ok(call.id, page(["a", "b"], "a")));
+
+		expect(landing).toEqual({_tag: "Paged", page: page(["a", "b"], "a")});
+	});
+
+	it("reads the kernel's own refusal as a refusal, keeping its words", () => {
+		const call = sessionTranscriptCall(READ);
+		const landing = readSessionTranscript(call, refusal(call.id));
+
+		expect(landing).toEqual({_tag: "Refused", failure});
+	});
+
+	it("refuses a result the schema cannot read rather than reading it as an empty session", () => {
+		const call = sessionTranscriptCall(READ);
+		const landing = readSessionTranscript(
+			call,
+			ok(call.id, {items: [{kind: "nonsense"}], next: null}),
+		);
+
+		expect(landing?._tag).toBe("Refused");
+		expect(landing?._tag === "Refused" && landing.failure.tag).toBe("tuval/BadSessionTranscript");
+	});
+});
+
+describe("folding landed pages", () => {
+	const first = landedPage(noPages, null, {_tag: "Paged", page: page(["c", "d"], "c")});
+
+	it("says nothing has landed before the first page does", () => {
+		expect(pagedAnswer(noPages)).toBeNull();
+	});
+
+	it("renders a session that really holds nothing as a landed empty page", () => {
+		const empty = landedPage(noPages, null, {_tag: "Paged", page: page([], null)});
+
+		expect(pagedAnswer(empty)).toEqual({
+			_tag: "Read",
+			page: {items: [], next: null},
+			older: {_tag: "Idle"},
+		});
+	});
+
+	it("puts an older page before the one already held", () => {
+		const older = landedPage(first, "c", {_tag: "Paged", page: page(["a", "b"], "a")});
+
+		expect(ids(older)).toEqual(["a", "b", "c", "d"]);
+		expect(older.next).toBe("a");
+	});
+
+	it("drops an overlapping item rather than repeating one already on screen", () => {
+		const older = landedPage(first, "c", {_tag: "Paged", page: page(["a", "b", "c"], null)});
+
+		expect(ids(older)).toEqual(["a", "b", "c", "d"]);
+	});
+
+	it("ends the walk when a page reports no cursor", () => {
+		const older = landedPage(first, "c", {_tag: "Paged", page: page(["a"], null)});
+
+		expect(pagedAnswer(older)).toEqual({
+			_tag: "Read",
+			page: {items: [item("a"), item("c"), item("d")], next: null},
+			older: {_tag: "Idle"},
+		});
+	});
+
+	it("keeps the history and the cursor when an older page fails", () => {
+		const failed = landedPage(askedOlder(first), "c", {_tag: "Refused", failure});
+
+		expect(ids(failed)).toEqual(["c", "d"]);
+		expect(failed.next).toBe("c");
+		expect(pagedAnswer(failed)).toEqual({
+			_tag: "Read",
+			page: {items: [item("c"), item("d")], next: "c"},
+			older: {_tag: "Failed", failure},
+		});
+	});
+
+	it("clears that failure when the same cursor is asked for again and answers", () => {
+		const failed = landedPage(askedOlder(first), "c", {_tag: "Refused", failure});
+		const retried = landedPage(askedOlder(failed), "c", {
+			_tag: "Paged",
+			page: page(["a", "b"], null),
+		});
+
+		expect(ids(retried)).toEqual(["a", "b", "c", "d"]);
+		expect(retried.older).toEqual({_tag: "Idle"});
+	});
+
+	it("makes a refused first page the whole view's refusal, never an empty transcript", () => {
+		const refused = landedPage(noPages, null, {_tag: "Refused", failure});
+
+		expect(pagedAnswer(refused)).toEqual({_tag: "Refused", failure});
+	});
+});

--- a/apps/tuval/src/protocol/session-transcript.ts
+++ b/apps/tuval/src/protocol/session-transcript.ts
@@ -23,9 +23,22 @@ import {
 	type JsonValue,
 	TOOL_RESULT_BYTE_LIMIT,
 } from "../ai-agent/ports/transcript-item.ts";
+import {SESSION_LIST_PROGRAM} from "./session-list.ts";
 
 /** The spell's address on the session-list program row: `session.transcript`. */
 export const SESSION_TRANSCRIPT_PATH = ["session", "transcript"] as const;
+
+/**
+ * The whole address a caller sends. The registry keys a row's spell under `[programId, ...path]`
+ * (`../commands/registry.ts`), so a call carrying the bare `session.transcript` reaches no spell and
+ * the kernel answers `UnknownSpell` — which is what a page sending the bare path did (#8238). The
+ * row is the session list's own, because that row declares both spells
+ * (`../ai-agent/session-list.ts`), so the program id is imported rather than respelled.
+ */
+export const SESSION_TRANSCRIPT_CALL_PATH = [
+	SESSION_LIST_PROGRAM,
+	...SESSION_TRANSCRIPT_PATH,
+] as const;
 
 /**
  * A tool's input, as `TranscriptItem` declares it: plain JSON and never a backend's own type.

--- a/apps/tuval/tsconfig.design.json
+++ b/apps/tuval/tsconfig.design.json
@@ -27,6 +27,7 @@
 		"src/page/proof/no-recovery.tsx",
 		"src/page/attached-desk.unit.test.tsx",
 		"src/page/readable-state.unit.test.tsx",
+		"src/page/session-transcript-window.unit.test.tsx",
 		"src/claude/proof/subagent-vertical.integration.test.ts",
 		"src/page/assets.d.ts"
 	],

--- a/apps/tuval/tsconfig.json
+++ b/apps/tuval/tsconfig.json
@@ -28,9 +28,11 @@
 	// The slices that reach `@kampus/design` have their own lens, `tsconfig.design.json`, because
 	// the package is source-consumed and is authored with `exactOptionalPropertyTypes: false`.
 	// Excluding them here is what keeps the kernel on the strict flag; `typecheck` runs both.
-	// `src/page/` is split rather than excluded whole: the three React modules reach the chat window
+	// `src/page/` is split rather than excluded whole: the React modules reach the chat window
 	// through the page's renderer table (#7573) and go to the other lens, while `dev-server.ts` is
-	// Node-side, is imported by `src/bin.ts`, and stays here.
+	// Node-side, is imported by `src/bin.ts`, and stays here. `session-transcript.ts` is on this
+	// lens with `session-list.ts` beside it — the page's wire halves reach no React — and only the
+	// test that mounts the table over them is split off (#8238).
 	// `src/claude/proof/subagent-vertical.integration.test.ts` is split the same way and for the same
 	// reason: it mounts the shipped chat window over a live process, so it reaches `@kampus/design`
 	// through it. Its two neighbours — the config module and the capture handle — reach no React and
@@ -51,6 +53,7 @@
 		"src/page/proof/no-recovery.tsx",
 		"src/page/attached-desk.unit.test.tsx",
 		"src/page/readable-state.unit.test.tsx",
+		"src/page/session-transcript-window.unit.test.tsx",
 		"src/claude/proof/subagent-vertical.integration.test.ts"
 	]
 }


### PR DESCRIPTION
Picking a session row in Tuval's session list mounted a transcript view with no source behind it, so
the surface sat on "Reading this session's transcript…" forever and the "Load older messages" button
could never render. #8492 landed the store-side `sessionTranscript` API with cursor paging; this is
the client half.

**What it does now.** `apps/tuval/src/page/session-transcript.ts` is the page's own half of the
spell, the sibling of `page/session-list.ts`: it builds the `session.transcript` call, reads a reply
back through the wire schema, and folds landed pages into one history. `page/renderers.tsx` binds a
source over it and hands it to the session-list window, so picking a row sends that row's
`programId`, `sessionId`, `cwd`, a `null` cursor and the 50-item bound, and renders the decoded page.

**Paging.** When a page reports `next`, the older button asks for exactly that cursor. The older page
lands before the held one, overlapping item ids are dropped, and the affordance disappears once a
page reaches the beginning of history. A failed older page leaves the transcript readable, says what
failed, and leaves the cursor where it was — pressing again retries the same page rather than
skipping it.

**Scoping.** The transcript source is a hook, so it is mounted in a child component keyed on the
selected session: hooks stay unconditional, and picking a second row unmounts the first read instead
of folding its pages into the new session's history. A reply that lands after its read was left
behind is dropped, and a reply carrying another call's id is never folded in.

A refusal — `session-not-found`, a timed-out store walk, a result the schema cannot decode — renders
as a refusal with the kernel's own words, never as an empty session.

**Repair round 1 — the call was mis-addressed.** Hand-verification on a real desk found the page
sending the bare `["session","transcript"]` while the registry keys a row's spell under
`[programId, ...path]` (`commands/registry.ts`), so the kernel answered
`tuval/commands/UnknownSpell` and nothing ever rendered. `protocol/session-transcript.ts` now exports
`SESSION_TRANSCRIPT_CALL_PATH` — the session-list row's program id plus the spell's own path,
mirroring `SESSION_LIST_CALL_PATH` — and the page sends that.

The rendered test could not catch it because its scripted socket parked every non-list path. It is
now a registry rather than a router: it answers only the two addresses the kernel really registers
and refuses anything else with the kernel's own `UnknownSpell`, so a mis-addressed call reds the
file. Reverting the page to the bare path fails 16 of the 31 tests in these two files.

**What a reviewer should look at first.** `apps/tuval/src/page/session-transcript-window.unit.test.tsx`
mounts the renderer out of `pageRenderers` over that socket, because the fault this fixes was a seam
nobody bound: every unit around the window passed while the window read forever. It asserts on the
calls the socket actually received.

Nothing here spawns a process, takes over a session or writes restore state — reading and paging stay
read-only until the operator sends.

Fixes #8238

## Deviations

- **Out-of-scope change** — **Said:** #8238 names the client wiring for the transcript.
  **Did:** also added a `## A window that calls a spell` section to `.patterns/tuval-spells.md`,
  including the program-prefixed-address rule and the registry-not-router rule for scripted sockets.
  **Why:** this is the second instance of the page-side call/read/hook shape, and the address rule is
  the mistake this PR's repair round was; CLAUDE.md requires a load-bearing pattern to be documented
  rather than left implicit. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about `session-open.unit.test.tsx`.
  **Did:** updated its `useTranscript` stubs to the widened source signature (it now answers
  `{answer, onOlder?}` and takes `openRead`'s request rather than the read inside it).
  **Why:** the seam had to widen to carry the older affordance and the unopenable-row case; every
  assertion in that file is unchanged. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the TypeScript project lenses.
  **Did:** added the new rendered test to `apps/tuval/tsconfig.json`'s exclude and
  `tsconfig.design.json`'s include. **Why:** it reaches `@kampus/design` transitively, and the repo
  splits every such file onto the relaxed lens; without it the strict lens pulls `src/ai-agent/window`
  in and fails on `TS6307`. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left
  `apps/tuval/src/ai-agent/window/session-list-window.css` unvalidated by `build check`.
  **Why:** no surface in this repo validates CSS; the file adds one flex block for the older
  affordance and is covered by the rendered tests above it. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left the transport-level
  `Effect.catchCause(() => Effect.void)` arm as-is, so a socket that dies mid-read leaves the first
  page reading with no deadline. **Why:** it is the sibling `sessionListSource`'s existing shape, and
  that module's docblock rules a dropped link the desk connection banner's job; #8238's criteria are
  scoped to reply-level failure. Raised by review-code as a non-blocking sweep note.
  **Disposition:** stated here.
