### PR TITLE
fix: The Tuval Pi vertical harness serves a blank page on a cold worktree: Vite 504s its module graph

### DIFF
--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -16,7 +16,8 @@
  * to be told this one, and that is why this module takes the transport rather than its URL (#7560).
  */
 
-import {dirname} from "node:path";
+import {readFile} from "node:fs/promises";
+import {dirname, join} from "node:path";
 import {Effect, Schema} from "effect";
 import {featuresDefault, type TuvalFeatures} from "../features.ts";
 import type {TransportServer} from "../shell/transport/server.ts";
@@ -210,6 +211,65 @@ export const servedDirectories = (
 ];
 
 /**
+ * The page's entry modules: the `src` of every root-relative `<script type="module">` in its
+ * `index.html`. Root-relative is the whole filter — an absolute URL is somebody else's server and a
+ * relative one is not a URL this server answers, so neither is a graph this server can crawl.
+ */
+export const pageEntryModules = (html: string): ReadonlyArray<string> => [
+	...new Set(
+		[...html.matchAll(/<script\b[^>]*>/gi)]
+			.filter(([tag]) => /\btype\s*=\s*["']module["']/i.test(tag))
+			.flatMap(([tag]) => {
+				const src = /\bsrc\s*=\s*["']([^"']+)["']/i.exec(tag)?.[1];
+				return src === undefined || !src.startsWith("/") ? [] : [src];
+			}),
+	),
+];
+
+type ViteServer = Awaited<ReturnType<typeof import("vite").createServer>>;
+
+/**
+ * Long enough that a cold `pnpm install` prebundling the whole page is never cut short, short enough
+ * that a settle which is never coming does not wedge the boot: past it the URL is handed back
+ * unwarmed, which is exactly the behaviour that predates this warm.
+ */
+const WARM_TIMEOUT = "90 seconds";
+
+/**
+ * Crawl the page's static graph before the URL is handed back (#7939).
+ *
+ * Vite's dep optimizer settles on the first crawl of that graph, and until this ran, the first crawl
+ * was the browser's: the caller printed the URL the moment the server bound, so the founder's first
+ * load *was* the cold prebundle. A dep the scanner missed and the crawl then found re-bundles, and
+ * every in-flight request against the previous bundle is answered `504 (Outdated Optimize Dep)` —
+ * a blank page on the load the harness's stated bar is about. Warming here moves that whole settle
+ * in front of the printed URL, so the browser's first request meets a cache that is already built.
+ *
+ * `warmupRequest` handles its own errors and `waitForRequestsIdle` covers the static imports that
+ * request pulls in, which is the same graph the optimizer scans.
+ */
+const warmPageGraph = Effect.fn("Tuval.page.warm")(function* (server: ViteServer, root: string) {
+	const html = yield* attempt(() => readFile(join(root, "index.html"), "utf8")).pipe(
+		Effect.orElseSucceed(() => ""),
+	);
+	const entries = pageEntryModules(html);
+	if (entries.length === 0) return;
+	yield* attempt(async () => {
+		// `waitForRequestsIdle` tracks the crawl the *first* `transformRequest` starts, so the warm is
+		// started and not awaited: awaiting it first ends that crawl before the wait is armed, and the
+		// wait then answers "idle" about a graph nobody walked.
+		const warmed = Promise.all(entries.map((entry) => server.warmupRequest(entry)));
+		await server.waitForRequestsIdle();
+		await warmed;
+		// The crawl is what releases the optimizer's first run (`optimizeDeps.holdUntilCrawlEnd`), and
+		// that run is the prebundle — so the graph being walked is not yet the cache being built.
+		const optimizer = server.environments.client.depsOptimizer;
+		await optimizer?.scanProcessing;
+		await Promise.all((optimizer?.metadata.depInfoList ?? []).map((dep) => dep.processing));
+	}).pipe(Effect.timeout(WARM_TIMEOUT), Effect.ignore);
+});
+
+/**
  * The page's own resolver, told the one thing it cannot work out: which file each specifier the
  * loader module imports actually names. Only the loader module's imports are answered — the same
  * specifier written anywhere else in the app is nobody's business but Vite's.
@@ -370,5 +430,6 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 	// The browser's upgrade carries this server's origin, not the socket's, and a fence built from
 	// the socket's port alone refuses it (#7560). Done here so no caller can serve a page and forget.
 	options.transport.admitLoopbackPort(port);
+	yield* warmPageGraph(server, options.root);
 	return {url, port} satisfies PageServer;
 });

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -17,6 +17,7 @@ import {
 	featuresSource,
 	moduleRenderersSource,
 	optimizedDepEntries,
+	pageEntryModules,
 	servedDirectories,
 } from "./dev-server.ts";
 
@@ -150,5 +151,40 @@ describe("what a resolved reference tells the page server", () => {
 			"/home/founder/.tuval",
 			"/home/founder/.tuval/node_modules/@acme/win",
 		]);
+	});
+});
+
+describe("the page's entry modules", () => {
+	it("names the src of a root-relative module script, which is the graph the warm crawls", () => {
+		expect(
+			pageEntryModules(
+				'<body><div id="tuval"></div><script type="module" src="/src/page/main.tsx"></script></body>',
+			),
+		).toEqual(["/src/page/main.tsx"]);
+	});
+
+	it("leaves a classic script alone — it pulls no module graph for the optimiser to settle", () => {
+		expect(pageEntryModules('<script src="/legacy.js"></script>')).toEqual([]);
+	});
+
+	it("leaves an absolute or relative src alone: neither is a URL this server answers", () => {
+		expect(
+			pageEntryModules(
+				'<script type="module" src="https://cdn.example/a.js"></script>' +
+					'<script type="module" src="./b.js"></script>',
+			),
+		).toEqual([]);
+	});
+
+	it("warms one entry once, however many scripts name it", () => {
+		expect(
+			pageEntryModules(
+				'<script type="module" src="/a.js"></script><script type="module" src="/a.js"></script>',
+			),
+		).toEqual(["/a.js"]);
+	});
+
+	it("has nothing to warm when the page carries no module script", () => {
+		expect(pageEntryModules("<html><body></body></html>")).toEqual([]);
 	});
 });


### PR DESCRIPTION
`servePage` handed its URL back the moment Vite bound its port, and Vite had not prebundled
anything yet. The founder's first load *was* the cold prebundle: the browser drove the crawl, a dep
the scanner missed re-bundled mid-flight, and every request still holding the previous bundle came
back `504 (Outdated Optimize Dep)` — a blank desk on exactly the load the harness's stated bar is
about.

This moves the settle in front of the URL. After `listen()`, the server reads the page's own
`index.html`, warms every root-relative `<script type="module">` it names, waits for that crawl to
go idle, and then waits for the dep optimizer's first run to finish. Only then does `servePage`
return. It is in `dev-server.ts`, so `pnpm dev` gets it too. A 90-second ceiling and a page with no
module script both fall back to the old behaviour rather than wedging the boot.

Two ordering details are load-bearing and are commented at the line: the warm is started and not
awaited (awaiting it first ends the crawl before `waitForRequestsIdle` is armed, and the wait then
answers about a graph nobody walked), and the optimizer wait is separate from the crawl wait,
because `optimizeDeps.holdUntilCrawlEnd` makes the crawl the thing that *releases* the prebundle
rather than the prebundle itself.

### How the cold-cache state was reproduced

`apps/tuval/node_modules/.vite` is Vite's dep cache for this root. Deleting it puts the tree in the
same state a fresh `pnpm install` leaves it in, and the harness rebuilds it from scratch on the next
boot (113 chunks, ~14 optimized entries). Every run below deletes it first. The browser is headless
Chromium via the repo's own `@playwright/test`, launched *before* the harness so the page is
requested the instant `desk at <url>` is printed — a `sleep` between the two hides the window this
bug lives in.

### Before / after

The decisive measurement is the optimizer's own metadata (`node_modules/.vite/deps/_metadata.json`)
read at the moment the URL is printed, then again after one entry fetch:

```
before — ms to printed URL: 1239
         at printed URL: no _metadata.json — nothing was prebundled
         after one entry fetch: optimized 14, chunks 113, browserHash 9a8458a1

after  — ms to printed URL: 1690
         at printed URL: optimized 14, chunks 113, browserHash 9a8458a1
         after one entry fetch: optimized 14, chunks 113, browserHash 9a8458a1
```

Before, the whole prebundle happened after the URL was published, and the browser hash the page
loads against did not exist yet. After, it is fixed before the URL exists and does not move when the
browser arrives — and an `Outdated Optimize Dep` is by construction a request whose dep's
`browserHash` no longer matches current metadata
(`vite/dist/node/chunks/node.js`, `throwOutdatedRequest`). The URL costs ~450ms more to appear.

Console on the first load, headless Chromium, cold cache, five runs at `HEAD~` and three on this
branch:

```
before: {"shape":{"window":true,"chat":true,"textLength":458},"errors":[],"bad":[]}
after:  {"shape":{"window":true,"chat":true,"textLength":458},"errors":[],"bad":[]}
```

`errors` is every `console` error plus every uncaught page error; `bad` is every response with a
status ≥ 400.

### Acceptance criteria

- [x] the first load of `pnpm proof:pi-vertical` on a freshly installed worktree (no Vite dep cache)
      renders the desk — `.tuval-window` and `.tuval-chat` both present — with zero console errors
- [x] no `504 (Outdated Optimize Dep)` is served for any module request on that first load
- [x] the fix lives in `apps/tuval/src/page/dev-server.ts`, so `pnpm dev` gets it too, not only the
      proof harness
- [x] the PR body records how the cold-cache state was reproduced and the before/after console output
      for that first load

## Deviations

- **Known defect left unfixed** — **Said:** #7939 reports a blank page and five
  `504 (Outdated Optimize Dep)` on the first cold load. **Did:** could not reproduce that failure at
  `origin/main`; eight cold runs (five before the change, three after) all rendered the desk with an
  empty console. What I did reproduce is the gap the issue names as the cause — at the printed URL
  nothing is prebundled, so the browser's first load drives the whole optimize — and that is what
  this fixes. **Why:** the 504 needs the optimizer's metadata to change while a request for the old
  bundle is in flight, and whether that race is lost depends on machine speed and on `vite: ^8.0.16`
  resolving to a different 8.x than the reporter's tree did on 2026-09-05 (this tree: 8.1.5). The
  window is real and measurable even where the race is won. **Disposition:** stated here; the before
  column of the console table is a clean load rather than the reported failure, and I have not
  claimed otherwise.
- **Out-of-scope change** — **Said:** the fix belongs in `dev-server.ts`. **Did:** also added five
  unit cases to `dev-server.unit.test.ts`. **Why:** `pageEntryModules` is the one part of the fix
  that is pure text and can be pinned without standing a server up. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the issue offers `optimizeDeps.include` as the other option.
  **Did:** did not hand-enumerate the page's deps. **Why:** that list would have to be maintained by
  hand against every import the page grows, and waiting for the optimizer settles the same window
  without a list to rot. **Disposition:** stated here.

Fixes #7939
