### PR TITLE
fix: A paged Pi window can still show one operator turn twice once the layer's echo clears the local mark

### DIFF
--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -48,6 +48,18 @@ interface ItemBase {
 	 * reasoning from the agent's own.
 	 */
 	readonly parentId?: ItemId;
+	/**
+	 * The other id this same row is known by, when a backend keys its live tail and its history
+	 * reads in two id spaces. Absent means the row has one identity, which is every row a backend
+	 * with a single id space emits.
+	 *
+	 * It exists because the page/tail stitch (`shell/chat/rows.ts`) has to decide whether a page
+	 * copy and a tail row are one turn, and on Pi they never share an `id`: the live tail is keyed
+	 * positionally over the context messages, the history page by the stored session entry
+	 * (`pi/ai-agent/entries.ts`). The backend that holds both spaces states the join here rather
+	 * than the window guessing at one from text (#8032).
+	 */
+	readonly alias?: ItemId;
 }
 
 /**
@@ -205,15 +217,16 @@ const isToolResult = (value: unknown): value is ToolResult =>
 const statuses: ReadonlySet<string> = new Set<ToolStatus>(["running", "ok", "error"]);
 
 /**
- * The port predicate for one item: identity, clock, parent tag, kind, and the tool result's own
- * bound. The parent tag is read once ahead of the switch, because every kind may carry one.
+ * The port predicate for one item: identity, clock, parent tag, second identity, kind, and the tool
+ * result's own bound. The tags are read once ahead of the switch, because every kind may carry them.
  */
 export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 	if (
 		!Predicate.isObject(value) ||
 		!isId(value.id) ||
 		!Number.isFinite(value.timestamp) ||
-		!isOptionalId(value.parentId)
+		!isOptionalId(value.parentId) ||
+		!isOptionalId(value.alias)
 	)
 		return false;
 	switch (value.kind) {

--- a/apps/tuval/src/pi/ai-agent/entries.ts
+++ b/apps/tuval/src/pi/ai-agent/entries.ts
@@ -14,6 +14,10 @@
  * documented contract — `item-<index>` over the message list it was handed — which is what lets an
  * entry be matched back to its projected item here and re-keyed to the entry's own stable id.
  *
+ * That re-key is also why a row read back here carries `alias`: the live tail keeps the positional
+ * id, so a page copy and the tail row for one turn share no `id` and the window would render both.
+ * `alias` is the live id for the same row, and it is what the page/tail stitch joins on (#8032).
+ *
  * A `compaction` is the one entry that moved the transcript out from under the reader, so it gets
  * the port's own boundary kind; every other non-message entry — a branch summary, a model or
  * thinking-level change, an extension's own entry, a rename, a label — is one collapsed `system`
@@ -45,6 +49,11 @@ const millisOf = (timestamp: string): number => {
  * that identity is what makes a later result supersede its running row — and everything else
  * takes the entry's own id, which is stable across the renumbering a compaction causes. A turn's
  * reasoning row is derived from that same entry id, so it stays distinct from the reply beside it.
+ *
+ * The re-key is what leaves Pi with two id spaces, so `aliased` below states the join between them:
+ * a stored row carries the live tail's own id for the same turn in `alias`, which is how the
+ * window's page/tail stitch knows a page copy and a tail row are one turn rather than two (#8032).
+ * A tool row needs none — `toolCallId` is the same string on both paths.
  */
 const onEntry = (item: TranscriptItem, entry: SessionMessageEntry): TranscriptItem => {
 	const timestamp = millisOf(entry.timestamp);
@@ -130,7 +139,21 @@ export const pageCursorAliases = (
 	return aliases;
 };
 
+/** `pageCursorAliases` read the other way: a stored id → the live tail's own id for that row. */
+const liveIdsOf = (entries: ReadonlyArray<SessionEntry>): ReadonlyMap<string, string> => {
+	const live = new Map<string, string>();
+	for (const [alias, stored] of pageCursorAliases(entries)) live.set(stored, alias);
+	return live;
+};
+
+/** Stamp a stored row with the live id for the same turn, when the two spaces disagree about it. */
+const aliased = (item: TranscriptItem, live: ReadonlyMap<string, string>): TranscriptItem => {
+	const alias = live.get(item.id);
+	return alias === undefined || alias === item.id ? item : {...item, alias: itemId(alias)};
+};
+
 export const pageItems = (entries: ReadonlyArray<SessionEntry>): ReadonlyArray<TranscriptItem> => {
+	const live = liveIdsOf(entries);
 	const messages = entries.flatMap((entry) =>
 		entry.type === "message" ? [entry.message as SourceMessage] : [],
 	);
@@ -147,7 +170,7 @@ export const pageItems = (entries: ReadonlyArray<SessionEntry>): ReadonlyArray<T
 			// A message whose role the wire does not carry — an extension's own — projects to
 			// nothing, and its index is spent all the same, which is why the counter advances first.
 			if (source !== undefined)
-				for (const item of itemsOf(source)) items.push(onEntry(item, entry));
+				for (const item of itemsOf(source)) items.push(aliased(onEntry(item, entry), live));
 			continue;
 		}
 		const notice = noticeItemOf(entry);

--- a/apps/tuval/src/pi/ai-agent/entries.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/entries.unit.test.ts
@@ -18,8 +18,11 @@ import type {
 	SessionInfoEntry,
 	ThinkingLevelChangeEntry,
 } from "@earendil-works/pi-coding-agent";
+import {buildContextEntries, sessionEntryToContextMessages} from "@earendil-works/pi-coding-agent";
 import {describe, expect, it} from "vitest";
+import {projectTranscript, type SourceMessage} from "../server/index.ts";
 import {pageCursorAliases, pageItems} from "./entries.ts";
+import {itemsOf} from "./items.ts";
 
 /** The package's root does not re-export the label entry's interface; the union still names it. */
 type LabelEntry = Extract<SessionEntry, {type: "label"}>;
@@ -57,8 +60,20 @@ describe("a session branch as pageable history", () => {
 			message("e2", "e1", 2, replied("older answer")),
 		]);
 		expect(items).toEqual([
-			{kind: "user", id: "e1", timestamp: Date.parse(at(1)), text: "older question"},
-			{kind: "assistant", id: "e2", timestamp: Date.parse(at(2)), text: "older answer"},
+			{
+				kind: "user",
+				id: "e1",
+				alias: "item-0",
+				timestamp: Date.parse(at(1)),
+				text: "older question",
+			},
+			{
+				kind: "assistant",
+				id: "e2",
+				alias: "item-1",
+				timestamp: Date.parse(at(2)),
+				text: "older answer",
+			},
 		]);
 	});
 
@@ -156,7 +171,7 @@ describe("a session branch as pageable history", () => {
 		const items = pageItems([compaction, message("e2", "e1", 2, said("carry on"))]);
 		expect(items).toEqual([
 			{kind: "compaction", id: "e1", timestamp: Date.parse(at(1)), text: "we agreed on the plan"},
-			{kind: "user", id: "e2", timestamp: Date.parse(at(2)), text: "carry on"},
+			{kind: "user", id: "e2", alias: "item-1", timestamp: Date.parse(at(2)), text: "carry on"},
 		]);
 	});
 
@@ -190,8 +205,20 @@ describe("a session branch as pageable history", () => {
 			}),
 		]);
 		expect(items.slice(1)).toEqual([
-			{kind: "thinking", id: "e2:thinking", timestamp: Date.parse(at(2)), text: "weighing it up"},
-			{kind: "assistant", id: "e2", timestamp: Date.parse(at(2)), text: "here is the answer"},
+			{
+				kind: "thinking",
+				id: "e2:thinking",
+				alias: "item-1:thinking",
+				timestamp: Date.parse(at(2)),
+				text: "weighing it up",
+			},
+			{
+				kind: "assistant",
+				id: "e2",
+				alias: "item-1",
+				timestamp: Date.parse(at(2)),
+				text: "here is the answer",
+			},
 		]);
 	});
 
