### PR TITLE
chore: A subagent's whole reply still lands in the agent transcript, inside the CLI's task_notification notice

### DIFF
--- a/apps/tuval/src/ai-agent-fixtures/transcripts.ts
+++ b/apps/tuval/src/ai-agent-fixtures/transcripts.ts
@@ -58,12 +58,14 @@ export const systemItem = (
 	text = "resumed",
 	timestamp = AT,
 	detail?: string,
+	subagent?: string,
 ): SystemItem => ({
 	kind: "system",
 	id: ItemId.make(id),
 	timestamp,
 	text,
 	...(detail === undefined ? {} : {detail}),
+	...(subagent === undefined ? {} : {subagent: ItemId.make(subagent)}),
 });
 
 export const thinkingItem = (id: string, text = "weighing it", timestamp = AT): ThinkingItem => ({

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -135,6 +135,15 @@ export interface SystemItem extends ItemBase {
 	readonly kind: "system";
 	readonly text: string;
 	readonly detail?: string;
+	/**
+	 * The subagent slot this notice reports on, when it reports on one — the id of the spawning
+	 * call, which is what `SubagentSlot` is keyed by. A window offers it as the way into that
+	 * worker's own rows, so a notice that only names an outcome still reaches the report behind it.
+	 *
+	 * Model-blind: it is the port's own slot id, not a backend's task handle, and a notice about
+	 * nothing a slot was opened for carries none.
+	 */
+	readonly subagent?: ItemId;
 }
 
 export type TranscriptItem =
@@ -235,7 +244,8 @@ export const isTranscriptItem = (value: unknown): value is TranscriptItem => {
 		case "system":
 			return (
 				typeof value.text === "string" &&
-				(value.detail === undefined || typeof value.detail === "string")
+				(value.detail === undefined || typeof value.detail === "string") &&
+				isOptionalId(value.subagent)
 			);
 		case "compaction":
 			return typeof value.text === "string";

--- a/apps/tuval/src/claude/history/events.ts
+++ b/apps/tuval/src/claude/history/events.ts
@@ -26,6 +26,7 @@ import {
 	resultEvents,
 	skipMessage,
 	systemNoticeEvents,
+	taskNoticeEvents,
 	userEvents,
 } from "./map.ts";
 
@@ -57,6 +58,9 @@ export const toAgentEvents = (
 			if (message.subtype === "commands_changed") return commandsChangedEvents(message, mapping);
 			if (message.subtype === "compact_boundary") {
 				return compactBoundaryEvents(message, mapping, options);
+			}
+			if (message.subtype === "task_notification") {
+				return taskNoticeEvents(message, mapping, options);
 			}
 			return systemNoticeEvents(message, mapping, options);
 		default:

--- a/apps/tuval/src/claude/history/events.unit.test.ts
+++ b/apps/tuval/src/claude/history/events.unit.test.ts
@@ -1009,3 +1009,50 @@ describe("toAgentEvents over a subagent's streamed reasoning", () => {
 		).toBeGreaterThan(0);
 	});
 });
+
+/**
+ * The settled worker's notice, shrunk (founder ruling on #8475). The capture is the two-worker one
+ * because that is where the repetition was found: each `task_notification` in it carries the whole
+ * of a worker's final report in `summary`, and the same text arrives again as the spawning call's
+ * own tool result.
+ */
+describe("toAgentEvents over the captured task notifications", () => {
+	const stream = messages("two-subagent-turn");
+	const raw = stream.filter(
+		(one): one is Extract<SDKMessage, {type: "system"}> =>
+			one.type === "system" && one.subtype === "task_notification",
+	);
+	const {events} = run(stream);
+	const notices = items(events).filter(
+		(one) => one.kind === "system" && / (finished|failed|stopped)$/.test(one.text),
+	);
+
+	it("reads one line per notification, naming the worker and how it ended", () => {
+		expect(raw).toHaveLength(2);
+		expect(notices.map((one) => one.kind === "system" && one.text)).toEqual([
+			"Explore finished",
+			"Explore finished",
+		]);
+	});
+
+	it("carries no payload at all, so the worker's report is not repeated in the transcript", () => {
+		expect(notices.map((one) => one.kind === "system" && one.detail)).toEqual([
+			undefined,
+			undefined,
+		]);
+		const summaries = raw.map((one) => (one as {readonly summary: string}).summary);
+		expect(summaries.every((text) => text.length > 300)).toBe(true);
+		const said = items(events)
+			.filter((one) => one.kind === "system")
+			.map((one) => one.text)
+			.join("\n");
+		expect(summaries.filter((text) => said.includes(text))).toEqual([]);
+	});
+
+	it("names the worker's slot, which is the row the list draws for it", () => {
+		expect(notices.map((one) => one.kind === "system" && one.subagent)).toEqual([
+			"toolu_000000000000000000000001",
+			"toolu_000000000000000000000002",
+		]);
+	});
+});

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -957,7 +957,8 @@ const noticeDetailOf = (message: Record<string, unknown>): string => {
  * Read shape-blind on purpose: the SDK names some fifteen such subtypes at 0.3.259 and adds more
  * each release, so this takes the frame's own name for the line, its prose when it carries any,
  * and folds everything the envelope did not claim into `detail`. A per-subtype arm here would be
- * fifteen arms none of which a golden capture backs.
+ * fifteen arms none of which a golden capture backs — `taskNoticeEvents` below is the one that a
+ * capture and a founder ruling do back, and it is the only one.
  */
 export const systemNoticeEvents = (
 	message: unknown,
@@ -983,6 +984,57 @@ export const systemNoticeEvents = (
 				timestamp: at,
 				text: summary,
 				...(detail.length === 0 ? {} : {detail}),
+			}),
+		],
+	};
+};
+
+/**
+ * What a settled task reads as. `SDKTaskNotificationMessage.status` is
+ * `'completed' | 'failed' | 'stopped'` (`sdk.d.ts`, 0.3.259); only the first wants a different
+ * word, and a value the union grows later is shown verbatim rather than forced into one of these.
+ * The frame is raised when a task settles, so one carrying no status at all still settled.
+ */
+const taskOutcomeOf = (status: unknown): string => {
+	if (typeof status !== "string" || status.length === 0) return "finished";
+	return status === "completed" ? "finished" : status;
+};
+
+/**
+ * A settled task's notice, as one line naming the worker and how it ended.
+ *
+ * The frame carries the worker's entire final report in `summary`, and the collapsed-notice arm
+ * above would fold that whole payload into `detail` — a second copy of a report the spawning call's
+ * own tool result already carries, in the one transcript the running list exists to keep a worker's
+ * output out of. The founder ruled "shrink it"
+ * (https://github.com/kamp-us/phoenix/issues/8475#issuecomment-5589392284): one line, the worker's
+ * name and its outcome, linking to that worker's row in the subagent list where the full report
+ * already lives. The spawning `Agent` tool result is untouched — it is not this frame.
+ *
+ * The name is the slot's, so the notice and the list row a reader jumps to say the same word about
+ * the same worker. A task holding no slot — a backgrounded `Bash` raises this frame too — falls
+ * back to the spawning call's name and carries no link, because there is no row to link to.
+ */
+export const taskNoticeEvents = (
+	message: unknown,
+	mapping: Mapping,
+	options: MappingOptions,
+): MappingStep => {
+	if (!isRecord(message)) return skipMessage(mapping);
+	const at = timestampOf(message, options.at);
+	const id = typeof message.uuid === "string" ? message.uuid : `notice-${at}`;
+	const callId = typeof message.tool_use_id === "string" ? message.tool_use_id : "";
+	const slot = callId.length === 0 ? undefined : mapping.subagents.get(callId);
+	const name = slot?.type ?? mapping.toolCalls.get(callId)?.name ?? "task";
+	return {
+		mapping,
+		events: [
+			item({
+				kind: "system",
+				id: itemId(id),
+				timestamp: at,
+				text: `${name} ${taskOutcomeOf(message.status)}`,
+				...(slot === undefined ? {} : {subagent: itemId(callId)}),
 			}),
 		],
 	};

--- a/apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts
@@ -468,8 +468,8 @@ describe("the running-subagent list on a real Claude row", () => {
 					);
 
 					// Claim 2: no row of either worker in the agent's own window. Counted by kind rather
-					// than matched by text, because the CLI's own `task_notification` notice quotes a
-					// worker's summary and that notice is the agent's row, not the worker's.
+					// than matched by text, because the spawning `Agent` call's own tool result carries
+					// the worker's summary and that row is the agent's, not the worker's.
 					const spoken = repliesOf(both, first);
 					assert.isNotEmpty(spoken, "the first worker has written nothing yet to look for");
 					const kindsIn = (state: AiAgentSessionState, kind: string): number =>

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -317,6 +317,7 @@ function RowView({
 	unfolded,
 	onToggleRow,
 	onToggleFold,
+	onViewSubagent,
 }: {
 	readonly row: ChatRow;
 	readonly interruptedId: string | null;
@@ -326,6 +327,7 @@ function RowView({
 	readonly unfolded: ReadonlySet<string>;
 	readonly onToggleRow: (id: string, open: boolean) => void;
 	readonly onToggleFold: (id: string, open: boolean) => void;
+	readonly onViewSubagent: ((id: string) => void) | null;
 }): ReactElement {
 	if (row.kind === "loading") {
 		return (
@@ -371,6 +373,7 @@ function RowView({
 					run={row.items}
 					expanded={expanded.has(id)}
 					onToggle={(next) => onToggleRow(id, next)}
+					onViewSubagent={onViewSubagent}
 				/>
 			</>
 		);
@@ -1044,6 +1047,9 @@ function ChatWindow({
 										unfolded={unfolded}
 										onToggleRow={toggleRow}
 										onToggleFold={toggleFold}
+										// Only where the navigator is drawn: a jump into a worker's rows with
+										// no list above them leaves the reader no way back out (#8405).
+										onViewSubagent={options.subagentList ? showSubagent : null}
 									/>
 								</div>
 							);

--- a/apps/tuval/src/shell/chat/SessionRow.tsx
+++ b/apps/tuval/src/shell/chat/SessionRow.tsx
@@ -14,6 +14,11 @@
  * The line always showing is the newest one — the session's current word — and the rest of the run
  * folds away with the details.
  *
+ * A notice naming a subagent slot (`ports/transcript-item.ts`, `subagent`) draws one control beside
+ * it, and that is still no branch per kind: the field is the port's, so any mapper filling it gets
+ * the control. A settled worker's notice is one line by then (founder ruling on #8475), so the
+ * control is where the report behind that line is read.
+ *
  * The disclosure is `@kampus/design`'s `Collapsible`, the primitive `ToolRow` and `ThinkingRow`
  * use, so `aria-expanded`/`aria-controls` are the primitive's and the accessible name is the
  * summary line (`.patterns/manti-accessibility.md`). A lone notice carrying no detail has nothing
@@ -21,7 +26,7 @@
  * the row cannot keep.
  */
 
-import {Collapsible} from "@kampus/design";
+import {Button, Collapsible} from "@kampus/design";
 import type {ReactElement} from "react";
 import type {SystemItem} from "../../ai-agent/ports/index.ts";
 import type {SessionRun} from "./rows.ts";
@@ -47,48 +52,83 @@ export function SessionRow({
 	run,
 	expanded,
 	onToggle,
+	onViewSubagent,
 }: {
 	readonly run: SessionRun;
 	readonly expanded: boolean;
 	readonly onToggle: (open: boolean) => void;
+	/**
+	 * How the row reaches the worker a notice reports on, or `null` where no list is drawn to reach.
+	 * A settled worker's notice names an outcome and nothing else (`claude/history/map.ts`), so this
+	 * is the way to the rows behind it.
+	 */
+	readonly onViewSubagent?: ((id: string) => void) | null;
 }): ReactElement {
 	const latest = run[run.length - 1] ?? run[0];
 	const earlier = run.length - 1;
 	const alone = earlier === 0 ? latest.detail : undefined;
+	const worker = latest.subagent;
+	const link =
+		worker === undefined || onViewSubagent === undefined || onViewSubagent === null ? null : (
+			<Button
+				type="button"
+				variant="tertiary"
+				size="sm"
+				className="tuval-chat-session-link"
+				style={{minBlockSize: "var(--tap-min, 36px)"}}
+				onClick={() => onViewSubagent(worker)}
+			>
+				Show its rows
+				{/* The name in context, so the control reads on its own out of the rows around it. */}
+				<span className="kp-visually-hidden"> — {sessionLine(latest)}</span>
+			</Button>
+		);
 	if (earlier === 0 && alone === undefined) {
-		return <p className="tuval-chat-text tuval-chat-session-line">{sessionLine(latest)}</p>;
+		return link === null ? (
+			<p className="tuval-chat-text tuval-chat-session-line">{sessionLine(latest)}</p>
+		) : (
+			<div className="tuval-chat-session-head">
+				<p className="tuval-chat-text tuval-chat-session-line">{sessionLine(latest)}</p>
+				{link}
+			</div>
+		);
 	}
 	return (
-		<Collapsible
-			className="tuval-chat-session"
-			open={expanded}
-			onOpenChange={onToggle}
-			trigger={
-				<span className="tuval-chat-session-head">
-					<span className="tuval-chat-session-line">{sessionLine(latest)}</span>
-					{earlier === 0 ? null : (
-						<span className="tuval-chat-session-count">{earlierLine(earlier)}</span>
-					)}
-				</span>
-			}
-		>
-			{alone !== undefined ? (
-				// A lone notice's line is the trigger, so the panel is its detail and nothing else —
-				// restating the line under the control that already says it is noise read twice.
-				<pre className="tuval-chat-pre">{alone}</pre>
-			) : (
-				// A run reads as a log, oldest-first, in the order the session raised it.
-				<ol className="tuval-chat-session-detail">
-					{run.map((item) => (
-						<li key={item.id} className="tuval-chat-session-entry">
-							<p className="tuval-chat-text">{sessionLine(item)}</p>
-							{item.detail === undefined ? null : (
-								<pre className="tuval-chat-pre">{item.detail}</pre>
-							)}
-						</li>
-					))}
-				</ol>
-			)}
-		</Collapsible>
+		<>
+			<Collapsible
+				className="tuval-chat-session"
+				open={expanded}
+				onOpenChange={onToggle}
+				trigger={
+					<span className="tuval-chat-session-head">
+						<span className="tuval-chat-session-line">{sessionLine(latest)}</span>
+						{earlier === 0 ? null : (
+							<span className="tuval-chat-session-count">{earlierLine(earlier)}</span>
+						)}
+					</span>
+				}
+			>
+				{alone !== undefined ? (
+					// A lone notice's line is the trigger, so the panel is its detail and nothing else —
+					// restating the line under the control that already says it is noise read twice.
+					<pre className="tuval-chat-pre">{alone}</pre>
+				) : (
+					// A run reads as a log, oldest-first, in the order the session raised it.
+					<ol className="tuval-chat-session-detail">
+						{run.map((item) => (
+							<li key={item.id} className="tuval-chat-session-entry">
+								<p className="tuval-chat-text">{sessionLine(item)}</p>
+								{item.detail === undefined ? null : (
+									<pre className="tuval-chat-pre">{item.detail}</pre>
+								)}
+							</li>
+						))}
+					</ol>
+				)}
+			</Collapsible>
+			{/* Outside the disclosure: the trigger is a button, and a button inside one is neither
+			    valid nor reachable. */}
+			{link}
+		</>
 	);
 }

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -340,6 +340,13 @@
 	text-overflow: ellipsis;
 }
 
+/* The way into the rows a settled worker's notice names (#8475). Aligned to the start rather than
+   stretched, so the control is the size of its own label and not of the row it sits in. */
+.tuval-chat-session-link {
+	flex: none;
+	align-self: flex-start;
+}
+
 .tuval-chat-session-count {
 	flex: none;
 	font: var(--t-micro);

--- a/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
@@ -23,7 +23,7 @@ import {installDomShims} from "../ui/dom.testing.ts";
 import {testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {type ChatWindowOptions, chatWindow} from "./ChatWindow.tsx";
-import {assistantItem, call, userItem, withTranscript} from "./chat.testing.ts";
+import {assistantItem, call, systemItem, userItem, withTranscript} from "./chat.testing.ts";
 import {type ChatView, initialChatView} from "./view.ts";
 
 installDomShims();
@@ -401,6 +401,56 @@ describe("with the flag off", () => {
 		expect(dom(root).text()).toContain("the agent's own call");
 		expect(dom(root).text()).toContain("the fold looks right");
 		expect(root.querySelectorAll('[data-nested="true"]').length).toBeGreaterThan(0);
+		rendered.unmount();
+	});
+});
+
+/**
+ * The way from a settled worker's notice into that worker's rows (#8475). The notice is one line by
+ * the time it reaches the window — the mapper drops the report it used to carry — so this control
+ * is where that report is read.
+ */
+describe("a notice naming a worker", () => {
+	const withNotice = (...held: ReadonlyArray<SubagentSlot>) =>
+		withTranscript(
+			[
+				userItem("u1", "go"),
+				call("agent", {name: "Agent"}),
+				...reviewerItems,
+				systemItem("n1", "reviewer finished", undefined, undefined, "agent"),
+			],
+			{subagents: slots(...held)},
+		);
+
+	const link = (root: ParentNode): HTMLButtonElement | null =>
+		root.querySelector<HTMLButtonElement>(".tuval-chat-session-link");
+
+	it("offers the worker's rows from the line, and swaps the view onto them", async () => {
+		const {rendered, view} = await openOne(withNotice(reviewer("finished")), {}, atOldest());
+		const root = rendered.container;
+		const control = link(root);
+		expect(control?.tagName).toBe("BUTTON");
+		// The visible label is short; the name a screen reader announces carries the line it belongs
+		// to, and contains that visible label (WCAG 2.5.3).
+		expect(control?.textContent).toBe("Show its rows — reviewer finished");
+
+		await act(async () => {
+			(control as HTMLButtonElement).click();
+		});
+
+		expect(view().viewing?.id).toBe("agent");
+		expect(dom(root).text()).toContain("the fold looks right");
+		rendered.unmount();
+	});
+
+	it("offers nothing where no list is drawn to come back to", async () => {
+		const {rendered} = await openOne(withNotice(reviewer("finished")), {subagentList: false});
+		const root = rendered.container;
+
+		expect(dom(root).list()).toBeNull();
+		expect(link(root)).toBeNull();
+		// The line itself is the row either way — it is the payload behind it that went.
+		expect(dom(root).text()).toContain("reviewer finished");
 		rendered.unmount();
 	});
 });


### PR DESCRIPTION
A finished subagent's `task_notification` carried the worker's whole final report in its `summary`,
and the collapsed-notice mapper folded that payload into the row's `detail`. So the report the
running-subagent list exists to keep out of the agent transcript landed there anyway, as JSON,
beside the spawning `Agent` call's tool result carrying the same text again.

Founder ruling, 2026-09-08, verbatim: "shrink it" —
https://github.com/kamp-us/phoenix/issues/8475#issuecomment-5589392284

Now the notice reads as one line: the worker's name and how it ended (`Explore finished`), with no
payload at all. Beside it the row draws one control that swaps the window onto that worker's own
rows, where the full report already lives. The spawning `Agent` tool result is untouched.

What to look at first:

- `apps/tuval/src/claude/history/map.ts` — `taskNoticeEvents`, the one per-subtype arm in a
  deliberately shape-blind notice mapper. The name comes off the worker's slot, so the notice and
  the list row a reader jumps to say the same word. A backgrounded `Bash` raises this frame too and
  holds no slot: it falls back to the call's name and carries no link.
- `apps/tuval/src/ai-agent/ports/transcript-item.ts` — `SystemItem.subagent`, the port's own slot
  id. Model-blind, so any mapper filling it gets the control.
- `apps/tuval/src/shell/chat/SessionRow.tsx` — the control sits outside the `Collapsible`, because
  its trigger is a button and a button inside one is neither valid nor reachable.

The outcome word is the frame's `status` (`'completed' | 'failed' | 'stopped'`, `sdk.d.ts` at
0.3.259); only `completed` is reworded, to `finished`.

## Deviations

- **Scope narrowing** — **Said:** the acceptance criteria ask for the presentation choice to be
  recorded, and for a later implementation to be scoped from it. **Did:** built the
  implementation the ruling comment already scoped, and did not write an ADR. **Why:** the ruling
  is the recorded choice, and it names the shape exactly: one line, worker name + finished/failed,
  linking to the worker's row, the `Agent` result untouched. **Disposition:** the ruling comment
  is cited in `taskNoticeEvents`' docblock, so the citation lands in the diff.
- **Out-of-scope change** — **Said:** #8475 names the notice mapper and its row. **Did:** also
  rewrote one comment in `apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts`.
  **Why:** it said a text match hits the notice because the notice quotes the worker's summary,
  which this change makes false; the assertion it explains is unchanged and still correct, because
  the spawning call's tool result carries that text. **Disposition:** comment only, no assertion
  touched.
- **Known defect left unfixed** — **Said:** shrink the notice. **Did:** left the other three
  `task_*` notices (`task_started`, `task_progress`, `task_updated`) on the shape-blind arm, JSON
  detail and all. **Why:** the ruling names the finished worker's notification and nothing else.
  **Disposition:** stated here.

Fixes #8475
