### PR TITLE
fix: pi-restore.integration.test.ts is red on main: the restored session never starts its new turn

### DIFF
--- a/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
+++ b/apps/tuval/src/pi/restore/pi-restore.integration.test.ts
@@ -23,7 +23,11 @@ import {Effect, type FileSystem, Option, type Scope} from "effect";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {type AiAgentSessionState, isAiAgentSessionState} from "../../ai-agent/core/index.ts";
 import {aiAgentPortNames} from "../../ai-agent/handlers/index.ts";
-import type {TranscriptPagePayload, TranscriptPayload} from "../../ai-agent/ports/index.ts";
+import type {
+	TranscriptItem,
+	TranscriptPagePayload,
+	TranscriptPayload,
+} from "../../ai-agent/ports/index.ts";
 import type {Arrival} from "../../ai-agent/restore/fixtures/window.ts";
 import {type Booted, boot, projectDir} from "../../boot.ts";
 import {Processes} from "../../process/Processes.ts";
@@ -60,17 +64,32 @@ const payloadsOn = (arrivals: ReadonlyArray<Arrival>, port: string): ReadonlyArr
 	arrivals.filter((arrival) => arrival.port === port).map((arrival) => arrival.payload);
 
 /** The tail as the window last saw it. Everything the proof reads about the transcript comes off this. */
-const rendered = (window: ProcessHandle): ReadonlyArray<string> => {
+const tailOf = (window: ProcessHandle): ReadonlyArray<TranscriptItem> => {
 	const last = payloadsOn(arrivalsOf(window), aiAgentPortNames.transcript).at(-1);
-	return ((last as TranscriptPayload | undefined)?.items ?? []).map(
-		(item) => `${item.kind}:${item.id}`,
-	);
+	return (last as TranscriptPayload | undefined)?.items ?? [];
 };
 
-const textsIn = (window: ProcessHandle): ReadonlyArray<string> => {
-	const last = payloadsOn(arrivalsOf(window), aiAgentPortNames.transcript).at(-1);
-	return ((last as TranscriptPayload | undefined)?.items ?? []).flatMap((item) =>
+const rendered = (window: ProcessHandle): ReadonlyArray<string> =>
+	tailOf(window).map((item) => `${item.kind}:${item.id}`);
+
+const textsIn = (window: ProcessHandle): ReadonlyArray<string> =>
+	tailOf(window).flatMap((item) =>
 		item.kind === "user" || item.kind === "assistant" ? [item.text] : [],
+	);
+
+/**
+ * A turn is over when its own prompt sits on the tail with a finished reply after it.
+ *
+ * The outcome is the only thing a poll can read here: `prompting` is transient, and once #8517
+ * compiled pi-protocol's validators a whole turn could finish between two 10 ms polls, so the wait
+ * that sampled the phase spun its full budget on a turn that had already landed (#8564).
+ */
+const answered = (window: ProcessHandle, text: string): boolean => {
+	const items = tailOf(window);
+	const asked = items.findLastIndex((item) => item.kind === "user" && item.text === text);
+	return (
+		asked >= 0 &&
+		items.slice(asked + 1).some((item) => item.kind === "assistant" && item.partial !== true)
 	);
 };
 
@@ -174,30 +193,25 @@ const runFirstBoot = (project: string): Effect.Effect<FirstRun, unknown, FileSys
 			phase: sessionOf(agent).phase,
 			failure: sessionOf(agent).failure,
 			items: sessionOf(agent).transcript.items.map((item) => item.kind),
+			tail: rendered(window),
 		});
 		yield* until("the Pi session to open", () => sessionOf(agent).sessionId !== null, seen);
 		yield* until("the session to be ready", () => sessionOf(agent).phase === "ready", seen);
 
-		// Each turn is waited out on the phase, in two steps: the send moves the core to `prompting`
-		// on its own, so `ready` alone could be the one this turn has not left yet. The end of a
-		// turn is a fact the send's own answer carries even when the push that would have said so is
-		// coalesced away (#7897), so this is the signal and the tail is what the assertions read.
-		const turn = (what: string) =>
+		const turn = (what: string, text: string, key: string) =>
 			Effect.gen(function* () {
-				yield* until(`${what} to start`, () => sessionOf(agent).phase === "prompting", seen);
-				yield* until(`${what} to finish`, () => sessionOf(agent).phase === "ready", seen);
+				yield* say(window, text, key);
+				yield* until(`${what} to be answered`, () => answered(window, text), seen);
 			});
 
-		yield* say(window, "read the readme", "k1");
-		yield* turn("the first turn");
+		yield* turn("the first turn", "read the readme", "k1");
 		yield* quiet(window);
 		assert.isTrue(
 			sessionOf(agent).transcript.items.some((item) => item.kind === "assistant"),
 			"the first turn settled with no reply in the tail",
 		);
 
-		yield* say(window, "now run the tool", "k2");
-		yield* turn("the tool turn");
+		yield* turn("the tool turn", "now run the tool", "k2");
 		yield* quiet(window);
 		assert.isTrue(
 			sessionOf(agent).transcript.items.some((item) => item.kind === "tool"),
@@ -229,6 +243,7 @@ const runFromTheCheckpoint = (
 			phase: sessionOf(agent).phase,
 			failure: sessionOf(agent).failure,
 			items: sessionOf(agent).transcript.items.map((item) => item.kind),
+			tail: rendered(window),
 		});
 		yield* until(
 			"the kernel's own resume to settle",
@@ -254,8 +269,7 @@ const runFromTheCheckpoint = (
 
 		const before = new Set(rendered(window));
 		yield* say(window, "and once more", "k3");
-		yield* until("the new turn to start", () => sessionOf(agent).phase === "prompting", seen);
-		yield* until("the new turn to finish", () => sessionOf(agent).phase === "ready", seen);
+		yield* until("the new turn to be answered", () => answered(window, "and once more"), seen);
 		yield* quiet(window);
 		assert.isTrue(
 			textsIn(window).includes("and once more"),


### PR DESCRIPTION
The restore proof's turn waits now read the turn's outcome off the window's transcript arrivals — the prompt on the tail with a finished assistant reply after it — instead of polling for a transient `prompting` phase.

`prompting` never lasted long enough to sample. Since #8517 compiled pi-protocol's validators, the restored turn finished inside a single 10 ms poll, so the wait spun its full 20 s budget on a turn that had already landed and the file went red on main. Boot one's `turn()` helper had the same latent race, surviving only on the ~170 ms one-time lazy compile of `ServerMessageSchema`; it moves to the same outcome wait.

Test-only. No production code changed, and no timeout or poll interval was raised.

Runs on this head:

- `--project integration src/pi/restore` solo, 5 times in a row: 7 passed each time, ~3.6 s per run (it used to sit at the 20 s budget before failing).
- `pnpm --filter @kampus/tuval test:integration` under the default worker count: 11 files, 48 tests, all passed.
- `pnpm --filter @kampus/tuval typecheck`: 0 errors. `pnpm lint`: clean.

A reviewer should look at `answered()` first: it requires the assistant item to be non-`partial`, so a mid-stream reply does not end the wait early.

Closes #8564

## Deviations

None.
