### PR TITLE
fix: lane settle refuses 40 (lock held) instead of 7 (no lane) when the lane directory is absent

### DIFF
--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -93,6 +93,12 @@ export interface FakeFsOptions {
 	 * lock another writer holds, so the losing side of an append race is testable on demand.
 	 */
 	readonly mkdirExisting?: ReadonlyArray<string>;
+	/**
+	 * Directory paths whose non-recursive creation fails `NotFound` — a real `mkdir`'s ENOENT when the
+	 * parent is not there. Kept apart from {@link FakeFsOptions.mkdirExisting} because the two are
+	 * opposite answers: one says a holder exists, the other that the containing directory does not.
+	 */
+	readonly mkdirMissingParent?: ReadonlyArray<string>;
 }
 
 export interface FakeFs {
@@ -138,6 +144,9 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 			},
 			makeDirectory: (path: string) => {
 				if (options.unwritable?.includes(path) === true) return notFound("makeDirectory", path);
+				if (options.mkdirMissingParent?.includes(path) === true) {
+					return notFound("makeDirectory", path);
+				}
 				if (options.mkdirExisting?.includes(path) === true) {
 					return Effect.fail(
 						PlatformError.systemError({

--- a/packages/fabrika-cli/src/lane/append-lock.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.ts
@@ -94,7 +94,7 @@ const removeLock = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<v
  *
  * `absent` returns on the first attempt instead of polling: waiting out the budget for a directory
  * to appear reports contention that can never clear, which is what sent a shipper into a retry loop
- * against a lane nobody had opened (#8578).
+ * against a lane nobody had opened.
  */
 export const acquireLedgerLock = (
 	fs: FileSystem.FileSystem,
@@ -130,7 +130,7 @@ export const releaseLedgerLock = (
  * the holder clears" — and it belongs only to a lock a live writer holds. `onAbsent` is the lane's
  * own absence, checked **before** the lock precisely because the lock sits inside the lane
  * directory: a verb that takes the lock first can never reach its own `loadLane`, so an unopened
- * lane answered "another writer holds it" forever (#8578). Nothing here creates the lane directory —
+ * lane answered "another writer holds it" forever. Nothing here creates the lane directory —
  * a ledger nobody booted would spend the proven absence `operate` boots on.
  */
 export const withLedgerLock = <A, R>(

--- a/packages/fabrika-cli/src/lane/append-lock.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.ts
@@ -23,6 +23,7 @@
  */
 import {Effect, type FileSystem, Option, type Path, Result} from "effect";
 import {CONCURRENT_WRITE} from "./codes.ts";
+import {WORKFLOW_FILE} from "./store.ts";
 
 /** The sidecar directory a holding writer creates inside the lane directory. */
 export const LOCK_DIR_NAME = "events.lock";
@@ -52,13 +53,25 @@ export interface LockRefusal {
 	readonly reason: string;
 }
 
-const acquireOnce = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<boolean, never> =>
+/**
+ * What one `mkdir` attempt proved. `held` and `absent` are opposite answers taking opposite
+ * remedies: wait for the holder, versus stop — no lock ever appears inside a directory that is not
+ * there.
+ */
+export type LockAttempt = "acquired" | "held" | "absent";
+
+const acquireOnce = (
+	fs: FileSystem.FileSystem,
+	lockDir: string,
+): Effect.Effect<LockAttempt, never> =>
 	Effect.gen(function* () {
 		const made = yield* Effect.result(fs.makeDirectory(lockDir, {recursive: false}));
-		if (Result.isSuccess(made)) return true;
-		// Any failure to create is treated as "held" — the atomic-mkdir race lands here too,
-		// and a non-existence failure mode is not one mkdir has.
-		return false;
+		if (Result.isSuccess(made)) return "acquired";
+		// A non-recursive mkdir fails two ways that mean opposite things, so the reason decides it:
+		// EEXIST (`AlreadyExists`) is the atomic-mkdir race — someone holds the lock — while ENOENT
+		// (`NotFound`) is the lane directory itself missing, which no amount of waiting fixes. The
+		// errno mapping is `@effect/platform-node-shared`'s `internal/utils.ts`.
+		return made.failure.reason._tag === "NotFound" ? "absent" : "held";
 	});
 
 const stealIfStale = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<boolean, never> =>
@@ -74,21 +87,30 @@ const removeLock = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<v
 	Effect.ignore(fs.remove(lockDir, {recursive: true}));
 
 /**
- * Wait for and hold the lane's write lock. `true` means this writer holds it — release is the
- * caller's duty, best-effort via {@link releaseLock}. `false` means the budget ran out with the
- * lock still held elsewhere; nothing was written anywhere.
+ * Wait for and hold the lane's write lock. `acquired` means this writer holds it — release is the
+ * caller's duty, best-effort via {@link releaseLedgerLock}. `held` means the budget ran out with the
+ * lock still held elsewhere, and `absent` that the directory the lock would live in is not there.
+ * Nothing was written anywhere on either refusal.
+ *
+ * `absent` returns on the first attempt instead of polling: waiting out the budget for a directory
+ * to appear reports contention that can never clear, which is what sent a shipper into a retry loop
+ * against a lane nobody had opened (#8578).
  */
 export const acquireLedgerLock = (
 	fs: FileSystem.FileSystem,
 	lockDir: string,
 	budgetMs: number = lockBudgetMs(),
-): Effect.Effect<boolean, never> =>
+): Effect.Effect<LockAttempt, never> =>
 	Effect.gen(function* () {
 		const deadline = Date.now() + budgetMs;
 		while (true) {
-			if (yield* acquireOnce(fs, lockDir)) return true;
-			if ((yield* stealIfStale(fs, lockDir)) && (yield* acquireOnce(fs, lockDir))) return true;
-			if (Date.now() >= deadline) return false;
+			const attempt = yield* acquireOnce(fs, lockDir);
+			if (attempt !== "held") return attempt;
+			if (yield* stealIfStale(fs, lockDir)) {
+				const stolen = yield* acquireOnce(fs, lockDir);
+				if (stolen !== "held") return stolen;
+			}
+			if (Date.now() >= deadline) return "held";
 			yield* Effect.sleep(`${POLL_MS} millis`);
 		}
 	});
@@ -101,10 +123,15 @@ export const releaseLedgerLock = (
 
 /**
  * Run one verb body inside the lane's write lock. The inner effect sees the bytes as they are when
- * the lock is already held, so its validation cannot race another writer's append. On lock-budget
- * exhaustion the caller's `onLocked` builds the refusal — {@link CONCURRENT_WRITE}'s seat, never
- * an ordinary machine-refusal code, so a caller can tell "retry me" from "this event is invalid".
- * Release runs on every exit, refusal included.
+ * the lock is already held, so its validation cannot race another writer's append. Release runs on
+ * every exit, refusal included.
+ *
+ * Two refusals, two seats. `onLocked` is {@link CONCURRENT_WRITE}'s — "retry this same event once
+ * the holder clears" — and it belongs only to a lock a live writer holds. `onAbsent` is the lane's
+ * own absence, checked **before** the lock precisely because the lock sits inside the lane
+ * directory: a verb that takes the lock first can never reach its own `loadLane`, so an unopened
+ * lane answered "another writer holds it" forever (#8578). Nothing here creates the lane directory —
+ * a ledger nobody booted would spend the proven absence `operate` boots on.
  */
 export const withLedgerLock = <A, R>(
 	deps: {
@@ -116,13 +143,22 @@ export const withLedgerLock = <A, R>(
 		readonly verb: string;
 	},
 	inner: Effect.Effect<A, never, R>,
-	onLocked: (lockDir: string, reason: string) => A,
+	refusals: {
+		/** No lane at `dir` — the caller's own "no lane" answer, never the lock's. */
+		readonly onAbsent: (dir: string) => A;
+		readonly onLocked: (lockDir: string, reason: string) => A;
+	},
 ): Effect.Effect<A, never, R> =>
 	Effect.gen(function* () {
 		const lockDir = deps.path.join(deps.dir, LOCK_DIR_NAME);
-		const held = yield* acquireLedgerLock(deps.fs, lockDir);
-		if (!held) {
-			return onLocked(
+		// The same document `loadLane` proves a lane absent by, so "no lane" means one thing here and
+		// downstream. An unprobeable path is UNKNOWN rather than absent: it falls through to the lock.
+		const booted = yield* Effect.result(deps.fs.exists(deps.path.join(deps.dir, WORKFLOW_FILE)));
+		if (Result.isSuccess(booted) && !booted.success) return refusals.onAbsent(deps.dir);
+		const attempt = yield* acquireLedgerLock(deps.fs, lockDir);
+		if (attempt === "absent") return refusals.onAbsent(deps.dir);
+		if (attempt === "held") {
+			return refusals.onLocked(
 				lockDir,
 				`another writer holds ${lockDir} — concurrent writers are serialized, so retry this exact event once the holder clears`,
 			);

--- a/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
@@ -8,10 +8,11 @@
  * for the guard to matter — lives in [`append-race.cli.test.ts`](append-race.cli.test.ts), which
  * races real processes against one ledger.
  */
-import {Effect} from "effect";
+import {Effect, FileSystem} from "effect";
 import {afterEach, describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
-import {CONCURRENT_WRITE, EVENT_REFUSED} from "./codes.ts";
+import {acquireLedgerLock} from "./append-lock.ts";
+import {CONCURRENT_WRITE, EVENT_REFUSED, LANE_ABSENT} from "./codes.ts";
 import {coderTemplateText} from "./fixtures.test-support.ts";
 import {runTransition} from "./transition-verb.ts";
 
@@ -78,6 +79,58 @@ describe("lane append lock", {timeout: 10_000}, () => {
 		expect(lockedOut.code).not.toBe(refused.code);
 		// And the wording itself carries the distinction, not just the number.
 		expect(lockedOut.stderr.join(" ")).toContain("retry this exact event");
+	});
+
+	it("a lock whose parent directory is absent reports absent, without spending the budget", async () => {
+		const fs = fakeFs({mkdirMissingParent: [LOCK]});
+		const started = Date.now();
+
+		const attempt = await Effect.runPromise(
+			Effect.provide(
+				Effect.gen(function* () {
+					const filesystem = yield* FileSystem.FileSystem;
+					return yield* acquireLedgerLock(filesystem, LOCK, 5_000);
+				}),
+				fs.layer,
+			),
+		);
+
+		expect(attempt).toBe("absent");
+		// The whole defect was polling this one out: an ENOENT read as contention waits for a holder
+		// that cannot arrive.
+		expect(Date.now() - started).toBeLessThan(1_000);
+	});
+
+	it("an appending verb on an absent lane refuses LANE_ABSENT, writing and creating nothing", async () => {
+		process.env.FABRIKA_LANE_LOCK_BUDGET_MS = SHORT_LOCK_MS;
+		const fs = fakeFs({});
+
+		const out = await run(fs);
+		expect(out.code).toBe(LANE_ABSENT);
+		expect(out.stderr.join(" ")).toContain("no lane at");
+		expect(fs.written.size).toBe(0);
+		// The lane directory stays absent: a ledger nobody booted is not this verb's to manufacture.
+		const made = await Effect.runPromise(
+			Effect.provide(
+				Effect.gen(function* () {
+					const filesystem = yield* FileSystem.FileSystem;
+					return yield* filesystem.exists(`${ROOT}/42`);
+				}),
+				fs.layer,
+			),
+		);
+		expect(made).toBe(false);
+	});
+
+	it("an absent lane and a held lock keep their own seats", async () => {
+		process.env.FABRIKA_LANE_LOCK_BUDGET_MS = SHORT_LOCK_MS;
+
+		const absent = await run(fakeFs({}));
+		const held = await run(freshLane({mkdirExisting: [LOCK]}));
+
+		expect(absent.code).toBe(LANE_ABSENT);
+		expect(held.code).toBe(CONCURRENT_WRITE);
+		expect(held.stderr.join(" ")).toContain("another writer holds");
 	});
 
 	it("the uncontended path appends exactly as before the lock existed", async () => {

--- a/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
@@ -122,6 +122,17 @@ describe("lane append lock", {timeout: 10_000}, () => {
 		expect(made).toBe(false);
 	});
 
+	it("a lane that goes away after the probe still refuses LANE_ABSENT, not a held lock", async () => {
+		process.env.FABRIKA_LANE_LOCK_BUDGET_MS = SHORT_LOCK_MS;
+		// The probe passes and the mkdir then hits ENOENT — the window between the two, which only the
+		// lock's own reason read can answer.
+		const fs = freshLane({mkdirMissingParent: [LOCK]});
+
+		const out = await run(fs);
+		expect(out.code).toBe(LANE_ABSENT);
+		expect(fs.written.get(LOG)).toBeUndefined();
+	});
+
 	it("an absent lane and a held lock keep their own seats", async () => {
 		process.env.FABRIKA_LANE_LOCK_BUDGET_MS = SHORT_LOCK_MS;
 

--- a/packages/fabrika-cli/src/lane/clearance.ts
+++ b/packages/fabrika-cli/src/lane/clearance.ts
@@ -73,11 +73,14 @@ export const recordClearedRound = (
 					? ({_tag: "Unusable", path: loaded.logPath, reason: wrote.failure.reason} as const)
 					: ({_tag: "Recorded", task: resolved.taskId, path: loaded.logPath} as const);
 			}),
-			(lockDir) => ({
-				_tag: "Unusable" as const,
-				path: lockDir,
-				reason: lockedRefusal(VERB, lockDir),
-			}),
+			{
+				onAbsent: (dir) => ({_tag: "NoLane" as const, dir}),
+				onLocked: (lockDir) => ({
+					_tag: "Unusable" as const,
+					path: lockDir,
+					reason: lockedRefusal(VERB, lockDir),
+				}),
+			},
 		);
 	});
 };

--- a/packages/fabrika-cli/src/lane/reconcile-verb.ts
+++ b/packages/fabrika-cli/src/lane/reconcile-verb.ts
@@ -250,7 +250,19 @@ const reconcileLane = <R>(
 					? unappended(`the append to ${fresh.logPath} did not land: ${wrote.failure.reason}`)
 					: {key, root, verdict: partial ? ("corrected" as const) : ("confirmed" as const), ...row};
 			}),
-			(lockDir) => unappended(lockedRefusal(VERB, lockDir)),
+			{
+				// This sweep only reaches lanes it just loaded, so an absent one here means the lane was
+				// removed under the sweep. `unknown` is that seat — the row a reader re-runs, not the
+				// `unappended` fault of an append this run actually tried.
+				onAbsent: (dir) => ({
+					key,
+					root,
+					verdict: "unknown" as const,
+					corrects,
+					reason: `no lane at ${dir} — it went away between this sweep's read and its append`,
+				}),
+				onLocked: (lockDir) => unappended(lockedRefusal(VERB, lockDir)),
+			},
 		);
 	});
 

--- a/packages/fabrika-cli/src/lane/report-verb.ts
+++ b/packages/fabrika-cli/src/lane/report-verb.ts
@@ -208,6 +208,9 @@ export const runReport = <R>(
 					],
 				);
 			}),
-			(lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
+			{
+				onAbsent: (dir) => loadRefusal(VERB, {_tag: "Absent", dir}),
+				onLocked: (lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
+			},
 		);
 	});

--- a/packages/fabrika-cli/src/lane/settle-verb.ts
+++ b/packages/fabrika-cli/src/lane/settle-verb.ts
@@ -386,6 +386,9 @@ export const runSettle = <R = never>(
 					],
 				);
 			}),
-			(lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
+			{
+				onAbsent: (dir) => loadRefusal(VERB, {_tag: "Absent", dir}),
+				onLocked: (lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
+			},
 		);
 	});

--- a/packages/fabrika-cli/src/lane/store.ts
+++ b/packages/fabrika-cli/src/lane/store.ts
@@ -36,6 +36,9 @@ export const DEFAULT_CHORES_ROOT = ".fabrika/chores";
  */
 export const DEFAULT_ARCHIVED_LANES_ROOT = ".fabrika/lanes-archived";
 
+/** The machine document whose absence is what makes a lane absent, and nothing else. */
+export const WORKFLOW_FILE = "workflow.json";
+
 export interface LaneRef {
 	/** The lanes root — `.fabrika/lanes`, or `.fabrika/chores` for a chore key. */
 	readonly root: string;
@@ -62,7 +65,7 @@ export const loadLane = (
 	Effect.gen(function* () {
 		const path = yield* Path.Path;
 		const dir = path.join(ref.root, ref.lane);
-		const workflowPath = path.join(dir, "workflow.json");
+		const workflowPath = path.join(dir, WORKFLOW_FILE);
 		const logPath = path.join(dir, "events.jsonl");
 
 		const workflowText = yield* Effect.result(readFile(workflowPath));
@@ -123,7 +126,7 @@ export const placeMachine = (
 			return {_tag: "Unprobeable", dir, reason: probe.failure.reason} as const;
 		}
 		if (probe.success) return {_tag: "Exists", dir} as const;
-		const workflow = path.join(dir, "workflow.json");
+		const workflow = path.join(dir, WORKFLOW_FILE);
 		const wrote = yield* Effect.result(writeFile(workflow, text));
 		if (Result.isFailure(wrote)) {
 			return {_tag: "Unwritten", path: workflow, reason: wrote.failure.reason} as const;

--- a/packages/fabrika-cli/src/lane/transition-verb.ts
+++ b/packages/fabrika-cli/src/lane/transition-verb.ts
@@ -159,6 +159,9 @@ export const runTransition = (
 					[`${VERB}: appended ${entry.event} to ${loaded.logPath}.`],
 				);
 			}),
-			(lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
+			{
+				onAbsent: (dir) => loadRefusal(VERB, {_tag: "Absent", dir}),
+				onLocked: (lockDir) => refuse(CONCURRENT_WRITE, lockedRefusal(VERB, lockDir)),
+			},
 		);
 	});


### PR DESCRIPTION
`fabrika lane settle` on a lane that was never opened refused 40 ("another writer holds
`events.lock`") instead of 7 ("no lane"). 40 tells the caller to retry once the holder clears, so a
shipper burned its whole budget waiting on a directory that does not exist and the landing row was
never recorded.

Two things caused it, and both are fixed here.

`acquireOnce` treated every failed `mkdir` as "the lock is held". A non-recursive `mkdir` fails two
ways that mean opposite things: `EEXIST` is the atomic-mkdir race, `ENOENT` is the parent lane
directory missing. It now reads the failure's reason (`AlreadyExists` vs `NotFound`, the errno
mapping in `@effect/platform-node-shared`'s `internal/utils.ts`) and reports `held` or `absent`.
`acquireLedgerLock` returns an `absent` on the first attempt instead of polling the budget out. The
comment that produced the bug is gone.

`withLedgerLock` took the lock around each verb's whole load → fold → append section, so `loadLane`
— the thing that refuses `LANE_ABSENT` — was unreachable on an absent lane. It now probes the lane's
`workflow.json` before the lock, the same document `loadLane` proves a lane absent by, and hands the
answer to a new `onAbsent`. Nothing creates the lane directory: a ledger nobody booted would spend
the proven absence `operate` boots on. An unprobeable path stays UNKNOWN and falls through to the
lock.

All five callers pass their own `onAbsent`, so the seat is each verb's own: `settle`, `report` and
`transition` refuse `LANE_ABSENT` (7) through the shared `loadRefusal`, `build clear` answers
`NoLane` exactly as it already did on a load-time absence, and `lane reconcile` — which has no
per-lane exit code, only verdict rows — returns `unknown` for a lane that went away under the sweep,
rather than the `unappended` fault of an append it actually tried.

Tests: `acquireLedgerLock` against a lock whose parent is missing answers `absent` in well under the
budget; an appending verb on an absent lane exits 7, writes nothing, and leaves the lane directory
absent; and a third case pins the two seats apart — absent is 7, a genuinely held lock is still 40.
The existing held-lock and uncontended cases are untouched and green. `fakeFs` gained
`mkdirMissingParent` so a real `mkdir`'s ENOENT is scriptable, kept separate from `mkdirExisting`
because the two are opposite answers.

Verified against the real filesystem too: `fabrika lane settle 99999991 --landed-by 8571` now exits
7 immediately with "no lane at …", and creates no directory.

Fixes #8578

Closing #8392 as a duplicate of this one is triage's call, per the issue's attach note — this PR
does not close it.

## Deviations

- **Scope narrowing** — **Said:** the acceptance criteria say "the same absent-lane refusal reaches
  every `withLedgerLock` caller", naming `reconcile-verb.ts`. **Did:** `lane reconcile` returns an
  `unknown` verdict row for the absent lane instead of exiting 7. **Why:** `reconcile` sweeps many
  lanes and has no per-lane exit code — its own answer to an absent lane at load time is to skip the
  row, and `unknown` is the seat a reader re-runs. What the criterion is about, the false
  "lock held", is gone on that path too. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8578 names the lock and its five callers. **Did:** also added
  `WORKFLOW_FILE` to `store.ts` and used it at the two existing `workflow.json` joins there.
  **Why:** the pre-lock probe has to name the same document `loadLane` proves absence by, and two
  modules hardcoding the string is how they drift apart. **Disposition:** stated here.
