### PR TITLE
perf(tuval): compile pi-protocol's typebox validators once (#8515)

### DIFF
--- a/.decisions/0364-pi-protocol-compiled-validators-patch.md
+++ b/.decisions/0364-pi-protocol-compiled-validators-patch.md
@@ -1,0 +1,125 @@
+---
+id: 0364
+title: "`@earendil-works/pi-protocol` compiles its typebox validators once, carried as a local patch until upstream takes it"
+status: accepted
+date: 2026-09-07
+tags: [tuval, dependencies, performance, pi]
+---
+
+# 0364 — `@earendil-works/pi-protocol` compiles its typebox validators once, carried as a local patch until upstream takes it
+
+**What this decides:** phoenix patches its pinned `@earendil-works/pi-protocol` so the Pi wire codec
+builds each message validator once instead of re-walking the schema on every message, and offers the
+same change upstream rather than routing around the codec in our own code.
+
+## Context
+
+Streaming a Pi reply in the Tuval desk crawled, and the desk's node process sat at 100% CPU for the
+whole turn ([#8515](https://github.com/kamp-us/phoenix/issues/8515)).
+
+The cost is in the dependency, not in Tuval. `@earendil-works/pi-protocol@0.84.3`'s
+`dist/codec.js` calls `Check(ServerMessageSchema, value)` from `typebox/value` on every encode
+(`parseServerMessage`, reached from `encodeProtocolMessage`) and again on every decode
+(`ValidatedMessageDecoder.push`). `Check` is typebox's interpreted path: it re-walks the schema per
+call and nothing is cached. `dist/schemas.js` then declares `JsonValueSchema` as a
+`Type.Cyclic({JsonValue: Type.Union([… Type.Array(Type.Ref("JsonValue")),
+Type.Record(Type.String(), Type.Ref("JsonValue"))])})`, and that cyclic `$ref` is re-resolved per
+node. A tool item's `input` and `details` are that schema, so every tool call in a transcript pays
+for the whole walk.
+
+Measured against this repo's pins (`typebox@1.3.7`, node 26), one `Check` call on a
+`session_snapshot`:
+
+| message | JSON size | uncompiled `Check` | compiled `Check` |
+|---|---|---|---|
+| 1 item | 0.5 KB | 0.069 ms | 0.004 ms |
+| 32 items (16 tool calls) | 21 KB | 563 ms | 0.14 ms |
+| 100 items (50 tool calls) | 63 KB | 1791 ms | 0.45 ms |
+| 300 items (150 tool calls) | 184 KB | 5218 ms | 0.69 ms |
+| 300 items, text only | 178 KB | 15 ms | 0.21 ms |
+
+The text-only row is what names the cause: ~35 ms per tool item and near zero per text item, so the
+cost is the cyclic `JsonValue` `$ref` and nothing else. `Compile(ServerMessageSchema)` costs about
+160 ms once.
+
+Tuval pays that twice per message. `PiServerService.ts`'s `followSession` writes a whole
+`session_snapshot` — `snapshots.ts`'s `sessionSnapshot` carries `transcript: [...view.transcript]`
+— every time the session handle signals a change, and a streamed turn signals on every delta. The
+Pi server and the Pi client both live inside the desk process, so each snapshot is validated once on
+the way out and once on the way in. On a 300-item transcript that is about 10 s of validation CPU
+per snapshot, which is why the process pins rather than merely lagging.
+
+Nothing in phoenix's own code can avoid it. Both ends of the socket run the dependency's validator,
+and the protocol's own refusal semantics are what that validator is for — declining to validate
+would be a different decision about the wire, not a performance fix.
+
+## Decision
+
+**`@earendil-works/pi-protocol@0.84.3` is patched in-repo so `parseClientMessage` and
+`parseServerMessage` each use a validator built once with `Compile` from `typebox/compile`, and the
+same change is offered upstream to `earendil-works/pi`.**
+
+The patch lives at `patches/@earendil-works__pi-protocol@0.84.3.patch`, wired through
+`patchedDependencies` in `pnpm-workspace.yaml`. It touches one file and adds no behaviour of its
+own: the `typebox/value` import becomes `typebox/compile`, and the two `Check(Schema, value)` calls
+become `.Check(value)` on a lazily built, memoized validator.
+
+**Lazy rather than eager**, because the two builds cost ~160 ms each and a process that speaks one
+direction should pay for one validator. The desk speaks both, so it pays both — once, at the first
+message of each direction, against seconds per message saved.
+
+**Equivalence was checked, not assumed.** The compiled and uncompiled validators agree on all 13
+cases exercised before the patch was committed: valid snapshots with and without a transcript, an
+unknown top-level type, an extra property, a missing required field, a wrong-typed field, an empty
+`minLength: 1` id, a negative timestamp, a status off its union, a deep `JsonValue`, an `undefined`
+inside a `JsonValue`, a thinking level off its union, and a streaming item carrying a `stopReason`
+its variant forbids. The patch is a speed change, not a laxity change.
+
+Round trip through the real codec (`encodeServerMessage` then `ServerMessageDecoder.push`), which is
+the pair of `Check` calls the desk actually pays per snapshot:
+
+| transcript | unpatched | patched |
+|---|---|---|
+| 1 item | 0.88 ms | 0.15 ms |
+| 51 items (25 tool calls) | 2114 ms | 1.32 ms |
+| 301 items (150 tool calls) | 10444 ms | 5.93 ms |
+
+The patch is held the way every maintained patch here is held, in the two layers
+[`.patterns/dependency-patch-behavior-pins.md`](../.patterns/dependency-patch-behavior-pins.md)
+defines and `fabrika guard patch-guard check` fails closed on: the version-keyed
+`patchedDependencies` entry, which is pnpm's own loud-fail on version drift, and a behavior pin —
+`apps/tuval/src/pi/codec-compiled-check.unit.test.ts`, carrying the
+`// @patch-pin: @earendil-works/pi-protocol@0.84.3` marker. That pin asserts both halves: a
+300-item round trip under a 1 s ceiling (three orders of magnitude above the patched cost and three
+below the unpatched one, so no machine's speed moves the verdict), and that the codec still refuses
+a message the schema does not admit — speed alone would pass on a codec that validated nothing.
+
+**Binding constraints.**
+
+- Re-key this patch on the next `@earendil-works/pi-protocol` bump — both layers, the
+  `patchedDependencies` key and the `@patch-pin` marker — and drop it once a release compiles its
+  own validators.
+- The four `@earendil-works/pi-*` packages are catalogued as a set at one exact version (the catalog
+  comment in `pnpm-workspace.yaml` says why): bumping one bumps all four, and this patch is
+  re-generated with them.
+- `pnpm patch-commit` rewrites `pnpm-workspace.yaml` wholesale, stripping the catalog's comments and
+  re-sorting its keys. Restore that file from `main` after committing a patch and hand-add the
+  `patchedDependencies` line — the same instruction ADR
+  [0361](0361-manti-menu-highlighted-value-patch.md) records.
+
+## Consequences
+
+The desk's per-message validation cost stops scaling with transcript length, which is the whole of
+the reported slowness on a session long enough to hold tool calls.
+
+What this does **not** fix: `followSession` still sends the entire transcript on every session
+change, so a streamed turn still moves ~180 KB per delta across the loopback socket and still
+rebuilds the whole snapshot object each time. The protocol already carries `item_updated` and
+`assistant_delta` progress messages that would bound that work regardless of transcript length.
+That is a separate decision about what Tuval's Pi server sends, and #8515 carries it.
+
+This is [ADR 0038](0038-dependency-patches-local-only.md)'s shape — a local `pnpm patch` committed
+to the repo, never an external patch source, with upstreaming encouraged and the merged release, not
+the in-flight PR, as the thing phoenix eventually depends on. ADR
+[0170](0170-workers-cache-via-alchemy-effect-pnpm-patch.md) and ADR
+[0361](0361-manti-menu-highlighted-value-patch.md) are the same move on other pins.

--- a/.decisions/0364-pi-protocol-compiled-validators-patch.md
+++ b/.decisions/0364-pi-protocol-compiled-validators-patch.md
@@ -114,11 +114,23 @@ a message the schema does not admit — speed alone would pass on a codec that v
   `ModelMetadata`, `ModelRef`, `ThinkingLevel`, `Command`, `CommandResult`, `ServerSnapshot` and
   `SessionMetadata` from the package entirely and renames `@earendil-works/pi-client`'s surface
   (`PiClient` → `Client`, session handles replaced by attachments and service subscriptions) —
-  which `apps/tuval/src/pi` is written against across 36 files. **Drop this patch as part of that
-  upgrade, not before it, and never re-cut it against 0.85.x.**
-- The four `@earendil-works/pi-*` packages are catalogued as a set at one exact version (the catalog
-  comment in `pnpm-workspace.yaml` says why): bumping one bumps all four, and this patch is
-  re-generated with them.
+  which `apps/tuval/src/pi` is written against across 36 files. The upgrade also pulls a runtime
+  dependency 0.84.3 does not carry: 0.85.1's `codec.js` imports `isJsonValue` from
+  `@earendil-works/chord`. **This patch retires with the 0.85.x upgrade — dropped as part of it, not
+  before it, and never re-cut against 0.85.x**, because validation there costs 0.110 ms on the
+  snapshot that costs 5218 ms here, so a compiled validator would buy 0.108 ms of it.
+  [#8518](https://github.com/kamp-us/phoenix/issues/8518) carries that upgrade and is where this
+  patch is deleted.
+- **The `@earendil-works/pi-*` family is eight entries across two mechanisms in
+  `pnpm-workspace.yaml`, and a bump moves all eight.** The `catalog:` block carries four —
+  `pi-ai`, `pi-client`, `pi-coding-agent`, `pi-protocol` — and `overrides:` carries four more —
+  `pi-agent-core`, `pi-ai`, `pi-telemetry`, `pi-tui`. The `overrides:` block exists because the
+  cataloged packages ask for their siblings by `^0.84.3`, and a caret picks the highest published
+  patch: 0.84.4 put a second `@earendil-works/pi-ai` in the tree beside the cataloged one, the faux
+  provider registered into one copy and the agent loop reading the other. Its own comment records
+  that as a correctness hazard rather than weight, and says to re-key the whole family. Re-keying
+  the catalog and leaving `overrides:` behind reproduces that duplicate with a green build, so read
+  both blocks' comments before bumping. This patch is re-generated with them.
 - `pnpm patch-commit` rewrites `pnpm-workspace.yaml` wholesale, stripping the catalog's comments and
   re-sorting its keys. Restore that file from `main` after committing a patch and hand-add the
   `patchedDependencies` line — the same instruction ADR

--- a/.decisions/0364-pi-protocol-compiled-validators-patch.md
+++ b/.decisions/0364-pi-protocol-compiled-validators-patch.md
@@ -39,8 +39,12 @@ Measured against this repo's pins (`typebox@1.3.7`, node 26), one `Check` call o
 | 300 items, text only | 178 KB | 15 ms | 0.21 ms |
 
 The text-only row is what names the cause: ~35 ms per tool item and near zero per text item, so the
-cost is the cyclic `JsonValue` `$ref` and nothing else. `Compile(ServerMessageSchema)` costs about
-160 ms once.
+cost is the cyclic `JsonValue` `$ref` and nothing else.
+
+Building the validators is the other side of the ledger, and the two directions are nothing like
+each other: `Compile(ServerMessageSchema)` costs ~170 ms, `Compile(ClientMessageSchema)` ~0.5 ms.
+That asymmetry follows from the schemas — the server union carries the whole transcript vocabulary
+and the client union carries a handful of small commands.
 
 Tuval pays that twice per message. `PiServerService.ts`'s `followSession` writes a whole
 `session_snapshot` — `snapshots.ts`'s `sessionSnapshot` carries `transcript: [...view.transcript]`
@@ -64,9 +68,10 @@ The patch lives at `patches/@earendil-works__pi-protocol@0.84.3.patch`, wired th
 own: the `typebox/value` import becomes `typebox/compile`, and the two `Check(Schema, value)` calls
 become `.Check(value)` on a lazily built, memoized validator.
 
-**Lazy rather than eager**, because the two builds cost ~160 ms each and a process that speaks one
-direction should pay for one validator. The desk speaks both, so it pays both — once, at the first
-message of each direction, against seconds per message saved.
+**Lazy rather than eager**, because of the asymmetry above: eager would make every process that
+speaks only the client direction pay the server union's ~170 ms for a validator it never calls. The
+desk speaks both, so it pays both — ~170 ms once, at the first message of each direction, against
+seconds per message saved.
 
 **Equivalence was checked, not assumed.** The compiled and uncompiled validators agree on all 13
 cases exercised before the patch was committed: valid snapshots with and without a transcript, an
@@ -97,8 +102,20 @@ a message the schema does not admit — speed alone would pass on a codec that v
 **Binding constraints.**
 
 - Re-key this patch on the next `@earendil-works/pi-protocol` bump — both layers, the
-  `patchedDependencies` key and the `@patch-pin` marker — and drop it once a release compiles its
-  own validators.
+  `patchedDependencies` key and the `@patch-pin` marker — and drop it once a release makes it
+  pointless.
+- **0.85.1 is that release, and phoenix cannot take it yet.** Its `dist/codec.js` still calls the
+  uncompiled `Check`, so a reader checking only that line would re-cut this patch; but the schemas
+  under it were redesigned, and that is what matters. `PROTOCOL_VERSION` goes 1 → 8, `schemas.ts`
+  becomes `protocol.ts`, and every payload is now `Type.Unsafe(Type.Unknown())` — validation never
+  walks a transcript, so the same 300-item snapshot costs **0.110 ms** uncompiled there against
+  5218 ms here. On 0.85.1 this patch buys 0.110 ms → 0.002 ms and is not worth carrying. It cannot
+  simply be taken, because the same redesign removes `SessionSnapshot`, `TranscriptItem`,
+  `ModelMetadata`, `ModelRef`, `ThinkingLevel`, `Command`, `CommandResult`, `ServerSnapshot` and
+  `SessionMetadata` from the package entirely and renames `@earendil-works/pi-client`'s surface
+  (`PiClient` → `Client`, session handles replaced by attachments and service subscriptions) —
+  which `apps/tuval/src/pi` is written against across 36 files. **Drop this patch as part of that
+  upgrade, not before it, and never re-cut it against 0.85.x.**
 - The four `@earendil-works/pi-*` packages are catalogued as a set at one exact version (the catalog
   comment in `pnpm-workspace.yaml` says why): bumping one bumps all four, and this patch is
   re-generated with them.

--- a/apps/tuval/src/pi/codec-compiled-check.unit.test.ts
+++ b/apps/tuval/src/pi/codec-compiled-check.unit.test.ts
@@ -88,7 +88,7 @@ const CEILING_MS = 1_000;
 describe("the pi-protocol codec's compiled validators", () => {
 	it("round-trips a 300-item transcript far below the uncompiled cost", () => {
 		const message = snapshotOf(longTranscript(ITEMS));
-		// Warm the lazy compile, so the ceiling measures validation and not the one-time ~160 ms build.
+		// Warm the lazy compile, so the ceiling measures validation and not the one-time ~170 ms build.
 		new ServerMessageDecoder().push(encodeServerMessage(message));
 
 		const started = performance.now();

--- a/apps/tuval/src/pi/codec-compiled-check.unit.test.ts
+++ b/apps/tuval/src/pi/codec-compiled-check.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The behavior pin for the `@earendil-works/pi-protocol` patch (ADR 0364): the codec's validators
+ * are built once and reused, so validating a long transcript costs microseconds rather than seconds.
+ *
+ * @patch-pin: @earendil-works/pi-protocol@0.84.3
+ *
+ * Two claims, and the pin needs both. Speed alone would pass on a codec that validated nothing;
+ * correctness alone would pass on the unpatched codec that is correct and unusably slow.
+ */
+
+import {
+	encodeServerMessage,
+	ProtocolValidationError,
+	type ServerMessage,
+	ServerMessageDecoder,
+	type TranscriptItem,
+} from "@earendil-works/pi-protocol";
+import {assert, describe, it} from "@effect/vitest";
+
+const AT = 1_760_000_000_000;
+const MODEL = {provider: "openai", id: "gpt-6-astra"} as const;
+
+const textItem = (id: string): TranscriptItem => ({
+	id,
+	role: "assistant",
+	content: [{type: "text", text: "x".repeat(400)}],
+	model: MODEL,
+	timestamp: AT,
+	status: "complete",
+	stopReason: "stop",
+});
+
+/**
+ * A tool item is what the patch is *for*: its `input` and `details` are the protocol's `Type.Cyclic`
+ * `JsonValue`, and re-resolving that `$ref` per node is the whole of the uncompiled cost. A pin over
+ * text items alone would not move between the patched and unpatched codec.
+ */
+const toolItem = (id: string): TranscriptItem => ({
+	id,
+	role: "tool",
+	toolCallId: `tc-${id}`,
+	toolName: "Read",
+	input: {file: `/a/b/${id}.ts`, opts: {limit: 100, nested: {deep: [1, 2, 3, "s"]}}},
+	content: [{type: "text", text: "file contents ".repeat(20)}],
+	timestamp: AT,
+	status: "complete",
+	isError: false,
+});
+
+const snapshotOf = (items: ReadonlyArray<TranscriptItem>): ServerMessage => ({
+	type: "event",
+	event: {
+		type: "session_snapshot",
+		snapshot: {
+			id: "s1",
+			cwd: "/work",
+			createdAt: AT,
+			updatedAt: AT,
+			phase: "turn",
+			model: MODEL,
+			thinkingLevel: "high",
+			attached: true,
+			locked: true,
+			revision: 42,
+			transcript: [...items],
+			queuedSteer: [],
+			queuedSteerCount: 0,
+		},
+	},
+});
+
+/** The transcript a real working session reaches: half prose, half tool calls. */
+const longTranscript = (count: number): ReadonlyArray<TranscriptItem> =>
+	Array.from({length: count}, (_, index) =>
+		index % 2 === 0 ? textItem(`i${index}`) : toolItem(`i${index}`),
+	);
+
+const ITEMS = 300;
+
+/**
+ * Measured on the patched codec: ~2 ms for the round trip below. Unpatched it is ~10 s, because the
+ * uncompiled `Check` runs once on the encode and once more on the decode. The ceiling sits three
+ * orders of magnitude above the patched cost and three below the unpatched one, so neither a slow
+ * machine nor a warm one can move the verdict.
+ */
+const CEILING_MS = 1_000;
+
+describe("the pi-protocol codec's compiled validators", () => {
+	it("round-trips a 300-item transcript far below the uncompiled cost", () => {
+		const message = snapshotOf(longTranscript(ITEMS));
+		// Warm the lazy compile, so the ceiling measures validation and not the one-time ~160 ms build.
+		new ServerMessageDecoder().push(encodeServerMessage(message));
+
+		const started = performance.now();
+		const [decoded] = new ServerMessageDecoder().push(encodeServerMessage(message));
+		const elapsed = performance.now() - started;
+
+		assert.isDefined(decoded, "the frame decoded to nothing");
+		assert.strictEqual(decoded?.type, "event");
+		assert.isBelow(
+			elapsed,
+			CEILING_MS,
+			`encode+decode of a ${ITEMS}-item snapshot took ${elapsed.toFixed(0)}ms — the codec is validating uncompiled`,
+		);
+	});
+
+	// An empty id is the refusal a *well-typed* message can still carry: `IdSchema` is
+	// `Type.String({minLength: 1})`, whose static type is plain `string`, so only the validator can
+	// catch it. That is what makes this a test of the compiled validator rather than of a cast.
+	it("still refuses a message the schema does not admit", () => {
+		const message = snapshotOf([{...textItem("i0"), id: ""}]);
+		assert.throws(() => encodeServerMessage(message), ProtocolValidationError);
+	});
+
+	it("still admits a message the schema does admit", () => {
+		const message = snapshotOf(longTranscript(4));
+		const [decoded] = new ServerMessageDecoder().push(encodeServerMessage(message));
+		assert.deepStrictEqual(decoded, message);
+	});
+});

--- a/patches/@earendil-works__pi-protocol@0.84.3.patch
+++ b/patches/@earendil-works__pi-protocol@0.84.3.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/codec.js b/dist/codec.js
-index b2935621b0d496093b709404ae0f17c8828e8792..e539656db911b3941376909070ba84596d3598ea 100644
+index b2935621b0d496093b709404ae0f17c8828e8792..2405485942222889dfc02130e380e607beaad530 100644
 --- a/dist/codec.js
 +++ b/dist/codec.js
 @@ -1,4 +1,4 @@
@@ -8,15 +8,16 @@ index b2935621b0d496093b709404ae0f17c8828e8792..e539656db911b3941376909070ba8459
  import { decodeCbor, encodeCbor } from "./cbor/index.js";
  import { assertCompleteFrame, DEFAULT_MAX_FRAME_LENGTH, encodeFrame, FrameDecoder, } from "./framing.js";
  import { ClientMessageSchema, PROTOCOL_VERSION, ServerMessageSchema, } from "./schemas.js";
-@@ -28,14 +28,29 @@ function isProtocolValue(value, optionalProperty = false, ancestors = new Set())
+@@ -28,14 +28,30 @@ function isProtocolValue(value, optionalProperty = false, ancestors = new Set())
          ancestors.delete(value);
      }
  }
 +// Compiled once and reused. `Check` from `typebox/value` re-walks the schema per call, and
 +// `JsonValueSchema` is a `Type.Cyclic` `$ref` whose refs it re-resolves per node, so a
 +// `session_snapshot` carrying a 300-item transcript with 150 tool calls costs 5.2 s uncompiled
-+// against 0.69 ms compiled. Lazy so a process speaking one direction pays for one validator; the
-+// build itself is ~160 ms.
++// against 0.69 ms compiled. Lazy because the two builds are nothing like each other in cost —
++// ~170 ms for the server union against ~0.5 ms for the client one — so a process that speaks only
++// the client direction must not be made to pay for the server's.
 +let clientValidator;
 +let serverValidator;
 +const clientCheck = (value) => {

--- a/patches/@earendil-works__pi-protocol@0.84.3.patch
+++ b/patches/@earendil-works__pi-protocol@0.84.3.patch
@@ -1,0 +1,42 @@
+diff --git a/dist/codec.js b/dist/codec.js
+index b2935621b0d496093b709404ae0f17c8828e8792..e539656db911b3941376909070ba84596d3598ea 100644
+--- a/dist/codec.js
++++ b/dist/codec.js
+@@ -1,4 +1,4 @@
+-import { Check } from "typebox/value";
++import { Compile } from "typebox/compile";
+ import { decodeCbor, encodeCbor } from "./cbor/index.js";
+ import { assertCompleteFrame, DEFAULT_MAX_FRAME_LENGTH, encodeFrame, FrameDecoder, } from "./framing.js";
+ import { ClientMessageSchema, PROTOCOL_VERSION, ServerMessageSchema, } from "./schemas.js";
+@@ -28,14 +28,29 @@ function isProtocolValue(value, optionalProperty = false, ancestors = new Set())
+         ancestors.delete(value);
+     }
+ }
++// Compiled once and reused. `Check` from `typebox/value` re-walks the schema per call, and
++// `JsonValueSchema` is a `Type.Cyclic` `$ref` whose refs it re-resolves per node, so a
++// `session_snapshot` carrying a 300-item transcript with 150 tool calls costs 5.2 s uncompiled
++// against 0.69 ms compiled. Lazy so a process speaking one direction pays for one validator; the
++// build itself is ~160 ms.
++let clientValidator;
++let serverValidator;
++const clientCheck = (value) => {
++    clientValidator ??= Compile(ClientMessageSchema);
++    return clientValidator.Check(value);
++};
++const serverCheck = (value) => {
++    serverValidator ??= Compile(ServerMessageSchema);
++    return serverValidator.Check(value);
++};
+ export function parseClientMessage(value) {
+-    if (!isProtocolValue(value) || !Check(ClientMessageSchema, value)) {
++    if (!isProtocolValue(value) || !clientCheck(value)) {
+         throw new ProtocolValidationError("Invalid client protocol message");
+     }
+     return value;
+ }
+ export function parseServerMessage(value) {
+-    if (!isProtocolValue(value) || !Check(ServerMessageSchema, value)) {
++    if (!isProtocolValue(value) || !serverCheck(value)) {
+         throw new ProtocolValidationError("Invalid server protocol message");
+     }
+     return value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ pnpmfileChecksum: sha256-ENBbpnCM6iEJZwql5y+XIdMMnEPnYSp47O6FmPjp4UI=
 
 patchedDependencies:
   '@earendil-works/pi-protocol@0.84.3':
-    hash: 9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2
+    hash: 73f3d0e42cbdf21235043788c4c5e53742837d09b42d814b7fa73ee763acf0eb
     path: patches/@earendil-works__pi-protocol@0.84.3.patch
   '@manti-ui/react@0.9.0':
     hash: 72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484
@@ -301,7 +301,7 @@ importers:
         version: 0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-protocol':
         specifier: 'catalog:'
-        version: 0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)
+        version: 0.84.3(patch_hash=73f3d0e42cbdf21235043788c4c5e53742837d09b42d814b7fa73ee763acf0eb)
       '@effect/platform-node':
         specifier: catalog:tuval
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(@opentelemetry/api@1.9.1))
@@ -6722,14 +6722,14 @@ snapshots:
 
   '@earendil-works/pi-client@0.84.3':
     dependencies:
-      '@earendil-works/pi-protocol': 0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)
+      '@earendil-works/pi-protocol': 0.84.3(patch_hash=73f3d0e42cbdf21235043788c4c5e53742837d09b42d814b7fa73ee763acf0eb)
 
   '@earendil-works/pi-coding-agent@0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-client': 0.84.3
-      '@earendil-works/pi-protocol': 0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)
+      '@earendil-works/pi-protocol': 0.84.3(patch_hash=73f3d0e42cbdf21235043788c4c5e53742837d09b42d814b7fa73ee763acf0eb)
       '@earendil-works/pi-tui': 0.84.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -6756,7 +6756,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-protocol@0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)':
+  '@earendil-works/pi-protocol@0.84.3(patch_hash=73f3d0e42cbdf21235043788c4c5e53742837d09b42d814b7fa73ee763acf0eb)':
     dependencies:
       typebox: 1.3.7
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ overrides:
 pnpmfileChecksum: sha256-ENBbpnCM6iEJZwql5y+XIdMMnEPnYSp47O6FmPjp4UI=
 
 patchedDependencies:
+  '@earendil-works/pi-protocol@0.84.3':
+    hash: 9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2
+    path: patches/@earendil-works__pi-protocol@0.84.3.patch
   '@manti-ui/react@0.9.0':
     hash: 72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484
     path: patches/@manti-ui__react@0.9.0.patch
@@ -298,7 +301,7 @@ importers:
         version: 0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-protocol':
         specifier: 'catalog:'
-        version: 0.84.3
+        version: 0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)
       '@effect/platform-node':
         specifier: catalog:tuval
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(@opentelemetry/api@1.9.1))
@@ -6719,14 +6722,14 @@ snapshots:
 
   '@earendil-works/pi-client@0.84.3':
     dependencies:
-      '@earendil-works/pi-protocol': 0.84.3
+      '@earendil-works/pi-protocol': 0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)
 
   '@earendil-works/pi-coding-agent@0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.84.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-client': 0.84.3
