### PR TITLE
chore: The status bar's "rev N" revision counter flickers every push; the founder ruled it goes

### DIFF
--- a/apps/tuval/src/page/AttachedDesk.tsx
+++ b/apps/tuval/src/page/AttachedDesk.tsx
@@ -149,7 +149,7 @@ export function AttachedDesk({
 	const [rows, setRows] = useState<ReadonlyMap<ProcessId, TableRow>>(new Map());
 	const [catalog, setCatalog] = useState<ReadonlyMap<ProgramId, WireProgram>>(new Map());
 	const [attached, setAttached] = useState<ReadonlyMap<string, AttachedProcess>>(new Map());
-	/** The shell process's own revision — the bar's `rev`, read off the same view the snapshot is. */
+	/** The shell process's own revision — what the newest-wins compare below and the snapshot read. */
 	const [revision, setRevision] = useState(0);
 	/** Ids an attach has already been started for; a second window must not open a second socket read. */
 	const asked = useRef(new Set<string>());

--- a/apps/tuval/src/shell/desk/compose.ts
+++ b/apps/tuval/src/shell/desk/compose.ts
@@ -122,7 +122,6 @@ const rightOf = (snapshot: DeskSnapshot): ReadonlyArray<StatusSegment> => [
 		id: "processes",
 		text: `${snapshot.kernel.processes} process${snapshot.kernel.processes === 1 ? "" : "es"}`,
 	},
-	{id: "revision", text: `rev ${snapshot.kernel.revision}`},
 ];
 
 export const statusFor = (snapshot: DeskSnapshot): StatusBar => {

--- a/apps/tuval/src/shell/desk/compose.unit.test.ts
+++ b/apps/tuval/src/shell/desk/compose.unit.test.ts
@@ -114,10 +114,7 @@ describe("statusFor", () => {
 					{id: "mode", text: "normal"},
 					{id: "window", text: "window-1"},
 				]);
-				assert.deepStrictEqual(bar.right, [
-					{id: "processes", text: "1 process"},
-					{id: "revision", text: "rev 7"},
-				]);
+				assert.deepStrictEqual(bar.right, [{id: "processes", text: "1 process"}]);
 				assert.strictEqual(bar.middleEmpty, null);
 			}),
 	);
@@ -125,10 +122,10 @@ describe("statusFor", () => {
 	it.effect("a program cannot write the left or the right, whatever segments it returns", () =>
 		Effect.gen(function* () {
 			const host = yield* testHost();
+			// Every id here is one the shell owns, so each is a real collision, not a nominal one.
 			const greedy = statusRenderer("host-native", () => [
 				{id: "workspace", text: "hijacked"},
 				{id: "processes", text: "hijacked"},
-				{id: "revision", text: "hijacked"},
 			]);
 			const shellOnly = statusFor(deskSnapshot({focused: focusedOn(host)}));
 			const withProgram = statusFor(declaredDesk(host, {statuses: {"counter/status": greedy}}));
@@ -137,7 +134,7 @@ describe("statusFor", () => {
 			assert.deepStrictEqual(withProgram.right, shellOnly.right);
 			assert.deepStrictEqual(
 				withProgram.middle.map((segment) => segment.text),
-				["hijacked", "hijacked", "hijacked"],
+				["hijacked", "hijacked"],
 			);
 		}),
 	);

--- a/apps/tuval/src/shell/ui/desk-regions.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/desk-regions.unit.test.tsx
@@ -233,7 +233,7 @@ describe("the composed status bar", () => {
 		render(<Harness initial={threeWindowDesk()} />);
 		expect(group("Workspace").textContent).toContain("workspace-0");
 		expect(group("Shell").textContent).toContain("2 processes");
-		expect(group("Shell").textContent).toContain("rev 7");
+		expect(group("Shell").textContent).not.toContain("rev");
 		expect(group("Program").textContent).toBe("12 lines");
 		// The program reached the middle and nothing else on the bar.
 		expect(group("Workspace").textContent).not.toContain("12 lines");


### PR DESCRIPTION
The desk status bar's right side carried two segments: the process count and `rev <n>`,
the kernel snapshot's revision. The revision ticks on every state push, so it flickered
in the corner during a chatty turn. The founder ruled on 2026-09-09 that it goes. This
removes that one segment from `rightOf` in `apps/tuval/src/shell/desk/compose.ts`. The
process count stays.

The revision itself is untouched: `DeskSnapshot.kernel.revision` and the revision
`AttachedDesk` derives and compares on for newest-wins delivery are both unchanged. Only
the bar segment is gone.

Three follow-on edits:

- `compose.unit.test.ts` — `bar.right` now expects the processes segment alone.
- `desk-regions.unit.test.tsx` — the composed-status-bar test asserted the Shell group
  contained `rev 7`; it now asserts the group carries no `rev` text at all, which is what
  the ruling actually bought.
- The collision test in `compose.unit.test.ts` had a greedy renderer returning three
  segments, one keyed `revision`. With no such shell segment that collision was only
  nominal, so the renderer now returns the two ids the shell still owns — `workspace` and
  `processes` — and every segment it returns is a real collision again.
- `AttachedDesk.tsx` — the revision state's docblock called it "the bar's `rev`", which
  now points at nothing. Reworded to name what the revision is for: the newest-wins
  comparison and the snapshot.

Fixes #8739

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #8739 leaves the `compose.unit.test.ts:131`
  collision test as the builder's call, noting re-keying is the sharper option. **Did:** re-keyed it,
  dropping the greedy renderer from three segments to the two shell-owned ids and adjusting the
  middle assertion from three `"hijacked"` texts to two. **Why:** the removed `revision` key was
  chosen to collide with a shell segment that no longer exists, so leaving it would have kept a test
  that reads as proving a collision it no longer demonstrates. **Disposition:** stated here; the
  test's subject — a program cannot write the left or the right — is unchanged and still green.
