### PR TITLE
fix: Fabrika orchestration skills still prescribe Claude-specific spawns

### DIFF
--- a/.decisions/0360-retire-opencode-harness.md
+++ b/.decisions/0360-retire-opencode-harness.md
@@ -1,7 +1,7 @@
 ---
 id: 0360
 title: Claude Code and pi are fabrika's only harnesses, never opencode
-status: accepted
+status: amended-in-part by [0367](0367-codex-is-a-supported-harness.md)
 date: 2026-09-07
 tags: [fabrika, harness, opencode, packaging, retirement]
 ---

--- a/.decisions/0367-codex-is-a-supported-harness.md
+++ b/.decisions/0367-codex-is-a-supported-harness.md
@@ -1,0 +1,43 @@
+---
+id: 0367
+title: Codex is a supported Fabrika harness
+status: accepted
+date: 2026-09-08
+tags: [fabrika, harness, codex, packaging]
+---
+
+# 0367 — Codex is a supported Fabrika harness
+
+**What this decides:** Fabrika supports Codex alongside Claude Code and pi through the shared plugin skills and a deterministic CLI dispatch adapter.
+
+## Context
+
+The founder requested a Codex plugin equivalent to Fabrika's Claude Code and pi integrations and authorized its complete pipeline delivery in [issue #8617](https://github.com/kamp-us/phoenix/issues/8617).
+
+[ADR 0360](0360-retire-opencode-harness.md) requires a separate decision before admitting a third harness. This record supplies that decision and amends only its two-harness constraint. Its retirement of opencode, removal of executable pointers, and preservation of the neutral session override remain binding.
+
+The questions settled here are: may Codex run Fabrika stages, and which component owns its stage isolation and completion proof?
+
+## Decision
+
+**Codex is a supported Fabrika harness alongside Claude Code and pi.**
+
+The existing Fabrika plugin tree carries a Codex manifest pointing to the shared skills. The existing Fabrika CLI owns Codex lane dispatch; no additional published npm package is required.
+
+The adapter creates and verifies a dedicated git worktree, preloads the required stage skills through a fixed prompt envelope, and preserves the emitted lane brief verbatim within that envelope. It runs Codex in that worktree and verifies a fresh task report and live artifact evidence after the child exits. Child output alone is not completion evidence.
+
+**Binding constraints.**
+
+- Codex admission does not restore opencode support or its retired distribution surfaces.
+- Shared skills remain the stage contract; Codex plugin installation does not imply native registration of Fabrika agent roles.
+- Dispatch preserves configured sandbox, approval, and model policy rather than overriding them. Operators must configure child policy explicitly when their parent session uses transient overrides.
+- The neutral session override remains authoritative; Codex session identifiers are fallback identity sources.
+- Claude Code and pi remain supported through their existing integrations.
+
+## Consequences
+
+Codex users can install the same skills and run isolated pipeline stages with deterministic completion checks. Fabrika must maintain the Codex adapter and its integration tests alongside the existing harness integrations. Failed or incomplete child runs retain their worktrees for inspection and repair.
+
+## Records
+
+no vocabulary impact

