### PR TITLE
fix: A Tuval feature flag stated in a config layer never reaches the node side

### DIFF
--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -101,6 +101,14 @@ the seam has to work this way: a config module is imported inside `boot`, before
 so the only thing it can name is the `scope` its kernel tools call under — the bridge itself has to
 arrive at spawn (#7958).
 
+`pi-session` is the second instance, over `Features` — the merged feature flags as a kernel service
+(`src/feature-flags.ts`). Same forcing constraint: `loadLayeredConfig` merges the layers *after*
+every config module has been evaluated, so a row built inside one is a closure that cannot read the
+merge. Before the flags rode this seam, `PiAiAgent`'s host read `featuresDefault` directly and a
+config layer stating a flag moved the browser and nothing on the node side (#8595). Any node-side
+flag reads it through `Features`; `featuresDefault` is what a caller with no config layers to merge
+gets, which is every `start` caller but `boot`.
+
 ## Which Cmds the kernel runs, and which the surface does
 
 The shell core emits eight Cmds, and the type says which side runs each: `KernelCmd` and `PageCmd`

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -840,14 +840,18 @@ not-found and the reacquire run against the loopback server on Pi's faux provide
 
 ## The Pi AI agent layer
 
-`src/pi/ai-agent/` is where Pi's protocol stops. `PiAiAgent.layer()` is a `Layer<TuvalAiAgent>` and
-requires nothing (founder ruling 4, [#7570](https://github.com/kamp-us/phoenix/issues/7570)):
-building it inside the process's scope stands up Pi's model runtime, the `PiSessionHost` over it,
-one loopback server and one client, and closing that scope closes the client, the server and every
-session exactly once. A process therefore holds no Pi value of its own — `PiAiAgentOptions` carries
-plain strings, and `agentDir` is the only path it usually sets. Nothing on that surface is a Pi
-type, and the per-launch token is unwrapped once, into the transport factory's closure, and reaches
-no event, no method's answer and no log line.
+`src/pi/ai-agent/` is where Pi's protocol stops. `PiAiAgent.layer()` is a
+`Layer<TuvalAiAgent, never, Features>`, never-failing, asking only for the merged feature-flag
+record the row's spawner provides — the same shape the Claude layer has, one service open and it is
+a Tuval one. Founder ruling 4 ([#7570](https://github.com/kamp-us/phoenix/issues/7570)) is what puts
+the runtime inside the layer, and it required nothing at all until the node-side flag route landed
+([#8595](https://github.com/kamp-us/phoenix/issues/8595)); what the ruling guards is unchanged,
+since no Pi type is named in either channel. Building it inside the process's scope stands up Pi's
+model runtime, the `PiSessionHost` over it, one loopback server and one client, and closing that
+scope closes the client, the server and every session exactly once. A process therefore holds no Pi
+value of its own — `PiAiAgentOptions` carries plain strings, and `agentDir` is the only path it
+usually sets. Nothing on that surface is a Pi type, and the per-launch token is unwrapped once, into
+the transport factory's closure, and reaches no event, no method's answer and no log line.
 
 `start({cwd, resume?})` is the caller's, not the layer's, so restore is "rebuild the layer, then
 `start({cwd, resume: sessionId})`" — and that same call is the only way back after a drop. A dropped

--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -17,6 +17,7 @@ import {type ConfigLoadError, loadLayeredConfig, type TuvalFeatures} from "./con
 import {Checkpoints} from "./durability/Checkpoints.ts";
 import {restore} from "./durability/restore.ts";
 import {fileStores} from "./durability/stores.ts";
+import {Features} from "./feature-flags.ts";
 import {type LaunchedProcess, launch} from "./launch/launch.ts";
 import {compile} from "./ports/compile.ts";
 import type {Graph} from "./ports/graph.ts";
@@ -45,6 +46,10 @@ export const projectConfig = (project: string): string =>
 
 export type Kernel =
 	| Registry
+	// The merged feature flags. A program row's layer reads what the config layers resolved through
+	// this and nothing else: the row is built while a config module is being evaluated, which is
+	// before the merge exists (#8595).
+	| Features
 	// The session-list spell's own requirement, filled from the built kernel below: the union it
 	// answers builds each backend's layer under the context a spawn of that row would run under.
 	| AiAgentSessionList
@@ -81,6 +86,11 @@ export interface StartOptions {
 	 * Absent for a caller that has no config layers to offer, which is every caller but `boot`.
 	 */
 	readonly keys?: ReadonlyArray<BindingSource>;
+	/**
+	 * The merged feature flags this kernel runs under. Absent for a caller with no config layers to
+	 * merge — every caller but `boot` — which is what `featuresDefault` means.
+	 */
+	readonly features?: TuvalFeatures;
 }
 
 export interface Started {
@@ -103,6 +113,7 @@ export const start = Effect.fn("Tuval.start")(function* ({
 	graph,
 	stateDir,
 	keys,
+	features,
 }: StartOptions) {
 	const registry = yield* Layer.build(Registry.layer(programs));
 	const compiled = yield* compile(graph).pipe(Effect.provideContext(registry));
@@ -125,7 +136,7 @@ export const start = Effect.fn("Tuval.start")(function* ({
 		),
 	);
 	const built = yield* Layer.build(
-		Layer.mergeAll(ProcessTablePort.layer, commands).pipe(
+		Layer.mergeAll(ProcessTablePort.layer, Features.layer(features), commands).pipe(
 			Layer.provideMerge(Processes.layer),
 			Layer.provideMerge(Checkpoints.layer(fileStores(stateDir))),
 			Layer.provideMerge(Layer.succeedContext(registry)),
@@ -231,7 +242,13 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 	// Config rows are trusted local code (#7484 R1.1); the loader checks each row's id, not its shape.
 	const programs = config.programs as ReadonlyArray<AnyProgram>;
 	const stateDir = projectDir(options.project);
-	const started = yield* start({programs, graph: config.graph, stateDir, keys: config.keys});
+	const started = yield* start({
+		programs,
+		graph: config.graph,
+		stateDir,
+		keys: config.keys,
+		features: config.features,
+	});
 	const live = yield* ProcessTable.use((table) => table.list).pipe(
 		Effect.provideContext(started.kernel),
 	);

--- a/apps/tuval/src/boot.unit.test.ts
+++ b/apps/tuval/src/boot.unit.test.ts
@@ -5,10 +5,20 @@ import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Schema} from "effect";
+import {Context, Effect, Layer, Schema} from "effect";
 import {afterEach, expect} from "vitest";
 import {sessionListProgram} from "./ai-agent/session-list.ts";
-import {boot, coreSpells, defaultGlobalConfig, projectConfig, projectDir} from "./boot.ts";
+import {
+	boot,
+	coreSpells,
+	defaultGlobalConfig,
+	type Kernel,
+	projectConfig,
+	projectDir,
+} from "./boot.ts";
+import {Features} from "./feature-flags.ts";
+import {featuresDefault, type TuvalFeatures} from "./features.ts";
+import {subagentExtensionPaths} from "./pi/server/index.ts";
 import {shellSpells} from "./shell/commands/spells.ts";
 
 /** Every boot registers these, whatever the config declares; no fixture program declares a spell. */
@@ -349,5 +359,73 @@ describe("boot", () => {
 			expect(result.stdout).toContain("--project");
 		},
 		spawnBudget(1),
+	);
+});
+
+/**
+ * The node-side half of the flag route (#8595). The browser half is `page/dev-server.ts`'s generated
+ * module; this half is the kernel service a program row's layer reads at spawn, and the probe below
+ * is built the way `ai-agent/backends.ts` builds a backend's layer — under the boot's own kernel
+ * context. What `PiAiAgent.layer` does with the record it gets there is `subagentExtensionPaths`,
+ * and that its `R` is this service and nothing else is pinned in
+ * `pi/ai-agent/boundary.unit.test.ts`.
+ */
+describe("the merged feature flags on the node side", () => {
+	class Probe extends Context.Service<Probe, {readonly features: TuvalFeatures}>()(
+		"tuval/test/Probe",
+	) {}
+
+	/** A layer shaped like a backend's: `Features` left open, satisfied by the spawner's kernel. */
+	const probe = Layer.effect(
+		Probe,
+		Effect.map(Features, (features) => ({features})),
+	);
+
+	const flagsAtSpawn = (booted: {readonly kernel: Context.Context<Kernel>}) =>
+		Effect.scoped(Layer.build(probe).pipe(Effect.provideContext(booted.kernel))).pipe(
+			Effect.map((built) => Context.get(built, Probe).features),
+		);
+
+	it.effect(
+		"reach a row's layer as the defaults when no layer states one",
+		() =>
+			Effect.gen(function* () {
+				const booted = yield* bootDirect(fixture("two-rows"), freshProject());
+				assert.deepStrictEqual(yield* flagsAtSpawn(booted), featuresDefault);
+			}),
+		DIRECT_BOOT_MS,
+	);
+
+	// The direction that costs something: `piSubagents` defaults on, so an operator turning it off is
+	// a project layer stating `false` over a global `true` — and before this the layer read
+	// `featuresDefault` and loaded the extension anyway.
+	it.effect(
+		"let the project layer's false beat the global layer's true",
+		() =>
+			Effect.gen(function* () {
+				const booted = yield* bootDirect(
+					fixture("pi-subagents-on"),
+					projectWithConfig("pi-subagents-off"),
+				);
+				const features = yield* flagsAtSpawn(booted);
+				assert.deepStrictEqual(features, {subagentList: true, piSubagents: false});
+				assert.deepStrictEqual(subagentExtensionPaths(features), []);
+			}),
+		DIRECT_BOOT_MS,
+	);
+
+	it.effect(
+		"let the project layer's true beat the global layer's false",
+		() =>
+			Effect.gen(function* () {
+				const booted = yield* bootDirect(
+					fixture("pi-subagents-off"),
+					projectWithConfig("pi-subagents-on"),
+				);
+				const features = yield* flagsAtSpawn(booted);
+				assert.deepStrictEqual(features, {subagentList: true, piSubagents: true});
+				assert.strictEqual(subagentExtensionPaths(features).length, 1);
+			}),
+		DIRECT_BOOT_MS,
 	);
 });

--- a/apps/tuval/src/config-fixtures/pi-subagents-off.ts
+++ b/apps/tuval/src/config-fixtures/pi-subagents-off.ts
@@ -1,0 +1,1 @@
+export default {version: 1, programs: [{id: "a"}], features: {piSubagents: false}};

--- a/apps/tuval/src/config-fixtures/pi-subagents-on.ts
+++ b/apps/tuval/src/config-fixtures/pi-subagents-on.ts
@@ -1,0 +1,1 @@
+export default {version: 1, programs: [{id: "a"}], features: {piSubagents: true}};

--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -65,6 +65,11 @@ const DeclaredFeatures = Schema.Struct({
 	 * one change — a subagent's rows leaving the agent window's transcript (#8405).
 	 */
 	subagentList: Schema.optionalKey(Schema.Boolean),
+	/**
+	 * Load the `pi-subagents` extension into a Pi session (#8555). A key missing here is a key the
+	 * decode drops, so a layer that stated it reached the browser and nothing else (#8595).
+	 */
+	piSubagents: Schema.optionalKey(Schema.Boolean),
 });
 
 export {featuresDefault, type TuvalFeatures} from "./features.ts";

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -133,6 +133,26 @@ describe("the feature flags", () => {
 			assert.deepStrictEqual(overGlobalOn.features, {subagentList: false, piSubagents: true});
 		}),
 	);
+
+	// A key the schema does not declare is a key the decode drops, so a flag missing from
+	// `DeclaredFeatures` reads as a config that stated nothing (#8595).
+	it.effect("keep a stated piSubagents rather than dropping it at the decode", () =>
+		Effect.gen(function* () {
+			const config = yield* loadConfigModule(fixture("pi-subagents-off"));
+			assert.deepStrictEqual(config.features, {piSubagents: false});
+		}),
+	);
+
+	it.effect("let a layer turn piSubagents off against its on default", () =>
+		Effect.gen(function* () {
+			const global = yield* layered(fixture("pi-subagents-off"), fixture("two-rows"));
+			assert.deepStrictEqual(global.features, {subagentList: true, piSubagents: false});
+			const project = yield* layered(fixture("two-rows"), fixture("pi-subagents-off"));
+			assert.deepStrictEqual(project.features, {subagentList: true, piSubagents: false});
+			const overGlobalOn = yield* layered(fixture("pi-subagents-on"), fixture("pi-subagents-off"));
+			assert.deepStrictEqual(overGlobalOn.features, {subagentList: true, piSubagents: false});
+		}),
+	);
 });
 
 describe("loadLayeredConfig", () => {

--- a/apps/tuval/src/feature-flags.ts
+++ b/apps/tuval/src/feature-flags.ts
@@ -1,0 +1,20 @@
+/**
+ * The merged feature flags as a kernel service, so the node side can read what a config layer
+ * stated.
+ *
+ * `./features.ts` holds the vocabulary both ends share and stays node-free, because the browser
+ * imports the generated `virtual:tuval/features` written from it (#8439). This module is the other
+ * end: the flags a boot actually resolved, carried into the kernel context `start` builds. A
+ * program row's layer declares `Features` as its leftover requirement and is handed it at spawn —
+ * the seam a Claude row already reaches `SpellBridge` through (#7951) — because a config module is
+ * evaluated before the merge exists, so a row's layer is a closure that cannot read one (#8595).
+ */
+
+import {Context, Layer} from "effect";
+import {featuresDefault, type TuvalFeatures} from "./features.ts";
+
+export class Features extends Context.Service<Features, TuvalFeatures>()("tuval/Features") {
+	/** The record a boot merged. `start` builds this; a caller with no config gets the defaults. */
+	static readonly layer = (features: TuvalFeatures = featuresDefault): Layer.Layer<Features> =>
+		Layer.succeed(Features, features);
+}

--- a/apps/tuval/src/features.ts
+++ b/apps/tuval/src/features.ts
@@ -7,7 +7,9 @@
  * Node import (#8439).
  *
  * A flag added here crosses to the page with no other edit: the generated module is written by
- * walking this record (`page/dev-server.ts`).
+ * walking this record (`page/dev-server.ts`). Reaching the node side takes two: the key has to be
+ * declared in `config.ts`'s `DeclaredFeatures`, or the decode drops it, and the reader takes the
+ * merged record off the `Features` kernel service rather than off `featuresDefault` (#8595).
  */
 
 export interface TuvalFeatures {

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -897,9 +897,10 @@ const transport = (
 /**
  * Pi's model runtime and the session host over it, created inside this layer's own Scope.
  *
- * This is what keeps ruling 4's `R` empty. The call site supplies `authPath` and `modelsPath` and
- * nothing further, so the strings on `PiAiAgentOptions` are the whole of what a process gives Pi
- * and no Pi value ever crosses back out to it. `CreateModelRuntimeOptions` does declare three
+ * This is what keeps every Pi type out of ruling 4's `R`, which holds one service and it is a
+ * Tuval one: `Features`, the merged flag record (#8595). The call site supplies `authPath` and
+ * `modelsPath` and nothing further, so the strings on `PiAiAgentOptions` are the whole of what a
+ * process gives Pi and no Pi value ever crosses back out to it. `CreateModelRuntimeOptions` does declare three
  * options that are neither a path nor a flag — `credentials`, `modelsStore` and `signal` — and
  * leaving all three unset is what keeps this seam string-only at 0.84.3
  * (`dist/core/model-runtime.d.ts:3-18`). The two paths are Pi's own, rebased on `agentDir` so an
@@ -908,7 +909,7 @@ const transport = (
  * runtime holds nothing to release — it declares no `dispose` or `close` — so it is created rather
  * than acquired.
  */
-const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost, never, Features> =>
+const host = (options: PiAiAgentOptions) =>
 	Layer.unwrap(
 		Effect.gen(function* () {
 			const agentDir = options.agentDir ?? getAgentDir();
@@ -973,12 +974,18 @@ export const PiAiAgent = {
 	/**
 	 * Ruling 4's layer (#7570): building it inside the process's Scope stands up Pi's model runtime,
 	 * the session host, the loopback server and the client, and closing that Scope tears all four
-	 * down. `R` is empty and `E` is `never`, so a process hands this to `aiAgentProgram` and holds no
-	 * Pi value of its own. A bind failure dies rather than riding the error channel: the layer is
+	 * down. `E` is `never` and `R` is `Features` alone — the merged flag record a spawn hands over
+	 * (#8595) — so a process hands this to `aiAgentProgram` and holds no Pi value of its own.
+	 *
+	 * The shape is inferred rather than annotated on purpose, and `boundary.unit.test.ts` pins it: an
+	 * annotation would declare `Features` in `R` even after a body stopped reading it, which is how a
+	 * revert to `featuresDefault` passed every gate in the round that added this.
+	 *
+	 * A bind failure dies rather than riding the error channel: the layer is
 	 * built before any handler runs, so there is no caller to hand a `ServerBindFailed` to and
 	 * nothing that could act on one — a loopback port this process cannot bind is a broken host, not
 	 * a case the row models.
 	 */
-	layer: (options: PiAiAgentOptions = {}): Layer.Layer<TuvalAiAgent, never, Features> =>
+	layer: (options: PiAiAgentOptions = {}) =>
 		aiAgentOverHost(options).pipe(Layer.provide(host(options))),
 } as const;

--- a/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
+++ b/apps/tuval/src/pi/ai-agent/PiAiAgent.ts
@@ -58,7 +58,7 @@ import {
 	type TuvalAiAgentApi,
 	UnknownRequest,
 } from "../../ai-agent/service/index.ts";
-import {featuresDefault} from "../../features.ts";
+import {Features} from "../../feature-flags.ts";
 import {PiClientService, type PiSessionRef, type SessionUpdate} from "../client/index.ts";
 import {retaining} from "../diagnostics.ts";
 import {
@@ -908,7 +908,7 @@ const transport = (
  * runtime holds nothing to release — it declares no `dispose` or `close` — so it is created rather
  * than acquired.
  */
-const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost> =>
+const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost, never, Features> =>
 	Layer.unwrap(
 		Effect.gen(function* () {
 			const agentDir = options.agentDir ?? getAgentDir();
@@ -927,10 +927,11 @@ const host = (options: PiAiAgentOptions): Layer.Layer<PiSessionHost> =>
 						}),
 					),
 			}).pipe(Effect.orDie);
-			// The `piSubagents` flag and nothing else decides this. Off — the shipped default — it is
-			// an empty list, and an empty list is the same session this layer opened before the flag
-			// existed (`../server/AgentSessionHost.ts`'s `loaderFor`).
-			const extensionPaths = subagentExtensionPaths(featuresDefault);
+			// The `piSubagents` flag and nothing else decides this, read off the merged config rather
+			// than the defaults: a layer that states it wins, in either direction (#8595). Off is an
+			// empty list, which is the same session this layer opened before the flag existed
+			// (`../server/AgentSessionHost.ts`'s `loaderFor`).
+			const extensionPaths = subagentExtensionPaths(yield* Features);
 			return agentSessionHostLayer({
 				modelRuntime,
 				agentDir,
@@ -978,6 +979,6 @@ export const PiAiAgent = {
 	 * nothing that could act on one — a loopback port this process cannot bind is a broken host, not
 	 * a case the row models.
 	 */
-	layer: (options: PiAiAgentOptions = {}): Layer.Layer<TuvalAiAgent> =>
+	layer: (options: PiAiAgentOptions = {}): Layer.Layer<TuvalAiAgent, never, Features> =>
 		aiAgentOverHost(options).pipe(Layer.provide(host(options))),
 } as const;

--- a/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
@@ -13,17 +13,20 @@ import {join} from "node:path";
 import type {Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import type {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import type {Features} from "../../feature-flags.ts";
 import type {PiServerService, PiSessionHost, ServerBindFailed} from "../server/index.ts";
 import {PiAiAgent} from "./index.ts";
 
 /**
- * Ruling 4's shape. `E` is `never` — a bind failure dies inside the layer — and `R` is empty: the
- * ruled `Scope` is the scoped layer's own and is not a requirement a `Layer` type carries, so a
- * process provides this layer nothing and holds no Pi value of its own.
+ * Ruling 4's shape. `E` is `never` — a bind failure dies inside the layer — and `R` is `Features`
+ * and nothing else: the ruled `Scope` is the scoped layer's own and is not a requirement a `Layer`
+ * type carries, and the one open requirement is the merged flag record the kernel hands over at
+ * spawn (#8595). It is a kernel service, so the boundary this file guards still holds: no Pi value
+ * crosses out and no Pi type is named in `R`.
  */
 type RuledShape<L> =
 	L extends Layer.Layer<infer A, infer E, infer R>
-		? [A, E, R] extends [TuvalAiAgent, never, never]
+		? [A, E, R] extends [TuvalAiAgent, never, Features]
 			? true
 			: false
 		: false;
@@ -31,10 +34,12 @@ type RuledShape<L> =
 const surface: RuledShape<ReturnType<typeof PiAiAgent.layer>> = true;
 
 /** The control: a layer that published the server would publish the token with it. */
-const leaksTheServer: RuledShape<Layer.Layer<TuvalAiAgent | PiServerService>> = false;
+const leaksTheServer: RuledShape<Layer.Layer<TuvalAiAgent | PiServerService, never, Features>> =
+	false;
 
 /** The second control: a departure this test used to pin, now red on the error channel. */
-const raisesTheBindFailure: RuledShape<Layer.Layer<TuvalAiAgent, ServerBindFailed>> = false;
+const raisesTheBindFailure: RuledShape<Layer.Layer<TuvalAiAgent, ServerBindFailed, Features>> =
+	false;
 
 /**
  * The third control: the departure round 1 shipped. A `PiSessionHost` in `R` is a Pi-typed

--- a/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
+++ b/apps/tuval/src/pi/ai-agent/boundary.unit.test.ts
@@ -18,6 +18,14 @@ import type {PiServerService, PiSessionHost, ServerBindFailed} from "../server/i
 import {PiAiAgent} from "./index.ts";
 
 /**
+ * Mutual assignability, and it is the whole point of this file: `extends` alone admits `never` on
+ * either side, so a one-way `[A, E, R] extends [TuvalAiAgent, never, Features]` reads `true` for a
+ * layer requiring `Features` and for one requiring nothing at all. Under that check the whole pin
+ * survived reverting the `host` line back to `featuresDefault` (#8595).
+ */
+type Exactly<X, Y> = [X] extends [Y] ? ([Y] extends [X] ? true : false) : false;
+
+/**
  * Ruling 4's shape. `E` is `never` — a bind failure dies inside the layer — and `R` is `Features`
  * and nothing else: the ruled `Scope` is the scoped layer's own and is not a requirement a `Layer`
  * type carries, and the one open requirement is the merged flag record the kernel hands over at
@@ -26,9 +34,7 @@ import {PiAiAgent} from "./index.ts";
  */
 type RuledShape<L> =
 	L extends Layer.Layer<infer A, infer E, infer R>
-		? [A, E, R] extends [TuvalAiAgent, never, Features]
-			? true
-			: false
+		? Exactly<[A, E, R], [TuvalAiAgent, never, Features]>
 		: false;
 
 const surface: RuledShape<ReturnType<typeof PiAiAgent.layer>> = true;
@@ -48,14 +54,23 @@ const raisesTheBindFailure: RuledShape<Layer.Layer<TuvalAiAgent, ServerBindFaile
  */
 const requiresTheHost: RuledShape<Layer.Layer<TuvalAiAgent, never, PiSessionHost>> = false;
 
+/**
+ * The fourth control, and the one the exact check exists for: a layer requiring nothing is not the
+ * ruled shape. It is what `host` reading `featuresDefault` again would make `PiAiAgent.layer`, so
+ * `surface` above reds at typecheck on that revert — which is what binds the node-side flag route
+ * to the real consumer's type rather than to a test's own stand-in (#8595).
+ */
+const dropsTheFlagRequirement: RuledShape<Layer.Layer<TuvalAiAgent, never, never>> = false;
+
 describe("the Pi AI agent layer's surface", () => {
 	it("is the ruled shape and provides the interface and nothing else", () => {
-		expect([surface, leaksTheServer, raisesTheBindFailure, requiresTheHost]).toEqual([
-			true,
-			false,
-			false,
-			false,
-		]);
+		expect([
+			surface,
+			leaksTheServer,
+			raisesTheBindFailure,
+			requiresTheHost,
+			dropsTheFlagRequirement,
+		]).toEqual([true, false, false, false, false]);
 	});
 
 	it("publishes one layer and its own options", () => {

--- a/apps/tuval/src/pi/program.ts
+++ b/apps/tuval/src/pi/program.ts
@@ -27,6 +27,7 @@ import type {Layer} from "effect";
 import {type AiAgentProgram, aiAgentProgram} from "../ai-agent/program.ts";
 import {AI_AGENT_INSPECTOR_REF} from "../ai-agent/renderer-ref.ts";
 import type {TuvalAiAgent} from "../ai-agent/service/index.ts";
+import type {Features} from "../feature-flags.ts";
 import {PiAiAgent, type PiAiAgentOptions} from "./ai-agent/index.ts";
 import {PI_CHAT_WINDOW_REF, PI_SESSION_PROGRAM} from "./renderer-ref.ts";
 
@@ -58,8 +59,13 @@ export interface PiSessionProgramOptions {
 	readonly layer?: Layer.Layer<TuvalAiAgent>;
 }
 
-export const piSessionProgram = (options: PiSessionProgramOptions): AiAgentProgram =>
-	aiAgentProgram({
+/**
+ * `Features` rides out unclosed, the way the Claude row leaves `SpellBridge` open (#7951): the row
+ * is built while a config module is evaluated, which is before the flags are merged, so the layer
+ * is handed the resolved record at spawn from the kernel context (#8595).
+ */
+export const piSessionProgram = (options: PiSessionProgramOptions): AiAgentProgram<Features> =>
+	aiAgentProgram<Features>({
 		id: PI_SESSION_PROGRAM,
 		layer: options.layer ?? PiAiAgent.layer({...options.pi, projectRoot: options.cwd}),
 		config: {cwd: options.cwd},


### PR DESCRIPTION
Tuval merges feature flags from the global and project config layers, but nothing on the node side
could read the merged record. `loadLayeredConfig` runs after every config module has been
evaluated, and a program row's layer is already a closure by then — so `PiAiAgent`'s host read
`featuresDefault` directly. An operator who wrote `features: {piSubagents: false}` in either layer
saw the extension load anyway. `DeclaredFeatures` did not even declare the key, so the decode
dropped it before the merge ever saw it.

Three changes:

- `config.ts` declares `piSubagents`, so a layer that states it survives the decode. Precedence is
  the existing per-key merge, unchanged.
- New `src/feature-flags.ts` holds `Features`, the merged record as a kernel service. `start` builds
  it into the kernel context (defaults when a caller has no layers to merge, which is every caller
  but `boot`); `boot` hands it `config.features`.
- `PiAiAgent`'s host reads `Features` instead of `featuresDefault`, so `PiAiAgent.layer` leaves that
  requirement open and the spawner fills it from the kernel — the same seam the `claude-session` row
  reaches `SpellBridge` through (#7951). `piSessionProgram` carries the requirement out on the row's
  type.

`features.ts` is untouched as data: no default moved, no flag was added, and the browser still gets
the same resolved record with no Node import crossing into it.

### Coverage

- `config.unit.test.ts`: a stated `piSubagents` survives the decode; a layer's `false` beats the
  `true` default, global-stated, project-stated, and project-over-global.
- `boot.unit.test.ts`: a new block boots real config layers and builds a probe layer with `Features`
  left open under the boot's kernel context — the way `ai-agent/backends.ts` builds a backend's
  layer. It pins the defaults with no layer stating anything, project `false` over global `true`
  (and `subagentExtensionPaths` answering empty), and project `true` over global `false`.
- `pi/ai-agent/boundary.unit.test.ts`: the type-level pin on the layer's shape now checks all three
  slots by mutual assignability and reads `R` as `Features` and nothing else. `extends` alone let
  `R = never` satisfy it. Its three controls are re-anchored so each still fails on the axis it was
  written for, and a fourth names the reverted shape. `PiAiAgent.layer`'s type is inferred from its
  body rather than annotated, because an annotation declares `Features` in `R` whatever the body
  reads — with both fixed, reverting `host` to `subagentExtensionPaths(featuresDefault)` reds at
  typecheck.

Ran: `src/config.unit.test.ts`, `src/boot.unit.test.ts`, `src/pi/ai-agent/boundary.unit.test.ts`,
`src/pi/server/subagents.unit.test.ts`, `src/page/dev-server.unit.test.ts`,
`src/pi/program.unit.test.ts` — all passing. `pnpm typecheck` green across all three tsconfigs.

Fixes #8595

## Deviations

- **Scope narrowing** — **Said:** criterion 4 asks for regression coverage "through the actual
  node-side layer consumer". **Did:** the boot test builds a probe layer with `Features` open under
  the boot kernel rather than building `PiAiAgent.layer` itself, and asserts
  `subagentExtensionPaths` over the record that arrives. **Why:** building the real Pi layer stands
  up a model runtime against the operator's own Pi agent-dir credentials and a loopback server, which is
  not a unit test. The probe is built exactly as `ai-agent/backends.ts` builds a backend's layer, and
  the real consumer is held by type instead: `PiAiAgent.layer`'s shape is inferred from its body and
  pinned exactly in `boundary.unit.test.ts`, so a `host` that stops reading `Features` drops it from
  `R` and reds the pin. That was verified by making the revert and watching `tsc` fail, then undoing
  it. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #8595 names the config, boot and Pi files. **Did:** also
  extended `.patterns/tuval-shell-assembly.md` with a paragraph naming `pi-session`/`Features` as the
  second instance of the satisfied-at-spawn seam, and rewrote the Pi-layer paragraph in
  `apps/tuval/README.md`, which still said the layer requires nothing. **Why:** CLAUDE.md requires a
  load-bearing pattern you rely on to be documented and the source to win when a doc disagrees with
  it; both surfaces stated the pre-change shape. **Disposition:** stated here.
