### PR TITLE
feat: An async or workflow Pi spawn still opens to an empty transcript after #8663

### DIFF
--- a/.patterns/tuval-detached-child-tail.md
+++ b/.patterns/tuval-detached-child-tail.md
@@ -20,6 +20,22 @@ onto the tool row as `details`, so the id crosses the wire on the row it belongs
 of one agent kind started in the same second are indistinguishable, and the artifact's own id is
 already in the process.
 
+**When the launch emits no event, correlate through the backend's own on-disk index.** A
+`pi-subagents` call with `async: true` — every `workflowScript` run — detaches without a
+`tool_execution_update`, so part 1's route never fires and the row's only remaining key is its own
+`toolCallId` ([#8679](https://github.com/kamp-us/phoenix/issues/8679)). The backend writes one:
+`updateActiveRunIndex` drops an alias file at
+`<asyncRunRoot>/.active-runs/tool-calls/<encoded toolCallId>/<asyncRunId>` while the run is queued or
+running, and each run's `status.json` names its `toolCallId` and its `steps[]` — the worker run ids
+and agent names. `apps/tuval/src/pi/ai-agent/async-spawn.ts` reads that chain.
+
+**The alias is a hint; the status is the proof.** An alias is a filename and survives a crash, so a
+run is trusted only when its own `status.toolCallId` is the one being asked for. Never parse a run id
+out of the tool result's prose — the text says "Async workflow [id]", and reading it would make a
+display string load-bearing. Everything on this path is total: a missing marker, an unreadable status
+or a mismatched claim all answer "no workers yet", which leaves the slot exactly as an unresolved one
+looks.
+
 **2. Reimplement the artifact's parse; do not import the backend's reader.** `pi-subagents`' own
 `readFleetTranscript` lives under `src/tui/` and pulls `@earendil-works/pi-tui`, which the paths-only
 rule in `apps/tuval/src/pi/server/subagents.ts` refuses. The grammar is versioned and small, so
@@ -42,5 +58,7 @@ take the same child transcripts the tail last handed over
 
 The slot stays keyed on the spawning call's id. One call can start several children, so the slot is
 already 1:N against a parallel spawn; reading the artifacts does not change that and must not be used
-as an excuse to re-key. Rows the artifact does not carry are absent rather than guessed — the child's
-initial prompt is written as `PROMPT_REDACTED`, and no reasoning row is written at all.
+as an excuse to re-key. A detached run's `steps[]` make that plural explicit — the workers' rows are
+concatenated into the one slot and the row is named after the agents the steps report, which is the
+most a single row can say. Rows the artifact does not carry are absent rather than guessed — the
+child's initial prompt is written as `PROMPT_REDACTED`, and no reasoning row is written at all.

--- a/.patterns/tuval-detached-child-tail.md
+++ b/.patterns/tuval-detached-child-tail.md
@@ -36,6 +36,15 @@ display string load-bearing. Everything on this path is total: a missing marker,
 or a mismatched claim all answer "no workers yet", which leaves the slot exactly as an unresolved one
 looks.
 
+**Resolve on every tick, not once.** `steps[]` is declared up front and each step gains its `runId`
+only when it launches, so a sequential lane — builder, then reviewer, then shipper — publishes its
+workers one at a time. A run resolved once and never re-read keeps the first worker forever: the row
+sits on that worker's last line, labelled with its agent, looking live while it is stale. So the tail
+re-reads the index for every detached spawn it is still tracking, and the fresh answer replaces the
+held one whole (the status read already carries every step launched so far). A read that resolves
+nothing leaves the held answer standing — a tick that finds nothing must never blank a slot someone
+is reading.
+
 **2. Reimplement the artifact's parse; do not import the backend's reader.** `pi-subagents`' own
 `readFleetTranscript` lives under `src/tui/` and pulls `@earendil-works/pi-tui`, which the paths-only
 rule in `apps/tuval/src/pi/server/subagents.ts` refuses. The grammar is versioned and small, so

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -72,6 +72,7 @@ import {
 	subagentExtensionPaths,
 } from "../server/index.ts";
 import type {ThinkingLevel} from "../wire/index.ts";
+import {type AsyncSpawns, asyncRunRoot, readAsyncSpawns} from "./async-spawn.ts";
 import {
 	type ChildTranscripts,
 	readChildTranscripts,
@@ -148,7 +149,12 @@ type FoldInput =
 	| SessionUpdate
 	| {readonly _tag: "sent"}
 	/** What the running workers' own artifacts said when the tail last read them. */
-	| {readonly _tag: "children"; readonly children: ChildTranscripts};
+	| {
+			readonly _tag: "children";
+			readonly children: ChildTranscripts;
+			/** The detached spawns the same read resolved through the tool-call index. */
+			readonly resolved: AsyncSpawns;
+	  };
 
 /**
  * How often the tail re-reads a running worker's transcript artifact.
@@ -302,7 +308,7 @@ const make = (
 							}
 							if (input._tag === "children") {
 								yield* Ref.set(children, input.children);
-								const tailed = childEventsOf(previous, input.children);
+								const tailed = childEventsOf(previous, input.children, input.resolved);
 								yield* Ref.set(projection, tailed.next);
 								return yield* emit(open, tailed.events);
 							}
@@ -324,13 +330,23 @@ const make = (
 						yield* Effect.sleep(childTailInterval);
 						const running = [...(yield* Ref.get(projection)).spawns.values()];
 						if (running.length === 0) return;
-						const read = yield* Effect.sync(() =>
-							readChildTranscripts(
-								artifacts,
-								running.map((spawn) => spawn.runId),
-							),
-						);
-						yield* Queue.offer(feed, {_tag: "children", children: read});
+						const read = yield* Effect.sync(() => {
+							// A detached spawn's row carries no run id, so its workers are looked up by
+							// the call id through the tool-call index before anything is tailed.
+							const resolved = readAsyncSpawns(
+								asyncRunRoot(),
+								running
+									.filter((spawn) => spawn.runIds.length === 0)
+									.map((spawn) => spawn.toolCallId),
+							);
+							const runIds = running.flatMap((spawn) =>
+								spawn.runIds.length > 0
+									? spawn.runIds
+									: (resolved.get(spawn.toolCallId)?.runIds ?? []),
+							);
+							return {children: readChildTranscripts(artifacts, runIds), resolved};
+						});
+						yield* Queue.offer(feed, {_tag: "children", ...read});
 					}),
 				);
 				const dropped = pi.disconnections.pipe(

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -87,6 +87,7 @@ import {
 	paintOf,
 	projectionOf,
 	type SnapshotProjection,
+	spawnRunIds,
 } from "./items.ts";
 import {
 	interruptFailureOf,
@@ -331,18 +332,15 @@ const make = (
 						const running = [...(yield* Ref.get(projection)).spawns.values()];
 						if (running.length === 0) return;
 						const read = yield* Effect.sync(() => {
-							// A detached spawn's row carries no run id, so its workers are looked up by
-							// the call id through the tool-call index before anything is tailed.
+							// Every detached spawn, every tick — not just the ones with no workers yet.
+							// A workflow's `steps[]` gain their run ids as each step launches, so a run
+							// resolved once and never re-read freezes on its first worker (#8684).
 							const resolved = readAsyncSpawns(
 								asyncRunRoot(),
-								running
-									.filter((spawn) => spawn.runIds.length === 0)
-									.map((spawn) => spawn.toolCallId),
+								running.filter((spawn) => spawn.runId === null).map((spawn) => spawn.toolCallId),
 							);
 							const runIds = running.flatMap((spawn) =>
-								spawn.runIds.length > 0
-									? spawn.runIds
-									: (resolved.get(spawn.toolCallId)?.runIds ?? []),
+								spawnRunIds(spawn, resolved.get(spawn.toolCallId)),
 							);
 							return {children: readChildTranscripts(artifacts, runIds), resolved};
 						});

--- a/apps/tuval/src/pi/ai-agent/async-spawn.ts
+++ b/apps/tuval/src/pi/ai-agent/async-spawn.ts
@@ -72,6 +72,31 @@ export const encodeIndexSegment = (value: string): string => {
 		: hashedSegment(value);
 };
 
+/** The pre-hash key, where it still fits — `index-segment.ts`'s `historicallyReadableSegment`. */
+const historicalSegment = (value: string): string | undefined => {
+	let encoded: string;
+	try {
+		encoded = encodeURIComponent(value);
+	} catch {
+		return undefined;
+	}
+	if (encoded.length === 0 || encoded === "." || encoded === ".." || encoded.endsWith("."))
+		return undefined;
+	if (WINDOWS_RESERVED_NAME.test(encoded)) return undefined;
+	return Buffer.byteLength(encoded, "utf-8") > MAX_INDEX_SEGMENT_BYTES ? undefined : encoded;
+};
+
+/**
+ * Every directory name this call's aliases could be under — `indexSegmentAliases`: the key the
+ * current writer spells first, then the pre-hash one an older writer left behind. Read rather than
+ * assumed away, so a run launched under a previous pin is still findable.
+ */
+export const indexSegmentAliases = (value: string): ReadonlyArray<string> => {
+	const current = encodeIndexSegment(value);
+	const historical = historicalSegment(value);
+	return historical === undefined || historical === current ? [current] : [current, historical];
+};
+
 const sanitizeScopeSegment = (value: string): string =>
 	value
 		.trim()
@@ -111,22 +136,26 @@ const objectOf = (value: unknown): Record<string, unknown> | undefined =>
 const stringOf = (value: unknown): string | undefined =>
 	typeof value === "string" && value.trim() !== "" ? value : undefined;
 
-/** The async run ids the index aliases to this call — a hint, not yet a match. */
-const aliasedRunDirs = (root: string, toolCallId: string): ReadonlyArray<string> => {
+const aliasEntries = (root: string, segment: string): ReadonlyArray<string> => {
 	try {
-		return readdirSync(
-			join(root, ACTIVE_RUN_INDEX_DIR, TOOL_CALL_INDEX_DIR, encodeIndexSegment(toolCallId)),
-			{
-				withFileTypes: true,
-			},
-		)
+		return readdirSync(join(root, ACTIVE_RUN_INDEX_DIR, TOOL_CALL_INDEX_DIR, segment), {
+			withFileTypes: true,
+		})
 			.filter((entry) => entry.isFile())
-			.map((entry) => entry.name)
-			.sort();
+			.map((entry) => entry.name);
 	} catch {
 		return [];
 	}
 };
+
+/**
+ * The async run ids the index aliases to this call — a hint, not yet a match. Sorted by run id
+ * rather than left in `readdir` order, so two reads of one unchanged index answer identically.
+ */
+const aliasedRunDirs = (root: string, toolCallId: string): ReadonlyArray<string> =>
+	[
+		...new Set(indexSegmentAliases(toolCallId).flatMap((segment) => aliasEntries(root, segment))),
+	].sort();
 
 const readStatus = (dir: string): Record<string, unknown> | undefined => {
 	try {
@@ -152,7 +181,11 @@ const stepWorker = (
  * The status's own `toolCallId` is the confirmation: an alias directory is a filename and survives
  * a crash, so a run that does not claim this call is skipped rather than read. Several runs can
  * alias one call — a relaunch under the same row — and every confirmed one contributes its steps,
- * in the index's own order.
+ * in run-id order.
+ *
+ * The whole status is re-read on every call, so the answer always carries every step that has
+ * launched so far. That is what makes a sequential lane's later steps arrive at all: a step is
+ * declared up front with no `runId` and gains one when it launches (#8684).
  */
 export const readAsyncSpawn = (root: string, toolCallId: string): AsyncSpawn | null => {
 	const runIds: Array<string> = [];

--- a/apps/tuval/src/pi/ai-agent/async-spawn.ts
+++ b/apps/tuval/src/pi/ai-agent/async-spawn.ts
@@ -1,0 +1,183 @@
+/**
+ * A detached (`async: true`) spawn call → the worker run ids and agent name its slot reads by.
+ *
+ * A foreground spawn tells the parent session its run id on a `tool_execution_update`
+ * (`../server/AgentSessionHost.ts`'s `runDetails`). An async launch emits none, so the only key the
+ * row still holds is its own `toolCallId` — and `pi-subagents` writes an index for exactly that:
+ * `updateActiveRunIndex` drops an empty alias file at
+ * `<asyncRunRoot>/.active-runs/tool-calls/<encodeIndexSegment(toolCallId)>/<asyncRunId>` while the
+ * run is queued or running (`src/runs/background/active-run-index.ts:18-24,79-95`), and both launch
+ * sites pass the call id. `indexedToolCallIdAsyncLocations`
+ * (`src/runs/background/run-id-resolver.ts:67-87`) is the read this mirrors: take the alias entries,
+ * read each run's `status.json`, and trust a run only when its own `toolCallId` is the one asked
+ * for. The alias is a hint; the status is the proof.
+ *
+ * `AsyncStatus.steps[]` (`src/shared/types.ts:1861-1899`) is then the parent-call-to-worker map: each
+ * step names its `agent` and its own child `runId`, which is the `<runId>_<agent>_transcript.jsonl`
+ * prefix `child-transcript.ts` already reads by.
+ *
+ * Nothing here imports `pi-subagents` — the package ships raw TypeScript and Tuval loads it by path
+ * only (`../server/subagents.ts`). The grammar is small and versioned, so it is reimplemented, and
+ * every read is total: a missing marker, an unreadable status or a status naming another call all
+ * answer "no workers found" rather than throwing at a fold.
+ */
+
+import {createHash} from "node:crypto";
+import {readdirSync, readFileSync} from "node:fs";
+import {homedir, tmpdir} from "node:os";
+import {join, resolve} from "node:path";
+
+/** What one resolved async call contributes to its row: whose artifacts to read, and its name. */
+export interface AsyncSpawn {
+	readonly runIds: ReadonlyArray<string>;
+	/** The agents the resolved steps report, or `null` when they name none. */
+	readonly agent: string | null;
+}
+
+/** Resolved async calls by the `toolCallId` each was launched under. */
+export type AsyncSpawns = ReadonlyMap<string, AsyncSpawn>;
+
+const MAX_INDEX_SEGMENT_BYTES = 255;
+const HASHED_INDEX_SEGMENT_PREFIX = "~sha256-";
+const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
+
+const hashedSegment = (value: string): string =>
+	`${HASHED_INDEX_SEGMENT_PREFIX}${createHash("sha256").update(value).digest("hex")}`;
+
+const isPortableSegment = (value: string): boolean =>
+	value.length > 0 &&
+	value !== "." &&
+	value !== ".." &&
+	!value.endsWith(".") &&
+	!WINDOWS_RESERVED_NAME.test(value) &&
+	!/%5C/i.test(value) &&
+	!/\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(value);
+
+/**
+ * The directory name one tool call's aliases live under — `src/runs/background/index-segment.ts`'s
+ * `encodeIndexSegment`. Reimplemented rather than approximated by `encodeURIComponent`, because the
+ * writer falls back to a digest for anything a `readdir` could refuse on Windows, and a reader that
+ * only ever spells the encoded form would miss those runs entirely.
+ */
+export const encodeIndexSegment = (value: string): string => {
+	let encoded: string;
+	try {
+		encoded = encodeURIComponent(value);
+	} catch {
+		return hashedSegment(value);
+	}
+	return Buffer.byteLength(encoded, "utf-8") <= MAX_INDEX_SEGMENT_BYTES &&
+		isPortableSegment(encoded)
+		? encoded
+		: hashedSegment(value);
+};
+
+const sanitizeScopeSegment = (value: string): string =>
+	value
+		.trim()
+		.replace(/[^A-Za-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "") || "unknown";
+
+/** `resolveTempScopeId` (`src/shared/types.ts:2683-2726`), down to the branches a desk can reach. */
+const tempScopeId = (): string => {
+	const uid = process.getuid?.();
+	if (uid !== undefined) return `uid-${uid}`;
+	for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
+		const value = process.env[key];
+		if (value !== undefined && value !== "") return `user-${sanitizeScopeSegment(value)}`;
+	}
+	return `home-${sanitizeScopeSegment(homedir())}`;
+};
+
+/**
+ * Where detached runs keep their status directories — `ASYNC_DIR`
+ * (`src/shared/types.ts:2730-2735`). It is process-scoped rather than session-scoped, so it is read
+ * off the same environment the extension runs in: this process spawns the children.
+ */
+export const asyncRunRoot = (): string => {
+	const configured = process.env.PI_SUBAGENTS_TEMP_ROOT?.trim();
+	const root = configured ? resolve(configured) : join(tmpdir(), `pi-subagents-${tempScopeId()}`);
+	return join(root, "async-subagent-runs");
+};
+
+const ACTIVE_RUN_INDEX_DIR = ".active-runs";
+const TOOL_CALL_INDEX_DIR = "tool-calls";
+
+const objectOf = (value: unknown): Record<string, unknown> | undefined =>
+	typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+
+const stringOf = (value: unknown): string | undefined =>
+	typeof value === "string" && value.trim() !== "" ? value : undefined;
+
+/** The async run ids the index aliases to this call — a hint, not yet a match. */
+const aliasedRunDirs = (root: string, toolCallId: string): ReadonlyArray<string> => {
+	try {
+		return readdirSync(
+			join(root, ACTIVE_RUN_INDEX_DIR, TOOL_CALL_INDEX_DIR, encodeIndexSegment(toolCallId)),
+			{
+				withFileTypes: true,
+			},
+		)
+			.filter((entry) => entry.isFile())
+			.map((entry) => entry.name)
+			.sort();
+	} catch {
+		return [];
+	}
+};
+
+const readStatus = (dir: string): Record<string, unknown> | undefined => {
+	try {
+		return objectOf(JSON.parse(readFileSync(join(dir, "status.json"), "utf-8")));
+	} catch {
+		return undefined;
+	}
+};
+
+/** One step's worker, where it names both halves — a step still pending names no run of its own. */
+const stepWorker = (
+	value: unknown,
+): {readonly runId: string; readonly agent: string | undefined} | undefined => {
+	const step = objectOf(value);
+	if (step === undefined) return undefined;
+	const runId = stringOf(step.runId);
+	return runId === undefined ? undefined : {runId, agent: stringOf(step.agent)};
+};
+
+/**
+ * The workers one async call started, or `null` when nothing on disk proves any.
+ *
+ * The status's own `toolCallId` is the confirmation: an alias directory is a filename and survives
+ * a crash, so a run that does not claim this call is skipped rather than read. Several runs can
+ * alias one call — a relaunch under the same row — and every confirmed one contributes its steps,
+ * in the index's own order.
+ */
+export const readAsyncSpawn = (root: string, toolCallId: string): AsyncSpawn | null => {
+	const runIds: Array<string> = [];
+	const agents: Array<string> = [];
+	for (const entry of aliasedRunDirs(root, toolCallId)) {
+		const status = readStatus(join(root, entry));
+		if (status === undefined || stringOf(status.toolCallId) !== toolCallId) continue;
+		const steps = Array.isArray(status.steps) ? status.steps : [];
+		for (const step of steps) {
+			const worker = stepWorker(step);
+			if (worker === undefined) continue;
+			if (!runIds.includes(worker.runId)) runIds.push(worker.runId);
+			if (worker.agent !== undefined && !agents.includes(worker.agent)) agents.push(worker.agent);
+		}
+	}
+	if (runIds.length === 0 && agents.length === 0) return null;
+	return {runIds, agent: agents.length === 0 ? null : agents.join(", ")};
+};
+
+/** Every named call resolved fresh — the step the tail repeats beside its artifact read. */
+export const readAsyncSpawns = (root: string, toolCallIds: ReadonlyArray<string>): AsyncSpawns => {
+	const found = new Map<string, AsyncSpawn>();
+	for (const toolCallId of toolCallIds) {
+		const spawn = readAsyncSpawn(root, toolCallId);
+		if (spawn !== null) found.set(toolCallId, spawn);
+	}
+	return found;
+};

--- a/apps/tuval/src/pi/ai-agent/async-spawn.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/async-spawn.unit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The detached-spawn resolution, over directories laid out exactly as `pi-subagents`
+ * `src/runs/background/active-run-index.ts` writes them. The index is reimplemented rather than
+ * imported, so a test that spells the layout out is the only thing holding the two in step.
+ */
+
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, describe, expect, it} from "vitest";
+import {asyncRunRoot, encodeIndexSegment, readAsyncSpawn} from "./async-spawn.ts";
+
+const roots: Array<string> = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, {recursive: true, force: true});
+});
+
+const asyncRoot = (): string => {
+	const root = realpathSync(mkdtempSync(join(tmpdir(), "tuval-async-spawn-")));
+	roots.push(root);
+	return root;
+};
+
+/** One queued/running run: its `status.json`, plus the alias file the tool-call index carries. */
+const launch = (
+	root: string,
+	asyncRunId: string,
+	status: Record<string, unknown>,
+	aliasFor?: string,
+): void => {
+	mkdirSync(join(root, asyncRunId), {recursive: true});
+	writeFileSync(join(root, asyncRunId, "status.json"), JSON.stringify(status));
+	if (aliasFor === undefined) return;
+	const dir = join(root, ".active-runs", "tool-calls", encodeIndexSegment(aliasFor));
+	mkdirSync(dir, {recursive: true});
+	writeFileSync(join(dir, asyncRunId), "");
+};
+
+describe("resolving a detached spawn through the tool-call index", () => {
+	it("reads the workers and the agent off the aliased run's steps", () => {
+		const root = asyncRoot();
+		launch(
+			root,
+			"async-1",
+			{
+				runId: "async-1",
+				toolCallId: "call-9",
+				mode: "workflow",
+				state: "running",
+				startedAt: 1,
+				steps: [{agent: "builder", runId: "worker-1", status: "running"}],
+			},
+			"call-9",
+		);
+		expect(readAsyncSpawn(root, "call-9")).toEqual({runIds: ["worker-1"], agent: "builder"});
+	});
+
+	// The alias is a filename and survives a crash, so the status's own claim is the proof.
+	it("rejects an aliased run whose status names another call", () => {
+		const root = asyncRoot();
+		launch(
+			root,
+			"async-2",
+			{
+				runId: "async-2",
+				toolCallId: "call-other",
+				mode: "workflow",
+				state: "running",
+				startedAt: 1,
+				steps: [{agent: "builder", runId: "worker-2", status: "running"}],
+			},
+			"call-9",
+		);
+		expect(readAsyncSpawn(root, "call-9")).toBeNull();
+	});
+
+	it("answers nothing when no marker was ever written", () => {
+		expect(readAsyncSpawn(asyncRoot(), "call-9")).toBeNull();
+	});
+
+	it("answers nothing when the aliased run has no status to read", () => {
+		const root = asyncRoot();
+		const dir = join(root, ".active-runs", "tool-calls", encodeIndexSegment("call-9"));
+		mkdirSync(dir, {recursive: true});
+		writeFileSync(join(dir, "async-3"), "");
+		expect(readAsyncSpawn(root, "call-9")).toBeNull();
+	});
+
+	it("carries every worker a fan-out started, naming the row after all of them", () => {
+		const root = asyncRoot();
+		launch(
+			root,
+			"async-4",
+			{
+				runId: "async-4",
+				toolCallId: "call-9",
+				mode: "workflow",
+				state: "running",
+				startedAt: 1,
+				steps: [
+					{agent: "builder", runId: "worker-1", status: "complete"},
+					{agent: "reviewer", runId: "worker-2", status: "running"},
+					{agent: "reviewer", status: "pending"},
+				],
+			},
+			"call-9",
+		);
+		expect(readAsyncSpawn(root, "call-9")).toEqual({
+			runIds: ["worker-1", "worker-2"],
+			agent: "builder, reviewer",
+		});
+	});
+});
+
+describe("the index segment a tool call's aliases live under", () => {
+	it("keeps a portable id in its URI-encoded form", () => {
+		expect(encodeIndexSegment("call-9")).toBe("call-9");
+		expect(encodeIndexSegment("toolu_01/A B")).toBe("toolu_01%2FA%20B");
+	});
+
+	// A trailing extension is what `readdir` refuses on Windows, so the writer digests it instead.
+	it("digests an id the writer would not spell out", () => {
+		expect(encodeIndexSegment("session.jsonl")).toMatch(/^~sha256-[0-9a-f]{64}$/);
+		expect(encodeIndexSegment("a".repeat(300))).toMatch(/^~sha256-[0-9a-f]{64}$/);
+	});
+});
+
+describe("where detached runs keep their status directories", () => {
+	it("is the configured temp root's own async directory", () => {
+		const previous = process.env.PI_SUBAGENTS_TEMP_ROOT;
+		process.env.PI_SUBAGENTS_TEMP_ROOT = "/tmp/pi-subagents-test";
+		try {
+			expect(asyncRunRoot()).toBe(join("/tmp/pi-subagents-test", "async-subagent-runs"));
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_TEMP_ROOT;
+			else process.env.PI_SUBAGENTS_TEMP_ROOT = previous;
+		}
+	});
+});

--- a/apps/tuval/src/pi/ai-agent/async-spawn.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/async-spawn.unit.test.ts
@@ -8,7 +8,12 @@ import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {afterEach, describe, expect, it} from "vitest";
-import {asyncRunRoot, encodeIndexSegment, readAsyncSpawn} from "./async-spawn.ts";
+import {
+	asyncRunRoot,
+	encodeIndexSegment,
+	indexSegmentAliases,
+	readAsyncSpawn,
+} from "./async-spawn.ts";
 
 const roots: Array<string> = [];
 
@@ -85,6 +90,69 @@ describe("resolving a detached spawn through the tool-call index", () => {
 		mkdirSync(dir, {recursive: true});
 		writeFileSync(join(dir, "async-3"), "");
 		expect(readAsyncSpawn(root, "call-9")).toBeNull();
+	});
+
+	// The sequential lane: `steps[]` is declared up front and each step gains its `runId` at launch,
+	// so a second read of the same run has to see workers the first one could not.
+	it("sees a later step's worker when the status gains it between reads", () => {
+		const root = asyncRoot();
+		const status = (steps: ReadonlyArray<Record<string, unknown>>) => ({
+			runId: "async-5",
+			toolCallId: "call-9",
+			mode: "workflow",
+			state: "running",
+			startedAt: 1,
+			steps,
+		});
+		launch(
+			root,
+			"async-5",
+			status([
+				{agent: "builder", runId: "worker-1", status: "running"},
+				{agent: "reviewer", status: "pending"},
+			]),
+			"call-9",
+		);
+		expect(readAsyncSpawn(root, "call-9")).toEqual({runIds: ["worker-1"], agent: "builder"});
+
+		writeFileSync(
+			join(root, "async-5", "status.json"),
+			JSON.stringify(
+				status([
+					{agent: "builder", runId: "worker-1", status: "complete"},
+					{agent: "reviewer", runId: "worker-2", status: "running"},
+				]),
+			),
+		);
+		expect(readAsyncSpawn(root, "call-9")).toEqual({
+			runIds: ["worker-1", "worker-2"],
+			agent: "builder, reviewer",
+		});
+	});
+
+	// An alias written by an older pin sits under the pre-hash key, and the run outlives the writer.
+	it("finds a run aliased under the pre-hash key", () => {
+		const root = asyncRoot();
+		const id = "call.jsonl";
+		mkdirSync(join(root, "async-6"), {recursive: true});
+		writeFileSync(
+			join(root, "async-6", "status.json"),
+			JSON.stringify({
+				runId: "async-6",
+				toolCallId: id,
+				mode: "workflow",
+				state: "running",
+				startedAt: 1,
+				steps: [{agent: "builder", runId: "worker-1", status: "running"}],
+			}),
+		);
+		const [current, historical] = indexSegmentAliases(id);
+		expect(historical).toBeDefined();
+		expect(historical).not.toBe(current);
+		const dir = join(root, ".active-runs", "tool-calls", historical as string);
+		mkdirSync(dir, {recursive: true});
+		writeFileSync(join(dir, "async-6"), "");
+		expect(readAsyncSpawn(root, id)).toEqual({runIds: ["worker-1"], agent: "builder"});
 	});
 
 	it("carries every worker a fan-out started, naming the row after all of them", () => {

--- a/apps/tuval/src/pi/ai-agent/child-transcript.ts
+++ b/apps/tuval/src/pi/ai-agent/child-transcript.ts
@@ -270,9 +270,11 @@ export const readChildTranscript = (dir: string, runId: string): ChildTranscript
  * Several runs' transcripts as one slot's rows. An async spawn is one call over as many workers as
  * its `steps[]` names, and the slot stays keyed on the call (#8664 owns how a fan-out is laid out),
  * so their rows are concatenated in the order the steps were resolved and re-keyed apart.
+ *
+ * The re-key runs even for a single run, matching `readChildTranscript`'s own `child-<at>-` prefix:
+ * a step that launches later must not renumber the ids of the rows already on screen.
  */
 export const joinChildTranscripts = (parts: ReadonlyArray<ChildTranscript>): ChildTranscript => {
-	if (parts.length === 1) return parts[0] as ChildTranscript;
 	const items = parts.flatMap((part, at) =>
 		part.items.map((item) => ({...item, id: childItemId(`run-${at}-${item.id}`)})),
 	);

--- a/apps/tuval/src/pi/ai-agent/child-transcript.ts
+++ b/apps/tuval/src/pi/ai-agent/child-transcript.ts
@@ -266,6 +266,24 @@ export const readChildTranscript = (dir: string, runId: string): ChildTranscript
 	};
 };
 
+/**
+ * Several runs' transcripts as one slot's rows. An async spawn is one call over as many workers as
+ * its `steps[]` names, and the slot stays keyed on the call (#8664 owns how a fan-out is laid out),
+ * so their rows are concatenated in the order the steps were resolved and re-keyed apart.
+ */
+export const joinChildTranscripts = (parts: ReadonlyArray<ChildTranscript>): ChildTranscript => {
+	if (parts.length === 1) return parts[0] as ChildTranscript;
+	const items = parts.flatMap((part, at) =>
+		part.items.map((item) => ({...item, id: childItemId(`run-${at}-${item.id}`)})),
+	);
+	const last = items.at(-1);
+	return {
+		items,
+		lastLine: last === undefined ? "" : lineOf(last),
+		tokens: parts.reduce((sum, part) => sum + part.tokens, 0),
+	};
+};
+
 /** Every named run's artifact, read fresh — the tail step the watcher repeats while a slot runs. */
 export const readChildTranscripts = (
 	dir: string,

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -231,11 +231,16 @@ const runIdOf = (item: PiTranscriptItem): string | null => {
  */
 export interface RunningSpawn {
 	readonly id: ItemId;
-	/** The call's own id — the key a detached run is resolved by, once nothing else addresses it. */
+	/** The call's own id — the key a detached run is resolved by, since nothing else addresses it. */
 	readonly toolCallId: string;
-	/** Whose artifacts this slot reads. Empty for a detached run the index has not answered yet. */
-	readonly runIds: ReadonlyArray<string>;
-	/** The agent the call named, or `null` for a spawn that names none. */
+	/**
+	 * The run the wire named, or `null` for a detached call. That `null` is also what marks the
+	 * spawn detached: a foreground row with no run id is not tracked at all.
+	 */
+	readonly runId: string | null;
+	/** What the tool-call index last said about a detached call, re-read on every tail tick. */
+	readonly resolved: AsyncSpawn | null;
+	/** The agent the call itself named, or `null` when it named none. */
 	readonly agent: string | null;
 	readonly startedAt: number;
 }
@@ -249,24 +254,37 @@ export const runningSpawnOf = (item: PiTranscriptItem): RunningSpawn | null => {
 	return {
 		id: itemId(item.toolCallId),
 		toolCallId: item.toolCallId,
-		runIds: runId === null ? [] : [runId],
+		runId,
+		resolved: null,
 		agent: namedAgent(item.input),
 		startedAt: item.timestamp,
 	};
 };
 
 /**
- * One spawn plus whatever has since been resolved for it — the tool-call index's answer, or the
- * projection's own earlier one when a wire push rebuilds the row from scratch.
+ * One spawn under whatever the index last said about it — a fresh tail read, or the projection's
+ * own earlier answer when a wire push rebuilds the row from scratch.
  *
- * A spawn that already knows its workers keeps them: the wire's run id is the call's own, and the
- * index answers only for runs it has not released yet. The name is filled only where the call named
- * none, so an explicit `agent` is never overwritten by what the workers turned out to be.
+ * A resolution replaces the held one whole rather than merging into it, because `readAsyncSpawn`
+ * re-reads the run's entire `status.json`: its answer already carries every step that has launched
+ * so far, and a sequential lane's later steps arrive by that route and no other. An absent
+ * answer — a read that resolved nothing, or a foreground row that never resolves — leaves the held
+ * one standing, which is what stops a tick from blanking a slot the operator is reading (#8684).
  */
-const filled = (spawn: RunningSpawn, held: AsyncSpawn | RunningSpawn | undefined): RunningSpawn =>
-	held === undefined || spawn.runIds.length > 0
+const filled = (spawn: RunningSpawn, resolution: AsyncSpawn | null | undefined): RunningSpawn =>
+	resolution === null || resolution === undefined || spawn.runId !== null
 		? spawn
-		: {...spawn, runIds: held.runIds, agent: spawn.agent ?? held.agent};
+		: {...spawn, resolved: resolution};
+
+/** Whose artifacts this spawn's slot reads: the run the wire named, else the resolved workers. */
+const runIdsOf = (spawn: RunningSpawn): ReadonlyArray<string> =>
+	spawn.runId === null ? (spawn.resolved?.runIds ?? []) : [spawn.runId];
+
+/** The same rule for the tail, which needs the run ids before the fold has folded the answer. */
+export const spawnRunIds = (
+	spawn: RunningSpawn,
+	resolution?: AsyncSpawn | undefined,
+): ReadonlyArray<string> => runIdsOf(filled(spawn, resolution));
 
 /** One worker's own rows under the call that spawned it, so a window can tell whose they are. */
 const childItems = (id: ItemId, child: ChildTranscript): ReadonlyArray<TranscriptItem> =>
@@ -275,7 +293,7 @@ const childItems = (id: ItemId, child: ChildTranscript): ReadonlyArray<Transcrip
 /** A still-running worker's slot, off its own artifact — the shape both folds below agree on. */
 const runningSlotOf = (spawn: RunningSpawn, child: ChildTranscript): SubagentSlot => ({
 	id: spawn.id,
-	type: subagentType(spawn.agent),
+	type: subagentType(spawn.agent ?? spawn.resolved?.agent ?? null),
 	lastLine: child.lastLine,
 	startedAt: spawn.startedAt,
 	tokens: countOf(child.tokens),
@@ -328,7 +346,7 @@ export const subagentSlotsOf = (
 						{
 							id: itemId(part.toolCallId),
 							type: subagentType(
-								namedAgent(part.input) ?? held?.get(part.toolCallId)?.agent ?? null,
+								namedAgent(part.input) ?? held?.get(part.toolCallId)?.resolved?.agent ?? null,
 							),
 							lastLine: "",
 							startedAt: item.timestamp,
@@ -359,15 +377,15 @@ export const subagentSlotsOf = (
 			];
 		// One shape for both folds, so a wire push and an artifact tail cannot fingerprint the same
 		// worker differently and repaint the row between them.
-		const resolved = filled(spawn, carried);
-		return [runningSlotOf(resolved, childOf(children, resolved.runIds) ?? emptyChild)];
+		const resolved = filled(spawn, carried?.resolved);
+		return [runningSlotOf(resolved, childOf(children, runIdsOf(resolved)) ?? emptyChild)];
 	}
 	const runId = runIdOf(item);
-	const child = childOf(children, runId === null ? (carried?.runIds ?? []) : [runId]);
+	const child = childOf(children, runId === null ? (carried?.resolved?.runIds ?? []) : [runId]);
 	return [
 		{
 			id,
-			type: subagentType(namedAgent(item.input) ?? carried?.agent ?? null),
+			type: subagentType(namedAgent(item.input) ?? carried?.resolved?.agent ?? null),
 			lastLine: child?.lastLine || lastLineOf(boundToolResult(textOf(item.content)).text),
 			startedAt: item.timestamp,
 			// The child's own spend where the artifact reported one, else what the result says it
@@ -500,7 +518,8 @@ export const eventsOf = (
 			if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 		}
 		const spawn = runningSpawnOf(source);
-		if (spawn !== null) spawns.set(spawn.id, filled(spawn, previous.spawns.get(spawn.id)));
+		if (spawn !== null)
+			spawns.set(spawn.id, filled(spawn, previous.spawns.get(spawn.id)?.resolved));
 	}
 
 	for (const source of snapshot.transcript) {
@@ -551,7 +570,8 @@ export const deltaEventsOf = (
 			if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 		}
 		const spawn = runningSpawnOf(source);
-		if (spawn !== null) spawns.set(spawn.id, filled(spawn, previous.spawns.get(spawn.id)));
+		if (spawn !== null)
+			spawns.set(spawn.id, filled(spawn, previous.spawns.get(spawn.id)?.resolved));
 		// A tool row that stopped running is a worker with nothing left to append, so the tail
 		// stops reading its artifact here rather than on a clock of its own.
 		else if (source.role === "tool") spawns.delete(source.toolCallId);
@@ -597,7 +617,7 @@ export const childEventsOf = (
 	for (const spawn of previous.spawns.values()) {
 		const found = filled(spawn, resolved?.get(spawn.toolCallId));
 		spawns.set(found.id, found);
-		const child = childOf(children, found.runIds);
+		const child = childOf(children, runIdsOf(found));
 		if (child === undefined) continue;
 		const slot = runningSlotOf(found, child);
 		const key = slotKey(slot);

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -36,7 +36,12 @@ import type {
 	SessionPhase,
 	SessionSnapshot,
 } from "../wire/index.ts";
-import type {ChildTranscript, ChildTranscripts} from "./child-transcript.ts";
+import type {AsyncSpawn, AsyncSpawns} from "./async-spawn.ts";
+import {
+	type ChildTranscript,
+	type ChildTranscripts,
+	joinChildTranscripts,
+} from "./child-transcript.ts";
 import {providerFailureText} from "./provider-failure.ts";
 
 /** `ItemId` is an opaque string brand, minted here so no call site writes its own cast. */
@@ -177,13 +182,25 @@ const spawns = (toolName: string, input: unknown): boolean =>
 /**
  * What kind of worker the call started, in the extension's own words: the `agent` argument, which
  * names one of the configured agents (`pi-subagents` `src/extension/schemas.ts:283`). A spawn that
- * names none — a `workflowScript`, which picks its own children — is labelled by the tool, because
- * the row has to say something and that is the only true thing left.
+ * names none — a `workflowScript`, which picks its own children — is `null`, so the row can be
+ * named later off the workers that actually started (`async-spawn.ts`) rather than being stamped
+ * with a fallback nothing can improve on.
  */
-const subagentType = (input: unknown): string => {
+const namedAgent = (input: unknown): string | null => {
 	const agent = Predicate.isObject(input) ? (input as {readonly agent?: unknown}).agent : undefined;
-	return typeof agent === "string" && agent !== "" ? agent : "subagent";
+	return typeof agent === "string" && agent !== "" ? agent : null;
 };
+
+/** What the row is labelled once nothing better is left: the tool's own name. */
+const subagentType = (agent: string | null): string => agent ?? "subagent";
+
+/**
+ * Whether the call detached. A detached run emits no `tool_execution_update`, so its row carries no
+ * run id and the tool-call index is the only address it has (`async-spawn.ts`) — which is why it is
+ * tracked as a spawn with no workers yet rather than dropped like a row that names none.
+ */
+const detached = (input: unknown): boolean =>
+	Predicate.isObject(input) && (input as {readonly async?: unknown}).async === true;
 
 /** The newest thing the worker wrote, off a result already bounded by `boundToolResult`. */
 const lastLineOf = (text: string): string => {
@@ -214,8 +231,12 @@ const runIdOf = (item: PiTranscriptItem): string | null => {
  */
 export interface RunningSpawn {
 	readonly id: ItemId;
-	readonly runId: string;
-	readonly type: string;
+	/** The call's own id — the key a detached run is resolved by, once nothing else addresses it. */
+	readonly toolCallId: string;
+	/** Whose artifacts this slot reads. Empty for a detached run the index has not answered yet. */
+	readonly runIds: ReadonlyArray<string>;
+	/** The agent the call named, or `null` for a spawn that names none. */
+	readonly agent: string | null;
 	readonly startedAt: number;
 }
 
@@ -224,15 +245,28 @@ export const runningSpawnOf = (item: PiTranscriptItem): RunningSpawn | null => {
 	if (item.role !== "tool" || item.status !== "running" || !spawns(item.toolName, item.input))
 		return null;
 	const runId = runIdOf(item);
-	return runId === null
-		? null
-		: {
-				id: itemId(item.toolCallId),
-				runId,
-				type: subagentType(item.input),
-				startedAt: item.timestamp,
-			};
+	if (runId === null && !detached(item.input)) return null;
+	return {
+		id: itemId(item.toolCallId),
+		toolCallId: item.toolCallId,
+		runIds: runId === null ? [] : [runId],
+		agent: namedAgent(item.input),
+		startedAt: item.timestamp,
+	};
 };
+
+/**
+ * One spawn plus whatever has since been resolved for it — the tool-call index's answer, or the
+ * projection's own earlier one when a wire push rebuilds the row from scratch.
+ *
+ * A spawn that already knows its workers keeps them: the wire's run id is the call's own, and the
+ * index answers only for runs it has not released yet. The name is filled only where the call named
+ * none, so an explicit `agent` is never overwritten by what the workers turned out to be.
+ */
+const filled = (spawn: RunningSpawn, held: AsyncSpawn | RunningSpawn | undefined): RunningSpawn =>
+	held === undefined || spawn.runIds.length > 0
+		? spawn
+		: {...spawn, runIds: held.runIds, agent: spawn.agent ?? held.agent};
 
 /** One worker's own rows under the call that spawned it, so a window can tell whose they are. */
 const childItems = (id: ItemId, child: ChildTranscript): ReadonlyArray<TranscriptItem> =>
@@ -241,13 +275,27 @@ const childItems = (id: ItemId, child: ChildTranscript): ReadonlyArray<Transcrip
 /** A still-running worker's slot, off its own artifact — the shape both folds below agree on. */
 const runningSlotOf = (spawn: RunningSpawn, child: ChildTranscript): SubagentSlot => ({
 	id: spawn.id,
-	type: spawn.type,
+	type: subagentType(spawn.agent),
 	lastLine: child.lastLine,
 	startedAt: spawn.startedAt,
 	tokens: countOf(child.tokens),
 	items: childItems(spawn.id, child),
 	status: "running",
 });
+
+const emptyChild: ChildTranscript = {items: [], lastLine: "", tokens: 0};
+
+/** The rows the named runs have written, or `undefined` while no artifact of theirs has been read. */
+const childOf = (
+	children: ChildTranscripts | undefined,
+	runIds: ReadonlyArray<string>,
+): ChildTranscript | undefined => {
+	const read = runIds.flatMap((runId) => {
+		const child = children?.get(runId);
+		return child === undefined ? [] : [child];
+	});
+	return read.length === 0 ? undefined : joinChildTranscripts(read);
+};
 
 /**
  * The subagent slots one wire item is worth — the model-blind row the running list already draws
@@ -259,15 +307,19 @@ const runningSlotOf = (spawn: RunningSpawn, child: ChildTranscript): SubagentSlo
  * (`../../ai-agent/core/fold.ts`) instead of drawing a second row.
  *
  * `items`, `lastLine` and `tokens` are the child's own, read off the JSONL artifact it appends to
- * while it runs (`child-transcript.ts`) and matched to the row by the `runId` the session stamped
- * on it. The spawn is a detached child process with its own `ModelRuntime` (#8555), so none of its
- * turns reach this transcript — the artifact is the only channel, and a slot whose artifact has not
- * been read yet falls back to what the parent knows: nothing while it runs, the tool result's own
- * text and usage once it is over.
+ * while it runs (`child-transcript.ts`). The spawn is a detached child process with its own
+ * `ModelRuntime` (#8555), so none of its turns reach this transcript — the artifact is the only
+ * channel, and a slot whose artifact has not been read yet falls back to what the parent knows:
+ * nothing while it runs, the tool result's own text and usage once it is over.
+ *
+ * A foreground row is matched to its artifact by the `runId` the session stamped on it. A detached
+ * one carries none, so `held` — the workers the tail resolved through the tool-call index — is what
+ * matches it, and it also supplies the name for a call that named no `agent` (#8679).
  */
 export const subagentSlotsOf = (
 	item: PiTranscriptItem,
 	children?: ChildTranscripts | undefined,
+	held?: ReadonlyMap<string, RunningSpawn> | undefined,
 ): ReadonlyArray<SubagentSlot> => {
 	if (item.role === "assistant") {
 		return item.content.flatMap((part) =>
@@ -275,7 +327,9 @@ export const subagentSlotsOf = (
 				? [
 						{
 							id: itemId(part.toolCallId),
-							type: subagentType(part.input),
+							type: subagentType(
+								namedAgent(part.input) ?? held?.get(part.toolCallId)?.agent ?? null,
+							),
 							lastLine: "",
 							startedAt: item.timestamp,
 							tokens: 0,
@@ -287,31 +341,33 @@ export const subagentSlotsOf = (
 		);
 	}
 	if (item.role !== "tool" || !spawns(item.toolName, item.input)) return [];
-	const runId = runIdOf(item);
-	const child = runId === null ? undefined : children?.get(runId);
 	const id = itemId(item.toolCallId);
+	const carried = held?.get(item.toolCallId);
 	if (item.status === "running") {
 		const spawn = runningSpawnOf(item);
+		if (spawn === null)
+			return [
+				{
+					id,
+					type: subagentType(namedAgent(item.input)),
+					lastLine: "",
+					startedAt: item.timestamp,
+					tokens: 0,
+					items: [],
+					status: "running",
+				},
+			];
 		// One shape for both folds, so a wire push and an artifact tail cannot fingerprint the same
 		// worker differently and repaint the row between them.
-		return [
-			spawn === null
-				? {
-						id,
-						type: subagentType(item.input),
-						lastLine: "",
-						startedAt: item.timestamp,
-						tokens: 0,
-						items: [],
-						status: "running",
-					}
-				: runningSlotOf(spawn, child ?? {items: [], lastLine: "", tokens: 0}),
-		];
+		const resolved = filled(spawn, carried);
+		return [runningSlotOf(resolved, childOf(children, resolved.runIds) ?? emptyChild)];
 	}
+	const runId = runIdOf(item);
+	const child = childOf(children, runId === null ? (carried?.runIds ?? []) : [runId]);
 	return [
 		{
 			id,
-			type: subagentType(item.input),
+			type: subagentType(namedAgent(item.input) ?? carried?.agent ?? null),
 			lastLine: child?.lastLine || lastLineOf(boundToolResult(textOf(item.content)).text),
 			startedAt: item.timestamp,
 			// The child's own spend where the artifact reported one, else what the result says it
@@ -437,14 +493,14 @@ export const eventsOf = (
 			items.set(item.id, mark);
 			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
 		}
-		for (const slot of subagentSlotsOf(source, children)) {
+		for (const slot of subagentSlotsOf(source, children, previous.spawns)) {
 			const key = slotKey(slot);
 			const mark = fingerprint(slot);
 			subagents.set(key, mark);
 			if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 		}
 		const spawn = runningSpawnOf(source);
-		if (spawn !== null) spawns.set(spawn.id, spawn);
+		if (spawn !== null) spawns.set(spawn.id, filled(spawn, previous.spawns.get(spawn.id)));
 	}
 
 	for (const source of snapshot.transcript) {
@@ -488,14 +544,14 @@ export const deltaEventsOf = (
 			items.set(item.id, mark);
 			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
 		}
-		for (const slot of subagentSlotsOf(source, children)) {
+		for (const slot of subagentSlotsOf(source, children, previous.spawns)) {
 			const key = slotKey(slot);
 			const mark = fingerprint(slot);
 			subagents.set(key, mark);
 			if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 		}
 		const spawn = runningSpawnOf(source);
-		if (spawn !== null) spawns.set(spawn.id, spawn);
+		if (spawn !== null) spawns.set(spawn.id, filled(spawn, previous.spawns.get(spawn.id)));
 		// A tool row that stopped running is a worker with nothing left to append, so the tail
 		// stops reading its artifact here rather than on a clock of its own.
 		else if (source.role === "tool") spawns.delete(source.toolCallId);
@@ -525,20 +581,31 @@ export const deltaEventsOf = (
  *
  * It leaves `revision` alone, because a child's own progress is not a revision of the parent's
  * transcript and bumping it would make the parent's next real push read as stale.
+ *
+ * `resolved` is the other half of the same read: a detached spawn learns its workers and its name
+ * from the tool-call index rather than the wire, so the answer is folded onto the projection here
+ * and carried by every later wire fold (#8679).
  */
-export const childEventsOf = (previous: SnapshotProjection, children: ChildTranscripts): Folded => {
+export const childEventsOf = (
+	previous: SnapshotProjection,
+	children: ChildTranscripts,
+	resolved?: AsyncSpawns | undefined,
+): Folded => {
 	const events: Array<AgentEvent> = [];
 	const subagents = new Map(previous.subagents);
+	const spawns = new Map(previous.spawns);
 	for (const spawn of previous.spawns.values()) {
-		const child = children.get(spawn.runId);
+		const found = filled(spawn, resolved?.get(spawn.toolCallId));
+		spawns.set(found.id, found);
+		const child = childOf(children, found.runIds);
 		if (child === undefined) continue;
-		const slot = runningSlotOf(spawn, child);
+		const slot = runningSlotOf(found, child);
 		const key = slotKey(slot);
 		const mark = fingerprint(slot);
 		subagents.set(key, mark);
 		if (previous.subagents.get(key) !== mark) events.push({kind: "subagent", slot});
 	}
-	return {events, next: {...previous, subagents}};
+	return {events, next: {...previous, subagents, spawns}};
 };
 
 /**

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -1002,7 +1002,7 @@ describe("a running subagent filled from its own transcript artifact", () => {
 
 	const childRow = {
 		kind: "assistant",
-		id: "call-9:child-0",
+		id: "call-9:run-0-child-0",
 		parentId: "call-9",
 		timestamp: 12,
 		text: "reading src/a.ts",
@@ -1014,7 +1014,14 @@ describe("a running subagent filled from its own transcript artifact", () => {
 
 	it("tracks the run the running row names", () => {
 		expect([...opened.next.spawns.values()]).toEqual([
-			{id: "call-9", toolCallId: "call-9", runIds: ["run-1"], agent: "reviewer", startedAt: 11},
+			{
+				id: "call-9",
+				toolCallId: "call-9",
+				runId: "run-1",
+				resolved: null,
+				agent: "reviewer",
+				startedAt: 11,
+			},
 		]);
 	});
 
@@ -1124,7 +1131,14 @@ describe("a detached subagent filled through the tool-call index", () => {
 
 	it("tracks the call with no workers until the index answers", () => {
 		expect([...opened.next.spawns.values()]).toEqual([
-			{id: "call-async", toolCallId: "call-async", runIds: [], agent: null, startedAt: 21},
+			{
+				id: "call-async",
+				toolCallId: "call-async",
+				runId: null,
+				resolved: null,
+				agent: null,
+				startedAt: 21,
+			},
 		]);
 	});
 
@@ -1156,7 +1170,7 @@ describe("a detached subagent filled through the tool-call index", () => {
 					items: [
 						{
 							kind: "assistant",
-							id: "call-async:child-0",
+							id: "call-async:run-0-child-0",
 							parentId: "call-async",
 							timestamp: 22,
 							text: "cutting the lane",
@@ -1181,8 +1195,9 @@ describe("a detached subagent filled through the tool-call index", () => {
 			{
 				id: "call-async",
 				toolCallId: "call-async",
-				runIds: ["worker-1"],
-				agent: "builder",
+				runId: null,
+				resolved: {runIds: ["worker-1"], agent: "builder"},
+				agent: null,
 				startedAt: 21,
 			},
 		]);
@@ -1190,6 +1205,72 @@ describe("a detached subagent filled through the tool-call index", () => {
 
 	it("leaves the slot alone when the index resolves nothing", () => {
 		expect(childEventsOf(opened.next, new Map(), new Map()).events).toEqual([]);
+	});
+
+	// A `workflowScript` declares its steps up front and each gains its `runId` at launch, so a run
+	// resolved once and never re-read would sit on the first worker's last line for the whole lane.
+	it("picks up a step that gains its run id after the first resolution", () => {
+		const first = childEventsOf(opened.next, new Map([["worker-1", child]]), resolved);
+		const reviewing = {
+			items: [
+				{
+					kind: "assistant" as const,
+					id: itemId("child-0"),
+					timestamp: 24,
+					text: "reading the diff",
+				},
+			],
+			lastLine: "reading the diff",
+			tokens: 9,
+		};
+		const second = childEventsOf(
+			first.next,
+			new Map([
+				["worker-1", child],
+				["worker-2", reviewing],
+			]),
+			new Map([["call-async", {runIds: ["worker-1", "worker-2"], agent: "builder, reviewer"}]]),
+		);
+		expect(second.events).toEqual([
+			{
+				kind: "subagent",
+				slot: {
+					id: "call-async",
+					type: "builder, reviewer",
+					lastLine: "reading the diff",
+					startedAt: 21,
+					tokens: 26,
+					items: [
+						{
+							kind: "assistant",
+							id: "call-async:run-0-child-0",
+							parentId: "call-async",
+							timestamp: 22,
+							text: "cutting the lane",
+						},
+						{
+							kind: "assistant",
+							id: "call-async:run-1-child-0",
+							parentId: "call-async",
+							timestamp: 24,
+							text: "reading the diff",
+						},
+					],
+					status: "running",
+				},
+			},
+		]);
+	});
+
+	// A tick that reads nothing must not undo the last one that read something.
+	it("keeps the workers it resolved when a later read answers nothing", () => {
+		const first = childEventsOf(opened.next, new Map([["worker-1", child]]), resolved);
+		const blank = childEventsOf(first.next, new Map([["worker-1", child]]), new Map());
+		expect(blank.events).toEqual([]);
+		expect([...blank.next.spawns.values()][0]?.resolved).toEqual({
+			runIds: ["worker-1"],
+			agent: "builder",
+		});
 	});
 
 	it("keeps the agent the call named over the one its steps report", () => {

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -1014,7 +1014,7 @@ describe("a running subagent filled from its own transcript artifact", () => {
 
 	it("tracks the run the running row names", () => {
 		expect([...opened.next.spawns.values()]).toEqual([
-			{id: "call-9", runId: "run-1", type: "reviewer", startedAt: 11},
+			{id: "call-9", toolCallId: "call-9", runIds: ["run-1"], agent: "reviewer", startedAt: 11},
 		]);
 	});
 
@@ -1088,5 +1088,119 @@ describe("a running subagent filled from its own transcript artifact", () => {
 
 	it("leaves the slot empty when the artifact is not readable yet", () => {
 		expect(childEventsOf(opened.next, new Map()).events).toEqual([]);
+	});
+});
+
+/**
+ * A detached spawn (`async: true`, which every `workflowScript` run is) emits no
+ * `tool_execution_update`, so its row carries no run id and its workers write under ids of their
+ * own. The tool-call index is the only address left, and the tail hands its answer to the fold
+ * (#8679).
+ */
+describe("a detached subagent filled through the tool-call index", () => {
+	const running: PiTranscriptItem = {
+		id: "item-3",
+		role: "tool",
+		toolCallId: "call-async",
+		toolName: "subagent",
+		input: {async: true, context: "fresh", workflowScript: "runs.run('lane')"},
+		content: [],
+		timestamp: 21,
+		status: "running",
+		isError: false,
+	};
+
+	const child = {
+		items: [
+			{kind: "assistant" as const, id: itemId("child-0"), timestamp: 22, text: "cutting the lane"},
+		],
+		lastLine: "cutting the lane",
+		tokens: 17,
+	};
+
+	const opened = eventsOf(emptyProjection, snapshot([running], "turn"));
+	const resolved = new Map([["call-async", {runIds: ["worker-1"], agent: "builder"}]]);
+	const tailed = () => childEventsOf(opened.next, new Map([["worker-1", child]]), resolved);
+
+	it("tracks the call with no workers until the index answers", () => {
+		expect([...opened.next.spawns.values()]).toEqual([
+			{id: "call-async", toolCallId: "call-async", runIds: [], agent: null, startedAt: 21},
+		]);
+	});
+
+	it("draws an empty running slot while nothing has resolved", () => {
+		expect(opened.events).toContainEqual({
+			kind: "subagent",
+			slot: {
+				id: "call-async",
+				type: "subagent",
+				lastLine: "",
+				startedAt: 21,
+				tokens: 0,
+				items: [],
+				status: "running",
+			},
+		});
+	});
+
+	it("fills the slot off the resolved worker's artifact and names it after the step", () => {
+		expect(tailed().events).toEqual([
+			{
+				kind: "subagent",
+				slot: {
+					id: "call-async",
+					type: "builder",
+					lastLine: "cutting the lane",
+					startedAt: 21,
+					tokens: 17,
+					items: [
+						{
+							kind: "assistant",
+							id: "call-async:child-0",
+							parentId: "call-async",
+							timestamp: 22,
+							text: "cutting the lane",
+						},
+					],
+					status: "running",
+				},
+			},
+		]);
+	});
+
+	// The resolution is the projection's now, so a wire push landing between two reads restates the
+	// filled slot rather than blanking the rows the operator is looking at.
+	it("keeps the resolution when a later push refolds the same row", () => {
+		const pushed = deltaEventsOf(
+			tailed().next,
+			{id: "session-8679", revision: 2, updatedAt: 200, items: [running]},
+			new Map([["worker-1", child]]),
+		);
+		expect(pushed.events).toEqual([]);
+		expect([...pushed.next.spawns.values()]).toEqual([
+			{
+				id: "call-async",
+				toolCallId: "call-async",
+				runIds: ["worker-1"],
+				agent: "builder",
+				startedAt: 21,
+			},
+		]);
+	});
+
+	it("leaves the slot alone when the index resolves nothing", () => {
+		expect(childEventsOf(opened.next, new Map(), new Map()).events).toEqual([]);
+	});
+
+	it("keeps the agent the call named over the one its steps report", () => {
+		const named = eventsOf(
+			emptyProjection,
+			snapshot([{...running, input: {async: true, agent: "reviewer"}}], "turn"),
+		);
+		expect(
+			childEventsOf(named.next, new Map([["worker-1", child]]), resolved).events.map(
+				(event) => event.kind === "subagent" && event.slot.type,
+			),
+		).toEqual(["reviewer"]);
 	});
 });


### PR DESCRIPTION
An async Pi spawn — `async: true`, which every `workflowScript` run is — detaches without a `tool_execution_update`, so the row it leaves on the transcript carries no `runId` and its workers write artifacts under ids of their own. #8663 keyed the tail on that event, so those rows opened empty, counted 0, and were named the literal "subagent".

This adds the async arm. A detached spawn is now tracked with no workers yet, and the tail resolves it through `pi-subagents`' own on-disk index: the alias file at `<asyncRunRoot>/.active-runs/tool-calls/<encoded toolCallId>/<asyncRunId>`, then that run's `status.json`, trusted only when its own `toolCallId` is the one being asked for. The run's `steps[]` give the worker run ids and agent names, and `readChildTranscript` reads the same `<runId>_<agent>_transcript.jsonl` files it already read for a foreground spawn. Nothing is parsed out of the result text.

The index is re-read on **every** tail tick for as long as the spawn runs, not once. `steps[]` is declared up front and each step gains its `runId` only at launch, so a sequential lane — builder, then reviewer, then shipper — publishes its workers one at a time; resolving once would leave the row on the builder's last line for the whole run, looking live while stale. A fresh answer replaces the held one whole, because the status read already carries every step launched so far; a read that resolves nothing leaves the held answer standing, so a tick that finds nothing never blanks a slot someone is reading.

The row is named after the agents the steps report when the call named none; an explicit `agent` still wins. The resolution lands on the projection, so a wire push between two reads restates the filled slot instead of blanking it. Every read is total — a missing marker, an unreadable status or a mismatched claim leaves the slot exactly as it looks today.

Grounded in `pi-subagents@0.66.0` source at the pin: `src/runs/background/active-run-index.ts` (the index layout), `src/runs/background/run-id-resolver.ts`'s `indexedToolCallIdAsyncLocations` (the read this mirrors, including the status confirmation), `src/runs/background/index-segment.ts` (`encodeIndexSegment` and `indexSegmentAliases`, digest fallback included), `src/shared/types.ts` (`AsyncStatus.steps[]`, `ASYNC_DIR`, `resolveTempScopeId`).

Tests: `async-spawn.unit.test.ts` covers the resolution over fixture directories — a marker resolving to one worker, a status naming another call (rejected), a missing marker, a status that will not read, a status that gains a second step's `runId` between two reads, a run aliased under the pre-hash key, and a multi-step fan-out. `items.unit.test.ts` covers the fold: the untracked-then-resolved slot, the fill, the later step reaching the slot, a blank read that must not undo the last one, the push that must not blank it, and the explicit-agent precedence. `.patterns/tuval-detached-child-tail.md` gains the async correlation route and the re-read rule.

Fixes #8679

## Deviations

- **Out-of-scope change** — **Said:** #8679 names the async resolution chain and the tail. **Did:** also extended `.patterns/tuval-detached-child-tail.md` with the async correlation route, the re-read rule and the fan-out note. **Why:** CLAUDE.md requires a load-bearing pattern to be documented, and that doc's part 1 said the correlation comes off the event — true only for the foreground arm now. **Disposition:** stated here.
- **Scope narrowing** — **Said:** criterion 2 says the resolved `steps[]` supply the worker run ids and agent names. **Did:** several workers under one call are concatenated into the one slot, in step order, and the row is named after the distinct agents joined by `, `. **Why:** how a fan-out should be laid out on screen is #8664's, and the issue says to keep one row per spawn call. **Disposition:** stated here; #8664 owns the layout.
- **Known defect left unfixed** — **Said:** nothing about a finished async row. **Did:** a detached spawn that has already answered resolves nothing, because `releaseActiveRunIndex` removes the alias at a terminal state, so its slot falls back to the tool result's own text as it does today. **Why:** the terminal-run index is a separate read the issue does not name, and criterion 5 asks a failed resolution to leave the slot as it is. **Disposition:** stated here; filed as https://github.com/kamp-us/phoenix/issues/8685.
- **Pre-existing test or fixture changed** — **Said:** nothing about a foreground spawn's row ids. **Did:** `joinChildTranscripts` now prefixes every run's items, single-run included, so a foreground slot's item ids moved from `<callId>:child-N` to `<callId>:run-0-child-N`, and the foreground test's expectation moved with them. **Why:** the round-1 review flagged that a conditional prefix renumbers every id the moment a second worker appears, which is exactly what a sequential lane now does mid-run. Item ids are positional labels inside a slot the fold re-emits whole, so nothing renders differently. **Disposition:** stated here.
