### PR TITLE
fix: Tuval interleaved stop unit test times out in CI

### DIFF
--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -170,6 +170,37 @@ Two scoped exceptions:
 Existing plain-vitest tests that run Effects via `runPromise` convert to `it.effect`
 opportunistically — when a change next touches the file, not as a churn pass.
 
+## A race between two synchronous ops is not a race a test can pin
+
+`Scheduler.MaxOpsBeforeYield` is not a coordination primitive. Cutting the run loop's yield budget
+to force two fibers to interleave tunes a number between two failure modes — one op too high and the
+fibers never interleave, one op too low and they starve — and the value that interleaves on an idle
+box is the value that starves on a loaded CI runner. Tuval's interleaved-stop case was pinned at a
+budget of `3` and timed out at 5000ms on a PR that touched no Tuval code (#8940).
+
+Nothing replaces the budget where the window is two **adjacent synchronous ops** — a `Ref.get`
+followed by a `Ref.set`, say. No `Latch` or `Deferred` a test owns can suspend a fiber between them,
+because the fiber never reaches a suspension point there; the only thing that splits the pair is a
+scheduler preemption, which is the non-determinism you were trying to remove.
+
+So close the window by construction instead, and judge *that* at a named seam:
+
+- Move the read-and-write into a module that owns the `Ref` and exposes only the atomic operation
+  (`apps/tuval/src/agy/ai-agent/stop-claim.ts` — one `Ref.modify`, no `Ref` on the interface). The
+  two-step shape stops being something a caller can spell.
+- At the seam, assert the invariant that holds under *every* interleaving ("exactly one owner"), so
+  no load can red it falsely, and read the single step off the module's own source for the one
+  property no call can observe (`stop-claim.unit.test.ts`).
+
+## An inner wait must be bounded strictly below the per-test budget
+
+A helper that bounds its own wait at the per-test timeout can never reach its own message: vitest's
+bare `Test timed out in 5000ms` always wins the race, and that is all the CI log carries. Bound every
+in-test wait strictly under the budget the project runs on — `interrupt-respawn.unit.test.ts` holds
+one `INNER_BOUND` constant under the 5000ms `unit` default — so a starved wait names what it was
+waiting for. Raising `testTimeout` to fix a flake is the inverse move: it spends the budget and keeps
+the dependence.
+
 ## Which tier to write
 
 Apply the litmus — *"could this be wrong even if the database behaved perfectly?"* In practice:
@@ -259,6 +290,8 @@ Never use `setTimeout`, `Date.now()`, or real wall-clock sleeps in tests. `TestC
 - **Booting a SQL engine and calling it a unit test** (the banned `node:sqlite` / `makeSqliteTestDb` pattern, ADR 0082). If a test needs a database, it is an `integration` test on real D1.
 - **Proving a pure-logic or decision-level fact at `integration`.** It belongs in `unit` — offline and flake-free. `integration` pays remote-D1 latency; spend it only on real-D1 fidelity.
 - **Setting up a unit-test layer inside `beforeEach`** when it doesn't change between tests. Module-scope it.
+- **`Scheduler.MaxOpsBeforeYield` to force an interleave**, and an inner wait bounded at the per-test
+  timeout — see the two sections above.
 - **`setTimeout`/timer ticks as fiber coordination.** Await a `Latch`/`Deferred` the program resolves — see "Fiber coordination" above. Timers are for negative liveness checks only.
 - **Snapshot tests against effect-internal shapes** (Causes, Exits) — they include implementation details that change between effect versions. Assert on the success value or the error `_tag`, not the cause structure.
 

--- a/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
+++ b/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
@@ -104,6 +104,7 @@ import {
 	transcriptUnreadable,
 	unknownCursor,
 } from "./refusals.ts";
+import {makeStopClaim} from "./stop-claim.ts";
 import {conversationDir, readTranscriptPage} from "./transcript.ts";
 import {decodeLine} from "./wire.ts";
 
@@ -179,13 +180,9 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 		const session = yield* Ref.make<Session | null>(null);
 		const keys = yield* Ref.make<ReadonlySet<string>>(new Set());
 		const commandCache = yield* Ref.make<ReadonlyArray<CommandRef>>([]);
-		// The child a stop was delivered to, which is the stop itself: set to that child's handle when
-		// SIGINT goes, given back by a refused signal. Two members read it — `processGone` spends it
-		// where the wire said nothing (`refusals.ts`), and the exit watch reads it to tell an exit
-		// this layer asked for from one it did not. It is the *child* and not a layer-wide flag
-		// because a relaunch whose `openSession` failed would otherwise leave a boolean stale-`true`
-		// and the next child's own death would read as a stop nobody sent (#8709).
-		const stopSentTo = yield* Ref.make<ChildProcessSpawner.ChildProcessHandle | null>(null);
+		// The child a stop was delivered to, which is the stop itself — see `stop-claim.ts` for why
+		// the memory is a domain object rather than a `Ref` this scope can read and write.
+		const stop = yield* makeStopClaim;
 		// Set from the delivered signal through to the session the relaunch reopened: the span in
 		// which `session` still holds a torn-down child. `prompt` refuses across it — see there.
 		const relaunching = yield* Ref.make(false);
@@ -304,7 +301,7 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				const ended = Effect.gen(function* () {
 					const code = yield* child.handle.exitCode.pipe(Effect.orElseSucceed(() => null));
 					yield* Ref.set(turnLive, false);
-					const stopped = (yield* Ref.get(stopSentTo)) === child.handle;
+					const stopped = yield* stop.heldBy(child.handle);
 					const failure = processGone(code, stopped);
 					// A child that died before it ever said `init` is a start that failed, and its
 					// caller is still holding that await.
@@ -327,20 +324,6 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 					ended,
 				);
 			});
-
-		/**
-		 * Claim the stop for one child, in a single step.
-		 *
-		 * A read and a write are two steps: two presses that interleave between them both find the
-		 * stop unclaimed and both go on to relaunch, and the second tears down the child the first
-		 * just opened (#8883). `false` is "this child's stop is already in flight", which is all a
-		 * second press has to be told — and because the claim names the child, a stop left behind by a
-		 * relaunch that failed can never be read as the next child's.
-		 */
-		const claimStop = (child: Child): Effect.Effect<boolean> =>
-			Ref.modify(stopSentTo, (held) =>
-				held === child.handle ? [false, held] : [true, child.handle],
-			);
 
 		/**
 		 * Run one relaunch's span with `relaunching` set, given back on every exit — a failure and an
@@ -584,7 +567,7 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 			// A stop already in flight has nothing for a second press to send, and a second press must
 			// not be able to take the first one's claim back: an exit read as one nobody asked for
 			// fails the very queue the relaunch is keeping (#8883).
-			if (!(yield* claimStop(current.child))) return;
+			if (!(yield* stop.claim(current.child.handle))) return;
 			const delivered = yield* current.child.handle.kill({killSignal: "SIGINT"}).pipe(
 				Effect.as(true),
 				// `interrupt` declares no error channel, so the refusal rides the stream as a tag the
@@ -593,7 +576,7 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				// with it: one that was never delivered must not speak for whatever ends this child.
 				Effect.catch((refusal) =>
 					Effect.gen(function* () {
-						yield* Ref.set(stopSentTo, null);
+						yield* stop.release;
 						const live = yield* Ref.get(turnLive);
 						yield* publish([{kind: "failure", failure: interruptFailureOf(refusal, live)}]);
 						return false;

--- a/apps/tuval/src/agy/ai-agent/child-stub.ts
+++ b/apps/tuval/src/agy/ai-agent/child-stub.ts
@@ -159,7 +159,9 @@ export const agyChildrenStub = Effect.gen(function* () {
 		child: (index: number) =>
 			childAt(index).pipe(
 				Effect.timeoutOrElse({
-					duration: "5 seconds",
+					// Under the 5000ms per-test default this wait has to end early enough to say so:
+					// bounded at the budget itself, the die message below is unreachable (#8940).
+					duration: "2 seconds",
 					orElse: () => Effect.die(new Error(`no child was launched at index ${index}`)),
 				}),
 			),

--- a/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/interrupt-respawn.unit.test.ts
@@ -7,6 +7,10 @@
  * asserted separately: the second launch carries `--conversation=<id>`, the phase the window ends on
  * is `ready`, and the stream the window subscribed to is still the same live stream afterwards.
  *
+ * The interleaved second press is not here: it is covered at the claim's own seam
+ * (`stop-claim.unit.test.ts`), because forcing the race through this path needed the run loop's yield
+ * budget cut to a value that starved under CI load (#8940). The *sequential* second press is below.
+ *
  * Limits of the proof: the spawner is a stub, so the signal is recorded rather than delivered and
  * the exit is the test's. What is real is everything above the pipe — `follow`'s fold, the exit
  * watch's own reading of the stop, and `respawn`. The scripted binary beside this file
@@ -14,13 +18,20 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {Cause, Effect, Exit, Fiber, Option, Queue, Scheduler, Stream} from "effect";
+import {Cause, Effect, Exit, Fiber, Option, Queue, Stream} from "effect";
 import type {AgentEvent, StartError} from "../../ai-agent/service/index.ts";
 import {TuvalAiAgent} from "../../ai-agent/service/index.ts";
 import {agyChildrenStub, agyLayerOver, type StubChild} from "./child-stub.ts";
 import {init, resultInterrupted, userInput} from "./fixtures.ts";
 
 const CWD = "/tuval/agy-interrupt-respawn";
+
+/**
+ * What every wait in this file is bounded by, and it is strictly under the 5000ms per-test budget the
+ * `unit` project runs on: at the budget itself a starved wait never reaches its own message and
+ * vitest's bare `Test timed out in 5000ms` is all a CI log carries (#8940).
+ */
+const INNER_BOUND = "2 seconds";
 
 /** The conversation id the captured `init` line opens, which is what a relaunch has to carry. */
 const CONVERSATION = "9dcbb5a5-9a5f-4f9c-989b-ede03e790bbf";
@@ -34,7 +45,7 @@ const collectTo = (
 	Effect.gen(function* () {
 		const seen: Array<AgentEvent> = [];
 		while (true) {
-			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption("5 seconds"));
+			const next = yield* Queue.take(events).pipe(Effect.orDie, Effect.timeoutOption(INNER_BOUND));
 			if (Option.isNone(next)) {
 				assert.fail(`timed out waiting for ${what}; saw ${JSON.stringify(seen)}`);
 			}
@@ -49,7 +60,7 @@ const signalled = (child: StubChild): Effect.Effect<void> =>
 		seen.length === 0 ? Effect.andThen(Effect.sleep("5 millis"), signalled(child)) : Effect.void,
 	).pipe(
 		Effect.timeoutOrElse({
-			duration: "5 seconds",
+			duration: INNER_BOUND,
 			orElse: () => Effect.die(new Error("the stop sent no signal")),
 		}),
 	);
@@ -71,7 +82,7 @@ const writtenTo = (child: StubChild): Effect.Effect<ReadonlyArray<string>> =>
 			: Effect.succeed(lines),
 	).pipe(
 		Effect.timeoutOrElse({
-			duration: "5 seconds",
+			duration: INNER_BOUND,
 			orElse: () => Effect.succeed<ReadonlyArray<string>>([]),
 		}),
 	);
@@ -146,62 +157,6 @@ describe("an agy turn the operator stops", () => {
 				assert.isTrue(
 					after.some(isInterruptedItem),
 					"the cut reply lost its interrupted mark across the relaunch",
-				);
-			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
-		}),
-	);
-
-	/**
-	 * Two stops that interleave, rather than one after the other.
-	 *
-	 * The sequential second press is covered above; this is the one a read-then-write guard lets
-	 * through (#8883). Two forked `interrupt` fibers would otherwise each run their synchronous steps
-	 * straight to the first async boundary and never interleave, so the yield budget is cut to 3: at
-	 * that value the run loop really does suspend one fiber inside the guard — with the read-then-write
-	 * guard in place this test sees two SIGINTs and three launches. Three, not 1 or 2, because a
-	 * budget under 3 starves the fibers entirely and no signal is ever sent.
-	 */
-	it.live("claims the stop once when two presses interleave", () =>
-		Effect.gen(function* () {
-			const children = yield* agyChildrenStub;
-
-			yield* Effect.gen(function* () {
-				const agent = yield* TuvalAiAgent;
-				yield* opened(children);
-				const events = yield* Stream.toQueue(agent.events, {capacity: "unbounded"});
-				yield* agent.prompt("something long");
-				yield* collectTo(events, "the turn's prompting", isPrompting);
-
-				const stopping = yield* Effect.forkChild(
-					Effect.all([agent.interrupt, agent.interrupt], {
-						concurrency: "unbounded",
-						discard: true,
-					}).pipe(Effect.provideService(Scheduler.MaxOpsBeforeYield, 3)),
-				);
-				const first = yield* children.child(0);
-				yield* signalled(first);
-				yield* first.say(userInput);
-				yield* first.say(resultInterrupted);
-				yield* first.exit(1);
-				yield* Effect.flatMap(children.child(1), (child) => child.say(init));
-				yield* Fiber.join(stopping);
-
-				assert.deepStrictEqual(
-					yield* first.signals,
-					["SIGINT"],
-					"an interleaved second press sent its own signal",
-				);
-				const launches = yield* children.launches;
-				assert.strictEqual(
-					launches.length,
-					2,
-					"the interleaved presses relaunched more than once: the child the first stop reopened was torn down again",
-				);
-				assert.include(launches[1] ?? [], `--conversation=${CONVERSATION}`);
-				const after = yield* collectTo(events, "the session back at ready", isReady);
-				assert.isEmpty(
-					after.filter((event) => event.kind === "phase" && event.phase === "gone"),
-					"the second press narrated a session the layer went on to keep",
 				);
 			}).pipe(Effect.provide(agyLayerOver(children)), Effect.scoped);
 		}),

--- a/apps/tuval/src/agy/ai-agent/stop-claim.ts
+++ b/apps/tuval/src/agy/ai-agent/stop-claim.ts
@@ -1,0 +1,45 @@
+/**
+ * Which child a stop was delivered to, as the one thing that can be asked about it.
+ *
+ * Two presses of Escape race, and a guard that reads the memory and then writes it is two steps:
+ * both presses find the stop unclaimed, both send SIGINT, and the second tears down the child the
+ * first just reopened (#8883). The claim is therefore one `Ref.modify` — and the `Ref` lives here,
+ * reachable through nothing but `claim` / `heldBy` / `release`, so the read-then-write shape is not
+ * something a caller can spell again (#8940). That is the whole reason this is a module and not
+ * three lines inside `AgyAiAgent`: the interleave cannot be pinned by a test — it exists only
+ * between two adjacent synchronous ops, which no latch a test owns can split — so it is closed by
+ * construction instead.
+ *
+ * The claim names the *child* rather than being a layer-wide flag: a relaunch whose `openSession`
+ * failed would otherwise leave a boolean stale-`true` and the next child's own death would read as a
+ * stop nobody sent (#8709).
+ */
+
+import {Effect, Ref} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+
+export interface StopClaim {
+	/**
+	 * Take the stop for one child. `true` to the press that owns it, `false` to every later press
+	 * while that child's stop is still in flight — which is all a second press has to be told.
+	 */
+	readonly claim: (handle: ChildProcessSpawner.ChildProcessHandle) => Effect.Effect<boolean>;
+	/**
+	 * Whether the stop in flight is this child's. `processGone` spends it where the wire said
+	 * nothing (`refusals.ts`), and the exit watch reads it to tell an exit this layer asked for from
+	 * one it did not.
+	 */
+	readonly heldBy: (handle: ChildProcessSpawner.ChildProcessHandle) => Effect.Effect<boolean>;
+	/** Give the claim back, for a signal the backend refused: one never delivered speaks for nothing. */
+	readonly release: Effect.Effect<void>;
+}
+
+export const makeStopClaim: Effect.Effect<StopClaim> = Effect.map(
+	Ref.make<ChildProcessSpawner.ChildProcessHandle | null>(null),
+	(held) => ({
+		claim: (handle) =>
+			Ref.modify(held, (current) => (current === handle ? [false, current] : [true, handle])),
+		heldBy: (handle) => Effect.map(Ref.get(held), (current) => current === handle),
+		release: Ref.set(held, null),
+	}),
+);

--- a/apps/tuval/src/agy/ai-agent/stop-claim.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/stop-claim.unit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The stop claim, driven at its own seam (#8940).
+ *
+ * This is where the interleaved second press is covered. The layer-level version of that case drove
+ * the race through the real `interrupt` and cut the run loop's yield budget to 3 to force it, which
+ * is a value one op away from starving the fibers outright — on a loaded CI runner it starved and
+ * the case timed out on a PR that touched no Tuval code. Nothing replaces that budget: in the
+ * read-then-write shape #8883 describes, the window between the read and the write is two adjacent
+ * *synchronous* ops, so no rendezvous a test owns can suspend a fiber inside it, and a budget of 1 —
+ * the one value that would split the pair by construction rather than by timing — starves the two
+ * fibers outright (measured here: the case hung to its 5000ms budget).
+ *
+ * So the race is not what defends the claim, and two other things are. The concurrent case below
+ * asserts "exactly one owner", which holds under every interleaving and can therefore never red
+ * falsely. The last case reads this module's own source, because the one property no behavioural
+ * test can reach is that the read and the write are a single op — a claim re-spelled as two would
+ * answer every other case here identically.
+ */
+
+import {readFileSync} from "node:fs";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {makeStopClaim} from "./stop-claim.ts";
+
+/** A handle that does nothing: the claim reads identity and nothing else. */
+const handle = (pid: number): ChildProcessSpawner.ChildProcessHandle =>
+	ChildProcessSpawner.makeHandle({
+		pid: ChildProcessSpawner.ProcessId(pid),
+		exitCode: Effect.never,
+		isRunning: Effect.succeed(true),
+		kill: () => Effect.void,
+		stdin: Sink.drain,
+		stdout: Stream.empty,
+		stderr: Stream.empty,
+		all: Stream.empty,
+		getInputFd: () => Sink.drain,
+		getOutputFd: () => Stream.empty,
+		unref: Effect.succeed(Effect.void),
+	});
+
+describe("the claim a stop takes on one child", () => {
+	it.effect("answers the press that owns it, and tells a second press no", () =>
+		Effect.gen(function* () {
+			const stop = yield* makeStopClaim;
+			const child = handle(1);
+
+			assert.isTrue(yield* stop.claim(child), "the first press did not own the stop it sent");
+			assert.isFalse(
+				yield* stop.claim(child),
+				"a second press was told to send a signal of its own",
+			);
+			assert.isTrue(yield* stop.heldBy(child), "the stop in flight named no child");
+		}),
+	);
+
+	it.effect("leaves one owner when two presses claim it at once", () =>
+		Effect.gen(function* () {
+			const stop = yield* makeStopClaim;
+			const child = handle(1);
+
+			const answers = yield* Effect.all([stop.claim(child), stop.claim(child)], {
+				concurrency: "unbounded",
+			});
+
+			assert.deepStrictEqual(
+				answers.filter((owned) => owned),
+				[true],
+				"both presses claimed the stop, so both would have signalled and both relaunched",
+			);
+		}),
+	);
+
+	it.effect("gives the claim back for a signal the backend refused", () =>
+		Effect.gen(function* () {
+			const stop = yield* makeStopClaim;
+			const child = handle(1);
+
+			yield* stop.claim(child);
+			yield* stop.release;
+
+			assert.isFalse(yield* stop.heldBy(child), "a refused signal went on speaking for the child");
+			assert.isTrue(
+				yield* stop.claim(child),
+				"the press after a refusal was locked out of a stop that was never sent",
+			);
+		}),
+	);
+
+	// The claim names the child, not the layer: a relaunch whose `openSession` failed must not leave
+	// the next child's own death reading as a stop nobody sent (#8709).
+	it.effect("names the child, so the next child's stop is its own", () =>
+		Effect.gen(function* () {
+			const stop = yield* makeStopClaim;
+			const first = handle(1);
+			const second = handle(2);
+
+			yield* stop.claim(first);
+			assert.isTrue(yield* stop.claim(second), "the relaunched child could not be stopped");
+			assert.isFalse(
+				yield* stop.heldBy(first),
+				"the stopped child still held the claim after the relaunch took it",
+			);
+		}),
+	);
+
+	/**
+	 * A `claim` re-spelled as a `Ref.get` and a `Ref.set` answers every case above identically and is
+	 * the #8883 defect back, so the single step is read off the source instead — the same probe idiom
+	 * `boundary.unit.test.ts` uses in this directory for a property no call can observe.
+	 */
+	it("takes the stop in one step", () => {
+		const source = readFileSync(new URL("./stop-claim.ts", import.meta.url), "utf8");
+		const from = source.indexOf("\t\tclaim: (");
+		const to = source.indexOf("\t\theldBy: (");
+		assert.isTrue(from > -1 && to > from, "stop-claim.ts no longer spells `claim` before `heldBy`");
+
+		const claim = source.slice(from, to);
+		assert.include(claim, "Ref.modify(", "the claim is no longer one atomic step");
+		assert.notInclude(claim, "Ref.get(", "the claim reads the memory in a step of its own");
+		assert.notInclude(claim, "Ref.set(", "the claim writes the memory in a step of its own");
+	});
+});


### PR DESCRIPTION
The Tuval unit case `claims the stop once when two presses interleave` forced its race by cutting the
run loop's yield budget to 3. That is one op from the starving side, and under CI load it starved:
the case timed out at 5000ms and redded `unit + client tests` on PR #8915, a Fabrika-docs change
with no Tuval code in it.

## The route taken, and why the rendezvous route is not available

Criterion 7's sanctioned alternative: **the interleave is covered at a named seam and the layer-level
case is removed.** The rendezvous route (criteria 2 and 3) cannot be built. In the read-then-write
shape #8883 describes, the window between the read and the write is two *adjacent synchronous ops* —
a fiber never reaches a suspension point inside it, so no `Deferred`, latch or stub-child seam a test
owns can split the pair. The only thing that splits it is a scheduler preemption, which is exactly
the load-dependence the ticket calls the defect. Measured, not assumed: a budget of `1` — the one
value that would split the pair by construction rather than by timing — starves the two fibers
outright, and the seam case hung to its 5000ms budget under it before that approach was dropped.

So the window is closed by construction instead:

- **`apps/tuval/src/agy/ai-agent/stop-claim.ts`** owns the `Ref` and exposes only `claim` / `heldBy` /
  `release`. The read and the write are one `Ref.modify`, and the two-step guard is no longer
  something a caller can spell. `AgyAiAgent` holds a `StopClaim` where it held a raw `Ref`.
- **`apps/tuval/src/agy/ai-agent/stop-claim.unit.test.ts`** judges the claim directly: one owner per
  child, the second press told no, the claim given back after a refused signal, the claim named to
  the child rather than the layer, and — for the one property no call can observe — a source probe
  that the claim is a single `Ref.modify`, the idiom `boundary.unit.test.ts` already uses in this
  directory.
- The layer-level interleave case is gone from `interrupt-respawn.unit.test.ts`, with its docblock
  naming where that coverage now lives. The *sequential* second press stays where it was.

## What reds against the pre-fix shape

Two experiments, both run in this tree:

1. **The old case against the two-step claim** (`Ref.get` then `Ref.set` in place of `claimStop`, at
   `origin/main`'s test file): `Tests 1 failed | 4 passed`, and the failure is
   `Error: Test timed out in 5000ms` at `interrupt-respawn.unit.test.ts:164` — *not* the documented
   two SIGINTs and three launches. Both presses relaunch, the third child is never fed its `init`
   line, and `Fiber.join(stopping)` hangs past the budget. That is criterion 6's defect in the same
   frame: the case could only ever red with vitest's bare message, which is all the original CI log
   carried.
2. **The new seam test against the same two-step claim** (re-spelled inside `stop-claim.ts`):
   `takes the stop in one step` reds in 3ms with
   `AssertionError: the claim is no longer one atomic step`. Every behavioural case in that file
   passes under the two-step shape — which is the point, and the reason the probe exists.

## Assertions kept, and the inner bounds

The surviving sequential case in `interrupt-respawn.unit.test.ts` is untouched and still carries the
four facts criterion 4 lists: one `SIGINT` on the first child, exactly two launches, the second
carrying `--conversation=<id>`, and no `gone` phase before the session is back at `ready`.

`collectTo`, `signalled` and `writtenTo` now bound their waits at one `INNER_BOUND = "2 seconds"`
constant rather than at `"5 seconds"`, which is the whole per-test budget — so a starved wait fails
with the helper's own message instead of vitest's. `child-stub.ts`'s `child()` carried the same
unreachable 5s bound and is lowered with them.

`.patterns/effect-testing.md` gains the two sections this change relies on (the unpinnable
two-sync-op race and its seam route; inner bounds strictly below the per-test budget) plus the
matching anti-pattern bullet.

## Five runs, recorded

`pnpm vitest run --project unit` in `apps/tuval`, no `testTimeout` raised on the `unit` project and no
per-test override anywhere:

| run | result |
| --- | --- |
| 1 | `Test Files 314 passed (314)` / `Tests 3235 passed (3235)` |
| 2 | `Test Files 314 passed (314)` / `Tests 3235 passed (3235)` |
| 3 | `Test Files 314 passed (314)` / `Tests 3235 passed (3235)` |
| 4 | `Test Files 314 passed (314)` / `Tests 3235 passed (3235)` |
| 5 | `Test Files 314 passed (314)` / `Tests 3235 passed (3235)` |

13 earlier runs of the same command on this branch also passed. One run before those — the first
after the pre-fix experiment was reverted — reported `Test Files 1 failed | 313 passed (314)`, and its
identity was lost to a summary-only output filter. That is #7911's open observation exactly, and the
data point is noted there (https://github.com/kamp-us/phoenix/issues/7911#issuecomment-5616377269)
rather than filed again; it is not the removed case, which was no longer in the suite.

Fixes #8940

## Deviations

- **Declined guidance** — **Said:** criteria 2 and 3 ask for an explicit rendezvous the test owns that
  still reds against the two-step guard. **Did:** took criterion 7's sanctioned alternative instead —
  the claim is covered at its own named seam and the layer-level case is removed. **Why:** the
  interleave window is two adjacent synchronous ops, so no test-owned latch can suspend a fiber
  inside it, and the one scheduler value that would split the pair deterministically starves the
  fibers (measured, see above). **Disposition:** stated here and in the PR body's route section, with
  both experiments' observed output.
- **Out-of-scope change** — **Said:** criterion 6 names `collectTo` and `signalled`. **Did:** also
  lowered `writtenTo` in the same file and `child()` in `child-stub.ts`. **Why:** both bounded their
  waits at the same 5000ms per-test budget, so both carried messages no run could ever print — the
  same defect in the same frame. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the ticket names Tuval test files only. **Did:** also extended
  `.patterns/effect-testing.md`. **Why:** CLAUDE.md requires a pattern a change relies on to be
  documented, and both the seam route and the inner-bound rule were undocumented. **Disposition:**
  stated here.
