### PR TITLE
chore: A command-declared spell that emits needs ProcessPorts, which the Kernel context does not carry

### DIFF
--- a/.decisions/0372-a-commands-cell-cannot-emit.md
+++ b/.decisions/0372-a-commands-cell-cannot-emit.md
@@ -50,8 +50,9 @@ and with one there is an out-port belonging to somebody else.
 3. **The narrowing is carried by the handler table, not by a runtime check.** `COMMAND_HANDLERS` in
    [`apps/tuval/src/authoring/define-program.ts`](../apps/tuval/src/authoring/define-program.ts) is
    the spine's five command-reachable handlers, typed
-   `CommandHandlers<EffectFailure, CommandEffectServices>` where
-   `CommandEffectServices = ProcessSelf | SpawnedProcesses | Processes`. `emitHandler` is the only
+   `CommandHandlers<EffectFailure, CommandEffectServices>` where `CommandEffectServices` is
+   `Exclude<EffectServices, ProcessPorts>`, so it stays in lockstep as the spine's service set
+   grows. `emitHandler` is the only
    reader of `ProcessPorts`, and it is unreachable from a compiled spell, so no spell requires that
    service. `HANDLERS` and `EffectServices` keep all six for the `update` path.
 4. **A spell that runs *inside* a process is a different call site and is untouched.** Such a spell

