### PR TITLE
chore: The architecture-audit skill landed without a writing-for-agents pass

### DIFF
--- a/claude-plugins/fabrika/skills/architecture-audit/DEEPENING.md
+++ b/claude-plugins/fabrika/skills/architecture-audit/DEEPENING.md
@@ -9,7 +9,7 @@ redefined here.
 ## Dependency categories
 
 Classify a finding's dependencies. The category decides how the deepened module is tested across its
-seam.
+seam, and **every finding whose direction proposes deepening carries exactly one of the four.**
 
 ### 1. In-process
 
@@ -27,11 +27,8 @@ interface.
 
 Your own services across a network or isolate boundary. Define a **port** at the seam: the deep
 module owns the logic and the transport is injected as an **adapter** — an in-memory one for tests,
-the real one in production.
-
-Recommendation shape: *"define a port at the seam, implement a transport adapter for production and
-an in-memory adapter for tests, so the logic sits in one deep module even though it is deployed
-across a boundary."*
+the real one in production — so the logic sits in one deep module even though it is deployed across
+a boundary.
 
 ### 4. True external
 

--- a/claude-plugins/fabrika/skills/architecture-audit/SKILL.md
+++ b/claude-plugins/fabrika/skills/architecture-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-audit
-description: "Walk one folder for architectural friction and hand back a ranked table of deepening opportunities for a human to pick from. Trigger on \"/fabrika:architecture-audit\", \"audit the architecture of <folder>\", \"find deepening opportunities\", \"find shallow modules\", \"find refactor candidates\", \"where should we deepen\" — and reach for it whenever someone is about to re-derive that question by hand. It files nothing until a human picks; filing the picked set is `report`'s path. Not a code review, not a grilling loop, and it never edits the code it reads."
+description: "Audit one folder for architectural friction and hand back a ranked table of deepening opportunities a human picks from. Trigger on \"/fabrika:architecture-audit\", \"audit the architecture of <folder>\", \"where should we deepen this code\" — and reach for it whenever someone is about to re-derive that question by hand. Read-only on the code, and it files exactly what the human picks, through `report`. Judging a pull request is `review`'s lane; drilling one finding is `grilling`'s."
 ---
 
 # architecture-audit
@@ -63,10 +63,10 @@ fabrika glossary check --register both
 
 `clean` or `defects` both mean the registers exist — read `.glossary/LANGUAGE.md` for the
 architecture vocabulary and `.glossary/TERMS.md` for the domain nouns, and use those terms exactly.
-On `defects`, read them anyway and say in your report which rows looked stale. **`bootstrap` means
-this repo has no vocabulary yet**: stop on `STOPPED-NO-VOCABULARY` and say that `/fabrika:glossary`
-seeds it. Do not substitute your own definitions — a vocabulary invented for one run is one nothing
-later can compare against. A non-zero exit is UNKNOWN, not `clean`: re-run it.
+The registers are the only source: a vocabulary invented for one run is one nothing later can
+compare against. On `defects`, read them anyway and say in your report which rows looked stale.
+**`bootstrap` means this repo has no vocabulary yet**: stop on `STOPPED-NO-VOCABULARY` and say that
+`/fabrika:glossary` seeds it. A non-zero exit is UNKNOWN, not `clean`: re-run it.
 
 Then read the decided ground, so the audit does not surface a finding against something already
 settled. Where the decision corpus lives is the repo's own answer, not this skill's:
@@ -81,7 +81,8 @@ decision is decided ground: do not surface a finding that contradicts one unless
 enough to reopen it, and then say so inside the finding. A repo that declined a corpus has no decided
 ground to read; note that in your report and carry on.
 
-Done when you can name the terms you will use and the decisions your scope sits under.
+Done when both registers are read and every record under `decisionsDir` that touches the scope is
+open in front of you.
 
 ## 3 — Walk the folder through three lenses, in parallel
 
@@ -126,18 +127,16 @@ canonical surface. A smell the lenses already raised lands as `✗ found` pointi
 smell you find here that they missed is promoted into the finding set; a smell that genuinely does
 not apply is `— N/A` with a one-line reason.
 
-**Never hardcode the row count.** Emit one row per smell the catalog defines.
+**Count the rows at run time**, one per smell the catalog defines.
 
 Then extend the gate with the repo's own catalogs, if it declared any. `fabrika status settings`
 prints the `auditCatalogs` row: a list of repo-relative markdown paths, each a catalog in the same
 table shape. **The extension is add-only, and the order is the rule that makes it so**: emit every
 shipped row first, in the shipped order, then each declared catalog's rows in the order the key lists
