### PR TITLE
feat: compound parts: Surface, Field, Toolbar, Settings, Hint and the Control primitive

### DIFF
--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -227,6 +227,17 @@ function ComposedComposer() {
 const GENERATED_IDS =
 	/\s(id|for|aria-controls|aria-activedescendant|aria-labelledby|aria-describedby|data-uid|data-controls)="[^"]*"/g;
 
+/**
+ * The composer paints before its catalog resolves, and the model and thinking labels are the last
+ * thing the four bridge loads move. Reading the markup before they land compares half-settled
+ * trees, which goes red on timing rather than on a difference.
+ */
+async function settledComposerMarkup(container: HTMLElement): Promise<string> {
+	await screen.findAllByText("GPT-5");
+	await screen.findAllByText("orta");
+	return composerMarkup(container);
+}
+
 function composerMarkup(container: HTMLElement): string {
 	const composer = container.querySelector('[data-testid="agent-chat-input"]');
 	if (!composer) throw new Error("no composer rendered");
@@ -640,9 +651,7 @@ describe("AgentChatInput", () => {
 		it("assemble into the tree the plain export renders", async () => {
 			const {bridge} = installHarnessFetch();
 			const plain = render(<AgentChatInput bridge={bridge} variant={variant} />);
-			await screen.findByLabelText("Pi'ye mesaj yaz");
-			await waitFor(() => expect(composerMarkup(plain.container)).toContain("kp-agent-chat__hint"));
-			const expected = composerMarkup(plain.container);
+			const expected = await settledComposerMarkup(plain.container);
 			plain.unmount();
 
 			const composed = render(
@@ -650,7 +659,7 @@ describe("AgentChatInput", () => {
 					<ComposedComposer />
 				</AgentChatInput.Root>,
 			);
-			await screen.findByLabelText("Pi'ye mesaj yaz");
+			await settledComposerMarkup(composed.container);
 			await waitFor(() => expect(composerMarkup(composed.container)).toBe(expected));
 		});
 	});

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -2,7 +2,9 @@ import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {createRef} from "react";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {AgentChatInput} from "./AgentChatInput";
+import {useAgentChatInput} from "./agent-chat/Root";
 import type {AgentChatInputBridge} from "./agent-chat-bridge";
+import {Form} from "./Form";
 import {type DesignTranslate, DesignTranslationProvider, defaultDesignTranslate} from "./i18n";
 
 function response(body: unknown): Response {
@@ -195,6 +197,40 @@ function collidingCatalogBridge(): {
 		subscribeToPiEvents: () => () => undefined,
 	};
 	return {bridge, picks};
+}
+
+/**
+ * The composer assembled from its compound parts, in the order the export assembles them. Two
+ * renders never draw the same generated ids — React's `useId` and Manti's own `data-uid` both
+ * count up per render — so the comparison below reads the markup with every id-carrying attribute
+ * blanked.
+ */
+function ComposedComposer() {
+	const {submit} = useAgentChatInput();
+	return (
+		<AgentChatInput.Surface>
+			<Form
+				className="kp-agent-chat__form"
+				onSubmit={(event) => {
+					event.preventDefault();
+					void submit();
+				}}
+			>
+				<AgentChatInput.Field />
+				<AgentChatInput.Toolbar />
+			</Form>
+			<AgentChatInput.Hint />
+		</AgentChatInput.Surface>
+	);
+}
+
+const GENERATED_IDS =
+	/\s(id|for|aria-controls|aria-activedescendant|aria-labelledby|aria-describedby|data-uid|data-controls)="[^"]*"/g;
+
+function composerMarkup(container: HTMLElement): string {
+	const composer = container.querySelector('[data-testid="agent-chat-input"]');
+	if (!composer) throw new Error("no composer rendered");
+	return composer.innerHTML.replace(GENERATED_IDS, ' $1="*"');
 }
 
 afterEach(() => vi.unstubAllGlobals());
@@ -598,6 +634,50 @@ describe("AgentChatInput", () => {
 			"GPT-5",
 			"GPT-5.6",
 		]);
+	});
+
+	describe.each(["harness", "focused"] as const)("the %s composer's compound parts", (variant) => {
+		it("assemble into the tree the plain export renders", async () => {
+			const {bridge} = installHarnessFetch();
+			const plain = render(<AgentChatInput bridge={bridge} variant={variant} />);
+			await screen.findByLabelText("Pi'ye mesaj yaz");
+			await waitFor(() => expect(composerMarkup(plain.container)).toContain("kp-agent-chat__hint"));
+			const expected = composerMarkup(plain.container);
+			plain.unmount();
+
+			const composed = render(
+				<AgentChatInput.Root bridge={bridge} variant={variant}>
+					<ComposedComposer />
+				</AgentChatInput.Root>,
+			);
+			await screen.findByLabelText("Pi'ye mesaj yaz");
+			await waitFor(() => expect(composerMarkup(composed.container)).toBe(expected));
+		});
+	});
+
+	it("keeps the settings slot rendering inside the fieldset", async () => {
+		const {bridge} = installHarnessFetch();
+		render(<AgentChatInput bridge={bridge} settings={<button type="button">Ajan kipi</button>} />);
+
+		const slotted = await screen.findByRole("button", {name: "Ajan kipi"});
+		expect(slotted.closest("fieldset")?.className).toContain("kp-agent-chat__settings");
+		expect(screen.getByRole("combobox", {name: "Pi modeli"})).toBeTruthy();
+	});
+
+	it("lets Settings children stand in for the controls it owns, slot untouched", async () => {
+		const {bridge} = installHarnessFetch();
+		render(
+			<AgentChatInput.Root bridge={bridge} settings={<button type="button">Ajan kipi</button>}>
+				<AgentChatInput.Settings>
+					<button type="button">Yalnız bu</button>
+				</AgentChatInput.Settings>
+			</AgentChatInput.Root>,
+		);
+
+		const own = await screen.findByRole("button", {name: "Yalnız bu"});
+		expect(own.closest("fieldset")?.className).toContain("kp-agent-chat__settings");
+		expect(screen.queryByRole("combobox", {name: "Pi modeli"})).toBeNull();
+		expect(screen.queryByRole("button", {name: "Ajan kipi"})).toBeNull();
 	});
 
 	// A host's only way to focus the composer, and it travels as an ordinary prop through the

--- a/packages/design/src/AgentChatInput.tsx
+++ b/packages/design/src/AgentChatInput.tsx
@@ -1,48 +1,19 @@
-import {
-	Bot,
-	Brain,
-	ChevronDown,
-	ChevronUp,
-	FileImage,
-	Paperclip,
-	SendHorizontal,
-	ShieldCheck,
-	Square,
-	X,
-} from "lucide-react";
-import {useMemo, useRef} from "react";
+import {ChevronDown, ChevronUp} from "lucide-react";
 import {Alert} from "./Alert";
 import {AgentActivity} from "./agent-chat/AgentActivity";
-import {
-	deliveryModeKeys,
-	projectTrustKeys,
-	thinkingLevelIcons,
-	thinkingLevelKeys,
-	toItems,
-} from "./agent-chat/catalog";
+import {AgentChatControl} from "./agent-chat/Control";
+import {AgentChatField} from "./agent-chat/Field";
 import {HarnessWidget} from "./agent-chat/HarnessWidget";
+import {AgentChatHint} from "./agent-chat/Hint";
 import {Icon} from "./agent-chat/Icon";
 import {PiExtensionDialog} from "./agent-chat/PiExtensionDialog";
