### PR TITLE
fix: The Tuval transport logs an unhandled SocketError for every page socket that closes abnormally

### DIFF
--- a/.patterns/effect-socket-session.md
+++ b/.patterns/effect-socket-session.md
@@ -57,3 +57,26 @@ depends on from being started after the frame that needed it.
   `connection` event fires, which is the only way to refuse before a frame exists.
 - **Closing on a bad frame is a `CloseEvent` through the same writer** —
   `write(new Socket.CloseEvent(1008, reason))` — never a bare `ws.close`.
+
+## Expected page closes finish the session
+
+The server applies one named `quietPageClose` policy to the run loop: 1000 (normal), 1001
+(going away), and 1006 (observed abnormal closure without a close frame). These meanings come from
+[RFC 6455 §7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1); treating those page
+disconnections as successful session completion is Tuval's policy, not a protocol requirement.
+1006 is observed locally, never sent in a close frame. Other codes, including policy violation
+1008, remain failures.
+
+At `effect@4.0.0-rc.112`, `SocketCloseError.filterClean` checks both the outer `SocketError`
+and inner close reason before applying its code predicate. Unmatched values return unchanged.
+Pair it with `Effect.catchFilter` on `runString`, as the pinned `Socket.fromWebSocket`
+implementation does internally. Read, write, and open failures escaping the run loop retain their
+identity. The existing per-frame write-race policy above is separate.
+
+At `@effect/platform-node-shared@4.0.0-rc.112`, `src/NodeSocketServer.ts` constructs accepted
+sockets without a close-code override and reports the handler's failure cause. The socket default
+considers every close code an error, so the session must apply its own narrow policy before that
+reporter. Session scope finalization still removes its page sender and stops its subscriptions;
+it does not terminate attached kernel processes. The session unit tests prove cleanup and process
+survival, and the real WebSocket regression terminates a page without a handshake, captures the
+server reporter, and reattaches to the retained process.

--- a/apps/tuval/src/shell/transport/server.ts
+++ b/apps/tuval/src/shell/transport/server.ts
@@ -122,6 +122,7 @@ export interface SocketSession {
 }
 
 const CLOSE_POLICY = 1008;
+const quietPageClose = (code: number): boolean => code === 1000 || code === 1001 || code === 1006;
 
 /** Every attached page's writer. A catalog change reaches the pages already open through these. */
 type Attached = Set<(frame: ServerFrame) => Effect.Effect<void>>;
@@ -234,7 +235,7 @@ export const serve = Effect.fn("Tuval.transport.serve")(function* (options: Serv
 	} satisfies TransportServer;
 });
 
