### PR TITLE
feat: Tuval chat: a run of tool calls renders as one sentence-shaped row

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -72,6 +72,7 @@ import {SessionRow} from "./SessionRow.tsx";
 import {SubagentList, type SubagentListHandle} from "./SubagentList.tsx";
 import {ThinkingRow} from "./ThinkingRow.tsx";
 import {type ToolFold, ToolRow} from "./ToolRow.tsx";
+import {ToolRunRow} from "./ToolRunRow.tsx";
 import {UnsentMessages} from "./UnsentMessages.tsx";
 import {asChatView, type ChatView, viewMain, viewSubagent} from "./view.ts";
 import "./chat.css";
@@ -221,6 +222,18 @@ const who: Readonly<Record<RowItem["kind"], string>> = {
  */
 const authorName = (kind: RowItem["kind"], nested: boolean): string =>
 	nested ? `${who[kind]}, inside a subagent call` : who[kind];
+
+/**
+ * The wrapper's shape hooks for one row. A run of calls is about its calls, so it reads as a tool
+ * row's shape and indents at its own depth; a paging head and a session run have neither.
+ */
+const rowShape = (
+	row: ChatRow,
+): {readonly role?: RowItem["kind"]; readonly nested: boolean; readonly depth: number} => {
+	if (row.kind === "item") return {role: row.item.kind, nested: row.nested, depth: row.depth};
+	if (row.kind === "tools") return {role: "tool", nested: row.nested, depth: row.depth};
+	return {nested: false, depth: 0};
+};
 
 /**
  * What a row shows under its label. Three kinds carry a shape of their own, and all three are
@@ -384,6 +397,14 @@ function RowView({
 					expanded={expanded.has(id)}
 					onToggle={(next) => onToggleRow(id, next)}
 				/>
+			</>
+		);
+	}
+	if (row.kind === "tools") {
+		return (
+			<>
+				<span className="kp-visually-hidden">{authorName("tool", row.nested)}</span>
+				<ToolRunRow calls={row.calls} />
 			</>
 		);
 	}
@@ -1032,6 +1053,7 @@ function ChatWindow({
 						{virtualizer.getVirtualItems().map((virtual) => {
 							const row = rows[virtual.index];
 							if (row === undefined) return null;
+							const shape = rowShape(row);
 							return (
 								<div
 									key={virtual.key}
@@ -1040,14 +1062,14 @@ function ChatWindow({
 									data-kind={row.kind === "item" ? row.item.kind : row.kind}
 									// Authorship as the row's shape carries it (#8210), and the hook the bubble and
 									// prose rules in `chat.css` hang on.
-									data-message-role={row.kind === "item" ? row.item.kind : undefined}
-									data-nested={row.kind === "item" && row.nested ? "true" : undefined}
+									data-message-role={shape.role}
+									data-nested={shape.nested ? "true" : undefined}
 									ref={virtualizer.measureElement}
 									style={{
 										transform: `translateY(${virtual.start}px)`,
 										// One indent step per fold the row sits inside, so a subagent's own subagent
 										// reads as a further step in rather than as another row at the same level.
-										...(row.kind === "item" && row.depth > 0 ? {"--nest-depth": row.depth} : {}),
+										...(shape.depth > 0 ? {"--nest-depth": shape.depth} : {}),
 									}}
 								>
 									<RowView

--- a/apps/tuval/src/shell/chat/ToolRunRow.tsx
+++ b/apps/tuval/src/shell/chat/ToolRunRow.tsx
@@ -1,0 +1,39 @@
+/**
+ * A run of consecutive tool calls as one line: a status dot, the run's sentence, and the status as
+ * a word whenever the run is not simply finished.
+ *
+ * The dot is a state marker, not an icon — `aria-hidden`, and paired with the word beside it — so
+ * neither the tint nor the shimmer is ever the only thing saying what happened (ADR 0162, Pillar 4,
+ * and the manifest's state-marker bound). The shimmer collapses under `prefers-reduced-motion`
+ * (`chat.css`), and the word is what survives that collapse.
+ *
+ * Opening the run to read one call is the next slice (#8613); this row is the line and nothing else.
+ */
+
+import type {ReactElement} from "react";
+import type {ToolRun} from "./rows.ts";
+import {runSentence, runStatus, runStatusWord} from "./tool-run.ts";
+
+export function ToolRunRow({calls}: {readonly calls: ToolRun}): ReactElement {
+	const status = runStatus(calls);
+	const word = runStatusWord(status);
+	return (
+		<span className="tuval-chat-tool-run" data-status={status}>
+			<span className="tuval-chat-tool-run-dot" data-status={status} aria-hidden="true" />
+			<span
+				className={
+					status === "running"
+						? "tuval-chat-tool-run-line tuval-chat-tool-run-shimmer"
+						: "tuval-chat-tool-run-line"
+				}
+			>
+				{runSentence(calls)}
+			</span>
+			{word === null ? null : (
+				<span className="tuval-chat-tool-run-status" data-status={status}>
+					{word}
+				</span>
+			)}
+		</span>
+	);
+}

--- a/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
@@ -522,10 +522,15 @@ describe("the composer's thinking picker", () => {
 
 describe("two windows over one process", () => {
 	it("keep their own expanded rows and share the cards and the mode", async () => {
-		const state = withTranscript([call("t1"), call("t2", {name: "grep"})], {
-			permissions: {r1: pendingPermission()},
-			modes: modes(["plan", "build"], "plan"),
-		});
+		// A reply between the two calls, so each is a row of its own with a disclosure of its own —
+		// consecutive calls are one collapsed run (#8612), and this case is about two open rows.
+		const state = withTranscript(
+			[call("t1"), assistantItem("a1", "on it"), call("t2", {name: "grep"})],
+			{
+				permissions: {r1: pendingPermission()},
+				modes: modes(["plan", "build"], "plan"),
+			},
+		);
 		const shared = await Effect.runPromise(
 			testProcess<AiAgentSessionState, AiAgentSessionMsg>(processId, state),
 		);

--- a/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-a11y.unit.test.tsx
@@ -654,3 +654,66 @@ describe("the chat turn shape's authorship", () => {
 		SLOW,
 	);
 });
+
+/**
+ * A run of consecutive calls is one sentence-shaped row (#8612), and the sentence says what
+ * happened, never how it went. So the two states a reader must not miss — a failure, and a call
+ * still going — are words on the row, and the dot's tint and the shimmer are each the second
+ * signal rather than the only one (ADR 0162, Pillar 4).
+ */
+describe("a run of tool calls as one row", () => {
+	const runRow = (root: HTMLElement): HTMLElement | null =>
+		root.querySelector<HTMLElement>('.tuval-chat-row[data-kind="tools"]');
+
+	it("says a failure in words as well as in the tint", async () => {
+		const rendered = await mountWindow(
+			withTranscript([
+				userItem("u1", "go"),
+				call("t0", {input: {file_path: "a.ts"}}),
+				call("t1", {name: "bash", input: {command: "ls"}, status: "error"}),
+			]),
+		);
+		const root = rendered.container.firstElementChild as HTMLElement;
+		const run = runRow(root);
+		expect(run?.textContent).toContain("Read 1 file and ran 1 command");
+		expect(run?.textContent).toContain("failed");
+		// The dot says nothing on its own: it is out of the accessible name entirely.
+		expect(run?.querySelector(".tuval-chat-tool-run-dot")?.getAttribute("aria-hidden")).toBe(
+			"true",
+		);
+		rendered.unmount();
+	});
+
+	it("says a call is still going in words, so the shimmer is never the only tell", async () => {
+		const rendered = await mountWindow(
+			withTranscript([
+				userItem("u1", "go"),
+				call("t0", {input: {file_path: "a.ts"}}),
+				call("t1", {input: {file_path: "b.ts"}, status: "running"}),
+			]),
+		);
+		const root = rendered.container.firstElementChild as HTMLElement;
+		const run = runRow(root);
+		expect(run?.textContent).toContain("Read 2 files");
+		expect(run?.textContent).toContain("running");
+		rendered.unmount();
+	});
+
+	it(
+		"holds the enforced pillar-4 invariants over the collapsed run",
+		async () => {
+			const rendered = await mountWindow(
+				withTranscript([
+					userItem("u1", "go"),
+					call("t0", {input: {file_path: "a.ts"}}),
+					call("t1", {name: "bash", input: {command: "ls"}, status: "error"}),
+					call("t2", {input: {path: "a.ts", old_string: "one", new_string: "two"}}),
+				]),
+			);
+			const root = rendered.container.firstElementChild as HTMLElement;
+			expect(await scanRegions(root)).toEqual([]);
+			rendered.unmount();
+		},
+		SLOW,
+	);
+});

--- a/apps/tuval/src/shell/chat/chat-reduced-motion.unit.test.ts
+++ b/apps/tuval/src/shell/chat/chat-reduced-motion.unit.test.ts
@@ -124,6 +124,18 @@ describe("the reduced-motion collapse", () => {
 		}
 	});
 
+	// The generic assertion above already covers this rule; it is named here because a run's
+	// "still going" is the one state in the transcript a reader would otherwise read off motion.
+	it("cancels the tool-run shimmer, whose state is carried by the word beside it", () => {
+		const shimmer = [...rest.matchAll(/([^{}]+)\{([^{}]*)\}/g)].find(
+			([, selectors, body]) =>
+				(selectors ?? "").includes("tuval-chat-tool-run-shimmer") &&
+				/animation(?:-name)?\s*:\s*tuval-chat-tool-run-pulse/.test(body ?? ""),
+		);
+		expect(shimmer, "the tool-run shimmer rule is gone — re-point this assertion").toBeDefined();
+		expect(overrides).toContain(".tuval-chat-tool-run-shimmer");
+	});
+
 	// Pillar 4: the collapse above is only safe if the state does not ride on the motion it cancels.
 	it("leaves the in-flight dot distinguishable once the pulse is collapsed", () => {
 		const declaredIn = (block: string): ReadonlyArray<string> =>

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -1636,7 +1636,7 @@ describe("a group head's fold, as a control assistive tech can read", () => {
 		const fold = foldButton();
 		expect(fold.textContent).toBe("Show 2 nested calls");
 		expect(fold.getAttribute("aria-expanded")).toBe("false");
-		expect(screen.queryByText("bash")).toBeNull();
+		expect(screen.queryByText("Read 2 files")).toBeNull();
 
 		await act(async () => {
 			fireEvent.click(fold);
@@ -1645,8 +1645,8 @@ describe("a group head's fold, as a control assistive tech can read", () => {
 		const opened = foldButton();
 		expect(opened.textContent).toBe("Hide 2 nested calls");
 		expect(opened.getAttribute("aria-expanded")).toBe("true");
-		expect(screen.queryByText("bash")).not.toBeNull();
-		expect(screen.queryByText("grep")).not.toBeNull();
+		// The two revealed calls are consecutive at one depth, so what appears is their run (#8612).
+		expect(screen.queryByText("Read 2 files")).not.toBeNull();
 	});
 
 	// The rows are virtualized, so any idref list the button named would go stale as the reader
@@ -1955,7 +1955,14 @@ describe("the view slot's writer, under StrictMode", () => {
 	// this render was given. It reds against a ref written from an effect rather than in `commit`.
 	it("composes batched commits off the last committed value", async () => {
 		const {writes, view} = await openWindow(
-			withTranscript([userItem("a", "do it"), call("c"), call("d", {name: "grep"})]),
+			// A reply between the calls: consecutive ones collapse into one run (#8612), and this case
+			// needs two rows with a disclosure each to batch two toggles.
+			withTranscript([
+				userItem("a", "do it"),
+				call("c"),
+				assistantItem("b", "next"),
+				call("d", {name: "grep"}),
+			]),
 			{},
 			undefined,
 			{strict: true},

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -506,6 +506,72 @@
 	align-self: flex-start;
 }
 
+/*
+ * A run of consecutive calls as one line (#8612): a status dot, the sentence, and the status as a
+ * word for a run that failed or is still going. The dot is a state marker rather than an icon —
+ * `aria-hidden`, and it never carries the state alone: the word beside it does, which is also what
+ * survives the reduced-motion collapse of the shimmer below (ADR 0162, Pillar 4).
+ */
+.tuval-chat-tool-run {
+	display: flex;
+	gap: var(--s-2);
+	align-items: baseline;
+	min-inline-size: 0;
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
+.tuval-chat-tool-run-dot {
+	flex: none;
+	align-self: center;
+	inline-size: 6px;
+	block-size: 6px;
+	border-radius: 50%;
+	background: var(--text-muted);
+}
+
+.tuval-chat-tool-run-dot[data-status="error"] {
+	background: var(--danger);
+}
+
+.tuval-chat-tool-run-dot[data-status="running"] {
+	background: var(--accent);
+}
+
+.tuval-chat-tool-run-line {
+	min-inline-size: 0;
+}
+
+.tuval-chat-tool-run-status {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.tuval-chat-tool-run-status[data-status="error"] {
+	color: var(--danger);
+}
+
+.tuval-chat-tool-run-status[data-status="running"] {
+	color: var(--accent);
+}
+
+/* A single class, so the reduced-motion override below ties on specificity and wins on source
+   order — the compound form would silently lose and keep pulsing (see #8121, and the sheet's own
+   note at the block). */
+.tuval-chat-tool-run-shimmer {
+	animation: tuval-chat-tool-run-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes tuval-chat-tool-run-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.55;
+	}
+}
+
 .tuval-chat-tool-detail {
 	display: flex;
 	flex-direction: column;
@@ -863,7 +929,8 @@
    is carried here to tie, and the tie goes to this rule because it comes later. */
 @media (prefers-reduced-motion: reduce) {
 	.tuval-chat-phase[data-phase] .tuval-chat-phase-dot,
-	.tuval-chat-working-dots span {
+	.tuval-chat-working-dots span,
+	.tuval-chat-tool-run-shimmer {
 		animation: none;
 		opacity: 1;
 	}

--- a/apps/tuval/src/shell/chat/index.ts
+++ b/apps/tuval/src/shell/chat/index.ts
@@ -27,14 +27,20 @@ export {
 	rowIndexOfItem,
 	rowKey,
 	type SessionRun,
+	type ToolRun,
 } from "./rows.ts";
 export {SessionRow} from "./SessionRow.tsx";
 export {ToolRow} from "./ToolRow.tsx";
+export {ToolRunRow} from "./ToolRunRow.tsx";
 export {
 	type DiffLine,
 	diffLines,
 	omissionLine,
+	type ToolAction,
 	type ToolDetail,
+	type ToolShape,
 	toolDetail,
+	toolShape,
 } from "./tool-detail.ts";
+export {runSentence, runStatus, runStatusWord} from "./tool-run.ts";
 export {asChatView, type ChatView, initialChatView} from "./view.ts";

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -36,8 +36,19 @@ import type {ItemId, SubagentSlot, SystemItem, TranscriptItem} from "../../ai-ag
  */
 export type RowItem = Exclude<TranscriptItem, SystemItem>;
 
+/** A tool call, off the union rather than off a second import: the one above is at its width bound,
+ * and `boundary.unit.test.ts` reads import lines one at a time, so a wrapped one reads as untyped. */
+export type ToolCall = Extract<RowItem, {readonly kind: "tool"}>;
+
 /** One run of consecutive session notices, oldest-first. Non-empty by construction. */
 export type SessionRun = readonly [SystemItem, ...ReadonlyArray<SystemItem>];
+
+/**
+ * One run of consecutive tool calls, oldest-first. **Two or more** by construction: a lone call is
+ * already one row, and collapsing it into a sentence would spend its name and its disclosure to
+ * say "Read 1 file". So the type is what says a run of one is not a run.
+ */
+export type ToolRun = readonly [ToolCall, ToolCall, ...ReadonlyArray<ToolCall>];
 
 export type ChatRow =
 	/** There is more history behind this point; `items` is what the live-tail bound already dropped. */
@@ -50,6 +61,18 @@ export type ChatRow =
 	 * row that grows rather than N rows that push everything the reader was looking at down the page.
 	 */
 	| {readonly kind: "session"; readonly items: SessionRun}
+	/**
+	 * A run of consecutive tool calls as one sentence-shaped row (#8612). Six reads are one line
+	 * saying "Read 6 files" instead of six labelled blocks saying nothing about what was read.
+	 */
+	| {
+			readonly kind: "tools";
+			readonly calls: ToolRun;
+			/** This run ran inside another tool call — a subagent's, not the agent's own. */
+			readonly nested: boolean;
+			/** How many folds deep the run sits. Every call in it sits at this one depth. */
+			readonly depth: number;
+	  }
 	| {
 			readonly kind: "item";
 			readonly item: RowItem;
@@ -123,6 +146,9 @@ export const rowKey = (row: ChatRow): string => {
 	if (row.kind === "item") return `item:${row.item.id}`;
 	// The run's first notice, so the key holds still as later notices join the run behind it.
 	if (row.kind === "session") return `session:${row.items[0].id}`;
+	// Its own prefix rather than the first call's `item:` key: the two would otherwise be one string
+	// in the window's shared `expanded` set, and a run could not be opened without opening that call.
+	if (row.kind === "tools") return `tools:${row.calls[0].id}`;
 	return row.kind;
 };
 
@@ -257,6 +283,67 @@ const pushSession = (rows: Array<ChatRow>, item: SystemItem): void => {
 };
 
 /**
+ * The call this row is, when it is one a run may absorb.
+ *
+ * A **spawning** call is not one, and that is the whole of the exclusion: it carries a fold of its
+ * own — a second disclosure, its `aria-expanded`, and the nested rows it reveals (#8027/#8057) —
+ * which a sentence has no room for, so it stays the tool row it was and breaks the run around it.
+ * T3 excludes its `agentSpawn` entries the same way. A call whose worker rows are in this list says
+ * so in `nestedIds`; one whose rows left the window entirely says so by holding a subagent slot,
+ * and neither reading covers the other.
+ *
+ * Every other row kind answers `null`, which is what makes a compaction boundary, a session notice,
+ * a reply, a thought and the operator's own turn each break a run just by sitting between two calls.
+ */
+const runCall = (row: ChatRow, subagents: ReadonlySet<string>): ToolCall | null => {
+	if (row.kind !== "item" || row.item.kind !== "tool") return null;
+	if (row.nestedIds.length > 0 || subagents.has(row.item.id)) return null;
+	return row.item;
+};
+
+/**
+ * Collapse each maximal span of consecutive absorbable tool calls **at one depth** into a single
+ * row (#8612). A depth change ends a span, so an open fold never reads as one sentence spanning the
+ * agent's calls and its worker's.
+ *
+ * A span of one is left exactly as it was — see `ToolRun`.
+ */
+const collapseToolRuns = (
+	rows: ReadonlyArray<ChatRow>,
+	subagents: ReadonlySet<string>,
+): ReadonlyArray<ChatRow> => {
+	const out: Array<ChatRow> = [];
+	let run: Array<{readonly row: ChatRow; readonly call: ToolCall; readonly depth: number}> = [];
+	const flush = (): void => {
+		const [first, second, ...rest] = run;
+		run = [];
+		if (first === undefined) return;
+		if (second === undefined) {
+			out.push(first.row);
+			return;
+		}
+		out.push({
+			kind: "tools",
+			calls: [first.call, second.call, ...rest.map((entry) => entry.call)],
+			nested: first.depth > 0,
+			depth: first.depth,
+		});
+	};
+	for (const row of rows) {
+		const call = runCall(row, subagents);
+		if (call === null || row.kind !== "item") {
+			flush();
+			out.push(row);
+			continue;
+		}
+		if (run[0] !== undefined && run[0].depth !== row.depth) flush();
+		run.push({row, call, depth: row.depth});
+	}
+	flush();
+	return out;
+};
+
+/**
  * The list the window renders. The tail wins on a collision: an item that reached the live stream is
  * the newer copy of itself, and a page that happens to overlap the tail must not double it. The
  * collision is `unheld`'s — id, then text against a turn the tail still holds as `local` — so the
@@ -334,7 +421,7 @@ export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	for (const item of items) {
 		if (!reachable.has(item.id)) emit(item, 1);
 	}
-	return rows;
+	return collapseToolRuns(rows, subagents);
 };
 
 /**
@@ -363,6 +450,7 @@ export const oldestLoadedId = (rows: ReadonlyArray<ChatRow>): string | null => {
 	for (const row of rows) {
 		if (row.kind === "item") return row.item.id;
 		if (row.kind === "session") return row.items[0].id;
+		if (row.kind === "tools") return row.calls[0].id;
 	}
 	return null;
 };
@@ -376,16 +464,18 @@ export const olderPageRequest = (
 	const items = rows.flatMap((row): ReadonlyArray<TranscriptItem> => {
 		if (row.kind === "item") return [row.item];
 		if (row.kind === "session") return row.items;
+		if (row.kind === "tools") return row.calls;
 		return [];
 	});
 	const cursor = pageCursor(items, anchor);
 	return cursor.kind === "page" && cursor.before !== null ? {before: cursor.before, anchor} : null;
 };
 
-/** Membership rather than the row's key: an anchor may name a notice buried mid-run. */
+/** Membership rather than the row's key: an anchor may name a notice or a call buried mid-run. */
 const holds = (row: ChatRow, id: string): boolean => {
 	if (row.kind === "item") return row.item.id === id;
 	if (row.kind === "session") return row.items.some((item) => item.id === id);
+	if (row.kind === "tools") return row.calls.some((call) => call.id === id);
 	return false;
 };
 

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -12,6 +12,7 @@ import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
 import {
 	assistantItem,
 	call,
+	compactionItem,
 	systemItem,
 	thinkingItem,
 	toolItem,
@@ -47,6 +48,14 @@ const stored = <Item extends TranscriptItem>(item: Item, position: number): Item
 
 const itemIds = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<string> =>
 	rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []));
+
+/** Every transcript item a row carries, in list order — a run's calls included (#8612). */
+const carriedIds = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<string> =>
+	rows.flatMap((row) => {
+		if (row.kind === "item") return [row.item.id];
+		if (row.kind === "tools") return row.calls.map((call) => call.id);
+		return [];
+	});
 
 describe("chatRows", () => {
 	it("puts one head row above the transcript while there is history behind it", () => {
@@ -136,15 +145,13 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 			atOldest: true,
 			unfolded: new Set(["agent"]),
 		});
-		expect(rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []))).toEqual([
-			"agent",
-			"child-1",
-			"child-2",
-			"own",
-		]);
-		expect(rows.flatMap((row) => (row.kind === "item" && row.nested ? [row.item.id] : []))).toEqual(
-			["child-1", "child-2"],
-		);
+		expect(carriedIds(rows)).toEqual(["agent", "child-1", "child-2", "own"]);
+		// The two worker calls are consecutive at one depth, so they are one run (#8612) — and the
+		// run is marked nested, which is what the indent and the spoken author name both read.
+		const run = rows[1];
+		expect(run?.kind).toBe("tools");
+		expect(run?.kind === "tools" && run.nested).toBe(true);
+		expect(run?.kind === "tools" && run.depth).toBe(1);
 	});
 
 	it("leaves a row whose parent is not loaded in place, marked nested and heading nothing", () => {
@@ -227,12 +234,13 @@ describe("chatRows folds a subagent's calls under the call that spawned it", () 
 		]);
 	});
 
-	it("leaves a transcript with no parent marked on it exactly as it was", () => {
-		const flat = [call("a"), call("b")];
+	it("leaves a transcript with no parent marked on it unnested, at depth zero", () => {
+		const flat = [call("a"), assistantItem("mid", "thinking about it"), call("b")];
 		const rows = chatRows({...base, tail: flat, atOldest: true});
 		expect(rows).toEqual([
 			{kind: "item", item: flat[0], nestedIds: [], nested: false, depth: 0},
 			{kind: "item", item: flat[1], nestedIds: [], nested: false, depth: 0},
+			{kind: "item", item: flat[2], nestedIds: [], nested: false, depth: 0},
 		]);
 	});
 });
@@ -519,7 +527,7 @@ describe("a live tail carrying an exchange the bounds cannot hold", () => {
 			loading: false,
 			atOldest: true,
 		});
-		const ids = rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []));
+		const ids = carriedIds(rows);
 		expect(ids).toEqual(history.map((item) => item.id));
 		expect(new Set(ids).size).toBe(ids.length);
 	});
@@ -704,5 +712,138 @@ describe("subagentRows", () => {
 		const open = subagentRows(slot, new Set(["t1"]));
 		expect(itemIds(open)).toEqual(["t1", "nested"]);
 		expect(open[1]?.kind === "item" && open[1].depth).toBe(1);
+	});
+});
+
+/**
+ * The run scan (#8612). Six reads are one line saying "Read 6 files", not six labelled blocks — so
+ * what has to be proven here is where a run *ends*, because a boundary the scan misses is two
+ * unrelated stretches of work read as one sentence.
+ */
+describe("chatRows collapses a run of consecutive tool calls", () => {
+	const runAt = (rows: ReadonlyArray<ChatRow>, index: number) => {
+		const row = rows[index];
+		return row?.kind === "tools" ? row.calls.map((item) => item.id) : null;
+	};
+
+	it("groups a maximal span into one row carrying the calls in order", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [userItem("u", "go"), call("t1"), call("t2"), call("t3"), assistantItem("a", "done")],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "tools", "item"]);
+		expect(runAt(rows, 1)).toEqual(["t1", "t2", "t3"]);
+	});
+
+	it("leaves a span of one as the tool row it was, disclosure and all", () => {
+		const rows = chatRows({...base, atOldest: true, tail: [call("t1"), assistantItem("a")]});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "item"]);
+	});
+
+	it("breaks on a compaction row, so two contexts never read as one run", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [call("t1"), call("t2"), compactionItem("c1"), call("t3"), call("t4")],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["tools", "item", "tools"]);
+		expect(runAt(rows, 0)).toEqual(["t1", "t2"]);
+		expect(runAt(rows, 2)).toEqual(["t3", "t4"]);
+	});
+
+	it("breaks on a session notice, which keeps its own row untouched", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [call("t1"), call("t2"), systemItem("s1"), call("t3"), call("t4")],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["tools", "session", "tools"]);
+	});
+
+	it("breaks on a spawning call, and never absorbs one", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				call("t1"),
+				call("t2"),
+				call("agent", {name: "Agent"}),
+				call("child", {parentId: "agent"}),
+				call("t3"),
+				call("t4"),
+			],
+		});
+		// The spawning call stays an item row: its fold, its `aria-expanded` and the rows it reveals
+		// are a second disclosure a sentence has no room for (#8027/#8057).
+		expect(rows.map((row) => row.kind)).toEqual(["tools", "item", "tools"]);
+		expect(rows[1]?.kind === "item" && rows[1].item.id).toBe("agent");
+		expect(rows[1]?.kind === "item" && rows[1].nestedIds).toEqual(["child"]);
+	});
+
+	it("never absorbs a spawning call whose worker rows left the window entirely", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			subagents: new Set(["agent"]),
+			tail: [
+				call("t1"),
+				call("agent", {name: "Agent"}),
+				call("child", {parentId: "agent"}),
+				call("t2"),
+			],
+		});
+		// With the worker's rows gone the call heads nothing, so the slot is the only thing left
+		// saying it spawned — and the scan has to read that rather than the now-empty `nestedIds`.
+		expect(carriedIds(rows)).toEqual(["t1", "agent", "t2"]);
+		expect(rows.every((row) => row.kind === "item")).toBe(true);
+	});
+
+	it("breaks on a reply, a thought and the operator's own turn between calls", () => {
+		for (const between of [assistantItem("a", "done"), thinkingItem("th"), userItem("u", "go")]) {
+			const rows = chatRows({
+				...base,
+				atOldest: true,
+				tail: [call("t1"), call("t2"), between, call("t3"), call("t4")],
+			});
+			expect(rows.map((row) => row.kind)).toEqual(["tools", "item", "tools"]);
+		}
+	});
+
+	it("breaks on a depth change, so a worker's calls and the agent's are two runs", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			unfolded: new Set(["agent"]),
+			tail: [
+				call("agent", {name: "Agent"}),
+				call("child-1", {parentId: "agent"}),
+				call("child-2", {parentId: "agent"}),
+				call("own-1"),
+				call("own-2"),
+			],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "tools", "tools"]);
+		expect(rows[1]?.kind === "tools" && rows[1].depth).toBe(1);
+		expect(rows[2]?.kind === "tools" && rows[2].depth).toBe(0);
+	});
+
+	it("keys the run apart from every call's own row id, so one `expanded` set holds both", () => {
+		const first = call("t1");
+		const calls = [first, call("t2")];
+		const rows = chatRows({...base, atOldest: true, tail: calls});
+		const key = rowKey(rows[0] as ChatRow);
+		expect(key).toBe("tools:t1");
+		expect(key).not.toBe(
+			rowKey({kind: "item", item: first, nestedIds: [], nested: false, depth: 0}),
+		);
+		expect(calls.map((item) => String(item.id))).not.toContain(key);
+	});
+
+	it("carries the page cursor and the prepend anchor like any other row", () => {
+		const rows = chatRows({...base, atOldest: true, tail: [call("t1"), call("t2")]});
+		expect(oldestLoadedId(rows)).toBe("t1");
+		// Membership, not the run's key: an anchor may name a call buried mid-run.
+		expect(rowIndexOfItem(rows, "t2")).toBe(0);
 	});
 });

