### PR TITLE
fix: The Tuval composer's thinking-level control reads loading for the whole session

### DIFF
--- a/.patterns/agent-layer-phase-contract.md
+++ b/.patterns/agent-layer-phase-contract.md
@@ -88,6 +88,31 @@ So a layer whose `start` narrates a `ready` owes a `prompting` per send. Emittin
 backend confirms the turn — or trusting the core's own admission — leaves the first turn of every
 freshly opened session narrated as idle.
 
+## The open's `ready` ships with its catalogs
+
+The open's `ready` is also the answer to a second question, and the layer owes both in one batch:
+**emit `model` and `thinking` before the `ready` that closes the open, never after it.**
+
+A layer's `models`/`thinking` slices start on the reducer's empty defaults
+([`core/state.ts`](../apps/tuval/src/ai-agent/core/state.ts)), and an empty offered set is two
+different facts — "the layer has not answered yet" and "answered, nothing offered". Nothing in
+`AgentEvent` distinguishes them, so
+[`shell/chat/composer-bridge.ts`](../apps/tuval/src/shell/chat/composer-bridge.ts) reads the answer
+off the phase instead: past `starting`, the offer counts as resolved, and the composer stops showing
+`loading` and starts showing `thinking effort: none offered`. That read is only true of a layer
+whose catalogs are already folded when its `ready` lands.
+
+`ClaudeAiAgent` used to emit `ready` first and its catalogs 52 lines and four awaited subprocess
+round-trips later — `supportedModels`, `getContextUsage`, `supportedCommands`, `applyFlagSettings` —
+so every Claude session opened onto a disabled picker reading `none offered` until they returned
+([#8425](https://github.com/kamp-us/phoenix/issues/8425)). Delaying `ready` behind them costs
+nothing the core can see: the core reaches `ready` on the `started` Msg that `start` *returns*, and
+nothing drains the layer's queue before then, so no prompt can be admitted inside the window either
+way.
+
+`PiAiAgent` sends the whole handshake as one `emit` array with `phase: ready` last; `ClaudeAiAgent`
+now batches `thinking` with it. A new layer copies that order.
+
 ## Reference shapes
 
 - [`claude/agent/ClaudeAiAgent.ts`](../apps/tuval/src/claude/agent/ClaudeAiAgent.ts) — `prompt`

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -599,10 +599,6 @@ const make = (
 			const continuing = previous !== null && resuming === previous.id;
 			if (!continuing) yield* Ref.set(keys, new Set<string>());
 
-			// The layer's own narration of the open, which the handshake is: the core is already
-			// `ready` off the `started` this call answers, and `coreOwned` drops a layer `starting`
-			// (`ai-agent/core/fold.ts`, #7948) but not this.
-			yield* emit(out, [{kind: "phase", phase: "ready"}]);
 			// The announced mode is resolved by the same call `open` opened the query with, never the
 			// raw `held`: `held` is null until an operator calls `setMode`, so a row carrying any
 			// non-default `permissionMode` would run on that mode and tell every subscriber it has
@@ -654,7 +650,17 @@ const make = (
 						? wanted
 						: null;
 			yield* Ref.set(effort, running);
-			yield* emit(out, [{kind: "thinking", current: running, available: levels}]);
+			// The open's `ready` ships here, behind the catalogs, and never ahead of them: the
+			// composer derives "the layer has said what this session offers" from the phase, so a
+			// `ready` emitted before these four subprocess round-trips tells the picker the offer
+			// resolved empty for as long as they take (#8425). The catalogs are the layer's own
+			// narration of the open too — the core is already `ready` off the `started` this call
+			// answers, and `coreOwned` drops a layer `starting` (`ai-agent/core/fold.ts`, #7948) but
+			// not this. See `.patterns/agent-layer-phase-contract.md`.
+			yield* emit(out, [
+				{kind: "thinking", current: running, available: levels},
+				{kind: "phase", phase: "ready"},
+			]);
 			// A card the layer does not hold cannot be answered, so a window restored with one would
 			// wedge on it. Resolving it is what lets the generic restore drop it (#7608).
 			yield* emit(

--- a/apps/tuval/src/claude/agent/events.unit.test.ts
+++ b/apps/tuval/src/claude/agent/events.unit.test.ts
@@ -33,11 +33,11 @@ describe("events over a captured tool turn", () => {
 					// names — then the turn, which ends on the `ready` its `result` carries.
 					[
 						"phase",
-						"phase",
 						"mode",
 						"model",
 						"commands",
 						"thinking",
+						"phase",
 						"usage",
 						"version",
 						"item",
@@ -115,11 +115,11 @@ describe("every kind rides the one stream", () => {
 					[...turn, ...card, ...rest].map((event) => event.kind),
 					[
 						"phase",
-						"phase",
 						"mode",
 						"model",
 						"commands",
 						"thinking",
+						"phase",
 						"usage",
 						"version",
 						"item",

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -26,8 +26,9 @@ export const MODES: ReadonlyArray<Mode> = [
 ];
 
 /**
- * What `start` itself emits: starting, ready, the mode list, the model list (#7981), then the
- * slash-command catalog (#8060) and the thinking-level set that model offers (#8062).
+ * What `start` itself emits: starting, the mode list, the model list (#7981), the slash-command
+ * catalog (#8060), the thinking-level set that model offers (#8062), and the handshake's `ready`
+ * last — behind the catalogs, never ahead of them (#8425).
  */
 export const START_EVENTS = 6;
 

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -118,13 +118,12 @@ describe("start opens one streaming query", () => {
 		}),
 	);
 
-	it.effect("emits starting, the handshake's ready phase, then every list it offers", () =>
+	it.effect("emits starting, every list it offers, then the handshake's ready phase", () =>
 		on({modes: MODES}, (agent) =>
 			Effect.gen(function* () {
 				yield* agent.start({cwd: CWD});
 				assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS)), [
 					{kind: "phase", phase: "starting"},
-					{kind: "phase", phase: "ready"},
 					// The opening mode, not the layer's raw held `null`: nothing has called `setMode`, so
 					// what the query opened on is the row's own `permissionMode` (#7828).
 					{kind: "mode", current: Mode.make("default"), available: MODES},
@@ -133,6 +132,9 @@ describe("start opens one streaming query", () => {
 					// A CLI offering no catalog offers no effort levels either: the set is a model's
 					// (#8062), and there is no model here to read one off.
 					{kind: "thinking", current: null, available: []},
+					// Last, behind the catalogs it resolves — see `.patterns/agent-layer-phase-contract.md`
+					// and the ordering case below (#8425).
+					{kind: "phase", phase: "ready"},
 				]);
 			}),
 		),
@@ -168,11 +170,11 @@ describe("start against a CLI that says nothing until the first prompt", () => {
 				assert.lengthOf(scripted.opened[0]?.record.prompts ?? [], 0);
 				assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS)), [
 					{kind: "phase", phase: "starting"},
-					{kind: "phase", phase: "ready"},
 					{kind: "mode", current: Mode.make("default"), available: MODES},
 					{kind: "model", current: null, available: []},
 					{kind: "commands", available: []},
 					{kind: "thinking", current: null, available: []},
+					{kind: "phase", phase: "ready"},
 				]);
 			}),
 		),
@@ -834,6 +836,25 @@ describe("setThinkingLevel", () => {
 					current: null,
 					available: [],
 				});
+			}),
+		),
+	);
+
+	/**
+	 * The ordering the composer's `offerResolved` rests on (#8425). `shell/chat/composer-bridge.ts`
+	 * reads "the layer has said what this session offers" off the phase, because an empty offered
+	 * set is otherwise indistinguishable from an unanswered one — so a `ready` ahead of these
+	 * catalogs tells the picker the offer resolved empty for the length of four subprocess
+	 * round-trips. The contract is `.patterns/agent-layer-phase-contract.md`.
+	 */
+	it.effect("closes the open on ready, behind every catalog it resolves (#8425)", () =>
+		on({models: EFFORT, model: "opus", modes: MODES}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const kinds = (yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS))).map(
+					(event) => event.kind,
+				);
+				assert.deepStrictEqual(kinds, ["phase", "mode", "model", "commands", "thinking", "phase"]);
 			}),
 		),
 	);