-them. A repo catalog can only append smells. It can never remove or replace a shipped one, and a
-declared row that restates a shipped smell is a duplicate row, not an override — the gate keeps
-both, and the shipped one is the one that counts. A `Malformed` row for the key means the repo's
-catalog list did not decode: say so, run the shipped catalog alone, and do not guess at what it meant.
+them.
 
-The row grammar and what each status commits you to are one section:
+The row grammar, what each status commits you to, and what each `auditCatalogs` answer means for the
+gate are one section:
 
 ```bash
 fabrika wire doc-section --heading "The coverage gate" < <skill-base>/contract.md
@@ -153,8 +152,13 @@ lens findings and a gate row describing one duplicated contract are one finding 
 attributions, not three findings. Nor is the reverse acceptable — three unrelated problems in one
 finding make triage do the splitting.
 
-Rank the set. Rank on the cost of leaving it, not on how much you enjoyed finding it: how much
-scatters, what the interface fails to hide, what cannot be tested through it today.
+Rank the set. Rank on the cost of leaving it: how much scatters, what the interface fails to hide,
+what cannot be tested through it today.
+
+Each finding's deepening direction carries one dependency category, and
+[DEEPENING.md](DEEPENING.md) is where the four categories and the test seam each implies live. The
+category is a non-binding hint that travels with the finding into the table's Direction column and
+into the filed issue's suggested next step.
 
 Then check each against what is already on the board, immediately before you hand the table over:
 
@@ -169,7 +173,7 @@ is UNKNOWN, never `none` — say in the table that the dedup did not run for tha
 reads is the verb's own section
 (`fabrika wire doc-section --heading "report dedup" < ../report/contract.md`).
 
-Done when every finding carries a rank, an attribution, and a dedup answer.
+Done when every finding carries a rank, an attribution, a dependency category, and a dedup answer.
 
 ## 7 — Hand back the table, and stop
 
@@ -186,9 +190,9 @@ The column list and the recommendation vocabulary are one section:
 fabrika wire doc-section --heading "The finding table" < <skill-base>/contract.md
 ```
 
-Then stop and wait. Do not file the set you would have picked, do not file the unambiguous ones
-early, and do not read silence as approval. An audit that files ahead of the pick has spent the whole
-gate.
+Then stop and wait for a named pick — every row of it, including the ones you would have picked
+yourself and the ones nothing could argue with. Silence is a run still waiting, and an audit that
+files ahead of the pick has spent the whole gate.
 
 Done when the table is in front of a human and nothing has been written.
 
@@ -225,8 +229,9 @@ Done when every picked finding has a number and a URL, and nothing unpicked was 
 
 ## 9 — Report
 
-End on exactly one terminal. Name the scope, then the numbers and URLs — never re-state the findings
-the table already carried, and never triage, prioritize or fix what you filed.
+End on exactly one terminal. Name the scope, then the numbers and URLs, and stop there — the table
+already carried the findings, and triaging, prioritizing or fixing what you filed is someone else's
+turn.
 
 - **`FILED`** — the picked set is on the board; the count, the numbers, and any finding that went on
   an existing issue as a note. Nothing else was written.
@@ -243,19 +248,10 @@ the table already carried, and never triage, prioritize or fix what you filed.
 
 ## Hard rules
 
-- **The output is issues, never a doc.** No audit doc, no vault file, no decision record. A finding
-  becomes an issue or it becomes nothing.
-- **Nothing is filed without a human's pick.** The table is the terminal of the audit half.
-- **Read-only on the code.** The explorer's tool restriction is the contract; the orchestrator holds
-  itself to it too.
-- **Vocabulary comes from the registers, read at run time.** This skill carries no copy of them.
-- **Three lenses, parallel, framed as instructions.** Not one lens, not serial, and never as a
-  persona — "you are a senior testability auditor" costs measurable accuracy against "focus this
-  pass on testability".
-- **Single-lens findings survive.** Cluster size ranks; it never filters.
-- **The catalog is a coverage gate.** It proves the walk covered the surface; it is not the
-  discovery mechanism.
-- **Repo catalogs add and never subtract.** Shipped rows first, always.
-- **Type-blind, priority-blind on file.** Only `status:needs-triage`.
-- **No embedded grilling.** Stop after filing. A finding worth drilling into is `/fabrika:grilling`,
-  one command away.
+The two rules that bind the whole run rather than one step of it — every other invariant is stated
+where it acts, and the step that states it is the one that owns it.
+
+- **Every finding leaves as an issue, or it leaves as nothing.** The run writes no audit doc, no
+  vault file, and no decision record; the ranked table and the filed issues are its entire output.
+- **The run stops after filing.** A finding worth drilling into is `/fabrika:grilling`, one command
+  away, and that is a fresh run someone starts on purpose.

