### PR TITLE
roadmap: declare the Epic planning campaign (#56, paused)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,7 @@ flowchart TD
 		camp_phoenix_i18n["phoenix i18n"]:::active
 		camp_tuval_first_slice_fast_follows["Tuval first slice - fast follows"]:::active
 		camp_tuval_programs["Tuval programs"]:::active
+		camp_epic_planning["Epic planning"]:::paused
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -121,6 +122,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | phoenix i18n | #53 | active |
 | Tuval first slice - fast follows | #54 | active |
 | Tuval programs | #55 | active |
+| Epic planning | #56 | paused |
 
 **Tuval programs** carries the new Tuval scope after the first slice shipped: the program authoring API (#8716) and the desk showing kernel children (#8715). **Tuval first slice - fast follows** remains open and active for follow-up repairs discovered during Tuval work, including when its backlog is temporarily empty. Completing the current issues does not close this campaign; closure requires an explicit founder decision.
 


### PR DESCRIPTION
Milestone #56 (Epic planning) had no `ROADMAP.md` campaign row, so `roadmap-guard` I3 redded on every PR cut from main. Adds the row (`paused`, cited to the campaign-approve marker on #8827) and the matching mermaid node.

Closes #8827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations
None.
