### PR TITLE
fix: A Tuval system notice's detail field carries no size ceiling

### DIFF
--- a/apps/tuval/src/claude/history/local-command.unit.test.ts
+++ b/apps/tuval/src/claude/history/local-command.unit.test.ts
@@ -14,7 +14,8 @@
 
 import type {SDKMessage, SessionMessage} from "@anthropic-ai/claude-agent-sdk";
 import {describe, expect, it} from "vitest";
-import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
+import {itemBytes} from "../../ai-agent/history/index.ts";
+import {byteLength, type TranscriptItem} from "../../ai-agent/ports/index.ts";
 import {toAgentEvents} from "./events.ts";
 import {loadFixture} from "./fixtures/load.ts";
 import {toHistoryItems} from "./items.ts";
@@ -234,6 +235,59 @@ describe("a captured skill invocation", () => {
 			"<command-name>/a</command-name>\n<command-name>/b</command-name>\n<command-args>x</command-args>";
 		const [one] = mapped(withText(captured, prompt));
 		expect(one?.kind).toBe("user");
+	});
+});
+
+describe("a notice body larger than the mapping's own ceiling", () => {
+	const captured = frame("local-command-skill-turn");
+
+	/** `map.ts`'s `NOTICE_DETAIL_BYTE_LIMIT`, which the module keeps to itself. */
+	const DETAIL_LIMIT = 8_000;
+
+	// The committed skill fixture is trimmed to six lines, so the size this bound exists for is
+	// built here: the tags a real skill frame carries, then a body past the ceiling.
+	const skillFrame = (body: string): string =>
+		[
+			"<command-message>fabrika:triage</command-message>",
+			"<command-name>fabrika:triage</command-name>",
+			"<skill-format>true</skill-format>",
+			body,
+		].join("\n");
+
+	const detailOf = (text: string): string => {
+		const [one] = mapped(withText(captured, text));
+		return one?.kind === "system" ? (one.detail ?? "") : "";
+	};
+
+	it("cuts a skill's body to the ceiling and says in the panel that it did", () => {
+		const detail = detailOf(skillFrame("word ".repeat(4_000)));
+		expect(byteLength(detail)).toBeLessThanOrEqual(DETAIL_LIMIT);
+		expect(detail).toMatch(/cut to fit the transcript window/);
+	});
+
+	it("holds the whole item inside that ceiling, which is what the window counts", () => {
+		const [one] = mapped(withText(captured, skillFrame("word ".repeat(40_000))));
+		expect(one).toBeDefined();
+		if (one === undefined) return;
+		expect(itemBytes(one)).toBeLessThan(DETAIL_LIMIT + 1_000);
+	});
+
+	it("cuts on a code-point boundary, so the panel reads no replacement character", () => {
+		const detail = detailOf(skillFrame("é".repeat(6_000)));
+		expect(byteLength(detail)).toBeLessThanOrEqual(DETAIL_LIMIT);
+		expect(detail).not.toMatch(/�/);
+	});
+
+	it("leaves a body inside the ceiling whole, with no marker on it", () => {
+		const body = "the skill's whole text";
+		expect(detailOf(skillFrame(body))).toBe(body);
+	});
+
+	it("bounds a command output's own detail on the same ceiling", () => {
+		const output = `first line\n${"word ".repeat(4_000)}`;
+		const detail = detailOf(`<local-command-stdout>${output}</local-command-stdout>`);
+		expect(byteLength(detail)).toBeLessThanOrEqual(DETAIL_LIMIT);
+		expect(detail).toMatch(/cut to fit the transcript window/);
 	});
 });
 

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -16,12 +16,14 @@
 
 import type {AgentEvent} from "../../ai-agent/events.ts";
 import {boundToolOutput} from "../../ai-agent/history/index.ts";
