### PR TITLE
fix: A restored Tuval Claude session replays its checkpointed tail verbatim, so a pre-#8831 tail stays empty forever

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -13,7 +13,7 @@
  */
 
 import type {AgentEvent, AgentFailure, Phase} from "../events.ts";
-import {isRefusal, planTranscriptWindow} from "../history/index.ts";
+import {isRefusal, localEchoes, planTranscriptWindow} from "../history/index.ts";
 import {
 	ItemId,
 	type PendingPermission,
@@ -100,6 +100,72 @@ export const foldItem = (
 	return isRefusal(planned)
 		? transcript
 		: {items: planned.items, omitted: addOmission(transcript.omitted, planned.omitted)};
+};
+
+/** Which rows of the store's history this process is already holding a copy of, by their index. */
+const heldPositions = (
+	held: ReadonlyArray<TranscriptItem>,
+	history: ReadonlyArray<TranscriptItem>,
+): ReadonlySet<number> => {
+	// The operator's own turns join on text, not on id: the core records one at the send under a
+	// `local:<key>` id no backend ever sees (#7978), and a layer that echoes no `user` item never
+	// clears it — so an id-only join would read every unechoed prompt as a row the store lacks.
+	const echoes = localEchoes(history, held);
+	const ids = new Set(held.map((item) => item.id));
+	return new Set(
+		history.flatMap((item, index) => (echoes.has(index) || ids.has(item.id) ? [index] : [])),
+	);
+};
+
+/**
+ * The store's history with the tail this process is holding spliced back in whole.
+ *
+ * **The held tail wins over the range it covers**, rather than each of its rows being merged in one
+ * at a time. Two things live in that tail and in no store: the operator's turns, recorded locally
+ * at the send, and the half-written reply the restart cut, which the backend never finished writing
+ * down. Merged row by row they land at the end — every prompt of the session below the replies it
+ * produced — so the range is what is substituted, and what the store adds is what sits outside it.
+ * Inside the range, our copy is also the one the restore marked `interrupted` (`./state.ts`) and the
+ * operator has already read that way; a row that genuinely moved while the transport was down
+ * arrives on the event stream and upserts over this (#8374).
+ *
+ * A tail with nothing in the store at all is the whole store's junior, so it goes behind it.
+ */
+const rebaseOnStore = (
+	held: ReadonlyArray<TranscriptItem>,
+	history: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> => {
+	if (held.length === 0) return history;
+	const positions = heldPositions(held, history);
+	const covered = [...positions].sort((left, right) => left - right);
+	const first = covered[0];
+	const last = covered[covered.length - 1];
+	if (first === undefined || last === undefined) return [...history, ...held];
+	const outside = (from: number, to: number): ReadonlyArray<TranscriptItem> =>
+		history.slice(from, to).filter((_, offset) => !positions.has(from + offset));
+	return [...outside(0, first), ...held, ...outside(last + 1, history.length)];
+};
+
+/**
+ * The tail a resumed session comes back with: a fresh window over the store's whole history rather
+ * than the one the checkpoint carried (#8855).
+ *
+ * `foldItem` above runs per arriving live item, so it can shed rows and never bring one back — a
+ * checkpoint written under an older window rule stays exactly as unrenderable after every boot.
+ * This is the one entrance that re-plans, which is also what makes any later change to the window
+ * rule self-healing.
+ *
+ * The omission is replaced, not added to: it describes the window that was just planned, and the
+ * count the stale tail carried was about a window that no longer exists. A refused plan leaves the
+ * tail as it was, the same answer `foldItem` gives.
+ */
+export const refillTranscript = (
+	transcript: TranscriptPayload,
+	history: ReadonlyArray<TranscriptItem>,
+	limits: WindowLimits,
+): TranscriptPayload => {
+	const planned = planTranscriptWindow(rebaseOnStore(transcript.items, history), limits);
+	return isRefusal(planned) ? transcript : {items: planned.items, omitted: planned.omitted};
 };
 
 /**

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -37,6 +37,7 @@ import {
 	interruptionAfter,
 	phaseAfterFailure,
 	promptItem,
+	refillTranscript,
 	unresolvedAnswer,
 	type WindowLimits,
 } from "./fold.ts";
@@ -213,6 +214,11 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 
 			// Both open completions advance the subscription lifetime: the slot was rebuilt whether
 			// start succeeded or refused. Ordinary failures leave that lifetime alone.
+			//
+			// A layer that read the resumed session's whole stored transcript hands it over here, and
+			// the tail is re-planned over it rather than trusted (#8855). Without the refill a
+			// checkpoint written under an older window rule replays verbatim on every boot: the live
+			// planner runs per arriving item, so it can shed rows and never restore one.
 			started: (state, msg) =>
 				state.phase === "gone"
 					? [state, noCmds]
@@ -224,6 +230,9 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 								connection: state.connection + 1,
 								interruption: null,
 								failure: null,
+								...(msg.history === undefined
+									? {}
+									: {transcript: refillTranscript(state.transcript, msg.history, limits)}),
 							},
 							noCmds,
 						]),

--- a/apps/tuval/src/ai-agent/core/messages.ts
+++ b/apps/tuval/src/ai-agent/core/messages.ts
@@ -9,12 +9,27 @@
 
 import {type Sub, type SubId, subId} from "@demlik/tea";
 import type {AgentEvent} from "../events.ts";
-import type {Mode, ModelRef, PermissionDecision, ThinkingLevel} from "../ports/index.ts";
+import type {
+	Mode,
+	ModelRef,
+	PermissionDecision,
+	ThinkingLevel,
+	TranscriptItem,
+} from "../ports/index.ts";
 import type {AgentFailure, HistoryPage} from "./state.ts";
 
 export type AiAgentSessionMsg =
 	| {readonly type: "start"; readonly cwd: string; readonly resume: string | null}
-	| {readonly type: "started"; readonly sessionId: string}
+	/**
+	 * The open landed. `history` is the resumed session's whole stored transcript when the layer
+	 * read one (`../service/TuvalAiAgent.ts`, `StartedSession`), and the `started` cell re-plans the
+	 * tail over it rather than keeping the one the checkpoint carried (#8855).
+	 */
+	| {
+			readonly type: "started";
+			readonly sessionId: string;
+			readonly history?: ReadonlyArray<TranscriptItem>;
+	  }
 	/** The slot was rebuilt, but its start call refused; the subscription lifetime still changed. */
 	| {readonly type: "openFailed"; readonly failure: AgentFailure}
 	/**

--- a/apps/tuval/src/ai-agent/handlers/index.ts
+++ b/apps/tuval/src/ai-agent/handlers/index.ts
@@ -161,7 +161,10 @@ export const aiAgentHandlers = <RIn = never>(
 			};
 			const started = yield* Effect.result(underPolicy(agent.start(options), policy));
 			if (Result.isSuccess(started)) {
-				return [{type: "started", sessionId: started.success.sessionId}];
+				// The stored history rides through untouched: the core plans the window, because the
+				// bounds are its own and a layer planning them would answer to a second copy of them.
+				const {sessionId, history} = started.success;
+				return [{type: "started", sessionId, ...(history === undefined ? {} : {history})}];
 			}
 			const error = started.failure;
 			return [

--- a/apps/tuval/src/ai-agent/history/index.ts
+++ b/apps/tuval/src/ai-agent/history/index.ts
@@ -17,7 +17,7 @@ export {
 	weighGroup,
 } from "./groups.ts";
 export {KERNEL_TOOL_SERVER, type KernelSpawn, kernelSpawnOf} from "./kernel-spawn.ts";
-export {withoutLocalEchoes} from "./local-turns.ts";
+export {localEchoes, withoutLocalEchoes} from "./local-turns.ts";
 export {
 	type PageOptions,
 	planTranscriptPage,

--- a/apps/tuval/src/ai-agent/history/local-turns.ts
+++ b/apps/tuval/src/ai-agent/history/local-turns.ts
@@ -14,39 +14,56 @@
 
 import type {TranscriptItem} from "../ports/index.ts";
 
-const localTurnCounts = (tail: ReadonlyArray<TranscriptItem>): Map<string, number> => {
-	const counts = new Map<string, number>();
+const localTurnsByText = (
+	tail: ReadonlyArray<TranscriptItem>,
+): Map<string, Array<TranscriptItem>> => {
+	const rows = new Map<string, Array<TranscriptItem>>();
 	for (const item of tail) {
-		if (item.kind === "user" && item.local === true) {
-			counts.set(item.text, (counts.get(item.text) ?? 0) + 1);
-		}
+		if (item.kind !== "user" || item.local !== true) continue;
+		const held = rows.get(item.text);
+		if (held === undefined) rows.set(item.text, [item]);
+		else held.push(item);
 	}
-	return counts;
+	return rows;
 };
 
 /**
- * `page` minus the rows that are the store's copy of a turn `tail` already holds locally.
+ * Which `page` rows are the store's copy of a turn `tail` holds locally, by their index in `page`,
+ * paired with the local row each one is a copy of.
  *
  * Bounded by count and walked newest-first, because text alone is not identity. A prompt sent twice
- * leaves two local rows and drops two stored rows, so the two deliberate turns stay two. A turn
- * whose local row has already fallen out of the bounded tail keeps its stored row — past the tail
- * that row is the only place the operator's own words exist, and dropping it would hand back the
+ * leaves two local rows and pairs two stored rows, so the two deliberate turns stay two. A turn
+ * whose local row has already fallen out of the bounded tail pairs with nothing — past the tail its
+ * stored row is the only place the operator's own words exist, and dropping it would hand back the
  * very defect this join exists to close.
+ *
+ * The pairing is the answer rather than the filtered list because its two callers want opposite
+ * halves of it: the paging stitch drops the stored copy (`withoutLocalEchoes`), and the resume's
+ * refill puts the local row *where the stored copy sat* (`../core/fold.ts`, #8855) — appending it
+ * instead reorders the operator's own turns to the end of the tail.
  */
+export const localEchoes = (
+	page: ReadonlyArray<TranscriptItem>,
+	tail: ReadonlyArray<TranscriptItem>,
+): ReadonlyMap<number, TranscriptItem> => {
+	const paired = new Map<number, TranscriptItem>();
+	const rows = localTurnsByText(tail);
+	if (rows.size === 0) return paired;
+	for (let index = page.length - 1; index >= 0; index -= 1) {
+		const item = page[index];
+		if (item === undefined || item.kind !== "user") continue;
+		const local = rows.get(item.text)?.pop();
+		if (local === undefined) continue;
+		paired.set(index, local);
+	}
+	return paired;
+};
+
+/** `page` minus the rows that are the store's copy of a turn `tail` already holds locally. */
 export const withoutLocalEchoes = (
 	page: ReadonlyArray<TranscriptItem>,
 	tail: ReadonlyArray<TranscriptItem>,
 ): ReadonlyArray<TranscriptItem> => {
-	const budget = localTurnCounts(tail);
-	if (budget.size === 0) return page;
-	const dropped = new Set<number>();
-	for (let index = page.length - 1; index >= 0; index -= 1) {
-		const item = page[index];
-		if (item === undefined || item.kind !== "user") continue;
-		const left = budget.get(item.text) ?? 0;
-		if (left === 0) continue;
-		budget.set(item.text, left - 1);
-		dropped.add(index);
-	}
-	return dropped.size === 0 ? page : page.filter((_, index) => !dropped.has(index));
+	const paired = localEchoes(page, tail);
+	return paired.size === 0 ? page : page.filter((_, index) => !paired.has(index));
 };

--- a/apps/tuval/src/ai-agent/restore/refill.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/refill.unit.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The restore path's transcript refill: what a resumed session's tail is planned over, and what a
+ * reader sees once it is (#8855).
+ *
+ * The founder's own checkpoint is the fixture shape — 21 nested worker rows, 17 session notices,
+ * no user row, `omitted.items` in the thousands — because a tail written under an older window
+ * rule is unrenderable and `restore` alone replays it verbatim, so it comes back unrenderable
+ * after every boot. The assertions run the tail through `chatRows`, the same join the desk renders
+ * through: a window is empty or it is not, and only the renderer can say which.
+ */
+
+import {applyCellChecked} from "@demlik/tea";
+import {describe, expect, it} from "vitest";
+import {
+	assistantItem,
+	nestedUnder,
+	subagentSlot,
+	systemItem,
+	toolItem,
+	userItem,
+} from "../../ai-agent-fixtures/transcripts.ts";
+import {type ChatRow, chatRows} from "../../shell/chat/rows.ts";
+import {aiAgentSessionMachine} from "../core/machine.ts";
+import type {AiAgentSessionCmd, AiAgentSessionMsg} from "../core/messages.ts";
+import {type AiAgentSessionState, initialState, restore} from "../core/state.ts";
+import type {TranscriptItem} from "../ports/index.ts";
+
+const CWD = "/work";
+const SESSION = "session-3c82b30d";
+const SPAWN = "call-spawn";
+
+/** What the pre-#8831 window rule left in the founder's checkpoint: passengers and notices only. */
+const NESTED_ROWS = 21;
+const NOTICE_ROWS = 17;
+/** Older exchanges the store still holds behind the tail, so the refilled window omits some. */
+const OLDER_TURNS = 30;
+/** The count the broken checkpoint carried — a window that no longer exists. */
+const STALE_OMITTED = 5043;
+
+const machine = aiAgentSessionMachine({cwd: CWD});
+
+const apply = (
+	state: AiAgentSessionState,
+	msg: AiAgentSessionMsg,
+): readonly [AiAgentSessionState, ReadonlyArray<AiAgentSessionCmd>] =>
+	applyCellChecked<AiAgentSessionState, AiAgentSessionMsg, AiAgentSessionCmd>(machine, state, msg);
+
+const workerRows: ReadonlyArray<TranscriptItem> = Array.from({length: NESTED_ROWS}, (_, index) =>
+	nestedUnder(assistantItem(`w-${index}`, `worker line ${index}`), SPAWN),
+);
+
+const noticeRows: ReadonlyArray<TranscriptItem> = Array.from({length: NOTICE_ROWS}, (_, index) =>
+	systemItem(`n-${index}`, `task progress ${index}`),
+);
+
+const olderRows: ReadonlyArray<TranscriptItem> = Array.from(
+	{length: OLDER_TURNS},
+	(_, index): ReadonlyArray<TranscriptItem> => [
+		userItem(`u-${index}`, `older prompt ${index}`),
+		assistantItem(`a-${index}`, `older answer ${index}`),
+	],
+).flat();
+
+/** The whole session as the backend's store holds it — the rows a resume's own read already maps. */
+const storedHistory: ReadonlyArray<TranscriptItem> = [
+	...olderRows,
+	userItem("u-spawn", "run three workers"),
+	toolItem(SPAWN, "spawned"),
+	...workerRows,
+	...noticeRows,
+	assistantItem("a-spawn", "all three came back"),
+];
+
+/** The checkpoint the founder's desk came back with: the tail nothing can render. */
+const brokenCheckpoint: AiAgentSessionState = {
+	...initialState(CWD),
+	phase: "ready",
+	sessionId: SESSION,
+	subagents: {[SPAWN]: subagentSlot(SPAWN, {items: [...workerRows]})},
+	transcript: {
+		items: [...workerRows, ...noticeRows],
+		omitted: {items: STALE_OMITTED, bytes: 4_000_000, reason: "item-limit"},
+	},
+};
+
+/** The resume as the pipeline runs it: restore the checkpoint, then land the layer's open. */
+const resumed = (
+	checkpoint: AiAgentSessionState,
+	history: ReadonlyArray<TranscriptItem>,
+): AiAgentSessionState => {
+	const [reconnecting] = apply(restore(checkpoint), {type: "reconnect"});
+	const [ready] = apply(reconnecting, {type: "started", sessionId: SESSION, history});
+	return ready;
+};
+
+/** A `turn` row hides its own rows behind a summary, so a reader's rows are the flattened list. */
+const flatten = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<ChatRow> =>
+	rows.flatMap((row) => (row.kind === "turn" ? [row, ...flatten(row.hidden)] : [row]));
+
+const rowsFor = (state: AiAgentSessionState): ReadonlyArray<ChatRow> =>
+	flatten(
+		chatRows({
+			older: [],
+			tail: state.transcript.items,
+			omitted: state.transcript.omitted.items,
+			loading: false,
+			atOldest: false,
+			subagents: new Set(Object.keys(state.subagents)),
+		}),
+	);
+
+/** Content the operator can actually read: a row of its own, not one folded under a worker's call. */
+const contentRows = (rows: ReadonlyArray<ChatRow>): ReadonlyArray<ChatRow> =>
+	rows.filter((row) => row.kind === "item" && !row.nested);
+
+describe("a checkpoint whose tail is all passengers and notices", () => {
+	it("renders nothing before the refill — the defect, stated", () => {
+		expect(contentRows(rowsFor(restore(brokenCheckpoint)))).toEqual([]);
+	});
+
+	it("renders the operator's own turns once the resume re-plans the tail", () => {
+		const rows = contentRows(rowsFor(resumed(brokenCheckpoint, storedHistory)));
+		const ids = rows.flatMap((row) => (row.kind === "item" ? [row.item.id] : []));
+		expect(ids.length).toBeGreaterThan(0);
+		// The spawning turn, read as the operator wrote it: their prompt, the call, the reply.
+		expect(ids.slice(-3)).toEqual(["u-spawn", SPAWN, "a-spawn"]);
+	});
+
+	it("replaces the stale omission with what the newly planned window left out", () => {
+		const state = resumed(brokenCheckpoint, storedHistory);
+		expect(state.transcript.omitted.items).toBe(
+			storedHistory.length - state.transcript.items.length,
+		);
+		expect(state.transcript.omitted.items).toBeLessThan(STALE_OMITTED);
+	});
+
+	it("keeps the subagent slots and the strip that pages back past the window", () => {
+		const state = resumed(brokenCheckpoint, storedHistory);
+		expect(Object.keys(state.subagents)).toEqual([SPAWN]);
+		expect(rowsFor(state)).toContainEqual({
+			kind: "older",
+			items: state.transcript.omitted.items,
+		});
+	});
+});
+
+describe("a checkpoint whose tail already renders", () => {
+	const tail: ReadonlyArray<TranscriptItem> = [
+		userItem("u-live", "what changed"),
+		assistantItem("a-live", "two files", undefined, true),
+	];
+	const passing: AiAgentSessionState = {
+		...initialState(CWD),
+		phase: "ready",
+		sessionId: SESSION,
+		transcript: {items: tail, omitted: {items: 4, bytes: 900, reason: "item-limit"}},
+	};
+
+	it("keeps every row it carried, in the order it carried them", () => {
+		const state = resumed(passing, [...olderRows.slice(0, 8), ...tail]);
+		const ids = state.transcript.items.map((item) => item.id);
+		expect(ids.slice(-tail.length)).toEqual(tail.map((item) => item.id));
+		expect(ids).toContain("u-0");
+	});
+
+	it("keeps this process's own copy of a row the store also holds", () => {
+		// The restore marked the cut reply `interrupted`; the store's copy carries no such marker,
+		// and the operator has already read ours (#8369).
+		const stale = assistantItem("a-live", "two files");
+		const state = resumed(passing, [...olderRows.slice(0, 8), userItem("u-live", "x"), stale]);
+		expect(state.transcript.items.find((item) => item.id === "a-live")).toEqual(tail[1]);
+	});
+
+	it("holds an unechoed prompt and a cut reply in place, neither of which the store has", () => {
+		// The shape the Claude CLI leaves: it echoes no `user` frame, so the operator's turn exists
+		// only as the core's local row — and the reply the restart cut was never written down.
+		const local: TranscriptItem = {...userItem("local:k1", "run it"), local: true};
+		const cut = assistantItem("a-cut", "I was in the middle of", undefined, true);
+		const held = {
+			...passing,
+			transcript: {items: [local, cut], omitted: {items: 2, bytes: 50, reason: "item-limit"}},
+		} satisfies AiAgentSessionState;
+		const state = resumed(held, [...olderRows.slice(0, 4), userItem("s-k1", "run it")]);
+		expect(state.transcript.items.map((item) => item.id).slice(-2)).toEqual(["local:k1", "a-cut"]);
+		// The store's copy of that same turn is the one dropped, not carried beside it.
+		expect(state.transcript.items.map((item) => item.id)).not.toContain("s-k1");
+	});
+});
+
+describe("a layer that read no history", () => {
+	it("leaves the restored tail exactly as it was", () => {
+		const restored = restore(brokenCheckpoint);
+		const [reconnecting] = apply(restored, {type: "reconnect"});
+		const [ready] = apply(reconnecting, {type: "started", sessionId: SESSION});
+		expect(ready.transcript).toEqual(restored.transcript);
+	});
+});

--- a/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/ScriptedAiAgent.ts
@@ -238,7 +238,12 @@ const make = (script: AgentScript): Effect.Effect<TuvalAiAgentApi, never, Scope.
 				mode: openedOn,
 				...(resuming === undefined ? {} : {turn: script.resumeAtTurn ?? previous.turn}),
 			}));
