### PR TITLE
feat: Reviewers inside an epic can't file a fix-it-next-round note

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -255,6 +255,18 @@ a regression test covers qty > 1
 EOF
 ```
 
+**On an epic child, name the range instead of a PR.** There is no PR mid-run (§6), so the subject
+is the same `--base`/`--tip` pair your verdict was posted over, the positional is the child issue,
+and the tag reads `range:<base>..<tip>` rather than `pr:#<n>`. Every fence runs unchanged, so the
+route this step names is open on a child exactly as it is on a PR — a finding that ends up as prose
+in the verdict body instead enters no cycle.
+
+```bash
+fabrika review append-criterion $child_issue --base 9f2c1ab --tip 03135b9 --round 1 <<'EOF'
+a regression test covers the widened union
+EOF
+```
+
 **Trivial mode.** A bounded-trivial diff (one concern, `harness: false` in scope — blast radius,
 never the governance obligation, which is §6's `governance` token — no new surface,
 truthful `None.`) skips the fan-out only — fewer dimensions, **not** a lowered bar; any ambiguity
@@ -312,7 +324,10 @@ undisclosed that this gate could see"* — never "no deviations exist".
   same range appends exactly as the PR path does** — the prior verdict is retired below the fence,
   the answer's sixth field reads `superseded`, and a polarity flip over that range is exit `17`
   until `--supersede` says so. It matters more here than on a PR: a child's comment is the
