### PR TITLE
fix: A dropped socket leaves Tuval's transcript source reading forever with the older button stuck disabled

### DIFF
--- a/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
@@ -317,6 +317,7 @@ export interface TranscriptPaged {
 	readonly answer: TranscriptAnswer | null;
 	/** Absent when the caller cannot page — then the older affordance is not offered at all. */
 	readonly onOlder?: () => void;
+	readonly onRetry?: () => void;
 }
 
 /**
@@ -451,6 +452,7 @@ function SessionTranscriptHost({
 			onBack={onBack}
 			onSend={onSend}
 			{...(paged.onOlder === undefined ? {} : {onOlder: paged.onOlder})}
+			{...(paged.onRetry === undefined ? {} : {onRetry: paged.onRetry})}
 		/>
 	);
 }

--- a/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
@@ -32,6 +32,7 @@ import {sessionLabel} from "./rows.ts";
 import "./session-list-window.css";
 
 const COPY = {
+	retry: "Try reading this transcript again",
 	reading: "Reading this session's transcript…",
 	empty: "This session holds no messages yet.",
 	older: "Load older messages",
@@ -63,6 +64,7 @@ export interface SessionTranscriptProps {
 	readonly answer: TranscriptAnswer | null;
 	/** Ask for the page older than the one on screen. Absent means this caller does not page. */
 	readonly onOlder?: () => void;
+	readonly onRetry?: () => void;
 	/** The operator sent. What that does to the process is the caller's, through `send`. */
 	readonly onSend: (text: string) => void;
 	/** Leave the session and put the list back in this window. */