-			return {sessionId: script.sessionId};
+			// A resume hands back the whole scripted history, the way a real store-backed layer hands
+			// back what its open read (#8855). A fresh open has no session to have read one from.
+			return {
+				sessionId: script.sessionId,
+				...(resuming === undefined ? {} : {history: script.history}),
+			};
 		});
 
 		const prompt = Effect.fn("TuvalAiAgent.prompt")(function* (text: string, key?: string) {

--- a/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
+++ b/apps/tuval/src/ai-agent/service/TuvalAiAgent.ts
@@ -100,6 +100,21 @@ export interface StartOptions {
 
 export interface StartedSession {
 	readonly sessionId: string;
+	/**
+	 * The whole stored transcript of a resumed session, oldest-first — the rows the open already
+	 * read, handed back so the core can plan a fresh window over them (#8855).
+	 *
+	 * A checkpointed tail is replayed verbatim by `restore`, so one written under an older window
+	 * rule stays unrenderable after every boot: `planTranscriptWindow` runs per arriving live item
+	 * and can shed rows, never bring back rows already in `omitted`. This is the one field that
+	 * lets a resume re-plan instead of re-trust.
+	 *
+	 * **Whole, or absent.** The core replaces `transcript.omitted` with what the fresh plan left
+	 * out, so a partial slice would report a session with 5000 older rows as having none. A layer
+	 * that cannot read the whole stored transcript in the open omits this and the resumed tail
+	 * stays exactly as it was. A fresh open never carries one — there is no session to have read.
+	 */
+	readonly history?: ReadonlyArray<TranscriptItem>;
 }
 
 /** One page of history, oldest-first. `hasMore` is false once the page reaches the beginning. */

--- a/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
+++ b/apps/tuval/src/claude/agent/ClaudeAiAgent.ts
@@ -556,6 +556,11 @@ const make = (
 			held: Mode | null,
 		) {
 			const stale: Array<string> = [];
+			// The rows this read maps are the resumed session's whole stored transcript, and the core
+			// re-plans its window over them (#8855). Before that they were mapped for the unsettled
+			// tool ids and thrown away, which is why a checkpointed tail written under an older window
+			// rule could only ever be replayed verbatim.
+			let history: ReadonlyArray<TranscriptItem> | undefined;
 			if (resume !== undefined) {
 				const rows = yield* Effect.tryPromise({
 					try: () => sdk.getSessionMessages(resume, {dir: cwd}),
@@ -573,6 +578,7 @@ const make = (
 				}
 				const {items} = toHistoryItems(rows, {at: Date.now()});
 				stale.push(...unsettledToolIds(items).filter((id) => !parked.has(id)));
+				history = items;
 			}
 
 			// A resumed session already has the CLI's id; a fresh one is opened under an id this layer
@@ -624,6 +630,7 @@ const make = (
 				} satisfies Session,
 				iterator: handle[Symbol.asyncIterator](),
 				stale: stale as ReadonlyArray<string>,
+				history,
 			};
 		});
 
@@ -759,7 +766,10 @@ const make = (
 				drive(out, opened.iterator, emptyMapping, opened.session),
 				opened.session.scope,
 			);
-			return {sessionId: opened.session.id};
+			return {
+				sessionId: opened.session.id,
+				...(opened.history === undefined ? {} : {history: opened.history}),
+			};
 		});
 
 		const prompt = Effect.fn("TuvalAiAgent.prompt")(function* (text: string, key?: string) {

--- a/apps/tuval/tsconfig.design.json
+++ b/apps/tuval/tsconfig.design.json
@@ -32,6 +32,7 @@
 		"src/page/session-transcript-window.unit.test.tsx",
 		"src/claude/proof/subagent-vertical.integration.test.ts",
 		"src/claude/proof/subagent-paging.integration.test.ts",
+		"src/ai-agent/restore/refill.unit.test.ts",
 		"src/page/assets.d.ts"
 	],
 	// `exclude` is inherited, and the base excludes exactly this directory.

--- a/apps/tuval/tsconfig.json
+++ b/apps/tuval/tsconfig.json
@@ -39,6 +39,9 @@
 	// stay here. `subagent-paging.integration.test.ts` is split for the directory rather than the
 	// package: it joins the layer's history read to the window's own page request, so it reaches
 	// `src/shell/chat/rows.ts` — pure, but inside the slice this lens excludes whole.
+	// `src/ai-agent/restore/refill.unit.test.ts` is split for that same directory reason: it asserts
+	// what a restored tail *renders*, so it reaches `src/shell/chat/rows.ts` — pure, but inside the
+	// slice this lens excludes whole (#8855).
 	// `src/pi/renderer-ref.ts`, `src/claude/renderer-ref.ts`, `src/agy/renderer-ref.ts`,
 	// `src/codex/renderer-ref.ts` and `src/ai-agent/renderer-ref.ts` still enter this project by
 	// import from their rows, which is the point of those leaves: a row names its renderer without
@@ -60,6 +63,7 @@
 		"src/page/readable-state.unit.test.tsx",
 		"src/page/session-transcript-window.unit.test.tsx",
 		"src/claude/proof/subagent-vertical.integration.test.ts",
-		"src/claude/proof/subagent-paging.integration.test.ts"
+		"src/claude/proof/subagent-paging.integration.test.ts",
+		"src/ai-agent/restore/refill.unit.test.ts"
 	]
 }


