### PR TITLE
feat: One design-package Diff component wrapping @pierre/diffs, consumed by Tuval's tool detail

### DIFF
--- a/apps/tuval/src/shell/chat/copy.ts
+++ b/apps/tuval/src/shell/chat/copy.ts
@@ -32,6 +32,7 @@ const messages: Readonly<Record<DesignCatalogKey, string>> = {
 	"ui.draftRestore.text": "You have a saved draft. Restore it?",
 	"ui.draftRestore.restore": "restore the draft",
 	"ui.draftRestore.dismiss": "dismiss",
+	"ui.diff": "diff of {path}",
 	"ui.markdown.table": "table",
 	"ui.markdown.code": "code block",
 	"ui.markdown.diagram": "diagram",

--- a/apps/web/src/i18n/en/account.ts
+++ b/apps/web/src/i18n/en/account.ts
@@ -195,6 +195,7 @@ export const account = {
 	"ui.draftRestore.text": "you have a saved draft. want to restore it?",
 	"ui.draftRestore.restore": "restore the draft",
 	"ui.draftRestore.dismiss": "ignore",
+	"ui.diff": "diff of {path}",
 	"ui.markdown.table": "table",
 	"ui.markdown.code": "code block",
 	"ui.markdown.diagram": "diagram",

--- a/apps/web/src/i18n/tr/account.ts
+++ b/apps/web/src/i18n/tr/account.ts
@@ -196,6 +196,7 @@ export const account = {
 	"ui.draftRestore.text": "kaydedilmiş bir taslağın var. geri yüklemek ister misin?",
 	"ui.draftRestore.restore": "taslağı geri yükle",
 	"ui.draftRestore.dismiss": "yoksay",
+	"ui.diff": "{path} dosyasının değişiklik farkı",
 	"ui.markdown.table": "tablo",
 	"ui.markdown.code": "kod bloğu",
 	"ui.markdown.diagram": "diyagram",

--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -163,6 +163,7 @@ until they land, the rule still governs (do not seed a fresh hand-built instance
 | A button (incl. `pressed` / `icon` / `loading`) | The widened `Button` primitive | Hand-roll a button wrapper around the primitive. |
 | Empty / short / sparse state | The reusable empty-state primitive ([#2162](https://github.com/kamp-us/phoenix/issues/2162)) | Ship a bare `0 yorum`-style label as the whole treatment. |
 | A reaction affordance | The on-brand controlled reaction asset ([#2165](https://github.com/kamp-us/phoenix/issues/2165)) | Ship a raw system-emoji glyph (OS-drift). |
+| A before/after text diff | The `Diff` primitive (`@pierre/diffs` behind role tokens, unified or `split`) | Hand-roll a line table, or embed a second diff renderer. |
 | A functional icon (vote / nav / toolbar / inline) | A drawn **Lucide** icon at the ruled size + role token (the [icon idiom](#the-canonical-icon-idiom) below) | Ship a Unicode functional glyph (`△` `↑` `→` `⌘` `↵`) or a hand-inlined SVG as an icon. |
 
 **One system throughout:** one type ramp, one four-level elevation system, one icon idiom — never

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -12,6 +12,7 @@ entries and ownership boundaries.
 | `@kampus/design/fonts.css` | First-party IBM Plex Sans and JetBrains Mono faces |
 | `AgentChatInputBridge` | App-owned Pi RPC transport supplied to `AgentChatInput` |
 | `CommandPalette` | Modal, keyboard-first search surface over caller-owned results |
+| `Diff` | Before/after renderer over `@pierre/diffs` — unified or split, role-token themed, shadow DOM |
 | `Markdown` | Read-only renderer for agent markdown — raw HTML in the source prints as text |
 | `design-token-lint.config.json` | The token guard's package-owned baseline and allow-list |
 | `src/a11y/` | Property-based accessibility suite and its posture/registry |

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -24,6 +24,7 @@
 		"@manti-ui/react": "catalog:",
 		"@fontsource/ibm-plex-sans": "catalog:",
 		"@fontsource/jetbrains-mono": "catalog:",
+		"@pierre/diffs": "catalog:",
 		"lucide-react": "catalog:",
 		"marked": "catalog:",
 		"mermaid": "catalog:"

--- a/packages/design/src/Diff.css
+++ b/packages/design/src/Diff.css
@@ -27,10 +27,15 @@
 	 * `color-scheme` — and its `:host` sets `light dark`, so every one of those would follow the
 	 * operator's OS rather than phoenix's `data-theme`. Pinning the scheme here, from the same
 	 * attribute the role tokens switch on, settles all of them at once, including the row-tint
-	 * ratios (`--diffs-bg-addition`/`-deletion` and their emphasis pairs) that have no
-	 * `-override` input to reach.
+	 * ratios (`--diffs-bg-context`, `-gutter`, `-separator`, `-addition`/`-deletion` and their
+	 * emphasis pairs) that have no `-override` input to reach.
+	 *
+	 * Dark is the unconditional arm because the token set's own default is dark — `tokens.css`
+	 * hangs the dark scales off a bare `:root` and makes `[data-theme="light"]` the opt-in. Same
+	 * rule, same reason, as `MermaidBlock`'s `darkMode: host.closest('[data-theme="light"]')
+	 * === null`.
 	 */
-	color-scheme: light;
+	color-scheme: dark;
 
 	display: block;
 
@@ -86,6 +91,6 @@
 	--diffs-token-changed: var(--warning);
 }
 
-[data-theme="dark"] .kp-diff__pane {
-	color-scheme: dark;
+[data-theme="light"] .kp-diff__pane {
+	color-scheme: light;
 }

--- a/packages/design/src/Diff.css
+++ b/packages/design/src/Diff.css
@@ -1,0 +1,55 @@
+.kp-diff {
+	max-block-size: var(--kp-diff-max-block-size, 60vh);
+	overflow: auto;
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	background: var(--surface-sunken);
+}
+
+.kp-diff:focus-visible {
+	outline: var(--manti-focus-ring-width) solid var(--manti-focus-ring);
+	outline-offset: var(--manti-focus-ring-offset);
+}
+
+/*
+ * The seam. These are declared on the shadow host rather than on `.kp-diff` because the library's
+ * own `:host` rule sets some of them, and a `:host` declaration beats a value inherited from an
+ * ancestor; a rule matching the host from this document does not. Everything below is a role token
+ * — see `Diff.tsx` for why the pair-shaped `--diffs-light-*`/`--diffs-dark-*` inputs are fed the
+ * same token on both sides, and why the `-override` inputs are preferred where the library has one.
+ */
+.kp-diff__pane {
+	display: block;
+
+	/* chrome */
+	--diffs-font-family: var(--font-mono);
+	--diffs-header-font-family: var(--font-body);
+	--diffs-light-bg: var(--surface-sunken);
+	--diffs-dark-bg: var(--surface-sunken);
+	--diffs-light: var(--text-primary);
+	--diffs-dark: var(--text-primary);
+	--diffs-mixer: var(--text-primary);
+	--diffs-addition-color-override: var(--success);
+	--diffs-deletion-color-override: var(--danger);
+	--diffs-modified-color-override: var(--warning);
+	--diffs-fg-number-override: var(--text-muted);
+
+	/* the Shiki css-variables theme registered in `Diff.tsx` */
+	--diffs-foreground: var(--text-primary);
+	--diffs-background: var(--surface-sunken);
+	--diffs-ansi-green: var(--success);
+	--diffs-ansi-red: var(--danger);
+	--diffs-ansi-blue: var(--accent);
+	--diffs-token-comment: var(--text-muted);
+	--diffs-token-string: var(--success);
+	--diffs-token-string-expression: var(--success);
+	--diffs-token-keyword: var(--link);
+	--diffs-token-function: var(--accent);
+	--diffs-token-constant: var(--warning);
+	--diffs-token-parameter: var(--text-secondary);
+	--diffs-token-punctuation: var(--text-muted);
+	--diffs-token-link: var(--link);
+	--diffs-token-inserted: var(--success);
+	--diffs-token-deleted: var(--danger);
+	--diffs-token-changed: var(--warning);
+}

--- a/packages/design/src/Diff.css
+++ b/packages/design/src/Diff.css
@@ -1,5 +1,8 @@
 .kp-diff {
-	max-block-size: var(--kp-diff-max-block-size, 60vh);
+	/* A consumer retunes the cap by re-declaring this on `.kp-diff` from a more specific rule. */
+	--kp-diff-max-block-size: 60vh;
+
+	max-block-size: var(--kp-diff-max-block-size);
 	overflow: auto;
 	border: 1px solid var(--border);
 	border-radius: var(--r-md);
@@ -19,6 +22,16 @@
  * same token on both sides, and why the `-override` inputs are preferred where the library has one.
  */
 .kp-diff__pane {
+	/*
+	 * The library's stylesheet is full of `light-dark()`, which resolves off the USED
+	 * `color-scheme` — and its `:host` sets `light dark`, so every one of those would follow the
+	 * operator's OS rather than phoenix's `data-theme`. Pinning the scheme here, from the same
+	 * attribute the role tokens switch on, settles all of them at once, including the row-tint
+	 * ratios (`--diffs-bg-addition`/`-deletion` and their emphasis pairs) that have no
+	 * `-override` input to reach.
+	 */
+	color-scheme: light;
+
 	display: block;
 
 	/* chrome */
@@ -37,9 +50,28 @@
 	/* the Shiki css-variables theme registered in `Diff.tsx` */
 	--diffs-foreground: var(--text-primary);
 	--diffs-background: var(--surface-sunken);
-	--diffs-ansi-green: var(--success);
+	/*
+	 * The full ANSI set, not just the three the diff chrome reads: the theme emits
+	 * `var(--diffs-ansi-…)` with NO fallback for every one of them, so an ANSI-scoped grammar
+	 * would hit an unresolved colour. The role layer has one accent, so magenta and cyan share it.
+	 */
+	--diffs-ansi-black: var(--surface);
 	--diffs-ansi-red: var(--danger);
+	--diffs-ansi-green: var(--success);
+	--diffs-ansi-yellow: var(--warning);
 	--diffs-ansi-blue: var(--accent);
+	--diffs-ansi-magenta: var(--link);
+	--diffs-ansi-cyan: var(--link);
+	--diffs-ansi-white: var(--text-muted);
+	--diffs-ansi-bright-black: var(--text-faint);
+	--diffs-ansi-bright-red: var(--danger);
+	--diffs-ansi-bright-green: var(--success);
+	--diffs-ansi-bright-yellow: var(--warning);
+	--diffs-ansi-bright-blue: var(--accent);
+	--diffs-ansi-bright-magenta: var(--link);
+	--diffs-ansi-bright-cyan: var(--link);
+	--diffs-ansi-bright-white: var(--text-primary);
+
 	--diffs-token-comment: var(--text-muted);
 	--diffs-token-string: var(--success);
 	--diffs-token-string-expression: var(--success);
@@ -52,4 +84,8 @@
 	--diffs-token-inserted: var(--success);
 	--diffs-token-deleted: var(--danger);
 	--diffs-token-changed: var(--warning);
+}
+
+[data-theme="dark"] .kp-diff__pane {
+	color-scheme: dark;
 }

--- a/packages/design/src/Diff.test.tsx
+++ b/packages/design/src/Diff.test.tsx
@@ -42,7 +42,9 @@ describe("Diff", () => {
 		expect(region.classList.contains("kp-diff")).toBe(true);
 	});
 
-	it("names no individual line, so a screen reader reads the code and not a label per row", () => {
+	// `querySelectorAll` does not cross a shadow boundary, so this holds for the light DOM this
+	// component owns and says nothing about the rows the library draws inside its shadow root.
+	it("adds exactly one aria-label of its own — the region's — and none per line", () => {
 		const {container} = render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
 
 		expect(container.querySelectorAll("[aria-label]").length).toBe(1);

--- a/packages/design/src/Diff.test.tsx
+++ b/packages/design/src/Diff.test.tsx
@@ -1,3 +1,5 @@
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
 import {render, screen} from "@testing-library/react";
 import fc from "fast-check";
 import {beforeEach, describe, expect, it, vi} from "vitest";
@@ -70,6 +72,34 @@ describe("Diff", () => {
 		render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
 
 		expect(seen.calls.at(-1)?.theme).toBe("kampus-role-tokens");
+	});
+
+	/**
+	 * Every `light-dark()` the library's sheet leaves without an `-override` input reads the pane's
+	 * used `color-scheme`, and the token set's own default is dark — `tokens.css` hangs the dark
+	 * scales off a bare `:root` and makes `[data-theme="light"]` the opt-in. Getting that polarity
+	 * backwards paints the light-tuned mix ratios over dark tokens, which collapses the context,
+	 * gutter and separator rows into the surface. Vitest injects no CSS, so the sheet is read off
+	 * disk and put in the document; jsdom resolves `color-scheme` and this selector itself.
+	 */
+	it("resolves color-scheme dark by default and light only under [data-theme=light]", () => {
+		const style = document.createElement("style");
+		style.textContent = readFileSync(join(import.meta.dirname, "Diff.css"), "utf8");
+		document.head.append(style);
+		const {container} = render(
+			<div data-theme="light">
+				<Diff before={BEFORE} after={AFTER} path="src/count.ts" />
+			</div>,
+		);
+		const light = container.querySelector(".kp-diff__pane") as HTMLElement;
+		const dflt = render(
+			<Diff before={BEFORE} after={AFTER} path="src/count.ts" />,
+		).container.querySelector(".kp-diff__pane") as HTMLElement;
+
+		expect(getComputedStyle(dflt).colorScheme).toBe("dark");
+		expect(getComputedStyle(light).colorScheme).toBe("light");
+
+		style.remove();
 	});
 
 	it("has no axe violations", async () => {

--- a/packages/design/src/Diff.test.tsx
+++ b/packages/design/src/Diff.test.tsx
@@ -1,0 +1,82 @@
+import {render, screen} from "@testing-library/react";
+import fc from "fast-check";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {runEnforcedInvariants} from "./a11y/check";
+import {Diff} from "./Diff";
+
+// The layout is a prop the library reads inside its shadow root, and jsdom neither lays out nor
+// finishes the async highlight — so the only place it is decidable here is at the call.
+const seen = vi.hoisted(() => ({calls: [] as Array<Record<string, unknown>>}));
+
+vi.mock("@pierre/diffs/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@pierre/diffs/react")>();
+	return {
+		...actual,
+		FileDiff: (props: Parameters<typeof actual.FileDiff>[0]) => {
+			seen.calls.push({...props.options, lang: props.fileDiff.lang});
+			return actual.FileDiff(props);
+		},
+	};
+});
+
+/**
+ * The rows themselves are drawn by `@pierre/diffs` inside a shadow root, and jsdom applies no CSS
+ * and runs no layout — so what a test here can hold is the contract this package owns: the scroller
+ * is focusable and named, the layout prop reaches the library, and the markup this component adds
+ * carries no axe violation.
+ */
+const BEFORE = "const a = 1;\nconst b = 2;\n";
+const AFTER = "const a = 1;\nconst b = 3;\n";
+
+describe("Diff", () => {
+	beforeEach(() => {
+		seen.calls = [];
+	});
+
+	it("puts the tab stop and the name on the element that scrolls", () => {
+		render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
+
+		const region = screen.getByRole("region", {name: /src\/count\.ts/});
+		expect(region.tagName).toBe("DIV");
+		expect(region.tabIndex).toBe(0);
+		expect(region.classList.contains("kp-diff")).toBe(true);
+	});
+
+	it("names no individual line, so a screen reader reads the code and not a label per row", () => {
+		const {container} = render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
+
+		expect(container.querySelectorAll("[aria-label]").length).toBe(1);
+	});
+
+	it("renders unified by default and split on request", () => {
+		render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
+		expect(seen.calls.at(-1)?.diffStyle).toBe("unified");
+
+		render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" split />);
+		expect(seen.calls.at(-1)?.diffStyle).toBe("split");
+	});
+
+	it("derives the language from the path's extension", () => {
+		render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
+		expect(seen.calls.at(-1)?.lang).toBe("typescript");
+
+		render(<Diff before="# a" after="# b" path="docs/notes.md" />);
+		expect(seen.calls.at(-1)?.lang).toBe("markdown");
+	});
+
+	it("colours through the role-token theme, never a theme of the library's own", () => {
+		render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
+
+		expect(seen.calls.at(-1)?.theme).toBe("kampus-role-tokens");
+	});
+
+	it("has no axe violations", async () => {
+		const {container} = render(<Diff before={BEFORE} after={AFTER} path="src/count.ts" />);
+
+		const violations = await runEnforcedInvariants(container, {
+			kind: "presentational",
+			arb: fc.constant(<div />),
+		});
+		expect(violations).toEqual([]);
+	});
+});

--- a/packages/design/src/Diff.tsx
+++ b/packages/design/src/Diff.tsx
@@ -24,6 +24,8 @@ import {useDesignT} from "./i18n";
  *   disagree the moment an operator picks a theme against their OS. A single Shiki
  *   css-variables theme (`registerCustomCSSVariableTheme`) emits `var(--diffs-…)` for every colour
  *   instead, so light and dark come from the role tokens, which already switch on `data-theme`.
+ *   The library's own stylesheet still calls `light-dark()` for things no property overrides — the
+ *   row-tint ratios — so `Diff.css` also pins `color-scheme` off `data-theme`.
  * - **`overflow: "wrap"`, not the default scroll.** The default puts the horizontal scroller inside
  *   the shadow root, where no tab stop can be placed on it (WCAG 2.1.1). Wrapping removes that
  *   scroller, which leaves the block below as the one that scrolls and the one that carries the tab

--- a/packages/design/src/Diff.tsx
+++ b/packages/design/src/Diff.tsx
@@ -1,0 +1,80 @@
+import {
+	getFiletypeFromFileName,
+	parseDiffFromFile,
+	registerCustomCSSVariableTheme,
+} from "@pierre/diffs";
+import {FileDiff} from "@pierre/diffs/react";
+import {type ReactElement, useMemo} from "react";
+import "./Diff.css";
+import {useDesignT} from "./i18n";
+
+/**
+ * `@pierre/diffs` renders into a Shadow DOM and offers no light-DOM mode: its React `FileDiff`
+ * returns a `<diffs-container>` custom element whose constructor calls
+ * `attachShadow({mode: "open"})` and adopts the library's own stylesheet
+ * (`dist/components/web-components.js` at 1.4.1). So a `tokens.css` rule can never reach the rendered
+ * rows, and the only thing that crosses the boundary is an inherited CSS custom property. Every one
+ * that does is declared in `Diff.css` on `.kp-diff__pane` — the host element itself, because the
+ * library's own `:host` rule beats a value inherited from an ancestor.
+ *
+ * Two of the library's shapes are deliberately not taken:
+ *
+ * - **One theme, not a light/dark pair.** The library resolves a pair through CSS `light-dark()`,
+ *   which follows the used `color-scheme` rather than phoenix's `data-theme` attribute — the two
+ *   disagree the moment an operator picks a theme against their OS. A single Shiki
+ *   css-variables theme (`registerCustomCSSVariableTheme`) emits `var(--diffs-…)` for every colour
+ *   instead, so light and dark come from the role tokens, which already switch on `data-theme`.
+ * - **`overflow: "wrap"`, not the default scroll.** The default puts the horizontal scroller inside
+ *   the shadow root, where no tab stop can be placed on it (WCAG 2.1.1). Wrapping removes that
+ *   scroller, which leaves the block below as the one that scrolls and the one that carries the tab
+ *   stop — `CodeBlock`'s rule, that the element that scrolls is the element that is focusable.
+ */
+const THEME = "kampus-role-tokens";
+
+let themeRegistered = false;
+
+/**
+ * Registered on the first render rather than at import. A top-level call here is a module side
+ * effect, and a side effect is what stops a bundler dropping an unused module — it put 15 KB of
+ * Shiki's theme registry into the desk bundle for a component the desk never rendered.
+ */
+function ensureTheme(): void {
+	if (themeRegistered) return;
+	registerCustomCSSVariableTheme(THEME, {});
+	themeRegistered = true;
+}
+
+export interface DiffProps {
+	/** The text before the change. Empty means an added file. */
+	readonly before: string;
+	/** The text after the change. Empty means a deleted file. */
+	readonly after: string;
+	/** The file's path — it names the diff and its extension picks the language. */
+	readonly path: string;
+	/** Old and new side by side. Unified (one column) is the default. */
+	readonly split?: boolean;
+}
+
+export function Diff({before, after, path, split = false}: DiffProps): ReactElement {
+	const t = useDesignT();
+	ensureTheme();
+	const fileDiff = useMemo(() => {
+		const lang = getFiletypeFromFileName(path);
+		return parseDiffFromFile(
+			{name: path, contents: before, lang},
+			{name: path, contents: after, lang},
+		);
+	}, [before, after, path]);
+
+	return (
+		// biome-ignore lint/a11y/noNoninteractiveTabindex: the tab stop is the point — see the docblock above.
+		// biome-ignore lint/a11y/useSemanticElements: a `<section>` would not be the box that scrolls.
+		<div className="kp-diff" tabIndex={0} role="region" aria-label={t("ui.diff", {path})}>
+			<FileDiff
+				className="kp-diff__pane"
+				fileDiff={fileDiff}
+				options={{diffStyle: split ? "split" : "unified", overflow: "wrap", theme: THEME}}
+			/>
+		</div>
+	);
+}

--- a/packages/design/src/Diff.tsx
+++ b/packages/design/src/Diff.tsx
@@ -25,7 +25,8 @@ import {useDesignT} from "./i18n";
  *   css-variables theme (`registerCustomCSSVariableTheme`) emits `var(--diffs-…)` for every colour
  *   instead, so light and dark come from the role tokens, which already switch on `data-theme`.
  *   The library's own stylesheet still calls `light-dark()` for things no property overrides — the
- *   row-tint ratios — so `Diff.css` also pins `color-scheme` off `data-theme`.
+ *   row-tint ratios — so `Diff.css` also pins `color-scheme` off `data-theme`, dark unless an
+ *   explicit `[data-theme="light"]` ancestor says otherwise, which is the token set's own default.
  * - **`overflow: "wrap"`, not the default scroll.** The default puts the horizontal scroller inside
  *   the shadow root, where no tab stop can be placed on it (WCAG 2.1.1). Wrapping removes that
  *   scroller, which leaves the block below as the one that scrolls and the one that carries the tab

--- a/packages/design/src/a11y/registry.tsx
+++ b/packages/design/src/a11y/registry.tsx
@@ -14,6 +14,7 @@ import {Badge} from "../Badge";
 import {Button} from "../Button";
 import {Card, Surface} from "../Card";
 import {CountToggle} from "../CountToggle";
+import {Diff} from "../Diff";
 import {Markdown} from "../Markdown";
 import {MetaRow} from "../MetaRow";
 import {NumberInput} from "../NumberInput";
@@ -241,6 +242,19 @@ const markdownArb: fc.Arbitrary<ReactElement> = fc
 	)
 	.map((parts) => <Markdown>{parts.join("\n\n")}</Markdown>);
 
+const diffArb: fc.Arbitrary<ReactElement> = fc
+	.record({
+		before: fc.constantFrom("const a = 1;\n", "", "# notes\n\nold line\n"),
+		after: fc.constantFrom(
+			"const a = 2;\n",
+			"const a = 1;\nconst b = 2;\n",
+			"# notes\n\nnew line\n",
+		),
+		path: fc.constantFrom("src/count.ts", "docs/notes.md", "worker/index.tsx"),
+		split: fc.boolean(),
+	})
+	.map((props) => <Diff {...props} />);
+
 const COMPOUND_REASON =
 	"Manti machine primitive — needs required items/trigger/content props or a portal interaction to render a representative surface; covered by composed-usage tests.";
 
@@ -259,6 +273,7 @@ export const REGISTRY: Readonly<Record<string, PrimitiveSpec>> = {
 
 	Surface: {kind: "presentational", arb: surfaceArb},
 	Card: {kind: "presentational", arb: cardArb},
+	Diff: {kind: "presentational", arb: diffArb},
 	Markdown: {kind: "presentational", arb: markdownArb},
 	MetaRow: {kind: "presentational", arb: metaRowArb},
 	SandboxMarker: {

--- a/packages/design/src/i18n.tsx
+++ b/packages/design/src/i18n.tsx
@@ -15,6 +15,7 @@ export const designTrMessages = {
 	"ui.draftRestore.text": "kaydedilmiş bir taslağın var. geri yüklemek ister misin?",
 	"ui.draftRestore.restore": "taslağı geri yükle",
 	"ui.draftRestore.dismiss": "yoksay",
+	"ui.diff": "{path} dosyasının değişiklik farkı",
 	"ui.markdown.table": "tablo",
 	"ui.markdown.code": "kod bloğu",
 	"ui.markdown.diagram": "diyagram",

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -45,6 +45,8 @@ export {CopyLinkButton} from "./CopyLinkButton";
 export type {CountToggleProps} from "./CountToggle";
 export {CountToggle} from "./CountToggle";
 export {Dialog} from "./Dialog";
+export type {DiffProps} from "./Diff";
+export {Diff} from "./Diff";
 export {DraftRestoreBanner} from "./DraftRestoreBanner";
 export {EditedIndicator} from "./EditedIndicator";
 export {EmptyState} from "./EmptyState";

--- a/packages/design/test-setup.ts
+++ b/packages/design/test-setup.ts
@@ -23,6 +23,12 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 	globalThis.ResizeObserver = ResizeObserverShim;
 }
 
+// jsdom 26 constructs a CSSStyleSheet but implements neither `replaceSync` nor `adoptedStyleSheets`,
+// and a custom element that adopts its own sheet in its constructor (`@pierre/diffs`) throws there.
+if (typeof CSSStyleSheet.prototype.replaceSync === "undefined") {
+	CSSStyleSheet.prototype.replaceSync = () => undefined;
+}
+
 if (typeof Element.prototype.scrollIntoView === "undefined") {
 	Element.prototype.scrollIntoView = () => undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     '@nkzw/fate':
       specifier: 1.3.1
       version: 1.3.1
+    '@pierre/diffs':
+      specifier: 1.4.1
+      version: 1.4.1
     '@playwright/test':
       specifier: ^1.62.1
       version: 1.62.1
@@ -873,6 +876,9 @@ importers:
       '@manti-ui/react':
         specifier: 'catalog:'
         version: 0.9.0(patch_hash=72865e8a70f6bf95ae32fbb5907bfc7c7d59d738856f188e91801d2e45bd7484)(@internationalized/date@3.12.3)(@manti-ui/styles@0.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@pierre/diffs':
+        specifier: 'catalog:'
+        version: 1.4.1(@shikijs/themes@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -2712,6 +2718,41 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
+  '@pierre/diffs@1.4.1':
+    resolution: {integrity: sha512-rzvY9FeeYdGtVcErjNsW6tnrjpMb0DvGtgCFNuMoYT8wufE+gO1ZXAzKAc2VPRBS3Rl5HELEQ38WDlis4qZHkQ==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@pierre/theme@2.0.0':
+    resolution: {integrity: sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==}
+    engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@1.0.1':
+    resolution: {integrity: sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==}
+    peerDependencies:
+      '@pierre/theme': ^1.1.0 || ^2.0.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
+
   '@playwright/test@1.62.1':
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
@@ -3038,6 +3079,41 @@ packages:
   '@sentry/replay@10.62.0':
     resolution: {integrity: sha512-rWp4hBhZOmdQhisxcKzAwTGiRk/LvWnNaElWe7nbRhjsM/usp2095yfjq4iJ47v9MtO7xxY6eUz++fLBycqXKg==}
     engines: {node: '>=18'}
+
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/transformers@4.4.3':
+    resolution: {integrity: sha512-oJSARV6NaWd+rnNJbtnpAdj3Zg0ZVyzsnMgb3vi3HA+35y8lBWUCpOnWsmyiXZIikY+x1BDqrQUgmxfzWh7Jvw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
@@ -3461,6 +3537,12 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/node@25.6.2':
     resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
 
@@ -3477,6 +3559,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -3603,6 +3688,9 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@ungap/structured-clone@1.4.0':
+    resolution: {integrity: sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==}
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -4094,6 +4182,9 @@ packages:
   capnweb@0.6.1:
     resolution: {integrity: sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4101,6 +4192,12 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -4124,6 +4221,9 @@ packages:
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -4404,8 +4504,15 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dom-accessibility-api@0.5.16:
@@ -4817,6 +4924,12 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -4831,6 +4944,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -5186,6 +5302,9 @@ packages:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lucide-react@1.23.0:
     resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
@@ -5217,6 +5336,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
@@ -5231,6 +5353,21 @@ packages:
 
   mermaid@11.17.2:
     resolution: {integrity: sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5336,6 +5473,12 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   openai@6.40.0:
     resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
@@ -5550,6 +5693,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   prosemirror-changeset@2.4.1:
     resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
 
@@ -5681,6 +5827,15 @@ packages:
     resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
     engines: {node: '>= 20.0.0'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -5785,6 +5940,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@4.4.3:
+    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
+    engines: {node: '>=20'}
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -5817,6 +5976,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -5859,6 +6021,9 @@ packages:
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -5931,6 +6096,9 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -5995,6 +6163,21 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
@@ -6017,6 +6200,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -6203,6 +6392,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -7708,6 +7900,31 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@pierre/diffs@1.4.1(@shikijs/themes@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@pierre/theme': 2.0.0
+      '@pierre/theming': 1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(shiki@4.4.3)
+      '@shikijs/transformers': 4.4.3
+      diff: 9.0.0
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      shiki: 4.4.3
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
+  '@pierre/theme@2.0.0': {}
+
+  '@pierre/theming@1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(shiki@4.4.3)':
+    optionalDependencies:
+      '@pierre/theme': 2.0.0
+      '@shikijs/themes': 4.4.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      shiki: 4.4.3
+
   '@playwright/test@1.62.1':
     dependencies:
       playwright: 1.62.1
@@ -7928,6 +8145,51 @@ snapshots:
     dependencies:
       '@sentry/browser-utils': 10.62.0
       '@sentry/core': 10.62.0
+
+  '@shikijs/core@4.4.3':
+    dependencies:
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/primitive@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/transformers@4.4.3':
+    dependencies:
+      '@shikijs/core': 4.4.3
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/types@4.4.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
@@ -8392,6 +8654,14 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
@@ -8408,6 +8678,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -8474,6 +8746,8 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@ungap/structured-clone@1.4.0': {}
 
   '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
@@ -9232,9 +9506,15 @@ snapshots:
 
   capnweb@0.6.1: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -9254,6 +9534,8 @@ snapshots:
   code-excerpt@4.0.0:
     dependencies:
       convert-to-spaces: 2.0.1
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@7.2.0: {}
 
@@ -9526,7 +9808,13 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -9918,6 +10206,24 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   highlight.js@10.7.3: {}
 
   hono@4.13.5: {}
@@ -9929,6 +10235,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -10280,6 +10588,8 @@ snapshots:
 
   lru.min@1.1.4: {}
 
+  lru_map@0.4.1: {}
+
   lucide-react@1.23.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -10297,6 +10607,18 @@ snapshots:
   marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.4.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
 
   media-typer@1.1.1: {}
 
@@ -10328,6 +10650,23 @@ snapshots:
       stylis: 4.4.0
       ts-dedent: 2.3.0
       uuid: 14.0.0
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -10428,6 +10767,14 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   openai@6.40.0(ws@8.21.3)(zod@4.4.3):
     optionalDependencies:
@@ -10609,6 +10956,8 @@ snapshots:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+
+  property-information@7.2.0: {}
 
   prosemirror-changeset@2.4.1:
     dependencies:
@@ -10793,6 +11142,16 @@ snapshots:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -10932,6 +11291,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@4.4.3:
+    dependencies:
+      '@shikijs/core': 4.4.3
+      '@shikijs/engine-javascript': 4.4.3
+      '@shikijs/engine-oniguruma': 4.4.3
+      '@shikijs/langs': 4.4.3
+      '@shikijs/themes': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -10973,6 +11343,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split2@4.2.0: {}
 
   sql-escaper@1.3.3: {}
@@ -11010,6 +11382,11 @@ snapshots:
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@7.2.0:
     dependencies:
@@ -11063,6 +11440,8 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  trim-lines@3.0.1: {}
 
   ts-algebra@2.0.0: {}
 
@@ -11142,6 +11521,29 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universal-user-agent@7.0.3: {}
 
   unpipe@1.0.0: {}
@@ -11155,6 +11557,16 @@ snapshots:
   uuid@14.0.0: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -11271,3 +11683,5 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalog:
   '@manti-ui/styles': 0.9.0
   '@modelcontextprotocol/sdk': 1.30.0
   '@nkzw/fate': 1.3.1
+  '@pierre/diffs': 1.4.1
   '@playwright/test': ^1.62.1
   '@sentry/cloudflare': 10.62.0
   '@sentry/effect': 10.62.0


### PR DESCRIPTION
One `Diff` component in `packages/design`, wrapping `@pierre/diffs` 1.4.1. It takes `before`, `after`
and a `path`, derives the language from the extension, renders unified by default and `split` on
request. Tuval's tool-call detail (#8613) is the first consumer; nothing is wired here.

**The library only renders into Shadow DOM.** Its React `FileDiff` returns a `<diffs-container>`
custom element whose constructor calls `attachShadow({mode: "open"})` and adopts its own stylesheet
(`dist/components/web-components.js` at 1.4.1) — there is no light-DOM mode. So `tokens.css` cannot
reach the rows, and the only thing that crosses is an inherited CSS custom property. Every one that
does is written down in `Diff.css`, on the host element rather than the wrapper, because the
library's own `:host` rule beats a value inherited from an ancestor.

**Colour comes from role tokens in both themes, by construction.** The library resolves a
light/dark theme pair through CSS `light-dark()`, which follows the used `color-scheme` and not
phoenix's `data-theme` — the two disagree the moment someone picks a theme against their OS. So this
registers one Shiki css-variables theme (`registerCustomCSSVariableTheme`) instead: every colour it
emits is `var(--diffs-…)`, and those are fed role tokens that already switch on `data-theme`. Checked
rendered in Chromium at both themes: dark resolves the surface to `#111113` and a keyword to
`rgb(158, 177, 255)`, light to `#fcfcfd` and `rgb(58, 91, 199)` — the same tokens, no
`prefers-color-scheme` in the path. Comments and gutter numbers sit on `--text-muted`, the AA floor
for meaning-carrying text, not `--text-faint`.

**The scroller is the focusable element**, `CodeBlock`'s rule. The library's default `overflow` puts
a horizontal scroller inside the shadow root where no tab stop can be placed on it (WCAG 2.1.1), so
the component passes `overflow: "wrap"` and the wrapper is the one box that scrolls, carrying
`tabIndex={0}`, `role="region"` and one localized `aria-label` — and only one, so no per-line noise.

**Dependency.** `@pierre/diffs: 1.4.1` is a new root `catalog:` entry consumed as `catalog:` from
`packages/design`. The lockfile diff adds 80 entries and removes none. Read for a second copy: the
two `@pierre/*` rows that look duplicated are peer-suffix variants of one version, and the one real
duplicate is `diff` — 8.0.4 (already in the tree via `@earendil-works/pi-*`, node-side) beside 9.0.0
(exact-pinned by `@pierre/diffs`, browser-side). Neither is declared by a workspace manifest, so
there is nothing to catalog, and jsdiff holds no registry or singleton, so two copies are weight
rather than a correctness hazard. `fabrika guard catalog-guard check` passes.

**Bundle.** The desk pays +330 B gzip today, all of it CSS, because the JS tree-shakes out until
#8613 renders one. The full numbers, the method, and what #8613 buys (+144 KB gzip on the entry
chunk) are on the issue.

Grounded in the installed package under `node_modules`, not the website: `dist/components/web-components.js`,
`dist/react/FileDiff.js`, `dist/react/types.d.ts`, `dist/style.js`, `dist/utils/getHighlighterThemeStyles.js`,
`dist/utils/parseDiffFromFile.js`, `dist/highlighter/themes/registerCustomCSSVariableTheme.js`, and
`@shikijs/core@4.4.3`'s `createCssVariablesTheme`.

Fixes #8620

## Deviations

- **Out-of-scope change** — **Said:** #8620 names `packages/design`. **Did:** also added a `ui.diff`
  row to `apps/tuval/src/shell/chat/copy.ts` and to `apps/web/src/i18n/{en,tr}/account.ts`.
  **Why:** both apps supply a full `DesignTranslate` catalog and the typecheck fails on a missing
  design key; without these three rows the repo does not compile. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the component and its test. **Did:** also shimmed
  `CSSStyleSheet.prototype.replaceSync` in `packages/design/test-setup.ts` and added a `Diff` row to
  `src/a11y/registry.tsx`. **Why:** jsdom 26 constructs a `CSSStyleSheet` but implements no
  `replaceSync`, so the library's custom-element constructor throws in every design test; and the
  a11y suite's coverage test fails on any unclassified runtime export of `index.ts`.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about it. **Did:** left `diff` at two versions in
  the lockfile (8.0.4 and 9.0.0). **Why:** `@pierre/diffs` pins 9.0.0 exactly, so an override to
  Pi's 8.0.4 would misstate what the parent asked for; the two never meet. **Disposition:** stated
  here.
