### PR TITLE
fix: ClaudeAiAgent.setModel's held-pick branch is unreachable, and its docblock and PR body claim otherwise

### DIFF
--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -217,8 +217,12 @@ const make = (
 		const keys = yield* Ref.make<ReadonlySet<string>>(new Set());
 		const mode = yield* Ref.make<Mode | null>(null);
 		const model = yield* Ref.make<ModelRef | null>(null);
-		// Only an operator pick survives as an override; a discovered default is read afresh.
+		// Only an operator pick survives as an override; a discovered default is read afresh. The
+		// pick is recorded whether or not a session exists, and `start` re-applies it against the
+		// catalog it reads (#8061).
 		const pickedModel = yield* Ref.make<ModelRef | null>(null);
+		// The session's catalog, and it dies with the session: `closeCurrent` empties it, so a pick
+		// made between sessions is never judged against rows the dead session offered (#8061).
 		const models = yield* Ref.make<ReadonlyArray<ModelRef>>([]);
 		const commands = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
 		// The effort axis is per model — `ModelInfo` carries `supportedEffortLevels` per row — so the
@@ -364,6 +368,9 @@ const make = (
 			// Only now: the generator has ended, so the pump's next pull resolves and the fiber this
 			// closes is finishing rather than blocked.
 			yield* Scope.close(held.scope, Exit.void);
+			// The catalog was read off this session, so it goes with it: kept, it would still be the
+			// set `setModel` judges a pick against after the session offering it is gone (#8061).
+			yield* Ref.set(models, []);
 			yield* denyEveryParked;
 		});
 
