### PR TITLE
fix: Front-door loads in Codex but fails its packaging validator

### DIFF
--- a/claude-plugins/fabrika/skills/front-door/SKILL.md
+++ b/claude-plugins/fabrika/skills/front-door/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: front-door
-description: "The operating front door — type /fabrika in a cold session for the factory's live state, the skill menu, and new-repo onboarding. Human-typed only; the model cannot fire this."
+description: "The operating front door — explicitly invoke front-door for the factory's live state, the skill menu, and new-repo onboarding."
 disable-model-invocation: true
 ---
 
 # front-door
-
-!`fabrika status open`
 
 You orient a cold **operating** session: what the factory's state is, and which skill to reach for
 next.
@@ -25,6 +23,17 @@ here because a front door hands a session its premises, and a wrong premise is n
 answer — it is every later decision taken on it.
 
 ## 1 — Read the readout three-state, never two
+
+Run the readout through the shell tool:
+
+```bash
+fabrika status open
+```
+
+Read the exit status, stdout and stderr. If the command could not run or returned no readout,
+report `the status source was unreadable` with the reason; no factory state was established.
+Continue only from the readout this invocation produced. The invocation policies for Claude Code
+and Codex are in the contract (`fabrika wire doc-section --heading "Explicit invocation across harnesses" < <skill-base>/contract.md`).
 
 <!-- anchor: UNKNOWN-IS-NEVER-A-PLAUSIBLE-VALUE --> Every field resolves to exactly one of three
 **classes**, and **the third is not the second**: a **live value**; a **proven negative** — the
@@ -190,8 +199,8 @@ never held.
 and merges nothing** — every terminal below leaves the branch untouched, because it cannot touch one.
 It holds a shell and a repo-scoped token. Its only writes are `status bootstrap`'s — a repo file, the
 board label set, or the durable readout artifact — each read back after writing, and it emits no
-cross-lane signal. The injected `fabrika status open` is read-only: it takes no stdin, writes
-nothing, and runs before you see a token.
+cross-lane signal. The first `fabrika status open` call is read-only: it takes no stdin and writes
+nothing.
 
 Orienting and routing happen on every run and are not terminals. Every run **ends** as exactly one of
 these five, and each names itself a success or a back-off. <!-- anchor: TERMINALS-ARE-ORDERED -->
@@ -240,18 +249,6 @@ routes through a verb** and none through an ad-hoc `gh` call. Re-gating is named
 
 ## Editing this file
 
-**Only `fabrika status open` is injected**, because everything injected is paid on **every**
-invocation and runs before the session sees a token. It is read-only, and in its injected form — no
-flags — it has no reachable refusal, so it cannot open a session with an error where a readout
-should be; it can still fail to *run*, which step 1 handles as its own state. The drill-downs
-(`menu`, `config`, `board`, `readout`, `bootstrap`) are separate commands run on demand. The menu
-lives behind its verb rather than in this body for the same reason it is generated at all — a body
-copy is the stale copy.
-
-An exclamation-mark-prefixed command in a `SKILL.md` body executes on **invoke**, not on plugin
-load, and its stdout lands in context.
-
-<!-- anchor: ONE-MARKER-PER-PAGE --> **A fenced code block does not neutralise the marker — it still
-runs.** So this page carries exactly one, at the top, and prose about the mechanism never places an
-exclamation mark immediately before a backtick, because that two-character sequence *is* the marker
-wherever it appears. Say "exclamation-mark-prefixed" in words instead.
+Keep the first read an explicit tool call so every harness executes the same step. The drill-downs
+(`menu`, `settings`, `board`, `readout`, `bootstrap`) run on demand. The menu stays behind its verb;
+a body copy would become stale.

--- a/claude-plugins/fabrika/skills/front-door/agents/openai.yaml
+++ b/claude-plugins/fabrika/skills/front-door/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "fabrika front-door"
+  short_description: "Factory status and repository onboarding"
+policy:
+  allow_implicit_invocation: false

