### PR TITLE
docs: declare Tuval first slice fast-follows campaign

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ flowchart TD
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
 		camp_phoenix_i18n["phoenix i18n"]:::active
+		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::paused
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -117,6 +118,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
 | phoenix i18n | #53 | active |
+| Tuval first slice - fast follows | #54 | paused |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Declare Tuval first slice - fast follows against milestone #54, giving the four follow-up repairs (#8494, #8504, #8506 and #8509) a home outside active first-slice intake. Add the matching diagram node. The campaign is paused; starting dispatch remains a separate action.

Founder creation instruction recorded at https://github.com/kamp-us/phoenix/issues/8494#issuecomment-5577900269. The four issues are already homed to https://github.com/kamp-us/phoenix/milestone/54.

Validation: roadmap-guard passed against the live GitHub milestones; pre-commit Biome and leak-guard passed.

## Deviations

None.
