### PR TITLE
fix: Epic lane can't find its own tail PR when the PR body has Closes lines

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -410,9 +410,7 @@ things, none of them a summary you compose:
   The epic's is what makes the PR findable at all — `lane brief` resolves the tail's PR through the
   same nominator `lane prove` uses (GitHub's closing-issue edge unioned with a body search), and a
   body naming the epic on neither refuses every tail dispatch with exit
-  `20`. Either kind of reference makes it findable: the nominator reads closing keywords and
-  `Part of` together, so an epic that must outlive its own tail merge may carry `Part of #<epic>`
-  instead and still be traced. The children's are what make all of them close at the single merge, which is how the epic's
+  `20`. The children's are what make all of them close at the single merge, which is how the epic's
   own auto-close reads under this shape — the epic closes when every child is closed, and that fires
   on the GitHub edge after the merge, never mid-lane. **The epic's own reference must CLOSE it, not
   say `Part of`** — a tail that merges without closing its epic folds this lane to `shipped` and then

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -410,7 +410,9 @@ things, none of them a summary you compose:
   The epic's is what makes the PR findable at all — `lane brief` resolves the tail's PR through the
   same nominator `lane prove` uses (GitHub's closing-issue edge unioned with a body search), and a
   body naming the epic on neither refuses every tail dispatch with exit
-  `20`. The children's are what make all of them close at the single merge, which is how the epic's
+  `20`. Either kind of reference makes it findable: the nominator reads closing keywords and
+  `Part of` together, so an epic that must outlive its own tail merge may carry `Part of #<epic>`
+  instead and still be traced. The children's are what make all of them close at the single merge, which is how the epic's
   own auto-close reads under this shape — the epic closes when every child is closed, and that fires
   on the GitHub edge after the merge, never mid-lane. **The epic's own reference must CLOSE it, not
   say `Part of`** — a tail that merges without closing its epic folds this lane to `shipped` and then

--- a/packages/fabrika-cli/src/lane/assembly-body.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/assembly-body.unit.test.ts
@@ -53,9 +53,9 @@ describe("tailBodyRead", () => {
 		expect(read._tag === "Unclosing" && read.read).toContain("#4301, #4302");
 	});
 
-	// The shape `provenClosure` calls out by name: a body carrying both kinds drops every `Part of`
-	// number, so the epic is in neither set and the merge answers `unknown` — no `partial` recorded,
-	// and the tail folds to `shipped` over an open epic.
+	// The shape `provenClosure` calls out by name: a body carrying both kinds reaches the judgement
+	// over the epic it named with `Part of`, and that merge proves only `partial` — so relaying it
+	// would fold the tail to `shipped` over an epic the board still calls open.
 	it("refuses a body mixing the children's closings with a `Part of` on the epic", () => {
 		expect(tailBodyRead(`${CHILDREN}Part of #${EPIC}\n`, EPIC)._tag).toBe("Unclosing");
 	});

--- a/packages/fabrika-cli/src/lane/assembly-body.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/assembly-body.unit.test.ts
@@ -19,6 +19,7 @@ const merged = (body: string) => {
 			merged: true,
 			linkedIssues: refs.numbers,
 			linkKind: refs.kind,
+			referencedIssues: refs.referenced,
 		},
 	]);
 };

--- a/packages/fabrika-cli/src/lane/closure.ts
+++ b/packages/fabrika-cli/src/lane/closure.ts
@@ -72,6 +72,7 @@ export const closureReader = (
 					merged: pull.value.merged,
 					linkedIssues: refs.numbers,
 					linkKind: refs.kind,
+					referencedIssues: refs.referenced,
 				},
 			]);
 		});

--- a/packages/fabrika-cli/src/lane/nominate.ts
+++ b/packages/fabrika-cli/src/lane/nominate.ts
@@ -21,6 +21,11 @@
  * builds the field off the single PR a recorded ship line names, because a merged `Part of #N` is
  * invisible to both reads above and that is the case the read exists for.
  *
+ * The numbers ride in two sets, and the difference only shows on a body carrying both kinds — an
+ * epic tail's. `referencedIssues` is every number either kind names and is what `tracePulls` traces;
+ * `linkedIssues` is the winning kind's alone and is what the closure reads test against `linkKind`.
+ * One set for both questions is what left a finished epic run with no PR the nominator could find.
+ *
  * **Why it is shared rather than copied.** `lane prove` unioned both reads while `lane brief` read
  * the edge alone, so a `Part of #N` PR proved a `DONE`, folded the lane to `review`, and then had no
  * reviewer dispatchable against it — a park no event could clear, because the divergence was a
