### PR TITLE
chore: Pi refuses a queued mid-turn prompt: 'Agent is already processing, specify streamingBehavior'

### DIFF
--- a/apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts
@@ -1,0 +1,319 @@
+/**
+ * The reproduction for #8214: why a send the core admitted reaches Pi mid-turn and is refused with
+ * `Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the
+ * message.`
+ *
+ * Three claims, in the order the failure travels. The layer emits a `ready` under a live turn; the
+ * core admits the next prompt on that `ready`; and the pinned wire cannot carry the field Pi's own
+ * error names, so the remedy cannot live on the prompt command.
+ *
+ * The variable is the send, not the order of the pair: whichever of a turn's push and its answer
+ * lands *after* the next send's `sent` mark re-folds a stale `idle` into a second `ready`. Both
+ * orders are here, and so is the same schedule with nothing sent in the gap.
+ *
+ * The findings this pins are written up in
+ * `reports/2026-09-07-pi-mid-turn-prompt-refusal.md`. Nothing here asserts a fix: the tests describe
+ * the mechanism as current source runs it, so a fix reds the first one by name.
+ */
+
+import {applyCellChecked} from "@demlik/tea";
+import {
+	type ClientMessage,
+	type TranscriptItem as PiTranscriptItem,
+	ProtocolValidationError,
+	parseClientMessage,
+	type SessionSnapshot,
+} from "@earendil-works/pi-protocol";
+import {assert, describe, it} from "@effect/vitest";
+import {type Cause, Deferred, Effect, Layer, Option, Queue, Stream} from "effect";
+import {aiAgentSessionMachine} from "../../ai-agent/core/machine.ts";
+import type {AiAgentSessionCmd, AiAgentSessionMsg} from "../../ai-agent/core/messages.ts";
+import {type AiAgentSessionState, initialState} from "../../ai-agent/core/state.ts";
+import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
+import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {aiAgentOverClient} from "./PiAiAgent.ts";
+
+const CWD = "/tuval/mid-turn";
+const SESSION: PiSessionRef = {
+	id: "session-8214",
+	cwd: CWD,
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+};
+
+const user = (id: string, text: string): PiTranscriptItem => ({
+	id,
+	role: "user",
+	content: [{type: "text", text}],
+	timestamp: 10,
+});
+
+const reply = (id: string, text: string): PiTranscriptItem => ({
+	id,
+	role: "assistant",
+	content: [{type: "text", text}],
+	model: SESSION.model,
+	timestamp: 11,
+	status: "complete",
+	stopReason: "stop",
+});
+
+const snapshot = (
+	transcript: ReadonlyArray<PiTranscriptItem>,
+	phase: SessionSnapshot["phase"],
+	revision: number,
+): SessionSnapshot => ({
+	id: SESSION.id,
+	cwd: CWD,
+	createdAt: 0,
+	updatedAt: 0,
+	phase,
+	model: SESSION.model,
+	thinkingLevel: "off",
+	attached: true,
+	locked: true,
+	revision,
+	transcript: [...transcript],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+const USER_A = user("u-0", "first");
+const REPLY_A = reply("a-0", "first reply");
+const TURN_A = [USER_A, REPLY_A];
+
+/**
+ * The stub server, with one settleable answer per send rather than one for the session: the
+ * schedule under test is exactly a *previous* send's answer landing after a later send has gone
+ * out, which one shared Deferred cannot express.
+ */
+const stub = Effect.gen(function* () {
+	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const first = yield* Deferred.make<SessionSnapshot>();
+	const second = yield* Deferred.make<SessionSnapshot>();
+	const answers = [first, second];
+	let sent = 0;
+	const api: PiClientApi = {
+		connect: Effect.void,
+		reconnect: Effect.void,
+		connected: Effect.succeed(true),
+		createSession: () => Effect.succeed(SESSION),
+		attachSession: () => Effect.succeed(SESSION),
+		heldSnapshot: () => Effect.succeed(snapshot([], "idle", 0)),
+		// Read at call time, on the fiber that called `prompt`, so the nth send takes the nth
+		// answer in the order the layer issued them.
+		prompt: () => {
+			const answer = answers[sent];
+			sent += 1;
+			return answer === undefined ? Effect.never : Deferred.await(answer);
+		},
+		abort: () => Effect.never,
+		setModel: () => Effect.never,
+		setThinkingLevel: () => Effect.never,
+		models: Effect.succeed([]),
+		snapshots: () => Stream.fromQueue(pushes),
+		disconnections: Stream.never,
+	};
+	return {
+		layer: Layer.succeed(PiClientService, api),
+		push: (value: SessionSnapshot) => Queue.offer(pushes, value),
+		/** Settle the nth send's own answer, as the server's response frame does. */
+		answer: (nth: 0 | 1, value: SessionSnapshot) =>
+			Deferred.succeed(nth === 0 ? first : second, value),
+	};
+});
+
+type Events = Queue.Dequeue<AgentEvent, TransportError | Cause.Done>;
+
+const collectTo = (events: Events, what: string, found: (event: AgentEvent) => boolean) =>
+	Effect.gen(function* () {
+		const seen: Array<AgentEvent> = [];
+		while (true) {
+			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("5 seconds"));
+			if (Option.isNone(next)) {
+				assert.fail(`timed out waiting for ${what}; saw ${JSON.stringify(seen)}`);
+			}
+			const event = next.value;
+			seen.push(event);
+			if (found(event)) return seen;
+		}
+	});
+
+const isReady = (event: AgentEvent): boolean => event.kind === "phase" && event.phase === "ready";
+const isPrompting = (event: AgentEvent): boolean =>
+	event.kind === "phase" && event.phase === "prompting";
+
+/** Whatever the layer emitted in a quarter second, or nothing. */
+const settled = (events: Events) =>
+	Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("250 millis"));
+
+describe("a send admitted while Pi is still running the previous turn", () => {
+	it.live("pushes turn A's end, then re-emits ready from A's late answer under live turn B", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("first");
+				yield* client.push(snapshot([USER_A], "turn", 1));
+				// Turn A ends on the push, ahead of its own answer frame.
+				yield* client.push(snapshot(TURN_A, "idle", 2));
+				yield* collectTo(events, "turn A's ready", isReady);
+
+				// The core admits on that `ready`. The send's `sent` mark walks the projection back
+				// to `prompting`, which is what makes the stale answer a difference again.
+				yield* agent.prompt("second");
+				yield* collectTo(events, "turn B's prompting", isPrompting);
+
+				// A's answer, arriving after B went out. `SnapshotProjection` carries no revision
+				// (`./items.ts`), so `eventsOf` has nothing to compare and folds it as current.
+				yield* client.answer(0, snapshot(TURN_A, "idle", 2));
+
+				const late = yield* settled(events);
+				assert.isTrue(
+					Option.isSome(late) && isReady(late.value),
+					`turn A's late answer emitted ${JSON.stringify(late)} rather than a second ready`,
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	it.live("does the same answer-first, so the pair's order is not the variable", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("first");
+				// A's answer wins the race this time, and turn A's end reaches the core from it.
+				yield* client.answer(0, snapshot(TURN_A, "idle", 2));
+				yield* collectTo(events, "turn A's ready", isReady);
+
+				yield* agent.prompt("second");
+				yield* collectTo(events, "turn B's prompting", isPrompting);
+
+				// A's push, arriving after B went out — the same stale `idle` from the other side.
+				yield* client.push(snapshot(TURN_A, "idle", 2));
+
+				const late = yield* settled(events);
+				assert.isTrue(
+					Option.isSome(late) && isReady(late.value),
+					`answer-first emitted ${JSON.stringify(late)} rather than a second ready`,
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	it.live("emits nothing late when no send lands in the gap — the send is the variable", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("first");
+				yield* client.push(snapshot([USER_A], "turn", 1));
+				yield* client.push(snapshot(TURN_A, "idle", 2));
+				yield* collectTo(events, "turn A's ready", isReady);
+
+				// The same late answer as the first case, with nothing sent in between: the
+				// projection is still at `ready`, so the stale snapshot is worth no event at all.
+				yield* client.answer(0, snapshot(TURN_A, "idle", 2));
+
+				const late = yield* settled(events);
+				assert.isTrue(
+					Option.isNone(late),
+					`the late answer emitted ${JSON.stringify(late)} with no send in the gap`,
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+});
+
+const machine = aiAgentSessionMachine({cwd: CWD});
+
+const apply = (
+	state: AiAgentSessionState,
+	msg: AiAgentSessionMsg,
+): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
+
+describe("what the core does with that second ready", () => {
+	it("admits the operator's next send instead of queueing it", () => {
+		const running: AiAgentSessionState = {
+			...initialState(CWD),
+			phase: "prompting",
+			sessionId: SESSION.id,
+		};
+
+		const [ready] = apply(running, {
+			type: "event",
+			sessionId: SESSION.id,
+			event: {kind: "phase", phase: "ready"},
+		});
+		assert.strictEqual(ready.phase, "ready");
+
+		const [after, cmds] = apply(ready, {
+			type: "prompt",
+			text: "third",
+			key: "key-c",
+			timestamp: 1_700_000_000_000,
+		});
+		// Admitted, not queued: the text goes to the layer, which hands it to a session Pi is
+		// still running.
+		assert.deepStrictEqual(after.queued, []);
+		assert.isTrue(
+			cmds.some((cmd) => cmd.type === "aiAgent.prompt"),
+			`the core queued rather than admitting: ${JSON.stringify(cmds)}`,
+		);
+	});
+});
+
+const request = (command: Record<string, unknown>): unknown => ({
+	type: "request",
+	id: "req-1",
+	request: command,
+});
+
+describe("the pinned pi-protocol prompt command", () => {
+	/**
+	 * `PromptCommandSchema` is a `StrictObject` (`additionalProperties: false`, `dist/schemas.js`),
+	 * so `streamingBehavior` is not a field a caller may add to the wire — the frame is refused
+	 * before it reaches a session. Pi's error names an option on the *SDK*'s `PromptOptions`
+	 * (`pi-coding-agent/dist/core/agent-session.d.ts`), which is a different surface.
+	 */
+	it("refuses a prompt carrying streamingBehavior, and takes the same prompt without it", () => {
+		const bare = request({command: "prompt", sessionId: SESSION.id, text: "hello"});
+		assert.deepStrictEqual(parseClientMessage(bare), bare as ClientMessage);
+
+		assert.throws(
+			() =>
+				parseClientMessage(
+					request({
+						command: "prompt",
+						sessionId: SESSION.id,
+						text: "hello",
+						streamingBehavior: "followUp",
+					}),
+				),
+			ProtocolValidationError,
+		);
+	});
+
+	it("already carries steer as its own command, so that arm needs no wire change", () => {
+		const steer = request({command: "steer", sessionId: SESSION.id, text: "hello"});
+		assert.deepStrictEqual(parseClientMessage(steer), steer as ClientMessage);
+	});
+});

--- a/reports/2026-09-07-pi-mid-turn-prompt-refusal.md
+++ b/reports/2026-09-07-pi-mid-turn-prompt-refusal.md
@@ -1,0 +1,147 @@
+# Why Pi refuses a mid-turn prompt — investigation for #8214
+
+**Date:** 2026-09-07 · **Issue:** [#8214](https://github.com/kamp-us/phoenix/issues/8214) ·
+**Milestone:** Tuval first slice (#52)
+
+Point-in-time. Source read at `apps/tuval` on `main` at `ab17cdab5e`; dependency claims read from
+the pinned `@earendil-works/*` 0.84.3 trees in this clone's `node_modules`, never from the 0.85.1
+line (that upgrade is epic [#8518](https://github.com/kamp-us/phoenix/issues/8518) and is not this).
+
+The reproduction is committed beside the code it describes, as
+[`apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts`](../apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts).
+Six cases, no model spend, no socket.
+
+## The short version
+
+```
+turn A running ──► A's end pushed ──► core: ready ──► operator sends B ──► core: prompting
+                                                                             │
+                          A's *other* frame (the answer) arrives here ───────┘
+                                            │
+                                            ▼
+                          projection folds stale idle ──► second "ready"
+                                            │
+                                            ▼
+                     core is ready while Pi runs B ──► operator sends C ──► Pi refuses C
+```
+
+The core's phase and Pi's phase disagree because one turn's end reaches the projection **twice**,
+and the second arrival lands after a later send has already walked the projection back to
+`prompting`.
+
+## Reproduces, on current source
+
+`PiAiAgent`'s `follow` folds two things through one queue: the server's snapshot pushes and the
+snapshot each `pi.prompt` answer carries. `SnapshotProjection` (`pi/ai-agent/items.ts`) holds
+`items`, `usage` and `phase` — **no `revision`** — so `eventsOf` has nothing to compare a snapshot
+against and folds every arrival as current. `SessionSnapshot` does carry `revision` on the wire
+(`pi-protocol` `SessionSnapshotSchema`, and `pi/server/snapshots.ts` fills it); only the projection
+ignores it.
+
+The event order that produces the disagreement, all three cases in the committed test:
+
+| Schedule | Sent in the gap? | Second `ready`? |
+|---|---|---|
+| A's push, then B's send, then A's answer | yes | **yes** |
+| A's answer, then B's send, then A's push | yes | **yes** |
+| A's push, then A's answer, nothing sent | no | no |
+
+**The variable is the send, not the order of the pair.** #8183's folded comment reads the push-first
+schedule as the failure and answer-first as the control; the control does not hold. Whichever of a
+turn's two frames lands *after* the next send's `sent` mark re-folds a stale `idle` over a
+`prompting` projection, and the difference is emitted as `ready`. Answer-first is a different
+arrival order, not a protective one.
+
+With nothing sent in the gap the same late frame is worth no event, which is the case
+`turn-end.unit.test.ts` already pins — that test passes and always did, because it has no send in
+the gap.
+
+## The trace, both cases
+
+**A normal turn.** Core admits at `ready`, walks itself to `prompting`, `PiAiAgent.prompt` offers
+`{_tag: "sent"}` onto the fold queue and forks `pi.prompt`. The `sent` mark emits `prompting`, the
+core marks the oldest unstarted send `running` (`core/sends.ts` `markTurnRunning`). The turn's end
+arrives once — push and answer carry the same revision, and the second is a no-op difference — the
+core folds `ready` and `settleAccepted` accepts the oldest running send.
+
+**The failing case.** Same up to turn A's end. Then:
+
+1. B admitted at `ready`; `sent` mark → projection `prompting`; core marks B `running`.
+2. A's late frame folds → `ready`. The core folds it and `settleAccepted` accepts **B**, whose text
+   Pi is at that moment still running. Truthful in outcome (B did cross) but reached early.
+3. Core phase is `ready` under a live turn. C is admitted rather than queued — `core/machine.ts`'s
+   `prompt` cell queues only at `phase === "prompting"`.
+4. `AgentSessionHost` calls `session.prompt(text, {expandPromptTemplates: false})`. `AgentSession`
+   is streaming, no `streamingBehavior` was passed, and it throws
+   (`pi-coding-agent/dist/core/agent-session.js:836`).
+5. The refusal comes back as `ProtocolRefused` → `PromptError{reason: "refused"}`
+   (`pi/ai-agent/refusals.ts`), rides the event stream as a keyless `failure`, and
+   `settleFailedTurn` attributes it by order: B is already `accepted`, so `runningSend` is C. **The
+   right key is settled.**
+
+## The original report's "the message vanishes" no longer holds
+
+`readHeld` (`shell/chat/outgoing.ts`) turns a `refused` outcome into an `UnsentMessage`, and
+`UnsentMessages.tsx` renders it above the composer in `ChatWindow` with a Restore. The window that
+sent C holds C's copy under C's key until the outcome lands, and a `refused` outcome is exactly the
+one that surfaces it. So C's text is recoverable today. What is *not* fixed is that the send is
+refused at all, and that the phase line reads `ready` while the agent is working.
+
+## What could carry `streamingBehavior`, and what each would cost
+
+The error names an option on the **SDK**, and the SDK is not the wire.
+
+- **`@earendil-works/pi-protocol@0.84.3`'s `PromptCommandSchema` is
+  `StrictObject({command, sessionId, text})`** — `additionalProperties: false` (`dist/schemas.js:5`,
+  `:260`). A prompt frame carrying `streamingBehavior` is refused by `parseClientMessage` before it
+  reaches any session. The committed test asserts both arms. **The remedy cannot ride the pinned
+  prompt command.** The protocol package is already patched in this repo (ADR 0364), but that patch
+  is a codec-compilation speed fix; widening a schema is a different order of change.
+- **`AgentSessionHost` (`handleOf().prompt`)** — the one place Pi's own types live. It can pass
+  `streamingBehavior` on `PromptOptions` with no wire change at all, either as a constant or as a
+  decision read off `session.isStreaming`. Cheapest boundary by a distance.
+- **`dispatch.ts`'s `case "prompt"`** — could route to `handle.steer` when the session is streaming.
+  Also no wire change; `steer` is already a wire command and already on `PiSessionHandle`.
+- **`PiSessionHandle` gaining `followUp`** — the SDK has `followUp()` and `getFollowUpMessages()`,
+  but `SessionSnapshotSchema` projects `queuedSteer`/`queuedSteerCount` and **nothing for follow-ups**.
+  A follow-up queued at Pi would be invisible to every Tuval surface and cancellable from none. Making
+  it visible means widening a vendored strict schema.
+- **The core (`core/machine.ts` / `core/queue.ts`)** — could stop admitting on a `ready` it cannot
+  trust. That is a fix for the disagreement rather than for its symptom.
+
+## Recommendation
+
+Two bounded repairs, in this order. Neither picks `steer` over `followUp`.
+
+**R1 — drop the stale snapshot (fixes the cause).** Carry the last folded `revision` on
+`SnapshotProjection` and ignore a snapshot at or below it. The field is already on the wire and
+already filled by the server, so this is a projection change with no protocol surface. Regression
+cases: the two failing schedules in the committed test flip to "no second ready"; the third and
+`turn-end.unit.test.ts`'s two cases stay green (a resume seeds the projection off `heldSnapshot`,
+so the seed's revision has to seed the comparison too, or the first push after a reattach is
+dropped).
+
+**R2 — make the refusal impossible rather than unlikely (defence in depth).** Pass a
+`streamingBehavior` from `AgentSessionHost`, so a send that still races loses nothing. Regression
+case: a `PiSessionHost` fake whose session reports streaming takes the prompt instead of refusing.
+
+R1 alone leaves a narrower race (the core's `ready` is still a moment old when the operator sends).
+R2 alone leaves the phase line lying to the operator. R1 without R2 is the honest minimum.
+
+## The decision this leaves for a human
+
+**Which behaviour does a raced mid-turn send take — `steer` or `followUp` — and does Tuval keep two
+queues?**
+
+Not answerable from the source, and R2 cannot land without it:
+
+- `steer` interrupts the running turn with the operator's text. Already projected on the wire
+  (`queuedSteer`), already on `PiSessionHandle`, already dispatchable. Visible and cancellable.
+- `followUp` waits for the turn to end. Matches what `core/queue.ts` already promises an operator,
+  and duplicates it: the text would then be queued at Pi, invisible to the window, outside the
+  core's `queueLimit`, and released by nothing when the session is abandoned — which is the exact
+  failure ADR 0357 and #8159 built the core queue to end.
+- The third answer is "neither": fix R1, keep one queue in the core, and let a raced send stay a
+  refusal the window offers back.
+
+#8159's author owns this one. Nothing in this investigation selects it.


### PR DESCRIPTION
An investigation, not a behaviour change. #8214 asks why a send the core admitted reaches Pi
mid-turn and comes back as `Agent is already processing. Specify streamingBehavior ('steer' or
'followUp') to queue the message.` This lands a deterministic reproduction and the write-up.

## Acceptance criteria

- [x] Record a deterministic current-source reproduction or a precise account of why the original
      incident no longer reproduces, with source revision and event order; use scripted/local
      fixtures without live model spend — `mid-turn-refusal.unit.test.ts`, read at `ab17cdab5e`,
      stub client, no model spend.
- [x] Trace core admission, server processing state, push/answer order, send-key settlement and
      held-text recovery for the failing case and a normal turn — the report's "The trace, both
      cases" and the held-text section.
- [x] Test the folded #8183 schedule and its answer-first control, distinguishing demonstrated cause
      from remaining hypotheses — three schedules in the test; answer-first is not protective, the
      send in the gap is the variable.
- [x] Establish which repo-owned boundaries could carry streamingBehavior and what each candidate
      remedy would change; do not assume the pinned RPC supports a field because the underlying SDK
      error names it — five boundaries in the report; the wire's refusal is asserted in the test.
- [x] Deliver a bounded repair recommendation with checkable regression cases, or evidence of
      supersession. Explicitly identify any unresolved queue/recovery product decision for a human
      instead of silently selecting it — R1/R2 with regression cases; `steer` vs `followUp` left to
      #8159's author.

## What it reproduces

`apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts` — six cases, scripted stub client, no
model spend, no socket:

- turn A's end pushed, a send in the gap, A's answer late → a second `ready` under a live turn
- the same answer-first → the same second `ready`, so the pair's arrival order is **not** the
  variable; the send in the gap is
- the same schedule with nothing sent in the gap → nothing late, isolating the cause
- the core admits (rather than queues) the next prompt on that second `ready`
- the pinned `pi-protocol@0.84.3` prompt command refuses a `streamingBehavior` field and takes the
  same command without it; `steer` is already its own wire command

The mechanism: `SnapshotProjection` (`pi/ai-agent/items.ts`) carries no `revision`, so `eventsOf`
folds a stale snapshot as current. A turn's end reaches the projection twice — the server's push and
the `pi.prompt` answer — and whichever arrives after the next send's `sent` mark re-folds a stale
`idle` over a `prompting` projection and emits `ready`.

## What the report says

`reports/2026-09-07-pi-mid-turn-prompt-refusal.md` carries the full trace (normal turn vs failing
case), the boundary analysis, and the recommendation. Three things a reader should not miss:

- **The pinned RPC cannot carry `streamingBehavior`.** `PromptCommandSchema` is a `StrictObject`
  (`additionalProperties: false`), so the field is refused before it reaches a session. Pi's error
  names an option on the SDK's `PromptOptions`, which is a different surface. `AgentSessionHost` is
  the cheapest boundary that could pass it, with no wire change.
- **The original report's "the message vanishes" is superseded.** The refusal settles the right key
  (`settleFailedTurn` picks the refused send, because the earlier one is already accepted), and
  `readHeld` + `UnsentMessages.tsx` surface it as a Restore.
- **`steer` vs `followUp` is left open for a human**, with the cost of each stated. `followUp` would
  put the operator's text in a Pi-side queue no Tuval surface projects and nothing releases — which
  is the failure ADR 0357 built the core queue to end.

Fixes #8214

## Deviations

- **Scope narrowing** — **Said:** the spawn brief asked for a code fix passing `streamingBehavior`
  on the queued mid-turn prompt path. **Did:** landed the reproduction and the report, and left the
  behaviour unchanged. **Why:** the issue's criterion 4 forbids assuming the pinned RPC carries the
  field (it does not), and criterion 5 requires the queue/recovery decision to go to a human rather
  than be silently selected. **Disposition:** stated here and in the report's closing section.
- **Out-of-scope change** — **Said:** #8214 names the mid-turn refusal. **Did:** the report also
  records that the #8183 folded comment's answer-first *control* does not hold, and that
  `settleAccepted` accepts the second send early on the spurious `ready`. **Why:** both fell out of
  the same reproduction and the issue asks to distinguish demonstrated cause from hypothesis.
  **Disposition:** stated here; no code changed for either.
