### PR TITLE
fix: A screen reader is never told the Tuval composer is off inside a subagent view

### DIFF
--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -51,7 +51,11 @@ import type {ProcessView, WindowHost, WindowRenderer} from "../window/index.ts";
 import {prefixArmedAround, windowRenderer} from "../window/index.ts";
 import {CompactionMarker} from "./CompactionMarker.tsx";
 import {composerBridge} from "./composer-bridge.ts";
-import {tuvalDesignTranslate, tuvalSubagentViewTranslate} from "./copy.ts";
+import {
+	composerStateAnnouncement,
+	tuvalDesignTranslate,
+	tuvalSubagentViewTranslate,
+} from "./copy.ts";
 import {ModeSwitch} from "./ModeSwitch.tsx";
 import {dropSend, holdSend, readHeld, recoverInto} from "./outgoing.ts";
 import {type PermissionAnswer, PermissionCards} from "./PermissionCards.tsx";
@@ -580,6 +584,12 @@ function ChatWindow({
 	 */
 	const viewing = options.subagentList ? view.viewing : null;
 	const viewedSlot = viewing === null ? undefined : state?.subagents[viewing.id];
+
+	/**
+	 * One predicate behind the composer's `disabled` prop and behind what the view slot's live region
+	 * says about it, so an operator who cannot see the field still hears its state (#8635).
+	 */
+	const composerDisabled = viewing !== null;
 
 	/** The scroll offset `onScroll` is holding for its settle window, and the timer holding it. */
 	const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1120,7 +1130,8 @@ function ChatWindow({
 									: "Showing a subagent whose transcript is not in this session's state."
 								: viewedSlot.status === "finished"
 									? `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Finished: ${viewedSlot.lastLine}`
-									: `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Still running.`}
+									: `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Still running.`}{" "}
+							{composerStateAnnouncement(composerDisabled)}
 						</p>
 					</>
 				) : null}