@@ -201,7 +228,7 @@ describe("a session branch as pageable history", () => {
 			message("e2", "e1", 2, said("still mine")),
 		]);
 		expect(items).toEqual([
-			{kind: "user", id: "e2", timestamp: Date.parse(at(2)), text: "still mine"},
+			{kind: "user", id: "e2", alias: "item-1", timestamp: Date.parse(at(2)), text: "still mine"},
 		]);
 	});
 });
@@ -287,7 +314,115 @@ describe("the session's own entries as collapsed notices", () => {
 		const page = [laterPi, message("e2", "e1", 2, said("still here"))];
 		expect(() => pageItems(page)).not.toThrow();
 		expect(pageItems(page)).toEqual([
-			{kind: "user", id: "e2", timestamp: Date.parse(at(2)), text: "still here"},
+			{kind: "user", id: "e2", alias: "item-0", timestamp: Date.parse(at(2)), text: "still here"},
 		]);
+	});
+});
+
+/**
+ * The two id spaces one Pi turn lives in. The live tail is built the way the host builds it
+ * (`../server/AgentSessionHost.ts`: `buildContextEntries` → `sessionEntryToContextMessages` →
+ * `projectTranscript`) rather than hand-numbered, because hand-numbered positions would agree with
+ * `alias` by construction and prove nothing about the path the window actually renders.
+ */
+describe("the live id a stored row is also known by", () => {
+	const liveIds = (entries: ReadonlyArray<SessionEntry>): ReadonlyArray<string> => {
+		const messages = buildContextEntries([...entries]).flatMap(
+			sessionEntryToContextMessages,
+		) as ReadonlyArray<SourceMessage>;
+		return projectTranscript(messages).flatMap((item) =>
+			itemsOf(item).map((row) => String(row.id)),
+		);
+	};
+
+	it("gives a stored user turn the id the live tail keys the same turn by", () => {
+		const entries = [
+			message("e1", null, 1, said("first question")),
+			message("e2", "e1", 2, replied("first answer")),
+		];
+		expect(liveIds(entries)).toEqual(["item-0", "item-1"]);
+		expect(pageItems(entries).map((item) => [item.id, item.alias])).toEqual([
+			["e1", "item-0"],
+			["e2", "item-1"],
+		]);
+	});
+
+	it("gives an assistant turn's reasoning row its own live id, not the reply's", () => {
+		const entries = [
+			message("e1", null, 1, said("think first")),
+			message("e2", "e1", 2, {
+				role: "assistant",
+				content: [
+					{type: "thinking", thinking: "weighing it up"},
+					{type: "text", text: "here is the answer"},
+				],
+				provider: "faux",
+				model: "faux-1",
+				stopReason: "stop",
+				timestamp: 0,
+			}),
+		];
+		expect(liveIds(entries)).toEqual(["item-0", "item-1:thinking", "item-1"]);
+		expect(pageItems(entries).map((item) => [item.id, item.alias])).toEqual([
+			["e1", "item-0"],
+			["e2:thinking", "item-1:thinking"],
+			["e2", "item-1"],
+		]);
+	});
+
+	it("follows the renumbering a compaction causes rather than the stored order", () => {
+		const compaction: CompactionEntry = {
+			type: "compaction",
+			id: "compact",
+			parentId: "e4",
+			timestamp: at(5),
+			summary: "the first exchange, summarized",
+			firstKeptEntryId: "e3",
+			tokensBefore: 4_000,
+		};
+		const entries = [
+			message("e1", null, 1, said("first question")),
+			message("e2", "e1", 2, replied("first answer")),
+			message("e3", "e2", 3, said("second question")),
+			message("e4", "e3", 4, replied("second answer")),
+			compaction,
+			message("e5", "compact", 6, said("third question")),
+		];
+		// The stored order is untouched; the live tail starts at the summary the compaction left.
+		expect(pageItems(entries).map((item) => [item.id, item.alias])).toEqual([
+			["e1", undefined],
+			["e2", undefined],
+			["e3", "item-1"],
+			["e4", "item-2"],
+			["compact", undefined],
+			["e5", "item-3"],
+		]);
+		expect(liveIds(entries)).toEqual(["item-1", "item-2", "item-3"]);
+	});
+
+	it("leaves a tool row unaliased — its call id is the same string on both paths", () => {
+		const entries = [
+			message("e1", null, 1, said("read it")),
+			message("e2", "e1", 2, {
+				role: "assistant",
+				content: [{type: "toolCall", id: "call-1", name: "read_file", arguments: {path: "a.md"}}],
+				provider: "faux",
+				model: "faux-1",
+				stopReason: "toolUse",
+				timestamp: 0,
+			}),
+			message("e3", "e2", 3, {
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read_file",
+				content: [{type: "text", text: "file body"}],
+				isError: false,
+				timestamp: 0,
+			}),
+		];
+		const tool = pageItems(entries).at(-1);
+		expect(tool?.id).toBe("call-1");
+		expect(tool?.alias).toBeUndefined();
+		expect(liveIds(entries)).toContain("call-1");
 	});
 });

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -7,12 +7,21 @@
  * and "a page prepends without duplicating what the tail already holds" are decisions a test can
  * make without a DOM.
  *
