### PR TITLE
fix: A codex child with an empty agentRole makes a whole session checkpoint refuse to restore

### DIFF
--- a/apps/tuval/src/codex/child-store.ts
+++ b/apps/tuval/src/codex/child-store.ts
@@ -79,7 +79,9 @@ export const readChildTranscript = Effect.fn("Codex.readChildTranscript")(functi
 			}
 			return {
 				items: [...items.values()],
-				type: metadata.agentRole ?? "agent",
+				// `||`, not `??`: an empty role is no role, and `""` reaching the slot makes the port
+				// refuse it and sink the whole checkpoint (#8701).
+				type: metadata.agentRole || "agent",
 				status: metadata.status.type === "active" ? "running" : "finished",
 				turnId: thread.turns.findLast((turn) => turn.status === "inProgress")?.id ?? null,
 			};

--- a/apps/tuval/src/codex/subagents.unit.test.ts
+++ b/apps/tuval/src/codex/subagents.unit.test.ts
@@ -3,9 +3,10 @@ import {Deferred, Effect, Fiber, Stream} from "effect";
 import {TestClock} from "effect/testing";
 import {expect} from "vitest";
 import {foldEvent} from "../ai-agent/core/fold.ts";
+import {parseSessionState} from "../ai-agent/core/snapshot.ts";
 import {initialState} from "../ai-agent/core/state.ts";
 import type {AgentEvent} from "../ai-agent/events.ts";
-import {ItemId} from "../ai-agent/ports/index.ts";
+import {ItemId, isSubagentSlots} from "../ai-agent/ports/index.ts";
 import {TransportError, type TuvalAiAgentApi} from "../ai-agent/service/index.ts";
 import {readChildTranscript} from "./child-store.ts";
 import {fakeCodex, itemMessage, onCodex, thread, turn, turnMessage} from "./fixtures.ts";
@@ -716,6 +717,44 @@ describe("Codex read-only child store", () => {
 					yield* Effect.flip(readChildTranscript(fake.connection, thread.id, "child-1")),
 				).toMatchObject({reason: "malformed"});
 			}
+		}),
+	);
+	it.effect("reads an empty agent role as the default label, like an absent or null one", () =>
+		Effect.gen(function* () {
+			const fake = yield* fakeCodex;
+			const {agentRole: _absent, ...roleless} = childThread;
+			for (const [view, type] of [
+				[{...childThread, agentRole: ""}, "agent"],
+				[{...childThread, agentRole: null}, "agent"],
+				[roleless, "agent"],
+				[childThread, "reviewer"],
+			] as const) {
+				fake.handlers.set("thread/read", () => Effect.succeed({thread: view}));
+				const transcript = yield* readChildTranscript(fake.connection, thread.id, "child-1");
+				expect(transcript.type).toBe(type);
+				expect(transcript.type.length).toBeGreaterThan(0);
+			}
+		}),
+	);
+	it.effect("leaves a checkpoint carrying an empty-role child readable", () =>
+		Effect.gen(function* () {
+			const fake = yield* fakeCodex;
+			fake.handlers.set("thread/read", () =>
+				Effect.succeed({thread: {...childThread, agentRole: ""}}),
+			);
+			const children = new NativeSubagents();
+			const events = children.collab(spawn, thread.id, 10);
+			const hydrated = children.hydrate(
+				"child-1",
+				yield* readChildTranscript(fake.connection, thread.id, "child-1"),
+			);
+			const state = [...events, ...(hydrated === null ? [] : [hydrated])].reduce(
+				(state, event) => foldEvent(state, event, {itemLimit: 100}),
+				initialState(thread.cwd),
+			);
+			expect(state.subagents["spawn-1"]?.type).toBe("agent");
+			expect(isSubagentSlots(state.subagents)).toBe(true);
+			expect(parseSessionState(state)).not.toBeNull();
 		}),
 	);
 });


### PR DESCRIPTION
`apps/tuval/src/codex/child-store.ts` defaulted a codex child's label with `??`, which only
replaces `null` and `undefined`. An `agentRole` of `""` — which the schema admits — passed straight
through onto `ChildTranscript.type`, `NativeSubagents.hydrate` copied it onto the subagent slot, and
`isSubagentSlot` refuses an empty `type`. Since `isSubagentSlots` is an `every`, that one slot made
`parseSessionState` return `null` for the whole checkpoint: the desk came back with no restored
session and nothing named why.

The fix is one operator — `||` instead of `??` — so an empty role reads as the default `"agent"`
label the way an absent or `null` one does. Nothing else changes: `null`, absent and a non-empty
role all still produce the type they produced before, so no rendered label moves.

Two tests ride it, both in `apps/tuval/src/codex/subagents.unit.test.ts` under the existing
`Codex read-only child store` block. The first reads all four `agentRole` shapes through
`readChildTranscript` and asserts the resulting `type`. The second is the round trip: it hydrates a
slot from an `agentRole: ""` child, folds the events into a session state, and asserts
`isSubagentSlots` and `parseSessionState` both accept it. Both are red at the old `??` and green at
the new `||` (verified by reverting the operator and re-running).

Grounded by reading the path at this head rather than the issue's summary: `ChildMetadata`'s
`Schema.optionalKey(Schema.NullOr(Schema.String))` admits `""`, `hydrate` in
`apps/tuval/src/codex/subagents.ts` writes `transcript.type` onto the slot verbatim, and the
predicate in `apps/tuval/src/ai-agent/ports/subagent.ts` is the refusal.

Reviewer's first look: the inline comment on the `||`, which exists because a `||` where a `??`
stands elsewhere reads as a slip without the forcing constraint named.

Fixes #8701

## Deviations

- **Scope narrowing** — **Said:** the issue names two direction calls it puts out of scope: whether
  one unreadable slot should sink a whole checkpoint, and whether codex's absent-role default should
  become `null` to match Pi's `namedAgent`. **Did:** left both untouched. **Why:** the issue scopes
  them out explicitly as direction calls. **Disposition:** stated here; neither is filed by this PR.
- **Out-of-scope change** — **Said:** n/a. **Did:** none. **Why:** n/a. **Disposition:** none.
- **Governing-ADR departure** — **Said:** n/a. **Did:** none. **Why:** n/a. **Disposition:** none.
- **Guard or gate bypassed** — **Said:** n/a. **Did:** none. **Why:** n/a. **Disposition:** none.
- **Pre-existing test or fixture changed** — **Said:** n/a. **Did:** none; the two new tests are
  additions to an existing describe block, and no existing test or fixture was edited. **Why:** n/a.
  **Disposition:** none.
