### PR TITLE
fix: Tuval renders the CLI's command-name frame as a raw-markup YOU row

### DIFF
--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -92,6 +92,7 @@ describe("the Claude history mapping is pure", () => {
 			"local-command-caveat-turn",
 			"local-command-invocation-turn",
 			"local-command-lines-turn",
+			"local-command-skill-turn",
 			"local-command-turn",
 			"oversized-tool-turn",
 			"permission-denied",

--- a/apps/tuval/src/claude/history/boundary.unit.test.ts
+++ b/apps/tuval/src/claude/history/boundary.unit.test.ts
@@ -90,6 +90,7 @@ describe("the Claude history mapping is pure", () => {
 			"init",
 			"interrupted-assistant",
 			"local-command-caveat-turn",
+			"local-command-invocation-turn",
 			"local-command-lines-turn",
 			"local-command-turn",
 			"oversized-tool-turn",

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -6,13 +6,14 @@ and ADR [0180](../../../../../../.decisions/0180-capture-real-runtime-artifact-b
 Nothing here is hand-authored: the SDK's message shapes are observable only at execution, so an
 invented envelope would prove the mapping against a contract nobody emits.
 
-Most of them came off `query()`. Six did not, because no `query()` run can force what they carry;
+Most of them came off `query()`. Seven did not, because no `query()` run can force what they carry;
 they were excerpted from an operator's own CLI session log and re-keyed to the SDK's declared
 envelope, and the two sections below say exactly which part of each is the captured part.
 
 ## What produced them
 
-The rows below describe the `query()` captures; the six excerpted fixtures have their own sections.
+The rows below describe the `query()` captures; the seven excerpted fixtures have their own
+sections.
 
 | | |
 |---|---|
@@ -47,7 +48,7 @@ in order.
 | `streaming-turn.json` | one prompt with `includePartialMessages: true`, captured 2026-09-06 — the whole `stream_event` run of one turn, `message_start` through `message_stop` (#8172) |
 | `subagent-turn.json` | one prompt asking for a single `Task` spawn, run with `forwardSubagentText: true` and `includePartialMessages: true` on `claude-opus-5` with `thinking: {type: "enabled", budgetTokens: 8000}`, captured 2026-09-07 — the whole 74-frame run of a turn that spawns one worker (#8403) |
 | `two-subagent-turn.json` | the same options on `claude-fable-5-1`, with a prompt asking for **two** `Explore` workers in parallel over two files in the throwaway cwd, captured 2026-09-07 — the whole 59-frame run, and the one capture where two workers overlap (#8408) |
-| `local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json` | excerpted from an operator's own CLI session transcript, from sessions where a slash command ran — see below |
+| `local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json`, `local-command-invocation-turn.json` | excerpted from an operator's own CLI session transcript, from sessions where a slash command ran — see below |
 | `thinking-turn.json` | excerpted from an operator's own CLI session transcript, not from a `query()` run — see below |
 | `compact-boundary.json` | the same, from a session that compacted |
 | `informational-notice.json` | the same, from a session that hit a usage limit |
@@ -122,18 +123,22 @@ Sanitization is the same as everywhere else here: uuids, `msg_*` and `req_*` ids
 consistently, the thinking block's signature replaced with a short placeholder, and every CLI-only
 field naming a machine or a checkout dropped rather than rewritten.
 
-## The three local-command captures
+## The four local-command captures
 
-`local-command-turn.json`, `local-command-lines-turn.json` and `local-command-caveat-turn.json`
-are the same kind of excerpt as the three above, under the same founder ruling
+`local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json` and
+`local-command-invocation-turn.json` are the same kind of excerpt as the three above, under the same
+founder ruling
 ([#8151](https://github.com/kamp-us/phoenix/issues/8151#issuecomment-5556626806)), and for the same
 reason: a slash command is the CLI's, so no `query()` run can produce one. Each is the record of one
-command the operator ran — `/model`, `/terminal-setup` and `/effort` in that order.
+command the operator ran — `/model`, `/terminal-setup`, `/effort` and `/effort` in that order.
 
 The first two are the command's **output**, and they are why #8211 exists: the CLI writes a result
 as a user-role message whose whole text is a `<local-command-stdout>` wrapper, which the mapping
 read as an operator turn. The third is the **caveat** the CLI writes ahead of that output, and it is
-why #8641 does.
+why #8641 does. The fourth is the **invocation record** the CLI writes between them, and it is why
+#8665 does — the last of the three user-role frames one slash command writes to reach the mapping
+as raw markup under YOU. The last two came out of one `/effort` run in one session, so the corpus
+now holds that whole three-frame sequence.
 
 ### The two output captures
 
@@ -171,6 +176,26 @@ path. `../map.ts` matches the tag instead, and this fixture is what holds it to 
 The text is the golden part and it is fixed boilerplate — the same sentence on every occurrence, so
 this one row stands for all 1,774 of them in the corpus it was counted in. Sanitized as everywhere
 else here: the uuid and session id substituted. The row carries no path.
+
+### The invocation record
+
+`local-command-invocation-turn.json` is the frame between the caveat and the output — the CLI's
+record of *which* command ran, as `<command-name>` and its `<command-message>` / `<command-args>`
+siblings in one user-role message. It records `/effort medium`, and it is the row immediately after
+the caveat capture above, out of the same session and the same run.
+
+| | |
+|---|---|
+| Captured | 2026-09-09, from a local session transcript written by CLI **2.1.220** — the `/effort` invocation, the row timestamped `2026-07-25T23:22:33.911Z` |
+| Verbatim | the whole `message` body — the role and the three tags with the CLI's own line breaks and indentation between them, character for character — and the row's own `timestamp` |
+| Re-keyed | `sessionId` → `session_id`, `parent_tool_use_id`/`parent_agent_id` added as `null`, and the CLI-only keys (`parentUuid`, `promptId`, `cwd`, `gitBranch`, `version`, `userType`, `entrypoint`, `isSidechain`) dropped |
+
+The indentation is the golden part rather than a formatting slip: the CLI writes the second and
+third tags indented twelve spaces, so a matcher that expects the tags flush against each other
+would fail on every real frame. It carries no `isMeta` — that flag is the caveat's, which is why
+`../map.ts` matches this frame by its tags and not by a field.
+
+Sanitized as everywhere else here: the uuid and session id substituted. The row carries no path.
 
 ## The sidechain capture
 
@@ -210,7 +235,7 @@ sidechain file is still uncovered here and rides
 ## What was sanitized, and what is golden
 
 For the `query()` captures, the **key set and the field shapes are the golden part** and are
-untouched. The six excerpted fixtures are re-keyed instead, exactly as the two sections above
+untouched. The seven excerpted fixtures are re-keyed instead, exactly as the two sections above
 record —
 their golden part is the payload inside that envelope, not the envelope. Substituted, in both
 groups:
@@ -303,11 +328,11 @@ an operator act, not a test fixture generator. To re-capture the `query()` fixtu
 from a scratch directory exactly as the first table describes, then apply the substitutions above
 before the JSON comes anywhere near this directory.
 
-The six excerpted fixtures cannot be re-produced that way — no `query()` run forces reasoning, a
+The seven excerpted fixtures cannot be re-produced that way — no `query()` run forces reasoning, a
 compaction, a usage-limit notice or a slash command. Re-producing them means finding the frame again
 in an operator's own local CLI session log and re-keying it against `sdk.d.ts` at the catalog pin,
 per the table in
 [the section above](#the-three-excerpted-from-a-cli-session-transcript) or in
-[the one after it](#the-three-local-command-captures). Replacing them with real
+[the one after it](#the-four-local-command-captures). Replacing them with real
 `query()` captures is [#8038](https://github.com/kamp-us/phoenix/issues/8038)'s live capture run,
 which is where `compact-boundary.json`'s declaration-derived key names get closed.

--- a/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
+++ b/apps/tuval/src/claude/history/fixtures/PROVENANCE.md
@@ -6,13 +6,13 @@ and ADR [0180](../../../../../../.decisions/0180-capture-real-runtime-artifact-b
 Nothing here is hand-authored: the SDK's message shapes are observable only at execution, so an
 invented envelope would prove the mapping against a contract nobody emits.
 
-Most of them came off `query()`. Seven did not, because no `query()` run can force what they carry;
+Most of them came off `query()`. Eight did not, because no `query()` run can force what they carry;
 they were excerpted from an operator's own CLI session log and re-keyed to the SDK's declared
 envelope, and the two sections below say exactly which part of each is the captured part.
 
 ## What produced them
 
-The rows below describe the `query()` captures; the seven excerpted fixtures have their own
+The rows below describe the `query()` captures; the eight excerpted fixtures have their own
 sections.
 
 | | |
@@ -48,7 +48,7 @@ in order.
 | `streaming-turn.json` | one prompt with `includePartialMessages: true`, captured 2026-09-06 — the whole `stream_event` run of one turn, `message_start` through `message_stop` (#8172) |
 | `subagent-turn.json` | one prompt asking for a single `Task` spawn, run with `forwardSubagentText: true` and `includePartialMessages: true` on `claude-opus-5` with `thinking: {type: "enabled", budgetTokens: 8000}`, captured 2026-09-07 — the whole 74-frame run of a turn that spawns one worker (#8403) |
 | `two-subagent-turn.json` | the same options on `claude-fable-5-1`, with a prompt asking for **two** `Explore` workers in parallel over two files in the throwaway cwd, captured 2026-09-07 — the whole 59-frame run, and the one capture where two workers overlap (#8408) |
-| `local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json`, `local-command-invocation-turn.json` | excerpted from an operator's own CLI session transcript, from sessions where a slash command ran — see below |
+| `local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json`, `local-command-invocation-turn.json`, `local-command-skill-turn.json` | excerpted from an operator's own CLI session transcript, from sessions where a slash command or a skill ran — see below |
 | `thinking-turn.json` | excerpted from an operator's own CLI session transcript, not from a `query()` run — see below |
 | `compact-boundary.json` | the same, from a session that compacted |
 | `informational-notice.json` | the same, from a session that hit a usage limit |
@@ -123,22 +123,26 @@ Sanitization is the same as everywhere else here: uuids, `msg_*` and `req_*` ids
 consistently, the thinking block's signature replaced with a short placeholder, and every CLI-only
 field naming a machine or a checkout dropped rather than rewritten.
 
-## The four local-command captures
+## The five local-command captures
 
-`local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json` and
-`local-command-invocation-turn.json` are the same kind of excerpt as the three above, under the same
-founder ruling
+`local-command-turn.json`, `local-command-lines-turn.json`, `local-command-caveat-turn.json`,
+`local-command-invocation-turn.json` and `local-command-skill-turn.json` are the same kind of
+excerpt as the three above, under the same founder ruling
 ([#8151](https://github.com/kamp-us/phoenix/issues/8151#issuecomment-5556626806)), and for the same
 reason: a slash command is the CLI's, so no `query()` run can produce one. Each is the record of one
-command the operator ran — `/model`, `/terminal-setup`, `/effort` and `/effort` in that order.
+command that ran — `/model`, `/terminal-setup`, `/effort`, `/effort` and `fabrika:triage` in that
+order.
 
 The first two are the command's **output**, and they are why #8211 exists: the CLI writes a result
 as a user-role message whose whole text is a `<local-command-stdout>` wrapper, which the mapping
 read as an operator turn. The third is the **caveat** the CLI writes ahead of that output, and it is
 why #8641 does. The fourth is the **invocation record** the CLI writes between them, and it is why
-#8665 does — the last of the three user-role frames one slash command writes to reach the mapping
-as raw markup under YOU. The last two came out of one `/effort` run in one session, so the corpus
-now holds that whole three-frame sequence.
+#8665 does — the last of the three still landing as raw markup under YOU. The fifth is that same
+record in a **skill's** hand, and it is why acceptance criterion 10 of #8665 does.
+
+So the corpus covers all three frame kinds a slash command writes, not one run's three frames: the
+caveat and the invocation are the first two frames of one `/effort` run, the two outputs are from
+two other runs, and that `/effort` run's own output was never captured.
 
 ### The two output captures
 
@@ -197,6 +201,34 @@ would fail on every real frame. It carries no `isMeta` — that flag is the cave
 
 Sanitized as everywhere else here: the uuid and session id substituted. The row carries no path.
 
+### The skill invocation record
+
+`local-command-skill-turn.json` is the same record written for a **skill** rather than a plain
+slash command, and it is what holds `../map.ts` to the two ways that hand differs. The tag order is
+one: this frame writes `<command-message>` first and `<command-name>` second, where the plain
+command writes them the other way round. The second is `<skill-format>`, a sibling the plain
+command never writes — and the frame that carries it carries the whole skill body after its tags,
+in a second content block, which is why the mapping reads that body as the notice's `detail`
+instead of refusing the frame for having text past the tags.
+
+| | |
+|---|---|
+| Captured | 2026-09-09, from a subagent's own transcript in a local session written by CLI **2.1.233** — a `fabrika:triage` worker's inbound frame, the row timestamped `2026-08-18T01:48:12.086Z` |
+| Verbatim | the tag block, character for character; the two-block `content` array's own shape; the role; and the row's own `timestamp` |
+| Trimmed | the second block — the skill's body, 9,477 bytes in the capture — cut to its first six lines, the same kind of trim the `init` discovery lists take below |
+| Re-keyed | `sessionId` → `session_id`, `parent_tool_use_id`/`parent_agent_id` added as `null`, and the CLI-only keys (`parentUuid`, `promptId`, `agentId`, `isMeta`, `isSidechain`, `cwd`, `gitBranch`, `version`, `userType`, `entrypoint`) dropped |
+
+Two of those dropped keys are worth naming. `isSidechain: true` says the row is a worker's, not the
+operator's; `agentId` names that worker. Neither is a field the SDK's row mapper reads, so neither
+reaches the mapping down the history path, and the fixture's `parent_agent_id` is `null` for the
+same reason the caveat's is — the re-key adds it, the CLI record has no such key.
+
+The body's one absolute path was rewritten to `/tmp/tuval-capture` as everywhere else here, along
+with the uuid and session id. **The plugin-command shape is not captured**: a plugin command writes
+`<command-message>` first like this one but adds no `<skill-format>` and no body, and
+`../local-command.unit.test.ts` covers it with a `/unslop` frame's text quoted verbatim over this
+envelope rather than with a fixture of its own.
+
 ## The sidechain capture
 
 `agent-a1b2c3d4e5f60718a.jsonl` and `agent-a1b2c3d4e5f60718a.meta.json` are one subagent's own
@@ -235,7 +267,7 @@ sidechain file is still uncovered here and rides
 ## What was sanitized, and what is golden
 
 For the `query()` captures, the **key set and the field shapes are the golden part** and are
-untouched. The seven excerpted fixtures are re-keyed instead, exactly as the two sections above
+untouched. The eight excerpted fixtures are re-keyed instead, exactly as the two sections above
 record —
 their golden part is the payload inside that envelope, not the envelope. Substituted, in both
 groups:
@@ -328,11 +360,11 @@ an operator act, not a test fixture generator. To re-capture the `query()` fixtu
 from a scratch directory exactly as the first table describes, then apply the substitutions above
 before the JSON comes anywhere near this directory.
 
-The seven excerpted fixtures cannot be re-produced that way — no `query()` run forces reasoning, a
+The eight excerpted fixtures cannot be re-produced that way — no `query()` run forces reasoning, a
 compaction, a usage-limit notice or a slash command. Re-producing them means finding the frame again
 in an operator's own local CLI session log and re-keying it against `sdk.d.ts` at the catalog pin,
 per the table in
 [the section above](#the-three-excerpted-from-a-cli-session-transcript) or in
-[the one after it](#the-four-local-command-captures). Replacing them with real
+[the one after it](#the-five-local-command-captures). Replacing them with real
 `query()` captures is [#8038](https://github.com/kamp-us/phoenix/issues/8038)'s live capture run,
 which is where `compact-boundary.json`'s declaration-derived key names get closed.

--- a/apps/tuval/src/claude/history/fixtures/load.ts
+++ b/apps/tuval/src/claude/history/fixtures/load.ts
@@ -19,6 +19,7 @@ export type FixtureName =
 	| "local-command-caveat-turn"
 	| "local-command-invocation-turn"
 	| "local-command-lines-turn"
+	| "local-command-skill-turn"
 	| "local-command-turn"
 	| "oversized-tool-turn"
 	| "permission-denied"

--- a/apps/tuval/src/claude/history/fixtures/load.ts
+++ b/apps/tuval/src/claude/history/fixtures/load.ts
@@ -17,6 +17,7 @@ export type FixtureName =
 	| "init"
 	| "interrupted-assistant"
 	| "local-command-caveat-turn"
+	| "local-command-invocation-turn"
 	| "local-command-lines-turn"
 	| "local-command-turn"
 	| "oversized-tool-turn"

--- a/apps/tuval/src/claude/history/fixtures/local-command-invocation-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/local-command-invocation-turn.json
@@ -1,0 +1,12 @@
+{
+	"type": "user",
+	"uuid": "00000000-0000-4000-8000-000000000079",
+	"session_id": "00000000-0000-4000-8000-000000000080",
+	"message": {
+		"role": "user",
+		"content": "<command-name>/effort</command-name>\n            <command-message>effort</command-message>\n            <command-args>medium</command-args>"
+	},
+	"parent_tool_use_id": null,
+	"parent_agent_id": null,
+	"timestamp": "2026-07-25T23:22:33.911Z"
+}

--- a/apps/tuval/src/claude/history/fixtures/local-command-skill-turn.json
+++ b/apps/tuval/src/claude/history/fixtures/local-command-skill-turn.json
@@ -1,0 +1,21 @@
+{
+	"type": "user",
+	"uuid": "00000000-0000-4000-8000-000000000081",
+	"session_id": "00000000-0000-4000-8000-000000000082",
+	"message": {
+		"role": "user",
+		"content": [
+			{
+				"type": "text",
+				"text": "<command-message>fabrika:triage</command-message>\n<command-name>fabrika:triage</command-name>\n<skill-format>true</skill-format>"
+			},
+			{
+				"type": "text",
+				"text": "Base directory for this skill: /tmp/tuval-capture/claude-plugins/fabrika/skills/triage\n\n# triage\n\nYou are the guardrail. **The failure that matters is not a missing label — it is a confident wrong\none**, indistinguishable from a correct one once it lands. Each step makes its answer checkable, not"
+			}
+		]
+	},
+	"parent_tool_use_id": null,
+	"parent_agent_id": null,
+	"timestamp": "2026-08-18T01:48:12.086Z"
+}

--- a/apps/tuval/src/claude/history/local-command.unit.test.ts
+++ b/apps/tuval/src/claude/history/local-command.unit.test.ts
@@ -4,8 +4,9 @@
  * The CLI runs a command like `/model` locally and records its caveat, the invocation itself and
  * its result as user-role messages whose whole text is markup. Read as turns they land under YOU,
  * tags and terminal escapes included — the shape the founder's desk screenshot caught. The output
- * and the invocation each become their own notice, the caveat becomes nothing. Every fixture here
- * is that record, taken
+ * and the invocation each become their own notice, the caveat becomes nothing. A plugin's or a
+ * skill's invocation is the same record in a different hand — its tags come in another order, and a
+ * skill's carries the whole skill body after them. Every fixture here is that record, taken
  * from an operator's own CLI session log under the founder's ruling on
  * [#8151](https://github.com/kamp-us/phoenix/issues/8151#issuecomment-5556626806) and re-keyed to
  * `SessionMessage` (`fixtures/PROVENANCE.md`).
@@ -149,7 +150,7 @@ describe("a captured local command's invocation record", () => {
 		);
 	});
 
-	it("is one row above the output's own, over the three frames one command writes", () => {
+	it("puts the invocation above the output, over one of each frame kind", () => {
 		const command = [
 			frame("local-command-caveat-turn") as SessionMessage,
 			captured as SessionMessage,
@@ -181,6 +182,58 @@ describe("a captured local command's invocation record", () => {
 		const [one] = mapped(withText(captured, prompt));
 		expect(one?.kind).toBe("user");
 		expect(one?.kind === "user" ? one.text : "").toBe(prompt);
+	});
+});
+
+describe("a captured skill invocation", () => {
+	const captured = frame("local-command-skill-turn");
+	const body =
+		"Base directory for this skill: /tmp/tuval-capture/claude-plugins/fabrika/skills/triage\n\n# triage\n\nYou are the guardrail. **The failure that matters is not a missing label — it is a confident wrong\none**, indistinguishable from a correct one once it lands. Each step makes its answer checkable, not";
+
+	it("lands as a notice naming the skill, with its body behind the disclosure", () => {
+		expect(mapped(captured)).toEqual([
+			{
+				kind: "system",
+				id: "00000000-0000-4000-8000-000000000081",
+				timestamp: Date.parse("2026-08-18T01:48:12.086Z"),
+				text: "fabrika:triage",
+				detail: body,
+			},
+		]);
+	});
+
+	it("replays the same way off a stored session", () => {
+		const {items, skipped} = toHistoryItems([captured as SessionMessage], {at: AT});
+		expect(items.map((one) => (one.kind === "system" ? one.text : one.kind))).toEqual([
+			"fabrika:triage",
+		]);
+		expect(skipped).toBe(0);
+	});
+
+	// Verbatim from a `/unslop` row in an operator's own session log: a plugin command writes the
+	// two tags in this order and adds neither `<command-args>` nor `<skill-format>`.
+	it("reads a plugin command that writes its message tag ahead of its name", () => {
+		const plugin =
+			"<command-message>unslop</command-message>\n<command-name>/unslop</command-name>";
+		const [one] = mapped(withText(captured, plugin));
+		expect(one?.kind).toBe("system");
+		expect(one?.kind === "system" ? one.text : "").toBe("/unslop");
+		expect(one?.kind === "system" ? one.detail : "none").toBeUndefined();
+	});
+
+	it("stays a user item when a prompt writes tags and then prose without the skill marker", () => {
+		const prompt =
+			"<command-message>unslop</command-message>\n<command-name>/unslop</command-name>\nwhy is this my message?";
+		const [one] = mapped(withText(captured, prompt));
+		expect(one?.kind).toBe("user");
+		expect(one?.kind === "user" ? one.text : "").toBe(prompt);
+	});
+
+	it("stays a user item when a tag repeats, which no invocation record does", () => {
+		const prompt =
+			"<command-name>/a</command-name>\n<command-name>/b</command-name>\n<command-args>x</command-args>";
+		const [one] = mapped(withText(captured, prompt));
+		expect(one?.kind).toBe("user");
 	});
 });
 

--- a/apps/tuval/src/claude/history/local-command.unit.test.ts
+++ b/apps/tuval/src/claude/history/local-command.unit.test.ts
@@ -1,10 +1,11 @@
 /**
- * A slash command's own frames are the session's word, not the operator's (#8211, #8641).
+ * A slash command's own frames are the session's word, not the operator's (#8211, #8641, #8665).
  *
- * The CLI runs a command like `/model` locally and records both its caveat and its result as
- * user-role messages whose whole text is one wrapper. Read as turns they land under YOU, wrapper
- * and terminal escapes included — the shape the founder's desk screenshot caught. The output
- * becomes a notice, the caveat becomes nothing. All three fixtures here are that record, taken
+ * The CLI runs a command like `/model` locally and records its caveat, the invocation itself and
+ * its result as user-role messages whose whole text is markup. Read as turns they land under YOU,
+ * tags and terminal escapes included — the shape the founder's desk screenshot caught. The output
+ * and the invocation each become their own notice, the caveat becomes nothing. Every fixture here
+ * is that record, taken
  * from an operator's own CLI session log under the founder's ruling on
  * [#8151](https://github.com/kamp-us/phoenix/issues/8151#issuecomment-5556626806) and re-keyed to
  * `SessionMessage` (`fixtures/PROVENANCE.md`).
@@ -95,6 +96,88 @@ describe("an operator's own turn on the same envelope", () => {
 	it("stays a user item when the prompt quotes the wrapper as a code example", () => {
 		const prompt =
 			"```\n<local-command-stdout>Set model to X</local-command-stdout>\n```\nfix this";
+		const [one] = mapped(withText(captured, prompt));
+		expect(one?.kind).toBe("user");
+		expect(one?.kind === "user" ? one.text : "").toBe(prompt);
+	});
+});
+
+describe("a captured local command's invocation record", () => {
+	const captured = frame("local-command-invocation-turn");
+
+	it("lands as its own session notice naming the command and its arguments", () => {
+		expect(mapped(captured)).toEqual([
+			{
+				kind: "system",
+				id: "00000000-0000-4000-8000-000000000079",
+				timestamp: Date.parse("2026-07-25T23:22:33.911Z"),
+				text: "/effort medium",
+			},
+		]);
+	});
+
+	it("shows the invocation as readable text: no tags, no colour escapes", () => {
+		const [one] = mapped(captured);
+		const line = one?.kind === "system" ? one.text : "";
+		expect(line).not.toMatch(/[<>]/);
+		expect(line).not.toMatch(new RegExp(String.fromCharCode(27)));
+	});
+
+	it("replays the same way off a stored session, so an old session reads back as it ran", () => {
+		const {items, skipped} = toHistoryItems([captured as SessionMessage], {at: AT});
+		expect(items).toEqual([
+			{
+				kind: "system",
+				id: "00000000-0000-4000-8000-000000000079",
+				timestamp: Date.parse("2026-07-25T23:22:33.911Z"),
+				text: "/effort medium",
+			},
+		]);
+		expect(skipped).toBe(0);
+	});
+
+	it("names the command alone when the invocation carries no arguments", () => {
+		const [one] = mapped(withText(captured, "<command-name>/clear</command-name>"));
+		expect(one?.kind === "system" ? one.text : "").toBe("/clear");
+	});
+
+	it("leaves the command's own output its own separate notice", () => {
+		const [one] = mapped(frame("local-command-turn"));
+		expect(one?.kind).toBe("system");
+		expect(one?.kind === "system" ? one.text : "").toBe(
+			"Set model to Fable 5 and saved as your default for new sessions",
+		);
+	});
+
+	it("is one row above the output's own, over the three frames one command writes", () => {
+		const command = [
+			frame("local-command-caveat-turn") as SessionMessage,
+			captured as SessionMessage,
+			frame("local-command-turn") as SessionMessage,
+		];
+		const {items, skipped} = toHistoryItems(command, {at: AT});
+		expect(items.map((one) => one.kind)).toEqual(["system", "system"]);
+		expect(items.map((one) => (one.kind === "system" ? one.text : ""))).toEqual([
+			"/effort medium",
+			"Set model to Fable 5 and saved as your default for new sessions",
+		]);
+		expect(skipped).toBe(1);
+	});
+
+	it("stays a user item when the prompt merely quotes the invocation markup", () => {
+		const prompt = "why does <command-name>/effort</command-name> show up as my message?";
+		expect(mapped(withText(captured, prompt))).toEqual([
+			{
+				kind: "user",
+				id: "00000000-0000-4000-8000-000000000079",
+				timestamp: Date.parse("2026-07-25T23:22:33.911Z"),
+				text: prompt,
+			},
+		]);
+	});
+
+	it("stays a user item when the prompt opens with the tag and then says more", () => {
+		const prompt = "<command-name>/effort</command-name> is what I ran — why the raw markup?";
 		const [one] = mapped(withText(captured, prompt));
 		expect(one?.kind).toBe("user");
 		expect(one?.kind === "user" ? one.text : "").toBe(prompt);

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -641,7 +641,8 @@ const sgr = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
  *
  * The match is the captured shape and nothing looser: the text must *be* the wrapper, so a prompt
  * quoting or explaining these tags is still the operator's own and stays one. The sibling
- * `<local-command-caveat>` frame is `isLocalCommandCaveat`'s; `<command-name>` is read nowhere yet.
+ * `<local-command-caveat>` frame is `isLocalCommandCaveat`'s, and the `<command-name>` frame
+ * between them is `localCommandInvocationOf`'s.
  */
 const localCommandOutputOf = (text: string): string | null => {
 	const trimmed = text.trim();
@@ -666,6 +667,43 @@ const isLocalCommandCaveat = (text: string): boolean => {
 };
 
 /**
+ * One `<command-name>` / `<command-message>` / `<command-args>` block of the invocation record,
+ * matched at the head of what is left. Each tag may appear once, and `command-name` opens the frame.
+ */
+const COMMAND_TAG = /^<(command-name|command-message|command-args)>([\s\S]*?)<\/\1>/;
+
+const COMMAND_NAME_OPEN = "<command-name>";
+
+/**
+ * The command a slash-command invocation names, with its arguments, when this user frame is the
+ * CLI's record of that invocation rather than a turn.
+ *
+ * The middle of the three frames one slash command writes: the caveat, this record, then the
+ * output. Unlike the caveat it carries something a reader wants — which command ran — so it becomes
+ * its own notice rather than nothing (#8665). `<command-message>` restates the name and is dropped.
+ *
+ * The match is the whole trimmed text, as it is for the two siblings: every tag is consumed in turn
+ * and anything left over means this is an operator's prompt quoting the markup, which stays theirs.
+ */
+const localCommandInvocationOf = (text: string): string | null => {
+	let rest = text.trim();
+	if (!rest.startsWith(COMMAND_NAME_OPEN)) return null;
+	const parts = new Map<string, string>();
+	while (rest.length > 0) {
+		const match = COMMAND_TAG.exec(rest);
+		if (match === null) return null;
+		const [whole, tag, inner] = match;
+		if (tag === undefined || inner === undefined || parts.has(tag)) return null;
+		parts.set(tag, inner.replaceAll(sgr, "").trim());
+		rest = rest.slice(whole.length).trimStart();
+	}
+	const name = parts.get("command-name") ?? "";
+	if (name.length === 0) return null;
+	const args = parts.get("command-args") ?? "";
+	return args.length === 0 ? name : `${name} ${args}`;
+};
+
+/**
  * One command's output as the collapsed notice's two fields: the line always shown, and the whole
  * output behind the disclosure whenever that line is not all of it (`shell/chat/SessionRow.tsx`).
  */
@@ -681,8 +719,24 @@ const noticeOf = (output: string): {readonly text: string; readonly detail?: str
 };
 
 /**
- * A user frame is either the operator's prompt, a local command's caveat or output, or the results
- * of the calls the last turn opened.
+ * What one user frame stands for: the operator's own turn, or one of the two slash-command frames
+ * the CLI writes under the operator's role — the invocation record and the command's output. Each
+ * is read off its own text alone, so nothing has to survive between the frames of one command.
+ */
+const promptItemOf = (
+	text: string,
+	base: {readonly id: ItemId; readonly timestamp: number; readonly parentId?: ItemId},
+): TranscriptItem => {
+	const output = localCommandOutputOf(text);
+	if (output !== null) return {kind: "system", ...base, ...noticeOf(output)};
+	const invocation = localCommandInvocationOf(text);
+	if (invocation !== null) return {kind: "system", ...base, text: invocation};
+	return {kind: "user", ...base, text};
+};
+
+/**
+ * A user frame is either the operator's prompt, a local command's caveat, invocation record or
+ * output, or the results of the calls the last turn opened.
  *
  * A result whose call this mapping never saw is dropped and counted: the item union has no
  * name-less tool row, and inventing one would put a lie on screen. It happens only to a reader
@@ -706,11 +760,7 @@ export const userEvents = (
 		// A worker's inbound turn is parent-tagged too, and untagged it landed top-level beside the
 		// agent's own prose — seen live on #8400's desk run.
 		const tag = framedParentId === null ? {} : {parentId: itemId(framedParentId)};
-		const output = localCommandOutputOf(text);
-		const prompt: TranscriptItem =
-			output === null
-				? {kind: "user", id: itemId(id), timestamp: at, text, ...tag}
-				: {kind: "system", id: itemId(id), timestamp: at, ...noticeOf(output), ...tag};
+		const prompt = promptItemOf(text, {id: itemId(id), timestamp: at, ...tag});
 		const folded = foldSlots(mapping, [prompt], framedParentId, 0);
 		return {
 			mapping: {...mapping, subagents: folded.subagents},

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -667,12 +667,14 @@ const isLocalCommandCaveat = (text: string): boolean => {
 };
 
 /**
- * One `<command-name>` / `<command-message>` / `<command-args>` block of the invocation record,
- * matched at the head of what is left. Each tag may appear once, and `command-name` opens the frame.
+ * One tag of the invocation record, matched at the head of what is left. The set is open rather
+ * than the three the plain slash command writes, because a plugin or skill invocation carries
+ * siblings of its own — `<skill-format>` on every one (`fixtures/local-command-skill-turn.json`).
  */
-const COMMAND_TAG = /^<(command-name|command-message|command-args)>([\s\S]*?)<\/\1>/;
+const COMMAND_TAG = /^<([a-z][a-z-]*)>([\s\S]*?)<\/\1>/;
 
-const COMMAND_NAME_OPEN = "<command-name>";
+/** The CLI's marker that this frame is a skill's, and that the skill's own body follows its tags. */
+const SKILL_FORMAT = "skill-format";
 
 /**
  * The command a slash-command invocation names, with its arguments, when this user frame is the
@@ -682,16 +684,21 @@ const COMMAND_NAME_OPEN = "<command-name>";
  * output. Unlike the caveat it carries something a reader wants — which command ran — so it becomes
  * its own notice rather than nothing (#8665). `<command-message>` restates the name and is dropped.
  *
- * The match is the whole trimmed text, as it is for the two siblings: every tag is consumed in turn
- * and anything left over means this is an operator's prompt quoting the markup, which stays theirs.
+ * Order is not fixed and the tag set is not closed: a plain command writes `<command-name>` first,
+ * a plugin command writes `<command-message>` first, and a skill's frame adds `<skill-format>` and
+ * then the whole skill body. So the read is the tags themselves — every one consumed in turn, each
+ * at most once, and `<command-name>` required. What is left over decides the rest: on a skill frame
+ * it is the body and rides the notice's `detail`, and anywhere else it means an operator wrote
+ * about the markup, which stays their own turn.
  */
-const localCommandInvocationOf = (text: string): string | null => {
+const localCommandInvocationOf = (
+	text: string,
+): {readonly text: string; readonly detail?: string} | null => {
 	let rest = text.trim();
-	if (!rest.startsWith(COMMAND_NAME_OPEN)) return null;
 	const parts = new Map<string, string>();
 	while (rest.length > 0) {
 		const match = COMMAND_TAG.exec(rest);
-		if (match === null) return null;
+		if (match === null) break;
 		const [whole, tag, inner] = match;
 		if (tag === undefined || inner === undefined || parts.has(tag)) return null;
 		parts.set(tag, inner.replaceAll(sgr, "").trim());
@@ -699,8 +706,12 @@ const localCommandInvocationOf = (text: string): string | null => {
 	}
 	const name = parts.get("command-name") ?? "";
 	if (name.length === 0) return null;
+	// A skill's own body follows its tags in the same frame, and only there: without the CLI's
+	// `<skill-format>` marker, text past the tags is an operator writing about the markup.
+	if (rest.length > 0 && !parts.has(SKILL_FORMAT)) return null;
 	const args = parts.get("command-args") ?? "";
-	return args.length === 0 ? name : `${name} ${args}`;
+	const line = args.length === 0 ? name : `${name} ${args}`;
+	return rest.length === 0 ? {text: line} : {text: line, detail: rest.replaceAll(sgr, "")};
 };
 
 /**
@@ -730,7 +741,7 @@ const promptItemOf = (
 	const output = localCommandOutputOf(text);
 	if (output !== null) return {kind: "system", ...base, ...noticeOf(output)};
 	const invocation = localCommandInvocationOf(text);
-	if (invocation !== null) return {kind: "system", ...base, text: invocation};
+	if (invocation !== null) return {kind: "system", ...base, ...invocation};
 	return {kind: "user", ...base, text};
 };
 


### PR DESCRIPTION
The CLI writes three consecutive user-role frames per slash command. Two were already handled —
`<local-command-stdout>` became a system notice (#8211) and `<local-command-caveat>` became nothing
(#8641). The middle one, the `<command-name>` invocation record, still fell through as an ordinary
prompt, so the desk showed a raw-markup YOU row for every slash command.

It now takes the notice route: `localCommandInvocationOf` in
`apps/tuval/src/claude/history/map.ts` reads the frame's tags and the row lands as its own `system`
item reading `/effort medium` — the command and, when the frame carries them, its arguments, with
no tags and no terminal colour escapes.

A plugin's or a skill's invocation is the same record in a different hand, and the matcher reads
that too (AC 10): the tags may come in any order, each at most once, and the set is open, because a
skill's frame adds `<skill-format>`. That marker is also what says a body follows the tags — on a
skill frame the remainder is the skill's own text and rides the notice's `detail`; anywhere else,
text past the tags means an operator wrote about the markup and the row stays theirs.

The three frames stay three independent reads: the arm that decides what a user frame is lives in
`promptItemOf`, which reads one frame's text and nothing else, so no state is carried between an
invocation and the output below it.

Two fixtures, both real captures. `local-command-invocation-turn.json` is the `<command-name>` row
from the same `/effort` run the caveat fixture came from (CLI 2.1.220). `local-command-skill-turn.json`
is a `fabrika:triage` worker's inbound frame (CLI 2.1.233) — message tag first, `<skill-format>`
sibling, skill body in a second content block, trimmed to six lines. Both are documented in
`PROVENANCE.md`, whose local-command section is now five captures.

## Deviations

- **Out-of-scope change** — **Said:** #8665 names the mapper arm, the fixture and the tests.
  **Did:** also folded the existing output/user branch of `userEvents` into the same
  `promptItemOf` helper. **Why:** a third frame kind made the inline ternary a nested one; the
  helper keeps all three reads in one place with no behaviour change. **Disposition:** stated here.

- **Scope narrowing** — **Said:** AC 10 asks that a plugin- or skill-command invocation frame land
  as a system row, with one such frame captured as a fixture. **Did:** captured the skill shape
  (`<skill-format>`, message tag first) and covered the plugin shape with a `/unslop` frame's text
  quoted verbatim in the test rather than as a second fixture. **Why:** no top-level plugin-command
  frame in the operator's logs carries `<skill-format>`, and the skill capture is the shape that
  carries both differences at once; a second fixture would add an envelope and prove nothing the
  first does not. **Disposition:** stated here and in `PROVENANCE.md`.

- **Known defect left unfixed** — **Said:** AC 2 asks that no angle-bracket markup reach the
  transcript. **Did:** a skill frame's `detail` carries the skill body verbatim, which may itself
  contain angle brackets. **Why:** the body is the frame's payload, not the invocation markup, and
  dropping it would lose a worker's whole inbound prompt from the transcript; the summary line the
  criterion is about carries no markup. **Disposition:** stated here.

Fixes #8665
