### PR TITLE
fix: Tuval's kernel prefix table is named twice on the boot path, so a config-set table reaches only the shell row

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -202,6 +202,14 @@ program-blind: a process's state still crosses as `unknown`.
   grammar shows no desk rather than inventing one. `Duration` does not survive JSON, so the frame
   carries `repeatTimeoutMs` and `toWirePrefixTable`/`fromWirePrefixTable` convert.
 
+- **The grammar has one namer, and it is the shell row.** `shellProgram` resolves its `table` option
+  against `defaultPrefixTable` and publishes the answer on the row it returns; `shellPrefixTable`
+  reads it back off a config's rows, `boot` reports that as `Booted.keyTable`, and `src/bin.ts`
+  hands that value to `serveDesk`. Before this the bin named the default itself, so a config that
+  passed `shellProgram` a table put the kernel on its grammar and every page on the default, with
+  nothing failing (#7890). A new caller that needs the grammar reads it off the row the same way —
+  it never reaches for `defaultPrefixTable`, which is why the single namer holds.
+
 - The kernel decides what is in the catalog, and it decides with `showsInAWindow`
   (`src/shell/picker/entries.ts`) — the one place the headless test lives. A row with no `renderer`
   never crosses, so `WireProgram.renderer` is required and a page cannot be offered a program it

--- a/apps/tuval/src/bin.ts
+++ b/apps/tuval/src/bin.ts
@@ -19,7 +19,6 @@ import {boot, defaultGlobalConfig} from "./boot.ts";
 import {renderBindingErrors} from "./commands/bindings/index.ts";
 import {servePage} from "./page/dev-server.ts";
 import {serveDesk} from "./shell/host/index.ts";
-import {defaultPrefixTable} from "./shell/keys/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 import type {TableRow} from "./table/row.ts";
 
@@ -64,7 +63,7 @@ const tuval = Command.make(
 		),
 	},
 	Effect.fn(function* ({config, project, noPage, pagePort}) {
-		const {report, kernel, moduleRenderers, features} = yield* boot({
+		const {report, kernel, keyTable, moduleRenderers, features} = yield* boot({
 			global: Option.getOrElse(config, defaultGlobalConfig),
 			project: Option.getOrElse(project, () => process.cwd()),
 		}).pipe(
@@ -91,9 +90,7 @@ const tuval = Command.make(
 
 		// The socket first: the page is handed its URL, so the transport has to be bound before the
 		// dev server that will answer with it.
-		// The default is the shell row's too, because nothing passes `shellProgram` a table yet; a
-		// config that does would reach only the row, which is #7890.
-		const transport = yield* serveDesk({kernel, port: 0, table: defaultPrefixTable});
+		const transport = yield* serveDesk({kernel, port: 0, table: keyTable});
 		yield* Console.log(`tuval: transport on 127.0.0.1:${transport.port}`);
 		if (noPage) {
 			yield* Console.log("tuval: no page served (--no-page)");

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -29,7 +29,8 @@ import {Registry} from "./registry/Registry.ts";
 import {dispatchConfigChanged} from "./reload.ts";
 import type {ShellDispatch} from "./shell/commands/dispatch.ts";
 import {shellDispatchKernel, shellWindowIndexKernel} from "./shell/commands/kernel.ts";
-import {shellId} from "./shell/program.ts";
+import type {PrefixTable} from "./shell/keys/index.ts";
+import {shellId, shellPrefixTable} from "./shell/program.ts";
 import type {ModuleRendererRef} from "./shell/window/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 
@@ -198,6 +199,13 @@ export interface Booted {
 	 */
 	readonly features: TuvalFeatures;
 	/**
+	 * The key grammar the booted shell row was built with. Carried out of the boot because the
+	 * transport sends it to every attached page (ADR 0353) and is started from `src/bin.ts`, which
+	 * holds the kernel and not the config — before this it named `defaultPrefixTable` a second time,
+	 * so a config-set table reached the shell row and nothing else (#7890).
+	 */
+	readonly keyTable: PrefixTable;
+	/**
 	 * The config read again, its spells registered and its bindings compiled against them in one
 	 * write, and then every live process handed what its own row says the new config means for it
 	 * (`reload.ts`). Nothing restarts and nothing respawns: a process keeps running under the row
@@ -260,6 +268,7 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 		kernel: started.kernel,
 		moduleRenderers: config.moduleRenderers,
 		features: config.features,
+		keyTable: shellPrefixTable(programs),
 		reload: reload().pipe(Effect.provideContext(started.kernel)),
 	} satisfies Booted;
 });

--- a/apps/tuval/src/config-fixtures/shell-rebound-keys.ts
+++ b/apps/tuval/src/config-fixtures/shell-rebound-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * A config layer that registers the shell row on a rebound prefix. This is the case #7890 is about:
+ * the kernel routes over `reboundTable`, and the transport must be sent the same table rather than
+ * a default of its own.
+ */
+
+import {Result} from "effect";
+import {applyKeysConfig, defaultPrefixTable, type PrefixTable} from "../shell/keys/index.ts";
+import {shellGraphNode, shellProgram, unwiredShellEffects} from "../shell/program.ts";
+
+/** tmux's other common prefix, so the table differs from the default in a value a test can read. */
+export const reboundTable: PrefixTable = Result.getOrThrow(
+	applyKeysConfig(defaultPrefixTable, {prefix: "<c-a>"}),
+);
+
+export default {
+	version: 1,
+	programs: [shellProgram({table: reboundTable, effects: unwiredShellEffects})],
+	graph: {nodes: [shellGraphNode]},
+};

--- a/apps/tuval/src/shell/host/serve.ts
+++ b/apps/tuval/src/shell/host/serve.ts
@@ -35,8 +35,9 @@ export interface ServeDeskOptions {
 	readonly host?: string;
 	/**
 	 * The key grammar every attached page is sent and routes over (ADR 0353). It is the caller's,
-	 * because a kernel context does not carry it: the shell row closes over the table it was built
-	 * with and no registry row hands one back — [#7890](https://github.com/kamp-us/phoenix/issues/7890).
+	 * because a kernel context does not carry it. On the boot path the caller does not name one
+	 * either: the shell row publishes the table it resolved and `boot` reports it as
+	 * `Booted.keyTable`, which is what `src/bin.ts` passes here (#7890).
 	 */
 	readonly table: PrefixTable;
 }

--- a/apps/tuval/src/shell/program.ts
+++ b/apps/tuval/src/shell/program.ts
@@ -90,10 +90,26 @@ export const unwiredShellEffects: ShellEffects = {
 };
 
 export interface ShellProgramOptions<E = never, R = never> {
-	/** The key grammar the core routes against. Configuration, never state — it holds `Duration`s. */
+	/**
+	 * The key grammar the core routes against. Configuration, never state — it holds `Duration`s.
+	 * Absent means `defaultPrefixTable`.
+	 */
 	readonly table?: PrefixTable;
 	/** What runs the core's Cmds. Required: an absent set would be an inert desk nobody chose. */
 	readonly effects: ShellEffects<E, R>;
+}
+
+/**
+ * The one place on the boot path that names `defaultPrefixTable`. Both readers go through it — the
+ * row resolving its own option, and `shellPrefixTable` reading a config's rows back — so the value
+ * the kernel routes over and the value the transport sends cannot be two different tables (#7890,
+ * the open consequence ADR 0353 left).
+ */
+const resolveTable = (table: PrefixTable | undefined): PrefixTable => table ?? defaultPrefixTable;
+
+/** The shell's row, publishing the grammar it resolved so a later reader need not re-derive it. */
+export interface ShellRow extends AnyProgram {
+	readonly table: PrefixTable;
 }
 
 /**
@@ -110,14 +126,20 @@ export interface ShellProgramOptions<E = never, R = never> {
  * bridge all read the shell's commands there rather than from a second catalogue. Running one needs
  * `ShellDispatch`, which `AnySpell` erases; `src/boot.ts` owes it and pays it with
  * `shellDispatchKernel(shellId)`, which finds this row's live process and dispatches into it.
+ *
+ * `table` is the resolved grammar, on the row rather than only closed into the core: the transport
+ * is started from `src/bin.ts`, which holds the kernel and not the config, so without a value it
+ * could read back it had to name a default of its own (#7890).
  */
 export const shellProgram = <E = never, R = never>({
-	table = defaultPrefixTable,
+	table,
 	effects,
-}: ShellProgramOptions<E, R>): AnyProgram =>
-	({
+}: ShellProgramOptions<E, R>): ShellRow => {
+	const resolved = resolveTable(table);
+	return {
 		id: shellId,
-		core: shellCore({table}),
+		table: resolved,
+		core: shellCore({table: resolved}),
 		ports: {},
 		spells: shellSpells,
 		handlers: effects,
@@ -131,7 +153,29 @@ export const shellProgram = <E = never, R = never>({
 		// The kernel's word for the Node host is `local` (`src/registry/program.ts`); the shell runs
 		// where the kernel runs, and a browser-placed shell is not a thing this slice can spawn.
 		placement: {host: "local"},
-	}) satisfies Program<ShellState, ShellMsg, ShellCmd, never, unknown, E, R>;
+	} satisfies Program<ShellState, ShellMsg, ShellCmd, never, unknown, E, R> & {
+		readonly table: PrefixTable;
+	};
+};
+
+/**
+ * A config's rows carry whatever they were built with, and `Registry` erases none of it. Config
+ * rows are trusted local code (#7484 R1.1) — the loader checks a row's id, not its shape — so the
+ * id plus a published table is the whole test.
+ */
+const isShellRow = (program: AnyProgram): program is ShellRow =>
+	program.id === shellId && "table" in program;
+
+/**
+ * The key grammar a config's rows put the kernel on: the shell row's resolved table, or the same
+ * default that row would have taken when the config registers no shell at all (a kernel with no
+ * desk still serves a socket, and the grammar it sends a page is that default).
+ *
+ * `boot` reports this as `Booted.keyTable` and `src/bin.ts` hands that to `serveDesk`, which is
+ * what leaves the shell row the single namer of the kernel's grammar (#7890).
+ */
+export const shellPrefixTable = (programs: ReadonlyArray<AnyProgram>): PrefixTable =>
+	resolveTable(programs.find(isShellRow)?.table);
 
 /**
  * The shell's node: a root — no `parent` — with no routes, because it speaks over no port. A config

--- a/apps/tuval/src/shell/program.unit.test.ts
+++ b/apps/tuval/src/shell/program.unit.test.ts
@@ -14,9 +14,10 @@ import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Context, Effect, Layer, Option} from "effect";
+import {Context, Effect, Layer, Option, Result} from "effect";
 import {afterAll} from "vitest";
 import {boot, projectDir} from "../boot.ts";
+import {reboundTable} from "../config-fixtures/shell-rebound-keys.ts";
 import {Checkpoints} from "../durability/Checkpoints.ts";
 import {SnapshotRefused} from "../durability/errors.ts";
 import {memoryStores} from "../durability/stores.ts";
@@ -26,12 +27,14 @@ import {ProcessId} from "../process/process.ts";
 import type {AnyProgram} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
 import {applyMsg, initialState, type ShellMsg} from "./core/index.ts";
-import {defaultPrefixTable} from "./keys/index.ts";
+import type {ServeDeskOptions} from "./host/index.ts";
+import {applyKeysConfig, defaultPrefixTable} from "./keys/index.ts";
 import {showsInAWindow} from "./picker/entries.ts";
 import {
 	SHELL_VERSION,
 	shellId,
 	shellNode,
+	shellPrefixTable,
 	shellProgram,
 	shellStateOf,
 	unwiredShellEffects,
@@ -41,6 +44,11 @@ import {WindowId} from "./window/index.ts";
 
 /** The box's own config module — the user-owned surface the shell is registered through. */
 const boxConfig = fileURLToPath(new URL("../../.tuval/tuval.config.ts", import.meta.url));
+
+/** A config layer whose shell row is built on a rebound prefix, for the #7890 walk below. */
+const reboundConfig = fileURLToPath(
+	new URL("../config-fixtures/shell-rebound-keys.ts", import.meta.url),
+);
 
 const tempDirs: string[] = [];
 /** A project dir whose `.tuval/` is empty: no project config, nothing checkpointed. */
@@ -288,6 +296,57 @@ describe("the shell as a program row", () => {
 				}
 			}
 		},
+		BUDGET_MS,
+	);
+});
+
+/**
+ * The kernel's key grammar has one namer on the boot path (#7890). The shell row publishes the
+ * table it resolved, `boot` reports it, and `src/bin.ts` hands that value — never a default of its
+ * own — to `serveDesk`, whose `table` is what every attached page is sent (ADR 0353). The
+ * socket-level half of that walk belongs to `./transport/transport.integration.test.ts`; what these
+ * cases hold is the value the bin passes it.
+ */
+describe("the boot path's one prefix table", () => {
+	it(
+		"reads a shell row's own table back off the row, and the default when a config names none",
+		() => {
+			const rebound = Result.getOrThrow(applyKeysConfig(defaultPrefixTable, {prefix: "<c-a>"}));
+			assert.deepStrictEqual(
+				shellPrefixTable([shellProgram({table: rebound, effects: unwiredShellEffects})]),
+				rebound,
+			);
+			assert.deepStrictEqual(shellPrefixTable([row()]), defaultPrefixTable);
+			assert.deepStrictEqual(shellPrefixTable([]), defaultPrefixTable);
+		},
+		BUDGET_MS,
+	);
+
+	it.effect(
+		"carries a config-set table through to the value the bin hands `serveDesk`",
+		() =>
+			Effect.gen(function* () {
+				const booted = yield* boot({global: reboundConfig, project: freshProject()});
+				// The one expression `src/bin.ts` builds around the reported table.
+				const options = {
+					kernel: booted.kernel,
+					port: 0,
+					table: booted.keyTable,
+				} satisfies ServeDeskOptions;
+				assert.deepStrictEqual(options.table, reboundTable);
+				assert.notDeepEqual(options.table, defaultPrefixTable);
+			}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer)),
+		BUDGET_MS,
+	);
+
+	it.effect(
+		"leaves a config that names no table on the default, on both sides",
+		() =>
+			Effect.gen(function* () {
+				const booted = yield* boot({global: boxConfig, project: freshProject()});
+				assert.deepStrictEqual(booted.keyTable, defaultPrefixTable);
+				assert.deepStrictEqual(shellPrefixTable([row()]), booted.keyTable);
+			}).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer)),
 		BUDGET_MS,
 	);
 });


### PR DESCRIPTION
Tuval's key grammar was named twice on the boot path: `shellProgram` resolved a `PrefixTable` and closed it into the shell core, and `src/bin.ts` named `defaultPrefixTable` again for `serveDesk`. They agreed only because nothing had passed a table yet — a config that did would put the kernel on its own grammar and every attached page on the default, with nothing failing. That is ADR 0353's open consequence, and the failure #7781 closed at the page, reopened one hop upstream.

The row is now the single namer. `shellProgram` publishes the table it resolved on the row it returns, `shellPrefixTable` reads it back off a config's rows, `boot` reports that as `Booted.keyTable`, and the bin hands that value to `serveDesk`. `resolveTable` is the one expression on the boot path that mentions `defaultPrefixTable`, and both readers go through it, so the kernel's table and the transport's cannot diverge. `ShellProgramOptions.table` is unchanged for a config that names none. `TuvalConfig` gains no field and `boot`'s spell-binding compilation is untouched — the `keys` field there is the spell-binding table, a different thing.

Three unit cases in `apps/tuval/src/shell/program.unit.test.ts`: the pure read off a row (custom, default, and no shell row at all); a boot over a new fixture whose shell row carries a rebound prefix, asserting the value the bin hands `serveDesk` is that table and not the default; and the default case over the box config, asserting both sides land on `defaultPrefixTable`.

Patterns: `.patterns/index.md`, `.patterns/tuval-shell-assembly.md` (extended with the single-namer rule), `.patterns/effect-schema-validation.md`, `.patterns/tuval-program-row-effects.md`.

Ran `pnpm vitest run --project unit` over `src/shell/program.unit.test.ts`, `src/boot.unit.test.ts`, `src/config.unit.test.ts` and `src/shell/keys` — 115 passed. `build check --surface code` and `--surface prose` both green.

Fixes #7890

## Deviations

- **Out-of-scope change** — **Said:** #7890 names `apps/tuval/src/bin.ts`, `program.ts` and `serve.ts`. **Did:** also extended `.patterns/tuval-shell-assembly.md` with the single-namer rule. **Why:** CLAUDE.md requires a load-bearing shape to be written down, and that doc's page-frames section already describes the prefix table; without it the next builder has nothing stopping them naming a second default. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the boot path names `defaultPrefixTable` at most once. **Did:** left the proof harnesses (`src/page/proof/serve.ts`, `src/pi/proof/serve.ts`, `src/claude/proof/serve.ts`) and the integration tests that call `serveDesk` naming it themselves. **Why:** they are dev harnesses and test inputs, not the boot path the ticket scopes, and two of them build their kernel through `bootChattedVertical` rather than `boot`, so threading the reported table there is its own change. **Disposition:** filed as a follow-up issue.
- **Guard or gate bypassed** — **Said:** cut the lane branch and work inside the isolated worktree. **Did:** ran `fabrika build branch` once with the working directory set to the shared checkout, which cut `build/7890-one-boot-prefix-table-13bd848f` there and left that checkout standing on it; the real work then happened in the worktree on this PR's branch, cut from the same claim nonce. **Why:** my own mistake. The harness refuses a worktree-isolated agent any repository operation against the shared checkout, so I could not put it back on `main` myself. **Disposition:** stated here. That branch carries no commits and no working-tree change, it was never pushed, and switching the shared checkout back to `main` clears it.
