### PR TITLE
feat: An authored ask never gets its reply, and spawn's child-port routing is dropped

### DIFF
--- a/.patterns/tuval-spells.md
+++ b/.patterns/tuval-spells.md
@@ -441,6 +441,14 @@ spells as one list.
   table exposes rows and no dispatch; `send` and `read` answer `UnknownProcess` for a process this
   service did not spawn.
 
+  `SpawnedProcesses` also carries the answer path, which is not a spell and is reachable from no
+  spell's params: `ask` puts a payload on a request port and holds, against a correlation it mints,
+  where the answer goes; `answer` spends one correlation, checks the payload against that port's own
+  output schema, and hands it to the asking process; and `spawn`'s `on` record turns a named child
+  out-port into one of the spawner's own events. All three land through `deliver`
+  ([`process/inbox.ts`](../apps/tuval/src/process/inbox.ts)), which needs only a live handle — so an
+  answer reaches any process, not only one these spells spawned.
+
 ### The bridge
 
 `SpellBridge` ([`bridge/SpellBridge.ts`](../apps/tuval/src/commands/bridge/SpellBridge.ts)) is

--- a/apps/tuval/src/authoring/answer-path.unit.test.ts
+++ b/apps/tuval/src/authoring/answer-path.unit.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The two answer paths an authored program has, end to end on a real kernel (#8756): an `ask`
+ * answered by its callee, and a spawned child's out-port arriving as the spawner's own event.
+ *
+ * Driven through live processes rather than through the handlers alone, because what is under test
+ * is the delivery the handlers cannot fake — the caller's `Reply` is dispatched by the kernel into a
+ * process that is not the one that asked for it (`../process/inbox.ts`), and the child's route is
+ * seen at the emit rather than at the spawn.
+ *
+ * `it.live` because both answers cross a pump: the callee's in-port queue is drained by a forked
+ * fiber, so the asking dispatch returns before the answer exists and the assertion has to wait for
+ * a real clock rather than a test one.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Option, Schema} from "effect";
+import {SpawnedProcesses} from "../commands/core/process.ts";
+import {Checkpoints} from "../durability/Checkpoints.ts";
+import {memoryStores} from "../durability/stores.ts";
+import {Processes} from "../process/Processes.ts";
+import {ProcessTable} from "../process/ProcessTable.ts";
+import type {ProcessHandle, ProcessId} from "../process/process.ts";
+import {type AnyProgram, ProgramId} from "../registry/program.ts";
+import {Registry} from "../registry/Registry.ts";
+import {defineProgram} from "./define-program.ts";
+import {ask, emit, reply, spawn} from "./effect.ts";
+import {port} from "./port.ts";
+
+const kernel = (programs: ReadonlyArray<AnyProgram>) =>
+	SpawnedProcesses.layer({readTimeout: "1 second"}).pipe(
+		Layer.provideMerge(Processes.layer),
+		Layer.provideMerge(Layer.mergeAll(Registry.layer(programs), Checkpoints.layer(memoryStores()))),
+	);
+
+const handleOf = (process: ProcessId): Effect.Effect<ProcessHandle, never, Processes> =>
+	Effect.map(
+		Processes.use((live) => live.handle(process)),
+		Option.getOrThrow,
+	);
+
+/**
+ * Read until the answer lands or the attempts run out. A settled read is the assertion's own — a
+ * timed-out one answers the last value it saw, so the failure names what was there instead.
+ */
+const settle = <A>(read: Effect.Effect<A>, done: (value: A) => boolean): Effect.Effect<A> =>
+	Effect.gen(function* () {
+		let seen = yield* read;
+		for (let attempt = 0; attempt < 200 && !done(seen); attempt++) {
+			yield* Effect.sleep("5 millis");
+			seen = yield* read;
+		}
+		return seen;
+	});
+
+const calleeId = ProgramId.make("answer-path-callee");
+const askerId = ProgramId.make("answer-path-asker");
+
+/** The callee: one request port, and a cell whose whole answer is the bound `reply` it was handed. */
+const callee = defineProgram({
+	id: calleeId,
+	ports: {question: port.request(Schema.Number, Schema.String)},
+	init: () => ({}),
+	update: {
+		question: (state: Record<string, never>, event) => [
+			state,
+			[reply(event.reply, `answered ${event.payload}`)],
+		],
+	},
+});
+
+interface AskerState {
+	readonly heard: ReadonlyArray<string>;
+}
+
+const asker = defineProgram({
+	id: askerId,
+	init: (): AskerState => ({heard: []}),
+	update: {
+		put: (state: AskerState, event: {readonly type: "put"; readonly at: ProcessId}) => [
+			state,
+			[ask({process: event.at, port: "question"}, 8756, {reply: "answered"})],
+		],
+		answered: (state: AskerState, event: {readonly type: "answered"; readonly payload: string}) => [
+			{heard: [...state.heard, event.payload]},
+			[],
+		],
+	},
+});
+
+const routedChildId = ProgramId.make("answer-path-child");
+const spawnerId = ProgramId.make("answer-path-spawner");
+
+/** Two out-ports, one of which the spawner names in `on` and the other of which it does not. */
+const routedChild = defineProgram({
+	id: routedChildId,
+	ports: {result: port.out(Schema.String), noise: port.out(Schema.String)},
+	init: () => ({}),
+	update: {
+		say: (
+			state: Record<string, never>,
+			event: {readonly type: "say"; readonly port: string; readonly text: string},
+		) => [state, [emit(event.port, event.text)]],
+	},
+});
+
+interface SpawnerState {
+	readonly reviewed: ReadonlyArray<unknown>;
+	readonly stray: ReadonlyArray<unknown>;
+}
+
+const spawner = defineProgram({
+	id: spawnerId,
+	init: (): SpawnerState => ({reviewed: [], stray: []}),
+	update: {
+		hatch: (state: SpawnerState) => [
+			state,
+			[spawn({programId: routedChildId, out: {result: "", noise: ""}}, {on: {result: "reviewed"}})],
+		],
+		spawned: (state: SpawnerState) => [state, []],
+		reviewed: (
+			state: SpawnerState,
+			event: {readonly type: "reviewed"; readonly payload: unknown},
+		) => [{...state, reviewed: [...state.reviewed, event.payload]}, []],
+		// The port `on` does not name. A cell under the port's own name is what would catch a route
+		// that fired for every out-port rather than only the named ones.
+		noise: (state: SpawnerState, event: {readonly type: "noise"; readonly payload: unknown}) => [
+			{...state, stray: [...state.stray, event.payload]},
+			[],
+		],
+	},
+});
+
+describe("an authored program's answer paths", () => {
+	it.live("answers an `ask` as the caller's own `Reply` event", () =>
+		Effect.gen(function* () {
+			const spells = yield* SpawnedProcesses;
+			const answering = yield* spells.spawn(calleeId, Option.none());
+			const asking = yield* spells.spawn(askerId, Option.none());
+			const askerHandle = yield* handleOf(asking);
+
+			yield* askerHandle.dispatch({type: "put", at: answering});
+
+			const state = yield* settle(
+				Effect.sync(() => askerHandle.getState() as AskerState),
+				(seen) => seen.heard.length > 0,
+			);
+			assert.deepStrictEqual(state.heard, ["answered 8756"]);
+		}).pipe(Effect.provide(kernel([callee, asker])), Effect.orDie),
+	);
+
+	it.live(
+		"routes a child's named out-port into the spawner's event, and an unnamed one nowhere",
+		() =>
+			Effect.gen(function* () {
+				const spells = yield* SpawnedProcesses;
+				const spawning = yield* spells.spawn(spawnerId, Option.none());
+				const spawnerHandle = yield* handleOf(spawning);
+
+				yield* spawnerHandle.dispatch({type: "hatch"});
+				const rows = yield* ProcessTable.use((table) => table.list);
+				const child = rows.find((row) => row.programId === routedChildId);
+				assert.ok(child !== undefined, "the spawner hatched a child");
+				const childHandle = yield* handleOf(child.id);
+
+				yield* childHandle.dispatch({type: "say", port: "noise", text: "ignore me"});
+				yield* childHandle.dispatch({type: "say", port: "result", text: "ship it"});
+
+				const state = yield* settle(
+					Effect.sync(() => spawnerHandle.getState() as SpawnerState),
+					(seen) => seen.reviewed.length > 0,
+				);
+				assert.deepStrictEqual(state.reviewed, ["ship it"]);
+				assert.deepStrictEqual(state.stray, []);
+			}).pipe(Effect.provide(kernel([spawner, routedChild])), Effect.orDie),
+	);
+});

