### PR TITLE
fix: A Claude local-command-stdout block renders as an operator YOU message in Tuval chat

### DIFF
--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -89,6 +89,8 @@ describe("the Claude history mapping is pure", () => {
 			"informational-notice",
 			"init",
 			"interrupted-assistant",
+			"local-command-lines-turn",
+			"local-command-turn",
 			"oversized-tool-turn",
 			"permission-denied",
 			"resumed-init",

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -6,13 +6,13 @@ and ADR [0180](../../../../../../.decisions/0180-capture-real-runtime-artifact-b
 Nothing here is hand-authored: the SDK's message shapes are observable only at execution, so an
 invented envelope would prove the mapping against a contract nobody emits.
 
-Most of them came off `query()`. Three did not, because no `query()` run can force what they carry;
+Most of them came off `query()`. Five did not, because no `query()` run can force what they carry;
 they were excerpted from an operator's own CLI session log and re-keyed to the SDK's declared
-envelope, and the section below says exactly which part of each is the captured part.
+envelope, and the two sections below say exactly which part of each is the captured part.
 
 ## What produced them
 
-The rows below describe the `query()` captures; the last three fixtures have their own section.
+The rows below describe the `query()` captures; the five excerpted fixtures have their own sections.
 
 | | |
 |---|---|
@@ -47,6 +47,7 @@ in order.
 | `streaming-turn.json` | one prompt with `includePartialMessages: true`, captured 2026-09-06 — the whole `stream_event` run of one turn, `message_start` through `message_stop` (#8172) |
 | `subagent-turn.json` | one prompt asking for a single `Task` spawn, run with `forwardSubagentText: true` and `includePartialMessages: true` on `claude-opus-5` with `thinking: {type: "enabled", budgetTokens: 8000}`, captured 2026-09-07 — the whole 74-frame run of a turn that spawns one worker (#8403) |
 | `two-subagent-turn.json` | the same options on `claude-fable-5-1`, with a prompt asking for **two** `Explore` workers in parallel over two files in the throwaway cwd, captured 2026-09-07 — the whole 59-frame run, and the one capture where two workers overlap (#8408) |
+| `local-command-turn.json`, `local-command-lines-turn.json` | excerpted from an operator's own CLI session transcript, from sessions where a slash command ran — see below |
 | `thinking-turn.json` | excerpted from an operator's own CLI session transcript, not from a `query()` run — see below |
 | `compact-boundary.json` | the same, from a session that compacted |
 | `informational-notice.json` | the same, from a session that hit a usage limit |
@@ -121,6 +122,30 @@ Sanitization is the same as everywhere else here: uuids, `msg_*` and `req_*` ids
 consistently, the thinking block's signature replaced with a short placeholder, and every CLI-only
 field naming a machine or a checkout dropped rather than rewritten.
 
+## The two local-command captures
+
+`local-command-turn.json` and `local-command-lines-turn.json` are the same kind of excerpt as the
+three above, under the same founder ruling
+([#8151](https://github.com/kamp-us/phoenix/issues/8151#issuecomment-5556626806)), and for the same
+reason: a slash command is the CLI's, so no `query()` run can produce one. Both are the record of a
+command the operator ran — `/model` and `/terminal-setup` — and both are why #8211 exists: the CLI
+writes a command's result as a **user-role** message whose whole text is a
+`<local-command-stdout>` wrapper, which the mapping read as an operator turn.
+
+| | |
+|---|---|
+| Captured | 2026-09-08, from local session transcripts written by CLI **2.1.218** (the `/model` result) and **2.1.170** (the `/terminal-setup` one) |
+| Verbatim | the whole `message` body — the role and the wrapped text, terminal colour escapes included — and each row's own `timestamp` |
+| Re-keyed | `sessionId` → `session_id`, `parent_tool_use_id`/`parent_agent_id` added as `null`, and the CLI-only keys (`parentUuid`, `promptId`, `cwd`, `gitBranch`, `version`, `userType`, `entrypoint`, `isSidechain`) dropped |
+
+The escapes are the golden part of the first one, not noise a sanitizer missed: `/model` writes SGR
+runs around the model's name, and stripping them is the mapping's job (`../map.ts`), so a fixture
+without them would prove nothing about the line a reader sees. The second is the multi-line case —
+three lines, so the notice's summary line is not its whole output — and it is what pins the detail
+half of the row.
+
+Sanitized as everywhere else here: the uuid and session id substituted. Neither row carries a path.
+
 ## The sidechain capture
 
 `agent-a1b2c3d4e5f60718a.jsonl` and `agent-a1b2c3d4e5f60718a.meta.json` are one subagent's own
@@ -159,7 +184,8 @@ sidechain file is still uncovered here and rides
 ## What was sanitized, and what is golden
 
 For the `query()` captures, the **key set and the field shapes are the golden part** and are
-untouched. The three excerpted fixtures are re-keyed instead, exactly as the section above records —
+untouched. The five excerpted fixtures are re-keyed instead, exactly as the two sections above
+record —
 their golden part is the payload inside that envelope, not the envelope. Substituted, in both
 groups:
 
@@ -251,9 +277,11 @@ an operator act, not a test fixture generator. To re-capture the `query()` fixtu
 from a scratch directory exactly as the first table describes, then apply the substitutions above
 before the JSON comes anywhere near this directory.
 
-The three excerpted fixtures cannot be re-produced that way — no `query()` run forces reasoning, a
-compaction or a usage-limit notice. Re-producing them means finding the frame again in an operator's
-own local CLI session log and re-keying it against `sdk.d.ts` at the catalog pin, per the table in
-[the section above](#the-three-excerpted-from-a-cli-session-transcript). Replacing them with real
+The five excerpted fixtures cannot be re-produced that way — no `query()` run forces reasoning, a
+compaction, a usage-limit notice or a slash command. Re-producing them means finding the frame again
+in an operator's own local CLI session log and re-keying it against `sdk.d.ts` at the catalog pin,
+per the table in
+[the section above](#the-three-excerpted-from-a-cli-session-transcript) or in
+[the one after it](#the-two-local-command-captures). Replacing them with real
 `query()` captures is [#8038](https://github.com/kamp-us/phoenix/issues/8038)'s live capture run,
 which is where `compact-boundary.json`'s declaration-derived key names get closed.

--- a/apps/tuval/src/claude/history/fixtures/load.ts
+++ b/apps/tuval/src/claude/history/fixtures/load.ts
@@ -16,6 +16,8 @@ export type FixtureName =
 	| "informational-notice"
 	| "init"
 	| "interrupted-assistant"
+	| "local-command-lines-turn"
+	| "local-command-turn"
 	| "oversized-tool-turn"
 	| "permission-denied"
 	| "resumed-init"

--- a/apps/tuval/src/claude/history/fixtures/local-command-lines-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/local-command-lines-turn.json
@@ -1,0 +1,12 @@
+{
+	"type": "user",
+	"uuid": "00000000-0000-4000-8000-000000000062",
+	"session_id": "00000000-0000-4000-8000-000000000061",
+	"message": {
+		"role": "user",
+		"content": "<local-command-stdout>Shift+Enter is natively supported in Kitty.\n\nNo configuration needed. Just use Shift+Enter to add newlines.</local-command-stdout>"
+	},
+	"parent_tool_use_id": null,
+	"parent_agent_id": null,
+	"timestamp": "2026-06-10T05:50:46.734Z"
+}

--- a/apps/tuval/src/claude/history/fixtures/local-command-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/local-command-turn.json
@@ -1,0 +1,12 @@
+{
+	"type": "user",
+	"uuid": "00000000-0000-4000-8000-000000000060",
+	"session_id": "00000000-0000-4000-8000-000000000061",
+	"message": {
+		"role": "user",
+		"content": "<local-command-stdout>Set model to \u001b[1mFable 5\u001b[22m and saved as your default for new sessions</local-command-stdout>"
+	},
+	"parent_tool_use_id": null,
+	"parent_agent_id": null,
+	"timestamp": "2026-07-24T06:56:27.863Z"
+}

--- a/apps/tuval/src/claude/history/local-command.unit.test.ts
+++ b/apps/tuval/src/claude/history/local-command.unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A slash command's own output is the session's word, not the operator's (#8211).
+ *
+ * The CLI runs a command like `/model` locally and records its result as a user-role message whose
+ * whole text is a `<local-command-stdout>` wrapper. Read as a turn it lands under YOU, wrapper and
+ * terminal escapes included — the shape the founder's desk screenshot caught. Both fixtures here
+ * are that record, taken from an operator's own CLI session log under the founder's ruling on
+ * [#8151](https://github.com/kamp-us/phoenix/issues/8151#issuecomment-5556626806) and re-keyed to
+ * `SessionMessage` (`fixtures/PROVENANCE.md`).
+ */
+
+import type {SDKMessage, SessionMessage} from "@anthropic-ai/claude-agent-sdk";
+import {describe, expect, it} from "vitest";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {toAgentEvents} from "./events.ts";
+import {loadFixture} from "./fixtures/load.ts";
+import {toHistoryItems} from "./items.ts";
+import {emptyMapping} from "./map.ts";
+
+const AT = 1_700_000_000_000;
+
+const frame = (name: Parameters<typeof loadFixture>[0]) => loadFixture(name) as SDKMessage;
+
+const mapped = (message: SDKMessage): ReadonlyArray<TranscriptItem> =>
+	toAgentEvents(message, emptyMapping, {at: AT}).events.flatMap((event) =>
+		event.kind === "item" ? [event.item] : [],
+	);
+
+/** The captured frame with one field replaced, so the envelope under test stays the capture's. */
+const withText = (message: SDKMessage, text: string): SDKMessage =>
+	({...message, message: {role: "user", content: text}}) as SDKMessage;
+
+describe("a captured local command's output", () => {
+	const captured = frame("local-command-turn");
+
+	it("lands as a session notice, keeping the frame's identity, clock and top-level attribution", () => {
+		expect(mapped(captured)).toEqual([
+			{
+				kind: "system",
+				id: "00000000-0000-4000-8000-000000000060",
+				timestamp: Date.parse("2026-07-24T06:56:27.863Z"),
+				text: "Set model to Fable 5 and saved as your default for new sessions",
+			},
+		]);
+	});
+
+	it("shows the result as readable text: no wrapper, no colour escapes", () => {
+		const [one] = mapped(captured);
+		expect(one?.kind).toBe("system");
+		const line = one?.kind === "system" ? one.text : "";
+		expect(line).not.toMatch(/local-command-stdout/);
+		expect(line).not.toMatch(new RegExp(String.fromCharCode(27)));
+	});
+
+	it("replays the same way off a stored session, so an old session reads back as it ran", () => {
+		const {items, skipped} = toHistoryItems([captured as SessionMessage], {at: AT});
+		expect(items.map((one) => one.kind)).toEqual(["system"]);
+		expect(skipped).toBe(0);
+	});
+
+	it("keeps the whole output behind the notice's detail when the line is not all of it", () => {
+		const whole =
+			"Shift+Enter is natively supported in Kitty.\n\nNo configuration needed. Just use Shift+Enter to add newlines.";
+		expect(mapped(frame("local-command-lines-turn"))).toEqual([
+			{
+				kind: "system",
+				id: "00000000-0000-4000-8000-000000000062",
+				timestamp: Date.parse("2026-06-10T05:50:46.734Z"),
+				text: "Shift+Enter is natively supported in Kitty.",
+				detail: whole,
+			},
+		]);
+	});
+});
+
+describe("an operator's own turn on the same envelope", () => {
+	const captured = frame("local-command-turn");
+
+	it("stays a user item when the prompt merely talks about the wrapper", () => {
+		const prompt = "why does <local-command-stdout>x</local-command-stdout> show up as my message?";
+		expect(mapped(withText(captured, prompt))).toEqual([
+			{
+				kind: "user",
+				id: "00000000-0000-4000-8000-000000000060",
+				timestamp: Date.parse("2026-07-24T06:56:27.863Z"),
+				text: prompt,
+			},
+		]);
+	});
+
+	it("stays a user item when the prompt quotes the wrapper as a code example", () => {
+		const prompt =
+			"```\n<local-command-stdout>Set model to X</local-command-stdout>\n```\nfix this";
+		const [one] = mapped(withText(captured, prompt));
+		expect(one?.kind).toBe("user");
+		expect(one?.kind === "user" ? one.text : "").toBe(prompt);
+	});
+});

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -617,8 +617,56 @@ export const partialReplyEvents = (
 	};
 };
 
+/** How much of a notice's own prose rides the summary line before the rest folds into `detail`. */
+const NOTICE_SUMMARY_LIMIT = 200;
+
+const LOCAL_COMMAND_OPEN = "<local-command-stdout>";
+const LOCAL_COMMAND_CLOSE = "</local-command-stdout>";
+
 /**
- * A user frame is either the operator's prompt or the results of the calls the last turn opened.
+ * The escape a command writes to colour its own output for a terminal. The captured `/model`
+ * result carries two, and left in they reach a transcript as unprintable bytes inside the line.
+ */
+const sgr = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+/**
+ * What a local command printed, when this user frame is a command's output rather than a turn.
+ *
+ * The CLI records a slash command's result as a user-role message whose whole text is that one
+ * wrapper (`fixtures/local-command-turn.json`), so the frame is the operator's only in role — read
+ * as a turn it puts a system echo and its markup under YOU (#8211).
+ *
+ * The match is the captured shape and nothing looser: the text must *be* the wrapper, so a prompt
+ * quoting or explaining these tags is still the operator's own and stays one. Sibling tags —
+ * `<local-command-caveat>`, `<command-name>` — are a different shape and are not read here.
+ */
+const localCommandOutputOf = (text: string): string | null => {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith(LOCAL_COMMAND_OPEN) || !trimmed.endsWith(LOCAL_COMMAND_CLOSE)) {
+		return null;
+	}
+	const inner = trimmed.slice(LOCAL_COMMAND_OPEN.length, -LOCAL_COMMAND_CLOSE.length);
+	return inner.replaceAll(sgr, "").trim();
+};
+
+/**
+ * One command's output as the collapsed notice's two fields: the line always shown, and the whole
+ * output behind the disclosure whenever that line is not all of it (`shell/chat/SessionRow.tsx`).
+ */
+const noticeOf = (output: string): {readonly text: string; readonly detail?: string} => {
+	const first =
+		output
+			.split("\n")
+			.find((line) => line.trim().length > 0)
+			?.trim() ?? "";
+	const line =
+		first.length > NOTICE_SUMMARY_LIMIT ? `${first.slice(0, NOTICE_SUMMARY_LIMIT)}…` : first;
+	return line === output ? {text: line} : {text: line, detail: output};
+};
+
+/**
+ * A user frame is either the operator's prompt, a local command's output, or the results of the
+ * calls the last turn opened.
  *
  * A result whose call this mapping never saw is dropped and counted: the item union has no
  * name-less tool row, and inventing one would put a lie on screen. It happens only to a reader
@@ -640,13 +688,12 @@ export const userEvents = (
 		const id = typeof message.uuid === "string" ? message.uuid : `user-${at}`;
 		// A worker's inbound turn is parent-tagged too, and untagged it landed top-level beside the
 		// agent's own prose — seen live on #8400's desk run.
-		const prompt: TranscriptItem = {
-			kind: "user",
-			id: itemId(id),
-			timestamp: at,
-			text,
-			...(framedParentId === null ? {} : {parentId: itemId(framedParentId)}),
-		};
+		const tag = framedParentId === null ? {} : {parentId: itemId(framedParentId)};
+		const output = localCommandOutputOf(text);
+		const prompt: TranscriptItem =
+			output === null
+				? {kind: "user", id: itemId(id), timestamp: at, text, ...tag}
+				: {kind: "system", id: itemId(id), timestamp: at, ...noticeOf(output), ...tag};
 		const folded = foldSlots(mapping, [prompt], framedParentId, 0);
 		return {
 			mapping: {...mapping, subagents: folded.subagents},
@@ -911,10 +958,6 @@ export const compactBoundaryEvents = (
 		],
 	};
 };
-
-/** How much of a notice's own prose rides the summary line before the rest folds into `detail`. */
-const NOTICE_SUMMARY_LIMIT = 200;
-
 /** The keys every frame carries; what is left is the notice's own payload, whatever its subtype. */
 const noticeEnvelope: ReadonlySet<string> = new Set([
 	"type",

--- a/apps/tuval/src/shell/chat/local-command-notice.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/local-command-notice.unit.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The renderer half of #8211: a slash command's output reads as a session notice, never as a YOU
+ * turn showing its own wrapper.
+ *
+ * The rows come off the real Claude mapper over the captured frames (`claude/history/fixtures`), so
+ * this case and the mapper's own move together — a renderer case fed a hand-made item would still
+ * pass with the mapping put back the way it was. The import is this file's alone: `boundary.unit.
+ * test.ts` forbids a shipped file under `shell/chat/` from reaching a backend, and exempts tests.
+ */
+
+import type {SDKMessage} from "@anthropic-ai/claude-agent-sdk";
+import {act, fireEvent, render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {toAgentEvents} from "../../claude/history/events.ts";
+import {loadFixture} from "../../claude/history/fixtures/load.ts";
+import {emptyMapping} from "../../claude/history/map.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type TestProcess, testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {userItem, withTranscript} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+const AT = 1_700_000_000_000;
+
+const mapped = (name: Parameters<typeof loadFixture>[0]): ReadonlyArray<TranscriptItem> =>
+	toAgentEvents(loadFixture(name) as SDKMessage, emptyMapping, {at: AT}).events.flatMap((event) =>
+		event.kind === "item" ? [event.item] : [],
+	);
+
+const openWindow = async (items: ReadonlyArray<TranscriptItem>): Promise<void> => {
+	const process: TestProcess<AiAgentSessionState, AiAgentSessionMsg> = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+			ProcessId.make("p1"),
+			withTranscript(items),
+		),
+	);
+	const host = await Effect.runPromise(
+		process.window<ChatView>(WindowId.make("w1"), initialChatView),
+	);
+	const element = chatWindow({scrollCommitMs: 0, scrollToFn: () => {}}).render(
+		host,
+	) as ReactElement;
+	render(element);
+	await screen.findByRole("log", {name: "Transcript"});
+};
+
+/** The operator rows on screen: `ChatWindow` tags every item row with the item's own kind. */
+const roles = (): ReadonlyArray<string> =>
+	[...document.querySelectorAll<HTMLElement>(".tuval-chat-row")]
+		.map((row) => row.getAttribute("data-message-role"))
+		.filter((role): role is string => role === "user");
+
+describe("a captured local command's output in the transcript", () => {
+	it("reads as a session notice, with no operator row and no wrapper markup on screen", async () => {
+		await openWindow(mapped("local-command-turn"));
+
+		expect(roles()).toEqual([]);
+		expect(screen.getByText("Set model to Fable 5 and saved as your default for new sessions"));
+		expect(document.body.textContent).not.toMatch(/local-command-stdout/);
+	});
+
+	/**
+	 * The control for the case above: `roles()` is what an operator row looks like, so the empty
+	 * answer there is this window declining to draw one rather than the query finding nothing.
+	 */
+	it("still draws the operator's own row for a real prompt", async () => {
+		await openWindow([userItem("u1", "read the readme")]);
+
+		expect(roles()).toEqual(["user"]);
+	});
+
+	it("keeps the whole output reachable behind the notice's own disclosure", async () => {
+		await openWindow(mapped("local-command-lines-turn"));
+
+		const trigger = screen.getByRole("button", {name: /^Shift\+Enter is natively supported/});
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+		await act(async () => {
+			fireEvent.click(trigger);
+		});
+
+		expect(trigger.getAttribute("aria-expanded")).toBe("true");
+		const panel = document.getElementById(trigger.getAttribute("aria-controls") ?? "");
+		expect(panel?.textContent).toContain("No configuration needed.");
+		expect(panel?.textContent).not.toMatch(/local-command-stdout/);
+	});
+});


### PR DESCRIPTION
A Claude slash command's result (`/model`, `/terminal-setup`) is recorded by the CLI as a
**user-role** message whose whole text is a `<local-command-stdout>` wrapper. The mapper read that
as a turn, so the desk showed a YOU row carrying a system echo plus its own markup and terminal
colour escapes.

`userEvents` now reads that one captured shape and maps it to the existing `SystemItem` instead: the
frame's uuid, timestamp and parent tag are kept, the wrapper and the SGR escapes are stripped, and a
multi-line result puts its first line on the notice and the whole output in `detail`, which
`SessionRow` already discloses. No new item kind, no renderer branch.

Detection is the captured shape, not a tag sweep: the text has to *be* the wrapper, so a prompt that
quotes or asks about these tags stays the operator's own. Sibling tags (`<local-command-caveat>`,
`<command-name>`) are untouched.

Two fixtures back it, both excerpted from an operator's own CLI session log under the founder's
ruling on #8151 and re-keyed to `SessionMessage` — `PROVENANCE.md` records which part of each is
verbatim. `local-command.unit.test.ts` covers the mapper on both the live and the history path, and
`local-command-notice.unit.test.tsx` renders the mapped rows through the real window: no operator
row, no wrapper on screen, whole output behind the disclosure. Both were confirmed red with the
mapping put back the way it was.

Fixes #8211

## Deviations

- **Out-of-scope change** — **Said:** #8211 names the wrapper markup. **Did:** also strip the SGR
  colour escapes from the command's output. **Why:** the captured `/model` result carries two of
  them around the model name, and left in they land in the notice line as unprintable bytes, so the
  criterion "preserving the command result's readable content" is not met without it.
  **Disposition:** stated here, and scoped to this one arm — no other text path strips escapes.
