### PR TITLE
fix: build check does not run the local-tree guards ADR 0380 puts on its path

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -257,6 +257,15 @@ fabrika build check --surface code
 
 Loop construct → check until green. `red` rows name the diagnostics; fix them here, in this tree.
 
+**Every run also sweeps the shipped local-tree guards, whatever the surface**, so a guard that would
+red in CI reds here first. A passing member is named in the green's `ran` as `guard <name> <leaf>`; a
+failing one reds the whole run on `18` and the failing line names it — fix that guard's finding like
+any other red. A member that **refused** — zero scope, or a read it could not make — lands in the
+green's `skipped` array as `<name> (<reason>)` and on stderr. **A skip is not a pass**: it says CI's
+own gate will answer that one, so read the line rather than treating the green as covering it.
+Membership is a property each guard declares beside its own registration, so there is no list here to
+keep in step with it and none to pass on the command line.
+
 A green names the files it did not read in `unvalidated`. When that list holds a file class another
 surface validates, run `build check` again there: markdown beside your code — the common case — goes
 to `--surface prose`, or `--surface plan` if that markdown is an epic ledger, which runs the prose

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1861,8 +1861,26 @@ fabrika build check --surface code
 | `--surface` | enum: `code` \| `prose` \| `plan` \| `workflows` | yes | — | the surface whose validators run; the skill names it, this verb anchors it |
 
 **Output** — machine. On green, one JSON object:
-`{"verdict": "green", "surface": "code", "tree": "<abs tree root>", "ran": [<the commands that ran>], "unvalidated": []}`.
+`{"verdict": "green", "surface": "code", "tree": "<abs tree root>", "ran": [<the commands that ran>, "guard <name> <leaf>", …], "skipped": [], "unvalidated": []}`.
 Red and unknown produce no stdout (`18` / `11`), diagnostics on stderr verbatim from the runners.
+
+**Every run also sweeps the shipped local-tree guards, on every surface.** A local-tree guard is
+argument-free, reads only the checked-out tree, and needs no PR number, no board read and no auth;
+membership is declared beside each guard's registration in
+`packages/fabrika-cli/src/guard/command.ts` and nowhere else. Each member that passed is named in
+`ran` as `guard <name> <leaf>` — the leaf is not always `check`, `decisions-index`'s is `validate` —
+and a member that failed reds the whole run on `18`, with `build check: red — guard <name> <leaf>
+failed; diagnostics above.` naming it. A member that **refused** — zero scope (`7`) or an UNKNOWN
+read (`11`) — is reported as `skipped: <name> (<reason>)` in the JSON's `skipped` array and on
+stderr, and is never folded into the green: a skip is a disclosure, read as *CI will answer this
+one*. The repo's own fail-closed-on-zero-scope rule for its CI gates is untouched by it — this is a
+local predictor with no authority to answer for a gate.
+
+The sweep is deliberately **not** anchored by `--surface`. `portability-guard` reads shipped
+markdown and `patch-guard` reads `patches/`, so a prose-only diff is exactly the diff that kept
+reaching review red under a `code`-only check. `--surface` stays an anchor over the repo's own
+declared validators, and nothing else. The accepted cost is a dozen-odd tree walks on every
+`build check`, on every lane — cheaper than the review round it saves.
 
 `unvalidated` is always present and lists the changed files **this verdict does not cover** —
 computed against *this* surface's validators, so it holds both the class no surface validates
@@ -2073,6 +2091,8 @@ Preconditions: a readable tree root (`11`), the lane's branch checked out (`14`)
 | `build check: --surface prose, but the diff changes no markdown file — the surface is provably wrong.` | 10 | refusal |
 | `build check: the diff against <base> is empty — nothing to validate.` | 7 | refusal |
 | `build check: red — <runner> failed; diagnostics above.` | 18 | refusal |
+| `build check: red — guard <name> <leaf> failed; diagnostics above.` | 18 | refusal |
+| `build check: skipped: <name> (<reason>) — not a pass; CI's own gate answers this one.` | 0 | disclosure beside a green |
 | `build check: no surface validates any of the <n> changed file(s) (<files>) — there is nothing here to run, so the verdict is a refusal, never green.` | 22 | refusal |
 | `build check: <n> changed file(s) --surface <surface> does not validate — NOT covered by this verdict: <files>.` | 0 | scope note beside a green |
 

--- a/claude-plugins/fabrika/skills/build/references/code.md
+++ b/claude-plugins/fabrika/skills/build/references/code.md
@@ -3,7 +3,9 @@
 Compiled, tested text. `fabrika build check` runs the commands this repo declares under
 `.fabrika.jsonc`'s `codeValidators` in this tree — typically a typecheck and a lint, whatever the
 repo named. A repo that declares none refuses UNKNOWN rather than running someone else's script