--- a/.decisions/0372-a-commands-cell-cannot-emit.md
+++ b/.decisions/0372-a-commands-cell-cannot-emit.md
@@ -1,0 +1,72 @@
+---
+id: 0372
+title: A program's commands cell cannot declare emit, because a spell call runs under no process
+status: accepted
+date: 2026-09-09
+tags: [tuval, authoring, commands, spells, effects, ports]
+---
+
+# 0372 — A program's `commands` cell cannot declare `emit`, because a spell call runs under no process
+
+**What this decides:** the effects a declared command may ask for are `spawn`, `send`, `ask`,
+`reply` and `stop` — every effect an `update` cell may ask for, less `emit`. `emit` stays an
+`update` cell's alone. An `emit` written in a `commands` cell is a type error where it is written,
+not a missing-service defect at the first call.
+
+Founder ruling: <https://github.com/kamp-us/phoenix/issues/8766#issuecomment-5612412328> — "Ruled:
+direction 2. A commands cell cannot declare emit; a spell call from a scope with no process has no
+caller to emit from." Same shape as the ruling on #8757: what belongs to a process is stamped by the
+kernel off the process it is interpreting for, never carried by the effect.
+
+## Context
+
+#8766 named the gap. `compileCommands` (`apps/tuval/src/authoring/commands.ts`) built each spell's
+`execute` by driving the declared `run`'s effects through the spine's handlers, so a command
+answering `emit(...)` required `ProcessPorts`. The `Kernel` union in `apps/tuval/src/boot.ts` does
+not name that service. Nothing caught it: `AnySpell` erases a spell's requirements, which is exactly
+the erasure `apps/tuval/src/commands/executor.ts`'s docblock says the composition root owes a
+provider for. The unit test passed a hand-built `ProcessPorts` layer, so no test was red either.
+
+Under it sat a design question the wiring could not answer. `ProcessPorts.emit(port, payload)`
+announces on **a running process's** out-port. A spell call is not a process step: the `Scope` it
+runs under (`apps/tuval/src/commands/spell.ts`) names a workspace and a client, and its `process`
+is *the caller's* — the process the kernel resolved the call from, which is how `process spawn`
+picks a parent (`apps/tuval/src/commands/core/process.ts`). It is never the declaring program's own
+process. So adding `ProcessPorts` to `Kernel` would have satisfied the checker while leaving the
+runtime question open in both directions: with no `process` in scope there is no out-port at all,
+and with one there is an out-port belonging to somebody else.
+
+## Decision
+
+1. **`emit` is not declarable in a `commands` cell.** `CommandEffect` in
+   [`apps/tuval/src/authoring/commands.ts`](../apps/tuval/src/authoring/commands.ts) is
+   `Exclude<ProgramEffect, EmitEffect>`, and `CommandAnswer` is built over it — so the refusal lands
+   on the author's `run` at the line that wrote it.
+2. **What an `emit` from a `commands` cell means: nothing, in either scope case.** With no `process`
+   in the calling `Scope` there is no out-port for the payload to leave by. With one, that process
+   is the caller's and its out-ports are not the declaring program's to announce on. There is no
+   reading under which the call is honest, which is why the answer is a refusal rather than a
+   fallback.
+3. **The narrowing is carried by the handler table, not by a runtime check.** `COMMAND_HANDLERS` in
+   [`apps/tuval/src/authoring/define-program.ts`](../apps/tuval/src/authoring/define-program.ts) is
+   the spine's five command-reachable handlers, typed
+   `CommandHandlers<EffectFailure, CommandEffectServices>` where
+   `CommandEffectServices = ProcessSelf | SpawnedProcesses | Processes`. `emitHandler` is the only
+   reader of `ProcessPorts`, and it is unreachable from a compiled spell, so no spell requires that
+   service. `HANDLERS` and `EffectServices` keep all six for the `update` path.
+4. **A spell that runs *inside* a process is a different call site and is untouched.** Such a spell
+   gets `ProcessPorts` through its process's own context, not through `Kernel`. Nothing here widens
+   `Kernel`.
+
+## Consequences
+
+- A program that wants to announce does it from an `update` cell. A command that should cause an
+  announcement `send`s into the program's own in-port and lets the cell emit — which is the same
+  route any other caller takes.
+- `apps/tuval/src/authoring/commands.unit.test.ts` no longer hand-provides a `ProcessPorts`: its
+  effect test drives a `send` through a capturing `SpawnedProcesses`, and a `@ts-expect-error` case
+  holds the refusal in place, so deleting the narrowing turns that test red.
+- The erasure `executor.ts` describes is still erasure. This decision removes one service from what
+  a compiled spell needs; it does not make the remaining ones compile-time. `CommandEffectServices`
+  still names `ProcessSelf`, which `Kernel` does not carry either — the same shape one service over,
+  filed as [#8858](https://github.com/kamp-us/phoenix/issues/8858).

--- a/apps/tuval/src/authoring/commands.ts
+++ b/apps/tuval/src/authoring/commands.ts
@@ -14,13 +14,23 @@ import {Effect, Schema} from "effect";
 import {type AnySpell, defineSpell, type Scope, type SpellPath} from "../commands/spell.ts";
 import type {CapabilityRequest, HostHandlers} from "../registry/program.ts";
 import type {AuthoredEvent} from "./define-program.ts";
-import type {ProgramEffect} from "./effect.ts";
+import type {EmitEffect, ProgramEffect} from "./effect.ts";
 
 /** What a command's `args` may be declared over: decodable from `unknown` with no services. */
 export type CommandArgs<A> = Schema.Codec<A, any, never, unknown>;
 
+/**
+ * The effects a command may ask for: every one an `update` cell may, less `emit`.
+ *
+ * `emit` announces on **a running process's** out-port, and a spell call is not a process step —
+ * the `Scope` it runs under names a workspace and a client, never a process, so there is no
+ * out-port an emitted payload would leave by. Excluding it here makes that a refusal the checker
+ * states where the command is written (ADR 0372).
+ */
+export type CommandEffect = Exclude<ProgramEffect, EmitEffect>;
+
 /** What a command's `run` answers: the effects it asks for, one or a list. */
-export type CommandAnswer = ProgramEffect | ReadonlyArray<ProgramEffect>;
+export type CommandAnswer = CommandEffect | ReadonlyArray<CommandEffect>;
 
 /** One command, as a user writes it. Nothing on it names a spell, a path prefix or an Effect. */
 export interface CommandDecl<A> {
@@ -50,11 +60,15 @@ export type CommandTable<C> = {readonly [K in keyof C]: CommandDecl<C[K]>};
 /** What `defineProgram` binds its command generic to: one argument type per declared name. */
 export type CommandArgTypes = Readonly<Record<string, unknown>>;
 
-/** What the compiled `execute` needs to interpret an effect: the spine's own five handlers. */
-export type EffectHandlers<E, R> = HostHandlers<AuthoredEvent, ProgramEffect, E, R>;
+/**
+ * What the compiled `execute` needs to interpret a command's effects: the spine's handlers for the
+ * five a command may ask for. There is no `emit` key, so the handler that reads `ProcessPorts` is
+ * not reachable from here and a compiled spell never requires that service.
+ */
+export type CommandHandlers<E, R> = HostHandlers<AuthoredEvent, CommandEffect, E, R>;
 
-const asList = (answer: CommandAnswer): ReadonlyArray<ProgramEffect> =>
-	Array.isArray(answer) ? answer : [answer as ProgramEffect];
+const asList = (answer: CommandAnswer): ReadonlyArray<CommandEffect> =>
+	Array.isArray(answer) ? answer : [answer as CommandEffect];
 
 /**
  * Run a command's effects through the spine's handlers, exactly as an `update` cell's effects are
@@ -63,11 +77,11 @@ const asList = (answer: CommandAnswer): ReadonlyArray<ProgramEffect> =>
  */
 const interpret = <E, R>(
 	answer: CommandAnswer,
-	handlers: EffectHandlers<E, R>,
+	handlers: CommandHandlers<E, R>,
 ): Effect.Effect<void, E, R> => {
 	const byType = handlers as {
-		readonly [K in ProgramEffect["type"]]: (
-			cmd: ProgramEffect,
+		readonly [K in CommandEffect["type"]]: (
+			cmd: CommandEffect,
 		) => Effect.Effect<ReadonlyArray<AuthoredEvent>, E, R>;
 	};
 	// Serial on purpose: a command's effects are asked for in the order they were written, exactly
@@ -102,7 +116,7 @@ const NO_CAPABILITIES: ReadonlyArray<CapabilityRequest> = [];
  */
 export const compileCommands = <E, R>(
 	commands: CommandDecls | undefined,
-	handlers: EffectHandlers<E, R>,
+	handlers: CommandHandlers<E, R>,
 ): ReadonlyArray<AnySpell> | undefined => {
 	const declared = Object.entries(commands ?? {});
 	if (declared.length === 0) return undefined;

--- a/apps/tuval/src/authoring/commands.ts
+++ b/apps/tuval/src/authoring/commands.ts
@@ -22,10 +22,11 @@ export type CommandArgs<A> = Schema.Codec<A, any, never, unknown>;
 /**
  * The effects a command may ask for: every one an `update` cell may, less `emit`.
  *
- * `emit` announces on **a running process's** out-port, and a spell call is not a process step —
- * the `Scope` it runs under names a workspace and a client, never a process, so there is no
- * out-port an emitted payload would leave by. Excluding it here makes that a refusal the checker
- * states where the command is written (ADR 0372).
+ * `emit` announces on **a running process's** out-port, and a spell call is not a process step. The
+ * `Scope` it runs under names a workspace and a client, and the `process` it may carry is the
+ * *caller's* — so with none there is no out-port at all, and with one the out-port is somebody
+ * else's. Neither case leaves an out-port that is the declaring program's to announce on. Excluding
+ * `emit` here makes that a refusal the checker states where the command is written (ADR 0372).
  */
 export type CommandEffect = Exclude<ProgramEffect, EmitEffect>;
 

--- a/apps/tuval/src/authoring/commands.unit.test.ts
+++ b/apps/tuval/src/authoring/commands.unit.test.ts
@@ -76,10 +76,10 @@ const capturingSends = (sent: Array<readonly [string, unknown]>) =>
 					sent.push([portName, payload]);
 					return {delivered: true, evicted: 0};
 				}),
-			spawn: unreachable("spawn") as never,
-			ask: unreachable("ask") as never,
-			answer: unreachable("answer") as never,
-			read: unreachable("read") as never,
+			spawn: unreachable("spawn"),
+			ask: unreachable("ask"),
+			answer: unreachable("answer"),
+			read: unreachable("read"),
 		}),
 	);
 