--- a/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
@@ -21,6 +21,7 @@ import {type TestProcess, testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
 import {
+	assistantItem,
 	call,
 	commands,
 	models,
@@ -490,6 +491,32 @@ describe("the composer's thinking picker", () => {
 		// The model picker beside it stays untouched by the push, which is the other half of "no
 		// rebuild": a new bridge identity would have re-run its load and emptied this too.
 		expect(screen.queryByRole("button", {name: /^model: /})).toBeTruthy();
+	});
+
+	it("says nothing is offered on a ready backend that offers no levels", async () => {
+		// The reported desk (#8425): Pi's faux backend advertises no levels, so this control read
+		// `loading` from boot to exit on a session that was answering turns. It is the same empty
+		// list as the case above; the phase is what tells the two apart.
+		const answered = withTranscript([userItem("u1", "go"), assistantItem("a1", "done")], {
+			thinking: {current: null, available: []},
+		});
+		const {process} = await open(answered);
+		const trigger = await picker();
+		await waitFor(() =>
+			expect(trigger.getAttribute("aria-label")).toBe("thinking effort: none offered"),
+		);
+		expect(trigger.getAttribute("disabled")).not.toBeNull();
+
+		// And it stays settled across the restore the report also captured: a rebuilt session with
+		// the same empty offer has nothing new to say, and nothing re-enters loading.
+		await act(async () => {
+			await Effect.runPromise(process.commit({...answered, sessionId: "session-2"}));
+		});
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", {name: /^thinking effort: /}).getAttribute("aria-label"),
+			).toBe("thinking effort: none offered"),
+		);
 	});
 });
 

