### PR TITLE
chore: The Tuval desk page binds IPv4 only, so a second server on ::1 silently takes localhost

### DIFF
--- a/.decisions/0370-desk-serves-localhost-on-both-loopback-families.md
+++ b/.decisions/0370-desk-serves-localhost-on-both-loopback-families.md
@@ -75,3 +75,11 @@ and from the `port: 0` path, where a taken `[::1]` is skipped rather than refuse
 - Two desks can still run at once: they take different ports, because `port: 0` is the default.
 - A `[::1]`-only program on a requested port now blocks the desk's start where it used to be
   invisible. That is the point: the collision is reported instead of served.
+- The forwarder ends the connections it accepted before it closes. They are adopted by the page
+  server, which is torn down after it, so waiting on them instead would never settle — and the wait
+  would land on Ctrl-C, in front of the kernel's checkpoint.
+
+## Records
+
+`no vocabulary impact` — "reservation" and "forwarder" name two values inside
+`apps/tuval/src/page/loopback.ts` and are not corpus-level terms; nothing in `.glossary/` changes.

--- a/.decisions/0370-desk-serves-localhost-on-both-loopback-families.md
+++ b/.decisions/0370-desk-serves-localhost-on-both-loopback-families.md
@@ -1,0 +1,77 @@
+---
+id: 0370
+title: The Tuval desk serves localhost on both loopback families, and refuses a requested port either one has taken
+status: accepted
+date: 2026-09-09
+tags: [tuval, page, dev-server, localhost, ports]
+---
+
+# 0370 — The Tuval desk serves localhost on both loopback families, and refuses a requested port either one has taken
+
+**What this decides:** `localhost:<port>` is the Tuval desk's supported address. The page server
+binds both loopback addresses — `127.0.0.1` and `::1` — so whichever one the browser resolves
+reaches the desk. A *requested* port that either family has already taken refuses the start, naming
+the taken address; the default `port: 0` keeps its fallback and simply picks a port free on both.
+The desk stays loopback-only: nothing here widens it to the LAN.
+
+Founder ruling: <https://github.com/kamp-us/phoenix/issues/8593#issuecomment-5609491263> — "Ruled:
+the Tuval desk page server binds both the IPv4 and IPv6 loopback addresses."
+
+## Context
+
+The incident (#8593): the desk ran on `127.0.0.1:5173` and a bare `vite` from another worktree ran
+on `[::1]:5173`. Neither failed to bind. Chrome resolved `localhost` to `::1`, so the founder opened
+his desk's URL and got the other app, with no error anywhere.
+
+The obvious fix — `host: "localhost"` — does not do it, and Vite says so in
+[`server.host`'s docs](https://vite.dev/config/server-options#server-host). The installed source
+agrees (`vite@8.1.5`, `dist/node/chunks/node.js`): `resolveHostname` returns **one** `host` string,
+`startServer` hands that one string to `httpServerStart`, and `httpServerStart` calls
+`tryBindServer(httpServer, port, host)` — one `listen`, one address. `strictPort` only stops the
+port scan; it has nothing to say about the other family.
+
+So covering both families takes an explicit second listener, and the desk's address contract has to
+say what happens when only one of them is free.
+
+## Decision
+
+1. **`localhost:<port>` is the supported desk address.** The page server binds every loopback
+   address it can, and prints the `localhost` URL — the address a founder types.
+2. **A requested port binds both families or neither.** Falling back would put the desk on some
+   other port while whatever it collided with keeps answering the URL the founder typed: the same
+   silent swap with an extra step. The refusal names the taken address (`[::1]:5173`), because that
+   is what tells the founder which program to go find.
+3. **`port: 0` keeps its fallback.** That is `pnpm dev`'s "any free port", and it now means a port
+   free on *both* families.
+4. **A family this machine does not have is not a collision.** Binding `::1` on a host with IPv6
+   switched off answers `EADDRNOTAVAIL`, and the desk serves the families it has.
+5. **Loopback only.** No wildcard host, no LAN.
+
+## Implementation
+
+- [`apps/tuval/src/page/loopback.ts`](../apps/tuval/src/page/loopback.ts) — `reserveLoopbackPort`
+  settles the port across both families before Vite exists, and `forwardLoopback` accepts on the
+  family Vite did not bind, handing each connection to the page's own `http.Server` with
+  `emit("connection", …)`. One HTTP server answers both addresses, so there is one middleware stack,
+  one HMR websocket and one module graph — a proxy would have had to re-implement all three.
+- [`apps/tuval/src/page/dev-server.ts`](../apps/tuval/src/page/dev-server.ts) — `servePage` takes the
+  reservation, hands Vite `strictPort: true` on the reserved port, binds the forwarder inside the
+  caller's `Scope`, and returns the `localhost` URL plus the addresses behind it.
+- [`apps/tuval/src/bin.ts`](../apps/tuval/src/bin.ts) — prints
+  `tuval: desk at http://localhost:<port>/ — 127.0.0.1 and [::1]` once both are bound.
+- The `strictPort` option and the pi proof's `--strict-port` flag are gone: a requested port is now
+  always bound exactly or refused, which is what that flag asked for (#7992).
+
+**The verification case** is the reported one and it is a unit test
+([`loopback.unit.test.ts`](../apps/tuval/src/page/loopback.unit.test.ts)): a listener holding
+`[::1]:<port>` makes a start on that explicit port refuse, naming `[::1]`. That is distinct from a
+collision on the desk's own bound address (`127.0.0.1:<port>`), which refuses naming `127.0.0.1`,
+and from the `port: 0` path, where a taken `[::1]` is skipped rather than refused.
+
+## Consequences
+
+- The reservation is released before Vite binds it, so a program that takes the port in that window
+  still wins the race. The loss is loud — `strictPort: true` refuses — never a silent move.
+- Two desks can still run at once: they take different ports, because `port: 0` is the default.
+- A `[::1]`-only program on a requested port now blocks the desk's start where it used to be
+  invisible. That is the point: the collision is reported instead of served.

--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -137,7 +137,7 @@
 			"prefix": "apps/tuval/src/",
 			"mount": "/tuval/pi-vertical",
 			"basePath": "/",
-			"command": "pnpm --filter @kampus/tuval proof:pi-vertical --page-port {{port}} --strict-port 1>&2",
+			"command": "pnpm --filter @kampus/tuval proof:pi-vertical --page-port {{port}} 1>&2",
 			"readyPath": "/"
 		}
 	],

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -111,14 +111,17 @@ tuval: process shell program=shell parent=- ports=- state=running@0
 tuval: process counter program=counter parent=- ports=ticks:out(count/v1) state=running@0
 tuval: process log program=log parent=counter ports=ticks:in(count/v1) state=running@0
 tuval: transport on 127.0.0.1:58319
-tuval: desk at http://127.0.0.1:5173/
+tuval: desk at http://localhost:5173/ — 127.0.0.1 and [::1]
 tuval: running — Ctrl-C stops and checkpoints
 count 1
 count 2
 ```
 
 Those are two ports on purpose — the socket and the page bind separately — and the transport admits
-the page's origin as it starts, so the browser's attach goes through (#7560).
+the page's origin as it starts, so the browser's attach goes through (#7560). The desk answers
+`localhost` on both loopback addresses, so it cannot be shadowed by another program holding the same
+port on the family it did not bind; a `--page-port` either family has taken refuses the start and
+names that address (ADR [0370](../../.decisions/0370-desk-serves-localhost-on-both-loopback-families.md)).
 
 Open that URL and the desk is yours by keyboard: `<c-b> |` and `<c-b> -` split, `<c-b> h/j/k/l`
 walk focus, `<c-b> N` makes a workspace and `<c-b> <c-h>` / `<c-b> <c-l>` walk them, `<c-b> z`

--- a/apps/tuval/src/bin.ts
+++ b/apps/tuval/src/bin.ts
@@ -18,6 +18,7 @@ import {Command, Flag} from "effect/unstable/cli";
 import {boot, defaultGlobalConfig} from "./boot.ts";
 import {renderBindingErrors} from "./commands/bindings/index.ts";
 import {servePage} from "./page/dev-server.ts";
+import {displayHost} from "./page/loopback.ts";
 import {serveDesk} from "./shell/host/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 import type {TableRow} from "./table/row.ts";
@@ -106,7 +107,11 @@ const tuval = Command.make(
 			// a module its renderer table imports, and that is the only way a flag an operator turned
 			// on in their config reaches the browser (#8439).
 			yield* servePage({root: appRoot, transport, port: pagePort, moduleRenderers, features}).pipe(
-				Effect.flatMap((page) => Console.log(`tuval: desk at ${page.url}`)),
+				Effect.flatMap((page) =>
+					// The localhost URL, and the addresses behind it: whichever family the browser resolves
+					// reaches this desk, and the founder can see that it does (ADR 0370, #8593).
+					Console.log(`tuval: desk at ${page.url} — ${page.hosts.map(displayHost).join(" and ")}`),
+				),
 				Effect.catch((error) => Console.error(`tuval: ${error.message}`)),
 			);
 		}

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -22,6 +22,7 @@ import {Effect, Schema} from "effect";
 import {featuresDefault, type TuvalFeatures} from "../features.ts";
 import type {TransportServer} from "../shell/transport/server.ts";
 import type {ModuleRendererRef} from "../shell/window/index.ts";
+import {forwardLoopback, LOOPBACK_HOSTS, reserveLoopbackPort} from "./loopback.ts";
 
 /** The page did not start. The kernel is unaffected — the bin reports this and keeps running. */
 export class PageServerFailed extends Schema.TaggedError<PageServerFailed>()(
@@ -45,16 +46,13 @@ export interface PageServerOptions {
 	 * than its URL is what makes those two one act, so a served page's origin is never unadmitted.
 	 */
 	readonly transport: TransportServer;
-	/** `0` picks a free port, which is what a second `pnpm dev` on one machine needs. */
-	readonly port: number;
 	/**
-	 * Bind `port` or fail. A caller that was *handed* a port — the render harness allocates one and
-	 * builds the origin it will screenshot from it — needs the loud failure: falling back to the next
-	 * free port leaves that origin pointing at whatever else answers there, which on a machine running
-	 * several worktrees is a green capture of another tree (#7992). A caller that asked for `0` is
-	 * unaffected either way, so the default stays the forgiving one for `pnpm dev`.
+	 * `0` picks a free port, which is what a second `pnpm dev` on one machine needs. Any other port
+	 * is bound on every loopback address or refused (ADR 0370) — the loud failure a caller that was
+	 * *handed* a port needs, since falling back leaves the origin it built pointing at whatever else
+	 * answers there (#7992).
 	 */
-	readonly strictPort?: boolean;
+	readonly port: number;
 	/**
 	 * The `kind: "module"` renderer specifiers the booted rows declared (`moduleRendererRefs`,
 	 * `../shell/window/renderer.ts`), each beside the config module that declared it (ADR 0359, as
@@ -71,10 +69,12 @@ export interface PageServerOptions {
 }
 
 export interface PageServer {
-	/** What the founder opens. */
+	/** What the founder opens: `localhost`, which every bound loopback address answers. */
 	readonly url: string;
 	/** The port `url` names — the port whose loopback origins the transport now admits. */
 	readonly port: number;
+	/** The loopback addresses serving that URL, in `LOOPBACK_HOSTS` order. */
+	readonly hosts: ReadonlyArray<string>;
 }
 
 export const LAUNCH_ENDPOINT = "/__tuval/launch";
@@ -381,6 +381,10 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 		options.root,
 		options.moduleRenderers ?? [],
 	);
+	// Both loopback families are settled before Vite is created: the port it is handed is one every
+	// family this machine has is free on, and a collision on a requested port refuses here, naming
+	// the address that is taken (ADR 0370).
+	const reservation = yield* attempt(() => reserveLoopbackPort(options.port));
 	const server = yield* Effect.acquireRelease(
 		attempt(() =>
 			createServer({
@@ -394,9 +398,11 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 					react.default(),
 				],
 				server: {
-					port: options.port,
-					strictPort: options.strictPort ?? false,
-					host: "127.0.0.1",
+					port: reservation.port,
+					// The reservation is what picked this port, so moving off it would only land somewhere
+					// the other family was never checked on.
+					strictPort: true,
+					host: LOOPBACK_HOSTS[0],
 					// A program installed beside the user's config is outside the app's workspace, and
 					// Vite's default allowance is that workspace alone — so the page would resolve the
 					// module and then refuse to serve it. The workspace stays in the list: the app's own
@@ -419,17 +425,34 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 		(dev) => Effect.ignore(attempt(() => dev.close())),
 	);
 	yield* attempt(() => server.listen());
-	const url = server.resolvedUrls?.local[0];
-	if (url === undefined) {
+	const bound = server.resolvedUrls?.local[0];
+	if (bound === undefined) {
 		return yield* new PageServerFailed({cause: new Error("it bound no local address")});
 	}
-	const port = Number(new URL(url).port);
+	const local = new URL(bound);
+	const port = Number(local.port);
 	if (!Number.isInteger(port) || port === 0) {
-		return yield* new PageServerFailed({cause: new Error(`its local URL names no port: ${url}`)});
+		return yield* new PageServerFailed({cause: new Error(`its local URL names no port: ${bound}`)});
 	}
+	const httpServer = server.httpServer;
+	if (httpServer === null) {
+		return yield* new PageServerFailed({cause: new Error("it serves no HTTP server to attach to")});
+	}
+	// Vite listens on one address (`resolveHostname` → `httpServerStart`), so every other loopback
+	// address gets an accepting socket of its own handing connections to that same server.
+	for (const host of reservation.hosts.filter((host) => host !== LOOPBACK_HOSTS[0])) {
+		yield* Effect.acquireRelease(
+			attempt(() => forwardLoopback(httpServer, host, port)),
+			(socket) => Effect.ignore(attempt(() => new Promise((done) => socket.close(done)))),
+		);
+	}
+	// `localhost` is the desk's address, and it is only honest once every family is bound: the whole
+	// point of ADR 0370 is that whichever one the browser resolves reaches this server.
+	local.hostname = "localhost";
+	const url = local.toString();
 	// The browser's upgrade carries this server's origin, not the socket's, and a fence built from
 	// the socket's port alone refuses it (#7560). Done here so no caller can serve a page and forget.
 	options.transport.admitLoopbackPort(port);
 	yield* warmPageGraph(server, options.root);
-	return {url, port} satisfies PageServer;
+	return {url, port, hosts: reservation.hosts} satisfies PageServer;
 });

--- a/apps/tuval/src/page/dev-server.ts
+++ b/apps/tuval/src/page/dev-server.ts
@@ -22,7 +22,7 @@ import {Effect, Schema} from "effect";
 import {featuresDefault, type TuvalFeatures} from "../features.ts";
 import type {TransportServer} from "../shell/transport/server.ts";
 import type {ModuleRendererRef} from "../shell/window/index.ts";
-import {forwardLoopback, LOOPBACK_HOSTS, reserveLoopbackPort} from "./loopback.ts";
+import {forwardLoopback, reserveLoopbackPort} from "./loopback.ts";
 
 /** The page did not start. The kernel is unaffected — the bin reports this and keeps running. */
 export class PageServerFailed extends Schema.TaggedError<PageServerFailed>()(
@@ -73,7 +73,7 @@ export interface PageServer {
 	readonly url: string;
 	/** The port `url` names — the port whose loopback origins the transport now admits. */
 	readonly port: number;
-	/** The loopback addresses serving that URL, in `LOOPBACK_HOSTS` order. */
+	/** The loopback addresses serving that URL: the one Vite bound, then each forwarded one. */
 	readonly hosts: ReadonlyArray<string>;
 }
 
@@ -402,7 +402,7 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 					// The reservation is what picked this port, so moving off it would only land somewhere
 					// the other family was never checked on.
 					strictPort: true,
-					host: LOOPBACK_HOSTS[0],
+					host: reservation.host,
 					// A program installed beside the user's config is outside the app's workspace, and
 					// Vite's default allowance is that workspace alone — so the page would resolve the
 					// module and then refuse to serve it. The workspace stays in the list: the app's own
@@ -440,10 +440,10 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 	}
 	// Vite listens on one address (`resolveHostname` → `httpServerStart`), so every other loopback
 	// address gets an accepting socket of its own handing connections to that same server.
-	for (const host of reservation.hosts.filter((host) => host !== LOOPBACK_HOSTS[0])) {
+	for (const host of reservation.forwards) {
 		yield* Effect.acquireRelease(
 			attempt(() => forwardLoopback(httpServer, host, port)),
-			(socket) => Effect.ignore(attempt(() => new Promise((done) => socket.close(done)))),
+			(forwarder) => Effect.ignore(attempt(() => forwarder.close())),
 		);
 	}
 	// `localhost` is the desk's address, and it is only honest once every family is bound: the whole
@@ -454,5 +454,9 @@ export const servePage = Effect.fn("Tuval.page.serve")(function* (options: PageS
 	// the socket's port alone refuses it (#7560). Done here so no caller can serve a page and forget.
 	options.transport.admitLoopbackPort(port);
 	yield* warmPageGraph(server, options.root);
-	return {url, port, hosts: reservation.hosts} satisfies PageServer;
+	return {
+		url,
+		port,
+		hosts: [reservation.host, ...reservation.forwards],
+	} satisfies PageServer;
 });

--- a/apps/tuval/src/page/loopback.ts
+++ b/apps/tuval/src/page/loopback.ts
@@ -56,20 +56,41 @@ const freePort = (host: string): Promise<number> =>
 		});
 	});
 
-/** Which loopback addresses this machine can serve, and the port every one of them is free on. */
+/**
+ * One port, free on every loopback family this machine has. The families are split into the one the
+ * page server binds itself and the rest, because that is the split the caller acts on — and it
+ * leaves no way to state "bind this family" for a family the reservation never cleared.
+ */
 export interface LoopbackReservation {
 	readonly port: number;
-	/** The addresses to bind, in `LOOPBACK_HOSTS` order, minus any family this machine lacks. */
-	readonly hosts: ReadonlyArray<string>;
+	/** The address the page server binds. Never a family this machine lacks. */
+	readonly host: string;
+	/** The remaining addresses, each needing an accepting socket of its own. */
+	readonly forwards: ReadonlyArray<string>;
 }
 
+const reservationOf = (port: number, hosts: ReadonlyArray<string>): LoopbackReservation => {
+	const [host, ...forwards] = hosts;
+	if (host === undefined) throw new Error("this machine has no loopback address to bind");
+	return {port, host, forwards};
+};
+
+/** The families this machine has at all: binding port 0 on one it lacks answers `absent`. */
+const presentHosts = async (): Promise<ReadonlyArray<string>> => {
+	const present: Array<string> = [];
+	for (const host of LOOPBACK_HOSTS) {
+		if ((await availability(host, 0)) !== "absent") present.push(host);
+	}
+	return present;
+};
+
 /**
- * Reserve one port across both loopback families.
+ * Reserve one port across every loopback family.
  *
- * A requested port binds both families or neither: falling back would put the desk on a port the
- * founder did not ask for while whatever they collided with keeps answering the URL they typed,
- * which is the silent swap of #8593 with an extra step. A requested `0` is `pnpm dev`'s ask for
- * "any free port" and keeps its fallback — here that means retrying until one port is free on both.
+ * A requested port binds them all or none: falling back would put the desk on a port the founder did
+ * not ask for while whatever they collided with keeps answering the URL they typed, which is the
+ * silent swap of #8593 with an extra step. A requested `0` is `pnpm dev`'s ask for "any free port"
+ * and keeps its fallback — here that means retrying until one port is free on every family.
  *
  * The reservation is released before it is used, so a program that binds the port in between still
  * wins the race. That loss is loud: the page server binds `strictPort`, so it refuses rather than
@@ -87,18 +108,21 @@ export const reserveLoopbackPort = async (requested: number): Promise<LoopbackRe
 			}
 			if (state === "free") hosts.push(host);
 		}
-		return {port: requested, hosts};
+		return reservationOf(requested, hosts);
 	}
+	const present = await presentHosts();
+	const [first, ...rest] = present;
+	if (first === undefined) throw new Error("this machine has no loopback address to bind");
 	for (let attempt = 0; attempt < FREE_PORT_ATTEMPTS; attempt++) {
-		const port = await freePort(LOOPBACK_HOSTS[0]);
-		const hosts: Array<string> = [LOOPBACK_HOSTS[0]];
-		const other = await availability(LOOPBACK_HOSTS[1], port);
-		if (other === "taken") continue;
-		if (other === "free") hosts.push(LOOPBACK_HOSTS[1]);
-		return {port, hosts};
+		const port = await freePort(first);
+		const taken: Array<string> = [];
+		for (const host of rest) {
+			if ((await availability(host, port)) === "taken") taken.push(host);
+		}
+		if (taken.length === 0) return reservationOf(port, present);
 	}
 	throw new Error(
-		`no port was free on both ${displayHost(LOOPBACK_HOSTS[0])} and ${displayHost(LOOPBACK_HOSTS[1])} after ${FREE_PORT_ATTEMPTS} tries`,
+		`no port was free on ${present.map(displayHost).join(" and ")} after ${FREE_PORT_ATTEMPTS} tries`,
 	);
 };
 
@@ -107,25 +131,50 @@ export interface ConnectionSink {
 	emit(event: "connection", socket: Socket): boolean;
 }
 
+/** An accepting socket on one loopback address, and the way to take it down. */
+export interface LoopbackForwarder {
+	/** Stop accepting, end what was accepted, and settle. */
+	readonly close: () => Promise<void>;
+}
+
 /**
  * Accept on `host:port` and hand every connection to `target`.
  *
  * `emit("connection", socket)` is how an `http.Server` adopts a socket it did not accept: it runs
  * the same connection listener the server's own socket would, so requests, `upgrade` events and the
  * HMR websocket all behave as they do on the address Vite bound itself.
+ *
+ * The forwarder destroys what it accepted before it closes, because `net.Server.close` settles only
+ * once every accepted connection has ended. The connections here are adopted by `target`, which is
+ * torn down after this one, so waiting on them alone would wait forever — an open HMR websocket is a
+ * browser tab, and the hang lands on Ctrl-C, in front of the kernel's checkpoint (#8804).
  */
 export const forwardLoopback = (
 	target: ConnectionSink,
 	host: string,
 	port: number,
-): Promise<NetServer> =>
+): Promise<LoopbackForwarder> =>
 	new Promise((resolve, reject) => {
+		const accepted = new Set<Socket>();
 		// The handler is registered with the server rather than after it listens: a connection that
 		// arrives in between would otherwise be accepted and dropped.
-		const socket = createServer((connection) => target.emit("connection", connection));
+		const socket: NetServer = createServer((connection) => {
+			accepted.add(connection);
+			connection.once("close", () => accepted.delete(connection));
+			target.emit("connection", connection);
+		});
 		socket.once("error", (error) => {
 			socket.close();
 			reject(error);
 		});
-		socket.listen({host, port}, () => resolve(socket));
+		socket.listen({host, port}, () =>
+			resolve({
+				close: () =>
+					new Promise((done) => {
+						for (const connection of accepted) connection.destroy();
+						accepted.clear();
+						socket.close(() => done());
+					}),
+			}),
+		);
 	});

--- a/apps/tuval/src/page/loopback.ts
+++ b/apps/tuval/src/page/loopback.ts
@@ -1,0 +1,131 @@
+/**
+ * `localhost` on both loopback addresses — the desk's supported address (ADR 0370, #8593).
+ *
+ * A browser resolving `localhost` may pick `::1` or `127.0.0.1`, and Vite binds exactly one of them:
+ * `resolveHostname` turns `server.host` into a single name and `httpServerStart` hands that one name
+ * to `tryBindServer` (`vite/dist/node/chunks/node.js` at the installed 8.1.5). So a desk on
+ * `127.0.0.1:5173` leaves `[::1]:5173` free for any other program, and the founder's `localhost`
+ * lands there instead, with nothing failing anywhere.
+ *
+ * The fix is not a second HTTP server but a second accepting socket: a `net.Server` on the other
+ * family hands each connection to the page's own `http.Server` with `emit("connection", …)`, so one
+ * server — one middleware stack, one HMR websocket, one module graph — answers both addresses.
+ */
+
+import {createServer, type Server as NetServer, type Socket} from "node:net";
+
+/** The two addresses `localhost` resolves to. The first is the one Vite itself binds. */
+export const LOOPBACK_HOSTS = ["127.0.0.1", "::1"] as const;
+
+/** How many free ports to try before giving up, on the `port: 0` path only. */
+const FREE_PORT_ATTEMPTS = 10;
+
+/** A host as a URL authority writes it, which is the spelling an error message has to carry. */
+export const displayHost = (host: string): string => (host.includes(":") ? `[${host}]` : host);
+
+type Availability = "free" | "taken" | "absent";
+
+/**
+ * `absent` is a machine with that address family switched off: binding it answers `EADDRNOTAVAIL`
+ * (or `EAFNOSUPPORT`), which is not a collision and must not refuse the desk — there is no second
+ * family for anything to hide on.
+ */
+const availability = (host: string, port: number): Promise<Availability> =>
+	new Promise((resolve, reject) => {
+		const socket = createServer();
+		socket.once("error", (error: NodeJS.ErrnoException) => {
+			socket.close();
+			if (error.code === "EADDRINUSE") resolve("taken");
+			else if (error.code === "EADDRNOTAVAIL" || error.code === "EAFNOSUPPORT") resolve("absent");
+			else reject(error);
+		});
+		socket.listen({host, port}, () => socket.close(() => resolve("free")));
+	});
+
+/** A port the kernel picked as free on `host`, released again before it is returned. */
+const freePort = (host: string): Promise<number> =>
+	new Promise((resolve, reject) => {
+		const socket = createServer();
+		socket.once("error", reject);
+		socket.listen({host, port: 0}, () => {
+			const address = socket.address();
+			const port = typeof address === "object" && address !== null ? address.port : 0;
+			socket.close(() =>
+				port === 0 ? reject(new Error("the kernel named no port")) : resolve(port),
+			);
+		});
+	});
+
+/** Which loopback addresses this machine can serve, and the port every one of them is free on. */
+export interface LoopbackReservation {
+	readonly port: number;
+	/** The addresses to bind, in `LOOPBACK_HOSTS` order, minus any family this machine lacks. */
+	readonly hosts: ReadonlyArray<string>;
+}
+
+/**
+ * Reserve one port across both loopback families.
+ *
+ * A requested port binds both families or neither: falling back would put the desk on a port the
+ * founder did not ask for while whatever they collided with keeps answering the URL they typed,
+ * which is the silent swap of #8593 with an extra step. A requested `0` is `pnpm dev`'s ask for
+ * "any free port" and keeps its fallback — here that means retrying until one port is free on both.
+ *
+ * The reservation is released before it is used, so a program that binds the port in between still
+ * wins the race. That loss is loud: the page server binds `strictPort`, so it refuses rather than
+ * moving.
+ */
+export const reserveLoopbackPort = async (requested: number): Promise<LoopbackReservation> => {
+	if (requested !== 0) {
+		const hosts: Array<string> = [];
+		for (const host of LOOPBACK_HOSTS) {
+			const state = await availability(host, requested);
+			if (state === "taken") {
+				throw new Error(
+					`port ${requested} is already taken on ${displayHost(host)} — the desk answers localhost on every loopback address it can, so it binds them all or none`,
+				);
+			}
+			if (state === "free") hosts.push(host);
+		}
+		return {port: requested, hosts};
+	}
+	for (let attempt = 0; attempt < FREE_PORT_ATTEMPTS; attempt++) {
+		const port = await freePort(LOOPBACK_HOSTS[0]);
+		const hosts: Array<string> = [LOOPBACK_HOSTS[0]];
+		const other = await availability(LOOPBACK_HOSTS[1], port);
+		if (other === "taken") continue;
+		if (other === "free") hosts.push(LOOPBACK_HOSTS[1]);
+		return {port, hosts};
+	}
+	throw new Error(
+		`no port was free on both ${displayHost(LOOPBACK_HOSTS[0])} and ${displayHost(LOOPBACK_HOSTS[1])} after ${FREE_PORT_ATTEMPTS} tries`,
+	);
+};
+
+/** Whatever adopts the socket: Vite's server is an `http.Server` or an HTTP/2 one. */
+export interface ConnectionSink {
+	emit(event: "connection", socket: Socket): boolean;
+}
+
+/**
+ * Accept on `host:port` and hand every connection to `target`.
+ *
+ * `emit("connection", socket)` is how an `http.Server` adopts a socket it did not accept: it runs
+ * the same connection listener the server's own socket would, so requests, `upgrade` events and the
+ * HMR websocket all behave as they do on the address Vite bound itself.
+ */
+export const forwardLoopback = (
+	target: ConnectionSink,
+	host: string,
+	port: number,
+): Promise<NetServer> =>
+	new Promise((resolve, reject) => {
+		// The handler is registered with the server rather than after it listens: a connection that
+		// arrives in between would otherwise be accepted and dropped.
+		const socket = createServer((connection) => target.emit("connection", connection));
+		socket.once("error", (error) => {
+			socket.close();
+			reject(error);
+		});
+		socket.listen({host, port}, () => resolve(socket));
+	});

--- a/apps/tuval/src/page/loopback.unit.test.ts
+++ b/apps/tuval/src/page/loopback.unit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The reservation, against real sockets — the incident of #8593 reproduced: a program holding
+ * `[::1]:<port>` while the desk is asked for that same port. A fake would pin nothing here, because
+ * what is being tested is which addresses the kernel says are free.
+ */
+
+import {createServer, type Server} from "node:net";
+import {afterEach, describe, expect, it} from "vitest";
+import {displayHost, forwardLoopback, LOOPBACK_HOSTS, reserveLoopbackPort} from "./loopback.ts";
+
+const open: Array<Server> = [];
+
+const listen = (host: string, port: number): Promise<Server> =>
+	new Promise((resolve, reject) => {
+		const socket = createServer();
+		open.push(socket);
+		socket.once("error", reject);
+		socket.listen({host, port}, () => resolve(socket));
+	});
+
+const portOf = (socket: Server): number => {
+	const address = socket.address();
+	if (typeof address !== "object" || address === null) throw new Error("no port");
+	return address.port;
+};
+
+afterEach(async () => {
+	await Promise.all(open.splice(0).map((socket) => new Promise((done) => socket.close(done))));
+});
+
+describe("reserving a requested port", () => {
+	it("refuses when another program holds it on ::1 only, naming that address", async () => {
+		const squatter = await listen("::1", 0);
+		const port = portOf(squatter);
+		await expect(reserveLoopbackPort(port)).rejects.toThrow(
+			`port ${port} is already taken on [::1]`,
+		);
+	});
+
+	it("refuses when another program holds it on 127.0.0.1 only, naming that address", async () => {
+		const squatter = await listen("127.0.0.1", 0);
+		const port = portOf(squatter);
+		await expect(reserveLoopbackPort(port)).rejects.toThrow(
+			`port ${port} is already taken on 127.0.0.1`,
+		);
+	});
+
+	it("hands back the requested port, with both families to bind, when nobody holds it", async () => {
+		const free = await listen("127.0.0.1", 0);
+		const port = portOf(free);
+		await new Promise((done) => free.close(done));
+		expect(await reserveLoopbackPort(port)).toEqual({port, hosts: [...LOOPBACK_HOSTS]});
+	});
+});
+
+describe("reserving a free port", () => {
+	it("keeps its fallback: a port taken on ::1 is skipped rather than refused", async () => {
+		const squatter = await listen("::1", 0);
+		const reserved = await reserveLoopbackPort(0);
+		expect(reserved.port).not.toBe(portOf(squatter));
+		expect(reserved.hosts).toEqual([...LOOPBACK_HOSTS]);
+	});
+});
+
+describe("the forwarded address", () => {
+	it("is answered by the server that bound the other family", async () => {
+		const {createServer: createHttpServer} = await import("node:http");
+		const app = createHttpServer((_request, response) => response.end("desk"));
+		const reserved = await reserveLoopbackPort(0);
+		await new Promise<void>((done) =>
+			app.listen({host: LOOPBACK_HOSTS[0], port: reserved.port}, () => done()),
+		);
+		const forwarder = await forwardLoopback(app, LOOPBACK_HOSTS[1], reserved.port);
+		try {
+			const answered = await fetch(`http://[::1]:${reserved.port}/`).then((r) => r.text());
+			expect(answered).toBe("desk");
+		} finally {
+			await new Promise((done) => forwarder.close(done));
+			await new Promise((done) => app.close(done));
+		}
+	});
+});
+
+describe("displayHost", () => {
+	it("brackets an IPv6 address, so a message reads as a URL authority", () => {
+		expect(displayHost("::1")).toBe("[::1]");
+		expect(displayHost("127.0.0.1")).toBe("127.0.0.1");
+	});
+});

