### PR TITLE
chore: carve the composer into modules under packages/design/src/agent-chat/

### DIFF
--- a/apps/tuval/src/shell/chat/chat-picker-group-label.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-picker-group-label.unit.test.tsx
@@ -11,7 +11,9 @@ installDomShims();
 
 // Vitest's css: false empties the component import; read the same shipped stylesheet instead.
 const entry = fileURLToPath(import.meta.resolve("@kampus/design"));
-const css = readFileSync(entry.replace(/index\.ts$/, "AgentChatInput.css"), "utf8");
+const css = ["AgentChatInput.css", "agent-chat/SettingMenu.css"]
+	.map((name) => readFileSync(entry.replace(/index\.ts$/, name), "utf8"))
+	.join("\n");
 const style = document.createElement("style");
 style.textContent = css;
 

--- a/apps/tuval/src/shell/chat/chat-picker-menu-cap.unit.test.ts
+++ b/apps/tuval/src/shell/chat/chat-picker-menu-cap.unit.test.ts
@@ -31,7 +31,7 @@ const designCss = (name: string): string => {
 };
 
 beforeAll(() => {
-	for (const name of ["Menu.css", "AgentChatInput.css"]) {
+	for (const name of ["Menu.css", "AgentChatInput.css", "agent-chat/SettingMenu.css"]) {
 		const style = document.createElement("style");
 		style.textContent = designCss(name);
 		document.head.appendChild(style);

--- a/apps/tuval/src/shell/chat/chat-picker-note-truncation.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-picker-note-truncation.unit.test.tsx
@@ -16,7 +16,9 @@ const style = document.createElement("style");
 beforeEach(() => {
 	// Vitest elides CSS imports; inspect the shipped cascade, not an unstyled component.
 	const entry = fileURLToPath(import.meta.resolve("@kampus/design"));
-	style.textContent = readFileSync(entry.replace(/index\.ts$/, "AgentChatInput.css"), "utf8");
+	style.textContent = ["AgentChatInput.css", "agent-chat/SettingMenu.css"]
+		.map((name) => readFileSync(entry.replace(/index\.ts$/, name), "utf8"))
+		.join("\n");
 	document.head.append(style);
 });
 

--- a/apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-picker-opens-on-checked-row.unit.test.tsx
@@ -37,7 +37,7 @@ const designCss = (name: string): string => {
 	return readFileSync(entry.replace(/index\.ts$/, name), "utf8");
 };
 
-const styles = ["Menu.css", "AgentChatInput.css"].map((name) => {
+const styles = ["Menu.css", "AgentChatInput.css", "agent-chat/SettingMenu.css"].map((name) => {
 	const style = document.createElement("style");
 	style.textContent = designCss(name);
 	return style;

--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -48,10 +48,7 @@
 
 .kp-agent-chat__status,
 .kp-agent-chat__scope,
-.kp-agent-chat__hint,
-.kp-agent-chat__widget-title,
-.kp-agent-chat__activity-title,
-.kp-agent-chat__empty {
+.kp-agent-chat__hint {
 	margin: 0;
 }
 
@@ -141,36 +138,6 @@
 	max-height: calc(var(--s-8) * 8);
 	overflow: auto;
 	padding: var(--s-1);
-}
-
-.kp-agent-chat__suggestion:where([data-scope="button"][data-part="root"]) {
-	justify-content: flex-start;
-	min-width: 0;
-	min-height: var(--tap-min);
-	padding: var(--s-2);
-	text-align: start;
-}
-
-.kp-agent-chat__suggestion[aria-selected="true"] {
-	background: var(--accent-faint);
-	color: var(--text-primary);
-}
-
-.kp-agent-chat__suggestion-main {
-	min-width: 0;
-	font: var(--t-mono);
-	color: inherit;
-}
-
-.kp-agent-chat__suggestion-detail {
-	margin-inline-start: auto;
-	min-width: 0;
-	overflow: hidden;
-	color: var(--text-muted);
-	font: var(--t-meta);
-	text-align: end;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .kp-agent-chat__actions {
@@ -280,100 +247,13 @@
 	flex-wrap: nowrap;
 }
 
-.kp-agent-chat__picker-trigger:where([data-scope="button"][data-part="root"]),
 .kp-agent-chat__resources-button:where([data-scope="button"][data-part="root"]) {
 	--manti-button-padding-x: var(--s-2);
 	min-width: 0;
 	color: var(--text-secondary);
 }
 
-.kp-agent-chat__picker-trigger > [data-part="label"],
-.kp-agent-chat__picker-menu [data-part="item-text"] {
-	min-width: 0;
-}
-
-.kp-agent-chat__picker-trigger [data-part="label"] > span:not(.kp-agent-chat__picker-note),
-.kp-agent-chat__picker-option > span:not(.kp-agent-chat__picker-note) {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.kp-agent-chat__picker-trigger .kp-agent-chat__picker-note,
-.kp-agent-chat__picker-trigger .kp-icon {
-	flex-shrink: 0;
-}
-
-.kp-agent-chat__picker-option {
-	display: flex;
-	align-items: baseline;
-	gap: var(--s-1);
-	min-width: 0;
-}
-
-.kp-agent-chat__picker-note {
-	min-width: 0;
-	overflow: hidden;
-	color: var(--text-secondary);
-	font: var(--t-meta);
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.kp-agent-chat__picker-menu:where([data-scope="menu"][data-part="content"]) {
-	width: calc(var(--s-8) * 6);
-	max-width: calc(100vw - var(--s-4));
-	/* The cap belongs on `content`: that is the `rootEl` Zag's menu machine scrolls a highlighted
-	   item within, so an inner scroll box would leave arrow-key navigation scrolling the wrong
-	   element. */
-	max-height: min(26.25rem, 55dvh);
-	overflow-y: auto;
-	overscroll-behavior: contain;
-}
-
-.kp-agent-chat__picker-menu:focus-visible {
-	outline: none;
-}
-
-.kp-agent-chat__picker-menu [data-part="item-group-label"] {
-	padding: var(--s-2) var(--s-3) var(--s-1);
-	color: var(--text-secondary);
-	font: var(--t-meta);
-	font-weight: 700;
-}
-
 .kp-agent-chat__hint {
-	color: var(--text-muted);
-	font: var(--t-meta);
-}
-
-.kp-agent-chat__widget,
-.kp-agent-chat__activity {
-	display: flex;
-	flex-direction: column;
-	gap: var(--s-2);
-}
-
-.kp-agent-chat__widget-title,
-.kp-agent-chat__activity-title {
-	color: var(--text-secondary);
-	font: var(--t-meta);
-	font-weight: 700;
-}
-
-.kp-agent-chat__widget pre,
-.kp-agent-chat__assistant-text {
-	max-height: calc(var(--s-8) * 8);
-	margin: 0;
-	overflow: auto;
-	color: var(--text-primary);
-	font: var(--t-body);
-	white-space: pre-wrap;
-	word-break: break-word;
-}
-
-.kp-agent-chat__empty {
 	color: var(--text-muted);
 	font: var(--t-meta);
 }
@@ -436,23 +316,6 @@
 	gap: var(--s-2);
 }
 
-.kp-agent-chat__activity-list {
-	display: flex;
-	flex-direction: column;
-	gap: var(--s-1);
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	color: var(--text-secondary);
-	font: var(--t-meta);
-}
-
-.kp-agent-chat__extension-options {
-	display: flex;
-	flex-direction: column;
-	gap: var(--s-2);
-}
-
 @media (max-width: 40rem) {
 	.kp-agent-chat__status-row,
 	.kp-agent-chat__actions {
@@ -475,9 +338,5 @@
 
 	.kp-agent-chat__setting {
 		flex: 1 1 auto;
-	}
-
-	.kp-agent-chat__suggestion-detail {
-		display: none;
 	}
 }

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -2,20 +2,12 @@ import {
 	Bot,
 	Brain,
 	ChevronDown,
-	ChevronsDown,
-	ChevronsUp,
 	ChevronUp,
-	CircleOff,
-	File as FileIcon,
 	FileImage,
-	type LucideIcon,
-	Minus,
 	Paperclip,
 	SendHorizontal,
 	ShieldCheck,
-	Sparkles,
 	Square,
-	Terminal,
 	X,
 } from "lucide-react";
 import {
@@ -30,6 +22,42 @@ import {
 	useState,
 } from "react";
 import {Alert} from "./Alert";
+import {AgentActivity} from "./agent-chat/AgentActivity";
+import {
+	deliveryModeKeys,
+	projectTrustKeys,
+	thinkingLevelIcons,
+	thinkingLevelKeys,
+	toItems,
+} from "./agent-chat/catalog";
+import {HarnessWidget} from "./agent-chat/HarnessWidget";
+import {Icon} from "./agent-chat/Icon";
+import {fileAsImage, MAX_IMAGE_BYTES} from "./agent-chat/image";
+import {mockCommands, mockFiles, mockModels, mockThinkingLevels} from "./agent-chat/mock-harness";
+import {PiExtensionDialog} from "./agent-chat/PiExtensionDialog";
+import {
+	assistantMessageText,
+	booleanValue,
+	commandList,
+	completionFor,
+	deliveryMode,
+	extensionRequest,
+	isRecord,
+	modelList,
+	modelName,
+	modelValue,
+	projectTrustValue,
+	providersCollide,
+	runningModelLabel,
+	selectedModelValue,
+	stringValue,
+	thinkingLevelList,
+	thinkingLevelValue,
+} from "./agent-chat/parse";
+import {type PickerItem, SettingMenu} from "./agent-chat/SettingMenu";
+import {SuggestionRow} from "./agent-chat/SuggestionRow";
+import type {Activity, ConnectionState, ExtensionRequest, Suggestion} from "./agent-chat/types";
+import {unavailableBridge} from "./agent-chat/unavailable-bridge";
 import type {
 	AgentChatInputBridge,
 	PiCommand,
@@ -45,340 +73,12 @@ import {Kbd} from "./atoms";
 import {Button} from "./Button";
 import {Card} from "./Card";
 import {Collapsible} from "./Collapsible";
-import {Dialog} from "./Dialog";
 import {Form, Input, Textarea} from "./Form";
-import {type DesignCatalogKey, type DesignTranslate, useDesignT} from "./i18n";
+import {useDesignT} from "./i18n";
 import {Menu, type MenuItem} from "./Menu";
 import {Select, type SelectItem} from "./Select";
 import "./AgentChatInput.css";
 import "./visually-hidden.css";
-
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
-
-const unavailableBridge: AgentChatInputBridge = {
-	loadPiState: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	loadPiCommands: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	loadPiModels: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	loadPiThinkingLevels: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	loadPiFiles: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	setPiModel: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	setPiThinkingLevel: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	setPiProjectTrust: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	sendPiPrompt: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	abortPi: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	answerPiExtension: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
-	subscribeToPiEvents: () => () => undefined,
-};
-
-const deliveryModeKeys: readonly {value: PiDeliveryMode; key: DesignCatalogKey}[] = [
-	{value: "prompt", key: "admin.agent.delivery.prompt"},
-	{value: "steer", key: "admin.agent.delivery.steer"},
-	{value: "follow_up", key: "admin.agent.delivery.followUp"},
-];
-
-const projectTrustKeys: readonly {value: PiProjectTrust; key: DesignCatalogKey}[] = [
-	{value: "approve", key: "admin.agent.trust.approve"},
-	{value: "no-approve", key: "admin.agent.trust.ignore"},
-];
-
-const thinkingLevelKeys: Readonly<Record<PiThinkingLevel, DesignCatalogKey>> = {
-	off: "admin.agent.thinking.off",
-	minimal: "admin.agent.thinking.minimal",
-	low: "admin.agent.thinking.low",
-	medium: "admin.agent.thinking.medium",
-	high: "admin.agent.thinking.high",
-	xhigh: "admin.agent.thinking.xhigh",
-	max: "admin.agent.thinking.max",
-	ultra: "admin.agent.thinking.ultra",
-};
-
-const toItems = (
-	entries: readonly {value: string; key: DesignCatalogKey}[],
-	t: DesignTranslate,
-): SelectItem[] => entries.map(({value, key}) => ({value, label: t(key)}));
-
-const thinkingLevelIcons: Readonly<Record<PiThinkingLevel, LucideIcon>> = {
-	off: CircleOff,
-	minimal: ChevronsDown,
-	low: ChevronDown,
-	medium: Minus,
-	high: ChevronUp,
-	xhigh: ChevronsUp,
-	max: Sparkles,
-	ultra: Sparkles,
-};
-
-const mockModels: readonly PiModel[] = [
-	{provider: "openai", id: "gpt-5.5", name: "GPT-5.5"},
-	{provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna"},
-	{provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol"},
-	{provider: "openai", id: "gpt-5.6-terra", name: "GPT-5.6 Terra"},
-];
-
-const mockThinkingLevels: readonly PiThinkingLevel[] = [
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-];
-
-const mockCommands = (t: DesignTranslate): readonly PiCommand[] => [
-	{name: "review", description: t("admin.agent.mock.command.review")},
-	{name: "compact", description: t("admin.agent.mock.command.compact")},
-];
-
-const mockFiles = ["apps/web/src/App.tsx", "packages/design/src/AgentChatInput.tsx"];
-
-type ConnectionState = "loading" | "ready" | "unavailable" | "working";
-
-interface Completion {
-	readonly kind: "command" | "file";
-	readonly query: string;
-	readonly start: number;
-	readonly end: number;
-}
-
-type Suggestion =
-	| {readonly kind: "command"; readonly command: PiCommand}
-	| {readonly kind: "file"; readonly path: string};
-
-interface Activity {
-	readonly id: number;
-	readonly text: string;
-}
-
-/** One row of a settings picker. Exported as `AgentSettingItem`, which is what a host's slot binds. */
-export interface PickerItem {
-	readonly value: string;
-	readonly label: string;
-	/** Secondary text beside the label, for a row the label alone does not tell apart. */
-	readonly note?: string;
-	readonly icon?: LucideIcon;
-}
-
-interface ExtensionRequest {
-	readonly id: string;
-	readonly method: "select" | "confirm" | "input" | "editor";
-	readonly title: string;
-	readonly message?: string;
-	readonly options?: readonly string[];
-	readonly placeholder?: string;
-	readonly prefill?: string;
-}
-
-type IconSize = 12 | 14 | 16 | 20 | 24;
-
-function Icon({
-	icon: Glyph,
-	size = 20,
-	className,
-	label,
-}: {
-	readonly icon: LucideIcon;
-	readonly size?: IconSize;
-	readonly className?: string;
-	readonly label?: string;
-}) {
-	return (
-		<Glyph
-			className={className ? `kp-icon ${className}` : "kp-icon"}
-			size={size}
-			aria-hidden={label ? undefined : true}
-			aria-label={label}
-			role={label ? "img" : undefined}
-		/>
-	);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringValue(record: Record<string, unknown>, key: string): string | undefined {
-	const value = record[key];
-	return typeof value === "string" ? value : undefined;
-}
-
-function booleanValue(record: Record<string, unknown>, key: string): boolean | undefined {
-	const value = record[key];
-	return typeof value === "boolean" ? value : undefined;
-}
-
-function deliveryMode(value: string | undefined): PiDeliveryMode | undefined {
-	return value === "prompt" || value === "steer" || value === "follow_up" ? value : undefined;
-}
-
-function projectTrustValue(value: unknown): PiProjectTrust | undefined {
-	return value === "approve" || value === "no-approve" ? value : undefined;
-}
-
-function thinkingLevelValue(value: unknown): PiThinkingLevel | undefined {
-	return value === "off" ||
-		value === "minimal" ||
-		value === "low" ||
-		value === "medium" ||
-		value === "high" ||
-		value === "xhigh" ||
-		value === "max" ||
-		value === "ultra"
-		? value
-		: undefined;
-}
-
-function modelValue(model: Pick<PiModel, "provider" | "id">): string {
-	return `${model.provider}/${model.id}`;
-}
-
-/**
- * Two providers can offer the same display name, and then the name alone names two rows. The
- * provider is the fact that tells them apart, so it rides every row once a second one is offered.
- */
-function providersCollide(models: readonly PiModel[]): boolean {
-	return new Set(models.map((model) => model.provider)).size > 1;
-}
-
-/** A pushed command catalog, admitted row by row. A malformed push leaves the held list alone. */
-function commandList(value: unknown): readonly PiCommand[] | undefined {
-	if (!Array.isArray(value)) return undefined;
-	const rows: PiCommand[] = [];
-	for (const row of value) {
-		if (!isRecord(row)) return undefined;
-		const name = stringValue(row, "name");
-		if (!name) return undefined;
-		const description = stringValue(row, "description");
-		const source = stringValue(row, "source");
-		rows.push({name, ...(description ? {description} : {}), ...(source ? {source} : {})});
-	}
-	return rows;
-}
-
-/** A pushed model catalog, admitted row by row. A malformed push leaves the held list alone. */
-function modelList(value: unknown): readonly PiModel[] | undefined {
-	if (!Array.isArray(value)) return undefined;
-	const rows: PiModel[] = [];
-	for (const row of value) {
-		if (!isRecord(row)) return undefined;
-		const provider = stringValue(row, "provider");
-		const id = stringValue(row, "id");
-		const name = stringValue(row, "name");
-		if (!provider || !id || !name) return undefined;
-		rows.push({provider, id, name});
-	}
-	return rows;
-}
-
-/**
- * A pushed level set, admitted row by row like the model catalog. `off` is dropped for the reason
- * the mount-time load drops it: it is not a row this picker selects.
- */
-function thinkingLevelList(value: unknown): readonly PiThinkingLevel[] | undefined {
-	if (!Array.isArray(value)) return undefined;
-	const levels: PiThinkingLevel[] = [];
-	for (const row of value) {
-		const level = thinkingLevelValue(row);
-		if (!level) return undefined;
-		if (level !== "off") levels.push(level);
-	}
-	return levels;
-}
-
-function selectedModelValue(state: Record<string, unknown> | undefined): string | undefined {
-	const model = state && isRecord(state.model) ? state.model : undefined;
-	if (!model) return undefined;
-	const provider = stringValue(model, "provider");
-	const id = stringValue(model, "id");
-	return provider && id ? modelValue({provider, id}) : undefined;
-}
-
-function completionFor(draft: string): Completion | undefined {
-	const match = /(?:^|\s)([/@])([^\s]*)$/.exec(draft);
-	if (!match) return undefined;
-	const sigil = match[1];
-	const query = match[2] ?? "";
-	if (!sigil) return undefined;
-	const start = draft.length - match[0].length + match[0].lastIndexOf(sigil);
-	return {kind: sigil === "/" ? "command" : "file", query, start, end: draft.length};
-}
-
-function modelName(state: Record<string, unknown> | undefined): string | undefined {
-	const model = state && isRecord(state.model) ? state.model : undefined;
-	if (!model) return undefined;
-	return (
-		stringValue(model, "displayName") ?? stringValue(model, "name") ?? stringValue(model, "id")
-	);
-}
-
-/** The running model as the status line names it: bare name, or name + provider once two collide. */
-function runningModelLabel(
-	state: Record<string, unknown> | undefined,
-	models: readonly PiModel[],
-): string | undefined {
-	const name = modelName(state);
-	if (!name || !providersCollide(models)) return name;
-	const model = state && isRecord(state.model) ? state.model : undefined;
-	const provider = model && stringValue(model, "provider");
-	return provider ? `${name} (${provider})` : name;
-}
-
-function assistantMessageText(value: unknown): string | undefined {
-	if (!isRecord(value) || value.role !== "assistant" || !Array.isArray(value.content))
-		return undefined;
-	const text = value.content.flatMap((block) => {
-		if (!isRecord(block)) return [];
-		const value = stringValue(block, "text");
-		return value ? [value] : [];
-	});
-	return text.length > 0 ? text.join("") : undefined;
-}
-
-function extensionRequest(event: PiEvent, fallbackTitle: string): ExtensionRequest | undefined {
-	if (event.type !== "extension_ui_request") return undefined;
-	const id = stringValue(event, "id");
-	const rawMethod = stringValue(event, "method");
-	const title = stringValue(event, "title") ?? fallbackTitle;
-	if (!id || !rawMethod) return undefined;
-	if (
-		rawMethod !== "select" &&
-		rawMethod !== "confirm" &&
-		rawMethod !== "input" &&
-		rawMethod !== "editor"
-	) {
-		return undefined;
-	}
-	const options = Array.isArray(event.options)
-		? event.options.filter((option): option is string => typeof option === "string")
-		: undefined;
-	return {
-		id,
-		method: rawMethod,
-		title,
-		...(stringValue(event, "message") ? {message: stringValue(event, "message")} : {}),
-		...(options && options.length > 0 ? {options} : {}),
-		...(stringValue(event, "placeholder") ? {placeholder: stringValue(event, "placeholder")} : {}),
-		...(stringValue(event, "prefill") ? {prefill: stringValue(event, "prefill")} : {}),
-	};
-}
-
-function fileAsImage(file: File, unreadable: string): Promise<PiImage> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onerror = () => reject(new Error(unreadable));
-		reader.onload = () => {
-			if (typeof reader.result !== "string") {
-				reject(new Error(unreadable));
-				return;
-			}
-			const data = reader.result.split(",", 2)[1];
-			if (!data) {
-				reject(new Error(unreadable));
-				return;
-			}
-			resolve({data, mimeType: file.type, name: file.name});
-		};
-		reader.readAsDataURL(file);
-	});
-}
 
 export interface AgentChatInputProps {
 	readonly bridge?: AgentChatInputBridge;
@@ -1367,276 +1067,5 @@ export function AgentChatInput({
 			)}
 			{extension ? <PiExtensionDialog request={extension} onAnswer={answerExtension} /> : null}
 		</section>
-	);
-}
-
-export interface SettingMenuProps {
-	/** The control's accessible name, and the group heading inside the menu. */
-	readonly label: string;
-	/**
-	 * What the host offers, or `undefined` while the offer is unresolved. `[]` is a resolved answer
-	 * — the host knows and offers nothing — and reads that way rather than as loading (#8425).
-	 */
-	readonly items: readonly PickerItem[] | undefined;
-	readonly value?: string;
-	/**
-	 * The selection as the host describes it, for when `items` carries no row for it — a pick held
-	 * with no live catalog behind it (#8542). The trigger names this rather than the empty offer's
-	 * copy, so the control never contradicts the selection the host is holding.
-	 */
-	readonly held?: PickerItem;
-	readonly onValueChange: (value: string) => void;
-	readonly disabled?: boolean;
-}
-
-/**
- * One settings picker of the composer's fieldset. Exported as `AgentSettingMenu` so a host filling
- * the `settings` slot builds its control out of this rather than reaching for a bare `Select`,
- * which would put a differently-shaped control in a row of these.
- */
-export function SettingMenu({
-	label,
-	items,
-	value,
-	held,
-	onValueChange,
-	disabled,
-}: SettingMenuProps) {
-	const t = useDesignT();
-	const [open, setOpen] = useState(false);
-	// The highlight is ours to drive, not the machine's: Zag clears it on close and re-seeds it to
-	// row 1 on the next open, so a catalogue taller than the popover always opens away from the
-	// checked row. Seeding it to `value` at the open makes the machine's own scroll-into-view land
-	// there and the first arrow key move from there. See ADR 0361.
-	const [highlighted, setHighlighted] = useState<string | null>(null);
-	const offered = items ?? [];
-	// Three unselected states, and only the first is loading: `undefined` items is a host that has
-	// not resolved what it offers, `[]` is one that resolved and offers nothing, and a populated
-	// list with no `value` is a setting the session has not picked yet (#8190, #8425). Reading the
-	// middle one as loading left an operator waiting on rows that were never coming.
-	const unselectedName = t(
-		items === undefined
-			? "admin.agent.picker.loading"
-			: items.length === 0
-				? "admin.agent.picker.empty"
-				: "admin.agent.picker.none",
-	);
-	// A pick the offer carries no row for is still a pick: the trigger names it and the empty copy
-	// rides as its note, so an operator reads both what is held and that nothing live sits behind
-	// it. A control that showed the copy alone said the opposite of the model it was on (#8542).
-	const selected =
-		offered.find((item) => item.value === value) ??
-		(held !== undefined && held.value === value ? {...held, note: unselectedName} : undefined);
-	// Nothing to pick is nothing to open, either way round: an unresolved offer has no rows yet and
-	// a resolved-empty one never will, so the trigger does not advertise an operation the host
-	// cannot perform. `disabled` from the host still wins on top of this.
-	const operable = offered.length > 0;
-	const selectedName = selected
-		? selected.note
-			? `${selected.label} (${selected.note})`
-			: selected.label
-		: unselectedName;
-	return (
-		<Menu
-			open={open}
-			onOpenChange={(next) => {
-				if (next) setHighlighted(value ?? null);
-				setOpen(next);
-			}}
-			highlightedValue={highlighted}
-			onHighlightChange={setHighlighted}
-			placement="top-start"
-			ariaLabel={label}
-			className="kp-agent-chat__picker-menu"
-			trigger={
-				<Button
-					type="button"
-					variant="tertiary"
-					size="sm"
-					className="kp-agent-chat__picker-trigger"
-					aria-label={`${label}: ${selectedName}`}
-					disabled={disabled || !operable}
-				>
-					{selected?.icon ? <Icon icon={selected.icon} size={14} /> : null}
-					<span>{selected?.label ?? unselectedName}</span>
-					{selected?.note ? (
-						<span className="kp-agent-chat__picker-note">{selected.note}</span>
-					) : null}
-					<Icon icon={open ? ChevronUp : ChevronDown} size={14} />
-				</Button>
-			}
-			items={[
-				{
-					type: "group",
-					label,
-					items: offered.map((item) => ({
-						type: "radio",
-						value: item.value,
-						label: item.note ? (
-							<span className="kp-agent-chat__picker-option">
-								<span>{item.label}</span>
-								<span className="kp-agent-chat__picker-note">{item.note}</span>
-							</span>
-						) : (
-							item.label
-						),
-						checked: item.value === value,
-						...(item.icon ? {icon: <Icon icon={item.icon} size={16} />} : {}),
-					})),
-				},
-			]}
-			onSelect={(nextValue) => {
-				onValueChange(nextValue);
-				setOpen(false);
-			}}
-		/>
-	);
-}
-
-function SuggestionRow({
-	id,
-	suggestion,
-	active,
-	onSelect,
-}: {
-	readonly id: string;
-	readonly suggestion: Suggestion;
-	readonly active: boolean;
-	readonly onSelect: () => void;
-}) {
-	const command = suggestion.kind === "command" ? suggestion.command : undefined;
-	return (
-		<Button
-			id={id}
-			type="button"
-			variant="tertiary"
-			block
-			className="kp-agent-chat__suggestion"
-			role="option"
-			aria-selected={active}
-			onClick={onSelect}
-		>
-			<Icon icon={suggestion.kind === "command" ? Terminal : FileIcon} size={16} />
-			<span className="kp-agent-chat__suggestion-main">
-				{suggestion.kind === "command" ? `/${command?.name ?? ""}` : `@${suggestion.path}`}
-			</span>
-			{command?.description ? (
-				<span className="kp-agent-chat__suggestion-detail">{command.description}</span>
-			) : null}
-		</Button>
-	);
-}
-
-function HarnessWidget({lines}: {readonly lines: readonly string[]}) {
-	const t = useDesignT();
-	return (
-		<Card className="kp-agent-chat__widget" role="status">
-			<p className="kp-agent-chat__widget-title">{t("admin.agent.extension.title")}</p>
-			<pre>{lines.join("\n")}</pre>
-		</Card>
-	);
-}
-
-function AgentActivity({
-	assistantText,
-	activities,
-}: {
-	readonly assistantText: string;
-	readonly activities: readonly Activity[];
-}) {
-	const t = useDesignT();
-	return (
-		<Card className="kp-agent-chat__activity" aria-live="polite">
-			<p className="kp-agent-chat__activity-title">{t("admin.agent.activity.title")}</p>
-			{assistantText ? (
-				<pre className="kp-agent-chat__assistant-text">{assistantText}</pre>
-			) : (
-				<p className="kp-agent-chat__empty">{t("admin.agent.activity.empty")}</p>
-			)}
-			{activities.length > 0 ? (
-				<ul className="kp-agent-chat__activity-list">
-					{activities.map((activity) => (
-						<li key={activity.id}>{activity.text}</li>
-					))}
-				</ul>
-			) : null}
-		</Card>
-	);
-}
-
-function PiExtensionDialog({
-	request,
-	onAnswer,
-}: {
-	readonly request: ExtensionRequest;
-	readonly onAnswer: (answer: PiExtensionAnswer) => Promise<void>;
-}) {
-	const t = useDesignT();
-	const [value, setValue] = useState(request.prefill ?? "");
-	useEffect(() => setValue(request.prefill ?? ""), [request.id, request.prefill]);
-	const cancel = () => void onAnswer({id: request.id, cancelled: true});
-	const answer = (next: Omit<PiExtensionAnswer, "id">) => void onAnswer({id: request.id, ...next});
-	return (
-		<Dialog
-			open
-			onOpenChange={(open) => {
-				if (!open) cancel();
-			}}
-			title={request.title}
-			{...(request.message ? {description: request.message} : {})}
-			footer={() =>
-				request.method === "confirm" ? (
-					<>
-						<Button variant="tertiary" onClick={cancel}>
-							{t("admin.agent.extension.cancel")}
-						</Button>
-						<Button variant="primary" onClick={() => answer({confirmed: true})}>
-							{t("admin.agent.extension.confirm")}
-						</Button>
-					</>
-				) : request.method === "select" ? (
-					<Button variant="tertiary" onClick={cancel}>
-						{t("admin.agent.extension.cancel")}
-					</Button>
-				) : (
-					<>
-						<Button variant="tertiary" onClick={cancel}>
-							{t("admin.agent.extension.cancel")}
-						</Button>
-						<Button variant="primary" onClick={() => answer({value})}>
-							{t("admin.agent.extension.submit")}
-						</Button>
-					</>
-				)
-			}
-		>
-			{request.method === "select" ? (
-				<div className="kp-agent-chat__extension-options">
-					{request.options?.map((option) => (
-						<Button key={option} variant="secondary" block onClick={() => answer({value: option})}>
-							{option}
-						</Button>
-					))}
-				</div>
-			) : request.method === "input" ? (
-				<Input
-					label={<span className="kp-visually-hidden">{t("admin.agent.extension.input")}</span>}
-					placeholder={request.placeholder}
-					value={value}
-					onChange={(event) => setValue(event.currentTarget.value)}
-					fullWidth
-				/>
-			) : request.method === "editor" ? (
-				<Textarea
-					label={<span className="kp-visually-hidden">{t("admin.agent.extension.editor")}</span>}
-					placeholder={request.placeholder}
-					value={value}
-					onChange={(event) => setValue(event.currentTarget.value)}
-					rows={8}
-					resize="vertical"
-					fullWidth
-				/>
-			) : null}
-		</Dialog>
 	);
 }

--- a/packages/design/src/a11y/registry.tsx
+++ b/packages/design/src/a11y/registry.tsx
@@ -6,9 +6,9 @@
 
 import fc from "fast-check";
 import type {ReactElement} from "react";
-import {SettingMenu} from "../AgentChatInput";
 import {Alert} from "../Alert";
 import {Avatar} from "../Avatar";
+import {SettingMenu} from "../agent-chat/SettingMenu";
 import {Code, Kbd, Mark, Skeleton, Tag} from "../atoms";
 import {Badge} from "../Badge";
 import {Button} from "../Button";

--- a/packages/design/src/agent-chat/AgentActivity.css
+++ b/packages/design/src/agent-chat/AgentActivity.css
@@ -1,0 +1,39 @@
+.kp-agent-chat__activity {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+
+.kp-agent-chat__activity-title {
+	margin: 0;
+	color: var(--text-secondary);
+	font: var(--t-meta);
+	font-weight: 700;
+}
+
+.kp-agent-chat__assistant-text {
+	max-height: calc(var(--s-8) * 8);
+	margin: 0;
+	overflow: auto;
+	color: var(--text-primary);
+	font: var(--t-body);
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.kp-agent-chat__empty {
+	margin: 0;
+	color: var(--text-muted);
+	font: var(--t-meta);
+}
+
+.kp-agent-chat__activity-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	color: var(--text-secondary);
+	font: var(--t-meta);
+}

--- a/packages/design/src/agent-chat/AgentActivity.tsx
+++ b/packages/design/src/agent-chat/AgentActivity.tsx
@@ -1,0 +1,31 @@
+import {Card} from "../Card";
+import {useDesignT} from "../i18n";
+import type {Activity} from "./types";
+import "./AgentActivity.css";
+
+export function AgentActivity({
+	assistantText,
+	activities,
+}: {
+	readonly assistantText: string;
+	readonly activities: readonly Activity[];
+}) {
+	const t = useDesignT();
+	return (
+		<Card className="kp-agent-chat__activity" aria-live="polite">
+			<p className="kp-agent-chat__activity-title">{t("admin.agent.activity.title")}</p>
+			{assistantText ? (
+				<pre className="kp-agent-chat__assistant-text">{assistantText}</pre>
+			) : (
+				<p className="kp-agent-chat__empty">{t("admin.agent.activity.empty")}</p>
+			)}
+			{activities.length > 0 ? (
+				<ul className="kp-agent-chat__activity-list">
+					{activities.map((activity) => (
+						<li key={activity.id}>{activity.text}</li>
+					))}
+				</ul>
+			) : null}
+		</Card>
+	);
+}

--- a/packages/design/src/agent-chat/HarnessWidget.css
+++ b/packages/design/src/agent-chat/HarnessWidget.css
@@ -1,0 +1,22 @@
+.kp-agent-chat__widget {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+
+.kp-agent-chat__widget-title {
+	margin: 0;
+	color: var(--text-secondary);
+	font: var(--t-meta);
+	font-weight: 700;
+}
+
+.kp-agent-chat__widget pre {
+	max-height: calc(var(--s-8) * 8);
+	margin: 0;
+	overflow: auto;
+	color: var(--text-primary);
+	font: var(--t-body);
+	white-space: pre-wrap;
+	word-break: break-word;
+}

--- a/packages/design/src/agent-chat/HarnessWidget.tsx
+++ b/packages/design/src/agent-chat/HarnessWidget.tsx
@@ -1,0 +1,13 @@
+import {Card} from "../Card";
+import {useDesignT} from "../i18n";
+import "./HarnessWidget.css";
+
+export function HarnessWidget({lines}: {readonly lines: readonly string[]}) {
+	const t = useDesignT();
+	return (
+		<Card className="kp-agent-chat__widget" role="status">
+			<p className="kp-agent-chat__widget-title">{t("admin.agent.extension.title")}</p>
+			<pre>{lines.join("\n")}</pre>
+		</Card>
+	);
+}

--- a/packages/design/src/agent-chat/Icon.tsx
+++ b/packages/design/src/agent-chat/Icon.tsx
@@ -1,0 +1,25 @@
+import type {LucideIcon} from "lucide-react";
+
+type IconSize = 12 | 14 | 16 | 20 | 24;
+
+export function Icon({
+	icon: Glyph,
+	size = 20,
+	className,
+	label,
+}: {
+	readonly icon: LucideIcon;
+	readonly size?: IconSize;
+	readonly className?: string;
+	readonly label?: string;
+}) {
+	return (
+		<Glyph
+			className={className ? `kp-icon ${className}` : "kp-icon"}
+			size={size}
+			aria-hidden={label ? undefined : true}
+			aria-label={label}
+			role={label ? "img" : undefined}
+		/>
+	);
+}

--- a/packages/design/src/agent-chat/PiExtensionDialog.css
+++ b/packages/design/src/agent-chat/PiExtensionDialog.css
@@ -1,0 +1,5 @@
+.kp-agent-chat__extension-options {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}

--- a/packages/design/src/agent-chat/PiExtensionDialog.tsx
+++ b/packages/design/src/agent-chat/PiExtensionDialog.tsx
@@ -1,0 +1,86 @@
+import {useEffect, useState} from "react";
+import type {PiExtensionAnswer} from "../agent-chat-bridge";
+import {Button} from "../Button";
+import {Dialog} from "../Dialog";
+import {Input, Textarea} from "../Form";
+import {useDesignT} from "../i18n";
+import type {ExtensionRequest} from "./types";
+import "./PiExtensionDialog.css";
+import "../visually-hidden.css";
+
+export function PiExtensionDialog({
+	request,
+	onAnswer,
+}: {
+	readonly request: ExtensionRequest;
+	readonly onAnswer: (answer: PiExtensionAnswer) => Promise<void>;
+}) {
+	const t = useDesignT();
+	const [value, setValue] = useState(request.prefill ?? "");
+	useEffect(() => setValue(request.prefill ?? ""), [request.id, request.prefill]);
+	const cancel = () => void onAnswer({id: request.id, cancelled: true});
+	const answer = (next: Omit<PiExtensionAnswer, "id">) => void onAnswer({id: request.id, ...next});
+	return (
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open) cancel();
+			}}
+			title={request.title}
+			{...(request.message ? {description: request.message} : {})}
+			footer={() =>
+				request.method === "confirm" ? (
+					<>
+						<Button variant="tertiary" onClick={cancel}>
+							{t("admin.agent.extension.cancel")}
+						</Button>
+						<Button variant="primary" onClick={() => answer({confirmed: true})}>
+							{t("admin.agent.extension.confirm")}
+						</Button>
+					</>
+				) : request.method === "select" ? (
+					<Button variant="tertiary" onClick={cancel}>
+						{t("admin.agent.extension.cancel")}
+					</Button>
+				) : (
+					<>
+						<Button variant="tertiary" onClick={cancel}>
+							{t("admin.agent.extension.cancel")}
+						</Button>
+						<Button variant="primary" onClick={() => answer({value})}>
+							{t("admin.agent.extension.submit")}
+						</Button>
+					</>
+				)
+			}
+		>
+			{request.method === "select" ? (
+				<div className="kp-agent-chat__extension-options">
+					{request.options?.map((option) => (
+						<Button key={option} variant="secondary" block onClick={() => answer({value: option})}>
+							{option}
+						</Button>
+					))}
+				</div>
+			) : request.method === "input" ? (
+				<Input
+					label={<span className="kp-visually-hidden">{t("admin.agent.extension.input")}</span>}
+					placeholder={request.placeholder}
+					value={value}
+					onChange={(event) => setValue(event.currentTarget.value)}
+					fullWidth
+				/>
+			) : request.method === "editor" ? (
+				<Textarea
+					label={<span className="kp-visually-hidden">{t("admin.agent.extension.editor")}</span>}
+					placeholder={request.placeholder}
+					value={value}
+					onChange={(event) => setValue(event.currentTarget.value)}
+					rows={8}
+					resize="vertical"
+					fullWidth
+				/>
+			) : null}
+		</Dialog>
+	);
+}

--- a/packages/design/src/agent-chat/SettingMenu.css
+++ b/packages/design/src/agent-chat/SettingMenu.css
@@ -1,0 +1,61 @@
+.kp-agent-chat__picker-trigger:where([data-scope="button"][data-part="root"]) {
+	--manti-button-padding-x: var(--s-2);
+	min-width: 0;
+	color: var(--text-secondary);
+}
+
+.kp-agent-chat__picker-trigger > [data-part="label"],
+.kp-agent-chat__picker-menu [data-part="item-text"] {
+	min-width: 0;
+}
+
+.kp-agent-chat__picker-trigger [data-part="label"] > span:not(.kp-agent-chat__picker-note),
+.kp-agent-chat__picker-option > span:not(.kp-agent-chat__picker-note) {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kp-agent-chat__picker-trigger .kp-agent-chat__picker-note,
+.kp-agent-chat__picker-trigger .kp-icon {
+	flex-shrink: 0;
+}
+
+.kp-agent-chat__picker-option {
+	display: flex;
+	align-items: baseline;
+	gap: var(--s-1);
+	min-width: 0;
+}
+
+.kp-agent-chat__picker-note {
+	min-width: 0;
+	overflow: hidden;
+	color: var(--text-secondary);
+	font: var(--t-meta);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kp-agent-chat__picker-menu:where([data-scope="menu"][data-part="content"]) {
+	width: calc(var(--s-8) * 6);
+	max-width: calc(100vw - var(--s-4));
+	/* The cap belongs on `content`: that is the `rootEl` Zag's menu machine scrolls a highlighted
+	   item within, so an inner scroll box would leave arrow-key navigation scrolling the wrong
+	   element. */
+	max-height: min(26.25rem, 55dvh);
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
+.kp-agent-chat__picker-menu:focus-visible {
+	outline: none;
+}
+
+.kp-agent-chat__picker-menu [data-part="item-group-label"] {
+	padding: var(--s-2) var(--s-3) var(--s-1);
+	color: var(--text-secondary);
+	font: var(--t-meta);
+	font-weight: 700;
+}

--- a/packages/design/src/agent-chat/SettingMenu.tsx
+++ b/packages/design/src/agent-chat/SettingMenu.tsx
@@ -1,0 +1,139 @@
+import {ChevronDown, ChevronUp, type LucideIcon} from "lucide-react";
+import {useState} from "react";
+import {Button} from "../Button";
+import {useDesignT} from "../i18n";
+import {Menu} from "../Menu";
+import {Icon} from "./Icon";
+import "./SettingMenu.css";
+
+/** One row of a settings picker. Exported as `AgentSettingItem`, which is what a host's slot binds. */
+export interface PickerItem {
+	readonly value: string;
+	readonly label: string;
+	/** Secondary text beside the label, for a row the label alone does not tell apart. */
+	readonly note?: string;
+	readonly icon?: LucideIcon;
+}
+
+export interface SettingMenuProps {
+	/** The control's accessible name, and the group heading inside the menu. */
+	readonly label: string;
+	/**
+	 * What the host offers, or `undefined` while the offer is unresolved. `[]` is a resolved answer
+	 * — the host knows and offers nothing — and reads that way rather than as loading (#8425).
+	 */
+	readonly items: readonly PickerItem[] | undefined;
+	readonly value?: string;
+	/**
+	 * The selection as the host describes it, for when `items` carries no row for it — a pick held
+	 * with no live catalog behind it (#8542). The trigger names this rather than the empty offer's
+	 * copy, so the control never contradicts the selection the host is holding.
+	 */
+	readonly held?: PickerItem;
+	readonly onValueChange: (value: string) => void;
+	readonly disabled?: boolean;
+}
+
+/**
+ * One settings picker of the composer's fieldset. Exported as `AgentSettingMenu` so a host filling
+ * the `settings` slot builds its control out of this rather than reaching for a bare `Select`,
+ * which would put a differently-shaped control in a row of these.
+ */
+export function SettingMenu({
+	label,
+	items,
+	value,
+	held,
+	onValueChange,
+	disabled,
+}: SettingMenuProps) {
+	const t = useDesignT();
+	const [open, setOpen] = useState(false);
+	// The highlight is ours to drive, not the machine's: Zag clears it on close and re-seeds it to
+	// row 1 on the next open, so a catalogue taller than the popover always opens away from the
+	// checked row. Seeding it to `value` at the open makes the machine's own scroll-into-view land
+	// there and the first arrow key move from there. See ADR 0361.
+	const [highlighted, setHighlighted] = useState<string | null>(null);
+	const offered = items ?? [];
+	// Three unselected states, and only the first is loading: `undefined` items is a host that has
+	// not resolved what it offers, `[]` is one that resolved and offers nothing, and a populated
+	// list with no `value` is a setting the session has not picked yet (#8190, #8425). Reading the
+	// middle one as loading left an operator waiting on rows that were never coming.
+	const unselectedName = t(
+		items === undefined
+			? "admin.agent.picker.loading"
+			: items.length === 0
+				? "admin.agent.picker.empty"
+				: "admin.agent.picker.none",
+	);
+	// A pick the offer carries no row for is still a pick: the trigger names it and the empty copy
+	// rides as its note, so an operator reads both what is held and that nothing live sits behind
+	// it. A control that showed the copy alone said the opposite of the model it was on (#8542).
+	const selected =
+		offered.find((item) => item.value === value) ??
+		(held !== undefined && held.value === value ? {...held, note: unselectedName} : undefined);
+	// Nothing to pick is nothing to open, either way round: an unresolved offer has no rows yet and
+	// a resolved-empty one never will, so the trigger does not advertise an operation the host
+	// cannot perform. `disabled` from the host still wins on top of this.
+	const operable = offered.length > 0;
+	const selectedName = selected
+		? selected.note
+			? `${selected.label} (${selected.note})`
+			: selected.label
+		: unselectedName;
+	return (
+		<Menu
+			open={open}
+			onOpenChange={(next) => {
+				if (next) setHighlighted(value ?? null);
+				setOpen(next);
+			}}
+			highlightedValue={highlighted}
+			onHighlightChange={setHighlighted}
+			placement="top-start"
+			ariaLabel={label}
+			className="kp-agent-chat__picker-menu"
+			trigger={
+				<Button
+					type="button"
+					variant="tertiary"
+					size="sm"
+					className="kp-agent-chat__picker-trigger"
+					aria-label={`${label}: ${selectedName}`}
+					disabled={disabled || !operable}
+				>
+					{selected?.icon ? <Icon icon={selected.icon} size={14} /> : null}
+					<span>{selected?.label ?? unselectedName}</span>
+					{selected?.note ? (
+						<span className="kp-agent-chat__picker-note">{selected.note}</span>
+					) : null}
+					<Icon icon={open ? ChevronUp : ChevronDown} size={14} />
+				</Button>
+			}
+			items={[
+				{
+					type: "group",
+					label,
+					items: offered.map((item) => ({
+						type: "radio",
+						value: item.value,
+						label: item.note ? (
+							<span className="kp-agent-chat__picker-option">
+								<span>{item.label}</span>
+								<span className="kp-agent-chat__picker-note">{item.note}</span>
+							</span>
+						) : (
+							item.label
+						),
+						checked: item.value === value,
+						...(item.icon ? {icon: <Icon icon={item.icon} size={16} />} : {}),
+					})),
+				},
+			]}
+			onSelect={(nextValue) => {
+				onValueChange(nextValue);
+				setOpen(false);
+			}}
+		/>
+	);
+}

--- a/packages/design/src/agent-chat/SuggestionRow.css
+++ b/packages/design/src/agent-chat/SuggestionRow.css
@@ -1,0 +1,35 @@
+.kp-agent-chat__suggestion:where([data-scope="button"][data-part="root"]) {
+	justify-content: flex-start;
+	min-width: 0;
+	min-height: var(--tap-min);
+	padding: var(--s-2);
+	text-align: start;
+}
+
+.kp-agent-chat__suggestion[aria-selected="true"] {
+	background: var(--accent-faint);
+	color: var(--text-primary);
+}
+
+.kp-agent-chat__suggestion-main {
+	min-width: 0;
+	font: var(--t-mono);
+	color: inherit;
+}
+
+.kp-agent-chat__suggestion-detail {
+	margin-inline-start: auto;
+	min-width: 0;
+	overflow: hidden;
+	color: var(--text-muted);
+	font: var(--t-meta);
+	text-align: end;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+@media (max-width: 40rem) {
+	.kp-agent-chat__suggestion-detail {
+		display: none;
+	}
+}

--- a/packages/design/src/agent-chat/SuggestionRow.tsx
+++ b/packages/design/src/agent-chat/SuggestionRow.tsx
@@ -1,0 +1,39 @@
+import {File as FileIcon, Terminal} from "lucide-react";
+import {Button} from "../Button";
+import {Icon} from "./Icon";
+import type {Suggestion} from "./types";
+import "./SuggestionRow.css";
+
+export function SuggestionRow({
+	id,
+	suggestion,
+	active,
+	onSelect,
+}: {
+	readonly id: string;
+	readonly suggestion: Suggestion;
+	readonly active: boolean;
+	readonly onSelect: () => void;
+}) {
+	const command = suggestion.kind === "command" ? suggestion.command : undefined;
+	return (
+		<Button
+			id={id}
+			type="button"
+			variant="tertiary"
+			block
+			className="kp-agent-chat__suggestion"
+			role="option"
+			aria-selected={active}
+			onClick={onSelect}
+		>
+			<Icon icon={suggestion.kind === "command" ? Terminal : FileIcon} size={16} />
+			<span className="kp-agent-chat__suggestion-main">
+				{suggestion.kind === "command" ? `/${command?.name ?? ""}` : `@${suggestion.path}`}
+			</span>
+			{command?.description ? (
+				<span className="kp-agent-chat__suggestion-detail">{command.description}</span>
+			) : null}
+		</Button>
+	);
+}

--- a/packages/design/src/agent-chat/catalog.ts
+++ b/packages/design/src/agent-chat/catalog.ts
@@ -1,0 +1,51 @@
+import {
+	ChevronDown,
+	ChevronsDown,
+	ChevronsUp,
+	ChevronUp,
+	CircleOff,
+	type LucideIcon,
+	Minus,
+	Sparkles,
+} from "lucide-react";
+import type {PiDeliveryMode, PiProjectTrust, PiThinkingLevel} from "../agent-chat-bridge";
+import type {DesignCatalogKey, DesignTranslate} from "../i18n";
+import type {SelectItem} from "../Select";
+
+export const deliveryModeKeys: readonly {value: PiDeliveryMode; key: DesignCatalogKey}[] = [
+	{value: "prompt", key: "admin.agent.delivery.prompt"},
+	{value: "steer", key: "admin.agent.delivery.steer"},
+	{value: "follow_up", key: "admin.agent.delivery.followUp"},
+];
+
+export const projectTrustKeys: readonly {value: PiProjectTrust; key: DesignCatalogKey}[] = [
+	{value: "approve", key: "admin.agent.trust.approve"},
+	{value: "no-approve", key: "admin.agent.trust.ignore"},
+];
+
+export const thinkingLevelKeys: Readonly<Record<PiThinkingLevel, DesignCatalogKey>> = {
+	off: "admin.agent.thinking.off",
+	minimal: "admin.agent.thinking.minimal",
+	low: "admin.agent.thinking.low",
+	medium: "admin.agent.thinking.medium",
+	high: "admin.agent.thinking.high",
+	xhigh: "admin.agent.thinking.xhigh",
+	max: "admin.agent.thinking.max",
+	ultra: "admin.agent.thinking.ultra",
+};
+
+export const toItems = (
+	entries: readonly {value: string; key: DesignCatalogKey}[],
+	t: DesignTranslate,
+): SelectItem[] => entries.map(({value, key}) => ({value, label: t(key)}));
+
+export const thinkingLevelIcons: Readonly<Record<PiThinkingLevel, LucideIcon>> = {
+	off: CircleOff,
+	minimal: ChevronsDown,
+	low: ChevronDown,
+	medium: Minus,
+	high: ChevronUp,
+	xhigh: ChevronsUp,
+	max: Sparkles,
+	ultra: Sparkles,
+};

--- a/packages/design/src/agent-chat/image.ts
+++ b/packages/design/src/agent-chat/image.ts
@@ -1,0 +1,23 @@
+import type {PiImage} from "../agent-chat-bridge";
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export function fileAsImage(file: File, unreadable: string): Promise<PiImage> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onerror = () => reject(new Error(unreadable));
+		reader.onload = () => {
+			if (typeof reader.result !== "string") {
+				reject(new Error(unreadable));
+				return;
+			}
+			const data = reader.result.split(",", 2)[1];
+			if (!data) {
+				reject(new Error(unreadable));
+				return;
+			}
+			resolve({data, mimeType: file.type, name: file.name});
+		};
+		reader.readAsDataURL(file);
+	});
+}

--- a/packages/design/src/agent-chat/mock-harness.ts
+++ b/packages/design/src/agent-chat/mock-harness.ts
@@ -1,0 +1,24 @@
+import type {PiCommand, PiModel, PiThinkingLevel} from "../agent-chat-bridge";
+import type {DesignTranslate} from "../i18n";
+
+export const mockModels: readonly PiModel[] = [
+	{provider: "openai", id: "gpt-5.5", name: "GPT-5.5"},
+	{provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna"},
+	{provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol"},
+	{provider: "openai", id: "gpt-5.6-terra", name: "GPT-5.6 Terra"},
+];
+
+export const mockThinkingLevels: readonly PiThinkingLevel[] = [
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+];
+
+export const mockCommands = (t: DesignTranslate): readonly PiCommand[] => [
+	{name: "review", description: t("admin.agent.mock.command.review")},
+	{name: "compact", description: t("admin.agent.mock.command.compact")},
+];
+
+export const mockFiles = ["apps/web/src/App.tsx", "packages/design/src/AgentChatInput.tsx"];

--- a/packages/design/src/agent-chat/parse.ts
+++ b/packages/design/src/agent-chat/parse.ts
@@ -1,0 +1,181 @@
+import type {
+	PiCommand,
+	PiDeliveryMode,
+	PiEvent,
+	PiModel,
+	PiProjectTrust,
+	PiThinkingLevel,
+} from "../agent-chat-bridge";
+import type {Completion, ExtensionRequest} from "./types";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function stringValue(record: Record<string, unknown>, key: string): string | undefined {
+	const value = record[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+export function booleanValue(record: Record<string, unknown>, key: string): boolean | undefined {
+	const value = record[key];
+	return typeof value === "boolean" ? value : undefined;
+}
+
+export function deliveryMode(value: string | undefined): PiDeliveryMode | undefined {
+	return value === "prompt" || value === "steer" || value === "follow_up" ? value : undefined;
+}
+
+export function projectTrustValue(value: unknown): PiProjectTrust | undefined {
+	return value === "approve" || value === "no-approve" ? value : undefined;
+}
+
+export function thinkingLevelValue(value: unknown): PiThinkingLevel | undefined {
+	return value === "off" ||
+		value === "minimal" ||
+		value === "low" ||
+		value === "medium" ||
+		value === "high" ||
+		value === "xhigh" ||
+		value === "max" ||
+		value === "ultra"
+		? value
+		: undefined;
+}
+
+export function modelValue(model: Pick<PiModel, "provider" | "id">): string {
+	return `${model.provider}/${model.id}`;
+}
+
+/**
+ * Two providers can offer the same display name, and then the name alone names two rows. The
+ * provider is the fact that tells them apart, so it rides every row once a second one is offered.
+ */
+export function providersCollide(models: readonly PiModel[]): boolean {
+	return new Set(models.map((model) => model.provider)).size > 1;
+}
+
+/** A pushed command catalog, admitted row by row. A malformed push leaves the held list alone. */
+export function commandList(value: unknown): readonly PiCommand[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const rows: PiCommand[] = [];
+	for (const row of value) {
+		if (!isRecord(row)) return undefined;
+		const name = stringValue(row, "name");
+		if (!name) return undefined;
+		const description = stringValue(row, "description");
+		const source = stringValue(row, "source");
+		rows.push({name, ...(description ? {description} : {}), ...(source ? {source} : {})});
+	}
+	return rows;
+}
+
+/** A pushed model catalog, admitted row by row. A malformed push leaves the held list alone. */
+export function modelList(value: unknown): readonly PiModel[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const rows: PiModel[] = [];
+	for (const row of value) {
+		if (!isRecord(row)) return undefined;
+		const provider = stringValue(row, "provider");
+		const id = stringValue(row, "id");
+		const name = stringValue(row, "name");
+		if (!provider || !id || !name) return undefined;
+		rows.push({provider, id, name});
+	}
+	return rows;
+}
+
+/**
+ * A pushed level set, admitted row by row like the model catalog. `off` is dropped for the reason
+ * the mount-time load drops it: it is not a row this picker selects.
+ */
+export function thinkingLevelList(value: unknown): readonly PiThinkingLevel[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const levels: PiThinkingLevel[] = [];
+	for (const row of value) {
+		const level = thinkingLevelValue(row);
+		if (!level) return undefined;
+		if (level !== "off") levels.push(level);
+	}
+	return levels;
+}
+
+export function selectedModelValue(state: Record<string, unknown> | undefined): string | undefined {
+	const model = state && isRecord(state.model) ? state.model : undefined;
+	if (!model) return undefined;
+	const provider = stringValue(model, "provider");
+	const id = stringValue(model, "id");
+	return provider && id ? modelValue({provider, id}) : undefined;
+}
+
+export function completionFor(draft: string): Completion | undefined {
+	const match = /(?:^|\s)([/@])([^\s]*)$/.exec(draft);
+	if (!match) return undefined;
+	const sigil = match[1];
+	const query = match[2] ?? "";
+	if (!sigil) return undefined;
+	const start = draft.length - match[0].length + match[0].lastIndexOf(sigil);
+	return {kind: sigil === "/" ? "command" : "file", query, start, end: draft.length};
+}
+
+export function modelName(state: Record<string, unknown> | undefined): string | undefined {
+	const model = state && isRecord(state.model) ? state.model : undefined;
+	if (!model) return undefined;
+	return (
+		stringValue(model, "displayName") ?? stringValue(model, "name") ?? stringValue(model, "id")
+	);
+}
+
+/** The running model as the status line names it: bare name, or name + provider once two collide. */
+export function runningModelLabel(
+	state: Record<string, unknown> | undefined,
+	models: readonly PiModel[],
+): string | undefined {
+	const name = modelName(state);
+	if (!name || !providersCollide(models)) return name;
+	const model = state && isRecord(state.model) ? state.model : undefined;
+	const provider = model && stringValue(model, "provider");
+	return provider ? `${name} (${provider})` : name;
+}
+
+export function assistantMessageText(value: unknown): string | undefined {
+	if (!isRecord(value) || value.role !== "assistant" || !Array.isArray(value.content))
+		return undefined;
+	const text = value.content.flatMap((block) => {
+		if (!isRecord(block)) return [];
+		const value = stringValue(block, "text");
+		return value ? [value] : [];
+	});
+	return text.length > 0 ? text.join("") : undefined;
+}
+
+export function extensionRequest(
+	event: PiEvent,
+	fallbackTitle: string,
+): ExtensionRequest | undefined {
+	if (event.type !== "extension_ui_request") return undefined;
+	const id = stringValue(event, "id");
+	const rawMethod = stringValue(event, "method");
+	const title = stringValue(event, "title") ?? fallbackTitle;
+	if (!id || !rawMethod) return undefined;
+	if (
+		rawMethod !== "select" &&
+		rawMethod !== "confirm" &&
+		rawMethod !== "input" &&
+		rawMethod !== "editor"
+	) {
+		return undefined;
+	}
+	const options = Array.isArray(event.options)
+		? event.options.filter((option): option is string => typeof option === "string")
+		: undefined;
+	return {
+		id,
+		method: rawMethod,
+		title,
+		...(stringValue(event, "message") ? {message: stringValue(event, "message")} : {}),
+		...(options && options.length > 0 ? {options} : {}),
+		...(stringValue(event, "placeholder") ? {placeholder: stringValue(event, "placeholder")} : {}),
+		...(stringValue(event, "prefill") ? {prefill: stringValue(event, "prefill")} : {}),
+	};
+}

--- a/packages/design/src/agent-chat/types.ts
+++ b/packages/design/src/agent-chat/types.ts
@@ -1,0 +1,29 @@
+import type {PiCommand} from "../agent-chat-bridge";
+
+export type ConnectionState = "loading" | "ready" | "unavailable" | "working";
+
+export interface Completion {
+	readonly kind: "command" | "file";
+	readonly query: string;
+	readonly start: number;
+	readonly end: number;
+}
+
+export type Suggestion =
+	| {readonly kind: "command"; readonly command: PiCommand}
+	| {readonly kind: "file"; readonly path: string};
+
+export interface Activity {
+	readonly id: number;
+	readonly text: string;
+}
+
+export interface ExtensionRequest {
+	readonly id: string;
+	readonly method: "select" | "confirm" | "input" | "editor";
+	readonly title: string;
+	readonly message?: string;
+	readonly options?: readonly string[];
+	readonly placeholder?: string;
+	readonly prefill?: string;
+}

--- a/packages/design/src/agent-chat/unavailable-bridge.ts
+++ b/packages/design/src/agent-chat/unavailable-bridge.ts
@@ -1,0 +1,16 @@
+import type {AgentChatInputBridge} from "../agent-chat-bridge";
+
+export const unavailableBridge: AgentChatInputBridge = {
+	loadPiState: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	loadPiCommands: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	loadPiModels: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	loadPiThinkingLevels: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	loadPiFiles: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	setPiModel: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	setPiThinkingLevel: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	setPiProjectTrust: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	sendPiPrompt: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	abortPi: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	answerPiExtension: () => Promise.reject(new Error("Pi harness kullanılamıyor.")),
+	subscribeToPiEvents: () => () => undefined,
+};

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -1,11 +1,12 @@
-export type {
-	AgentChatInputProps,
-	PickerItem as AgentSettingItem,
-	SettingMenuProps as AgentSettingMenuProps,
-} from "./AgentChatInput";
-export {AgentChatInput, SettingMenu as AgentSettingMenu} from "./AgentChatInput";
+export type {AgentChatInputProps} from "./AgentChatInput";
+export {AgentChatInput} from "./AgentChatInput";
 export {Alert} from "./Alert";
 export {Avatar} from "./Avatar";
+export type {
+	PickerItem as AgentSettingItem,
+	SettingMenuProps as AgentSettingMenuProps,
+} from "./agent-chat/SettingMenu";
+export {SettingMenu as AgentSettingMenu} from "./agent-chat/SettingMenu";
 export type {
 	AgentChatInputBridge,
 	PiCommand,


### PR DESCRIPTION
Carves `packages/design/src/AgentChatInput.tsx` (1,642 lines) into `packages/design/src/agent-chat/`. Slice 1 of epic #8668 — a pure move, so no JSX, state, props or class names change.

Twelve modules now sit under `agent-chat/`: the five private components (`SettingMenu`, `SuggestionRow`, `HarnessWidget`, `AgentActivity`, `PiExtensionDialog`), the `Icon` wrapper, and the pure helpers grouped by what they answer — `parse.ts` (the bridge-payload readers), `catalog.ts` (the picker key/icon tables), `mock-harness.ts`, `image.ts`, `unavailable-bridge.ts` and `types.ts`. `AgentChatInput.tsx` drops to 1,075 lines and holds the exported component, its props docblock, its state and its JSX.

`AgentChatInput.css` splits alongside them: the picker rules to `SettingMenu.css`, the suggestion-row rules to `SuggestionRow.css`, the widget/activity rules to their two files, the extension-options rule to `PiExtensionDialog.css`. The set of `kp-*` classes declared before and after is byte-identical, so `kp-class-coverage.test.ts` needed no edit.

`index.ts` exports the same five names with the same spellings and types; only the module they come from moved.

Four `apps/tuval` picker tests inject `@kampus/design`'s stylesheets into jsdom by filename, because Vitest's default `css: false` empties the component's own CSS import. They listed `AgentChatInput.css` only, so the moved picker rules resolved to `''` and eight assertions went vacuous. Each now loads `agent-chat/SettingMenu.css` beside it — the `entry.replace(/index\.ts$/, name)` helper already handles a nested name (criterion 8).

**Reviewer's first look:** the CSS split, because that is the one place a pure move can change what renders. Two rules had to be reshaped rather than relocated (see Deviations), and the two `noDescendingSpecificity` biome warnings in `SettingMenu.css` are the same two the original file carried — verified by running biome against `HEAD:packages/design/src/AgentChatInput.css`.

`AgentChatInput.test.tsx` (25 tests), `kp-class-coverage.test.ts` (3) and the design a11y coverage suite (23, via `pnpm test:a11y`) all pass with zero edits. `vitest run src/shell/chat` in `apps/tuval` is green: 32 files, 451 tests.

## Deviations

- **Out-of-scope change** — **Said:** #8673 names three consumers to leave untouched and says nothing about `packages/design/src/a11y/registry.tsx`. **Did:** repointed its one import line from `../AgentChatInput` to `../agent-chat/SettingMenu`. **Why:** `SettingMenu` no longer lives in the old module, so the a11y registry would not compile; the three named consumers are genuinely untouched. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** the split is a pure move of CSS rules. **Did:** three grouped selectors could not move whole, so they were rewritten as per-component copies: the shared `margin: 0` group dropped `__widget-title`, `__activity-title` and `__empty` and each moved rule gained its own `margin: 0`; the `__widget`/`__activity`, title and `pre`/`__assistant-text` groups became one rule per component file; and `__picker-trigger` was separated from `__resources-button` into two identical rules. **Why:** a selector list spanning two components cannot live in one component's stylesheet. Every rewrite preserves the computed declarations exactly, and the declared class set is unchanged. **Disposition:** stated here; verified by diffing the `.kp-*` class sets before and after.
- **Pre-existing test or fixture changed** — **Said:** #8673's original body scoped the change to `packages/design`. **Did:** edited four `apps/tuval/src/shell/chat/chat-picker-*.unit.test.*` files to add `agent-chat/SettingMenu.css` to the stylesheets they inject. **Why:** those tests read the design package's CSS off disk by filename, so the carve made their picker assertions read `''`; criterion 8 was added to #8673 for exactly this. Two of them held one filename rather than a list and were changed to a list, matching the shape the other two already use. No assertion changed. **Disposition:** stated here.
- **Scope narrowing** — **Said:** split the stylesheet alongside the components it styles, including "the suggestion rules". **Did:** moved `.kp-agent-chat__suggestion`, `-main` and `-detail` (plus the `-detail` media rule) to `SuggestionRow.css`, but left the `.kp-agent-chat__suggestions` listbox container in `AgentChatInput.css`. **Why:** that container is rendered by `AgentChatInput` itself, and its rules position it against the composer frame. **Disposition:** stated here.

Fixes #8673
