### PR TITLE
chore: The four receive refusal paths on the Tuval AI agent row have no test

### DIFF
--- a/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts
@@ -18,6 +18,7 @@ import {Checkpoints} from "../durability/Checkpoints.ts";
 import {memoryStores} from "../durability/stores.ts";
 import {launch} from "../launch/launch.ts";
 import {compile} from "../ports/compile.ts";
+import {PayloadRejected} from "../ports/errors.ts";
 import {type Graph, NodeId} from "../ports/graph.ts";
 import {ProcessPorts} from "../ports/ProcessPorts.ts";
 import {open} from "../ports/wiring.ts";
@@ -315,5 +316,87 @@ describe("the AI agent interface over a compiled graph", () => {
 				assert.strictEqual(current(), modeBrand("plan"));
 			}),
 		),
+	);
+});
+
+/**
+ * The four payloads the row's in-ports refuse at the send (#7750).
+ *
+ * `program.ts`'s receivers are pure translations with nothing left to refuse: each in-port declares
+ * one direction's predicate, so the kernel's `accepts` check turns an unstamped prompt (#7991) and
+ * a wrong-direction payload (#8235) away inside the caller's own `emit`. The refusal names the port
+ * it crossed, and the window renders a failure by that port's kind (ruling 3, #7570) — so an end
+ * that admitted the whole union again would deliver a mode-set as a page request with nothing red.
+ */
+describe("what the agent row's in-ports refuse at the send", () => {
+	const pageReply = {
+		kind: "page",
+		items: [],
+		omitted: {items: 0, bytes: 0, reason: "none"},
+		next: null,
+	};
+	const pageRequest = {kind: "request", before: null, limit: 3};
+	const pendingSet = {kind: "pending", requests: {}};
+	const answer = {kind: "decision", request: PERMISSION_REQUEST, decision: "allow-once"};
+	const modeState = {kind: "state", current: modes.current, available: modes.available};
+	const modeSet = {kind: "set", mode: modeBrand("plan")};
+
+	const refusals = [
+		{
+			sends: "a prompt carrying no idempotency key",
+			port: aiAgentPortNames.prompt,
+			kind: prompt.kind,
+			wrong: {text: "hello", timestamp: 1},
+			right: {text: "hello", key: "k1", timestamp: 1},
+		},
+		{
+			sends: "a page at the end that takes requests",
+			port: aiAgentPortNames.pageRequest,
+			kind: transcriptPage.kind,
+			wrong: pageReply,
+			right: pageRequest,
+		},
+		{
+			sends: "a pending set at the end that takes answers",
+			port: aiAgentPortNames.permissionDecision,
+			kind: permission.kind,
+			wrong: pendingSet,
+			right: answer,
+		},
+		{
+			sends: "a mode state at the end that takes sets",
+			port: aiAgentPortNames.modeSet,
+			kind: mode.kind,
+			wrong: modeState,
+			right: modeSet,
+		},
+	] as const;
+
+	/** One compiled graph per send, so a refused payload leaves no queue behind for the next case. */
+	const sending = (port: string, payload: unknown) =>
+		Effect.gen(function* () {
+			const wiring = yield* open(yield* compile(graph));
+			return yield* wiring.emit({node: windowNode, port}, payload);
+		}).pipe(Effect.scoped, Effect.provide(Registry.layer([agentRow(plainReply), windowProgram])));
+
+	it.effect.each(refusals)(
+		"refuses $sends, naming the port it crossed",
+		({port, kind, wrong, right}) =>
+			Effect.gen(function* () {
+				const refusal = yield* Effect.flip(sending(port, wrong));
+				if (!(refusal instanceof PayloadRejected)) {
+					return assert.fail(`expected PayloadRejected on ${port}, got ${String(refusal)}`);
+				}
+				assert.deepStrictEqual(
+					{node: refusal.node, program: refusal.program, port: refusal.port, kind: refusal.kind},
+					{node: agentNode, program: AGENT, port, kind},
+				);
+
+				// The same port takes its own direction, so what the case above pinned is the direction
+				// and not a port that refuses everything.
+				assert.deepStrictEqual(yield* sending(port, right), [
+					{to: {node: agentNode, port}, accepted: true},
+				]);
+			}),
 	);
 });


### PR DESCRIPTION
The four inbound paths named in #7750 now have a test — but not where the issue said they were.

## What changed

`apps/tuval/src/ai-agent/ai-agent-ports.unit.test.ts` gains one table-driven `describe` block with
four cases, one per inbound port the AI agent row plays. Each case sends the payload that port
cannot act on, asserts the `PayloadRejected` the kernel raises at the caller's own `emit`, and pins
the node, program, port key and port kind the refusal names. Each case then sends the right-direction
payload at the same port and asserts it is delivered, so what the case pins is the direction and not
a port that refuses everything.

| Sends | At | Refused because |
|---|---|---|
| a prompt with no idempotency key | `prompt` | `isPromptPayload` requires `key` (#7991) |
| a `page` | `pageRequest` | that end admits `isTranscriptPageRequest` only (#8235) |
| a `pending` set | `permissionDecision` | that end admits `isPermissionAnswer` only |
| a `state` | `modeSet` | that end admits `isModeSet` only |

Every port key comes from `aiAgentPortNames` and every kind from the port objects in
`apps/tuval/src/ai-agent/ports/index.ts`, so a rename moves the test with the source rather than
leaving a re-typed string behind.

No production file changes. `pnpm --filter @kampus/tuval test:unit` is 2313/2313 green over 232
files; `pnpm typecheck` and `pnpm lint` are clean.

## The regression check

Criterion 3 asks that collapsing the arms back to one shared refusal reds at least three of the new
cases. I collapsed `defineTwoWayPort` in `apps/tuval/src/ai-agent/ports/ports.ts` so both ends of
each two-way port carry the union predicate — the pre-#8235 shape — and watched exactly three of the
four cases red: the three direction crossings. The prompt case stayed green, correctly: its refusal
is the missing idempotency key, which that collapse does not touch. Reverted before committing.

## Deviations

- **Scope narrowing** — **Said:** #7750 names four `refuse(tag, detail)` arms in `aiAgentProgram`'s
  `receive` map and asks each new case to assert the `failure.tag` and `failure.reason` that arm
  emits, with the tag read as a literal from `apps/tuval/src/ai-agent/core/failures.ts`.
  **Did:** asserted the `PayloadRejected` each port raises at the send instead — its `port` and
  `kind`, with the kind read as a literal from `apps/tuval/src/ai-agent/ports/index.ts`.
  **Why:** the four arms no longer exist. The issue was verified against `origin/epic/7497` before
  #8235 landed; PR #8491 deleted `refuse` and `portRefused` and moved the refusal into the kernel's
  `accepts` check, which is where `program.ts`'s own comment now points. `portRefused` is not in
  `core/failures.ts` on `main`, so the criteria as literally written cannot be satisfied by any diff.
  The gap they describe is real and still open: nothing sends a wrong payload at a live agent row's
  in-port. `ports/ports.unit.test.ts` calls the end predicates directly, which proves the predicate
  and not that the kernel consults it. **Disposition:** stated here; the four arms are covered at
  the surface that now carries them.
- **Scope narrowing** — **Said:** criterion 3 asks that collapsing the four arms to a single shared
  tag reds at least three cases. **Did:** collapsed both ends of each two-way port to the union
  predicate instead, and got exactly three red. **Why:** same reason — there is no shared tag left
  to collapse to; the union predicate is the equivalent regression on the surface the refusal moved
  to. **Disposition:** stated here, and the run is described under "The regression check" above.

Closes #7750
