### PR TITLE
feat: Tuval chat: a finished turn folds behind one "Worked for …" row

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -387,6 +387,25 @@ function RowView({
 			</span>
 		);
 	}
+	if (row.kind === "turn") {
+		// A `Button` and not a `Collapsible`: the rows this reveals are virtualized siblings outside
+		// any content this control owns, so a primitive that wired `aria-controls` over its own panel
+		// would announce a panel while N unrelated rows appeared unannounced (#8027). Same shape and
+		// same reason as the group head's fold button, `aria-expanded` and no `aria-controls` (#8057).
+		return (
+			<Button
+				type="button"
+				variant="tertiary"
+				size="sm"
+				className="tuval-chat-turn"
+				aria-expanded={row.open}
+				onClick={() => onToggleFold(rowKey(row), !row.open)}
+			>
+				<span className="tuval-chat-turn-chevron" data-open={row.open} aria-hidden="true" />
+				{row.label}
+			</Button>
+		);
+	}
 	if (row.kind === "session") {
 		// The run's first notice is its identity, in the `expanded` set as in `rowKey`, so a notice
 		// joining the run behind it does not close a disclosure the reader opened.

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -2087,13 +2087,9 @@ describe("the view slot's writer, under StrictMode", () => {
 	it("composes batched commits off the last committed value", async () => {
 		const {writes, view} = await openWindow(
 			// A reply between the calls: consecutive ones collapse into one run (#8612), and this case
-			// needs two rows with a disclosure each to batch two toggles.
-			withTranscript([
-				userItem("a", "do it"),
-				call("c"),
-				assistantItem("b", "next"),
-				call("d", {name: "grep"}),
-			]),
+			// needs two rows with a disclosure each to batch two toggles. No opening `user` item, so
+			// these rows head no turn and the turn fold leaves them where they are (#8614).
+			withTranscript([call("c"), assistantItem("b", "next"), call("d", {name: "grep"})]),
 			{},
 			undefined,
 			{strict: true},

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -514,6 +514,34 @@
 }
 
 /*
+ * A settled turn's scaffolding behind one line (#8614). The chevron is decoration — `aria-hidden`,
+ * and the label beside it is the whole accessible name — so the rotation never carries the state
+ * alone (ADR 0162, Pillar 4). The button keeps the 36px hit area and the shared focus ring the
+ * `Button` primitive already paints.
+ */
+.tuval-chat-turn {
+	align-self: flex-start;
+	gap: var(--s-2);
+	min-block-size: var(--tap-min);
+	color: var(--text-muted);
+}
+
+.tuval-chat-turn-chevron {
+	flex: none;
+	inline-size: 0;
+	block-size: 0;
+	border-block-start: 4px solid transparent;
+	border-block-end: 4px solid transparent;
+	border-inline-start: 6px solid currentcolor;
+}
+
+/* Rotated, not animated: the rows the button reveals arrive in the same commit, so a transition
+   here would only trail the state change the list itself already shows. */
+.tuval-chat-turn-chevron[data-open="true"] {
+	rotate: 90deg;
+}
+
+/*
  * A run of consecutive calls as one line (#8612): a status dot, the sentence, and the status as a
  * word for a run that failed or is still going. The dot is a state marker rather than an icon —
  * `aria-hidden`, and it never carries the state alone: the word beside it does, which is also what

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -50,6 +50,9 @@ export type SessionRun = readonly [SystemItem, ...ReadonlyArray<SystemItem>];
  */
 export type ToolRun = readonly [ToolCall, ToolCall, ...ReadonlyArray<ToolCall>];
 
+/** The operator's own turn, off the union for the same width reason `ToolCall` is. */
+type UserTurn = Extract<RowItem, {readonly kind: "user"}>;
+
 export type ChatRow =
 	/** There is more history behind this point; `items` is what the live-tail bound already dropped. */
 	| {readonly kind: "older"; readonly items: number}
@@ -72,6 +75,21 @@ export type ChatRow =
 			readonly nested: boolean;
 			/** How many folds deep the run sits. Every call in it sits at this one depth. */
 			readonly depth: number;
+	  }
+	/**
+	 * One settled turn's scaffolding behind a single "Worked for …" line (#8614). The rows it stands
+	 * for travel with it rather than being dropped, so the anchor lookup below still finds an item
+	 * the fold is hiding and a prepend can restore the viewport onto it.
+	 */
+	| {
+			readonly kind: "turn";
+			/** The opening `user` item's id — this row's identity in the window's `unfolded` set. */
+			readonly id: ItemId;
+			/** `Worked for 4.2s`, or `You stopped after 4.2s` on a turn the operator cut short. */
+			readonly label: string;
+			readonly open: boolean;
+			/** The rows behind this summary, in list order. Emitted after it while `open`. */
+			readonly hidden: ReadonlyArray<ChatRow>;
 	  }
 	| {
 			readonly kind: "item";
@@ -149,8 +167,34 @@ export const rowKey = (row: ChatRow): string => {
 	// Its own prefix rather than the first call's `item:` key: the two would otherwise be one string
 	// in the window's shared `expanded` set, and a run could not be opened without opening that call.
 	if (row.kind === "tools") return `tools:${row.calls[0].id}`;
+	// Prefixed for the same reason a run is: the key is what the window's `unfolded` set holds, and
+	// a bare item id would put the turn and its opening `user` row under one string.
+	if (row.kind === "turn") return `turn:${row.id}`;
 	return row.kind;
 };
+
+/**
+ * The transcript items one row carries, in list order. A turn summary carries none of its own: what
+ * it stands for is `hidden`, and `listItems` below is what reads through it.
+ */
+const rowItems = (row: ChatRow): ReadonlyArray<TranscriptItem> => {
+	if (row.kind === "item") return [row.item];
+	if (row.kind === "session") return row.items;
+	if (row.kind === "tools") return row.calls;
+	return [];
+};
+
+/**
+ * Every item the list holds, in list order, **including the ones a turn summary is hiding**. The
+ * page cursor and the prepend anchor are questions about the transcript, not about what is on
+ * screen: a fold that dropped its rows out of this walk would move the cursor as it closed.
+ *
+ * An open summary's rows are emitted beside it, so reading them again here would double them.
+ */
+const listItems = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<TranscriptItem> =>
+	rows.flatMap((row) =>
+		row.kind === "turn" ? (row.open ? [] : listItems(row.hidden)) : rowItems(row),
+	);
 
 /**
  * How many still-unconfirmed turns `held` carries per text — the budget a page's own copies of
@@ -344,6 +388,191 @@ const collapseToolRuns = (
 };
 
 /**
+ * How long a turn took, in the words the summary row says it. `null` is "the items do not say" —
+ * a timestamp that is not a finite number — and the label falls back to the bare verb.
+ *
+ * The thresholds are T3's `formatDuration` (`packages/shared/src/orchestrationTiming.ts` at
+ * `pingdotgg/t3code@0fe4c99`): sub-second in whole milliseconds, under ten seconds to one decimal,
+ * under a minute in whole seconds, and above that the non-zero `1h 2m 4s` parts.
+ */
+export const turnDuration = (elapsedMs: number): string | null => {
+	if (!Number.isFinite(elapsedMs)) return null;
+	const elapsed = Math.max(0, elapsedMs);
+	if (elapsed < 1_000) return `${Math.max(1, Math.round(elapsed))}ms`;
+	if (elapsed < 10_000) {
+		const tenths = Math.round(elapsed / 100) / 10;
+		return tenths >= 10 ? "10s" : `${tenths.toFixed(1)}s`;
+	}
+	if (elapsed < 60_000) return `${Math.round(elapsed / 1_000)}s`;
+	const total = Math.round(elapsed / 1_000);
+	const parts: Array<string> = [];
+	const hours = Math.floor(total / 3_600);
+	const minutes = Math.floor((total % 3_600) / 60);
+	const seconds = total % 60;
+	if (hours > 0) parts.push(`${hours}h`);
+	if (minutes > 0) parts.push(`${minutes}m`);
+	if (seconds > 0) parts.push(`${seconds}s`);
+	return parts.join(" ");
+};
+
+/** One top-level row with the rows an open fold nested under it, so a fold hides a head with its own. */
+interface Block {
+	readonly head: ChatRow;
+	readonly rows: ReadonlyArray<ChatRow>;
+}
+
+/** A row's own indent step; a paging head, a session run and a turn summary all sit at the top. */
+const rowDepth = (row: ChatRow): number =>
+	row.kind === "item" || row.kind === "tools" ? row.depth : 0;
+
+/**
+ * Cut the list into blocks: each top-level row, plus the deeper rows an open group fold put after
+ * it. Hiding a block is what keeps a folded group head and the rows it revealed one decision — a
+ * head folded away without them would leave its children behind as orphans.
+ */
+const blocksOf = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<Block> => {
+	const out: Array<{head: ChatRow; rows: Array<ChatRow>}> = [];
+	for (const row of rows) {
+		const open = out[out.length - 1];
+		if (rowDepth(row) > 0 && open !== undefined) open.rows.push(row);
+		else out.push({head: row, rows: [row]});
+	}
+	return out;
+};
+
+/** The item a block leads with, when the block leads with one at all. */
+const blockItem = (block: Block): RowItem | null =>
+	block.head.kind === "item" ? block.head.item : null;
+
+/** A turn: the operator's prompt, and the blocks the agent produced before the next prompt. */
+interface Turn {
+	readonly user: UserTurn;
+	readonly body: ReadonlyArray<Block>;
+}
+
+/**
+ * Cut the blocks into turns. A `user` item opens one and the next `user` item closes it; a
+ * compaction row closes one too, and belongs to the turn it closes — which is what makes "a fold
+ * whose only hidden content is a compaction row is not drawn" a rule about something rather than a
+ * rule about nothing.
+ *
+ * The opening prompt is the turn's head and never its body: what folds away is what the agent did,
+ * never what the operator asked. Blocks before the first prompt belong to no turn — a page walked
+ * back past a turn's opening `user` item leaves its rows headless, and those rows stay exactly as
+ * they render today rather than vanishing behind a summary nothing opened.
+ */
+const turnsOf = (blocks: ReadonlyArray<Block>): ReadonlyArray<Turn> => {
+	const out: Array<{user: UserTurn; body: Array<Block>}> = [];
+	let open: {user: UserTurn; body: Array<Block>} | null = null;
+	for (const block of blocks) {
+		const item = blockItem(block);
+		if (item?.kind === "user") {
+			open = {user: item, body: []};
+			out.push(open);
+			continue;
+		}
+		if (open === null) continue;
+		open.body.push(block);
+		if (item?.kind === "compaction") open = null;
+	}
+	return out;
+};
+
+/** Still moving: text or reasoning mid-stream, or a call that has not reported back. */
+const unsettled = (item: TranscriptItem): boolean =>
+	((item.kind === "assistant" || item.kind === "thinking") && item.partial === true) ||
+	(item.kind === "tool" && item.status === "running");
+
+/**
+ * A call that spawns a subagent, which never folds: the work outlives the turn that launched it,
+ * and this row is the only route into the worker's transcript — its own fold when the worker's rows
+ * are in this list, its slot when they have left it. T3 skips its `agentSpawn` entries the same way.
+ */
+const spawning = (block: Block, subagents: ReadonlySet<string>): boolean => {
+	const head = block.head;
+	if (head.kind !== "item" || head.item.kind !== "tool") return false;
+	return head.nestedIds.length > 0 || subagents.has(head.item.id);
+};
+
+/**
+ * Fold each settled turn's scaffolding behind one summary row (#8614).
+ *
+ * What folds is everything the agent produced **before** its terminal reply; the reply itself stays
+ * visible, and so does everything after it — except a single harmless trailing call, which joins the
+ * fold rather than dangling under a summary as one orphan line. Two of them, or a failing one, stay
+ * out and read as the run row they already are.
+ *
+ * **A turn with no terminal reply does not fold**, and that one rule is what keeps a running turn
+ * open without the window having to tell this pure function what the session's phase is: a turn
+ * mid-flight has either no reply yet, a `partial` one, or a call still running.
+ *
+ * A session notice never folds — it is an open founder decision (#8475) and reads as its own row —
+ * and neither does a spawning call. A fold hiding nothing, or hiding only a compaction row, is not
+ * drawn at all.
+ */
+const foldTurns = (
+	rows: ReadonlyArray<ChatRow>,
+	unfolded: ReadonlySet<string>,
+	subagents: ReadonlySet<string>,
+): ReadonlyArray<ChatRow> => {
+	const blocks = blocksOf(rows);
+	const summaries = new Map<Block, ChatRow>();
+	/** Every folded block, against whether its summary is showing them. */
+	const folds = new Map<Block, boolean>();
+	for (const turn of turnsOf(blocks)) {
+		const items = turn.body.flatMap((block) => block.rows.flatMap(rowItems));
+		if (items.some(unsettled)) continue;
+		const terminal = turn.body.findLastIndex((block) => blockItem(block)?.kind === "assistant");
+		if (terminal === -1) continue;
+		const folded = turn.body.filter((block, index) => {
+			if (index === terminal || block.head.kind === "session") return false;
+			if (spawning(block, subagents)) return false;
+			if (blockItem(block)?.kind === "compaction") return true;
+			if (index <= terminal) return true;
+			// The one trailing call that joins the fold: alone after the reply, and not a failure.
+			const call = blockItem(block);
+			return (
+				turn.body.length === terminal + 2 &&
+				call?.kind === "tool" &&
+				call.status !== "error" &&
+				block.rows.length === 1
+			);
+		});
+		const first = folded[0];
+		if (first === undefined) continue;
+		// A compaction boundary folds away with the work around it, never on its own.
+		if (folded.every((block) => blockItem(block)?.kind === "compaction")) continue;
+		const ends = [turn.user.timestamp, ...items.map((item) => item.timestamp)];
+		const duration = turnDuration(Math.max(...ends) - turn.user.timestamp);
+		const stopped = items.some((item) => item.kind === "assistant" && item.interrupted === true);
+		const open = unfolded.has(`turn:${turn.user.id}`);
+		summaries.set(first, {
+			kind: "turn",
+			id: turn.user.id,
+			label: stopped
+				? duration === null
+					? "You stopped this response"
+					: `You stopped after ${duration}`
+				: duration === null
+					? "Worked"
+					: `Worked for ${duration}`,
+			open,
+			hidden: folded.flatMap((block) => block.rows),
+		});
+		for (const block of folded) folds.set(block, open);
+	}
+	if (summaries.size === 0) return rows;
+	const out: Array<ChatRow> = [];
+	for (const block of blocks) {
+		const summary = summaries.get(block);
+		if (summary !== undefined) out.push(summary);
+		// Absent from `folds` is "no summary stands for this block"; `false` is "its summary is shut".
+		if (folds.get(block) !== false) out.push(...block.rows);
+	}
+	return out;
+};
+
+/**
  * The list the window renders. The tail wins on a collision: an item that reached the live stream is
  * the newer copy of itself, and a page that happens to overlap the tail must not double it. The
  * collision is `unheld`'s — id, then text against a turn the tail still holds as `local` — so the
@@ -421,7 +650,7 @@ export const chatRows = (input: ChatRowsInput): ReadonlyArray<ChatRow> => {
 	for (const item of items) {
 		if (!reachable.has(item.id)) emit(item, 1);
 	}
-	return collapseToolRuns(rows, subagents);
+	return foldTurns(collapseToolRuns(rows, subagents), unfolded, subagents);
 };
 
 /**
@@ -445,15 +674,9 @@ export const subagentRows = (
 		...(unfolded === undefined ? {} : {unfolded}),
 	});
 
-/** The prepend anchor: the visually oldest item, including a local echo. */
-export const oldestLoadedId = (rows: ReadonlyArray<ChatRow>): string | null => {
-	for (const row of rows) {
-		if (row.kind === "item") return row.item.id;
-		if (row.kind === "session") return row.items[0].id;
-		if (row.kind === "tools") return row.calls[0].id;
-	}
-	return null;
-};
+/** The prepend anchor: the oldest item the list holds, including a local echo and a folded one. */
+export const oldestLoadedId = (rows: ReadonlyArray<ChatRow>): string | null =>
+	listItems(rows)[0]?.id ?? null;
 
 /** The stored cursor and visual anchor are different id spaces when the oldest row is local. */
 export const olderPageRequest = (
@@ -461,23 +684,19 @@ export const olderPageRequest = (
 ): {readonly before: string; readonly anchor: string} | null => {
 	const anchor = oldestLoadedId(rows);
 	if (anchor === null) return null;
-	const items = rows.flatMap((row): ReadonlyArray<TranscriptItem> => {
-		if (row.kind === "item") return [row.item];
-		if (row.kind === "session") return row.items;
-		if (row.kind === "tools") return row.calls;
-		return [];
-	});
-	const cursor = pageCursor(items, anchor);
+	const cursor = pageCursor(listItems(rows), anchor);
 	return cursor.kind === "page" && cursor.before !== null ? {before: cursor.before, anchor} : null;
 };
 
-/** Membership rather than the row's key: an anchor may name a notice or a call buried mid-run. */
-const holds = (row: ChatRow, id: string): boolean => {
-	if (row.kind === "item") return row.item.id === id;
-	if (row.kind === "session") return row.items.some((item) => item.id === id);
-	if (row.kind === "tools") return row.calls.some((call) => call.id === id);
-	return false;
-};
+/**
+ * Membership rather than the row's key: an anchor may name a notice, a call buried mid-run, or a
+ * row a turn summary is folding away — and that last one is what keeps a prepend anchored. The
+ * viewport lands on the summary standing in for the row, rather than on nothing at all.
+ */
+const holds = (row: ChatRow, id: string): boolean =>
+	row.kind === "turn"
+		? !row.open && row.hidden.some((held) => holds(held, id))
+		: rowItems(row).some((item) => item.id === id);
 
 /** Where the row carrying `id` sits, or `-1`. The anchor a prepend restores the viewport onto. */
 export const rowIndexOfItem = (rows: ReadonlyArray<ChatRow>, id: string | null): number =>

--- a/apps/tuval/src/shell/chat/rows.unit.test.ts
+++ b/apps/tuval/src/shell/chat/rows.unit.test.ts
@@ -30,6 +30,7 @@ import {
 	rowKey,
 	subagentHeads,
 	subagentRows,
+	turnDuration,
 } from "./rows.ts";
 
 const base = {older: [], tail: [], omitted: 0, loading: false, atOldest: false};
@@ -672,6 +673,8 @@ describe("subagentRows", () => {
 	const under = (head: string) => ({parentId: ItemId.make(head)});
 
 	it("reads the worker's own rows at depth zero, not as rows nested under a head it lacks", () => {
+		// The worker's turn is settled, so its own summary row folds the trailing call away (#8614);
+		// opened, all three of its rows are back in the list and the depth is what this is about.
 		const rows = subagentRows(
 			subagentSlot("agent", {
 				items: [
@@ -680,9 +683,10 @@ describe("subagentRows", () => {
 					call("t1", {parentId: "agent"}),
 				],
 			}),
+			new Set(["turn:u1"]),
 		);
 		expect(itemIds(rows)).toEqual(["u1", "a1", "t1"]);
-		expect(rows.every((row) => row.kind === "item" && !row.nested && row.depth === 0)).toBe(true);
+		expect(rows.every((row) => row.kind !== "item" || (!row.nested && row.depth === 0))).toBe(true);
 	});
 
 	it("has no head row: a subagent's rows arrive with its slot, and nothing older can be asked for", () => {
@@ -730,10 +734,12 @@ describe("chatRows collapses a run of consecutive tool calls", () => {
 		const rows = chatRows({
 			...base,
 			atOldest: true,
+			// Unfolded, because the turn is settled and the run is what its summary hides (#8614).
+			unfolded: new Set(["turn:u"]),
 			tail: [userItem("u", "go"), call("t1"), call("t2"), call("t3"), assistantItem("a", "done")],
 		});
-		expect(rows.map((row) => row.kind)).toEqual(["item", "tools", "item"]);
-		expect(runAt(rows, 1)).toEqual(["t1", "t2", "t3"]);
+		expect(rows.map((row) => row.kind)).toEqual(["item", "turn", "tools", "item"]);
+		expect(runAt(rows, 2)).toEqual(["t1", "t2", "t3"]);
 	});
 
 	it("leaves a span of one as the tool row it was, disclosure and all", () => {
@@ -845,5 +851,319 @@ describe("chatRows collapses a run of consecutive tool calls", () => {
 		expect(oldestLoadedId(rows)).toBe("t1");
 		// Membership, not the run's key: an anchor may name a call buried mid-run.
 		expect(rowIndexOfItem(rows, "t2")).toBe(0);
+	});
+});
+
+/**
+ * The turn fold (#8614). What a finished turn leaves on screen is its prompt, its reply, and one
+ * line saying how long the work between them took — so what has to be proven here is *which* rows
+ * that line stands for, and the four cases where it must not be drawn at all.
+ *
+ * The rule is T3's (`MessagesTimeline.logic.ts:575-723` at `pingdotgg/t3code@0fe4c99`), read against
+ * Tuval's own item union: `partial` is its streaming marker, `AssistantItem.interrupted` its
+ * cut-short one, and the timings are the items' own epoch-ms `timestamp`.
+ */
+describe("chatRows folds a settled turn", () => {
+	const AT = 1_756_000_000_000;
+
+	/** A finished turn: a thought and a call before the reply, four point two seconds end to end. */
+	const settledTurn: ReadonlyArray<TranscriptItem> = [
+		userItem("u", "go", AT),
+		thinkingItem("k", "weighing it", AT + 100),
+		toolItem("t", "ok", AT + 200),
+		assistantItem("a", "done", AT + 4_200),
+	];
+
+	const turnRow = (rows: ReadonlyArray<ChatRow>) => {
+		const row = rows.find((candidate) => candidate.kind === "turn");
+		return row?.kind === "turn" ? row : null;
+	};
+
+	const hiddenIds = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<string> =>
+		carriedIds(turnRow(rows)?.hidden ?? []);
+
+	it("puts one summary where the work was and leaves the prompt and the reply standing", () => {
+		const rows = chatRows({...base, atOldest: true, tail: settledTurn});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "turn", "item"]);
+		expect(carriedIds(rows)).toEqual(["u", "a"]);
+		expect(hiddenIds(rows)).toEqual(["k", "t"]);
+		expect(turnRow(rows)?.label).toBe("Worked for 4.2s");
+	});
+
+	it("shows the rows again, in place, once its own key is in the unfolded set", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			unfolded: new Set(["turn:u"]),
+			tail: settledTurn,
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "turn", "item", "item", "item"]);
+		expect(carriedIds(rows)).toEqual(["u", "k", "t", "a"]);
+		expect(turnRow(rows)?.open).toBe(true);
+		// The key is the turn's, not the opening prompt's: the two share the one `unfolded` set.
+		expect(rowKey(turnRow(rows) as ChatRow)).toBe("turn:u");
+	});
+
+	it("folds every reply before the terminal one and leaves that one visible", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				assistantItem("a1", "first", AT + 100),
+				assistantItem("a2", "final", AT + 900),
+			],
+		});
+		expect(carriedIds(rows)).toEqual(["u", "a2"]);
+		expect(hiddenIds(rows)).toEqual(["a1"]);
+	});
+
+	it("does not fold a turn holding a streaming reply, nor one holding a running call", () => {
+		const streaming = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				thinkingItem("k", "weighing it", AT + 100),
+				{...assistantItem("a", "typ", AT + 300), partial: true},
+			],
+		});
+		expect(turnRow(streaming)).toBeNull();
+
+		const running = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				assistantItem("a", "on it", AT + 100),
+				call("t", {status: "running"}),
+			],
+		});
+		expect(turnRow(running)).toBeNull();
+	});
+
+	it("does not fold a turn that has produced no reply yet — the one still running", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [userItem("u", "go", AT), thinkingItem("k", "weighing it", AT + 100)],
+		});
+		expect(turnRow(rows)).toBeNull();
+		expect(carriedIds(rows)).toEqual(["u", "k"]);
+	});
+
+	it("takes one harmless trailing call into the fold", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				thinkingItem("k", "weighing it", AT + 100),
+				assistantItem("a", "done", AT + 400),
+				toolItem("t", "ok", AT + 600),
+			],
+		});
+		expect(carriedIds(rows)).toEqual(["u", "a"]);
+		expect(hiddenIds(rows)).toEqual(["k", "t"]);
+	});
+
+	// T3's own spec case (`MessagesTimeline.logic.test.ts:1401-1484`): three trailing commands stay
+	// out of the fold and render as the summary row they already are.
+	it("leaves three trailing calls visible, as the run row they collapse into", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				toolItem("before", "ok", AT + 100),
+				assistantItem("a", "I could not finish the task.", AT + 500),
+				call("x0"),
+				call("x1"),
+				call("x2"),
+			],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "turn", "item", "tools"]);
+		expect(hiddenIds(rows)).toEqual(["before"]);
+	});
+
+	it("leaves a single trailing call visible when it failed", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				toolItem("before", "ok", AT + 100),
+				assistantItem("a", "done", AT + 500),
+				call("x", {status: "error"}),
+			],
+		});
+		expect(carriedIds(rows)).toEqual(["u", "a", "x"]);
+		expect(hiddenIds(rows)).toEqual(["before"]);
+	});
+
+	it("draws no summary for a turn with nothing to hide", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [userItem("u", "go", AT), assistantItem("a", "done", AT + 100)],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "item"]);
+	});
+
+	it("draws no summary when the only thing it would hide is a compaction row", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				assistantItem("a", "done", AT + 100),
+				compactionItem("c", "context compacted", AT + 200),
+			],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "item", "item"]);
+	});
+
+	it("takes the compaction row into a fold that already hides work, and closes the turn on it", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				thinkingItem("k", "weighing it", AT + 100),
+				assistantItem("a", "done", AT + 400),
+				compactionItem("c", "context compacted", AT + 500),
+				toolItem("after", "ok", AT + 900),
+			],
+		});
+		// `after` sits past the compaction row, so it belongs to no turn and folds into none.
+		expect(carriedIds(rows)).toEqual(["u", "a", "after"]);
+		expect(hiddenIds(rows)).toEqual(["k", "c"]);
+	});
+
+	it("never folds a spawning call, whichever way this list knows it is one", () => {
+		const bySlot = chatRows({
+			...base,
+			atOldest: true,
+			subagents: new Set(["s"]),
+			tail: [
+				userItem("u", "go", AT),
+				call("s", {name: "Agent"}),
+				assistantItem("a", "done", AT + 1),
+			],
+		});
+		expect(turnRow(bySlot)).toBeNull();
+		expect(carriedIds(bySlot)).toEqual(["u", "s", "a"]);
+
+		const byFold = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				call("s", {name: "Agent"}),
+				call("w", {parentId: "s"}),
+				assistantItem("a", "done", AT + 1),
+			],
+		});
+		expect(turnRow(byFold)).toBeNull();
+		expect(carriedIds(byFold)).toEqual(["u", "s", "a"]);
+	});
+
+	it("never folds a session notice into a turn summary", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				systemItem("s1", "hook fired", AT + 100),
+				thinkingItem("k", "weighing it", AT + 200),
+				assistantItem("a", "done", AT + 400),
+			],
+		});
+		expect(rows.map((row) => row.kind)).toEqual(["item", "session", "turn", "item"]);
+		expect(hiddenIds(rows)).toEqual(["k"]);
+	});
+
+	it("says the operator stopped it, beside the marker the interrupted reply still renders", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				thinkingItem("k", "weighing it", AT + 100),
+				assistantItem("a", "half an ans", AT + 2_000, true),
+			],
+		});
+		expect(turnRow(rows)?.label).toBe("You stopped after 2.0s");
+		// The reply itself is the terminal row and stays visible, so its marker and Resend do too.
+		expect(carriedIds(rows)).toEqual(["u", "a"]);
+	});
+
+	it("falls back to the bare verb when the items do not say how long it took", () => {
+		const rows = chatRows({
+			...base,
+			atOldest: true,
+			tail: [
+				userItem("u", "go", AT),
+				thinkingItem("k", "weighing it", AT + 100),
+				{...assistantItem("a", "done", AT), timestamp: Number.NaN},
+			],
+		});
+		expect(turnRow(rows)?.label).toBe("Worked");
+	});
+
+	it("formats a duration the way T3 does", () => {
+		expect(turnDuration(400)).toBe("400ms");
+		expect(turnDuration(4_200)).toBe("4.2s");
+		expect(turnDuration(9_960)).toBe("10s");
+		expect(turnDuration(12_400)).toBe("12s");
+		expect(turnDuration(64_000)).toBe("1m 4s");
+		expect(turnDuration(3_600_000)).toBe("1h");
+		expect(turnDuration(Number.NaN)).toBeNull();
+	});
+
+	it("holds still as a late upsert of the same reply lands", () => {
+		const growing = chatRows({
+			...base,
+			atOldest: true,
+			tail: [...settledTurn.slice(0, 3), {...assistantItem("a", "don", AT + 4_200), partial: true}],
+		});
+		expect(turnRow(growing)).toBeNull();
+
+		const folded = chatRows({...base, atOldest: true, tail: settledTurn});
+		const again = chatRows({
+			...base,
+			atOldest: true,
+			tail: [...settledTurn.slice(0, 3), assistantItem("a", "done, and then some", AT + 4_200)],
+		});
+		expect(hiddenIds(again)).toEqual(hiddenIds(folded));
+		expect(turnRow(again)?.label).toBe(turnRow(folded)?.label);
+	});
+
+	it("renders a turn whose opening prompt is older than the pages walked back to", () => {
+		const rows = chatRows({...base, atOldest: true, tail: settledTurn.slice(1)});
+		expect(turnRow(rows)).toBeNull();
+		expect(carriedIds(rows)).toEqual(["k", "t", "a"]);
+	});
+
+	it("does not re-cut a loaded turn's fold when an older page prepends", () => {
+		const older = [
+			userItem("u0", "first", AT - 9_000),
+			thinkingItem("k0", "weighing it", AT - 8_900),
+			assistantItem("a0", "answered", AT - 8_000),
+		];
+		const before = chatRows({...base, atOldest: true, tail: settledTurn});
+		const after = chatRows({...base, atOldest: true, older, tail: settledTurn});
+		expect(after.map((row) => row.kind)).toEqual(["item", "turn", "item", "item", "turn", "item"]);
+		expect(carriedIds(after.slice(3))).toEqual(carriedIds(before));
+		expect(hiddenIds(after.slice(3))).toEqual(hiddenIds(before));
+	});
+
+	it("keeps the page cursor and the prepend anchor reachable through the summary", () => {
+		const rows = chatRows({...base, atOldest: true, tail: settledTurn});
+		expect(oldestLoadedId(rows)).toBe("u");
+		// The anchor names a row the fold is hiding, and the summary standing in for it is where the
+		// viewport lands — without this a prepend mid-turn would have nothing to restore onto.
+		expect(rowIndexOfItem(rows, "t")).toBe(1);
+		expect(rowIndexOfItem(rows, "a")).toBe(2);
 	});
 });

