### PR TITLE
chore: A Tuval Claude session opened from the picker never narrates prompting for its first turn

### DIFF
--- a/.patterns/agent-layer-phase-contract.md
+++ b/.patterns/agent-layer-phase-contract.md
@@ -60,6 +60,34 @@ turn's end and accepts a send the backend never started
 ([#8107](https://github.com/kamp-us/phoenix/issues/8107)). `prompting` marks the send's turn
 running; only that turn's end accepts it.
 
+## The open's own `ready`, and the first turn it can swallow
+
+A layer narrates its open on the same stream it narrates turns on, and the core is not listening
+yet. `subscriptions` in [`core/machine.ts`](../apps/tuval/src/ai-agent/core/machine.ts) opens the
+events Sub off `state.sessionId`, which the `started` Msg sets — and `started` is what the layer's
+own `start` call answered, so everything `start` emitted is already sitting in the layer's queue
+when the Sub attaches. The queue is unbounded and nothing is lost; what varies is *when* it drains.
+
+That leaves a window: the core reaches `ready` on `started`, so a prompt written in it is admitted
+and `admit` walks the session to `prompting` — and then the open's own `ready`, folded a moment
+later, walks it straight back. The turn is running and the phase line says `Ready.`, with no
+`Working…` and no Escape affordance, which is what an operator measured across a 30 s first turn on
+a picker-opened Claude session ([#8358](https://github.com/kamp-us/phoenix/issues/8358)). A page
+re-attaching to an already-open process never sees it: that process opened long ago and has no
+opening events left to drain.
+
+The per-turn `prompting` is the whole defence, and it is why the layer owes one at the send rather
+than leaving `admit`'s to stand. It rides the same queue *behind* the open's events, so the session
+is back on `prompting` before the turn's first frame whichever order the drain took
+([#8156](https://github.com/kamp-us/phoenix/issues/8156)). Both orders are pinned in
+[`claude/agent/phases.unit.test.ts`](../apps/tuval/src/claude/agent/phases.unit.test.ts), which
+folds the layer's real event stream through the real core — including the case with that one event
+removed, where the running turn reads idle for its whole length.
+
+So a layer whose `start` narrates a `ready` owes a `prompting` per send. Emitting one only when the
+backend confirms the turn — or trusting the core's own admission — leaves the first turn of every
+freshly opened session narrated as idle.
+
 ## Reference shapes
 
 - [`claude/agent/ClaudeAiAgent.ts`](../apps/tuval/src/claude/agent/ClaudeAiAgent.ts) — `prompt`

--- a/apps/tuval/src/claude/agent/phases.unit.test.ts
+++ b/apps/tuval/src/claude/agent/phases.unit.test.ts
@@ -42,15 +42,19 @@ const promptedTurn = (opening: ReadonlyArray<SDKMessage>, count: number) =>
 		}),
 	);
 
-/** What the open alone puts on the queue, before any prompt — the `ready` #8107 is about. */
-const openingOf = (opening: ReadonlyArray<SDKMessage>) =>
+/** Everything the open alone puts on the queue, in order, before any prompt. */
+const openingEvents = (opening: ReadonlyArray<SDKMessage>) =>
 	on({opening, deferOpening: true}, (agent) =>
 		Effect.gen(function* () {
 			yield* agent.start({cwd: CWD});
-			return [...(yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS)))].filter(
-				(event) => event.kind === "phase" && event.phase === "ready",
-			);
+			return [...(yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS)))];
 		}),