-names.
+names. On top of those it sweeps every shipped local-tree guard — the same on any surface, so a
+prose-only diff gets them too — naming each one in the green's `ran` or, where a guard refused, in
+its `skipped`.
 
 - **Match the surrounding code's idiom** — comment density, naming, bracket style. A diff that
   reads as a different author is a defect before it is a style choice.

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -98,7 +98,7 @@ Contract: [`skills/build/contract.md`](../../../claude-plugins/fabrika/skills/bu
 | `build branch` / `scratch` | the lane's branch off a fresh base, and its scratch directory |
 | `build resume-child` | an epic child's standing-`FAIL` repair lane, opened as one operation: claim, confirm, clean tree, resumed branch, armed proof |
 | `build commit` / `push` | the commit whose message is proven this lane's, and the push whose ref is proven moved |
-| `build check` | this surface's validators, run in this tree |
+| `build check` | this surface's validators plus every shipped local-tree guard, run in this tree — each guard named in `ran`, or in `skipped` when it refused |
 | `build pr` / `pr-body` / `note` | the guarded, read-back PR write surfaces |
 | `build verdicts` | the latest gate verdict per namespace at a PR's live head |
 | `build clear` | the founder's clearance of one extra repair round |

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -12,6 +12,13 @@
  * **This verb predicts; the gate decides.** The repo's CI gate owns redness, and where they disagree the
  * gate's answer supersedes this one (interface convention rule 6). Nothing here re-reads CI.
  *
+ * **Every run also sweeps the shipped local-tree guards, whatever the surface.** A guard that only
+ * needs the checked-out tree runs here so it reds on the builder's machine before it reds in CI, and
+ * each member is named in the answer — `guard <name> <leaf>` in `ran`, or `skipped: <name>
+ * (<reason>)` for one that refused, which is a disclosure and never a pass. Membership is declared
+ * beside each guard's registration in `guard/command.ts` and nowhere else; see
+ * {@link sweepLocalTreeGuards}.
+ *
  * `--surface` is an **anchor, not a second classifier**: naming the surface is a judgement the skill
  * makes reading the issue, and a verb that guessed it from file extensions would be wrong exactly on
  * the mixed diffs where the answer matters. The verb takes the skill's answer and refuses one the diff
@@ -26,7 +33,7 @@
  * that merely enters a diff no longer hands its author every defect line it already carried; the
  * shape and its deliberate limits live in `prose-baseline.ts`.
  */
-import {Effect, FileSystem} from "effect";
+import {Effect, FileSystem, type Path} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import type {Resolution} from "../config/key-group.ts";
@@ -38,6 +45,7 @@ import {
 } from "../config/keys/code-validators.ts";
 import {loadConfig, resolve} from "../config/load.ts";
 import {readConfigSource} from "../config/source.ts";
+import type {LocalTreeGuard} from "../guard/local-tree.ts";
 import {execStatus} from "../io/exec.ts";
 import {
 	CONFIG_PATH,
@@ -45,7 +53,7 @@ import {
 	readWorkflowValidators,
 	type WorkflowValidator,
 } from "../repo-config.ts";
-import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {ANSWER, answer, refuse, type VerbOutcome} from "../verb.ts";
 import {requireSession} from "./claim.ts";
 import {
 	OFF_VOCABULARY,
@@ -90,6 +98,14 @@ export interface CheckOptions {
 	readonly surface: string;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/**
+	 * The local-tree guards to sweep, whatever the surface — the adapter hands over the set
+	 * `guard/command.ts` derives from its own registry, and a test names the guards it means.
+	 *
+	 * An operand rather than an import, because a verb that reached for the registry itself would
+	 * make every existing test of this verb run twenty guards over a fake filesystem.
+	 */
+	readonly guards: ReadonlyArray<LocalTreeGuard>;
 }
 
 /**
@@ -473,6 +489,79 @@ const diagnostics = (output: string): ReadonlyArray<string> => {
 			];
 };
 
+/**
+ * The two guard refusals a sweep may report beside a green, and how each reads back.
+ *
+ * Everything else — a violation (`12`), or any code a guard is not supposed to speak — is red. A
+ * guard that refused proved nothing about the tree, so folding it into the green would be exactly
+ * the "I could not tell" this verb refuses to spell as a pass. The repo's fail-closed-on-zero-scope
+ * rule for its CI gates is untouched by this: the gate still owns the verdict, and this predicts it.
+ */
+const SKIP_REASONS: ReadonlyMap<number, string> = new Map([
+	[ZERO_SCOPE, "zero scope"],
+	[PRECONDITION_UNKNOWN, "UNKNOWN read"],
+]);
+
+/** What a clean sweep contributes to the answer: the members that passed, and the ones that refused. */
+export interface GuardSweep {
+	/** One `guard <name> <leaf>` label per member that ran and passed, folded into the green's `ran`. */
+	readonly ran: ReadonlyArray<string>;
+	/** One `<name> (<reason>)` line per member that refused — never a pass. */
+	readonly skipped: ReadonlyArray<string>;
+}
+
+type SweepOutcome =
+	| {readonly _tag: "Swept"; readonly sweep: GuardSweep; readonly notes: ReadonlyArray<string>}
+	| {
+			readonly _tag: "Red";
+			readonly label: string;
+			readonly notes: ReadonlyArray<string>;
+			readonly output: string;
+	  };
+
+/**
+ * Run every local-tree guard over this tree, on every surface, and name each one in the answer.
+ *
+ * The sweep is deliberately **not** anchored by `--surface`: `portability-guard` reads shipped
+ * markdown and `patch-guard` reads `patches/`, so a prose-only diff is exactly the diff that kept
+ * reaching review red under a `code`-only check — three repair rounds went on guards a surface-bound
+ * check could never reach. The anchor stays what it was: a claim about the repo's *declared*
+ * validators.
+ *
+ * The first red stops the sweep: the builder has a guard to fix, and the sixteen that would have
+ * run after it say nothing about that.
+ */
+const sweepLocalTreeGuards = (
+	guards: ReadonlyArray<LocalTreeGuard>,
+	root: string,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<
+	SweepOutcome,
+	never,
+	FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const ran: string[] = [];
+		const skipped: string[] = [];
+		const notes: string[] = [];
+		for (const guard of guards) {
+			const label = `guard ${guard.name} ${guard.leaf}`;
+			const outcome = yield* guard.run({root, env});
+			if (outcome.code === ANSWER) {
+				ran.push(label);
+				continue;
+			}
+			const reason = SKIP_REASONS.get(outcome.code);
+			if (reason === undefined) {
+				return {_tag: "Red", label, notes, output: outcome.stderr.join("\n")} as const;
+			}
+			const line = `${guard.name} (${reason}: ${outcome.stderr.at(-1) ?? `exit ${outcome.code}`})`;
+			skipped.push(line);
+			notes.push(`${VERB}: skipped: ${line} — not a pass; CI's own gate answers this one.`);
+		}
+		return {_tag: "Swept", sweep: {ran, skipped}, notes} as const;
+	});
+
 /** The code validators to run, or why the answer is UNKNOWN. */
 type CodeScope =
 	| {
@@ -523,6 +612,7 @@ const runCodeSurface = (
 	root: string,
 	unvalidated: ReadonlyArray<string>,
 	noted: ReadonlyArray<string>,
+	sweep: GuardSweep,
 ): Effect.Effect<
 	VerbOutcome,
 	never,
@@ -565,7 +655,14 @@ const runCodeSurface = (
 			}
 		}
 		return answer(
-			JSON.stringify({verdict: "green", surface: "code", tree: root, ran, unvalidated}),
+			JSON.stringify({
+				verdict: "green",
+				surface: "code",
+				tree: root,
+				ran: [...ran, ...sweep.ran],
+				skipped: sweep.skipped,
+				unvalidated,
+			}),
 			scoped,
 		);
 	});