@@ -133,8 +133,8 @@ describe("authoring.commands", () => {
 			commands: {
 				announce: {
 					args: Schema.Number,
-					// @ts-expect-error `emit` is not a `CommandEffect`: a spell call runs under no process,
-					// so there is no out-port for the payload to leave by.
+					// @ts-expect-error `emit` is not a `CommandEffect`: a spell call's `Scope` carries no
+					// process of the declaring program's, so no out-port here is its to announce on.
 					run: (n: number) => [emit("announced", n)],
 				},
 			},

--- a/apps/tuval/src/authoring/commands.unit.test.ts
+++ b/apps/tuval/src/authoring/commands.unit.test.ts
@@ -1,13 +1,14 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer, Schema} from "effect";
 import {expect, expectTypeOf} from "vitest";
+import {SpawnedProcesses} from "../commands/core/process.ts";
 import {buildRegistry} from "../commands/registry.ts";
 import {type AnySpell, ClientId, type Scope, WorkspaceId} from "../commands/spell.ts";
-import {ProcessPorts} from "../ports/ProcessPorts.ts";
 import {ProcessId} from "../process/process.ts";
 import type {AnyProgram} from "../registry/program.ts";
+import type {CommandEffect} from "./commands.ts";
 import {defineProgram} from "./define-program.ts";
-import {emit, send} from "./effect.ts";
+import {emit, type ProgramEffect, send} from "./effect.ts";
 import {port} from "./port.ts";
 
 const scope: Scope = {workspace: WorkspaceId.make("w"), client: ClientId.make("c")};
@@ -28,7 +29,9 @@ const authored = {
 		},
 		"session.start": {
 			args: Schema.Struct({name: Schema.String}),
-			run: (args: {readonly name: string}) => [emit("announced", args.name.length)],
+			run: (args: {readonly name: string}) => [
+				send({process: ProcessId.make("p1"), port: "sessions"}, args.name),
+			],
 		},
 	},
 } as const;