--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -91,8 +91,25 @@ expensive to change after shipping.
 Where a repo's own instructions pin skill routing to a filesystem path that points at some other
 tree, no path reaches any fabrika skill. That is the repo's own wiring to fix, and no clause here
 patches it — the same disposition `review`, `ship` and `governance` took.
-**This skill is a special case worth stating:** it is `disable-model-invocation: true`, so no routing
-*instruction* could reach it anyway — a human types it.
+**This skill is explicitly invoked by a human.** Its per-harness declarations are below.
+
+### Explicit invocation across harnesses
+
+Claude Code reads `disable-model-invocation: true` in `SKILL.md`. Codex reads
+`policy.allow_implicit_invocation: false` in the adjacent
+[`agents/openai.yaml`](agents/openai.yaml). Keep both declarations: neither harness's metadata is
+a substitute for the other's. Codex's policy keeps the skill available to explicit invocation
+while excluding it from automatic selection; see
+[Build skills, optional metadata](https://learn.chatgpt.com/docs/build-skills#optional-metadata).
+
+The body runs `fabrika status open` as an ordinary shell-tool step. It relies on no inline command
+interpolation. Failed execution or an absent readout reaches the existing unreadable-source terminal;
+the command's output remains report data under the skill's readout boundary.
+
+The plugin-creator packaging validator rejects `disable-model-invocation: true`, even though the
+Codex runtime loader accepts the shared file. That validator result must be reported separately
+from skill discovery and invocation-policy evidence. Retaining the Claude declaration preserves
+its invocation contract; it is not a claim that the packaging validator passed.
 
 ## Shared conventions
 
@@ -147,7 +164,7 @@ vocabulary in this group. Four consequences bind every verb below:
    one exit status; because a non-zero exit cannot carry a payload, the exit status answers only
    *"did I produce a readout at all"* and each field carries its own state inside it.
 4. <a id="open-is-total"></a>**`status open` therefore has no zero-scope and no failed-read seat at
-   all.** It is the command the skill injects before the session reads a token; a refusal writes zero
+   all.** It is the first command the skill runs; a refusal writes zero
    bytes, so a front door that refused would be silent on exactly the cold start it exists for. Every
    source it cannot read becomes a field state. Its only refusals are a bad `--field` and the
    universals.
@@ -216,7 +233,7 @@ header, whether an empty result is a fact or a failed read: **an empty roster is
 partial install), an unreadable one is `11`. Exit `7` is reserved for an **explicitly passed**
 `--skills-dir` that is proven absent — a caller error, not a state of the world — and it is seated on
 `menu` only. **`status open` is exempt though it takes the same flag**: it is the
