### PR TITLE
feat: The window picker answers the keyboard only, so a click on an option does nothing

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -249,6 +249,12 @@ program-blind: a process's state still crosses as `unknown`.
 - The page's picker offers both sections: every windowed program, and every running process. Opening
   by name still works through `prefix : window:open <program>`, and both routes end in the same
   `window.open` Msg, so the picker and the command line cannot drift into two spawn paths.
+- **A picker's two inputs answer in one union.** `pickerKey` takes a key and `pickerPointer` takes a
+  row index plus `"hover"` / `"click"`, and both return the same `PickerKeyAnswer`
+  (`src/shell/picker/view.ts`) — one shared `movedTo`, one cursor in the window's view slot. The
+  surface holds one switch over that union and no second write path, so `aria-activedescendant` is
+  the single highlight the mouse and the keyboard both move and a screen reader announces. Founder's
+  ruling, 2026-09-08: any picker uses the same underlying structure for both (#8655).
 - **The kernel pushes the catalog; the page never asks.** A spell call is the only page-to-kernel
   message (#7617 R1.3), so the catalog goes out as the socket opens and again on
   `TransportServer.publishRegistry`, which re-reads the registry and writes to every attached page.

--- a/apps/tuval/src/shell/picker/browser.ts
+++ b/apps/tuval/src/shell/picker/browser.ts
@@ -54,7 +54,9 @@ export {
 	highlighted,
 	mountPicker,
 	type PickerKeyAnswer,
+	type PickerPointer,
 	type PickerView,
 	pickerKey,
+	pickerPointer,
 	withRefusal,
 } from "./view.ts";

--- a/apps/tuval/src/shell/picker/frame.ts
+++ b/apps/tuval/src/shell/picker/frame.ts
@@ -47,6 +47,12 @@ export interface PickerOption {
 	readonly selected: boolean;
 	/** The highlight as a character, so selection is never carried by colour alone. */
 	readonly marker: string;
+	/**
+	 * This option's index into `flatten(entries)` — the argument `pickerPointer` takes, so a surface
+	 * binding a pointer event reads the row number off the frame instead of re-deriving the offset
+	 * its section starts at.
+	 */
+	readonly index: number;
 	readonly entry: PickerEntry;
 }
 
@@ -153,6 +159,7 @@ export const pickerFrame = (
 				detail: detailOf(entry),
 				selected,
 				marker: selected ? "▸" : " ",
+				index: absolute,
 				entry,
 			};
 		});

