### PR TITLE
fix: Tuval chat never reads an item's own interrupted flag, so a textless cut turn shows no badge

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -27,6 +27,7 @@ import {INTERRUPT_ERROR, START_ERROR} from "./failures.ts";
 import {markTurnRunning, settleAccepted, settleEndedSession, settleFailedTurn} from "./sends.ts";
 import {
 	type AiAgentSessionState,
+	cutReplyAfterItem,
 	emptyOmission,
 	lastAssistantId,
 	settleTurn,
@@ -268,7 +269,11 @@ export const foldEvent = (
 ): AiAgentSessionState => {
 	switch (event.kind) {
 		case "item":
-			return {...state, transcript: foldItem(state.transcript, event.item, limits)};
+			return {
+				...state,
+				interrupted: cutReplyAfterItem(state, event.item),
+				transcript: foldItem(state.transcript, event.item, limits),
+			};
 		// The phase line is also where a send in flight learns it crossed, and it takes two events
 		// to say so: the layer narrating the backend *starting* a turn, and then that turn ending.
 		//

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -873,6 +873,57 @@ describe("interrupt", () => {
 		expect(cmds).toEqual([{type: "aiAgent.interrupt"}]);
 	});
 
+	const abortedItem = (id: string, text = ""): AiAgentSessionMsg => ({
+		type: "event",
+		sessionId: "session-1",
+		event: {kind: "item", item: assistantItem(id, text, undefined, true)},
+	});
+
+	const cutBeforeAnyText = (): AiAgentSessionState =>
+		running({
+			transcript: {
+				items: [userItem("u0"), assistantItem("a1"), userItem("u2")],
+				omitted: initialState("/x").transcript.omitted,
+			},
+		});
+
+	// The other half of the case above: the stop had no row to mark, so the `aborted` row the
+	// backend pushes afterwards is the only thing that ever names the cut turn's reply (#8584).
+	it("takes the marker from the aborted row when the stop had no reply to name", () => {
+		const [asked] = apply(cutBeforeAnyText(), {type: "interrupt", at: SENT_AT});
+		const [landed] = apply(asked, abortedItem("a3"));
+		expect(landed.interrupted).toBe("a3");
+		// The phase line settles after the item within one revision (`../../pi/ai-agent/items.ts`),
+		// so the marker the row supplied is what the window reads once the turn is over.
+		const [over] = apply(landed, phaseEvent("ready"));
+		expect(over.interrupted).toBe("a3");
+		expect(over.interruption).toBeNull();
+	});
+
+	it("keeps the reply the stop already named rather than following a later aborted row", () => {
+		const [asked] = apply(running(), {type: "interrupt", at: SENT_AT});
+		const [landed] = apply(asked, abortedItem("a3"));
+		expect(landed.interrupted).toBe("a1");
+	});
+
+	// A snapshot replaying an old interruption's row, or a session that has since moved on: no
+	// request is outstanding, so nothing here is the answer to one and the resend stays unoffered.
+	it("ignores an aborted row that arrives under no outstanding request", () => {
+		const [landed] = apply(started(), abortedItem("a3"));
+		expect(landed.interrupted).toBeNull();
+		const [after] = apply(cutBeforeAnyText(), abortedItem("a3"));
+		expect(after.interrupted).toBeNull();
+	});
+
+	// The resend is a fresh send, and the row it belonged to is two turns back by then.
+	it("drops the row-supplied marker when the operator sends again", () => {
+		const [asked] = apply(cutBeforeAnyText(), {type: "interrupt", at: SENT_AT});
+		const [landed] = apply(asked, abortedItem("a3"));
+		const [over] = apply(landed, phaseEvent("ready"));
+		const [next] = apply(over, {type: "prompt", text: "again", key: "k9", timestamp: SENT_AT + 1});
+		expect(next.interrupted).toBeNull();
+	});
+
 	// The prompt waits rather than being refused (#8159), and the stop request stands over it: an
 	// outstanding interruption is still the session's answer about the turn that is running.
 	it("sends nothing new while the interruption is outstanding", () => {

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -404,6 +404,28 @@ export const lastAssistantId = (items: ReadonlyArray<TranscriptItem>): ItemId | 
 	return null;
 };
 
+/**
+ * Where the cut-turn marker stands once one more item has landed.
+ *
+ * `lastAssistantId` answers `null` for a turn cut before it wrote anything, so on that path the
+ * marker is set here instead — by the `aborted` row the backend pushes afterwards, which is the
+ * only thing that ever names that turn's reply (#8584). Without it the row rendered plain: no
+ * break, no resend, for the one turn the operator definitely stopped.
+ *
+ * The outstanding `interruption` is the whole gate. It is the operator's request with no event
+ * against it yet, so an `aborted` row arriving under one is that request's answer; a historical
+ * abort replayed by a snapshot arrives under none and leaves the marker alone. A marker already set
+ * stands, so this never re-points the resend away from the row `interrupt` or `restore` chose.
+ */
+export const cutReplyAfterItem = (
+	state: AiAgentSessionState,
+	item: TranscriptItem,
+): ItemId | null => {
+	if (state.interrupted !== null) return state.interrupted;
+	if (state.interruption === null) return null;
+	return item.kind === "assistant" && item.interrupted === true ? item.id : null;
+};
+
 /** The cut-short turn, marked in the tail so a window renders the break off the transcript alone. */
 const markInterrupted = (
 	items: ReadonlyArray<TranscriptItem>,

--- a/apps/tuval/src/shell/chat/interrupted-textless-turn.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/interrupted-textless-turn.unit.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #8584's rendered half: a turn the operator cut before the model wrote anything. The stop has no
+ * assistant row to name, so the marker comes from the `aborted` row the backend pushes afterwards
+ * — and the window has to draw the break and the resend off it like any other cut turn.
+ *
+ * The state is folded by the real machine over events the Pi mapper produced, rather than written
+ * by hand: the defect was the window and the core disagreeing about which row was cut, so a
+ * hand-built state would decide the very thing under test. Reaching into a backend is a liberty
+ * test files have and source files do not — `boundary.unit.test.ts` holds that import out of every
+ * `.ts`/`.tsx` in this directory.
+ */
+
+import {applyCellChecked} from "@demlik/tea";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {
+	AiAgentSessionCmd,
+	AiAgentSessionMsg,
+	AiAgentSessionState,
+} from "../../ai-agent/core/index.ts";
+import {aiAgentSessionMachine} from "../../ai-agent/core/machine.ts";
+import {emptyProjection, eventsOf} from "../../pi/ai-agent/items.ts";
+import type {TranscriptItem as PiTranscriptItem, SessionSnapshot} from "../../pi/wire/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {type TestProcess, testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {type ChatWindowHost, chatWindow} from "./ChatWindow.tsx";
+import {sessionState} from "./chat.testing.ts";
+import {type ChatView, initialChatView} from "./view.ts";
+
+installDomShims();
+
+const SESSION = "session-8584";
+const SENT_AT = 1_756_000_000_000;
+
+const machine = aiAgentSessionMachine({cwd: "/workspace"});
+
+const apply = (state: AiAgentSessionState, msg: AiAgentSessionMsg): AiAgentSessionState =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(
+		machine,
+		state,
+		msg,
+	)[0];
+
+const snapshotOf = (
+	transcript: ReadonlyArray<PiTranscriptItem>,
+	phase: SessionSnapshot["phase"],
+	revision: number,
+): SessionSnapshot => ({
+	id: SESSION,
+	cwd: "/workspace",
+	createdAt: 0,
+	updatedAt: 0,
+	phase,
+	model: {provider: "faux", id: "faux-1"},
+	thinkingLevel: "off",
+	attached: true,
+	locked: false,
+	revision,
+	transcript: [...transcript],
+	queuedSteer: [],
+	queuedSteerCount: 0,
+});
+
+/** The wire snapshot as Msgs, in the order the live path delivers them. */
+const pushed = (
+	state: AiAgentSessionState,
+	transcript: ReadonlyArray<PiTranscriptItem>,
+	phase: SessionSnapshot["phase"],
+	revision: number,
+): AiAgentSessionState =>
+	eventsOf(emptyProjection, snapshotOf(transcript, phase, revision)).events.reduce(
+		(carried, event) => apply(carried, {type: "event", sessionId: SESSION, event}),
+		state,
+	);
+
+const prompt: PiTranscriptItem = {
+	id: "item-0",
+	role: "user",
+	content: [{type: "text", text: "rewrite the README"}],
+	timestamp: 10,
+};
+
+/** The cut turn as Pi reports it: aborted, and with not one token of text on it. */
+const abortedTextlessTurn: PiTranscriptItem = {
+	id: "item-1",
+	role: "assistant",
+	content: [],
+	model: {provider: "faux", id: "faux-1"},
+	timestamp: 11,
+	status: "aborted",
+	stopReason: "aborted",
+};
+
+/** Prompt sent, Escape pressed, then the backend's report of the turn it stopped. */
+const cutBeforeAnyText = (): AiAgentSessionState => {
+	const sent = apply(sessionState({sessionId: SESSION}), {
+		type: "prompt",
+		text: "rewrite the README",
+		key: "k1",
+		timestamp: SENT_AT,
+	});
+	const asked = apply(sent, {type: "interrupt", at: SENT_AT + 500});
+	return pushed(asked, [prompt, abortedTextlessTurn], "idle", 1);
+};
+
+const openWindow = async (
+	state: AiAgentSessionState,
+): Promise<TestProcess<AiAgentSessionState, AiAgentSessionMsg>> => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
+	);
+	const host: ChatWindowHost = await Effect.runPromise(
+		process.window<ChatView>(WindowId.make("w1"), {...initialChatView, pinned: true}),
+	);
+	render(chatWindow({scrollToFn: () => {}}).render(host) as ReactElement);
+	return process;
+};
+
+describe("a turn cut before the model wrote anything", () => {
+	it("draws the break and offers the resend", async () => {
+		await openWindow(cutBeforeAnyText());
+		expect(screen.getByText("interrupted")).toBeTruthy();
+		expect(screen.getByRole("button", {name: /Resend/})).toBeTruthy();
+	});
+
+	it("resends the prompt that turn was answering, not some other one", async () => {
+		const process = await openWindow(cutBeforeAnyText());
+		fireEvent.click(screen.getByRole("button", {name: /Resend/}));
+		expect(process.inbox()).toEqual([
+			expect.objectContaining({type: "prompt", text: "rewrite the README"}),
+		]);
+	});
+
+	// The same aborted row replayed by a snapshot on a session with no stop outstanding. Nothing
+	// here is the answer to an operator's request, so a resend would send the newest prompt under a
+	// badge pointing at an old row.
+	it("draws no break for an aborted row that answers no request of the operator's", async () => {
+		await openWindow(
+			pushed(sessionState({sessionId: SESSION}), [prompt, abortedTextlessTurn], "idle", 1),
+		);
+		expect(screen.queryByText("interrupted")).toBeNull();
+		expect(screen.queryByRole("button", {name: /Resend/})).toBeNull();
+	});
+});


### PR DESCRIPTION
Interrupting a turn before the model had written anything left the operator with nothing: no
"interrupted" line, no Resend button, just a blank agent row. The stop marker (`state.interrupted`)
is computed once, when Escape is pressed, from `lastAssistantId` — and for a turn with no text yet
that answers `null`, correctly, because no row exists to name. The `aborted` row the backend pushes
a moment later is the only thing that ever names that reply, and nothing read it.

So the core adopts it. `foldEvent`'s `item` arm now runs `cutReplyAfterItem` (in `state.ts`, beside
`lastAssistantId`, which owns this field): an assistant row carrying `interrupted: true` supplies
the marker when — and only when — the operator has a stop request outstanding and no marker is set
yet. That is the reconciliation done at the boundary that already owns `interrupted`, so
`ChatWindow` is untouched and keeps its single source.

The two gates are what keep the wrong row from being labelled. A marker already set stands, so an
`aborted` row landing after an ordinary nonempty interrupt cannot re-point the resend. An
outstanding `interruption` is required, so a snapshot replaying an old interruption's row on a
session that has moved on marks nothing — which matters because `resend` sends `state.lastPrompt`,
and a badge over a historical row would offer to resend an unrelated latest prompt. A new prompt
clears the marker as it always did (`admit`).

## Evidence

The rendered rows for the same cut turn, dumped from the production path (Pi wire snapshot →
`eventsOf` → the real machine → `chatWindow`), before and after:

Before — `state.interrupted = null`:

```html
<div class="tuval-chat-row" data-kind="assistant" data-message-role="assistant">
  <span class="kp-visually-hidden">agent</span>
  <div class="kp-markdown tuval-chat-markdown"></div>
</div>
```

After — `state.interrupted = "item-1"`:

```html
<div class="tuval-chat-row" data-kind="assistant" data-message-role="assistant">
  <span class="kp-visually-hidden">agent</span>
  <div class="kp-markdown tuval-chat-markdown"></div>
  <span class="tuval-chat-interrupted">
    <span class="tuval-chat-interrupted-mark">interrupted</span>
    <button type="button" class="kp-btn">Resend <kbd class="kp-kbd">Alt+R</kbd></button>
  </span>
</div>
```

## Tests

Seven regressions, each flip-verified against the change that would break it:

- `machine.unit.test.ts` — the marker is taken from the aborted row and survives the `ready` that
  follows it; a stop that already named a reply keeps it; an aborted row under no outstanding
  request marks nothing; a new prompt drops the marker.
- `interrupted-textless-turn.unit.test.tsx` — the same case through the render path: the break and
  the Resend button appear, clicking Resend dispatches the prompt that turn was answering, and the
  replayed-abort case draws neither.

Checks run in this tree: `pnpm --filter @kampus/tuval exec vitest run src/ai-agent/core src/shell/chat
src/pi/ai-agent` (825 passed), `pnpm --filter @kampus/tuval typecheck`, biome on the touched files.

Fixes #8584

## Deviations

None.
