### PR TITLE
chore: The Tuval composer says nothing about where a prompt goes while a subagent view is open

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -51,7 +51,7 @@ import type {ProcessView, WindowHost, WindowRenderer} from "../window/index.ts";
 import {prefixArmedAround, windowRenderer} from "../window/index.ts";
 import {CompactionMarker} from "./CompactionMarker.tsx";
 import {composerBridge} from "./composer-bridge.ts";
-import {tuvalDesignTranslate} from "./copy.ts";
+import {tuvalDesignTranslate, tuvalSubagentViewTranslate} from "./copy.ts";
 import {ModeSwitch} from "./ModeSwitch.tsx";
 import {dropSend, holdSend, readHeld, recoverInto} from "./outgoing.ts";
 import {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
@@ -954,7 +954,9 @@ function ChatWindow({
 		// The provider sits above the whole window, not just the composer: a design primitive the
 		// transcript mounts (a table's scroller name) reads this catalog too, and the package's own
 		// default is Turkish.
-		<DesignTranslationProvider translate={tuvalDesignTranslate}>
+		<DesignTranslationProvider
+			translate={viewing === null ? tuvalDesignTranslate : tuvalSubagentViewTranslate}
+		>
 			<section
 				className="tuval-chat"
 				aria-label="Agent chat"
@@ -1097,6 +1099,12 @@ function ChatWindow({
 				<AgentChatInput
 					variant="focused"
 					bridge={composer.bridge}
+					// Founder ruling on #8466: while the view slot shows a subagent the composer is
+					// disabled, not re-worded. A prompt typed here would land in the transcript the
+					// operator is not reading, and there is no second session to address it to. It stays
+					// mounted — the draft is the component's own state, so unmounting it would drop text
+					// the swap must not touch — and the placeholder swapped above says why.
+					disabled={viewing !== null}
 					// The mode picker rides the composer's `settings` slot rather than the bridge: mode is
 					// this window's vocabulary, and a bridge method would make every other implementor of
 					// `AgentChatInputBridge` answer a question only this one has (#8190).

--- a/apps/tuval/src/shell/chat/composer-in-subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/composer-in-subagent-view.unit.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer while the view slot shows a subagent (#8466, founder ruling 2026-09-08).
+ *
+ * A subagent has no session of its own to address, so a prompt typed inside its view would land in
+ * the transcript the operator is not reading. The founder picked disable over re-word, and these
+ * cases are that ruling: the field and the send control are off while a worker is showing, the
+ * placeholder says where prompts go and how to get back, and the round trip never touches the draft.
+ *
+ * The process here is `testProcess` over a plain session fixture — no Claude, no Pi. That is the
+ * point of mounting it this way: the window reads its own `viewing` slot, so nothing about the
+ * behaviour can depend on which layer owns the parent.
+ */
+
+import {act, fireEvent, render, within} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {SubagentSlot, TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {ItemId} from "../../ai-agent/ports/index.ts";
+import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {assistantItem, call, userItem, withTranscript} from "./chat.testing.ts";
+import {subagentViewPlaceholder, tuvalDesignMessages} from "./copy.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+const reviewerItems: ReadonlyArray<TranscriptItem> = [
+	{...assistantItem("r-out", "the fold looks right"), parentId: ItemId.make("agent")},
+];
+
+const reviewer = (): SubagentSlot =>
+	subagentSlot("agent", {type: "reviewer", items: reviewerItems, lastLine: "wrote 4 rows"});
+
+const session = (): AiAgentSessionState =>
+	withTranscript([userItem("u1", "go"), call("agent", {name: "Agent"}), ...reviewerItems], {
+		subagents: {agent: reviewer()},
+	});
+
+const open = async () => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), session()),
+	);
+	const opened: ChatView = {...initialChatView, atOldest: true};
+	const bound = await Effect.runPromise(process.window(WindowId.make("w1"), opened));
+	const rendered = render(
+		chatWindow({scrollCommitMs: 0, scrollToFn: () => {}, subagentList: true}).render(
+			bound,
+		) as ReactElement,
+	);
+	const root = rendered.container;
+	await within(root).findByRole("log", {name: /^Transcript/});
+	// Re-read on every use: Manti's field owns the element, so a case asserting across a swap would
+	// otherwise hold a node React has since replaced.
+	const composer = (): HTMLTextAreaElement => {
+		const found = root.querySelector<HTMLTextAreaElement>("textarea");
+		expect(found, "no composer field").toBeTruthy();
+		return found as HTMLTextAreaElement;
+	};
+	return {
+		rendered,
+		root,
+		process,
+		composer,
+		send: () => root.querySelector<HTMLButtonElement>("button[type='submit']"),
+		view: () => bound.view(),
+	};
+};
+
+/** Click the navigator row whose visible text starts with `label`. */
+const pick = async (root: ParentNode, label: string) => {
+	const button = Array.from(
+		root.querySelectorAll<HTMLButtonElement>(".tuval-chat-subagent-pick"),
+	).find((candidate) => (candidate.textContent ?? "").startsWith(label));
+	expect(button, `no navigator row for "${label}"`).toBeTruthy();
+	await act(async () => {
+		(button as HTMLButtonElement).click();
+	});
+};
+
+const type = async (composer: HTMLTextAreaElement, text: string) => {
+	await act(async () => {
+		fireEvent.change(composer, {target: {value: text}});
+	});
+};
+
+const ordinary = tuvalDesignMessages["admin.agent.compose.placeholder"];
+
+describe("the composer inside a subagent view", () => {
+	it("disables the field and the send control, and says where prompts go", async () => {
+		const {rendered, root, composer, send} = await open();
+		expect(composer().disabled).toBe(false);
+		expect(composer().placeholder).toBe(ordinary);
+		expect(send()?.disabled).toBe(false);
+
+		await pick(root, "reviewer");
+
+		expect(composer().disabled).toBe(true);
+		expect(composer().placeholder).toBe(subagentViewPlaceholder);
+		expect(send()?.disabled).toBe(true);
+		rendered.unmount();
+	});
+
+	it("re-enables on the way back, with the ordinary placeholder", async () => {
+		const {rendered, root, composer, send} = await open();
+		await pick(root, "reviewer");
+		await pick(root, "Back to the agent transcript");
+
+		expect(composer().disabled).toBe(false);
+		expect(composer().placeholder).toBe(ordinary);
+		expect(send()?.disabled).toBe(false);
+		rendered.unmount();
+	});
+
+	it("keeps a draft typed before the swap, and holds it in the window's own slot", async () => {
+		const {rendered, root, composer, view} = await open();
+		await type(composer(), "half a prompt");
+
+		await pick(root, "reviewer");
+		expect(composer().value).toBe("half a prompt");
+
+		await pick(root, "Back to the agent transcript");
+		expect(composer().value).toBe("half a prompt");
+		expect(view().draft).toBe("half a prompt");
+		rendered.unmount();
+	});
+
+	it("re-enables when Escape in the navigator is the way back", async () => {
+		const {rendered, root, composer} = await open();
+		await type(composer(), "still here");
+		await pick(root, "reviewer");
+		expect(composer().disabled).toBe(true);
+
+		const list = root.querySelector<HTMLElement>(".tuval-chat-subagents");
+		expect(list).toBeTruthy();
+		await act(async () => {
+			fireEvent.keyDown(list as HTMLElement, {key: "Escape"});
+		});
+
+		expect(composer().disabled).toBe(false);
+		expect(composer().value).toBe("still here");
+		rendered.unmount();
+	});
+});

--- a/apps/tuval/src/shell/chat/copy.ts
+++ b/apps/tuval/src/shell/chat/copy.ts
@@ -133,6 +133,17 @@ const messages: Readonly<Record<DesignCatalogKey, string>> = {
 	"admin.agent.error.extension": "The agent extension could not be answered.",
 };
 
+/**
+ * What the composer's placeholder says while this window's view slot shows a subagent (#8466).
+ *
+ * A subagent has no session of its own to address — Q6 on #8384 read
+ * `@anthropic-ai/claude-agent-sdk` 0.3.259 and found a sidechain is driven through its parent — so
+ * the composer is disabled there rather than silently sending somewhere the operator is not
+ * reading. The field is where the reason belongs: it is the control the operator reached for.
+ */
+export const subagentViewPlaceholder =
+	"Prompts go to the main agent — go back to its transcript to send (the row above, or Escape).";
+
 const PLACEHOLDER = /\{(\w+)\}/g;
 
 /**
@@ -150,3 +161,14 @@ export const tuvalDesignTranslate: DesignTranslate = (key, params) => {
 
 /** The table itself, so a test can walk every key the package declares. */
 export const tuvalDesignMessages = messages;
+
+/**
+ * The same catalog with the composer's placeholder swapped for the subagent-view hint. A second
+ * translate rather than a prop on the composer: the placeholder is the package's own copy, read
+ * through `DesignTranslationProvider`, and that provider is the injection point the package
+ * publishes for exactly this.
+ */
+export const tuvalSubagentViewTranslate: DesignTranslate = (key, params) =>
+	key === "admin.agent.compose.placeholder"
+		? subagentViewPlaceholder
+		: tuvalDesignTranslate(key, params);


### PR DESCRIPTION
While the chat window's view slot shows a subagent, the composer is now disabled. It stays
mounted so the layout does not jump, and its placeholder is swapped for a line saying prompts go
to the main agent and how to get back (the navigator's "Back to the agent transcript" row, or
Escape in that list). Returning to main puts the ordinary placeholder back and re-enables it.

This transcribes the founder's 2026-09-08 ruling on #8466 —
https://github.com/kamp-us/phoenix/issues/8466#issuecomment-5589408790, "let's make it disabled
for now, i wanna try that way" — of the three shapes the report named.

How it is wired:

- `ChatWindow` passes `disabled={viewing !== null}` to `AgentChatInput`. That is the prop the
  composer already uses for its own busy state: it puts `disabled` on the textarea, on the submit
  button, and short-circuits the send (`packages/design/src/AgentChatInput.tsx`), so a keyboard
  user can neither type nor submit. It reads the window's `viewing` slot and nothing about the
  agent layer, so Claude today and Pi later behave the same.
- The hint lives in `apps/tuval/src/shell/chat/copy.ts` beside the existing placeholder, as
  `subagentViewPlaceholder`, and reaches the composer through a second `DesignTranslate` the
  window swaps onto `DesignTranslationProvider`. That provider is the package's published
  injection point for its own copy, so nothing reaches inside the component.
- The draft is untouched: the composer is not unmounted, so its text is still its own state, and
  the window's `draft` slot is written by the same `onDraftChange` as before.

Nothing about dispatch changes; there is still no worker-addressed send (Q6/Q7 on #8384 stand).
#8470 (focus on return) is a separate lane and is not implemented here.

One knock-on worth naming: `disabled` also disables the composer's model and thinking pickers
(`settingsDisabled` in the same file). The mode switch, which rides Tuval's own `settings` slot,
is unaffected. That reads right — none of those settings can be acted on from inside a worker's
view either — but it is a wider reach than the two controls the criteria name.

New unit test `apps/tuval/src/shell/chat/composer-in-subagent-view.unit.test.tsx` covers disabled
while viewing a worker, enabled on return by both ways back, and the draft surviving the round
trip. The whole `apps/tuval/src/shell/chat` suite is green (362 tests), `boundary.unit.test.ts`
included.

Fixes #8466

## Deviations

None.