--- a/apps/tuval/src/shell/chat/turn-fold.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/turn-fold.unit.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The turn summary as a control (#8614): one `<button>` whose accessible name is the label, whose
+ * `aria-expanded` is the whole of its state, and whose click puts the turn's own key in this
+ * window's `unfolded` set — so a window switched away from and back to comes back as it was left.
+ *
+ * It is deliberately **not** a `Collapsible`. The rows it reveals are virtualized siblings in the
+ * transcript, outside any content this control owns, so a primitive wiring `aria-controls` over its
+ * own panel would announce a panel while N unrelated rows appeared unannounced (#8027). That is the
+ * same shape and the same reason as the group head's fold button (#8057).
+ *
+ * `chat.css` is read off disk and put in the document because Vitest's default `css: false` makes
+ * the window's own `import "./chat.css"` an empty module.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {act, fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {beforeAll, describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ItemId, type TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {type WindowHost, WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {assistantItem, thinkingItem, toolItem, userItem, withTranscript} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+beforeAll(() => {
+	const style = document.createElement("style");
+	style.textContent = readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
+	document.head.appendChild(style);
+});
+
+const AT = 1_756_000_000_000;
+
+/** One settled turn: a thought and a call behind the reply, four point two seconds end to end. */
+const TURN: ReadonlyArray<TranscriptItem> = [
+	userItem("u", "go", AT),
+	thinkingItem("k", "weighing it", AT + 100),
+	toolItem("t", "ok", AT + 200),
+	assistantItem("a", "done", AT + 4_200),
+];
+
+/** The same turn, cut short by the operator — the label says so beside the marker the reply keeps. */
+const STOPPED: ReadonlyArray<TranscriptItem> = [
+	userItem("u", "go", AT),
+	thinkingItem("k", "weighing it", AT + 100),
+	assistantItem("a", "half an ans", AT + 2_000, true),
+];
+
+type ChatHost = WindowHost<AiAgentSessionState, AiAgentSessionMsg, ChatView>;
+
+const hostOver = async (
+	items: ReadonlyArray<TranscriptItem>,
+	over: Partial<AiAgentSessionState> = {},
+): Promise<ChatHost> => {
+	const running = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+			ProcessId.make("p1"),
+			withTranscript(items, over),
+		),
+	);
+	return await Effect.runPromise(running.window<ChatView>(WindowId.make("w1"), initialChatView));
+};
+
+const mount = async (host: ChatHost): Promise<{readonly unmount: () => void}> => {
+	const element = chatWindow({scrollCommitMs: 0, scrollToFn: () => {}}).render(
+		host,
+	) as ReactElement;
+	const rendered = render(element);
+	await screen.findAllByRole("log", {name: "Transcript"});
+	return {unmount: rendered.unmount};
+};
+
+const summary = (name: string): HTMLElement => screen.getByRole("button", {name});
+
+const click = async (element: HTMLElement): Promise<void> => {
+	await act(async () => {
+		fireEvent.click(element);
+	});
+};
+
+describe("the row a settled turn folds behind", () => {
+	it("is a button named by its label, and says how long the turn took", async () => {
+		const host = await hostOver(TURN);
+		const {unmount} = await mount(host);
+
+		const button = summary("Worked for 4.2s");
+		expect(button.tagName).toBe("BUTTON");
+		expect(button.getAttribute("aria-expanded")).toBe("false");
+		// The chevron is decoration: it never reaches the name and never carries the state alone.
+		expect(button.querySelector(".tuval-chat-turn-chevron")?.getAttribute("aria-hidden")).toBe(
+			"true",
+		);
+		expect(screen.queryByText("weighing it")).toBeNull();
+		unmount();
+	});
+
+	it("reveals the rows it stands for, and writes the turn's own key to this window's slot", async () => {
+		const host = await hostOver(TURN);
+		const {unmount} = await mount(host);
+
+		await click(summary("Worked for 4.2s"));
+
+		expect(summary("Worked for 4.2s").getAttribute("aria-expanded")).toBe("true");
+		await waitFor(() => expect(host.view().unfolded).toEqual(["turn:u"]));
+		// The prompt's own id is not the key: the two share the one `unfolded` set (#8027).
+		expect(host.view().unfolded).not.toContain("u");
+		expect(host.view().expanded).toEqual([]);
+		unmount();
+	});
+
+	it("comes back open on a window remounted onto the same slot", async () => {
+		const host = await hostOver(TURN);
+		const first = await mount(host);
+		await click(summary("Worked for 4.2s"));
+		await waitFor(() => expect(host.view().unfolded).toEqual(["turn:u"]));
+		first.unmount();
+
+		const again = await mount(host);
+
+		expect(summary("Worked for 4.2s").getAttribute("aria-expanded")).toBe("true");
+		again.unmount();
+	});
+
+	it("says the operator stopped it, and leaves the marker and Resend where they were", async () => {
+		const host = await hostOver(STOPPED, {interrupted: ItemId.make("a"), lastPrompt: "go"});
+		const {unmount} = await mount(host);
+
+		expect(summary("You stopped after 2.0s")).toBeDefined();
+		expect(screen.getByText("interrupted")).toBeDefined();
+		expect(screen.getByRole("button", {name: /^Resend/})).toBeDefined();
+		unmount();
+	});
+});
+
+describe("the law the summary row is judged against", () => {
+	const css = (): string => readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
+
+	it("floors the summary at the 36px hit area", () => {
+		expect(css()).toMatch(/\.tuval-chat-turn \{[^}]*min-block-size: var\(--tap-min\)/s);
+	});
+
+	it("hand-rolls no outline, so the shared focus ring is what paints it", () => {
+		const blocks = css()
+			.split("}")
+			.filter((block) => /tuval-chat-turn/.test(block.split("{")[0] ?? ""));
+		expect(blocks.length).toBeGreaterThan(0);
+		expect(blocks.filter((block) => /\boutline\s*:/.test(block))).toEqual([]);
+	});
+});