-injected command and [cannot refuse](#open-is-total), so a bad path it was handed renders as a field
+initial readout and [cannot refuse](#open-is-total), so a bad path it was handed renders as a field
 state like any other unreadable source. `bootstrap` does not take the flag at all.
 
 <a id="core-to-field"></a>
@@ -412,8 +429,8 @@ rule for "three fine, one unknown", and every such rule either hides the unknown
 
 **That is the whole table, and it is the point** ([why](#open-is-total)). An unresolvable repo, an
 unreachable GitHub, an unreadable roster, an absent roster and an unregistered digest format each
-render their field `unknown` or `empty` at exit `0`. This verb is injected before the session reads a
-token; a refusal would write zero bytes on the cold start it exists for.
+render their field `unknown` or `empty` at exit `0`. This verb runs at the start of the skill;
+a refusal would write zero bytes on the cold start it exists for.
 
 **Errors**
 
@@ -1464,9 +1481,9 @@ readout artifact issue, and creating board labels. **No push, no branch, no merg
 access, no pull request, and no label applied to any existing issue.** This group emits no cross-lane
 signal of any kind.
 
-**`fabrika status open` is the command the skill injects**, so its capability set is the one that
+**`fabrika status open` is the skill's first command**, so its capability set is the one that
 matters most: read-only over the filesystem and GitHub, takes no stdin, and writes nothing. **The
-injected form cannot refuse** — it passes no flags, so its one refusal seat (`10`, a bad `--field`)
+initial form cannot refuse** — it passes no flags, so its one refusal seat (`10`, a bad `--field`)
 is unreachable, and every source failure becomes a field state. It can still fail to *run* (`1`, `126`,
-`127`), which is the no-readout case the skill handles as its own state. Nothing that mutates is ever
-injected.
+`127`), which is the no-readout case the skill handles as its own state. Bootstrap mutations remain
+separate calls after the readout.

--- a/packages/fabrika-cli/src/status/front-door-codex.cli.test.ts
+++ b/packages/fabrika-cli/src/status/front-door-codex.cli.test.ts
@@ -21,7 +21,7 @@ describe.runIf(process.env.FABRIKA_CODEX_PROOF === "1")(
 			const repo = join(root, "repo");
 			const market = join(root, "market");
 			const plugin = join(market, "fabrika");
-			const env = {PATH: process.env.PATH, HOME: process.env.HOME, CODEX_HOME: home};
+			const env = {PATH: process.env.PATH, HOME: home, CODEX_HOME: home};
 			let accept: (body: string) => void = () => {};
 			const server = createServer(async (req, res) => {
 				const chunks: Buffer[] = [];

--- a/packages/fabrika-cli/src/status/front-door-codex.cli.test.ts
+++ b/packages/fabrika-cli/src/status/front-door-codex.cli.test.ts
@@ -1,0 +1,144 @@
+import {spawn, spawnSync} from "node:child_process";
+import {cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {createServer} from "node:http";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+
+const source = fileURLToPath(
+	new URL("../../../../claude-plugins/fabrika/skills/front-door/", import.meta.url),
+);
+
+describe.runIf(process.env.FABRIKA_CODEX_PROOF === "1")(
+	"front-door in the installed Codex runtime (loopback provider, no model calls)",
+	{timeout: SUBPROCESS_TEST_TIMEOUT_MS},
+	() => {
+		it("withholds implicit discovery but expands an explicit skill invocation", async () => {
+			const root = mkdtempSync(join(tmpdir(), "fabrika-codex-policy-"));
+			const home = join(root, "home");
+			const repo = join(root, "repo");
+			const market = join(root, "market");
+			const plugin = join(market, "fabrika");
+			const env = {PATH: process.env.PATH, HOME: process.env.HOME, CODEX_HOME: home};
+			let accept: (body: string) => void = () => {};
+			const server = createServer(async (req, res) => {
+				const chunks: Buffer[] = [];
+				for await (const chunk of req) chunks.push(Buffer.from(chunk));
+				if (req.method === "POST" && req.url?.includes("responses")) {
+					accept(Buffer.concat(chunks).toString());
+					res.writeHead(503).end("request captured; no model invoked");
+				} else res.writeHead(404).end();
+			});
+			try {
+				for (const dir of [
+					home,
+					repo,
+					join(market, ".claude-plugin"),
+					join(plugin, ".claude-plugin"),
+				]) {
+					mkdirSync(dir, {recursive: true});
+				}
+				cpSync(source, join(plugin, "skills/front-door"), {recursive: true});
+				mkdirSync(join(plugin, "skills/control"), {recursive: true});
+				writeFileSync(
+					join(plugin, "skills/control/SKILL.md"),
+					"---\nname: control\ndescription: Codex policy proof discovery control.\n---\nSay hello.\n",
+				);
+				writeFileSync(
+					join(market, ".claude-plugin/marketplace.json"),
+					JSON.stringify({
+						name: "policy-proof",
+						owner: {name: "proof"},
+						plugins: [{name: "fabrika", source: "./fabrika"}],
+					}),
+				);
+				writeFileSync(
+					join(plugin, ".claude-plugin/plugin.json"),
+					JSON.stringify({name: "fabrika", version: "0.1.0", description: "Policy proof"}),
+				);
+				for (const args of [
+					["plugin", "marketplace", "add", market],
+					["plugin", "add", "fabrika@policy-proof"],
+				]) {
+					const run = spawnSync("codex", args, {
+						env,
+						encoding: "utf8",
+						timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+					});
+					expect(run.status, run.stderr).toBe(0);
+				}
+				await new Promise<void>((resolve, reject) => {
+					server.once("error", reject);
+					server.listen(0, "127.0.0.1", resolve);
+				});
+				const address = server.address();
+				if (address === null || typeof address === "string") throw new Error("No loopback port");
+				for (const [prompt, explicit] of [
+					["Say hello.", false],
+					["$fabrika:front-door", true],
+				] as const) {
+					const captured = new Promise<string>((resolve) => {
+						accept = resolve;
+					});
+					const child = spawn(
+						"codex",
+						[
+							"exec",
+							"--skip-git-repo-check",
+							"-C",
+							repo,
+							"-c",
+							'model_provider="proof"',
+							"-c",
+							'model="proof-model"',
+							"-c",
+							'model_providers.proof.name="proof"',
+							"-c",
+							'model_providers.proof.wire_api="responses"',
+							"-c",
+							"model_providers.proof.requires_openai_auth=false",
+							"-c",
+							`model_providers.proof.base_url="http://127.0.0.1:${address.port}/v1"`,
+							prompt,
+						],
+						{env, stdio: ["ignore", "ignore", "pipe"]},
+					);
+					let stderr = "";
+					child.stderr.on("data", (chunk) => {
+						stderr += chunk;
+					});
+					const exited = new Promise<void>((resolve) => {
+						child.once("close", () => resolve());
+					});
+					const failed = new Promise<never>((_, reject) => {
+						child.once("error", reject);
+						child.once("exit", () => reject(new Error(`Codex exited before capture: ${stderr}`)));
+					});
+					let timer: ReturnType<typeof setTimeout> | undefined;
+					try {
+						const timeout = new Promise<never>((_, reject) => {
+							timer = setTimeout(
+								() => reject(new Error(`No request captured: ${stderr}`)),
+								SUBPROCESS_TEST_TIMEOUT_MS / 4,
+							);
+						});
+						const body = await Promise.race([captured, failed, timeout]);
+						expect(body).toContain("Codex policy proof discovery control.");
+						expect(body.includes("The operating front door — explicitly invoke")).toBe(explicit);
+						expect(body.includes("Run the readout through the shell tool:")).toBe(explicit);
+					} finally {
+						clearTimeout(timer);
+						child.kill("SIGKILL");
+						await exited;
+					}
+				}
+			} finally {
+				server.closeAllConnections();
+				await new Promise<void>((resolve) => server.close(() => resolve()));
+				rmSync(root, {recursive: true, force: true});
+			}
+		});
+	},
+);

--- a/packages/fabrika-cli/src/status/front-door-policy.unit.test.ts
+++ b/packages/fabrika-cli/src/status/front-door-policy.unit.test.ts
@@ -1,0 +1,17 @@
+import {readFileSync} from "node:fs";
+import {describe, expect, it} from "vitest";
+import {parse} from "yaml";
+import {skillFrom} from "./roster.ts";
+
+const skill = new URL("../../../../claude-plugins/fabrika/skills/front-door/", import.meta.url);
+
+describe("front-door invocation policy", () => {
+	it("keeps the roster's human-only axis and Codex's implicit policy consistent", () => {
+		const row = skillFrom("front-door", readFileSync(new URL("SKILL.md", skill), "utf8"));
+		const metadata = parse(readFileSync(new URL("agents/openai.yaml", skill), "utf8"));
+		expect(row.frontmatterReadable).toBe(true);
+		expect(row.invocationAxis).toBe("user");
+		expect(metadata.policy.allow_implicit_invocation).toBe(false);
+		expect(metadata.interface.short_description).toBeTruthy();
+	});
+});

--- a/reports/2026-09-08-codex-front-door-policy.md
+++ b/reports/2026-09-08-codex-front-door-policy.md
@@ -1,0 +1,66 @@
+# Codex front-door invocation proof
+
+Issue: [#8618](https://github.com/kamp-us/phoenix/issues/8618).
+Runtime: Codex CLI `0.153.4`. Date: 2026-09-08.
+
+## Result
+
+The shared skill remains human-only in the Fabrika roster and in Claude's frontmatter.
+Its adjacent `agents/openai.yaml` adds Codex's explicit-only policy. The real Codex runtime
+omits the skill from an ordinary prompt and includes its complete body when the prompt explicitly
+names `$fabrika:front-door`.
+
+| Request | Discovery control advertised | front-door advertised | front-door body loaded |
+|---|---|---|---|
+| `Say hello.` | yes | no | no |
+| `$fabrika:front-door` | yes | yes | yes |
+
+The control is an ordinary skill in the same installed plugin. Its presence distinguishes policy
+exclusion from a plugin that failed to load altogether. The test compares the request Codex constructs,
+before any model responds; it makes no claim about a model's subsequent decisions.
+
+## Reproduce
+
+With Codex CLI on `PATH` and workspace dependencies installed, run from the repository root:
+
+```bash
+pnpm --filter @kampus/fabrika-cli exec vitest run src/status/front-door-policy.unit.test.ts src/status/status.cli.test.ts
+FABRIKA_CODEX_PROOF=1 pnpm --filter @kampus/fabrika-cli exec vitest run src/status/front-door-codex.cli.test.ts
+```
+
+The first command passed four checks, including the real `status open --field menu` command's
+exit status and readout shape. The second passed the real Codex policy proof. Its
+[test source](../packages/fabrika-cli/src/status/front-door-codex.cli.test.ts) creates a temporary
+marketplace, installs the shared front-door skill and a discovery control in an isolated Codex
+profile, and starts two requests against a loopback provider. The provider captures request construction
+and returns no model output; the test then terminates each child. No API credentials, hosted model
+calls, GitHub writes or production pipeline execution are involved.
+
+The Codex proof is opt-in because Codex CLI is an external prerequisite, not a workspace dependency.
+An ordinary test run skips it; a skipped proof is not runtime evidence. The unit policy check runs
+in the normal suite.
+
+## Validator discrepancy
+
+The supplied plugin-creator validator rejects the retained Claude field with:
+
+```text
+skill `front-door` frontmatter field `disable-model-invocation` must be false
+```
+
+The supplied skill-creator quick validator also rejects that field as outside its allowed keys.
+These are validator failures, not passes. Neither validator was modified or bypassed. The runtime
+proof establishes the narrower fact that Codex accepts this shared skill and honors its Codex
+invocation policy. Removing the Claude field would change the other harness's behavior merely to
+satisfy a packaging check.
+
+## Sources and limits
+
+[OpenAI's optional skill metadata](https://learn.chatgpt.com/docs/build-skills#optional-metadata)
+documents `policy.allow_implicit_invocation: false` and continued explicit invocation. The test above
+checks that behavior in the installed runtime instead of inferring it from successful installation.
+
+The skill now runs `fabrika status open` as an explicit tool step. It relies on no inline shell
+interpolation. The existing unreadable-source terminal handles a failed command or missing readout;
+the output-as-data boundary and per-field unknown states remain in force. This proof does not run
+the full operating conversation or establish Codex lane orchestration compatibility.


### PR DESCRIPTION
Front-door now carries Codex's explicit-only invocation metadata and runs its status readout through a normal tool call. Claude's existing human-only flag remains intact.

The offline Codex proof confirms that an ordinary prompt omits the skill while explicit invocation loads it. Policy and status checks pass, along with Fabrika's code and prose validators. The report distinguishes actual runtime behavior from the supplied packaging validators, which still reject the Claude-specific flag.

Fixes #8618

## Deviations

None.
