### PR TITLE
fix: Tuval's pi adapter copies exception text into generic agent errors

### DIFF
--- a/.patterns/backend-exception-translation.md
+++ b/.patterns/backend-exception-translation.md
@@ -63,3 +63,36 @@ CLI declined), the log line takes the deliberate message **and the retained caus
 `logRefused(what, refusal)`, which passes `refusal.cause` as a second argument to
 `Effect.logWarning`. Reading `refusal.detail` alone would drop the diagnosis the translation just
 moved off it.
+
+## Pi keeps diagnostics on the local side of protocol 8
+
+Pi uses the same split in [`pi/diagnostics.ts`](../apps/tuval/src/pi/diagnostics.ts):
+`retaining` assigns the original thrown value to the JavaScript `Error.cause` slot, outside the
+schema fields. The client and session host translate exceptions into deliberate operation text;
+[`pi/ai-agent/refusals.ts`](../apps/tuval/src/pi/ai-agent/refusals.ts) translates their typed
+refusals again at the generic agent boundary. `failureOf` projects only tag, reason and message
+into checkpoint data. Listing has its own boundary: `session-list.ts` projects the typed error's
+message into `unreadable`, not its cause.
+
+At the `@earendil-works/pi-client@0.85.1` pin, `dist/errors.js` exports `ServerError` with a `code`,
+`DisconnectedError` and `ClientDisposedError`. The client adapter tests these actual classes;
+`session_locked` and `not_found` are the owned dispatch's stable codes. They preserve locked,
+missing-session and disconnected guidance. Unknown codes and arbitrary exception text earn only
+the operation sentence, never inferred authentication or billing advice.
+
+Protocol 8's opaque service payload does not make local exceptions wire data. The owned
+[`dispatch.ts`](../apps/tuval/src/pi/server/dispatch.ts) logs refused create, resume and session
+calls with their retained error, then answers only an owned code and deliberate sentence. The
+session host's working directory and original exception never become the response message.
+Framing errors follow the same split: the local classifier retains the pinned
+`@earendil-works/pi-protocol@0.85.1` `dist/framing.js` literal `Frame length … exceeds configured
+limit of …` to preserve the oversized-frame close code. The close reason is fixed text; the
+original decoder error stays in the local log. This internal framing classification adds no
+user-facing diagnosis from exception text.
+
+`StoreRead.failures` and `StoreDirs.failures` carry optional local causes. Their sole production
+consumer is `PiAiAgent.ts`: successful reads return only sessions, partial failures log locally,
+and total failures retain the diagnostic array as `ListError.cause` or `TranscriptError.cause`.
+No caller serializes the whole store result or its diagnostic array. The generic list schema,
+checkpoint projection and dispatch codec regressions pin these distinct boundaries; neither a
+schema field nor a protocol payload may acquire `cause` to transport those diagnostics.

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -619,6 +619,15 @@ const make = (
 			query: TranscriptQuery,
 		) {
 			const stores = yield* piSessionDirs({agentDir, tuvalDir: sessionDir(query.cwd)});
+			yield* Effect.forEach(
+				stores.failures,
+				(failure) =>
+					Effect.logWarning(
+						`Pi could not enumerate the ${failure.store} store while reading a stored transcript`,
+						failure.cause,
+					),
+				{concurrency: 1, discard: true},
+			);
 			const file = yield* locateBranch(stores.dirs, query.sessionId);
 			if (file === null) {
 				// A store that would not enumerate may be the one the file was in, so a miss across the

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -46,7 +46,6 @@ import type {
 import {sameModel} from "../../ai-agent/ports/index.ts";
 import {
 	type AgentEvent,
-	ListError,
 	ModelUnsupported,
 	ModeUnsupported,
 	PageError,
@@ -60,6 +59,7 @@ import {
 	UnknownRequest,
 } from "../../ai-agent/service/index.ts";
 import {PiClientService, type PiSessionRef} from "../client/index.ts";
+import {retaining} from "../diagnostics.ts";
 import {
 	agentSessionHostLayer,
 	defaultSessionDir,
@@ -84,6 +84,7 @@ import {
 	promptErrorOf,
 	promptFailureOf,
 	startErrorOf,
+	storeUnlistable,
 	storeUnreadable,
 	transcriptSessionMissing,
 	transcriptUnknownCursor,
@@ -325,10 +326,7 @@ const make = (
 			pi.setThinkingLevel(sessionId, level).pipe(
 				Effect.map((answered) => answered.thinkingLevel),
 				Effect.catch((refusal) =>
-					Effect.as(
-						Effect.logWarning(`the thinking switch was refused: ${refusal.message}`),
-						fallback,
-					),
+					Effect.as(Effect.logWarning("the Pi thinking switch was refused", refusal), fallback),
 				),
 			);
 
@@ -345,10 +343,7 @@ const make = (
 			pi.setModel(sessionId, selection).pipe(
 				Effect.map((answered) => answered.model),
 				Effect.catch((refusal) =>
-					Effect.as(
-						Effect.logWarning(`the model switch was refused: ${refusal.message}`),
-						fallback,
-					),
+					Effect.as(Effect.logWarning("the Pi model switch was refused", refusal), fallback),
 				),
 			);
 
@@ -484,6 +479,7 @@ const make = (
 			yield* Effect.forkIn(
 				pi.prompt(current.id, text).pipe(
 					Effect.mapError(promptErrorOf),
+					Effect.tapError((refusal) => Effect.logWarning("Pi send failed", refusal)),
 					// A send that never landed is not a turn this session has seen, so the key goes
 					// back and a retry of it is admitted.
 					Effect.tapError(() => (key === undefined ? Effect.void : Ref.update(keys, without(key)))),
@@ -510,6 +506,7 @@ const make = (
 			const current = yield* Ref.get(session);
 			if (current === null) return;
 			yield* pi.abort(current.id).pipe(
+				Effect.tapError((refusal) => Effect.logWarning("Pi interrupt failed", refusal)),
 				Effect.asVoid,
 				// `interrupt` declares no error channel, so the refusal rides the stream as a tag the
 				// fold routes on its own (ADR 0356) — a log line left the window unable to tell a
@@ -628,10 +625,7 @@ const make = (
 				// rest is not the claim that the session is gone.
 				return yield* stores.failures.length === 0
 					? transcriptSessionMissing(query.sessionId)
-					: transcriptUnreadable(
-							query.sessionId,
-							stores.failures.map((failure) => `${failure.store}: ${failure.detail}`).join("; "),
-						);
+					: transcriptUnreadable(query.sessionId, stores.failures);
 			}
 			const entries = yield* Effect.try({
 				try: () => SessionManager.open(file, dirname(file), query.cwd).getBranch(),
@@ -675,15 +669,13 @@ const make = (
 				read.failures,
 				(failure) =>
 					Effect.logWarning(
-						`the ${failure.store} Pi session store could not be read: ${failure.detail}`,
+						`the ${failure.store} Pi session store could not be read`,
+						failure.cause,
 					),
 				{concurrency: 1, discard: true},
 			);
 			if (read.answered.length === 0) {
-				return yield* new ListError({
-					reason: "store-unreadable",
-					detail: read.failures.map((failure) => `${failure.store}: ${failure.detail}`).join("; "),
-				});
+				return yield* storeUnlistable(read.failures);
 			}
 			return read.sessions;
 		}).pipe(Effect.withSpan("TuvalAiAgent.listSessions"));
@@ -769,7 +761,14 @@ const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost> =>
 						authPath: join(agentDir, "auth.json"),
 						modelsPath: join(agentDir, "models.json"),
 					}),
-				catch: (cause) => new ModelRuntimeUnavailable({agentDir, detail: String(cause)}),
+				catch: (cause) =>
+					retaining(
+						cause,
+						new ModelRuntimeUnavailable({
+							agentDir,
+							detail: "Pi could not initialize its model runtime",
+						}),
+					),
 			}).pipe(Effect.orDie);
 			return agentSessionHostLayer({
 				modelRuntime,

--- a/apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/interrupt-refusal.unit.test.ts
@@ -119,7 +119,8 @@ describe("a Pi abort the server refuses", () => {
 				const failure = failureOf(yield* collectTo(events, "the refused abort", isFailure));
 				assert.strictEqual(failure.tag, "tuval/ai-agent/InterruptError");
 				assert.strictEqual(failure.reason, "turn-running");
-				assert.include(failure.detail, "the session is not yours");
+				assert.include(failure.detail, "another connection holds the session");
+				assert.notInclude(failure.detail, "the session is not yours");
 			}).pipe(Effect.provide(aiAgentOverClient().pipe(Layer.provide(client.layer))), Effect.scoped);
 		}),
 	);

--- a/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
@@ -7,11 +7,11 @@
  * are fixture directories, written the way `sessions.unit.test.ts` writes them.
  */
 
-import {mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
+import {appendFileSync, mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Schema, Stream} from "effect";
+import {Effect, Layer, Logger, Schema, Stream} from "effect";
 import {ListError, TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {type PiClientApi, PiClientService} from "../client/index.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
@@ -88,6 +88,58 @@ describe("the Pi layer's listSessions", () => {
 			assert.isTrue(causes.every((failure) => failure.cause instanceof Error));
 			assert.notInclude(JSON.stringify(Schema.encodeSync(ListError)(error)), agentDir);
 			assert.notInclude(JSON.stringify(Schema.encodeSync(ListError)(error)), projectRoot);
+		}),
+	);
+});
+
+describe("Pi stored transcript partial success", () => {
+	it.effect("keeps the readable transcript and logs the original failed-store error locally", () =>
+		Effect.gen(function* () {
+			const agentDir = temp();
+			const projectRoot = temp();
+			const brokenStore = join(agentDir, "sessions");
+			writeFileSync(brokenStore, "not a directory\n");
+			const directory = join(projectRoot, ".tuval", "pi-sessions");
+			writeSession(directory, "stored", projectRoot, 20);
+			appendFileSync(
+				join(directory, `${at(20).replace(/[:.]/g, "-")}_stored.jsonl`),
+				`${JSON.stringify({
+					type: "message",
+					id: "first",
+					parentId: null,
+					timestamp: at(21),
+					message: {role: "user", content: "Readable transcript", timestamp: Date.parse(at(21))},
+				})}\n`,
+			);
+			const logged: unknown[] = [];
+			const page = yield* Effect.flatMap(TuvalAiAgent, (agent) =>
+				agent.sessionTranscript({sessionId: "stored", cwd: projectRoot, before: null, limit: 20}),
+			).pipe(
+				Effect.provide([
+					aiAgentOverClient({agentDir, projectRoot}).pipe(
+						Layer.provide(Layer.succeed(PiClientService, idle)),
+					),
+					Logger.layer([
+						Logger.make(({message}) => {
+							logged.push(message);
+						}),
+					]),
+				]),
+			);
+			assert.include(JSON.stringify(page), "Readable transcript");
+			assert.notInclude(JSON.stringify(page), brokenStore);
+			assert.notInclude(JSON.stringify(page), "ENOTDIR");
+			const log = logged.find(
+				(line) =>
+					Array.isArray(line) &&
+					line[0] === "Pi could not enumerate the pi-cli store while reading a stored transcript",
+			);
+			assert.isArray(log);
+			const cause = (log as unknown[])[1];
+			assert.isTrue(cause instanceof Error);
+			assert.propertyVal(cause, "code", "ENOTDIR");
+			assert.propertyVal(cause, "path", brokenStore);
+			assert.propertyVal(cause, "syscall", "scandir");
 		}),
 	);
 });

--- a/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/lists-sessions.unit.test.ts
@@ -11,7 +11,7 @@ import {mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Stream} from "effect";
+import {Effect, Layer, Schema, Stream} from "effect";
 import {ListError, TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {type PiClientApi, PiClientService} from "../client/index.ts";
 import {aiAgentOverClient} from "./PiAiAgent.ts";
@@ -82,6 +82,12 @@ describe("the Pi layer's listSessions", () => {
 
 			assert.isTrue(error instanceof ListError);
 			assert.strictEqual(error.reason, "store-unreadable");
+			assert.strictEqual(error.detail, "Pi could not enumerate the session stores");
+			assert.isArray(error.cause);
+			const causes = error.cause as ReadonlyArray<{cause?: unknown}>;
+			assert.isTrue(causes.every((failure) => failure.cause instanceof Error));
+			assert.notInclude(JSON.stringify(Schema.encodeSync(ListError)(error)), agentDir);
+			assert.notInclude(JSON.stringify(Schema.encodeSync(ListError)(error)), projectRoot);
 		}),
 	);
 });

--- a/apps/tuval/src/pi/ai-agent/refusals.ts
+++ b/apps/tuval/src/pi/ai-agent/refusals.ts
@@ -1,15 +1,8 @@
-/**
- * The client's four refusals → the interface's per-method errors.
- *
- * Founder ruling 3 (#7570) keys an error class to the method that raises it and enumerates the
- * cases inside it, so `SessionLocked`, `SessionNotFound`, `Disconnected` and `Refused` are not
- * tags on this side of the seam — they are `reason`s. This module is the whole translation, so a
- * `tuval/pi/client/*` error never reaches a caller of `TuvalAiAgent`.
- */
-
+/** Pi refusals become operation-specific generic errors; causes stay local (see backend-exception-translation.md). */
 import type {AgentFailure} from "../../ai-agent/events.ts";
 import {
 	InterruptError,
+	ListError,
 	PageError,
 	PromptError,
 	StartError,
@@ -17,112 +10,113 @@ import {
 	TransportError,
 } from "../../ai-agent/service/index.ts";
 import type {ConnectionRefusal, Disconnected, SessionRefusal} from "../client/index.ts";
+import {retaining} from "../diagnostics.ts";
 
-export const startErrorOf = (
-	cwd: string,
-	refusal: SessionRefusal | ConnectionRefusal,
-): StartError => {
+type Refusal = SessionRefusal | ConnectionRefusal;
+const detail = (operation: string, refusal: Refusal): string => {
 	switch (refusal._tag) {
 		case "tuval/pi/client/SessionNotFound":
-			return new StartError({reason: "session-not-found", cwd, detail: refusal.detail});
+			return `${operation}: the session is no longer available`;
 		case "tuval/pi/client/SessionLocked":
-			return new StartError({reason: "session-locked", cwd, detail: refusal.detail});
+			return `${operation}: another connection holds the session`;
 		case "tuval/pi/client/Disconnected":
-			return new StartError({reason: "transport", cwd, detail: refusal.detail});
+			return `${operation}: the Pi connection closed; reopen the session to reconnect`;
 		case "tuval/pi/client/ProtocolRefused":
-			return new StartError({reason: "refused", cwd, detail: `${refusal.code}: ${refusal.detail}`});
+			return `${operation}: the Pi server refused the request`;
 	}
 };
-
-export const promptErrorOf = (refusal: SessionRefusal): PromptError => {
-	switch (refusal._tag) {
-		case "tuval/pi/client/SessionNotFound":
-			return new PromptError({reason: "no-session", detail: refusal.detail});
-		case "tuval/pi/client/Disconnected":
-			return new PromptError({reason: "disconnected", detail: refusal.detail});
-		// A lease another connection holds refuses this send the same way a protocol code does:
-		// the session is there and it said no, which is `refused` rather than `no-session`.
-		case "tuval/pi/client/SessionLocked":
-			return new PromptError({reason: "refused", detail: refusal.detail});
-		case "tuval/pi/client/ProtocolRefused":
-			return new PromptError({reason: "refused", detail: `${refusal.code}: ${refusal.detail}`});
-	}
-};
-
-export const transportErrorOf = (dropped: Disconnected): TransportError =>
-	new TransportError({reason: "disconnected", detail: dropped.detail});
-
-/**
- * A refused send, as the plain failure the event stream carries.
- *
- * `prompt` returns at the send (#8018), so by the time the pin refuses one there is no caller left
- * holding a `PromptError` channel and the event stream is the only outbound channel the layer
- * still owns. It rides that stream as a `failure` event rather than failing the queue: the session
- * is still there and the next turn still has to reach the window. Only a lost transport ends the
- * stream, and `transportErrorOf` is the one that does it.
- */
+export const startErrorOf = (cwd: string, refusal: Refusal): StartError =>
+	retaining(
+		refusal,
+		new StartError({
+			cwd,
+			detail: detail("Pi could not start or resume the session", refusal),
+			reason:
+				refusal._tag === "tuval/pi/client/SessionNotFound"
+					? "session-not-found"
+					: refusal._tag === "tuval/pi/client/SessionLocked"
+						? "session-locked"
+						: refusal._tag === "tuval/pi/client/Disconnected"
+							? "transport"
+							: "refused",
+		}),
+	);
+export const promptErrorOf = (refusal: SessionRefusal): PromptError =>
+	retaining(
+		refusal,
+		new PromptError({
+			detail: detail("Pi could not send the message", refusal),
+			reason:
+				refusal._tag === "tuval/pi/client/SessionNotFound"
+					? "no-session"
+					: refusal._tag === "tuval/pi/client/Disconnected"
+						? "disconnected"
+						: "refused",
+		}),
+	);
+export const transportErrorOf = (refusal: Disconnected): TransportError =>
+	retaining(
+		refusal,
+		new TransportError({
+			reason: "disconnected",
+			detail: "Pi stopped receiving session updates; reopen the session to reconnect",
+		}),
+	);
 export const promptFailureOf = (refusal: PromptError): AgentFailure => ({
 	tag: refusal._tag,
 	reason: refusal.reason,
 	detail: refusal.message,
 });
-
 export const storeUnreadable = (cause: unknown): PageError =>
-	new PageError({
-		reason: "store-unreadable",
-		detail: cause instanceof Error ? cause.message : String(cause),
-	});
-
-/**
- * The three ways a *stored* session's transcript does not come back (#8233).
- *
- * `transcriptSessionMissing` is the one `storeUnreadable` above cannot say. `page` reads the file
- * of a session the layer already holds, so a missing file there is a broken store; the store read
- * is handed an id off a listing and a file that is nowhere is the ordinary answer that the session
- * is gone — which a caller must be able to tell from a store it could not enumerate.
- */
+	retaining(
+		cause,
+		new PageError({
+			reason: "store-unreadable",
+			detail: "Pi could not read this session's history page",
+		}),
+	);
+export const storeUnlistable = (cause: unknown): ListError =>
+	retaining(
+		cause,
+		new ListError({
+			reason: "store-unreadable",
+			detail: "Pi could not enumerate the session stores",
+		}),
+	);
 export const transcriptSessionMissing = (sessionId: string): TranscriptError =>
 	new TranscriptError({
 		reason: "session-not-found",
 		sessionId,
 		detail: "neither of Pi's session stores holds a file for this id",
 	});
-
 export const transcriptUnreadable = (sessionId: string, cause: unknown): TranscriptError =>
-	new TranscriptError({
-		reason: "store-unreadable",
-		sessionId,
-		detail: cause instanceof Error ? cause.message : String(cause),
-	});
-
+	retaining(
+		cause,
+		new TranscriptError({
+			reason: "store-unreadable",
+			sessionId,
+			detail: "Pi could not read the stored session transcript",
+		}),
+	);
 export const transcriptUnknownCursor = (sessionId: string, reason: string): TranscriptError =>
 	new TranscriptError({reason: "unknown-cursor", sessionId, detail: reason});
-
-/**
- * A send refused because the socket is gone, as the terminal failure that ends the event stream.
- *
- * The one refusal that takes the exit `follow` takes on `pi.disconnections`, and for the same
- * reason: nothing dials again, so leaving the stream open would leave a window waiting on a
- * transport that is not coming back. The way back in is another `start({cwd, resume})`.
- */
 export const promptDropOf = (refusal: PromptError): TransportError =>
-	new TransportError({reason: "disconnected", detail: refusal.detail});
-
-/**
- * A refused abort, as the plain failure the event stream carries (ADR 0356).
- *
- * `interrupt` keeps `Effect.Effect<void>`, so no caller is left to raise to and the stream is the
- * only outbound channel this layer still owns. It rides as an event rather than failing the queue
- * for `promptFailureOf`'s reason: the session is still there and every later turn still has to
- * reach the window.
- *
- * `turnRunning` is the half only this layer can answer, and the fold routes on it. Pi says nothing
- * about it in the refusal itself, so it comes from the session projection's own phase.
- */
+	retaining(
+		refusal,
+		new TransportError({
+			reason: "disconnected",
+			detail:
+				"Pi could not send the message because the connection closed; reopen the session to reconnect",
+		}),
+	);
+/** Refused interrupts remain nonterminal events; turnRunning remains the fold's transition discriminant. */
 export const interruptFailureOf = (refusal: SessionRefusal, turnRunning: boolean): AgentFailure => {
-	const error = new InterruptError({
-		reason: turnRunning ? "turn-running" : "no-live-turn",
-		detail: refusal.message,
-	});
+	const error = retaining(
+		refusal,
+		new InterruptError({
+			reason: turnRunning ? "turn-running" : "no-live-turn",
+			detail: detail("Pi could not interrupt the turn", refusal),
+		}),
+	);
 	return {tag: error._tag, reason: error.reason, detail: error.message};
 };

--- a/apps/tuval/src/pi/ai-agent/sessions.ts
+++ b/apps/tuval/src/pi/ai-agent/sessions.ts
@@ -33,6 +33,7 @@ export type PiSessionStore = "pi-cli" | "tuval";
 export interface StoreFailure {
 	readonly store: PiSessionStore;
 	readonly detail: string;
+	readonly cause?: unknown;
 }
 
 export interface StoreRead {
@@ -49,9 +50,6 @@ export interface PiSessionStores {
 	/** Tuval's own store, or absent when this layer has no project root to locate one under. */
 	readonly tuvalDir?: string | undefined;
 }
-
-const detailOf = (cause: unknown): string =>
-	cause instanceof Error ? cause.message : String(cause);
 
 /** What the pin writes as `firstMessage` for a session holding none. An absence, not a prompt. */
 const NO_MESSAGES = "(no messages)";
@@ -98,7 +96,7 @@ const leavesOf = (
 				.filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
 				.map((entry) => join(root, entry.name));
 		},
-		catch: (cause) => ({store, detail: detailOf(cause)}),
+		catch: (cause) => ({store, detail: "Pi could not read the session store", cause}),
 	});
 
 /** Every directory the stores keep `.jsonl` files in, beside the stores that would not answer. */
@@ -154,7 +152,11 @@ const readStore = (store: PiSessionStore, root: string): Effect.Effect<StoreAnsw
 				(leaf) =>
 					Effect.tryPromise({
 						try: () => SessionManager.listAll(leaf),
-						catch: (cause): StoreFailure => ({store, detail: detailOf(cause)}),
+						catch: (cause): StoreFailure => ({
+							store,
+							detail: "Pi could not read the session store",
+							cause,
+						}),
 					}),
 				// Independent directory reads, and the result order is the input's either way.
 				{concurrency: "unbounded"},

--- a/apps/tuval/src/pi/client/refusals.ts
+++ b/apps/tuval/src/pi/client/refusals.ts
@@ -9,6 +9,7 @@
  */
 
 import {ClientDisposedError, DisconnectedError, ServerError} from "@earendil-works/pi-client";
+import {retaining} from "../diagnostics.ts";
 import {
 	type ConnectionRefusal,
 	Disconnected,
@@ -18,29 +19,42 @@ import {
 	type SessionRefusal,
 } from "./errors.ts";
 
-const detailOf = (cause: unknown): string =>
-	cause instanceof Error ? cause.message : String(cause);
-
 const isConnectionLoss = (cause: unknown): boolean =>
 	cause instanceof DisconnectedError || cause instanceof ClientDisposedError;
 
 /** The refusal for a call that names no session: connect, reconnect, create. */
 export const connectionRefusalOf = (cause: unknown): ConnectionRefusal => {
-	if (isConnectionLoss(cause)) return new Disconnected({detail: detailOf(cause)});
+	if (isConnectionLoss(cause))
+		return retaining(cause, new Disconnected({detail: "the Pi connection ended"}));
 	if (cause instanceof ServerError) {
-		return new ProtocolRefused({code: cause.code, detail: detailOf(cause)});
+		return retaining(
+			cause,
+			new ProtocolRefused({code: cause.code, detail: "the Pi server refused the request"}),
+		);
 	}
-	return new ProtocolRefused({code: "internal_error", detail: detailOf(cause)});
+	return retaining(
+		cause,
+		new ProtocolRefused({
+			code: "internal_error",
+			detail: "the Pi client could not complete the request",
+		}),
+	);
 };
 
 /** The refusal for a call that names a session: attach, prompt. */
 export const sessionRefusalOf = (sessionId: string, cause: unknown): SessionRefusal => {
 	if (cause instanceof ServerError) {
 		if (cause.code === "session_locked") {
-			return new SessionLocked({sessionId, detail: detailOf(cause)});
+			return retaining(
+				cause,
+				new SessionLocked({sessionId, detail: "another connection holds this session"}),
+			);
 		}
 		if (cause.code === "not_found") {
-			return new SessionNotFound({sessionId, detail: detailOf(cause)});
+			return retaining(
+				cause,
+				new SessionNotFound({sessionId, detail: "the Pi server could not find this session"}),
+			);
 		}
 	}
 	return connectionRefusalOf(cause);

--- a/apps/tuval/src/pi/diagnostics.ts
+++ b/apps/tuval/src/pi/diagnostics.ts
@@ -1,0 +1,5 @@
+/** Local exception retention; see .patterns/backend-exception-translation.md. */
+export const retaining = <E extends Error>(cause: unknown, error: E): E => {
+	error.cause = cause;
+	return error;
+};

--- a/apps/tuval/src/pi/server/AgentSessionHost.ts
+++ b/apps/tuval/src/pi/server/AgentSessionHost.ts
@@ -20,6 +20,7 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import {Effect, Layer, Queue} from "effect";
+import {retaining} from "../diagnostics.ts";
 import type {ModelMetadata, ModelRef, ThinkingLevel} from "../wire/index.ts";
 import {projectModelCost, type SourceModelCost} from "./cost.ts";
 import {SessionCallFailed, SessionOpenFailed} from "./errors.ts";
@@ -58,9 +59,6 @@ const allThinkingLevels: ReadonlyArray<ThinkingLevel> = [
 	"xhigh",
 	"max",
 ];
-
-const detailOf = (error: unknown): string =>
-	error instanceof Error ? error.message : String(error);
 
 /**
  * Where a session's JSONL lands. Exported because it is a convention two modules share: this host
@@ -124,11 +122,14 @@ const call = <A>(
 			await run();
 		},
 		catch: (error) =>
-			new SessionCallFailed({
-				sessionId: session.sessionId,
-				call: name,
-				detail: detailOf(error),
-			}),
+			retaining(
+				error,
+				new SessionCallFailed({
+					sessionId: session.sessionId,
+					call: name,
+					detail: "the Pi session did not complete the operation",
+				}),
+			),
 	});
 
 /**
@@ -258,7 +259,11 @@ export const layer = (options: AgentSessionHostOptions): Layer.Layer<PiSessionHo
 							settingsManager: SettingsManager.create(request.cwd, options.agentDir),
 							...(options.noTools === undefined ? {} : {noTools: options.noTools}),
 						}).then((result) => result.session),
-					catch: (error) => new SessionOpenFailed({cwd: request.cwd, detail: detailOf(error)}),
+					catch: (error) =>
+						retaining(
+							error,
+							new SessionOpenFailed({cwd: request.cwd, detail: "Pi could not create the session"}),
+						),
 				});
 
 				if (request.name !== undefined) session.setSessionName(request.name);
@@ -285,9 +290,9 @@ export const layer = (options: AgentSessionHostOptions): Layer.Layer<PiSessionHo
 				const refuse = (detail: string) => new SessionOpenFailed({cwd, detail});
 				const file = yield* Effect.try({
 					try: () => sessionFile(dir, sessionId),
-					catch: (error) => refuse(detailOf(error)),
+					catch: (error) => retaining(error, refuse("Pi could not reopen the stored session")),
 				});
-				if (file === undefined) return yield* refuse(`no session file for ${sessionId} in ${dir}`);
+				if (file === undefined) return yield* refuse("Pi could not find the stored session file");
 
 				const session = yield* Effect.tryPromise({
 					try: () =>
@@ -298,7 +303,7 @@ export const layer = (options: AgentSessionHostOptions): Layer.Layer<PiSessionHo
 							settingsManager: SettingsManager.create(cwd, options.agentDir),
 							...(options.noTools === undefined ? {} : {noTools: options.noTools}),
 						}).then((result) => result.session),
-					catch: (error) => refuse(detailOf(error)),
+					catch: (error) => retaining(error, refuse("Pi could not reopen the stored session")),
 				});
 				return yield* handleOf(options, session, cwd);
 			}),

--- a/apps/tuval/src/pi/server/PiServerService.ts
+++ b/apps/tuval/src/pi/server/PiServerService.ts
@@ -18,6 +18,7 @@ import type {AddressInfo} from "node:net";
 import type {Duplex} from "node:stream";
 import {Context, Effect, FiberSet, Layer, Queue, Redacted, type Scope} from "effect";
 import {type WebSocket, WebSocketServer} from "ws";
+import {retaining} from "../diagnostics.ts";
 import {boundedTeardown} from "../teardown.ts";
 import {
 	type ClientMessage,
@@ -88,7 +89,14 @@ export class PiServerService extends Context.Service<PiServerService, PiServerAp
 const listen = (server: HttpServer, host: string): Effect.Effect<AddressInfo, ServerBindFailed> =>
 	Effect.callback<AddressInfo, ServerBindFailed>((resume) => {
 		const onError = (error: Error): void => {
-			resume(Effect.fail(new ServerBindFailed({host, detail: error.message})));
+			resume(
+				Effect.fail(
+					retaining(
+						error,
+						new ServerBindFailed({host, detail: "the loopback listener could not be opened"}),
+					),
+				),
+			);
 		};
 		server.once("error", onError);
 		server.listen({host, port: 0}, () => {
@@ -214,7 +222,11 @@ const make = (
 				const write = (message: ServerMessage): Effect.Effect<void> =>
 					Effect.try({
 						try: () => encodeServerMessage(message),
-						catch: (cause) => new MessageNotEncodable({detail: detailOf(cause)}),
+						catch: (cause) =>
+							retaining(
+								cause,
+								new MessageNotEncodable({detail: "the Pi response could not be encoded"}),
+							),
 					}).pipe(
 						Effect.flatMap((frame) =>
 							Effect.sync(() => {
@@ -250,12 +262,15 @@ const make = (
 						try: () => decoder.push(bytes),
 						catch: (cause) => {
 							const detail = detailOf(cause);
-							return new FrameRefused({
-								detail,
-								overLengthBound:
-									detail.toLowerCase().includes("length") ||
-									detail.toLowerCase().includes("exceeds"),
-							});
+							return retaining(
+								cause,
+								new FrameRefused({
+									detail: "the Pi client frame could not be decoded",
+									overLengthBound:
+										detail.toLowerCase().includes("length") ||
+										detail.toLowerCase().includes("exceeds"),
+								}),
+							);
 						},
 					});
 
@@ -360,6 +375,7 @@ const make = (
 									discard: true,
 								}),
 							),
+							Effect.tapError((error) => Effect.logWarning("Pi client frame rejected", error)),
 							Effect.catch((error: FrameRefused) =>
 								Effect.sync(() => {
 									closeWith(

--- a/apps/tuval/src/pi/server/dispatch.ts
+++ b/apps/tuval/src/pi/server/dispatch.ts
@@ -109,7 +109,11 @@ const withSession = (
 		Effect.flatMap(() => context.onChanged(sessionId)),
 		Effect.flatMap(() => snapshotOf(context, gate.record)),
 		Effect.map((session): Answer => ({ok: true, result: {command, session}})),
-		Effect.catch((error) => Effect.succeed(internal(error.message))),
+		Effect.catch((error) =>
+			Effect.logWarning("Pi session operation failed", error).pipe(
+				Effect.as(internal(`Pi could not complete ${command}`)),
+			),
+		),
 	);
 };
 
@@ -152,7 +156,11 @@ export const dispatch = (
 							result: {command: "create", session, attachmentId},
 						}),
 					),
-					Effect.catch((error) => Effect.succeed(internal(error.message))),
+					Effect.catch((error) =>
+						Effect.logWarning("Pi session creation failed", error).pipe(
+							Effect.as(internal("Pi could not create the session")),
+						),
+					),
 				);
 		}
 
@@ -177,7 +185,11 @@ export const dispatch = (
 							result: {command: "attach", session, attachmentId},
 						}),
 					),
-					Effect.orElseSucceed(() => notFound(command.sessionId)),
+					Effect.catch((error) =>
+						Effect.logWarning("Pi session resume failed", error).pipe(
+							Effect.as(notFound(command.sessionId)),
+						),
+					),
 				);
 			}
 			if (outcome._tag === "Locked") return Effect.succeed(locked(command.sessionId));

--- a/apps/tuval/src/pi/server/exception-translation.unit.test.ts
+++ b/apps/tuval/src/pi/server/exception-translation.unit.test.ts
@@ -1,0 +1,82 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {retaining} from "../diagnostics.ts";
+import {createServerMessageDecoder, encodeServerMessage} from "../wire/codec.ts";
+import {type DispatchContext, dispatch} from "./dispatch.ts";
+import {SessionCallFailed, SessionOpenFailed} from "./errors.ts";
+import {makeScriptedHost} from "./fixtures.ts";
+import {PiSessionHost} from "./PiSessionHost.ts";
+import {makeSessionRecords} from "./records.ts";
+
+const privateDetail = "SYNTHETIC-PRIVATE-DIAGNOSTIC-8509";
+const original = new Error(privateDetail);
+const serverId = "00000000-0000-4000-8000-000000000001";
+
+describe("Pi exception boundary before protocol 8 encoding", () => {
+	it.effect("logs local create/resume/call failures while encoding only deliberate refusals", () =>
+		Effect.gen(function* () {
+			const host = yield* PiSessionHost;
+			const opened = yield* host.open({cwd: "/workspace"});
+			const failedCall = retaining(
+				original,
+				new SessionCallFailed({sessionId: opened.id, call: "prompt", detail: privateDetail}),
+			);
+			const failedOpen = retaining(
+				original,
+				new SessionOpenFailed({cwd: privateDetail, detail: privateDetail}),
+			);
+			const records = makeSessionRecords();
+			records.insert(
+				{...opened, prompt: () => Effect.fail(failedCall)},
+				"connection",
+				"attachment",
+				0,
+			);
+			const context: DispatchContext = {
+				connection: "connection",
+				serverId,
+				records,
+				now: () => 0,
+				onChanged: () => Effect.void,
+				host: {...host, open: () => Effect.fail(failedOpen), resume: () => Effect.fail(failedOpen)},
+			};
+			const cases = [
+				{
+					target: {serverId},
+					command: {command: "create", cwd: "/workspace"},
+					code: "internal_error",
+					message: "Pi could not create the session",
+				},
+				{
+					target: {serverId},
+					command: {command: "attach", sessionId: "missing"},
+					code: "not_found",
+					message: "no session missing",
+				},
+				{
+					target: {serverId, sessionId: opened.id, attachmentId: "attachment"},
+					command: {command: "prompt", sessionId: opened.id, text: "hello"},
+					code: "internal_error",
+					message: "Pi could not complete prompt",
+				},
+			] as const;
+			for (const entry of cases) {
+				const answer = yield* dispatch(context, entry.target, entry.command);
+				assert.isFalse(answer.ok);
+				if (answer.ok) continue;
+				assert.deepStrictEqual(answer.error, {code: entry.code, message: entry.message});
+				const encoded = encodeServerMessage({
+					type: "response",
+					id: "failure",
+					ok: false,
+					error: answer.error,
+				});
+				const decoded = createServerMessageDecoder().push(encoded);
+				assert.notInclude(JSON.stringify(decoded), privateDetail);
+				assert.strictEqual(decoded.length, 1);
+			}
+			assert.strictEqual(failedOpen.cause, original);
+			assert.strictEqual(failedCall.cause, original);
+		}).pipe(Effect.provide(makeScriptedHost().layer)),
+	);
+});

--- a/apps/tuval/src/pi/window/exception-translation.unit.test.tsx
+++ b/apps/tuval/src/pi/window/exception-translation.unit.test.tsx
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+import {ClientDisposedError, DisconnectedError, ServerError} from "@earendil-works/pi-client";
+import {render, screen} from "@testing-library/react";
+import {Effect, Schema} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {failureOf} from "../../ai-agent/handlers/failures.ts";
+import {TranscriptError} from "../../ai-agent/service/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {chatWindow} from "../../shell/chat/ChatWindow.tsx";
+import {sessionState} from "../../shell/chat/chat.testing.ts";
+import {type ChatView, initialChatView} from "../../shell/chat/view.ts";
+import {installDomShims} from "../../shell/ui/dom.testing.ts";
+import {testProcess} from "../../shell/window/fixtures.ts";
+import {WindowId} from "../../shell/window/index.ts";
+import {
+	interruptFailureOf,
+	promptDropOf,
+	promptErrorOf,
+	promptFailureOf,
+	startErrorOf,
+	storeUnlistable,
+	storeUnreadable,
+	transcriptUnreadable,
+	transportErrorOf,
+} from "../ai-agent/refusals.ts";
+import {Disconnected, ProtocolRefused} from "../client/errors.ts";
+import {connectionRefusalOf, sessionRefusalOf} from "../client/refusals.ts";
+
+installDomShims();
+const sentinel = "SYNTHETIC-PRIVATE-DIAGNOSTIC-8509";
+const thrown = new Error(sentinel);
+
+describe("Pi exception translation into checkpointed/rendered failure data", () => {
+	it.each([
+		thrown,
+		sentinel,
+		{detail: sentinel},
+	])("keeps an arbitrary cause local at every generic operation: %j", (cause) => {
+		const client = connectionRefusalOf(cause);
+		expect(client.cause).toBe(cause);
+		expect(client.detail).not.toContain(sentinel);
+		const start = startErrorOf("/workspace", client);
+		const prompt = promptErrorOf(client);
+		const errors = [
+			start,
+			prompt,
+			storeUnreadable(cause),
+			promptDropOf(prompt),
+			transportErrorOf(new Disconnected({detail: sentinel})),
+		];
+		for (const error of errors) {
+			expect(error.cause).toBeDefined();
+			expect(error.detail).toContain("Pi");
+			expect(JSON.stringify(failureOf(error))).not.toContain(sentinel);
+		}
+		expect(storeUnlistable([{store: "tuval", cause}]).cause).toEqual([{store: "tuval", cause}]);
+		expect(start.cause).toBe(client);
+		expect(prompt.cause).toBe(client);
+		expect(storeUnreadable(cause).cause).toBe(cause);
+		expect(transcriptUnreadable("session", cause).cause).toBe(cause);
+		expect(
+			JSON.stringify(Schema.encodeSync(TranscriptError)(transcriptUnreadable("session", cause))),
+		).not.toContain(sentinel);
+		expect(JSON.stringify(promptFailureOf(prompt))).not.toContain(sentinel);
+		expect(JSON.stringify(interruptFailureOf(client, true))).not.toContain(sentinel);
+		expect(interruptFailureOf(client, false).reason).toBe("no-live-turn");
+	});
+
+	it("routes only pinned classes and owned codes, never text that resembles a diagnosis", () => {
+		expect(connectionRefusalOf(new DisconnectedError(sentinel))._tag).toBe(
+			"tuval/pi/client/Disconnected",
+		);
+		expect(connectionRefusalOf(new ClientDisposedError())._tag).toBe(
+			"tuval/pi/client/Disconnected",
+		);
+		for (const [code, reason] of [
+			["session_locked", "session-locked"],
+			["not_found", "session-not-found"],
+		] as const) {
+			const original = new ServerError({code, message: sentinel});
+			const refusal = sessionRefusalOf("session", original);
+			expect(refusal.cause).toBe(original);
+			expect(startErrorOf("/workspace", refusal).reason).toBe(reason);
+		}
+		const impostor = new Error(`session_locked invalid API key billing ${sentinel}`);
+		expect(startErrorOf("/workspace", connectionRefusalOf(impostor)).detail).toBe(
+			"Pi could not start or resume the session: the Pi server refused the request",
+		);
+		const unknown = new ProtocolRefused({code: sentinel, detail: sentinel});
+		expect(JSON.stringify(failureOf(promptErrorOf(unknown)))).not.toContain(sentinel);
+	});
+
+	it("renders only the deliberate failure and checkpoints no local diagnostic", async () => {
+		const refusal = connectionRefusalOf(thrown);
+		const error = startErrorOf("/workspace", refusal);
+		const state = sessionState({phase: "idle", failure: failureOf(error)});
+		expect(JSON.stringify(state)).not.toContain(sentinel);
+		expect(error.cause).toBe(refusal);
+		expect(refusal.cause).toBe(thrown);
+		const process = await Effect.runPromise(
+			testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("exception"), state),
+		);
+		const host = await Effect.runPromise(
+			process.window<ChatView>(WindowId.make("exception"), initialChatView),
+		);
+		render(chatWindow({scrollToFn: () => {}}).render(host) as ReactElement);
+		expect(screen.getByText(/Pi could not start or resume the session/)).toBeDefined();
+		expect(document.body.textContent).not.toContain(sentinel);
+	});
+});

--- a/apps/tuval/src/pi/window/proof/exception.html
+++ b/apps/tuval/src/pi/window/proof/exception.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Pi live exception proof</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./exception.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/pi/window/proof/exception.tsx
+++ b/apps/tuval/src/pi/window/proof/exception.tsx
@@ -1,0 +1,39 @@
+/** The existing chat window fed through production projection/adapter; no model or socket. */
+import {Effect} from "effect";
+import {createRoot} from "react-dom/client";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../../ai-agent/core/index.ts";
+import {failureOf} from "../../../ai-agent/handlers/failures.ts";
+import {ProcessId} from "../../../process/process.ts";
+import {sessionState} from "../../../shell/chat/chat.testing.ts";
+import {type ChatView, initialChatView} from "../../../shell/chat/index.ts";
+import {testProcess} from "../../../shell/window/fixtures.ts";
+import {WindowId} from "../../../shell/window/index.ts";
+import {startErrorOf} from "../../ai-agent/refusals.ts";
+import {connectionRefusalOf} from "../../client/refusals.ts";
+import {piChatWindow} from "../PiChatWindow.tsx";
+import "../../../page/styles.ts";
+import "./proof.css";
+
+const mount = Effect.gen(function* () {
+	const host = document.getElementById("proof");
+	if (host === null) return yield* Effect.die(new Error("Missing proof host"));
+	const process = yield* testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+		ProcessId.make("exception-proof"),
+		sessionState({
+			phase: "idle",
+			failure: failureOf(
+				startErrorOf(
+					"/workspace",
+					connectionRefusalOf(new Error("Synthetic internal diagnostic from the Pi client")),
+				),
+			),
+		}),
+	);
+	const window = yield* process.window<ChatView>(WindowId.make("exception"), initialChatView);
+	createRoot(host).render(
+		<div className="tuval-surface proof-desk" data-scheme="dark">
+			<div className="proof-pane">{piChatWindow().render(window)}</div>
+		</div>,
+	);
+});
+void Effect.runPromise(mount);


### PR DESCRIPTION
Pi exceptions now produce deliberate operation messages for start/resume, sends, interruption, transport and stored history reads. Original thrown values remain local causes or logged diagnostics; dispatch sends only owned refusal codes and safe text across protocol 8. Known class/code guidance preserves existing recovery semantics.

Fixes #8509.

Release containment: none. This local-only Tuval recovery fix is available by default.

Validation: all 2,477 Tuval tests pass across 257 files; affected typecheck/lint and prose checks pass. The new saved-state/render regression fails against the original refusal modules because the synthetic diagnostic enters checkpoint JSON, then passes with the fix. Boundary tests exercise actual session listing and dispatch through the pinned codec, retaining local causes while excluding them from outward data.

Builder hand-verification: inspected before/after 1280×900 captures of `/tuval/pi-window/exception.html`. The before status exposes the synthetic internal diagnostic; the after status shows the deliberate failed-start sentence with no diagnostic. The existing layout and composer remain visible. Captures are attached with `ui evidence`; the committed fixture uses production refusal translation and PiChatWindow. LAW-SOURCE: manifest-prose.

The partial-store transcript regression reads a real successful JSONL transcript beside an unreadable store, checks that the original filesystem error reaches only the local logger, and excludes its path/code from the successful response. The repair capture is byte-identical to the previously inspected after image.

## Deviations

- **Boundary scope** — **Said:** translate arbitrary Pi exception text out of generic errors. **Did:** also fixed the owned dispatch and frame-close text, retaining and logging local causes before wire projection. **Why:** translating only the generic adapter would still send private diagnostics over protocol 8 and would lose causes when dispatch catches and continues. **Disposition:** included as required boundary protection; no new recovery policy.
- **Existing test expectation** — **Said:** preserve interrupt semantics. **Did:** replaced an existing assertion for arbitrary server wording with fixed locked-session guidance and an assertion that the original text is absent. **Why:** the full suite exposed the old leak as an expected value; failure tag and turn-running reason remain asserted. **Disposition:** corrected and the entire suite rerun green.
- **Visual review route** — **Said:** apply build-ui to the copy delta. **Did:** captured and inspected the real production status surface with a synthetic failed-start fixture; independent review uses the open #7306 interim route. **Why:** Tuval has no admissible independent renderer until #7306 lands. **Disposition:** Tuval surface; no admissible renderer until #7306 lands (founder ruling 2026-09-06). Text review PASS + builder hand-verification stand in.

- **Partial-store repair** — **Said:** retain StoreDirs diagnostics even when another store provides the requested transcript. **Did:** added local logging before transcript lookup and an actual mixed-store success regression. **Why:** independent review found the successful fallback discarded the other store’s cause despite the documented convention. **Disposition:** corrected without changing successful response semantics; full suite and affected checks pass.

- **Base integration** — **Said:** ship the reviewed exception translation repair. **Did:** integrated main d07dd507 (Pi delta streaming, PR #8589), resolving the sole PiAiAgent import conflict by retaining both SessionUpdate and retaining. **Why:** main advanced and made the PR conflict before merge. **Disposition:** both intents preserved; full combined-tree suite and affected checks pass, with unchanged visual output.
