### PR TITLE
fix: build branch cuts an epic child's branch from main, not from the epic assembly branch

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -222,6 +222,13 @@ surfaces at all — walk all six and land every one in this PR.
 fabrika build branch $issue_or_pr_number --slug editor-focus-loss --token <claim-token>
 ```
 
+**The base is the verb's to pick, and that line is complete without one.** It reads the issue's own
+parent and cuts an epic child off the run's assembly branch `epic/<parent>`, a proven-standalone
+issue off `origin/main`, and refuses rather than guessing when either read fails — so never hand it
+`--base` to "make sure" a child lands on the epic branch. It says which base it used and where that
+came from on stderr; read that line instead of re-deriving it. Pass `--base` only when you mean a
+ref the derivation would not pick, and expect it to be honoured verbatim.
+
 Construct. Match the surrounding artifact's idiom; for code: domain logic in domain objects,
 invalid states unrepresentable. Before the first `build branch` cut, re-run
 `fabrika build tree --require-clean`; after that cut, re-run `fabrika build tree --issue

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1463,7 +1463,7 @@ fabrika build branch 9 --resume-lane --token <token>
 |---|---|---|---|---|
 | `<number>` | positional integer | yes (create mode) | — | the claimed issue the branch serves |
 | `--slug` | string | yes (create mode) | — | kebab-case, ≤5 words, must not begin with `-` |
-| `--base` | string | no | `origin/main` | the base ref, **fetched before the branch is cut** |
+| `--base` | string | no | *derived* | the base ref, **fetched before the branch is cut**, honoured verbatim on every lane. Absent, create mode derives it — see below |
 | `--resume` | integer | exclusive with the positional | — | a PR number whose head branch to switch to, for repair |
 | `--resume-lane` | boolean | no | `false` | child-repair mode: take over the local branch a prior lane built `<number>` on. Exclusive with `--resume` and with `--slug` |
 | `--token` | string | yes | — | the token `build claim` handed this lane — which lane is asking. Not a claim token, or one carrying another session id, is `1` |
@@ -1484,12 +1484,46 @@ find the lane — the branch name is the record, and there is no
 stamp file to duplicate or go stale (the stamp machinery is the accretion the 2026-08-03
 amendment measured, and it is not rebuilt).
 