+	);
+
+/** What the open alone puts on the queue, before any prompt — the `ready` #8107 is about. */
+const openingOf = (opening: ReadonlyArray<SDKMessage>) =>
+	Effect.map(openingEvents(opening), (events) =>
+		events.filter((event) => event.kind === "phase" && event.phase === "ready"),
 	);
 
 /**
@@ -231,6 +235,65 @@ describe("the core over what the layer emitted", () => {
 			});
 			assert.isNull(next.failure);
 			assert.deepStrictEqual(cmds, [{type: "aiAgent.prompt", text: "and again", key: "k2"}]);
+		}),
+	);
+});
+
+/**
+ * The first turn of a session the picker has just opened (#8358).
+ *
+ * The open's own events sit in the layer's queue until the core's `started` commit opens the events
+ * Sub (`../../ai-agent/core/machine.ts`, `subscriptions`), so a prompt admitted in that window is
+ * folded ahead of them: `admit` walks the session to `prompting` and the open's own `ready` lands on
+ * top of it. That is the order the operator measured on PR #8199's head — a 30 s turn narrated
+ * `Ready.`, with no `Working…` and no Escape affordance.
+ *
+ * What closes it is the `prompting` the send itself narrates (#8156, `prompt` in
+ * `./ClaudeAiAgent.ts`). It sits behind the open's events on the one queue, so the session is back
+ * on `prompting` before the turn's first frame and stays there until the `result`.
+ */
+describe("a first turn whose open drained after the send", () => {
+	const sent = (): AiAgentSessionState =>
+		apply(opened, {type: "prompt", text: "hello", key: "k1", timestamp: SENT_AT})[0];
+
+	it.effect("narrates prompting for the whole turn, and ready only at its end", () =>
+		Effect.gen(function* () {
+			const opening = yield* openingEvents(messages("assistant-turn"));
+			const turn = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
+
+			const late = fold(sent(), opening);
+			assert.strictEqual(late.phase, "ready", "the open's ready is what walks the send back");
+			assert.deepStrictEqual(
+				late.sends,
+				[{key: "k1", state: "pending", turn: "unstarted"}],
+				"the open's ready must not accept a send whose turn never began (#8107)",
+			);
+
+			const running = fold(late, turn.slice(0, -1));
+			assert.strictEqual(running.phase, "prompting");
+			assert.deepStrictEqual(running.sends, [{key: "k1", state: "pending", turn: "running"}]);
+
+			const settled = fold(running, turn.slice(-1));
+			assert.strictEqual(settled.phase, "ready");
+			assert.deepStrictEqual(settled.sends, [{key: "k1", state: "accepted"}]);
+		}),
+	);
+
+	/**
+	 * Why that narration is load-bearing rather than decoration. Drop the one event the send
+	 * publishes and the same fold leaves a running turn reading idle for its whole length — the
+	 * defect itself, pinned here so a layer that stops narrating its own send reds the case above
+	 * rather than shipping a `Ready.` line over a live turn.
+	 */
+	it.effect("would read idle for the whole turn without the send's own prompting", () =>
+		Effect.gen(function* () {
+			const opening = yield* openingEvents(messages("assistant-turn"));
+			const turn = yield* promptedTurn(messages("assistant-turn"), ASSISTANT_TURN_EVENTS);
+			assert.deepStrictEqual(turn[0], {kind: "phase", phase: "prompting"});
+
+			const unnarrated = fold(fold(sent(), opening), turn.slice(1, -1));
+			assert.strictEqual(unnarrated.phase, "ready");
+			assert.deepStrictEqual(unnarrated.sends, [{key: "k1", state: "pending", turn: "unstarted"}]);
 		}),
 	);
 });


### PR DESCRIPTION
Fixes #8358

An investigation into why a Claude session opened from the Tuval picker narrates `Ready.` through
its whole first turn. The answer lands as evidence rather than a repair: the defect is not
reproducible on current source, and the change that closed it is named and now pinned.

## What the investigation found

The window reads the phase line and the transcript off the same value — `state` in
`apps/tuval/src/shell/chat/ChatWindow.tsx`, the process's own committed state. So the report's core
observation (`data-phase="ready"` while the assistant row grows to 4740 characters) is a fact about
the core's session state, not about rendering: the core really was at `ready` while it folded the
turn's items. That also rules out #8538 (a picker-opened window painting once and never repainting)
as the cause here — under that defect the transcript would have been frozen too.

One mechanism produces exactly that state. A layer narrates its open on the same stream it narrates
turns on, and the core is not listening yet: `subscriptions` opens the events Sub off
`state.sessionId`, which the `started` Msg sets, and `started` is what the layer's own `start` call
answered — so everything `start` emitted is already in the layer's queue when the Sub attaches. The
core reaches `ready` on that same commit, so a prompt admitted before the queue drains is walked to
`prompting` by `admit` and then walked back by the open's own `ready`. With nothing behind that
`ready` to re-narrate the turn, the session sits at `ready` until the `result` lands.

What closes it is the `prompting` the send itself publishes — `ClaudeAiAgent.prompt`, added by
#8156, which landed after the head the report was measured on (`a17a1bb0`). It rides the same queue
behind the open's events, so the session is back on `prompting` before the turn's first frame
whichever order the drain took.

## What lands

- Two cases in `apps/tuval/src/claude/agent/phases.unit.test.ts` folding the layer's real event
  stream through the real core in the reported order — the open's events drained *after* the send.
  One holds the expectation (`prompting` for the whole turn, `ready` only at its end, and the send
  accepted only on the turn it ran); the other removes the send's own `prompting` and shows the same
  fold leaving a running turn narrated idle, so a layer that stops narrating its send reds the first
  case rather than shipping a `Ready.` line over a live turn.
