### PR TITLE
fix: readChildTranscript's parallel-spawn artifact merge has no test over it

### DIFF
--- a/apps/tuval/src/pi/ai-agent/child-transcript.ts
+++ b/apps/tuval/src/pi/ai-agent/child-transcript.ts
@@ -228,10 +228,33 @@ export const subagentArtifactsDir = (sessionDir: string): string =>
 	join(sessionDir, "subagent-artifacts");
 
 /**
+ * The step index a run's artifact name carries, or `-1` for one that carries none.
+ *
+ * `getArtifactPaths` mints `${runId}_${safeAgent}${suffix}_transcript.jsonl` with
+ * `suffix = index !== undefined ? "_" + index : ""` (`src/shared/artifacts.ts`), and the index it
+ * is handed is `ctx.flatStepCount > 1 ? ctx.flatIndex : undefined`
+ * (`src/runs/background/subagent-runner.ts:851`) — so a single-step run's file has no index at all.
+ * `safeAgent` is the agent name with every non-`[\w.-]` character replaced by `_`, so `_` and
+ * digits both survive into it: an agent literally named `worker_2` on a single-step run reads back
+ * as index 2. That is only ever the one file such a run wrote, so there is nothing left to order.
+ */
+const stepIndexOf = (name: string, runId: string): number => {
+	const middle = name.slice(`${runId}_`.length, -"_transcript.jsonl".length);
+	const tail = middle.slice(middle.lastIndexOf("_") + 1);
+	return /^\d+$/.test(tail) ? Number(tail) : -1;
+};
+
+/**
  * The artifacts one run wrote. A parallel spawn starts several children under one run, each with
- * its own `<runId>_<agent>_<index>_transcript.jsonl`, and they are read in name order so the slot
- * keyed on the spawning call — which is 1:N against a parallel spawn either way — shows all of them
- * rather than an arbitrary one.
+ * its own `<runId>_<agent>_<index>_transcript.jsonl`, and they are read in step-index order so the
+ * slot keyed on the spawning call — which is 1:N against a parallel spawn either way — shows all of
+ * them, in the order the steps ran.
+ *
+ * The index is what orders them, never the whole name: the name puts the agent before the index, so
+ * a lexicographic sort ranks a run's steps alphabetically by agent and prints step 1 above step 0
+ * whenever two steps use different agents. The index is a bare decimal too, so as text `_10_` also
+ * sorts before `_2_`. Files carrying no index tie at `-1` and fall back to the name, which keeps the
+ * order total; a run without indices wrote one file anyway (#8672).
  *
  * Raw `node:fs` under `.patterns/effect-platform-access.md`'s "a `node:*`-only API the platform
  * service doesn't expose" case, for the reason `PiAiAgent`'s own `readBranch` reads that way: this
@@ -244,7 +267,11 @@ export const readChildTranscript = (dir: string, runId: string): ChildTranscript
 	try {
 		names = readdirSync(dir)
 			.filter((name) => name.startsWith(`${runId}_`) && name.endsWith("_transcript.jsonl"))
-			.sort();
+			.sort(
+				(left, right) =>
+					stepIndexOf(left, runId) - stepIndexOf(right, runId) ||
+					(left < right ? -1 : left > right ? 1 : 0),
+			);
 	} catch {
 		return emptyTranscript;
 	}

--- a/apps/tuval/src/pi/ai-agent/child-transcript.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/child-transcript.unit.test.ts
@@ -1,11 +1,19 @@
 /**
  * The child artifact's grammar, over lines shaped exactly as `pi-subagents`
- * `src/shared/child-transcript.ts` writes them. It is reimplemented rather than imported, so the
- * only thing holding the two in step is a test that spells the records out.
+ * `src/shared/child-transcript.ts` writes them, and the merge that reads a run's artifacts off disk
+ * on top of it. Both are reimplemented rather than imported, so the only thing holding them in step
+ * with `pi-subagents` is a test that spells the records and the file names out.
  */
 
