### PR TITLE
fix: A skill-class diff can merge without the writing-for-agents pass ever firing

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -198,8 +198,10 @@ write an issue body; a human or triage does. Release the claim
 
 Check any falsifiable claim the body makes against the source before building on it — a summary of a
 contract is not the contract. Name the surface you are on — **code** (compiled/tested text), **prose**
-(docs, decision records, briefs), **plan** (a ledger with topology), or **workflows** (`.github/workflows/**`,
-which reads under [`code.md`](references/code.md)'s rubric) — and read the matching rubric file in
+(docs, decision records, briefs), **plan** (a ledger with topology), **workflows** (`.github/workflows/**`,
+which reads under [`code.md`](references/code.md)'s rubric), or **skill** (agent-facing text under
+`claude-plugins/*/skills/`, which reads [`skill.md`](references/skill.md)'s rubric and, being
+markdown, validates under `prose`) — and read the matching rubric file in
 [`references/`](references/) before writing. Done when every acceptance criterion maps to
 something you can point at.
 

--- a/claude-plugins/fabrika/skills/build/references/prose.md
+++ b/claude-plugins/fabrika/skills/build/references/prose.md
@@ -21,6 +21,7 @@ resolution and doc-surface placement here.
   here.
 - **Never rewrite a filed issue body** — append a dated `## Amendment`. The tracker keeps no body
   history, so an overwrite destroys what the issue used to say with nothing to recover it from.
-- **Sentence-level writing discipline lives in the shared writing rubric skill**, consumed by
-  `build` and `review` both, so one rewrite of a rule reaches both stages. This file carries only
-  placement and sourcing rules; do not grow style guidance here.
+- **Sentence-level writing discipline lives in
+  [`writing-for-agents`](../../writing-for-agents/SKILL.md)**, consumed by `build` and `review`
+  both, so one rewrite of a rule reaches both stages. Read it inline as a reference. This file
+  carries placement and sourcing rules alone; style guidance belongs there.

--- a/claude-plugins/fabrika/skills/build/references/skill.md
+++ b/claude-plugins/fabrika/skills/build/references/skill.md
@@ -1,0 +1,21 @@
+# Surface rubric — skill
+
+Agent-facing text under `claude-plugins/*/skills/`: a `SKILL.md`, a rubric or reference file beside
+it, a `contract.md`. These files are markdown, so `fabrika build check --surface prose` validates
+them; this file is the rubric you read before writing one.
+
+- **Read [`writing-for-agents`](../../writing-for-agents/SKILL.md) and write under it**, before
+  authoring or editing any of those files. It carries the levers the text is judged on — where each
+  piece sits on the information hierarchy, whether a step's completion criterion is checkable, which
+  restatements a leading word retires, and the no-op test every sentence owes. Read it inline as a
+  reference; it has no run to spawn. That discipline is the whole route into a skill folder
+  (`claude-plugins/fabrika/docs/skill-conventions.md` §8 gate 1), and the gate reads the text rather
+  than the session that produced it — so writing some other way and tidying afterwards still lands
+  on a refusal.
+- **Hold the text to that plugin's conventions doc as well** — for fabrika, the same
+  `skill-conventions.md`: a deterministic step belongs in a verb, each fact keeps one home, and a
+  contract is read one heading at a time.
+- **The placement and sourcing rules in [`prose.md`](prose.md) still bind** — resolvable relative
+  links, one home per fact, point rather than restate. Skill text adds discipline on top; it
+  replaces none of that. Fabrika's own skill text is read in other repos, so every reference in it
+  resolves for a reader who has only the plugin.

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -112,8 +112,8 @@ bytes it read **at the commit you scoped** — pass step 1's head as `--sha`, an
 verdict is a label; bytes read out of that commit are the immunity. Apply the matching rubric file
 to each class's slice: code → [rubrics/code.md](rubrics/code.md) · doc →
 [rubrics/doc.md](rubrics/doc.md) · skill → [rubrics/skill.md](rubrics/skill.md). Editorial craft on
-any prose surface: apply **fabrika's** shared writing rubric skill verbatim, never v1's copy; the
-doc rubric's prose-craft line is the fallback until it lands.
+any prose surface: apply [`writing-for-agents`](../writing-for-agents/SKILL.md) verbatim, reading it
+inline as a reference, and state its outcome in that class's namespace.
 
 **A diff touching fabrika's own two trees owes the portability check, in the doc class and the skill
 class alike.** When any changed file sits under `claude-plugins/fabrika/` or

--- a/claude-plugins/fabrika/skills/review/rubrics/doc.md
+++ b/claude-plugins/fabrika/skills/review/rubrics/doc.md
@@ -33,8 +33,10 @@ Read the CI-at-head result; do not re-derive them.
   the repo declared as its own all resolve nowhere else, and the docs fabrika ships are read
   elsewhere. Raising an allow-list ceiling to fit a new one is itself the finding — that floor only
   shrinks.
-- **Prose craft.** Plain words, short sentences, nothing a reader must re-read to parse; once
-  fabrika's shared writing rubric skill lands, apply it verbatim instead of this line.
+- **Prose craft.** Plain words, short sentences, nothing a reader must re-read to parse. The
+  levers and the pruning tests live in the
+  [`writing-for-agents`](../../writing-for-agents/SKILL.md) skill; apply it verbatim to the
+  doc-class slice, reading it inline as a reference, and state its verdict here.
 
 ## Not this rubric's
 

--- a/claude-plugins/fabrika/skills/review/rubrics/skill.md
+++ b/claude-plugins/fabrika/skills/review/rubrics/skill.md
@@ -55,3 +55,17 @@ resolves one heading at a time, never a document loaded whole. Skill text and an
 spawn prompt in the diff point at
 `fabrika wire doc-section --heading "…" < <skill-base>/contract.md`; text telling an agent to read,
 open, or load a `contract.md` whole is a finding, whatever the read's shape.
+
+## 5 — Writing craft
+
+Apply [`writing-for-agents`](../../writing-for-agents/SKILL.md) verbatim to the skill-class slice
+and state its verdict here. `claude-plugins/fabrika/docs/skill-conventions.md` §8 gate 1 admits a
+skill only when it is written under that discipline, and the gate reads the text rather than the
+session that produced it, so this section is where the gate acquires teeth. Read the skill inline as
+a reference; it has no run to spawn.
+
+Name what it catches: a step whose completion criterion nothing can check, reference that buries the
+steps around it, one meaning kept in two homes, a sentence that changes no behaviour against the
+model's default, a rule steered by prohibition where the positive target would land harder. An unmet
+line is a finding, and a finding here refuses PASS on the `review-skill` namespace on the same
+footing as one from sections 1–4.


### PR DESCRIPTION
Wires the `writing-for-agents` pass into the two stages that touch skill-class text, mirroring how
`diataxis` is wired.

`build` gains a fifth named surface, **skill**, routed to a new
`claude-plugins/fabrika/skills/build/references/skill.md`. That rubric tells the builder to read
`writing-for-agents` before authoring or editing any `SKILL.md`, rubric, reference or `contract.md`
under `claude-plugins/*/skills/`, links it by relative path, and says it is read inline rather than
spawned.

`review` gains section 5 of `rubrics/skill.md`, which applies the same skill to the skill-class slice
and states that an unmet line refuses PASS on the `review-skill` namespace, on the same footing as
sections 1–4. The two hedges that told a reader the skill was unbuilt are gone: `review/SKILL.md`'s
editorial-craft sentence and `rubrics/doc.md`'s **Prose craft** bullet both name and link it now.

`fabrika build check --surface prose` is green with an empty `unvalidated`, and
`fabrika guard portability-guard check` is clean at 204 references, none above a ceiling.

The last acceptance criterion is the reviewer's to discharge, not the diff's: this PR is itself
skill-class, so the `review-skill` verdict on it is where the `writing-for-agents` outcome gets
stated under the wiring the PR adds.

## Deviations

- **Scope narrowing** — **Said:** name a **skill** surface alongside code/prose/plan/workflows.
  **Did:** named it as a rubric-routing surface and stated in the same sentence that a skill file,
  being markdown, validates under `--surface prose`. **Why:** `build check`'s `--surface` is a closed
  four-value enum in `packages/fabrika-cli/src/build/check-verb.ts` (`SURFACES`), and the contract
  documents it as such; a fifth value would be a CLI change claiming the same markdown class `prose`
  already claims, plus the six-place grammar sweep, none of which this issue's criteria ask for.
  **Disposition:** stated here, and the divergence between the named surfaces and the enum is filed
  as #8837.
- **Out-of-scope change** — **Said:** the criteria name two stale hedges, in `review/SKILL.md` and
  `rubrics/doc.md`. **Did:** also fixed a third dangling pointer, the last bullet of
  `build/references/prose.md`, which said "the shared writing rubric skill" without naming or linking
  it. **Why:** the issue body's own diagnosis names that bullet as part of the gap — an agent reading
  it cannot find the skill — so leaving it would ship the fix with the prose surface still unable to
  reach what the skill surface now reaches. **Disposition:** stated here.
- **Declined guidance** — **Said:** `review/SKILL.md` carried "never v1's copy" beside the rubric
  instruction. **Did:** dropped that clause when rewriting the sentence. **Why:** the clause
  disambiguated between two copies by prohibition; the relative link now names exactly one file, so
  the prohibition steers by naming a thing that no longer exists to reach for.
  **Disposition:** stated here.

Fixes #8834
