### PR TITLE
fix: Subagent list: focus falls to the body when the region unmounts on the way back to main

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -563,10 +563,28 @@ function ChatWindow({
 		},
 		[commit, settleScroll],
 	);
+	/**
+	 * Where focus goes when the operator leaves a worker's view (founder ruling 2026-09-08 on
+	 * #8470, the Claude Code model): the composer, always. The navigator cannot hold it — the way
+	 * back is gone with the view, and the last finished worker takes the whole region with it — so
+	 * the destination has to be a control the window keeps, and the composer is the one an operator
+	 * leaving a transcript is on their way to anyway.
+	 */
+	const composerRef = useRef<HTMLTextAreaElement>(null);
+	const [leaving, setLeaving] = useState(false);
 	const showMain = useCallback(() => {
 		settleScroll();
+		setLeaving(true);
 		commit(viewMain);
 	}, [commit, settleScroll]);
+	// Placed from here rather than from the click, because the composer is `disabled` while a view
+	// is open (#8466) and a disabled field takes no focus. Both writes above land in one render, so
+	// by the time this runs the field is enabled and the region that held focus has already gone.
+	useLayoutEffect(() => {
+		if (!leaving || viewing !== null) return;
+		setLeaving(false);
+		composerRef.current?.focus();
+	}, [leaving, viewing]);
 
 	/**
 	 * `<c-b> a`, arriving as the key that chord's command row mints (`../commands/table.ts`). The
@@ -1112,6 +1130,7 @@ function ChatWindow({
 					onDiscard={discardSend}
 				/>
 				<AgentChatInput
+					ref={composerRef}
 					variant="focused"
 					bridge={composer.bridge}
 					// Founder ruling on #8466: while the view slot shows a subagent the composer is

--- a/apps/tuval/src/shell/chat/SubagentList.tsx
+++ b/apps/tuval/src/shell/chat/SubagentList.tsx
@@ -207,10 +207,14 @@ export function SubagentList({
 	}, [running]);
 
 	/**
-	 * A line that took the focus and then removed itself — the way back, the "more" row — would drop
-	 * focus onto the body, which is where a keyboard operator loses the list entirely. So an
-	 * activation that changes the entries names where focus goes next, and this places it once the
-	 * new entries are drawn.
+	 * A line that took the focus and then removed itself — the "more" row — would drop focus onto
+	 * the body, which is where a keyboard operator loses the list entirely. So an activation that
+	 * changes the entries names where focus goes next, and this places it once the new entries are
+	 * drawn.
+	 *
+	 * The way back is not one of them any more: leaving a view can take the whole region with it
+	 * (the last finished worker), so its destination is the window's composer and the window places
+	 * it (`ChatWindow.tsx`, founder ruling 2026-09-08 on #8470).
 	 */
 	useLayoutEffect(() => {
 		if (request === null) return;
@@ -225,11 +229,6 @@ export function SubagentList({
 		},
 		[onView],
 	);
-
-	const pickMain = useCallback(() => {
-		setRequest({kind: "first"});
-		onMain();
-	}, [onMain]);
 
 	const expand = useCallback(() => {
 		const first = runningSubagents(slots, viewing, Number.POSITIVE_INFINITY).rows[SUBAGENT_ROW_CAP];
@@ -268,12 +267,12 @@ export function SubagentList({
 					if (viewing === null) return;
 					event.preventDefault();
 					event.stopPropagation();
-					return pickMain();
+					return onMain();
 				default:
 					return;
 			}
 		},
-		[keys, moveTo, pickMain, stop, viewing],
+		[keys, moveTo, onMain, stop, viewing],
 	);
 
 	// A subagent view always draws the region, even with nothing to list: the way back is in it, and
@@ -297,7 +296,7 @@ export function SubagentList({
 							entryKey={entry.key}
 							stop={stop === entry.key}
 							register={register}
-							onPick={pickMain}
+							onPick={onMain}
 						>
 							<MetaRow as="span" className="tuval-chat-subagent">
 								Back to the agent transcript

--- a/apps/tuval/src/shell/chat/subagent-navigator.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-navigator.unit.test.tsx
@@ -82,6 +82,13 @@ const openWindow = async (
 };
 
 const active = (): HTMLElement => document.activeElement as HTMLElement;
+/** Re-read on every use: Manti owns the field, so a case asserting across a swap would hold a
+ * node React has since replaced. */
+const composer = (): HTMLTextAreaElement => {
+	const found = document.querySelector<HTMLTextAreaElement>("textarea");
+	expect(found, "no composer field").toBeTruthy();
+	return found as HTMLTextAreaElement;
+};
 const rows = (): ReadonlyArray<HTMLButtonElement> =>
 	Array.from(
 		document.querySelectorAll<HTMLButtonElement>(
@@ -152,7 +159,7 @@ describe("<c-b> a and the list it lands in", () => {
 		rendered.unmount();
 	});
 
-	it("comes back to main from the way-back row, and leaves focus in the list", async () => {
+	it("comes back to main from the way-back row, and leaves focus on the composer", async () => {
 		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
 		await chord();
 		await click(active());
@@ -162,13 +169,15 @@ describe("<c-b> a and the list it lands in", () => {
 		await click(back);
 
 		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
-		// The row that took the click is gone with the view it left, so focus would have fallen to
-		// the body — where a keyboard operator loses the list altogether.
-		expect(active()).toBe(rows()[0]);
+		// The navigator survives here — two workers are still running — and focus still leaves it:
+		// the destination is the composer whether or not the list outlives the view.
+		expect(rows()).toHaveLength(2);
+		expect(composer().disabled).toBe(false);
+		expect(active()).toBe(composer());
 		rendered.unmount();
 	});
 
-	it("comes back to main on Escape from inside a subagent view", async () => {
+	it("comes back to main on Escape from inside a subagent view, onto the composer", async () => {
 		const {rendered, chord} = await openWindow(twoRunning(), {subagentList: true});
 		await chord();
 		await click(active());
@@ -176,6 +185,8 @@ describe("<c-b> a and the list it lands in", () => {
 
 		await press("Escape");
 		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
+		expect(composer().disabled).toBe(false);
+		expect(active()).toBe(composer());
 		rendered.unmount();
 	});
 
@@ -211,6 +222,58 @@ describe("<c-b> a and the list it lands in", () => {
 		expect(rows()).toHaveLength(8);
 		expect(screen.queryByRole("button", {name: /more running$/})).toBeNull();
 		expect(active()).toBe(rows()[SUBAGENT_ROW_CAP]);
+		rendered.unmount();
+	});
+});
+
+/**
+ * The path where the region itself goes: the only worker finishes under its own open view, so
+ * leaving lands on a window with no navigator at all. Before the founder's 2026-09-08 ruling on
+ * #8470 the list asked for its own first line here and there was none, which put focus on the body.
+ */
+describe("leaving the last finished worker", () => {
+	/** One worker, so main has nothing to list once it has stopped. */
+	const one = (status: SubagentSlot["status"]): AiAgentSessionState =>
+		withTranscript([userItem("u1", "go"), call("agent", {name: "Agent"})], {
+			subagents: slots(subagentSlot("agent", {type: "reviewer", lastLine: "wrote 4 rows", status})),
+		});
+
+	const openFinished = async () => {
+		const opened = await openWindow(one("running"), {subagentList: true});
+		await opened.chord();
+		await click(active());
+		await act(async () => {
+			await Effect.runPromise(opened.process.commit(one("finished")));
+		});
+		// Q9 on #8384, unchanged: the view it finished under stays open until the operator leaves.
+		expect(screen.getByRole("log", {name: "Transcript: reviewer subagent"})).toBeTruthy();
+		expect(composer().disabled).toBe(true);
+		return opened;
+	};
+
+	it("lands on the composer when Escape is the way out", async () => {
+		const {rendered} = await openFinished();
+
+		await press("Escape");
+
+		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
+		expect(document.querySelector(".tuval-chat-subagents")).toBeNull();
+		expect(composer().disabled).toBe(false);
+		expect(active()).toBe(composer());
+		rendered.unmount();
+	});
+
+	it("lands on the composer when the back button is the way out", async () => {
+		const {rendered} = await openFinished();
+
+		const back = rows()[0] as HTMLButtonElement;
+		expect(back.textContent).toBe("Back to the agent transcript");
+		await click(back);
+
+		expect(screen.getByRole("log", {name: "Transcript"})).toBeTruthy();
+		expect(document.querySelector(".tuval-chat-subagents")).toBeNull();
+		expect(composer().disabled).toBe(false);
+		expect(active()).toBe(composer());
 		rendered.unmount();
 	});
 });

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -22,6 +22,7 @@ import {
 	type ClipboardEvent,
 	type KeyboardEvent,
 	type ReactNode,
+	type Ref,
 	useEffect,
 	useId,
 	useMemo,
@@ -401,6 +402,11 @@ export interface AgentChatInputProps {
 	 * pickers rather than as a foreign control wedged beside them.
 	 */
 	readonly settings?: ReactNode;
+	/**
+	 * The prompt field itself, for a host that has to place DOM focus on it — the composer is the
+	 * only control here a host can be asked to focus, so the ref is the field and not a handle.
+	 */
+	readonly ref?: Ref<HTMLTextAreaElement>;
 }
 
 export function AgentChatInput({
@@ -411,6 +417,7 @@ export function AgentChatInput({
 	mockWhenUnavailable = false,
 	onDraftChange,
 	settings,
+	ref,
 }: AgentChatInputProps) {
 	const activeBridge = bridge ?? unavailableBridge;
 	const t = useDesignT();
@@ -1069,6 +1076,7 @@ export function AgentChatInput({
 
 					<div className="kp-agent-chat__field">
 						<Textarea
+							ref={ref}
 							id={inputId}
 							className="kp-agent-chat__textarea"
 							role="combobox"


### PR DESCRIPTION
Leaving a subagent view now puts DOM focus on the composer, every time.

Before this, `SubagentList` asked for its own first line on the way back. When the only worker had
finished, main had no rows, the whole region unmounted and there was no line to focus — DOM focus
fell to the document body, by Escape and by the back button alike.

The founder ruled the Claude Code model on #8470 (comment 5589657679): nothing auto-returns, and on
leaving, focus lands on the composer. So the destination moved out of the list and into the window.

- `SubagentList` no longer requests focus for the way back; `pickMain` was a one-line wrapper over
  `onMain` and is gone with it. The "more" row still names its own destination, unchanged.
- `ChatWindow.showMain` flags the leave and a layout effect places focus once the commit has landed.
  It runs after the render that re-enables the composer (#8466's `disabled={viewing !== null}`), so
  the field takes the focus rather than refusing it while disabled.
- `AgentChatInput` gained an optional `ref` to its prompt field. The composer is the only control a
  host can be asked to focus, so the ref is the textarea and not a handle.

Four cases in `subagent-navigator.unit.test.tsx`: the last finished worker by Escape and by the back
button (the region gone, composer focused and enabled), and the two-workers-remain path where the
navigator survives and focus still leaves it. The finished-worker setup asserts Q9 on the way — the
view stays open under the worker that finished, until the operator leaves.

Fixes #8470

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8470 names the focus destination on return.
  **Did:** rewrote two standing cases in `subagent-navigator.unit.test.tsx` that asserted focus
  landed back on the list's first row. **Why:** those cases pinned the behaviour the founder's
  ruling replaces; leaving them would have been a red on the ruled outcome.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue's pointers are `SubagentList.tsx` and
  `ChatWindow.tsx`. **Did:** also added an optional `ref` prop to `AgentChatInput` in
  `packages/design`. **Why:** the field's id is a `useId` value and the component exposed no handle,
  so the window had no typed way to reach the textarea; a class-name query from the consumer would
  couple Tuval to a design-package internal. Renders nothing new and changes no default.
  **Disposition:** stated here.
