### PR TITLE
docs: finish Tuval fast-follows campaign

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ flowchart TD
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
 		camp_phoenix_i18n["phoenix i18n"]:::active
-		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::active
+		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::done
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -118,7 +118,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
 | phoenix i18n | #53 | active |
-| Tuval first slice - fast follows | #54 | active |
+| Tuval first slice - fast follows | #54 | done |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Mark Tuval first slice - fast follows as done in the campaign table and matching diagram node. Milestone #54 is closed with zero open and nine closed issues; all nine repairs have merged.

Closeout authorization: https://github.com/kamp-us/phoenix/issues/8494#issuecomment-5583763739.

Validation: the roadmap guard passes against live GitHub milestones (I1–I5); git diff --check passes. Only the two campaign state values change.

## Deviations

- **Said:** Complete the delegated campaign closeout. **Did:** Published through the session driver. **Why:** The build PR command requires an open issue claim, while this campaign bookkeeping is legitimately issueless. **Disposition:** Normal independent review and ship gates still apply.
