### PR TITLE
fix: process send reports delivered when a sliding in-port evicted an older message

### DIFF
--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -993,7 +993,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 										payload: {text: CHILD_PROMPT, key: "child-1", timestamp: Date.now()},
 									}),
 								),
-							) as {readonly delivered: boolean};
+							) as {readonly delivered: boolean; readonly evicted: number};
 
 							// `read` answers the port's current value, so it is polled rather than waited on:
 							// the transcript is published before the prompt lands and again after the reply.
@@ -1018,11 +1018,15 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 								);
 							});
 
-							return {child, claudeId: opened.processId, delivered: sent.delivered, transcript};
+							return {child, claudeId: opened.processId, sent, transcript};
 						}),
 					);
 					noLiveHttp(calls);
-					assert.isTrue(result.delivered, "the child's prompt port refused the payload");
+					assert.deepStrictEqual(
+						result.sent,
+						{delivered: true, evicted: 0},
+						"the child's prompt port refused the payload or dropped an earlier one",
+					);
 					assert.strictEqual(result.child.programId, CHILD_PROGRAM);
 					assert.strictEqual(
 						result.child.parentId._tag === "Some" ? result.child.parentId.value : null,

--- a/apps/tuval/src/claude/tools/KernelBridge.ts
+++ b/apps/tuval/src/claude/tools/KernelBridge.ts
@@ -43,7 +43,12 @@ const KERNEL_TAGS = {
 } as const;
 
 const Spawned = Schema.Struct({process: ProcessId});
-const Sent = Schema.Struct({delivered: Schema.Boolean});
+const Sent = Schema.Struct({delivered: Schema.Boolean, evicted: Schema.Number});
+/**
+ * The `send` reply as this side reads it: `delivered` is whether the payload landed, `evicted` how
+ * many queued payloads a `sliding` in-port took off to make room for it (#7971).
+ */
+export type Sent = typeof Sent.Type;
 const Read = Schema.Union([
 	Schema.Struct({empty: Schema.Literal(true)}),
 	Schema.Struct({empty: Schema.Literal(false), value: Schema.Unknown}),
@@ -75,7 +80,7 @@ export class KernelBridge extends Context.Service<
 			process: ProcessId,
 			port: string,
 			payload: unknown,
-		) => Effect.Effect<boolean, UnknownProcess | UnknownPort | PortRefused>;
+		) => Effect.Effect<Sent, UnknownProcess | UnknownPort | PortRefused>;
 		readonly read: (
 			process: ProcessId,
 			port: string,
@@ -147,8 +152,7 @@ const make = Effect.fn("Tuval.KernelBridge.make")(function* (scope: Scope) {
 			failure.tag === KERNEL_TAGS.portRefused
 				? Effect.fail(new PortRefused({process, port, detail: failure.message}))
 				: liftPortFailure(SEND, process, port, "in", failure);
-		const answer = yield* call(SEND, {process, port, payload}, Sent, lift);
-		return answer.delivered;
+		return yield* call(SEND, {process, port, payload}, Sent, lift);
 	});
 
 	const read = Effect.fn("Tuval.KernelBridge.read")(function* (process: ProcessId, port: string) {
@@ -232,7 +236,7 @@ const buildScripted = (table: ScriptedKernel): KernelBridge["Service"] => {
 				detail: `port "${port}" takes ${declared.kind} and refused the payload`,
 			});
 		}
-		return true;
+		return {delivered: true, evicted: 0};
 	});
 
 	const read = Effect.fn("Tuval.KernelBridge.scripted.read")(function* (

--- a/apps/tuval/src/claude/tools/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/tools/boundary.unit.test.ts
@@ -12,7 +12,7 @@ import {describe, expect, expectTypeOf, it} from "vitest";
 import type {ProcessId} from "../../process/process.ts";
 import type {ProgramId} from "../../registry/program.ts";
 import type {PortRefused, UnknownPort, UnknownProcess, UnknownProgram} from "./errors.ts";
-import type {KernelBridge} from "./KernelBridge.ts";
+import type {KernelBridge, Sent} from "./KernelBridge.ts";
 
 type Service = KernelBridge["Service"];
 
@@ -35,7 +35,7 @@ describe("claude tools boundary", () => {
 				process: ProcessId,
 				port: string,
 				payload: unknown,
-			) => Effect.Effect<boolean, UnknownProcess | UnknownPort | PortRefused>
+			) => Effect.Effect<Sent, UnknownProcess | UnknownPort | PortRefused>
 		>();
 		expectTypeOf<Service["read"]>().toEqualTypeOf<
 			(

--- a/apps/tuval/src/claude/tools/bridge.unit.test.ts
+++ b/apps/tuval/src/claude/tools/bridge.unit.test.ts
@@ -194,11 +194,11 @@ describe("KernelBridge over the real kernel", () => {
 				Effect.gen(function* () {
 					const bridge = yield* KernelBridge;
 					const child = yield* bridge.spawn(echoId);
-					const delivered = yield* bridge.send(child, "words", "hi");
-					return {delivered, heard: yield* bridge.read(child, "echoed")};
+					const sent = yield* bridge.send(child, "words", "hi");
+					return {sent, heard: yield* bridge.read(child, "echoed")};
 				}),
 			);
-			assert.isTrue(answer.delivered);
+			assert.deepStrictEqual(answer.sent, {delivered: true, evicted: 0});
 			assert.deepStrictEqual(answer.heard, Option.some("HI"));
 		}),
 	);

--- a/apps/tuval/src/claude/tools/server.ts
+++ b/apps/tuval/src/claude/tools/server.ts
@@ -72,7 +72,7 @@ const KERNEL =
 	"Tuval's kernel is a registry of programs and a table of running processes; a process has typed ports, an in-port you write to and an out-port you read from.";
 
 const SPAWN_DESCRIPTION = `Start a new process of a program the registry knows, as a child of your own process. ${KERNEL} Answers with the new process's id.`;
-const SEND_DESCRIPTION = `Write one payload to a named in-port of a process you spawned. ${KERNEL} The port decides what it takes, and a payload it refuses is an error naming what the port takes. A port whose protocol runs both ways takes one direction per end, so a reply written to the end that takes requests is refused here rather than delivered.`;
+const SEND_DESCRIPTION = `Write one payload to a named in-port of a process you spawned. ${KERNEL} The port decides what it takes, and a payload it refuses is an error naming what the port takes. A port whose protocol runs both ways takes one direction per end, so a reply written to the end that takes requests is refused here rather than delivered. The reply also carries \`evicted\`: how many queued payloads the port discarded unread to make room for this one, which is non-zero only on a port that keeps the latest rather than blocking.`;
 const READ_DESCRIPTION = `Read the current value of a named out-port of a process you spawned. ${KERNEL} A port that has said nothing yet answers empty rather than making you wait.`;
 
 const text = (value: unknown): CallToolResult => ({
@@ -105,8 +105,8 @@ export const tuvalToolServer = (
 		spawn: (args: {readonly program: string}) =>
 			answer(run, bridge.spawn(ProgramId.make(args.program)), (process) => text({process})),
 		send: (args: {readonly process: string; readonly port: string; readonly payload: unknown}) =>
-			answer(run, bridge.send(ProcessId.make(args.process), args.port, args.payload), (delivered) =>
-				text({delivered}),
+			answer(run, bridge.send(ProcessId.make(args.process), args.port, args.payload), (sent) =>
+				text(sent),
 			),
 		read: (args: {readonly process: string; readonly port: string}) =>
 			answer(run, bridge.read(ProcessId.make(args.process), args.port), (held) =>

--- a/apps/tuval/src/claude/tools/server.unit.test.ts
+++ b/apps/tuval/src/claude/tools/server.unit.test.ts
@@ -122,7 +122,7 @@ describe("the tuval tool server", () => {
 				}),
 			);
 			assert.isNotTrue(sent.isError);
-			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true});
+			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true, evicted: 0});
 
 			const held = yield* answered(() =>
 				tools.handlers.read({process: scriptedProcess, port: "echoed"}),
@@ -239,7 +239,7 @@ describe("send, on the AI agent's prompt port", () => {
 				}),
 			);
 			assert.isNotTrue(sent.isError);
-			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true});
+			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true, evicted: 0});
 		}),
 	);
 });