--- a/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A resolved empty thinking offer is not a loading one (#8425).
+ *
+ * The composer used to read both off one fact — an empty row list — so Pi's faux backend, which
+ * offers no levels at all, sat on "loading" for the whole session while answering turns. These
+ * cases run the real seam end to end: `composerBridge` decides whether the offer is resolved and
+ * `AgentChatInput` renders it, in both variants, so neither half can be right on its own.
+ */
+
+import {AgentChatInput, DesignTranslationProvider} from "@kampus/design";
+import {act, render, screen, waitFor} from "@testing-library/react";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {ModelState, ThinkingState} from "../../ai-agent/core/index.ts";
+import type {Phase} from "../../ai-agent/events.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type ComposerBridge, composerBridge} from "./composer-bridge.ts";
+import {tuvalDesignTranslate} from "./copy.ts";
+
+installDomShims();
+
+const noModels: ModelState = {current: null, available: []};
+const noThinking: ThinkingState = {current: null, available: []};
+/** Pi's faux backend, which advertises no levels — the session this bug was reported on. */
+const emptyOffer: ThinkingState = {current: null, available: []};
+const offered: ThinkingState = {current: null, available: ["low", "medium", "high"]};
+const picked: ThinkingState = {current: "medium", available: ["low", "medium", "high"]};
+
+type Variant = "focused" | "harness";
+
+const mount = (
+	phase: Phase,
+	variant: Variant,
+	thinking: ThinkingState = noThinking,
+): ComposerBridge => {
+	const composer = composerBridge({
+		initialPhase: phase,
+		initialModels: noModels,
+		initialCommands: [],
+		initialThinking: thinking,
+		onPrompt: () => undefined,
+		onInterrupt: () => undefined,
+		onSetModel: () => undefined,
+		onSetThinkingLevel: () => undefined,
+	});
+	render(
+		(
+			<DesignTranslationProvider translate={tuvalDesignTranslate}>
+				<AgentChatInput bridge={composer.bridge} variant={variant} />
+			</DesignTranslationProvider>
+		) as ReactElement,
+	);
+	return composer;
+};
+
+/**
+ * The control's own reading. The focused variant names itself `<label>: <state>` on a button; the
+ * harness variant is a Manti `Select`, whose unselected reading is its placeholder — so this reads
+ * the rendered text rather than the accessible name for that one.
+ */
+const control = async (variant: Variant): Promise<HTMLElement> =>
+	variant === "focused"
+		? await screen.findByRole("button", {name: /^thinking effort: /})
+		: await screen.findByRole("combobox", {name: "Agent thinking effort"});
+
+const reading = async (variant: Variant): Promise<string> =>
+	variant === "focused"
+		? ((await control(variant)).getAttribute("aria-label") ?? "")
+		: ((await control(variant)).textContent ?? "");
+
+describe.each(["focused", "harness"] as const)("the %s thinking control", (variant) => {
+	it("says loading only while the offer is unresolved", async () => {
+		const composer = mount("starting", variant);
+		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
+
+		// `ready` is where both layers emit their offer — `pi/ai-agent/PiAiAgent.ts` and
+		// `claude/agent/ClaudeAiAgent.ts` each put the `thinking` event in the same batch as the
+		// phase — so crossing it is what resolves the question the control was waiting on.
+		await act(async () => composer.setPhase("ready"));
+		await waitFor(async () => expect(await reading(variant)).not.toContain("loading"));
+	});
+
+	it("reads a resolved empty offer as nothing offered, and refuses to open", async () => {
+		mount("ready", variant, emptyOffer);
+		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
+		expect((await control(variant)).getAttribute("disabled")).not.toBeNull();
+	});
+
+	it("keeps resolved-populated-unselected apart from resolved-populated-selected", async () => {
+		const composer = mount("ready", variant, offered);
+		// No row is checked, so the control says so rather than borrowing the first row's label —
+		// a fallback would report a level the operator never picked as their selection.
+		await waitFor(async () => expect(await reading(variant)).toContain("none selected"));
+		expect(await reading(variant)).not.toContain("low");
+
+		await act(async () => composer.setThinking(picked));
+		await waitFor(async () => expect(await reading(variant)).toContain("medium"));
+	});
+
+	it("follows the offer both ways as the session changes model", async () => {
+		const composer = mount("ready", variant, emptyOffer);
+		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
+
+		await act(async () => composer.setThinking(picked));
+		await waitFor(async () => expect(await reading(variant)).toContain("medium"));
+
+		// Back to a model that offers none: the rows go, and no level the session no longer runs on
+		// is left standing as the current one.
+		await act(async () => composer.setThinking(emptyOffer));
+		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
+		expect(screen.queryByRole(variant === "focused" ? "menuitemradio" : "option")).toBeNull();
+	});
+
+	it("says nothing offered on a restored session whose backend offers no levels", async () => {
+		// The reported shape: a restored Pi faux desk, past its turns, phase `ready`. Every capture
+		// of it read `loading`, and the session it describes was never going to fill.
+		mount("ready", variant, emptyOffer);
+		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
+		await waitFor(async () => expect(await reading(variant)).not.toContain("loading"));
+	});
+});

--- a/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
@@ -75,11 +75,30 @@ describe.each(["focused", "harness"] as const)("the %s thinking control", (varia
 		const composer = mount("starting", variant);
 		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
 
-		// `ready` is where both layers emit their offer — `pi/ai-agent/PiAiAgent.ts` and
-		// `claude/agent/ClaudeAiAgent.ts` each put the `thinking` event in the same batch as the
-		// phase — so crossing it is what resolves the question the control was waiting on.
+		// The phase carries the answer because every layer owes its catalogs ahead of the `ready`
+		// that closes its open — `.patterns/agent-layer-phase-contract.md`, "The open's `ready`
+		// ships with its catalogs" — so crossing it resolves the question the control waited on.
 		await act(async () => composer.setPhase("ready"));
 		await waitFor(async () => expect(await reading(variant)).not.toContain("loading"));
+	});
+
+	it("stays on loading across a Claude open's catalog round-trips (#8425)", async () => {
+		// `ClaudeAiAgent.open` reads four catalogs off the subprocess before it closes the open, and
+		// each is a real IPC round-trip, so its events reach the composer over several ticks. The
+		// order that keeps this honest is the layer's own: every catalog first, `ready` last.
+		const composer = mount("starting", variant);
+		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
+
+		// The `thinking` emit — a model offering no levels, which is what a Claude row without an
+		// effort axis answers. The offer is now known and still unresolved to the control, because
+		// the open has not closed.
+		await act(async () => composer.setThinking(emptyOffer));
+		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
+		expect(await reading(variant)).not.toContain("none offered");
+
+		// The handshake's `ready`, a tick later. Only here does the empty offer become an answer.
+		await act(async () => composer.setPhase("ready"));
+		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
 	});
 
 	it("reads a resolved empty offer as nothing offered, and refuses to open", async () => {

--- a/apps/tuval/src/shell/chat/composer-bridge.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.ts
@@ -100,10 +100,10 @@ const levelOf = (
  *
  * Before the session is open it has not, and its `models`/`thinking` slices still hold the
  * reducer's empty defaults — so an empty offered set read here is "not known yet", not "nothing
- * offered". Both layers settle that in the same emit batch as the `ready` phase
- * (`pi/ai-agent/PiAiAgent.ts`, `claude/agent/ClaudeAiAgent.ts`), which makes the phase the honest
- * carrier of the answer and keeps the composer's loading state off a session that will never fill
- * (#8425).
+ * offered". The phase carries the answer only because every layer owes its catalogs ahead of the
+ * `ready` that closes its open — the contract is in
+ * `.patterns/agent-layer-phase-contract.md` ("The open's `ready` ships with its catalogs"), and a
+ * layer that breaks it opens onto a picker claiming nothing is offered (#8425).
  */
 const offerResolved = (phase: Phase): boolean => phase !== "idle" && phase !== "starting";
 

--- a/apps/tuval/src/shell/chat/composer-bridge.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.ts
@@ -22,7 +22,10 @@
  * list is known at mount, because the agent has not started when the composer runs its loads, so
  * all three are *pushed* through the same subscription the phase is: `AgentChatInput` re-runs its
  * whole load on a new bridge identity, and rebuilding the bridge per state change would drop the
- * composer back to `loading` on every turn.
+ * composer back to `loading` on every turn. That is also why this bridge answers *whether* a
+ * catalog is known and not only what is in it: an empty offer read before the session opens is a
+ * different fact from a backend that offers nothing, and collapsing the two left Pi's faux desk
+ * saying "loading" through a whole answering session (#8425).
  *
  * Nothing here is React. It is a plain object with a setter, so its behaviour is unit-testable
  * without a DOM — which is what `composer-bridge.unit.test.ts` does.
@@ -92,18 +95,36 @@ const levelOf = (
 	offered: ReadonlyArray<ThinkingLevel>,
 ): ThinkingLevel | null => offered.find((candidate) => candidate === level) ?? null;
 
-/** The one event the composer takes its catalogs on: its `harness_status` arm. */
+/**
+ * Has the layer said what this session offers?
+ *
+ * Before the session is open it has not, and its `models`/`thinking` slices still hold the
+ * reducer's empty defaults — so an empty offered set read here is "not known yet", not "nothing
+ * offered". Both layers settle that in the same emit batch as the `ready` phase
+ * (`pi/ai-agent/PiAiAgent.ts`, `claude/agent/ClaudeAiAgent.ts`), which makes the phase the honest
+ * carrier of the answer and keeps the composer's loading state off a session that will never fill
+ * (#8425).
+ */
+const offerResolved = (phase: Phase): boolean => phase !== "idle" && phase !== "starting";
+
+/**
+ * The one event the composer takes its catalogs on: its `harness_status` arm. An unresolved offer
+ * omits both catalog keys rather than sending empty ones, because the composer reads an omitted key
+ * as "nothing said" and an empty array as a resolved answer.
+ */
 const catalogStatus = (
 	models: ModelState,
 	commands: ReadonlyArray<CommandRef>,
 	thinking: ThinkingState,
+	resolved: boolean,
 ): PiEvent => ({
 	type: "harness_status",
 	status: {
-		models: models.available.map(composerModel),
 		commands: commands.map(composerCommand),
+		...(resolved
+			? {models: models.available.map(composerModel), thinkingLevels: thinking.available}
+			: {}),
 		...(models.current === null ? {} : {model: composerModel(models.current)}),
-		thinkingLevels: thinking.available,
 		...(thinking.current === null ? {} : {thinkingLevel: thinking.current}),
 	},
 });
@@ -147,8 +168,10 @@ export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 				...(thinking.current === null ? {} : {thinkingLevel: thinking.current}),
 			}),
 		loadPiCommands: () => Promise.resolve(commands.map(composerCommand)),
-		loadPiModels: () => Promise.resolve(models.available.map(composerModel)),
-		loadPiThinkingLevels: () => Promise.resolve(thinking.available),
+		loadPiModels: () =>
+			Promise.resolve(offerResolved(phase) ? models.available.map(composerModel) : undefined),
+		loadPiThinkingLevels: () =>
+			Promise.resolve(offerResolved(phase) ? thinking.available : undefined),
 		loadPiFiles: none([]),
 		// A pick the session does not offer is dropped rather than rejected: the bridge's contract is
 		// that nothing here rejects, and the core would refuse the Msg anyway.
@@ -174,11 +197,18 @@ export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 		answerPiExtension: none(undefined),
 		subscribeToPiEvents: (onEvent) => {
 			listener = onEvent;
-			// The composer subscribes *after* its four loads resolve, so a catalog that landed in
+			// The composer subscribes *after* its four loads resolve, so anything that landed in
 			// between was pushed at a listener that did not exist yet and would be lost until the
-			// next catalog event — which, on a session nobody switches, never comes.
-			if (models.available.length > 0 || commands.length > 0 || thinking.available.length > 0) {
-				onEvent(catalogStatus(models, commands, thinking));
+			// next catalog event — which, on a session nobody switches, never comes. Resolution is
+			// one of those things: this window's own `setPhase` runs before the child's loads have
+			// settled, so a session already `ready` answered its loads as unresolved (#8425).
+			if (
+				offerResolved(phase) ||
+				models.available.length > 0 ||
+				commands.length > 0 ||
+				thinking.available.length > 0
+			) {
+				onEvent(catalogStatus(models, commands, thinking, offerResolved(phase)));
 			}
 			return () => {
 				if (listener === onEvent) listener = null;
@@ -190,22 +220,29 @@ export const composerBridge = (handlers: ComposerHandlers): ComposerBridge => {
 		bridge,
 		setPhase: (next) => {
 			const was = isWorking(phase);
+			const knew = offerResolved(phase);
 			phase = next;
+			// A phase carries the offer's resolution, so crossing into a resolved one is itself news
+			// the pickers need: without this push a control left saying "loading" at `starting` has
+			// nothing to correct it if the layer's catalogs never change again.
+			if (offerResolved(next) !== knew) {
+				listener?.(catalogStatus(models, commands, thinking, offerResolved(next)));
+			}
 			const now = isWorking(next);
 			if (was === now) return;
 			listener?.({type: now ? "agent_start" : "agent_settled"});
 		},
 		setModels: (next) => {
 			models = next;
-			listener?.(catalogStatus(next, commands, thinking));
+			listener?.(catalogStatus(next, commands, thinking, offerResolved(phase)));
 		},
 		setCommands: (next) => {
 			commands = next;
-			listener?.(catalogStatus(models, next, thinking));
+			listener?.(catalogStatus(models, next, thinking, offerResolved(phase)));
 		},
 		setThinking: (next) => {
 			thinking = next;
-			listener?.(catalogStatus(models, commands, next));
+			listener?.(catalogStatus(models, commands, next, offerResolved(phase)));
 		},
 	};
 };

--- a/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
+++ b/apps/tuval/src/shell/chat/composer-bridge.unit.test.ts
@@ -67,11 +67,17 @@ describe("composerBridge", () => {
 			(event) => seen.push(event.type),
 			() => undefined,
 		);
+		// The subscribe-time replay is another case's subject ("the offer's resolution"); what this
+		// one is about starts here.
+		seen.length = 0;
 		composer.setPhase("prompting");
 		composer.setPhase("prompting");
 		composer.setPhase("ready");
+		// The last one is not a turn boundary but an offer boundary: a session walked back to
+		// `starting` no longer knows what it offers, so the pickers are told to re-enter loading
+		// rather than keep showing a catalog from the session that ended (#8425).
 		composer.setPhase("starting");
-		expect(seen).toEqual(["agent_start", "agent_settled"]);
+		expect(seen).toEqual(["agent_start", "agent_settled", "harness_status"]);
 	});
 
 	it("stops pushing once the composer unsubscribes", () => {
@@ -81,6 +87,7 @@ describe("composerBridge", () => {
 			(event) => seen.push(event.type),
 			() => undefined,
 		);
+		seen.length = 0;
 		off();
 		composer.setPhase("prompting");
 		expect(seen).toEqual([]);
@@ -212,9 +219,10 @@ describe("composerBridge", () => {
 		composer.setThinking(effort);
 		// Pushed events, not a second bridge: the composer re-runs its whole load on a new bridge
 		// identity, so a rebuild here would drop it back into `loading` (#8062). Each push carries
-		// every catalog, so the last one is the whole picture.
-		expect(seen.length).toBe(2);
-		expect(seen[1]).toEqual({
+		// every catalog, so the last one is the whole picture. The first is the subscribe-time one
+		// that re-states the resolved-but-still-empty offer.
+		expect(seen.length).toBe(3);
+		expect(seen[2]).toEqual({
 			type: "harness_status",
 			status: {
 				models: [
@@ -227,8 +235,8 @@ describe("composerBridge", () => {
 				thinkingLevel: "medium",
 			},
 		});
-		expect((await composer.bridge.loadPiModels()).length).toBe(2);
-		expect((await composer.bridge.loadPiThinkingLevels()).length).toBe(5);
+		expect(await composer.bridge.loadPiModels()).toHaveLength(2);
+		expect(await composer.bridge.loadPiThinkingLevels()).toHaveLength(5);
 	});
 
 	it("replays a level set that landed before the composer subscribed", async () => {
@@ -264,6 +272,7 @@ describe("composerBridge", () => {
 		);
 		composer.setCommands([compact]);
 		expect(seen).toEqual([
+			{type: "harness_status", status: {models: [], commands: [], thinkingLevels: []}},
 			{
 				type: "harness_status",
 				status: {
@@ -341,5 +350,70 @@ describe("composerBridge", () => {
 			await composer.bridge.setPiModel({provider: "openai", id: "gpt", name: "GPT"}),
 		).toBeUndefined();
 		expect(handlers.onSetModel.mock.calls).toEqual([]);
+	});
+});
+
+/**
+ * Whether the session has *said* what it offers, which is a different fact from what it offers
+ * (#8425). The bridge carries it rather than leaving the composer to guess from an empty list,
+ * because Pi's faux backend offers no levels at all and read as loading forever.
+ */
+describe("the offer's resolution", () => {
+	it("withholds both catalogs until the session is past starting", async () => {
+		const composer = composerBridge({...seam(), initialPhase: "starting"});
+		expect(await composer.bridge.loadPiModels()).toBeUndefined();
+		expect(await composer.bridge.loadPiThinkingLevels()).toBeUndefined();
+
+		composer.setPhase("ready");
+		expect(await composer.bridge.loadPiModels()).toEqual([]);
+		expect(await composer.bridge.loadPiThinkingLevels()).toEqual([]);
+	});
+
+	it("answers an empty offer on a ready session rather than withholding it", async () => {
+		const composer = composerBridge({...seam(), initialPhase: "ready"});
+		// `[]`, not `undefined`: both layers emit their thinking offer in the same batch as the
+		// `ready` phase, so a ready session with no levels has answered and offers none.
+		expect(await composer.bridge.loadPiThinkingLevels()).toEqual([]);
+	});
+
+	it("omits the catalog keys from a status pushed before the offer resolves", () => {
+		const composer = composerBridge({...seam(), initialPhase: "starting"});
+		const seen: Array<unknown> = [];
+		composer.bridge.subscribeToPiEvents(
+			(event) => seen.push(event),
+			() => undefined,
+		);
+		composer.setThinking(effort);
+		// An omitted key leaves the composer's held list alone; an empty one would tell it the
+		// session had resolved and offers nothing.
+		expect(seen).toEqual([
+			{type: "harness_status", status: {commands: [], thinkingLevel: "medium"}},
+		]);
+	});
+
+	it("pushes the resolved catalogs when the phase itself is the news", () => {
+		const composer = composerBridge({...seam(), initialPhase: "starting"});
+		const seen: Array<unknown> = [];
+		composer.bridge.subscribeToPiEvents(
+			(event) => seen.push(event),
+			() => undefined,
+		);
+		// Nothing about what is offered changed here — only whether it is known. Without this push
+		// a control left on "loading" at `starting` has nothing to correct it on a backend whose
+		// catalogs never change again.
+		composer.setPhase("ready");
+		expect(seen).toEqual([
+			{type: "harness_status", status: {commands: [], models: [], thinkingLevels: []}},
+		]);
+	});
+
+	it("says nothing on subscribe while the offer is unresolved and there is no command", () => {
+		const composer = composerBridge({...seam(), initialPhase: "starting"});
+		const seen: Array<unknown> = [];
+		composer.bridge.subscribeToPiEvents(
+			(event) => seen.push(event),
+			() => undefined,
+		);
+		expect(seen).toEqual([]);
 	});
 });

--- a/apps/tuval/src/shell/chat/copy.ts
+++ b/apps/tuval/src/shell/chat/copy.ts
@@ -48,6 +48,7 @@ const messages: Readonly<Record<DesignCatalogKey, string>> = {
 	"admin.agent.settings": "Agent settings",
 	"admin.agent.picker.loading": "loading",
 	"admin.agent.picker.none": "none selected",
+	"admin.agent.picker.empty": "none offered",
 	"admin.agent.setting.model": "model",
 	"admin.agent.setting.thinking": "thinking effort",
 	"admin.agent.select.model": "Agent model",

--- a/apps/web/src/i18n/en/admin.ts
+++ b/apps/web/src/i18n/en/admin.ts
@@ -97,6 +97,7 @@ export const admin = {
 	"admin.agent.settings": "Pi settings",
 	"admin.agent.picker.loading": "loading",
 	"admin.agent.picker.none": "none selected",
+	"admin.agent.picker.empty": "none offered",
 	"admin.agent.setting.model": "model",
 	"admin.agent.setting.thinking": "thinking effort",
 	"admin.agent.select.model": "Pi model",

--- a/apps/web/src/i18n/tr/admin.ts
+++ b/apps/web/src/i18n/tr/admin.ts
@@ -97,6 +97,7 @@ export const admin = {
 	"admin.agent.settings": "Pi ayarları",
 	"admin.agent.picker.loading": "yükleniyor",
 	"admin.agent.picker.none": "seçili değil",
+	"admin.agent.picker.empty": "seçenek sunulmuyor",
 	"admin.agent.setting.model": "model",
 	"admin.agent.setting.thinking": "düşünme eforu",
 	"admin.agent.select.model": "Pi modeli",

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -143,8 +143,10 @@ function lateCatalogBridge(): {
 	const bridge: AgentChatInputBridge = {
 		loadPiState: async () => ({isStreaming: false}),
 		loadPiCommands: async () => [],
-		loadPiModels: async () => [],
-		loadPiThinkingLevels: async () => [],
+		// `undefined`, not `[]`: this host does not know what it offers yet, which is a different
+		// answer from knowing it offers nothing (#8425).
+		loadPiModels: async () => undefined,
+		loadPiThinkingLevels: async () => undefined,
 		loadPiFiles: async () => [],
 		setPiModel: async () => undefined,
 		setPiThinkingLevel: async () => undefined,

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -419,8 +419,10 @@ export function AgentChatInput({
 	const [connection, setConnection] = useState<ConnectionState>("loading");
 	const [state, setState] = useState<Record<string, unknown>>();
 	const [commands, setCommands] = useState<readonly PiCommand[]>([]);
-	const [models, setModels] = useState<readonly PiModel[]>([]);
-	const [thinkingLevels, setThinkingLevels] = useState<readonly PiThinkingLevel[]>([]);
+	// `undefined` until the host answers, and an answer of `[]` is a real one: a harness that offers
+	// no models or no thinking levels is not a harness still loading them (#8425).
+	const [models, setModels] = useState<readonly PiModel[]>();
+	const [thinkingLevels, setThinkingLevels] = useState<readonly PiThinkingLevel[]>();
 	const [projectTrust, setProjectTrust] = useState<PiProjectTrust>("approve");
 	const [settingsChanging, setSettingsChanging] = useState(false);
 	const [files, setFiles] = useState<readonly string[]>([]);
@@ -472,10 +474,10 @@ export function AgentChatInput({
 		])
 			.then(([nextState, nextCommands, nextModels, nextThinkingLevels]) => {
 				if (!current) return;
-				const selectableThinkingLevels = nextThinkingLevels.filter((level) => level !== "off");
+				const selectableThinkingLevels = nextThinkingLevels?.filter((level) => level !== "off");
 				if (
 					mockWhenUnavailable &&
-					(nextModels.length === 0 || selectableThinkingLevels.length === 0)
+					((nextModels?.length ?? 0) === 0 || (selectableThinkingLevels?.length ?? 0) === 0)
 				) {
 					applyMockHarness();
 					return;
@@ -619,7 +621,18 @@ export function AgentChatInput({
 			// learns its per-model level set after connecting would otherwise leave a live picker
 			// over no rows (#8062).
 			const nextLevels = status && thinkingLevelList(status.thinkingLevels);
-			if (nextLevels) setThinkingLevels(nextLevels);
+			if (nextLevels) {
+				setThinkingLevels(nextLevels);
+				// A level the session has stopped offering is not the level it is running on. Left
+				// standing it reads as an operator selection the backend would refuse — and on the
+				// harness variant it kept rendering as the trigger's own label (#8425).
+				setState((current) => {
+					const held = thinkingLevelValue(current?.thinkingLevel);
+					if (held === undefined || nextLevels.includes(held)) return current;
+					const {thinkingLevel: _dropped, ...rest} = current ?? {};
+					return rest;
+				});
+			}
 			const nextLevel = status && thinkingLevelValue(status.thinkingLevel);
 			if (nextLevel) setState((current) => ({...(current ?? {}), thinkingLevel: nextLevel}));
 			if (status && booleanValue(status, "available") === false) setConnection("unavailable");
@@ -731,7 +744,7 @@ export function AgentChatInput({
 	}
 
 	async function changeModel(value: string | undefined) {
-		const nextModel = models.find((model) => modelValue(model) === value);
+		const nextModel = models?.find((model) => modelValue(model) === value);
 		if (!nextModel || value === selectedModelValue(state)) return;
 		if (usingMockHarness) {
 			setState((current) => ({...(current ?? {}), model: nextModel}));
@@ -747,7 +760,7 @@ export function AgentChatInput({
 				activeBridge.loadPiThinkingLevels(),
 			]);
 			applyState(nextState);
-			setThinkingLevels(nextThinkingLevels.filter((level) => level !== "off"));
+			setThinkingLevels(nextThinkingLevels?.filter((level) => level !== "off"));
 			addActivity(t("admin.agent.activity.modelChanged", {model: nextModel.name}));
 		} catch (cause) {
 			setError(cause instanceof Error ? cause.message : t("admin.agent.error.model"));
@@ -807,7 +820,7 @@ export function AgentChatInput({
 			applyState(nextState);
 			setCommands(nextCommands);
 			setModels(nextModels);
-			setThinkingLevels(nextThinkingLevels.filter((level) => level !== "off"));
+			setThinkingLevels(nextThinkingLevels?.filter((level) => level !== "off"));
 			addActivity(
 				t(
 					nextProjectTrust === "approve"
@@ -899,13 +912,15 @@ export function AgentChatInput({
 		}
 	}
 
-	const model = runningModelLabel(state, models);
+	const model = runningModelLabel(state, models ?? []);
 	// Manti's `SelectItem.label` is `string`, and the select collection stringifies it for typeahead
 	// (`itemToString: (item) => item.label`), so this list carries the provider in the label itself
 	// while the Menu-backed picker below renders it as its own dimmed span. See #8065.
-	const modelItems = useMemo<SelectItem[]>(
+	// Each list stays `undefined` while its offer is unresolved, so the pickers are handed the same
+	// three-way answer the bridge gave rather than a flattened array (#8425).
+	const modelItems = useMemo<SelectItem[] | undefined>(
 		() =>
-			models.map((candidate) => ({
+			models?.map((candidate) => ({
 				value: modelValue(candidate),
 				label: providersCollide(models)
 					? `${candidate.name} (${candidate.provider})`
@@ -913,36 +928,37 @@ export function AgentChatInput({
 			})),
 		[models],
 	);
-	const thinkingItems = useMemo<SelectItem[]>(
-		() => thinkingLevels.map((level) => ({value: level, label: t(thinkingLevelKeys[level])})),
+	const thinkingItems = useMemo<SelectItem[] | undefined>(
+		() => thinkingLevels?.map((level) => ({value: level, label: t(thinkingLevelKeys[level])})),
 		[thinkingLevels, t],
 	);
-	const focusedModelItems = useMemo<PickerItem[]>(
+	const focusedModelItems = useMemo<PickerItem[] | undefined>(
 		() =>
-			models.map((candidate) => ({
+			models?.map((candidate) => ({
 				value: modelValue(candidate),
 				label: candidate.name,
 				...(providersCollide(models) ? {note: candidate.provider} : {}),
 			})),
 		[models],
 	);
-	const focusedThinkingItems = useMemo<PickerItem[]>(
+	const focusedThinkingItems = useMemo<PickerItem[] | undefined>(
 		() =>
-			thinkingLevels.map((level) => ({
+			thinkingLevels?.map((level) => ({
 				value: level,
 				label: t(thinkingLevelKeys[level]),
 				icon: thinkingLevelIcons[level],
 			})),
 		[thinkingLevels, t],
 	);
-	const selectedModel = selectedModelValue(state) ?? modelItems[0]?.value;
+	const selectedModel = selectedModelValue(state) ?? modelItems?.[0]?.value;
 	const stateThinking = thinkingLevelValue(state?.thinkingLevel);
 	const selectedThinking = stateThinking !== "off" ? stateThinking : undefined;
 	const settingsDisabled = disabled || settingsChanging || connection !== "ready";
+	const offeredThinking = thinkingItems?.length ?? 0;
 	const thinkingDisabled =
 		settingsDisabled ||
-		thinkingItems.length === 0 ||
-		(thinkingItems.length === 1 && selectedThinking !== undefined);
+		offeredThinking === 0 ||
+		(offeredThinking === 1 && selectedThinking !== undefined);
 	const focusedDelivery =
 		connection === "working" ? (delivery === "prompt" ? "follow_up" : delivery) : "prompt";
 	const focusedMenuItems: MenuItem[] = [
@@ -1130,7 +1146,7 @@ export function AgentChatInput({
 											items={focusedModelItems}
 											value={selectedModel}
 											onValueChange={(value) => void changeModel(value)}
-											disabled={settingsDisabled || focusedModelItems.length < 2}
+											disabled={settingsDisabled || (focusedModelItems?.length ?? 0) < 2}
 										/>
 										<SettingMenu
 											label={t("admin.agent.setting.thinking")}
@@ -1151,12 +1167,12 @@ export function AgentChatInput({
 														{t("admin.agent.select.model")}
 													</span>
 												}
-												items={modelItems}
+												items={modelItems ?? []}
 												value={selectedModel ? [selectedModel] : []}
 												onValueChange={(values) => void changeModel(values[0])}
 												placement="top-start"
 												size="sm"
-												disabled={settingsDisabled || modelItems.length < 2}
+												disabled={settingsDisabled || (modelItems?.length ?? 0) < 2}
 											/>
 										</div>
 										<div className="kp-agent-chat__setting">
@@ -1168,9 +1184,15 @@ export function AgentChatInput({
 														{t("admin.agent.select.thinking")}
 													</span>
 												}
-												items={thinkingItems}
+												items={thinkingItems ?? []}
 												value={selectedThinking ? [selectedThinking] : []}
-												placeholder={t("admin.agent.picker.none")}
+												placeholder={t(
+													thinkingItems === undefined
+														? "admin.agent.picker.loading"
+														: thinkingItems.length === 0
+															? "admin.agent.picker.empty"
+															: "admin.agent.picker.none",
+												)}
 												onValueChange={(values) => void changeThinkingLevel(values[0])}
 												placement="top-start"
 												size="sm"
@@ -1318,7 +1340,11 @@ export function AgentChatInput({
 export interface SettingMenuProps {
 	/** The control's accessible name, and the group heading inside the menu. */
 	readonly label: string;
-	readonly items: readonly PickerItem[];
+	/**
+	 * What the host offers, or `undefined` while the offer is unresolved. `[]` is a resolved answer
+	 * — the host knows and offers nothing — and reads that way rather than as loading (#8425).
+	 */
+	readonly items: readonly PickerItem[] | undefined;
 	readonly value?: string;
 	readonly onValueChange: (value: string) => void;
 	readonly disabled?: boolean;
@@ -1337,13 +1363,23 @@ export function SettingMenu({label, items, value, onValueChange, disabled}: Sett
 	// checked row. Seeding it to `value` at the open makes the machine's own scroll-into-view land
 	// there and the first arrow key move from there. See ADR 0361.
 	const [highlighted, setHighlighted] = useState<string | null>(null);
-	const selected = items.find((item) => item.value === value);
-	// Two different unselected states, and only one of them is loading: an empty `items` is a host
-	// that has not resolved what it can offer, while a populated `items` with no `value` is a
-	// setting the session simply has not picked yet (#8190). Naming the second one "loading" told
-	// the screen reader something untrue.
-	const unselectedName =
-		items.length === 0 ? t("admin.agent.picker.loading") : t("admin.agent.picker.none");
+	const offered = items ?? [];
+	const selected = offered.find((item) => item.value === value);
+	// Three unselected states, and only the first is loading: `undefined` items is a host that has
+	// not resolved what it offers, `[]` is one that resolved and offers nothing, and a populated
+	// list with no `value` is a setting the session has not picked yet (#8190, #8425). Reading the
+	// middle one as loading left an operator waiting on rows that were never coming.
+	const unselectedName = t(
+		items === undefined
+			? "admin.agent.picker.loading"
+			: items.length === 0
+				? "admin.agent.picker.empty"
+				: "admin.agent.picker.none",
+	);
+	// Nothing to pick is nothing to open, either way round: an unresolved offer has no rows yet and
+	// a resolved-empty one never will, so the trigger does not advertise an operation the host
+	// cannot perform. `disabled` from the host still wins on top of this.
+	const operable = offered.length > 0;
 	const selectedName = selected
 		? selected.note
 			? `${selected.label} (${selected.note})`
@@ -1368,7 +1404,7 @@ export function SettingMenu({label, items, value, onValueChange, disabled}: Sett
 					size="sm"
 					className="kp-agent-chat__picker-trigger"
 					aria-label={`${label}: ${selectedName}`}
-					disabled={disabled}
+					disabled={disabled || !operable}
 				>
 					{selected?.icon ? <Icon icon={selected.icon} size={14} /> : null}
 					<span>{selected?.label ?? unselectedName}</span>
@@ -1382,7 +1418,7 @@ export function SettingMenu({label, items, value, onValueChange, disabled}: Sett
 				{
 					type: "group",
 					label,
-					items: items.map((item) => ({
+					items: offered.map((item) => ({
 						type: "radio",
 						value: item.value,
 						label: item.note ? (

--- a/packages/design/src/agent-chat-bridge.ts
+++ b/packages/design/src/agent-chat-bridge.ts
@@ -36,8 +36,14 @@ export interface PiExtensionAnswer {
 export interface AgentChatInputBridge {
 	readonly loadPiState: () => Promise<Record<string, unknown>>;
 	readonly loadPiCommands: () => Promise<readonly PiCommand[]>;
-	readonly loadPiModels: () => Promise<readonly PiModel[]>;
-	readonly loadPiThinkingLevels: () => Promise<readonly PiThinkingLevel[]>;
+	/**
+	 * What the host offers, or `undefined` while it does not know yet. The two are different facts
+	 * and an empty array is only ever the second one: a host whose agent starts after the composer
+	 * answers `undefined` until its agent reports, and a host whose agent reports no rows answers
+	 * `[]`. Collapsing them left a backend that offers nothing reading as one still loading (#8425).
+	 */
+	readonly loadPiModels: () => Promise<readonly PiModel[] | undefined>;
+	readonly loadPiThinkingLevels: () => Promise<readonly PiThinkingLevel[] | undefined>;
 	readonly loadPiFiles: (query: string) => Promise<readonly string[]>;
 	readonly setPiModel: (model: PiModel) => Promise<void>;
 	readonly setPiThinkingLevel: (level: PiThinkingLevel) => Promise<void>;

--- a/packages/design/src/i18n.tsx
+++ b/packages/design/src/i18n.tsx
@@ -31,6 +31,7 @@ export const designTrMessages = {
 	"admin.agent.settings": "Pi ayarları",
 	"admin.agent.picker.loading": "yükleniyor",
 	"admin.agent.picker.none": "seçili değil",
+	"admin.agent.picker.empty": "seçenek sunulmuyor",
 	"admin.agent.setting.model": "model",
 	"admin.agent.setting.thinking": "düşünme eforu",
 	"admin.agent.select.model": "Pi modeli",


### PR DESCRIPTION
The Tuval composer's thinking-level control said `loading` for a whole session on Pi's faux proof desk, on a session that was answering turns. It read both "we don't know yet" and "there is nothing on offer" off one fact — an empty row list — so a backend that legitimately offers no thinking levels was indistinguishable from one whose levels had not arrived.

## What changed

The offer's *resolution* now travels the seam instead of being guessed at the end of it.

- `AgentChatInputBridge.loadPiModels` / `loadPiThinkingLevels` answer `undefined` while the host does not know what it offers, and an array — possibly empty — once it does.
- `AgentSettingMenu` reads three states, not two: `undefined` items say `loading`, `[]` says `none offered` (new `admin.agent.picker.empty` key in all three catalogs), and a populated list with no `value` still says `none selected`. Nothing to pick also means nothing to open, so the trigger is disabled in the first two rather than advertising an operation the host cannot perform.
- `AgentChatInput` holds both catalogs as `undefined` until answered, and drops a held current level the session has stopped offering. That last one was a second defect the new tests caught: on the harness variant a populated-to-empty transition left the old level rendering as the trigger's own label.
- Tuval's `composerBridge` carries the answer off the phase: `idle`/`starting` is unresolved, everything past it is resolved. Crossing that line is itself pushed, and the subscribe-time replay re-states it — this window's `setPhase` runs before the composer's own loads settle, so a session already `ready` would otherwise have answered its loads as unresolved and had nothing to correct it.
- **`ClaudeAiAgent.open` now emits its `ready` behind its catalogs rather than ahead of them.** It used to send `ready` first and `mode`/`model`/`commands`/`thinking` 52 lines later, with four awaited subprocess round-trips in between (`supportedModels`, `getContextUsage`, `supportedCommands`, `applyFlagSettings`) — so the phase-derived read above reported the offer resolved while it was genuinely unknown, and every Claude session opened onto a disabled `thinking effort: none offered`. The `ready` now rides the same `emit` array as `thinking`, last, exactly as `PiAiAgent` already sent its handshake. Delaying it is invisible to the core: `subscriptions` opens the events Sub off the `sessionId` the `started` Msg sets, and `started` is what `start` returns, so nothing drains the layer's queue until the open has finished either way.
- `.patterns/agent-layer-phase-contract.md` gains "The open's `ready` ships with its catalogs" — the rule a new layer follows, why an empty offered set cannot carry the answer alone, and why the delay costs the core nothing. `composer-bridge.ts`'s docblock points there instead of asserting what the layers do.

Nothing synthesizes a level, changes a model, or enables an unsupported action.

## Where to look first

`packages/design/src/AgentChatInput.tsx` (the `SettingMenu` three-way read and the stale-level drop), `apps/tuval/src/shell/chat/composer-bridge.ts` (`offerResolved`), and the emit order at the end of `ClaudeAiAgent.open`.

## Evidence

All of it is scripted — no real-provider check was run, and none is presumed to fail. `apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx` drives the real bridge into the real composer across both variants: unresolved, resolved-empty, resolved-populated unselected and selected, both directions of the empty/populated transition, and a Claude open's catalog round-trips — the offer landing a tick ahead of the `ready`, with the control asserted to still read `loading` and not `none offered` in between. `agent-controls.unit.test.tsx` reproduces the reported desk through `ChatWindow` itself — a `ready` session with completed turns and an empty offer, held across a restore — and it now reads `thinking effort: none offered`. `composer-bridge.unit.test.ts` covers the resolution seam on its own. At the layer, `claude/agent/start.unit.test.ts` pins the open's emitted kinds as `phase, mode, model, commands, thinking, phase` over a populated effort catalog.

Closes #8425

## Deviations

- **Declined guidance** — **Said:** the lane brief said to run only `pnpm --filter @kampus/tuval test:unit`, `typecheck` and `pnpm lint`. **Did:** also ran `packages/design`'s `AgentChatInput.test.tsx` (25 passed). **Why:** this PR changes that component's behaviour and one of its fixtures, and shipping an unrun red into CI is worse than the one extra file. The `a11y-pbt` suite sits behind a separate vitest config and was not run; its `AgentSettingMenu` generator only ever produces non-empty item lists, so no branch this PR touches is in its range. **Disposition:** stated here.
- **Declined guidance** — **Said:** the round-1 review asked for a case driving "phase `ready`, then `thinking` a tick later", asserting the control stays on `loading` in between. **Did:** drove the two emits in the opposite order — `thinking` first, `ready` a tick later — and asserted `loading` across the gap. **Why:** the review's order is the one the *broken* layer emitted, and it is the right test under the other fix it offered (resolution carried per-catalog). This branch took the fix the review preferred, so the layer's real order is now the reverse, and criterion 6's own wording asks for "the layer's real order". A ready-then-thinking case would assert a contract this branch deliberately does not implement. The order itself is pinned separately in `start.unit.test.ts`. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8425 names the thinking control. **Did:** the model control and `apps/web`'s two locale catalogs changed too. **Why:** both are forced. `SettingMenu` is shared, so the model picker had to learn the same three-way answer or it would have started reading an unresolved offer as "none offered"; and `admin.agent.picker.empty` is a key in the design catalog, which `apps/web`'s `Translate` must satisfy to typecheck. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing asked for the Claude layer's existing order assertions to move. **Did:** updated the two `START_EVENTS` lists in `claude/agent/start.unit.test.ts`, the two kind lists in `claude/agent/events.unit.test.ts`, and the `START_EVENTS` docblock in `claude/agent/fixtures/harness.ts`. **Why:** each spelled out the open's emit order, which this fix changes; every one moved the `ready` to its new position and none was weakened or removed. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the criteria ask for no first-item fallback presented as an operator selection. **Did:** fixed it for thinking; left `selectedModel = … ?? modelItems?.[0]?.value` in place for the model chip. **Why:** it predates this bug, is not what #8425 reports, and changing which model the composer shows as running is a behaviour change the model control's own owner should make. **Disposition:** stated here, and filed as a follow-up issue.