--- a/claude-plugins/fabrika/skills/architecture-audit/SMELLS.md
+++ b/claude-plugins/fabrika/skills/architecture-audit/SMELLS.md
@@ -1,12 +1,12 @@
 # Smell catalog
 
 The finite list of code-shape smells the audit checks explicitly. It runs as a **coverage gate**
-after the lens passes ([SKILL.md](SKILL.md) step 5). Each smell gets one row, and one of three
-statuses:
+after the lens passes ([SKILL.md](SKILL.md) step 5): each smell gets one row carrying `✓ checked`,
+`— N/A` or `✗ found`. What each status commits you to, and the table's shape, are the contract's:
 
-- **✓ checked** — looked, found none
-- **— N/A** — the smell does not apply to this code shape, with a one-line reason
-- **✗ found** — present, with the file or symbol, and the finding that covers it
+```bash
+fabrika wire doc-section --heading "The coverage gate" < <skill-base>/contract.md
+```
 
 The gate converts open-ended audit output into a **covered surface**. Two runs that surface
 different findings can still be honestly compared, because they checked the same finite list. **The
@@ -14,20 +14,19 @@ catalog is the durable artifact; the candidate set is not.**
 
 ## Why a catalog at all
 
-Smell catalogs are the transferable half of pre-LLM refactoring research: the search algorithms did
-not survive, the catalogs did. So the list is borrowed and the metrics are not — every smell below is
-a qualitative predicate, never a numeric threshold, because a reader who cannot count tokens
-precisely will invent a count that clears whatever bar you set.
+Every smell below is a **qualitative predicate**, never a numeric threshold: a reader who cannot
+count tokens precisely will invent a count that clears whatever bar you set, so the bar is a shape
+you can see rather than a number you have to measure.
 
-## Why these ten
+## Why these smells
 
 They are language-neutral, and each one names friction in the architecture vocabulary the repo's own
-`.glossary/LANGUAGE.md` defines — depth, seam, locality, leverage. **This file does not define those
-terms and must not**: it points at the register, and the audit reads the register at run time.
+`.glossary/LANGUAGE.md` defines — depth, seam, locality, leverage. **The register is where those
+terms are defined**, read at run time; this file points at it and holds no copy.
 
-The ten are a starter, not a ceiling. A repo adds its own in the same table shape through the
-`auditCatalogs` config key, and the gate emits those rows after the shipped ones. The extension is
-add-only: nothing a repo declares can remove or replace a smell below.
+The shipped list is a starter, not a ceiling. A repo adds its own in the same table shape through
+the `auditCatalogs` config key, and the gate emits those rows after the shipped ones. The extension
+is add-only: nothing a repo declares can remove or replace a smell below.
 
 ## The smells
 
@@ -80,27 +79,10 @@ Symptom: "always do X" in docs, with no lint rule, type, or runtime check behind
 
 ## Reporting the gate
 
-The gate is an internal accounting step, **not a filed artifact**. This skill files one issue per
-picked finding and writes no audit document. Run the gate as a table, then promote any `✗ found`
-smell the lens passes missed into the finding set before the table goes back to the human:
-
-```markdown
-| Smell | Status | Notes |
-|---|---|---|
-| 1. Shallow module | ✗ found | finding 2 (`adapt-payload`) |
-| 2. Pass-through layer | ✓ checked | none |
-| 3. Duplicated contract | ✗ found | finding 1 |
-| 4. Magic-string seam | ✗ found | finding 4 |
-| 5. Stale module | ✓ checked | none |
-| 6. Test surface mismatch | ✗ found | finding 3 |
-| 7. Hidden global state | — N/A | no shared mutable state in scope |
-| 8. Shotgun surgery hotspot | ✓ checked | none in this scope |
-| 9. Stale duplicate test | ✓ checked | none |
-| 10. Convention-over-code drift | — N/A | no convention claims in scope |
-```
+Run the gate as a table, then promote any `✗ found` smell the lens passes missed into the finding
+set before the table goes back to the human.
 
 Two runs over the same code may surface different findings, and **their rows should still match** —
 that is what the gate buys. A Status column that moves between runs is itself worth looking at.
 
