### PR TITLE
feat: Tuval's parser binds one token per parameter, so a spell path argument cannot be typed with spaces

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -366,7 +366,8 @@ properties of that rendering are load-bearing, all read off `Schema.toJsonSchema
 arrives as `{"type": "string", "enum": [...]}`; and a `Schema.Class` params, or any
 identifier-annotated struct, renders its root as `{"$ref": "#/$defs/<name>"}` with the object itself
 under the document's `definitions`, so the root ref is followed once before the properties are read.
-Everything else is read defensively, because the module is total.
+Unannotated input is read defensively. Explicit invalid rest declarations throw
+`InvalidRestParameter`; registration catches that refusal before publishing the description.
 
 `describeExpected(param)` renders one slot: `<name>`, or the literals joined by `|`.
 

--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -17,6 +17,7 @@ moved.
 | File | What is in it |
 |---|---|
 | [`spell.ts`](../apps/tuval/src/commands/spell.ts) | `Spell`, `defineSpell`, `SpellPath`, `Scope`, `renderPath`, the `WindowId` / `WorkspaceId` / `ClientId` brands |
+| [`rest-parameter.ts`](../apps/tuval/src/commands/rest-parameter.ts) | `RestParameter`, the explicit final free-text parameter schema, and its wire annotation key |
 | [`registry.ts`](../apps/tuval/src/commands/registry.ts) | `buildRegistry`, `SpellRegistry`, `SpellRow`, `SpellNode`, `RegistryTable`, `lookupRow`, `describeSpell` |
 | [`spell-set.ts`](../apps/tuval/src/commands/spell-set.ts) | `SpellSet`: the table and the key bindings compiled against it, in one cell |
 | [`scope.ts`](../apps/tuval/src/commands/scope.ts) | `WindowIndex`, `WindowPlacement`, `Client`, `resolveScope` |
@@ -101,11 +102,12 @@ the core spell list and the program rows, and it produces a `RegistryTable`:
   registered at exactly its path.
 - `rows`, the flat list `list` and `describe` read.
 
-Registration is the one place a spell can be refused, and there are two refusals. Two spells
+Registration is the one place a spell can be refused. Two spells
 claiming one path fail with `DuplicateSpellPath`. A spell whose `params` has no JSON Schema form
 fails with `SpellNotDescribable`: `Schema.toJsonSchemaDocument` throws at the pin, and rendering
 happens here, at registration, so a spell nobody can describe never enters the table and describing
-a registered one cannot throw. Both name the path and the source (`describeSource` renders "the core
+a registered one cannot throw. Invalid rest declarations also fail as `SpellNotDescribable`, before
+bindings or snapshots can consume them. Both failures name the path and the source (`describeSource` renders "the core
 spell list" or `program "<id>"`).
 
 `SpellRegistry` is a `Context.Service` over one `Ref` holding the table:
@@ -308,6 +310,37 @@ Arguments bind as text. The only *value* the parser refuses is one outside an en
 literals, which is the check the kernel would make anyway, made here so a page running this parser cannot
 accept what the kernel rejects. It also refuses a token with no parameter left to bind to, with
 `no further arguments`.
+
+### A final parameter that consumes remaining words
+
+Declare `RestParameter` from
+[`rest-parameter.ts`](../apps/tuval/src/commands/rest-parameter.ts) as the final field of a spell's
+`Schema.Struct`; wrap it in `Schema.optionalKey` when omission is allowed. It is a string schema
+annotated with `x-command-rest: true`. No other trailing string becomes rest implicitly.
+
+The registry renders that annotation using Effect's `includeAnnotationKey` option, whitelisting
+only this vendor key in addition to Effect's standard metadata. This follows
+[`Schema.ToJsonSchemaOptions.includeAnnotationKey` at rc.112](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.112/packages/effect/src/Schema.ts)
+(see also [LLMS.md, Defining schemas and domain models](https://github.com/Effect-TS/effect/blob/main/LLMS.md#defining-schemas-and-domain-models)).
+The protocol's open JSON Schema nodes preserve it across serialization, including optional fields.
+
+`readParams` carries it as `ParamSpec.rest`. A declared rest field must be last and describe a
+string without literal choices; an invalid declaration throws `InvalidRestParameter` when the
+index is built. Registration performs the same validation inside its existing failure channel.
+
+Once a positional token or `name=value` binding starts rest capture, every following token is
+content, including another `name=value`. Earlier required parameters must already have been
+supplied; addressing rest by name does not make them optional. Token values are joined with one
+space: quoted internal whitespace, escaped characters and dots retain their meaning. Separator
+whitespace between tokens is normalized, and trailing separators add no text. The caret remains in
+the rest slot after a separator; completion offers no candidates there, even when the parameter's
+name would normally select live values.
+
+`help` and `spell describe` opt their path into rest. They retain `segmentsOf` to resolve dotted
+and whitespace-separated paths to the same command; the generic parser does not normalize dots
+in arbitrary text. [`parse/rest.unit.test.ts`](../apps/tuval/src/commands/parse/rest.unit.test.ts)
+exercises declaration refusals, the wire round trip, completion, unchanged non-rest refusals and
+the three path spellings through the real discovery handlers.
 
 `parse(input, registry, snapshot)` ([`parse/parse.ts`](../apps/tuval/src/commands/parse/parse.ts))
 answers one of three (the second parameter is named `registry` and its type is `SpellIndex`):

--- a/apps/tuval/src/commands/core/help.ts
+++ b/apps/tuval/src/commands/core/help.ts
@@ -17,6 +17,7 @@ import {UnknownSpell} from "../errors.ts";
 import {didYouMean} from "../parse/did-you-mean.ts";
 import {describeExpected, type ParamSpec, readParams} from "../parse/spell-index.ts";
 import {SpellRegistry} from "../registry.ts";
+import {RestParameter} from "../rest-parameter.ts";
 import {defineSpell} from "../spell.ts";
 
 /** One line of the table: the spell's address, what it expects, and its own sentence. */
@@ -86,7 +87,7 @@ export const renderHelp = (rows: ReadonlyArray<HelpRow>): string => {
 export const helpSpell = defineSpell({
 	path: ["help"],
 	describe: "List every spell, or only the ones under one path.",
-	params: Schema.Struct({path: Schema.optionalKey(Schema.String)}),
+	params: Schema.Struct({path: Schema.optionalKey(RestParameter)}),
 	result: HelpRows,
 	execute: Effect.fn("Tuval.Spells.help")(function* (args: {readonly path?: string}) {
 		const registry = yield* SpellRegistry;

--- a/apps/tuval/src/commands/core/spell.ts
+++ b/apps/tuval/src/commands/core/spell.ts
@@ -12,6 +12,7 @@ import {RegistryDescription, SpellDescription} from "../../protocol/registry-des
 import {UnknownSpell} from "../errors.ts";
 import {didYouMean} from "../parse/did-you-mean.ts";
 import {SpellRegistry} from "../registry.ts";
+import {RestParameter} from "../rest-parameter.ts";
 import {defineSpell} from "../spell.ts";
 import {segmentsOf} from "./help.ts";
 
@@ -30,7 +31,7 @@ export const spellList = defineSpell({
 export const spellDescribe = defineSpell({
 	path: ["spell", "describe"],
 	describe: "Describe one spell, including the schema of its parameters.",
-	params: Schema.Struct({path: Schema.String}),
+	params: Schema.Struct({path: RestParameter}),
 	result: SpellDescription,
 	execute: Effect.fn("Tuval.Spells.spellDescribe")(function* (args: {readonly path: string}) {
 		const registry = yield* SpellRegistry;

--- a/apps/tuval/src/commands/index.ts
+++ b/apps/tuval/src/commands/index.ts
@@ -50,6 +50,7 @@ export {
 	type SpellRow,
 	type SpellSource,
 } from "./registry.ts";
+export {RestParameter} from "./rest-parameter.ts";
 export {type Client, resolveScope, WindowIndex, type WindowPlacement} from "./scope.ts";
 export {
 	type AnySpell,

--- a/apps/tuval/src/commands/parse/complete.ts
+++ b/apps/tuval/src/commands/parse/complete.ts
@@ -159,6 +159,7 @@ export const candidatesFor = (slot: Slot, snapshot: Snapshot): ReadonlyArray<Can
 		}
 		return byPrefix(segments, slot.token.text);
 	}
+	if (slot.param.rest === true) return [];
 	if (slot.param.literals !== undefined) {
 		return byPrefix(
 			slot.param.literals.map((literal) => unstamped({value: literal, kind: "literal"})),

--- a/apps/tuval/src/commands/parse/reading.ts
+++ b/apps/tuval/src/commands/parse/reading.ts
@@ -170,12 +170,12 @@ const bind = (
 ): Reading => {
 	const caretIsArgument = caretIndex >= consumed && caretIndex < tokens.length;
 	const committed = tokens.slice(consumed, caretIsArgument ? caretIndex : tokens.length);
-	const pending = caretIsArgument && caret.text !== "" ? caret : undefined;
 
 	const args: Record<string, string> = {};
 	const bound = new Set<string>();
 	const byName = new Map(spell.params.map((param) => [param.name, param]));
 	let position = 0;
+	let rest: ParamSpec | undefined;
 
 	const nextPositional = (): ParamSpec | undefined => {
 		while (position < spell.params.length) {
@@ -197,6 +197,7 @@ const bind = (
 		| {readonly kind: "full"};
 
 	const target = (token: Token): Target => {
+		if (rest !== undefined) return {kind: "bind", param: rest, value: token.text};
 		const named = NAMED.exec(token.text);
 		const name = named?.[1];
 		const value = named?.[2];
@@ -212,6 +213,12 @@ const bind = (
 		return positional === undefined
 			? {kind: "full"}
 			: {kind: "bind", param: positional, value: token.text};
+	};
+
+	const assign = (param: ParamSpec, value: string): void => {
+		args[param.name] = rest === undefined ? value : `${args[param.name]} ${value}`;
+		bound.add(param.name);
+		if (param.rest === true) rest = param;
 	};
 
 	for (const token of committed) {
@@ -235,10 +242,13 @@ const bind = (
 				slot: {kind: "value", param: slot.param, token},
 			};
 		}
-		args[slot.param.name] = slot.value;
-		bound.add(slot.param.name);
+		assign(slot.param, slot.value);
 	}
 
+	const pending =
+		caretIsArgument && (caret.text !== "" || rest !== undefined || nextPositional()?.rest === true)
+			? caret
+			: undefined;
 	if (pending !== undefined) {
 		const slot = target(pending);
 		if (slot.kind === "full") {
@@ -265,12 +275,11 @@ const bind = (
 						slot: valueSlot,
 					};
 		}
-		args[slot.param.name] = slot.value;
-		bound.add(slot.param.name);
+		assign(slot.param, slot.value);
 		return {core: finish(spell, args, bound), slot: valueSlot};
 	}
 
-	const open = nextPositional();
+	const open = rest ?? nextPositional();
 	return {
 		core: finish(spell, args, bound),
 		slot: open === undefined ? {kind: "none"} : {kind: "value", param: open, token: caret},

--- a/apps/tuval/src/commands/parse/rest.unit.test.ts
+++ b/apps/tuval/src/commands/parse/rest.unit.test.ts
@@ -1,0 +1,173 @@
+import {Effect, Schema} from "effect";
+import {describe, expect, it} from "vitest";
+import {RegistryDescription} from "../../protocol/registry-description.ts";
+import {scope, table} from "../core/fixtures.ts";
+import {helpSpell, segmentsOf} from "../core/help.ts";
+import {spellDescribe} from "../core/spell.ts";
+import {buildRegistry, describeSpell, SpellRegistry} from "../registry.ts";
+import {REST_PARAMETER_ANNOTATION, RestParameter} from "../rest-parameter.ts";
+import {defineSpell} from "../spell.ts";
+import {complete} from "./complete.ts";
+import {registry, snapshot} from "./fixtures.ts";
+import {parse} from "./parse.ts";
+import {buildSpellIndex, InvalidRestParameter, readParams} from "./spell-index.ts";
+
+const document = (params: Schema.Top) =>
+	Schema.toJsonSchemaDocument(params, {
+		includeAnnotationKey: (key) => key === REST_PARAMETER_ANNOTATION,
+	});
+
+const echo = (params: Schema.Top) =>
+	defineSpell({
+		path: ["echo"],
+		describe: "Return the supplied text.",
+		params,
+		result: Schema.Unknown,
+		execute: (args: unknown) => Effect.succeed(args),
+		capabilities: [],
+	});
+
+const indexFor = (params: Schema.Top) =>
+	buildSpellIndex([
+		{path: ["echo"], describe: "Return text.", params: document(params), capabilities: []},
+	]);
+
+describe("rest declarations", () => {
+	it("keeps optionality, annotations and rest through registration and the wire", () => {
+		const built = Effect.runSync(buildRegistry({core: [helpSpell, spellDescribe], programs: []}));
+		const codec = Schema.toCodecJson(RegistryDescription);
+		const wire = Schema.encodeSync(codec)(built.rows.map(describeSpell));
+		const descriptions = Schema.decodeUnknownSync(codec)(wire);
+		expect(descriptions.map((row) => readParams(row.params))).toEqual([
+			[{name: "path", required: false, rest: true}],
+			[{name: "path", required: true, rest: true}],
+		]);
+		const annotated = Effect.runSync(
+			buildRegistry({
+				core: [
+					echo(
+						Schema.Struct({text: RestParameter.annotate({description: "Text", unrelated: true})}),
+					),
+				],
+				programs: [],
+			}),
+		);
+		expect(annotated.rows[0]?.paramsDocument.schema.properties).toEqual({
+			text: {type: "string", description: "Text", "x-command-rest": true},
+		});
+	});
+
+	it("reads rest through a referenced property and a referenced root", () => {
+		const params = Schema.Struct({
+			text: Schema.optionalKey(RestParameter.annotate({identifier: "RestText"})),
+		}).annotate({identifier: "RestArgs"});
+		expect(readParams(document(params))).toEqual([{name: "text", required: false, rest: true}]);
+	});
+
+	it.each([
+		Schema.Struct({text: RestParameter, after: Schema.String}),
+		Schema.Struct({first: RestParameter, second: RestParameter}),
+		Schema.Struct({text: Schema.Boolean.annotate({"x-command-rest": true})}),
+		Schema.Struct({text: Schema.Literals(["one", "two"]).annotate({"x-command-rest": true})}),
+		Schema.Struct({text: Schema.String.annotate({"x-command-rest": "yes"})}),
+	])("rejects invalid rest declarations when building the index and registry", (params) => {
+		expect(() => indexFor(params)).toThrow(InvalidRestParameter);
+		const failure = Effect.runSync(
+			Effect.flip(buildRegistry({core: [echo(params)], programs: []})),
+		);
+		expect(failure._tag).toBe("tuval/commands/SpellNotDescribable");
+		expect(failure.message).toContain("rest parameter");
+	});
+});
+
+describe("rest binding", () => {
+	const index = indexFor(Schema.Struct({mode: Schema.String, text: RestParameter}));
+
+	it.each([
+		["echo plain two words", "two words"],
+		["echo plain two words ", "two words"],
+		['echo plain ""', ""],
+		['echo plain hello ""', "hello "],
+		['echo plain "two  spaces" next', "two  spaces next"],
+		["echo plain file.name mode=value text=more", "file.name mode=value text=more"],
+		["echo mode=plain text=two words", "two words"],
+		['echo plain say\\ \\"hi\\" now', 'say "hi" now'],
+	])("binds %s without rewriting its contents", (line, text) => {
+		expect(parse(line, index, snapshot)).toEqual({
+			_tag: "Complete",
+			call: {path: ["echo"], args: {mode: "plain", text}},
+		});
+	});
+
+	it("requires the preceding arguments even when rest is addressed by name first", () => {
+		expect(parse("echo text=hello mode=plain", index, snapshot)).toMatchObject({
+			_tag: "Partial",
+			cursorArg: {name: "mode"},
+		});
+	});
+
+	it("leaves unannotated surplus and rebinding refusals unchanged", () => {
+		expect(parse("workspace rename a b c", registry, snapshot)).toEqual({
+			_tag: "Refused",
+			position: 21,
+			expected: "no further arguments",
+		});
+		expect(parse("echo mode=plain mode=other", index, snapshot)).toMatchObject({
+			_tag: "Refused",
+			expected: "mode is already bound",
+		});
+	});
+
+	it("keeps every prefix of a multiword line usable", () => {
+		const line = 'echo plain "two  spaces" file.name text=value';
+		for (let length = 0; length <= line.length; length += 1) {
+			expect(parse(line.slice(0, length), index, snapshot)._tag).not.toBe("Refused");
+		}
+	});
+
+	it("offers no candidates anywhere in rest, even for a live-value parameter name", () => {
+		const liveName = indexFor(Schema.Struct({workspace: RestParameter}));
+		for (const line of [
+			"echo ",
+			"echo scr",
+			"echo scratch ",
+			"echo scratch ws",
+			'echo "scratch ws',
+		]) {
+			expect(complete(line, liveName, snapshot)).toEqual([]);
+		}
+		expect(parse("echo ", liveName, snapshot)).toMatchObject({_tag: "Partial"});
+		expect(
+			parse("echo", indexFor(Schema.Struct({text: Schema.optionalKey(RestParameter)})), snapshot),
+		).toMatchObject({_tag: "Complete", call: {args: {}}});
+	});
+});
+
+describe("discovery command paths", () => {
+	const built = Effect.runSync(table);
+	const index = buildSpellIndex(built.rows.map(describeSpell));
+
+	it.each([
+		"window close",
+		'"window close"',
+		"window.close",
+	])("help and spell describe resolve %s to the same registered command", (value) => {
+		const help = parse(`help ${value}`, index, snapshot);
+		const describe = parse(`spell describe ${value}`, index, snapshot);
+		expect(help._tag).toBe("Complete");
+		expect(describe._tag).toBe("Complete");
+		if (help._tag !== "Complete" || describe._tag !== "Complete") return;
+		const args = Schema.decodeUnknownSync(spellDescribe.params)(describe.call.args);
+		expect(segmentsOf(args.path)).toEqual(["window", "close"]);
+		const found = Effect.runSync(
+			spellDescribe.execute(args, scope).pipe(Effect.provide(SpellRegistry.layer(built))),
+		);
+		expect(found.path).toEqual(["window", "close"]);
+		const rows = Effect.runSync(
+			helpSpell
+				.execute(Schema.decodeUnknownSync(helpSpell.params)(help.call.args), scope)
+				.pipe(Effect.provide(SpellRegistry.layer(built))),
+		);
+		expect(rows.map((row) => row.path)).toEqual(["window close"]);
+	});
+});

--- a/apps/tuval/src/commands/parse/spell-index.ts
+++ b/apps/tuval/src/commands/parse/spell-index.ts
@@ -17,19 +17,31 @@
  * `{"type": "string", "enum": [...]}`. A third followed from the same reading: a `Schema.Class` or
  * an identifier-annotated struct renders its root as `{"$ref": "#/$defs/<name>"}` with the object
  * itself under the document's `definitions`, so the root ref is followed once before the properties
- * are read. Everything else is read defensively — this module is total.
+ * are read. Invalid explicit rest declarations throw `InvalidRestParameter`; registration runs
+ * this validation before publishing descriptions. Unannotated input retains its defensive reads.
  */
 
-import {Predicate} from "effect";
+import {Predicate, Schema} from "effect";
 import type {RegistryDescription} from "../../protocol/registry-description.ts";
+import {REST_PARAMETER_ANNOTATION} from "../rest-parameter.ts";
 import type {SpellPath} from "../spell.ts";
 
 /** One parameter of a spell, as the parser binds it and the palette describes it. */
 export interface ParamSpec {
 	readonly name: string;
 	readonly required: boolean;
+	readonly rest?: true;
 	/** The literal choices when the parameter is an enum; a value outside them is refused. */
 	readonly literals?: ReadonlyArray<string>;
+}
+
+export class InvalidRestParameter extends Schema.TaggedError<InvalidRestParameter>()(
+	"tuval/commands/InvalidRestParameter",
+	{name: Schema.String, reason: Schema.String},
+) {
+	override get message(): string {
+		return `rest parameter "${this.name}" ${this.reason}`;
+	}
 }
 
 export interface IndexedSpell {
@@ -106,7 +118,26 @@ export const readParams = (params: unknown): ReadonlyArray<ParamSpec> => {
 			? declaredRequired.filter((name): name is string => typeof name === "string")
 			: [],
 	);
-	return Object.keys(properties).map((name) => {
+	const names = Object.keys(properties);
+	return names.map((name, index) => {
+		const property = followRef(asRecord(properties[name]), params);
+		const rest = property?.[REST_PARAMETER_ANNOTATION];
+		if (rest !== undefined && rest !== true) {
+			throw new InvalidRestParameter({name, reason: "must be declared with true"});
+		}
+		if (rest === true) {
+			if (index !== names.length - 1) {
+				throw new InvalidRestParameter({name, reason: "must be the last declared parameter"});
+			}
+			if (
+				property?.type !== "string" ||
+				property.enum !== undefined ||
+				property.const !== undefined
+			) {
+				throw new InvalidRestParameter({name, reason: "must be a free string"});
+			}
+			return {name, required: required.has(name), rest: true};
+		}
 		const literals = stringLiterals(properties[name]);
 		return literals === undefined
 			? {name, required: required.has(name)}

--- a/apps/tuval/src/commands/registry.ts
+++ b/apps/tuval/src/commands/registry.ts
@@ -10,6 +10,8 @@
 import {Context, Effect, type JsonSchema, Layer, Ref, Schema} from "effect";
 import type {AnyProgram, CapabilityRequest, ProgramId} from "../registry/program.ts";
 import {DuplicateSpellPath, SpellNotDescribable, SpellNotFound} from "./errors.ts";
+import {readParams} from "./parse/spell-index.ts";
+import {REST_PARAMETER_ANNOTATION} from "./rest-parameter.ts";
 import {type AnySpell, renderPath, type SpellPath} from "./spell.ts";
 
 /** Where a registered spell came from. A refusal names both sides through `describeSource`. */
@@ -83,7 +85,13 @@ const describeParams = (
 	row: Omit<SpellRow, "paramsDocument">,
 ): Effect.Effect<JsonSchema.Document<"draft-2020-12">, SpellNotDescribable> =>
 	Effect.try({
-		try: () => Schema.toJsonSchemaDocument(row.spell.params),
+		try: () => {
+			const document = Schema.toJsonSchemaDocument(row.spell.params, {
+				includeAnnotationKey: (key) => key === REST_PARAMETER_ANNOTATION,
+			});
+			readParams(document);
+			return document;
+		},
 		catch: (cause) =>
 			new SpellNotDescribable({
 				path: renderPath(row.path),

--- a/apps/tuval/src/commands/rest-parameter.ts
+++ b/apps/tuval/src/commands/rest-parameter.ts
@@ -1,0 +1,5 @@
+import {Schema} from "effect";
+
+export const REST_PARAMETER_ANNOTATION = "x-command-rest";
+
+export const RestParameter = Schema.String.annotate({[REST_PARAMETER_ANNOTATION]: true});


### PR DESCRIPTION
`help window close` and `spell describe window close` now accept unquoted paths. Commands opt their final string field into consuming remaining words with `RestParameter`; ordinary commands retain surplus-argument refusals. Rest completion offers no candidates, and invalid declarations fail during registration and index construction.

`segmentsOf` stays in the discovery handlers so quoted, spaced and dotted paths resolve the same command without rewriting arbitrary text in the generic parser. The registry preserves the explicit annotation through Effect's vendor-key whitelist, grounded in [Schema.ToJsonSchemaOptions.includeAnnotationKey at rc.112](https://github.com/Effect-TS/effect/blob/effect%404.0.0-rc.112/packages/effect/src/Schema.ts) and [LLMS.md, Defining schemas and domain models](https://github.com/Effect-TS/effect/blob/main/LLMS.md#defining-schemas-and-domain-models).

Validation: 222 command/palette unit tests pass, including real discovery-handler execution and registry-description serialization. Fabrika code and prose checks are green. Browser command access remains the separate #8255 integration.

Fixes #7713

## Deviations

- **Said:** The acceptance criterion asks spaced and dotted forms to produce identical bound arguments. **Did:** Preserve their string contents and prove they resolve the same registered command through both discovery handlers. **Why:** Generic rest arguments must preserve dots and quoted whitespace; separator interpretation belongs to the discovery command, consistent with the founder's revised scope. **Disposition:** Explicitly documented and covered by tests; no global argument normalization.
