### PR TITLE
fix: A failed reconnect leaves a Tuval AI agent process with a live transport and no event stream

### DIFF
--- a/.patterns/agent-layer-phase-contract.md
+++ b/.patterns/agent-layer-phase-contract.md
@@ -145,3 +145,24 @@ a layer that never sent one.
 
 A conformance test over every layer would be stronger than this doc. The layers differ enough in how
 a turn is driven that its shape is an open question; no such test exists today and none is filed.
+
+## An open outcome also ends a subscription lifetime
+
+The transport is rebuilt before the agent's `start` call in
+[`handlers/index.ts`](../apps/tuval/src/ai-agent/handlers/index.ts), so both `started` and
+`openFailed` advance `connection`. The latter is a dedicated completion message, not a diagnostic
+classification: an ordinary `failed` message has rebuilt nothing and cannot advance the generation.
+The existing failure fold still chooses `idle` for a refused open and `gone` for a missing resumed
+session; a process with no session id or a terminal session desires no event subscription.
+
+This distinction follows the current host's
+[`reconcile`](../apps/tuval/src/host/actor.ts): an ended or failed manual subscription keeps its
+registered id, and an unchanged id is never re-armed. A new generation closes that registration and
+subscribes to the agent now held by the slot. The slot's child Scope independently closes the old
+transport on rebuild; Effect rc.112's `Scope.fork` documents that closing a child detaches it from
+its parent. Neither an ended event fiber nor a failed start can stand in for the new lifetime id.
+
+The handler regression drives the real process registry with a script whose second build refuses
+start. It observes the changed desired id, a notification from that rebuilt agent's actual event
+queue, and a reply after a third build reconnects successfully. Transport and subscription
+finalizers are counted separately, and ordinary failure keeps the existing subscription identity.

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -211,8 +211,8 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 							],
 						],
 
-			// The connection bump is what re-opens the events Sub: a reconnect stands a new transport
-			// up under the same session id, and the Sub is reconciled by id (`messages.ts`).
+			// Both open completions advance the subscription lifetime: the slot was rebuilt whether
+			// start succeeded or refused. Ordinary failures leave that lifetime alone.
 			started: (state, msg) =>
 				state.phase === "gone"
 					? [state, noCmds]
@@ -470,6 +470,8 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 					],
 				];
 			},
+
+			openFailed: (state, msg) => failed({...state, connection: state.connection + 1}, msg.failure),
 
 			failed: (state, msg) => failed(state, msg.failure),
 		},

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -1012,6 +1012,22 @@ describe("reconnect", () => {
 	});
 });
 