-**Never hardcode the row count.** Emit one row per smell defined above, in order, then one per smell
-in each declared repo catalog, in the order the `auditCatalogs` key lists them.
+**Count the rows at run time**, one per smell defined above, in order.

--- a/claude-plugins/fabrika/skills/architecture-audit/contract.md
+++ b/claude-plugins/fabrika/skills/architecture-audit/contract.md
@@ -121,13 +121,16 @@ saying out loud in the notes.
 **The gate is an accounting step, never a filed artifact.** It goes back to the human with the
 finding table and stops there.
 
-Three answers the `auditCatalogs` row can carry, and what each means for the gate:
+Three answers the `auditCatalogs` row's provenance cell can carry, and what each means for the gate:
 
 - **`default`** — the repo declared none. Run the shipped catalog alone. This is the ordinary case.
 - **`declared`** — read each path. A path that does not resolve is a fact to report beside the
   table, not a reason to skip the gate: run the shipped rows and say which catalog was unreadable.
-- **`malformed`** — the declared list did not decode, and the reason names what was rejected. Run
-  the shipped catalog alone and relay the reason. Do not guess at the intended list.
+- **`unknown`** — the declared list did not decode, and the row's detail cell names what was
+  rejected. Run the shipped catalog alone, relay that reason verbatim, and treat the intended list
+  as unread. `status settings` renders a malformed value and an unreadable file as the same
+  `unknown`, precisely so neither can print as the default it never resolved to
+  ([`settings-verb.ts`](../../../../packages/fabrika-cli/src/status/settings-verb.ts)).
 
 ## The finding table
 
@@ -178,13 +181,17 @@ prescribes, and prescribing here is the classification triage owes.
 A picked `note` row skips all of this: it adds to the existing issue only what that issue does not
 already carry, through `fabrika report note`.
 
-## What this skill's shape owes elsewhere
+## What this skill's shape owes the plugin conventions
 
-- **It does not fork.** It declares neither `context: fork` nor `background: true`, because a human
-  is waiting on the finding table and a backgrounded run's table dies with its context — the same
-  clause-2 failure the conversational skills have.
-- **It declares no `arguments:`.** Its scope is a path, not a number, so the frontmatter rule that
-  binds a number-taking skill does not reach it; step 1 of the `SKILL.md` is the whole scope
+Each rule lives in [`skill-conventions.md`](../../docs/skill-conventions.md); this section records
+which side of it this skill falls on and why.
+
+- **It does not fork** (§13). It declares neither `context: fork` nor `background: true`, because a
+  human is waiting on the finding table and a backgrounded run's table dies with its context — the
+  same clause-2 failure the conversational skills have.
+- **It declares no `arguments:`** (§12). Its scope is a path, not a number, so the frontmatter rule
+  that binds a number-taking skill does not reach it; step 1 of the `SKILL.md` is the whole scope
   contract.
-- **Its GitHub access is the `report` verbs' and nothing else.** It makes no direct forge call, so
-  the REST-only rule binds it through those verbs rather than through any invocation of its own.
+- **Its GitHub access is the `report` verbs' and nothing else** (§11). It makes no direct forge
+  call, so the REST-only rule binds it through those verbs rather than through any invocation of
+  its own.


### PR DESCRIPTION
`writing-for-agents` (plus its `SKILL-MECHANICS.md` sibling) applied to the four files PR #8823
added under `claude-plugins/fabrika/skills/architecture-audit/`. Editorial only: same three lens
passes, same coverage gate, same human-pick step, same filing path through `report`, same `fabrika`
verbs.

Fixes #8833

## What the pass changed, per file

**`SKILL.md`** — the `description` rewritten as a context pointer: front-loaded on `Audit` (the word
that does the triggering), the four synonyms for one branch (`find deepening opportunities` /
`find shallow modules` / `find refactor candidates` / `where should we deepen`) collapsed to one
trigger, the identity the body already carries cut, and the boundary framed positively
(`Read-only on the code` rather than `never edits`; `review`'s and `grilling`'s lanes named rather
than "not a code review, not a grilling loop"). Step 2's completion criterion sharpened from "you
can name the terms" to a checkable, exhaustive bound. Step 5's inlined `auditCatalogs` detail pulled
back behind the pointer that already fires there — `contract.md` owns it, and skill-conventions §2
calls a `SKILL.md` that inlines what its contract owns the defect. Step 6 now points at
`DEEPENING.md`, which nothing in `SKILL.md` reached before, and its criterion names the dependency
category the finding table's Direction column already required. Three negation-led passages flipped
positive (step 2's vocabulary rule, step 5's row count, step 7's three "do not"s, step 9's two
"never"s). Hard rules cut from ten to the two that bind the whole run rather than one step;
each of the eight removed is stated verbatim where it acts:

