### PR TITLE
feat: The agent composer takes twice the height it needs; compact is its one shape

### DIFF
--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -125,14 +125,20 @@
  * 26.2 (mdn/browser-compat-data `css/properties/field-sizing.json`), and where it is missing the
  * `rows={1}` attribute still opens the field at one line and the box scrolls instead of growing.
  *
- * `min-height: 0` is the load-bearing one: Form.css floors every textarea at 80px, which is the
- * same 80px this rule used to restate, so dropping the restated floor alone left the composer
- * exactly as tall as it was. The selector carries `[data-scope="field"]` to outrank that rule
- * whatever order the two sheets load in.
+ * The floor is `--tap-min`, not zero. `padding: 0` here and the zeroed padding and border on
+ * `[data-part="control"]` leave the box exactly one 14px/1.5 line — 23px, under Pillar 4's 36px
+ * hit area — and nothing around it recovers the area: the label part is `display: none` and no
+ * ancestor forwards a click to the field, so the textarea's own box is the whole target (#8714).
+ *
+ * Two things make the floor the right shape rather than the old one. It is a *floor*, so
+ * `field-sizing` still grows past it; and it outranks Form.css's own 80px textarea floor, which
+ * this rule used to restate at the same value — dropping the restated floor alone left the
+ * composer exactly as tall as it was, because the two selectors tied and Form.css won on order.
+ * The `[data-scope="field"]` in the selector is what breaks that tie.
  */
 .kp-agent-chat__textarea [data-scope="field"][data-part="input"]:is(textarea) {
 	field-sizing: content;
-	min-height: 0;
+	min-height: var(--tap-min);
 	max-height: calc(var(--s-8) * 5);
 	padding: 0;
 	font: var(--t-body);

--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -119,11 +119,25 @@
 	border-radius: 0;
 }
 
-.kp-agent-chat__textarea [data-part="input"]:is(textarea) {
-	min-height: calc(var(--s-8) * 2);
+/*
+ * One line at rest, growing with what is typed until the cap. `field-sizing: content` is what
+ * tracks the content without a resize listener; it lands in Chrome 123, Firefox 152 and Safari
+ * 26.2 (mdn/browser-compat-data `css/properties/field-sizing.json`), and where it is missing the
+ * `rows={1}` attribute still opens the field at one line and the box scrolls instead of growing.
+ *
+ * `min-height: 0` is the load-bearing one: Form.css floors every textarea at 80px, which is the
+ * same 80px this rule used to restate, so dropping the restated floor alone left the composer
+ * exactly as tall as it was. The selector carries `[data-scope="field"]` to outrank that rule
+ * whatever order the two sheets load in.
+ */
+.kp-agent-chat__textarea [data-scope="field"][data-part="input"]:is(textarea) {
+	field-sizing: content;
+	min-height: 0;
+	max-height: calc(var(--s-8) * 5);
 	padding: 0;
 	font: var(--t-body);
 	line-height: 1.5;
+	overflow-y: auto;
 	resize: none;
 }
 
@@ -253,9 +267,20 @@
 	color: var(--text-secondary);
 }
 
