### PR TITLE
feat: stream Pi deltas instead of a full snapshot per token

### DIFF
--- a/.patterns/snapshot-authoritative-to-delta-events.md
+++ b/.patterns/snapshot-authoritative-to-delta-events.md
@@ -1,27 +1,54 @@
 # A snapshot-authoritative backend as a delta event stream
 
-A backend that pushes its **whole state** every revision, feeding a consumer that wants **what
+A backend whose state is **a whole value per revision**, feeding a consumer that wants **what
 changed**, needs an explicit fold between them. This is the shape every `TuvalAiAgent` layer over a
-snapshot-pushing agent has to write, and the choices in it are not obvious.
+snapshot-shaped agent has to write, and the choices in it are not obvious.
 
 Where this lives today: [`apps/tuval/src/pi/ai-agent/items.ts`](../apps/tuval/src/pi/ai-agent/items.ts)
-(`eventsOf`), pinned by
-[`items.unit.test.ts`](../apps/tuval/src/pi/ai-agent/items.unit.test.ts). It folds Pi's pushed
-`SessionSnapshot` — authoritative and whole by its own protocol contract, carrying the entire
-`transcript` on every `revision` ([`pi/wire/session.ts`](../apps/tuval/src/pi/wire/session.ts)) —
+(`eventsOf` and `deltaEventsOf`), pinned by
+[`items.unit.test.ts`](../apps/tuval/src/pi/ai-agent/items.unit.test.ts). It folds Tuval's
+`SessionSnapshot` and `SessionDelta` ([`pi/wire/session.ts`](../apps/tuval/src/pi/wire/session.ts))
 onto the `AgentEvent` union founder ruling 1
 ([#7570](https://github.com/kamp-us/phoenix/issues/7570)) defines, where `item` means "new **or
 updated** by id".
 
-## The three choices
+## The wire is snapshot-then-delta, and the fold has two arms
+
+The state is whole-value *by construction*, and that does not have to mean whole-value *on the
+wire*. A streamed turn signals per token, so sending the transcript per signal is a whole-transcript
+frame per token. Tuval's server therefore sends the whole value on a viewer's first subscribe and a
+delta for every revision after it, diffed against the last thing it sent that viewer
+([`pi/wire/delta.ts`](../apps/tuval/src/pi/wire/delta.ts)'s `nextPush`,
+[`pi/server/PiServerService.ts`](../apps/tuval/src/pi/server/PiServerService.ts)'s `followSession`).
+Measured over the protocol-8 envelope, that is ~40 µs per frame against ~3.2 ms for a 200-item
+snapshot ([`pi/wire/codec.unit.test.ts`](../apps/tuval/src/pi/wire/codec.unit.test.ts)).
+
+Two rules make the split safe rather than a source of drift:
+
+- **The diff and the apply live in one module, and both ends run it.** The server diffs with
+  `nextPush`; the client folds the delta into events *and* keeps its lease's whole value current
+  with `applyDelta`. Splitting them across the socket is how the two copies stop agreeing.
+- **A delta is a change set over ids, and it falls back to the whole value whenever it cannot be
+  one.** Tuval's transcript ids are positional, so a transcript that no longer extends the last one
+  as a prefix is a rewrite — a compaction, a branch — and there is nothing to patch. The fallback is
+  the invariant, not a heuristic: guessing leaves the viewer reading a transcript the session does
+  not have. An absent scalar means unchanged, so a field that can go *absent* (Tuval's session
+  `name`) takes the whole value too.
+
+## The four choices
 
 ### 1. The fold is pure, and it carries the previous projection as a value
 
-`(previous, snapshot) => {events, next}` — no Ref inside, no subscription, no transport. The layer
-owns one `Ref` holding `next` and hands it back on the following revision. That is what makes every
-case the fold has to get right — a tool result superseding its running row, a compaction
-renumbering the transcript, a revision that changed nothing — a table of hand-built values rather
-than something to provoke out of a live model.
+`(previous, update) => {events, next}` — no Ref inside, no subscription, no transport, and one
+signature for both arms. The layer owns one `Ref` holding `next` and hands it back on the following
+revision. That is what makes every case the fold has to get right — a tool result superseding its
+running row, a compaction renumbering the transcript, a revision that changed nothing — a table of
+hand-built values rather than something to provoke out of a live model.
+
+The two arms differ in exactly one thing, and it is not the diffing. A whole value **rebuilds** the
+item map, because it is also the answer to a rewritten transcript and a row it no longer carries has
+to leave with it. A delta **merges into** the previous map and walks only the items it names, which
+is what makes folding a token cost one item rather than the transcript.
 
 ### 2. Compare the **projected** value, not the source
 
@@ -36,10 +63,33 @@ A tool row is keyed by its call id, not the transcript index it happens to sit a
 that arrives later supersedes the running row it belongs to. Positional keys look correct until the
 first compaction renumbers the array, and then every row after the cut reads as new.
 
+### 4. The projection carries the revision, and an update at or below it is dropped
+
+The same state reaches the consumer down two paths — the push stream and the answer to the command
+that caused it — and nothing orders them. When a turn's push wins that race and the operator's next
+send lands in the gap, the late answer re-folds a phase the projection has already passed and emits
+a settled phase under a live turn; the core admits on it, and the next message is refused mid-turn
+([#8544](https://github.com/kamp-us/phoenix/issues/8544),
+[#8214](https://github.com/kamp-us/phoenix/issues/8214)). The revision is what refuses it, and it is
+the whole remedy: making the answer arrive first is not a control, because either arm can be the
+late one.
+
+The seed a resume opens on must therefore come from a value of the **current** record, so its
+revision is comparable to what the pushes carry. A seed the fold cannot build — the caller's
+boundary is not in this snapshot — is not "start empty and let the next push replay"; on a delta
+wire a push carries no history. It is a paint at the attach.
+
 ## The emit order within one revision
 
 Content, then cost, then phase. A consumer rendering in arrival order must never show a settled
 phase above a reply that has not landed yet, and usage annotates a turn that is already on screen.
+
+## The update stream ending is not the fold ending
+
+Where the pushes fill a queue and a separate fiber drains it, the two are not peers in a race: an
+ended push stream would interrupt the fold with the turn's last update still queued and unfolded.
+The fill runs as a child fiber (`Effect.forkChild`) and only the transport drop ends the fold
+([`PiAiAgent.ts`](../apps/tuval/src/pi/ai-agent/PiAiAgent.ts)'s `follow`).
 
 ## Paging joins a separate identity space
 
@@ -75,14 +125,22 @@ behavior.
 
 ## The foreseeable worse version
 
-Re-emitting the whole transcript on every revision. It is correct, it passes every test that checks
-*what* arrives, and it repaints the window on every streamed token. The diff is the point.
+Sending and re-emitting the whole transcript on every revision. It is correct, it passes every test
+that checks *what* arrives, and it costs a whole-transcript frame plus a whole-transcript repaint
+per streamed token. The diff is the point, at both ends.
 
 ## Where this stops applying
 
-A backend that already pushes deltas needs none of this — fold its events directly. The shape is
-for the snapshot-authoritative case only, and the tell is a protocol whose push carries state
-rather than a change.
+A backend whose own protocol emits change events needs none of this — fold them directly. The shape
+is for the whole-value case, and the tell is a state model where a revision *is* the state rather
+than a description of what moved.
+
+It also stops at the wire's own delta vocabulary. Chord (under `@earendil-works/pi-client`) ships
+one, and Tuval does not use it: subscribing for real means answering `$chord.service`/`subscribe`
+with a `WireServiceSubscriptionSnapshot` and pushing every update through a decoder that is stateful
+across frames, where anything it rejects fails the whole connection. The reasoning and the source
+citations are at
+[`pi/wire/codec.ts`](../apps/tuval/src/pi/wire/codec.ts)'s `createServerFrameSplitter`.
 
 ## See also
 

--- a/.patterns/snapshot-authoritative-to-delta-events.md
+++ b/.patterns/snapshot-authoritative-to-delta-events.md
@@ -20,8 +20,12 @@ frame per token. Tuval's server therefore sends the whole value on a viewer's fi
 delta for every revision after it, diffed against the last thing it sent that viewer
 ([`pi/wire/delta.ts`](../apps/tuval/src/pi/wire/delta.ts)'s `nextPush`,
 [`pi/server/PiServerService.ts`](../apps/tuval/src/pi/server/PiServerService.ts)'s `followSession`).
-Measured over the protocol-8 envelope, that is ~40 µs per frame against ~3.2 ms for a 200-item
-snapshot ([`pi/wire/codec.unit.test.ts`](../apps/tuval/src/pi/wire/codec.unit.test.ts)).
+Over the protocol-8 envelope a delta frame round trips in under a tenth of what the whole-transcript
+frame costs — pinned as that ratio, not as a wall-clock figure, in
+[`pi/wire/codec.unit.test.ts`](../apps/tuval/src/pi/wire/codec.unit.test.ts). Absolute microseconds
+are a fact about the machine that measured them: the same bound that held on a developer laptop reds
+on a shared CI runner, so a ratio between two measurements taken in one process is the only form of
+this claim that travels.
 
 Two rules make the split safe rather than a source of drift:
 

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -59,7 +59,7 @@ import {
 	type TuvalAiAgentApi,
 	UnknownRequest,
 } from "../../ai-agent/service/index.ts";
-import {PiClientService, type PiSessionRef} from "../client/index.ts";
+import {PiClientService, type PiSessionRef, type SessionUpdate} from "../client/index.ts";
 import {
 	agentSessionHostLayer,
 	defaultSessionDir,
@@ -69,9 +69,9 @@ import {
 	type PiSessionHost,
 	type ServerBindFailed,
 } from "../server/index.ts";
-import type {SessionSnapshot} from "../wire/index.ts";
 import {planPageOverEntries} from "./entries.ts";
 import {
+	deltaEventsOf,
 	emptyProjection,
 	eventsOf,
 	paintOf,
@@ -134,9 +134,7 @@ type EventQueue = Queue.Queue<AgentEvent, TransportError | Cause.Done>;
  * otherwise sit at `ready` from before the send to after it and emit nothing, while the core moved
  * itself to `prompting` at the send and stayed there — refusing every later message (#7897).
  */
-type FoldInput =
-	| {readonly _tag: "snapshot"; readonly snapshot: SessionSnapshot}
-	| {readonly _tag: "sent"};
+type FoldInput = SessionUpdate | {readonly _tag: "sent"};
 
 /**
  * Read one session's branch out of Pi's JSONL, oldest-first.
@@ -265,8 +263,8 @@ const make = (
 			Effect.gen(function* () {
 				yield* Ref.set(projection, seed);
 				const pushes = pi
-					.snapshots(sessionId)
-					.pipe(Stream.runForEach((snapshot) => Queue.offer(feed, {_tag: "snapshot", snapshot})));
+					.updates(sessionId)
+					.pipe(Stream.runForEach((update) => Queue.offer(feed, update)));
 				const folding = Stream.fromQueue(feed).pipe(
 					Stream.runForEach((input) =>
 						Effect.gen(function* () {
@@ -276,7 +274,10 @@ const make = (
 								yield* Ref.set(projection, {...previous, phase: "prompting"});
 								return yield* emit(open, [{kind: "phase", phase: "prompting"}]);
 							}
-							const folded = eventsOf(previous, input.snapshot);
+							const folded =
+								input._tag === "snapshot"
+									? eventsOf(previous, input.snapshot)
+									: deltaEventsOf(previous, input.delta);
 							yield* Ref.set(projection, folded.next);
 							yield* emit(open, folded.events);
 						}),
@@ -286,7 +287,12 @@ const make = (
 					Stream.take(1),
 					Stream.runForEach((drop) => Queue.fail(open, transportErrorOf(drop))),
 				);
-				yield* Effect.race(Effect.race(pushes, folding), dropped);
+				// `pushes` only fills `feed`, so it is not a party to the race: raced against
+				// `folding` it would interrupt the fold the moment the update stream ended, and a
+				// turn's last update — queued, unfolded — would go with it (#8554). As a child
+				// fiber it is interrupted when this effect returns, which is what the race decides.
+				yield* Effect.forkChild(pushes);
+				yield* Effect.race(folding, dropped);
 			});
 
 		/**
@@ -385,19 +391,18 @@ const make = (
 					return {ref: opened, seed: emptyProjection, paint: []};
 				}
 				// Either way the lease's own snapshot is the seed, and neither reading of it costs a
-				// round trip: Pi re-sends the whole transcript on every revision, so a fold that
-				// opened on `emptyProjection` replays the session as live items on the first push
-				// after the attach (#8369). What differs is what the caller can already see.
+				// round trip. What differs is what the caller can already see.
 				const resumed = yield* pi.attachSession(resume.sessionId);
 				const lease = yield* pi.heldSnapshot(resumed.id);
 				// A restored process is looking at its own committed tail, so the seed suppresses
 				// everything through the boundary that tail reaches and emits whatever the session
 				// finished past it — or changed under it — while the socket was down (#8374).
-				if (resume.holdsTranscript) {
-					return {ref: resumed, seed: projectionOf(lease, resume.held), paint: []};
-				}
-				// A window opened out of the picker holds nothing, so the history is painted here,
-				// at the attach, while its tail is still empty.
+				const seeded = resume.holdsTranscript ? projectionOf(lease, resume.held) : null;
+				if (seeded !== null) return {ref: resumed, seed: seeded, paint: []};
+				// Nothing to seed from: a window opened out of the picker holds nothing, or the
+				// boundary the caller holds is not in this snapshot. Either way the history is
+				// painted here, at the attach, while its tail is still empty — a push carries only
+				// what changed, so waiting for one would replay nothing (#8554).
 				const painted = paintOf(lease);
 				return {ref: resumed, seed: painted.projection, paint: painted.events};
 			}).pipe(Effect.mapError((refusal) => startErrorOf(options_.cwd, refusal)));

--- a/apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts
@@ -20,6 +20,7 @@ import {
 	PiClientService,
 	type PiSessionRef,
 	SessionLocked,
+	type SessionUpdate,
 } from "../client/index.ts";
 import type {SessionSnapshot} from "../wire/index.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
@@ -50,7 +51,7 @@ const snapshot = (phase: SessionSnapshot["phase"], revision: number): SessionSna
 
 /** The stub server: a snapshot stream the test feeds, a `prompt` it settles, an `abort` that says no. */
 const stub = Effect.gen(function* () {
-	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const pushes = yield* Queue.unbounded<SessionUpdate>();
 	const ended = yield* Deferred.make<SessionSnapshot>();
 	const api: PiClientApi = {
 		connect: Effect.void,
@@ -65,7 +66,7 @@ const stub = Effect.gen(function* () {
 		setModel: () => Effect.never,
 		setThinkingLevel: () => Effect.never,
 		models: Effect.succeed([]),
-		snapshots: () => Stream.fromQueue(pushes),
+		updates: () => Stream.fromQueue(pushes),
 		disconnections: Stream.never,
 	};
 	return {

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -30,6 +30,7 @@ import {
 import type {AgentEvent, Phase} from "../../ai-agent/service/index.ts";
 import type {
 	TranscriptItem as PiTranscriptItem,
+	SessionDelta,
 	SessionPhase,
 	SessionSnapshot,
 } from "../wire/index.ts";
@@ -164,42 +165,58 @@ const usageEventOf = (item: PiTranscriptItem): Extract<AgentEvent, {kind: "usage
 };
 
 /**
- * What the last snapshot said, so the next one emits only what changed.
+ * What the revision this fold last folded said, so the next one emits only what changed.
  *
- * A snapshot is authoritative and whole — Pi re-sends the entire transcript every revision — so
- * without this the window would repaint every item on every revision. The push rate is what makes
- * that expensive: the server ticks once per session event, so a turn writing text costs a
- * revision per delta once the host is projecting the reply as it is written
- * (`../server/AgentSessionHost.ts`'s `streamPartialText`, off by default), and one item changes
- * while the rest do not. The fingerprints are the projected item's own JSON, which is exactly the
- * value the window renders: two snapshots whose projections match are, to the window, the same
- * transcript.
+ * The fingerprints are the projected item's own JSON, which is exactly the value the window
+ * renders: two revisions whose projections match are, to the window, the same transcript. That is
+ * what keeps a whole-value snapshot — the first push, and any transcript a delta cannot patch —
+ * from repainting rows the operator is already reading.
+ *
+ * `revision` is the ordering, and it is what makes a late arrival droppable. A turn's push can win
+ * the race against its own answer, and if the operator's next send lands in that gap the answer
+ * arrives carrying an `idle` this projection has already passed — folded again it emits a second
+ * `ready` under a live turn (#8544). Every fold below refuses an update at or below this number,
+ * so arrival order stops being the thing that decides. `emptyProjection` sits below every real
+ * revision because a record's first is 0.
  */
 export interface SnapshotProjection {
 	readonly items: ReadonlyMap<string, string>;
 	readonly usage: ReadonlyMap<string, string>;
 	readonly phase: Phase | null;
+	readonly revision: number;
 }
 
 export const emptyProjection: SnapshotProjection = {
 	items: new Map(),
 	usage: new Map(),
 	phase: null,
+	revision: -1,
 };
 
 const fingerprint = (value: unknown): string => JSON.stringify(value);
 
+/** What one fold answers: the events it emitted, and the projection they left behind. */
+export interface Folded {
+	readonly events: ReadonlyArray<AgentEvent>;
+	readonly next: SnapshotProjection;
+}
+
+/** An update the projection has already passed, left exactly as it was. */
+const stale = (previous: SnapshotProjection): Folded => ({events: [], next: previous});
+
 /**
- * Fold one pushed snapshot into the events it changed, oldest item first.
+ * Fold one whole-value snapshot into the events it changed, oldest item first.
  *
  * The order within a revision is content, then cost, then phase: an item is what the operator is
  * reading, its usage annotates it, and the phase line is the last thing to settle — so a window
  * that renders in arrival order never shows `ready` above a reply that has not landed yet.
+ *
+ * The item map is rebuilt from the snapshot rather than merged into the previous one, because a
+ * whole value is also the answer to a transcript that was rewritten: a row this snapshot no longer
+ * carries has to leave the projection with it.
  */
-export const eventsOf = (
-	previous: SnapshotProjection,
-	snapshot: SessionSnapshot,
-): {readonly events: ReadonlyArray<AgentEvent>; readonly next: SnapshotProjection} => {
+export const eventsOf = (previous: SnapshotProjection, snapshot: SessionSnapshot): Folded => {
+	if (snapshot.revision <= previous.revision) return stale(previous);
 	const events: Array<AgentEvent> = [];
 	const items = new Map<string, string>();
 	const usage = new Map<string, string>();
@@ -223,25 +240,64 @@ export const eventsOf = (
 	const phase = phaseOf(snapshot.phase);
 	if (previous.phase !== phase) events.push({kind: "phase", phase});
 
-	return {events, next: {items, usage, phase}};
+	return {events, next: {items, usage, phase, revision: snapshot.revision}};
+};
+
+/**
+ * Fold one delta, in the same order and by the same fingerprints `eventsOf` uses.
+ *
+ * A delta names only what moved, so the projection is carried forward and the walk is over the
+ * delta's own items — which is the whole point of the shape: a streamed turn signals per token,
+ * and folding a token costs one item rather than the transcript (#8554). An absent scalar means
+ * unchanged, so an absent `phase` leaves the phase line where it stands.
+ */
+export const deltaEventsOf = (previous: SnapshotProjection, delta: SessionDelta): Folded => {
+	if (delta.revision <= previous.revision) return stale(previous);
+	const events: Array<AgentEvent> = [];
+	const items = new Map(previous.items);
+	const usage = new Map(previous.usage);
+	const changed = delta.items ?? [];
+
+	for (const source of changed) {
+		for (const item of itemsOf(source)) {
+			const mark = fingerprint(item);
+			items.set(item.id, mark);
+			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
+		}
+	}
+
+	for (const source of changed) {
+		const event = usageEventOf(source);
+		if (event === null) continue;
+		const mark = fingerprint(event);
+		usage.set(source.id, mark);
+		if (previous.usage.get(source.id) !== mark) events.push(event);
+	}
+
+	const phase = delta.phase === undefined ? previous.phase : phaseOf(delta.phase);
+	if (phase !== null && previous.phase !== phase) events.push({kind: "phase", phase});
+
+	return {events, next: {items, usage, phase, revision: delta.revision}};
 };
 
 /**
  * What a snapshot the operator has already read leaves behind, so a resume folds it to nothing.
  *
- * Pi re-sends the whole transcript every revision, so a `follow` that opened on `emptyProjection`
- * after a reattach re-emits the entire history as live items — landing on top of the operator's
- * own newly typed turn and pushing it out of the window's 40-item cut (#8369). The attach lease
- * already carries the session's snapshot, and this is that snapshot read as "already rendered".
+ * The attach lease carries the session's whole transcript, and a `follow` that opened on
+ * `emptyProjection` after a reattach emits all of it as live items — landing on top of the
+ * operator's own newly typed turn and pushing it out of the window's 40-item cut (#8369). This is
+ * that same snapshot read as "already rendered".
  *
  * `held` is the caller's own tail, oldest first, and it answers both halves. Its newest
  * backend-minted row is where "already read" stops: everything at or older than that is seeded,
  * and anything after it is left unseeded so it emits — a turn the session finished while the
  * socket was down is work the operator has never seen, and seeding the whole snapshot would bury
  * it for the life of the session with no gap marker and no way to page to it (#8374). An empty
- * tail seeds nothing. A boundary this snapshot does not carry — a compaction renumbered the
- * transcript out from under the caller — also seeds nothing, which replays: a visibly wrong
- * transcript is recoverable and a silently missing reply is not.
+ * tail is `null`, which is this function's whole "nothing to seed from" answer. A boundary this
+ * snapshot does not carry — a compaction renumbered the transcript out from under the caller — is
+ * `null` too, and the caller replays: a visibly wrong transcript is recoverable and a silently
+ * missing reply is not. The replay is `paintOf` at the attach rather than the next push, because
+ * a push carries only what changed (`../wire/delta.ts`) and there is no history in one.
  *
  * A seeded row is fingerprinted off the **caller's** copy, never off the snapshot's. Being at or
  * older than the boundary means "already read" only if an item's content cannot move, and on this
@@ -271,9 +327,9 @@ export const eventsOf = (
 export const projectionOf = (
 	snapshot: SessionSnapshot,
 	held: ReadonlyArray<TranscriptItem>,
-): SnapshotProjection => {
+): SnapshotProjection | null => {
 	const through = newestBackendItemId(held);
-	if (through === null) return emptyProjection;
+	if (through === null) return null;
 	const carried = new Map(held.map((item) => [item.id as string, fingerprint(item)]));
 	const items = new Map<string, string>();
 	const usage = new Map<string, string>();
@@ -294,7 +350,7 @@ export const projectionOf = (
 		const event = !moved && seeded.length === rows.length ? usageEventOf(source) : null;
 		if (event !== null) usage.set(source.id, fingerprint(event));
 	}
-	return reached ? {items, usage, phase: null} : emptyProjection;
+	return reached ? {items, usage, phase: null, revision: snapshot.revision} : null;
 };
 
 /**

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -16,8 +16,13 @@ import {
 } from "../../ai-agent/core/index.ts";
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {TOOL_RESULT_BYTE_LIMIT, type TranscriptItem} from "../../ai-agent/ports/index.ts";
-import type {TranscriptItem as PiTranscriptItem, SessionSnapshot} from "../wire/index.ts";
+import type {
+	TranscriptItem as PiTranscriptItem,
+	SessionDelta,
+	SessionSnapshot,
+} from "../wire/index.ts";
 import {
+	deltaEventsOf,
 	emptyProjection,
 	eventsOf,
 	itemId,
@@ -26,6 +31,21 @@ import {
 	phaseOf,
 	projectionOf,
 } from "./items.ts";
+
+/**
+ * The seed a resume opens on, with the "nothing to seed from" answer read as the empty projection
+ * — which is what `PiAiAgent` does with it before painting the history instead.
+ */
+const seedOf = (
+	source: SessionSnapshot,
+	held: ReadonlyArray<TranscriptItem>,
+): ReturnType<typeof eventsOf>["next"] => projectionOf(source, held) ?? emptyProjection;
+
+/** The same snapshot one revision on, which is what the push after a seed actually carries. */
+const bumped = (source: SessionSnapshot): SessionSnapshot => ({
+	...source,
+	revision: source.revision + 1,
+});
 
 /**
  * The tail an operator holds who read this snapshot as far as `through`: the rows the fold would
@@ -275,14 +295,38 @@ describe("one revision folded into events", () => {
 	});
 
 	/**
+	 * The schedule from PR #8544's report: a turn's push wins the race against its own answer, the
+	 * operator's next send walks the projection back to `prompting`, and the answer lands carrying
+	 * an `idle` the projection has already passed. Folded, it emits a second `ready` under a live
+	 * turn and the core admits the next send mid-turn (#8214). The revision is what refuses it, so
+	 * arrival order is no longer the variable.
+	 */
+	it("drops an update at the revision it has already folded", () => {
+		const turn = snapshot([user, assistant("hi back", 0.42)], "idle", 2);
+		const folded = eventsOf(emptyProjection, turn);
+		const sent = {...folded.next, phase: "prompting" as const};
+
+		const late = eventsOf(sent, turn);
+		expect(late.events).toEqual([]);
+		expect(late.next).toBe(sent);
+	});
+
+	it("drops an update below the revision it has already folded", () => {
+		const folded = eventsOf(emptyProjection, snapshot([user, assistant("hi back")], "idle", 5));
+		const behind = eventsOf(folded.next, snapshot([user], "turn", 4));
+		expect(behind.events).toEqual([]);
+		expect(behind.next).toBe(folded.next);
+	});
+
+	/**
 	 * A resume opens a fresh fold over a transcript the operator is already reading, so the seed
-	 * off the attach lease's snapshot has to make Pi's next whole-transcript push a no-op: no
+	 * off the attach lease's snapshot has to make a whole-value push a no-op: no
 	 * `item`, so nothing is appended after the operator's own turn and pushed out of the window's
 	 * 40-item cut, and no `usage`, so the session's totals are not re-added (#8369).
 	 */
 	it("emits no item and no usage when a resume's seed already holds the whole transcript", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored, heldThrough(restored, "item-1")), restored);
+		const folded = eventsOf(seedOf(restored, heldThrough(restored, "item-1")), bumped(restored));
 		expect(folded.events).toEqual([{kind: "phase", phase: "ready"}]);
 	});
 
@@ -295,7 +339,7 @@ describe("one revision folded into events", () => {
 			timestamp: 13,
 		};
 		const folded = eventsOf(
-			projectionOf(restored, heldThrough(restored, "item-1")),
+			seedOf(restored, heldThrough(restored, "item-1")),
 			snapshot([user, assistant("hi back", 0.42), sent], "turn", 8),
 		);
 		expect(folded.events).toEqual([
@@ -311,7 +355,7 @@ describe("one revision folded into events", () => {
 	 */
 	it("emits what the session finished past the boundary the caller holds", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
-		const folded = eventsOf(projectionOf(restored, heldThrough(restored, user.id)), restored);
+		const folded = eventsOf(seedOf(restored, heldThrough(restored, user.id)), bumped(restored));
 		expect(folded.events).toEqual([
 			{
 				kind: "item",
@@ -339,8 +383,8 @@ describe("one revision folded into events", () => {
 	it("emits the cost of a turn the boundary fell inside, not just its reply", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
 		const folded = eventsOf(
-			projectionOf(restored, heldThrough(restored, "item-1:thinking")),
-			restored,
+			seedOf(restored, heldThrough(restored, "item-1:thinking")),
+			bumped(restored),
 		);
 		expect(folded.events).toEqual([
 			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
@@ -378,8 +422,8 @@ describe("one revision folded into events", () => {
 			status: "streaming",
 		};
 		const folded = eventsOf(
-			projectionOf(restored, [itemOf(user), ...itemsOf(streaming)]),
-			restored,
+			seedOf(restored, [itemOf(user), ...itemsOf(streaming)]),
+			bumped(restored),
 		);
 		expect(folded.events).toEqual([
 			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
@@ -403,10 +447,8 @@ describe("one revision folded into events", () => {
 	it("replays rather than guesses when the boundary is not in the snapshot", () => {
 		const restored = snapshot([user, assistant("hi back", 0.42)], "idle", 7);
 		const folded = eventsOf(
-			projectionOf(restored, [
-				{kind: "assistant", id: itemId("item-gone"), timestamp: 9, text: "gone"},
-			]),
-			restored,
+			seedOf(restored, [{kind: "assistant", id: itemId("item-gone"), timestamp: 9, text: "gone"}]),
+			bumped(restored),
 		);
 		expect(folded.events.filter((event) => event.kind === "item")).toHaveLength(3);
 	});
@@ -417,16 +459,16 @@ describe("one revision folded into events", () => {
 	 */
 	it("restates the phase of a session that was still working when it was reattached", () => {
 		const working = snapshot([user], "turn", 7);
-		expect(eventsOf(projectionOf(working, heldThrough(working, "item-0")), working).events).toEqual(
-			[{kind: "phase", phase: "prompting"}],
-		);
+		expect(
+			eventsOf(seedOf(working, heldThrough(working, "item-0")), bumped(working)).events,
+		).toEqual([{kind: "phase", phase: "prompting"}]);
 	});
 
 	/**
-	 * A turn mid-stream is still one whole message: the wire's own `assistant_delta` never reaches
-	 * this fold — `PiClientService.snapshots` keeps only `session_snapshot` — so a growing reply
-	 * arrives as successive whole revisions. Its reasoning must therefore supersede itself under one
-	 * id, not stack a second row per revision.
+	 * A turn mid-stream is still one whole message. Tuval's wire carries no per-token content patch:
+	 * a `SessionDelta` names the whole item that moved (`../wire/delta.ts`), so a growing reply
+	 * arrives as successive whole copies of one item. Its reasoning must therefore supersede itself
+	 * under one id, not stack a second row per revision.
 	 */
 	it("supersedes a streaming turn's reasoning row instead of stacking one per revision", () => {
 		const streaming: PiTranscriptItem = {
@@ -458,6 +500,71 @@ describe("one revision folded into events", () => {
 			{kind: "item", item: itemOf(settledTool)},
 			{kind: "phase", phase: "ready"},
 		]);
+	});
+});
+
+/**
+ * The same fold over a delta rather than a whole value. A streamed turn signals per token, so this
+ * is the arm a live turn actually rides: the walk is over what the delta names, and everything it
+ * does not name is carried forward untouched.
+ */
+describe("one delta folded into events", () => {
+	const delta = (
+		items: ReadonlyArray<PiTranscriptItem>,
+		revision: number,
+		phase?: SessionSnapshot["phase"],
+	): SessionDelta => ({
+		id: "session-7602",
+		revision,
+		updatedAt: revision * 100,
+		...(phase === undefined ? {} : {phase}),
+		...(items.length === 0 ? {} : {items: [...items]}),
+	});
+
+	it("emits the one item a token changed and nothing else", () => {
+		const opened = eventsOf(emptyProjection, snapshot([user, streamingAssistant("hi")], "turn"));
+		const folded = deltaEventsOf(opened.next, delta([streamingAssistant("hi t")], 2));
+		expect(folded.events).toEqual([{kind: "item", item: itemOf(streamingAssistant("hi t"))}]);
+	});
+
+	it("carries the rest of the transcript forward rather than re-emitting it", () => {
+		const opened = eventsOf(emptyProjection, snapshot([user, streamingAssistant("hi")], "turn"));
+		const folded = deltaEventsOf(opened.next, delta([streamingAssistant("hi t")], 2));
+		const again = deltaEventsOf(folded.next, delta([streamingAssistant("hi t")], 3));
+		expect(again.events).toEqual([]);
+		expect(folded.next.items.get("item-0")).toBe(opened.next.items.get("item-0"));
+	});
+
+	it("emits a settled turn's cost with the reply it annotates, in that order", () => {
+		const opened = eventsOf(emptyProjection, snapshot([user, streamingAssistant("hi")], "turn"));
+		const folded = deltaEventsOf(opened.next, delta([assistant("hi back", 0.42)], 2, "idle"));
+		expect(folded.events).toEqual([
+			{kind: "item", item: itemsOf(assistant("hi back", 0.42))[0]},
+			{kind: "item", item: itemOf(assistant("hi back", 0.42))},
+			{
+				kind: "usage",
+				turn: "item-1",
+				model: "faux/faux-1",
+				inputTokens: 11,
+				outputTokens: 22,
+				cost: 0.42,
+			},
+			{kind: "phase", phase: "ready"},
+		]);
+	});
+
+	it("leaves the phase line where it stands when the delta does not name one", () => {
+		const opened = eventsOf(emptyProjection, snapshot([user], "turn"));
+		const folded = deltaEventsOf(opened.next, delta([streamingAssistant("hi")], 2));
+		expect(folded.events.some((event) => event.kind === "phase")).toBe(false);
+		expect(folded.next.phase).toBe("prompting");
+	});
+
+	it("drops a delta at or below the revision it has already folded", () => {
+		const opened = eventsOf(emptyProjection, snapshot([user], "turn", 5));
+		const late = deltaEventsOf(opened.next, delta([streamingAssistant("hi")], 5, "idle"));
+		expect(late.events).toEqual([]);
+		expect(late.next).toBe(opened.next);
 	});
 });
 

--- a/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
@@ -42,7 +42,7 @@ const idle: PiClientApi = {
 	setModel: () => Effect.die("listing must not switch models"),
 	setThinkingLevel: () => Effect.die("listing must not switch thinking levels"),
 	models: Effect.succeed([]),
-	snapshots: () => Stream.never,
+	updates: () => Stream.never,
 	disconnections: Stream.never,
 };
 

--- a/apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/mid-turn-refusal.unit.test.ts
@@ -7,13 +7,15 @@
  * core admits the next prompt on that `ready`; and the pinned wire cannot carry the field Pi's own
  * error names, so the remedy cannot live on the prompt command.
  *
- * The variable is the send, not the order of the pair: whichever of a turn's push and its answer
- * lands *after* the next send's `sent` mark re-folds a stale `idle` into a second `ready`. Both
+ * The variable was the send, not the order of the pair: whichever of a turn's push and its answer
+ * landed *after* the next send's `sent` mark re-folded a stale `idle` into a second `ready`. Both
  * orders are here, and so is the same schedule with nothing sent in the gap.
  *
  * The findings this pins are written up in
- * `reports/2026-09-07-pi-mid-turn-prompt-refusal.md`. Nothing here asserts a fix: the tests describe
- * the mechanism as current source runs it, so a fix reds the first one by name.
+ * `reports/2026-09-07-pi-mid-turn-prompt-refusal.md`. The first claim is now closed by the
+ * revision `SnapshotProjection` carries (#8554): all three schedules assert no second `ready`, and
+ * removing that guard reds the first two by name. The other two claims still describe current
+ * source — the core admits on a `ready`, and the wire no longer judges a prompt's fields.
  */
 
 import {applyCellChecked} from "@demlik/tea";
@@ -24,7 +26,12 @@ import type {AiAgentSessionCmd, AiAgentSessionMsg} from "../../ai-agent/core/mes
 import {type AiAgentSessionState, initialState} from "../../ai-agent/core/state.ts";
 import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
-import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {
+	type PiClientApi,
+	PiClientService,
+	type PiSessionRef,
+	type SessionUpdate,
+} from "../client/index.ts";
 import {
 	type TranscriptItem as PiTranscriptItem,
 	ProtocolValidationError,
@@ -89,7 +96,7 @@ const TURN_A = [USER_A, REPLY_A];
  * out, which one shared Deferred cannot express.
  */
 const stub = Effect.gen(function* () {
-	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const pushes = yield* Queue.unbounded<SessionUpdate>();
 	const first = yield* Deferred.make<SessionSnapshot>();
 	const second = yield* Deferred.make<SessionSnapshot>();
 	const answers = [first, second];
@@ -112,12 +119,12 @@ const stub = Effect.gen(function* () {
 		setModel: () => Effect.never,
 		setThinkingLevel: () => Effect.never,
 		models: Effect.succeed([]),
-		snapshots: () => Stream.fromQueue(pushes),
+		updates: () => Stream.fromQueue(pushes),
 		disconnections: Stream.never,
 	};
 	return {
 		layer: Layer.succeed(PiClientService, api),
-		push: (value: SessionSnapshot) => Queue.offer(pushes, value),
+		push: (value: SessionSnapshot) => Queue.offer(pushes, {_tag: "snapshot", snapshot: value}),
 		/** Settle the nth send's own answer, as the server's response frame does. */
 		answer: (nth: 0 | 1, value: SessionSnapshot) =>
 			Deferred.succeed(nth === 0 ? first : second, value),
@@ -149,7 +156,7 @@ const settled = (events: Events) =>
 	Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("250 millis"));
 
 describe("a send admitted while Pi is still running the previous turn", () => {
-	it.live("pushes turn A's end, then re-emits ready from A's late answer under live turn B", () =>
+	it.live("drops turn A's late answer instead of re-emitting ready under live turn B", () =>
 		Effect.gen(function* () {
 			const client = yield* stub;
 
@@ -170,14 +177,14 @@ describe("a send admitted while Pi is still running the previous turn", () => {
 				yield* agent.prompt("second");
 				yield* collectTo(events, "turn B's prompting", isPrompting);
 
-				// A's answer, arriving after B went out. `SnapshotProjection` carries no revision
-				// (`./items.ts`), so `eventsOf` has nothing to compare and folds it as current.
+				// A's answer, arriving after B went out, at the revision the push already carried.
+				// The projection is past it, so it is dropped rather than folded (`./items.ts`).
 				yield* client.answer(0, snapshot(TURN_A, "idle", 2));
 
 				const late = yield* settled(events);
 				assert.isTrue(
-					Option.isSome(late) && isReady(late.value),
-					`turn A's late answer emitted ${JSON.stringify(late)} rather than a second ready`,
+					Option.isNone(late),
+					`turn A's late answer emitted ${JSON.stringify(late)} under a live turn`,
 				);
 			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
 		}),
@@ -201,13 +208,14 @@ describe("a send admitted while Pi is still running the previous turn", () => {
 				yield* agent.prompt("second");
 				yield* collectTo(events, "turn B's prompting", isPrompting);
 
-				// A's push, arriving after B went out — the same stale `idle` from the other side.
+				// A's push, arriving after B went out — the same stale `idle` from the other side,
+				// and dropped on the same test, which is what makes arrival order stop mattering.
 				yield* client.push(snapshot(TURN_A, "idle", 2));
 
 				const late = yield* settled(events);
 				assert.isTrue(
-					Option.isSome(late) && isReady(late.value),
-					`answer-first emitted ${JSON.stringify(late)} rather than a second ready`,
+					Option.isNone(late),
+					`answer-first emitted ${JSON.stringify(late)} under a live turn`,
 				);
 			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
 		}),

--- a/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/publishes-the-send.unit.test.ts
@@ -34,6 +34,7 @@ import {
 	PiClientService,
 	type PiSessionRef,
 	SessionLocked,
+	type SessionUpdate,
 } from "../client/index.ts";
 import type {SessionSnapshot} from "../wire/index.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
@@ -110,7 +111,7 @@ const pin = (options: {readonly refusals?: number} = {}): Effect.Effect<Pin> =>
 	Effect.gen(function* () {
 		const sends: Array<string> = [];
 		const turn = yield* Deferred.make<void>();
-		const pushed = yield* Queue.unbounded<SessionSnapshot>();
+		const pushed = yield* Queue.unbounded<SessionUpdate>();
 		const state = {ended: false};
 
 		const api: PiClientApi = {
@@ -137,7 +138,7 @@ const pin = (options: {readonly refusals?: number} = {}): Effect.Effect<Pin> =>
 			setModel: () => Effect.succeed(snapshotOf([], "idle", 0)),
 			setThinkingLevel: () => Effect.succeed(snapshotOf([], "idle", 0)),
 			models: Effect.succeed([]),
-			snapshots: () => Stream.fromQueue(pushed),
+			updates: () => Stream.fromQueue(pushed),
 			disconnections: Stream.never,
 		};
 
@@ -146,7 +147,7 @@ const pin = (options: {readonly refusals?: number} = {}): Effect.Effect<Pin> =>
 			get sends() {
 				return sends;
 			},
-			push: (snapshot) => Effect.asVoid(Queue.offer(pushed, snapshot)),
+			push: (snapshot) => Effect.asVoid(Queue.offer(pushed, {_tag: "snapshot", snapshot})),
 			endTurn: Effect.asVoid(Deferred.succeed(turn, undefined)),
 			hasEnded: () => state.ended,
 		};

--- a/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/resumes-without-replay.unit.test.ts
@@ -1,9 +1,9 @@
 /**
- * What a resume owes the window, over a stub `PiClientService` whose snapshot stream is a queue the
+ * What a resume owes the window, over a stub `PiClientService` whose update stream is a queue the
  * test pushes.
  *
- * Pi re-sends the whole transcript every revision, so the fold's projection is the only thing
- * standing between a reattach and a full replay of the session as live items. A restored process
+ * The attach lease carries the session's whole transcript, so the fold's projection is the only
+ * thing standing between a reattach and a full replay of it as live items. A restored process
  * comes back with that transcript already on screen, and the replay lands on top of the operator's
  * own newly typed turn, pushing it out of the 40-item window (#8369). A window opened on a session
  * out of the picker holds nothing, and the same replay is the only way its history paints — so both
@@ -32,7 +32,12 @@ import {
 import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
 import type {AgentEvent, Phase, TransportError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
-import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {
+	type PiClientApi,
+	PiClientService,
+	type PiSessionRef,
+	type SessionUpdate,
+} from "../client/index.ts";
 import type {TranscriptItem as PiTranscriptItem, SessionSnapshot} from "../wire/index.ts";
 import {itemsOf} from "./items.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
@@ -100,11 +105,17 @@ const snapshot = (
 /** The transcript the session already had when this client attached to it. */
 const HELD = snapshot([user, reply], "idle", 7);
 
+/**
+ * The first push after that attach. Every push carries a revision the record just bumped, so a
+ * push at the lease's own revision is one the fold drops as already folded (`./items.ts`).
+ */
+const PUSHED = snapshot([user, reply], "idle", 8);
+
 /** The tail a restored process comes back with: the rows the fold emitted it for these turns. */
 const held = (...sources: ReadonlyArray<PiTranscriptItem>) => sources.flatMap(itemsOf);
 
 const stub = Effect.gen(function* () {
-	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const pushes = yield* Queue.unbounded<SessionUpdate>();
 	const api: PiClientApi = {
 		connect: Effect.void,
 		reconnect: Effect.void,
@@ -117,12 +128,12 @@ const stub = Effect.gen(function* () {
 		setModel: () => Effect.never,
 		setThinkingLevel: () => Effect.never,
 		models: Effect.succeed([]),
-		snapshots: () => Stream.fromQueue(pushes),
+		updates: () => Stream.fromQueue(pushes),
 		disconnections: Stream.never,
 	};
 	return {
 		layer: Layer.succeed(PiClientService, api),
-		push: (value: SessionSnapshot) => Queue.offer(pushes, value),
+		push: (value: SessionSnapshot) => Queue.offer(pushes, {_tag: "snapshot", snapshot: value}),
 	};
 });
 
@@ -189,7 +200,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 					yield* drain(events);
 
-					yield* client.push(HELD);
+					yield* client.push(PUSHED);
 					const folded = yield* drain(events);
 					assert.deepStrictEqual(itemIds(folded), [], "the resume replayed the transcript");
 					assert.strictEqual(usages(folded), 0, "the resume re-added the session's usage");
@@ -290,7 +301,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 				yield* drain(events);
 
-				yield* client.push(HELD);
+				yield* client.push(PUSHED);
 				const folded = yield* drain(events);
 				assert.deepStrictEqual(
 					itemIds(folded),
@@ -333,7 +344,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 					const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 					yield* drain(events);
 
-					yield* client.push(HELD);
+					yield* client.push(PUSHED);
 					const folded = yield* drain(events);
 					assert.deepStrictEqual(
 						itemIds(folded),
@@ -366,7 +377,7 @@ describe("a Pi session resumed by a caller that already holds its transcript", (
 				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
 				yield* drain(events);
 
-				yield* client.push(HELD);
+				yield* client.push(PUSHED);
 				const folded = yield* drain(events);
 				assert.strictEqual(
 					spent(counted(tail, "ready"), folded).cost,

--- a/apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/turn-end.unit.test.ts
@@ -17,7 +17,12 @@ import {assert, describe, it} from "@effect/vitest";
 import {type Cause, Deferred, Effect, Layer, Option, Queue, Stream} from "effect";
 import type {AgentEvent, TransportError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
-import {type PiClientApi, PiClientService, type PiSessionRef} from "../client/index.ts";
+import {
+	type PiClientApi,
+	PiClientService,
+	type PiSessionRef,
+	type SessionUpdate,
+} from "../client/index.ts";
 import type {TranscriptItem as PiTranscriptItem, SessionSnapshot} from "../wire/index.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
 
@@ -68,7 +73,7 @@ const snapshot = (
 
 /** The stub server: a snapshot stream the test feeds, and a `prompt` the test settles. */
 const stub = Effect.gen(function* () {
-	const pushes = yield* Queue.unbounded<SessionSnapshot>();
+	const pushes = yield* Queue.unbounded<SessionUpdate, Cause.Done>();
 	const ended = yield* Deferred.make<SessionSnapshot>();
 	const api: PiClientApi = {
 		connect: Effect.void,
@@ -82,12 +87,17 @@ const stub = Effect.gen(function* () {
 		setModel: () => Effect.never,
 		setThinkingLevel: () => Effect.never,
 		models: Effect.succeed([]),
-		snapshots: () => Stream.fromQueue(pushes),
+		updates: () => Stream.fromQueue(pushes),
 		disconnections: Stream.never,
 	};
 	return {
 		layer: Layer.succeed(PiClientService, api),
-		push: (value: SessionSnapshot) => Queue.offer(pushes, value),
+		push: (value: SessionSnapshot) => Queue.offer(pushes, {_tag: "snapshot", snapshot: value}),
+		/** The turn's last update and the end of the stream carrying it, with no gap between. */
+		pushAndEnd: (value: SessionSnapshot) =>
+			Queue.offer(pushes, {_tag: "snapshot", snapshot: value}).pipe(
+				Effect.andThen(Queue.end(pushes)),
+			),
 		/** Settle the send with the snapshot the turn ended on, as the server's answer does. */
 		endTurn: (value: SessionSnapshot) => Deferred.succeed(ended, value),
 	};
@@ -178,6 +188,33 @@ describe("a Pi turn whose pushes coalesced away", () => {
 				assert.isTrue(
 					Option.isNone(after),
 					`the settled snapshot repainted something already folded: ${JSON.stringify(after)}`,
+				);
+			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
+		}),
+	);
+
+	/**
+	 * The update stream ending is not the fold ending. `follow` used to race the two, so the moment
+	 * the stream ran out the fold was interrupted with the turn's last update still queued and
+	 * unfolded — the operator's window kept `prompting` under a turn that had finished (#8554).
+	 */
+	it.live("folds the turn's last update even when the stream ends behind it", () =>
+		Effect.gen(function* () {
+			const client = yield* stub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* collectTo(events, "the opened session's ready", isReady);
+
+				yield* agent.prompt("say hello");
+				yield* client.pushAndEnd(snapshot([user, reply], "idle", 1));
+
+				const turn = yield* collectTo(events, "the turn's ready", isReady);
+				assert.isTrue(
+					turn.some(isReply),
+					"the reply the ended stream carried never reached the window",
 				);
 			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
 		}),

--- a/apps/tuval/src/pi/ai-agent/turn.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/turn.unit.test.ts
@@ -130,7 +130,7 @@ const stub = (options: StubOptions) =>
 							: Effect.succeed({...SNAPSHOT, thinkingLevel: level}),
 				),
 			models: Effect.succeed(options.catalog ?? []),
-			snapshots: () => Stream.never,
+			updates: () => Stream.never,
 			disconnections: Stream.never,
 		};
 		return {

--- a/apps/tuval/src/pi/client/PiClientService.ts
+++ b/apps/tuval/src/pi/client/PiClientService.ts
@@ -37,11 +37,12 @@ import type {
 	ModelRef,
 	RpcTarget,
 	ServerEvent,
+	SessionDelta,
 	SessionSnapshot,
 	SessionTarget,
 	ThinkingLevel,
 } from "../wire/index.ts";
-import {SERVICE_ID} from "../wire/index.ts";
+import {applyDelta, SERVICE_ID} from "../wire/index.ts";
 import {
 	type ConnectionRefusal,
 	Disconnected,
@@ -117,11 +118,20 @@ export interface PiClientApi {
 	 * `PiSessionRef`.
 	 */
 	readonly models: Effect.Effect<ReadonlyArray<ModelMetadata>>;
-	/** Every snapshot the server pushes for this session, for as long as the stream is pulled. */
-	readonly snapshots: (sessionId: string) => Stream.Stream<SessionSnapshot>;
+	/**
+	 * Everything the server pushes for this session, for as long as the stream is pulled: a whole
+	 * value on the first push and on a transcript no delta can patch, and what changed on every
+	 * revision in between. A caller folds both arms; this service only routes them.
+	 */
+	readonly updates: (sessionId: string) => Stream.Stream<SessionUpdate>;
 	/** One element per connection loss, so a caller can decide whether and when to reconnect. */
 	readonly disconnections: Stream.Stream<Disconnected>;
 }
+
+/** One revision as it reached this client; the two `_tag`s are the fold's own arms in `../ai-agent/`. */
+export type SessionUpdate =
+	| {readonly _tag: "snapshot"; readonly snapshot: SessionSnapshot}
+	| {readonly _tag: "delta"; readonly delta: SessionDelta};
 
 export interface PiClientConfig {
 	readonly transportFactory: ByteTransportFactory;
@@ -219,6 +229,16 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 			if (event.type === "session_snapshot") {
 				const lease = leases.get(event.snapshot.id);
 				if (lease !== undefined) lease.snapshot = event.snapshot;
+			}
+			if (event.type === "session_delta") {
+				const lease = leases.get(event.delta.id);
+				// A command answer carries the whole value without bumping the revision, so a lease
+				// can already be past a delta the server built against an older send. Applying that
+				// one would walk the lease backwards; the window's fold drops it on the same test
+				// (`../ai-agent/items.ts`).
+				if (lease !== undefined && event.delta.revision > lease.snapshot.revision) {
+					lease.snapshot = applyDelta(lease.snapshot, event.delta);
+				}
 			}
 			for (const listener of eventListeners) listener(event);
 		};
@@ -392,13 +412,16 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 			});
 		});
 
-		const snapshots = (sessionId: string): Stream.Stream<SessionSnapshot> =>
-			Stream.callback<SessionSnapshot>((queue) =>
+		const updates = (sessionId: string): Stream.Stream<SessionUpdate> =>
+			Stream.callback<SessionUpdate>((queue) =>
 				Effect.acquireRelease(
 					Effect.sync(() => {
 						const listener = (event: ServerEvent): void => {
 							if (event.type === "session_snapshot" && event.snapshot.id === sessionId) {
-								Queue.offerUnsafe(queue, event.snapshot);
+								Queue.offerUnsafe(queue, {_tag: "snapshot", snapshot: event.snapshot});
+							}
+							if (event.type === "session_delta" && event.delta.id === sessionId) {
+								Queue.offerUnsafe(queue, {_tag: "delta", delta: event.delta});
 							}
 						};
 						eventListeners.add(listener);
@@ -435,7 +458,7 @@ const make = (config: PiClientConfig): Effect.Effect<PiClientApi, never, Scope.S
 			setModel,
 			setThinkingLevel,
 			models: Effect.sync(() => models),
-			snapshots,
+			updates,
 			disconnections,
 		};
 	});

--- a/apps/tuval/src/pi/client/index.ts
+++ b/apps/tuval/src/pi/client/index.ts
@@ -13,6 +13,7 @@ export {
 	PiClientService,
 	type PiClientWebSocketConfig,
 	type PiSessionRef,
+	type SessionUpdate,
 } from "./PiClientService.ts";
 export {connectionRefusalOf, sessionRefusalOf} from "./refusals.ts";
 export {

--- a/apps/tuval/src/pi/client/pi-client.integration.test.ts
+++ b/apps/tuval/src/pi/client/pi-client.integration.test.ts
@@ -119,7 +119,7 @@ describe("the Pi client lease service against the loopback server", () => {
 					yield* pi.connect;
 
 					const session = yield* pi.createSession(cwd, {model: MODEL});
-					const pushed = yield* Stream.toQueue(pi.snapshots(session.id), {
+					const pushed = yield* Stream.toQueue(pi.updates(session.id), {
 						capacity: "unbounded",
 					});
 
@@ -129,10 +129,16 @@ describe("the Pi client lease service against the loopback server", () => {
 						["user", "assistant"],
 					);
 
-					// The server pushes the session's own snapshots to the connection that owns it,
-					// and `snapshots` is the stream the handlers turn into a Sub.
+					// The server pushes the session's own revisions to the connection that owns it, and
+					// `updates` is the stream the handlers turn into a Sub. The first one is the whole
+					// value — this connection has been sent nothing for the session yet — and every
+					// one after it is a delta.
 					const first = yield* Queue.take(pushed);
-					assert.strictEqual(first.id, session.id);
+					assert.strictEqual(first._tag, "snapshot");
+					assert.strictEqual(
+						first._tag === "snapshot" ? first.snapshot.id : first.delta.id,
+						session.id,
+					);
 
 					socket.drop();
 					const failed = yield* Effect.flip(pi.prompt(session.id, "into the void"));

--- a/apps/tuval/src/pi/server/PiServerService.ts
+++ b/apps/tuval/src/pi/server/PiServerService.ts
@@ -23,10 +23,12 @@ import {
 	type ClientMessage,
 	createClientMessageDecoder,
 	encodeServerMessage,
+	nextPush,
 	PROTOCOL_VERSION,
 	SESSION_SUBSCRIPTION_ID,
 	type ServerEvent,
 	type ServerMessage,
+	type SessionSnapshot,
 } from "../wire/index.ts";
 import {dispatch} from "./dispatch.ts";
 import {FrameRefused, MessageNotEncodable, ServerBindFailed} from "./errors.ts";
@@ -264,15 +266,27 @@ const make = (
 				const publish = (event: ServerEvent): Effect.Effect<void> =>
 					write({type: "service_update", subscriptionId: SESSION_SUBSCRIPTION_ID, update: event});
 
-				const snapshotFor = (sessionId: string) =>
+				/**
+				 * The last whole value this connection was sent per session, which is what the next
+				 * revision is diffed against. One writer per session — `followSession` runs one
+				 * fiber each — so the read-diff-store round has no second writer to interleave with.
+				 */
+				const sent = new Map<string, SessionSnapshot>();
+
+				const pushFor = (sessionId: string) =>
 					Effect.gen(function* () {
 						const record = records.get(sessionId);
 						if (record === undefined) return;
 						const view = yield* record.handle.read;
-						yield* publish({
-							type: "session_snapshot",
-							snapshot: sessionSnapshot(record, view, connection),
-						});
+						const snapshot = sessionSnapshot(record, view, connection);
+						const push = nextPush(sent.get(sessionId), snapshot);
+						sent.set(sessionId, snapshot);
+						if (push._tag === "Unchanged") return;
+						yield* publish(
+							push._tag === "Snapshot"
+								? {type: "session_snapshot", snapshot: push.snapshot}
+								: {type: "session_delta", delta: push.delta},
+						);
 					});
 
 				const context = {
@@ -289,14 +303,18 @@ const make = (
 
 				/**
 				 * A session's own pushes: the host says it changed, the record's revision advances and
-				 * the owner sees the new snapshot. Forked once per session this connection touches,
-				 * over the handle rather than the id so a drained table cannot strand the loop.
+				 * the owner sees what moved. Forked once per session this connection touches, over the
+				 * handle rather than the id so a drained table cannot strand the loop.
+				 *
+				 * A streamed turn signals per token, so this loop runs per token and what it sends has
+				 * to cost per token: the first pass sends the whole value, every later one sends only
+				 * the items and scalars that changed (#8554).
 				 */
 				const followSession = (handle: PiSessionHandle) =>
 					Effect.forever(
 						handle.changes.pipe(
 							Effect.andThen(Effect.sync(() => records.bump(handle.id, Date.now()))),
-							Effect.andThen(snapshotFor(handle.id)),
+							Effect.andThen(pushFor(handle.id)),
 						),
 					);
 

--- a/apps/tuval/src/pi/server/pi-server.integration.test.ts
+++ b/apps/tuval/src/pi/server/pi-server.integration.test.ts
@@ -12,6 +12,7 @@ import {ModelRuntime, SessionManager} from "@earendil-works/pi-coding-agent";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer, Redacted} from "effect";
 import type {ProtocolError, ServerMessage, SessionSnapshot} from "../wire/index.ts";
+import {applyDelta} from "../wire/index.ts";
 import {layer as agentSessionHostLayer} from "./AgentSessionHost.ts";
 import {SessionOpenFailed} from "./errors.ts";
 import {PiServerService} from "./PiServerService.ts";
@@ -32,23 +33,35 @@ const sessionOf = (message: Extract<ServerMessage, {type: "response"}>): Session
 	return message.result.session;
 };
 
-/** The first pushed snapshot at or past `revision`. Snapshots coalesce, so revisions can skip. */
+/**
+ * The session as this connection sees it at or past `revision`, folded the way a client folds it:
+ * the whole value arrives once and every revision after it is a delta, so reading one means
+ * applying them. Pushes coalesce, so revisions can skip.
+ *
+ * The fold rides `next`'s own matcher because that is the one thing this fixture calls on every
+ * message, in arrival order, over both the messages already in and the ones still to come.
+ * Re-folding a delta is a no-op, so a message the two passes both reach costs nothing.
+ */
 const pushedSnapshot = (client: WireClient, revision: number): Effect.Effect<SessionSnapshot> =>
-	client
-		.next(
-			(message) =>
-				message.type === "service_update" &&
-				message.update.type === "session_snapshot" &&
-				message.update.snapshot.revision >= revision,
-		)
-		.pipe(
-			Effect.map((message) => {
-				if (message.type !== "service_update" || message.update.type !== "session_snapshot") {
-					throw new Error("unreachable");
-				}
-				return message.update.snapshot;
-			}),
-		);
+	Effect.suspend(() => {
+		let held: SessionSnapshot | undefined;
+		const fold = (message: ServerMessage): boolean => {
+			if (message.type !== "service_update") return false;
+			const update = message.update;
+			if (update.type === "session_snapshot") held = update.snapshot;
+			else if (update.type === "session_delta" && held !== undefined) {
+				held = applyDelta(held, update.delta);
+			} else return false;
+			return held.revision >= revision;
+		};
+		return client
+			.next(fold)
+			.pipe(
+				Effect.flatMap(() =>
+					held === undefined ? Effect.die("no session update was folded") : Effect.succeed(held),
+				),
+			);
+	});
 
 const errorOf = (message: Extract<ServerMessage, {type: "response"}>): ProtocolError => {
 	if (message.ok) throw new Error("expected a refusal");

--- a/apps/tuval/src/pi/server/server.unit.test.ts
+++ b/apps/tuval/src/pi/server/server.unit.test.ts
@@ -1,6 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer, Redacted, type Scope} from "effect";
-import type {ProtocolError, ServerMessage, ServerSnapshot, SessionSnapshot} from "../wire/index.ts";
+import type {
+	ProtocolError,
+	ServerMessage,
+	ServerSnapshot,
+	SessionDelta,
+	SessionSnapshot,
+} from "../wire/index.ts";
 import {makeScriptedHost, type ScriptedHost} from "./fixtures.ts";
 import {CLOSE_FRAME_TOO_LARGE, CLOSE_QUEUE_OVERFLOW} from "./limits.ts";
 import {makeOutbound} from "./outbound.ts";
@@ -20,11 +26,24 @@ const serverSnapshotOf = (message: ServerMessage): ServerSnapshot => {
 	return message.update.snapshot;
 };
 
+const isSessionSnapshot = (message: ServerMessage) =>
+	message.type === "service_update" && message.update.type === "session_snapshot";
+
+const isSessionDelta = (message: ServerMessage) =>
+	message.type === "service_update" && message.update.type === "session_delta";
+
 const sessionSnapshotOf = (message: ServerMessage): SessionSnapshot => {
 	if (message.type !== "service_update" || message.update.type !== "session_snapshot") {
 		throw new Error("expected a session snapshot update");
 	}
 	return message.update.snapshot;
+};
+
+const sessionDeltaOf = (message: ServerMessage): SessionDelta => {
+	if (message.type !== "service_update" || message.update.type !== "session_delta") {
+		throw new Error("expected a session delta update");
+	}
+	return message.update.delta;
 };
 
 const responseOf = (client: WireClient, id: string) =>
@@ -117,6 +136,42 @@ describe("PiServerService", () => {
 
 				const slow = yield* responseOf(client, "slow");
 				assert.strictEqual(okResult(slow).command, "prompt");
+			}),
+		);
+	});
+
+	/**
+	 * The whole value goes out once, on this connection's first push for the session; every change
+	 * after it costs a delta naming what moved. A streamed turn signals per token, so the second
+	 * frame is the one a live turn actually rides (#8554).
+	 */
+	it.live("sends the whole value once, then a delta per change", () => {
+		const host = makeScriptedHost();
+		return withServer(host, (server) =>
+			Effect.gen(function* () {
+				const client = yield* dial(server);
+				const session = yield* createSession(client, "r0");
+
+				yield* client.request("p1", {command: "prompt", sessionId: session.id, text: "hi"});
+				yield* responseOf(client, "p1");
+				const whole = sessionSnapshotOf(yield* client.next(isSessionSnapshot));
+
+				yield* client.request("p2", {command: "prompt", sessionId: session.id, text: "again"});
+				yield* responseOf(client, "p2");
+				const delta = sessionDeltaOf(yield* client.next(isSessionDelta));
+
+				assert.isAbove(delta.revision, whole.revision);
+				assert.isDefined(delta.items, "the delta named no item for a turn that appended two");
+				assert.isBelow(
+					(delta.items ?? []).length,
+					whole.transcript.length + (delta.items ?? []).length,
+					"the delta carried the whole transcript rather than what changed",
+				);
+				assert.deepStrictEqual(
+					(delta.items ?? []).map((item) => item.id),
+					["item-2", "item-3"],
+					"the delta named rows the first push had already carried",
+				);
 			}),
 		);
 	});

--- a/apps/tuval/src/pi/server/transcript.ts
+++ b/apps/tuval/src/pi/server/transcript.ts
@@ -9,9 +9,9 @@
  *
  * Pi's messages carry no id, so the item id is the message's position. That is stable while
  * history only grows, which is the case for a live session; a compaction rewrites the array and
- * therefore renumbers, and the snapshot that carries the renumbering is the client's cue to
- * replace its transcript wholesale — snapshots are authoritative, which is the model the wire's
- * own `TranscriptProgress` comment states.
+ * therefore renumbers, and a renumbering is exactly the case `../wire/delta.ts` refuses to patch:
+ * the ids stop extending the last ones, so the viewer is sent a whole snapshot and replaces its
+ * transcript wholesale.
  *
  * An in-flight message is projected at the position it will land at, which is why it is passed as
  * one more message rather than handled apart: Pi pushes the finished message onto `messages` on

--- a/apps/tuval/src/pi/window/provider-failure.unit.test.tsx
+++ b/apps/tuval/src/pi/window/provider-failure.unit.test.tsx
@@ -43,7 +43,13 @@ const failed = (
 		errorMessage,
 		timestamp: 2,
 	}) as SourceMessage;
-const snapshotOf = (messages: ReadonlyArray<SourceMessage>): SessionSnapshot => {
+/**
+ * `revision` is a parameter because the fold drops an update at or below the one it last folded
+ * (`../ai-agent/items.ts`): two snapshots whose content differs must carry different revisions, the
+ * way the server's own `records.bump` gives them. A pair sharing one revision is a state the wire
+ * cannot produce, and folding it proves nothing.
+ */
+const snapshotOf = (messages: ReadonlyArray<SourceMessage>, revision = 1): SessionSnapshot => {
 	const snapshot: SessionSnapshot = {
 		id: "failure",
 		cwd: "/workspace",
@@ -54,7 +60,7 @@ const snapshotOf = (messages: ReadonlyArray<SourceMessage>): SessionSnapshot => 
 		thinkingLevel: "off",
 		attached: true,
 		locked: false,
-		revision: 1,
+		revision,
 		transcript: [...projectTranscript(messages)],
 		queuedSteer: [],
 		queuedSteerCount: 0,
@@ -156,27 +162,31 @@ describe("Pi provider failures across the owned transcript", () => {
 			],
 		};
 		const previous = eventsOf(emptyProjection, partial);
-		const settled = snapshotOf([
-			{
-				...failed(credit, content),
-				usage: {
-					input: 3,
-					output: 2,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 5,
-					cost: {input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0, total: 0.3},
+		// The revision the turn settled at, one past the in-flight one `partial` carries.
+		const settled = snapshotOf(
+			[
+				{
+					...failed(credit, content),
+					usage: {
+						input: 3,
+						output: 2,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 5,
+						cost: {input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0, total: 0.3},
+					},
+				} as SourceMessage,
+				{
+					role: "toolResult",
+					toolCallId: "call",
+					toolName: "read",
+					content: [{type: "text", text: "Tool output"}],
+					isError: false,
+					timestamp: 3,
 				},
-			} as SourceMessage,
-			{
-				role: "toolResult",
-				toolCallId: "call",
-				toolName: "read",
-				content: [{type: "text", text: "Tool output"}],
-				isError: false,
-				timestamp: 3,
-			},
-		]);
+			],
+			2,
+		);
 		const projected = rows(settled);
 		expect(projected.map((item) => item.kind)).toEqual(["thinking", "assistant", "system", "tool"]);
 		expect(new Set(projected.map((item) => item.id)).size).toBe(4);
@@ -236,10 +246,16 @@ describe("Pi provider failures across the owned transcript", () => {
 				.events.filter((event) => event.kind === "item")
 				.map((event) => event.item),
 		).toEqual(tail);
+		// The seed is what has to suppress these rows, so the fold runs against the *next* revision:
+		// at or below the seed's own the fold drops the update before the seed is consulted, and the
+		// assertion would hold whatever `projectionOf` returned.
+		const seed = projectionOf(snapshot, tail);
+		expect(seed, "the resume seed reached no boundary, so it suppresses nothing").not.toBeNull();
 		expect(
-			eventsOf(projectionOf(snapshot, tail), snapshot).events.filter(
-				(event) => event.kind === "item",
-			),
+			eventsOf(seed ?? emptyProjection, {
+				...snapshot,
+				revision: snapshot.revision + 1,
+			}).events.filter((event) => event.kind === "item"),
 		).toEqual([]);
 		expect(tail[1]).toMatchObject({kind: "assistant", text: "Later answer"});
 	});

--- a/apps/tuval/src/pi/wire/codec.ts
+++ b/apps/tuval/src/pi/wire/codec.ts
@@ -224,9 +224,20 @@ export interface SplitFrames {
  *
  * `Client` routes a `service_update` only to a subscription its own `subscribeService` opened, and
  * drops every other one silently (`client.js`, `#handleMessage`) — so Tuval's events cannot reach
- * the app through it. Subscribing for real would mean speaking Chord's replicated-state protocol,
- * which is the next slice's question, not this one's. Splitting here costs nothing extra: each
- * frame is CBOR-decoded once, and a forwarded frame is handed on as the bytes it arrived as.
+ * the app through it. Splitting here costs nothing extra: each frame is CBOR-decoded once, and a
+ * forwarded frame is handed on as the bytes it arrived as.
+ *
+ * **Tuval does not speak Chord's replicated-state protocol, and the split stays** (#8554). Read at
+ * the 0.85.1 pin, subscribing for real means answering a `$chord.service`/`subscribe` request with
+ * a `WireServiceSubscriptionSnapshot` and then pushing every update as
+ * `{type: "state", sequence, ops}`, where `ops` is chord's own delta vocabulary decoded by a
+ * decoder that is stateful across frames — one per `(instance, member)`, with an interned path
+ * dictionary that outlives the batch (`@earendil-works/chord` `dist/delta/index.js`,
+ * `dist/services/state-codec.js`). Anything that decoder rejects fails the whole connection with a
+ * `ProtocolValidationError` (`pi-client` `dist/client.js`, `#handleMessage`), and chord is not a
+ * declared dependency of `apps/tuval` — it arrives only under `pi-client`. What that buys is a
+ * generic delta format; what this app needs is a delta over its own `SessionSnapshot`, which is one
+ * diff over a shape both ends already own (`./delta.ts`) and needs none of it.
  */
 export const createServerFrameSplitter = (
 	options?: FrameOptions,

--- a/apps/tuval/src/pi/wire/codec.unit.test.ts
+++ b/apps/tuval/src/pi/wire/codec.unit.test.ts
@@ -189,19 +189,22 @@ describe("the inbound frame splitter", () => {
 });
 
 /**
- * What one revision costs on this socket. A streamed turn signals per token and every signal is a
- * frame, so one frame's encode-plus-decode round trip *is* the per-token cost the delta shape
- * exists to bring down (#8554).
+ * What one revision costs on this socket, as a **ratio**. A streamed turn signals per token and
+ * every signal is a frame, so one frame's encode-plus-decode round trip is the per-token cost the
+ * delta shape exists to bring down (#8554).
  *
- * Measured on the 0.85.1 envelope: ~40 µs for the 274-byte delta below, against ~3.2 ms for the
- * 200-item snapshot the old shape sent in its place — two orders of magnitude apart, and in the
- * same range as the spike's 25.5 µs for a 133-byte frame. The ceiling is an order of magnitude
- * above the measured cost and an order below the snapshot's, so it reds on a real regression rather
- * than on a busy CI runner.
+ * The assertion is `delta * 10 < whole` and deliberately nothing absolute. Both figures come from
+ * the same process on the same hardware within one test, so the machine's speed divides out and
+ * what is left is the property this shape claims: a delta costs a fraction of the whole-transcript
+ * frame the old wire sent in its place. A fixed µs ceiling over `performance.now()` cannot say that
+ * — it says "this machine is at least this fast", which is a fact about the runner. One reded on a
+ * shared GitHub runner at 535 µs against a 500 µs bound while the ratio beside it passed, and every
+ * such red reads as a delta-encoding regression that is not one (#8589 review round 1).
+ *
+ * For orientation only, never asserted: on one developer machine the 274-byte delta below round
+ * trips in ~40 µs and the 200-item snapshot in ~3.2 ms. Those are that machine's numbers.
  */
 describe("what one revision costs on the wire", () => {
-	const CEILING_MICROS = 500;
-
 	const longTranscript = (count: number): SessionSnapshot["transcript"] =>
 		Array.from({length: count}, (_, at) => ({
 			id: `item-${at}`,
@@ -259,15 +262,6 @@ describe("what one revision costs on the wire", () => {
 			snapshot: {...snapshot, revision: 42, transcript: [...longTranscript(200)]},
 		},
 	};
-
-	it("carries a per-delta frame in tens of microseconds, not tenths of a millisecond", () => {
-		const micros = roundTripMicros(deltaFrame, 2_000);
-		assert.isBelow(
-			micros,
-			CEILING_MICROS,
-			`one delta round trip cost ${micros.toFixed(1)} µs, over the ${CEILING_MICROS} µs ceiling`,
-		);
-	});
 
 	it("costs a fraction of the whole-transcript frame the old shape sent per token", () => {
 		const delta = roundTripMicros(deltaFrame, 2_000);

--- a/apps/tuval/src/pi/wire/codec.unit.test.ts
+++ b/apps/tuval/src/pi/wire/codec.unit.test.ts
@@ -187,3 +187,99 @@ describe("the inbound frame splitter", () => {
 		);
 	});
 });
+
+/**
+ * What one revision costs on this socket. A streamed turn signals per token and every signal is a
+ * frame, so one frame's encode-plus-decode round trip *is* the per-token cost the delta shape
+ * exists to bring down (#8554).
+ *
+ * Measured on the 0.85.1 envelope: ~40 µs for the 274-byte delta below, against ~3.2 ms for the
+ * 200-item snapshot the old shape sent in its place — two orders of magnitude apart, and in the
+ * same range as the spike's 25.5 µs for a 133-byte frame. The ceiling is an order of magnitude
+ * above the measured cost and an order below the snapshot's, so it reds on a real regression rather
+ * than on a busy CI runner.
+ */
+describe("what one revision costs on the wire", () => {
+	const CEILING_MICROS = 500;
+
+	const longTranscript = (count: number): SessionSnapshot["transcript"] =>
+		Array.from({length: count}, (_, at) => ({
+			id: `item-${at}`,
+			role: "assistant" as const,
+			content: [
+				{type: "text" as const, text: "a settled reply, roughly a paragraph long. ".repeat(6)},
+			],
+			model: {provider: "faux", id: "faux-1"},
+			timestamp: at,
+			status: "complete" as const,
+			stopReason: "stop" as const,
+		}));
+
+	/**
+	 * Microseconds per encode-plus-decode round trip, averaged over `rounds`. One decoder for the
+	 * whole run, because that is what a connection holds — a fresh one per frame would price an
+	 * allocation neither end of this socket makes.
+	 */
+	const roundTripMicros = (message: ServerMessage, rounds: number): number => {
+		const decoder = createServerMessageDecoder();
+		for (let warm = 0; warm < 20; warm += 1) decoder.push(encodeServerMessage(message));
+		const started = performance.now();
+		for (let round = 0; round < rounds; round += 1) decoder.push(encodeServerMessage(message));
+		return ((performance.now() - started) * 1000) / rounds;
+	};
+
+	const deltaFrame: ServerMessage = {
+		type: "service_update",
+		subscriptionId: SESSION_SUBSCRIPTION_ID,
+		update: {
+			type: "session_delta",
+			delta: {
+				id: snapshot.id,
+				revision: 42,
+				updatedAt: 1_700_000_000_000,
+				items: [
+					{
+						id: "item-1",
+						role: "assistant",
+						content: [{type: "text", text: "the reply so far, one token longer"}],
+						model: {provider: "faux", id: "faux-1"},
+						timestamp: 11,
+						status: "streaming",
+					},
+				],
+			},
+		},
+	};
+
+	const snapshotFrame: ServerMessage = {
+		type: "service_update",
+		subscriptionId: SESSION_SUBSCRIPTION_ID,
+		update: {
+			type: "session_snapshot",
+			snapshot: {...snapshot, revision: 42, transcript: [...longTranscript(200)]},
+		},
+	};
+
+	it("carries a per-delta frame in tens of microseconds, not tenths of a millisecond", () => {
+		const micros = roundTripMicros(deltaFrame, 2_000);
+		assert.isBelow(
+			micros,
+			CEILING_MICROS,
+			`one delta round trip cost ${micros.toFixed(1)} µs, over the ${CEILING_MICROS} µs ceiling`,
+		);
+	});
+
+	it("costs a fraction of the whole-transcript frame the old shape sent per token", () => {
+		const delta = roundTripMicros(deltaFrame, 2_000);
+		const whole = roundTripMicros(snapshotFrame, 50);
+		assert.isBelow(
+			delta * 10,
+			whole,
+			`a delta cost ${delta.toFixed(1)} µs against the snapshot's ${whole.toFixed(1)} µs — under 10x`,
+		);
+	});
+
+	it("round trips a delta unchanged", () => {
+		assert.deepStrictEqual(roundTripServer(deltaFrame), deltaFrame);
+	});
+});

--- a/apps/tuval/src/pi/wire/delta.ts
+++ b/apps/tuval/src/pi/wire/delta.ts
@@ -1,0 +1,122 @@
+/**
+ * The incremental half of the session stream: what one revision changed, and how a holder of the
+ * previous whole value applies it.
+ *
+ * Both ends of the socket run this file. The server diffs the snapshot it is about to send against
+ * the one it last sent and pushes `nextPush`'s answer; the client applies `applyDelta` to the
+ * snapshot its lease holds. Keeping the two beside each other is what makes the round trip one
+ * fact rather than two that have to be kept in step.
+ *
+ * A delta is a *change set over ids*, never a positional patch: the wire's transcript item id is
+ * the message's own position (`../server/transcript.ts`), so an id that moves is a transcript that
+ * was rewritten, and `nextPush` answers a whole snapshot for that rather than a delta nothing can
+ * apply. The fallback is the invariant, not a heuristic — a delta is emitted only where the next
+ * transcript extends the last one's id sequence as a prefix.
+ */
+
+import type {SessionDelta, SessionSnapshot} from "./session.ts";
+import type {TranscriptItem} from "./transcript.ts";
+
+/** What one revision is worth to a viewer that holds the previous one. */
+export type SessionPush =
+	| {readonly _tag: "Snapshot"; readonly snapshot: SessionSnapshot}
+	| {readonly _tag: "Delta"; readonly delta: SessionDelta}
+	/** The revision moved but nothing this viewer can see did, so there is nothing to send. */
+	| {readonly _tag: "Unchanged"};
+
+const sameItem = (left: TranscriptItem, right: TranscriptItem): boolean =>
+	JSON.stringify(left) === JSON.stringify(right);
+
+/**
+ * Whether `next`'s transcript continues `last`'s rather than replacing it: same ids in the same
+ * order for as far as `last` goes, and nothing dropped off the end. A compaction renumbers and a
+ * branch replaces, and both land here as `false`.
+ */
+const extendsTranscript = (
+	last: ReadonlyArray<TranscriptItem>,
+	next: ReadonlyArray<TranscriptItem>,
+): boolean => next.length >= last.length && last.every((item, at) => item.id === next[at]?.id);
+
+const changedItems = (
+	last: ReadonlyArray<TranscriptItem>,
+	next: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> =>
+	next.filter((item, at) => {
+		const before = last[at];
+		return before === undefined || !sameItem(item, before);
+	});
+
+const sameSteer = (left: SessionSnapshot, right: SessionSnapshot): boolean =>
+	left.queuedSteerCount === right.queuedSteerCount &&
+	JSON.stringify(left.queuedSteer) === JSON.stringify(right.queuedSteer);
+
+/**
+ * The frame one revision is worth to a viewer holding `last` — absent for a viewer holding
+ * nothing, which is its first subscribe and takes the whole value.
+ *
+ * A `name` that went away is the one scalar a delta cannot state: an absent key means unchanged,
+ * so "no longer named" would be indistinguishable from it. That takes the whole value too.
+ */
+export const nextPush = (last: SessionSnapshot | undefined, next: SessionSnapshot): SessionPush => {
+	if (last === undefined) return {_tag: "Snapshot", snapshot: next};
+	if (!extendsTranscript(last.transcript, next.transcript)) {
+		return {_tag: "Snapshot", snapshot: next};
+	}
+	if (last.name !== undefined && next.name === undefined) {
+		return {_tag: "Snapshot", snapshot: next};
+	}
+
+	const items = changedItems(last.transcript, next.transcript);
+	const steerMoved = !sameSteer(last, next);
+	const delta: SessionDelta = {
+		id: next.id,
+		revision: next.revision,
+		updatedAt: next.updatedAt,
+		...(next.name === undefined || next.name === last.name ? {} : {name: next.name}),
+		...(next.phase === last.phase ? {} : {phase: next.phase}),
+		...(next.model.provider === last.model.provider && next.model.id === last.model.id
+			? {}
+			: {model: next.model}),
+		...(next.thinkingLevel === last.thinkingLevel ? {} : {thinkingLevel: next.thinkingLevel}),
+		...(next.attached === last.attached ? {} : {attached: next.attached}),
+		...(next.locked === last.locked ? {} : {locked: next.locked}),
+		...(steerMoved
+			? {queuedSteer: [...next.queuedSteer], queuedSteerCount: next.queuedSteerCount}
+			: {}),
+		...(items.length === 0 ? {} : {items: [...items]}),
+	};
+
+	// Three keys are the address and the clock, not a change; a delta carrying only them says
+	// nothing a viewer can render, and sending it would put a frame on the wire per silent bump.
+	return Object.keys(delta).length === 3 ? {_tag: "Unchanged"} : {_tag: "Delta", delta};
+};
+
+/**
+ * `base` moved on by one delta. Items land by id — a known id is replaced in place, an unknown one
+ * is appended in the order the delta carries them — which is the same rule the client's own fold
+ * runs (`../ai-agent/items.ts`), so the lease's whole value and the window's rows never disagree
+ * about what the transcript is.
+ */
+export const applyDelta = (base: SessionSnapshot, delta: SessionDelta): SessionSnapshot => {
+	const transcript = [...base.transcript];
+	for (const item of delta.items ?? []) {
+		const at = transcript.findIndex((held) => held.id === item.id);
+		if (at === -1) transcript.push(item);
+		else transcript[at] = item;
+	}
+	return {
+		...base,
+		revision: delta.revision,
+		updatedAt: delta.updatedAt,
+		...(delta.name === undefined ? {} : {name: delta.name}),
+		...(delta.phase === undefined ? {} : {phase: delta.phase}),
+		...(delta.model === undefined ? {} : {model: delta.model}),
+		...(delta.thinkingLevel === undefined ? {} : {thinkingLevel: delta.thinkingLevel}),
+		...(delta.attached === undefined ? {} : {attached: delta.attached}),
+		...(delta.locked === undefined ? {} : {locked: delta.locked}),
+		...(delta.queuedSteer === undefined
+			? {}
+			: {queuedSteer: [...delta.queuedSteer], queuedSteerCount: delta.queuedSteerCount ?? 0}),
+		transcript,
+	};
+};

--- a/apps/tuval/src/pi/wire/delta.unit.test.ts
+++ b/apps/tuval/src/pi/wire/delta.unit.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The incremental half of the session stream, over hand-built wire values: what one revision is
+ * worth to a viewer holding the last one, and that applying it lands on the value it was diffed
+ * from. The pair is a round trip, so both halves are asserted against the same snapshots.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {applyDelta, nextPush} from "./delta.ts";
+import type {SessionSnapshot, TranscriptItem} from "./index.ts";
+
+const user: TranscriptItem = {
+	id: "item-0",
+	role: "user",
+	content: [{type: "text", text: "say hello"}],
+	timestamp: 10,
+};
+
+const reply = (text: string, status: "streaming" | "complete"): TranscriptItem =>
+	status === "streaming"
+		? {
+				id: "item-1",
+				role: "assistant",
+				content: [{type: "text", text}],
+				model: {provider: "faux", id: "faux-1"},
+				timestamp: 11,
+				status: "streaming",
+			}
+		: {
+				id: "item-1",
+				role: "assistant",
+				content: [{type: "text", text}],
+				model: {provider: "faux", id: "faux-1"},
+				timestamp: 11,
+				status: "complete",
+				stopReason: "stop",
+			};
+
+const snapshot = (options: {
+	readonly transcript: ReadonlyArray<TranscriptItem>;
+	readonly phase?: SessionSnapshot["phase"];
+	readonly revision: number;
+	readonly name?: string;
+}): SessionSnapshot => ({
+	id: "session-8554",
+	...(options.name === undefined ? {} : {name: options.name}),
+	cwd: "/workspace",
+	createdAt: 0,
+	updatedAt: options.revision * 100,
+	phase: options.phase ?? "idle",
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+	attached: true,
+	locked: true,
+	revision: options.revision,
+	transcript: [...options.transcript],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+describe("what one revision is worth to a viewer", () => {
+	it("hands a viewer holding nothing the whole value", () => {
+		const first = snapshot({transcript: [user], revision: 1});
+		assert.deepStrictEqual(nextPush(undefined, first), {_tag: "Snapshot", snapshot: first});
+	});
+
+	it("sends one item and the phase for a token appended to a running reply", () => {
+		const before = snapshot({
+			transcript: [user, reply("hi", "streaming")],
+			phase: "turn",
+			revision: 4,
+		});
+		const after = snapshot({
+			transcript: [user, reply("hi t", "streaming")],
+			phase: "turn",
+			revision: 5,
+		});
+		const push = nextPush(before, after);
+		assert.strictEqual(push._tag, "Delta");
+		if (push._tag !== "Delta") return;
+		assert.deepStrictEqual(push.delta.items, [reply("hi t", "streaming")]);
+		assert.strictEqual(push.delta.revision, 5);
+		assert.strictEqual(
+			push.delta.phase,
+			undefined,
+			"an unchanged scalar rode along, which is the cost the delta exists to avoid",
+		);
+	});
+
+	it("names a scalar that moved and leaves the transcript out when it did not", () => {
+		const before = snapshot({transcript: [user], phase: "turn", revision: 4});
+		const after = snapshot({transcript: [user], phase: "idle", revision: 5});
+		const push = nextPush(before, after);
+		assert.strictEqual(push._tag, "Delta");
+		if (push._tag !== "Delta") return;
+		assert.strictEqual(push.delta.phase, "idle");
+		assert.strictEqual(push.delta.items, undefined);
+	});
+
+	/**
+	 * A delta is a change set over ids and the wire's ids are positional, so a transcript that no
+	 * longer extends the last one is a rewrite — a compaction, or a branch. There is nothing to
+	 * patch, and guessing would leave the viewer reading a transcript the session does not have.
+	 */
+	it("falls back to the whole value when the transcript stopped extending", () => {
+		const before = snapshot({transcript: [user, reply("hi back", "complete")], revision: 4});
+		const compacted = snapshot({transcript: [reply("summary", "complete")], revision: 5});
+		assert.deepStrictEqual(nextPush(before, compacted), {
+			_tag: "Snapshot",
+			snapshot: compacted,
+		});
+	});
+
+	it("falls back to the whole value when the session lost its name", () => {
+		const before = snapshot({transcript: [user], revision: 4, name: "kefil"});
+		const after = snapshot({transcript: [user], revision: 5});
+		assert.strictEqual(nextPush(before, after)._tag, "Snapshot");
+	});
+
+	it("sends nothing when the revision moved but nothing a viewer reads did", () => {
+		const before = snapshot({transcript: [user], revision: 4});
+		const after = snapshot({transcript: [user], revision: 5});
+		assert.deepStrictEqual(nextPush(before, after), {_tag: "Unchanged"});
+	});
+});
+
+describe("applying one delta to the value it was diffed from", () => {
+	const roundTrip = (before: SessionSnapshot, after: SessionSnapshot): SessionSnapshot => {
+		const push = nextPush(before, after);
+		if (push._tag === "Snapshot") return push.snapshot;
+		if (push._tag === "Unchanged") return before;
+		return applyDelta(before, push.delta);
+	};
+
+	it("lands on the snapshot the server diffed, for a token, a settle and a new turn", () => {
+		const opened = snapshot({transcript: [user], phase: "turn", revision: 1});
+		const writing = snapshot({
+			transcript: [user, reply("hi", "streaming")],
+			phase: "turn",
+			revision: 2,
+		});
+		const settled = snapshot({
+			transcript: [user, reply("hi back", "complete")],
+			phase: "idle",
+			revision: 3,
+		});
+		assert.deepStrictEqual(roundTrip(opened, writing), writing);
+		assert.deepStrictEqual(roundTrip(writing, settled), settled);
+	});
+
+	it("replaces a row by id rather than appending a second copy of it", () => {
+		const writing = snapshot({
+			transcript: [user, reply("hi", "streaming")],
+			phase: "turn",
+			revision: 2,
+		});
+		const settled = snapshot({
+			transcript: [user, reply("hi back", "complete")],
+			phase: "turn",
+			revision: 3,
+		});
+		const applied = roundTrip(writing, settled);
+		assert.lengthOf(applied.transcript, 2);
+		assert.deepStrictEqual(applied.transcript[1], reply("hi back", "complete"));
+	});
+});

--- a/apps/tuval/src/pi/wire/index.ts
+++ b/apps/tuval/src/pi/wire/index.ts
@@ -37,6 +37,7 @@ export type {
 	SteerCommand,
 	SteerResult,
 } from "./command.ts";
+export {applyDelta, nextPush, type SessionPush} from "./delta.ts";
 export type {JsonValue} from "./json.ts";
 export type {
 	AttachmentEnvelope,
@@ -53,7 +54,13 @@ export type {
 } from "./message.ts";
 export {SERVICE_ID, SESSION_SUBSCRIPTION_ID} from "./message.ts";
 export type {ModelCost, ModelMetadata, ModelRef, ThinkingLevel} from "./model.ts";
-export type {ServerSnapshot, SessionMetadata, SessionPhase, SessionSnapshot} from "./session.ts";
+export type {
+	ServerSnapshot,
+	SessionDelta,
+	SessionMetadata,
+	SessionPhase,
+	SessionSnapshot,
+} from "./session.ts";
 export {PROTOCOL_VERSION} from "./session.ts";
 export {isSessionTarget, type RpcTarget, type ServerTarget, type SessionTarget} from "./target.ts";
 export type {
@@ -73,7 +80,6 @@ export type {
 	ToolContent,
 	ToolTranscriptItem,
 	TranscriptItem,
-	TranscriptProgress,
 	Usage,
 	UserContent,
 	UserTranscriptItem,

--- a/apps/tuval/src/pi/wire/message.ts
+++ b/apps/tuval/src/pi/wire/message.ts
@@ -1,7 +1,6 @@
 import type {Command, CommandResult, ProtocolError} from "./command.ts";
-import type {PROTOCOL_VERSION, ServerSnapshot, SessionSnapshot} from "./session.ts";
+import type {PROTOCOL_VERSION, ServerSnapshot, SessionDelta, SessionSnapshot} from "./session.ts";
 import type {RpcTarget, SessionTarget} from "./target.ts";
-import type {TranscriptProgress} from "./transcript.ts";
 
 /**
  * Tuval's session stream rides one protocol-8 service subscription, under an id fixed here rather
@@ -39,14 +38,16 @@ export interface CancelEnvelope {
 
 export type ClientMessage = ClientHello | RequestEnvelope | CancelEnvelope;
 
+/**
+ * A session reaches a viewer as one whole value and then as what each later revision changed:
+ * `session_snapshot` on the first subscribe and on a transcript the viewer cannot patch, and
+ * `session_delta` for everything in between. A streamed turn signals per token, so the delta is
+ * the frame that turn actually rides on (`./delta.ts`).
+ */
 export type ServerEvent =
 	| {readonly type: "server_snapshot"; readonly snapshot: ServerSnapshot}
 	| {readonly type: "session_snapshot"; readonly snapshot: SessionSnapshot}
-	| {
-			readonly type: "session_progress";
-			readonly sessionId: string;
-			readonly progress: TranscriptProgress;
-	  }
+	| {readonly type: "session_delta"; readonly delta: SessionDelta}
 	| {readonly type: "session_removed"; readonly sessionId: string};
 
 export interface ServerHello {

--- a/apps/tuval/src/pi/wire/session.ts
+++ b/apps/tuval/src/pi/wire/session.ts
@@ -41,3 +41,27 @@ export interface ServerSnapshot {
 	readonly sessions: SessionMetadata[];
 	readonly models: ModelMetadata[];
 }
+
+/**
+ * What one revision changed, for a viewer that already holds the previous whole value.
+ *
+ * Every field beside the three below is optional and means *unchanged when absent*, which is what
+ * keeps a streamed turn's per-token frame to the one item that moved instead of the transcript.
+ * `./delta.ts` owns both halves of that reading — the diff that builds one and the apply
+ * that folds one back into a `SessionSnapshot`.
+ */
+export interface SessionDelta {
+	readonly id: string;
+	readonly revision: number;
+	readonly updatedAt: number;
+	readonly name?: string;
+	readonly phase?: SessionPhase;
+	readonly model?: ModelRef;
+	readonly thinkingLevel?: ThinkingLevel;
+	readonly attached?: boolean;
+	readonly locked?: boolean;
+	readonly queuedSteer?: UserTranscriptItem[];
+	readonly queuedSteerCount?: number;
+	/** Transcript items that appeared or changed, in transcript order. */
+	readonly items?: TranscriptItem[];
+}

--- a/apps/tuval/src/pi/wire/transcript.ts
+++ b/apps/tuval/src/pi/wire/transcript.ts
@@ -122,24 +122,3 @@ export type ToolTranscriptItem =
 	| ErrorToolTranscriptItem;
 
 export type TranscriptItem = UserTranscriptItem | AssistantTranscriptItem | ToolTranscriptItem;
-
-/** Normalized incremental activity. Snapshots remain authoritative. */
-export type TranscriptProgress =
-	| {readonly type: "item_started"; readonly item: TranscriptItem}
-	| {
-			readonly type: "assistant_delta";
-			readonly messageId: string;
-			readonly contentIndex: number;
-			readonly kind: "text" | "thinking" | "toolCall";
-			readonly delta: string;
-	  }
-	| {readonly type: "item_updated"; readonly item: AssistantTranscriptItem | ToolTranscriptItem}
-	| {
-			readonly type: "item_finished";
-			readonly item:
-				| CompleteAssistantTranscriptItem
-				| ErrorAssistantTranscriptItem
-				| AbortedAssistantTranscriptItem
-				| CompleteToolTranscriptItem
-				| ErrorToolTranscriptItem;
-	  };


### PR DESCRIPTION
Tuval's Pi session stream sent a whole `session_snapshot` — the entire transcript — every time the
session handle signalled. A streamed turn signals per token, so that was a whole-transcript frame
per token. This makes the wire incremental and fixes two ordering defects the old shape hid.

## What changed

**The wire.** `ServerEvent` gains `session_delta`, carrying a `SessionDelta`: an id, a revision, an
`updatedAt`, and every other field optional and meaning *unchanged when absent*. Both halves of the
reading live in one module, `apps/tuval/src/pi/wire/delta.ts` — `nextPush` (server: diff against
what this viewer was last sent) and `applyDelta` (client: fold one back into a whole value). The
server sends the whole value once per viewer per session, on its first push, and a delta after that.

A delta is a change set over ids, never a positional patch, and it falls back to the whole value
whenever it cannot be one: the transcript stopped extending the last one as a prefix (a compaction
renumbers, a branch replaces, a boundary row from #8588 is substituted mid-transcript), or the
session's `name` went away, which an absent-means-unchanged field cannot state. A revision that
moved but changed nothing a viewer reads sends no frame at all.

**The fold.** `SnapshotProjection` now carries the revision it last folded, and both `eventsOf` and
the new `deltaEventsOf` drop an update at or below it. That closes the first claim of PR #8544's
report: when a turn's push wins the race against its own answer and the operator's next send lands
in the gap, the late answer used to re-fold an `idle` the projection had passed and emit a second
`ready` under a live turn — which the core admits on, refusing the next message mid-turn (#8214).
The three schedules in `mid-turn-refusal.unit.test.ts` flip from pinning that mechanism to asserting
it is gone; removing the guard reds the first two by name.

**The fan.** `follow`'s `Effect.race(Effect.race(pushes, folding), dropped)` let an ended update
stream interrupt the folding fiber with the turn's last update still queued. The fill is now an
`Effect.forkChild` and only the drop ends the fold. `turn-end.unit.test.ts` pins it, and it times
out against the old shape.

## Criterion 2 is pinned as a ratio, not a wall-clock ceiling

The first round of this test asserted an absolute 500 µs bound. It passed on a developer laptop at
~40 µs and reds on a shared GitHub runner at 535 µs, which is what review round 1 caught. A fixed µs
bound over `performance.now()` is a fact about the machine, and every red would have read as a
delta-encoding regression that is not one.

What `codec.unit.test.ts` asserts now is `delta * 10 < whole`: both figures measured in the same
process on the same hardware within one test, so runner speed divides out and what is left is the
property this change actually claims — a delta costs a fraction of the whole-transcript frame the
old wire sent in its place. That is the "far below the old snapshot cost" half of the criterion,
pinned portably. The "well under 0.1 ms" half is a one-machine observation and is now labelled as
one in the test's docblock rather than asserted; it is not true of every runner and never was. See
the Deviations entry.

## The `provider-failure` test's revision pair, after #8591

#8591's `provider-failure.unit.test.tsx` folds a pair of snapshots that its `snapshotOf` helper gave
the same hardcoded `revision: 1`, and this PR's fold drops an update at or below the revision it
last folded — so the second fold returned no events and the usage assertion reded.

**This is the test's fixture, not a regression in the reshape.** A pair of snapshots whose content
differs cannot share a revision on this wire: the server bumps through `records.bump` before it
reads the session, so the revision moves on every change. I proved the usage row still flows rather
than assuming it: over a realistic pair the fold emits
`{kind: "usage", turn: "item-0", model: "openai/synthetic", inputTokens: 3, outputTokens: 2, cost: 0.3}`
on the **delta** path too — `deltaEventsOf` walks the same `usageEventOf` as the snapshot arm, and
`usageEventOf` reads `role` and `usage` without consulting `status`, so a failed turn's cost is
carried exactly like a settled one's. The failure notice row is emitted once at the revision it
first appears and correctly not re-emitted at the next, its fingerprint being unchanged.

The adaptation is minimal: `snapshotOf` takes an optional `revision` defaulting to 1, and the one
settled snapshot in that pair passes 2. The second fold in the same file needed the same bump for a
second reason — at an equal revision the fold drops the update *before* the resume seed is
consulted, so its "the seed suppresses these rows" assertion would have held whatever the seed was.
It now folds the next revision and asserts the seed is non-null, which is what makes the null
narrowing at that call site safe rather than silently vacuous.

## What a reviewer should look at first

- `apps/tuval/src/pi/wire/delta.ts` — the prefix invariant in `extendsTranscript` is what makes the
  whole-value fallback sound rather than a guess, and it is what makes a substituted compaction
  boundary row take the whole-value arm.
- `apps/tuval/src/pi/ai-agent/PiAiAgent.ts`'s `start` — `projectionOf` now answers `null` for "no
  seed", and that arm paints at the attach instead of waiting for a push. On the old wire the empty
  seed replayed via the next whole-transcript push; a delta carries no history, so waiting would
  replay nothing.

## Chord

The reviewer of #8586 asked whether Tuval should speak Chord's replicated-state protocol instead of
splitting `service_update` frames off the byte stream. Read at the installed 0.85.1 pin, no: it
means answering a `$chord.service`/`subscribe` request with a `WireServiceSubscriptionSnapshot` and
pushing every update as `{type: "state", sequence, ops}`, decoded by a decoder that is stateful
across frames — one per `(instance, member)`, with an interned path dictionary outliving the batch
(`@earendil-works/chord` `dist/delta/index.js`, `dist/services/state-codec.js`). Anything it rejects
fails the whole connection with a `ProtocolValidationError` (`pi-client` `dist/client.js`,
`#handleMessage`), and chord is not a declared dependency of `apps/tuval` — it arrives only under
`pi-client`. What it buys is a generic delta format; what this needed is a delta over Tuval's own
`SessionSnapshot`, one diff over a shape both ends already own. The splitter stays, and the
reasoning with its citations is now in the comment above `createServerFrameSplitter`.

## Deviations

- **Scope narrowing** — **Said:** #8554's criterion 2 asks for a per-delta cost "well under 0.1 ms",
  "asserted by a test with a ceiling far above the measured cost and far below the old snapshot
  cost". **Did:** assert only the ratio `delta * 10 < whole`, and deleted the absolute µs ceiling
  after it reded on CI at 535 µs. **Why:** an absolute wall-clock bound is machine-dependent by
  construction — the criterion's own "far above the measured cost" has no fixed value, because the
  measured cost differs by an order of magnitude between a laptop and a shared runner. The ratio
  keeps the half of the criterion that is a property of the change and drops the half that is a
  property of the hardware. The ~40 µs / ~3.2 ms figures survive in the docblock labelled as one
  machine's, asserted by nothing. **Disposition:** stated here; the narrowing is visible to the
  gate rather than papered over.
- **Pre-existing test or fixture changed** — **Said:** nothing about #8591's tests. **Did:** gave
  `provider-failure.unit.test.tsx`'s `snapshotOf` an optional `revision` parameter, passed 2 for the
  settled half of its folded pair, bumped the revision on its resume-seed fold, and added a non-null
  assertion on that seed. **Why:** the file landed on main after this branch and folds pairs sharing
  one revision, which this PR's fold drops by design and which the wire cannot produce. Every
  assertion in it is preserved; two are now stronger, because at an equal revision they held
  regardless of what they were testing. **Disposition:** stated here, with the evidence that the
  usage row still flows on both the snapshot and the delta path.
- **Out-of-scope change** — **Said:** #8554 names the delta wire, the projection's revision, and the
  raced folding fiber. **Did:** also deleted the `session_progress` `ServerEvent` arm and the
  `TranscriptProgress` type it carried, and repointed the one docblock in `server/transcript.ts`
  that referenced it. **Why:** nothing ever sent or read either one, and leaving a dead "incremental
  activity" event beside a live `session_delta` puts two incremental shapes in front of the next
  reader with no way to tell which is real. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria name code and tests. **Did:** also rewrote
  `.patterns/snapshot-authoritative-to-delta-events.md`. **Why:** its premise was "the backend
  pushes its whole state every revision", which this PR makes false, and its "where this stops
  applying" section named a delta-pushing backend as the case the pattern does *not* cover — which
  is now Tuval itself. A pattern doc contradicted by the source it cites sends its next reader
  wrong. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about existing tests. **Did:** flipped
  two `mid-turn-refusal.unit.test.ts` cases from asserting a second `ready` to asserting none, and
  rewrote that file's header. **Why:** they were characterization tests for the defect criterion 4
  asks to close; its own header said "a fix reds the first one by name". The file's other two claims
  are untouched. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about the stubs. **Did:** renamed
  `PiClientApi.snapshots` to `updates` and changed its element type, which touched seven stub
  `PiClientApi` literals and `pi-server.integration.test.ts`'s `pushedSnapshot` helper. **Why:** the
  stream no longer yields only snapshots, and a name that says it does is a lie at the one seam a
  reader checks. Each stub's behaviour is unchanged — the push helpers wrap the same snapshots in
  the `snapshot` arm. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about it. **Did:** left the `steer` versus
  `followUp` question from PR #8544's report open. **Why:** the issue says so in as many words.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about it. **Did:** left `PiClientService`'s
  `session_snapshot` and `onSession` lease writes without the revision guard the `session_delta` arm
  has. **Why:** review round 1 found it, it is latent rather than shipped (the only consumer
  re-`hold`s a fresh whole snapshot before reading), and it is filed as #8590. **Disposition:**
  stated here.

Fixes #8554
