### PR TITLE
feat: Tuval inspector shows the Claude account a session booted on, as organization and plan

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -377,6 +377,11 @@ export const foldEvent = (
 		// what that backend is running.
 		case "version":
 			return {...state, agentVersion: event.version};
+		// Replaced whole, never merged into the standing one: the layer resolves the account at the
+		// open, so a field the newest announcement omits is a field this session does not have — and
+		// a merge would keep the organization a previous login reported.
+		case "account":
+			return {...state, account: event.account};
 		// Replaced under its own id, never merged: the mapper computes the whole slot from the
 		// worker's frames, so a merge would keep a line the newer read has already superseded. A
 		// finished slot is kept rather than dropped — its rows are a view an operator may be

--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -319,3 +319,43 @@ describe("folding the version a layer reports", () => {
 		expect({...folded, agentVersion: null}).toEqual(start);
 	});
 });
+
+describe("folding the account a layer reports", () => {
+	const limits: WindowLimits = {};
+	const account = {organization: "kamp.us", subscriptionType: "max"};
+
+	it("fills the slot the state starts empty", () => {
+		const start = initialState("/repo");
+		expect(start.account).toBeNull();
+		expect(foldEvent(start, {kind: "account", account}, limits).account).toEqual(account);
+	});
+
+	// Each field stands alone: an API-key login reports a plan and no organization, and neither is
+	// a state the slot has to represent with a placeholder.
+	it("keeps a report that carries only one of the two fields", () => {
+		const folded = foldEvent(initialState("/repo"), {kind: "account", account: {}}, limits);
+		expect(folded.account).toEqual({});
+		expect(
+			foldEvent(
+				initialState("/repo"),
+				{kind: "account", account: {subscriptionType: "max"}},
+				limits,
+			).account,
+		).toEqual({subscriptionType: "max"});
+	});
+
+	// Replaced whole rather than merged: a field the newest announcement omits is a field this
+	// session does not have, and keeping the previous login's organization beside it would lie.
+	it("replaces what it held rather than merging into it", () => {
+		const first = foldEvent(initialState("/repo"), {kind: "account", account}, limits);
+		expect(
+			foldEvent(first, {kind: "account", account: {subscriptionType: "pro"}}, limits).account,
+		).toEqual({subscriptionType: "pro"});
+	});
+
+	it("touches nothing else on the session", () => {
+		const start: AiAgentSessionState = {...initialState("/repo"), phase: "prompting"};
+		const folded = foldEvent(start, {kind: "account", account}, limits);
+		expect({...folded, account: null}).toEqual(start);
+	});
+});

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -71,6 +71,7 @@ export {
 	withUsageLedger,
 } from "./snapshot.ts";
 export {
+	type AgentAccount,
 	type AgentFailure,
 	type AiAgentSessionState,
 	type CheckpointField,

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -39,6 +39,23 @@ const isNullOrString = (value: unknown): value is string | null =>
 const isFiniteNumber = (value: unknown): value is number =>
 	typeof value === "number" && Number.isFinite(value);
 
+const isAbsentOrString = (value: unknown): boolean =>
+	value === undefined || typeof value === "string";
+
+/**
+ * The booted-on account, whose two fields are each optional.
+ *
+ * The `email` clause is the founder's org-and-plan-only ruling held at the parse boundary (#8649):
+ * `AgentAccount` declares no such field, so nothing in this process can write one, and a checkpoint
+ * that carries one was not written by this program and is not a session this program will load.
+ */
+const isNullOrAccount = (value: unknown): boolean =>
+	value === null ||
+	(Predicate.isObject(value) &&
+		value.email === undefined &&
+		isAbsentOrString(value.organization) &&
+		isAbsentOrString(value.subscriptionType));
+
 /** The flat totals a checkpoint written before usage was keyed by turn carries; see `withUsageLedger`. */
 const isFlatUsage = (value: unknown): value is UsageTotals =>
 	Predicate.isObject(value) &&
@@ -148,6 +165,7 @@ export const isAiAgentSessionState = (value: unknown): value is AiAgentSessionSt
 	isInterruption(value.interruption) &&
 	isUsage(value.usage) &&
 	isNullOrString(value.agentVersion) &&
+	isNullOrAccount(value.account) &&
 	isPermissions(value.permissions) &&
 	isFiniteNumber(value.permissionsRaised) &&
 	isModes(value.modes) &&

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -10,7 +10,7 @@
  * plus the running total of what the bounds dropped.
  */
 
-import type {AgentFailure, Phase} from "../events.ts";
+import type {AgentAccount, AgentFailure, Phase} from "../events.ts";
 import type {
 	CommandRef,
 	ItemId,
@@ -98,8 +98,8 @@ export interface ThinkingState {
 	readonly available: ReadonlyArray<ThinkingLevel>;
 }
 
-// A layer pushes one of these on the event stream too, so it is declared beside `Phase`.
-export type {AgentFailure} from "../events.ts";
+// A layer pushes one of these on the event stream too, so they are declared beside `Phase`.
+export type {AgentAccount, AgentFailure} from "../events.ts";
 
 /**
  * An interruption the operator asked for and no backend event has answered yet (#8007).
@@ -159,6 +159,16 @@ export interface AiAgentSessionState {
 	 * `claude --version` on the same box read `2.1.263`.
 	 */
 	readonly agentVersion: string | null;
+	/**
+	 * The account this session booted on, as the layer reported it — or `null` for every way there
+	 * is nothing to report: no layer has said yet, the layer has no account concept (Pi, Codex), or
+	 * the login carries neither field (an API key, a third-party provider).
+	 *
+	 * Model-blind like `agentVersion` beside it, and it holds no email by construction: `AgentAccount`
+	 * has no such field, so the founder's org-and-plan-only ruling is a shape here rather than a
+	 * filter at the render (#8649).
+	 */
+	readonly account: AgentAccount | null;
 	/**
 	 * Pending permission cards by request id: one arrives with an event, and one leaves on the
 	 * confirmation of its answer rather than on the click that answered it (#8006).
@@ -242,6 +252,7 @@ export const checkpointFields = [
 	"interruption",
 	"usage",
 	"agentVersion",
+	"account",
 	"permissions",
 	"permissionsRaised",
 	"modes",
@@ -277,6 +288,7 @@ export const initialState = (cwd: string): AiAgentSessionState => ({
 	interruption: null,
 	usage: emptyUsage,
 	agentVersion: null,
+	account: null,
 	permissions: {},
 	permissionsRaised: 0,
 	modes: {current: null, available: []},
@@ -426,6 +438,11 @@ const markInterrupted = (
  * `null` for that gap says "nobody has told me yet" rather than showing a version nothing is
  * running.
  *
+ * `account` is dropped on that same argument. It names the account the *previous* process booted
+ * on, and the operator can log into another one while the desk is off — so a row still naming the
+ * old account is exactly the wrong answer to "which of my two accounts is this billing" (#8649).
+ * The layer re-announces as this session opens.
+ *
  * A queued prompt does not come back queued. The turn it was waiting for ended with the process, so
  * there is nothing left to flush it, and it is released to its window as an unsent send the same way
  * an interrupted queue is — recoverable, never resent on the operator's behalf.
@@ -458,6 +475,7 @@ export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
 		interrupted: cut ?? loaded.interrupted,
 		interruption: null,
 		agentVersion: null,
+		account: null,
 		queued: [],
 		sends: releaseQueued(
 			loaded.queued,

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -125,6 +125,40 @@ describe("the version slot the layers fill", () => {
 	});
 });
 
+describe("the booted-on account slot", () => {
+	const account = {organization: "kamp.us", subscriptionType: "max"};
+
+	it("starts empty, because no layer has reported one yet", () => {
+		expect(initialState("/repo").account).toBeNull();
+	});
+
+	it("round-trips through JSON with either field present or absent", () => {
+		for (const carried of [account, {organization: "kamp.us"}, {subscriptionType: "max"}, {}]) {
+			const withAccount = {...saved, account: carried};
+			expect(parseSessionState(JSON.parse(JSON.stringify(withAccount)))).toEqual(withAccount);
+		}
+	});
+
+	// The operator can log into the other account while the desk is off, and the row exists to
+	// answer which one this session bills — so the previous process's answer is the wrong one.
+	it("comes back empty from a checkpoint, since the login can have moved", () => {
+		expect(restore({...saved, account}).account).toBeNull();
+	});
+
+	it("refuses a saved shape that is not an account", () => {
+		expect(parseSessionState({...saved, account: {organization: 7}})).toBeNull();
+		expect(parseSessionState({...saved, account: "kamp.us"})).toBeNull();
+	});
+
+	// The founder's org-and-plan-only ruling, held at the parse boundary: nothing in this process
+	// can write an email into the slot, so a checkpoint carrying one is not this program's.
+	it("refuses a saved account carrying an email", () => {
+		expect(
+			parseSessionState({...saved, account: {...account, email: "someone@example.com"}}),
+		).toBeNull();
+	});
+});
+
 describe("a restored session and its subagents", () => {
 	const items = [userItem("u1"), assistantItem("a1")];
 	const loaded: AiAgentSessionState = {

--- a/apps/tuval/src/ai-agent/events.ts
+++ b/apps/tuval/src/ai-agent/events.ts
@@ -199,6 +199,39 @@ export interface VersionEvent {
 	readonly version: string;
 }
 
+/**
+ * The account a session booted on: the organization and the plan, and never the email.
+ *
+ * Both fields are optional because absence has three causes and none of them is an error — a layer
+ * with no account concept at all (Pi, Codex), a Claude login that carries neither (an API key, a
+ * third-party provider, where `AccountInfo`'s fields are documented absent at the `0.3.259` pin),
+ * and a CLI that answers the handshake with an empty object. A required field would have to be
+ * filled with a placeholder for all three, and the placeholder is what would reach the render.
+ *
+ * `email` is on the SDK's `AccountInfo` and is deliberately not a field here: the founder ruled org
+ * and plan only (#8649), so it is never carried rather than carried and filtered at the edge.
+ */
+export interface AgentAccount {
+	readonly organization?: string;
+	readonly subscriptionType?: string;
+}
+
+/**
+ * Which account the session booted on.
+ *
+ * Its own kind for `VersionEvent`'s reason: it is a fact about the session that arrives whether or
+ * not anything was spent, so it is not a field on `usage`. It replaces whatever the slot held, so a
+ * layer that re-announces on a resume is a no-op.
+ *
+ * "Booted on" is the honest wording, not a hedge. The SDK's `accountInfo()` never refreshes — it
+ * answers the object cached at the first connect — while the CLI re-reads the keychain every 30s,
+ * so a session whose account changed underneath it still reports the one it opened on (#8447).
+ */
+export interface AccountEvent {
+	readonly kind: "account";
+	readonly account: AgentAccount;
+}
+
 /** Plain numbers and a plain model name: no backend's usage type reaches the core. */
 export interface UsageEvent {
 	readonly kind: "usage";
@@ -229,5 +262,6 @@ export type AgentEvent =
 	| SessionResetEvent
 	| UsageEvent
 	| VersionEvent
+	| AccountEvent
 	| SubagentEvent
 	| FailureEvent;

--- a/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
+++ b/apps/tuval/src/ai-agent/window/AiAgentInspector.tsx
@@ -25,7 +25,7 @@ import {useEffect, useState} from "react";
 import type {AnyInspectorRenderer} from "../../shell/desk/index.ts";
 import {inspectorRenderer} from "../../shell/desk/index.ts";
 import type {AnyWindowHost} from "../../shell/window/index.ts";
-import {type AiAgentSessionState, usageTotals} from "../core/index.ts";
+import {type AgentAccount, type AiAgentSessionState, usageTotals} from "../core/index.ts";
 import {isAiAgentSessionState} from "../core/snapshot.ts";
 import "./ai-agent-inspector.css";
 
@@ -46,11 +46,27 @@ const tokens = new Intl.NumberFormat("en-US");
 /** Before `start` answers there is no session id, and an empty slot would read as a lost one. */
 const NO_SESSION_YET = "no session yet";
 
+/**
+ * The booted-on account as one line, or `null` when there is nothing to say.
+ *
+ * Both fields of `AgentAccount` are optional and either can stand alone, so the answer is what is
+ * present joined rather than a fixed `org · plan` template — an API-key login reports a plan and no
+ * organization, and a template would render a leading separator against nothing.
+ */
+const accountLine = (account: AgentAccount | null): string | null => {
+	if (account === null) return null;
+	const parts = [account.organization, account.subscriptionType].filter(
+		(part): part is string => part !== undefined && part !== "",
+	);
+	return parts.length === 0 ? null : parts.join(" · ");
+};
+
 /** The rows this panel shows, in the order it shows them. */
 const inspectorRows = (
 	state: AiAgentSessionState,
 ): ReadonlyArray<readonly [label: string, value: string, className?: string]> => {
 	const usage = usageTotals(state.usage);
+	const account = accountLine(state.account);
 	return [
 		["Cost", money.format(usage.cost), "tuval-agent-inspector-number"],
 		["Input tokens", tokens.format(usage.inputTokens), "tuval-agent-inspector-number"],
@@ -62,6 +78,12 @@ const inspectorRows = (
 		...(state.agentVersion === null
 			? []
 			: [["Version", state.agentVersion] as readonly [string, string]]),
+		// The label carries "booted on" because that is the whole claim: the SDK answers the account
+		// cached at the first connect and never re-reads it, so a row saying plain "Account" would
+		// promise a currency this value does not have (#8447). Omitted on the version row's rule.
+		...(account === null
+			? []
+			: [["Account (booted on)", account, "tuval-agent-inspector-wrap"] as const]),
 	];
 };
 

--- a/apps/tuval/src/ai-agent/window/ai-agent-inspector.unit.test.tsx
+++ b/apps/tuval/src/ai-agent/window/ai-agent-inspector.unit.test.tsx
@@ -26,7 +26,7 @@ import {inspectorFor} from "../../shell/desk/index.ts";
 import {installDomShims} from "../../shell/ui/dom.testing.ts";
 import {testProcess} from "../../shell/window/fixtures.ts";
 import {type AnyWindowHost, WindowId} from "../../shell/window/index.ts";
-import type {AiAgentSessionMsg, AiAgentSessionState} from "../core/index.ts";
+import type {AgentAccount, AiAgentSessionMsg, AiAgentSessionState} from "../core/index.ts";
 import {ScriptedAiAgent} from "../service/index.ts";
 import {AiAgentInspector} from "./AiAgentInspector.tsx";
 import {agentSessionState, CWD, SESSION_ID, usageOf} from "./inspector.testing.ts";
@@ -94,6 +94,68 @@ describe("what the inspector shows", () => {
 	it("leaves the row out entirely while no layer has reported one", async () => {
 		await open(agentSessionState({agentVersion: null}));
 		expect(within(panel()).queryByText("Version")).toBeNull();
+	});
+
+	it("names the account the session booted on, as organization and plan", async () => {
+		await open(agentSessionState({account: {organization: "kamp.us", subscriptionType: "max"}}));
+		const region = panel();
+		expect(within(region).getByText("Account (booted on)")).toBeDefined();
+		expect(within(region).getByText("kamp.us · max")).toBeDefined();
+	});
+
+	// Each field stands alone: an API-key login reports a plan and no organization, and a fixed
+	// `org · plan` template would render a separator against nothing.
+	it("shows whichever of the two fields the login reported", async () => {
+		await open(agentSessionState({account: {subscriptionType: "max"}}));
+		expect(within(panel()).getByText("max")).toBeDefined();
+	});
+
+	it("leaves the row out while no layer has reported an account", async () => {
+		await open(agentSessionState({account: null}));
+		expect(within(panel()).queryByText("Account (booted on)")).toBeNull();
+	});
+
+	// An account with neither field is what a third-party provider answers with, and a row reading
+	// `Account (booted on)` against an empty value says less than no row at all.
+	it("leaves the row out when the reported account carries neither field", async () => {
+		await open(agentSessionState({account: {}}));
+		expect(within(panel()).queryByText("Account (booted on)")).toBeNull();
+	});
+
+	// The founder ruled org and plan only, and the ruling holds at two places on this path. Here is
+	// the render: an account is one line of the fields the row shows, so nothing else on it reaches
+	// the panel however the state was built.
+	it("renders the row as the two ruled fields and nothing else", async () => {
+		await open(agentSessionState({account: {organization: "kamp.us", subscriptionType: "max"}}));
+		const row = [...panel().querySelectorAll(".tuval-agent-inspector-row")].find(
+			(candidate) => candidate.querySelector("dt")?.textContent === "Account (booted on)",
+		);
+		expect(row?.querySelector("dd")?.textContent).toBe("kamp.us · max");
+	});
+
+	// And here is the reader in front of it. `AgentAccount` has no email field, so a state carrying
+	// one was not written by this program — `isAiAgentSessionState` refuses it, and the panel never
+	// takes the state rather than taking it and filtering the field at the edge.
+	it("refuses a state whose account carries an email, so none is ever on screen", async () => {
+		const email = "someone@example.com";
+		render(
+			AiAgentInspector.render(
+				(await Effect.runPromise(
+					Effect.flatMap(
+						testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+							ProcessId.make("p-email"),
+							agentSessionState({
+								account: {organization: "kamp.us", subscriptionType: "max", email} as AgentAccount,
+							}),
+						),
+						(process) => process.window(WindowId.make("w-email"), {selected: null}),
+					),
+				)) as AnyWindowHost,
+			) as ReactElement,
+		);
+		await screen.findByTestId("empty-state");
+		expect(screen.queryByRole("group", {name: "Agent session"})).toBeNull();
+		expect(document.body.textContent).not.toContain(email);
 	});
 
 	it("names every value, because a bare number names nothing to a screen reader", async () => {

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -36,7 +36,7 @@ import type {
 	SDKMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import {type Cause, Effect, Exit, Layer, Queue, Ref, Scope, Stream} from "effect";
-import type {AgentEvent} from "../../ai-agent/events.ts";
+import type {AgentAccount, AgentEvent} from "../../ai-agent/events.ts";
 import {isRefusal, planTranscriptPage} from "../../ai-agent/history/index.ts";
 import type {
 	CommandRef,
@@ -422,6 +422,27 @@ const make = (
 			});
 
 		/**
+		 * The two `AccountInfo` fields the desk shows, or `null` when the handshake carried neither.
+		 *
+		 * `email` is on that type and is never read here: the founder ruled organization and plan
+		 * only (#8649). Every field of it is optional at the `0.3.259` pin, and `apiProvider`'s own
+		 * doc comment says why — for a third-party provider "the other fields are absent and auth is
+		 * external" — so a settled handshake is not the same as a known account, and one carrying
+		 * neither field announces nothing rather than an empty row.
+		 */
+		const accountOf = (handshake: {
+			readonly account?: {readonly organization?: string; readonly subscriptionType?: string};
+		}): AgentAccount | null => {
+			const organization = handshake.account?.organization;
+			const subscriptionType = handshake.account?.subscriptionType;
+			if (organization === undefined && subscriptionType === undefined) return null;
+			return {
+				...(organization === undefined ? {} : {organization}),
+				...(subscriptionType === undefined ? {} : {subscriptionType}),
+			};
+		};
+
+		/**
 		 * The first `init` frame of a session, which is the first turn's rather than the open's.
 		 *
 		 * It carries the two values the handshake does not — `SDKControlInitializeResponse` declares
@@ -583,12 +604,13 @@ const make = (
 				handle.close();
 			});
 
-			yield* Effect.tryPromise({
+			const handshake = yield* Effect.tryPromise({
 				try: () => handle.initializationResult(),
 				catch: (cause) => startWithoutHandshake(cwd, cause),
 			}).pipe(Effect.tapError(() => abandon));
 
 			return {
+				account: accountOf(handshake),
 				session: {
 					id: choice.sessionId,
 					cwd,
@@ -641,6 +663,13 @@ const make = (
 			);
 
 			yield* Ref.set(session, opened.session);
+			// Said as soon as it is known rather than behind the catalogs: unlike the model and the
+			// thinking levels this costs no subprocess round-trip — the handshake `open` already
+			// waited for carried it. A login that reported neither field announces nothing, so the
+			// inspector's row stays absent rather than empty.
+			if (opened.account !== null) {
+				yield* emit(out, [{kind: "account", account: opened.account}]);
+			}
 			// The keys belong to a session, not to the layer: a key is dropped when this *session* has
 			// seen it, so a new session admits one the previous session spent. Resuming the session the
 			// keys were recorded under is the one case that keeps them.

--- a/apps/tuval/src/claude/agent/fixtures/harness.ts
+++ b/apps/tuval/src/claude/agent/fixtures/harness.ts
@@ -128,6 +128,7 @@ export const on = <A, E>(
 			...(harness.commands === undefined ? {} : {commands: harness.commands}),
 			...(harness.commandsFail === undefined ? {} : {commandsFail: harness.commandsFail}),
 			...(harness.interruptFails === undefined ? {} : {interruptFails: harness.interruptFails}),
+			...(harness.account === undefined ? {} : {account: harness.account}),
 			...(harness.effortSwitchFails === undefined
 				? {}
 				: {effortSwitchFails: harness.effortSwitchFails}),

--- a/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
+++ b/apps/tuval/src/claude/agent/fixtures/scripted-query.ts
@@ -14,6 +14,7 @@
  */
 
 import type {
+	AccountInfo,
 	EffortLevel,
 	ListSessionsOptions,
 	ModelInfo,
@@ -89,6 +90,12 @@ export interface ScriptedBehaviour {
 	 * layer's reading of its own turn state the input the fold routes on (ADR 0356).
 	 */
 	readonly interruptFails?: Error;
+	/**
+	 * What the handshake reports as the logged-in account. The default is the empty object, which is
+	 * the shape a login with no organization and no plan answers with — so a test that wants the
+	 * inspector's account row has to say so.
+	 */
+	readonly account?: AccountInfo;
 }
 
 export const scriptedQuery = (
@@ -128,8 +135,8 @@ export const scriptedQuery = (
 	// request (`sdk.mjs`, `performCleanup`). The `catch` is the SDK's own guard against an unhandled
 	// rejection on a query nobody asked the handshake of.
 	let refuseHandshake: ((cause: unknown) => void) | null = null;
-	const handshake = new Promise<unknown>((resolve, reject) => {
-		if (behaviour.endsAtOnce !== true) resolve({commands: [], agents: [], models: []});
+	const handshake = new Promise<{readonly account: AccountInfo}>((resolve, reject) => {
+		if (behaviour.endsAtOnce !== true) resolve({account: behaviour.account ?? {}});
 		refuseHandshake = reject;
 	});
 	handshake.catch(() => {});

--- a/apps/tuval/src/claude/agent/sdk.ts
+++ b/apps/tuval/src/claude/agent/sdk.ts
@@ -18,6 +18,7 @@ import type {
 	Options,
 	PermissionMode,
 	SDKControlGetContextUsageResponse,
+	SDKControlInitializeResponse,
 	SDKMessage,
 	SDKSessionInfo,
 	SDKUserMessage,
@@ -35,18 +36,19 @@ export const SDK_VERSION = "0.3.259";
  * Narrower than the SDK's own `Query`, which declares two dozen control requests: a scripted
  * stand-in has to implement what the layer calls, not everything the CLI can be asked. The real
  * `Query` satisfies this structurally, so the seam's default needs no adapter. The return types are
- * `unknown` where the layer reads nothing off the answer, which keeps a stand-in from having to
- * mint an SDK payload it never uses.
+ * `unknown` where the layer reads nothing off the answer, and a `Pick` of the SDK's own where it
+ * reads one field, which keeps a stand-in from having to mint an SDK payload it never uses.
  *
- * `initializationResult` is the layer's opened-ness signal. `sdk.d.ts` at the `0.3.259` pin
- * documents it as returning "the cached first-connect result" (the contrast `Query.reinitialize`
- * draws against itself), so the `initialize` control request it settles completes on connect with
- * no prompt sent. The `system`/`init` message is the other thing and cannot serve: the same file
+ * `initializationResult` is the layer's opened-ness signal, and since #8649 also the one place the
+ * booted-on account is readable. `sdk.d.ts` at the `0.3.259` pin documents it as returning "the
+ * cached first-connect result" (the contrast `Query.reinitialize` draws against itself), so the
+ * `initialize` control request it settles completes on connect with no prompt sent — and so the
+ * account it carries is the one this session opened on, never a later one. The `system`/`init` message is the other thing and cannot serve: the same file
  * calls it "session metadata the CLI emits at the start of each turn", and there is no turn before
  * a prompt.
  */
 export interface AgentSession extends AsyncGenerator<SDKMessage, void> {
-	initializationResult(): Promise<unknown>;
+	initializationResult(): Promise<Pick<SDKControlInitializeResponse, "account">>;
 	interrupt(): Promise<unknown>;
 	setPermissionMode(mode: PermissionMode): Promise<void>;
 	/**

--- a/apps/tuval/src/claude/agent/start.unit.test.ts
+++ b/apps/tuval/src/claude/agent/start.unit.test.ts
@@ -156,6 +156,53 @@ describe("start opens one streaming query", () => {
 	);
 });
 
+describe("the account the handshake reports", () => {
+	it.effect("carries the organization and the plan onto the event stream", () =>
+		on({account: {organization: "kamp.us", subscriptionType: "max"}}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS + 1));
+				assert.deepStrictEqual(
+					events.find((event) => event.kind === "account"),
+					{
+						kind: "account",
+						account: {organization: "kamp.us", subscriptionType: "max"},
+					},
+				);
+			}),
+		),
+	);
+
+	// The founder ruled organization and plan only, and the ruling is held by never reading the
+	// field rather than by dropping it later — so it is absent from the whole stream, not just the
+	// account event.
+	it.effect("carries no email, whatever the handshake reported", () =>
+		on(
+			{account: {email: "someone@example.com", organization: "kamp.us", subscriptionType: "max"}},
+			(agent) =>
+				Effect.gen(function* () {
+					yield* agent.start({cwd: CWD});
+					const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS + 1));
+					assert.notInclude(JSON.stringify(events), "someone@example.com");
+					assert.notInclude(JSON.stringify(events), "email");
+				}),
+		),
+	);
+
+	// Absence is three ordinary cases at the `0.3.259` pin — an API-key login, a third-party
+	// provider, an older CLI — so the layer says nothing rather than announcing an empty account
+	// the inspector would then have to render as a blank row.
+	it.effect("announces nothing when the handshake carried neither field", () =>
+		on({modes: MODES}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				const events = yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				assert.isUndefined(events.find((event) => event.kind === "account"));
+			}),
+		),
+	);
+});
+
 describe("start against a CLI that says nothing until the first prompt", () => {
 	// The defect this shape exists for (#7962): in streaming-input mode `init` is a turn's frame, the
 	// machine refuses a prompt outside `ready`, and an open that waited for `init` was waiting for

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -44,6 +44,9 @@ const cutMidReply: AiAgentSessionState = {
 	interruption: null,
 	usage: {model: "faux/faux-1", turns: {"item-1": {inputTokens: 10, outputTokens: 4, cost: 0}}},
 	agentVersion: "0.42.0",
+	// Pi reports no account: it is a Claude handshake fact, and the slot stays empty for a layer
+	// that has no such thing to say.
+	account: null,
 	permissions: {},
 	permissionsRaised: 0,
 	modes: {current: null, available: []},


### PR DESCRIPTION
The Tuval desk inspector now names the Claude account a session booted on, as organization and plan.

`ClaudeAiAgent.start` already awaited `handle.initializationResult()` as a handshake barrier and threw the value away. It now reads `organization` and `subscriptionType` off it and announces them on the model-blind event port. `email` is on the SDK's `AccountInfo` and is never read — the founder ruled org and plan only, so the field is absent from `AgentAccount` rather than carried and filtered at the render.

It follows the `version` event's chain end to end: its own event kind (`AccountEvent`), a fold arm that replaces rather than merges, a `state.account` slot that is `null` until a layer says, and an inspector row omitted rather than shown empty.

Both fields are optional the whole way down, because absence has three ordinary causes at the `0.3.259` pin — a layer with no account concept (Pi, Codex), an API-key or third-party-provider login (`AccountInfo.apiProvider`'s own doc comment says the other fields are absent there), and a handshake that answers an empty object. A login reporting neither field announces nothing, so no blank row can reach the panel.

The row reads `Account (booted on)`. "Booted on" is in the label because the SDK's `accountInfo()` never refreshes — it answers the object cached at the first connect — while the CLI re-reads the keychain every 30s (#8447), so a plain `Account` would promise a currency the value does not have. The slot is dropped on restore for the same reason `agentVersion` is: it names the account the previous process opened on.

The org-and-plan-only ruling is held at two places, not one. The layer never reads `email`, and `isAiAgentSessionState` refuses a checkpoint whose account carries one — so a state with an email in it is not admitted by the inspector at all, rather than admitted and filtered.

`.patterns/agent-layer-phase-contract.md` is untouched: this took the dedicated-event-kind route, which leaves the ready payload's contract alone.

Reviewer's first look: `apps/tuval/src/ai-agent/events.ts` for the port shape and why both fields are optional, then `AiAgentInspector.tsx`'s `accountLine` for the omit-when-absent rule.

Fixes #8649

## Deviations

- **Out-of-scope change** — **Said:** #8649 names the port, the fold, the state and the inspector. **Did:** also narrowed `AgentSession.initializationResult` in `apps/tuval/src/claude/agent/sdk.ts` from `Promise<unknown>` to `Promise<Pick<SDKControlInitializeResponse, "account">>`, and gave the scripted query fixture an `account` behaviour. **Why:** the seam typed the handshake `unknown` precisely because the layer read nothing off it; reading a field now makes that type wrong, and the fixture is the only way to drive the read under test. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** tests belong in the inspector's and the fold's files. **Did:** also added `account: null` to the hand-built state in `apps/tuval/src/pi/restore/interrupted.unit.test.ts`. **Why:** it writes `AiAgentSessionState` field by field rather than spreading `initialState`, so a new required field breaks its compile. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the email test drives an initialize response with an `email` and checks no state or rendered output contains it. **Did:** the layer test drives exactly that and asserts the whole event stream carries neither the address nor the key; the inspector test instead asserts that a state carrying an email is refused by `isAiAgentSessionState` and never renders. **Why:** the smuggled-email state cannot reach the panel — the reader rejects it upstream — so a "renders without the email" assertion would have been testing a path that does not exist. **Disposition:** stated here.
