### PR TITLE
feat(tuval): pi-subagents ships on by default

### DIFF
--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -116,7 +116,7 @@ describe("the feature flags", () => {
 	it.effect("merge project over global one flag at a time", () =>
 		Effect.gen(function* () {
 			const merged = yield* layered(fixture("features-on"), fixture("two-rows"));
-			assert.deepStrictEqual(merged.features, {subagentList: true, piSubagents: false});
+			assert.deepStrictEqual(merged.features, {subagentList: true, piSubagents: true});
 		}),
 	);
 
@@ -126,11 +126,11 @@ describe("the feature flags", () => {
 	it.effect("let a layer that states a flag off win over the on default", () =>
 		Effect.gen(function* () {
 			const global = yield* layered(fixture("features-off"), fixture("two-rows"));
-			assert.deepStrictEqual(global.features, {subagentList: false, piSubagents: false});
+			assert.deepStrictEqual(global.features, {subagentList: false, piSubagents: true});
 			const project = yield* layered(fixture("two-rows"), fixture("features-off"));
-			assert.deepStrictEqual(project.features, {subagentList: false, piSubagents: false});
+			assert.deepStrictEqual(project.features, {subagentList: false, piSubagents: true});
 			const overGlobalOn = yield* layered(fixture("features-on"), fixture("features-off"));
-			assert.deepStrictEqual(overGlobalOn.features, {subagentList: false, piSubagents: false});
+			assert.deepStrictEqual(overGlobalOn.features, {subagentList: false, piSubagents: true});
 		}),
 	);
 });
@@ -143,7 +143,7 @@ describe("loadLayeredConfig", () => {
 				const config = yield* layered(fixture("global-layer"), fixture("project-layer"));
 				assert.deepStrictEqual(config, {
 					programs: [{id: "a"}, {id: "b", core: "project"}],
-					features: {subagentList: true, piSubagents: false},
+					features: {subagentList: true, piSubagents: true},
 					moduleRenderers: [],
 					graph: {
 						nodes: [
@@ -165,7 +165,7 @@ describe("loadLayeredConfig", () => {
 			const missing = fixture("does-not-exist");
 			assert.deepStrictEqual(yield* layered(missing, fixture("with-graph")), {
 				programs: [{id: "a"}],
-				features: {subagentList: true, piSubagents: false},
+				features: {subagentList: true, piSubagents: true},
 				moduleRenderers: [],
 				graph: {nodes: [{id: NodeId.make("n"), program: ProgramId.make("a"), on: []}]},
 				keys: [{file: `project ${layerName("with-graph")}`, bindings: {}}],
@@ -173,7 +173,7 @@ describe("loadLayeredConfig", () => {
 			});
 			assert.deepStrictEqual(yield* layered(fixture("two-rows"), missing), {
 				programs: [{id: "a"}, {id: "b"}],
-				features: {subagentList: true, piSubagents: false},
+				features: {subagentList: true, piSubagents: true},
 				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [{file: `global ${layerName("two-rows")}`, bindings: {}}],
@@ -181,7 +181,7 @@ describe("loadLayeredConfig", () => {
 			});
 			assert.deepStrictEqual(yield* layered(missing, missing), {
 				programs: [],
-				features: {subagentList: true, piSubagents: false},
+				features: {subagentList: true, piSubagents: true},
 				moduleRenderers: [],
 				graph: {nodes: []},
 				keys: [],

--- a/apps/tuval/src/features.ts
+++ b/apps/tuval/src/features.ts
@@ -18,7 +18,7 @@ export interface TuvalFeatures {
 	readonly subagentList: boolean;
 	/**
 	 * Load the `pi-subagents` extension into a Pi session, so a Pi row can spawn a subagent (#8555).
-	 * Off: the row opens exactly the session it opened before the flag existed.
+	 * On by default since the founder desk check on 2026-09-08. Off: the row opens the session it opened before the flag existed.
 	 */
 	readonly piSubagents: boolean;
 }
@@ -29,4 +29,4 @@ export interface TuvalFeatures {
  * runbook pass, so a flag's entry moves from `false` to `true` in this record and nowhere else. A
  * layer that states a flag still wins over it, in either direction (`./config.ts`'s merge).
  */
-export const featuresDefault: TuvalFeatures = {subagentList: true, piSubagents: false};
+export const featuresDefault: TuvalFeatures = {subagentList: true, piSubagents: true};

--- a/apps/tuval/src/page/dev-server.unit.test.ts
+++ b/apps/tuval/src/page/dev-server.unit.test.ts
@@ -70,13 +70,13 @@ describe("the feature-flag module", () => {
 
 	it("carries a flag a layer turned on", async () => {
 		expect(await generated("features-on", "two-rows")).toBe(
-			'export default {\n\t"subagentList": true,\n\t"piSubagents": false,\n};\n',
+			'export default {\n\t"subagentList": true,\n\t"piSubagents": true,\n};\n',
 		);
 	});
 
 	it("carries a flag a layer turned off", async () => {
 		expect(await generated("features-off", "two-rows")).toBe(
-			'export default {\n\t"subagentList": false,\n\t"piSubagents": false,\n};\n',
+			'export default {\n\t"subagentList": false,\n\t"piSubagents": true,\n};\n',
 		);
 	});
 
@@ -85,7 +85,7 @@ describe("the feature-flag module", () => {
 	// operator who stated nothing would get the flag off.
 	it("carries every flag at its default when no layer declares a features block", async () => {
 		expect(await generated("two-rows", "one-counter")).toBe(
-			'export default {\n\t"subagentList": true,\n\t"piSubagents": false,\n};\n',
+			'export default {\n\t"subagentList": true,\n\t"piSubagents": true,\n};\n',
 		);
 	});
 

--- a/apps/tuval/src/pi/server/subagents.unit.test.ts
+++ b/apps/tuval/src/pi/server/subagents.unit.test.ts
@@ -28,8 +28,8 @@ const toolNames = async (paths: ReadonlyArray<string>): Promise<ReadonlyArray<st
 };
 
 describe("the piSubagents flag", () => {
-	it("ships off, so a Pi row opens the session it opened before it existed", () => {
-		expect(featuresDefault.piSubagents).toBe(false);
+	it("ships on since the founder desk check, and off still opens the pre-flag session", () => {
+		expect(featuresDefault.piSubagents).toBe(true);
 		expect(subagentExtensionPaths({piSubagents: false})).toEqual([]);
 	});
 


### PR DESCRIPTION
## Summary
Flips `piSubagents` from default-off to default-on. The founder tested a real spawn from a Pi row on the desk on 2026-09-08 with the flag flipped locally and ruled "flip it to default".

One line in `apps/tuval/src/features.ts` plus the three tests that pinned the old default (`config.unit`, `page/dev-server.unit`, `pi/server/subagents.unit`). A layer that states the flag off still wins, unchanged.

Part of #8555

## Verification
`vitest` on the three touched test files: 38/38. biome clean.

## Deviations
- **Said:** #8555 criterion 2 asks for a default-off `piSubagents` flag, and five assertions pinned that default (`config.unit.test.ts` lines 119/129/131/133, `subagents.unit.test.ts` line 32).
  **Did:** Flipped `featuresDefault.piSubagents` to `true` and changed those five assertions to expect `true`. The off-path assertion `subagentExtensionPaths({piSubagents: false}) → []` and the layer-off-wins merge are unchanged.
  **Why:** The founder drove a live spawn on the desk on 2026-09-08 and ruled "flip it to default", which is the ship-dark-then-flip step the docblock above `featuresDefault` names. The "default-off" wording of criterion 2 is superseded by that ruling; the load-bearing half (the flag exists, off restores the pre-flag session) still holds.
  **Disposition:** Accepted; no follow-up.