@@ -636,6 +733,7 @@ const runWorkflowSurface = (
 	workflows: ReadonlyArray<string>,
 	unvalidated: ReadonlyArray<string>,
 	noted: ReadonlyArray<string>,
+	sweep: GuardSweep,
 ): Effect.Effect<
 	VerbOutcome,
 	never,
@@ -726,7 +824,8 @@ const runWorkflowSurface = (
 				verdict: "green",
 				surface: "workflows",
 				tree: root,
-				ran,
+				ran: [...ran, ...sweep.ran],
+				skipped: sweep.skipped,
 				unvalidated: [...unvalidated, ...unopened],
 			}),
 			disclosed,
@@ -738,7 +837,10 @@ export const runCheck = (
 ): Effect.Effect<
 	VerbOutcome,
 	never,
-	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | HttpClient.HttpClient
+	| ChildProcessSpawner.ChildProcessSpawner
+	| FileSystem.FileSystem
+	| HttpClient.HttpClient
+	| Path.Path
 > =>
 	Effect.gen(function* () {
 		const surface = options.surface.trim().toLowerCase();
@@ -808,7 +910,7 @@ export const runCheck = (
 		// workflow files whose `ran` line was true and misleading at once, and a `--surface code` green
 		// then did the same to markdown while reporting an empty list.
 		const unvalidated = notCoveredBy(surface as Surface, files);
-		const noted =
+		const covered =
 			unvalidated.length === 0
 				? scope
 				: [
@@ -816,9 +918,19 @@ export const runCheck = (
 						`${VERB}: ${unvalidated.length} changed file(s) --surface ${surface} does not validate — NOT covered by this verdict: ${unvalidated.join(", ")}.`,
 					];
 
+		const swept = yield* sweepLocalTreeGuards(options.guards, lane.root, options.env);
+		const noted = [...covered, ...swept.notes];
+		if (swept._tag === "Red") {
+			return refuse(VALIDATION_RED, `${VERB}: red — ${swept.label} failed; diagnostics above.`, [
+				...noted,
+				...diagnostics(swept.output),
+			]);
+		}
+		const sweep = swept.sweep;
+
 		const fs = yield* FileSystem.FileSystem;
 		if (surface === "code") {
-			return yield* runCodeSurface(lane.root, unvalidated, noted);
+			return yield* runCodeSurface(lane.root, unvalidated, noted, sweep);
 		}
 
 		if (surface === "workflows") {
@@ -828,6 +940,7 @@ export const runCheck = (
 				classifyDiff(files).workflows,
 				unvalidated,
 				noted,
+				sweep,
 			);
 		}
 
@@ -898,7 +1011,11 @@ export const runCheck = (
 				verdict: "green",
 				surface,
 				tree: lane.root,
-				ran: surface === "plan" ? [MARKDOWN_SCAN, PLAN_GRAMMAR] : [MARKDOWN_SCAN],
+				ran: [
+					...(surface === "plan" ? [MARKDOWN_SCAN, PLAN_GRAMMAR] : [MARKDOWN_SCAN]),
+					...sweep.ran,
+				],
+				skipped: sweep.skipped,
 				unvalidated,
 			}),
 			scoped,

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -1,7 +1,9 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeSeams, okOut, type Scripted} from "../fakes.test-support.ts";
+import type {LocalTreeGuard} from "../guard/local-tree.ts";
 import type {ExecResult} from "../io/exec.ts";
+import type {VerbOutcome} from "../verb.ts";
 import {
 	classifyDiff,
 	linkTargets,
@@ -111,6 +113,8 @@ const options = {
 		string,
 		string | undefined
 	>,
+	/** No local-tree guard unless a test names one — the sweep has its own describe block. */
+	guards: [] as ReadonlyArray<LocalTreeGuard>,
 };
 
 const run = (
@@ -239,6 +243,7 @@ describe("runCheck", () => {
 			surface: "code",
 			tree: "/repo/trees/lane-a",
 			ran: ["pnpm typecheck --force", "pnpm lint:worktree"],
+			skipped: [],
 			unvalidated: [],
 		});
 		expect(shell.calls).toContain("pnpm typecheck --force");
@@ -1029,6 +1034,7 @@ describe("--surface workflows", () => {
 			surface: "workflows",
 			tree: "/repo/trees/lane-a",
 			ran: ["actionlint", GUARD.join(" ")],
+			skipped: [],
 			unvalidated: [],
 		});
 		expect(calls).toContain("actionlint .github/workflows/ci.yml .github/workflows/publish.yml");
@@ -1308,5 +1314,124 @@ describe("--surface code reads its validators from the config", () => {
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("is UNKNOWN, never green");
 		expect(shell.calls).not.toContain("pnpm typecheck --force");
+	});
+});
+
+/**
+ * The local-tree guard sweep.
+ *
+ * The guards arrive as an operand, so these tests hand the verb the ones they mean. Which guards the
+ * shipped CLI hands it is a fact about the registry, pinned in `guard/local-tree.data.unit.test.ts`.
+ */
+describe("runCheck — the local-tree guard sweep", () => {
+	const guard = (
+		name: string,
+		outcome: VerbOutcome,
+		leaf = "check",
+		seen: string[] = [],
+	): LocalTreeGuard => ({
+		name,
+		leaf,
+		run: () =>
+			Effect.sync(() => {
+				seen.push(`${name} ${leaf}`);
+				return outcome;
+			}),
+	});
+
+	const clean: VerbOutcome = {code: 0, stdout: "patch-guard: clean.\n", stderr: []};
+
+	const sweepRun = (guards: ReadonlyArray<LocalTreeGuard>) =>
+		run(
+			[...LANE_OK, [DIFF, okOut("src/app/App.tsx\n")], [TYPECHECK, okOut("")], [LINT, okOut("")]],
+			{guards},
+		);
+
+	it("folds a passing member into `ran` under its own leaf", async () => {
+		const out = await sweepRun([
+			guard("patch-guard", clean),
+			guard("decisions-index", clean, "validate"),
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).ran).toEqual([
+			"pnpm typecheck --force",
+			"pnpm lint:worktree",
+			"guard patch-guard check",
+			"guard decisions-index validate",
+		]);
+		expect(JSON.parse(out.stdout).skipped).toEqual([]);
+	});
+
+	// The reproduction that forced this: patch-guard red at the tip while `--surface code` greened.
+	it("reds on 18 naming the member that failed, with nothing on stdout", async () => {
+		const out = await sweepRun([
+			guard("patch-guard", {
+				code: 12,
+				stdout: "",
+				stderr: ["patches/effect.patch has no @patch-pin marker"],
+			}),
+		]);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build check: red — guard patch-guard check failed; diagnostics above.",
+		);
+		expect(out.stderr).toContain("patches/effect.patch has no @patch-pin marker");
+	});
+
+	it("reports a member's exit 7 as `skipped:`, never as a pass", async () => {
+		const out = await sweepRun([
+			guard("readme-guard", {
+				code: ZERO_SCOPE,
+				stdout: "",
+				stderr: ["readme-guard: no workspace member was scanned."],
+			}),
+		]);
+		expect(out.code).toBe(0);
+		const green = JSON.parse(out.stdout);
+		expect(green.skipped).toEqual([
+			"readme-guard (zero scope: readme-guard: no workspace member was scanned.)",
+		]);
+		expect(green.ran).not.toContain("guard readme-guard check");
+		expect(out.stderr).toContain(
+			"build check: skipped: readme-guard (zero scope: readme-guard: no workspace member was scanned.) — not a pass; CI's own gate answers this one.",
+		);
+	});
+
+	it("reports a member's exit 11 as `skipped:`, never as a pass", async () => {
+		const out = await sweepRun([
+			guard("i18n-guard", {
+				code: PRECONDITION_UNKNOWN,
+				stdout: "",
+				stderr: ["i18n-guard: the allow-list could not be read."],
+			}),
+		]);
+		expect(out.code).toBe(0);
+		const green = JSON.parse(out.stdout);
+		expect(green.skipped).toEqual([
+			"i18n-guard (UNKNOWN read: i18n-guard: the allow-list could not be read.)",
+		]);
+		expect(green.ran).not.toContain("guard i18n-guard check");
+	});
+
+	// Two portability-guard repair rounds were spent on prose-only diffs, which the `code` surface
+	// never reaches. The sweep is not anchored by --surface for exactly that reason.
+	it("sweeps under a markdown surface too, not `code` alone", async () => {
+		const seen: string[] = [];
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/a.md\n")]],
+			{guards: [guard("portability-guard", clean, "check", seen)], surface: "prose"},
+			{[`${ROOT}/docs/a.md`]: "# a\n"},
+		);
+		expect(out.code).toBe(0);
+		expect(seen).toEqual(["portability-guard check"]);
+		expect(JSON.parse(out.stdout).ran).toContain("guard portability-guard check");
+	});
+
+	it("invokes nothing when it is handed no member", async () => {
+		const out = await sweepRun([]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).skipped).toEqual([]);
+		expect(JSON.parse(out.stdout).ran).toEqual(["pnpm typecheck --force", "pnpm lint:worktree"]);
 	});
 });

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -18,6 +18,7 @@ import {Effect, type FileSystem, Option, Result} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {emit} from "../emit.ts";
 import {leafCommand} from "../excess-operand.ts";
