### PR TITLE
docs: campaign Tuval first slice done; declare and start Tuval programs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,9 +50,10 @@ flowchart TD
 		camp_epic_lanes["Epic lanes"]:::active
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
 		camp_tuval["Tuval"]:::done
-		camp_tuval_first_slice["Tuval first slice"]:::active
+		camp_tuval_first_slice["Tuval first slice"]:::done
 		camp_phoenix_i18n["phoenix i18n"]:::active
 		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::active
+		camp_tuval_programs["Tuval programs"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -116,11 +117,12 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Epic lanes | #49 | active |
 | Diátaxis README passes | #50 | active |
 | Tuval | #51 | done |
-| Tuval first slice | #52 | active |
+| Tuval first slice | #52 | done |
 | phoenix i18n | #53 | active |
 | Tuval first slice - fast follows | #54 | active |
+| Tuval programs | #55 | active |
 
-**Tuval first slice - fast follows** remains open and active for follow-up repairs discovered during Tuval work, including when its backlog is temporarily empty. Completing the current issues does not close this campaign; closure requires an explicit founder decision.
+**Tuval programs** carries the new Tuval scope after the first slice shipped: the program authoring API (#8716) and the desk showing kernel children (#8715). **Tuval first slice - fast follows** remains open and active for follow-up repairs discovered during Tuval work, including when its backlog is temporarily empty. Completing the current issues does not close this campaign; closure requires an explicit founder decision.
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
## What

Runs the `/campaign` pass after the Tuval first slice drained.

- Tuval first slice (#52): active → done. Milestone closed at 277 closed, 0 open.
- Tuval programs (#55): new row, declared paused then flipped active. Holds epics #8715 and #8716 and their 17 children, moved out of #52.
- Tuval first slice - fast follows (#54): untouched, stays open and active by its own charter for repairs on the shipped slice.

Mermaid nodes restyled and added to match. `fabrika guard roadmap-guard check` is green at this head.

## Cites

- https://github.com/kamp-us/phoenix/issues/7625#issuecomment-5609102882
- https://github.com/kamp-us/phoenix/issues/8716#issuecomment-5609103026
- https://github.com/kamp-us/phoenix/issues/8716#issuecomment-5609103199

## Deviations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
