### PR TITLE
docs: campaign Diátaxis README passes flips to done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ flowchart TD
 		camp_ge_it_product_push["Geçit product push"]:::active
 		camp_lane_integrity["Lane integrity"]:::active
 		camp_epic_lanes["Epic lanes"]:::active
-		camp_di_taxis_readme_passes["Diátaxis README passes"]:::active
+		camp_di_taxis_readme_passes["Diátaxis README passes"]:::done
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::active
 		camp_phoenix_i18n["phoenix i18n"]:::active
@@ -114,7 +114,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Geçit product push | #24 | active |
 | Lane integrity | #48 | active |
 | Epic lanes | #49 | active |
-| Diátaxis README passes | #50 | active |
+| Diátaxis README passes | #50 | done |
 | Tuval | #51 | done |
 | Tuval first slice | #52 | active |
 | phoenix i18n | #53 | active |


### PR DESCRIPTION
## What

Diátaxis README passes (#50): active → done. Milestone closed at 21 closed, 0 open. Mermaid node restyled to match. `fabrika guard roadmap-guard check` is green at this head.

## Cites

- https://github.com/kamp-us/phoenix/issues/7303#issuecomment-5609165134

## Deviations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