--- a/apps/tuval/src/shell/picker/view.ts
+++ b/apps/tuval/src/shell/picker/view.ts
@@ -1,7 +1,8 @@
 /**
- * The picker's keyboard model. Everything the picker "remembers" is the window's own view slot — a
- * cursor, at most one refusal, and the process the window was showing before it came back here — so
- * the picker itself holds nothing: `mountPicker` derives a fresh view from its one argument, which
+ * The picker's cursor model, and the one structure both the keyboard and the pointer write
+ * through. Everything the picker "remembers" is the window's own view slot — a cursor, at most one
+ * refusal, and the process the window was showing before it came back here — so the picker itself
+ * holds nothing: `mountPicker` derives a fresh view from its one argument, which
  * is why a second mount after a registry change cannot show yesterday's list or yesterday's
  * highlight.
  *
@@ -119,6 +120,16 @@ const CHOOSE = ["<enter>", "<space>"];
 const DISMISS = ["<escape>"];
 
 /**
+ * The one move. A move onto the row already under the cursor keeps a showing refusal, because
+ * nothing has been moved on from; any other move clears it. Both inputs go through here, so hover
+ * and the arrow keys cannot answer the same move two ways.
+ */
+const movedTo = (view: PickerView, at: number, next: number, length: number): PickerKeyAnswer =>
+	length === 0 || next === at
+		? {_tag: "Moved", view: {...view, cursor: at}}
+		: {_tag: "Moved", view: {...view, cursor: next, refusal: null}};
+
+/**
  * One key against the picker. `<arrow*>` are the ARIA listbox keys and `j`/`k`/`<c-n>`/`<c-p>` the
  * Vim and readline spellings of the same move, so the founder's muscle memory and a screen-reader
  * user's expected keys are one implementation rather than two.
@@ -144,10 +155,7 @@ export const pickerKey = (
 	const rows = flatten(entries);
 	const at = cursorOf(entries, view);
 
-	const moveTo = (next: number): PickerKeyAnswer =>
-		rows.length === 0 || next === at
-			? {_tag: "Moved", view: {...view, cursor: at}}
-			: {_tag: "Moved", view: {...view, cursor: next, refusal: null}};
+	const moveTo = (next: number): PickerKeyAnswer => movedTo(view, at, next, rows.length);
 
 	if (DOWN.includes(pressed)) return moveTo(clamp(at + 1, rows.length));
 	if (UP.includes(pressed)) return moveTo(clamp(at - 1, rows.length));
@@ -166,4 +174,37 @@ export const pickerKey = (
 		return entry === undefined ? ignored : {_tag: "Chose", intent: intentOf(windowId, entry)};
 	}
 	return ignored;
+};
+
+/**
+ * What a pointer did to one row. `hover` is the pointer landing on it, `click` the commit — the two
+ * gestures a `role="option"` offers, and nothing else: a listbox driven by `aria-activedescendant`
+ * has no per-option focus to model.
+ */
+export type PickerPointer = "hover" | "click";
+
+/**
+ * One pointer gesture against the picker, answered in `pickerKey`'s own union so the surface has a
+ * single switch to dispatch (founder's ruling, 2026-09-08: one underlying structure for both
+ * inputs). `index` addresses `flatten(entries)` — the same list the cursor indexes — so a hover and
+ * an arrow key that land on one row store the same view, and `aria-activedescendant` stays the one
+ * highlight either way.
+ *
+ * An index naming no row is `Ignored` rather than clamped: a pointer event carries a row that was
+ * really under it, so an out-of-range index means the list changed under the gesture, and moving
+ * the cursor somewhere the user never pointed at is worse than doing nothing.
+ */
+export const pickerPointer = (
+	windowId: WindowId,
+	entries: PickerEntries,
+	view: PickerView,
+	index: number,
+	gesture: PickerPointer,
+): PickerKeyAnswer => {
+	const rows = flatten(entries);
+	const entry = rows[index];
+	if (entry === undefined) return ignored;
+	return gesture === "click"
+		? {_tag: "Chose", intent: intentOf(windowId, entry)}
+		: movedTo(view, cursorOf(entries, view), index, rows.length);
 };

--- a/apps/tuval/src/shell/picker/view.unit.test.ts
+++ b/apps/tuval/src/shell/picker/view.unit.test.ts
@@ -3,7 +3,7 @@ import type {PickerEntries} from "./entries.ts";
 import {noEntries, programEntries} from "./entries.ts";
 import {processId, programId, programRow, windowId} from "./fixtures.ts";
 import {unknownProgram} from "./refusal.ts";
-import {highlighted, mountPicker, pickerKey, withRefusal} from "./view.ts";
+import {highlighted, mountPicker, pickerKey, pickerPointer, withRefusal} from "./view.ts";
 
 const window = windowId("window-1");
 
@@ -144,5 +144,58 @@ describe("picker keyboard", () => {
 			_tag: "Moved",
 			view: {cursor: 1, refusal: null, previous: null},
 		});
