### PR TITLE
feat: The Tuval picker has no way to narrow its program and process list by typing

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -147,6 +147,14 @@
 			"basePath": "/",
 			"command": "pnpm --filter @kampus/tuval proof:pi-vertical --page-port {{port}} 1>&2",
 			"readyPath": "/"
+		},
+		{
+			"name": "tuval-picker",
+			"prefix": "apps/tuval/src/",
+			"mount": "/tuval/picker",
+			"basePath": "/",
+			"command": "pnpm --filter @kampus/tuval proof:picker --port {{port}} --strictPort 1>&2",
+			"readyPath": "/"
 		}
 	],
 

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -579,6 +579,20 @@ provider and serves the real desk (`pnpm proof:pi-vertical`, `src/pi/proof/serve
 about the assembled surface. The second one found `.tuval-window` sizing to its content rather than
 to its panel — a 302px window in a 775px panel, transcript 2px — which no headless proof could see.
 
+**A state you can only reach by typing owes a proof page that starts in it.** `fabrika ui render`
+navigates a bare route and drives nothing, so a surface behind a keystroke — the window picker is
+behind `<c-b> w`, its filter behind a further `/` — is invisible to the design gate however well it
+paints, and `ship gate` then refuses the PR with `review-ui absent` (#8450 on PR #8914). The fix is
+one page that mounts the state directly rather than one surface per sub-state:
+`src/shell/picker/proof/` renders two empty windows through the real `WindowView`, one plain and one
+with a query already in its filter. Two things that page has to get right and neither is obvious.
+Only one element on a page holds the caret, so the pane whose focus is under judgment is the focused
+one and the other is not. And a capture is taken at network-idle, so any product delay longer than
+the page's own load — the picker's 1000 ms announce pause — is missed unless a request outlives it
+(`proof/vite.config.ts`'s `/announce-pause`, whose body the page must *read*: an unread response
+stream leaves the request in flight and network-idle never arrives). The wider fix, letting a capture
+set be produced by an interaction script so no gated state owes its own surface, is [#7306](https://github.com/kamp-us/phoenix/issues/7306).
+
 Two more mechanics the Claude vertical added
 (`apps/tuval/src/claude/proof/claude-vertical.integration.test.ts`).
 

--- a/.patterns/tuval-shell-assembly.md
+++ b/.patterns/tuval-shell-assembly.md
@@ -265,6 +265,22 @@ program-blind: a process's state still crosses as `unknown`.
   to be one structure and not two is ADR
   [0368](../.decisions/0368-picker-one-cursor-both-inputs.md), which binds every Tuval picker
   (#8655).
+- **The `/` filter narrows before anything reads the list.** `visibleEntries`
+  (`src/shell/picker/filter.ts`) runs the `fzf` package over each section's own `label`, and
+  `visibleFor` is the one door every reader goes through — `cursorOf`, `highlighted`, `pickerKey`,
+  `pickerPointer` and `pickerFrame` all address the narrowed list, so the highlight, the frame and
+  the intent `<enter>` runs cannot name three different rows. The filter text lives in the window's
+  view slot (`PickerView.filter`, `null` until `/` opens it) and every mount starts at `null`.
+  While the filter exists it is a `combobox` and the DOM focus holder, so it carries
+  `aria-activedescendant` and the listbox drops it: that attribute is announced only off the focused
+  element (#7499), and a highlight on an unfocused listbox is a highlight nobody hears.
+- **The match count is a debounced, alternating status region.** The count is a WCAG 2.2 SC 4.1.3
+  status message — `role="status"`, `aria-live="polite"`, `aria-atomic="true"`, focus untouched —
+  announced 1000 ms after the typing stops rather than per keystroke, because a per-keystroke live
+  region turns one search into a run of interruptions. `pickerFrame` names **two** region ids and
+  `PickerView.tsx` writes into them by turns: a live region rewritten with the string it already
+  holds is not a change and is read out by nothing, so two queries that leave the same count would
+  otherwise announce once. `role="alert"` stays the refusal's alone.
 - **The kernel pushes the catalog; the page never asks.** A spell call is the only page-to-kernel
   message (#7617 R1.3), so the catalog goes out as the socket opens and again on
   `TransportServer.publishRegistry`, which re-reads the registry and writes to every attached page.

--- a/apps/tuval/README.md
+++ b/apps/tuval/README.md
@@ -26,6 +26,7 @@ pnpm test:integration # the slow tier: a real Pi AgentSession on a real loopback
 pnpm typecheck
 pnpm proof:board      # the process board in a real browser, on fixture rows — see "Paint proofs"
 pnpm proof:chat       # the chat window in a real browser, on fixtures — see "Paint proofs"
+pnpm proof:picker     # the window picker, open and filtering, in a real browser — see "Paint proofs"
 pnpm proof:pi-vertical   # the Pi vertical in a real browser, on Pi's faux provider — free
 pnpm proof:claude-real   # the Claude vertical on the REAL CLI — the founder's run, spends tokens
 ```
@@ -55,6 +56,14 @@ and a stopping shell — nested three deep, so the tile rhythm, the nesting and 
 line wraps are visible somewhere a jsdom test cannot look. It is the page the design gate captures
 as the `tuval-board` surface. The rows are a still life: a board that spawned a process on a timer
 would capture differently on every run, and what the entry animation *does* is the unit tier's.
+
+`pnpm proof:picker` serves `src/shell/picker/proof/`: two empty windows through the real
+`WindowView`, one holding the picker as `<c-b> w` leaves it and one holding the same picker with
+`co` already in its `/` filter, so both sections are narrowed and the match count is on the page.
+It is the page the design gate captures as the `tuval-picker` surface, and it exists because the
+picker is two gestures deep on the real desk while `fabrika ui render` drives a bare route — without
+it the gate cannot reach the state it is asked to judge (#8450). No kernel, no registry, no socket:
+the entries are literals, and what the keys *do* is the unit tier's.
 
 The same server's `/session-refusal` fixture mounts the production read-only transcript with a
 missing-folder row beside a refused initial read, using the page's stylesheet entry. Both keep

--- a/apps/tuval/package.json
+++ b/apps/tuval/package.json
@@ -33,6 +33,7 @@
 		"@modelcontextprotocol/sdk": "catalog:",
 		"@tanstack/react-virtual": "catalog:",
 		"effect": "catalog:tuval",
+		"fzf": "catalog:tuval",
 		"pi-subagents": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:",

--- a/apps/tuval/package.json
+++ b/apps/tuval/package.json
@@ -15,6 +15,7 @@
 		"proof:board": "vite --config src/shell/board/proof/vite.config.ts",
 		"proof:chat": "vite --config src/shell/chat/proof/vite.config.ts",
 		"proof:pi-window": "vite --config src/pi/window/proof/vite.config.ts",
+		"proof:picker": "vite --config src/shell/picker/proof/vite.config.ts",
 		"proof:page-reconnect": "node src/page/proof/serve.ts",
 		"proof:pi-vertical": "node src/pi/proof/serve.ts",
 		"proof:claude-real": "node src/claude/proof/serve.ts"

--- a/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/claude-vertical.integration.test.ts
@@ -241,6 +241,7 @@ const pickerPress = (
 	switch (answer._tag) {
 		case "Moved":
 		case "Cleared":
+		case "Filtering":
 			return {type: "window.setView", windowId: windowId as never, view: answer.view};
 		case "Chose":
 			return answer.intent._tag === "OpenProgram"

--- a/apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts
+++ b/apps/tuval/src/claude/proof/subagent-vertical.integration.test.ts
@@ -201,6 +201,7 @@ const pickerPress = (
 	switch (answer._tag) {
 		case "Moved":
 		case "Cleared":
+		case "Filtering":
 			return {type: "window.setView", windowId: windowId as never, view: answer.view};
 		case "Chose":
 			return answer.intent._tag === "OpenProgram"

--- a/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
+++ b/apps/tuval/src/pi/proof/pi-vertical.integration.test.ts
@@ -205,6 +205,7 @@ const pickerPress = (
 	switch (answer._tag) {
 		case "Moved":
 		case "Cleared":
+		case "Filtering":
 			return {type: "window.setView", windowId: windowId as never, view: answer.view};
 		case "Chose":
 			return answer.intent._tag === "OpenProgram"

--- a/apps/tuval/src/shell/commands/window-pick.unit.test.ts
+++ b/apps/tuval/src/shell/commands/window-pick.unit.test.ts
@@ -83,6 +83,7 @@ const press = (state: ShellState, entries: PickerEntries, windowId: WindowId, ke
 		switch (answer._tag) {
 			case "Moved":
 			case "Cleared":
+			case "Filtering":
 				return apply(state, {type: "window.setView", windowId, view: answer.view});
 			case "Chose":
 				return yield* dispatch(
@@ -275,6 +276,7 @@ describe("window:pick returns a filled window to the picker", () => {
 			cursor: 1,
 			refusal: null,
 			previous: null,
+			filter: null,
 		});
 	});
 });

--- a/apps/tuval/src/shell/picker/browser.ts
+++ b/apps/tuval/src/shell/picker/browser.ts
@@ -18,8 +18,10 @@ export {
 	readEntries,
 	showsInAWindow,
 } from "./entries.ts";
+export {type PickerFilter, visibleEntries} from "./filter.ts";
 export {
 	type PickerAnnouncement,
+	type PickerFilterFrame,
 	type PickerFrame,
 	type PickerFrameOptions,
 	type PickerGroup,
@@ -58,5 +60,7 @@ export {
 	type PickerView,
 	pickerKey,
 	pickerPointer,
+	visibleFor,
+	withFilter,
 	withRefusal,
 } from "./view.ts";

--- a/apps/tuval/src/shell/picker/filter.ts
+++ b/apps/tuval/src/shell/picker/filter.ts
@@ -1,0 +1,36 @@
+/**
+ * What the operator's typing leaves standing. Narrowing only — `showsInAWindow` still decides which
+ * rows exist at all (`./entries.ts`), and this shrinks that answer without ever widening it.
+ *
+ * The matcher is the `fzf` package (fzf-for-js), founder-ruled on #8450: the ranking engine is
+ * theirs, not ours, so nothing here scores, weights a position or breaks a tie. `selector` reads the
+ * row's own `label` and nothing else — a program id, a process id or a parent never reaches the
+ * query, which is the ticket's no-go.
+ *
+ * Both sections are matched separately and kept in that order, so the two groups the frame renders
+ * survive the filter; within a section fzf's own descending score is the order.
+ */
+
+import {Fzf} from "fzf";
+import type {PickerEntries, PickerEntry} from "./entries.ts";
+
+/**
+ * The filter as the view stores it. `null` is the picker with no filter open at all — the state
+ * every mount starts in (ruling Q3) — and a string is an open filter, empty included.
+ */
+export type PickerFilter = string | null;
+
+const selector = (entry: PickerEntry): string => entry.label;
+
+/**
+ * The rows a filter leaves. A closed or empty filter is the whole list in its own order rather than
+ * fzf's: an empty query scores every row alike, and re-ordering a list nobody narrowed would move
+ * the highlight under an operator who only pressed `/`.
+ */
+export const visibleEntries = (entries: PickerEntries, filter: PickerFilter): PickerEntries =>
+	filter === null || filter === ""
+		? entries
+		: {
+				programs: new Fzf(entries.programs, {selector}).find(filter).map((match) => match.item),
+				processes: new Fzf(entries.processes, {selector}).find(filter).map((match) => match.item),
+			};

--- a/apps/tuval/src/shell/picker/filter.unit.test.ts
+++ b/apps/tuval/src/shell/picker/filter.unit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * What the filter narrows, and what it refuses to read. The matcher itself is fzf's and is not
+ * re-proved here — these are the two claims that are ours: both sections narrow, and only the row's
+ * own label is ever matched against (#8450).
+ */
+
+import {describe, expect, it} from "vitest";
+import type {PickerEntries} from "./entries.ts";
+import {programEntries} from "./entries.ts";
+import {visibleEntries} from "./filter.ts";
+import {processId, programId, programRow} from "./fixtures.ts";
+
+const entries: PickerEntries = {
+	programs: programEntries([
+		programRow("counter", {label: "Counter"}),
+		programRow("claude", {label: "Claude"}),
+		programRow("pi", {label: "Pi"}),
+	]),
+	processes: [
+		{
+			_tag: "Process",
+			processId: processId("dead-beef-counter"),
+			programId: programId("counter"),
+			label: "Counter",
+			parentId: null,
+		},
+		{
+			_tag: "Process",
+			processId: processId("p-2"),
+			programId: programId("pi"),
+			label: "Pi",
+			parentId: processId("claude-parent"),
+		},
+	],
+};
+
+const labels = (narrowed: PickerEntries) => ({
+	programs: narrowed.programs.map((entry) => entry.label),
+	processes: narrowed.processes.map((entry) => entry.label),
+});
+
+describe("the picker's filter", () => {
+	it("narrows the programs and the processes together, not one of them", () => {
+		expect(labels(visibleEntries(entries, "pi"))).toEqual({programs: ["Pi"], processes: ["Pi"]});
+	});
+
+	it("matches a subsequence with gaps, smart-cased — which is what fzf answers", () => {
+		expect(labels(visibleEntries(entries, "cur")).programs).toEqual(["Counter"]);
+		// Smart case is fzf's default (`BaseOptions.casing`): an all-lowercase query ignores case, and
+		// typing a capital is the operator asking for one.
+		expect(labels(visibleEntries(entries, "cld")).programs).toEqual(["Claude"]);
+		expect(labels(visibleEntries(entries, "CLD")).programs).toEqual([]);
+	});
+
+	it("reads the row's own label and never a program, process or parent id", () => {
+		// "beef" appears only inside the process id, "claude-parent" only inside a parent id, and
+		// "counter" as a program id — the labels above carry none of those spellings.
+		expect(labels(visibleEntries(entries, "beef"))).toEqual({programs: [], processes: []});
+		expect(labels(visibleEntries(entries, "parent"))).toEqual({programs: [], processes: []});
+	});
+
+	it("leaves a closed or empty filter the whole list, in its own order", () => {
+		expect(visibleEntries(entries, null)).toBe(entries);
+		expect(visibleEntries(entries, "")).toBe(entries);
+	});
+
+	it("answers a query nothing matches with two empty sections rather than the whole list", () => {
+		expect(labels(visibleEntries(entries, "zzz"))).toEqual({programs: [], processes: []});
+	});
+});

--- a/apps/tuval/src/shell/picker/frame.ts
+++ b/apps/tuval/src/shell/picker/frame.ts
@@ -14,7 +14,7 @@ import type {ProcessId} from "../../process/process.ts";
 import type {WindowId} from "../window/host.ts";
 import {flatten, type PickerEntries, type PickerEntry} from "./entries.ts";
 import {refusalMessage} from "./refusal.ts";
-import {cursorOf, type PickerView} from "./view.ts";
+import {cursorOf, type PickerView, visibleFor} from "./view.ts";
 
 /**
  * The role tokens the picker paints in, by name. Dark is the only scheme the shell has: Tuval is a
@@ -67,11 +67,47 @@ export interface PickerGroup {
 
 /**
  * The refusal channel. An `alert` interrupts because the user just acted and nothing happened;
- * `status` does not, because it is only ever the count.
+ * `status` does not, because it is only ever the count. That split is the whole of the rule that
+ * the filter's count never reaches the assertive channel — an `alert` is a refusal and nothing else.
  */
 export type PickerAnnouncement =
-	| {readonly role: "status"; readonly live: "polite"; readonly text: string}
+	| {
+			readonly role: "status";
+			readonly live: "polite";
+			/** WCAG 2.2 SC 4.1.3: the count is read whole, never as the characters that changed. */
+			readonly atomic: true;
+			readonly text: string;
+			/**
+			 * The two region ids the surface writes into by turns, so a count that did not change is
+			 * still announced (the GOV.UK status technique). `null` is one static region, which is what
+			 * a picker nobody is filtering needs.
+			 */
+			readonly alternates: readonly [string, string] | null;
+	  }
 	| {readonly role: "alert"; readonly live: "assertive"; readonly text: string};
+
+/**
+ * The filter input at the top of the list, once `/` has opened it. `null` until then.
+ *
+ * It is a combobox and not a bare text field, because while it exists it is the element that holds
+ * DOM focus — and `aria-activedescendant` is announced only off the focused element (#7499). So the
+ * highlight moves with the combobox's own `aria-activedescendant`, `controls` names the listbox it
+ * points into, and the listbox goes back to carrying it the moment Escape closes this.
+ */
+export interface PickerFilterFrame {
+	readonly role: "combobox";
+	readonly id: string;
+	readonly label: string;
+	readonly placeholder: string;
+	readonly value: string;
+	readonly expanded: true;
+	readonly autocomplete: "list";
+	/** The listbox this filter's highlight walks. */
+	readonly controls: string;
+	/** How many of the picker's rows this query left, and how many there were. */
+	readonly matches: number;
+	readonly total: number;
+}
 
 export interface PickerFrame {
 	readonly role: "listbox";
@@ -79,6 +115,7 @@ export interface PickerFrame {
 	readonly label: string;
 	readonly windowId: WindowId;
 	readonly activeDescendant: string | null;
+	readonly filter: PickerFilterFrame | null;
 	readonly groups: ReadonlyArray<PickerGroup>;
 	readonly announcement: PickerAnnouncement;
 	readonly theme: PickerTheme;
@@ -120,8 +157,9 @@ const detailOf = (entry: PickerEntry): string =>
 		: `${entry.processId}${entry.parentId === null ? "" : ` ← ${entry.parentId}`}`;
 
 const KEY_HELP = [
-	{keys: "↑ ↓ / k j", action: "Move between rows"},
+	{keys: "↑ ↓ or k j", action: "Move between rows"},
 	{keys: "Home / End", action: "Jump to the first or last row"},
+	{keys: "/", action: "Filter the rows by typing"},
 	{keys: "Enter", action: "Open or attach the highlighted row"},
 ] as const;
 
@@ -129,9 +167,11 @@ const KEY_HELP = [
 const escapeHelp = (view: PickerView) => ({
 	keys: "Escape",
 	action:
-		view.previous === null
-			? "Dismiss the message"
-			: "Return to the process this window was showing",
+		view.filter !== null
+			? "Close the filter and show every row"
+			: view.previous === null
+				? "Dismiss the message"
+				: "Return to the process this window was showing",
 });
 
 /**
@@ -144,7 +184,8 @@ export const pickerFrame = (
 	view: PickerView,
 	options?: PickerFrameOptions,
 ): PickerFrame => {
-	const rows = flatten(entries);
+	const visible = visibleFor(entries, view);
+	const rows = flatten(visible);
 	const at = cursorOf(entries, view);
 	const optionId = (index: number) => `picker-${windowId}-option-${index}`;
 
@@ -164,34 +205,69 @@ export const pickerFrame = (
 			};
 		});
 
+	const filtering = view.filter !== null;
 	const groups: ReadonlyArray<PickerGroup> = [
 		{
 			role: "group",
 			id: `picker-${windowId}-programs`,
 			label: "Programs",
-			options: optionsFrom(entries.programs, 0),
+			options: optionsFrom(visible.programs, 0),
 			emptyMessage:
-				entries.programs.length === 0 ? "No registered program can fill a window." : null,
+				visible.programs.length > 0
+					? null
+					: filtering
+						? "No program matches this filter."
+						: "No registered program can fill a window.",
 		},
 		{
 			role: "group",
 			id: `picker-${windowId}-processes`,
 			label: "Running processes",
-			options: optionsFrom(entries.processes, entries.programs.length),
-			emptyMessage: entries.processes.length === 0 ? "Nothing is running to attach to." : null,
+			options: optionsFrom(visible.processes, visible.programs.length),
+			emptyMessage:
+				visible.processes.length > 0
+					? null
+					: filtering
+						? "No running process matches this filter."
+						: "Nothing is running to attach to.",
 		},
 	];
 
+	const total = flatten(entries).length;
+	const counts = `${entries.programs.length} program${
+		entries.programs.length === 1 ? "" : "s"
+	}, ${entries.processes.length} running process${entries.processes.length === 1 ? "" : "es"}.`;
+	const matchCount =
+		rows.length === 0 ? "No windows match this filter." : `${rows.length} of ${total} windows`;
+
 	const announcement: PickerAnnouncement =
-		view.refusal === null
-			? {
+		view.refusal !== null
+			? {role: "alert", live: "assertive", text: refusalMessage(view.refusal)}
+			: {
 					role: "status",
 					live: "polite",
-					text: `${entries.programs.length} program${entries.programs.length === 1 ? "" : "s"}, ${
-						entries.processes.length
-					} running process${entries.processes.length === 1 ? "" : "es"}.`,
-				}
-			: {role: "alert", live: "assertive", text: refusalMessage(view.refusal)};
+					atomic: true,
+					text: filtering ? matchCount : counts,
+					alternates: filtering
+						? [`picker-${windowId}-status-a`, `picker-${windowId}-status-b`]
+						: null,
+				};
+
+	const filter: PickerFilterFrame | null =
+		view.filter === null
+			? null
+			: {
+					role: "combobox",
+					id: `picker-${windowId}-filter`,
+					label: "Filter rows by name",
+					placeholder: "Type to narrow",
+					value: view.filter,
+					expanded: true,
+					autocomplete: "list",
+					controls: `picker-${windowId}`,
+					matches: rows.length,
+					total,
+				};
 
 	return {
 		role: "listbox",
@@ -199,6 +275,7 @@ export const pickerFrame = (
 		label: "Open a program or attach a running process",
 		windowId,
 		activeDescendant: rows.length === 0 ? null : optionId(at),
+		filter,
 		groups,
 		announcement,
 		theme: themeFor(options),

--- a/apps/tuval/src/shell/picker/frame.unit.test.ts
+++ b/apps/tuval/src/shell/picker/frame.unit.test.ts
@@ -9,7 +9,7 @@ import {noEntries, type PickerEntries, programEntries} from "./entries.ts";
 import {processId, programId, programRow, windowId} from "./fixtures.ts";
 import {pickerFrame} from "./frame.ts";
 import {processGone} from "./refusal.ts";
-import {mountPicker, withRefusal} from "./view.ts";
+import {mountPicker, withFilter, withRefusal} from "./view.ts";
 
 const window = windowId("window-1");
 
@@ -45,7 +45,12 @@ describe("picker frame", () => {
 	});
 
 	it("names the active option by id, and marks exactly one option selected", () => {
-		const frame = pickerFrame(window, entries, {cursor: 2, refusal: null, previous: null});
+		const frame = pickerFrame(window, entries, {
+			cursor: 2,
+			refusal: null,
+			previous: null,
+			filter: null,
+		});
 		const options = frame.groups.flatMap((group) => group.options);
 		expect(frame.activeDescendant).toBe("picker-window-1-option-2");
 		expect(options.filter((option) => option.selected).map((option) => option.id)).toEqual([
@@ -82,6 +87,8 @@ describe("picker frame", () => {
 		expect(pickerFrame(window, entries, mountPicker()).announcement).toEqual({
 			role: "status",
 			live: "polite",
+			atomic: true,
+			alternates: null,
 			text: "2 programs, 2 running processes.",
 		});
 		expect(
@@ -120,6 +127,7 @@ describe("picker frame", () => {
 		expect(pickerFrame(window, entries, mountPicker()).keyHelp.map((row) => row.action)).toEqual([
 			"Move between rows",
 			"Jump to the first or last row",
+			"Filter the rows by typing",
 			"Open or attach the highlighted row",
 			"Dismiss the message",
 		]);
@@ -145,6 +153,80 @@ describe("picker frame", () => {
 		// The help still offers the return: the attach handler is where a dead id becomes a refusal.
 		expect(frame.keyHelp.map((row) => row.action)).toContain(
 			"Return to the process this window was showing",
+		);
+	});
+});
+
+/** The filter's own contract (#8450): what it renders, what it counts, and what it announces. */
+describe("picker frame under a filter", () => {
+	const filtered = (text: string) => pickerFrame(window, entries, withFilter(mountPicker(), text));
+
+	it("offers no filter until `/` opens one", () => {
+		expect(pickerFrame(window, entries, mountPicker()).filter).toBeNull();
+		expect(pickerFrame(window, entries, withFilter(mountPicker(), "")).filter).toEqual({
+			role: "combobox",
+			expanded: true,
+			autocomplete: "list",
+			controls: "picker-window-1",
+			id: "picker-window-1-filter",
+			label: "Filter rows by name",
+			placeholder: "Type to narrow",
+			value: "",
+			matches: 4,
+			total: 4,
+		});
+	});
+
+	it("renders only the rows that matched, both sections narrowed together", () => {
+		const frame = filtered("pi");
+		expect(frame.groups.map((group) => group.options.map((option) => option.detail))).toEqual([
+			["pi"],
+			[],
+		]);
+		expect(frame.filter?.matches).toBe(1);
+	});
+
+	it("carries the count as a polite, atomic status message and never as an alert", () => {
+		expect(filtered("pi").announcement).toEqual({
+			role: "status",
+			live: "polite",
+			atomic: true,
+			text: "1 of 4 windows",
+			alternates: ["picker-window-1-status-a", "picker-window-1-status-b"],
+		});
+	});
+
+	it("says so when nothing matched, rather than announcing a count of none", () => {
+		const frame = filtered("zzzz");
+		expect(frame.announcement.text).toBe("No windows match this filter.");
+		expect(frame.announcement.role).toBe("status");
+		expect(frame.activeDescendant).toBeNull();
+		expect(frame.groups.map((group) => group.emptyMessage)).toEqual([
+			"No program matches this filter.",
+			"No running process matches this filter.",
+		]);
+	});
+
+	it("keeps the assertive channel for a refusal even while a filter is on", () => {
+		const refused = pickerFrame(
+			window,
+			entries,
+			withRefusal(withFilter(mountPicker(), "pi"), processGone("p-9")),
+		);
+		expect(refused.announcement).toEqual({
+			role: "alert",
+			live: "assertive",
+			text: 'Process "p-9" is no longer running.',
+		});
+	});
+
+	it("tells the reader `/` is the key, and what Escape does once it is open", () => {
+		expect(pickerFrame(window, entries, mountPicker()).keyHelp).toContainEqual({
+			keys: "/",
+			action: "Filter the rows by typing",
+		});
+		expect(filtered("pi").keyHelp.map((row) => row.action)).toContain(
+			"Close the filter and show every row",
 		);
 	});
 });

--- a/apps/tuval/src/shell/picker/mount.unit.test.ts
+++ b/apps/tuval/src/shell/picker/mount.unit.test.ts
@@ -55,8 +55,13 @@ describe("a mount reads the world fresh", () => {
 	);
 
 	it("a fresh mount starts unplaced with no refusal, whatever the last one ended on", () => {
-		expect(mountPicker()).toEqual({cursor: null, refusal: null, previous: null});
-		expect(mountPicker("p-1")).toEqual({cursor: null, refusal: null, previous: "p-1"});
+		expect(mountPicker()).toEqual({cursor: null, refusal: null, previous: null, filter: null});
+		expect(mountPicker("p-1")).toEqual({
+			cursor: null,
+			refusal: null,
+			previous: "p-1",
+			filter: null,
+		});
 		expect(mountPicker()).not.toBe(mountPicker());
 	});
 });

--- a/apps/tuval/src/shell/picker/proof/index.html
+++ b/apps/tuval/src/shell/picker/proof/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" data-theme="dark" data-color-theme="indigo">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="color-scheme" content="dark" />
+		<title>Window picker proof</title>
+	</head>
+	<body>
+		<div id="proof"></div>
+		<script type="module" src="./main.tsx"></script>
+	</body>
+</html>

--- a/apps/tuval/src/shell/picker/proof/main.tsx
+++ b/apps/tuval/src/shell/picker/proof/main.tsx
@@ -1,0 +1,123 @@
+/**
+ * The window picker in a real browser, with its `/` filter open — no kernel, no socket, no registry.
+ *
+ * On the real desk the picker is two gestures deep (`<c-b> w`, then `/`) and `fabrika ui render`
+ * drives a bare route, so without this page the design gate cannot reach the state it is asked to
+ * judge: PR #8914's `ship gate` refused at head with `review-ui absent` for exactly that reason.
+ * The page mounts the two states side by side instead — the picker as `<c-b> w` leaves it, and the
+ * same picker with a query already typed — through the real `WindowView` on its real `Empty` arm,
+ * so what is captured is the window chrome the operator sees and not a bare list.
+ *
+ * The filter's behaviour is the unit tier's (`../view.unit.test.ts`,
+ * `../../ui/picker-filter.unit.test.tsx`); what only a browser can settle is paint: the filter row's
+ * box against the command line's, where the narrowed sections sit, and that the two status regions
+ * take no room. Both panes stay live, so `/`, `j`, `k` and Escape all work if you drive it by hand
+ * with `pnpm proof:picker` from `apps/tuval`.
+ */
+
+import {StrictMode, useState} from "react";
+import {createRoot} from "react-dom/client";
+import {ProcessId} from "../../../process/process.ts";
+import {ProgramId} from "../../../registry/program.ts";
+import type {ShellMsg} from "../../core/index.ts";
+import {WindowView} from "../../ui/WindowView.tsx";
+import {empty, type ViewState, WindowId} from "../../window/index.ts";
+import {
+	mountPicker,
+	type PickerEntries,
+	type PickerView as PickerViewState,
+	withFilter,
+} from "../browser.ts";
+import "../../../page/styles.ts";
+import "./proof.css";
+
+const program = (id: string, label: string) => ({
+	_tag: "Program" as const,
+	programId: ProgramId.make(id),
+	label,
+});
+
+const process = (id: string, programId: string, label: string, parent?: string) => ({
+	_tag: "Process" as const,
+	processId: ProcessId.make(id),
+	programId: ProgramId.make(programId),
+	label,
+	parentId: parent === undefined ? null : ProcessId.make(parent),
+});
+
+/**
+ * Enough rows that both sections narrow under one query and neither empties: `co` leaves Counter and
+ * Clock among the programs and the counter process among the running ones. A query that emptied a
+ * section would capture the no-match line instead, which is a different state and has its own
+ * assertions in the unit tier.
+ */
+const entries: PickerEntries = {
+	programs: [
+		program("demo/counter", "Counter"),
+		program("demo/clock", "Clock"),
+		program("demo/log", "Log viewer"),
+		program("ai/claude", "Claude"),
+		program("ai/pi", "Pi chat"),
+	],
+	processes: [
+		process("p-counter", "demo/counter", "Counter"),
+		process("p-claude", "ai/claude", "Claude"),
+		process("p-log", "demo/log", "Log viewer", "p-claude"),
+	],
+};
+
+const QUERY = "co";
+
+function Pane({
+	name,
+	start,
+	focused,
+}: {
+	readonly name: string;
+	readonly start: PickerViewState;
+	readonly focused: boolean;
+}) {
+	// The slot the desk would hold, at the desk's own type: `WindowView` reads it back through the
+	// real `asPickerView`, so the page proves the round trip rather than a narrowed object.
+	const [view, setView] = useState<ViewState>({...start});
+	const windowId = WindowId.make(name);
+	return (
+		<div className="proof-pane">
+			<WindowView
+				windowId={windowId}
+				mount={empty}
+				focused={focused}
+				view={view}
+				entries={entries}
+				dispatch={(msg: ShellMsg) => {
+					if (msg.type === "window.setView") setView(msg.view);
+					else globalThis.console.log(msg.type);
+				}}
+				reducedMotion={false}
+			/>
+		</div>
+	);
+}
+
+const host = document.getElementById("proof");
+if (host === null) throw new Error("the proof page has no #proof element");
+
+// A request that outlives the announce pause, so a capture taken at network-idle has the match count
+// on the page rather than two empty status regions (`./vite.config.ts`). It changes nothing the page
+// renders; only when a capture is allowed to be taken.
+// The body is read rather than dropped: an unread response stream leaves the request in flight as
+// far as the browser is concerned, and network-idle then never arrives at all.
+void fetch("/announce-pause")
+	.then((response) => response.text())
+	.catch(() => {});
+
+createRoot(host).render(
+	<StrictMode>
+		<div className="tuval-surface proof-desk" data-scheme="dark">
+			{/* The unfocused pane, because only one element on a page holds the caret and the filtering
+			    one has to be the one that holds it. */}
+			<Pane name="picker-open" start={mountPicker()} focused={false} />
+			<Pane name="picker-filtering" start={withFilter(mountPicker(), QUERY)} focused={true} />
+		</div>
+	</StrictMode>,
+);

--- a/apps/tuval/src/shell/picker/proof/proof.css
+++ b/apps/tuval/src/shell/picker/proof/proof.css
@@ -1,0 +1,46 @@
+/*
+ * The two seats the desk would give these windows, and nothing the picker itself paints — that is
+ * `../../ui/tokens.css`. The separation is the point: a rule that belongs to the harness must never
+ * be mistaken for one the product ships.
+ *
+ * `.tuval-surface` is a flex *column* (`../../ui/tokens.css`), so the row direction is re-declared
+ * at equal specificity and wins on order. It wraps back to a column under the narrow viewport the
+ * design gate also captures at, because two picker lists side by side at 390px are two columns of
+ * broken words.
+ */
+
+html,
+body {
+	block-size: 100%;
+	margin: 0;
+	background: var(--page-backdrop);
+}
+
+#proof {
+	block-size: 100%;
+}
+
+.proof-desk {
+	flex-direction: row;
+	flex-wrap: wrap;
+	min-block-size: 0;
+}
+
+.proof-pane {
+	display: flex;
+	flex: 1 1 24rem;
+	min-inline-size: 0;
+	min-block-size: 0;
+	padding: var(--s-3, 12px);
+	border-inline-end: 1px solid var(--border);
+}
+
+.proof-pane:last-child {
+	border-inline-end: 0;
+}
+
+.proof-pane > * {
+	flex: 1 1 auto;
+	min-inline-size: 0;
+	min-block-size: 0;
+}

--- a/apps/tuval/src/shell/picker/proof/vite.config.ts
+++ b/apps/tuval/src/shell/picker/proof/vite.config.ts
@@ -1,0 +1,36 @@
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import react from "@vitejs/plugin-react";
+import {defineConfig} from "vite";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * How long `/announce-pause` stays open. `ui render` captures at network-idle, and the match count
+ * is deliberately held back 1000 ms (`../../ui/PickerView.tsx`), so without a request outliving that
+ * pause the gate captures the two status regions still empty — which is the one thing on this page
+ * the pause exists to produce. Same technique as the chat proof's `/paging-inspection`.
+ */
+const ANNOUNCE_SETTLE_MS = 1_600;
+
+export default defineConfig({
+	root: here,
+	plugins: [
+		react(),
+		{
+			name: "picker-announce-pause",
+			configureServer(server) {
+				server.middlewares.use("/announce-pause", (_request, response) => {
+					setTimeout(() => {
+						response.setHeader("Content-Type", "text/plain");
+						response.setHeader("Cache-Control", "no-store");
+						response.end("settled");
+					}, ANNOUNCE_SETTLE_MS);
+				});
+			},
+		},
+	],
+	// `@kampus/design` and the design tokens are source-consumed out of the workspace, so the dev
+	// server has to be allowed to read above this app's root.
+	server: {fs: {allow: [resolve(here, "../../../../../..")]}},
+});

--- a/apps/tuval/src/shell/picker/view.ts
+++ b/apps/tuval/src/shell/picker/view.ts
@@ -18,6 +18,7 @@ import {ProcessId} from "../../process/process.ts";
 import {normalize} from "../keys/syntax.ts";
 import type {WindowId} from "../window/host.ts";
 import {flatten, type PickerEntries, type PickerEntry} from "./entries.ts";
+import {type PickerFilter, visibleEntries} from "./filter.ts";
 import {attachProcess, intentOf, type PickerIntent} from "./intent.ts";
 import {isPickerRefusal, type PickerRefusal} from "./refusal.ts";
 
@@ -36,6 +37,8 @@ export type PickerView = {
 	readonly refusal: PickerRefusal | null;
 	/** The process this window was showing when `window:pick` put it back on the picker (#8265). */
 	readonly previous: string | null;
+	/** `null` until `/` opens it; a string once open, and every mount opens with none (#8450). */
+	readonly filter: PickerFilter;
 };
 
 /**
@@ -46,11 +49,24 @@ export const mountPicker = (previous: string | null = null): PickerView => ({
 	cursor: null,
 	refusal: null,
 	previous,
+	filter: null,
 });
 
 export const withRefusal = (view: PickerView, refusal: PickerRefusal): PickerView => ({
 	...view,
 	refusal,
+});
+
+/**
+ * The view one edit of the filter input leaves. The cursor goes back to unplaced rather than being
+ * carried: the row under index 2 of the old match set is not the row under index 2 of the new one,
+ * and an unplaced cursor is resolved against whatever the new query actually left standing.
+ */
+export const withFilter = (view: PickerView, filter: string): PickerView => ({
+	...view,
+	filter,
+	cursor: null,
+	refusal: null,
 });
 
 /**
@@ -67,10 +83,12 @@ export const asPickerView = (slot: unknown): PickerView => {
 	if (cursor !== null && typeof cursor !== "number") return mountPicker();
 	const refusal = record.refusal;
 	const previous = record.previous;
+	const filter = record.filter;
 	return {
 		cursor,
 		refusal: isPickerRefusal(refusal) ? refusal : null,
 		previous: typeof previous === "string" ? previous : null,
+		filter: typeof filter === "string" ? filter : null,
 	};
 };
 
@@ -81,13 +99,21 @@ const clamp = (cursor: number, length: number): number => {
 };
 
 /**
+ * The rows this view actually offers. Every read below goes through it and so does the frame, which
+ * is what stops the highlight, the announcement and the intent `<enter>` runs from addressing three
+ * different lists once a filter is on.
+ */
+export const visibleFor = (entries: PickerEntries, view: PickerView): PickerEntries =>
+	visibleEntries(entries, view.filter);
+
+/**
  * Where the highlight actually sits. An unplaced cursor lands on the row of the process this window
  * was showing, so `<c-b> w` mounts the picker pointing at where Escape would take the operator
  * back; a `previous` no row offers — the process exited while the picker was up — falls back to the
  * first row rather than to nothing.
  */
 export const cursorOf = (entries: PickerEntries, view: PickerView): number => {
-	const rows = flatten(entries);
+	const rows = flatten(visibleFor(entries, view));
 	if (view.cursor !== null) return clamp(view.cursor, rows.length);
 	if (view.previous === null) return 0;
 	const at = rows.findIndex(
@@ -98,15 +124,18 @@ export const cursorOf = (entries: PickerEntries, view: PickerView): number => {
 
 /** The row the cursor names, or `null` when there is nothing to name. */
 export const highlighted = (entries: PickerEntries, view: PickerView): PickerEntry | null =>
-	flatten(entries)[cursorOf(entries, view)] ?? null;
+	flatten(visibleFor(entries, view))[cursorOf(entries, view)] ?? null;
 
 /**
- * What one key did. `Moved` and `Cleared` carry the view to store; `Chose` carries the intent to
- * run; `Ignored` says this key was never the picker's, so the surface may pass it on.
+ * What one key did. `Moved` and `Cleared` carry the view to store, and so does `Filtering` — a
+ * separate arm because it is the one answer that also moves DOM focus, into and out of the filter
+ * input, which the surface cannot read off a `Moved`. `Chose` carries the intent to run; `Ignored`
+ * says this key was never the picker's, so the surface may pass it on.
  */
 export type PickerKeyAnswer =
 	| {readonly _tag: "Moved"; readonly view: PickerView}
 	| {readonly _tag: "Cleared"; readonly view: PickerView}
+	| {readonly _tag: "Filtering"; readonly view: PickerView}
 	| {readonly _tag: "Chose"; readonly intent: PickerIntent}
 	| {readonly _tag: "Ignored"};
 
@@ -118,6 +147,7 @@ const FIRST = ["<home>", "g"];
 const LAST = ["<end>", "G"];
 const CHOOSE = ["<enter>", "<space>"];
 const DISMISS = ["<escape>"];
+const FILTER = ["/"];
 
 /**
  * The one move. A move onto the row already under the cursor keeps a showing refusal, because
@@ -137,11 +167,15 @@ const movedTo = (view: PickerView, at: number, next: number, length: number): Pi
  * Movement clamps at both ends instead of wrapping, which is the APG listbox default: a wrap makes
  * "am I at the end" unanswerable to someone reading one option at a time.
  *
- * Escape is two keys in one, and the order is what makes both reachable: a refusal showing is
- * cleared first, and only a picker with nothing to dismiss goes back to `previous`. A `previous`
- * whose process has since stopped still chooses — `runPickerIntent`'s attach arm (`./open.ts`)
- * answers a missing row with a `ProcessGone` refusal shown in the window, which is the one place
- * the process table can be read.
+ * Escape is three keys in one, and the order is what makes all three reachable: a refusal showing
+ * is cleared first, then an open filter is closed, and only a picker with neither goes back to
+ * `previous`. A `previous` whose process has since stopped still chooses — `runPickerIntent`'s
+ * attach arm (`./open.ts`) answers a missing row with a `ProcessGone` refusal shown in the window,
+ * which is the one place the process table can be read.
+ *
+ * `/` opens the filter and nothing else takes text (founder ruling, 2026-09-09 on #8450), which is
+ * what keeps `j` / `k` / `g` / `G` movement keys. Every key typed *into* the filter is the input's
+ * own: the desk leaves a focused text entry its presses, so nothing below ever sees them.
  */
 export const pickerKey = (
 	windowId: WindowId,
@@ -152,7 +186,7 @@ export const pickerKey = (
 	const spelled = normalize(key);
 	if (Result.isFailure(spelled)) return ignored;
 	const pressed = spelled.success;
-	const rows = flatten(entries);
+	const rows = flatten(visibleFor(entries, view));
 	const at = cursorOf(entries, view);
 
 	const moveTo = (next: number): PickerKeyAnswer => movedTo(view, at, next, rows.length);
@@ -161,9 +195,24 @@ export const pickerKey = (
 	if (UP.includes(pressed)) return moveTo(clamp(at - 1, rows.length));
 	if (FIRST.includes(pressed)) return moveTo(0);
 	if (LAST.includes(pressed)) return moveTo(clamp(rows.length - 1, rows.length));
+	if (FILTER.includes(pressed)) {
+		return view.filter === null
+			? {_tag: "Filtering", view: {...view, filter: "", refusal: null}}
+			: ignored;
+	}
 	if (DISMISS.includes(pressed)) {
 		if (view.refusal !== null) {
 			return {_tag: "Cleared", view: {...view, cursor: at, refusal: null}};
+		}
+		if (view.filter !== null) {
+			// The cursor is written down as the filtered list left it, then the filter is dropped: the
+			// row the operator was looking at keeps the highlight instead of the widened list's Nth.
+			const row = rows[at];
+			const widened = row === undefined ? -1 : flatten(entries).indexOf(row);
+			return {
+				_tag: "Filtering",
+				view: {...view, cursor: widened === -1 ? 0 : widened, filter: null},
+			};
 		}
 		return view.previous === null
 			? ignored
@@ -201,7 +250,7 @@ export const pickerPointer = (
 	index: number,
 	gesture: PickerPointer,
 ): PickerKeyAnswer => {
-	const rows = flatten(entries);
+	const rows = flatten(visibleFor(entries, view));
 	const entry = rows[index];
 	if (entry === undefined) return ignored;
 	return gesture === "click"

--- a/apps/tuval/src/shell/picker/view.unit.test.ts
+++ b/apps/tuval/src/shell/picker/view.unit.test.ts
@@ -3,7 +3,16 @@ import type {PickerEntries} from "./entries.ts";
 import {noEntries, programEntries} from "./entries.ts";
 import {processId, programId, programRow, windowId} from "./fixtures.ts";
 import {unknownProgram} from "./refusal.ts";
-import {highlighted, mountPicker, pickerKey, pickerPointer, withRefusal} from "./view.ts";
+import {
+	asPickerView,
+	cursorOf,
+	highlighted,
+	mountPicker,
+	pickerKey,
+	pickerPointer,
+	withFilter,
+	withRefusal,
+} from "./view.ts";
 
 const window = windowId("window-1");
 
@@ -70,7 +79,7 @@ describe("picker keyboard", () => {
 		const refused = withRefusal(mountPicker(), unknownProgram("nope"));
 		expect(pickerKey(window, entries, refused, "<escape>")).toEqual({
 			_tag: "Cleared",
-			view: {cursor: 0, refusal: null, previous: null},
+			view: {cursor: 0, refusal: null, previous: null, filter: null},
 		});
 		expect(pickerKey(window, entries, mountPicker(), "<escape>")).toEqual({_tag: "Ignored"});
 	});
@@ -87,7 +96,7 @@ describe("picker keyboard", () => {
 		const cleared = pickerKey(window, entries, refused, "<escape>");
 		expect(cleared).toEqual({
 			_tag: "Cleared",
-			view: {cursor: 2, refusal: null, previous: "p-1"},
+			view: {cursor: 2, refusal: null, previous: "p-1", filter: null},
 		});
 		if (cleared._tag !== "Cleared") throw new Error("test setup: Escape cleared nothing");
 		expect(pickerKey(window, entries, cleared.view, "<escape>")).toEqual({
@@ -111,6 +120,7 @@ describe("picker keyboard", () => {
 			cursor: 0,
 			refusal: null,
 			previous: "p-1",
+			filter: null,
 		});
 	});
 
@@ -118,7 +128,7 @@ describe("picker keyboard", () => {
 		const refused = withRefusal(mountPicker(), unknownProgram("nope"));
 		expect(pickerKey(window, entries, refused, "j")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 1, refusal: null, previous: null},
+			view: {cursor: 1, refusal: null, previous: null, filter: null},
 		});
 	});
 
@@ -133,16 +143,16 @@ describe("picker keyboard", () => {
 		expect(pickerKey(window, noEntries, mountPicker(), "<enter>")).toEqual({_tag: "Ignored"});
 		expect(pickerKey(window, noEntries, mountPicker(), "j")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 0, refusal: null, previous: null},
+			view: {cursor: 0, refusal: null, previous: null, filter: null},
 		});
 	});
 
 	it("a cursor left past the end of a shrunken list reads as the last row", () => {
-		const stale = {cursor: 9, refusal: null, previous: null};
+		const stale = {cursor: 9, refusal: null, previous: null, filter: null};
 		expect(highlighted(entries, stale)).toEqual(entries.processes[0]);
 		expect(pickerKey(window, entries, stale, "<arrowup>")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 1, refusal: null, previous: null},
+			view: {cursor: 1, refusal: null, previous: null, filter: null},
 		});
 	});
 });
@@ -151,7 +161,7 @@ describe("picker pointer", () => {
 	it("a pointer landing on a row moves the same cursor an arrow key moves", () => {
 		expect(pickerPointer(window, entries, mountPicker(), 2, "hover")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 2, refusal: null, previous: null},
+			view: {cursor: 2, refusal: null, previous: null, filter: null},
 		});
 		expect(pickerPointer(window, entries, mountPicker(), 2, "hover")).toEqual(
 			pickerKey(window, entries, press(mountPicker(), "j"), "j"),
@@ -183,13 +193,13 @@ describe("picker pointer", () => {
 		const refused = withRefusal(mountPicker(), unknownProgram("nope"));
 		expect(pickerPointer(window, entries, refused, 1, "hover")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 1, refusal: null, previous: null},
+			view: {cursor: 1, refusal: null, previous: null, filter: null},
 		});
 		// Landing on the row already under the cursor is not moving on from anything — the answer
 		// `movedTo` gives a keyboard press that cannot move either.
 		expect(pickerPointer(window, entries, refused, 0, "hover")).toEqual({
 			_tag: "Moved",
-			view: {cursor: 0, refusal: unknownProgram("nope"), previous: null},
+			view: {cursor: 0, refusal: unknownProgram("nope"), previous: null, filter: null},
 		});
 	});
 
@@ -197,5 +207,67 @@ describe("picker pointer", () => {
 		expect(pickerPointer(window, entries, mountPicker(), 9, "hover")).toEqual({_tag: "Ignored"});
 		expect(pickerPointer(window, entries, mountPicker(), 9, "click")).toEqual({_tag: "Ignored"});
 		expect(pickerPointer(window, noEntries, mountPicker(), 0, "click")).toEqual({_tag: "Ignored"});
+	});
+});
+
+/**
+ * The filter's half of the keyboard (#8450). Everything typed *into* the filter is the input's own —
+ * the desk leaves a focused text entry its presses — so what is proved here is the keys that open
+ * it, move under it, close it and commit through it.
+ */
+describe("picker filter", () => {
+	const filtered = (text: string) => withFilter(mountPicker(), text);
+
+	it("`/` opens the filter, and it is no longer a key the picker ignores", () => {
+		expect(pickerKey(window, entries, mountPicker(), "/")).toEqual({
+			_tag: "Filtering",
+			view: {cursor: null, refusal: null, previous: null, filter: ""},
+		});
+	});
+
+	it("keeps j, k, g and G as movement, because `/` is what takes text", () => {
+		expect(press(mountPicker(), "j").cursor).toBe(1);
+		expect(press(mountPicker(), "j", "j", "k").cursor).toBe(1);
+		expect(press(mountPicker(), "G").cursor).toBe(2);
+		expect(press(mountPicker(), "G", "g").cursor).toBe(0);
+	});
+
+	it("narrows the list the cursor addresses, so a stale cursor cannot outrun it", () => {
+		// `pi` is the second row unfiltered; filtered to "pi" it is the only one. A cursor left on 2 —
+		// a row the filter hides — reads as a row that survived, and Enter runs that same row.
+		const stale = {...filtered("pi"), cursor: 2};
+		expect(cursorOf(entries, stale)).toBe(0);
+		expect(highlighted(entries, stale)).toEqual(entries.programs[1]);
+		expect(pickerKey(window, entries, stale, "<enter>")).toEqual({
+			_tag: "Chose",
+			intent: {_tag: "OpenProgram", windowId: window, programId: "pi"},
+		});
+	});
+
+	it("Escape closes the filter before it reaches `previous`, keeping the row in view", () => {
+		expect(pickerKey(window, entries, filtered("counter"), "<escape>")).toEqual({
+			_tag: "Filtering",
+			// Row 0 of the "counter" match set is the flattened list's row 0 again, widened.
+			view: {cursor: 0, refusal: null, previous: null, filter: null},
+		});
+		// Only a picker with no filter left goes back to the process it was showing.
+		expect(pickerKey(window, entries, mountPicker("p-1"), "<escape>")._tag).toBe("Chose");
+	});
+
+	it("an edit of the filter unplaces the cursor, because index 2 is a different row now", () => {
+		expect(withFilter({...mountPicker(), cursor: 2}, "co")).toEqual({
+			cursor: null,
+			refusal: null,
+			previous: null,
+			filter: "co",
+		});
+	});
+
+	it("reads a filter back out of the slot, and anything that is not a string as none", () => {
+		expect(asPickerView({cursor: 1, refusal: null, previous: null, filter: "pi"}).filter).toBe(
+			"pi",
+		);
+		expect(asPickerView({cursor: 1, refusal: null, previous: null, filter: 7}).filter).toBeNull();
+		expect(asPickerView({cursor: 1}).filter).toBeNull();
 	});
 });

--- a/apps/tuval/src/shell/proof/end-to-end.integration.test.ts
+++ b/apps/tuval/src/shell/proof/end-to-end.integration.test.ts
@@ -231,6 +231,7 @@ const pickerPress = (
 	switch (answer._tag) {
 		case "Moved":
 		case "Cleared":
+		case "Filtering":
 			return {type: "window.setView", windowId: windowId as never, view: answer.view};
 		case "Chose":
 			return answer.intent._tag === "OpenProgram"

--- a/apps/tuval/src/shell/ui/PickerView.tsx
+++ b/apps/tuval/src/shell/ui/PickerView.tsx
@@ -13,10 +13,15 @@
  * nothing ever focused moves a highlight nobody hears (#7499). Taking focus is not a second
  * listener — the desk's document listener still sees every press, because a `div` is not a text
  * entry and the key never stops there.
+ *
+ * The filter `/` opens is the one exception, and it is the command line's own shape (#8450): while
+ * it holds focus the desk leaves it every press (`./text-entry.ts`), so the four keys the picker
+ * still owns there — Enter, Escape and the two arrows — are read off the input's own `onKeyDown`
+ * and answered by the same `pickerKey`. That is a React prop, not a second document listener.
  */
 
-import type {ReactElement} from "react";
-import {useCallback, useEffect, useRef} from "react";
+import type {KeyboardEvent, ReactElement} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 import type {ShellMsg} from "../core/index.ts";
 import {
 	type PickerEntries,
@@ -25,10 +30,27 @@ import {
 	pickerFrame,
 	pickerKey,
 	pickerPointer,
+	withFilter,
 } from "../picker/browser.ts";
 import type {WindowId} from "../window/index.ts";
 import {useForwardedKey} from "./forwarded-key.tsx";
 import {isTextEntry} from "./text-entry.ts";
+
+/**
+ * How long the typing has to stop before the match count is announced. Founder-ruled on #8450:
+ * announcing per keystroke turns one search into a run of interruptions. GOV.UK's
+ * accessible-autocomplete waits 1400 ms for the same reason; this list is local and instant, so
+ * ours is shorter.
+ */
+const ANNOUNCE_PAUSE_MS = 1_000;
+
+/** The keys the picker still answers while the caret is in the filter, by their DOM `key`. */
+const FILTER_KEYS: Readonly<Record<string, string>> = {
+	Enter: "<enter>",
+	Escape: "<escape>",
+	ArrowDown: "<arrowdown>",
+	ArrowUp: "<arrowup>",
+};
 
 export interface PickerViewProps {
 	readonly windowId: WindowId;
@@ -51,6 +73,7 @@ export function PickerView({
 }: PickerViewProps): ReactElement {
 	const frame = pickerFrame(windowId, entries, view, {reducedMotion});
 	const listbox = useRef<HTMLDivElement>(null);
+	const filterInput = useRef<HTMLInputElement>(null);
 
 	// Never off the command line's input: the desk hands that surface focus deliberately, and a
 	// picker that grabbed it back would eat the line the user is typing.
@@ -62,9 +85,15 @@ export function PickerView({
 		node.focus({preventScroll: true});
 	}, []);
 
+	// The two ends of the picker's focus, in one place so they cannot both claim it: `/` moves the
+	// caret into the filter and Escape hands it straight back to the listbox, which is the element
+	// `aria-activedescendant` has to be announced off.
+	const filtering = frame.filter !== null;
 	useEffect(() => {
-		if (focused) takeFocus();
-	}, [focused, takeFocus]);
+		if (!focused) return;
+		if (filtering) filterInput.current?.focus({preventScroll: true});
+		else takeFocus();
+	}, [filtering, focused, takeFocus]);
 
 	// Nothing else moves the scroll port: the listbox holds focus and the options are untabbable, so
 	// the browser never scrolls a row into view on its own and the highlight walks out of
@@ -78,11 +107,37 @@ export function PickerView({
 			?.scrollIntoView({block: "nearest"});
 	}, [activeDescendant]);
 
+	// The count, held back until the typing stops, and written into the two status regions by turns.
+	// The turn is what re-announces a count that did not change: a live region whose text is
+	// rewritten with the same string is not a change, so nothing is read out (GOV.UK's status
+	// component technique, founder-ruled on #8450).
+	const [announced, setAnnounced] = useState<{readonly text: string; readonly slot: 0 | 1}>({
+		text: "",
+		slot: 1,
+	});
+	const announcement = frame.announcement;
+	const regions = announcement.role === "status" ? announcement.alternates : null;
+	// A boolean rather than the id pair: the frame mints a fresh array every render, and an effect
+	// keyed on it would re-arm the pause on renders nobody typed into.
+	const alternating = regions !== null;
+	const countText = announcement.text;
+	// The query and not only the text: two different queries can leave the same count, and that is
+	// exactly the announcement the alternation exists to repeat.
+	const query = frame.filter?.value ?? null;
+	useEffect(() => {
+		if (!alternating || query === null) return;
+		const timer = setTimeout(() => {
+			setAnnounced((previous) => ({text: countText, slot: previous.slot === 0 ? 1 : 0}));
+		}, ANNOUNCE_PAUSE_MS);
+		return () => clearTimeout(timer);
+	}, [alternating, query, countText]);
+
 	const run = useCallback(
 		(answer: PickerKeyAnswer) => {
 			switch (answer._tag) {
 				case "Moved":
 				case "Cleared":
+				case "Filtering":
 					dispatch({type: "window.setView", windowId, view: answer.view});
 					return;
 				case "Chose":
@@ -99,6 +154,19 @@ export function PickerView({
 		[dispatch, windowId],
 	);
 
+	// The caret is in the filter, so the desk left this press here (`./text-entry.ts`). Only the four
+	// keys the picker still owns are taken; every other one — `j`, `k`, `g`, `G` included — is a
+	// character the operator is typing and stays the input's.
+	const onFilterKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLInputElement>) => {
+			const spelled = FILTER_KEYS[event.key];
+			if (spelled === undefined) return;
+			event.preventDefault();
+			run(pickerKey(windowId, entries, view, spelled));
+		},
+		[entries, run, view, windowId],
+	);
+
 	useForwardedKey(windowId, (key) => {
 		// A forwarded key means the desk considers this window focused. Re-claiming here is what
 		// carries focus back after the command line closes onto the desk container.
@@ -108,12 +176,47 @@ export function PickerView({
 
 	return (
 		<div className="tuval-picker">
+			{frame.filter === null ? null : (
+				<div className="tuval-picker-filter">
+					<label htmlFor={frame.filter.id} aria-hidden="true">
+						/
+					</label>
+					{/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: the role is an expression, so the
+					    rule judges the input's implicit `textbox`; `combobox` is what `pickerFrame` says
+					    and what the element carries, and `aria-expanded` is required on it */}
+					<input
+						id={frame.filter.id}
+						ref={filterInput}
+						type="text"
+						// The focus holder while it exists, so it is the element the highlight is announced
+						// off — the listbox below drops `aria-activedescendant` for exactly as long.
+						role={frame.filter.role}
+						aria-expanded={frame.filter.expanded}
+						aria-autocomplete={frame.filter.autocomplete}
+						aria-controls={frame.filter.controls}
+						aria-activedescendant={frame.activeDescendant ?? undefined}
+						value={frame.filter.value}
+						autoComplete="off"
+						spellCheck={false}
+						placeholder={frame.filter.placeholder}
+						aria-label={frame.filter.label}
+						onChange={(event) =>
+							dispatch({
+								type: "window.setView",
+								windowId,
+								view: withFilter(view, event.target.value),
+							})
+						}
+						onKeyDown={onFilterKeyDown}
+					/>
+				</div>
+			)}
 			<div
 				ref={listbox}
 				role="listbox"
 				id={frame.id}
 				aria-label={frame.label}
-				aria-activedescendant={frame.activeDescendant ?? undefined}
+				aria-activedescendant={filtering ? undefined : (frame.activeDescendant ?? undefined)}
 				tabIndex={-1}
 			>
 				{frame.groups.map((group) => (
@@ -157,13 +260,31 @@ export function PickerView({
 					</div>
 				))}
 			</div>
-			<p
-				className="tuval-refusal"
-				role={frame.announcement.role}
-				aria-live={frame.announcement.live}
-			>
-				{frame.announcement.text}
-			</p>
+			{regions === null ? (
+				<p
+					className="tuval-refusal"
+					role={announcement.role}
+					aria-live={announcement.live}
+					{...(announcement.role === "status" ? {"aria-atomic": true} : {})}
+				>
+					{announcement.text}
+				</p>
+			) : (
+				// Two regions, written into by turns. Both are always in the DOM — a live region added to
+				// the page at the same moment its text arrives is announced by nothing.
+				regions.map((id, slot) => (
+					<p
+						key={id}
+						id={id}
+						className="tuval-refusal"
+						role="status"
+						aria-live="polite"
+						aria-atomic="true"
+					>
+						{announced.slot === slot ? announced.text : ""}
+					</p>
+				))
+			)}
 			<dl className="tuval-refusal">
 				{frame.keyHelp.map((help) => (
 					<div key={help.keys}>

--- a/apps/tuval/src/shell/ui/picker-filter.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/picker-filter.unit.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The `/` filter as the operator meets it (#8450): where the caret goes, which keys stay the
+ * picker's while it is there, and how the match count is announced without stealing focus.
+ *
+ * The announcement is the half a frame cannot prove on its own — the 1000 ms pause and the two
+ * alternating status regions are both behaviour over time, so they are asserted here on real
+ * elements with the clock under the test's control.
+ */
+
+import {act, fireEvent, render} from "@testing-library/react";
+import type {ReactElement} from "react";
+import {useState} from "react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {
+	mountPicker,
+	type PickerEntries,
+	type PickerView as PickerViewState,
+	programEntries,
+	withFilter,
+} from "../picker/browser.ts";
+import {processId, programId, programRow} from "../picker/fixtures.ts";
+import {WindowId} from "../window/index.ts";
+import {installDomShims} from "./dom.testing.ts";
+import {PickerView} from "./PickerView.tsx";
+
+installDomShims();
+
+/** The pause `./PickerView.tsx` holds the count back for. Stated once, asserted either side of it. */
+const ANNOUNCE_PAUSE = 1_000;
+
+const windowId = WindowId.make("window-1");
+
+const entries: PickerEntries = {
+	programs: programEntries([
+		programRow("counter", {label: "Counter"}),
+		programRow("pi", {label: "Pi"}),
+	]),
+	processes: [
+		{
+			_tag: "Process",
+			processId: processId("p-1"),
+			programId: programId("counter"),
+			label: "Counter",
+			parentId: null,
+		},
+	],
+};
+
+/**
+ * The desk's fold, in miniature: the picker's `window.setView` writes the slot and the next render
+ * reads it back, which is the only route the filter's text has to the input.
+ */
+function Desk({start}: {readonly start: PickerViewState}): ReactElement {
+	const [view, setView] = useState(start);
+	return (
+		<PickerView
+			windowId={windowId}
+			entries={entries}
+			view={view}
+			dispatch={(msg) => {
+				if (msg.type === "window.setView") setView(msg.view as PickerViewState);
+			}}
+			reducedMotion={true}
+			focused={true}
+		/>
+	);
+}
+
+const mount = (start: PickerViewState = mountPicker()) => {
+	const {container} = render(<Desk start={start} />);
+	return {
+		container,
+		input: () => container.querySelector<HTMLInputElement>("input"),
+		listbox: () => container.querySelector('[role="listbox"]'),
+		rows: () =>
+			[...container.querySelectorAll('[role="option"]')].map(
+				(option) => option.getAttribute("aria-label") ?? "",
+			),
+		statuses: () =>
+			[...container.querySelectorAll('[role="status"]')].map((region) => region.textContent ?? ""),
+		alerts: () => [...container.querySelectorAll('[role="alert"]')],
+	};
+};
+
+const typing = (picker: ReturnType<typeof mount>) => (text: string) => {
+	const input = picker.input();
+	if (input === null) throw new Error("the picker rendered no filter input");
+	fireEvent.change(input, {target: {value: text}});
+	return input;
+};
+
+const pause = (ms: number) => {
+	act(() => {
+		vi.advanceTimersByTime(ms);
+	});
+};
+
+beforeEach(() => {
+	vi.useFakeTimers({shouldAdvanceTime: true});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("the picker's `/` filter", () => {
+	it("renders above the list, takes the caret, and starts with every row still shown", () => {
+		const picker = mount(withFilter(mountPicker(), ""));
+		const input = picker.input();
+		const listbox = picker.listbox();
+		expect(input).not.toBeNull();
+		expect(input?.value).toBe("");
+		expect(picker.rows()).toHaveLength(3);
+		expect(input?.ownerDocument.activeElement).toBe(input);
+		expect(input?.compareDocumentPosition(listbox as Node)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+	});
+
+	it("carries the highlight on itself while it holds focus, so it is announced at all", () => {
+		const picker = mount(withFilter(mountPicker(), ""));
+		const input = picker.input();
+		expect(input?.getAttribute("role")).toBe("combobox");
+		expect(input?.getAttribute("aria-expanded")).toBe("true");
+		expect(input?.getAttribute("aria-autocomplete")).toBe("list");
+		expect(input?.getAttribute("aria-controls")).toBe("picker-window-1");
+		expect(input?.getAttribute("aria-activedescendant")).toBe("picker-window-1-option-0");
+		// The listbox is not the focus holder any more, so it must not also claim the highlight.
+		expect(picker.listbox()?.getAttribute("aria-activedescendant")).toBeNull();
+
+		fireEvent.keyDown(input as HTMLInputElement, {key: "ArrowDown"});
+		expect(picker.input()?.getAttribute("aria-activedescendant")).toBe("picker-window-1-option-1");
+	});
+
+	it("narrows both sections as the operator types, and `j` is a character not a move", () => {
+		const picker = mount(withFilter(mountPicker(), ""));
+		const type = typing(picker);
+		type("counter");
+		expect(picker.rows()).toEqual([
+			"Counter — program counter",
+			"Counter — process p-1, no parent",
+		]);
+
+		// `j` reaches the input as text, so the list narrows rather than the cursor moving.
+		type("j");
+		expect(picker.rows()).toEqual([]);
+		expect(picker.input()?.value).toBe("j");
+	});
+
+	it("announces the count once the typing stops, not once per keystroke", () => {
+		const picker = mount(withFilter(mountPicker(), ""));
+		const type = typing(picker);
+		type("c");
+		pause(400);
+		type("co");
+		pause(400);
+		type("cou");
+		expect(picker.statuses().join("")).toBe("");
+
+		pause(ANNOUNCE_PAUSE);
+		expect(picker.statuses().filter((text) => text !== "")).toEqual(["2 of 3 windows"]);
+	});
+
+	it("re-announces an unchanged count by writing into the other status region", () => {
+		const picker = mount(withFilter(mountPicker(), ""));
+		const type = typing(picker);
+		type("co");
+		pause(ANNOUNCE_PAUSE);
+		expect(picker.statuses()).toEqual(["2 of 3 windows", ""]);
+
+		// A different query, the same count: without the alternation nothing would be read out again.
+		type("cou");
+		pause(ANNOUNCE_PAUSE);
+		expect(picker.statuses()).toEqual(["", "2 of 3 windows"]);
+	});
+
+	it("keeps the count out of the assertive channel — `alert` is still the refusal's alone", () => {
+		const picker = mount(withFilter(mountPicker(), ""));
+		typing(picker)("zzz");
+		pause(ANNOUNCE_PAUSE);
+		expect(picker.alerts()).toEqual([]);
+		expect(picker.statuses().filter((text) => text !== "")).toEqual([
+			"No windows match this filter.",
+		]);
+		expect(
+			picker.container.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]'),
+		).toHaveLength(2);
+	});
+
+	it("Escape closes the filter and hands the caret back to the listbox", () => {
+		const picker = mount(withFilter(mountPicker(), "pi"));
+		const input = picker.input();
+		expect(picker.rows()).toHaveLength(1);
+		fireEvent.keyDown(input as HTMLInputElement, {key: "Escape"});
+		expect(picker.input()).toBeNull();
+		expect(picker.rows()).toHaveLength(3);
+		expect(picker.container.ownerDocument.activeElement).toBe(picker.listbox());
+		// The highlight comes back onto the element that now holds focus, and onto the row the
+		// operator was actually looking at — "Pi" is row 1 of the widened list, not row 0.
+		expect(picker.listbox()?.getAttribute("aria-activedescendant")).toBe(
+			"picker-window-1-option-1",
+		);
+	});
+
+	it("a fresh mount starts with no filter and the whole list, whatever the last one held", () => {
+		const filtering = mount(withFilter(mountPicker(), "pi"));
+		expect(filtering.rows()).toHaveLength(1);
+
+		// What `mountPicker()` produces is what the next `<c-b> w` renders — nothing carries over.
+		const reopened = mount(mountPicker());
+		expect(reopened.input()).toBeNull();
+		expect(reopened.rows()).toHaveLength(3);
+	});
+});

--- a/apps/tuval/src/shell/ui/picker-view.unit.test.tsx
+++ b/apps/tuval/src/shell/ui/picker-view.unit.test.tsx
@@ -65,12 +65,12 @@ describe("the picker answers the pointer through the keyboard's own cursor", () 
 			{
 				type: "window.setView",
 				windowId,
-				view: {cursor: 2, refusal: null, previous: null},
+				view: {cursor: 2, refusal: null, previous: null, filter: null},
 			},
 		]);
 
 		// The desk folds that view back in; the highlight the mouse moved is the one ARIA announces.
-		const moved = mount({cursor: 2, refusal: null, previous: null});
+		const moved = mount({cursor: 2, refusal: null, previous: null, filter: null});
 		expect(moved.listbox.getAttribute("aria-activedescendant")).toBe("picker-window-1-option-2");
 		expect(rowAt(moved.options, 2).getAttribute("aria-selected")).toBe("true");
 	});

--- a/apps/tuval/src/shell/ui/tokens.css
+++ b/apps/tuval/src/shell/ui/tokens.css
@@ -217,6 +217,35 @@
 	color: var(--text-primary);
 }
 
+/* The `/` filter at the top of the list. Same box as the command line's input, because it is the
+   same gesture: a prompt the desk hands the caret to. */
+.tuval-picker-filter {
+	display: flex;
+	gap: var(--s-2);
+	align-items: center;
+}
+
+.tuval-picker-filter label {
+	color: var(--text-muted);
+	font: var(--t-mono);
+}
+
+.tuval-picker-filter input {
+	flex: 1 1 auto;
+	min-inline-size: 0;
+	min-block-size: var(--tap-min);
+	background: var(--surface-sunken);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	color: var(--text-primary);
+	font: var(--t-mono);
+	padding: 0 var(--s-2);
+}
+
+.tuval-picker-filter input::placeholder {
+	color: var(--text-muted);
+}
+
 .tuval-picker-detail {
 	color: var(--text-muted);
 	font: var(--t-meta);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ catalogs:
     effect:
       specifier: 4.0.0-rc.112
       version: 4.0.0-rc.112
+    fzf:
+      specifier: 0.5.2
+      version: 0.5.2
 
 overrides:
   '@effect/platform-node@4.0.0-beta.92>@effect/platform-node-shared': 4.0.0-beta.92
@@ -330,6 +333,9 @@ importers:
       effect:
         specifier: catalog:tuval
         version: 4.0.0-rc.112
+      fzf:
+        specifier: catalog:tuval
+        version: 0.5.2
       pi-subagents:
         specifier: 'catalog:'
         version: 0.66.0(@earendil-works/pi-agent-core@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-ai@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3))(@earendil-works/pi-tui@0.85.1)(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
@@ -4881,6 +4887,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fzf@0.5.2:
+    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
   gaxios@7.3.1:
     resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
@@ -10152,6 +10161,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fzf@0.5.2: {}
 
   gaxios@7.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -132,11 +132,15 @@ catalog:
 # sits on beta.92. A named catalog declares one version per consumer set, and that is a claim about
 # the manifests only: it does not reach what those declared packages pull in underneath. One such
 # transitive edge did cross over, and the `overrides` block below is what holds it.
+#
+# `fzf` (fzf-for-js) rides here rather than in the root catalog because apps/tuval is its only
+# consumer — the picker's type-to-filter matcher, founder-ruled on #8450.
 catalogs:
   tuval:
     '@effect/platform-node': 4.0.0-rc.112
     '@effect/vitest': 4.0.0-rc.112
     effect: 4.0.0-rc.112
+    fzf: 0.5.2
 
 # `@effect/platform-node@4.0.0-beta.92` asks for `@effect/platform-node-shared` by a caret range, and
 # a caret over a prerelease picks the highest version present in the workspace. So the moment


### PR DESCRIPTION
The Tuval window picker offered every windowed program and every attachable process as one flat
list, and the only way to a row was to arrow onto it. `/` now opens a filter input at the top of the
list and narrows both sections as the operator types.

Fixes #8450

## What changed

- **`fzf` (fzf-for-js) is the matcher**, added under `catalogs.tuval` in `pnpm-workspace.yaml` and
  taken as `catalog:tuval`. No repo-local scorer, tie-break table or positional weight — the ranking
  engine is theirs. The lockfile records it as `fzf@0.5.2: {}`: no transitive deps, so no crossed
  catalog edge to hold under `overrides:`.
- **`apps/tuval/src/shell/picker/filter.ts`** is the whole narrowing: one `Fzf` per section, its
  `selector` reading the row's own `label` and nothing else, so a program id, a process id and a
  parent id never reach the query.
- **`visibleFor` is the one door every reader goes through** — `cursorOf`, `highlighted`,
  `pickerKey`, `pickerPointer` and `pickerFrame` all address the narrowed list, so the highlight, the
  frame and the intent `<enter>` runs cannot name three different rows under a stale cursor.
- **`PickerView.filter`** is a `string | null` slot: `null` is "no filter open", which is what every
  mount starts at. Nothing persists it across a mount.
- **`j` / `k` / `g` / `G` stay movement keys.** While the caret is in the filter the desk leaves the
  input every press (`isTextEntry`), and only Enter, Escape and the two arrows are taken back — off
  the input's own `onKeyDown` prop, which is not a second document listener.
- **Escape is three keys in one now:** clear a refusal, else close the filter (carrying the
  highlighted row's index into the widened list), else return to `previous`.
- **`tuval-picker` is a new proof surface** (`apps/tuval/src/shell/picker/proof/`, `pnpm
  proof:picker`), in the shape of the four Tuval surfaces already declared: two empty windows through
  the real `WindowView`, one plain and one already filtering on `co`. See the deviation below.

## Accessibility

- The filter is a **`combobox`** while it exists, because it is the DOM focus holder and
  `aria-activedescendant` is announced only off the focused element (#7499). It carries the
  highlight; the listbox drops `aria-activedescendant` for exactly as long and takes it back on
  Escape.
- The match count is a **WCAG 2.2 SC 4.1.3 status message** — `role="status"`, `aria-live="polite"`,
  `aria-atomic="true"`, focus untouched — announced **1000 ms after the typing stops**, not per
  keystroke.
- `pickerFrame` names **two** status region ids and the surface writes into them by turns, so a count
  that did not change is still read out (the GOV.UK status-component technique). A test drives two
  queries that leave the same count and asserts the alternation.
- `role="alert"` / `aria-live="assertive"` stays the refusal's alone; the count never reaches it.

## Evidence

A capture of the new `/tuval/picker` surface is attached, marked first-render: it has no before,
because the surface is new in this PR. It shows both states side by side — the picker as `<c-b> w`
leaves it, and the same picker filtering on `co` with both sections narrowed, the caret in the input
and `3 of 8 windows` in the status region.

## Deviations

- **Out-of-scope change** — **Said:** #8450's 13 acceptance criteria name no proof surface, and an
earlier round of this PR said adding one was outside the ticket.
**Did:** added a fifth Tuval `uiSurfaces` row, `tuval-picker`, with its proof page, its package
script and a `.patterns` bullet.
**Why:** `ship gate` refused this PR at head with `review-ui absent`. `ship scope` derives `ui` over
the `uiSurfaces` prefixes, so `review-ui` is a required namespace for this diff — but the picker is
behind `<c-b> w` and its filter behind a further `/`, `fabrika ui render` drives a bare route, and no
picker surface was declared. So no lawful capture set could reach the state under judgment and the PR
could not ship. The PR adds a rendered surface the repo's own design gate cannot see; this closes
that.
**Disposition:** stated here. The wider fix — letting a capture set be produced by an interaction
script, so a gated state does not each owe its own surface — is filed as #7306 and is not in this PR.

- **Said:** build against the typed prohibition registry.
**Did:** built against the manifest's prose prohibitions — `LAW-SOURCE: manifest-prose`.
**Why:** `fabrika ui law` answers 13; there is no `design-prohibitions.json` beside
`design-system-manifest.md`.
**Disposition:** the new CSS reaches for role tokens only (`--surface-sunken`, `--border`,
`--text-primary`, `--text-muted`, `--r-md`, `--s-2`, `--t-mono`, `--tap-min`) and mints nothing. The
proof page's own sheet adds three harness rules (`.proof-desk`, `.proof-pane`, the page backdrop),
paints nothing the product ships, and reaches for role tokens too.

- **Said:** no lint suppressions.
**Did:** one `biome-ignore` on the filter input, for `lint/a11y/useAriaPropsSupportedByRole`.
**Why:** the rule reads `role={frame.filter.role}` as an expression it cannot evaluate and judges
the element by the implicit `textbox` role, under which `aria-expanded` is unsupported. The role is
`combobox`, where ARIA 1.2 requires `aria-expanded`.
**Disposition:** kept, with the reason inline. Spelling the role as a JSX literal would silence the
rule but would take the role declaration out of the frame, which is the one place it belongs.

- **Said:** the superseded Q1 amendment asked for case-insensitive matching.
**Did:** fzf's smart case — an all-lowercase query ignores case, a capital asks for one.
**Why:** the sharpened ruling replaces that reading with "use fzf", and smart case is that package's
documented `BaseOptions.casing` default.
**Disposition:** kept as fzf answers it; `filter.unit.test.ts` pins both halves so the behaviour is
stated rather than implied.

- **Said:** touch only what the ticket names.
**Did:** added three bullets to `.patterns/tuval-shell-assembly.md`, a paragraph and a command line
to `apps/tuval/README.md`, and a `Filtering` arm to five exhaustive switches outside the picker
(`window-pick`, `end-to-end`, `claude-vertical`, `subagent-vertical`, `pi-vertical`).
**Why:** the repo's rule is that a load-bearing pattern gets documented rather than left implicit —
the third pattern bullet and the README paragraph are the new proof surface's; and those switches
were exhaustive over `PickerKeyAnswer`, so they stopped compiling when the arm landed.
**Disposition:** all kept. Each switch already grouped `Moved` with `Cleared`, and `Filtering` joins
that group — no behaviour moved.