@@ -90,6 +95,7 @@ export const nominatePulls = (
 				merged: pull.value.merged,
 				linkedIssues: refs.numbers,
 				linkKind: refs.kind,
+				referencedIssues: refs.referenced,
 				htmlUrl: pull.value.htmlUrl,
 			});
 		}

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -318,17 +318,26 @@ export interface PullFact {
 	 */
 	readonly merged: boolean;
 	/**
-	 * **Every** issue the body links, through the closing keywords or `Part of` — never the search
-	 * term. Plural because an epic tail links one issue per landed child plus the epic itself, and a
-	 * scalar field there can only ever report one of them.
+	 * The issues the body links through its *winning* reference kind — never the search term. Plural
+	 * because an epic tail links one issue per landed child, and a scalar field there can only ever
+	 * report one of them. Narrower than {@link PullFact.referencedIssues} on one body shape alone:
+	 * one carrying both kinds, where this holds the closing numbers and drops the `Part of` ones.
 	 */
 	readonly linkedIssues: ReadonlyArray<number>;
 	/**
 	 * Which kind of reference {@link linkedIssues} came off — a closing keyword, or the explicit
-	 * non-closing `Part of #N`. Only the closing kind discharges the issue on merge, so it is the one
-	 * fact that tells a ship's `DONE` whether the lane it folds is finished.
+	 * non-closing `Part of #N`. Only the closing kind discharges an issue on merge, so the pair
+	 * answers that per issue: closing kind *and* membership in {@link linkedIssues}. Read alone it
+	 * is a body-wide fact, and an epic tail's body closes its children while sparing its epic.
 	 */
 	readonly linkKind: IssueRefs["kind"];
+	/**
+	 * **Every** issue the body names, closing references and `Part of` together — the set that says
+	 * what a PR is *about*, which is the nomination question rather than the closure one. An epic
+	 * tail is about its epic through a `Part of` its closing children push out of
+	 * {@link linkedIssues}, so tracing on that field left a finished epic run with no PR at all.
+	 */
+	readonly referencedIssues: ReadonlyArray<number>;
 }
 
 export type PullTrace =
