### PR TITLE
feat: Tuval: the Claude CLI version reaches only a log line, so no window can render it

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -373,6 +373,10 @@ export const foldEvent = (
 			};
 		case "usage":
 			return {...state, usage: addUsage(state.usage, event)};
+		// Replaced, never accumulated: one layer drives one backend, and the newest announcement is
+		// what that backend is running.
+		case "version":
+			return {...state, agentVersion: event.version};
 		// Replaced under its own id, never merged: the mapper computes the whole slot from the
 		// worker's frames, so a merge would keep a line the newer read has already superseded. A
 		// finished slot is kept rather than dropped — its rows are a view an operator may be

--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -292,3 +292,30 @@ describe("folding a refused interrupt", () => {
 		expect(refused.failure).toEqual(failure);
 	});
 });
+
+describe("folding the version a layer reports", () => {
+	const limits: WindowLimits = {};
+
+	it("fills the slot the state starts empty", () => {
+		const start = initialState("/repo");
+		expect(start.agentVersion).toBeNull();
+		expect(foldEvent(start, {kind: "version", version: "2.1.259"}, limits).agentVersion).toBe(
+			"2.1.259",
+		);
+	});
+
+	// A layer re-announces on every open, and a resume walks a stream that has already announced —
+	// so the newest report has to win rather than accumulate beside the one before it.
+	it("replaces what it held, so a re-announced session reads as what it runs now", () => {
+		const first = foldEvent(initialState("/repo"), {kind: "version", version: "2.1.259"}, limits);
+		expect(foldEvent(first, {kind: "version", version: "2.2.0"}, limits).agentVersion).toBe(
+			"2.2.0",
+		);
+	});
+
+	it("touches nothing else on the session", () => {
+		const start: AiAgentSessionState = {...initialState("/repo"), phase: "prompting"};
+		const folded = foldEvent(start, {kind: "version", version: "2.1.259"}, limits);
+		expect({...folded, agentVersion: null}).toEqual(start);
+	});
+});

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -147,6 +147,7 @@ export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionSt
 	isNullOrString(value.interrupted) &&
 	isInterruption(value.interruption) &&
 	isUsage(value.usage) &&
