### PR TITLE
fix: Closing a Tuval chat fold fires a history page read nobody asked for

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -680,8 +680,8 @@ function ChatWindow({
 	const selfScrollRef = useRef<number | null>(null);
 
 	/**
-	 * Where the content ended at the last scroll event, so the next one can tell the browser's own
-	 * clamp from the reader.
+	 * Where the content ended, and where the scroller rested, at the last scroll event — the pair
+	 * the next event needs to tell the browser's own clamp from the reader.
 	 *
 	 * Shortening the row list — closing a fold, and every other path that drops rows — leaves the
 	 * scroller resting past the end of what is left, and the browser answers by clamping the offset
@@ -689,8 +689,17 @@ function ChatWindow({
 	 * *caused* but never *asked* its scroller for, so `selfScrollRef` above is null and the clamp
 	 * reads as the reader moving: on a transcript barely taller than its viewport the clamped offset
 	 * is inside `topThreshold`, and a page of history nobody asked for goes out (#8643).
+	 *
+	 * The offset is half of it because the end alone does not name a clamp: a shrink under a reader
+	 * resting *above* the new end clamps nothing and fires no event at all, so the end left here is
+	 * the taller one, and the reader's next arrival at the bottom in a single event — `End`, a click
+	 * on the scrollbar track, a fling — would read as that clamp. A browser clamps only an offset
+	 * that was already past the new end, so requiring the rested offset to have been past it is what
+	 * makes this exactly as narrow as the event it names. `restingAt` above cannot serve: the commit
+	 * debounce nulls it (#8643, review round 1).
 	 */
 	const contentEndRef = useRef<number | null>(null);
+	const restedAtRef = useRef<number | null>(null);
 	const scrollToFn = useCallback<
 		NonNullable<VirtualizerOptions<HTMLDivElement, Element>["scrollToFn"]>
 	>(
@@ -847,13 +856,20 @@ function ChatWindow({
 			const asked = selfScrollRef.current;
 			selfScrollRef.current = null;
 			// …and neither is a question the browser's clamp answers: the content ended further down
-			// at the last scroll event and this offset is exactly the new end, which is the shape of
-			// a list that shortened under a scroller resting past it (`contentEndRef` above).
+			// at the last scroll event, the scroller rested past where it ends now, and this offset is
+			// exactly that new end — a list that shortened under a scroller sitting past it
+			// (`contentEndRef` above).
 			const contentEnd = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
 			const endBefore = contentEndRef.current;
+			const restedAt = restedAtRef.current;
 			contentEndRef.current = contentEnd;
+			restedAtRef.current = offset;
 			const clamped =
-				endBefore !== null && endBefore > contentEnd && Math.abs(offset - contentEnd) <= 1;
+				endBefore !== null &&
+				endBefore > contentEnd &&
+				restedAt !== null &&
+				restedAt > contentEnd &&
+				Math.abs(offset - contentEnd) <= 1;
 			const byReader = !clamped && (asked === null || Math.abs(offset - asked) > 1);
 			// The pin is written on the transition and not through the debounce below: a turn landing
 			// inside the settle window would otherwise read a pin the operator has already left.

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -678,6 +678,19 @@ function ChatWindow({
 	 * the follow stops dead in the middle of a streaming reply (#8174).
 	 */
 	const selfScrollRef = useRef<number | null>(null);
+
+	/**
+	 * Where the content ended at the last scroll event, so the next one can tell the browser's own
+	 * clamp from the reader.
+	 *
+	 * Shortening the row list — closing a fold, and every other path that drops rows — leaves the
+	 * scroller resting past the end of what is left, and the browser answers by clamping the offset
+	 * to the new end and firing one ordinary `scroll` carrying it. That offset is one the window
+	 * *caused* but never *asked* its scroller for, so `selfScrollRef` above is null and the clamp
+	 * reads as the reader moving: on a transcript barely taller than its viewport the clamped offset
+	 * is inside `topThreshold`, and a page of history nobody asked for goes out (#8643).
+	 */
+	const contentEndRef = useRef<number | null>(null);
 	const scrollToFn = useCallback<
 		NonNullable<VirtualizerOptions<HTMLDivElement, Element>["scrollToFn"]>
 	>(
@@ -824,7 +837,8 @@ function ChatWindow({
 
 	const onScroll = useCallback(
 		(event: UIEvent<HTMLDivElement>) => {
-			const offset = event.currentTarget.scrollTop;
+			const scroller = event.currentTarget;
+			const offset = scroller.scrollTop;
 			// This event is the arrival of the offset `scrollToFn` above just asked for, so it is the
 			// window hearing its own request rather than the reader moving. Both readings below are
 			// about where the *reader* went — whether they left the newest turn, and whether they
@@ -832,11 +846,19 @@ function ChatWindow({
 			// own answers.
 			const asked = selfScrollRef.current;
 			selfScrollRef.current = null;
-			const byReader = asked === null || Math.abs(offset - asked) > 1;
+			// …and neither is a question the browser's clamp answers: the content ended further down
+			// at the last scroll event and this offset is exactly the new end, which is the shape of
+			// a list that shortened under a scroller resting past it (`contentEndRef` above).
+			const contentEnd = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+			const endBefore = contentEndRef.current;
+			contentEndRef.current = contentEnd;
+			const clamped =
+				endBefore !== null && endBefore > contentEnd && Math.abs(offset - contentEnd) <= 1;
+			const byReader = !clamped && (asked === null || Math.abs(offset - asked) > 1);
 			// The pin is written on the transition and not through the debounce below: a turn landing
 			// inside the settle window would otherwise read a pin the operator has already left.
 			if (byReader) {
-				const pinned = onNewest(event.currentTarget, totalSize, options.bottomThreshold);
+				const pinned = onNewest(scroller, totalSize, options.bottomThreshold);
 				commit((current) => (current.pinned === pinned ? current : {...current, pinned}));
 			}
 			// The offset is where the transcript rests whoever moved it, so it is committed either way.

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -984,6 +984,30 @@ describe("a fold closing under the reader", () => {
 		expect(screen.queryByText("Loading earlier messages…")).toBeNull();
 	});
 
+	// The other side of the guard, and the failure the first version of it shipped (review round 1
+	// on #8646): a shrink under a reader resting *above* the new end clamps nothing and fires no
+	// event, so the held content end is the taller one until the next scroll. The reader arriving at
+	// the bottom in a single event — `End`, a click on the scrollbar track, a fling — then looks
+	// exactly like the clamp, and a window that reads it as one never re-arms its pin and stops
+	// following new turns, which is #8174 arriving through this guard.
+	it("re-arms the pin when the reader jumps to the bottom after a shrink that clamped nothing", async () => {
+		const {process, view} = await withFoldOpen();
+		// The top asks for one page of history, as it should — that is the reader, and this case is
+		// not about that read.
+		await scrollTo(0);
+		await waitFor(() => expect(process.inbox()).toHaveLength(1));
+		expect(view().pinned).toBe(false);
+
+		await closeFold();
+		const closedEnd = contentEnd();
+		expect(closedEnd).toBeGreaterThan(0);
+
+		await scrollTo(closedEnd);
+
+		await waitFor(() => expect(view().pinned).toBe(true));
+		expect(process.inbox()).toHaveLength(1);
+	});
+
 	// The twin, and the reason the guard above is about the clamp rather than about folds: with the
 	// reader resting on the newest turn the window is pinned, its own follow effect issues the
 	// scroll, and `selfScrollRef` already answers the event that carries it back.

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -900,6 +900,113 @@ describe("paging", () => {
 	});
 });
 
+describe("a fold closing under the reader", () => {
+	// The shape #8446 was sighted on: a tool call heading a fold of nested children, ordinary turns
+	// above it, more history behind. Closing the fold drops the revealed rows, the scroller is left
+	// resting past the end of what is left, and the browser clamps the offset to that end and fires
+	// one ordinary scroll carrying it — measured in Chromium through the repo's own playwright, on
+	// #8446. jsdom neither lays out nor clamps, so the clamp is staged: the offset is written and
+	// the event fired, the way every other scroll in this file is.
+	const group = [
+		userItem("i0", "prompt 0"),
+		assistantItem("i1", "answer 1"),
+		call("agent", {name: "Agent"}),
+		call("child-1", {name: "bash", parentId: "agent"}),
+		// Between the two calls so the fold reveals three rows rather than one: consecutive calls at
+		// one depth render as a single run row (#8612), and this case is about the height the reveal
+		// adds, not about how the calls print.
+		{...assistantItem("child-2", "nested answer"), parentId: ItemId.make("agent")},
+		call("child-3", {name: "grep", parentId: "agent"}),
+	];
+
+	// Every row measures a full viewport here, so a transcript short enough for the clamped offset
+	// to land inside the top threshold is staged from the threshold instead — the same staging the
+	// "stops following the newest turn when it is the top that asked for the page" case uses. On a
+	// real desk it is the transcript that is short: closing the fold brings it near its viewport's
+	// own height.
+	const TOP_THRESHOLD = TEST_VIEWPORT.height * 4;
+
+	const foldButton = (): HTMLElement => screen.getByRole("button", {name: /nested calls?$/});
+
+	/**
+	 * A window opened on the fold already unfolded, with its opening scroll landed and its box
+	 * following the rows.
+	 *
+	 * Restored open rather than clicked open, so the only scroll the window has asked for is the
+	 * opening one and landing it leaves the reader's own scroll as the first thing it did not ask
+	 * for. Clicking would leave the opening `scrollToIndex` re-deriving its target off the reveal's
+	 * own measurements, and a scroll of the window's own is exempt from both readings under test.
+	 */
+	const withFoldOpen = async (view: Partial<ChatView> = {}) => {
+		const harness = await openWindow(
+			withTranscript(group),
+			{pageLimit: 25, topThreshold: TOP_THRESHOLD},
+			{...initialChatView, unfolded: ["agent"], ...view},
+		);
+		trackContentHeight();
+		await landPendingScroll(harness.scrolls);
+		await settle();
+		return harness;
+	};
+
+	const closeFold = async (): Promise<void> => {
+		await act(async () => {
+			fireEvent.click(foldButton());
+		});
+		await settle();
+	};
+
+	it("reads the clamp the close produces as the clamp it is, and asks for no page", async () => {
+		const {process, view} = await withFoldOpen();
+		const revealedEnd = contentEnd();
+		// The reader resting inside the rows the fold revealed, short of the end — so the window is
+		// unpinned, which is the state `toggleFold` leaves it in when it opens one, and the state
+		// with no protection.
+		const restingAt = revealedEnd - TEST_VIEWPORT.height;
+		await scrollTo(restingAt);
+		await waitFor(() => expect(view().pinned).toBe(false));
+		await settle();
+		expect(process.inbox()).toEqual([]);
+
+		await closeFold();
+		const closedEnd = contentEnd();
+		// The list shortened under the reader, the offset they rest at is past the new end, and that
+		// end is inside the top threshold: the three facts that make the clamp reach `requestOlder`.
+		expect(closedEnd).toBeLessThan(revealedEnd);
+		expect(restingAt).toBeGreaterThan(closedEnd);
+		expect(closedEnd).toBeLessThanOrEqual(TOP_THRESHOLD);
+		expect(restingAt).toBeGreaterThan(TOP_THRESHOLD);
+
+		await scrollTo(closedEnd);
+		await settle();
+
+		expect(process.inbox()).toEqual([]);
+		expect(screen.queryByText("Loading earlier messages…")).toBeNull();
+	});
+
+	// The twin, and the reason the guard above is about the clamp rather than about folds: with the
+	// reader resting on the newest turn the window is pinned, its own follow effect issues the
+	// scroll, and `selfScrollRef` already answers the event that carries it back.
+	it("asks for no page when the reader rests at the bottom and the follow issues the scroll", async () => {
+		const {process, scrolls, view} = await withFoldOpen();
+		await scrollTo(contentEnd());
+		await waitFor(() => expect(view().pinned).toBe(true));
+		await settle();
+		const before = scrolls.length;
+
+		await closeFold();
+
+		await waitFor(() => expect(scrolls.length).toBeGreaterThan(before));
+		const asked = scrolls[scrolls.length - 1];
+		if (asked === undefined) throw new Error("the follow asked its scroller for nothing");
+		await scrollTo(asked);
+		await settle();
+
+		expect(process.inbox()).toEqual([]);
+		expect(view().pinned).toBe(true);
+	});
+});
+
 describe("the composer", () => {
 	it("sends one prompt with a fresh key and clears the draft", async () => {
 		const {process, keys, view} = await openWindow(withTranscript(transcriptOf(2)));


### PR DESCRIPTION
Closing a fold in a Tuval chat window drops its nested rows, so the transcript shrinks. The browser clamps a scroller resting past the new content end and fires one ordinary `scroll` carrying it — measured in Chromium on #8446. `onScroll` guarded only offsets the window *asked* its scroller for (`selfScrollRef`), and a clamp is an offset the window *caused* but never asked for, so it read as the reader arriving at the top: on a short transcript the clamped offset lands inside `topThreshold` and a page of history nobody wanted goes out, swapping the `older` head row for `loading` and then `page-error`.

`onScroll` now holds the content end across scroll events. An offset that equals the current end while the previous end was larger is that clamp, and neither of the two readings `byReader` gates — did the reader leave the newest turn, did they reach the top asking for history — is a question a clamp answers. It sits at the scroll seam, so every list-shortening path is covered, not the fold alone.

Two cases in `chat-window.unit.test.tsx`, the pair the diagnosis describes. The first is the bug: fold open, reader resting inside the revealed rows, fold closed, clamp fired — it reds on `origin/main`'s `onScroll` with exactly `{"before": "i0", "limit": 25, "type": "page"}` and is green here. The second is the twin that already passed and still does: the reader at the bottom, the window pinned, its follow effect issuing the scroll and `selfScrollRef` answering the event.

`apps/tuval/src/shell/chat` unit tests: 404 passed, `boundary.unit.test.ts` included.

The diagnosis's open second half — why that one page read came back unconfirmed — is untouched, as #8643 says.

Fixes #8643

## Deviations

None.
