### PR TITLE
fix: The Tuval agent inspector's cost and token digits reflow while a turn streams

### DIFF
--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -31,6 +31,14 @@ pnpm proof:claude-real   # the Claude vertical on the REAL CLI — the founder's
 
 ### Paint proofs
 
+`pnpm proof:pi-window` also serves `/inspector.html`: the production agent inspector over an
+in-memory process. `window.inspectorProof.update(cost, input, output)` commits a usage snapshot
+through its normal subscription, so a browser can compare repeated digit substitutions and
+digit-count growth at a narrow viewport. The fixture opens no backend or model. Cost and token
+rows use tabular figures; session/directory text keeps its wrapping and ordinary typography.
+Equal digit advances stabilize same-length substitutions, not the total width of a growing number
+or a currency value whose existing formatter changes its fraction length.
+
 Both test tiers run in jsdom, which has no layout: a claim about what the chat window *paints* —
 a diff column's width, a disclosure indicator's size, whether a portaled listbox resolves its
 tokens — cannot be made there, and a report of a browser run whose harness was thrown away cannot

--- a/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
+++ b/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
@@ -52,9 +52,9 @@ const inspectorRows = (
 ): ReadonlyArray<readonly [label: string, value: string, className?: string]> => {
 	const usage = usageTotals(state.usage);
 	return [
-		["Cost", money.format(usage.cost)],
-		["Input tokens", tokens.format(usage.inputTokens)],
-		["Output tokens", tokens.format(usage.outputTokens)],
+		["Cost", money.format(usage.cost), "tuval-agent-inspector-number"],
+		["Input tokens", tokens.format(usage.inputTokens), "tuval-agent-inspector-number"],
+		["Output tokens", tokens.format(usage.outputTokens), "tuval-agent-inspector-number"],
 		["Session", state.sessionId ?? NO_SESSION_YET, "tuval-agent-inspector-wrap"],
 		["Directory", state.cwd, "tuval-agent-inspector-wrap"],
 		// Omitted rather than shown empty: unlike the session id, an absent version is not a state

--- a/apps/tuval/src/ai-agent/window/ai-agent-inspector.css
+++ b/apps/tuval/src/ai-agent/window/ai-agent-inspector.css
@@ -41,3 +41,7 @@
 .tuval-agent-inspector-wrap {
 	overflow-wrap: anywhere;
 }
+
+.tuval-agent-inspector-list dd.tuval-agent-inspector-number {
+	font-variant-numeric: tabular-nums;
+}

--- a/apps/tuval/src/ai-agent/window/ai-agent-inspector.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/ai-agent-inspector.unit.test.tsx
@@ -10,6 +10,8 @@
  * with each other. Both rows and the table are imported; nothing here restates a reference.
  */
 
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
 import {render, screen, waitFor, within} from "@testing-library/react";
 import {Effect} from "effect";
 import type {ReactElement} from "react";
@@ -47,6 +49,24 @@ const open = async (state: AiAgentSessionState) => {
 const panel = (): HTMLElement => screen.getByRole("group", {name: "Agent session"});
 
 describe("what the inspector shows", () => {
+	it("uses tabular figures only for cost and token counts", async () => {
+		const style = document.createElement("style");
+		style.textContent = readFileSync(join(import.meta.dirname, "ai-agent-inspector.css"), "utf8");
+		document.head.append(style);
+		try {
+			await open(agentSessionState({agentVersion: "2.1.259"}));
+			for (const row of panel().querySelectorAll(".tuval-agent-inspector-row")) {
+				const label = row.querySelector("dt")?.textContent;
+				const value = row.querySelector("dd") as HTMLElement;
+				const numeric = ["Cost", "Input tokens", "Output tokens"].includes(label ?? "");
+				expect(getComputedStyle(value).fontVariantNumeric === "tabular-nums").toBe(numeric);
+				if (label === "Session" || label === "Directory")
+					expect(getComputedStyle(value).overflowWrap).toBe("anywhere");
+			}
+		} finally {
+			style.remove();
+		}
+	});
 	it("renders the cost, the token counts, the session id and the cwd off the state", async () => {
 		await open(
 			agentSessionState({

--- a/apps/tuval/src/pi/window/proof/inspector.html
+++ b/apps/tuval/src/pi/window/proof/inspector.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Agent inspector numeric proof</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./inspector.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/pi/window/proof/inspector.tsx
+++ b/apps/tuval/src/pi/window/proof/inspector.tsx
@@ -1,0 +1,50 @@
+/** The production inspector over a controllable in-memory process; no backend or model. */
+import {Effect} from "effect";
+import {createRoot} from "react-dom/client";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../../ai-agent/core/index.ts";
+import {AiAgentInspector} from "../../../ai-agent/window/AiAgentInspector.tsx";
+import {agentSessionState, usageOf} from "../../../ai-agent/window/inspector.testing.ts";
+import {ProcessId} from "../../../process/process.ts";
+import {testProcess} from "../../../shell/window/fixtures.ts";
+import {WindowId} from "../../../shell/window/index.ts";
+import "../../../page/styles.ts";
+import "./proof.css";
+
+const state = agentSessionState({
+	cwd: "/project/a-long-directory-name/another-long-directory-name/source",
+	usage: usageOf({model: "fixture", cost: 0.1111, input: 111111, output: 111111}),
+});
+
+declare global {
+	interface Window {
+		inspectorProof: {update: (cost: number, input: number, output: number) => Promise<void>};
+	}
+}
+
+const mount = Effect.gen(function* () {
+	const element = document.getElementById("proof");
+	if (element === null) return yield* Effect.die(new Error("Missing inspector proof host"));
+	const process = yield* testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+		ProcessId.make("inspector-proof"),
+		state,
+	);
+	const host = yield* process.window(WindowId.make("inspector"), null);
+	createRoot(element).render(
+		<div className="tuval-surface proof-desk" data-scheme="dark">
+			<div className="proof-pane">{AiAgentInspector.render(host)}</div>
+		</div>,
+	);
+	return process;
+});
+
+void Effect.runPromise(mount).then((process) => {
+	window.inspectorProof = {
+		update: (cost, input, output) =>
+			Effect.runPromise(
+				process.commit({
+					...state,
+					usage: usageOf({model: "fixture", cost, input, output}),
+				}),
+			),
+	};
+});


### PR DESCRIPTION
Cost and token digits changed width while the inspector streamed updates. Apply tabular figures only to Cost, Input tokens and Output tokens, keeping the existing formatters, typography role and metadata wrapping. The production inspector now has an in-memory proof entry for repeatable measurements.

Fixes #8424.

Release containment: none. This local-only Tuval presentation fix is available by default.

Validation: 2,512 Tuval tests across 260 files pass; all 11 inspector tests pass, including a regression that failed before the fix and checks numeric-only computed styling plus metadata wrapping. Code and prose checks pass. No backend behavior changed.

Builder hand-verification at head f2db9f978c2149a24c3b9365f06cde75ebc3de94, using the actual AiAgentInspector and production stylesheet through the existing Pi proof server:

| Actual text-range width | Before | After |
| --- | ---: | ---: |
| $0.1111 | 45.765625px | 56.015625px |
| $0.8888 | 55.484375px | 56.015625px |
| 111,111 (both token rows) | 41.328125px | 56.015625px |
| 888,888 (both token rows) | 55.796875px | 56.015625px |

UTC 2026-09-08: baseline 09:59:37.234–09:59:37.788; fixed 10:03:46.419–10:03:46.962. Thirteen process commits with alternating same-length digit sequences all measured 56.015625px in each numeric row after the fix. The zero-containing values $0.0001 and 100,000 also measured 56.015625px. Formatted text matched baseline throughout. CDP identified the actual platform font as .SF NS / .SFNS-Regular; computed family, 14px size and 21px line height remained unchanged. The numeric feature follows [CSS Fonts 4 §6.7](https://www.w3.org/TR/css-fonts-4/#font-variant-numeric-prop).

Narrow verification, UTC 10:04:53.203–10:04:53.743: at a 240px viewport, the 216px value column accommodated 999,999 (56.015625px), 1,000,000 (68.6875px) and 1,000,000,000 (98.703125px) without overflow. Digit-count growth remains natural; currency still uses its existing two-to-four decimal formatter. Session ID wrapped to two lines and directory to three, retaining overflow-wrap:anywhere. No page overflow or live regions appeared. Local before/after and narrow captures were visually inspected; there is no blessed golden for this surface.

LAW-SOURCE: manifest-prose. No captures were uploaded. This hand-verification uses the recorded-timings alternative under the open #7306 Tuval interim ruling; independent UI review remains the reviewer's decision.

## Deviations

- **Proof entry** — **Said:** verify the real inspector while values update. **Did:** added an inspector entry to the existing Pi proof server using the actual renderer and in-memory test process. **Why:** permits repeatable live subscription updates and text-range measurements without a backend. **Disposition:** retained as a documented local proof surface.
- **Evidence publication** — **Said:** provide rendered before/after evidence. **Did:** kept captures local and recorded UTC timings and measured results here. **Why:** an earlier screenshot upload was rejected by automatic approval review; the driver explicitly prohibited retrying uploads and selected the existing #7306 timings alternative. **Disposition:** no upload attempted for this PR; independent UI review uses the documented interim route.