--- a/apps/tuval/src/shell/chat/tool-detail.ts
+++ b/apps/tuval/src/shell/chat/tool-detail.ts
@@ -84,19 +84,62 @@ export const diffLines = (before: string, after: string): ReadonlyArray<DiffLine
 	return rows;
 };
 
-/** What the expanded row shows for one call. Total: every input has a rendering. */
-export const toolDetail = (item: ToolItem): ToolDetail => {
+/**
+ * What one call did, read off its input alone. The four actions are what a run of calls is counted
+ * and spoken in (`tool-run.ts`), and they carry the strings the reading found rather than a flag
+ * beside them, so nothing downstream has to probe the input a second time and reach a different
+ * answer.
+ *
+ * `other` is the honest end of the ladder: a shape this file does not recognise says only that a
+ * tool ran. It is never guessed into one of the other three.
+ */
+export type ToolShape =
+	| {
+			readonly action: "edit";
+			readonly path: string;
+			readonly before: string;
+			readonly after: string;
+	  }
+	| {readonly action: "read"; readonly path: string}
+	| {readonly action: "command"; readonly command: string}
+	| {readonly action: "other"};
+
+export type ToolAction = ToolShape["action"];
+
+/**
+ * The one shape probe. The order is the precedence: an edit is a path plus both texts, a shell call
+ * is a command, and a bare path with neither is a read — so a call carrying a path *and* a command
+ * reads as the command it ran, as it did before this was a named answer.
+ */
+export const toolShape = (item: ToolItem): ToolShape => {
 	const input = item.input;
-	if (!isRecord(input)) return {kind: "generic", input: JSON.stringify(input) ?? "null"};
+	if (!isRecord(input)) return {action: "other"};
 	const path = stringAt(input, PATH_KEYS);
 	const before = stringAt(input, OLD_KEYS);
 	const after = stringAt(input, NEW_KEYS);
 	if (path !== null && before !== null && after !== null) {
-		return {kind: "edit", path, diff: diffLines(before, after)};
+		return {action: "edit", path, before, after};
 	}
 	const command = stringAt(input, COMMAND_KEYS);
-	if (command !== null) return {kind: "shell", command};
-	return {kind: "generic", input: JSON.stringify(input, null, 2) ?? "null"};
+	if (command !== null) return {action: "command", command};
+	return path === null ? {action: "other"} : {action: "read", path};
+};
+
+/**
+ * The raw input a generic row falls back to. A record is pretty-printed and anything else is not:
+ * an array or a bare string has no keys to lay out, and indenting one only spreads it down the row.
+ */
+const rawInput = (input: JsonValue): string =>
+	(isRecord(input) ? JSON.stringify(input, null, 2) : JSON.stringify(input)) ?? "null";
+
+/** What the expanded row shows for one call. Total: every input has a rendering. */
+export const toolDetail = (item: ToolItem): ToolDetail => {
+	const shape = toolShape(item);
+	if (shape.action === "edit") {
+		return {kind: "edit", path: shape.path, diff: diffLines(shape.before, shape.after)};
+	}
+	if (shape.action === "command") return {kind: "shell", command: shape.command};
+	return {kind: "generic", input: rawInput(item.input)};
 };
 
 /** The omission line an expanded row shows when the per-item bound cut the result. */

--- a/apps/tuval/src/shell/chat/tool-run.ts
+++ b/apps/tuval/src/shell/chat/tool-run.ts
@@ -1,0 +1,86 @@
+/**
+ * A run of consecutive tool calls as one sentence, in the tool's own words — "Read 3 files",
+ * "Ran 2 commands and changed 1 file".
+ *
+ * The grammar is T3 Code's, read at pingdotgg/t3code `0fe4c99`
+ * (`packages/client-runtime/src/work-log/presentation.ts:487-563`): bucket the calls by action in
+ * first-seen order, one clause per bucket, then join — one clause as it stands, two as "A and b",
+ * three or more as "A, b, and c", with every clause after the first lowercased at its first
+ * character so the line reads as one sentence rather than a list of headings.
+ *
+ * Two things this deliberately does not do. It never names a target: the line says how many files
+ * were read, never which, because the argument belongs to the call's own disclosure and a summary
+ * that guessed one would be a fictional tool argument. And it reads the action off the call's input
+ * *shape* (`tool-detail.ts`'s `toolShape`), never off the tool's name, which is what serves Pi's
+ * `edit_file` and the SDK's `Edit` from one code path.
+ */
+
+import type {ToolItem, ToolStatus} from "../../ai-agent/ports/index.ts";
+import {type ToolAction, toolShape} from "./tool-detail.ts";
+
+const clause: Readonly<Record<ToolAction, (count: number) => string>> = {
+	read: (count) => `Read ${count} ${count === 1 ? "file" : "files"}`,
+	edit: (count) => `Changed ${count} ${count === 1 ? "file" : "files"}`,
+	command: (count) => `Ran ${count} ${count === 1 ? "command" : "commands"}`,
+	other: (count) => `Used ${count} ${count === 1 ? "tool" : "tools"}`,
+};
+
+/**
+ * What one bucket counts. Edits count **distinct files** — three edits to one file changed one file
+ * — so the bucket carries the paths as well as the calls, and `count` reads whichever the action
+ * asks for.
+ */
+interface Bucket {
+	calls: number;
+	readonly paths: Set<string>;
+}
+
+/** The buckets in first-seen order. A `Map` keeps insertion order, and re-setting a key never moves it. */
+const bucketed = (calls: ReadonlyArray<ToolItem>): ReadonlyMap<ToolAction, Bucket> => {
+	const buckets = new Map<ToolAction, Bucket>();
+	for (const item of calls) {
+		const shape = toolShape(item);
+		const bucket = buckets.get(shape.action) ?? {calls: 0, paths: new Set<string>()};
+		bucket.calls += 1;
+		if (shape.action === "edit") bucket.paths.add(shape.path);
+		buckets.set(shape.action, bucket);
+	}
+	return buckets;
+};
+
+/** Join the clauses into one sentence, lowercasing every clause after the first. */
+const sentence = (clauses: ReadonlyArray<string>): string => {
+	const joined = clauses.map((text, index) =>
+		index === 0 ? text : text.charAt(0).toLowerCase() + text.slice(1),
+	);
+	if (joined.length < 2) return joined[0] ?? "";
+	if (joined.length === 2) return joined.join(" and ");
+	return `${joined.slice(0, -1).join(", ")}, and ${joined[joined.length - 1]}`;
+};
+
+/** The run's whole line. Empty only for an empty run, which the row type cannot hold. */
+export const runSentence = (calls: ReadonlyArray<ToolItem>): string =>
+	sentence(
+		[...bucketed(calls)].map(([action, bucket]) =>
+			clause[action](action === "edit" ? bucket.paths.size : bucket.calls),
+		),
+	);
+
+/**
+ * The run's status: a failure anywhere is the run's, and a call still going outranks a settled one.
+ * A run never hides a failure behind the calls that succeeded around it.
+ */
+export const runStatus = (calls: ReadonlyArray<ToolItem>): ToolStatus => {
+	if (calls.some((call) => call.status === "error")) return "error";
+	return calls.some((call) => call.status === "running") ? "running" : "ok";
+};
+
+/**
+ * The status as a word beside the sentence, or nothing at all for a run that simply finished.
+ * Pillar 4: this is what carries the state, so neither the dot's tint nor the shimmer is ever the
+ * only signal — and a reader who asked for no motion still reads "running".
+ */
+export const runStatusWord = (status: ToolStatus): string | null => {
+	if (status === "error") return "failed";
+	return status === "running" ? "running" : null;
+};

--- a/apps/tuval/src/shell/chat/tool-run.unit.test.ts
+++ b/apps/tuval/src/shell/chat/tool-run.unit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The run's sentence, with no DOM: bucketing, counting, and the join.
+ *
+ * The grammar is T3 Code's, so the cases below are the ones its own composer distinguishes — one
+ * clause, two, three or more, and the distinct-file count an edit bucket carries.
+ */
+
+import {describe, expect, it} from "vitest";
+import type {JsonValue, ToolItem, ToolStatus} from "../../ai-agent/ports/index.ts";
+import {boundToolResult, ItemId} from "../../ai-agent/ports/index.ts";
+import {runSentence, runStatus, runStatusWord} from "./tool-run.ts";
+
+let next = 0;
+const nextId = (): string => {
+	next += 1;
+	return `t${next}`;
+};
+
+const call = (input: JsonValue, status: ToolStatus = "ok"): ToolItem => ({
+	kind: "tool",
+	id: ItemId.make(nextId()),
+	timestamp: 1,
+	name: "whatever_the_backend_called_it",
+	input,
+	result: boundToolResult("done"),
+	status,
+});
+
+const read = (path: string) => call({file_path: path});
+const edit = (path: string) => call({path, old_string: "one", new_string: "two"});
+const command = (line: string) => call({command: line});
+
+describe("runSentence", () => {
+	it("says one clause as it stands", () => {
+		expect(runSentence([read("a.ts"), read("b.ts"), read("c.ts")])).toBe("Read 3 files");
+		expect(runSentence([command("ls"), command("pwd")])).toBe("Ran 2 commands");
+	});
+
+	it("singularizes a bucket of one", () => {
+		expect(runSentence([read("a.ts"), command("ls")])).toBe("Read 1 file and ran 1 command");
+	});
+
+	it("joins two clauses with `and`, lowercasing the second", () => {
+		expect(runSentence([read("a.ts"), read("b.ts"), command("ls")])).toBe(
+			"Read 2 files and ran 1 command",
+		);
+	});
+
+	it("joins three or more with commas and a final `and`, lowercasing every clause after the first", () => {
+		const line = runSentence([read("a.ts"), edit("b.ts"), command("ls"), call({pattern: "TODO"})]);
+		expect(line).toBe("Read 1 file, changed 1 file, ran 1 command, and used 1 tool");
+	});
+
+	it("buckets in first-seen order, not in the order the clauses are declared", () => {
+		expect(runSentence([command("ls"), read("a.ts")])).toBe("Ran 1 command and read 1 file");
+	});
+
+	// Three edits to one file changed one file, which is what a reader counts.
+	it("counts distinct files for edits, and calls for everything else", () => {
+		expect(runSentence([edit("a.ts"), edit("a.ts"), edit("a.ts")])).toBe("Changed 1 file");
+		expect(runSentence([edit("a.ts"), edit("b.ts"), edit("a.ts")])).toBe("Changed 2 files");
+		// A read is a call, not a file: the same file read twice is two reads.
+		expect(runSentence([read("a.ts"), read("a.ts")])).toBe("Read 2 files");
+	});
+
+	it("falls into the generic clause for a shape it does not recognise, inventing no target", () => {
+		const line = runSentence([call({pattern: "TODO", glob: "**/*.ts"}), call(null)]);
+		expect(line).toBe("Used 2 tools");
+		expect(line).not.toContain("TODO");
+	});
+
+	it("reads the action off the input shape, whatever the tool is called", () => {
+		expect(runSentence([call({filePath: "a.ts"}), call({cmd: "pwd"})])).toBe(
+			"Read 1 file and ran 1 command",
+		);
+	});
+});
+
+describe("runStatus", () => {
+	it("carries a failure out of the run rather than hiding it behind the calls that worked", () => {
+		expect(runStatus([read("a.ts"), call({file_path: "b.ts"}, "error")])).toBe("error");
+		// A failure outranks a call still in flight, so a run never settles into `running` on one.
+		expect(runStatus([call({file_path: "a.ts"}, "running"), call({cmd: "ls"}, "error")])).toBe(
+			"error",
+		);
+	});
+
+	it("is running while any call is, and ok only when every one of them settled", () => {
+		expect(runStatus([read("a.ts"), call({file_path: "b.ts"}, "running")])).toBe("running");
+		expect(runStatus([read("a.ts"), read("b.ts")])).toBe("ok");
+	});
+});
+
+describe("runStatusWord", () => {
+	it("names the two states that are not simply finished, and says nothing about the one that is", () => {
+		expect(runStatusWord("error")).toBe("failed");
+		expect(runStatusWord("running")).toBe("running");
+		expect(runStatusWord("ok")).toBeNull();
+	});
+});


### PR DESCRIPTION
A run of consecutive tool calls now renders as one sentence-shaped row instead of one labelled
block per call. Six reads were roughly eighteen lines saying `read ok` six times; they are now one
line saying "Read 6 files".

Three pieces:

- **The scan** (`rows.ts`). A new `tools` row kind holds a maximal span of consecutive tool calls at
  one depth, in order. The span breaks on a compaction row, a session notice, a spawning call, any
  reply/thought/prompt between calls, and a depth change. A span of one is left as the tool row it
  was — the `ToolRun` type says so by requiring two elements — so a lone call keeps its name and its
  disclosure. The row keys on `tools:<first call id>`, its own prefix, so it cannot collide with a
  call's `item:` key in the window's shared `expanded` set.
- **The sentence** (`tool-run.ts`, beside `tool-detail.ts`). T3 Code's grammar, read at
  pingdotgg/t3code `0fe4c99` (`packages/client-runtime/src/work-log/presentation.ts:487-563`):
  bucket by action in first-seen order, one clause per bucket (`Read N file(s)` / `Changed N file(s)`
  / `Ran N command(s)` / `Used N tool(s)`), join as one, "A and b", or "A, b, and c" with later
  clauses lowercased. Edits count distinct files. The action is read off the call's **input shape**
  through a new `toolShape` in `tool-detail.ts` — the same probe `toolDetail` now runs, so the two
  cannot drift — never off the tool's name, and an unrecognised shape falls into the generic clause
  rather than being guessed at.
- **The row** (`ToolRunRow.tsx`, `chat.css`). A status dot, the sentence, and the status as a word
  when the run failed or is still going. The dot is `aria-hidden` and the word is what carries the
  state, so neither the tint nor the running shimmer is ever the only signal; the shimmer is
  cancelled under `prefers-reduced-motion` and the word survives that collapse.

A failure does not break a run — it is carried out of the run as the run's own status and said in
words, which is the arm of the issue's "either the failing call breaks the run or the run says it
failed in words".

Opening a run to read one call is #8613, not this slice.

Three existing tests had fixtures with two consecutive calls, which now collapse; each was given a
row between the calls (or re-pointed at the run's sentence) so it still tests what it was written to
test.

Fixes #8612

## Deviations

- **Scope narrowing** — **Said:** criterion 1 reads "groups maximal spans of consecutive `tool`
  rows", which taken literally includes a span of one. **Did:** a span of one is left as the
  `ToolRow` it was; only two or more collapse, and `ToolRun` makes a one-element run
  unrepresentable. **Why:** collapsing a lone call spends its name and its whole disclosure to print
  "Read 1 file", with no compression won and no way back in until #8613 lands.
  **Disposition:** stated here.
- **Scope narrowing** — **Said:** "render that sentence as one line with a leading icon."
  **Did:** the leading mark is a tinted dot, not a drawn icon. **Why:** the design manifest's icon
  idiom requires a Lucide glyph for a functional icon, and Tuval has no Lucide dependency — adding
  one is a catalog change outside this issue. The dot is a state marker under the manifest's
  four-way partition: `aria-hidden`, paired with the status word, never in the accessible name, and
  it matches the sheet's existing `.tuval-chat-phase-dot`. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names `rows.ts`, a new module beside
  `tool-detail.ts`, and the render files. **Did:** also refactored `toolDetail` itself onto the new
  `toolShape` probe. **Why:** the sentence needs the same input-shape reading `toolDetail` already
  does, and a second copy of that precedence table is a drift the tests could not catch.
  **Disposition:** stated here; `tool-detail.unit.test.ts` is unchanged and still green, which is
  the proof the refactor is behaviour-preserving.
