### PR TITLE
fix: The prompt handler's projection re-seed can rewind an event the Sub folded but the host has not applied

### DIFF
--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -115,7 +115,7 @@ export const aiAgentHandlers = <RIn = never>(
 		...(options.byteLimit === undefined ? {} : {byteLimit: options.byteLimit}),
 	};
 	const slot = agentSlot(options.layer);
-	const projection = transcriptProjection();
+	const projection = transcriptProjection(limits);
 
 	/**
 	 * `onFail` is how a call whose refusal belongs to something the core is holding open answers for
@@ -235,8 +235,8 @@ export const aiAgentHandlers = <RIn = never>(
 			Effect.gen(function* () {
 				const state = yield* readSession;
 				if (state === null) return nothing;
-				yield* projection.seed(state);
-				yield* emit(aiAgentPortNames.transcript, transcriptOf(state));
+				const seeded = yield* projection.seed(state);
+				yield* emit(aiAgentPortNames.transcript, transcriptOf(seeded));
 				yield* emit(aiAgentPortNames.permissionPending, pendingOf(state));
 				yield* emit(aiAgentPortNames.modeState, modeStateOf(state));
 				return nothing;
@@ -244,8 +244,10 @@ export const aiAgentHandlers = <RIn = never>(
 
 		// The turn the core recorded in the very commit that produced this Cmd (#7978) rides no
 		// layer event, so the Sub's projection would publish a tail with the operator's half
-		// missing (#7979). Re-seeding is sound here rather than a race: this Cmd is applied after
-		// every event Msg the projection has folded, so the committed state is never behind it.
+		// missing (#7979). The committed state can be behind the projection while this runs — the
+		// Sub folds each event before the host applies its Msg — so the seed carries that tail
+		// across rather than replacing it (`./projection.ts`, #8034), and the emit publishes what
+		// the seed answered rather than the commit it started from.
 		//
 		// It is also the one handler whose answer names the send it is about. `sent` carries the
 		// Cmd's own key, so the window that minted it learns what became of *its* text rather than
@@ -257,8 +259,8 @@ export const aiAgentHandlers = <RIn = never>(
 			Effect.gen(function* () {
 				const state = yield* readSession;
 				if (state !== null) {
-					yield* projection.seed(state);
-					yield* emit(aiAgentPortNames.transcript, transcriptOf(state));
+					const seeded = yield* projection.seed(state);
+					yield* emit(aiAgentPortNames.transcript, transcriptOf(seeded));
 				}
 				const agent = yield* slot.current;
 				if (agent === null) {

--- a/apps/tuval/src/ai-agent/handlers/projection.ts
+++ b/apps/tuval/src/ai-agent/handlers/projection.ts
@@ -9,17 +9,35 @@
  * the founder's own bug, one surface over from the window (#7979). So the projection lives here,
  * where the `aiAgent.prompt` handler can put it back on the core's committed state.
  *
+ * `seed` rebases rather than replaces, and #8034 is why. The Sub dispatches an event and folds it
+ * in the same breath, and the host applies a dispatched Msg on a forked fiber that has to take the
+ * transition tail first (`../../host/actor.ts`), so the projection legitimately leads the committed
+ * state. A Cmd handler runs inside the permit its own commit holds, which puts it strictly ahead of
+ * every event Msg still queued — so a plain replace drops whatever the Sub folded in that gap, and
+ * drops it for good, because the Sub folds each event exactly once.
+ *
+ * The committed state stays the authority for everything else on purpose: the pending cards and the
+ * mode are what the core holds, and re-seeding those is how an answer's own progress reaches a
+ * projection no event will ever push forward (#8006). Only the transcript is carried across, and
+ * only its tail past the last item the commit names — an item older than that and absent from the
+ * commit is one the core's own window evicted, and appending it would put it back at the wrong end.
+ *
  * A plain map rather than a `Ref` for `agentSlot`'s reason (`./session.ts`): every read and write
  * of it is synchronous, which on one JS thread is the atomicity a `Ref` would buy.
  */
 
 import {Effect, type Scope} from "effect";
 import {ProcessSelf} from "../../process/self.ts";
