### PR TITLE
fix: Tuval marks a turn ready before interruption is confirmed

### DIFF
--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -871,9 +871,9 @@ describe("interrupt", () => {
 		expect(next.interruption).toEqual({requestedAt: SENT_AT});
 	});
 
-	// The refusal case as the generic contract can see it: `interrupt` declares no error channel and
-	// both layers log a refused abort, so a refusal reaches the core as nothing at all. The session
-	// must therefore stay busy with the request on the record, never fall back to ready.
+	// A second press while the first ask is still unanswered: nothing has confirmed a stop, so the
+	// session stays busy with the request on the record rather than falling back to ready. (A
+	// backend that answers by refusing is a failure event instead — `../core/fold.unit.test.ts`.)
 	it("leaves a refused abort outstanding rather than fabricating a stop", () => {
 		const [asked] = apply(running(), {type: "interrupt", at: SENT_AT});
 		const [again, cmds] = apply(asked, {type: "interrupt", at: SENT_AT + 3_000});

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -124,6 +124,7 @@ export const on = <A, E>(
 			...(harness.catalogFails === undefined ? {} : {catalogFails: harness.catalogFails}),
 			...(harness.commands === undefined ? {} : {commands: harness.commands}),
 			...(harness.commandsFail === undefined ? {} : {commandsFail: harness.commandsFail}),
+			...(harness.interruptFails === undefined ? {} : {interruptFails: harness.interruptFails}),
 			...(harness.effortSwitchFails === undefined
 				? {}
 				: {effortSwitchFails: harness.effortSwitchFails}),

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -83,6 +83,12 @@ export interface ScriptedBehaviour {
 	readonly commands?: ReadonlyArray<SlashCommand>;
 	/** A `supportedCommands()` that throws — a session with no slash picker, not a failed open. */
 	readonly commandsFail?: Error;
+	/**
+	 * An `interrupt()` the CLI refuses, recorded the same way a refused `setModel` is. The SDK's own
+	 * rejection carries no account of why (`sdk.d.ts`, `Query.interrupt`), which is what makes the
+	 * layer's reading of its own turn state the input the fold routes on (ADR 0356).
+	 */
+	readonly interruptFails?: Error;
 }
 
 export const scriptedQuery = (
@@ -176,6 +182,7 @@ export const scriptedQuery = (
 		initializationResult: () => handshake,
 		interrupt: async () => {
 			record.interrupts += 1;
+			if (behaviour.interruptFails !== undefined) throw behaviour.interruptFails;
 			return undefined;
 		},
 		setPermissionMode: async (mode: PermissionMode) => {

--- a/apps/tuval/src/claude/agent/interrupt-refusal.unit.test.ts
+++ b/apps/tuval/src/claude/agent/interrupt-refusal.unit.test.ts
@@ -1,0 +1,97 @@
+/**
+ * A Claude abort the CLI would not take, over the layer's real event path (#8007, ADR 0356).
+ *
+ * `interrupt` declares no error channel, so the refusal has one way out of this layer — the event
+ * stream — and this is the test that the way out is taken. Before ADR 0356 it was a log line, and
+ * the window went on showing an abort in flight that the backend had already declined.
+ *
+ * Which of the two reasons it carries is the half only this layer can answer: `interruptFailureOf`
+ * reads `TurnState.settled`, so a refusal with the turn still going is `turn-running` and one after
+ * its `result` is `no-live-turn`. The fold routes on that field alone, so both run below.
+ *
+ * Limits of the proof: the SDK is scripted, so what is exercised is the mapping from a rejected
+ * `Query.interrupt()` to the event the core folds — not the real CLI's abort timing, and not the
+ * conditions under which a real CLI refuses one.
+ */
+
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Stream} from "effect";
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {CWD, messages, on, START_EVENTS} from "./fixtures/harness.ts";
+
+const REFUSAL = new Error("Operation aborted");
+
+/** The captured turn with its `result` withheld, which is a turn the CLI is still running. */
+const unfinishedTurn = (): ReadonlyArray<SDKMessage> =>
+	messages("assistant-turn").filter((message) => message.type !== "result");
+
+const interruptFailure = (
+	events: ReadonlyArray<AgentEvent>,
+): Extract<AgentEvent, {kind: "failure"}>["failure"] => {
+	const failed = events.filter((event) => event.kind === "failure");
+	assert.lengthOf(
+		failed,
+		1,
+		`the refusal did not reach the event stream: ${JSON.stringify(events)}`,
+	);
+	const one = failed[0];
+	assert.isTrue(one?.kind === "failure");
+	return (one as Extract<AgentEvent, {kind: "failure"}>).failure;
+};
+
+/**
+ * Start, let the open's own events go by, prompt, drain what `opening` produced, then ask for the
+ * abort the scripted SDK refuses and read the events that follow it.
+ */
+const refusedInterrupt = (opening: ReadonlyArray<SDKMessage>, turnEvents: number) =>
+	on({opening, deferOpening: true, interruptFails: REFUSAL}, (agent, scripted) =>
+		Effect.gen(function* () {
+			yield* agent.start({cwd: CWD});
+			yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+			yield* agent.prompt("hello");
+			yield* Stream.runCollect(Stream.take(agent.events, turnEvents));
+			yield* agent.interrupt;
+			const after = [...(yield* Stream.runCollect(Stream.take(agent.events, 1)))];
+			return {after, interrupts: scripted.opened[0]?.record.interrupts ?? 0};
+		}),
+	);
+
+/** `assistant-turn` minus its `result`: the send's own `prompting`, the model init, the reply. */
+const RUNNING_TURN_EVENTS = 3;
+/** The whole of it, `result` included — the turn's spend and the `ready` that ends it. */
+const FINISHED_TURN_EVENTS = 5;
+
+describe("a Claude interrupt the CLI refuses", () => {
+	it.effect("reaches the core as its own failure tag rather than a log line", () =>
+		Effect.gen(function* () {
+			const {after, interrupts} = yield* refusedInterrupt(unfinishedTurn(), RUNNING_TURN_EVENTS);
+			const failure = interruptFailure(after);
+			assert.strictEqual(interrupts, 1, "the layer reported a refusal it never asked for");
+			assert.strictEqual(failure.tag, "tuval/ai-agent/InterruptError");
+			assert.strictEqual(failure.reason, "turn-running");
+			assert.include(failure.detail, "did not answer the control request");
+		}),
+	);
+
+	// A refusal is not a turn ending: nothing the layer emits for it may read as one, because the
+	// phase is what the window's stop control and its Escape branch key on.
+	it.effect("narrates no phase change of its own", () =>
+		Effect.gen(function* () {
+			const {after} = yield* refusedInterrupt(unfinishedTurn(), RUNNING_TURN_EVENTS);
+			assert.isEmpty(
+				after.filter((event) => event.kind === "phase"),
+				"the refusal narrated a phase the backend never entered",
+			);
+		}),
+	);
+
+	// The other half the fold routes on: the turn ended while the control request was in flight, so
+	// there was nothing left to stop and the session is owed its way back to `ready`.
+	it.effect("says there was no live turn once the result has landed", () =>
+		Effect.gen(function* () {
+			const {after} = yield* refusedInterrupt(messages("assistant-turn"), FINISHED_TURN_EVENTS);
+			assert.strictEqual(interruptFailure(after).reason, "no-live-turn");
+		}),
+	);
+});

--- a/apps/tuval/src/claude/agent/phases.unit.test.ts
+++ b/apps/tuval/src/claude/agent/phases.unit.test.ts
@@ -117,10 +117,10 @@ describe("a turn ends on its result", () => {
 });
 
 /**
- * Claude's half of #8007. The layer's `interrupt` declares no error channel and logs a refused
- * one, so nothing about the abort itself reaches the core — the confirming event is the turn's own
- * `result`, which the pump emits `ready` for on every subtype including the errors an aborted turn
- * ends on.
+ * Claude's half of #8007, on the path where the CLI takes the abort: the confirming event is the
+ * turn's own `result`, which the pump emits `ready` for on every subtype including the errors an
+ * aborted turn ends on. A refused one is a failure event of its own and reads in
+ * `interrupt-refusal.unit.test.ts` (ADR 0356).
  */
 describe("an interruption over the Claude event path", () => {
 	const asked = (

--- a/apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts
@@ -1,0 +1,168 @@
+/**
+ * A Pi abort the server would not take, over the layer's real event path (#8007, ADR 0356).
+ *
+ * The same contract the Claude layer owes, proved separately because the two answer it from
+ * different places: Pi's refusal says nothing about the turn, so `turnRunning` comes off the
+ * layer's own session projection rather than off a turn-state flag. A layer that read that wrong
+ * would send the fold to the other arm and walk a running turn to `ready`.
+ *
+ * Limits of the proof: the server is a stub, so what runs is the mapping from a refused
+ * `PiClientService.abort` to the event the core folds — not a real Pi abort, and not the conditions
+ * under which a real server refuses one.
+ */
+
+import type {SessionSnapshot} from "@earendil-works/pi-protocol";
+import {assert, describe, it} from "@effect/vitest";
+import {type Cause, Deferred, Effect, Layer, Option, Queue, Stream} from "effect";
+import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
+import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {
+	type PiClientApi,
+	PiClientService,
+	type PiSessionRef,
+	SessionLocked,
+} from "../client/index.ts";
+import {aiAgentOverClient} from "./PiAiAgent.ts";
+
+const CWD = "/tuval/interrupt-refusal";
+const SESSION: PiSessionRef = {
+	id: "session-8007",
+	cwd: CWD,
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+};
+
+const snapshot = (phase: SessionSnapshot["phase"], revision: number): SessionSnapshot => ({
+	id: SESSION.id,
+	cwd: CWD,
+	createdAt: 0,
+	updatedAt: 0,
+	phase,
+	model: SESSION.model,
+	thinkingLevel: "off",
+	attached: true,
+	locked: true,
+	revision,
+	transcript: [],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+/** The stub server: a snapshot stream the test feeds, a `prompt` it settles, an `abort` that says no. */
+const stub = Effect.gen(function* () {
+	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const ended = yield* Deferred.make<SessionSnapshot>();
+	const api: PiClientApi = {
+		connect: Effect.void,
+		reconnect: Effect.void,
+		connected: Effect.succeed(true),
+		createSession: () => Effect.succeed(SESSION),
+		attachSession: () => Effect.succeed(SESSION),
+		heldSnapshot: () => Effect.succeed(snapshot("idle", 0)),
+		prompt: () => Deferred.await(ended),
+		abort: () =>
+			Effect.fail(new SessionLocked({sessionId: SESSION.id, detail: "the session is not yours"})),
+		setModel: () => Effect.never,
+		setThinkingLevel: () => Effect.never,
+		models: Effect.succeed([]),
+		snapshots: () => Stream.fromQueue(pushes),
+		disconnections: Stream.never,
+	};
+	return {
+		layer: Layer.succeed(PiClientService, api),
+		endTurn: (value: SessionSnapshot) => Deferred.succeed(ended, value),
+	};
+});
+
+type Events = Queue.Dequeue<AgentEvent, TransportError | Cause.Done>;
+
+/** Every event up to and including the first one `found` accepts, bounded so a miss names itself. */
+const collectTo = (events: Events, what: string, found: (event: AgentEvent) => boolean) =>
+	Effect.gen(function* () {
+		const seen: Array<AgentEvent> = [];
+		while (true) {
+			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("5 seconds"));
+			if (Option.isNone(next)) {
+				assert.fail(`timed out waiting for ${what}; saw ${JSON.stringify(seen)}`);
+			}
+			seen.push(next.value);
+			if (found(next.value)) return seen;
+		}
+	});
+
+const isReady = (event: AgentEvent): boolean => event.kind === "phase" && event.phase === "ready";
+const isPrompting = (event: AgentEvent): boolean =>
+	event.kind === "phase" && event.phase === "prompting";
+const isFailure = (event: AgentEvent): boolean => event.kind === "failure";
+
+const failureOf = (events: ReadonlyArray<AgentEvent>) => {
+	const one = events.at(-1);
+	assert.isTrue(one?.kind === "failure", "the last event collected is not the refusal");
+	return (one as Extract<AgentEvent, {kind: "failure"}>).failure;
+};
+
+describe("a Pi abort the server refuses", () => {
+	it.live("rides the event stream as its own failure tag while the turn is still running", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("say hello");
+				yield* collectTo(events, "the turn's prompting", isPrompting);
+				yield* agent.interrupt;
+
+				const failure = failureOf(yield* collectTo(events, "the refused abort", isFailure));
+				assert.strictEqual(failure.tag, "tuval/ai-agent/InterruptError");
+				assert.strictEqual(failure.reason, "turn-running");
+				assert.include(failure.detail, "the session is not yours");
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	// Nothing was running, so the refusal is the server saying there is no turn to stop — the arm
+	// the fold walks back to `ready`, and the one that unfroze the founder's desk on 2026-09-05.
+	it.live("says there was no live turn when the session is not on one", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.interrupt;
+				const failure = failureOf(yield* collectTo(events, "the refused abort", isFailure));
+				assert.strictEqual(failure.reason, "no-live-turn");
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	// The refusal is an event, never the end of the stream: the session is still there and every
+	// later turn still has to reach the window.
+	it.live("leaves the stream open, so the turn it would not stop still ends on it", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("say hello");
+				yield* collectTo(events, "the turn's prompting", isPrompting);
+				yield* agent.interrupt;
+				yield* collectTo(events, "the refused abort", isFailure);
+
+				yield* client.endTurn(snapshot("idle", 2));
+				yield* collectTo(events, "the turn's own end", isReady);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+});

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -55,7 +55,7 @@ import {tuvalDesignTranslate} from "./copy.ts";
 import {ModeSwitch} from "./ModeSwitch.tsx";
 import {dropSend, holdSend, readHeld, recoverInto} from "./outgoing.ts";
 import {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
-import {interruptionGraceMillis, isWorking, statusLine} from "./phase.ts";
+import {interruptionGraceMillis, isWorking, statusLine, workingTell} from "./phase.ts";
 import {QueuedMessages} from "./QueuedMessages.tsx";
 import {
 	type ChatRow,
@@ -1069,7 +1069,12 @@ function ChatWindow({
 							<span />
 							<span />
 						</span>
-						{interruption === null ? "Working…" : "Interrupting…"}
+						{workingTell({
+							phase,
+							failure: state?.failure ?? null,
+							interruption,
+							now: options.now(),
+						})}
 					</p>
 				) : null}
 				<PermissionCards permissions={process.state.permissions} onAnswer={answerPermission} />

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -958,6 +958,33 @@ describe("the composer", () => {
 		expect(phaseLine().textContent).not.toContain("Ready");
 	});
 
+	// The bar and the tell render together, so they have to say one thing: a refusal the bar names
+	// while the tell still claims an abort is in flight reads as an abort the backend has not
+	// answered, which is the case ADR 0356 exists to tell apart.
+	it("says a refused interrupt was refused, in the bar and in the tell alike", async () => {
+		const {process} = await openWindow(withTranscript(transcriptOf(2), {phase: "prompting"}));
+		await act(async () => {
+			await Effect.runPromise(
+				process.commit(
+					withTranscript(transcriptOf(2), {
+						phase: "prompting",
+						interruption: {requestedAt: SENT_AT},
+						failure: {
+							tag: "tuval/ai-agent/InterruptError",
+							reason: "turn-running",
+							detail: "the agent transport failed (refused): Operation aborted",
+						},
+					}),
+				),
+			);
+		});
+		await waitFor(() => expect(phaseLine().textContent).toContain("refused to stop"));
+		expect(phaseLine().textContent).not.toContain("has not confirmed");
+		const tell = document.querySelector(".tuval-chat-working");
+		expect(tell?.textContent).toContain("refused");
+		expect(tell?.textContent).not.toBe("Interrupting…");
+	});
+
 	it("restores the draft the window was left with", async () => {
 		await openWindow(
 			withTranscript(transcriptOf(2)),

--- a/apps/tuval/src/shell/chat/phase.ts
+++ b/apps/tuval/src/shell/chat/phase.ts
@@ -105,3 +105,18 @@ export const statusLine = (status: Status): string => {
  * this, and so does the phase line's own status role.
  */
 export const isWorking = (phase: Phase): boolean => phase === "prompting";
+
+/**
+ * The word under the transcript while a turn runs — the visual tell, not the announced surface.
+ *
+ * It reads the same three states `statusLine` does, off the same `Status`, because the two rendered
+ * side by side are one readout: a tell still saying "Interrupting…" beside a bar saying the agent
+ * refused to stop tells the operator an abort is in flight that the backend has already declined
+ * (#8007). The full sentence stays on the bar; this is the tail's short form of it.
+ */
+export const workingTell = (status: Status): string => {
+	if (status.phase === "prompting" && status.failure?.tag === INTERRUPT_ERROR) {
+		return "Interrupt refused — still working…";
+	}
+	return status.interruption === null ? "Working…" : "Interrupting…";
+};

--- a/apps/tuval/src/shell/chat/phase.unit.test.ts
+++ b/apps/tuval/src/shell/chat/phase.unit.test.ts
@@ -9,7 +9,7 @@
 import {describe, expect, it} from "vitest";
 import type {AgentFailure} from "../../ai-agent/core/index.ts";
 import type {Phase} from "../../ai-agent/events.ts";
-import {interruptionGraceMillis, isWorking, phaseLines, statusLine} from "./phase.ts";
+import {interruptionGraceMillis, isWorking, phaseLines, statusLine, workingTell} from "./phase.ts";
 
 const startFailure = (detail: string, reason: string): AgentFailure => ({
 	tag: "tuval/ai-agent/StartError",
@@ -142,5 +142,44 @@ describe("the status line", () => {
 			"gone",
 		];
 		expect(phases.filter(isWorking)).toEqual(["prompting"]);
+	});
+});
+
+/**
+ * The tell under the transcript, which renders beside the bar while a turn runs. The two are read
+ * as one readout, so a refusal the bar names has to reach this word too (#8007).
+ */
+describe("the working tell", () => {
+	const refused: AgentFailure = {
+		tag: "tuval/ai-agent/InterruptError",
+		reason: "turn-running",
+		detail: "the agent transport failed (refused): Operation aborted",
+	};
+
+	const tellOf = (failure: AgentFailure | null, interruption: number | null): string =>
+		workingTell({
+			phase: "prompting",
+			failure,
+			interruption: interruption === null ? null : {requestedAt: interruption},
+			now: NOW,
+		});
+
+	it("says the turn is working while no abort has been asked for", () => {
+		expect(tellOf(null, null)).toBe("Working…");
+	});
+
+	it("says an unanswered abort is interrupting", () => {
+		expect(tellOf(null, NOW)).toBe("Interrupting…");
+	});
+
+	// The contradiction this closes: the bar said the agent refused to stop while this word still
+	// claimed an abort was in flight.
+	it("stops claiming an abort is in flight once the agent has refused it", () => {
+		expect(tellOf(refused, NOW)).toContain("refused");
+		expect(tellOf(refused, NOW)).not.toBe("Interrupting…");
+	});
+
+	it("is not read by a failure about some other act", () => {
+		expect(tellOf(startFailure("the call did not answer", "transport"), NOW)).toBe("Interrupting…");
 	});
 });


### PR DESCRIPTION
Fixes #8007.

The last of it: a backend that answers an abort by refusing now reads as a refusal everywhere the
window says anything about the turn, and both layers' refusal paths have deterministic tests.

Most of the issue landed already, and this states which file proves each part rather than rebuilding
it:

- [x] **Requesting interruption does not by itself move a process to ready.** Landed in #8080 — the
  `interrupt` cell in `apps/tuval/src/ai-agent/core/machine.ts` records `Interruption{requestedAt}`
  and holds the phase at `prompting`; `interruptionAfter` in `apps/tuval/src/ai-agent/core/fold.ts`
  settles it only when the session leaves the turn.
- [x] **Delayed abort visibly outstanding; a known refusal visible as a refusal; never as
  completion.** The outstanding and unknown-outcome copy landed in #8080, the refusal line in #8507
  (ADR 0356). What was still wrong is in this PR: the tell under the transcript
  (`apps/tuval/src/shell/chat/ChatWindow.tsx`) hard-coded `Interrupting…` off the interruption alone,
  so it went on claiming an abort was in flight beside a bar already saying the agent had refused it.
  Both now read the same `Status` through `workingTell` in `apps/tuval/src/shell/chat/phase.ts`.
- [x] **A confirmed return to ready takes a later deliberate prompt and sends nothing on its own.**
  Landed in #8080 — `apps/tuval/src/ai-agent/core/machine.unit.test.ts`, "takes a deliberate prompt
  once the confirmation landed, and sends nothing on its own".
- [x] **Deterministic tests for delayed confirmation, refusal, eventual readiness and late events,
  per layer.** Delayed/eventual/late landed in #8080 and the fold's refusal arms in #8507. The
  refusal was untested at either layer, because until #8507 neither layer emitted one. Added here:
  `apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts` and
  `apps/tuval/src/claude/agent/interrupt-refusal.unit.test.ts`, each driving its real layer over a
  refusing backend and reading the failure event off the layer's own stream — including the
  `turn-running` / `no-live-turn` split, which the two layers answer from different places.
- [x] **Does the backend-blind interface support this?** Yes for readiness confirmation (#8080's
  answer, unchanged). No for showing a refusal, which is why ADR 0356 put the refusal on the event
  stream as `InterruptError` rather than widening `interrupt`'s signature; it is still
  `Effect.Effect<void>` and no Claude-specific method exists.
- [x] **Interruption destroys nothing.** Landed in #8080 —
  `apps/tuval/src/ai-agent/core/machine.unit.test.ts`, "asks for the turn only, leaving the session
  and its history alone". Nothing here touches session lifetime.

**The grace window is still a guess, and stays one.** `interruptionGraceMillis` is 5 s. I looked for
something to ground it in — the SDK documents no control-request timeout for `Query.interrupt()`, and
its rejection carries no timing — so grounding it needs a timed real CLI abort, which no scripted
test can produce. It is named as a working guess at its definition and here.

**Limits of the scripted proof**, restated because the criterion asks for them: every test is
scripted or golden-fixture. The Claude case replays a captured turn through a scripted SDK whose
`interrupt()` rejects; the Pi case runs the real mapping layer over a stub server whose `abort`
refuses. What is proved is the mapping and the fold, not the backends' real abort timing and not the
conditions under which a real backend refuses.

## Deviations

- **Out-of-scope change** — **Said:** #8007's criteria are about the phase line's copy and state.
  **Did:** also changed the transcript-tail tell in `ChatWindow.tsx`. **Why:** the two render side by
  side and are read as one readout — a tell saying `Interrupting…` beside a bar saying the agent
  refused to stop is the "presented as something it is not" the criterion forbids.
  **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** add tests. **Did:** also added an
  `interruptFails` knob to the scripted Claude SDK (`fixtures/scripted-query.ts`, `fixtures/harness.ts`)
  and corrected two stale comments in `phases.unit.test.ts` and `machine.unit.test.ts` that still said
  a refused abort is only logged. **Why:** the knob is the only way to script a refusal at that seam,
  and the comments describe behaviour ADR 0356 replaced. **Disposition:** stated here.