+import {localTreeGuards} from "../guard/command.ts";
 import {readFile} from "../io/fs.ts";
 import {readStdin} from "../io/stdin.ts";
 import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
@@ -488,12 +489,21 @@ const check = leafCommand(
 		repo: repoFlag,
 	},
 	Effect.fn(function* ({surface, repo}) {
-		yield* emit(yield* runCheck({surface, repo: Option.getOrNull(repo), env: process.env}));
+		yield* emit(
+			yield* runCheck({
+				surface,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				guards: localTreeGuards,
+			}),
+		);
 	}),
 ).pipe(
-	Command.withShortDescription("Run this surface's validators in this tree."),
+	Command.withShortDescription(
+		"Run this surface's validators and the local-tree guards, in this tree.",
+	),
 	Command.withDescription(
-		'Run this surface\'s validators IN THIS TREE — a green borrowed from another checkout has been another tree\'s answer. Whether a validator reads a build cache is the repo\'s own declaration, not this verb\'s. Prints {"verdict":"green","surface":"…","tree":"…","ran":[…]}; red and unknown print nothing. A workflows-only diff (.github/workflows/**) is --surface workflows: actionlint over the changed files when the tree has it, plus the commands `.fabrika.jsonc` declares under `workflowValidators` (each naming the files it `reads`); a changed workflow nothing opened is reported in `unvalidated`, and a run that opened none of them is UNKNOWN. This verb predicts; the repo\'s CI gate decides, and supersedes it where they disagree. Exits 7 (the diff against the base is empty — zero scope), 10 (--surface is off-enum or provably mismatches the diff), 11 (the tree root could not be read, a validator could not be executed, `.fabrika.jsonc` could not be read, or the lane\'s claim could not be read — UNKNOWN, never green), 14 (the checked-out branch is not this lane\'s), 15 (the lane\'s claim is held by another session), 18 (proven red), 22 (no surface validates any changed file). Example: fabrika build check --surface code',
+		'Run this surface\'s validators IN THIS TREE — a green borrowed from another checkout has been another tree\'s answer. Whether a validator reads a build cache is the repo\'s own declaration, not this verb\'s. EVERY surface additionally sweeps the shipped local-tree guards — the ones that are argument-free and read only the checked-out tree — so a guard that reds in CI reds here first; membership is declared beside each guard\'s registration and the sweep is not anchored by --surface. Prints {"verdict":"green","surface":"…","tree":"…","ran":[…,"guard <name> <leaf>",…],"skipped":[…],"unvalidated":[…]}; red and unknown print nothing. A guard that exited 7 (zero scope) or 11 (UNKNOWN) is reported in `skipped` as "<name> (<reason>)" and is never folded into the green — CI\'s own gate answers that one. A workflows-only diff (.github/workflows/**) is --surface workflows: actionlint over the changed files when the tree has it, plus the commands `.fabrika.jsonc` declares under `workflowValidators` (each naming the files it `reads`); a changed workflow nothing opened is reported in `unvalidated`, and a run that opened none of them is UNKNOWN. This verb predicts; the repo\'s CI gate decides, and supersedes it where they disagree. Exits 7 (the diff against the base is empty — zero scope), 10 (--surface is off-enum or provably mismatches the diff), 11 (the tree root could not be read, a validator could not be executed, `.fabrika.jsonc` could not be read, or the lane\'s claim could not be read — UNKNOWN, never green), 14 (the checked-out branch is not this lane\'s), 15 (the lane\'s claim is held by another session), 18 (proven red — a validator or a local-tree guard failed, and the failing line names it), 22 (no surface validates any changed file). Example: fabrika build check --surface code',
 	),
 );
 