-import type {AiAgentSessionState} from "../core/index.ts";
+import {type AiAgentSessionState, foldEvent, type WindowLimits} from "../core/index.ts";
 
 export interface TranscriptProjection {
-	/** Put this process's projection at `state`, replacing whatever stood before. */
-	readonly seed: (state: AiAgentSessionState) => Effect.Effect<void, never, ProcessSelf>;
+	/**
+	 * Put this process's projection on `state`, carry over the transcript tail it already holds past
+	 * that state, and answer what stands after — which is the state to publish from.
+	 */
+	readonly seed: (
+		state: AiAgentSessionState,
+	) => Effect.Effect<AiAgentSessionState, never, ProcessSelf>;
 	/**
 	 * Fold `step` over the standing projection and answer what it left, or `null` when this process
 	 * has none — which is every process whose events Sub has not opened yet.
@@ -29,11 +47,37 @@ export interface TranscriptProjection {
 	) => Effect.Effect<AiAgentSessionState | null, never, ProcessSelf>;
 }
 
-export const transcriptProjection = (): TranscriptProjection => {
+/**
+ * Replay the standing tail the commit has not caught up to, through the core's own item fold so a
+ * backend's user item still joins the local echo it supersedes (`../core/fold.ts`).
+ */
+const rebase = (
+	committed: AiAgentSessionState,
+	standing: AiAgentSessionState,
+	limits: WindowLimits,
+): AiAgentSessionState => {
+	const named = new Set(committed.transcript.items.map((item) => item.id));
+	let cut = -1;
+	standing.transcript.items.forEach((item, index) => {
+		if (named.has(item.id)) cut = index;
+	});
+	return standing.transcript.items
+		.slice(cut + 1)
+		.reduce((state, item) => foldEvent(state, {kind: "item", item}, limits), committed);
+};
+
+export const transcriptProjection = (limits: WindowLimits): TranscriptProjection => {
 	const held = new WeakMap<Scope.Scope, AiAgentSessionState>();
 
-	const seed = (state: AiAgentSessionState): Effect.Effect<void, never, ProcessSelf> =>
-		Effect.map(ProcessSelf, (self) => void held.set(self.scope, state));
+	const seed = (
+		state: AiAgentSessionState,
+	): Effect.Effect<AiAgentSessionState, never, ProcessSelf> =>
+		Effect.map(ProcessSelf, (self) => {
+			const standing = held.get(self.scope);
+			const next = standing === undefined ? state : rebase(state, standing, limits);
+			held.set(self.scope, next);
+			return next;
+		});
 
 	const fold = (
 		step: (state: AiAgentSessionState) => AiAgentSessionState,

--- a/apps/tuval/src/ai-agent/handlers/seed-rebase.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/seed-rebase.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The interleaving #8034 named: an event the Sub has folded and the host has not applied yet, and
+ * then a Cmd that re-seeds the projection from the committed state.
+ *
+ * It is driven at the handler set rather than through a spawned process, because the thing under
+ * test is exactly the gap a running host closes for itself — the Msg the Sub dispatched waits for
+ * the transition tail the Cmd's own commit is holding. Here `dispatch` records and applies nothing,
+ * which holds that gap open for as long as the test needs it.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Scope} from "effect";
+import {assistantItem} from "../../ai-agent-fixtures/transcripts.ts";
+import {ProcessPorts} from "../../ports/index.ts";
+import {ProcessSelf} from "../../process/self.ts";
+import {
+	type AiAgentSessionMsg,
+	type AiAgentSessionState,
+	eventsSub,
+	initialState,
+} from "../core/index.ts";
+import type {TranscriptPayload} from "../ports/index.ts";
+import {plainReply, SESSION_ID} from "../service/fixtures/scripts.ts";
+import {ScriptedAiAgent} from "../service/index.ts";
+import {aiAgentHandlers} from "./index.ts";
+import {aiAgentPortNames} from "./publish.ts";
+
+const CWD = "/w";
+
+const settled = assistantItem("a-0", "first");
+const late = assistantItem("a-1", "late");
+
+/** What the core has committed: one settled reply, and nothing the first turn produced. */
+const committed: AiAgentSessionState = {
+	...initialState(CWD),
+	phase: "ready",
+	sessionId: SESSION_ID,
+	transcript: {items: [settled], omitted: initialState(CWD).transcript.omitted},
+};
+
+/** Turn one narrates an item; turn two narrates nothing, so only the seed can publish it back. */
+const script = {
+	...plainReply,
+	turns: [{events: [{kind: "item", item: late} as const]}, {events: []}],
+};
+
+describe("the prompt handler's re-seed", () => {
+	it.live("keeps an item the Sub folded before the host applied its Msg", () =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const scope = yield* Effect.scope;
+				const published: Array<{port: string; payload: unknown}> = [];
+				const dispatched: Array<AiAgentSessionMsg> = [];
+
+				const provide = <A, E>(
+					effect: Effect.Effect<A, E, ProcessSelf | ProcessPorts | Scope.Scope>,
+				) =>
+					effect.pipe(
+						Effect.provideService(Scope.Scope, scope),
+						Effect.provideService(ProcessSelf, {scope, state: () => committed}),
+						Effect.provideService(ProcessPorts, {
+							emit: (port: string, payload: unknown) =>
+								Effect.sync(() => {
+									published.push({port, payload});
+									return [];
+								}),
+						}),
+					);
+
+				const row = aiAgentHandlers({layer: ScriptedAiAgent.layer(script), cwd: CWD});
+
+				yield* provide(
+					row.handlers["aiAgent.start"]({
+						type: "aiAgent.start",
+						cwd: CWD,
+						resume: null,
+						mode: null,
+					}),
+				);
+				yield* Effect.forkScoped(
+					provide(
+						row.subs["aiAgent.events"](
+							eventsSub(SESSION_ID, 0),
+							(msg) => void dispatched.push(msg),
+						),
+					),
+				);
+				yield* Effect.sleep("20 millis");
+
+				yield* provide(
+					row.handlers["aiAgent.prompt"]({type: "aiAgent.prompt", text: "one", key: "k1"}),
+				);
+				yield* Effect.sleep("20 millis");
+
+				// The Sub folded the item and handed the host a Msg this test never applies, so the
+				// committed state the second Cmd re-seeds from is a turn behind the projection.
+				assert.isTrue(dispatched.some((msg) => msg.type === "event"));
+				assert.deepStrictEqual(committed.transcript.items, [settled]);
+
+				yield* provide(
+					row.handlers["aiAgent.prompt"]({type: "aiAgent.prompt", text: "two", key: "k2"}),
+				);
+
+				const tails = published
+					.filter((entry) => entry.port === aiAgentPortNames.transcript)
+					.map((entry) => entry.payload as TranscriptPayload);
+				assert.deepStrictEqual(
+					tails.at(-1)?.items.map((item) => item.id),
+					["a-0", "a-1"],
+				);
+			}),
+		),
+	);
+});


