### PR TITLE
fix: closeCurrent empties the Claude layer's model catalog without announcing it, so subscribers keep the dead session's rows

### DIFF
--- a/.patterns/agent-layer-phase-contract.md
+++ b/.patterns/agent-layer-phase-contract.md
@@ -113,6 +113,27 @@ way.
 `PiAiAgent` sends the whole handshake as one `emit` array with `phase: ready` last; `ClaudeAiAgent`
 now batches `thinking` with it. A new layer copies that order.
 
+## A catalog that dies with its session is announced as dead
+
+A catalog read off a live session belongs to that session, so a teardown empties it. **The emptying
+is an event, not only a write to a `Ref`**: a consumer that is not told keeps painting the dead
+session's rows, and every pick it then takes is judged against a catalog nothing holds
+([#8542](https://github.com/kamp-us/phoenix/issues/8542)).
+
+Where the layer says it matters, because a teardown shuts the queue it happened on.
+`ClaudeAiAgent.closeCurrent` empties `models` and `efforts` and says nothing; `start` says it on the
+*new* queue, right behind that queue's `starting` and only when a session was actually torn down.
+That places the clear ahead of the `gone` a refused reconnect emits, which is the one path with no
+later catalog to correct it.
+
+The selection does not go with the catalog. A pick is the operator's, not the session's, so the
+clear carries `current: <the held pick>` beside `available: []`, and the picker names the pick while
+saying the offer behind it is empty ([`AgentChatInput`](../packages/design/src/AgentChatInput.tsx)'s
+`SettingMenu` takes it as `held`). The next open re-validates it against the catalog it reads and
+drops it there if that catalog does not carry it — the deferred validation of
+[#7981](https://github.com/kamp-us/phoenix/issues/7981), which is also why a setter with no session
+holds a pick rather than refusing it against an empty offer.
+
 ## Reference shapes
 
 - [`claude/agent/ClaudeAiAgent.ts`](../apps/tuval/src/claude/agent/ClaudeAiAgent.ts) — `prompt`

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -226,9 +226,13 @@ const make = (
 		const models = yield* Ref.make<ReadonlyArray<ModelRef>>([]);
 		const commands = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
 		// The effort axis is per model — `ModelInfo` carries `supportedEffortLevels` per row — so the
-		// offered set is looked up by the model the session is running on rather than held flat.
+		// offered set is looked up by the model the session is running on rather than held flat. It
+		// dies with the session beside `models`, for the same reason (#8542).
 		const efforts = yield* Ref.make<ReadonlyMap<string, ReadonlyArray<EffortLevel>>>(new Map());
-		const effort = yield* Ref.make<EffortLevel | null>(null);
+		// A `ThinkingLevel` rather than an `EffortLevel`, because a pick made with no session is held
+		// unvalidated: the two levels Claude has no effort for are refused by the next open's
+		// re-check, not by the setter that could only refuse them against an empty offer (#8542).
+		const effort = yield* Ref.make<ThinkingLevel | null>(null);
 		const parked = new Map<string, Parked>();
 
 		const emit = (open: EventQueue, events: ReadonlyArray<AgentEvent>): Effect.Effect<void> =>
@@ -305,7 +309,7 @@ const make = (
 		): ReadonlyArray<EffortLevel> => (current === null ? [] : (table.get(current.id) ?? []));
 
 		const publishThinking = (
-			current: EffortLevel | null,
+			current: ThinkingLevel | null,
 			offered: ReadonlyArray<EffortLevel>,
 		): Effect.Effect<void> => publish([{kind: "thinking", current, available: offered}]);
 
@@ -368,9 +372,13 @@ const make = (
 			// Only now: the generator has ended, so the pump's next pull resolves and the fiber this
 			// closes is finishing rather than blocked.
 			yield* Scope.close(held.scope, Exit.void);
-			// The catalog was read off this session, so it goes with it: kept, it would still be the
-			// set `setModel` judges a pick against after the session offering it is gone (#8061).
+			// Both catalogs were read off this session, so both go with it: kept, either would still
+			// be the set a pick is judged against after the session offering it is gone (#8061,
+			// #8542). The held selections stay — a pick is the operator's, not the session's, and the
+			// next open re-validates it (#7981). Announcing the clear is `start`'s, because this
+			// queue is shut the moment this returns; see the emit behind its `starting`.
 			yield* Ref.set(models, []);
+			yield* Ref.set(efforts, new Map());
 			yield* denyEveryParked;
 		});
 
@@ -580,6 +588,19 @@ const make = (
 			const out = yield* Queue.unbounded<AgentEvent, TransportError | Cause.Done>();
 			yield* Ref.set(queue, out);
 			yield* emit(out, [{kind: "phase", phase: "starting"}]);
+			// The clear `closeCurrent` just made, said out loud on the queue a consumer is on. Without
+			// it a subscription taken across the swap keeps painting the dead session's rows, and an
+			// open that then fails emits `gone` with nothing to correct them (#8542). The held
+			// selections ride along, so the control names the pick rather than a catalog nobody holds
+			// — the founder's ruling of 2026-09-08. Only after a teardown: with no previous session
+			// this layer knows no selection, and announcing `current: null` would erase the one a
+			// restored window is showing.
+			if (previous !== null) {
+				yield* emit(out, [
+					{kind: "model", current: yield* Ref.get(model), available: []},
+					{kind: "thinking", current: yield* Ref.get(effort), available: []},
+				]);
+			}
 
 			// The layer's own switch first, then the mode the caller says to open on. The Ref is per
 			// build, so on the rebuilt layer a reconnect stands up it is null and the caller's mode is
@@ -643,11 +664,15 @@ const make = (
 			// this session landed on does not offer is dropped instead of sent.
 			const levels = offeredEfforts(table, opening);
 			const wanted = yield* Ref.get(effort);
+			// `find` rather than `includes`: the held pick is a `ThinkingLevel`, and what comes back
+			// is typed by this session's own offer, so `applyEffort` cannot be reached with one of
+			// the two levels Claude has no effort for.
+			const supported = levels.find((candidate) => candidate === wanted);
 			const running =
-				wanted === null || !levels.includes(wanted)
+				supported === undefined
 					? null
-					: (yield* applyEffort(opened.session, wanted))
-						? wanted
+					: (yield* applyEffort(opened.session, supported))
+						? supported
 						: null;
 			yield* Ref.set(effort, running);
 			// The open's `ready` ships here, behind the catalogs, and never ahead of them: the
@@ -794,11 +819,14 @@ const make = (
 			yield* publish([{kind: "model", current: held, available: offered}]);
 			// The offered levels are the model's, so a switch moves the picker's rows. A level the
 			// new model does not offer stops being the current one rather than staying on a state it
-			// would now refuse.
+			// would now refuse — against a live catalog only: between sessions there is none to judge
+			// it by, and dropping the held level there would spend the operator's pick on a model
+			// switch the next open has not seen yet (#8542).
 			const table = yield* Ref.get(efforts);
 			const levels = offeredEfforts(table, held);
 			const running = yield* Ref.get(effort);
-			const kept = running !== null && levels.includes(running) ? running : null;
+			const kept =
+				current === null ? running : (levels.find((candidate) => candidate === running) ?? null);
 			yield* Ref.set(effort, kept);
 			yield* publishThinking(kept, levels);
 		});
@@ -808,17 +836,24 @@ const make = (
 		) {
 			const table = yield* Ref.get(efforts);
 			const levels = offeredEfforts(table, yield* Ref.get(model));
+			const current = yield* Ref.get(session);
+			// The session is read before the offer is judged, and that order is the whole fix: with
+			// no session the table is empty, so judging first refused every pick with the level
+			// listed against an empty `available` — the self-contradicting refusal #7981 ruled out,
+			// and the hold the comment here used to describe was unreachable (#8542). Validation is
+			// deferred, not skipped: `start` re-checks the held level against the catalog it reads
+			// and drops one this session's model does not offer.
+			if (current === null) {
+				yield* Ref.set(effort, next);
+				return yield* publishThinking(next, levels);
+			}
 			// `find` rather than `includes`: what comes back is typed as an `EffortLevel`, so the SDK
 			// call below cannot be reached with one of the two levels Claude has no effort for.
 			const picked = levels.find((candidate) => candidate === next);
 			if (picked === undefined) {
 				return yield* new ThinkingUnsupported({level: next, available: levels});
 			}
-			const current = yield* Ref.get(session);
-			// No session yet is not a refusal: the pick is held and applied by the next open, exactly
-			// as a mode or a model set before the first session is.
-			const changed = current === null ? true : yield* applyEffort(current, picked);
-			if (changed) yield* Ref.set(effort, picked);
+			if (yield* applyEffort(current, picked)) yield* Ref.set(effort, picked);
 			yield* publishThinking(yield* Ref.get(effort), levels);
 		});
 

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -468,9 +468,18 @@ describe("setModel", () => {
 					// The first session's rows died with it, so a model none of them named is held for
 					// the next open rather than refused against a list nothing offers any more.
 					yield* agent.setModel({id: "gpt", name: "GPT"});
-					// The failed open's own `starting` and `gone` come first on the fresh queue.
-					const events = yield* Stream.runCollect(Stream.take(agent.events, 3));
-					assert.deepStrictEqual(events[2], {
+					// The fresh queue's own opening: `starting`, the teardown's clear on both axes,
+					// then the failed open's `gone` (#8542). Without that clear a subscription taken
+					// across the swap keeps the dead session's rows, and the `gone` behind it never
+					// corrects them.
+					const events = yield* Stream.runCollect(Stream.take(agent.events, 5));
+					assert.deepStrictEqual(events.slice(0, 4), [
+						{kind: "phase", phase: "starting"},
+						{kind: "model", current: null, available: []},
+						{kind: "thinking", current: null, available: []},
+						{kind: "phase", phase: "gone"},
+					]);
+					assert.deepStrictEqual(events[4], {
 						kind: "model",
 						current: {id: "gpt", name: "GPT"},
 						available: [],
@@ -794,6 +803,92 @@ describe("setThinkingLevel", () => {
 			);
 			assert.strictEqual(failure(exit)._tag, "tuval/ai-agent/ThinkingUnsupported");
 		}),
+	);
+
+	it.effect("holds a level picked before any session instead of refusing it", () =>
+		on({models: EFFORT, model: "opus"}, (agent) =>
+			Effect.gen(function* () {
+				// The model axis's ruling on the thinking axis (#7981, #8542): with no session the
+				// offer is empty, so refusing here would list the level against nothing.
+				yield* agent.setThinkingLevel("xhigh");
+				const events = yield* Stream.runCollect(Stream.take(agent.events, 1));
+				assert.deepStrictEqual(events[0], {
+					kind: "thinking",
+					current: "xhigh",
+					available: [],
+				});
+			}),
+		),
+	);
+
+	it.effect("applies a level held before the first open at that open", () =>
+		on({models: EFFORT, model: "opus"}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.setThinkingLevel("xhigh");
+				yield* agent.start({cwd: CWD});
+				assert.deepStrictEqual(scripted.opened[0]?.record.efforts, ["xhigh"]);
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(
+					events.find((event) => event.kind === "thinking"),
+					{
+						kind: "thinking",
+						current: "xhigh",
+						available: ["low", "medium", "high", "xhigh", "max"],
+					},
+				);
+			}),
+		),
+	);
+
+	it.effect("drops a held level the first open's model does not offer", () =>
+		on({models: EFFORT, model: "opus"}, (agent, scripted) =>
+			Effect.gen(function* () {
+				// Held unvalidated, so it is the open that judges it — and `minimal` is one of the two
+				// levels Claude has no effort for, so nothing is applied and nothing is announced.
+				yield* agent.setThinkingLevel("minimal");
+				yield* agent.start({cwd: CWD});
+				assert.deepStrictEqual(scripted.opened[0]?.record.efforts, []);
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.deepStrictEqual(
+					events.find((event) => event.kind === "thinking"),
+					{
+						kind: "thinking",
+						current: null,
+						available: ["low", "medium", "high", "xhigh", "max"],
+					},
+				);
+			}),
+		),
+	);
+
+	it.effect("ends the effort catalog with the session and says so, keeping the level", () =>
+		on(
+			{
+				models: EFFORT,
+				model: "opus",
+				openFails: new Error("the CLI would not spawn"),
+				openFailsAt: 2,
+			},
+			(agent) =>
+				Effect.gen(function* () {
+					yield* agent.start({cwd: CWD});
+					yield* agent.setThinkingLevel("high");
+					const exit = yield* Effect.exit(agent.start({cwd: CWD}));
+					assert.isTrue(Exit.isFailure(exit));
+					// The dead session's levels are gone from the announcement, and the level the
+					// operator picked is not: the control names the pick, and the offer behind it is
+					// empty rather than the dead session's rows (#8542).
+					const events = yield* Stream.runCollect(Stream.take(agent.events, 3));
+					assert.deepStrictEqual(events[2], {
+						kind: "thinking",
+						current: "high",
+						available: [],
+					});
+					// And the pick survives the teardown, so the next open re-applies it.
+					const held = yield* Effect.exit(agent.setThinkingLevel("max"));
+					assert.isTrue(Exit.isSuccess(held));
+				}),
+		),
 	);
 
 	it.effect("offers nothing on a model whose row declares no effort levels", () =>

--- a/apps/tuval/src/shell/chat/chat-held-selection.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-held-selection.unit.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The reproduced incident of #8542: a restored desk whose reconnect was refused, an operator
+ * picking a model, the activity list reading "The agent model changed to Opus 5." and the composer's
+ * button still reading "Sonnet 5".
+ *
+ * It runs the whole seam the founder ran by hand, minus the CLI: the real `ClaudeAiAgent` layer over
+ * the scripted SDK, the real core fold, the real `composerBridge` and the shared `AgentChatInput`.
+ * The layer's own events are what drive the composer, so neither half can be right on its own — the
+ * layer announcing the clear does nothing if the picker paints the copy over the pick, and the
+ * picker naming the pick does nothing if the layer never says the catalog is gone.
+ */
+
+import type {ModelInfo} from "@anthropic-ai/claude-agent-sdk";
+import {AgentChatInput, DesignTranslationProvider} from "@kampus/design";
+import {act, render, screen} from "@testing-library/react";
+import {Effect, Stream} from "effect";
+import type {ReactElement} from "react";
+import {expect, it} from "vitest";
+import {type AiAgentSessionState, foldEvent, initialState} from "../../ai-agent/core/index.ts";
+import type {AgentEvent} from "../../ai-agent/events.ts";
+import {CWD, on, START_EVENTS, settled} from "../../claude/agent/fixtures/harness.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type ComposerBridge, composerBridge} from "./composer-bridge.ts";
+import {tuvalDesignTranslate} from "./copy.ts";
+
+installDomShims();
+
+const CATALOG: ReadonlyArray<ModelInfo> = [
+	{
+		value: "opus",
+		resolvedModel: "claude-opus-5",
+		displayName: "Opus 5",
+		description: "Scripted catalog row, not a live model claim",
+		supportsEffort: true,
+		supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+	},
+	{
+		value: "sonnet",
+		displayName: "Sonnet 5",
+		description: "Scripted catalog row, not a live model claim",
+		supportsEffort: true,
+		supportedEffortLevels: ["low", "medium", "high"],
+	},
+];
+
+/** What `ChatWindow` does with the four slices, in the order its effects run. */
+const push = (composer: ComposerBridge, state: AiAgentSessionState): void => {
+	composer.setPhase(state.phase);
+	composer.setModels(state.models);
+	composer.setCommands(state.commands);
+	composer.setThinking(state.thinking);
+};
+
+const fold = (state: AiAgentSessionState, events: ReadonlyArray<AgentEvent>): AiAgentSessionState =>
+	events.reduce((held, event) => foldEvent(held, event, {}), state);
+
+const modelButton = async (): Promise<string> =>
+	(await screen.findByRole("button", {name: /^model: /})).getAttribute("aria-label") ?? "";
+
+it("names the held pick on the button when the reconnect left no catalog behind it", async () => {
+	await Effect.runPromise(
+		on(
+			{
+				models: CATALOG,
+				runningModel: "claude-opus-5",
+				openFails: new Error("the CLI would not spawn"),
+				openFailsAt: 2,
+			},
+			(agent) =>
+				Effect.gen(function* () {
+					// The live half of the incident: a session on the scripted catalog, and the operator
+					// picking Sonnet 5 on it.
+					yield* agent.start({cwd: CWD});
+					yield* agent.setModel({id: "sonnet", name: "Sonnet 5"});
+					const opened = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS + 2));
+					const live = fold(initialState(CWD), opened);
+					expect(live.models.current).toEqual({id: "sonnet", name: "Sonnet 5"});
+
+					// The restart: the window comes back on its checkpoint, which is why the composer is
+					// mounted on the state above rather than on an empty one.
+					const composer = composerBridge({
+						initialPhase: live.phase,
+						initialModels: live.models,
+						initialCommands: live.commands,
+						initialThinking: live.thinking,
+						onPrompt: () => undefined,
+						onInterrupt: () => undefined,
+						onSetModel: () => undefined,
+						onSetThinkingLevel: () => undefined,
+					});
+					yield* settled(
+						act(async () => {
+							render(
+								(
+									<DesignTranslationProvider translate={tuvalDesignTranslate}>
+										<AgentChatInput bridge={composer.bridge} variant="focused" />
+									</DesignTranslationProvider>
+								) as ReactElement,
+							);
+						}),
+					);
+					expect(yield* settled(modelButton())).toContain("Sonnet 5");
+
+					// The refused reconnect, and then the pick the founder made in that state.
+					yield* Effect.exit(agent.start({cwd: CWD}));
+					yield* agent.setModel({id: "opus", name: "Opus 5"});
+					const after = yield* Stream.runCollect(Stream.take(agent.events, 6));
+					const now = fold(live, after);
+					yield* settled(act(async () => push(composer, now)));
+
+					// The button follows the pick rather than contradicting it, and says the offer behind
+					// it is empty rather than painting the dead session's rows as live.
+					expect(now.models).toEqual({current: {id: "opus", name: "Opus 5"}, available: []});
+					const named = yield* settled(modelButton());
+					expect(named).toContain("Opus 5");
+					expect(named).toContain("none offered");
+					expect(named).not.toContain("Sonnet 5");
+				}),
+		),
+	);
+});

--- a/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
@@ -140,3 +140,18 @@ describe.each(["focused", "harness"] as const)("the %s thinking control", (varia
 		await waitFor(async () => expect(await reading(variant)).not.toContain("loading"));
 	});
 });
+
+/**
+ * The other half of the same fact, on the axis #8542's founder ruling puts beside the model one: a
+ * level held with no live catalog behind it. The focused variant is Tuval's own, and the only one
+ * that can name a selection its offer carries no row for.
+ */
+it("names a held level beside the empty offer rather than instead of it", async () => {
+	const composer = mount("ready", "focused", picked);
+	await waitFor(async () => expect(await reading("focused")).toContain("medium"));
+
+	// The session goes and its levels go with it. The pick is the operator's, so it stays named.
+	await act(async () => composer.setThinking({current: "medium", available: []}));
+	await waitFor(async () => expect(await reading("focused")).toContain("none offered"));
+	expect(await reading("focused")).toContain("medium");
+});

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -950,9 +950,29 @@ export function AgentChatInput({
 			})),
 		[thinkingLevels, t],
 	);
