### PR TITLE
fix: An interrupt landing before any reply text leaves the cut turn with no Resend control

### DIFF
--- a/apps/tuval/src/ai-agent/core/fold.ts
+++ b/apps/tuval/src/ai-agent/core/fold.ts
@@ -28,9 +28,7 @@ import {markTurnRunning, settleAccepted, settleEndedSession, settleFailedTurn} f
 import {
 	type AiAgentSessionState,
 	closeOfferedCatalogs,
-	cutReplyAfterItem,
 	emptyOmission,
-	lastAssistantId,
 	settleTurn,
 	type UsageLedger,
 } from "./state.ts";
@@ -83,6 +81,23 @@ export const upsertItem = (
 	return at < 0
 		? [...items, item]
 		: items.map((candidate, index) => (index === at ? item : candidate));
+};
+
+/**
+ * The cut-turn marker after one item folded: a row the echo join re-keys takes the marker with it.
+ *
+ * The marker names the operator's own prompt (`cutPromptId`, #8699) and the echo join replaces that
+ * row with the layer's copy under the layer's own id, so the marker would otherwise name a row no
+ * longer in the tail — the Resend gone the moment the backend echoed the very prompt it is for.
+ * This follows a re-key and decides nothing: with no marker standing there is nothing to move, and
+ * an incoming row that supersedes some other item leaves it alone.
+ */
+const reanchored = (state: AiAgentSessionState, item: TranscriptItem): ItemId | null => {
+	if (state.interrupted === null) return null;
+	const echo = echoOf(state.transcript.items, item);
+	return echo >= 0 && state.transcript.items[echo]?.id === state.interrupted
+		? item.id
+		: state.interrupted;
 };
 
 const addOmission = (carried: WindowOmission, dropped: WindowOmission): WindowOmission => ({
@@ -310,6 +325,10 @@ export const phaseAfterFailure = (
  * late, and the send it belonged to has no other event coming to accept it. `settleFailedTurn` is
  * the wrong settle here and stays unused on both halves: this failure names the interrupt call
  * rather than a send, which is why `sendAfterFailure` (`./sends.ts`) answers `null` for the tag.
+ *
+ * Neither half touches `interrupted`. The `interrupt` cell anchors the marker on the operator's own
+ * prompt at the press, so by the time a refusal can arrive it is already set, and a second decider
+ * here could only re-point it at a reply — which is the anchor #8699 moved away from.
  */
 export const foldInterruptRefusal = (
 	state: AiAgentSessionState,
@@ -322,7 +341,6 @@ export const foldInterruptRefusal = (
 	return {
 		...turn,
 		phase: "ready",
-		interrupted: turn.interrupted ?? lastAssistantId(turn.transcript.items),
 		interruption: null,
 		failure,
 		sends: settleAccepted(turn.sends),
@@ -338,7 +356,7 @@ export const foldEvent = (
 		case "item":
 			return {
 				...state,
-				interrupted: cutReplyAfterItem(state, event.item),
+				interrupted: reanchored(state, event.item),
 				transcript: foldItem(state.transcript, event.item, limits),
 			};
 		// The phase line is also where a send in flight learns it crossed, and it takes two events

--- a/apps/tuval/src/ai-agent/core/fold.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/fold.unit.test.ts
@@ -280,16 +280,20 @@ describe("folding a failure and a `gone` under two sends in flight", () => {
 /**
  * ADR 0356's two halves. The tag is routed before `phaseAfterFailure`, so neither of these is the
  * walk-to-`ready` every other failure gets — one of them stays put, and the other lands there for a
- * different reason and marks the turn on the way.
+ * different reason, settling the turn and its send on the way.
  */
 describe("folding a refused interrupt", () => {
 	const limits: WindowLimits = {};
 	const refusal = (reason: string, detail: string) => ({tag: INTERRUPT_ERROR, reason, detail});
+	const cutPrompt = userItem("u0");
 	const reply = assistantItem("a1");
+	// As the press leaves it: the marker is already on the operator's prompt, so neither half of this
+	// fold has an anchor to choose (#8699).
 	const prompting: AiAgentSessionState = {
 		...initialState("/repo"),
 		phase: "prompting",
-		transcript: {items: [reply], omitted: {items: 0, bytes: 0, reason: "none"}},
+		transcript: {items: [cutPrompt, reply], omitted: {items: 0, bytes: 0, reason: "none"}},
+		interrupted: cutPrompt.id,
 		interruption: {requestedAt: 1_700_000_000_000},
 		sends: [{key: "first", state: "pending", turn: "running"}],
 	};
@@ -300,7 +304,7 @@ describe("folding a refused interrupt", () => {
 		expect(refused.phase).toBe("prompting");
 		expect(refused.failure).toEqual(failure);
 		expect(refused.interruption).toEqual(prompting.interruption);
-		expect(refused.interrupted).toBeNull();
+		expect(refused.interrupted).toBe(cutPrompt.id);
 	});
 
 	// The turn goes on, so the send it is about goes on too: this failure names the interrupt call
@@ -317,7 +321,7 @@ describe("folding a refused interrupt", () => {
 		const failure = refusal("no-live-turn", "Operation aborted");
 		const refused = foldEvent(prompting, {kind: "failure", failure}, limits);
 		expect(refused.phase).toBe("ready");
-		expect(refused.interrupted).toBe(reply.id);
+		expect(refused.interrupted).toBe(cutPrompt.id);
 		expect(refused.interruption).toBeNull();
 		expect(refused.failure).toEqual(failure);
 	});

--- a/apps/tuval/src/ai-agent/core/index.ts
+++ b/apps/tuval/src/ai-agent/core/index.ts
@@ -78,6 +78,7 @@ export {
 	type CheckpointField,
 	checkpointFields,
 	checkpointWorthy,
+	cutPromptId,
 	emptyUsage,
 	type HistoryPage,
 	holdsPartialItem,

--- a/apps/tuval/src/ai-agent/core/machine.ts
+++ b/apps/tuval/src/ai-agent/core/machine.ts
@@ -53,8 +53,8 @@ import {loadCheckpoint} from "./snapshot.ts";
 import {
 	type AgentFailure,
 	type AiAgentSessionState,
+	cutPromptId,
 	initialState,
-	lastAssistantId,
 	settleTurn,
 } from "./state.ts";
 
@@ -433,6 +433,12 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 			 * long the interruption has been outstanding, and that clock starts when they first
 			 * asked.
 			 *
+			 * It is anchored on the operator's own prompt (`cutPromptId`), so it lands at the press on
+			 * every turn — including one cut before the model wrote a token, and one whose content was
+			 * tool calls alone and so never draws a reply row at all. Anchored on the reply it left
+			 * those turns with no way back, and left every other one waiting on a backend row to render
+			 * the affordance the operator had just asked for (#8699).
+			 *
 			 * The queue goes, because an operator asking a turn to stop is not asking the next queued
 			 * one to start. It is released rather than dropped, so every word is still theirs to take
 			 * back (`./queue.ts`).
@@ -443,7 +449,7 @@ export const aiAgentSessionMachine = (options: AiAgentSessionOptions): AiAgentSe
 					: [
 							{
 								...state,
-								interrupted: state.interrupted ?? lastAssistantId(state.transcript.items),
+								interrupted: state.interrupted ?? cutPromptId(state.transcript.items),
 								interruption: state.interruption ?? {requestedAt: msg.at},
 								queued: [],
 								sends: releaseQueued(

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -966,6 +966,19 @@ describe("interrupt", () => {
 		expect(landed.interrupted).toBeNull();
 	});
 
+	// #8753's path, closed by construction: a compaction re-emits the whole transcript as item events
+	// under a phase that still reads as `prompting`, so an *older* aborted row folds first. With the
+	// marker on the prompt there is no first-wins race left for it to win.
+	it("lets a replayed older aborted row take nothing, however many fold under the open request", () => {
+		const [asked] = apply(cutBeforeAnyText(), {type: "interrupt", at: SENT_AT});
+		const replayed = [abortedItem("older-1"), abortedItem("older-2"), abortedItem("a3")].reduce(
+			(carried, msg) => apply(carried, msg)[0],
+			asked,
+		);
+		expect(replayed.interrupted).toBe("u2");
+		expect(replayed.interruption).toEqual({requestedAt: SENT_AT});
+	});
+
 	// The resend is a fresh send, and the turn it belonged to is behind the operator by then.
 	it("drops the marker when the operator sends again", () => {
 		const [asked] = apply(cutBeforeAnyText(), {type: "interrupt", at: SENT_AT});

--- a/apps/tuval/src/ai-agent/core/machine.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/machine.unit.test.ts
@@ -73,13 +73,18 @@ describe("init", () => {
 		// `idle`, not `reconnecting`: a booted process holds no transport, and `idle` is the phase a
 		// `reconnect` Msg is admissible from (`../restore/checkpoint.ts`).
 		expect(state.phase).toBe("idle");
-		expect(state.interrupted).toBe("a1");
+		// The marker rides the prompt, and the reply the restart cut carries the flag its fold label
+		// is read off (#8699).
+		expect(state.interrupted).toBe("u0");
+		const cut = state.transcript.items.at(-1);
+		expect(cut?.kind === "assistant" && cut.interrupted === true).toBe(true);
 		expect(cmds).toEqual([]);
 	});
 
 	// The same restart, over a turn that had written nothing of its own yet — the tail ends on the
-	// operator's prompt. The reply above it belongs to the turn before and is not what got cut.
-	it("marks no cut reply when the restart caught a turn that had written none", () => {
+	// operator's prompt. The reply above it belongs to the turn before, so nothing is badged as cut
+	// short, and the marker still lands: that prompt is what the operator gets back (#8699).
+	it("marks no cut reply when the restart caught a turn that had written none, and still offers it back", () => {
 		const loaded = started({
 			phase: "prompting",
 			transcript: {
@@ -88,7 +93,12 @@ describe("init", () => {
 			},
 		});
 		const [state] = machine.init(loaded, {});
-		expect(state.interrupted).toBeNull();
+		expect(state.interrupted).toBe("u2");
+		expect(
+			state.transcript.items.every(
+				(item) => item.kind !== "assistant" || item.interrupted !== true,
+			),
+		).toBe(true);
 	});
 
 	// The rehydrate branch is the defaulting parse and nothing else, so what the store read back is
@@ -885,14 +895,15 @@ describe("interrupt", () => {
 		const [state, cmds] = apply(running(), {type: "interrupt", at: SENT_AT});
 		expect(state.phase).toBe("prompting");
 		expect(state.interruption).toEqual({requestedAt: SENT_AT});
-		expect(state.interrupted).toBe("a1");
+		expect(state.interrupted).toBe("u0");
 		expect(cmds).toEqual([{type: "aiAgent.interrupt"}]);
 	});
 
-	// Turn 1 answered in prose and settled; turn 2's content is tool calls alone, which draws no
-	// assistant row at all (#8216). The stop belongs to turn 2, so turn 1's finished reply — sitting
-	// above the operator's second prompt — must not come back badged as cut short.
-	it("marks nothing when the running turn wrote no reply of its own", () => {
+	// #8699's whole case, and the one the old anchor had no answer for: turn 1 answered in prose and
+	// settled; turn 2's content is tool calls alone, which draws no assistant row at all (#8216).
+	// Reading the reply answered `null` here — turn 1's finished reply must not come back badged as
+	// cut short — and the operator got no Resend. The prompt is there either way.
+	it("marks the prompt of a running turn that wrote no reply of its own", () => {
 		const toolOnly = running({
 			transcript: {
 				items: [userItem("u0"), assistantItem("a1"), userItem("u2"), toolItem("t3")],
@@ -900,9 +911,24 @@ describe("interrupt", () => {
 			},
 		});
 		const [state, cmds] = apply(toolOnly, {type: "interrupt", at: SENT_AT});
-		expect(state.interrupted).toBeNull();
+		expect(state.interrupted).toBe("u2");
 		expect(state.interruption).toEqual({requestedAt: SENT_AT});
 		expect(cmds).toEqual([{type: "aiAgent.interrupt"}]);
+	});
+
+	// The same press over a transcript whose tail *is* the prompt: no assistant item exists at all,
+	// and none is needed to get the marker (#8699).
+	it("marks a turn whose tail is the prompt, with no assistant item anywhere", () => {
+		const [state] = apply(
+			running({
+				transcript: {
+					items: [userItem("u0")],
+					omitted: initialState("/x").transcript.omitted,
+				},
+			}),
+			{type: "interrupt", at: SENT_AT},
+		);
+		expect(state.interrupted).toBe("u0");
 	});
 
 	const abortedItem = (id: string, text = ""): AiAgentSessionMsg => ({
@@ -919,36 +945,29 @@ describe("interrupt", () => {
 			},
 		});
 
-	// The other half of the case above: the stop had no row to mark, so the `aborted` row the
-	// backend pushes afterwards is the only thing that ever names the cut turn's reply (#8584).
-	it("takes the marker from the aborted row when the stop had no reply to name", () => {
+	// The marker is the operator's act, already recorded at the press, so the `aborted` row the
+	// backend pushes afterwards has nothing left to supply and may not re-point it. #8747 let it,
+	// which is how a replayed abort could steal the marker (#8753).
+	it("leaves the marker on the prompt when the aborted row lands afterwards", () => {
 		const [asked] = apply(cutBeforeAnyText(), {type: "interrupt", at: SENT_AT});
 		const [landed] = apply(asked, abortedItem("a3"));
-		expect(landed.interrupted).toBe("a3");
+		expect(landed.interrupted).toBe("u2");
 		// The phase line settles after the item within one revision (`../../pi/ai-agent/items.ts`),
-		// so the marker the row supplied is what the window reads once the turn is over.
+		// so that is still what the window reads once the turn is over.
 		const [over] = apply(landed, phaseEvent("ready"));
-		expect(over.interrupted).toBe("a3");
+		expect(over.interrupted).toBe("u2");
 		expect(over.interruption).toBeNull();
 	});
 
-	it("keeps the reply the stop already named rather than following a later aborted row", () => {
-		const [asked] = apply(running(), {type: "interrupt", at: SENT_AT});
-		const [landed] = apply(asked, abortedItem("a3"));
-		expect(landed.interrupted).toBe("a1");
-	});
-
-	// A snapshot replaying an old interruption's row, or a session that has since moved on: no
-	// request is outstanding, so nothing here is the answer to one and the resend stays unoffered.
-	it("ignores an aborted row that arrives under no outstanding request", () => {
+	// A snapshot replaying an old interruption's row, or a session that has since moved on: no press
+	// of the operator's stands here, so no marker does either.
+	it("marks nothing for an aborted row that answers no press of the operator's", () => {
 		const [landed] = apply(started(), abortedItem("a3"));
 		expect(landed.interrupted).toBeNull();
-		const [after] = apply(cutBeforeAnyText(), abortedItem("a3"));
-		expect(after.interrupted).toBeNull();
 	});
 
-	// The resend is a fresh send, and the row it belonged to is two turns back by then.
-	it("drops the row-supplied marker when the operator sends again", () => {
+	// The resend is a fresh send, and the turn it belonged to is behind the operator by then.
+	it("drops the marker when the operator sends again", () => {
 		const [asked] = apply(cutBeforeAnyText(), {type: "interrupt", at: SENT_AT});
 		const [landed] = apply(asked, abortedItem("a3"));
 		const [over] = apply(landed, phaseEvent("ready"));
@@ -1001,7 +1020,7 @@ describe("interrupt", () => {
 		const [confirmed] = apply(asked, phaseEvent("ready"));
 		expect(confirmed.phase).toBe("ready");
 		expect(confirmed.interruption).toBeNull();
-		expect(confirmed.interrupted).toBe("a1");
+		expect(confirmed.interrupted).toBe("u0");
 	});
 
 	it("settles the request on a failed turn too, since that turn has stopped as well", () => {

--- a/apps/tuval/src/ai-agent/core/state.ts
+++ b/apps/tuval/src/ai-agent/core/state.ts
@@ -435,13 +435,37 @@ export const checkpointWorthy = (state: AiAgentSessionState): boolean =>
 	!holdsPartialItem(state) && !holdsRunningSubagent(state);
 
 /**
- * The reply row of the turn in flight, which is the one an interrupt or a restart can have cut.
+ * The operator's prompt for the turn in flight: the row a cut turn's Resend is anchored on.
  *
- * Scoped to the newest `user` row deliberately: a turn whose content was tool calls alone draws no
- * assistant row at all (`../pi/items.ts` suppresses it), so a scan that walked past the operator's
- * prompt would answer with the *previous* turn's finished reply and badge it as cut short (#8216).
- * `null` is the right answer there — the turn has no row to mark, and `state.interruption` plus the
- * `aborted` row the backend pushes already carry the indication.
+ * The anchor is the prompt rather than the reply because Escape must always leave a way back, and
+ * the reply is the one row that may not exist yet — or ever. A turn cut before the model wrote a
+ * token has no assistant row at the press, and a turn whose content was tool calls alone draws none
+ * at all (`../pi/items.ts` suppresses it), so an anchor read off the reply is missing in exactly the
+ * case the operator stopped fastest (#8699). The prompt is in the tail from the send: the `prompt`
+ * cell folds a local echo of it before the layer is called, and `planTranscriptWindow` admits the
+ * newest turn's group whole whatever the bounds, so at `prompting` this answers.
+ *
+ * `null` therefore means the tail holds no prompt at all — no turn here to offer back.
+ */
+export const cutPromptId = (items: ReadonlyArray<TranscriptItem>): ItemId | null => {
+	for (let index = items.length - 1; index >= 0; index -= 1) {
+		const item = items[index];
+		if (item?.kind === "user") return item.id;
+	}
+	return null;
+};
+
+/**
+ * The reply row of the turn in flight: the row a cut turn's "You stopped this response" fold label
+ * is read off, once `markInterrupted` has flagged it.
+ *
+ * This names the *mark*, never the resend anchor — `cutPromptId` owns that. Scoped to the newest
+ * `user` row deliberately: a turn whose content was tool calls alone draws no assistant row at all
+ * (`../pi/items.ts` suppresses it), so a scan that walked past the operator's prompt would answer
+ * with the *previous* turn's finished reply and badge it as cut short (#8216). `null` is still the
+ * right answer there — that turn has no row to mark, and badging another turn's reply is the defect.
+ * What `null` no longer costs is the resend, which rides the prompt and lands whether a reply does
+ * or not.
  */
 export const lastAssistantId = (items: ReadonlyArray<TranscriptItem>): ItemId | null => {
 	for (let index = items.length - 1; index >= 0; index -= 1) {
@@ -450,28 +474,6 @@ export const lastAssistantId = (items: ReadonlyArray<TranscriptItem>): ItemId | 
 		if (item?.kind === "assistant") return item.id;
 	}
 	return null;
-};
-
-/**
- * Where the cut-turn marker stands once one more item has landed.
- *
- * `lastAssistantId` answers `null` for a turn cut before it wrote anything, so on that path the
- * marker is set here instead — by the `aborted` row the backend pushes afterwards, which is the
- * only thing that ever names that turn's reply (#8584). Without it the row rendered plain: no
- * break, no resend, for the one turn the operator definitely stopped.
- *
- * The outstanding `interruption` is the whole gate. It is the operator's request with no event
- * against it yet, so an `aborted` row arriving under one is that request's answer; a historical
- * abort replayed by a snapshot arrives under none and leaves the marker alone. A marker already set
- * stands, so this never re-points the resend away from the row `interrupt` or `restore` chose.
- */
-export const cutReplyAfterItem = (
-	state: AiAgentSessionState,
-	item: TranscriptItem,
-): ItemId | null => {
-	if (state.interrupted !== null) return state.interrupted;
-	if (state.interruption === null) return null;
-	return item.kind === "assistant" && item.interrupted === true ? item.id : null;
 };
 
 /** The cut-short turn, marked in the tail so a window renders the break off the transcript alone. */
@@ -541,7 +543,11 @@ const markInterrupted = (
  * reconnect is a Msg the spawner dispatches (`../restore/checkpoint.ts`), never one scheduled here.
  */
 export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
-	const cut = loaded.phase === "prompting" ? lastAssistantId(loaded.transcript.items) : null;
+	const interrupted = loaded.phase === "prompting";
+	// Two rows, one cut turn: the reply carries the mark its fold label is read off, the prompt
+	// carries the resend — and a turn that wrote no reply has only the second of them (#8699).
+	const reply = interrupted ? lastAssistantId(loaded.transcript.items) : null;
+	const cut = interrupted ? cutPromptId(loaded.transcript.items) : null;
 	const settled =
 		loaded.phase === "gone"
 			? closeOfferedCatalogs(settleRunningSubagents(loaded))
@@ -549,7 +555,7 @@ export const restore = (loaded: AiAgentSessionState): AiAgentSessionState => {
 	return {
 		...settled,
 		phase: loaded.phase === "gone" ? "gone" : "idle",
-		transcript: {...loaded.transcript, items: markInterrupted(loaded.transcript.items, cut)},
+		transcript: {...loaded.transcript, items: markInterrupted(loaded.transcript.items, reply)},
 		interrupted: cut ?? loaded.interrupted,
 		interruption: null,
 		agentVersion: null,

--- a/apps/tuval/src/ai-agent/core/state.unit.test.ts
+++ b/apps/tuval/src/ai-agent/core/state.unit.test.ts
@@ -19,6 +19,7 @@ import {
 	type AiAgentSessionState,
 	checkpointFields,
 	checkpointWorthy,
+	cutPromptId,
 	initialState,
 	lastAssistantId,
 	phases,
@@ -263,6 +264,21 @@ describe("reading the tail", () => {
 		expect(
 			lastAssistantId([userItem("i0"), assistantItem("i1"), userItem("i2"), toolItem("i3")]),
 		).toBeNull();
+	});
+
+	// The resend anchor (#8699). It answers on every tail the reply-scan above answers `null` for,
+	// which is the whole point: no assistant item is needed to get a marker.
+	it("names the newest prompt, whatever the turn above it wrote", () => {
+		expect(cutPromptId([userItem("i0"), assistantItem("i1"), toolItem("i2")])).toBe("i0");
+		expect(cutPromptId([userItem("i0"), assistantItem("i1"), userItem("i2"), toolItem("i3")])).toBe(
+			"i2",
+		);
+		expect(cutPromptId([userItem("i0")])).toBe("i0");
+	});
+
+	it("answers nothing only for a tail holding no prompt at all", () => {
+		expect(cutPromptId([])).toBeNull();
+		expect(cutPromptId([assistantItem("i1"), toolItem("i2")])).toBeNull();
 	});
 });
 

--- a/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/checkpoint.unit.test.ts
@@ -194,22 +194,24 @@ describe("restoring a saved session", () => {
 		expect(restore(saved).permissions).toEqual(saved.permissions);
 	});
 
-	it("marks the assistant turn the restart cut, in state and in the tail", () => {
+	// Two rows for one cut turn: the reply carries the flag the fold label is read off, the prompt
+	// carries the marker the resend is anchored on (#8699).
+	it("marks the assistant turn the restart cut, and anchors the resend on the prompt", () => {
 		const cut: AiAgentSessionState = {
 			...saved,
 			transcript: {...saved.transcript, items: [userItem("i0"), assistantItem("i1")]},
 		};
 		const restored = restore(cut);
-		expect(restored.interrupted).toBe("i1");
+		expect(restored.interrupted).toBe("i0");
 		expect(restored.transcript.items[1]).toEqual({...assistantItem("i1"), interrupted: true});
 	});
 
-	it("marks nothing when the cut turn had no assistant item yet", () => {
+	it("has nothing to flag when the cut turn had no assistant item yet, and still offers it back", () => {
 		const firstTurn: AiAgentSessionState = {
 			...saved,
 			transcript: {...saved.transcript, items: [userItem("i0")]},
 		};
-		expect(restore(firstTurn).interrupted).toBeNull();
+		expect(restore(firstTurn).interrupted).toBe("i0");
 		expect(restore(firstTurn).transcript.items).toEqual([userItem("i0")]);
 	});
 
@@ -247,7 +249,7 @@ describe("restoring a saved session", () => {
 		});
 		expect(restored.transcript.items).toHaveLength(2);
 		// The cut-short marking is the other half of a `prompting` checkpoint and is untouched by it.
-		expect(restored.interrupted).toBe("i1");
+		expect(restored.interrupted).toBe(promptItemId("k1"));
 		expect(restored.transcript.items[1]).toEqual({...assistantItem("i1"), interrupted: true});
 	});
 });

--- a/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore-proof.unit.test.ts
@@ -292,7 +292,7 @@ describe("the whole app, stopped mid-reply and booted back over its checkpoints"
 			outcome.second.afterReconnect,
 			"the restored window is not looking at the transcript the stop left",
 		).toEqual(afterTheCut);
-		expect(outcome.second.restored.interrupted).toBe("a3");
+		expect(outcome.second.restored.interrupted).toBe("u3");
 		const cut = outcome.second.restored.transcript.items.at(-1);
 		expect(
 			cut?.kind === "assistant" && cut.interrupted === true,

--- a/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
+++ b/apps/tuval/src/ai-agent/restore/restore.unit.test.ts
@@ -219,7 +219,7 @@ describe("a restored agent session", () => {
 			yield* resume(stores, script(), starts, (restored) =>
 				Effect.sync(() => {
 					assert.strictEqual(restored.sessionId, SESSION_ID);
-					assert.strictEqual(restored.interrupted, "a1");
+					assert.strictEqual(restored.interrupted, "u1");
 					assert.deepStrictEqual(
 						restored.transcript.items.map((item) => item.id),
 						["u1", "a1"],

--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -26,7 +26,11 @@ import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, type FileSystem, Queue, Result, Schema, Scope, Stream} from "effect";
 import {Socket} from "effect/unstable/socket";
-import type {AiAgentSessionMsg, AiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {
+	type AiAgentSessionMsg,
+	type AiAgentSessionState,
+	promptItemId,
+} from "../../ai-agent/core/index.ts";
 import {boot, projectDir} from "../../boot.ts";
 import {PI_SESSION_PROGRAM} from "../../pi/renderer-ref.ts";
 import {ProcessId} from "../../process/process.ts";
@@ -820,7 +824,7 @@ describe("a Claude session in the Tuval shell, end to end", () => {
 							);
 							assert.strictEqual(
 								restored.interrupted,
-								"a3",
+								promptItemId(PROMPT_3_KEY),
 								"the cut turn came back unmarked, so no window could offer the resend",
 							);
 

--- a/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
+++ b/apps/tuval/src/claude/restore/claude-restore-proof.unit.test.ts
@@ -22,7 +22,11 @@ import {NodeFileSystem} from "@effect/platform-node";
 import {assert} from "@effect/vitest";
 import {Effect, type FileSystem, Option, type Scope} from "effect";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
-import {type AiAgentSessionState, isAiAgentSessionState} from "../../ai-agent/core/index.ts";
+import {
+	type AiAgentSessionState,
+	isAiAgentSessionState,
+	promptItemId,
+} from "../../ai-agent/core/index.ts";
 import {aiAgentPortNames} from "../../ai-agent/handlers/index.ts";
 import type {
 	ModePayload,
@@ -353,7 +357,7 @@ describe("the claude-session row, driven through ports and booted back over its 
 			outcome.second.afterReconnect,
 			"the restored window is not looking at the transcript the stop left",
 		).toEqual(afterTheCut);
-		expect(outcome.second.restored.interrupted).toBe("a3");
+		expect(outcome.second.restored.interrupted).toBe(promptItemId(KEYS.cut));
 		const cut = outcome.second.restored.transcript.items.at(-1);
 		expect(
 			cut?.kind === "assistant" && cut.interrupted === true,

--- a/apps/tuval/src/pi/restore/interrupted.unit.test.ts
+++ b/apps/tuval/src/pi/restore/interrupted.unit.test.ts
@@ -68,7 +68,7 @@ describe("a pi-session checkpoint written mid-reply", () => {
 	it("comes back idle, with the cut turn marked so a window can offer the resend", () => {
 		const restored = restoreSession(cutMidReply);
 		assert.strictEqual(restored.phase, "idle");
-		assert.strictEqual(restored.interrupted, "item-1" as ItemId);
+		assert.strictEqual(restored.interrupted, "item-0" as ItemId);
 		const cut = restored.transcript.items.at(-1);
 		assert.isTrue(
 			cut?.kind === "assistant" && cut.interrupted === true,

--- a/apps/tuval/src/shell/chat/interrupted-textless-turn.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/interrupted-textless-turn.unit.test.tsx
@@ -1,9 +1,10 @@
 /**
  * @vitest-environment jsdom
  *
- * #8584's rendered half: a turn the operator cut before the model wrote anything. The stop has no
- * assistant row to name, so the marker comes from the `aborted` row the backend pushes afterwards
- * — and the window has to draw the break and the resend off it like any other cut turn.
+ * #8584's rendered half, re-anchored by #8699: a turn the operator cut before the model wrote
+ * anything. The stop has no assistant row to name, so the marker rides the operator's own prompt and
+ * is there from the press — the window draws the break and the resend off it like any other cut
+ * turn, including on a turn that never draws an assistant row at all.
  *
  * The state is folded by the real machine over events the Pi mapper produced, rather than written
  * by hand: the defect was the window and the core disagreeing about which row was cut, so a
@@ -97,17 +98,39 @@ const abortedTextlessTurn: PiTranscriptItem = {
 	stopReason: "aborted",
 };
 
-/** Prompt sent, Escape pressed, then the backend's report of the turn it stopped. */
-const cutBeforeAnyText = (): AiAgentSessionState => {
+/**
+ * The same turn as Pi reports it when its content was tool calls alone: `complete`, and with not one
+ * token of text — which `emptyReply` (`../../pi/ai-agent/items.ts`) suppresses, so the tail holds no
+ * assistant row for this turn at all and never will.
+ */
+const toolOnlyTurn: PiTranscriptItem = {
+	id: "item-1",
+	role: "assistant",
+	content: [{type: "toolCall", toolCallId: "call-0", toolName: "read", input: {path: "README"}}],
+	model: {provider: "faux", id: "faux-1"},
+	timestamp: 11,
+	status: "complete",
+	stopReason: "toolUse",
+};
+
+/** Prompt sent, Escape pressed, and nothing from the backend yet. */
+const atThePress = (): AiAgentSessionState => {
 	const sent = apply(sessionState({sessionId: SESSION}), {
 		type: "prompt",
 		text: "rewrite the README",
 		key: "k1",
 		timestamp: SENT_AT,
 	});
-	const asked = apply(sent, {type: "interrupt", at: SENT_AT + 500});
-	return pushed(asked, [prompt, abortedTextlessTurn], "idle", 1);
+	return apply(sent, {type: "interrupt", at: SENT_AT + 500});
 };
+
+/** Prompt sent, Escape pressed, then the backend's report of the turn it stopped. */
+const cutBeforeAnyText = (): AiAgentSessionState =>
+	pushed(atThePress(), [prompt, abortedTextlessTurn], "idle", 1);
+
+/** The same, for a turn whose only content was a call — so no reply row ever lands. */
+const cutWithToolCallsOnly = (): AiAgentSessionState =>
+	pushed(atThePress(), [prompt, toolOnlyTurn], "idle", 1);
 
 const openWindow = async (
 	state: AiAgentSessionState,
@@ -123,10 +146,30 @@ const openWindow = async (
 };
 
 describe("a turn cut before the model wrote anything", () => {
+	// #8699: the affordance is the operator's own act rendered back, so it is there on the press and
+	// owes nothing to a row the backend may send later — or never.
+	it("offers the resend from the press, with nothing yet heard from the backend", async () => {
+		await openWindow(atThePress());
+		expect(screen.getByText("interrupted")).toBeTruthy();
+		expect(screen.getByRole("button", {name: /Resend/})).toBeTruthy();
+	});
+
 	it("draws the break and offers the resend", async () => {
 		await openWindow(cutBeforeAnyText());
 		expect(screen.getByText("interrupted")).toBeTruthy();
 		expect(screen.getByRole("button", {name: /Resend/})).toBeTruthy();
+	});
+
+	// The turn that drew no reply row at all, and the case #8747's anchor had no answer for: its only
+	// content was a call, so `emptyReply` suppresses the assistant row and nothing the backend ever
+	// sends will name this turn's reply.
+	it("offers the resend on a turn whose content was tool calls alone", async () => {
+		const process = await openWindow(cutWithToolCallsOnly());
+		expect(screen.getByRole("button", {name: /Resend/})).toBeTruthy();
+		fireEvent.click(screen.getByRole("button", {name: /Resend/}));
+		expect(process.inbox()).toEqual([
+			expect.objectContaining({type: "prompt", text: "rewrite the README"}),
+		]);
 	});
 
 	it("resends the prompt that turn was answering, not some other one", async () => {


### PR DESCRIPTION
Escape now leaves a Resend control on every cut turn, and it renders from the press itself rather
than waiting on a row the backend may send later — or never.

## What changed

`cutPromptId` (`apps/tuval/src/ai-agent/core/state.ts`) names the operator's own prompt for the turn
in flight, and the `interrupt` cell anchors `state.interrupted` on it. That row is in the tail from
the send — the `prompt` cell folds a local echo before the layer is called, and
`planTranscriptWindow` admits the newest turn's group whole whatever the bounds — so the marker lands
on every press, including the two cases the assistant-row anchor had no answer for: a turn cut before
the model wrote a token, and a turn whose content was tool calls alone, which `emptyReply`
(`apps/tuval/src/pi/ai-agent/items.ts`) suppresses the reply row for entirely.

The reply keeps its own `interrupted` flag, so `chatRows`' "You stopped this response" fold label is
unchanged. `restore` now sets both: `lastAssistantId` for the flag, `cutPromptId` for the anchor.
`lastAssistantId`'s docblock is rewritten to say it names the mark and not the resend, which is what
its old "`null` is the right answer there" claim got wrong.

Two late deciders of the same field are gone with it. `cutReplyAfterItem` existed only to supply the
marker an assistant-row anchor could not: with it set at the press there is nothing left to supply,
and its first-wins race was the path a replayed abort could steal the marker down (#8753 — see
below). `foldInterruptRefusal` drops its own `lastAssistantId` fallback on the same argument.

One piece of bookkeeping is new rather than removed. `echoOf` re-keys the operator's local row to the
layer's own id when the backend echoes the prompt (#7978), so `reanchored` follows the marker across
that re-key — without it the Resend vanished the moment the backend echoed the very prompt it is for.
It decides nothing: with no marker standing there is nothing to move, and a row superseding anything
else leaves it alone.

## On #8753

The issue body asks whoever lands this to check it. #8753's defect is closed here by construction —
its mechanism is `cutReplyAfterItem`'s first-wins race, and that function is deleted, so no path
after the press writes `interrupted` except the echo re-key above, which can only follow the
operator's own row. There is a test for exactly that replay shape. Its acceptance criteria are now
stale rather than merely satisfied — criterion 2 asks that the aborted row still take the marker,
which is the behaviour this PR deliberately removes. Left open for triage, with the above posted on
it.

## Reviewer's first look

`reanchored` in `apps/tuval/src/ai-agent/core/fold.ts` — it is the one place state bookkeeping
follows a transcript re-key, and the question worth asking is whether any *other* seam re-keys a row.
`rebaseOnStore`'s refill keeps the local row and drops the store's copy (`localEchoes`), so that path
needs nothing; the live item fold is the only one that replaces.

Verified by hand on a real pi desk; the comment below carries the transcript.

Fixes #8699

## Deviations

- **Out-of-scope change** — **Said:** #8699's criteria name the `interrupt` cell, the fold,
  `lastAssistantId` and `cutReplyAfterItem`. **Did:** also re-anchored `restore` and dropped
  `foldInterruptRefusal`'s `lastAssistantId` fallback. **Why:** both decide the same field off the
  reply, so leaving either would mean a restored session with no Resend on a textless cut, and a
  second decider able to re-point the anchor at a reply — the thing criterion 2 forbids.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about #8753. **Did:** added a regression test for its
  compaction replay shape. **Why:** the issue body instructs the builder to check #8753, and a test
  is how that check is falsifiable rather than asserted. **Disposition:** stated here; #8753 left
  open for triage.
- **Pre-existing test or fixture changed** — **Said:** nothing about the restore proofs. **Did:**
  updated the asserted marker id in six restore/proof test files, and retitled three interrupt-cell
  tests. **Why:** each pinned the anchor to an assistant row id, which is the value this ticket
  moves; the surrounding assertions (the reply's own flag, the tail's shape) are untouched.
  **Disposition:** stated here.
