### PR TITLE
chore(roadmap): register campaign row for milestone #54

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ flowchart TD
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
 		camp_phoenix_i18n["phoenix i18n"]:::active
+		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::paused
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -117,6 +118,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
 | phoenix i18n | #53 | active |
+| Tuval first slice - fast follows | #54 | paused |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
The milestone "Tuval first slice - fast follows" (#54) exists on the board with no ROADMAP row, so the I1-I4 milestone-sync check fails on main for every open PR. This adds the row, paused.

Closes #8567

🤖 Generated with [Claude Code](https://claude.com/claude-code)