+/*
+ * The hint reserves no room at rest — it is the second half of #8669's height win. It surfaces on
+ * the one state that asks for it, an empty field with the caret in it, and the flex column drops
+ * its gap with it because `display: none` takes the box out of layout entirely.
+ */
 .kp-agent-chat__hint {
+	display: none;
 	color: var(--text-muted);
 	font: var(--t-meta);
+}
+
+.kp-agent-chat__composer:has(.kp-agent-chat__textarea textarea:focus:placeholder-shown)
+	.kp-agent-chat__hint {
+	display: block;
 }
 
 .kp-agent-chat__inspector:where([data-scope="collapsible"][data-part="root"]) {

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -742,6 +742,14 @@ describe("AgentChatInput", () => {
  */
 describe("the compact composer", () => {
 	const sheet = readFileSync(fileURLToPath(import.meta.resolve("./AgentChatInput.css")), "utf8");
+	const fieldRule =
+		sheet
+			.split('.kp-agent-chat__textarea [data-scope="field"][data-part="input"]:is(textarea) {')[1]
+			?.split("}")[0] ?? "";
+
+	it("has a prompt-field rule to read", () => {
+		expect(fieldRule).not.toBe("");
+	});
 
 	it("opens the prompt field at one row", async () => {
 		const {bridge} = installHarnessFetch();
@@ -751,10 +759,10 @@ describe("the compact composer", () => {
 		expect(field.rows).toBe(1);
 	});
 
-	it("grows the field to a cap instead of standing on a min-height floor", () => {
+	it("grows the field to a cap, off the old 80px floor", () => {
 		expect(sheet).not.toContain("min-height: calc(var(--s-8) * 2)");
-		expect(sheet).toContain("field-sizing: content");
-		expect(sheet).toContain("max-height: calc(var(--s-8) * 5)");
+		expect(fieldRule).toContain("field-sizing: content");
+		expect(fieldRule).toContain("max-height: calc(var(--s-8) * 5)");
 	});
 
 	it("keeps the hint out of layout until the empty field is focused", () => {
@@ -764,9 +772,17 @@ describe("the compact composer", () => {
 		);
 	});
 
-	// Pillar 4 owns the tap target and #8669 does not spend it: the height win is the field and the
-	// hint, never a control shrunk under the floor.
+	/*
+	 * Pillar 4's floor is absolute, and the first cut of #8669 spent it: the field landed at 23px
+	 * because it dropped its floor to zero, and the sheet-wide count below could not see it — a
+	 * control that never names `--tap-min` is invisible to a count of `--tap-min` (#8714). So the
+	 * field is asserted at its own rule, and the count stays as the tripwire for the other five.
+	 */
+	it("floors the prompt field at the tap target", () => {
+		expect(fieldRule).toContain("min-height: var(--tap-min)");
+	});
+
 	it("leaves every toolbar control on the tap-target floor", () => {
-		expect(sheet.match(/var\(--tap-min\)/g) ?? []).toHaveLength(5);
+		expect(sheet.match(/var\(--tap-min\)/g) ?? []).toHaveLength(6);
 	});
 });

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -1,3 +1,5 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {Paperclip} from "lucide-react";
 import {createRef, useRef} from "react";
@@ -729,5 +731,42 @@ describe("AgentChatInput", () => {
 		render(<AgentChatInput bridge={bridge} ref={field} />);
 
 		expect(await screen.findByLabelText("Pi'ye mesaj yaz")).toBe(field.current);
+	});
+});
+
+/**
+ * The compact shape #8669 ruled: one row that grows to a cap, and a hint that reserves no room
+ * until the empty field is focused. jsdom runs no layout engine and Vitest's default `css: false`
+ * drops the component's own `import "./AgentChatInput.css"`, so the height rules are read off the
+ * shipped sheet's own bytes rather than off a computed box.
+ */
+describe("the compact composer", () => {
+	const sheet = readFileSync(fileURLToPath(import.meta.resolve("./AgentChatInput.css")), "utf8");
+
+	it("opens the prompt field at one row", async () => {
+		const {bridge} = installHarnessFetch();
+		render(<AgentChatInput bridge={bridge} />);
+
+		const field = (await screen.findByLabelText("Pi'ye mesaj yaz")) as HTMLTextAreaElement;
+		expect(field.rows).toBe(1);
+	});
+
+	it("grows the field to a cap instead of standing on a min-height floor", () => {
+		expect(sheet).not.toContain("min-height: calc(var(--s-8) * 2)");
+		expect(sheet).toContain("field-sizing: content");
+		expect(sheet).toContain("max-height: calc(var(--s-8) * 5)");
+	});
+
+	it("keeps the hint out of layout until the empty field is focused", () => {
+		expect(sheet).toContain(".kp-agent-chat__hint {\n\tdisplay: none;");
+		expect(sheet).toContain(
+			".kp-agent-chat__composer:has(.kp-agent-chat__textarea textarea:focus:placeholder-shown)",
+		);
+	});
+
+	// Pillar 4 owns the tap target and #8669 does not spend it: the height win is the field and the
+	// hint, never a control shrunk under the floor.
+	it("leaves every toolbar control on the tap-target floor", () => {
+		expect(sheet.match(/var\(--tap-min\)/g) ?? []).toHaveLength(5);
 	});
 });

--- a/packages/design/src/agent-chat/Field.tsx
+++ b/packages/design/src/agent-chat/Field.tsx
@@ -71,7 +71,7 @@ export function AgentChatField() {
 					onChange={(event) => typeDraft(event.currentTarget.value)}
 					onPaste={onPaste}
 					onKeyDown={onKeyDown}
-					rows={3}
+					rows={1}
 					resize="none"
 					spellCheck
 					fullWidth

--- a/packages/design/src/agent-chat/Hint.tsx
+++ b/packages/design/src/agent-chat/Hint.tsx
@@ -2,7 +2,11 @@ import {Kbd} from "../atoms";
 import {useDesignT} from "../i18n";
 import {useAgentChatInput} from "./Root";
 
-/** The line under the composer naming what the field accepts. */
+/**
+ * The line under the composer naming what the field accepts. It stays in the DOM and out of
+ * layout, surfacing only while an empty field holds the caret — the sheet owns that, not a state
+ * branch here (#8669).
+ */
 export function AgentChatHint() {
 	const {variant, commands} = useAgentChatInput();
 	const t = useDesignT();

--- a/packages/design/src/agent-chat/Root.tsx
+++ b/packages/design/src/agent-chat/Root.tsx
@@ -54,8 +54,9 @@ export interface AgentChatInputProps {
 	readonly initialValue?: string;
 	readonly disabled?: boolean;
 	/**
-	 * Styling only. It picks the composer's border, layout and which controls sit behind the
-	 * disclosure; `deliveryRule` decides how a send goes out. #8669 retires this prop.
+	 * Which chrome the composer carries — the status row, the attach button, the overflow menu —
+	 * and the border it wears; `deliveryRule` decides how a send goes out. It is **not** a size
+	 * prop: the compact shape #8669 ruled is unconditional under both arms.
 	 */
 	readonly variant?: "harness" | "focused";
 	/**


### PR DESCRIPTION
## What

Compact is the agent composer's one shape. The empty composer took **174px** before a word was
typed; it now takes **105px** — a 40% cut, all of it out of the field and the hint line, none of it
out of a control's hit area.

Measured live on `/tuval/chat` at 1280×900 with Playwright, on the same tree at each point:

| | field | hint | composer |
|---|---|---|---|
| before (`a39812fe`) | 80px | 17px | **174px** |
| after (`66dc7be4`) | 36px | 0px | **105px** |

Two changes get there.

**The field opens at one row and grows to a cap.** `rows={1}` replaces `rows={3}`, and
`field-sizing: content` tracks the typed content up to `calc(var(--s-8) * 5)` — 200px, T3's cap —
without a resize listener. Verified in the render harness's own Chromium 151: an empty box is 21px,
four lines is 84px, and `CSS.supports("field-sizing", "content")` is true.

Its floor is `var(--tap-min)`, so the resting box is 36px rather than the 23px a bare line would be.
That is Pillar 4's hit area, and it costs 13px of the height win — see the Deviations entry and
#8714. It is a *floor*, not a height: `field-sizing` still grows past it to the same cap.

The floor that actually held the box at 80px turned out **not** to be this component's. `Form.css`
puts `min-height: 80px` on every textarea, and the component's own
`min-height: calc(var(--s-8) * 2)` restated that same 80px — so deleting the restated floor alone
moved nothing (the first `after` capture proved it). The two selectors tied on specificity and
`Form.css` won on order. Adding `[data-scope="field"]` breaks the tie.

**The hint keeps no permanent line.** It stays in the DOM, out of layout, and surfaces only while an
empty field holds the caret — `:has(… textarea:focus:placeholder-shown)`. `display: none` takes the
box out of the flex column, so its gap goes with it. That is the criterion's second option
("shown only while the composer is empty and focused") rather than folding it into the placeholder:
the hint carries five things behind `Kbd` glyphs, and a placeholder that swallowed them would be a
paragraph.

Every toolbar control is untouched.

## Evidence

Before/after captures of `/tuval/chat` and `/tuval/pi-window` are attached below by
`fabrika ui evidence`, re-rendered at `66dc7be4`.

## Tests

- `packages/design` — `src/AgentChatInput.test.tsx` + `src/agent-chat`: 77 passed. Six new cases
  under `the compact composer` lock the one-row open, the cap-not-floor sizing, the hint's rest
  state, the field's own tap-target floor, and the sheet-wide tap-target count.
- `pnpm --filter @kampus/design test:a11y` — 23 passed.
- `apps/tuval` — `vitest run src/shell/chat`: 454 passed across 32 files, including the four that
  read `AgentChatInput.css` off disk by filename. No sheet moved, so none of them needed a change.
- `fabrika build check --surface code` — green (`typecheck:affected`, `lint:worktree`).

The assembled-vs-plain markup test needed no change: the DOM is byte-identical to before, all of
this is CSS and one attribute value.

LAW-SOURCE: manifest-prose (`fabrika ui law` exits 13 — this repo ships no typed
`design-prohibitions.json`, so `design-system-manifest.md`'s prose prohibitions are the law).

## Deviations

- **Said:** Acceptance criterion 4 — "The component exposes no `density`, `variant`, `compact` or equivalent size prop; the compact shape is unconditional for every consumer." `Root.tsx`'s own docblock, landed in #8668, also said "#8669 retires this prop."
  **Did:** Left `variant` in place. Made the compact shape unconditional under both of its arms, and rewrote the docblock so it no longer promises a retirement this PR does not perform.
  **Why:** `variant` is not a size prop. It selects which chrome the composer carries — the connection status row under `harness`, the attach button and overflow menu under `focused` — plus the composer border, and it derives the default `deliveryRule`. Retiring it means picking one chrome for every host: either apps/web's harness surface loses its status row, or Tuval's chat window gains one it does not want (it has its own status bar). That is a product call, not a height fix, and the issue scopes this ticket explicitly — "the height win comes from the textarea and the hint line only." The criterion's second half does hold: nothing about the compact shape reads `variant`.
  **Disposition:** Filed as #8712 for the product call. Criterion 4 is met in substance (no size prop is exposed, compact is unconditional) and open in letter (the named prop still exists).

- **Said:** Acceptance criterion 1 — the field "opens at a single row", and the height note this PR opened with put the empty composer at 92px with the field at 23px.
  **Did:** Floored the field at `min-height: var(--tap-min)`. The field rests at 36px and the composer at 105px, 13px above what the first head measured.
  **Why:** 23px is under Pillar 4's 36px minimum hit area, and nothing recovered the area — `[data-part="label"]` is `display: none`, the surface is a plain `Card` and the form a plain `Form`, so no ancestor forwards a click to the field. The composer's most-used control had a 23px target. `@kampus/design` is the shared package, so the breach reached Tuval's desk, `/lab` and the `/__pi/*` harness at once. The founder standard is no UX shortcut on a11y, so the 13px is not a trade worth taking. The field still opens at one visual row and still grows to the cap, so criterion 1 holds.
  **Disposition:** Fixed at `66dc7be4`, which answers the finding #8714 carries. The height table above is restated at the new measurement; the original numbers are preserved in the amendment at the foot of this body.

- **Said:** The T3 read on #8668 describes a resting-on-scroll layout — the composer collapses to a 32px line once the thread overflows and the user scrolls.
  **Did:** Did not build it.
  **Why:** The driver's brief scopes it out explicitly, alongside T3's glass styling. It is a behaviour, not a height default, and it needs its own ticket. Worth noting for whoever picks it up: 32px is itself under the tap floor, so that ticket inherits the same Pillar 4 question this one just answered.
  **Disposition:** Out of scope, not filed — the T3 read on #8668 already records it as a known, deliberate carve.

- **Said:** The field should "grow with typed content up to a cap."
  **Did:** Used `field-sizing: content` rather than a JS auto-grow.
  **Why:** It is the declarative answer, needs no ref merging against the host's forwarded `ref`, and matches T3's "no rows attr" shape. Support (mdn/browser-compat-data `css/properties/field-sizing.json`): Chrome 123, Firefox 152, Safari 26.2. Where it is missing the `rows={1}` attribute still opens the field at one line and the box scrolls instead of growing — degraded, not broken. This composer's hosts are Tuval's desk and apps/web's `/lab` exhibit plus the `/__pi/*` dev harness, all Chromium-era developer surfaces, so the floor is comfortable.
  **Disposition:** Accepted, with the compat floor cited in the sheet at the rule.

---

### Amendment — 2026-09-09, at `66dc7be4`

This body opened at head `7010366c` and measured the empty composer at **92px**, the field at
**23px**, and called it a 47% cut. `review-code` passed that head and routed the 23px field to
#8714 as a Pillar 4 question; the answer came back that the floor is not spent here.

What the numbers were, and are:

| | field | hint | composer | cut |
|---|---|---|---|---|
| `7010366c` (original) | 23px | 0px | 92px | 47% |
| `66dc7be4` (current) | 36px | 0px | 105px | 40% |

Nothing else in the body changed but the height figures, the test count (75 → 77), and the new
Deviations entry disclosing this. The captures attached above are re-rendered at `66dc7be4`; the
ones posted against `7010366c` describe the earlier head and not this one.

Fixes #8669