+describe("openFailed", () => {
+	it("advances a failed fresh open without inventing a session subscription", () => {
+		const opening = {...initialState("/repo"), phase: "starting" as const};
+		const failure = {tag: "tuval/ai-agent/StartError", reason: "refused", detail: "not accepted"};
+		const [state, cmds] = apply(opening, {type: "openFailed", failure});
+		expect(state).toMatchObject({
+			phase: "idle",
+			sessionId: null,
+			connection: opening.connection + 1,
+			failure,
+		});
+		expect(machine.subscriptions?.(state)).toEqual([]);
+		expect(cmds).toEqual([]);
+	});
+});
+
 describe("failed", () => {
 	it("records the layer's tag and leaves the phase where the act began", () => {
 		const failure = {tag: "tuval/ai-agent/PromptError", reason: "disconnected", detail: "gone"};
@@ -1025,13 +1041,16 @@ describe("failed", () => {
 		expect(fromReconnect.phase).toBe("idle");
 	});
 
-	it("ends a resume the backend refused at gone, never anywhere a fresh session can open", () => {
+	it.each([
+		"failed",
+		"openFailed",
+	] as const)("ends a missing session at gone through %s", (type) => {
 		const failure = {
 			tag: "tuval/ai-agent/StartError",
 			reason: "session-not-found",
 			detail: "the backend holds no session-1",
 		};
-		const [refused] = apply(started({phase: "reconnecting"}), {type: "failed", failure});
+		const [refused] = apply(started({phase: "reconnecting"}), {type, failure});
 		expect(refused).toMatchObject({phase: "gone", sessionId: "session-1", failure});
 		expect(machine.subscriptions?.(refused)).toEqual([]);
 	});
@@ -1457,6 +1476,14 @@ describe("the Cmd each Msg answers for", () => {
 		],
 		[started({phase: "prompting"}), {type: "interrupt", at: SENT_AT}, ["aiAgent.interrupt"]],
 		[started(), {type: "reconnect"}, ["aiAgent.republish", "aiAgent.reconnect"]],
+		[
+			started({phase: "reconnecting"}),
+			{
+				type: "openFailed",
+				failure: {tag: "tuval/ai-agent/StartError", reason: "refused", detail: "not accepted"},
+			},
+			[],
+		],
 		[
 			started(),
 			{type: "failed", failure: {tag: "tuval/ai-agent/PageError", reason: null, detail: "x"}},

--- a/apps/tuval/src/ai-agent/core/messages.ts
+++ b/apps/tuval/src/ai-agent/core/messages.ts
@@ -15,6 +15,8 @@ import type {AgentFailure, HistoryPage} from "./state.ts";
 export type AiAgentSessionMsg =
 	| {readonly type: "start"; readonly cwd: string; readonly resume: string | null}
 	| {readonly type: "started"; readonly sessionId: string}
+	/** The slot was rebuilt, but its start call refused; the subscription lifetime still changed. */
+	| {readonly type: "openFailed"; readonly failure: AgentFailure}
 	/**
 	 * `key` is the idempotency key the window mints per deliberate send (ruling 2, #7570), and the
 	 * id of the turn the `prompt` cell records is derived from it. `timestamp` rides along because

--- a/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/handlers.unit.test.ts
@@ -8,7 +8,7 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Context, Effect, Layer, type Scope} from "effect";
+import {Context, Effect, Layer, type Scope, Stream} from "effect";
 import {assistantItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
 import {Checkpoints} from "../../durability/Checkpoints.ts";
 import {memoryStores} from "../../durability/stores.ts";
@@ -18,7 +18,11 @@ import {Processes} from "../../process/Processes.ts";
 import type {ProcessTable} from "../../process/ProcessTable.ts";
 import type {ProcessHandle} from "../../process/process.ts";
 import {Registry} from "../../registry/Registry.ts";
-import {type AiAgentSessionState, isAiAgentSessionState} from "../core/index.ts";
+import {
+	type AiAgentSessionState,
+	aiAgentSessionMachine,
+	isAiAgentSessionState,
+} from "../core/index.ts";
 import type {
 	ModelRef,
 	ModePayload,
@@ -44,12 +48,18 @@ import {
 	StartError,
 	type StartOptions,
 	TuvalAiAgent,
+	type TuvalAiAgentApi,
 } from "../service/index.ts";
 import {aiAgentPortNames} from "./publish.ts";
 
 const PROGRAM = "ai-agent-session-test";
 
+type ScriptSource = AgentScript | ((build: number) => AgentScript);
+
 interface Probe {
+	agents: Array<TuvalAiAgentApi>;
+	subscribed: Array<number>;
+	unsubscribed: Array<number>;
 	acquired: number;
 	released: number;
 	/** Prompts the layer was actually asked for; a refused prompt has to reach none of them. */
@@ -59,7 +69,16 @@ interface Probe {
 	pages: Array<string | null>;
 }
 
-const probeOf = (): Probe => ({acquired: 0, released: 0, prompts: 0, sent: [], pages: []});
+const probeOf = (): Probe => ({
+	acquired: 0,
+	released: 0,
+	prompts: 0,
+	sent: [],
+	pages: [],
+	agents: [],
+	subscribed: [],
+	unsubscribed: [],
+});
 
 /** A backend that holds no session at all, whatever it is asked to open. */
 const refusesEveryStart = (options: StartOptions) =>
@@ -75,27 +94,40 @@ const refusesEveryStart = (options: StartOptions) =>
  * that the *row* builds the layer once per process and closes it once, not anything about the
  * script.
  *
- * `refuseStart` is the one behaviour the script itself cannot produce. A fresh session opens itself
- * now (#7925), so no caller is left that can hand `start` an id the backend does not hold — the
- * refusal a start answers with has to come from the layer.
+ * A script factory varies the backend by build, so a reconnect can refuse where the first open
+ * succeeded. The probe observes real streams and their finalizers without replacing the handlers.
  */
 const countingLayer = (
-	script: AgentScript,
+	script: ScriptSource,
 	probe: Probe,
 	refuseStart = false,
 ): Layer.Layer<TuvalAiAgent> =>
 	Layer.effect(
 		TuvalAiAgent,
 		Effect.gen(function* () {
-			probe.acquired += 1;
+			const build = ++probe.acquired;
 			yield* Effect.addFinalizer(() =>
 				Effect.sync(() => {
 					probe.released += 1;
 				}),
 			);
-			const agent = Context.get(yield* Layer.build(ScriptedAiAgent.layer(script)), TuvalAiAgent);
+			const selected = typeof script === "function" ? script(build) : script;
+			const agent = Context.get(yield* Layer.build(ScriptedAiAgent.layer(selected)), TuvalAiAgent);
+			probe.agents.push(agent);
 			return {
 				...agent,
+				events: Stream.unwrap(
+					Effect.sync(() => {
+						probe.subscribed.push(build);
+						return agent.events;
+					}),
+				).pipe(
+					Stream.ensuring(
+						Effect.sync(() => {
+							probe.unsubscribed.push(build);
+						}),
+					),
+				),
 				start: (options: StartOptions) =>
 					refuseStart ? Effect.fail(refusesEveryStart(options)) : agent.start(options),
 				page: (before: string | null, limit: number) =>
@@ -139,7 +171,7 @@ interface KernelOptions {
 	readonly refuseStart?: boolean;
 }
 
-const row = (script: AgentScript, probe: Probe, options: KernelOptions) =>
+const row = (script: ScriptSource, probe: Probe, options: KernelOptions) =>
 	aiAgentProgram({
 		id: PROGRAM,
 		layer: countingLayer(script, probe, options.refuseStart ?? false),
@@ -150,7 +182,7 @@ const row = (script: AgentScript, probe: Probe, options: KernelOptions) =>
 	});
 
 const withKernel = <A, E>(
-	script: AgentScript,
+	script: ScriptSource,
 	probe: Probe,
 	body: (
 		spawn: Effect.Effect<ProcessHandle, unknown>,
@@ -495,7 +527,7 @@ describe("the AI agent handlers under a process", () => {
 		);
 	});
 
-	it.live("turns a start the backend refuses into a failed Msg carrying the tag", () => {
+	it.live("turns a start the backend refuses into an openFailed Msg carrying the tag", () => {
 		const probe = probeOf();
 		return withKernel(
 			plainReply,
@@ -606,6 +638,102 @@ describe("the AI agent handlers under a process", () => {
 			}),
 		);
 	});
+
+	it.live(
+		"rearms the rebuilt transport after a failed second start and a later successful reconnect",
+		() => {
+			const probe = probeOf();
+			const machine = aiAgentSessionMachine({cwd: "/work"});
+			const ids = (handle: ProcessHandle) =>
+				(machine.subscriptions?.(sessionOf(handle)) ?? []).map((sub) => sub.id);
+			const script: ScriptSource = (build) => ({
+				...plainReply,
+				...(build === 2
+					? {
+							startRefusal: new StartError({
+								cwd: "/work",
+								reason: "refused",
+								detail: "second open refused",
+							}),
+						}
+					: {}),
+				interrupt: [
+					{kind: "item", item: assistantItem(`notice-${build}`, `transport-${build} notification`)},
+				],
+				turns: [
+					{
+						events: [
+							{kind: "phase", phase: "prompting"},
+							{kind: "item", item: assistantItem(`answer-${build}`, `reply-${build}`)},
+							{kind: "phase", phase: "ready"},
+						],
+					},
+				],
+			});
+			return withKernel(script, probe, (spawn, log) =>
+				Effect.gen(function* () {
+					const handle = yield* spawn;
+					yield* eventually(() => sessionOf(handle).phase === "ready");
+					yield* handle.dispatch({type: "prompt", text: "first", key: "first", timestamp: 1});
+					yield* eventually(() =>
+						sessionOf(handle).transcript.items.some((item) => item.id === "answer-1"),
+					);
+					const before = ids(handle);
+					assert.lengthOf(before, 1);
+					yield* handle.dispatch({type: "reconnect"});
+					yield* eventually(
+						() => sessionOf(handle).failure?.detail.includes("second open refused") === true,
+					);
+					const failed = ids(handle);
+					assert.notDeepEqual(failed, before);
+					assert.lengthOf(failed, 1);
+					assert.strictEqual(sessionOf(handle).phase, "idle");
+					yield* eventually(() => probe.subscribed.includes(2));
+					assert.deepStrictEqual(probe.subscribed, [1, 2]);
+					assert.deepStrictEqual([probe.acquired, probe.released], [2, 1]);
+					assert.deepStrictEqual(probe.unsubscribed, [1]);
+					const rebuilt = probe.agents[1];
+					if (rebuilt === undefined) return yield* Effect.die("missing rebuilt backend");
+					yield* rebuilt.interrupt;
+					yield* eventually(() =>
+						sessionOf(handle).transcript.items.some((item) => item.id === "notice-2"),
+					);
+					assert.isTrue(sessionOf(handle).transcript.items.some((item) => item.id === "notice-2"));
+					assert.isTrue(sessionOf(handle).transcript.items.some((item) => item.id === "answer-1"));
+					assert.include(
+						JSON.stringify(lastOn(log, aiAgentPortNames.transcript)),
+						"transport-2 notification",
+					);
+					yield* handle.dispatch({
+						type: "failed",
+						failure: {
+							tag: "tuval/ai-agent/PromptError",
+							reason: "refused",
+							detail: "ordinary refusal",
+						},
+					});
+					assert.deepStrictEqual(ids(handle), failed);
+					assert.deepStrictEqual(probe.subscribed, [1, 2]);
+					yield* handle.dispatch({type: "reconnect"});
+					yield* eventually(
+						() => sessionOf(handle).phase === "ready" && probe.subscribed.includes(3),
+					);
+					assert.notDeepEqual(ids(handle), failed);
+					assert.deepStrictEqual([probe.acquired, probe.released], [3, 2]);
+					assert.deepStrictEqual(probe.unsubscribed, [1, 2]);
+					yield* handle.dispatch({type: "prompt", text: "again", key: "again", timestamp: 2});
+					yield* eventually(() =>
+						sessionOf(handle).transcript.items.some((item) => item.id === "answer-3"),
+					);
+					assert.isTrue(sessionOf(handle).transcript.items.some((item) => item.id === "answer-3"));
+					assert.include(JSON.stringify(lastOn(log, aiAgentPortNames.transcript)), "reply-3");
+					yield* handle.stop;
+					assert.deepStrictEqual([probe.acquired, probe.released], [3, 3]);
+					assert.deepStrictEqual(probe.unsubscribed, [1, 2, 3]);
+				}),
+			);
+		},
+	);
 
 	it.live("publishes nothing and fails nothing when a port has no route", () => {
 		const probe = probeOf();

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -159,11 +159,14 @@ export const aiAgentHandlers = <RIn = never>(
 				return [{type: "started", sessionId: started.success.sessionId}];
 			}
 			const error = started.failure;
-			return refusal(
-				isTimeout(error)
-					? deadlineFailure(START_ERROR, policy.deadlineMillis)
-					: failureOf(error as AgentServiceError),
-			);
+			return [
+				{
+					type: "openFailed",
+					failure: isTimeout(error)
+						? deadlineFailure(START_ERROR, policy.deadlineMillis)
+						: failureOf(error as AgentServiceError),
+				},
+			];
 		});
 
 	/**


### PR DESCRIPTION
A reconnect whose start call fails now gives the rebuilt transport a new event subscription identity. The dedicated `openFailed` completion advances the connection generation and uses the existing failure fold; ordinary failures keep their subscription lifetime. A later reconnect still receives events, and missing sessions retain their terminal behavior.

Fixes #7749.

Release containment: none. This local-only Tuval lifecycle fix is available by default.

Validation: root `pnpm typecheck` passed all 22 tasks; all 2,480 Tuval tests pass across 257 files; affected typecheck/lint and prose checks are green. The new actual-process regression first failed on identical pre/post-failure subscription IDs, then passed with event delivery from the second transport's real scripted queue, preserved history, a third reconnect's reply, and exact transport/subscription cleanup counts. Fresh-open and missing-session cases remain covered.

The lifetime rule is grounded in the current host's `manualSubs.has(sub.id)` reconciliation and Effect rc.112's `Scope.fork`/`Stream.ensuring` source, following [Effect LLMS resource and stream guidance](https://github.com/Effect-TS/effect/blob/main/LLMS.md#managing-resources-and-scopes). The existing pattern explains how both open outcomes renew the lifetime.

## Deviations

- **Generation ownership** — **Said:** the issue suggests minting a generation at rebuild or in the failed reducer as possible mechanics. **Did:** added a dedicated `openFailed` completion beside `started`, advancing the generation only for completed open attempts. **Why:** a generic failure can describe an ordinary operation that rebuilt nothing, so it cannot reliably identify a new transport. **Disposition:** within the acceptance criteria; no new retry or phase policy.
- **Lifecycle fixture** — **Said:** add a script whose second start fails. **Did:** extended the existing counting fixture to choose a real ScriptedAiAgent script per build and observe actual stream finalizers. **Why:** the regression must prove registry reconciliation, event delivery and cleanup rather than only a numeric increment. **Disposition:** covered through the real Processes/handler path; no product copy or component changes.