### PR DESCRIPTION
A finished turn now collapses to one line: the prompt, the reply, and a `Worked for 4.2s` button
standing in for the thinking and tool work between them. Opening it puts every row back where it
was. The window holds the conversation instead of its scaffolding.

Fixes #8614

## What is here

- `apps/tuval/src/shell/chat/rows.ts` derives the turn purely, after the tool-run collapse. A `user`
  item opens a turn; the next `user` item or a compaction row closes it. Everything before the
  terminal reply folds, the reply stays, and one harmless trailing call joins the fold — two or
  more, or a failing one, stay out. A fold that hides nothing, or only a compaction row, is not
  drawn. A spawning call and a session notice never fold.
- A turn with no terminal reply does not fold. That is what keeps the running turn open without
  handing this pure function the session's phase: mid-flight a turn has no reply yet, a `partial`
  one, or a call still running.
- The summary row carries the rows it hides rather than dropping them, so `oldestLoadedId`,
  `olderPageRequest` and `rowIndexOfItem` still resolve through it — a page prepended mid-turn
  re-anchors onto the summary standing in for the anchor row.
- Fold state is the turn's own `turn:<user item id>` key in the existing `view.unfolded` set. No new
  `ChatView` field; `boundary.unit.test.ts` is untouched and green.
- 26 new tests: 20 in `rows.unit.test.ts` (including T3's own three-trailing-calls spec case and the
  duration table), 6 in a new `turn-fold.unit.test.tsx` for the button, its `aria-expanded`, the
  slot round-trip and the interrupted label beside the marker.