+	});
+});
+
+describe("picker pointer", () => {
+	it("a pointer landing on a row moves the same cursor an arrow key moves", () => {
+		expect(pickerPointer(window, entries, mountPicker(), 2, "hover")).toEqual({
+			_tag: "Moved",
+			view: {cursor: 2, refusal: null, previous: null},
+		});
+		expect(pickerPointer(window, entries, mountPicker(), 2, "hover")).toEqual(
+			pickerKey(window, entries, press(mountPicker(), "j"), "j"),
+		);
+	});
+
+	it("a click commits the row under it to the same intent Enter would run", () => {
+		expect(pickerPointer(window, entries, mountPicker(), 0, "click")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "OpenProgram", windowId: window, programId: "counter"},
+		});
+		expect(pickerPointer(window, entries, mountPicker(), 2, "click")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "AttachProcess", windowId: window, processId: "p-1"},
+		});
+	});
+
+	it("the row the pointer last landed on is the row Enter then chooses", () => {
+		const hovered = pickerPointer(window, entries, mountPicker(), 2, "hover");
+		if (hovered._tag !== "Moved") throw new Error("a hover onto a row must answer Moved");
+		expect(highlighted(entries, hovered.view)).toEqual(entries.processes[0]);
+		expect(pickerKey(window, entries, hovered.view, "<enter>")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "AttachProcess", windowId: window, processId: "p-1"},
+		});
+	});
+
+	it("a pointer move onto another row clears the refusal, as a keyboard move does", () => {
+		const refused = withRefusal(mountPicker(), unknownProgram("nope"));
+		expect(pickerPointer(window, entries, refused, 1, "hover")).toEqual({
+			_tag: "Moved",
+			view: {cursor: 1, refusal: null, previous: null},
+		});
+		// Landing on the row already under the cursor is not moving on from anything — the answer
+		// `movedTo` gives a keyboard press that cannot move either.
+		expect(pickerPointer(window, entries, refused, 0, "hover")).toEqual({
+			_tag: "Moved",
+			view: {cursor: 0, refusal: unknownProgram("nope"), previous: null},
+		});
+	});
+
+	it("a gesture on a row the list no longer offers is ignored, never clamped", () => {
+		expect(pickerPointer(window, entries, mountPicker(), 9, "hover")).toEqual({_tag: "Ignored"});
+		expect(pickerPointer(window, entries, mountPicker(), 9, "click")).toEqual({_tag: "Ignored"});
+		expect(pickerPointer(window, noEntries, mountPicker(), 0, "click")).toEqual({_tag: "Ignored"});
 	});
 });

