### PR TITLE
chore: The agent composer still exposes a variant prop after compact became its one shape

### DIFF
--- a/.decisions/0369-agent-composer-has-one-chrome.md
+++ b/.decisions/0369-agent-composer-has-one-chrome.md
@@ -1,0 +1,50 @@
+---
+id: 0369
+title: The agent composer has one chrome
+status: accepted
+date: 2026-09-09
+tags: [design-system, frontend, agent-chat]
+---
+
+# 0369 — The agent composer has one chrome
+
+**What this decides:** `AgentChatInput` renders the same chrome for every host. There is no
+`variant` prop, no second documented shape, and no branch a part has to answer for twice.
+
+## Context
+
+The composer carried `variant: "harness" | "focused"`. It was not a size prop — #8669 made the
+compact shape unconditional under both arms — it picked which chrome the composer wore. Six files
+branched on it: the root class and the widget above the card (`Frame`), the connection status row
+(`Surface`), the attach button and the overflow menu (`Toolbar`), flat-vs-disclosure activity
+(`Inspector`), where project trust and effort live (`Pickers`), and the default send rule
+(`deliveryRuleForVariant`). The stylesheet carried four `.kp-agent-chat--focused` blocks on top.
+
+At `main` both shipping hosts passed `focused` — Tuval's chat window and its session transcript.
+The `harness` arm's only homes were the atölye exhibit's knob and the design package's own tests;
+apps/web has no harness surface. So the branch cost review attention on every change to the
+composer and bought nothing a user could see
+([#8712](https://github.com/kamp-us/phoenix/issues/8712)).
+
+## Decision
+
+The composer has one chrome, and it is the one both hosts already ran on.
+
+- `variant` is gone from `AgentChatInput` and from `Root`'s published state.
+- The connection status row and the widget-above-the-card are **deleted**, not rehomed. Tuval
+  carries its own status bar; nothing else asked for them. `HarnessWidget` itself survives — the
+  inspector's disclosure still paints it.
+- The `.kp-agent-chat--focused` rules are now the unconditional ones.
+- The atölye exhibits lose their variant knob; both keep the prompt and disabled knobs.
+- `deliveryRule` stays an explicit prop, defaulting to `queue-while-working` — the rule the
+  surviving chrome always implied, so no host's send behaviour moves.
+
+## Consequences
+
+Six files stop branching and the next control added to the composer has one shape to answer for.
+A future apps/web agent surface that wants a status row owns that row itself, above the composer,
+rather than asking the design system to carry a second chrome for it.
+
+The i18n keys the deleted row read (`admin.agent.status.*`, `admin.agent.scope`) are still declared
+in every catalog; retiring them crosses `apps/web`'s catalogs and Tuval's copy map and is tracked
+separately.

--- a/.patterns/agent-chat-compound-parts.md
+++ b/.patterns/agent-chat-compound-parts.md
@@ -8,8 +8,8 @@ so the two can't drift.
 
 ```tsx
 <AgentChatInput.Root {...props}>
-  <AgentChatInput.Frame>                 {/* the labelled section + the harness widget */}
-    <AgentChatInput.Surface>             {/* the card + the harness status row */}
+  <AgentChatInput.Frame>                 {/* the labelled section */}
+    <AgentChatInput.Surface>             {/* the card */}
       <AgentChatInput.Form>              {/* the form; it wires submit off the Root */}
         <AgentChatInput.Field />         {/* attachments, textarea, completion listbox */}
         <AgentChatInput.Toolbar />       {/* Attach + Settings + Overflow, then PrimaryActions */}
@@ -24,8 +24,13 @@ so the two can't drift.
 
 ## The rules a host has to know
 
+- **The composer has one chrome.** There is no `variant` prop and no second shape to pick between:
+  every host gets the same card, the same toolbar and the same pickers (ADR
+  [0369](../.decisions/0369-agent-composer-has-one-chrome.md)). What a host still names is
+  `deliveryRule` — how a send goes out, `queue-while-working` unless it says otherwise.
 - **Every part except `.Control` reads the Root context, and throws outside one**
-  (`packages/design/src/agent-chat/Root.test.tsx`). That is also why the host itself cannot reach
+  (`packages/design/src/agent-chat/Root.test.tsx`). `.Frame` and `.Surface` paint no state of their
+  own and read it only to hold that guard. That is also why the host itself cannot reach
   the state: a host renders `Root`, so it is the parent of the provider, not a child of it. Anything
   needing `submit`, `addImage` or the draft is a part — `.Form` and `.Attach` exist for exactly that
   reason.
@@ -45,15 +50,15 @@ Both shapes are on the atölye — `agent-chat-input` takes the component whole,
 (`apps/web/src/lab/atolye/exhibits/AgentChatInput.exhibit.tsx`).
 
 The parity check lives in `packages/design/src/AgentChatInput.test.tsx`: the hand-assembled tree
-must render the markup the plain export renders, on both variants. What it compares is the whole
-`Frame` subtree *including the section's own attributes* — the `kp-agent-chat--{variant}` class and
-the `aria-label` — plus what `ExtensionDialog` paints, which Manti portals to `document.body` and so
-lands beside the render container rather than inside it. Before #8711 the comparison read the
+must render the markup the plain export renders. What it compares is the whole `Frame` subtree
+*including the section's own attributes* — the `kp-agent-chat` class and the `aria-label` — plus
+what `ExtensionDialog` paints, which Manti portals to `document.body` and so lands beside the render
+container rather than inside it. Before #8711 the comparison read the
 `[data-testid="agent-chat-input"]` Card's `innerHTML`, which left `Frame`, `Inspector` and
 `ExtensionDialog` outside it entirely.
 
 Two of those three render nothing at rest, so the test drives them: it pushes a
-`tool_execution_start` event for `Inspector` to list (opening the disclosure on `focused`) and an
-`extension_ui_request` for `ExtensionDialog` to raise, then asserts each part's markup is in the
-compared string. Adding a part that renders only in some state means driving that state here too —
+`tool_execution_start` event for `Inspector` to list, opens its disclosure, and raises an
+`extension_ui_request` for `ExtensionDialog`, then asserts each part's markup is in the compared
+string. Adding a part that renders only in some state means driving that state here too —
 a part that is `null` on both sides compares equal and is not covered.

--- a/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
+++ b/apps/tuval/src/ai-agent/window/SessionTranscript.tsx
@@ -181,7 +181,7 @@ export function SessionTranscriptView({
 			{body}
 			{sendable ? (
 				<DesignTranslationProvider translate={tuvalDesignTranslate}>
-					<AgentChatInput variant="focused" bridge={composer.bridge} />
+					<AgentChatInput bridge={composer.bridge} />
 				</DesignTranslationProvider>
 			) : null}
 		</section>

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -1239,7 +1239,6 @@ function ChatWindow({
 				/>
 				<AgentChatInput.Root
 					ref={composerRef}
-					variant="focused"
 					bridge={composer.bridge}
 					// Founder ruling on #8466: while the view slot shows a subagent the composer is
 					// disabled, not re-worded. A prompt typed here would land in the transcript the

--- a/apps/tuval/src/shell/chat/chat-held-selection.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-held-selection.unit.test.tsx
@@ -95,7 +95,7 @@ it("names the held pick on the button when the reconnect left no catalog behind 
 							render(
 								(
 									<DesignTranslationProvider translate={tuvalDesignTranslate}>
-										<AgentChatInput bridge={composer.bridge} variant="focused" />
+										<AgentChatInput bridge={composer.bridge} />
 									</DesignTranslationProvider>
 								) as ReactElement,
 							);

--- a/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-thinking-offer.unit.test.tsx
@@ -6,7 +6,7 @@
  * The composer used to read both off one fact — an empty row list — so Pi's faux backend, which
  * offers no levels at all, sat on "loading" for the whole session while answering turns. These
  * cases run the real seam end to end: `composerBridge` decides whether the offer is resolved and
- * `AgentChatInput` renders it, in both variants, so neither half can be right on its own.
+ * `AgentChatInput` renders it, so neither half can be right on its own.
  */
 
 import {AgentChatInput, DesignTranslationProvider} from "@kampus/design";
@@ -28,13 +28,7 @@ const emptyOffer: ThinkingState = {current: null, available: []};
 const offered: ThinkingState = {current: null, available: ["low", "medium", "high"]};
 const picked: ThinkingState = {current: "medium", available: ["low", "medium", "high"]};
 
-type Variant = "focused" | "harness";
-
-const mount = (
-	phase: Phase,
-	variant: Variant,
-	thinking: ThinkingState = noThinking,
-): ComposerBridge => {
+const mount = (phase: Phase, thinking: ThinkingState = noThinking): ComposerBridge => {
 	const composer = composerBridge({
 		initialPhase: phase,
 		initialModels: noModels,
@@ -48,110 +42,100 @@ const mount = (
 	render(
 		(
 			<DesignTranslationProvider translate={tuvalDesignTranslate}>
-				<AgentChatInput bridge={composer.bridge} variant={variant} />
+				<AgentChatInput bridge={composer.bridge} />
 			</DesignTranslationProvider>
 		) as ReactElement,
 	);
 	return composer;
 };
 
-/**
- * The control's own reading. The focused variant names itself `<label>: <state>` on a button; the
- * harness variant is a Manti `Select`, whose unselected reading is its placeholder — so this reads
- * the rendered text rather than the accessible name for that one.
- */
-const control = async (variant: Variant): Promise<HTMLElement> =>
-	variant === "focused"
-		? await screen.findByRole("button", {name: /^thinking effort: /})
-		: await screen.findByRole("combobox", {name: "Agent thinking effort"});
+/** The control's own reading: it names itself `<label>: <state>` on a button. */
+const control = async (): Promise<HTMLElement> =>
+	await screen.findByRole("button", {name: /^thinking effort: /});
 
-const reading = async (variant: Variant): Promise<string> =>
-	variant === "focused"
-		? ((await control(variant)).getAttribute("aria-label") ?? "")
-		: ((await control(variant)).textContent ?? "");
+const reading = async (): Promise<string> => (await control()).getAttribute("aria-label") ?? "";
 
-describe.each(["focused", "harness"] as const)("the %s thinking control", (variant) => {
+describe("the thinking control", () => {
 	it("says loading only while the offer is unresolved", async () => {
-		const composer = mount("starting", variant);
-		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
+		const composer = mount("starting");
+		await waitFor(async () => expect(await reading()).toContain("loading"));
 
 		// The phase carries the answer because every layer owes its catalogs ahead of the `ready`
 		// that closes its open — `.patterns/agent-layer-phase-contract.md`, "The open's `ready`
 		// ships with its catalogs" — so crossing it resolves the question the control waited on.
 		await act(async () => composer.setPhase("ready"));
-		await waitFor(async () => expect(await reading(variant)).not.toContain("loading"));
+		await waitFor(async () => expect(await reading()).not.toContain("loading"));
 	});
 
 	it("stays on loading across a Claude open's catalog round-trips (#8425)", async () => {
 		// `ClaudeAiAgent.open` reads four catalogs off the subprocess before it closes the open, and
 		// each is a real IPC round-trip, so its events reach the composer over several ticks. The
 		// order that keeps this honest is the layer's own: every catalog first, `ready` last.
-		const composer = mount("starting", variant);
-		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
+		const composer = mount("starting");
+		await waitFor(async () => expect(await reading()).toContain("loading"));
 
 		// The `thinking` emit — a model offering no levels, which is what a Claude row without an
 		// effort axis answers. The offer is now known and still unresolved to the control, because
 		// the open has not closed.
 		await act(async () => composer.setThinking(emptyOffer));
-		await waitFor(async () => expect(await reading(variant)).toContain("loading"));
-		expect(await reading(variant)).not.toContain("none offered");
+		await waitFor(async () => expect(await reading()).toContain("loading"));
+		expect(await reading()).not.toContain("none offered");
 
 		// The handshake's `ready`, a tick later. Only here does the empty offer become an answer.
 		await act(async () => composer.setPhase("ready"));
-		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
+		await waitFor(async () => expect(await reading()).toContain("none offered"));
 	});
 
 	it("reads a resolved empty offer as nothing offered, and refuses to open", async () => {
-		mount("ready", variant, emptyOffer);
-		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
-		expect((await control(variant)).getAttribute("disabled")).not.toBeNull();
+		mount("ready", emptyOffer);
+		await waitFor(async () => expect(await reading()).toContain("none offered"));
+		expect((await control()).getAttribute("disabled")).not.toBeNull();
 	});
 
 	it("keeps resolved-populated-unselected apart from resolved-populated-selected", async () => {
-		const composer = mount("ready", variant, offered);
+		const composer = mount("ready", offered);
 		// No row is checked, so the control says so rather than borrowing the first row's label —
 		// a fallback would report a level the operator never picked as their selection.
-		await waitFor(async () => expect(await reading(variant)).toContain("none selected"));
-		expect(await reading(variant)).not.toContain("low");
+		await waitFor(async () => expect(await reading()).toContain("none selected"));
+		expect(await reading()).not.toContain("low");
 
 		await act(async () => composer.setThinking(picked));
-		await waitFor(async () => expect(await reading(variant)).toContain("medium"));
+		await waitFor(async () => expect(await reading()).toContain("medium"));
 	});
 
 	it("follows the offer both ways as the session changes model", async () => {
-		const composer = mount("ready", variant, emptyOffer);
-		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
+		const composer = mount("ready", emptyOffer);
+		await waitFor(async () => expect(await reading()).toContain("none offered"));
 
 		await act(async () => composer.setThinking(picked));
-		await waitFor(async () => expect(await reading(variant)).toContain("medium"));
+		await waitFor(async () => expect(await reading()).toContain("medium"));
 
 		// Back to a model that offers none: the rows go, and no level the session no longer runs on
 		// is left standing as the current one.
 		await act(async () => composer.setThinking(emptyOffer));
-		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
-		expect(screen.queryByRole(variant === "focused" ? "menuitemradio" : "option")).toBeNull();
+		await waitFor(async () => expect(await reading()).toContain("none offered"));
+		expect(screen.queryByRole("menuitemradio")).toBeNull();
 	});
 
 	it("says nothing offered on a restored session whose backend offers no levels", async () => {
 		// The reported shape: a restored Pi faux desk, past its turns, phase `ready`. Every capture
 		// of it read `loading`, and the session it describes was never going to fill.
-		mount("ready", variant, emptyOffer);
-		await waitFor(async () => expect(await reading(variant)).toContain("none offered"));
-		await waitFor(async () => expect(await reading(variant)).not.toContain("loading"));
+		mount("ready", emptyOffer);
+		await waitFor(async () => expect(await reading()).toContain("none offered"));
+		await waitFor(async () => expect(await reading()).not.toContain("loading"));
 	});
 });
 
 /**
  * The other half of the same fact, on the axis #8542's founder ruling puts beside the model one: a
- * level held with no live catalog behind it. The focused variant is Tuval's own, and the only one
- * that can name a selection its offer carries no row for.
+ * level held with no live catalog behind it.
  */
 it("names a held level beside the empty offer rather than instead of it", async () => {
-	const composer = mount("ready", "focused", picked);
-	await waitFor(async () => expect(await reading("focused")).toContain("medium"));
+	const composer = mount("ready", picked);
+	await waitFor(async () => expect(await reading()).toContain("medium"));
 
 	// The session goes and its levels go with it. The pick is the operator's, so it stays named.
 	await act(async () => composer.setThinking({current: "medium", available: []}));
-	await waitFor(async () => expect(await reading("focused")).toContain("none offered"));
-	expect(await reading("focused")).toContain("medium");
+	await waitFor(async () => expect(await reading()).toContain("none offered"));
+	expect(await reading()).toContain("medium");
 });

--- a/apps/web/src/components/agent/AgentChatInput.production.test.tsx
+++ b/apps/web/src/components/agent/AgentChatInput.production.test.tsx
@@ -51,12 +51,12 @@ describe("AgentChatInput production bridge", () => {
 		render(<AgentChatInput bridge={agentChatInputBridge} />);
 		const input = await screen.findByLabelText("Pi'ye mesaj yaz");
 
-		expect(await screen.findByText("Pi hazır · GPT-5")).toBeTruthy();
+		expect(await screen.findByRole("button", {name: "model: GPT-5"})).toBeTruthy();
 		fireEvent.change(input, {target: {value: "/rev"}});
 		expect(await screen.findByRole("option", {name: /\/skill:review/i})).toBeTruthy();
 
 		fireEvent.change(input, {target: {value: "Merhaba Pi"}});
-		fireEvent.click(screen.getByRole("button", {name: /gönder/i}));
+		fireEvent.click(screen.getByRole("button", {name: /^gönder$/i}));
 
 		await waitFor(() => {
 			expect(fetch).toHaveBeenCalledWith(

--- a/apps/web/src/lab/atolye/exhibits/AgentChatInput.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/AgentChatInput.exhibit.tsx
@@ -11,15 +11,6 @@ export const agentChatInputExhibit = defineExhibit<React.ComponentProps<typeof A
 	component: AgentChatInput,
 	fixedProps: {bridge: agentChatInputBridge, mockWhenUnavailable: true},
 	knobs: {
-		variant: {
-			kind: "enum",
-			label: "Varyant",
-			default: "focused",
-			options: [
-				{value: "focused", label: "Odaklı"},
-				{value: "harness", label: "Harness"},
-			],
-		},
 		initialValue: {
 			kind: "string",
 			label: "Başlangıç istemi",
@@ -36,11 +27,9 @@ export const agentChatInputExhibit = defineExhibit<React.ComponentProps<typeof A
  * does with its mode picker.
  */
 function AgentChatInputParts({
-	variant,
 	initialValue,
 	disabled,
 }: {
-	readonly variant?: "harness" | "focused";
 	readonly initialValue?: string;
 	readonly disabled?: boolean;
 }) {
@@ -48,7 +37,6 @@ function AgentChatInputParts({
 		<AgentChatInput.Root
 			bridge={agentChatInputBridge}
 			mockWhenUnavailable
-			variant={variant}
 			initialValue={initialValue}
 			disabled={disabled}
 		>
@@ -76,15 +64,6 @@ export const agentChatInputPartsExhibit = defineExhibit<
 		"Aynı besteci, tek parça yerine bileşik parçalarından kurulmuş: Root durumu taşır, her parça onu okur.",
 	component: AgentChatInputParts,
 	knobs: {
-		variant: {
-			kind: "enum",
-			label: "Varyant",
-			default: "focused",
-			options: [
-				{value: "focused", label: "Odaklı"},
-				{value: "harness", label: "Harness"},
-			],
-		},
 		initialValue: {
 			kind: "string",
 			label: "Başlangıç istemi",

--- a/packages/design/src/AgentChatInput.css
+++ b/packages/design/src/AgentChatInput.css
@@ -22,15 +22,11 @@
 .kp-agent-chat__composer {
 	display: flex;
 	flex-direction: column;
-	gap: var(--s-3);
-	transition: border-color var(--motion-fast) var(--ease-standard);
+	gap: var(--s-2);
+	border: 1px solid var(--border);
+	box-shadow: var(--shadow-raised);
 }
 
-.kp-agent-chat__composer:has(textarea:focus-visible) {
-	border-color: var(--accent);
-}
-
-.kp-agent-chat__status-row,
 .kp-agent-chat__actions,
 .kp-agent-chat__settings,
 .kp-agent-chat__send-controls,
@@ -40,28 +36,9 @@
 	align-items: center;
 }
 
-.kp-agent-chat__status-row,
 .kp-agent-chat__actions {
 	justify-content: space-between;
 	gap: var(--s-2);
-}
-
-.kp-agent-chat__status,
-.kp-agent-chat__scope {
-	margin: 0;
-}
-
-.kp-agent-chat__status,
-.kp-agent-chat__scope {
-	font: var(--t-meta);
-}
-
-.kp-agent-chat__status {
-	color: var(--text-secondary);
-}
-
-.kp-agent-chat__scope {
-	color: var(--text-muted);
 }
 
 .kp-agent-chat__form {
@@ -111,11 +88,14 @@
 	display: none;
 }
 
-.kp-agent-chat__textarea [data-part="control"] {
+.kp-agent-chat__textarea [data-part="control"],
+.kp-agent-chat__textarea:has(:focus-visible) [data-part="control"] {
 	--manti-field-padding-x: 0;
 	background: transparent;
 	border: 0;
 	border-radius: 0;
+	outline: none;
+	outline-offset: 0;
 }
 
 /*
@@ -165,7 +145,6 @@
 	border-top: 1px solid var(--border-faint);
 }
 
-.kp-agent-chat__settings,
 .kp-agent-chat__primary-controls,
 .kp-agent-chat__send-controls {
 	gap: var(--s-1);
@@ -179,54 +158,12 @@
 }
 
 .kp-agent-chat__settings {
+	gap: var(--s-1);
+	flex-wrap: nowrap;
 	min-width: 0;
 	margin: 0;
 	padding: 0;
 	border: 0;
-}
-
-.kp-agent-chat__setting {
-	display: flex;
-	align-items: center;
-	gap: var(--s-1);
-	min-width: 0;
-	color: var(--text-secondary);
-}
-
-.kp-agent-chat__setting > .kp-icon {
-	flex: none;
-}
-
-.kp-agent-chat__setting-select[data-scope="select"][data-part="root"] {
-	min-width: 0;
-}
-
-.kp-agent-chat__setting-select [data-part="label"] {
-	display: none;
-}
-
-.kp-agent-chat__setting-select [data-part="trigger"] {
-	min-height: var(--tap-min);
-	max-width: calc(var(--s-8) * 4);
-	padding-inline: var(--s-1);
-	border-color: var(--border-faint);
-	border-radius: var(--r-sm);
-	background: var(--surface-sunken);
-	color: var(--text-secondary);
-}
-
-.kp-agent-chat__setting-select [data-part="trigger"]:hover,
-.kp-agent-chat__setting-select [data-part="trigger"][data-state="open"] {
-	border-color: var(--border);
-	background: var(--surface-raised);
-	color: var(--text-primary);
-}
-
-.kp-agent-chat__setting-select [data-part="value-text"] {
-	overflow: hidden;
-	font: var(--t-meta);
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .kp-agent-chat__icon-button:where([data-scope="button"][data-part="root"]) {
@@ -235,35 +172,11 @@
 	color: var(--text-secondary);
 }
 
-.kp-agent-chat--focused .kp-agent-chat__composer {
-	gap: var(--s-2);
-	border: 1px solid var(--border);
-	box-shadow: var(--shadow-raised);
-}
-
-.kp-agent-chat--focused .kp-agent-chat__composer:has(textarea:focus-visible) {
-	border-color: var(--border);
-	outline: none;
-}
-
-.kp-agent-chat--focused .kp-agent-chat__textarea [data-part="control"],
-.kp-agent-chat--focused .kp-agent-chat__textarea:has(:focus-visible) [data-part="control"] {
-	border: 0;
-	outline: none;
-	outline-offset: 0;
-}
-
-.kp-agent-chat--focused
-	.kp-agent-chat__textarea[data-scope="field"][data-part="root"]:focus-within
-	[data-part="control"] {
+.kp-agent-chat__textarea[data-scope="field"][data-part="root"]:focus-within [data-part="control"] {
 	border-color: transparent;
 	outline: none;
 	outline-offset: 0;
 	box-shadow: none;
-}
-
-.kp-agent-chat--focused .kp-agent-chat__settings {
-	flex-wrap: nowrap;
 }
 
 .kp-agent-chat__resources-button:where([data-scope="button"][data-part="root"]) {
@@ -331,7 +244,6 @@
 }
 
 @media (max-width: 40rem) {
-	.kp-agent-chat__status-row,
 	.kp-agent-chat__actions {
 		align-items: flex-start;
 		flex-direction: column;
@@ -348,9 +260,5 @@
 
 	.kp-agent-chat__settings {
 		width: 100%;
-	}
-
-	.kp-agent-chat__setting {
-		flex: 1 1 auto;
 	}
 }

--- a/packages/design/src/AgentChatInput.test.tsx
+++ b/packages/design/src/AgentChatInput.test.tsx
@@ -216,7 +216,7 @@ function collidingCatalogBridge(): {
  * blanked.
  */
 function ComposedComposer() {
-	const {submit, variant, disabled, addImage} = useAgentChatInput();
+	const {submit, disabled, addImage} = useAgentChatInput();
 	const t = defaultDesignTranslate;
 	const imageInputRef = useRef<HTMLInputElement>(null);
 	return (
@@ -232,31 +232,27 @@ function ComposedComposer() {
 					<AgentChatInput.Field />
 					<div className="kp-agent-chat__actions">
 						<div className="kp-agent-chat__primary-controls">
-							{variant === "focused" ? (
-								<>
-									<Input
-										ref={imageInputRef}
-										className="kp-visually-hidden"
-										label={t("admin.agent.image.add")}
-										type="file"
-										accept="image/*"
-										tabIndex={-1}
-										onChange={(event) => {
-											void addImage(event.currentTarget.files?.[0]);
-											event.currentTarget.value = "";
-										}}
-									/>
-									<AgentChatInput.Control
-										icon={Paperclip}
-										className="kp-agent-chat__icon-button"
-										aria-label={t("admin.agent.image.add")}
-										onClick={() => imageInputRef.current?.click()}
-										disabled={disabled}
-									/>
-								</>
-							) : null}
+							<Input
+								ref={imageInputRef}
+								className="kp-visually-hidden"
+								label={t("admin.agent.image.add")}
+								type="file"
+								accept="image/*"
+								tabIndex={-1}
+								onChange={(event) => {
+									void addImage(event.currentTarget.files?.[0]);
+									event.currentTarget.value = "";
+								}}
+							/>
+							<AgentChatInput.Control
+								icon={Paperclip}
+								className="kp-agent-chat__icon-button"
+								aria-label={t("admin.agent.image.add")}
+								onClick={() => imageInputRef.current?.click()}
+								disabled={disabled}
+							/>
 							<AgentChatInput.Settings />
-							{variant === "focused" ? <AgentChatInput.Overflow /> : null}
+							<AgentChatInput.Overflow />
 						</div>
 						<AgentChatInput.PrimaryActions />
 					</div>
@@ -284,14 +280,11 @@ async function settleComposer(): Promise<void> {
 
 /**
  * Drives the three parts that render nothing at rest: `Inspector` has no activity to list until
- * the harness pushes one and, on `focused`, stays folded until the disclosure is opened;
- * `ExtensionDialog` is `null` until a request is outstanding. Without this the parity comparison
- * reads empty against empty and proves nothing about them (#8711).
+ * the harness pushes one and stays folded until the disclosure is opened; `ExtensionDialog` is
+ * `null` until a request is outstanding. Without this the parity comparison reads empty against
+ * empty and proves nothing about them (#8711).
  */
-async function driveComposerParts(
-	variant: "harness" | "focused",
-	push: (event: PiEvent) => void,
-): Promise<void> {
+async function driveComposerParts(push: (event: PiEvent) => void): Promise<void> {
 	act(() => {
 		push({type: "tool_execution_start", toolName: "Read"});
 		push({
@@ -303,16 +296,14 @@ async function driveComposerParts(
 			placeholder: "umut/…",
 		});
 	});
-	if (variant === "focused") {
-		fireEvent.click(await screen.findByRole("button", {name: /Pi denetçisi/}));
-	}
+	fireEvent.click(await screen.findByRole("button", {name: /Pi denetçisi/}));
 	await screen.findByText("Pi Read kullanıyor.");
 	await screen.findByRole("dialog");
 }
 
 /**
- * Everything the composer paints: the `Frame` section with its own attributes — the variant class
- * and the label the whole composer is named off — and the overlay `ExtensionDialog` raises, which
+ * Everything the composer paints: the `Frame` section with its own attributes — its class and the
+ * label the whole composer is named off — and the overlay `ExtensionDialog` raises, which
  * Manti portals to `document.body` and so lands beside the render container rather than inside it.
  * Two renders never draw the same generated ids — React's `useId` and Manti's own `data-uid` both
  * count up per render — so every id-carrying attribute is blanked.
@@ -332,14 +323,14 @@ function composerMarkup(container: HTMLElement): string {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("AgentChatInput", () => {
-	describe.each(["focused", "harness"] as const)("%s effort picker", (variant) => {
+	describe("the effort picker", () => {
 		const translate: DesignTranslate = (key, params) =>
 			key === "admin.agent.picker.none"
 				? "No effort selected"
 				: defaultDesignTranslate(key, params);
-		const role = variant === "focused" ? "button" : "combobox";
-		const itemRole = variant === "focused" ? "menuitemradio" : "option";
-		const selectedAttribute = variant === "focused" ? "aria-checked" : "aria-selected";
+		const role = "button";
+		const itemRole = "menuitemradio";
+		const selectedAttribute = "aria-checked";
 
 		it.each([
 			{levels: ["low", "medium"] as const},
@@ -361,7 +352,7 @@ describe("AgentChatInput", () => {
 			};
 			render(
 				<DesignTranslationProvider translate={translate}>
-					<AgentChatInput bridge={bridge} variant={variant} />
+					<AgentChatInput bridge={bridge} />
 				</DesignTranslationProvider>,
 			);
 
@@ -386,7 +377,7 @@ describe("AgentChatInput", () => {
 
 		it("keeps a supplied level selected", async () => {
 			const {bridge} = installHarnessFetch();
-			render(<AgentChatInput bridge={bridge} variant={variant} />);
+			render(<AgentChatInput bridge={bridge} />);
 
 			const picker = await screen.findByRole(role, {name: /düşünme eforu/});
 			await waitFor(() => expect(picker.textContent).toBe("orta"));
@@ -452,36 +443,12 @@ describe("AgentChatInput", () => {
 		expect((input as HTMLTextAreaElement).value).toBe("@apps/web/src/App.tsx ");
 	});
 
-	it("sends the selected delivery mode through the Pi bridge", async () => {
-		const {fetch, bridge} = installHarnessFetch();
-		render(<AgentChatInput bridge={bridge} />);
-		const input = await screen.findByLabelText("Pi'ye mesaj yaz");
-
-		fireEvent.change(input, {target: {value: "Review the component."}});
-		fireEvent.click(screen.getByRole("combobox", {name: "Pi teslim modu"}));
-		fireEvent.click(await screen.findByRole("option", {name: "sonraya al"}));
-		await waitFor(() => {
-			expect(screen.getByRole("combobox", {name: "Pi teslim modu"}).textContent).toBe("sonraya al");
-		});
-		fireEvent.click(screen.getByRole("button", {name: /gönder/i}));
-
-		await waitFor(() => {
-			expect(fetch).toHaveBeenCalledWith(
-				"/__pi/prompt",
-				expect.objectContaining({
-					method: "POST",
-					body: JSON.stringify({type: "follow_up", message: "Review the component."}),
-				}),
-			);
-		});
-	});
-
-	it("changes Pi model, effort, and project trust from the composer", async () => {
+	it("changes the Pi model from the composer", async () => {
 		const {fetch, bridge} = installHarnessFetch();
 		render(<AgentChatInput bridge={bridge} />);
 
-		fireEvent.click(await screen.findByRole("combobox", {name: "Pi modeli"}));
-		fireEvent.click(await screen.findByRole("option", {name: "GPT-5.6"}));
+		fireEvent.click(await screen.findByRole("button", {name: "model: GPT-5"}));
+		fireEvent.click(await screen.findByRole("menuitemradio", {name: "GPT-5.6"}));
 		await waitFor(() => {
 			expect(fetch).toHaveBeenCalledWith(
 				"/__pi/model",
@@ -491,32 +458,11 @@ describe("AgentChatInput", () => {
 				}),
 			);
 		});
-
-		fireEvent.click(screen.getByRole("combobox", {name: "Pi düşünme eforu"}));
-		fireEvent.click(await screen.findByRole("option", {name: "yüksek"}));
-		await waitFor(() => {
-			expect(fetch).toHaveBeenCalledWith(
-				"/__pi/thinking-level",
-				expect.objectContaining({method: "POST", body: JSON.stringify({level: "high"})}),
-			);
-		});
-
-		fireEvent.click(screen.getByRole("combobox", {name: /Pi proje izni/i}));
-		fireEvent.click(await screen.findByRole("option", {name: "yoksay"}));
-		await waitFor(() => {
-			expect(fetch).toHaveBeenCalledWith(
-				"/__pi/project-trust",
-				expect.objectContaining({
-					method: "POST",
-					body: JSON.stringify({projectTrust: "no-approve"}),
-				}),
-			);
-		});
 	});
 
 	it("takes a catalog pushed after mount and enables the picker on it", async () => {
 		const {bridge, push} = lateCatalogBridge();
-		render(<AgentChatInput bridge={bridge} variant="focused" />);
+		render(<AgentChatInput bridge={bridge} />);
 
 		const before = await screen.findByRole("button", {name: /model/i});
 		expect(before.getAttribute("disabled")).not.toBeNull();
@@ -557,7 +503,7 @@ describe("AgentChatInput", () => {
 
 	it("omits off effort returned by the bridge on load and model refresh", async () => {
 		const {fetch, bridge} = installHarnessFetch();
-		render(<AgentChatInput bridge={bridge} variant="focused" />);
+		render(<AgentChatInput bridge={bridge} />);
 
 		fireEvent.click(await screen.findByRole("button", {name: "düşünme eforu: orta"}));
 		expect(await screen.findByRole("menuitemradio", {name: "minimal"})).toBeTruthy();
@@ -578,9 +524,9 @@ describe("AgentChatInput", () => {
 		expect(screen.queryByRole("menuitemradio", {name: "kapalı"})).toBeNull();
 	});
 
-	it("keeps secondary harness controls behind disclosure in the focused variant", async () => {
+	it("keeps the composer's secondary controls behind the overflow menu", async () => {
 		const {fetch, bridge} = installHarnessFetch();
-		render(<AgentChatInput bridge={bridge} variant="focused" />);
+		render(<AgentChatInput bridge={bridge} />);
 
 		await screen.findByRole("button", {name: "model: GPT-5"});
 		expect(screen.queryByText("yalnızca yerel atölye")).toBeNull();
@@ -604,7 +550,7 @@ describe("AgentChatInput", () => {
 
 	it("adds an image pasted from clipboard items", async () => {
 		const {bridge} = installHarnessFetch();
-		render(<AgentChatInput bridge={bridge} variant="focused" />);
+		render(<AgentChatInput bridge={bridge} />);
 		const input = await screen.findByLabelText("Pi'ye mesaj yaz");
 		const image = new File([new Uint8Array([137, 80, 78, 71])], "ekran.png", {
 			type: "image/png",
@@ -625,7 +571,7 @@ describe("AgentChatInput", () => {
 			"fetch",
 			vi.fn(async () => response({})),
 		);
-		render(<AgentChatInput variant="focused" mockWhenUnavailable />);
+		render(<AgentChatInput mockWhenUnavailable />);
 
 		expect(await screen.findByRole("button", {name: "model: GPT-5.5"})).toBeTruthy();
 		fireEvent.click(screen.getByRole("button", {name: "düşünme eforu: orta"}));
@@ -670,24 +616,9 @@ describe("AgentChatInput", () => {
 		expect(drafts).toEqual([]);
 	});
 
-	it("tells two providers' same-named models apart in the select list", async () => {
-		const {bridge, picks} = collidingCatalogBridge();
-		render(<AgentChatInput bridge={bridge} />);
-
-		fireEvent.click(await screen.findByRole("combobox", {name: "Pi modeli"}));
-		const rows = await screen.findAllByRole("option");
-		expect(rows.map((row) => row.textContent)).toEqual([
-			"GPT-5.6 Luna (openai)",
-			"GPT-5.6 Luna (openai-codex)",
-		]);
-
-		fireEvent.click(screen.getByRole("option", {name: "GPT-5.6 Luna (openai-codex)"}));
-		await waitFor(() => expect(picks).toEqual([{provider: "openai-codex", id: "gpt-5.6-luna"}]));
-	});
-
 	it("renders the provider as a row's secondary text in the focused picker", async () => {
 		const {bridge, picks} = collidingCatalogBridge();
-		render(<AgentChatInput bridge={bridge} variant="focused" />);
+		render(<AgentChatInput bridge={bridge} />);
 
 		fireEvent.click(await screen.findByRole("button", {name: "model: GPT-5.6 Luna (openai)"}));
 		const rows = await screen.findAllByRole("menuitemradio");
@@ -703,44 +634,38 @@ describe("AgentChatInput", () => {
 		await waitFor(() => expect(picks).toEqual([{provider: "openai-codex", id: "gpt-5.6-luna"}]));
 	});
 
-	it("names the running model with its provider once two providers are offered", async () => {
-		const {bridge} = collidingCatalogBridge();
-		render(<AgentChatInput bridge={bridge} />);
-
-		expect(await screen.findByText(/Pi hazır · GPT-5\.6 Luna \(openai\)/)).toBeTruthy();
-	});
-
 	it("leaves a single-provider catalog's rows bare", async () => {
 		const {bridge} = installHarnessFetch();
 		render(<AgentChatInput bridge={bridge} />);
 
-		fireEvent.click(await screen.findByRole("combobox", {name: "Pi modeli"}));
-		expect((await screen.findAllByRole("option")).map((row) => row.textContent)).toEqual([
-			"GPT-5",
-			"GPT-5.6",
+		fireEvent.click(await screen.findByRole("button", {name: "model: GPT-5"}));
+		const rows = await screen.findAllByRole("menuitemradio");
+		expect(rows.map((row) => row.querySelector(".kp-agent-chat__picker-note"))).toEqual([
+			null,
+			null,
 		]);
 	});
 
-	describe.each(["harness", "focused"] as const)("the %s composer's compound parts", (variant) => {
+	describe("the composer's compound parts", () => {
 		it("assemble into the tree the plain export renders", async () => {
 			const {bridge, push} = installHarnessFetch();
-			const plain = render(<AgentChatInput bridge={bridge} variant={variant} />);
+			const plain = render(<AgentChatInput bridge={bridge} />);
 			await settleComposer();
-			await driveComposerParts(variant, push);
+			await driveComposerParts(push);
 			const expected = composerMarkup(plain.container);
-			expect(expected).toContain(`class="kp-agent-chat kp-agent-chat--${variant}"`);
+			expect(expected).toContain('class="kp-agent-chat"');
 			expect(expected).toContain('aria-label="Agent chat input"');
 			expect(expected).toContain("Pi Read kullanıyor.");
 			expect(expected).toContain("Hangi dala geçelim?");
 			plain.unmount();
 
 			const composed = render(
-				<AgentChatInput.Root bridge={bridge} variant={variant}>
+				<AgentChatInput.Root bridge={bridge}>
 					<ComposedComposer />
 				</AgentChatInput.Root>,
 			);
 			await settleComposer();
-			await driveComposerParts(variant, push);
+			await driveComposerParts(push);
 			await waitFor(() => expect(composerMarkup(composed.container)).toBe(expected));
 		});
 	});
@@ -751,7 +676,7 @@ describe("AgentChatInput", () => {
 
 		const slotted = await screen.findByRole("button", {name: "Ajan kipi"});
 		expect(slotted.closest("fieldset")?.className).toContain("kp-agent-chat__settings");
-		expect(screen.getByRole("combobox", {name: "Pi modeli"})).toBeTruthy();
+		expect(screen.getByRole("button", {name: "model: GPT-5"})).toBeTruthy();
 	});
 
 	it("lets Settings children stand in for the controls it owns, slot untouched", async () => {
@@ -766,7 +691,7 @@ describe("AgentChatInput", () => {
 
 		const own = await screen.findByRole("button", {name: "Yalnız bu"});
 		expect(own.closest("fieldset")?.className).toContain("kp-agent-chat__settings");
-		expect(screen.queryByRole("combobox", {name: "Pi modeli"})).toBeNull();
+		expect(screen.queryByRole("button", {name: /^model:/})).toBeNull();
 		expect(screen.queryByRole("button", {name: "Ajan kipi"})).toBeNull();
 	});
 
@@ -816,13 +741,13 @@ describe("the compact composer", () => {
 	 * Pillar 4's floor is absolute, and the first cut of #8669 spent it: the field landed at 23px
 	 * because it dropped its floor to zero, and the sheet-wide count below could not see it — a
 	 * control that never names `--tap-min` is invisible to a count of `--tap-min` (#8714). So the
-	 * field is asserted at its own rule, and the count stays as the tripwire for the other five.
+	 * field is asserted at its own rule, and the count stays as the tripwire for the other four.
 	 */
 	it("floors the prompt field at the tap target", () => {
 		expect(fieldRule).toContain("min-height: var(--tap-min)");
 	});
 
 	it("leaves every toolbar control on the tap-target floor", () => {
-		expect(sheet.match(/var\(--tap-min\)/g) ?? []).toHaveLength(6);
+		expect(sheet.match(/var\(--tap-min\)/g) ?? []).toHaveLength(5);
 	});
 });

--- a/packages/design/src/agent-chat/Frame.tsx
+++ b/packages/design/src/agent-chat/Frame.tsx
@@ -1,22 +1,16 @@
 import type {ReactNode} from "react";
 import {useDesignT} from "../i18n";
-import {HarnessWidget} from "./HarnessWidget";
 import {useAgentChatInput} from "./Root";
 
-/**
- * The composer's outermost element: the labelled region everything else sits in, and — on the
- * harness variant — the widget the harness paints above the card.
- */
+/** The composer's outermost element: the labelled region everything else sits in. */
 export function AgentChatFrame({children}: {readonly children: ReactNode}) {
-	const {variant, widget} = useAgentChatInput();
+	// Read for the placement guard alone: this part paints no state of its own, and without the
+	// read it would be the one part that renders happily outside a Root (`Root.test.tsx`).
+	useAgentChatInput();
 	const t = useDesignT();
 
 	return (
-		<section
-			className={`kp-agent-chat kp-agent-chat--${variant}`}
-			aria-label={t("admin.agent.label")}
-		>
-			{variant === "harness" && widget ? <HarnessWidget lines={widget} /> : null}
+		<section className="kp-agent-chat" aria-label={t("admin.agent.label")}>
 			{children}
 		</section>
 	);

--- a/packages/design/src/agent-chat/Inspector.tsx
+++ b/packages/design/src/agent-chat/Inspector.tsx
@@ -7,15 +7,14 @@ import {Icon} from "./Icon";
 import {useAgentChatInput} from "./Root";
 
 /**
- * What the harness is doing under the composer: the focused variant folds it behind a disclosure
- * that counts the activities, the harness variant lays it out flat.
+ * What the harness is doing under the composer, folded behind a disclosure that counts the
+ * activities.
  */
 export function AgentChatInspector() {
-	const {variant, widget, assistantText, activities, inspectorOpen, setInspectorOpen} =
-		useAgentChatInput();
+	const {widget, assistantText, activities, inspectorOpen, setInspectorOpen} = useAgentChatInput();
 	const t = useDesignT();
 
-	return variant === "focused" ? (
+	return (
 		<Collapsible
 			className="kp-agent-chat__inspector"
 			open={inspectorOpen}
@@ -36,7 +35,5 @@ export function AgentChatInspector() {
 				<AgentActivity assistantText={assistantText} activities={activities} />
 			</div>
 		</Collapsible>
-	) : (
-		<AgentActivity assistantText={assistantText} activities={activities} />
 	);
 }

--- a/packages/design/src/agent-chat/Pickers.tsx
+++ b/packages/design/src/agent-chat/Pickers.tsx
@@ -1,9 +1,6 @@
-import {Bot, Brain, ShieldCheck} from "lucide-react";
 import {useMemo} from "react";
 import {useDesignT} from "../i18n";
-import {Select, type SelectItem} from "../Select";
-import {projectTrustKeys, thinkingLevelIcons, thinkingLevelKeys, toItems} from "./catalog";
-import {Icon} from "./Icon";
+import {thinkingLevelIcons, thinkingLevelKeys} from "./catalog";
 import {
 	modelName,
 	modelValue,
@@ -15,46 +12,26 @@ import {useAgentChatInput} from "./Root";
 import {type PickerItem, SettingMenu} from "./SettingMenu";
 
 /**
- * The settings rows the composer owns: model and thinking effort on both variants, project trust
- * on the harness one — where the focused variant keeps trust in the overflow menu instead.
+ * The settings rows the composer owns: model and thinking effort. Project trust has no row here —
+ * it lives in the overflow menu.
  *
  * It is its own part so a host that fills `Settings` with a row set of its own can still place
  * these rows in it, rather than choosing between the composer's controls and its own.
  */
 export function AgentChatPickers() {
 	const {
-		variant,
 		harnessState: state,
 		models,
 		thinkingLevels,
-		projectTrust,
 		settingsDisabled,
 		changeModel,
 		changeThinkingLevel,
-		changeProjectTrust,
 	} = useAgentChatInput();
 	const t = useDesignT();
 
-	// Manti's `SelectItem.label` is `string`, and the select collection stringifies it for typeahead
-	// (`itemToString: (item) => item.label`), so this list carries the provider in the label itself
-	// while the Menu-backed picker below renders it as its own dimmed span. See #8065.
 	// Each list stays `undefined` while its offer is unresolved, so the pickers are handed the same
 	// three-way answer the bridge gave rather than a flattened array (#8425).
-	const modelItems = useMemo<SelectItem[] | undefined>(
-		() =>
-			models?.map((candidate) => ({
-				value: modelValue(candidate),
-				label: providersCollide(models)
-					? `${candidate.name} (${candidate.provider})`
-					: candidate.name,
-			})),
-		[models],
-	);
-	const thinkingItems = useMemo<SelectItem[] | undefined>(
-		() => thinkingLevels?.map((level) => ({value: level, label: t(thinkingLevelKeys[level])})),
-		[thinkingLevels, t],
-	);
-	const focusedModelItems = useMemo<PickerItem[] | undefined>(
+	const modelItems = useMemo<PickerItem[] | undefined>(
 		() =>
 			models?.map((candidate) => ({
 				value: modelValue(candidate),
@@ -63,7 +40,7 @@ export function AgentChatPickers() {
 			})),
 		[models],
 	);
-	const focusedThinkingItems = useMemo<PickerItem[] | undefined>(
+	const thinkingItems = useMemo<PickerItem[] | undefined>(
 		() =>
 			thinkingLevels?.map((level) => ({
 				value: level,
@@ -101,73 +78,24 @@ export function AgentChatPickers() {
 		offeredThinking === 0 ||
 		(offeredThinking === 1 && selectedThinking !== undefined);
 
-	return variant === "focused" ? (
+	return (
 		<>
 			<SettingMenu
 				label={t("admin.agent.setting.model")}
-				items={focusedModelItems}
+				items={modelItems}
 				value={selectedModel}
 				held={heldModel}
 				onValueChange={(value) => void changeModel(value)}
-				disabled={settingsDisabled || (focusedModelItems?.length ?? 0) < 2}
+				disabled={settingsDisabled || (modelItems?.length ?? 0) < 2}
 			/>
 			<SettingMenu
 				label={t("admin.agent.setting.thinking")}
-				items={focusedThinkingItems}
+				items={thinkingItems}
 				value={selectedThinking}
 				held={heldThinking}
 				onValueChange={(value) => void changeThinkingLevel(value)}
 				disabled={thinkingDisabled}
 			/>
-		</>
-	) : (
-		<>
-			<div className="kp-agent-chat__setting">
-				<Icon icon={Bot} size={14} />
-				<Select
-					className="kp-agent-chat__setting-select kp-agent-chat__setting-select--model"
-					label={<span className="kp-visually-hidden">{t("admin.agent.select.model")}</span>}
-					items={modelItems ?? []}
-					value={selectedModel ? [selectedModel] : []}
-					onValueChange={(values) => void changeModel(values[0])}
-					placement="top-start"
-					size="sm"
-					disabled={settingsDisabled || (modelItems?.length ?? 0) < 2}
-				/>
-			</div>
-			<div className="kp-agent-chat__setting">
-				<Icon icon={Brain} size={14} />
-				<Select
-					className="kp-agent-chat__setting-select"
-					label={<span className="kp-visually-hidden">{t("admin.agent.select.thinking")}</span>}
-					items={thinkingItems ?? []}
-					value={selectedThinking ? [selectedThinking] : []}
-					placeholder={t(
-						thinkingItems === undefined
-							? "admin.agent.picker.loading"
-							: thinkingItems.length === 0
-								? "admin.agent.picker.empty"
-								: "admin.agent.picker.none",
-					)}
-					onValueChange={(values) => void changeThinkingLevel(values[0])}
-					placement="top-start"
-					size="sm"
-					disabled={thinkingDisabled}
-				/>
-			</div>
-			<div className="kp-agent-chat__setting">
-				<Icon icon={ShieldCheck} size={14} />
-				<Select
-					className="kp-agent-chat__setting-select"
-					label={<span className="kp-visually-hidden">{t("admin.agent.select.trust")}</span>}
-					items={toItems(projectTrustKeys, t)}
-					value={[projectTrust]}
-					onValueChange={(values) => void changeProjectTrust(values[0])}
-					placement="top-start"
-					size="sm"
-					disabled={settingsDisabled}
-				/>
-			</div>
 		</>
 	);
 }

--- a/packages/design/src/agent-chat/PrimaryActions.tsx
+++ b/packages/design/src/agent-chat/PrimaryActions.tsx
@@ -1,42 +1,24 @@
 import {SendHorizontal, Square} from "lucide-react";
 import {Button} from "../Button";
 import {useDesignT} from "../i18n";
-import {Select} from "../Select";
 import {AgentChatControl} from "./Control";
-import {deliveryModeKeys, toItems} from "./catalog";
 import {requestedDelivery} from "./delivery";
 import {Icon} from "./Icon";
-import {deliveryMode} from "./parse";
 import {useAgentChatInput} from "./Root";
 
 /**
- * How a draft leaves the composer: the delivery picker where it renders inline, the stop
- * affordance while the harness runs, and the send button. The button's copy is resolved through
+ * How a draft leaves the composer: the stop affordance while the harness runs, and the send
+ * button. The button's copy is resolved through
  * the same `requestedDelivery` the send itself uses, so the label cannot name a delivery the
  * payload will not carry (#8691).
  */
 export function AgentChatPrimaryActions() {
-	const {disabled, variant, delivery, deliveryRule, connection, setDelivery, stop} =
-		useAgentChatInput();
+	const {disabled, delivery, deliveryRule, connection, stop} = useAgentChatInput();
 	const t = useDesignT();
 	const requested = requestedDelivery(deliveryRule, connection, delivery);
 
 	return (
 		<div className="kp-agent-chat__send-controls">
-			{variant === "harness" ? (
-				<Select
-					className="kp-agent-chat__delivery"
-					label={<span className="kp-visually-hidden">{t("admin.agent.select.delivery")}</span>}
-					items={toItems(deliveryModeKeys, t)}
-					value={[delivery]}
-					onValueChange={(values) => {
-						const nextDelivery = deliveryMode(values[0]);
-						if (nextDelivery) setDelivery(nextDelivery);
-					}}
-					placement="top-end"
-					size="sm"
-				/>
-			) : null}
 			{connection === "working" ? (
 				<AgentChatControl icon={Square} onClick={() => void stop()}>
 					{" "}

--- a/packages/design/src/agent-chat/Root.test.tsx
+++ b/packages/design/src/agent-chat/Root.test.tsx
@@ -9,8 +9,8 @@ import type {ConnectionState} from "./types";
 type SentPrompt = Parameters<AgentChatInputBridge["sendPiPrompt"]>[0];
 
 function Part() {
-	const {variant, connection} = useAgentChatInput();
-	return <p>{`${variant}/${connection}`}</p>;
+	const {connection} = useAgentChatInput();
+	return <p>{connection}</p>;
 }
 
 /**
@@ -70,16 +70,11 @@ function Composer({picked}: {readonly picked: PiDeliveryMode}) {
 async function send(options: {
 	readonly connection: ConnectionState;
 	readonly picked: PiDeliveryMode;
-	readonly variant?: "harness" | "focused";
 	readonly deliveryRule?: AgentChatDeliveryRule;
 }): Promise<SentPrompt[]> {
 	const {bridge, sent} = bridgeAt(options.connection);
 	render(
-		<AgentChatInput.Root
-			bridge={bridge}
-			variant={options.variant}
-			deliveryRule={options.deliveryRule}
-		>
+		<AgentChatInput.Root bridge={bridge} deliveryRule={options.deliveryRule}>
 			<Composer picked={options.picked} />
 		</AgentChatInput.Root>,
 	);
@@ -95,50 +90,27 @@ async function send(options: {
 const deliveries: readonly PiDeliveryMode[] = ["prompt", "steer", "follow_up"];
 
 /**
- * What each variant delivered before the rule was its own prop, at every connection state crossed
- * with every picker value. `undefined` is a send the composer refuses. Written out rather than
- * derived, so the table is a check on the rule and not a second copy of it.
+ * What the default rule delivers, at every connection state crossed with every picker value.
+ * `undefined` is a send the composer refuses. Written out rather than derived, so the table is a
+ * check on the rule and not a second copy of it.
  */
-const legacy: Record<
-	"focused" | "harness",
-	Record<ConnectionState, Record<PiDeliveryMode, SentPrompt | undefined>>
-> = {
-	focused: {
-		loading: {
-			prompt: {type: "prompt", message: "Ship it."},
-			steer: {type: "prompt", message: "Ship it."},
-			follow_up: {type: "prompt", message: "Ship it."},
-		},
-		ready: {
-			prompt: {type: "prompt", message: "Ship it."},
-			steer: {type: "prompt", message: "Ship it."},
-			follow_up: {type: "prompt", message: "Ship it."},
-		},
-		working: {
-			prompt: {type: "follow_up", message: "Ship it."},
-			steer: {type: "steer", message: "Ship it."},
-			follow_up: {type: "follow_up", message: "Ship it."},
-		},
-		unavailable: {prompt: undefined, steer: undefined, follow_up: undefined},
+const byDefault: Record<ConnectionState, Record<PiDeliveryMode, SentPrompt | undefined>> = {
+	loading: {
+		prompt: {type: "prompt", message: "Ship it."},
+		steer: {type: "prompt", message: "Ship it."},
+		follow_up: {type: "prompt", message: "Ship it."},
 	},
-	harness: {
-		loading: {
-			prompt: {type: "prompt", message: "Ship it."},
-			steer: {type: "steer", message: "Ship it."},
-			follow_up: {type: "follow_up", message: "Ship it."},
-		},
-		ready: {
-			prompt: {type: "prompt", message: "Ship it."},
-			steer: {type: "steer", message: "Ship it."},
-			follow_up: {type: "follow_up", message: "Ship it."},
-		},
-		working: {
-			prompt: {type: "prompt", message: "Ship it.", streamingBehavior: "steer"},
-			steer: {type: "steer", message: "Ship it."},
-			follow_up: {type: "follow_up", message: "Ship it."},
-		},
-		unavailable: {prompt: undefined, steer: undefined, follow_up: undefined},
+	ready: {
+		prompt: {type: "prompt", message: "Ship it."},
+		steer: {type: "prompt", message: "Ship it."},
+		follow_up: {type: "prompt", message: "Ship it."},
 	},
+	working: {
+		prompt: {type: "follow_up", message: "Ship it."},
+		steer: {type: "steer", message: "Ship it."},
+		follow_up: {type: "follow_up", message: "Ship it."},
+	},
+	unavailable: {prompt: undefined, steer: undefined, follow_up: undefined},
 };
 
 describe("AgentChatInput.Root", () => {
@@ -175,58 +147,41 @@ describe("AgentChatInput.Root", () => {
 
 	it("provides its state to a part rendered inside it", () => {
 		render(
-			<AgentChatInput.Root variant="focused">
+			<AgentChatInput.Root>
 				<Part />
 			</AgentChatInput.Root>,
 		);
-		expect(screen.getByText("focused/loading")).toBeTruthy();
+		expect(screen.getByText("loading")).toBeTruthy();
 	});
 });
 
 describe("the send-delivery rule", () => {
 	describe.each([
-		"focused",
-		"harness",
-	] as const)("with deliveryRule unset on variant=%s", (variant) => {
-		describe.each([
-			"loading",
-			"ready",
-			"working",
-			"unavailable",
-		] as const)("while %s", (connection) => {
-			it.each(deliveries)("delivers a picked %s as it did before the prop", async (picked) => {
-				const sent = await send({connection, picked, variant});
-				const expected = legacy[variant][connection][picked];
-				expect(sent).toEqual(expected ? [expected] : []);
-			});
+		"loading",
+		"ready",
+		"working",
+		"unavailable",
+	] as const)("with deliveryRule unset while %s", (connection) => {
+		it.each(deliveries)("delivers a picked %s under the default rule", async (picked) => {
+			const sent = await send({connection, picked});
+			const expected = byDefault[connection][picked];
+			expect(sent).toEqual(expected ? [expected] : []);
 		});
 	});
 
-	it("takes an explicit as-picked over the focused variant's default", async () => {
+	it("takes an explicit as-picked over the default", async () => {
 		const sent = await send({
 			connection: "working",
 			picked: "prompt",
-			variant: "focused",
 			deliveryRule: "as-picked",
 		});
 		expect(sent).toEqual([{type: "prompt", message: "Ship it.", streamingBehavior: "steer"}]);
-	});
-
-	it("takes an explicit queue-while-working over the harness variant's default", async () => {
-		const sent = await send({
-			connection: "working",
-			picked: "prompt",
-			variant: "harness",
-			deliveryRule: "queue-while-working",
-		});
-		expect(sent).toEqual([{type: "follow_up", message: "Ship it."}]);
 	});
 
 	it("leaves an idle send a fresh prompt under queue-while-working", async () => {
 		const sent = await send({
 			connection: "ready",
 			picked: "follow_up",
-			variant: "harness",
 			deliveryRule: "queue-while-working",
 		});
 		expect(sent).toEqual([{type: "prompt", message: "Ship it."}]);

--- a/packages/design/src/agent-chat/Root.tsx
+++ b/packages/design/src/agent-chat/Root.tsx
@@ -26,7 +26,6 @@ import {useDesignT} from "../i18n";
 import {thinkingLevelKeys} from "./catalog";
 import {
 	type AgentChatDeliveryRule,
-	deliveryRuleForVariant,
 	requestedDelivery as resolveRequestedDelivery,
 } from "./delivery";
 import {fileAsImage, MAX_IMAGE_BYTES} from "./image";
@@ -49,16 +48,14 @@ import {
 import type {Activity, ConnectionState, ExtensionRequest, Suggestion} from "./types";
 import {unavailableBridge} from "./unavailable-bridge";
 
+/**
+ * The composer's props. There is no chrome prop: it has one shape for every host — see ADR 0369,
+ * which is where a case for a second one is argued, not here.
+ */
 export interface AgentChatInputProps {
 	readonly bridge?: AgentChatInputBridge;
 	readonly initialValue?: string;
 	readonly disabled?: boolean;
-	/**
-	 * Which chrome the composer carries — the status row, the attach button, the overflow menu —
-	 * and the border it wears; `deliveryRule` decides how a send goes out. It is **not** a size
-	 * prop: the compact shape #8669 ruled is unconditional under both arms.
-	 */
-	readonly variant?: "harness" | "focused";
 	/**
 	 * How a send is delivered.
 	 *
@@ -67,8 +64,7 @@ export interface AgentChatInputProps {
 	 *   picked there queues as a `follow_up` instead of interrupting the run. A send at any other
 	 *   connection state is always a fresh `prompt`.
 	 *
-	 * Unset, it is derived from `variant` — `focused` means `queue-while-working`, `harness` means
-	 * `as-picked` — so a host that never named it keeps the delivery it has today.
+	 * Unset, it is `queue-while-working`, the rule every shipping host runs on.
 	 */
 	readonly deliveryRule?: AgentChatDeliveryRule;
 	readonly mockWhenUnavailable?: boolean;
@@ -101,7 +97,6 @@ export interface AgentChatInputProps {
  */
 export interface AgentChatInputState {
 	readonly disabled: boolean;
-	readonly variant: "harness" | "focused";
 	readonly deliveryRule: AgentChatDeliveryRule;
 	readonly settings: ReactNode;
 	readonly fieldRef: Ref<HTMLTextAreaElement> | undefined;
@@ -171,8 +166,7 @@ export function AgentChatInputRoot({
 	bridge,
 	initialValue = "",
 	disabled = false,
-	variant = "harness",
-	deliveryRule,
+	deliveryRule = "queue-while-working",
 	mockWhenUnavailable = false,
 	onDraftChange,
 	settings,
@@ -180,7 +174,6 @@ export function AgentChatInputRoot({
 	children,
 }: AgentChatInputProps & {readonly children: ReactNode}) {
 	const activeBridge = bridge ?? unavailableBridge;
-	const rule = deliveryRule ?? deliveryRuleForVariant(variant);
 	const t = useDesignT();
 	const inputId = useId();
 	const suggestionsId = `${inputId}-suggestions`;
@@ -387,8 +380,8 @@ export function AgentChatInputRoot({
 			if (nextLevels) {
 				setThinkingLevels(nextLevels);
 				// A level the session has stopped offering is not the level it is running on. Left
-				// standing it reads as an operator selection the backend would refuse — and on the
-				// harness variant it kept rendering as the trigger's own label (#8425).
+				// standing it reads as an operator selection the backend would refuse, and it kept
+				// rendering as the trigger's own label (#8425).
 				setState((current) => {
 					const held = thinkingLevelValue(current?.thinkingLevel);
 					if (held === undefined || nextLevels.includes(held)) return current;
@@ -467,7 +460,7 @@ export function AgentChatInputRoot({
 			return;
 		}
 		try {
-			const requestedDelivery = resolveRequestedDelivery(rule, connection, delivery);
+			const requestedDelivery = resolveRequestedDelivery(deliveryRule, connection, delivery);
 			const streamedPrompt = connection === "working" && requestedDelivery === "prompt";
 			await activeBridge.sendPiPrompt({
 				type: requestedDelivery,
@@ -722,8 +715,7 @@ export function AgentChatInputRoot({
 	const value = useMemo<AgentChatInputContextValue>(
 		() => ({
 			disabled,
-			variant,
-			deliveryRule: rule,
+			deliveryRule,
 			settings,
 			fieldRef: ref,
 			inputId,
@@ -770,8 +762,8 @@ export function AgentChatInputRoot({
 			inspectorOpen,
 			models,
 			projectTrust,
+			deliveryRule,
 			ref,
-			rule,
 			settings,
 			settingsChanging,
 			settingsDisabled,
@@ -779,7 +771,6 @@ export function AgentChatInputRoot({
 			suggestions,
 			suggestionsId,
 			thinkingLevels,
-			variant,
 			widget,
 		],
 	);

--- a/packages/design/src/agent-chat/Surface.tsx
+++ b/packages/design/src/agent-chat/Surface.tsx
@@ -1,39 +1,14 @@
 import type {ReactNode} from "react";
 import {Card} from "../Card";
-import {useDesignT} from "../i18n";
-import {runningModelLabel} from "./parse";
 import {useAgentChatInput} from "./Root";
 
-/**
- * The composer's frame: the card everything else sits in, and the status row that names the
- * connection above it.
- */
+/** The composer's frame: the card everything else sits in. */
 export function AgentChatSurface({children}: {readonly children: ReactNode}) {
-	const {variant, connection, harnessState, models, extensionStatus} = useAgentChatInput();
-	const t = useDesignT();
-	const model = runningModelLabel(harnessState, models ?? []);
-	const status =
-		connection === "loading"
-			? t("admin.agent.status.loading")
-			: connection === "working"
-				? t("admin.agent.status.working")
-				: connection === "ready"
-					? model
-						? t("admin.agent.status.readyWithModel", {model})
-						: t("admin.agent.status.ready")
-					: t("admin.agent.status.unavailable");
+	// Read for the placement guard alone — see `Frame.tsx`.
+	useAgentChatInput();
 
 	return (
 		<Card className="kp-agent-chat__composer" data-testid="agent-chat-input">
-			{variant === "harness" ? (
-				<div className="kp-agent-chat__status-row">
-					<p className="kp-agent-chat__status" aria-live="polite">
-						{status}
-						{extensionStatus ? ` · ${extensionStatus}` : ""}
-					</p>
-					<p className="kp-agent-chat__scope">{t("admin.agent.scope")}</p>
-				</div>
-			) : null}
 			{children}
 		</Card>
 	);

--- a/packages/design/src/agent-chat/Toolbar.tsx
+++ b/packages/design/src/agent-chat/Toolbar.tsx
@@ -2,7 +2,6 @@ import type {ReactNode} from "react";
 import {AgentChatAttach} from "./Attach";
 import {AgentChatOverflow} from "./Overflow";
 import {AgentChatPrimaryActions} from "./PrimaryActions";
-import {useAgentChatInput} from "./Root";
 import {AgentChatSettings} from "./Settings";
 
 /**
@@ -13,16 +12,14 @@ import {AgentChatSettings} from "./Settings";
  * dropped it would have a composer nothing leaves.
  */
 export function AgentChatToolbar({children}: {readonly children?: ReactNode}) {
-	const {variant} = useAgentChatInput();
-
 	return (
 		<div className="kp-agent-chat__actions">
 			<div className="kp-agent-chat__primary-controls">
 				{children ?? (
 					<>
-						{variant === "focused" ? <AgentChatAttach /> : null}
+						<AgentChatAttach />
 						<AgentChatSettings />
-						{variant === "focused" ? <AgentChatOverflow /> : null}
+						<AgentChatOverflow />
 					</>
 				)}
 			</div>

--- a/packages/design/src/agent-chat/catalog.ts
+++ b/packages/design/src/agent-chat/catalog.ts
@@ -8,20 +8,8 @@ import {
 	Minus,
 	Sparkles,
 } from "lucide-react";
-import type {PiDeliveryMode, PiProjectTrust, PiThinkingLevel} from "../agent-chat-bridge";
-import type {DesignCatalogKey, DesignTranslate} from "../i18n";
-import type {SelectItem} from "../Select";
-
-export const deliveryModeKeys: readonly {value: PiDeliveryMode; key: DesignCatalogKey}[] = [
-	{value: "prompt", key: "admin.agent.delivery.prompt"},
-	{value: "steer", key: "admin.agent.delivery.steer"},
-	{value: "follow_up", key: "admin.agent.delivery.followUp"},
-];
-
-export const projectTrustKeys: readonly {value: PiProjectTrust; key: DesignCatalogKey}[] = [
-	{value: "approve", key: "admin.agent.trust.approve"},
-	{value: "no-approve", key: "admin.agent.trust.ignore"},
-];
+import type {PiThinkingLevel} from "../agent-chat-bridge";
+import type {DesignCatalogKey} from "../i18n";
 
 export const thinkingLevelKeys: Readonly<Record<PiThinkingLevel, DesignCatalogKey>> = {
 	off: "admin.agent.thinking.off",
@@ -33,11 +21,6 @@ export const thinkingLevelKeys: Readonly<Record<PiThinkingLevel, DesignCatalogKe
 	max: "admin.agent.thinking.max",
 	ultra: "admin.agent.thinking.ultra",
 };
-
-export const toItems = (
-	entries: readonly {value: string; key: DesignCatalogKey}[],
-	t: DesignTranslate,
-): SelectItem[] => entries.map(({value, key}) => ({value, label: t(key)}));
 
 export const thinkingLevelIcons: Readonly<Record<PiThinkingLevel, LucideIcon>> = {
 	off: CircleOff,

--- a/packages/design/src/agent-chat/delivery.ts
+++ b/packages/design/src/agent-chat/delivery.ts
@@ -11,11 +11,6 @@ import type {ConnectionState} from "./types";
  */
 export type AgentChatDeliveryRule = "as-picked" | "queue-while-working";
 
-/** The rule a `variant` implied before the rule was its own prop. */
-export function deliveryRuleForVariant(variant: "harness" | "focused"): AgentChatDeliveryRule {
-	return variant === "focused" ? "queue-while-working" : "as-picked";
-}
-
 export function requestedDelivery(
 	rule: AgentChatDeliveryRule,
 	connection: ConnectionState,

--- a/packages/design/src/agent-chat/parse.ts
+++ b/packages/design/src/agent-chat/parse.ts
@@ -1,6 +1,5 @@
 import type {
 	PiCommand,
-	PiDeliveryMode,
 	PiEvent,
 	PiModel,
 	PiProjectTrust,
@@ -20,10 +19,6 @@ export function stringValue(record: Record<string, unknown>, key: string): strin
 export function booleanValue(record: Record<string, unknown>, key: string): boolean | undefined {
 	const value = record[key];
 	return typeof value === "boolean" ? value : undefined;
-}
-
-export function deliveryMode(value: string | undefined): PiDeliveryMode | undefined {
-	return value === "prompt" || value === "steer" || value === "follow_up" ? value : undefined;
 }
 
 export function projectTrustValue(value: unknown): PiProjectTrust | undefined {
@@ -124,18 +119,6 @@ export function modelName(state: Record<string, unknown> | undefined): string | 
 	return (
 		stringValue(model, "displayName") ?? stringValue(model, "name") ?? stringValue(model, "id")
 	);
-}
-
-/** The running model as the status line names it: bare name, or name + provider once two collide. */
-export function runningModelLabel(
-	state: Record<string, unknown> | undefined,
-	models: readonly PiModel[],
-): string | undefined {
-	const name = modelName(state);
-	if (!name || !providersCollide(models)) return name;
-	const model = state && isRecord(state.model) ? state.model : undefined;
-	const provider = model && stringValue(model, "provider");
-	return provider ? `${name} (${provider})` : name;
 }
 
 export function assistantMessageText(value: unknown): string | undefined {

--- a/packages/design/src/kp-class-coverage.test.ts
+++ b/packages/design/src/kp-class-coverage.test.ts
@@ -28,10 +28,7 @@ const SRC = dirname(fileURLToPath(import.meta.url));
 const UNSTYLED_HOOKS: Readonly<Record<string, string>> = {
 	"kp-card": "Card's naming hook over Surface, which carries every rule the card renders with.",
 	"kp-edited-indicator": "Marker for consumers to target; the indicator's own styling is Tag's.",
-	"kp-agent-chat__delivery": "Hook on the delivery Select; the control's styling is Manti's.",
 	"kp-agent-chat__error": "Hook on the error Alert; the styling is Alert's own.",
-	"kp-agent-chat__setting-select--model":
-		"Modifier hook beside the styled `kp-agent-chat__setting-select` base.",
 };
 
 const walk = (dir: string): ReadonlyArray<string> =>


### PR DESCRIPTION
The agent composer has one chrome. `AgentChatInput` no longer takes `variant`, and every
`harness` branch is gone with it.

Fixes #8712

## What moved

- **`Frame`** — root class is a bare `kp-agent-chat`; the widget-above-the-card is gone
  (`HarnessWidget` itself survives, inside the inspector's disclosure).
- **`Surface`** — the connection status row is deleted, along with the `runningModelLabel` helper
  that existed only to write it. Tuval carries its own status bar; apps/web has no harness surface.
- **`Toolbar`** — attach and overflow render unconditionally.
- **`Inspector`** — the counting disclosure is the only layout.
- **`Pickers`** — the two menu-backed rows only; project trust stays in the overflow menu, and the
  three `Select`-backed rows go.
- **`PrimaryActions`** — the inline delivery `Select` (harness-only) goes; the overflow menu's
  delivery rows are the one path.
- **`delivery.ts`** — `deliveryRuleForVariant` is deleted. `deliveryRule` stays an explicit prop.
- **CSS** — the four `.kp-agent-chat--focused` blocks are now the unconditional rules; the dead
  status-row and settings-Select rules go with the markup that used them.
- **Hosts** — `variant="focused"` dropped from `ChatWindow.tsx` and `SessionTranscript.tsx`; the
  atölye exhibits lose the variant knob.
- **Docs** — `.patterns/agent-chat-compound-parts.md` re-grounded; the founder ruling is recorded as
  ADR 0369 (`.decisions/0369-agent-composer-has-one-chrome.md`), which the issue's fourth criterion
  asked for.

LAW-SOURCE: manifest-prose (this repo declares no typed `design-prohibitions.json`).

## What was run

- `packages/design`: full unit suite (24 files, 198 tests) — including `kp-class-coverage` and the
  assembled-vs-plain parity test through `settleComposer`.
- `apps/tuval`: `src/shell/chat` + `src/ai-agent/window` (39 files, 535 tests).
- `typecheck` for design, tuval and web; biome on the touched files.
- Renders: `/tuval/chat` and `/lab/atolye/agent-chat-input`, before and after. The Tuval capture is
  byte-identical across the two sets (same sha256) — the shipping host's chrome does not move, which
  is the whole claim of the ruling.

## Deviations

- **Said:** `deliveryRule` stays an explicit prop "with its current default". **Did:** defaulted it
  to `queue-while-working`. **Why:** the literal current default came off `variant`'s own default
  (`harness` → `as-picked`); keeping that would silently change both Tuval hosts' send behaviour,
  which is what "keep the focused chrome" rules out. The surviving arm's rule is the default.
  **Disposition:** named here for the reviewer; no real host's behaviour moves.
- **Said:** run only the design and tuval suites named in the brief. **Did:** also ran
  `apps/web --project client src/components/agent src/lab/atolye`. **Why:** the web production test
  asserted the deleted status row's text, and a second `/gönder/i` match appeared once the overflow
  trigger renders for every host; both had to be fixed, so both were run. **Disposition:** two files
  touched, both green.
- **Said:** remove the `harness` branches. **Did:** also deleted `deliveryModeKeys`,
  `projectTrustKeys`, `toItems`, `parse.deliveryMode` and `parse.runningModelLabel`. **Why:** each
  had exactly one caller and that caller was a deleted branch; leaving them ships dead exports.
  **Disposition:** done.
- **Said:** nothing about `extensionStatus`. **Did:** kept it on Root's published state. **Why:** its
  only reader was the deleted status row, but it is real state a host may render, and dropping it
  exceeds the ruling. **Disposition:** left in place, named rather than silently kept.
- **Said:** nothing about the parts contract. **Did:** kept `.Frame` and `.Surface` reading the Root
  context. **Why:** neither paints state any more, so without the read they would be the only parts
  that render happily outside a Root, breaking the contract `Root.test.tsx` holds. **Disposition:**
  the read is commented as the guard it is, and the pattern doc says so.
- **Said:** nothing about copy. **Did:** left `admin.agent.status.*` and `admin.agent.scope` in the
  catalogs. **Why:** their only reader is gone, but removing them crosses apps/web's two locale
  catalogs and Tuval's copy map with their own parity tests. **Disposition:** out of scope here;
  recorded in ADR 0369 and filed as a follow-up.
