### PR TITLE
fix: A Tuval handler's services depend on which fiber dispatched, so the picker's ProcessPorts omit is not sealed

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -35,35 +35,58 @@ close over them; it declares them as its `R` instead, and the spawner provides t
 ```ts
 // src/boot.ts
 const launched = yield* launch(compiled, wiring, {services: kernel}).pipe(
-  Effect.provideContext(kernel),
+  Effect.provideContext(spawnerNeeds),
 );
 ```
 
 `launch` merges that context into each spawn's `SpawnOptions.services` beside the node's own
 `ProcessPorts`. `SpawnOptions.services` is the only seam a program row's requirements can arrive
 through, and handing them over is a wiring decision rather than a capability grant — local program
-code is fully trusted, there is no sandbox (#7484 R1.1).
+code is fully trusted, there is no sandbox (#7484 R1.1). The `provideContext` above is `launch`'s
+own `R` and not a second route to a handler: what a spawner is *called* under reaches nothing it
+spawns.
 
-**Two of the three spawners hand that same kernel context over, so a program a picker may open may
-require kernel services** (#7951). `start` passes it to `restore` for the checkpointed processes the
-graph did not plan (`src/boot.ts`); the picker passes on the context its own shell process was
-launched with (`src/shell/picker/open.ts`). The third does not: the `process spawn` spell hands its
-child `Context.make(ProcessPorts, ports)` and nothing else (`src/commands/core/process.ts`), so under
-the spawner an agent program itself reaches for, a row needing a kernel service still dies at its
-handler.
+**The spawn set is exactly what a handler resolves, and that is enforced** (#7972). `toDefinition`
+runs every command and sub handler under `Effect.updateContext(() => handlerServices)`, which sets
+the fiber's context outright, rather than under `Effect.provideContext(handlerServices)`, which
+merges over whatever the fiber that dispatched happened to carry (rc.112,
+`src/internal/effect.ts:2197`). Two things follow, and both used to be false:
 
-`ProcessPorts` is the one service those first two refuse to pass down — a port binding emits from one
-node, so a child holding its spawner's would emit out of the wrong one — and they refuse it
-differently. `restore` merges an `unwired` `ProcessPorts` in second, so a restored process has one
-and an emit fails `PortNotWired` where the graph owns no route (#7789). The picker only removes the
-service (`Context.omit(ProcessPorts)`), and `Processes.spawn` puts back only `ProcessSelf`, so a
-picker-opened process is spawned with no `ProcessPorts` at all. `src/demo/counter.ts` is the example
-under both: its `announce` handler wants `ProcessPorts`, which comes back un-wired under `restore`
-and is absent from the spawn context under the picker.
+- **A removal is a removal.** The picker's `Context.omit(ProcessPorts)` really does keep the shell's
+  ports out of the child, including when the shell forwards a key into it from its own handler fiber
+  — the path that made the guard a no-op.
+- **The two dispatch paths agree.** `handle.dispatch` runs on the caller's fiber and a follow-up Msg
+  runs on a forked one with no ambient (`src/host/actor.ts`), so before the seal a handler could
+  resolve a service on one and not the other, and a proof written over the wrong fiber passed for
+  the wrong reason.
+
+Effect's own runtime rides through the seal — the clock, the scheduler, the loggers and log level,
+the tracer and its parent span, and the `Scope` a sub handler is given, every one of them keyed
+`effect/…` and re-derived by `FiberImpl.setContext` on each replace (rc.112,
+`src/internal/effect.ts:709`). Everything else is the spawn set's alone.
+
+**So every spawner names what it passes.** `start` hands `restore` the kernel as its `services`
+argument, and that argument is now the single route (`src/boot.ts`); the picker passes on the
+context its own shell process was launched with (`src/shell/picker/open.ts`); and the `process spawn`
+spell reads its own caller's context and passes that on beside the child's ports
+(`src/commands/core/process.ts`) — it used to hand over `Context.make(ProcessPorts, ports)` and let
+the merge cover the rest, which under the seal would have left an agent-spawned row dead at its
+first kernel call.
+
+`ProcessPorts` is the one service no spawner passes down — a port binding emits from one node, so a
+child holding its spawner's would emit out of the wrong one — and all three replace it the same way:
+an `unwired` pair keyed to the child's own id, so the process has ports and an emit fails
+`PortNotWired` where the graph owns no route to bind (#7789). `restore` merges one in second; the
+picker removes the spawner's (`Context.omit(ProcessPorts)`) and adds the child's, minting the process
+id a call early so the ports know which node they are. Under the seal it has to: a row declaring
+`ProcessPorts` has nothing to fall back on, and before the seal it silently fell back on the shell's
+(#7972). `src/demo/counter.ts` is the example under both — its `announce` handler wants
+`ProcessPorts` and gets an un-wired pair either way.
 
 **Nothing checks the pairing, so the failure is at the handler.** `SpawnOptions.services` is typed
 `Context.Context<never>`, which every context satisfies, so a row asking for a service its spawner
-does not hold spawns fine and dies on the first handler that reaches for it. Where the requirement is
+does not hold spawns fine and dies on the first handler that reaches for it — deterministically now,
+whichever fiber dispatched. Where the requirement is
 visible is the row's own type: `aiAgentProgram` is generic over the leftover requirement of the layer
 it is handed (`src/ai-agent/program.ts`), so an agent row over a layer that still needs `SpellBridge`
 says `SpellBridge` on its services rather than closing it.

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -47,10 +47,11 @@ own `R` and not a second route to a handler: what a spawner is *called* under re
 spawns.
 
 **The spawn set is exactly what a handler resolves, and that is enforced** (#7972). `toDefinition`
-runs every command and sub handler under `Effect.updateContext(() => handlerServices)`, which sets
-the fiber's context outright, rather than under `Effect.provideContext(handlerServices)`, which
-merges over whatever the fiber that dispatched happened to carry (rc.112,
-`src/internal/effect.ts:2197`). Two things follow, and both used to be false:
+runs every command and sub handler under an `Effect.updateContext`, which sets the fiber's context
+outright, rather than under `Effect.provideContext(handlerServices)`, which merges over whatever the
+fiber that dispatched happened to carry (rc.112, `src/internal/effect.ts:2197`). What it sets is the
+spawn set over the ambient's `effect/…` keys and nothing else — the paragraph below says why those
+ride through. Two things follow, and both used to be false:
 
 - **A removal is a removal.** The picker's `Context.omit(ProcessPorts)` really does keep the shell's
   ports out of the child, including when the shell forwards a key into it from its own handler fiber
@@ -74,14 +75,18 @@ the merge cover the rest, which under the seal would have left an agent-spawned 
 first kernel call.
 
 `ProcessPorts` is the one service no spawner passes down — a port binding emits from one node, so a
-child holding its spawner's would emit out of the wrong one — and all three replace it the same way:
-an `unwired` pair keyed to the child's own id, so the process has ports and an emit fails
-`PortNotWired` where the graph owns no route to bind (#7789). `restore` merges one in second; the
-picker removes the spawner's (`Context.omit(ProcessPorts)`) and adds the child's, minting the process
-id a call early so the ports know which node they are. Under the seal it has to: a row declaring
-`ProcessPorts` has nothing to fall back on, and before the seal it silently fell back on the shell's
-(#7972). `src/demo/counter.ts` is the example under both — its `announce` handler wants
-`ProcessPorts` and gets an un-wired pair either way.
+child holding its spawner's would emit out of the wrong one. Every spawner replaces it with a pair
+keyed to the child's own id, and **what that pair can do differs by who owns a route to the child**.
+`launch` binds the node's to the graph's wiring, and the `process spawn` spell mints outbox-latch
+ports (`ProcessPorts.of({emit: emitter(id, row, outboxes)})`), because the spell itself is the
+route — that is what a later `read` on the spawned process takes from. `restore` and the picker have
+no route to bind, so both mint an `unwired` pair: the process has ports, and an emit fails
+`PortNotWired` naming the port rather than dropping the payload (#7789). `restore` merges one in
+second; the picker removes the spawner's (`Context.omit(ProcessPorts)`) and adds the child's,
+minting the process id a call early so the ports know which node they are. Under the seal it has to:
+a row declaring `ProcessPorts` has nothing to fall back on, and before the seal it silently fell back
+on the shell's (#7972). `src/demo/counter.ts` is the example under those two — its `announce` handler
+wants `ProcessPorts` and gets an un-wired pair either way.
 
 **Nothing checks the pairing, so the failure is at the handler.** `SpawnOptions.services` is typed
 `Context.Context<never>`, which every context satisfies, so a row asking for a service its spawner

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -136,15 +136,21 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	// layer inside the merge above would be asking for itself.
 	const listing = Context.add(built, AiAgentSessionList, aiAgentSessionListKernel(built));
 	const kernel = Context.add(listing, AiAgentTranscripts, aiAgentTranscriptsKernel(listing));
+	// The kernel reaches a process's handlers on one route only, the `services` argument: a handler
+	// is sealed to its spawn set, so the ambient a spawner is called under can no longer stand in
+	// for a `services` that forgot something (#7972). What each spawner is *called* under is
+	// therefore its own `R` and nothing more — the four services `launch` and `restore` name for
+	// themselves, not the kernel a second time.
+	const spawnerNeeds = Context.pick(Checkpoints, Processes, ProcessTable, Registry)(kernel);
 	// The kernel rides into every launched process's handlers: the shell row's Cmds spawn programs
 	// and read the process table, and a program row declares exactly those needs as its `R`.
 	const launched = yield* launch(compiled, wiring, {services: kernel}).pipe(
-		Effect.provideContext(kernel),
+		Effect.provideContext(spawnerNeeds),
 	);
 	// The same kernel a launched process gets, so a row's `R` is satisfied whichever spawner brings
 	// it up (#7951). What still differs is the ports: the graph does not own a restored process, so
 	// restore builds it an un-wired `ProcessPorts` of its own (#7789).
-	const restored = yield* restore(kernel).pipe(Effect.provideContext(kernel));
+	const restored = yield* restore(kernel).pipe(Effect.provideContext(spawnerNeeds));
 	return {kernel, launched, restored} satisfies Started;
 });
 

--- a/apps/tuval/src/commands/agent-proof.unit.test.ts
+++ b/apps/tuval/src/commands/agent-proof.unit.test.ts
@@ -368,11 +368,11 @@ const runAgent = Effect.gen(function* () {
 	const rows = [agentProgram(done), echoProgram()];
 	return yield* Effect.gen(function* () {
 		const processes = yield* Processes;
-		const executor = yield* SpellExecutor;
-		const agent = yield* processes.spawn(agentId, {
-			id: agentProcess,
-			services: Context.make(SpellExecutor, executor),
-		});
+		// The whole app context is the spawn set, because that is what the agent's handlers reach for
+		// and a handler resolves its spawn set alone (#7972). `SpellExecutor` alone used to be enough
+		// here only because the rest — `SpellRegistry`, `SpawnedProcesses` — rode in off this fiber.
+		const kernel = yield* Effect.context<never>();
+		const agent = yield* processes.spawn(agentId, {id: agentProcess, services: kernel});
 		yield* agent.dispatch({type: "begin"});
 		const {transcript, unsettled} = yield* Deferred.await(done);
 		const rowsInRegistry = yield* SpellRegistry.use((registry) => registry.list);
@@ -587,9 +587,12 @@ const runServiceAgent = Effect.gen(function* () {
 		const rowsInRegistry = yield* SpellRegistry.use((registry) => registry.list);
 		const bridge = yield* Effect.provide(SpellBridge, SpellBridge.layer({allow: everyRegistered}));
 		yield* Deferred.succeed(latch, bridge);
+		// Same as above: everything the bridge's `call` reaches through — the executor and the
+		// registry it reads at call time — is named on the spawn rather than left to the fiber (#7972).
+		const kernel = yield* Effect.context<never>();
 		const agent = yield* processes.spawn(serviceAgentId, {
 			id: serviceProcess,
-			services: Context.make(ProcessPorts, {
+			services: Context.add(kernel, ProcessPorts, {
 				emit: (port: string, payload: unknown) =>
 					Effect.sync(() => {
 						emitted.push({port, payload});

--- a/apps/tuval/src/commands/core/process.ts
+++ b/apps/tuval/src/commands/core/process.ts
@@ -211,11 +211,17 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 		}
 		const ports = ProcessPorts.of({emit: emitter(id, row, outboxes)});
 
+		// The spawn set is stated here in full, because it is all the child's handlers will resolve
+		// (#7972). `Effect.context()` is this caller's own — the spell fiber's, which is the kernel
+		// one an executor runs a spell under — so a spawned row's `R` is satisfied the same way the
+		// picker satisfies a window's (`../../shell/picker/open.ts`), and the ports below are the
+		// one thing minted for the child rather than passed on.
+		const inherited = yield* Effect.context<never>();
 		const handle = yield* processes
 			.spawn(program, {
 				id,
 				...(Option.isSome(parent) ? {parent: parent.value} : {}),
-				services: Context.make(ProcessPorts, ports),
+				services: Context.add(inherited, ProcessPorts, ports),
 			})
 			.pipe(
 				Effect.catchTag("tuval/ProgramNotFound", () => Effect.fail(new UnknownProgram({program}))),

--- a/apps/tuval/src/durability/boot-restore-context.unit.test.ts
+++ b/apps/tuval/src/durability/boot-restore-context.unit.test.ts
@@ -10,12 +10,12 @@
  * `Processes`, `ProcessTable`, `Registry`) — narrow the context `boot.ts` restores under and the
  * second boot dies with `Service not found: tuval/SpellBridge`.
  *
- * The narrowing has to be of both routes at once, because `boot.ts` carries the kernel on two:
- * `restore`'s `services` argument, and the ambient `Effect.provideContext(kernel)` around the call.
- * `Effect.provideContext` merges into the fiber's context rather than replacing it
- * (`effect` `src/internal/effect.ts`'s `provideContext`, `updateContext(self, Context.merge(…))`),
- * so a handler that misses the argument still resolves off the ambient and each route masks the
- * other. That a spawner's `services` is a floor rather than the set is #7972's, not this test's.
+ * The narrowing is of `restore`'s `services` argument, and of nothing else, because that argument
+ * is the only route the kernel has into a restored process's handlers: a handler is sealed to its
+ * spawn set (#7972), and `boot.ts` no longer calls `restore` under the kernel as an ambient too.
+ * It used to be both, and each route masked the other — `Effect.provideContext` merges into the
+ * fiber's context rather than replacing it — so this proof could only red against a narrowing of
+ * the two at once, and could not say which one `boot.ts` had got wrong.
  */
 
 import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
@@ -58,8 +58,8 @@ const handleOf = (id: ProcessId) =>
 /**
  * The first boot: nothing is planned and nothing is checkpointed, so the probe is spawned the way
  * the picker spawns one — under no node — and marked twice, which is the state the next boot has
- * to find. Its handler is never reached here: `SpawnedProcesses` hands a spawn its ports and
- * nothing else, so `mark` is deliberately a Msg that emits no Cmd.
+ * to find. Its handler is never reached here, because `mark` is deliberately a Msg that emits no
+ * Cmd: what this boot has to leave behind is a checkpoint, not a resolved service.
  */
 const firstBoot = (project: string) =>
 	Effect.gen(function* () {

--- a/apps/tuval/src/durability/restore.ts
+++ b/apps/tuval/src/durability/restore.ts
@@ -20,7 +20,8 @@ import {dispatchResume} from "./resume.ts";
  * An entry already live — a planned process the launcher spawned back at its own id
  * (`src/launch/`) — is already restored, so it is left alone.
  *
- * `services` is the caller's ambient context for every process this brings back; each spawn also
+ * `services` is the whole set every process this brings back will resolve — a handler is sealed to
+ * its spawn set, so nothing reaches it off the fiber this call runs on (#7972). Each spawn also
  * gets a `ProcessPorts` of its own. What the graph does not own has no route to bind, so those
  * ports are `unwired`: the process comes back either way, and an emit fails `PortNotWired` at the
  * first call rather than dropping the payload (#7789).

--- a/apps/tuval/src/process/Processes.ts
+++ b/apps/tuval/src/process/Processes.ts
@@ -35,7 +35,10 @@ export interface SpawnOptions {
 	/** Restore's: the id the process was checkpointed under. A fresh spawn mints its own. */
 	readonly id?: ProcessId;
 	/**
-	 * Provided to this process's handlers: the services its program's `R` names, per process.
+	 * Exactly what this process's handlers resolve: the services its program's `R` names, per
+	 * process. Not a floor — a handler is sealed to this set, so a service the fiber that
+	 * dispatched holds and this set does not is not resolvable inside the handler (#7972). A
+	 * spawner that wants to pass its own context on says so, the way `shell/picker/open.ts` does.
 	 * Never optional — a spawner with nothing to give says so with `Context.empty()`. Omission
 	 * used to be silent, and `restore` took it, so a restored process's first handler died on a
 	 * missing service one boot later (#7789).
@@ -113,6 +116,40 @@ type ErasedDefinition = ActorDefinition<
 	ErasedSubscribe
 >;
 
+/**
+ * Every key effect keeps its own runtime under is namespaced `effect/…` — the clock, the scheduler
+ * and its yield knobs, the loggers and log level, the tracer and its parent span, and `Scope`
+ * (rc.112: `Context.Reference("effect/Clock")` and friends in `src/internal/effect.ts`,
+ * `src/Scheduler.ts`, `src/Tracer.ts`, `src/Scope.ts`). Tuval's own services are namespaced
+ * `tuval/…` by `Context.Service`, so the prefix is the line between "what a spawner grants" and
+ * "how the fiber runs".
+ */
+const EFFECT_RUNTIME_PREFIX = "effect/";
+
+/**
+ * The seal: a handler resolves exactly the set its spawn was given, never that set merged over
+ * whatever the fiber that dispatched happened to carry (#7972). `Effect.provideContext` is
+ * `updateContext(self, Context.merge(context))` (rc.112, `src/internal/effect.ts:2197`), which
+ * makes the spawn set a floor; `Effect.updateContext` sets the fiber context outright at the same
+ * seam and restores it on exit (rc.112, `src/internal/effect.ts:2073`).
+ *
+ * effect's own runtime rides through, because `FiberImpl.setContext` re-derives the scheduler,
+ * clock, log level, stack frame, tracer and parent span from the context on every replace (rc.112,
+ * `src/internal/effect.ts:709`): dropping those would silently reset a handler's clock and logger
+ * to the process defaults, and would take a sub handler's `Scope` — the one the host forks for it
+ * (`../host/actor.ts`) — with them. Everything the runtime does not own is the spawn set's alone.
+ */
+const sealed =
+	(services: Context.Context<never>) =>
+	<A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+		Effect.updateContext(self, (ambient: Context.Context<R>) => {
+			const runtime = new Map<string, unknown>();
+			for (const [key, value] of ambient.mapUnsafe) {
+				if (key.startsWith(EFFECT_RUNTIME_PREFIX)) runtime.set(key, value);
+			}
+			return Context.merge(Context.makeUnsafe<R>(runtime), services);
+		});
+
 const toDefinition = (
 	program: AnyProgram,
 	store: Store<unknown>,
@@ -132,7 +169,7 @@ const toDefinition = (
 				Effect.mapError(
 					(cause) => new HandlerFailed({programId: program.id, cmdType: cmd.type, cause}),
 				),
-				Effect.provideContext(services),
+				sealed(services),
 			);
 	}
 	// Kept for the erasure, not for `subFailure` — the row's own type carries the policy now
@@ -159,7 +196,7 @@ const toDefinition = (
 				Effect.mapError(
 					(cause) => new HandlerFailed({programId: program.id, cmdType: sub.type, cause}),
 				),
-				Effect.provideContext(services),
+				sealed(services),
 			);
 	}
 	return {
@@ -209,13 +246,17 @@ function makeServices() {
 			// Read late on purpose: the definition that closes over this is built before the actor
 			// exists, and a handler only ever calls it once the actor is running.
 			let readState: () => unknown = () => undefined;
-			// What handlers actually get: the spawner's context plus this process's own `ProcessSelf`.
-			// Never `options.services` directly — spawn is the one place `ProcessSelf` is provided, so
-			// no caller and no `restore` has to know it exists (#7603).
-			const handlerServices = Context.add(options.services, ProcessSelf, {
-				scope,
-				state: () => readState(),
-			});
+			// What handlers actually get, and under the seal it is all they get: the spawner's set
+			// plus this process's own `ProcessSelf`. Never `options.services` directly — spawn is the
+			// one place `ProcessSelf` is provided, so no caller and no `restore` has to know it
+			// exists (#7603). The spawner's `Scope` is dropped on the way in: a spawner that passes
+			// its whole context on carries one, and the seal would let it beat the Scope the host
+			// forks for a sub handler. A handler that wants this process's own reads `ProcessSelf`.
+			const handlerServices = Context.add(
+				Context.omit(Scope.Scope)(options.services),
+				ProcessSelf,
+				{scope, state: () => readState()},
+			);
 
 			yield* Scope.addFinalizer(
 				scope,

--- a/apps/tuval/src/process/handler-context-seal.unit.test.ts
+++ b/apps/tuval/src/process/handler-context-seal.unit.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The seal: a handler resolves its spawn set and nothing else. Before #7972 `toDefinition` put
+ * `Effect.provideContext(services)` on each handler, which merges into the fiber's context rather
+ * than replacing it (rc.112, `src/internal/effect.ts:2197`), so the same handler resolved a service
+ * on one dispatch path and not on another — and a spawn guard written as a removal, like the
+ * picker's `Context.omit(ProcessPorts)`, removed nothing.
+ *
+ * The two paths carry different ambients, which is what makes the disagreement observable:
+ * `handle.dispatch` runs `dispatchOnce` on the caller's own fiber (`../host/actor.ts:476`, `484`),
+ * while a follow-up Msg goes through `dispatchUnawaited`, an `Effect.runFork` that carries none
+ * (`../host/actor.ts:190`). One Msg is driven down both here and the two answers compared, because
+ * "the paths agree" is the property, not just "the first one is sealed".
+ */
+
+import {defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Context, Effect, Layer} from "effect";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {memoryStores} from "../durability/stores.ts";
+import {type AnyProgram, type Program, ProgramId} from "../registry/program.ts";
+import {Registry} from "../registry/Registry.ts";
+import {Processes} from "./Processes.ts";
+import type {ProcessTable} from "./ProcessTable.ts";
+
+/** The service under test: never in a spawn set unless a case puts it there. */
+class Leak extends Context.Service<Leak, {readonly mark: string}>()("tuval/test/Leak") {}
+
+type State = {readonly probes: number};
+type Msg = {readonly type: "probe"} | {readonly type: "probe-again"};
+type ProbeCmd = {readonly type: "probe"; readonly path: "direct" | "follow-up"};
+
+/** What one handler saw: the service's own mark, or the message the resolution died with. */
+interface Sighting {
+	readonly path: ProbeCmd["path"];
+	readonly saw: string;
+}
+
+const messageOf = (cause: Cause.Cause<never>): string => {
+	const error: unknown = Cause.squash(cause);
+	return error instanceof Error ? error.message : String(error);
+};
+
+const readLeak = (path: ProbeCmd["path"], seen: Array<Sighting>) =>
+	Effect.map(Leak, (leak) => leak.mark).pipe(
+		Effect.catchCause((cause) => Effect.succeed(messageOf(cause))),
+		Effect.tap((saw) => Effect.sync(() => void seen.push({path, saw}))),
+	);
+
+/**
+ * One `probe` Msg reaches both dispatch paths: its reduce emits the `probe` Cmd, whose handler
+ * follows up with `probe-again`, and that follow-up's own Cmd runs on the forked fiber. The row
+ * declares no `init` Cmd, so nothing is probed on the spawner's fiber — a third ambient, and not
+ * the disagreement under test.
+ */
+const proberProgram = (seen: Array<Sighting>): AnyProgram =>
+	({
+		id: ProgramId.make("prober"),
+		core: defineMachine<State, Msg, ProbeCmd, never, unknown>({
+			init: (loaded) => [loaded ?? {probes: 0}, []],
+			update: {
+				probe: (state) => [{probes: state.probes + 1}, [{type: "probe", path: "direct"}]],
+				"probe-again": (state) => [
+					{probes: state.probes + 1},
+					[{type: "probe", path: "follow-up"}],
+				],
+			},
+			// Demlik's `Machine` demands a Promise `interpret` beside the row's `handlers`; the host
+			// never reads it (#7576).
+			interpret: {probe: () => Promise.resolve()},
+		}),
+		ports: {},
+		handlers: {
+			probe: (cmd: ProbeCmd) =>
+				Effect.map(
+					readLeak(cmd.path, seen),
+					(): ReadonlyArray<Msg> => (cmd.path === "direct" ? [{type: "probe-again"}] : []),
+				),
+		},
+		capabilities: [],
+		identity: {
+			package: "@kampus/tuval",
+			program: "prober",
+			version: "1.0.0",
+			digest: "sha256:prober",
+		},
+		placement: {host: "local"},
+	}) satisfies Program<State, Msg, ProbeCmd, never, unknown, never, Leak>;
+
+const prober = ProgramId.make("prober");
+
+const withKernel = <A, E>(
+	rows: ReadonlyArray<AnyProgram>,
+	body: Effect.Effect<A, E, Processes | ProcessTable>,
+) =>
+	body.pipe(
+		Effect.provide(
+			Processes.layer.pipe(
+				Layer.provide([Registry.layer(rows), Checkpoints.layer(memoryStores())]),
+			),
+		),
+	);
+
+/**
+ * Spawn with `services`, then dispatch from a fiber that holds `Leak` — the shape of the shell
+ * forwarding a key into a picker-opened child (`../shell/host/effects.ts:56`).
+ */
+const probeFrom = (services: Context.Context<never>) => {
+	const seen: Array<Sighting> = [];
+	return withKernel(
+		[proberProgram(seen)],
+		Effect.gen(function* () {
+			const processes = yield* Processes;
+			const handle = yield* processes.spawn(prober, {services});
+			yield* handle.dispatch({type: "probe"});
+			return seen as ReadonlyArray<Sighting>;
+		}),
+	).pipe(Effect.provideService(Leak, {mark: "the dispatching fiber's"}), Effect.scoped);
+};
+
+describe("a handler's services are its spawn set", () => {
+	it.effect("a service only the dispatching fiber holds is not resolvable, on either path", () =>
+		Effect.gen(function* () {
+			const sightings = yield* probeFrom(Context.empty());
+
+			assert.deepStrictEqual(
+				sightings.map((sighting) => sighting.path),
+				["direct", "follow-up"],
+			);
+			for (const sighting of sightings) {
+				assert.include(sighting.saw, "Service not found");
+				assert.include(sighting.saw, "tuval/test/Leak");
+			}
+			// Agreement is the property, not just the first row: before the seal the direct path
+			// resolved the dispatching fiber's mark and the forked one did not.
+			assert.strictEqual(sightings[0]?.saw, sightings[1]?.saw);
+		}),
+	);
+
+	it.effect(
+		"a service the spawn set holds is resolvable on both paths, and it is the spawn's",
+		() =>
+			Effect.gen(function* () {
+				const sightings = yield* probeFrom(Context.make(Leak, {mark: "the spawn set's"}));
+
+				assert.deepStrictEqual(sightings, [
+					{path: "direct", saw: "the spawn set's"},
+					{path: "follow-up", saw: "the spawn set's"},
+				]);
+			}),
+	);
+});

--- a/apps/tuval/src/shell/picker/open.ts
+++ b/apps/tuval/src/shell/picker/open.ts
@@ -9,12 +9,14 @@
  * handle and no throw to catch.
  */
 
+import {randomUUID} from "node:crypto";
 import {Context, Effect} from "effect";
 import {SessionOpening} from "../../ai-agent/opening.ts";
-import {ProcessPorts} from "../../ports/ProcessPorts.ts";
+import {NodeId} from "../../ports/graph.ts";
+import {ProcessPorts, unwired} from "../../ports/ProcessPorts.ts";
 import {Processes} from "../../process/Processes.ts";
 import {ProcessTable} from "../../process/ProcessTable.ts";
-import type {ProcessId} from "../../process/process.ts";
+import {ProcessId} from "../../process/process.ts";
 import {type AnyProgram, type ProgramId, takesForwardedKeys} from "../../registry/program.ts";
 import {Registry} from "../../registry/Registry.ts";
 import type {ShellMsg} from "../core/machine.ts";
@@ -76,26 +78,34 @@ const open = Effect.fn("Tuval.Picker.open")(function* (
 	if (row._tag === "Failure") return refuse(windowId, options, unknownProgram(programId));
 	if (!showsInAWindow(row.success)) return refuse(windowId, options, programHeadless(programId));
 
-	// A picker-opened program may require kernel services, and this is where they arrive: the shell
-	// process's own context is the kernel one `launch` handed it (`src/boot.ts`), so the child gets
-	// the same. `Effect.context()` reads the running fiber's whole services map (`effect` rc.112,
-	// `internal/effect.ts`), which is why nothing here has to name what it passes on.
+	// A picker-opened program may require kernel services, and this is where they arrive: this
+	// handler is sealed to the shell process's own spawn set, which is the kernel one `launch`
+	// handed it (`src/boot.ts`), so `Effect.context()` reads exactly that and the child gets the
+	// same. Passing the context on is the whole grant — a handler resolves its spawn set and
+	// nothing else (#7972), so what is dropped here is dropped for good.
 	//
 	// `ProcessPorts` is the one thing dropped rather than passed: a port binding emits from *this*
-	// node, so handing it down would send the child's payloads out of the shell's own ports. Removing
-	// it leaves the child with none, where restore overrides the inherited one with an un-wired
-	// `ProcessPorts` of its own (`src/durability/restore.ts`).
+	// node, so handing it down would send the child's payloads out of the shell's own ports. The
+	// child gets one of its own below.
 	const inherited = Context.omit(ProcessPorts)(yield* Effect.context());
+	// Minted here rather than by `Processes.spawn` — same value, one call earlier — because the
+	// ports below have to know which process they emit from.
+	const id = ProcessId.make(randomUUID());
+	// The child's own ports, put back after the omit above, the way `restore` puts one back
+	// (`src/durability/restore.ts`). `unwired` because the graph owns no route to a picker-opened
+	// process: an emit fails `PortNotWired` naming this child, where before the handler seal (#7972)
+	// a row declaring `ProcessPorts` silently emitted out of the shell's.
+	const opened = Context.add(inherited, ProcessPorts, unwired(NodeId.make(id)));
 	// The one thing added rather than inherited. An open carrying a session is the first send on a
 	// row the operator picked out of the session list, and the child has to come up resuming that
 	// session instead of booting a second one beside it (epic #8070, ruling 2). The agent row's
 	// `aiAgent.boot` handler is the only reader (`../../ai-agent/handlers/index.ts`).
 	const services =
 		session === undefined
-			? inherited
-			: Context.add(inherited, SessionOpening, {cwd: session.cwd, resume: session.resume});
+			? opened
+			: Context.add(opened, SessionOpening, {cwd: session.cwd, resume: session.resume});
 	const spawned = yield* Effect.result(
-		processes.spawn(programId, {parent: options.shellProcessId, services}),
+		processes.spawn(programId, {id, parent: options.shellProcessId, services}),
 	);
 	return spawned._tag === "Failure"
 		? refuse(windowId, options, spawnFailed(programId, spawned.failure.message))

--- a/apps/tuval/src/shell/picker/port-seal.unit.test.ts
+++ b/apps/tuval/src/shell/picker/port-seal.unit.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The picker's `Context.omit(ProcessPorts)` is a real removal, end to end on the path that made it
+ * a no-op. `open.ts` drops the shell's ports and puts an `unwired` pair of the child's own back, and
+ * the shell then forwards a keystroke into that child from its own handler fiber — the fiber that
+ * holds the shell's `ProcessPorts` (`../host/effects.ts:56`). Before #7972 the child resolved the
+ * shell's ports on exactly that dispatch and emitted out of the shell's node; the assertion is that
+ * its emit now refuses, naming the child.
+ *
+ * Two changes keep the shell's ports out and this pins the outcome rather than either mechanism:
+ * the handler seal, which stops them arriving off the dispatching fiber at all, and the child's own
+ * `unwired` pair, which the picker adds because an agent row genuinely declares `ProcessPorts` and
+ * the seal leaves it nothing to fall back on. The seal's own falsifiable proof, which reds against
+ * the merge, is `../../process/handler-context-seal.unit.test.ts`.
+ *
+ * Everything under test is the shipped code: the real `Processes`, the real `runPickerIntent`, and
+ * the real `wiredShellEffects().forwardKey`. Only the two program rows are the test's, because the
+ * claim needs a child whose handler says out loud what it emitted through.
+ */
+
+import {defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Context, Effect, Layer} from "effect";
+import {Checkpoints} from "../../durability/Checkpoints.ts";
+import {memoryStores} from "../../durability/stores.ts";
+import {NodeId} from "../../ports/graph.ts";
+import {ProcessPorts} from "../../ports/ProcessPorts.ts";
+import {Processes} from "../../process/Processes.ts";
+import type {ProcessTable} from "../../process/ProcessTable.ts";
+import {ProcessId} from "../../process/process.ts";
+import {type AnyProgram, type Program, ProgramId} from "../../registry/program.ts";
+import {Registry} from "../../registry/Registry.ts";
+import {wiredShellEffects} from "../host/effects.ts";
+import {WindowId} from "../window/host.ts";
+import {openProgram} from "./intent.ts";
+import {runPickerIntent} from "./open.ts";
+
+const shellProcessId = ProcessId.make("shell-process");
+const window = WindowId.make("window-1");
+const leakyId = ProgramId.make("leaky");
+const driverId = ProgramId.make("driver");
+
+const identity = (program: string) => ({
+	package: "@kampus/tuval",
+	program,
+	version: "1.0.0",
+	digest: `sha256:${program}`,
+});
+
+interface Opened {
+	/** The child the picker spawned, read off the `window.bind` Msg the real open answers with. */
+	child: string | undefined;
+	/** Where the child's `key` handler emitted: a wired port, or its own refusal. */
+	saw: string | undefined;
+}
+
+type ChildMsg = {readonly type: "key"; readonly key: string};
+type ChildCmd = {readonly type: "emit"};
+
+/** A window program that takes forwarded keys and reports what its handler can reach. */
+const leakyProgram = (opened: Opened): AnyProgram =>
+	({
+		id: leakyId,
+		core: defineMachine<{readonly keys: number}, ChildMsg, ChildCmd, never, unknown>({
+			init: (loaded) => [loaded ?? {keys: 0}, []],
+			update: {key: (state) => [{keys: state.keys + 1}, [{type: "emit"}]]},
+			interpret: {emit: () => Promise.resolve()},
+		}),
+		ports: {},
+		takesKeys: true,
+		renderer: {kind: "host-native", ref: "tuval/leaky"},
+		handlers: {
+			emit: () =>
+				Effect.flatMap(ProcessPorts, (ports) => ports.emit("out", 1)).pipe(
+					Effect.map(() => "reached a wired port"),
+					Effect.catchCause((cause) => {
+						const error = Cause.squash(cause) as {_tag?: string; message?: string};
+						return Effect.succeed(`${error._tag ?? "defect"}: ${error.message ?? String(error)}`);
+					}),
+					Effect.map((saw): ReadonlyArray<ChildMsg> => {
+						opened.saw = saw;
+						return [];
+					}),
+				),
+		},
+		capabilities: [],
+		identity: identity("leaky"),
+		placement: {host: "local"},
+	}) satisfies Program<
+		{readonly keys: number},
+		ChildMsg,
+		ChildCmd,
+		never,
+		unknown,
+		never,
+		ProcessPorts
+	>;
+
+type DriverMsg = {readonly type: "open"} | {readonly type: "forward"};
+type DriverCmd = {readonly type: "open"} | {readonly type: "forward"};
+
+/**
+ * Stands in for the shell process: it runs the real picker open, then the real key forward, both
+ * from its own handler fiber. The shell row itself is not used because driving it would mean
+ * driving its whole workspace state to get one key to one window, and none of that is the claim.
+ */
+const driverProgram = (opened: Opened): AnyProgram =>
+	({
+		id: driverId,
+		core: defineMachine<{readonly steps: number}, DriverMsg, DriverCmd, never, unknown>({
+			init: (loaded) => [loaded ?? {steps: 0}, []],
+			update: {
+				open: (state) => [{steps: state.steps + 1}, [{type: "open"}]],
+				forward: (state) => [{steps: state.steps + 1}, [{type: "forward"}]],
+			},
+			interpret: {open: () => Promise.resolve(), forward: () => Promise.resolve()},
+		}),
+		ports: {},
+		handlers: {
+			open: () =>
+				Effect.map(
+					runPickerIntent(openProgram(window, leakyId), {shellProcessId}),
+					(msgs): ReadonlyArray<DriverMsg> => {
+						for (const msg of msgs) {
+							if (msg.type === "window.bind") opened.child = msg.processId;
+						}
+						return [];
+					},
+				),
+			forward: () =>
+				Effect.map(
+					wiredShellEffects({shellProcessId}).forwardKey({
+						type: "forwardKey",
+						processId: opened.child ?? "unopened",
+						windowId: window,
+						key: "j",
+					}),
+					(): ReadonlyArray<DriverMsg> => [],
+				),
+		},
+		capabilities: [],
+		identity: identity("driver"),
+		placement: {host: "local"},
+	}) satisfies Program<
+		{readonly steps: number},
+		DriverMsg,
+		DriverCmd,
+		never,
+		unknown,
+		never,
+		Registry | Processes | ProcessTable
+	>;
+
+const run = Effect.fnUntraced(function* () {
+	const opened: Opened = {child: undefined, saw: undefined};
+	const body = Effect.gen(function* () {
+		const processes = yield* Processes;
+		// The shell's own spawn set: the kernel its handlers resolve, plus the `ProcessPorts` that
+		// emit from the shell's node — the service the child must not reach.
+		const kernel = yield* Effect.context<never>();
+		// Wired on purpose: if the child reaches these, its emit succeeds and the row below says so.
+		const shellPorts = ProcessPorts.of({
+			emit: () =>
+				Effect.succeed([{to: {node: NodeId.make("shell-node"), port: "out"}, accepted: true}]),
+		});
+		const shell = yield* processes.spawn(driverId, {
+			id: shellProcessId,
+			services: Context.add(kernel, ProcessPorts, shellPorts),
+		});
+		yield* shell.dispatch({type: "open"});
+		yield* shell.dispatch({type: "forward"});
+		return opened;
+	});
+	return yield* body.pipe(
+		Effect.provide(
+			// `provideMerge`, not `provide`: `Registry` has to stay in the body's own context, because
+			// the shell's spawn set is read off it and the picker's open needs it (`open.ts`).
+			Processes.layer.pipe(
+				Layer.provideMerge(
+					Layer.mergeAll(
+						Registry.layer([driverProgram(opened), leakyProgram(opened)]),
+						Checkpoints.layer(memoryStores()),
+					),
+				),
+			),
+		),
+		Effect.scoped,
+	);
+});
+
+describe("the picker's ProcessPorts omit", () => {
+	it.effect(
+		"a picker-opened child keyed from the shell's fiber cannot reach the shell's ports",
+		() =>
+			Effect.gen(function* () {
+				const opened = yield* run();
+
+				// The open really happened: without a bound child there is nothing to key and the row
+				// below would read `undefined` for a reason that has nothing to do with the seal.
+				assert.isDefined(opened.child);
+				assert.notStrictEqual(opened.child, shellProcessId);
+				// Reaching the shell's wired ports is exactly the pre-seal outcome; the child's own are
+				// unwired, so its emit refuses naming the child's node and nothing leaves the shell.
+				assert.notStrictEqual(opened.saw, "reached a wired port");
+				assert.include(opened.saw ?? "", "tuval/ports/PortNotWired");
+				assert.include(opened.saw ?? "", opened.child ?? "");
+			}),
+	);
+});


### PR DESCRIPTION
Fixes #7972

A Tuval process's handlers used to run under the spawner's `services` **merged over** whatever the fiber that dispatched happened to carry, so `SpawnOptions.services` was a floor rather than the set — and the picker's `Context.omit(ProcessPorts)` guard removed nothing. Per the founder ruling on the issue, a handler is now sealed to its spawn set.

`toDefinition` runs every command handler and every sub handler under `Effect.updateContext(() => handlerServices)` instead of `Effect.provideContext(handlerServices)`. `provideContext` is `updateContext(self, Context.merge(context))` (rc.112, `src/internal/effect.ts:2197`), which merges; `updateContext` sets the fiber context outright and restores it on exit (rc.112, `src/internal/effect.ts:2073`). The seal is applied over `handlerServices`, not `options.services`, so `spawn` remains the one place `ProcessSelf` is provided.

**What the seal keeps, read off rc.112 rather than assumed.** `FiberImpl.setContext` re-derives the scheduler, clock, log level, stack frame, tracer and parent span from the context on every replace (`src/internal/effect.ts:709`), and every key those live under is namespaced `effect/…` — `Context.Reference("effect/Clock")` and friends in `src/internal/effect.ts`, `src/Scheduler.ts`, `src/Tracer.ts`, `src/Scope.ts`. So the seal carries the ambient's `effect/…` entries through and replaces everything else. That is what keeps a handler's logger and clock behaving, and it is how a sub handler keeps the `Scope` the host forks for it (`host/actor.ts` provides it as `effect/Scope` outside the handler). Tuval's own services are namespaced `tuval/…`, so the split lands exactly on "what a spawner grants".

**Every spawner now names what it passes.** `boot.ts` no longer calls `launch`/`restore` under the kernel as an ambient — the `services` argument is the single route, and each spawner is called under its own four services. `commands/core/process.ts` reads its caller's context and passes it on beside the child's ports, where it used to hand over `Context.make(ProcessPorts, ports)` and let the merge cover the rest. `shell/picker/open.ts` passes the shell's context on minus `ProcessPorts` and adds an `unwired` pair of the child's own, the way `restore` does.

**Proofs.** `process/handler-context-seal.unit.test.ts` drives one Msg down both dispatch paths — `handle.dispatch` on the caller's fiber and a follow-up through `dispatchUnawaited`'s fork — and asserts a service only the dispatching fiber holds dies with `Service not found` on both, and that the two agree. Flip-verified: against the pre-fix seam the direct path reads the dispatching fiber's value and the assertion reds. `shell/picker/port-seal.unit.test.ts` runs the real picker open and the real `wiredShellEffects().forwardKey` from a real process's handler fiber and pins that the child's emit refuses naming its own node. `durability/boot-restore-context.unit.test.ts` is narrowed to the `services` argument alone; verified by narrowing that argument in `boot.ts` and watching it red with `Service not found: tuval/SpellBridge`.

`.patterns/tuval-shell-assembly.md` records the sealed rule, what rides through, and the ports change.

Reviewer, start at `apps/tuval/src/process/Processes.ts` — `sealed` and `handlerServices` are the whole mechanism.

## Acceptance criteria

- [x] `toDefinition` runs every command handler and every sub handler under the spawn set alone.
- [x] The seal is applied over `handlerServices`, not `options.services`, so `ProcessSelf` still resolves.
- [x] Effect references and runtime defaults still behave under the seal — stated above, read off rc.112.
- [x] Every production spawner audited and providing explicitly: `boot.ts`, `durability/restore.ts`, `commands/core/process.ts`, `shell/picker/open.ts`.
- [x] `boot.ts` no longer carries the kernel on both routes at once.
- [x] A unit test proves the seal directly, on both dispatch paths, asserting the two agree.
- [x] `boot-restore-context.unit.test.ts` narrowed to the `services` argument alone; docblock rewritten.
- [x] The picker's omit is a real removal on the key-forward path, proven by a test; the comment is corrected. (See the second deviation for what that test does and does not falsify.)
- [x] `SpawnOptions.services`' doc comment says the set is exact; `.patterns/tuval-shell-assembly.md` records the sealed rule.
- [x] `pnpm typecheck`, `pnpm lint` and the `apps/tuval` suite pass — 226 unit files / 2247 tests, plus the shell, Claude, Pi and ai-agent proofs.

## Deviations

- **Out-of-scope change** — **Said:** #7972 names the picker's omit as the guard to make real. **Did:** also changed `shell/picker/open.ts` to mint the child's process id early and hand it an `unwired` `ProcessPorts` of its own. **Why:** the AI agent row declares `ProcessPorts` in its `R` and was resolving the shell's off the dispatching fiber; with the seal in place and no ports at all, six integration proofs died on `Service not found: tuval/ProcessPorts`. `restore` already replaces ports the same way, so this aligns the picker with it rather than inventing a shape. **Disposition:** stated here, and recorded in `.patterns/tuval-shell-assembly.md`.
- **Scope narrowing** — **Said:** criterion 8 asks the picker proof to be seal-dependent. **Did:** `port-seal.unit.test.ts` pins the outcome (the child cannot reach the shell's ports on the key-forward path) but no longer reds against the merge on its own, because the child's own `unwired` ports win the merge too. **Why:** two changes now independently keep the shell's ports out; the seal's falsifiable proof is `handler-context-seal.unit.test.ts`, which does red against the merge. The test's docblock says so. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** criterion 10 asks for tests fixed by providing services explicitly. **Did:** `commands/agent-proof.unit.test.ts`'s two spawns now hand the app context as the spawn set instead of `Context.make(SpellExecutor, executor)` / `Context.make(ProcessPorts, …)`. **Why:** their handlers reach `SpellRegistry` and `SpawnedProcesses`, which used to ride in off the test fiber. Nothing in the seal was widened. **Disposition:** stated here.
- **Guard or gate bypassed** — **Said:** a lane works in its own worktree. **Did:** the first five source edits of this run were written into the shared checkout by mistake, then copied into the worktree and the shared checkout restored byte-for-byte from `HEAD` before anything was committed. **Why:** `cd` to the repo root resolved to the primary checkout, not the worktree. **Disposition:** stated here; the shared checkout was verified clean against `HEAD` for all five files.
- **Known defect left unfixed** — **Said:** the seal replaces every non-`effect/…` service. **Did:** `effect/platform/FileSystem` and `effect/platform/Terminal` are platform services, not references, and ride through the seal on the `effect/` prefix. **Why:** the prefix rule is what keeps the runtime working without a hand-maintained key list that rots; no Tuval program declares either service today. **Disposition:** stated here.