@@ -1234,8 +1245,9 @@ function ChatWindow({
 					// disabled, not re-worded. A prompt typed here would land in the transcript the
 					// operator is not reading, and there is no second session to address it to. It stays
 					// mounted — the draft is the component's own state, so unmounting it would drop text
-					// the swap must not touch — and the placeholder swapped above says why.
-					disabled={viewing !== null}
+					// the swap must not touch. The placeholder swapped above says why, and the view slot's
+					// live region says the same for a reader the disabled field never lets in (#8635).
+					disabled={composerDisabled}
 					initialValue={view.draft}
 					onDraftChange={(draft) =>
 						commit((current) => (current.draft === draft ? current : {...current, draft}))

--- a/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/agent-controls.unit.test.tsx
@@ -1,9 +1,10 @@
 /**
  * @vitest-environment jsdom
  *
- * The five agent controls the window adds on top of the transcript: the collapsible tool row, the
- * permission cards, the mode switch, and the composer's model and slash-command pickers. Same test
- * double as the transcript's own tests (`../window/fixtures.ts`) — no kernel, no socket, no layer.
+ * The agent controls the window adds on top of the transcript: the collapsible tool row, the
+ * permission cards, the mode switch, the composer's model and slash-command pickers, and what the
+ * composer's off state inside a subagent view is announced as. Same test double as the transcript's
+ * own tests (`../window/fixtures.ts`) — no kernel, no socket, no layer.
  *
  * Every control here is Manti-backed, so a click and a same-tick read prove nothing: Zag defers the
  * transition by at least one microtask (`.patterns/zag-machine-interaction-tests.md`). Each
@@ -15,6 +16,9 @@ import {Effect} from "effect";
 import type {ReactElement} from "react";
 import {describe, expect, it} from "vitest";
 import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {ItemId} from "../../ai-agent/ports/index.ts";
+import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
 import {ProcessId} from "../../process/process.ts";
 import {installDomShims, TEST_VIEWPORT} from "../ui/dom.testing.ts";
 import {type TestProcess, testProcess} from "../window/fixtures.ts";
@@ -32,7 +36,8 @@ import {
 	userItem,
 	withTranscript,
 } from "./chat.testing.ts";
-import {initialChatView} from "./view.ts";
+import {composerStateAnnouncement, subagentViewPlaceholder} from "./copy.ts";
+import {type ChatView, initialChatView} from "./view.ts";
 
 installDomShims();
 
@@ -587,5 +592,70 @@ describe("two windows over one process", () => {
 			}
 		});
 		expect(TEST_VIEWPORT.height).toBe(1_000);
+	});
+});
+
+describe("the composer's off state inside a subagent view", () => {
+	const reviewerItems: ReadonlyArray<TranscriptItem> = [
+		{...assistantItem("r-out", "the fold looks right"), parentId: ItemId.make("agent")},
+	];
+
+	const session = (): AiAgentSessionState =>
+		withTranscript([userItem("u1", "go"), call("agent", {name: "Agent"}), ...reviewerItems], {
+			subagents: {
+				agent: subagentSlot("agent", {
+					type: "reviewer",
+					items: reviewerItems,
+					lastLine: "wrote 4 rows",
+				}),
+			},
+		});
+
+	const openWithNavigator = async (): Promise<HTMLElement> => {
+		const process = await Effect.runPromise(
+			testProcess<AiAgentSessionState, AiAgentSessionMsg>(processId, session()),
+		);
+		const opened: ChatView = {...initialChatView, atOldest: true};
+		const host = await Effect.runPromise(process.window(WindowId.make("w1"), opened));
+		const {container} = render(
+			chatWindow({scrollCommitMs: 0, scrollToFn: () => undefined, subagentList: true}).render(
+				host,
+			) as ReactElement,
+		);
+		await within(container).findByRole("log", {name: /^Transcript/});
+		return container;
+	};
+
+	// The window draws a second `role="status"` for the turn phase, so this reads the one under the
+	// navigator — the view slot's own live region.
+	const announced = (root: ParentNode): string =>
+		root.querySelector<HTMLElement>('.tuval-chat-subagents + p[role="status"]')?.textContent ?? "";
+
+	/** Click the navigator row whose visible text starts with `label`. */
+	const pick = async (root: ParentNode, label: string): Promise<void> => {
+		const row = Array.from(
+			root.querySelectorAll<HTMLButtonElement>(".tuval-chat-subagent-pick"),
+		).find((candidate) => (candidate.textContent ?? "").startsWith(label));
+		expect(row, `no navigator row for "${label}"`).toBeTruthy();
+		await click(row as HTMLElement);
+	};
+
+	it("announces the composer is off and where prompts go, and drops it on the way back", async () => {
+		const root = await openWithNavigator();
+		const field = () => root.querySelector<HTMLTextAreaElement>("textarea");
+		expect(announced(root)).toContain(composerStateAnnouncement(false));
+
+		await pick(root, "reviewer");
+
+		// The field is out of the tab order here, so this region is the only surface that can say so.
+		expect(field()?.disabled).toBe(true);
+		expect(announced(root)).toContain("The composer is off here.");
+		expect(announced(root)).toContain(subagentViewPlaceholder);
+
+		await pick(root, "Back to the agent transcript");
+
+		expect(field()?.disabled).toBe(false);
+		expect(announced(root)).not.toContain("The composer is off here.");
+		expect(announced(root)).toContain(composerStateAnnouncement(false));
 	});
 });

--- a/apps/tuval/src/shell/chat/copy.ts
+++ b/apps/tuval/src/shell/chat/copy.ts
@@ -146,6 +146,18 @@ const messages: Readonly<Record<DesignCatalogKey, string>> = {
 export const subagentViewPlaceholder =
 	"Prompts go to the main agent — go back to its transcript to send (the row above, or Escape).";
 
+/**
+ * What the view slot's live region says about the composer (#8635).
+ *
+ * The placeholder above is the reason the field gives for being off, and a disabled textarea is
+ * neither focusable nor in the tab order — so a screen-reader operator never reaches it and hears
+ * the composer vanish with no reason given. This sentence carries the same reason on the one
+ * surface that is announced, and takes the composer's own `disabled` predicate so the two cannot
+ * say different things.
+ */
+export const composerStateAnnouncement = (disabled: boolean): string =>
+	disabled ? `The composer is off here. ${subagentViewPlaceholder}` : "The composer is on.";
+
 const PLACEHOLDER = /\{(\w+)\}/g;
 
 /**

--- a/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
@@ -25,6 +25,7 @@ import {testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {type ChatWindowOptions, chatWindow} from "./ChatWindow.tsx";
 import {assistantItem, call, systemItem, userItem, withTranscript} from "./chat.testing.ts";
+import {composerStateAnnouncement} from "./copy.ts";
 import {type ChatView, initialChatView} from "./view.ts";
 
 installDomShims();
@@ -556,7 +557,9 @@ describe("naming the worker a view is open on", () => {
 		const root = rendered.container;
 
 		expect(dom(root).end()).toBe("The subagent is still running.");
-		expect(status(root)).toBe("Showing the subagent's transcript. Still running.");
+		expect(status(root)).toBe(
+			`Showing the subagent's transcript. Still running. ${composerStateAnnouncement(true)}`,
+		);
 		expect(within(root).getByRole("log", {name: "Transcript: subagent"})).toBeTruthy();
 		rendered.unmount();
 	});
@@ -580,7 +583,9 @@ describe("naming the worker a view is open on", () => {
 		const root = rendered.container;
 
 		expect(dom(root).end()).toBe("The builder subagent is still running.");
-		expect(status(root)).toBe("Showing the builder subagent's transcript. Still running.");
+		expect(status(root)).toBe(
+			`Showing the builder subagent's transcript. Still running. ${composerStateAnnouncement(true)}`,
+		);
 		expect(within(root).getByRole("log", {name: "Transcript: builder subagent"})).toBeTruthy();
 		expect(typeField(root)?.textContent).toBe("builder");
 		rendered.unmount();


### PR DESCRIPTION
While Tuval's chat window shows a subagent, the composer is switched off and the only explanation
was the field's placeholder. A `disabled` textarea is neither focusable nor in the tab order, so a
screen-reader operator reached nothing where the composer was and heard no reason for it.

The view slot's existing `role="status"` region — the one live region for the swap — now carries the
composer's state too. Entering a subagent view it announces the transcript swap plus "The composer is
off here." followed by the same sentence the placeholder shows, so the reason and the way back
(the subagent row above, or Escape) are both spoken. Returning to the main transcript announces
"The composer is on."

`composerStateAnnouncement(disabled)` in `apps/tuval/src/shell/chat/copy.ts` reuses
`subagentViewPlaceholder`, so the announced reason and the placeholder cannot drift. It takes the
composer's own predicate, and `ChatWindow` now hoists that predicate into one `composerDisabled`
const feeding both the announcement and the `AgentChatInput.Root` `disabled` prop.

The textarea keeps its real `disabled` attribute and the composer stays mounted with its draft — the
founder ruling on #8466 stands, and nothing here reads or renders `AgentChatInput.Hint`, so the
announcement holds once PR #8745 removes that line.

Tests: a new case in `agent-controls.unit.test.tsx` walks into the reviewer view and back, asserting
the announced text names the off state and where prompts go, and no longer names the off state after
returning. Two exact-string assertions in `subagent-view.unit.test.tsx` now compose the same helper
rather than restating the sentence.

Verified in this tree: `pnpm typecheck` and biome green (`build check --surface code`), and the
`apps/tuval` `src/shell/chat` unit suite green at 32 files / 455 tests.

Fixes #8635

## Deviations

- **Out-of-scope change** — **Said:** #8635 names `ChatWindow.tsx`, `copy.ts` and
  `agent-controls.unit.test.tsx`. **Did:** also updated two `toBe` assertions in
  `subagent-view.unit.test.tsx`. **Why:** they pin the exact text of the same live region, so
  appending the composer sentence reds them; they now compose `composerStateAnnouncement` instead of
  restating it. **Disposition:** stated here.
