### PR TITLE
feat: Tuval chat: open a tool run to its calls, and each call to its detail

### DIFF
--- a/.patterns/markdown-async-block.md
+++ b/.patterns/markdown-async-block.md
@@ -73,3 +73,22 @@ Judging the drawn diagram is `review-ui`'s.
 Only inside `Markdown`, and only for a block whose content is derived from source already in the
 document. Content that needs the network is out: it can fail slowly, it can change between renders,
 and images are already excluded for exactly that reason.
+
+## The lazy-chunk case
+
+Rule 1 says the first paint is the real content, never a placeholder. One block in the transcript
+deliberately breaks it: an edit call's diff
+([`apps/tuval/src/shell/chat/ToolCallDetail.tsx`](../apps/tuval/src/shell/chat/ToolCallDetail.tsx))
+renders `@kampus/design`'s `Diff` through a `React.lazy` import, so what paints first is a one-line
+fallback and the diff arrives a frame later.
+
+The forcing constraint is measured, not assumed: referencing `Diff` from the desk entry puts
+**+143,566 B gzip** on the entry chunk (#8620's bundle comment), and a reader who never opens a tool
+call would pay all of it before first paint. Two things make the trade safe here where it would not
+be inside `Markdown`. The content is behind a disclosure, so nothing shifts under a reader who did
+not ask for it — the row only grows once they open the call. And rule 2 still holds unchanged: the
+virtualizer's `ResizeObserver` re-measures the row when the chunk lands, with no callback out of the
+block.
+
+So the exception is a disclosed block whose weight is measured and whose growth is the reader's own
+act. A block that paints into the transcript unasked still owes rule 1.

--- a/.patterns/property-based-a11y.md
+++ b/.patterns/property-based-a11y.md
@@ -21,7 +21,8 @@ the whole prop cross-product a hand-written test would enumerate one case at a t
 
 Three files, one responsibility each:
 
-- **`registry.tsx`** — classifies every runtime export of `packages/design/src/index.ts` as
+- **`registry.tsx`** — classifies every runtime export the package publishes — the barrel
+  `packages/design/src/index.ts` plus each component subpath entry — as
   `interactive` / `presentational` / `deferred`, with an arbitrary for the first
   two.
 - **`posture.ts`** — the per-invariant `enforced` / `warning` posture map (the
@@ -41,10 +42,17 @@ catching by hand becomes a permanent guardrail. Never assert a geometry/paint fa
 in jsdom; that is a false gate.
 
 **2. Fail-closed auto-coverage.** The coverage test asserts the registry's key set
-**equals** the barrel's runtime export set (symmetric difference empty). A new
+**equals** the package's runtime export set (symmetric difference empty). A new
 primitive that no one classified — or a stale entry for a removed one — **fails the
 gate** (ADR [0092](../.decisions/0092-gates-fail-closed-on-zero-scope.md)), so the
-covered set tracks `packages/design/src/index.ts` and never silently goes stale. `deferred` is a
+covered set tracks what the package publishes and never silently goes stale.
+
+That set is the barrel **plus every component subpath entry**. A component sits on its own entry so
+a consumer can code-split it — `Diff` pulls `@pierre/diffs` and Shiki, and a barrel edge is one no
+bundler can cut — and being off the barrel is a packaging fact, not an exemption from this gate. The
+entries are listed in `a11y-pbt.test.tsx`'s `SUBPATH_ENTRIES` so they can be imported statically, and
+a second case checks that list against `package.json`'s own `exports`: a new entry nobody adds there
+reds instead of quietly leaving its component uncovered. `deferred` is a
 reasoned, reason-carrying parking spot (Manti machine primitives needing required
 `items`/`trigger`/`content` props or a portal interaction; form controls whose name
 comes from a composed label prop), not an escape hatch.
@@ -79,8 +87,9 @@ Three things that pass are worth copying:
 
 ## Adding a primitive
 
-Add its export to `packages/design/src/index.ts`, then classify it in `registry.tsx` — the coverage
-test fails until you do. If it renders standalone with a valid prop arbitrary, make
+Add its export to `packages/design/src/index.ts` — or, if it is heavy enough to want code-splitting,
+to its own `exports` entry plus `a11y-pbt.test.tsx`'s `SUBPATH_ENTRIES` — then classify it in
+`registry.tsx`. The coverage test fails until you do. If it renders standalone with a valid prop arbitrary, make
 it `interactive` (with a `selector` for its control) or `presentational`; if it needs
 composition/portal/provider context to be representative, make it `deferred` with the
 reason. Keep arbitraries generating only **valid** props — the harness asserts that a

--- a/apps/tuval/package.json
+++ b/apps/tuval/package.json
@@ -45,6 +45,7 @@
 		"@playwright/test": "catalog:",
 		"@testing-library/dom": "catalog:",
 		"@testing-library/react": "catalog:",
+		"@testing-library/user-event": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -404,10 +404,19 @@ function RowView({
 		);
 	}
 	if (row.kind === "tools") {
+		// The run's own key, not its first call's id: the two would be one string in this window's
+		// shared `expanded` set, and the run could not be opened without opening that call (`rowKey`).
+		const id = rowKey(row);
 		return (
 			<>
 				<span className="kp-visually-hidden">{authorName("tool", row.nested)}</span>
-				<ToolRunRow calls={row.calls} />
+				<ToolRunRow
+					calls={row.calls}
+					open={expanded.has(id)}
+					onToggle={(next) => onToggleRow(id, next)}
+					expanded={expanded}
+					onToggleCall={onToggleRow}
+				/>
 			</>
 		);
 	}

--- a/apps/tuval/src/shell/chat/EditDiff.tsx
+++ b/apps/tuval/src/shell/chat/EditDiff.tsx
@@ -1,0 +1,29 @@
+/**
+ * The lazy boundary around `@kampus/design`'s `Diff`, and the only reason this module exists.
+ *
+ * `Diff` pulls `@pierre/diffs` and Shiki: wiring it in statically put **+143,566 B gzip** on the
+ * desk's entry chunk, measured on #8620 by forcing a reference to it from the page entry. Nothing a
+ * reader sees before opening a tool call may cost that, so the reference lives behind a `React.lazy`
+ * import of this file instead — a module the bundler can put in a chunk of its own.
+ *
+ * The import is the package's `./Diff` subpath and not its barrel: the barrel is already in the
+ * entry chunk, so a dynamic import through it puts `Diff` back where it started — measured, not
+ * assumed (the entry moved 0 B). The deep path is the only edge the bundler can cut.
+ *
+ * A default export because that is what `lazy` resolves; nothing else imports this directly.
+ */
+
+import {Diff} from "@kampus/design/Diff";
+import type {ReactElement} from "react";
+
+export default function EditDiff({
+	path,
+	before,
+	after,
+}: {
+	readonly path: string;
+	readonly before: string;
+	readonly after: string;
+}): ReactElement {
+	return <Diff path={path} before={before} after={after} />;
+}

--- a/apps/tuval/src/shell/chat/ToolCallDetail.tsx
+++ b/apps/tuval/src/shell/chat/ToolCallDetail.tsx
@@ -1,0 +1,45 @@
+/**
+ * What one tool call shows once it is open, shared by the standalone `ToolRow` and by a call inside
+ * a run. The blocks it renders are already deduped against the row's visible label
+ * (`tool-detail.ts`, `callDisclosure`), so this decides nothing about content — it only draws it.
+ *
+ * An edit renders through `@kampus/design`'s `Diff`, which is what the design law names for a
+ * before/after text diff, and which arrives in its own chunk (`EditDiff.tsx`). It is therefore the
+ * one block here that paints after the row's first frame. The row is re-measured with no
+ * cooperation from this component: the virtualizer observes each row node it is handed, so a border
+ * box that changes after the first measure is re-measured
+ * (`.patterns/markdown-async-block.md`, "the lazy-chunk case").
+ */
+
+import {lazy, type ReactElement, Suspense} from "react";
+import type {CallDisclosure} from "./tool-detail.ts";
+
+const EditDiff = lazy(() => import("./EditDiff.tsx"));
+
+export function ToolCallDetail({disclosure}: {readonly disclosure: CallDisclosure}): ReactElement {
+	return (
+		<>
+			{disclosure.edit === null ? null : (
+				<div className="tuval-chat-tool-detail">
+					<p className="tuval-chat-tool-label">edit · {disclosure.edit.path}</p>
+					<Suspense fallback={<p className="tuval-chat-tool-label">loading the diff…</p>}>
+						<EditDiff
+							path={disclosure.edit.path}
+							before={disclosure.edit.before}
+							after={disclosure.edit.after}
+						/>
+					</Suspense>
+				</div>
+			)}
+			{disclosure.blocks.map((block) => (
+				<div key={block.label} className="tuval-chat-tool-detail">
+					<p className="tuval-chat-tool-label">{block.label}</p>
+					<pre className="tuval-chat-pre">{block.text}</pre>
+				</div>
+			))}
+			{disclosure.omitted === null ? null : (
+				<p className="tuval-chat-omission">{disclosure.omitted}</p>
+			)}
+		</>
+	);
+}

--- a/apps/tuval/src/shell/chat/ToolCallRow.tsx
+++ b/apps/tuval/src/shell/chat/ToolCallRow.tsx
@@ -1,0 +1,58 @@
+/**
+ * One call inside an opened run: its line, and — when it has anything more to say — its detail a
+ * disclosure away.
+ *
+ * The disclosure is `Collapsible`, whose trigger is a real `<button>` (`@manti-ui/react@0.9.0`,
+ * `dist/index.js`), so Enter and Space are the platform's activation behaviour rather than a
+ * hand-written `onKeyDown` over `role="button"` — which is what T3 needs and this does not
+ * (`MessagesTimeline.tsx:3352-3366`).
+ *
+ * A call whose detail would only repeat the line is not a disclosure at all: no button, no
+ * `aria-expanded`, nothing in the tab order. The chevron's place is held by an `aria-hidden` span
+ * so the labels of the rows around it still line up.
+ */
+
+import {Collapsible} from "@kampus/design";
+import type {ReactElement} from "react";
+import type {ToolCall} from "./rows.ts";
+import {ToolCallDetail} from "./ToolCallDetail.tsx";
+import {callDisclosure, callLabel, canExpandCall} from "./tool-detail.ts";
+
+export function ToolCallRow({
+	item,
+	expanded,
+	onToggle,
+}: {
+	readonly item: ToolCall;
+	readonly expanded: boolean;
+	readonly onToggle: (open: boolean) => void;
+}): ReactElement {
+	const label = callLabel(item);
+	const disclosure = callDisclosure(item, label);
+	const line = (
+		<span className="tuval-chat-tool-head">
+			<span className="tuval-chat-tool-call-label">{label}</span>
+			<span className="tuval-chat-tool-status" data-status={item.status}>
+				{item.status}
+			</span>
+		</span>
+	);
+	if (!canExpandCall(disclosure)) {
+		return (
+			<span className="tuval-chat-tool-call tuval-chat-tool-call-flat">
+				{line}
+				<span className="tuval-chat-tool-call-blank" aria-hidden="true" />
+			</span>
+		);
+	}
+	return (
+		<Collapsible
+			className="tuval-chat-tool tuval-chat-tool-call"
+			open={expanded}
+			onOpenChange={onToggle}
+			trigger={line}
+		>
+			<ToolCallDetail disclosure={disclosure} />
+		</Collapsible>
+	);
+}

--- a/apps/tuval/src/shell/chat/ToolRow.tsx
+++ b/apps/tuval/src/shell/chat/ToolRow.tsx
@@ -25,64 +25,8 @@
 import {Button, Collapsible} from "@kampus/design";
 import type {ReactElement} from "react";
 import type {ToolItem} from "../../ai-agent/ports/index.ts";
-import {omissionLine, type ToolDetail, toolDetail} from "./tool-detail.ts";
-
-function DetailView({detail}: {readonly detail: ToolDetail}): ReactElement {
-	if (detail.kind === "edit") {
-		return (
-			<div className="tuval-chat-tool-detail">
-				<p className="tuval-chat-tool-label">edit · {detail.path}</p>
-				{/*
-				 * A `table` rather than a list: each row is a line and a marker, and the marker is a
-				 * real cell rather than a `::before` glyph, so a screen reader reads "removed" instead
-				 * of nothing at all. The caption names the table for the same reason.
-				 */}
-				<table className="tuval-chat-diff">
-					<caption className="kp-visually-hidden">Changes to {detail.path}</caption>
-					<tbody>
-						{detail.diff.map((line, index) => (
-							<tr
-								// A diff line has no identity of its own — two identical lines are two rows
-								// of the same text — so the index is the only stable key there is, and the
-								// list is rebuilt whole whenever the item changes.
-								key={`${index}:${line.kind}:${line.text}`}
-								data-line={line.kind}
-							>
-								{/*
-								 * The marker is the word itself, not a `+`/`-` glyph: the change is
-								 * carried by text for everyone, and the row tint is the second signal
-								 * rather than the only one (ADR 0162, Pillar 4). An unchanged line says
-								 * so only to assistive tech, because a column of "unchanged" beside every
-								 * context line is noise on screen.
-								 */}
-								<th scope="row" className="tuval-chat-diff-kind">
-									<span className={line.kind === "same" ? "kp-visually-hidden" : undefined}>
-										{line.kind === "same" ? "unchanged" : line.kind}
-									</span>
-								</th>
-								<td className="tuval-chat-diff-text">{line.text}</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
-		);
-	}
-	if (detail.kind === "shell") {
-		return (
-			<div className="tuval-chat-tool-detail">
-				<p className="tuval-chat-tool-label">command</p>
-				<pre className="tuval-chat-pre">{detail.command}</pre>
-			</div>
-		);
-	}
-	return (
-		<div className="tuval-chat-tool-detail">
-			<p className="tuval-chat-tool-label">input</p>
-			<pre className="tuval-chat-pre">{detail.input}</pre>
-		</div>
-	);
-}
+import {ToolCallDetail} from "./ToolCallDetail.tsx";
+import {callDisclosure} from "./tool-detail.ts";
 
 /**
  * The fold button's own text, which is also its accessible name. It names the act rather than the
@@ -111,8 +55,9 @@ export function ToolRow({
 	readonly fold: ToolFold | null;
 	readonly onToggle: (open: boolean) => void;
 }): ReactElement {
-	const detail = toolDetail(item);
-	const omitted = omissionLine(item.result.omitted.bytes);
+	// The trigger shows the tool's name and nothing else, so that is the whole of what the detail
+	// below is deduped against.
+	const disclosure = callDisclosure(item, item.name);
 	return (
 		<>
 			<Collapsible
@@ -128,12 +73,7 @@ export function ToolRow({
 					</span>
 				}
 			>
-				<DetailView detail={detail} />
-				<div className="tuval-chat-tool-detail">
-					<p className="tuval-chat-tool-label">{detail.kind === "shell" ? "output" : "result"}</p>
-					<pre className="tuval-chat-pre">{item.result.text}</pre>
-					{omitted === null ? null : <p className="tuval-chat-omission">{omitted}</p>}
-				</div>
+				<ToolCallDetail disclosure={disclosure} />
 			</Collapsible>
 			{fold === null ? null : (
 				<Button

--- a/apps/tuval/src/shell/chat/ToolRunRow.tsx
+++ b/apps/tuval/src/shell/chat/ToolRunRow.tsx
@@ -1,39 +1,79 @@
 /**
- * A run of consecutive tool calls as one line: a status dot, the run's sentence, and the status as
- * a word whenever the run is not simply finished.
+ * A run of consecutive tool calls: one line — a status dot, the run's sentence, and the status as a
+ * word whenever the run is not simply finished — that opens to the calls it counted (#8613).
  *
  * The dot is a state marker, not an icon — `aria-hidden`, and paired with the word beside it — so
  * neither the tint nor the shimmer is ever the only thing saying what happened (ADR 0162, Pillar 4,
  * and the manifest's state-marker bound). The shimmer collapses under `prefers-reduced-motion`
  * (`chat.css`), and the word is what survives that collapse.
  *
- * Opening the run to read one call is the next slice (#8613); this row is the line and nothing else.
+ * Two levels of disclosure, both controlled off the window's one `expanded` set: the run keys on its
+ * own `tools:<first call id>` row key and each call keys on its own item id, so opening a call never
+ * opens the run beside it and two windows over one process disclose independently.
+ *
+ * The names are English and fixed: `apps/tuval` has no i18n catalog, and only the product names are
+ * Turkish (`.glossary/LANGUAGE.md`).
  */
 
+import {Collapsible} from "@kampus/design";
 import type {ReactElement} from "react";
 import type {ToolRun} from "./rows.ts";
+import {ToolCallRow} from "./ToolCallRow.tsx";
 import {runSentence, runStatus, runStatusWord} from "./tool-run.ts";
 
-export function ToolRunRow({calls}: {readonly calls: ToolRun}): ReactElement {
+export function ToolRunRow({
+	calls,
+	open,
+	onToggle,
+	expanded,
+	onToggleCall,
+}: {
+	readonly calls: ToolRun;
+	readonly open: boolean;
+	readonly onToggle: (open: boolean) => void;
+	/** The window's own disclosed-row ids, read for each call in this run. */
+	readonly expanded: ReadonlySet<string>;
+	readonly onToggleCall: (id: string, open: boolean) => void;
+}): ReactElement {
 	const status = runStatus(calls);
 	const word = runStatusWord(status);
 	return (
-		<span className="tuval-chat-tool-run" data-status={status}>
-			<span className="tuval-chat-tool-run-dot" data-status={status} aria-hidden="true" />
-			<span
-				className={
-					status === "running"
-						? "tuval-chat-tool-run-line tuval-chat-tool-run-shimmer"
-						: "tuval-chat-tool-run-line"
+		<section className="tuval-chat-tool tuval-chat-tool-run" aria-label="Activity">
+			<Collapsible
+				open={open}
+				onOpenChange={onToggle}
+				trigger={
+					<span className="tuval-chat-tool-run-head" data-status={status}>
+						<span className="tuval-chat-tool-run-dot" data-status={status} aria-hidden="true" />
+						<span
+							className={
+								status === "running"
+									? "tuval-chat-tool-run-line tuval-chat-tool-run-shimmer"
+									: "tuval-chat-tool-run-line"
+							}
+						>
+							{runSentence(calls)}
+						</span>
+						{word === null ? null : (
+							<span className="tuval-chat-tool-run-status" data-status={status}>
+								{word}
+							</span>
+						)}
+					</span>
 				}
 			>
-				{runSentence(calls)}
-			</span>
-			{word === null ? null : (
-				<span className="tuval-chat-tool-run-status" data-status={status}>
-					{word}
-				</span>
-			)}
-		</span>
+				<ul className="tuval-chat-tool-calls" aria-label="Tool calls">
+					{calls.map((call) => (
+						<li key={call.id}>
+							<ToolCallRow
+								item={call}
+								expanded={expanded.has(call.id)}
+								onToggle={(next) => onToggleCall(call.id, next)}
+							/>
+						</li>
+					))}
+				</ul>
+			</Collapsible>
+		</section>
 	);
 }

--- a/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
@@ -87,7 +87,10 @@ describe("a collapsible tool row", () => {
 		expect(host.view().expanded).toEqual(["t1"]);
 	});
 
-	it("renders an edit call as a diff, with a marker word per changed line", async () => {
+	// The rows themselves are drawn by `@pierre/diffs` inside a shadow root, which
+	// `querySelector` does not cross and jsdom does not lay out — so what this holds is the seam:
+	// the edit reaches the design `Diff`, named for the file it touched.
+	it("renders an edit call through the design Diff, named for the file", async () => {
 		await open(
 			withTranscript([
 				call("t1", {
@@ -101,13 +104,11 @@ describe("a collapsible tool row", () => {
 			]),
 		);
 		await click(await screen.findByRole("button", {name: "edit ok"}));
-		const table = await screen.findByRole("table", {name: "Changes to src/a.ts"});
-		expect(within(table).getByRole("rowheader", {name: "removed"})).toBeDefined();
-		expect(within(table).getByRole("rowheader", {name: "added"})).toBeDefined();
-		expect(within(table).getByText("const a = 1;")).toBeDefined();
-		expect(within(table).getByText("const a = 2;")).toBeDefined();
-		// The unchanged line is present and is named, so a screen reader reads context as context.
-		expect(within(table).getAllByRole("rowheader", {name: "unchanged"}).length).toBe(1);
+		const diff = await screen.findByRole("region", {name: "diff of src/a.ts"});
+		expect(diff.classList.contains("kp-diff")).toBe(true);
+		expect(await screen.findByText("edit · src/a.ts")).toBeDefined();
+		// The one thing the old hand-rolled table was: a line table this window drew itself.
+		expect(document.querySelector(".tuval-chat-diff")).toBeNull();
 	});
 
 	it("renders a shell call as the command plus the output", async () => {

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -520,12 +520,61 @@
  * survives the reduced-motion collapse of the shimmer below (ADR 0162, Pillar 4).
  */
 .tuval-chat-tool-run {
+	font: var(--t-body-sm);
+}
+
+.tuval-chat-tool-run-head {
 	display: flex;
 	gap: var(--s-2);
 	align-items: baseline;
 	min-inline-size: 0;
-	font: var(--t-body-sm);
+}
+
+/*
+ * The calls an opened run lists. No marker and no indent of its own: each row already carries a
+ * chevron — or the blank that holds a chevron's place — and a second glyph beside it would read as
+ * two affordances on one line.
+ */
+.tuval-chat-tool-calls {
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	padding: 0 0 0 var(--s-3);
+	list-style: none;
+}
+
+.tuval-chat-tool-call {
+	min-inline-size: 0;
+	font: var(--t-mono);
 	color: var(--text-secondary);
+}
+
+.tuval-chat-tool-call-label {
+	color: var(--text-primary);
+	min-inline-size: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/*
+ * A call with nothing beyond its label is not a control, so it gets the trigger's box without the
+ * trigger's affordance: the same 36px line and the same blank where the chevron sits, so the labels
+ * of the rows around it still line up.
+ */
+.tuval-chat-tool-call-flat {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-2);
+	inline-size: 100%;
+	min-block-size: var(--tap-min);
+}
+
+.tuval-chat-tool-call-blank {
+	flex: none;
+	inline-size: 14px;
+	block-size: 14px;
 }
 
 .tuval-chat-tool-run-dot {
@@ -611,42 +660,6 @@
 	/* Meaning, so it sits on `--text-muted` and never on `--text-faint` (Pillar 4). */
 	font: var(--t-micro);
 	color: var(--text-muted);
-}
-
-.tuval-chat-diff {
-	border-collapse: collapse;
-	inline-size: 100%;
-	font: var(--t-mono);
-}
-
-/*
- * `width: 1%` plus `nowrap` is the shrink-to-fit idiom for an auto-layout table: the marker column
- * takes exactly its own text and the line column takes the rest. A `table-layout: fixed` with an
- * explicit `9ch` was tried first and a real browser split the row evenly down the middle anyway.
- */
-.tuval-chat-diff-kind {
-	width: 1%;
-	white-space: nowrap;
-	padding-inline-end: var(--s-2);
-	text-align: start;
-	vertical-align: top;
-	font: var(--t-micro);
-	font-weight: 400;
-	color: var(--text-muted);
-}
-
-.tuval-chat-diff-text {
-	white-space: pre-wrap;
-	overflow-wrap: anywhere;
-	color: var(--text-secondary);
-}
-
-.tuval-chat-diff [data-line="removed"] .tuval-chat-diff-text {
-	background: color-mix(in oklab, var(--danger) 14%, transparent);
-}
-
-.tuval-chat-diff [data-line="added"] .tuval-chat-diff-text {
-	background: color-mix(in oklab, var(--accent) 14%, transparent);
 }
 
 /* The phase line and the mode control are one header row above the transcript. */

--- a/apps/tuval/src/shell/chat/index.ts
+++ b/apps/tuval/src/shell/chat/index.ts
@@ -30,11 +30,17 @@ export {
 	type ToolRun,
 } from "./rows.ts";
 export {SessionRow} from "./SessionRow.tsx";
+export {ToolCallDetail} from "./ToolCallDetail.tsx";
+export {ToolCallRow} from "./ToolCallRow.tsx";
 export {ToolRow} from "./ToolRow.tsx";
 export {ToolRunRow} from "./ToolRunRow.tsx";
 export {
-	type DiffLine,
-	diffLines,
+	type CallBlock,
+	type CallDisclosure,
+	callArgument,
+	callDisclosure,
+	callLabel,
+	canExpandCall,
 	omissionLine,
 	type ToolAction,
 	type ToolDetail,

--- a/apps/tuval/src/shell/chat/tool-detail.ts
+++ b/apps/tuval/src/shell/chat/tool-detail.ts
@@ -184,6 +184,12 @@ export const callDisclosure = (item: ToolItem, visibleLabel: string): CallDisclo
  * Whether a call's line is worth a disclosure at all. A call whose whole content is its own label
  * gets none: no trigger, no `aria-expanded`, nothing to tab to (T3's `canExpand`,
  * `MessagesTimeline.tsx:3312-3320`).
+ *
+ * The content decides it, and a failure does not override that. T3's first arm makes a **failed**
+ * call expandable on its label alone (`:3314`), because its row's failure lives in an icon and the
+ * accessible name it builds for the trigger is where the word "failed" appears. Here the word is on
+ * the line itself either way, so that arm would buy a reader nothing and cost them a control that
+ * opens onto an empty panel — the one thing the run's own disclosure is not allowed to be.
  */
 export const canExpandCall = (disclosure: CallDisclosure): boolean =>
 	disclosure.edit !== null || disclosure.blocks.length > 0 || disclosure.omitted !== null;

--- a/apps/tuval/src/shell/chat/tool-detail.ts
+++ b/apps/tuval/src/shell/chat/tool-detail.ts
@@ -13,14 +13,13 @@
 
 import type {JsonValue, ToolItem} from "../../ai-agent/ports/index.ts";
 
-export interface DiffLine {
-	readonly kind: "same" | "removed" | "added";
-	readonly text: string;
-}
-
 export type ToolDetail =
-	/** A file edit: the path it touched, and the line diff between the two texts. */
-	| {readonly kind: "edit"; readonly path: string; readonly diff: ReadonlyArray<DiffLine>}
+	/**
+	 * A file edit: the path it touched and the two texts, handed to `@kampus/design`'s `Diff` as
+	 * they arrived. Splitting them here would be a hand-rolled line table, which the design law
+	 * names as the thing that primitive replaces (`design-system-manifest.md`, component selection).
+	 */
+	| {readonly kind: "edit"; readonly path: string; readonly before: string; readonly after: string}
 	/** A shell call. The output is the item's own `result`, which every row renders. */
 	| {readonly kind: "shell"; readonly command: string}
 	/** Anything else: the input, pretty-printed. */
@@ -43,45 +42,6 @@ const stringAt = (
 		if (typeof value === "string") return value;
 	}
 	return null;
-};
-
-/**
- * Split on `\n` and drop a single trailing empty line, so a text ending in a newline and the same
- * text without one diff as identical rather than as one phantom removed line.
- */
-const lines = (text: string): ReadonlyArray<string> => {
-	const split = text.split("\n");
-	return split.length > 1 && split[split.length - 1] === "" ? split.slice(0, -1) : split;
-};
-
-/**
- * The line diff: trim the common prefix and the common suffix, and call everything between them
- * removed-then-added.
- *
- * Deliberately **not** an LCS. A tool input carries no bound — it is whatever the backend put on
- * the wire — and an LCS is quadratic in the line counts, so a single large edit would spend the
- * render thread on a table nobody reads. This pass is linear, deterministic, and shows an edit the
- * way an edit tool makes one: a contiguous region replaced inside unchanged surroundings.
- */
-export const diffLines = (before: string, after: string): ReadonlyArray<DiffLine> => {
-	const from = lines(before);
-	const to = lines(after);
-	let head = 0;
-	while (head < from.length && head < to.length && from[head] === to[head]) head += 1;
-	let tail = 0;
-	while (
-		tail < from.length - head &&
-		tail < to.length - head &&
-		from[from.length - 1 - tail] === to[to.length - 1 - tail]
-	) {
-		tail += 1;
-	}
-	const rows: Array<DiffLine> = [];
-	for (const text of from.slice(0, head)) rows.push({kind: "same", text});
-	for (const text of from.slice(head, from.length - tail)) rows.push({kind: "removed", text});
-	for (const text of to.slice(head, to.length - tail)) rows.push({kind: "added", text});
-	for (const text of from.slice(from.length - tail)) rows.push({kind: "same", text});
-	return rows;
 };
 
 /**
@@ -136,7 +96,7 @@ const rawInput = (input: JsonValue): string =>
 export const toolDetail = (item: ToolItem): ToolDetail => {
 	const shape = toolShape(item);
 	if (shape.action === "edit") {
-		return {kind: "edit", path: shape.path, diff: diffLines(shape.before, shape.after)};
+		return {kind: "edit", path: shape.path, before: shape.before, after: shape.after};
 	}
 	if (shape.action === "command") return {kind: "shell", command: shape.command};
 	return {kind: "generic", input: rawInput(item.input)};
@@ -145,3 +105,85 @@ export const toolDetail = (item: ToolItem): ToolDetail => {
 /** The omission line an expanded row shows when the per-item bound cut the result. */
 export const omissionLine = (bytes: number): string | null =>
 	bytes > 0 ? `${bytes} bytes omitted from this result` : null;
+
+/**
+ * The call's main argument as one line: the path it touched, or the first line of the command it
+ * ran. A shape with no argument has none — a bare tool name is the whole of what that call says.
+ *
+ * One line rather than the whole string because this is a *label*, and a command spanning ten lines
+ * would make the run's list ten rows tall. Truncating here is also what keeps the raw form
+ * reachable: the disclosure below dedupes against this line, so a one-line command is never printed
+ * twice while a multi-line one still shows in full (T3's `workEntryRawCommand`,
+ * `MessagesTimeline.tsx:3073-3081`).
+ */
+export const callArgument = (item: ToolItem): string | null => {
+	const shape = toolShape(item);
+	if (shape.action === "other") return null;
+	const value = shape.action === "command" ? shape.command : shape.path;
+	const first = value.trim().split("\n")[0]?.trim() ?? "";
+	return first.length === 0 ? null : first;
+};
+
+/** The call's line in a run: the tool, and what it was pointed at. */
+export const callLabel = (item: ToolItem): string => {
+	const argument = callArgument(item);
+	return argument === null ? item.name : `${item.name} ${argument}`;
+};
+
+/** One labelled block of text inside a call's disclosure. */
+export interface CallBlock {
+	readonly label: string;
+	readonly text: string;
+}
+
+/** What a call discloses under its line, with nothing the line already says repeated. */
+export interface CallDisclosure {
+	/** The edit to render through the design `Diff`, or `null` on every other shape. */
+	readonly edit: {readonly path: string; readonly before: string; readonly after: string} | null;
+	readonly blocks: ReadonlyArray<CallBlock>;
+	readonly omitted: string | null;
+}
+
+/**
+ * What one call discloses, deduped against the label the reader can already see and against itself.
+ *
+ * The label is a parameter rather than `callLabel` because two rows disclose the same call under
+ * different lines: a run's call row shows the tool and its argument, and a standalone `ToolRow`
+ * shows the tool alone. Dedupe is only ever right against the line actually on screen —
+ * T3 passes its `visibleLabel` down for the same reason
+ * (`buildToolCallExpandedBody`, `MessagesTimeline.tsx:3083-3128`). An empty block is dropped too: a
+ * labelled box with nothing in it is a line of noise.
+ */
+export const callDisclosure = (item: ToolItem, visibleLabel: string): CallDisclosure => {
+	const detail = toolDetail(item);
+	const label = visibleLabel.trim();
+	const argument = callArgument(item);
+	const seen = new Set<string>([label]);
+	if (argument !== null && label.includes(argument)) seen.add(argument);
+	const blocks: Array<CallBlock> = [];
+	const add = (label: string, value: string): void => {
+		const text = value.trim();
+		if (text.length === 0 || seen.has(text)) return;
+		seen.add(text);
+		blocks.push({label, text});
+	};
+	if (detail.kind === "shell") add("command", detail.command);
+	if (detail.kind === "generic") add("input", detail.input);
+	add(detail.kind === "shell" ? "output" : "result", item.result.text);
+	return {
+		edit:
+			detail.kind === "edit"
+				? {path: detail.path, before: detail.before, after: detail.after}
+				: null,
+		blocks,
+		omitted: omissionLine(item.result.omitted.bytes),
+	};
+};
+
+/**
+ * Whether a call's line is worth a disclosure at all. A call whose whole content is its own label
+ * gets none: no trigger, no `aria-expanded`, nothing to tab to (T3's `canExpand`,
+ * `MessagesTimeline.tsx:3312-3320`).
+ */
+export const canExpandCall = (disclosure: CallDisclosure): boolean =>
+	disclosure.edit !== null || disclosure.blocks.length > 0 || disclosure.omitted !== null;

--- a/apps/tuval/src/shell/chat/tool-detail.unit.test.ts
+++ b/apps/tuval/src/shell/chat/tool-detail.unit.test.ts
@@ -146,6 +146,14 @@ describe("canExpandCall", () => {
 		expect(canExpandCall(callDisclosure(item, callLabel(item)))).toBe(false);
 	});
 
+	// T3 makes a failed call expandable on its label alone (`MessagesTimeline.tsx:3314`), because its
+	// row carries the failure in an icon. Tuval's line carries the word, so the arm is not taken —
+	// see `canExpandCall`. This is what that decision looks like from outside.
+	it("does not admit a failed call whose panel would be empty", () => {
+		const item: ToolItem = {...shellCall("pnpm test", ""), status: "error"};
+		expect(canExpandCall(callDisclosure(item, callLabel(item)))).toBe(false);
+	});
+
 	it("admits one with an edit, and one with a block", () => {
 		const edit = call({path: "a.ts", old: "one", new: "two"}, "Edit");
 		expect(canExpandCall(callDisclosure(edit, callLabel(edit)))).toBe(true);

--- a/apps/tuval/src/shell/chat/tool-detail.unit.test.ts
+++ b/apps/tuval/src/shell/chat/tool-detail.unit.test.ts
@@ -1,7 +1,8 @@
 /**
- * The pure half of the expanded tool row: what an input's shape says the call was, and the line
- * diff an edit renders. No DOM here — the recognition and the diff are decisions a test can make
- * without one, which is why they live outside the component.
+ * The pure half of the expanded tool row: what an input's shape says the call was, the line that
+ * names the call in a run, and what it discloses under that line. No DOM here — the recognition and
+ * the dedupe are decisions a test can make without one, which is why they live outside the
+ * component.
  */
 
 import {describe, expect, it} from "vitest";
@@ -11,7 +12,7 @@ import {
 	type JsonValue,
 	type ToolItem,
 } from "../../ai-agent/ports/index.ts";
-import {diffLines, omissionLine, toolDetail} from "./tool-detail.ts";
+import {callDisclosure, callLabel, canExpandCall, omissionLine, toolDetail} from "./tool-detail.ts";
 
 const call = (input: ToolItem["input"], name = "a_tool"): ToolItem => ({
 	kind: "tool",
@@ -35,6 +36,8 @@ describe("toolDetail", () => {
 			const detail = toolDetail(call(input));
 			expect(detail.kind).toBe("edit");
 			expect(detail.kind === "edit" ? detail.path : null).toBe("a.ts");
+			// The two texts reach `Diff` as they arrived: nothing here splits them into lines.
+			expect(detail.kind === "edit" ? [detail.before, detail.after] : null).toEqual(["one", "two"]);
 		}
 	});
 
@@ -69,57 +72,83 @@ describe("toolDetail", () => {
 	});
 });
 
-describe("diffLines", () => {
-	it("keeps the unchanged surroundings and replaces the region between them", () => {
-		expect(diffLines("a\nb\nc\nd", "a\nB\nC\nd")).toEqual([
-			{kind: "same", text: "a"},
-			{kind: "removed", text: "b"},
-			{kind: "removed", text: "c"},
-			{kind: "added", text: "B"},
-			{kind: "added", text: "C"},
-			{kind: "same", text: "d"},
-		]);
-	});
-
-	it("marks nothing when the two texts are the same", () => {
-		const rows = diffLines("a\nb", "a\nb");
-		expect(rows.every((row) => row.kind === "same")).toBe(true);
-		expect(rows.length).toBe(2);
-	});
-
-	it("reads a pure insertion as added lines and a pure deletion as removed ones", () => {
-		expect(diffLines("a\nc", "a\nb\nc")).toEqual([
-			{kind: "same", text: "a"},
-			{kind: "added", text: "b"},
-			{kind: "same", text: "c"},
-		]);
-		expect(diffLines("a\nb\nc", "a\nc")).toEqual([
-			{kind: "same", text: "a"},
-			{kind: "removed", text: "b"},
-			{kind: "same", text: "c"},
-		]);
-	});
-
-	it("does not invent a phantom line for a trailing newline", () => {
-		expect(diffLines("a\nb\n", "a\nb")).toEqual([
-			{kind: "same", text: "a"},
-			{kind: "same", text: "b"},
-		]);
-	});
-
-	it("never counts one line as both the common prefix and the common suffix", () => {
-		// "a" is the whole of both texts' overlap. Counting it twice would emit it twice, which is
-		// what a prefix scan and a suffix scan that do not bound each other do.
-		expect(diffLines("a", "a\nb")).toEqual([
-			{kind: "same", text: "a"},
-			{kind: "added", text: "b"},
-		]);
-	});
-});
-
 describe("omissionLine", () => {
 	it("says how much a bound cut, and says nothing when it cut nothing", () => {
 		expect(omissionLine(0)).toBeNull();
 		expect(omissionLine(4_096)).toBe("4096 bytes omitted from this result");
+	});
+});
+
+const shellCall = (command: string, output = "done"): ToolItem => ({
+	...call({command}, "Bash"),
+	result: boundToolResult(output),
+});
+
+describe("callLabel", () => {
+	it("names the tool and what it was pointed at", () => {
+		expect(callLabel(call({path: "src/rows.ts"}, "Read"))).toBe("Read src/rows.ts");
+		expect(callLabel(call({path: "a.ts", old: "x", new: "y"}, "Edit"))).toBe("Edit a.ts");
+		expect(callLabel(shellCall("pnpm test"))).toBe("Bash pnpm test");
+	});
+
+	it("is the tool alone when the shape carries no argument", () => {
+		expect(callLabel(call({pattern: "TODO"}, "Grep"))).toBe("Grep");
+		expect(callLabel(call(null, "Task"))).toBe("Task");
+	});
+
+	it("takes one line of a command, so a script does not become a ten-line label", () => {
+		expect(callLabel(shellCall("pnpm build\npnpm test"))).toBe("Bash pnpm build");
+	});
+});
+
+describe("callDisclosure", () => {
+	it("drops a command the visible label already shows", () => {
+		const disclosure = callDisclosure(shellCall("pnpm test"), "Bash pnpm test");
+		expect(disclosure.blocks).toEqual([{label: "output", text: "done"}]);
+	});
+
+	it("keeps that same command when the row on screen does not show it", () => {
+		// The standalone `ToolRow`'s trigger is the tool's name alone, so nothing is repeated.
+		expect(callDisclosure(shellCall("pnpm test"), "Bash").blocks).toEqual([
+			{label: "command", text: "pnpm test"},
+			{label: "output", text: "done"},
+		]);
+	});
+
+	it("shows the raw command whenever it differs from the line on screen", () => {
+		const item = shellCall("pnpm build\npnpm test");
+		expect(callDisclosure(item, callLabel(item)).blocks).toEqual([
+			{label: "command", text: "pnpm build\npnpm test"},
+			{label: "output", text: "done"},
+		]);
+	});
+
+	it("hands an edit's two texts over whole, and prints no input block beside them", () => {
+		const item = call({path: "a.ts", old: "one", new: "two"}, "Edit");
+		const disclosure = callDisclosure(item, callLabel(item));
+		expect(disclosure.edit).toEqual({path: "a.ts", before: "one", after: "two"});
+		expect(disclosure.blocks).toEqual([{label: "result", text: "done"}]);
+	});
+
+	it("carries the omission line when the per-item bound cut the result", () => {
+		const item: ToolItem = {...call({path: "a.ts"}, "Read"), result: boundToolResult("abcdef", 2)};
+		expect(callDisclosure(item, callLabel(item)).omitted).toBe("4 bytes omitted from this result");
+	});
+
+	it("drops an empty result rather than labelling an empty box", () => {
+		expect(callDisclosure(shellCall("pnpm test", ""), "Bash pnpm test").blocks).toEqual([]);
+	});
+});
+
+describe("canExpandCall", () => {
+	it("refuses a call whose whole content is the line already on screen", () => {
+		const item = shellCall("pnpm test", "");
+		expect(canExpandCall(callDisclosure(item, callLabel(item)))).toBe(false);
+	});
+
+	it("admits one with an edit, and one with a block", () => {
+		const edit = call({path: "a.ts", old: "one", new: "two"}, "Edit");
+		expect(canExpandCall(callDisclosure(edit, callLabel(edit)))).toBe(true);
+		expect(canExpandCall(callDisclosure(shellCall("pnpm test"), "Bash pnpm test"))).toBe(true);
 	});
 });

--- a/apps/tuval/src/shell/chat/tool-run-disclosure.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/tool-run-disclosure.unit.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Opening a run of tool calls, and opening one of those calls (#8613).
+ *
+ * Two disclosures over one `expanded` set: the run keys on its own `tools:<first call id>` row key
+ * and each call on its own item id, so the two never open each other and two windows over one
+ * process open the same run independently.
+ *
+ * `Collapsible` keeps its panel in the document and hides it, so every content assertion here reads
+ * the *visible* panel — `hiddenPanels` is what a `textContent` over the whole row would have
+ * silently included.
+ *
+ * `chat.css` is read off disk and put in the document because Vitest's default `css: false` makes
+ * the window's own `import "./chat.css"` an empty module — without this every style assertion is
+ * vacuous.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {act, fireEvent, render, screen, waitFor, within} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {beforeAll, describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type TestProcess, testProcess} from "../window/fixtures.ts";
+import {type WindowHost, WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {call, userItem, withTranscript} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+beforeAll(() => {
+	const style = document.createElement("style");
+	style.textContent = readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
+	document.head.appendChild(style);
+});
+
+/** Two reads and a shell call — three consecutive calls, so the window collapses them into a run. */
+const RUN: ReadonlyArray<TranscriptItem> = [
+	userItem("u1", "go"),
+	call("t0", {name: "Read", input: {file_path: "src/rows.ts"}, output: "export const rows = 1;"}),
+	call("t1", {name: "Read", input: {file_path: "src/view.ts"}, output: "export const view = 2;"}),
+	call("t2", {name: "Bash", input: {command: "pnpm test"}, output: "12 passed"}),
+];
+
+type ChatHost = WindowHost<AiAgentSessionState, AiAgentSessionMsg, ChatView>;
+
+const hostOver = async (
+	items: ReadonlyArray<TranscriptItem>,
+	windowId = "w1",
+	process?: TestProcess<AiAgentSessionState, AiAgentSessionMsg>,
+): Promise<ChatHost> => {
+	const running =
+		process ??
+		(await Effect.runPromise(
+			testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+				ProcessId.make("p1"),
+				withTranscript(items),
+			),
+		));
+	return await Effect.runPromise(
+		running.window<ChatView>(WindowId.make(windowId), initialChatView),
+	);
+};
+
+const mount = async (host: ChatHost): Promise<{readonly unmount: () => void}> => {
+	const element = chatWindow({scrollCommitMs: 0, scrollToFn: () => {}}).render(
+		host,
+	) as ReactElement;
+	const rendered = render(element);
+	await screen.findAllByRole("log", {name: "Transcript"});
+	return {unmount: rendered.unmount};
+};
+
+interface Harness {
+	readonly view: () => ChatView;
+	readonly unmount: () => void;
+}
+
+const openWindow = async (items: ReadonlyArray<TranscriptItem> = RUN): Promise<Harness> => {
+	const host = await hostOver(items);
+	const {unmount} = await mount(host);
+	return {view: () => host.view(), unmount};
+};
+
+const activity = (): HTMLElement => screen.getByRole("region", {name: "Activity"});
+
+const buttonIn = (root: HTMLElement, name: RegExp): HTMLElement =>
+	within(root).getByRole("button", {name});
+
+const runTrigger = (): HTMLElement => buttonIn(activity(), /^Read 2 files/);
+
+const callTrigger = (name: RegExp): HTMLElement => buttonIn(activity(), name);
+
+/** The panel a trigger owns, or `null` while the primitive has it hidden. */
+const visiblePanel = (trigger: HTMLElement): HTMLElement | null => {
+	const panel = document.getElementById(trigger.getAttribute("aria-controls") ?? "");
+	return panel === null || panel.hidden ? null : panel;
+};
+
+const open = async (trigger: HTMLElement): Promise<void> => {
+	await act(async () => {
+		fireEvent.click(trigger);
+	});
+};
+
+describe("a run of tool calls opens to its calls", () => {
+	it("is a disclosure, and lists the calls in order once it is open", async () => {
+		const harness = await openWindow();
+
+		expect(runTrigger().getAttribute("aria-expanded")).toBe("false");
+		expect(visiblePanel(runTrigger())).toBeNull();
+
+		await open(runTrigger());
+
+		expect(runTrigger().getAttribute("aria-expanded")).toBe("true");
+		const list = screen.getByRole("list", {name: "Tool calls"});
+		expect(visiblePanel(runTrigger())?.contains(list)).toBe(true);
+		const lines = within(list)
+			.getAllByRole("listitem")
+			.map((row) => row.querySelector(".tuval-chat-tool-head")?.textContent);
+		expect(lines).toEqual(["Read src/rows.tsok", "Read src/view.tsok", "Bash pnpm testok"]);
+		harness.unmount();
+	});
+
+	it("keys the run on its own row key, never on the first call's id", async () => {
+		const harness = await openWindow();
+
+		await open(runTrigger());
+
+		await waitFor(() => expect(harness.view().expanded).toEqual(["tools:t0"]));
+		harness.unmount();
+	});
+});
+
+describe("a call inside a run opens to its detail", () => {
+	it("carries its own aria-expanded and discloses its input and its result", async () => {
+		const harness = await openWindow();
+		await open(runTrigger());
+
+		const trigger = callTrigger(/^Bash pnpm test/);
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+		expect(visiblePanel(trigger)).toBeNull();
+
+		await open(trigger);
+
+		const opened = callTrigger(/^Bash pnpm test/);
+		expect(opened.getAttribute("aria-expanded")).toBe("true");
+		expect(visiblePanel(opened)?.textContent).toContain("12 passed");
+		// One set, three distinct keys: the run stayed open and its siblings stayed shut.
+		await waitFor(() => expect(harness.view().expanded).toEqual(["tools:t0", "t2"]));
+		expect(callTrigger(/^Read src\/rows\.ts/).getAttribute("aria-expanded")).toBe("false");
+		harness.unmount();
+	});
+
+	it("prints no command block for a command the call's own line already shows", async () => {
+		const harness = await openWindow();
+		await open(runTrigger());
+		const trigger = callTrigger(/^Bash pnpm test/);
+
+		await open(trigger);
+
+		const panel = visiblePanel(trigger);
+		const labels = [...(panel?.querySelectorAll(".tuval-chat-tool-label") ?? [])].map(
+			(node) => node.textContent,
+		);
+		expect(labels).toEqual(["output"]);
+		harness.unmount();
+	});
+
+	it("shows the whole command when the line could only carry its first line", async () => {
+		const script = "pnpm build\npnpm test";
+		const harness = await openWindow([
+			userItem("u1", "go"),
+			call("t0", {name: "Read", input: {file_path: "a.ts"}}),
+			call("t1", {name: "Bash", input: {command: script}, output: "12 passed"}),
+		]);
+		await open(buttonIn(activity(), /^Read 1 file/));
+		const trigger = callTrigger(/^Bash pnpm build/);
+
+		await open(trigger);
+
+		const blocks = [...(visiblePanel(trigger)?.querySelectorAll(".tuval-chat-pre") ?? [])].map(
+			(node) => node.textContent,
+		);
+		expect(blocks).toEqual([script, "12 passed"]);
+		harness.unmount();
+	});
+
+	it("renders an edit through the design Diff rather than a table of its own", async () => {
+		const harness = await openWindow([
+			userItem("u1", "go"),
+			call("t0", {name: "Read", input: {file_path: "a.ts"}}),
+			call("t1", {
+				name: "Edit",
+				input: {file_path: "src/count.ts", old_string: "const a = 1;", new_string: "const a = 2;"},
+				output: "edited",
+			}),
+		]);
+		await open(buttonIn(activity(), /^Read 1 file/));
+		const trigger = callTrigger(/^Edit src\/count\.ts/);
+
+		await open(trigger);
+
+		// The diff arrives with its own chunk, a frame after the row's first paint.
+		await waitFor(() => expect(screen.getByRole("region", {name: /src\/count\.ts/})).toBeDefined());
+		expect(visiblePanel(trigger)?.textContent).toContain("edited");
+		expect(document.querySelector(".tuval-chat-diff")).toBeNull();
+		harness.unmount();
+	});
+});
+
+describe("a call with nothing beyond its own line", () => {
+	it("is not a disclosure at all: no button, no tab stop, no chevron", async () => {
+		const harness = await openWindow([
+			userItem("u1", "go"),
+			call("t0", {name: "Read", input: {file_path: "a.ts"}}),
+			call("t1", {name: "Bash", input: {command: "pnpm test"}, output: ""}),
+		]);
+
+		await open(buttonIn(activity(), /^Read 1 file/));
+
+		expect(within(activity()).queryByRole("button", {name: /^Bash pnpm test/})).toBeNull();
+		const flat = document.querySelector<HTMLElement>(".tuval-chat-tool-call-flat");
+		expect(flat?.textContent).toBe("Bash pnpm testok");
+		expect(flat?.getAttribute("role")).toBeNull();
+		expect(flat?.getAttribute("tabindex")).toBeNull();
+		expect(flat?.querySelector(".tuval-chat-tool-call-blank")?.getAttribute("aria-hidden")).toBe(
+			"true",
+		);
+		harness.unmount();
+	});
+});
+
+describe("every disclosure a run adds is operable from the keyboard", () => {
+	it("opens the run with Enter and a call with Space, reaching each by Tab", async () => {
+		const user = userEvent.setup();
+		const harness = await openWindow();
+
+		while (document.activeElement !== runTrigger()) {
+			await user.tab();
+		}
+		await user.keyboard("{Enter}");
+		expect(runTrigger().getAttribute("aria-expanded")).toBe("true");
+
+		while (document.activeElement !== callTrigger(/^Bash pnpm test/)) {
+			await user.tab();
+		}
+		await user.keyboard(" ");
+
+		expect(callTrigger(/^Bash pnpm test/).getAttribute("aria-expanded")).toBe("true");
+		await waitFor(() => expect(harness.view().expanded).toEqual(["tools:t0", "t2"]));
+		harness.unmount();
+	});
+});
+
+describe("a failure is words, never only a tint", () => {
+	it("says so on the collapsed run and again on the call that failed", async () => {
+		const harness = await openWindow([
+			userItem("u1", "go"),
+			call("t0", {name: "Read", input: {file_path: "a.ts"}}),
+			call("t1", {name: "Bash", input: {command: "pnpm test"}, status: "error", output: "boom"}),
+		]);
+
+		const run = buttonIn(activity(), /^Read 1 file and ran 1 command/);
+		expect(run.textContent).toContain("failed");
+
+		await open(run);
+
+		expect(callTrigger(/^Bash pnpm test/).textContent).toContain("error");
+		harness.unmount();
+	});
+});
+
+describe("the disclosure state is the window's, not the component's", () => {
+	it("opens the same run independently in two windows over one process", async () => {
+		const process = await Effect.runPromise(
+			testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+				ProcessId.make("p1"),
+				withTranscript(RUN),
+			),
+		);
+		const left = await hostOver(RUN, "w-left", process);
+		const right = await hostOver(RUN, "w-right", process);
+		const mounted = [await mount(left), await mount(right)];
+
+		const [leftRun] = screen.getAllByRole("button", {name: /^Read 2 files/});
+		await open(leftRun as HTMLElement);
+
+		await waitFor(() => expect(left.view().expanded).toEqual(["tools:t0"]));
+		expect(right.view().expanded).toEqual([]);
+		for (const rendered of mounted) rendered.unmount();
+	});
+
+	it("comes back open on a window remounted onto the same slot", async () => {
+		const host = await hostOver(RUN);
+		const first = await mount(host);
+		await open(runTrigger());
+		await waitFor(() => expect(host.view().expanded).toEqual(["tools:t0"]));
+		first.unmount();
+
+		const again = await mount(host);
+
+		expect(runTrigger().getAttribute("aria-expanded")).toBe("true");
+		again.unmount();
+	});
+});
+
+describe("the law the new triggers are judged against", () => {
+	const css = (): string => readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
+
+	it("floors every collapsible trigger at the 36px hit area", () => {
+		const sheet = css();
+		expect(sheet).toContain("--tap-min: 36px;");
+		// The run's trigger and each call's are inside `.tuval-chat-tool`, which is the scope the
+		// shared trigger rule sizes; a call that is no trigger holds the same line for itself.
+		expect(sheet).toMatch(
+			/\.tuval-chat-tool \[data-scope="collapsible"\]\[data-part="trigger"\][^}]*min-block-size: var\(--tap-min\)/s,
+		);
+		expect(sheet).toMatch(/\.tuval-chat-tool-call-flat \{[^}]*min-block-size: var\(--tap-min\)/s);
+	});
+
+	it("hand-rolls no outline for the rows this slice adds", () => {
+		const blocks = css()
+			.split("}")
+			.filter((block) => /tuval-chat-tool-(call|run)/.test(block.split("{")[0] ?? ""));
+		expect(blocks.length).toBeGreaterThan(0);
+		expect(blocks.filter((block) => /\boutline\s*:/.test(block))).toEqual([]);
+	});
+});

--- a/apps/tuval/src/shell/ui/dom.testing.ts
+++ b/apps/tuval/src/shell/ui/dom.testing.ts
@@ -154,6 +154,11 @@ export const installDomShims = (): void => {
 		return measure(this);
 	};
 	Element.prototype.scrollIntoView ??= function scrollIntoView(): void {};
+	// jsdom 26 constructs a `CSSStyleSheet` but implements neither `replaceSync` nor
+	// `adoptedStyleSheets`, and a custom element that adopts its own sheet in its constructor
+	// (`@pierre/diffs`, behind the design `Diff`) throws there. Same shim as the design package's
+	// own `test-setup.ts`.
+	CSSStyleSheet.prototype.replaceSync ??= function replaceSync(): void {};
 	Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
 		configurable: true,
 		get: () => TEST_VIEWPORT.width,

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -8,11 +8,12 @@ entries and ownership boundaries.
 | Entry | Contents |
 | --- | --- |
 | `@kampus/design` | Component and type exports from [`src/index.ts`](./src/index.ts) |
+| `@kampus/design/Diff` | The `Diff` component, on its own entry so a consumer can code-split it |
 | `@kampus/design/tokens.css` | Raw, semantic, role, density, and Manti bridge tokens |
 | `@kampus/design/fonts.css` | First-party IBM Plex Sans and JetBrains Mono faces |
 | `AgentChatInputBridge` | App-owned Pi RPC transport supplied to `AgentChatInput` |
 | `CommandPalette` | Modal, keyboard-first search surface over caller-owned results |
-| `Diff` | Before/after renderer over `@pierre/diffs` — unified or split, role-token themed, shadow DOM |
+| `Diff` | Before/after renderer over `@pierre/diffs` — unified or split, role-token themed, shadow DOM. Off the barrel deliberately: its library costs ~144 KB gzip, and a barrel edge is one no bundler can cut |
 | `Markdown` | Read-only renderer for agent markdown — raw HTML in the source prints as text |
 | `design-token-lint.config.json` | The token guard's package-owned baseline and allow-list |
 | `src/a11y/` | Property-based accessibility suite and its posture/registry |

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -7,6 +7,7 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./a11y": "./src/a11y/check.ts",
+		"./Diff": "./src/Diff.tsx",
 		"./tokens.css": "./src/tokens.css",
 		"./fonts.css": "./src/fonts.css",
 		"./visually-hidden.css": "./src/visually-hidden.css"

--- a/packages/design/src/a11y/a11y-pbt.test.tsx
+++ b/packages/design/src/a11y/a11y-pbt.test.tsx
@@ -1,7 +1,10 @@
 /** The property-based a11y suite — see `.patterns/property-based-a11y.md`. */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {render} from "@testing-library/react";
 import fc from "fast-check";
 import {describe, expect, it} from "vitest";
+import * as DiffEntry from "../Diff.tsx";
 import * as UI from "../index.ts";
 import {runEnforcedInvariants} from "./check.ts";
 import {POSTURE, postureOf} from "./posture.ts";
@@ -12,15 +15,50 @@ const RUNS_PER_PRIMITIVE = 20;
 const testable = (spec: PrimitiveSpec): spec is Exclude<PrimitiveSpec, {kind: "deferred"}> =>
 	spec.kind !== "deferred";
 
+/**
+ * The component entries the package publishes beside its barrel. A component sits on its own entry
+ * so a consumer can code-split it — `Diff` pulls `@pierre/diffs` and Shiki, and a barrel edge is one
+ * no bundler can cut (#8613) — and being off the barrel changes nothing about owing this gate. So
+ * the covered set below is the union rather than the barrel alone.
+ */
+const SUBPATH_ENTRIES: Readonly<Record<string, Readonly<Record<string, unknown>>>> = {
+	"./Diff": DiffEntry,
+};
+
+/**
+ * The same entries read off `package.json`, so the map above is checked rather than trusted: a new
+ * subpath entry nobody adds there reds here instead of quietly leaving its component uncovered.
+ * `.` is the barrel and anything under `src/a11y/` is this suite's own harness, not a primitive.
+ */
+const publishedComponentEntries = (): ReadonlyArray<string> => {
+	const manifest = JSON.parse(
+		readFileSync(fileURLToPath(import.meta.resolve("../../package.json")), "utf8"),
+	) as {readonly exports: Readonly<Record<string, string>>};
+	return Object.entries(manifest.exports)
+		.filter(
+			([name, target]) =>
+				name !== "." && /\.tsx?$/.test(target) && !target.startsWith("./src/a11y/"),
+		)
+		.map(([name]) => name)
+		.sort();
+};
+
 describe("ui/ primitive a11y coverage (auto-covers new primitives)", () => {
+	it("names every component entry the package publishes beside the barrel", () => {
+		expect(publishedComponentEntries()).toEqual(Object.keys(SUBPATH_ENTRIES).sort());
+	});
+
 	it("classifies every runtime export of @kampus/design — a new primitive fails until classified", () => {
 		// Runtime (value) exports only; `export type` is erased, so this is exactly
 		// the set of primitives that render. The symmetric diff must be empty:
 		// an unclassified new export, or a stale entry for a removed one, fails.
-		const exported = Object.keys(UI).sort();
+		const covered = new Set(
+			[UI, ...Object.values(SUBPATH_ENTRIES)].flatMap((entry) => Object.keys(entry)),
+		);
+		const exported = [...covered].sort();
 		const classified = Object.keys(REGISTRY).sort();
-		const unclassified = exported.filter((n) => !(n in REGISTRY));
-		const stale = classified.filter((n) => !(n in UI));
+		const unclassified = exported.filter((name) => !(name in REGISTRY));
+		const stale = classified.filter((name) => !covered.has(name));
 		expect({unclassified, stale}).toEqual({unclassified: [], stale: []});
 	});
 });

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -45,8 +45,6 @@ export {CopyLinkButton} from "./CopyLinkButton";
 export type {CountToggleProps} from "./CountToggle";
 export {CountToggle} from "./CountToggle";
 export {Dialog} from "./Dialog";
-export type {DiffProps} from "./Diff";
-export {Diff} from "./Diff";
 export {DraftRestoreBanner} from "./DraftRestoreBanner";
 export {EditedIndicator} from "./EditedIndicator";
 export {EmptyState} from "./EmptyState";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ catalogs:
     '@testing-library/react':
       specifier: ^16.3.0
       version: 16.3.2
+    '@testing-library/user-event':
+      specifier: ^14.6.7
+      version: 14.6.7
     '@tiptap/core':
       specifier: 3.30.4
       version: 3.30.4
@@ -358,6 +361,9 @@ importers:
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.7(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -3224,6 +3230,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.7':
+    resolution: {integrity: sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tiptap/core@3.30.4':
     resolution: {integrity: sha512-V9yKuUfV8qC9WBrnVxkFWmYLBomc3d1CwXoFSjED5DRu5q2oyxv07F+jOJSRogJAY+feHjuxvjhixwxeHm2DXQ==}
@@ -8311,6 +8323,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.7(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tiptap/core@3.30.4(@tiptap/pm@3.27.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,7 @@ catalog:
   '@tanstack/react-virtual': 3.14.10
   '@testing-library/dom': ^10.4.1
   '@testing-library/react': ^16.3.0
+  '@testing-library/user-event': ^14.6.7
   '@tiptap/core': 3.30.4
   '@tiptap/markdown': 3.27.3
   '@tiptap/pm': 3.27.3


### PR DESCRIPTION
A run of tool calls is now a disclosure. Opening it lists the calls it counted, one line each —
the tool and its main argument (`Read src/rows.ts`, `Bash pnpm test`) plus its status as a word.
Opening a call shows that call's detail: its input or command, its result, and the omission line.

Both levels are `Collapsible` from `@kampus/design`, controlled off the window's one
`view.expanded` set. The run keys on its own `tools:<first call id>` row key and each call on its
own item id, so opening a call never opens the run beside it, two windows over one process disclose
independently, and a window switched away from and back to returns as it was left. No `ChatView`
field was added.

Three things are worth a reviewer's time first.

**Dedupe, and the call that is not a disclosure at all.** `callDisclosure(item, visibleLabel)` seeds
its `seen` set with the line the reader can already see, so a command equal to that line is not
printed twice while a multi-line command still shows in full. The label is a parameter because two
rows disclose the same call under different lines — a run's call row shows the argument, a
standalone `ToolRow` shows the tool alone. A call left with nothing after the dedupe gets no button,
no `aria-expanded` and no tab stop; its chevron's place is an `aria-hidden` blank. Both read off
T3's `buildToolCallExpandedBody` / `canExpand` (`MessagesTimeline.tsx:3083-3128`, `:3312-3320`).

**The diff is the design primitive now, and it costs the desk nothing at first paint.** The
hand-rolled line table in `ToolRow.tsx` is gone — the manifest names `Diff` as what replaces it —
and `diffLines` went with it, since `Diff` takes the two texts whole. #8620 measured that wiring
`Diff` in puts +143,566 B gzip on the entry chunk, so it is behind a `React.lazy` boundary
(`EditDiff.tsx`). That alone did not work: the design barrel statically reaches `Diff.tsx`, so the
chunk the bundler emitted was 155 bytes and the library stayed in the entry (measured, entry moved
0 B). `Diff` therefore moves off the barrel onto its own `@kampus/design/Diff` entry, which is the
one edge a bundler can cut. That move breaks the package's a11y coverage gate, which reads the
barrel's runtime exports on purpose, so the gate now covers the union of the barrel and every
component subpath entry — and a second case checks that entry list against `package.json`'s
`exports`, so a future subpath entry reds instead of quietly leaving its component uncovered.

| | origin/main | this branch | delta |
|---|---|---|---|
| all assets, raw | 4,561,151 B | 15,343,508 B | +10,782,357 B |
| all assets, gzip | 1,261,086 B | 3,276,705 B | +2,015,619 B |
| entry chunk, raw | 906,535 B | 906,642 B | +107 B |
| **entry chunk, gzip** | **276,221 B** | **276,163 B** | **−58 B** |

Same method as #8620's comment: `vite build` of `apps/tuval` rooted at the app, entry
`src/page/main.tsx`, the desk's own react plugin + `dedupe`, the two virtual modules stubbed; gzip
is `zlib.gzipSync` per file. The 2 MB is Shiki's language grammars, emitted as lazy chunks and
fetched per language only once a reader opens an edit call. First paint is unchanged.

**Keyboard operability is the platform's, and a test drives it.** `Collapsible`'s trigger is a real
`<button>` (`@manti-ui/react@0.9.0`, `dist/index.js`), so Enter and Space need no hand-written
`onKeyDown` over `role="button"` — but jsdom implements no activation behaviour, so a `fireEvent`
keydown proves nothing. `@testing-library/user-event` is added as a tuval devDependency for exactly
that: the case tabs to each trigger and opens the run with Enter and a call with Space.

Names are English and fixed — the activity block is a `section` labelled "Activity", the call list a
list labelled "Tool calls".

Grounded in source, not recall: `@manti-ui/react@0.9.0` `dist/index.js` for the `Collapsible`
trigger being a `<button>`, `@zag-js/collapsible@1.43.0` `collapsible.connect.mjs` for the hidden
panel, and `.patterns/manti-accessibility.md` for the naming rule.

Fixes #8613

## Deviations

- **Governing-ADR departure** — **Said:** `.patterns/markdown-async-block.md` rule 1 says a block's
  first paint is the real content, never a placeholder. **Did:** the edit diff paints a one-line
  fallback first and swaps the diff in when its chunk lands. **Why:** the measured alternative is
  +143,566 B gzip on the entry chunk for a component most sessions never render, the content is
  behind a disclosure so nothing shifts under a reader who did not open it, and rule 2 still holds —
  the virtualizer's `ResizeObserver` re-measures the row with no callback out of the block.
  **Disposition:** the pattern doc gained a "the lazy-chunk case" section stating the exception and
  its bound.
- **Out-of-scope change** — **Said:** #8613 names `apps/tuval`. **Did:** also moved `Diff` off
  `@kampus/design`'s barrel onto a `./Diff` entry, updated the package README, and taught the
  package's a11y coverage gate to read its subpath entries beside the barrel. **Why:** with the
  barrel edge in place the lazy boundary emitted a 155-byte chunk and left the whole library in the
  desk's entry — the split is not achievable from the tuval side alone. **Disposition:** the move
  broke one consumer, `src/a11y/a11y-pbt.test.tsx`, which reads the barrel's runtime exports on
  purpose and reported `Diff` as a stale registry entry (round 1's blocker; an earlier version of
  this entry claimed no consumer broke, which was wrong). The gate now covers the union of the
  barrel and every component subpath entry, with a second case checking that entry list against
  `package.json`'s own `exports` — so a future subpath entry reds rather than silently dropping its
  component out of a11y coverage. The registry entry for `Diff` is untouched.
- **Declined guidance** — **Said:** T3's `canExpand` admits a failed call even when its body would
  be empty (`MessagesTimeline.tsx:3314`), and the port is otherwise line-for-line. **Did:** kept a
  failed call with an empty panel flat — not expandable. **Why:** that arm exists because T3's row
  carries its failure in an icon, so the accessible name it builds for the trigger is the only place
  the word "failed" appears. Tuval's line carries the word itself either way, so the arm would buy a
  reader nothing and cost them a control that opens onto nothing — which is what the issue calls
  worse than no disclosure. **Disposition:** stated at `canExpandCall` with the divergence and its
  reason, and pinned by a case in `tool-detail.unit.test.ts`.
- **Out-of-scope change** — **Said:** nothing about dependencies. **Did:** added
  `@testing-library/user-event` to the workspace catalog and to `apps/tuval`'s devDependencies.
  **Why:** the acceptance criteria ask for a test that drives the disclosure through the keyboard,
  and jsdom implements no activation behaviour for Enter/Space on a button — no tool already in the
  tree can make that assertion honest. **Disposition:** stated here; the lockfile change is 16
  additive lines.
- **Pre-existing test or fixture changed** — **Said:** don't delete tests. **Did:** replaced
  `agent-controls.unit.test.tsx`'s "renders an edit call as a diff, with a marker word per changed
  line" with one asserting the edit reaches the design `Diff`, and dropped `tool-detail`'s
  `diffLines` describe. **Why:** both graded the hand-rolled table this PR removes; the claim they
  held — an edit call discloses its change, named for the file — is asserted in the new shape, plus
  an explicit assertion that no `.tuval-chat-diff` table is drawn any more. **Disposition:** stated
  here; no claim was dropped, both were re-expressed against the primitive that replaced the table.
- **Out-of-scope change** — **Said:** nothing about test shims. **Did:** added a
  `CSSStyleSheet.prototype.replaceSync` no-op to `apps/tuval/src/shell/ui/dom.testing.ts`. **Why:**
  jsdom 26 constructs a `CSSStyleSheet` but implements neither `replaceSync` nor
  `adoptedStyleSheets`, and `@pierre/diffs` adopts its own sheet in a custom element constructor —
  the same shim `packages/design/test-setup.ts` already carries. **Disposition:** stated here.
