### PR TITLE
fix: Empty Claude session resumes as session-not-found, contradicting the resume contract #8097 landed

### DIFF
--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -86,6 +86,7 @@ import {
 	noSessionToPage,
 	promptDisconnected,
 	sessionNotFound,
+	startStoreUnreadable,
 	startTransport,
 	startWithoutHandshake,
 	storeUnlistable,
@@ -501,6 +502,25 @@ const make = (
 			});
 
 		/**
+		 * Whether the CLI's store holds a session at all — the pinned existence check, asked only
+		 * where a transcript read came back empty.
+		 *
+		 * At `0.3.259` `getSessionMessages` "returns Array of messages, or empty array if the session
+		 * was not found" (`sdk.d.ts`), so an empty read is two answers in one and settles neither: an
+		 * existing session with no rows and an id nobody stored read the same. `listSessions` is the
+		 * one that distinguishes them — with no options it is the whole store, the same call and the
+		 * same reason as `listSessions` below.
+		 *
+		 * The failure mapper is the caller's because the two callers refuse on different channels —
+		 * `start` owes a `StartError`, the store read a `TranscriptError` — and neither may read a
+		 * store that would not open as a session that is not there (#8131).
+		 */
+		const storeHolds = <E>(sessionId: string, unreadable: (cause: unknown) => E) =>
+			Effect.map(Effect.tryPromise({try: () => sdk.listSessions(), catch: unreadable}), (stored) =>
+				stored.some((info) => info.sessionId === sessionId),
+			);
+
+		/**
 		 * Open the session, and wait for the CLI's connect-time handshake rather than for a message.
 		 *
 		 * Nothing is read off the message iterator here. In streaming-input mode every frame belongs
@@ -519,9 +539,16 @@ const make = (
 					try: () => sdk.getSessionMessages(resume, {dir: cwd}),
 					catch: (cause) => startTransport(cwd, cause),
 				});
-				// "Returns an array of messages, or an empty array if the session was not found"
-				// (`sdk.d.ts`, `getSessionMessages`) — the miss itself, with no error text to scrape.
-				if (rows.length === 0) return yield* sessionNotFound(cwd, resume);
+				// An empty read is not a miss: the pin answers `[]` for a session it does not hold and
+				// for one that is genuinely empty alike, and `ResumeTarget` promises any listed id
+				// resumes. So the store's listing settles it, and only a listing with no such row is
+				// `session-not-found` (#8131).
+				if (
+					rows.length === 0 &&
+					!(yield* storeHolds(resume, (cause) => startStoreUnreadable(cwd, cause)))
+				) {
+					return yield* sessionNotFound(cwd, resume);
+				}
 				const {items} = toHistoryItems(rows, {at: Date.now()});
 				stale.push(...unsettledToolIds(items).filter((id) => !parked.has(id)));
 			}
@@ -885,20 +912,6 @@ const make = (
 		});
 
 		/**
-		 * Whether the CLI's store holds a session at all, asked only where the transcript read came
-		 * back empty. `listSessions` with no options is the whole store, which is the same call
-		 * `listSessions` below makes and the same reason it makes it that way.
-		 */
-		const storeHolds = (sessionId: string) =>
-			Effect.map(
-				Effect.tryPromise({
-					try: () => sdk.listSessions(),
-					catch: (cause) => transcriptUnreadable(sessionId, cause),
-				}),
-				(stored) => stored.some((info) => info.sessionId === sessionId),
-			);
-
-		/**
 		 * `page`'s answer off the store, with no session open (#8233). `getSessionMessages` reads the
 		 * CLI's transcript files directly, so nothing here touches the `query()` this layer's `start`
 		 * owns and the read works on a layer that never opened one.
@@ -913,7 +926,12 @@ const make = (
 			// The pin answers an empty array for a session it does not hold as readily as for one
 			// that is genuinely empty (`refusals.ts`), so the listing settles which of the two this
 			// is rather than the caller reading silence as either.
-			if (rows.length === 0 && !(yield* storeHolds(query.sessionId))) {
+			if (
+				rows.length === 0 &&
+				!(yield* storeHolds(query.sessionId, (cause) =>
+					transcriptUnreadable(query.sessionId, cause),
+				))
+			) {
 				return yield* transcriptSessionNotFound(query.sessionId);
 			}
 			const {items, cursorAliases} = toHistoryItems(rows, {at: Date.now()});

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -250,7 +250,11 @@ export interface ScriptedSdk {
 export interface ScriptedSdkOptions extends ScriptedBehaviour {
 	/** The messages a fresh `query()` puts on its stream, in order. */
 	readonly opening: ReadonlyArray<SDKMessage>;
