### PR TITLE
fix: The agent composer's textarea paints no focus ring

### DIFF
--- a/apps/tuval/src/shell/chat/composer-focus-ring.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/composer-focus-ring.unit.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer's focus ring, keyboard-only (#8786). A browser matches `:focus-visible` on a text
+ * field for pointer focus too, so the desk's one ring rule paints on a click unless something tells
+ * it which input the operator last used — `../ui/input-modality.ts` is that something and the desk
+ * publishes it on its root.
+ *
+ * The composer is reached through a real `Desk`, not a bare surface `div`: the attribute is the
+ * desk's to write, and a test that wrote it itself would stay green after the wiring came out.
+ *
+ * jsdom does not resolve `var()` substitution, so the ring is checked by selector match against the
+ * gated selector read off the sheet, never by a computed `outline` string.
+ */
+
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {Effect} from "effect";
+import type {ReactElement} from "react";
+import {describe, expect, it} from "vitest";
+import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {ProcessId} from "../../process/process.ts";
+import {defaultPrefixTable} from "../keys/index.ts";
+import {createStack, createTree, createWindow} from "../layout/index.ts";
+import {Desk} from "../ui/Desk.tsx";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {deskWith} from "../ui/fixtures.ts";
+import {INPUT_MODALITY_ATTRIBUTE} from "../ui/input-modality.ts";
+import type {MountResolver} from "../ui/mount.ts";
+import {refused} from "../ui/press.ts";
+import {testProcess} from "../window/fixtures.ts";
+import {empty, WindowId} from "../window/index.ts";
+import {chatWindow} from "./ChatWindow.tsx";
+import {sessionState} from "./chat.testing.ts";
+import {initialChatView} from "./view.ts";
+
+installDomShims();
+
+/** The gated rule the desk paints its one ring with. Read back off the sheet by the first case. */
+const RING_SELECTOR = '.tuval-surface:not([data-input-modality="pointer"]) :focus-visible';
+
+const deskSheet = (): string =>
+	readFileSync(fileURLToPath(import.meta.resolve("../ui/tokens.css")), "utf8");
+
+/** Every stylesheet the app ships, comments stripped — a comment naming a rule is not a rule. */
+const tuvalSheets = (): ReadonlyArray<readonly [string, string]> => {
+	const src = join(fileURLToPath(import.meta.resolve("./view.ts")), "..", "..", "..");
+	return readdirSync(src, {recursive: true})
+		.filter((name): name is string => typeof name === "string" && name.endsWith(".css"))
+		.map((name) => [name, readFileSync(join(src, name), "utf8").replace(/\/\*[\s\S]*?\*\//g, "")]);
+};
+
+/** The selector of every rule in the app that declares an `outline`. */
+const ringPainters = (): ReadonlyArray<string> =>
+	tuvalSheets().flatMap(([name, source]) =>
+		source
+			.split("}")
+			.filter((block) => /(^|;|\{)\s*outline(-offset)?\s*:/.test(block))
+			.map((block) => `${name}: ${(block.split("{")[0] ?? "").trim()}`),
+	);
+
+const oneWindowDesk = () =>
+	deskWith(
+		createTree(createStack("stack-root", "horizontal", [createWindow("window-1", "process-1")])),
+	);
+
+/** A desk showing the chat window, which is where the composer lives. */
+const openDesk = async () => {
+	const process = await Effect.runPromise(
+		testProcess<AiAgentSessionState, AiAgentSessionMsg>(
+			ProcessId.make("process-1"),
+			sessionState(),
+		),
+	);
+	const host = await Effect.runPromise(process.window(WindowId.make("window-1"), initialChatView));
+	const renderer = chatWindow({scrollCommitMs: 0, scrollToFn: () => undefined});
+	const resolveMount: MountResolver = (_windowId, processId) =>
+		processId === null
+			? empty
+			: {
+					_tag: "Bound",
+					host,
+					render: () => renderer.render(host) as ReactElement,
+				};
+	const rendered = render(
+		<Desk
+			state={oneWindowDesk()}
+			dispatch={() => undefined}
+			press={() => Promise.resolve(refused)}
+			resolveMount={resolveMount}
+			table={defaultPrefixTable}
+		/>,
+	);
+	await screen.findByRole("log", {name: "Transcript"});
+	const root = document.querySelector<HTMLElement>(".tuval-surface");
+	const composer = document.querySelector<HTMLTextAreaElement>("textarea");
+	if (root === null || composer === null) throw new Error("the desk rendered no composer");
+	return {root, composer, unmount: () => rendered.unmount()};
+};
+
+const modalityOf = (root: HTMLElement): string | null =>
+	root.getAttribute(INPUT_MODALITY_ATTRIBUTE);
+
+/** Does the desk's one ring rule reach this element as the desk currently stands? */
+const wearsTheRing = (element: Element): boolean =>
+	[...document.querySelectorAll(RING_SELECTOR)].includes(element);
+
+describe("the composer's focus ring", () => {
+	it("is the desk's one rule, gated on the modality the desk publishes", () => {
+		expect(deskSheet()).toMatch(
+			/\.tuval-surface:not\(\[data-input-modality="pointer"\]\) :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
+		);
+		// One rule and no second: a component sheet under `apps/tuval/src` that painted its own ring
+		// would be the per-component outline Pillar 4 forbids, and the gate would not reach it.
+		expect(ringPainters()).toEqual([`shell/ui/tokens.css: ${RING_SELECTOR}`]);
+	});
+
+	it("still reaches a surface that publishes no modality at all", () => {
+		// The attaching placeholder, the boot screens and every proof page are `.tuval-surface` roots
+		// that are not the desk and mark nothing. The gate may only take a ring off a surface that has
+		// seen a click, so those keep the one they had.
+		const surface = document.createElement("div");
+		surface.className = "tuval-surface";
+		const button = document.createElement("button");
+		surface.append(button);
+		document.body.append(surface);
+
+		button.focus();
+
+		expect(wearsTheRing(button)).toBe(true);
+		surface.remove();
+	});
+
+	it("is armed on a desk nobody has touched, so the first Tab lands on a ring", async () => {
+		const opened = await openDesk();
+		expect(modalityOf(opened.root)).toBe("keyboard");
+		opened.composer.focus();
+		expect(wearsTheRing(opened.composer)).toBe(true);
+		opened.unmount();
+	});
+
+	it("paints nothing when the operator lands there with the mouse", async () => {
+		const opened = await openDesk();
+		fireEvent.pointerDown(opened.composer);
+		opened.composer.focus();
+
+		expect(modalityOf(opened.root)).toBe("pointer");
+		expect(wearsTheRing(opened.composer)).toBe(false);
+		opened.unmount();
+	});
+
+	it("paints when the operator arrives on a key", async () => {
+		const opened = await openDesk();
+		fireEvent.pointerDown(opened.composer);
+		fireEvent.keyDown(opened.composer, {key: "Tab"});
+		opened.composer.focus();
+
+		expect(modalityOf(opened.root)).toBe("keyboard");
+		expect(wearsTheRing(opened.composer)).toBe(true);
+		opened.unmount();
+	});
+
+	it("tracks the last input rather than latching on the first", async () => {
+		const opened = await openDesk();
+		opened.composer.focus();
+
+		fireEvent.pointerDown(opened.composer);
+		expect([modalityOf(opened.root), wearsTheRing(opened.composer)]).toEqual(["pointer", false]);
+
+		fireEvent.keyDown(opened.composer, {key: "a"});
+		expect([modalityOf(opened.root), wearsTheRing(opened.composer)]).toEqual(["keyboard", true]);
+
+		fireEvent.pointerDown(opened.composer);
+		expect([modalityOf(opened.root), wearsTheRing(opened.composer)]).toEqual(["pointer", false]);
+		opened.unmount();
+	});
+
+	it("hears a key the composer stops on its way up", async () => {
+		const opened = await openDesk();
+		fireEvent.pointerDown(opened.composer);
+		opened.composer.addEventListener("keydown", (event) => event.stopPropagation());
+
+		fireEvent.keyDown(opened.composer, {key: "Tab"});
+
+		expect(modalityOf(opened.root)).toBe("keyboard");
+		opened.unmount();
+	});
+
+	it("stays armed when the desk takes focus back from an overlay, which is a keyboard path", async () => {
+		const opened = await openDesk();
+		fireEvent.keyDown(opened.root, {key: "Escape"});
+		opened.root.focus();
+
+		expect(modalityOf(opened.root)).toBe("keyboard");
+		opened.unmount();
+	});
+});

--- a/apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx
@@ -21,6 +21,7 @@ import type {SubagentSlot} from "../../ai-agent/ports/index.ts";
 import {subagentSlot} from "../../ai-agent-fixtures/transcripts.ts";
 import {ProcessId} from "../../process/process.ts";
 import {installDomShims} from "../ui/dom.testing.ts";
+import {INPUT_MODALITY_ATTRIBUTE} from "../ui/input-modality.ts";
 import {testProcess} from "../window/fixtures.ts";
 import {WindowId} from "../window/index.ts";
 import {chatWindow} from "./ChatWindow.tsx";
@@ -42,6 +43,10 @@ const slots = (...entries: ReadonlyArray<SubagentSlot>): Record<string, Subagent
 const openUnderSurface = async (state: AiAgentSessionState) => {
 	const surface = document.createElement("div");
 	surface.className = "tuval-surface";
+	// The desk root's own mark, which the ring rule is gated on since #8786 (`../ui/Desk.tsx` writes
+	// it). Keyboard, because that is what a desk carries until a pointer touches it, and a row
+	// reached by keyboard is the case this file is about.
+	surface.setAttribute(INPUT_MODALITY_ATTRIBUTE, "keyboard");
 	document.body.append(surface);
 	const process = await Effect.runPromise(
 		testProcess<AiAgentSessionState, AiAgentSessionMsg>(ProcessId.make("p1"), state),
@@ -75,7 +80,7 @@ describe("the subagent rows' focus ring", () => {
 
 	it("is the desk's one rule, declared off the ring tokens", () => {
 		expect(deskSheet()).toMatch(
-			/\.tuval-surface :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
+			/\.tuval-surface:not\(\[data-input-modality="pointer"\]\) :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
 		);
 	});
 
@@ -90,7 +95,13 @@ describe("the subagent rows' focus ring", () => {
 
 		pick?.focus();
 
-		expect(Array.from(document.querySelectorAll(".tuval-surface :focus-visible"))).toContain(pick);
+		expect(
+			Array.from(
+				document.querySelectorAll(
+					'.tuval-surface:not([data-input-modality="pointer"]) :focus-visible',
+				),
+			),
+		).toContain(pick);
 		opened.unmount();
 	});
 });

--- a/apps/tuval/src/shell/ui/Desk.tsx
+++ b/apps/tuval/src/shell/ui/Desk.tsx
@@ -58,6 +58,12 @@ import {
 	statusFrame,
 	zoomedWindow,
 } from "./frame.ts";
+import {
+	INITIAL_INPUT_MODALITY,
+	INPUT_MODALITY_ATTRIBUTE,
+	type InputModality,
+	inputModalityHandlers,
+} from "./input-modality.ts";
 import {LayoutView} from "./LayoutView.tsx";
 import type {MountResolver} from "./mount.ts";
 import {focusedWindowOf, PaletteHost} from "./PaletteHost.tsx";
@@ -129,6 +135,8 @@ export function Desk({
 }: DeskProps): ReactElement {
 	const [commandLineOpen, setCommandLineOpen] = useState(false);
 	const [forwarded, setForwarded] = useState<ForwardedKey | null>(null);
+	const [modality, setModality] = useState<InputModality>(INITIAL_INPUT_MODALITY);
+	const modalityHandlers = useMemo(() => inputModalityHandlers(setModality), []);
 	const seq = useRef(0);
 	const desk = useRef<HTMLDivElement>(null);
 
@@ -326,6 +334,11 @@ export function Desk({
 			// prefix — the acknowledgement for `<c-b>` carries it, so the mark lands with the answer
 			// rather than with the next broadcast (#8274).
 			{...(state.prefix.armed ? {[PREFIX_ARMED_ATTRIBUTE]: "true"} : {})}
+			// Which input the operator last used, so the ring rule in `./tokens.css` can paint on a Tab
+			// and stay off a click — a text field matches `:focus-visible` either way (#8786). The pair
+			// below maintains it and routes nothing; the desk's one key router is the listener above.
+			{...{[INPUT_MODALITY_ATTRIBUTE]: modality}}
+			{...modalityHandlers}
 		>
 			<div className="tuval-desk-body">
 				<ForwardedKeyProvider value={forwarded}>

--- a/apps/tuval/src/shell/ui/index.ts
+++ b/apps/tuval/src/shell/ui/index.ts
@@ -31,6 +31,13 @@ export {
 	statusFrame,
 	zoomedWindow,
 } from "./frame.ts";
+export {
+	INITIAL_INPUT_MODALITY,
+	INPUT_MODALITY_ATTRIBUTE,
+	type InputModality,
+	inputModalityAround,
+	inputModalityHandlers,
+} from "./input-modality.ts";
 export {LayoutView, type LayoutViewProps} from "./LayoutView.tsx";
 export {
 	boundMount,

--- a/apps/tuval/src/shell/ui/input-modality.ts
+++ b/apps/tuval/src/shell/ui/input-modality.ts
@@ -1,0 +1,59 @@
+/**
+ * Which kind of input the operator last used, published on the desk root so CSS can read it.
+ *
+ * A browser matches `:focus-visible` on a text field for pointer focus too — the heuristic keeps the
+ * ring on an always-interactive control — so the desk's one ring rule cannot tell a click from a Tab
+ * on its own. The founder ruled the composer's ring keyboard-only (#8786), and this is the fact that
+ * rule needs: `./tokens.css` gates the ring on `[data-input-modality="keyboard"]`.
+ *
+ * The shape is `../window/prefix-signal.ts`'s — a named constant plus its reader, never an inline
+ * attribute string at the call site. Unlike that one the mark is always present and carries a value,
+ * because "no attribute yet" would be the no-ring state on a desk nobody has touched.
+ *
+ * The pairing is handed out as React handlers for the desk root rather than as listeners on the
+ * document: the page registers exactly one native key listener and it is the desk's router (#7559,
+ * asserted from three files, `./Desk.tsx`). React's capture handlers run at the root container
+ * before the target's own, so a child that stops a key on its way up cannot starve this either.
+ */
+
+import type {KeyboardEventHandler, PointerEventHandler} from "react";
+
+/** The last input was a key, or a pointer. Nothing else moves it. */
+export type InputModality = "keyboard" | "pointer";
+
+export const INPUT_MODALITY_ATTRIBUTE = "data-input-modality";
+
+/**
+ * What the desk publishes before any input has been seen. Keyboard, because a desk nobody has
+ * touched must not be the no-ring state — the first Tab into it has to land on a marked control.
+ */
+export const INITIAL_INPUT_MODALITY: InputModality = "keyboard";
+
+/** The modality of the desk this element sits in, or `null` outside a marked desk entirely. */
+export const inputModalityAround = (
+	target: EventTarget | null | undefined,
+): InputModality | null => {
+	if (target === null || target === undefined || typeof target !== "object") return null;
+	const element = target as {closest?: unknown};
+	if (typeof element.closest !== "function") return null;
+	const desk = (element as Element).closest(`[${INPUT_MODALITY_ATTRIBUTE}]`);
+	const value = desk?.getAttribute(INPUT_MODALITY_ATTRIBUTE);
+	return value === "keyboard" || value === "pointer" ? value : null;
+};
+
+interface InputModalityHandlers {
+	readonly onKeyDownCapture: KeyboardEventHandler<Element>;
+	readonly onPointerDownCapture: PointerEventHandler<Element>;
+}
+
+/**
+ * The two handlers that maintain the mark, spread onto the desk root. Every event is reported, not
+ * only the flips — the caller decides what a repeat is worth, and a React `useState` setter already
+ * bails out on an equal value, so a held key costs no render.
+ */
+export const inputModalityHandlers = (
+	report: (modality: InputModality) => void,
+): InputModalityHandlers => ({
+	onKeyDownCapture: () => report("keyboard"),
+	onPointerDownCapture: () => report("pointer"),
+});

--- a/apps/tuval/src/shell/ui/tokens.css
+++ b/apps/tuval/src/shell/ui/tokens.css
@@ -38,7 +38,17 @@
 	inline-size: 100%;
 }
 
-.tuval-surface :focus-visible {
+/* Gated on the last input the desk saw (`./input-modality.ts`), because a browser matches
+   `:focus-visible` on a text field for a *pointer* focus too — the composer got a ring on every
+   click and the founder ruled it keyboard-only (#8786). Still the one rule on the root: for a
+   button or a picker row the gate is a no-op, since a browser already withholds `:focus-visible`
+   from those on pointer focus.
+
+   Written as "not pointer" rather than "is keyboard" so the gate can only ever *remove* a ring, and
+   only from a surface that has seen a click. Several `.tuval-surface` roots are not the desk and
+   publish nothing — the attaching placeholder (`../../page/AttachedDesk.tsx`), the boot screens,
+   every proof page — and a positive gate would have silently stripped the ring off all of them. */
+.tuval-surface:not([data-input-modality="pointer"]) :focus-visible {
 	outline: var(--focus-ring);
 	outline-offset: var(--focus-ring-offset);
 }


### PR DESCRIPTION
The Tuval desk's focus ring now paints on keyboard focus only. A pointer click into the composer
leaves the caret and nothing else, which is the founder's 2026-09-09 ruling.

Fixes #8786

## What changed

`apps/tuval/src/shell/ui/input-modality.ts` is new: it owns the `data-input-modality` attribute
name, the `keyboard` default, a reader in the shape of `../window/prefix-signal.ts`, and the pair of
handlers that maintain the mark. `Desk.tsx` holds the value in state, spreads the handlers onto the
`.tuval-surface` root beside `PREFIX_ARMED_ATTRIBUTE`, and publishes `keyboard` before any input
event lands. `tokens.css` gates its one ring rule on the mark — still one rule on the desk root, and
no component sheet gains an `outline`.

The gate reads `:not([data-input-modality="pointer"])` rather than `[data-input-modality="keyboard"]`
so it can only ever take a ring away, and only from a surface that has seen a click. Several
`.tuval-surface` roots are not the desk and publish nothing — the attaching placeholder in
`page/AttachedDesk.tsx`, the boot screens, every proof page — and a positive gate would have stripped
the ring off all of them silently.

## Tests

`apps/tuval/src/shell/chat/composer-focus-ring.unit.test.tsx` is new and drives the real composer
inside a real `Desk`: a pointer-sourced focus matches no ring, a keyboard-sourced one does, a
pointer→keyboard→pointer sequence proves the mark tracks the last input rather than latching, a key
the composer stops on its way up still arms it, an untouched desk is already armed, and a surface
publishing no modality keeps the ring it had. Both directions were flip-verified — inverting either
handler reds two cases.

`apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx` moves to the gated selector and keeps
its "declared off the ring tokens, hand-rolled nowhere" assertions.

`pnpm --filter @kampus/tuval exec vitest run src/shell` — 961 passed. `typecheck` 0 errors, biome
clean on the touched files.

## Deviations

- **Said:** triage asked for a module owning "the listeners that maintain it", both on the document
  in capture phase. **Did:** the module hands out `onKeyDownCapture` / `onPointerDownCapture` for the
  desk root; no document listener is added. **Why:** a second `addEventListener("keydown", ...)`
  breaks the one-key-listener invariant of #7559, which three separate files assert
  (`ui/boundary.unit.test.ts`, `ui/desk.unit.test.tsx` across three cases,
  `chat/subagent-navigator.unit.test.tsx`). React's capture handlers run at the root container before
  the target's own, so the starvation the capture phase was asked for is still ruled out, and the
  module still owns the attribute name, the default, the reader and the pairing. **Disposition:**
  standing. Nothing was weakened; the three invariant tests are untouched and green.
- **Said:** gate the ring rule on the attribute. **Did:** gated it as
  `:not([data-input-modality="pointer"])` rather than `[data-input-modality="keyboard"]`. **Why:**
  six `.tuval-surface` roots are not the desk and publish no modality — the attaching placeholder in
  `page/AttachedDesk.tsx`, the boot screens, the proof pages — and a positive gate would have taken
  their ring away with nothing to notice it. This way the gate can only remove a ring, and only from
  a surface that has seen a click. **Disposition:** standing.
- **Said:** one new test file covering the pointer case, the keyboard case and the flip-back.
  **Did:** one new file, plus one extra case proving an unmarked surface keeps its ring. **Why:** the
  extra case is the guard for the deviation above. **Disposition:** standing.
- **Said:** attach before/after captures of every changed surface. **Did:** captured `/tuval/chat`,
  the only declared surface that renders the composer; its before and after bytes are identical
  (`sha256:21e7131e...`). **Why:** the chat proof page is not a `Desk` and publishes no modality, and
  the shipped desk — the surface the ruling is about — is not a declared render surface: it needs a
  live Tuval kernel behind it and `.fabrika.jsonc` declares no route for it. No capture in this repo
  can show the fix rendered, so the unit tests are the proof; the identical bytes do prove no
  regression on the surface that is declared. **Disposition:** named here rather than left silent. A
  declared desk surface is worth its own row.
- **Said:** nothing about the proof pages. **Did:** left the composer on `/tuval/chat` ringing on a
  click. **Why:** it is a dev harness, not the desk, and publishes no modality; the ruling's scope is
  the desk. **Disposition:** deliberate.

LAW-SOURCE: manifest-prose