- * That second decision joins on **id, and then on text for a turn the layer never echoed** (#7998).
- * Id alone cannot deliver it: the core records the operator's own turn at send time under a
- * synthetic `local:<key>` id (`ai-agent/core/fold.ts`, `promptItem`), and a layer that emits no
- * `user` item of its own never clears that marker — so the same turn comes back from the layer's
- * history store under the layer's id and matches nothing in the tail. `unheld` below is the fold's
- * `echoOf` join applied to the page/tail stitch, under the same two guards.
+ * That second decision joins on **either of a row's two ids, and then on text for a turn the layer
+ * never echoed**. Id alone cannot deliver either half.
+ *
+ * The `alias` half is #8032: a backend may key its live tail and its history reads in two id spaces
+ * — Pi keys the tail positionally and the page by the stored session entry — so one turn arrives
+ * under two strings and a single-id join renders it twice. The backend that holds both spaces says
+ * so on the row (`ports/transcript-item.ts`, `alias`), and matching a page row's `alias` against
+ * what the tail holds is the whole of the join; nothing here learns which backend has two spaces.
+ *
+ * The text half is #7998: the core records the operator's own turn at send time under a synthetic
+ * `local:<key>` id (`ai-agent/core/fold.ts`, `promptItem`), and a layer that emits no `user` item
+ * of its own never clears that marker — so the same turn comes back from the layer's history store
+ * under the layer's id and matches nothing in the tail. `unheld` below is the fold's `echoOf` join
+ * applied to the page/tail stitch, under the same two guards. It cannot cover the `alias` half:
+ * Pi does echo, and the echo clears `local` before the operator can page at all.
  *
  * The head row is one row, never two: the loading row *replaces* the omitted-count line while a page
  * is in flight, and both disappear at the beginning of history (founder ruling, 2026-09-02).
@@ -143,7 +152,9 @@ const claimsLocal = (item: TranscriptItem, budget: Map<string, number>): boolean
 /**
  * The `page` items `held` does not already carry, in page order.
  *
- * Two joins, and the second is the fold's `echoOf` with both of its guards intact: only a *layer's*
+ * Two joins. The first is identity, and it reads both of a row's ids — its own and the `alias` its
+ * backend gave it for the other id space — so a page copy keyed differently from the tail row for
+ * one turn is still one turn. The second is the fold's `echoOf` with both of its guards intact: only a *layer's*
  * item may claim a still-`local` held one, and a `local` item never claims another, so two
  * deliberate sends of the same text stay two turns. The budget is what makes the claim one-to-one —
  * one unconfirmed turn cancels one page copy, never every copy that shares its text.
@@ -156,19 +167,27 @@ const unheld = (
 	held: ReadonlyArray<TranscriptItem>,
 	page: ReadonlyArray<TranscriptItem>,
 ): ReadonlyArray<TranscriptItem> => {
-	const known = new Set<string>(held.map((item) => item.id));
+	const known = new Set<string>();
+	for (const item of held) {
+		known.add(item.id);
+		if (item.alias !== undefined) known.add(item.alias);
+	}
 	const budget = localTextBudget(held);
 	const fresh: Array<TranscriptItem> = [];
 	for (let index = page.length - 1; index >= 0; index -= 1) {
 		const item = page[index];
 		if (item === undefined) continue;
-		if (known.has(item.id) || claimsLocal(item, budget)) continue;
+		const carried = known.has(item.id) || (item.alias !== undefined && known.has(item.alias));
+		if (carried || claimsLocal(item, budget)) continue;
 		fresh.push(item);
 	}
 	return fresh.reverse();
 };
 
-/** Prepend a page, dropping anything the window already holds. Oldest-first, in and out. */
+/**
+ * Prepend a page, dropping anything the window already holds. Oldest-first, in and out. Through the
+ * same `unheld` `chatRows` uses, so a second page cannot re-introduce a copy the first reconciled.
+ */
 export const mergeOlder = (
 	held: ReadonlyArray<TranscriptItem>,
 	page: ReadonlyArray<TranscriptItem>,

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -7,7 +7,7 @@
 import {describe, expect, it} from "vitest";
 import {promptItem} from "../../ai-agent/core/fold.ts";
 import {planTranscriptPage, planTranscriptWindow} from "../../ai-agent/history/index.ts";
-import {ItemId} from "../../ai-agent/ports/index.ts";
+import {ItemId, type TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
 import {
 	assistantItem,
@@ -35,6 +35,15 @@ const base = {older: [], tail: [], omitted: 0, loading: false, atOldest: false};
 
 /** The operator's turn exactly as the core records it on send: `local: true` under a `local:` id. */
 const sent = (key: string, text: string) => promptItem({text, key, timestamp: 1_756_000_000_000});
+
+/**
+ * A history row from a backend that keys its live tail in another id space: the row's own stored id,
+ * plus the `item-<index>` the same turn carries in the tail (Pi, `pi/ai-agent/entries.ts`).
+ */
+const stored = <Item extends TranscriptItem>(item: Item, position: number): Item => ({
+	...item,
+	alias: ItemId.make(`item-${position}`),
+});
 
 const itemIds = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<string> =>
 	rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []));
@@ -311,6 +320,52 @@ describe("mergeOlder", () => {
 		const held = [sent("k1", "merhaba")];
 		const merged = mergeOlder(held, [userItem("a", "merhaba"), userItem("b", "merhaba")]);
 		expect(merged.map((item) => item.id)).toEqual(["a", "local:k1"]);
+	});
+
+	it("drops a page copy the tail holds under the other id, and keeps dropping it", () => {
+		const held = [userItem("item-0", "merhaba"), assistantItem("item-1", "hoş")];
+		const first = mergeOlder(held, [userItem("e0", "önce"), stored(userItem("e1", "merhaba"), 0)]);
+		expect(first.map((item) => item.id)).toEqual(["e0", "item-0", "item-1"]);
+		expect(mergeOlder(first, [stored(userItem("e1", "merhaba"), 0)])).toBe(first);
+	});
+});
+
+/**
+ * The Pi shape #8032 reported: the live tail keys a turn `item-<index>` and the history page keys
+ * the same turn by its session entry, so a single-id join renders it twice. The page row carries
+ * the live id in `alias`, which is what the stitch matches on. The tail rows here are ordinary
+ * confirmed rows — Pi echoes every turn, so the `local` mark is long gone by the time an operator
+ * can page at all, and the text join has nothing to work with.
+ */
+describe("a page and a tail that key one turn in two id spaces", () => {
+	it("emits one row for a user turn the page and the tail both carry", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [userItem("item-0", "merhaba")],
+			older: [stored(userItem("e1", "merhaba"), 0)],
+		});
+		expect(itemIds(rows)).toEqual(["item-0"]);
+	});
+
+	it("emits one row for an assistant turn too, since the re-key is not the user turn's alone", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [assistantItem("item-1", "buyurun")],
+			older: [stored(assistantItem("e2", "buyurun"), 1)],
+		});
+		expect(itemIds(rows)).toEqual(["item-1"]);
+	});
+
+	it("keeps two genuinely different turns of identical text as two rows", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [userItem("item-4", "merhaba")],
+			older: [stored(userItem("e1", "merhaba"), 0), stored(userItem("e5", "merhaba"), 4)],
+		});
+		expect(itemIds(rows)).toEqual(["e1", "item-4"]);
 	});
 });
 