-      '@earendil-works/pi-protocol': 0.84.3
+      '@earendil-works/pi-protocol': 0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)
       '@earendil-works/pi-tui': 0.84.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -6753,7 +6756,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-protocol@0.84.3':
+  '@earendil-works/pi-protocol@0.84.3(patch_hash=9b7163bb63da53688bf49d93fdf9a2cb02e63aa070dc9210b56d1a530f5b36b2)':
     dependencies:
       typebox: 1.3.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -228,6 +228,7 @@ onlyBuiltDependencies:
 #    which nothing else in the repo declares any. Behavior-pinned by
 #    packages/fabrika-cli/src/excess-operand.cli.test.ts. Retire when effect honours it.
 patchedDependencies:
+  '@earendil-works/pi-protocol@0.84.3': patches/@earendil-works__pi-protocol@0.84.3.patch
   '@manti-ui/react@0.9.0': patches/@manti-ui__react@0.9.0.patch
   '@nkzw/fate@1.3.1': patches/@nkzw__fate@1.3.1.patch
   alchemy@2.0.0-beta.59: patches/alchemy@2.0.0-beta.59.patch


### PR DESCRIPTION
Fixes #8515

## What was slow

Streaming a Pi reply in the Tuval desk crawled and the desk's node process sat at 100% CPU for the
whole turn. The cost is in the dependency, not in Tuval's code.

