### PR TITLE
tuval: stopping an agy turn ends the session for good — the window renders "The session is gone." and its Resend button is a no-op

### DIFF
--- a/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
+++ b/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
@@ -529,9 +529,11 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 			if (current === null) return;
 			// A stop already in flight has nothing for a second press to send, and a second press must
 			// not be able to take the first one's memory of the signal back: an exit read as one nobody
-			// asked for fails the very queue the relaunch is keeping.
-			if (yield* Ref.get(interrupted)) return;
-			yield* Ref.set(interrupted, true);
+			// asked for fails the very queue the relaunch is keeping. Claimed in one step, because a
+			// read and a write are two: two presses that interleave between them both read `false` and
+			// both go on to relaunch, and the second tears down the child the first just opened
+			// (#8883).
+			if (yield* Ref.getAndSet(interrupted, true)) return;
 			const delivered = yield* current.child.handle.kill({killSignal: "SIGINT"}).pipe(
 				Effect.as(true),
 				// `interrupt` declares no error channel, so the refusal rides the stream as a tag the

--- a/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
+++ b/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
@@ -16,13 +16,16 @@
  * `--conversation=<id>`, which returns the same conversation id and carries its context. The event
  * queue is *not* replaced across a respawn: a model switch must not end the window's subscription.
  *
- * **`interrupt` ends the session, and the wire does say so.** SIGINT makes agy exit 1 after a
+ * **`interrupt` ends the child, and then relaunches it.** SIGINT makes agy exit 1 after a
  * well-formed terminal `result` reading `status: "ERROR"` / `error: "interrupted"` — measured at
  * v1.1.27 and v1.1.28, correcting ADR 0362's original reading of that string as
  * `"timeout waiting for response"` (#8694). So the stop is named on the stream and `mapper.ts` marks
  * the cut reply off it; the layer's own memory of having sent the signal is still what `refusals.ts`'s
  * `processGone` spends, because a child that dies with no terminal result at all says nothing either
- * way. The way back is another `start({cwd, resume})`.
+ * way. That memory is also what keeps the exit watch off the event queue for a stop, because the
+ * fourth respawn is this one: `interrupt` relaunches on the same conversation id the way the three
+ * switches do, so a stop lands the window back on `ready` with a live child instead of on a session
+ * nothing but a fresh window could replace (#8709).
  *
  * **Two agy behaviours shape this file without being visible in it.** Turns are strictly sequential
  * — stdin lines queue and a second prompt does not preempt a running one — so nothing here
@@ -173,8 +176,10 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 		const session = yield* Ref.make<Session | null>(null);
 		const keys = yield* Ref.make<ReadonlySet<string>>(new Set());
 		const commandCache = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
-		// This process's own memory of having sent SIGINT, spent only where the wire said nothing: a
-		// child that exits with no terminal `result` at all (see `refusals.ts`'s `processGone`).
+		// A delivered stop, in flight on this child: set when SIGINT goes, given back by a refused
+		// signal and by the relaunch's own `openSession`. Two members read it — `processGone` spends
+		// it where the wire said nothing (`refusals.ts`), and the exit watch reads it to tell an exit
+		// this layer asked for from one it did not.
 		const interrupted = yield* Ref.make(false);
 		// Whether a turn is in flight: true from the send, false once the envelope says `result`.
 		// It is the reason a refused interrupt carries (ADR 0356), and nothing on agy's wire answers
@@ -238,9 +243,9 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 		 * Everything one child says, folded once.
 		 *
 		 * The stdout drain, the stderr drain and the exit watch race: whichever finishes first ends
-		 * the fan, and the exit is the one that fails the queue — a subprocess that is gone is a
-		 * transport that is gone, and nothing relaunches on its own. The way back in is another
-		 * `start`.
+		 * the fan, and the exit is the one that fails the queue — a subprocess that went on its own is
+		 * a transport that is gone, and the way back in is another `start`. An exit this layer asked
+		 * for is the exception, and `interrupt` owns it.
 		 *
 		 * Each line is read twice, on purpose. `eventsOf` is #8178's mapper and owns the whole
 		 * projection onto `AgentEvent`; `decodeLine` is consulted here for the *envelope* only,
@@ -291,10 +296,15 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				const ended = Effect.gen(function* () {
 					const code = yield* child.handle.exitCode.pipe(Effect.orElseSucceed(() => null));
 					yield* Ref.set(turnLive, false);
-					const failure = processGone(code, yield* Ref.get(interrupted));
+					const stopped = yield* Ref.get(interrupted);
+					const failure = processGone(code, stopped);
 					// A child that died before it ever said `init` is a start that failed, and its
 					// caller is still holding that await.
 					yield* Deferred.fail(opened, failure.detail);
+					// A stop's exit is this layer's own doing and `interrupt` relaunches on the same
+					// conversation, so the queue outlives it: failing it here would end the window's
+					// subscription the relaunch exists to keep (#8709).
+					if (stopped) return;
 					yield* emit(into, [{kind: "phase", phase: "gone"}]);
 					yield* Queue.fail(into, failure);
 				});
@@ -501,20 +511,45 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 			yield* Queue.offer(current.child.stdin, encoder.encode(composed.line));
 		});
 
+		/**
+		 * Stop the running turn, and come back on the same conversation.
+		 *
+		 * SIGINT makes agy exit, so there is no stop this child survives — which leaves the relaunch
+		 * `respawn` already is as the way back, and that is what makes a stop end on `ready` with a
+		 * live child rather than on a session the operator can only replace (#8709).
+		 *
+		 * The fan is awaited between the signal and the relaunch. `kill` resolves on the exit it
+		 * asked for (`@effect/platform-node-shared`'s `NodeChildProcessSpawner`), and the fold runs a
+		 * fiber behind it: the terminal `result` is what marks the cut reply `interrupted`, so a
+		 * relaunch that announced the session back first would put `ready` ahead of the mark the
+		 * window renders the cut turn from.
+		 */
 		const interrupt = Effect.gen(function* () {
 			const current = yield* Ref.get(session);
 			if (current === null) return;
+			// A stop already in flight has nothing for a second press to send, and a second press must
+			// not be able to take the first one's memory of the signal back: an exit read as one nobody
+			// asked for fails the very queue the relaunch is keeping.
+			if (yield* Ref.get(interrupted)) return;
 			yield* Ref.set(interrupted, true);
-			yield* current.child.handle.kill({killSignal: "SIGINT"}).pipe(
+			const delivered = yield* current.child.handle.kill({killSignal: "SIGINT"}).pipe(
+				Effect.as(true),
 				// `interrupt` declares no error channel, so the refusal rides the stream as a tag the
 				// fold routes on its own (ADR 0356) — a log line left the window unable to tell a
-				// backend that said no from a stop still in flight.
+				// backend that said no from a stop still in flight. The memory of the signal goes back
+				// with it: one that was never delivered must not speak for whatever ends this child.
 				Effect.catch((refusal) =>
-					Effect.flatMap(Ref.get(turnLive), (live) =>
-						publish([{kind: "failure", failure: interruptFailureOf(refusal, live)}]),
-					),
+					Effect.gen(function* () {
+						yield* Ref.set(interrupted, false);
+						const live = yield* Ref.get(turnLive);
+						yield* publish([{kind: "failure", failure: interruptFailureOf(refusal, live)}]);
+						return false;
+					}),
 				),
 			);
+			if (!delivered) return;
+			yield* Fiber.await(current.child.fiber);
+			yield* respawn(yield* Ref.get(settings));
 		}).pipe(Effect.withSpan("TuvalAiAgent.interrupt"));
 
 		const setModel = Effect.fn("TuvalAiAgent.setModel")(function* (model: ModelRef) {

--- a/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
+++ b/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
@@ -20,12 +20,14 @@
  * well-formed terminal `result` reading `status: "ERROR"` / `error: "interrupted"` — measured at
  * v1.1.27 and v1.1.28, correcting ADR 0362's original reading of that string as
  * `"timeout waiting for response"` (#8694). So the stop is named on the stream and `mapper.ts` marks
- * the cut reply off it; the layer's own memory of having sent the signal is still what `refusals.ts`'s
- * `processGone` spends, because a child that dies with no terminal result at all says nothing either
- * way. That memory is also what keeps the exit watch off the event queue for a stop, because the
- * fourth respawn is this one: `interrupt` relaunches on the same conversation id the way the three
- * switches do, so a stop lands the window back on `ready` with a live child instead of on a session
- * nothing but a fresh window could replace (#8709).
+ * the cut reply off it; the layer's own memory of *which child* it signalled is still what
+ * `refusals.ts`'s `processGone` spends, because a child that dies with no terminal result at all says
+ * nothing either way. That memory is also what keeps the exit watch off the event queue for a stop,
+ * because the fourth respawn is this one: `interrupt` relaunches on the same conversation id the way
+ * the three switches do, so a stop lands the window back on `ready` with a live child instead of on a
+ * session nothing but a fresh window could replace (#8709). The `ready` that stop ends on is
+ * published off the terminal `result`, which is *before* the relaunch finishes — so the relaunch is
+ * also the one span in which `prompt` refuses: see `relaunchOver`.
  *
  * **Two agy behaviours shape this file without being visible in it.** Turns are strictly sequential
  * — stdin lines queue and a second prompt does not preempt a running one — so nothing here
@@ -94,6 +96,7 @@ import {
 	malformedPrompt,
 	noSession,
 	processGone,
+	relaunchInFlight,
 	resumeFailed,
 	startFailed,
 	transcriptSessionMissing,
@@ -176,11 +179,16 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 		const session = yield* Ref.make<Session | null>(null);
 		const keys = yield* Ref.make<ReadonlySet<string>>(new Set());
 		const commandCache = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
-		// A delivered stop, in flight on this child: set when SIGINT goes, given back by a refused
-		// signal and by the relaunch's own `openSession`. Two members read it — `processGone` spends
-		// it where the wire said nothing (`refusals.ts`), and the exit watch reads it to tell an exit
-		// this layer asked for from one it did not.
-		const interrupted = yield* Ref.make(false);
+		// The child a stop was delivered to, which is the stop itself: set to that child's handle when
+		// SIGINT goes, given back by a refused signal. Two members read it — `processGone` spends it
+		// where the wire said nothing (`refusals.ts`), and the exit watch reads it to tell an exit
+		// this layer asked for from one it did not. It is the *child* and not a layer-wide flag
+		// because a relaunch whose `openSession` failed would otherwise leave a boolean stale-`true`
+		// and the next child's own death would read as a stop nobody sent (#8709).
+		const stopSentTo = yield* Ref.make<ChildProcessSpawner.ChildProcessHandle | null>(null);
+		// Set from the delivered signal through to the session the relaunch reopened: the span in
+		// which `session` still holds a torn-down child. `prompt` refuses across it — see there.
+		const relaunching = yield* Ref.make(false);
 		// Whether a turn is in flight: true from the send, false once the envelope says `result`.
 		// It is the reason a refused interrupt carries (ADR 0356), and nothing on agy's wire answers
 		// that question — a layer that read it off the stream would have to wait for the very
@@ -296,7 +304,7 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				const ended = Effect.gen(function* () {
 					const code = yield* child.handle.exitCode.pipe(Effect.orElseSucceed(() => null));
 					yield* Ref.set(turnLive, false);
-					const stopped = yield* Ref.get(interrupted);
+					const stopped = (yield* Ref.get(stopSentTo)) === child.handle;
 					const failure = processGone(code, stopped);
 					// A child that died before it ever said `init` is a start that failed, and its
 					// caller is still holding that await.
@@ -319,6 +327,31 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 					ended,
 				);
 			});
+
+		/**
+		 * Claim the stop for one child, in a single step.
+		 *
+		 * A read and a write are two steps: two presses that interleave between them both find the
+		 * stop unclaimed and both go on to relaunch, and the second tears down the child the first
+		 * just opened (#8883). `false` is "this child's stop is already in flight", which is all a
+		 * second press has to be told — and because the claim names the child, a stop left behind by a
+		 * relaunch that failed can never be read as the next child's.
+		 */
+		const claimStop = (child: Child): Effect.Effect<boolean> =>
+			Ref.modify(stopSentTo, (held) =>
+				held === child.handle ? [false, held] : [true, child.handle],
+			);
+
+		/**
+		 * Run one relaunch's span with `relaunching` set, given back on every exit — a failure and an
+		 * interruption included, which is what keeps a failed relaunch from locking sends out for the
+		 * life of the layer.
+		 */
+		const whileRelaunching = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+			Ref.set(relaunching, true).pipe(
+				Effect.andThen(effect),
+				Effect.ensuring(Ref.set(relaunching, false)),
+			);
 
 		const teardown = (child: Child): Effect.Effect<void> =>
 			Fiber.interrupt(child.fiber).pipe(
@@ -394,7 +427,6 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 					child,
 				};
 			}).pipe(
-				Effect.tap(() => Ref.set(interrupted, false)),
 				Effect.tap(() => Ref.set(turnLive, false)),
 				Effect.mapError((detail) =>
 					resume === undefined ? startFailed(cwd, detail) : resumeFailed(cwd, resume, detail),
@@ -415,15 +447,14 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 			]);
 
 		/**
-		 * A switch agy can only answer by being relaunched. The conversation id carries, so this is a
-		 * restart under the hood rather than a lost session — but it is a restart, so any turn still
-		 * running goes with it, exactly as agy's own refusal implies.
+		 * The teardown-to-reopened-session span, which is the span no send may cross: between
+		 * the two, `session` holds a child whose stdin is shut down, and `Queue.offer` on a queue that
+		 * is not `Open` answers `false` rather than failing (`effect`'s `Queue.ts`) — so a send
+		 * admitted here would be dropped, with its idempotency key already burned and nothing left to
+		 * settle it (#8709).
 		 */
-		const respawn = (next: Settings): Effect.Effect<void> =>
+		const relaunchOver = (current: Session, next: Settings): Effect.Effect<Session | null> =>
 			Effect.gen(function* () {
-				const current = yield* Ref.get(session);
-				yield* Ref.set(settings, next);
-				if (current === null) return;
 				yield* teardown(current.child);
 				const reopened = yield* openSession(next, current.cwd, current.conversationId).pipe(
 					Effect.tapError((failure) =>
@@ -445,8 +476,25 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 					),
 					Effect.orElseSucceed(() => null),
 				);
-				if (reopened === null) return;
+				if (reopened === null) return null;
 				yield* Ref.set(session, reopened);
+				return reopened;
+			});
+
+		/**
+		 * A switch agy can only answer by being relaunched. The conversation id carries, so this is a
+		 * restart under the hood rather than a lost session — but it is a restart, so any turn still
+		 * running goes with it, exactly as agy's own refusal implies.
+		 */
+		const respawn = (next: Settings): Effect.Effect<void> =>
+			Effect.gen(function* () {
+				const current = yield* Ref.get(session);
+				yield* Ref.set(settings, next);
+				if (current === null) return;
+				const reopened = yield* whileRelaunching(relaunchOver(current, next));
+				if (reopened === null) return;
+				// Announced outside the guard, because `announce` ends on `ready` and a window that
+				// answers that phase with a send must not meet the refusal the guard exists to raise.
 				yield* announce(reopened);
 			});
 
@@ -490,6 +538,12 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 		const prompt = Effect.fn("TuvalAiAgent.prompt")(function* (text: string, key?: string) {
 			const current = yield* Ref.get(session);
 			if (current === null) return yield* noSession();
+			// `ready` is published off the terminal `result`, which lands *before* the stop's relaunch
+			// is finished — so a send can arrive while `session` still holds the torn-down child, and
+			// the offer below would answer `false` on its shut-down stdin and settle nowhere. Refused
+			// here instead, which is the one answer that renders as text the operator still has
+			// (#8709).
+			if (yield* Ref.get(relaunching)) return yield* relaunchInFlight();
 			const composed = promptLine(text);
 			// Refused *before* stdin, and that ordering is the point: a malformed `user` message is
 			// fatal to the whole run rather than skipped, so a line this layer is not sure of is a
@@ -528,12 +582,9 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 			const current = yield* Ref.get(session);
 			if (current === null) return;
 			// A stop already in flight has nothing for a second press to send, and a second press must
-			// not be able to take the first one's memory of the signal back: an exit read as one nobody
-			// asked for fails the very queue the relaunch is keeping. Claimed in one step, because a
-			// read and a write are two: two presses that interleave between them both read `false` and
-			// both go on to relaunch, and the second tears down the child the first just opened
-			// (#8883).
-			if (yield* Ref.getAndSet(interrupted, true)) return;
+			// not be able to take the first one's claim back: an exit read as one nobody asked for
+			// fails the very queue the relaunch is keeping (#8883).
+			if (!(yield* claimStop(current.child))) return;
 			const delivered = yield* current.child.handle.kill({killSignal: "SIGINT"}).pipe(
 				Effect.as(true),
 				// `interrupt` declares no error channel, so the refusal rides the stream as a tag the
@@ -542,7 +593,7 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				// with it: one that was never delivered must not speak for whatever ends this child.
 				Effect.catch((refusal) =>
 					Effect.gen(function* () {
-						yield* Ref.set(interrupted, false);
+						yield* Ref.set(stopSentTo, null);
 						const live = yield* Ref.get(turnLive);
 						yield* publish([{kind: "failure", failure: interruptFailureOf(refusal, live)}]);
 						return false;
@@ -550,8 +601,15 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				),
 			);
 			if (!delivered) return;
-			yield* Fiber.await(current.child.fiber);
-			yield* respawn(yield* Ref.get(settings));
+			// Guarded from here rather than from the teardown inside `respawn`: the cut turn's
+			// terminal `result` has already published `ready`, so the window is free to send from the
+			// instant the signal lands — and between that `result` and the exit the child is on its
+			// way out with nothing left that will settle a send (#8709).
+			yield* whileRelaunching(
+				Fiber.await(current.child.fiber).pipe(
+					Effect.andThen(Effect.flatMap(Ref.get(settings), respawn)),
+				),
+			);
 		}).pipe(Effect.withSpan("TuvalAiAgent.interrupt"));
 
 		const setModel = Effect.fn("TuvalAiAgent.setModel")(function* (model: ModelRef) {

--- a/apps/tuval/src/agy/ai-agent/agy-ai-agent.integration.test.ts
+++ b/apps/tuval/src/agy/ai-agent/agy-ai-agent.integration.test.ts
@@ -334,7 +334,7 @@ describe("the agy layer over a scripted binary", () => {
 		expect(refusal._tag).toBe("tuval/ai-agent/UnknownRequest");
 	});
 
-	it("interrupts with SIGINT, and marks the cut turn rather than failing it", async () => {
+	it("interrupts with SIGINT, marks the cut turn, and comes back on the same conversation", async () => {
 		const collectedEvents = await drive((collected) =>
 			Effect.gen(function* () {
 				const agent = yield* TuvalAiAgent;
@@ -344,15 +344,12 @@ describe("the agy layer over a scripted binary", () => {
 				);
 				yield* agent.prompt("something long");
 				yield* agent.interrupt;
-				yield* until(collected, (events) =>
-					events.some((event) => event.kind === "phase" && event.phase === "gone"),
-				);
 				return [...collected];
 			}),
 		);
 		// The wire names the stop (`error: "interrupted"`, #8694), so the turn is marked rather than
-		// failed — and the child is really gone, which the window has to be told: the exit watch used
-		// to lose a race to stdout's own EOF and the session read `ready` over a dead process (#8693).
+		// failed — and the stop is not the end of the session: the child it killed is relaunched on the
+		// same conversation id, so the window is left able to send again (#8709).
 		expect(
 			collectedEvents.flatMap((event) => (event.kind === "failure" ? [event.failure] : [])),
 		).toEqual([]);
@@ -365,7 +362,13 @@ describe("the agy layer over a scripted binary", () => {
 		const phases = collectedEvents.flatMap((event) =>
 			event.kind === "phase" ? [event.phase] : [],
 		);
-		expect(phases.at(-1)).toBe("gone");
+		expect(phases).not.toContain("gone");
+		expect(phases.at(-1)).toBe("ready");
+		// Two launches, and the second reopens what the first opened: the relaunch is the `respawn`
+		// the three switches take, not a fresh session.
+		const composed = launches();
+		expect(composed).toHaveLength(2);
+		expect(composed[1]?.join(" ")).toContain("--conversation=fake-0000-1111-2222");
 	});
 
 	it("pages history out of agy's own transcript.jsonl", async () => {

--- a/apps/tuval/src/agy/ai-agent/child-stub.ts
+++ b/apps/tuval/src/agy/ai-agent/child-stub.ts
@@ -64,7 +64,7 @@ export const agyChildStub = Effect.gen(function* () {
 	};
 });
 
-/** One launched stub child, and the three things a test does to it. */
+/** One launched stub child, and the four things a test does to it. */
 export interface StubChild {
 	/** One agy stdout line, as the fan reads it. */
 	readonly say: (line: string) => Effect.Effect<void>;
@@ -72,7 +72,15 @@ export interface StubChild {
 	readonly signals: Effect.Effect<ReadonlyArray<string>>;
 	/** The exit a delivered signal earns: the pipes end, then the code lands. */
 	readonly exit: (code: number) => Effect.Effect<void>;
+	/**
+	 * Every line that really crossed this child's stdin, decoded. A send the layer dropped onto a
+	 * shut-down queue is absent here, which is the only way a test can tell it apart from one that
+	 * landed (#8709).
+	 */
+	readonly written: Effect.Effect<ReadonlyArray<string>>;
 }
+
+const decoder = new TextDecoder();
 
 const stubChild = Effect.gen(function* () {
 	const stdout = yield* Queue.unbounded<Uint8Array, Cause.Done>();
@@ -80,6 +88,7 @@ const stubChild = Effect.gen(function* () {
 	// and a stderr that completes at once wins that race and ends the fan before a line is read.
 	const stderr = yield* Queue.unbounded<Uint8Array, Cause.Done>();
 	const signals = yield* Ref.make<ReadonlyArray<string>>([]);
+	const written = yield* Ref.make<ReadonlyArray<string>>([]);
 	const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
 	const exit = (code: number): Effect.Effect<void> =>
 		Queue.end(stdout).pipe(
@@ -108,8 +117,9 @@ const stubChild = Effect.gen(function* () {
 		say: (line: string) => Effect.asVoid(Queue.offer(stdout, encoder.encode(`${line}\n`))),
 		signals: Ref.get(signals),
 		exit,
+		written: Ref.get(written),
 	};
-	return {handle, child};
+	return {handle, child, written};
 });
 
 /** A spawner that launches a fresh stub child every time, which is what a respawn asks of it. */
@@ -117,8 +127,21 @@ export const agyChildrenStub = Effect.gen(function* () {
 	const launched = yield* Ref.make<ReadonlyArray<ReadonlyArray<string>>>([]);
 	const children = yield* Ref.make<ReadonlyArray<StubChild>>([]);
 	const spawn = Effect.fnUntraced(function* (command: ChildProcess.Command) {
-		const {handle, child} = yield* stubChild;
+		const {handle, child, written} = yield* stubChild;
 		const argv = ChildProcess.isStandardCommand(command) ? [...command.args] : [];
+		// The real spawner runs the command's input stream into the child's stdin; a stub that only
+		// hands back a handle never consumes it, and then no test can see which child a send reached.
+		// Forked into the spawn's own scope, so it dies with the child like the real pipe does.
+		const input = ChildProcess.isStandardCommand(command) ? command.options.stdin : undefined;
+		const piped =
+			typeof input === "object" && input !== null && "stream" in input ? input.stream : input;
+		if (typeof piped === "object" && piped !== null) {
+			yield* Effect.forkScoped(
+				Stream.runForEach(piped, (bytes) =>
+					Ref.update(written, (seen) => [...seen, decoder.decode(bytes)]),
+				).pipe(Effect.ignore),
+			);
+		}
 		yield* Ref.update(launched, (seen) => [...seen, argv]);
 		yield* Ref.update(children, (seen) => [...seen, child]);
 		return handle;

--- a/apps/tuval/src/agy/ai-agent/child-stub.ts
+++ b/apps/tuval/src/agy/ai-agent/child-stub.ts
@@ -1,15 +1,23 @@
 /**
- * One stubbed agy child, for the tests that drive this layer's real event path without a CLI.
+ * Stubbed agy children, for the tests that drive this layer's real event path without a CLI.
  *
- * A stdout the test writes agy's own captured lines into, an exit that never comes, and a `kill`
- * that always says no. `exitCode` is `Effect.never` on purpose — an exit is what ends `events` with
- * a transport failure, and a refusal must not be confused with the child having gone away.
+ * `agyChildStub` is one child whose `kill` always says no: a stdout the test writes agy's own
+ * captured lines into, and an exit that never comes. `exitCode` is `Effect.never` on purpose — an
+ * exit is what ends `events` with a transport failure, and a refusal must not be confused with the
+ * child having gone away.
+ *
+ * `agyChildrenStub` is the other half, for a stop that is taken: a child per launch, each with the
+ * argv it was launched with, a `kill` that records the signal and resolves on the exit the test
+ * then gives it, and pipes that close with that exit. The resolve-on-exit is not a convenience —
+ * the real `kill` awaits the exit it asked for
+ * (`@effect/platform-node-shared`'s `NodeChildProcessSpawner`), which is the ordering
+ * `interrupt`'s relaunch stands on.
  */
 
 import {NodeFileSystem, NodePath} from "@effect/platform-node";
-import {Effect, Layer, Queue, Ref, Sink, Stream} from "effect";
+import {type Cause, Deferred, Effect, Layer, Queue, Ref, Sink, Stream} from "effect";
 import * as PlatformError from "effect/PlatformError";
-import {ChildProcessSpawner} from "effect/unstable/process";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {aiAgentOverSpawner} from "./AgyAiAgent.ts";
 
@@ -53,6 +61,87 @@ export const agyChildStub = Effect.gen(function* () {
 		/** One agy stdout line, as the fan reads it. */
 		say: (line: string) => Queue.offer(stdout, encoder.encode(`${line}\n`)),
 		kills: Ref.get(kills),
+	};
+});
+
+/** One launched stub child, and the three things a test does to it. */
+export interface StubChild {
+	/** One agy stdout line, as the fan reads it. */
+	readonly say: (line: string) => Effect.Effect<void>;
+	/** Every signal `kill` was asked for, in order. */
+	readonly signals: Effect.Effect<ReadonlyArray<string>>;
+	/** The exit a delivered signal earns: the pipes end, then the code lands. */
+	readonly exit: (code: number) => Effect.Effect<void>;
+}
+
+const stubChild = Effect.gen(function* () {
+	const stdout = yield* Queue.unbounded<Uint8Array, Cause.Done>();
+	// Open and silent, never `Stream.empty`: `follow` races the stdout drain against the stderr one,
+	// and a stderr that completes at once wins that race and ends the fan before a line is read.
+	const stderr = yield* Queue.unbounded<Uint8Array, Cause.Done>();
+	const signals = yield* Ref.make<ReadonlyArray<string>>([]);
+	const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
+	const exit = (code: number): Effect.Effect<void> =>
+		Queue.end(stdout).pipe(
+			Effect.andThen(Queue.end(stderr)),
+			Effect.andThen(Deferred.succeed(exited, ChildProcessSpawner.ExitCode(code))),
+			Effect.asVoid,
+		);
+	const handle: ChildProcessSpawner.ChildProcessHandle = ChildProcessSpawner.makeHandle({
+		pid: ChildProcessSpawner.ProcessId(424_243),
+		exitCode: Deferred.await(exited),
+		isRunning: Effect.map(Deferred.isDone(exited), (done) => !done),
+		kill: (options) =>
+			Ref.update(signals, (seen) => [...seen, options?.killSignal ?? "SIGTERM"]).pipe(
+				Effect.andThen(Deferred.await(exited)),
+				Effect.asVoid,
+			),
+		stdin: Sink.drain,
+		stdout: Stream.fromQueue(stdout),
+		stderr: Stream.fromQueue(stderr),
+		all: Stream.fromQueue(stderr),
+		getInputFd: () => Sink.drain,
+		getOutputFd: () => Stream.empty,
+		unref: Effect.succeed(Effect.void),
+	});
+	const child: StubChild = {
+		say: (line: string) => Effect.asVoid(Queue.offer(stdout, encoder.encode(`${line}\n`))),
+		signals: Ref.get(signals),
+		exit,
+	};
+	return {handle, child};
+});
+
+/** A spawner that launches a fresh stub child every time, which is what a respawn asks of it. */
+export const agyChildrenStub = Effect.gen(function* () {
+	const launched = yield* Ref.make<ReadonlyArray<ReadonlyArray<string>>>([]);
+	const children = yield* Ref.make<ReadonlyArray<StubChild>>([]);
+	const spawn = Effect.fnUntraced(function* (command: ChildProcess.Command) {
+		const {handle, child} = yield* stubChild;
+		const argv = ChildProcess.isStandardCommand(command) ? [...command.args] : [];
+		yield* Ref.update(launched, (seen) => [...seen, argv]);
+		yield* Ref.update(children, (seen) => [...seen, child]);
+		return handle;
+	});
+	/** The nth child, waited for: a relaunch is in flight when the test goes looking for it. */
+	const childAt = (index: number): Effect.Effect<StubChild> =>
+		Effect.flatMap(Ref.get(children), (seen) => {
+			const one = seen[index];
+			return one === undefined
+				? Effect.andThen(Effect.sleep("5 millis"), childAt(index))
+				: Effect.succeed(one);
+		});
+	return {
+		layer: Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, ChildProcessSpawner.make(spawn)),
+		child: (index: number) =>
+			childAt(index).pipe(
+				Effect.timeoutOrElse({
+					duration: "5 seconds",
+					orElse: () => Effect.die(new Error(`no child was launched at index ${index}`)),
+				}),
+			),
+		/** Every launch's argv, in order. */
+		launches: Ref.get(launched),
 	};
 });
 

--- a/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * What an agy stop leaves behind, over the layer's real event path (#8709).
+ *
+ * A SIGINT agy takes ends the child, so the session the window holds survives only if the layer
+ * relaunches it — and the relaunch has to be the one `setModel` already uses, because that is the
+ * one that keeps the conversation id and the event queue. Three facts make that true and are
+ * asserted separately: the second launch carries `--conversation=<id>`, the phase the window ends on
+ * is `ready`, and the stream the window subscribed to is still the same live stream afterwards.
+ *
+ * Limits of the proof: the spawner is a stub, so the signal is recorded rather than delivered and
+ * the exit is the test's. What is real is everything above the pipe — `follow`'s fold, the exit
+ * watch's own reading of the stop, and `respawn`. The scripted binary beside this file
+ * (`agy-ai-agent.integration.test.ts`) drives the same path over a real SIGINT and a real exit.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Fiber, Option, Queue, Stream} from "effect";
+import type {AgentEvent, StartError} from "../../ai-agent/service/index.ts";
+import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
+import {agyChildrenStub, agyLayerOver, type StubChild} from "./child-stub.ts";
+import {init, resultInterrupted, userInput} from "./fixtures.ts";
+
+const CWD = "/tuval/agy-interrupt-respawn";
+
+/** The conversation id the captured `init` line opens, which is what a relaunch has to carry. */
+const CONVERSATION = "9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf";
+
+/** Every event up to and including the first one `found` accepts, bounded so a miss names itself. */
+const collectTo = (
+	events: Queue.Dequeue<AgentEvent, unknown>,
+	what: string,
+	found: (event: AgentEvent) => boolean,
+) =>
+	Effect.gen(function* () {
+		const seen: Array<AgentEvent> = [];
+		while (true) {
+			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("5 seconds"));
+			if (Option.isNone(next)) {
+				assert.fail(`timed out waiting for ${what}; saw ${JSON.stringify(seen)}`);
+			}
+			seen.push(next.value);
+			if (found(next.value)) return seen;
+		}
+	});
+
+/** Waits until the stop has reached the child, so what follows is ordered after the signal. */
+const signalled = (child: StubChild): Effect.Effect<void> =>
+	Effect.flatMap(child.signals, (seen) =>
+		seen.length === 0 ? Effect.andThen(Effect.sleep("5 millis"), signalled(child)) : Effect.void,
+	).pipe(
+		Effect.timeoutOrElse({
+			duration: "5 seconds",
+			orElse: () => Effect.die(new Error("the stop sent no signal")),
+		}),
+	);
+
+const isReady = (event: AgentEvent): boolean => event.kind === "phase" && event.phase === "ready";
+const isPrompting = (event: AgentEvent): boolean =>
+	event.kind === "phase" && event.phase === "prompting";
+const isInterruptedItem = (event: AgentEvent): boolean =>
+	event.kind === "item" && event.item.kind === "assistant" && event.item.interrupted === true;
+
+describe("an agy turn the operator stops", () => {
+	/**
+	 * One opened session over a relaunching stub. `start` awaits `init`, and the child it awaits does
+	 * not exist until the launch — so the launch is forked and the line written into the child it
+	 * produced.
+	 */
+	const opened = (children: {
+		readonly child: (index: number) => Effect.Effect<StubChild>;
+	}): Effect.Effect<void, StartError, TuvalAiAgent> =>
+		Effect.gen(function* () {
+			const agent = yield* TuvalAiAgent;
+			const starting = yield* Effect.forkChild(agent.start({cwd: CWD}));
+			yield* Effect.flatMap(children.child(0), (child) => child.say(init));
+			yield* Fiber.join(starting);
+		});
+
+	it.live("comes back on the same conversation, on the same stream, at ready", () =>
+		Effect.gen(function* () {
+			const children = yield* agyChildrenStub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* opened(children);
+				// Subscribed after the open, because `start` replaces the queue it opened on: a
+				// subscription taken before it is reading a queue `start` shuts down.
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* agent.prompt("something long");
+				yield* collectTo(events, "the turn's prompting", isPrompting);
+
+				// The stop, as the wire and the process really order it: the signal lands, agy writes
+				// its terminal `result` naming the stop, and only then does the child exit.
+				const stopping = yield* Effect.forkChild(agent.interrupt);
+				const first = yield* children.child(0);
+				yield* signalled(first);
+				// An impatient second press, which the core does dispatch: the phase is still
+				// `prompting` until the terminal `result` lands. It has nothing left to send, and a
+				// second signal would take the first one's relaunch down with the queue.
+				yield* agent.interrupt;
+				yield* first.say(userInput);
+				yield* first.say(resultInterrupted);
+				yield* first.exit(1);
+				// The relaunch is in flight behind the exit, and it is waiting on its own `init`.
+				yield* Effect.flatMap(children.child(1), (child) => child.say(init));
+				yield* Fiber.join(stopping);
+
+				const launches = yield* children.launches;
+				assert.strictEqual(launches.length, 2, "the stop did not relaunch the child");
+				assert.include(launches[1] ?? [], `--conversation=${CONVERSATION}`);
+				assert.deepStrictEqual(
+					yield* first.signals,
+					["SIGINT"],
+					"the stop sent something other than one SIGINT",
+				);
+
+				// The queue the window subscribed to before the stop is the one still answering: a
+				// `gone` or a failed take here is the subscription the relaunch exists to keep.
+				const after = yield* collectTo(events, "the session back at ready", isReady);
+				assert.isEmpty(
+					after.filter((event) => event.kind === "phase" && event.phase === "gone"),
+					"the stop narrated a session the layer went on to relaunch",
+				);
+				assert.isTrue(
+					after.some(isInterruptedItem),
+					"the cut reply lost its interrupted mark across the relaunch",
+				);
+			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
+		}),
+	);
+
+	// The other half of the exit watch's reading: an exit nobody asked for is still a transport that
+	// is gone, and the window is still owed the `gone` and the failed stream.
+	it.live("still reports an exit the layer did not ask for", () =>
+		Effect.gen(function* () {
+			const children = yield* agyChildrenStub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* opened(children);
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+
+				const first = yield* children.child(0);
+				yield* first.exit(1);
+
+				yield* collectTo(
+					events,
+					"the gone phase",
+					(event) => event.kind === "phase" && event.phase === "gone",
+				);
+				const failed = yield* Effect.result(Queue.take(events));
+				assert.isTrue(failed._tag === "Failure", "the dead transport left the stream live");
+				assert.strictEqual(
+					(yield* children.launches).length,
+					1,
+					"the layer relaunched a child it never stopped",
+				);
+			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
+		}),
+	);
+});

--- a/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
@@ -14,7 +14,7 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Fiber, Option, Queue, Scheduler, Stream} from "effect";
+import {Cause, Effect, Exit, Fiber, Option, Queue, Scheduler, Stream} from "effect";
 import type {AgentEvent, StartError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {agyChildrenStub, agyLayerOver, type StubChild} from "./child-stub.ts";
@@ -51,6 +51,28 @@ const signalled = (child: StubChild): Effect.Effect<void> =>
 		Effect.timeoutOrElse({
 			duration: "5 seconds",
 			orElse: () => Effect.die(new Error("the stop sent no signal")),
+		}),
+	);
+
+/** The refusal a failed call carries, as the two fields a test asserts on. */
+const causeError = (exit: Exit.Exit<unknown, unknown>): {_tag?: string; reason?: string} =>
+	Exit.isFailure(exit)
+		? ((Option.getOrUndefined(Cause.findErrorOption(exit.cause)) ?? {}) as {
+				_tag?: string;
+				reason?: string;
+			})
+		: {};
+
+/** Every line one stub child really took on stdin, waited for rather than sampled once. */
+const writtenTo = (child: StubChild): Effect.Effect<ReadonlyArray<string>> =>
+	Effect.flatMap(child.written, (lines) =>
+		lines.length === 0
+			? Effect.andThen(Effect.sleep("5 millis"), writtenTo(child))
+			: Effect.succeed(lines),
+	).pipe(
+		Effect.timeoutOrElse({
+			duration: "5 seconds",
+			orElse: () => Effect.succeed<ReadonlyArray<string>>([]),
 		}),
 	);
 
@@ -180,6 +202,96 @@ describe("an agy turn the operator stops", () => {
 				assert.isEmpty(
 					after.filter((event) => event.kind === "phase" && event.phase === "gone"),
 					"the second press narrated a session the layer went on to keep",
+				);
+			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
+		}),
+	);
+
+	/**
+	 * Where the window is, and what is in it.
+	 *
+	 * Driven to the one instant the issue's own flow lands in: the terminal `result` has published
+	 * `ready`, so the operator's hand is free, and the relaunch is past its teardown and waiting on the
+	 * new child's `init`. `session` holds the torn-down child there — its stdin queue is shut down, and
+	 * an offer onto a queue that is not `Open` answers `false` rather than failing, so a send admitted
+	 * here would be dropped with its key burned and nothing left to settle it (#8709). Returns the
+	 * stopped child, the relaunching one, and the stop still in flight.
+	 */
+	const inTheRelaunchWindow = (children: {
+		readonly child: (index: number) => Effect.Effect<StubChild>;
+		readonly launches: Effect.Effect<ReadonlyArray<ReadonlyArray<string>>>;
+	}) =>
+		Effect.gen(function* () {
+			const agent = yield* TuvalAiAgent;
+			yield* opened(children);
+			const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+			yield* agent.prompt("something long");
+			yield* collectTo(events, "the turn's prompting", isPrompting);
+
+			const stopping = yield* Effect.forkChild(agent.interrupt);
+			const first = yield* children.child(0);
+			yield* signalled(first);
+			yield* first.say(userInput);
+			yield* first.say(resultInterrupted);
+			yield* collectTo(events, "the stop's ready", isReady);
+			yield* first.exit(1);
+			const second = yield* children.child(1);
+			return {agent, events, stopping, first, second};
+		});
+
+	it.live("refuses a send that arrives inside the relaunch, and writes it to no stdin", () =>
+		Effect.gen(function* () {
+			const children = yield* agyChildrenStub;
+
+			yield* Effect.gen(function* () {
+				const {agent, first, second, stopping} = yield* inTheRelaunchWindow(children);
+
+				const refused = causeError(yield* Effect.exit(agent.prompt("resent text", "resend-key")));
+				assert.strictEqual(
+					refused._tag,
+					"tuval/ai-agent/PromptError",
+					"the send inside the relaunch was admitted",
+				);
+				// `no-session` and not `disconnected`: `sends.ts` settles the first `refused` and the
+				// second `uncertain`, and only `refused` renders the unsent bar the text comes back from.
+				assert.strictEqual(refused.reason, "no-session");
+				assert.deepStrictEqual(
+					(yield* first.written).filter((line) => line.includes("resent text")),
+					[],
+					"the refused send was written to the torn-down child's stdin",
+				);
+
+				yield* second.say(init);
+				yield* Fiber.join(stopping);
+			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
+		}),
+	);
+
+	it.live("closes the window: the next send crosses on the child the relaunch opened", () =>
+		Effect.gen(function* () {
+			const children = yield* agyChildrenStub;
+
+			yield* Effect.gen(function* () {
+				const {agent, events, second, stopping} = yield* inTheRelaunchWindow(children);
+				// Refused first, so the key this send carries is one a refusal has already been asked
+				// to leave unburned — a send dropped silently would have burned it and this would be
+				// deduped into nothing.
+				yield* Effect.exit(agent.prompt("resent text", "resend-key"));
+
+				yield* second.say(init);
+				yield* Fiber.join(stopping);
+				yield* collectTo(events, "the relaunched session at ready", isReady);
+
+				yield* agent.prompt("resent text", "resend-key");
+				const crossed = yield* writtenTo(second);
+				assert.isTrue(
+					crossed.some((line) => line.includes("resent text")),
+					`the send after the relaunch reached no child; saw ${JSON.stringify(crossed)}`,
+				);
+				assert.strictEqual(
+					(yield* children.launches).length,
+					2,
+					"the send after the relaunch launched a child of its own",
 				);
 			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
 		}),

--- a/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
@@ -14,7 +14,7 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Fiber, Option, Queue, Stream} from "effect";
+import {Effect, Fiber, Option, Queue, Scheduler, Stream} from "effect";
 import type {AgentEvent, StartError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {agyChildrenStub, agyLayerOver, type StubChild} from "./child-stub.ts";
@@ -124,6 +124,62 @@ describe("an agy turn the operator stops", () => {
 				assert.isTrue(
 					after.some(isInterruptedItem),
 					"the cut reply lost its interrupted mark across the relaunch",
+				);
+			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
+		}),
+	);
+
+	/**
+	 * Two stops that interleave, rather than one after the other.
+	 *
+	 * The sequential second press is covered above; this is the one a read-then-write guard lets
+	 * through (#8883). Two forked `interrupt` fibers would otherwise each run their synchronous steps
+	 * straight to the first async boundary and never interleave, so the yield budget is cut to 3: at
+	 * that value the run loop really does suspend one fiber inside the guard — with the read-then-write
+	 * guard in place this test sees two SIGINTs and three launches. Three, not 1 or 2, because a
+	 * budget under 3 starves the fibers entirely and no signal is ever sent.
+	 */
+	it.live("claims the stop once when two presses interleave", () =>
+		Effect.gen(function* () {
+			const children = yield* agyChildrenStub;
+
+			yield* Effect.gen(function* () {
+				const agent = yield* TuvalAiAgent;
+				yield* opened(children);
+				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
+				yield* agent.prompt("something long");
+				yield* collectTo(events, "the turn's prompting", isPrompting);
+
+				const stopping = yield* Effect.forkChild(
+					Effect.all([agent.interrupt, agent.interrupt], {
+						concurrency: "unbounded",
+						discard: true,
+					}).pipe(Effect.provideService(Scheduler.MaxOpsBeforeYield, 3)),
+				);
+				const first = yield* children.child(0);
+				yield* signalled(first);
+				yield* first.say(userInput);
+				yield* first.say(resultInterrupted);
+				yield* first.exit(1);
+				yield* Effect.flatMap(children.child(1), (child) => child.say(init));
+				yield* Fiber.join(stopping);
+
+				assert.deepStrictEqual(
+					yield* first.signals,
+					["SIGINT"],
+					"an interleaved second press sent its own signal",
+				);
+				const launches = yield* children.launches;
+				assert.strictEqual(
+					launches.length,
+					2,
+					"the interleaved presses relaunched more than once: the child the first stop reopened was torn down again",
+				);
+				assert.include(launches[1] ?? [], `--conversation=${CONVERSATION}`);
+				const after = yield* collectTo(events, "the session back at ready", isReady);
+				assert.isEmpty(
+					after.filter((event) => event.kind === "phase" && event.phase === "gone"),
+					"the second press narrated a session the layer went on to keep",
 				);
 			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
 		}),

--- a/apps/tuval/src/agy/ai-agent/refusals.ts
+++ b/apps/tuval/src/agy/ai-agent/refusals.ts
@@ -42,6 +42,20 @@ export const noSession = (): PromptError =>
 		detail: "start has not opened an agy session on this layer",
 	});
 
+/**
+ * A send that arrived while the child it would have crossed on was being replaced.
+ *
+ * `no-session` rather than `disconnected`, and that choice is the whole point of the refusal: the
+ * relaunch window is the one moment the layer knows for certain no text crossed, and `sends.ts`
+ * settles a `no-session` prompt failure `refused`, which is what renders the unsent bar the operator
+ * can Restore or Discard from (#8709).
+ */
+export const relaunchInFlight = (): PromptError =>
+	new PromptError({
+		reason: "no-session",
+		detail: "agy is being relaunched on this conversation, so the send did not reach it",
+	});
+
 /** A turn this layer refused before it reached stdin — see `launch.ts`'s `promptLine`. */
 export const malformedPrompt = (detail: string): PromptError =>
 	new PromptError({reason: "refused", detail});

--- a/apps/tuval/src/shell/chat/ChatWindow.tsx
+++ b/apps/tuval/src/shell/chat/ChatWindow.tsx
@@ -1070,10 +1070,19 @@ function ChatWindow({
 	}, [interruption, options.now]);
 
 	const lastPrompt = state?.lastPrompt ?? null;
+	// A resend is a send, so it is held under its own key exactly as the composer's is: the text the
+	// layer never took is the operator's to take back, and a resend that kept no copy of it was a
+	// silent no-op over any transport that had gone (#8709).
 	const resend = useCallback(() => {
 		if (lastPrompt === null) return;
-		dispatch({type: "prompt", text: lastPrompt, key: options.newKey(), timestamp: options.now()});
-	}, [dispatch, lastPrompt, options.newKey, options.now]);
+		const key = options.newKey();
+		dispatch({type: "prompt", text: lastPrompt, key, timestamp: options.now()});
+		commit((current) => ({
+			...current,
+			pinned: true,
+			outgoing: holdSend(current.outgoing, {key, text: lastPrompt}),
+		}));
+	}, [commit, dispatch, lastPrompt, options.newKey, options.now]);
 
 	const onKeyDown = useCallback(
 		(event: ReactKeyboardEvent<HTMLDivElement>) => {

--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -1485,6 +1485,47 @@ describe("an interrupted turn", () => {
 		});
 	});
 
+	// A resend over a transport that has gone is the case this bookkeeping exists for: the core
+	// refuses a prompt at any phase but `ready`, and a resend holding no copy of its text had nothing
+	// for that refusal to settle — no unsent row, no Restore, no trace at all (#8709).
+	it("holds the resent text under its key, so a resend nobody took is recoverable", async () => {
+		const {process, keys, view} = await openWindow(interrupted);
+		await act(async () => {
+			fireEvent.click(await screen.findByRole("button", {name: /Resend/}));
+		});
+		const key = keys[0] ?? "";
+		await waitFor(() => expect(view().outgoing).toEqual([{key, text: "go"}]));
+
+		await act(async () => {
+			await Effect.runPromise(
+				process.commit({
+					...interrupted,
+					phase: "gone",
+					sends: [
+						{
+							key,
+							state: "refused",
+							failure: {
+								tag: PROMPT_ERROR,
+								reason: "refused",
+								detail: "the session is not accepting prompts",
+							},
+						},
+					],
+				}),
+			);
+		});
+
+		expect(await screen.findByText("This message was not sent.")).toBeDefined();
+		const unsent = within(screen.getByRole("list", {name: "Unsent messages"}));
+		expect(unsent.getByText("go")).toBeDefined();
+		await act(async () => {
+			fireEvent.click(unsent.getByRole("button", {name: "Restore"}));
+		});
+		await waitFor(() => expect(view().draft).toBe("go"));
+		expect(view().outgoing).toEqual([]);
+	});
+
 	it("resends on Alt+R from the composer, and on nothing else", async () => {
 		const {process} = await openWindow(interrupted);
 		await act(async () => {


### PR DESCRIPTION
Escape on a working `agy` turn used to end the session for good: the SIGINT killed the child, the
exit watch walked the window to `The session is gone.` and failed the event stream, and the live-looking
affordances left on that dead end — composer, pickers, `Resend Alt+R` — could do nothing. Two defects,
fixed in their own layers.

**1 — the stop relaunches the child.** `interrupt` now does what the three setting switches already
did: after the signal it awaits the fold, then `respawn`s on `--conversation=<id>`. The conversation
and the window's event queue both carry, so the stop lands back on `Ready.` with a live child and the
cut reply keeps the `interrupted` mark `mapper.ts` read off agy's terminal `result`. The exit watch
gates its `gone` + `Queue.fail` on the layer's own memory of *which child* it signalled — an exit nobody
asked for still ends the stream, which the second unit case pins. A refused signal gives that memory
back (a signal that never went must not speak for the next exit), and a second Escape while the stop is
in flight sends nothing: it would otherwise clear the claim the pending relaunch depends on.

The restore defect falls out of this one. `resumeMessages` dispatches nothing only at `phase: "gone"`
(`apps/tuval/src/ai-agent/restore/checkpoint.ts`), and a stop no longer reaches that phase — the
checkpoint holds `ready` with its session id, so the reboot takes the `reconnect` route every other
checkpoint takes (already pinned in `apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts`).

**2 — a resend is held like any other send.** `resend` now mints its key *and* holds the text under
it, the way the composer's `onPrompt` does. The core refuses a prompt at any phase but `ready` and
settles that send `refused`, so a resend the layer never took renders as `This message was not sent.`
with Restore / Discard instead of vanishing. It still mints a fresh key and never reuses the cut
turn's.

**3 — a send inside the relaunch is refused rather than dropped.** `ready` is published off the
terminal `result`, which lands *before* `respawn` has torn the old child down and awaited the new
one's `init`: in that span `session` still holds the dead child, and `Queue.offer` onto its shut-down
stdin answers `false` rather than failing (`effect`'s `Queue.ts`), so Escape-then-`Alt+R` used to burn
its idempotency key, write nowhere and leave the send `pending` with nothing left to settle it — no
bar, no Restore, no Discard. The relaunch is now a span `prompt` can see: a `relaunching` flag held
from the delivered signal through to the session the relaunch reopened, and a prompt across it raises
the `no-session` refusal, which `sends.ts` settles `refused` — the one outcome that renders the text
back as Restore / Discard. Given back on every exit, a failed or interrupted relaunch included, and
`announce` runs outside it so the `ready` it ends on is never answered by a refusal (criterion 8).

Grounding: `kill` resolving on the exit it asked for is read off
`@effect/platform-node-shared`'s `NodeChildProcessSpawner` at the rc.112 pin (`kill` → `killProcessGroup`
→ `Deferred.await(exitSignal)`), and its release finalizer's already-exited branch is why the relaunch's
`teardown` of a dead child is safe.

Verification: `pnpm vitest run` in `apps/tuval` — 3130 passed. The integration case drives the whole
path over a real SIGINT against the scripted binary, and the new unit case fails (times out on a
window that never comes back) against the pre-change layer.

Fixes #8709

## Deviations

- **Out-of-scope change** — **Said:** #8709 names the respawn and the resend bookkeeping. **Did:**
  also made `interrupt` drop a second press while a stop is in flight. **Why:** the relaunch reads
  one flag to know the exit was its own, and a second press reset that flag mid-stop, which failed
  the queue the fix exists to keep — the fix is incomplete without it. **Disposition:** stated here,
  and covered in `interrupt-respawn.unit.test.ts`.

- **Guard is wider than the criterion's wording** — **Said:** criterion 8 names a flag "around
  `respawn`'s teardown-to-`Ref.set(session, reopened)` span". **Did:** set it from the delivered signal
  instead, so it also covers `Fiber.await` of the dying child's fan. **Why:** the cut turn's `result`
  publishes `ready` *before* that exit, so the window is free to send from the instant the signal lands
  — a guard that started at the teardown would still have an unsettlable gap in front of it.
  **Disposition:** stated here; `respawn`'s own span is guarded too, which is what also covers the
  three setting switches.
- **Secondary review note taken** — **Said:** the review marked "bind the stop to the child it was sent
  to" non-blocking. **Did:** replaced the layer-wide `interrupted` boolean with the signalled child's
  handle (`Ref.modify` still claims it in one step). **Why:** a relaunch whose `openSession` failed left
  the boolean stale-`true`, and the next child's own death then read as a stop nobody sent — `gone` and
  the queue failure both skipped. **Disposition:** stated here; the existing interrupt cases cover the
  claim, and no new surface is added.
- **Test-stub change** — **Said:** nothing about the stub spawner. **Did:** `child-stub.ts` now runs the
  command's stdin stream into a recording sink, the way the real spawner does, and `StubChild` exposes
  `written`. **Why:** a dropped send and a delivered one are indistinguishable from outside unless the
  stub consumes stdin; both new cases assert on which child the text crossed. **Disposition:** stated
  here, test-only.