### PR DESCRIPTION
Fixes #8034

`aiAgent.prompt` re-seeded the process's transcript projection from the core's committed state and
`projection.seed` replaced wholesale, so anything the events Sub had folded and the host had not
applied yet was dropped from the tail published on the `transcript` port — and dropped for good,
because the Sub folds each event exactly once.

## The reachability question, answered: it is reachable

Grounded in this repo's host, `apps/tuval/src/host/actor.ts`, which mirrors `run` in
`kamp-us/demlik/src/run.ts` at the pinned `@demlik/tea@0.12.0`:

- The Sub's body is `dispatch(event)` then `projection.fold(...)`
  (`apps/tuval/src/ai-agent/handlers/index.ts`), so the projection is written first.
- `dispatchUnawaited` does not apply the Msg. It forks it with `Effect.forkIn(enqueue(msg), scope)`
  and no `startImmediately`, so the Msg's own head is scheduled rather than run inline — the same
  host passes `{startImmediately: true}` explicitly where it *does* want a synchronous head
  (`armSub`).
- `enqueue` puts every Msg behind `tail.withPermits(1)`, the single transition tail.
- `commit` runs `runInterpret(cmds)` while still holding that permit, so a Cmd handler runs strictly
  ahead of every event Msg still queued on the tail.

So between the Sub's fold and the event Msg taking the tail there is at least one scheduler turn, and
a `prompt` Msg that takes the tail in that gap runs its Cmd with the projection ahead of the commit.
The `ready` guard in `core/machine.ts` bounds *when* the prompt is accepted; it does not close this
gap, because the queued event has not been applied and so cannot have moved the phase.

## The fix

`projection.seed` now rebases: the committed state stays the base, and the standing projection's
transcript tail past the last item that state names is replayed onto it through the core's own
`foldEvent` item path — so a backend's user item still joins the local echo it supersedes. Only the
tail past the last named item is carried, because an older item absent from the commit is one the
core's window evicted and appending it would put it back at the wrong end. `seed` answers the state
that stands, and both callers now publish `transcriptOf(seeded)` rather than the commit they started
from.

The pending cards and the mode stay authoritative from the commit on purpose: re-seeding those is
how an answer's own progress reaches a projection no event will ever push forward (#8006).

## Acceptance criteria

- [x] The reachability question is answered in the PR description, grounded in the host's Msg/Cmd
  scheduling and cited by call site.
- [x] It is reachable, so `projection.seed` no longer discards items the standing projection holds,
  and `apps/tuval/src/ai-agent/handlers/seed-rebase.unit.test.ts` drives the interleaving — the Sub
  folds an item and hands the host a Msg the test never applies, then an `aiAgent.prompt` Cmd runs —
  and asserts the emitted `transcript` tail still carries that item. It reds on the old
  replace-wholesale seed.
- [x] Not applicable: the reachable arm was taken.
- [x] No comment under `apps/tuval/src/ai-agent/handlers/` asserts the ordering that `index.ts`'s
  own top docblock and `claude-restore-proof.unit.test.ts` contradict. The `aiAgent.prompt` comment
  now states that the commit can be behind the projection, which is what those two say.
- [x] `pnpm typecheck` and `pnpm lint` pass (`build check --surface code`: green, nothing
  unvalidated).

## Deviations

- **Scope narrowing** — **Said:** #8034 asks that the re-seed stop rewinding what the projection
  folded. **Did:** carried across the transcript only; a permission card or a mode the Sub folded
  and the host has not applied is still taken from the commit. **Why:** the commit has to stay
  authoritative for those two — re-seeding them is the mechanism #8006 added so an answer's own
  progress reaches a projection no event will push forward, and basing them on the projection would
  resurrect a card the operator already answered. **Disposition:** stated here and in
  `projection.ts`'s docblock.
- **Out-of-scope change** — **Said:** #8034 names the `aiAgent.prompt` handler. **Did:** also changed
  `aiAgent.republish` to publish `transcriptOf(seeded)`. **Why:** both call the one `projection.seed`
  this change rewrites, and leaving `republish` publishing its pre-seed argument would have kept the
  same rewind on the restore path. **Disposition:** stated here.
