### PR TITLE
fix: A program-spawned child is always a root: a Cmd handler cannot name its own process

### DIFF
--- a/apps/tuval/src/ai-agent/handlers/seed-rebase.unit.test.ts
+++ b/apps/tuval/src/ai-agent/handlers/seed-rebase.unit.test.ts
@@ -12,6 +12,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Scope} from "effect";
 import {assistantItem} from "../../ai-agent-fixtures/transcripts.ts";
 import {ProcessPorts} from "../../ports/index.ts";
+import {ProcessId} from "../../process/process.ts";
 import {ProcessSelf} from "../../process/self.ts";
 import {
 	type AiAgentSessionMsg,
@@ -57,7 +58,11 @@ describe("the prompt handler's re-seed", () => {
 				) =>
 					effect.pipe(
 						Effect.provideService(Scope.Scope, scope),
-						Effect.provideService(ProcessSelf, {scope, state: () => committed}),
+						Effect.provideService(ProcessSelf, {
+							id: ProcessId.make("seed-rebase"),
+							scope,
+							state: () => committed,
+						}),
 						Effect.provideService(ProcessPorts, {
 							emit: (port: string, payload: unknown) =>
 								Effect.sync(() => {

--- a/apps/tuval/src/authoring/define-program.ts
+++ b/apps/tuval/src/authoring/define-program.ts
@@ -32,6 +32,7 @@ import type {PayloadRejected, PortNotWired} from "../ports/errors.ts";
 import {ProcessPorts} from "../ports/ProcessPorts.ts";
 import type {HandlerFailed, ProcessNotFound} from "../process/errors.ts";
 import {Processes} from "../process/Processes.ts";
+import {ProcessSelf} from "../process/self.ts";
 import type {
 	AnyProgram,
 	CapabilityRequest,
@@ -226,10 +227,11 @@ const emitHandler = (cmd: EmitEffect) =>
 const spawnHandler = (cmd: SpawnEffect) =>
 	Effect.gen(function* () {
 		const processes = yield* SpawnedProcesses;
-		// The spawner's own process id is not something a handler can name — `ProcessPorts` is the
-		// whole of what a running process knows about itself — so a program-spawned child is a root
-		// and `on` has nowhere to route the child's out-ports back to (#8756, #8757).
-		const child = yield* processes.spawn(ProgramId.make(cmd.program), Option.none());
+		const self = yield* ProcessSelf;
+		// The parent is stamped here, off the process this interpretation is running for, and is
+		// never something the `spawn` effect carries (#8757). `on` still has nowhere to route the
+		// child's out-ports back to; that half is #8756's.
+		const child = yield* processes.spawn(ProgramId.make(cmd.program), Option.some(self.id));
 		return [spawned(child, cmd.program)];
 	});
 
@@ -272,7 +274,7 @@ export type EffectFailure =
 	| HandlerFailed
 	| ProcessNotFound;
 
-export type EffectServices = ProcessPorts | SpawnedProcesses | Processes;
+export type EffectServices = ProcessPorts | ProcessSelf | SpawnedProcesses | Processes;
 
 const HANDLERS: HostHandlers<AuthoredEvent, ProgramEffect, EffectFailure, EffectServices> = {
 	emit: emitHandler,

--- a/apps/tuval/src/authoring/define-program.unit.test.ts
+++ b/apps/tuval/src/authoring/define-program.unit.test.ts
@@ -6,6 +6,7 @@ import {SpawnedProcesses} from "../commands/core/process.ts";
 import {ProcessPorts} from "../ports/ProcessPorts.ts";
 import {Processes} from "../process/Processes.ts";
 import {type ProcessHandle, ProcessId} from "../process/process.ts";
+import {ProcessSelf} from "../process/self.ts";
 import {type AnyProgram, ProgramId} from "../registry/program.ts";
 import {type ArrivalEvent, defineProgram} from "./define-program.ts";
 import {emit, send, spawn, stop} from "./effect.ts";
@@ -194,8 +195,14 @@ describe("authoring.defineProgram", () => {
 		Effect.gen(function* () {
 			const sent: Array<readonly [ProcessId, string, unknown]> = [];
 			const child = ProcessId.make("process-child");
+			const self = ProcessId.make("process-self");
+			const parents: Array<Option.Option<ProcessId>> = [];
 			const spells = SpawnedProcesses.of({
-				spawn: () => Effect.succeed(child),
+				spawn: (_program, parent) =>
+					Effect.sync(() => {
+						parents.push(parent);
+						return child;
+					}),
 				send: (process, portName, payload) =>
 					Effect.sync(() => {
 						sent.push([process, portName, payload]);
@@ -204,12 +211,20 @@ describe("authoring.defineProgram", () => {
 				read: () => Effect.succeed(Option.none()),
 			});
 
-			const spawnedEvents = yield* runEffect(counter, spawn({programId: "reviewer", out: {}})).pipe(
-				Effect.provideService(SpawnedProcesses, spells),
+			const spawnedEvents = yield* Effect.scoped(
+				runEffect(counter, spawn({programId: "reviewer", out: {}})).pipe(
+					Effect.provideService(SpawnedProcesses, spells),
+					Effect.provideServiceEffect(
+						ProcessSelf,
+						Effect.map(Effect.scope, (scope) => ({id: self, scope, state: () => undefined})),
+					),
+				),
 			);
 			assert.deepStrictEqual(spawnedEvents, [
 				{type: "spawned", process: child, program: "reviewer"},
 			]);
+			// The handler stamps the parent off `ProcessSelf` and the effect carries no id (#8757).
+			assert.deepStrictEqual(parents, [Option.some(self)]);
 
 			const sentEvents = yield* runEffect(counter, send({process: child, port: "pr"}, 8728)).pipe(
 				Effect.provideService(SpawnedProcesses, spells),

--- a/apps/tuval/src/authoring/spawn-parentage.unit.test.ts
+++ b/apps/tuval/src/authoring/spawn-parentage.unit.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The parent edge a program-spawned child carries, end to end on a real kernel (#8757).
+ *
+ * Driven through a spawned process rather than the handler alone, because the thing under test is
+ * exactly what the handler cannot fake: `ProcessSelf.id` is the kernel's, provided at the one
+ * `Processes.spawn` every path goes through, and the child's parent is read back off the process
+ * table rather than off the value the handler passed.
+ *
+ * The second boot is the other half of the same claim: the edge is written into the checkpoint
+ * manifest, so a restore brings the child back still naming its spawner.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer, Option} from "effect";
+import {SpawnedProcesses} from "../commands/core/process.ts";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {restore} from "../durability/restore.ts";
+import {type CheckpointStores, memoryStores} from "../durability/stores.ts";
+import {Processes} from "../process/Processes.ts";
+import {ProcessTable} from "../process/ProcessTable.ts";
+import type {ProcessId} from "../process/process.ts";
+import {ProgramId} from "../registry/program.ts";
+import {Registry} from "../registry/Registry.ts";
+import {defineProgram} from "./define-program.ts";
+import {spawn} from "./effect.ts";
+
+const childId = ProgramId.make("spawn-parentage-child");
+const parentId = ProgramId.make("spawn-parentage-parent");
+
+const child = defineProgram({
+	id: childId,
+	init: () => ({}),
+	update: {},
+});
+
+/** One authored cell whose whole answer is a `spawn`, which is the effect this edge rides on. */
+const parent = defineProgram({
+	id: parentId,
+	init: (): {readonly spawns: number} => ({spawns: 0}),
+	update: {
+		hatch: (state: {readonly spawns: number}) => [
+			{spawns: state.spawns + 1},
+			[spawn({programId: childId, out: {}})],
+		],
+	},
+});
+
+const kernel = (stores: CheckpointStores) =>
+	SpawnedProcesses.layer({readTimeout: "1 second"}).pipe(
+		Layer.provideMerge(Processes.layer),
+		Layer.provideMerge(Layer.mergeAll(Registry.layer([parent, child]), Checkpoints.layer(stores))),
+	);
+
+/** Spawn the parent as a root, then make it hatch. The rows it left behind are the answer. */
+const firstBoot = (stores: CheckpointStores) =>
+	Effect.gen(function* () {
+		const spawned = yield* SpawnedProcesses;
+		const parentProcess = yield* spawned.spawn(parentId, Option.none());
+		const handle = Option.getOrThrow(
+			yield* Processes.use((kernel) => kernel.handle(parentProcess)),
+		);
+		yield* handle.dispatch({type: "hatch"});
+		const rows = yield* ProcessTable.use((table) => table.list);
+		return {parentProcess, rows: rows.map((row) => ({id: row.id, parentId: row.parentId}))};
+	}).pipe(Effect.provide(kernel(stores)), Effect.orDie);
+
+const secondBoot = (stores: CheckpointStores) =>
+	Effect.gen(function* () {
+		yield* restore(Context.empty());
+		const rows = yield* ProcessTable.use((table) => table.list);
+		return rows.map((row) => ({id: row.id, parentId: row.parentId}));
+	}).pipe(Effect.provide(kernel(stores)), Effect.orDie);
+
+const childRowOf = (
+	rows: ReadonlyArray<{readonly id: ProcessId; readonly parentId: Option.Option<ProcessId>}>,
+	parentProcess: ProcessId,
+) => {
+	const found = rows.filter((row) => row.id !== parentProcess);
+	assert.strictEqual(found.length, 1, "exactly one child was spawned");
+	return found[0]!;
+};
+
+describe("a program-spawned child's parent", () => {
+	it.effect("is the process the spawn was interpreted for", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+
+			const {parentProcess, rows} = yield* firstBoot(stores);
+
+			assert.deepStrictEqual(childRowOf(rows, parentProcess).parentId, Option.some(parentProcess));
+		}),
+	);
+
+	it.effect("survives a restore", () =>
+		Effect.gen(function* () {
+			const stores = memoryStores();
+			const {parentProcess} = yield* firstBoot(stores);
+
+			const rows = yield* secondBoot(stores);
+
+			assert.deepStrictEqual(childRowOf(rows, parentProcess).parentId, Option.some(parentProcess));
+		}),
+	);
+});

--- a/apps/tuval/src/ports/ProcessPorts.ts
+++ b/apps/tuval/src/ports/ProcessPorts.ts
@@ -1,7 +1,12 @@
 /**
  * The wiring as one running process sees it: emit on its own out-ports by name, and nothing
- * else. A program's Cmd handler requires this service and never a node id or the `Wiring`, so
- * which node it is running as stays its spawner's knowledge.
+ * else. A program's Cmd handler requires this service and never a node id or the `Wiring`: the
+ * routes stay its spawner's knowledge.
+ *
+ * Its own identity does not. A handler reads the process it is running as off `ProcessSelf`
+ * (`../process/self.ts`), which every spawn provides — parentage is the kernel's to stamp from the
+ * process it is interpreting for, identity is a free read, and neither is a relation a handler can
+ * set by naming an id (founder's ruling on #8757).
  *
  * Two spawners provide one per process. `src/launch/` binds a graph node's to the wiring, and
  * `src/commands/core/process.ts` binds a picker-spawned process's to that process's latches. A

--- a/apps/tuval/src/process/Processes.ts
+++ b/apps/tuval/src/process/Processes.ts
@@ -258,10 +258,14 @@ function makeServices() {
 			// What handlers actually get, and under the seal it is all they get: the spawner's set
 			// plus this process's own `ProcessSelf`. Never `options.services` directly — spawn is the
 			// one place `ProcessSelf` is provided, so no caller and no `restore` has to know it
-			// exists (#7603). The spawner's `Scope` is dropped on the way in: a spawner that passes
-			// its whole context on carries one, and the seal would let it beat the Scope the host
-			// forks for a sub handler. A handler that wants this process's own reads `ProcessSelf`.
+			// exists (#7603), and `id` rides along here for the same reason: every spawn path — the
+			// graph's launcher, the picker, an ad-hoc spawn, a restore — mints or carries the id at
+			// this one call, so a handler's `self` is a free read on all four (#8757). The spawner's
+			// `Scope` is dropped on the way in: a spawner that passes its whole context on carries
+			// one, and the seal would let it beat the Scope the host forks for a sub handler. A
+			// handler that wants this process's own reads `ProcessSelf`.
 			const granted = Context.add(Context.omit(Scope.Scope)(options.services), ProcessSelf, {
+				id,
 				scope,
 				state: () => readState(),
 			});

--- a/apps/tuval/src/process/self.ts
+++ b/apps/tuval/src/process/self.ts
@@ -1,20 +1,27 @@
 /**
  * What a running process knows about itself, as a service its own handlers may yield.
  *
- * Two things a row's handlers cannot otherwise reach, and both are per-process: the process's own
- * Scope (#7513), so a handler that acquires a resource for the life of the process acquires it
- * there and the stop releases it exactly once; and a read of the machine's committed state, so a
- * Sub handler can publish a projection of it on an out-port without keeping a second copy.
+ * Three things a row's handlers cannot otherwise reach, and all three are per-process: the
+ * process's own `ProcessId`, so a handler can name the process it is running as the way Elixir's
+ * `self()` is a free read (founder's ruling on #8757); its own Scope (#7513), so a handler that
+ * acquires a resource for the life of the process acquires it there and the stop releases it
+ * exactly once; and a read of the machine's committed state, so a Sub handler can publish a
+ * projection of it on an out-port without keeping a second copy.
+ *
+ * `id` is a read and never a write: a relation is the kernel's to stamp from the process it is
+ * interpreting for, so no authoring effect takes a process id as input to set one.
  *
  * `state` is `unknown` because the row's private types are erased at the registry (`ProcessRow`);
  * the program's own module owns the predicate that reads it back.
  */
 
 import {Context, type Scope} from "effect";
+import type {ProcessId} from "./process.ts";
 
 export class ProcessSelf extends Context.Service<
 	ProcessSelf,
 	{
+		readonly id: ProcessId;
 		readonly scope: Scope.Scope;
 		readonly state: () => unknown;
 	}


### PR DESCRIPTION
The kernel now stamps a program-spawned child's parent, and a running program can read its own
process id.

**The base is `epic/8716`, not `main`** — the code this touches (`apps/tuval/src/authoring/define-program.ts`
and the `defineProgram` spine around it) is not on `main` yet.

## What changed

- `ProcessSelf` (`apps/tuval/src/process/self.ts`) gains `id`, the running process's own `ProcessId`.
  It is a read and never a write.
- `Processes.spawn` supplies it at the same `Context.add` that already provides `ProcessSelf`. That
  is the one call every spawn path goes through — the graph's launcher, the picker, an ad-hoc
  `SpawnedProcesses.spawn`, and `restore` — so `self` is a free read on all four.
- `spawnHandler` in `define-program.ts` passes `Option.some(self.id)` instead of `Option.none()`.
  The `spawn` effect still carries no process id: parentage is the kernel's to stamp from the
  process it is interpreting for.
- `EffectServices` names `ProcessSelf`.
- `ProcessPorts`'s docblock now states the ruling instead of the superseded "which node it is
  running as stays its spawner's knowledge".

This implements the founder ruling recorded as the "Founder ruling, 2026-09-09" amendment on #8757.

## Proof

`apps/tuval/src/authoring/spawn-parentage.unit.test.ts` drives a real kernel: an authored program
whose `update` cell answers a `spawn`, then reads the child's `parentId` off the process table, and
again after a `restore` from the checkpoint manifest. Both assertions fail if `spawnHandler` goes
back to `Option.none()` — checked by reverting that one line and watching them red.

Reviewer's first stop: the `Processes.spawn` change, since that is the deviation below.

Fixes #8757

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 2 puts the new `self` service at the
  `Context.add` in `SpawnedProcesses.spawn` that injects `ProcessPorts`. **Did:** added `id` to the
  existing `ProcessSelf` service and supplied it at `Processes.spawn`'s `Context.add` instead.
  **Why:** `Processes.spawn` already provides `ProcessSelf` on every spawn, and its `Context.add`
  runs *after* the one in `SpawnedProcesses.spawn`, so a tag added there would be overwritten; a
  `self` that existed only for ad-hoc spawns would also leave a graph-launched or restored
  process's `spawnHandler` unable to resolve it, which criterion 4's restore half needs.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names `define-program.ts` and `process.ts`.
  **Did:** also added `id` to the one `ProcessSelf` a test constructs by hand
  (`apps/tuval/src/ai-agent/handlers/seed-rebase.unit.test.ts`). **Why:** the service's shape
  changed, so that construction no longer typechecks without it. **Disposition:** stated here.