-Create mode: fetch `--base`, cut `build/<number>-<slug>-<nonce>` off `FETCH_HEAD` (never a stale
+Create mode: fetch the base, cut `build/<number>-<slug>-<nonce>` off `FETCH_HEAD` (never a stale
 local ref), switch to it. Resume mode: resolve the PR's current head branch, fetch it, and check
 it out under the **local** lane name `build/pr-<pr>-<nonce>` with its upstream set to the remote
 head branch — `build push` publishes via that tracked upstream, so the PR updates while the local
 name carries the *current* repair claim's nonce. Each repair run gets its own local branch, so a
 dead earlier lane can never pin this one. A closed or merged PR refuses (`7`).
+
+**Create mode derives the base; it does not default to the trunk.** `build branch` used to fetch
+whatever `--base` said and cut there, with `origin/main` as the flag's own default — and the skill's
+canonical invocation carries no `--base`, so an epic child landed on the trunk unless its builder
+thought to pass one. That is a silent wrong base: the child's commits sit on code the assembly
+branch does not have, `lane prove` resolves a fork point that is not on the branch, and it surfaces
+at integrate as a conflict or as a clean merge that drops a sibling's work. It cost one epic child a
+whole lane: the trunk lacked the routing fix that child depended on and still carried a commit the
+epic branch had reverted, and the range resolved only because the builder noticed and reset by hand.
+
+So with no `--base`, create mode reads `<number>`'s parent through GitHub's own issue-parent
+endpoint and derives from it. Both endpoints are derived, never taken from the caller, the way
+`readAssembly` derives them: the parent from that endpoint, the branch name from the parent number
+through `epicBranch`. A **`Present`** parent gives the assembly branch `epic/<parent>` —
+`origin/epic/<parent>` when origin carries it, the bare local name when only this clone does, and
+either spelling goes through the same `fetchBase`, so a stale local `epic/<n>` is never the cut. A
+parent **proven `Absent`** (the endpoint's own 404) leaves a standalone lane exactly as it stood:
+`origin/main`, with no epic base invented from a signal nobody read.
+
+Both halves of the ruling are refusals, and they are split on evidence. A parent read that **failed**
+is `11` naming the read — never a fall back to `origin/main`, because that fallback is the defect. A
+derived assembly branch **proven** absent from both origin and this clone is `7` naming the branch it
+derived; a ref read that **failed** is `11`. Nothing fuses the two, per the proven-vs-UNKNOWN split
+`packages/fabrika-cli/src/build/codes.ts` states.
+
+An explicit `--base` is honoured verbatim on every lane, epic child included, and suppresses the
+derivation — the parent is not even read. That is why the flag lost its `origin/main` default:
+"the operator named the trunk" and "nobody passed one" were the same value, and only one of them
+should skip the derivation.
+
+Every run says which base it used and where it came from, on stderr beside the claim's own notes —
+`base <ref> — derived from #<n>'s parent epic #<p>`, `— named by the operator with --base`, or
+`— #<n> is proven standalone`. A builder reading the transcript tells the three apart without
+re-deriving anything.
 
 **Child-repair mode (`--resume-lane`) — resume for the artifact that has no PR to resume.** An epic
 child opens none, so `--resume` has nothing to take, and a fresh cut off the assembly
@@ -1521,9 +1555,9 @@ number, which is the number repair mode claims.
 
 | Code | Trigger |
 |---|---|
-| `7` | `--resume`'s PR is proven absent, closed, or merged; or `--resume-lane` found no branch anywhere in this clone's refs cut for `<number>` |
+| `7` | `--resume`'s PR is proven absent, closed, or merged; `--resume-lane` found no branch anywhere in this clone's refs cut for `<number>`; or the derived assembly branch `epic/<parent>` is proven absent from both origin and this clone |
 | `10` | `--slug` is not kebab-case, exceeds 5 words, or is flag-shaped; or `--resume-lane` was given beside `--resume` or `--slug` |
-| `11` | the fetch failed, the claim state could not be read, or `--resume-lane` could not read this clone's branches or its worktrees, found several candidates, proved another worktree holds the branch, or could not re-key or check out the one it found |
+| `11` | the fetch failed, the claim state could not be read, the parent read or the assembly-branch read failed so which base this lane belongs on is UNKNOWN, or `--resume-lane` could not read this clone's branches or its worktrees, found several candidates, proved another worktree holds the branch, or could not re-key or check out the one it found |
 | `15` | proven: the claim on `<number>` is foreign |
 
 **Errors**
@@ -1532,6 +1566,9 @@ number, which is the number repair mode claims.
 |---|---|---|
 | `build branch: --slug "<value>" is not kebab-case (lowercase letters, digits, single hyphens, ≤5 words).` | 10 | refusal |
 | `build branch: cannot fetch <ref>: <reason> — refusing to cut a branch off a stale base.` | 11 | refusal |
+| `build branch: cannot read #<n>'s parent through GitHub's issue-parent endpoint: <reason> — whether this is an epic child is UNKNOWN, and cutting off origin/main anyway is exactly the silent wrong base this derivation exists to remove. No branch was cut; pass --base to name one yourself.` | 11 | refusal |
+| `build branch: #<n> is a child of epic #<p>, and whether origin carries its assembly branch epic/<p> could not be read: <reason> — which base this child belongs on is UNKNOWN. Nothing was cut.` | 11 | refusal |
+| `build branch: #<n> is a child of epic #<p>, whose assembly branch epic/<p> is proven absent — origin holds no refs/heads/epic/<p> and neither does this clone. Place the run's branch with "fabrika lane assembly <p>" before building a child on it. Nothing was cut.` | 7 | refusal |
 | `build branch: PR #<n> is proven closed or merged — nothing to resume.` | 7 | refusal |
 | `build branch: --resume-lane takes over the local branch of an epic child, which has no PR — it cannot be combined with --resume <pr>.` | 10 | refusal |
 | `build branch: --resume-lane reads the slug off the branch it takes over — drop --slug "<value>".` | 10 | refusal |
@@ -1549,7 +1586,21 @@ number, which is the number repair mode claims.
 
 ```
 $ fabrika build branch 4 --slug editor-focus-loss --token <token>
+build branch: base origin/main — #4 is proven standalone (its parent endpoint answered 404), so no epic base was derived.
 build/4-editor-focus-loss-c1a4d6f8
+```
+
+```
+$ fabrika build branch 9 --slug prove-requires-review-ui --token <token>
+build branch: base origin/epic/5 — derived from #9's parent epic #5; --base was not given.
+build/9-prove-requires-review-ui-99345500
+```
+
+```
+$ fabrika build branch 9 --slug prove-requires-review-ui --token <token>
+build branch: #9 is a child of epic #5, whose assembly branch epic/5 is proven absent — origin holds no refs/heads/epic/5 and neither does this clone. Place the run's branch with "fabrika lane assembly 5" before building a child on it. Nothing was cut.
+$ echo $?
+7
 ```
 
 ```
@@ -1563,6 +1614,8 @@ $ echo $?
 
 - Branch off `FETCH_HEAD` after a real fetch; a stale local `origin/main` is the recurring wrong
   base.
+- The verb derives an epic child's base rather than trusting prose to make a builder pass it — a
+  guard made of prose fails exactly where a builder does not follow prose.
 - A slug that looks like a flag is refused, so a slug can never be read as an option.
 - Eight trees once shared one stamp file: identity via per-claim nonce makes duplicate lanes
   unconstructible instead of detected.

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -95,7 +95,7 @@ Contract: [`skills/build/contract.md`](../../../claude-plugins/fabrika/skills/bu
 | `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, explicitly select a repair PR's served issue, re-prove it, retract it, or take a dead session's |
 | `build claimants` | who holds an issue's claim, read by a caller holding none — no token, no write, no clearance |
 | `build issue` | the claimed issue's body and its criteria — `found` / `absent` / `malformed`, all on exit 0 |
-| `build branch` / `scratch` | the lane's branch off a fresh base, and its scratch directory |
+| `build branch` / `scratch` | the lane's branch off a fresh base it derives — `epic/<parent>` for an epic child, `origin/main` for a proven-standalone issue — and its scratch directory |
 | `build resume-child` | an epic child's standing-`FAIL` repair lane, opened as one operation: claim, confirm, clean tree, resumed branch, armed proof |
 | `build commit` / `push` | the commit whose message is proven this lane's, and the push whose ref is proven moved |
 | `build check` | this surface's validators plus every shipped local-tree guard, run in this tree — each guard named in `ran`, or in `skipped` when it refused |

--- a/packages/fabrika-cli/src/build/branch-verb.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.ts
@@ -3,7 +3,10 @@
  *
  * The lane-identity rule lives in `lane.ts`; this verb is where a name that obeys it first comes into
  * existence. Create mode cuts `build/<number>-<slug>-<nonce>` off `FETCH_HEAD` — never a local
- * `origin/main`, which can predate the base the lane needs. Resume mode checks the
+ * `origin/main`, which can predate the base the lane needs. **Which base that is, create mode
+ * derives**: an epic child is cut off its run's assembly branch `epic/<parent>` and a standalone
+ * issue off the trunk, with an explicit `--base` honoured verbatim over either — see
+ * {@link resolveBase} for the silent wrong base that derivation removes. Resume mode checks the
  * PR's head branch out under the **local** name `build/pr-<pr>-<nonce>` with its upstream pointed at
  * the remote head, so `build push` updates the PR while the local name carries *this* repair claim's
  * nonce — which is what stops a dead earlier lane from pinning this one.
@@ -21,19 +24,21 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {localBranches} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {epicBranch} from "../wire/lane-brief.ts";
 import {requireCallerToken, requireClaim, requireSession} from "./claim.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {
 	branchExists,
 	currentBranch,
 	fetchBase,
+	remoteSha,
 	renameBranch,
 	setUpstream,
 	switchTo,
 	switchToNew,
 	worktreeCheckouts,
 } from "./git.ts";
-import {getPullHead} from "./github.ts";
+import {getParent, getPullHead} from "./github.ts";
 import {
 	childLaneBranches,
 	createBranchName,
@@ -50,7 +55,12 @@ export interface BranchOptions {
 	/** Create mode: the claimed issue the branch serves. `null` in resume mode. */
 	readonly number: number | null;
 	readonly slug: string | null;
-	readonly base: string;
+	/**
+	 * The base ref an operator named, honoured verbatim on every lane. `null` is "nobody passed one",
+	 * which is what lets the create path derive an epic child's assembly base instead — the two used
+	 * to be one value, and `origin/main` was then indistinguishable from a deliberate trunk cut.
+	 */
+	readonly base: string | null;
 	/** Resume mode: the PR whose head branch to publish back to. Exclusive with `number`. */
 	readonly resume: number | null;
 	/**
@@ -66,6 +76,92 @@ export interface BranchOptions {
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
+
+/** The trunk a lane with no parent epic and no operator-named base is cut from. */
+const TRUNK = "origin/main";
+
+type ResolvedBase =
+	| {readonly _tag: "Resolved"; readonly base: string; readonly note: string}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/**
+ * Which base the create path cuts off, and where that answer came from.
+ *
+ * An epic child's commits belong on the run's assembly branch, and the verb derives that itself
+ * rather than trusting a builder to pass `--base epic/<n>` — the omission is silent, and a child cut
+ * off the trunk is graded against a fork point the assembly branch does not contain, which surfaces
+ * at integrate as a conflict or as a clean merge that drops a sibling's work. Both endpoints are
+ * derived the way `readAssembly` derives them: the parent from GitHub's own parent endpoint, the
+ * branch name from that number through {@link epicBranch}.
+ *
+ * Every arm is proven. A parent read that failed refuses rather than falling back to the trunk,
+ * because that fallback IS the silent wrong base. A derived branch that exists nowhere is a proven
+ * `7`, split from the unreadable `11` rather than fused into one message.
+ */
+const resolveBase = (
+	env: Readonly<Record<string, string | undefined>>,
+	repo: string,
+	issue: number,
+	named: string | null,
+): Effect.Effect<
+	ResolvedBase,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient
+> =>
+	Effect.gen(function* () {
+		if (named !== null) {
+			return {
+				_tag: "Resolved" as const,
+				base: named,
+				note: `${VERB}: base ${named} — named by the operator with --base; no epic derivation ran.`,
+			};
+		}
+		const parent = yield* getParent(env, repo, issue);
+		if (parent._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read #${issue}'s parent through GitHub's issue-parent endpoint: ${parent.reason} — whether this is an epic child is UNKNOWN, and cutting off ${TRUNK} anyway is exactly the silent wrong base this derivation exists to remove. No branch was cut; pass --base to name one yourself.`,
+				),
+			};
+		}
+		if (parent._tag === "Absent") {
+			return {
+				_tag: "Resolved" as const,
+				base: TRUNK,
+				note: `${VERB}: base ${TRUNK} — #${issue} is proven standalone (its parent endpoint answered 404), so no epic base was derived.`,
+			};
+		}
+		const assembly = epicBranch(parent.value);
+		const published = yield* remoteSha("origin", assembly);
+		if (published._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: #${issue} is a child of epic #${parent.value}, and whether origin carries its assembly branch ${assembly} could not be read: ${published.reason} — which base this child belongs on is UNKNOWN. Nothing was cut.`,
+				),
+			};
+		}
+		if (published.value === null && !(yield* branchExists(assembly))) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					ZERO_SCOPE,
+					`${VERB}: #${issue} is a child of epic #${parent.value}, whose assembly branch ${assembly} is proven absent — origin holds no refs/heads/${assembly} and neither does this clone. Place the run's branch with "fabrika lane assembly ${parent.value}" before building a child on it. Nothing was cut.`,
+				),
+			};
+		}
+		// The published spelling when origin carries it, the bare local one when only this clone does;
+		// either way `fetchBase` fetches before it resolves, so a stale local `epic/<n>` is never the cut.
+		const base = published.value === null ? assembly : `origin/${assembly}`;
+		return {
+			_tag: "Resolved" as const,
+			base,
+			note: `${VERB}: base ${base} — derived from #${issue}'s parent epic #${parent.value}; --base was not given.`,
+		};
+	});
 
 /** Check the branch out, whether or not it already exists — the idempotent half. */
 const checkout = (name: string, start: string) =>
