### PR TITLE
fix: boot.unit.test.ts's restart case flakes on a trailing-stdout race under a loaded suite

### DIFF
--- a/apps/tuval/src/boot.unit.test.ts
+++ b/apps/tuval/src/boot.unit.test.ts
@@ -63,7 +63,12 @@ const spawnBudget = (spawns: number) => spawns * SPAWN_GUARD_MS + 5_000;
  */
 const DIRECT_BOOT_MS = 20_000;
 
-/** A boot with live processes stays up until a signal: send SIGINT once it says it is running. */
+/**
+ * A boot with live processes stays up until a signal: send SIGINT once it says it is running.
+ *
+ * It resolves on `close`, not on `exit`, so `stdout` holds everything the child wrote up to EOF —
+ * including whatever lands after `tuval: stopping`. See the restart case for why that matters.
+ */
 const runUntilRunning = (
 	args: ReadonlyArray<string>,
 	env: NodeJS.ProcessEnv = process.env,
@@ -239,7 +244,16 @@ describe("boot", () => {
 				"tuval: process log program=log parent=counter ports=ticks:in(count/v1) state=running@0\n",
 			);
 			expect(first.stdout).toContain("tuval: running — Ctrl-C stops and checkpoints\n");
-			expect(first.stdout.trimEnd().endsWith("tuval: stopping")).toBe(true);
+			// The stop line says the interrupt landed, not that teardown is over: `bin.ts` prints it
+			// from the innermost `onInterrupt`, and the processes stop as the outer scope closes after
+			// it, so the demo log's once-a-second `count N` can legally land between the two. That is
+			// deliberate, and asserting the stop line was *last* turned it into a random red (#8579).
+			// The stop happened: this line is here, after the run line, and `status` above is 0.
+			const stopLine = first.stdout.search(/^tuval: stopping$/m);
+			expect(stopLine).toBeGreaterThanOrEqual(0);
+			expect(stopLine).toBeGreaterThan(
+				first.stdout.indexOf("tuval: running — Ctrl-C stops and checkpoints\n"),
+			);
 
 			const second = await runUntilRunning(args);
 			expect(second.status).toBe(0);


### PR DESCRIPTION
`boot.unit.test.ts`'s restart case asserted that the child's trimmed stdout *ends* with
`tuval: stopping`. It does not always, and the child is right.

`bin.ts` prints the stop line from the innermost `onInterrupt` on `Effect.never`. That runs first,
before the outer scope closes and stops the kernel's processes — so the stop line means "the
interrupt landed", not "teardown is over". The box config's demo log writes one `count N` a second,
and a tick that lands during teardown goes into the pipe after the stop line. Nothing is truncated
and the harness reads to EOF (it resolves on `close`), so the old assertion was simply asserting an
ordering the child never promised.

Reproduced before touching anything: 24 boots of the box config with SIGINT sent one tick after
`tuval: running`, 8 at a time — 2 of the 24 ended `tuval: stopping\ncount 1`. Under the 232-file
parallel suite the same window opens by itself, which is #8579.

So the fix is in the test, not in `boot.ts`: the trailing write is deliberate behaviour and the
comment at the assertion says so. The case now asserts the stop line is present and comes after the
run line, with `status` already asserted 0 above — the stop happened and the child exited —
and lets whatever follows be.

Verified: the full parallel `pnpm --filter @kampus/tuval test:unit` 10 times in a row, 2358 passed
each time (67–74s per run). `pnpm typecheck` and `pnpm lint` green. No timeout constant touched.

Closes #8579

## Deviations

None.