## Deviations

- **Declined guidance** — **Said:** the spawn brief said to render the summary "via `Collapsible`
  off `view.expanded`". **Did:** rendered it as a `Button` with `aria-expanded` and no
  `aria-controls`, with the state in `view.unfolded`. **Why:** the rows it reveals are virtualized
  siblings in the transcript, outside any content the control owns — `Collapsible` wires
  `aria-controls` over its own panel, which is exactly the mis-announcement #8027 was filed for, and
  #8057 already settled this shape for the group head's fold button. The issue's own acceptance
  criteria ask for a `<button>` with `aria-expanded` and put fold state in `view.unfolded` "or the
  same per-window discipline", so the contract is met as written.
  **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** #8614 names `rows.ts`, `ChatWindow.tsx`,
  `chat.css` and `view.ts`. **Did:** also adjusted three existing test cases whose fixtures the fold
  now legitimately changes — two in `rows.unit.test.ts` (one opens the fold, one asserts through it)
  and one in `chat-window.unit.test.tsx` (its fixture's opening `user` item removed, so the two
  calls it batches toggles over head no turn). **Why:** each was asserting on rows the fold now
  hides; the assertions were re-pointed, never weakened. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** `build check --surface code` should cover the diff.
  **Did:** it reports `apps/tuval/src/shell/chat/chat.css` as unvalidated. **Why:** no `build check`
  surface validates CSS. The file is covered by tests instead — the existing
  `chat-reduced-motion.unit.test.ts` and two new assertions in `turn-fold.unit.test.tsx` for the
  36px hit-area floor and the absence of a hand-rolled outline. **Disposition:** stated here.
