### PR TITLE
fix: The running-subagent status line doubles the word when the worker has no name

### DIFF
--- a/apps/tuval/src/ai-agent/ports/subagent.ts
+++ b/apps/tuval/src/ai-agent/ports/subagent.ts
@@ -35,8 +35,13 @@ export type SubagentStatus = "running" | "finished";
 export interface SubagentSlot {
 	/** The spawning call's item id: one tool row, one worker, one slot. */
 	readonly id: ItemId;
-	/** What kind of worker this is, in the backend's own words — a label, never a type tag. */
-	readonly type: string;
+	/**
+	 * What kind of worker this is, in the backend's own words — a label, never a type tag. `null`
+	 * means no name is known: the spawning call named none and nothing resolved one. An empty string
+	 * is not that fact and stays refused, so a surface can phrase the nameless row once instead of
+	 * reading a placeholder back out (#8680).
+	 */
+	readonly type: string | null;
 	/** The newest line the worker wrote, whatever kind of item carried it. */
 	readonly lastLine: string;
 	/** Epoch milliseconds, so the window computes elapsed without a backend clock type. */
@@ -57,7 +62,7 @@ export const isSubagentSlot = (value: unknown): value is SubagentSlot =>
 	Predicate.isObject(value) &&
 	typeof value.id === "string" &&
 	value.id.length > 0 &&
-	typeof value.type === "string" &&
+	(value.type === null || (typeof value.type === "string" && value.type.length > 0)) &&
 	typeof value.lastLine === "string" &&
 	Number.isFinite(value.startedAt) &&
 	isNonNegativeInteger(value.tokens) &&

--- a/apps/tuval/src/ai-agent/ports/subagent.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/subagent.unit.test.ts
@@ -39,6 +39,9 @@ describe("a subagent slot", () => {
 		expect(isSubagentSlot({...slot, id: 7})).toBe(false);
 		expect(isSubagentSlot({...slot, id: ""})).toBe(false);
 		expect(isSubagentSlot({...slot, type: {name: "general-purpose"}})).toBe(false);
+		// An unnamed worker and a worker named "" are different facts, and only the first is a slot.
+		expect(isSubagentSlot({...slot, type: null})).toBe(true);
+		expect(isSubagentSlot({...slot, type: ""})).toBe(false);
 		expect(isSubagentSlot({...slot, lastLine: null})).toBe(false);
 		expect(isSubagentSlot({...slot, startedAt: "2026-09-07"})).toBe(false);
 		expect(isSubagentSlot({...slot, startedAt: Number.NaN})).toBe(false);

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -191,9 +191,6 @@ const namedAgent = (input: unknown): string | null => {
 	return typeof agent === "string" && agent !== "" ? agent : null;
 };
 
-/** What the row is labelled once nothing better is left: the tool's own name. */
-const subagentType = (agent: string | null): string => agent ?? "subagent";
-
 /**
  * Whether the call detached. A detached run emits no `tool_execution_update`, so its row carries no
  * run id and the tool-call index is the only address it has (`async-spawn.ts`) — which is why it is
@@ -293,7 +290,7 @@ const childItems = (id: ItemId, child: ChildTranscript): ReadonlyArray<Transcrip
 /** A still-running worker's slot, off its own artifact — the shape both folds below agree on. */
 const runningSlotOf = (spawn: RunningSpawn, child: ChildTranscript): SubagentSlot => ({
 	id: spawn.id,
-	type: subagentType(spawn.agent ?? spawn.resolved?.agent ?? null),
+	type: spawn.agent ?? spawn.resolved?.agent ?? null,
 	lastLine: child.lastLine,
 	startedAt: spawn.startedAt,
 	tokens: countOf(child.tokens),
@@ -345,9 +342,7 @@ export const subagentSlotsOf = (
 				? [
 						{
 							id: itemId(part.toolCallId),
-							type: subagentType(
-								namedAgent(part.input) ?? held?.get(part.toolCallId)?.resolved?.agent ?? null,
-							),
+							type: namedAgent(part.input) ?? held?.get(part.toolCallId)?.resolved?.agent ?? null,
 							lastLine: "",
 							startedAt: item.timestamp,
 							tokens: 0,
@@ -367,7 +362,7 @@ export const subagentSlotsOf = (
 			return [
 				{
 					id,
-					type: subagentType(namedAgent(item.input)),
+					type: namedAgent(item.input),
 					lastLine: "",
 					startedAt: item.timestamp,
 					tokens: 0,
@@ -385,7 +380,7 @@ export const subagentSlotsOf = (
 	return [
 		{
 			id,
-			type: subagentType(namedAgent(item.input) ?? carried?.resolved?.agent ?? null),
+			type: namedAgent(item.input) ?? carried?.resolved?.agent ?? null,
 			lastLine: child?.lastLine || lastLineOf(boundToolResult(textOf(item.content)).text),
 			startedAt: item.timestamp,
 			// The child's own spend where the artifact reported one, else what the result says it

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -656,12 +656,12 @@ describe("a subagent's start and end over the delta stream", () => {
 		expect(folded.events.some((event) => event.kind === "subagent")).toBe(false);
 	});
 
-	it("labels a spawn that names no agent by the tool that made it", () => {
+	it("leaves a spawn that names no agent unnamed rather than stamping a placeholder", () => {
 		const script: PiTranscriptItem = {...finished, input: {workflowScript: "runs.run('a', {})"}};
 		const folded = deltaEventsOf(opened().next, delta([script], 2));
 		const slots = folded.events.filter((event) => event.kind === "subagent");
 		expect(slots).toHaveLength(1);
-		expect(slots[0]?.slot.type).toBe("subagent");
+		expect(slots[0]?.slot.type).toBeNull();
 	});
 
 	// `subagent` is one multiplexed tool: with an `action` it manages rather than spawns, and the
@@ -1147,7 +1147,7 @@ describe("a detached subagent filled through the tool-call index", () => {
 			kind: "subagent",
 			slot: {
 				id: "call-async",
-				type: "subagent",
+				type: null,
 				lastLine: "",
 				startedAt: 21,
 				tokens: 0,
@@ -1271,6 +1271,18 @@ describe("a detached subagent filled through the tool-call index", () => {
 			runIds: ["worker-1"],
 			agent: "builder",
 		});
+	});
+
+	// #8680: the call named none and the steps report none either, so there is no name to draw and
+	// the row says so — the sentences read it as an absence rather than as a worker called
+	// "subagent".
+	it("stays unnamed when neither the call nor its resolved steps name an agent", () => {
+		const nameless = new Map([["call-async", {runIds: ["worker-1"], agent: null}]]);
+		expect(
+			childEventsOf(opened.next, new Map([["worker-1", child]]), nameless).events.map(
+				(event) => event.kind === "subagent" && event.slot.type,
+			),
+		).toEqual([null]);
 	});
 
 	it("keeps the agent the call named over the one its steps report", () => {

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -70,6 +70,7 @@ import {
 } from "./rows.ts";
 import {SessionRow} from "./SessionRow.tsx";
 import {SubagentList, type SubagentListHandle} from "./SubagentList.tsx";
+import {subagentPhrase} from "./subagents.ts";
 import {ThinkingRow} from "./ThinkingRow.tsx";
 import {type ToolFold, ToolRow} from "./ToolRow.tsx";
 import {ToolRunRow} from "./ToolRunRow.tsx";
@@ -1118,8 +1119,8 @@ function ChatWindow({
 									? "Showing the agent's own transcript."
 									: "Showing a subagent whose transcript is not in this session's state."
 								: viewedSlot.status === "finished"
-									? `Showing the ${viewedSlot.type} subagent's transcript. Finished: ${viewedSlot.lastLine}`
-									: `Showing the ${viewedSlot.type} subagent's transcript. Still running.`}
+									? `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Finished: ${viewedSlot.lastLine}`
+									: `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Still running.`}
 						</p>
 					</>
 				) : null}
@@ -1131,7 +1132,9 @@ function ChatWindow({
 					role="log"
 					data-view={viewing === null ? undefined : viewing.id}
 					aria-label={
-						viewedSlot === undefined ? "Transcript" : `Transcript: ${viewedSlot.type} subagent`
+						viewedSlot === undefined
+							? "Transcript"
+							: `Transcript: ${subagentPhrase(viewedSlot.type)}`
 					}
 					// The scroll container is the only way to older turns on a plain transcript, so a
 					// keyboard user must be able to focus it (axe scrollable-region-focusable).
@@ -1193,7 +1196,7 @@ function ChatWindow({
 								{viewedSlot.lastLine}
 							</>
 						) : (
-							`The ${viewedSlot.type} subagent is still running.`
+							`The ${subagentPhrase(viewedSlot.type)} is still running.`
 						)}
 					</p>
 				)}

--- a/apps/tuval/src/shell/chat/SubagentList.tsx
+++ b/apps/tuval/src/shell/chat/SubagentList.tsx
@@ -107,10 +107,15 @@ function Line({
 function RowFields({row, at}: {readonly row: SubagentRow; readonly at: number}): ReactElement {
 	return (
 		<MetaRow as="span" className="tuval-chat-subagent">
-			<span className="tuval-chat-subagent-type" data-field="type">
-				{row.type}
-			</span>
-			<MetaRow.Dot />
+			{/* A row whose worker named itself nothing draws no name field — and no dot for one. */}
+			{row.type === null ? null : (
+				<>
+					<span className="tuval-chat-subagent-type" data-field="type">
+						{row.type}
+					</span>
+					<MetaRow.Dot />
+				</>
+			)}
 			<span className="tuval-chat-subagent-line" data-field="line">
 				{row.lastLine}
 			</span>

--- a/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
@@ -525,3 +525,64 @@ describe("a notice naming a worker", () => {
 		rendered.unmount();
 	});
 });
+
+/**
+ * #8680: three sentences and one list field name the worker, and all three sentences already carry
+ * the word "subagent". A slot whose call named no agent and whose steps resolved none has
+ * `type: null`, and each surface phrases that absence instead of reading a placeholder back out.
+ */
+describe("naming the worker a view is open on", () => {
+	const nameless = () =>
+		subagentSlot("agent", {type: null, items: reviewerItems, lastLine: "wrote 4 rows"});
+
+	const openOnFirstRow = async (slot: SubagentSlot) => {
+		const opened = await openOne(agentSession(slot), {}, atOldest());
+		await act(async () => {
+			dom(opened.rendered.container).picks()[0]?.click();
+		});
+		return opened;
+	};
+
+	// The window draws a second `role="status"` for the turn phase, so this is scoped to the one
+	// that sits under the navigator — the view slot's own live region.
+	const status = (root: ParentNode) =>
+		root.querySelector<HTMLElement>('.tuval-chat-subagents + p[role="status"]')?.textContent ?? "";
+
+	const typeField = (root: ParentNode) =>
+		root.querySelector<HTMLElement>('.tuval-chat-subagent-type[data-field="type"]');
+
+	it("says the word once when no name is known", async () => {
+		const {rendered} = await openOnFirstRow(nameless());
+		const root = rendered.container;
+
+		expect(dom(root).end()).toBe("The subagent is still running.");
+		expect(status(root)).toBe("Showing the subagent's transcript. Still running.");
+		expect(within(root).getByRole("log", {name: "Transcript: subagent"})).toBeTruthy();
+		rendered.unmount();
+	});
+
+	it("draws no name field in the navigator row for that worker", async () => {
+		const {rendered} = await openOne(agentSession(nameless()), {}, atOldest());
+		const root = rendered.container;
+
+		expect(typeField(root)).toBeNull();
+		expect(dom(root).picks()[0]?.textContent).toContain("wrote 4 rows");
+		rendered.unmount();
+	});
+
+	it("keeps a named worker's phrasing on every one of those surfaces", async () => {
+		const named = subagentSlot("agent", {
+			type: "builder",
+			items: reviewerItems,
+			lastLine: "wrote 4 rows",
+		});
+		const {rendered} = await openOnFirstRow(named);
+		const root = rendered.container;
+
+		expect(dom(root).end()).toBe("The builder subagent is still running.");
+		expect(status(root)).toBe("Showing the builder subagent's transcript. Still running.");
+		expect(within(root).getByRole("log", {name: "Transcript: builder subagent"})).toBeTruthy();
+		expect(typeField(root)?.textContent).toBe("builder");
+		rendered.unmount();
+	});
+});

--- a/apps/tuval/src/shell/chat/subagents.ts
+++ b/apps/tuval/src/shell/chat/subagents.ts
@@ -17,9 +17,18 @@ import type {ItemId, SubagentSlot, SubagentStatus} from "../../ai-agent/ports/in
 /** How many rows the list shows before the tail collapses into one "more" row (Q3). */
 export const SUBAGENT_ROW_CAP = 5;
 
+/**
+ * How a worker is named inside a sentence that already says "subagent" — the slot's own label, or
+ * the bare word when no name is known. One phrase for the footer, the live region and the
+ * transcript label, so none of them can double the word (#8680).
+ */
+export const subagentPhrase = (type: string | null): string =>
+	type === null ? "subagent" : `${type} subagent`;
+
 export interface SubagentRow {
 	readonly id: ItemId;
-	readonly type: string;
+	/** The slot's label as-is, `null` included: a row with no name draws none. */
+	readonly type: string | null;
 	readonly lastLine: string;
 	/** Epoch milliseconds, so the row's elapsed is the reader's own clock minus this. */
 	readonly startedAt: number;


### PR DESCRIPTION
The subagent view said "The subagent subagent is still running." when the spawning call named no
agent. `subagentType` in `apps/tuval/src/pi/ai-agent/items.ts` stamped the literal `"subagent"` as
the label of last resort, and three sentences in `ChatWindow.tsx` composed that label into a phrase
that already ends in the word. #8684 narrowed the fallback by naming a row off its resolved workers;
it did not remove it.

`SubagentSlot.type` is now `string | null`, so "no name is known" is a state the port can hold
rather than a placeholder every reader has to see through. `isSubagentSlot` accepts `null` and now
rejects an empty string too — an unnamed worker and a worker named `""` are different facts, and the
guard used to admit both. `subagentType` is gone; the four slot-construction sites pass the resolved
name or `null` through unchanged. `SubagentRow.type` widens with it.

One helper phrases the absence: `subagentPhrase` in `shell/chat/subagents.ts` returns `"subagent"`
for `null` and `"<name> subagent"` otherwise, and the footer, the hidden `role="status"` line and
the transcript `aria-label` all read it. An unnamed worker now gets "The subagent is still running.",
"Showing the subagent's transcript. Still running." and "Transcript: subagent"; a named one is
unchanged. In the navigator, a nameless row draws no name field and no separator dot for one.

Tests: `items.unit.test.ts` covers a spawn whose call names no agent and whose async resolution
supplies none (`type: null`) beside a resolved and an explicitly named one; `subagent.unit.test.ts`
pins the guard's `null`/`""` split; `subagent-view.unit.test.tsx` asserts all four surfaces for both
the unnamed and the named case. `pnpm typecheck` is clean and
`vitest run src/shell/chat src/pi src/ai-agent` is 1311 green.

Fixes #8680

## Deviations

- **Guard or gate bypassed** — **Said:** the acceptance criterion reads "`isSubagentSlot` accepts
  `null` and still rejects an empty string." **Did:** added the empty-string rejection, which the
  guard did not previously have — at main it was a bare `typeof value.type === "string"`, so `""`
  was admitted. **Why:** the criterion's "still" describes an invariant the code did not yet hold,
  and widening without it would leave `""` as a second way to say "no name" — the representable
  invalid state this ticket exists to close. **Disposition:** stated here; no producer in the tree
  emits `""` (`claude/history/map.ts` and `codex/subagents.ts` both default to a non-empty label), so
  nothing regresses.

- **Out-of-scope change** — **Said:** the ticket names four surfaces and two type declarations.
  **Did:** also scoped the `status()` selector in the new `subagent-view.unit.test.tsx` cases to
  `.tuval-chat-subagents + p[role="status"]`. **Why:** the window draws a second `role="status"` for
  the turn phase, and an unscoped selector reads that one instead. **Disposition:** stated here;
  confined to the tests this PR adds.

- **Pre-existing test or fixture changed** — **Said:** nothing about
  `apps/tuval/src/process/row-sub-failure.unit.test.ts`. **Did:** `biome check --write` over
  `apps/tuval/src` applied an unrelated `import type` fix there, which I then reverted. **Why:** the
  formatter's scope was the whole app tree rather than my changed files, so it picked up a file this
  ticket does not touch. **Disposition:** reverted, not shipped — the file is absent from this diff,
  and the fix belongs in its own change.