-import {describe, expect, it} from "vitest";
-import {parseChildTranscript} from "./child-transcript.ts";
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {
+	type ChildTranscript,
+	parseChildTranscript,
+	readChildTranscript,
+} from "./child-transcript.ts";
 
 const base = (recordType: string, ts: number) => ({
 	version: 1,
@@ -136,5 +144,85 @@ describe("the child transcript's record grammar", () => {
 
 	it("reads an empty artifact as an empty slot", () => {
 		expect(parseChildTranscript("")).toEqual({items: [], lastLine: "", tokens: 0});
+	});
+});
+
+/**
+ * `getArtifactPaths` mints `${runId}_${safeAgent}${suffix}_transcript.jsonl`, and the suffix is
+ * `_${index}` only when the run has more than one step (`src/shared/artifacts.ts`;
+ * `src/runs/background/subagent-runner.ts:851` passes `ctx.flatStepCount > 1 ? ctx.flatIndex :
+ * undefined`) — so these are the names a real run writes.
+ */
+const artifact = (runId: string, agent: string, index?: number): string =>
+	`${runId}_${agent}${index === undefined ? "" : `_${index}`}_transcript.jsonl`;
+
+const assistantTexts = (transcript: ChildTranscript): ReadonlyArray<string> =>
+	transcript.items.flatMap((item) => (item.kind === "assistant" ? [item.text] : []));
+
+describe("the merge over one run's artifacts", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "child-transcript-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	const write = (name: string, records: ReadonlyArray<unknown>): void =>
+		writeFileSync(join(dir, name), lines(records), "utf-8");
+
+	// The name puts the agent before the index, so a sort over the whole name ranks the steps
+	// alphabetically by agent — two steps on different agents is already enough to invert them.
+	it("orders the steps by their index, not by the agent name the index sits behind", () => {
+		write(artifact("run-1", "beta", 0), [assistant("step zero", 1)]);
+		write(artifact("run-1", "alpha", 1), [assistant("step one", 2)]);
+		expect(assistantTexts(readChildTranscript(dir, "run-1"))).toEqual(["step zero", "step one"]);
+	});
+
+	it("orders past nine, where the bare decimal index as text would put ten before two", () => {
+		write(artifact("run-1", "worker", 2), [assistant("step two", 1)]);
+		write(artifact("run-1", "worker", 10), [assistant("step ten", 2)]);
+		expect(assistantTexts(readChildTranscript(dir, "run-1"))).toEqual(["step two", "step ten"]);
+	});
+
+	it("reads a single-step run back, whose artifact carries no index suffix at all", () => {
+		write(artifact("run-1", "solo"), [assistant("only step", 1)]);
+		expect(assistantTexts(readChildTranscript(dir, "run-1"))).toEqual(["only step"]);
+	});
+
+	it("re-keys every row apart, sums the spend, and takes the newest line from the last step", () => {
+		write(artifact("run-1", "beta", 0), [
+			assistant("zero first", 1, {input: 10, output: 4, cacheRead: 0, cacheWrite: 0, cost: 0}),
+			assistant("zero second", 2),
+		]);
+		write(artifact("run-1", "alpha", 1), [
+			assistant("one first", 3, {input: 20, output: 6, cacheRead: 0, cacheWrite: 0, cost: 0}),
+			assistant("one last", 4),
+		]);
+		const merged = readChildTranscript(dir, "run-1");
+		const ids = merged.items.map((item) => item.id);
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(merged.tokens).toBe(40);
+		expect(merged.lastLine).toBe("one last");
+	});
+
+	it("skips another run's artifacts sitting in the same directory", () => {
+		write(artifact("run-1", "worker", 0), [assistant("ours", 1)]);
+		write(artifact("run-2", "worker", 0), [
+			assistant("theirs", 2, {input: 99, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0}),
+		]);
+		const merged = readChildTranscript(dir, "run-1");
+		expect(assistantTexts(merged)).toEqual(["ours"]);
+		expect(merged.tokens).toBe(0);
+	});
+
+	it("reads a directory that does not exist yet as an empty slot", () => {
+		expect(readChildTranscript(join(dir, "not-yet"), "run-1")).toEqual({
+			items: [],
+			lastLine: "",
+			tokens: 0,
+		});
 	});
 });


### PR DESCRIPTION
`readChildTranscript` merged one run's artifact files by sorting their whole file names. The name is
`<runId>_<agent>_<index>_transcript.jsonl`, so that sort ranks a run's steps by agent name first and
by the index as text second: two steps on different agents already print step 1 above step 0, and a
run past nine steps interleaves `_10_` before `_2_`. `readChildTranscripts` is what `PiAiAgent`'s
`follow` tail calls every 500ms, so the mis-ordered array is what an operator reads in a live
subagent pane — and `lastLine`, taken from the flattened tail, was the last row of an arbitrary step
rather than the newest output.

The sort now keys on the step index parsed out of the name. A file carrying no index — a single-step
run, where `subagent-runner.ts:851` passes `undefined` — ties at `-1` and falls back to the name, so
the order stays total. The docblock no longer claims the files are read "in name order"; it names
the step-index order and why the whole name cannot give it.

The merge had no test over it at all: every existing case ran `parseChildTranscript`. A new block
writes real artifacts into a temp directory and pins the three orderings, plus the three behaviours
that were unasserted — unique ids across the merged files, the token sum, and `lastLine` off the
last step in the corrected order — and that a second run's artifacts in the same directory are
skipped. The three ordering cases red against the old `.sort()` (verified by reverting the sort:
3 failed / 14 passed) and green after the fix.

Fixes #8672

## Deviations

None.