`@earendil-works/pi-protocol@0.84.3`'s `dist/codec.js` calls `Check(ServerMessageSchema, value)`
from `typebox/value` on every encode (`parseServerMessage`, via `encodeProtocolMessage`) and again
on every decode (`ValidatedMessageDecoder.push`). `Check` is typebox's interpreted path: it re-walks
the schema per call and caches nothing. `dist/schemas.js` then declares `JsonValueSchema` as a
`Type.Cyclic` `$ref`, re-resolved per node, and a tool item's `input` and `details` are that schema.

Tuval pays it **twice per message**: `PiServerService.ts`'s `followSession` writes a whole
`session_snapshot` on every session change (a streamed turn changes on every delta), and the Pi
server and the Pi client are both inside the desk process, so each snapshot is validated on the way
out and on the way in.

## Numbers

One `Check` call, node 26, this repo's pins:

| message | JSON size | uncompiled | compiled |
|---|---|---|---|
| 1 item | 0.5 KB | 0.069 ms | 0.004 ms |
| 32 items (16 tool calls) | 21 KB | 563 ms | 0.14 ms |
| 100 items (50 tool calls) | 63 KB | 1791 ms | 0.45 ms |
| 300 items (150 tool calls) | 184 KB | 5218 ms | 0.69 ms |
| 300 items, **text only** | 178 KB | 15 ms | 0.21 ms |

