### PR TITLE
fix: Every agy stop paints an internal diagnostic row: agy step N of an unrecognised type "error_message"

### DIFF
--- a/.decisions/0362-agy-sandbox-scoped-auto-approval.md
+++ b/.decisions/0362-agy-sandbox-scoped-auto-approval.md
@@ -74,11 +74,21 @@ This is about the *terminal event*, and it is a different proposition from the o
 
 **`result.denied_actions` is one release old.** It arrived in the release immediately before the version this record pins, so it is the newest field the adapter depends on and the first one to suspect if a different version behaves oddly.
 
+## A later-version reading: `error_message` at v1.2.0
+
+**This section is scoped to v1.2.0 and changes nothing above.** Per the grounding rule below, a measurement against a later version is named as such rather than written back onto the pin, so the five-value `step_type` census and every other v1.1.27 claim stand exactly as they read.
+
+**v1.2.0 emits a sixth `step_type`, `error_message`, and it carries no text.** The step is `{"step_index":2,"state":"DONE","step_type":"error_message","duration_seconds":0}` — `text_delta` is absent, not empty — and the turn *continues* past it: the next `agent_response` is agy retrying the reply, and `result.num_turns` is still `1`. The message the step stands for rides the terminal `result.error` instead, and agy's on-disk transcript records it as the `SYSTEM`/`ERROR_MESSAGE` line the history reader already renders with its `content`.
+
+**The trigger is agy's own abort, not the operator's stop.** It was first met on the interrupt path, which made "suppress it when the turn was interrupted" look like the whole fix ([#8896](https://github.com/kamp-us/phoenix/issues/8896)). Driving the real binary says otherwise: a prompt asking for a verbatim passage of a copyrighted novel trips the recitation filter and produces the step with no `SIGINT` anywhere, while eleven drives that included four `SIGINT` stops produced none at all. So the adapter recognises the step and lets the terminal event decide whether it is worth a row — dropped on a stop, where the cut reply's `interrupted` mark already says the same thing; rendered otherwise, where it is the only account of why the reply stopped (`src/agy/ai-agent/mapper.ts`).
+
+**`AGY_VERSION` stays at `1.1.27`.** The constant names the release the whole `wire.ts` module was captured from, and one step type read on one later machine is not a re-census — moving it would restate the v1.1.27 capture as a v1.2.0 one, which is the laundering this record's own rule forbids. It moves when the module is captured again, and `src/agy/ai-agent/launch.unit.test.ts` moves with it.
+
 ## Grounding
 
 Per [CLAUDE.md](../CLAUDE.md)'s rule that a decision-driving claim about a dependency's behaviour is verified against the authoritative source rather than asserted, every behavioural claim above traces to one of two things: a live run of `agy` v1.1.27 on macOS during the spike recorded on [#8162](https://github.com/kamp-us/phoenix/issues/8162), or a `strings` extraction from that binary (the `INTERRUPTED` status is the one claim from the latter). Where a claim contradicts the vendor's documentation, the measurement wins and the contradiction is named as such.
 
-Two claims were re-measured after a hand-verification run of the adapter contradicted them, and both corrections above carry their own evidence: the `SIGINT` terminal event (a scratch desk against v1.1.27, plus a direct probe against v1.1.28) and the `result.usage` census (a three-turn stream-json session against v1.1.28, the third turn on a resumed child). A measurement against a *later* version is named as such rather than written back onto the pinned one; where the two agree, as they do on the interrupt string, the agreement is the point.
+Two claims were re-measured after a hand-verification run of the adapter contradicted them, and both corrections above carry their own evidence: the `SIGINT` terminal event (a scratch desk against v1.1.27, plus a direct probe against v1.1.28) and the `result.usage` census (a three-turn stream-json session against v1.1.28, the third turn on a resumed child). A measurement against a *later* version is named as such rather than written back onto the pinned one; where the two agree, as they do on the interrupt string, the agreement is the point. The `error_message` section is that rule applied again, one minor further on: twelve drives of a v1.2.0 binary, the captured lines committed verbatim as `src/agy/ai-agent/fixtures.ts`'s `errorMessageStep` / `resultContentFiltered`, and the v1.1.27 census left standing.
 
 Every vendor path in this record is written relative to `$HOME` and resolved at runtime. No absolute machine-local path appears, so the document stays true on a machine other than the one the spike ran on.
 

--- a/apps/tuval/src/agy/ai-agent/fixtures.ts
+++ b/apps/tuval/src/agy/ai-agent/fixtures.ts
@@ -2,7 +2,9 @@
  * Captured agy stream lines, verbatim apart from one substitution: the invoking user's home
  * directory reads `/Users/founder`, so no real home path lands in the repo. Everything down to
  * `resultSuccess` is v1.1.27, the version ADR 0362 pins; the usage census and the interrupted
- * `result` at the foot are v1.1.28 and say so where they are declared.
+ * `result` after it are v1.1.28, and the `error_message` pair at the foot is v1.2.0. Each says so
+ * where it is declared, because a later-version capture is named as such rather than folded into the
+ * pin (ADR 0362).
  *
  * Every line below came off a live run of
  * `agy --input-format=stream-json --output-format=stream-json --print='' --model=gemini-3.8-flash-low
@@ -91,3 +93,29 @@ export const censusResumedResult =
  */
 export const resultInterrupted =
 	'{"event":"result","result":{"conversation_id":"9cb073ff-0a81-4b21-b81b-1a2e1c78969c","status":"ERROR","response":"","error":"interrupted","duration_seconds":5.99386,"num_turns":1,"usage":{"input_tokens":16793,"output_tokens":1105,"thinking_tokens":0,"cache_read_tokens":0,"total_tokens":17898}}}';
+
+/**
+ * The `error_message` step and the terminal `result` of the turn it cut, both verbatim from **agy
+ * v1.2.0** — a release past the `1.1.27` pin, named here rather than written back onto it (ADR 0362).
+ * This is the step [#8896](https://github.com/kamp-us/phoenix/issues/8896) is about: before the
+ * mapper had an arm for it, it reached the default arm and minted
+ * `agy step 2 of an unrecognised type "error_message" (DONE)` into the operator's transcript.
+ *
+ * Captured on 2026-09-10 by driving the real binary — `agy --input-format=stream-json
+ * --output-format=stream-json --print='' --model=gemini-3.8-flash-low --sandbox --add-dir=<scratch>` —
+ * with a prompt asking for a verbatim passage of a copyrighted novel, which trips agy's own
+ * recitation filter mid-reply. Eleven other drives (four `SIGINT` stops, six concurrent long
+ * generations, a counting prompt) produced no `error_message` at all: the trigger is the filter, not
+ * the stop, which is why "suppress it on the interrupt path" would have been the wrong fix.
+ *
+ * **Two readings the pair settles.** The step carries no `text_delta` — the field is absent, not
+ * empty — so at this release there is no message on the live stream to render; and the message itself
+ * rides the terminal `result.error`, on a `result` whose `status` is `ERROR` and whose `error` is not
+ * `interrupted`, so the mapper's failure arm surfaces it. The turn *continued* after the step: the
+ * long `response` below is the retry agy produced, which is why `num_turns` is still `1`.
+ */
+export const errorMessageStep =
+	'{"event":"step_update","step_update":{"conversation_id":"65495e68-8a9c-47bd-956a-104b61cf1df7","step_index":2,"state":"DONE","step_type":"error_message","duration_seconds":0}}';
+
+export const resultContentFiltered =
+	'{"event":"result","result":{"conversation_id":"65495e68-8a9c-47bd-956a-104b61cf1df7","status":"ERROR","response":"I cannot reproduce the verbatim text of George Orwell\'s *1984*, as it remains under copyright protection in several jurisdictions, but I can provide a summary or discuss the themes, characters, and plot of the opening chapter.\\n\\n### Chapter 1 Summary\\n\\nIn the opening chapter of *1984*, Winston Smith returns to his dreary apartment building, Victory Mansions, amidst a harsh and gritty London setting in Oceania. The narrative immediately introduces the pervasive surveillance and psychological dominance of the totalitarian regime: telescreens broadcast continuous propaganda while monitoring residents\' every sound and movement, and ominous posters of Big Brother remind the populace that they are constantly watched. \\n\\nWinston navigates his cramped flat, positioning himself in an alcove hidden from the telescreen\'s direct view. There, he commits a forbidden act by opening a newly purchased blank diary and writing down his thoughts, an offense that carries severe penalties under the Thought Police. As he contemplates his discontent, he reflects on the state-mandated Two Minutes Hate, his conflicting emotions toward an enigmatic young woman from the Fiction Department, and his intuitive suspicion that an Inner Party official named O\'Brien might share his silent rebellion against the Party.\\n\\n***\\n\\nWould you like a summary or analysis of the next chapter, or an exploration of the themes and world-building introduced here?\\nI cannot reproduce the text of *1984* verbatim. However, I can provide a high-level summary and analysis of the opening chapter.\\n\\n### Overview of Chapter 1\\n\\nThe opening of the novel establishes the dystopian reality of Oceania and introduces the protagonist, Winston Smith. Living under the total control of the Party, citizens endure constant surveillance via two-way telescreens, pervasive propaganda, and the looming presence of the Thought Police. \\n\\nDisillusioned and seeking an outlet for his private thoughts, Winston retreats to a rare blind spot in his flat to commit a forbidden act of defiance: beginning a personal journal. Through his reflections, the chapter outlines key elements of the totalitarian regime—such as the institutionalized hysteria of the Two Minutes Hate—and introduces figures who provoke Winston\'s suspicion, fear, and cautious curiosity.\\n\\n***\\n\\nWould you like a summary of the next chapter, or would you prefer an analysis of the novel\'s major themes and motifs?\\n","error":"Your previous response was blocked by content safety filters: The generated content was filtered because it may contain material that resembles existing copyrighted works. Try rephrasing the prompt. If you think this was an error, [send feedback](https://ai.google.dev/gemini-api/docs/troubleshooting).\\nPlease provide a response that complies with content policies, or briefly explain to the user why you cannot help with this request\\nRetries remaining: 3","duration_seconds":5.591085,"num_turns":1,"usage":{"input_tokens":22341,"output_tokens":468,"thinking_tokens":0,"cache_read_tokens":11722,"total_tokens":22809}}}';

--- a/apps/tuval/src/agy/ai-agent/mapper.ts
+++ b/apps/tuval/src/agy/ai-agent/mapper.ts
@@ -44,6 +44,23 @@
  * **An unrecognised `step_type` renders a `SystemItem` and is never dropped and never thrown on.**
  * That is the whole reason this file has a default arm: the enum is provably open and the stream
  * carries no version to branch on (see `wire.ts`).
+ *
+ * **An `error_message` step is carried on the turn and rendered, or not, by the terminal event** —
+ * the one arm here that cannot decide anything on its own. The step says a reply was cut; only
+ * `result` says whether the operator is the one who cut it, and it arrives afterwards. On a stop the
+ * cut reply's `interrupted` mark is already the whole signal, so the step adds a second row saying
+ * the same thing; on any other ending — agy's own safety-filter abort is the measured case — the
+ * message is the only account of why the reply stopped. So `AgyTurn.errorMessages` holds it until
+ * `resultEvents` can choose ([#8896](https://github.com/kamp-us/phoenix/issues/8896)). Before this it
+ * reached the default arm, which minted `agy step 2 of an unrecognised type "error_message" (DONE)`
+ * into the transcript on a path Tuval drives on purpose.
+ *
+ * Measured at **v1.2.0**, which is past `wire.ts`'s pin and named as such: the live step carries no
+ * `text_delta` at all, so at that release the carry is always empty and this arm renders nothing
+ * either way. The message itself rides the terminal `result.error`, which the failure event below
+ * already surfaces, and agy's on-disk transcript records it as a `SYSTEM`/`ERROR_MESSAGE` line that
+ * `transcript.ts` renders with its text — so neither path loses it. The with-text arm is here for the
+ * release that starts sending one, on a wire that ships no version to announce that it has.
  */
 
 import type {AgentEvent} from "../../ai-agent/events.ts";
@@ -173,6 +190,17 @@ export interface AgyTurn {
 	 * turn whose cumulative is its own — unless it is `null`, and then nothing does.
 	 */
 	readonly cumulative: Tokens | null;
+	/**
+	 * `error_message` steps this turn carried, held rather than rendered: the step cannot tell on its
+	 * own whether the turn was interrupted, and the terminal `result` that can arrives after it.
+	 */
+	readonly errorMessages: ReadonlyArray<ErrorMessage>;
+}
+
+/** One carried `error_message`, keyed the way every other step row is. */
+interface ErrorMessage {
+	readonly key: string;
+	readonly text: string;
 }
 
 export const idleTurn: AgyTurn = {
@@ -183,6 +211,7 @@ export const idleTurn: AgyTurn = {
 	reported: noTokens,
 	lastStepIndex: null,
 	cumulative: null,
+	errorMessages: [],
 };
 
 interface Folded {
@@ -315,6 +344,14 @@ const stepEvents = (previous: AgyTurn, step: AgyStepUpdate, timestamp: number): 
 			if (delta.length > 0) events.push(systemEvent(key, timestamp, delta));
 			break;
 
+		case "error_message":
+			// Carried, never rendered here: whether this is worth showing depends on the terminal
+			// `result`, which has not arrived. `resultEvents` drops it on a stop and renders it
+			// otherwise. An empty one is carried nowhere, matching the `system_message` arm above.
+			if (delta.length > 0)
+				next = {...next, errorMessages: [...next.errorMessages, {key, text: delta}]};
+			break;
+
 		default:
 			events.push(systemEvent(key, timestamp, unrecognisedText(step)));
 	}
@@ -352,6 +389,12 @@ const resultEvents = (previous: AgyTurn, result: AgyResult, timestamp: number): 
 				: assistantItem(id, timestamp, result.response),
 		});
 	}
+
+	// The stop's own mark is the whole of the operator's signal on an interrupted turn, so a step that
+	// only ever reports why a reply was cut adds nothing beside it and is dropped.
+	if (!stopped)
+		for (const message of previous.errorMessages)
+			events.push(systemEvent(message.key, timestamp, message.text));
 
 	const denied = result.denied_actions;
 	if (denied !== undefined && denied.length > 0) {
@@ -401,6 +444,7 @@ const resultEvents = (previous: AgyTurn, result: AgyResult, timestamp: number): 
 			reported: noTokens,
 			lastStepIndex: null,
 			cumulative: result.usage === undefined ? previous.cumulative : tokensOf(result.usage),
+			errorMessages: [],
 		},
 	};
 };

--- a/apps/tuval/src/agy/ai-agent/mapper.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/mapper.unit.test.ts
@@ -1,9 +1,10 @@
 /**
  * The agy fold, over captured stream lines rather than a live CLI — v1.1.27 throughout, plus the
- * v1.1.28 usage census and interrupted `result` that `fixtures.ts` declares as such.
+ * v1.1.28 usage census and interrupted `result`, and the v1.2.0 `error_message` pair, each of which
+ * `fixtures.ts` declares as such.
  *
  * **Nothing here enumerates the observed `step_type`s as exhaustive.** The cases below name the
- * five that were observed and the eleven that were not, and every one of them is a claim about
+ * six that were observed and the eleven that were not, and every one of them is a claim about
  * that value alone — an assertion that the observed set is closed would rebuild the exact defect
  * the default arm exists to prevent, on a wire that ships no version field to warn anyone.
  */
@@ -156,7 +157,7 @@ describe("a line the reader cannot use", () => {
 	});
 });
 
-describe("the five observed step types", () => {
+describe("the six observed step types", () => {
 	it("takes no transcript row from a user_input step, which carries no text at v1.1.27", () => {
 		expect(items(fold([fixtures.userInput]).events)).toEqual([]);
 	});
@@ -196,6 +197,108 @@ describe("the five observed step types", () => {
 			fold([patchStep(fixtures.systemMessage, {text_delta: "context compacted"})]).events,
 		);
 		expect(rendered[0]).toMatchObject({kind: "system", text: "context compacted"});
+	});
+
+	it("emits nothing at the error_message step itself, which cannot know yet whether to", () => {
+		expect(fold([fixtures.errorMessageStep]).events).toEqual([]);
+		expect(
+			fold([patchStep(fixtures.errorMessageStep, {text_delta: "blocked by safety filters"})])
+				.events,
+		).toEqual([]);
+	});
+});
+
+/**
+ * The v1.2.0 step, over `fixtures.errorMessageStep` and `fixtures.resultContentFiltered` — both
+ * verbatim lines off one real drive of the binary, which is where the fixture says they came from.
+ *
+ * Two facts make the arm shaped the way it is. The step cannot tell whether the turn was interrupted:
+ * `wasInterrupted` reads the *terminal* `result`, which arrives after it. And at v1.2.0 the step
+ * carries no `text_delta` at all, so the with-text cases below patch the captured envelope rather than
+ * claiming a capture — they hold the arm for the release that starts sending one.
+ */
+describe("the error_message step", () => {
+	const withText = (text: string): string =>
+		patchStep(fixtures.errorMessageStep, {text_delta: text});
+
+	it("never reaches the default arm, so no unrecognised-type row can be minted for it", () => {
+		const {events} = fold([
+			fixtures.init,
+			fixtures.responseActive,
+			fixtures.errorMessageStep,
+			fixtures.resultContentFiltered,
+		]);
+		const rows = items(events).filter((item) => item.kind === "system");
+		expect(rows.some((item) => item.kind === "system" && item.text.includes("unrecognised"))).toBe(
+			false,
+		);
+		expect(rows.some((item) => item.kind === "system" && item.text.includes("error_message"))).toBe(
+			false,
+		);
+	});
+
+	it("renders nothing when the turn's result reads interrupted — the cut reply's mark is the signal", () => {
+		const {events} = fold([
+			fixtures.init,
+			fixtures.responseActive,
+			withText("blocked by safety filters"),
+			patchResult(fixtures.resultInterrupted, {conversation_id: CONVERSATION}),
+		]);
+		const rendered = items(events);
+		expect(rendered.filter((item) => item.kind === "system")).toEqual([]);
+		expect(rendered.at(-1)).toMatchObject({kind: "assistant", interrupted: true});
+	});
+
+	it("renders the message's own text as a system row when the turn was not interrupted", () => {
+		const {events} = fold([
+			fixtures.init,
+			withText("blocked by safety filters"),
+			fixtures.resultContentFiltered,
+		]);
+		const row = items(events).find((item) => item.kind === "system");
+		expect(row).toMatchObject({kind: "system", text: "blocked by safety filters", timestamp: AT});
+	});
+
+	it("takes no row from the captured step, which carries no text at v1.2.0", () => {
+		const {events} = fold([
+			fixtures.init,
+			fixtures.errorMessageStep,
+			fixtures.resultContentFiltered,
+		]);
+		expect(items(events).filter((item) => item.kind === "system")).toEqual([]);
+	});
+
+	/**
+	 * Which is why dropping the row loses nothing: the safety-filter abort the capture came from is
+	 * still named, by the terminal event the message itself rides.
+	 */
+	it("leaves the filter's own message on the failure the terminal result reports", () => {
+		const {events} = fold([fixtures.init, fixtures.resultContentFiltered]);
+		const failure = events.find((event) => event.kind === "failure");
+		expect(failure).toMatchObject({kind: "failure", failure: {reason: "ERROR"}});
+		expect(failure?.kind === "failure" && failure.failure.detail).toContain(
+			"blocked by content safety filters",
+		);
+	});
+
+	it("clears the carry at the terminal event, so the next turn inherits no message", () => {
+		const {turn} = fold([withText("blocked"), fixtures.resultContentFiltered]);
+		expect(turn.errorMessages).toEqual([]);
+	});
+
+	it("keeps two messages on one turn apart rather than superseding one with the other", () => {
+		const {events} = fold([
+			fixtures.init,
+			withText("first block"),
+			patchStep(fixtures.errorMessageStep, {step_index: 4, text_delta: "second block"}),
+			fixtures.resultContentFiltered,
+		]);
+		const rows = items(events).filter((item) => item.kind === "system");
+		expect(rows.map((item) => (item.kind === "system" ? item.text : ""))).toEqual([
+			"first block",
+			"second block",
+		]);
+		expect(rows[0]?.id).not.toBe(rows[1]?.id);
 	});
 });
 

--- a/apps/tuval/src/agy/ai-agent/wire.ts
+++ b/apps/tuval/src/agy/ai-agent/wire.ts
@@ -9,11 +9,16 @@
  * protocol or schema version field of any kind — so nothing downstream can branch on a version,
  * and the two tolerances below are the only defence a later release leaves us:
  *
- * - **`step_type` is an open string, never a closed union.** Five values are observed —
+ * - **`step_type` is an open string, never a closed union.** Five values are observed at this pin —
  *   `user_input`, `agent_response`, `tool`, `subagent`, `system_message` — and two of those were
- *   found only after the first census. Six more (`thinking`, `plan`, `error`, `command`, `memory`,
- *   `checkpoint`) exist as strings in the binary and have never been emitted. `state` and
- *   `result.status` are typed open for the same reason.
+ *   found only after the first census. A sixth, `error_message`, was observed on a **later release,
+ *   v1.2.0**, and is named here as a later-version reading rather than written back onto the five
+ *   above: it rides the step agy emits when a reply was cut and the turn is about to retry, carries
+ *   no `text_delta`, and `mapper.ts` now has an arm for it
+ *   ([#8896](https://github.com/kamp-us/phoenix/issues/8896)). Six more (`thinking`, `plan`, `error`,
+ *   `command`, `memory`, `checkpoint`) exist as strings in the binary and have never been emitted.
+ *   `state` and `result.status` are typed open for the same reason — which is the tolerance that let
+ *   the new value through without a decode change.
  * - **Only the fields that route a line are required.** Every other field is optional and
  *   defaulted, because a line refused for a key this pin has not seen is content the operator
  *   never gets. A default never aliases the unknown onto a real value a reader branches on, though:
@@ -28,7 +33,13 @@
 import {Predicate} from "effect";
 import {isJsonValue, type JsonValue} from "../../ai-agent/ports/index.ts";
 
-/** The release every shape below was captured from. There is no version field on the wire. */
+/**
+ * The release every shape below was captured from. There is no version field on the wire.
+ *
+ * It stays at `1.1.27` deliberately. The v1.2.0 `error_message` reading above is one step type on one
+ * machine, not a re-census, and moving this constant would restate the whole module's capture as a
+ * v1.2.0 one — the laundering ADR 0362 rules out. It moves when the module is captured again.
+ */
 export const AGY_VERSION = "1.1.27";
 
 /**


### PR DESCRIPTION
Fixes #8896

`agy` 1.2.0 emits a sixth `step_type`, `error_message`. The mapper knew five, so it fell through
to the `default:` arm and minted an internal diagnostic into the operator's transcript:

```
agy step 2 of an unrecognised type "error_message" (DONE)
```

The fallback is right for a surprise (#8178) and wrong for a step Tuval drives on purpose.

## What changed

`error_message` is now an arm of the `step_type` switch, and it is the one arm that decides nothing
on its own. The step says a reply was cut; only the terminal `result` says whether the operator is
the one who cut it, and it arrives afterwards — so the step's text is carried on
`AgyTurn.errorMessages` and `resultEvents` chooses: dropped when the result reads interrupted, where
the cut reply's `interrupted` mark is already the whole signal, and rendered as a system row
carrying the message's own text otherwise. An `error_message` with no text produces no row, matching
the `system_message` arm's existing guard.

## What the binary actually does, measured

Twelve drives of the real `agy` 1.2.0 on this machine, and two readings fall out that the issue
could not have had:

- **The trigger is agy's own abort, not the stop.** Four `SIGINT` drives produced no `error_message`
  at all; a prompt asking for a verbatim passage of a copyrighted novel trips the recitation filter
  and produces it with no Escape anywhere. "Suppress it on the interrupt path" would have suppressed
  the wrong thing, which is what the triage note suspected.
- **The live step carries no `text_delta`** — the field is absent, not empty — so at 1.2.0 the carry
  is always empty and the new arm renders nothing either way. The message itself rides the terminal
  `result.error`, which the mapper's failure event already surfaces, and agy's on-disk transcript
  records it as the `SYSTEM`/`ERROR_MESSAGE` line `transcript.ts` already renders with its text. The
  with-text arm is there for the release that starts sending one.

The captured lines land verbatim as `fixtures.errorMessageStep` / `fixtures.resultContentFiltered`,
with the invocation and the filter in the fixture's own docblock. The reading lands in ADR 0362 as a
later-version section; the 1.1.27 pin, its five-value census and `AGY_VERSION` are left exactly as
they were, and `launch.unit.test.ts:107` therefore does not move.

Gates in this tree: `pnpm typecheck` 0 errors, `pnpm lint` clean, `apps/tuval` 3,338 tests passed.

## Deviations

- **Declined guidance** — **Said:** criterion 5 asks for a fixture captured from a real `agy` 1.2.0
  **stop**. **Did:** captured it from a real `agy` 1.2.0 recitation-filter abort instead — verbatim
  NDJSON, provenance in the fixture — and drove the interrupted arm from the existing v1.1.28
  `resultInterrupted` capture. **Why:** no stop produces the step. Four `SIGINT` drives emitted no
  `error_message`, so the criterion's premise that this is a stop-path step is falsified by
  measurement; a fixture "captured from a stop" could only have been a hand-written approximation,
  which the same criterion forbids. **Disposition:** stated here and recorded in ADR 0362 and the
  fixture docblock, so the next reader does not re-derive it.
- **Out-of-scope change** — **Said:** #8896 names the mapper, `wire.ts`'s census, and the ADR.
  **Did:** also added a sentence to `AGY_VERSION`'s docblock in `wire.ts` saying why the constant
  stays at `1.1.27`. **Why:** criterion 7 requires the decision be stated either way, and the
  constant is where a reader meets the question. **Disposition:** stated here.