@@ -270,21 +366,28 @@ export const runBranch = (
 					]);
 		}
 
-		const fetched = yield* fetchBase(options.base);
+		const issue = number as number;
+		const resolvedBase = yield* resolveBase(options.env, repo, issue, options.base);
+		if (resolvedBase._tag === "Refused")
+			return {...resolvedBase.outcome, stderr: [...held.notes, ...resolvedBase.outcome.stderr]};
+		const {base} = resolvedBase;
+		const notes = [...held.notes, resolvedBase.note];
+
+		const fetched = yield* fetchBase(base);
 		if (fetched._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot fetch ${options.base}: ${fetched.reason} — refusing to cut a branch off a stale base.`,
-				held.notes,
+				`${VERB}: cannot fetch ${base}: ${fetched.reason} — refusing to cut a branch off a stale base.`,
+				notes,
 			);
 		}
-		const name = createBranchName(number as number, slug as string, nonce);
+		const name = createBranchName(issue, slug as string, nonce);
 		const switched = yield* checkout(name, fetched.value);
 		return switched._tag === "Failure"
 			? refuse(
 					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot cut ${name} off ${options.base}: ${switched.reason} — nothing was changed.`,
-					held.notes,
+					`${VERB}: cannot cut ${name} off ${base}: ${switched.reason} — nothing was changed.`,
+					notes,
 				)