@@ -75,6 +77,7 @@ export function SessionTranscriptView({
 	session,
 	answer,
 	onOlder,
+	onRetry,
 	onSend,
 	onBack,
 	unopenable = false,
@@ -111,9 +114,14 @@ export function SessionTranscriptView({
 
 	const body: ReactElement =
 		unopenable || refusal !== null ? (
-			<p className="tuval-session-transcript-refused" role="alert">
-				{refusal === null ? COPY.noFolder : failureLine(refusal)}
-			</p>
+			<div className="tuval-session-transcript-refused">
+				<p role="alert">{refusal === null ? COPY.noFolder : failureLine(refusal)}</p>
+				{!unopenable && refusal !== null && onRetry !== undefined ? (
+					<Button type="button" variant="tertiary" size="sm" onClick={onRetry}>
+						{COPY.retry}
+					</Button>
+				) : null}
+			</div>
 		) : answer === null ? (
 			<p className="tuval-session-transcript-note">{COPY.reading}</p>
 		) : items.length === 0 ? (

--- a/apps/tuval/src/page/renderers.tsx
+++ b/apps/tuval/src/page/renderers.tsx
@@ -28,7 +28,7 @@
 import features from "virtual:tuval/features";
 import {Effect, Fiber, Stream} from "effect";
 import type {ReactElement} from "react";
-import {useCallback, useEffect, useState} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 import {isAiAgentSessionState} from "../ai-agent/core/snapshot.ts";
 import {isSessionListState} from "../ai-agent/renderer-ref.ts";
 import {
@@ -199,10 +199,12 @@ const sessionTranscriptSource = (call: SpellCaller): TranscriptSource => {
 		const [paging, setPaging] = useState(noPages);
 		const [cursor, setCursor] = useState<string | null>(null);
 		const [attempt, setAttempt] = useState(0);
+		const reading = useRef(false);
 
 		useEffect(() => {
 			if (request._tag !== "Read") return;
 			let current = true;
+			reading.current = true;
 			const spell = sessionTranscriptCall({...request.read, before: cursor}, window);
 			const fiber = Effect.runFork(
 				call(spell).pipe(
@@ -210,10 +212,27 @@ const sessionTranscriptSource = (call: SpellCaller): TranscriptSource => {
 						Effect.sync(() => {
 							if (!current) return;
 							const landing = readSessionTranscript(spell, reply);
-							if (landing !== null) setPaging((held) => landedPage(held, cursor, landing));
+							if (landing !== null) {
+								reading.current = false;
+								setPaging((held) => landedPage(held, cursor, landing));
+							}
 						}),
 					),
-					Effect.catchCause(() => Effect.void),
+					Effect.catchTag("SocketError", () =>
+						Effect.sync(() => {
+							if (!current) return;
+							reading.current = false;
+							setPaging((held) =>
+								landedPage(held, cursor, {
+									_tag: "Refused",
+									failure: {
+										tag: "tuval/TranscriptReadFailed",
+										message: "This transcript page could not be read. You can try it again.",
+									},
+								}),
+							);
+						}),
+					),
 				),
 			);
 			return () => {
@@ -225,18 +244,29 @@ const sessionTranscriptSource = (call: SpellCaller): TranscriptSource => {
 		const next = paging.next;
 		const olderOut = paging.older._tag === "Reading";
 		const older = useCallback(() => {
-			if (next === null || olderOut) return;
+			if (next === null || olderOut || reading.current) return;
+			reading.current = true;
 			setPaging(askedOlder);
 			setCursor(next);
 			setAttempt((current) => current + 1);
 		}, [next, olderOut]);
+
+		const retry = useCallback(() => {
+			if (paging.refusal === null || reading.current) return;
+			reading.current = true;
+			setPaging(noPages);
+			setCursor(null);
+			setAttempt((current) => current + 1);
+		}, [paging.refusal]);
 
 		const answer = request._tag === "Read" ? pagedAnswer(paging) : null;
 		// The affordance is offered only where there is a page to ask for, so the surface's own rule
 		// ("gone once there is nothing older") and this one cannot disagree about the end of history.
 		return answer !== null && answer._tag === "Read" && answer.page.next !== null
 			? {answer, onOlder: older}
-			: {answer};
+			: answer?._tag === "Refused"
+				? {answer, onRetry: retry}
+				: {answer};
 	};
 	return useSessionTranscript;
 };

--- a/apps/tuval/src/page/session-transcript-window.unit.test.tsx
+++ b/apps/tuval/src/page/session-transcript-window.unit.test.tsx
@@ -13,9 +13,9 @@
  * is `./session-transcript.unit.test.ts`.
  */
 
-import {act, fireEvent, render, screen, within} from "@testing-library/react";
+import {act, cleanup, fireEvent, render, screen, within} from "@testing-library/react";
 import {Effect, Stream} from "effect";
-import type {Socket} from "effect/unstable/socket";
+import {Socket} from "effect/unstable/socket";
 import type {ReactElement} from "react";
 import {beforeEach, describe, expect, it} from "vitest";
 import type {SessionListState} from "../ai-agent/renderer-ref.ts";
@@ -57,6 +57,8 @@ installDomShims();
 interface Parked {
 	readonly spell: SpellCall;
 	readonly answer: (reply: SpellReply) => void;
+	readonly fail: () => void;
+	interrupted: boolean;
 }
 
 let parked: Array<Parked> = [];
@@ -103,7 +105,23 @@ const call: SpellCaller = (spell) =>
 			resume(Effect.succeed(refusal(spell.id, unknownSpell(spell.path))));
 			return;
 		}
-		parked.push({spell, answer: (reply) => resume(Effect.succeed(reply))});
+		const pending: Parked = {
+			spell,
+			answer: (reply) => resume(Effect.succeed(reply)),
+			fail: () =>
+				resume(
+					Effect.fail(
+						new Socket.SocketError({
+							reason: new Socket.SocketCloseError({code: 1006}),
+						}),
+					),
+				),
+			interrupted: false,
+		};
+		parked.push(pending);
+		return Effect.sync(() => {
+			pending.interrupted = true;
+		});
 	});
 
 /**
@@ -407,5 +425,104 @@ describe("the read-only contract", () => {
 		expect(new Set(parked.map((sent) => sent.spell.path.join(".")))).toEqual(
 			new Set([SESSION_TRANSCRIPT_CALL_PATH.join(".")]),
 		);
+	});
+});
+
+const failRead = async (index: number): Promise<void> => {
+	const pending = parked[index];
+	if (pending === undefined) throw new Error("missing transcript call");
+	await act(async () => {
+		pending.fail();
+	});
+};
+
+describe("transport read failures", () => {
+	it("leaves the first read recoverable until one explicit correlated retry succeeds", async () => {
+		const container = await openSession();
+		await failRead(0);
+		expect(screen.queryByText("Reading this session's transcript…")).toBeNull();
+		expect(screen.getByRole("alert").textContent).toContain(
+			"This transcript page could not be read",
+		);
+		await settle();
+		expect(parked).toHaveLength(1);
+		const retry = screen.getByRole("button", {name: "Try reading this transcript again"});
+		await act(async () => {
+			fireEvent.click(retry);
+			fireEvent.click(retry);
+		});
+		expect(parked).toHaveLength(2);
+		expect(parked[1]?.spell.args).toEqual(parked[0]?.spell.args);
+		expect(parked[1]?.spell.id).not.toBe(parked[0]?.spell.id);
+		expect(parked[1]?.spell.window).toBe("w-1");
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(screen.getByText("Reading this session's transcript…")).toBeTruthy();
+		await answer(1, (id) => ok(id, pageOf(1, 2, null)));
+		expect(texts(container)).toEqual(["userturn m-1", "userturn m-2"]);
+		expect(new Set(parked.map(({spell}) => spell.path.join(".")))).toEqual(
+			new Set([SESSION_TRANSCRIPT_CALL_PATH.join(".")]),
+		);
+	});
+
+	it("retains older history and its cursor across repeated failures and explicit retries", async () => {
+		const container = await openSession();
+		await answer(0, (id) => ok(id, pageOf(3, 2, "m-3")));
+		fireEvent.click(older() as HTMLElement);
+		await settle();
+		await failRead(1);
+		expect(texts(container)).toEqual(["userturn m-3", "userturn m-4"]);
+		expect(screen.queryByText("Reading older messages…")).toBeNull();
+		const retry = screen.getByRole("button", {name: "Try the older messages again"});
+		expect(retry.hasAttribute("disabled")).toBe(false);
+		await settle();
+		expect(parked).toHaveLength(2);
+		await act(async () => {
+			fireEvent.click(retry);
+			fireEvent.click(retry);
+		});
+		expect(parked).toHaveLength(3);
+		expect(parked[2]?.spell.args).toEqual(parked[1]?.spell.args);
+		expect(parked[2]?.spell.id).not.toBe(parked[1]?.spell.id);
+		await failRead(2);
+		fireEvent.click(screen.getByRole("button", {name: "Try the older messages again"}));
+		await settle();
+		expect(parked[3]?.spell.args).toMatchObject({before: "m-3"});
+		await answer(3, (id) => ok(id, pageOf(1, 2, null)));
+		expect(texts(container)).toEqual([
+			"userturn m-1",
+			"userturn m-2",
+			"userturn m-3",
+			"userturn m-4",
+		]);
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(older()).toBeNull();
+	});
+
+	it("interrupts a left read silently and ignores its late failure after reopening", async () => {
+		const container = await openSession();
+		fireEvent.click(screen.getByRole("button", {name: "Back to the session list"}));
+		await settle();
+		expect(parked[0]?.interrupted).toBe(true);
+		expect(screen.queryByRole("alert")).toBeNull();
+		fireEvent.keyDown(screen.getByRole("combobox", {name: "AI agent sessions"}), {key: "Enter"});
+		await settle();
+		await failRead(0);
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(screen.getByText("Reading this session's transcript…")).toBeTruthy();
+		await answer(1, (id) => ok(id, pageOf(1, 1, null)));
+		expect(texts(container)).toEqual(["userturn m-1"]);
+	});
+
+	it("interrupts an older read on unmount without retrying or leaking a failure", async () => {
+		await openSession();
+		await answer(0, (id) => ok(id, pageOf(3, 2, "m-3")));
+		fireEvent.click(older() as HTMLElement);
+		await settle();
+		cleanup();
+		await settle();
+		expect(parked[1]?.interrupted).toBe(true);
+		await failRead(1);
+		expect(parked).toHaveLength(2);
+		expect(screen.queryByRole("alert")).toBeNull();
 	});
 });

--- a/apps/tuval/src/pi/window/proof/transcript.html
+++ b/apps/tuval/src/pi/window/proof/transcript.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Transcript read failure proof</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./transcript.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/pi/window/proof/transcript.tsx
+++ b/apps/tuval/src/pi/window/proof/transcript.tsx
@@ -1,0 +1,39 @@
+/** Rendered failure affordances only; the actual socket branch is proved by page/session-transcript-window.unit.test.tsx. */
+import {createRoot} from "react-dom/client";
+import {claudeSession} from "../../../ai-agent/window/fixtures.ts";
+import {SessionTranscriptView} from "../../../ai-agent/window/SessionTranscript.tsx";
+import type {TranscriptAnswer} from "../../../page/session-transcript.ts";
+import "../../../page/styles.ts";
+import "./proof.css";
+
+const failure = {
+	tag: "tuval/TranscriptReadFailed",
+	message: "This transcript page could not be read. You can try it again.",
+};
+const older = new URLSearchParams(location.search).has("older");
+const answer: TranscriptAnswer = older
+	? {
+			_tag: "Read",
+			page: {
+				items: [{kind: "user", id: "m-3", timestamp: 1, text: "Keep this loaded history visible."}],
+				next: "m-3",
+			},
+			older: {_tag: "Failed", failure},
+		}
+	: {_tag: "Refused", failure};
+const host = document.getElementById("proof");
+if (host === null) throw new Error("Missing proof host");
+createRoot(host).render(
+	<div className="tuval-surface proof-desk" data-scheme="dark">
+		<div className="proof-pane">
+			<SessionTranscriptView
+				session={claudeSession}
+				answer={answer}
+				onRetry={() => {}}
+				onOlder={() => {}}
+				onSend={() => {}}
+				onBack={() => {}}
+			/>
+		</div>
+	</div>,
+);

--- a/apps/web/tests/e2e/32-bootstrap-helper.spec.ts
+++ b/apps/web/tests/e2e/32-bootstrap-helper.spec.ts
@@ -1,0 +1,32 @@
+import {expect, test} from "@playwright/test";
+import {completeBootstrap} from "./_helpers/auth";
+
+test.describe("fresh-account bootstrap helper", () => {
+	test("rejects a missing gate instead of treating it as a completed account", async ({page}) => {
+		await page.setContent("<main>Waiting for account data</main>");
+		await expect(completeBootstrap(page)).rejects.toThrow(/bootstrap-username/);
+	});
+
+	test("waits for the gate and completes the two-click prefill confirmation", async ({page}) => {
+		await page.setContent("<main></main>");
+		const completion = completeBootstrap(page);
+		await page.evaluate(() => {
+			const main = document.querySelector("main");
+			if (main === null) throw new Error("Missing fixture main");
+			main.innerHTML = `
+				<h2>kullanıcı adını seç</h2>
+				<form>
+					<input id="bootstrap-username" value="test-reader" />
+					<button type="submit" class="kp-auth__submit">devam et</button>
+				</form>`;
+			let submits = 0;
+			main.querySelector("form")?.addEventListener("submit", (event) => {
+				event.preventDefault();
+				submits += 1;
+				if (submits === 2) main.innerHTML = "<p>Account ready</p>";
+			});
+		});
+		await completion;
+		await expect(page.getByText("Account ready")).toBeVisible();
+	});
+});

--- a/apps/web/tests/e2e/_helpers/auth.ts
+++ b/apps/web/tests/e2e/_helpers/auth.ts
@@ -61,7 +61,7 @@ export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<C
 }
 
 /**
- * Complete the username bootstrap gate if it's up. A fresh Pasaport user has `username = NULL`, so
+ * Complete the username bootstrap gate for a fresh account. A new user has `username = NULL`, so
  * the Layout replaces the page content with <UsernameBootstrap> — specs that sign up and then
  * assert page content must clear this first or they see the form.
  *
@@ -71,14 +71,8 @@ export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<C
  */
 export async function completeBootstrap(page: Page): Promise<void> {
 	const input = page.locator("input#bootstrap-username");
-	// The gate mounts only after `useMe` resolves (async over fate), so a
-	// point-in-time visibility check races the fetch. Wait for it to appear; if
-	// it never does within the window, assume the user is already bootstrapped.
-	try {
-		await expect(input).toBeVisible({timeout: 10_000});
-	} catch {
-		return;
-	}
+	// Every caller just signed up: an absent gate is failed setup, never a completed account.
+	await expect(input).toBeVisible({timeout: 10_000});
 	const prefilled = await input.inputValue();
 	const handle =
 		prefilled && prefilled.length >= 3


### PR DESCRIPTION
A failed transcript socket call now leaves Reading immediately and offers an explicit retry. First-page retry reissues the same address with a fresh call ID; older-page retry preserves loaded history and the failed cursor. Cleanup still interrupts silently, and repeated clicks cannot queue another read while one is pending.

Release containment: none. This local-only Tuval recovery fix is available by default.

Validated with 41 transcript/window tests and `fabrika build check --surface code` (affected typechecks and worktree lint). The tests fail the actual source's SocketError channel and cover retry recovery, preserved cursors, navigation, late answers and unmount cleanup. Typed recovery follows [Effect LLMS.md, Error handling basics](https://github.com/Effect-TS/effect/blob/main/LLMS.md#error-handling-basics), checked against Tuval's installed effect 4.0.0-rc.112 `Effect.ts` catchTag and socket error schema.

Rendered hand-verification: `pnpm --filter @kampus/tuval proof:pi-window` serves `/transcript.html` and `/transcript.html?older`, committed static failure fixtures using the real component and page styles. At 1280×900 the first retry sits beside its error; older failure leaves the history visible. These captures prove paint, while the source tests prove transport behavior. The before capture uses the baseline SessionTranscriptView against the same fixtures; it does not claim a baseline socket failure already reached that state. LAW-SOURCE: manifest-prose.

The prerequisite web CI setup repair now rejects a missing fresh-account username gate instead of saving an incomplete session. Browser regression failed on the old helper and both cases pass after repair. Live preview setup and authenticated smoke pass in isolation (4.0s and 3.0s); an earlier run alongside local typechecks reached the unchanged 15s setup cap during confirmation. The original CI gate-absence condition did not reproduce in isolation; this does not settle [investigation #6398](https://github.com/kamp-us/phoenix/issues/6398).

Fixes #8506

## Deviations

- **Pre-existing test or fixture changed** — **Said:** tests must drive actual transport failure and cleanup. **Did:** extended the existing scripted socket with typed failure and interruption recording, preserving its existing assertions. **Why:** the source's catch branch and fiber cleanup cannot be tested by reply callbacks alone. **Disposition:** covered by the new source regression tests.

- **Out-of-scope change** — **Said:** implement the Tuval transcript repair. **Did:** removed the web fresh-account bootstrap helper's swallowed visibility timeout and added browser regression coverage. **Why:** the gating authenticated smoke failure revealed setup could report success without completing onboarding; the user explicitly authorized the prerequisite CI repair after scope review. **Disposition:** affected typechecks and lint pass, missing-gate regression is red on baseline and green after repair, and isolated live setup plus authenticated smoke pass. The underlying initial absence remains an open investigation under #6398.
