### PR TITLE
fix: Tuval chat renders an AGENT label with no text under it between tool calls

### DIFF
--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -60,7 +60,7 @@ describe("init", () => {
 		const loaded = started({
 			phase: "prompting",
 			transcript: {
-				items: [assistantItem("a1"), userItem("u2")],
+				items: [userItem("u0"), assistantItem("a1")],
 				omitted: initialState("/x").transcript.omitted,
 			},
 		});
@@ -70,6 +70,20 @@ describe("init", () => {
 		expect(state.phase).toBe("idle");
 		expect(state.interrupted).toBe("a1");
 		expect(cmds).toEqual([]);
+	});
+
+	// The same restart, over a turn that had written nothing of its own yet — the tail ends on the
+	// operator's prompt. The reply above it belongs to the turn before and is not what got cut.
+	it("marks no cut reply when the restart caught a turn that had written none", () => {
+		const loaded = started({
+			phase: "prompting",
+			transcript: {
+				items: [userItem("u0"), assistantItem("a1"), userItem("u2")],
+				omitted: initialState("/x").transcript.omitted,
+			},
+		});
+		const [state] = machine.init(loaded, {});
+		expect(state.interrupted).toBeNull();
 	});
 
 	// The rehydrate branch is the defaulting parse and nothing else, so what the store read back is
@@ -840,6 +854,22 @@ describe("interrupt", () => {
 		expect(state.phase).toBe("prompting");
 		expect(state.interruption).toEqual({requestedAt: SENT_AT});
 		expect(state.interrupted).toBe("a1");
+		expect(cmds).toEqual([{type: "aiAgent.interrupt"}]);
+	});
+
+	// Turn 1 answered in prose and settled; turn 2's content is tool calls alone, which draws no
+	// assistant row at all (#8216). The stop belongs to turn 2, so turn 1's finished reply — sitting
+	// above the operator's second prompt — must not come back badged as cut short.
+	it("marks nothing when the running turn wrote no reply of its own", () => {
+		const toolOnly = running({
+			transcript: {
+				items: [userItem("u0"), assistantItem("a1"), userItem("u2"), toolItem("t3")],
+				omitted: initialState("/x").transcript.omitted,
+			},
+		});
+		const [state, cmds] = apply(toolOnly, {type: "interrupt", at: SENT_AT});
+		expect(state.interrupted).toBeNull();
+		expect(state.interruption).toEqual({requestedAt: SENT_AT});
 		expect(cmds).toEqual([{type: "aiAgent.interrupt"}]);
 	});
 

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -374,10 +374,19 @@ export const settleTurn = (state: AiAgentSessionState): AiAgentSessionState =>
 export const checkpointWorthy = (state: AiAgentSessionState): boolean =>
 	!holdsPartialItem(state) && !holdsRunningSubagent(state);
 
-/** The newest assistant turn in the tail, which is the one a restart can have cut. */
+/**
+ * The reply row of the turn in flight, which is the one an interrupt or a restart can have cut.
+ *
+ * Scoped to the newest `user` row deliberately: a turn whose content was tool calls alone draws no
+ * assistant row at all (`../pi/items.ts` suppresses it), so a scan that walked past the operator's
+ * prompt would answer with the *previous* turn's finished reply and badge it as cut short (#8216).
+ * `null` is the right answer there — the turn has no row to mark, and `state.interruption` plus the
+ * `aborted` row the backend pushes already carry the indication.
+ */
 export const lastAssistantId = (items: ReadonlyArray<TranscriptItem>): ItemId | null => {
 	for (let index = items.length - 1; index >= 0; index -= 1) {
 		const item = items[index];
+		if (item?.kind === "user") return null;
 		if (item?.kind === "assistant") return item.id;
 	}
 	return null;

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -222,4 +222,12 @@ describe("reading the tail", () => {
 		expect(lastAssistantId([userItem("i0")])).toBeNull();
 		expect(lastAssistantId([])).toBeNull();
 	});
+
+	// A turn whose content was tool calls alone draws no assistant row (#8216), so a scan that ran
+	// past the operator's prompt would answer with the *previous* turn's finished reply.
+	it("stops at the newest prompt, so a tool-only turn names no cut reply", () => {
+		expect(
+			lastAssistantId([userItem("i0"), assistantItem("i1"), userItem("i2"), toolItem("i3")]),
+		).toBeNull();
+	});
 });

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -115,10 +115,26 @@ const thinkingOf = (item: PiTranscriptItem): ThinkingItem | null => {
 	return {kind: "thinking", id: thinkingId(item.id), timestamp: item.timestamp, text};
 };
 
+/**
+ * An assistant turn with nothing to read and no cut to report: its content is tool calls alone, or
+ * it is a reply the model has not begun writing. Such a turn earns no reply row — an `agent` label
+ * over nothing reads as a message that was dropped or is still loading, and the calls it made are
+ * already rows of their own (#8216). Claude's mapper holds the same rule on its own wire
+ * (`../../claude/history/map.ts`, `settles && (text.length > 0 || interrupted)`).
+ *
+ * `aborted` and `error` are excluded on purpose: for those the status *is* the content, and an
+ * interrupted reply with no text still has to say the turn was cut.
+ */
+const emptyOrdinaryReply = (item: PiTranscriptItem): boolean =>
+	item.role === "assistant" &&
+	(item.status === "complete" || item.status === "streaming") &&
+	textOf(item.content) === "";
+
 /** One wire item as every row it is worth: the reasoning first, then the turn that produced it. */
 export const itemsOf = (item: PiTranscriptItem): ReadonlyArray<TranscriptItem> => {
 	const thinking = thinkingOf(item);
-	return thinking === null ? [itemOf(item)] : [thinking, itemOf(item)];
+	const reply = emptyOrdinaryReply(item) ? [] : [itemOf(item)];
+	return thinking === null ? reply : [thinking, ...reply];
 };
 
 /**

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -580,3 +580,154 @@ describe("an interruption over the Pi event path", () => {
 		expect(after.interruption).toBeNull();
 	});
 });
+
+/**
+ * The empty `agent` row of #8216: a turn that only called a tool has no text, and a label over
+ * nothing reads as a reply that was dropped or is still loading. The rows the turn really produced
+ * — its reasoning, its calls, its cost — are the ones that must survive the suppression.
+ */
+describe("a turn with nothing to read", () => {
+	const machine = aiAgentSessionMachine({cwd: "/workspace"});
+
+	const fold = (
+		state: AiAgentSessionState,
+		events: ReadonlyArray<AgentEvent>,
+	): AiAgentSessionState =>
+		events.reduce(
+			(carried, event) =>
+				applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(
+					machine,
+					carried,
+					{type: "event", sessionId: "session-7602", event},
+				)[0],
+			state,
+		);
+
+	const opened: AiAgentSessionState = {
+		...initialState("/workspace"),
+		phase: "ready",
+		sessionId: "session-7602",
+	};
+
+	const call = {
+		type: "toolCall" as const,
+		toolCallId: "call-1",
+		toolName: "read_file",
+		input: {path: "README.md"},
+	};
+
+	/** The reported shape: the model answered by calling a tool and wrote no prose at all. */
+	const toolOnly: PiTranscriptItem = {
+		id: "item-1",
+		role: "assistant",
+		content: [call],
+		model: {provider: "faux", id: "faux-1"},
+		usage: usage(0.42),
+		timestamp: 11,
+		status: "complete",
+		stopReason: "toolUse",
+	};
+
+	const reasonedToolOnly: PiTranscriptItem = {
+		...toolOnly,
+		content: [{type: "thinking", thinking: "read it first"}, call],
+	};
+
+	it("draws the tool it called and no empty reply beside it", () => {
+		expect(itemsOf(toolOnly)).toEqual([]);
+		const folded = eventsOf(emptyProjection, snapshot([user, toolOnly, settledTool], "idle"));
+		const items = folded.events.flatMap((event) => (event.kind === "item" ? [event.item] : []));
+		expect(items.map((item) => item.kind)).toEqual(["user", "tool"]);
+	});
+
+	it("keeps the reasoning, the tool row, the cost and the phase the turn ended on", () => {
+		const folded = eventsOf(
+			emptyProjection,
+			snapshot([user, reasonedToolOnly, settledTool], "idle"),
+		);
+		expect(folded.events).toEqual([
+			{kind: "item", item: {kind: "user", id: "item-0", timestamp: 10, text: "say hello"}},
+			{
+				kind: "item",
+				item: {kind: "thinking", id: "item-1:thinking", timestamp: 11, text: "read it first"},
+			},
+			{
+				kind: "item",
+				item: {
+					kind: "tool",
+					id: "call-1",
+					timestamp: 12,
+					name: "read_file",
+					input: {path: "README.md"},
+					result: {text: "the file", omitted: {bytes: 0}},
+					status: "ok",
+				},
+			},
+			{
+				kind: "usage",
+				turn: "item-1",
+				model: "faux/faux-1",
+				inputTokens: 11,
+				outputTokens: 22,
+				cost: 0.42,
+			},
+			{kind: "phase", phase: "ready"},
+		]);
+	});
+
+	it("renders one reply once when an empty partial grows into a settled one", () => {
+		const first = eventsOf(emptyProjection, snapshot([user, streamingAssistant("")], "turn"));
+		const second = eventsOf(first.next, snapshot([user, streamingAssistant("hi")], "turn", 2));
+		const third = eventsOf(second.next, snapshot([user, settledAssistant("hi back")], "idle", 3));
+		expect(
+			first.events.some((event) => event.kind === "item" && event.item.kind === "assistant"),
+		).toBe(false);
+		const settled = fold(fold(fold(opened, first.events), second.events), third.events);
+		expect(settled.transcript.items.map((item) => [item.id, item.kind])).toEqual([
+			["item-0", "user"],
+			["item-1", "assistant"],
+		]);
+		expect(settled.transcript.items.at(-1)).toEqual({
+			kind: "assistant",
+			id: "item-1",
+			timestamp: 11,
+			text: "hi back",
+		});
+	});
+
+	it("leaves no empty reply behind when the turn settles textless", () => {
+		const first = eventsOf(emptyProjection, snapshot([user, streamingAssistant("")], "turn"));
+		const second = eventsOf(first.next, snapshot([user, toolOnly, settledTool], "idle", 2));
+		const settled = fold(fold(opened, first.events), second.events);
+		expect(settled.transcript.items.map((item) => item.kind)).toEqual(["user", "tool"]);
+		expect(holdsPartialItem(settled)).toBe(false);
+	});
+
+	it("still draws an interrupted reply that carries no text", () => {
+		const aborted: PiTranscriptItem = {
+			...toolOnly,
+			content: [],
+			status: "aborted",
+			stopReason: "aborted",
+		};
+		expect(itemsOf(aborted)).toEqual([
+			{kind: "assistant", id: "item-1", timestamp: 11, text: "", interrupted: true},
+		]);
+	});
+
+	it("leaves an ordinary reply, a user turn and a failed turn alone", () => {
+		expect(itemsOf(settledAssistant("hi back"))).toEqual([
+			{kind: "assistant", id: "item-1", timestamp: 11, text: "hi back"},
+		]);
+		expect(itemsOf({...user, content: []})).toEqual([
+			{kind: "user", id: "item-0", timestamp: 10, text: ""},
+		]);
+		const failed: PiTranscriptItem = {
+			...toolOnly,
+			content: [],
+			status: "error",
+			stopReason: "error",
+		};
+		expect(itemsOf(failed)).toEqual([{kind: "assistant", id: "item-1", timestamp: 11, text: ""}]);
+	});
+});

--- a/apps/tuval/src/shell/chat/empty-reply-row.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/empty-reply-row.unit.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #8216's rendered half: a Pi turn that only called a tool draws that call and no `agent` label
+ * over nothing.
+ *
+ * The rows come from the Pi mapper rather than a hand-written transcript. The defect was a mapped
+ * item the window then rendered faithfully, so a fixture composed here would decide the answer it
+ * is meant to check. Reaching into a backend is a liberty test files have and source files do not —
+ * `boundary.unit.test.ts` holds that import out of every `.ts`/`.tsx` in this directory.
+ */
+
+import {render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {emptyProjection, eventsOf} from "../../pi/ai-agent/items.ts";
+import type {TranscriptItem as PiTranscriptItem, SessionSnapshot} from "../../pi/wire/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
+import {withTranscript} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+const openWindow = async (state: AiAgentSessionState): Promise<void> => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
+	);
+	const host: ChatWindowHost = await Effect.runPromise(
+		process.window<ChatView>(WindowId.make("w1"), {...initialChatView, pinned: true}),
+	);
+	render(chatWindow({scrollToFn: () => {}}).render(host) as ReactElement);
+};
+
+const snapshotOf = (transcript: ReadonlyArray<PiTranscriptItem>): SessionSnapshot => ({
+	id: "session-8216",
+	cwd: "/workspace",
+	createdAt: 0,
+	updatedAt: 0,
+	phase: "idle",
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+	attached: true,
+	locked: false,
+	revision: 1,
+	transcript: [...transcript],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+/** The wire transcript as the window would hold it, mapped the one way the live path maps it. */
+const rowsOf = (transcript: ReadonlyArray<PiTranscriptItem>): ReadonlyArray<TranscriptItem> =>
+	eventsOf(emptyProjection, snapshotOf(transcript)).events.flatMap((event) =>
+		event.kind === "item" ? [event.item] : [],
+	);
+
+const prompt: PiTranscriptItem = {
+	id: "item-0",
+	role: "user",
+	content: [{type: "text", text: "read the readme"}],
+	timestamp: 10,
+};
+
+const toolOnlyTurn: PiTranscriptItem = {
+	id: "item-1",
+	role: "assistant",
+	content: [
+		{type: "toolCall", toolCallId: "call-1", toolName: "read_file", input: {path: "README.md"}},
+	],
+	model: {provider: "faux", id: "faux-1"},
+	timestamp: 11,
+	status: "complete",
+	stopReason: "toolUse",
+};
+
+const toolResult: PiTranscriptItem = {
+	id: "item-2",
+	role: "tool",
+	toolCallId: "call-1",
+	toolName: "read_file",
+	input: {path: "README.md"},
+	content: [{type: "text", text: "the file"}],
+	timestamp: 12,
+	status: "complete",
+	isError: false,
+};
+
+const reply: PiTranscriptItem = {
+	...toolOnlyTurn,
+	id: "item-3",
+	content: [{type: "text", text: "it says hello"}],
+	timestamp: 13,
+	status: "complete",
+	stopReason: "stop",
+};
+
+describe("a tool-only turn in the window", () => {
+	it("draws the tool row and no agent label above it", async () => {
+		await openWindow(withTranscript(rowsOf([prompt, toolOnlyTurn, toolResult])));
+
+		expect(screen.queryAllByText("agent")).toHaveLength(0);
+		expect(screen.getByText("tool")).toBeDefined();
+		expect(screen.getByText("read the readme")).toBeDefined();
+	});
+
+	it("still labels the reply the same turn's model went on to write", async () => {
+		await openWindow(withTranscript(rowsOf([prompt, toolOnlyTurn, toolResult, reply])));
+
+		expect(screen.queryAllByText("agent")).toHaveLength(1);
+		expect(screen.getByText("it says hello")).toBeDefined();
+	});
+});


### PR DESCRIPTION
Fixes #8216

A Pi assistant turn whose content is tool calls alone has no text, and the mapper still emitted an
`assistant` row for it. The window drew the `AGENT` label over nothing — the empty rows between tool
calls in the founder's screenshot.

`itemsOf` in `apps/tuval/src/pi/ai-agent/items.ts` now leaves out the reply row when the turn is
`complete` or `streaming` and its text is empty. Everything else the turn produced is untouched: the
reasoning row, the tool rows keyed by call id, the usage event, the phase. Claude's mapper already
held the same rule (`settles && (text.length > 0 || interrupted)`), so both backends now agree.

`aborted` and `error` are left alone — for those the status is the content, and an interrupted reply
with no text still has to say the turn was cut.

Suppressing the empty *streaming* row matters as much as the settled one. A partial that never gets
superseded is settled in place by `settleTurn`, so a turn that starts empty and ends textless would
have stranded a permanently empty row even with the settled case fixed.

## Tests

`apps/tuval/src/pi/ai-agent/items.unit.test.ts` — six cases over the mapper and the real core fold:
the tool-only turn, the reasoning/tool/usage/phase that survive it, the empty→growing→settled reply
landing once under one id, the textless settle leaving nothing behind, the interrupted empty row, and
the untouched ordinary/user/error rows.

`apps/tuval/src/shell/chat/empty-reply-row.unit.test.tsx` — the rendered half, mapping a Pi wire
transcript through `eventsOf` and rendering the real chat window against the window contract's own
double. Four of the mapper cases and both rendered cases fail without the change; I flipped it back
and forth to check.

## Hand-verified on a scratch desk

`node src/pi/proof/serve.ts --page-port 5241 --strict-port` from `apps/tuval`, with the proof's
scripted faux replies temporarily led by `fauxAssistantMessage([fauxToolCall("bash", {command:
"ls"})], {stopReason: "toolUse"})`. Read in Chromium through Playwright, reading every
`.tuval-chat-who` label with the text under it.

Without the change, port 5242:

```
you   "what is this project"
agent ""
tool  "bash error …"
agent "a local app on the Tuval kernel"
```

With it, port 5241:

```
you   "what is this project"
tool  "bash error …"
agent "a local app on the Tuval kernel"
```

Zero console errors on both loads. The harness edit was reverted before the commit; the diff carries
only the mapper and the two test files.

## Deviations

- **Known defect left unfixed** — **Said:** #8216 names the settled empty ordinary reply. **Did:**
  left a `status: "error"` turn with no text still drawing its `AGENT` label over nothing. **Why:**
  the wire's `errorMessage` never reaches the port, so suppressing that row would erase the only
  trace of a failed turn; #8453 already owns the case and I noted the boundary there
  (https://github.com/kamp-us/phoenix/issues/8453#issuecomment-5578659284). **Disposition:** stated
  here and on that issue.
- **Out-of-scope change** — **Said:** the shell slice is backend-blind. **Did:** the new rendered
  test imports `../../pi/ai-agent/items.ts` and `../../pi/wire/index.ts`. **Why:** the defect was a
  mapped item the window rendered faithfully, so a transcript hand-written in the shell slice would
  decide the answer it is meant to check; `boundary.unit.test.ts` scans source files only, and its
  own docblock records that exclusion existing so fixtures may reach a backend at runtime.
  **Disposition:** stated here — a reviewer who wants the edge gone can have the rendered assertion
  live on a hand-built transcript instead, at the cost of it no longer failing before the fix.
- **Known defect left unfixed** — **Said:** run `pnpm --filter @kampus/tuval test:unit`. **Did:**
  the full suite came back 1 failed / 2316 passed, on `src/boot.unit.test.ts`'s restart case, and I
  did not chase it. **Why:** it passes on its own (11/11) and fails only under the loaded parallel
  run; it is outside this diff and #8579 already tracks it. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** repair the criterion-4 finding without
  weakening existing assertions. **Did:** reordered the `init` test's fixture in
  `machine.unit.test.ts` from `[assistantItem("a1"), userItem("u2")]` to
  `[userItem("u0"), assistantItem("a1")]`. **Why:** that ordering was the defect written down — an
  assistant row above the operator's prompt at `phase: "prompting"`, i.e. a tail whose last event is
  an unanswered prompt, where `"a1"` belongs to the previous turn. Its assertion (`interrupted` is
  `"a1"`) is unchanged and still passes; the case the old ordering described is now its own test
  asserting `null`. **Disposition:** stated here.
