### PR TITLE
fix: The session picker's elapsed clock keeps ticking after the read has timed out

### DIFF
--- a/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
@@ -86,8 +86,9 @@ const TICK_MILLIS = 250;
  * this window's own, ticking only while a read is actually out. A pinned clock never ticks, which
  * is what lets a test render one exact moment of the wait.
  */
-const useClock = (pinned: number | undefined, ticking: boolean): number => {
+const useClock = (pinned: number | undefined, status: SessionListStatus): number => {
 	const [now, setNow] = useState(() => pinned ?? Date.now());
+	const ticking = atClock(status, pinned ?? now)._tag === "Reading";
 	useEffect(() => {
 		if (pinned !== undefined || !ticking) return;
 		const timer = setInterval(() => setNow(Date.now()), TICK_MILLIS);
@@ -189,7 +190,7 @@ export interface SessionListProps {
  */
 export function SessionList({status, onActivate, onRetry, now}: SessionListProps): ReactElement {
 	const [chosen, setChosen] = useState<string | null>(null);
-	const clock = useClock(now, status._tag === "Reading");
+	const clock = useClock(now, status);
 	const shown = atClock(status, clock);
 
 	const sessions = shown._tag === "Listed" ? shown.sessions : [];

--- a/apps/tuval/src/ai-agent/window/session-list-window.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/session-list-window.unit.test.tsx
@@ -6,9 +6,10 @@
  * substituted by `installDomShims` and asserted nowhere.
  */
 
-import {fireEvent, render, screen} from "@testing-library/react";
+import {act, cleanup, fireEvent, render, screen} from "@testing-library/react";
 import type {ReactElement} from "react";
-import {describe, expect, it, vi} from "vitest";
+import {Profiler, useState} from "react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import type {SessionListStatus} from "../../page/session-list.ts";
 import {reading, settled} from "../../page/session-list.ts";
 import type {SessionRow, UnreadableBackend} from "../../protocol/session-list.ts";
@@ -20,6 +21,80 @@ import {NO_FIRST_PROMPT} from "./rows.ts";
 import {SessionList} from "./SessionListWindow.tsx";
 
 installDomShims();
+
+describe("the unpinned wait clock", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({
+			toFake: ["Date", "setInterval", "clearInterval", "setTimeout", "clearTimeout"],
+		});
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+
+	it("crosses the deadline on its own, then stops updating until a fresh retry", () => {
+		const committed = vi.fn();
+		function RetriableList(): ReactElement {
+			const [status, setStatus] = useState(() => reading(Date.now()));
+			return <SessionList status={status} onRetry={() => setStatus(reading(Date.now()))} />;
+		}
+		render(
+			<Profiler id="session-list" onRender={committed}>
+				<RetriableList />
+			</Profiler>,
+		);
+		act(() => vi.advanceTimersByTime(SESSION_LIST_DEADLINE_MILLIS - 250));
+		expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("9");
+		act(() => vi.advanceTimersByTime(250));
+		expect(screen.queryByRole("progressbar")).toBeNull();
+		expect(screen.getByRole("status").textContent).toContain("ran past its deadline");
+		expect(vi.getTimerCount()).toBe(0);
+		committed.mockClear();
+		act(() => vi.advanceTimersByTime(60_000));
+		expect(committed).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", {name: "Read the sessions again"}));
+		expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("0");
+		act(() => vi.advanceTimersByTime(1_000));
+		expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("1");
+		act(() => vi.advanceTimersByTime(SESSION_LIST_DEADLINE_MILLIS - 1_000));
+		expect(screen.getByRole("status").textContent).toContain("ran past its deadline");
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("never starts a timer for an already expired read or a pinned clock", () => {
+		const {rerender} = render(<SessionList status={reading(NOW - SESSION_LIST_DEADLINE_MILLIS)} />);
+		act(() => vi.advanceTimersByTime(0));
+		expect(screen.getByRole("status").textContent).toContain("ran past its deadline");
+		expect(vi.getTimerCount()).toBe(0);
+		rerender(<SessionList status={reading(NOW)} now={NOW} />);
+		expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("0");
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it.each<SessionListStatus>([
+		{_tag: "Listed", sessions: [], unreadable: []},
+		{_tag: "Refused", failure: {tag: "tuval/UnknownSpell", message: "no spell there"}},
+	])("cleans up when a $_tag answer lands", (status) => {
+		const {rerender} = render(<SessionList status={reading(NOW)} />);
+		act(() => vi.advanceTimersByTime(0));
+		expect(vi.getTimerCount()).toBe(1);
+		rerender(<SessionList status={status} />);
+		expect(screen.queryByRole("progressbar")).toBeNull();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("cleans up an unanswered read on unmount", () => {
+		const {unmount} = render(<SessionList status={reading(NOW)} />);
+		act(() => vi.advanceTimersByTime(0));
+		expect(vi.getTimerCount()).toBe(1);
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});
 
 const listed = (
 	sessions: ReadonlyArray<SessionRow>,


### PR DESCRIPTION
The session picker kept its interval running after an unanswered read displayed TimedOut. Derive ticking from the effective read state so the deadline-crossing render stops the interval, while retry starts it again.

Deterministic component coverage checks deadline crossing, terminal quiescence, retry, expired mount, pinned clocks, answered reads and unmount. All 79 related unit tests pass; `build check --surface code` passes typecheck and lint with no unvalidated files. Effect cleanup is grounded in the installed React DOM 19.2.6 `updateEffectImpl` and `commitHookEffectListUnmount` implementations.

This changes clock lifetime only; markup, styles and rendered states are unchanged. LAW-SOURCE: manifest-prose.

Fixes #8494

## Deviations

None.
