### PR TITLE
fix: The window picker's keyboard cursor leaves the viewport when the list overflows

### DIFF
--- a/apps/tuval/src/shell/ui/PickerView.tsx
+++ b/apps/tuval/src/shell/ui/PickerView.tsx
@@ -61,6 +61,18 @@ export function PickerView({
 		if (focused) takeFocus();
 	}, [focused, takeFocus]);
 
+	// Nothing else moves the scroll port: the listbox holds focus and the options are untabbable, so
+	// the browser never scrolls a row into view on its own and the highlight walks out of
+	// `.tuval-window-body` (#8656). `block: "nearest"` scrolls instantly and only when the row is off
+	// screen, which is why `reducedMotion` gets no say here.
+	const activeDescendant = frame.activeDescendant;
+	useEffect(() => {
+		if (activeDescendant === null) return;
+		listbox.current?.ownerDocument
+			.getElementById(activeDescendant)
+			?.scrollIntoView({block: "nearest"});
+	}, [activeDescendant]);
+
 	useForwardedKey(windowId, (key) => {
 		// A forwarded key means the desk considers this window focused. Re-claiming here is what
 		// carries focus back after the command line closes onto the desk container.

--- a/apps/tuval/src/shell/ui/picker-scroll.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/picker-scroll.unit.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The picker's scroll follows its highlight. Nothing else can move it: the listbox is the focus
+ * holder and the options are untabbable, so a browser that scrolls a focused element into view is
+ * never handed one, and the highlight walks out of the window body (#8656).
+ *
+ * The keys arrive the way the desk sends them — one `ForwardedKey` per press, with a rising `seq` —
+ * because that is the only channel a renderer has (`./forwarded-key.tsx`).
+ */
+
+import {render, screen} from "@testing-library/react";
+import type {ReactElement} from "react";
+import {useState} from "react";
+import {describe, expect, it, vi} from "vitest";
+import {ProgramId} from "../../registry/program.ts";
+import type {ShellMsg} from "../core/index.ts";
+import {
+	asPickerView,
+	mountPicker,
+	noEntries,
+	type PickerEntries,
+	type PickerView as PickerViewState,
+} from "../picker/browser.ts";
+import {WindowId} from "../window/index.ts";
+import {installDomShims} from "./dom.testing.ts";
+import {type ForwardedKey, ForwardedKeyProvider} from "./forwarded-key.tsx";
+import {PickerView} from "./PickerView.tsx";
+
+installDomShims();
+
+const window0 = WindowId.make("window-1");
+
+/** Six rows: more than a window box holds, which is the case the scroll exists for. */
+const sixPrograms: PickerEntries = {
+	programs: Array.from({length: 6}, (_, index) => ({
+		_tag: "Program" as const,
+		programId: ProgramId.make(`program-${index}`),
+		label: `Program ${index}`,
+	})),
+	processes: [],
+};
+
+interface StageProps {
+	readonly entries: PickerEntries;
+	readonly forwarded: ForwardedKey | null;
+}
+
+function Stage({entries, forwarded}: StageProps): ReactElement {
+	const [view, setView] = useState<PickerViewState>(mountPicker);
+	const dispatch = (msg: ShellMsg): void => {
+		if (msg.type === "window.setView") setView(asPickerView(msg.view));
+	};
+	return (
+		<ForwardedKeyProvider value={forwarded}>
+			<PickerView
+				windowId={window0}
+				entries={entries}
+				view={view}
+				dispatch={dispatch}
+				reducedMotion={true}
+				focused={true}
+			/>
+		</ForwardedKeyProvider>
+	);
+}
+
+interface Scroll {
+	readonly row: Element;
+	readonly options: unknown;
+}
+
+const recordScrolls = (into: Array<Scroll>) =>
+	vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(function record(
+		this: Element,
+		options?: unknown,
+	): void {
+		into.push({row: this, options});
+	});
+
+describe("the picker scrolls its active option into view", () => {
+	// `<arrowup>` sits between `<end>` and `<home>` rather than after both: the picker clamps at each
+	// end instead of wrapping (`../picker/view.ts`), so an `<arrowup>` on the first row moves nothing
+	// and there would be no scroll to assert.
+	it("scrolls the row the activedescendant names on `<end>`, `<arrowup>` and `<home>`", () => {
+		const scrolled: Array<Scroll> = [];
+		const spy = recordScrolls(scrolled);
+		try {
+			const stage = render(<Stage entries={sixPrograms} forwarded={null} />);
+			const listbox = screen.getByRole("listbox", {name: /Open a program/});
+			const rows = screen.getAllByRole("option");
+			expect(rows).toHaveLength(6);
+
+			const press = (key: string, seq: number): void => {
+				stage.rerender(<Stage entries={sixPrograms} forwarded={{windowId: window0, key, seq}} />);
+			};
+
+			scrolled.length = 0;
+			press("<end>", 1);
+			expect(listbox.getAttribute("aria-activedescendant")).toBe(rows.at(-1)?.id);
+			expect(scrolled.at(-1)).toEqual({row: rows.at(-1), options: {block: "nearest"}});
+
+			press("<arrowup>", 2);
+			expect(listbox.getAttribute("aria-activedescendant")).toBe(rows.at(-2)?.id);
+			expect(scrolled.at(-1)?.row).toBe(rows.at(-2));
+
+			press("<home>", 3);
+			expect(listbox.getAttribute("aria-activedescendant")).toBe(rows[0]?.id);
+			expect(scrolled.at(-1)?.row).toBe(rows[0]);
+
+			// The pattern's whole premise: the listbox still holds DOM focus, so the move is announced
+			// (#7499). A row that had been focused would have scrolled itself and hidden this.
+			expect(document.activeElement).toBe(listbox);
+			expect(rows.some((row) => row === document.activeElement)).toBe(false);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("scrolls nothing and throws nothing when the list is empty", () => {
+		const scrolled: Array<Scroll> = [];
+		const spy = recordScrolls(scrolled);
+		try {
+			const stage = render(<Stage entries={noEntries} forwarded={null} />);
+			const listbox = screen.getByRole("listbox", {name: /Open a program/});
+			expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+			expect(screen.queryAllByRole("option")).toHaveLength(0);
+
+			stage.rerender(
+				<Stage entries={noEntries} forwarded={{windowId: window0, key: "<end>", seq: 1}} />,
+			);
+			expect(scrolled).toHaveLength(0);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
The window picker moved its highlight with `aria-activedescendant` and never scrolled, so on a desk
with more rows than the window box holds, `j`/`k`/arrows/`G` walked the cursor off screen. The
listbox is the focus holder and the options are untabbable by design (#7499), so nothing else was
ever going to bring a row back into view.

One effect in `apps/tuval/src/shell/ui/PickerView.tsx`, keyed on `pickerFrame`'s `activeDescendant`,
looks the option up by id and calls `scrollIntoView({block: "nearest"})`. That is the shape
`@kampus/design`'s `CommandPalette` already uses. `block: "nearest"` scrolls instantly and only when
the row is off screen, so `reducedMotion` gains no branch, and the element scrolled is the option —
nothing calls `focus()` on a row, so DOM focus stays on the listbox through every move.

No CSS was needed: `.tuval-window-body` already carries `overflow: auto`, so the window body is the
scroll port and `block: "nearest"` finds it.

`apps/tuval/src/shell/ui/picker-scroll.unit.test.tsx` drives keys through the desk's real
`ForwardedKey` channel and spies on `Element.prototype.scrollIntoView`, asserting the row the
activedescendant names is scrolled on `<end>`, `<arrowup>` and `<home>`, that focus never leaves the
listbox, and that an empty list scrolls nothing and throws nothing.

`origin/main` is merged in: #8658 (the picker's pointer arm) landed in this same file and conflicted.
Both sides are kept — main's `run` callback and pointer handlers, and this effect.

Reviewer: start at the effect in `PickerView.tsx` — it is eleven lines and the whole fix. Then the
last Deviations entry, which is the one thing the merge changed about this PR's behaviour.

Fixes #8656

## Deviations

- **Out-of-scope change** — **Said:** the brief asked for a branch under the `umut/` prefix.
  **Did:** the branch is `build/8656-picker-scroll-follows-cursor-4fcaafa3`. **Why:** `fabrika build
  branch` owns lane branch naming and the claim nonce is part of the name; a hand-cut `umut/` branch
  would not carry it. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the acceptance criterion asks for the test to assert the scroll on
  `End`, on `Home`, and on a single `ArrowUp`, "matching the palette's test". **Did:** asserted all
  three, but in the order `<end>` → `<arrowup>` → `<home>` rather than the palette's `End` → `Home`
  → `ArrowUp`. **Why:** the picker clamps at both ends instead of wrapping
  (`apps/tuval/src/shell/picker/view.ts`, the APG listbox default), so an `ArrowUp` on the first row
  moves nothing and there would be no scroll to assert; the palette wraps, which is why its order
  works there. **Disposition:** stated here and noted in a comment on the test.
- **Scope narrowing** — **Said:** the issue leaves open whether `.tuval-picker`'s listbox needs
  `overflow-y: auto` to scroll at all, and says that CSS is part of the fix if so. **Did:** changed
  no CSS. **Why:** `.tuval-window-body` (`apps/tuval/src/shell/ui/tokens.css`) already declares
  `overflow: auto`, so the window body is the scroll port `block: "nearest"` walks up to.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** run the picker's existing unit tests plus `pnpm typecheck`,
  `pnpm lint` and `pnpm --filter @kampus/tuval test`. **Did:** ran `vitest run src/shell/picker
  src/shell/ui` (22 files, 185 tests, green at the merged head) and `fabrika build check --surface
  code`, which ran `pnpm typecheck:affected` and `pnpm lint:worktree` — not the full tuval suite.
  **Why:** the operator scoped the test run to those two directories to keep parallel lanes off one
  machine's fans; CI runs the rest. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8656 asks the scroll to follow the *keyboard* cursor.
  **Did:** after merging #8658, the same effect also fires on a pointer hover. **Why:** the effect
  keys on `frame.activeDescendant`, and `pickerPointer`'s `hover` gesture answers `Moved`
  (`apps/tuval/src/shell/picker/view.ts:207-209`), which is the one-highlight design #8658 states —
  both inputs move the same cursor, so anything watching it sees both. A hovered row is under the
  pointer and therefore visible, and `block: "nearest"` is a no-op on a fully visible row; a
  *partially* clipped row it does nudge fully into view. **Disposition:** stated here, not changed —
  suppressing it would need the effect to know which input moved the cursor, which is the
  distinction #8658 deliberately removed.