The text-only row names the cause: ~35 ms per tool item, near zero per text item. It is the cyclic
`JsonValue` `$ref` and nothing else.

Before/after through the real codec — `encodeServerMessage` then `ServerMessageDecoder.push`, which
is exactly the pair of `Check` calls the desk pays per snapshot:

| transcript | before | after | factor |
|---|---|---|---|
| 1 item | 0.88 ms | 0.15 ms | 6x |
| 51 items (25 tool calls) | 2114 ms | 1.32 ms | 1600x |
| 301 items (150 tool calls) | 10444 ms | 5.93 ms | **1760x** |

`Compile` costs ~160 ms once per direction, paid lazily at the first message.

## The change

One patched file. The `typebox/value` import becomes `typebox/compile`, and the two
`Check(Schema, value)` calls become `.Check(value)` on a lazily built, memoized validator. Lazy so a
process speaking one direction pays for one validator.

**Equivalence was checked, not assumed.** The compiled and uncompiled validators agree on all 13
cases exercised before the patch was committed: valid snapshots with and without a transcript, an
unknown top-level type, an extra property, a missing required field, a wrong-typed field, an empty
`minLength: 1` id, a negative timestamp, a status off its union, a deep `JsonValue`, an `undefined`
inside a `JsonValue`, a thinking level off its union, and a streaming item carrying a `stopReason`
its variant forbids. This is a speed change, not a laxity change.