-  whole record of that child's review, with no PR surface holding a second copy. Deferring the
+  whole record of that child's review, with no PR surface holding a second copy. **§4's
+  append takes the same pair** — `fabrika review append-criterion <child-issue> --base <b> --tip <t>
+  --round <n>` — so an in-scope finding on a child binds the next round through the fences rather
+  than surviving as prose. Deferring the
   namespace strands the lane whichever polarity you reached: a claimed `PASS` reds at `lane prove`
   exit `23`, and a `FAIL` is recorded only once every derived namespace is terminal against the
   range (`operate`'s `FAIL` row). The every-round rule above is unchanged here — a child's FAIL

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -1279,8 +1279,8 @@ fabrika review append-criterion 6095 --base 9f2c1ab --tip 03135b9 --round 1 [--r
 
 The criterion text arrives on **stdin** — one checkbox row's text, without the leading `- [ ]`.
 
-**The subject is a PR or a range, never both.** An epic child has no pull request mid-run (ADR
-0285), so `--base`/`--tip` name what the round was judged over, exactly as they do for `review post`.
+**The subject is a PR or a range, never both.** An epic child has no pull request mid-run, so
+`--base`/`--tip` name what the round was judged over, exactly as they do for `review post`.
 All four fences run identically on either form; the only thing that differs is what the provenance
 tag names.
 

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -28,7 +28,7 @@ Named because a spec that leaves the substrate open makes the implementer guess.
 | `review verdicts` | every verdict marker on the PR, per namespace, each with its `Current` / `Stale` / `Unbindable` binding against the live head and the content it bound | comment sweep + registered parse + `bindToContent` is mechanical; what a stale marker means for this round is judgment |
 | `review deviations` | the PR body's `## Deviations` section state (found / absent / malformed), its entries, and the Tier-M token scan over the diff | section detection and token scanning are mechanical; matching entry *substance* against findings is judgment (Tier R) |
 | `review post` | the single sanctioned verdict emit: compose through the `verdict-marker` wire format, bind to the inspected head at post time, post one comment per namespace at that head, read it back | marker composition, head re-resolution, leak scan and read-back are a protocol; the polarity and clause are judgment |
-| `review append-criterion` | append one reviewer-authored acceptance criterion to the linked issue under the four fences (append-only · ACL-gated fail-closed · frozen at `src/retry-budget.ts`'s `CAP_ROUND`), with provenance tag | the fences and the diff-guarded append are mechanical; whether a finding is in-scope is judgment |
+| `review append-criterion` | append one reviewer-authored acceptance criterion to the linked issue under the four fences (append-only · ACL-gated fail-closed · frozen at `src/retry-budget.ts`'s `CAP_ROUND`), with a provenance tag naming the PR or, on an epic child, the range | the fences and the diff-guarded append are mechanical; whether a finding is in-scope is judgment |
 | `review scratch` | the per-lane directory this reviewer's staged files go under, allocated fail-closed | deriving a namespace no second lane resolves to, and refusing when it cannot be derived, is mechanical; what to stage there is judgment |
 
 ### Considered and deliberately not derived
@@ -127,7 +127,7 @@ prose copies are not the authority.
 | `7` | zero scope: the target is **proven absent (404)** or closed, the PR has zero changed files or zero declared check runs, or a required block is proven absent or malformed — a fail-closed refusal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `8` | the write itself failed — the outcome is **UNKNOWN** | — | — | — | — | — | — | ✓ | ✓ |
 | `9` | the write landed but the read-back does not match | — | — | — | — | — | — | ✓ | ✓ |
-| `10` | a supplied classification value is off the closed vocabulary — a namespace outside this PR's derived class set, a bad polarity or carrier, a `--sha` that is not a head SHA | ✓ | ✓ | — | — | — | ✓ | ✓ | — |
+| `10` | a supplied classification value is off the closed vocabulary — a namespace outside this PR's derived class set, a bad polarity or carrier, a `--sha` that is not a head SHA, or flags that name no review subject or two | ✓ | ✓ | — | — | — | ✓ | ✓ | ✓ |
 | `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `12` | refused: the `--sha` given is not the PR's head — a read taken over, or a verdict bound to, a tree that is no longer the PR | ✓ | ✓ | — | — | — | ✓ | ✓ | — |
 | `13` | refused: the read was completed but its scope is **provably incomplete** — a truncated file list or diff, a check-run enumeration short of `total_count` | ✓ | ✓ | — | ✓ | ✓ | ✓ | — | — |
@@ -1274,16 +1274,24 @@ $ echo $?
 
 ```
 fabrika review append-criterion 4287 --pr 4321 --round 1 [--repo <owner/name>] [--json]
+fabrika review append-criterion 6095 --base 9f2c1ab --tip 03135b9 --round 1 [--repo <owner/name>] [--json]
 ```
 
 The criterion text arrives on **stdin** — one checkbox row's text, without the leading `- [ ]`.
+
+**The subject is a PR or a range, never both.** An epic child has no pull request mid-run (ADR
+0285), so `--base`/`--tip` name what the round was judged over, exactly as they do for `review post`.
+All four fences run identically on either form; the only thing that differs is what the provenance
+tag names.
 
 **Inputs**
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
-| *(positional)* | integer | yes | — | the linked issue receiving the criterion |
-| `--pr` | integer | yes | — | the PR whose review round produced the finding — half the provenance tag |
+| *(positional)* | integer | yes | — | the linked issue receiving the criterion — on the range form, the epic child |
+| `--pr` | integer | yes, unless `--base`/`--tip` | — | the PR whose review round produced the finding — half the provenance tag |
+| `--base` | string | yes, unless `--pr` | — | with `--tip`: the range `<base>..<tip>` the round was judged over, standing in for `--pr`; never combined with `--pr` |
+| `--tip` | string | with `--base` | — | the range's tip revision — the other half of `--base` |
 | `--round` | integer | yes | — | this review round's number; at or past the freeze (`src/retry-budget.ts`'s `CAP_ROUND`) the verb escalates instead of appending |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
@@ -1302,7 +1310,9 @@ With `--json`: `{"outcome":…,"issue":…,"rows":…,"round":…,"acl":"write+"
    below `write`, or any ACL lookup failure, refuses — authority comes from the ACL check, never
    from the text being plausible.
 2. **Append-only**: the new body is the old body plus exactly one row (`- [ ] <text>
-   <!-- ac:review pr:#<pr> round:<round> -->`) under the existing conforming heading; a diff
+   <!-- ac:review pr:#<pr> round:<round> -->`, or `<!-- ac:review range:<base>..<tip> round:<round> -->`
+   on the range form — the range spelled as `range-verdict-marker.ts` spells it, so one range reads
+   the same in a criterion row and in the verdicts `lane prove` folds) under the existing conforming heading; a diff
    guard refuses any write that would drop or mutate a prior byte. The row lands after the last
    criterion's **last physical line**, taken from the parser's own span — a criterion that wraps
    spans several lines and its text appears on none of them, so matching text against lines found
@@ -1324,6 +1334,7 @@ The row enters the **next** review cycle's conjunctive verdict; the verb does no
 | `7` | the issue is proven absent (404) or closed; or its body carries no conforming acceptance-criteria block to append under (the wire read's `Absent`/`Malformed`, distinguished on stderr) |
 | `8` | the body PATCH, or on the frozen path the escalation comment, failed — UNKNOWN; the message names which |
 | `9` | the write landed but the read-back does not show exactly the old rows plus this one |
+| `10` | the flags name no subject, or two — no `--pr` and no range, `--pr` beside a range, a lone `--base`/`--tip`, or an end that is not a revision |
 | `11` | the issue body, the ACL, or the block could not be read — nothing was written |
 | `14` | refused: the invoking token resolves below `write`, or the ACL lookup failed, fail-closed — an authorization denial, never mistakable for an absent target |
 | `15` | refused: the composed write is not provably the old body plus one row — the append-only fence. Its three causes carry three different messages: no row to append under, a line the diff guard says would move (named), or a composed body the format re-reads as something other than the prior rows plus this one |
@@ -1335,6 +1346,10 @@ The row enters the **next** review cycle's conjunctive verdict; the verb does no
 | `review append-criterion: no criterion on stdin.` | 3 | refusal |
 | `review append-criterion: the criterion carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
 | `review append-criterion: the criterion is a bare "@" path reference — the text never arrived. Send it on stdin.` | 6 | refusal |
+| `review append-criterion: name the subject the round was judged over — --pr on a pull request, --base/--tip on an epic child's range.` | 10 | refusal |
+| `review append-criterion: --pr does not combine with --base/--tip — a round is judged over one subject, and the tag names it.` | 10 | refusal |
+| `review append-criterion: --base and --tip come together — a range has two ends.` | 10 | refusal |
+| `review append-criterion: --<base\|tip> "<v>" is not a revision — expected 7–40 lowercase hex characters.` | 10 | refusal |
 | `review append-criterion: issue #<n> not found in <repo>.` | 7 | refusal |
 | `review append-criterion: issue #<n> is closed — an appended row there enters no cycle; file the finding instead.` | 7 | refusal |
 | `review append-criterion: #<n> carries no conforming acceptance-criteria block (<absent|malformed>: <wire reason>) — nothing to append under.` | 7 | refusal |
@@ -1361,6 +1376,11 @@ appended	4287	3
 ```
 $ printf 'anything' | fabrika review append-criterion 4287 --pr 4321 --round 4
 escalated-frozen	4287	4
+```
+
+```
+$ printf 'a regression test covers the widened union' | fabrika review append-criterion 6095 --base 9f2c1ab --tip 03135b9 --round 1
+appended	6095	7
 ```
 
 **Grounding**

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -865,7 +865,7 @@ back. Contract:
 | `review verdicts` | every verdict marker on the PR — standing and superseded alike — each with its `current` / `stale` / `unbindable` binding |
 | `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan |
 | `review post` | the single sanctioned verdict emit — compose, bind, append into one comment per namespace, read back; with `--base`/`--tip` the positional is the child issue and the marker binds the range instead of a head |
-| `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
+| `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences, its provenance tag naming the `--pr` or, with `--base`/`--tip`, the range an epic child's round was judged over |
 | `review scratch` | the per-lane directory a reviewer's staged files go under — `<temp root>/fabrika-review/<session-id>/<pr>-<lane-nonce>/<slug>` |
 
 **Exit codes.** The shared table, plus `12` the live head moved past the inspected `--sha` · `13`

--- a/packages/fabrika-cli/src/review/append-criterion-verb.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.ts
@@ -16,6 +16,11 @@
  *
  * v1's `reviewer-append-ac.sh` was mandated at four call sites and called at none — a first-class
  * verb is the difference between a fence and a fence description.
+ *
+ * **The subject is a PR or a commit range, and the fences do not move between them.** An epic child
+ * has no pull request mid-run (ADR 0285), so `--base`/`--tip` name what the round was judged over
+ * exactly as they do for `review post`; all four fences run on that form unchanged, and the only
+ * thing that differs is what the provenance tag can name (`./append.ts`).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -25,16 +30,25 @@ import type {StdinRead} from "../io/stdin.ts";
 import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
-import {appendOnly, criterionRow, grewByOne, insertAfterLastCriterion} from "./append.ts";
+import {
+	appendOnly,
+	type CriterionProvenance,
+	criterionRow,
+	grewByOne,
+	insertAfterLastCriterion,
+	provenanceSubject,
+} from "./append.ts";
 import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
 import {
 	ACL_DENIED,
 	APPEND_ONLY,
+	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
 	ZERO_SCOPE,
 } from "./codes.ts";
+import {readRangeFlags} from "./range-flags.ts";
 import {badNumber, resolveTargetRepo} from "./target.ts";
 
 const VERB = "review append-criterion";
@@ -52,13 +66,55 @@ const SURFACE: AuthoredSurface = {
 
 export interface AppendCriterionOptions {
 	readonly issue: number;
-	readonly pr: number;
+	readonly pr: number | null;
+	readonly base: string | null;
+	readonly tip: string | null;
 	readonly round: number;
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
 	readonly stdin: Effect.Effect<StdinRead>;
 }
+
+type SubjectRead =
+	| {readonly _tag: "Subject"; readonly provenance: CriterionProvenance}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/**
+ * Which subject these flags name, or the refusal that says why they name none.
+ *
+ * `--pr` and a range are alternatives, never a pair: a row tagged with both would claim two
+ * different things about where the finding came from, and a caller that passed the epic's tail PR
+ * beside the range it actually read would get the plausible-but-wrong tag written silently.
+ */
+const readSubject = (options: AppendCriterionOptions): SubjectRead => {
+	const ranged = readRangeFlags(VERB, {base: options.base, tip: options.tip, sha: null});
+	if (ranged._tag === "Refused") return ranged;
+	if (ranged._tag === "Ranged") {
+		return options.pr === null
+			? {_tag: "Subject", provenance: {_tag: "Ranged", range: ranged.range}}
+			: {
+					_tag: "Refused",
+					outcome: refuse(
+						OFF_VOCABULARY,
+						`${VERB}: --pr does not combine with --base/--tip — a round is judged over one subject, and the tag names it.`,
+					),
+				};
+	}
+	if (options.pr === null) {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				OFF_VOCABULARY,
+				`${VERB}: name the subject the round was judged over — --pr on a pull request, --base/--tip on an epic child's range.`,
+			),
+		};
+	}
+	const bad = badNumber(VERB, "a pull-request number", options.pr);
+	return bad !== null
+		? {_tag: "Refused", outcome: bad}
+		: {_tag: "Subject", provenance: {_tag: "Pull", pr: options.pr}};
+};
 
 const unreadable = (what: string, reason: string): VerbOutcome =>
 	refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${what}: ${reason} — nothing was written.`);
@@ -73,11 +129,12 @@ export const runAppendCriterion = (
 	options: AppendCriterionOptions,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
-		const {issue, pr, round, json} = options;
+		const {issue, round, json} = options;
 		const badIssue = badNumber(VERB, "an issue number", issue);
 		if (badIssue !== null) return badIssue;
-		const badPr = badNumber(VERB, "a pull-request number", pr);
-		if (badPr !== null) return badPr;
+		const subject = readSubject(options);
+		if (subject._tag === "Refused") return subject.outcome;
+		const provenance = subject.provenance;
 		const badRound = badNumber(VERB, "a review round", round);
 		if (badRound !== null) return badRound;
 
@@ -132,7 +189,7 @@ export const runAppendCriterion = (
 			const escalated = yield* createComment(
 				repo,
 				issue,
-				`review append-criterion: a finding from PR #${pr}'s round ${round} was NOT appended — the acceptance-criteria fence is frozen at round ${CAP_ROUND}. Routing it to a human instead.\n\n${authored.text}`,
+				`review append-criterion: a finding from ${provenanceSubject(provenance)}'s round ${round} was NOT appended — the acceptance-criteria fence is frozen at round ${CAP_ROUND}. Routing it to a human instead.\n\n${authored.text}`,
 			);
 			if (escalated._tag === "Failure") {
 				return refuse(
@@ -159,7 +216,7 @@ export const runAppendCriterion = (
 		// against what the registered format reads back out of the composed body. The three ways it
 		// can fail refuse on the same code and say different things: one refusal covering all three
 		// left a caller unable to tell a fence hit from an anchor the verb never found.
-		const row = criterionRow(authored.text, pr, round);
+		const row = criterionRow(authored.text, provenance, round);
 		const composition = insertAfterLastCriterion(target.value.body, row);
 		if (composition._tag === "NoAnchor") {
 			return refuse(

--- a/packages/fabrika-cli/src/review/append-criterion-verb.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.ts
@@ -18,8 +18,8 @@
  * verb is the difference between a fence and a fence description.
  *
  * **The subject is a PR or a commit range, and the fences do not move between them.** An epic child
- * has no pull request mid-run (ADR 0285), so `--base`/`--tip` name what the round was judged over
- * exactly as they do for `review post`; all four fences run on that form unchanged, and the only
+ * has no pull request mid-run, so `--base`/`--tip` name what the round was judged over exactly as
+ * they do for `review post`; all four fences run on that form unchanged, and the only
  * thing that differs is what the provenance tag can name (`./append.ts`).
  */
 import {Effect} from "effect";

--- a/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
@@ -379,8 +379,8 @@ ${ROW}
 	});
 
 	/**
-	 * The no-PR form. An epic child is reviewed over a range and has no pull request until the tail
-	 * (ADR 0285), so the range is the subject the round was judged over and the tag names it.
+	 * The no-PR form. An epic child is reviewed over a range and has no pull request until the tail,
+	 * so the range is the subject the round was judged over and the tag names it.
 	 */
 	describe("over a range, with no PR", () => {
 		const ranged = {pr: null, base: BASE, tip: TIP};

--- a/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
@@ -11,6 +11,7 @@ import {
 	BARE_AT_PATH,
 	EMPTY_STDIN,
 	LEAKED_PATH,
+	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
@@ -50,9 +51,24 @@ const APPENDED = `Build the thing.
 ${ROW}
 `;
 
+const BASE = "9f2c1ab";
+const TIP = "03135b9";
+const RANGED_ROW = `- [ ] ${TEXT} <!-- ac:review range:${BASE}..${TIP} round:1 -->`;
+
+const RANGE_APPENDED = `Build the thing.
+
+### Acceptance criteria
+
+- [ ] the first retry delay equals \`base\`
+- [x] the retry guide documents the delay table
+${RANGED_ROW}
+`;
+
 const options = {
 	issue: 4287,
-	pr: 4321,
+	pr: 4321 as number | null,
+	base: null as string | null,
+	tip: null as string | null,
 	round: 1,
 	repo: null,
 	json: false,
@@ -359,6 +375,119 @@ ${ROW}
 			rows: 3,
 			round: 1,
 			acl: "write",
+		});
+	});
+
+	/**
+	 * The no-PR form. An epic child is reviewed over a range and has no pull request until the tail
+	 * (ADR 0285), so the range is the subject the round was judged over and the tag names it.
+	 */
+	describe("over a range, with no PR", () => {
+		const ranged = {pr: null, base: BASE, tip: TIP};
+
+		const rangeHappy = (): ReadonlyArray<Scripted> => [
+			[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+			[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+			[once(ISSUE), served(issue())],
+			[ISSUE, served(issue(RANGE_APPENDED))],
+			[PATCH, {status: 200, body: "{}"}],
+		];
+
+		it("appends one row whose tag names the range, not a PR", async () => {
+			const shell = fakeSeams(rangeHappy());
+			const out = await Effect.runPromise(
+				Effect.provide(runAppendCriterion({...options, ...ranged}), shell.layer),
+			);
+			expect(out.code).toBe(0);
+			expect(out.stdout).toBe("appended\t4287\t3\n");
+			const write = patched(shell);
+			expect(write).toContain(RANGED_ROW);
+			expect(write).not.toContain("ac:review pr:#");
+		});
+
+		it("runs the ACL, block and read-back fences unchanged", async () => {
+			const belowWrite = fakeSeams([
+				[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+				[PERMISSION, {status: 200, body: JSON.stringify({permission: "read"})}],
+			]);
+			const denied = await Effect.runPromise(
+				Effect.provide(runAppendCriterion({...options, ...ranged}), belowWrite.layer),
+			);
+			expect(denied.code).toBe(ACL_DENIED);
+			expect(belowWrite.requests.some((request) => PATCH.test(request))).toBe(false);
+
+			const noBlock = await run(
+				[
+					[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+					[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+					[ISSUE, served(issue("no block here"))],
+				],
+				ranged,
+			);
+			expect(noBlock.code).toBe(ZERO_SCOPE);
+
+			const readBack = await run(
+				[
+					[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+					[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+					[once(ISSUE), served(issue())],
+					[ISSUE, served(issue())],
+					[PATCH, {status: 200, body: "{}"}],
+				],
+				ranged,
+			);
+			expect(readBack.code).toBe(READBACK_MISMATCH);
+		});
+
+		it("escalates at the freeze, naming the range there is no PR to name", async () => {
+			const shell = fakeSeams([
+				[USER, {status: 200, body: JSON.stringify({login: "kampus-bot"})}],
+				[PERMISSION, {status: 200, body: JSON.stringify({permission: "write"})}],
+				[ISSUE, served(issue())],
+				[
+					COMMENT,
+					{status: 201, body: JSON.stringify({id: 1, html_url: "https://example.test/c/1"})},
+				],
+			]);
+			const out = await Effect.runPromise(
+				Effect.provide(runAppendCriterion({...options, ...ranged, round: CAP_ROUND}), shell.layer),
+			);
+			expect(out.code).toBe(0);
+			expect(out.stdout).toBe(`escalated-frozen\t4287\t${CAP_ROUND}\n`);
+			expect(shell.requests.some((request) => PATCH.test(request))).toBe(false);
+			const escalation = String(
+				JSON.parse(
+					shell.bodies[shell.requests.findIndex((request) => COMMENT.test(request))] ?? "{}",
+				).body ?? "",
+			);
+			expect(escalation).toContain(`the range ${BASE}..${TIP}'s round ${CAP_ROUND}`);
+			expect(escalation).not.toContain("PR #");
+		});
+
+		it("refuses on 10 when the flags name no subject, or two", async () => {
+			const none = await run(happy(), {pr: null});
+			expect(none.code).toBe(OFF_VOCABULARY);
+			expect(none.stderr.at(-1)).toContain("name the subject the round was judged over");
+
+			const both = await run(happy(), {pr: 4321, base: BASE, tip: TIP});
+			expect(both.code).toBe(OFF_VOCABULARY);
+			expect(both.stderr.at(-1)).toContain("--pr does not combine with --base/--tip");
+
+			const loneBase = await run(happy(), {pr: null, base: BASE});
+			expect(loneBase.code).toBe(OFF_VOCABULARY);
+			expect(loneBase.stderr.at(-1)).toContain("a range has two ends");
+
+			const notARevision = await run(happy(), {pr: null, base: "main", tip: TIP});
+			expect(notARevision.code).toBe(OFF_VOCABULARY);
+			expect(notARevision.stderr.at(-1)).toContain("is not a revision");
+		});
+
+		it("writes nothing on a flag refusal — the subject is read before the ACL", async () => {
+			const shell = fakeSeams(happy());
+			await Effect.runPromise(
+				Effect.provide(runAppendCriterion({...options, pr: null}), shell.layer),
+			);
+			expect(shell.log).toEqual([]);
 		});
 	});
 });

--- a/packages/fabrika-cli/src/review/append.ts
+++ b/packages/fabrika-cli/src/review/append.ts
@@ -19,7 +19,7 @@ import type {HeadSha} from "../wire/verdict-marker.ts";
 /**
  * What the round was judged over — the half of the provenance tag that is not the round number.
  *
- * An epic child has no pull request mid-run (ADR 0285), so the subject there is the commit range the
+ * An epic child has no pull request mid-run, so the subject there is the commit range the
  * reviewer read, spelled exactly as `range-verdict-marker.ts` spells it so a later reader resolves
  * one range against `lane prove`'s verdicts and this row with the same bytes.
  */

--- a/packages/fabrika-cli/src/review/append.ts
+++ b/packages/fabrika-cli/src/review/append.ts
@@ -11,14 +11,39 @@
  * A composition that inserted the row somewhere the parser does not see it passes the first and reds
  * on the second, which is the whole reason both exist.
  */
+import type {CommitRange} from "../io/git.ts";
 import {type AcceptanceCriterion, readSpans} from "../wire/acceptance-criteria.ts";
+import {renderRange} from "../wire/range-verdict-marker.ts";
+import type {HeadSha} from "../wire/verdict-marker.ts";
+
+/**
+ * What the round was judged over — the half of the provenance tag that is not the round number.
+ *
+ * An epic child has no pull request mid-run (ADR 0285), so the subject there is the commit range the
+ * reviewer read, spelled exactly as `range-verdict-marker.ts` spells it so a later reader resolves
+ * one range against `lane prove`'s verdicts and this row with the same bytes.
+ */
+export type CriterionProvenance =
+	| {readonly _tag: "Pull"; readonly pr: number}
+	| {readonly _tag: "Ranged"; readonly range: CommitRange<HeadSha>};
 
 /** The provenance tag — what makes a routed row auditable after the fact. */
-export const provenanceTag = (pr: number, round: number): string =>
-	`<!-- ac:review pr:#${pr} round:${round} -->`;
+export const provenanceTag = (provenance: CriterionProvenance, round: number): string =>
+	provenance._tag === "Pull"
+		? `<!-- ac:review pr:#${provenance.pr} round:${round} -->`
+		: `<!-- ac:review range:${renderRange(provenance.range)} round:${round} -->`;
 
-export const criterionRow = (text: string, pr: number, round: number): string =>
-	`- [ ] ${text.trim()} ${provenanceTag(pr, round)}`;
+/** How a refusal or an escalation names the subject in prose. */
+export const provenanceSubject = (provenance: CriterionProvenance): string =>
+	provenance._tag === "Pull"
+		? `PR #${provenance.pr}`
+		: `the range ${renderRange(provenance.range)}`;
+
+export const criterionRow = (
+	text: string,
+	provenance: CriterionProvenance,
+	round: number,
+): string => `- [ ] ${text.trim()} ${provenanceTag(provenance, round)}`;
 
 export type Composition =
 	| {readonly _tag: "Composed"; readonly body: string}

--- a/packages/fabrika-cli/src/review/append.unit.test.ts
+++ b/packages/fabrika-cli/src/review/append.unit.test.ts
@@ -1,7 +1,9 @@
 import {describe, expect, it} from "vitest";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
+import {headSha} from "../wire/verdict-marker.ts";
 import {
 	appendOnly,
+	type CriterionProvenance,
 	criterionRow,
 	grewByOne,
 	insertAfterLastCriterion,
@@ -42,11 +44,30 @@ const WRAPPED = `### Acceptance criteria
 `;
 
 describe("criterionRow", () => {
+	const sha = (raw: string) => {
+		const value = headSha(raw);
+		if (value === null) throw new Error(`fixture is not a revision: ${raw}`);
+		return value;
+	};
+	const pull: CriterionProvenance = {_tag: "Pull", pr: 4321};
+	const ranged: CriterionProvenance = {
+		_tag: "Ranged",
+		range: {base: sha("9f2c1ab"), tip: sha("03135b9")},
+	};
+
 	it("carries the provenance tag that makes a routed row auditable", () => {
-		expect(criterionRow("a regression test covers qty > 1", 4321, 1)).toBe(
+		expect(criterionRow("a regression test covers qty > 1", pull, 1)).toBe(
 			"- [ ] a regression test covers qty > 1 <!-- ac:review pr:#4321 round:1 -->",
 		);
-		expect(provenanceTag(4321, 2)).toBe("<!-- ac:review pr:#4321 round:2 -->");
+		expect(provenanceTag(pull, 2)).toBe("<!-- ac:review pr:#4321 round:2 -->");
+	});
+
+	it("names the range when the round was judged over one, distinguishably from a PR", () => {
+		expect(criterionRow("a regression test covers qty > 1", ranged, 1)).toBe(
+			"- [ ] a regression test covers qty > 1 <!-- ac:review range:9f2c1ab..03135b9 round:1 -->",
+		);
+		expect(provenanceTag(ranged, 2)).toBe("<!-- ac:review range:9f2c1ab..03135b9 round:2 -->");
+		expect(provenanceTag(ranged, 2)).not.toContain("pr:#");
 	});
 });
 

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -314,7 +314,7 @@ const appendCriterion = leafCommand(
 		base: Flag.string("base").pipe(
 			Flag.optional,
 			Flag.withDescription(
-				"with --tip: the range <base>..<tip> the round was judged over, standing in for --pr on an epic child that has no PR (#5935's shape); never combined with --pr",
+				"with --tip: the range <base>..<tip> the round was judged over, standing in for --pr on an epic child that has no PR; never combined with --pr",
 			),
 		),
 		tip: Flag.string("tip").pipe(

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -306,9 +306,20 @@ const appendCriterion = leafCommand(
 			Argument.withDescription("the linked issue receiving the criterion"),
 		),
 		pr: Flag.integer("pr").pipe(
+			Flag.optional,
 			Flag.withDescription(
-				"the PR whose review round produced the finding — half the provenance tag",
+				"the PR whose review round produced the finding — half the provenance tag; required unless --base/--tip name an epic child's range instead",
 			),
+		),
+		base: Flag.string("base").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"with --tip: the range <base>..<tip> the round was judged over, standing in for --pr on an epic child that has no PR (#5935's shape); never combined with --pr",
+			),
+		),
+		tip: Flag.string("tip").pipe(
+			Flag.optional,
+			Flag.withDescription("the range's tip revision — the other half of --base"),
 		),
 		round: Flag.integer("round").pipe(
 			Flag.withDescription(
@@ -318,11 +329,13 @@ const appendCriterion = leafCommand(
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({issue, pr, round, repo, json}) {
+	Effect.fn(function* ({issue, pr, base, tip, round, repo, json}) {
 		yield* emit(
 			yield* runAppendCriterion({
 				issue,
-				pr,
+				pr: Option.getOrNull(pr),
+				base: Option.getOrNull(base),
+				tip: Option.getOrNull(tip),
 				round,
 				repo: Option.getOrNull(repo),
 				json,
@@ -334,7 +347,7 @@ const appendCriterion = leafCommand(
 ).pipe(
 	Command.withShortDescription("Append one reviewer-authored acceptance criterion."),
 	Command.withDescription(
-		"Append one reviewer-authored acceptance criterion from STDIN under four fences — ACL-gated fail-closed, append-only, provenance-tagged, frozen at the declared cap round. Prints `appended\\t<issue>\\t<rows-after>`, or `escalated-frozen\\t<issue>\\t<round>` at the freeze; both are proven answers at exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (issue absent or closed, or no conforming acceptance-criteria block), 8 (the PATCH or the escalation comment failed — UNKNOWN), 9 (read-back does not show the prior rows plus this one), 11 (a precondition read failed), 14 (token below write or the ACL lookup failed), 15 (the write is not provably the prior rows plus one — the append-only fence). Example: printf 'a regression test covers qty > 1' | fabrika review append-criterion 4287 --pr 4321 --round 1",
+		"Append one reviewer-authored acceptance criterion from STDIN under four fences — ACL-gated fail-closed, append-only, provenance-tagged, frozen at the declared cap round. The round's subject is a PR (`--pr`) or, on an epic child that has none, the commit range it was judged over (`--base`/`--tip`); the two never combine, and the provenance tag names whichever was given — `pr:#<n>` or `range:<base>..<tip>`, the same spelling `lane prove` reads. Every fence runs identically on both. Prints `appended\\t<issue>\\t<rows-after>`, or `escalated-frozen\\t<issue>\\t<round>` at the freeze; both are proven answers at exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (issue absent or closed, or no conforming acceptance-criteria block), 8 (the PATCH or the escalation comment failed — UNKNOWN), 9 (read-back does not show the prior rows plus this one), 10 (no subject named, both named, a lone --base/--tip, or an end that is not a revision), 11 (a precondition read failed), 14 (token below write or the ACL lookup failed), 15 (the write is not provably the prior rows plus one — the append-only fence). Examples: printf 'a regression test covers qty > 1' | fabrika review append-criterion 4287 --pr 4321 --round 1; printf 'a regression test covers qty > 1' | fabrika review append-criterion 6095 --base 9f2c1ab --tip 03135b9 --round 1",
 	),
 );
 

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -545,6 +545,8 @@ describe("the append-only fence", () => {
 	const options = {
 		issue: 4287,
 		pr: 4321,
+		base: null,
+		tip: null,
 		round: 1,
 		repo: null,
 		json: false,


### PR DESCRIPTION
`review append-criterion` grew the no-PR form the founder ruled on 2026-08-19 (shape A): `append-criterion <issue> --base <b> --tip <t> --round <n>`, mirroring `review post`'s range flags through the same `readRangeFlags` reader. The provenance tag now names whichever subject the round was judged over — `pr:#<n>` or `range:<base>..<tip>` — with the range spelled by `wire/range-verdict-marker.ts`'s `renderRange`, so one range reads identically in a criterion row and in the verdicts `lane prove` folds.

`--pr` and a range are alternatives, never a pair: a row tagged with both would claim two things about where the finding came from, and passing an epic's tail PR beside the range actually read would write a plausible-but-wrong tag. Naming neither, naming both, a lone `--base`/`--tip`, or an end that is not a revision all refuse on `10` before the ACL lookup, so a flag mistake writes nothing.

All four ADR-0079 fences run identically on both forms — the subject only decides what the tag can name. The freeze escalation names the range where there is no PR to name.

Reviewer's first stop: `readSubject` in `append-criterion-verb.ts` (the alternation and its refusals) and `provenanceTag` in `append.ts` (the two tag shapes). The PR-scoped path is byte-identical — the existing `criterionRow` test still pins the old tag exactly.

Docs swept in the same change: the review skill's §4 (the epic-child route, with the range example) and §6 (which had rewritten `review post` for the child path and left `append-criterion` unmentioned), the verb's contract.md section (invocation, inputs, fence 2's row shape, the `10` row in both exit tables, four error rows, a worked example), its `Command.withDescription` help, and its verb-reference row. `--pr`'s help text now says it is required unless `--base`/`--tip` scope the round, which is the discovery cost the 2026-09-10 comment named.

## Deviations

- **Out-of-scope change** — **Said:** criterion 6 names the review skill's §4 only. **Did:** documented §6's epic-child bullet as well. **Why:** §6 is the seam that rewrites `review post` for the child path, so a reviewer reading it alone still ended up at the PR form; the folded duplicate #7670 asked for both. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the folded #7670 note records a second failure mode — once an epic's tail PR is open, `--pr <tail-pr>` is accepted on a child and writes a tag naming a round nobody ran. **Did:** left it. **Why:** no acceptance criterion reaches it, and refusing it needs a new fence the issue's rabbit-holes rule out ("no new fence"). The range form gives that reviewer the correct route; the wrong one staying open is unchanged behaviour. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** the criteria name only `append-criterion-verb.unit.test.ts`. **Did:** also updated `append.unit.test.ts` and `mutation.unit.test.ts`. **Why:** `criterionRow`/`provenanceTag` take a provenance value instead of a bare PR number, and `AppendCriterionOptions` grew two fields; both files construct those operands. No assertion was weakened — the PR-scoped expectations are unchanged and a second case was added beside them. **Disposition:** stated here.

Fixes #6165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