-	const selectedModel = selectedModelValue(state) ?? modelItems?.[0]?.value;
+	// The host's own answer and nothing else. Falling back to the first row named a model nobody
+	// picked as the one the session runs on, and a picker opened with that row already checked read
+	// as a choice already made (#8573).
+	const selectedModel = selectedModelValue(state);
 	const stateThinking = thinkingLevelValue(state?.thinkingLevel);
 	const selectedThinking = stateThinking !== "off" ? stateThinking : undefined;
+	// Each selection as a row of its own, for the picker to name when the offer carries no row for
+	// it — the pick an operator holds while no session's catalog is live (#8542).
+	const heldModel = useMemo<PickerItem | undefined>(() => {
+		const name = modelName(state);
+		return selectedModel && name ? {value: selectedModel, label: name} : undefined;
+	}, [selectedModel, state]);
+	const heldThinking = useMemo<PickerItem | undefined>(
+		() =>
+			selectedThinking === undefined
+				? undefined
+				: {
+						value: selectedThinking,
+						label: t(thinkingLevelKeys[selectedThinking]),
+						icon: thinkingLevelIcons[selectedThinking],
+					},
+		[selectedThinking, t],
+	);
 	const settingsDisabled = disabled || settingsChanging || connection !== "ready";
 	const offeredThinking = thinkingItems?.length ?? 0;
 	const thinkingDisabled =
