### PR TITLE
fix: A picker-opened Tuval window paints its first state and never repaints

### DIFF
--- a/apps/tuval/src/host/actor.ts
+++ b/apps/tuval/src/host/actor.ts
@@ -420,12 +420,19 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 		if (firstError !== null) return yield* Effect.die(firstError);
 	});
 
+	/**
+	 * This commit's publication, owed to the world however its Cmds settle: by the time a handler
+	 * runs the state is applied and checkpointed. Before #8538 the publication sat after
+	 * `runInterpret` in the same error channel, so one failing handler aborted the commit before it
+	 * and the process's public revision froze at 0 while its state went on advancing.
+	 */
+	const published = onCommit === undefined ? Effect.void : Effect.suspend(() => onCommit(state));
+
 	const commit = Effect.fn("Tuval.host.commit")(function* (next: S, cmds: readonly C[]) {
 		state = next;
 		yield* checkpoint(next);
 		yield* reconcile();
-		yield* runInterpret(cmds);
-		if (onCommit) yield* onCommit(state);
+		yield* runInterpret(cmds).pipe(Effect.ensuring(published));
 	});
 
 	const isMisaddressed = (msg: M): boolean => {
@@ -522,7 +529,7 @@ export const make = Effect.fn("Tuval.host.make")(function* <
 		Effect.gen(function* () {
 			yield* reconcile();
 			yield* runInterpret(initCmds);
-			if (onCommit) yield* onCommit(state);
+			yield* published;
 		}),
 	);
 

--- a/apps/tuval/src/process/commit-revision.unit.test.ts
+++ b/apps/tuval/src/process/commit-revision.unit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * A commit publishes whatever its Cmds do. The state a Msg produced is applied and checkpointed
+ * before any handler runs, so the process's public revision is owed it either way — and before
+ * #8538 it was not: `Tuval.host.commit` ran `onCommit` after `runInterpret` in the same error
+ * channel, so a failing handler aborted the commit before the `revision++` and the
+ * `state-changed` publish that live in `Processes.spawn`'s `onCommit`.
+ *
+ * The pairing is the point. One program and one Msg, spawned twice: wired ports (a graph-planned
+ * process) and `unwired` ports (what `../shell/picker/open.ts` grants everything it opens, so
+ * every emit fails `PortNotWired`). Both must reach revision 1 — the wired case passed before the
+ * fix, the unwired one answered `{count: 1}` at revision 0, which is the picker-opened window
+ * painting its first state forever. Two cases rather than one because that asymmetry is what
+ * distinguishes this process's publication stopping from a desk-wide transport failure.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer} from "effect";
+import {counterId, counterProgram} from "../demo/counter.ts";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {memoryStores} from "../durability/stores.ts";
+import {NodeId} from "../ports/graph.ts";
+import {ProcessPorts, unwired} from "../ports/ProcessPorts.ts";
+import {Registry} from "../registry/Registry.ts";
+import {Processes} from "./Processes.ts";
+
+/** Ports that accept every emit, standing in for a graph route to this process's `ticks`. */
+const wired = ProcessPorts.of({emit: () => Effect.succeed([])});
+
+/** Spawn the demo counter with `ports`, drive one `key`, and read the fold's own summary. */
+const dispatchOnce = (ports: Context.Service.Shape<typeof ProcessPorts>) =>
+	Effect.gen(function* () {
+		const processes = yield* Processes;
+		const handle = yield* processes.spawn(counterId, {
+			services: Context.make(ProcessPorts, ports),
+		});
+		return (yield* handle.dispatchFolded({type: "key", key: "a"})).summary;
+	}).pipe(
+		Effect.provide(
+			Processes.layer.pipe(
+				Layer.provide([
+					// `everyMs: null` so the only commit under test is the dispatched one.
+					Registry.layer([counterProgram({everyMs: null})]),
+					Checkpoints.layer(memoryStores()),
+				]),
+			),
+		),
+		Effect.scoped,
+	);
+
+describe("a commit publishes however its Cmds settle", () => {
+	it.effect("a process whose Cmd handler succeeds advances its revision", () =>
+		Effect.gen(function* () {
+			const summary = yield* dispatchOnce(wired);
+
+			assert.deepStrictEqual(summary.state, {count: 1});
+			assert.strictEqual(summary.revision, 1);
+		}),
+	);
+
+	it.effect("a process whose Cmd handler fails advances its revision too", () =>
+		Effect.gen(function* () {
+			const summary = yield* dispatchOnce(unwired(NodeId.make("window-0")));
+
+			// The Msg applied: the reducer ran and the state was checkpointed before `announce`.
+			assert.deepStrictEqual(summary.state, {count: 1});
+			// And the world was told. This read 0 before #8538 — the window's stale count.
+			assert.strictEqual(summary.revision, 1);
+		}),
+	);
+});

--- a/apps/tuval/src/shell/transport/server.ts
+++ b/apps/tuval/src/shell/transport/server.ts
@@ -314,9 +314,16 @@ const session = Effect.fn("Tuval.transport.session")(function* (
 						cause: error.cause,
 					}).pipe(Effect.as(false)),
 			}),
