### PR TITLE
feat: Tuval's shell chrome keeps its own token scale beside @kampus/design

### DIFF
--- a/apps/tuval/src/ai-agent/window/ai-agent-inspector.css
+++ b/apps/tuval/src/ai-agent/window/ai-agent-inspector.css
@@ -1,6 +1,6 @@
 /*
- * The inspector panel's own layout, and nothing else. Every value is a role token the shell already
- * declares (`../../shell/ui/tokens.css`); no token is added here (#7884, #8190).
+ * The inspector panel's own layout, and nothing else. Every value is a `@kampus/design` role token;
+ * no token is added here (#7884, #8190).
  */
 
 /* A `fieldset` ships a browser border and padding; the panel's own frame is the inspector Card's. */

--- a/apps/tuval/src/page/page.css
+++ b/apps/tuval/src/page/page.css
@@ -1,7 +1,7 @@
 /*
  * The page around the desk: the document's own box, and the two demo renderers' rows. Every colour
- * and every size is a role token from `../shell/ui/tokens.css` — nothing here reaches under the role
- * layer (`design-system-manifest.md`).
+ * and every size is a role token from `@kampus/design` — nothing here reaches under the role layer
+ * (`design-system-manifest.md`).
  */
 
 html,
@@ -28,18 +28,14 @@ body {
  */
 .tuval-attach-reason {
 	color: var(--text-muted);
-	font:
-		var(--t-mono) ui-monospace,
-		monospace;
+	font: var(--t-mono);
 }
 
 .tuval-demo {
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-2);
-	font:
-		var(--t-mono) ui-monospace,
-		monospace;
+	font: var(--t-mono);
 }
 
 .tuval-demo p {
@@ -50,17 +46,13 @@ body {
 	color: var(--text-muted);
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 }
 
 /* A sentence and an empty-state line, so `--text-muted` for the same reason as the reason above. */
 .tuval-demo-hint {
 	color: var(--text-muted);
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 }
 
 .tuval-demo-lines {
@@ -86,9 +78,7 @@ body {
 	border-radius: var(--r-md);
 	background: var(--surface-raised);
 	color: var(--text-secondary);
-	font:
-		var(--t-body-sm) system-ui,
-		sans-serif;
+	font: var(--t-body-sm);
 	text-align: center;
 }
 

--- a/apps/tuval/src/page/styles.ts
+++ b/apps/tuval/src/page/styles.ts
@@ -2,10 +2,10 @@
  * The page's stylesheet order, in one module so every entry that mounts the page gets the same one.
  *
  * Manti's base first — a `@kampus/design` primitive is a Manti component, and without this its
- * dialog has no positioning at all and lands in the document flow. Then the design token layer, then
- * Tuval's: both declare role tokens at `:root` and the desk's own values have to win that tie. The
- * design layer is what the palette resolves against (`../palette/palette.css`); the desk keeps its
- * dark-only scale (`../shell/ui/tokens.css`).
+ * dialog has no positioning at all and lands in the document flow. Then the package's one role-token
+ * layer, which the palette, the design primitives and the desk all resolve against. Tuval's own
+ * sheet comes after it and declares no role the package owns (#7884) — it carries the desk's chrome
+ * and the two tokens the package has no member of (`../shell/ui/tokens.css`).
  *
  * Tuval's own markup carries `kp-visually-hidden` too (`../shell/chat/ToolRow.tsx`), so the page
  * takes the package's rule directly rather than inheriting it from whichever design component

--- a/apps/tuval/src/pi/window/proof/compaction.html
+++ b/apps/tuval/src/pi/window/proof/compaction.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/pi/window/proof/exception.html
+++ b/apps/tuval/src/pi/window/proof/exception.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/pi/window/proof/index.html
+++ b/apps/tuval/src/pi/window/proof/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/pi/window/proof/inspector.html
+++ b/apps/tuval/src/pi/window/proof/inspector.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/pi/window/proof/main.tsx
+++ b/apps/tuval/src/pi/window/proof/main.tsx
@@ -23,7 +23,7 @@ import {type TestProcess, testProcess} from "../../../shell/window/fixtures.ts";
 import {WindowId} from "../../../shell/window/index.ts";
 import {piChatWindow} from "../PiChatWindow.tsx";
 import {piSession, usageOf} from "../pi-window.testing.ts";
-import "../../../shell/ui/tokens.css";
+import "../../../page/styles.ts";
 import "./proof.css";
 
 const MODEL = "anthropic/claude-sonnet-4-5-20250929";

--- a/apps/tuval/src/pi/window/proof/provider-failure.html
+++ b/apps/tuval/src/pi/window/proof/provider-failure.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/pi/window/proof/transcript.html
+++ b/apps/tuval/src/pi/window/proof/transcript.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -1,50 +1,16 @@
 /*
- * The chat window's own layout, and the one adapter between two role-token layers.
+ * The chat window's own layout.
  *
- * Tuval declares its roles in `../ui/tokens.css` and apps/web declares the same names in
- * `packages/design/src/tokens.css`, at two different shapes. The typography roles are the ones that
- * actually differ: the package's `--t-*` are whole `font` shorthands with the family baked in
- * (`--t-meta: 12px / 1.4 var(--font-body)`) while Tuval's carry size and line-height only and each
- * call site appends its own family. A `@kampus/design` stylesheet's `font: var(--t-meta)` is an
- * invalid shorthand under Tuval's values and the whole declaration is dropped — an unstyled
- * composer, silently.
- *
- * So this scope re-declares the roles the package's sheets read, in the package's own shape, off
- * Tuval's own scale. A role this block *omits* fails the other way and quieter: it resolves from
- * the package's `:root`, where the family is already substituted to IBM Plex, so the element renders
- * in a second typeface beside Tuval's `system-ui` (#8012 shipped that with `--t-h-feed`). Every
- * `--t-*` a package sheet reads under this scope belongs here.
- * It is the only place the two layers meet; nothing under `.tuval-chat` may use
- * Tuval's two-part `font: var(--t-body) system-ui, sans-serif` form, because inside this scope
- * `--t-body` already carries a family.
+ * This scope used to carry an adapter between two role-token layers, because Tuval's local `--t-*`
+ * were size and line-height only while a `@kampus/design` sheet's bake the family in — so the
+ * package's own `font: var(--t-meta)` was an invalid shorthand here and the whole declaration was
+ * dropped, silently, leaving an unstyled composer. Tuval reads the package's layer directly now
+ * (#7884, `../../page/styles.ts`), so there is one shape and no adapter.
  */
 
 .tuval-chat {
 	/* The window is dark whatever it is mounted inside; Tuval is chrome, not a document. */
 	color-scheme: dark;
-
-	--font-body: system-ui, sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-
-	--t-body: 14px / 1.5 var(--font-body);
-	--t-body-sm: 13px / 1.45 var(--font-body);
-	--t-meta: 12px / 1.4 var(--font-body);
-	--t-micro: 11px / 1.4 var(--font-body);
-	--t-mono: 13px / 1.5 var(--font-mono);
-	--t-h-feed: 16px / 1.35 var(--font-body);
-
-	--r-lg: 6px;
-	--s-8: 40px;
-	--tap-min: 36px;
-	--ease-standard: ease-out;
-
-	/* The one role Tuval's layer has no member of. Same hue as the manifest's, at this scale's
-	   lightness so it clears 4.5:1 on `--surface` (`design-system-manifest.md`, Pillar 4). */
-	--danger: oklch(0.72 0.16 25);
-
-	--shadow-raised: 0 1px 3px 0 rgb(0 0 0 / 40%);
-	--shadow-dropdown: 0 6px 16px -4px rgb(0 0 0 / 50%);
-	--shadow-overlay: 0 16px 40px -8px rgb(0 0 0 / 60%);
 
 	display: flex;
 	flex-direction: column;
@@ -138,7 +104,7 @@
 	text-align: start;
 	cursor: pointer;
 	/* The list is dense, so the row's own height is the target rather than a taller padded box. */
-	min-block-size: var(--tap-min, 36px);
+	min-block-size: var(--tap-min);
 }
 
 .tuval-chat-subagent-pick:hover {

--- a/apps/tuval/src/shell/chat/proof/effort-offered.html
+++ b/apps/tuval/src/shell/chat/proof/effort-offered.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/shell/chat/proof/effort.html
+++ b/apps/tuval/src/shell/chat/proof/effort.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/shell/chat/proof/index.html
+++ b/apps/tuval/src/shell/chat/proof/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" data-color-theme="indigo">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/tuval/src/shell/chat/proof/main.tsx
+++ b/apps/tuval/src/shell/chat/proof/main.tsx
@@ -31,7 +31,7 @@ import {
 } from "../chat.testing.ts";
 import {type ChatView, initialChatView} from "../view.ts";
 import {mountPagingProof} from "./paging.tsx";
-import "../../ui/tokens.css";
+import "../../../page/styles.ts";
 import "./proof.css";
 
 class SessionRefusalProofLoadError extends Schema.TaggedError<SessionRefusalProofLoadError>()(

--- a/apps/tuval/src/shell/chat/tool-run-disclosure.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/tool-run-disclosure.unit.test.tsx
@@ -315,9 +315,19 @@ describe("the disclosure state is the window's, not the component's", () => {
 describe("the law the new triggers are judged against", () => {
 	const css = (): string => readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
 
+	/**
+	 * `--tap-min` is `@kampus/design`'s since #7884 — Tuval stopped re-declaring the role layer — so
+	 * the floor's value is read where it is now declared rather than out of the consuming sheet.
+	 */
+	const designTokens = (): string =>
+		readFileSync(
+			fileURLToPath(import.meta.resolve("@kampus/design")).replace(/index\.ts$/, "tokens.css"),
+			"utf8",
+		);
+
 	it("floors every collapsible trigger at the 36px hit area", () => {
 		const sheet = css();
-		expect(sheet).toContain("--tap-min: 36px;");
+		expect(designTokens()).toContain("--tap-min: 36px;");
 		// The run's trigger and each call's are inside `.tuval-chat-tool`, which is the scope the
 		// shared trigger rule sizes; a call that is no trigger holds the same line for itself.
 		expect(sheet).toMatch(

--- a/apps/tuval/src/shell/ui/desk.css
+++ b/apps/tuval/src/shell/ui/desk.css
@@ -2,9 +2,9 @@
  * Layout for the two desk-level regions — where they sit, not what they look like.
  *
  * Everything painted here comes from a `@kampus/design` primitive (`Card` for the inspector panel,
- * `Kbd` for the prefix chip) or from a role token already declared in `./tokens.css`. There is no
- * new token in this file and no literal colour, radius or shadow: a rule that wanted one is a rule
- * that should have reached for a primitive instead.
+ * `Kbd` for the prefix chip) or from one of that package's role tokens. There is no new token in
+ * this file and no literal colour, radius or shadow: a rule that wanted one is a rule that should
+ * have reached for a primitive instead.
  */
 
 /* The tiling area and the inspector share one row; the status line stays below both. */
@@ -37,9 +37,7 @@
 
 .tuval-inspector-title {
 	margin: 0 0 var(--s-2);
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 	color: var(--text-muted);
 	text-transform: uppercase;
 	letter-spacing: 0.04em;

--- a/apps/tuval/src/shell/ui/tokens.css
+++ b/apps/tuval/src/shell/ui/tokens.css
@@ -1,90 +1,37 @@
 /*
- * Tuval's role-token layer, dark only.
+ * The desk's chrome: the two tokens `@kampus/design` has no member of, and every `.tuval-*` rule
+ * that paints a window, the status line, the picker, the command line or a failure panel.
  *
- * `design-system-manifest.md` grounds the role names in `apps/web/src/styles/tokens.css`, and a
- * component may reach for the role alias and nothing under it. Tuval cannot import that file — it
- * is another app's stylesheet, and the shared `packages/design` (#7561) is not built — so the role
- * names are re-declared here at the scale values a dark terminal-shaped surface needs. The names
- * are the contract: `../picker/frame.ts` already emits `--surface`, `--border`, `--focus-ring` and
- * the rest by name, and this file is what resolves them.
+ * The role layer itself is the package's, loaded ahead of this file by `../../page/styles.ts`, and
+ * nothing here re-declares a name it already owns. That is what `../picker/frame.ts` resolves
+ * against when it emits `--surface`, `--border`, `--focus-ring` and the rest.
  *
- * Dark is the only scheme. Tuval is window chrome, not a document, so there is no light branch to
- * fall back to and nothing here reads `prefers-color-scheme`.
+ * Dark is the only scheme. Tuval is window chrome, not a document, so the theme is pinned on every
+ * HTML entry (`data-theme="dark" data-color-theme="indigo"`) and nothing here reads
+ * `prefers-color-scheme`.
  */
 
 /*
- * The document behind the desk. The scale and its role aliases are scoped to `.tuval-surface`, and
- * `body` is not inside it, so the one role the page itself paints is declared here — off the same
- * value `--surface-sunken` resolves to. Overscroll is the only place it shows (#7560).
+ * `body` sits outside `.tuval-surface`, so the one role the page itself paints is aliased here —
+ * off the same value `--surface-sunken` resolves to. Overscroll is the only place it shows (#7560).
  */
 :root {
-	--gray-1: #0b0c0e;
-	--page-backdrop: var(--gray-1);
+	--page-backdrop: var(--surface-sunken);
 }
 
 .tuval-surface {
 	color-scheme: dark;
 
-	--gray-2: #111316;
-	--gray-3: #191c20;
-	--gray-5: #262a30;
-	--gray-6: #31363d;
-	--gray-7: #3f454e;
-	--gray-10: #6d757f;
-	--gray-11: #9aa3ae;
-	--gray-12: #eceef1;
-	--accent-3: #10202e;
-	--accent-5: #14384f;
-	--accent-9: #3b9eff;
-	--accent-11: #78c0ff;
-	--accent-contrast: #06131f;
-
-	--surface: var(--gray-2);
-	--surface-sunken: var(--gray-1);
-	--surface-raised: var(--gray-3);
-
-	--border-faint: var(--gray-5);
-	--border: var(--gray-6);
-	--border-strong: var(--gray-7);
-
-	--text-primary: var(--gray-12);
-	--text-secondary: color-mix(in oklab, var(--gray-11), var(--gray-12));
-	--text-muted: var(--gray-11);
-	--text-faint: var(--gray-10);
-
-	--accent: var(--accent-9);
-	--accent-soft: var(--accent-5);
-	--accent-faint: var(--accent-3);
-	--link: var(--accent-11);
-	--accent-fg: var(--accent-contrast);
-
-	/* The manifest's ring law: 2px ring plus a 2px transparent gap, so it clears 3:1 against a
-	   same-family dark surface. Painted once by the `:focus-visible` rule below, never per component. */
-	--focus-ring: 2px solid var(--accent-9);
+	/* The package declares `--manti-focus-ring*` for Manti's own consumption and no role token for
+	   the desk's ring, so the manifest's law lives here: 2px ring plus a 2px transparent gap, which
+	   clears 3:1 against a same-family dark surface. Painted once by the rule below, never per
+	   component. */
+	--focus-ring: 2px solid var(--accent);
 	--focus-ring-offset: 2px;
-
-	--t-body: 14px / 1.5;
-	--t-body-sm: 13px / 1.45;
-	--t-meta: 12px / 1.4;
-	--t-mono: 13px / 1.5;
-
-	--s-1: 4px;
-	--s-2: 8px;
-	--s-3: 12px;
-	--s-4: 16px;
-
-	/* One duration for every transition on this surface, so the reduced-motion answer below is one
-	   declaration rather than an `!important` sweep over every descendant. */
-	--motion-fast: 120ms;
-
-	--r-sm: 2px;
-	--r-md: 4px;
 
 	background: var(--surface-sunken);
 	color: var(--text-primary);
-	font:
-		var(--t-body) system-ui,
-		sans-serif;
+	font: var(--t-body);
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;
@@ -130,9 +77,7 @@
 	align-items: center;
 	padding: var(--s-1) var(--s-2);
 	border-block-end: 1px solid var(--border-faint);
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 	color: var(--text-muted);
 }
 
@@ -178,12 +123,10 @@
 	gap: var(--s-4);
 	align-items: center;
 	padding: var(--s-1) var(--s-3);
-	min-block-size: 36px;
+	min-block-size: var(--tap-min);
 	border-block-start: 1px solid var(--border);
 	background: var(--surface-raised);
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 	color: var(--text-muted);
 }
 
@@ -193,9 +136,7 @@
 }
 
 .tuval-kbd {
-	font:
-		var(--t-mono) ui-monospace,
-		monospace;
+	font: var(--t-mono);
 	padding: 0 var(--s-1);
 	border: 1px solid var(--border);
 	border-radius: var(--r-sm);
@@ -221,21 +162,17 @@
 	overflow-wrap: anywhere;
 	margin: 0;
 	color: var(--text-primary);
-	font:
-		var(--t-mono) ui-monospace,
-		monospace;
+	font: var(--t-mono);
 }
 
 .tuval-command-line input {
 	flex: 1 1 auto;
-	min-block-size: 36px;
+	min-block-size: var(--tap-min);
 	background: var(--surface-sunken);
 	border: 1px solid var(--border);
 	border-radius: var(--r-md);
 	color: var(--text-primary);
-	font:
-		var(--t-mono) ui-monospace,
-		monospace;
+	font: var(--t-mono);
 	padding: 0 var(--s-2);
 }
 
@@ -246,9 +183,7 @@
 
 .tuval-refusal {
 	color: var(--text-muted);
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 }
 
 .tuval-picker {
@@ -261,7 +196,7 @@
 	display: flex;
 	gap: var(--s-2);
 	align-items: baseline;
-	min-block-size: 36px;
+	min-block-size: var(--tap-min);
 	padding: var(--s-1) var(--s-2);
 	border-radius: var(--r-sm);
 	transition: background var(--motion-fast) ease;
@@ -274,16 +209,12 @@
 
 .tuval-picker-detail {
 	color: var(--text-muted);
-	font:
-		var(--t-meta) ui-monospace,
-		monospace;
+	font: var(--t-meta);
 }
 
 .tuval-picker-group-label {
 	color: var(--text-muted);
-	font:
-		var(--t-meta) system-ui,
-		sans-serif;
+	font: var(--t-meta);
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
 }
@@ -330,24 +261,18 @@
 .tuval-boundary-reason,
 .tuval-boundary-stack {
 	color: var(--text-muted);
-	font:
-		var(--t-mono) ui-monospace,
-		monospace;
+	font: var(--t-mono);
 }
 
 .tuval-boundary-stack {
 	margin: 0;
 	white-space: pre-wrap;
-	font:
-		var(--t-meta) ui-monospace,
-		monospace;
+	font: var(--t-meta);
 }
 
 .tuval-boundary-where summary {
 	color: var(--text-secondary);
-	font:
-		var(--t-body-sm) system-ui,
-		sans-serif;
+	font: var(--t-body-sm);
 	cursor: pointer;
 }
 
@@ -358,14 +283,14 @@
 	border-radius: var(--r-md);
 	padding: var(--s-1) var(--s-3);
 	cursor: pointer;
-	font:
-		var(--t-body-sm) system-ui,
-		sans-serif;
-	transition: background var(--motion-fast) ease;
+	font: var(--t-body-sm);
+	transition: filter var(--motion-fast) ease;
 }
 
+/* The package's own primary-button hover (`packages/design/src/Button.css`), so this panel's retry
+   lightens the same way every other accent fill in the system does. */
 .tuval-boundary button:hover {
-	background: var(--accent-11);
+	filter: brightness(1.06);
 }
 
 /* Every transition collapses to an instant swap. Honouring this is part of the behavioural spine


### PR DESCRIPTION
Closes #7884.

LAW-SOURCE: manifest-prose (`fabrika ui law` exit 13 — this repo ships no typed `design-prohibitions.json`, so `design-system-manifest.md`'s prose prohibitions are the law this diff was built to).

## What changed

`apps/tuval/src/shell/ui/tokens.css` re-declared the whole role layer under `.tuval-surface`. `apps/tuval/src/page/styles.ts` already loaded `@kampus/design/tokens.css`, but the package declares its roles at `:root` and Tuval declared the same names under a class, so Tuval won the cascade on every desk surface and the shared layer was loaded and inert.

The local declarations are deleted — no hex, no `--gray-N`, no `--accent-N`, no role alias the package already owns. What the file keeps is the desk's chrome (`.tuval-*` window, separator, status line, picker, command line, error boundary) plus the three tokens the package has no member of:

- `--focus-ring` / `--focus-ring-offset`, still painted once by the single `.tuval-surface :focus-visible` rule. The package declares `--manti-focus-ring*` for Manti's own consumption and no role token for the desk's ring.
- `--page-backdrop`, the one role `body` paints from outside `.tuval-surface`, now aliased to `var(--surface-sunken)` instead of a local `--gray-1` hex.

## The part that is not a delete

Design's type steps bake the family in (`--t-body: 14px / 1.5 var(--font-body)`); Tuval's did not, so every consumer appended its own. Once the shared value resolves, that names a family twice — a `font` shorthand parse error that drops the whole declaration and falls the element back to the UA font. Every such site lost its trailing family: 13 in `shell/ui/tokens.css`, 5 in `page/page.css`, 1 in `shell/ui/desk.css`.

`shell/chat/chat.css` carried an adapter block that re-declared `--font-body` / `--font-mono` / the `--t-*` ramp / `--r-lg` / `--s-8` / `--tap-min` / `--ease-standard` / `--danger` / the three shadows, in the package's shape but off Tuval's scale. Its whole reason was that the two `--t-*` shapes differed. They are one shape now, so the block is gone and `.tuval-chat` reads the package's values like every other scope. Left untouched: the scope's `color-scheme: dark`, its reset, and its reduced-motion block.

Two other law fixes fell out and are in the diff:

- `.tuval-boundary button:hover` reached for `var(--accent-11)`, a semantic scale a component may not consume. It now uses the package's own primary-button hover (`filter: brightness(1.06)`, `packages/design/src/Button.css`). Under the shared layer the old rule would also have put `--accent-fg` (`#fff` on indigo) on `--accent-11` (`#9eb1ff`), which fails the contrast floor.
- Three raw `min-block-size: 36px` tap-target floors became `var(--tap-min)`, which the package now declares.

## The proof harnesses

`shell/chat/proof/main.tsx` and `pi/window/proof/main.tsx` imported the shell's local `tokens.css` and nothing from the package; without the local role layer both would have rendered on the UA font, no role tokens, and — because `:root` defaults to ember — on tomato rather than indigo. Both now import `page/styles.ts`, the same stylesheet order the page uses and the one their six sibling entries already used. Every proof HTML entry (9 files) pins `data-theme="dark" data-color-theme="indigo"` on `<html>`, so the design layer's `[data-theme="light"]` branch can never resolve.

## Verification

- `pnpm --filter @kampus/tuval exec vitest run src/shell/chat src/shell/ui src/palette src/pi/window src/page src/ai-agent/window` — 71 files, 850 tests, green. Includes the four tests that read CSS off disk (`chat-visually-hidden`, `palette/tokens`, `chat-reduced-motion`, `chat-composer-width`).
- `pnpm --filter @kampus/tuval typecheck` — 0 errors.
- `fabrika build check --surface code` — green (`pnpm typecheck:affected`, `pnpm lint:worktree`). 14 CSS/HTML files in the diff are outside both validators' reach and are covered by the renders below and the unit tier instead.
- `fabrika ui render` before/after on `/tuval/chat`, `/tuval/pi-window`, `/tuval/pi-vertical` — attached. The deliberate visible change: neutrals move to slate, the accent to indigo `#3e63dd`, body type to IBM Plex Sans and mono to JetBrains Mono. Dark-only holds; the window title bar, status line and `<c-b>` Kbd chip all resolve on the shared layer.

Every acceptance criterion checked mechanically against the tree at this head: no hex / `--gray-N` / `--accent-N` / duplicated role alias in `shell/ui/tokens.css`; all seven role names `shell/picker/frame.ts` emits still resolve; no `font:` under `apps/tuval/src` names a family after a `var(--t-*)`; no rule reads `prefers-color-scheme`; every HTML entry carries both theme attributes.

## Deviations

- **Said:** the issue counts 23 `font:` sites appending a family — 13 `shell/ui/tokens.css`, 5 `page/page.css`, 4 `shell/chat/chat.css`, 1 `shell/ui/desk.css`.
  **Did:** rewrote 19 — 13, 5, 1, and **0** in `chat.css`.
  **Why:** triage read `origin/main` on 2026-09-09; `chat.css`'s four were already rewritten by commits that landed before this branch was cut. Its one remaining regex hit is inside a comment, not a declaration.
  **Disposition:** the criterion is met at this head — no such site remains anywhere under `apps/tuval/src`.

- **Said:** the issue scopes the change to `shell/ui/tokens.css`'s declarations, the font sites, and the two proof entries.
  **Did:** also deleted `shell/chat/chat.css`'s token adapter block.
  **Why:** the adapter re-declared `--font-body: system-ui` under `.tuval-chat`. Leaving it would have rendered the whole chat window — most of the desk — in system-ui while everything around it rendered IBM Plex Sans, failing the "the desk renders IBM Plex Sans for body text" criterion on the surface that matters most. The block's own stated reason was that the two `--t-*` shapes differed, which is exactly what this change removes.
  **Disposition:** in scope by consequence; kept.

- **Said:** nothing about the test tier changing.
  **Did:** changed one assertion in `shell/chat/tool-run-disclosure.unit.test.tsx`.
  **Why:** it asserted `chat.css` literally contains `--tap-min: 36px;`. That declaration moved to `packages/design/src/tokens.css`, so the test now reads the value where it is now declared. The floor it guards is unchanged and its two selector assertions are untouched.
  **Disposition:** same guarantee, one source; kept.

- **Said:** run the render → look → fix loop.
  **Did:** looked from `fabrika ui render` captures only.
  **Why:** this session's tool surface carries no `claude-in-chrome` tools, so the interactive look mode was unavailable.
  **Disposition:** not a gap — the captures are the record either way.

- **Said:** nothing about a defect outside the diff.
  **Did:** filed #8751 rather than fixing it here.
  **Why:** `.tuval-chat-subagent-pick:focus-visible` substitutes `--focus-ring` (a whole `outline` shorthand) into another `outline`'s color slot, so the declaration is invalid at computed-value time and that row paints no focus ring. Pre-existing, identical before and after this diff, and its fix needs a cascade check a token migration has no business making.
  **Disposition:** filed, not carried.


- **Said:** the issue scopes the change to token declarations, the `font:` sites, and the two proof entries — and the entry above claims that scope while naming only the `chat.css` deletion as falling outside it.
  **Did:** also repainted `.tuval-boundary button:hover` (`apps/tuval/src/shell/ui/tokens.css` ll.286-292): `transition: background` → `transition: filter`, and `background: var(--accent-11)` → `filter: brightness(1.06)`.
  **Why:** two reasons, both forced by the migration. Under `[data-color-theme="indigo"]` the old rule hovered an `--accent-fg: #fff` label onto `--accent-11: #9eb1ff` — roughly 1.9:1, far under the 4.5:1 floor; it only read acceptably against Tuval's deleted local `--accent-11: #78c0ff` with its dark `--accent-contrast`. And once the local scale is gone, `--accent-11` is the package's *semantic* layer, which `packages/design/src/tokens.css` and `design-system-manifest.md` both state a component never references directly. The replacement is not invented: `filter: brightness(1.06)` is verbatim the primary variant's own hover in `packages/design/src/Button.css:44-46`, so this button lightens the way every other accent fill in the system does. The `transition` property moved with it because the animated property changed.
  **Disposition:** kept. It is the same "in scope by consequence" class as the `chat.css` deletion above, and it should have carried its own entry from the start — this one closes that gap. Disclosure only; no code moved, so the head stays `4b24c7dfaccbedb4f7c233cadbccb1be4118540a`.