### PR DESCRIPTION
Fixes #8855.

A restored Claude session replayed its checkpointed transcript tail verbatim, so a tail written under the pre-#8831 window rule stayed unrenderable after every boot — the founder's desk sessions came back as "Load earlier messages / 5043 omitted" plus a SESSION group and nothing else. `planTranscriptWindow` runs per arriving live item, so it can shed rows and never bring one back.

A resume now re-plans the tail instead of trusting it. The Claude layer's resume `open` already reads the whole stored transcript through `getSessionMessages` and maps it through `toHistoryItems` — it kept only the unsettled tool ids and threw the rows away. Those same rows now ride back on `StartedSession.history`, the `started` Msg carries them, and the core plans a fresh window over them. No second store read, and it self-heals on any future window-rule change.

The merge is where the care went. The held tail wins over the range it covers rather than being merged row by row: two things live in that tail and in no store — the operator's turns, recorded locally at the send, and the half-written reply a restart cut — and merging them one at a time lands every unechoed prompt of the session below the replies it produced. So the store fills in what sits outside the held range, and inside it our copy stands, which is also the copy the restore marked `interrupted`. `withoutLocalEchoes` is refactored to expose that pairing (`localEchoes`) since the paging stitch wants the opposite half of the same join.

`transcript.omitted` is replaced rather than accumulated: it describes the window just planned, so the stale 5043 becomes a real count and the "Load earlier" strip pages from the right place.