@@ -61,15 +64,22 @@ const call = (spell: AnySpell, args: unknown) =>
 		spell.execute(decoded, scope),
 	);
 
-const capturingPorts = (emitted: Array<readonly [string, unknown]>) =>
+const unreachable = (name: string) => () => Effect.die(`a command cannot reach ${name}`);
+
+/** Only `send` is exercised, so the other four members answer by dying rather than by pretending. */
+const capturingSends = (sent: Array<readonly [string, unknown]>) =>
 	Layer.succeed(
-		ProcessPorts,
-		ProcessPorts.of({
-			emit: (portName, payload) =>
+		SpawnedProcesses,
+		SpawnedProcesses.of({
+			send: (_process, portName, payload) =>
 				Effect.sync(() => {
-					emitted.push([portName, payload]);
-					return [];
+					sent.push([portName, payload]);
+					return {delivered: true, evicted: 0};
 				}),
+			spawn: unreachable("spawn") as never,
+			ask: unreachable("ask") as never,
+			answer: unreachable("answer") as never,
+			read: unreachable("read") as never,
 		}),
 	);
 
@@ -103,15 +113,34 @@ describe("authoring.commands", () => {
 	});
 
 	it.effect("interprets run's effects as an update cell's effects are interpreted", () => {
-		const emitted: Array<readonly [string, unknown]> = [];
+		const sent: Array<readonly [string, unknown]> = [];
 		return Effect.map(
 			Effect.provide(call(spellNamed(reviewer, "session.start"), {name: "umut"}), [
-				capturingPorts(emitted),
+				capturingSends(sent),
 			]),
 			() => {
-				expect(emitted).toEqual([["announced", 4]]);
+				expect(sent).toEqual([["sessions", "umut"]]);
 			},
 		);
+	});
+
+	it("refuses an `emit` in a commands cell where it is written (ADR 0372)", () => {
+		defineProgram({
+			id: "emitting",
+			ports: {announced: port.out(Schema.Number)},
+			init: () => ({}),
+			update: {noop: (state: Record<string, never>) => [state, []]},
+			commands: {
+				announce: {
+					args: Schema.Number,
+					// @ts-expect-error `emit` is not a `CommandEffect`: a spell call runs under no process,
+					// so there is no out-port for the payload to leave by.
+					run: (n: number) => [emit("announced", n)],
+				},
+			},
+		});
+		// The declaration still compiles to a spell; the refusal is the checker's, not the compiler's.
+		expectTypeOf<CommandEffect>().not.toEqualTypeOf<ProgramEffect>();
 	});
 
 	it.effect("lets two programs declare one command name without colliding", () =>

--- a/apps/tuval/src/authoring/define-program.ts
+++ b/apps/tuval/src/authoring/define-program.ts
@@ -48,7 +48,12 @@ import type {
 } from "../registry/program.ts";
 import {ProgramId} from "../registry/program.ts";
 import {type AnyArgRefs, argKeys} from "./args.ts";
-import {type CommandArgTypes, type CommandTable, compileCommands} from "./commands.ts";
+import {
+	type CommandArgTypes,
+	type CommandHandlers,
+	type CommandTable,
+	compileCommands,
+} from "./commands.ts";
 import {
 	type AskEffect,
 	type EmitEffect,
@@ -228,8 +233,9 @@ const arrivingPorts = (authored: AnyAuthoredProgram): ReadonlyArray<string> =>
 		.map(([name]) => name);
 
 /**
- * The five effect handlers, written once. Each answers the events its effect produces: `emit` and
- * `send` announce nothing back, `spawn` answers `spawned` and `stop` answers `stopped`.
+ * The six effect handlers, written once. Each answers the events its effect produces: `emit` and
+ * `send` announce nothing back, `spawn` answers `spawned` and `stop` answers `stopped`. A command
+ * reaches five of them; `emit` is an `update` cell's alone (ADR 0372).
  */
 const emitHandler = (cmd: EmitEffect) =>
 	Effect.gen(function* () {
@@ -317,6 +323,21 @@ const HANDLERS: HostHandlers<AuthoredEvent, ProgramEffect, EffectFailure, Effect
 	stop: stopHandler,
 };
 
+/**
+ * What a compiled command needs — `EffectServices` without `ProcessPorts`, because a command may
+ * not declare `emit` (ADR 0372) and `emitHandler` is the only reader of that service.
+ */
+export type CommandEffectServices = ProcessSelf | SpawnedProcesses | Processes;
+
+/** The same handlers minus `emit`, so no command's spell can reach a process out-port. */
+const COMMAND_HANDLERS: CommandHandlers<EffectFailure, CommandEffectServices> = {
+	spawn: spawnHandler,
+	send: sendHandler,
+	ask: askHandler,
+	reply: replyHandler,
+	stop: stopHandler,
+};
+
 /** Demlik demands a Promise `interpret` beside the row's `handlers`; the host never reads it (#7576). */
 const dead = (): Promise<void> => Promise.resolve();
 
@@ -392,7 +413,7 @@ export const FIELD_COMPILERS = {
 	receive: (authored) => compileReceive(authored),
 	handlers: () => HANDLERS,
 	args: (authored) => (authored.args === undefined ? undefined : argKeys(authored.args)),
-	spells: (authored) => compileCommands(authored.commands, HANDLERS),
+	spells: (authored) => compileCommands(authored.commands, COMMAND_HANDLERS),
 	takesKeys: (authored) => compileTakesKeys(authored),
 	renderer: (authored, context) => compileWindow(authored, context),
 	capabilities: (authored) => authored.capabilities ?? NO_CAPABILITIES,

--- a/apps/tuval/src/authoring/define-program.ts
+++ b/apps/tuval/src/authoring/define-program.ts
@@ -327,7 +327,7 @@ const HANDLERS: HostHandlers<AuthoredEvent, ProgramEffect, EffectFailure, Effect
  * What a compiled command needs — `EffectServices` without `ProcessPorts`, because a command may
  * not declare `emit` (ADR 0372) and `emitHandler` is the only reader of that service.
  */
-export type CommandEffectServices = ProcessSelf | SpawnedProcesses | Processes;
+export type CommandEffectServices = Exclude<EffectServices, ProcessPorts>;
 
 /** The same handlers minus `emit`, so no command's spell can reach a process out-port. */
 const COMMAND_HANDLERS: CommandHandlers<EffectFailure, CommandEffectServices> = {

--- a/apps/tuval/src/authoring/effect.ts
+++ b/apps/tuval/src/authoring/effect.ts
@@ -115,7 +115,7 @@ export const ask = <Event extends string>(
 /** Answer the `ask` whose arrival carried `to`. Spending one twice is refused, not doubled. */
 export const reply = (to: ReplyTo, payload: unknown): ReplyEffect => ({type: "reply", to, payload});
 
-/** Announce on one of my own out-ports. */
+/** Announce on one of my own out-ports. An `update` cell's alone: a command may not (ADR 0372). */
 export const emit = <Port extends string>(port: Port, payload: unknown): EmitEffect<Port> => ({
 	type: "emit",
 	port,


### PR DESCRIPTION
The founder ruled direction 2 on #8766: a `commands` cell cannot declare `emit`. This records that
ruling as ADR 0372 and makes the authoring surface enforce it.

`emit` announces on a running process's out-port. A spell call is not a process step: the `Scope` it
runs under names a workspace and a client, and its `process` — when present — is the *caller's*, not
the declaring program's. So there is no honest reading of an `emit` written in a `commands` cell in
either case, which is why the answer is a refusal rather than a wiring fix.

What changed:

- `CommandEffect` in `apps/tuval/src/authoring/commands.ts` is `Exclude<ProgramEffect, EmitEffect>`,
  and `CommandAnswer` is built over it — the refusal lands on the author's `run` at the line that
  wrote it.
- `COMMAND_HANDLERS` in `apps/tuval/src/authoring/define-program.ts` is the five command-reachable
  handlers, typed over `CommandEffectServices = ProcessSelf | SpawnedProcesses | Processes`.
  `emitHandler` is the only reader of `ProcessPorts` and is unreachable from a compiled spell, so no
  spell requires that service. `HANDLERS`/`EffectServices` keep all six for the `update` path.
- `commands.unit.test.ts` drops `capturingPorts` — its effect test drives a `send` through a
  capturing `SpawnedProcesses`, and a `@ts-expect-error` case holds the refusal in place, so
  deleting the narrowing turns the test red.

Base is `epic/8716`: none of these files exist on `main` yet.

Reviewer's first stop is the deviation below — the sibling `ProcessSelf` gap this ruling leaves
open, filed as #8858.

Ruling comment: https://github.com/kamp-us/phoenix/issues/8766#issuecomment-5612412328

Fixes #8766

## Deviations

- **Known defect left unfixed** — **Said:** the issue's contract is `emit` and `ProcessPorts`.
  **Did:** left `ProcessSelf` required by a compiled command's `spawn`/`ask` handlers while the
  `Kernel` union still does not name it. **Why:** it is the same erased-requirement shape one service
  over, and it needs its own ruling (narrow `spawn`/`ask` too, or resolve a `self` from
  `Scope.process`) — not a call this lane may make. **Disposition:** filed as #8858 and named in ADR
  0372's consequences.