@@ -1145,6 +1165,7 @@ export function AgentChatInput({
 											label={t("admin.agent.setting.model")}
 											items={focusedModelItems}
 											value={selectedModel}
+											held={heldModel}
 											onValueChange={(value) => void changeModel(value)}
 											disabled={settingsDisabled || (focusedModelItems?.length ?? 0) < 2}
 										/>
@@ -1152,6 +1173,7 @@ export function AgentChatInput({
 											label={t("admin.agent.setting.thinking")}
 											items={focusedThinkingItems}
 											value={selectedThinking}
+											held={heldThinking}
 											onValueChange={(value) => void changeThinkingLevel(value)}
 											disabled={thinkingDisabled}
 										/>
@@ -1346,6 +1368,12 @@ export interface SettingMenuProps {
 	 */
 	readonly items: readonly PickerItem[] | undefined;
 	readonly value?: string;
+	/**
+	 * The selection as the host describes it, for when `items` carries no row for it — a pick held
+	 * with no live catalog behind it (#8542). The trigger names this rather than the empty offer's
+	 * copy, so the control never contradicts the selection the host is holding.
+	 */
+	readonly held?: PickerItem;
 	readonly onValueChange: (value: string) => void;
 	readonly disabled?: boolean;
 }
@@ -1355,7 +1383,14 @@ export interface SettingMenuProps {
  * the `settings` slot builds its control out of this rather than reaching for a bare `Select`,
  * which would put a differently-shaped control in a row of these.
  */
-export function SettingMenu({label, items, value, onValueChange, disabled}: SettingMenuProps) {
+export function SettingMenu({
+	label,
+	items,
+	value,
+	held,
+	onValueChange,
+	disabled,
+}: SettingMenuProps) {
 	const t = useDesignT();
 	const [open, setOpen] = useState(false);
 	// The highlight is ours to drive, not the machine's: Zag clears it on close and re-seeds it to
@@ -1364,7 +1399,6 @@ export function SettingMenu({label, items, value, onValueChange, disabled}: Sett
 	// there and the first arrow key move from there. See ADR 0361.
 	const [highlighted, setHighlighted] = useState<string | null>(null);
 	const offered = items ?? [];
-	const selected = offered.find((item) => item.value === value);
 	// Three unselected states, and only the first is loading: `undefined` items is a host that has
 	// not resolved what it offers, `[]` is one that resolved and offers nothing, and a populated
 	// list with no `value` is a setting the session has not picked yet (#8190, #8425). Reading the
@@ -1376,6 +1410,12 @@ export function SettingMenu({label, items, value, onValueChange, disabled}: Sett
 				? "admin.agent.picker.empty"
 				: "admin.agent.picker.none",
 	);
+	// A pick the offer carries no row for is still a pick: the trigger names it and the empty copy
+	// rides as its note, so an operator reads both what is held and that nothing live sits behind
+	// it. A control that showed the copy alone said the opposite of the model it was on (#8542).
+	const selected =
+		offered.find((item) => item.value === value) ??
+		(held !== undefined && held.value === value ? {...held, note: unselectedName} : undefined);
 	// Nothing to pick is nothing to open, either way round: an unresolved offer has no rows yet and
 	// a resolved-empty one never will, so the trigger does not advertise an operation the host
 	// cannot perform. `disabled` from the host still wins on top of this.


### PR DESCRIPTION
The Claude layer emptied its model catalog at teardown and told nobody, so a picker kept the dead
session's rows — and the pick made in that state was announced against a catalog nothing held. On the
founder's reproduction the composer's button read "Sonnet 5" while the activity list read "The agent
model changed to Opus 5."

Both halves are fixed, on both axes:

- `closeCurrent` now ends `efforts` beside `models`, so the effort catalog does not outlive the
  session it was read from either.
- `start` announces that clear on the queue a consumer is actually on — behind the new queue's
  `starting`, and only when a session was torn down. The old queue is shut the moment `closeCurrent`
  returns, so announcing there reaches nobody; announcing here puts the clear ahead of the `gone` a
  refused reconnect emits, which is the one path with no later catalog to correct it.
- The clear carries the held selection beside `available: []`. A pick is the operator's, not the
  session's, so it survives the teardown and the next open re-validates it (#7981).
- `setThinkingLevel` reads the session before it judges the offer. With no session the table is
  empty, so judging first refused every pre-session pick with the level listed against an empty
  `available` — the self-contradicting refusal #7981 ruled out, and the hold the code's own comment
  described was unreachable (folded from #8539). A live session still refuses an unsupported level
  with `ThinkingUnsupported`.
- The composer's `SettingMenu` takes the held selection as a new `held` prop: when the offer carries
  no row for the current value, the trigger names the pick and the `admin.agent.picker.empty` copy
  rides as its note, so the control reads "model: Opus 5 (none offered)" instead of contradicting
  the model the layer is holding.

This is the founder's ruling of 2026-09-08 on this issue: the button shows the held selection, the
menu is empty and says so, the same on the thinking axis, and the next open validates per #7981.

Tests: the scenario is reproduced end to end in
`apps/tuval/src/shell/chat/chat-held-selection.unit.test.tsx` — the real layer over the scripted SDK,
the real core fold, the real `composerBridge` and the shared `AgentChatInput`, with a live pick, a
refused reconnect and the pick made in that state. No credentials, no CLI. The layer's first-open,
teardown, failed-reconnect and next-open-validation cases are in `start.unit.test.ts`, and the
thinking picker's held-selection reading in `chat-thinking-offer.unit.test.tsx`.

Fixes #8542

## Deviations

- **Out-of-scope change** — **Said:** #8542's criteria name the catalog lifetime and the held
  selection. **Did:** also dropped `selectedModel`'s `?? modelItems?.[0]?.value` fallback in
  `AgentChatInput`. **Why:** #8573 was folded into this issue and is exactly that fallback, and
  criterion 1 forbids a control that presents a selection nobody made; the value is display-only, so
  nothing sends a prompt on it. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the control must not contradict the held selection. **Did:** fixed
  the focused variant's `SettingMenu` only; the harness variant's Manti `Select` still falls back to
  its placeholder when the offer carries no row for the value. **Why:** Tuval renders
  `variant="focused"`, which is the surface the ruling was made on; the harness `Select` cannot
  render a label for a row it does not hold without a change to that component's contract.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the control must not present a dead session catalog as
  live. **Did:** left the window's restored checkpoint alone — a rebuilt layer whose open is refused
  paints the checkpointed rows until the operator picks something, because that layer knows no
  selection and announcing `current: null` would erase the one the restored window is showing.
  **Why:** criterion 3 scopes the clear to teardown, which is in-process; the restore path is a
  different lifetime and a different fix. **Disposition:** stated here.
