### PR TITLE
fix: Tuval's read-only transcript keeps a live composer on a session it cannot open

### DIFF
--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -40,6 +40,12 @@ tier uses, with a tool call of each shape, a pending permission card and three m
 kernel or agent session, so the default page proves paint and keyboard only. Pass `--port <n>`
 when the default is taken.
 
+The same server's `/session-refusal` fixture mounts the production read-only transcript with a
+missing-folder row beside a refused initial read, using the page's stylesheet entry. Both keep
+Back usable and omit the composer. The refused read's existing retry lands an empty readable
+transcript, which offers the composer again. The fixture supplies answers locally; it opens no
+kernel or agent. Session-open and page transcript tests cover send plans and socket-read recovery.
+
 The same harness has four paging routes: `/paging-local`, `/paging-partial`, `/paging-completed`
 and `/paging-prepended`. Each scrolls the real `ChatWindow` with shipped styles. The last route
 checks that a prepend retains the **same DOM row** for the oldest local echo, aligns it to the

--- a/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionListWindow.tsx
@@ -373,6 +373,7 @@ function SessionListHost({
 	const read = (useAnswer ?? nothingRead)(window);
 	const [view, setView] = useState<SessionListView>(listView);
 	const [phase, setPhase] = useState<OpenPhase>("reading");
+	const [sendRefusal, setSendRefusal] = useState<SendPlan["refused"]>(null);
 
 	const activate = useCallback(
 		(session: SessionRow, target: OpenTarget) => {
@@ -382,12 +383,17 @@ function SessionListHost({
 				return;
 			}
 			setPhase("reading");
+			setSendRefusal(null);
 			setView(sessionView(session));
 		},
 		[onActivate, onOpenInNewWindow],
 	);
 
-	const back = useCallback(() => setView(listView), []);
+	const back = useCallback(() => {
+		setPhase("reading");
+		setSendRefusal(null);
+		setView(listView);
+	}, []);
 
 	if (view.kind === "list") {
 		return (
@@ -409,13 +415,19 @@ function SessionListHost({
 			session={view.session}
 			window={window}
 			useTranscript={useTranscript ?? nothingPaged}
+			sendRefusal={sendRefusal}
 			onBack={back}
 			onSend={(text) => {
 				// The phase is what makes the transition happen once: the first send hands back a spawn
 				// and moves to `live`, and every send after it hands back none.
 				const plan = send(phase, view.session);
+				if (plan.refused !== null) {
+					setSendRefusal(plan.refused);
+					return false;
+				}
 				setPhase(plan.phase);
 				onSend?.(view.session, text, plan);
+				return true;
 			}}
 		/>
 	);
@@ -428,6 +440,7 @@ function SessionListHost({
  * whose session is no longer on screen.
  */
 function SessionTranscriptHost({
+	sendRefusal,
 	session,
 	window,
 	useTranscript,
@@ -438,7 +451,8 @@ function SessionTranscriptHost({
 	readonly window: WindowId;
 	readonly useTranscript: TranscriptSource;
 	readonly onBack: () => void;
-	readonly onSend: (text: string) => void;
+	readonly sendRefusal: SendPlan["refused"];
+	readonly onSend: (text: string) => boolean;
 }): ReactElement {
 	// Memoised on the row, so the source's own effect sees one request for the life of this mount: a
 	// fresh object every render would re-send the first page on every render.
@@ -448,7 +462,7 @@ function SessionTranscriptHost({
 		<SessionTranscriptView
 			session={session}
 			answer={paged.answer}
-			unopenable={request._tag === "OpenRefused"}
+			unopenable={request._tag === "OpenRefused" || sendRefusal !== null}
 			onBack={onBack}
 			onSend={onSend}
 			{...(paged.onOlder === undefined ? {} : {onOlder: paged.onOlder})}

--- a/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
@@ -19,7 +19,7 @@
  * did not move, so pressing it again asks for the same page rather than skipping past it.
  */
 
-import {AgentChatInput, Button, DesignTranslationProvider} from "@kampus/design";
+import {AgentChatInput, Button, DesignTranslationProvider, EmptyState} from "@kampus/design";
 import type {ReactElement} from "react";
 import {useCallback, useMemo, useState} from "react";
 import type {OlderRead, TranscriptAnswer} from "../../page/session-transcript.ts";
@@ -33,6 +33,7 @@ import "./session-list-window.css";
 
 const COPY = {
 	retry: "Try reading this transcript again",
+	refused: "This session cannot be opened",
 	reading: "Reading this session's transcript…",
 	empty: "This session holds no messages yet.",
 	older: "Load older messages",
@@ -65,8 +66,8 @@ export interface SessionTranscriptProps {
 	/** Ask for the page older than the one on screen. Absent means this caller does not page. */
 	readonly onOlder?: () => void;
 	readonly onRetry?: () => void;
-	/** The operator sent. What that does to the process is the caller's, through `send`. */
-	readonly onSend: (text: string) => void;
+	/** The caller handles the send; `false` refuses it without marking this transcript sent. */
+	readonly onSend: (text: string) => boolean | undefined;
 	/** Leave the session and put the list back in this window. */
 	readonly onBack: () => void;
 	/** Set when the row itself cannot be opened — the store filed it under no folder. */
@@ -83,12 +84,13 @@ export function SessionTranscriptView({
 	unopenable = false,
 }: SessionTranscriptProps): ReactElement {
 	const [sent, setSent] = useState(false);
+	const sendable = !unopenable && answer?._tag === "Read";
 	const submit = useCallback(
 		(text: string) => {
-			setSent(true);
-			onSend(text);
+			if (!sendable) return;
+			if (onSend(text) !== false) setSent(true);
 		},
-		[onSend],
+		[onSend, sendable],
 	);
 
 	const composer = useMemo(
@@ -115,12 +117,19 @@ export function SessionTranscriptView({
 	const body: ReactElement =
 		unopenable || refusal !== null ? (
 			<div className="tuval-session-transcript-refused">
-				<p role="alert">{refusal === null ? COPY.noFolder : failureLine(refusal)}</p>
-				{!unopenable && refusal !== null && onRetry !== undefined ? (
-					<Button type="button" variant="tertiary" size="sm" onClick={onRetry}>
-						{COPY.retry}
-					</Button>
-				) : null}
+				<EmptyState
+					title={COPY.refused}
+					description={
+						<span role="alert">{refusal === null ? COPY.noFolder : failureLine(refusal)}</span>
+					}
+					action={
+						!unopenable && refusal !== null && onRetry !== undefined ? (
+							<Button type="button" variant="tertiary" size="sm" onClick={onRetry}>
+								{COPY.retry}
+							</Button>
+						) : undefined
+					}
+				/>
 			</div>
 		) : answer === null ? (
 			<p className="tuval-session-transcript-note">{COPY.reading}</p>
@@ -170,9 +179,11 @@ export function SessionTranscriptView({
 				</div>
 			)}
 			{body}
-			<DesignTranslationProvider translate={tuvalDesignTranslate}>
-				<AgentChatInput variant="focused" bridge={composer.bridge} />
-			</DesignTranslationProvider>
+			{sendable ? (
+				<DesignTranslationProvider translate={tuvalDesignTranslate}>
+					<AgentChatInput variant="focused" bridge={composer.bridge} />
+				</DesignTranslationProvider>
+			) : null}
 		</section>
 	);
 }

--- a/apps/tuval/src/ai-agent/window/session-list-window.css
+++ b/apps/tuval/src/ai-agent/window/session-list-window.css
@@ -139,3 +139,9 @@
 	align-items: flex-start;
 	gap: var(--s-2);
 }
+
+div.tuval-session-transcript-refused {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}

--- a/apps/tuval/src/ai-agent/window/session-open.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/session-open.unit.test.tsx
@@ -22,6 +22,7 @@ import {WindowId} from "../../shell/window/index.ts";
 import {ItemId} from "../ports/index.ts";
 import {bareSession, claudeSession, NOW, scrambled} from "./fixtures.ts";
 import type {OpenRequest, SendPlan, TranscriptRead} from "./opening.ts";
+import * as opening from "./opening.ts";
 import {TRANSCRIPT_PAGE_SIZE} from "./opening.ts";
 import type {TranscriptPaged} from "./SessionListWindow.tsx";
 import {type SessionListWindowOptions, sessionListWindow} from "./SessionListWindow.tsx";
@@ -143,16 +144,28 @@ describe("the first send on an opened session", () => {
 		});
 	};
 
-	it("creates exactly one process on that session id, and reuses it on the second", async () => {
+	it.each([
+		[],
+		["existing turn"],
+	])("creates one process for readable history %j and reuses it", async (...texts) => {
 		const plans: Array<SendPlan> = [];
+		const sends: Array<{session: SessionRow; text: string}> = [];
 		activate({
-			useTranscript: () => paged([]),
-			onSend: (_session, _text, plan) => plans.push(plan),
+			useTranscript: () => paged(texts),
+			onSend: (session, text, plan) => {
+				plans.push(plan);
+				sends.push({session, text});
+			},
 		});
 
 		await type("first");
 		await type("second");
 
+		expect(sends).toEqual([
+			{session: claudeSession, text: "first"},
+			{session: claudeSession, text: "second"},
+		]);
+		expect(plans.every((plan) => plan.phase === "live" && plan.refused === null)).toBe(true);
 		expect(plans.map((plan) => plan.spawn)).toEqual([
 			{
 				programId: claudeSession.programId,
@@ -161,5 +174,112 @@ describe("the first send on an opened session", () => {
 			},
 			null,
 		]);
+	});
+});
+
+describe("refused session sends", () => {
+	it.each([
+		"missing-folder",
+		"read-refused",
+	])("offers no impossible keyboard send for %s, and Back opens a fresh valid session", async (kind) => {
+		const onSend = vi.fn();
+		const bad = {
+			...bareSession,
+			title: "Unopenable session",
+			...(kind === "missing-folder" ? {} : {folder: "project"}),
+		};
+		activate(
+			{
+				useAnswer: () => ({status: listed([bad, claudeSession])}),
+				useTranscript: (request) =>
+					request._tag === "Read" && request.read.sessionId === claudeSession.sessionId
+						? paged([])
+						: {
+								answer: {
+									_tag: "Refused",
+									failure: {
+										tag: "refused",
+										message: "Transcript unavailable",
+										path: ["session", "transcript"],
+									},
+								},
+							},
+				onSend,
+			},
+			{},
+		);
+		fireEvent.click(screen.getByRole("button", {name: "Back to the session list"}));
+		fireEvent.change(field(), {target: {value: "Unopenable session"}});
+		fireEvent.keyDown(field(), {key: "Enter"});
+		expect(screen.getByRole("alert")).toBeTruthy();
+		expect(screen.queryByRole("combobox", {name: "Write a message to the agent"})).toBeNull();
+		fireEvent.keyDown(
+			screen.getByRole("region", {name: /Unopenable session|Wire the session list window/}),
+			{key: "Enter"},
+		);
+		expect(onSend).not.toHaveBeenCalled();
+		expect(
+			screen
+				.getByRole("region", {name: /Unopenable session|Wire the session list window/})
+				.getAttribute("data-sent"),
+		).toBe("false");
+		fireEvent.click(screen.getByRole("button", {name: "Back to the session list"}));
+		fireEvent.keyDown(field(), {key: "Enter"});
+		expect(screen.queryByRole("alert")).toBeNull();
+		expect(
+			screen
+				.getByRole("region", {name: /Unopenable session|Wire the session list window/})
+				.getAttribute("data-sent"),
+		).toBe("false");
+		await act(async () => {
+			fireEvent.change(screen.getByRole("combobox", {name: "Write a message to the agent"}), {
+				target: {value: "new send"},
+			});
+		});
+		await act(async () => {
+			fireEvent.keyDown(screen.getByRole("combobox", {name: "Write a message to the agent"}), {
+				key: "Enter",
+			});
+		});
+		expect(onSend).toHaveBeenCalledExactlyOnceWith(
+			claudeSession,
+			"new send",
+			opening.send("reading", claudeSession),
+		);
+	});
+
+	it("consumes a refused plan before marking sent or forwarding a successful send", async () => {
+		const refused = opening.send("reading", bareSession);
+		const plan = vi.spyOn(opening, "send").mockReturnValueOnce(refused);
+		const onSend = vi.fn();
+		try {
+			activate({useTranscript: () => paged([]), onSend});
+			const input = screen.getByRole("combobox", {name: "Write a message to the agent"});
+			await act(async () => {
+				fireEvent.change(input, {target: {value: "refused send"}});
+			});
+			await act(async () => {
+				fireEvent.keyDown(input, {key: "Enter"});
+			});
+			expect(plan).toHaveBeenCalledWith("reading", claudeSession);
+			expect(onSend).not.toHaveBeenCalled();
+			expect(screen.getByRole("alert").textContent).toContain("no folder");
+			expect(
+				screen
+					.getByRole("region", {name: /Unopenable session|Wire the session list window/})
+					.getAttribute("data-sent"),
+			).toBe("false");
+			expect(screen.queryByRole("combobox", {name: "Write a message to the agent"})).toBeNull();
+			fireEvent.click(screen.getByRole("button", {name: "Back to the session list"}));
+			fireEvent.keyDown(field(), {key: "Enter"});
+			expect(screen.queryByRole("alert")).toBeNull();
+			expect(
+				screen
+					.getByRole("region", {name: /Unopenable session|Wire the session list window/})
+					.getAttribute("data-sent"),
+			).toBe("false");
+		} finally {
+			plan.mockRestore();
+		}
 	});
 });

--- a/apps/tuval/src/page/session-transcript-window.unit.test.tsx
+++ b/apps/tuval/src/page/session-transcript-window.unit.test.tsx
@@ -261,6 +261,7 @@ describe("picking a row", () => {
 
 		expect(screen.getByRole("alert").textContent).toContain('no session "c-1" is stored');
 		expect(screen.queryByText("This session holds no messages yet.")).toBeNull();
+		expect(screen.queryByRole("combobox", {name: "Write a message to the agent"})).toBeNull();
 	});
 
 	it("renders a result it cannot decode as a refusal rather than an empty session", async () => {
@@ -439,7 +440,9 @@ const failRead = async (index: number): Promise<void> => {
 describe("transport read failures", () => {
 	it("leaves the first read recoverable until one explicit correlated retry succeeds", async () => {
 		const container = await openSession();
+		expect(screen.queryByRole("combobox", {name: "Write a message to the agent"})).toBeNull();
 		await failRead(0);
+		expect(screen.queryByRole("combobox", {name: "Write a message to the agent"})).toBeNull();
 		expect(screen.queryByText("Reading this session's transcript…")).toBeNull();
 		expect(screen.getByRole("alert").textContent).toContain(
 			"This transcript page could not be read",
@@ -457,7 +460,9 @@ describe("transport read failures", () => {
 		expect(parked[1]?.spell.window).toBe("w-1");
 		expect(screen.queryByRole("alert")).toBeNull();
 		expect(screen.getByText("Reading this session's transcript…")).toBeTruthy();
+		expect(screen.queryByRole("combobox", {name: "Write a message to the agent"})).toBeNull();
 		await answer(1, (id) => ok(id, pageOf(1, 2, null)));
+		expect(screen.getByRole("combobox", {name: "Write a message to the agent"})).toBeTruthy();
 		expect(texts(container)).toEqual(["userturn m-1", "userturn m-2"]);
 		expect(new Set(parked.map(({spell}) => spell.path.join(".")))).toEqual(
 			new Set([SESSION_TRANSCRIPT_CALL_PATH.join(".")]),

--- a/apps/tuval/src/shell/chat/proof/main.tsx
+++ b/apps/tuval/src/shell/chat/proof/main.tsx
@@ -13,7 +13,7 @@
  * ClaudeAiAgent replay behind scripted SDK/store and WindowHost seams; see the app README.
  */
 
-import {Effect} from "effect";
+import {Effect, Schema} from "effect";
 import {StrictMode} from "react";
 import {createRoot} from "react-dom/client";
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../../ai-agent/core/index.ts";
@@ -33,6 +33,11 @@ import {type ChatView, initialChatView} from "../view.ts";
 import {mountPagingProof} from "./paging.tsx";
 import "../../ui/tokens.css";
 import "./proof.css";
+
+class SessionRefusalProofLoadError extends Schema.TaggedError<SessionRefusalProofLoadError>()(
+	"SessionRefusalProofLoadError",
+	{cause: Schema.Defect()},
+) {}
 
 const state: AiAgentSessionState = withTranscript(
 	[
@@ -67,6 +72,14 @@ const view: ChatView = initialChatView;
 const mount = Effect.gen(function* () {
 	const host = document.getElementById("proof");
 	if (host === null) return yield* Effect.die(new Error("the proof page has no #proof element"));
+	if (location.pathname === "/session-refusal") {
+		const {mountSessionRefusalProof} = yield* Effect.tryPromise({
+			try: () => import("./session-refusal.tsx"),
+			catch: (cause) => new SessionRefusalProofLoadError({cause}),
+		});
+		mountSessionRefusalProof(host);
+		return;
+	}
 	if (location.pathname.startsWith("/paging-")) {
 		return yield* mountPagingProof(host);
 	}

--- a/apps/tuval/src/shell/chat/proof/session-refusal.tsx
+++ b/apps/tuval/src/shell/chat/proof/session-refusal.tsx
@@ -1,0 +1,67 @@
+import {useState} from "react";
+import "../../../page/styles.ts";
+import {createRoot} from "react-dom/client";
+import {bareSession, claudeSession, NOW} from "../../../ai-agent/window/fixtures.ts";
+import {SessionList} from "../../../ai-agent/window/SessionListWindow.tsx";
+import {SessionTranscriptView} from "../../../ai-agent/window/SessionTranscript.tsx";
+import type {TranscriptAnswer} from "../../../page/session-transcript.ts";
+import type {SessionRow} from "../../../protocol/session-list.ts";
+
+const missing = {...bareSession, title: "Session without a folder"};
+const refused = {...claudeSession, title: "Transcript read refused"};
+const empty: TranscriptAnswer = {
+	_tag: "Read",
+	page: {items: [], next: null},
+	older: {_tag: "Idle"},
+};
+
+function SessionProof({initial}: {readonly initial: SessionRow}) {
+	const [session, setSession] = useState<SessionRow | null>(initial);
+	const [retried, setRetried] = useState(false);
+	return session === null ? (
+		<SessionList
+			status={{_tag: "Listed", sessions: [missing, refused], unreadable: []}}
+			now={NOW}
+			onActivate={(selected) => {
+				setRetried(false);
+				setSession(selected);
+			}}
+		/>
+	) : (
+		<SessionTranscriptView
+			key={session.sessionId}
+			session={session}
+			unopenable={session.folder === undefined}
+			answer={
+				session.folder === undefined
+					? null
+					: retried
+						? empty
+						: {
+								_tag: "Refused",
+								failure: {
+									tag: "tuval/TranscriptError",
+									message: "This session's transcript could not be read.",
+									path: ["session", "transcript"],
+								},
+							}
+			}
+			onSend={() => {}}
+			onBack={() => setSession(null)}
+			onRetry={() => setRetried(true)}
+		/>
+	);
+}
+
+export const mountSessionRefusalProof = (host: HTMLElement): void => {
+	createRoot(host).render(
+		<div className="tuval-surface proof-desk" data-scheme="dark">
+			<div className="proof-pane">
+				<SessionProof initial={missing} />
+			</div>
+			<div className="proof-pane">
+				<SessionProof initial={refused} />
+			</div>
+		</div>,
+	);
+};


### PR DESCRIPTION
An unopenable session now shows a centered refusal with Back available and no composer. A refused first read keeps its existing retry; a successful retry restores the composer. The host consumes refused SendPlans before invoking the send callback or advancing its phase, and the transcript marks itself sent only when the caller accepts. Valid empty and populated sessions retain one first-send spawn with the chosen session, working directory and text; later sends reuse it.

Release containment: none. This local-only Tuval fix is available by default.

Validation: 2,511 Tuval tests across 260 files passed, including 30 focused session-open and real page/source transcript tests. Three new baseline failures reproduced the two impossible composers and the forwarded refused plan. Affected typecheck/lint and prose checks are green. The proof loader uses the installed Effect 4.0.0-rc.112 Schema.TaggedError constructor and keeps its error local.

Builder hand-verification: validated 1280×900 before/after captures of `/tuval/chat/session-refusal` use the same final fixture and stylesheet loader, with baseline production components at 7d099c2567. The after capture has both refusal messages centered and no composers. In the real browser at 2026-09-08 09:21:27 UTC, both alerts were present, composer count was zero and both sent markers were false. Keyboard Enter on Back returned to the list; Enter on the refused read's retry produced an empty readable transcript, one composer, no alert and sent=false at 09:21:47 UTC. This fixture mounts production components with local answers; it starts no kernel or agent. The final loader only scopes stylesheet loading to this proof route. No blessed golden exists. LAW-SOURCE: manifest-prose.

Fixes #8237

## Deviations

- **Said:** Disable or omit impossible sends and consume refused plans. **Did:** Omitted the composer until the first readable answer and while refusal is present; the callback can return false without marking sent. **Why:** Keyboard submission must not race an unread or refused transcript, and refusal must not look successful. **Disposition:** Covered by host keyboard tests and the actual page/source retry test; existing first-send behavior remains covered for empty and populated history.
- **Said:** Communicate the refusal accessibly. **Did:** Used the shipped EmptyState primitive for the refusal body, retaining its alert and existing Back/retry controls. **Why:** Removing the composer should leave a deliberate refusal state, not an unexplained blank region. **Disposition:** Validated captures and browser keyboard checks cover the rendered change.
- **Said:** Cover session-open and transcript behavior. **Did:** Also committed a reproducible `/session-refusal` proof route with the production stylesheet entry. **Why:** The visual and keyboard evidence must be repeatable outside jsdom. **Disposition:** Documented under Paint proofs; the route supplies local read answers and makes no backend execution claim.