-import type {
-	CommandRef,
-	ItemId,
-	JsonValue,
-	SubagentSlot,
-	TranscriptItem,
+import {
+	boundToolResult,
+	byteLength,
+	type CommandRef,
+	type ItemId,
+	type JsonValue,
+	type SubagentSlot,
+	type TranscriptItem,
 } from "../../ai-agent/ports/index.ts";
 import {
 	isRecord,
@@ -620,6 +622,31 @@ export const partialReplyEvents = (
 /** How much of a notice's own prose rides the summary line before the rest folds into `detail`. */
 const NOTICE_SUMMARY_LIMIT = 200;
 
+/**
+ * How many bytes of a notice's body ride `detail`, marker included.
+ *
+ * A different budget from `NOTICE_SUMMARY_LIMIT`'s, which guards the always-visible line: this one
+ * guards `TRANSCRIPT_WINDOW_BYTE_LIMIT`, the live tail's. `itemBytes` counts the whole item with
+ * `detail` in it, so an unbounded body — a skill frame's is some ten kilobytes — spends the tail's
+ * budget and pushes older groups out of the operator's history (#8765). Sized like a tool result's
+ * own allowance, because a notice's body spends that budget the same way; its own constant rather
+ * than that one, so a change to what a tool result may spend does not silently move this ceiling.
+ */
+const NOTICE_DETAIL_BYTE_LIMIT = 8_000;
+
+/** What an opened disclosure reads at the cut, so the panel never passes a part off as the whole. */
+const NOTICE_DETAIL_CUT = "\n\n… cut to fit the transcript window; the rest is not here.";
+
+/**
+ * A notice's body bounded before the item is minted, cut on a code-point boundary by the same
+ * `boundToolResult` a tool row's output goes through. `SystemItem.detail` has no field to carry an
+ * omission count, so the cut says so inside the string it returns.
+ */
+const boundNoticeDetail = (detail: string): string => {
+	const bound = boundToolResult(detail, NOTICE_DETAIL_BYTE_LIMIT - byteLength(NOTICE_DETAIL_CUT));
+	return bound.omitted.bytes === 0 ? bound.text : `${bound.text}${NOTICE_DETAIL_CUT}`;
+};
+
 const LOCAL_COMMAND_OPEN = "<local-command-stdout>";
 const LOCAL_COMMAND_CLOSE = "</local-command-stdout>";
 
@@ -711,12 +738,15 @@ const localCommandInvocationOf = (
 	if (rest.length > 0 && !parts.has(SKILL_FORMAT)) return null;
 	const args = parts.get("command-args") ?? "";
 	const line = args.length === 0 ? name : `${name} ${args}`;
-	return rest.length === 0 ? {text: line} : {text: line, detail: rest.replaceAll(sgr, "")};
+	return rest.length === 0
+		? {text: line}
+		: {text: line, detail: boundNoticeDetail(rest.replaceAll(sgr, ""))};
 };
 
 /**
- * One command's output as the collapsed notice's two fields: the line always shown, and the whole
- * output behind the disclosure whenever that line is not all of it (`shell/chat/SessionRow.tsx`).
+ * One command's output as the collapsed notice's two fields: the line always shown, and the output
+ * behind the disclosure whenever that line is not all of it (`shell/chat/SessionRow.tsx`), bounded
+ * at `NOTICE_DETAIL_BYTE_LIMIT`.
  */
 const noticeOf = (output: string): {readonly text: string; readonly detail?: string} => {
 	const first =
@@ -726,7 +756,7 @@ const noticeOf = (output: string): {readonly text: string; readonly detail?: str
 			?.trim() ?? "";
 	const line =
 		first.length > NOTICE_SUMMARY_LIMIT ? `${first.slice(0, NOTICE_SUMMARY_LIMIT)}…` : first;
-	return line === output ? {text: line} : {text: line, detail: output};
+	return line === output ? {text: line} : {text: line, detail: boundNoticeDetail(output)};
 };
 
 /**


### PR DESCRIPTION
A system notice's `detail` had no size ceiling, so a skill invocation put its whole body — the real
captured one measures 9,477 bytes — on a `SystemItem`. `itemBytes` counts the whole item, `detail`
included, against `TRANSCRIPT_WINDOW_BYTE_LIMIT`, so about 27 skill invocations spent the live
tail's entire byte budget and `planTranscriptWindow` started dropping older groups off the
operator's visible history.

The bound now runs in the mapping, before the item is minted, beside the ceilings already there:

- `NOTICE_DETAIL_BYTE_LIMIT` (8,000) sits next to `NOTICE_SUMMARY_LIMIT`, with a docblock naming the
  budget it guards — the live tail's, not the summary line's. It is its own constant rather than
  `TOOL_RESULT_BYTE_LIMIT`, so a change to what a tool result may spend does not silently move it.
- `boundNoticeDetail` cuts through `boundToolResult` from `apps/tuval/src/ai-agent/ports/transcript-item.ts`,
  so the cut is measured in bytes and lands on a code-point boundary — no second hand-rolled slice.
- Both writers that fill `detail` go through it: `localCommandInvocationOf` (the skill body) and
  `noticeOf` (a command's output).
- `SystemItem.detail` is a plain `string | undefined` with no field for an omission count, so the
  cut marks itself inside the string. The disclosure panel `apps/tuval/src/shell/chat/SessionRow.tsx`
  draws renders `detail` in a `<pre>`, so an opened panel reads the marker at the end and never
  passes a part off as the whole. Nothing in the component had to change, and the port kept its
  shape.

The bound reserves the marker's own bytes, so the ceiling holds marker included.

The committed skill fixture is trimmed to six lines and does not exercise the size, so the tests
build their own oversized frame: the invocation tags a real skill frame carries, then a body past
the ceiling. They assert the minted `detail` is inside the limit, that `itemBytes` for the whole
item is too — the budget the fix exists to protect — that a multi-byte body cuts without a
replacement character, and that a body inside the ceiling comes through whole with no marker.

`pnpm --filter @kampus/tuval typecheck`, biome on both files, and the 663 unit tests under
`apps/tuval/src/claude/history` and `apps/tuval/src/ai-agent` are green.

Fixes #8765

## Deviations

- **Scope narrowing** — **Said:** the third acceptance criterion asks that a cut item say so in the
  disclosure panel `apps/tuval/src/shell/chat/SessionRow.tsx` draws. **Did:** put the cut marker in
  the `detail` string at mapping time and left `SessionRow.tsx` untouched. **Why:** the panel
  renders `detail` verbatim in a `<pre>`, so the marker already reads there; widening
  `SystemItem.detail` to carry an omission count would put a field on the port for one adapter's
  benefit, and the issue leaves that choice open. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** #8765 names `localCommandInvocationOf` and `noticeOf`.
  **Did:** bounded exactly those two; `systemNoticeEvents`'s own `noticeDetailOf` writer, further
  down the same module, is left unbounded. **Why:** it folds an SDK envelope's unclaimed fields
  rather than a skill body, the issue's criteria do not name it, and I have no capture saying how
  large a real one gets. **Disposition:** filed as #8777.