-	/** What `getSessionMessages` answers. Absent answers an empty session, which is the resume miss. */
+	/**
+	 * What `getSessionMessages` answers. Absent answers an empty array, which at the pin is both an
+	 * existing session with no rows and one the store does not hold — `sessions` is what tells the
+	 * two apart (#8131).
+	 */
 	readonly rows?: ReadonlyArray<SessionMessage>;
 	/** A read that throws instead of answering. */
 	readonly readFails?: Error;

--- a/apps/tuval/src/claude/agent/refusals.ts
+++ b/apps/tuval/src/claude/agent/refusals.ts
@@ -46,11 +46,12 @@ export const logRefused = (what: string, refusal: Error & {readonly detail: stri
 	Effect.logWarning(`${what}: ${refusal.detail}`, refusal.cause);
 
 /**
- * A resume whose session the store does not hold.
+ * A resume whose session the store does not hold — the store's own listing said so.
  *
- * `getSessionMessages` "returns Array of messages, or empty array if session not found"
- * (`sdk.d.ts`), so an empty read for a session the caller named is the miss itself — no error text
- * to scrape, and no `query()` opened against a session that is not there.
+ * Not the empty transcript read: `getSessionMessages` "returns Array of messages, or empty array if
+ * session not found" (`sdk.d.ts`), which is two answers in one, and an existing session with no
+ * message rows is legal to resume (`ai-agent/service/TuvalAiAgent.ts`, `ResumeTarget`). So this is
+ * raised only where `listSessions` holds no row for the id (#8131).
  */
 export const sessionNotFound = (cwd: string, resume: string): StartError =>
 	new StartError({
@@ -58,6 +59,23 @@ export const sessionNotFound = (cwd: string, resume: string): StartError =>
 		cwd,
 		detail: `no session "${resume}" is stored for this working directory`,
 	});
+
+/**
+ * The existence check itself did not answer, so whether the session is there is unknown.
+ *
+ * `transport` rather than `session-not-found`: a store that would not open is not a store that says
+ * the session is absent, and reading it as absence is the failure #8131 closed. `StartReason` has
+ * no store arm, and `transport` is what the sibling read failure at `start` already carries.
+ */
+export const startStoreUnreadable = (cwd: string, cause: unknown): StartError =>
+	retaining(
+		cause,
+		new StartError({
+			reason: "transport",
+			cwd,
+			detail: translated("the Claude Code session store could not be enumerated", cause),
+		}),
+	);
 
 export const startTransport = (cwd: string, cause: unknown): StartError =>
 	retaining(

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -6,7 +6,7 @@
  * layer folds are not something a test may invent.
  */
 
-import type {ModelInfo} from "@anthropic-ai/claude-agent-sdk";
+import type {ModelInfo, SDKSessionInfo} from "@anthropic-ai/claude-agent-sdk";
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit, Logger, Option, Stream} from "effect";
 import {Mode} from "../../ai-agent/ports/index.ts";
@@ -232,6 +232,19 @@ describe("start against a CLI that says nothing until the first prompt", () => {
 	);
 });
 
+/** An id no scripted store below holds, which is the only thing that makes a resume a miss. */
+const ABSENT_SESSION_ID = "00000000-0000-4000-8000-00000000dead";
+
+/** One row of the CLI's store — enough for the existence check, which reads the id alone. */
+const storedSession = (sessionId: string): SDKSessionInfo => ({
+	sessionId,
+	summary: "a session with nothing in it yet",
+	lastModified: 1_760_000_000_000,
+	firstPrompt: "",
+	cwd: CWD,
+	gitBranch: "main",
+});
+
 describe("start on a resume", () => {
 	it.effect("passes the session id through and reads that session's store", () =>
 		on({rows: rows()}, (agent, scripted) =>
@@ -249,10 +262,10 @@ describe("start on a resume", () => {
 	it.effect("refuses a session the store does not hold as SessionNotFound", () =>
 		Effect.gen(function* () {
 			const exit = yield* Effect.exit(
-				on({}, (agent) =>
+				on({sessions: [storedSession(TOOL_SESSION_ID)]}, (agent) =>
 					agent.start({
 						cwd: CWD,
-						resume: {sessionId: "00000000-0000-4000-8000-00000000dead", holdsTranscript: false},
+						resume: {sessionId: ABSENT_SESSION_ID, holdsTranscript: false},
 					}),
 				),
 			);
@@ -261,13 +274,85 @@ describe("start on a resume", () => {
 		}),
 	);
 
+	it.effect("opens an existing session that holds no message rows (#8131)", () =>
+		on({rows: [], sessions: [storedSession(TOOL_SESSION_ID)]}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+				});
+				// The empty read alone said nothing; the listing is what settled that the session is
+				// there, and the query opened under the id the operator picked rather than a new one.
+				assert.deepStrictEqual(scripted.lists, [undefined]);
+				assert.lengthOf(scripted.opened, 1);
+				assert.strictEqual(scripted.opened[0]?.record.options.resume, TOOL_SESSION_ID);
+			}),
+		),
+	);
+
+	it.effect("opens no query for an id the listing does not hold", () =>
+		on({sessions: [storedSession(TOOL_SESSION_ID)]}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* Effect.exit(
+					agent.start({
+						cwd: CWD,
+						resume: {sessionId: ABSENT_SESSION_ID, holdsTranscript: false},
+					}),
+				);
+				assert.lengthOf(scripted.opened, 0);
+			}),
+		),
+	);
+
+	it.effect("keeps a listing that would not answer a transport failure, not an absence", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				on({listFails: new Error("EACCES ~/.claude/projects")}, (agent) =>
+					agent.start({
+						cwd: CWD,
+						resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+					}),
+				),
+			);
+			assert.strictEqual(failure(exit)._tag, "tuval/ai-agent/StartError");
+			assert.strictEqual(failure(exit).reason, "transport");
+		}),
+	);
+
+	it.effect("keeps a transcript read that threw a transport failure, not an absence", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				on({readFails: new Error("EIO")}, (agent) =>
+					agent.start({
+						cwd: CWD,
+						resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+					}),
+				),
+			);
+			assert.strictEqual(failure(exit)._tag, "tuval/ai-agent/StartError");
+			assert.strictEqual(failure(exit).reason, "transport");
+		}),
+	);
+
+	it.effect("asks the store nothing when the transcript read came back with rows", () =>
+		on({rows: rows()}, (agent, scripted) =>
+			Effect.gen(function* () {
+				yield* agent.start({
+					cwd: CWD,
+					resume: {sessionId: TOOL_SESSION_ID, holdsTranscript: false},
+				});
+				assert.deepStrictEqual(scripted.lists, []);
+			}),
+		),
+	);
+
 	it.effect("takes the session down rather than leaving it on starting", () =>
 		on({}, (agent) =>
 			Effect.gen(function* () {
 				yield* Effect.exit(
 					agent.start({
 						cwd: CWD,
-						resume: {sessionId: "00000000-0000-4000-8000-00000000dead", holdsTranscript: false},
+						resume: {sessionId: ABSENT_SESSION_ID, holdsTranscript: false},
 					}),
 				);
 				assert.deepStrictEqual(yield* Stream.runCollect(Stream.take(agent.events, 2)), [


### PR DESCRIPTION
`ClaudeAiAgent.start` read an empty `getSessionMessages` result as `session-not-found`. At the
`0.3.259` pin that read answers `[]` both for a session the store does not hold and for one that is
genuinely empty, so an existing session with no message rows refused to resume — against
`ResumeTarget`'s promise that any id `listSessions` offers is legal to resume.

The store's own listing is now the existence check, which is the same reading `sessionTranscript`
already made for the no-session-open read (#8233). `storeHolds` became the one shared helper for
both, parameterized by the caller's refusal so `start` owes a `StartError` and the store read a
`TranscriptError`.

- An existing-but-empty session resumes under its own id; the query opens with `resume` set, no
  replacement session is minted.
- An id the listing does not hold still fails `StartError({reason: "session-not-found"})`, and no
  `query()` is opened for it.
- A listing that throws is `StartError({reason: "transport"})` via the new `startStoreUnreadable`,
  never absence. `StartReason` has no store arm, and `transport` is what the sibling failing
  transcript read at `start` already carries.
- The listing is only asked when the transcript read came back empty, so an ordinary nonempty
  resume makes no extra store call.

Tests are in `start.unit.test.ts` on the scripted SDK — existing-empty, absent, unreadable listing,
unreadable transcript read, and nonempty. No credentials and no model spend.

## Deviations

- **Out-of-scope change** — **Said:** #8131 names the resume path in `ClaudeAiAgent.start`.
  **Did:** also moved `sessionTranscript`'s existing `storeHolds` onto the shared helper and
  reworded its docblock. **Why:** the two callers now make the same existence check, and two copies
  of it is how one drifts from the other. **Disposition:** stated here; behaviour of
  `sessionTranscript` is unchanged.

Fixes #8131
