### PR TITLE
fix: Two tuval feature flags are missing from the config schema, so a layer that states them is ignored

### DIFF
--- a/apps/tuval/src/config-fixtures/pi-kernel-tools-off.ts
+++ b/apps/tuval/src/config-fixtures/pi-kernel-tools-off.ts
@@ -1,0 +1,1 @@
+export default {version: 1, programs: [{id: "a"}], features: {piKernelTools: false}};

--- a/apps/tuval/src/config-fixtures/pi-kernel-tools-on.ts
+++ b/apps/tuval/src/config-fixtures/pi-kernel-tools-on.ts
@@ -1,0 +1,1 @@
+export default {version: 1, programs: [{id: "a"}], features: {piKernelTools: true}};

--- a/apps/tuval/src/config.ts
+++ b/apps/tuval/src/config.ts
@@ -54,26 +54,26 @@ const GraphNode = Schema.Struct({
 const GraphSchema = Schema.Struct({nodes: Schema.Array(GraphNode)});
 
 /**
- * The feature flags a layer *states*. Every key is optional, and that is the whole point: absent
- * means "this layer says nothing", not "off", so a project layer naming one flag cannot put back to
- * its default a flag the global layer turned on. `featuresDefault` is where a flag nobody stated
- * lands.
+ * The feature flags a layer *states*, one optional boolean key per key of `TuvalFeatures`. Every
+ * key is optional, and that is the whole point: absent means "this layer says nothing", not "off",
+ * so a project layer naming one flag cannot put back to its default a flag the global layer turned
+ * on. `featuresDefault` is where a flag nobody stated lands.
+ *
+ * Derived rather than hand-listed, because hand-listing drifted twice: a key on `TuvalFeatures`
+ * that nobody re-typed here was dropped by the decode, so a layer stating it moved the browser and
+ * nothing on the node side (#8595, #8783). The mapped type takes the key set from `TuvalFeatures`
+ * and the runtime fields from `featuresDefault`'s own keys, and `featuresDefault` is annotated
+ * `TuvalFeatures`, so the two cannot name different keys.
  */
-const DeclaredFeatures = Schema.Struct({
-	/**
-	 * The running-subagent list at the top of the agent window, and — the same flag, because they are
-	 * one change — a subagent's rows leaving the agent window's transcript (#8405).
-	 */
-	subagentList: Schema.optionalKey(Schema.Boolean),
-	/**
-	 * Load the `pi-subagents` extension into a Pi session (#8555). A key missing here is a key the
-	 * decode drops, so a layer that stated it reached the browser and nothing else (#8595).
-	 */
-	piSubagents: Schema.optionalKey(Schema.Boolean),
-	kernelChildren: Schema.optionalKey(Schema.Boolean),
-	windowTitles: Schema.optionalKey(Schema.Boolean),
-	processBoard: Schema.optionalKey(Schema.Boolean),
-});
+type DeclaredFeatureFields = {
+	readonly [K in keyof TuvalFeatures]: Schema.optionalKey<typeof Schema.Boolean>;
+};
+
+const declaredFeatureFields = Object.fromEntries(
+	Object.keys(featuresDefault).map((key) => [key, Schema.optionalKey(Schema.Boolean)]),
+) as DeclaredFeatureFields;
+
+export const DeclaredFeatures = Schema.Struct(declaredFeatureFields);
 
 export {featuresDefault, type TuvalFeatures} from "./features.ts";
 

--- a/apps/tuval/src/config.unit.test.ts
+++ b/apps/tuval/src/config.unit.test.ts
@@ -2,7 +2,7 @@ import {fileURLToPath} from "node:url";
 import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {ConfigLoadError, loadConfigModule, loadLayeredConfig} from "./config.ts";
+import {ConfigLoadError, DeclaredFeatures, loadConfigModule, loadLayeredConfig} from "./config.ts";
 import {featuresDefault} from "./features.ts";
 import {NodeId} from "./ports/graph.ts";
 import {ProgramId} from "./registry/program.ts";
@@ -182,6 +182,36 @@ describe("the feature flags", () => {
 			assert.deepStrictEqual(overGlobalOn.features, {...featuresDefault, piSubagents: false});
 		}),
 	);
+
+	it.effect("keep a stated piKernelTools rather than dropping it at the decode", () =>
+		Effect.gen(function* () {
+			const config = yield* loadConfigModule(fixture("pi-kernel-tools-on"));
+			assert.deepStrictEqual(config.features, {piKernelTools: true});
+		}),
+	);
+
+	it.effect("let a layer turn piKernelTools on against its off default", () =>
+		Effect.gen(function* () {
+			const global = yield* layered(fixture("pi-kernel-tools-on"), fixture("two-rows"));
+			assert.deepStrictEqual(global.features, {...featuresDefault, piKernelTools: true});
+			const project = yield* layered(fixture("two-rows"), fixture("pi-kernel-tools-on"));
+			assert.deepStrictEqual(project.features, {...featuresDefault, piKernelTools: true});
+			const overGlobalOn = yield* layered(
+				fixture("pi-kernel-tools-on"),
+				fixture("pi-kernel-tools-off"),
+			);
+			assert.deepStrictEqual(overGlobalOn.features, {...featuresDefault, piKernelTools: false});
+		}),
+	);
+
+	// The derivation is what makes a hand-listed key impossible to forget, and this is the assertion
+	// that reds if it is ever unwound back to a literal (#8595, #8783).
+	it("declare exactly the keys featuresDefault carries", () => {
+		assert.deepStrictEqual(
+			Object.keys(DeclaredFeatures.fields).sort(),
+			Object.keys(featuresDefault).sort(),
+		);
+	});
 });
 
 describe("loadLayeredConfig", () => {

--- a/apps/tuval/src/features.ts
+++ b/apps/tuval/src/features.ts
@@ -6,10 +6,11 @@
  * `tsconfig.browser.json` — which compiles with `types: []` — is what would red if this file grew a
  * Node import (#8439).
  *
- * A flag added here crosses to the page with no other edit: the generated module is written by
- * walking this record (`page/dev-server.ts`). Reaching the node side takes two: the key has to be
- * declared in `config.ts`'s `DeclaredFeatures`, or the decode drops it, and the reader takes the
- * merged record off the `Features` kernel service rather than off `featuresDefault` (#8595).
+ * A flag added here is one edit: the generated browser module is written by walking this record
+ * (`page/dev-server.ts`), and `config.ts`'s `DeclaredFeatures` — the schema a layer's `features`
+ * block decodes against — is derived from this record's own keys, so a key added here cannot be
+ * absent from the config schema (#8783). What a node-side reader still owes is taking the merged
+ * record off the `Features` kernel service rather than off `featuresDefault` (#8595).
  */
 
 export interface TuvalFeatures {


### PR DESCRIPTION
`DeclaredFeatures` in `apps/tuval/src/config.ts` was a hand-written `Schema.Struct` listing the
feature-flag keys a config layer may state. `TuvalFeatures` in `apps/tuval/src/features.ts` is where
the keys actually live, and the two drifted twice: `piSubagents` in #8595, and `piKernelTools` still
open here. A key the schema does not name is a key the decode drops, so `features: {piKernelTools:
true}` in `.tuval/tuval.config.ts` never survived into the merged record and the #8720 Pi kernel
bridge could not be turned on by any config an operator can write.

`DeclaredFeatures` is now derived: a mapped type over `keyof TuvalFeatures` gives the field types,
and `Object.keys(featuresDefault)` gives the runtime fields. `featuresDefault` is annotated
`TuvalFeatures`, so TypeScript already forces those two key sets to match — a key added to
`features.ts` cannot be absent from the config schema. Every key stays `Schema.optionalKey(Boolean)`
and the merge in `config.ts` is untouched, so the per-key precedence is unchanged.

Tests: two new blocks in `config.unit.test.ts` modelled on the `piSubagents` ones — `piKernelTools`
surviving the decode, and a layer's value winning over the default in both directions, at global,
project, and project-over-global. Plus an explicit assertion that `DeclaredFeatures.fields` and
`featuresDefault` name the same keys, which reds if the derivation is ever unwound back to a
literal. `features.ts`'s docblock now states the one-edit rule it makes true.

Reviewer's first look: the `as DeclaredFeatureFields` cast in `config.ts`. It is the one unchecked
step, and the key-set test is what pins it.

Verified in this tree: `pnpm typecheck` green across all three tuval tsconfigs, and the full tuval
unit project green (294 files, 3052 tests), including `page/dev-server.unit.test.ts` unchanged.

Fixes #8783

## Deviations

- **Known defect left unfixed** — **Said:** criterion 6 covers `features.ts`'s docblock and any
  `.patterns/` text stating the two-edit rule. **Did:** updated `features.ts` only; no `.patterns/`
  file states the rule. **Why:** the only other place stating it is ADR 0363, which is the history
  surface and already carries a stale name (`featuresOff`, renamed to `featuresDefault` long ago) —
  a landed decision record states what was decided then, not how the code reads now.
  **Disposition:** stated here, ADR left as written.
