### PR TITLE
fix: Tuval's session-list heading reads an undeclared type token, so its font declaration is dropped

### DIFF
--- a/apps/tuval/src/ai-agent/window/session-list-window.css
+++ b/apps/tuval/src/ai-agent/window/session-list-window.css
@@ -87,7 +87,7 @@
 
 .tuval-session-transcript-header h2 {
 	margin: 0;
-	font: var(--t-heading-sm);
+	font: var(--t-h-feed);
 	color: var(--text-primary);
 }
 

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -131,7 +131,7 @@
 
 .kp-divan__decisions-title {
 	margin: 0;
-	font: var(--t-heading-sm, var(--t-body));
+	font: var(--t-h-feed);
 	color: var(--text-primary);
 }
 

--- a/packages/design/design-token-lint.config.json
+++ b/packages/design/design-token-lint.config.json
@@ -5,7 +5,6 @@
 	"grandfatheredMissingTokens": [
 		"--t-h1",
 		"--t-h3",
-		"--t-heading-sm",
 		"--border-subtle",
 		"--warning-soft",
 		"--bg",


### PR DESCRIPTION
`--t-heading-sm` is a token name nobody ever declared — a pickaxe search over `packages/design/src/tokens.css` history finds no commit that added it at any point. Two stylesheets consume it, and one of them has no fallback, so per CSS Variables 1 §3.2 the `var()` substitutes the guaranteed-invalid value and the whole `font` shorthand is dropped at computed-value time. Tuval's session-transcript `<h2>` therefore rendered at inherited body type instead of as a heading.

The type ramp already ships the small-heading step both consumers wanted, so this re-points rather than declares. Adding an eighth step would be an ADR 0162 change made on behalf of a name nobody designed.

- `apps/tuval/src/ai-agent/window/session-list-window.css:90` — `font: var(--t-h-feed);`, the visible fix.
- `apps/web/src/components/divan/Divan.css:134` — same, and the `var(--t-body)` fallback goes with the dead name it was guarding.
- `packages/design/design-token-lint.config.json` — `--t-heading-sm` drops out of `grandfatheredMissingTokens`. That list's own note says it only shrinks as remediation legs fix refs, and this is that leg. The six other entries and both `Note` strings are untouched.

`packages/design/src/tokens.css` is unchanged. A tree-wide search for `--t-heading-sm` now returns zero hits, and `fabrika guard design-token-guard check` reports 90 CSS files / 2385 refs with every ref resolving.

## Deviations

- **Scope narrowing** — **Said:** #8760 names the two consumers and the one allow-list entry. **Did:** exactly those three files. **Why:** the six other grandfathered names are dead refs the issue explicitly leaves alone. **Disposition:** no deviation; stated for the record.
- **Declined guidance** — **Said:** the original report floated declaring `--t-heading-sm` in the ramp as one option. **Did:** re-pointed both consumers at `--t-h-feed` instead. **Why:** triage ruled minting a token out of scope, since the ramp is a hand-tuned ladder under ADR 0162 and an eighth step is a design call this ticket does not carry. **Disposition:** followed the triaged direction.

Fixes #8760
