### PR TITLE
fix: A Pi turn that ends in a provider error renders as an empty AGENT row in the Tuval chat

### DIFF
--- a/.patterns/snapshot-authoritative-to-delta-events.md
+++ b/.patterns/snapshot-authoritative-to-delta-events.md
@@ -90,3 +90,28 @@ rather than a change.
   other direction: an in-memory value onto a strict wire schema
 - [effect-context-service.md](./effect-context-service.md) — where the `Ref` holding the projection
   lives
+
+## Failed Pi turns are transcript notices
+
+Pi 0.85.1's `pi-ai/dist/types.d.ts` carries `AssistantMessage.stopReason` and optional
+`errorMessage`; Tuval's server projection retains them on its error-status wire item. A failed
+turn is therefore snapshot content, even when its text is empty, and is not a socket failure or a
+new session phase.
+
+[`itemsOf`](../apps/tuval/src/pi/ai-agent/items.ts) appends a `SystemItem` under the stable
+`<turn>:failure` identity. Nonempty prose and reasoning retain their own identities; an empty
+failed prose row is omitted, while an interrupted row retains its resend control. Usage remains
+keyed by the source turn. Repeated snapshots fingerprint the notice exactly like other rows.
+
+[`providerFailureText`](../apps/tuval/src/pi/ai-agent/provider-failure.ts) translates explicitly
+recognized diagnostic prefixes into fixed credit/quota/rate/key guidance. Unknown, missing or
+non-string diagnostics receive a generic failed-turn explanation. No original diagnostic, URL,
+credential, exception object or diagnostic suffix is copied into generic state. These are provider
+reports, not independent diagnoses; this mapping does not alter RPC exception translation.
+
+History re-keys the notice as `<entry>:failure` and aliases it to the matching live notice. Thus
+initial paint, reattach and page/tail joins preserve one explanation without replacing the reply
+beside it. The shared `SessionRow` renders this text through React text content, never markdown.
+The [provider-failure regression](../apps/tuval/src/pi/window/provider-failure.unit.test.tsx) drives
+the source projection, actual protocol-8 codec, mapper, history join, reattach and rendered window
+with synthetic diagnostics and no provider credentials.

--- a/apps/tuval/src/pi/ai-agent/entries.ts
+++ b/apps/tuval/src/pi/ai-agent/entries.ts
@@ -22,7 +22,7 @@
  * the port's own boundary kind; every other non-message entry — a branch summary, a model or
  * thinking-level change, an extension's own entry, a rename, a label — is one collapsed `system`
  * notice. The entry union is `SessionEntry` in `@earendil-works/pi-coding-agent`
- * `dist/core/session-manager.d.ts` at 0.84.3, and a kind outside it is skipped rather than thrown
+ * `dist/core/session-manager.d.ts` at 0.85.1, and a kind outside it is skipped rather than thrown
  * on, so a session file a newer Pi wrote still opens.
  */
 
