### PR TITLE
feat: The process board is a fixed band over the desk; it should be a prefix-key overlay like tmux's window tree

### DIFF
--- a/apps/tuval/src/boot.ts
+++ b/apps/tuval/src/boot.ts
@@ -31,7 +31,7 @@ import {dispatchConfigChanged} from "./reload.ts";
 import type {ShellDispatch} from "./shell/commands/dispatch.ts";
 import {shellDispatchKernel, shellWindowIndexKernel} from "./shell/commands/kernel.ts";
 import type {PrefixTable} from "./shell/keys/index.ts";
-import {shellId, shellPrefixTable} from "./shell/program.ts";
+import {shellId, shellPrefixTable, withShellFeatures} from "./shell/program.ts";
 import type {ModuleRendererRef} from "./shell/window/index.ts";
 import {ProcessTablePort} from "./table/ProcessTablePort.ts";
 
@@ -240,7 +240,9 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 	const layers = {global: options.global, project: projectConfig(options.project)};
 	const config = yield* loadLayeredConfig(layers);
 	// Config rows are trusted local code (#7484 R1.1); the loader checks each row's id, not its shape.
-	const programs = config.programs as ReadonlyArray<AnyProgram>;
+	// The flags are applied once, here: a config module is evaluated before the merge exists (#8595),
+	// so this is the only place that holds both the rows and what the layers said about them (#8867).
+	const programs = withShellFeatures(config.programs as ReadonlyArray<AnyProgram>, config.features);
 	const stateDir = projectDir(options.project);
 	const started = yield* start({
 		programs,
@@ -272,7 +274,7 @@ export const boot = Effect.fn("Tuval.boot")(function* (options: BootOptions) {
 
 	const reload = Effect.fn("Tuval.reload")(function* () {
 		const next = yield* loadLayeredConfig(layers);
-		const rows = next.programs as ReadonlyArray<AnyProgram>;
+		const rows = withShellFeatures(next.programs as ReadonlyArray<AnyProgram>, next.features);
 		const set = yield* SpellSet;
 		yield* set.reload({core: coreSpells, programs: rows, keys: next.keys});
 		const notified = yield* dispatchConfigChanged(yield* Ref.getAndSet(generation, rows), rows);

--- a/apps/tuval/src/page/AttachedDesk.tsx
+++ b/apps/tuval/src/page/AttachedDesk.tsx
@@ -21,7 +21,7 @@ import type {ReactElement} from "react";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import type {ProcessId} from "../process/process.ts";
 import type {ProgramId} from "../registry/program.ts";
-import {ProcessBoard} from "../shell/board/index.ts";
+import {ProcessBoardOverlay} from "../shell/board/index.ts";
 import type {ShellMsg, ShellState} from "../shell/core/index.ts";
 import {openProcessMsg} from "../shell/core/machine.ts";
 import type {
@@ -63,9 +63,10 @@ export interface AttachedDeskProps {
 	readonly statuses?: Readonly<Record<string, AnyStatusRenderer>>;
 	readonly reducedMotion: boolean;
 	/**
-	 * Draw the process board over the desk — the page's half of `features.processBoard`
-	 * (`../features.ts`), off by default. Off, this component renders exactly the tree it rendered
-	 * before the flag existed: no board, and no wrapper around the desk (#8723).
+	 * The process board is reachable on this desk — the page's half of `features.processBoard`
+	 * (`../features.ts`), off by default. On, `<c-b> p` pulls it up as an overlay and the desk keeps
+	 * its full height until it does; off, this component renders exactly the tree it rendered before
+	 * the flag existed, and there is no command row or binding to reach it with either (#8867).
 	 */
 	readonly board?: boolean;
 	/**
@@ -370,6 +371,7 @@ export function AttachedDesk({
 		(processId: ProcessId) => dispatch(openProcessMsg(processId)),
 		[dispatch],
 	);
+	const closeBoard = useCallback(() => dispatch({type: "desk.board.close"}), [dispatch]);
 
 	// The half of a `DeskSnapshot` the shell state does not carry. Everything here is already on the
 	// page for the windows' sake; this is the same two frames read for the desk's own regions.
@@ -414,6 +416,7 @@ export function AttachedDesk({
 			call={page.call}
 			registry={spells}
 			commandsConnected={attachment.status === "attached" && refusal === null}
+			board={board}
 			windowTitles={windowTitles}
 		/>
 	);
@@ -421,17 +424,20 @@ export function AttachedDesk({
 	return (
 		<>
 			<ConnectionBanner status={attachment.status} reason={attachment.lastDrop} refusal={refusal} />
+			{deskElement}
+			{/* The overlay is a sibling of the desk, not a wrapper around it: it takes no height from
+			    the windows, and with the flag off it is not rendered at all — the tree the page had
+			    before the board existed. Its visibility is the shell's `desk.boardOpen`, read off the
+			    snapshot like every other desk-level fact (#8867). */}
 			{board ? (
-				// The desk is `block-size: 100%` of this column, so it is the item that gives the board
-				// its room back (`../shell/board/board.css`). Flag off, there is no wrapper at all and
-				// the page is the tree it was before the board existed.
-				<div className="tuval-surface tuval-board-page" data-scheme="dark">
-					<ProcessBoard rows={boardRows} onOpen={openProcess} reducedMotion={reducedMotion} />
-					{deskElement}
-				</div>
-			) : (
-				deskElement
-			)}
+				<ProcessBoardOverlay
+					open={desk.desk.boardOpen}
+					onClose={closeBoard}
+					rows={boardRows}
+					onOpen={openProcess}
+					reducedMotion={reducedMotion}
+				/>
+			) : null}
 		</>
 	);
 }

--- a/apps/tuval/src/page/attached-desk.unit.test.tsx
+++ b/apps/tuval/src/page/attached-desk.unit.test.tsx
@@ -634,6 +634,18 @@ describe("the process board flag", () => {
 
 			const dialog = screen.getByRole("dialog", {name: "Processes"});
 			assert.isNotNull(dialog.querySelector(`[data-process="${counterProcess}"]`));
+			// Modal and focused: the two halves of "announced and reachable". Both are the shared
+			// `Dialog`'s (`packages/design/src/Dialog.tsx` over Manti's zag machine), which is why they
+			// are asserted here rather than implemented anywhere in this app.
+			assert.strictEqual(dialog.getAttribute("aria-modal"), "true");
+			yield* Effect.tryPromise({
+				try: () =>
+					act(async () => {
+						await new Promise((resolve) => globalThis.setTimeout(resolve, 50));
+					}),
+				catch: (cause) => new TestIo({cause}),
+			}).pipe(Effect.orDie);
+			assert.isTrue(dialog.contains(document.activeElement));
 		}),
 	);
 

--- a/apps/tuval/src/page/attached-desk.unit.test.tsx
+++ b/apps/tuval/src/page/attached-desk.unit.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {act, render, screen} from "@testing-library/react";
+import {act, fireEvent, render, screen} from "@testing-library/react";
 import {Effect, Option, Schema, Stream, SubscriptionRef} from "effect";
 import {Socket} from "effect/unstable/socket";
 import {counterId} from "../demo/counter.ts";
@@ -66,7 +66,7 @@ const emptyDesk = (): ShellState => ({
 	order: ["workspace-0"],
 	activeWorkspace: "workspace-0",
 	views: {},
-	desk: {inspectorOpen: false},
+	desk: {inspectorOpen: false, boardOpen: false},
 	prefix: {armed: false},
 	nextId: 2,
 });
@@ -88,10 +88,16 @@ const twoWindowDesk = (): ShellState => ({
 	order: ["workspace-0"],
 	activeWorkspace: "workspace-0",
 	views: {},
-	desk: {inspectorOpen: false},
+	desk: {inspectorOpen: false, boardOpen: false},
 	prefix: {armed: false},
 	nextId: 3,
 });
+
+/** A desk whose board the chord has already pulled up. */
+const boardOpenDesk = (): ShellState => {
+	const state = twoWindowDesk();
+	return {...state, desk: {...state.desk, boardOpen: true}};
+};
 
 const counterRow: TableRow = {
 	id: counterProcess,
@@ -565,13 +571,14 @@ describe("the desk across a dropped socket", () => {
 });
 
 /**
- * The board's containment (#8723). Flag off, this component renders the tree it rendered before the
- * board existed — no board and no wrapper — which is the acceptance criterion the flag exists for.
+ * The board's containment (#8723) and its overlay (#8867). Flag off, this component renders the
+ * tree it rendered before the board existed — no board and no wrapper. Flag on, the desk keeps its
+ * whole height until `desk.boardOpen` says otherwise, and every dismissal goes back as a Msg.
  */
 describe("the process board flag", () => {
 	it.effect("draws no board and no wrapper when the flag is off", () =>
 		Effect.gen(function* () {
-			const app = yield* scripted();
+			const app = yield* scripted({state: boardOpenDesk()});
 			render(
 				<AttachedDesk
 					page={app.page}
@@ -584,14 +591,55 @@ describe("the process board flag", () => {
 			yield* settle;
 
 			assert.isNull(document.querySelector(".tuval-board"));
-			assert.isNull(document.querySelector(".tuval-board-page"));
+			assert.isNull(document.querySelector(".tuval-board-overlay"));
 			assert.lengthOf(screen.getAllByRole("region", {name: /^Window /}), 2);
 		}),
 	);
 
-	it.effect("draws a tile per row on, and opens that process in its own window", () =>
+	it.effect("draws no board on first paint with the flag on: the desk keeps its height", () =>
 		Effect.gen(function* () {
 			const app = yield* scripted();
+			render(
+				<AttachedDesk
+					page={app.page}
+					shell={app.shell}
+					renderers={renderers}
+					reducedMotion={true}
+					board={true}
+					refusal={null}
+				/>,
+			);
+			yield* settle;
+
+			assert.isNull(document.querySelector(".tuval-board"));
+			assert.isNull(screen.queryByRole("dialog", {name: "Processes"}));
+			assert.lengthOf(screen.getAllByRole("region", {name: /^Window /}), 2);
+		}),
+	);
+
+	it.effect("pulls the board up as a named dialog when the shell says it is open", () =>
+		Effect.gen(function* () {
+			const app = yield* scripted({state: boardOpenDesk()});
+			render(
+				<AttachedDesk
+					page={app.page}
+					shell={app.shell}
+					renderers={renderers}
+					reducedMotion={true}
+					board={true}
+					refusal={null}
+				/>,
+			);
+			yield* settle;
+
+			const dialog = screen.getByRole("dialog", {name: "Processes"});
+			assert.isNotNull(dialog.querySelector(`[data-process="${counterProcess}"]`));
+		}),
+	);
+
+	it.effect("opens the tile's process in a window and closes the board behind it", () =>
+		Effect.gen(function* () {
+			const app = yield* scripted({state: boardOpenDesk()});
 			render(
 				<AttachedDesk
 					page={app.page}
@@ -609,7 +657,44 @@ describe("the process board flag", () => {
 			yield* Effect.sync(() => act(() => (tile as HTMLElement).click()));
 			yield* settle;
 
-			assert.deepStrictEqual(app.sent, [openProcessMsg(counterProcess)]);
+			assert.deepStrictEqual(app.sent, [
+				openProcessMsg(counterProcess),
+				{type: "desk.board.close"},
+			]);
+		}),
+	);
+
+	it.effect("closes on Escape from inside the overlay", () =>
+		Effect.gen(function* () {
+			const app = yield* scripted({state: boardOpenDesk()});
+			render(
+				<AttachedDesk
+					page={app.page}
+					shell={app.shell}
+					renderers={renderers}
+					reducedMotion={true}
+					board={true}
+					refusal={null}
+				/>,
+			);
+			yield* settle;
+
+			const dialog = screen.getByRole("dialog", {name: "Processes"});
+			yield* Effect.sync(() =>
+				act(() => {
+					fireEvent.keyDown(dialog, {key: "Escape"});
+				}),
+			);
+			yield* settle;
+
+			// The desk's one document-level listener hears the same Escape and sends it on as any other
+			// key, which is what keeps `<c-b> p` working from inside the overlay. It is inert: Escape is
+			// unbound in the grammar, and `../shell/ui/Desk.tsx` forwards nothing to a window while the
+			// board is open.
+			assert.deepStrictEqual(
+				app.sent.filter((msg) => msg.type !== "keys.press"),
+				[{type: "desk.board.close"}],
+			);
 		}),
 	);
 });

--- a/apps/tuval/src/shell/board/ProcessBoard.tsx
+++ b/apps/tuval/src/shell/board/ProcessBoard.tsx
@@ -9,6 +9,9 @@
  *
  * Every tile is a button, so the keyboard reaches what the mouse does through the one handler the
  * mouse calls. The board is not the engine view (#7500), which stays out of this slice.
+ *
+ * It draws no heading: the surface that mounts it names it, which today is the overlay's dialog
+ * title (`./ProcessBoardOverlay.tsx`, #8867).
  */
 
 import {Card, EmptyState, MetaRow} from "@kampus/design";
@@ -119,7 +122,6 @@ export function ProcessBoard({rows, onOpen, reducedMotion}: ProcessBoardProps): 
 
 	return (
 		<section className="tuval-board" aria-label="Processes">
-			<h2 className="tuval-board-heading">Processes</h2>
 			{tiles.length === 0 ? (
 				<EmptyState
 					className="tuval-board-empty"

--- a/apps/tuval/src/shell/board/ProcessBoardOverlay.tsx
+++ b/apps/tuval/src/shell/board/ProcessBoardOverlay.tsx
@@ -1,0 +1,60 @@
+/**
+ * The process board as tmux pulls its tree picker up: hidden by default, over the desk while it is
+ * open, gone again on the same chord or on Escape (#8867). The band this replaced cost the windows
+ * about a third of the page height on every desk, open or not.
+ *
+ * **The dialog is `@kampus/design`'s, not a local overlay.** The focus trap, the return of focus to
+ * whatever held it, Escape, the backdrop and the `aria-modal` announcement are all the shared
+ * component's — `packages/design/src/Dialog.tsx` over Manti's zag dialog machine — which is the same
+ * reason the palette does not roll its own (ADR 0186). The title is the dialog's, so `ProcessBoard`
+ * draws no heading of its own: two "Processes" headings is what a second implementation looks like.
+ *
+ * **Visibility is not held here.** `open` comes off the shell snapshot and every dismissal goes back
+ * as a Msg, because the board is one desk-level surface and the page holds no desk state (#7556).
+ */
+
+import {Dialog} from "@kampus/design";
+import type {ReactElement} from "react";
+import type {ProcessId} from "../../process/process.ts";
+import type {TableRow} from "../../table/row.ts";
+import {ProcessBoard} from "./ProcessBoard.tsx";
+
+export interface ProcessBoardOverlayProps {
+	readonly open: boolean;
+	/** The board is gone: Escape, a click outside, the chord again, or a tile that opened a window. */
+	readonly onClose: () => void;
+	readonly rows: Iterable<TableRow>;
+	readonly onOpen: (processId: ProcessId) => void;
+	readonly reducedMotion: boolean;
+}
+
+export function ProcessBoardOverlay({
+	open,
+	onClose,
+	rows,
+	onOpen,
+	reducedMotion,
+}: ProcessBoardOverlayProps): ReactElement {
+	return (
+		<Dialog
+			title="Processes"
+			open={open}
+			onOpenChange={(next) => {
+				if (!next) onClose();
+			}}
+			// The desk's own chrome carries no close button either; the chord and Escape are the door.
+			showCloseButton={false}
+			size="lg"
+			className="tuval-board-overlay"
+		>
+			<ProcessBoard
+				rows={rows}
+				onOpen={(processId) => {
+					onOpen(processId);
+					onClose();
+				}}
+				reducedMotion={reducedMotion}
+			/>
+		</Dialog>
+	);
+}

--- a/apps/tuval/src/shell/board/board-focus-ring.unit.test.tsx
+++ b/apps/tuval/src/shell/board/board-focus-ring.unit.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The board overlay's focus ring, proven by inheritance rather than by selector text (#8867).
+ *
+ * `Dialog` mounts through a zag `Portal` into `document.body`, so the overlay is a sibling of the
+ * desk's `.tuval-surface` root and inherits nothing from it. While the ring tokens were declared on
+ * that root, `outline: var(--focus-ring)` inside the overlay resolved against an undefined custom
+ * property — invalid at computed-value time, which unsets `outline` in the author origin and beats
+ * the UA's own `:focus-visible` ring. A keyboard operator tabbing the tiles saw nothing, and every
+ * assertion in the tree passed, because each of them read the rule's text.
+ *
+ * jsdom resolves no `var()`, so the two halves of the sheet are read off disk and put to the live
+ * tree instead: the rule that paints the ring has to match the focused tile, and that tile has to
+ * have a self-or-ancestor matching the rule that declares the tokens the paint spends. A ring
+ * painted out of a root the element cannot reach fails the second half — which is the exact defect,
+ * and the one thing a selector-text assertion cannot see.
+ */
+
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {render, screen} from "@testing-library/react";
+import {Option} from "effect";
+import {describe, expect, it} from "vitest";
+import {ProcessId} from "../../process/process.ts";
+import {ProgramId} from "../../registry/program.ts";
+import type {TableRow} from "../../table/row.ts";
+import {installDomShims} from "../ui/dom.testing.ts";
+import {ProcessBoardOverlay} from "./ProcessBoardOverlay.tsx";
+
+installDomShims();
+
+/** The desk's sheet with its comments stripped: a comment naming a rule is not a rule. */
+const deskSheet = (): string =>
+	readFileSync(fileURLToPath(import.meta.resolve("../ui/tokens.css")), "utf8").replace(
+		/\/\*[\s\S]*?\*\//g,
+		"",
+	);
+
+/** The selector list of every rule in the desk's sheet whose declarations match `declaration`. */
+const selectorsDeclaring = (declaration: RegExp): ReadonlyArray<string> =>
+	deskSheet()
+		.split("}")
+		.flatMap((block) => {
+			const [selector, declarations] = block.split("{");
+			if (selector === undefined || declarations === undefined) return [];
+			return declaration.test(declarations) ? [selector.trim()] : [];
+		});
+
+/** Where the ring tokens are declared, and where the ring is painted from them. */
+const ringDeclarers = (): ReadonlyArray<string> => selectorsDeclaring(/--focus-ring\s*:/);
+const ringPainters = (): ReadonlyArray<string> =>
+	selectorsDeclaring(/outline\s*:\s*var\(--focus-ring\)/);
+
+const row = (id: string): TableRow => ({
+	id: ProcessId.make(id),
+	programId: ProgramId.make("demo/counter"),
+	parentId: Option.none(),
+	ports: {},
+	stateSummary: {lifecycle: "running", revision: 1},
+	title: Option.none(),
+	status: Option.none(),
+});
+
+/** The overlay as the page mounts it: open, inside a desk root the portal will leave behind. */
+const openOverlay = () => {
+	const rendered = render(
+		<div className="tuval-surface">
+			<ProcessBoardOverlay
+				open
+				onClose={() => undefined}
+				rows={[row("counter")]}
+				onOpen={() => undefined}
+				reducedMotion
+			/>
+		</div>,
+	);
+	const opener = document.querySelector<HTMLElement>('[data-process="counter"] .tuval-board-open');
+	if (opener === null) throw new Error("the overlay drew no tile to focus");
+	return {opener, unmount: () => rendered.unmount()};
+};
+
+describe("the board overlay's focus ring", () => {
+	it("is painted out of a root the portaled overlay can inherit from", async () => {
+		const opened = openOverlay();
+		await screen.findByRole("dialog", {name: "Processes"});
+
+		opened.opener.focus();
+
+		// The rule reaches the tile...
+		expect([...document.querySelectorAll(ringPainters().join(","))]).toContain(opened.opener);
+		// ...and the tokens it spends are declared somewhere the tile inherits from. Both halves, or
+		// the outline computes to its initial value and takes the UA's ring down with it.
+		expect(opened.opener.closest(ringDeclarers().join(","))).not.toBeNull();
+		opened.unmount();
+	});
+
+	it("leaves the overlay outside every `.tuval-surface` root, which is why the first case matters", async () => {
+		const opened = openOverlay();
+		const dialog = await screen.findByRole("dialog", {name: "Processes"});
+
+		expect(dialog.closest(".tuval-surface")).toBeNull();
+		expect(opened.opener.closest(".tuval-surface")).toBeNull();
+		opened.unmount();
+	});
+});

--- a/apps/tuval/src/shell/board/board.css
+++ b/apps/tuval/src/shell/board/board.css
@@ -1,31 +1,16 @@
 /*
  * The process board's paint. Every colour, size and radius is a role token from
  * `../ui/tokens.css` — nothing here reaches under the role layer (`design-system-manifest.md`,
- * Pillar 2). The tile's box, border and radius are `@kampus/design`'s `Card`; what is left here is
- * the board's own layout, the row control inside each tile, and the one entry animation.
+ * Pillar 2). The tile's box, border and radius are `@kampus/design`'s `Card`, and the overlay's
+ * panel, backdrop and title are its `Dialog`; what is left here is the board's own layout, the row
+ * control inside each tile, the one entry animation, and the overlay's width.
  */
 
 .tuval-board {
-	flex: 0 0 auto;
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-2);
-	/* Bounded, and scrolling past the bound: the desk under it is the work, and a board that grew
-	   with the process count would push the windows off the page on a busy desk. */
-	max-block-size: 40vh;
-	overflow: auto;
-	padding: var(--s-3);
-	border-block-end: 1px solid var(--border);
-	background: var(--surface-sunken);
-}
-
-.tuval-board-heading {
-	margin: 0;
-	font: var(--t-meta);
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-	color: var(--text-muted);
+	min-block-size: 0;
 }
 
 /* Tiles, not rows: the roots lay out across the width and each takes the height its children need. */
@@ -133,9 +118,9 @@
 }
 
 /*
- * `EmptyState`'s own block is sized for a page region — a 30vh centred well — and this board is a
- * bounded band above the desk. The paired class carries only that divergence, which is the
- * primitive's documented way to keep a surface's own tuning (`packages/design/src/MetaRow.css`).
+ * `EmptyState`'s own block is sized for a page region — a 30vh centred well — and this board is the
+ * body of a dialog. The paired class carries only that divergence, which is the primitive's
+ * documented way to keep a surface's own tuning (`packages/design/src/MetaRow.css`).
  */
 .tuval-board-empty {
 	min-block-size: 0;
@@ -143,15 +128,17 @@
 }
 
 /*
- * The page when the board is on: a column of board over desk. The desk is `block-size: 100%` of
- * this column (`../ui/tokens.css`), so it is the item that gives the board its room back, and
- * `min-block-size: 0` is what lets it shrink past its own content.
+ * The overlay, as tmux's tree picker is: wide enough for two columns of tiles and never wider than
+ * the viewport, scrolling past its own bound rather than growing with the process count. Everything
+ * else about the panel — the backdrop, the radius, the shadow, the title — is `Dialog`'s
+ * (`packages/design/src/Dialog.css`), and this file overrides only the width the same way the
+ * palette does (`../../palette/palette.css`).
  */
-.tuval-board-page {
-	min-block-size: 0;
+[data-scope="dialog"][data-part="content"].tuval-board-overlay {
+	--manti-dialog-max-width: min(64rem, 92vw);
 }
 
-.tuval-board-page > .tuval-surface {
-	flex: 1 1 auto;
-	min-block-size: 0;
+.tuval-board-overlay .tuval-board-tiles {
+	max-block-size: min(60vh, 40rem);
+	overflow: auto;
 }

--- a/apps/tuval/src/shell/board/board.css
+++ b/apps/tuval/src/shell/board/board.css
@@ -138,7 +138,13 @@
 	--manti-dialog-max-width: min(64rem, 92vw);
 }
 
+/* The block padding is the focus ring's room, not rhythm. The desk paints the ring 2px outside a
+   focused control (`--focus-ring-offset`, `../ui/tokens.css`), the first grid row sits flush against
+   this box's content edge, and `overflow: auto` clips whatever passes it — so without the inset a
+   keyboard operator on a first-row tile sees three sides of a rectangle (#8867). `--s-1` covers the
+   offset plus the ring's own width at every density. */
 .tuval-board-overlay .tuval-board-tiles {
 	max-block-size: min(60vh, 40rem);
 	overflow: auto;
+	padding-block: var(--s-1);
 }

--- a/apps/tuval/src/shell/board/index.ts
+++ b/apps/tuval/src/shell/board/index.ts
@@ -4,4 +4,8 @@
  */
 
 export {ProcessBoard, type ProcessBoardProps} from "./ProcessBoard.tsx";
+export {
+	ProcessBoardOverlay,
+	type ProcessBoardOverlayProps,
+} from "./ProcessBoardOverlay.tsx";
 export {enteredSince, type Tile, tileIds, tilesOf} from "./tiles.ts";

--- a/apps/tuval/src/shell/board/proof/main.tsx
+++ b/apps/tuval/src/shell/board/proof/main.tsx
@@ -9,6 +9,9 @@
  * The rows are a still life on purpose: a board that spawned a process on a timer would capture
  * differently on every run. What the entry animation does is the unit tier's
  * (`../process-board.unit.test.tsx`).
+ *
+ * The overlay is pinned open, because that is the only state worth capturing: closed, this surface
+ * is the desk and nothing else, which is the whole point of #8867.
  */
 
 import {Option} from "effect";
@@ -17,7 +20,7 @@ import {createRoot} from "react-dom/client";
 import {ProcessId} from "../../../process/process.ts";
 import {ProgramId} from "../../../registry/program.ts";
 import type {PortDeclaration, TableRow} from "../../../table/row.ts";
-import {ProcessBoard} from "../ProcessBoard.tsx";
+import {ProcessBoardOverlay} from "../ProcessBoardOverlay.tsx";
 import "../../../page/styles.ts";
 import "./proof.css";
 
@@ -72,18 +75,20 @@ if (host === null) throw new Error("the proof page has no #proof element");
 
 createRoot(host).render(
 	<StrictMode>
-		<div className="tuval-surface tuval-board-page" data-scheme="dark">
-			<ProcessBoard
-				rows={rows}
-				onOpen={(processId) => {
-					globalThis.console.log(`open ${processId}`);
-				}}
-				reducedMotion={false}
-			/>
-			{/* The desk's seat, so the board is captured at the height it actually gets. */}
-			<div className="tuval-surface proof-desk">
-				<p className="proof-desk-note">The desk sits here.</p>
-			</div>
+		{/* The desk's seat, so the overlay is captured over the surface it actually covers. */}
+		<div className="tuval-surface proof-desk" data-scheme="dark">
+			<p className="proof-desk-note">The desk sits here, at its full height.</p>
 		</div>
+		<ProcessBoardOverlay
+			open={true}
+			onClose={() => {
+				globalThis.console.log("close");
+			}}
+			rows={rows}
+			onOpen={(processId) => {
+				globalThis.console.log(`open ${processId}`);
+			}}
+			reducedMotion={false}
+		/>
 	</StrictMode>,
 );

--- a/apps/tuval/src/shell/board/proof/proof.css
+++ b/apps/tuval/src/shell/board/proof/proof.css
@@ -14,10 +14,9 @@ body {
 	block-size: 100%;
 }
 
-/* The desk's seat: the flex child that gives the board its room back on the real page. */
+/* The desk's seat: the whole page, which is what the desk gets now that the board is an overlay. */
 .proof-desk {
-	flex: 1 1 auto;
-	min-block-size: 0;
+	block-size: 100%;
 	align-items: center;
 	justify-content: center;
 }

--- a/apps/tuval/src/shell/chat/composer-focus-ring.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/composer-focus-ring.unit.test.tsx
@@ -38,8 +38,13 @@ import {initialChatView} from "./view.ts";
 
 installDomShims();
 
-/** The gated rule the desk paints its one ring with. Read back off the sheet by the first case. */
-const RING_SELECTOR = '.tuval-surface:not([data-input-modality="pointer"]) :focus-visible';
+/**
+ * The one rule the desk paints its ring with, read back off the sheet by the first case. The board's
+ * overlay is named beside the surface because a `Dialog` portals out of every `.tuval-surface` root
+ * (#8867); it is still one rule, which is the law this file holds.
+ */
+const RING_SELECTOR =
+	'.tuval-board-overlay :focus-visible,\n.tuval-surface:not([data-input-modality="pointer"]) :focus-visible';
 
 const deskSheet = (): string =>
 	readFileSync(fileURLToPath(import.meta.resolve("../ui/tokens.css")), "utf8");
@@ -106,12 +111,14 @@ const modalityOf = (root: HTMLElement): string | null =>
 
 /** Does the desk's one ring rule reach this element as the desk currently stands? */
 const wearsTheRing = (element: Element): boolean =>
+	// The rule's own selector list, newlines and all, is what `querySelectorAll` is handed — so this
+	// asks the exact question the sheet answers rather than a re-spelling of it.
 	[...document.querySelectorAll(RING_SELECTOR)].includes(element);
 
 describe("the composer's focus ring", () => {
 	it("is the desk's one rule, gated on the modality the desk publishes", () => {
 		expect(deskSheet()).toMatch(
-			/\.tuval-surface:not\(\[data-input-modality="pointer"\]\) :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
+			/\.tuval-board-overlay :focus-visible,\s*\.tuval-surface:not\(\[data-input-modality="pointer"\]\) :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
 		);
 		// One rule and no second: a component sheet under `apps/tuval/src` that painted its own ring
 		// would be the per-component outline Pillar 4 forbids, and the gate would not reach it.

--- a/apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-focus-ring.unit.test.tsx
@@ -80,7 +80,7 @@ describe("the subagent rows' focus ring", () => {
 
 	it("is the desk's one rule, declared off the ring tokens", () => {
 		expect(deskSheet()).toMatch(
-			/\.tuval-surface:not\(\[data-input-modality="pointer"\]\) :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
+			/\.tuval-board-overlay :focus-visible,\s*\.tuval-surface:not\(\[data-input-modality="pointer"\]\) :focus-visible \{[^}]*outline: var\(--focus-ring\);[^}]*outline-offset: var\(--focus-ring-offset\);/s,
 		);
 	});
 

--- a/apps/tuval/src/shell/commands/bindings.unit.test.ts
+++ b/apps/tuval/src/shell/commands/bindings.unit.test.ts
@@ -5,8 +5,8 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {applyKeysConfig, CommandName, defaultPrefixTable} from "../keys/index.ts";
-import {commandFor} from "./table.ts";
+import {applyKeysConfig, CommandName, defaultPrefixTable, prefixTableFor} from "../keys/index.ts";
+import {commandFor, commandIndexFor} from "./table.ts";
 
 /** Every command name a table binds, in table order. */
 const boundNames = (table: typeof defaultPrefixTable): ReadonlyArray<string> =>
@@ -31,6 +31,39 @@ describe("the default prefix table against the command table", () => {
 			return row !== undefined && Object.keys(row.params.fields).length > 0;
 		});
 		expect(needsArgument).toEqual([]);
+	});
+});
+
+/**
+ * The feature-gated half (#8867). A gated binding and its row are two lists keyed on one flag, so
+ * the pair either both exist or neither does — a gate applied to one and not the other is a key
+ * that names nothing, which is exactly what this file exists to catch.
+ */
+describe("a feature-gated binding against its own gated table", () => {
+	const on = {processBoard: true};
+	const off = {processBoard: false};
+
+	it("adds the board chord and its row together when the flag is on", () => {
+		const table = prefixTableFor(defaultPrefixTable, on);
+		const index = commandIndexFor(on);
+		expect(boundNames(table)).toContain("desk:board-toggle");
+		expect(index.commandFor("desk:board-toggle")).toBeDefined();
+		expect(boundNames(table).filter((name) => index.commandFor(name) === undefined)).toEqual([]);
+	});
+
+	it("has neither the chord nor the row when the flag is off", () => {
+		const table = prefixTableFor(defaultPrefixTable, off);
+		expect(table).toEqual(defaultPrefixTable);
+		expect(boundNames(table)).not.toContain("desk:board-toggle");
+		expect(commandIndexFor(off).commandFor("desk:board-toggle")).toBeUndefined();
+	});
+
+	it("binds a sequence the ungated table leaves free", () => {
+		const added = prefixTableFor(defaultPrefixTable, on).bindings.filter(
+			(binding) => !defaultPrefixTable.bindings.includes(binding),
+		);
+		expect(added.map((binding) => binding.sequence)).toEqual(["p"]);
+		expect(defaultPrefixTable.bindings.map((binding) => binding.sequence)).not.toContain("p");
 	});
 });
 

--- a/apps/tuval/src/shell/commands/index.ts
+++ b/apps/tuval/src/shell/commands/index.ts
@@ -20,12 +20,18 @@ export {
 	parameterNames,
 	type ShellCommand,
 } from "./row.ts";
-export {CommandDispatched, shellSpells} from "./spells.ts";
+export {CommandDispatched, shellSpells, shellSpellsFor} from "./spells.ts";
 export {
+	type CommandIndex,
 	commandFor,
+	commandIndexFor,
 	commandNames,
 	msgForCommandName,
+	noShellCommandFeatures,
 	resolveVerb,
+	type ShellCommandFeatures,
+	shellCommandIndex,
 	shellCommands,
+	shellCommandsFor,
 	verbSpellings,
 } from "./table.ts";

--- a/apps/tuval/src/shell/commands/line.ts
+++ b/apps/tuval/src/shell/commands/line.ts
@@ -18,13 +18,22 @@ import {
 	unknownCommand,
 } from "./errors.ts";
 import {type AnyShellCommand, commandName, isOptionalParameter, parameterNames} from "./row.ts";
-import {resolveVerb, verbSpellings} from "./table.ts";
+import {type CommandIndex, shellCommandIndex} from "./table.ts";
 
 export type CommandLineResult =
 	| {readonly _tag: "Msg"; readonly command: AnyShellCommand; readonly msg: ShellMsg}
 	| {readonly _tag: "Refused"; readonly refusal: CommandRefusal};
 
-export interface RegisteredLineOptions {
+export interface CommandLineOptions {
+	/**
+	 * The rows this line may name. Absent is the ungated table, which is what a caller that has
+	 * resolved no feature flags is entitled to — a surface that has them passes `commandIndexFor`'s
+	 * answer, so a flag-gated row is unreadable here exactly when it is unbindable (#8867).
+	 */
+	readonly commands?: CommandIndex | undefined;
+}
+
+export interface RegisteredLineOptions extends CommandLineOptions {
 	readonly registry: SpellIndex;
 	readonly snapshot: Snapshot;
 	readonly id: CallId;
@@ -41,32 +50,34 @@ const refused = (refusal: CommandRefusal): CommandLineResult => ({_tag: "Refused
  * Read one line. A verb resolves by its full name (`window:open`) or by its last segment when no
  * other row claims that segment (`open`), which is what makes `prefix :open counter` read.
  */
-export function readCommandLine(input: string): CommandLineResult;
+export function readCommandLine(input: string, options?: CommandLineOptions): CommandLineResult;
 export function readCommandLine(
 	input: string,
 	options: RegisteredLineOptions,
 ): RegisteredLineResult;
 export function readCommandLine(
 	input: string,
-	options?: RegisteredLineOptions,
+	options?: CommandLineOptions | RegisteredLineOptions,
 ): RegisteredLineResult {
+	const registered = options !== undefined && "registry" in options ? options : undefined;
+	const table = options?.commands ?? shellCommandIndex;
 	const {tokens} = tokenize(input);
 	const [verb, ...args] = tokens;
 	if (verb === undefined) return refused(emptyCommandLine(input.length));
 
-	const command = resolveVerb(verb.text);
+	const command = table.resolveVerb(verb.text);
 	if (command === undefined) {
-		if (options !== undefined) {
-			const parsed = parse(input, options.registry, options.snapshot);
+		if (registered !== undefined) {
+			const parsed = parse(input, registered.registry, registered.snapshot);
 			if (parsed._tag === "Complete")
 				return {
 					_tag: "Spell",
 					call: new SpellCall({
 						type: "spell.call",
 						version: PROTOCOL_VERSION,
-						id: options.id,
+						id: registered.id,
 						...parsed.call,
-						...(options.window === undefined ? {} : {window: options.window}),
+						...(registered.window === undefined ? {} : {window: registered.window}),
 					}),
 				};
 			return refused(
@@ -87,7 +98,9 @@ export function readCommandLine(
 						},
 			);
 		}
-		return refused(unknownCommand(verb.text, verb.start, didYouMean(verb.text, verbSpellings)));
+		return refused(
+			unknownCommand(verb.text, verb.start, didYouMean(verb.text, table.verbSpellings)),
+		);
 	}
 
 	const name = String(commandName(command.path));

--- a/apps/tuval/src/shell/commands/spells.ts
+++ b/apps/tuval/src/shell/commands/spells.ts
@@ -13,7 +13,7 @@ import {Effect, Schema} from "effect";
 import {type AnySpell, defineSpell} from "../../commands/spell.ts";
 import {ShellDispatch} from "./dispatch.ts";
 import type {AnyShellCommand} from "./row.ts";
-import {shellCommands} from "./table.ts";
+import {type ShellCommandFeatures, shellCommands, shellCommandsFor} from "./table.ts";
 
 /**
  * What a run answers with: the Msg type it dispatched. A caller cannot read the desk from a reply —
@@ -36,5 +36,13 @@ const toSpell = (command: AnyShellCommand): AnySpell =>
 		capabilities: [],
 	});
 
-/** Every command row as a spell, in table order. `shellProgram` declares this as its `spells`. */
+/** Every ungated command row as a spell, in table order. `shellProgram` declares this as its `spells`. */
 export const shellSpells: ReadonlyArray<AnySpell> = shellCommands.map(toSpell);
+
+/**
+ * The same, over the rows these flags leave standing. A gated row that is off is not registered at
+ * all, so `help`, `spell describe` and the palette answer about it exactly as they answer about a
+ * row nobody wrote (#8867).
+ */
+export const shellSpellsFor = (features: ShellCommandFeatures): ReadonlyArray<AnySpell> =>
+	shellCommandsFor(features).map(toSpell);

--- a/apps/tuval/src/shell/commands/table.ts
+++ b/apps/tuval/src/shell/commands/table.ts
@@ -84,8 +84,9 @@ const pickerRow = (command: PickerCommand): AnyShellCommand => {
 };
 
 /**
- * The whole table. Every name the default prefix table binds is here — `bindings.unit.test.ts`
- * fails on a binding that names a row this list does not hold.
+ * The rows every desk holds. Every name the default prefix table binds is here —
+ * `bindings.unit.test.ts` fails on a binding that names a row this list does not hold — and the
+ * rows a feature flag adds are declared below it rather than in a second table.
  */
 export const shellCommands: ReadonlyArray<AnyShellCommand> = [
 	defineCommand({
@@ -189,66 +190,119 @@ export const shellCommands: ReadonlyArray<AnyShellCommand> = [
 	}),
 ];
 
-const byName = new Map(
-	shellCommands.map((command) => [String(commandName(command.path)), command] as const),
-);
+/**
+ * The rows a feature flag adds, one list per flag. A gated row is declared here and nowhere else,
+ * so the flag decides whether the row exists at all rather than whether it does anything: with
+ * `processBoard` off there is no `desk:board-toggle` to bind, to type or to publish as a spell, and
+ * the desk is the one it was before the board existed (#8867).
+ */
+const boardCommands: ReadonlyArray<AnyShellCommand> = [
+	defineCommand({
+		path: ["desk", "board-toggle"],
+		describe: "Show or hide the process board over the desk.",
+		params: noParams,
+		toMsg: () => ({type: "desk.board.toggle"}),
+	}),
+];
 
-/** Every row's name, in table order — what a completion surface and the dangling-binding test read. */
-export const commandNames: ReadonlyArray<CommandName> = shellCommands.map((command) =>
-	commandName(command.path),
-);
+/** The flags a command row can be gated on — the shell's own read of `../../features.ts`. */
+export interface ShellCommandFeatures {
+	readonly processBoard: boolean;
+}
 
-/** The row a name addresses, or nothing. The name is the full colon form, `window:close`. */
-export const commandFor = (name: CommandName | string): AnyShellCommand | undefined =>
-	byName.get(String(name));
+/** Every flag off: the table a caller that has resolved no flags is entitled to. */
+export const noShellCommandFeatures: ShellCommandFeatures = {processBoard: false};
+
+/** The rows this desk holds: the ungated table, plus whatever each flag turned on. */
+export const shellCommandsFor = (features: ShellCommandFeatures): ReadonlyArray<AnyShellCommand> =>
+	features.processBoard ? [...shellCommands, ...boardCommands] : shellCommands;
 
 /**
- * The last segment of each row's name, when exactly one row claims it. A segment two rows share is
- * left out rather than resolved to whichever was declared first — `open` is claimed by both
- * `window:open` and `command:open`, and guessing between them would be a silent wrong window.
+ * One table's lookups. Built per row set rather than once per module because the set is now a
+ * function of the flags: a surface reading a name against the ungated table while the kernel routes
+ * over the gated one is exactly the disagreement the single declaration above exists to prevent.
  */
-const byBareVerb = ((): ReadonlyMap<string, AnyShellCommand> => {
+export interface CommandIndex {
+	readonly commands: ReadonlyArray<AnyShellCommand>;
+	/** Every row's name, in table order — what a completion surface and the dangling-binding test read. */
+	readonly commandNames: ReadonlyArray<CommandName>;
+	/** The row a name addresses, or nothing. The name is the full colon form, `window:close`. */
+	readonly commandFor: (name: CommandName | string) => AnyShellCommand | undefined;
+	/**
+	 * A verb as typed: the full name, else the `window:` row of that name, else the last segment when
+	 * exactly one row claims it. The `window:` step is #7557's own rule — a line typed at a window's
+	 * prompt is about that window, so `:open counter` is `window:open` and not `command:open` — and
+	 * it is what keeps the shared segment below from making `open` unreadable.
+	 */
+	readonly resolveVerb: (verb: string) => AnyShellCommand | undefined;
+	/** Every name a verb may be typed as, which is what a refusal's suggestion is drawn from. */
+	readonly verbSpellings: ReadonlyArray<string>;
+	/**
+	 * The Msg a bound key runs, for a row that takes no argument. A row that needs one cannot be
+	 * driven by a bare key sequence — there is nowhere on a binding to put the argument — so it
+	 * answers `null` and the core leaves the name as a `runCommand` Cmd for a surface to open a
+	 * command line over.
+	 */
+	readonly msgForCommandName: (name: CommandName) => ShellMsg | null;
+}
+
+const indexOf = (commands: ReadonlyArray<AnyShellCommand>): CommandIndex => {
+	const byName = new Map(
+		commands.map((command) => [String(commandName(command.path)), command] as const),
+	);
+	const commandNames = commands.map((command) => commandName(command.path));
+	const commandFor = (name: CommandName | string): AnyShellCommand | undefined =>
+		byName.get(String(name));
+
+	// The last segment of each row's name, when exactly one row claims it. A segment two rows share
+	// is left out rather than resolved to whichever was declared first — `open` is claimed by both
+	// `window:open` and `command:open`, and guessing between them would be a silent wrong window.
 	const counts = new Map<string, number>();
-	for (const command of shellCommands) {
+	for (const command of commands) {
 		const verb = command.path[command.path.length - 1] ?? "";
 		counts.set(verb, (counts.get(verb) ?? 0) + 1);
 	}
-	const unique = new Map<string, AnyShellCommand>();
-	for (const command of shellCommands) {
+	const byBareVerb = new Map<string, AnyShellCommand>();
+	for (const command of commands) {
 		const verb = command.path[command.path.length - 1] ?? "";
-		if (counts.get(verb) === 1) unique.set(verb, command);
+		if (counts.get(verb) === 1) byBareVerb.set(verb, command);
 	}
-	return unique;
-})();
 
-/**
- * A verb as typed: the full name, else the `window:` row of that name, else the last segment when
- * exactly one row claims it. The `window:` step is #7557's own rule — a line typed at a window's
- * prompt is about that window, so `:open counter` is `window:open` and not `command:open` — and it
- * is what keeps the shared segment above from making `open` unreadable.
- */
-export const resolveVerb = (verb: string): AnyShellCommand | undefined =>
-	commandFor(verb) ?? commandFor(`window:${verb}`) ?? byBareVerb.get(verb);
-
-/** Every name a verb may be typed as, which is what a refusal's suggestion is drawn from. */
-export const verbSpellings: ReadonlyArray<string> = [
-	...new Set([
-		...commandNames.map(String),
-		...shellCommands
-			.filter((command) => command.path[0] === "window")
-			.map((command) => command.path[command.path.length - 1] ?? ""),
-		...byBareVerb.keys(),
-	]),
-];
-
-/**
- * The Msg a bound key runs, for a row that takes no argument. A row that needs one cannot be
- * driven by a bare key sequence — there is nowhere on a binding to put the argument — so it
- * answers `null` and the core leaves the name as a `runCommand` Cmd for a surface to open a
- * command line over.
- */
-export const msgForCommandName = (name: CommandName): ShellMsg | null => {
-	const command = commandFor(name);
-	if (command === undefined) return null;
-	return Object.keys(command.params.fields ?? {}).length === 0 ? command.toMsg({}) : null;
+	return {
+		commands,
+		commandNames,
+		commandFor,
+		resolveVerb: (verb) => commandFor(verb) ?? commandFor(`window:${verb}`) ?? byBareVerb.get(verb),
+		verbSpellings: [
+			...new Set([
+				...commandNames.map(String),
+				...commands
+					.filter((command) => command.path[0] === "window")
+					.map((command) => command.path[command.path.length - 1] ?? ""),
+				...byBareVerb.keys(),
+			]),
+		],
+		msgForCommandName: (name) => {
+			const command = commandFor(name);
+			if (command === undefined) return null;
+			return Object.keys(command.params.fields ?? {}).length === 0 ? command.toMsg({}) : null;
+		},
+	};
 };
+
+/** The lookups over the rows these flags leave standing. */
+export const commandIndexFor = (features: ShellCommandFeatures): CommandIndex =>
+	indexOf(shellCommandsFor(features));
+
+/**
+ * The ungated table's lookups — the default every caller that resolves no flags reads. A caller
+ * that has flags reads `commandIndexFor` instead; nothing here is a second table, only this one
+ * narrowed to the rows every desk holds.
+ */
+export const shellCommandIndex: CommandIndex = indexOf(shellCommands);
+
+export const commandNames = shellCommandIndex.commandNames;
+export const commandFor = shellCommandIndex.commandFor;
+export const resolveVerb = shellCommandIndex.resolveVerb;
+export const verbSpellings = shellCommandIndex.verbSpellings;
+export const msgForCommandName = shellCommandIndex.msgForCommandName;

--- a/apps/tuval/src/shell/core/boundary.unit.test.ts
+++ b/apps/tuval/src/shell/core/boundary.unit.test.ts
@@ -113,6 +113,8 @@ describe("shell core boundary", () => {
 			| "command.open"
 			| "config.reload"
 			| "desk.inspector.toggle"
+			| "desk.board.toggle"
+			| "desk.board.close"
 			| "keys.press"
 			| "prefix.repeatLapsed"
 		>();

--- a/apps/tuval/src/shell/core/machine.ts
+++ b/apps/tuval/src/shell/core/machine.ts
@@ -21,8 +21,14 @@
 
 import {defineMachine} from "@demlik/tea";
 import {Duration} from "effect";
-import {msgForCommandName} from "../commands/table.ts";
-import {type DeskMsg, initialDesk, toggleInspector} from "../desk/state.ts";
+import {type CommandIndex, shellCommandIndex} from "../commands/table.ts";
+import {
+	closeBoard,
+	type DeskMsg,
+	initialDesk,
+	toggleBoard,
+	toggleInspector,
+} from "../desk/state.ts";
 import type {CommandName, Key, PrefixState, PrefixTable, RouteAnswer} from "../keys/index.ts";
 import {idle, route} from "../keys/index.ts";
 import {
@@ -552,7 +558,10 @@ const attachHome = (
 	return [next, activeWorkspace(next)?.focused ?? target];
 };
 
-export const cellsFor = (table: PrefixTable): ShellCells => {
+export const cellsFor = (
+	table: PrefixTable,
+	commands: CommandIndex = shellCommandIndex,
+): ShellCells => {
 	const apply = (state: ShellState, msg: ShellMsg): Step => runCell(cells, state, msg);
 
 	/**
@@ -602,7 +611,7 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 		// The command table is the one place a name becomes a Msg, so a bound key and a typed line
 		// run the same row. A name it does not hold — or a row needing an argument a key sequence
 		// has nowhere to carry — leaves as a `runCommand` Cmd for a surface to answer.
-		const commanded = msgForCommandName(answer.name);
+		const commanded = commands.msgForCommandName(answer.name);
 		if (commanded === null) return [routed, [...timer, {type: "runCommand", name: answer.name}]];
 		const [next, cmds] = apply(routed, commanded);
 		return [next, [...timer, ...cmds]];
@@ -659,6 +668,8 @@ export const cellsFor = (table: PrefixTable): ShellCells => {
 		"config.reload": (state) => [state, [{type: "reloadConfig"}]],
 		// Desk-level, so every workspace cell above leaves it untouched by spreading `...state`.
 		"desk.inspector.toggle": (state) => [{...state, desk: toggleInspector(state.desk)}, NO_CMDS],
+		"desk.board.toggle": (state) => [{...state, desk: toggleBoard(state.desk)}, NO_CMDS],
+		"desk.board.close": (state) => [{...state, desk: closeBoard(state.desk)}, NO_CMDS],
 		"keys.press": pressKey,
 		// A lapse disarms a repeat window and nothing else: a timer left over from a spent window
 		// must not drop a prefix the user has since armed by hand, which waits indefinitely.
@@ -689,13 +700,19 @@ export const applyMsg = (table: PrefixTable, state: ShellState, msg: ShellMsg): 
 export interface ShellCoreOptions {
 	/** The grammar `keys.press` routes against — configuration, never state (it holds `Duration`s). */
 	readonly table: PrefixTable;
+	/**
+	 * The rows a bound key's name resolves against. It travels with the table because both are
+	 * gated on the same flags: a core routing over a table that binds a row its own index does not
+	 * hold would answer `runCommand` for a key the desk was told it had.
+	 */
+	readonly commands?: CommandIndex;
 }
 
 /** The shell's core machine. One `defineMachine`; the registry row that carries it lands with #7558. */
-export const shellCore = ({table}: ShellCoreOptions) =>
+export const shellCore = ({table, commands}: ShellCoreOptions) =>
 	defineMachine<ShellState, ShellMsg, ShellCmd, never, unknown>({
 		init: (loaded) => [loaded ?? initialState(), []],
-		update: cellsFor(table),
+		update: cellsFor(table, commands),
 		// Demlik's `Machine` demands a Promise `interpret` beside the row's own handlers; the host
 		// never reads it (#7576). The shell's Effect handlers land with its registry row (#7558).
 		interpret: {

--- a/apps/tuval/src/shell/core/machine.unit.test.ts
+++ b/apps/tuval/src/shell/core/machine.unit.test.ts
@@ -4,12 +4,14 @@
  */
 
 import {describe, expect, it} from "vitest";
+import {commandIndexFor} from "../commands/index.ts";
 import {
 	CommandName,
 	defaultPrefixTable,
 	FOCUS_LIST_KEY,
 	type Key,
 	type PrefixTable,
+	prefixTableFor,
 } from "../keys/index.ts";
 import {findWindow, windows} from "../layout/index.ts";
 import {mountPicker} from "../picker/view.ts";
@@ -48,6 +50,8 @@ describe("shell core: the reducer's cells", () => {
 		expect(Object.keys(cellsFor(table)).sort()).toEqual([
 			"command.open",
 			"config.reload",
+			"desk.board.close",
+			"desk.board.toggle",
 			"desk.inspector.toggle",
 			"keys.press",
 			"layout.resize",
@@ -77,7 +81,7 @@ describe("shell core: the reducer's cells", () => {
 		expect(focusedProcess(state)).toBeNull();
 		expect(state.order).toEqual([state.activeWorkspace]);
 		expect(state.prefix).toEqual({armed: false});
-		expect(state.desk).toEqual({inspectorOpen: false});
+		expect(state.desk).toEqual({inspectorOpen: false, boardOpen: false});
 	});
 });
 
@@ -111,7 +115,58 @@ describe("shell core: the desk inspector", () => {
 	it("survives a checkpoint round trip, like the rest of the shell's state", () => {
 		const opened = fold(initialState(), {type: "desk.inspector.toggle"});
 		const restored = JSON.parse(JSON.stringify(opened)) as ShellState;
-		expect(restored.desk).toEqual({inspectorOpen: true});
+		expect(restored.desk).toEqual({inspectorOpen: true, boardOpen: false});
+	});
+});
+
+/**
+ * The board's overlay (#8867). It is desk-level like the inspector, and its chord is feature-gated,
+ * so the cells are driven over the gated table the flag builds rather than over the default one.
+ */
+describe("shell core: the process board", () => {
+	const gated = prefixTableFor(defaultPrefixTable, {processBoard: true});
+	const gatedCells = cellsFor(gated, commandIndexFor({processBoard: true}));
+	const run = (state: ShellState, ...msgs: readonly ShellMsg[]): ShellState =>
+		msgs.reduce(
+			(acc, msg) =>
+				(gatedCells[msg.type] as (s: ShellState, m: ShellMsg) => readonly [ShellState, unknown])(
+					acc,
+					msg,
+				)[0],
+			state,
+		);
+
+	it("desk.board.toggle pulls the board up and puts it away", () => {
+		const [opened] = apply(initialState(), {type: "desk.board.toggle"});
+		const [closed, cmds] = apply(opened, {type: "desk.board.toggle"});
+
+		expect([opened.desk.boardOpen, closed.desk.boardOpen]).toEqual([true, false]);
+		expect(cmds).toEqual([]);
+	});
+
+	it("desk.board.close closes an open board and leaves a closed one alone", () => {
+		const opened = fold(initialState(), {type: "desk.board.toggle"});
+		expect(apply(opened, {type: "desk.board.close"})[0].desk.boardOpen).toBe(false);
+		expect(apply(initialState(), {type: "desk.board.close"})[0].desk.boardOpen).toBe(false);
+	});
+
+	it("the chord opens it, and the same chord closes it again", () => {
+		const opened = run(initialState(), prefix, press("p"));
+		const closed = run(opened, prefix, press("p"));
+
+		expect([opened.desk.boardOpen, closed.desk.boardOpen]).toEqual([true, false]);
+	});
+
+	it("holds its state across a workspace switch, like every desk-level surface", () => {
+		const opened = run(initialState(), {type: "desk.board.toggle"});
+		const created = run(opened, {type: "workspace.create"});
+		expect(created.desk.boardOpen).toBe(true);
+	});
+
+	it("makes `p` an unbound sequence when the flag is off, and opens nothing", () => {
+		const [routed] = apply(fold(initialState(), prefix), press("p"));
+		expect(routed.desk.boardOpen).toBe(false);
+		expect(routed.lastPress?.outcome._tag).toBe("Consumed");
 	});
 });
 

--- a/apps/tuval/src/shell/desk/index.ts
+++ b/apps/tuval/src/shell/desk/index.ts
@@ -24,9 +24,11 @@ export type {
 	SnapshotProcess,
 } from "./snapshot.ts";
 export {
+	closeBoard,
 	type DeskMsg,
 	type DeskState,
 	initialDesk,
 	isDeskState,
+	toggleBoard,
 	toggleInspector,
 } from "./state.ts";

--- a/apps/tuval/src/shell/desk/state.ts
+++ b/apps/tuval/src/shell/desk/state.ts
@@ -1,30 +1,48 @@
 /**
  * Desk state: what the shell holds about the desk itself rather than about one workspace or one
- * window. Today that is one field — whether the inspector region is open — and its level is the
- * whole point of the ruling (#7500 ruling 4): the inspector is one region beside the tiling area at
- * the *desk* level, so switching workspaces leaves it exactly as it was. Held per workspace it
- * would flap on every switch; held per window it would flap on every focus move.
+ * window. Two fields today — whether the inspector region is open, and whether the process board's
+ * overlay is — and their level is the whole point of the ruling (#7500 ruling 4): each is one
+ * surface at the *desk* level, so switching workspaces leaves it exactly as it was. Held per
+ * workspace it would flap on every switch; held per window it would flap on every focus move.
  *
  * JSON, like the rest of the shell's state, because the shell checkpoints through the kernel.
  */
 
-/** One desk-level Msg today. It lands here, beside the state it writes, not in the core's own list. */
-export type DeskMsg = {readonly type: "desk.inspector.toggle"};
+/** The desk-level Msgs. They land here, beside the state they write, not in the core's own list. */
+export type DeskMsg =
+	| {readonly type: "desk.inspector.toggle"}
+	| {readonly type: "desk.board.toggle"}
+	/**
+	 * Closing without asking what the board was. The overlay's own dismissals — Escape, a click
+	 * outside, a tile opening a window — all fire from a board that is already open, and a toggle
+	 * sent from there would re-open it on any dismissal the chord raced (#8867).
+	 */
+	| {readonly type: "desk.board.close"};
 
 import {Predicate} from "effect";
 
 export interface DeskState {
 	readonly inspectorOpen: boolean;
+	/** The process board's overlay. Closed on a fresh desk: it is pulled up by `<c-b> p` (#8867). */
+	readonly boardOpen: boolean;
 }
 
-/** A fresh desk: the inspector collapsed, because a first paint with nothing selected shows nothing. */
-export const initialDesk: DeskState = {inspectorOpen: false};
+/** A fresh desk: both surfaces collapsed, because a first paint with nothing selected shows nothing. */
+export const initialDesk: DeskState = {inspectorOpen: false, boardOpen: false};
 
 export const isDeskState = (value: unknown): value is DeskState =>
-	Predicate.isObject(value) && typeof value.inspectorOpen === "boolean";
+	Predicate.isObject(value) &&
+	typeof value.inspectorOpen === "boolean" &&
+	typeof value.boardOpen === "boolean";
 
 /** The whole reducer piece behind `desk.inspector.toggle`. */
 export const toggleInspector = (desk: DeskState): DeskState => ({
 	...desk,
 	inspectorOpen: !desk.inspectorOpen,
 });
+
+/** The whole reducer piece behind `desk.board.toggle`. */
+export const toggleBoard = (desk: DeskState): DeskState => ({...desk, boardOpen: !desk.boardOpen});
+
+/** The whole reducer piece behind `desk.board.close`. */
+export const closeBoard = (desk: DeskState): DeskState => ({...desk, boardOpen: false});

--- a/apps/tuval/src/shell/desk/state.unit.test.ts
+++ b/apps/tuval/src/shell/desk/state.unit.test.ts
@@ -1,27 +1,46 @@
 /**
- * Desk state as data: the toggle, and the guard a checkpoint's `unknown` is recovered through. The
- * reducer's own proof — that the open inspector survives a workspace switch — is driven through the
- * core in `../core/machine.unit.test.ts`, because that is where the switch lives.
+ * Desk state as data: the two toggles, and the guard a checkpoint's `unknown` is recovered through.
+ * The reducer's own proof — that the open inspector survives a workspace switch — is driven through
+ * the core in `../core/machine.unit.test.ts`, because that is where the switch lives.
  */
 
 import {describe, expect, it} from "vitest";
-import {initialDesk, isDeskState, toggleInspector} from "./state.ts";
+import {closeBoard, initialDesk, isDeskState, toggleBoard, toggleInspector} from "./state.ts";
 
 describe("desk state", () => {
 	it("starts collapsed and toggles both ways", () => {
-		expect(initialDesk).toEqual({inspectorOpen: false});
+		expect(initialDesk).toEqual({inspectorOpen: false, boardOpen: false});
 		expect(toggleInspector(initialDesk).inspectorOpen).toBe(true);
 		expect(toggleInspector(toggleInspector(initialDesk))).toEqual(initialDesk);
 	});
 
+	it("pulls the board up and puts it away, and a close from either side is closed", () => {
+		expect(toggleBoard(initialDesk).boardOpen).toBe(true);
+		expect(toggleBoard(toggleBoard(initialDesk))).toEqual(initialDesk);
+		expect(closeBoard(toggleBoard(initialDesk))).toEqual(initialDesk);
+		expect(closeBoard(initialDesk)).toEqual(initialDesk);
+	});
+
+	it("moves one surface without touching the other", () => {
+		const open = toggleInspector(initialDesk);
+		expect(toggleBoard(open).inspectorOpen).toBe(true);
+		expect(toggleInspector(toggleBoard(initialDesk)).boardOpen).toBe(true);
+	});
+
 	it("admits a desk it could have written and refuses anything else", () => {
-		expect([isDeskState({inspectorOpen: true}), isDeskState(initialDesk)]).toEqual([true, true]);
+		expect([isDeskState({inspectorOpen: true, boardOpen: true}), isDeskState(initialDesk)]).toEqual(
+			[true, true],
+		);
 		expect([
 			isDeskState({}),
-			isDeskState({inspectorOpen: "yes"}),
+			isDeskState({inspectorOpen: "yes", boardOpen: false}),
+			// A desk written before the board existed. Refused rather than defaulted: `SHELL_VERSION`
+			// is what refuses a checkpoint under the old shape, and a guard that filled the gap in
+			// would be a second, quieter answer to the same question (`../program.ts`).
+			isDeskState({inspectorOpen: false}),
 			isDeskState(null),
 			isDeskState([]),
 			isDeskState("open"),
-		]).toEqual([false, false, false, false, false]);
+		]).toEqual([false, false, false, false, false, false]);
 	});
 });

--- a/apps/tuval/src/shell/keys/index.ts
+++ b/apps/tuval/src/shell/keys/index.ts
@@ -31,8 +31,10 @@ export {
 	type Binding,
 	CommandName,
 	defaultPrefixTable,
+	type KeyFeatures,
 	type KeysConfig,
 	normalizeSequence,
 	type PrefixTable,
+	prefixTableFor,
 	type UnreadableSequenceError,
 } from "./table.ts";

--- a/apps/tuval/src/shell/keys/table.ts
+++ b/apps/tuval/src/shell/keys/table.ts
@@ -73,6 +73,27 @@ export const defaultPrefixTable: PrefixTable = {
 	],
 };
 
+/**
+ * The bindings a feature flag adds. tmux pulls its tree picker up with `choose-tree` on `prefix s`;
+ * the founder ruled `p`, for processes, and `p` is free in the table above (#8867).
+ */
+const boardBindings: ReadonlyArray<Binding> = [
+	{sequence: "p", command: command("desk:board-toggle"), repeatable: false},
+];
+
+/** The flags a binding can be gated on — the shell's own read of `../../features.ts`. */
+export interface KeyFeatures {
+	readonly processBoard: boolean;
+}
+
+/**
+ * The grammar these flags leave standing. A gated binding names a gated command row
+ * (`../commands/table.ts`), and both are gated on the one flag, so a key can never name a row this
+ * build does not hold.
+ */
+export const prefixTableFor = (table: PrefixTable, features: KeyFeatures): PrefixTable =>
+	features.processBoard ? {...table, bindings: [...table.bindings, ...boardBindings]} : table;
+
 /** A config value naming a sequence — or a prefix — the key grammar cannot read. */
 export interface UnreadableSequenceError {
 	readonly _tag: "UnreadableSequenceError";

--- a/apps/tuval/src/shell/program.ts
+++ b/apps/tuval/src/shell/program.ts
@@ -18,7 +18,8 @@ import {NodeId} from "../ports/graph.ts";
 import {ProcessId} from "../process/process.ts";
 import type {AnyProgram, HostHandlers, Program} from "../registry/program.ts";
 import {ProgramId} from "../registry/program.ts";
-import {shellSpells} from "./commands/spells.ts";
+import {shellSpells, shellSpellsFor} from "./commands/spells.ts";
+import {commandIndexFor, type ShellCommandFeatures} from "./commands/table.ts";
 import {
 	isShellState,
 	type ShellCmd,
@@ -26,7 +27,7 @@ import {
 	type ShellState,
 	shellCore,
 } from "./core/index.ts";
-import {defaultPrefixTable, type PrefixTable} from "./keys/index.ts";
+import {defaultPrefixTable, type PrefixTable, prefixTableFor} from "./keys/index.ts";
 import {windows} from "./layout/index.ts";
 import {type Empty, empty, type ProcessGone, processGone, WindowId} from "./window/index.ts";
 
@@ -43,7 +44,7 @@ export const shellNode = NodeId.make("shell");
  * The definition version a snapshot is checked against. Bumping it refuses every desk saved under
  * the old one rather than replaying it into a changed state shape (#7467).
  */
-export const SHELL_VERSION = "1.1.0";
+export const SHELL_VERSION = "1.2.0";
 
 /**
  * What the core asks its host to do, as the kernel's own handler shape. `E` and `R` ride through to
@@ -165,6 +166,32 @@ export const shellProgram = <E = never, R = never>({
  */
 const isShellRow = (program: AnyProgram): program is ShellRow =>
 	program.id === shellId && "table" in program;
+
+/**
+ * The rows a boot's merged feature flags leave standing. A config module is evaluated before the
+ * merge exists (#8595), so the shell's row is built flag-blind and this is the one seam that knows
+ * both: `boot` calls it once, and everything downstream — the registry, the spell set, the grammar
+ * the transport sends — reads the gated row rather than re-deriving the gate for itself (#8867).
+ *
+ * Gating is additive and lives in two lists, `boardBindings` in `./keys/table.ts` and
+ * `boardCommands` in `./commands/table.ts`. Both are keyed on the one flag, so a key can never name
+ * a row this build does not hold.
+ */
+export const withShellFeatures = (
+	programs: ReadonlyArray<AnyProgram>,
+	features: ShellCommandFeatures,
+): ReadonlyArray<AnyProgram> =>
+	programs.map((program) => {
+		if (!isShellRow(program)) return program;
+		const table = prefixTableFor(program.table, features);
+		const commands = commandIndexFor(features);
+		return {
+			...program,
+			table,
+			core: shellCore({table, commands}),
+			spells: shellSpellsFor(features),
+		} satisfies ShellRow;
+	});
 
 /**
  * The key grammar a config's rows put the kernel on: the shell row's resolved table, or the same

--- a/apps/tuval/src/shell/program.unit.test.ts
+++ b/apps/tuval/src/shell/program.unit.test.ts
@@ -25,6 +25,7 @@ import {Processes} from "../process/Processes.ts";
 import {ProcessTable} from "../process/ProcessTable.ts";
 import {ProcessId} from "../process/process.ts";
 import type {AnyProgram} from "../registry/program.ts";
+import {ProgramId} from "../registry/program.ts";
 import {Registry} from "../registry/Registry.ts";
 import {applyMsg, initialState, type ShellMsg} from "./core/index.ts";
 import type {ServeDeskOptions} from "./host/index.ts";
@@ -39,6 +40,7 @@ import {
 	shellStateOf,
 	unwiredShellEffects,
 	windowBindings,
+	withShellFeatures,
 } from "./program.ts";
 import {WindowId} from "./window/index.ts";
 
@@ -295,6 +297,52 @@ describe("the shell as a program row", () => {
 					assert.strictEqual(`${path}: ${code.includes(forbidden)}`, `${path}: false`);
 				}
 			}
+		},
+		BUDGET_MS,
+	);
+});
+
+/**
+ * The one seam that knows both the rows and the merged flags (#8867). A config module is evaluated
+ * before the merge exists (#8595), so the shell's row is built flag-blind and `boot` re-keys it here
+ * — the grammar, the core's own lookups and the registered spells, all off the one flag.
+ */
+describe("the shell row under a boot's merged feature flags", () => {
+	const named = (program: AnyProgram): ReadonlyArray<string> =>
+		(program.spells ?? []).map((spell) => spell.path.join(":"));
+
+	it(
+		"adds the board's binding and its spell together when the flag is on",
+		() => {
+			const [gated] = withShellFeatures([row()], {processBoard: true});
+			assert.isDefined(gated);
+			const table = shellPrefixTable([gated as AnyProgram]);
+			assert.include(
+				table.bindings.map((binding) => String(binding.command)),
+				"desk:board-toggle",
+			);
+			assert.include(named(gated as AnyProgram), "desk:board-toggle");
+		},
+		BUDGET_MS,
+	);
+
+	it(
+		"leaves the row exactly as the config built it when the flag is off",
+		() => {
+			const [plain] = withShellFeatures([row()], {processBoard: false});
+			assert.isDefined(plain);
+			assert.deepStrictEqual(shellPrefixTable([plain as AnyProgram]), defaultPrefixTable);
+			assert.notInclude(named(plain as AnyProgram), "desk:board-toggle");
+		},
+		BUDGET_MS,
+	);
+
+	it(
+		"touches no row but the shell's",
+		() => {
+			const other: AnyProgram = {...row(), id: ProgramId.make("not-the-shell")} as AnyProgram;
+			const [kept] = withShellFeatures([other], {processBoard: true});
+			assert.strictEqual(kept, other);
 		},
 		BUDGET_MS,
 	);

--- a/apps/tuval/src/shell/ui/CommandLine.tsx
+++ b/apps/tuval/src/shell/ui/CommandLine.tsx
@@ -7,6 +7,7 @@ import {buildSpellIndex} from "../../commands/parse/spell-index.ts";
 import {CallId, type WindowId} from "../../protocol/ids.ts";
 import type {Snapshot} from "../../protocol/messages.ts";
 import type {RegistryDescription} from "../../protocol/registry-description.ts";
+import type {CommandIndex} from "../commands/index.ts";
 import {readCommandLine, refusalMessage} from "../commands/index.ts";
 import type {ShellMsg} from "../core/index.ts";
 import type {PageAttachment} from "../transport/browser.ts";
@@ -19,6 +20,11 @@ export interface CommandLineProps {
 	readonly snapshot?: Snapshot | undefined;
 	readonly call?: PageAttachment["call"] | undefined;
 	readonly window?: WindowId | undefined;
+	/**
+	 * The rows this line may name. Absent is the ungated table; a desk with feature flags resolved
+	 * passes the gated index, so a row a flag turned off is as unreadable here as it is unbindable.
+	 */
+	readonly commands?: CommandIndex | undefined;
 }
 
 export function CommandLine({
@@ -28,6 +34,7 @@ export function CommandLine({
 	snapshot,
 	call,
 	window,
+	commands,
 }: CommandLineProps): ReactElement {
 	const [line, setLine] = useState("");
 	const [refusal, setRefusal] = useState<string | null>(null);
@@ -66,12 +73,13 @@ export function CommandLine({
 		if (pending.current) return;
 		const answer =
 			index === null || snapshot === undefined
-				? readCommandLine(line)
+				? readCommandLine(line, {commands})
 				: readCommandLine(line, {
 						registry: index,
 						snapshot,
 						id: CallId.make(crypto.randomUUID()),
 						window,
+						commands,
 					});
 		setOutput(null);
 		if (answer._tag === "Refused") {

--- a/apps/tuval/src/shell/ui/Desk.tsx
+++ b/apps/tuval/src/shell/ui/Desk.tsx
@@ -35,6 +35,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {usePalette} from "../../palette/index.ts";
 import {WindowId as ProtocolWindowId} from "../../protocol/ids.ts";
 import type {RegistryDescription} from "../../protocol/registry-description.ts";
+import {commandIndexFor} from "../commands/index.ts";
 import type {ShellMsg, ShellState} from "../core/index.ts";
 import {activeWorkspace, processOf} from "../core/index.ts";
 import {inspectorFor, statusFor} from "../desk/index.ts";
@@ -117,6 +118,12 @@ export interface DeskProps {
 	readonly registry?: RegistryDescription | undefined;
 	readonly commandsConnected?: boolean | undefined;
 	/**
+	 * The operator's `processBoard` flag (`../../features.ts`, #8867). It decides which command rows
+	 * this desk holds at all, so the command line and the palette read the gated table rather than
+	 * offering a row no key on this desk can reach.
+	 */
+	readonly board?: boolean;
+	/**
 	 * The operator's `windowTitles` flag (`../../features.ts`, #8721), as the desk's two halves of it
 	 * read it: a window titled by its process's `title@1` line, and the process id under the
 	 * inspector's heading. Off — the default — leaves both exactly as they were, and the resolver
@@ -139,8 +146,10 @@ export function Desk({
 	call,
 	registry,
 	commandsConnected = true,
+	board = false,
 	windowTitles = false,
 }: DeskProps): ReactElement {
+	const commands = useMemo(() => commandIndexFor({processBoard: board}), [board]);
 	const [commandLineOpen, setCommandLineOpen] = useState(false);
 	const [forwarded, setForwarded] = useState<ForwardedKey | null>(null);
 	const [modality, setModality] = useState<InputModality>(INITIAL_INPUT_MODALITY);
@@ -199,6 +208,7 @@ export function Desk({
 			// pressed while an answer is outstanding is the shell's whatever the snapshot says: the
 			// kernel may have armed the prefix on the key before it, and this page has not heard yet.
 			// That is what stops `<prefix> |` typing a pipe into whatever had focus (#8274).
+			const boardOpen = current.desk.boardOpen;
 			const shellOwns =
 				outstanding.current > 0 || shellOwnsKey(grammar, routerPrefix(current), key);
 			if (!shellOwns && isTextEntry(event.target)) return;
@@ -230,6 +240,11 @@ export function Desk({
 						return;
 					}
 					if (reply._tag !== "ToWindow") return;
+					// An overlay holding focus takes the desk's windows out of reach: the board is modal,
+					// so a key typed into it must not also land in whatever chat is behind it. The chord
+					// still reaches the kernel — that is how the same `<c-b> p` closes the board — which is
+					// why this stands down here rather than at ownership above (#8867).
+					if (boardOpen) return;
 					// The window focused when the key was pressed, not the one focused when the answer
 					// came back: the kernel routed this key against the desk as it stood at the press.
 					if (window === null) return;
@@ -389,6 +404,7 @@ export function Desk({
 					onClose={closeCommandLine}
 					registry={registry}
 					snapshot={lineSnapshot}
+					commands={commands}
 					call={commandsConnected ? call : undefined}
 					window={focused === null ? undefined : ProtocolWindowId.make(focused)}
 				/>
@@ -400,6 +416,7 @@ export function Desk({
 					{...(call === undefined || !commandsConnected ? {} : {call})}
 					window={palette.window}
 					onClose={closePalette}
+					commands={commands}
 				/>
 			) : null}
 			<StatusLine frame={statusFrame(state)} bar={bar} prefixKey={table.prefix} />

--- a/apps/tuval/src/shell/ui/PaletteHost.tsx
+++ b/apps/tuval/src/shell/ui/PaletteHost.tsx
@@ -9,19 +9,21 @@ import {WindowId} from "../../protocol/ids.ts";
 import type {SpellReply} from "../../protocol/messages.ts";
 import {PROTOCOL_VERSION, SpellCall, SpellReplyError} from "../../protocol/messages.ts";
 import type {RegistryDescription} from "../../protocol/registry-description.ts";
-import {shellCommands} from "../commands/table.ts";
+import type {CommandIndex} from "../commands/table.ts";
+import {shellCommandIndex} from "../commands/table.ts";
 import type {ShellState} from "../core/index.ts";
 import {activeWorkspace} from "../core/index.ts";
 import {type PageAttachment, SHELL_PROGRAM_ID} from "../transport/browser.ts";
 import {commandSnapshot} from "./command-snapshot.ts";
 
-/** Every shell row as the wire describes a spell. Built once: the table is a module constant. */
-const shellDescriptions: RegistryDescription = shellCommands.map((command) => ({
-	path: [...command.path],
-	describe: command.describe,
-	params: Schema.toJsonSchemaDocument(command.params),
-	capabilities: [],
-}));
+/** Every shell row this desk holds, as the wire describes a spell. */
+const describeShellRows = (commands: CommandIndex): RegistryDescription =>
+	commands.commands.map((command) => ({
+		path: [...command.path],
+		describe: command.describe,
+		params: Schema.toJsonSchemaDocument(command.params),
+		capabilities: [],
+	}));
 
 const refusal = (call: SpellCall, tag: string, message: string): SpellReply =>
 	new SpellReplyError({
@@ -47,6 +49,8 @@ export interface PaletteHostProps {
 	/** The window focused when the palette opened — the call's scope, never the layout's. */
 	readonly window: WindowId | undefined;
 	readonly onClose: () => void;
+	/** The rows this palette offers. Absent is the ungated table (`../commands/table.ts`). */
+	readonly commands?: CommandIndex | undefined;
 }
 
 export function PaletteHost({
@@ -55,8 +59,10 @@ export function PaletteHost({
 	call,
 	window,
 	onClose,
+	commands = shellCommandIndex,
 }: PaletteHostProps): ReactElement {
 	const catalog = useMemo(() => {
+		const shellDescriptions = describeShellRows(commands);
 		const shortcuts = shellDescriptions.flatMap((shortcut) => {
 			if (live === undefined) return [shortcut];
 			const registered = live.find(
@@ -75,7 +81,7 @@ export function PaletteHost({
 				),
 			],
 		};
-	}, [live]);
+	}, [live, commands]);
 	const descriptions = catalog.descriptions;
 	const registry = useMemo(() => buildSpellIndex(descriptions), [descriptions]);
 	const [reply, setReply] = useState<SpellReply | null>(null);

--- a/apps/tuval/src/shell/ui/tokens.css
+++ b/apps/tuval/src/shell/ui/tokens.css
@@ -12,22 +12,31 @@
  */
 
 /*
- * `body` sits outside `.tuval-surface`, so the one role the page itself paints is aliased here —
- * off the same value `--surface-sunken` resolves to. Overscroll is the only place it shows (#7560).
+ * The three roles the desk paints outside any one root, so all three are declared on the document
+ * element — which is also where `@kampus/design`'s own layer declares the names they alias, since
+ * the theme is pinned on `<html>`.
+ *
+ * `--page-backdrop` because `body` sits outside `.tuval-surface`; overscroll is the only place it
+ * shows (#7560).
+ *
+ * The ring pair because the board's overlay leaves that root: `@kampus/design`'s `Dialog` mounts
+ * through a zag `Portal` into `document.body`, a sibling of `#root` that inherits nothing from
+ * `.tuval-surface`. Declared there, both `var()`s below would be undefined inside the overlay, and
+ * an undefined `var()` is invalid at computed-value time — which unsets `outline` in the author
+ * origin and beats the UA's own `:focus-visible` ring, so a keyboard operator tabbing the tiles got
+ * no ring at all (#8867). The package declares `--manti-focus-ring*` for Manti's own consumption and
+ * no role token for the desk's ring, so the manifest's law lives here: 2px ring plus a 2px
+ * transparent gap, which clears 3:1 against a same-family dark surface. Painted once by the rule
+ * below, never per component.
  */
 :root {
 	--page-backdrop: var(--surface-sunken);
+	--focus-ring: 2px solid var(--accent);
+	--focus-ring-offset: 2px;
 }
 
 .tuval-surface {
 	color-scheme: dark;
-
-	/* The package declares `--manti-focus-ring*` for Manti's own consumption and no role token for
-	   the desk's ring, so the manifest's law lives here: 2px ring plus a 2px transparent gap, which
-	   clears 3:1 against a same-family dark surface. Painted once by the rule below, never per
-	   component. */
-	--focus-ring: 2px solid var(--accent);
-	--focus-ring-offset: 2px;
 
 	background: var(--surface-sunken);
 	color: var(--text-primary);

--- a/apps/tuval/src/shell/ui/tokens.css
+++ b/apps/tuval/src/shell/ui/tokens.css
@@ -47,7 +47,16 @@
    Written as "not pointer" rather than "is keyboard" so the gate can only ever *remove* a ring, and
    only from a surface that has seen a click. Several `.tuval-surface` roots are not the desk and
    publish nothing — the attaching placeholder (`../../page/AttachedDesk.tsx`), the boot screens,
-   every proof page — and a positive gate would have silently stripped the ring off all of them. */
+   every proof page — and a positive gate would have silently stripped the ring off all of them.
+
+   The board's overlay is named beside the surface because a `Dialog` renders through a portal, out
+   of every `.tuval-surface` root (`../board/ProcessBoardOverlay.tsx`, #8867). It is the one rule
+   either way: a second one in the board's own sheet would be the per-component outline Pillar 4
+   forbids. It carries no modality gate because it has no root publishing one, and needs none — the
+   gate exists for a text field, and everything focusable in the overlay is a button, which a
+   browser already withholds `:focus-visible` from on pointer focus. It is written first because the
+   selector list ascends in specificity, which is what biome's descending-specificity rule asks. */
+.tuval-board-overlay :focus-visible,
 .tuval-surface:not([data-input-modality="pointer"]) :focus-visible {
 	outline: var(--focus-ring);
 	outline-offset: var(--focus-ring-offset);


### PR DESCRIPTION
The process board no longer draws as a permanent band above the desk. `<c-b> p` pulls it up as a modal overlay over the desk; the same chord, Escape, a click outside, or opening a tile puts it away. With `features.processBoard` on and the board closed, the desk gets the whole page — the third of the height the band was taking is back.

**Where the visibility lives.** `desk.boardOpen` is shell state beside `desk.inspectorOpen`, so the page reads it off the snapshot and sends `desk.board.toggle` / `desk.board.close` back as Msgs. `AttachedDesk` holds none of it. `SHELL_VERSION` moves to `1.2.0`, which is what refuses a desk checkpointed under the old shape rather than replaying it into the new one.

**The chord.** `<c-b> p`, per the founder's amendment on the issue (the triage rewrite's `s` recommendation is superseded there). tmux binds its tree picker to `prefix s`; `p` is for processes, and it is free in `defaultPrefixTable`. The note on the binding names both, in the shape the `w` and `a` notes use.

**The flag gates the row, not just its effect.** The board's command row (`commands/table.ts`) and its binding (`keys/table.ts`) are two lists keyed on the one flag. A config module is evaluated before the flag merge exists (#8595), so `boot` applies them at the one seam that holds both — `withShellFeatures`, which re-keys the shell row's grammar, its core's lookups and its registered spells. `bindings.unit.test.ts` proves the pair moves together in both directions. On the page, `Desk` builds the same gated index and hands it to the command line and the palette, so a typed `:desk board-toggle` is as unreadable with the flag off as the key is unbindable.

**The overlay is `@kampus/design`'s `Dialog`, not a local one.** The focus trap, the return of focus on close, Escape, the backdrop and the `aria-modal` announcement are the shared component's, over Manti's zag dialog machine — the same reason the palette does not roll its own (ADR 0186). The dialog's title is the accessible name, so `ProcessBoard` draws no heading of its own. One thing the desk had to learn: while the board is open, `Desk`'s document listener still sends every key to the kernel — that is how `<c-b> p` closes it from inside — but forwards nothing to a window behind the modal.

Rendered before/after captures of the `tuval-board` surface are attached; the proof page now pins the overlay open, because closed it is the desk and nothing else.

**Round 1 — the ring the overlay could not inherit.** `--focus-ring` and `--focus-ring-offset` were declared on `.tuval-surface`, and the `Dialog`'s zag `Portal` mounts into `document.body`, outside that root. Inside the overlay both `var()`s were undefined, which is invalid at computed-value time: `outline` computed to its initial value in the author origin and beat the UA's own `:focus-visible` ring, so a keyboard operator tabbing the tiles saw no ring at all. Both tokens now sit on `:root`, beside `--page-backdrop` and beside the role names they alias. The attached captures are the proof: the autofocused tile wears no ring in the before and a full one in the after.

LAW-SOURCE: manifest-prose — the repo declares no typed prohibition registry beside `design-system-manifest.md`.

Fixes #8867

## Deviations

- **Pre-existing test or fixture changed** — **Said:** the issue asks for the overlay and its gating. **Did:** also changed the focus-ring assertion in `shell/chat/composer-focus-ring.unit.test.tsx` and `shell/chat/subagent-focus-ring.unit.test.tsx`. **Why:** the desk's one ring rule is scoped to `.tuval-surface` and a `Dialog` portals out of every such root, so the overlay would have lost the ring; the rule's selector list now names the overlay too. Both tests assert that exact selector, and the law they hold — one rule, no per-component outline — is unchanged. **Disposition:** stated here; the "one painter" assertion still runs and still fails on a second rule.
- **Out-of-scope change** — **Said:** the issue names the board. **Did:** also refactored `commands/table.ts`'s lookups into a `commandIndexFor(features)` factory and threaded it through `shellCore`, `readCommandLine`, `CommandLine` and `PaletteHost`. **Why:** "no command row exists with the flag off" cannot be met while every lookup surface reads one module-level table; the factory is what makes the gate reach the typed line and the palette rather than only the key. The ungated exports are unchanged in value and still the default everywhere. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about Escape reaching the kernel. **Did:** left it reaching. **Why:** the desk's one document listener hears the same Escape the dialog dismisses on, and stopping it at the overlay would risk the machine's own dismissal; it is inert — Escape is unbound in the grammar, and nothing is forwarded to a window while the board is open. **Disposition:** stated here and asserted in the Escape test.
- **Out-of-scope change** — **Said:** criterion 9 asks for the ring tokens somewhere the overlay inherits them. **Did:** also gave `.tuval-board-overlay .tuval-board-tiles` `padding-block: var(--s-1)`. **Why:** with the tokens fixed the ring painted, and the render showed its top segment clipped — the ring is drawn 2px outside a control, the first grid row is flush with that scroll box's content edge, and `overflow: auto` cuts whatever passes it. A first-row tile wore three sides of a rectangle. **Disposition:** stated here; the after capture shows the closed ring.
- **Scope narrowing** — **Said:** validate the diff. **Did:** three CSS files in the diff are covered by no `build check` surface (`board.css`, `board/proof/proof.css`, `tokens.css`). **Why:** the repo declares no CSS surface; biome's CSS lint does run over them under `pnpm lint:worktree`, which is one of the two code validators. **Disposition:** stated here. This is the gap round 1's FAIL fell through, and it is narrower now: `shell/board/board-focus-ring.unit.test.tsx` reads the sheet's two halves off disk and puts them to the live portaled tree, so a ring painted out of a root the tile cannot reach fails. The clipping half stays unfalsifiable in jsdom, which has no layout — the proof page and its capture are that record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2TbFsCnKqFeVtcxqELoUJ