--- a/packages/fabrika-cli/src/guard/command.ts
+++ b/packages/fabrika-cli/src/guard/command.ts
@@ -4,8 +4,11 @@
  * Unlike every other group here, this one nests: a guard is its own subcommand and `check` is its
  * leaf, so CI reads `node packages/fabrika-cli/src/bin.ts guard readme-guard check` — the shape
  * `governance-floor.yml` already uses, with the guard's name where a reader expects it. Each ported
- * guard appends one row to {@link guards} and one `<name>-verb.ts` beside this file; nothing else
+ * guard appends one row to {@link registry} and one `<name>-verb.ts` beside this file; nothing else
  * about the group changes, which is what keeps five batches of ports off each other's lines.
+ *
+ * A row carries the guard's command **and its local-tree membership** — whether `build check` runs
+ * it over the checked-out tree, and under which leaf. See `local-tree.ts`.
  *
  * The adapter and nothing else: it declares the flags, reads the two machine facts the verbs do not
  * derive — the working directory and the environment — runs the pure verb, and emits its outcome.
@@ -25,6 +28,7 @@ import {runFanoutGuard} from "./fanout-verb.ts";
 import {runHomingGuard} from "./homing-verb.ts";
 import {runI18nGuard} from "./i18n-literal-verb.ts";
 import {runLeakGuard} from "./leak-verb.ts";