@@ -38,7 +38,7 @@ import type {SystemItem, TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {projectTranscript, type SourceMessage} from "../server/index.ts";
 import {compactionId} from "../wire/compaction.ts";
 import type {TranscriptItem as PiTranscriptItem} from "../wire/index.ts";
-import {itemId, itemsOf, thinkingId} from "./items.ts";
+import {failureId, itemId, itemsOf, thinkingId} from "./items.ts";
 
 /** An entry's ISO timestamp as epoch milliseconds; an unparseable one reads as the epoch. */
 const millisOf = (timestamp: string): number => {
@@ -60,7 +60,12 @@ const millisOf = (timestamp: string): number => {
 const onEntry = (item: TranscriptItem, entry: SessionMessageEntry): TranscriptItem => {
 	const timestamp = millisOf(entry.timestamp);
 	if (item.kind === "tool") return {...item, timestamp};
-	const id = item.kind === "thinking" ? thinkingId(entry.id) : itemId(entry.id);
+	const id =
+		item.kind === "thinking"
+			? thinkingId(entry.id)
+			: item.kind === "system"
+				? failureId(entry.id)
+				: itemId(entry.id);
 	return {...item, id, timestamp};
 };
 
@@ -121,7 +126,7 @@ const noticeItemOf = (entry: SessionEntry): TranscriptItem | null => {
 };
 
 /**
- * Live positions count context messages, not disk entries. Pi 0.84.3's `buildSessionContext`
+ * Live positions count context messages, not disk entries. Pi 0.85.1's `buildSessionContext`
  * composes these two exports, including compacted summaries and invisible custom messages.
  * Stored entry ids remain unchanged; only the page planner consumes these aliases.
  */
@@ -135,6 +140,8 @@ export const pageCursorAliases = (
 		if (entry.type === "message" && messages.length === 1) {
 			aliases.set(`item-${index}`, entry.id);
 			aliases.set(thinkingId(`item-${index}`), thinkingId(entry.id));
+			if (entry.message.role === "assistant" && entry.message.stopReason === "error")
+				aliases.set(failureId(`item-${index}`), failureId(entry.id));
 		}
 		if (entry.type === "compaction" && messages.length === 1) {
 			aliases.set(compactionId(index), entry.id);

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -33,6 +33,7 @@ import type {
 	SessionPhase,
 	SessionSnapshot,
 } from "../wire/index.ts";
+import {providerFailureText} from "./provider-failure.ts";
 
 /** `ItemId` is an opaque string brand, minted here so no call site writes its own cast. */
 export const itemId = (value: string): ItemId => value as ItemId;
@@ -48,6 +49,8 @@ const textOf = (parts: ReadonlyArray<PiContent>): string =>
  * revision projection and `entries.ts` can re-key both off one entry.
  */
 export const thinkingId = (base: string): ItemId => itemId(`${base}:thinking`);
+
+export const failureId = (base: string): ItemId => itemId(`${base}:failure`);
 
 /**
  * `isError` decides `error` on its own: the wire pairs it with `status: "error"`, and reading the
@@ -122,20 +125,28 @@ const thinkingOf = (item: PiTranscriptItem): ThinkingItem | null => {
  * over nothing reads as a message that was dropped or is still loading, and the calls it made are
  * already rows of their own (#8216). Claude's mapper holds the same rule on its own wire
  * (`../../claude/history/map.ts`, `settles && (text.length > 0 || interrupted)`).
- *
- * `aborted` and `error` are excluded on purpose: for those the status *is* the content, and an
- * interrupted reply with no text still has to say the turn was cut.
+ * Failed turns carry their explanation in a distinct session notice; empty interrupted replies
+ * retain their resend control.
  */
-const emptyOrdinaryReply = (item: PiTranscriptItem): boolean =>
-	item.role === "assistant" &&
-	(item.status === "complete" || item.status === "streaming") &&
-	textOf(item.content) === "";
+const emptyReply = (item: PiTranscriptItem): boolean =>
+	item.role === "assistant" && item.status !== "aborted" && textOf(item.content) === "";
 
 /** One wire item as every row it is worth: the reasoning first, then the turn that produced it. */
 export const itemsOf = (item: PiTranscriptItem): ReadonlyArray<TranscriptItem> => {
 	const thinking = thinkingOf(item);
-	const reply = emptyOrdinaryReply(item) ? [] : [itemOf(item)];
-	return thinking === null ? reply : [thinking, ...reply];
+	const reply = emptyReply(item) ? [] : [itemOf(item)];
+	const rows = thinking === null ? reply : [thinking, ...reply];
+	if (item.role === "assistant" && item.status === "error")
+		return [
+			...rows,
+			{
+				kind: "system",
+				id: failureId(item.id),
+				timestamp: item.timestamp,
+				text: providerFailureText(item.errorMessage),
+			},
+		];
+	return rows;
 };
 
 /**

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -715,7 +715,7 @@ describe("a turn with nothing to read", () => {
 		]);
 	});
 
-	it("leaves an ordinary reply, a user turn and a failed turn alone", () => {
+	it("keeps ordinary replies and user turns, and explains an empty failed turn", () => {
 		expect(itemsOf(settledAssistant("hi back"))).toEqual([
 			{kind: "assistant", id: "item-1", timestamp: 11, text: "hi back"},
 		]);
@@ -728,6 +728,13 @@ describe("a turn with nothing to read", () => {
 			status: "error",
 			stopReason: "error",
 		};
-		expect(itemsOf(failed)).toEqual([{kind: "assistant", id: "item-1", timestamp: 11, text: ""}]);
+		expect(itemsOf(failed)).toEqual([
+			{
+				kind: "system",
+				id: "item-1:failure",
+				timestamp: 11,
+				text: "Turn failed: the provider could not complete the response. Check your provider account or try again later.",
+			},
+		]);
 	});
 });

--- a/apps/tuval/src/pi/ai-agent/provider-failure.ts
+++ b/apps/tuval/src/pi/ai-agent/provider-failure.ts
@@ -1,0 +1,15 @@
+/** Safe fixed guidance only; provider diagnostics never enter generic transcript state. */
+export const providerFailureText = (message: unknown): string => {
+	if (typeof message === "string") {
+		const text = message.trim().toLowerCase();
+		if (text.startsWith("you have no credits remaining."))
+			return "Turn failed: the provider reports no credits remaining. Add credits in your provider account before sending again.";
+		if (/^you exceeded your current quota(?:[\s.,:]|$)/.test(text))
+			return "Turn failed: the provider reports an exceeded quota. Check your provider plan and billing limits before sending again.";
+		if (/^rate limit (?:exceeded|reached)(?:[\s.,:]|$)/.test(text))
+			return "Turn failed: the provider reports a rate limit. Wait before sending again.";
+		if (/^(?:incorrect api key provided|invalid api key)(?:[\s.,:]|$)/.test(text))
+			return "Turn failed: the provider rejected the API key. Check the credentials in your provider configuration.";
+	}
+	return "Turn failed: the provider could not complete the response. Check your provider account or try again later.";
+};

--- a/apps/tuval/src/pi/window/proof/provider-failure.html
+++ b/apps/tuval/src/pi/window/proof/provider-failure.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Pi live provider-failure proof</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./provider-failure.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/pi/window/proof/provider-failure.tsx
+++ b/apps/tuval/src/pi/window/proof/provider-failure.tsx
@@ -1,0 +1,46 @@
+/** The existing chat window fed through production projection/adapter; no model or socket. */
+import {Effect} from "effect";
+import {createRoot} from "react-dom/client";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../../ai-agent/core/index.ts";
+import {ProcessId} from "../../../process/process.ts";
+import {withTranscript} from "../../../shell/chat/chat.testing.ts";
+import {type ChatView, initialChatView} from "../../../shell/chat/index.ts";
+import {testProcess} from "../../../shell/window/fixtures.ts";
+import {WindowId} from "../../../shell/window/index.ts";
+import {itemsOf} from "../../ai-agent/items.ts";
+import {projectTranscript, type SourceMessage} from "../../server/transcript.ts";
+import {piChatWindow} from "../PiChatWindow.tsx";
+import "../../../page/styles.ts";
+import "./proof.css";
+
+const messages: ReadonlyArray<SourceMessage> = [
+	{role: "user", content: "Explain the next step.", timestamp: 1},
+	{
+		role: "assistant",
+		content: [],
+		provider: "openai",
+		model: "synthetic",
+		stopReason: "error",
+		errorMessage:
+			"You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
+		timestamp: 2,
+	},
+];
+const mount = Effect.gen(function* () {
+	const host = document.getElementById("proof");
+	if (host === null) return yield* Effect.die(new Error("Missing proof host"));
+	const process = yield* testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+		ProcessId.make("provider-failure-proof"),
+		withTranscript(projectTranscript(messages).flatMap(itemsOf)),
+	);
+	const window = yield* process.window<ChatView>(
+		WindowId.make("provider-failure"),
+		initialChatView,
+	);
+	createRoot(host).render(
+		<div className="tuval-surface proof-desk" data-scheme="dark">
+			<div className="proof-pane">{piChatWindow().render(window)}</div>
+		</div>,
+	);
+});
+void Effect.runPromise(mount);

--- a/apps/tuval/src/pi/window/provider-failure.unit.test.tsx
+++ b/apps/tuval/src/pi/window/provider-failure.unit.test.tsx
@@ -1,0 +1,246 @@
+/** @vitest-environment jsdom */
+import type {SessionEntry} from "@earendil-works/pi-coding-agent";
+import {act, fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {chatWindow} from "../../shell/chat/ChatWindow.tsx";
+import {withTranscript} from "../../shell/chat/chat.testing.ts";
+import {mergeOlder} from "../../shell/chat/rows.ts";
+import {type ChatView, initialChatView} from "../../shell/chat/view.ts";
+import {installDomShims} from "../../shell/ui/dom.testing.ts";
+import {testProcess} from "../../shell/window/fixtures.ts";
+import {WindowId} from "../../shell/window/index.ts";
+import {pageCursorAliases, pageItems} from "../ai-agent/entries.ts";
+import {emptyProjection, eventsOf, itemsOf, paintOf, projectionOf} from "../ai-agent/items.ts";
+import {projectTranscript, type SourceMessage} from "../server/transcript.ts";
+import {
+	createServerMessageDecoder,
+	encodeServerMessage,
+	SESSION_SUBSCRIPTION_ID,
+	type SessionSnapshot,
+} from "../wire/index.ts";
+
+installDomShims();
+const credit =
+	"You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.";
+const guidance =
+	"Turn failed: the provider reports no credits remaining. Add credits in your provider account before sending again.";
+const generic =
+	"Turn failed: the provider could not complete the response. Check your provider account or try again later.";
+const failed = (
+	errorMessage: unknown = credit,
+	content: Extract<SourceMessage, {role: "assistant"}>["content"] = [],
+): SourceMessage =>
+	({
+		role: "assistant",
+		content,
+		provider: "openai",
+		model: "synthetic",
+		stopReason: "error",
+		errorMessage,
+		timestamp: 2,
+	}) as SourceMessage;
+const snapshotOf = (messages: ReadonlyArray<SourceMessage>): SessionSnapshot => {
+	const snapshot: SessionSnapshot = {
+		id: "failure",
+		cwd: "/workspace",
+		createdAt: 0,
+		updatedAt: 2,
+		phase: "idle",
+		model: {provider: "openai", id: "synthetic"},
+		thinkingLevel: "off",
+		attached: true,
+		locked: false,
+		revision: 1,
+		transcript: [...projectTranscript(messages)],
+		queuedSteer: [],
+		queuedSteerCount: 0,
+	};
+	const decoder = createServerMessageDecoder();
+	const [decoded] = decoder.push(
+		encodeServerMessage({
+			type: "service_update",
+			subscriptionId: SESSION_SUBSCRIPTION_ID,
+			update: {type: "session_snapshot", snapshot},
+		}),
+	);
+	decoder.end();
+	if (decoded?.type !== "service_update" || decoded.update.type !== "session_snapshot")
+		throw new Error("Expected snapshot roundtrip");
+	return decoded.update.snapshot;
+};
+const rows = (snapshot: SessionSnapshot) => snapshot.transcript.flatMap(itemsOf);
+
+describe("Pi provider failures across the owned transcript", () => {
+	it("retains a useful safe exhausted-credit notice through source, codec, mapper and rendering", async () => {
+		const snapshot = snapshotOf([failed()]);
+		expect(rows(snapshot)).toEqual([
+			{kind: "system", id: "item-0:failure", timestamp: 2, text: guidance},
+		]);
+		const process = await Effect.runPromise(
+			testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+				ProcessId.make("failure"),
+				withTranscript(rows(snapshot)),
+			),
+		);
+		const host = await Effect.runPromise(
+			process.window<ChatView>(WindowId.make("failure"), {...initialChatView, pinned: true}),
+		);
+		render(chatWindow({scrollToFn: () => {}}).render(host) as ReactElement);
+		expect(screen.getByText(guidance)).toBeDefined();
+		expect(screen.queryByText("AGENT", {exact: true})).toBeNull();
+		const composer = screen.getByRole("combobox");
+		expect(composer.hasAttribute("disabled")).toBe(false);
+		await act(async () => {
+			fireEvent.change(composer, {target: {value: "Try a later turn"}});
+			fireEvent.keyDown(composer, {key: "Enter", code: "Enter"});
+		});
+		await waitFor(() =>
+			expect(process.inbox()).toContainEqual(expect.objectContaining({type: "prompt"})),
+		);
+		expect(screen.queryByRole("link")).toBeNull();
+	});
+
+	it.each([
+		undefined,
+		null,
+		"",
+		"   ",
+		{secret: "sensitive"},
+		"<script>secret()</script>",
+		"Authorization: Bearer synthetic-private-token",
+		"billing maybe?",
+		"invalid api keyboard",
+	])("uses a generic explanation without forwarding unusable or unknown data: %j", (error) => {
+		const message = failed(error);
+		const snapshot = snapshotOf([{...message, errorMessage: error} as SourceMessage]);
+		expect(rows(snapshot)).toEqual([
+			{kind: "system", id: "item-0:failure", timestamp: 2, text: generic},
+		]);
+	});
+
+	it.each([
+		[
+			"Rate limit exceeded: private request",
+			"Turn failed: the provider reports a rate limit. Wait before sending again.",
+		],
+		[
+			"Invalid API key: synthetic-private-token",
+			"Turn failed: the provider rejected the API key. Check the credentials in your provider configuration.",
+		],
+		[
+			"You exceeded your current quota, private account details",
+			"Turn failed: the provider reports an exceeded quota. Check your provider plan and billing limits before sending again.",
+		],
+		[`${credit} Authorization: Bearer synthetic-private-token`, guidance],
+	])("keeps recognized guidance without diagnostic tails: %s", (error, expected) => {
+		expect(rows(snapshotOf([failed(error)]))[0]).toMatchObject({kind: "system", text: expected});
+	});
+
+	it("preserves text, reasoning, tool rows, usage and readiness when a partial reply fails", () => {
+		const content = [
+			{type: "thinking" as const, thinking: "Check the evidence"},
+			{type: "text" as const, text: "Partial answer"},
+			{type: "toolCall" as const, id: "call", name: "read", arguments: {}},
+		];
+		const partial = {
+			...snapshotOf([]),
+			transcript: [
+				...projectTranscript([], {...failed(credit, content), stopReason: "stop"} as Extract<
+					SourceMessage,
+					{role: "assistant"}
+				>),
+			],
+		};
+		const previous = eventsOf(emptyProjection, partial);
+		const settled = snapshotOf([
+			{
+				...failed(credit, content),
+				usage: {
+					input: 3,
+					output: 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 5,
+					cost: {input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0, total: 0.3},
+				},
+			} as SourceMessage,
+			{
+				role: "toolResult",
+				toolCallId: "call",
+				toolName: "read",
+				content: [{type: "text", text: "Tool output"}],
+				isError: false,
+				timestamp: 3,
+			},
+		]);
+		const projected = rows(settled);
+		expect(projected.map((item) => item.kind)).toEqual(["thinking", "assistant", "system", "tool"]);
+		expect(new Set(projected.map((item) => item.id)).size).toBe(4);
+		expect(projected[1]).toMatchObject({text: "Partial answer"});
+		expect(projected[1]).not.toHaveProperty("partial");
+		const delta = eventsOf(previous.next, settled);
+		expect(delta.events).toContainEqual({
+			kind: "usage",
+			turn: "item-0",
+			model: "openai/synthetic",
+			inputTokens: 3,
+			outputTokens: 2,
+			cost: 0.3,
+		});
+		expect(
+			delta.events.filter((event) => event.kind === "item" && event.item.kind === "system"),
+		).toHaveLength(1);
+		expect(eventsOf(delta.next, settled).events).toEqual([]);
+		expect(eventsOf(emptyProjection, settled).events).toContainEqual({
+			kind: "phase",
+			phase: "ready",
+		});
+	});
+
+	it("keeps failure identity in history, initial paint, reattach, overlap and a later successful turn", () => {
+		const messages = [
+			failed(),
+			{
+				role: "assistant",
+				content: [{type: "text", text: "Later answer"}],
+				provider: "openai",
+				model: "synthetic",
+				stopReason: "stop",
+				timestamp: 3,
+			},
+		] satisfies ReadonlyArray<SourceMessage>;
+		const snapshot = snapshotOf(messages);
+		const entries = messages.map((message, index) => ({
+			type: "message",
+			id: `entry-${index}`,
+			parentId: index === 0 ? null : "entry-0",
+			timestamp: new Date(message.timestamp).toISOString(),
+			message,
+		})) as SessionEntry[];
+		const tail = rows(snapshot);
+		const page = pageItems(entries);
+		expect(page[0]).toMatchObject({
+			kind: "system",
+			id: "entry-0:failure",
+			alias: "item-0:failure",
+			text: guidance,
+		});
+		expect(pageCursorAliases(entries).get("item-0:failure")).toBe("entry-0:failure");
+		expect(mergeOlder(tail, page)).toEqual(tail);
+		expect(
+			paintOf(snapshot)
+				.events.filter((event) => event.kind === "item")
+				.map((event) => event.item),
+		).toEqual(tail);
+		expect(
+			eventsOf(projectionOf(snapshot, tail), snapshot).events.filter(
+				(event) => event.kind === "item",
+			),
+		).toEqual([]);
+		expect(tail[1]).toMatchObject({kind: "assistant", text: "Later answer"});
+	});
+});


### PR DESCRIPTION
A settled Pi provider error now produces a useful session notice in live chat and stored history. Empty error prose no longer leaves a blank AGENT row; nonempty text, reasoning and tool rows retain their identities alongside a distinct failure notice. Stored-entry aliases preserve the explanation across paging and reopening, and repeated snapshots do not duplicate it.

Recognized credit, quota, rate-limit and API-key reports become fixed actionable guidance. Missing, unusable or unknown diagnostics receive an honest generic failure explanation; original diagnostics, URLs, credentials and exception objects are never copied into generic transcript state. Existing readiness, usage accounting, interrupted-turn controls and later prompting remain intact.

Release containment: none. This local-only Tuval recovery fix is available by default.

Fixes #8453

Validation: 2400 Tuval unit tests across 242 files pass (76.05 seconds with required loopback permission); affected typecheck/lint and prose checks pass. Sixteen focused synthetic cases cover source→protocol-8 codec→mapper, DOM rendering and a later prompt, missing/unsafe diagnostics, partial-then-error, usage, repeated snapshots, initial paint, held-tail reattach, history aliases and page/tail joining. The initial 11 regression cases failed against the information-loss baseline.

Builder visual verification: inspected 1280×900 before/after captures at `/tuval/pi-window/provider-failure.html`, using the reported exhausted-credit shape through production projection/adapter and the existing Pi chat window. Before: empty AGENT row. After: a SESSION notice says the provider reports no credits remaining and to add credits before sending again; Ready and the composer remain visible. No provider call or real credentials were used. Captures are attached through `ui evidence`.

LAW-SOURCE: manifest-prose

## Deviations

- **Said:** Preserve a useful provider failure explanation without forwarding secrets. **Did:** Translate explicit known diagnostic prefixes into fixed guidance and use a generic fallback for everything else, rather than displaying raw errorMessage. **Why:** Provider diagnostics may carry credentials, arbitrary objects or links. **Disposition:** Safe projection is bounded to snapshot-contained provider failures; RPC exception translation remains separate.
- **Said:** Keep existing transcript assertions correct. **Did:** Replace the existing expected blank error row with an explicit generic session notice while preserving ordinary-text, tool-only and interruption assertions. Added a committed production-backed visual fixture. **Why:** The previous expectation encoded this bug; a rendered fixture makes its visible correction reviewable. **Disposition:** Full Tuval suite and before/after verification pass; no new row design, phase, automatic retry or transport teardown.