+	isNullOrString(value.agentVersion) &&
 	isPermissions(value.permissions) &&
 	isFiniteNumber(value.permissionsRaised) &&
 	isModes(value.modes) &&

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -412,9 +412,10 @@ const markInterrupted = (
  * for, and an abort in flight to a backend this process no longer holds a transport to.
  *
  * `agentVersion` is dropped for a narrower reason: it names the binary the *previous* process
- * drove, and the CLI on PATH can have been upgraded while the desk was off — which is the exact
- * drift the line exists to show (#7580). The layer re-reports it as this session opens, so `null`
- * for that gap says "nobody has told me yet" rather than showing a version nothing is running.
+ * drove, and a dependency update swaps the CLI the SDK bundles while the desk is off — which is the
+ * exact drift the line exists to show (#7580). The layer re-reports it as this session opens, so
+ * `null` for that gap says "nobody has told me yet" rather than showing a version nothing is
+ * running.
  *
  * A queued prompt does not come back queued. The turn it was waiting for ended with the process, so
  * there is nothing left to flush it, and it is released to its window as an unsent send the same way

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -147,12 +147,16 @@ export interface AiAgentSessionState {
 	readonly usage: UsageLedger;
 	/**
 	 * The version of whatever the layer is driving, as that layer reports it — the Claude Code CLI
-	 * on PATH for one row, Pi's adapter for the other — or `null` before any layer has said.
+	 * for one row, Pi's adapter for the other — or `null` before any layer has said.
 	 *
 	 * Model-blind on purpose: it is one string nobody parses, so a second backend fills the same
-	 * slot rather than growing its own. The point of showing it is drift — the SDK pin is ours and
-	 * the CLI is whatever is on PATH (#7580) — so it is rendered as the desk inspector's `Version`
-	 * row (`../window/AiAgentInspector.tsx`) rather than living in the Claude layer's log line.
+	 * slot rather than growing its own. The point of showing it is drift (#7580), so it is rendered
+	 * as the desk inspector's `Version` row (`../window/AiAgentInspector.tsx`) rather than living in
+	 * the Claude layer's log line. What the Claude row reports is the CLI the Agent SDK bundles and
+	 * launches, which is not necessarily the `claude` on `PATH`: the SDK spawns its own built-in
+	 * executable unless `pathToClaudeCodeExecutable` names another (`sdk.d.ts` at the `0.3.259`
+	 * pin), and this program never sets it — a desk on SDK `0.3.259` reported CLI `2.1.259` while
+	 * `claude --version` on the same box read `2.1.263`.
 	 */
 	readonly agentVersion: string | null;
 	/**

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -151,8 +151,8 @@ export interface AiAgentSessionState {
 	 *
 	 * Model-blind on purpose: it is one string nobody parses, so a second backend fills the same
 	 * slot rather than growing its own. The point of showing it is drift — the SDK pin is ours and
-	 * the CLI is whatever is on PATH (#7580) — and today it reaches a log line and nothing else
-	 * (#7955).
+	 * the CLI is whatever is on PATH (#7580) — so it is rendered as the desk inspector's `Version`
+	 * row (`../window/AiAgentInspector.tsx`) rather than living in the Claude layer's log line.
 	 */
 	readonly agentVersion: string | null;
 	/**

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -146,6 +146,16 @@ export interface AiAgentSessionState {
 	readonly interruption: Interruption | null;
 	readonly usage: UsageLedger;
 	/**
+	 * The version of whatever the layer is driving, as that layer reports it — the Claude Code CLI
+	 * on PATH for one row, Pi's adapter for the other — or `null` before any layer has said.
+	 *
+	 * Model-blind on purpose: it is one string nobody parses, so a second backend fills the same
+	 * slot rather than growing its own. The point of showing it is drift — the SDK pin is ours and
+	 * the CLI is whatever is on PATH (#7580) — and today it reaches a log line and nothing else
+	 * (#7955).
+	 */
+	readonly agentVersion: string | null;
+	/**
 	 * Pending permission cards by request id: one arrives with an event, and one leaves on the
 	 * confirmation of its answer rather than on the click that answered it (#8006).
 	 */
@@ -227,6 +237,7 @@ export const checkpointFields = [
 	"interrupted",
 	"interruption",
 	"usage",
+	"agentVersion",
 	"permissions",
 	"permissionsRaised",
 	"modes",
@@ -261,6 +272,7 @@ export const initialState = (cwd: string): AiAgentSessionState => ({
 	interrupted: null,
 	interruption: null,
 	usage: emptyUsage,
+	agentVersion: null,
 	permissions: {},
 	permissionsRaised: 0,
 	modes: {current: null, available: []},
@@ -395,6 +407,11 @@ const markInterrupted = (
  * refusal nobody can act on any more, a page the window asked a transport that no longer exists
  * for, and an abort in flight to a backend this process no longer holds a transport to.
  *
+ * `agentVersion` is dropped for a narrower reason: it names the binary the *previous* process
+ * drove, and the CLI on PATH can have been upgraded while the desk was off — which is the exact
+ * drift the line exists to show (#7580). The layer re-reports it as this session opens, so `null`
+ * for that gap says "nobody has told me yet" rather than showing a version nothing is running.
+ *
  * A queued prompt does not come back queued. The turn it was waiting for ended with the process, so
  * there is nothing left to flush it, and it is released to its window as an unsent send the same way
  * an interrupted queue is — recoverable, never resent on the operator's behalf.
@@ -426,6 +443,7 @@ export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
 		transcript: {...loaded.transcript, items: markInterrupted(loaded.transcript.items, cut)},
 		interrupted: cut ?? loaded.interrupted,
 		interruption: null,
+		agentVersion: null,
 		queued: [],
 		sends: releaseQueued(
 			loaded.queued,

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -116,7 +116,7 @@ describe("the version slot the layers fill", () => {
 		expect(initialState("/repo").agentVersion).toBeNull();
 	});
 
-	it("comes back empty from a checkpoint, since the binary on PATH can have moved", () => {
+	it("comes back empty from a checkpoint, since the binary the layer launches can have moved", () => {
 		expect(restore({...saved, agentVersion: "2.1.259"}).agentVersion).toBeNull();
 	});
 

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -111,6 +111,20 @@ describe("a save snapshot", () => {
 	});
 });
 
+describe("the version slot the layers fill", () => {
+	it("starts empty, because no layer has reported one yet", () => {
+		expect(initialState("/repo").agentVersion).toBeNull();
+	});
+
+	it("comes back empty from a checkpoint, since the binary on PATH can have moved", () => {
+		expect(restore({...saved, agentVersion: "2.1.259"}).agentVersion).toBeNull();
+	});
+
+	it("refuses a saved value that is neither a string nor absent", () => {
+		expect(parseSessionState({...saved, agentVersion: 2.1})).toBeNull();
+	});
+});
+
 describe("a restored session and its subagents", () => {
 	const items = [userItem("u1"), assistantItem("a1")];
 	const loaded: AiAgentSessionState = {

--- a/apps/tuval/src/ai-agent/events.ts
+++ b/apps/tuval/src/ai-agent/events.ts
@@ -186,6 +186,19 @@ export interface SessionResetEvent {
 	readonly sessionId: string;
 }
 
+/**
+ * What the layer is driving, as a version string — the Claude Code CLI on PATH for one row, Pi's
+ * adapter for the other.
+ *
+ * Its own kind rather than a field on `usage`: usage is a turn's spend, keyed on that turn, and a
+ * version is a fact about the session that arrives whether or not anything was spent. It replaces
+ * whatever the slot held, so a layer that re-announces on a resume is a no-op.
+ */
+export interface VersionEvent {
+	readonly kind: "version";
+	readonly version: string;
+}
+
 /** Plain numbers and a plain model name: no backend's usage type reaches the core. */
 export interface UsageEvent {
 	readonly kind: "usage";
@@ -215,5 +228,6 @@ export type AgentEvent =
 	| ThinkingEvent
 	| SessionResetEvent
 	| UsageEvent
+	| VersionEvent
 	| SubagentEvent
 	| FailureEvent;

--- a/apps/tuval/src/ai-agent/events.ts
+++ b/apps/tuval/src/ai-agent/events.ts
@@ -187,8 +187,8 @@ export interface SessionResetEvent {
 }
 
 /**
- * What the layer is driving, as a version string — the Claude Code CLI on PATH for one row, Pi's
- * adapter for the other.
+ * What the layer is driving, as a version string — the Claude Code CLI for one row, Pi's adapter
+ * for the other.
  *
  * Its own kind rather than a field on `usage`: usage is a turn's spend, keyed on that turn, and a
  * version is a fact about the session that arrives whether or not anything was spent. It replaces

--- a/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
+++ b/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
@@ -1,7 +1,7 @@
 /**
  * What every ai-agent backend shows in the desk inspector: the five facts the chat bar used to
  * carry (founder ruling 2026-09-05, #8190) — cost, input tokens, output tokens, the session id and
- * the working directory.
+ * the working directory — plus the version the layer reports for whatever it is driving (#7955).
  *
  * One renderer for both backends rather than one each. The Claude window's usage and session lines
  * and the Pi window's usage line were the same values written three times, once per surface
@@ -57,6 +57,11 @@ const inspectorRows = (
 		["Output tokens", tokens.format(usage.outputTokens)],
 		["Session", state.sessionId ?? NO_SESSION_YET, "tuval-agent-inspector-wrap"],
 		["Directory", state.cwd, "tuval-agent-inspector-wrap"],
+		// Omitted rather than shown empty: unlike the session id, an absent version is not a state
+		// the operator has to be told about — the layer reports one as the session opens.
+		...(state.agentVersion === null
+			? []
+			: [["Version", state.agentVersion] as readonly [string, string]]),
 	];
 };
 

--- a/apps/tuval/src/ai-agent/window/ai-agent-inspector.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/ai-agent-inspector.unit.test.tsx
@@ -61,6 +61,21 @@ describe("what the inspector shows", () => {
 		expect(within(region).getByText(CWD)).toBeDefined();
 	});
 
+	it("renders the version the layer reported, beside the session id and the cwd", async () => {
+		await open(agentSessionState({agentVersion: "2.1.259"}));
+		const region = panel();
+		expect(within(region).getByText("Version")).toBeDefined();
+		expect(within(region).getByText("2.1.259")).toBeDefined();
+		expect(within(region).getByText(SESSION_ID)).toBeDefined();
+		expect(within(region).getByText(CWD)).toBeDefined();
+	});
+
+	// Unlike the session id, an absent version is not a state the operator is owed a word about.
+	it("leaves the row out entirely while no layer has reported one", async () => {
+		await open(agentSessionState({agentVersion: null}));
+		expect(within(panel()).queryByText("Version")).toBeNull();
+	});
+
 	it("names every value, because a bare number names nothing to a screen reader", async () => {
 		await open(agentSessionState());
 		for (const label of ["Cost", "Input tokens", "Output tokens", "Session", "Directory"]) {

--- a/apps/tuval/src/claude/agent/events.unit.test.ts
+++ b/apps/tuval/src/claude/agent/events.unit.test.ts
@@ -14,9 +14,10 @@ import {CWD, MODES, messages, OPENED_EVENTS, on, settled} from "./fixtures/harne
 /**
  * The tool turn's four frames after `init`, folded: the call opens `running`, its answer settles it
  * `ok`, the reply lands, and the result reports spend and then ends the turn. The first assistant
- * frame carries only the `tool_use` block, so it earns no text item of its own.
+ * frame carries only the `tool_use` block, so it earns no text item of its own. `init` itself is
+ * two: the model it names and the CLI version it reports (#7955).
  */
-const TURN_EVENTS = 5;
+const TURN_EVENTS = 6;
 
 describe("events over a captured tool turn", () => {
 	it.effect("carries the turn's items and its usage in one ordered stream", () =>
@@ -28,8 +29,8 @@ describe("events over a captured tool turn", () => {
 				);
 				assert.deepStrictEqual(
 					events.map((event) => event.kind),
-					// The start's own, then the first turn's `init` — the model it names, and nothing
-					// else — then the turn, which ends on the `ready` its `result` carries.
+					// The start's own, then the first turn's `init` — the model and the CLI version it
+					// names — then the turn, which ends on the `ready` its `result` carries.
 					[
 						"phase",
 						"phase",
@@ -38,6 +39,7 @@ describe("events over a captured tool turn", () => {
 						"commands",
 						"thinking",
 						"usage",
+						"version",
 						"item",
 						"item",
 						"item",
@@ -119,6 +121,7 @@ describe("every kind rides the one stream", () => {
 						"commands",
 						"thinking",
 						"usage",
+						"version",
 						"item",
 						"item",
 						"item",

--- a/apps/tuval/src/claude/agent/options.ts
+++ b/apps/tuval/src/claude/agent/options.ts
@@ -4,9 +4,11 @@
  * Kept out of the layer so the whole of what reaches the SDK is assertable without a subprocess:
  * `queryOptionsOf` is a pure function of the config, the tool server and the environment.
  *
- * `pathToClaudeCodeExecutable` is deliberately never set. The CLI the SDK spawns is the `claude` on
- * `PATH`, and SDK/CLI drift is accepted for this slice (founder ruling on #7580) — the `start` log
- * line names both versions so a drifted pair is visible in the transcript rather than silent.
+ * `pathToClaudeCodeExecutable` is deliberately never set, so the SDK launches the CLI it bundles
+ * ("Uses the built-in executable if not specified", `sdk.d.ts` at the `0.3.259` pin) rather than
+ * whatever `claude` is on `PATH` — the two routinely differ. SDK/CLI drift is accepted for this
+ * slice (founder ruling on #7580) — the `start` log line names both versions so a drifted pair is
+ * visible in the transcript rather than silent.
  */
 
 import {userInfo} from "node:os";
@@ -43,7 +45,7 @@ export interface ClaudeAiAgentOptions {
 	readonly streamPartialReplies?: boolean;
 	/** The SDK seam. Absent is the real SDK; a test hands in a scripted `Query`. */
 	readonly sdk?: AgentSdk;
-	/** Absent leaves the SDK's own local spawn, which is what runs the `claude` on `PATH`. */
+	/** Absent leaves the SDK's own local spawn, which is what runs its bundled CLI. */
 	readonly spawn?: SpawnClaudeCodeProcess;
 	/**
 	 * The id a fresh session opens under. Absent mints a v4 UUID, which is what a run does; a test

--- a/apps/tuval/src/claude/agent/phases.unit.test.ts
+++ b/apps/tuval/src/claude/agent/phases.unit.test.ts
@@ -54,11 +54,11 @@ const openingOf = (opening: ReadonlyArray<SDKMessage>) =>
 	);
 
 /**
- * `assistant-turn.json` is init, one assistant frame and one `success` result — five events out:
- * the `prompting` the send itself narrates, the model init names, the reply, the turn's spend, and
- * the `ready` that ends it.
+ * `assistant-turn.json` is init, one assistant frame and one `success` result — six events out: the
+ * `prompting` the send itself narrates, the model and the CLI version init names, the reply, the
+ * turn's spend, and the `ready` that ends it.
  */
-const ASSISTANT_TURN_EVENTS = 5;
+const ASSISTANT_TURN_EVENTS = 6;
 
 const machine = aiAgentSessionMachine({cwd: CWD});
 
@@ -89,7 +89,7 @@ describe("a turn ends on its result", () => {
 			const events = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
 			assert.deepStrictEqual(
 				events.map((event) => event.kind),
-				["phase", "usage", "item", "usage", "phase"],
+				["phase", "usage", "version", "item", "usage", "phase"],
 			);
 			assert.deepStrictEqual(
 				events.filter((event) => event.kind === "phase"),

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -79,7 +79,7 @@ describe("start opens one streaming query", () => {
 				assert.isString(options?.env?.USER);
 				assert.notStrictEqual(options?.env?.USER, "");
 				// SDK/CLI drift is accepted for this slice, so the executable is never pinned: the
-				// CLI is whatever `claude` on PATH is (founder ruling on #7580).
+				// CLI is the one the SDK bundles (founder ruling on #7580).
 				assert.isUndefined(options?.pathToClaudeCodeExecutable);
 				// A fresh session names no `resume`, so `continue` cannot be implied either.
 				assert.isUndefined(options?.resume);

--- a/apps/tuval/src/claude/agent/subprocess.ts
+++ b/apps/tuval/src/claude/agent/subprocess.ts
@@ -5,7 +5,7 @@
  * "Close the query and terminate the underlying process"). The one place a consumer can observe it
  * is `Options.spawnClaudeCodeProcess`, which replaces the spawn outright. So this wraps a spawner
  * the row supplied rather than installing one: with no spawner the SDK's own local spawn stands,
- * which is what runs the `claude` on `PATH`, and the exit reason is simply unknown.
+ * which is what runs its bundled CLI, and the exit reason is simply unknown.
  *
  * Nothing here spawns anything. The wrapper registers one `exit` listener and records what it
  * hears, which is the whole of what a `TransportError`'s detail needs.

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -10,7 +10,8 @@
 
 import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
 import {describe, expect, it} from "vitest";
-import {upsertItem} from "../../ai-agent/core/fold.ts";
+import {foldEvent, upsertItem} from "../../ai-agent/core/fold.ts";
+import {initialState} from "../../ai-agent/core/state.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {
 	byteLength,
@@ -65,8 +66,28 @@ describe("toAgentEvents over a captured init", () => {
 				outputTokens: 0,
 				cost: 0,
 			},
+			{kind: "version", version: "2.1.259"},
 		]);
 		expect(mapping.model).toBe("claude-fable-5-1");
+	});
+
+	it("reports the CLI on PATH, which is not the SDK this repo pins", () => {
+		const {events} = run([message("init")]);
+		expect(events.filter((one) => one.kind === "version")).toEqual([
+			{kind: "version", version: "2.1.259"},
+		]);
+	});
+
+	// The field is stamped off the captured frame rather than captured absent: every CLI that can be
+	// run reports one, so a frame without it is only reachable by taking it away.
+	it("emits no version at all when the frame carries none, leaving the slot empty", () => {
+		const {claude_code_version: _absent, ...withoutVersion} = message("init") as SDKMessage &
+			Record<string, unknown>;
+		const {events} = run([withoutVersion as SDKMessage]);
+		expect(events.filter((one) => one.kind === "version")).toEqual([]);
+		expect(
+			events.reduce((state, one) => foldEvent(state, one, {}), initialState("/repo")),
+		).toMatchObject({agentVersion: null});
 	});
 
 	it("reads a resumed session's init the same way", () => {
@@ -80,6 +101,7 @@ describe("toAgentEvents over a captured init", () => {
 				outputTokens: 0,
 				cost: 0,
 			},
+			{kind: "version", version: "2.1.259"},
 		]);
 	});
 });

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -71,7 +71,7 @@ describe("toAgentEvents over a captured init", () => {
 		expect(mapping.model).toBe("claude-fable-5-1");
 	});
 
-	it("reports the CLI on PATH, which is not the SDK this repo pins", () => {
+	it("reports the bundled CLI's own version, which is not the SDK version this repo pins", () => {
 		const {events} = run([message("init")]);
 		expect(events.filter((one) => one.kind === "version")).toEqual([
 			{kind: "version", version: "2.1.259"},

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -780,10 +780,17 @@ const MODEL_ANNOUNCEMENT = "claude:model-announcement";
 export const initEvents = (message: unknown, mapping: Mapping): MappingStep => {
 	if (!isRecord(message)) return skipMessage(mapping);
 	const model = typeof message.model === "string" ? message.model : mapping.model;
+	// The CLI on PATH is not the SDK we pin, and the drift between them is the whole point of
+	// carrying it (#7580). A frame without the field emits nothing rather than a placeholder: the
+	// core's slot stays `null`, which is what says nobody has reported one (#7955).
+	const version = message.claude_code_version;
 	return {
 		mapping: {...mapping, model},
 		events: [
 			{kind: "usage", turn: MODEL_ANNOUNCEMENT, model, inputTokens: 0, outputTokens: 0, cost: 0},
+			...(typeof version === "string" && version.length > 0
+				? [{kind: "version", version} as const]
+				: []),
 		],
 	};
 };

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -780,9 +780,9 @@ const MODEL_ANNOUNCEMENT = "claude:model-announcement";
 export const initEvents = (message: unknown, mapping: Mapping): MappingStep => {
 	if (!isRecord(message)) return skipMessage(mapping);
 	const model = typeof message.model === "string" ? message.model : mapping.model;
-	// The CLI on PATH is not the SDK we pin, and the drift between them is the whole point of
-	// carrying it (#7580). A frame without the field emits nothing rather than a placeholder: the
-	// core's slot stays `null`, which is what says nobody has reported one (#7955).
+	// The CLI is not the SDK we pin, and the drift between them is the whole point of carrying it
+	// (#7580). A frame without the field emits nothing rather than a placeholder: the core's slot
+	// stays `null`, which is what says nobody has reported one (#7955).
 	const version = message.claude_code_version;
 	return {
 		mapping: {...mapping, model},

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -43,6 +43,7 @@ const cutMidReply: AiAgentSessionState = {
 	interrupted: null,
 	interruption: null,
 	usage: {model: "faux/faux-1", turns: {"item-1": {inputTokens: 10, outputTokens: 4, cost: 0}}},
+	agentVersion: "0.42.0",
 	permissions: {},
 	permissionsRaised: 0,
 	modes: {current: null, available: []},


### PR DESCRIPTION
Fixes #7955

The Claude CLI version reached one `Effect.logInfo` line and nothing else, so no window could show it. This gives the shared `ai-agent` core one model-blind slot, has the Claude layer fill it off the SDK `init` frame, and renders it in the desk inspector beside the session id and the cwd.

- `AiAgentSessionState.agentVersion` — a `string | null`, `null` in `initialState`, listed in `checkpointFields`, admitted by the snapshot predicate. `restore` clears it: it names the binary the previous process drove, and a dependency update swaps the CLI the SDK bundles while the desk is off, which is the drift #7580 wants visible. The layer re-reports it as the session opens.
- `VersionEvent` (`kind: "version"`) on `AgentEvent`, folded by `core/fold.ts` as a replace. Its own kind rather than a field on `usage`: usage is a turn's spend keyed on that turn, a version is a session fact that arrives whether or not anything was spent.
- `initEvents` in `claude/history/map.ts` emits it off `claude_code_version`; a frame without the field emits nothing, leaving the slot `null`.
- The desk inspector grows a `Version` row, omitted entirely while the slot is `null`.

What the Claude row reports is the CLI the Agent SDK **bundles and launches**, not the `claude` on `PATH`: the SDK spawns its own built-in executable unless `pathToClaudeCodeExecutable` names another ("Uses the built-in executable if not specified", `sdk.d.ts` at the `0.3.259` pin), and this program never sets it. Hand-verified — a desk on SDK `0.3.259` reported CLI `2.1.259` while `claude --version` on the same box read `2.1.263`.

Tests: the initial value and the `restore` clear (`core/state.unit.test.ts`), the reducer (`core/fold.unit.test.ts`), the captured `init` frame with and without the field (`claude/history/events.unit.test.ts`), and the rendered row present/absent (`ai-agent/window/ai-agent-inspector.unit.test.tsx`). `apps/tuval/src/claude/window/boundary.unit.test.ts` still passes — nothing new is imported under `src/claude/window/`.

### Acceptance criteria

- [x] `AiAgentSessionState` carries a model-blind version slot, `null` in `initialState` and until a layer reports one; a unit test pins the initial value
- [x] the shared core's event surface carries the version from a layer to that slot, with a unit test over the reducer
- [x] `initEvents` reads `claude_code_version` off the SDK `init` message and emits it; a unit test proves an `init` message with no version leaves the slot `null`
- [x] the operator-facing line renders session id, cwd and the version, and renders without the version when the slot is `null`; unit-tested — landed in the desk inspector rather than `ClaudeChatWindow`, see Deviations
- [x] the docblock about the missing version is rewritten to describe what now happens — the inspector's, see Deviations
- [x] `apps/tuval/src/claude/window/boundary.unit.test.ts` still passes
- [x] `pnpm typecheck` and `pnpm lint` pass

## Deviations

- **Scope narrowing** — **Said:** criterion 4 asks `SessionLine` in `apps/tuval/src/claude/window/ClaudeChatWindow.tsx` to render session id, cwd and the version. **Did:** rendered the version in `apps/tuval/src/ai-agent/window/AiAgentInspector.tsx`, which is where the session id and the cwd now live. **Why:** the founder's 2026-09-05 ruling (#8190) landed at `origin/main` after this issue was filed and moved all five chat-bar facts to the desk inspector; `SessionLine` no longer exists and `ClaudeChatWindow` is a thin binding over the shared `chatWindow()`. Putting the version back on the bar would re-open the surface that ruling closed. **Disposition:** stated here; the criterion's intent — the operator sees the version beside the session id and the cwd — is met on the surface those two are on.
- **Scope narrowing** — **Said:** criterion 5 asks the `ClaudeChatWindow` docblock's paragraph about the missing version to be rewritten. **Did:** updated the `AiAgentInspector` docblock instead. **Why:** the paragraph the criterion names is gone at `origin/main` — the same #8190 change rewrote that docblock, and it no longer mentions the version. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #7955 names the core, the Claude mapping and the window. **Did:** also updated four test files that pin an exact event stream — `claude/agent/events.unit.test.ts`, `claude/agent/phases.unit.test.ts` (both count and list the kinds a captured turn emits) and `pi/restore/interrupted.unit.test.ts` (a hand-built state literal). **Why:** a new event kind on `init` shifts every one of those counted sequences; leaving them would red CI. **Disposition:** the assertions gained the `version` row and the counts moved by one; no behaviour of theirs changed.
- **Out-of-scope change** — **Said:** #7955 names no comment outside the core and the Claude mapping. **Did:** also corrected four pre-existing notes that state the SDK spawns the `claude` on `PATH` — `claude/agent/options.ts` (module docblock and the `spawn` field), `claude/agent/subprocess.ts` and `claude/agent/start.unit.test.ts`. **Why:** they are the same false claim this PR's own notes carried, and leaving them would ship a tree whose Claude layer says one thing and whose core says the opposite. **Disposition:** folded in here; #8543, filed for them before this round, is closed as covered.
- **Known defect left unfixed** — **Said:** nothing. **Did:** left `apps/tuval/src/pi/restore/pi-restore.integration.test.ts` alone after it timed out once ("the new turn to start") and passed on an immediate re-run, before and independent of this diff's surface. **Why:** it is a real-Pi integration test with a timing wait, and nothing here touches the Pi layer. **Disposition:** noted on #7964, which already tracks that shape.
