### PR TITLE
fix: An agy result with no num_turns decodes as turn zero, so a resumed child re-reports the whole conversation's usage

### DIFF
--- a/apps/tuval/src/agy/ai-agent/mapper.ts
+++ b/apps/tuval/src/agy/ai-agent/mapper.ts
@@ -20,7 +20,9 @@
  *   usage by plain addition, so a `result` reported as this turn's own total double-counts every
  *   earlier turn ([#8695](https://github.com/kamp-us/phoenix/issues/8695)): the turn is the
  *   cumulative's increment over the last cumulative this child read, and `result.num_turns` is what
- *   says whether there is an earlier one inside it at all.
+ *   says whether there is an earlier one inside it at all — or, when agy sent no `num_turns`, what
+ *   cannot say, which is why that unknown takes the same arm a resumed child does
+ *   ([#8707](https://github.com/kamp-us/phoenix/issues/8707)).
  * - A row with no natural wire key (an unreadable line, a denied-action report) needs an id that
  *   does not collide with the next one.
  *
@@ -130,8 +132,23 @@ const spent = (tokens: Tokens): boolean => tokens.inputTokens > 0 || tokens.outp
 const stepUsageKey = (conversationId: string, stepIndex: number): string =>
 	`agy:usage:${conversationId}:step:${stepIndex}`;
 
-const turnUsageKey = (conversationId: string, turns: number): string =>
-	`agy:usage:${conversationId}:turn:${turns}`;
+/**
+ * The result's own key. `num_turns` names the turn whenever agy sent one; when it did not, the last
+ * `step_index` this turn carried is the only other identity agy itself numbered, and it is as stable
+ * across a restore as the turn number is — both count the conversation, not the process. A turn that
+ * carried no step at all leaves neither, and then the conversation is the whole of the key: a second
+ * such turn folds onto this entry and is dropped, which is the under-reporting side `turnTokensOf`
+ * already takes on an unknown turn number, not the over-charging one.
+ */
+const turnUsageKey = (
+	conversationId: string,
+	turns: number | null,
+	lastStepIndex: number | null,
+): string => {
+	if (turns !== null) return `agy:usage:${conversationId}:turn:${turns}`;
+	if (lastStepIndex !== null) return `agy:usage:${conversationId}:turn-after-step:${lastStepIndex}`;
+	return `agy:usage:${conversationId}:turn:unnumbered`;
+};
 
 export interface AgyTurn {
 	/** `agy/<model>` once `init` names one, else the bare binary — agy omits `init.model` on a default run. */
@@ -144,11 +161,16 @@ export interface AgyTurn {
 	/** What this turn's own steps have already reported, so the `result` reports only the residual. */
 	readonly reported: Tokens;
 	/**
+	 * The last `step_index` this turn's steps carried, `null` before any of them has. It keys the
+	 * result's usage when agy numbered no turn — see `turnUsageKey`.
+	 */
+	readonly lastStepIndex: number | null;
+	/**
 	 * The last `result.usage` this child read — the *conversation's* cumulative, against which the
 	 * next `result` is an increment. `null` before this child has read one, which is the case a
 	 * resumed child is in for its first turn: the cumulative it then reads contains turns this
 	 * process never saw, and `result.num_turns` is what distinguishes that from a genuinely first
-	 * turn whose cumulative is its own.
+	 * turn whose cumulative is its own — unless it is `null`, and then nothing does.
 	 */
 	readonly cumulative: Tokens | null;
 }
@@ -159,6 +181,7 @@ export const idleTurn: AgyTurn = {
 	responseText: "",
 	minted: 0,
 	reported: noTokens,
+	lastStepIndex: null,
 	cumulative: null,
 };
 
@@ -188,18 +211,23 @@ const usageEvent = (model: string, key: string, tokens: Tokens): UsageEvent => (
 /**
  * What this turn spent, read out of a cumulative that may contain turns this child never saw.
  *
- * Three arms, and the middle one is the measurement: with a cumulative of its own to subtract, the
- * turn is the difference. Without one, `num_turns` decides — a first turn's cumulative *is* its own,
- * while a resumed child's first cumulative carries the whole conversation, and then the turn's own
- * steps are the only grounded measure of it. Reporting the cumulative there would charge the operator
- * again for every turn before the restore, which is the defect #8695 caught; reporting the steps
- * under-reports only a turn whose steps said nothing, and that is the smaller lie by the whole of
- * the conversation's history.
+ * Four arms, and the first is the measurement: with a cumulative of its own to subtract, the turn is
+ * the difference. Without one, `num_turns` decides — a first turn's cumulative *is* its own, while a
+ * resumed child's first cumulative carries the whole conversation, and then the turn's own steps are
+ * the only grounded measure of it. Reporting the cumulative there would charge the operator again for
+ * every turn before the restore, which is the defect #8695 caught; reporting the steps under-reports
+ * only a turn whose steps said nothing, and that is the smaller lie by the whole of the
+ * conversation's history.
+ *
+ * A `num_turns` agy did not send takes the steps too, for the same reason the terminal status below
+ * reads only `SUCCESS` as a success: an unknown that could be the costly case is read as the costly
+ * case ([#8707](https://github.com/kamp-us/phoenix/issues/8707)).
  */
 const turnTokensOf = (previous: AgyTurn, result: AgyResult): Tokens => {
 	if (result.usage === undefined) return noTokens;
 	const cumulative = tokensOf(result.usage);
 	if (previous.cumulative !== null) return minus(cumulative, previous.cumulative);
+	if (result.num_turns === null) return previous.reported;
 	return result.num_turns <= 1 ? cumulative : previous.reported;
 };
 
@@ -233,7 +261,7 @@ const stepEvents = (previous: AgyTurn, step: AgyStepUpdate, timestamp: number): 
 	const events: Array<AgentEvent> = [];
 	const key = `${step.conversation_id}:${step.step_index}`;
 	const delta = step.text_delta ?? "";
-	let next = previous;
+	let next: AgyTurn = {...previous, lastStepIndex: step.step_index};
 
 	switch (step.step_type) {
 		case "user_input":
@@ -340,7 +368,11 @@ const resultEvents = (previous: AgyTurn, result: AgyResult, timestamp: number): 
 	const residual = minus(turnTokensOf(previous, result), previous.reported);
 	if (spent(residual)) {
 		events.push(
-			usageEvent(previous.model, turnUsageKey(result.conversation_id, result.num_turns), residual),
+			usageEvent(
+				previous.model,
+				turnUsageKey(result.conversation_id, result.num_turns, previous.lastStepIndex),
+				residual,
+			),
 		);
 	}
 
@@ -367,6 +399,7 @@ const resultEvents = (previous: AgyTurn, result: AgyResult, timestamp: number): 
 			responseText: "",
 			minted,
 			reported: noTokens,
+			lastStepIndex: null,
 			cumulative: result.usage === undefined ? previous.cumulative : tokensOf(result.usage),
 		},
 	};

--- a/apps/tuval/src/agy/ai-agent/mapper.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/mapper.unit.test.ts
@@ -74,6 +74,13 @@ const patchResult = (line: string, patch: Record<string, unknown>): string => {
 	return JSON.stringify({...parsed, result: {...parsed.result, ...patch}});
 };
 
+/** A captured `result` with `num_turns` taken off it — the line a later agy release could send. */
+const withoutNumTurns = (line: string): string => {
+	const parsed = JSON.parse(line) as {result: Record<string, unknown>};
+	const {num_turns: _dropped, ...result} = parsed.result;
+	return JSON.stringify({...parsed, result});
+};
+
 describe("an unrecognised step_type", () => {
 	// The six that exist as strings in the agy binary and have never been emitted.
 	const neverEmitted = ["thinking", "plan", "error", "command", "memory", "checkpoint"];
@@ -446,6 +453,68 @@ describe("usage", () => {
 		]);
 		const totals = usageTotals(usage.reduce(addUsage, emptyUsage));
 		expect(totals).toMatchObject({inputTokens: 21419 + 4861, outputTokens: 3});
+	});
+
+	// agy v1.1.27 sends `num_turns` on every captured `result` and the stream carries no version field
+	// to branch on, so a later release dropping it is exactly the case `wire.ts`'s tolerance is for.
+	// The unknown takes the arm that cannot over-charge (#8707).
+	describe("a result agy sent no num_turns on", () => {
+		it("reports a first turn from its own steps, not from the whole cumulative", () => {
+			const {events} = fold([
+				fixtures.init,
+				fixtures.responseDone,
+				withoutNumTurns(fixtures.resultSuccess),
+			]);
+			// With the field present this is turn 1 and the cumulative is its own (20963/151). Absent,
+			// the same cumulative could be a resumed child's whole conversation, so the steps are the
+			// only grounded measure and the result adds nothing.
+			expect(events.filter((event) => event.kind === "usage")).toHaveLength(1);
+			expect(summed(events)).toEqual({inputTokens: 4481, outputTokens: 110});
+		});
+
+		it("reports a resumed child exactly as a numbered resumed child is reported", () => {
+			const numbered = fold([
+				fixtures.init,
+				fixtures.censusResumedStep,
+				fixtures.censusResumedResult,
+			]);
+			const {events} = fold([
+				fixtures.init,
+				fixtures.censusResumedStep,
+				withoutNumTurns(fixtures.censusResumedResult),
+			]);
+			expect(summed(events)).toEqual(summed(numbered.events));
+			expect(summed(events)).toEqual({inputTokens: 4861, outputTokens: 1});
+		});
+
+		it("keys two such turns apart, so the core keeps both instead of only the first", () => {
+			// A residual needs a cumulative that outruns the turn's own steps, which the census numbers
+			// never do — so each result here carries input tokens its step did not report.
+			const overCumulative = (line: string, input: number, output: number): string =>
+				patchResult(withoutNumTurns(line), {
+					usage: {input_tokens: input, output_tokens: output, total_tokens: input + output},
+				});
+			const {events} = fold([
+				fixtures.init,
+				fixtures.censusTurnOneStep,
+				withoutNumTurns(fixtures.censusTurnOneResult),
+				fixtures.censusTurnTwoStep,
+				overCumulative(fixtures.censusTurnTwoResult, 21419 + 100, 2),
+				fixtures.censusResumedStep,
+				overCumulative(fixtures.censusResumedResult, 26280 + 200, 3),
+			]);
+			const usage = events.filter((event) => event.kind === "usage");
+			expect(usage.map((event) => event.turn)).toEqual([
+				`agy:usage:${CENSUS_CONVERSATION}:step:1`,
+				`agy:usage:${CENSUS_CONVERSATION}:step:3`,
+				`agy:usage:${CENSUS_CONVERSATION}:turn-after-step:3`,
+				`agy:usage:${CENSUS_CONVERSATION}:step:6`,
+				`agy:usage:${CENSUS_CONVERSATION}:turn-after-step:6`,
+			]);
+			// Both residuals land: under one key per unknown turn the second is dropped by `addUsage`.
+			const totals = usageTotals(usage.reduce(addUsage, emptyUsage));
+			expect(totals).toMatchObject({inputTokens: 16771 + 4648 + 100 + 4861 + 100, outputTokens: 3});
+		});
 	});
 
 	it("falls back to the bare binary name when init announced no model", () => {

--- a/apps/tuval/src/agy/ai-agent/wire.ts
+++ b/apps/tuval/src/agy/ai-agent/wire.ts
@@ -16,7 +16,9 @@
  *   `result.status` are typed open for the same reason.
  * - **Only the fields that route a line are required.** Every other field is optional and
  *   defaulted, because a line refused for a key this pin has not seen is content the operator
- *   never gets.
+ *   never gets. A default never aliases the unknown onto a real value a reader branches on, though:
+ *   `result.num_turns` is `number | null` and not `0`, because `0` is a turn number the usage fold
+ *   reads as a decision ([#8707](https://github.com/kamp-us/phoenix/issues/8707)).
  *
  * The envelope is nested and each payload is keyed by its own event name —
  * `{"event":"step_update","step_update":{…}}` — and `conversation_id` sits at the top level on
@@ -98,7 +100,13 @@ export interface AgyResult {
 	/** The turn's whole reply. The step deltas are lossy against this; this one is authoritative. */
 	readonly response: string;
 	readonly error?: string;
-	readonly num_turns: number;
+	/**
+	 * `null` when the line carried no `num_turns` — the unknown is kept distinct from the real value
+	 * `0`, because the mapper reads the turn number to decide whether a cumulative contains turns
+	 * this child never ran, and a missing field defaulted to a turn number picks that arm for it
+	 * ([#8707](https://github.com/kamp-us/phoenix/issues/8707)).
+	 */
+	readonly num_turns: number | null;
 	readonly usage?: AgyUsage;
 	/** Element shape unmeasured at this pin, so it stays `JsonValue` and is rendered, not parsed. */
 	readonly denied_actions?: ReadonlyArray<JsonValue>;
@@ -240,7 +248,7 @@ const readResult = (value: unknown): AgyResult | undefined => {
 		conversation_id: conversationId,
 		status,
 		response: text(source.response) ?? "",
-		num_turns: count(source.num_turns) ?? 0,
+		num_turns: count(source.num_turns) ?? null,
 		...optional("error", text(source.error)),
 		...optional("usage", readUsage(source.usage)),
 		...optional("denied_actions", denied),


### PR DESCRIPTION
`readResult` defaulted an absent `num_turns` to `0`, and the usage fold reads `num_turns <= 1` as
"this cumulative is this turn's own spend" — so a `result` that omitted the field charged the
operator for the whole conversation again. `AgyResult.num_turns` is now `number | null`: the unknown
is a value of its own, and `turnTokensOf` routes it to the steps-fallback arm, the same way the
terminal status beside it reads only `SUCCESS` as a success. A `result` that carries the field is
unchanged — a first turn still reports its cumulative whole, a resumed child still falls back.

The ledger key moves with it. `turnUsageKey` took `num_turns` alone, so every unknown turn keyed to
`agy:usage:<cid>:turn:0` and `addUsage`'s first-write-wins dropped all but the first. It now takes
the turn number when agy sent one, else the last `step_index` the turn carried — agy's other
per-conversation identity, as restore-stable as the turn number — and only a turn with neither falls
back to one shared key, which drops rather than over-charges. The carry gained `lastStepIndex` to
hold it.

Three mapper tests cover the absent field: a first turn, a resumed child graded against the numbered
one, and two unknown-`num_turns` turns whose residuals must land on two keys.

Fixes #8707

## Deviations

None.
