### PR TITLE
feat: the send-delivery rule moves off variant onto its own prop

### DIFF
--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -1,4 +1,5 @@
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {createRef} from "react";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {AgentChatInput} from "./AgentChatInput";
 import type {AgentChatInputBridge} from "./agent-chat-bridge";
@@ -597,5 +598,15 @@ describe("AgentChatInput", () => {
 			"GPT-5",
 			"GPT-5.6",
 		]);
+	});
+
+	// A host's only way to focus the composer, and it travels as an ordinary prop through the
+	// spread onto Root. Nothing throws when it stops attaching — focus just never moves (#8688).
+	it("lands a host's ref on the prompt field", async () => {
+		const {bridge} = installHarnessFetch();
+		const field = createRef<HTMLTextAreaElement>();
+		render(<AgentChatInput bridge={bridge} ref={field} />);
+
+		expect(await screen.findByLabelText("Pi'ye mesaj yaz")).toBe(field.current);
 	});
 });

--- a/packages/design/src/agent-chat/Root.test.tsx
+++ b/packages/design/src/agent-chat/Root.test.tsx
@@ -1,12 +1,145 @@
-import {render, screen} from "@testing-library/react";
+import {act, fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {describe, expect, it, vi} from "vitest";
 import {AgentChatInput} from "../AgentChatInput";
+import type {AgentChatInputBridge, PiDeliveryMode} from "../agent-chat-bridge";
+import type {AgentChatDeliveryRule} from "./delivery";
 import {useAgentChatInput} from "./Root";
+import type {ConnectionState} from "./types";
+
+type SentPrompt = Parameters<AgentChatInputBridge["sendPiPrompt"]>[0];
 
 function Part() {
 	const {variant, connection} = useAgentChatInput();
 	return <p>{`${variant}/${connection}`}</p>;
 }
+
+/**
+ * A bridge parked in one connection state. `loading` is the load that never answers, which is the
+ * state the composer mounts in; `unavailable` is the load that rejects.
+ */
+function bridgeAt(connection: ConnectionState): {
+	bridge: AgentChatInputBridge;
+	sent: SentPrompt[];
+} {
+	const sent: SentPrompt[] = [];
+	const state = async (): Promise<Record<string, unknown>> => {
+		if (connection === "loading") return new Promise<never>(() => undefined);
+		if (connection === "unavailable") throw new Error("no harness");
+		return {isStreaming: connection === "working"};
+	};
+	const bridge: AgentChatInputBridge = {
+		loadPiState: state,
+		loadPiCommands: async () => [],
+		loadPiModels: async () => [],
+		loadPiThinkingLevels: async () => [],
+		loadPiFiles: async () => [],
+		setPiModel: async () => undefined,
+		setPiThinkingLevel: async () => undefined,
+		setPiProjectTrust: async () => undefined,
+		sendPiPrompt: async (options) => {
+			sent.push(options);
+		},
+		abortPi: async () => undefined,
+		answerPiExtension: async () => undefined,
+		subscribeToPiEvents: () => () => undefined,
+	};
+	return {bridge, sent};
+}
+
+function Composer({picked}: {readonly picked: PiDeliveryMode}) {
+	const {connection, setDelivery, typeDraft, submit} = useAgentChatInput();
+	return (
+		<>
+			<p data-testid="connection">{connection}</p>
+			<button
+				type="button"
+				onClick={() => {
+					typeDraft("Ship it.");
+					setDelivery(picked);
+				}}
+			>
+				compose
+			</button>
+			<button type="button" onClick={() => void submit()}>
+				send
+			</button>
+		</>
+	);
+}
+
+async function send(options: {
+	readonly connection: ConnectionState;
+	readonly picked: PiDeliveryMode;
+	readonly variant?: "harness" | "focused";
+	readonly deliveryRule?: AgentChatDeliveryRule;
+}): Promise<SentPrompt[]> {
+	const {bridge, sent} = bridgeAt(options.connection);
+	render(
+		<AgentChatInput.Root
+			bridge={bridge}
+			variant={options.variant}
+			deliveryRule={options.deliveryRule}
+		>
+			<Composer picked={options.picked} />
+		</AgentChatInput.Root>,
+	);
+	await waitFor(() =>
+		expect(screen.getByTestId("connection").textContent).toBe(options.connection),
+	);
+	fireEvent.click(screen.getByRole("button", {name: "compose"}));
+	fireEvent.click(screen.getByRole("button", {name: "send"}));
+	await act(async () => undefined);
+	return sent;
+}
+
+const deliveries: readonly PiDeliveryMode[] = ["prompt", "steer", "follow_up"];
+
+/**
+ * What each variant delivered before the rule was its own prop, at every connection state crossed
+ * with every picker value. `undefined` is a send the composer refuses. Written out rather than
+ * derived, so the table is a check on the rule and not a second copy of it.
+ */
+const legacy: Record<
+	"focused" | "harness",
+	Record<ConnectionState, Record<PiDeliveryMode, SentPrompt | undefined>>
+> = {
+	focused: {
+		loading: {
+			prompt: {type: "prompt", message: "Ship it."},
+			steer: {type: "prompt", message: "Ship it."},
+			follow_up: {type: "prompt", message: "Ship it."},
+		},
+		ready: {
+			prompt: {type: "prompt", message: "Ship it."},
+			steer: {type: "prompt", message: "Ship it."},
+			follow_up: {type: "prompt", message: "Ship it."},
+		},
+		working: {
+			prompt: {type: "follow_up", message: "Ship it."},
+			steer: {type: "steer", message: "Ship it."},
+			follow_up: {type: "follow_up", message: "Ship it."},
+		},
+		unavailable: {prompt: undefined, steer: undefined, follow_up: undefined},
+	},
+	harness: {
+		loading: {
+			prompt: {type: "prompt", message: "Ship it."},
+			steer: {type: "steer", message: "Ship it."},
+			follow_up: {type: "follow_up", message: "Ship it."},
+		},
+		ready: {
+			prompt: {type: "prompt", message: "Ship it."},
+			steer: {type: "steer", message: "Ship it."},
+			follow_up: {type: "follow_up", message: "Ship it."},
+		},
+		working: {
+			prompt: {type: "prompt", message: "Ship it.", streamingBehavior: "steer"},
+			steer: {type: "steer", message: "Ship it."},
+			follow_up: {type: "follow_up", message: "Ship it."},
+		},
+		unavailable: {prompt: undefined, steer: undefined, follow_up: undefined},
+	},
+};
 
 describe("AgentChatInput.Root", () => {
 	it("names itself when a part is rendered outside a Root", () => {
@@ -25,5 +158,55 @@ describe("AgentChatInput.Root", () => {
 			</AgentChatInput.Root>,
 		);
 		expect(screen.getByText("focused/loading")).toBeTruthy();
+	});
+});
+
+describe("the send-delivery rule", () => {
+	describe.each([
+		"focused",
+		"harness",
+	] as const)("with deliveryRule unset on variant=%s", (variant) => {
+		describe.each([
+			"loading",
+			"ready",
+			"working",
+			"unavailable",
+		] as const)("while %s", (connection) => {
+			it.each(deliveries)("delivers a picked %s as it did before the prop", async (picked) => {
+				const sent = await send({connection, picked, variant});
+				const expected = legacy[variant][connection][picked];
+				expect(sent).toEqual(expected ? [expected] : []);
+			});
+		});
+	});
+
+	it("takes an explicit as-picked over the focused variant's default", async () => {
+		const sent = await send({
+			connection: "working",
+			picked: "prompt",
+			variant: "focused",
+			deliveryRule: "as-picked",
+		});
+		expect(sent).toEqual([{type: "prompt", message: "Ship it.", streamingBehavior: "steer"}]);
+	});
+
+	it("takes an explicit queue-while-working over the harness variant's default", async () => {
+		const sent = await send({
+			connection: "working",
+			picked: "prompt",
+			variant: "harness",
+			deliveryRule: "queue-while-working",
+		});
+		expect(sent).toEqual([{type: "follow_up", message: "Ship it."}]);
+	});
+
+	it("leaves an idle send a fresh prompt under queue-while-working", async () => {
+		const sent = await send({
+			connection: "ready",
+			picked: "follow_up",
+			variant: "harness",
+			deliveryRule: "queue-while-working",
+		});
+		expect(sent).toEqual([{type: "prompt", message: "Ship it."}]);
 	});
 });

--- a/packages/design/src/agent-chat/Root.tsx
+++ b/packages/design/src/agent-chat/Root.tsx
@@ -24,6 +24,11 @@ import type {
 } from "../agent-chat-bridge";
 import {useDesignT} from "../i18n";
 import {thinkingLevelKeys} from "./catalog";
+import {
+	type AgentChatDeliveryRule,
+	deliveryRuleForVariant,
+	requestedDelivery as resolveRequestedDelivery,
+} from "./delivery";
 import {fileAsImage, MAX_IMAGE_BYTES} from "./image";
 import {mockCommands, mockFiles, mockModels, mockThinkingLevels} from "./mock-harness";
 import {
@@ -48,7 +53,23 @@ export interface AgentChatInputProps {
 	readonly bridge?: AgentChatInputBridge;
 	readonly initialValue?: string;
 	readonly disabled?: boolean;
+	/**
+	 * Styling only. It picks the composer's border, layout and which controls sit behind the
+	 * disclosure; `deliveryRule` decides how a send goes out. #8669 retires this prop.
+	 */
 	readonly variant?: "harness" | "focused";
+	/**
+	 * How a send is delivered.
+	 *
+	 * - `as-picked` — send exactly what the delivery picker holds, whatever the harness is doing.
+	 * - `queue-while-working` — the picker only applies while the harness is working, and a `prompt`
+	 *   picked there queues as a `follow_up` instead of interrupting the run. A send at any other
+	 *   connection state is always a fresh `prompt`.
+	 *
+	 * Unset, it is derived from `variant` — `focused` means `queue-while-working`, `harness` means
+	 * `as-picked` — so a host that never named it keeps the delivery it has today.
+	 */
+	readonly deliveryRule?: AgentChatDeliveryRule;
 	readonly mockWhenUnavailable?: boolean;
 	/**
 	 * Called with the composer's text whenever an edit changes it — a keystroke, an accepted
@@ -80,6 +101,7 @@ export interface AgentChatInputProps {
 export interface AgentChatInputContextValue {
 	readonly disabled: boolean;
 	readonly variant: "harness" | "focused";
+	readonly deliveryRule: AgentChatDeliveryRule;
 	readonly settings: ReactNode;
 	readonly fieldRef: Ref<HTMLTextAreaElement> | undefined;
 	readonly inputId: string;
@@ -136,6 +158,7 @@ export function AgentChatInputRoot({
 	initialValue = "",
 	disabled = false,
 	variant = "harness",
+	deliveryRule,
 	mockWhenUnavailable = false,
 	onDraftChange,
 	settings,
@@ -143,6 +166,7 @@ export function AgentChatInputRoot({
 	children,
 }: AgentChatInputProps & {readonly children: ReactNode}) {
 	const activeBridge = bridge ?? unavailableBridge;
+	const rule = deliveryRule ?? deliveryRuleForVariant(variant);
 	const t = useDesignT();
 	const inputId = useId();
 	const suggestionsId = `${inputId}-suggestions`;
@@ -428,14 +452,7 @@ export function AgentChatInputRoot({
 			return;
 		}
 		try {
-			const requestedDelivery =
-				variant === "focused"
-					? connection === "working"
-						? delivery === "prompt"
-							? "follow_up"
-							: delivery
-						: "prompt"
-					: delivery;
+			const requestedDelivery = resolveRequestedDelivery(rule, connection, delivery);
 			const streamedPrompt = connection === "working" && requestedDelivery === "prompt";
 			await activeBridge.sendPiPrompt({
 				type: requestedDelivery,
@@ -648,6 +665,7 @@ export function AgentChatInputRoot({
 	const value: AgentChatInputContextValue = {
 		disabled,
 		variant,
+		deliveryRule: rule,
 		settings,
 		fieldRef: ref,
 		inputId,

--- a/packages/design/src/agent-chat/delivery.ts
+++ b/packages/design/src/agent-chat/delivery.ts
@@ -1,0 +1,27 @@
+import type {PiDeliveryMode} from "../agent-chat-bridge";
+import type {ConnectionState} from "./types";
+
+/**
+ * How a send is delivered, independent of how the composer looks.
+ *
+ * - `as-picked` — send exactly what the delivery picker holds, whatever the harness is doing.
+ * - `queue-while-working` — the picker only applies while the harness is working, and a `prompt`
+ *   picked there queues as a `follow_up` instead of interrupting the run. A send at any other
+ *   connection state is always a fresh `prompt`.
+ */
+export type AgentChatDeliveryRule = "as-picked" | "queue-while-working";
+
+/** The rule a `variant` implied before the rule was its own prop. */
+export function deliveryRuleForVariant(variant: "harness" | "focused"): AgentChatDeliveryRule {
+	return variant === "focused" ? "queue-while-working" : "as-picked";
+}
+
+export function requestedDelivery(
+	rule: AgentChatDeliveryRule,
+	connection: ConnectionState,
+	picked: PiDeliveryMode,
+): PiDeliveryMode {
+	if (rule === "as-picked") return picked;
+	if (connection !== "working") return "prompt";
+	return picked === "prompt" ? "follow_up" : picked;
+}

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -2,6 +2,7 @@ export type {AgentChatInputProps} from "./AgentChatInput";
 export {AgentChatInput} from "./AgentChatInput";
 export {Alert} from "./Alert";
 export {Avatar} from "./Avatar";
+export type {AgentChatDeliveryRule} from "./agent-chat/delivery";
 export type {
 	PickerItem as AgentSettingItem,
 	SettingMenuProps as AgentSettingMenuProps,


### PR DESCRIPTION
## Summary

`submit()` used to read `variant` to decide whether a send went out as a prompt or a follow-up, so a styling choice silently changed delivery. That rule is now its own prop.

`AgentChatInputProps` carries `deliveryRule?: "as-picked" | "queue-while-working"`:

- `as-picked` — send exactly what the delivery picker holds, whatever the harness is doing.
- `queue-while-working` — the picker only applies while the harness is working, and a `prompt` picked there queues as a `follow_up`. A send at any other connection state is a fresh `prompt`.

Unset, it derives from `variant` (`focused` → `queue-while-working`, `harness` → `as-picked`), so every current consumer's delivered send is byte-identical before and after. The rule itself is a pure function in `packages/design/src/agent-chat/delivery.ts`; Root resolves the default once and puts it on the context, and `submit()` reads it from there. `variant`'s docblock now says it styles only, and names #8669 as the ticket that retires it.

## What a reviewer should look at first

`packages/design/src/agent-chat/Root.test.tsx` — the `legacy` table is written out by hand rather than derived from the new function, so it is a check on the rule and not a second copy of it. It covers both variants with the prop unset, across all four `connection` states crossed with all three picker values, plus the two cases where an explicit prop overrides the variant-derived default. I mutation-checked it: making `requestedDelivery` return the picked value unconditionally reds 7 of them.

Also carried here, at the reviewer's request on #8687: a test that a host's `ref` lands on the textarea, which answers #8688. That path is React 19's ref-as-prop travelling across a spread onto `AgentChatInput.Root`, and its failure mode in Tuval is an optional-chained `focus()` that silently does nothing.

Nothing in `packages/design/src/AgentChatInput.test.tsx` was edited; the ref case is appended. The three consumers are untouched.

Part of #8668. Fixes #8675.

## Deviations

- **Out-of-scope change** — **Said:** #8675 names the delivery rule only. **Did:** also added a test that the composer's forwarded ref lands on the textarea, and exported the `AgentChatDeliveryRule` type from `packages/design/src/index.ts`. **Why:** the ref test was asked for on this ticket by #8687's reviewer (#8688), and the type export is owed because the union is now part of the public `AgentChatInputProps`. **Disposition:** stated here; both land in this PR. #8688 is left open for a human to close against this PR.