+import {type LocalTreeGuard, localTree, membersOf, notLocalTree} from "./local-tree.ts";
 import {runNoGh} from "./no-gh-verb.ts";
 import {runPatchGuard} from "./patch-verb.ts";
 import {runPathFilterGuard} from "./path-filter-verb.ts";
@@ -695,31 +699,66 @@ const designInventoryGuard = Command.make("design-inventory").pipe(
 	),
 );
 
-/** The registered guards. One appended row per port; the order is the `--help` order. */
-const guards = [
-	readmeGuard,
-	skillLint,
-	homingGuard,
-	pitchGuard,
-	roadmapGuard,
-	unresolvedThreadsGuard,
-	settingsEnvGuard,
-	catalogGuard,
-	fanoutGuard,
-	patchGuard,
-	pointerGuard,
-	publishIsolationGuard,
-	leakGuard,
-	pathFilterGuard,
-	changeDetectGuard,
-	codeownersCpGuard,
-	decisionsIndexGuard,
-	designTokenGuard,
-	designInventoryGuard,
-	i18nGuard,
-	noGhGuard,
-	portabilityGuard,
+/**
+ * The registered guards, each row carrying its **local-tree membership** beside the registration.
+ *
+ * One appended row per port; the order is the `--help` order. The second field is the contract:
+ * `localTree` says `build check` runs this guard over the checked-out tree under the named leaf,
+ * `notLocalTree` says which clause of the predicate it fails. Membership is answered here and
+ * nowhere else, so adding a guard is where the question gets asked.
+ */
+const registry = [
+	localTree(readmeGuard, "check", (o) => runReadmeGuard({root: o.root, cwd: o.root, env: o.env})),
+	localTree(skillLint, "check", (o) => runSkillLint({root: o.root, cwd: o.root, env: o.env})),
+	notLocalTree(homingGuard, "reads the live board"),
+	notLocalTree(pitchGuard, "reads the live board and resolves approval at the repository ACL"),
+	notLocalTree(roadmapGuard, "projects the repository's milestones off the API"),
+	notLocalTree(unresolvedThreadsGuard, "takes a pull-request number"),
+	localTree(settingsEnvGuard, "check", (o) =>
+		runSettingsEnvGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
+	localTree(catalogGuard, "check", (o) => runCatalogGuard({root: o.root, cwd: o.root, env: o.env})),
+	localTree(fanoutGuard, "check", (o) => runFanoutGuard({root: o.root, cwd: o.root, env: o.env})),
+	localTree(patchGuard, "check", (o) => runPatchGuard({root: o.root, cwd: o.root, env: o.env})),
+	localTree(pointerGuard, "check", (o) => runPointerGuard({root: o.root, cwd: o.root, env: o.env})),
+	localTree(publishIsolationGuard, "check", (o) =>
+		runPublishIsolationGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
+	notLocalTree(leakGuard, "takes the changed files as arguments"),
+	localTree(pathFilterGuard, "check", (o) =>
+		runPathFilterGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
+	localTree(changeDetectGuard, "check", (o) =>
+		runChangeDetectGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
+	localTree(codeownersCpGuard, "check", (o) =>
+		runCodeownersCpGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
+	localTree(decisionsIndexGuard, "validate", (o) =>
+		runDecisionsIndexGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
+	localTree(designTokenGuard, "check", (o) =>
+		runDesignTokenGuard({root: o.root, cwd: o.root, env: o.env, writeBaseline: false}),
+	),
+	localTree(designInventoryGuard, "check", (o) =>
+		runDesignInventoryCheck({root: o.root, cwd: o.root, env: o.env}),
+	),
+	localTree(i18nGuard, "check", (o) => runI18nGuard({root: o.root, cwd: o.root, env: o.env})),
+	localTree(noGhGuard, "check", (o) => runNoGh({root: o.root, cwd: o.root, env: o.env})),
+	localTree(portabilityGuard, "check", (o) =>
+		runPortabilityGuard({root: o.root, cwd: o.root, env: o.env}),
+	),
 ];
+
+const guards = registry.map((row) => row.command);
+
+/**
+ * The set `build check` sweeps, derived from {@link registry} — never a list of its own.
+ *
+ * Exported for `build/command.ts`, which hands it to the check verb. The verb takes it as an
+ * operand rather than importing it, so a test names the guards it means.
+ */
+export const localTreeGuards: ReadonlyArray<LocalTreeGuard> = membersOf(registry);
 
 export const guardCommand = Command.make("guard").pipe(
 	Command.withSubcommands(guards),

--- a/packages/fabrika-cli/src/guard/local-tree.data.unit.test.ts
+++ b/packages/fabrika-cli/src/guard/local-tree.data.unit.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The membership of the local-tree set, asserted against the ruling that named it.
+ *
+ * A data test over the shipped registry, not over a copy of it: the ruling names seven members and
+ * three non-members by hand, and the rest are classified by the predicate. If a later port drops a
+ * named member out of the set — or lets a board-reading guard into it — a builder's `build check`
+ * silently stops predicting a CI gate, which is the failure the record exists to close.
+ */
+
+import {describe, expect, it} from "vitest";
+import {localTreeGuards} from "./command.ts";
+
+const names = localTreeGuards.map((guard) => guard.name);
+
+describe("the local-tree guard set", () => {
+	it("holds every member the ruling names", () => {
+		for (const name of [
+			"portability-guard",
+			"patch-guard",
+			"catalog-guard",
+			"readme-guard",
+			"fanout-guard",
+			"i18n-guard",
+			"decisions-index",
+		]) {
+			expect(names).toContain(name);
+		}
+	});
+
+	// The predicate's whole warrant: a builder can run the set offline against the tree in front of
+	// them. A guard needing a PR number, a board read or a credential has nothing to say there.
+	it("holds no guard that needs a pull request, the board or a credential", () => {
+		for (const name of [
+			"unresolved-threads-guard",
+			"homing-guard",
+			"pitch-guard",
+			"roadmap-guard",
+		]) {
+			expect(names).not.toContain(name);
+		}
+	});
+
+	it("holds no guard that takes operands — leak-guard scans the files it is handed", () => {
+		expect(names).not.toContain("leak-guard");
+	});
+
+	it("invokes each member under its own leaf, which is not always `check`", () => {
+		expect(localTreeGuards.find((guard) => guard.name === "decisions-index")?.leaf).toBe(
+			"validate",
+		);
+	});
+
+	it("names each member once", () => {
+		expect(new Set(names).size).toBe(names.length);
+	});
+});

--- a/packages/fabrika-cli/src/guard/local-tree.ts
+++ b/packages/fabrika-cli/src/guard/local-tree.ts
@@ -1,0 +1,83 @@
+/**
+ * What it means for a guard to be a **local-tree guard**, and the two constructors that say so.
+ *
+ * A local-tree guard is argument-free, reads only the checked-out tree, and needs no pull-request
+ * number, no board read and no auth. `build check` sweeps exactly that set on every surface, so a
+ * guard that reds in CI reds on the builder's machine first.
+ *
+ * This module holds the **shape** and never the membership. Every row is declared beside its own
+ * registration in `command.ts`, because a second list — here, in a config file, in a workflow, or in
+ * a skill — is the drift the decision exists to prevent.
+ */
+
+import type {Effect, FileSystem, Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import type {VerbOutcome} from "../verb.ts";
+
+/**
+ * One local-tree guard's invocation, bound to the tree it judges.
+ *
+ * The three services are the ceiling the predicate implies: the filesystem and path for the walk,
+ * the spawner for the guards that shell out to `git` against this same checkout. An `HttpClient`
+ * here would mean the guard reads the board, which is what disqualifies it.
+ */
+export type LocalTreeRun = (options: {
+	readonly root: string;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}) => Effect.Effect<
+	VerbOutcome,
+	never,
+	FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+>;
+
+/** A member of the local-tree set, as `build check` invokes and names it. */
+export interface LocalTreeGuard {
+	/** The guard's name, read off its own command so the two spellings cannot drift. */
+	readonly name: string;
+	/** The leaf that runs it — `check` for most, `validate` for `decisions-index`. */
+	readonly leaf: string;
+	readonly run: LocalTreeRun;
+}
+
+/**
+ * A registered guard's membership answer.
+ *
+ * The refusing arm carries its reason as data rather than a comment: a row that cannot name the
+ * clause of the predicate it fails is a row whose membership was never decided.
+ */
+export type Membership =
+	| {readonly _tag: "LocalTree"; readonly guard: LocalTreeGuard}
+	| {readonly _tag: "NotLocalTree"; readonly why: string};
+
+/** One registry row: the registered command and its membership, side by side. */
+export interface GuardRow<C extends {readonly name: string}> {
+	readonly command: C;
+	readonly membership: Membership;
+}
+
+/**
+ * Register a guard as a member: `build check` runs `leaf` over the checked-out tree.
+ *
+ * The name comes off the command, so a member cannot be registered under a name the CLI does not
+ * answer to.
+ */
+export const localTree = <C extends {readonly name: string}>(
+	command: C,
+	leaf: string,
+	run: LocalTreeRun,
+): GuardRow<C> => ({
+	command,
+	membership: {_tag: "LocalTree", guard: {name: command.name, leaf, run}},
+});
+
+/** Register a guard as a non-member, naming the clause of the predicate it fails. */
+export const notLocalTree = <C extends {readonly name: string}>(
+	command: C,
+	why: string,
+): GuardRow<C> => ({command, membership: {_tag: "NotLocalTree", why}});
+
+/** The members of a registry, in registration order — the set `build check` sweeps. */
+export const membersOf = (
+	rows: ReadonlyArray<GuardRow<{readonly name: string}>>,
+): ReadonlyArray<LocalTreeGuard> =>
+	rows.flatMap((row) => (row.membership._tag === "LocalTree" ? [row.membership.guard] : []));


### PR DESCRIPTION
`fabrika build check` greened on trees CI then redded: it ran only the argv entries the repo declares
under `.fabrika.jsonc`'s `codeValidators` and never invoked a shipped guard. Three review rounds were
spent reproducing `patch-guard` and `portability-guard` by hand — twice under prose-only diffs the
`code` surface could not reach at all.

Now every registry row in `guard/command.ts` carries its own membership answer beside the
registration, and `build check` sweeps the members on every surface.

- `guard/local-tree.ts` — the shape and the two constructors: `localTree(command, leaf, run)` and
  `notLocalTree(command, why)`. The name comes off the command, so a member cannot be registered
  under a name the CLI does not answer to; the refusing arm carries its reason as data.
- `guard/command.ts` — the flat `guards` array becomes a `registry` of those rows. `guards` and the
  exported `localTreeGuards` are both derived from it, so there is no second list to drift.
  17 members; the 5 non-members are `homing-guard`, `pitch-guard`, `roadmap-guard` (board reads),
  `unresolved-threads-guard` (a PR number) and `leak-guard` (takes the changed files as operands).
- `build/check-verb.ts` — the sweep. A member's exit 0 is folded into the green's `ran` as
  `guard <name> <leaf>`; exit 7 or 11 lands in the new `skipped` array as `<name> (<reason>)` and on
  stderr, never as a pass; anything else reds the run on `18` with the guard named on the failing
  line. The sweep is not anchored by `--surface` — that anchor stays a claim about the repo's own
  declared validators.
- The guard set arrives as a `CheckOptions.guards` operand rather than an import, so the verb's
  existing tests are not made to run twenty guards over a fake filesystem.

Verified in this tree: `--surface code` and `--surface prose` both green with all 17 members named,
about 9s of sweep on top of typecheck and lint.

What to look at first: the membership calls in `guard/command.ts`'s `registry`, and
`sweepLocalTreeGuards` in `check-verb.ts`.

Fixes #8973

## Deviations

- **Out-of-scope change** — **Said:** the issue names `check-verb.ts`'s docblock, the verb's
  `Command.withDescription`, the build skill step and the verb-reference row. **Did:** also updated
  `claude-plugins/fabrika/skills/build/contract.md` (its `build check` Output paragraph and two
  exit-line rows) and `references/code.md`. **Why:** those are two of the six places this verb's
  grammar is hand-copied to, and leaving them stating the old contract is the drift the build skill's
  own six-surface rule exists to stop. **Disposition:** stated here.
- **Scope narrowing** — **Said:** "no second membership list exists anywhere in the tree."
  **Did:** the assertion is a data test over the shipped `localTreeGuards`, not a guard that scans
  the tree for a rival list. **Why:** the ruling bounds the follow-on to the `build check` change
  itself and explicitly refuses a new universal loop; a list nothing derives from would show up as a
  drifting data test rather than silently. **Disposition:** stated here.