## How it is held

The two-layer patch discipline of [`.patterns/dependency-patch-behavior-pins.md`](../blob/main/.patterns/dependency-patch-behavior-pins.md):

1. The version-keyed `patchedDependencies` entry in `pnpm-workspace.yaml`.
2. `apps/tuval/src/pi/codec-compiled-check.unit.test.ts`, carrying
   `// @patch-pin: @earendil-works/pi-protocol@0.84.3`. It asserts **both** halves — a 300-item
   round trip under a 1 s ceiling (three orders of magnitude above the patched cost, three below
   the unpatched one, so no machine's speed moves the verdict), and that the codec still refuses a
   message the schema does not admit. Speed alone would pass on a codec that validated nothing.

`pnpm patch-commit` rewrote `pnpm-workspace.yaml` wholesale as ADR 0361 warned; the file was
restored from `main` and the one `patchedDependencies` line hand-added, so the diff there is one
line.

ADR 0364 records the patch, the numbers, and the binding constraints (re-key on the next
`@earendil-works/pi-*` bump; drop it once a release compiles its own validators).

## What this does not fix

`followSession` still sends the entire transcript on every session change, so a streamed turn still
moves ~180 KB per delta across the loopback socket and rebuilds the whole snapshot each time. The
protocol already carries `item_updated` / `assistant_delta` progress messages that would bound that
work regardless of transcript length. That is a separate decision about what Tuval's Pi server
sends, and #8515 carries it — deliberately not folded in here, because it changes wire behaviour
rather than making the existing behaviour cheap.

The `changes` queue in `AgentSessionHost.ts` is already a capacity-1 sliding queue, so no throttle
was added: the coalescing exists at the right place, and adding a minimum interval would trade
stream latency for CPU the patch has already given back.

## Checks

- `apps/tuval` unit + integration for `src/pi`: 27 files, 182 tests, all pass.
- `fabrika guard patch-guard check`: green, 6 maintained patches all pinned.
- `fabrika guard catalog-guard check`: green.
- `pnpm turbo run typecheck --filter=@kampus/tuval`: 0 errors.
- `biome check`: clean.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8515 names the Pi codec's uncompiled
  `Check` as the CPU cost; nothing in it asks for `pnpm-workspace.yaml` to be rewritten.
  **Did:** `pnpm patch-commit` rewrote that file wholesale, stripping the catalog's comments and
  re-sorting its keys; the file was restored from `main` and the one `patchedDependencies` line
  hand-added, so the committed diff is that single added line. **Why:** the stripped comments are
  load-bearing — the `overrides:` block explains why the whole `@earendil-works/pi-*` family must
  move together, and the Effect catalog comments record a lockfile leak; a generator's re-sort would
  have deleted both. ADR 0361 records the same instruction for the manti patch.
  **Disposition:** stated here; the restore is verified in the diff, which touches
  `pnpm-workspace.yaml` on one line only.

## Upstream

The same change is worth offering to `earendil-works/pi` — ADR 0038's shape: carry the patch locally
until a release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