--- a/.patterns/codex-lane-dispatch.md
+++ b/.patterns/codex-lane-dispatch.md
@@ -1,0 +1,27 @@
+# Codex lane dispatch
+
+The [dispatch verb](../packages/fabrika-cli/src/lane/dispatch-verb.ts) adapts the existing lane
+brief to a Codex child process. Its [pure module](../packages/fabrika-cli/src/lane/codex-dispatch.ts)
+owns role-to-skill selection and the fixed preload envelope. The brief remains byte-identical
+inside that envelope; it is never summarized by the driver. No Codex configuration override is
+needed to preload a stage, so configured developer instructions remain present.
+
+Git worktree creation precedes child execution. The verb verifies the root, common repository,
+commit and cleanliness before running repository setup or Codex. An exclusive per-task lock
+prevents duplicate dispatch; it is separate from the ledger append lock because a child must
+remain able to record its terminal while the dispatcher waits.
+
+Completion requires both a new task report and fresh artifact evidence.
+[The shared prover](../packages/fabrika-cli/src/lane/prove-verb.ts) accepts an internal captured
+lane snapshot for this second read: re-reading the current post-report state would ask what the
+*next* stage owes. The snapshot changes only state selection; the board and Git evidence are
+still read live. There is no CLI override to bypass state selection.
+
+[Real-Git integration tests](../packages/fabrika-cli/src/lane/dispatch.integration.test.ts) exercise
+the actual child cwd with a fake Codex executable. They establish isolation and handoff behavior,
+not model adherence. This pattern applies to Fabrika lane stages, not ordinary Codex subagents.
+
+The Effect shape follows [LLMS.md — Working with child processes and Writing Effect code](https://github.com/Effect-TS/effect/blob/main/LLMS.md).
+At the repository's beta pin, `ChildProcess.make` supports `cwd`, `env`, `extendEnv` and streamed
+stdin; implementation grounds those options in the installed `effect/unstable/process` source.
+Codex configuration and CLI references are linked in [the Codex guide](../claude-plugins/fabrika/guide/codex.md).

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -201,6 +201,8 @@ Tuval is the local runnable app under `apps/tuval` (ADR [0345](../.decisions/034
 |---|---|---|
 | [package-readme-shape.md](./package-readme-shape.md) | The canonical `packages/*/README.md` section order (explanation → how-to → reference → testing), the no-tutorial-at-package-scale rule, the small-package minimum; the [`diataxis`](../claude-plugins/fabrika/skills/diataxis/SKILL.md) skill is the single-mode classifier | Writing or restructuring a package README |
 
+- [Codex lane dispatch](./codex-lane-dispatch.md): fixed skill preload, dedicated worktree, unchanged brief, and post-child proof against captured state.
+
 ## When to add a new pattern doc here
 
 A pattern may enter through either source-backed path:

--- a/claude-plugins/fabrika/.codex-plugin/plugin.json
+++ b/claude-plugins/fabrika/.codex-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+	"name": "fabrika",
+	"version": "0.1.0",
+	"description": "Shared Fabrika pipeline skills over deterministic CLI verbs.",
+	"skills": "./skills/",
+	"interface": {
+		"displayName": "Fabrika",
+		"shortDescription": "Build, review and ship through verified CLI verbs",
+		"longDescription": "Shared stage skills with a Codex dispatch adapter that isolates lane tasks in dedicated git worktrees. Requires the Fabrika CLI and an initialized repository.",
+		"category": "Productivity",
+		"capabilities": ["Read", "Write"],
+		"defaultPrompt": ["Use Fabrika to operate the requested issue lane."]
+	}
+}

--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -1,6 +1,6 @@
 # fabrika
 
-**fabrika** is an agent pipeline, shipped as a Claude Code plugin. You file an issue; a
+**fabrika** is an agent pipeline, shipped for Claude Code, Codex, and pi. You file an issue; a
 chain of agents triages it, plans it, builds it, reviews it, and merges it. Every stage leaves its
 record on the issue or the pull request, not in a chat log. It works in any GitHub repo, and it is
 for anyone who wants agents doing real work on a repo with that work reviewable afterwards.
@@ -14,6 +14,7 @@ and points at the other fabrika surfaces.
 
 ```
 claude-plugins/fabrika/
+├── .codex-plugin/plugin.json    Codex manifest; shares skills and uses CLI dispatch
 ├── .claude-plugin/plugin.json   the plugin manifest (no version — it ships continuously, addressed by commit)
 ├── README.md                    this file
 ├── agents/                      the eight agent shells, one per stage role (see docs/agent-shells.md)
@@ -32,6 +33,8 @@ meet [docs/skill-conventions.md](docs/skill-conventions.md). Nothing lands in `s
 it is the text that is graded, not the session that produced it.
 
 ## Install
+
+For Codex, follow [the Codex guide](guide/codex.md). The commands below install the Claude Code plugin.
 
 From the `kampus` marketplace on GitHub:
 

--- a/claude-plugins/fabrika/guide/README.md
+++ b/claude-plugins/fabrika/guide/README.md
@@ -23,3 +23,5 @@ These pages are written for a person. Each holds one Diátaxis mode.
 - **[`packages/fabrika-cli/docs/verb-reference.md`](../../../packages/fabrika-cli/docs/verb-reference.md)**
   — the verb reference: what each command does and its exit codes.
 - **[`../skills/`](../skills/)** — one `SKILL.md` per skill: the contracts agents execute.
+
+- [Use Fabrika in Codex](codex.md): install the shared plugin and dispatch isolated lane stages.

--- a/claude-plugins/fabrika/guide/codex.md
+++ b/claude-plugins/fabrika/guide/codex.md
@@ -1,0 +1,60 @@
+# Use Fabrika in Codex
+
+Install the CLI and initialize the repository using [adopt Fabrika](adopt-fabrika-in-a-new-repo.md).
+The plugin supplies shared skills and references; the CLI supplies their deterministic verbs.
+GitHub credentials, Node, Git, and Codex CLI must already work in the environment.
+
+From this repository's root, install the existing marketplace entry:
+
+```bash
+codex plugin marketplace add ./
+codex plugin add fabrika@kampus
+```
+
+Start a new session. Use `/plugins` to inspect the installed plugin. Re-run the install command
+after updating the marketplace checkout and restart the session to use updated cached skills.
+
+## Dispatch a lane task
+
+Ask Codex to use the shared `operate` skill. Its Codex route runs `fabrika lane dispatch` for
+each active task. Supply the absolute directory containing the installed plugin's shared skills
+and an absent worktree path outside the primary checkout. Resolve the skill directory from the
+installed `operate` skill's location; do not guess a cache version.
+
+```bash
+fabrika lane dispatch 123 --task issue --harness codex --skills /installed/fabrika/skills --worktree /scratch/lane-123
+```
+
+The adapter creates a detached worktree, verifies its repository and commit, and runs the
+repository's `dependencyReconciler` if declared. A repository requiring dependencies must declare
+that command in `.fabrika.jsonc`. Each child receives a fixed instruction to read the selected
+stage skills, followed by the emitted lane brief without changing its bytes. The child runs
+`codex exec --cd` there. Read the [dispatch contract](../../../packages/fabrika-cli/docs/codex-dispatch.md)
+for refusals, completion, and recovery.
+
+Codex's persistent model, reasoning, developer instructions, sandbox and approval configuration
+remain authoritative: the adapter overrides none of them. Parent-chat transient settings are
+not a CLI configuration export; configure the child policy in Codex before dispatch when such
+settings matter. Noninteractive approval failures remain failures. Never add an unrestricted
+execution flag to make a blocked stage continue.
+
+Session attribution preserves the existing precedence: `FABRIKA_SESSION_ID`, then
+`CLAUDE_CODE_SESSION_ID`, then `PI_SUBAGENT_PARENT_SESSION`, then `CODEX_THREAD_ID`, then
+`CODEX_SESSION_ID`. Blank values fall through; an absent identity refuses dispatch. The adapter
+carries the resolved identity into its child as `FABRIKA_SESSION_ID` so the lane remains attributed
+to its driver.
+
+## Host support
+
+The shared Claude `agents/*.md` files are not Codex agent registrations. This route selects skills
+inside the CLI; installing the plugin requires no custom Codex role configuration. Codex documents
+custom agents separately under [Subagents — Custom agents](https://learn.chatgpt.com/docs/agent-configuration/subagents#custom-agents).
+The [plugin manifest](https://developers.openai.com/plugins/build/plugins#manifest-fields) packages
+skills and supporting resources. The app's [worktree chats](https://learn.chatgpt.com/docs/environments/git-worktrees)
+are a separate workflow from this adapter's verified Git worktrees.
+
+The executable contract was checked against Codex CLI 0.153.4's `exec --help`: `--cd` selects the
+working root and `-` reads the prompt from stdin. Automated dispatch tests use real Git and a fake
+Codex executable; they do not spend model tokens or claim a live end-to-end pipeline run.
+The `front-door` explicit-invocation policy is a separate skill contract; shared Claude frontmatter
+may still be rejected by a packaging validator even when Codex loads the skill.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -218,7 +218,7 @@ active phase** (future phases read `waiting`; leave them alone), route on the le
 node <fabrika> lane brief $lane_key --task <name>
 ```
 
-Its stdout is the whole prompt — send those bytes to the spawn verbatim and add nothing to them. It
+For Claude, its stdout is the whole prompt — send those bytes to the spawn verbatim and add nothing to them. For Codex, use the dispatch adapter below; it preserves this brief inside a fixed skill preload envelope. The brief
 derives every value: the state from the same fold you just read, the shell from its own routing
 table (`build` → builder, `build:ui` → ui-builder, `review` → reviewer, `review:ui` → ui-reviewer,
 `ship` → shipper), the issue and PR URLs off the
@@ -231,9 +231,22 @@ never restatements, and the brief's own `fabrika:` entrypoint for every verb rat
 binstub (now in the spawned tree). They are in the brief because a prompt written per
 dispatch is a prompt two drivers write differently.
 
-The spawn flag is still yours: **`isolation: worktree`, no exceptions** — a non-isolated subagent
+On Claude, the spawn flag is still yours: **`isolation: worktree`, no exceptions** — a non-isolated subagent
 shares the primary checkout and can mutate its git state, and no bytes in a prompt can enforce that
 from the inside.
+
+On Codex, run the deterministic adapter instead of the shared-workspace subagent tool:
+
+```bash
+node <fabrika> lane dispatch $lane_key --task <name> --harness codex --skills <absolute-installed-skills-directory> --worktree <absent-absolute-worktree-path>
+```
+
+Read [the Codex installation and dispatch guide](../../guide/codex.md) for prerequisites.
+The adapter creates and verifies the worktree, runs the declared dependency reconciler, selects
+stage skills by role, and sends a fixed preload envelope followed by the unchanged emitted brief.
+It preserves Codex configuration and waits for the child process. A zero exit is insufficient:
+a new task terminal and the existing artifact proof must both stand. A refused dispatch retains
+its worktree; inspect its named cause before retrying. Never replace it with a non-isolated spawn.
 
 `lane brief`'s refusals are the parks it saves you from guessing at: `18` is a state that routes to
 no shell, `19` is a task whose issue cannot be resolved or is absent, `20` is zero open PRs where
@@ -246,7 +259,7 @@ and `11` is a ref this tree cannot read — the same three facts, and the same r
 seats on those codes. Each is a park naming what the verb named — never a prompt you write by hand
 instead. Parallel active tasks brief and spawn in parallel.
 
-**Then do nothing until a spawn returns — and never `sleep`.** A shell spawned with the Agent tool
+**Then do nothing until a spawn returns — and never `sleep`.** A Codex dispatch waits for its child process; a shell spawned with the Claude Agent tool
 returns its result to you, so that return *is* the wait. The rule and both incidents behind it are
 [the skill conventions' "a skill never sleeps and never polls on a timer"](../../docs/skill-conventions.md);
 the one thing it adds for you is that a timed `lane status` is the same defect wearing a fabrika

--- a/packages/fabrika-cli/docs/codex-dispatch.md
+++ b/packages/fabrika-cli/docs/codex-dispatch.md
@@ -1,0 +1,38 @@
+# Codex dispatch contract
+
+`fabrika lane dispatch <lane> --harness codex --skills <absolute-directory> --worktree <absent-absolute-path> [--task <task>] [--root <lanes-root>]`
+
+Inputs are an existing active lane, its task, installed shared Fabrika skills, a Git checkout,
+and an absent worktree path outside the source and primary checkout. Multi-task lanes require
+`--task`. The normal repository-derived lanes root remains the default. Dispatch accepts the
+five shell states that `lane brief` emits and no other state or harness.
+
+The verb reads `lane brief`, captures the task's state, validates its role skills, then takes
+a per-task dispatch lock. It creates and verifies a detached worktree at the source commit,
+or the epic assembly branch for an epic child. It runs the declared dependency reconciler and
+refuses if that process fails or changes tracked files. It starts `codex exec --cd` with the
+fixed skill preload envelope and the emitted brief as stdin. It passes no model or policy flags.
+
+Output on success is `{harness, task, event, worktree}`. Success means the child exited zero,
+the original ledger prefix remains intact, exactly one new terminal addresses the task, the
+updated ledger folds, and the existing artifact prover confirms that event against the captured
+pre-dispatch state using fresh evidence. The event can be a failure or park; callers route from
+the lane state, not from the dispatch exit code. stdout text from the child is never proof.
+
+Exit `11` means an input, worktree, process, or lane read failed; `18` means no supported dispatch;
+`22` means no unique new terminal. `lane brief`, lane loading, and artifact proof refusals retain
+their own exit codes. Every refusal leaves stdout empty.
+
+All created worktrees remain on disk, including clean successful ones. Child output is captured
+beside the ledger as `dispatch-<task>.stdout` and `dispatch-<task>.stderr`. Inspect those files and
+the worktree before recovery. The dispatch lock is removed when the process exits normally or is
+interrupted through Effect; a killed dispatcher may leave its lock directory. Confirm that its
+process is gone before removing a stale lock. Do not delete or reset a worktree merely to retry.
+
+Example:
+
+```bash
+fabrika lane dispatch 123 --harness codex --skills /installed/fabrika/skills --worktree /scratch/lane-123
+```
+
+See [using Codex](../../../claude-plugins/fabrika/guide/codex.md) for installation and configuration.

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -571,6 +571,7 @@ snapshot. Lane state is local and never committed.
 | `lane print` | the compiled topology: phases, terminals, and each state's legal events |
 | `lane open` / `emit` | boot a lane from a committed template, or generate an epic's machine from its board topology — `open` refuses an epic at `46`, typed `type:epic` or carrying sub-issue links, since the coder template has one task, and an epic's *child* at `48`, naming the parent whose lane already carries it as a task; `emit` refuses a lane already on disk at `14` and names the two-step remedy, retire the directory then re-run |
 | `lane brief` | the spawn prompt for one task's current leaf state |
+| `lane dispatch` | run one active task through Codex in a verified worktree; [contract](./codex-dispatch.md) |
 | `lane assembly` / `push` | an epic run's assembly worktree, and its published branch |
 | `lane integrate` | one reviewed child merged into that worktree, its dependencies reconciled from the merged lockfile, then judged by the repo's `codeValidators` — last stdout line on exit 0 is `INTEGRATE-VERDICT: MERGED`, the line above it the merged head; every refusal below the merge resets the branch to `ORIG_HEAD` and pushes nothing |
 | `lane stale` | which lanes have gone quiet with something owed on them — offline, or `--claims` to pair each non-terminal lane with the claim standing on its issue |

--- a/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
@@ -183,7 +183,7 @@ describe("runTree", () => {
 		});
 		expect(out.code).toBe(FAILED);
 		expect(out.stderr.at(-1)).toContain(
-			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION are all unset",
+			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION, CODEX_THREAD_ID, CODEX_SESSION_ID are all unset",
 		);
 	});
 

--- a/packages/fabrika-cli/src/io/session-id.ts
+++ b/packages/fabrika-cli/src/io/session-id.ts
@@ -2,8 +2,8 @@
  * The one session-attribution read — every verb's identity comes through here or nowhere.
  *
  * The precedence chain is `FABRIKA_SESSION_ID` → `CLAUDE_CODE_SESSION_ID` →
- * `PI_SUBAGENT_PARENT_SESSION`, and an environment carrying none of the three is refused by the
- * caller. A site that hardcodes one of the three instead fails on first contact under any harness
+ * `PI_SUBAGENT_PARENT_SESSION` → `CODEX_THREAD_ID` → `CODEX_SESSION_ID`. An environment
+ * carrying none is refused by the caller. Hardcoding one variable fails under any harness
  * that stamps another, which is why the chain is read in one place.
  *
  * The documented invariants are preserved structurally, not enforced here: the value is whatever the
@@ -15,15 +15,17 @@
  */
 
 /**
- * The consulted variables, in precedence order — the unset refusal names all three.
+ * The consulted variables, in precedence order — the unset refusal names all supported variables.
  *
  * `FABRIKA_SESSION_ID` leads as the harness-neutral override a driver exports by hand when the
- * harness it runs under stamps neither of the other two.
+ * harness it runs under stamps none of the harness variables.
  */
 export const SESSION_ID_VARS = [
 	"FABRIKA_SESSION_ID",
 	"CLAUDE_CODE_SESSION_ID",
 	"PI_SUBAGENT_PARENT_SESSION",
+	"CODEX_THREAD_ID",
+	"CODEX_SESSION_ID",
 ] as const;
 
 /** What a caller passes as the environment half of the read. */

--- a/packages/fabrika-cli/src/io/session-id.unit.test.ts
+++ b/packages/fabrika-cli/src/io/session-id.unit.test.ts
@@ -34,7 +34,7 @@ describe("sessionIdFrom", () => {
 		expect(sessionIdFrom({CLAUDE_CODE_SESSION_ID: "  cc  "})).toBe("cc");
 	});
 
-	it("resolves null when all three variables are unset or blank — fail-closed stays", () => {
+	it("resolves null when all supported variables are unset or blank — fail-closed stays", () => {
 		expect(sessionIdFrom({})).toBeNull();
 		expect(
 			sessionIdFrom({
@@ -45,7 +45,20 @@ describe("sessionIdFrom", () => {
 		).toBeNull();
 	});
 
-	it("names all three consulted variables in the unset refusal clause", () => {
+	it("names all supported consulted variables in the unset refusal clause", () => {
 		for (const name of SESSION_ID_VARS) expect(sessionIdUnset).toContain(name);
 	});
+});
+
+for (const name of ["CODEX_THREAD_ID", "CODEX_SESSION_ID"]) {
+	it(`recognizes ${name} while preserving existing harness precedence`, () => {
+		expect(sessionIdFrom({[name]: "codex"})).toBe("codex");
+		expect(sessionIdFrom({[name]: "codex", PI_SUBAGENT_PARENT_SESSION: "pi"})).toBe("pi");
+		expect(sessionIdFrom({[name]: "codex", FABRIKA_SESSION_ID: "override"})).toBe("override");
+	});
+}
+it("falls through blank Codex identities and prefers the thread identity", () => {
+	expect(sessionIdFrom({CODEX_THREAD_ID: "thread", CODEX_SESSION_ID: "session"})).toBe("thread");
+	expect(sessionIdFrom({CODEX_THREAD_ID: " ", CODEX_SESSION_ID: "session"})).toBe("session");
+	expect(sessionIdFrom({CODEX_THREAD_ID: " ", CODEX_SESSION_ID: " "})).toBeNull();
 });

--- a/packages/fabrika-cli/src/lane/codex-dispatch.ts
+++ b/packages/fabrika-cli/src/lane/codex-dispatch.ts
@@ -1,0 +1,31 @@
+import type {LaneShell} from "../wire/lane-brief.ts";
+import type {LogEntry} from "./fold.ts";
+import {bareEvent} from "./machine.ts";
+
+export const CODEX_ROLE_SKILLS: Readonly<Record<LaneShell, ReadonlyArray<string>>> = {
+	builder: ["build"],
+	"ui-builder": ["build", "build-ui"],
+	reviewer: ["review"],
+	"ui-reviewer": ["review-ui"],
+	shipper: ["ship"],
+};
+
+export const codexPrompt = (skills: ReadonlyArray<string>, brief: string): string =>
+	`Follow the Fabrika stage skills below. Read every named SKILL.md and its required references before acting. Resolve supporting files relative to the skill directory. Work only in this process's dedicated worktree. Use the lane brief's Fabrika entrypoint for every verb. Record your terminal through lane report as the skill requires. Do not run another pipeline stage.\n\n${skills.map((skill) => `Skill: ${JSON.stringify(skill)}`).join("\n")}\n\n${brief}`;
+
+export const reportedTerminal = (
+	before: ReadonlyArray<LogEntry>,
+	after: ReadonlyArray<LogEntry>,
+	task: string,
+): LogEntry | null => {
+	if (before.some((entry, index) => JSON.stringify(entry) !== JSON.stringify(after[index]))) {
+		return null;
+	}
+	const added = after.slice(before.length).filter((entry) => entry.task === task);
+	if (added.length !== 1) return null;
+	const entry = added[0];
+	return entry !== undefined &&
+		["DONE", "PASS", "FAIL", "BLOCKED", "WIP"].includes(bareEvent(entry.event))
+		? entry
+		: null;
+};

--- a/packages/fabrika-cli/src/lane/codex-dispatch.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/codex-dispatch.unit.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, it} from "vitest";
+import {CODEX_ROLE_SKILLS, codexPrompt, reportedTerminal} from "./codex-dispatch.ts";
+
+describe("Codex dispatch contract", () => {
+	it("preloads the UI builder's two construction laws without changing brief bytes", () => {
+		expect(CODEX_ROLE_SKILLS["ui-builder"]).toEqual(["build", "build-ui"]);
+		const brief = "## Task\n\nbytes with `quotes` and $variables\n";
+		const prompt = codexPrompt(["/installed/build/SKILL.md"], brief);
+		expect(prompt.endsWith(brief)).toBe(true);
+		expect(prompt).toContain('Skill: "/installed/build/SKILL.md"');
+	});
+	it("rejects absent, duplicate, foreign-task and rewritten terminal histories", () => {
+		const prior = {task: "issue", event: "ISSUE.WIP", at: "before"};
+		const done = {task: "issue", event: "ISSUE.DONE", at: "after"};
+		expect(reportedTerminal([prior], [prior], "issue")).toBeNull();
+		expect(reportedTerminal([prior], [prior, done, done], "issue")).toBeNull();
+		expect(reportedTerminal([prior], [prior, {...done, task: "other"}], "issue")).toBeNull();
+		expect(reportedTerminal([prior], [{...prior, at: "changed"}, done], "issue")).toBeNull();
+		expect(reportedTerminal([prior], [prior, done], "issue")).toEqual(done);
+	});
+});

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -25,6 +25,7 @@ import {claimHoldReader} from "./claim-hold.ts";
 import {runLaneAdopt, runLaneClaim, runLaneRelease} from "./claim-verb.ts";
 import {closureReader} from "./closure.ts";
 import {CLASS_UNRECOGNISED} from "./codes.ts";
+import {runDispatch} from "./dispatch-verb.ts";
 import {runEmit} from "./emit-verb.ts";
 import {expectationReader} from "./expectation.ts";
 import {deriveRepoRoot, onGround, repoGroundRefusal, resolveRootOrRefuse} from "./ground.ts";
@@ -34,7 +35,7 @@ import {archivedRoot, defaultRoot, type LaneKey, laneRef, parseKey, templateFile
 import {runMigrate} from "./migrate-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
-import {runProve} from "./prove-verb.ts";
+import {proveDispatched, runProve} from "./prove-verb.ts";
 import {runPush} from "./push-verb.ts";
 import {type ReconcileRoot, runReconcile} from "./reconcile-verb.ts";
 import {keyRefusal} from "./refusals.ts";
@@ -109,6 +110,56 @@ const onBoardKey = <R>(
 	const parsed = parseKey(raw);
 	return parsed._tag === "Malformed" ? Effect.succeed(keyRefusal(parsed)) : run(parsed.key);
 };
+
+const dispatch = leafCommand(
+	"dispatch",
+	{
+		lane: laneArgument,
+		root: rootFlag,
+		harness: Flag.string("harness").pipe(
+			Flag.withDescription("dispatch adapter; codex is supported"),
+		),
+		task: Flag.string("task").pipe(
+			Flag.optional,
+			Flag.withDescription("active lane task; required on multi-task lanes"),
+		),
+		skills: Flag.string("skills").pipe(
+			Flag.withDescription("absolute installed Fabrika skills directory"),
+		),
+		worktree: Flag.string("worktree").pipe(
+			Flag.withDescription(
+				"absent absolute path outside the primary checkout; retained after dispatch",
+			),
+		),
+	},
+	Effect.fn(function* ({lane, root, harness, task, skills, worktree}) {
+		const entrypoint = yield* resolveEntrypoint();
+		yield* emit(
+			yield* onKey("dispatch", lane, root, (_key, ref) =>
+				runDispatch(
+					{
+						...ref,
+						harness,
+						task: Option.getOrNull(task),
+						skills,
+						worktree,
+						cwd: process.cwd(),
+						env: process.env,
+						repo: null,
+						entrypoint,
+					},
+					runBrief,
+					proveDispatched,
+				),
+			),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Dispatch one active lane task to Codex in a verified worktree."),
+	Command.withDescription(
+		"Create a dedicated detached git worktree and run codex exec with a fixed skill preload envelope and the emitted lane brief unchanged. Preserves Codex model and policy configuration. Requires a new task terminal and fresh artifact proof; process exit zero alone is not completion. stdout: {harness, task, event, worktree}. Worktrees are retained. Exits 11 (missing input, isolation, process or state failure), 18 (unsupported harness or inactive state), 22 (no unique terminal), plus lane brief and lane prove refusals. Example: fabrika lane dispatch 5673 --harness codex --skills /installed/fabrika/skills --worktree /scratch/lane-5673",
+	),
+);
 
 const status = leafCommand(
 	"status",
@@ -1009,6 +1060,7 @@ export const laneCommand = Command.make("lane").pipe(
 		open,
 		emitLane,
 		brief,
+		dispatch,
 		assembly,
 		integrate,
 		pushLane,

--- a/packages/fabrika-cli/src/lane/dispatch-verb.ts
+++ b/packages/fabrika-cli/src/lane/dispatch-verb.ts
@@ -1,0 +1,251 @@
+import {Effect, FileSystem, Path, Result, Stream} from "effect";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {dependencyReconcilerKey} from "../config/keys/dependency-reconciler.ts";
+import {readKey} from "../config/read-key.ts";
+import {execCapture, execStatus} from "../io/exec.ts";
+import {sessionIdFrom, sessionIdUnset} from "../io/session-id.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {read as readBrief} from "../wire/lane-brief.ts";
+import type {BriefOptions} from "./brief-verb.ts";
+import {LANE_UNREADABLE, NO_SHELL, PROOF_ABSENT} from "./codes.ts";
+import {CODEX_ROLE_SKILLS, codexPrompt, reportedTerminal} from "./codex-dispatch.ts";
+import {applyEvent, foldLog} from "./fold.ts";
+import {bareEvent} from "./machine.ts";
+import type {ProveOptions} from "./prove-verb.ts";
+import {loadRefusal, replayRefusal} from "./refusals.ts";
+import {type LoadedLane, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane dispatch";
+type Services = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
+type Snapshot = Extract<LoadedLane, {_tag: "Loaded"}>;
+
+export interface DispatchOptions extends BriefOptions {
+	readonly cwd: string;
+	readonly harness: string;
+	readonly skills: string;
+	readonly worktree: string;
+}
+
+export const runDispatch = Effect.fn("lane.dispatch")(function* (
+	options: DispatchOptions,
+	brief: (options: BriefOptions) => Effect.Effect<VerbOutcome, never, Services>,
+	prove: (options: ProveOptions, snapshot: Snapshot) => Effect.Effect<VerbOutcome, never, Services>,
+): Effect.fn.Return<VerbOutcome, never, Services> {
+	if (options.harness !== "codex") return refuse(NO_SHELL, `${VERB}: unsupported harness.`);
+	const identity = sessionIdFrom(options.env);
+	if (identity === null) return refuse(LANE_UNREADABLE, `${VERB}: ${sessionIdUnset}.`);
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	if (!path.isAbsolute(options.worktree) || !path.isAbsolute(options.skills)) {
+		return refuse(LANE_UNREADABLE, `${VERB}: --worktree and --skills must be absolute paths.`);
+	}
+	const emitted = yield* brief(options);
+	if (emitted.code !== 0) return emitted;
+	const parsed = readBrief(emitted.stdout);
+	if (parsed._tag !== "Found") return refuse(LANE_UNREADABLE, `${VERB}: ${parsed.reason}.`);
+	const task = parsed.value.task;
+	const loaded = yield* loadLane(options);
+	if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+	const folded = foldLog(loaded.lane, loaded.entries);
+	if (folded._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, folded);
+	if (
+		folded.states[task]?.type !== parsed.value.state ||
+		applyEvent(loaded.lane, folded.states, task, "BLOCKED", new Date().toISOString())._tag ===
+			"Refused"
+	)
+		return refuse(NO_SHELL, `${VERB}: task is not active in the brief's state.`);
+	const skills: string[] = [];
+	for (const name of CODEX_ROLE_SKILLS[parsed.value.shell]) {
+		const file = path.join(options.skills, name, "SKILL.md");
+		const read = yield* Effect.result(fs.readFileString(file));
+		if (Result.isFailure(read) || read.success.trim() === "") {
+			return refuse(LANE_UNREADABLE, `${VERB}: required stage skill is unreadable: ${file}.`);
+		}
+		skills.push(file);
+	}
+	const exists = yield* Effect.result(fs.exists(options.worktree));
+	if (Result.isFailure(exists) || exists.success) {
+		return refuse(
+			LANE_UNREADABLE,
+			`${VERB}: worktree path must be absent; retain existing work for recovery.`,
+		);
+	}
+	const source = yield* execCapture("git", ["-C", options.cwd, "rev-parse", "--show-toplevel"]);
+	const common = yield* execCapture("git", [
+		"-C",
+		options.cwd,
+		"rev-parse",
+		"--path-format=absolute",
+		"--git-common-dir",
+	]);
+	if (!source.ok || !common.ok)
+		return refuse(LANE_UNREADABLE, `${VERB}: cannot establish source repository.`);
+	const parent = yield* Effect.result(fs.realPath(path.dirname(options.worktree)));
+	if (Result.isFailure(parent))
+		return refuse(LANE_UNREADABLE, `${VERB}: worktree parent must exist and be readable.`);
+	const destination = path.join(parent.success, path.basename(options.worktree));
+	const primary = path.dirname(common.stdout.trim());
+	if (
+		[source.stdout.trim(), primary].some(
+			(root) => destination === root || destination.startsWith(`${root}/`),
+		)
+	) {
+		return refuse(
+			LANE_UNREADABLE,
+			`${VERB}: worktree must be outside the source and primary checkout.`,
+		);
+	}
+	const ground = parsed.value.ground;
+	const base = ground._tag === "Epic" || ground._tag === "EpicRange" ? ground.branch : "HEAD";
+	const revision = yield* execCapture("git", [
+		"-C",
+		options.cwd,
+		"rev-parse",
+		"--verify",
+		`${base}^{commit}`,
+	]);
+	if (!revision.ok)
+		return refuse(LANE_UNREADABLE, `${VERB}: cannot resolve worktree base: ${revision.reason}.`);
+	const lock = path.join(loaded.dir, `dispatch-${task}.lock`);
+	const acquired = yield* Effect.result(fs.makeDirectory(lock));
+	if (Result.isFailure(acquired))
+		return refuse(LANE_UNREADABLE, `${VERB}: dispatch is held or unreadable: ${lock}.`);
+	return yield* Effect.gen(function* () {
+		const fresh = yield* loadLane(options);
+		if (
+			fresh._tag !== "Loaded" ||
+			JSON.stringify(fresh.entries) !== JSON.stringify(loaded.entries)
+		) {
+			return refuse(LANE_UNREADABLE, `${VERB}: lane moved before dispatch; re-read it.`);
+		}
+		const created = yield* execCapture("git", [
+			"-C",
+			options.cwd,
+			"worktree",
+			"add",
+			"--detach",
+			options.worktree,
+			revision.stdout.trim(),
+		]);
+		if (!created.ok)
+			return refuse(LANE_UNREADABLE, `${VERB}: worktree creation failed: ${created.reason}.`);
+		const actual = yield* fs.realPath(options.worktree);
+		const root = yield* execCapture("git", ["-C", actual, "rev-parse", "--show-toplevel"]);
+		const head = yield* execCapture("git", ["-C", actual, "rev-parse", "HEAD"]);
+		const shared = yield* execCapture("git", [
+			"-C",
+			actual,
+			"rev-parse",
+			"--path-format=absolute",
+			"--git-common-dir",
+		]);
+		const clean = yield* execCapture("git", ["-C", actual, "status", "--porcelain"]);
+		if (
+			!root.ok ||
+			root.stdout.trim() !== actual ||
+			!head.ok ||
+			head.stdout !== revision.stdout ||
+			!shared.ok ||
+			shared.stdout !== common.stdout ||
+			!clean.ok ||
+			clean.stdout !== ""
+		) {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: new worktree identity or cleanliness is unproven; retained ${actual}.`,
+			);
+		}
+		const reconciler = yield* readKey(actual, dependencyReconcilerKey);
+		if (reconciler._tag === "Refused")
+			return refuse(LANE_UNREADABLE, `${VERB}: ${reconciler.reason}.`);
+		if (reconciler.value !== null) {
+			const [binary, ...args] = reconciler.value.argv;
+			const installed = yield* execStatus(binary, args, actual);
+			if (installed._tag === "Unstartable" || !installed.ok)
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: dependency reconciliation failed; retained ${actual}.`,
+				);
+			const unchanged = yield* execCapture("git", [
+				"-C",
+				actual,
+				"status",
+				"--porcelain",
+				"--untracked-files=no",
+			]);
+			if (!unchanged.ok || unchanged.stdout !== "")
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: dependency reconciliation changed tracked files; retained ${actual}.`,
+				);
+		}
+		const child = yield* Effect.scoped(
+			Effect.gen(function* () {
+				const handle = yield* ChildProcess.make("codex", ["exec", "--cd", actual, "-"], {
+					cwd: actual,
+					env: {...options.env, FABRIKA_SESSION_ID: identity},
+					extendEnv: false,
+					stdin: Stream.fromIterable([
+						new TextEncoder().encode(codexPrompt(skills, emitted.stdout)),
+					]),
+				});
+				const [, , code] = yield* Effect.all(
+					[
+						Stream.run(handle.stdout, fs.sink(path.join(loaded.dir, `dispatch-${task}.stdout`))),
+						Stream.run(handle.stderr, fs.sink(path.join(loaded.dir, `dispatch-${task}.stderr`))),
+						handle.exitCode,
+					],
+					{concurrency: "unbounded"},
+				);
+				return code;
+			}),
+		);
+		if (child !== 0)
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: codex exited ${child}; worktree retained at ${actual}.`,
+			);
+		const after = yield* loadLane(options);
+		if (after._tag !== "Loaded") return loadRefusal(VERB, after);
+		const replay = foldLog(after.lane, after.entries);
+		if (replay._tag !== "Folded") return replayRefusal(VERB, after.logPath, replay);
+		const report = reportedTerminal(loaded.entries, after.entries, task);
+		if (report === null)
+			return refuse(
+				PROOF_ABSENT,
+				`${VERB}: child recorded no unique task terminal; retained ${actual}.`,
+			);
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const proof = yield* prove(
+			{
+				...options,
+				cwd: actual,
+				task,
+				event: bareEvent(report.event),
+				classes: report.classes ?? null,
+				pr: report.pr ?? null,
+			},
+			loaded,
+		).pipe(
+			Effect.provideService(
+				ChildProcessSpawner.ChildProcessSpawner,
+				ChildProcessSpawner.make((command) => spawner.spawn(ChildProcess.setCwd(command, actual))),
+			),
+		);
+		if (proof.code !== 0) return proof;
+		return answer(
+			JSON.stringify({harness: "codex", task, event: report.event, worktree: actual}),
+			proof.stderr,
+		);
+	}).pipe(
+		Effect.ensuring(Effect.ignore(fs.remove(lock, {recursive: true}))),
+		Effect.catchTag("PlatformError", (error) =>
+			Effect.succeed(
+				refuse(
+					LANE_UNREADABLE,
+					`${VERB}: ${error.message}; worktree retained at ${options.worktree}.`,
+				),
+			),
+		),
+	);
+});

--- a/packages/fabrika-cli/src/lane/dispatch.integration.test.ts
+++ b/packages/fabrika-cli/src/lane/dispatch.integration.test.ts
@@ -1,0 +1,210 @@
+import {execFileSync} from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {execCapture} from "../io/exec.ts";
+import {answer, refuse} from "../verb.ts";
+import {read as readBrief} from "../wire/lane-brief.ts";
+import {runBrief} from "./brief-verb.ts";
+import {PROOF_ABSENT} from "./codes.ts";
+import {runDispatch} from "./dispatch-verb.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+
+const git = (cwd: string, ...args: string[]) =>
+	execFileSync("git", args, {cwd, encoding: "utf8"}).trim();
+
+const fixture = (mode = "report") => {
+	const seat = realpathSync(mkdtempSync(join(tmpdir(), "fabrika-codex-dispatch-")));
+	const cwd = join(seat, "primary");
+	const root = join(seat, "lanes");
+	const skills = join(seat, "skills");
+	const bin = join(seat, "bin");
+	for (const dir of [cwd, join(root, "8617"), join(skills, "build"), bin])
+		mkdirSync(dir, {recursive: true});
+	git(cwd, "init", "--initial-branch=main");
+	git(cwd, "config", "user.name", "fixture");
+	git(cwd, "config", "user.email", "fixture@example.test");
+	writeFileSync(join(cwd, "tracked.txt"), "primary bytes\n");
+	git(cwd, "add", ".");
+	git(cwd, "commit", "-m", "fixture");
+	writeFileSync(join(root, "8617", "workflow.json"), coderTemplateText());
+	writeFileSync(
+		join(root, "8617", "events.jsonl"),
+		`${JSON.stringify({task: "issue", event: "ISSUE.WIP", at: "2026-09-08T00:00:00Z"})}\n`,
+	);
+	writeFileSync(
+		join(skills, "build", "SKILL.md"),
+		"---\nname: build\ndescription: Fixture.\n---\nBuild.\n",
+	);
+	const fake = join(bin, "codex");
+	writeFileSync(
+		fake,
+		`#!${process.execPath}\nconst fs = require('node:fs');\nconst input = fs.readFileSync(0, 'utf8');\nfs.writeFileSync('observed.json', JSON.stringify({cwd:process.cwd(),args:process.argv.slice(2),input,identity:process.env.FABRIKA_SESSION_ID,model:process.env.FIXTURE_MODEL}));\nif(process.env.FIXTURE_MODE === 'fail') process.exit(9);\nif(process.env.FIXTURE_MODE === 'report') fs.appendFileSync(process.env.FIXTURE_LOG, JSON.stringify({task:'issue',event:'ISSUE.DONE',at:'2026-09-08T00:01:00Z',pr:'https://example.test/pr/1'})+'\\n');\n`,
+	);
+	chmodSync(fake, 0o755);
+	return {
+		cwd,
+		root,
+		skills,
+		worktree: join(seat, "child"),
+		harness: "codex",
+		lane: "8617",
+		task: "issue",
+		repo: "o/r",
+		entrypoint: {_tag: "Entrypoint" as const, entrypoint: "/installed/fabrika/bin.js"},
+		env: {
+			...process.env,
+			PATH: `${bin}:${process.env.PATH}`,
+			CODEX_THREAD_ID: "codex-thread",
+			CODEX_SESSION_ID: undefined,
+			FABRIKA_SESSION_ID: undefined,
+			CLAUDE_CODE_SESSION_ID: undefined,
+			PI_SUBAGENT_PARENT_SESSION: undefined,
+			FIXTURE_MODE: mode,
+			FIXTURE_MODEL: "kept",
+			FIXTURE_LOG: join(root, "8617", "events.jsonl"),
+		},
+	};
+};
+
+// The production emitter is separately tested against board replies; this fixture uses its wire format.
+import {artifactUrl, emit, fabrikaEntry, lanesRoot} from "../wire/lane-brief.ts";
+
+const briefFor = (options: ReturnType<typeof fixture>) =>
+	emit({
+		lane: "8617",
+		root: lanesRoot(options.root)!,
+		fabrika: fabrikaEntry(options.entrypoint.entrypoint)!,
+		task: "issue",
+		state: "build",
+		shell: "builder",
+		issue: artifactUrl("https://example.test/issues/8617")!,
+		ground: {_tag: "Pull", pr: null},
+	});
+
+describe("Codex dispatch against real git and a fake child process", () => {
+	it("isolates actual child cwd, preloads the role, preserves brief and configuration, and proves the report", async () => {
+		const options = fixture();
+		const original = git(options.cwd, "rev-parse", "HEAD");
+		const brief = briefFor(options);
+		let proved = false;
+		const result = await Effect.runPromise(
+			runDispatch(
+				options,
+				() => Effect.succeed(answer(brief)),
+				(proof, snapshot) => {
+					proved = true;
+					expect(proof.event).toBe("DONE");
+					expect(snapshot.entries).toHaveLength(1);
+					return Effect.gen(function* () {
+						const root = yield* execCapture("git", ["rev-parse", "--show-toplevel"]);
+						expect(root.stdout.trim()).toBe(options.worktree);
+						return answer("proven");
+					});
+				},
+			).pipe(Effect.provide(NodeServices.layer)),
+		);
+		expect(result.code).toBe(0);
+		expect(proved).toBe(true);
+		const observation = JSON.parse(readFileSync(join(options.worktree, "observed.json"), "utf8"));
+		expect(observation.cwd).toBe(options.worktree);
+		expect(observation.args).toEqual(["exec", "--cd", options.worktree, "-"]);
+		expect(observation.input.endsWith(brief)).toBe(true);
+		expect(readBrief(brief)._tag).toBe("Found");
+		expect(observation.input).toContain(join(options.skills, "build", "SKILL.md"));
+		expect(observation.identity).toBe("codex-thread");
+		expect(observation.model).toBe("kept");
+		expect(git(options.cwd, "rev-parse", "HEAD")).toBe(original);
+		expect(git(options.cwd, "branch", "--show-current")).toBe("main");
+		expect(git(options.cwd, "status", "--porcelain")).toBe("");
+		expect(readFileSync(join(options.cwd, "tracked.txt"), "utf8")).toBe("primary bytes\n");
+	});
+	it.each([
+		"fail",
+		"silent",
+	])("refuses %s children and retains their dirty worktree", async (mode) => {
+		const options = fixture(mode);
+		let proved = false;
+		const result = await Effect.runPromise(
+			runDispatch(
+				options,
+				() => Effect.succeed(answer(briefFor(options))),
+				() => {
+					proved = true;
+					return Effect.succeed(answer("proven"));
+				},
+			).pipe(Effect.provide(NodeServices.layer)),
+		);
+		expect(result.code).toBe(mode === "fail" ? 11 : PROOF_ABSENT);
+		expect(result.stdout).toBe("");
+		expect(proved).toBe(false);
+		expect(existsSync(join(options.worktree, "observed.json"))).toBe(true);
+	});
+	it("refuses an unproven terminal despite a successful reporting child", async () => {
+		const options = fixture();
+		const result = await Effect.runPromise(
+			runDispatch(
+				options,
+				() => Effect.succeed(answer(briefFor(options))),
+				() => Effect.succeed(refuse(PROOF_ABSENT, "missing artifact")),
+			).pipe(Effect.provide(NodeServices.layer)),
+		);
+		expect(result.code).toBe(PROOF_ABSENT);
+	});
+	it("refuses unsupported harnesses before reading the board or starting a child", async () => {
+		const options = {...fixture(), harness: "unknown"};
+		const result = await Effect.runPromise(
+			runDispatch(options, runBrief, () => Effect.succeed(answer("unused"))).pipe(
+				Effect.provide(NodeServices.layer),
+			),
+		);
+		expect(result.code).toBe(18);
+		expect(existsSync(options.worktree)).toBe(false);
+	});
+	it.each([
+		"identity",
+		"skill",
+		"state",
+	])("refuses missing %s before worktree creation", async (missing) => {
+		const options = fixture();
+		if (missing === "identity") options.env.CODEX_THREAD_ID = "";
+		if (missing === "skill") options.skills = join(options.skills, "absent");
+		if (missing === "state") writeFileSync(join(options.root, "8617", "events.jsonl"), "");
+		const result = await Effect.runPromise(
+			runDispatch(
+				options,
+				() => Effect.succeed(answer(briefFor(options))),
+				() => Effect.succeed(answer("unused")),
+			).pipe(Effect.provide(NodeServices.layer)),
+		);
+		expect(result.code).not.toBe(0);
+		expect(existsSync(options.worktree)).toBe(false);
+	});
+	it("rejects a symlinked parent that would create the child inside the primary checkout", async () => {
+		const options = fixture();
+		const alias = join(options.root, "alias");
+		symlinkSync(options.cwd, alias);
+		options.worktree = join(alias, "child");
+		const result = await Effect.runPromise(
+			runDispatch(
+				options,
+				() => Effect.succeed(answer(briefFor(options))),
+				() => Effect.succeed(answer("unused")),
+			).pipe(Effect.provide(NodeServices.layer)),
+		);
+		expect(result.code).toBe(11);
+		expect(existsSync(join(options.cwd, "child"))).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -73,7 +73,7 @@ import {
 } from "./prove.ts";
 import {type ChildRange, DEEPEN_REMEDY, locateRange} from "./range.ts";
 import {loadRefusal, replayRefusal} from "./refusals.ts";
-import {type LaneRef, loadLane} from "./store.ts";
+import {type LaneRef, type LoadedLane, loadLane} from "./store.ts";
 
 const VERB = "fabrika lane prove";
 
@@ -187,13 +187,14 @@ export const runProve = (
  */
 const prove = (
 	options: ProveOptions,
+	snapshot?: Extract<LoadedLane, {_tag: "Loaded"}>,
 ): Effect.Effect<
 	ProofAnswer,
 	never,
 	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
-		const loaded = yield* loadLane(options);
+		const loaded = snapshot ?? (yield* loadLane(options));
 		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
 		const task = resolveTask(loaded.lane, options.task);
 		if (task._tag === "Unresolved") return refuse(TASK_UNKNOWN, `${VERB}: ${task.reason}`);
@@ -1126,3 +1127,9 @@ const proveRangeVerdicts = (
 			deferred,
 		};
 	});
+
+/** Re-read live evidence against the state captured before a dispatched child reported. */
+export const proveDispatched = (
+	options: ProveOptions,
+	snapshot: Extract<LoadedLane, {_tag: "Loaded"}>,
+) => prove(options, snapshot);

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -20,7 +20,8 @@ import {
 	PROOF_IN_FLIGHT,
 } from "./codes.ts";
 import {coderTemplateText, coderWorkflow} from "./fixtures.test-support.ts";
-import {runProve} from "./prove-verb.ts";
+import {proveDispatched, runProve} from "./prove-verb.ts";
+import {loadLane} from "./store.ts";
 
 const ROOT = ".fabrika/lanes";
 const WORKFLOW = `${ROOT}/5747/workflow.json`;
@@ -1580,4 +1581,34 @@ describe("lane prove — the ship stage's closure, read off the PR the event nam
 		expect(out.partial).toBe(null);
 		expect(out.landed).toEqual([]);
 	});
+});
+
+it("rechecks dispatched build evidence against captured build state after the ledger moved to review", async () => {
+	const snapshot = await Effect.runPromise(
+		loadLane({root: ROOT, lane: "5747"}).pipe(Effect.provide(laneAt("build").layer)),
+	);
+	if (snapshot._tag !== "Loaded") throw new Error("fixture did not load");
+	const seams = fakeSeams([
+		[CLOSERS, closingPulls()],
+		[SEARCH, nominated()],
+		[ISSUE, issue(["type:feature"])],
+		[ISSUE_COMMENTS, comments()],
+	]);
+	const result = await Effect.runPromise(
+		proveDispatched(
+			{
+				root: ROOT,
+				lane: "5747",
+				event: "DONE",
+				task: "issue",
+				classes: null,
+				pr: null,
+				repo: "o/r",
+				cwd: "/repo",
+				env: {},
+			},
+			snapshot,
+		).pipe(Effect.provide(Layer.mergeAll(laneAt("review").layer, seams.layer))),
+	);
+	expect(result.code).toBe(PROOF_ABSENT);
 });

--- a/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
@@ -379,7 +379,7 @@ describe("runClaim — preconditions", () => {
 		});
 		expect(outcome.code).toBe(1);
 		expect(outcome.stderr.join("\n")).toContain(
-			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION are all unset — refusing to post an unattributable claim.",
+			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION, CODEX_THREAD_ID, CODEX_SESSION_ID are all unset — refusing to post an unattributable claim.",
 		);
 		expect(requests).toHaveLength(0);
 	});