A layer that reads no history omits the field and its resumed tail is untouched, so Pi, Agy and Codex are unchanged.

Look first at `rebaseOnStore` in `apps/tuval/src/ai-agent/core/fold.ts` — the range-substitution rule is the one thing here a reader could disagree with, and `apps/tuval/src/ai-agent/restore/refill.unit.test.ts` pins each case it turns on, including the Claude-shaped one (unechoed prompt + cut reply, neither in the store) that the vertical proof caught when the first draft merged row by row.

## Deviations

- **Out-of-scope change** — **Said:** the issue names the reconnect path. **Did:** the Claude layer hands back `history` on any resume, including a fresh `start` carrying a resume from the session picker. **Why:** the layer reads those rows on one branch and telling the two flavours apart would mean plumbing `holdsTranscript` into a layer that reads it nowhere today; on the picker path the transcript is empty, so the refill paints history that path previously left blank until the operator paged. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about the scripted layer. **Did:** `ScriptedAiAgent.start` now returns `history: script.history` on a resume. **Why:** it is the reference implementation of the port, and without it no generic restore proof exercises the new seam at all. **Disposition:** stated here; the scripted proofs stayed green unchanged.
- **Out-of-scope change** — **Said:** nothing about tsconfig. **Did:** `apps/tuval/src/ai-agent/restore/refill.unit.test.ts` is moved from the Node lens to `tsconfig.design.json`. **Why:** the acceptance criterion puts the test under `src/ai-agent/restore/` and requires it to render through `src/shell/chat/rows.ts`, and the base lens excludes `src/shell/chat` whole; `src/claude/proof/subagent-paging.integration.test.ts` is split for exactly this reason already. **Disposition:** stated here, and the base lens's comment names the new entry beside that precedent.