-			// A handler's own failure is not the window's: the Msg reached a live process, so the ack
-			// says Delivered and the failure comes back through the state stream.
-			Effect.orElseSucceed(() => false),
+			// A handler's own failure is not the window's: the Msg reached a live process and was
+			// applied, so the ack stays Delivered. It is still not silence — this used to
+			// `orElseSucceed` the failure away on the belief that the state stream would carry it,
+			// and the same failure was what stopped that stream (#8538).
+			Effect.catch((error) =>
+				Effect.logError("tuval transport: a Cmd handler of a dispatched Msg failed", {
+					processId,
+					error,
+				}).pipe(Effect.as(false)),
+			),
 			// A defect from the actor fiber is nobody's declared failure; it is still not silence.
 			Effect.catchCause((cause) =>
 				Effect.logError("tuval transport: a dispatched Msg died in the actor", {


### PR DESCRIPTION
A picker-opened window painted its first state and never repainted. `Tuval.host.commit` ran
`onCommit` after `runInterpret`, in the same error channel, so one failing Cmd handler aborted the
commit before the `revision++` and the `state-changed` publish that live in `Processes.spawn`'s
`onCommit`. Every process the picker opens gets `unwired` ports, and the demo counter answers every
tick and key with an `announce` Cmd that emits — so on a picker-opened counter *every* commit failed
and *no* commit ever published. The state was applied and checkpointed by then, which is how the
process reached count 43 while its public revision stayed 0.

Two changes:

- `apps/tuval/src/host/actor.ts` — the publication moves into an `Effect.ensuring` around
  `runInterpret`. A state that is applied and checkpointed is owed to the world however its Cmds
  settle. Ordering is unchanged: `onCommit` still runs after the Cmds, and it reads live state
  through an `Effect.suspend`, so the boot commit's own call is the same expression.
- `apps/tuval/src/shell/transport/server.ts` — the dispatch path logs a Cmd handler failure instead
  of `orElseSucceed`-ing it away. The old comment said the failure would come back through the state
  stream; the same failure was what stopped that stream. The ack stays `Delivered` and now carries
  the real revision.

`apps/tuval/src/process/commit-revision.unit.test.ts` is the investigation's failing test: one
program and one Msg spawned twice, wired ports and `unwired` ports, both owed revision 1. Against
`origin/main`'s `actor.ts` the wired case passes and the unwired one fails `expected +0 to equal 1`;
with the fix both pass. The pairing distinguishes this process's publication stopping from a
desk-wide transport failure.

## Hand-verify

Scratch desk on a free port from this branch:

```
node src/bin.ts --project . --page-port 5197
```

Opened it in a Playwright Chromium context, pressed `<c-b> p`, opened the picker's `counter` row
into the focused window, then sampled the window and the shell status bar across timer ticks and
forwarded keys:

```
just opened      process 63625854…  window "count 63"  shell rev 23
timer tick 1     process 63625854…  window "count 64"  shell rev 23
timer tick 2     process 63625854…  window "count 65"  shell rev 23
timer tick 3     process 63625854…  window "count 66"  shell rev 23
timer tick 4     process 63625854…  window "count 67"  shell rev 23
keypress 1       process 63625854…  window "count 69"  shell rev 24
keypress 2       process 63625854…  window "count 70"  shell rev 25
keypress 3       process 63625854…  window "count 71"  shell rev 26
```

The window repaints on every tick with the shell's own revision standing still, so what moved is
this process's state push and not the page. The handler failure is still visible in the desk log as
`tuval/HandlerFailed` / `tuval/ports/PortNotWired` on `ticks`, once per tick — the window is honest
now and the unwired port is still loud.

Tests: `pnpm --filter @kampus/tuval test:unit` 2309 passed (232 files), `pnpm typecheck` 0 errors,
`pnpm lint` exit 0.

Closes #8538

## Deviations

None.