@@ -290,7 +290,7 @@ describe("send, on the AI agent's two-way in-ports", () => {
 				tools.handlers.send({process: agentProcess, port: each.port, payload: each.right}),
 			);
 			assert.isNotTrue(sent.isError);
-			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true});
+			assert.deepStrictEqual(JSON.parse(textOf(sent)), {delivered: true, evicted: 0});
 		}),
 	);
 });

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -468,7 +468,7 @@ describe("the agent proof", () => {
 
 			const spawned = answerAt("process.spawn") as {readonly process: string};
 			assert.isString(spawned.process);
-			assert.deepStrictEqual(answerAt("process.send"), {delivered: true});
+			assert.deepStrictEqual(answerAt("process.send"), {delivered: true, evicted: 0});
 			assert.deepStrictEqual(answerAt("echo.repeat"), {word: "haha"});
 		}),
 	);

--- a/apps/tuval/src/commands/core/process.ts
+++ b/apps/tuval/src/commands/core/process.ts
@@ -102,6 +102,37 @@ interface Inbox {
 	readonly queue: Queue.Queue<unknown>;
 }
 
+/**
+ * What one `send` did: whether the payload landed, and how many queued payloads the in-port took
+ * off to make room for it. Only a `sliding` bound displaces anything — `dropping` refuses the new
+ * payload instead and `suspend` waits — so `evicted` is `0` under the other two (#7971).
+ */
+export interface Sent {
+	readonly delivered: boolean;
+	readonly evicted: number;
+}
+
+/**
+ * The offer and the eviction it cost, read as one step. A `sliding` queue at capacity takes its
+ * oldest payload off inside the offer and answers `true` either way, so the displacement can only
+ * be inferred from the queue's own fullness at the moment of the offer: `Queue.offerUnsafe` is the
+ * same code as `Queue.offer` for a `sliding` queue in every state (`Queue.ts` at
+ * `effect@4.0.0-rc.112`), and running it beside the fullness read inside one `Effect.sync` leaves
+ * no yield point for the port's pump to `take` between them. A queue at capacity holding nothing
+ * is a zero-capacity bound, which has no payload to lose.
+ *
+ * A `suspend` bound must keep blocking until there is room, which `offerUnsafe` will not do, so it
+ * stays on the effectful offer along with `dropping`.
+ */
+const offerCounting = (inbox: Inbox, payload: unknown): Effect.Effect<Sent> =>
+	inbox.port.bound.overflow === "sliding"
+		? Effect.sync(() => {
+				const evicted =
+					Queue.isFullUnsafe(inbox.queue) && Queue.sizeUnsafe(inbox.queue) > 0 ? 1 : 0;
+				return {delivered: Queue.offerUnsafe(inbox.queue, payload), evicted};
+			})
+		: Effect.map(Queue.offer(inbox.queue, payload), (delivered) => ({delivered, evicted: 0}));
+
 interface Entry {
 	readonly handle: ProcessHandle;
 	readonly inboxes: ReadonlyMap<string, Inbox>;
@@ -239,7 +270,7 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 		if (!inbox.port.accepts(payload)) {
 			return yield* new PortRefused({process, port, kind: inbox.port.kind});
 		}
-		return yield* Queue.offer(inbox.queue, payload);
+		return yield* offerCounting(inbox, payload);
 	});
 
 	const read = Effect.fn("Tuval.SpawnedProcesses.read")(function* (
@@ -263,19 +294,18 @@ export class SpawnedProcesses extends Context.Service<
 			parent: Option.Option<ProcessId>,
 		) => Effect.Effect<ProcessId, UnknownProgram | UnknownProcess | OpenError | HandlerFailed>;
 		/**
-		 * `Queue.offer`'s own answer, and it covers less than a reader expects. `false` is one of two
-		 * things: a `dropping` in-port at capacity refusing the payload, or a queue that is no longer
-		 * open — the process stopped and the finalizer shut its in-port queues down. `true` is not
-		 * "nothing was lost": a `sliding` bound at capacity takes the oldest queued payload off,
-		 * appends this one and answers `true`, so a payload is dropped and no caller can learn it
-		 * (`Queue.offer` at the `effect@4.0.0-rc.112` pin). Whether `process send` should surface that
-		 * eviction is an open contract question (#7761).
+		 * `delivered` is `Queue.offer`'s own answer, and it covers less than a reader expects. `false`
+		 * is one of two things: a `dropping` in-port at capacity refusing the payload, or a queue that
+		 * is no longer open — the process stopped and the finalizer shut its in-port queues down.
+		 * `true` is not "nothing was lost", which is what `evicted` answers: a `sliding` bound at
+		 * capacity takes the oldest queued payload off to append this one, and that count is the only
+		 * way a sender can learn the earlier payload was never read (#7971).
 		 */
 		readonly send: (
 			process: ProcessId,
 			port: string,
 			payload: unknown,
-		) => Effect.Effect<boolean, UnknownProcess | UnknownPort | PortRefused>;
+		) => Effect.Effect<Sent, UnknownProcess | UnknownPort | PortRefused>;
 		readonly read: (
 			process: ProcessId,
 			port: string,
@@ -309,13 +339,10 @@ const sendSpell = defineSpell({
 	path: ["process", "send"],
 	describe: "Write one payload to a named in-port of a process.",
 	params: Schema.Struct({process: ProcessId, port: Schema.String, payload: Schema.Unknown}),
-	result: Schema.Struct({delivered: Schema.Boolean}),
+	result: Schema.Struct({delivered: Schema.Boolean, evicted: Schema.Number}),
 	execute: (args) =>
-		Effect.map(
-			Effect.flatMap(SpawnedProcesses, (spawned) =>
-				spawned.send(args.process, args.port, args.payload),
-			),
-			(delivered) => ({delivered}),
+		Effect.flatMap(SpawnedProcesses, (spawned) =>
+			spawned.send(args.process, args.port, args.payload),
 		),
 	capabilities: [{family: "process"}],
 });

--- a/apps/tuval/src/commands/core/process.unit.test.ts
+++ b/apps/tuval/src/commands/core/process.unit.test.ts
@@ -22,7 +22,7 @@ import {ProcessTable} from "../../process/ProcessTable.ts";
 import {ProcessId} from "../../process/process.ts";
 import {CallId} from "../../protocol/ids.ts";
 import {PROTOCOL_VERSION, SpellCall, type SpellReply} from "../../protocol/messages.ts";
-import {type AnyProgram, type Program, ProgramId} from "../../registry/program.ts";
+import {type AnyProgram, type PortBound, type Program, ProgramId} from "../../registry/program.ts";
 import {Registry} from "../../registry/Registry.ts";
 import {SpellExecutor} from "../executor.ts";
 import {SpellRegistry} from "../registry.ts";
@@ -40,7 +40,7 @@ type Say = {readonly type: "say"; readonly word: string};
 const echoId = ProgramId.make("echo");
 
 /** The fixture the demo pair does not offer: one program with both an in-port and an out-port. */
-const echoProgram = (): AnyProgram =>
+const echoProgram = (bound: PortBound = {capacity: 4, overflow: "suspend"}): AnyProgram =>
 	({
 		id: echoId,
 		core: defineMachine<EchoState, EchoMsg, Say, never, unknown>({
@@ -58,7 +58,7 @@ const echoProgram = (): AnyProgram =>
 				kind: WORD_KIND,
 				direction: "in",
 				accepts: isWord,
-				bound: {capacity: 4, overflow: "suspend"},
+				bound,
 			},
 			echoed: {kind: WORD_KIND, direction: "out", accepts: isWord},
 		},
@@ -88,6 +88,19 @@ const echoProgram = (): AnyProgram =>
 		PayloadRejected | PortNotWired,
 		ProcessPorts
 	>;
+
+/**
+ * `echo` under one named overflow at capacity 1: the three bounds side by side, so a proof over an
+ * eviction and a proof that the other two never evict read the same fixture (#7971).
+ */
+const boundedEchoId = (overflow: PortBound["overflow"]): ProgramId =>
+	ProgramId.make(`echo-${overflow}`);
+
+const boundedEchoProgram = (overflow: PortBound["overflow"]): AnyProgram => {
+	const base = echoProgram({capacity: 1, overflow});
+	const id = boundedEchoId(overflow);
+	return {...base, id, identity: {...base.identity, program: id, digest: `sha256:${id}`}};
+};
 
 const deafId = ProgramId.make("deaf");
 
@@ -120,6 +133,9 @@ const rows: ReadonlyArray<AnyProgram> = [
 	logProgram({write: () => Effect.void}),
 	echoProgram(),
 	deafProgram(),
+	boundedEchoProgram("sliding"),
+	boundedEchoProgram("dropping"),
+	boundedEchoProgram("suspend"),
 ];
 
 const kernel = SpawnedProcesses.layer({readTimeout: "1 second"}).pipe(
@@ -203,7 +219,7 @@ describe("the process spells", () => {
 			const sent = succeeded(
 				yield* invoke(["process", "send"], {process: spawned, port: "words", payload: "hi"}),
 			);
-			assert.deepStrictEqual(sent, {delivered: true});
+			assert.deepStrictEqual(sent, {delivered: true, evicted: 0});
 
 			const read = succeeded(
 				yield* invoke(["process", "read"], {process: spawned, port: "echoed"}),
@@ -323,7 +339,64 @@ describe("the process spells", () => {
 			for (const payload of ["one", "two", "three"]) {
 				assert.deepStrictEqual(
 					succeeded(yield* invoke(["process", "send"], {process: spawned, port: "words", payload})),
-					{delivered: true},
+					{delivered: true, evicted: 0},
+				);
+			}
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("a sliding in-port that displaced nothing reports no eviction", () =>
+		Effect.gen(function* () {
+			yield* startCaller;
+			const spawned = yield* spawnThrough(boundedEchoId("sliding"));
+
+			const sent = succeeded(
+				yield* invoke(["process", "send"], {process: spawned, port: "words", payload: "one"}),
+			);
+			assert.deepStrictEqual(sent, {delivered: true, evicted: 0});
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("a sliding in-port at capacity reports the payload it took off to make room", () =>
+		Effect.gen(function* () {
+			yield* startCaller;
+			const spawned = yield* spawnThrough(boundedEchoId("sliding"));
+
+			// The port holds one, and the pump's take is released on a scheduled task rather than
+			// inside the offer — so the second send lands on a full queue, which slides "one" out.
+			yield* invoke(["process", "send"], {process: spawned, port: "words", payload: "one"});
+			const sent = succeeded(
+				yield* invoke(["process", "send"], {process: spawned, port: "words", payload: "two"}),
+			);
+			assert.deepStrictEqual(sent, {delivered: true, evicted: 1});
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("a dropping in-port at capacity refuses the payload and evicts nothing", () =>
+		Effect.gen(function* () {
+			yield* startCaller;
+			const spawned = yield* spawnThrough(boundedEchoId("dropping"));
+
+			const first = succeeded(
+				yield* invoke(["process", "send"], {process: spawned, port: "words", payload: "one"}),
+			);
+			const second = succeeded(
+				yield* invoke(["process", "send"], {process: spawned, port: "words", payload: "two"}),
+			);
+			assert.deepStrictEqual(first, {delivered: true, evicted: 0});
+			assert.deepStrictEqual(second, {delivered: false, evicted: 0});
+		}).pipe(Effect.provide(app)),
+	);
+
+	it.effect("a suspending in-port waits for room and evicts nothing", () =>
+		Effect.gen(function* () {
+			yield* startCaller;
+			const spawned = yield* spawnThrough(boundedEchoId("suspend"));
+
+			for (const payload of ["one", "two"]) {
+				assert.deepStrictEqual(
+					succeeded(yield* invoke(["process", "send"], {process: spawned, port: "words", payload})),
+					{delivered: true, evicted: 0},
 				);
 			}
 		}).pipe(Effect.provide(app)),


### PR DESCRIPTION
`process send` now answers `{delivered, evicted}`. `evicted` is how many queued payloads a
`sliding` in-port took off to make room for this one — the loss no sender could previously learn
about. Only `sliding` displaces, so `dropping` and `suspend` always report `0`.

The count is carried the whole way up: `SpawnedProcesses.send` returns a `Sent` record instead of a
bare boolean, the spell's `result` schema gained the field, `KernelBridge`'s `Sent` schema decodes
it, and the Claude tool's `send` puts the whole reply in the text the agent reads (its description
now says what `evicted` means).

## Counting mechanism

The eviction is inferred from the queue's own fullness at the moment of the offer, read inside a
single `Effect.sync`:

```ts
const evicted = Queue.isFullUnsafe(queue) && Queue.sizeUnsafe(queue) > 0 ? 1 : 0;
return {delivered: Queue.offerUnsafe(queue, payload), evicted};
```

Safe against a concurrent `take` because the two reads and the offer are one synchronous JavaScript
step. A fiber only yields at an effect boundary, and there is none inside an `Effect.sync` body, so
the port's pump cannot run its `take` between the fullness read and the offer.

`offerUnsafe` is used rather than `offer` only where the bound is `sliding`, and there the two are
the same code: `Queue.ts` at `effect@4.0.0-rc.112` (`offer` lines 645-669, `offerUnsafe` lines
708-726) reaches the same `MutableList.take` + `MutableList.append` + `true` for a full sliding
queue and the same `append` + `scheduleReleaseTaker` otherwise. A `suspend` bound must keep blocking
until there is room, which `offerUnsafe` will not do, so `suspend` and `dropping` stay on the
effectful `Queue.offer`.

The `sizeUnsafe(queue) > 0` clause is not redundant: a zero-capacity bound is always "full" and has
no payload to lose.

## Proofs

`process.unit.test.ts` gains an `echo` fixture parameterised on its bound, and four cases over
capacity 1: sliding sending once reports `evicted: 0`, sliding sending twice reports `evicted: 1` on
the second, dropping at capacity reports `{delivered: false, evicted: 0}`, and suspend reports
`evicted: 0` on both. Callers asserting the old shape (`agent-proof`, `bridge.unit.test`,
`server.unit.test`, `boundary.unit.test`, `claude-vertical.integration.test`) are updated to the new
one.

Fixes #7971

## Deviations

- **Out-of-scope change** — **Said:** #7971 names `agent-proof.unit.test.ts`,
  `bridge.unit.test.ts` and `claude-vertical.integration.test.ts` as the callers to update.
  **Did:** also updated `apps/tuval/src/claude/tools/server.unit.test.ts` and
  `apps/tuval/src/claude/tools/boundary.unit.test.ts`. **Why:** both assert the send reply's shape
  too — `server.unit.test.ts` in three `deepStrictEqual`s against the tool text, and
  `boundary.unit.test.ts` in an `expectTypeOf` pin on `KernelBridge`'s `send` signature — so
  leaving them would have left the tree red. **Disposition:** stated here.