--- a/apps/tuval/src/authoring/commands.ts
+++ b/apps/tuval/src/authoring/commands.ts
@@ -59,7 +59,7 @@ const asList = (answer: CommandAnswer): ReadonlyArray<ProgramEffect> =>
 /**
  * Run a command's effects through the spine's handlers, exactly as an `update` cell's effects are
  * run. The events those handlers answer — a `spawn`'s `spawned`, a `stop`'s `stopped` — are
- * dropped here: a spell call is not a process step and has no inbox to dispatch them into (#8756).
+ * dropped here: a spell call is not a process step and has no inbox to dispatch them into.
  */
 const interpret = <E, R>(
 	answer: CommandAnswer,

--- a/apps/tuval/src/authoring/define-program.ts
+++ b/apps/tuval/src/authoring/define-program.ts
@@ -21,7 +21,9 @@
 import type {DepKeyedSub, Interpret} from "@demlik/tea";
 import {Effect, Option} from "effect";
 import type {
+	PortAnswersNothing,
 	PortRefused,
+	UnclaimedReply,
 	UnknownPort,
 	UnknownProcess,
 	UnknownProgram,
@@ -31,6 +33,7 @@ import type {OpenError} from "../durability/Checkpoints.ts";
 import type {PayloadRejected, PortNotWired} from "../ports/errors.ts";
 import {ProcessPorts} from "../ports/ProcessPorts.ts";
 import type {HandlerFailed, ProcessNotFound} from "../process/errors.ts";
+import {isAsked, NO_REPLY, type ReplyTo} from "../process/inbox.ts";
 import {Processes} from "../process/Processes.ts";
 import {ProcessSelf} from "../process/self.ts";
 import type {
@@ -50,6 +53,7 @@ import {
 	type AskEffect,
 	type EmitEffect,
 	type ProgramEffect,
+	type ReplyEffect,
 	type SendEffect,
 	type SpawnEffect,
 	type StopEffect,
@@ -63,6 +67,7 @@ import {
 	type OutPortDecl,
 	type PortDecls,
 	type PortPayload,
+	type RequestPortDecl,
 } from "./port.ts";
 import {
 	type AuthoredWindow,
@@ -90,6 +95,22 @@ export interface ArrivalEvent<Name extends string, Payload> {
 	readonly payload: Payload;
 }
 
+/**
+ * A `port.request` arrival: the same event as any other, plus the bound `reply` the caller's `ask`
+ * is waiting on (#8716 R17.1). The address is opaque and belongs to this one question, so the cell
+ * answers by handing it back to `reply(event.reply, answer)` and names no process.
+ */
+export interface RequestArrivalEvent<Name extends string, Payload>
+	extends ArrivalEvent<Name, Payload> {
+	readonly reply: ReplyTo;
+}
+
+/** What arrives on one declared port, which is the request kind's arrival for a request port. */
+export type ArrivalEventOf<D extends PortDecls, K extends keyof D & string> =
+	D[K] extends RequestPortDecl<any, any>
+		? RequestArrivalEvent<K, PortPayload<D[K]>>
+		: ArrivalEvent<K, PortPayload<D[K]>>;
+
 /** The declared ports that own a queue — `in` and `request` — which are the ones that arrive. */
 export type ArrivingPortNames<D extends PortDecls> = {
 	[K in keyof D]: D[K] extends OutPortDecl<any> ? never : K;
@@ -110,7 +131,7 @@ export type UpdateTable<S, D extends PortDecls, U> = {
 	[K in keyof U | ArrivingPortNames<D>]: K extends typeof KEY_EVENT
 		? EventHandler<S, KeyEvent>
 		: K extends ArrivingPortNames<D>
-			? EventHandler<S, ArrivalEvent<K & string, PortPayload<D[K & keyof D]>>>
+			? EventHandler<S, ArrivalEventOf<D, K & keyof D & string>>
 			: EventHandler<S, any>;
 };
 
@@ -229,9 +250,9 @@ const spawnHandler = (cmd: SpawnEffect) =>
 		const processes = yield* SpawnedProcesses;
 		const self = yield* ProcessSelf;
 		// The parent is stamped here, off the process this interpretation is running for, and is
-		// never something the `spawn` effect carries (#8757). `on` still has nowhere to route the
-		// child's out-ports back to; that half is #8756's.
-		const child = yield* processes.spawn(ProgramId.make(cmd.program), Option.some(self.id));
+		// never something the `spawn` effect carries (#8757). `on` rides along as that same
+		// process's routing table, so a named child port arrives as this process's own event.
+		const child = yield* processes.spawn(ProgramId.make(cmd.program), Option.some(self.id), cmd.on);
 		return [spawned(child, cmd.program)];
 	});
 
@@ -243,15 +264,24 @@ const sendHandler = (cmd: SendEffect) =>
 	});
 
 /**
- * An `ask` delivers on the target's request port exactly as a `send` does. The answer does not come
- * back yet: a request port compiles to an in-port and the kernel carries no reply channel to
- * correlate `reply` against, so the `Reply` event is owed by the substrate, not by this compiler
- * (#8756). Delivering is the half that exists; failing here would refuse a payload that lands.
+ * An `ask` delivers on the target's request port and hands the kernel the return address: this
+ * process, and the event name the `ask` itself declared as its correlation. When the callee answers,
+ * the kernel dispatches `{type: cmd.reply, payload}` — the `Reply` of `./effect.ts` — into this
+ * process's inbox (`../process/inbox.ts`), so nothing here waits and nothing is matched by hand.
  */
 const askHandler = (cmd: AskEffect) =>
 	Effect.gen(function* () {
 		const processes = yield* SpawnedProcesses;
-		yield* processes.send(cmd.to.process, cmd.to.port, cmd.payload);
+		const self = yield* ProcessSelf;
+		yield* processes.ask(self.id, cmd.to.process, cmd.to.port, cmd.payload, cmd.reply);
+		return NO_EVENTS;
+	});
+
+/** The callee's half: spend the bound `reply` its request-port arrival carried. */
+const replyHandler = (cmd: ReplyEffect) =>
+	Effect.gen(function* () {
+		const processes = yield* SpawnedProcesses;
+		yield* processes.answer(cmd.to, cmd.payload);
 		return NO_EVENTS;
 	});
 
@@ -269,6 +299,8 @@ export type EffectFailure =
 	| UnknownProgram
 	| UnknownProcess
 	| UnknownPort
+	| PortAnswersNothing
+	| UnclaimedReply
 	| PortRefused
 	| OpenError
 	| HandlerFailed
@@ -281,6 +313,7 @@ const HANDLERS: HostHandlers<AuthoredEvent, ProgramEffect, EffectFailure, Effect
 	spawn: spawnHandler,
 	send: sendHandler,
 	ask: askHandler,
+	reply: replyHandler,
 	stop: stopHandler,
 };
 
@@ -292,6 +325,7 @@ const INTERPRET: Interpret<AuthoredEvent, ProgramEffect, unknown> = {
 	spawn: dead,
 	send: dead,
 	ask: dead,
+	reply: dead,
 	stop: dead,
 };
 
@@ -313,14 +347,31 @@ const compileCore = (authored: AnyAuthoredProgram): ProgramCore<any, any, any, a
  * A receiver per arriving port, so launch can never refuse a compiled row for a missing one. The
  * payload crossed the wire as `unknown` and the port's own `accepts` ran before it was enqueued,
  * so what lands here already fits the schema the author declared.
+ *
+ * A request port's arrival is the one that carries more than the payload: an `ask` enqueues the
+ * kernel's envelope, and this unwraps it into the bound `reply` the cell answers with. A plain
+ * `send` can reach a request port too — nothing forbids it — and that arrival carries `NO_REPLY`,
+ * so answering it is refused loudly rather than addressed at a caller who never asked.
  */
+const receiverFor = (name: string, decl: AnyPortDecl): Receiver<AuthoredEvent> =>
+	decl.direction === "request"
+		? (payload: unknown) =>
+				isAsked(payload)
+					? ({
+							type: name,
+							payload: payload.payload,
+							reply: payload.reply,
+						} satisfies RequestArrivalEvent<string, unknown>)
+					: ({type: name, payload, reply: NO_REPLY} satisfies RequestArrivalEvent<string, unknown>)
+		: (payload: unknown) => ({type: name, payload}) satisfies ArrivalEvent<string, unknown>;
+
 const compileReceive = (
 	authored: AnyAuthoredProgram,
 ): Readonly<Record<string, Receiver<AuthoredEvent>>> =>
 	Object.fromEntries(
 		arrivingPorts(authored).map((name) => [
 			name,
-			(payload: unknown) => ({type: name, payload}) satisfies ArrivalEvent<string, unknown>,
+			receiverFor(name, (authored.ports ?? {})[name] as AnyPortDecl),
 		]),
 	);
 

--- a/apps/tuval/src/authoring/define-program.unit.test.ts
+++ b/apps/tuval/src/authoring/define-program.unit.test.ts
@@ -107,6 +107,7 @@ describe("authoring.defineProgram", () => {
 		expect(Object.keys(counter.core.interpret ?? {}).sort()).toEqual([
 			"ask",
 			"emit",
+			"reply",
 			"send",
 			"spawn",
 			"stop",
@@ -208,6 +209,8 @@ describe("authoring.defineProgram", () => {
 						sent.push([process, portName, payload]);
 						return {delivered: true, evicted: 0};
 					}),
+				ask: () => Effect.die("this test asks nothing"),
+				answer: () => Effect.die("this test answers nothing"),
 				read: () => Effect.succeed(Option.none()),
 			});
 

--- a/apps/tuval/src/authoring/effect.ts
+++ b/apps/tuval/src/authoring/effect.ts
@@ -1,5 +1,5 @@
 /**
- * The five things an authored `update` may ask for, and the events that answer them.
+ * The six things an authored `update` may ask for, and the events that answer them.
  *
  * **`effect` here is one of these five constructors and never an `Effect.Effect`** (#8716,
  * `### Vocabulary impact`). The collision is real: this module is named for the word the program
@@ -7,7 +7,10 @@
  * records. Interpreting them into the registry row's Cmds is the spine's (#8728).
  */
 
+import type {ReplyTo} from "../process/inbox.ts";
 import type {ProcessId} from "../process/process.ts";
+
+export type {ReplyTo};
 
 /**
  * A port of some other process, addressed. A process id arrives on `spawned`; the author never
@@ -52,6 +55,17 @@ export interface AskEffect<Event extends string = string> {
 	readonly reply: Event;
 }
 
+/**
+ * The callee's half of `ask` (#8716 R17.1): answer the question this process was asked. `to` is the
+ * bound `reply` its request-port arrival carried — an opaque address the kernel minted — so a
+ * program answers the caller it was asked by without ever naming one.
+ */
+export interface ReplyEffect {
+	readonly type: "reply";
+	readonly to: ReplyTo;
+	readonly payload: unknown;
+}
+
 export interface EmitEffect<Port extends string = string> {
 	readonly type: "emit";
 	readonly port: Port;
@@ -63,7 +77,13 @@ export interface StopEffect {
 	readonly process: ProcessId;
 }
 
-export type ProgramEffect = SpawnEffect | SendEffect | AskEffect | EmitEffect | StopEffect;
+export type ProgramEffect =
+	| SpawnEffect
+	| SendEffect
+	| AskEffect
+	| ReplyEffect
+	| EmitEffect
+	| StopEffect;
 
 /** Start a process of `program`, routing the child's out-ports back into my own events. */
 export const spawn = <Out extends string, Event extends string>(
@@ -91,6 +111,9 @@ export const ask = <Event extends string>(
 	payload: unknown,
 	options: {readonly reply: Event},
 ): AskEffect<Event> => ({type: "ask", to, payload, reply: options.reply});
+
+/** Answer the `ask` whose arrival carried `to`. Spending one twice is refused, not doubled. */
+export const reply = (to: ReplyTo, payload: unknown): ReplyEffect => ({type: "reply", to, payload});
 
 /** Announce on one of my own out-ports. */
 export const emit = <Port extends string>(port: Port, payload: unknown): EmitEffect<Port> => ({

--- a/apps/tuval/src/authoring/effect.unit.test.ts
+++ b/apps/tuval/src/authoring/effect.unit.test.ts
@@ -36,6 +36,8 @@ const interpret = (effect: ProgramEffect): string => {
 			return `send ${effect.to.port}`;
 		case "ask":
 			return `ask ${effect.to.port} -> ${effect.reply}`;
+		case "reply":
+			return `reply ${effect.to.correlation}`;
 		case "emit":
 			return `emit ${effect.port}`;
 		case "stop":

--- a/apps/tuval/src/authoring/port.ts
+++ b/apps/tuval/src/authoring/port.ts
@@ -34,9 +34,9 @@ export interface OutPortDecl<T> {
 
 /**
  * The Erlang `call` / Akka `ask` shape: a caller asks on this port and gets an answer addressed to
- * it. It carries both schemas; how a caller's `ask` and a callee's bound `reply` spend them is the
- * effect vocabulary's and the spine's. From the declaring program's side the arrival is an
- * in-port, which is what it compiles to.
+ * it. From the declaring program's side the arrival is an in-port, which is what it compiles to —
+ * carrying its output schema as the row port's `answers`, the predicate the kernel runs over the
+ * callee's answer before it reaches the caller.
  */
 export interface RequestPortDecl<In, Out> {
 	readonly direction: "request";
@@ -117,12 +117,17 @@ export const compilePort = <D extends AnyPortDecl>(
 	const compiled: PortSchema =
 		decl.direction === "out"
 			? {kind, direction: "out", accepts: admits(decl.schema)}
-			: {
-					kind,
-					direction: "in",
-					accepts: admits(decl.direction === "in" ? decl.schema : decl.input),
-					bound: decl.bound,
-				};
+			: decl.direction === "in"
+				? {kind, direction: "in", accepts: admits(decl.schema), bound: decl.bound}
+				: {
+						kind,
+						direction: "in",
+						accepts: admits(decl.input),
+						bound: decl.bound,
+						// The output schema is kept, not dropped: it is the only check an answer's shape
+						// gets, and the kernel runs it where the answer is handed back (#8756).
+						answers: admits(decl.output),
+					};
 	return compiled as CompiledPort<D>;
 };
 

--- a/apps/tuval/src/authoring/port.unit.test.ts
+++ b/apps/tuval/src/authoring/port.unit.test.ts
@@ -77,6 +77,17 @@ describe("authoring.port", () => {
 		expect(Result.isSuccess(Schema.decodeUnknownResult(asked.output)({pr: 1}))).toBe(false);
 	});
 
+	it("carries the request port's output schema onto the row as `answers`", () => {
+		const review = compilePort(counter, "review", port.request(Review, Count));
+		const ticks = compilePort(counter, "ticks", port.in(Count));
+		// The row is what the kernel checks an answer against, so the predicate has to survive the
+		// compile — dropping it is what left an `ask` unanswerable (#8756).
+		expect(review.answers?.(4)).toBe(true);
+		expect(review.answers?.("4")).toBe(false);
+		// A one-way in-port answers nothing, and its absence here is what says so.
+		expect(ticks.answers).toBeUndefined();
+	});
+
 	it("infers the payload type at the declaration site from the schema", () => {
 		const ticks = port.in(Count);
 		const announced = port.out(Review);

--- a/apps/tuval/src/authoring/test-program.ts
+++ b/apps/tuval/src/authoring/test-program.ts
@@ -19,6 +19,7 @@
 
 import {Result, Schema} from "effect";
 import {ClientId, type Scope, WorkspaceId} from "../commands/spell.ts";
+import type {ReplyTo} from "../process/inbox.ts";
 import {describeSchemaError} from "../protocol/issue.ts";
 import type {AnyCommandDecl, CommandAnswer, CommandArgTypes} from "./commands.ts";
 import type {
@@ -28,6 +29,7 @@ import type {
 	ArrivingPortNames,
 	AuthoredEvent,
 	AuthoredProgram,
+	RequestArrivalEvent,
 } from "./define-program.ts";
 import type {ProgramEffect} from "./effect.ts";
 import {KEY_EVENT, type KeyEvent} from "./keys.ts";
@@ -56,7 +58,7 @@ export interface ProgramRun<S, D extends PortDecls, U, C extends CommandArgTypes
 	/**
 	 * A declared command, called with its own args. A command call is not a process step — it moves
 	 * no state and its effects' answer events are dropped, exactly as the compiled spell drops them
-	 * (#8756) — so the run it answers carries the same state and the effects the command asked for.
+	 * — so the run it answers carries the same state and the effects the command asked for.
 	 */
 	readonly call: <K extends keyof C & string>(
 		command: K,
@@ -70,6 +72,9 @@ const TEST_SCOPE: Scope = {
 	workspace: WorkspaceId.make("tuval/test"),
 	client: ClientId.make("tuval/test"),
 };
+
+/** The bound `reply` a driven request-port arrival carries: an address no live kernel is holding. */
+const TEST_REPLY: ReplyTo = {correlation: "tuval/test"};
 
 type Cell = (state: unknown, event: unknown) => Answer<unknown>;
 
@@ -129,10 +134,14 @@ export const testProgram = <
 				if (decl === undefined) {
 					throw new Error(`the program declares no port named "${port}"`);
 				}
-				const arrival: ArrivalEvent<string, unknown> = {
-					type: port,
-					payload: decodeArrival(port, decl, payload),
-				};
+				const decoded = decodeArrival(port, decl, payload);
+				// A request port's cell reads `event.reply`, so a driven arrival owes one. It addresses
+				// no live ask — a test asserts the `reply` effect the cell asked for, and spending this
+				// address against a real kernel is refused (`../process/inbox.ts`).
+				const arrival: ArrivalEvent<string, unknown> | RequestArrivalEvent<string, unknown> =
+					decl.direction === "request"
+						? {type: port, payload: decoded, reply: TEST_REPLY}
+						: {type: port, payload: decoded};
 				return step(arrival);
 			},
 			event: (event) => step(event as AuthoredEvent),

--- a/apps/tuval/src/authoring/view.ts
+++ b/apps/tuval/src/authoring/view.ts
@@ -35,12 +35,12 @@ import {windowRenderer} from "../shell/window/index.ts";
 import type {
 	Answer,
 	AnyAuthoredProgram,
-	ArrivalEvent,
+	ArrivalEventOf,
 	ArrivingPortNames,
 	CompileContext,
 } from "./define-program.ts";
 import {emit, type ProgramEffect} from "./effect.ts";
-import type {PortDecls, PortPayload} from "./port.ts";
+import type {PortDecls} from "./port.ts";
 
 /** One line about the program, read off its state. Pure: the compiler calls it twice per transition. */
 export type DerivedLine<S> = (state: S) => string;
@@ -64,7 +64,7 @@ type EventOf<K, H> = H extends (state: any, event: infer E) => any
 export type ProgramEvent<D extends PortDecls, U> =
 	| {[K in keyof U]: EventOf<K & string, U[K]>}[keyof U]
 	| {
-			[K in ArrivingPortNames<D>]: ArrivalEvent<K, PortPayload<D[K & keyof D]>>;
+			[K in ArrivingPortNames<D>]: ArrivalEventOf<D, K & keyof D & string>;
 	  }[ArrivingPortNames<D>];
 
 /** What an authored window is handed: this process's state, and a way into its own events. */

--- a/apps/tuval/src/commands/core/process.ts
+++ b/apps/tuval/src/commands/core/process.ts
@@ -12,7 +12,14 @@
  * this service did not spawn has no retained handle, so `send` and `read` answer `UnknownProcess`
  * for it — the graph's own processes are `src/launch/`'s to feed.
  *
- * The four errors are declared here rather than in a `commands/core/errors.ts`: `core/` is one
+ * `ask` / `answer` and the `on` record on `spawn` are the answer path (#8756), and they are here
+ * because this is where the inboxes and the out-port latches are: an `ask` has to reach the port's
+ * own queue past its `accepts`, and a routed child port has to be seen at the emit. What they hand
+ * an answer *to* is `deliver` (`../../process/inbox.ts`), which needs only a live handle — so the
+ * asking process is any process, not only one this service spawned. The three spells below are
+ * untouched by either: nothing addressed by a correlation is reachable from a spell's params.
+ *
+ * The six errors are declared here rather than in a `commands/core/errors.ts`: `core/` is one
  * directory per core spell list, not one feature, and a shared errors file is a file two parallel
  * children would both write.
  */
@@ -25,6 +32,7 @@ import {NodeId} from "../../ports/graph.ts";
 import {ProcessPorts} from "../../ports/ProcessPorts.ts";
 import type {Delivery} from "../../ports/wiring.ts";
 import type {HandlerFailed} from "../../process/errors.ts";
+import {asked, deliver, type ReplyTo} from "../../process/inbox.ts";
 import {Processes} from "../../process/Processes.ts";
 import {type Message, type ProcessHandle, ProcessId} from "../../process/process.ts";
 import {type AnyProgram, type InPort, ProgramId, type Receiver} from "../../registry/program.ts";
@@ -59,6 +67,26 @@ export class UnknownPort extends Schema.TaggedError<UnknownPort>()("tuval/comman
 }) {
 	override get message(): string {
 		return `process "${this.process}" has no ${this.direction}-port "${this.port}"`;
+	}
+}
+
+/** An `ask` named a port that takes payloads and answers none: it is a `port.in`, not a `port.request`. */
+export class PortAnswersNothing extends Schema.TaggedError<PortAnswersNothing>()(
+	"tuval/commands/PortAnswersNothing",
+	{process: ProcessId, port: Schema.String},
+) {
+	override get message(): string {
+		return `port "${this.port}" of process "${this.process}" answers nothing, so it cannot be asked`;
+	}
+}
+
+/** The correlation an answer was addressed to is not outstanding: it was already spent, or expired. */
+export class UnclaimedReply extends Schema.TaggedError<UnclaimedReply>()(
+	"tuval/commands/UnclaimedReply",
+	{correlation: Schema.String},
+) {
+	override get message(): string {
+		return `no ask is waiting on correlation "${this.correlation}"`;
 	}
 }
 
@@ -159,9 +187,16 @@ const pump = (handle: ProcessHandle, inbox: Queue.Dequeue<unknown>, receive: Rec
 
 /**
  * The out-port half of an ad-hoc process's wiring: what `src/ports/`'s `Wiring.emit` is to a graph
- * node. There is no route to follow, so the delivery it reports is the port's own latch.
+ * node. The delivery it reports is the port's own latch; `routed` is the spawner's `on` record
+ * applied beside it, so a port the spawner named also lands in the spawner's inbox and a port it
+ * did not name lands nowhere else (#8756).
  */
-const emitter = (id: ProcessId, row: AnyProgram, outboxes: ReadonlyMap<string, OutboundLatch>) =>
+const emitter = (
+	id: ProcessId,
+	row: AnyProgram,
+	outboxes: ReadonlyMap<string, OutboundLatch>,
+	routed: (port: string, payload: unknown) => Effect.Effect<void>,
+) =>
 	Effect.fn("Tuval.SpawnedProcesses.emit")(function* (port: string, payload: unknown) {
 		const node = NodeId.make(id);
 		const latch = outboxes.get(port);
@@ -173,8 +208,28 @@ const emitter = (id: ProcessId, row: AnyProgram, outboxes: ReadonlyMap<string, O
 			return yield* new PayloadRejected({node, program: row.id, port, kind: declared.kind});
 		}
 		yield* latch.publish(payload);
+		yield* routed(port, payload);
 		return [{to: {node, port}, accepted: true}] as ReadonlyArray<Delivery>;
 	});
+
+/**
+ * Which of the spawner's own events each of the child's out-ports arrives as — the authoring
+ * layer's `spawn(x, {on})` as the kernel takes it. A port with no entry routes nowhere.
+ */
+export type ChildRoutes = Readonly<Record<string, string | undefined>>;
+
+const NO_ROUTES: ChildRoutes = {};
+
+/** One outstanding `ask`, held against the correlation the kernel minted for it. */
+interface Pending {
+	/** The process that asked, and the event its answer arrives as. */
+	readonly to: ProcessId;
+	readonly event: string;
+	/** Who was asked — kept so a refused answer can name the port that refused it. */
+	readonly of: ProcessId;
+	readonly port: string;
+	readonly answers: (payload: unknown) => boolean;
+}
 
 export interface SpawnedProcessesOptions {
 	/** How long a `read` waits for a port that has said nothing yet, before answering none. */
@@ -185,6 +240,8 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 	const registry = yield* Registry;
 	const processes = yield* Processes;
 	const live = new Map<ProcessId, Entry>();
+	/** The correlation table an answer is addressed by. One entry per outstanding `ask`. */
+	const pending = new Map<string, Pending>();
 
 	const entryOf = (process: ProcessId) =>
 		Effect.suspend(() => {
@@ -197,6 +254,7 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 	const spawn = Effect.fn("Tuval.SpawnedProcesses.spawn")(function* (
 		program: ProgramId,
 		parent: Option.Option<ProcessId>,
+		on: ChildRoutes = NO_ROUTES,
 	) {
 		const row = yield* Effect.mapError(
 			registry.resolve(program),
@@ -209,7 +267,15 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 		for (const [name, port] of Object.entries(row.ports)) {
 			if (port.direction === "out") outboxes.set(name, yield* openLatch);
 		}
-		const ports = ProcessPorts.of({emit: emitter(id, row, outboxes)});
+		// Routing is resolved per emit rather than wired once, because a route's target is the
+		// spawner's inbox and a spawner can stop while its child runs on: `deliver` answers `false`
+		// then, where a captured handle would have gone stale.
+		const routeOne = (port: string, payload: unknown): Effect.Effect<void> => {
+			const event = on[port];
+			if (event === undefined || Option.isNone(parent)) return Effect.void;
+			return Effect.asVoid(deliver(processes, parent.value, {type: event, payload}));
+		};
+		const ports = ProcessPorts.of({emit: emitter(id, row, outboxes, routeOne)});
 
 		// The spawn set is stated here in full, because it is all the child's handlers will resolve
 		// (#7972). `Effect.context()` is this caller's own — the spell fiber's, which is the kernel
@@ -259,7 +325,14 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 			live.set(id, {handle, inboxes, outboxes});
 			yield* Scope.addFinalizer(
 				handle.scope,
-				Effect.sync(() => void live.delete(id)),
+				Effect.sync(() => {
+					live.delete(id);
+					// A process that stopped answers nothing more, and a correlation nobody will ever
+					// spend is a leak: one sweep per process rather than one finalizer per `ask`.
+					for (const [correlation, held] of pending) {
+						if (held.of === id || held.to === id) pending.delete(correlation);
+					}
+				}),
 			);
 		}).pipe(Effect.onError(() => handle.stop));
 		return id;
@@ -279,6 +352,48 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 		return yield* offerCounting(inbox, payload);
 	});
 
+	const ask = Effect.fn("Tuval.SpawnedProcesses.ask")(function* (
+		from: ProcessId,
+		process: ProcessId,
+		port: string,
+		payload: unknown,
+		event: string,
+	) {
+		const entry = yield* entryOf(process);
+		const inbox = entry.inboxes.get(port);
+		if (inbox === undefined) return yield* new UnknownPort({process, port, direction: "in"});
+		const answers = inbox.port.answers;
+		if (answers === undefined) return yield* new PortAnswersNothing({process, port});
+		if (!inbox.port.accepts(payload)) {
+			return yield* new PortRefused({process, port, kind: inbox.port.kind});
+		}
+		const correlation = randomUUID();
+		pending.set(correlation, {to: from, event, of: process, port, answers});
+		const sent = yield* offerCounting(inbox, asked(payload, {correlation}));
+		// A payload the queue refused is a question nobody was asked, so it owes no answer.
+		if (!sent.delivered) pending.delete(correlation);
+		return sent;
+	});
+
+	const answer = Effect.fn("Tuval.SpawnedProcesses.answer")(function* (
+		to: ReplyTo,
+		payload: unknown,
+	) {
+		const held = pending.get(to.correlation);
+		if (held === undefined) return yield* new UnclaimedReply({correlation: to.correlation});
+		if (!held.answers(payload)) {
+			return yield* new PortRefused({
+				process: held.of,
+				port: held.port,
+				kind: `an answer to ${held.port}`,
+			});
+		}
+		// Spent before delivery: the caller's fold runs inside `deliver`, and a program that asks
+		// again from that fold must not find this correlation still outstanding.
+		pending.delete(to.correlation);
+		return yield* deliver(processes, held.to, {type: held.event, payload});
+	});
+
 	const read = Effect.fn("Tuval.SpawnedProcesses.read")(function* (
 		process: ProcessId,
 		port: string,
@@ -289,7 +404,7 @@ const make = Effect.fn("Tuval.SpawnedProcesses.make")(function* (options: Spawne
 		return yield* Effect.timeoutOption(latch.current, options.readTimeout);
 	});
 
-	return SpawnedProcesses.of({spawn, send, read});
+	return SpawnedProcesses.of({spawn, send, ask, answer, read});
 });
 
 export class SpawnedProcesses extends Context.Service<
@@ -298,6 +413,8 @@ export class SpawnedProcesses extends Context.Service<
 		readonly spawn: (
 			program: ProgramId,
 			parent: Option.Option<ProcessId>,
+			/** Which of the parent's events each named child out-port arrives as. Needs a parent to route to. */
+			on?: ChildRoutes,
 		) => Effect.Effect<ProcessId, UnknownProgram | UnknownProcess | OpenError | HandlerFailed>;
 		/**
 		 * `delivered` is `Queue.offer`'s own answer, and it covers less than a reader expects. `false`
@@ -312,6 +429,27 @@ export class SpawnedProcesses extends Context.Service<
 			port: string,
 			payload: unknown,
 		) => Effect.Effect<Sent, UnknownProcess | UnknownPort | PortRefused>;
+		/**
+		 * `send`'s two-way twin: deliver on a request port and hold, against a correlation the kernel
+		 * mints, where the answer goes. The callee's arrival carries that correlation and nothing
+		 * else, so a `from` it was not given is a process it cannot address (#8756).
+		 */
+		readonly ask: (
+			from: ProcessId,
+			process: ProcessId,
+			port: string,
+			payload: unknown,
+			event: string,
+		) => Effect.Effect<Sent, UnknownProcess | UnknownPort | PortAnswersNothing | PortRefused>;
+		/**
+		 * Spend one correlation: check the answer against the asked port's own output schema and hand
+		 * it to the asking process as the event that `ask` named. `false` means the asker is gone.
+		 * A correlation is spent once — a second answer to it is `UnclaimedReply`, not a second event.
+		 */
+		readonly answer: (
+			to: ReplyTo,
+			payload: unknown,
+		) => Effect.Effect<boolean, UnclaimedReply | PortRefused>;
 		readonly read: (
 			process: ProcessId,
 			port: string,

--- a/apps/tuval/src/process/inbox.ts
+++ b/apps/tuval/src/process/inbox.ts
@@ -1,0 +1,80 @@
+/**
+ * Handing a running process an event on behalf of another process, and the envelope an `ask` rides
+ * in.
+ *
+ * The kernel could route a payload *to* a port and it could latch a payload *off* one, and neither
+ * of those is an answer: a port is one-way and carries no return address, so an `ask`'s reply and a
+ * child out-port routed back into its spawner's events both had nowhere to land (#8756). What was
+ * missing is one primitive — put an event in a named process's inbox, addressed from outside — and
+ * `deliver` is it.
+ *
+ * It lives beside `Processes` rather than on `SpawnedProcesses` because the process being answered
+ * is any live process, not only one the process spells spawned: the picker opens a program straight
+ * through `Processes` (`../shell/picker/open.ts`), so an answer routed through the spells' own
+ * table would never reach a picker-opened caller. The live handle is the whole of what a delivery
+ * needs, and `Processes.handle` is where handles are.
+ *
+ * A delivery is best-effort by design, exactly as the shell's key forwarding is: a process that has
+ * stopped has no inbox to be handed anything, and a fold that fails on the event it was handed is
+ * the receiver's own failure, reported where it happened rather than raised at whoever answered.
+ */
+
+import {type Context, Effect, Option} from "effect";
+import type {Processes} from "./Processes.ts";
+import type {Message, ProcessId} from "./process.ts";
+
+/**
+ * Where one `ask` wants its answer. Opaque on purpose: the caller's process and the event the reply
+ * arrives as are the kernel's own copy, held against the correlation it minted, so a callee holding
+ * this value can answer the question it was asked and address nothing else — no authoring effect
+ * takes a process id as input to set a relation (founder's ruling on #8757).
+ */
+export interface ReplyTo {
+	readonly correlation: string;
+}
+
+const ASKED = Symbol.for("tuval/process/Asked");
+
+/**
+ * What an `ask` puts on the callee's in-port queue: the payload that port's own `accepts` already
+ * admitted, plus where the answer goes. The symbol key is what makes it unmistakable for a payload
+ * — the queue is untyped and this envelope never crosses a wire, so a tag no author can spell is
+ * cheaper and safer than a shape a payload could accidentally match.
+ */
+export interface Asked {
+	readonly [ASKED]: true;
+	readonly payload: unknown;
+	readonly reply: ReplyTo;
+}
+
+export const asked = (payload: unknown, reply: ReplyTo): Asked => ({
+	[ASKED]: true,
+	payload,
+	reply,
+});
+
+export const isAsked = (value: unknown): value is Asked =>
+	typeof value === "object" && value !== null && (value as Partial<Asked>)[ASKED] === true;
+
+/** The address a request-port arrival carries when nobody asked — a plain `send` reached it. */
+export const NO_REPLY: ReplyTo = {correlation: ""};
+
+/**
+ * Put one event in `to`'s inbox. Answers `true` when a live process took it and `false` when there
+ * was none to take it; a fold that fails on the event is logged and still counts as taken, because
+ * the event did land and the failure is the receiver's.
+ */
+export const deliver = (
+	processes: Context.Service.Shape<typeof Processes>,
+	to: ProcessId,
+	event: Message,
+): Effect.Effect<boolean> =>
+	Effect.gen(function* () {
+		const handle = yield* processes.handle(to);
+		if (Option.isNone(handle)) {
+			yield* Effect.logDebug(`deliver: process ${to} is gone; "${event.type}" was dropped`);
+			return false;
+		}
+		yield* handle.value.dispatch(event).pipe(Effect.catchCause((cause) => Effect.logError(cause)));
+		return true;
+	});

--- a/apps/tuval/src/registry/program.ts
+++ b/apps/tuval/src/registry/program.ts
@@ -27,6 +27,14 @@ export interface InPort<T = unknown> {
 	readonly direction: "in";
 	readonly accepts: (payload: unknown) => payload is T;
 	readonly bound: PortBound;
+	/**
+	 * The predicate an answer to this port must fit, present only on a port that answers its caller
+	 * — `port.request(In, Out)` in the authoring layer (#8716 R17.1). A request port arrives like any
+	 * other in-port, so it is one field here rather than a fourth `PortSchema` member every
+	 * `direction === "in"` reader would have to learn; its absence is what "this port answers
+	 * nothing" means, and an `ask` against such a port is refused (#8756).
+	 */
+	readonly answers?: (payload: unknown) => boolean;
 }
 
 export interface OutPort<T = unknown> {


### PR DESCRIPTION
Fixes #8756

The authoring layer advertised two answer paths and the kernel carried neither: an `ask` delivered
its payload and no `Reply` ever came back, and `spawn(x, {on})` dropped the routing record, so a
child's out-port had nowhere to land. Both compiled and both hung silently.

The missing piece was one primitive, not two — nothing could put an event in a running process's
inbox on behalf of another process. `deliver` in the new `apps/tuval/src/process/inbox.ts` is that
primitive. It sits beside `Processes` rather than on `SpawnedProcesses` because the process being
answered is any live process: the picker opens a program straight through `Processes`, so an answer
routed through the spells' own table would never reach a picker-opened caller.

On top of it:

- `port.request(In, Out)` now keeps its output schema on the row as `InPort.answers`, which is the
  only check an answer's shape gets.
- `SpawnedProcesses.ask` puts a payload on a request port and holds, against a correlation it mints,
  where the answer goes. `answer` spends that correlation once, checks the payload against the
  port's `answers`, and delivers `{type: <the ask's reply>, payload}` into the caller.
- A request-port arrival carries the bound `reply` its caller is waiting on, and the callee spends
  it with the new `reply(event.reply, answer)` effect — the callee half R17.1 names, which the
  landed vocabulary had no verb for.
- `spawn`'s `on` record rides to `SpawnedProcesses.spawn` and is applied at the child's emit, so a
  named out-port arrives as the spawner's event and an unnamed one goes nowhere.

The three `process spawn` / `send` / `read` spells are untouched — nothing addressed by a
correlation is reachable from a spell's params — and `process.unit.test.ts` passes unchanged.

Base is `epic/8716`, not `main`: every file this touches lives on the epic's assembly branch and
does not exist at `main`.

Reviewer's first stop: `apps/tuval/src/commands/core/process.ts` — the correlation table, its
one-sweep-per-process cleanup, and the `routeOne` closure on `spawn`.

## Deviations

- **Governing-ADR departure** — **Said:** epic #8716's plan states "Nothing under `registry/`,
  `ports/`, `host/`, `launch/` or `durability/` changes shape". **Did:** added one optional field,
  `answers?`, to `InPort` in `apps/tuval/src/registry/program.ts`. **Why:** this issue's first
  acceptance criterion requires the request port's output schema to survive onto the *row*, and the
  kernel checks an answer against the callee's row port. **Disposition:** stated here; the field is
  optional, so no existing reader or row changes.
- **Out-of-scope change** — **Said:** the issue names `port.ts`, `define-program.ts` and
  `process.ts`. **Did:** also added a `reply` effect to `apps/tuval/src/authoring/effect.ts` (#8727's
  file) and its `dead`/handler rows. **Why:** R17.1's callee half is "a bound `reply` in the callee's
  event", and the landed vocabulary has no verb that spends one — `send` addresses a port, and a
  reply is not addressed to a port. Without it the fifth criterion ("the callee's answer") is
  unbuildable. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `test-program.ts` or `view.ts`. **Did:** a driven
  request-port arrival now carries a `TEST_REPLY` address, and `ProgramEvent` picks the request
  arrival type. **Why:** the arrival's shape changed, so the two readers of that shape had to follow.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria name only the two `define-program.ts` docblocks.
  **Did:** also dropped the `(#8756)` citation from a comment in `apps/tuval/src/authoring/commands.ts`
  and extended `.patterns/tuval-spells.md` with the answer path. **Why:** the citation now points at
  closed work, and the pattern doc describes `SpawnedProcesses` without the half this adds.
  **Disposition:** stated here.