--- a/apps/tuval/src/shell/ui/PickerView.tsx
+++ b/apps/tuval/src/shell/ui/PickerView.tsx
@@ -1,7 +1,10 @@
 /**
  * The picker, bound to elements. It decides nothing: `pickerFrame` (`../picker/frame.ts`) already
  * said the roles, the accessible names, the active descendant and the live region, and this file
- * spells them as DOM. Keys go through `pickerKey`, whose answers are the only writes.
+ * spells them as DOM. Keys go through `pickerKey` and pointer gestures through `pickerPointer`,
+ * which answer in one union that `run` below is the only reader of — so the mouse writes nothing
+ * the keyboard could not have written, and `aria-activedescendant` stays the one highlight both
+ * inputs move (#8655).
  *
  * The listbox is the focus holder, not each option — that is the `aria-activedescendant` pattern,
  * and it is what keeps the desk's single keyboard listener the only listener: the options are not
@@ -17,9 +20,11 @@ import {useCallback, useEffect, useRef} from "react";
 import type {ShellMsg} from "../core/index.ts";
 import {
 	type PickerEntries,
+	type PickerKeyAnswer,
 	type PickerView as PickerViewState,
 	pickerFrame,
 	pickerKey,
+	pickerPointer,
 } from "../picker/browser.ts";
 import type {WindowId} from "../window/index.ts";
 import {useForwardedKey} from "./forwarded-key.tsx";
@@ -61,26 +66,32 @@ export function PickerView({
 		if (focused) takeFocus();
 	}, [focused, takeFocus]);
 
+	const run = useCallback(
+		(answer: PickerKeyAnswer) => {
+			switch (answer._tag) {
+				case "Moved":
+				case "Cleared":
+					dispatch({type: "window.setView", windowId, view: answer.view});
+					return;
+				case "Chose":
+					dispatch(
+						answer.intent._tag === "OpenProgram"
+							? {type: "window.open", windowId, programId: answer.intent.programId}
+							: {type: "window.attach", windowId, processId: answer.intent.processId},
+					);
+					return;
+				case "Ignored":
+					return;
+			}
+		},
+		[dispatch, windowId],
+	);
+
 	useForwardedKey(windowId, (key) => {
 		// A forwarded key means the desk considers this window focused. Re-claiming here is what
 		// carries focus back after the command line closes onto the desk container.
 		takeFocus();
-		const answer = pickerKey(windowId, entries, view, key);
-		switch (answer._tag) {
-			case "Moved":
-			case "Cleared":
-				dispatch({type: "window.setView", windowId, view: answer.view});
-				return;
-			case "Chose":
-				dispatch(
-					answer.intent._tag === "OpenProgram"
-						? {type: "window.open", windowId, programId: answer.intent.programId}
-						: {type: "window.attach", windowId, processId: answer.intent.processId},
-				);
-				return;
-			case "Ignored":
-				return;
-		}
+		run(pickerKey(windowId, entries, view, key));
 	});
 
 	return (
@@ -109,12 +120,22 @@ export function PickerView({
 						)}
 						{group.options.map((option) => (
 							// biome-ignore lint/a11y/useFocusableInteractive: activedescendant options are not tabbable
+							// biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard equivalent is `<enter>`, which the desk forwards to the listbox
 							<div
 								key={option.id}
 								id={option.id}
 								role="option"
 								aria-selected={option.selected}
 								aria-label={option.name}
+								onPointerEnter={() =>
+									run(pickerPointer(windowId, entries, view, option.index, "hover"))
+								}
+								onClick={() => {
+									// A click must not cost the listbox its focus, or the next key press goes
+									// nowhere and `aria-activedescendant` is announced off nothing (#7499).
+									takeFocus();
+									run(pickerPointer(windowId, entries, view, option.index, "click"));
+								}}
 							>
 								<span aria-hidden="true">{option.marker}</span>
 								<span>{option.name}</span>

--- a/apps/tuval/src/shell/ui/picker-view.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/picker-view.unit.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The picker under a pointer (#8655). The claim is not that a click works but that it works
+ * *through the cursor the keyboard uses*: hover writes the same `window.setView` an arrow key
+ * writes, a click dispatches the same `window.open` / `window.attach` Enter dispatches, and the
+ * listbox keeps DOM focus so `aria-activedescendant` stays the one highlight.
+ */
+
+import {fireEvent, render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import type {ShellMsg} from "../core/index.ts";
+import {mountPicker, type PickerEntries, programEntries} from "../picker/browser.ts";
+import {processId, programId, programRow} from "../picker/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {installDomShims} from "./dom.testing.ts";
+import {PickerView} from "./PickerView.tsx";
+
+installDomShims();
+
+const windowId = WindowId.make("window-1");
+
+const entries: PickerEntries = {
+	programs: programEntries([programRow("counter"), programRow("pi")]),
+	processes: [
+		{
+			_tag: "Process",
+			processId: processId("p-1"),
+			programId: programId("counter"),
+			label: "counter",
+			parentId: null,
+		},
+	],
+};
+
+const mount = (view = mountPicker()) => {
+	const sent: Array<ShellMsg> = [];
+	const result = render(
+		<PickerView
+			windowId={windowId}
+			entries={entries}
+			view={view}
+			dispatch={(msg) => sent.push(msg)}
+			reducedMotion={true}
+			focused={true}
+		/>,
+	);
+	const options = [...result.container.querySelectorAll('[role="option"]')];
+	const listbox = result.container.querySelector('[role="listbox"]');
+	if (listbox === null) throw new Error("the picker rendered no listbox");
+	return {sent, options, listbox, ...result};
+};
+
+const rowAt = (options: ReadonlyArray<Element>, index: number): Element => {
+	const option = options[index];
+	if (option === undefined) throw new Error(`the picker rendered no row ${index}`);
+	return option;
+};
+
+describe("the picker answers the pointer through the keyboard's own cursor", () => {
+	it("a pointer landing on a row moves the cursor there and names it active", () => {
+		const first = mount();
+		fireEvent.pointerOver(rowAt(first.options, 2));
+		expect(first.sent).toEqual([
+			{
+				type: "window.setView",
+				windowId,
+				view: {cursor: 2, refusal: null, previous: null},
+			},
+		]);
+
+		// The desk folds that view back in; the highlight the mouse moved is the one ARIA announces.
+		const moved = mount({cursor: 2, refusal: null, previous: null});
+		expect(moved.listbox.getAttribute("aria-activedescendant")).toBe("picker-window-1-option-2");
+		expect(rowAt(moved.options, 2).getAttribute("aria-selected")).toBe("true");
+	});
+
+	it("clicking a program row opens it and clicking a process row attaches it", () => {
+		const programs = mount();
+		fireEvent.click(rowAt(programs.options, 1));
+		expect(programs.sent).toEqual([{type: "window.open", windowId, programId: "pi"}]);
+
+		const processes = mount();
+		fireEvent.click(rowAt(processes.options, 2));
+		expect(processes.sent).toEqual([{type: "window.attach", windowId, processId: "p-1"}]);
+	});
+
+	it("keeps the listbox focused and the options untabbable, so both inputs read one highlight", () => {
+		const view = mount();
+		expect(view.listbox.ownerDocument.activeElement).toBe(view.listbox);
+		expect(view.options.map((option) => option.getAttribute("tabindex"))).toEqual([
+			null,
+			null,
+			null,
+		]);
+
+		fireEvent.click(rowAt(view.options, 0));
+		expect(view.listbox.ownerDocument.activeElement).toBe(view.listbox);
+	});
+});


### PR DESCRIPTION
The window picker (`<c-b> w`) only answered key presses: clicking a row did nothing and hovering one
did nothing. `pickerKey` matched normalized key names, and a pointer event had no way into it.

Founder's ruling, 2026-09-08: "any picker we have should use the same underlying structure for both
mouse and keyboard". So this adds a pointer arm beside `pickerKey` rather than a second path:

- `pickerPointer(windowId, entries, view, index, "hover" | "click")` in
  `apps/tuval/src/shell/picker/view.ts` answers in `pickerKey`'s own `PickerKeyAnswer` union —
  `Moved` for a hover, `Chose` for a click, `Ignored` for a row the list no longer offers. The move
  itself is a shared `movedTo` both inputs go through, so a hover clears a showing refusal exactly
  as an arrow key does, and landing on the row already under the cursor keeps it exactly as a press
  that cannot move does.
- `PickerOption` (`frame.ts`) now carries its `index` into `flatten(entries)`, so the surface reads
  the row number off the frame instead of re-deriving the offset its section starts at.
- `PickerView.tsx` folds its dispatch switch into one `run(answer)` and hands it both the key
  answers and the pointer answers. There is no second write path. A click calls the existing
  `takeFocus` first, so the listbox keeps DOM focus and `aria-activedescendant` stays the one
  highlight; the options are still not tabbable and still listen to nothing else.

Tests: five pointer cases in `picker/view.unit.test.ts` (including pointer-move-then-`<enter>`
choosing the hovered row) and a new jsdom component test,
`apps/tuval/src/shell/ui/picker-view.unit.test.tsx`, proving hover dispatches `window.setView`, a
program click dispatches `window.open`, a process click dispatches `window.attach`, and focus stays
on the listbox. Every existing keyboard case is untouched.

Fixes #8655

## Deviations

- **Out-of-scope change** — **Said:** #8655 names `picker/view.ts` and `ui/PickerView.tsx`.
  **Did:** also added an `index` field to `PickerOption` in `picker/frame.ts` and re-exported
  `pickerPointer` from `picker/browser.ts`. **Why:** the component only sees per-group option lists,
  so without the frame carrying the absolute row number the surface would have to re-derive the
  section offset — a second place that can disagree with the cursor, which is the exact drift the
  ruling forbids. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue asks for code and a unit test. **Did:** also added
  a bullet to `.patterns/tuval-shell-assembly.md` describing the one-union, two-inputs shape.
  **Why:** CLAUDE.md requires a load-bearing pattern to be documented, and that doc already
  described the picker's surface contract. **Disposition:** stated here.
- **Declined guidance** — **Said:** the spawn brief asked for a branch under the `umut/` prefix.
  **Did:** built on `build/8655-picker-pointer-cd4f6302`. **Why:** `fabrika build branch` mints the
  branch name, and the lane proof (`build tree --issue`) keys on that `build/<n>-<slug>-<nonce>`
  shape — a renamed branch fails that proof before every later mutation. **Disposition:** stated
  here.
