### PR TITLE
fix: Codex unprojected paginated fixtures read empty before resume

### DIFF
--- a/.patterns/tuval-codex.md
+++ b/.patterns/tuval-codex.md
@@ -65,13 +65,31 @@ A picker resume replays all history. A checkpoint resume compares backend rows w
 held tail, replaying changed rows and anything after its newest known ID. Clock fallback
 changes alone do not count as changed content.
 
-New threads explicitly request `historyMode: "legacy"`. In the installed 0.153.4 CLI,
-default durable threads reported paginated history but `thread/items/list` and the
-paginated `thread/read` implementation refused with not-supported errors. This is
-[tracked separately](https://github.com/kamp-us/phoenix/issues/8464); generated types are
-not proof that a runtime method works. An existing unreadable thread remains an error.
-A known fresh session returns empty history until its first accepted turn, because Codex
-does not materialize a durable legacy thread before its first user message.
+New threads explicitly request `historyMode: "legacy"`. The
+[0.153.4 history investigation](../reports/2026-09-09-codex-history-8464.md) found paginated
+history conditionally supported rather than uniformly refused: nonempty legacy history and
+*projected* paginated history both read back in full, with the paginated item IDs the rollout
+carries, while a paginated thread whose metadata row is missing refuses the read outright.
+Generated types are still not proof that a runtime method works. An existing unreadable
+thread remains an error. A known fresh session returns empty history until its first accepted
+turn, because Codex does not materialize a durable legacy thread before its first user message.
+
+**An empty paginated read is refused, not believed.** The same investigation read a known
+nonempty paginated rollout that Codex had not projected yet: `thread/read(includeTurns: true)`
+answered success with `turns: []`, and turn and item paging answered empty with null cursors,
+until an explicit resume projected it. So a successful empty answer and an exhausted cursor are
+both compatible with history the store simply has not built, and nothing else in the read-only
+protocol tells the two apart — the preview is evidence neither way, since a blank one is normal
+and a nonempty one only restates the contradiction. `readHistory` therefore trusts a zero-turn
+answer only under `historyMode: "legacy"`, whose loader replays the rollout directly; a
+paginated, absent or unrecognized mode fails as an unreadable store, carrying the session ID
+and the reason. This is fail-closed and deliberately conservative: a stored paginated session
+that really is empty is refused too, and Tuval says it could not verify the emptiness rather
+than claiming the session is empty. It detects no missing projection as such, recovers no
+data, and explains nothing about Codex's internal materialization. Read-only lookup still
+never starts, resumes or attaches anything to warm that history. The guard is shared, so the
+same refusal reaches `page` and explicit-resume replay; the known-fresh active session's empty
+page is unaffected, because that path answers before it reads the store at all.
 
 Known item types are decoded at the boundary. Unknown item kinds become bounded system
 rows instead of disappearing. Live reply updates reuse the item's ID and are optional,
@@ -151,8 +169,8 @@ successful read replaces it. Unknown activity without a spawning call is a visib
 unsupported notice. Multiple children from one spawn are refused because the shared
 slot contract is one spawning call per worker. Descendant spawns inside a child's
 transcript remain tool rows; recursive descendant navigation is not implemented.
-Ephemeral histories and runtime-unsupported paginated histories remain explicit
-refusals, including the limitation tracked in #8464. These are not claims of full
+Ephemeral histories and unprojected paginated histories remain explicit refusals,
+including the fail-closed empty-read limitation above. These are not claims of full
 native runtime parity.
 
 ## Source and checks

--- a/apps/tuval/src/codex/agent.unit.test.ts
+++ b/apps/tuval/src/codex/agent.unit.test.ts
@@ -5,7 +5,17 @@ import {foldEvent} from "../ai-agent/core/fold.ts";
 import {initialState} from "../ai-agent/core/state.ts";
 import {Mode} from "../ai-agent/ports/index.ts";
 import {TransportError, type TuvalAiAgentApi} from "../ai-agent/service/index.ts";
-import {itemMessage, modelRows, onCodex, opened, thread, turn, turnMessage} from "./fixtures.ts";
+import {
+	fixtureTurns,
+	itemMessage,
+	modelRows,
+	onCodex,
+	opened,
+	storedThread,
+	thread,
+	turn,
+	turnMessage,
+} from "./fixtures.ts";
 
 const take = (agent: TuvalAiAgentApi, count: number) =>
 	agent.events.pipe(Stream.take(count), Stream.runCollect);
@@ -400,6 +410,175 @@ describe("Codex implements TuvalAiAgent", () => {
 				);
 				expect(yield* Effect.flip(agent.sessionTranscript(query))).toMatchObject({
 					reason: "store-unreadable",
+				});
+				expect(fake.state.opened).toBe(fake.state.closed);
+			}),
+		),
+	);
+
+	it.effect.each([
+		{shape: "default-selected paginated (001)", id: "session-1"},
+		{shape: "explicit paginated (003)", id: "session-3"},
+	])("refuses the unprojected $shape fixture rather than reporting it empty", ({id}) =>
+		onCodex((agent, fake) =>
+			Effect.gen(function* () {
+				storedThread(fake, {
+					...thread,
+					id,
+					historyMode: "paginated",
+					preview: "fixture user 1",
+					turns: [],
+				});
+				const failure = yield* Effect.flip(
+					agent.sessionTranscript({cwd: thread.cwd, sessionId: id, before: null, limit: 10}),
+				);
+				expect(failure).toMatchObject({
+					reason: "store-unreadable",
+					sessionId: id,
+					detail: expect.stringContaining("cannot tell an empty session from history"),
+				});
+				expect(failure.detail).toContain("paginated");
+				expect(fake.calls.map((call) => call.method)).toEqual([
+					"thread/list",
+					"thread/list",
+					"thread/read",
+				]);
+				expect(fake.state).toEqual({opened: 1, closed: 1});
+				expect(fake.replies).toEqual([]);
+			}),
+		),
+	);
+
+	it.effect.each([
+		{mode: "paginated with a blank preview", patch: {historyMode: "paginated", preview: ""}},
+		{mode: "no reported history mode", patch: {preview: "fixture user 1"}},
+		{mode: "an unrecognized history mode", patch: {historyMode: "transcriptV2"}},
+	])("cannot certify an empty history read under $mode", ({mode, patch}) =>
+		onCodex((agent, fake) =>
+			Effect.gen(function* () {
+				const {historyMode: _reported, ...modeless} = thread;
+				storedThread(fake, {...modeless, ...patch, turns: []});
+				expect(
+					yield* Effect.flip(
+						agent.sessionTranscript({
+							cwd: thread.cwd,
+							sessionId: thread.id,
+							before: null,
+							limit: 10,
+						}),
+					),
+				).toMatchObject({
+					reason: "store-unreadable",
+					sessionId: thread.id,
+					detail: expect.stringContaining(
+						mode === "no reported history mode" ? "none reported" : "cannot tell",
+					),
+				});
+				expect(fake.calls.some((call) => call.method === "thread/resume")).toBe(false);
+				expect(fake.state).toEqual({opened: 1, closed: 1});
+			}),
+		),
+	);
+
+	it.effect("keeps the known-fresh active session's empty page, which reads no store", () =>
+		onCodex((agent, fake) =>
+			Effect.gen(function* () {
+				yield* start(agent);
+				expect(yield* agent.page(null, 10)).toEqual({items: [], hasMore: false});
+				expect(fake.calls.some((call) => call.method === "thread/read")).toBe(false);
+				yield* fake.push(turnMessage("started"));
+				yield* take(agent, 1);
+				storedThread(fake, {...thread, historyMode: "paginated", turns: []});
+				expect(yield* Effect.flip(agent.page(null, 10))).toMatchObject({
+					reason: "store-unreadable",
+					detail: expect.stringContaining("cannot tell an empty session from history"),
+				});
+				expect(fake.calls.some((call) => call.method === "turn/start")).toBe(false);
+			}),
+		),
+	);
+
+	it.effect("refuses an explicit resume whose stored paginated history reads empty", () =>
+		onCodex((agent, fake) =>
+			Effect.gen(function* () {
+				storedThread(fake, {...thread, historyMode: "paginated", turns: []});
+				expect(
+					yield* Effect.flip(
+						agent.start({
+							cwd: thread.cwd,
+							resume: {sessionId: thread.id, holdsTranscript: false},
+						}),
+					),
+				).toMatchObject({
+					reason: "transport",
+					detail: expect.stringContaining("cannot tell an empty session from history"),
+				});
+				expect(fake.calls.some((call) => call.method === "turn/start")).toBe(false);
+			}),
+		),
+	);
+
+	it.effect.each([
+		{
+			label: "legacy",
+			mode: "legacy",
+			ids: ["item-1", "item-2", "item-3", "item-4"] as const,
+		},
+		{
+			label: "projected paginated",
+			mode: "paginated",
+			ids: ["user-1", "assistant-1", "user-2", "assistant-2"] as const,
+		},
+	])("reads the four $label fixture messages oldest first, a whole turn at a time", ({mode, ids}) =>
+		onCodex((agent, fake) =>
+			Effect.gen(function* () {
+				storedThread(fake, {...thread, historyMode: mode, turns: fixtureTurns(ids)});
+				const query = {cwd: thread.cwd, sessionId: thread.id, before: null, limit: 1};
+				const newest = yield* agent.sessionTranscript(query);
+				expect(newest).toMatchObject({
+					items: [
+						{id: ids[2], text: "fixture user 2", timestamp: 4000},
+						{id: ids[3], text: "fixture assistant 2", timestamp: 4000},
+					],
+					hasMore: true,
+				});
+				expect(yield* agent.sessionTranscript({...query, before: ids[2]})).toMatchObject({
+					items: [
+						{id: ids[0], text: "fixture user 1", timestamp: 3000},
+						{id: ids[1], text: "fixture assistant 1", timestamp: 3000},
+					],
+					hasMore: false,
+				});
+				expect(yield* agent.sessionTranscript({...query, limit: 10})).toMatchObject({
+					items: ids.map((id) => ({id})),
+					hasMore: false,
+				});
+				expect(fake.calls.some((call) => call.method === "thread/resume")).toBe(false);
+				expect(fake.state.opened).toBe(fake.state.closed);
+			}),
+		),
+	);
+
+	it.effect("keeps unsupported and malformed history reads distinct from an uncertain empty", () =>
+		onCodex((agent, fake) =>
+			Effect.gen(function* () {
+				const query = {cwd: thread.cwd, sessionId: thread.id, before: null, limit: 10};
+				storedThread(fake, {...thread, turns: [{...turn("completed"), items: [{type: 23}]}]});
+				expect(yield* Effect.flip(agent.sessionTranscript(query))).toMatchObject({
+					reason: "store-unreadable",
+					detail: expect.stringContaining("SchemaError"),
+				});
+				fake.handlers.set("thread/read", () =>
+					Effect.fail(
+						new TransportError({
+							reason: "refused",
+							detail: "thread/items/list is not supported yet",
+						}),
+					),
+				);
+				expect(yield* Effect.flip(agent.sessionTranscript(query))).toMatchObject({
+					reason: "store-unreadable",
+					detail: expect.stringContaining("not supported yet"),
 				});
 				expect(fake.state.opened).toBe(fake.state.closed);
 			}),

--- a/apps/tuval/src/codex/fixtures.ts
+++ b/apps/tuval/src/codex/fixtures.ts
@@ -133,6 +133,44 @@ export const fakeCodex = Effect.gen(function* () {
 });
 export type FakeCodex = Effect.Success<typeof fakeCodex>;
 
+/** Serve one stored thread from both `thread/list` and `thread/read`, as the real store does. */
+export const storedThread = <A extends {id: string}>(fake: FakeCodex, stored: A) => {
+	fake.handlers.set("thread/list", (params) =>
+		Effect.succeed({
+			data: Schema.decodeUnknownSync(Schema.Struct({archived: Schema.Boolean}))(params).archived
+				? []
+				: [stored],
+			nextCursor: null,
+		}),
+	);
+	fake.handlers.set("thread/read", () => Effect.succeed({thread: stored}));
+	return stored;
+};
+
+/** The four messages every projected read of the investigation's fixtures returns, oldest first. */
+export const fixtureTurns = (ids: readonly [string, string, string, string]) => [
+	{
+		id: "turn-1",
+		status: "completed",
+		error: null,
+		startedAt: 3,
+		items: [
+			{type: "userMessage", id: ids[0], content: [{type: "text", text: "fixture user 1"}]},
+			{type: "agentMessage", id: ids[1], text: "fixture assistant 1"},
+		],
+	},
+	{
+		id: "turn-2",
+		status: "completed",
+		error: null,
+		startedAt: 4,
+		items: [
+			{type: "userMessage", id: ids[2], content: [{type: "text", text: "fixture user 2"}]},
+			{type: "agentMessage", id: ids[3], text: "fixture assistant 2"},
+		],
+	},
+];
+
 export const onCodex = <A, E, R>(
 	body: (agent: TuvalAiAgentApi, fake: FakeCodex) => Effect.Effect<A, E, R>,
 	options: CodexAiAgentOptions = {},

--- a/apps/tuval/src/codex/store.ts
+++ b/apps/tuval/src/codex/store.ts
@@ -82,11 +82,23 @@ export const readThread = Effect.fn("Codex.readThread")(function* (
 	return thread;
 });
 
+// A stored paginated history Codex has not projected yet answers thread/read with zero turns and
+// exhausted paging cursors, so nothing in the read-only protocol separates it from a session that
+// really is empty. Only the legacy loader's empty answer is evidence of emptiness; the thread preview
+// is evidence neither way. See reports/2026-09-09-codex-history-8464.md.
+const certifiesEmptiness = (thread: Thread) => thread.historyMode === "legacy";
+
 export const readHistory = Effect.fn("Codex.history")(function* (
 	connection: CodexConnection,
 	id: string,
 ) {
 	const thread = yield* readThread(connection, id);
+	if (thread.turns.length === 0 && !certifiesEmptiness(thread))
+		return yield* protocolError(
+			`Codex returned no turns for session ${id} under history mode ${
+				thread.historyMode ?? "none reported"
+			}; this read cannot tell an empty session from history the store has not projected`,
+		);
 	return yield* Effect.try({
 		try: () =>
 			thread.turns.flatMap((turn) =>


### PR DESCRIPTION
Codex can answer `thread/read(includeTurns: true)` with `turns: []` for a stored paginated history it has not projected yet, and its turn and item paging answer empty with null cursors too. `readHistory` trusted that answer, so Tuval could tell a user a nonempty session was empty.

`readHistory` now trusts a zero-turn answer only under `historyMode: "legacy"`, whose loader replays the rollout directly. A paginated, absent or unrecognized mode fails as an unreadable store, carrying the target session ID and a detail that says the read could not tell an empty session from history the store has not projected. The thread preview is not consulted either way: a blank one is normal, and a nonempty one only restates the contradiction.

The refusal is fail-closed and deliberately conservative. A stored paginated session that really is empty is refused too, and Tuval says it could not verify the emptiness rather than claiming the session is empty. Nothing here detects a missing projection as such, recovers its data, or explains Codex's internal materialization. The guard sits in `readHistory`, so the same refusal reaches `page` and explicit-resume replay; no read-only path starts, resumes or attaches anything to warm the history. The known-fresh active session's empty page is untouched, because it answers before it reads the store.

`.patterns/tuval-codex.md` drops the now-obsolete blanket "paginated reads refuse with not-supported" description for the merged investigation's conditional support, and states the new empty-read limitation.

Tests: `pnpm vitest run src/codex/agent.unit.test.ts src/codex/history.unit.test.ts src/codex/resume.unit.test.ts src/codex/subagents.unit.test.ts` in `apps/tuval` — 4 files, 73 tests, all passing. New regressions cover both retained unprojected paginated fixture shapes, the blank-preview and missing/unknown-mode empties, the retained legacy empty and known-fresh page results, the four-message legacy and projected-paginated controls with their own item IDs and whole-turn cursor, the resume and `page` callers, and the distinct malformed and unsupported-RPC errors. No packaged-runtime probe was run for this change, so there is no runtime evidence to record beside those deterministic results.

Fixes #8666

## Deviations

- **Scope narrowing** — **Said:** criterion 6 asks to record any isolated packaged-runtime evidence separately. **Did:** ran only the deterministic unit regressions and recorded them here; produced no packaged-runtime artifact. **Why:** the merged investigation's retained traces already supply the runtime evidence this guard is built on, and a fresh probe would add no fact the refusal depends on. **Disposition:** stated here; the criterion's packaged-runtime clause is conditional, so nothing is left unmet.
- **Known defect left unfixed** — **Said:** keep supported paginated reads unchanged. **Did:** a stored paginated session that is genuinely empty now also refuses. **Why:** the read-only protocol cannot separate it from an unprojected one, and the issue authorizes the conservative refusal. **Disposition:** stated in the PR, documented in `.patterns/tuval-codex.md`, covered by a regression test.
