### PR TITLE
feat: A parallel subagent spawn puts N Tuval workers into one slot

### DIFF
--- a/apps/tuval/src/ai-agent-fixtures/transcripts.ts
+++ b/apps/tuval/src/ai-agent-fixtures/transcripts.ts
@@ -96,6 +96,7 @@ export const subagentSlot = (
 	lastLine: "reading the file",
 	startedAt: AT,
 	tokens: 1_200,
+	workers: 1,
 	items: [],
 	status: "running",
 	...overrides,

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -68,6 +68,7 @@ export {
 	readCheckpoint,
 	SPENT_BEFORE_LEDGER,
 	withCheckpointDefaults,
+	withSubagentWorkers,
 	withUsageLedger,
 } from "./snapshot.ts";
 export {

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -8,7 +8,12 @@
 import {applyCellChecked} from "@demlik/tea";
 import {describe, expect, it} from "vitest";
 import {pendingPermission} from "../../ai-agent-fixtures/permissions.ts";
-import {assistantItem, toolItem, userItem} from "../../ai-agent-fixtures/transcripts.ts";
+import {
+	assistantItem,
+	subagentSlot,
+	toolItem,
+	userItem,
+} from "../../ai-agent-fixtures/transcripts.ts";
 import type {AgentEvent} from "../events.ts";
 import {Mode, type ModelRef, type PermissionRequest, type TranscriptItem} from "../ports/index.ts";
 import {checkpointUnreadable} from "./failures.ts";
@@ -163,6 +168,33 @@ describe("a checkpoint written by an older build", () => {
 
 	it("keeps a refusal the operator can read out of the restored session", () => {
 		expect(restoredFrom(deskShaped()).failure).toBeNull();
+	});
+
+	/**
+	 * A slot saved before it counted its workers, read as the one worker it meant (#8664).
+	 *
+	 * `withCheckpointDefaults` cannot reach it: `subagents` is present and well-formed, and it is
+	 * the per-slot shape that grew a field — so without the repair the predicate refuses the whole
+	 * checkpoint and every desk holding a subagent comes back `gone`.
+	 */
+	const uncounted = (): Record<string, unknown> => {
+		const {workers, ...slot} = subagentSlot("call-1");
+		return {...deskShaped(), subagents: {"call-1": slot}};
+	};
+
+	it("reads a slot that counted no workers as the one worker it held", () => {
+		const state = restoredFrom(uncounted());
+		expect(state.failure).toBeNull();
+		expect(state.subagents["call-1"]?.workers).toBe(1);
+		expect(state.subagents["call-1"]?.lastLine).toBe(subagentSlot("call-1").lastLine);
+	});
+
+	it("still refuses a slot whose count is present and wrong", () => {
+		const state = restoredFrom({
+			...deskShaped(),
+			subagents: {"call-1": {...subagentSlot("call-1"), workers: 0}},
+		});
+		expect(state.failure).toEqual(checkpointUnreadable);
 	});
 
 	// Reds if a field is added to the state with no entry in `initialState` to default it from.

--- a/apps/tuval/src/ai-agent/core/snapshot.ts
+++ b/apps/tuval/src/ai-agent/core/snapshot.ts
@@ -241,6 +241,37 @@ export const withUsageLedger = (raw: unknown): unknown => {
 };
 
 /**
+ * A checkpoint written before a slot counted its workers, read with the count it implied (#8664).
+ *
+ * A repair rather than a default, for the same reason `withUsageLedger` is one: `subagents` is
+ * present and well-formed, it is the per-slot shape that grew a field. Every slot the old shape
+ * could write held one spawning call and said nothing about a fan-out, so `1` is what it meant —
+ * and without this the predicate refuses the whole checkpoint and the desk comes back `gone`.
+ *
+ * It fills only an absent count. A slot carrying a `workers` of the wrong type stays wrong, and
+ * `parseSessionState` still refuses it.
+ */
+export const withSubagentWorkers = (raw: unknown): unknown => {
+	if (
+		!Predicate.isObject(raw) ||
+		!Predicate.isObject(raw.subagents) ||
+		Array.isArray(raw.subagents)
+	)
+		return raw;
+	const slots = Object.entries(raw.subagents);
+	if (!slots.some(([, slot]) => Predicate.isObject(slot) && slot.workers === undefined)) return raw;
+	return {
+		...raw,
+		subagents: Object.fromEntries(
+			slots.map(([key, slot]) => [
+				key,
+				Predicate.isObject(slot) && slot.workers === undefined ? {...slot, workers: 1} : slot,
+			]),
+		),
+	};
+};
+
+/**
  * The checkpoint read, as the defaulting and the predicate composed once: the session, or `null`.
  *
  * One function rather than two call sites of the same pair, because `loadCheckpoint` wants the
@@ -248,7 +279,7 @@ export const withUsageLedger = (raw: unknown): unknown => {
  * different verdict than the one the window renders would hold the wrong bytes (#8112).
  */
 export const readCheckpoint = (loaded: unknown, cwd: string): AiAgentSessionState | null =>
-	parseSessionState(withUsageLedger(withCheckpointDefaults(loaded, cwd)));
+	parseSessionState(withSubagentWorkers(withUsageLedger(withCheckpointDefaults(loaded, cwd))));
 
 /**
  * What the store loaded, read as a session — or the refusal, when it is not one. The machine's

--- a/apps/tuval/src/ai-agent/ports/subagent.ts
+++ b/apps/tuval/src/ai-agent/ports/subagent.ts
@@ -22,6 +22,7 @@ import {Predicate} from "effect";
 import {
 	type ItemId,
 	isNonNegativeInteger,
+	isPositiveInteger,
 	isTranscriptItems,
 	type TranscriptItem,
 } from "./transcript-item.ts";
@@ -33,7 +34,12 @@ import {
 export type SubagentStatus = "running" | "finished";
 
 export interface SubagentSlot {
-	/** The spawning call's item id: one tool row, one worker, one slot. */
+	/**
+	 * The spawning call's item id: one tool row, one slot, however many workers that call started.
+	 * A fan-out keeps this keying and merges its workers into the one slot — founder ruling
+	 * 2026-09-09 on #8664, which took that shape over one slot per worker and left this identity
+	 * standing. `workers` is what the merged slot says about the count.
+	 */
 	readonly id: ItemId;
 	/**
 	 * What kind of worker this is, in the backend's own words — a label, never a type tag. `null`
@@ -47,6 +53,15 @@ export interface SubagentSlot {
 	/** Epoch milliseconds, so the window computes elapsed without a backend clock type. */
 	readonly startedAt: number;
 	readonly tokens: number;
+	/**
+	 * How many workers the spawning call started, at least one. A call that started one is `1` and
+	 * says nothing more; above that the slot's rows, `lastLine` and `tokens` are all of them
+	 * together, and a surface that draws the count is the only thing telling a reader so.
+	 *
+	 * A count and not a list of worker ids: the ruling keyed the slot on the call, so there is no
+	 * per-worker row to address, and an id nothing can open is a field that only invites one.
+	 */
+	readonly workers: number;
 	/**
 	 * Every item the worker produced, in arrival order. Every kind, not the assistant and tool ones
 	 * alone: a worker's inbound turn arrives parent-tagged too, so a slot admitting less would drop
@@ -66,6 +81,7 @@ export const isSubagentSlot = (value: unknown): value is SubagentSlot =>
 	typeof value.lastLine === "string" &&
 	Number.isFinite(value.startedAt) &&
 	isNonNegativeInteger(value.tokens) &&
+	isPositiveInteger(value.workers) &&
 	isTranscriptItems(value.items) &&
 	typeof value.status === "string" &&
 	statuses.has(value.status);

--- a/apps/tuval/src/ai-agent/ports/subagent.unit.test.ts
+++ b/apps/tuval/src/ai-agent/ports/subagent.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * The subagent slot's admission test: the six fields it carries, and what each of them refuses.
+ * The subagent slot's admission test: the seven fields it carries, and what each of them refuses.
  *
  * The `items` arm is the one worth a case of its own. A worker's inbound turn arrives
  * parent-tagged like everything else it produces, so the slot admits every item kind rather than
@@ -22,7 +22,7 @@ import {isSubagentSlot, isSubagentSlots} from "./subagent.ts";
 const slot = subagentSlot("call-1");
 
 describe("a subagent slot", () => {
-	it("is admitted with the five reported fields and the id it is keyed on", () => {
+	it("is admitted with the six reported fields and the id it is keyed on", () => {
 		expect(isSubagentSlot(slot)).toBe(true);
 		expect(Object.keys(slot).sort()).toEqual([
 			"id",
@@ -32,6 +32,7 @@ describe("a subagent slot", () => {
 			"status",
 			"tokens",
 			"type",
+			"workers",
 		]);
 	});
 
@@ -48,6 +49,13 @@ describe("a subagent slot", () => {
 		expect(isSubagentSlot({...slot, tokens: -1})).toBe(false);
 		expect(isSubagentSlot({...slot, tokens: 1.5})).toBe(false);
 		expect(isSubagentSlot({...slot, tokens: "340k"})).toBe(false);
+		// A slot is of at least one worker, so zero is not a count and neither is an absent one.
+		expect(isSubagentSlot({...slot, workers: 3})).toBe(true);
+		expect(isSubagentSlot({...slot, workers: 0})).toBe(false);
+		expect(isSubagentSlot({...slot, workers: -1})).toBe(false);
+		expect(isSubagentSlot({...slot, workers: 1.5})).toBe(false);
+		expect(isSubagentSlot({...slot, workers: "3 workers"})).toBe(false);
+		expect(isSubagentSlot({...slot, workers: undefined})).toBe(false);
 		expect(isSubagentSlot({...slot, items: [{kind: "user"}]})).toBe(false);
 		expect(isSubagentSlot({...slot, items: {}})).toBe(false);
 		expect(isSubagentSlot({...slot, status: "done"})).toBe(false);

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -216,6 +216,9 @@ const isOptionalId = (value: unknown): boolean => value === undefined || isId(va
 export const isNonNegativeInteger = (value: unknown): boolean =>
 	typeof value === "number" && Number.isInteger(value) && value >= 0;
 
+export const isPositiveInteger = (value: unknown): boolean =>
+	isNonNegativeInteger(value) && (value as number) >= 1;
+
 const isToolResult = (value: unknown): value is ToolResult =>
 	Predicate.isObject(value) &&
 	typeof value.text === "string" &&

--- a/apps/tuval/src/claude/history/map.ts
+++ b/apps/tuval/src/claude/history/map.ts
@@ -217,6 +217,8 @@ const openSlot = (id: string, type: string, at: number): SubagentSlot => ({
 	lastLine: "",
 	startedAt: at,
 	tokens: 0,
+	// A sidechain is one worker: the SDK drives each through its own spawning call.
+	workers: 1,
 	items: [],
 	status: "running",
 });

--- a/apps/tuval/src/codex/subagents.ts
+++ b/apps/tuval/src/codex/subagents.ts
@@ -94,6 +94,8 @@ export class NativeSubagents {
 			this.slots.set(
 				value.id,
 				previous ?? {
+					// One worker by construction: the multi-child spawn is refused just above.
+					workers: 1,
 					id: ItemId.make(value.id),
 					type: "agent",
 					lastLine: "",

--- a/apps/tuval/src/pi/ai-agent/child-transcript.ts
+++ b/apps/tuval/src/pi/ai-agent/child-transcript.ts
@@ -295,8 +295,14 @@ export const readChildTranscript = (dir: string, runId: string): ChildTranscript
 
 /**
  * Several runs' transcripts as one slot's rows. An async spawn is one call over as many workers as
- * its `steps[]` names, and the slot stays keyed on the call (#8664 owns how a fan-out is laid out),
- * so their rows are concatenated in the order the steps were resolved and re-keyed apart.
+ * its `steps[]` names, and the slot stays keyed on the call, so their rows are concatenated in the
+ * order the steps were resolved and re-keyed apart.
+ *
+ * That merge is the shape the founder ruled on #8664 (2026-09-09), over one slot per worker: the
+ * rows, the `lastLine` and the summed `tokens` are every worker's together, and the slot's own
+ * `workers` count is what says so on the surface that draws it. This layer is unchanged by that
+ * ruling — it merged before it and merges after — and so is `readChildTranscript`'s within-run
+ * merge one layer down.
  *
  * The re-key runs even for a single run, matching `readChildTranscript`'s own `child-<at>-` prefix:
  * a step that launches later must not renumber the ids of the rows already on screen.

--- a/apps/tuval/src/pi/ai-agent/items.ts
+++ b/apps/tuval/src/pi/ai-agent/items.ts
@@ -300,6 +300,13 @@ const filled = (spawn: RunningSpawn, resolution: AsyncSpawn | null | undefined):
 const runIdsOf = (spawn: RunningSpawn): ReadonlyArray<string> =>
 	spawn.runId === null ? (spawn.resolved?.runIds ?? []) : [spawn.runId];
 
+/**
+ * How many workers a spawn's slot holds, off the runs its artifacts are read from. At least one:
+ * a call that has resolved no run yet still started a worker, and a zero would say the slot is of
+ * nothing (founder ruling 2026-09-09 on #8664).
+ */
+const workerCountOf = (runIds: ReadonlyArray<string>): number => Math.max(1, runIds.length);
+
 /** The same rule for the tail, which needs the run ids before the fold has folded the answer. */
 export const spawnRunIds = (
 	spawn: RunningSpawn,
@@ -317,6 +324,7 @@ const runningSlotOf = (spawn: RunningSpawn, child: ChildTranscript): SubagentSlo
 	lastLine: child.lastLine,
 	startedAt: spawn.startedAt,
 	tokens: countOf(child.tokens),
+	workers: workerCountOf(runIdsOf(spawn)),
 	items: childItems(spawn.id, child),
 	status: "running",
 });
@@ -375,6 +383,7 @@ export const subagentSlotsOf = (
 							lastLine: "",
 							startedAt: item.timestamp,
 							tokens: 0,
+							workers: workerCountOf(held?.get(part.toolCallId)?.resolved?.runIds ?? []),
 							items: [],
 							status: "running" as const,
 						},
@@ -395,6 +404,7 @@ export const subagentSlotsOf = (
 					lastLine: "",
 					startedAt: item.timestamp,
 					tokens: 0,
+					workers: 1,
 					items: [],
 					status: "running",
 				},
@@ -406,7 +416,8 @@ export const subagentSlotsOf = (
 	}
 	const runId = runIdOf(item);
 	const finished = carried?.resolved ?? resolved?.get(item.toolCallId) ?? null;
-	const child = childOf(children, runId === null ? (finished?.runIds ?? []) : [runId]);
+	const runIds = runId === null ? (finished?.runIds ?? []) : [runId];
+	const child = childOf(children, runIds);
 	return [
 		{
 			id,
@@ -418,6 +429,7 @@ export const subagentSlotsOf = (
 			tokens: countOf(
 				child === undefined || child.tokens === 0 ? item.usage?.totalTokens : child.tokens,
 			),
+			workers: workerCountOf(runIds),
 			items: child === undefined ? [] : childItems(id, child),
 			status: "finished",
 		},

--- a/apps/tuval/src/pi/ai-agent/items.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/items.unit.test.ts
@@ -621,6 +621,7 @@ describe("a subagent's start and end over the delta stream", () => {
 					lastLine: "",
 					startedAt: 11,
 					tokens: 0,
+					workers: 1,
 					items: [],
 					status: "running",
 				},
@@ -638,6 +639,7 @@ describe("a subagent's start and end over the delta stream", () => {
 					lastLine: "done: 3 findings",
 					startedAt: 12,
 					tokens: 0,
+					workers: 1,
 					items: [],
 					status: "finished",
 				},
@@ -1037,6 +1039,7 @@ describe("a running subagent filled from its own transcript artifact", () => {
 					lastLine: "reading src/a.ts",
 					startedAt: 11,
 					tokens: 42,
+					workers: 1,
 					items: [childRow],
 					status: "running",
 				},
@@ -1081,6 +1084,7 @@ describe("a running subagent filled from its own transcript artifact", () => {
 				lastLine: "reading src/a.ts",
 				startedAt: 13,
 				tokens: 42,
+				workers: 1,
 				items: [childRow],
 				status: "finished",
 			},
@@ -1153,6 +1157,7 @@ describe("a detached subagent filled through the tool-call index", () => {
 				lastLine: "",
 				startedAt: 21,
 				tokens: 0,
+				workers: 1,
 				items: [],
 				status: "running",
 			},
@@ -1169,6 +1174,7 @@ describe("a detached subagent filled through the tool-call index", () => {
 					lastLine: "cutting the lane",
 					startedAt: 21,
 					tokens: 17,
+					workers: 1,
 					items: [
 						{
 							kind: "assistant",
@@ -1242,6 +1248,8 @@ describe("a detached subagent filled through the tool-call index", () => {
 					lastLine: "reading the diff",
 					startedAt: 21,
 					tokens: 26,
+					// Two runs resolved, so the one slot says how many workers its merged rows are of.
+					workers: 2,
 					items: [
 						{
 							kind: "assistant",
@@ -1350,6 +1358,7 @@ describe("a finished detached subagent on a session that never watched it run", 
 				lastLine: "cutting the lane",
 				startedAt: 31,
 				tokens: 17,
+				workers: 1,
 				items: [
 					{
 						kind: "assistant",
@@ -1377,6 +1386,7 @@ describe("a finished detached subagent on a session that never watched it run", 
 				lastLine: "cutting the lane",
 				startedAt: 31,
 				tokens: 17,
+				workers: 1,
 				items: [
 					{
 						kind: "assistant",
@@ -1400,6 +1410,7 @@ describe("a finished detached subagent on a session that never watched it run", 
 				lastLine: "PR opened",
 				startedAt: 31,
 				tokens: 33,
+				workers: 1,
 				items: [],
 				status: "finished",
 			},

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -1129,8 +1129,8 @@ function ChatWindow({
 									? "Showing the agent's own transcript."
 									: "Showing a subagent whose transcript is not in this session's state."
 								: viewedSlot.status === "finished"
-									? `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Finished: ${viewedSlot.lastLine}`
-									: `Showing the ${subagentPhrase(viewedSlot.type)}'s transcript. Still running.`}{" "}
+									? `Showing the ${subagentPhrase(viewedSlot.type, viewedSlot.workers)}'s transcript. Finished: ${viewedSlot.lastLine}`
+									: `Showing the ${subagentPhrase(viewedSlot.type, viewedSlot.workers)}'s transcript. Still running.`}{" "}
 							{composerStateAnnouncement(composerDisabled)}
 						</p>
 					</>
@@ -1145,7 +1145,7 @@ function ChatWindow({
 					aria-label={
 						viewedSlot === undefined
 							? "Transcript"
-							: `Transcript: ${subagentPhrase(viewedSlot.type)}`
+							: `Transcript: ${subagentPhrase(viewedSlot.type, viewedSlot.workers)}`
 					}
 					// The scroll container is the only way to older turns on a plain transcript, so a
 					// keyboard user must be able to focus it (axe scrollable-region-focusable).
@@ -1207,7 +1207,7 @@ function ChatWindow({
 								{viewedSlot.lastLine}
 							</>
 						) : (
-							`The ${subagentPhrase(viewedSlot.type)} is still running.`
+							`The ${subagentPhrase(viewedSlot.type, viewedSlot.workers)} is still running.`
 						)}
 					</p>
 				)}

--- a/apps/tuval/src/shell/chat/SubagentList.tsx
+++ b/apps/tuval/src/shell/chat/SubagentList.tsx
@@ -35,6 +35,7 @@ import {
 } from "react";
 import type {SubagentSlot} from "../../ai-agent/ports/index.ts";
 import {prefixArmedAround} from "../window/index.ts";
+import {workerCountLabel} from "./copy.ts";
 import {
 	elapsedLabel,
 	runningSubagents,
@@ -105,6 +106,7 @@ function Line({
 }
 
 function RowFields({row, at}: {readonly row: SubagentRow; readonly at: number}): ReactElement {
+	const workers = workerCountLabel(row.workers);
 	return (
 		<MetaRow as="span" className="tuval-chat-subagent">
 			{/* A row whose worker named itself nothing draws no name field — and no dot for one. */}
@@ -112,6 +114,15 @@ function RowFields({row, at}: {readonly row: SubagentRow; readonly at: number}):
 				<>
 					<span className="tuval-chat-subagent-type" data-field="type">
 						{row.type}
+					</span>
+					<MetaRow.Dot />
+				</>
+			)}
+			{/* The count sits beside the name, because it qualifies whose line and spend follow it. */}
+			{workers === null ? null : (
+				<>
+					<span className="tuval-chat-subagent-workers" data-field="workers">
+						{workers}
 					</span>
 					<MetaRow.Dot />
 				</>

--- a/apps/tuval/src/shell/chat/chat.css
+++ b/apps/tuval/src/shell/chat/chat.css
@@ -132,6 +132,13 @@
 	color: var(--text-primary);
 }
 
+/* Short and fixed, so it never gives way to the line beside it. */
+.tuval-chat-subagent-workers {
+	flex: 0 0 auto;
+	color: var(--text-secondary);
+	white-space: nowrap;
+}
+
 /* The one field that may be any length, so it is the one that truncates. */
 .tuval-chat-subagent-line {
 	flex: 1 1 auto;

--- a/apps/tuval/src/shell/chat/copy.ts
+++ b/apps/tuval/src/shell/chat/copy.ts
@@ -152,6 +152,17 @@ export const subagentViewPlaceholder =
 export const composerStateAnnouncement = (disabled: boolean): string =>
 	disabled ? `The composer is off here. ${subagentViewPlaceholder}` : "The composer is on.";
 
+/**
+ * What a slot's label says about the workers it holds, or `null` when there is nothing to say.
+ *
+ * A fan-out is one slot over many workers (founder ruling 2026-09-09 on #8664), and this count is
+ * the only thing on the row telling a reader that its line, its elapsed and its tokens are all of
+ * them together. One worker draws nothing: a "1 workers" on every ordinary row would be noise on
+ * the common case to serve the rare one.
+ */
+export const workerCountLabel = (workers: number): string | null =>
+	workers <= 1 ? null : `${workers} workers`;
+
 const PLACEHOLDER = /\{(\w+)\}/g;
 
 /**

--- a/apps/tuval/src/shell/chat/copy.unit.test.ts
+++ b/apps/tuval/src/shell/chat/copy.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {tuvalDesignMessages, tuvalDesignTranslate} from "./copy.ts";
+import {tuvalDesignMessages, tuvalDesignTranslate, workerCountLabel} from "./copy.ts";
 
 const entries = Object.entries(tuvalDesignMessages);
 
@@ -33,5 +33,14 @@ describe("the Tuval design catalog", () => {
 			"The agent is using {tool}.",
 		);
 		expect(tuvalDesignTranslate("admin.agent.send")).toBe("send");
+	});
+});
+
+describe("workerCountLabel", () => {
+	// A fan-out stays one slot (founder ruling 2026-09-09 on #8664), and this is what says so.
+	it("counts a fan-out's workers and says nothing about a single one", () => {
+		expect(workerCountLabel(1)).toBeNull();
+		expect(workerCountLabel(2)).toBe("2 workers");
+		expect(workerCountLabel(12)).toBe("12 workers");
 	});
 });

--- a/apps/tuval/src/shell/chat/subagent-list.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-list.unit.test.tsx
@@ -113,7 +113,8 @@ describe("the running-subagent list", () => {
 		expect(list()).not.toBeNull();
 		const rows = rowsOf();
 		expect(rows).toHaveLength(3);
-		// Four fields and only four: a fifth would be the count Q1 answered "no" to.
+		// Four fields and only four: a fifth would be the count of *rows* Q1 answered "no" to. The
+		// worker count below is a different field and only a fan-out draws it.
 		expect(fieldsOf(rows[0] as HTMLElement)).toEqual({
 			type: "reviewer",
 			line: "reading rows.ts",
@@ -126,6 +127,32 @@ describe("the running-subagent list", () => {
 			elapsed: "elapsed 3s",
 			tokens: "4k tokens",
 		});
+		rendered.unmount();
+	});
+
+	// The founder ruled a fan-out stays one slot (2026-09-09 on #8664), so the count is the only
+	// thing on the row saying its line, elapsed and tokens are several workers' together.
+	it("says how many workers a fan-out slot holds, and says nothing on a single one", async () => {
+		vi.useFakeTimers({now: STARTED_AT + 3_000, shouldAdvanceTime: true});
+		const {rendered} = await openWindow(
+			withTranscript([userItem("u1", "go")], {
+				subagents: slots(
+					subagentSlot("a", {type: "explorer", lastLine: "grep", tokens: 4_000, workers: 3}),
+					subagentSlot("b", {type: "builder", lastLine: "writing", tokens: 900, workers: 1}),
+				),
+			}),
+			{subagentList: true},
+		);
+
+		const rows = rowsOf();
+		expect(fieldsOf(rows[0] as HTMLElement)).toEqual({
+			type: "explorer",
+			workers: "3 workers",
+			line: "grep",
+			elapsed: "elapsed 3s",
+			tokens: "4k tokens",
+		});
+		expect(fieldsOf(rows[1] as HTMLElement)).not.toHaveProperty("workers");
 		rendered.unmount();
 	});
 

--- a/apps/tuval/src/shell/chat/subagents.ts
+++ b/apps/tuval/src/shell/chat/subagents.ts
@@ -10,9 +10,15 @@
  * component reads makes of it, and computing it here would freeze it at the render that built the
  * model. `status` and `current` are not a fifth and sixth field but the row's own state: which
  * navigator entry is the one showing, and whether its worker still runs (#8406).
+ *
+ * `workers` is not that refused count either: Q1's "no" was about the transcript rows a slot holds,
+ * and this is how many workers the one spawning call started. A fan-out stays one slot (founder
+ * ruling 2026-09-09 on #8664), so without it the row's line, elapsed and tokens read as one
+ * worker's when they are several workers' together.
  */
 
 import type {ItemId, SubagentSlot, SubagentStatus} from "../../ai-agent/ports/index.ts";
+import {workerCountLabel} from "./copy.ts";
 
 /** How many rows the list shows before the tail collapses into one "more" row (Q3). */
 export const SUBAGENT_ROW_CAP = 5;
@@ -22,8 +28,13 @@ export const SUBAGENT_ROW_CAP = 5;
  * the bare word when no name is known. One phrase for the footer, the live region and the
  * transcript label, so none of them can double the word (#8680).
  */
-export const subagentPhrase = (type: string | null): string =>
-	type === null ? "subagent" : `${type} subagent`;
+export const subagentPhrase = (type: string | null, workers: number = 1): string => {
+	const named = type === null ? "subagent" : `${type} subagent`;
+	const count = workerCountLabel(workers);
+	// Read as an adjective rather than appended, because every call site drops this into a sentence
+	// ("the … is still running", "the …'s transcript") where a trailing count would break it.
+	return count === null ? named : `${workers}-worker ${named}`;
+};
 
 export interface SubagentRow {
 	readonly id: ItemId;
@@ -33,6 +44,8 @@ export interface SubagentRow {
 	/** Epoch milliseconds, so the row's elapsed is the reader's own clock minus this. */
 	readonly startedAt: number;
 	readonly tokens: number;
+	/** How many workers the slot holds. One is the ordinary row and draws no count. */
+	readonly workers: number;
 	/**
 	 * A `finished` row is only ever here because it is the one being viewed (Q9). It draws neither
 	 * elapsed nor tokens — Q2 answered "no" to both once a worker stops.
@@ -54,6 +67,7 @@ const rowOf = (slot: SubagentSlot, current: boolean): SubagentRow => ({
 	lastLine: slot.lastLine,
 	startedAt: slot.startedAt,
 	tokens: slot.tokens,
+	workers: slot.workers,
 	status: slot.status,
 	current,
 });

--- a/apps/tuval/src/shell/chat/subagents.unit.test.ts
+++ b/apps/tuval/src/shell/chat/subagents.unit.test.ts
@@ -5,7 +5,13 @@
 
 import {describe, expect, it} from "vitest";
 import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
-import {elapsedLabel, runningSubagents, SUBAGENT_ROW_CAP, tokenLabel} from "./subagents.ts";
+import {
+	elapsedLabel,
+	runningSubagents,
+	SUBAGENT_ROW_CAP,
+	subagentPhrase,
+	tokenLabel,
+} from "./subagents.ts";
 
 const slots = (...entries: ReadonlyArray<ReturnType<typeof subagentSlot>>) =>
 	Object.fromEntries(entries.map((slot) => [slot.id, slot]));
@@ -27,6 +33,7 @@ describe("runningSubagents", () => {
 					lastLine: "reading rows.ts",
 					startedAt: 1_756_000_000_000,
 					tokens: 2_400,
+					workers: 1,
 					status: "running",
 					current: false,
 				},
@@ -166,5 +173,23 @@ describe("tokenLabel", () => {
 	it("reads millions compactly too", () => {
 		expect(tokenLabel(1_250_000)).toBe("1.3M");
 		expect(tokenLabel(4_000_000)).toBe("4M");
+	});
+});
+
+describe("subagentPhrase", () => {
+	it("names one worker as the slot's own label, or the bare word when it has none", () => {
+		expect(subagentPhrase("explorer")).toBe("explorer subagent");
+		expect(subagentPhrase(null)).toBe("subagent");
+		expect(subagentPhrase("explorer", 1)).toBe("explorer subagent");
+	});
+
+	// Every call site drops this into a sentence — "the … is still running", "the …'s transcript" —
+	// so the count reads as an adjective rather than appended (founder ruling 2026-09-09 on #8664).
+	it("carries a fan-out's worker count where the sentence still parses", () => {
+		expect(subagentPhrase("explorer", 3)).toBe("3-worker explorer subagent");
+		expect(subagentPhrase(null, 3)).toBe("3-worker subagent");
+		expect(`The ${subagentPhrase("explorer", 3)} is still running.`).toBe(
+			"The 3-worker explorer subagent is still running.",
+		);
 	});
 });


### PR DESCRIPTION
A parallel `subagent` call starts several workers, and Tuval already merged them into the one slot
its tool call is keyed on — rows concatenated, tokens summed, `lastLine` off the flattened tail.
Nothing on the row said so, so a fan-out read as one worker's output.

The founder ruled shape A on 2026-09-09
(https://github.com/kamp-us/phoenix/issues/8664#issuecomment-5605843830): the slot stays keyed on
the call, the rows stay merged, and the label carries the worker count. This carries that count.

`SubagentSlot` gains `workers`, a positive integer — one worker is `1` and draws nothing, so only a
fan-out is labelled. The Pi mapper fills it from the runs a spawn resolved (`Math.max(1, runIds)`,
so an unresolved call is still one worker, never zero); the Claude and Codex mappers fill `1`, which
is what each of them can spawn per call. `workerCountLabel` in `shell/chat/copy.ts` is the copy —
`"3 workers"`, `null` at one — and the navigator draws it as its own field beside the name.
`subagentPhrase` takes the count too, as an adjective (`"3-worker explorer subagent"`), because
every one of its call sites drops it into a sentence a trailing count would break.

One thing beyond the label: a checkpoint written before the field would be refused whole by
`isSubagentSlot`, and the desk would come back `gone`. `withSubagentWorkers` in `core/snapshot.ts`
reads an uncounted slot as the one worker it meant — a repair on the `withUsageLedger` model, not a
default, since `subagents` is present and it is the per-slot shape that grew a field. A count that
is present and wrong is still refused.

Look first at `ports/subagent.ts` (the field and what the id docblock now says about the keying) and
at `pi/ai-agent/items.ts`, where all four slot branches fill it.

## Deviations

- **Out-of-scope change** — **Said:** #8664 rules the slot's label. **Did:** also added
  `withSubagentWorkers`, a checkpoint repair in `ai-agent/core/snapshot.ts`. **Why:** the new
  required field makes `isSubagentSlot` refuse every checkpoint holding a slot written before it,
  which lands the restored desk on `gone` — the label change is not shippable without it.
  **Disposition:** stated here, and pinned by two cases in `core/machine.unit.test.ts`.
- **Out-of-scope change** — **Said:** the brief named `SubagentList.tsx` and `subagentPhrase` as the
  surfaces. **Did:** changed both, and also `chat.css` and `ChatWindow.tsx`. **Why:** the new row
  field needs a rule that keeps it from giving way to the line beside it, and `ChatWindow` holds all
  four `subagentPhrase` call sites. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the ruling says the rows stay merged. **Did:** left
  `lastLine` as the flattened tail in sort order rather than newest by time, and `tokens` as the
  sum. **Why:** the ruling took shape A with those two costs named in the issue body, so changing
  them here would be building past it. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the issue's second criterion asks whether `readChildTranscript`'s
  own within-run file merge follows the same shape. **Did:** left that layer untouched and recorded
  in the `joinChildTranscripts` docblock that the ruling leaves both merges standing. **Why:** the
  ruling's words are "rows merged as today", which is what both layers already do.
  **Disposition:** stated here.

Fixes #8664