-const session = Effect.fn("Tuval.transport.session")(function* (
+export const session = Effect.fn("Tuval.transport.session")(function* (
 	socket: Socket.Socket,
 	handles: Handles,
 	spells: SpellChannel,
@@ -423,19 +424,23 @@ const session = Effect.fn("Tuval.transport.session")(function* (
 		yield* Effect.ignore(Deferred.succeed(ready, undefined));
 	});
 
-	yield* socket.runString(
-		(text) => {
-			const decoded = decodeClientFrame(text);
-			// A frame can land while `greet` is still forking the pumps; waiting here is what keeps an
-			// attach from marking a process before the stream that serves it is running.
-			return Deferred.await(ready).pipe(
-				Effect.andThen(
-					decoded._tag === "Frame"
-						? onFrame(decoded.frame)
-						: close(`undecodable frame: ${decoded.reason}`),
-				),
-			);
-		},
-		{onOpen: greet},
-	);
+	yield* socket
+		.runString(
+			(text) => {
+				const decoded = decodeClientFrame(text);
+				// A frame can land while `greet` is still forking the pumps; waiting here is what keeps an
+				// attach from marking a process before the stream that serves it is running.
+				return Deferred.await(ready).pipe(
+					Effect.andThen(
+						decoded._tag === "Frame"
+							? onFrame(decoded.frame)
+							: close(`undecodable frame: ${decoded.reason}`),
+					),
+				);
+			},
+			{onOpen: greet},
+		)
+		.pipe(
+			Effect.catchFilter(Socket.SocketCloseError.filterClean(quietPageClose), () => Effect.void),
+		);
 });

--- a/apps/tuval/src/shell/transport/session.unit.test.ts
+++ b/apps/tuval/src/shell/transport/session.unit.test.ts
@@ -1,0 +1,146 @@
+import {defineMachine} from "@demlik/tea";
+import {assert, describe, it} from "@effect/vitest";
+import {
+	Cause,
+	Context,
+	Deferred,
+	Effect,
+	Exit,
+	Fiber,
+	Layer,
+	Option,
+	Semaphore,
+	Stream,
+} from "effect";
+import {Socket} from "effect/unstable/socket";
+import {Checkpoints} from "../../durability/Checkpoints.ts";
+import {memoryStores} from "../../durability/stores.ts";
+import {Processes} from "../../process/Processes.ts";
+import {ProcessTable} from "../../process/ProcessTable.ts";
+import {ProcessId} from "../../process/process.ts";
+import {type AnyProgram, ProgramId} from "../../registry/program.ts";
+import {Registry} from "../../registry/Registry.ts";
+import {ProcessTablePort} from "../../table/ProcessTablePort.ts";
+import {defaultPrefixTable} from "../keys/index.ts";
+import {session} from "./server.ts";
+import {ATTACH_KIND, PROCESS_STATE_KIND} from "./wire.ts";
+
+const processId = ProcessId.make("retained");
+const program: AnyProgram = {
+	id: ProgramId.make("socket-test"),
+	core: defineMachine({init: () => [{count: 0}, []], update: {}}),
+	ports: {},
+	handlers: {},
+	capabilities: [],
+	placement: {host: "local"},
+	identity: {package: "@kampus/tuval", program: "socket-test", version: "1", digest: "socket-test"},
+};
+
+const controlled = Effect.gen(function* () {
+	const closed = yield* Deferred.make<void, Socket.SocketError>();
+	const ready = yield* Deferred.make<void>();
+	const writes: string[] = [];
+	const socket: Socket.Socket = Socket.Socket.of({
+		[Socket.TypeId]: Socket.TypeId,
+		writer: Effect.succeed((chunk) =>
+			Effect.sync(() => {
+				if (typeof chunk === "string") writes.push(chunk);
+			}),
+		),
+		run: () => Effect.never,
+		runRaw: () => Effect.never,
+		runString: (handler, options) =>
+			Effect.gen(function* () {
+				yield* options?.onOpen ?? Effect.void;
+				const handled = handler(JSON.stringify({kind: ATTACH_KIND, processId}));
+				if (handled !== undefined) yield* handled;
+				yield* Deferred.succeed(ready, undefined);
+				yield* Deferred.await(closed);
+			}),
+	});
+	return {socket, closed, ready, writes};
+});
+
+const kernel = Effect.gen(function* () {
+	const context = yield* Layer.build(
+		ProcessTablePort.layer.pipe(
+			Layer.provideMerge(Processes.layer),
+			Layer.provideMerge(Checkpoints.layer(memoryStores())),
+			Layer.provideMerge(Registry.layer([program])),
+		),
+	);
+	const processes = Context.get(context, Processes);
+	const handle = yield* processes.spawn(program.id, {id: processId, services: Context.empty()});
+	const pages: Parameters<typeof session>[5] = new Set();
+	const lock = yield* Semaphore.make(1);
+	const run = (socket: Socket.Socket) =>
+		session(
+			socket,
+			processes.handle,
+			Effect.succeed(() => Effect.die("unexpected spell")),
+			Stream.never,
+			defaultPrefixTable,
+			pages,
+			lock,
+		).pipe(Effect.scoped, Effect.provideContext(context));
+	return {run, pages, handle, table: Context.get(context, ProcessTable)};
+});
+
+const closeError = (code: number) =>
+	new Socket.SocketError({reason: new Socket.SocketCloseError({code})});
+
+describe("page socket session endings", () => {
+	for (const code of [1000, 1001, 1006]) {
+		it.effect(`ends close ${code} successfully and retains the process for another page`, () =>
+			Effect.gen(function* () {
+				const built = yield* kernel;
+				const first = yield* controlled;
+				const fiber = yield* Effect.forkScoped(built.run(first.socket));
+				yield* Deferred.await(first.ready);
+				assert.strictEqual(built.pages.size, 1);
+				assert.isTrue(first.writes.some((text) => text.includes(PROCESS_STATE_KIND)));
+				yield* Deferred.fail(first.closed, closeError(code));
+				const exit = yield* Fiber.await(fiber);
+				assert.isTrue(Exit.isSuccess(exit));
+				assert.strictEqual(built.pages.size, 0);
+				assert.strictEqual((yield* built.table.get(processId)).id, processId);
+				assert.deepStrictEqual(built.handle.getState(), {count: 0});
+				const second = yield* controlled;
+				const reattached = yield* Effect.forkScoped(built.run(second.socket));
+				yield* Deferred.await(second.ready);
+				assert.strictEqual(built.pages.size, 1);
+				assert.isTrue(
+					second.writes.some(
+						(text) => text.includes(PROCESS_STATE_KIND) && text.includes(processId),
+					),
+				);
+				yield* Deferred.fail(second.closed, closeError(1000));
+				assert.isTrue(Exit.isSuccess(yield* Fiber.await(reattached)));
+				assert.strictEqual(built.pages.size, 0);
+			}).pipe(Effect.scoped),
+		);
+	}
+	for (const reason of [
+		new Socket.SocketReadError({cause: new Error("read failure")}),
+		new Socket.SocketWriteError({cause: new Error("write failure")}),
+		new Socket.SocketOpenError({kind: "Unknown", cause: new Error("open failure")}),
+		...[1005, 1008, 1011, 4000].map((code) => new Socket.SocketCloseError({code})),
+	]) {
+		it.effect(`preserves the exact reported ${reason._tag} ${reason.message}`, () =>
+			Effect.gen(function* () {
+				const built = yield* kernel;
+				const page = yield* controlled;
+				const fiber = yield* Effect.forkScoped(built.run(page.socket));
+				yield* Deferred.await(page.ready);
+				const original = new Socket.SocketError({reason});
+				yield* Deferred.fail(page.closed, original);
+				const exit = yield* Fiber.await(fiber);
+				assert.isTrue(Exit.isFailure(exit));
+				if (Exit.isFailure(exit))
+					assert.strictEqual(Option.getOrUndefined(Cause.findErrorOption(exit.cause)), original);
+				assert.strictEqual(built.pages.size, 0);
+				assert.strictEqual((yield* built.table.get(processId)).id, processId);
+			}).pipe(Effect.scoped),
+		);
+	}
+});

--- a/apps/tuval/src/shell/transport/transport.integration.test.ts
+++ b/apps/tuval/src/shell/transport/transport.integration.test.ts
@@ -8,8 +8,21 @@
 
 import {type Cmd, DispatchDiscardedError, defineMachine} from "@demlik/tea";
 import {assert, describe, it} from "@effect/vitest";
-import {Context, Effect, Exit, Fiber, Layer, Option, Queue, Redacted, Scope, Stream} from "effect";
+import {
+	Context,
+	Effect,
+	Exit,
+	Fiber,
+	Layer,
+	Logger,
+	Option,
+	Queue,
+	Redacted,
+	Scope,
+	Stream,
+} from "effect";
 import {Socket} from "effect/unstable/socket";
+import {WebSocket as NodeWebSocket} from "ws";
 import type {SpellPath} from "../../commands/spell.ts";
 import {Checkpoints} from "../../durability/Checkpoints.ts";
 import {type CheckpointStores, memoryStores} from "../../durability/stores.ts";
@@ -240,6 +253,54 @@ const rawSocket = (url: string) =>
 	});
 
 describe("the page-to-kernel transport", () => {
+	it.live(
+		"an abruptly terminated page stays quiet in the actual socket-server reporter and reattaches",
+		() => {
+			const logs: unknown[] = [];
+			return Effect.gen(function* () {
+				const app = yield* served(memoryStores());
+				yield* Effect.callback<void, Error>((resume) => {
+					const socket = new NodeWebSocket(app.server.launchUrl);
+					socket.on("open", () =>
+						socket.send(
+							JSON.stringify({kind: "tuval/transport/attach/v1", processId: shellProcess}),
+						),
+					);
+					socket.on("message", (data) => {
+						const frame = JSON.parse(data.toString());
+						if (
+							frame.kind === "tuval/transport/process-state/v1" &&
+							frame.processId === shellProcess
+						)
+							socket.terminate();
+					});
+					socket.on("close", () => resume(Effect.void));
+					socket.on("error", (error) => resume(Effect.fail(error)));
+					return Effect.sync(() => socket.terminate());
+				});
+				const reconnected = yield* page(app.server.launchUrl);
+				const shell = yield* reconnected.attachProcess<DeskState, DeskMsg>(shellProcess);
+				const result = yield* shell.dispatch({type: "split", window: "after-drop"});
+				assert.deepStrictEqual(answered(result), {windows: ["root", "after-drop"]});
+				const unhandled = logs.filter(
+					(message) =>
+						Array.isArray(message) && message.includes("Unhandled error in SocketServer"),
+				);
+				assert.deepStrictEqual(unhandled, []);
+			}).pipe(
+				Effect.scoped,
+				Effect.provide(
+					Logger.layer([
+						Logger.make(({message}) => {
+							logs.push(message);
+						}),
+					]),
+				),
+			);
+		},
+		TIMEOUT,
+	);
+
 	it.live(
 		"a dispatch from the page reaches the named process and its next state comes back over the socket",
 		() =>


### PR DESCRIPTION
A page disappearing without a WebSocket close handshake no longer writes an unhandled-error stack. The session names a narrow quiet-close policy (1000, 1001, 1006), using the pinned Effect close filter; other close codes and read/write/open failures retain their original failure identity. Session cleanup removes the page sender while its kernel processes remain available for reattachment.

Release containment: none. This local-only Tuval transport fix is available by default.

Validation: all 2,491 Tuval tests across 258 files passed; affected typecheck/lint and prose checks passed. Before the fix, three session exit assertions and the real abruptly terminated WebSocket reporter assertion failed. Afterward, all 26 focused session/transport tests pass, including retained-process dispatch after reconnect and seven unexpected-error identity cases. No rendered surface or user copy changed.

Grounding: Effect main's [LLMS.md](https://github.com/Effect-TS/effect/blob/main/LLMS.md) error-handling and resource-management guidance, verified against installed effect 4.0.0-rc.112 SocketCloseError.filterClean/catchFilter and platform-node-shared 4.0.0-rc.112 NodeSocketServer. The close-code meanings and local-observation constraint for 1006 follow [RFC 6455 §7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1); the current pattern doc records the application policy.

Fixes #8086

## Deviations

- **Said:** Name which closes finish quietly; 1006 is the reported case. **Did:** Included normal close 1000 and going-away close 1001 alongside 1006. **Why:** They represent expected page session endings; the pinned server otherwise reports every close. **Disposition:** The named policy and regressions cover all three, with unlisted codes remaining failures.
- **Said:** Drive the session and prove cleanup plus process survival. **Did:** Exported the existing session function from its module for direct lifecycle tests and added a real dropped-WebSocket integration regression. **Why:** The tests need to observe the actual session fork and sender set as well as the installed server reporter. **Disposition:** The transport barrel API is unchanged; both test levels pass.
