### PR TITLE
feat: Tuval's chat window still renders the design harness's in-window Inspector; the founder ruled it goes

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -1263,7 +1263,6 @@ function ChatWindow({
 							<AgentChatInput.Hint />
 							<AgentChatInput.Error />
 						</AgentChatInput.Surface>
-						<AgentChatInput.Inspector />
 						<AgentChatInput.ExtensionDialog />
 					</AgentChatInput.Frame>
 				</AgentChatInput.Root>


### PR DESCRIPTION
Tuval's chat window no longer mounts the design package's in-window `Inspector`. That disclosure was built for the web lab's mock harness — it lists the bridge activity log and harness widget lines, none of which a Tuval operator reads. Tuval's real session facts moved to the desk inspector in #8190, and #8221 named the two-Inspectors confusion. The founder ruled on 2026-09-09 that it goes from Tuval.

One line removed from `apps/tuval/src/shell/chat/ChatWindow.tsx` — the only `AgentChatInput.Inspector` mount under `apps/tuval/src`. `packages/design/src/agent-chat/Inspector.tsx`, the `AgentChatInput.Inspector` member and the monolith export are untouched, so the web lab still renders it.

`apps/tuval/src/shell/chat/copy.ts` keeps `"admin.agent.inspector"` and the `admin.agent.activity.*` lines: the catalog is typed `Readonly<Record<DesignCatalogKey, string>>`, a total map over keys the package still declares, so deleting the key is a typecheck failure rather than a cleanup. The desk's own `inspectorOpen` (`apps/tuval/src/shell/desk/state.ts`) and `AiAgentInspector.tsx` are untouched — different surface, unrelated flag.

Verified in this tree: `pnpm --filter @kampus/tuval typecheck` green (0 errors across all three projects), the tuval unit project green (274 files, 2845 tests), and `fabrika build check --surface code` green with nothing unvalidated.

No test asserts the in-window Inspector — #8711 records that the assembled-vs-plain parity test cannot see `Frame`, `Inspector` or `ExtensionDialog`, and closing that gap stays #8711's.

Fixes #8738

## Deviations

- **Scope narrowing** — **Said:** none. **Did:** none. **Why:** the diff is the single mount line the issue names. **Disposition:** none.
- **Out-of-scope change** — **Said:** none. **Did:** none. **Why:** nothing outside `ChatWindow.tsx` was touched. **Disposition:** none.