--- a/apps/tuval/src/page/loopback.unit.test.ts
+++ b/apps/tuval/src/page/loopback.unit.test.ts
@@ -4,7 +4,7 @@
  * what is being tested is which addresses the kernel says are free.
  */
 
-import {createServer, type Server} from "node:net";
+import {connect, createServer, type Server} from "node:net";
 import {afterEach, describe, expect, it} from "vitest";
 import {displayHost, forwardLoopback, LOOPBACK_HOSTS, reserveLoopbackPort} from "./loopback.ts";
 
@@ -49,7 +49,11 @@ describe("reserving a requested port", () => {
 		const free = await listen("127.0.0.1", 0);
 		const port = portOf(free);
 		await new Promise((done) => free.close(done));
-		expect(await reserveLoopbackPort(port)).toEqual({port, hosts: [...LOOPBACK_HOSTS]});
+		expect(await reserveLoopbackPort(port)).toEqual({
+			port,
+			host: LOOPBACK_HOSTS[0],
+			forwards: [LOOPBACK_HOSTS[1]],
+		});
 	});
 });
 
@@ -58,24 +62,55 @@ describe("reserving a free port", () => {
 		const squatter = await listen("::1", 0);
 		const reserved = await reserveLoopbackPort(0);
 		expect(reserved.port).not.toBe(portOf(squatter));
-		expect(reserved.hosts).toEqual([...LOOPBACK_HOSTS]);
+		expect(reserved.host).toBe(LOOPBACK_HOSTS[0]);
+		expect(reserved.forwards).toEqual([LOOPBACK_HOSTS[1]]);
 	});
 });
 
 describe("the forwarded address", () => {
-	it("is answered by the server that bound the other family", async () => {
+	/** A page server on the reserved host, plus the forwarder on the family it did not bind. */
+	const served = async (answer: string) => {
 		const {createServer: createHttpServer} = await import("node:http");
-		const app = createHttpServer((_request, response) => response.end("desk"));
+		const app = createHttpServer((_request, response) => response.end(answer));
 		const reserved = await reserveLoopbackPort(0);
 		await new Promise<void>((done) =>
-			app.listen({host: LOOPBACK_HOSTS[0], port: reserved.port}, () => done()),
+			app.listen({host: reserved.host, port: reserved.port}, () => done()),
 		);
-		const forwarder = await forwardLoopback(app, LOOPBACK_HOSTS[1], reserved.port);
+		const forwarder = await forwardLoopback(app, reserved.forwards[0] ?? "::1", reserved.port);
+		return {app, forwarder, port: reserved.port};
+	};
+
+	it("is answered by the server that bound the other family", async () => {
+		const {app, forwarder, port} = await served("desk");
 		try {
-			const answered = await fetch(`http://[::1]:${reserved.port}/`).then((r) => r.text());
-			expect(answered).toBe("desk");
+			expect(await fetch(`http://[::1]:${port}/`).then((r) => r.text())).toBe("desk");
 		} finally {
-			await new Promise((done) => forwarder.close(done));
+			await forwarder.close();
+			await new Promise((done) => app.close(done));
+		}
+	});
+
+	/**
+	 * The stop the desk actually takes on Ctrl-C: the browser's HMR socket is open on the forwarded
+	 * family, and the page server it was handed to closes *after* this one. A release that waited on
+	 * those connections would wait forever (#8804).
+	 */
+	it("settles its close while a connection is still open", async () => {
+		const {app, forwarder, port} = await served("desk");
+		const held = connect(port, "::1");
+		await new Promise<void>((done) => {
+			held.once("connect", () =>
+				held.write(`GET / HTTP/1.1\r\nHost: localhost:${port}\r\nConnection: keep-alive\r\n\r\n`),
+			);
+			held.once("data", () => done());
+		});
+		try {
+			await Promise.race([
+				forwarder.close(),
+				new Promise((_, fail) => setTimeout(() => fail(new Error("close never settled")), 2000)),
+			]);
+		} finally {
+			held.destroy();
 			await new Promise((done) => app.close(done));
 		}
 	});

--- a/apps/tuval/src/pi/proof/serve.ts
+++ b/apps/tuval/src/pi/proof/serve.ts
@@ -29,23 +29,17 @@ const proof = Command.make(
 			Flag.withDescription("Port for the page (default: a free one)"),
 			Flag.withDefault(0),
 		),
-		strictPort: Flag.boolean("strict-port").pipe(
-			Flag.withDescription(
-				"Bind --page-port exactly or fail the start, instead of falling back to the next free port",
-			),
-			Flag.withDefault(false),
-		),
 	},
-	Effect.fn(function* ({pagePort, strictPort}) {
+	Effect.fn(function* ({pagePort}) {
 		const vertical = yield* bootChattedVertical({prompts: [PROMPT_1, PROMPT_2]});
 		const transport = yield* serveDesk({
 			kernel: vertical.kernel,
 			port: 0,
 			table: defaultPrefixTable,
 		});
-		const page = yield* servePage({root: appRoot, transport, port: pagePort, strictPort}).pipe(
-			Effect.orDie,
-		);
+		// A named `--page-port` binds exactly that port on every loopback address or refuses the start
+		// (ADR 0370), which is the guarantee the screenshot origin this harness prints needs (#7992).
+		const page = yield* servePage({root: appRoot, transport, port: pagePort}).pipe(Effect.orDie);
 		yield* Console.log(`pi-vertical proof: project ${vertical.project}`);
 		yield* Console.log(
 			`pi-vertical proof: process ${vertical.agent.id}, ${vertical.replies()} reply(ies) on the tail`,


### PR DESCRIPTION
The desk's page server bound `127.0.0.1` only, so another program could hold `[::1]:5173` and the
browser's `localhost` landed there instead — which is what happened in #8593: the founder opened his
desk URL and got a stranger's Vite server, with nothing failing anywhere.

`localhost:<port>` is now the desk's supported address, and it is bound on both loopback families.
The founder ruling that decides this is
https://github.com/kamp-us/phoenix/issues/8593#issuecomment-5609491263, recorded as ADR 0370.

**Why not `host: "localhost"`.** It does not bind both families. At the installed `vite@8.1.5`
(`dist/node/chunks/node.js`), `resolveHostname` returns one `host` string, `startServer` hands that
one string to `httpServerStart`, and `httpServerStart` calls `tryBindServer(httpServer, port, host)`
— a single `listen` on a single address. `strictPort` only stops the port scan.

**What binds the second family.** `apps/tuval/src/page/loopback.ts` reserves a port free on every
loopback family this machine has, then accepts on the family Vite did not bind with a `net.Server`
that hands each connection to the page's own HTTP server (`emit("connection", socket)`). One server
answers both addresses, so there is one middleware stack, one HMR websocket and one module graph.
The forwarder ends the connections it accepted before it closes: they are adopted by the page
server, which is torn down after it, so waiting on them instead would never settle and the wait
would land on Ctrl-C, in front of the kernel's checkpoint.

**The port contract.** A requested `--page-port` binds every available family or refuses the start,
naming the taken address (`port 5173 is already taken on [::1]`). The default `port: 0` keeps its
fallback and picks a port free on all of them. A family this machine lacks is not a collision, and
the reservation names the host the page server binds, so a host without IPv4 loopback binds `::1`.
Loopback only; nothing widens to the LAN. `bin.ts` prints
`tuval: desk at http://localhost:<port>/ — 127.0.0.1 and [::1]`.

Two cases are pinned as unit tests against real sockets: a listener on `[::1]` makes an
explicit-port start refuse (distinct from a collision on `127.0.0.1`, and from the `port: 0` path
where a taken `[::1]` is skipped), and the forwarder's close settles with a keep-alive connection
still open.

Tests: `apps/tuval` unit suites for `page/loopback` and `page/dev-server` (25 passed), plus
`page/module-renderers.integration.test.ts` (3 passed) to exercise the real Vite start through the
new reservation. `pnpm typecheck` clean for `apps/tuval`.

Fixes #8593

## Deviations

- **Out-of-scope change** — **Said:** #8593 names `page/dev-server.ts` and `bin.ts`. **Did:** also
  added `page/loopback.ts`, the reservation and forwarder the fix needs. **Why:** the two-family
  strategy is its own concern and its own unit surface. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names no removal. **Did:** removed the `strictPort`
  option from `PageServerOptions`, the `--strict-port` flag from `pi/proof/serve.ts`, and that flag
  from the `tuval-pi-vertical` command in `.fabrika.jsonc`. **Why:** a requested port is now always
  bound exactly or refused, so the flag asked for a guarantee the contract already gives (#7992);
  the render-target command would have failed on an unknown flag if left. **Disposition:** stated
  here.
- **Out-of-scope change** — **Said:** the issue names no doc. **Did:** updated the boot-output block
  in `apps/tuval/README.md`, which printed the old `http://127.0.0.1:5173/` line. **Why:** the
  printed line changed; leaving it would document a URL the app no longer prints.
  **Disposition:** stated here.
