### PR TITLE
fix: A Pi compaction row renders its whole summary as one nowrap uppercase line, scrolling the chat sideways

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -215,9 +215,10 @@ const who: Readonly<Record<RowItem["kind"], string>> = {
 };
 
 /**
- * What a row shows under its label. Three kinds carry a shape of their own: a tool call and a
- * thinking row are disclosures over this window's one `expanded` set, and a compaction row is a
- * divider rather than a line of prose. A session line never reaches here: `RowView` folds those
+ * What a row shows under its label. Three kinds carry a shape of their own, and all three are
+ * disclosures over this window's one `expanded` set: a tool call, a thinking row, and a compaction
+ * boundary, whose divider line is the trigger and whose summary is the panel. A session line never
+ * reaches here: `RowView` folds those
  * into the session row. Everything else, an agent reply and what the operator typed alike,
  * renders through the shared markdown block, which paints synchronously so the row's measurement
  * still holds (#8012/#8226): a fence the operator sends is the fence the agent received.
@@ -252,7 +253,15 @@ function RowBody({
 			/>
 		);
 	}
-	if (item.kind === "compaction") return <CompactionMarker text={item.text} />;
+	if (item.kind === "compaction") {
+		return (
+			<CompactionMarker
+				text={item.text}
+				expanded={expanded}
+				onToggle={(open) => onToggleRow(item.id, open)}
+			/>
+		);
+	}
 	// The transcript is a region inside the desk, so a `#` heading in a message is a subsection of
 	// it rather than a page title; and a transcript row is read as the lines it was typed on, so a
 	// lone newline is a break here where a document-shaped surface would fold it (#8244).

--- a/apps/tuval/src/shell/chat/CompactionMarker.tsx
+++ b/apps/tuval/src/shell/chat/CompactionMarker.tsx
@@ -1,21 +1,70 @@
 /**
- * Where the session compacted its context — a divider across the transcript, not a line of prose.
+ * Where the session compacted its context — a divider across the transcript, with the summary a
+ * disclosure away.
  *
  * The operator's question at this point is "why are the earlier turns gone", and the answer is
- * positional: everything above the rule was summarised away. A paragraph would sit in the reading
- * order as one more thing the session said, and be scrolled past like one.
+ * positional: everything above the rule was summarised away. So the boundary is still a real `hr`
+ * with a short label beside it, and the label is still the micro uppercase line the divider needs.
  *
- * So the boundary is a real `hr` and the line beside it is ordinary text: assistive tech reads a
- * separator and then what it separates, with no `aria-label` restating a string that is already
- * there. The rule is drawn by `chat.css`; nothing here is generated content.
+ * What the label is *not* is the payload. Pi's compaction item carries the whole summary the model
+ * wrote — a markdown document opening `## Goal …` (`../../pi/wire/compaction.ts`, #8588) — and
+ * uppercasing that onto one nowrap line scrolled the transcript sideways for the rest of the
+ * session (#8608). So the line beside the rule is a cut preview, and the document itself renders
+ * opened as ordinary markdown, wrapping like any other row.
+ *
+ * The disclosure is `Collapsible` from `@kampus/design`, the same primitive `ThinkingRow` and
+ * `ToolRow` use, so `aria-expanded` and `aria-controls` are the primitive's and the accessible
+ * name is the preview line. Open/closed is controlled off the window's own `view.expanded` set,
+ * which is what makes two windows over one process disclose independently.
  */
 
+import {Collapsible, Markdown} from "@kampus/design";
 import type {ReactElement} from "react";
 
