### PR TITLE
fix: Tuval Claude transcript empties after subagent spawns and load-more fails with unknown-cursor

### DIFF
--- a/apps/tuval/src/ai-agent-fixtures/transcripts.ts
+++ b/apps/tuval/src/ai-agent-fixtures/transcripts.ts
@@ -86,6 +86,12 @@ export const compactionItem = (
 	text,
 });
 
+/** The same row as a nested worker emits it: tagged with the call it ran inside (#8814). */
+export const nestedUnder = <A extends TranscriptItem>(item: A, parent: string): A => ({
+	...item,
+	parentId: ItemId.make(parent),
+});
+
 /** One subagent slot, running by default: the shape a mapper hands the core (#8401). */
 export const subagentSlot = (
 	id: string,

--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -10,6 +10,7 @@ import {describe, expect, it} from "vitest";
 import {
 	assistantItem,
 	compactionItem,
+	nestedUnder,
 	subagentSlot,
 	systemItem,
 	thinkingItem,
@@ -38,6 +39,50 @@ const foldAll = (
 	}
 	return steps;
 };
+
+/**
+ * The window bounds are spent on what the desk renders, so a spawn cannot shave the visible head.
+ *
+ * A worker's rows arrive as ordinary items tagged with the call they ran inside, and `chatRows`
+ * drops every one of them; before #8814 they paid full window freight on the way past, so a few
+ * spawns pushed the operator's own turns out of a tail that then rendered nothing at all.
+ */
+describe("folding turns that spawn subagents", () => {
+	const SPAWNS = 6;
+	const ROWS_PER_WORKER = 12;
+
+	/** `SPAWNS` operator exchanges, each ending in a call whose worker rows arrive tagged. */
+	const withSpawns = (workerOutput = "ok"): ReadonlyArray<TranscriptItem> =>
+		Array.from({length: SPAWNS}).flatMap((_spawnSlot, spawn) => {
+			const call = `spawn-${spawn}`;
+			const worker = Array.from({length: ROWS_PER_WORKER}).flatMap((_workerSlot, index) => [
+				systemItem(`worker-notice-${spawn}-${index}`),
+				assistantItem(`worker-reply-${spawn}-${index}`),
+				toolItem(`worker-tool-${spawn}-${index}`, workerOutput),
+			]);
+			return [
+				userItem(`u${spawn}`),
+				assistantItem(`a${spawn}`),
+				toolItem(call),
+				...worker.map((item) => nestedUnder(item, call)),
+			];
+		});
+
+	const ownIds = (items: ReadonlyArray<TranscriptItem>): ReadonlyArray<string> =>
+		items.filter((item) => item.parentId === undefined).map((item) => item.id);
+
+	it("leaves every one of the operator's own rows in the tail at itemLimit 40", () => {
+		const stream = withSpawns();
+		const tail = foldAll(empty, stream, {itemLimit: 40}).at(-1)?.items ?? [];
+		expect(ownIds(tail)).toEqual(ownIds(stream));
+	});
+
+	it("spends no byte budget on them either", () => {
+		const stream = withSpawns("x".repeat(4_000));
+		const tail = foldAll(empty, stream, {itemLimit: 40, byteLimit: 20_000}).at(-1)?.items ?? [];
+		expect(ownIds(tail)).toEqual(ownIds(stream));
+	});
+});
 
 describe("folding a turn that outgrows the bounds", () => {
 	it("never empties the tail while the open group is still growing", () => {

--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -41,11 +41,13 @@ const foldAll = (
 };
 
 /**
- * The window bounds are spent on what the desk renders, so a spawn cannot shave the visible head.
+ * The agent's own bounds are spent on its own rows, so a spawn cannot shave the visible head.
  *
- * A worker's rows arrive as ordinary items tagged with the call they ran inside, and `chatRows`
- * drops every one of them; before #8814 they paid full window freight on the way past, so a few
- * spawns pushed the operator's own turns out of a tail that then rendered nothing at all.
+ * A worker's rows arrive as ordinary items tagged with the call they ran inside, and with the
+ * subagent list on `chatRows` drops every one of them; before #8814 they paid full window freight
+ * on the way past, so a few spawns pushed the operator's own turns out of a tail that then rendered
+ * nothing at all. They are not free of every bound — `history/window.ts` holds them to a ceiling of
+ * their own, which is what keeps the tail bounded with the list off, where they do render.
  */
 describe("folding turns that spawn subagents", () => {
 	const SPAWNS = 6;

--- a/apps/tuval/src/ai-agent/core/properties.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/properties.unit.test.ts
@@ -11,14 +11,15 @@ import {applyCellChecked} from "@demlik/tea";
 import {describe, expect, it} from "vitest";
 import {
 	assistantItem,
+	nestedUnder,
 	randomStream,
 	systemItem,
 	toolItem,
 	userItem,
 } from "../../ai-agent-fixtures/transcripts.ts";
 import type {AgentEvent, Phase} from "../events.ts";
-import {groupBytes} from "../history/index.ts";
-import {Mode, type PermissionDecision} from "../ports/index.ts";
+import {groupBytes, nestedLimitsFor} from "../history/index.ts";
+import {isNestedItem, Mode, type PermissionDecision, type TranscriptItem} from "../ports/index.ts";
 import {aiAgentSessionMachine} from "./machine.ts";
 import type {AiAgentSessionCmd, AiAgentSessionMsg} from "./messages.ts";
 import {isAiAgentSessionState} from "./snapshot.ts";
@@ -27,6 +28,24 @@ import {type AiAgentSessionState, initialState} from "./state.ts";
 const ITEM_LIMIT = 8;
 const BYTE_LIMIT = 4_000;
 const SENT_AT = 1_700_000_000_000;
+const NESTED_LIMIT = nestedLimitsFor({items: ITEM_LIMIT, bytes: BYTE_LIMIT});
+
+/**
+ * Longest run of rows one spawned worker emits before the generator ends it.
+ *
+ * Well under `NESTED_LIMIT.items`, for the reason the own bounds are asserted strictly too: the
+ * newest group in range is carried whole past every ceiling, so a generator that could put a whole
+ * ceiling's worth of rows in one group would be asserting the exception rather than the bound.
+ */
+const WORKER_ROWS = 6;
+
+/**
+ * How often an item event opens a spawn rather than being the agent's own row.
+ *
+ * High enough that every fixed seed below carries worker rows — the run asserts that it did, and a
+ * seed that happened to spawn nothing would assert the nested ceiling over an empty set.
+ */
+const SPAWN_CHANCE = 0.35;
 
 const machine = aiAgentSessionMachine({
 	cwd: "/repo",
@@ -49,6 +68,7 @@ const decisions: ReadonlyArray<PermissionDecision> = ["allow-once", "allow-alway
 const randomMsg = (
 	random: ReturnType<typeof randomStream>,
 	step: number,
+	spawn: Spawn,
 ): {readonly msg: AiAgentSessionMsg; readonly newItem: boolean} => {
 	const id = `i${step}`;
 	switch (random.int(10)) {
@@ -138,37 +158,75 @@ const randomMsg = (
 			return {msg: {type: "interrupt", at: SENT_AT + step}, newItem: false};
 		default:
 			return {
-				msg: {type: "event", sessionId: "session-1", event: randomItem(random, id)},
+				msg: {type: "event", sessionId: "session-1", event: randomItem(random, id, spawn)},
 				newItem: true,
 			};
 	}
 };
 
-const randomItem = (random: ReturnType<typeof randomStream>, id: string): AgentEvent => {
+/** The spawn currently in flight, if any: the call id its worker's rows are tagged with. */
+interface Spawn {
+	open: string | null;
+	left: number;
+}
+
+const plainItem = (random: ReturnType<typeof randomStream>, id: string): TranscriptItem => {
 	const text = "x".repeat(random.int(300));
 	switch (random.int(4)) {
 		case 0:
-			return {kind: "item", item: userItem(id, text)};
+			return userItem(id, text);
 		case 1:
-			return {kind: "item", item: assistantItem(id, text)};
+			return assistantItem(id, text);
 		case 2:
-			return {kind: "item", item: toolItem(id, text)};
+			return toolItem(id, text);
 		default:
-			return {kind: "item", item: systemItem(id, text)};
+			return systemItem(id, text);
 	}
+};
+
+/**
+ * One transcript item, sometimes a spawned worker's rather than the agent's own.
+ *
+ * A worker's rows arrive as ordinary items tagged with the call they ran inside, and they answer to
+ * a ceiling of their own rather than the agent's (#8814) — so a generator that never emits one
+ * leaves that ceiling unasserted and the bounds test passes vacuously over every session that
+ * spawns anything.
+ */
+const randomItem = (
+	random: ReturnType<typeof randomStream>,
+	id: string,
+	spawn: Spawn,
+): AgentEvent => {
+	if (spawn.open === null) {
+		if (!random.chance(SPAWN_CHANCE)) return {kind: "item", item: plainItem(random, id)};
+		spawn.open = id;
+		spawn.left = 1 + random.int(WORKER_ROWS);
+		return {kind: "item", item: toolItem(id, "spawning")};
+	}
+	const parent = spawn.open;
+	spawn.left -= 1;
+	if (spawn.left <= 0) spawn.open = null;
+	return {kind: "item", item: nestedUnder(plainItem(random, id), parent)};
 };
 
 interface Run {
 	readonly state: AiAgentSessionState;
 	readonly items: number;
+	/** How many of those items a spawned worker emitted, so a test can refuse a vacuous run. */
+	readonly nested: number;
 }
 
 const drive = (seed: number, steps: number): Run => {
 	const random = randomStream(seed);
+	const spawn: Spawn = {open: null, left: 0};
 	let state = initialState("/repo");
 	let items = 0;
+	let nested = 0;
 	for (let step = 0; step < steps; step += 1) {
-		const {msg, newItem} = randomMsg(random, step);
+		const {msg, newItem} = randomMsg(random, step, spawn);
+		if (msg.type === "event" && msg.event.kind === "item" && isNestedItem(msg.event.item)) {
+			nested += 1;
+		}
 		const [next, cmds] = applyCellChecked<
 			AiAgentSessionState,
 			AiAgentSessionMsg,
@@ -181,7 +239,7 @@ const drive = (seed: number, steps: number): Run => {
 		if ((newItem || recorded) && next.phase !== "gone") items += 1;
 		state = next;
 	}
-	return {state, items};
+	return {state, items, nested};
 };
 
 const seeds = [1, 7, 42, 99, 1_337, 20_260_903, 6_553_601, 8_675_309];
@@ -190,14 +248,23 @@ describe("driving random messages through the table", () => {
 	it("never grows the tail past the planner's bounds", () => {
 		for (const seed of seeds) {
 			const {state} = drive(seed, 200);
-			expect({seed, items: state.transcript.items.length <= ITEM_LIMIT}).toEqual({
-				seed,
-				items: true,
-			});
-			expect({seed, bytes: groupBytes(state.transcript.items) <= BYTE_LIMIT}).toEqual({
-				seed,
-				bytes: true,
-			});
+			const own = state.transcript.items.filter((item) => !isNestedItem(item));
+			expect({seed, items: own.length <= ITEM_LIMIT}).toEqual({seed, items: true});
+			expect({seed, bytes: groupBytes(own) <= BYTE_LIMIT}).toEqual({seed, bytes: true});
+		}
+	});
+
+	it("holds a spawned worker's rows to a ceiling of their own", () => {
+		for (const seed of seeds) {
+			const run = drive(seed, 200);
+			// The stream has to have carried worker rows for the two bounds below to mean anything —
+			// before #8814 added the spawn arm the generator emitted none, and every bound over them
+			// passed vacuously. Asserted on what the run emitted, not on what survived: a tail that
+			// evicted them all is exactly the case the ceiling is allowed to produce.
+			expect({seed, spawned: run.nested > 0}).toEqual({seed, spawned: true});
+			const nested = run.state.transcript.items.filter(isNestedItem);
+			expect({seed, items: nested.length <= NESTED_LIMIT.items}).toEqual({seed, items: true});
+			expect({seed, bytes: groupBytes(nested) <= NESTED_LIMIT.bytes}).toEqual({seed, bytes: true});
 		}
 	});
 

--- a/apps/tuval/src/ai-agent/history/cursor.ts
+++ b/apps/tuval/src/ai-agent/history/cursor.ts
@@ -1,14 +1,26 @@
-import type {TranscriptItem} from "../ports/index.ts";
+import {isNestedItem, type TranscriptItem} from "../ports/index.ts";
 
 export type PageCursor =
 	| {readonly kind: "page"; readonly before: string | null}
 	| {readonly kind: "unavailable"};
 
-// The partial arm is read through `in` rather than off the assistant kind, for the reason
-// `../core/state.ts`'s `holdsPartialItem` is: reasoning grows a partial row of its own now (#8288),
-// and a third kind that grows one must not need this predicate edited to stay off the cursor.
+/**
+ * Rows no backend's history read can resolve, so a cursor minted from one comes back
+ * `cursor-not-found` and the window shows the unknown-cursor banner instead of a page (#8814).
+ *
+ * A `system` notice and a nested worker's row are live-only by construction: a stored session holds
+ * the conversation's own turns, and neither class is one — the Claude CLI writes a worker's frames
+ * to a `subagents/agent-*.jsonl` sidecar rather than the session file, and a task notice is minted
+ * from an SDK notification that was never a message at all.
+ *
+ * The partial arm is read through `in` rather than off the assistant kind, for the reason
+ * `../core/state.ts`'s `holdsPartialItem` is: reasoning grows a partial row of its own now (#8288),
+ * and a third kind that grows one must not need this predicate edited to stay off the cursor.
+ */
 const isUnavailable = (item: TranscriptItem): boolean =>
 	(item.kind === "user" && item.local === true) ||
+	item.kind === "system" ||
+	isNestedItem(item) ||
 	item.id.startsWith("local:") ||
 	("partial" in item && item.partial === true);
 

--- a/apps/tuval/src/ai-agent/history/cursor.unit.test.ts
+++ b/apps/tuval/src/ai-agent/history/cursor.unit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Which held row a page cursor may be minted from — the whole of what stands between a load-more
+ * and the unknown-cursor banner (#8814).
+ *
+ * A backend's history read resolves the conversation's own turns and nothing else, so a cursor
+ * naming a session notice or a nested worker's row comes back `cursor-not-found`. Both classes are
+ * live-only by construction: the Claude CLI writes a worker's frames to a `subagents/agent-*.jsonl`
+ * sidecar, and a task notice is minted from an SDK notification that was never a message.
+ */
+
+import {describe, expect, it} from "vitest";
+import {
+	assistantItem,
+	nestedUnder,
+	systemItem,
+	toolItem,
+	userItem,
+} from "../../ai-agent-fixtures/transcripts.ts";
+import {pageCursor} from "./cursor.ts";
+
+describe("the rows a page cursor may be minted from", () => {
+	it("leaves an ordinary stored row as its own cursor", () => {
+		const held = [userItem("prompt"), assistantItem("reply")];
+		expect(pageCursor(held, "prompt")).toEqual({kind: "page", before: "prompt"});
+	});
+
+	it("walks off a task notice to the oldest row a stored session can resolve", () => {
+		const held = [systemItem("task-notice"), assistantItem("reply"), userItem("prompt")];
+		expect(pageCursor(held, "task-notice")).toEqual({kind: "page", before: "reply"});
+	});
+
+	it("walks off a nested worker's row the same way", () => {
+		const held = [
+			nestedUnder(assistantItem("worker-reply"), "spawn"),
+			nestedUnder(toolItem("worker-tool"), "spawn"),
+			assistantItem("reply"),
+		];
+		expect(pageCursor(held, "worker-reply")).toEqual({kind: "page", before: "reply"});
+	});
+
+	it("refuses rather than mint one when every row past the anchor is unavailable", () => {
+		const held = [
+			systemItem("task-started"),
+			nestedUnder(toolItem("worker-tool"), "spawn"),
+			systemItem("task-progress"),
+		];
+		expect(pageCursor(held, "task-started")).toEqual({kind: "unavailable"});
+	});
+});

--- a/apps/tuval/src/ai-agent/history/groups.ts
+++ b/apps/tuval/src/ai-agent/history/groups.ts
@@ -30,6 +30,13 @@ export interface TranscriptGroup {
 	 * that spawned them.
 	 */
 	readonly weight: GroupWeight;
+	/**
+	 * What the nested worker's rows riding with this group weigh, against the separate ceiling
+	 * `nestedLimitsFor` sets. Free of `weight` is not free of every bound: with the subagent list
+	 * off those rows do render, so exempting them from both bounds outright would lift the ceiling
+	 * on a rendered tail instead of moving it (#8814).
+	 */
+	readonly nested: GroupWeight;
 }
 
 /** One item's weight against the byte bound: its wire form, which is what a transport pays for. */
@@ -38,9 +45,23 @@ export const itemBytes = (item: TranscriptItem): number => byteLength(JSON.strin
 export const groupBytes = (items: ReadonlyArray<TranscriptItem>): number =>
 	items.reduce((total, item) => total + itemBytes(item), 0);
 
-export const groupWeight = (items: ReadonlyArray<TranscriptItem>): GroupWeight => {
-	const own = items.filter((item) => !isNestedItem(item));
-	return {items: own.length, bytes: groupBytes(own)};
+const weigh = (items: ReadonlyArray<TranscriptItem>): GroupWeight => ({
+	items: items.length,
+	bytes: groupBytes(items),
+});
+
+/** A group's rows split by whose they are: the agent's own, and the workers' riding with them. */
+export const weighGroup = (
+	items: ReadonlyArray<TranscriptItem>,
+): Pick<TranscriptGroup, "weight" | "nested"> => ({
+	weight: weigh(items.filter((item) => !isNestedItem(item))),
+	nested: weigh(items.filter(isNestedItem)),
+});
+
+/** The same group with its nested passengers put down, or `null` when they were all it carried. */
+export const withoutNested = (group: TranscriptGroup): NonEmpty<TranscriptItem> | null => {
+	const [head, ...tail] = group.items.filter((item) => !isNestedItem(item));
+	return head === undefined ? null : [head, ...tail];
 };
 
 /**
@@ -72,7 +93,7 @@ export const groupTranscript = (
 			items: members,
 			bytes: groupBytes(members),
 			start: open.start,
-			weight: groupWeight(members),
+			...weighGroup(members),
 		});
 		open = null;
 	};
@@ -84,7 +105,7 @@ export const groupTranscript = (
 				items: [item],
 				bytes: itemBytes(item),
 				start: index,
-				weight: groupWeight([item]),
+				...weighGroup([item]),
 			});
 			return;
 		}

--- a/apps/tuval/src/ai-agent/history/groups.ts
+++ b/apps/tuval/src/ai-agent/history/groups.ts
@@ -6,15 +6,30 @@
  * a pure fold over the item union — model-blind, and the only shape both bounds below reason about.
  */
 
-import {byteLength, type TranscriptItem} from "../ports/index.ts";
+import {byteLength, isNestedItem, type TranscriptItem} from "../ports/index.ts";
 
 export type NonEmpty<A> = readonly [A, ...Array<A>];
+
+/** What one group spends against the bounds: item count and wire bytes, as `stoppedBy` reads them. */
+export interface GroupWeight {
+	readonly items: number;
+	readonly bytes: number;
+}
 
 export interface TranscriptGroup {
 	readonly items: NonEmpty<TranscriptItem>;
 	readonly bytes: number;
 	/** Index of the group's first item in the slice it was folded from, oldest-first. */
 	readonly start: number;
+	/**
+	 * What this group weighs against the bounds: its own rows, never the nested worker's rows riding
+	 * with them. A subagent's rows are carried by its slot and hidden from the transcript
+	 * (`shell/chat/rows.ts`), so charging the bounds for them evicts the operator's own turns to
+	 * make room for rows nothing renders — a few spawns and the visible tail is empty (#8814). They
+	 * still travel in `items`, because a window with the subagent list off folds them under the call
+	 * that spawned them.
+	 */
+	readonly weight: GroupWeight;
 }
 
 /** One item's weight against the byte bound: its wire form, which is what a transport pays for. */
@@ -22,6 +37,11 @@ export const itemBytes = (item: TranscriptItem): number => byteLength(JSON.strin
 
 export const groupBytes = (items: ReadonlyArray<TranscriptItem>): number =>
 	items.reduce((total, item) => total + itemBytes(item), 0);
+
+export const groupWeight = (items: ReadonlyArray<TranscriptItem>): GroupWeight => {
+	const own = items.filter((item) => !isNestedItem(item));
+	return {items: own.length, bytes: groupBytes(own)};
+};
 
 /**
  * Fold an oldest-first slice into atomic groups.
@@ -33,6 +53,10 @@ export const groupBytes = (items: ReadonlyArray<TranscriptItem>): number =>
  * A compaction marker stands alone for the same reason a system notice does, and for one more: it
  * is exactly the place a reader wants a bound to cut, so folding it into the turn beside it would
  * make the one boundary that explains missing history uncuttable.
+ *
+ * A nested worker's row is none of those things: it neither opens nor closes a group, so a
+ * subagent's own prompt cannot split the operator's exchange in two and its notices cannot stand
+ * between the operator's turn and the reply it produced (#8814).
  */
 export const groupTranscript = (
 	items: ReadonlyArray<TranscriptItem>,
@@ -44,16 +68,27 @@ export const groupTranscript = (
 	const close = () => {
 		if (open === null) return;
 		const members: NonEmpty<TranscriptItem> = [open.head, ...open.tail];
-		groups.push({items: members, bytes: groupBytes(members), start: open.start});
+		groups.push({
+			items: members,
+			bytes: groupBytes(members),
+			start: open.start,
+			weight: groupWeight(members),
+		});
 		open = null;
 	};
 	items.forEach((item, index) => {
-		if (item.kind === "system" || item.kind === "compaction") {
+		const nested = isNestedItem(item);
+		if (!nested && (item.kind === "system" || item.kind === "compaction")) {
 			close();
-			groups.push({items: [item], bytes: itemBytes(item), start: index});
+			groups.push({
+				items: [item],
+				bytes: itemBytes(item),
+				start: index,
+				weight: groupWeight([item]),
+			});
 			return;
 		}
-		if (item.kind === "user" || open === null) {
+		if (open === null || (!nested && item.kind === "user")) {
 			close();
 			open = {head: item, tail: [], start: index};
 			return;

--- a/apps/tuval/src/ai-agent/history/index.ts
+++ b/apps/tuval/src/ai-agent/history/index.ts
@@ -10,11 +10,11 @@ export {
 	type GroupWeight,
 	groupBytes,
 	groupTranscript,
-	groupWeight,
 	itemBytes,
 	locateCursor,
 	type NonEmpty,
 	type TranscriptGroup,
+	weighGroup,
 } from "./groups.ts";
 export {KERNEL_TOOL_SERVER, type KernelSpawn, kernelSpawnOf} from "./kernel-spawn.ts";
 export {withoutLocalEchoes} from "./local-turns.ts";
@@ -27,7 +27,9 @@ export {
 export {isRefusal, type PlanRefusal} from "./refusal.ts";
 export {boundToolOutput, droppedResultBytes, type RawToolItem} from "./tool-output.ts";
 export {
+	nestedLimitsFor,
 	planTranscriptWindow,
+	TRANSCRIPT_NESTED_ALLOWANCE,
 	TRANSCRIPT_WINDOW_BYTE_LIMIT,
 	TRANSCRIPT_WINDOW_ITEM_LIMIT,
 	type TranscriptWindow,

--- a/apps/tuval/src/ai-agent/history/index.ts
+++ b/apps/tuval/src/ai-agent/history/index.ts
@@ -7,8 +7,10 @@
 export {type PageCursor, pageCursor} from "./cursor.ts";
 export {
 	type CursorPosition,
+	type GroupWeight,
 	groupBytes,
 	groupTranscript,
+	groupWeight,
 	itemBytes,
 	locateCursor,
 	type NonEmpty,

--- a/apps/tuval/src/ai-agent/history/page.ts
+++ b/apps/tuval/src/ai-agent/history/page.ts
@@ -80,8 +80,8 @@ export const planTranscriptPage = (
 			break;
 		}
 		taken.unshift(group);
-		items += group.items.length;
-		bytes += group.bytes;
+		items += group.weight.items;
+		bytes += group.weight.bytes;
 	}
 
 	const start = taken[0]?.start ?? itemIndexOf(history, groups, boundary);

--- a/apps/tuval/src/ai-agent/history/page.ts
+++ b/apps/tuval/src/ai-agent/history/page.ts
@@ -9,16 +9,16 @@
  * adapter's question, not this bound's.
  */
 
-import type {TranscriptItem, TranscriptPagePayload, WindowOmission} from "../ports/index.ts";
-import {groupTranscript, type TranscriptGroup} from "./groups.ts";
+import type {TranscriptItem, TranscriptPagePayload} from "../ports/index.ts";
+import {groupTranscript} from "./groups.ts";
 import type {PlanRefusal} from "./refusal.ts";
 import {
 	boundaryOf,
 	bytesOf,
-	itemIndexOf,
+	nestedLimitsFor,
 	positiveLimit,
-	stoppedBy,
 	TRANSCRIPT_WINDOW_BYTE_LIMIT,
+	takeGroups,
 } from "./window.ts";
 
 export type TranscriptPage = Extract<TranscriptPagePayload, {kind: "page"}> & {
@@ -67,31 +67,18 @@ export const planTranscriptPage = (
 	const boundary = boundaryOf(history, groups, containing?.items[0].id ?? cursor);
 	if (typeof boundary !== "number") return boundary;
 
-	const taken: Array<TranscriptGroup> = [];
-	let items = 0;
-	let bytes = 0;
-	let reason: WindowOmission["reason"] = "none";
-	for (let index = boundary - 1; index >= 0; index -= 1) {
-		const group = groups[index];
-		if (group === undefined) break;
-		const stop = stoppedBy(group, {items, bytes}, {items: options.limit, bytes: byteLimit});
-		if (stop !== null && taken.length > 0) {
-			reason = stop;
-			break;
-		}
-		taken.unshift(group);
-		items += group.weight.items;
-		bytes += group.weight.bytes;
-	}
-
-	const start = taken[0]?.start ?? itemIndexOf(history, groups, boundary);
-	const older = history.slice(0, start);
-	const pageItems = taken.flatMap((group) => [...group.items]);
+	const own = {items: options.limit, bytes: byteLimit};
+	const taken = takeGroups(history, groups, boundary, {own, nested: nestedLimitsFor(own)});
+	const older = history.slice(0, taken.start);
 	return {
 		kind: "page",
-		start,
-		items: pageItems,
-		omitted: {items: older.length, bytes: bytesOf(older), reason},
-		next: older.length === 0 ? null : (pageItems[0]?.id ?? null),
+		start: taken.start,
+		items: taken.items,
+		omitted: {
+			items: older.length + taken.shed.length,
+			bytes: bytesOf(older) + bytesOf(taken.shed),
+			reason: taken.reason,
+		},
+		next: older.length === 0 ? null : (taken.items[0]?.id ?? null),
 	};
 };

--- a/apps/tuval/src/ai-agent/history/window.ts
+++ b/apps/tuval/src/ai-agent/history/window.ts
@@ -43,14 +43,18 @@ export interface WindowOptions {
 	readonly byteLimit?: number;
 }
 
-/** Which bound refuses this group here, in the vocabulary `WindowOmission` speaks. */
+/**
+ * Which bound refuses this group here, in the vocabulary `WindowOmission` speaks. The group's
+ * `weight` rather than everything it carries: a nested worker's rows ride along free
+ * (`./groups.ts`).
+ */
 export const stoppedBy = (
 	group: TranscriptGroup,
 	taken: {readonly items: number; readonly bytes: number},
 	limits: {readonly items: number; readonly bytes: number},
 ): WindowOmission["reason"] | null => {
-	if (taken.items + group.items.length > limits.items) return "item-limit";
-	if (taken.bytes + group.bytes > limits.bytes) return "byte-limit";
+	if (taken.items + group.weight.items > limits.items) return "item-limit";
+	if (taken.bytes + group.weight.bytes > limits.bytes) return "byte-limit";
 	return null;
 };
 
@@ -113,8 +117,8 @@ export const planTranscriptWindow = (
 			break;
 		}
 		taken.unshift(group);
-		items += group.items.length;
-		bytes += group.bytes;
+		items += group.weight.items;
+		bytes += group.weight.bytes;
 	}
 
 	const start = taken[0]?.start ?? itemIndexOf(history, groups, boundary);

--- a/apps/tuval/src/ai-agent/history/window.ts
+++ b/apps/tuval/src/ai-agent/history/window.ts
@@ -15,8 +15,20 @@
  * recoverable; losing the turn is not.
  */
 
-import type {TranscriptItem, TranscriptPayload, WindowOmission} from "../ports/index.ts";
-import {groupTranscript, itemBytes, locateCursor, type TranscriptGroup} from "./groups.ts";
+import {
+	isNestedItem,
+	type TranscriptItem,
+	type TranscriptPayload,
+	type WindowOmission,
+} from "../ports/index.ts";
+import {
+	type GroupWeight,
+	groupTranscript,
+	itemBytes,
+	locateCursor,
+	type TranscriptGroup,
+	withoutNested,
+} from "./groups.ts";
 import type {PlanRefusal} from "./refusal.ts";
 
 /** How many items the live tail may carry. */
@@ -24,6 +36,23 @@ export const TRANSCRIPT_WINDOW_ITEM_LIMIT = 40;
 
 /** How many bytes of wire form the live tail may carry. */
 export const TRANSCRIPT_WINDOW_BYTE_LIMIT = 256_000;
+
+/**
+ * How much more a bound may carry in nested workers' rows than in the agent's own.
+ *
+ * A worker's rows ride free of the item and byte bounds so a spawn cannot evict the operator's
+ * turns (#8814), but free of those bounds is not free of every bound: with the subagent list off
+ * `chatRows` renders them folded under their call, so no ceiling at all would mean an unbounded
+ * rendered tail — the defect moved rather than fixed. Four is the room for several whole workers
+ * beside a full window of the operator's own turns, which is what a spawn-heavy session needs and
+ * where a tail stops being one.
+ */
+export const TRANSCRIPT_NESTED_ALLOWANCE = 4;
+
+export const nestedLimitsFor = (limits: GroupWeight): GroupWeight => ({
+	items: limits.items * TRANSCRIPT_NESTED_ALLOWANCE,
+	bytes: limits.bytes * TRANSCRIPT_NESTED_ALLOWANCE,
+});
 
 export interface TranscriptWindow extends TranscriptPayload {
 	readonly kind: "window";
@@ -43,18 +72,14 @@ export interface WindowOptions {
 	readonly byteLimit?: number;
 }
 
-/**
- * Which bound refuses this group here, in the vocabulary `WindowOmission` speaks. The group's
- * `weight` rather than everything it carries: a nested worker's rows ride along free
- * (`./groups.ts`).
- */
+/** Which bound refuses this much more here, in the vocabulary `WindowOmission` speaks. */
 export const stoppedBy = (
-	group: TranscriptGroup,
-	taken: {readonly items: number; readonly bytes: number},
-	limits: {readonly items: number; readonly bytes: number},
+	weight: GroupWeight,
+	taken: GroupWeight,
+	limits: GroupWeight,
 ): WindowOmission["reason"] | null => {
-	if (taken.items + group.weight.items > limits.items) return "item-limit";
-	if (taken.bytes + group.weight.bytes > limits.bytes) return "byte-limit";
+	if (taken.items + weight.items > limits.items) return "item-limit";
+	if (taken.bytes + weight.bytes > limits.bytes) return "byte-limit";
 	return null;
 };
 
@@ -91,6 +116,79 @@ export const itemIndexOf = (
 export const bytesOf = (items: ReadonlyArray<TranscriptItem>): number =>
 	items.reduce((total, item) => total + itemBytes(item), 0);
 
+/** The two ceilings a walk answers to: the agent's own rows, and the workers' rows riding along. */
+export interface TakeLimits {
+	readonly own: GroupWeight;
+	readonly nested: GroupWeight;
+}
+
+/** What one walk kept, where it started, and what it put down on the way. */
+export interface TakenGroups {
+	readonly items: ReadonlyArray<TranscriptItem>;
+	/** Index of the oldest taken group's first item in the slice, oldest-first. */
+	readonly start: number;
+	/** Nested rows the ceiling made this walk put down, still inside the range it covers. */
+	readonly shed: ReadonlyArray<TranscriptItem>;
+	readonly reason: WindowOmission["reason"];
+}
+
+/**
+ * Walk older from `boundary`, taking whole groups until a ceiling refuses one.
+ *
+ * The one walk both bounds run, because the nested ceiling is the kind of rule that gets applied in
+ * one copy of a loop and forgotten in the other — and the copy that forgets it is unbounded.
+ *
+ * A ceiling reached does not evict the group: it puts the group's nested passengers down and keeps
+ * the agent's own rows, so a spawn can never cost the operator a turn (#8814) while the tail stays
+ * bounded at both ceilings. Only a group that was all passengers ends the walk, having nothing left
+ * to keep. The newest group in range is the exception to every one of these, carried whole: an
+ * empty tail is not a refusal, so `foldItem` would commit it and the live transcript would collapse
+ * (#8031).
+ */
+export const takeGroups = (
+	history: ReadonlyArray<TranscriptItem>,
+	groups: ReadonlyArray<TranscriptGroup>,
+	boundary: number,
+	limits: TakeLimits,
+): TakenGroups => {
+	const kept: Array<ReadonlyArray<TranscriptItem>> = [];
+	const shed: Array<ReadonlyArray<TranscriptItem>> = [];
+	let spent: GroupWeight = {items: 0, bytes: 0};
+	let carried: GroupWeight = {items: 0, bytes: 0};
+	let start = itemIndexOf(history, groups, boundary);
+	let reason: WindowOmission["reason"] = "none";
+	for (let index = boundary - 1; index >= 0; index -= 1) {
+		const group = groups[index];
+		if (group === undefined) break;
+		const newest = kept.length === 0;
+		const stop = stoppedBy(group.weight, spent, limits.own);
+		if (stop !== null && !newest) {
+			reason = stop;
+			break;
+		}
+		const nestedStop = newest ? null : stoppedBy(group.nested, carried, limits.nested);
+		const members = nestedStop === null ? group.items : withoutNested(group);
+		if (members === null) {
+			reason = nestedStop ?? reason;
+			break;
+		}
+		if (nestedStop !== null && group.nested.items > 0) {
+			shed.unshift(group.items.filter(isNestedItem));
+			reason = nestedStop;
+		}
+		kept.unshift(members);
+		spent = {items: spent.items + group.weight.items, bytes: spent.bytes + group.weight.bytes};
+		if (nestedStop === null) {
+			carried = {
+				items: carried.items + group.nested.items,
+				bytes: carried.bytes + group.nested.bytes,
+			};
+		}
+		start = group.start;
+	}
+	return {items: kept.flat(), start, shed: shed.flat(), reason};
+};
+
 export const planTranscriptWindow = (
 	history: ReadonlyArray<TranscriptItem>,
 	options: WindowOptions = {},
@@ -104,29 +202,17 @@ export const planTranscriptWindow = (
 	const boundary = boundaryOf(history, groups, options.before ?? null);
 	if (typeof boundary !== "number") return boundary;
 
-	const taken: Array<TranscriptGroup> = [];
-	let items = 0;
-	let bytes = 0;
-	let reason: WindowOmission["reason"] = "none";
-	for (let index = boundary - 1; index >= 0; index -= 1) {
-		const group = groups[index];
-		if (group === undefined) break;
-		const stop = stoppedBy(group, {items, bytes}, {items: itemLimit, bytes: byteLimit});
-		if (stop !== null && taken.length > 0) {
-			reason = stop;
-			break;
-		}
-		taken.unshift(group);
-		items += group.weight.items;
-		bytes += group.weight.bytes;
-	}
-
-	const start = taken[0]?.start ?? itemIndexOf(history, groups, boundary);
-	const dropped = history.slice(0, start);
+	const own: GroupWeight = {items: itemLimit, bytes: byteLimit};
+	const taken = takeGroups(history, groups, boundary, {own, nested: nestedLimitsFor(own)});
+	const dropped = history.slice(0, taken.start);
 	return {
 		kind: "window",
-		start,
-		items: taken.flatMap((group) => [...group.items]),
-		omitted: {items: dropped.length, bytes: bytesOf(dropped), reason},
+		start: taken.start,
+		items: taken.items,
+		omitted: {
+			items: dropped.length + taken.shed.length,
+			bytes: bytesOf(dropped) + bytesOf(taken.shed),
+			reason: taken.reason,
+		},
 	};
 };

--- a/apps/tuval/src/ai-agent/history/window.unit.test.ts
+++ b/apps/tuval/src/ai-agent/history/window.unit.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {
 	assistantItem,
+	nestedUnder,
 	randomStream,
 	randomTranscript,
 	toolItem,
@@ -9,6 +10,7 @@ import {
 import {isTranscriptPayload, type TranscriptItem} from "../ports/index.ts";
 import {groupTranscript, itemBytes} from "./groups.ts";
 import {
+	nestedLimitsFor,
 	planTranscriptWindow,
 	TRANSCRIPT_WINDOW_BYTE_LIMIT,
 	TRANSCRIPT_WINDOW_ITEM_LIMIT,
@@ -209,5 +211,66 @@ describe("the window holds both bounds over random transcripts", () => {
 			}
 		}
 		expect(failures).toEqual([]);
+	});
+});
+
+/**
+ * The other half of #8814: a worker's rows ride free of the agent's bounds, but not free of every
+ * bound. With the subagent list off `chatRows` renders them folded under their call, so a window
+ * that exempted them outright would have lifted the ceiling on a rendered tail rather than moved it.
+ */
+describe("the ceiling a spawned worker's rows answer to", () => {
+	const EXCHANGES = 8;
+	const ROWS_PER_WORKER = 30;
+	const ITEM_LIMIT = 40;
+
+	/** `EXCHANGES` operator turns, each ending in a call whose worker rows arrive tagged. */
+	const withWorkers = (rows: number): ReadonlyArray<TranscriptItem> =>
+		Array.from({length: EXCHANGES}).flatMap((_exchange, turn) => {
+			const call = `call-${turn}`;
+			return [
+				userItem(`u${turn}`),
+				assistantItem(`a${turn}`),
+				toolItem(call),
+				...Array.from({length: rows}).map((_row, index) =>
+					nestedUnder(assistantItem(`w${turn}-${index}`), call),
+				),
+			];
+		});
+
+	const ownIds = (items: ReadonlyArray<TranscriptItem>) =>
+		items.filter((item) => item.parentId === undefined).map((item) => item.id);
+
+	const plan = (history: ReadonlyArray<TranscriptItem>) => {
+		const planned = planTranscriptWindow(history, {itemLimit: ITEM_LIMIT});
+		if (planned.kind !== "window") throw new Error(`refused: ${planned.reason}`);
+		return planned;
+	};
+
+	it("puts the oldest of them down once they pass it, keeping every row of the agent's own", () => {
+		const history = withWorkers(ROWS_PER_WORKER);
+		const nestedLimit = nestedLimitsFor({items: ITEM_LIMIT, bytes: TRANSCRIPT_WINDOW_BYTE_LIMIT});
+		const window = plan(history);
+		const nested = window.items.filter((item) => item.parentId !== undefined);
+
+		expect(EXCHANGES * ROWS_PER_WORKER).toBeGreaterThan(nestedLimit.items);
+		expect(ownIds(window.items)).toEqual(ownIds(history));
+		expect(nested.length).toBeLessThanOrEqual(nestedLimit.items);
+		expect(window.omitted.reason).toBe("item-limit");
+	});
+
+	it("counts what it put down as omitted, so no row leaves the tail unaccounted", () => {
+		const history = withWorkers(ROWS_PER_WORKER);
+		const window = plan(history);
+
+		expect(window.items.length + window.omitted.items).toBe(history.length);
+	});
+
+	it("carries them all when they fit, so a spawn under the ceiling costs nothing", () => {
+		const history = withWorkers(4);
+		const window = plan(history);
+
+		expect(window.items.map((item) => item.id)).toEqual(history.map((item) => item.id));
+		expect(window.omitted).toEqual({items: 0, bytes: 0, reason: "none"});
 	});
 });

--- a/apps/tuval/src/ai-agent/ports/index.ts
+++ b/apps/tuval/src/ai-agent/ports/index.ts
@@ -76,6 +76,7 @@ export {
 	type CompactionItem,
 	ItemId,
 	isJsonValue,
+	isNestedItem,
 	isTranscriptItem,
 	isTranscriptItems,
 	type JsonValue,

--- a/apps/tuval/src/ai-agent/ports/transcript-item.ts
+++ b/apps/tuval/src/ai-agent/ports/transcript-item.ts
@@ -169,6 +169,13 @@ export const newestBackendItemId = (items: ReadonlyArray<TranscriptItem>): ItemI
 	return null;
 };
 
+/**
+ * Whether this row is a nested worker's rather than the agent's own — the `parentId` tag read as a
+ * predicate, so the bounds and the page cursor ask the question in one place instead of each
+ * spelling the field test.
+ */
+export const isNestedItem = (item: TranscriptItem): boolean => item.parentId !== undefined;
+
 /** One tool result may spend this many bytes of the window; the rest is omission metadata. */
 export const TOOL_RESULT_BYTE_LIMIT = 8_000;
 

--- a/apps/tuval/src/claude/proof/subagent-paging.integration.test.ts
+++ b/apps/tuval/src/claude/proof/subagent-paging.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Paging back after a subagent spawn, over the real `ClaudeAiAgent` and the real fold (#8814).
+ *
+ * The founder's desk answered "Could not load earlier messages … (unknown-cursor): cursor-not-found"
+ * here, and the seam is only visible with all three parts joined: the layer maps a worker's frames
+ * to items tagged `parentId` and its task notices to `system` items, the core folds those into the
+ * live tail, and the window anchors its page on the oldest row it holds. Neither class exists in the
+ * stored session — the CLI writes a worker's frames to a `subagents/agent-*.jsonl` sidecar — so a
+ * cursor minted from one is refused by the same layer that emitted it. Both halves are asserted in
+ * one run: the raw anchor still refuses, and the cursor `olderPageRequest` mints off it is served.
+ *
+ * The captured turn is `../history/fixtures/subagent-turn.json`, and what is scripted is the SDK
+ * seam and nothing else.
+ */
+
+import type {SDKMessage, SessionMessage} from "@anthropic-ai/claude-agent-sdk";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit, Option, Stream} from "effect";
+import {foldItem} from "../../ai-agent/core/fold.ts";
+import type {SubagentSlot, TranscriptPayload} from "../../ai-agent/ports/index.ts";
+import {chatRows, olderPageRequest, subagentHeads} from "../../shell/chat/rows.ts";
+import {CWD, messages, on, rows, SESSION_ID, START_EVENTS} from "../agent/fixtures/harness.ts";
+
+const PROMPT = "spawn a worker";
+const TURN: ReadonlyArray<SDKMessage> = messages("subagent-turn");
+
+/**
+ * The session file as the CLI leaves it after this turn: the standing exchange, the prompt that
+ * opened this one, and the turn's own frames. A worker's frames are deliberately absent — that is
+ * the fact under the bug, not a shortcut in the fixture.
+ */
+const storedAfterTurn = (): ReadonlyArray<SessionMessage> => [
+	...rows(),
+	{
+		type: "user",
+		uuid: "stored-spawn-prompt",
+		session_id: SESSION_ID,
+		message: {role: "user", content: PROMPT},
+		parent_tool_use_id: null,
+		parent_agent_id: null,
+	},
+	...TURN.flatMap((frame) =>
+		(frame.type === "assistant" || frame.type === "user") && frame.parent_tool_use_id === null
+			? [{...frame, session_id: SESSION_ID, parent_agent_id: null} as SessionMessage]
+			: [],
+	),
+];
+
+const reasonOf = (exit: Exit.Exit<unknown, unknown>): string | undefined =>
+	Exit.isFailure(exit)
+		? (Option.getOrUndefined(Cause.findErrorOption(exit.cause)) as {reason?: string} | undefined)
+				?.reason
+		: undefined;
+
+describe("paging back after a subagent spawn", () => {
+	it.effect("answers with a page rather than refusing the cursor the window holds", () =>
+		on({opening: [...TURN], rows: storedAfterTurn()}, (agent) =>
+			Effect.gen(function* () {
+				yield* agent.start({cwd: CWD});
+				yield* Stream.runCollect(Stream.take(agent.events, START_EVENTS));
+				yield* agent.prompt(PROMPT);
+				const events = yield* Stream.runCollect(
+					Stream.takeUntil(
+						agent.events,
+						(event) => event.kind === "phase" && event.phase === "ready",
+					),
+				);
+
+				let transcript: TranscriptPayload = {
+					items: [],
+					omitted: {items: 0, bytes: 0, reason: "none"},
+				};
+				const slots: Record<string, SubagentSlot> = {};
+				for (const event of events) {
+					// Narrow on purpose, so the tail ends inside the turn and there is stored history
+					// older than the row the window will anchor on.
+					if (event.kind === "item") transcript = foldItem(transcript, event.item, {itemLimit: 6});
+					if (event.kind === "subagent") slots[event.slot.id] = event.slot;
+				}
+				assert.isAbove(Object.keys(slots).length, 0, "the turn spawned no worker");
+				assert.isAbove(
+					transcript.items.filter((item) => item.parentId !== undefined).length,
+					0,
+					"the tail carries no nested rows",
+				);
+
+				const listed = chatRows({
+					older: [],
+					tail: transcript.items,
+					omitted: transcript.omitted.items,
+					loading: false,
+					atOldest: false,
+					subagents: subagentHeads(slots, true),
+				});
+				const request = olderPageRequest(listed);
+				assert.isNotNull(request, "the window minted no page request");
+				if (request === null) return;
+
+				// The banner's own path: the oldest row the window holds is a task notice this session
+				// never stored, so asking for it by id is still `unknown-cursor`.
+				const raw = yield* Effect.exit(agent.page(request.anchor, 20));
+				assert.equal(reasonOf(raw), "unknown-cursor");
+				assert.notEqual(request.before, request.anchor);
+
+				const page = yield* agent.page(request.before, 20);
+				assert.isAbove(page.items.length, 0);
+			}),
+		),
+	);
+});

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -712,8 +712,8 @@ function ChatWindow({
 	// exactly as they were, which is what lets the back action put the window back where it was.
 	//
 	// A view open on a slot the session no longer holds gets its own row, never main's: falling
-	// through showed the agent's own transcript under the worker's label and `aria-label`, which
-	// reads as the worker having said what the agent said (#8814).
+	// through drew the agent's own transcript inside the open subagent view, which reads as the
+	// worker having said what the agent said (#8814).
 	const rows = useMemo(() => {
 		if (viewedSlot !== undefined) return subagentRows(viewedSlot, unfolded);
 		return viewing === null ? mainRows : SLOT_GONE_ROWS;

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -69,6 +69,7 @@ import {
 	type RowItem,
 	rowIndexOfItem,
 	rowKey,
+	SLOT_GONE_ROWS,
 	subagentHeads,
 	subagentRows,
 } from "./rows.ts";
@@ -402,6 +403,13 @@ function RowView({
 			</span>
 		);
 	}
+	if (row.kind === "slot-gone") {
+		return (
+			<span className="tuval-chat-head">
+				This subagent's transcript is not in this session's state.
+			</span>
+		);
+	}
 	if (row.kind === "older") {
 		return (
 			<span className="tuval-chat-head">
@@ -702,10 +710,14 @@ function ChatWindow({
 
 	// The swap is a swap of *this* list and nothing else: main's own rows, pages and cursor are left
 	// exactly as they were, which is what lets the back action put the window back where it was.
-	const rows = useMemo(
-		() => (viewedSlot === undefined ? mainRows : subagentRows(viewedSlot, unfolded)),
-		[viewedSlot, mainRows, unfolded],
-	);
+	//
+	// A view open on a slot the session no longer holds gets its own row, never main's: falling
+	// through showed the agent's own transcript under the worker's label and `aria-label`, which
+	// reads as the worker having said what the agent said (#8814).
+	const rows = useMemo(() => {
+		if (viewedSlot !== undefined) return subagentRows(viewedSlot, unfolded);
+		return viewing === null ? mainRows : SLOT_GONE_ROWS;
+	}, [viewedSlot, viewing, mainRows, unfolded]);
 
 	/** The row the viewport was resting on when the current page was asked for. */
 	const anchorRef = useRef<string | null>(null);
@@ -1221,15 +1233,17 @@ function ChatWindow({
 						})}
 					</div>
 				</div>
-				{viewing === null ? null : (
+				{viewing === null || viewedSlot === undefined ? null : (
 					// Q9, verbatim: "we should show something to user if they are actually inside a
 					// subagent that's already finished." The view stays open on the rows it had and says
 					// so at the end of them; the way back is the navigator's first row, above. Not a live
 					// region — the hidden one above carries this same sentence and announces it once.
-					<p className="tuval-chat-subagent-end" data-status={viewedSlot?.status}>
-						{viewedSlot === undefined ? (
-							"This subagent's transcript is not in this session's state."
-						) : viewedSlot.status === "finished" ? (
+					//
+					// An unresolved slot has no end to report: its whole transcript is the `slot-gone` row
+					// inside the region above, and a second copy of that sentence here would be the one
+					// line a reader reads twice (#8814).
+					<p className="tuval-chat-subagent-end" data-status={viewedSlot.status}>
+						{viewedSlot.status === "finished" ? (
 							<>
 								<span className="tuval-chat-subagent-end-mark">finished</span>
 								{viewedSlot.lastLine}

--- a/apps/tuval/src/shell/chat/index.ts
+++ b/apps/tuval/src/shell/chat/index.ts
@@ -27,6 +27,7 @@ export {
 	rowIndexOfItem,
 	rowKey,
 	type SessionRun,
+	SLOT_GONE_ROWS,
 	type ToolRun,
 } from "./rows.ts";
 export {SessionRow} from "./SessionRow.tsx";

--- a/apps/tuval/src/shell/chat/rows.ts
+++ b/apps/tuval/src/shell/chat/rows.ts
@@ -60,6 +60,13 @@ export type ChatRow =
 	| {readonly kind: "loading"}
 	| {readonly kind: "page-error"; readonly detail: string}
 	/**
+	 * The window is showing a subagent whose slot the session no longer holds — cleared by a
+	 * `session-reset`, or never restored. Its own row rather than an empty list, because the
+	 * alternative the window had was falling through to the agent's own rows under the worker's
+	 * label, which reads as the worker having said what the agent said (#8814).
+	 */
+	| {readonly kind: "slot-gone"}
+	/**
 	 * A run of consecutive session notices as one row. A burst of hook frames landing mid-turn is a
 	 * row that grows rather than N rows that push everything the reader was looking at down the page.
 	 */
@@ -673,6 +680,15 @@ export const subagentRows = (
 		head: slot.id,
 		...(unfolded === undefined ? {} : {unfolded}),
 	});
+
+/**
+ * The list a window shows in place of a subagent's transcript when the session holds no slot for
+ * the one being viewed. One frozen value for the life of the module, for `NO_SUBAGENTS`' reason:
+ * the memo that reaches for it must not see a changed list on every frame.
+ */
+export const SLOT_GONE_ROWS: ReadonlyArray<ChatRow> = Object.freeze([
+	Object.freeze({kind: "slot-gone"} as const),
+]);
 
 /** The prepend anchor: the oldest item the list holds, including a local echo and a folded one. */
 export const oldestLoadedId = (rows: ReadonlyArray<ChatRow>): string | null =>

--- a/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-view.unit.test.tsx
@@ -528,6 +528,31 @@ describe("a notice naming a worker", () => {
 });
 
 /**
+ * #8814: the view slot outlives the slot it names — a `session-reset` clears `subagents`, and a
+ * restore brings the view back without them. The window used to fall through to the agent's own
+ * rows there, which is the agent's transcript drawn under the worker's label.
+ */
+describe("a view open on a slot the session no longer holds", () => {
+	const ghost = (): ChatView => ({
+		...atOldest(),
+		viewing: {id: "agent", from: {pinned: false, scroll: 0}},
+	});
+
+	it("draws its own empty state instead of the agent's own rows", async () => {
+		const {rendered} = await openOne(agentSession(), {}, ghost());
+		const root = rendered.container;
+
+		expect(dom(root).rowKinds()).toEqual(["slot-gone"]);
+		expect(dom(root).text()).toBe("This subagent's transcript is not in this session's state.");
+		expect(dom(root).text()).not.toContain("the agent's own call");
+		// One copy of that sentence, not two: the tail notice is the finished/running report, and an
+		// unresolved slot has neither.
+		expect(dom(root).end()).toBeNull();
+		rendered.unmount();
+	});
+});
+
+/**
  * #8680: three sentences and one list field name the worker, and all three sentences already carry
  * the word "subagent". A slot whose call named no agent and whose steps resolved none has
  * `type: null`, and each surface phrases that absence instead of reading a placeholder back out.

--- a/apps/tuval/tsconfig.design.json
+++ b/apps/tuval/tsconfig.design.json
@@ -31,6 +31,7 @@
 		"src/page/readable-state.unit.test.tsx",
 		"src/page/session-transcript-window.unit.test.tsx",
 		"src/claude/proof/subagent-vertical.integration.test.ts",
+		"src/claude/proof/subagent-paging.integration.test.ts",
 		"src/page/assets.d.ts"
 	],
 	// `exclude` is inherited, and the base excludes exactly this directory.

--- a/apps/tuval/tsconfig.json
+++ b/apps/tuval/tsconfig.json
@@ -36,7 +36,9 @@
 	// `src/claude/proof/subagent-vertical.integration.test.ts` is split the same way and for the same
 	// reason: it mounts the shipped chat window over a live process, so it reaches `@kampus/design`
 	// through it. Its two neighbours — the config module and the capture handle — reach no React and
-	// stay here.
+	// stay here. `subagent-paging.integration.test.ts` is split for the directory rather than the
+	// package: it joins the layer's history read to the window's own page request, so it reaches
+	// `src/shell/chat/rows.ts` — pure, but inside the slice this lens excludes whole.
 	// `src/pi/renderer-ref.ts`, `src/claude/renderer-ref.ts`, `src/agy/renderer-ref.ts`,
 	// `src/codex/renderer-ref.ts` and `src/ai-agent/renderer-ref.ts` still enter this project by
 	// import from their rows, which is the point of those leaves: a row names its renderer without
@@ -57,6 +59,7 @@
 		"src/page/attached-desk.unit.test.tsx",
 		"src/page/readable-state.unit.test.tsx",
 		"src/page/session-transcript-window.unit.test.tsx",
-		"src/claude/proof/subagent-vertical.integration.test.ts"
+		"src/claude/proof/subagent-vertical.integration.test.ts",
+		"src/claude/proof/subagent-paging.integration.test.ts"
 	]
 }


### PR DESCRIPTION
Three symptoms on the Tuval desk's Claude agent, one cause: the live-tail window and the pager
cursor both counted rows the desk never renders.

**The window spends the agent's bounds on the agent's own rows.** A nested worker's row arrives as
an ordinary transcript item tagged `parentId`, and with `subagentList` on `chatRows` drops every one
of them — but they paid full window freight on the way past, so each spawn shaved the operator's own
turns off the head until the rendered list was empty. `TranscriptGroup` now carries a `weight`
counting its own rows only, and the plan walk reads that instead of the group's whole size. A nested
row also no longer opens or closes a group, so a worker's own prompt cannot split the operator's
exchange in two.

**Those rows answer to a ceiling of their own.** Free of the agent's bounds is not free of every
bound: the tagging is unconditional, so with `subagentList` off the rows are both rendered — folded
under their call — and, if nothing else held them, unbounded. `nestedLimitsFor` gives them a second
ceiling at four times the agent's own. Reaching it puts a group's nested passengers down and keeps
the group's own rows, so a spawn still never costs the operator a turn, and the shed rows are
counted in `omitted` rather than vanishing. `takeGroups` is the one walk both the window and the
page run, so the ceiling cannot be applied in one loop and forgotten in the other.

**The pager no longer mints a cursor no backend can resolve.** `pageCursor`'s `isUnavailable` now
covers `system` items and `parentId` items beside the `local:` ids it already covered, so it walks
to the oldest row a stored session can actually resolve. Both classes are live-only: the Claude CLI
writes a worker's frames to a `subagents/agent-*.jsonl` sidecar rather than the session file
(`FixtureName`'s `subagent-turn` capture and `SIDECHAIN_AGENT_ID` in
`apps/tuval/src/claude/history/fixtures/load.ts`), and a task notice is minted from an SDK
notification that was never a message — `getSessionMessages` maps user and assistant rows only.

**A subagent's view has an empty state of its own.** An unresolved `viewedSlot` used to fall through
to `mainRows`, drawing the agent's own transcript inside the open subagent view. It now renders a
`slot-gone` row saying so; the trailing finished/running notice is suppressed there rather than
repeating that sentence twice.

Tests: a fold case pushing six spawns of nested rows at `itemLimit: 40` (and a byte-bound twin),
three `window.unit.test.ts` cases over the nested ceiling — that it sheds past it, that what it
sheds is counted, and that a spawn under it costs nothing — a new `cursor.unit.test.ts` over the
unavailable classes, a `ChatWindow` case for the unresolved slot, and
`claude/proof/subagent-paging.integration.test.ts`, which drives the real `ClaudeAiAgent` over the
captured `subagent-turn` frames and asserts both halves in one run. The property generator in
`core/properties.unit.test.ts` now emits spawns, so the bounds it names hold over a transcript that
has one — before, it emitted no `parentId` anywhere and every bound over nested rows passed
vacuously.

Reviewer: start at `apps/tuval/src/ai-agent/history/window.ts` — `takeGroups` is the whole idea, and
`groups.ts` only weighs what it reads.

## Deviations

- **Declined guidance** — **Said:** the issue's suggested shape is to skip `parentId` items at the
  fold when `subagentList` is on. **Did:** gave them a separate ceiling instead, with no flag
  anywhere in the core. **Why:** the flag cannot reach the fold. Program rows are built by
  user-written config modules calling `claudeSession({...})`, and the `features` block is a separate
  part of the config the row never sees, so threading it would mean a new option on
  `aiAgentProgram` that no real call site can fill. A ceiling needs no flag to be correct in both
  modes. **Disposition:** stated here.
- **Governing-ADR departure** — **Said:** #8405 contained the subagent work behind `subagentList`,
  so the flag off should leave the pre-flag window untouched. **Did:** with the flag off, a tail
  carrying more than the nested ceiling now sheds its oldest worker rows, which the pre-flag window
  would have kept. **Why:** the tagging is unconditional — `claude/history/map.ts` sets `parentId`
  off `parent_tool_use_id` with no flag in the path — so the flag-off mode is not reachable without
  either charging those rows the agent's bounds (which reintroduces the bug for anyone on the
  default) or bounding them separately. The rows are still rendered folded under their call up to
  the ceiling, and past it they are reported in `omitted` like any other bounded-out row.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names `ChatWindow.tsx`'s fallthrough. **Did:** also
  stopped rendering the trailing "not in this session's state" notice for an unresolved slot.
  **Why:** the new empty-state row carries that sentence inside the transcript region, and leaving
  the notice would print the same line twice on one screen. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `tsconfig`. **Did:** added the new integration
  test to `tsconfig.json`'s `exclude` and `tsconfig.design.json`'s `include`. **Why:** it joins the
  layer's history read to the window's own page request, so it imports `src/shell/chat/rows.ts` —
  pure, but inside the slice the node lens excludes whole. Same split
  `subagent-vertical.integration.test.ts` already carries, and the comment beside it says which of
  the two reasons applies. **Disposition:** stated here.

Fixes #8814
