### PR TITLE
chore: The agy layer's sessionTranscript has no behaviour test, so its three-way store read is unproven

### DIFF
--- a/apps/tuval/src/agy/ai-agent/child-stub.ts
+++ b/apps/tuval/src/agy/ai-agent/child-stub.ts
@@ -56,11 +56,21 @@ export const agyChildStub = Effect.gen(function* () {
 	};
 });
 
-/** The layer under test over one stubbed child, with the platform services `make` asks for. */
-export const agyLayerOver = (child: {
-	readonly layer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
-}): Layer.Layer<TuvalAiAgent> =>
-	Layer.effect(TuvalAiAgent, aiAgentOverSpawner({binary: "agy", home: "/tuval/agy-home"})).pipe(
+/**
+ * The layer under test over one stubbed child, with the platform services `make` asks for.
+ *
+ * `home` defaults to a path nothing is written under, which is all a test of the event path needs.
+ * A test of the store reads — `sessionTranscript`, whose answers turn on what is on disk under the
+ * home — hands a disposable directory instead, because the default cannot be made to hold a
+ * conversation and the real `$HOME` must never be read.
+ */
+export const agyLayerOver = (
+	child: {
+		readonly layer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
+	},
+	home = "/tuval/agy-home",
+): Layer.Layer<TuvalAiAgent> =>
+	Layer.effect(TuvalAiAgent, aiAgentOverSpawner({binary: "agy", home})).pipe(
 		Layer.provide(child.layer),
 		Layer.provide(NodeFileSystem.layer),
 		Layer.provide(NodePath.layer),

--- a/apps/tuval/src/agy/ai-agent/session-transcript.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/session-transcript.unit.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `sessionTranscript`'s three-way store read, driven through the published `TuvalAiAgent` (#8686).
+ *
+ * The reader underneath is covered by `transcript.unit.test.ts`. What is proven here is the
+ * wrapper's own fork — its `exists` guard on the conversation directory, and its mapping of the
+ * reader's `PlanRefusal` onto `TranscriptError` — i.e. that the three reasons come back *distinct*
+ * at the port, and that an existing conversation with no log yet is a page rather than a missing
+ * session. Shaped after `../../codex/agent.unit.test.ts`'s own distinctness case.
+ *
+ * Every home below is a disposable temporary directory: the layer resolves `homedir()` when it is
+ * given none, and a test that read the invoking user's real store would assert about his machine.
+ */
+
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterAll, describe, expect, it} from "@effect/vitest";
+import {Effect} from "effect";
+import type {TranscriptQuery, TuvalAiAgentApi} from "../../ai-agent/service/index.ts";
+import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {agyChildStub, agyLayerOver} from "./child-stub.ts";
+import {conversationDir, TRANSCRIPT_FILE, transcriptLogDir} from "./transcript.ts";
+import * as fixtures from "./transcript-fixtures.ts";
+
+const CID = fixtures.conversationId;
+const CWD = "/tuval/agy-session-transcript";
+
+const query: TranscriptQuery = {sessionId: CID, cwd: CWD, before: null, limit: 10};
+
+const homes: Array<string> = [];
+
+const freshHome = (): string => {
+	const home = mkdtempSync(join(tmpdir(), "agy-session-transcript-"));
+	homes.push(home);
+	return home;
+};
+
+/** A store holding no conversation at all — the directory the id names is nowhere. */
+const storeWithout = freshHome;
+
+/** A store holding the conversation, with the log agy writes as the turns run or without it yet. */
+const storeHolding = (transcript?: string): string => {
+	const home = freshHome();
+	if (transcript === undefined) mkdirSync(conversationDir(home, CID), {recursive: true});
+	else {
+		mkdirSync(transcriptLogDir(home, CID), {recursive: true});
+		writeFileSync(join(transcriptLogDir(home, CID), TRANSCRIPT_FILE), transcript);
+	}
+	return home;
+};
+
+/**
+ * A store the read cannot be answered for. `$HOME/.gemini` is a regular *file*, so `access` on the
+ * conversation path below it fails `ENOTDIR` — the forcing constraint, because `FileSystem.exists`
+ * folds only `NotFound` to `false` and a merely absent path would take the missing-session arm
+ * instead (`effect/FileSystem.ts`'s `make`; `ENOTDIR` maps to `BadResource` in
+ * `@effect/platform-node-shared`'s `handleErrnoException`).
+ */
+const unreadableStore = (): string => {
+	const home = freshHome();
+	writeFileSync(join(home, ".gemini"), "not a directory");
+	return home;
+};
+
+const conversation = [
+	fixtures.userInput,
+	fixtures.toolCall,
+	fixtures.toolResult,
+	fixtures.assistantReply,
+].join("\n");
+
+const onAgy = <A, E>(home: string, body: (agent: TuvalAiAgentApi) => Effect.Effect<A, E>) =>
+	Effect.gen(function* () {
+		const child = yield* agyChildStub;
+		return yield* Effect.gen(function* () {
+			return yield* body(yield* TuvalAiAgent);
+		}).pipe(Effect.provide(agyLayerOver(child, home)), Effect.scoped);
+	});
+
+afterAll(() => {
+	for (const home of homes) rmSync(home, {recursive: true, force: true});
+});
+
+describe("the agy layer's stored-transcript read", () => {
+	it.effect("reads a conversation this store does not hold as a missing session", () =>
+		onAgy(storeWithout(), (agent) =>
+			Effect.gen(function* () {
+				expect(yield* Effect.flip(agent.sessionTranscript(query))).toMatchObject({
+					reason: "session-not-found",
+					sessionId: CID,
+				});
+			}),
+		),
+	);
+
+	it.effect(
+		"reads a store that will not answer as unreadable rather than as a missing session",
+		() =>
+			onAgy(unreadableStore(), (agent) =>
+				Effect.gen(function* () {
+					const failure = yield* Effect.flip(agent.sessionTranscript(query));
+					expect(failure).toMatchObject({reason: "store-unreadable", sessionId: CID});
+					expect(failure.detail).not.toBe("");
+				}),
+			),
+	);
+
+	it.effect("refuses a cursor no stored item carries, carrying the reader's own reason", () =>
+		onAgy(storeHolding(conversation), (agent) =>
+			Effect.gen(function* () {
+				expect(
+					yield* Effect.flip(agent.sessionTranscript({...query, before: "no-such-item"})),
+				).toMatchObject({
+					reason: "unknown-cursor",
+					sessionId: CID,
+					detail: "cursor-not-found",
+				});
+			}),
+		),
+	);
+
+	it.effect("serves an empty page for a held conversation agy has written no log for yet", () =>
+		onAgy(storeHolding(), (agent) =>
+			Effect.gen(function* () {
+				expect(yield* agent.sessionTranscript(query)).toEqual({items: [], hasMore: false});
+			}),
+		),
+	);
+
+	/**
+	 * The cross-arm claim the three reasons exist for: collapse any two of them in `AgyAiAgent.ts`
+	 * and this reds, where each case above would still pass on its own.
+	 */
+	it.effect("keeps the three refusals and an ordinary page distinct from one another", () =>
+		Effect.gen(function* () {
+			const reasons = [
+				yield* onAgy(storeWithout(), (agent) =>
+					Effect.map(Effect.flip(agent.sessionTranscript(query)), (failure) => failure.reason),
+				),
+				yield* onAgy(unreadableStore(), (agent) =>
+					Effect.map(Effect.flip(agent.sessionTranscript(query)), (failure) => failure.reason),
+				),
+				yield* onAgy(storeHolding(conversation), (agent) =>
+					Effect.map(
+						Effect.flip(agent.sessionTranscript({...query, before: "no-such-item"})),
+						(failure) => failure.reason,
+					),
+				),
+			];
+			expect(reasons).toEqual(["session-not-found", "store-unreadable", "unknown-cursor"]);
+			expect(new Set(reasons).size).toBe(3);
+			expect(
+				yield* onAgy(storeHolding(conversation), (agent) => agent.sessionTranscript(query)),
+			).toMatchObject({hasMore: false});
+		}),
+	);
+});


### PR DESCRIPTION
`sessionTranscript` on the agy layer forked three ways on the conversation directory with nothing
testing any of them. This adds a behaviour test that drives the member through the published
`TuvalAiAgent` and pins all four answers: a missing conversation (`session-not-found`), a store
whose read cannot be answered (`store-unreadable`), a `before` cursor no item carries
(`unknown-cursor`, with the reader's own `cursor-not-found` reaching `detail`), and a held
conversation with no log written yet, which is an ordinary empty page rather than a missing session.

The `store-unreadable` arm needs an `exists` that *fails* rather than answering `false`, so the test
makes `$HOME/.gemini` a regular file: `access` on the conversation path below it fails `ENOTDIR`,
which `@effect/platform-node-shared`'s `handleErrnoException` maps to `BadResource`, and
`effect/FileSystem`'s `make` folds only `NotFound` to `false`. The forcing constraint is named at
the site.

A fifth case asserts the three refusals distinct from one another in one place, mirroring
`apps/tuval/src/codex/agent.unit.test.ts`'s `"keeps missing, empty, unreadable and unknown-cursor
histories distinct"`. Verified by mutation: collapsing the `exists` failure onto
`transcriptSessionMissing` reds both the unreadable case and the distinctness case.

`agyLayerOver` gained an optional `home` so the layer can be pointed at a disposable temporary
directory — it hardcoded `/tuval/agy-home`, which no test can write a conversation under, and the
default (`homedir()`) would read the invoking user's real store.

Fixes #8686

## Deviations

- **Out-of-scope change** — **Said:** #8686 asks for a test under `apps/tuval/src/agy/ai-agent/`.
  **Did:** also widened `agyLayerOver` in `child-stub.ts` with an optional `home` parameter,
  defaulting to the previous constant. **Why:** the issue's own wiring note names this as one of the
  two sanctioned routes to a disposable `$HOME`; the three existing callers are unchanged.
  **Disposition:** stated here.