| Removed rule | Where it still binds |
|---|---|
| Nothing is filed without a human's pick | preamble, the capabilities paragraph, and step 7 |
| Read-only on the code | the capabilities paragraph (orchestrator) and step 3 (explorer) |
| Vocabulary from the registers, read at run time | step 2, first line, bolded |
| Three lenses, parallel, never a persona | `contract.md` "The three lens briefs", fetched at step 3 |
| Single-lens findings survive | step 4, two bolded bullets |
| The catalog is a coverage gate | step 5, first bolded clause |
| Repo catalogs add and never subtract | step 5's add-only sentence |
| Type-blind, priority-blind on file | step 8 |

**`SMELLS.md`** — the three status definitions and the ten-row example table were second copies of
`contract.md`'s "The coverage gate"; replaced with the `doc-section` pointer to that section, which
also removes the ten-row example that invited hardcoding the row count. `## Why these ten` renamed
`## Why these smells` — the old title contradicted the catalog's own add-only extension and the
"count the rows at run time" rule. The pre-LLM-refactoring-research paragraph cut as exposition that
changes no behaviour; the qualitative-predicate rule it wrapped kept and promoted.

**`DEEPENING.md`** — an exhaustiveness bar added at the top ("every finding whose direction proposes
deepening carries exactly one of the four"), which is the demand an all-reference file needs to bind
anything. Category 3's "Recommendation shape" block quote folded into the category paragraph: it
restated the category in other words, and its one unique clause survives inline.

**`contract.md`** — the `auditCatalogs` answer list corrected against `settings-verb.ts`: the
provenance cell renders `unknown`, never `malformed`, so the branch as written waited on a token the
verb does not print. Section citations added to the plugin-convention bullets, and the vague
heading "What this skill's shape owes elsewhere" renamed.

## What the pass deliberately left alone

The ten smells' own text, the four dependency categories, every `fabrika` verb the skill calls, the
verb inventory table, "Considered and deliberately not derived", the terminal vocabulary, the three
lens framings verbatim, and the `## What this reads, what it may obey, and what it can do` heading
— a spelled-out triad the rubric would tighten, but one `glossary/SKILL.md` carries identically, so
changing it here alone would break the corpus-wide anchor rather than fix it.

## Verification

All four `fabrika wire doc-section` pointers re-resolved against the edited `contract.md`, plus the
`report dedup` pointer into `../report/contract.md`. `build check --surface prose` green with an
empty `unvalidated`. `guard skill-lint`, `guard portability-guard` and `guard pointer-guard` clean.

## Deviations

- **Out-of-scope change** — **Said:** the pass is editorial over agent-facing text. **Did:** also
  corrected `contract.md`'s `auditCatalogs` answer list from `malformed` to `unknown`. **Why:** the
  rubric's relevance test catches a line that has gone stale against the world it describes, and
  this one named a token `status settings` never prints, so the branch could not fire; grounded in
  `packages/fabrika-cli/src/status/settings-verb.ts`, which maps both `Malformed` and `Unknown` to
  the `unknown` provenance. **Disposition:** stated here, and the source cited inline in the file.
- **Out-of-scope change** — **Said:** re-point, do not add. **Did:** added a `SKILL.md` → 
  `DEEPENING.md` pointer at step 6 and named the dependency category in that step's completion
  criterion. **Why:** `DEEPENING.md` was unreachable from `SKILL.md` — the only pointer to it sat in
  the finding table's Direction column, which fires two steps after the category is composed. The
  category was already mandatory there and in the report mapping, so the criterion makes an existing
  requirement checkable rather than adding one. **Disposition:** stated here.
- **Pre-existing text cut** — **Said:** the pass may reword, re-tier and re-point. **Did:** deleted
  eight of `SKILL.md`'s ten hard rules, `SMELLS.md`'s status definitions and its ten-row example
  table. **Why:** the duplication lever — one meaning, one home. **Disposition:** every deleted
  meaning's surviving home is named in the table and the per-file notes above; nothing was cut
  without one.