### PR DESCRIPTION
On Pi the live tail and the history page key one turn under two different strings: the tail is
projected positionally over the context messages (`item-<index>`), the page by the stored session
entry. The window's page/tail stitch joins on id, so both copies render. The `local`-mark fallback
#7998 added cannot cover it — Pi echoes every turn, and the echo clears the mark long before the
operator can page.

The fix is a second identity on the row, stated by the only party that knows both spaces. The port
item gains an optional `alias`: the other id this same row is known by. `pageItems` stamps it from
`pageCursorAliases` read backwards, so a stored row carries the live id for the same turn — a tool
row needs none, since `toolCallId` is the same string on both paths. `unheld` in `shell/chat/rows.ts`
then matches on either id, which covers `chatRows` and `mergeOlder` together because both already go
through it.

Tests: `entries.unit.test.ts` builds the live tail the way `AgentSessionHost` builds it
(`buildContextEntries` → `sessionEntryToContextMessages` → `projectTranscript`) rather than
hand-numbering, and pins the alias for a user turn, a reasoning row, a compacted branch, and the
unaliased tool row. `rows.unit.test.ts` pins one row out of a page/tail pair for a user turn and an
assistant turn, two rows for two genuinely different turns of identical text, and the same drop
through `mergeOlder` on a second page.

Fixes #8032

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8032 asks for new tests in
  `entries.unit.test.ts` and `rows.unit.test.ts`. **Did:** also updated five existing `toEqual`
  expectations in `entries.unit.test.ts` that assert whole `pageItems` rows. **Why:** those rows now
  carry `alias`, so a whole-object assertion reds without it; each was updated to the new value read
  off the real construction, none was loosened to a partial match. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names four files under `pi/` and `shell/chat/`.
  **Did:** also added `alias` to `ItemBase` in `ai-agent/ports/transcript-item.ts` and to its
  predicate. **Why:** the join needs a field both paths can carry, and the port item union is the
  only place a field on every row can live; the shell join stays model-blind because of it.
  **Disposition:** stated here.
