### PR TITLE
fix: The Tuval subagent row's focus ring is dropped: --focus-ring is a shorthand used as a color

### DIFF
--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -111,11 +111,6 @@
 	background: var(--surface-raised);
 }
 
-.tuval-chat-subagent-pick:focus-visible {
-	outline: 2px solid var(--focus-ring, var(--text-primary));
-	outline-offset: 1px;
-}
-
 /* The one showing. The mark is the left rule plus the stronger text, never colour alone. */
 .tuval-chat-subagent-pick[aria-current="true"] {
 	background: var(--surface-raised);

--- a/apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The subagent rows' focus ring (#8751). The rows are buttons, so they owe a visible ring, and the
+ * desk paints it once for everything under `.tuval-surface`. What is proven here is that the chat
+ * sheet hand-rolls none of its own and that a focused row is inside the desk rule's reach.
+ *
+ * jsdom does not resolve `var()` substitution, so a computed `outline` string would read the same
+ * whether the declaration survived or was dropped — the sheet is read off disk and the desk rule is
+ * checked by selector match instead.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import type {SubagentSlot} from "../../ai-agent/ports/index.ts";
+import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
+import {ProcessId} from "../../process/process.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {userItem, withTranscript} from "./chat.testing.ts";
+import {initialChatView} from "./view.ts";
+
+installDomShims();
+
+const chatSheet = (): string =>
+	readFileSync(fileURLToPath(import.meta.resolve("./chat.css")), "utf8");
+
+const deskSheet = (): string =>
+	readFileSync(fileURLToPath(import.meta.resolve("../ui/tokens.css")), "utf8");
+
+const slots = (...entries: ReadonlyArray<SubagentSlot>): Record<string, SubagentSlot> =>
+	Object.fromEntries(entries.map((slot) => [slot.id, slot]));
+
+/** The window mounted under a desk root, which is what carries `.tuval-surface` in the app. */
+const openUnderSurface = async (state: AiAgentSessionState) => {
+	const surface = document.createElement("div");
+	surface.className = "tuval-surface";
+	document.body.append(surface);
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
+	);
+	const host = await Effect.runPromise(process.window(WindowId.make("w1"), initialChatView));
+	const rendered = render(
+		chatWindow({scrollCommitMs: 0, scrollToFn: () => undefined, subagentList: true}).render(
+			host,
+		) as ReactElement,
+		{container: surface},
+	);
+	await screen.findByRole("log", {name: "Transcript"});
+	return {
+		rendered,
+		unmount: () => {
+			rendered.unmount();
+			surface.remove();
+		},
+	};
+};
+
+describe("the subagent rows' focus ring", () => {
+	it("is hand-rolled nowhere in the chat sheet", () => {
+		const blocks = chatSheet()
+			.split("}")
+			.filter((block) => /tuval-chat-subagent/.test(block.split("{")[0] ?? ""));
+
+		expect(blocks.length).toBeGreaterThan(0);
+		expect(blocks.filter((block) => /\boutline\s*:/.test(block))).toEqual([]);
+	});
+
+	it("is the desk's one rule, declared off the ring tokens", () => {
+		expect(deskSheet()).toMatch(
+			/\.tuval-surface :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
+		);
+	});
+
+	it("reaches a focused pick row, which sits under the desk root", async () => {
+		const opened = await openUnderSurface(
+			withTranscript([userItem("u1", "go")], {
+				subagents: slots(subagentSlot("a", {type: "reviewer"})),
+			}),
+		);
+		const pick = document.querySelector<HTMLButtonElement>(".tuval-chat-subagent-pick");
+		expect(pick).not.toBeNull();
+
+		pick?.focus();
+
+		expect(Array.from(document.querySelectorAll(".tuval-surface :focus-visible"))).toContain(pick);
+		opened.unmount();
+	});
+});


### PR DESCRIPTION
The subagent rows in Tuval's chat window are buttons a keyboard user can tab to, and they painted no
focus ring. The rule meant to paint one read `outline: 2px solid var(--focus-ring, …)`, but
`--focus-ring` is itself a whole `outline` shorthand (`2px solid var(--accent)`), so the
substitution produced `outline: 2px solid 2px solid var(--accent)` — invalid at computed-value time,
and the browser dropped the declaration. WCAG 2.4.7 failed on a live control.

The fix is the delete. Both selectors are (0,2,0), and once the chat rule is gone there is no
contest at all: `.tuval-surface :focus-visible` in `apps/tuval/src/shell/ui/tokens.css` is a
descendant rule and the desk root carries `.tuval-surface`, so it paints the row. No second outline,
no `!important`, no specificity bump. `tokens.css` is untouched.

Three unit tests in `apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx`: the sheet
hand-rolls no `outline` for any `tuval-chat-subagent` selector (the block-filter shape already used
at `tool-run-disclosure.unit.test.tsx:337`), the desk rule still declares itself off the ring
tokens, and a focused pick row mounted under a `.tuval-surface` root is matched by
`.tuval-surface :focus-visible`. Both behavioural tests were checked red before green — the first
against the rule as it stood, the third with the surface class removed. jsdom does not resolve
`var()`, so nothing here asserts a computed `outline` string.

Fixes #8751

## Deviations

None.