-export function CompactionMarker({text}: {readonly text: string}): ReactElement {
+/** Longest preview the collapsed divider shows, in characters. */
+const PREVIEW_CHARS = 72;
+
+/**
+ * The divider's line, which is also the disclosure's accessible name. The first line that carries
+ * anything, with a markdown heading's own `#` run dropped — the marker is the document's syntax,
+ * not something the operator asked to read — cut to `PREVIEW_CHARS`; a fixed word when the payload
+ * is whitespace, so the control is never nameless.
+ */
+export const compactionLine = (text: string): string => {
+	const first =
+		text
+			.split("\n")
+			.map((line) => line.trim().replace(/^#{1,6}\s+/, ""))
+			.find((line) => line.length > 0) ?? "";
+	if (first.length === 0) return "Context compacted";
+	return first.length <= PREVIEW_CHARS ? first : `${first.slice(0, PREVIEW_CHARS).trimEnd()}…`;
+};
+
+export function CompactionMarker({
+	text,
+	expanded,
+	onToggle,
+}: {
+	readonly text: string;
+	readonly expanded: boolean;
+	readonly onToggle: (open: boolean) => void;
+}): ReactElement {
 	return (
 		<div className="tuval-chat-compaction">
-			<span className="tuval-chat-compaction-label">{text}</span>
+			<Collapsible
+				className="tuval-chat-compaction-disclosure"
+				open={expanded}
+				onOpenChange={onToggle}
+				trigger={<span className="tuval-chat-compaction-label">{compactionLine(text)}</span>}
+			>
+				<Markdown
+					className="tuval-chat-markdown tuval-chat-compaction-summary"
+					headingBase={3}
+					breaks
+				>
+					{text}
+				</Markdown>
+			</Collapsible>
 			<hr className="tuval-chat-compaction-rule" />
 		</div>
 	);

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -1786,9 +1786,15 @@ describe("the two daily rows", () => {
 		expect(marker?.getAttribute("data-kind")).toBe("compaction");
 		// The line is beside the rule and is not a text row: the assistant's turn above is what a
 		// text row looks like, and this is the one other shape the transcript draws.
-		expect(screen.getByText("context compacted").className).toBe("tuval-chat-compaction-label");
+		expect(marker?.querySelector(".tuval-chat-compaction-label")?.textContent).toBe(
+			"context compacted",
+		);
 		expect(screen.getByText("done").closest(".tuval-chat-markdown")).not.toBeNull();
-		expect(marker?.querySelector(".tuval-chat-markdown")).toBeNull();
+		// The payload's own markdown is behind the disclosure, so nothing of it is read until the
+		// row is opened — the marker itself stays a divider (#8608).
+		const summary = marker?.querySelector(".tuval-chat-compaction-summary");
+		expect(summary).not.toBeNull();
+		expect(summary?.closest("[data-part='content']")?.hasAttribute("hidden")).toBe(true);
 	});
 });
 

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -383,14 +383,56 @@
 /*
  * The compaction marker: its line, then a rule running out to the edge, because the operator's
  * question here is *where* the earlier turns went rather than what the session said about it.
+ *
+ * Two rows in a grid, and the disclosure is `display: contents` so its own two boxes take places in
+ * that grid: the trigger sits beside the rule on the divider's line, and the panel spans the whole
+ * width beneath both. Nesting the rule inside the trigger would be the simpler markup and is not
+ * available — a `Collapsible` trigger is a `button`, which takes phrasing content only.
  */
 .tuval-chat-compaction {
-	display: flex;
+	display: grid;
+	grid-template-columns: auto 1fr;
 	align-items: center;
-	gap: var(--s-2);
+	column-gap: var(--s-2);
+	min-inline-size: 0;
 }
 
+.tuval-chat-compaction-disclosure {
+	display: contents;
+}
+
+.tuval-chat-compaction [data-scope="collapsible"][data-part="trigger"] {
+	grid-row: 1;
+	grid-column: 1;
+	display: inline-flex;
+	align-items: center;
+	gap: var(--s-2);
+	min-inline-size: 0;
+	min-block-size: var(--tap-min);
+	text-align: start;
+}
+
+.tuval-chat-compaction [data-scope="collapsible"][data-part="indicator"] svg {
+	inline-size: 14px;
+	block-size: 14px;
+	color: var(--text-muted);
+}
+
+.tuval-chat-compaction [data-scope="collapsible"][data-part="content"] {
+	grid-row: 2;
+	grid-column: 1 / -1;
+	min-inline-size: 0;
+}
+
+/*
+ * The divider's own line: micro uppercase, and never wrapping against the rule beside it. It clips
+ * because it is a preview of a payload with no length bound — the summary itself wraps in the panel
+ * below, where `.tuval-chat-markdown` styles it like any other row (#8608).
+ */
 .tuval-chat-compaction-label {
+	min-inline-size: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	font: var(--t-micro);
 	color: var(--text-muted);
 	text-transform: uppercase;
@@ -398,8 +440,16 @@
 	white-space: nowrap;
 }
 
+.tuval-chat-compaction-summary {
+	padding-block-start: var(--s-2);
+	color: var(--text-secondary);
+	white-space: normal;
+	text-transform: none;
+}
+
 .tuval-chat-compaction-rule {
-	flex: 1;
+	grid-row: 1;
+	grid-column: 2;
 	margin: 0;
 	border: 0;
 	block-size: 1px;

--- a/apps/tuval/src/shell/chat/compaction-row.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/compaction-row.unit.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A compaction row is bounded by the transcript at every payload length (#8608).
+ *
+ * Pi's compaction item carries the whole summary the model wrote, and the divider used to render it
+ * as its label — micro, uppercase, `white-space: nowrap` — so a multi-paragraph document became one
+ * line the transcript had to scroll sideways to show. jsdom runs no layout engine, so no assertion
+ * here can measure a scrollbar; what jsdom does resolve is the cascade's declared values, and that
+ * is exactly where the defect lived. So the case renders the real window over a 2000-character
+ * summary and asks the two questions layout would have answered: is anything carrying the whole
+ * summary declared `nowrap`, and is what *is* declared `nowrap` bounded by its container.
+ *
+ * `chat.css` is read off disk and put in the document because Vitest's default `css: false` makes
+ * the window's own `import "./chat.css"` an empty module — without this every style assertion is
+ * vacuous.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {act, fireEvent, render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {beforeAll, describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type TestProcess, testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {compactionItem, withTranscript} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+beforeAll(() => {
+	const style = document.createElement("style");
+	style.textContent = readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
+	document.head.appendChild(style);
+});
+
+/** What Pi hands the window: a markdown document, opening on a heading. */
+const SUMMARY = `## Goal\n\n${"Ship codex as a sibling of pi and claude in tuval. ".repeat(40)}`;
+
+const openWindow = async (): Promise<void> => {
+	const process: TestProcess<AiAgentSessionState, AiAgentSessionMsg> = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+			ProcessId.make("p1"),
+			withTranscript([compactionItem("c", SUMMARY)]),
+		),
+	);
+	const host = await Effect.runPromise(
+		process.window<ChatView>(WindowId.make("w1"), initialChatView),
+	);
+	const element = chatWindow({scrollCommitMs: 0, scrollToFn: () => {}}).render(
+		host,
+	) as ReactElement;
+	render(element);
+	await screen.findByRole("log", {name: "Transcript"});
+};
+
+const trigger = (): HTMLElement => screen.getByRole("button", {name: /^Goal/});
+
+const label = (): HTMLElement => {
+	const found = document.querySelector<HTMLElement>(".tuval-chat-compaction-label");
+	if (found === null) throw new Error("the compaction label did not render");
+	return found;
+};
+
+const summaryElement = (): HTMLElement => {
+	const found = document.querySelector<HTMLElement>(".tuval-chat-compaction-summary");
+	if (found === null) throw new Error("the compaction summary did not render");
+	return found;
+};
+
+/**
+ * Every element from the one carrying the summary up to the transcript, so a declaration inherited
+ * from an ancestor is judged as well as one written on the element itself.
+ */
+const summaryChain = (): ReadonlyArray<HTMLElement> => {
+	const chain: Array<HTMLElement> = [];
+	for (
+		let node: HTMLElement | null = summaryElement();
+		node !== null && !node.classList.contains("tuval-chat-transcript");
+		node = node.parentElement
+	) {
+		chain.push(node);
+	}
+	return chain;
+};
+
+describe("a compaction row over a summary the model wrote", () => {
+	it("renders collapsed, with the summary out of the accessible tree", async () => {
+		await openWindow();
+
+		expect(SUMMARY.length).toBeGreaterThan(2000);
+		expect(trigger().getAttribute("aria-expanded")).toBe("false");
+		const panel = document.getElementById(trigger().getAttribute("aria-controls") ?? "");
+		expect(panel?.hidden).toBe(true);
+		expect(panel?.contains(summaryElement())).toBe(true);
+	});
+
+	it("keeps the whole summary off the divider's line, which clips inside its container", async () => {
+		await openWindow();
+
+		const line = label();
+		expect(line.textContent).toBe("Goal");
+		expect(trigger().textContent?.length).toBeLessThan(100);
+		const style = getComputedStyle(line);
+		// The line must not wrap against the rule, so being bounded is `overflow` doing it.
+		expect(style.whiteSpace).toBe("nowrap");
+		expect(style.overflow).toBe("hidden");
+		expect(style.textOverflow).toBe("ellipsis");
+	});
+
+	it("discloses the summary as ordinary wrapping markdown", async () => {
+		await openWindow();
+
+		await act(async () => {
+			fireEvent.click(trigger());
+		});
+
+		expect(trigger().getAttribute("aria-expanded")).toBe("true");
+		// `## Goal` is a heading in the panel, not one more run of text on the divider's line.
+		expect(summaryElement().querySelector("h1, h2, h3, h4, h5, h6")?.textContent).toBe("Goal");
+		for (const node of summaryChain()) {
+			const style = getComputedStyle(node);
+			expect([node.className, style.whiteSpace]).not.toEqual([node.className, "nowrap"]);
+			expect([node.className, style.textTransform]).not.toEqual([node.className, "uppercase"]);
+		}
+	});
+});


### PR DESCRIPTION
A Pi compaction row used to render the whole summary the model wrote as the divider's label — micro,
uppercase, `white-space: nowrap` — so a markdown document opening `## Goal …` landed on one line and
the transcript scrolled sideways for the rest of the session.

Now the boundary is a disclosure. The divider keeps its short uppercase line and its rule; the line
is a cut preview of the payload (a leading `#` run dropped, so the marker's own syntax stays out of
it) and it clips inside its container. The summary itself is the panel, rendered through `Markdown`
the way every other transcript row is, so it wraps and shows its headings. Open/closed is the chat
window's one `view.expanded` set and its `onToggleRow`, the same pair `ToolRow` and `ThinkingRow`
drive off, so no field was added to the view state and two windows over one process still disclose
independently. `aria-expanded` and `aria-controls` are `Collapsible`'s.

The label rule is scoped rather than deleted: `.tuval-chat-compaction-label` keeps `nowrap` and the
uppercase micro styling; the new `.tuval-chat-compaction-summary` inherits neither.

`apps/tuval/src/shell/chat/compaction-row.unit.test.tsx` renders the window over a 2000-character
summary and asserts what jsdom can answer: collapsed on first paint with the panel `hidden`, the
divider's line bounded and clipped, and nothing from the summary up to the transcript declared
`nowrap` or `uppercase` once opened. It reads `chat.css` off disk, because Vitest's `css: false`
would otherwise make every style assertion vacuous.

Reviewer's first look: the `display: contents` on the disclosure root in `chat.css`. A `Collapsible`
trigger is a `button` and takes phrasing content only, so the `hr` cannot sit inside it; instead the
marker is a two-row grid and the disclosure's own boxes take places in it — trigger beside the rule
on row 1, panel spanning row 2.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8608 names the component, the window branch
  and the stylesheet. **Did:** also amended the existing "renders a compaction item as a marker"
  case in `chat-window.unit.test.tsx`. **Why:** it asserted the marker contains no
  `.tuval-chat-markdown` and matched the payload text by `getByText`, both of which the disclosure
  makes false; the amended case now asserts the markdown is present but behind a `hidden` panel.
  **Disposition:** stated here.

Fixes #8608
