### PR TITLE
feat: spawn a pi-subagents subagent from a Tuval Pi row

### DIFF
--- a/apps/tuval/package.json
+++ b/apps/tuval/package.json
@@ -32,6 +32,7 @@
 		"@modelcontextprotocol/sdk": "catalog:",
 		"@tanstack/react-virtual": "catalog:",
 		"effect": "catalog:tuval",
+		"pi-subagents": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:",
 		"react-resizable-panels": "catalog:",

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -116,7 +116,7 @@ describe("the feature flags", () => {
 	it.effect("merge project over global one flag at a time", () =>
 		Effect.gen(function* () {
 			const merged = yield* layered(fixture("features-on"), fixture("two-rows"));
-			assert.deepStrictEqual(merged.features, {subagentList: true});
+			assert.deepStrictEqual(merged.features, {subagentList: true, piSubagents: false});
 		}),
 	);
 
@@ -126,11 +126,11 @@ describe("the feature flags", () => {
 	it.effect("let a layer that states a flag off win over the on default", () =>
 		Effect.gen(function* () {
 			const global = yield* layered(fixture("features-off"), fixture("two-rows"));
-			assert.deepStrictEqual(global.features, {subagentList: false});
+			assert.deepStrictEqual(global.features, {subagentList: false, piSubagents: false});
 			const project = yield* layered(fixture("two-rows"), fixture("features-off"));
-			assert.deepStrictEqual(project.features, {subagentList: false});
+			assert.deepStrictEqual(project.features, {subagentList: false, piSubagents: false});
 			const overGlobalOn = yield* layered(fixture("features-on"), fixture("features-off"));
-			assert.deepStrictEqual(overGlobalOn.features, {subagentList: false});
+			assert.deepStrictEqual(overGlobalOn.features, {subagentList: false, piSubagents: false});
 		}),
 	);
 });
@@ -143,7 +143,7 @@ describe("loadLayeredConfig", () => {
 				const config = yield* layered(fixture("global-layer"), fixture("project-layer"));
 				assert.deepStrictEqual(config, {
 					programs: [{id: "a"}, {id: "b", core: "project"}],
-					features: {subagentList: true},
+					features: {subagentList: true, piSubagents: false},
 					moduleRenderers: [],
 					graph: {
 						nodes: [
@@ -165,7 +165,7 @@ describe("loadLayeredConfig", () => {
 			const missing = fixture("does-not-exist");
 			assert.deepStrictEqual(yield* layered(missing, fixture("with-graph")), {
 				programs: [{id: "a"}],
-				features: {subagentList: true},
+				features: {subagentList: true, piSubagents: false},
 				moduleRenderers: [],
 				graph: {nodes: [{id: NodeId.make("n"), program: ProgramId.make("a"), on: []}]},
 				keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
@@ -173,7 +173,7 @@ describe("loadLayeredConfig", () => {
 			});
 			assert.deepStrictEqual(yield* layered(fixture("two-rows"), missing), {
 				programs: [{id: "a"}, {id: "b"}],
-				features: {subagentList: true},
+				features: {subagentList: true, piSubagents: false},
 				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
@@ -181,7 +181,7 @@ describe("loadLayeredConfig", () => {
 			});
 			assert.deepStrictEqual(yield* layered(missing, missing), {
 				programs: [],
-				features: {subagentList: true},
+				features: {subagentList: true, piSubagents: false},
 				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [],

--- a/apps/tuval/src/features.ts
+++ b/apps/tuval/src/features.ts
@@ -16,6 +16,11 @@ export interface TuvalFeatures {
 	 * one change — a subagent's rows leaving the agent window's transcript (#8405).
 	 */
 	readonly subagentList: boolean;
+	/**
+	 * Load the `pi-subagents` extension into a Pi session, so a Pi row can spawn a subagent (#8555).
+	 * Off: the row opens exactly the session it opened before the flag existed.
+	 */
+	readonly piSubagents: boolean;
 }
 
 /**
@@ -24,4 +29,4 @@ export interface TuvalFeatures {
  * runbook pass, so a flag's entry moves from `false` to `true` in this record and nowhere else. A
  * layer that states a flag still wins over it, in either direction (`./config.ts`'s merge).
  */
-export const featuresDefault: TuvalFeatures = {subagentList: true};
+export const featuresDefault: TuvalFeatures = {subagentList: true, piSubagents: false};

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -70,13 +70,13 @@ describe("the feature-flag module", () => {
 
 	it("carries a flag a layer turned on", async () => {
 		expect(await generated("features-on", "two-rows")).toBe(
-			'export default {\n\t"subagentList": true,\n};\n',
+			'export default {\n\t"subagentList": true,\n\t"piSubagents": false,\n};\n',
 		);
 	});
 
 	it("carries a flag a layer turned off", async () => {
 		expect(await generated("features-off", "two-rows")).toBe(
-			'export default {\n\t"subagentList": false,\n};\n',
+			'export default {\n\t"subagentList": false,\n\t"piSubagents": false,\n};\n',
 		);
 	});
 
@@ -85,7 +85,7 @@ describe("the feature-flag module", () => {
 	// operator who stated nothing would get the flag off.
 	it("carries every flag at its default when no layer declares a features block", async () => {
 		expect(await generated("two-rows", "one-counter")).toBe(
-			'export default {\n\t"subagentList": true,\n};\n',
+			'export default {\n\t"subagentList": true,\n\t"piSubagents": false,\n};\n',
 		);
 	});
 

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -59,6 +59,7 @@ import {
 	type TuvalAiAgentApi,
 	UnknownRequest,
 } from "../../ai-agent/service/index.ts";
+import {featuresDefault} from "../../features.ts";
 import {PiClientService, type PiSessionRef, type SessionUpdate} from "../client/index.ts";
 import {
 	agentSessionHostLayer,
@@ -68,6 +69,7 @@ import {
 	PiServerService,
 	type PiSessionHost,
 	type ServerBindFailed,
+	subagentExtensionPaths,
 } from "../server/index.ts";
 import {planPageOverEntries} from "./entries.ts";
 import {
@@ -776,9 +778,14 @@ const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost> =>
 					}),
 				catch: (cause) => new ModelRuntimeUnavailable({agentDir, detail: String(cause)}),
 			}).pipe(Effect.orDie);
+			// The `piSubagents` flag and nothing else decides this. Off — the shipped default — it is
+			// an empty list, and an empty list is the same session this layer opened before the flag
+			// existed (`../server/AgentSessionHost.ts`'s `loaderFor`).
+			const extensionPaths = subagentExtensionPaths(featuresDefault);
 			return agentSessionHostLayer({
 				modelRuntime,
 				agentDir,
+				...(extensionPaths.length === 0 ? {} : {extensionPaths}),
 				...(options.sessionDir === undefined ? {} : {sessionDir: options.sessionDir}),
 				...(options.projectRoot === undefined ? {} : {projectRoot: options.projectRoot}),
 				...(options.streamPartialText === undefined

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -153,22 +153,35 @@ export const itemsOf = (item: PiTranscriptItem): ReadonlyArray<TranscriptItem> =
 };
 
 /**
- * The two tools `pi-subagents` registers on the parent session — `subagent`
- * (`pi-subagents` `src/extension/index.ts:750`) and `bg_wait`
- * (`src/runs/background/wait-tool.ts:36`). A call to either is a worker this session started.
+ * Whether one tool call *starts* a worker, which is the only kind the running list draws.
+ *
+ * `pi-subagents` registers two tools and only one of them ever spawns. `subagent` is multiplexed:
+ * its `action` field is documented as the switch — "when present, tool operates in management mode"
+ * (`pi-subagents` `src/extension/schemas.ts:283-287`) — and the executor branches on exactly that,
+ * `if (action) { … }` answering out of the management arm with the spawn path as everything after
+ * it (`src/runs/foreground/subagent-executor.ts:5960,5976`). So any of the 55 actions
+ * (`src/shared/types.ts:2757` — `list`, `status`, `stop`, `steer`, the `schedule.*` and `mission.*`
+ * families) starts nothing, and an `agent` beside one names that action's *target* rather than a
+ * worker. `bg_wait` waits on work that is already running (`src/runs/background/wait-tool.ts:36`)
+ * and starts none of it.
+ *
+ * An input this cannot read draws no row either: a worker the operator cannot find is worse than a
+ * worker the list is missing.
  */
-const SUBAGENT_TOOLS: ReadonlySet<string> = new Set(["subagent", "bg_wait"]);
+const spawns = (toolName: string, input: unknown): boolean =>
+	toolName === "subagent" &&
+	Predicate.isObject(input) &&
+	(input as {readonly action?: unknown}).action === undefined;
 
 /**
- * What kind of worker a call started, in the extension's own words: the `agent` argument, which
- * names one of the configured agents (`pi-subagents` `src/extension/schemas.ts:283`). A call that
- * names none — a `bg_wait`, or a workflow script that picks its own children — is labelled by the
- * tool, because the row has to say something and the tool name is the only true thing left.
+ * What kind of worker the call started, in the extension's own words: the `agent` argument, which
+ * names one of the configured agents (`pi-subagents` `src/extension/schemas.ts:283`). A spawn that
+ * names none — a `workflowScript`, which picks its own children — is labelled by the tool, because
+ * the row has to say something and that is the only true thing left.
  */
-const subagentType = (toolName: string, input: unknown): string => {
-	if (!Predicate.isObject(input)) return toolName;
-	const agent = (input as {readonly agent?: unknown}).agent;
-	return typeof agent === "string" && agent !== "" ? agent : toolName;
+const subagentType = (input: unknown): string => {
+	const agent = Predicate.isObject(input) ? (input as {readonly agent?: unknown}).agent : undefined;
+	return typeof agent === "string" && agent !== "" ? agent : "subagent";
 };
 
 /** The newest thing the worker wrote, off a result already bounded by `boundToolResult`. */
@@ -197,11 +210,11 @@ const countOf = (tokens: number | undefined): number =>
 export const subagentSlotsOf = (item: PiTranscriptItem): ReadonlyArray<SubagentSlot> => {
 	if (item.role === "assistant") {
 		return item.content.flatMap((part) =>
-			part.type === "toolCall" && SUBAGENT_TOOLS.has(part.toolName)
+			part.type === "toolCall" && spawns(part.toolName, part.input)
 				? [
 						{
 							id: itemId(part.toolCallId),
-							type: subagentType(part.toolName, part.input),
+							type: subagentType(part.input),
 							lastLine: "",
 							startedAt: item.timestamp,
 							tokens: 0,
@@ -212,11 +225,11 @@ export const subagentSlotsOf = (item: PiTranscriptItem): ReadonlyArray<SubagentS
 				: [],
 		);
 	}
-	if (item.role !== "tool" || !SUBAGENT_TOOLS.has(item.toolName)) return [];
+	if (item.role !== "tool" || !spawns(item.toolName, item.input)) return [];
 	return [
 		{
 			id: itemId(item.toolCallId),
-			type: subagentType(item.toolName, item.input),
+			type: subagentType(item.input),
 			lastLine: lastLineOf(boundToolResult(textOf(item.content)).text),
 			startedAt: item.timestamp,
 			tokens: countOf(item.usage?.totalTokens),

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -18,11 +18,13 @@
  * said. An item's `image` parts have no port field to land in and are dropped.
  */
 
+import {Predicate} from "effect";
 import {
 	boundToolResult,
 	type ItemId,
 	type JsonValue,
 	newestBackendItemId,
+	type SubagentSlot,
 	type ThinkingItem,
 	type ToolStatus,
 	type TranscriptItem,
@@ -151,6 +153,80 @@ export const itemsOf = (item: PiTranscriptItem): ReadonlyArray<TranscriptItem> =
 };
 
 /**
+ * The two tools `pi-subagents` registers on the parent session — `subagent`
+ * (`pi-subagents` `src/extension/index.ts:750`) and `bg_wait`
+ * (`src/runs/background/wait-tool.ts:36`). A call to either is a worker this session started.
+ */
+const SUBAGENT_TOOLS: ReadonlySet<string> = new Set(["subagent", "bg_wait"]);
+
+/**
+ * What kind of worker a call started, in the extension's own words: the `agent` argument, which
+ * names one of the configured agents (`pi-subagents` `src/extension/schemas.ts:283`). A call that
+ * names none — a `bg_wait`, or a workflow script that picks its own children — is labelled by the
+ * tool, because the row has to say something and the tool name is the only true thing left.
+ */
+const subagentType = (toolName: string, input: unknown): string => {
+	if (!Predicate.isObject(input)) return toolName;
+	const agent = (input as {readonly agent?: unknown}).agent;
+	return typeof agent === "string" && agent !== "" ? agent : toolName;
+};
+
+/** The newest thing the worker wrote, off a result already bounded by `boundToolResult`. */
+const lastLineOf = (text: string): string => {
+	const lines = text.split("\n").filter((line) => line.trim() !== "");
+	return lines.length === 0 ? "" : (lines[lines.length - 1] as string);
+};
+
+/** `SubagentSlot.tokens` is a non-negative integer or the slot is unreadable off a checkpoint. */
+const countOf = (tokens: number | undefined): number =>
+	tokens === undefined || !Number.isFinite(tokens) ? 0 : Math.max(0, Math.trunc(tokens));
+
+/**
+ * The subagent slots one wire item is worth — the model-blind row the running list already draws
+ * (`../../ai-agent/ports/subagent.ts`), so a Pi worker lands in the same surface a Claude one does.
+ *
+ * Two items carry one worker: the assistant turn whose `toolCall` part started it, and the tool
+ * result that ends it. The call is the `running` slot, the result the `finished` one, and both are
+ * keyed on the call id — so the second supersedes the first in the state's own record
+ * (`../../ai-agent/core/fold.ts`) instead of drawing a second row.
+ *
+ * `items` is empty and `tokens` is what the result reports, not what the worker spent: the spawn
+ * is a detached child process with its own `ModelRuntime` (#8555), so none of the child's turns
+ * reach this transcript and there is nothing else here to read them off.
+ */
+export const subagentSlotsOf = (item: PiTranscriptItem): ReadonlyArray<SubagentSlot> => {
+	if (item.role === "assistant") {
+		return item.content.flatMap((part) =>
+			part.type === "toolCall" && SUBAGENT_TOOLS.has(part.toolName)
+				? [
+						{
+							id: itemId(part.toolCallId),
+							type: subagentType(part.toolName, part.input),
+							lastLine: "",
+							startedAt: item.timestamp,
+							tokens: 0,
+							items: [],
+							status: "running" as const,
+						},
+					]
+				: [],
+		);
+	}
+	if (item.role !== "tool" || !SUBAGENT_TOOLS.has(item.toolName)) return [];
+	return [
+		{
+			id: itemId(item.toolCallId),
+			type: subagentType(item.toolName, item.input),
+			lastLine: lastLineOf(boundToolResult(textOf(item.content)).text),
+			startedAt: item.timestamp,
+			tokens: countOf(item.usage?.totalTokens),
+			items: [],
+			status: "finished",
+		},
+	];
+};
+
+/**
  * Pi's five session phases against the core's six. `idle` is the only one that is not the agent
  * working, so everything else reads as `prompting`: a compaction and a retry are both a turn the
  * operator is waiting on, and the window's phase line says so.
@@ -194,6 +270,13 @@ const usageEventOf = (item: PiTranscriptItem): Extract<AgentEvent, {kind: "usage
 export interface SnapshotProjection {
 	readonly items: ReadonlyMap<string, string>;
 	readonly usage: ReadonlyMap<string, string>;
+	/**
+	 * Subagent slots, in their own map because a slot and its tool row share one id. Keyed by
+	 * `<call id>:<status>` rather than by the id alone: one worker is two slots, the call's
+	 * `running` and the result's `finished`, and a key that held only the latest would let a
+	 * re-folded assistant turn push its `running` back over the `finished` that superseded it.
+	 */
+	readonly subagents: ReadonlyMap<string, string>;
 	readonly phase: Phase | null;
 	readonly revision: number;
 }
@@ -201,11 +284,14 @@ export interface SnapshotProjection {
 export const emptyProjection: SnapshotProjection = {
 	items: new Map(),
 	usage: new Map(),
+	subagents: new Map(),
 	phase: null,
 	revision: -1,
 };
 
 const fingerprint = (value: unknown): string => JSON.stringify(value);
+
+const slotKey = (slot: SubagentSlot): string => `${slot.id}:${slot.status}`;
 
 /** What one fold answers: the events it emitted, and the projection they left behind. */
 export interface Folded {
@@ -232,12 +318,19 @@ export const eventsOf = (previous: SnapshotProjection, snapshot: SessionSnapshot
 	const events: Array<AgentEvent> = [];
 	const items = new Map<string, string>();
 	const usage = new Map<string, string>();
+	const subagents = new Map<string, string>();
 
 	for (const source of snapshot.transcript) {
 		for (const item of itemsOf(source)) {
 			const mark = fingerprint(item);
 			items.set(item.id, mark);
 			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
+		}
+		for (const slot of subagentSlotsOf(source)) {
+			const key = slotKey(slot);
+			const mark = fingerprint(slot);
+			subagents.set(key, mark);
+			if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 		}
 	}
 
@@ -252,7 +345,7 @@ export const eventsOf = (previous: SnapshotProjection, snapshot: SessionSnapshot
 	const phase = phaseOf(snapshot.phase);
 	if (previous.phase !== phase) events.push({kind: "phase", phase});
 
-	return {events, next: {items, usage, phase, revision: snapshot.revision}};
+	return {events, next: {items, usage, subagents, phase, revision: snapshot.revision}};
 };
 
 /**
@@ -268,6 +361,7 @@ export const deltaEventsOf = (previous: SnapshotProjection, delta: SessionDelta)
 	const events: Array<AgentEvent> = [];
 	const items = new Map(previous.items);
 	const usage = new Map(previous.usage);
+	const subagents = new Map(previous.subagents);
 	const changed = delta.items ?? [];
 
 	for (const source of changed) {
@@ -275,6 +369,12 @@ export const deltaEventsOf = (previous: SnapshotProjection, delta: SessionDelta)
 			const mark = fingerprint(item);
 			items.set(item.id, mark);
 			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
+		}
+		for (const slot of subagentSlotsOf(source)) {
+			const key = slotKey(slot);
+			const mark = fingerprint(slot);
+			subagents.set(key, mark);
+			if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 		}
 	}
 
@@ -289,7 +389,7 @@ export const deltaEventsOf = (previous: SnapshotProjection, delta: SessionDelta)
 	const phase = delta.phase === undefined ? previous.phase : phaseOf(delta.phase);
 	if (phase !== null && previous.phase !== phase) events.push({kind: "phase", phase});
 
-	return {events, next: {items, usage, phase, revision: delta.revision}};
+	return {events, next: {items, usage, subagents, phase, revision: delta.revision}};
 };
 
 /**
@@ -345,9 +445,11 @@ export const projectionOf = (
 	const carried = new Map(held.map((item) => [item.id as string, fingerprint(item)]));
 	const items = new Map<string, string>();
 	const usage = new Map<string, string>();
+	const subagents = new Map<string, string>();
 	let reached = false;
 	for (const source of snapshot.transcript) {
 		if (reached) break;
+		for (const slot of subagentSlotsOf(source)) subagents.set(slotKey(slot), fingerprint(slot));
 		const rows = itemsOf(source);
 		const cut = rows.findIndex((item) => item.id === through);
 		reached = cut !== -1;
@@ -362,7 +464,7 @@ export const projectionOf = (
 		const event = !moved && seeded.length === rows.length ? usageEventOf(source) : null;
 		if (event !== null) usage.set(source.id, fingerprint(event));
 	}
-	return reached ? {items, usage, phase: null, revision: snapshot.revision} : null;
+	return reached ? {items, usage, subagents, phase: null, revision: snapshot.revision} : null;
 };
 
 /**

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -655,12 +655,40 @@ describe("a subagent's start and end over the delta stream", () => {
 		expect(folded.events.some((event) => event.kind === "subagent")).toBe(false);
 	});
 
-	it("labels a call that names no agent by the tool that made it", () => {
-		const wait: PiTranscriptItem = {...finished, toolName: "bg_wait", input: {all: true}};
-		const folded = deltaEventsOf(opened().next, delta([wait], 2));
+	it("labels a spawn that names no agent by the tool that made it", () => {
+		const script: PiTranscriptItem = {...finished, input: {workflowScript: "runs.run('a', {})"}};
+		const folded = deltaEventsOf(opened().next, delta([script], 2));
 		const slots = folded.events.filter((event) => event.kind === "subagent");
 		expect(slots).toHaveLength(1);
-		expect(slots[0]?.slot.type).toBe("bg_wait");
+		expect(slots[0]?.slot.type).toBe("subagent");
+	});
+
+	// `subagent` is one multiplexed tool: with an `action` it manages rather than spawns, and the
+	// `agent` beside one names that action's target (`pi-subagents` `src/extension/schemas.ts:283-287`,
+	// `src/runs/foreground/subagent-executor.ts:5976`). A row for one is a worker that never ran.
+	it.each([
+		["list", {action: "list"}],
+		["status against an agent", {action: "status", agent: "reviewer"}],
+		["stop", {action: "stop", id: "run-3"}],
+		["schedule.create", {action: "schedule.create", agent: "worker", name: "nightly"}],
+		["mission.close", {action: "mission.close", id: "m-1"}],
+	])("draws no row for a management call: %s", (_case, managed) => {
+		const call: PiTranscriptItem = {
+			...spawning,
+			content: [{type: "toolCall", toolCallId: "call-9", toolName: "subagent", input: managed}],
+		};
+		const started = deltaEventsOf(opened().next, delta([call], 2));
+		const ended = deltaEventsOf(started.next, delta([{...finished, input: managed}], 3));
+		expect(started.events.some((event) => event.kind === "subagent")).toBe(false);
+		expect(ended.events.some((event) => event.kind === "subagent")).toBe(false);
+	});
+
+	// `bg_wait` waits on runs that are already slots (`src/runs/background/wait-tool.ts:36`), so a
+	// row for one duplicates a worker the list already draws.
+	it("draws no row for a bg_wait", () => {
+		const wait: PiTranscriptItem = {...finished, toolName: "bg_wait", input: {all: true}};
+		const folded = deltaEventsOf(opened().next, delta([wait], 2));
+		expect(folded.events.some((event) => event.kind === "subagent")).toBe(false);
 	});
 });
 

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -569,6 +569,102 @@ describe("one delta folded into events", () => {
 });
 
 /**
+ * A `pi-subagents` worker over the same delta stream: the call that starts it and the result that
+ * ends it are two items of the ordinary transcript, so the running list fills from the wire the
+ * whole session already rides (#8555).
+ */
+describe("a subagent's start and end over the delta stream", () => {
+	const delta = (items: ReadonlyArray<PiTranscriptItem>, revision: number): SessionDelta => ({
+		id: "session-8555",
+		revision,
+		updatedAt: revision * 100,
+		items: [...items],
+	});
+
+	const input = {agent: "reviewer", task: "read it"};
+
+	const spawning: PiTranscriptItem = {
+		id: "item-1",
+		role: "assistant",
+		content: [{type: "toolCall", toolCallId: "call-9", toolName: "subagent", input}],
+		model: {provider: "faux", id: "faux-1"},
+		timestamp: 11,
+		status: "complete",
+		stopReason: "toolUse",
+	};
+
+	const finished: PiTranscriptItem = {
+		id: "item-2",
+		role: "tool",
+		toolCallId: "call-9",
+		toolName: "subagent",
+		input,
+		content: [{type: "text", text: "spawning reviewer\ndone: 3 findings"}],
+		timestamp: 12,
+		status: "complete",
+		isError: false,
+	};
+
+	const opened = () => eventsOf(emptyProjection, snapshot([user], "turn"));
+
+	it("starts one running slot off the call and finishes it off the result", () => {
+		const start = deltaEventsOf(opened().next, delta([spawning], 2));
+		expect(start.events).toEqual([
+			{
+				kind: "subagent",
+				slot: {
+					id: "call-9",
+					type: "reviewer",
+					lastLine: "",
+					startedAt: 11,
+					tokens: 0,
+					items: [],
+					status: "running",
+				},
+			},
+		]);
+
+		const end = deltaEventsOf(start.next, delta([finished], 3));
+		expect(end.events).toEqual([
+			{kind: "item", item: itemOf(finished)},
+			{
+				kind: "subagent",
+				slot: {
+					id: "call-9",
+					type: "reviewer",
+					lastLine: "done: 3 findings",
+					startedAt: 12,
+					tokens: 0,
+					items: [],
+					status: "finished",
+				},
+			},
+		]);
+	});
+
+	// The call is still in the transcript after the result lands, so a later delta naming that turn
+	// again — a settling usage, a reattach — must not push the worker back to running.
+	it("never puts a finished worker back to running", () => {
+		const start = deltaEventsOf(opened().next, delta([spawning], 2));
+		const end = deltaEventsOf(start.next, delta([finished], 3));
+		expect(deltaEventsOf(end.next, delta([spawning], 4)).events).toEqual([]);
+	});
+
+	it("leaves an ordinary tool call out of the running list", () => {
+		const folded = deltaEventsOf(opened().next, delta([settledTool], 2));
+		expect(folded.events.some((event) => event.kind === "subagent")).toBe(false);
+	});
+
+	it("labels a call that names no agent by the tool that made it", () => {
+		const wait: PiTranscriptItem = {...finished, toolName: "bg_wait", input: {all: true}};
+		const folded = deltaEventsOf(opened().next, delta([wait], 2));
+		const slots = folded.events.filter((event) => event.kind === "subagent");
+		expect(slots).toHaveLength(1);
+		expect(slots[0]?.slot.type).toBe("bg_wait");
+	});
+});
+
+/**
  * What the streaming marker buys once it reaches the core: the in-flight row supersedes itself
  * under one id, and the tail holding it is a state `checkpointWorthy` refuses to write (#8170).
  * `holdsPartialItem` is the generic rule and needs no Pi arm — this pins that Pi now trips it.

--- a/apps/tuval/src/pi/proof/faux.ts
+++ b/apps/tuval/src/pi/proof/faux.ts
@@ -20,8 +20,9 @@ import {fauxProvider} from "@earendil-works/pi-ai";
 import {ModelRuntime} from "@earendil-works/pi-coding-agent";
 import {Effect, Layer} from "effect";
 import type {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {featuresDefault} from "../../features.ts";
 import {aiAgentOverHost} from "../ai-agent/PiAiAgent.ts";
-import {agentSessionHostLayer, SessionOpenFailed} from "../server/index.ts";
+import {agentSessionHostLayer, SessionOpenFailed, subagentExtensionPaths} from "../server/index.ts";
 
 /** The model the faux provider advertises. Its rates are per million tokens, as Pi's catalog states them. */
 export const FAUX_MODEL = {provider: "faux", id: "faux-1"} as const;
@@ -65,11 +66,20 @@ export const fauxPiLayer = ({root, replies}: FauxPiOptions): Layer.Layer<TuvalAi
 							authPath: join(root, ".tuval", "pi-agent", "auth.json"),
 						});
 						modelRuntime.registerNativeProvider(faux.provider);
+						// The same flag the shipped row reads (`../ai-agent/PiAiAgent.ts`), so flipping it
+						// and running `proof:pi-vertical` is the hand check for the extension (#8555).
+						// The child a `subagent` call spawns is a detached process with its own
+						// `ModelRuntime`, so it never sees this faux provider and needs a real model.
+						const extensionPaths = subagentExtensionPaths(featuresDefault);
 						return agentSessionHostLayer({
 							modelRuntime,
 							agentDir: join(root, ".tuval", "pi-agent"),
 							projectRoot: root,
-							noTools: "all",
+							// `"all"` is no tools at all; `"builtin"` drops the four disk-touching built-ins
+							// and leaves extension tools enabled (`pi-coding-agent` `dist/core/sdk.d.ts`),
+							// which is what lets the operator's turn actually reach `subagent`.
+							noTools: extensionPaths.length === 0 ? "all" : "builtin",
+							...(extensionPaths.length === 0 ? {} : {extensionPaths}),
 						});
 					},
 					catch: (cause) => new SessionOpenFailed({cwd: root, detail: String(cause)}),

--- a/apps/tuval/src/pi/proof/faux.ts
+++ b/apps/tuval/src/pi/proof/faux.ts
@@ -75,9 +75,11 @@ export const fauxPiLayer = ({root, replies}: FauxPiOptions): Layer.Layer<TuvalAi
 							modelRuntime,
 							agentDir: join(root, ".tuval", "pi-agent"),
 							projectRoot: root,
-							// `"all"` is no tools at all; `"builtin"` drops the four disk-touching built-ins
-							// and leaves extension tools enabled (`pi-coding-agent` `dist/core/sdk.d.ts`),
-							// which is what lets the operator's turn actually reach `subagent`.
+							// `"all"` is no tools at all; `"builtin"` leaves extension tools active and the four
+							// disk-touching built-ins inactive (`pi-coding-agent` `dist/core/sdk.js:141,144`
+							// with `agent-session.js:2086-2100`), which is what lets the turn reach
+							// `subagent`. Weaker than `"all"`, though: under `"builtin"` the builtins stay
+							// registered and allowed, so a `setActiveToolsByName` could bring them back.
 							noTools: extensionPaths.length === 0 ? "all" : "builtin",
 							...(extensionPaths.length === 0 ? {} : {extensionPaths}),
 						});

--- a/apps/tuval/src/pi/server/AgentSessionHost.ts
+++ b/apps/tuval/src/pi/server/AgentSessionHost.ts
@@ -15,7 +15,9 @@ import {join} from "node:path";
 import {
 	type AgentSession,
 	createAgentSession,
+	DefaultResourceLoader,
 	type ModelRuntime,
+	type ResourceLoader,
 	SessionManager,
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
@@ -47,6 +49,12 @@ export interface AgentSessionHostOptions {
 	 * it: a snapshot carrying a partial reply is a shape no client above this host reads yet.
 	 */
 	readonly streamPartialText?: boolean;
+	/**
+	 * Extension packages every session this host opens loads, as directories Pi's own loader reads
+	 * (`./subagents.ts`). Empty or absent builds no resource loader at all, which leaves
+	 * `createAgentSession` building exactly the one it built before this option existed.
+	 */
+	readonly extensionPaths?: ReadonlyArray<string>;
 }
 
 const allThinkingLevels: ReadonlyArray<ThinkingLevel> = [
@@ -113,6 +121,32 @@ export const streamingMessage = (
 	options.streamPartialText === true
 		? (state.streamingMessage as SourceMessage | undefined)
 		: undefined;
+
+/**
+ * Pi's resource loader with this host's extension packages added, or `undefined` when there are
+ * none — and `undefined` is the whole point of the branch: `createAgentSession` builds its own
+ * `DefaultResourceLoader({cwd, agentDir, settingsManager})` when handed no loader
+ * (`dist/core/sdk.js`), so a host with no extension paths opens the session it always opened.
+ *
+ * `reload()` is what loads them: the loader discovers nothing until it runs, and
+ * `createAgentSession` never calls it on a loader the caller supplied.
+ */
+export const extensionLoader = async (
+	paths: ReadonlyArray<string>,
+	cwd: string,
+	agentDir: string,
+	settingsManager: SettingsManager,
+): Promise<ResourceLoader | undefined> => {
+	if (paths.length === 0) return undefined;
+	const loader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		settingsManager,
+		additionalExtensionPaths: [...paths],
+	});
+	await loader.reload();
+	return loader;
+};
 
 const call = <A>(
 	session: AgentSession,
@@ -246,8 +280,15 @@ export const layer = (options: AgentSessionHostOptions): Layer.Layer<PiSessionHo
 						: options.modelRuntime.getModel(request.model.provider, request.model.id);
 
 				const session = yield* Effect.tryPromise({
-					try: () =>
-						createAgentSession({
+					try: async () => {
+						const settingsManager = SettingsManager.create(request.cwd, options.agentDir);
+						const resourceLoader = await extensionLoader(
+							options.extensionPaths ?? [],
+							request.cwd,
+							options.agentDir,
+							settingsManager,
+						);
+						const result = await createAgentSession({
 							cwd: request.cwd,
 							...(model === undefined ? {} : {model}),
 							...(request.thinkingLevel === undefined
@@ -255,9 +296,12 @@ export const layer = (options: AgentSessionHostOptions): Layer.Layer<PiSessionHo
 								: {thinkingLevel: request.thinkingLevel}),
 							modelRuntime: options.modelRuntime,
 							sessionManager: SessionManager.create(request.cwd, sessionDir),
-							settingsManager: SettingsManager.create(request.cwd, options.agentDir),
+							settingsManager,
+							...(resourceLoader === undefined ? {} : {resourceLoader}),
 							...(options.noTools === undefined ? {} : {noTools: options.noTools}),
-						}).then((result) => result.session),
+						});
+						return result.session;
+					},
 					catch: (error) => new SessionOpenFailed({cwd: request.cwd, detail: detailOf(error)}),
 				});
 
@@ -290,14 +334,24 @@ export const layer = (options: AgentSessionHostOptions): Layer.Layer<PiSessionHo
 				if (file === undefined) return yield* refuse(`no session file for ${sessionId} in ${dir}`);
 
 				const session = yield* Effect.tryPromise({
-					try: () =>
-						createAgentSession({
+					try: async () => {
+						const settingsManager = SettingsManager.create(cwd, options.agentDir);
+						const resourceLoader = await extensionLoader(
+							options.extensionPaths ?? [],
+							cwd,
+							options.agentDir,
+							settingsManager,
+						);
+						const result = await createAgentSession({
 							cwd,
 							modelRuntime: options.modelRuntime,
 							sessionManager: SessionManager.open(file, dir, cwd),
-							settingsManager: SettingsManager.create(cwd, options.agentDir),
+							settingsManager,
+							...(resourceLoader === undefined ? {} : {resourceLoader}),
 							...(options.noTools === undefined ? {} : {noTools: options.noTools}),
-						}).then((result) => result.session),
+						});
+						return result.session;
+					},
 					catch: (error) => refuse(detailOf(error)),
 				});
 				return yield* handleOf(options, session, cwd);

--- a/apps/tuval/src/pi/server/index.ts
+++ b/apps/tuval/src/pi/server/index.ts
@@ -1,6 +1,7 @@
 export {
 	type AgentSessionHostOptions,
 	defaultSessionDir,
+	extensionLoader,
 	layer as agentSessionHostLayer,
 } from "./AgentSessionHost.ts";
 export {type ProtocolModelCost, projectModelCost, type SourceModelCost} from "./cost.ts";
@@ -39,5 +40,10 @@ export {
 	type PiSessionHostApi,
 	type PiSessionView,
 } from "./PiSessionHost.ts";
+export {
+	SUBAGENTS_PACKAGE,
+	subagentExtensionPaths,
+	subagentsPackageDir,
+} from "./subagents.ts";
 export {mintCapabilityToken, tokenMatches} from "./token.ts";
 export {projectTranscript, projectUsage, type SourceMessage} from "./transcript.ts";

--- a/apps/tuval/src/pi/server/subagents.integration.test.ts
+++ b/apps/tuval/src/pi/server/subagents.integration.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The extension load against a real `AgentSession`: with `piSubagents` on, the host builds Pi's
+ * resource loader itself and hands it to `createAgentSession`, and the session it gets back still
+ * opens, prompts and answers.
+ *
+ * The tools that load are the unit tier's assertion (`./subagents.unit.test.ts`) — it needs no
+ * model. What only a real session can say is that a session carrying the extension still runs a
+ * turn: `pi-subagents` registers handlers on the session's own lifecycle events, and a handler that
+ * threw would break the loop rather than the registration.
+ *
+ * Pi's own faux provider, so the run costs nothing and calls no model API. The child a `subagent`
+ * call would spawn is a detached process with its own `ModelRuntime` and does not reach it (#8555),
+ * which is why spawning one is hand-verified on the desk rather than asserted here.
+ */
+
+import {mkdtempSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fauxAssistantMessage, fauxProvider} from "@earendil-works/pi-ai";
+import {ModelRuntime} from "@earendil-works/pi-coding-agent";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {layer as agentSessionHostLayer} from "./AgentSessionHost.ts";
+import {SessionOpenFailed} from "./errors.ts";
+import {PiSessionHost} from "./PiSessionHost.ts";
+import {subagentExtensionPaths} from "./subagents.ts";
+
+const MODEL = {provider: "faux", id: "faux-1"} as const;
+
+const hostLayer = (cwd: string, piSubagents: boolean) =>
+	Layer.unwrap(
+		Effect.tryPromise({
+			try: async () => {
+				const faux = fauxProvider({
+					provider: MODEL.provider,
+					api: "faux",
+					models: [{id: MODEL.id, cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0}}],
+				});
+				faux.setResponses([fauxAssistantMessage("hello from faux")]);
+				const modelRuntime = await ModelRuntime.create({
+					modelsPath: null,
+					refreshOnCreate: false,
+					allowModelNetwork: false,
+					authPath: join(cwd, "agent", "auth.json"),
+				});
+				modelRuntime.registerNativeProvider(faux.provider);
+				const extensionPaths = subagentExtensionPaths({piSubagents});
+				return agentSessionHostLayer({
+					modelRuntime,
+					agentDir: join(cwd, "agent"),
+					noTools: "all",
+					...(extensionPaths.length === 0 ? {} : {extensionPaths}),
+				});
+			},
+			catch: (cause) => new SessionOpenFailed({cwd, detail: String(cause)}),
+		}).pipe(Effect.orDie),
+	);
+
+/**
+ * One turn, read off the session's own change signal. The signal coalesces, so the reply can land
+ * on the first wake or a later one — the loop reads until the answer is in the transcript rather
+ * than assuming which wake carries it.
+ */
+const turn = (cwd: string) =>
+	Effect.gen(function* () {
+		const host = yield* PiSessionHost;
+		const session = yield* host.open({cwd, model: MODEL});
+		yield* session.prompt("say hello");
+		for (let wake = 0; wake < 20; wake += 1) {
+			const view = yield* session.read;
+			if (view.transcript.some((item) => item.role === "assistant")) {
+				assert.strictEqual(view.model.id, MODEL.id);
+				assert.deepStrictEqual(
+					view.transcript.map((item) => item.role),
+					["user", "assistant"],
+				);
+				return;
+			}
+			yield* session.changes;
+		}
+		return yield* Effect.die(new Error("the faux reply never reached the transcript"));
+	}).pipe(Effect.scoped);
+
+describe("a Pi session with the subagent extension loaded", () => {
+	it.live("opens, prompts and answers with the flag on", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "tuval-pi-subagents-on-"));
+		return turn(cwd).pipe(Effect.provide(hostLayer(cwd, true)));
+	});
+
+	it.live("opens the same session with the flag off", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "tuval-pi-subagents-off-"));
+		return turn(cwd).pipe(Effect.provide(hostLayer(cwd, false)));
+	});
+});

--- a/apps/tuval/src/pi/server/subagents.ts
+++ b/apps/tuval/src/pi/server/subagents.ts
@@ -1,0 +1,36 @@
+/**
+ * The `piSubagents` flag, turned into the one thing the session host takes: a list of extension
+ * package directories, empty when the flag is off.
+ *
+ * A *directory* rather than an import, because `pi-subagents` ships raw TypeScript
+ * (`exports: {".": "./index.ts"}`) and Node refuses to strip types under `node_modules`. Pi loads
+ * its own extensions through jiti off a path (`pi-coding-agent` `dist/core/extensions/loader.js`),
+ * and a package directory is what its resolver reads a `pi` manifest out of
+ * (`dist/core/package-manager.js`: a local source that stats as a directory goes to
+ * `collectPackageResources`) — so the extension, its skills and its prompts all arrive from one
+ * entry, and nothing in Tuval ever imports the package.
+ */
+
+import {dirname} from "node:path";
+import {fileURLToPath} from "node:url";
+import type {TuvalFeatures} from "../../features.ts";
+
+/** The npm package, unscoped — it is not one of the `@earendil-works/*` family (#8555). */
+export const SUBAGENTS_PACKAGE = "pi-subagents";
+
+/**
+ * Where the installed `pi-subagents` lives, resolved through its own export map rather than by
+ * walking up to a `node_modules`: pnpm's store means the directory beside this file is not the one
+ * the package resolves to.
+ */
+export const subagentsPackageDir = (): string =>
+	dirname(fileURLToPath(import.meta.resolve(SUBAGENTS_PACKAGE)));
+
+/**
+ * The extension paths a session opens with. Off is an empty list and not a disabled extension: the
+ * host builds no resource loader of its own for one, which leaves `createAgentSession` building
+ * exactly the loader it built before this flag existed.
+ */
+export const subagentExtensionPaths = (
+	features: Pick<TuvalFeatures, "piSubagents">,
+): ReadonlyArray<string> => (features.piSubagents ? [subagentsPackageDir()] : []);

--- a/apps/tuval/src/pi/server/subagents.unit.test.ts
+++ b/apps/tuval/src/pi/server/subagents.unit.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The `piSubagents` flag's two answers, proved against the installed extension rather than against
+ * a name: the flag off is no extension path at all, and the flag on is a package Pi's own loader
+ * reads `subagent` and `bg_wait` out of.
+ *
+ * The loading half runs here rather than in the integration tier on purpose — it needs no model, no
+ * socket and no credentials. What it does need is `node_modules`, so it reads the real installed
+ * package and would red on a pin whose extension no longer registers those two tools.
+ */
+
+import {mkdtempSync, readFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {SettingsManager} from "@earendil-works/pi-coding-agent";
+import {describe, expect, it} from "vitest";
+import {featuresDefault} from "../../features.ts";
+import {extensionLoader} from "./AgentSessionHost.ts";
+import {SUBAGENTS_PACKAGE, subagentExtensionPaths, subagentsPackageDir} from "./subagents.ts";
+
+const toolNames = async (paths: ReadonlyArray<string>): Promise<ReadonlyArray<string>> => {
+	const cwd = mkdtempSync(join(tmpdir(), "tuval-subagents-cwd-"));
+	const agentDir = mkdtempSync(join(tmpdir(), "tuval-subagents-agent-"));
+	const loader = await extensionLoader(paths, cwd, agentDir, SettingsManager.create(cwd, agentDir));
+	if (loader === undefined) return [];
+	const loaded = loader.getExtensions();
+	expect(loaded.errors).toEqual([]);
+	return loaded.extensions.flatMap((extension) => [...extension.tools.keys()]);
+};
+
+describe("the piSubagents flag", () => {
+	it("ships off, so a Pi row opens the session it opened before it existed", () => {
+		expect(featuresDefault.piSubagents).toBe(false);
+		expect(subagentExtensionPaths({piSubagents: false})).toEqual([]);
+	});
+
+	it("names the installed pi-subagents package when it is on", () => {
+		const paths = subagentExtensionPaths({piSubagents: true});
+		expect(paths).toHaveLength(1);
+		const manifest = JSON.parse(readFileSync(join(paths[0] as string, "package.json"), "utf8")) as {
+			readonly name: string;
+			readonly pi: {readonly extensions: ReadonlyArray<string>};
+		};
+		expect(manifest.name).toBe(SUBAGENTS_PACKAGE);
+		expect(manifest.pi.extensions).toContain("./index.ts");
+		expect(paths[0]).toBe(subagentsPackageDir());
+	});
+});
+
+describe("what Pi's own loader registers", () => {
+	it("registers the subagent tools when the flag is on", async () => {
+		const names = await toolNames(subagentExtensionPaths({piSubagents: true}));
+		expect(names).toContain("subagent");
+		expect(names).toContain("bg_wait");
+	});
+
+	it("registers nothing when the flag is off", async () => {
+		expect(await toolNames(subagentExtensionPaths({piSubagents: false}))).toEqual([]);
+	});
+});

--- a/apps/tuval/src/pi/server/subagents.unit.test.ts
+++ b/apps/tuval/src/pi/server/subagents.unit.test.ts
@@ -47,11 +47,23 @@ describe("the piSubagents flag", () => {
 });
 
 describe("what Pi's own loader registers", () => {
-	it("registers the subagent tools when the flag is on", async () => {
-		const names = await toolNames(subagentExtensionPaths({piSubagents: true}));
-		expect(names).toContain("subagent");
-		expect(names).toContain("bg_wait");
-	});
+	/**
+	 * Well past vitest's 5s default, and the cost is real rather than a flake to absorb: `reload()`
+	 * makes Pi's jiti loader compile `pi-subagents`' raw TypeScript entry and the `src/**` graph
+	 * behind it from cold, which on a CI runner with no warm jiti cache took longer than the default
+	 * allows (#8596 review round 1).
+	 */
+	const COLD_JITI_COMPILE = 120_000;
+
+	it(
+		"registers the subagent tools when the flag is on",
+		async () => {
+			const names = await toolNames(subagentExtensionPaths({piSubagents: true}));
+			expect(names).toContain("subagent");
+			expect(names).toContain("bg_wait");
+		},
+		COLD_JITI_COMPILE,
+	);
 
 	it("registers nothing when the flag is off", async () => {
 		expect(await toolNames(subagentExtensionPaths({piSubagents: false}))).toEqual([]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ catalogs:
     mermaid:
       specifier: 11.17.2
       version: 11.17.2
+    pi-subagents:
+      specifier: 0.66.0
+      version: 0.66.0
     react:
       specifier: 19.2.6
       version: 19.2.6
@@ -318,6 +321,9 @@ importers:
       effect:
         specifier: catalog:tuval
         version: 4.0.0-rc.112
+      pi-subagents:
+        specifier: 'catalog:'
+        version: 0.66.0(@earendil-works/pi-agent-core@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-ai@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-tui@0.85.1)(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -1730,6 +1736,10 @@ packages:
 
   '@earendil-works/pi-protocol@0.85.1':
     resolution: {integrity: sha512-w+pPvmw54Z8oFmJiSbPT4OwV4Hl97PA3vaLTp7KUwVLbPx3ucaAIldGrlNVt5F3k4C/reT4I39FKmuJIyrmKdg==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-server@0.85.0':
+    resolution: {integrity: sha512-S8a6a26TM40C7WInj7bNu+HLbVMGosg4gRo2jB5yw0mH1TZ6HHKMxT2YDJpDpnSyGmCwEPj5GBG2sG1jbthWrA==}
     engines: {node: '>=22.19.0'}
 
   '@earendil-works/pi-telemetry@0.85.1':
@@ -3875,6 +3885,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -5430,6 +5445,24 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  pi-subagents@0.66.0:
+    resolution: {integrity: sha512-PfvGutk0QJ2Ps0lC/a9L5T9n3RCo7w7Nt0hXg08cbj9uyUEwdrWRCYEpfZ2jMTC/1sOUpnCrVZF/669Qeek0lw==}
+    hasBin: true
+    peerDependencies:
+      '@earendil-works/pi-agent-core': 0.85.1
+      '@earendil-works/pi-ai': 0.85.1
+      '@earendil-works/pi-coding-agent': '*'
+      '@earendil-works/pi-tui': 0.85.1
+    peerDependenciesMeta:
+      '@earendil-works/pi-agent-core':
+        optional: true
+      '@earendil-works/pi-ai':
+        optional: true
+      '@earendil-works/pi-coding-agent':
+        optional: true
+      '@earendil-works/pi-tui':
+        optional: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5925,6 +5958,9 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
   typebox@1.3.7:
     resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
@@ -5943,6 +5979,10 @@ packages:
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   undici@8.10.1:
     resolution: {integrity: sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==}
@@ -6142,6 +6182,11 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -6856,6 +6901,19 @@ snapshots:
     dependencies:
       '@earendil-works/chord': 0.85.1
       typebox: 1.3.7
+
+  '@earendil-works/pi-server@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/chord': 0.85.1
+      '@earendil-works/pi-agent-core': 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-protocol': 0.85.1
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
   '@earendil-works/pi-telemetry@0.85.1': {}
 
@@ -8986,6 +9044,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  acorn@8.18.0: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -10460,6 +10520,27 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pi-subagents@0.66.0(@earendil-works/pi-agent-core@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-ai@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-tui@0.85.1)(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3):
+    dependencies:
+      '@earendil-works/pi-server': 0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      acorn: 8.18.0
+      jiti: 2.7.0
+      typebox: 1.1.38
+      undici: 8.10.0
+      yaml: 2.8.3
+    optionalDependencies:
+      '@earendil-works/pi-agent-core': 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent': 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.85.1
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -11016,6 +11097,8 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
+  typebox@1.1.38: {}
+
   typebox@1.3.7: {}
 
   typescript@7.0.2:
@@ -11048,6 +11131,8 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici@7.24.8: {}
+
+  undici@8.10.0: {}
 
   undici@8.10.1: {}
 
@@ -11174,6 +11259,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  yaml@2.8.3: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,8 +99,11 @@ catalog:
   mermaid: 11.17.2
   # Pi's subagent extension (#8555), pinned exact and loaded behind a default-off flag. It ships raw
   # TypeScript (`exports: {".": "./index.ts"}`), so Tuval never imports it — Pi's own jiti-backed
-  # extension loader reads the package directory. Its `@earendil-works/*` peers are all optional and
-  # resolve to the 0.85.1 copies the catalog and the overrides below already pin.
+  # extension loader reads the package directory. Its four `@earendil-works/*` peers are optional and
+  # resolve to the 0.85.1 copies the catalog and the overrides below already pin, but it also takes a
+  # HARD `@earendil-works/pi-server@0.85.0` — a tenth family member, off the 0.85.1 the other nine
+  # sit on. Nothing in the workspace declares `pi-server`, so that copy is alone in the tree and
+  # catalog-guard never sees it; re-read the lockfile for it when this pin moves.
   'pi-subagents': 0.66.0
   react: 19.2.6
   react-dom: 19.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,11 @@ catalog:
   # the version is part of that block's safety argument. It links its own nested `marked@^16`,
   # which never crosses a type boundary with the 18.0.5 above — mermaid parses its own labels.
   mermaid: 11.17.2
+  # Pi's subagent extension (#8555), pinned exact and loaded behind a default-off flag. It ships raw
+  # TypeScript (`exports: {".": "./index.ts"}`), so Tuval never imports it — Pi's own jiti-backed
+  # extension loader reads the package directory. Its `@earendil-works/*` peers are all optional and
+  # resolve to the 0.85.1 copies the catalog and the overrides below already pin.
+  'pi-subagents': 0.66.0
   react: 19.2.6
   react-dom: 19.2.6
   react-fate: 1.3.1


### PR DESCRIPTION
Adds `pi-subagents` to Tuval's Pi coding-agent session, behind a new default-off `piSubagents` flag.
With the flag off — the shipped default — a Pi row opens exactly the session it opened before.

**How the extension loads.** `pi-subagents` ships raw TypeScript (`exports: {".": "./index.ts"}`) and
Node refuses to strip types under `node_modules`, so Tuval never imports it. Pi's own jiti-backed
loader reads it off a path, and a package *directory* is what its resolver reads a `pi` manifest out
of — so `subagentExtensionPaths` hands `AgentSessionHost` a directory, and the host builds a
`DefaultResourceLoader` with it and passes that to `createAgentSession`. No extension paths means no
loader at all, which leaves `createAgentSession` building the same one it always built.

**How a running subagent reaches the desk.** It rides the transcript that is already there. A
spawning `subagent` call is a `toolCall` part on the assistant turn and its result is a tool item, so
`items.ts` folds the pair into the `SubagentSlot` events the running list already draws — the
`running` slot off the call, the `finished` one off the result, both keyed on the call id. No wire
change and no new surface.

**Only a spawn draws a row.** `subagent` is one multiplexed tool: with an `action` it manages rather
than spawns, and the `agent` beside one names that action's target (`pi-subagents`
`src/extension/schemas.ts:283-287`; the executor branches on exactly that at
`src/runs/foreground/subagent-executor.ts:5976`). `bg_wait` waits on work already running and starts
none. So the fold's trigger is `subagent` with no `action` field, and nothing else — anything looser
draws workers the operator cannot find.

**Coverage.** `subagents.unit.test.ts` loads the real installed package through Pi's own loader and
asserts `subagent` and `bg_wait` are registered with the flag on and nothing is with it off.
`items.unit.test.ts` folds a worker's start and end over two deltas, and pins five management calls
and a `bg_wait` as drawing no row. `subagents.integration.test.ts` opens a real `AgentSession` on
Pi's faux provider with the extension loaded and runs a turn through it. A real spawn on
`openai-codex/gpt-5.6-luna` is recorded on #8555 — one row, labelled `worker`, running then
finished, with the model's own unprompted `{"action": "status"}` call correctly drawing none.

Start with `apps/tuval/src/pi/server/subagents.ts` (the gate), then `AgentSessionHost.ts`'s
`extensionLoader`, then `spawns` and `subagentSlotsOf` in `apps/tuval/src/pi/ai-agent/items.ts`.

Fixes #8555

## Deviations

- **Known defect left unfixed** — **Said:** #8555 asks the flag in `apps/tuval/src/features.ts` to
  gate the extension load. **Did:** it does, but only through `featuresDefault` — an operator who
  states `features: {piSubagents: true}` in either config layer sees no change. **Why:**
  `loadLayeredConfig` merges the flags *after* every config module has been evaluated and its
  program rows built, so a row's layer closure has no route to the merged record; the browser side
  has one (`virtual:tuval/features`) and the node side has none. That matches what `featuresDefault`
  documents as the flip site, so the shipped behaviour is right, but the split is real.
  **Disposition:** filed as #8595, which sketches the fix (a `Features` service in the kernel
  context, the `SpellBridge` seam of #7951).
- **Known defect left unfixed** — **Said:** `SubagentSlot.startedAt` is documented as the time the
  worker started, so the window can compute elapsed. **Did:** the `finished` slot carries the tool
  result's timestamp instead, so a finished worker's `startedAt` jumps forward (seen live on the
  #8555 spawn: `1788854786823` on the running row, `1788854791476` on the finished one). **Why:**
  `subagentSlotsOf` sees one wire item at a time and the call's timestamp is not on the result, so
  carrying it needs the call time held in `SnapshotProjection` and threaded through both folds — not
  the small change it looks like. Nothing renders wrong today, since `SubagentList` hides elapsed on
  a finished slot; what it does affect is that list's sort key, which then orders finished workers by
  end time. **Disposition:** stated here, and named in the round-1 repair note for the reviewer to
  route.
- **Out-of-scope change** — **Said:** #8555 names the flag, the load and the desk surface.
  **Did:** also changed `apps/tuval/src/pi/proof/faux.ts` to read the same flag and to pass
  `noTools: "builtin"` instead of `"all"` when it is on. **Why:** the proof harness built its own
  host layer and never saw the flag, so `proof:pi-vertical` — the acceptance criterion's own hand
  check — could not have exercised the extension; and `"all"` leaves every tool inactive, so a turn
  could never reach `subagent`. `"builtin"` leaves the four disk-touching builtins inactive, which is
  the safety property that docblock rests on, though they stay registered and a
  `setActiveToolsByName` could reactivate them — the comment now says so. **Disposition:** stated
  here.