@@ -355,7 +364,7 @@ export const tracePulls = (
 	const counts = (fact: PullFact): boolean =>
 		fact.open || (scope === "open-or-merged" && fact.merged);
 	const live = facts.filter(counts);
-	const matched = live.filter((fact) => fact.linkedIssues.includes(issue));
+	const matched = live.filter((fact) => fact.referencedIssues.includes(issue));
 	const first = matched[0];
 	const noun = scope === "open" ? "open PR" : "open or merged PR";
 	if (first === undefined) {
@@ -392,16 +401,22 @@ export type Closure =
 	| {readonly _tag: "Partial"; readonly prs: ReadonlyArray<number>};
 
 /**
- * The merged pull requests whose body links this issue — the evidence every closure judgement rests
- * on, named once so a second reader cannot drift from what {@link traceClosure} counts as landed.
+ * The merged pull requests whose body names this issue at all — the evidence every closure judgement
+ * rests on, named once so a second reader cannot drift from what {@link traceClosure} counts as
+ * landed. Membership is the wide set on purpose: a merge that named the issue and did not close it
+ * is the `Partial` these reads exist to catch, and the narrow set cannot see it on an epic tail.
  */
 export const landedFor = (issue: number, facts: ReadonlyArray<PullFact>): ReadonlyArray<PullFact> =>
-	facts.filter((fact) => fact.merged && fact.linkedIssues.includes(issue));
+	facts.filter((fact) => fact.merged && fact.referencedIssues.includes(issue));
+
+/** Whether this merge discharges *this* issue — {@link PullFact.linkKind} alone is body-wide. */
+const closesIssue = (issue: number, fact: PullFact): boolean =>
+	fact.linkKind === "fixes" && fact.linkedIssues.includes(issue);
 
 export const traceClosure = (issue: number, facts: ReadonlyArray<PullFact>): Closure => {
 	const landed = landedFor(issue, facts);
 	if (landed.length === 0) return {_tag: "Closes", why: `no merged PR's body links #${issue}`};
-	const closing = landed.filter((fact) => fact.linkKind === "fixes");
+	const closing = landed.filter((fact) => closesIssue(issue, fact));
 	return closing.length > 0
 		? {
 				_tag: "Closes",

--- a/packages/fabrika-cli/src/lane/prove.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove.unit.test.ts
@@ -336,10 +336,29 @@ describe("tracePulls", () => {
 		merged: false,
 		linkedIssues: [4312],
 		linkKind: "fixes" as const,
+		referencedIssues: [4312],
 	};
 
 	it("traces the one open PR whose body links the issue", () => {
 		expect(tracePulls(4312, [linking])).toEqual({_tag: "One", pr: 4318});
+	});
+
+	/**
+	 * An epic tail carries a closing reference per landed child and `Part of #<epic>`, so the epic is
+	 * in `referencedIssues` and out of `linkedIssues`. Tracing the narrow set refused every tail
+	 * dispatch of a finished run at exit 20.
+	 */
+	it("proves the epic tail against an epic its body names with `Part of`", () => {
+		const tail = {
+			number: 7861,
+			open: true,
+			merged: false,
+			linkedIssues: [6642, 6643, 6648, 6629, 6630, 6631],
+			linkKind: "fixes" as const,
+			referencedIssues: [6642, 6643, 6648, 6629, 6630, 6631, 7497],
+		};
+		expect(tracePulls(7497, [tail])).toEqual({_tag: "One", pr: 7861});
+		expect(tracePulls(6642, [tail])).toEqual({_tag: "One", pr: 7861});
 	});
 
 	/**
@@ -354,6 +373,7 @@ describe("tracePulls", () => {
 			merged: false,
 			linkedIssues: [6642, 6643, 6648, 6629],
 			linkKind: "fixes" as const,
+			referencedIssues: [6642, 6643, 6648, 6629],
 		};
 		expect(tracePulls(6629, [tail])).toEqual({_tag: "One", pr: 6690});
 		expect(tracePulls(6642, [tail])).toEqual({_tag: "One", pr: 6690});
@@ -362,7 +382,14 @@ describe("tracePulls", () => {
 	it("does not count a PR that only mentions the number, or one that has closed", () => {
 		expect(
 			tracePulls(4312, [
-				{number: 4400, open: true, merged: false, linkedIssues: [], linkKind: "none" as const},
+				{
+					number: 4400,
+					open: true,
+					merged: false,
+					linkedIssues: [],
+					linkKind: "none" as const,
+					referencedIssues: [],
+				},
 			]),
 		).toMatchObject({
 			_tag: "None",
@@ -384,7 +411,14 @@ describe("tracePulls", () => {
 	it("keeps several linking PRs as their own answer rather than picking the first", () => {
 		const trace = tracePulls(4312, [
 			linking,
-			{number: 4319, open: true, merged: false, linkedIssues: [4312], linkKind: "fixes" as const},
+			{
+				number: 4319,
+				open: true,
+				merged: false,
+				linkedIssues: [4312],
+				linkKind: "fixes" as const,
+				referencedIssues: [4312],
+			},
 		]);
 		expect(trace).toEqual({_tag: "Many", prs: [4318, 4319]});
 	});
@@ -392,7 +426,14 @@ describe("tracePulls", () => {
 	it("tells a candidate that was read and discarded from one that was never nominated", () => {
 		const nothing = tracePulls(4312, []);
 		const read = tracePulls(4312, [
-			{number: 4400, open: true, merged: false, linkedIssues: [4000], linkKind: "fixes" as const},
+			{
+				number: 4400,
+				open: true,
+				merged: false,
+				linkedIssues: [4000],
+				linkKind: "fixes" as const,
+				referencedIssues: [4000],
+			},
 		]);
 		const closed = tracePulls(4312, [{...linking, open: false}]);
 		expect(nothing).toEqual({_tag: "None", why: "no open PR links #4312"});
@@ -411,6 +452,7 @@ describe("traceClosure", () => {
 		merged: true,
 		linkedIssues: [6980],
 		linkKind,
+		referencedIssues: [6980],
 	});
 
 	it("reads a closing merge as the discharge it is", () => {
@@ -425,11 +467,33 @@ describe("traceClosure", () => {
 		expect(traceClosure(6980, [merged("part-of")])).toEqual({_tag: "Partial", prs: [7328]});
 	});
 
+	/**
+	 * The permissive-fold regression, on the one body that carries both kinds. Widening
+	 * `linkedIssues` into the union would land the tail in `landedFor(<epic>)` carrying `fixes` and
+	 * report the epic closed — so the closing test is per issue, and the epic keeps the `Partial`
+	 * its `Part of` says.
+	 */
+	it("reads an epic tail as closing its children and leaving the epic open", () => {
+		const tail = {
+			number: 7861,
+			open: false,
+			merged: true,
+			linkedIssues: [6642, 6643],
+			linkKind: "fixes" as const,
+			referencedIssues: [6642, 6643, 7497],
+		};
+		expect(traceClosure(7497, [tail])).toEqual({_tag: "Partial", prs: [7861]});
+		expect(traceClosure(6642, [tail])).toEqual({
+			_tag: "Closes",
+			why: "#7861 closes #6642 on merge",
+		});
+	});
+
 	// Only positive evidence diverts, so every reading short of one answers what the machine already
 	// did — an unread board never reaches here, because the nominator refuses first.
 	it("answers Closes on an open PR, a merge linking elsewhere, and nothing nominated", () => {
 		const open = {...merged("part-of"), open: true, merged: false};
-		const elsewhere = {...merged("part-of"), linkedIssues: [6979]};
+		const elsewhere = {...merged("part-of"), linkedIssues: [6979], referencedIssues: [6979]};
 
 		expect(traceClosure(6980, [open])._tag).toBe("Closes");
 		expect(traceClosure(6980, [elsewhere])._tag).toBe("Closes");

--- a/packages/fabrika-cli/src/lane/reconcile.ts
+++ b/packages/fabrika-cli/src/lane/reconcile.ts
@@ -166,8 +166,12 @@ export type ClosureRead =
  * nothing would be the justification for leaving alone exactly the lane this sweep exists to catch —
  * and that empty answer is the common case, not the rare one. The PR-less fallback lands on it by
  * construction, a merged `Part of #N` being invisible to both nomination reads; so does a named PR
- * that is not merged; so does one whose body carries both link kinds, since `issueRefsOf` drops
- * every `Part of` number when it does.
+ * that is not merged.
+ *
+ * A body carrying both link kinds does not land there and must not: `landedFor` reads
+ * `referencedIssues`, so an epic tail reaches this judgement over its epic, and `traceClosure` tests
+ * the closing kind per issue rather than body-wide — the tail closes its children and answers
+ * `Partial` for the epic it named with `Part of`. Reading it as `Closes` is the permissive fold.
  *
  * So the absence of a closure proof is `Unknown`, and only a merged pull request that really links
  * this issue reaches the judgement. Both verbs land on it: `lane prove`'s ship stage reaches

--- a/packages/fabrika-cli/src/lane/reconcile.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/reconcile.unit.test.ts
@@ -180,6 +180,7 @@ describe("provenClosure", () => {
 		merged: true,
 		linkedIssues: [6980],
 		linkKind: "part-of",
+		referencedIssues: over.linkedIssues ?? [6980],
 		...over,
 	});
 
@@ -212,6 +213,25 @@ describe("provenClosure", () => {
 	it("reads a body whose `fixes` refs drop this lane's issue as unknown", () => {
 		expect(provenClosure(6980, [fact({linkKind: "fixes", linkedIssues: [7000]})])).toMatchObject({
 			_tag: "Unknown",
+		});
+	});
+
+	/**
+	 * The permissive fold on an epic tail: its closing children push the epic out of `linkedIssues`,
+	 * so a reader keyed on that field alone reports the merge closed the epic it was written to
+	 * spare.
+	 */
+	it("proves an epic tail's merge partial over the epic it names with `Part of`", () => {
+		const tail = fact({
+			number: 7861,
+			linkKind: "fixes",
+			linkedIssues: [6642, 6643],
+			referencedIssues: [6642, 6643, 6980],
+		});
+		expect(provenClosure(6980, [tail])).toEqual({
+			_tag: "Read",
+			closure: {_tag: "Partial", prs: [7861]},
+			landed: [7861],
 		});
 	});
 });

--- a/packages/fabrika-cli/src/lane/settle-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/settle-verb.unit.test.ts
@@ -65,6 +65,7 @@ const pull = (over: Partial<NominatedPull> = {}): NominatedPull => ({
 	merged: true,
 	linkedIssues: [ISSUE],
 	linkKind: "fixes",
+	referencedIssues: over.linkedIssues ?? [ISSUE],
 	htmlUrl: "https://example.test/o/r/pull/6874",
 	...over,
 });

--- a/packages/fabrika-cli/src/lane/settle.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/settle.unit.test.ts
@@ -16,6 +16,7 @@ const fact = (over: Partial<PullFact> = {}): PullFact => ({
 	merged: true,
 	linkedIssues: [ISSUE],
 	linkKind: "fixes",
+	referencedIssues: over.linkedIssues ?? [ISSUE],
 	...over,
 });
 

--- a/packages/fabrika-cli/src/review/classes.ts
+++ b/packages/fabrika-cli/src/review/classes.ts
@@ -271,25 +271,45 @@ export const issueRefOf = (body: string): IssueRef => {
 
 export interface IssueRefs {
 	readonly kind: "fixes" | "part-of" | "none";
+	/**
+	 * The issues of the winning kind alone — the closing ones where the body has any, else the
+	 * `Part of` ones. Read beside {@link IssueRefs.kind}, which says which set this is, so a caller
+	 * asking "does this body discharge #N on merge" tests membership here and nowhere else.
+	 */
 	readonly numbers: ReadonlyArray<number>;
+	/**
+	 * **Every** issue the body names either way, closing and `Part of` together, deduplicated.
+	 *
+	 * The set a nominator asks for: "is this PR about #N" is a wider question than "does merging it
+	 * close #N", and only this field can answer it of an epic tail, whose body carries one closing
+	 * reference per landed child plus `Part of #<epic>` so the merge leaves the epic open.
+	 * {@link IssueRefs.numbers} drops that `Part of` by precedence, which stranded a complete epic
+	 * run at exit `20` with no candidate linking the epic.
+	 */
+	readonly referenced: ReadonlyArray<number>;
 }
 
 /**
- * The plural sibling of {@link issueRefOf}: every issue of the winning kind, not the first.
+ * The plural sibling of {@link issueRefOf}: every issue of the winning kind, not the first — plus
+ * {@link IssueRefs.referenced}, every issue of either kind.
  *
- * Same precedence — closing beats `Part of`, and a body carrying both is a `fixes` body — so a
- * caller trading the scalar for this one changes only how many references it can see.
+ * `kind` and `numbers` keep the scalar's precedence: closing beats `Part of`, and a body carrying
+ * both is a `fixes` body whose `numbers` are the closing ones. That is load-bearing for closure —
+ * folding the `Part of` numbers in would make an epic tail's merge read as closing the epic it was
+ * written not to close. So the wider set arrives beside them rather than inside them, and the two
+ * reads take the field that answers their own question.
  */
 export const issueRefsOf = (body: string): IssueRefs => {
-	const closing = linkedIssuesOf(body);
-	if (closing.length > 0) return {kind: "fixes", numbers: closing};
 	const all = new RegExp(PART_OF.source, "gi");
 	const parts = [...body.matchAll(all)].flatMap((match) =>
 		match[1] === undefined ? [] : [Number.parseInt(match[1], 10)],
 	);
+	const closing = linkedIssuesOf(body);
+	const referenced = [...new Set([...closing, ...parts])];
+	if (closing.length > 0) return {kind: "fixes", numbers: closing, referenced};
 	return parts.length === 0
-		? {kind: "none", numbers: []}
-		: {kind: "part-of", numbers: [...new Set(parts)]};
+		? {kind: "none", numbers: [], referenced}
+		: {kind: "part-of", numbers: [...new Set(parts)], referenced};
 };
 
 /** `fixes:<n>` / `part-of:<n>`, or the calling group's null token. */

--- a/packages/fabrika-cli/src/review/classes.unit.test.ts
+++ b/packages/fabrika-cli/src/review/classes.unit.test.ts
@@ -239,12 +239,38 @@ describe("issueRefsOf", () => {
 		expect(issueRefsOf("Closes #6642. Closes #6629.\n\nPart of #6000")).toEqual({
 			kind: "fixes",
 			numbers: [6642, 6629],
+			referenced: [6642, 6629, 6000],
 		});
 		expect(issueRefsOf("does things\n\nPart of #5434\nPart of #5437\n")).toEqual({
 			kind: "part-of",
 			numbers: [5434, 5437],
+			referenced: [5434, 5437],
 		});
-		expect(issueRefsOf("see #4000")).toEqual({kind: "none", numbers: []});
+		expect(issueRefsOf("see #4000")).toEqual({kind: "none", numbers: [], referenced: []});
+	});
+
+	/**
+	 * The epic tail's body, which the precedence alone cannot represent: `numbers` is the six closing
+	 * children, and the epic reaches a nominator only through `referenced`.
+	 */
+	it("names every issue of either kind in `referenced`, deduplicated", () => {
+		const tail = [
+			"## About this epic",
+			"Closes #6642",
+			"Closes #6643",
+			"Closes #6648",
+			"Part of #7497",
+		].join("\n\n");
+		expect(issueRefsOf(tail)).toEqual({
+			kind: "fixes",
+			numbers: [6642, 6643, 6648],
+			referenced: [6642, 6643, 6648, 7497],
+		});
+		expect(issueRefsOf("Closes #12\nPart of #12")).toEqual({
+			kind: "fixes",
+			numbers: [12],
+			referenced: [12],
+		});
 	});
 
 	it("answers the scalar reader's kind and first number on every single-reference body", () => {


### PR DESCRIPTION
The nominator asked one question of a PR body and got the closure answer back. `issueRefsOf` ranked
closing references over `Part of #N`, so an epic tail body — one `Closes` per landed child plus
`Part of #<epic>` so the merge leaves the epic open — reported the children and dropped the epic.
`tracePulls` then found no candidate linking the epic, and `lane brief <epic> --task epic_<n>`
refused at exit `20` with a whole finished run behind it.

The two reads want different sets, so they get different sets.

- `IssueRefs` gains `referenced`: every number either kind names, deduplicated. `numbers` and `kind`
  are untouched, and the six callers outside `lane/nominate.ts` still read exactly what they read
  before.
- `PullFact` gains `referencedIssues` beside `linkedIssues`. `tracePulls` and `landedFor` trace the
  wide set; `linkedIssues` stays the winning kind's.
- `traceClosure` asks whether a merge closes *this* issue — closing kind **and** membership in
  `linkedIssues` — rather than reading `linkKind` as a body-wide fact. So the tail closes its
  children and answers `Partial` for the epic, which is the permissive fold this had to avoid: had
  `numbers` simply been widened, the tail would have entered `landedFor(<epic>)` carrying `fixes`
  and reported the epic closed.

`provenClosure` now reaches a real judgement over an epic tail instead of falling through to
`Unknown`, and `reconcile.ts`'s docblock — which cited the old drop as load-bearing — says so.

Tests pin both halves: the both-kinds body in `classes.unit.test.ts`, the `One` trace and the
`Partial` closure in `prove.unit.test.ts`, and the proven-partial read in `reconcile.unit.test.ts`.

`operate`'s tail-PR shape is `main`'s and stays `main`'s. This branch is rebased onto `main`, and
the earlier round's sentence — that an epic tail may name its epic with `Part of` and still be
traced — is gone: ADR 0382 refuses that body at `lane assembly-body` exit `58`. Tracing a `Part of`
reference is not sanctioning writing one, so the nominator half stands and the prose half is
`main`'s unchanged paragraph.

Fixes #7940

## Deviations

- **Pre-existing test or fixture changed** — **Said:** the issue names
  `packages/fabrika-cli/src/review/classes.unit.test.ts` as the test surface. **Did:** also touched
  the `PullFact` fixtures in `prove.unit.test.ts`, `reconcile.unit.test.ts`, `settle.unit.test.ts`,
  `settle-verb.unit.test.ts` and — after the rebase — `assembly-body.unit.test.ts`, which `main`
  added while this branch was open. **Why:** `referencedIssues` is a required field, so every
  fixture constructing a `PullFact` had to fill it; no assertion changed except where the old
  fixture would have made a body reference an issue its `linkedIssues` never named. The
  `assembly-body` fixture fills it off `issueRefsOf(body).referenced`, the same source it already
  reads `numbers` and `kind` from. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the issue lists `prove.ts` and `reconcile.ts` as the
  closure surfaces. **Did:** left `mergedLinking` in `lane/settle.ts` reading the narrow
  `linkedIssues`, so an epic tail is still invisible to the `Landed` entitlement for its epic.
  **Why:** it is a different verb's gate, outside this issue's named surfaces, and widening an
  entitlement deserves its own review. **Disposition:** filed as a follow-up issue (#8997).