--- a/packages/fabrika-cli/src/triage/scratch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/scratch-verb.unit.test.ts
@@ -100,7 +100,7 @@ describe("runScratch", () => {
 		expect(out.code).toBe(FAILED);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain(
-			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION are all unset",
+			"no session id is set — FABRIKA_SESSION_ID, CLAUDE_CODE_SESSION_ID, PI_SUBAGENT_PARENT_SESSION, CODEX_THREAD_ID, CODEX_SESSION_ID are all unset",
 		);
 	});
 


### PR DESCRIPTION
Fabrika's Codex plugin shares the existing stage skills, and `lane dispatch --harness codex` now runs active tasks in verified dedicated worktrees. The adapter preloads role skills through a fixed prompt envelope around the unchanged lane brief, preserves Codex configuration, retains recoverable work, and requires a new task terminal plus fresh artifact proof. Session attribution now recognizes Codex identities. ADR 0367 records Codex admission and amends ADR 0360's two-harness constraint while preserving opencode retirement.

Validated with Fabrika code and prose checks, package typechecking, portability guard, and real-Git fake-process integration tests covering isolation, handoff bytes, failure, missing reports, and proof state. The full Fabrika suite passes all 9,064 tests across 511 files after repair. Native Codex 0.153.4 marketplace installation discovered all 26 source skills with no loading errors. Effect process usage follows [LLMS.md](https://github.com/Effect-TS/effect/blob/main/LLMS.md#working-with-child-processes) and installed beta source. No paid model call or production lane run was used as a test.

Fixes #8617

## Deviations

- **Pre-existing test or fixture changed** — **Said:** existing missing-identity tests expected a refusal listing three environment variables. **Did:** updated three exact-string assertions to include CODEX_THREAD_ID and CODEX_SESSION_ID. **Why:** the required Codex identity fallbacks expand the production refusal; CI run 34276224449 failed only these stale assertions. **Disposition:** disclosed; exit-code and no-network assertions remain intact, and all 9,064 package tests pass.
