### PR TITLE
fix: The agy interrupt integration case snapshots its event log with no wait, so its ready assertion races the drain

### DIFF
--- a/apps/tuval/src/agy/ai-agent/agy-ai-agent.integration.test.ts
+++ b/apps/tuval/src/agy/ai-agent/agy-ai-agent.integration.test.ts
@@ -94,8 +94,15 @@ const usageOf = (
 ): ReadonlyArray<Extract<AgentEvent, {kind: "usage"}>> =>
 	events.filter((event) => event.kind === "usage");
 
-const turnEnded = (events: ReadonlyArray<AgentEvent>): boolean =>
-	events.filter((event) => event.kind === "phase" && event.phase === "ready").length >= 2;
+const readyPhases = (
+	events: ReadonlyArray<AgentEvent>,
+): ReadonlyArray<Extract<AgentEvent, {kind: "phase"}>> =>
+	events.filter(
+		(event): event is Extract<AgentEvent, {kind: "phase"}> =>
+			event.kind === "phase" && event.phase === "ready",
+	);
+
+const turnEnded = (events: ReadonlyArray<AgentEvent>): boolean => readyPhases(events).length >= 2;
 
 describe("the agy layer over a scripted binary", () => {
 	it("starts sandboxed and scoped to the workspace, and takes its id from init", async () => {
@@ -369,6 +376,15 @@ describe("the agy layer over a scripted binary", () => {
 				);
 				yield* agent.prompt("something long");
 				yield* agent.interrupt;
+				// `interrupt` awaits the relaunch, so both launches are recorded by the time it
+				// resolves — but `announce(reopened)`'s four events reach `collected` through `drive`'s
+				// forked pump, and its `ready` is the third this case sees: the opening, the cut turn's
+				// terminal `result`, then the reopened session. Snapshotting without this wait reads a
+				// log whose tail is still being appended (#8926).
+				yield* until(
+					collected,
+					(events) => launches().length === 2 && readyPhases(events).length === 3,
+				);
 				return [...collected];
 			}),
 		);
@@ -389,6 +405,10 @@ describe("the agy layer over a scripted binary", () => {
 		);
 		expect(phases).not.toContain("gone");
 		expect(phases.at(-1)).toBe("ready");
+		// The same condition the wait above is keyed on, asserted here too: `until` falls through its
+		// 20-second arm with `Effect.void` rather than failing, so without this a drain that never
+		// completed would surface as some unrelated expectation instead of as the missing relaunch.
+		expect(readyPhases(collectedEvents)).toHaveLength(3);
 		// Two launches, and the second reopens what the first opened: the relaunch is the `respawn`
 		// the three switches take, not a fresh session.
 		const composed = launches();


### PR DESCRIPTION
Fixes #8926

The interrupt case in `agy-ai-agent.integration.test.ts` returned `[...collected]` the instant
`agent.interrupt` resolved. `interrupt` awaits the relaunch, so both launches are recorded by then —
but `announce(reopened)`'s four events reach `collected` through `drive`'s forked pump, and nothing
ordered that drain against the snapshot. `phases.at(-1)` was an ordering assertion over a list whose
tail was still being appended.

The case now waits between the interrupt and the snapshot, keyed on the relaunch it is about:
`launches().length === 2` and a third `phase: "ready"` — the opening, the cut turn's terminal
`result`, then the reopened session. The same condition is asserted after the wait
(`expect(readyPhases(collectedEvents)).toHaveLength(3)`), because `until` falls through its
20-second arm with `Effect.void` rather than failing: without that assertion a drain that never
completed would surface as some unrelated expectation instead of as the missing relaunch.

Every existing assertion is untouched — `failure` empty, one `interrupted` item, no `gone`,
`phases.at(-1) === "ready"`, two launches, the second on `--conversation=fake-0000-1111-2222`.

Runs, in this worktree:

- the file 5 times in a row: `18 passed` each run, test phase 2.85–3.66s — two orders of magnitude
  under `until`'s 20s fall-through arm, so the wait is satisfied rather than timing out
- `pnpm test` in `apps/tuval` (unit + integration): `334 passed | 1 skipped`, `3343 passed`
- `fabrika build check --surface code`: green, nothing unvalidated (typecheck + lint + guards)

## Deviations

- **Out-of-scope change** — **Said:** #8926 names the interrupt case only. **Did:** also routed the
  file's existing `turnEnded` helper through the new `readyPhases` predicate. **Why:** `turnEnded`
  already inlined the identical `kind === "phase" && phase === "ready"` filter, so leaving it would
  have put two copies of one predicate in the file; the rewrite is `readyPhases(events).length >= 2`,
  provably the same boolean, and no case's behaviour moves. **Disposition:** stated here.