-import {
-	deliveryMode,
-	modelName,
-	modelValue,
-	providersCollide,
-	runningModelLabel,
-	selectedModelValue,
-	thinkingLevelValue,
-} from "./agent-chat/parse";
 import {type AgentChatInputProps, AgentChatInputRoot, useAgentChatInput} from "./agent-chat/Root";
-import {type PickerItem, SettingMenu} from "./agent-chat/SettingMenu";
-import {SuggestionRow} from "./agent-chat/SuggestionRow";
-import {Kbd} from "./atoms";
-import {Button} from "./Button";
-import {Card} from "./Card";
+import {AgentChatSettings} from "./agent-chat/Settings";
+import {AgentChatSurface} from "./agent-chat/Surface";
+import {AgentChatToolbar} from "./agent-chat/Toolbar";
 import {Collapsible} from "./Collapsible";
-import {Form, Input, Textarea} from "./Form";
+import {Form} from "./Form";
 import {useDesignT} from "./i18n";
-import {Menu, type MenuItem} from "./Menu";
-import {Select, type SelectItem} from "./Select";
 import "./AgentChatInput.css";
 import "./visually-hidden.css";
 
@@ -50,183 +21,18 @@ export type {AgentChatInputProps} from "./agent-chat/Root";
 
 function AgentChatInputBody() {
 	const {
-		disabled,
 		variant,
-		settings,
-		fieldRef,
-		inputId,
-		suggestionsId,
-		draft,
-		delivery,
-		connection,
-		harnessState: state,
-		commands,
-		models,
-		thinkingLevels,
-		projectTrust,
-		settingsChanging,
-		images,
 		error,
 		assistantText,
 		activities,
-		suggestions,
-		activeSuggestion,
-		activeSuggestionId,
 		extension,
-		extensionStatus,
 		widget,
 		inspectorOpen,
 		setInspectorOpen,
-		setDelivery,
-		typeDraft,
-		selectSuggestion,
-		removeImage,
-		addImage,
 		submit,
-		stop,
-		changeModel,
-		changeThinkingLevel,
-		changeProjectTrust,
 		answerExtension,
-		onPaste,
-		onKeyDown,
 	} = useAgentChatInput();
 	const t = useDesignT();
-	const imageInputRef = useRef<HTMLInputElement>(null);
-
-	// A harness that offers no commands does not advertise the sigil: typing `/` against an empty
-	// catalog opens nothing, and a hint promising a picker that never appears reads as a fault.
-	const commandHint =
-		commands.length > 0 ? (
-			<>
-				<Kbd>/</Kbd> {t("admin.agent.hint.command")} ·{" "}
-			</>
-		) : null;
-
-	const model = runningModelLabel(state, models ?? []);
-	// Manti's `SelectItem.label` is `string`, and the select collection stringifies it for typeahead
-	// (`itemToString: (item) => item.label`), so this list carries the provider in the label itself
-	// while the Menu-backed picker below renders it as its own dimmed span. See #8065.
-	// Each list stays `undefined` while its offer is unresolved, so the pickers are handed the same
-	// three-way answer the bridge gave rather than a flattened array (#8425).
-	const modelItems = useMemo<SelectItem[] | undefined>(
-		() =>
-			models?.map((candidate) => ({
-				value: modelValue(candidate),
-				label: providersCollide(models)
-					? `${candidate.name} (${candidate.provider})`
-					: candidate.name,
-			})),
-		[models],
-	);
-	const thinkingItems = useMemo<SelectItem[] | undefined>(
-		() => thinkingLevels?.map((level) => ({value: level, label: t(thinkingLevelKeys[level])})),
-		[thinkingLevels, t],
-	);
-	const focusedModelItems = useMemo<PickerItem[] | undefined>(
-		() =>
-			models?.map((candidate) => ({
-				value: modelValue(candidate),
-				label: candidate.name,
-				...(providersCollide(models) ? {note: candidate.provider} : {}),
-			})),
-		[models],
-	);
-	const focusedThinkingItems = useMemo<PickerItem[] | undefined>(
-		() =>
-			thinkingLevels?.map((level) => ({
-				value: level,
-				label: t(thinkingLevelKeys[level]),
-				icon: thinkingLevelIcons[level],
-			})),
-		[thinkingLevels, t],
-	);
-	// The host's own answer and nothing else. Falling back to the first row named a model nobody
-	// picked as the one the session runs on, and a picker opened with that row already checked read
-	// as a choice already made (#8573).
-	const selectedModel = selectedModelValue(state);
-	const stateThinking = thinkingLevelValue(state?.thinkingLevel);
-	const selectedThinking = stateThinking !== "off" ? stateThinking : undefined;
-	// Each selection as a row of its own, for the picker to name when the offer carries no row for
-	// it — the pick an operator holds while no session's catalog is live (#8542).
-	const heldModel = useMemo<PickerItem | undefined>(() => {
-		const name = modelName(state);
-		return selectedModel && name ? {value: selectedModel, label: name} : undefined;
-	}, [selectedModel, state]);
-	const heldThinking = useMemo<PickerItem | undefined>(
-		() =>
-			selectedThinking === undefined
-				? undefined
-				: {
-						value: selectedThinking,
-						label: t(thinkingLevelKeys[selectedThinking]),
-						icon: thinkingLevelIcons[selectedThinking],
-					},
-		[selectedThinking, t],
-	);
-	const settingsDisabled = disabled || settingsChanging || connection !== "ready";
-	const offeredThinking = thinkingItems?.length ?? 0;
-	const thinkingDisabled =
-		settingsDisabled ||
-		offeredThinking === 0 ||
-		(offeredThinking === 1 && selectedThinking !== undefined);
-	const focusedDelivery =
-		connection === "working" ? (delivery === "prompt" ? "follow_up" : delivery) : "prompt";
-	const focusedMenuItems: MenuItem[] = [
-		...(connection === "working"
-			? [
-					{
-						type: "group" as const,
-						label: t("admin.agent.menu.streaming"),
-						items: [
-							{
-								type: "radio" as const,
-								value: "delivery:steer",
-								label: t("admin.agent.delivery.steer"),
-								checked: focusedDelivery === "steer",
-							},
-							{
-								type: "radio" as const,
-								value: "delivery:follow_up",
-								label: t("admin.agent.delivery.followUp"),
-								checked: focusedDelivery === "follow_up",
-							},
-						],
-					},
-					{type: "separator" as const},
-				]
-			: []),
-		{
-			type: "group",
-			label: t("admin.agent.menu.projectResources"),
-			items: [
-				{
-					type: "radio",
-					value: "trust:approve",
-					label: t("admin.agent.trust.load"),
-					checked: projectTrust === "approve",
-					disabled: settingsDisabled,
-				},
-				{
-					type: "radio",
-					value: "trust:no-approve",
-					label: t("admin.agent.trust.skip"),
-					checked: projectTrust === "no-approve",
-					disabled: settingsDisabled,
-				},
-			],
-		},
-	];
-	const status =
-		connection === "loading"
-			? t("admin.agent.status.loading")
-			: connection === "working"
-				? t("admin.agent.status.working")
-				: connection === "ready"
-					? model
-						? t("admin.agent.status.readyWithModel", {model})
-						: t("admin.agent.status.ready")
-					: t("admin.agent.status.unavailable");
 
 	return (
 		<section
@@ -234,17 +40,7 @@ function AgentChatInputBody() {
 			aria-label={t("admin.agent.label")}
 		>
 			{variant === "harness" && widget ? <HarnessWidget lines={widget} /> : null}
-			<Card className="kp-agent-chat__composer" data-testid="agent-chat-input">
-				{variant === "harness" ? (
-					<div className="kp-agent-chat__status-row">
-						<p className="kp-agent-chat__status" aria-live="polite">
-							{status}
-							{extensionStatus ? ` · ${extensionStatus}` : ""}
-						</p>
-						<p className="kp-agent-chat__scope">{t("admin.agent.scope")}</p>
-					</div>
-				) : null}
-
+			<AgentChatSurface>
 				<Form
 					className="kp-agent-chat__form"
 					onSubmit={(event) => {
@@ -252,272 +48,17 @@ function AgentChatInputBody() {
 						void submit();
 					}}
 				>
-					{images.length > 0 ? (
-						<ul className="kp-agent-chat__attachments" aria-label={t("admin.agent.attachments")}>
-							{images.map((image) => (
-								<li key={image.name} className="kp-agent-chat__attachment">
-									<Icon icon={FileImage} size={16} />
-									<span>{image.name}</span>
-									<Button
-										type="button"
-										variant="tertiary"
-										size="sm"
-										className="kp-agent-chat__attachment-remove"
-										onClick={() => removeImage(image)}
-									>
-										<Icon icon={X} size={16} />
-										<span className="kp-visually-hidden">
-											{t("admin.agent.attachment.remove", {name: image.name})}
-										</span>
-									</Button>
-								</li>
-							))}
-						</ul>
-					) : null}
-
-					<div className="kp-agent-chat__field">
-						<Textarea
-							ref={fieldRef}
-							id={inputId}
-							className="kp-agent-chat__textarea"
-							role="combobox"
-							aria-autocomplete="list"
-							aria-expanded={suggestions.length > 0}
-							aria-controls={suggestions.length > 0 ? suggestionsId : undefined}
-							aria-activedescendant={activeSuggestionId}
-							label={<span className="kp-visually-hidden">{t("admin.agent.compose.label")}</span>}
-							placeholder={t("admin.agent.compose.placeholder")}
-							value={draft}
-							onChange={(event) => typeDraft(event.currentTarget.value)}
-							onPaste={onPaste}
-							onKeyDown={onKeyDown}
-							rows={3}
-							resize="none"
-							spellCheck
-							fullWidth
-							disabled={disabled}
-						/>
-						{suggestions.length > 0 ? (
-							<Card
-								id={suggestionsId}
-								className="kp-agent-chat__suggestions"
-								role="listbox"
-								aria-label={t("admin.agent.completions")}
-							>
-								{suggestions.map((suggestion, index) => (
-									<SuggestionRow
-										id={`${suggestionsId}-${index}`}
-										key={suggestion.kind === "command" ? suggestion.command.name : suggestion.path}
-										suggestion={suggestion}
-										active={index === activeSuggestion}
-										onSelect={() => selectSuggestion(suggestion)}
-									/>
-								))}
-							</Card>
-						) : null}
-					</div>
-
-					<div className="kp-agent-chat__actions">
-						<div className="kp-agent-chat__primary-controls">
-							{variant === "focused" ? (
-								<>
-									<Input
-										ref={imageInputRef}
-										className="kp-visually-hidden"
-										label={t("admin.agent.image.add")}
-										type="file"
-										accept="image/*"
-										tabIndex={-1}
-										onChange={(event) => {
-											void addImage(event.currentTarget.files?.[0]);
-											event.currentTarget.value = "";
-										}}
-									/>
-									<Button
-										type="button"
-										variant="tertiary"
-										size="sm"
-										className="kp-agent-chat__icon-button"
-										aria-label={t("admin.agent.image.add")}
-										onClick={() => imageInputRef.current?.click()}
-										disabled={disabled}
-									>
-										<Icon icon={Paperclip} size={16} />
-									</Button>
-								</>
-							) : null}
-							<fieldset className="kp-agent-chat__settings">
-								<legend className="kp-visually-hidden">{t("admin.agent.settings")}</legend>
-								{variant === "focused" ? (
-									<>
-										<SettingMenu
-											label={t("admin.agent.setting.model")}
-											items={focusedModelItems}
-											value={selectedModel}
-											held={heldModel}
-											onValueChange={(value) => void changeModel(value)}
-											disabled={settingsDisabled || (focusedModelItems?.length ?? 0) < 2}
-										/>
-										<SettingMenu
-											label={t("admin.agent.setting.thinking")}
-											items={focusedThinkingItems}
-											value={selectedThinking}
-											held={heldThinking}
-											onValueChange={(value) => void changeThinkingLevel(value)}
-											disabled={thinkingDisabled}
-										/>
-									</>
-								) : (
-									<>
-										<div className="kp-agent-chat__setting">
-											<Icon icon={Bot} size={14} />
-											<Select
-												className="kp-agent-chat__setting-select kp-agent-chat__setting-select--model"
-												label={
-													<span className="kp-visually-hidden">
-														{t("admin.agent.select.model")}
-													</span>
-												}
-												items={modelItems ?? []}
-												value={selectedModel ? [selectedModel] : []}
-												onValueChange={(values) => void changeModel(values[0])}
-												placement="top-start"
-												size="sm"
-												disabled={settingsDisabled || (modelItems?.length ?? 0) < 2}
-											/>
-										</div>
-										<div className="kp-agent-chat__setting">
-											<Icon icon={Brain} size={14} />
-											<Select
-												className="kp-agent-chat__setting-select"
-												label={
-													<span className="kp-visually-hidden">
-														{t("admin.agent.select.thinking")}
-													</span>
-												}
-												items={thinkingItems ?? []}
-												value={selectedThinking ? [selectedThinking] : []}
-												placeholder={t(
-													thinkingItems === undefined
-														? "admin.agent.picker.loading"
-														: thinkingItems.length === 0
-															? "admin.agent.picker.empty"
-															: "admin.agent.picker.none",
-												)}
-												onValueChange={(values) => void changeThinkingLevel(values[0])}
-												placement="top-start"
-												size="sm"
-												disabled={thinkingDisabled}
-											/>
-										</div>
-										<div className="kp-agent-chat__setting">
-											<Icon icon={ShieldCheck} size={14} />
-											<Select
-												className="kp-agent-chat__setting-select"
-												label={
-													<span className="kp-visually-hidden">
-														{t("admin.agent.select.trust")}
-													</span>
-												}
-												items={toItems(projectTrustKeys, t)}
-												value={[projectTrust]}
-												onValueChange={(values) => void changeProjectTrust(values[0])}
-												placement="top-start"
-												size="sm"
-												disabled={settingsDisabled}
-											/>
-										</div>
-									</>
-								)}
-								{settings}
-							</fieldset>
-							{variant === "focused" ? (
-								<Menu
-									placement="top-start"
-									ariaLabel={t("admin.agent.settings")}
-									trigger={
-										<Button
-											type="button"
-											variant="tertiary"
-											size="sm"
-											className="kp-agent-chat__resources-button"
-											aria-label={t("admin.agent.resources.label")}
-										>
-											<Icon icon={ShieldCheck} size={14} />
-											{t("admin.agent.resources")}
-										</Button>
-									}
-									items={focusedMenuItems}
-									onSelect={(value) => {
-										if (value === "delivery:steer") setDelivery("steer");
-										if (value === "delivery:follow_up") setDelivery("follow_up");
-										if (value === "trust:approve") void changeProjectTrust("approve");
-										if (value === "trust:no-approve") void changeProjectTrust("no-approve");
-									}}
-								/>
-							) : null}
-						</div>
-						<div className="kp-agent-chat__send-controls">
-							{variant === "harness" ? (
-								<Select
-									className="kp-agent-chat__delivery"
-									label={
-										<span className="kp-visually-hidden">{t("admin.agent.select.delivery")}</span>
-									}
-									items={toItems(deliveryModeKeys, t)}
-									value={[delivery]}
-									onValueChange={(values) => {
-										const nextDelivery = deliveryMode(values[0]);
-										if (nextDelivery) setDelivery(nextDelivery);
-									}}
-									placement="top-end"
-									size="sm"
-								/>
-							) : null}
-							{connection === "working" ? (
-								<Button type="button" variant="tertiary" size="sm" onClick={() => void stop()}>
-									<Icon icon={Square} size={16} /> {t("admin.agent.stop")}
-								</Button>
-							) : null}
-							<Button
-								type="submit"
-								variant="primary"
-								size="sm"
-								disabled={disabled || connection === "loading" || connection === "unavailable"}
-							>
-								{t(
-									variant === "focused" && connection === "working"
-										? focusedDelivery === "steer"
-											? "admin.agent.delivery.steer"
-											: "admin.agent.delivery.followUp"
-										: connection === "working"
-											? "admin.agent.queue"
-											: "admin.agent.send",
-								)}{" "}
-								<Icon icon={SendHorizontal} size={16} />
-							</Button>
-						</div>
-					</div>
+					<AgentChatField />
+					<AgentChatToolbar />
 				</Form>
 
-				{variant === "harness" ? (
-					<p className="kp-agent-chat__hint">
-						<Kbd>Enter</Kbd> {t("admin.agent.hint.send")} · <Kbd>Shift+Enter</Kbd>{" "}
-						{t("admin.agent.hint.newline")} · {commandHint}
-						<Kbd>@</Kbd> {t("admin.agent.hint.file")} · {t("admin.agent.hint.pasteImage")}
-					</p>
-				) : (
-					<p className="kp-agent-chat__hint">
-						{commandHint}
-						<Kbd>@</Kbd> {t("admin.agent.hint.file")} · {t("admin.agent.hint.addOrPasteImage")}
-					</p>
-				)}
+				<AgentChatHint />
 				{error ? (
 					<Alert className="kp-agent-chat__error" variant="danger">
 						{error}
 					</Alert>
 				) : null}
-			</Card>
+			</AgentChatSurface>
 
 			{variant === "focused" ? (
 				<Collapsible
@@ -557,3 +98,9 @@ export function AgentChatInput(props: AgentChatInputProps) {
 }
 
 AgentChatInput.Root = AgentChatInputRoot;
+AgentChatInput.Surface = AgentChatSurface;
+AgentChatInput.Field = AgentChatField;
+AgentChatInput.Toolbar = AgentChatToolbar;
+AgentChatInput.Settings = AgentChatSettings;
+AgentChatInput.Hint = AgentChatHint;
+AgentChatInput.Control = AgentChatControl;

--- a/packages/design/src/agent-chat/Control.tsx
+++ b/packages/design/src/agent-chat/Control.tsx
@@ -1,0 +1,23 @@
+import type {LucideIcon} from "lucide-react";
+import {Button, type ButtonProps} from "../Button";
+import {Icon, type IconSize} from "./Icon";
+
+export interface AgentChatControlProps
+	extends Omit<ButtonProps, "icon" | "variant" | "size" | "type"> {
+	readonly icon: LucideIcon;
+	readonly iconSize?: IconSize;
+}
+
+/**
+ * The one primitive every composer control is built from: a ghost button carrying a glyph, with
+ * whatever label it has as its children. `variant` and `size` are the primitive's, not the call
+ * site's, so a row of controls cannot drift apart one button at a time.
+ */
+export function AgentChatControl({icon, iconSize = 16, children, ...rest}: AgentChatControlProps) {
+	return (
+		<Button {...rest} type="button" variant="tertiary" size="sm">
+			<Icon icon={icon} size={iconSize} />
+			{children}
+		</Button>
+	);
+}

--- a/packages/design/src/agent-chat/Field.tsx
+++ b/packages/design/src/agent-chat/Field.tsx
@@ -1,0 +1,101 @@
+import {FileImage, X} from "lucide-react";
+import {Card} from "../Card";
+import {Textarea} from "../Form";
+import {useDesignT} from "../i18n";
+import {AgentChatControl} from "./Control";
+import {Icon} from "./Icon";
+import {useAgentChatInput} from "./Root";
+import {SuggestionRow} from "./SuggestionRow";
+
+/**
+ * What the operator types into: the attachments they have queued, the prompt textarea, and the
+ * completion listbox the textarea's combobox contract points at.
+ *
+ * The `role="combobox"` on the textarea is what axe reports as disallowed (#7876). It stays as it
+ * is here; changing it is that ticket's.
+ */
+export function AgentChatField() {
+	const {
+		disabled,
+		fieldRef,
+		inputId,
+		suggestionsId,
+		draft,
+		images,
+		suggestions,
+		activeSuggestion,
+		activeSuggestionId,
+		typeDraft,
+		selectSuggestion,
+		removeImage,
+		onPaste,
+		onKeyDown,
+	} = useAgentChatInput();
+	const t = useDesignT();
+
+	return (
+		<>
+			{images.length > 0 ? (
+				<ul className="kp-agent-chat__attachments" aria-label={t("admin.agent.attachments")}>
+					{images.map((image) => (
+						<li key={image.name} className="kp-agent-chat__attachment">
+							<Icon icon={FileImage} size={16} />
+							<span>{image.name}</span>
+							<AgentChatControl
+								icon={X}
+								className="kp-agent-chat__attachment-remove"
+								onClick={() => removeImage(image)}
+							>
+								<span className="kp-visually-hidden">
+									{t("admin.agent.attachment.remove", {name: image.name})}
+								</span>
+							</AgentChatControl>
+						</li>
+					))}
+				</ul>
+			) : null}
+
+			<div className="kp-agent-chat__field">
+				<Textarea
+					ref={fieldRef}
+					id={inputId}
+					className="kp-agent-chat__textarea"
+					role="combobox"
+					aria-autocomplete="list"
+					aria-expanded={suggestions.length > 0}
+					aria-controls={suggestions.length > 0 ? suggestionsId : undefined}
+					aria-activedescendant={activeSuggestionId}
+					label={<span className="kp-visually-hidden">{t("admin.agent.compose.label")}</span>}
+					placeholder={t("admin.agent.compose.placeholder")}
+					value={draft}
+					onChange={(event) => typeDraft(event.currentTarget.value)}
+					onPaste={onPaste}
+					onKeyDown={onKeyDown}
+					rows={3}
+					resize="none"
+					spellCheck
+					fullWidth
+					disabled={disabled}
+				/>
+				{suggestions.length > 0 ? (
+					<Card
+						id={suggestionsId}
+						className="kp-agent-chat__suggestions"
+						role="listbox"
+						aria-label={t("admin.agent.completions")}
+					>
+						{suggestions.map((suggestion, index) => (
+							<SuggestionRow
+								id={`${suggestionsId}-${index}`}
+								key={suggestion.kind === "command" ? suggestion.command.name : suggestion.path}
+								suggestion={suggestion}
+								active={index === activeSuggestion}
+								onSelect={() => selectSuggestion(suggestion)}
+							/>
+						))}
+					</Card>
+				) : null}
+			</div>
+		</>
+	);
+}

--- a/packages/design/src/agent-chat/Hint.tsx
+++ b/packages/design/src/agent-chat/Hint.tsx
@@ -1,0 +1,31 @@
+import {Kbd} from "../atoms";
+import {useDesignT} from "../i18n";
+import {useAgentChatInput} from "./Root";
+
+/** The line under the composer naming what the field accepts. */
+export function AgentChatHint() {
+	const {variant, commands} = useAgentChatInput();
+	const t = useDesignT();
+
+	// A harness that offers no commands does not advertise the sigil: typing `/` against an empty
+	// catalog opens nothing, and a hint promising a picker that never appears reads as a fault.
+	const commandHint =
+		commands.length > 0 ? (
+			<>
+				<Kbd>/</Kbd> {t("admin.agent.hint.command")} ·{" "}
+			</>
+		) : null;
+
+	return variant === "harness" ? (
+		<p className="kp-agent-chat__hint">
+			<Kbd>Enter</Kbd> {t("admin.agent.hint.send")} · <Kbd>Shift+Enter</Kbd>{" "}
+			{t("admin.agent.hint.newline")} · {commandHint}
+			<Kbd>@</Kbd> {t("admin.agent.hint.file")} · {t("admin.agent.hint.pasteImage")}
+		</p>
+	) : (
+		<p className="kp-agent-chat__hint">
+			{commandHint}
+			<Kbd>@</Kbd> {t("admin.agent.hint.file")} · {t("admin.agent.hint.addOrPasteImage")}
+		</p>
+	);
+}

--- a/packages/design/src/agent-chat/Icon.tsx
+++ b/packages/design/src/agent-chat/Icon.tsx
@@ -1,6 +1,6 @@
 import type {LucideIcon} from "lucide-react";
 
-type IconSize = 12 | 14 | 16 | 20 | 24;
+export type IconSize = 12 | 14 | 16 | 20 | 24;
 
 export function Icon({
 	icon: Glyph,

--- a/packages/design/src/agent-chat/Root.test.tsx
+++ b/packages/design/src/agent-chat/Root.test.tsx
@@ -151,6 +151,22 @@ describe("AgentChatInput.Root", () => {
 		logged.mockRestore();
 	});
 
+	// Every part reads Root, so every part is unusable outside one — the primitive `Control` is the
+	// exception on purpose: it takes no state and is a button a host can place anywhere.
+	it.each([
+		["Surface", () => <AgentChatInput.Surface>body</AgentChatInput.Surface>],
+		["Field", () => <AgentChatInput.Field />],
+		["Toolbar", () => <AgentChatInput.Toolbar />],
+		["Settings", () => <AgentChatInput.Settings />],
+		["Hint", () => <AgentChatInput.Hint />],
+	])("refuses %s outside a Root", (_name, Rendered) => {
+		const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		expect(() => render(<Rendered />)).toThrow(
+			"AgentChatInput parts must be rendered inside <AgentChatInput.Root>.",
+		);
+		logged.mockRestore();
+	});
+
 	it("provides its state to a part rendered inside it", () => {
 		render(
 			<AgentChatInput.Root variant="focused">

--- a/packages/design/src/agent-chat/Root.tsx
+++ b/packages/design/src/agent-chat/Root.tsx
@@ -98,7 +98,7 @@ export interface AgentChatInputProps {
  * What Root provides and every composer part reads. Root owns the bridge and the draft; a part is
  * then a component that reads this and returns markup, which is what makes it movable.
  */
-export interface AgentChatInputContextValue {
+export interface AgentChatInputState {
 	readonly disabled: boolean;
 	readonly variant: "harness" | "focused";
 	readonly deliveryRule: AgentChatDeliveryRule;
@@ -115,6 +115,8 @@ export interface AgentChatInputContextValue {
 	readonly thinkingLevels: readonly PiThinkingLevel[] | undefined;
 	readonly projectTrust: PiProjectTrust;
 	readonly settingsChanging: boolean;
+	/** Whether a settings control may be operated: read by the fieldset and by the overflow menu. */
+	readonly settingsDisabled: boolean;
 	readonly images: readonly PiImage[];
 	readonly error: string | undefined;
 	readonly assistantText: string;
@@ -126,6 +128,15 @@ export interface AgentChatInputContextValue {
 	readonly extensionStatus: string | undefined;
 	readonly widget: readonly string[] | undefined;
 	readonly inspectorOpen: boolean;
+}
+
+/**
+ * What a part can ask Root to do. Held apart from the state above only so Root can publish one
+ * identity for the whole set: every entry closes over the current render's state, so rebuilding
+ * the object each render would make the context value change on every keystroke for parts that
+ * read nothing but these.
+ */
+export interface AgentChatInputActions {
 	readonly setInspectorOpen: (open: boolean) => void;
 	readonly setDelivery: (delivery: PiDeliveryMode) => void;
 	/** An edit made in the field: it notifies the consumer and re-opens a dismissed completion. */
@@ -142,6 +153,8 @@ export interface AgentChatInputContextValue {
 	readonly onPaste: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
 	readonly onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
 }
+
+export interface AgentChatInputContextValue extends AgentChatInputState, AgentChatInputActions {}
 
 const AgentChatInputContext = createContext<AgentChatInputContextValue | undefined>(undefined);
 
@@ -312,6 +325,7 @@ export function AgentChatInputRoot({
 	}, [commands, completion, completionDismissed, files]);
 	const activeSuggestionId =
 		suggestions.length > 0 ? `${suggestionsId}-${activeSuggestion}` : undefined;
+	const settingsDisabled = disabled || settingsChanging || connection !== "ready";
 
 	useEffect(() => setActiveSuggestion(0), [completion?.kind, completion?.query]);
 
@@ -662,34 +676,11 @@ export function AgentChatInputRoot({
 		}
 	}
 
-	const value: AgentChatInputContextValue = {
-		disabled,
-		variant,
-		deliveryRule: rule,
-		settings,
-		fieldRef: ref,
-		inputId,
-		suggestionsId,
-		draft,
-		delivery,
-		connection,
-		harnessState: state,
-		commands,
-		models,
-		thinkingLevels,
-		projectTrust,
-		settingsChanging,
-		images,
-		error,
-		assistantText,
-		activities,
-		suggestions,
-		activeSuggestion,
-		activeSuggestionId,
-		extension,
-		extensionStatus,
-		widget,
-		inspectorOpen,
+	// Every handler above closes over this render's state, so publishing them directly would hand
+	// each part a new context value on every keystroke. The stable object below forwards into the
+	// current render's handler through a ref, which is what lets the value memo hold across a
+	// re-render that changed nothing a part reads.
+	const handlers: AgentChatInputActions = {
 		setInspectorOpen,
 		setDelivery,
 		typeDraft,
@@ -705,6 +696,92 @@ export function AgentChatInputRoot({
 		onPaste,
 		onKeyDown,
 	};
+	const handlersRef = useRef(handlers);
+	handlersRef.current = handlers;
+	const actions = useMemo<AgentChatInputActions>(
+		() => ({
+			setInspectorOpen: (open) => handlersRef.current.setInspectorOpen(open),
+			setDelivery: (mode) => handlersRef.current.setDelivery(mode),
+			typeDraft: (value) => handlersRef.current.typeDraft(value),
+			selectSuggestion: (suggestion) => handlersRef.current.selectSuggestion(suggestion),
+			removeImage: (image) => handlersRef.current.removeImage(image),
+			addImage: (file) => handlersRef.current.addImage(file),
+			submit: () => handlersRef.current.submit(),
+			stop: () => handlersRef.current.stop(),
+			changeModel: (value) => handlersRef.current.changeModel(value),
+			changeThinkingLevel: (value) => handlersRef.current.changeThinkingLevel(value),
+			changeProjectTrust: (value) => handlersRef.current.changeProjectTrust(value),
+			answerExtension: (answer) => handlersRef.current.answerExtension(answer),
+			onPaste: (event) => handlersRef.current.onPaste(event),
+			onKeyDown: (event) => handlersRef.current.onKeyDown(event),
+		}),
+		[],
+	);
+
+	const value = useMemo<AgentChatInputContextValue>(
+		() => ({
+			disabled,
+			variant,
+			deliveryRule: rule,
+			settings,
+			fieldRef: ref,
+			inputId,
+			suggestionsId,
+			draft,
+			delivery,
+			connection,
+			harnessState: state,
+			commands,
+			models,
+			thinkingLevels,
+			projectTrust,
+			settingsChanging,
+			settingsDisabled,
+			images,
+			error,
+			assistantText,
+			activities,
+			suggestions,
+			activeSuggestion,
+			activeSuggestionId,
+			extension,
+			extensionStatus,
+			widget,
+			inspectorOpen,
+			...actions,
+		}),
+		[
+			actions,
+			activeSuggestion,
+			activeSuggestionId,
+			activities,
+			assistantText,
+			commands,
+			connection,
+			delivery,
+			disabled,
+			draft,
+			error,
+			extension,
+			extensionStatus,
+			images,
+			inputId,
+			inspectorOpen,
+			models,
+			projectTrust,
+			ref,
+			rule,
+			settings,
+			settingsChanging,
+			settingsDisabled,
+			state,
+			suggestions,
+			suggestionsId,
+			thinkingLevels,
+			variant,
+			widget,
+		],
+	);
 
 	return <AgentChatInputContext.Provider value={value}>{children}</AgentChatInputContext.Provider>;
 }

--- a/packages/design/src/agent-chat/Settings.tsx
+++ b/packages/design/src/agent-chat/Settings.tsx
@@ -1,0 +1,191 @@
+import {Bot, Brain, ShieldCheck} from "lucide-react";
+import {type ReactNode, useMemo} from "react";
+import {useDesignT} from "../i18n";
+import {Select, type SelectItem} from "../Select";
+import {projectTrustKeys, thinkingLevelIcons, thinkingLevelKeys, toItems} from "./catalog";
+import {Icon} from "./Icon";
+import {
+	modelName,
+	modelValue,
+	providersCollide,
+	selectedModelValue,
+	thinkingLevelValue,
+} from "./parse";
+import {useAgentChatInput} from "./Root";
+import {type PickerItem, SettingMenu} from "./SettingMenu";
+
+/**
+ * The composer's settings fieldset — model, thinking effort and, on the harness variant, project
+ * trust.
+ *
+ * With no children it renders the controls this component owns followed by the host's `settings`
+ * slot, which is what the exported composer assembles. Children replace those controls, for a host
+ * that wants the fieldset with a row set of its own; the slot is untouched either way.
+ */
+export function AgentChatSettings({children}: {readonly children?: ReactNode}) {
+	const {
+		variant,
+		settings,
+		harnessState: state,
+		models,
+		thinkingLevels,
+		projectTrust,
+		settingsDisabled,
+		changeModel,
+		changeThinkingLevel,
+		changeProjectTrust,
+	} = useAgentChatInput();
+	const t = useDesignT();
+
+	// Manti's `SelectItem.label` is `string`, and the select collection stringifies it for typeahead
+	// (`itemToString: (item) => item.label`), so this list carries the provider in the label itself
+	// while the Menu-backed picker below renders it as its own dimmed span. See #8065.
+	// Each list stays `undefined` while its offer is unresolved, so the pickers are handed the same
+	// three-way answer the bridge gave rather than a flattened array (#8425).
+	const modelItems = useMemo<SelectItem[] | undefined>(
+		() =>
+			models?.map((candidate) => ({
+				value: modelValue(candidate),
+				label: providersCollide(models)
+					? `${candidate.name} (${candidate.provider})`
+					: candidate.name,
+			})),
+		[models],
+	);
+	const thinkingItems = useMemo<SelectItem[] | undefined>(
+		() => thinkingLevels?.map((level) => ({value: level, label: t(thinkingLevelKeys[level])})),
+		[thinkingLevels, t],
+	);
+	const focusedModelItems = useMemo<PickerItem[] | undefined>(
+		() =>
+			models?.map((candidate) => ({
+				value: modelValue(candidate),
+				label: candidate.name,
+				...(providersCollide(models) ? {note: candidate.provider} : {}),
+			})),
+		[models],
+	);
+	const focusedThinkingItems = useMemo<PickerItem[] | undefined>(
+		() =>
+			thinkingLevels?.map((level) => ({
+				value: level,
+				label: t(thinkingLevelKeys[level]),
+				icon: thinkingLevelIcons[level],
+			})),
+		[thinkingLevels, t],
+	);
+	// The host's own answer and nothing else. Falling back to the first row named a model nobody
+	// picked as the one the session runs on, and a picker opened with that row already checked read
+	// as a choice already made (#8573).
+	const selectedModel = selectedModelValue(state);
+	const stateThinking = thinkingLevelValue(state?.thinkingLevel);
+	const selectedThinking = stateThinking !== "off" ? stateThinking : undefined;
+	// Each selection as a row of its own, for the picker to name when the offer carries no row for
+	// it — the pick an operator holds while no session's catalog is live (#8542).
+	const heldModel = useMemo<PickerItem | undefined>(() => {
+		const name = modelName(state);
+		return selectedModel && name ? {value: selectedModel, label: name} : undefined;
+	}, [selectedModel, state]);
+	const heldThinking = useMemo<PickerItem | undefined>(
+		() =>
+			selectedThinking === undefined
+				? undefined
+				: {
+						value: selectedThinking,
+						label: t(thinkingLevelKeys[selectedThinking]),
+						icon: thinkingLevelIcons[selectedThinking],
+					},
+		[selectedThinking, t],
+	);
+	const offeredThinking = thinkingItems?.length ?? 0;
+	const thinkingDisabled =
+		settingsDisabled ||
+		offeredThinking === 0 ||
+		(offeredThinking === 1 && selectedThinking !== undefined);
+
+	return (
+		<fieldset className="kp-agent-chat__settings">
+			<legend className="kp-visually-hidden">{t("admin.agent.settings")}</legend>
+			{children ?? (
+				<>
+					{variant === "focused" ? (
+						<>
+							<SettingMenu
+								label={t("admin.agent.setting.model")}
+								items={focusedModelItems}
+								value={selectedModel}
+								held={heldModel}
+								onValueChange={(value) => void changeModel(value)}
+								disabled={settingsDisabled || (focusedModelItems?.length ?? 0) < 2}
+							/>
+							<SettingMenu
+								label={t("admin.agent.setting.thinking")}
+								items={focusedThinkingItems}
+								value={selectedThinking}
+								held={heldThinking}
+								onValueChange={(value) => void changeThinkingLevel(value)}
+								disabled={thinkingDisabled}
+							/>
+						</>
+					) : (
+						<>
+							<div className="kp-agent-chat__setting">
+								<Icon icon={Bot} size={14} />
+								<Select
+									className="kp-agent-chat__setting-select kp-agent-chat__setting-select--model"
+									label={
+										<span className="kp-visually-hidden">{t("admin.agent.select.model")}</span>
+									}
+									items={modelItems ?? []}
+									value={selectedModel ? [selectedModel] : []}
+									onValueChange={(values) => void changeModel(values[0])}
+									placement="top-start"
+									size="sm"
+									disabled={settingsDisabled || (modelItems?.length ?? 0) < 2}
+								/>
+							</div>
+							<div className="kp-agent-chat__setting">
+								<Icon icon={Brain} size={14} />
+								<Select
+									className="kp-agent-chat__setting-select"
+									label={
+										<span className="kp-visually-hidden">{t("admin.agent.select.thinking")}</span>
+									}
+									items={thinkingItems ?? []}
+									value={selectedThinking ? [selectedThinking] : []}
+									placeholder={t(
+										thinkingItems === undefined
+											? "admin.agent.picker.loading"
+											: thinkingItems.length === 0
+												? "admin.agent.picker.empty"
+												: "admin.agent.picker.none",
+									)}
+									onValueChange={(values) => void changeThinkingLevel(values[0])}
+									placement="top-start"
+									size="sm"
+									disabled={thinkingDisabled}
+								/>
+							</div>
+							<div className="kp-agent-chat__setting">
+								<Icon icon={ShieldCheck} size={14} />
+								<Select
+									className="kp-agent-chat__setting-select"
+									label={
+										<span className="kp-visually-hidden">{t("admin.agent.select.trust")}</span>
+									}
+									items={toItems(projectTrustKeys, t)}
+									value={[projectTrust]}
+									onValueChange={(values) => void changeProjectTrust(values[0])}
+									placement="top-start"
+									size="sm"
+									disabled={settingsDisabled}
+								/>
+							</div>
+						</>
+					)}
+					{settings}
+				</>
+			)}
+		</fieldset>
+	);
+}

--- a/packages/design/src/agent-chat/Surface.tsx
+++ b/packages/design/src/agent-chat/Surface.tsx
@@ -1,0 +1,40 @@
+import type {ReactNode} from "react";
+import {Card} from "../Card";
+import {useDesignT} from "../i18n";
+import {runningModelLabel} from "./parse";
+import {useAgentChatInput} from "./Root";
+
+/**
+ * The composer's frame: the card everything else sits in, and the status row that names the
+ * connection above it.
+ */
+export function AgentChatSurface({children}: {readonly children: ReactNode}) {
+	const {variant, connection, harnessState, models, extensionStatus} = useAgentChatInput();
+	const t = useDesignT();
+	const model = runningModelLabel(harnessState, models ?? []);
+	const status =
+		connection === "loading"
+			? t("admin.agent.status.loading")
+			: connection === "working"
+				? t("admin.agent.status.working")
+				: connection === "ready"
+					? model
+						? t("admin.agent.status.readyWithModel", {model})
+						: t("admin.agent.status.ready")
+					: t("admin.agent.status.unavailable");
+
+	return (
+		<Card className="kp-agent-chat__composer" data-testid="agent-chat-input">
+			{variant === "harness" ? (
+				<div className="kp-agent-chat__status-row">
+					<p className="kp-agent-chat__status" aria-live="polite">
+						{status}
+						{extensionStatus ? ` · ${extensionStatus}` : ""}
+					</p>
+					<p className="kp-agent-chat__scope">{t("admin.agent.scope")}</p>
+				</div>
+			) : null}
+			{children}
+		</Card>
+	);
+}

--- a/packages/design/src/agent-chat/Toolbar.tsx
+++ b/packages/design/src/agent-chat/Toolbar.tsx
@@ -1,0 +1,175 @@
+import {Paperclip, SendHorizontal, ShieldCheck, Square} from "lucide-react";
+import {useRef} from "react";
+import {Button} from "../Button";
+import {Input} from "../Form";
+import {useDesignT} from "../i18n";
+import {Menu, type MenuItem} from "../Menu";
+import {Select} from "../Select";
+import {AgentChatControl} from "./Control";
+import {deliveryModeKeys, toItems} from "./catalog";
+import {Icon} from "./Icon";
+import {deliveryMode} from "./parse";
+import {useAgentChatInput} from "./Root";
+import {AgentChatSettings} from "./Settings";
+
+/**
+ * The control row under the field: what the operator can attach and configure on the left, and how
+ * a draft leaves the composer on the right.
+ */
+export function AgentChatToolbar() {
+	const {
+		disabled,
+		variant,
+		delivery,
+		connection,
+		projectTrust,
+		settingsDisabled,
+		setDelivery,
+		addImage,
+		stop,
+		changeProjectTrust,
+	} = useAgentChatInput();
+	const t = useDesignT();
+	const imageInputRef = useRef<HTMLInputElement>(null);
+
+	const focusedDelivery =
+		connection === "working" ? (delivery === "prompt" ? "follow_up" : delivery) : "prompt";
+	const focusedMenuItems: MenuItem[] = [
+		...(connection === "working"
+			? [
+					{
+						type: "group" as const,
+						label: t("admin.agent.menu.streaming"),
+						items: [
+							{
+								type: "radio" as const,
+								value: "delivery:steer",
+								label: t("admin.agent.delivery.steer"),
+								checked: focusedDelivery === "steer",
+							},
+							{
+								type: "radio" as const,
+								value: "delivery:follow_up",
+								label: t("admin.agent.delivery.followUp"),
+								checked: focusedDelivery === "follow_up",
+							},
+						],
+					},
+					{type: "separator" as const},
+				]
+			: []),
+		{
+			type: "group",
+			label: t("admin.agent.menu.projectResources"),
+			items: [
+				{
+					type: "radio",
+					value: "trust:approve",
+					label: t("admin.agent.trust.load"),
+					checked: projectTrust === "approve",
+					disabled: settingsDisabled,
+				},
+				{
+					type: "radio",
+					value: "trust:no-approve",
+					label: t("admin.agent.trust.skip"),
+					checked: projectTrust === "no-approve",
+					disabled: settingsDisabled,
+				},
+			],
+		},
+	];
+
+	return (
+		<div className="kp-agent-chat__actions">
+			<div className="kp-agent-chat__primary-controls">
+				{variant === "focused" ? (
+					<>
+						<Input
+							ref={imageInputRef}
+							className="kp-visually-hidden"
+							label={t("admin.agent.image.add")}
+							type="file"
+							accept="image/*"
+							tabIndex={-1}
+							onChange={(event) => {
+								void addImage(event.currentTarget.files?.[0]);
+								event.currentTarget.value = "";
+							}}
+						/>
+						<AgentChatControl
+							icon={Paperclip}
+							className="kp-agent-chat__icon-button"
+							aria-label={t("admin.agent.image.add")}
+							onClick={() => imageInputRef.current?.click()}
+							disabled={disabled}
+						/>
+					</>
+				) : null}
+				<AgentChatSettings />
+				{variant === "focused" ? (
+					<Menu
+						placement="top-start"
+						ariaLabel={t("admin.agent.settings")}
+						trigger={
+							<AgentChatControl
+								icon={ShieldCheck}
+								iconSize={14}
+								className="kp-agent-chat__resources-button"
+								aria-label={t("admin.agent.resources.label")}
+							>
+								{t("admin.agent.resources")}
+							</AgentChatControl>
+						}
+						items={focusedMenuItems}
+						onSelect={(value) => {
+							if (value === "delivery:steer") setDelivery("steer");
+							if (value === "delivery:follow_up") setDelivery("follow_up");
+							if (value === "trust:approve") void changeProjectTrust("approve");
+							if (value === "trust:no-approve") void changeProjectTrust("no-approve");
+						}}
+					/>
+				) : null}
+			</div>
+			<div className="kp-agent-chat__send-controls">
+				{variant === "harness" ? (
+					<Select
+						className="kp-agent-chat__delivery"
+						label={<span className="kp-visually-hidden">{t("admin.agent.select.delivery")}</span>}
+						items={toItems(deliveryModeKeys, t)}
+						value={[delivery]}
+						onValueChange={(values) => {
+							const nextDelivery = deliveryMode(values[0]);
+							if (nextDelivery) setDelivery(nextDelivery);
+						}}
+						placement="top-end"
+						size="sm"
+					/>
+				) : null}
+				{connection === "working" ? (
+					<AgentChatControl icon={Square} onClick={() => void stop()}>
+						{" "}
+						{t("admin.agent.stop")}
+					</AgentChatControl>
+				) : null}
+				<Button
+					type="submit"
+					variant="primary"
+					size="sm"
+					disabled={disabled || connection === "loading" || connection === "unavailable"}
+				>
+					{t(
+						variant === "focused" && connection === "working"
+							? focusedDelivery === "steer"
+								? "admin.agent.delivery.steer"
+								: "admin.agent.delivery.followUp"
+							: connection === "working"
+								? "admin.agent.queue"
+								: "admin.agent.send",
+					)}{" "}
+					<Icon icon={SendHorizontal} size={16} />
+				</Button>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
The composer's layout is now six named parts a host can rearrange:

- **`.Surface`** — the `kp-agent-chat__composer` card and the harness status row above it.
- **`.Field`** — the attachments list, the prompt textarea and the completion listbox, with the
  paste and keydown handling that goes with them.
- **`.Toolbar`** — the `kp-agent-chat__actions` row: attach, settings, the overflow menu, the
  delivery picker, stop and send.
- **`.Settings`** — the settings fieldset. With no children it renders the controls the component
  owns followed by the `settings` slot; with children, those children stand in for the owned
  controls and the slot is untouched either way.
- **`.Hint`** — the hint line under the composer.
- **`.Control`** — the ghost `Button` at `size="sm"` with a glyph slot that every composer control
  is now built from (attachment-remove, attach, the resources trigger, stop). `variant` and `size`
  belong to the primitive, not the call site, so a row of controls cannot drift apart one button at
  a time. T3 Code's `ComposerControl` is the lineage; none of its glass styling came with it.

The first five read the Root context from #8674 and take no state props. `.Control` is the
primitive they are built from and reads nothing — disclosed below.

Per the ruling on #8670 (R1.1, @usirin 2026-09-09, "compound, go") each is a static on the existing
export, so `index.ts` is untouched and grows nothing. The exported `AgentChatInput` is now the Root
wrapping a body that assembles those parts in today's order; the `<section>` wrapper, the inspector,
the activity list and the extension dialog stay in that body, and the `<Form>` stays there too —
neither is a part any consumer has asked for yet.

**Same DOM, proved rather than asserted.** A new case renders the plain export, unmounts it, renders
the same composer hand-assembled from `.Surface` / `.Field` / `.Toolbar` / `.Hint` inside a
`.Root`, and compares the composer card's markup with every generated id blanked — React's `useId`
and Manti's own `data-uid` both count up per render. It runs for both `variant` values, and both
sides are read only after the catalog has landed: the four bridge loads paint the model and thinking
labels last, so `settledComposerMarkup` waits on those before reading either tree.

**Context value stability.** #8687's review flagged that Root's context value was a fresh object
every render and that it becomes a real question the moment Root has sibling parts. It has them now,
so `Root.tsx` splits the value's type into `AgentChatInputState` and `AgentChatInputActions`, holds
one stable actions object that forwards into the current render's handler through a ref, and wraps
the published value in a `useMemo` over the state it carries. `AgentChatInputContextValue` still
extends both, so `useAgentChatInput()` and every reader see exactly the surface they saw before.

**Grounding.** React 19.2.6's `useMemo` / `useRef` contract is the documented one; nothing here
relies on a behaviour outside it. The `role="combobox"` axe reports as disallowed (#7876) moved into
`.Field` byte-identical — fixing it is that ticket's.

**Checks.** `AgentChatInput.test.tsx` 30 passed (25 before, 5 added, no assertion edited),
`agent-chat/Root.test.tsx` 34, `kp-class-coverage` green with no `kp-agent-chat*` name changed,
`packages/design` `test:a11y` 23, `apps/tuval` `src/shell/chat` 451. `build check --surface code` is
green on `pnpm typecheck:affected` + `pnpm lint:worktree`. No consumer, no `index.ts`, no CSS in the
diff — the five `var(--tap-min)` rules stand untouched.

Part of #8668. Fixes #8676

## Deviations

- **Out-of-scope change** — **Said:** criterion 1 lists six parts and says each reads the Root
  context rather than taking state props. **Did:** shipped `.Control` as a pure props component: it
  reads no context, and `.Toolbar` hands it `disabled` out of Root. **Why:** the issue itself
  defines `.Control` as "the one primitive every composer control is built from — a ghost `Button`
  at `size="sm"`, with an icon slot", which has no session state to read; subscribing a button to
  Root would tie a primitive a host can place anywhere to a provider it does not need.
  **Disposition:** stated here, and pinned in code — `Root.test.tsx`'s `it.each` asserts the five
  context-reading parts throw outside a Root and names `Control` as the deliberate exception.
- **Out-of-scope change** — **Said:** #8676 names the six parts and says each reads the Root
  context. **Did:** also added a derived `settingsDisabled` to that context, and split the context
  value's type into `AgentChatInputState` + `AgentChatInputActions` with a stable actions object
  behind a ref. **Why:** `disabled || settingsChanging || connection !== "ready"` is read by both
  `.Settings` and `.Toolbar`, and computing it twice would put one domain rule in two parts; the
  type split plus the ref is what makes the `useMemo` the #8687 reviewer asked for actually hold,
  since every handler closes over the current render's state. **Disposition:** stated here;
  `AgentChatInputContextValue` extends both halves, so no reader's surface changed.
- **Scope narrowing** — **Said:** the reviewer on #8687 offered "a `useMemo` or a value split".
  **Did:** the memo and a state/actions type split, but not a split into separate contexts a part
  subscribes to selectively. **Why:** every part reads session state as well as actions, so a
  finer split buys nothing today, and a narrower per-concern reader hook would be a parts API
  invented ahead of a caller — one of the epic's own no-gos. #8669 changes the layout, which is
  when a caller for it would show up. **Disposition:** stated here; the memo holds the value across
  a re-render that changed nothing a part reads, which is the case that existed to be fixed.
- **Pre-existing test or fixture changed** — **Said:** `AgentChatInput.test.tsx` passes with no
  edited assertions; the PR only adds cases. **Did:** added one import line to that file
  (`useAgentChatInput`, `Form`) alongside the new cases. **Why:** the composition case has to reach
  Root's context to wire the form's `onSubmit`. **Disposition:** stated here; no existing case,
  assertion or helper was edited.
