### PR TITLE
feat: A finished async Pi spawn shows no transcript: its active-run alias is gone by then

### DIFF
--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -71,7 +71,7 @@ import {
 	type ServerBindFailed,
 	subagentExtensionPaths,
 } from "../server/index.ts";
-import type {ThinkingLevel} from "../wire/index.ts";
+import type {SessionSnapshot, ThinkingLevel} from "../wire/index.ts";
 import {type AsyncSpawns, asyncRunRoot, readAsyncSpawns} from "./async-spawn.ts";
 import {
 	type ChildTranscripts,
@@ -84,10 +84,12 @@ import {
 	deltaEventsOf,
 	emptyProjection,
 	eventsOf,
+	finishedAsyncCallIds,
 	paintOf,
 	projectionOf,
 	type SnapshotProjection,
 	spawnRunIds,
+	subagentSlotsOf,
 } from "./items.ts";
 import {
 	interruptFailureOf,
@@ -166,6 +168,36 @@ type FoldInput =
  * child's write rate — a slower tail costs latency on a row, never a record.
  */
 const childTailInterval = "500 millis";
+
+/**
+ * What a just-attached session can fill from disk for its finished detached spawn rows.
+ *
+ * A finished row is out of the projection's `spawns` map — a delta drops it there, and a session
+ * rebuilt from its transcript never put it there at all — so no tail tick will ever reach its
+ * workers. The results index still files them under the call's own id, so it is read once here and
+ * carried by every later fold (#8685). The events are the repaint that read is worth: the paint, or
+ * the caller's own held copy, drew those rows off the result text alone.
+ */
+const asyncFillOf = (
+	snapshot: SessionSnapshot,
+	artifacts: string,
+): {
+	readonly children: ChildTranscripts;
+	readonly resolved: AsyncSpawns;
+	readonly events: ReadonlyArray<AgentEvent>;
+} => {
+	const resolved = readAsyncSpawns(asyncRunRoot(), finishedAsyncCallIds(snapshot.transcript));
+	if (resolved.size === 0) return {children: new Map(), resolved, events: []};
+	const children = readChildTranscripts(artifacts, [
+		...new Set([...resolved.values()].flatMap((spawn) => spawn.runIds)),
+	]);
+	const events = snapshot.transcript.flatMap((source) =>
+		subagentSlotsOf(source, children, undefined, resolved)
+			.filter((slot) => slot.status === "finished")
+			.map((slot) => ({kind: "subagent", slot}) as const),
+	);
+	return {children, resolved, events};
+};
 
 /**
  * Read one session's branch out of Pi's JSONL, oldest-first.
@@ -291,10 +323,14 @@ const make = (
 			feed: Queue.Queue<FoldInput>,
 			seed: SnapshotProjection,
 			artifacts: string,
+			fill: {readonly children: ChildTranscripts; readonly resolved: AsyncSpawns},
 		): Effect.Effect<void> =>
 			Effect.gen(function* () {
 				yield* Ref.set(projection, seed);
-				const children = yield* Ref.make<ChildTranscripts>(new Map());
+				const children = yield* Ref.make<ChildTranscripts>(fill.children);
+				// Sticky, never replaced: a row resolved while it ran has to still be resolvable once
+				// it finishes and leaves the `spawns` map (#8685).
+				const resolvedAsync = yield* Ref.make<AsyncSpawns>(fill.resolved);
 				const pushes = pi
 					.updates(sessionId)
 					.pipe(Stream.runForEach((update) => Queue.offer(feed, update)));
@@ -309,6 +345,8 @@ const make = (
 							}
 							if (input._tag === "children") {
 								yield* Ref.set(children, input.children);
+								if (input.resolved.size > 0)
+									yield* Ref.update(resolvedAsync, (held) => new Map([...held, ...input.resolved]));
 								const tailed = childEventsOf(previous, input.children, input.resolved);
 								yield* Ref.set(projection, tailed.next);
 								return yield* emit(open, tailed.events);
@@ -317,10 +355,11 @@ const make = (
 							// landing between two reads restates the enriched slot rather than
 							// blanking the rows the operator is looking at.
 							const held = yield* Ref.get(children);
+							const resolved = yield* Ref.get(resolvedAsync);
 							const folded =
 								input._tag === "snapshot"
-									? eventsOf(previous, input.snapshot, held)
-									: deltaEventsOf(previous, input.delta, held);
+									? eventsOf(previous, input.snapshot, held, resolved)
+									: deltaEventsOf(previous, input.delta, held, resolved);
 							yield* Ref.set(projection, folded.next);
 							yield* emit(open, folded.events);
 						}),
@@ -331,6 +370,7 @@ const make = (
 						yield* Effect.sleep(childTailInterval);
 						const running = [...(yield* Ref.get(projection)).spawns.values()];
 						if (running.length === 0) return;
+						const carried = yield* Ref.get(resolvedAsync);
 						const read = yield* Effect.sync(() => {
 							// Every detached spawn, every tick — not just the ones with no workers yet.
 							// A workflow's `steps[]` gain their run ids as each step launches, so a run
@@ -339,9 +379,14 @@ const make = (
 								asyncRunRoot(),
 								running.filter((spawn) => spawn.runId === null).map((spawn) => spawn.toolCallId),
 							);
-							const runIds = running.flatMap((spawn) =>
-								spawnRunIds(spawn, resolved.get(spawn.toolCallId)),
-							);
+							// The finished rows' workers ride along because this read replaces the held
+							// children whole, and dropping them blanks a slot the operator is reading.
+							const runIds = [
+								...new Set([
+									...running.flatMap((spawn) => spawnRunIds(spawn, resolved.get(spawn.toolCallId))),
+									...[...carried.values()].flatMap((spawn) => spawn.runIds),
+								]),
+							];
 							return {children: readChildTranscripts(artifacts, runIds), resolved};
 						});
 						yield* Queue.offer(feed, {_tag: "children", ...read});
@@ -447,28 +492,43 @@ const make = (
 						options_.cwd,
 						opening === undefined ? {} : {model: opening},
 					);
-					return {ref: opened, seed: emptyProjection, paint: []};
+					return {
+						ref: opened,
+						seed: emptyProjection,
+						paint: [],
+						fill: {children: new Map(), resolved: new Map(), events: []},
+					};
 				}
 				// Either way the lease's own snapshot is the seed, and neither reading of it costs a
 				// round trip. What differs is what the caller can already see.
 				const resumed = yield* pi.attachSession(resume.sessionId);
 				const lease = yield* pi.heldSnapshot(resumed.id);
+				// Read before either branch answers: a finished detached row is invisible to both the
+				// seed and the paint, so its workers come off the results index either way (#8685).
+				const fill = yield* Effect.sync(() =>
+					asyncFillOf(lease, subagentArtifactsDir(sessionDir(options_.cwd))),
+				);
 				// A restored process is looking at its own committed tail, so the seed suppresses
 				// everything through the boundary that tail reaches and emits whatever the session
 				// finished past it — or changed under it — while the socket was down (#8374).
 				const seeded = resume.holdsTranscript ? projectionOf(lease, resume.held) : null;
-				if (seeded !== null) return {ref: resumed, seed: seeded, paint: []};
+				if (seeded !== null) return {ref: resumed, seed: seeded, paint: fill.events, fill};
 				// Nothing to seed from: a window opened out of the picker holds nothing, or the
 				// boundary the caller holds is not in this snapshot. Either way the history is
 				// painted here, at the attach, while its tail is still empty — a push carries only
 				// what changed, so waiting for one would replay nothing (#8554).
 				const painted = paintOf(lease);
-				return {ref: resumed, seed: painted.projection, paint: painted.events};
+				return {
+					ref: resumed,
+					seed: painted.projection,
+					paint: [...painted.events, ...fill.events],
+					fill,
+				};
 			}).pipe(Effect.mapError((refusal) => startErrorOf(options_.cwd, refusal)));
 
 			// One stream carries everything (ruling 1, #7570), so a failed start owes it a terminal
 			// phase: without this every subscriber sits on `starting` for the life of the layer.
-			const {ref, seed, paint} = yield* acquire.pipe(
+			const {ref, seed, paint, fill} = yield* acquire.pipe(
 				Effect.tapError(() => emit(open, [{kind: "phase", phase: "gone"}])),
 			);
 			yield* emit(open, paint);
@@ -503,7 +563,7 @@ const make = (
 			yield* Ref.set(
 				pump,
 				yield* Effect.forkIn(
-					follow(ref.id, open, feed, seed, subagentArtifactsDir(sessionDir(options_.cwd))),
+					follow(ref.id, open, feed, seed, subagentArtifactsDir(sessionDir(options_.cwd)), fill),
 					scope,
 				),
 			);

--- a/apps/tuval/src/pi/ai-agent/async-spawn.ts
+++ b/apps/tuval/src/pi/ai-agent/async-spawn.ts
@@ -114,18 +114,27 @@ const tempScopeId = (): string => {
 	return `home-${sanitizeScopeSegment(homedir())}`;
 };
 
-/**
- * Where detached runs keep their status directories — `ASYNC_DIR`
- * (`src/shared/types.ts:2730-2735`). It is process-scoped rather than session-scoped, so it is read
- * off the same environment the extension runs in: this process spawns the children.
- */
-export const asyncRunRoot = (): string => {
+/** `TEMP_ROOT_DIR` (`src/shared/types.ts:2733-2737`) — the parent both roots below hang off. */
+const tempRoot = (): string => {
 	const configured = process.env.PI_SUBAGENTS_TEMP_ROOT?.trim();
-	const root = configured ? resolve(configured) : join(tmpdir(), `pi-subagents-${tempScopeId()}`);
-	return join(root, "async-subagent-runs");
+	return configured ? resolve(configured) : join(tmpdir(), `pi-subagents-${tempScopeId()}`);
 };
 
+/**
+ * Where detached runs keep their status directories — `ASYNC_DIR`
+ * (`src/shared/types.ts:2739`). It is process-scoped rather than session-scoped, so it is read
+ * off the same environment the extension runs in: this process spawns the children.
+ */
+export const asyncRunRoot = (): string => join(tempRoot(), "async-subagent-runs");
+
+/**
+ * Where a finished run's result payload and its indexes live — `RESULTS_DIR`
+ * (`src/shared/types.ts:2738`), the sibling of the run root under the same temp scope.
+ */
+export const asyncResultsRoot = (): string => join(tempRoot(), "async-subagent-results");
+
 const ACTIVE_RUN_INDEX_DIR = ".active-runs";
+const RESULT_INDEX_DIR = "result-index";
 const TOOL_CALL_INDEX_DIR = "tool-calls";
 
 const objectOf = (value: unknown): Record<string, unknown> | undefined =>
@@ -157,6 +166,57 @@ const aliasedRunDirs = (root: string, toolCallId: string): ReadonlyArray<string>
 		...new Set(indexSegmentAliases(toolCallId).flatMap((segment) => aliasEntries(root, segment))),
 	].sort();
 
+/**
+ * The run ids the results-dir index files this call, read as JSON rather than by filename.
+ *
+ * `writeResultIndexForData` drops a `ResultIndexEntry` at
+ * `<resultsRoot>/result-index/tool-calls/<encodeIndexSegment(toolCallId)>/<encoded runId>.json`
+ * whenever a result payload carries a `toolCallId` (`src/runs/background/result-files.ts:103-108`,
+ * `149-153`), and nothing on the terminal path removes it — which is what makes it the route home
+ * for a run whose active alias is already gone. The entry's own `runId` is read rather than the
+ * filename's stem, because the stem is an encoding of it and can be a digest.
+ */
+const indexedRunIds = (resultsRoot: string, toolCallId: string): ReadonlyArray<string> => {
+	const found = new Set<string>();
+	for (const segment of indexSegmentAliases(toolCallId)) {
+		const dir = join(resultsRoot, RESULT_INDEX_DIR, TOOL_CALL_INDEX_DIR, segment);
+		let names: ReadonlyArray<string>;
+		try {
+			names = readdirSync(dir, {withFileTypes: true})
+				.filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+				.map((entry) => entry.name);
+		} catch {
+			continue;
+		}
+		for (const name of names) {
+			let entry: Record<string, unknown> | undefined;
+			try {
+				entry = objectOf(JSON.parse(readFileSync(join(dir, name), "utf-8")));
+			} catch {
+				continue;
+			}
+			const runId = entry === undefined ? undefined : stringOf(entry.runId);
+			if (runId !== undefined) found.add(runId);
+		}
+	}
+	return [...found];
+};
+
+/**
+ * Every run directory worth confirming for this call — the live aliases, then the run ids the
+ * results index still files under it. Both are hints keyed by the same run id, so the union is
+ * taken once and a run in both is confirmed once. Sorted rather than left in `readdir` order, so
+ * two reads of one unchanged pair of indexes answer identically.
+ */
+const candidateRunDirs = (
+	root: string,
+	toolCallId: string,
+	resultsRoot: string,
+): ReadonlyArray<string> =>
+	[
+		...new Set([...aliasedRunDirs(root, toolCallId), ...indexedRunIds(resultsRoot, toolCallId)]),
+	].sort();
+
 const readStatus = (dir: string): Record<string, unknown> | undefined => {
 	try {
 		return objectOf(JSON.parse(readFileSync(join(dir, "status.json"), "utf-8")));
@@ -186,11 +246,21 @@ const stepWorker = (
  * The whole status is re-read on every call, so the answer always carries every step that has
  * launched so far. That is what makes a sequential lane's later steps arrive at all: a step is
  * declared up front with no `runId` and gains one when it launches (#8684).
+ *
+ * The alias index is not the only key tried, because `releaseActiveRunIndex` deletes this call's
+ * alias the moment the run reaches a terminal state — the run directory and its `steps[]` survive,
+ * but the way back to them does not. The results index does survive, so it is read beside the
+ * aliases and confirmed by the same rule (#8685). `cleanupResultIndexes` ages those entries out at
+ * 24h, past which a finished call resolves nothing and its row shows the result text alone.
  */
-export const readAsyncSpawn = (root: string, toolCallId: string): AsyncSpawn | null => {
+export const readAsyncSpawn = (
+	root: string,
+	toolCallId: string,
+	resultsRoot: string = asyncResultsRoot(),
+): AsyncSpawn | null => {
 	const runIds: Array<string> = [];
 	const agents: Array<string> = [];
-	for (const entry of aliasedRunDirs(root, toolCallId)) {
+	for (const entry of candidateRunDirs(root, toolCallId, resultsRoot)) {
 		const status = readStatus(join(root, entry));
 		if (status === undefined || stringOf(status.toolCallId) !== toolCallId) continue;
 		const steps = Array.isArray(status.steps) ? status.steps : [];
@@ -206,10 +276,14 @@ export const readAsyncSpawn = (root: string, toolCallId: string): AsyncSpawn | n
 };
 
 /** Every named call resolved fresh — the step the tail repeats beside its artifact read. */
-export const readAsyncSpawns = (root: string, toolCallIds: ReadonlyArray<string>): AsyncSpawns => {
+export const readAsyncSpawns = (
+	root: string,
+	toolCallIds: ReadonlyArray<string>,
+	resultsRoot: string = asyncResultsRoot(),
+): AsyncSpawns => {
 	const found = new Map<string, AsyncSpawn>();
 	for (const toolCallId of toolCallIds) {
-		const spawn = readAsyncSpawn(root, toolCallId);
+		const spawn = readAsyncSpawn(root, toolCallId, resultsRoot);
 		if (spawn !== null) found.set(toolCallId, spawn);
 	}
 	return found;

--- a/apps/tuval/src/pi/ai-agent/async-spawn.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/async-spawn.unit.test.ts
@@ -1,7 +1,8 @@
 /**
  * The detached-spawn resolution, over directories laid out exactly as `pi-subagents`
- * `src/runs/background/active-run-index.ts` writes them. The index is reimplemented rather than
- * imported, so a test that spells the layout out is the only thing holding the two in step.
+ * `src/runs/background/active-run-index.ts` and `result-files.ts` write them. Both indexes are
+ * reimplemented rather than imported, so a test that spells the layout out is the only thing
+ * holding them in step.
  */
 
 import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:fs";
@@ -9,6 +10,7 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {afterEach, describe, expect, it} from "vitest";
 import {
+	asyncResultsRoot,
 	asyncRunRoot,
 	encodeIndexSegment,
 	indexSegmentAliases,
@@ -26,6 +28,12 @@ const asyncRoot = (): string => {
 	roots.push(root);
 	return root;
 };
+
+/**
+ * The results root a case reads by. Held inside the case's own temp root rather than left to
+ * `asyncResultsRoot()`, so a test never reads the desk's real index.
+ */
+const resultsRoot = (root: string): string => join(root, "results");
 
 /** One queued/running run: its `status.json`, plus the alias file the tool-call index carries. */
 const launch = (
@@ -58,7 +66,10 @@ describe("resolving a detached spawn through the tool-call index", () => {
 			},
 			"call-9",
 		);
-		expect(readAsyncSpawn(root, "call-9")).toEqual({runIds: ["worker-1"], agent: "builder"});
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toEqual({
+			runIds: ["worker-1"],
+			agent: "builder",
+		});
 	});
 
 	// The alias is a filename and survives a crash, so the status's own claim is the proof.
@@ -77,11 +88,12 @@ describe("resolving a detached spawn through the tool-call index", () => {
 			},
 			"call-9",
 		);
-		expect(readAsyncSpawn(root, "call-9")).toBeNull();
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toBeNull();
 	});
 
 	it("answers nothing when no marker was ever written", () => {
-		expect(readAsyncSpawn(asyncRoot(), "call-9")).toBeNull();
+		const root = asyncRoot();
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toBeNull();
 	});
 
 	it("answers nothing when the aliased run has no status to read", () => {
@@ -89,7 +101,7 @@ describe("resolving a detached spawn through the tool-call index", () => {
 		const dir = join(root, ".active-runs", "tool-calls", encodeIndexSegment("call-9"));
 		mkdirSync(dir, {recursive: true});
 		writeFileSync(join(dir, "async-3"), "");
-		expect(readAsyncSpawn(root, "call-9")).toBeNull();
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toBeNull();
 	});
 
 	// The sequential lane: `steps[]` is declared up front and each step gains its `runId` at launch,
@@ -113,7 +125,10 @@ describe("resolving a detached spawn through the tool-call index", () => {
 			]),
 			"call-9",
 		);
-		expect(readAsyncSpawn(root, "call-9")).toEqual({runIds: ["worker-1"], agent: "builder"});
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toEqual({
+			runIds: ["worker-1"],
+			agent: "builder",
+		});
 
 		writeFileSync(
 			join(root, "async-5", "status.json"),
@@ -124,7 +139,7 @@ describe("resolving a detached spawn through the tool-call index", () => {
 				]),
 			),
 		);
-		expect(readAsyncSpawn(root, "call-9")).toEqual({
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toEqual({
 			runIds: ["worker-1", "worker-2"],
 			agent: "builder, reviewer",
 		});
@@ -152,7 +167,10 @@ describe("resolving a detached spawn through the tool-call index", () => {
 		const dir = join(root, ".active-runs", "tool-calls", historical as string);
 		mkdirSync(dir, {recursive: true});
 		writeFileSync(join(dir, "async-6"), "");
-		expect(readAsyncSpawn(root, id)).toEqual({runIds: ["worker-1"], agent: "builder"});
+		expect(readAsyncSpawn(root, id, resultsRoot(root))).toEqual({
+			runIds: ["worker-1"],
+			agent: "builder",
+		});
 	});
 
 	it("carries every worker a fan-out started, naming the row after all of them", () => {
@@ -174,7 +192,7 @@ describe("resolving a detached spawn through the tool-call index", () => {
 			},
 			"call-9",
 		);
-		expect(readAsyncSpawn(root, "call-9")).toEqual({
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toEqual({
 			runIds: ["worker-1", "worker-2"],
 			agent: "builder, reviewer",
 		});
@@ -194,12 +212,147 @@ describe("the index segment a tool call's aliases live under", () => {
 	});
 });
 
+/**
+ * One finished run's results-index entry — `writeResultIndexForData`'s `ResultIndexEntry`
+ * (`src/runs/background/result-files.ts:103-108`, `149-153`). It outlives the alias the terminal
+ * path deletes, which is the whole reason the reader falls through to it.
+ */
+const indexResult = (
+	results: string,
+	toolCallId: string,
+	runId: string,
+	segment: string = encodeIndexSegment(toolCallId),
+): void => {
+	const dir = join(results, "result-index", "tool-calls", segment);
+	mkdirSync(dir, {recursive: true});
+	writeFileSync(
+		join(dir, `${encodeIndexSegment(runId)}.json`),
+		JSON.stringify({
+			version: 1,
+			runId,
+			sessionId: "session-1",
+			file: `${runId}.json`,
+			writtenAt: 1,
+		}),
+	);
+};
+
+/** A run whose alias the terminal path already removed: the directory and its steps, nothing else. */
+const finished = (root: string, asyncRunId: string, status: Record<string, unknown>): void => {
+	mkdirSync(join(root, asyncRunId), {recursive: true});
+	writeFileSync(join(root, asyncRunId, "status.json"), JSON.stringify(status));
+};
+
+const terminalStatus = (
+	asyncRunId: string,
+	toolCallId: string,
+	steps: ReadonlyArray<Record<string, unknown>>,
+): Record<string, unknown> => ({
+	runId: asyncRunId,
+	toolCallId,
+	mode: "workflow",
+	state: "complete",
+	startedAt: 1,
+	steps,
+});
+
+describe("resolving a finished detached spawn through the results index", () => {
+	it("reads the workers off a run whose active alias is already gone", () => {
+		const root = asyncRoot();
+		const results = resultsRoot(root);
+		finished(
+			root,
+			"async-10",
+			terminalStatus("async-10", "call-9", [
+				{agent: "builder", runId: "worker-1", status: "complete"},
+			]),
+		);
+		indexResult(results, "call-9", "async-10");
+		expect(readAsyncSpawn(root, "call-9", results)).toEqual({
+			runIds: ["worker-1"],
+			agent: "builder",
+		});
+	});
+
+	// The index entry is a hint exactly as the alias is; the status is still the proof.
+	it("rejects an indexed run whose status names another call", () => {
+		const root = asyncRoot();
+		const results = resultsRoot(root);
+		finished(
+			root,
+			"async-11",
+			terminalStatus("async-11", "call-other", [
+				{agent: "builder", runId: "worker-2", status: "complete"},
+			]),
+		);
+		indexResult(results, "call-9", "async-11");
+		expect(readAsyncSpawn(root, "call-9", results)).toBeNull();
+	});
+
+	it("answers nothing when neither index knows the call", () => {
+		const root = asyncRoot();
+		finished(
+			root,
+			"async-12",
+			terminalStatus("async-12", "call-9", [
+				{agent: "builder", runId: "worker-3", status: "complete"},
+			]),
+		);
+		expect(readAsyncSpawn(root, "call-9", resultsRoot(root))).toBeNull();
+	});
+
+	// Past `cleanupResultIndexes`' 24h age-out the entry is gone and the row shows the result text.
+	it("answers nothing when the indexed run left no status behind", () => {
+		const root = asyncRoot();
+		const results = resultsRoot(root);
+		indexResult(results, "call-9", "async-13");
+		expect(readAsyncSpawn(root, "call-9", results)).toBeNull();
+	});
+
+	it("folds a run both indexes name exactly once", () => {
+		const root = asyncRoot();
+		const results = resultsRoot(root);
+		launch(
+			root,
+			"async-14",
+			terminalStatus("async-14", "call-9", [
+				{agent: "builder", runId: "worker-1", status: "complete"},
+				{agent: "reviewer", runId: "worker-2", status: "complete"},
+			]),
+			"call-9",
+		);
+		indexResult(results, "call-9", "async-14");
+		expect(readAsyncSpawn(root, "call-9", results)).toEqual({
+			runIds: ["worker-1", "worker-2"],
+			agent: "builder, reviewer",
+		});
+	});
+
+	// The results index carries the same two spellings the alias index does.
+	it("finds a run indexed under the pre-hash key", () => {
+		const root = asyncRoot();
+		const results = resultsRoot(root);
+		const id = "call.jsonl";
+		finished(
+			root,
+			"async-15",
+			terminalStatus("async-15", id, [{agent: "builder", runId: "worker-1", status: "complete"}]),
+		);
+		const [current, historical] = indexSegmentAliases(id);
+		expect(historical).toBeDefined();
+		expect(historical).not.toBe(current);
+		indexResult(results, id, "async-15", historical as string);
+		expect(readAsyncSpawn(root, id, results)).toEqual({runIds: ["worker-1"], agent: "builder"});
+	});
+});
+
 describe("where detached runs keep their status directories", () => {
 	it("is the configured temp root's own async directory", () => {
 		const previous = process.env.PI_SUBAGENTS_TEMP_ROOT;
 		process.env.PI_SUBAGENTS_TEMP_ROOT = "/tmp/pi-subagents-test";
 		try {
 			expect(asyncRunRoot()).toBe(join("/tmp/pi-subagents-test", "async-subagent-runs"));
+			expect(asyncResultsRoot()).toBe(join("/tmp/pi-subagents-test", "async-subagent-results"));
 		} finally {
 			if (previous === undefined) delete process.env.PI_SUBAGENTS_TEMP_ROOT;
 			else process.env.PI_SUBAGENTS_TEMP_ROOT = previous;

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -262,6 +262,29 @@ export const runningSpawnOf = (item: PiTranscriptItem): RunningSpawn | null => {
 };
 
 /**
+ * The calls a finished detached spawn row still needs an address for.
+ *
+ * A row that stopped running is dropped from the projection's `spawns` map, and a session rebuilt
+ * from its transcript never had one — so the finished branch of `subagentSlotsOf` has nothing
+ * carried to read by, and the only key left is the call's own id. These are the ids to hand
+ * `readAsyncSpawns` before folding (#8685).
+ */
+export const finishedAsyncCallIds = (
+	sources: ReadonlyArray<PiTranscriptItem>,
+): ReadonlyArray<string> => [
+	...new Set(
+		sources.flatMap((item) =>
+			item.role === "tool" &&
+			item.status !== "running" &&
+			spawns(item.toolName, item.input) &&
+			runIdOf(item) === null
+				? [item.toolCallId]
+				: [],
+		),
+	),
+];
+
+/**
  * One spawn under whatever the index last said about it — a fresh tail read, or the projection's
  * own earlier answer when a wire push rebuilds the row from scratch.
  *
@@ -333,11 +356,17 @@ const childOf = (
  * A foreground row is matched to its artifact by the `runId` the session stamped on it. A detached
  * one carries none, so `held` — the workers the tail resolved through the tool-call index — is what
  * matches it, and it also supplies the name for a call that named no `agent` (#8679).
+ *
+ * `resolved` is that same answer for a row `held` cannot cover: a finished detached call is out of
+ * the `spawns` map, and a restored session never put it there, so its workers are read off the
+ * results index by `toolCallId` and handed in here (#8685). `held` still wins where both answer,
+ * since it is the live read.
  */
 export const subagentSlotsOf = (
 	item: PiTranscriptItem,
 	children?: ChildTranscripts | undefined,
 	held?: ReadonlyMap<string, RunningSpawn> | undefined,
+	resolved?: AsyncSpawns | undefined,
 ): ReadonlyArray<SubagentSlot> => {
 	if (item.role === "assistant") {
 		return item.content.flatMap((part) =>
@@ -381,11 +410,12 @@ export const subagentSlotsOf = (
 		return [runningSlotOf(resolved, childOf(children, runIdsOf(resolved)) ?? emptyChild)];
 	}
 	const runId = runIdOf(item);
-	const child = childOf(children, runId === null ? (carried?.resolved?.runIds ?? []) : [runId]);
+	const finished = carried?.resolved ?? resolved?.get(item.toolCallId) ?? null;
+	const child = childOf(children, runId === null ? (finished?.runIds ?? []) : [runId]);
 	return [
 		{
 			id,
-			type: subagentType(namedAgent(item.input) ?? carried?.resolved?.agent ?? null),
+			type: subagentType(namedAgent(item.input) ?? finished?.agent ?? null),
 			lastLine: child?.lastLine || lastLineOf(boundToolResult(textOf(item.content)).text),
 			startedAt: item.timestamp,
 			// The child's own spend where the artifact reported one, else what the result says it
@@ -497,6 +527,7 @@ export const eventsOf = (
 	previous: SnapshotProjection,
 	snapshot: SessionSnapshot,
 	children?: ChildTranscripts | undefined,
+	resolved?: AsyncSpawns | undefined,
 ): Folded => {
 	if (snapshot.revision <= previous.revision) return stale(previous);
 	const events: Array<AgentEvent> = [];
@@ -511,7 +542,7 @@ export const eventsOf = (
 			items.set(item.id, mark);
 			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
 		}
-		for (const slot of subagentSlotsOf(source, children, previous.spawns)) {
+		for (const slot of subagentSlotsOf(source, children, previous.spawns, resolved)) {
 			const key = slotKey(slot);
 			const mark = fingerprint(slot);
 			subagents.set(key, mark);
@@ -548,6 +579,7 @@ export const deltaEventsOf = (
 	previous: SnapshotProjection,
 	delta: SessionDelta,
 	children?: ChildTranscripts | undefined,
+	resolved?: AsyncSpawns | undefined,
 ): Folded => {
 	if (delta.revision <= previous.revision) return stale(previous);
 	const events: Array<AgentEvent> = [];
@@ -563,7 +595,7 @@ export const deltaEventsOf = (
 			items.set(item.id, mark);
 			if (previous.items.get(item.id) !== mark) events.push({kind: "item", item});
 		}
-		for (const slot of subagentSlotsOf(source, children, previous.spawns)) {
+		for (const slot of subagentSlotsOf(source, children, previous.spawns, resolved)) {
 			const key = slotKey(slot);
 			const mark = fingerprint(slot);
 			subagents.set(key, mark);

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -26,11 +26,13 @@ import {
 	deltaEventsOf,
 	emptyProjection,
 	eventsOf,
+	finishedAsyncCallIds,
 	itemId,
 	itemOf,
 	itemsOf,
 	phaseOf,
 	projectionOf,
+	subagentSlotsOf,
 } from "./items.ts";
 
 /**
@@ -1283,5 +1285,112 @@ describe("a detached subagent filled through the tool-call index", () => {
 				(event) => event.kind === "subagent" && event.slot.type,
 			),
 		).toEqual(["reviewer"]);
+	});
+});
+
+/**
+ * The other half of the same row: `pi-subagents` deletes a run's active alias the moment it ends,
+ * and a session rebuilt from its transcript never watched it run — so the finished branch has no
+ * carried spawn and resolves off the results index by the call's own id (#8685).
+ */
+describe("a finished detached subagent on a session that never watched it run", () => {
+	const answered: PiTranscriptItem = {
+		id: "item-4",
+		role: "tool",
+		toolCallId: "call-async",
+		toolName: "subagent",
+		input: {async: true, context: "fresh", workflowScript: "runs.run('lane')"},
+		content: [{type: "text", text: "lane landed\nPR opened"}],
+		timestamp: 31,
+		status: "complete",
+		isError: false,
+		usage: usage(1),
+	};
+
+	const child = {
+		items: [
+			{kind: "assistant" as const, id: itemId("child-0"), timestamp: 32, text: "cutting the lane"},
+		],
+		lastLine: "cutting the lane",
+		tokens: 17,
+	};
+	const children = new Map([["worker-1", child]]);
+	const resolved = new Map([["call-async", {runIds: ["worker-1"], agent: "builder"}]]);
+
+	it("names the call a restore has to resolve, and only that one", () => {
+		const stillRunning: PiTranscriptItem = {...answered, toolCallId: "call-run", status: "running"};
+		const foreground: PiTranscriptItem = {
+			...answered,
+			toolCallId: "call-fg",
+			details: {runId: "run-1"},
+		};
+		const notASpawn: PiTranscriptItem = {...answered, toolCallId: "call-read", toolName: "read"};
+		expect(finishedAsyncCallIds([answered, stillRunning, foreground, notASpawn])).toEqual([
+			"call-async",
+		]);
+	});
+
+	it("fills the slot from the recovered workers with no spawn ever held", () => {
+		expect(subagentSlotsOf(answered, children, undefined, resolved)).toEqual([
+			{
+				id: "call-async",
+				type: "builder",
+				lastLine: "cutting the lane",
+				startedAt: 31,
+				tokens: 17,
+				items: [
+					{
+						kind: "assistant",
+						id: "call-async:run-0-child-0",
+						parentId: "call-async",
+						timestamp: 32,
+						text: "cutting the lane",
+					},
+				],
+				status: "finished",
+			},
+		]);
+	});
+
+	// A restore folds the whole transcript with an empty `spawns` map, which is the case #8684's
+	// running arm cannot reach at all.
+	it("fills the row through a snapshot fold over an empty projection", () => {
+		expect(
+			eventsOf(emptyProjection, snapshot([answered], "turn"), children, resolved).events,
+		).toContainEqual({
+			kind: "subagent",
+			slot: {
+				id: "call-async",
+				type: "builder",
+				lastLine: "cutting the lane",
+				startedAt: 31,
+				tokens: 17,
+				items: [
+					{
+						kind: "assistant",
+						id: "call-async:run-0-child-0",
+						parentId: "call-async",
+						timestamp: 32,
+						text: "cutting the lane",
+					},
+				],
+				status: "finished",
+			},
+		});
+	});
+
+	// Past the index's 24h age-out there is nothing to recover, and the row reads as it does today.
+	it("degrades to the result's own last line when nothing resolves", () => {
+		expect(subagentSlotsOf(answered, children, undefined, new Map())).toEqual([
+			{
+				id: "call-async",
+				type: "subagent",
+				lastLine: "PR opened",
+				startedAt: 31,
+				tokens: 33,
+				items: [],
+				status: "finished",
+			},
+		]);
 	});
 });


### PR DESCRIPTION
A detached Pi spawn's row went empty the moment it answered. `readAsyncSpawn` only knew the live
alias index at `<asyncRunRoot>/.active-runs/tool-calls/`, and `pi-subagents` deletes that alias on
the terminal path (`releaseActiveRunIndex`, `src/runs/background/active-run-index.ts:46-77`,
`79-97`) — so a finished workflow row fell back to the tool result's one line while its workers'
transcripts sat unread in `subagent-artifacts/`.

The route home is the results-dir tool-call index, which is keyed by `toolCallId` directly and
which nothing on the terminal path removes: `writeResultIndexForData` writes
`<resultsDir>/result-index/tool-calls/<encodeIndexSegment(toolCallId)>/<encoded runId>.json`
whenever the result payload carries a `toolCallId` (`result-files.ts:103-108`, `149-153`), and
`indexedToolCallIdAsyncLocations` falls through to it for exactly this case
(`run-id-resolver.ts:76-85`). The run directory and its `steps[]` survive too, so once the run id
is recovered the existing step walk is unchanged.

- `async-spawn.ts` exports `asyncResultsRoot()` beside `asyncRunRoot()`, both off one `tempRoot()`
  — `<TEMP_ROOT_DIR>/async-subagent-results` and `.../async-subagent-runs`
  (`src/shared/types.ts:2730-2735`). `readAsyncSpawn` now unions the alias entries with the run ids
  the results index files, under both index spellings (`indexSegmentAliases`), and confirms every
  candidate by the same rule as before: a run whose `status.toolCallId` is not the one asked for is
  skipped. No run id is read out of result text. A run both indexes name is folded once.
- `items.ts` takes the resolutions as a map on the finished path: `subagentSlotsOf`'s finished
  branch reads `carried?.resolved ?? resolved?.get(toolCallId)`, so a row with no carried spawn
  still finds its workers. `finishedAsyncCallIds` names the calls a restore has to resolve.
- `PiAiAgent.ts` reads that index once at the attach (`asyncFillOf`) and repaints the finished rows
  it recovers, then carries the answer on a sticky ref every later wire fold reads. The tail keeps
  those workers' artifacts in its read, since it replaces the held children whole.

Every read stays total: a missing index entry, an unreadable status or a missing artifact answers
`null` and the row degrades to the result's own last line with an empty item list, which is what it
shows today. `cleanupResultIndexes` ages entries out at 24h (`result-files.ts:473`); past that a
finished row resolves nothing, and that bound is accepted rather than worked around.

Grounded against `pi-subagents@0.66.0` source at the installed pin, not recall.

Merged with main after #8698 landed: that PR made `SubagentSlot.type` nullable and deleted
`subagentType`, so the finished slot's type reads `namedAgent(item.input) ?? finished?.agent ?? null`
— main's shape, this lane's source.

`vitest run src/pi` in `apps/tuval` on the merged tree: 40 files, 335 tests, green. `pnpm typecheck`
clean.

Fixes #8685

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8685 asks for new cases over fixture
  directories in `async-spawn.unit.test.ts`. **Did:** also passed an explicit results root to the
  eight existing `readAsyncSpawn` calls in that file. **Why:** the new third argument defaults to
  `asyncResultsRoot()`, a real path on the machine running the test, so leaving the calls bare would
  let a stray desk index entry decide a test. The results root now points inside each case's own
  temp dir. No assertion changed. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria name `async-spawn.ts`, `items.ts` and the
  restored-session path. **Did:** also threaded the resolutions through `eventsOf` and
  `deltaEventsOf` and added the attach-time fill in `PiAiAgent.ts`. **Why:** `subagentSlotsOf` alone
  cannot fill a row nobody hands the resolutions to — a finished row is out of the projection's
  `spawns` map and the tail loop never reaches it, so without a reader at the attach and on every
  later fold the new lookup would never be called. **Disposition:** stated here.