-			: answer(name, held.notes);
+			: answer(name, notes);
 	});

--- a/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
@@ -35,7 +35,8 @@ const WRITE = served({permission: "write"});
 const options = {
 	number: 4312 as number | null,
 	slug: "editor-focus-loss" as string | null,
-	base: "origin/main",
+	/** Explicit, so a test that is not about the derivation never reaches the parent read. */
+	base: "origin/main" as string | null,
 	resume: null as number | null,
 	resumeLane: false,
 	token: LANE_TOKEN,
@@ -381,5 +382,147 @@ describe("runBranch — --resume-lane", () => {
 		const out = await run([], {resumeLane: true});
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.at(-1)).toContain("reads the slug off the branch it takes over");
+	});
+});
+
+describe("runBranch — create mode derives the base (#6730)", () => {
+	const PARENT = /^GET \S+\/repos\/o\/r\/issues\/4312\/parent$/;
+	const LS_REMOTE = /^git ls-remote origin refs\/heads\/epic\/6505$/;
+	const FETCH_EPIC = /^git fetch --quiet origin epic\/6505$/;
+	const VERIFY_EPIC = /^git rev-parse --verify --quiet refs\/heads\/epic\/6505/;
+	const VERIFY_LANE = /^git rev-parse --verify --quiet refs\/heads\/build\//;
+	const EPIC_TIP = "1c2b3a49f0e1d2c3b4a5968778695a4b3c2d1e0f";
+	/** No `--base`: the whole point is that a builder passing nothing still lands on the right ref. */
+	const derived = {base: null};
+
+	const parented = (): Scripted => [PARENT, served({number: 6505})];
+	const orphan = (): Scripted => [PARENT, {status: 404, body: '{"message":"Not Found"}'}];
+	const published = (): Scripted => [LS_REMOTE, okOut(`${EPIC_TIP}\trefs/heads/epic/6505\n`)];
+
+	it("cuts an epic child off the run's assembly branch, fetched", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			parented(),
+			published(),
+			[REMOTES, okOut("origin\n")],
+			[FETCH_EPIC, okOut("")],
+			[RESOLVE, okOut(`${EPIC_TIP}\n`)],
+			[VERIFY_BRANCH, errOut("")],
+			[SWITCH_NEW, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...derived}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain("git fetch --quiet origin epic/6505");
+		expect(shell.calls).toContain(
+			`git switch -c build/4312-editor-focus-loss-${NONCE} ${EPIC_TIP}`,
+		);
+		expect(out.stderr).toContain(
+			"build branch: base origin/epic/6505 — derived from #4312's parent epic #6505; --base was not given.",
+		);
+	});
+
+	it("cuts a proven-standalone issue off origin/main and invents no epic base", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			orphan(),
+			[REMOTES, okOut("origin\n")],
+			[FETCH, okOut("")],
+			[RESOLVE, okOut(`${HEAD}\n`)],
+			[VERIFY_BRANCH, errOut("")],
+			[SWITCH_NEW, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...derived}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain("git fetch --quiet origin main");
+		expect(shell.calls.some((line) => /epic\//.test(line))).toBe(false);
+		expect(out.stderr).toContain(
+			"build branch: base origin/main — #4312 is proven standalone (its parent endpoint answered 404), so no epic base was derived.",
+		);
+	});
+
+	it("honours an explicit --base on a child, and never reads the parent at all", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			[REMOTES, okOut("origin\n")],
+			[/^git fetch --quiet origin release\/2$/, okOut("")],
+			[RESOLVE, okOut(`${HEAD}\n`)],
+			[VERIFY_BRANCH, errOut("")],
+			[SWITCH_NEW, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, base: "origin/release/2"}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain("git fetch --quiet origin release/2");
+		expect(shell.calls.some((line) => PARENT.test(line))).toBe(false);
+		expect(out.stderr).toContain(
+			"build branch: base origin/release/2 — named by the operator with --base; no epic derivation ran.",
+		);
+	});
+
+	it("refuses an unreadable parent on 11 — never a fall back to origin/main", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			[PARENT, {status: 500, body: '{"message":"upstream is having a moment"}'}],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...derived}), shell.layer),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("whether this is an epic child is UNKNOWN");
+		expect(shell.calls.some((line) => /^git fetch/.test(line))).toBe(false);
+		expect(shell.calls.some((line) => /^git switch/.test(line))).toBe(false);
+	});
+
+	it("refuses a proven-absent assembly branch on 7, naming the branch it derived", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			parented(),
+			[LS_REMOTE, okOut("")],
+			[VERIFY_EPIC, errOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...derived}), shell.layer),
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("assembly branch epic/6505 is proven absent");
+		expect(shell.calls.some((line) => /^git switch/.test(line))).toBe(false);
+	});
+
+	it("refuses an unreadable assembly-branch read on 11, not on 7", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			parented(),
+			[LS_REMOTE, errOut("fatal: could not read from remote repository")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...derived}), shell.layer),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("which base this child belongs on is UNKNOWN");
+		expect(out.stderr.at(-1)).not.toContain("proven absent");
+	});
+
+	it("stays idempotent on a re-run under the same nonce — resolved and switched to, not re-cut", async () => {
+		const shell = fakeSeams([
+			...CLAIMED,
+			parented(),
+			published(),
+			[REMOTES, okOut("origin\n")],
+			[FETCH_EPIC, okOut("")],
+			[RESOLVE, okOut(`${EPIC_TIP}\n`)],
+			[VERIFY_LANE, okOut(`${EPIC_TIP}\n`)],
+			[/^git switch build\//, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...derived}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`build/4312-editor-focus-loss-${NONCE}\n`);
+		expect(shell.calls.some((line) => SWITCH_NEW.test(line))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -348,8 +348,10 @@ const branch = leafCommand(
 			Flag.withDescription("create mode: kebab-case, ≤5 words, must not begin with a hyphen"),
 		),
 		base: Flag.string("base").pipe(
-			Flag.withDefault("origin/main"),
-			Flag.withDescription("the base ref, FETCHED before the branch is cut (default: origin/main)"),
+			Flag.optional,
+			Flag.withDescription(
+				"the base ref, FETCHED before the branch is cut; honoured verbatim on every lane. Omit it and create mode DERIVES the base: epic/<parent> for a child of an epic, origin/main for a proven-standalone issue",
+			),
 		),
 		resume: Flag.integer("resume").pipe(
 			Flag.optional,
@@ -370,7 +372,7 @@ const branch = leafCommand(
 			yield* runBranch({
 				number: Option.getOrNull(number),
 				slug: Option.getOrNull(slug),
-				base,
+				base: Option.getOrNull(base),
 				resume: Option.getOrNull(resume),
 				resumeLane,
 				token,
@@ -382,7 +384,7 @@ const branch = leafCommand(
 ).pipe(
 	Command.withShortDescription("Cut or resume the lane's branch off a freshly fetched base."),
 	Command.withDescription(
-		"Cut (or resume) the lane's nonce branch off a FRESHLY FETCHED base, never a stale local ref. Prints the checked-out branch name: build/<number>-<slug>-<nonce> in create mode, build/pr-<pr>-<nonce> in resume mode, where <nonce> is the first 8 hex of --token's UUID — the token THIS lane holds, proven against the live claim before the name is composed, so a lane cannot cut a branch on a nonce that holds nothing. The branch name IS the lane record — there is no stamp file. --resume-lane is resume mode for an epic child, which opens no PR: it finds the one local branch this grammar says was cut for <number>, RE-KEYS it to this claim's nonce and checks it out, so the child's commits carry forward and exactly one branch keeps naming it — cutting a second is the underivable range lane prove refuses on. It fetches nothing, takes no --slug, and re-keys nothing when the name already matches. Exits 1 (--token is not a claim token of this session), 7 (--resume's PR is proven absent, closed or merged, or --resume-lane found no local branch cut for <number>), 10 (--slug is not kebab-case, exceeds 5 words, or is flag-shaped, or --resume-lane was combined with --resume or --slug), 11 (the fetch failed, the tree root or claim state could not be read, or --resume-lane found several candidate branches or could not re-key the one it found — the prior lane's worktree is likely still on it, which only an operator can release), 15 (proven: the claim is held by another lane). Why the nonce and the re-key are shaped this way is in claude-plugins/fabrika/skills/build/contract.md. Example: fabrika build branch 4312 --slug editor-focus-loss --token build:s-9f2e:c1a4d6f8-…",
+		"Cut (or resume) the lane's nonce branch off a FRESHLY FETCHED base, never a stale local ref. Prints the checked-out branch name: build/<number>-<slug>-<nonce> in create mode, build/pr-<pr>-<nonce> in resume mode, where <nonce> is the first 8 hex of --token's UUID — the token THIS lane holds, proven against the live claim before the name is composed, so a lane cannot cut a branch on a nonce that holds nothing. The branch name IS the lane record — there is no stamp file. CREATE MODE DERIVES THE BASE when --base is absent: it reads <number>'s parent through GitHub's issue-parent endpoint and, on a parent, cuts off that epic's assembly branch epic/<parent>, fetched like any other base; a proven-standalone issue cuts off origin/main. An explicit --base is honoured verbatim on every lane, epic child included, and suppresses the derivation. It NEVER falls back to origin/main on a read it could not make — that fallback is the silent wrong base that had an epic child graded against a fork point its assembly branch never contained. Every run names the base it used and where it came from on stderr. --resume-lane is resume mode for an epic child, which opens no PR: it finds the one local branch this grammar says was cut for <number>, RE-KEYS it to this claim's nonce and checks it out, so the child's commits carry forward and exactly one branch keeps naming it — cutting a second is the underivable range lane prove refuses on. It fetches nothing, takes no --slug, and re-keys nothing when the name already matches. Exits 1 (--token is not a claim token of this session), 7 (--resume's PR is proven absent, closed or merged; --resume-lane found no local branch cut for <number>; or the derived assembly branch epic/<parent> is proven absent from both origin and this clone), 10 (--slug is not kebab-case, exceeds 5 words, or is flag-shaped, or --resume-lane was combined with --resume or --slug), 11 (the fetch failed, the tree root or claim state could not be read, the parent read or the assembly-branch read failed so which base this lane belongs on is UNKNOWN, or --resume-lane found several candidate branches or could not re-key the one it found — the prior lane's worktree is likely still on it, which only an operator can release), 15 (proven: the claim is held by another lane). Why the nonce, the derivation and the re-key are shaped this way is in claude-plugins/fabrika/skills/build/contract.md. Example: fabrika build branch 4312 --slug editor-focus-loss --token build:s-9f2e:c1a4d6f8-…",
 	),
 );
 

--- a/packages/fabrika-cli/src/build/resume-child-verb.ts
+++ b/packages/fabrika-cli/src/build/resume-child-verb.ts
@@ -132,9 +132,9 @@ export const runResumeChild = (
 		const branched = yield* runBranch({
 			number: issue,
 			slug: null,
-			// Inert, not a rebase: the `resumeLane` path returns before it fetches or reads `base`, and a
-			// repair keeps the child's commits where they are. This is the CLI's own default for the flag.
-			base: "origin/main",
+			// Nobody named one, and nothing here needs one: the `resumeLane` path returns before any base
+			// is resolved or fetched, and a repair keeps the child's commits where they are.
+			base: null,
 			resume: null,
 			resumeLane: true,
 			token: won,


### PR DESCRIPTION
`build branch`'s create path fetched whatever `--base` said and cut there, and `--base` defaulted to `origin/main`. The build skill's canonical invocation carries no `--base`, so an epic child landed on the trunk unless its builder thought to pass one — a silent wrong base that puts a child's commits on code the assembly branch does not have and resolves its range against a fork point that is not on the branch.

Create mode now reads the claimed issue's parent through GitHub's own issue-parent endpoint and derives the base from it, the way `readAssembly` already derives both of its endpoints:

- a `Present` parent gives the run's assembly branch `epic/<parent>` — `origin/epic/<parent>` when origin carries it, the bare local name when only this clone does, and either spelling goes through the same `fetchBase`, so a stale local `epic/<n>` is never the cut;
- a parent proven `Absent` (the endpoint's 404) leaves a standalone lane on `origin/main` exactly as it stood, with no epic base invented;
- a parent read that **failed** refuses on `11` naming the read and cuts nothing — never a fall back to `origin/main`, which is the defect itself;
- a derived assembly branch **proven** absent from both origin and this clone refuses on `7` naming the branch it derived, while a ref read that **failed** refuses on `11`. Nothing fuses the two.

`--base` loses `Flag.withDefault("origin/main")` and becomes optional, so "the operator named a base" and "nobody passed one" stop being the same value. An explicit `--base` is honoured verbatim on every lane, epic child included, and suppresses the derivation — the parent is not even read. Every run says which base it used and where it came from on the verb's existing note channel.

Six unit tests cover the paths: a child cuts off `epic/<parent>`, a proven-standalone issue off `origin/main`, an explicit `--base` wins on a child and skips the parent read, an unreadable parent is `11` with no fetch and no switch, a proven-absent assembly branch is `7`, an unreadable assembly-branch read is `11` and not `7`, and a re-run under the same nonce still resolves the same name and switches rather than re-cutting.

The grammar landed on all six surfaces: the verb module's docblock and the new helper's, `Command.withDescription` and the `--base` flag description, the `build branch` section of the skill's `contract.md` (inputs table, prose, exit table, errors table, examples, grounding), the `build branch` step in `SKILL.md`, and the verb's row in `packages/fabrika-cli/docs/verb-reference.md`. `SKILL.md`'s canonical invocation still carries no `--base`, because after this it does not need one on an epic child.

Fixes #6730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations

None.
