### PR TITLE
docs: activate Tuval first slice fast-follows campaign

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ flowchart TD
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
 		camp_phoenix_i18n["phoenix i18n"]:::active
-		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::paused
+		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -118,7 +118,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
 | phoenix i18n | #53 | active |
-| Tuval first slice - fast follows | #54 | paused |
+| Tuval first slice - fast follows | #54 | active |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Activate Tuval first slice - fast follows (milestone #54), allowing dispatch against its bounded repair backlog. Update the campaign row and matching diagram node from paused to active.

The founder delegated this next step in the current session; the separate start authorization is recorded at https://github.com/kamp-us/phoenix/issues/8494#issuecomment-5578247999. The initial four repairs are joined by #7749, #8086, #8453, #8237 and #8424 after current-work checks. #8425 stays in its existing campaign because a builder already holds it. #8506 now has a recorded immediate-failure, explicit-retry policy.

Validation: roadmap-guard passes against live GitHub milestones; git diff --check passes.

## Deviations

None.