- A section in `.patterns/agent-layer-phase-contract.md` stating the rule the contract was missing:
  a layer whose `start` narrates a `ready` owes a `prompting` per send, and trusting the core's own
  admission to stand is what leaves a freshly opened session's first turn reading idle.

Evidence is scripted throughout — the existing `claude/agent/fixtures` harness replays golden SDK
fixtures, so nothing calls a model and no credential is needed.

## Acceptance criteria

- [x] Record current-source first-turn behavior for an immediate prompt during startup and a prompt
  after startup, with partial streaming on/off and a reattached-session control; distinguish
  original live observations from new scripted evidence. — recorded on current source for both drain
  orders as scripted evidence, and the original CLI observations are quoted as the report's, never
  restated as measured today. The streaming and reattach axes are reasoned from source rather than
  measured; see "What is not settled" and the first deviation.
- [x] Trace startup completion, prompt admission/release, Claude prompting publication, queued phase
  events and rendered phase in order, identifying the first point of divergence if reproduced. —
  traced in "What the investigation found"; the divergence point is the open's own `ready` folded
  after `admit`, and the test asserts the session at `ready` right there.
- [x] Use a deterministic scripted backend/SDK and controllable startup to exercise the real
  relevant handler/core path without requiring credentials or model spend; state any limitation of
  that evidence. — the `claude/agent/fixtures` scripted SDK with `deferOpening`, folded through the
  real `aiAgentSessionMachine`. Its limitation is stated: it fixes the drain order by construction
  rather than observing the one a live desk takes.
- [x] If the issue persists, deliver a bounded repair recommendation and failing regression scenario
  that preserves send-ledger and interruption semantics. If it is superseded, identify the landed
  change and evidence that distinguishes fixed behavior from an untested assertion. — superseded by
  #8156; the two cases are that evidence, and both assert the send ledger (`unstarted` under the
  open's `ready`, `running` under the send's `prompting`, `accepted` only on the turn's end).
- [x] Do not weaken the observed expectation: an actually running first turn must not be narrated as
  idle merely to make the test pass; any necessary real-CLI capture remains a separately identified
  human-owned evidence step. — the first case asserts `prompting` for the whole running turn; the
  second names the idle reading as the defect it holds against. The real-CLI capture is named as
  human-owned below.

## What is not settled

The reported head is not reproducible from here, so what delayed the drain past the send on that
particular run is unresolved. Answering it needs a run against `a17a1bb0` or a live desk with the
real CLI, which stays a human-owned evidence step. The partial-streaming axis is not implicated:
the report's own control run with the flag off shows identical phase behaviour, and nothing on the
phase path reads that flag.

Filed while here: #8545 — the composer sends a prompt whatever the phase, so a prompt typed while a
picker-spawned session is still `starting` is refused by the core rather than queued.

## Deviations

- **Scope narrowing** — **Said:** #8358's criterion 1 asks for current-source first-turn behaviour
  recorded with partial streaming on and off and a reattached-session control. **Did:** recorded the
  core/layer ordering under both drain orders with scripted SDK fixtures, and reasoned the streaming
  and reattach axes from source rather than measuring them. **Why:** both axes need a live desk
  driving the real CLI, which the criteria themselves keep as a separately identified human-owned
  step; the streaming flag is read nowhere on the phase path, and a reattached page attaches to a
  process whose opening events drained long ago. **Disposition:** stated here and in "What is not
  settled".
- **Known defect left unfixed** — **Said:** the lane is #8358. **Did:** left the composer's
  unconditional send unfixed. **Why:** it is a different defect on a different surface and needs a
  call on whether the composer holds the send or the core queues at `starting`. **Disposition:**
  filed as #8545.
- **Out-of-scope change** — **Said:** #8358 names no pattern doc. **Did:** added a section to
  `.patterns/agent-layer-phase-contract.md`. **Why:** the rule the investigation established has no
  other home, and CLAUDE.md requires a load-bearing pattern to be written down rather than left in a
  test. **Disposition:** stated here.
- **Declined guidance** — **Said:** the spawn brief asked for a branch under the `umut/` prefix.
  **Did:** the lane branch is `build/8358-first-turn-phase-f12039bb`. **Why:** `fabrika build branch`
  mints the name itself and the later verbs resume and verify against that shape; a hand-named branch
  would fail the lane's own proofs. **Disposition:** stated here.