@@ -756,16 +763,22 @@ const make = (
 
 		const setModel = Effect.fn("TuvalAiAgent.setModel")(function* (next: ModelRef) {
 			const offered = yield* Ref.get(models);
-			const picked = offered.find((candidate) => sameModel(candidate, next));
+			const current = yield* Ref.get(session);
+			// With no session there is no catalog to judge against — the rows belong to a live query
+			// and `closeCurrent` drops them — so the pick is taken unvalidated rather than refused
+			// with the model listed against an empty `available`, the self-contradicting refusal
+			// #7981 ruled out. Validation is not skipped, only deferred: `start` re-checks the held
+			// pick against the catalog it reads and opens on the spawned model instead when that
+			// catalog does not carry it, so `ModelUnsupported` still means "the session refuses it"
+			// wherever a session exists to refuse (#8061).
+			const picked =
+				current === null ? next : offered.find((candidate) => sameModel(candidate, next));
 			if (picked === undefined) {
 				return yield* new ModelUnsupported({
 					model: next.id,
 					available: offered.map((candidate) => candidate.id),
 				});
 			}
-			const current = yield* Ref.get(session);
-			// No session yet is not a refusal: the pick is held and applied by the next open, exactly
-			// as a mode set before the first session is.
 			const changed = current === null ? true : yield* applyModel(current, picked);
 			if (changed) {
 				yield* Ref.set(model, picked);

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -59,6 +59,7 @@ export interface HarnessOptions extends ScriptedBehaviour {
 	readonly rows?: ReadonlyArray<SessionMessage>;
 	readonly readFails?: Error;
 	readonly openFails?: Error;
+	readonly openFailsAt?: number;
 	readonly sessions?: ReadonlyArray<SDKSessionInfo>;
 	readonly listFails?: Error;
 	readonly spawn?: SpawnClaudeCodeProcess;
@@ -110,6 +111,7 @@ export const on = <A, E>(
 			...(harness.rows === undefined ? {} : {rows: harness.rows}),
 			...(harness.readFails === undefined ? {} : {readFails: harness.readFails}),
 			...(harness.openFails === undefined ? {} : {openFails: harness.openFails}),
+			...(harness.openFailsAt === undefined ? {} : {openFailsAt: harness.openFailsAt}),
 			...(harness.sessions === undefined ? {} : {sessions: harness.sessions}),
 			...(harness.listFails === undefined ? {} : {listFails: harness.listFails}),
 			...(harness.version === undefined ? {} : {version: harness.version}),

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -259,6 +259,12 @@ export interface ScriptedSdkOptions extends ScriptedBehaviour {
 	 * could not spawn, which is where its `errorClass` stamps arrive (#8010).
 	 */
 	readonly openFails?: Error;
+	/**
+	 * Which open, counting from one, `openFails` throws on; absent, every open throws it. A run that
+	 * opens, tears down and then fails to reopen is the only way to reach the layer's between-sessions
+	 * state, and it needs the second open alone to fail.
+	 */
+	readonly openFailsAt?: number;
 	/** What `listSessions` answers. Absent is a store holding none, which is a truthful empty list. */
 	readonly sessions?: ReadonlyArray<SDKSessionInfo>;
 	/** A listing that throws — a store that would not open, not a store with nothing in it. */
@@ -270,6 +276,7 @@ export const scriptedSdk = (options: ScriptedSdkOptions): ScriptedSdk => {
 	const opened: Array<ScriptedQuery> = [];
 	const reads: Array<{sessionId: string; dir: string | undefined}> = [];
 	const lists: Array<ListSessionsOptions | undefined> = [];
+	let opens = 0;
 	return {
 		opened,
 		reads,
@@ -277,7 +284,10 @@ export const scriptedSdk = (options: ScriptedSdkOptions): ScriptedSdk => {
 		sdk: {
 			version: options.version ?? "0.0.0-scripted",
 			query: (params) => {
-				if (options.openFails !== undefined) throw options.openFails;
+				opens += 1;
+				if (options.openFails !== undefined && (options.openFailsAt ?? opens) === opens) {
+					throw options.openFails;
+				}
 				const query = scriptedQuery(params, options.opening, options);
 				opened.push(query);
 				return query;

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -417,6 +417,66 @@ describe("setModel", () => {
 		}),
 	);
 
+	it.effect("holds a pick made before any session instead of refusing it", () =>
+		on({models: CATALOG}, (agent) =>
+			Effect.gen(function* () {
+				// No session means no catalog, and "no session yet" is not "not offered" (#7981): the
+				// pick is announced as current against the empty list rather than refused against it.
+				yield* agent.setModel({id: "sonnet", name: "Sonnet 5"});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, 1));
+				assert.deepStrictEqual(events[0], {
+					kind: "model",
+					current: {id: "sonnet", name: "Sonnet 5"},
+					available: [],
+				});
+			}),
+		),
+	);
+
+	it.effect("opens the first session on a pick made before it", () =>
+		on({models: CATALOG}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.setModel({id: "sonnet", name: "Sonnet 5"});
+				yield* agent.start({cwd: CWD});
+				assert.deepStrictEqual(scripted.opened[0]?.record.models, ["sonnet"]);
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(
+					events.find((event) => event.kind === "model"),
+					{
+						kind: "model",
+						current: {id: "sonnet", name: "Sonnet 5"},
+						available: [
+							{id: "opus", name: "Opus 5"},
+							{id: "sonnet", name: "Sonnet 5"},
+						],
+					},
+				);
+			}),
+		),
+	);
+
+	it.effect("judges no pick against the catalog of a session that is gone", () =>
+		on(
+			{models: CATALOG, openFails: new Error("the CLI would not spawn"), openFailsAt: 2},
+			(agent) =>
+				Effect.gen(function* () {
+					yield* agent.start({cwd: CWD});
+					const exit = yield* Effect.exit(agent.start({cwd: CWD}));
+					assert.isTrue(Exit.isFailure(exit));
+					// The first session's rows died with it, so a model none of them named is held for
+					// the next open rather than refused against a list nothing offers any more.
+					yield* agent.setModel({id: "gpt", name: "GPT"});
+					// The failed open's own `starting` and `gone` come first on the fresh queue.
+					const events = yield* Stream.runCollect(Stream.take(agent.events, 3));
+					assert.deepStrictEqual(events[2], {
+						kind: "model",
+						current: {id: "gpt", name: "GPT"},
+						available: [],
+					});
+				}),
+		),
+	);
+
 	it.effect("opens a later session on the model it announced", () =>
 		on({models: CATALOG}, (agent, scripted) =>
 			Effect.gen(function* () {


### PR DESCRIPTION
Fixes #8061

On the Claude layer, `setModel` validated every pick against the `models` Ref. That Ref fills in
exactly one place — inside `start`, from the session's own catalog — and nothing cleared it, so two
states were wrong:

- **Before the first `start`**, `models` is empty, so any pick was refused with `ModelUnsupported`
  naming the model against an empty `available`. That is the self-contradicting refusal #7981 ruled
  out and fixed for Pi ("no session yet is not 'not offered'"). The held-pick branch under the check,
  and the comment claiming the pick was held, were both out of reach.
- **After a session was torn down and none reopened**, `models` still held the dead session's rows,
  so a pick was judged against a catalog belonging to a session that is gone.

Now: with no session there is no catalog to judge against, so the pick is taken unvalidated, recorded
in `pickedModel` and announced as current. Validation is deferred, not skipped — `start` already
re-checks a held pick with `sameModel` against the catalog it reads and falls back to the spawned
model when that catalog does not carry it, so `ModelUnsupported` still means "the session refuses it"
wherever a session exists to refuse. And `closeCurrent` now empties `models`, so the between-sessions
state has no stale rows to judge anything against.

The Ref docblock and the comment inside `setModel` were rewritten to describe that.

Tests cover both states the issue named — a pick before the first `start` (held, announced, and
opened on by the next `start`) and a pick after a `start` that failed following a successful one
(held rather than judged against the dead catalog). All three are red on `origin/main`'s
`ClaudeAiAgent.ts` and green here. The scripted SDK gained one knob, `openFailsAt`, because the
between-sessions state needs the second open alone to fail.

### Acceptance criteria

- [x] `setModel` called before any `start` on the Claude layer records the pick instead of returning `ModelUnsupported` against an empty `available`, matching the ruling #7981 recorded for Pi.
- [x] The next `start` opens on, or applies, the pick recorded before it, and announces it on the `model` event.
- [x] `models` no longer outlives the session whose catalog it was read from: after a session is torn down and no new one opened, `setModel` cannot validate a pick against the dead session's catalog.
- [x] The comment over the `model` / `models` Refs, and any comment inside `setModel`, describe what the code does — no claim of a held pick the code cannot record.
- [x] Unit tests cover both states named in the triage note: a pick before the first `start`, and a pick after a `start` that failed following a successful one.
- [x] `pnpm typecheck` and `pnpm lint` pass.

## Deviations

- **Known defect left unfixed** — **Said:** the issue names the model axis. **Did:** left
  `setThinkingLevel` carrying the identical unreachable branch — `efforts` fills only inside `start`
  and outlives its session the same way, so a level picked before the first open is refused against
  an empty `available`. **Why:** it is not a copy of this diff — `effort` is typed
  `EffortLevel | null` while an unvalidated pick is a `ThinkingLevel`, so holding one needs a wider
  Ref, and no acceptance criterion here reaches it. **Disposition:** filed as #8539.
- **Pre-existing test or fixture changed** — **Said:** nothing about the scripted SDK. **Did:** added
  an `openFailsAt` knob to `fixtures/scripted-query.ts` and threaded it through
  `fixtures/harness.ts`. **Why:** `openFails` failed every open, and the second of the two states the
  criteria require testing needs one successful open followed by one failed one. **Disposition:**
  additive and defaulted, so every existing `openFails` caller behaves exactly as before.
