### PR TITLE
fix: Tuval thin chat renderers accept an extras option they silently discard

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -253,10 +253,13 @@ Three files, and the split between them is forced rather than stylistic.
 - **The renderer is a thin binding, and its extras go through one slot.** Both AI-agent programs
   render the one shared `ChatWindow` (founder ruling 2026-09-02, amended on #7572 / #7584):
   `chatWindow({extras})` takes a `(state) => ReactNode` that lands in the window's status bar beside
-  the phase line and the mode switch, and that is the whole of what a program adds. Pi's is its
-  usage line — model, cumulative cost, token counts, off `state.usage`
-  (`src/pi/window/PiChatWindow.tsx`); Claude's is that line plus a session line — session id and
-  cwd, off `state.sessionId` and `state.cwd` (`src/claude/window/ClaudeChatWindow.tsx`). Each
+  the phase line and the mode switch, and that is the whole of what a program adds. Neither program
+  passes one today: the founder's 2026-09-05 ruling (#8190) sent Pi's usage line and Claude's
+  session line to the desk inspector, so both bars carry the phase line alone. **The slot is the
+  binding's, and its type says so.** A binding takes `ThinChatWindowOptions` — every window option
+  but `extras` — so a caller reaching the slot through `piChatWindow` or `claudeChatWindow` is a
+  compile error rather than an argument the binding overwrites without a signal (#7957); a caller
+  that wants its own extras wants the shared `chatWindow`, under its own name. Each
   renderer directory is named in `tsconfig.json`'s `exclude` and `tsconfig.design.json`'s `include`,
   for the lens reason above. It is a function of the live state because a renderer *is*
   `f(state, view)`; a renderer that accumulated its own totals would disagree with the checkpoint

--- a/apps/tuval/src/claude/window/ClaudeChatWindow.tsx
+++ b/apps/tuval/src/claude/window/ClaudeChatWindow.tsx
@@ -14,11 +14,14 @@
  * binding adds is nothing today, which is the ruling's point.
  */
 
-import type {ChatWindowOptions, ChatWindowRenderer} from "../../shell/chat/index.ts";
+import type {ChatWindowRenderer, ThinChatWindowOptions} from "../../shell/chat/index.ts";
 import {chatWindow} from "../../shell/chat/index.ts";
 
-/** The Claude renderer at whatever window options a caller needs. */
-export const claudeChatWindow = (options: ChatWindowOptions = {}): ChatWindowRenderer =>
+/**
+ * The Claude renderer at whatever window options a caller needs — every option but `extras`, which
+ * `ThinChatWindowOptions` withholds because the binding owns that slot.
+ */
+export const claudeChatWindow = (options: ThinChatWindowOptions = {}): ChatWindowRenderer =>
 	chatWindow(options);
 
 /**

--- a/apps/tuval/src/claude/window/claude-chat-window.unit.test.tsx
+++ b/apps/tuval/src/claude/window/claude-chat-window.unit.test.tsx
@@ -27,7 +27,7 @@ import {pageRenderers} from "../../page/renderers.tsx";
 const renderers = pageRenderers(() => Effect.never);
 
 import {ProcessId} from "../../process/process.ts";
-import type {ChatWindowOptions, ChatWindowRenderer} from "../../shell/chat/index.ts";
+import type {ChatWindowRenderer, ThinChatWindowOptions} from "../../shell/chat/index.ts";
 import {type ChatView, chatWindow, initialChatView} from "../../shell/chat/index.ts";
 import {installDomShims} from "../../shell/ui/dom.testing.ts";
 import {type TestProcess, testProcess} from "../../shell/window/fixtures.ts";
@@ -163,7 +163,7 @@ describe("what this binding adds to the shared window", () => {
 
 	/** One window of the given renderer, in its own container, over its own process. */
 	const mount = async (
-		make: (options: ChatWindowOptions) => ChatWindowRenderer,
+		make: (options: ThinChatWindowOptions) => ChatWindowRenderer,
 		state: AiAgentSessionState,
 	) => {
 		const process = await Effect.runPromise(
@@ -238,5 +238,16 @@ describe("what this binding adds to the shared window", () => {
 		// renders rather than about the order the two were mounted in.
 		const withoutIds = (root: HTMLElement) => root.innerHTML.replace(/_r_[0-9a-z]+_/g, "_id_");
 		expect(withoutIds(claude.rendered.container)).toEqual(withoutIds(shared.rendered.container));
+	});
+});
+
+describe("the options this binding admits", () => {
+	// The same claim the Pi binding's test holds: the parameter is `ThinChatWindowOptions`, so a
+	// caller's `extras` is a compile error rather than an argument the binding drops in silence
+	// (#7957).
+	it("refuses the `extras` the binding owns, and takes every other option", () => {
+		// @ts-expect-error `extras` is the binding's slot, not the caller's.
+		expect(claudeChatWindow({extras: () => null})).toBeDefined();
+		expect(claudeChatWindow({subagentList: false, pageLimit: 10, scrollCommitMs: 0})).toBeDefined();
 	});
 });

--- a/apps/tuval/src/page/renderers.tsx
+++ b/apps/tuval/src/page/renderers.tsx
@@ -42,7 +42,7 @@ import {CLAUDE_CHAT_WINDOW_REF, claudeChatWindow} from "../claude/window/index.t
 import {type CounterState, isCounterState} from "../demo/counter.ts";
 import {isLogState, type LogState} from "../demo/log.ts";
 import {PI_CHAT_WINDOW_REF, piChatWindow} from "../pi/window/index.ts";
-import type {ChatWindowOptions} from "../shell/chat/index.ts";
+import type {ThinChatWindowOptions} from "../shell/chat/index.ts";
 import type {AnyInspectorRenderer} from "../shell/desk/index.ts";
 import type {PageAttachment} from "../shell/transport/browser.ts";
 import type {WindowHost} from "../shell/window/index.ts";
@@ -178,7 +178,7 @@ const sessionListSource = (call: SpellCaller): SessionListSource => {
  * Nothing here reaches `../config.ts` at runtime: the flags arrive as generated source and the
  * shape arrives as a type (`./assets.d.ts`), so the page's Node-free walk is unaffected.
  */
-const chatOptions: ChatWindowOptions = {subagentList: features.subagentList};
+const chatOptions: ThinChatWindowOptions = {subagentList: features.subagentList};
 
 const claudeWindow = claudeChatWindow(chatOptions);
 const piWindow = piChatWindow(chatOptions);

--- a/apps/tuval/src/pi/window/PiChatWindow.tsx
+++ b/apps/tuval/src/pi/window/PiChatWindow.tsx
@@ -13,11 +13,14 @@
  * the name the row declares, and a page's table binds a renderer by that name.
  */
 
-import type {ChatWindowOptions, ChatWindowRenderer} from "../../shell/chat/index.ts";
+import type {ChatWindowRenderer, ThinChatWindowOptions} from "../../shell/chat/index.ts";
 import {chatWindow} from "../../shell/chat/index.ts";
 
-/** The Pi renderer at whatever window options a caller needs. */
-export const piChatWindow = (options: ChatWindowOptions = {}): ChatWindowRenderer =>
+/**
+ * The Pi renderer at whatever window options a caller needs — every option but `extras`, which
+ * `ThinChatWindowOptions` withholds because the binding owns that slot.
+ */
+export const piChatWindow = (options: ThinChatWindowOptions = {}): ChatWindowRenderer =>
 	chatWindow(options);
 
 /**

--- a/apps/tuval/src/pi/window/pi-chat-window.unit.test.tsx
+++ b/apps/tuval/src/pi/window/pi-chat-window.unit.test.tsx
@@ -104,3 +104,14 @@ describe("the window's scheme", () => {
 		);
 	});
 });
+
+describe("the options this binding admits", () => {
+	// A type claim, held by the typechecker rather than by this run: `@ts-expect-error` itself reds if
+	// the parameter ever widens back to the full `ChatWindowOptions`, which is the shape that dropped
+	// a caller's `extras` in silence (#7957).
+	it("refuses the `extras` the binding owns, and takes every other option", () => {
+		// @ts-expect-error `extras` is the binding's slot, not the caller's.
+		expect(piChatWindow({extras: () => null})).toBeDefined();
+		expect(piChatWindow({subagentList: false, pageLimit: 10, scrollCommitMs: 0})).toBeDefined();
+	});
+});

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -124,6 +124,14 @@ export interface ChatWindowOptions {
 	readonly scrollToFn?: VirtualizerOptions<HTMLDivElement, Element>["scrollToFn"];
 }
 
+/**
+ * What a thin binding's own caller may set: every window option except `extras`, which the binding
+ * owns. A binding exists to fill that slot (founder ruling 2026-09-02, amended on #7572 / #7584), so
+ * a caller reaching it through the binding would be asking for the shared window under the binding's
+ * name — and before this type that argument compiled, ran, and was dropped without a signal (#7957).
+ */
+export type ThinChatWindowOptions = Omit<ChatWindowOptions, "extras">;
+
 interface ResolvedOptions {
 	readonly extras: ((state: AiAgentSessionState) => ReactNode) | null;
 	readonly newKey: () => string;

--- a/apps/tuval/src/shell/chat/index.ts
+++ b/apps/tuval/src/shell/chat/index.ts
@@ -9,6 +9,7 @@ export {
 	type ChatWindowOptions,
 	type ChatWindowRenderer,
 	chatWindow,
+	type ThinChatWindowOptions,
 } from "./ChatWindow.tsx";
 export {type ComposerBridge, type ComposerHandlers, composerBridge} from "./composer-bridge.ts";
 export {tuvalDesignMessages, tuvalDesignTranslate} from "./copy.ts";


### PR DESCRIPTION
Both thin chat bindings took the full `ChatWindowOptions`, so `extras` — the one slot a binding
exists to own — was reachable through them. This narrows both parameters to a new
`ThinChatWindowOptions` (`Omit<ChatWindowOptions, "extras">`, exported from `shell/chat`), so a
caller passing `extras` to `claudeChatWindow` or `piChatWindow` is a compile error instead of an
argument that disappears.

The shared `chatWindow` still takes the full options — its `extras` slot is the one the bindings
fill. Every other field (`newKey`, `now`, `subagentList`, `pageLimit`, `overscan`,
`estimateRowHeight`, `topThreshold`, `bottomThreshold`, `scrollCommitMs`, `scrollToFn`) still
reaches it through both bindings, unchanged.

The type is declared once in `shell/chat` rather than written `Omit<...>` twice, because the issue's
own reason for pricing this now is that the hole propagates by copy: the next binding copied from
these two imports the right type instead of inheriting the wide one.

Each binding's unit test now holds the refusal at compile time with a `@ts-expect-error` on
`extras`. That directive reds if the parameter ever widens back, so the claim is the typechecker's
rather than this PR's prose.

Tests run in `apps/tuval`: `src/claude/window`, `src/pi/window`,
`src/shell/chat/chat-window.unit.test.tsx`, `src/shell/chat/boundary.unit.test.ts` — 8 files, 106
passing. `build check --surface code` (typecheck + lint) and `--surface prose` both green.

Fixes #7957

## Deviations

- **Scope narrowing** — **Said:** criterion 4 asks that the docblock paragraph arguing the override
  in prose be reduced to a pointer at the type. **Did:** there was no such paragraph left to reduce.
  **Why:** #8190 landed after the issue was filed and removed both bindings' `extras` overrides
  entirely, so their docblocks no longer argue one; each binding's one-line doc now points at
  `ThinChatWindowOptions` instead. **Disposition:** the criterion's intent is met — the type carries
  the refusal and the prose points at it.
- **Scope narrowing** — **Said:** the issue describes a live silent-drop, where a caller's `extras`
  is overwritten by the binding's own. **Did:** fixed the type, not a drop. **Why:** at `origin/main`
  neither binding overrides `extras` any more (#8190), so the argument was being forwarded rather
  than dropped. The invariant the issue exists to encode is still live and still unheld: the slot is
  the binding's, the type admitted a caller into it, and `ChatWindowOptions.extras` is explicitly
  kept rather than retired. **Disposition:** built as specified; the acceptance criteria are about
  the type, and all six are met.
- **Out-of-scope change** — **Said:** the issue names the two bindings, the shared window and the
  Claude binding's test. **Did:** also retyped `chatOptions` in `apps/tuval/src/page/renderers.tsx`
  and rewrote the extras half of the `.patterns/tuval-shell-assembly.md` bullet. **Why:**
  `chatOptions` feeds only these two bindings, so leaving it at the wide type would keep one live
  caller able to reach the slot. The pattern doc's bullet is where this shape is documented, and it
  still described Pi's usage line and Claude's session line as live extras — stale since #8190 — so
  stating the new type boundary beside a false claim was not an option. **Disposition:** stated
  here.
